### PR TITLE
Add gradle build scripts.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,12 @@
 #########
 target
 
+# Gradle #
+#########
+/.gradle
+*/build/
+dd-trace-examples/**/build/
+
 # Eclipse #
 ###########
 *.launch

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,23 @@
+allprojects {
+    apply plugin: 'maven'
+
+    group = 'com.datadoghq'
+    version = '0.1.2-SNAPSHOT'
+}
+
+subprojects {
+    apply plugin: 'java'
+    sourceCompatibility = 1.7
+    targetCompatibility = 1.7
+
+    task packageSources(type: Jar) {
+        classifier = 'sources'
+        from sourceSets.main.allSource\
+    }
+    artifacts.archives packageSources
+    repositories {
+        mavenLocal()
+
+        maven { url "http://repo.maven.apache.org/maven2" }
+    }
+}

--- a/dd-java-agent-ittests/build.gradle
+++ b/dd-java-agent-ittests/build.gradle
@@ -1,0 +1,37 @@
+description = 'dd-java-agent-ittests'
+dependencies {
+    testCompile project(':dd-java-agent')
+    testCompile group: 'io.opentracing', name: 'opentracing-mock', version: '0.30.0'
+    testCompile group: 'junit', name: 'junit', version: '4.12'
+    testCompile group: 'org.assertj', name: 'assertj-core', version: '3.6.2'
+    testCompile group: 'org.mockito', name: 'mockito-core', version: '2.7.22'
+    testCompile group: 'org.mongodb', name: 'mongo-java-driver', version: '3.4.2'
+    testCompile group: 'org.eclipse.jetty', name: 'jetty-server', version: '9.4.1.v20170120'
+    testCompile group: 'org.eclipse.jetty', name: 'jetty-servlet', version: '9.4.1.v20170120'
+    testCompile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '8.0.41'
+    testCompile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-jasper', version: '8.0.41'
+    testCompile(group: 'com.amazonaws', name: 'aws-java-sdk', version: '1.11.119') {
+        exclude(module: 'httpclient')
+    }
+    testCompile group: 'com.squareup.okhttp3', name: 'okhttp', version: '3.6.0'
+    testCompile group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.3'
+    testCompile(group: 'com.datastax.cassandra', name: 'cassandra-driver-core', version: '3.2.0') {
+        exclude(module: 'netty-handler')
+    }
+    testCompile(group: 'org.cassandraunit', name: 'cassandra-unit', version: '3.1.3.2') {
+        exclude(module: 'netty-handler')
+    }
+    testCompile group: 'org.elasticsearch.client', name: 'transport', version: '5.4.1'
+    testCompile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.8.2'
+    testCompile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.8.2'
+    testCompile group: 'javax.jms', name: 'javax.jms-api', version: '2.0.1'
+    testCompile group: 'org.apache.activemq.tooling', name: 'activemq-junit', version: '5.14.5'
+    testCompile group: 'org.apache.activemq', name: 'activemq-broker', version: '5.14.5'
+}
+
+test {
+    jvmArgs "-javaagent:${project(':dd-java-agent').buildDir}/libs/dd-java-agent-${project.version}-shadow.jar"
+    jvmArgs "-Dorg.jboss.byteman.verbose=true"
+}
+
+test.dependsOn project(':dd-java-agent').shadowJar

--- a/dd-java-agent/build.gradle
+++ b/dd-java-agent/build.gradle
@@ -1,0 +1,85 @@
+plugins {
+    id 'application'
+    id "com.github.johnrengelman.shadow" version "2.0.1"
+}
+
+description = 'dd-java-agent'
+mainClassName = "com.datadoghq.trace.agent.AnnotationsTracingAgent"
+
+dependencies {
+    compile project(':dd-trace')
+    compile project(':dd-trace-annotations')
+
+    compile group: 'io.opentracing.contrib', name: 'opentracing-agent', version: '0.1.0'
+    compile group: 'org.reflections', name: 'reflections', version: '0.9.11'
+
+
+    compile(group: 'io.opentracing.contrib', name: 'opentracing-web-servlet-filter', version: '0.0.9') {
+        exclude(module: 'jetty-servlet')
+    }
+    compile(group: 'io.opentracing.contrib', name: 'opentracing-mongo-driver', version: '0.0.2') {
+        exclude(module: 'mongodb-driver-async')
+        exclude(module: 'mongo-java-driver')
+    }
+    compile group: 'io.opentracing.contrib', name: 'opentracing-jdbc', version: '0.0.2'
+    compile(group: 'io.opentracing.contrib', name: 'opentracing-okhttp3', version: '0.0.5') {
+        exclude(module: 'okhttp')
+    }
+    compile(group: 'io.opentracing.contrib', name: 'opentracing-jms-2', version: '0.0.3') {
+        exclude(module: 'javax.jms-api')
+    }
+    compile(group: 'io.opentracing.contrib', name: 'opentracing-aws-sdk', version: '0.0.2') {
+        exclude(module: 'aws-java-sdk')
+    }
+    compile(group: 'io.opentracing.contrib', name: 'opentracing-cassandra-driver', version: '0.0.2') {
+        exclude(module: 'cassandra-driver-core')
+    }
+    compile(group: 'io.opentracing.contrib', name: 'opentracing-elasticsearch-client', version: '0.0.2') {
+        exclude(module: 'transport')
+    }
+    compile(group: 'io.opentracing.contrib', name: 'opentracing-apache-httpclient', version: '0.0.2') {
+        exclude(module: 'httpclient')
+    }
+
+    testCompile group: 'io.opentracing', name: 'opentracing-mock', version: '0.30.0'
+    testCompile group: 'junit', name: 'junit', version: '4.12'
+    testCompile group: 'org.assertj', name: 'assertj-core', version: '3.6.2'
+    testCompile group: 'org.mockito', name: 'mockito-core', version: '2.7.22'
+    compileOnly group: 'org.eclipse.jetty', name: 'jetty-servlet', version: '9.3.6.v20151106'
+    compileOnly group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.0.0.M1'
+    compileOnly group: 'org.mongodb', name: 'mongo-java-driver', version: '3.4.2'
+    compileOnly group: 'org.mongodb', name: 'mongodb-driver-async', version: '3.4.2'
+    compileOnly group: 'com.squareup.okhttp3', name: 'okhttp', version: '3.6.0'
+    compileOnly group: 'javax.jms', name: 'javax.jms-api', version: '2.0.1'
+    compileOnly group: 'com.amazonaws', name: 'aws-java-sdk', version: '1.11.119'
+    compileOnly group: 'com.datastax.cassandra', name: 'cassandra-driver-core', version: '3.2.0'
+    compileOnly group: 'org.elasticsearch.client', name: 'transport', version: '5.4.1'
+    compileOnly group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.3'
+}
+
+jar {
+    manifest {
+        attributes(
+                // I don't think we want to define this since we can't really load after startup:
+                //"Agent-Class": "com.datadoghq.trace.agent.AnnotationsTracingAgent",
+                "Premain-Class": "com.datadoghq.trace.agent.AnnotationsTracingAgent",
+                "Can-Redefine-Classes": true,
+                "Can-Retransform-Classes": true,
+                // It is dangerous putting everything on the bootstrap classpath,
+                // but kept for consistency with previous versions.
+                "Boot-Class-Path": "./${jar.archiveName}.jar"
+        )
+    }
+}
+
+shadowJar {
+    append 'otarules.btm'
+
+    classifier 'shadow'
+
+//    mergeServiceFiles()
+
+    relocate('', 'dd.deps.') {
+        exclude '%ant[META-INF/**/*]'
+    }
+}

--- a/dd-trace-annotations/build.gradle
+++ b/dd-trace-annotations/build.gradle
@@ -1,0 +1,4 @@
+description = 'dd-trace-annotations'
+dependencies {
+    testCompile group: 'junit', name: 'junit', version: '3.8.1'
+}

--- a/dd-trace-examples/async-tracing/build.gradle
+++ b/dd-trace-examples/async-tracing/build.gradle
@@ -1,0 +1,5 @@
+description = 'async-tracing'
+dependencies {
+    compile project(':dd-trace')
+    compile group: 'io.opentracing.contrib', name: 'opentracing-spanmanager', version: '0.0.5'
+}

--- a/dd-trace-examples/dropwizard-mongo-client/build.gradle
+++ b/dd-trace-examples/dropwizard-mongo-client/build.gradle
@@ -1,0 +1,7 @@
+description = 'dropwizard-mongo-client'
+dependencies {
+    compile project(':dd-trace-annotations')
+    compile group: 'io.dropwizard', name: 'dropwizard-core', version: '0.9.2'
+    compile group: 'org.mongodb', name: 'mongo-java-driver', version: '3.4.2'
+    compile group: 'com.squareup.okhttp3', name: 'okhttp', version: '3.7.0'
+}

--- a/dd-trace-examples/spring-boot-jdbc/build.gradle
+++ b/dd-trace-examples/spring-boot-jdbc/build.gradle
@@ -1,0 +1,6 @@
+description = 'spring-boot-jdbc'
+dependencies {
+    compile group: 'mysql', name: 'mysql-connector-java', version: '5.1.41'
+    compile group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: '1.5.3.RELEASE'
+    compile group: 'org.springframework.boot', name: 'spring-boot-starter-data-jpa', version: '1.5.3.RELEASE'
+}

--- a/dd-trace/build.gradle
+++ b/dd-trace/build.gradle
@@ -1,0 +1,29 @@
+plugins {
+    id "com.github.johnrengelman.shadow" version "2.0.1"
+}
+
+description = 'dd-trace'
+dependencies {
+    compile group: 'io.opentracing', name: 'opentracing-api', version: '0.30.0'
+    compile group: 'io.opentracing', name: 'opentracing-noop', version: '0.30.0'
+    compile group: 'io.opentracing', name: 'opentracing-util', version: '0.30.0'
+    compile group: 'io.opentracing.contrib', name: 'opentracing-tracerresolver', version: '0.1.0'
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.8.8'
+    compile group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: '2.8.8'
+    compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
+    compile group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
+    compile group: 'com.google.auto.service', name: 'auto-service', version: '1.0-rc3'
+    testCompile group: 'junit', name: 'junit', version: '4.12'
+    testCompile group: 'org.assertj', name: 'assertj-core', version: '3.6.2'
+    testCompile group: 'org.mockito', name: 'mockito-core', version: '2.7.22'
+}
+
+shadowJar {
+//    mergeServiceFiles()
+
+    classifier 'shadow'
+
+    relocate('', 'dd.deps.') {
+        exclude '%ant[META-INF/**/*]'
+    }
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,6 @@
+#Fri Jun 30 11:21:26 PDT 2017
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.0-bin.zip

--- a/gradlew
+++ b/gradlew
@@ -1,0 +1,172 @@
+#!/usr/bin/env sh
+
+##############################################################################
+##
+##  Gradle start up script for UN*X
+##
+##############################################################################
+
+# Attempt to set APP_HOME
+# Resolve links: $0 may be a link
+PRG="$0"
+# Need this for relative symlinks.
+while [ -h "$PRG" ] ; do
+    ls=`ls -ld "$PRG"`
+    link=`expr "$ls" : '.*-> \(.*\)$'`
+    if expr "$link" : '/.*' > /dev/null; then
+        PRG="$link"
+    else
+        PRG=`dirname "$PRG"`"/$link"
+    fi
+done
+SAVED="`pwd`"
+cd "`dirname \"$PRG\"`/" >/dev/null
+APP_HOME="`pwd -P`"
+cd "$SAVED" >/dev/null
+
+APP_NAME="Gradle"
+APP_BASE_NAME=`basename "$0"`
+
+# Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
+DEFAULT_JVM_OPTS=""
+
+# Use the maximum available, or set MAX_FD != -1 to use that value.
+MAX_FD="maximum"
+
+warn ( ) {
+    echo "$*"
+}
+
+die ( ) {
+    echo
+    echo "$*"
+    echo
+    exit 1
+}
+
+# OS specific support (must be 'true' or 'false').
+cygwin=false
+msys=false
+darwin=false
+nonstop=false
+case "`uname`" in
+  CYGWIN* )
+    cygwin=true
+    ;;
+  Darwin* )
+    darwin=true
+    ;;
+  MINGW* )
+    msys=true
+    ;;
+  NONSTOP* )
+    nonstop=true
+    ;;
+esac
+
+CLASSPATH=$APP_HOME/gradle/wrapper/gradle-wrapper.jar
+
+# Determine the Java command to use to start the JVM.
+if [ -n "$JAVA_HOME" ] ; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
+        # IBM's JDK on AIX uses strange locations for the executables
+        JAVACMD="$JAVA_HOME/jre/sh/java"
+    else
+        JAVACMD="$JAVA_HOME/bin/java"
+    fi
+    if [ ! -x "$JAVACMD" ] ; then
+        die "ERROR: JAVA_HOME is set to an invalid directory: $JAVA_HOME
+
+Please set the JAVA_HOME variable in your environment to match the
+location of your Java installation."
+    fi
+else
+    JAVACMD="java"
+    which java >/dev/null 2>&1 || die "ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
+
+Please set the JAVA_HOME variable in your environment to match the
+location of your Java installation."
+fi
+
+# Increase the maximum file descriptors if we can.
+if [ "$cygwin" = "false" -a "$darwin" = "false" -a "$nonstop" = "false" ] ; then
+    MAX_FD_LIMIT=`ulimit -H -n`
+    if [ $? -eq 0 ] ; then
+        if [ "$MAX_FD" = "maximum" -o "$MAX_FD" = "max" ] ; then
+            MAX_FD="$MAX_FD_LIMIT"
+        fi
+        ulimit -n $MAX_FD
+        if [ $? -ne 0 ] ; then
+            warn "Could not set maximum file descriptor limit: $MAX_FD"
+        fi
+    else
+        warn "Could not query maximum file descriptor limit: $MAX_FD_LIMIT"
+    fi
+fi
+
+# For Darwin, add options to specify how the application appears in the dock
+if $darwin; then
+    GRADLE_OPTS="$GRADLE_OPTS \"-Xdock:name=$APP_NAME\" \"-Xdock:icon=$APP_HOME/media/gradle.icns\""
+fi
+
+# For Cygwin, switch paths to Windows format before running java
+if $cygwin ; then
+    APP_HOME=`cygpath --path --mixed "$APP_HOME"`
+    CLASSPATH=`cygpath --path --mixed "$CLASSPATH"`
+    JAVACMD=`cygpath --unix "$JAVACMD"`
+
+    # We build the pattern for arguments to be converted via cygpath
+    ROOTDIRSRAW=`find -L / -maxdepth 1 -mindepth 1 -type d 2>/dev/null`
+    SEP=""
+    for dir in $ROOTDIRSRAW ; do
+        ROOTDIRS="$ROOTDIRS$SEP$dir"
+        SEP="|"
+    done
+    OURCYGPATTERN="(^($ROOTDIRS))"
+    # Add a user-defined pattern to the cygpath arguments
+    if [ "$GRADLE_CYGPATTERN" != "" ] ; then
+        OURCYGPATTERN="$OURCYGPATTERN|($GRADLE_CYGPATTERN)"
+    fi
+    # Now convert the arguments - kludge to limit ourselves to /bin/sh
+    i=0
+    for arg in "$@" ; do
+        CHECK=`echo "$arg"|egrep -c "$OURCYGPATTERN" -`
+        CHECK2=`echo "$arg"|egrep -c "^-"`                                 ### Determine if an option
+
+        if [ $CHECK -ne 0 ] && [ $CHECK2 -eq 0 ] ; then                    ### Added a condition
+            eval `echo args$i`=`cygpath --path --ignore --mixed "$arg"`
+        else
+            eval `echo args$i`="\"$arg\""
+        fi
+        i=$((i+1))
+    done
+    case $i in
+        (0) set -- ;;
+        (1) set -- "$args0" ;;
+        (2) set -- "$args0" "$args1" ;;
+        (3) set -- "$args0" "$args1" "$args2" ;;
+        (4) set -- "$args0" "$args1" "$args2" "$args3" ;;
+        (5) set -- "$args0" "$args1" "$args2" "$args3" "$args4" ;;
+        (6) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" ;;
+        (7) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" "$args6" ;;
+        (8) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" "$args6" "$args7" ;;
+        (9) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" "$args6" "$args7" "$args8" ;;
+    esac
+fi
+
+# Escape application args
+save ( ) {
+    for i do printf %s\\n "$i" | sed "s/'/'\\\\''/g;1s/^/'/;\$s/\$/' \\\\/" ; done
+    echo " "
+}
+APP_ARGS=$(save "$@")
+
+# Collect all arguments for the java command, following the shell quoting and substitution rules
+eval set -- $DEFAULT_JVM_OPTS $JAVA_OPTS $GRADLE_OPTS "\"-Dorg.gradle.appname=$APP_BASE_NAME\"" -classpath "\"$CLASSPATH\"" org.gradle.wrapper.GradleWrapperMain "$APP_ARGS"
+
+# by default we should be in the correct project dir, but when run from Finder on Mac, the cwd is wrong
+if [ "$(uname)" = "Darwin" ] && [ "$HOME" = "$PWD" ]; then
+  cd "$(dirname "$0")"
+fi
+
+exec "$JAVACMD" "$@"

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -1,0 +1,84 @@
+@if "%DEBUG%" == "" @echo off
+@rem ##########################################################################
+@rem
+@rem  Gradle startup script for Windows
+@rem
+@rem ##########################################################################
+
+@rem Set local scope for the variables with windows NT shell
+if "%OS%"=="Windows_NT" setlocal
+
+set DIRNAME=%~dp0
+if "%DIRNAME%" == "" set DIRNAME=.
+set APP_BASE_NAME=%~n0
+set APP_HOME=%DIRNAME%
+
+@rem Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
+set DEFAULT_JVM_OPTS=
+
+@rem Find java.exe
+if defined JAVA_HOME goto findJavaFromJavaHome
+
+set JAVA_EXE=java.exe
+%JAVA_EXE% -version >NUL 2>&1
+if "%ERRORLEVEL%" == "0" goto init
+
+echo.
+echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
+echo.
+echo Please set the JAVA_HOME variable in your environment to match the
+echo location of your Java installation.
+
+goto fail
+
+:findJavaFromJavaHome
+set JAVA_HOME=%JAVA_HOME:"=%
+set JAVA_EXE=%JAVA_HOME%/bin/java.exe
+
+if exist "%JAVA_EXE%" goto init
+
+echo.
+echo ERROR: JAVA_HOME is set to an invalid directory: %JAVA_HOME%
+echo.
+echo Please set the JAVA_HOME variable in your environment to match the
+echo location of your Java installation.
+
+goto fail
+
+:init
+@rem Get command-line arguments, handling Windows variants
+
+if not "%OS%" == "Windows_NT" goto win9xME_args
+
+:win9xME_args
+@rem Slurp the command line arguments.
+set CMD_LINE_ARGS=
+set _SKIP=2
+
+:win9xME_args_slurp
+if "x%~1" == "x" goto execute
+
+set CMD_LINE_ARGS=%*
+
+:execute
+@rem Setup the command line
+
+set CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
+
+@rem Execute Gradle
+"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %CMD_LINE_ARGS%
+
+:end
+@rem End local scope for the variables with windows NT shell
+if "%ERRORLEVEL%"=="0" goto mainEnd
+
+:fail
+rem Set variable GRADLE_EXIT_CONSOLE if you need the _script_ return code instead of
+rem the _cmd.exe /c_ return code!
+if  not "" == "%GRADLE_EXIT_CONSOLE%" exit 1
+exit /b 1
+
+:mainEnd
+if "%OS%"=="Windows_NT" endlocal
+
+:omega

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,18 @@
+rootProject.name = 'dd-trace-java'
+include ':dd-trace'
+include ':dd-java-agent'
+include ':dd-java-agent-ittests'
+include ':dd-trace-examples:async-tracing'
+include ':dd-trace-examples:dropwizard-mongo-client'
+include ':dd-trace-examples:spring-boot-jdbc'
+include ':dd-trace-examples'
+include ':dd-trace-annotations'
+
+project(':dd-trace').projectDir = "$rootDir/dd-trace" as File
+project(':dd-java-agent').projectDir = "$rootDir/dd-java-agent" as File
+project(':dd-java-agent-ittests').projectDir = "$rootDir/dd-java-agent-ittests" as File
+project(':dd-trace-examples:async-tracing').projectDir = "$rootDir/dd-trace-examples/async-tracing" as File
+project(':dd-trace-examples:dropwizard-mongo-client').projectDir = "$rootDir/dd-trace-examples/dropwizard-mongo-client" as File
+project(':dd-trace-examples:spring-boot-jdbc').projectDir = "$rootDir/dd-trace-examples/spring-boot-jdbc" as File
+project(':dd-trace-examples').projectDir = "$rootDir/dd-trace-examples" as File
+project(':dd-trace-annotations').projectDir = "$rootDir/dd-trace-annotations" as File


### PR DESCRIPTION
Currently has issues with shadow jar due to Java 9 compiled classes inside byteman used by dd-java-agent.

I think we can still get this merged in.  We just won't use it till it's ready.