### PR TITLE
Don't use nexus plugin for release

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -1,6 +1,29 @@
 ## Developer instructions
 
-* How to release a new version
+### Testing a release locally
+Run nexus locally (assuming you have docker running locally):
+
+```bash
+docker run -d -p 8081:8081 --name nexus sonatype/nexus
+```
+
+Configure the `distributionManagement` section in the root `pom.xml` to point to the repo on localhost.
+
+Add/update your `~/.m2/settings.xml` with the following config block:
+
+```xml
+<settings>
+  <servers>
+    <server>
+      <id>nexus-local</id>
+      <username>admin</username>
+      <password>admin123</password>
+    </server>
+  </servers>
+</settings>
+```
+
+Perform the release process as described below.
 
 
 ### How to release a new version

--- a/pom.xml
+++ b/pom.xml
@@ -51,11 +51,11 @@
 
     <distributionManagement>
         <snapshotRepository>
-            <id>nexus</id>
+            <id>nexus-local</id>
             <url>http://localhost:8081/nexus/content/repositories/snapshots</url>
         </snapshotRepository>
         <repository>
-            <id>nexus</id>
+            <id>nexus-local</id>
             <url>http://localhost:8081/nexus/content/repositories/snapshots</url>
         </repository>
         <!--<snapshotRepository>-->


### PR DESCRIPTION
It doesn't support only deploying select modules, resulting in all modules getting deployed.
Also effectively disabling distribution management (by routing to local) until everything is straightened out.

(The suggested way of using `skipNexusStagingDeployMojo ` [doesn't work](https://stackoverflow.com/questions/25305850/how-to-disable-nexus-staging-maven-plugin-in-sub-modules#comment44691362_27557285))