### PR TITLE
Ensure headers are never null

### DIFF
--- a/dd-java-agent-ittests/build.gradle
+++ b/dd-java-agent-ittests/build.gradle
@@ -37,3 +37,7 @@ test {
 }
 
 test.dependsOn project(':dd-java-agent').shadowJar
+
+parent.subprojects.collect { it.tasks.withType(Test) } each {
+    test.shouldRunAfter it
+}

--- a/dd-trace/build.gradle
+++ b/dd-trace/build.gradle
@@ -1,4 +1,5 @@
 plugins {
+    id 'groovy'
     id "com.github.johnrengelman.shadow" version "2.0.1"
 }
 

--- a/dd-trace/src/main/java/com/datadoghq/trace/DDTracer.java
+++ b/dd-trace/src/main/java/com/datadoghq/trace/DDTracer.java
@@ -22,8 +22,13 @@ import java.util.*;
  */
 public class DDTracer implements io.opentracing.Tracer {
 
-	public final static String CURRENT_VERSION = DDTracer.class.getPackage().getImplementationVersion();
 	public final static String JAVA_VERSION = System.getProperty("java.version", "unknown");
+	public final static String CURRENT_VERSION;
+
+	static {
+		String version = DDTracer.class.getPackage().getImplementationVersion();
+		CURRENT_VERSION = version != null ? version : "unknown";
+	}
 
 	/**
 	 * Writer is an charge of reporting traces and spans to the desired endpoint

--- a/dd-trace/src/test/groovy/com/datadoghq/trace/SpanFactory.groovy
+++ b/dd-trace/src/test/groovy/com/datadoghq/trace/SpanFactory.groovy
@@ -1,7 +1,4 @@
-package com.datadog.trace
-
-import com.datadoghq.trace.DDSpan
-import com.datadoghq.trace.DDSpanContext
+package com.datadoghq.trace
 
 class SpanFactory {
     static def newSpanOf(long timestampMicro) {

--- a/dd-trace/src/test/java/com/datadoghq/trace/DDSpanBuilderTest.java
+++ b/dd-trace/src/test/java/com/datadoghq/trace/DDSpanBuilderTest.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -124,15 +125,14 @@ public class DDSpanBuilderTest {
         assertThat(span.getStartTime()).isEqualTo(expectedTimestamp * 1000L);
 
         // auto-timestamp in nanoseconds
-        long tick = System.currentTimeMillis() * 1000 * 1000L;
+        long tick = System.currentTimeMillis();
         span = tracer
                 .buildSpan(expectedName)
                 .withServiceName("foo")
                 .start();
 
-        // between now and now + 100ms
-        assertThat(span.getStartTime()).isBetween(tick, tick + 100 * 1000L);
-
+        // Give a range of +/- 2 millis
+        assertThat(span.getStartTime()).isBetween(MILLISECONDS.toNanos(tick - 2), MILLISECONDS.toNanos(tick + 2));
     }
 
 
@@ -143,7 +143,7 @@ public class DDSpanBuilderTest {
         final long expectedParentId = spanId;
 
         DDSpanContext mockedContext = mock(DDSpanContext.class);
-       
+
         when(mockedContext.getSpanId()).thenReturn(spanId);
         when(mockedContext.getServiceName()).thenReturn("foo");
 


### PR DESCRIPTION
Null tracer version results in the request being rejected by the agent.

Also make the DDSpanBuilderTest.shouldBuildSpanTimestampInNano more reliable.