### PR TITLE
Apply minimum code coverage assertions

### DIFF
--- a/dd-java-agent-ittests/build.gradle
+++ b/dd-java-agent-ittests/build.gradle
@@ -1,3 +1,6 @@
+// Not adding jacoco here as it inexplicably breaks our tests.
+// apply from: "${rootDir}/gradle/jacoco.gradle"
+
 description = 'dd-java-agent-ittests'
 dependencies {
     testCompile project(':dd-java-agent')

--- a/dd-java-agent/build.gradle
+++ b/dd-java-agent/build.gradle
@@ -4,6 +4,16 @@ plugins {
 
 description = 'dd-java-agent'
 
+apply from: "${rootDir}/gradle/jacoco.gradle"
+jacocoTestReport.dependsOn project(':dd-java-agent-ittests').test
+whitelistedInstructionClasses += whitelistedBranchClasses += [
+        "com.datadoghq.trace.agent.integration.*",
+        'com.datadoghq.trace.agent.AnnotationsTracingAgent',
+        'com.datadoghq.trace.agent.AgentTracerConfig',
+        'com.datadoghq.trace.agent.TraceAnnotationsManager',
+        'com.datadoghq.trace.agent.InstrumentationChecker'
+]
+
 dependencies {
     compile project(':dd-trace')
     compile project(':dd-trace-annotations')

--- a/dd-trace-annotations/build.gradle
+++ b/dd-trace-annotations/build.gradle
@@ -1,3 +1,5 @@
+apply from: "${rootDir}/gradle/jacoco.gradle"
+
 description = 'dd-trace-annotations'
 dependencies {
     testCompile group: 'junit', name: 'junit', version: '3.8.1'

--- a/dd-trace/build.gradle
+++ b/dd-trace/build.gradle
@@ -4,6 +4,15 @@ plugins {
 }
 
 description = 'dd-trace'
+
+apply from: "${rootDir}/gradle/jacoco.gradle"
+minimumBranchCoverage = 0.3
+minimumInstructionCoverage = 0.5
+whitelistedInstructionClasses += whitelistedBranchClasses += [
+        "com.datadoghq.trace.integration.*",
+        'com.datadoghq.trace.DDTags'
+]
+
 dependencies {
     compile group: 'io.opentracing', name: 'opentracing-api', version: '0.30.0'
     compile group: 'io.opentracing', name: 'opentracing-noop', version: '0.30.0'

--- a/dd-trace/src/main/java/com/datadoghq/trace/resolver/DDTracerResolver.java
+++ b/dd-trace/src/main/java/com/datadoghq/trace/resolver/DDTracerResolver.java
@@ -41,19 +41,10 @@ public class DDTracerResolver extends TracerResolver {
 
 	@SuppressWarnings("static-access")
 	public static Tracer registerTracer() {
-
-		ServiceLoader<TracerResolver> RESOLVERS = ServiceLoader.load(TracerResolver.class);
-
-		Tracer tracer = null;
-		for (TracerResolver value : RESOLVERS) {
-			tracer = value.resolveTracer();
-			if (tracer != null) {
-				break;
-			}
-		}
+		Tracer tracer = TracerResolver.resolveTracer();
 
 		if (tracer == null) {
-			tracer = NoopTracerFactory.create();
+			return NoopTracerFactory.create();
 		}
 
 		GlobalTracer.register(tracer);

--- a/gradle/jacoco.gradle
+++ b/gradle/jacoco.gradle
@@ -1,0 +1,43 @@
+apply plugin: "jacoco"
+
+jacocoTestReport {
+    dependsOn test
+    reports {
+        xml.enabled true
+        csv.enabled false
+        html.destination file("${buildDir}/reports/jacoco/")
+    }
+}
+
+project.ext.whitelistedBranchClasses = []
+project.ext.whitelistedInstructionClasses = []
+
+project.ext.minimumBranchCoverage = 0.6
+project.ext.minimumInstructionCoverage = 0.6
+
+afterEvaluate {
+    jacocoTestCoverageVerification {
+        violationRules {
+            rule {
+                element = 'CLASS'
+                excludes = project.whitelistedBranchClasses
+                limit {
+                    counter = 'BRANCH'
+                    minimum = project.minimumBranchCoverage
+                }
+            }
+
+            rule {
+                element = 'CLASS'
+                excludes = project.whitelistedInstructionClasses
+                limit {
+                    counter = 'INSTRUCTION'
+                    minimum = project.minimumInstructionCoverage
+                }
+            }
+        }
+    }
+
+    jacocoTestCoverageVerification.dependsOn jacocoTestReport
+    check.dependsOn jacocoTestCoverageVerification
+}


### PR DESCRIPTION
Improved the test coverage slightly in the process.

The whitelisted classes are an area where coverage could be improved.

I'm not sure why, but jacoco just wouldn't work with the integration tests, which is why I couldn't apply it at the parent project level.