### PR TITLE
Embed signing key for jar signing in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,8 @@ jobs:
       - checkout
 
       - restore_cache:
-          key: dd-trace-java
+          # Reset the cache approx every release
+          key: dd-trace-java-{{ checksum "dd-trace-java.gradle" }}
 
       - run:
           name: Run Tests
@@ -18,7 +19,7 @@ jobs:
       - save_cache:
           paths:
             - ~/.gradle
-          key: dd-trace-java
+          key: dd-trace-java-{{ checksum "dd-trace-java.gradle" }}
 
       - store_test_results:
           path: dd-java-agent/build/test-results
@@ -38,6 +39,14 @@ jobs:
           path: dd-java-agent/build/libs
       - store_artifacts:
           path: dd-trace/build/libs
+
+      - run:
+          name: Decode Signing Key
+          command: echo $PGP_KEY_FILE | base64 --decode > /home/circleci/dd-trace-java/.circleci/secring.gpg
+
+      - run:
+          name: Sign Archives
+          command: ./gradlew -Psigning.keyId=${PGP_KEY_ID} -Psigning.password=${PGP_KEY_PASS} -Psigning.secretKeyRingFile=/home/circleci/dd-trace-java/.circleci/secring.gpg signArchives
 
       - deploy:
           name: Publish master to Artifactory

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -31,28 +31,12 @@ tasks.withType(Upload).matching { it.name != "install" }.all {
     }
 }
 
-def isSnapshot = version.endsWith("-SNAPSHOT")
+def isCI = Boolean.parseBoolean("$System.env.CI")
 
-//if (!isSnapshot) {
-//    tasks.withType(Upload) {
-//        repositories.matching { it.name == "mavenInstaller" }.all {
-//            beforeDeployment { deployment ->
-//                signing.signPom(deployment)
-//            }
-//        }
-//    }
-//}
-//
-//signing {
-//    if (!isSnapshot) {
-//        required = true
-//        sign configurations.archives
-//    }
-//}
-//
-//configurations.signatures.artifacts.all {
-//    extension = toSignArtifact.extension + "." + extension
-//}
+signing {
+  required = isCI
+  sign configurations.archives
+}
 
 configurations {
     configurations {
@@ -72,6 +56,7 @@ configurations {
     }
 }
 
+def isSnapshot = version.endsWith("-SNAPSHOT")
 // define in ~/.gradle/gradle.properties to override for testing
 def forceLocal = project.hasProperty('forceLocal') && forceLocal
 


### PR DESCRIPTION
I haven't published the key to a key server yet, so this probably won't work right in Maven.  Given that the password is like 50 characters, is it ok to check the key in like this?

Once merged to master, it should actually attempt to publish the artifacts along with the signatures.