### PR TITLE
[dependencies] Proper handling of slf4j as dependency.

### DIFF
--- a/dd-trace/dd-trace.gradle
+++ b/dd-trace/dd-trace.gradle
@@ -39,12 +39,10 @@ shadowJar {
 
     classifier 'shadow'
 
-    relocate 'ch.qos.logback', 'dd.deps.ch.qos.logback'
     relocate 'com.fasterxml', 'dd.deps.com.fasterxml'
     relocate 'com.google', 'dd.deps.com.google'
     relocate 'javassist', 'dd.deps.javassist'
     relocate 'org.jboss.byteman', 'dd.deps.org.jboss.byteman'
     relocate 'org.reflections', 'dd.deps.org.reflections'
-    relocate 'org.slf4j', 'dd.deps.org.slf4j'
     relocate 'org.yaml', 'dd.deps.org.yaml'
 }


### PR DESCRIPTION
This PR makes sure slf4j is properly packaged in order for applications to benefit from the facade it offers to any underlying logger.

With this PR dd-trace-java properly packages the slf4j-api, and underlying apps decide which implementation to use by adding the proper slf4j-* package. 

Example with JDK14, showing ALL logs (even debug ones):

```groovy
dependencies {
    ...
    // Datadog
    compile group:'com.datadoghq', name:'dd-trace', version:'VERSION'
    compile group:'com.google.auto.service', name:'auto-service', version:'1.0-rc3'
    compile group: 'org.slf4j', name: 'slf4j-jdk14', version: '1.8.0-alpha2'
}
```

```java
import java.util.logging.Logger;
import java.util.logging.Level;
...
Logger.getLogger("com.datadoghq.trace").setLevel(Level.ALL);
Logger.getLogger("").getHandlers()[0].setLevel(Level.FINE);
```

Example with logback only showing warnings:

```groovy
dependencies {
    ...
    // Datadog
    compile group:'com.datadoghq', name:'dd-trace', version:'VERSION'
    compile group:'com.google.auto.service', name:'auto-service', version:'1.0-rc3'
    compile group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
}
```

```java
import org.slf4j.LoggerFactory;
import ch.qos.logback.classic.Logger;
import ch.qos.logback.classic.Level;
...
Logger logger = (Logger)LoggerFactory.getLogger("com.datadoghq.trace");
logger.setLevel(Level.WARN);
```
