### PR TITLE
Report the java vm name as the interpreter

### DIFF
--- a/dd-java-agent/dd-java-agent.gradle
+++ b/dd-java-agent/dd-java-agent.gradle
@@ -14,7 +14,8 @@ whitelistedInstructionClasses += whitelistedBranchClasses += [
   'com.datadoghq.trace.agent.AnnotationsTracingAgent',
   'com.datadoghq.trace.agent.AgentTracerConfig',
   'com.datadoghq.trace.agent.TraceAnnotationsManager',
-  'com.datadoghq.trace.agent.InstrumentationChecker'
+  'com.datadoghq.trace.agent.InstrumentationChecker',
+  'com.datadoghq.trace.agent.DDJavaAgentInfo',
 ]
 
 dependencies {
@@ -113,4 +114,8 @@ shadowJar {
   exclude 'org/jboss/byteman/layer/LayerModuleFinder.class'
   exclude 'org/jboss/byteman/layer/LayerModuleReader.class'
   exclude 'org/jboss/byteman/layer/LayerModuleReference.class'
+
+  dependencies {
+    exclude(dependency('org.projectlombok:lombok:1.16.18'))
+  }
 }

--- a/dd-java-agent/src/main/java/com/datadoghq/trace/agent/DDJavaAgentInfo.java
+++ b/dd-java-agent/src/main/java/com/datadoghq/trace/agent/DDJavaAgentInfo.java
@@ -1,0 +1,26 @@
+package com.datadoghq.trace.agent;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+
+public class DDJavaAgentInfo {
+  public static final String VERSION;
+
+  static {
+    String v;
+    try {
+      final StringBuffer sb = new StringBuffer();
+
+      final BufferedReader br =
+          new BufferedReader(
+              new InputStreamReader(
+                  DDJavaAgentInfo.class.getResourceAsStream("dd-java-agent.version"), "UTF-8"));
+      for (int c = br.read(); c != -1; c = br.read()) sb.append((char) c);
+
+      v = sb.toString().trim();
+    } catch (final Exception e) {
+      v = "unknown";
+    }
+    VERSION = v;
+  }
+}

--- a/dd-trace-annotations/src/main/java/com/datadoghq/trace/DDTraceAnnotationsInfo.java
+++ b/dd-trace-annotations/src/main/java/com/datadoghq/trace/DDTraceAnnotationsInfo.java
@@ -1,0 +1,27 @@
+package com.datadoghq.trace;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+
+public class DDTraceAnnotationsInfo {
+  public static final String VERSION;
+
+  static {
+    String v;
+    try {
+      final StringBuffer sb = new StringBuffer();
+
+      final BufferedReader br =
+          new BufferedReader(
+              new InputStreamReader(
+                  DDTraceAnnotationsInfo.class.getResourceAsStream("dd-trace-annotations.version"),
+                  "UTF-8"));
+      for (int c = br.read(); c != -1; c = br.read()) sb.append((char) c);
+
+      v = sb.toString().trim();
+    } catch (final Exception e) {
+      v = "unknown";
+    }
+    VERSION = v;
+  }
+}

--- a/dd-trace/dd-trace.gradle
+++ b/dd-trace/dd-trace.gradle
@@ -14,7 +14,8 @@ minimumInstructionCoverage = 0.5
 whitelistedInstructionClasses += whitelistedBranchClasses += [
   "com.datadoghq.trace.integration.*",
   'com.datadoghq.trace.writer.ListWriter',
-  'com.datadoghq.trace.DDTags'
+  'com.datadoghq.trace.DDTags',
+  'com.datadoghq.trace.DDTraceInfo',
 ]
 
 dependencies {
@@ -52,6 +53,10 @@ shadowJar {
   relocate 'org.jboss.byteman', 'dd.deps.org.jboss.byteman'
   relocate 'org.reflections', 'dd.deps.org.reflections'
   relocate 'org.yaml', 'dd.deps.org.yaml'
+
+  dependencies {
+    exclude(dependency('org.projectlombok:lombok:1.16.18'))
+  }
 }
 
 jmh {

--- a/dd-trace/src/main/java/com/datadoghq/trace/DDTraceInfo.java
+++ b/dd-trace/src/main/java/com/datadoghq/trace/DDTraceInfo.java
@@ -1,0 +1,30 @@
+package com.datadoghq.trace;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+
+public class DDTraceInfo {
+
+  public static final String JAVA_VERSION = System.getProperty("java.version", "unknown");
+  public static final String JAVA_VM_NAME = System.getProperty("java.vm.name", "unknown");
+
+  public static final String VERSION;
+
+  static {
+    String v;
+    try {
+      final StringBuffer sb = new StringBuffer();
+
+      final BufferedReader br =
+          new BufferedReader(
+              new InputStreamReader(
+                  DDTraceInfo.class.getResourceAsStream("dd-trace.version"), "UTF-8"));
+      for (int c = br.read(); c != -1; c = br.read()) sb.append((char) c);
+
+      v = sb.toString().trim();
+    } catch (final Exception e) {
+      v = "unknown";
+    }
+    VERSION = v;
+  }
+}

--- a/dd-trace/src/main/java/com/datadoghq/trace/DDTracer.java
+++ b/dd-trace/src/main/java/com/datadoghq/trace/DDTracer.java
@@ -25,15 +25,6 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class DDTracer extends ThreadLocalActiveSpanSource implements io.opentracing.Tracer {
 
-  public static final String JAVA_VERSION = System.getProperty("java.version", "unknown");
-  public static final String JAVA_VM_NAME = System.getProperty("java.vm.name", "unknown");
-  public static final String CURRENT_VERSION;
-
-  static {
-    final String version = DDTracer.class.getPackage().getImplementationVersion();
-    CURRENT_VERSION = version != null ? version : "unknown";
-  }
-
   public static final String UNASSIGNED_DEFAULT_SERVICE_NAME = "unnamed-java-app";
   public static final Writer UNASSIGNED_WRITER = new LoggingWriter();
   public static final Sampler UNASSIGNED_SAMPLER = new AllSampler();

--- a/dd-trace/src/main/java/com/datadoghq/trace/writer/DDApi.java
+++ b/dd-trace/src/main/java/com/datadoghq/trace/writer/DDApi.java
@@ -1,7 +1,7 @@
 package com.datadoghq.trace.writer;
 
 import com.datadoghq.trace.DDBaseSpan;
-import com.datadoghq.trace.DDTracer;
+import com.datadoghq.trace.DDTraceInfo;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -90,9 +90,9 @@ public class DDApi {
     httpCon.setRequestMethod("PUT");
     httpCon.setRequestProperty("Content-Type", "application/json");
     httpCon.setRequestProperty("Datadog-Meta-Lang", "java");
-    httpCon.setRequestProperty("Datadog-Meta-Lang-Version", DDTracer.JAVA_VERSION);
-    httpCon.setRequestProperty("Datadog-Meta-Lang-Interpreter", DDTracer.JAVA_VM_NAME);
-    httpCon.setRequestProperty("Datadog-Meta-Tracer-Version", DDTracer.CURRENT_VERSION);
+    httpCon.setRequestProperty("Datadog-Meta-Lang-Version", DDTraceInfo.JAVA_VERSION);
+    httpCon.setRequestProperty("Datadog-Meta-Lang-Interpreter", DDTraceInfo.JAVA_VM_NAME);
+    httpCon.setRequestProperty("Datadog-Meta-Tracer-Version", DDTraceInfo.VERSION);
     return httpCon;
   }
 }

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -19,6 +19,8 @@
 apply plugin: 'maven'
 apply plugin: "com.jfrog.artifactory"
 apply plugin: "signing"
+
+apply from: "$rootDir/gradle/version.gradle"
 apply from: "${rootDir}/gradle/pom.gradle"
 
 afterEvaluate {

--- a/gradle/version.gradle
+++ b/gradle/version.gradle
@@ -1,0 +1,22 @@
+def getGitHash = { ->
+  def stdout = new ByteArrayOutputStream()
+  exec {
+    commandLine 'git', 'rev-parse', '--short', 'HEAD'
+    standardOutput = stdout
+  }
+  return stdout.toString().trim()
+}
+
+task writeVersionNumberFile {
+
+  def versionFile = file("${sourceSets.main.output.resourcesDir}/${project.name}.version")
+  inputs.property "version", project.version
+  outputs.file versionFile
+
+  doFirst {
+    assert versionFile.parentFile.mkdirs() || versionFile.parentFile.directory
+    versionFile.text = "${project.version}~${getGitHash()}"
+  }
+}
+
+processResources.dependsOn writeVersionNumberFile


### PR DESCRIPTION
This would report values for `Datadog-Meta-Lang-Interpreter` like:
* `Java HotSpot(TM) 64-Bit Server VM`
* `Oracle JRockit(R)`
* `IBM J9 VM`

This is useful diagnostic information when troubleshooting.

Is this an appropriate usage of this header?