### PR TITLE
Use a factory to create TracingCommandListener

### DIFF
--- a/dd-java-agent/dd-java-agent.gradle
+++ b/dd-java-agent/dd-java-agent.gradle
@@ -16,6 +16,7 @@ whitelistedInstructionClasses += whitelistedBranchClasses += [
   'com.datadoghq.trace.agent.TraceAnnotationsManager',
   'com.datadoghq.trace.agent.InstrumentationChecker',
   'com.datadoghq.trace.agent.DDJavaAgentInfo',
+  'io.opentracing.contrib.mongo.TracingCommandListenerFactory',
 ]
 
 dependencies {
@@ -30,7 +31,7 @@ dependencies {
   compile(group: 'io.opentracing.contrib', name: 'opentracing-web-servlet-filter', version: '0.0.9') {
     exclude(group: 'org.eclipse.jetty', module: 'jetty-servlet')
   }
-  compile(group: 'io.opentracing.contrib', name: 'opentracing-mongo-driver', version: '0.0.2') {
+  compile(group: 'io.opentracing.contrib', name: 'opentracing-mongo-driver', version: '0.0.3') {
     exclude(group: 'org.mongodb', module: 'mongodb-driver-async')
     exclude(group: 'org.mongodb', module: 'mongo-java-driver')
   }

--- a/dd-java-agent/src/main/java/com/datadoghq/trace/agent/integration/MongoHelper.java
+++ b/dd-java-agent/src/main/java/com/datadoghq/trace/agent/integration/MongoHelper.java
@@ -5,6 +5,7 @@ import com.mongodb.MongoClientOptions;
 import com.mongodb.event.CommandStartedEvent;
 import io.opentracing.Span;
 import io.opentracing.contrib.mongo.TracingCommandListener;
+import io.opentracing.contrib.mongo.TracingCommandListenerFactory;
 import io.opentracing.tag.Tags;
 import java.util.Arrays;
 import java.util.List;
@@ -41,7 +42,7 @@ public class MongoHelper extends DDAgentTracingHelper<MongoClientOptions.Builder
   protected MongoClientOptions.Builder doPatch(final MongoClientOptions.Builder builder)
       throws Exception {
 
-    final TracingCommandListener listener = new TracingCommandListener(tracer);
+    final TracingCommandListener listener = TracingCommandListenerFactory.create(tracer);
     builder.addCommandListener(listener);
 
     setState(builder, 1);

--- a/dd-java-agent/src/main/java/io/opentracing/contrib/mongo/TracingCommandListenerFactory.java
+++ b/dd-java-agent/src/main/java/io/opentracing/contrib/mongo/TracingCommandListenerFactory.java
@@ -1,0 +1,10 @@
+package io.opentracing.contrib.mongo;
+
+import io.opentracing.Tracer;
+
+public class TracingCommandListenerFactory {
+
+  public static TracingCommandListener create(final Tracer tracer) {
+    return new TracingCommandListener(tracer);
+  }
+}


### PR DESCRIPTION
This bypasses the inexplicable change in visibility of the constructor.