### PR TITLE
[example] upgrade OT Mongo contrib module to 0.0.3

### DIFF
--- a/dd-trace-examples/rest-spark/rest-spark.gradle
+++ b/dd-trace-examples/rest-spark/rest-spark.gradle
@@ -17,7 +17,7 @@ dependencies {
 
   compile 'io.opentracing:opentracing-api:0.30.0'
   compile 'io.opentracing:opentracing-util:0.30.0'
-  compile 'io.opentracing.contrib:opentracing-mongo-driver:0.0.2'
+  compile 'io.opentracing.contrib:opentracing-mongo-driver:0.0.3'
 
   compile group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
   compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'


### PR DESCRIPTION
### Overview

Follow-up of https://github.com/DataDog/dd-trace-java/pull/80 that patches version 0.0.3