### PR TITLE
[example] added 404 endpoint to test the rewrite decorator

### DIFF
--- a/dd-trace-examples/rest-spark/README.md
+++ b/dd-trace-examples/rest-spark/README.md
@@ -36,7 +36,7 @@ Launch the application using the run wrapper you've built during the ``installDi
 JAVA_OPTS=-javaagent:../../dd-java-agent/build/libs/dd-java-agent-{version}.jar build/install/rest-spark/bin/rest-spark
 ```
 
-``0.1.2-SNAPSHOT`` is an example of what ``{version}`` looks like.
+``0.2.0-SNAPSHOT`` is an example of what ``{version}`` looks like.
 
 ### Generate traces
 

--- a/dd-trace-examples/rest-spark/src/main/java/com/datadoghq/example/restspark/SparkApplication.java
+++ b/dd-trace-examples/rest-spark/src/main/java/com/datadoghq/example/restspark/SparkApplication.java
@@ -26,8 +26,6 @@ public class SparkApplication {
         "/key/:id",
         (req, res) -> {
           try (ActiveSpan activeSpan = mTracer.buildSpan("spark.request").startActive()) {
-            activeSpan.setTag("http.url", req.url());
-
             final String id = req.params(":id");
 
             // create a collection
@@ -44,8 +42,23 @@ public class SparkApplication {
             // write the count somewhere
             System.out.println(collection.count());
 
+            // add some metadata to the request Span
+            activeSpan.setTag("http.status_code", res.status());
+            activeSpan.setTag("http.url", req.url());
+
             return "Stored!";
           }
+        });
+    get(
+        "/users/:id",
+        (req, res) -> {
+          try (ActiveSpan activeSpan = mTracer.buildSpan("spark.request").startActive()) {
+            // this endpoint tests the 404 decorator
+            res.status(404);
+            activeSpan.setTag("http.status_code", res.status());
+            activeSpan.setTag("http.url", req.url());
+          }
+          return "404";
         });
   }
 }


### PR DESCRIPTION
### Overview

Added `/users/:id` route that returns always a `404`.