### PR TITLE
dd-trace shouldn’t be shadow bundled

### DIFF
--- a/dd-trace/dd-trace.gradle
+++ b/dd-trace/dd-trace.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'groovy'
-  id "com.github.johnrengelman.shadow" version "2.0.1"
   id "me.champeau.gradle.jmh" version "0.4.4"
 }
 
@@ -41,30 +40,6 @@ dependencies {
   testCompile group: 'io.ratpack', name: 'ratpack-groovy-test', version: '1.4.6'
 
   jmh 'commons-io:commons-io:2.4'
-}
-
-jar {
-  classifier = 'unbundled'
-}
-
-shadowJar {
-//    mergeServiceFiles()
-
-  classifier null
-
-  // Don't relocate slf4j or opentracing deps.
-  relocate 'com.fasterxml', 'dd.deps.com.fasterxml'
-  relocate 'com.google', 'dd.deps.com.google'
-  relocate 'org.yaml', 'dd.deps.org.yaml'
-
-  dependencies {
-    exclude(dependency('org.projectlombok:lombok:1.16.18'))
-  }
-}
-
-// We don't want bundled dependencies to show up in the pom.
-modifyPom {
-  dependencies.removeAll { true }
 }
 
 jmh {

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -110,7 +110,9 @@ bintray {
     key = bintrayApiKey
   }
 
-  configurations = ['archives']
+  if (!isRoot) {
+    configurations = ['archives']
+  }
 
 //  dryRun = true //[Default: false] Whether to run this as dry-run, without deploying
   publish = true //[Default: false] Whether version should be auto published after an upload


### PR DESCRIPTION
`dd-trace` is intended to be used like a library in the context of a dependency managed environment like gradle or maven.  I think we're better off letting the dependency manager manage our dependencies.  Conceivably this might cause dependency conflicts in the future, but I think we're better off solving that down the road.

Here's what the resulting pom looks like:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <modelVersion>4.0.0</modelVersion>
  <groupId>com.datadoghq</groupId>
  <artifactId>dd-trace</artifactId>
  <version>0.2.1-SNAPSHOT</version>
  <name>dd-trace</name>
  <description>dd-trace</description>
  <url>https://github.com/datadog/dd-trace-java</url>
  <licenses>
    <license>
      <name>The Apache Software License, Version 2.0</name>
      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
      <distribution>repo</distribution>
    </license>
  </licenses>
  <developers>
    <developer>
      <id>datadog</id>
      <name>Datadog</name>
    </developer>
  </developers>
  <scm>
    <connection>scm:https://datadog@github.com/datadog/dd-trace-java</connection>
    <developerConnection>scm:git@github.com:datadog/dd-trace-java.git</developerConnection>
    <url>https://github.com/datadog/dd-trace-java</url>
  </scm>
  <dependencies>
    <dependency>
      <groupId>io.opentracing</groupId>
      <artifactId>opentracing-api</artifactId>
      <version>0.30.0</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>io.opentracing</groupId>
      <artifactId>opentracing-noop</artifactId>
      <version>0.30.0</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>io.opentracing</groupId>
      <artifactId>opentracing-util</artifactId>
      <version>0.30.0</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>io.opentracing.contrib</groupId>
      <artifactId>opentracing-tracerresolver</artifactId>
      <version>0.1.0</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>com.fasterxml.jackson.core</groupId>
      <artifactId>jackson-databind</artifactId>
      <version>2.8.8</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>com.fasterxml.jackson.dataformat</groupId>
      <artifactId>jackson-dataformat-yaml</artifactId>
      <version>2.8.8</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>org.slf4j</groupId>
      <artifactId>slf4j-api</artifactId>
      <version>1.7.25</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>com.google.auto.service</groupId>
      <artifactId>auto-service</artifactId>
      <version>1.0-rc3</version>
      <scope>compile</scope>
    </dependency>
  </dependencies>
</project>
```
