### PR TITLE
Rename google and byteman dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ Thumbs.db
 /logs/*
 /bin
 /out
+*/out

--- a/dd-java-agent-ittests/dd-java-agent-ittests.gradle
+++ b/dd-java-agent-ittests/dd-java-agent-ittests.gradle
@@ -6,6 +6,7 @@ apply from: "${rootDir}/gradle/java.gradle"
 description = 'dd-java-agent-ittests'
 dependencies {
   testCompile project(':dd-java-agent')
+
   testCompile group: 'io.opentracing', name: 'opentracing-mock', version: '0.30.0'
   testCompile group: 'junit', name: 'junit', version: '4.12'
   testCompile group: 'org.assertj', name: 'assertj-core', version: '3.6.2'
@@ -30,6 +31,12 @@ dependencies {
   testCompile group: 'javax.jms', name: 'javax.jms-api', version: '2.0.1'
   testCompile group: 'org.apache.activemq.tooling', name: 'activemq-junit', version: '5.14.5'
   testCompile group: 'org.apache.activemq', name: 'activemq-broker', version: '5.14.5'
+}
+
+configurations.all {
+  resolutionStrategy {
+    force 'com.google.guava:guava:18.0' // Force to test package renaming in agent jar. (see ShadowPackageRenamingTest)
+  }
 }
 
 test {

--- a/dd-java-agent-ittests/src/test/java/com/datadoghq/trace/agent/ShadowPackageRenamingTest.java
+++ b/dd-java-agent-ittests/src/test/java/com/datadoghq/trace/agent/ShadowPackageRenamingTest.java
@@ -1,0 +1,17 @@
+package com.datadoghq.trace.agent;
+
+import com.google.common.collect.MapMaker;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ShadowPackageRenamingTest {
+
+  @Test
+  public void test() {
+    try {
+      (new MapMaker()).softValues(); // this method exists in 18.0 but was removed in 20.0
+    } catch (final NoSuchMethodError e) {
+      Assert.fail("wrong class was loaded");
+    }
+  }
+}

--- a/dd-java-agent/dd-java-agent.gradle
+++ b/dd-java-agent/dd-java-agent.gradle
@@ -93,15 +93,21 @@ shadowJar {
 
 //    mergeServiceFiles()
 
-  // Various tests fail when these are uncommented:
-//    relocate 'com.google', 'dd.deps.com.google'
-//    relocate 'org.jboss.byteman', 'dd.deps.org.jboss.byteman'
-
   // Don't relocate slf4j or opentracing deps.
   relocate 'com.fasterxml', 'dd.deps.com.fasterxml'
   relocate 'javassist', 'dd.deps.javassist'
   relocate 'org.reflections', 'dd.deps.org.reflections'
   relocate 'org.yaml', 'dd.deps.org.yaml'
+
+  relocate('org.jboss.byteman', 'dd.deps.org.jboss.byteman') {
+    // Renaming these causes a verify error in the tests.
+    exclude 'org.jboss.byteman.rule.*'
+    exclude 'org.jboss.byteman.rule.helper.*'
+  }
+  relocate('com.google', 'dd.deps.com.google') {
+    // This is used in the Cassandra Cluster.connectAsync signature so we can't relocate it. :fingers_crossed:
+    exclude 'com.google.common.util.concurrent.ListenableFuture'
+  }
 
   //Exclude Java 9 compiled classes:
   exclude 'org/jboss/byteman/agent/JigsawAccessEnablerGenerator.class'


### PR DESCRIPTION
But exclude the ones that cause the tests to fail.
Also add a test to verify the correct version of guava is loaded with the agent running.