### PR TITLE
Remove dd-java-agent as a dependency for the integ test

### DIFF
--- a/dd-java-agent-ittests/dd-java-agent-ittests.gradle
+++ b/dd-java-agent-ittests/dd-java-agent-ittests.gradle
@@ -5,13 +5,14 @@ apply from: "${rootDir}/gradle/java.gradle"
 
 description = 'dd-java-agent-ittests'
 dependencies {
-  testCompile project(':dd-java-agent')
+  testCompile project(':dd-trace-annotations')
+  testCompile project(':dd-trace')
 
   testCompile group: 'io.opentracing', name: 'opentracing-mock', version: '0.30.0'
-  testCompile group: 'junit', name: 'junit', version: '4.12'
   testCompile group: 'org.assertj', name: 'assertj-core', version: '3.6.2'
-  testCompile group: 'org.mockito', name: 'mockito-core', version: '2.7.22'
+
   testCompile group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
+
   testCompile group: 'org.mongodb', name: 'mongo-java-driver', version: '3.4.2'
   testCompile group: 'org.eclipse.jetty', name: 'jetty-server', version: '9.4.1.v20170120'
   testCompile group: 'org.eclipse.jetty', name: 'jetty-servlet', version: '9.4.1.v20170120'

--- a/dd-java-agent-ittests/src/test/java/com/datadoghq/trace/agent/integration/AWSInstrumentationTest.java
+++ b/dd-java-agent-ittests/src/test/java/com/datadoghq/trace/agent/integration/AWSInstrumentationTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
-import io.opentracing.contrib.aws.TracingRequestHandler;
 import org.junit.Test;
 
 public class AWSInstrumentationTest {
@@ -19,7 +18,7 @@ public class AWSInstrumentationTest {
 
     assertThat(builder.getRequestHandlers()).isNotNull();
     assertThat(builder.getRequestHandlers().size()).isEqualTo(1);
-    assertThat(builder.getRequestHandlers().get(0).getClass())
-        .isEqualTo(TracingRequestHandler.class);
+    assertThat(builder.getRequestHandlers().get(0).getClass().getSimpleName())
+        .isEqualTo("TracingRequestHandler");
   }
 }

--- a/dd-java-agent-ittests/src/test/java/com/datadoghq/trace/agent/integration/ApacheHTTPClientTest.java
+++ b/dd-java-agent-ittests/src/test/java/com/datadoghq/trace/agent/integration/ApacheHTTPClientTest.java
@@ -2,7 +2,6 @@ package com.datadoghq.trace.agent.integration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.opentracing.contrib.apache.http.client.TracingHttpClientBuilder;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.junit.Test;
 
@@ -12,6 +11,6 @@ public class ApacheHTTPClientTest {
   public void test() throws Exception {
 
     final HttpClientBuilder builder = HttpClientBuilder.create();
-    assertThat(builder).isInstanceOf(TracingHttpClientBuilder.class);
+    assertThat(builder.getClass().getSimpleName()).isEqualTo("TracingHttpClientBuilder");
   }
 }

--- a/dd-java-agent-ittests/src/test/java/com/datadoghq/trace/agent/integration/JMSInstrumentationTest.java
+++ b/dd-java-agent-ittests/src/test/java/com/datadoghq/trace/agent/integration/JMSInstrumentationTest.java
@@ -2,8 +2,6 @@ package com.datadoghq.trace.agent.integration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.opentracing.contrib.jms.TracingMessageProducer;
-import io.opentracing.contrib.jms.common.TracingMessageConsumer;
 import javax.jms.Connection;
 import javax.jms.JMSException;
 import javax.jms.MessageConsumer;
@@ -40,7 +38,7 @@ public class JMSInstrumentationTest {
     MessageProducer producer = session.createProducer(destination);
     MessageConsumer consumer = session.createConsumer(destination);
 
-    assertThat(producer).isInstanceOf(TracingMessageProducer.class);
-    assertThat(consumer).isInstanceOf(TracingMessageConsumer.class);
+    assertThat(producer.getClass().getSimpleName()).isEqualTo("TracingMessageProducer");
+    assertThat(consumer.getClass().getSimpleName()).isEqualTo("TracingMessageConsumer");
   }
 }

--- a/dd-java-agent-ittests/src/test/java/com/datadoghq/trace/agent/integration/MongoClientInstrumentationTest.java
+++ b/dd-java-agent-ittests/src/test/java/com/datadoghq/trace/agent/integration/MongoClientInstrumentationTest.java
@@ -3,7 +3,6 @@ package com.datadoghq.trace.agent.integration;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.mongodb.MongoClient;
-import io.opentracing.contrib.mongo.TracingCommandListener;
 import org.junit.Test;
 
 public class MongoClientInstrumentationTest {
@@ -13,8 +12,14 @@ public class MongoClientInstrumentationTest {
     MongoClient mongoClient = new MongoClient();
 
     assertThat(mongoClient.getMongoClientOptions().getCommandListeners().size()).isEqualTo(1);
-    assertThat(mongoClient.getMongoClientOptions().getCommandListeners().get(0).getClass())
-        .isEqualTo(TracingCommandListener.class);
+    assertThat(
+            mongoClient
+                .getMongoClientOptions()
+                .getCommandListeners()
+                .get(0)
+                .getClass()
+                .getSimpleName())
+        .isEqualTo("TracingCommandListener");
 
     mongoClient.close();
   }

--- a/dd-java-agent-ittests/src/test/java/com/datadoghq/trace/agent/integration/OkHTTPInstrumentationTest.java
+++ b/dd-java-agent-ittests/src/test/java/com/datadoghq/trace/agent/integration/OkHTTPInstrumentationTest.java
@@ -2,7 +2,6 @@ package com.datadoghq.trace.agent.integration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.opentracing.contrib.okhttp3.TracingInterceptor;
 import okhttp3.OkHttpClient;
 import org.junit.Test;
 
@@ -13,6 +12,7 @@ public class OkHTTPInstrumentationTest {
     OkHttpClient client = new OkHttpClient().newBuilder().build();
 
     assertThat(client.interceptors().size()).isEqualTo(1);
-    assertThat(client.interceptors().get(0).getClass()).isEqualTo(TracingInterceptor.class);
+    assertThat(client.interceptors().get(0).getClass().getSimpleName())
+        .isEqualTo("TracingInterceptor");
   }
 }


### PR DESCRIPTION
This better simulates the classpath for an application where the agent is only added via the commandline.