### PR TITLE
Add property to gradle.properties for easier debugging

### DIFF
--- a/dd-java-agent-ittests/dd-java-agent-ittests.gradle
+++ b/dd-java-agent-ittests/dd-java-agent-ittests.gradle
@@ -43,6 +43,10 @@ test {
   jvmArgs "-Ddd.trace.configurationFile=${project.buildDir}/resources/test/dd-trace.yaml"
   jvmArgs "-javaagent:${project(':dd-java-agent').buildDir}/libs/dd-java-agent-${project.version}.jar"
   jvmArgs "-Dorg.jboss.byteman.verbose=true"
+
+  if (project.hasProperty("disableShadowRelocate") && disableShadowRelocate) {
+    exclude 'com/datadoghq/trace/agent/ShadowPackageRenamingTest.class'
+  }
 }
 
 test.dependsOn project(':dd-java-agent').shadowJar

--- a/dd-java-agent/dd-java-agent.gradle
+++ b/dd-java-agent/dd-java-agent.gradle
@@ -91,20 +91,22 @@ shadowJar {
 
 //    mergeServiceFiles()
 
-  // Don't relocate slf4j or opentracing deps.
-  relocate 'com.fasterxml', 'dd.deps.com.fasterxml'
-  relocate 'javassist', 'dd.deps.javassist'
-  relocate 'org.reflections', 'dd.deps.org.reflections'
-  relocate 'org.yaml', 'dd.deps.org.yaml'
+  if (!project.hasProperty("disableShadowRelocate") || !disableShadowRelocate) {
+    // Don't relocate slf4j or opentracing deps.
+    relocate 'com.fasterxml', 'dd.deps.com.fasterxml'
+    relocate 'javassist', 'dd.deps.javassist'
+    relocate 'org.reflections', 'dd.deps.org.reflections'
+    relocate 'org.yaml', 'dd.deps.org.yaml'
 
-  relocate('org.jboss.byteman', 'dd.deps.org.jboss.byteman') {
-    // Renaming these causes a verify error in the tests.
-    exclude 'org.jboss.byteman.rule.*'
-    exclude 'org.jboss.byteman.rule.helper.*'
-  }
-  relocate('com.google', 'dd.deps.com.google') {
-    // This is used in the Cassandra Cluster.connectAsync signature so we can't relocate it. :fingers_crossed:
-    exclude 'com.google.common.util.concurrent.ListenableFuture'
+    relocate('org.jboss.byteman', 'dd.deps.org.jboss.byteman') {
+      // Renaming these causes a verify error in the tests.
+      exclude 'org.jboss.byteman.rule.*'
+      exclude 'org.jboss.byteman.rule.helper.*'
+    }
+    relocate('com.google', 'dd.deps.com.google') {
+      // This is used in the Cassandra Cluster.connectAsync signature so we can't relocate it. :fingers_crossed:
+      exclude 'com.google.common.util.concurrent.ListenableFuture'
+    }
   }
 
   //Exclude Java 9 compiled classes:


### PR DESCRIPTION
When using a jar with packages renamed, the line numbers don’t match the classes in the IDE.