### PR TITLE
Mark servlet trace filter as async supported

### DIFF
--- a/dd-java-agent/src/main/java/com/datadoghq/trace/agent/integration/JettyServletHelper.java
+++ b/dd-java-agent/src/main/java/com/datadoghq/trace/agent/integration/JettyServletHelper.java
@@ -3,6 +3,7 @@ package com.datadoghq.trace.agent.integration;
 import io.opentracing.contrib.web.servlet.filter.TracingFilter;
 import java.util.EnumSet;
 import javax.servlet.Filter;
+import javax.servlet.FilterRegistration;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.jboss.byteman.rule.Rule;
 
@@ -25,11 +26,11 @@ public class JettyServletHelper extends DDAgentTracingHelper<ServletContextHandl
     String[] patterns = {"/*"};
 
     Filter filter = new TracingFilter(tracer);
-    contextHandler
-        .getServletContext()
-        .addFilter("tracingFilter", filter)
-        .addMappingForUrlPatterns(
-            EnumSet.allOf(javax.servlet.DispatcherType.class), true, patterns);
+    FilterRegistration.Dynamic registration =
+        contextHandler.getServletContext().addFilter("tracingFilter", filter);
+    registration.setAsyncSupported(true);
+    registration.addMappingForUrlPatterns(
+        EnumSet.allOf(javax.servlet.DispatcherType.class), true, patterns);
 
     setState(contextHandler.getServletContext(), 1);
     return contextHandler;

--- a/dd-java-agent/src/main/java/com/datadoghq/trace/agent/integration/TomcatServletHelper.java
+++ b/dd-java-agent/src/main/java/com/datadoghq/trace/agent/integration/TomcatServletHelper.java
@@ -3,6 +3,7 @@ package com.datadoghq.trace.agent.integration;
 import io.opentracing.contrib.web.servlet.filter.TracingFilter;
 import java.util.EnumSet;
 import javax.servlet.Filter;
+import javax.servlet.FilterRegistration;
 import org.apache.catalina.core.ApplicationContext;
 import org.jboss.byteman.rule.Rule;
 
@@ -25,10 +26,10 @@ public class TomcatServletHelper extends DDAgentTracingHelper<ApplicationContext
     String[] patterns = {"/*"};
 
     Filter filter = new TracingFilter(tracer);
-    contextHandler
-        .addFilter("tracingFilter", filter)
-        .addMappingForUrlPatterns(
-            EnumSet.allOf(javax.servlet.DispatcherType.class), true, patterns);
+    FilterRegistration.Dynamic registration = contextHandler.addFilter("tracingFilter", filter);
+    registration.setAsyncSupported(true);
+    registration.addMappingForUrlPatterns(
+        EnumSet.allOf(javax.servlet.DispatcherType.class), true, patterns);
 
     return contextHandler;
   }

--- a/dd-trace-examples/dropwizard-mongo-client/src/main/java/com/datadoghq/example/dropwizard/resources/SimpleCrudResource.java
+++ b/dd-trace-examples/dropwizard-mongo-client/src/main/java/com/datadoghq/example/dropwizard/resources/SimpleCrudResource.java
@@ -14,6 +14,8 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
+import javax.ws.rs.container.AsyncResponse;
+import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.MediaType;
 import org.bson.Document;
 
@@ -94,6 +96,13 @@ public class SimpleCrudResource {
     afterDB();
 
     return books;
+  }
+
+  @GET
+  @Path("/async")
+  public void async(@Suspended AsyncResponse response) {
+    // not actually async, but useful for testing that codepath.
+    response.resume("Returned from async");
   }
 
   /**


### PR DESCRIPTION
Otherwise the added filter breaks any async endpoints with the following message:

```
Attempt to put servlet request into asynchronous mode has failed. Please check your servlet configuration - all Servlet instances and Servlet filters involved in the request processing must explicitly declare support for asynchronous request processing.
java.lang.IllegalStateException: !asyncSupported
```