### PR TITLE
Report version from main

### DIFF
--- a/dd-java-agent/dd-java-agent.gradle
+++ b/dd-java-agent/dd-java-agent.gradle
@@ -78,6 +78,7 @@ jar {
 
   manifest {
     attributes(
+      "Main-Class": "com.datadoghq.trace.agent.DDJavaAgentInfo",
       // I don't think we want to define this since we can't really load after startup:
       //"Agent-Class": "com.datadoghq.trace.agent.AnnotationsTracingAgent",
       "Premain-Class": "com.datadoghq.trace.agent.AnnotationsTracingAgent",

--- a/dd-java-agent/src/main/java/com/datadoghq/trace/agent/DDJavaAgentInfo.java
+++ b/dd-java-agent/src/main/java/com/datadoghq/trace/agent/DDJavaAgentInfo.java
@@ -16,14 +16,19 @@ public class DDJavaAgentInfo {
       final BufferedReader br =
           new BufferedReader(
               new InputStreamReader(
-                  DDJavaAgentInfo.class.getResourceAsStream("dd-java-agent.version"), "UTF-8"));
+                  DDJavaAgentInfo.class.getResourceAsStream("/dd-java-agent.version"), "UTF-8"));
       for (int c = br.read(); c != -1; c = br.read()) sb.append((char) c);
 
       v = sb.toString().trim();
     } catch (final Exception e) {
+      e.printStackTrace();
       v = "unknown";
     }
     VERSION = v;
     log.info("dd-java-agent - version: {}", v);
+  }
+
+  public static void main(String... args) {
+    System.out.println(VERSION);
   }
 }

--- a/dd-trace-annotations/src/main/java/com/datadoghq/trace/DDTraceAnnotationsInfo.java
+++ b/dd-trace-annotations/src/main/java/com/datadoghq/trace/DDTraceAnnotationsInfo.java
@@ -16,7 +16,7 @@ public class DDTraceAnnotationsInfo {
       final BufferedReader br =
           new BufferedReader(
               new InputStreamReader(
-                  DDTraceAnnotationsInfo.class.getResourceAsStream("dd-trace-annotations.version"),
+                  DDTraceAnnotationsInfo.class.getResourceAsStream("/dd-trace-annotations.version"),
                   "UTF-8"));
       for (int c = br.read(); c != -1; c = br.read()) sb.append((char) c);
 
@@ -26,5 +26,9 @@ public class DDTraceAnnotationsInfo {
     }
     VERSION = v;
     log.info("dd-trace-annotations - version: {}", v);
+  }
+
+  public static void main(String... args) {
+    System.out.println(VERSION);
   }
 }

--- a/dd-trace-examples/rest-spark/rest-spark.gradle
+++ b/dd-trace-examples/rest-spark/rest-spark.gradle
@@ -1,3 +1,7 @@
+plugins {
+  id "com.github.johnrengelman.shadow" version "2.0.1"
+}
+
 apply plugin: 'application'
 apply from: "${rootDir}/gradle/java.gradle"
 apply from: "${rootDir}/gradle/jacoco.gradle"
@@ -21,6 +25,16 @@ dependencies {
 
   compile group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
   compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
+}
+
+jar {
+  manifest {
+    attributes 'Main-Class': 'com.datadoghq.example.restspark.SparkApplication'
+  }
+}
+
+shadowJar {
+  mergeServiceFiles()
 }
 
 task wrapper(type: Wrapper) {

--- a/dd-trace-java.gradle
+++ b/dd-trace-java.gradle
@@ -30,25 +30,20 @@ apply from: "${rootDir}/gradle/publish.gradle"
 // Source: https://github.com/ratpack/ratpack/blob/master/ratpack.gradle#L101
 task bintrayPublish() {
   doLast {
-    if (!project.hasProperty("bintrayApiKey")) {
-      throw new InvalidUserDataException("You must provide bintrayApiKey")
+    if (!project.hasProperty("bintrayApiKey") || bintrayApiKey.length() < 20) {
+      throw new InvalidUserDataException("You must provide a valid bintrayApiKey")
     }
 
-    if (!project.hasProperty('buildNumber')) {
-      throw new GradleException("Must provide buildNumber of a release from https://oss.jfrog.org/artifactory/webapp/#/builds/dd-trace-java")
+    if (!project.hasProperty('buildNumber') || !"$buildNumber".isInteger()) {
+      throw new TaskExecutionException("Must provide buildNumber of a release from https://oss.jfrog.org/artifactory/webapp/#/builds/dd-trace-java")
     }
 
-    def curl = ['curl',
-                '-X', 'POST',
-                "-u", "${bintrayUser}:${bintrayApiKey}",
-                "-H", "Content-Type: application/json",
-                "-d", """{
-    "dryRun": "true",
-    "targetRepo": "datadog-maven",
-    "sourceRepos": ["oss-release-local"]
-}
-""",
-                "https://oss.jfrog.org/api/build/distribute/dd-trace-java/$project.buildNumber"
+    def curl = [
+      'curl',
+      '-X', 'POST',
+      '-u', "${bintrayUser}:${bintrayApiKey}",
+      '-d', '',
+      "http://oss.jfrog.org/api/plugins/build/promote/snapshotsToBintray/dd-trace-java/$project.buildNumber"
     ].execute()
     logger.info("Received response: ${curl.text}")
   }

--- a/dd-trace/src/main/java/com/datadoghq/trace/DDTraceInfo.java
+++ b/dd-trace/src/main/java/com/datadoghq/trace/DDTraceInfo.java
@@ -20,7 +20,7 @@ public class DDTraceInfo {
       final BufferedReader br =
           new BufferedReader(
               new InputStreamReader(
-                  DDTraceInfo.class.getResourceAsStream("dd-trace.version"), "UTF-8"));
+                  DDTraceInfo.class.getResourceAsStream("/dd-trace.version"), "UTF-8"));
       for (int c = br.read(); c != -1; c = br.read()) sb.append((char) c);
 
       v = sb.toString().trim();
@@ -29,5 +29,9 @@ public class DDTraceInfo {
     }
     VERSION = v;
     log.info("dd-trace - version: {}", v);
+  }
+
+  public static void main(String... args) {
+    System.out.println(VERSION);
   }
 }

--- a/dd-trace/src/test/groovy/com/datadoghq/trace/writer/DDApiTest.groovy
+++ b/dd-trace/src/test/groovy/com/datadoghq/trace/writer/DDApiTest.groovy
@@ -76,7 +76,7 @@ class DDApiTest extends Specification {
     requestContentType.get().type == "application/msgpack"
     requestHeaders.get().get("Datadog-Meta-Lang") == "java"
     requestHeaders.get().get("Datadog-Meta-Lang-Version") == System.getProperty("java.version", "unknown")
-    requestHeaders.get().get("Datadog-Meta-Tracer-Version") == "unknown"
+    requestHeaders.get().get("Datadog-Meta-Tracer-Version") == "Stubbed-Test-Version"
     convertList(requestBody.get()) == expectedRequestBody
 
     cleanup:
@@ -175,7 +175,7 @@ class DDApiTest extends Specification {
     requestContentType.get().type == "application/msgpack"
     requestHeaders.get().get("Datadog-Meta-Lang") == "java"
     requestHeaders.get().get("Datadog-Meta-Lang-Version") == System.getProperty("java.version", "unknown")
-    requestHeaders.get().get("Datadog-Meta-Tracer-Version") == "unknown"
+    requestHeaders.get().get("Datadog-Meta-Tracer-Version") == "Stubbed-Test-Version"
     convertMap(requestBody.get()) == expectedRequestBody
 
     cleanup:

--- a/dd-trace/src/test/resources/dd-trace.version
+++ b/dd-trace/src/test/resources/dd-trace.version
@@ -1,0 +1,1 @@
+Stubbed-Test-Version


### PR DESCRIPTION
This allows running the agent as an executable jar to report the version number.

Also repot version scan errors better.