### PR TITLE
Use package-renamed Simple SLF4J logger

### DIFF
--- a/dd-java-agent/dd-java-agent.gradle
+++ b/dd-java-agent/dd-java-agent.gradle
@@ -30,6 +30,10 @@ dependencies {
   compile group: 'com.google.auto.service', name: 'auto-service', version: '1.0-rc3'
   compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
 
+  compile group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.25'
+  // ^ Generally a bad idea for libraries, but we're shadowing.
+
+
   compile(group: 'io.opentracing.contrib', name: 'opentracing-web-servlet-filter', version: '0.0.9') {
     exclude(group: 'org.eclipse.jetty', module: 'jetty-servlet')
   }
@@ -96,16 +100,20 @@ shadowJar {
 
 //    mergeServiceFiles()
 
+  relocate 'org.slf4j', 'dd.deps.org.slf4j'  // Prevents conflict with other SLF4J instances. Important for premain.
+
   if (!project.hasProperty("disableShadowRelocate") || !disableShadowRelocate) {
-    // Don't relocate slf4j or opentracing deps.
+    // Don't relocate opentracing deps.
+
+    relocate 'org.yaml', 'dd.deps.org.yaml'
+    relocate 'org.msgpack', 'dd.deps.org.msgpack'
     relocate('com.fasterxml', 'dd.deps.com.fasterxml') {
       exclude 'com.fasterxml.jackson.core.type.TypeReference'
       exclude 'com.fasterxml.jackson.annotation.*'
     }
+
     relocate 'javassist', 'dd.deps.javassist'
     relocate 'org.reflections', 'dd.deps.org.reflections'
-    relocate 'org.yaml', 'dd.deps.org.yaml'
-
     relocate('org.jboss.byteman', 'dd.deps.org.jboss.byteman') {
       // Renaming these causes a verify error in the tests.
       exclude 'org.jboss.byteman.rule.*'

--- a/dd-java-agent/src/main/java/com/datadoghq/trace/agent/TraceAnnotationsManager.java
+++ b/dd-java-agent/src/main/java/com/datadoghq/trace/agent/TraceAnnotationsManager.java
@@ -1,5 +1,7 @@
 package com.datadoghq.trace.agent;
 
+import com.datadoghq.trace.DDTraceAnnotationsInfo;
+import com.datadoghq.trace.DDTraceInfo;
 import com.datadoghq.trace.Trace;
 import com.datadoghq.trace.resolver.DDTracerFactory;
 import com.datadoghq.trace.resolver.FactoryUtils;
@@ -41,6 +43,11 @@ import org.reflections.util.FilterBuilder;
  */
 @Slf4j
 public class TraceAnnotationsManager {
+
+  // Initialize the info classes so they print out their version info:
+  private static final String ddJavaAgentVersion = DDJavaAgentInfo.VERSION;
+  private static final String ddTraceVersion = DDTraceInfo.VERSION;
+  private static final String ddTraceAnnotationsVersion = DDTraceAnnotationsInfo.VERSION;
 
   private static final String AGENT_RULES = "otarules.btm";
   private static final String CURRENT_SPAN_EXISTS = "IF TRUE\n";


### PR DESCRIPTION
This will prevent us from respecting any existing SLF4J implementation and just print to the console.  This is important for things like Spring Boot that never put a SLF4J implementation on the system classpath, but instead keep it inside the jar.

Just to be clear, I don't view this as a final destination, more as a step towards a better solution.