### PR TITLE
Turns out Byteman doesn’t like $this as a reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ For Maven, add this to pom.xml:
 <!-- OpenTracing Util -->
 <dependency>
     <groupId>io.opentracing</groupId>
-    <artifactId>io.opentracing:opentracing-util</artifactId>
+    <artifactId>opentracing-util</artifactId>
     <version>0.30.0</version>
 </dependency>
 

--- a/dd-java-agent/src/main/resources/otarules.btm
+++ b/dd-java-agent/src/main/resources/otarules.btm
@@ -31,7 +31,7 @@ HELPER com.datadoghq.trace.agent.integration.AWSClientHelper
 AT ENTRY
 IF TRUE
 DO
-  patch($this);
+  patch($0);
 ENDRULE
 
 
@@ -81,7 +81,7 @@ HELPER com.datadoghq.trace.agent.integration.MongoHelper
 AT ENTRY
 IF getState($0) == 0
 DO
-  patch($this);
+  patch($0);
 ENDRULE
 
 RULE opentracing-mongo-driver-helper
@@ -104,7 +104,7 @@ HELPER com.datadoghq.trace.agent.integration.OkHttpHelper
 AT ENTRY
 IF TRUE
 DO
-  patch($this)
+  patch($0)
 ENDRULE
 
 
@@ -119,7 +119,7 @@ HELPER com.datadoghq.trace.agent.integration.JettyServletHelper
 AT EXIT
 IF getState($0.getServletContext()) == 0
 DO
-  patch($this)
+  patch($0)
 ENDRULE
 
 
@@ -133,5 +133,5 @@ HELPER com.datadoghq.trace.agent.integration.TomcatServletHelper
 AT EXIT
 IF TRUE
 DO
-  patch($this)
+  patch($0)
 ENDRULE


### PR DESCRIPTION
Their docs were misleading.

Also fix the readme’s maven dependency.