### PR TITLE
Speed up integ tests by reducing scope for annotation scan.

### DIFF
--- a/dd-java-agent-ittests/dd-java-agent-ittests.gradle
+++ b/dd-java-agent-ittests/dd-java-agent-ittests.gradle
@@ -50,7 +50,7 @@ test {
   }
 
   if (project.hasProperty("disableShadowRelocate") && disableShadowRelocate) {
-    exclude 'com/datadoghq/trace/agent/ShadowPackageRenamingTest.class'
+    exclude 'com/datadoghq/trace/agent/test/ShadowPackageRenamingTest.class'
   }
 }
 

--- a/dd-java-agent-ittests/src/test/java/com/datadoghq/trace/agent/test/SayTracedHello.java
+++ b/dd-java-agent-ittests/src/test/java/com/datadoghq/trace/agent/test/SayTracedHello.java
@@ -1,4 +1,4 @@
-package com.datadoghq.trace.agent;
+package com.datadoghq.trace.agent.test;
 
 import com.datadoghq.trace.DDTags;
 import com.datadoghq.trace.Trace;

--- a/dd-java-agent-ittests/src/test/java/com/datadoghq/trace/agent/test/ShadowPackageRenamingTest.java
+++ b/dd-java-agent-ittests/src/test/java/com/datadoghq/trace/agent/test/ShadowPackageRenamingTest.java
@@ -1,4 +1,4 @@
-package com.datadoghq.trace.agent;
+package com.datadoghq.trace.agent.test;
 
 import com.google.common.collect.MapMaker;
 import org.junit.Assert;

--- a/dd-java-agent-ittests/src/test/java/com/datadoghq/trace/agent/test/TraceAnnotationsManagerTest.java
+++ b/dd-java-agent-ittests/src/test/java/com/datadoghq/trace/agent/test/TraceAnnotationsManagerTest.java
@@ -1,4 +1,4 @@
-package com.datadoghq.trace.agent;
+package com.datadoghq.trace.agent.test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/dd-java-agent-ittests/src/test/java/com/datadoghq/trace/agent/test/integration/AWSInstrumentationTest.java
+++ b/dd-java-agent-ittests/src/test/java/com/datadoghq/trace/agent/test/integration/AWSInstrumentationTest.java
@@ -1,4 +1,4 @@
-package com.datadoghq.trace.agent.integration;
+package com.datadoghq.trace.agent.test.integration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/dd-java-agent-ittests/src/test/java/com/datadoghq/trace/agent/test/integration/ApacheHTTPClientTest.java
+++ b/dd-java-agent-ittests/src/test/java/com/datadoghq/trace/agent/test/integration/ApacheHTTPClientTest.java
@@ -1,4 +1,4 @@
-package com.datadoghq.trace.agent.integration;
+package com.datadoghq.trace.agent.test.integration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/dd-java-agent-ittests/src/test/java/com/datadoghq/trace/agent/test/integration/CassandraIntegrationTest.java
+++ b/dd-java-agent-ittests/src/test/java/com/datadoghq/trace/agent/test/integration/CassandraIntegrationTest.java
@@ -1,4 +1,4 @@
-package com.datadoghq.trace.agent.integration;
+package com.datadoghq.trace.agent.test.integration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/dd-java-agent-ittests/src/test/java/com/datadoghq/trace/agent/test/integration/JMSInstrumentationTest.java
+++ b/dd-java-agent-ittests/src/test/java/com/datadoghq/trace/agent/test/integration/JMSInstrumentationTest.java
@@ -1,4 +1,4 @@
-package com.datadoghq.trace.agent.integration;
+package com.datadoghq.trace.agent.test.integration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/dd-java-agent-ittests/src/test/java/com/datadoghq/trace/agent/test/integration/JettyServletInstrumentationTest.java
+++ b/dd-java-agent-ittests/src/test/java/com/datadoghq/trace/agent/test/integration/JettyServletInstrumentationTest.java
@@ -1,4 +1,4 @@
-package com.datadoghq.trace.agent.integration;
+package com.datadoghq.trace.agent.test.integration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/dd-java-agent-ittests/src/test/java/com/datadoghq/trace/agent/test/integration/MongoClientInstrumentationTest.java
+++ b/dd-java-agent-ittests/src/test/java/com/datadoghq/trace/agent/test/integration/MongoClientInstrumentationTest.java
@@ -1,4 +1,4 @@
-package com.datadoghq.trace.agent.integration;
+package com.datadoghq.trace.agent.test.integration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/dd-java-agent-ittests/src/test/java/com/datadoghq/trace/agent/test/integration/OkHTTPInstrumentationTest.java
+++ b/dd-java-agent-ittests/src/test/java/com/datadoghq/trace/agent/test/integration/OkHTTPInstrumentationTest.java
@@ -1,4 +1,4 @@
-package com.datadoghq.trace.agent.integration;
+package com.datadoghq.trace.agent.test.integration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/dd-java-agent-ittests/src/test/java/com/datadoghq/trace/agent/test/integration/TomcatServletInstrumentationTest.java
+++ b/dd-java-agent-ittests/src/test/java/com/datadoghq/trace/agent/test/integration/TomcatServletInstrumentationTest.java
@@ -1,4 +1,4 @@
-package com.datadoghq.trace.agent.integration;
+package com.datadoghq.trace.agent.test.integration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/dd-java-agent-ittests/src/test/resources/dd-trace.yaml
+++ b/dd-java-agent-ittests/src/test/resources/dd-trace.yaml
@@ -21,7 +21,7 @@ sampler:
   # skipTagsPatterns: {"http.url": ".*/demo/add.*"}
   
 # Enable custom annotation tracing over a selected set of packages
-enableCustomAnnotationTracingOver: ["com.datadoghq.trace.agent"]
+enableCustomAnnotationTracingOver: ["com.datadoghq.trace.agent.test"]
 
 # Disable some instrumentations
 # disabledInstrumentations: ["apache http", "mongo", "jetty", "tomcat", ...]


### PR DESCRIPTION
Small improvement, but cuts the test down by a few seconds.