### PR TITLE
Remove dependency on OpenTracing Agent

### DIFF
--- a/dd-java-agent/dd-java-agent.gradle
+++ b/dd-java-agent/dd-java-agent.gradle
@@ -22,7 +22,8 @@ dependencies {
     transitive = false
   }
 
-  compile group: 'io.opentracing.contrib', name: 'opentracing-agent', version: '0.1.0'
+  compile group: 'org.jboss.byteman', name: 'byteman', version: '4.0.0-BETA5'
+
   compile group: 'org.reflections', name: 'reflections', version: '0.9.11'
   compile group: 'com.google.auto.service', name: 'auto-service', version: '1.0-rc3'
   compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
@@ -53,9 +54,6 @@ jar {
       "Premain-Class": "com.datadoghq.trace.agent.TracingAgent",
       "Can-Redefine-Classes": true,
       "Can-Retransform-Classes": true,
-      // It is dangerous putting everything on the bootstrap classpath,
-      // but kept for consistency with previous versions.
-      "Boot-Class-Path": "./${jar.archiveName}.jar"
     )
   }
 }

--- a/dd-java-agent/integrations/helpers/helpers.gradle
+++ b/dd-java-agent/integrations/helpers/helpers.gradle
@@ -11,7 +11,7 @@ dependencies {
   compileOnly project(':dd-trace-annotations')
   compileOnly group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
 
-  compileOnly group: 'io.opentracing.contrib', name: 'opentracing-agent', version: '0.1.0'
+  compileOnly group: 'org.jboss.byteman', name: 'byteman', version: '4.0.0-BETA5'
 
   compile group: 'io.opentracing.contrib', name: 'opentracing-web-servlet-filter', version: '0.0.9'
   compile group: 'io.opentracing.contrib', name: 'opentracing-mongo-driver', version: '0.0.3'

--- a/dd-java-agent/integrations/helpers/src/main/java/com/datadoghq/trace/agent/integration/DDAgentTracingHelper.java
+++ b/dd-java-agent/integrations/helpers/src/main/java/com/datadoghq/trace/agent/integration/DDAgentTracingHelper.java
@@ -2,7 +2,6 @@ package com.datadoghq.trace.agent.integration;
 
 import io.opentracing.NoopTracerFactory;
 import io.opentracing.Tracer;
-import io.opentracing.contrib.agent.OpenTracingHelper;
 import lombok.extern.slf4j.Slf4j;
 import org.jboss.byteman.rule.Rule;
 

--- a/dd-java-agent/integrations/helpers/src/main/java/com/datadoghq/trace/agent/integration/OpenTracingHelper.java
+++ b/dd-java-agent/integrations/helpers/src/main/java/com/datadoghq/trace/agent/integration/OpenTracingHelper.java
@@ -1,0 +1,296 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datadoghq.trace.agent.integration;
+
+import io.opentracing.ActiveSpan;
+import io.opentracing.BaseSpan;
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.opentracing.Tracer.SpanBuilder;
+import io.opentracing.contrib.tracerresolver.TracerResolver;
+import io.opentracing.propagation.Format;
+import io.opentracing.util.GlobalTracer;
+import java.net.HttpURLConnection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.WeakHashMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.jboss.byteman.rule.Rule;
+import org.jboss.byteman.rule.helper.Helper;
+
+/** This class provides helper capabilities to the byteman rules. */
+public class OpenTracingHelper extends Helper {
+
+  private static final Logger log = Logger.getLogger(OpenTracingHelper.class.getName());
+
+  private static Tracer tracer;
+
+  private static final Map<Object, Span> spanAssociations =
+      Collections.synchronizedMap(new WeakHashMap<Object, Span>());
+  private static final Map<Object, Span> finished =
+      Collections.synchronizedMap(new WeakHashMap<Object, Span>());
+
+  private static final Map<Object, Integer> state =
+      Collections.synchronizedMap(new WeakHashMap<Object, Integer>());
+
+  private static final Object SYNC = new Object();
+
+  public OpenTracingHelper(Rule rule) {
+    super(rule);
+  }
+
+  /**
+   * This method returns the OpenTracing tracer.
+   *
+   * @return The tracer
+   */
+  public Tracer getTracer() {
+    if (tracer == null) {
+      // Initialize on first use
+      initTracer();
+    }
+    return tracer;
+  }
+
+  protected void initTracer() {
+    synchronized (SYNC) {
+      if (tracer == null) {
+        if (!GlobalTracer.isRegistered()) {
+          // Try to obtain a tracer using the TracerResolver
+          Tracer resolved = TracerResolver.resolveTracer();
+          if (resolved != null) {
+            try {
+              GlobalTracer.register(resolved);
+            } catch (RuntimeException re) {
+              log.log(Level.WARNING, "Failed to register tracer '" + resolved + "'", re);
+            }
+          }
+        }
+        // Initialize the tracer even if one has not been registered
+        // (i.e. it will use a NoopTracer under the covers)
+        tracer = new AgentTracer(GlobalTracer.get());
+      }
+    }
+  }
+
+  /**
+   * This method establishes an association between an application object (i.e. the subject of the
+   * instrumentation) and a span. Once the application object is no longer being used, the
+   * association with the span will automatically be discarded.
+   *
+   * @param obj The application object to be associated with the span
+   * @param span The span
+   */
+  public void associateSpan(Object obj, Span span) {
+    spanAssociations.put(obj, span);
+  }
+
+  /**
+   * This method retrieves the span associated with the supplied application object.
+   *
+   * @param obj The application object
+   * @return The span, or null if no associated span exists
+   */
+  public Span retrieveSpan(Object obj) {
+    return spanAssociations.get(obj);
+  }
+
+  /** ******************************************* */
+  /** Needs to be replaced by span.isFinished() */
+  public void finishedSpan(Object key, Span span) {
+    finished.put(key, span);
+  }
+
+  public boolean isFinished(Object key) {
+    return finished.containsKey(key);
+  }
+  /** ******************************************* */
+
+  /**
+   * This method enables an instrumentation rule to record a 'state' number against an application
+   * object. This can be used in situations where rules are only applicable in certain states. For
+   * example, the simple case for rules responsible for installing filters would be states
+   * representing NOT_INSTALLED and INSTALLED. This means that the filter would only be installed if
+   * the application object (target of the instrumentation rule) was in the NOT_INSTALLED state.
+   * However other more complex scenarios may be encountered where more than two states are
+   * required.
+   *
+   * @param obj The application object
+   * @param value The state value
+   */
+  public void setState(Object obj, int value) {
+    state.put(obj, new Integer(value));
+  }
+
+  /**
+   * This method retrieves the current 'state' number associated with the supplied application
+   * object.
+   *
+   * @param obj The application object
+   * @return The state, or 0 if no state currently exists
+   */
+  public int getState(Object obj) {
+    Integer value = state.get(obj);
+    return value == null ? 0 : value.intValue();
+  }
+
+  /**
+   * This method determines whether the instrumentation point, associated with the supplied object,
+   * should be ignored.
+   *
+   * @param obj The instrumentation target
+   * @return Whether the instrumentation point should be ignored
+   */
+  public boolean ignore(Object obj) {
+    boolean ignore = false;
+
+    if (obj instanceof HttpURLConnection) {
+      String value = ((HttpURLConnection) obj).getRequestProperty("opentracing.ignore");
+      ignore = value != null && value.equalsIgnoreCase("true");
+    }
+
+    // TODO: If other technologies need to use this feature,
+    // then create an Adapter to wrap the specifics of each
+    // technology and provide access to their properties
+
+    if (ignore && log.isLoggable(Level.FINEST)) {
+      log.finest("Ignoring request because the property [opentracing.ignore] is present.");
+    }
+
+    return ignore;
+  }
+
+  /**
+   * Proxy tracer used for one purpose - to enable the rules to define a ChildOf relationship
+   * without being concerned whether the supplied Span is null. If the spec (and Tracer
+   * implementations) are updated to indicate a null should be ignored, then this proxy can be
+   * removed.
+   */
+  public static class AgentTracer implements Tracer {
+
+    private Tracer tracer;
+
+    public AgentTracer(Tracer tracer) {
+      this.tracer = tracer;
+    }
+
+    @Override
+    public SpanBuilder buildSpan(String operation) {
+      return new AgentSpanBuilder(tracer.buildSpan(operation));
+    }
+
+    @Override
+    public <C> SpanContext extract(Format<C> format, C carrier) {
+      return tracer.extract(format, carrier);
+    }
+
+    @Override
+    public <C> void inject(SpanContext ctx, Format<C> format, C carrier) {
+      tracer.inject(ctx, format, carrier);
+    }
+
+    @Override
+    public ActiveSpan activeSpan() {
+      return tracer.activeSpan();
+    }
+
+    @Override
+    public ActiveSpan makeActive(Span span) {
+      return tracer.makeActive(span);
+    }
+  }
+
+  public static class AgentSpanBuilder implements SpanBuilder {
+
+    private SpanBuilder spanBuilder;
+
+    public AgentSpanBuilder(SpanBuilder spanBuilder) {
+      this.spanBuilder = spanBuilder;
+    }
+
+    @Override
+    public SpanBuilder addReference(String type, SpanContext ctx) {
+      if (ctx != null) {
+        spanBuilder.addReference(type, ctx);
+      }
+      return this;
+    }
+
+    @Override
+    public SpanBuilder asChildOf(SpanContext ctx) {
+      if (ctx != null) {
+        spanBuilder.asChildOf(ctx);
+      }
+      return this;
+    }
+
+    @Override
+    public SpanBuilder asChildOf(BaseSpan<?> span) {
+      if (span != null) {
+        spanBuilder.asChildOf(span);
+      }
+      return this;
+    }
+
+    @Override
+    public Span start() {
+      return spanBuilder.start();
+    }
+
+    @Override
+    public SpanBuilder withStartTimestamp(long ts) {
+      spanBuilder.withStartTimestamp(ts);
+      return this;
+    }
+
+    @Override
+    public SpanBuilder withTag(String name, String value) {
+      spanBuilder.withTag(name, value);
+      return this;
+    }
+
+    @Override
+    public SpanBuilder withTag(String name, boolean value) {
+      spanBuilder.withTag(name, value);
+      return this;
+    }
+
+    @Override
+    public SpanBuilder withTag(String name, Number value) {
+      spanBuilder.withTag(name, value);
+      return this;
+    }
+
+    @Override
+    public SpanBuilder ignoreActiveSpan() {
+      spanBuilder.ignoreActiveSpan();
+      return this;
+    }
+
+    @Override
+    public ActiveSpan startActive() {
+      return spanBuilder.startActive();
+    }
+
+    @Override
+    public Span startManual() {
+      return spanBuilder.startManual();
+    }
+  }
+}

--- a/dd-java-agent/src/main/java/com/datadoghq/trace/agent/OpenTracingHelper.java
+++ b/dd-java-agent/src/main/java/com/datadoghq/trace/agent/OpenTracingHelper.java
@@ -1,0 +1,296 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datadoghq.trace.agent;
+
+import io.opentracing.ActiveSpan;
+import io.opentracing.BaseSpan;
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.opentracing.Tracer.SpanBuilder;
+import io.opentracing.contrib.tracerresolver.TracerResolver;
+import io.opentracing.propagation.Format;
+import io.opentracing.util.GlobalTracer;
+import java.net.HttpURLConnection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.WeakHashMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.jboss.byteman.rule.Rule;
+import org.jboss.byteman.rule.helper.Helper;
+
+/** This class provides helper capabilities to the byteman rules. */
+public class OpenTracingHelper extends Helper {
+
+  private static final Logger log = Logger.getLogger(OpenTracingHelper.class.getName());
+
+  private static Tracer tracer;
+
+  private static final Map<Object, Span> spanAssociations =
+      Collections.synchronizedMap(new WeakHashMap<Object, Span>());
+  private static final Map<Object, Span> finished =
+      Collections.synchronizedMap(new WeakHashMap<Object, Span>());
+
+  private static final Map<Object, Integer> state =
+      Collections.synchronizedMap(new WeakHashMap<Object, Integer>());
+
+  private static final Object SYNC = new Object();
+
+  public OpenTracingHelper(Rule rule) {
+    super(rule);
+  }
+
+  /**
+   * This method returns the OpenTracing tracer.
+   *
+   * @return The tracer
+   */
+  public Tracer getTracer() {
+    if (tracer == null) {
+      // Initialize on first use
+      initTracer();
+    }
+    return tracer;
+  }
+
+  protected void initTracer() {
+    synchronized (SYNC) {
+      if (tracer == null) {
+        if (!GlobalTracer.isRegistered()) {
+          // Try to obtain a tracer using the TracerResolver
+          Tracer resolved = TracerResolver.resolveTracer();
+          if (resolved != null) {
+            try {
+              GlobalTracer.register(resolved);
+            } catch (RuntimeException re) {
+              log.log(Level.WARNING, "Failed to register tracer '" + resolved + "'", re);
+            }
+          }
+        }
+        // Initialize the tracer even if one has not been registered
+        // (i.e. it will use a NoopTracer under the covers)
+        tracer = new AgentTracer(GlobalTracer.get());
+      }
+    }
+  }
+
+  /**
+   * This method establishes an association between an application object (i.e. the subject of the
+   * instrumentation) and a span. Once the application object is no longer being used, the
+   * association with the span will automatically be discarded.
+   *
+   * @param obj The application object to be associated with the span
+   * @param span The span
+   */
+  public void associateSpan(Object obj, Span span) {
+    spanAssociations.put(obj, span);
+  }
+
+  /**
+   * This method retrieves the span associated with the supplied application object.
+   *
+   * @param obj The application object
+   * @return The span, or null if no associated span exists
+   */
+  public Span retrieveSpan(Object obj) {
+    return spanAssociations.get(obj);
+  }
+
+  /** ******************************************* */
+  /** Needs to be replaced by span.isFinished() */
+  public void finishedSpan(Object key, Span span) {
+    finished.put(key, span);
+  }
+
+  public boolean isFinished(Object key) {
+    return finished.containsKey(key);
+  }
+  /** ******************************************* */
+
+  /**
+   * This method enables an instrumentation rule to record a 'state' number against an application
+   * object. This can be used in situations where rules are only applicable in certain states. For
+   * example, the simple case for rules responsible for installing filters would be states
+   * representing NOT_INSTALLED and INSTALLED. This means that the filter would only be installed if
+   * the application object (target of the instrumentation rule) was in the NOT_INSTALLED state.
+   * However other more complex scenarios may be encountered where more than two states are
+   * required.
+   *
+   * @param obj The application object
+   * @param value The state value
+   */
+  public void setState(Object obj, int value) {
+    state.put(obj, new Integer(value));
+  }
+
+  /**
+   * This method retrieves the current 'state' number associated with the supplied application
+   * object.
+   *
+   * @param obj The application object
+   * @return The state, or 0 if no state currently exists
+   */
+  public int getState(Object obj) {
+    Integer value = state.get(obj);
+    return value == null ? 0 : value.intValue();
+  }
+
+  /**
+   * This method determines whether the instrumentation point, associated with the supplied object,
+   * should be ignored.
+   *
+   * @param obj The instrumentation target
+   * @return Whether the instrumentation point should be ignored
+   */
+  public boolean ignore(Object obj) {
+    boolean ignore = false;
+
+    if (obj instanceof HttpURLConnection) {
+      String value = ((HttpURLConnection) obj).getRequestProperty("opentracing.ignore");
+      ignore = value != null && value.equalsIgnoreCase("true");
+    }
+
+    // TODO: If other technologies need to use this feature,
+    // then create an Adapter to wrap the specifics of each
+    // technology and provide access to their properties
+
+    if (ignore && log.isLoggable(Level.FINEST)) {
+      log.finest("Ignoring request because the property [opentracing.ignore] is present.");
+    }
+
+    return ignore;
+  }
+
+  /**
+   * Proxy tracer used for one purpose - to enable the rules to define a ChildOf relationship
+   * without being concerned whether the supplied Span is null. If the spec (and Tracer
+   * implementations) are updated to indicate a null should be ignored, then this proxy can be
+   * removed.
+   */
+  public static class AgentTracer implements Tracer {
+
+    private Tracer tracer;
+
+    public AgentTracer(Tracer tracer) {
+      this.tracer = tracer;
+    }
+
+    @Override
+    public SpanBuilder buildSpan(String operation) {
+      return new AgentSpanBuilder(tracer.buildSpan(operation));
+    }
+
+    @Override
+    public <C> SpanContext extract(Format<C> format, C carrier) {
+      return tracer.extract(format, carrier);
+    }
+
+    @Override
+    public <C> void inject(SpanContext ctx, Format<C> format, C carrier) {
+      tracer.inject(ctx, format, carrier);
+    }
+
+    @Override
+    public ActiveSpan activeSpan() {
+      return tracer.activeSpan();
+    }
+
+    @Override
+    public ActiveSpan makeActive(Span span) {
+      return tracer.makeActive(span);
+    }
+  }
+
+  public static class AgentSpanBuilder implements SpanBuilder {
+
+    private SpanBuilder spanBuilder;
+
+    public AgentSpanBuilder(SpanBuilder spanBuilder) {
+      this.spanBuilder = spanBuilder;
+    }
+
+    @Override
+    public SpanBuilder addReference(String type, SpanContext ctx) {
+      if (ctx != null) {
+        spanBuilder.addReference(type, ctx);
+      }
+      return this;
+    }
+
+    @Override
+    public SpanBuilder asChildOf(SpanContext ctx) {
+      if (ctx != null) {
+        spanBuilder.asChildOf(ctx);
+      }
+      return this;
+    }
+
+    @Override
+    public SpanBuilder asChildOf(BaseSpan<?> span) {
+      if (span != null) {
+        spanBuilder.asChildOf(span);
+      }
+      return this;
+    }
+
+    @Override
+    public Span start() {
+      return spanBuilder.start();
+    }
+
+    @Override
+    public SpanBuilder withStartTimestamp(long ts) {
+      spanBuilder.withStartTimestamp(ts);
+      return this;
+    }
+
+    @Override
+    public SpanBuilder withTag(String name, String value) {
+      spanBuilder.withTag(name, value);
+      return this;
+    }
+
+    @Override
+    public SpanBuilder withTag(String name, boolean value) {
+      spanBuilder.withTag(name, value);
+      return this;
+    }
+
+    @Override
+    public SpanBuilder withTag(String name, Number value) {
+      spanBuilder.withTag(name, value);
+      return this;
+    }
+
+    @Override
+    public SpanBuilder ignoreActiveSpan() {
+      spanBuilder.ignoreActiveSpan();
+      return this;
+    }
+
+    @Override
+    public ActiveSpan startActive() {
+      return spanBuilder.startActive();
+    }
+
+    @Override
+    public Span startManual() {
+      return spanBuilder.startManual();
+    }
+  }
+}

--- a/dd-java-agent/src/main/java/com/datadoghq/trace/agent/TraceAnnotationsManager.java
+++ b/dd-java-agent/src/main/java/com/datadoghq/trace/agent/TraceAnnotationsManager.java
@@ -126,7 +126,7 @@ public class TraceAnnotationsManager {
         transformer.installScript(
             Arrays.asList(generatedScripts.toString()), Arrays.asList("@Trace annotations"), pr);
       }
-      log.trace("Install new rules: \n{}", sw.toString());
+      log.debug("Install new rules: \n{}", sw.toString());
     } catch (final Exception e) {
       log.warn("Could not install annotation scripts.", e);
     }
@@ -153,7 +153,7 @@ public class TraceAnnotationsManager {
             false,
             false,
             javassistMethod.getName() + Descriptor.toString(javassistMethod.getSignature()),
-            "io.opentracing.contrib.agent.OpenTracingHelper",
+            OpenTracingHelper.class.getName(),
             imports,
             loc,
             ruleText,

--- a/dd-java-agent/src/main/java/com/datadoghq/trace/agent/TracingAgent.java
+++ b/dd-java-agent/src/main/java/com/datadoghq/trace/agent/TracingAgent.java
@@ -16,7 +16,6 @@
  */
 package com.datadoghq.trace.agent;
 
-import io.opentracing.contrib.agent.OpenTracingAgent;
 import java.lang.instrument.Instrumentation;
 import lombok.extern.slf4j.Slf4j;
 
@@ -25,7 +24,7 @@ import lombok.extern.slf4j.Slf4j;
  * and the manager class.
  */
 @Slf4j
-public class TracingAgent extends OpenTracingAgent {
+public class TracingAgent {
 
   public static void premain(String agentArgs, final Instrumentation inst) throws Exception {
     agentArgs = addManager(agentArgs);


### PR DESCRIPTION
It brings in a bunch of duplicate and unnecessary dependencies since it also bundles them in its’ jar.  Copying the OpenTracingHelper class to our repo until we can refactor it away.  It also is Apache 2 licensed so I think we should be ok.