### PR TITLE
Remove version numbers from generated files

### DIFF
--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -84,5 +84,11 @@ if (project.plugins.hasPlugin('com.github.johnrengelman.shadow')) {
   }
 }
 
+if(project.hasProperty("removeJarVersionNumbers") && removeJarVersionNumbers) {
+  tasks.withType(AbstractArchiveTask) {
+    version = null
+  }
+}
+
 apply from: "$rootDir/gradle/checkstyle.gradle"
 apply from: "$rootDir/gradle/codenarc.gradle"

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -78,6 +78,7 @@ artifactoryPublish { task ->
 artifactory {
   gradle.taskGraph.whenReady { taskGraph ->
     if (taskGraph.hasTask(artifactoryPublish)) {
+      assert !project.hasProperty("removeJarVersionNumbers") || !removeJarVersionNumbers
       // trigger error if missing
       bintrayUser
       bintrayApiKey
@@ -115,6 +116,7 @@ bintrayUpload { task ->
 bintray {
   gradle.taskGraph.whenReady { taskGraph ->
     if (taskGraph.hasTask(bintrayUpload)) {
+      assert !project.hasProperty("removeJarVersionNumbers") || !removeJarVersionNumbers
       // trigger error if missing
       bintrayUser
       bintrayApiKey


### PR DESCRIPTION
This should only be used for local development.  This makes it easier for command line testing to have consistent file references that don’t change each release.