### PR TITLE
Prevent NPE for double registrations

### DIFF
--- a/dd-java-agent-ittests/dd-java-agent-ittests.gradle
+++ b/dd-java-agent-ittests/dd-java-agent-ittests.gradle
@@ -45,9 +45,9 @@ test {
 
   doFirst {
     // Defining here to allow jacoco to be first on the command line.
-    jvmArgs "-javaagent:${project(':dd-java-agent').buildDir}/libs/dd-java-agent-${project.version}.jar"
+    jvmArgs "-javaagent:${project(':dd-java-agent').tasks.shadowJar.archivePath}"
   }
-  
+
   testLogging {
     events "started"
   }

--- a/dd-java-agent/integrations/helpers/src/main/java/com/datadoghq/agent/integration/JettyServletHelper.java
+++ b/dd-java-agent/integrations/helpers/src/main/java/com/datadoghq/agent/integration/JettyServletHelper.java
@@ -10,7 +10,9 @@ import org.jboss.byteman.rule.Rule;
 /** Patch the Jetty Servlet during the init steps */
 public class JettyServletHelper extends DDAgentTracingHelper<ServletContextHandler> {
 
-  public JettyServletHelper(Rule rule) {
+  private static final String pattern = "/*";
+
+  public JettyServletHelper(final Rule rule) {
     super(rule);
   }
 
@@ -21,18 +23,19 @@ public class JettyServletHelper extends DDAgentTracingHelper<ServletContextHandl
    * @return The same current contextHandler but patched
    * @throws Exception
    */
-  protected ServletContextHandler doPatch(ServletContextHandler contextHandler) throws Exception {
-
-    String[] patterns = {"/*"};
-
-    Filter filter = new TracingFilter(tracer);
-    FilterRegistration.Dynamic registration =
-        contextHandler.getServletContext().addFilter("tracingFilter", filter);
-    registration.setAsyncSupported(true);
-    registration.addMappingForUrlPatterns(
-        EnumSet.allOf(javax.servlet.DispatcherType.class), true, patterns);
-
-    setState(contextHandler.getServletContext(), 1);
+  @Override
+  protected ServletContextHandler doPatch(final ServletContextHandler contextHandler)
+      throws Exception {
+    if (contextHandler.getServletContext().getFilterRegistration("tracingFilter") == null) {
+      final Filter filter = new TracingFilter(tracer);
+      final FilterRegistration.Dynamic registration =
+          contextHandler.getServletContext().addFilter("tracingFilter", filter);
+      if (registration != null) { // filter of that name must already be registered.
+        registration.setAsyncSupported(true);
+        registration.addMappingForUrlPatterns(
+            EnumSet.allOf(javax.servlet.DispatcherType.class), true, pattern);
+      }
+    }
     return contextHandler;
   }
 }

--- a/dd-java-agent/integrations/helpers/src/main/java/com/datadoghq/agent/integration/TomcatServletHelper.java
+++ b/dd-java-agent/integrations/helpers/src/main/java/com/datadoghq/agent/integration/TomcatServletHelper.java
@@ -7,10 +7,12 @@ import javax.servlet.FilterRegistration;
 import org.apache.catalina.core.ApplicationContext;
 import org.jboss.byteman.rule.Rule;
 
-/** Patch the Jetty Servlet during the init steps */
+/** Patch the Tomcat Servlet during the init steps */
 public class TomcatServletHelper extends DDAgentTracingHelper<ApplicationContext> {
 
-  public TomcatServletHelper(Rule rule) {
+  private static final String pattern = "/*";
+
+  public TomcatServletHelper(final Rule rule) {
     super(rule);
   }
 
@@ -21,16 +23,18 @@ public class TomcatServletHelper extends DDAgentTracingHelper<ApplicationContext
    * @return The same current contextHandler but patched
    * @throws Exception
    */
-  protected ApplicationContext doPatch(ApplicationContext contextHandler) throws Exception {
-
-    String[] patterns = {"/*"};
-
-    Filter filter = new TracingFilter(tracer);
-    FilterRegistration.Dynamic registration = contextHandler.addFilter("tracingFilter", filter);
-    registration.setAsyncSupported(true);
-    registration.addMappingForUrlPatterns(
-        EnumSet.allOf(javax.servlet.DispatcherType.class), true, patterns);
-
+  @Override
+  protected ApplicationContext doPatch(final ApplicationContext contextHandler) throws Exception {
+    if (contextHandler.getFilterRegistration("tracingFilter") == null) {
+      final Filter filter = new TracingFilter(tracer);
+      final FilterRegistration.Dynamic registration =
+          contextHandler.addFilter("tracingFilter", filter);
+      if (registration != null) { // filter of that name must already be registered.
+        registration.setAsyncSupported(true);
+        registration.addMappingForUrlPatterns(
+            EnumSet.allOf(javax.servlet.DispatcherType.class), true, pattern);
+      }
+    }
     return contextHandler;
   }
 }


### PR DESCRIPTION
When using jetty with spring boot, the helper is being called more than once, the second time resulting in null being returned by `addFilter`.  This should prevent an error from being thrown.