### PR TITLE
Reduce noise generated when injecting classes into classloader

### DIFF
--- a/dd-java-agent/src/main/java/com/datadoghq/agent/InstrumentationRulesManager.java
+++ b/dd-java-agent/src/main/java/com/datadoghq/agent/InstrumentationRulesManager.java
@@ -102,7 +102,7 @@ public class InstrumentationRulesManager {
       }
       initializedClassloaders.add(classLoader);
     }
-    log.info("Initializing on classloader ", classLoader);
+    log.info("Initializing on classloader {}", classLoader);
 
     injector.inject(classLoader);
 


### PR DESCRIPTION
Because some classes depend on other classes that must be injected, we must keep trying.  This results in a fair bit of log noise at debug and it's not obvious which is important.  This waits till complete before printing out.