### PR TITLE
Minor cleanup to publish

### DIFF
--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -100,6 +100,7 @@ artifactory {
     }
     defaults {
       if (!isRoot) publishConfigs('archives')
+      publishIvy = false   // This isn't supported by bintray anyway.
     }
   }
 }
@@ -128,9 +129,7 @@ bintray {
     key = bintrayApiKey
   }
 
-  if (!isRoot) {
-    configurations = ['archives']
-  }
+  if (!isRoot) configurations = ['archives']
 
 //  dryRun = true //[Default: false] Whether to run this as dry-run, without deploying
   publish = true //[Default: false] Whether version should be auto published after an upload
@@ -149,29 +148,6 @@ bintray {
 
     githubRepo = 'datadog/dd-trace-java' //Optional Github repository
     githubReleaseNotesFile = 'README.md' //Optional Github readme file
-
-//    //Optional version descriptor
-//    version {
-//      name = '1.3-Final' //Bintray logical version name
-//      desc = //Optional - Version-specific description'
-//        released = //Optional - Date of the version release. 2 possible values: date in the format of 'yyyy-MM-dd'T'HH:mm:ss.SSSZZ' OR a java.util.Date instance
-//          vcsTag = '1.3.0'
-//      attributes = ['gradle-plugin': 'com.use.less:com.use.less.gradle:gradle-useless-plugin']
-//      //Optional version-level attributes
-//      //Optional configuration for GPG signing
-//      gpg {
-//        sign = true //Determines whether to GPG sign the files. The default is false
-//        passphrase = 'passphrase' //Optional. The passphrase for GPG signing'
-//      }
-//      //Optional configuration for Maven Central sync of the version
-//      mavenCentralSync {
-//        sync = true //[Default: true] Determines whether to sync the version to Maven Central.
-//        user = 'userToken' //OSS user token: mandatory
-//        password = 'paasword' //OSS user password: mandatory
-//        close = '1'
-//        //Optional property. By default the staging repository is closed and artifacts are released to Maven Central. You can optionally turn this behaviour off (by puting 0 as value) and release the version manually.
-//      }
-//    }
   }
 }
 


### PR DESCRIPTION
Ivy isn’t used by bintray or maven central.  We don’t really need to publish it for our snapshots.