### PR TITLE
Adjust log levels and rate limit logging.

### DIFF
--- a/dd-trace/src/main/java/com/datadoghq/trace/writer/DDAgentWriter.java
+++ b/dd-trace/src/main/java/com/datadoghq/trace/writer/DDAgentWriter.java
@@ -173,7 +173,7 @@ public class DDAgentWriter implements Writer {
         final boolean isSent = api.sendTraces(payload);
 
         if (!isSent) {
-          log.warn("Failing to send {} traces to the API", payload.size());
+          log.debug("Failing to send {} traces to the API", payload.size());
           return 0L;
         }
         return (long) payload.size();


### PR DESCRIPTION
If we’re not able to connect and send data to the agent, we don’t want to fill up their logs.