### PR TITLE
Null tags are intended for “deletion”

### DIFF
--- a/dd-trace/src/main/java/com/datadoghq/trace/DDSpanContext.java
+++ b/dd-trace/src/main/java/com/datadoghq/trace/DDSpanContext.java
@@ -181,6 +181,7 @@ public class DDSpanContext implements io.opentracing.SpanContext {
    */
   public synchronized void setTag(final String tag, final Object value) {
     if (value == null) {
+      tags.remove(tag);
       return;
     }
 


### PR DESCRIPTION
This was not well tested and misunderstood.  Some existing decorators depend on this behavior.