### PR TITLE
Fix maven doc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ For Maven, add this to pom.xml:
 <!-- OpenTracing API -->
 <dependency>
     <groupId>io.opentracing</groupId>
-    <artifactId>io.opentracing:opentracing-api</artifactId>
+    <artifactId>opentracing-api</artifactId>
     <version>0.30.0</version>
 </dependency>
 


### PR DESCRIPTION
Fix a typo in the maven documentation. Found during a call with Ping.