### PR TITLE
init global tracer in premain

### DIFF
--- a/dd-java-agent/src/main/java/com/datadoghq/agent/AgentRulesManager.java
+++ b/dd-java-agent/src/main/java/com/datadoghq/agent/AgentRulesManager.java
@@ -24,6 +24,7 @@ public class AgentRulesManager {
   public AgentRulesManager(final TracingAgentConfig config) {
     agentTracerConfig = config;
     instrumentationRulesManager = new InstrumentationRulesManager(config, this);
+    instrumentationRulesManager.initTracer();
   }
 
   /** This method initializes the manager. */

--- a/dd-java-agent/src/main/java/com/datadoghq/agent/InstrumentationRulesManager.java
+++ b/dd-java-agent/src/main/java/com/datadoghq/agent/InstrumentationRulesManager.java
@@ -120,11 +120,9 @@ public class InstrumentationRulesManager {
     log.info("Initializing on classloader {}", classLoader);
 
     injector.inject(classLoader);
-
-    initTracer();
   }
 
-  private void initTracer() {
+  void initTracer() {
     synchronized (SYNC) {
       if (!GlobalTracer.isRegistered()) {
         // Try to obtain a tracer using the TracerResolver
@@ -135,6 +133,8 @@ public class InstrumentationRulesManager {
           } catch (final RuntimeException re) {
             log.warn("Failed to register tracer '" + resolved + "'", re);
           }
+        } else {
+          log.warn("Failed to resolve dd tracer");
         }
       }
     }


### PR DESCRIPTION
Ran into another spring-boot issue. The springboot classloader was the context loader for the thread that initialized the global tracer. This caused the ServiceLoader to look on the spring classpath for loading the tracer services, which couldn't see our agent jar.

Doing the init at premain bypasses the problem by using the system classloader to set up the global tracer.