### PR TITLE
Support for eclipse + buildship

### DIFF
--- a/dd-trace/dd-trace.gradle
+++ b/dd-trace/dd-trace.gradle
@@ -29,9 +29,6 @@ dependencies {
 
   testCompile group: 'org.objenesis', name: 'objenesis', version: '2.6'
   testCompile group: 'cglib', name: 'cglib-nodep', version: '3.2.5'
-
-  testCompile 'org.openjdk.jmh:jmh-core:1.19'
-  testCompile 'org.openjdk.jmh:jmh-generator-annprocess:1.19'
 }
 
 jmh {

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -11,6 +11,17 @@ lombok { // optional: values below are the defaults
   sha256 = "9d957f572386b9e257093a45b148f9b411cff80d9efd55eaf6fca27002d2e4d9"
 }
 
+apply plugin: "eclipse"
+eclipse {
+  classpath {
+    downloadSources = true
+    downloadJavadoc = true
+  }
+}
+if (configurations.find { it.name == 'jmh' }) {
+  eclipse.classpath.plusConfigurations += [ configurations.jmh ]
+}
+
 task packageSources(type: Jar) {
   classifier = 'sources'
   from sourceSets.main.allSource


### PR DESCRIPTION
* Use eclipse plugin to support eclipse+buildship with the `dd-trace-java` project

Just a tooling change.

