### PR TITLE
Fix jersey servlet instrumentation which overrides method

### DIFF
--- a/dd-java-agent/integrations/servlet-2/src/main/java/dd/inst/servlet2/HttpServlet2Instrumentation.java
+++ b/dd-java-agent/integrations/servlet-2/src/main/java/dd/inst/servlet2/HttpServlet2Instrumentation.java
@@ -1,6 +1,8 @@
 package dd.inst.servlet2;
 
 import static dd.trace.ClassLoaderMatcher.classLoaderHasClasses;
+import static net.bytebuddy.matcher.ElementMatchers.hasSuperType;
+import static net.bytebuddy.matcher.ElementMatchers.isInterface;
 import static net.bytebuddy.matcher.ElementMatchers.isProtected;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.not;
@@ -30,7 +32,7 @@ public final class HttpServlet2Instrumentation implements Instrumenter {
   public AgentBuilder instrument(final AgentBuilder agentBuilder) {
     return agentBuilder
         .type(
-            named("javax.servlet.http.HttpServlet"),
+            not(isInterface()).and(hasSuperType(named("javax.servlet.http.HttpServlet"))),
             not(classLoaderHasClasses("javax.servlet.AsyncEvent", "javax.servlet.AsyncListener"))
                 .and(
                     classLoaderHasClasses(

--- a/dd-java-agent/integrations/servlet-3/src/main/java/dd/inst/servlet3/HttpServlet3Instrumentation.java
+++ b/dd-java-agent/integrations/servlet-3/src/main/java/dd/inst/servlet3/HttpServlet3Instrumentation.java
@@ -1,8 +1,11 @@
 package dd.inst.servlet3;
 
 import static dd.trace.ClassLoaderMatcher.classLoaderHasClasses;
+import static net.bytebuddy.matcher.ElementMatchers.hasSuperType;
+import static net.bytebuddy.matcher.ElementMatchers.isInterface;
 import static net.bytebuddy.matcher.ElementMatchers.isProtected;
 import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.not;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
@@ -33,7 +36,7 @@ public final class HttpServlet3Instrumentation implements Instrumenter {
   public AgentBuilder instrument(final AgentBuilder agentBuilder) {
     return agentBuilder
         .type(
-            named("javax.servlet.http.HttpServlet"),
+            not(isInterface()).and(hasSuperType(named("javax.servlet.http.HttpServlet"))),
             classLoaderHasClasses("javax.servlet.AsyncEvent", "javax.servlet.AsyncListener"))
         .transform(
             DDAdvice.create()


### PR DESCRIPTION
Jersey doesn’t seem to delegate to the original method on HttpServlet, which causes those methods to not be traced properly.

This is impacting dropwizard applications which uses Jersey with embedded Jetty.