### PR TITLE
Link instrumentation test reports to dd-java-agent/build/reports/

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,24 +30,16 @@ jobs:
             - ~/.gradle
           key: dd-trace-java-{{ checksum "dd-trace-java.gradle" }}
 
+      - run:
+          name: Save Artifacts to (project-root)/build
+          when: always
+          command: .circleci/save_artifacts.sh
+
       - store_test_results:
-          path: dd-java-agent/build/test-results
-      - store_test_results:
-          path: dd-java-agent-ittests/build/test-results
-      - store_test_results:
-          path: dd-trace/build/test-results
+          path: build/test-results
 
       - store_artifacts:
-          path: dd-java-agent/build/reports
-      - store_artifacts:
-          path: dd-java-agent-ittests/build/reports
-      - store_artifacts:
-          path: dd-trace/build/reports
-
-      - store_artifacts:
-          path: dd-java-agent/build/libs
-      - store_artifacts:
-          path: dd-trace/build/libs
+          path: build
 
       - run:
           name: Decode Signing Key

--- a/.circleci/save_artifacts.sh
+++ b/.circleci/save_artifacts.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Save all important reports and artifacts into (project-root)/build
+# This folder will be saved by circleci and available after test runs.
+
+ARTIFACT_DIR=./build/
+TEST_RESULTS_DIR=./build/test-results
+
+mkdir -p $ARTIFACT_DIR >/dev/null 2>&1
+mkdir -p $TEST_RESULTS_DIR >/dev/null 2>&1
+
+function save_reports () {
+    project_to_save=$1
+    if [ -d $project_to_save/build/reports ]; then
+        report_path=$ARTIFACT_DIR/$project_to_save/build
+        mkdir -p $report_path
+        cp -r $project_to_save/build/reports $report_path/
+    fi
+    if [ -d $project_to_save/build/test-results ]; then
+        find "$project_to_save/build/test-results" -name \*.xml -exec cp {} $TEST_RESULTS_DIR \;
+    fi
+}
+
+function save_libs () {
+    project_to_save=$1
+    if [ -d $project_to_save/build/libs ]; then
+        libs_path=$ARTIFACT_DIR/$project_to_save/build
+        mkdir -p $libs_path
+        cp -r $project_to_save/build/libs $libs_path/
+    fi
+}
+
+save_reports dd-java-agent
+save_reports dd-java-agent/tooling
+# Save reports for all instrumentation projects
+for integration_path in dd-java-agent/integrations/*; do
+    save_reports $integration_path
+done
+save_reports dd-java-agent-ittests
+save_reports dd-trace
+
+save_libs dd-java-agent
+save_libs dd-trace


### PR DESCRIPTION
CircleCI: Before artifacts are uploaded, copy `integrations/*/build/reports` into `dd-java-agent` report directory. This allows saving all the instrumentation test reports without creating new entries in the circleci config.

@tylerbenson If you don't get a good answer on that ticket, I believe this will solve our problem. If there's a more elegant solution then we can close this out.