### PR TITLE
Fix types for Intellij

### DIFF
--- a/dd-java-agent/integrations/mongo-async-3.3/src/main/java/dd/inst/mongo/MongoAsyncClientInstrumentation.java
+++ b/dd-java-agent/integrations/mongo-async-3.3/src/main/java/dd/inst/mongo/MongoAsyncClientInstrumentation.java
@@ -1,6 +1,10 @@
 package dd.inst.mongo;
 
-import static net.bytebuddy.matcher.ElementMatchers.*;
+import static net.bytebuddy.matcher.ElementMatchers.declaresMethod;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.isPublic;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
 import com.mongodb.async.client.MongoClientSettings;
@@ -8,6 +12,7 @@ import dd.trace.DDAdvice;
 import dd.trace.Instrumenter;
 import io.opentracing.util.GlobalTracer;
 import java.lang.reflect.Modifier;
+import java.util.Collections;
 import net.bytebuddy.agent.builder.AgentBuilder;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
@@ -16,7 +21,7 @@ import net.bytebuddy.description.type.TypeDescription;
 public final class MongoAsyncClientInstrumentation implements Instrumenter {
 
   @Override
-  public AgentBuilder instrument(AgentBuilder agentBuilder) {
+  public AgentBuilder instrument(final AgentBuilder agentBuilder) {
     return agentBuilder
         .type(
             named("com.mongodb.async.client.MongoClientSettings$Builder")
@@ -29,7 +34,7 @@ public final class MongoAsyncClientInstrumentation implements Instrumenter {
                                         "com.mongodb.event.CommandListener",
                                         Modifier.PUBLIC,
                                         null,
-                                        new TypeDescription.Generic[] {})))
+                                        Collections.<TypeDescription.Generic>emptyList())))
                             .and(isPublic()))))
         .transform(MongoClientInstrumentation.MONGO_HELPER_INJECTOR)
         .transform(

--- a/dd-java-agent/tooling/src/main/java/dd/trace/HelperInjector.java
+++ b/dd-java-agent/tooling/src/main/java/dd/trace/HelperInjector.java
@@ -3,6 +3,7 @@ package dd.trace;
 import com.datadoghq.agent.Utils;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -20,7 +21,7 @@ import net.bytebuddy.utility.JavaModule;
 public class HelperInjector implements Transformer {
   private final Set<String> helperClassNames;
   private Map<TypeDescription, byte[]> helperMap = null;
-  private final Set<ClassLoader> injectedClassLoaders = new HashSet<ClassLoader>();
+  private final Set<ClassLoader> injectedClassLoaders = new HashSet<>();
 
   /**
    * Construct HelperInjector.
@@ -28,18 +29,20 @@ public class HelperInjector implements Transformer {
    * @param helperClassNames binary names of the helper classes to inject. These class names must be
    *     resolvable by the classloader returned by dd.trace.DDAdvice#getAgentClassLoader()
    */
-  public HelperInjector(String... helperClassNames) {
-    this.helperClassNames = new HashSet<String>(Arrays.asList(helperClassNames));
+  public HelperInjector(final String... helperClassNames) {
+    this.helperClassNames = new HashSet<>(Arrays.asList(helperClassNames));
   }
 
   private synchronized Map<TypeDescription, byte[]> getHelperMap() throws IOException {
     if (helperMap == null) {
-      helperMap = new HashMap<TypeDescription, byte[]>(helperClassNames.size());
-      for (String helperName : helperClassNames) {
+      helperMap = new HashMap<>(helperClassNames.size());
+      for (final String helperName : helperClassNames) {
         final ClassFileLocator locator =
             ClassFileLocator.ForClassLoader.of(Utils.getAgentClassLoader());
         final byte[] classBytes = locator.locate(helperName).resolve();
-        final TypeDescription typeDesc = new TypeDescription.Latent(helperName, 0, null);
+        final TypeDescription typeDesc =
+            new TypeDescription.Latent(
+                helperName, 0, null, Collections.<TypeDescription.Generic>emptyList());
         helperMap.put(typeDesc, classBytes);
       }
     }
@@ -48,16 +51,16 @@ public class HelperInjector implements Transformer {
 
   @Override
   public DynamicType.Builder<?> transform(
-      DynamicType.Builder<?> builder,
-      TypeDescription typeDescription,
-      ClassLoader classLoader,
-      JavaModule module) {
+      final DynamicType.Builder<?> builder,
+      final TypeDescription typeDescription,
+      final ClassLoader classLoader,
+      final JavaModule module) {
     if (helperClassNames.size() > 0 && classLoader != null) {
       synchronized (this) {
         if (!injectedClassLoaders.contains(classLoader)) {
           try {
             new ClassInjector.UsingReflection(classLoader).inject(getHelperMap());
-          } catch (Exception e) {
+          } catch (final Exception e) {
             log.error("Failed to inject helper classes into " + classLoader, e);
             throw new RuntimeException(e);
           }


### PR DESCRIPTION
Idea doesn’t like the vararg representation of `TypeDescription.Latent`.  Using an empty list is the same behavior and doesn’t get the errors.