### PR TITLE
Ensure helper classes are injected in a fixed order

### DIFF
--- a/dd-java-agent/testing/src/main/java/datadog/trace/agent/test/TestUtils.java
+++ b/dd-java-agent/testing/src/main/java/datadog/trace/agent/test/TestUtils.java
@@ -9,8 +9,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.net.URL;
 import java.util.UUID;
 import java.util.concurrent.Callable;
@@ -19,15 +17,6 @@ import java.util.jar.JarOutputStream;
 import java.util.jar.Manifest;
 
 public class TestUtils {
-  private static Method findLoadedClassMethod = null;
-
-  static {
-    try {
-      findLoadedClassMethod = ClassLoader.class.getDeclaredMethod("findLoadedClass", String.class);
-    } catch (NoSuchMethodException | SecurityException e) {
-      throw new IllegalStateException(e);
-    }
-  }
 
   public static void registerOrReplaceGlobalTracer(final Tracer tracer) {
     try {
@@ -62,18 +51,6 @@ public class TestUtils {
       throw new IllegalStateException(e);
     } finally {
       scope.close();
-    }
-  }
-
-  public static boolean isClassLoaded(final String className, final ClassLoader classLoader) {
-    try {
-      findLoadedClassMethod.setAccessible(true);
-      final Class<?> loadedClass = (Class<?>) findLoadedClassMethod.invoke(classLoader, className);
-      return null != loadedClass && loadedClass.getClassLoader() == classLoader;
-    } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
-      throw new IllegalStateException(e);
-    } finally {
-      findLoadedClassMethod.setAccessible(false);
     }
   }
 

--- a/dd-java-agent/tooling/src/main/java/datadog/trace/agent/tooling/Utils.java
+++ b/dd-java-agent/tooling/src/main/java/datadog/trace/agent/tooling/Utils.java
@@ -1,6 +1,19 @@
 package datadog.trace.agent.tooling;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
 public class Utils {
+  private static Method findLoadedClassMethod = null;
+
+  static {
+    try {
+      findLoadedClassMethod = ClassLoader.class.getDeclaredMethod("findLoadedClass", String.class);
+    } catch (NoSuchMethodException | SecurityException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
   /** Return the classloader the core agent is running on. */
   public static ClassLoader getAgentClassLoader() {
     return AgentInstaller.class.getClassLoader();
@@ -9,6 +22,18 @@ public class Utils {
   /** com.foo.Bar -> com/foo/Bar.class */
   public static String getResourceName(final String className) {
     return className.replace('.', '/') + ".class";
+  }
+
+  public static boolean isClassLoaded(final String className, final ClassLoader classLoader) {
+    try {
+      findLoadedClassMethod.setAccessible(true);
+      final Class<?> loadedClass = (Class<?>) findLoadedClassMethod.invoke(classLoader, className);
+      return null != loadedClass && loadedClass.getClassLoader() == classLoader;
+    } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+      throw new IllegalStateException(e);
+    } finally {
+      findLoadedClassMethod.setAccessible(false);
+    }
   }
 
   private Utils() {}


### PR DESCRIPTION
This is important if they depend on each other. If the child loads first, the parent could get loaded on the wrong classloader before itself gets injected.

In practice, this problem was manifested in the OkHttp instrumentation, resulting in `java.lang.NoClassDefFoundError: okhttp3/Request`.