### PR TITLE
Use workflows in Circle to test Java 7 and 8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,34 +1,85 @@
 version: 2
+
+defaults: &defaults
+  working_directory: ~/dd-trace-java
+  resource_class: large
+  docker:
+    - image: circleci/openjdk:8
+
+test_job: &test_job
+  steps:
+    - attach_workspace:
+        at: .
+
+    - run:
+        name: Run Tests
+        command: GRADLE_OPTS="-Dorg.gradle.jvmargs=-Xmx2G -Xms512M" ./gradlew -g=gradle-home test --parallel --stacktrace --no-daemon --max-workers=3
+
+    - run:
+        name: Save Artifacts to (project-root)/build
+        when: always
+        command: .circleci/save_artifacts.sh
+
+    - store_test_results:
+        path: build/test-results
+
+    - store_artifacts:
+        path: build
+
+    - persist_to_workspace:
+        root: .
+        paths: .
+
 jobs:
   build:
-    working_directory: ~/dd-trace-java
+    <<: *defaults
     docker:
       - image: circleci/openjdk:8-jdk
-    resource_class: xlarge
 
     steps:
       - checkout
 
       - restore_cache:
           # Reset the cache approx every release
-          key: dd-trace-java-{{ checksum "dd-trace-java.gradle" }}
+          keys:
+            - dd-trace-java-{{ checksum "dd-trace-java.gradle" }}-{{ .Branch }}-{{ .Revision }}-verified
+            - dd-trace-java-{{ checksum "dd-trace-java.gradle" }}-{{ .Branch }}-{{ .Revision }}
+            - dd-trace-java-{{ checksum "dd-trace-java.gradle" }}-{{ .Branch }}
+            - dd-trace-java-{{ checksum "dd-trace-java.gradle" }}
+            - dd-trace-java
 
       - run:
           name: Build Project
-          command: GRADLE_OPTS="-Dorg.gradle.jvmargs=-Xmx2G -Xms512M" ./gradlew clean compileJava compileTestJava compileGroovy compileTestGroovy shadowJar --stacktrace --no-daemon
+          command: GRADLE_OPTS="-Dorg.gradle.jvmargs=-Xmx2G -Xms512M" ./gradlew -g=gradle-home clean check -x test --stacktrace --no-daemon
+
+      - save_cache:
+          key: dd-trace-java-{{ checksum "dd-trace-java.gradle" }}-{{ .Branch }}-{{ .Revision }}
+          paths: gradle-home
+          background: true
+
+      - persist_to_workspace:
+          root: .
+          paths: .
+
+  test_7:
+    <<: *defaults
+    docker:
+      - image: openjdk:7-jdk
+
+    steps:
+      - attach_workspace:
+          at: .
+
+      - run:
+          name: Fix EC parameters error # (ref https://github.com/travis-ci/travis-ci/issues/8503)
+          command: |
+            wget "https://downloads.bouncycastle.org/java/bcprov-ext-jdk15on-158.jar" -O "${JAVA_HOME}"/jre/lib/ext/bcprov-ext-jdk15on-158.jar && \
+            perl -pi.bak -e 's/^(security\.provider\.)([0-9]+)/$1.($2+1)/ge' /etc/java-7-openjdk/security/java.security && \
+            echo "security.provider.1=org.bouncycastle.jce.provider.BouncyCastleProvider" | tee -a /etc/java-7-openjdk/security/java.security
 
       - run:
           name: Run Tests
-          command: GRADLE_OPTS="-Dorg.gradle.jvmargs=-Xmx2G -Xms512M" ./gradlew check --parallel --stacktrace --no-daemon --max-workers=3
-
-      - run:
-          name: Verify Version Scan
-          command: ./gradlew verifyVersionScan --parallel --stacktrace --no-daemon
-
-      - save_cache:
-          paths:
-            - ~/.gradle
-          key: dd-trace-java-{{ checksum "dd-trace-java.gradle" }}
+          command: GRADLE_OPTS="-Dorg.gradle.jvmargs=-Xmx2G -Xms512M" ./gradlew -g=gradle-home test --parallel --stacktrace --no-daemon --max-workers=3
 
       - run:
           name: Save Artifacts to (project-root)/build
@@ -41,6 +92,49 @@ jobs:
       - store_artifacts:
           path: build
 
+  test_8:
+    <<: *defaults
+    <<: *test_job
+    docker:
+      - image: circleci/openjdk:8-jdk
+
+#  test_9:
+#    <<: *defaults
+#    <<: *test_job
+#    docker:
+#      - image: circleci/openjdk:9-jdk
+
+  scan_and_save:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: .
+
+      - run:
+          name: Verify Version Scan
+          command: ./gradlew -g=gradle-home verifyVersionScan --parallel --stacktrace --no-daemon
+
+      - run:
+          name: Save Artifacts to (project-root)/build
+          when: always
+          command: .circleci/save_artifacts.sh
+
+      - store_test_results:
+          path: build/test-results
+
+      - store_artifacts:
+          path: build
+
+      - save_cache:
+          key: dd-trace-java-{{ checksum "dd-trace-java.gradle" }}-{{ .Branch }}-{{ .Revision }}-verified
+          paths: gradle-home
+
+  deploy:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: .
+
       - run:
           name: Decode Signing Key
           command: echo $PGP_KEY_FILE | base64 --decode > /home/circleci/dd-trace-java/.circleci/secring.gpg
@@ -49,7 +143,7 @@ jobs:
           name: Publish master to Artifactory
           command: |
             if [ "${CIRCLE_BRANCH}" == "master" ]; then
-              ./gradlew -Psigning.keyId=${PGP_KEY_ID} \
+              ./gradlew -g=gradle-home -Psigning.keyId=${PGP_KEY_ID} \
                 -Psigning.password=${PGP_KEY_PASS} \
                 -Psigning.secretKeyRingFile=/home/circleci/dd-trace-java/.circleci/secring.gpg \
                 -PbintrayUser=${BINTRAY_USER} \
@@ -57,3 +151,33 @@ jobs:
                 -PbuildInfo.build.number=${CIRCLE_BUILD_NUM} \
                 artifactoryPublish --max-workers=1 --stacktrace --no-daemon
             fi
+
+workflows:
+  version: 2
+  build_test_deploy:
+    jobs:
+      - build
+
+      - test_7:
+          requires:
+            - build
+      - test_8:
+          requires:
+            - build
+#      - test_9:
+#          requires:
+#            - build
+
+      - scan_and_save:
+          requires:
+            - build
+            - test_7
+            - test_8
+#            - test_9
+
+      - deploy:
+          requires:
+            - scan_and_save
+          filters:
+            branches:
+              only: master

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -12,6 +12,6 @@ dependencies {
   compile group: 'org.eclipse.aether', name: 'aether-transport-http', version: '1.1.0'
   compile group: 'org.apache.maven', name: 'maven-aether-provider', version: '3.3.9'
 
-  compile group: 'com.google.guava', name: 'guava', version: '23.0'
+  compile group: 'com.google.guava', name: 'guava', version: '20.0'
   compile group: 'org.ow2.asm', name: 'asm-all', version: '5.2'
 }

--- a/dd-java-agent-ittests/dd-java-agent-ittests.gradle
+++ b/dd-java-agent-ittests/dd-java-agent-ittests.gradle
@@ -5,6 +5,17 @@ description = 'dd-java-agent-ittests'
 evaluationDependsOn(':dd-java-agent:tooling')
 compileTestJava.dependsOn tasks.getByPath(':dd-java-agent:tooling:testClasses')
 
+if (!JavaVersion.current().isJava8Compatible()) {
+  sourceSets {
+    test {
+      groovy {
+        // These classes use Ratpack which requires Java 8.
+        exclude '**/TestHttpServer.groovy', '**/ApacheHttpClientTest.groovy'
+      }
+    }
+  }
+}
+
 dependencies {
   testCompile project(':dd-trace-api')
   testCompile project(':dd-trace-ot')
@@ -20,10 +31,10 @@ dependencies {
   testCompile group: 'org.mongodb', name: 'mongo-java-driver', version: '3.4.2'
   testCompile group: 'org.mongodb', name: 'mongodb-driver-async', version: '3.4.2'
   // run embeded mongodb for integration testing
-  testCompile group: 'de.flapdoodle.embed', name: 'de.flapdoodle.embed.mongo', version: '2.0.0'
+  testCompile group: 'de.flapdoodle.embed', name: 'de.flapdoodle.embed.mongo', version: '1.50.5'
 
-  testCompile group: 'org.eclipse.jetty', name: 'jetty-server', version: '9.4.1.v20170120'
-  testCompile group: 'org.eclipse.jetty', name: 'jetty-servlet', version: '9.4.1.v20170120'
+  testCompile group: 'org.eclipse.jetty', name: 'jetty-server', version: '8.2.0.v20160908'
+  testCompile group: 'org.eclipse.jetty', name: 'jetty-servlet', version: '8.2.0.v20160908'
   testCompile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '8.0.41'
   testCompile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-jasper', version: '8.0.41'
   // note: aws transitively pulls in apache-httpclient, which we also test against:
@@ -39,8 +50,8 @@ dependencies {
 
   // JDBC tests:
   testCompile group: 'com.h2database', name: 'h2', version: '1.4.196'
-  testCompile group: 'org.hsqldb', name: 'hsqldb', version: '2.4.0'
-  testCompile group: 'org.apache.derby', name: 'derby', version: '10.14.1.0'
+  testCompile group: 'org.hsqldb', name: 'hsqldb', version: '2.3.+'
+  testCompile group: 'org.apache.derby', name: 'derby', version: '10.12.1.1'
 }
 
 test {

--- a/dd-java-agent/dd-java-agent.gradle
+++ b/dd-java-agent/dd-java-agent.gradle
@@ -86,7 +86,7 @@ shadowJar {
   }
 
   dependencies {
-    exclude(dependency('org.projectlombok:lombok:1.16.18'))
+    exclude(dependency('org.projectlombok:lombok:1.16.20'))
   }
 }
 

--- a/dd-java-agent/instrumentation/datastax-cassandra-3.2/datastax-cassandra-3.2.gradle
+++ b/dd-java-agent/instrumentation/datastax-cassandra-3.2/datastax-cassandra-3.2.gradle
@@ -31,6 +31,17 @@ versionScan {
 
 apply from: "${rootDir}/gradle/java.gradle"
 
+if (!JavaVersion.current().isJava8Compatible()) {
+  sourceSets {
+    test {
+      groovy {
+        // These classes use Cassandra 3 which requires Java 8.
+        exclude '**/CassandraClientTest.groovy'
+      }
+    }
+  }
+}
+
 dependencies {
   compileOnly group: 'com.datastax.cassandra', name: 'cassandra-driver-core', version: '3.2.0'
   compile('io.opentracing.contrib:opentracing-cassandra-driver:0.0.3-RC1') {

--- a/dd-java-agent/instrumentation/okhttp-3/okhttp-3.gradle
+++ b/dd-java-agent/instrumentation/okhttp-3/okhttp-3.gradle
@@ -14,6 +14,17 @@ versionScan {
 
 apply from: "${rootDir}/gradle/java.gradle"
 
+if (!JavaVersion.current().isJava8Compatible()) {
+  sourceSets {
+    test {
+      groovy {
+        // These classes use Ratpack which requires Java 8.
+        exclude '**/OkHttp3Test.groovy'
+      }
+    }
+  }
+}
+
 dependencies {
   compileOnly group: 'com.squareup.okhttp3', name: 'okhttp', version: '3.0.0'
   compile('io.opentracing.contrib:opentracing-okhttp3:0.1.0-RC1') {

--- a/dd-trace-ot/dd-trace-ot.gradle
+++ b/dd-trace-ot/dd-trace-ot.gradle
@@ -16,6 +16,17 @@ whitelistedInstructionClasses += whitelistedBranchClasses += [
   'datadog.trace.api.DDTags',
 ]
 
+if (!JavaVersion.current().isJava8Compatible()) {
+  sourceSets {
+    test {
+      groovy {
+        // These classes use Ratpack which requires Java 8.
+        exclude 'datadog/trace/api/writer/DDApiTest.groovy'
+      }
+    }
+  }
+}
+
 dependencies {
   compile project(':dd-trace-api')
   compile deps.opentracing

--- a/examples/dropwizard-mongo-client/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/dropwizard-mongo-client/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.3.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.3.1-bin.zip

--- a/examples/rest-spark/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/rest-spark/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.3.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.3.1-bin.zip

--- a/examples/spring-boot-jdbc/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/spring-boot-jdbc/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.3.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.3.1-bin.zip

--- a/gradle/checkstyle.gradle
+++ b/gradle/checkstyle.gradle
@@ -49,8 +49,15 @@ tasks.withType(Test) {
   mustRunAfter checkstyleTasks
 }
 
-apply plugin: 'com.github.sherter.google-java-format'
+if (!JavaVersion.current().isJava9Compatible()) {
+  // Verification seems broken on Java 9.
+  apply plugin: 'com.github.sherter.google-java-format'
 
-tasks.withType(Checkstyle) {
-  mustRunAfter verifyGoogleJavaFormat
+  googleJavaFormat {
+    exclude 'gradle-home'
+  }
+
+  tasks.withType(Checkstyle) {
+    mustRunAfter verifyGoogleJavaFormat
+  }
 }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -6,7 +6,7 @@ ext {
     opentracing: '0.31.0',
 
     slf4j      : "1.7.25",
-    guava      : "23.0",
+    guava      : "20.0",
     jackson    : "2.9.3",
 
     spock      : "1.0-groovy-$spockGroovyVer",

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -7,8 +7,8 @@ targetCompatibility = 1.7
 apply plugin: "io.franzbecker.gradle-lombok"
 
 lombok { // optional: values below are the defaults
-  version = "1.16.18"
-  sha256 = "9d957f572386b9e257093a45b148f9b411cff80d9efd55eaf6fca27002d2e4d9"
+  version = "1.16.20"
+  sha256 = "c5178b18caaa1a15e17b99ba5e4023d2de2ebc18b58cde0f5a04ca4b31c10e6d"
 }
 
 apply plugin: "eclipse"
@@ -36,7 +36,7 @@ repositories {
 
 dependencies {
   testCompile deps.junit
-  testCompile group: 'org.assertj', name: 'assertj-core', version: '3.6.2'
+  testCompile group: 'org.assertj', name: 'assertj-core', version: '2.9.+'
   testCompile group: 'org.mockito', name: 'mockito-core', version: '2.7.22'
 
   testCompile deps.spock

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.3.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.3.1-bin.zip

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,18 +2,10 @@ rootProject.name = 'dd-trace-java'
 
 include ':dd-trace-ot'
 include ':dd-java-agent'
-include ':dd-java-agent:benchmark'
-include ':dd-java-agent:benchmark-integration'
-include ':dd-java-agent:benchmark-integration:jetty-perftest'
 include ':dd-java-agent:testing'
 include ':dd-java-agent:tooling'
 include ':dd-java-agent-ittests'
 include ':dd-trace-api'
-
-// examples
-include ':examples:dropwizard-mongo-client'
-include ':examples:spring-boot-jdbc'
-include ':examples:rest-spark'
 
 // instrumentation:
 include ':dd-java-agent:instrumentation:apache-httpclient-4.3'
@@ -29,6 +21,19 @@ include ':dd-java-agent:instrumentation:servlet-2'
 include ':dd-java-agent:instrumentation:servlet-3'
 include ':dd-java-agent:instrumentation:spring-web'
 include ':dd-java-agent:instrumentation:trace-annotation'
+
+
+if (JavaVersion.current().isJava8Compatible()) {
+  // benchmark
+  include ':dd-java-agent:benchmark'
+  include ':dd-java-agent:benchmark-integration'
+  include ':dd-java-agent:benchmark-integration:jetty-perftest'
+
+  // examples
+  include ':examples:dropwizard-mongo-client'
+  include ':examples:spring-boot-jdbc'
+  include ':examples:rest-spark'
+}
 
 def setBuildFile(project) {
   project.buildFileName = "${project.name}.gradle"


### PR DESCRIPTION
Java 9 is commented out because there are some test failures that will be investigated later.

Some tests had to be excluded from Java 7 because they don’t have a Java 7 compatible version.