### PR TITLE
Patch getLogger calls to safe logger.

### DIFF
--- a/dd-java-agent-ittests/dd-java-agent-ittests.gradle
+++ b/dd-java-agent-ittests/dd-java-agent-ittests.gradle
@@ -11,6 +11,9 @@ if (JavaVersion.current() != JavaVersion.VERSION_1_8) {
       groovy {
         // These classes use Ratpack which requires Java 8. (Currently also incompatible with Java 9.)
         exclude '**/TestHttpServer.groovy', '**/ApacheHttpClientTest.groovy'
+
+        // log rewrite incompatible with Java9 test classpath
+        exclude '**/TestLoggerRewrite.groovy'
       }
     }
   }

--- a/dd-java-agent-ittests/src/test/groovy/datadog/trace/agent/integration/TestLoggerRewrite.groovy
+++ b/dd-java-agent-ittests/src/test/groovy/datadog/trace/agent/integration/TestLoggerRewrite.groovy
@@ -1,0 +1,20 @@
+package datadog.trace.agent.integration
+
+import io.opentracing.util.GlobalTracer
+import java.lang.reflect.Field
+import spock.lang.Specification
+
+class TestLoggerRewrite extends Specification {
+  def "java getLogger rewritten to safe logger"() {
+    setup:
+    Field logField = GlobalTracer.getDeclaredField("LOGGER")
+    logField.setAccessible(true)
+    Object logger = logField.get(null)
+
+    expect:
+    !logger.getClass().getName().startsWith("java.util.logging")
+
+    cleanup:
+    logField?.setAccessible(false)
+  }
+}

--- a/dd-java-agent/dd-java-agent.gradle
+++ b/dd-java-agent/dd-java-agent.gradle
@@ -83,6 +83,9 @@ shadowJar {
       // This is used in the Cassandra Cluster.connectAsync signature so we can't relocate it. :fingers_crossed:
       exclude 'com.google.common.util.concurrent.ListenableFuture'
     }
+
+    // rewrite dependencies calling Logger.getLogger
+    relocate 'java.util.logging.Logger', 'datadog.trace.agent.PatchLogger'
   }
 
   dependencies {

--- a/dd-java-agent/src/main/java/datadog/trace/agent/PatchLogger.java
+++ b/dd-java-agent/src/main/java/datadog/trace/agent/PatchLogger.java
@@ -1,0 +1,105 @@
+package datadog.trace.agent;
+
+import java.util.ResourceBundle;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+/**
+ * Dependencies of the agent somtimes call Logger.getLogger This can have the effect of initializing
+ * the global logger incompatibly with the user's app.
+ *
+ * <p>Shadow rewrites will redirect those calls to this class, which will return a safe logger.
+ */
+public class PatchLogger {
+  private static final PatchLogger SAFE_LOGGER = new PatchLogger("datadogSafeLogger", "bundle");
+
+  public static PatchLogger getLogger(String name) {
+    return SAFE_LOGGER;
+  }
+
+  public static PatchLogger getLogger(String name, String resourceBundleName) {
+    return SAFE_LOGGER;
+  }
+
+  public static PatchLogger getAnonymousLogger() {
+    return SAFE_LOGGER;
+  }
+
+  public static PatchLogger getAnonymousLogger(String resourceBundleName) {
+    return SAFE_LOGGER;
+  }
+
+  protected PatchLogger(String name, String resourceBundleName) {
+    // super(name, resourceBundleName);
+  }
+
+  // providing a bunch of empty log methods
+
+  public void log(LogRecord record) {}
+
+  public void log(Level level, String msg) {}
+
+  public void log(Level level, String msg, Object param1) {}
+
+  public void log(Level level, String msg, Object params[]) {}
+
+  public void log(Level level, String msg, Throwable thrown) {}
+
+  public void logp(Level level, String sourceClass, String sourceMethod, String msg) {}
+
+  public void logp(
+      Level level, String sourceClass, String sourceMethod, String msg, Object param1) {}
+
+  public void logp(
+      Level level, String sourceClass, String sourceMethod, String msg, Object params[]) {}
+
+  public void logp(
+      Level level, String sourceClass, String sourceMethod, String msg, Throwable thrown) {}
+
+  public void logrb(
+      Level level, String sourceClass, String sourceMethod, String bundleName, String msg) {}
+
+  public void logrb(
+      Level level,
+      String sourceClass,
+      String sourceMethod,
+      String bundleName,
+      String msg,
+      Object param1) {}
+
+  public void logrb(
+      Level level,
+      String sourceClass,
+      String sourceMethod,
+      String bundleName,
+      String msg,
+      Object params[]) {}
+
+  public void logrb(
+      Level level,
+      String sourceClass,
+      String sourceMethod,
+      ResourceBundle bundle,
+      String msg,
+      Object... params) {}
+
+  public void logrb(
+      Level level,
+      String sourceClass,
+      String sourceMethod,
+      String bundleName,
+      String msg,
+      Throwable thrown) {}
+
+  public void logrb(
+      Level level,
+      String sourceClass,
+      String sourceMethod,
+      ResourceBundle bundle,
+      String msg,
+      Throwable thrown) {}
+
+  public void throwing(String sourceClass, String sourceMethod, Throwable thrown) {}
+
+  public void setLevel(Level newLevel) throws SecurityException {}
+}


### PR DESCRIPTION
Agent dependencies which call `Logger.getLogger` may initialize the global logger incompatibly with the user's logger configuration.

https://github.com/opentracing/opentracing-java/blob/master/opentracing-util/src/main/java/io/opentracing/util/GlobalTracer.java#L52

This PR renames `java.util.logging.Logger` to the agent controlled `PatchLogger`, which no-ops for logging operations.