### PR TITLE
Fix dependency problem in dropwizard example

### DIFF
--- a/dd-trace-ot/dd-trace-ot.gradle
+++ b/dd-trace-ot/dd-trace-ot.gradle
@@ -36,7 +36,7 @@ dependencies {
   compile deps.jackson
   compile deps.slf4j
   compile deps.autoservice
-  compile group: 'org.msgpack', name: 'jackson-dataformat-msgpack', version: '0.8.13'
+  compile group: 'org.msgpack', name: 'jackson-dataformat-msgpack', version: '0.8.2'
 
   testCompile group: 'org.objenesis', name: 'objenesis', version: '2.6'
   testCompile group: 'cglib', name: 'cglib-nodep', version: '3.2.5'

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -7,7 +7,7 @@ ext {
 
     slf4j      : "1.7.25",
     guava      : "20.0",
-    jackson    : "2.9.3",
+    jackson    : "2.6.3",
 
     spock      : "1.0-groovy-$spockGroovyVer",
     groovy     : groovyVer,
@@ -27,27 +27,27 @@ ext {
     opentracingMock: dependencies.create(group: 'io.opentracing', name: 'opentracing-mock', version: version.opentracing),
 
     // General
-    slf4j      : "org.slf4j:slf4j-api:${version.slf4j}",
-    guava      : "com.google.guava:guava:$version.guava",
-    jackson    : [
+    slf4j          : "org.slf4j:slf4j-api:${version.slf4j}",
+    guava          : "com.google.guava:guava:$version.guava",
+    jackson        : [
       dependencies.create(group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: version.jackson),
       dependencies.create(group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: version.jackson),
     ],
-    bytebuddy  : dependencies.create(group: 'net.bytebuddy', name: 'byte-buddy', version: "${version.bytebuddy}"),
-    autoservice: [
+    bytebuddy      : dependencies.create(group: 'net.bytebuddy', name: 'byte-buddy', version: "${version.bytebuddy}"),
+    autoservice    : [
       dependencies.create(group: 'com.google.auto.service', name: 'auto-service', version: '1.0-rc3'),
       dependencies.create(group: 'com.google.auto', name: 'auto-common', version: '0.3'),
       dependencies.create(group: 'com.google.guava', name: 'guava', version: "${version.guava}"),
     ],
 
     // Testing
-    spock      : dependencies.create("org.spockframework:spock-core:${version.spock}", {
+    spock          : dependencies.create("org.spockframework:spock-core:${version.spock}", {
       exclude group: "org.codehaus.groovy", module: "groovy-all"
     }),
-    bytebuddyagent  : dependencies.create(group: 'net.bytebuddy', name: 'byte-buddy-agent', version: "${version.bytebuddy}"),
-    groovy     : "org.codehaus.groovy:groovy-all:${version.groovy}",
-    junit      : "junit:junit:${version.junit}",
-    testLogging: [
+    bytebuddyagent : dependencies.create(group: 'net.bytebuddy', name: 'byte-buddy-agent', version: "${version.bytebuddy}"),
+    groovy         : "org.codehaus.groovy:groovy-all:${version.groovy}",
+    junit          : "junit:junit:${version.junit}",
+    testLogging    : [
       dependencies.create(group: 'ch.qos.logback', name: 'logback-classic', version: version.logback),
       dependencies.create(group: 'org.slf4j', name: 'log4j-over-slf4j', version: version.slf4j),
       dependencies.create(group: 'org.slf4j', name: 'jcl-over-slf4j', version: version.slf4j),


### PR DESCRIPTION
There was an incompatible mix of jackson dependencies which caused the app to not start up.  Changed the tracer client to use an old version, but allow the agent to still use a newer version (since it is shadowed).