### PR TITLE
Add exception for version segments in URLs

### DIFF
--- a/dd-trace-ot/src/main/java/datadog/opentracing/decorators/URLAsResourceName.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/decorators/URLAsResourceName.java
@@ -11,9 +11,9 @@ public class URLAsResourceName extends AbstractDecorator {
 
   // Matches everything after the ? character.
   public static final Pattern QUERYSTRING = Pattern.compile("\\?.*$");
-  // Matches any path segments with numbers in them.
+  // Matches any path segments with numbers in them. (exception for versioning: "/v1/")
   public static final Pattern PATH_MIXED_ALPHANUMERICS =
-      Pattern.compile("/(?:[^\\/\\d\\?]*[\\d]+[^\\/\\?]*)");
+      Pattern.compile("(?<=/)(?![vV]\\d{1,2}/)(?:[^\\/\\d\\?]*[\\d]+[^\\/\\?]*)");
 
   public URLAsResourceName() {
     super();
@@ -60,7 +60,7 @@ public class URLAsResourceName extends AbstractDecorator {
 
     String norm = origin;
     norm = QUERYSTRING.matcher(norm).replaceAll("");
-    norm = PATH_MIXED_ALPHANUMERICS.matcher(norm).replaceAll("/?");
+    norm = PATH_MIXED_ALPHANUMERICS.matcher(norm).replaceAll("?");
 
     return norm;
   }

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/decorators/URLAsResourceNameTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/decorators/URLAsResourceNameTest.groovy
@@ -20,6 +20,8 @@ class URLAsResourceNameTest extends Specification {
 
     where:
     input                          | output
+    "/"                            | "/"
+    "/?asdf"                       | "/"
     "/search"                      | "/search"
     "/search?"                     | "/search"
     "/search?id=100&private=true"  | "/search"
@@ -52,10 +54,10 @@ class URLAsResourceNameTest extends Specification {
 
     where:
     input                                              | output
-    "/a1"                                              | "/?"
-    "/1a"                                              | "/?"
-    "/abc/-1?"                                         | "/abc/?"
-    "/ABC/a-1/b_2/c.3/d4d/5f/6"                        | "/ABC/?/?/?/?/?/?"
+    "/a1/v2"                                           | "/?/?"
+    "/v3/1a"                                           | "/v3/?"
+    "/V01/v9/abc/-1?"                                  | "/V01/v9/abc/?"
+    "/ABC/av-1/b_2/c.3/d4d/v5f/v699/7"                 | "/ABC/?/?/?/?/?/?/?"
     "/user/asdf123/repository/01234567-9ABC-DEF0-1234" | "/user/?/repository/?"
   }
 


### PR DESCRIPTION
This seems like a common enough segment and useful to not remove.