### PR TITLE
classloader validation

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
@@ -1,9 +1,7 @@
 package datadog.trace.agent.tooling;
 
-import static datadog.trace.agent.tooling.ClassLoaderMatcher.classLoaderWithName;
-import static datadog.trace.agent.tooling.ClassLoaderMatcher.isReflectionClassLoader;
+import static datadog.trace.agent.tooling.ClassLoaderMatcher.skipClassLoader;
 import static net.bytebuddy.matcher.ElementMatchers.any;
-import static net.bytebuddy.matcher.ElementMatchers.isBootstrapClassLoader;
 import static net.bytebuddy.matcher.ElementMatchers.nameContains;
 import static net.bytebuddy.matcher.ElementMatchers.nameMatches;
 import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;
@@ -27,12 +25,6 @@ public class AgentInstaller {
    * @return the agent's class transformer
    */
   public static ResettableClassFileTransformer installBytebuddyAgent(final Instrumentation inst) {
-    // Classloader notes:
-
-    // 1. Skip classloaders which don't delegate to bootstrap
-
-    // 2. Skip incompatible versions of OpenTracing
-
     AgentBuilder agentBuilder =
         new AgentBuilder.Default()
             .disableClassFormatChanges()
@@ -52,13 +44,7 @@ public class AgentInstaller {
             .or(nameContains("javassist"))
             .or(nameContains(".asm."))
             .or(nameMatches("com\\.mchange\\.v2\\.c3p0\\..*Proxy"))
-            .ignore(
-                any(),
-                isBootstrapClassLoader()
-                    .or(isReflectionClassLoader())
-                    .or(
-                        classLoaderWithName(
-                            "org.codehaus.groovy.runtime.callsite.CallSiteClassLoader")));
+            .ignore(any(), skipClassLoader());
     int numInstrumenters = 0;
     for (final Instrumenter instrumenter : ServiceLoader.load(Instrumenter.class)) {
       log.debug("Loading instrumentation {}", instrumenter);

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/test/ClassLoaderMatcherTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/test/ClassLoaderMatcherTest.groovy
@@ -1,0 +1,49 @@
+package datadog.trace.agent.test
+
+import datadog.trace.agent.bootstrap.DatadogClassLoader
+import datadog.trace.agent.tooling.ClassLoaderMatcher
+import spock.lang.Specification
+
+
+class ClassLoaderMatcherTest extends Specification {
+
+  def "skip non-delegating classloader"() {
+    setup:
+    final URLClassLoader badLoader = new NonDelegatingClassLoader()
+    expect:
+    ClassLoaderMatcher.skipClassLoader().matches(badLoader)
+  }
+
+  def "skips agent classloader"() {
+    setup:
+    URL root = new URL("file://")
+    final URLClassLoader agentLoader = new DatadogClassLoader(root, root, null)
+    expect:
+    ClassLoaderMatcher.skipClassLoader().matches(agentLoader)
+  }
+
+  def "does not skip empty classloader"() {
+    setup:
+    final ClassLoader emptyLoader = new ClassLoader(){}
+    expect:
+    !ClassLoaderMatcher.skipClassLoader().matches(emptyLoader)
+  }
+
+  /*
+   * A URLClassloader which only delegates java.* classes
+   */
+  private static class NonDelegatingClassLoader extends URLClassLoader {
+    NonDelegatingClassLoader() {
+      super(new URL[0], (ClassLoader)null)
+    }
+
+    @Override
+    Class<?> loadClass(String className) {
+      if (className.startsWith("java.")) {
+        return super.loadClass(className)
+      }
+      throw new ClassNotFoundException(className)
+    }
+  }
+
+}


### PR DESCRIPTION
* Skip instrumenting classes loaded by classloaders which do not delegate to the bootstrap

This ensures all our injected instructions can reach the core java agent.