### PR TITLE
Set timeouts on all the tests.

### DIFF
--- a/dd-java-agent-ittests/src/test/groovy/datadog/trace/agent/integration/classloading/ClassLoadingTest.groovy
+++ b/dd-java-agent-ittests/src/test/groovy/datadog/trace/agent/integration/classloading/ClassLoadingTest.groovy
@@ -1,13 +1,13 @@
 package datadog.trace.agent.integration.classloading
 
 import datadog.trace.agent.test.IntegrationTestUtils
+import datadog.trace.api.Trace
+import spock.lang.Specification
+import spock.lang.Timeout
 
 import static datadog.trace.agent.test.IntegrationTestUtils.createJarWithClasses
 
-import datadog.trace.api.Trace
-import spock.lang.Specification
-
-
+@Timeout(1)
 class ClassLoadingTest extends Specification {
 
   /** Assert that we can instrument classloaders which cannot resolve agent advice classes. */

--- a/dd-java-agent-ittests/src/test/groovy/datadog/trace/agent/integration/classloading/ShadowPackageRenamingTest.groovy
+++ b/dd-java-agent-ittests/src/test/groovy/datadog/trace/agent/integration/classloading/ShadowPackageRenamingTest.groovy
@@ -5,10 +5,11 @@ import com.google.common.reflect.ClassPath
 import datadog.trace.agent.test.IntegrationTestUtils
 import io.opentracing.util.GlobalTracer
 import spock.lang.Specification
+import spock.lang.Timeout
 
 import java.lang.reflect.Field
 
-
+@Timeout(1)
 class ShadowPackageRenamingTest extends Specification {
   def "agent dependencies renamed"() {
     setup:

--- a/dd-java-agent-ittests/src/test/groovy/datadog/trace/agent/integration/httpclient/ApacheHttpClientTest.groovy
+++ b/dd-java-agent-ittests/src/test/groovy/datadog/trace/agent/integration/httpclient/ApacheHttpClientTest.groovy
@@ -14,7 +14,9 @@ import org.apache.http.impl.client.HttpClientBuilder
 import org.apache.http.message.BasicHeader
 import spock.lang.Shared
 import spock.lang.Specification
+import spock.lang.Timeout
 
+@Timeout(5)
 class ApacheHttpClientTest extends Specification {
 
   @Shared

--- a/dd-java-agent-ittests/src/test/groovy/datadog/trace/agent/integration/jdbc/JDBCInstrumentationTest.groovy
+++ b/dd-java-agent-ittests/src/test/groovy/datadog/trace/agent/integration/jdbc/JDBCInstrumentationTest.groovy
@@ -8,6 +8,7 @@ import org.h2.Driver
 import org.hsqldb.jdbc.JDBCDriver
 import spock.lang.Shared
 import spock.lang.Specification
+import spock.lang.Timeout
 import spock.lang.Unroll
 
 import java.sql.Connection
@@ -15,6 +16,7 @@ import java.sql.PreparedStatement
 import java.sql.ResultSet
 import java.sql.Statement
 
+@Timeout(5)
 class JDBCInstrumentationTest extends Specification {
 
   final ListWriter writer = new ListWriter()

--- a/dd-java-agent/instrumentation/aws-sdk/src/test/groovy/AWSClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-sdk/src/test/groovy/AWSClientTest.groovy
@@ -11,11 +11,13 @@ import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.DDTags
 import io.opentracing.tag.Tags
 import ratpack.http.Headers
+import spock.lang.Timeout
 
 import java.util.concurrent.atomic.AtomicReference
 
 import static ratpack.groovy.test.embed.GroovyEmbeddedApp.ratpack
 
+@Timeout(5)
 class AWSClientTest extends AgentTestRunner {
 
   def "request handler is hooked up with builder"() {

--- a/dd-java-agent/instrumentation/datastax-cassandra-3.2/src/test/groovy/CassandraClientTest.groovy
+++ b/dd-java-agent/instrumentation/datastax-cassandra-3.2/src/test/groovy/CassandraClientTest.groovy
@@ -5,7 +5,9 @@ import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.DDTags
 import io.opentracing.tag.Tags
 import org.cassandraunit.utils.EmbeddedCassandraServerHelper
+import spock.lang.Timeout
 
+@Timeout(15)
 class CassandraClientTest extends AgentTestRunner {
 
   def setupSpec() {

--- a/dd-java-agent/instrumentation/jax-rs/src/test/groovy/JaxRsInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/jax-rs/src/test/groovy/JaxRsInstrumentationTest.groovy
@@ -1,10 +1,12 @@
 import datadog.opentracing.DDSpanContext
 import datadog.trace.agent.test.AgentTestRunner
 import io.opentracing.util.GlobalTracer
+import spock.lang.Timeout
 import spock.lang.Unroll
 
 import javax.ws.rs.*
 
+@Timeout(1)
 class JaxRsInstrumentationTest extends AgentTestRunner {
 
   static {

--- a/dd-java-agent/instrumentation/jax-rs/src/test/groovy/JerseyTest.groovy
+++ b/dd-java-agent/instrumentation/jax-rs/src/test/groovy/JerseyTest.groovy
@@ -2,7 +2,9 @@ import datadog.trace.agent.test.AgentTestRunner
 import io.dropwizard.testing.junit.ResourceTestRule
 import org.junit.ClassRule
 import spock.lang.Shared
+import spock.lang.Timeout
 
+@Timeout(1)
 class JerseyTest extends AgentTestRunner {
 
   static {

--- a/dd-java-agent/instrumentation/jboss-classloading/src/test/groovy/JBossClassloadingTest.groovy
+++ b/dd-java-agent/instrumentation/jboss-classloading/src/test/groovy/JBossClassloadingTest.groovy
@@ -1,5 +1,7 @@
 import datadog.trace.agent.test.AgentTestRunner
+import spock.lang.Timeout
 
+@Timeout(1)
 class JBossClassloadingTest extends AgentTestRunner {
   def "delegation property set on module load"() {
     setup:

--- a/dd-java-agent/instrumentation/jms-1/src/test/groovy/JMS1Test.groovy
+++ b/dd-java-agent/instrumentation/jms-1/src/test/groovy/JMS1Test.groovy
@@ -5,6 +5,7 @@ import org.apache.activemq.ActiveMQMessageConsumer
 import org.apache.activemq.ActiveMQMessageProducer
 import org.apache.activemq.junit.EmbeddedActiveMQBroker
 import spock.lang.Shared
+import spock.lang.Timeout
 import spock.lang.Unroll
 
 import javax.jms.Connection
@@ -13,6 +14,7 @@ import javax.jms.TextMessage
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.atomic.AtomicReference
 
+@Timeout(1)
 class JMS1Test extends AgentTestRunner {
   @Shared
   static Session session

--- a/dd-java-agent/instrumentation/jms-2/src/test/groovy/JMS2Test.groovy
+++ b/dd-java-agent/instrumentation/jms-2/src/test/groovy/JMS2Test.groovy
@@ -15,6 +15,7 @@ import org.hornetq.core.server.HornetQServers
 import org.hornetq.jms.client.HornetQMessageConsumer
 import org.hornetq.jms.client.HornetQMessageProducer
 import spock.lang.Shared
+import spock.lang.Timeout
 import spock.lang.Unroll
 
 import javax.jms.Session
@@ -22,6 +23,7 @@ import javax.jms.TextMessage
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.atomic.AtomicReference
 
+@Timeout(1)
 class JMS2Test extends AgentTestRunner {
   @Shared
   static Session session

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTest.groovy
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTest.groovy
@@ -11,10 +11,12 @@ import org.springframework.kafka.test.rule.KafkaEmbedded
 import org.springframework.kafka.test.utils.ContainerTestUtils
 import org.springframework.kafka.test.utils.KafkaTestUtils
 import spock.lang.Shared
+import spock.lang.Timeout
 
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
 
+@Timeout(5)
 class KafkaClientTest extends AgentTestRunner {
   static final SHARED_TOPIC = "shared.topic"
 

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/src/test/groovy/KafkaStreamsTest.groovy
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/src/test/groovy/KafkaStreamsTest.groovy
@@ -20,10 +20,12 @@ import org.springframework.kafka.test.rule.KafkaEmbedded
 import org.springframework.kafka.test.utils.ContainerTestUtils
 import org.springframework.kafka.test.utils.KafkaTestUtils
 import spock.lang.Shared
+import spock.lang.Timeout
 
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
 
+@Timeout(5)
 class KafkaStreamsTest extends AgentTestRunner {
   static final STREAM_PENDING = "test.pending"
   static final STREAM_PROCESSED = "test.processed"

--- a/dd-java-agent/instrumentation/okhttp-3/src/test/groovy/OkHttp3Test.groovy
+++ b/dd-java-agent/instrumentation/okhttp-3/src/test/groovy/OkHttp3Test.groovy
@@ -1,14 +1,16 @@
-import datadog.trace.api.DDTags
 import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.api.DDTags
 import io.opentracing.tag.Tags
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import ratpack.http.Headers
+import spock.lang.Timeout
 
 import java.util.concurrent.atomic.AtomicReference
 
 import static ratpack.groovy.test.embed.GroovyEmbeddedApp.ratpack
 
+@Timeout(10)
 class OkHttp3Test extends AgentTestRunner {
 
   def "sending a request creates spans and sends headers"() {

--- a/dd-java-agent/instrumentation/osgi-classloading/src/test/groovy/OSGIClassloadingTest.groovy
+++ b/dd-java-agent/instrumentation/osgi-classloading/src/test/groovy/OSGIClassloadingTest.groovy
@@ -1,5 +1,7 @@
 import datadog.trace.agent.test.AgentTestRunner
+import spock.lang.Timeout
 
+@Timeout(1)
 class OSGIClassloadingTest extends AgentTestRunner {
   def "delegation property set on module load"() {
     setup:

--- a/dd-java-agent/instrumentation/servlet-2/src/test/groovy/JettyServletTest.groovy
+++ b/dd-java-agent/instrumentation/servlet-2/src/test/groovy/JettyServletTest.groovy
@@ -10,12 +10,14 @@ import okhttp3.Request
 import okhttp3.Response
 import org.eclipse.jetty.server.Server
 import org.eclipse.jetty.servlet.ServletContextHandler
+import spock.lang.Timeout
 import spock.lang.Unroll
 
 import java.lang.reflect.Field
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
+@Timeout(1)
 class JettyServletTest extends AgentTestRunner {
 
   static final int PORT = randomOpenPort()

--- a/dd-java-agent/instrumentation/servlet-3/src/test/groovy/JettyServletTest.groovy
+++ b/dd-java-agent/instrumentation/servlet-3/src/test/groovy/JettyServletTest.groovy
@@ -10,12 +10,14 @@ import okhttp3.Request
 import okhttp3.Response
 import org.eclipse.jetty.server.Server
 import org.eclipse.jetty.servlet.ServletContextHandler
+import spock.lang.Timeout
 import spock.lang.Unroll
 
 import java.lang.reflect.Field
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
+@Timeout(5)
 class JettyServletTest extends AgentTestRunner {
 
   static final int PORT = randomOpenPort()

--- a/dd-java-agent/instrumentation/servlet-3/src/test/groovy/TomcatServletTest.groovy
+++ b/dd-java-agent/instrumentation/servlet-3/src/test/groovy/TomcatServletTest.groovy
@@ -10,10 +10,12 @@ import org.apache.catalina.Context
 import org.apache.catalina.startup.Tomcat
 import org.apache.tomcat.JarScanFilter
 import org.apache.tomcat.JarScanType
+import spock.lang.Timeout
 import spock.lang.Unroll
 
 import java.lang.reflect.Field
 
+@Timeout(5)
 class TomcatServletTest extends AgentTestRunner {
 
   static final int PORT = randomOpenPort()

--- a/dd-java-agent/instrumentation/spring-web/src/test/groovy/test/SpringBootBasedTest.groovy
+++ b/dd-java-agent/instrumentation/spring-web/src/test/groovy/test/SpringBootBasedTest.groovy
@@ -9,7 +9,9 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment
 import org.springframework.boot.test.web.client.TestRestTemplate
 import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.util.NestedServletException
+import spock.lang.Timeout
 
+@Timeout(5)
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 class SpringBootBasedTest extends AgentTestRunner {
 

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/DDSpanSerializationTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/DDSpanSerializationTest.groovy
@@ -5,8 +5,10 @@ import com.google.common.collect.Maps
 import datadog.trace.api.DDTags
 import datadog.trace.common.sampling.PrioritySampling
 import spock.lang.Specification
+import spock.lang.Timeout
 import spock.lang.Unroll
 
+@Timeout(2)
 class DDSpanSerializationTest extends Specification {
 
   @Unroll

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/DDSpanTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/DDSpanTest.groovy
@@ -2,7 +2,9 @@ package datadog.opentracing
 
 import datadog.trace.common.sampling.PrioritySampling
 import spock.lang.Specification
+import spock.lang.Timeout
 
+@Timeout(1)
 class DDSpanTest extends Specification {
 
   def "getters and setters"() {

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/decorators/SpanDecoratorTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/decorators/SpanDecoratorTest.groovy
@@ -7,7 +7,9 @@ import datadog.trace.common.writer.LoggingWriter
 import io.opentracing.tag.StringTag
 import io.opentracing.tag.Tags
 import spock.lang.Specification
+import spock.lang.Timeout
 
+@Timeout(1)
 class SpanDecoratorTest extends Specification {
 
   def "adding span personalisation using Decorators"() {

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/decorators/URLAsResourceNameTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/decorators/URLAsResourceNameTest.groovy
@@ -5,7 +5,9 @@ import datadog.trace.common.sampling.PrioritySampling
 import io.opentracing.tag.Tags
 import spock.lang.Specification
 import spock.lang.Subject
+import spock.lang.Timeout
 
+@Timeout(1)
 class URLAsResourceNameTest extends Specification {
 
   @Subject

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/propagation/HTTPCodecTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/propagation/HTTPCodecTest.groovy
@@ -6,8 +6,10 @@ import io.opentracing.propagation.TextMapExtractAdapter
 import io.opentracing.propagation.TextMapInjectAdapter
 import spock.lang.Shared
 import spock.lang.Specification
+import spock.lang.Timeout
 import spock.lang.Unroll
 
+@Timeout(1)
 class HTTPCodecTest extends Specification {
   @Shared
   private static final String OT_BAGGAGE_PREFIX = "ot-baggage-"

--- a/dd-trace-ot/src/test/groovy/datadog/trace/DDSpanContextTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/trace/DDSpanContextTest.groovy
@@ -2,7 +2,9 @@ package datadog.trace
 
 import datadog.trace.api.DDTags
 import spock.lang.Specification
+import spock.lang.Timeout
 
+@Timeout(1)
 class DDSpanContextTest extends Specification {
 
   def "null values for tags delete existing tags"() {

--- a/dd-trace-ot/src/test/groovy/datadog/trace/DDTraceConfigTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/trace/DDTraceConfigTest.groovy
@@ -10,10 +10,12 @@ import org.junit.Rule
 import org.junit.contrib.java.lang.system.EnvironmentVariables
 import org.junit.contrib.java.lang.system.RestoreSystemProperties
 import spock.lang.Specification
+import spock.lang.Timeout
 import spock.lang.Unroll
 
 import static datadog.trace.common.DDTraceConfig.*
 
+@Timeout(1)
 class DDTraceConfigTest extends Specification {
   @Rule
   public final RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties()

--- a/dd-trace-ot/src/test/groovy/datadog/trace/ServiceTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/trace/ServiceTest.groovy
@@ -5,10 +5,12 @@ import datadog.trace.common.Service
 import datadog.trace.common.sampling.AllSampler
 import datadog.trace.common.writer.DDAgentWriter
 import spock.lang.Specification
+import spock.lang.Timeout
 
 import static org.mockito.ArgumentMatchers.any
 import static org.mockito.Mockito.*
 
+@Timeout(1)
 class ServiceTest extends Specification {
 
 

--- a/dd-trace-ot/src/test/groovy/datadog/trace/api/sampling/RateByServiceSamplerTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/trace/api/sampling/RateByServiceSamplerTest.groovy
@@ -7,7 +7,9 @@ import datadog.opentracing.DDTracer
 import datadog.trace.common.sampling.PrioritySampling
 import datadog.trace.common.sampling.RateByServiceSampler
 import spock.lang.Specification
+import spock.lang.Timeout
 
+@Timeout(1)
 class RateByServiceSamplerTest extends Specification {
 
   def "rate by service name"() {

--- a/dd-trace-ot/src/test/groovy/datadog/trace/api/writer/DDAgentWriterTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/trace/api/writer/DDAgentWriterTest.groovy
@@ -5,11 +5,13 @@ import datadog.trace.common.writer.DDAgentWriter
 import datadog.trace.common.writer.DDApi
 import datadog.trace.common.writer.WriterQueue
 import spock.lang.Specification
+import spock.lang.Timeout
 
 import static datadog.trace.SpanFactory.newSpanOf
 import static org.mockito.Mockito.mock
 import static org.mockito.Mockito.verifyNoMoreInteractions
 
+@Timeout(5)
 class DDAgentWriterTest extends Specification {
 
 
@@ -39,8 +41,6 @@ class DDAgentWriterTest extends Specification {
     trace = [newSpanOf(0)]
     flush_time_wait = (int) (1.2 * (DDAgentWriter.FLUSH_TIME_SECONDS * 1_000))
     tick << [1, 3]
-
-
   }
 
   def "check if trace has been added by force"() {
@@ -88,9 +88,5 @@ class DDAgentWriterTest extends Specification {
 
     where:
     flush_time_wait = (int) (1.2 * (DDAgentWriter.FLUSH_TIME_SECONDS * 1_000))
-
-
   }
-
-
 }

--- a/dd-trace-ot/src/test/groovy/datadog/trace/api/writer/DDApiTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/trace/api/writer/DDApiTest.groovy
@@ -12,15 +12,19 @@ import ratpack.exec.Blocking
 import ratpack.http.Headers
 import ratpack.http.MediaType
 import spock.lang.Specification
+import spock.lang.Timeout
 import spock.lang.Unroll
 
 import java.util.concurrent.atomic.AtomicReference
 
 import static ratpack.groovy.test.embed.GroovyEmbeddedApp.ratpack
 
+@Timeout(1)
 class DDApiTest extends Specification {
   static mapper = new ObjectMapper(new MessagePackFactory())
 
+  @Timeout(5)
+  // first test takes longer
   def "sending an empty list of traces returns no errors"() {
     setup:
     def agent = ratpack {
@@ -36,6 +40,8 @@ class DDApiTest extends Specification {
     def client = new DDApi("localhost", agent.address.port)
 
     expect:
+    client.tracesEndpoint == "http://localhost:${agent.address.port}/v0.4/traces"
+    client.servicesEndpoint == "http://localhost:${agent.address.port}/v0.4/services"
     client.sendTraces([])
 
     cleanup:
@@ -57,6 +63,8 @@ class DDApiTest extends Specification {
     def client = new DDApi("localhost", agent.address.port)
 
     expect:
+    client.tracesEndpoint == "http://localhost:${agent.address.port}/v0.3/traces"
+    client.servicesEndpoint == "http://localhost:${agent.address.port}/v0.3/services"
     !client.sendTraces([])
 
     cleanup:
@@ -86,6 +94,8 @@ class DDApiTest extends Specification {
     def client = new DDApi("localhost", agent.address.port)
 
     expect:
+    client.tracesEndpoint == "http://localhost:${agent.address.port}/v0.4/traces"
+    client.servicesEndpoint == "http://localhost:${agent.address.port}/v0.4/services"
     client.sendTraces(traces)
     requestContentType.get().type == "application/msgpack"
     requestHeaders.get().get("Datadog-Meta-Lang") == "java"
@@ -144,6 +154,8 @@ class DDApiTest extends Specification {
     def client = new DDApi("localhost", agent.address.port)
 
     expect:
+    client.tracesEndpoint == "http://localhost:${agent.address.port}/v0.4/traces"
+    client.servicesEndpoint == "http://localhost:${agent.address.port}/v0.4/services"
     client.sendServices()
 
     cleanup:
@@ -165,6 +177,8 @@ class DDApiTest extends Specification {
     def client = new DDApi("localhost", agent.address.port)
 
     expect:
+    client.tracesEndpoint == "http://localhost:${agent.address.port}/v0.3/traces"
+    client.servicesEndpoint == "http://localhost:${agent.address.port}/v0.3/services"
     !client.sendServices([:])
 
     cleanup:
@@ -194,6 +208,8 @@ class DDApiTest extends Specification {
     def client = new DDApi("localhost", agent.address.port)
 
     expect:
+    client.tracesEndpoint == "http://localhost:${agent.address.port}/v0.4/traces"
+    client.servicesEndpoint == "http://localhost:${agent.address.port}/v0.4/services"
     client.sendServices(services)
     requestContentType.get().type == "application/msgpack"
     requestHeaders.get().get("Datadog-Meta-Lang") == "java"
@@ -274,6 +290,8 @@ class DDApiTest extends Specification {
     def client = new DDApi("localhost", v3Agent.address.port)
 
     expect:
+    client.tracesEndpoint == "http://localhost:${v3Agent.address.port}/v0.3/traces"
+    client.servicesEndpoint == "http://localhost:${v3Agent.address.port}/v0.3/services"
     client.sendTraces([])
     client.sendServices()
 
@@ -281,6 +299,7 @@ class DDApiTest extends Specification {
     v3Agent.close()
   }
 
+  @Timeout(5)
   @Unroll
   def "Api Downgrades to v3 if timeout exceeded (#delayTrace, #delayServices, #badPort)"() {
     // This test is unfortunately only exercising the read timeout, not the connect timeout.
@@ -323,8 +342,8 @@ class DDApiTest extends Specification {
     "v0.3"          | 0          | 0             | true
     "v0.4"          | 500        | 0             | false
     "v0.4"          | 0          | 500           | false
-    "v0.3"          | 3000       | 0             | false
-    "v0.3"          | 0          | 3000          | false
+    "v0.3"          | 30000      | 0             | false
+    "v0.3"          | 0          | 30000         | false
   }
 
   static List<TreeMap<String, Object>> convertList(byte[] bytes) {

--- a/dd-trace-ot/src/test/groovy/datadog/trace/api/writer/WriterQueueTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/trace/api/writer/WriterQueueTest.groovy
@@ -2,10 +2,12 @@ package datadog.trace.api.writer
 
 import datadog.trace.common.writer.WriterQueue
 import spock.lang.Specification
+import spock.lang.Timeout
 
 import java.util.concurrent.Phaser
 import java.util.concurrent.atomic.AtomicInteger
 
+@Timeout(1)
 class WriterQueueTest extends Specification {
 
   def "instantiate a empty queue throws an exception"() {


### PR DESCRIPTION
This might cause some occasional failures depending on the performance of where the tests are running.  They can be increased as needed.