### PR TITLE
Remove unneeded dependencies on dd-trace-ot.

### DIFF
--- a/dd-java-agent/agent-tooling/agent-tooling.gradle
+++ b/dd-java-agent/agent-tooling/agent-tooling.gradle
@@ -2,9 +2,11 @@ apply from: "${rootDir}/gradle/java.gradle"
 
 dependencies {
   compile project(':dd-java-agent:agent-bootstrap')
-  compile project(':dd-trace-ot')
   compile deps.bytebuddy
   compile deps.bytebuddyagent
+  compile deps.autoservice
+
+  compileOnly project(':dd-trace-ot')
 
   testCompile deps.opentracing
 }

--- a/dd-java-agent/instrumentation/apache-httpclient-4.3/apache-httpclient-4.3.gradle
+++ b/dd-java-agent/instrumentation/apache-httpclient-4.3/apache-httpclient-4.3.gradle
@@ -27,7 +27,6 @@ apply from: "${rootDir}/gradle/java.gradle"
 dependencies {
   compileOnly group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.3'
 
-  compile project(':dd-trace-ot')
   compile project(':dd-java-agent:agent-tooling')
 
   compile deps.bytebuddy

--- a/dd-java-agent/instrumentation/aws-sdk/aws-sdk.gradle
+++ b/dd-java-agent/instrumentation/aws-sdk/aws-sdk.gradle
@@ -29,7 +29,6 @@ if (JavaVersion.current() != JavaVersion.VERSION_1_8) {
 dependencies {
   compileOnly group: 'com.amazonaws', name: 'aws-java-sdk-core', version: '1.11.119'
 
-  compile project(':dd-trace-ot')
   compile project(':dd-java-agent:agent-tooling')
 
   compile deps.bytebuddy

--- a/dd-java-agent/instrumentation/datastax-cassandra-3.2/datastax-cassandra-3.2.gradle
+++ b/dd-java-agent/instrumentation/datastax-cassandra-3.2/datastax-cassandra-3.2.gradle
@@ -48,7 +48,6 @@ dependencies {
     transitive = false
   }
 
-  compile project(':dd-trace-ot')
   compile project(':dd-java-agent:agent-tooling')
 
   compile deps.bytebuddy

--- a/dd-java-agent/instrumentation/jax-rs/jax-rs.gradle
+++ b/dd-java-agent/instrumentation/jax-rs/jax-rs.gradle
@@ -15,7 +15,6 @@ dependencies {
   compile deps.opentracing
   compile deps.autoservice
 
-  compile project(':dd-trace-ot')
   compile project(':dd-java-agent:agent-tooling')
 
   testCompile project(':dd-java-agent:testing')

--- a/dd-java-agent/instrumentation/jdbc/jdbc.gradle
+++ b/dd-java-agent/instrumentation/jdbc/jdbc.gradle
@@ -1,7 +1,6 @@
 apply from: "${rootDir}/gradle/java.gradle"
 
 dependencies {
-  compile project(':dd-trace-ot')
   compile project(':dd-java-agent:agent-tooling')
 
   compile deps.bytebuddy

--- a/dd-java-agent/instrumentation/jms-1/jms-1.gradle
+++ b/dd-java-agent/instrumentation/jms-1/jms-1.gradle
@@ -20,7 +20,6 @@ dependencies {
   compile deps.opentracing
   compile deps.autoservice
 
-  compile project(':dd-trace-ot')
   compile project(':dd-java-agent:agent-tooling')
 
   testCompile project(':dd-java-agent:testing')

--- a/dd-java-agent/instrumentation/jms-2/jms-2.gradle
+++ b/dd-java-agent/instrumentation/jms-2/jms-2.gradle
@@ -24,7 +24,6 @@ dependencies {
   compile deps.opentracing
   compile deps.autoservice
 
-  compile project(':dd-trace-ot')
   compile project(':dd-java-agent:agent-tooling')
 
   testCompile project(':dd-java-agent:testing')

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/kafka-clients-0.11.gradle
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/kafka-clients-0.11.gradle
@@ -15,7 +15,6 @@ apply from: "${rootDir}/gradle/java.gradle"
 dependencies {
   compileOnly group: 'org.apache.kafka', name: 'kafka-clients', version: '0.11.0.0'
 
-  compile project(':dd-trace-ot')
   compile project(':dd-java-agent:agent-tooling')
 
   compile deps.bytebuddy

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/kafka-streams-0.11.gradle
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/kafka-streams-0.11.gradle
@@ -15,7 +15,6 @@ apply from: "${rootDir}/gradle/java.gradle"
 dependencies {
   compileOnly group: 'org.apache.kafka', name: 'kafka-streams', version: '0.11.0.0'
 
-  compile project(':dd-trace-ot')
   compile project(':dd-java-agent:agent-tooling')
 
   compile deps.bytebuddy

--- a/dd-java-agent/instrumentation/mongo-3.1/mongo-3.1.gradle
+++ b/dd-java-agent/instrumentation/mongo-3.1/mongo-3.1.gradle
@@ -15,11 +15,11 @@ apply from: "${rootDir}/gradle/java.gradle"
 dependencies {
   compileOnly group: 'org.mongodb', name: 'mongo-java-driver', version: '3.4.2'
 
-  compile project(':dd-trace-ot')
   compile project(':dd-java-agent:agent-tooling')
 
   compile deps.bytebuddy
   compile deps.opentracing
 
+  testCompile project(':dd-trace-ot')
   testCompile group: 'org.mongodb', name: 'mongo-java-driver', version: '3.4.2'
 }

--- a/dd-java-agent/instrumentation/mongo-async-3.3/mongo-async-3.3.gradle
+++ b/dd-java-agent/instrumentation/mongo-async-3.3/mongo-async-3.3.gradle
@@ -19,7 +19,6 @@ dependencies {
   }
   compileOnly group: 'org.mongodb', name: 'mongodb-driver-async', version: '3.4.2'
 
-  compile project(':dd-trace-ot')
   compile project(':dd-java-agent:agent-tooling')
 
   compile deps.bytebuddy

--- a/dd-java-agent/instrumentation/okhttp-3/okhttp-3.gradle
+++ b/dd-java-agent/instrumentation/okhttp-3/okhttp-3.gradle
@@ -31,7 +31,6 @@ dependencies {
     transitive = false
   }
 
-  compile project(':dd-trace-ot')
   compile project(':dd-java-agent:agent-tooling')
 
   compile deps.bytebuddy

--- a/dd-java-agent/instrumentation/servlet-2/servlet-2.gradle
+++ b/dd-java-agent/instrumentation/servlet-2/servlet-2.gradle
@@ -18,7 +18,6 @@ dependencies {
     transitive = false
   }
 
-  compile project(':dd-trace-ot')
   compile project(':dd-java-agent:agent-tooling')
 
   compile deps.bytebuddy

--- a/dd-java-agent/instrumentation/spring-web/spring-web.gradle
+++ b/dd-java-agent/instrumentation/spring-web/spring-web.gradle
@@ -19,7 +19,6 @@ dependencies {
 //  compileOnly group: 'org.springframework', name: 'spring-webmvc', version: '2.5.6'
 //  compileOnly group: 'javax.servlet', name: 'servlet-api', version: '2.4'
 
-  compile project(':dd-trace-ot')
   compile project(':dd-java-agent:agent-tooling')
 
   compile deps.bytebuddy

--- a/dd-java-agent/instrumentation/trace-annotation/trace-annotation.gradle
+++ b/dd-java-agent/instrumentation/trace-annotation/trace-annotation.gradle
@@ -1,7 +1,6 @@
 apply from: "${rootDir}/gradle/java.gradle"
 
 dependencies {
-  compile project(':dd-trace-ot')
   compile project(':dd-trace-api')
   compile project(':dd-java-agent:agent-tooling')
 


### PR DESCRIPTION
Most instrumentation currently only needs an opentracing dependency.