### PR TITLE
Use nanotime for additional clock resolution

### DIFF
--- a/dd-java-agent/instrumentation/jboss-classloading/src/test/groovy/JBossClassloadingTest.groovy
+++ b/dd-java-agent/instrumentation/jboss-classloading/src/test/groovy/JBossClassloadingTest.groovy
@@ -1,7 +1,7 @@
 import datadog.trace.agent.test.AgentTestRunner
 import spock.lang.Timeout
 
-@Timeout(1)
+@Timeout(5)
 class JBossClassloadingTest extends AgentTestRunner {
   def "delegation property set on module load"() {
     setup:

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/DDSpanTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/DDSpanTest.groovy
@@ -1,29 +1,34 @@
 package datadog.opentracing
 
 import datadog.trace.common.sampling.PrioritySampling
+import datadog.trace.common.writer.ListWriter
 import spock.lang.Specification
 import spock.lang.Timeout
 
+import java.util.concurrent.TimeUnit
+
 @Timeout(1)
 class DDSpanTest extends Specification {
+  def writer = new ListWriter()
+  def tracer = new DDTracer(writer)
 
   def "getters and setters"() {
     setup:
     final DDSpanContext context =
-        new DDSpanContext(
-            1L,
-            1L,
-            0L,
-            "fakeService",
-            "fakeOperation",
-            "fakeResource",
-            PrioritySampling.UNSET,
-            Collections.<String, String>emptyMap(),
-            false,
-            "fakeType",
-            null,
-            null,
-            null)
+      new DDSpanContext(
+        1L,
+        1L,
+        0L,
+        "fakeService",
+        "fakeOperation",
+        "fakeResource",
+        PrioritySampling.UNSET,
+        Collections.<String, String> emptyMap(),
+        false,
+        "fakeType",
+        null,
+        null,
+        null)
 
     final DDSpan span = new DDSpan(1L, context)
 
@@ -70,7 +75,7 @@ class DDSpanTest extends Specification {
     DDSpan span
 
     when:
-    span = new DDTracer().buildSpan(opName).startManual()
+    span = tracer.buildSpan(opName).start()
     then:
     span.getResourceName() == opName
     span.getServiceName() == DDTracer.UNASSIGNED_DEFAULT_SERVICE_NAME
@@ -79,12 +84,73 @@ class DDSpanTest extends Specification {
     final String resourceName = "fake"
     final String serviceName = "myService"
     span = new DDTracer()
-            .buildSpan(opName)
-            .withResourceName(resourceName)
-            .withServiceName(serviceName)
-            .startManual()
+      .buildSpan(opName)
+      .withResourceName(resourceName)
+      .withServiceName(serviceName)
+      .start()
     then:
     span.getResourceName() == resourceName
     span.getServiceName() == serviceName
+  }
+
+  def "duration measured in nanoseconds"() {
+    setup:
+    def mod = TimeUnit.MILLISECONDS.toNanos(1)
+    def builder = tracer.buildSpan("test")
+    def start = System.nanoTime()
+    def span = builder.start()
+    def between = System.nanoTime()
+    def betweenDur = System.nanoTime() - between
+    span.finish()
+    def total = System.nanoTime() - start
+
+    expect:
+    span.durationNano > betweenDur
+    span.durationNano < total
+    span.durationNano % mod > 0 // Very slim chance of a false negative.
+  }
+
+  def "starting with a timestamp disables nanotime"() {
+    setup:
+    def mod = TimeUnit.MILLISECONDS.toNanos(1)
+    def start = System.currentTimeMillis()
+    def builder = tracer.buildSpan("test")
+      .withStartTimestamp(TimeUnit.MILLISECONDS.toMicros(System.currentTimeMillis()))
+    def span = builder.start()
+    def between = System.currentTimeMillis()
+    def betweenDur = System.currentTimeMillis() - between
+    span.finish()
+    def total = System.currentTimeMillis() - start
+
+    expect:
+    span.durationNano >= TimeUnit.MILLISECONDS.toNanos(betweenDur)
+    span.durationNano <= TimeUnit.MILLISECONDS.toNanos(total)
+    span.durationNano % mod == 0
+  }
+
+  def "stopping with a timestamp disables nanotime"() {
+    setup:
+    def mod = TimeUnit.MILLISECONDS.toNanos(1)
+    def builder = tracer.buildSpan("test")
+    def start = System.currentTimeMillis()
+    def span = builder.start()
+    def between = System.currentTimeMillis()
+    def betweenDur = System.currentTimeMillis() - between
+    span.finish(TimeUnit.MILLISECONDS.toMicros(System.currentTimeMillis() + 1))
+    def total = System.currentTimeMillis() - start + 1
+
+    expect:
+    span.durationNano >= TimeUnit.MILLISECONDS.toNanos(betweenDur)
+    span.durationNano <= TimeUnit.MILLISECONDS.toNanos(total)
+    span.durationNano % mod == 0
+  }
+
+  def "stopping with a timestamp after start time yeilds a min duration of 1"() {
+    setup:
+    def span = tracer.buildSpan("test").start()
+    span.finish(span.startTimeMicro - 10)
+
+    expect:
+    span.durationNano == 1
   }
 }

--- a/dd-trace-ot/src/test/groovy/datadog/trace/api/writer/DDApiTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/trace/api/writer/DDApiTest.groovy
@@ -23,7 +23,7 @@ import static ratpack.groovy.test.embed.GroovyEmbeddedApp.ratpack
 class DDApiTest extends Specification {
   static mapper = new ObjectMapper(new MessagePackFactory())
 
-  @Timeout(5)
+  @Timeout(10)
   // first test takes longer
   def "sending an empty list of traces returns no errors"() {
     setup:


### PR DESCRIPTION
If a start or stop timestamp on a span is provided, the nanotime is ignored.