### PR TITLE
CI: publish branches prefixed with 'patch_release'

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,9 +137,7 @@ jobs:
               -PbuildInfo.build.number=${CIRCLE_BUILD_NUM} \
               artifactoryPublish --max-workers=1 --stacktrace --no-daemon
 
-  publish_master:
-    <<: *publish
-  publish_tag:
+  publish_branch:
     <<: *publish
 
 workflows:
@@ -177,24 +175,15 @@ workflows:
             branches:
               ignore: master
 
-      - publish_master:
+      - publish_branch:
           requires:
             - test_7
             - test_8
             - test_9
           filters:
             branches:
-              only: master
+              only:
+              - master
+              - /patch_release.*/
             tags:
               ignore: /.*/
-
-      - publish_tag:
-          requires:
-            - test_7
-            - test_8
-            - test_9
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v.*/

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -63,7 +63,6 @@ if (!isRoot) {
 }
 
 def isSnapshot = version.endsWith("-SNAPSHOT")
-def isCIandTagged = System.getenv("CIRCLE_TAG") != null
 // define in ~/.gradle/gradle.properties to override for testing
 def forceLocal = project.hasProperty('forceLocal') && forceLocal
 
@@ -152,6 +151,6 @@ bintray {
   }
 }
 
-if (!isSnapshot && isCIandTagged) {
+if (!isSnapshot) {
   artifactoryPublish.finalizedBy bintrayUpload
 }


### PR DESCRIPTION
CI can't detect tag pushes, so allow branches prefixed with `patch_release` to be published. These patch release branches should still be tagged with the appropriate version.