### PR TITLE
Revert "CI: publish branches prefixed with 'patch_release'"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,7 +137,9 @@ jobs:
               -PbuildInfo.build.number=${CIRCLE_BUILD_NUM} \
               artifactoryPublish --max-workers=1 --stacktrace --no-daemon
 
-  publish_branch:
+  publish_master:
+    <<: *publish
+  publish_tag:
     <<: *publish
 
 workflows:
@@ -175,15 +177,24 @@ workflows:
             branches:
               ignore: master
 
-      - publish_branch:
+      - publish_master:
           requires:
             - test_7
             - test_8
             - test_9
           filters:
             branches:
-              only:
-              - master
-              - /patch_release.*/
+              only: master
             tags:
               ignore: /.*/
+
+      - publish_tag:
+          requires:
+            - test_7
+            - test_8
+            - test_9
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -63,6 +63,7 @@ if (!isRoot) {
 }
 
 def isSnapshot = version.endsWith("-SNAPSHOT")
+def isCIandTagged = System.getenv("CIRCLE_TAG") != null
 // define in ~/.gradle/gradle.properties to override for testing
 def forceLocal = project.hasProperty('forceLocal') && forceLocal
 
@@ -151,6 +152,6 @@ bintray {
   }
 }
 
-if (!isSnapshot) {
+if (!isSnapshot && isCIandTagged) {
   artifactoryPublish.finalizedBy bintrayUpload
 }


### PR DESCRIPTION
Reverts DataDog/dd-trace-java#248

Sounds like the previous system was working ok.