### PR TITLE
Implement the TraceInterceptor API

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
@@ -61,7 +61,7 @@ public class AgentInstaller {
     }
     int numInstrumenters = 0;
     for (final Instrumenter instrumenter : ServiceLoader.load(Instrumenter.class)) {
-      log.debug("Loading instrumentation {}", instrumenter);
+      log.debug("Loading instrumentation {}", instrumenter.getClass().getName());
       agentBuilder = instrumenter.instrument(agentBuilder);
       numInstrumenters++;
     }

--- a/dd-java-agent/dd-java-agent.gradle
+++ b/dd-java-agent/dd-java-agent.gradle
@@ -48,12 +48,6 @@ def includeShadowJar(subproject, jarname) {
       relocate 'java.util.logging.Logger', 'datadog.trace.agent.bootstrap.PatchLogger'
 
       if (!project.hasProperty("disableShadowRelocate") || !disableShadowRelocate) {
-
-        // These need to be relocated to prevent conflicts in case the regular dd-trace is already on the classpath.
-        relocate('datadog.trace.api', 'datadog.trace.agent.api') {
-          // We want to ensure to not miss if a user is using the annotation.
-          exclude 'datadog.trace.api.Trace'
-        }
         relocate 'datadog.trace.common', 'datadog.trace.agent.common'
         relocate 'datadog.opentracing', 'datadog.trace.agent.ot'
 

--- a/dd-java-agent/instrumentation/classloaders/classloaders.gradle
+++ b/dd-java-agent/instrumentation/classloaders/classloaders.gradle
@@ -1,0 +1,12 @@
+apply from: "${rootDir}/gradle/java.gradle"
+
+dependencies {
+  compile project(':dd-trace-ot')
+  compile project(':dd-java-agent:agent-tooling')
+
+  compile deps.bytebuddy
+  compile deps.opentracing
+  compile deps.autoservice
+  
+  testCompile project(':dd-java-agent:testing')
+}

--- a/dd-java-agent/instrumentation/classloaders/src/main/java/datadog/trace/instrumentation/classloaders/CallDepthThreadLocalMap.java
+++ b/dd-java-agent/instrumentation/classloaders/src/main/java/datadog/trace/instrumentation/classloaders/CallDepthThreadLocalMap.java
@@ -1,0 +1,22 @@
+package datadog.trace.instrumentation.classloaders;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class CallDepthThreadLocalMap {
+  private static final ThreadLocal<AtomicInteger> tls = new ThreadLocal<>();
+
+  public static int incrementCallDepth() {
+    AtomicInteger depth = tls.get();
+    if (depth == null) {
+      depth = new AtomicInteger(0);
+      tls.set(depth);
+      return 0;
+    } else {
+      return depth.incrementAndGet();
+    }
+  }
+
+  public static void reset() {
+    tls.remove();
+  }
+}

--- a/dd-java-agent/instrumentation/classloaders/src/main/java/datadog/trace/instrumentation/classloaders/ClassLoaderInstrumentation.java
+++ b/dd-java-agent/instrumentation/classloaders/src/main/java/datadog/trace/instrumentation/classloaders/ClassLoaderInstrumentation.java
@@ -1,0 +1,73 @@
+package datadog.trace.instrumentation.classloaders;
+
+import static datadog.trace.agent.tooling.ClassLoaderMatcher.classLoaderHasClasses;
+import static net.bytebuddy.matcher.ElementMatchers.failSafe;
+import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
+import static net.bytebuddy.matcher.ElementMatchers.isSubTypeOf;
+
+import com.google.auto.service.AutoService;
+import datadog.opentracing.DDTracer;
+import datadog.trace.agent.tooling.DDAdvice;
+import datadog.trace.agent.tooling.HelperInjector;
+import datadog.trace.agent.tooling.Instrumenter;
+import io.opentracing.util.GlobalTracer;
+import java.lang.reflect.Field;
+import net.bytebuddy.agent.builder.AgentBuilder;
+import net.bytebuddy.asm.Advice;
+
+@AutoService(Instrumenter.class)
+public final class ClassLoaderInstrumentation extends Instrumenter.Configurable {
+
+  public ClassLoaderInstrumentation() {
+    super("classloader");
+  }
+
+  @Override
+  protected boolean defaultEnabled() {
+    return false;
+  }
+
+  @Override
+  public AgentBuilder apply(final AgentBuilder agentBuilder) {
+    return agentBuilder
+        .type(
+            failSafe(isSubTypeOf(ClassLoader.class)),
+            classLoaderHasClasses("io.opentracing.util.GlobalTracer"))
+        .transform(
+            new HelperInjector(
+                "datadog.trace.instrumentation.classloaders.CallDepthThreadLocalMap"))
+        .transform(DDAdvice.create().advice(isConstructor(), ClassloaderAdvice.class.getName()))
+        .asDecorator();
+  }
+
+  public static class ClassloaderAdvice {
+
+    @Advice.OnMethodEnter
+    public static int constructorEnter() {
+      // We use this to make sure we only apply the exit instrumentation
+      // after the constructors are done calling their super constructors.
+      return CallDepthThreadLocalMap.incrementCallDepth();
+    }
+
+    // Not sure why, but adding suppress causes a verify error.
+    @Advice.OnMethodExit // (suppress = Throwable.class)
+    public static void constructorExit(
+        @Advice.This final ClassLoader cl, @Advice.Enter final int depth) {
+      if (depth == 0) {
+        CallDepthThreadLocalMap.reset();
+
+        try {
+          final Field field = GlobalTracer.class.getDeclaredField("tracer");
+          field.setAccessible(true);
+
+          final Object o = field.get(null);
+          if (o instanceof DDTracer) {
+            final DDTracer tracer = (DDTracer) o;
+            tracer.registerClassLoader(cl);
+          }
+        } catch (final Throwable e) {
+        }
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/classloaders/src/test/groovy/ClassLoaderInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/classloaders/src/test/groovy/ClassLoaderInstrumentationTest.groovy
@@ -12,7 +12,7 @@ class ClassLoaderInstrumentationTest extends AgentTestRunner {
   DDTracer tracer = Mock()
 
   def setup() {
-    TestUtils.registerOrReplaceGlobalTracer(tracer);
+    TestUtils.registerOrReplaceGlobalTracer(tracer)
   }
 
   def "creating classloader calls register on tracer"() {

--- a/dd-java-agent/instrumentation/classloaders/src/test/groovy/ClassLoaderInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/classloaders/src/test/groovy/ClassLoaderInstrumentationTest.groovy
@@ -1,0 +1,53 @@
+import datadog.opentracing.DDTracer
+import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.agent.test.TestUtils
+
+import java.security.SecureClassLoader
+
+class ClassLoaderInstrumentationTest extends AgentTestRunner {
+  static {
+    System.setProperty("dd.integration.classloader.enabled", "true")
+  }
+
+  DDTracer tracer = Mock()
+
+  def setup() {
+    TestUtils.registerOrReplaceGlobalTracer(tracer);
+  }
+
+  def "creating classloader calls register on tracer"() {
+    when:
+    new EmptyNonDelegatingLoader()
+
+    then:
+    1 * tracer.registerClassLoader(_ as EmptyNonDelegatingLoader)
+    0 * _
+  }
+
+  def "creating anonymous classloader calls register on tracer"() {
+    when:
+    new EmptyNonDelegatingLoader() {}
+
+    then:
+    1 * tracer.registerClassLoader(_ as EmptyNonDelegatingLoader)
+    0 * _
+  }
+
+  def "bootstrap classloaders aren't instrumented"() {
+    // (Because they don't have access to GlobalTracer)
+    when:
+    new SecureClassLoader()
+    new SecureClassLoader(null) {}
+    new URLClassLoader(new URL[0], ClassLoader.systemClassLoader)
+
+    then:
+    0 * tracer.registerClassLoader(_)
+    0 * _
+  }
+
+  class EmptyNonDelegatingLoader extends SecureClassLoader {
+    EmptyNonDelegatingLoader() {
+      super(null)
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/jax-rs/src/main/java/datadog/trace/instrumentation/jaxrs/JaxRsInstrumentation.java
+++ b/dd-java-agent/instrumentation/jax-rs/src/main/java/datadog/trace/instrumentation/jaxrs/JaxRsInstrumentation.java
@@ -1,6 +1,7 @@
 package datadog.trace.instrumentation.jaxrs;
 
 import static net.bytebuddy.matcher.ElementMatchers.declaresMethod;
+import static net.bytebuddy.matcher.ElementMatchers.failSafe;
 import static net.bytebuddy.matcher.ElementMatchers.hasSuperType;
 import static net.bytebuddy.matcher.ElementMatchers.isAnnotatedWith;
 import static net.bytebuddy.matcher.ElementMatchers.named;
@@ -38,7 +39,10 @@ public final class JaxRsInstrumentation extends Instrumenter.Configurable {
         .type(
             hasSuperType(
                 isAnnotatedWith(named("javax.ws.rs.Path"))
-                    .or(hasSuperType(declaresMethod(isAnnotatedWith(named("javax.ws.rs.Path")))))))
+                    .or(
+                        failSafe(
+                            hasSuperType(
+                                declaresMethod(isAnnotatedWith(named("javax.ws.rs.Path"))))))))
         .transform(
             DDAdvice.create()
                 .advice(

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/ConnectionInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/ConnectionInstrumentation.java
@@ -1,10 +1,10 @@
 package datadog.trace.instrumentation.jdbc;
 
-import static net.bytebuddy.matcher.ElementMatchers.hasSuperType;
+import static net.bytebuddy.matcher.ElementMatchers.failSafe;
 import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
 import static net.bytebuddy.matcher.ElementMatchers.isInterface;
+import static net.bytebuddy.matcher.ElementMatchers.isSubTypeOf;
 import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;
-import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.not;
 import static net.bytebuddy.matcher.ElementMatchers.returns;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
@@ -28,7 +28,7 @@ public final class ConnectionInstrumentation extends Instrumenter.Configurable {
   @Override
   public AgentBuilder apply(final AgentBuilder agentBuilder) {
     return agentBuilder
-        .type(not(isInterface()).and(hasSuperType(named(Connection.class.getName()))))
+        .type(not(isInterface()).and(failSafe(isSubTypeOf(Connection.class))))
         .transform(
             DDAdvice.create()
                 .advice(

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/PreparedStatementInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/PreparedStatementInstrumentation.java
@@ -1,11 +1,11 @@
 package datadog.trace.instrumentation.jdbc;
 
 import static io.opentracing.log.Fields.ERROR_OBJECT;
-import static net.bytebuddy.matcher.ElementMatchers.hasSuperType;
+import static net.bytebuddy.matcher.ElementMatchers.failSafe;
 import static net.bytebuddy.matcher.ElementMatchers.isInterface;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
+import static net.bytebuddy.matcher.ElementMatchers.isSubTypeOf;
 import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;
-import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.not;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
@@ -35,7 +35,7 @@ public final class PreparedStatementInstrumentation extends Instrumenter.Configu
   @Override
   public AgentBuilder apply(final AgentBuilder agentBuilder) {
     return agentBuilder
-        .type(not(isInterface()).and(hasSuperType(named(PreparedStatement.class.getName()))))
+        .type(not(isInterface()).and(failSafe(isSubTypeOf(PreparedStatement.class))))
         .transform(
             DDAdvice.create()
                 .advice(

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/StatementInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/StatementInstrumentation.java
@@ -1,11 +1,11 @@
 package datadog.trace.instrumentation.jdbc;
 
 import static io.opentracing.log.Fields.ERROR_OBJECT;
-import static net.bytebuddy.matcher.ElementMatchers.hasSuperType;
+import static net.bytebuddy.matcher.ElementMatchers.failSafe;
 import static net.bytebuddy.matcher.ElementMatchers.isInterface;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
+import static net.bytebuddy.matcher.ElementMatchers.isSubTypeOf;
 import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;
-import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.not;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
@@ -35,7 +35,7 @@ public final class StatementInstrumentation extends Instrumenter.Configurable {
   @Override
   public AgentBuilder apply(final AgentBuilder agentBuilder) {
     return agentBuilder
-        .type(not(isInterface()).and(hasSuperType(named(Statement.class.getName()))))
+        .type(not(isInterface()).and(failSafe(isSubTypeOf(Statement.class))))
         .transform(
             DDAdvice.create()
                 .advice(

--- a/dd-java-agent/instrumentation/jms-1/src/main/java/datadog/trace/instrumentation/jms1/JMS1MessageConsumerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jms-1/src/main/java/datadog/trace/instrumentation/jms1/JMS1MessageConsumerInstrumentation.java
@@ -3,6 +3,7 @@ package datadog.trace.instrumentation.jms1;
 import static datadog.trace.agent.tooling.ClassLoaderMatcher.classLoaderHasClasses;
 import static datadog.trace.instrumentation.jms.util.JmsUtil.toResourceName;
 import static io.opentracing.log.Fields.ERROR_OBJECT;
+import static net.bytebuddy.matcher.ElementMatchers.failSafe;
 import static net.bytebuddy.matcher.ElementMatchers.hasSuperType;
 import static net.bytebuddy.matcher.ElementMatchers.isInterface;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
@@ -45,7 +46,7 @@ public final class JMS1MessageConsumerInstrumentation extends Instrumenter.Confi
   public AgentBuilder apply(final AgentBuilder agentBuilder) {
     return agentBuilder
         .type(
-            not(isInterface()).and(hasSuperType(named("javax.jms.MessageConsumer"))),
+            not(isInterface()).and(failSafe(hasSuperType(named("javax.jms.MessageConsumer")))),
             not(classLoaderHasClasses("javax.jms.JMSContext", "javax.jms.CompletionListener")))
         .transform(JMS1_HELPER_INJECTOR)
         .transform(

--- a/dd-java-agent/instrumentation/jms-1/src/main/java/datadog/trace/instrumentation/jms1/JMS1MessageListenerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jms-1/src/main/java/datadog/trace/instrumentation/jms1/JMS1MessageListenerInstrumentation.java
@@ -3,6 +3,7 @@ package datadog.trace.instrumentation.jms1;
 import static datadog.trace.agent.tooling.ClassLoaderMatcher.classLoaderHasClasses;
 import static datadog.trace.instrumentation.jms.util.JmsUtil.toResourceName;
 import static io.opentracing.log.Fields.ERROR_OBJECT;
+import static net.bytebuddy.matcher.ElementMatchers.failSafe;
 import static net.bytebuddy.matcher.ElementMatchers.hasSuperType;
 import static net.bytebuddy.matcher.ElementMatchers.isInterface;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
@@ -39,7 +40,7 @@ public final class JMS1MessageListenerInstrumentation extends Instrumenter.Confi
   public AgentBuilder apply(final AgentBuilder agentBuilder) {
     return agentBuilder
         .type(
-            not(isInterface()).and(hasSuperType(named("javax.jms.MessageListener"))),
+            not(isInterface()).and(failSafe(hasSuperType(named("javax.jms.MessageListener")))),
             not(classLoaderHasClasses("javax.jms.JMSContext", "javax.jms.CompletionListener")))
         .transform(JMS1MessageConsumerInstrumentation.JMS1_HELPER_INJECTOR)
         .transform(

--- a/dd-java-agent/instrumentation/jms-1/src/main/java/datadog/trace/instrumentation/jms1/JMS1MessageProducerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jms-1/src/main/java/datadog/trace/instrumentation/jms1/JMS1MessageProducerInstrumentation.java
@@ -3,6 +3,7 @@ package datadog.trace.instrumentation.jms1;
 import static datadog.trace.agent.tooling.ClassLoaderMatcher.classLoaderHasClasses;
 import static datadog.trace.instrumentation.jms.util.JmsUtil.toResourceName;
 import static io.opentracing.log.Fields.ERROR_OBJECT;
+import static net.bytebuddy.matcher.ElementMatchers.failSafe;
 import static net.bytebuddy.matcher.ElementMatchers.hasSuperType;
 import static net.bytebuddy.matcher.ElementMatchers.isInterface;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
@@ -40,7 +41,7 @@ public final class JMS1MessageProducerInstrumentation extends Instrumenter.Confi
   public AgentBuilder apply(final AgentBuilder agentBuilder) {
     return agentBuilder
         .type(
-            not(isInterface()).and(hasSuperType(named("javax.jms.MessageProducer"))),
+            not(isInterface()).and(failSafe(hasSuperType(named("javax.jms.MessageProducer")))),
             not(classLoaderHasClasses("javax.jms.JMSContext", "javax.jms.CompletionListener")))
         .transform(JMS1MessageConsumerInstrumentation.JMS1_HELPER_INJECTOR)
         .transform(

--- a/dd-java-agent/instrumentation/jms-2/src/main/java/datadog/trace/instrumentation/jms2/JMS2MessageConsumerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jms-2/src/main/java/datadog/trace/instrumentation/jms2/JMS2MessageConsumerInstrumentation.java
@@ -3,6 +3,7 @@ package datadog.trace.instrumentation.jms2;
 import static datadog.trace.agent.tooling.ClassLoaderMatcher.classLoaderHasClasses;
 import static datadog.trace.instrumentation.jms.util.JmsUtil.toResourceName;
 import static io.opentracing.log.Fields.ERROR_OBJECT;
+import static net.bytebuddy.matcher.ElementMatchers.failSafe;
 import static net.bytebuddy.matcher.ElementMatchers.hasSuperType;
 import static net.bytebuddy.matcher.ElementMatchers.isInterface;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
@@ -45,7 +46,7 @@ public final class JMS2MessageConsumerInstrumentation extends Instrumenter.Confi
   public AgentBuilder apply(final AgentBuilder agentBuilder) {
     return agentBuilder
         .type(
-            not(isInterface()).and(hasSuperType(named("javax.jms.MessageConsumer"))),
+            not(isInterface()).and(failSafe(hasSuperType(named("javax.jms.MessageConsumer")))),
             classLoaderHasClasses("javax.jms.JMSContext", "javax.jms.CompletionListener"))
         .transform(JMS2_HELPER_INJECTOR)
         .transform(

--- a/dd-java-agent/instrumentation/jms-2/src/main/java/datadog/trace/instrumentation/jms2/JMS2MessageListenerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jms-2/src/main/java/datadog/trace/instrumentation/jms2/JMS2MessageListenerInstrumentation.java
@@ -3,6 +3,7 @@ package datadog.trace.instrumentation.jms2;
 import static datadog.trace.agent.tooling.ClassLoaderMatcher.classLoaderHasClasses;
 import static datadog.trace.instrumentation.jms.util.JmsUtil.toResourceName;
 import static io.opentracing.log.Fields.ERROR_OBJECT;
+import static net.bytebuddy.matcher.ElementMatchers.failSafe;
 import static net.bytebuddy.matcher.ElementMatchers.hasSuperType;
 import static net.bytebuddy.matcher.ElementMatchers.isInterface;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
@@ -39,7 +40,7 @@ public final class JMS2MessageListenerInstrumentation extends Instrumenter.Confi
   public AgentBuilder apply(final AgentBuilder agentBuilder) {
     return agentBuilder
         .type(
-            not(isInterface()).and(hasSuperType(named("javax.jms.MessageListener"))),
+            not(isInterface()).and(failSafe(hasSuperType(named("javax.jms.MessageListener")))),
             classLoaderHasClasses("javax.jms.JMSContext", "javax.jms.CompletionListener"))
         .transform(JMS2MessageConsumerInstrumentation.JMS2_HELPER_INJECTOR)
         .transform(

--- a/dd-java-agent/instrumentation/jms-2/src/main/java/datadog/trace/instrumentation/jms2/JMS2MessageProducerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jms-2/src/main/java/datadog/trace/instrumentation/jms2/JMS2MessageProducerInstrumentation.java
@@ -3,6 +3,7 @@ package datadog.trace.instrumentation.jms2;
 import static datadog.trace.agent.tooling.ClassLoaderMatcher.classLoaderHasClasses;
 import static datadog.trace.instrumentation.jms.util.JmsUtil.toResourceName;
 import static io.opentracing.log.Fields.ERROR_OBJECT;
+import static net.bytebuddy.matcher.ElementMatchers.failSafe;
 import static net.bytebuddy.matcher.ElementMatchers.hasSuperType;
 import static net.bytebuddy.matcher.ElementMatchers.isInterface;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
@@ -40,7 +41,7 @@ public final class JMS2MessageProducerInstrumentation extends Instrumenter.Confi
   public AgentBuilder apply(final AgentBuilder agentBuilder) {
     return agentBuilder
         .type(
-            not(isInterface()).and(hasSuperType(named("javax.jms.MessageProducer"))),
+            not(isInterface()).and(failSafe(hasSuperType(named("javax.jms.MessageProducer")))),
             classLoaderHasClasses("javax.jms.JMSContext", "javax.jms.CompletionListener"))
         .transform(JMS2MessageConsumerInstrumentation.JMS2_HELPER_INJECTOR)
         .transform(

--- a/dd-java-agent/instrumentation/servlet-2/src/main/java/datadog/trace/instrumentation/servlet2/FilterChain2Instrumentation.java
+++ b/dd-java-agent/instrumentation/servlet-2/src/main/java/datadog/trace/instrumentation/servlet2/FilterChain2Instrumentation.java
@@ -2,6 +2,7 @@ package datadog.trace.instrumentation.servlet2;
 
 import static datadog.trace.agent.tooling.ClassLoaderMatcher.classLoaderHasClasses;
 import static io.opentracing.log.Fields.ERROR_OBJECT;
+import static net.bytebuddy.matcher.ElementMatchers.failSafe;
 import static net.bytebuddy.matcher.ElementMatchers.hasSuperType;
 import static net.bytebuddy.matcher.ElementMatchers.isInterface;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
@@ -42,7 +43,7 @@ public final class FilterChain2Instrumentation extends Instrumenter.Configurable
   public AgentBuilder apply(final AgentBuilder agentBuilder) {
     return agentBuilder
         .type(
-            not(isInterface()).and(hasSuperType(named("javax.servlet.FilterChain"))),
+            not(isInterface()).and(failSafe(hasSuperType(named("javax.servlet.FilterChain")))),
             not(classLoaderHasClasses("javax.servlet.AsyncEvent", "javax.servlet.AsyncListener"))
                 .and(
                     classLoaderHasClasses(

--- a/dd-java-agent/instrumentation/servlet-2/src/main/java/datadog/trace/instrumentation/servlet2/HttpServlet2Instrumentation.java
+++ b/dd-java-agent/instrumentation/servlet-2/src/main/java/datadog/trace/instrumentation/servlet2/HttpServlet2Instrumentation.java
@@ -2,6 +2,7 @@ package datadog.trace.instrumentation.servlet2;
 
 import static datadog.trace.agent.tooling.ClassLoaderMatcher.classLoaderHasClasses;
 import static io.opentracing.log.Fields.ERROR_OBJECT;
+import static net.bytebuddy.matcher.ElementMatchers.failSafe;
 import static net.bytebuddy.matcher.ElementMatchers.hasSuperType;
 import static net.bytebuddy.matcher.ElementMatchers.isInterface;
 import static net.bytebuddy.matcher.ElementMatchers.isProtected;
@@ -42,7 +43,7 @@ public final class HttpServlet2Instrumentation extends Instrumenter.Configurable
   public AgentBuilder apply(final AgentBuilder agentBuilder) {
     return agentBuilder
         .type(
-            not(isInterface()).and(hasSuperType(named("javax.servlet.http.HttpServlet"))),
+            not(isInterface()).and(failSafe(hasSuperType(named("javax.servlet.http.HttpServlet")))),
             not(classLoaderHasClasses("javax.servlet.AsyncEvent", "javax.servlet.AsyncListener"))
                 .and(
                     classLoaderHasClasses(

--- a/dd-java-agent/instrumentation/servlet-3/src/main/java/datadog/trace/instrumentation/servlet3/FilterChain3Instrumentation.java
+++ b/dd-java-agent/instrumentation/servlet-3/src/main/java/datadog/trace/instrumentation/servlet3/FilterChain3Instrumentation.java
@@ -2,6 +2,7 @@ package datadog.trace.instrumentation.servlet3;
 
 import static datadog.trace.agent.tooling.ClassLoaderMatcher.classLoaderHasClasses;
 import static io.opentracing.log.Fields.ERROR_OBJECT;
+import static net.bytebuddy.matcher.ElementMatchers.failSafe;
 import static net.bytebuddy.matcher.ElementMatchers.hasSuperType;
 import static net.bytebuddy.matcher.ElementMatchers.isInterface;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
@@ -47,7 +48,7 @@ public final class FilterChain3Instrumentation extends Instrumenter.Configurable
   public AgentBuilder apply(final AgentBuilder agentBuilder) {
     return agentBuilder
         .type(
-            not(isInterface()).and(hasSuperType(named("javax.servlet.FilterChain"))),
+            not(isInterface()).and(failSafe(hasSuperType(named("javax.servlet.FilterChain")))),
             classLoaderHasClasses("javax.servlet.AsyncEvent", "javax.servlet.AsyncListener"))
         .transform(
             new HelperInjector(

--- a/dd-java-agent/instrumentation/servlet-3/src/main/java/datadog/trace/instrumentation/servlet3/HttpServlet3Instrumentation.java
+++ b/dd-java-agent/instrumentation/servlet-3/src/main/java/datadog/trace/instrumentation/servlet3/HttpServlet3Instrumentation.java
@@ -2,6 +2,7 @@ package datadog.trace.instrumentation.servlet3;
 
 import static datadog.trace.agent.tooling.ClassLoaderMatcher.classLoaderHasClasses;
 import static io.opentracing.log.Fields.ERROR_OBJECT;
+import static net.bytebuddy.matcher.ElementMatchers.failSafe;
 import static net.bytebuddy.matcher.ElementMatchers.hasSuperType;
 import static net.bytebuddy.matcher.ElementMatchers.isInterface;
 import static net.bytebuddy.matcher.ElementMatchers.isProtected;
@@ -45,7 +46,7 @@ public final class HttpServlet3Instrumentation extends Instrumenter.Configurable
   public AgentBuilder apply(final AgentBuilder agentBuilder) {
     return agentBuilder
         .type(
-            not(isInterface()).and(hasSuperType(named("javax.servlet.http.HttpServlet"))),
+            not(isInterface()).and(failSafe(hasSuperType(named("javax.servlet.http.HttpServlet")))),
             classLoaderHasClasses("javax.servlet.AsyncEvent", "javax.servlet.AsyncListener"))
         .transform(
             new HelperInjector(

--- a/dd-java-agent/instrumentation/spring-web/src/main/java/datadog/trace/instrumentation/springweb/SpringWebInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-web/src/main/java/datadog/trace/instrumentation/springweb/SpringWebInstrumentation.java
@@ -2,6 +2,7 @@ package datadog.trace.instrumentation.springweb;
 
 import static datadog.trace.agent.tooling.ClassLoaderMatcher.classLoaderHasClassWithField;
 import static io.opentracing.log.Fields.ERROR_OBJECT;
+import static net.bytebuddy.matcher.ElementMatchers.failSafe;
 import static net.bytebuddy.matcher.ElementMatchers.hasSuperType;
 import static net.bytebuddy.matcher.ElementMatchers.isInterface;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
@@ -39,7 +40,9 @@ public final class SpringWebInstrumentation extends Instrumenter.Configurable {
     return agentBuilder
         .type(
             not(isInterface())
-                .and(hasSuperType(named("org.springframework.web.servlet.HandlerAdapter"))),
+                .and(
+                    failSafe(
+                        hasSuperType(named("org.springframework.web.servlet.HandlerAdapter")))),
             classLoaderHasClassWithField(
                 "org.springframework.web.servlet.HandlerMapping",
                 "BEST_MATCHING_PATTERN_ATTRIBUTE"))

--- a/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceAnnotationInstrumentation.java
+++ b/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceAnnotationInstrumentation.java
@@ -2,6 +2,7 @@ package datadog.trace.instrumentation.trace_annotation;
 
 import static io.opentracing.log.Fields.ERROR_OBJECT;
 import static net.bytebuddy.matcher.ElementMatchers.declaresMethod;
+import static net.bytebuddy.matcher.ElementMatchers.failSafe;
 import static net.bytebuddy.matcher.ElementMatchers.hasSuperType;
 import static net.bytebuddy.matcher.ElementMatchers.isAnnotatedWith;
 
@@ -28,7 +29,7 @@ public final class TraceAnnotationInstrumentation extends Instrumenter.Configura
   @Override
   public AgentBuilder apply(final AgentBuilder agentBuilder) {
     return agentBuilder
-        .type(hasSuperType(declaresMethod(isAnnotatedWith(Trace.class))))
+        .type(failSafe(hasSuperType(declaresMethod(isAnnotatedWith(Trace.class)))))
         .transform(
             DDAdvice.create().advice(isAnnotatedWith(Trace.class), TraceAdvice.class.getName()))
         .asDecorator();

--- a/dd-trace-api/src/main/java/datadog/trace/api/interceptor/MutableSpan.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/interceptor/MutableSpan.java
@@ -1,0 +1,37 @@
+package datadog.trace.api.interceptor;
+
+import java.util.Map;
+
+public interface MutableSpan {
+  String getOperationName();
+
+  MutableSpan setOperationName(final String serviceName);
+
+  String getServiceName();
+
+  MutableSpan setServiceName(final String serviceName);
+
+  String getResourceName();
+
+  MutableSpan setResourceName(final String resourceName);
+
+  Integer getSamplingPriority();
+
+  MutableSpan setSamplingPriority(final int newPriority);
+
+  String getSpanType();
+
+  MutableSpan setSpanType(final String type);
+
+  Map<String, Object> getTags();
+
+  MutableSpan setTag(final String tag, final String value);
+
+  MutableSpan setTag(final String tag, final boolean value);
+
+  MutableSpan setTag(final String tag, final Number value);
+
+  Boolean isError();
+
+  MutableSpan setError(boolean value);
+}

--- a/dd-trace-api/src/main/java/datadog/trace/api/interceptor/TraceInterceptor.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/interceptor/TraceInterceptor.java
@@ -1,0 +1,22 @@
+package datadog.trace.api.interceptor;
+
+import java.util.Collection;
+
+public interface TraceInterceptor {
+
+  /**
+   * After a trace is "complete" but before it is written, it is provided to the interceptors to
+   * modify. The result following all interceptors is sampled then sent to the trace writer.
+   *
+   * @param trace - The collection of spans that represent a trace. Can be modified in place. Order
+   *     of spans should not be relied upon.
+   * @return A potentially modified or replaced collection of spans. Must not be null.
+   */
+  Collection<? extends MutableSpan> onTraceComplete(Collection<? extends MutableSpan> trace);
+
+  /**
+   * @return A unique priority for sorting relative to other TraceInterceptors. Unique because
+   *     interceptors are stored in a sorted set, so duplicates will not be added.
+   */
+  int priority();
+}

--- a/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
@@ -1,6 +1,7 @@
 package datadog.opentracing;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import datadog.opentracing.decorators.AbstractDecorator;
 import datadog.opentracing.decorators.DDDecoratorsFactory;
@@ -10,6 +11,8 @@ import datadog.opentracing.propagation.HTTPCodec;
 import datadog.opentracing.scopemanager.ContextualScopeManager;
 import datadog.opentracing.scopemanager.ScopeContext;
 import datadog.trace.api.DDTags;
+import datadog.trace.api.interceptor.MutableSpan;
+import datadog.trace.api.interceptor.TraceInterceptor;
 import datadog.trace.common.DDTraceConfig;
 import datadog.trace.common.Service;
 import datadog.trace.common.sampling.AllSampler;
@@ -25,12 +28,17 @@ import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.propagation.Format;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.ServiceLoader;
+import java.util.SortedSet;
+import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.ThreadLocalRandom;
 import lombok.extern.slf4j.Slf4j;
 
@@ -56,6 +64,14 @@ public class DDTracer implements io.opentracing.Tracer {
   private final Map<String, List<AbstractDecorator>> spanContextDecorators =
       new ConcurrentHashMap<>();
 
+  private final SortedSet<TraceInterceptor> interceptors =
+      new ConcurrentSkipListSet<>(
+          new Comparator<TraceInterceptor>() {
+            @Override
+            public int compare(final TraceInterceptor o1, final TraceInterceptor o2) {
+              return Integer.compare(o1.priority(), o2.priority());
+            }
+          });
   private final CodecRegistry registry;
   private final Map<String, Service> services = new HashMap<>();
 
@@ -106,6 +122,10 @@ public class DDTracer implements io.opentracing.Tracer {
       final DDApi api = ((DDAgentWriter) this.writer).getApi();
       api.addResponseListener((DDApi.ResponseListener) this.sampler);
     }
+
+    for (final TraceInterceptor interceptor : ServiceLoader.load(TraceInterceptor.class)) {
+      interceptors.add(interceptor);
+    }
     log.info("New instance: {}", this);
   }
 
@@ -140,6 +160,17 @@ public class DDTracer implements io.opentracing.Tracer {
     list.add(decorator);
 
     spanContextDecorators.put(decorator.getMatchingTag(), list);
+  }
+
+  /**
+   * Add a new interceptor to the tracer. Interceptors with duplicate priority to existing ones are
+   * ignored.
+   *
+   * @param interceptor
+   * @return false if an interceptor with same priority exists.
+   */
+  public boolean addInterceptor(final TraceInterceptor interceptor) {
+    return interceptors.add(interceptor);
   }
 
   public void addScopeContext(final ScopeContext context) {
@@ -194,8 +225,23 @@ public class DDTracer implements io.opentracing.Tracer {
     if (trace.isEmpty()) {
       return;
     }
-    if (this.sampler.sample(trace.peek())) {
-      this.writer.write(new ArrayList<>(trace));
+    final ArrayList<DDSpan> writtenTrace;
+    if (interceptors.isEmpty()) {
+      writtenTrace = Lists.newArrayList(trace);
+    } else {
+      Collection<? extends MutableSpan> interceptedTrace = Lists.newArrayList(trace);
+      for (final TraceInterceptor interceptor : interceptors) {
+        interceptedTrace = interceptor.onTraceComplete(interceptedTrace);
+      }
+      writtenTrace = Lists.newArrayListWithExpectedSize(interceptedTrace.size());
+      for (final MutableSpan span : interceptedTrace) {
+        if (span instanceof DDSpan) {
+          writtenTrace.add((DDSpan) span);
+        }
+      }
+    }
+    if (!writtenTrace.isEmpty() && this.sampler.sample(writtenTrace.get(0))) {
+      this.writer.write(writtenTrace);
     }
   }
 

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/DDSpanBuilderTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/DDSpanBuilderTest.groovy
@@ -235,6 +235,9 @@ class DDSpanBuilderTest extends Specification {
     expect:
     span.tags == tags
 
+    cleanup:
+    System.clearProperty("dd.trace.span.tags")
+
     where:
     tagString     | tags
     ""            | [:]

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/DDSpanSerializationTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/DDSpanSerializationTest.groovy
@@ -9,7 +9,7 @@ import spock.lang.Specification
 import spock.lang.Timeout
 import spock.lang.Unroll
 
-@Timeout(2)
+@Timeout(5)
 class DDSpanSerializationTest extends Specification {
 
   @Unroll

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/TraceInterceptorTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/TraceInterceptorTest.groovy
@@ -1,0 +1,149 @@
+package datadog.opentracing
+
+import datadog.trace.api.interceptor.MutableSpan
+import datadog.trace.api.interceptor.TraceInterceptor
+import datadog.trace.common.writer.ListWriter
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import java.util.concurrent.atomic.AtomicBoolean
+
+class TraceInterceptorTest extends Specification {
+  def writer = new ListWriter()
+  def tracer = new DDTracer(writer)
+
+  def "interceptor is registered as a service"() {
+    expect:
+    tracer.interceptors.iterator().hasNext()
+    tracer.interceptors.iterator().next() instanceof TestInterceptor
+  }
+
+  def "interceptors with the same priority replaced"() {
+    setup:
+    int priority = 999
+    ((TestInterceptor) tracer.interceptors.iterator().next()).priority = priority
+    tracer.interceptors.add(new TraceInterceptor() {
+      @Override
+      Collection<? extends MutableSpan> onTraceComplete(Collection<? extends MutableSpan> trace) {
+        return null
+      }
+
+      @Override
+      int priority() {
+        return priority
+      }
+    })
+
+    expect:
+    tracer.interceptors.size() == 1
+    tracer.interceptors.iterator().next() instanceof TestInterceptor
+  }
+
+  def "interceptors with different priority sorted"() {
+    setup:
+    def priority = score
+    def existingInterceptor = tracer.interceptors.iterator().next()
+    def newInterceptor = new TraceInterceptor() {
+      @Override
+      Collection<? extends MutableSpan> onTraceComplete(Collection<? extends MutableSpan> trace) {
+        return null
+      }
+
+      @Override
+      int priority() {
+        return priority
+      }
+    }
+    tracer.interceptors.add(newInterceptor)
+
+    expect:
+    tracer.interceptors == reverse ? [newInterceptor, existingInterceptor] : [existingInterceptor, newInterceptor]
+
+    where:
+    score | reverse
+    -1    | false
+    1     | true
+  }
+
+  @Unroll
+  def "interceptor can discard a trace (p=#score)"() {
+    setup:
+    def called = new AtomicBoolean(false)
+    def priority = score
+    tracer.interceptors.add(new TraceInterceptor() {
+      @Override
+      Collection<? extends MutableSpan> onTraceComplete(Collection<? extends MutableSpan> trace) {
+        called.set(true)
+        return Collections.emptyList()
+      }
+
+      @Override
+      int priority() {
+        return priority
+      }
+    })
+    tracer.buildSpan("test").start().finish()
+
+    expect:
+    tracer.interceptors.size() == Math.abs(score) + 1
+    (called.get()) == (score != 0)
+    (writer == []) == (score != 0)
+
+    where:
+    score | _
+    -1    | _
+    0     | _
+    1     | _
+  }
+
+  @Unroll
+  def "interceptor can modify a span"() {
+    setup:
+    tracer.interceptors.add(new TraceInterceptor() {
+      @Override
+      Collection<? extends MutableSpan> onTraceComplete(Collection<? extends MutableSpan> trace) {
+        for (MutableSpan span : trace) {
+          span
+            .setOperationName("modifiedON-" + span.getOperationName())
+            .setServiceName("modifiedSN-" + span.getServiceName())
+            .setResourceName("modifiedRN-" + span.getResourceName())
+            .setSpanType("modifiedST-" + span.getSpanType())
+            .setTag("boolean-tag", true)
+            .setTag("number-tag", 5.0)
+            .setTag("string-tag", "howdy")
+            .setError(true)
+        }
+        return trace
+      }
+
+      @Override
+      int priority() {
+        return 1
+      }
+    })
+    tracer.buildSpan("test").start().finish()
+
+    expect:
+    def trace = writer.firstTrace()
+    trace.size() == 1
+
+    def span = trace[0]
+
+    span.context().operationName == "modifiedON-test"
+    span.serviceName == "modifiedSN-unnamed-java-app"
+    span.resourceName == "modifiedRN-modifiedON-test"
+    span.type == "modifiedST-null"
+    span.context().getErrorFlag()
+
+    def tags = span.context().tags
+
+    tags["boolean-tag"] == true
+    tags["number-tag"] == 5.0
+    tags["string-tag"] == "howdy"
+
+    tags["span.type"] == "modifiedST-null"
+    tags["thread.name"] != null
+    tags["thread.id"] != null
+    tags.size() == 6
+  }
+}

--- a/dd-trace-ot/src/test/java/datadog/opentracing/TestInterceptor.java
+++ b/dd-trace-ot/src/test/java/datadog/opentracing/TestInterceptor.java
@@ -1,0 +1,22 @@
+package datadog.opentracing;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.api.interceptor.MutableSpan;
+import datadog.trace.api.interceptor.TraceInterceptor;
+import java.util.Collection;
+
+@AutoService(TraceInterceptor.class)
+public class TestInterceptor implements TraceInterceptor {
+  public volatile int priority = 0;
+
+  @Override
+  public Collection<? extends MutableSpan> onTraceComplete(
+      final Collection<? extends MutableSpan> trace) {
+    return trace;
+  }
+
+  @Override
+  public int priority() {
+    return priority;
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -12,6 +12,7 @@ include ':dd-trace-api'
 // instrumentation:
 include ':dd-java-agent:instrumentation:apache-httpclient-4.3'
 include ':dd-java-agent:instrumentation:aws-sdk'
+include ':dd-java-agent:instrumentation:classloaders'
 include ':dd-java-agent:instrumentation:datastax-cassandra-3.2'
 include ':dd-java-agent:instrumentation:jax-rs'
 include ':dd-java-agent:instrumentation:jboss-classloading'


### PR DESCRIPTION
Add a TraceInterceptor API with the design intent to only require a dependency on `dd-trace-api`.  This is done by using java's `ServiceLoader`.  Unfortunately in my testing, this doesn't seem to work smoothly with Spring Boot's executable jar.  If this issue comes up, I can revisit.

(Merging into `configurable-scope-manager` branch)