### PR TITLE
SpringWebErrorHandler capture stacktrace, but not set error

### DIFF
--- a/dd-java-agent/instrumentation/spring-web/src/main/java/datadog/trace/instrumentation/springweb/SpringWebInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-web/src/main/java/datadog/trace/instrumentation/springweb/SpringWebInstrumentation.java
@@ -90,8 +90,10 @@ public final class SpringWebInstrumentation extends Instrumenter.Configurable {
       final Scope scope = GlobalTracer.get().scopeManager().active();
       if (scope != null && exception != null) {
         final Span span = scope.span();
-        Tags.ERROR.set(span, true);
         span.log(Collections.singletonMap(ERROR_OBJECT, exception));
+        // We want to capture the stacktrace, but that doesn't mean it should be an error.
+        // We rely on a decorator to set the error state based on response code. (5xx -> error)
+        Tags.ERROR.set(span, false);
       }
     }
   }

--- a/dd-java-agent/instrumentation/spring-web/src/test/groovy/test/SpringBootBasedTest.groovy
+++ b/dd-java-agent/instrumentation/spring-web/src/test/groovy/test/SpringBootBasedTest.groovy
@@ -205,7 +205,7 @@ class SpringBootBasedTest extends AgentTestRunner {
     span0.context().operationName == "servlet.request"
     span0.context().resourceName == "POST /validated"
     span0.context().spanType == DDSpanTypes.WEB_SERVLET
-    span0.context().getErrorFlag()
+    !span0.context().getErrorFlag() // This should be an error once we have the http status code decorator working.
     span0.context().parentId == 0
     span0.context().tags["http.url"] == "http://localhost:$port/validated"
     span0.context().tags["http.method"] == "POST"
@@ -215,7 +215,7 @@ class SpringBootBasedTest extends AgentTestRunner {
     span0.context().tags["http.status_code"] == 400
     span0.context().tags["thread.name"] != null
     span0.context().tags["thread.id"] != null
-    span0.context().tags["error"] == true
+//    span0.context().tags["error"] == true // This should be an error once we have the http status code decorator working.
     span0.context().tags["error.msg"].toString().startsWith("Validation failed")
     span0.context().tags["error.type"] == MethodArgumentNotValidException.getName()
     span0.context().tags["error.stack"] != null


### PR DESCRIPTION
We will rely on a decorator instead to do so.