### PR TITLE
Remove opentracing from TestRunner fields to support Idea single test run

### DIFF
--- a/dd-java-agent/instrumentation/jax-rs-annotations/src/test/groovy/JerseyTest.groovy
+++ b/dd-java-agent/instrumentation/jax-rs-annotations/src/test/groovy/JerseyTest.groovy
@@ -18,7 +18,7 @@ class JerseyTest extends AgentTestRunner {
   def "test resource"() {
     setup:
     // start a trace because the test doesn't go through any servlet or other instrumentation.
-    def scope = TEST_TRACER.buildSpan("test.span").startActive(true)
+    def scope = getTestTracer().buildSpan("test.span").startActive(true)
     def response = resources.client().resource("/test/hello/bob").post(String)
     scope.close()
 

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/src/test/groovy/KafkaStreamsTest.groovy
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/src/test/groovy/KafkaStreamsTest.groovy
@@ -62,7 +62,7 @@ class KafkaStreamsTest extends AgentTestRunner {
       @Override
       void onMessage(ConsumerRecord<String, String> record) {
         WRITER_PHASER.arriveAndAwaitAdvance() // ensure consistent ordering of traces
-        TEST_TRACER.activeSpan().setTag("testing", 123)
+        getTestTracer().activeSpan().setTag("testing", 123)
         records.add(record)
       }
     })
@@ -81,7 +81,7 @@ class KafkaStreamsTest extends AgentTestRunner {
       @Override
       String apply(String textLine) {
         WRITER_PHASER.arriveAndAwaitAdvance() // ensure consistent ordering of traces
-        TEST_TRACER.activeSpan().setTag("asdf", "testing")
+        getTestTracer().activeSpan().setTag("asdf", "testing")
         return textLine.toLowerCase()
       }
     })

--- a/dd-java-agent/testing/src/test/groovy/AgentTestRunnerTest.groovy
+++ b/dd-java-agent/testing/src/test/groovy/AgentTestRunnerTest.groovy
@@ -1,4 +1,5 @@
 import datadog.trace.agent.test.TestUtils
+import io.opentracing.Tracer
 
 import java.lang.reflect.Field
 
@@ -8,6 +9,8 @@ class AgentTestRunnerTest extends AgentTestRunner {
   private static final ClassLoader BOOTSTRAP_CLASSLOADER = null
   private static final ClassLoader OT_LOADER
   private static final boolean AGENT_INSTALLED_IN_CLINIT
+  // having opentracing class in test field should not cause problems
+  private static final Tracer A_TRACER = null
 
   static {
     // when test class initializes, opentracing should be set up, but not the agent.
@@ -17,9 +20,10 @@ class AgentTestRunnerTest extends AgentTestRunner {
 
   def "classpath setup"() {
     expect:
+    A_TRACER == null
     OT_LOADER == BOOTSTRAP_CLASSLOADER
     !AGENT_INSTALLED_IN_CLINIT
-    TEST_TRACER == TestUtils.getUnderlyingGlobalTracer()
+    getTestTracer() == TestUtils.getUnderlyingGlobalTracer()
     getAgentTransformer() != null
     datadog.trace.api.Trace.getClassLoader() == BOOTSTRAP_CLASSLOADER
   }


### PR DESCRIPTION
For single test runs in idea, Junit test runner loads all fields in AgentTestRunner before our bootstrap setup can take effect. Removing all bootstrap classes from the fields of AgentTestRunner works around the problem.