### PR TITLE
Add missing helper to servlet2 helper injector

### DIFF
--- a/dd-java-agent/instrumentation/servlet-2/src/main/java/datadog/trace/instrumentation/servlet2/FilterChain2Instrumentation.java
+++ b/dd-java-agent/instrumentation/servlet-2/src/main/java/datadog/trace/instrumentation/servlet2/FilterChain2Instrumentation.java
@@ -13,7 +13,6 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.DDAdvice;
 import datadog.trace.agent.tooling.DDTransformers;
-import datadog.trace.agent.tooling.HelperInjector;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.DDSpanTypes;
 import datadog.trace.api.DDTags;
@@ -49,11 +48,7 @@ public final class FilterChain2Instrumentation extends Instrumenter.Configurable
                 .and(
                     classLoaderHasClasses(
                         "javax.servlet.ServletContextEvent", "javax.servlet.ServletRequest")))
-        .transform(
-            new HelperInjector(
-                "io.opentracing.contrib.web.servlet.filter.HttpServletRequestExtractAdapter",
-                "io.opentracing.contrib.web.servlet.filter.HttpServletRequestExtractAdapter$MultivaluedMapFlatIterator",
-                "datadog.trace.instrumentation.servlet2.ServletFilterSpanDecorator"))
+        .transform(HttpServlet2Instrumentation.SERVLET2_HELPER_INJECTOR)
         .transform(DDTransformers.defaultTransformers())
         .transform(
             DDAdvice.create()

--- a/dd-java-agent/instrumentation/servlet-2/src/main/java/datadog/trace/instrumentation/servlet2/HttpServlet2Instrumentation.java
+++ b/dd-java-agent/instrumentation/servlet-2/src/main/java/datadog/trace/instrumentation/servlet2/HttpServlet2Instrumentation.java
@@ -35,6 +35,12 @@ import net.bytebuddy.asm.Advice;
 @AutoService(Instrumenter.class)
 public final class HttpServlet2Instrumentation extends Instrumenter.Configurable {
   public static final String SERVLET_OPERATION_NAME = "servlet.request";
+  static final HelperInjector SERVLET2_HELPER_INJECTOR =
+      new HelperInjector(
+          "io.opentracing.contrib.web.servlet.filter.HttpServletRequestExtractAdapter",
+          "io.opentracing.contrib.web.servlet.filter.HttpServletRequestExtractAdapter$MultivaluedMapFlatIterator",
+          "datadog.trace.instrumentation.servlet2.ServletFilterSpanDecorator",
+          "datadog.trace.instrumentation.servlet2.ServletFilterSpanDecorator$1");
 
   public HttpServlet2Instrumentation() {
     super("servlet", "servlet-2");
@@ -49,11 +55,7 @@ public final class HttpServlet2Instrumentation extends Instrumenter.Configurable
                 .and(
                     classLoaderHasClasses(
                         "javax.servlet.ServletContextEvent", "javax.servlet.FilterChain")))
-        .transform(
-            new HelperInjector(
-                "io.opentracing.contrib.web.servlet.filter.HttpServletRequestExtractAdapter",
-                "io.opentracing.contrib.web.servlet.filter.HttpServletRequestExtractAdapter$MultivaluedMapFlatIterator",
-                "datadog.trace.instrumentation.servlet2.ServletFilterSpanDecorator"))
+        .transform(SERVLET2_HELPER_INJECTOR)
         .transform(DDTransformers.defaultTransformers())
         .transform(
             DDAdvice.create(false) // Can't use the error handler for pre 1.5 classes...


### PR DESCRIPTION
* Add missing servlet2 helper class

There isn't a simple (non-contrived) way to assert this in a test. The existing servlet2 test passes because the classpath in junit can see the helper classes without injection.

The right way to test this is to hook up proper static analysis to the instrumentation.