### PR TITLE
Misc upgrades.

### DIFF
--- a/dd-java-agent/agent-bootstrap/agent-bootstrap.gradle
+++ b/dd-java-agent/agent-bootstrap/agent-bootstrap.gradle
@@ -9,7 +9,7 @@ dependencies {
   compile project(':dd-trace-api')
   compile deps.opentracing
   compile deps.slf4j
-  compile group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.25'
+  compile group: 'org.slf4j', name: 'slf4j-simple', version: versions.slf4j
   // ^ Generally a bad idea for libraries, but we're shadowing.
 }
 

--- a/dd-java-agent/dd-java-agent.gradle
+++ b/dd-java-agent/dd-java-agent.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.github.johnrengelman.shadow" version "2.0.1"
+  id "com.github.johnrengelman.shadow" version "2.0.3"
 }
 
 description = 'dd-java-agent'

--- a/dd-trace-java.gradle
+++ b/dd-trace-java.gradle
@@ -30,7 +30,7 @@ description = 'dd-trace-java'
 // Applied here to allow publishing of artifactory build info
 apply from: "${rootDir}/gradle/publish.gradle"
 
-ext.gradleWrapperVersion = '4.3.1'
+ext.gradleWrapperVersion = '4.6'
 task wrapper(type: Wrapper) {
   gradleVersion = gradleWrapperVersion
 }

--- a/examples/dropwizard-mongo-client/dropwizard-mongo-client.gradle
+++ b/examples/dropwizard-mongo-client/dropwizard-mongo-client.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.github.johnrengelman.shadow" version "2.0.1"
+  id "com.github.johnrengelman.shadow" version "2.0.3"
 }
 
 apply plugin: 'application'

--- a/examples/dropwizard-mongo-client/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/dropwizard-mongo-client/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.3.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-bin.zip

--- a/examples/rest-spark/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/rest-spark/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.3.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-bin.zip

--- a/examples/rest-spark/rest-spark.gradle
+++ b/examples/rest-spark/rest-spark.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.github.johnrengelman.shadow" version "2.0.1"
+  id "com.github.johnrengelman.shadow" version "2.0.3"
 }
 
 apply plugin: 'application'

--- a/examples/spring-boot-jdbc-redis/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/spring-boot-jdbc-redis/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.3.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-bin.zip

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -2,56 +2,58 @@ def groovyVer = GroovySystem.version
 def spockGroovyVer = GroovySystem.version.replaceAll(/\.\d+$/, '')
 
 ext {
-  version = [
+  versions = [
     opentracing: '0.31.0',
 
     slf4j      : "1.7.25",
-    guava      : "20.0",
-    jackson    : "2.6.3",
+    guava      : "20.0", // Last version to support Java 7
+    jackson    : "2.6.3", // This is a transitive dependency for the tracer.
+    // Use an old version to not force an upgrade for others using tracer as a dependency.
 
     spock      : "1.1-groovy-$spockGroovyVer",
     groovy     : groovyVer,
     junit      : "4.12",
     logback    : "1.2.3",
-    bytebuddy  : "1.7.9"
+    bytebuddy  : "1.7.11",  // Test failure when updating to 1.8.0.
   ]
 
   deps = [
     // OpenTracing
-    opentracingApi : dependencies.create(group: 'io.opentracing', name: 'opentracing-api', version: version.opentracing),
+    opentracingApi : dependencies.create(group: 'io.opentracing', name: 'opentracing-api', version: versions.opentracing),
     opentracing    : [
-      dependencies.create(group: 'io.opentracing', name: 'opentracing-api', version: version.opentracing),
-      dependencies.create(group: 'io.opentracing', name: 'opentracing-noop', version: version.opentracing),
-      dependencies.create(group: 'io.opentracing', name: 'opentracing-util', version: version.opentracing),
+      dependencies.create(group: 'io.opentracing', name: 'opentracing-api', version: versions.opentracing),
+      dependencies.create(group: 'io.opentracing', name: 'opentracing-noop', version: versions.opentracing),
+      dependencies.create(group: 'io.opentracing', name: 'opentracing-util', version: versions.opentracing),
     ],
-    opentracingMock: dependencies.create(group: 'io.opentracing', name: 'opentracing-mock', version: version.opentracing),
+    opentracingMock: dependencies.create(group: 'io.opentracing', name: 'opentracing-mock', version: versions.opentracing),
 
     // General
-    slf4j          : "org.slf4j:slf4j-api:${version.slf4j}",
-    guava          : "com.google.guava:guava:$version.guava",
+    slf4j          : "org.slf4j:slf4j-api:${versions.slf4j}",
+    guava          : "com.google.guava:guava:$versions.guava",
     jackson        : [
-      dependencies.create(group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: version.jackson),
-      dependencies.create(group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: version.jackson),
+      dependencies.create(group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: versions.jackson),
+      dependencies.create(group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: versions.jackson),
     ],
-    bytebuddy      : dependencies.create(group: 'net.bytebuddy', name: 'byte-buddy', version: "${version.bytebuddy}"),
+    bytebuddy      : dependencies.create(group: 'net.bytebuddy', name: 'byte-buddy', version: "${versions.bytebuddy}"),
     autoservice    : [
       dependencies.create(group: 'com.google.auto.service', name: 'auto-service', version: '1.0-rc3'),
-      dependencies.create(group: 'com.google.auto', name: 'auto-common', version: '0.3'),
-      dependencies.create(group: 'com.google.guava', name: 'guava', version: "${version.guava}"),
+      dependencies.create(group: 'com.google.auto', name: 'auto-common', version: '0.8'),
+      // These are the last versions that support guava 20.0.  Upgrading has odd interactions with shadow.
+      dependencies.create(group: 'com.google.guava', name: 'guava', version: "${versions.guava}"),
     ],
 
     // Testing
-    spock          : dependencies.create("org.spockframework:spock-core:${version.spock}", {
+    spock          : dependencies.create("org.spockframework:spock-core:${versions.spock}", {
       exclude group: "org.codehaus.groovy", module: "groovy-all"
     }),
-    bytebuddyagent : dependencies.create(group: 'net.bytebuddy', name: 'byte-buddy-agent', version: "${version.bytebuddy}"),
-    groovy         : "org.codehaus.groovy:groovy-all:${version.groovy}",
-    junit          : "junit:junit:${version.junit}",
+    bytebuddyagent : dependencies.create(group: 'net.bytebuddy', name: 'byte-buddy-agent', version: "${versions.bytebuddy}"),
+    groovy         : "org.codehaus.groovy:groovy-all:${versions.groovy}",
+    junit          : "junit:junit:${versions.junit}",
     testLogging    : [
-      dependencies.create(group: 'ch.qos.logback', name: 'logback-classic', version: version.logback),
-      dependencies.create(group: 'org.slf4j', name: 'log4j-over-slf4j', version: version.slf4j),
-      dependencies.create(group: 'org.slf4j', name: 'jcl-over-slf4j', version: version.slf4j),
-      dependencies.create(group: 'org.slf4j', name: 'jul-to-slf4j', version: version.slf4j),
+      dependencies.create(group: 'ch.qos.logback', name: 'logback-classic', version: versions.logback),
+      dependencies.create(group: 'org.slf4j', name: 'log4j-over-slf4j', version: versions.slf4j),
+      dependencies.create(group: 'org.slf4j', name: 'jcl-over-slf4j', version: versions.slf4j),
+      dependencies.create(group: 'org.slf4j', name: 'jul-to-slf4j', version: versions.slf4j),
     ],
   ]
 }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -14,7 +14,7 @@ ext {
     groovy     : groovyVer,
     junit      : "4.12",
     logback    : "1.2.3",
-    bytebuddy  : "1.7.11",  // Test failure when updating to 1.8.0.
+    bytebuddy  : "1.8.1",
   ]
 
   deps = [

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.3.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-bin.zip


### PR DESCRIPTION
When I tried upgrading to Byte Buddy 1.8.0 I get the following error in `JerseyTest`:

```
java.lang.ArrayIndexOutOfBoundsException: 1
	at net.bytebuddy.jar.asm.AnnotationWriter.computeParameterAnnotationsSize(AnnotationWriter.java:363)
	at net.bytebuddy.jar.asm.MethodWriter.computeMethodInfoSize(MethodWriter.java:2036)
	at net.bytebuddy.jar.asm.ClassWriter.toByteArray(ClassWriter.java:426)
	at net.bytebuddy.dynamic.scaffold.TypeWriter$Default$ForInlining.create(TypeWriter.java:2946)
	at net.bytebuddy.dynamic.scaffold.TypeWriter$Default.make(TypeWriter.java:1633)
	at net.bytebuddy.dynamic.scaffold.inline.RedefinitionDynamicTypeBuilder.make(RedefinitionDynamicTypeBuilder.java:171)
	at net.bytebuddy.agent.builder.AgentBuilder$Default$Transformation$Simple$Resolution.apply(AgentBuilder.java:8951)
	at net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer.doTransform(AgentBuilder.java:9352)
	at net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer.transform(AgentBuilder.java:9315)
	at net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer.access$1300(AgentBuilder.java:9093)
	at net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer$LegacyVmDispatcher.run(AgentBuilder.java:9671)
	at net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer$LegacyVmDispatcher.run(AgentBuilder.java:9621)
	at java.security.AccessController.doPrivileged(Native Method)
	at net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer.transform(AgentBuilder.java:9240)
	at sun.instrument.TransformerManager.transform(TransformerManager.java:188)
	at sun.instrument.InstrumentationImpl.transform(InstrumentationImpl.java:428)
	at sun.instrument.InstrumentationImpl.retransformClasses0(Native Method)
	at sun.instrument.InstrumentationImpl.retransformClasses(InstrumentationImpl.java:144)
	at net.bytebuddy.agent.builder.AgentBuilder$RedefinitionStrategy$Collector$ForRetransformation.doApply(AgentBuilder.java:6216)
	at net.bytebuddy.agent.builder.AgentBuilder$RedefinitionStrategy$Collector.apply(AgentBuilder.java:6071)
	at net.bytebuddy.agent.builder.AgentBuilder$RedefinitionStrategy.apply(AgentBuilder.java:4252)
	at net.bytebuddy.agent.builder.AgentBuilder$Default.installOn(AgentBuilder.java:8307)
	at net.bytebuddy.agent.builder.AgentBuilder$Default$Delegator.installOn(AgentBuilder.java:10006)
	at datadog.trace.agent.tooling.AgentInstaller.installBytebuddyAgent(AgentInstaller.java:71)
	at datadog.trace.agent.test.AgentTestRunner.agentSetup(AgentTestRunner.java:105)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.spockframework.util.ReflectionUtil.invokeMethod(ReflectionUtil.java:188)
	at org.spockframework.runtime.model.MethodInfo.invoke(MethodInfo.java:84)
...
```

As a result, I'm leaving it at 1.7.11.

cc/ @raphw