### PR TITLE
Clean up version logging and name start timestamp unit correctly

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/TracerInstaller.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/TracerInstaller.java
@@ -1,8 +1,6 @@
 package datadog.trace.agent.tooling;
 
-import datadog.opentracing.DDTraceOTInfo;
 import datadog.opentracing.DDTracer;
-import datadog.trace.api.DDTraceApiInfo;
 import io.opentracing.Tracer;
 import io.opentracing.util.GlobalTracer;
 import lombok.extern.slf4j.Slf4j;
@@ -24,11 +22,7 @@ public class TracerInstaller {
   }
 
   public static void logVersionInfo() {
-    // version classes log important info
-    // in static initializers
-    final String s = DDTraceOTInfo.VERSION.toString();
-    final String s1 = DDTraceApiInfo.VERSION.toString();
-    final String s2 = DDJavaAgentInfo.VERSION.toString();
+    VersionLogger.logAllVersions();
     log.debug(GlobalTracer.class.getName() + " loaded on " + GlobalTracer.class.getClassLoader());
     log.debug(
         AgentInstaller.class.getName() + " loaded on " + AgentInstaller.class.getClassLoader());

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/VersionLogger.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/VersionLogger.java
@@ -1,0 +1,47 @@
+package datadog.trace.agent.tooling;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class VersionLogger {
+
+  /** Log version strings for dd-trace-ot, dd-trace-pai, and dd-java-agent */
+  public static void logAllVersions() {
+    log.info(
+        "dd-trace-ot - version: {}",
+        getVersionString(Utils.getAgentClassLoader().getResourceAsStream("dd-trace-ot.version")));
+    log.info(
+        "dd-trace-api - version: {}",
+        getVersionString(Utils.getAgentClassLoader().getResourceAsStream("dd-trace-api.version")));
+    log.info(
+        "dd-java-agent - version: {}",
+        getVersionString(
+            ClassLoader.getSystemClassLoader().getResourceAsStream("dd-java-agent.version")));
+  }
+
+  private static String getVersionString(InputStream stream) {
+    String v;
+    try {
+      final StringBuilder sb = new StringBuilder();
+      final BufferedReader br = new BufferedReader(new InputStreamReader(stream, "UTF-8"));
+      for (int c = br.read(); c != -1; c = br.read()) sb.append((char) c);
+
+      v = sb.toString().trim();
+    } catch (final Exception e) {
+      log.error("failed to read version stream", e);
+      v = "unknown";
+    } finally {
+      try {
+        if (null != stream) {
+          stream.close();
+        }
+      } catch (IOException e) {
+      }
+    }
+    return v;
+  }
+}

--- a/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
@@ -330,7 +330,7 @@ public class DDTracer implements io.opentracing.Tracer {
     // Builder attributes
     private Map<String, Object> tags =
         spanTags.isEmpty() ? Collections.<String, Object>emptyMap() : Maps.newHashMap(spanTags);
-    private long timestamp;
+    private long timestampMicro;
     private SpanContext parent;
     private String serviceName;
     private String resourceName;
@@ -350,7 +350,7 @@ public class DDTracer implements io.opentracing.Tracer {
     }
 
     private DDSpan startSpan() {
-      final DDSpan span = new DDSpan(this.timestamp, buildSpanContext());
+      final DDSpan span = new DDSpan(this.timestampMicro, buildSpanContext());
       if (DDTracer.this.sampler instanceof RateByServiceSampler) {
         ((RateByServiceSampler) DDTracer.this.sampler).initializeSamplingPriority(span);
       }
@@ -402,8 +402,8 @@ public class DDTracer implements io.opentracing.Tracer {
     }
 
     @Override
-    public DDSpanBuilder withStartTimestamp(final long timestampMillis) {
-      this.timestamp = timestampMillis;
+    public DDSpanBuilder withStartTimestamp(final long timestampMicroseconds) {
+      this.timestampMicro = timestampMicroseconds;
       return this;
     }
 


### PR DESCRIPTION
* Move java-agent version logging to a location where all version files are visible
* Rename withStartTimestamp param to timestampMicroseconds

@palazzem From our troubleshooting session earlier today.

It turns out we actually are expecting microseconds to `withStartTimestamp`; the parameter name was misleading.