### PR TITLE
Handle spans registered after trace is written

### DIFF
--- a/dd-trace-ot/src/main/java/datadog/opentracing/PendingTrace.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/PendingTrace.java
@@ -75,7 +75,7 @@ public class PendingTrace extends ConcurrentLinkedDeque<DDSpan> {
 
   public void addSpan(final DDSpan span) {
     if (span.getDurationNano() == 0) {
-      log.warn("{} - added to trace, but not complete.", span);
+      log.debug("{} - added to trace, but not complete.", span);
       return;
     }
     if (traceId != span.getTraceId()) {
@@ -85,10 +85,10 @@ public class PendingTrace extends ConcurrentLinkedDeque<DDSpan> {
 
     if (!isWritten.get()) {
       addFirst(span);
-      expireSpan(span);
     } else {
-      log.warn("{} - finished after trace reported.", span);
+      log.debug("{} - finished after trace reported.", span);
     }
+    expireSpan(span);
   }
 
   /**

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/PendingTraceTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/PendingTraceTest.groovy
@@ -142,4 +142,20 @@ class PendingTraceTest extends Specification {
     otherTrace.weakReferences.size() == 0
     otherTrace.asList() == []
   }
+
+
+  def "child spans created after trace written" () {
+    setup:
+    rootSpan.finish()
+    // this shouldn't happen, but it's possible users of the api
+    // may incorrectly add spans after the trace is reported.
+    // in those cases we should still decrement the pending trace count
+    DDSpan childSpan = tracer.buildSpan("child").asChildOf(rootSpan).start()
+    childSpan.finish()
+
+    expect:
+    trace.pendingReferenceCount.get() == 0
+    trace.asList() == [rootSpan]
+    writer == [[rootSpan]]
+  }
 }


### PR DESCRIPTION
Decrement the pending trace count when spans are registered after a
trace writes. Log certain pending trace messages at debug.