### PR TITLE
Enable executor instrumentation by default

### DIFF
--- a/dd-java-agent/instrumentation/java-concurrent/akka-testing/src/test/groovy/AkkaActorTest.groovy
+++ b/dd-java-agent/instrumentation/java-concurrent/akka-testing/src/test/groovy/AkkaActorTest.groovy
@@ -3,9 +3,6 @@ import datadog.trace.agent.test.AgentTestRunner
 import spock.lang.Unroll
 
 class AkkaActorTest extends AgentTestRunner {
-  static {
-    System.setProperty("dd.integration.java_concurrent.enabled", "true")
-  }
 
   @Override
   void afterTest() {

--- a/dd-java-agent/instrumentation/java-concurrent/scala-testing/src/test/groovy/ScalaInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/java-concurrent/scala-testing/src/test/groovy/ScalaInstrumentationTest.groovy
@@ -2,10 +2,6 @@ import datadog.opentracing.DDSpan
 import datadog.trace.agent.test.AgentTestRunner
 
 class ScalaInstrumentationTest extends AgentTestRunner {
-  static {
-    System.setProperty("dd.integration.java_concurrent.enabled", "true")
-  }
-
   @Override
   void afterTest() {
     // Ignore failures to instrument sun proxy classes

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/ExecutorInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/ExecutorInstrumentation.java
@@ -87,11 +87,6 @@ public final class ExecutorInstrumentation extends Instrumenter.Configurable {
   }
 
   @Override
-  protected boolean defaultEnabled() {
-    return false;
-  }
-
-  @Override
   public AgentBuilder apply(final AgentBuilder agentBuilder) {
     return agentBuilder
         .type(not(isInterface()).and(hasSuperType(named(Executor.class.getName()))))

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/FutureInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/FutureInstrumentation.java
@@ -70,11 +70,6 @@ public final class FutureInstrumentation extends Instrumenter.Configurable {
   }
 
   @Override
-  protected boolean defaultEnabled() {
-    return false;
-  }
-
-  @Override
   public AgentBuilder apply(final AgentBuilder agentBuilder) {
     return agentBuilder
         .type(not(isInterface()).and(hasSuperType(named(Future.class.getName()))))

--- a/dd-java-agent/instrumentation/play-2.4/play-2.6-testing/src/test/groovy/Play26Test.groovy
+++ b/dd-java-agent/instrumentation/play-2.4/play-2.6-testing/src/test/groovy/Play26Test.groovy
@@ -9,7 +9,6 @@ import spock.lang.Shared
 
 class Play26Test extends AgentTestRunner {
   static {
-    System.setProperty("dd.integration.java_concurrent.enabled", "true")
     System.setProperty("dd.integration.play.enabled", "true")
   }
 

--- a/dd-java-agent/instrumentation/play-2.4/src/test/groovy/Play24Test.groovy
+++ b/dd-java-agent/instrumentation/play-2.4/src/test/groovy/Play24Test.groovy
@@ -9,7 +9,6 @@ import spock.lang.Shared
 
 class Play24Test extends AgentTestRunner {
   static {
-    System.setProperty("dd.integration.java_concurrent.enabled", "true")
     System.setProperty("dd.integration.play.enabled", "true")
   }
 


### PR DESCRIPTION
Executor instrumentation does not need to be turned off by default
because the instrumentation will not apply unless the TraceScope is
activated.