### PR TITLE
Fix NoClassDefFound errors for ratpack

### DIFF
--- a/dd-java-agent/instrumentation/ratpack-1.4/src/main/java/datadog/trace/instrumentation/ratpack/RatpackHttpClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/ratpack-1.4/src/main/java/datadog/trace/instrumentation/ratpack/RatpackHttpClientInstrumentation.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.ratpack;
 
+import static datadog.trace.instrumentation.ratpack.RatpackInstrumentation.ROOT_RATPACK_HELPER_INJECTOR;
 import static net.bytebuddy.matcher.ElementMatchers.hasSuperType;
 import static net.bytebuddy.matcher.ElementMatchers.isInterface;
 import static net.bytebuddy.matcher.ElementMatchers.named;
@@ -22,7 +23,12 @@ public final class RatpackHttpClientInstrumentation extends Instrumenter.Configu
       new HelperInjector(
           "datadog.trace.instrumentation.ratpack.impl.RatpackHttpClientAdvice$RatpackHttpClientRequestAdvice",
           "datadog.trace.instrumentation.ratpack.impl.RatpackHttpClientAdvice$RatpackHttpClientRequestStreamAdvice",
-          "datadog.trace.instrumentation.ratpack.impl.RatpackHttpClientAdvice$RatpackHttpGetAdvice");
+          "datadog.trace.instrumentation.ratpack.impl.RatpackHttpClientAdvice$RatpackHttpGetAdvice",
+          "datadog.trace.instrumentation.ratpack.impl.RatpackHttpClientAdvice$RequestAction",
+          "datadog.trace.instrumentation.ratpack.impl.RatpackHttpClientAdvice$ResponseAction",
+          "datadog.trace.instrumentation.ratpack.impl.RatpackHttpClientAdvice$StreamedResponseAction",
+          "datadog.trace.instrumentation.ratpack.impl.RequestSpecInjectAdapter",
+          "datadog.trace.instrumentation.ratpack.impl.WrappedRequestSpec");
   public static final TypeDescription.ForLoadedType URI_TYPE_DESCRIPTION =
       new TypeDescription.ForLoadedType(URI.class);
 
@@ -42,6 +48,7 @@ public final class RatpackHttpClientInstrumentation extends Instrumenter.Configu
         .type(
             not(isInterface()).and(hasSuperType(named("ratpack.http.client.HttpClient"))),
             RatpackInstrumentation.CLASSLOADER_CONTAINS_RATPACK_1_4_OR_ABOVE)
+        .transform(ROOT_RATPACK_HELPER_INJECTOR)
         .transform(HTTP_CLIENT_HELPER_INJECTOR)
         .transform(
             DDAdvice.create()

--- a/dd-java-agent/instrumentation/ratpack-1.4/src/main/java/datadog/trace/instrumentation/ratpack/RatpackInstrumentation.java
+++ b/dd-java-agent/instrumentation/ratpack-1.4/src/main/java/datadog/trace/instrumentation/ratpack/RatpackInstrumentation.java
@@ -19,11 +19,18 @@ import net.bytebuddy.matcher.ElementMatcher;
 public final class RatpackInstrumentation extends Instrumenter.Configurable {
 
   static final String EXEC_NAME = "ratpack";
+
+  static final HelperInjector ROOT_RATPACK_HELPER_INJECTOR =
+      new HelperInjector(
+          "datadog.opentracing.scopemanager.ContextualScopeManager",
+          "datadog.opentracing.scopemanager.ScopeContext");
+
   private static final HelperInjector SERVER_REGISTRY_HELPER_INJECTOR =
       new HelperInjector(
+          "datadog.trace.instrumentation.ratpack.impl.RatpackRequestExtractAdapter",
           "datadog.trace.instrumentation.ratpack.impl.RatpackScopeManager",
-          "datadog.trace.instrumentation.ratpack.impl.TracingHandler",
-          "datadog.trace.instrumentation.ratpack.impl.RatpackServerAdvice$RatpackServerRegistryAdvice");
+          "datadog.trace.instrumentation.ratpack.impl.RatpackServerAdvice$RatpackServerRegistryAdvice",
+          "datadog.trace.instrumentation.ratpack.impl.TracingHandler");
   private static final HelperInjector EXEC_STARTER_HELPER_INJECTOR =
       new HelperInjector(
           "datadog.trace.instrumentation.ratpack.impl.RatpackServerAdvice$ExecStarterAdvice",
@@ -52,6 +59,7 @@ public final class RatpackInstrumentation extends Instrumenter.Configurable {
         .type(
             named("ratpack.server.internal.ServerRegistry"),
             CLASSLOADER_CONTAINS_RATPACK_1_4_OR_ABOVE)
+        .transform(ROOT_RATPACK_HELPER_INJECTOR)
         .transform(SERVER_REGISTRY_HELPER_INJECTOR)
         .transform(
             DDAdvice.create()
@@ -62,6 +70,7 @@ public final class RatpackInstrumentation extends Instrumenter.Configurable {
         .type(
             not(isInterface()).and(hasSuperType(named("ratpack.exec.ExecStarter"))),
             CLASSLOADER_CONTAINS_RATPACK_1_4_OR_ABOVE)
+        .transform(ROOT_RATPACK_HELPER_INJECTOR)
         .transform(EXEC_STARTER_HELPER_INJECTOR)
         .transform(
             DDAdvice.create()

--- a/dd-java-agent/instrumentation/ratpack-1.4/src/main/java8/datadog/trace/instrumentation/ratpack/impl/RatpackRequestExtractAdapter.java
+++ b/dd-java-agent/instrumentation/ratpack-1.4/src/main/java8/datadog/trace/instrumentation/ratpack/impl/RatpackRequestExtractAdapter.java
@@ -1,25 +1,24 @@
 package datadog.trace.instrumentation.ratpack.impl;
 
-import com.google.common.collect.ListMultimap;
 import io.opentracing.propagation.TextMap;
-import java.util.Iterator;
-import java.util.Map;
+import java.util.*;
 import ratpack.http.Request;
+import ratpack.util.MultiValueMap;
 
 /**
  * Simple request extractor in the same vein as @see
  * io.opentracing.contrib.web.servlet.filter.HttpServletRequestExtractAdapter
  */
 public class RatpackRequestExtractAdapter implements TextMap {
-  private final ListMultimap<String, String> headers;
+  private final MultiValueMap<String, String> headers;
 
   RatpackRequestExtractAdapter(Request request) {
-    this.headers = request.getHeaders().asMultiValueMap().asMultimap();
+    this.headers = request.getHeaders().asMultiValueMap();
   }
 
   @Override
   public Iterator<Map.Entry<String, String>> iterator() {
-    return headers.entries().iterator();
+    return headers.entrySet().iterator();
   }
 
   @Override


### PR DESCRIPTION
This PR fixes #300 removing Google Collections runtime and adding all the necessary HelperInjector classes.

I have verified that this works in a real world Ratpack application (not just those in the integration tests)