### PR TITLE
Remove dependency on guava for dd-trace-ot

### DIFF
--- a/dd-trace-ot/dd-trace-ot.gradle
+++ b/dd-trace-ot/dd-trace-ot.gradle
@@ -27,15 +27,17 @@ testSets {
 }
 
 dependencies {
+  compile deps.autoservice
+  
   compile project(':dd-trace-api')
   compile deps.opentracing
   compile group: 'io.opentracing.contrib', name: 'opentracing-tracerresolver', version: '0.1.0'
 
   compile deps.jackson
   compile deps.slf4j
-  compile deps.autoservice
   compile group: 'org.msgpack', name: 'jackson-dataformat-msgpack', version: '0.8.2'
 
+  testCompile deps.autoservice
   testCompile group: 'org.objenesis', name: 'objenesis', version: '2.6'
   testCompile group: 'cglib', name: 'cglib-nodep', version: '3.2.5'
   testCompile 'com.github.stefanbirkner:system-rules:1.17.1'

--- a/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
@@ -1,7 +1,5 @@
 package datadog.opentracing;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import datadog.opentracing.decorators.AbstractDecorator;
 import datadog.opentracing.decorators.DDDecoratorsFactory;
 import datadog.opentracing.propagation.Codec;
@@ -244,13 +242,13 @@ public class DDTracer implements io.opentracing.Tracer {
     }
     final ArrayList<DDSpan> writtenTrace;
     if (interceptors.isEmpty()) {
-      writtenTrace = Lists.newArrayList(trace);
+      writtenTrace = new ArrayList<>(trace);
     } else {
-      Collection<? extends MutableSpan> interceptedTrace = Lists.newArrayList(trace);
+      Collection<? extends MutableSpan> interceptedTrace = new ArrayList<>(trace);
       for (final TraceInterceptor interceptor : interceptors) {
         interceptedTrace = interceptor.onTraceComplete(interceptedTrace);
       }
-      writtenTrace = Lists.newArrayListWithExpectedSize(interceptedTrace.size());
+      writtenTrace = new ArrayList<>(interceptedTrace.size());
       for (final MutableSpan span : interceptedTrace) {
         if (span instanceof DDSpan) {
           writtenTrace.add((DDSpan) span);
@@ -304,7 +302,7 @@ public class DDTracer implements io.opentracing.Tracer {
 
     // Builder attributes
     private Map<String, Object> tags =
-        spanTags.isEmpty() ? Collections.<String, Object>emptyMap() : Maps.newHashMap(spanTags);
+        spanTags.isEmpty() ? Collections.<String, Object>emptyMap() : new HashMap<>(spanTags);
     private long timestampMicro;
     private SpanContext parent;
     private String serviceName;
@@ -429,7 +427,7 @@ public class DDTracer implements io.opentracing.Tracer {
     // Private methods
     private DDSpanBuilder withTag(final String tag, final Object value) {
       if (this.tags.isEmpty()) {
-        this.tags = Maps.newHashMap();
+        this.tags = new HashMap<>();
       }
       this.tags.put(tag, value);
       return this;

--- a/dd-trace-ot/src/main/java/datadog/trace/common/DDTraceConfig.java
+++ b/dd-trace-ot/src/main/java/datadog/trace/common/DDTraceConfig.java
@@ -1,10 +1,10 @@
 package datadog.trace.common;
 
-import com.google.common.collect.Maps;
 import datadog.opentracing.DDTracer;
 import datadog.trace.common.writer.DDAgentWriter;
 import datadog.trace.common.writer.Writer;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import lombok.extern.slf4j.Slf4j;
@@ -84,7 +84,7 @@ public class DDTraceConfig extends Properties {
     }
 
     final String[] tokens = str.split(",");
-    final Map<String, Object> map = Maps.newHashMapWithExpectedSize(tokens.length);
+    final Map<String, Object> map = new HashMap<>(tokens.length + 1, 1f);
 
     for (final String token : tokens) {
       final String[] keyValue = token.split(":");

--- a/dd-trace-ot/src/main/java/datadog/trace/common/writer/DDAgentWriter.java
+++ b/dd-trace-ot/src/main/java/datadog/trace/common/writer/DDAgentWriter.java
@@ -1,7 +1,5 @@
 package datadog.trace.common.writer;
 
-import com.google.auto.service.AutoService;
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import datadog.opentracing.DDSpan;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -25,7 +23,6 @@ import lombok.extern.slf4j.Slf4j;
  * spans.
  */
 @Slf4j
-@AutoService(Writer.class)
 public class DDAgentWriter implements Writer {
 
   /** Default location of the DD agent */
@@ -43,7 +40,14 @@ public class DDAgentWriter implements Writer {
   static final long FLUSH_TIME_SECONDS = 1;
 
   private final ThreadFactory agentWriterThreadFactory =
-      new ThreadFactoryBuilder().setNameFormat("dd-agent-writer-%d").setDaemon(true).build();
+      new ThreadFactory() {
+        @Override
+        public Thread newThread(final Runnable r) {
+          final Thread thread = new Thread(r, "dd-agent-writer");
+          thread.setDaemon(true);
+          return thread;
+        }
+      };
 
   /** Scheduled thread pool, acting like a cron */
   private final ScheduledExecutorService scheduledExecutor =

--- a/dd-trace-ot/src/main/java/datadog/trace/common/writer/LoggingWriter.java
+++ b/dd-trace-ot/src/main/java/datadog/trace/common/writer/LoggingWriter.java
@@ -1,13 +1,11 @@
 package datadog.trace.common.writer;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.auto.service.AutoService;
 import datadog.opentracing.DDSpan;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-@AutoService(Writer.class)
 public class LoggingWriter implements Writer {
   private final ObjectMapper serializer = new ObjectMapper();
 


### PR DESCRIPTION
I assumed a low guava version was a big deal as long as it updated seamlessly.  This should remove that concern.

Closes #292

/cc @nhoughto