### PR TITLE
Use bytebuddy-gradle-plugin to hook up Instrumentation Muzzle

### DIFF
--- a/dd-java-agent-ittests/src/test/groovy/datadog/trace/agent/integration/classloading/ShadowPackageRenamingTest.groovy
+++ b/dd-java-agent-ittests/src/test/groovy/datadog/trace/agent/integration/classloading/ShadowPackageRenamingTest.groovy
@@ -57,7 +57,7 @@ class ShadowPackageRenamingTest extends Specification {
    setup:
    final ClassPath agentClasspath = ClassPath.from(IntegrationTestUtils.getAgentClassLoader())
 
-   final ClassPath bootstrapClasspath = ClassPath.from(IntegrationTestUtils.getBootstrapResourceLocator())
+   final ClassPath bootstrapClasspath = ClassPath.from(IntegrationTestUtils.getBootstrapProxy())
    final Set<String> bootstrapClasses = new HashSet<>()
    final String[] bootstrapPrefixes = IntegrationTestUtils.getBootstrapPackagePrefixes()
    final String[] agentPrefixes = IntegrationTestUtils.getAgentPackagePrefixes()

--- a/dd-java-agent-ittests/src/test/groovy/datadog/trace/agent/integration/muzzle/MuzzleBytecodeTransformTest.groovy
+++ b/dd-java-agent-ittests/src/test/groovy/datadog/trace/agent/integration/muzzle/MuzzleBytecodeTransformTest.groovy
@@ -1,0 +1,23 @@
+package datadog.trace.agent.integration.muzzle
+
+import datadog.trace.agent.test.IntegrationTestUtils
+import spock.lang.Specification
+
+
+class MuzzleBytecodeTransformTest extends Specification {
+
+  def "muzzle fields added to all instrumentation"() {
+    setup:
+    List<Class> unMuzzledClasses = []
+    for (final Object instrumenter : ServiceLoader.load(IntegrationTestUtils.getAgentClassLoader().loadClass("datadog.trace.agent.tooling.Instrumenter"), IntegrationTestUtils.getAgentClassLoader())) {
+      try {
+        instrumenter.getClass().getDeclaredField("referenceMatcher")
+      } catch(NoSuchFieldException nsfe) {
+        unMuzzledClasses.add(instrumenter.getClass())
+      }
+    }
+    expect:
+    unMuzzledClasses == []
+  }
+
+}

--- a/dd-java-agent-ittests/src/test/groovy/datadog/trace/agent/integration/muzzle/MuzzleBytecodeTransformTest.groovy
+++ b/dd-java-agent-ittests/src/test/groovy/datadog/trace/agent/integration/muzzle/MuzzleBytecodeTransformTest.groovy
@@ -11,7 +11,7 @@ class MuzzleBytecodeTransformTest extends Specification {
     List<Class> unMuzzledClasses = []
     for (final Object instrumenter : ServiceLoader.load(IntegrationTestUtils.getAgentClassLoader().loadClass("datadog.trace.agent.tooling.Instrumenter"), IntegrationTestUtils.getAgentClassLoader())) {
       try {
-        instrumenter.getClass().getDeclaredField("referenceMatcher")
+        instrumenter.getClass().getDeclaredField("instrumentationMuzzle")
       } catch(NoSuchFieldException nsfe) {
         unMuzzledClasses.add(instrumenter.getClass())
       }

--- a/dd-java-agent-ittests/src/test/java/datadog/trace/agent/test/IntegrationTestUtils.java
+++ b/dd-java-agent-ittests/src/test/java/datadog/trace/agent/test/IntegrationTestUtils.java
@@ -49,9 +49,9 @@ public class IntegrationTestUtils {
   }
 
   /** Returns the URL to the jar the agent appended to the bootstrap classpath * */
-  public static ClassLoader getBootstrapResourceLocator() throws Exception {
+  public static ClassLoader getBootstrapProxy() throws Exception {
     final ClassLoader agentClassLoader = getAgentClassLoader();
-    final Field field = agentClassLoader.getClass().getDeclaredField("bootstrapResourceLocator");
+    final Field field = agentClassLoader.getClass().getDeclaredField("bootstrapProxy");
     try {
       field.setAccessible(true);
       return (ClassLoader) field.get(agentClassLoader);

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/DatadogClassLoader.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/DatadogClassLoader.java
@@ -39,7 +39,8 @@ public class DatadogClassLoader extends URLClassLoader {
   }
 
   /**
-   * A stand-in for the bootstrap classloader. Used to look up bootstrap resources and resources appended by instrumentation.
+   * A stand-in for the bootstrap classloader. Used to look up bootstrap resources and resources
+   * appended by instrumentation.
    *
    * <p>This class is thread safe.
    */

--- a/dd-java-agent/agent-tooling/agent-tooling.gradle
+++ b/dd-java-agent/agent-tooling/agent-tooling.gradle
@@ -4,6 +4,11 @@ whitelistedInstructionClasses += whitelistedBranchClasses += [
   'datadog.trace.agent.tooling.*'
 ]
 
+configurations {
+  // classpath used by the instrumentation muzzle plugin
+  instrumentationMuzzle
+}
+
 dependencies {
   compile project(':dd-java-agent:agent-bootstrap')
   compile deps.bytebuddy
@@ -14,4 +19,7 @@ dependencies {
   compileOnly project(':dd-trace-ot')
 
   testCompile deps.opentracing
+
+  instrumentationMuzzle sourceSets.main.output
+  instrumentationMuzzle configurations.compile
 }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
@@ -7,6 +7,8 @@ import static net.bytebuddy.matcher.ElementMatchers.nameMatches;
 import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;
 import static net.bytebuddy.matcher.ElementMatchers.not;
 
+import datadog.trace.agent.tooling.muzzle.Reference.Mismatch;
+import datadog.trace.agent.tooling.muzzle.ReferenceMatcher.MismatchException;
 import java.lang.instrument.Instrumentation;
 import java.util.ServiceLoader;
 import lombok.extern.slf4j.Slf4j;
@@ -82,7 +84,15 @@ public class AgentInstaller {
         final JavaModule module,
         final boolean loaded,
         final Throwable throwable) {
-      log.debug("Failed to handle {} for transformation: {}", typeName, throwable.getMessage());
+      if (throwable instanceof MismatchException) {
+        final MismatchException mismatchException = (MismatchException) throwable;
+        log.debug("{}", mismatchException.getMessage());
+        for (Mismatch mismatch : mismatchException.getMismatches()) {
+          log.debug("--{}", mismatch);
+        }
+      } else {
+        log.debug("Failed to handle {} for transformation: {}", typeName, throwable.getMessage());
+      }
     }
 
     @Override

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/HelperInjector.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/HelperInjector.java
@@ -4,7 +4,13 @@ import static datadog.trace.agent.tooling.ClassLoaderMatcher.BOOTSTRAP_CLASSLOAD
 
 import java.io.File;
 import java.io.IOException;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import net.bytebuddy.agent.builder.AgentBuilder.Transformer;
 import net.bytebuddy.description.type.TypeDescription;

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/AdviceReferenceVisitor.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/AdviceReferenceVisitor.java
@@ -85,7 +85,7 @@ public class AdviceReferenceVisitor extends ClassVisitor {
     final Set<String> visitedSources = new HashSet<String>();
     final Map<String, Reference> references = new HashMap<>();
 
-    final Queue<String> instrumentationQueue = new LinkedList<>();
+    final Queue<String> instrumentationQueue = new ArrayDeque<>();
     instrumentationQueue.add(entryPointClassName);
 
     while (!instrumentationQueue.isEmpty()) {

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/AdviceReferenceVisitor.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/AdviceReferenceVisitor.java
@@ -1,0 +1,128 @@
+package datadog.trace.agent.tooling.muzzle;
+
+import datadog.trace.agent.tooling.Utils;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.*;
+import net.bytebuddy.jar.asm.*;
+
+/** Visit a class and collect all references made by the visited class. */
+public class AdviceReferenceVisitor extends ClassVisitor {
+  private Map<String, Reference> references = new HashMap<>();
+  private String refSourceClassName;
+
+  public AdviceReferenceVisitor(ClassVisitor classVisitor) {
+    super(Opcodes.ASM6, classVisitor);
+  }
+
+  public Map<String, Reference> getReferences() {
+    return references;
+  }
+
+  private void addReference(Reference ref) {
+    if (references.containsKey(ref.getClassName())) {
+      references.put(ref.getClassName(), references.get(ref.getClassName()).merge(ref));
+    } else {
+      references.put(ref.getClassName(), ref);
+    }
+  }
+
+  @Override
+  public void visit(
+      final int version,
+      final int access,
+      final String name,
+      final String signature,
+      final String superName,
+      final String[] interfaces) {
+    refSourceClassName = Utils.getClassName(name);
+    super.visit(version, access, name, signature, superName, interfaces);
+  }
+
+  @Override
+  public MethodVisitor visitMethod(
+      final int access,
+      final String name,
+      final String descriptor,
+      final String signature,
+      final String[] exceptions) {
+    return new AdviceReferenceMethodVisitor(
+        super.visitMethod(access, name, descriptor, signature, exceptions));
+  }
+
+  private class AdviceReferenceMethodVisitor extends MethodVisitor {
+    private boolean isAdviceMethod = false;
+    private int currentLineNumber = -1;
+
+    public AdviceReferenceMethodVisitor(MethodVisitor methodVisitor) {
+      super(Opcodes.ASM6, methodVisitor);
+    }
+
+    @Override
+    public void visitLineNumber(final int line, final Label start) {
+      currentLineNumber = line;
+      super.visitLineNumber(line, start);
+    }
+
+    @Override
+    public void visitMethodInsn(
+        final int opcode,
+        final String owner,
+        final String name,
+        final String descriptor,
+        final boolean isInterface) {
+      addReference(
+          new Reference(
+              new Reference.Source[] {new Reference.Source(refSourceClassName, currentLineNumber)},
+              Utils.getClassName(owner),
+              null,
+              null));
+    }
+  }
+
+  public static Map<String, Reference> createReferencesFrom(
+      String entryPointClassName, ClassLoader loader) {
+    final Set<String> visitedSources = new HashSet<String>();
+    final Map<String, Reference> references = new HashMap<>();
+
+    final Queue<String> instrumentationQueue = new LinkedList<>();
+    instrumentationQueue.add(entryPointClassName);
+
+    while (!instrumentationQueue.isEmpty()) {
+      final String className = instrumentationQueue.remove();
+      visitedSources.add(className);
+      try {
+        final InputStream in =
+            ReferenceMatcher.class
+                .getClassLoader()
+                .getResourceAsStream(Utils.getResourceName(className));
+        try {
+          final AdviceReferenceVisitor cv = new AdviceReferenceVisitor(null);
+          final ClassReader reader = new ClassReader(in);
+          reader.accept(cv, ClassReader.SKIP_FRAMES);
+
+          Map<String, Reference> instrumentationReferences = cv.getReferences();
+          for (Map.Entry<String, Reference> entry : instrumentationReferences.entrySet()) {
+            // TODO: expose config instead of hardcoding datadog instrumentation namespace
+            if (!visitedSources.contains(entry.getKey())
+                && entry.getKey().startsWith("datadog.trace.instrumentation.")) {
+              instrumentationQueue.add(entry.getKey());
+            }
+            if (references.containsKey(entry.getKey())) {
+              references.put(
+                  entry.getKey(), references.get(entry.getKey()).merge(entry.getValue()));
+            } else {
+              references.put(entry.getKey(), entry.getValue());
+            }
+          }
+
+        } finally {
+          in.close();
+        }
+      } catch (IOException ioe) {
+        throw new IllegalStateException(ioe);
+      }
+    }
+    return references;
+  }
+}

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/MuzzleGradlePlugin.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/MuzzleGradlePlugin.java
@@ -1,0 +1,60 @@
+package datadog.trace.agent.tooling.muzzle;
+
+import datadog.trace.agent.tooling.Instrumenter;
+import net.bytebuddy.build.Plugin;
+import net.bytebuddy.description.type.TypeDefinition;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.dynamic.DynamicType.Builder;
+
+public class MuzzleGradlePlugin implements Plugin {
+  // TODO:
+  // - PR1
+  //   - Make errorprone happy
+  //   - Unit tests
+  //   - Review design and ease of adding future features
+  //     - better checking
+  //     - versionScan
+  // - Optimizations
+  //   - Cache safe and unsafe classloaders
+  //   - Do reference checking at compile time
+  //   - lazy-load reference muzzle field
+  // - Additional references to check
+  //   - Fields
+  //   - methods
+  //     - visit annotations
+  //     - visit parameter types
+  //     - visit method instructions
+  //     - method invoke type
+  //   - access flags (including implicit package-private)
+  //   - supertypes
+  // - Misc
+  //   - Expose config instead of hardcoding datadog namespace (or reconfigure classpath)
+  //   - Throw checked exception for better logging of mismatches
+  //   - Run muzzle in matching phase (may require a rewrite of the instrumentation api)
+  //   - Remove ReplaceIsSafeVisitor
+  //   - IntegrationTest: assert all instrumentation has matcher field
+  //   - Documentation
+
+  private static final TypeDescription InstrumenterTypeDesc =
+      new TypeDescription.ForLoadedType(Instrumenter.class);
+
+  @Override
+  public boolean matches(final TypeDescription target) {
+    // AutoService annotation is not retained at runtime. Check for instrumenter supertype
+    boolean isInstrumenter = false;
+    TypeDefinition instrumenter = target;
+    while (instrumenter != null) {
+      if (instrumenter.getInterfaces().contains(InstrumenterTypeDesc)) {
+        isInstrumenter = true;
+        break;
+      }
+      instrumenter = instrumenter.getSuperClass();
+    }
+    return isInstrumenter;
+  }
+
+  @Override
+  public Builder<?> apply(Builder<?> builder, TypeDescription typeDescription) {
+    return builder.visit(new MuzzleVisitor());
+  }
+}

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/MuzzleGradlePlugin.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/MuzzleGradlePlugin.java
@@ -18,6 +18,7 @@ public class MuzzleGradlePlugin implements Plugin {
   //   - Cache safe and unsafe classloaders
   //   - Do reference checking at compile time
   //   - lazy-load reference muzzle field
+  //   - Also match interfaces which extend Instrumenter
   // - Additional references to check
   //   - Fields
   //   - methods

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/MuzzleVisitor.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/MuzzleVisitor.java
@@ -1,0 +1,262 @@
+package datadog.trace.agent.tooling.muzzle;
+
+import java.util.Collection;
+import java.util.HashSet;
+import net.bytebuddy.asm.AsmVisitorWrapper;
+import net.bytebuddy.description.field.FieldDescription;
+import net.bytebuddy.description.field.FieldList;
+import net.bytebuddy.description.method.MethodList;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.implementation.Implementation;
+import net.bytebuddy.jar.asm.*;
+import net.bytebuddy.pool.TypePool;
+
+/**
+ * Add a referenceMatcher field and 2.
+ *
+ * <p>And for each decorator add a final transformer to assert the classpath is safe instrument.
+ */
+public class MuzzleVisitor implements AsmVisitorWrapper {
+  @Override
+  public int mergeWriter(int flags) {
+    return flags | ClassWriter.COMPUTE_MAXS;
+  }
+
+  @Override
+  public int mergeReader(int flags) {
+    return flags;
+  }
+
+  @Override
+  public ClassVisitor wrap(
+      TypeDescription instrumentedType,
+      ClassVisitor classVisitor,
+      Implementation.Context implementationContext,
+      TypePool typePool,
+      FieldList<FieldDescription.InDefinedShape> fields,
+      MethodList<?> methods,
+      int writerFlags,
+      int readerFlags) {
+    return new InsertSafetyMatcher(classVisitor);
+  }
+
+  public static class InsertSafetyMatcher extends ClassVisitor {
+    public InsertSafetyMatcher(ClassVisitor classVisitor) {
+      super(Opcodes.ASM6, classVisitor);
+    }
+
+    public String instrumentationClassName;
+
+    @Override
+    public void visit(
+        final int version,
+        final int access,
+        final String name,
+        final String signature,
+        final String superName,
+        final String[] interfaces) {
+      this.instrumentationClassName = name;
+      super.visit(version, access, name, signature, superName, interfaces);
+    }
+
+    @Override
+    public MethodVisitor visitMethod(
+        final int access,
+        final String name,
+        final String descriptor,
+        final String signature,
+        final String[] exceptions) {
+      MethodVisitor methodVisitor =
+          super.visitMethod(access, name, descriptor, signature, exceptions);
+      if ("<init>".equals(name)) {
+        methodVisitor = new InitializeFieldVisitor(methodVisitor);
+      }
+      // return new ReplaceIsSafeVisitor(methodVisitor);
+      return new InsertMuzzleTransformer(methodVisitor);
+    }
+
+    @Override
+    public void visitEnd() {
+      super.visitField(
+          Opcodes.ACC_PUBLIC,
+          "referenceMatcher",
+          Type.getDescriptor(ReferenceMatcher.class),
+          null,
+          null);
+      super.visitEnd();
+    }
+
+    /**
+     * Changes this:<br>
+     * &nbsp.transform(DDAdvice.create().advice(named("fooMethod", FooAdvice.class.getname())))
+     * &nbsp.asDecorator(); Into this:<br>
+     * &nbsp.transform(DDAdvice.create().advice(named("fooMethod", FooAdvice.class.getname())))
+     * &nbsp.transform(this.referenceMatcher.assertSafeTransformation("foo.package.FooAdvice"));
+     * &nbsp.asDecorator(); className)
+     */
+    public class InsertMuzzleTransformer extends MethodVisitor {
+      // it would be nice to manage the state with an enum, but that requires this class to be non-static
+      private final int INIT = 0;
+      // SomeClass
+      private final int PREVIOUS_INSTRUCTION_LDC = 1;
+      // SomeClass.getName()
+      private final int PREVIOUS_INSTRUCTION_GET_CLASS_NAME = 2;
+
+      private String lastClassLDC = null;
+
+      private Collection<String> adviceClassNames = new HashSet<>();
+      private int STATE = INIT;
+
+      public InsertMuzzleTransformer(MethodVisitor methodVisitor) {
+        super(Opcodes.ASM6, methodVisitor);
+      }
+
+      public void reset() {
+        STATE = INIT;
+        lastClassLDC = null;
+        adviceClassNames.clear();
+      }
+
+      @Override
+      public void visitMethodInsn(
+          final int opcode,
+          final String owner,
+          final String name,
+          final String descriptor,
+          final boolean isInterface) {
+        if (name.equals("getName")) {
+          if (STATE == PREVIOUS_INSTRUCTION_LDC) {
+            STATE = PREVIOUS_INSTRUCTION_GET_CLASS_NAME;
+          }
+        } else if (name.equals("advice")) {
+          if (STATE == PREVIOUS_INSTRUCTION_GET_CLASS_NAME) {
+            adviceClassNames.add(lastClassLDC);
+          }
+          // add last LDC/ToString to adivce list
+        } else if (name.equals("asDecorator")) {
+          this.visitVarInsn(Opcodes.ALOAD, 0);
+          this.visitFieldInsn(
+              Opcodes.GETFIELD,
+              instrumentationClassName,
+              "referenceMatcher",
+              Type.getDescriptor(ReferenceMatcher.class));
+          mv.visitIntInsn(Opcodes.BIPUSH, adviceClassNames.size());
+          mv.visitTypeInsn(Opcodes.ANEWARRAY, "java/lang/String");
+          int i = 0;
+          for (String adviceClassName : adviceClassNames) {
+            mv.visitInsn(Opcodes.DUP);
+            mv.visitIntInsn(Opcodes.BIPUSH, i);
+            mv.visitLdcInsn(adviceClassName);
+            mv.visitInsn(Opcodes.AASTORE);
+            ++i;
+          }
+          mv.visitMethodInsn(
+              Opcodes.INVOKEVIRTUAL,
+            "datadog/trace/agent/tooling/muzzle/ReferenceMatcher",
+              "assertSafeTransformation",
+              "([Ljava/lang/String;)Lnet/bytebuddy/agent/builder/AgentBuilder$Transformer;",
+              false);
+          mv.visitMethodInsn(
+              Opcodes.INVOKEINTERFACE,
+              "net/bytebuddy/agent/builder/AgentBuilder$Identified$Narrowable",
+              "transform",
+              "(Lnet/bytebuddy/agent/builder/AgentBuilder$Transformer;)Lnet/bytebuddy/agent/builder/AgentBuilder$Identified$Extendable;",
+              true);
+          reset();
+        } else {
+          STATE = INIT;
+          lastClassLDC = null;
+        }
+        super.visitMethodInsn(opcode, owner, name, descriptor, isInterface);
+      }
+
+      @Override
+      public void visitLdcInsn(final Object value) {
+        if (value instanceof Type) {
+          Type type = (Type) value;
+          if (type.getSort() == Type.OBJECT) {
+            lastClassLDC = type.getClassName();
+            STATE = PREVIOUS_INSTRUCTION_LDC;
+            type.getClassName();
+          }
+        }
+        super.visitLdcInsn(value);
+      }
+    }
+
+    /**
+     * Replace:<br>
+     * &nbsp&nbsp advice(elementMatcher, className)<br>
+     * Into:<br>
+     * &nbsp&nbsp advice(this.referenceMatcher.createElementMatcher(elementMatcher, className),
+     * className)
+     */
+    public class ReplaceIsSafeVisitor extends MethodVisitor {
+      public ReplaceIsSafeVisitor(MethodVisitor methodVisitor) {
+        super(Opcodes.ASM6, methodVisitor);
+      }
+
+      @Override
+      public void visitMethodInsn(
+          final int opcode,
+          final String owner,
+          final String name,
+          final String descriptor,
+          final boolean isInterface) {
+        if (name.equals("advice")) {
+          // stack: [class, matcher]
+          this.visitVarInsn(Opcodes.ALOAD, 0);
+          // stack: [this, class, matcher]
+          this.visitFieldInsn(
+              Opcodes.GETFIELD,
+              instrumentationClassName,
+              "referenceMatcher",
+              Type.getDescriptor(ReferenceMatcher.class));
+          // stack: [referenceMatcher, class, matcher]
+          this.visitInsn(Opcodes.DUP2_X1);
+          // stack: [referenceMatcher, class, matcher, referenceMatcher, class]
+          this.visitInsn(Opcodes.POP);
+          // stack: [class, matcher, referenceMatcher, class]
+          this.visitMethodInsn(
+              Opcodes.INVOKEVIRTUAL,
+            "datadog/trace/agent/tooling/muzzle/ReferenceMatcher",
+              "createElementMatcher",
+              "(Lnet/bytebuddy/matcher/ElementMatcher;Ljava/lang/String;)Lnet/bytebuddy/matcher/ElementMatcher;",
+              false);
+          // stack: [safe-matcher, class]
+          this.visitInsn(Opcodes.SWAP);
+          // stack: [class, safe-matcher]
+        }
+        super.visitMethodInsn(opcode, owner, name, descriptor, isInterface);
+      }
+    }
+
+    /** Append a field initializer to the end of a method. */
+    public class InitializeFieldVisitor extends MethodVisitor {
+      public InitializeFieldVisitor(MethodVisitor methodVisitor) {
+        super(Opcodes.ASM6, methodVisitor);
+      }
+
+      @Override
+      public void visitInsn(final int opcode) {
+        if (opcode == Opcodes.RETURN) {
+          super.visitVarInsn(Opcodes.ALOAD, 0);
+          mv.visitTypeInsn(Opcodes.NEW, "datadog/trace/agent/tooling/muzzle/ReferenceMatcher");
+          mv.visitInsn(Opcodes.DUP);
+          mv.visitMethodInsn(
+              Opcodes.INVOKESPECIAL,
+            "datadog/trace/agent/tooling/muzzle/ReferenceMatcher",
+              "<init>",
+              "()V",
+              false);
+          super.visitFieldInsn(
+              Opcodes.PUTFIELD,
+              instrumentationClassName.replace('.', '/'),
+              "referenceMatcher",
+              Type.getDescriptor(ReferenceMatcher.class));
+        }
+        super.visitInsn(opcode);
+      }
+    }
+  }
+}

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/Reference.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/Reference.java
@@ -1,0 +1,141 @@
+package datadog.trace.agent.tooling.muzzle;
+
+import static datadog.trace.agent.tooling.ClassLoaderMatcher.BOOTSTRAP_CLASSLOADER;
+
+import datadog.trace.agent.tooling.Utils;
+import java.util.*;
+
+/** A reference to a single class file. */
+public class Reference {
+  private final Source[] sources;
+  private final String className;
+  private final String superName;
+  private final String[] interfaceNames;
+
+  public Reference(Source[] sources, String className, String superName, String[] interfaces) {
+    this.className = Utils.getClassName(className);
+    this.superName = null == superName ? null : Utils.getClassName(superName);
+    this.sources = null == sources ? new Source[0] : sources;
+    this.interfaceNames = new String[interfaces == null ? 0 : interfaces.length];
+    for (int i = 0; i < interfaceNames.length; ++i) {
+      interfaceNames[i] = Utils.getClassName(interfaces[i]);
+    }
+  }
+
+  public String getClassName() {
+    return className;
+  }
+
+  /**
+   * TODO: doc
+   *
+   * @param anotherReference A reference to the same class
+   * @return a new Reference which merges the two references
+   */
+  public Reference merge(Reference anotherReference) {
+    if (!anotherReference.getClassName().equals(className)) {
+      throw new IllegalStateException("illegal merge " + this + " != " + anotherReference);
+    }
+    String superName = null == this.superName ? anotherReference.superName : this.superName;
+
+    return new Reference(
+        mergeWithoutDuplicates(sources, anotherReference.sources),
+        className,
+        superName,
+        mergeWithoutDuplicates(interfaceNames, anotherReference.interfaceNames));
+  }
+
+  private <T> T[] mergeWithoutDuplicates(T[] array1, T[] array2) {
+    final Set<T> set = new HashSet<>();
+    set.addAll(Arrays.asList(array1));
+    set.addAll(Arrays.asList(array2));
+    return set.toArray(array1);
+  }
+
+  /**
+   * Check this reference against a classloader's classpath.
+   *
+   * @param loader
+   * @return A list of mismatched sources. A list of size 0 means the reference matches the class.
+   */
+  public List<Mismatch> checkMatch(ClassLoader loader) {
+    if (loader == BOOTSTRAP_CLASSLOADER) {
+      throw new IllegalStateException("Cannot directly check against bootstrap classloader");
+    }
+    if (onClasspath(className, loader)) {
+      return new ArrayList<>(0);
+    } else {
+      final List<Mismatch> mismatches = new ArrayList<>();
+      mismatches.add(new Mismatch.MissingClass(sources, className));
+      return mismatches;
+    }
+  }
+
+  private boolean onClasspath(final String className, final ClassLoader loader) {
+    final String resourceName = Utils.getResourceName(className);
+    return loader.getResource(resourceName) != null
+        // helper classes are not on the resource path because they are loaded with reflection (See HelperInjector)
+        || (className.startsWith("datadog.trace.")
+            && Utils.findLoadedClass(className, loader) != null)
+        // bootstrap class
+        || Utils.getBootstrapProxy().getResource(resourceName) != null;
+  }
+
+  public static class Source {
+    private final String name;
+    private final int line;
+
+    public Source(String name, int line) {
+      this.name = name;
+      this.line = line;
+    }
+
+    @Override
+    public String toString() {
+      return getName() + ":" + getLine();
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public int getLine() {
+      return line;
+    }
+
+    // FIXME: Override equals and hashCode
+  }
+
+  public abstract static class Mismatch {
+    final Source[] mismatchSources;
+
+    Mismatch(Source[] mismatchSources) {
+      this.mismatchSources = mismatchSources;
+    }
+
+    @Override
+    public String toString() {
+      if (mismatchSources.length > 0) {
+        return mismatchSources[0].toString() + " " + getMismatchDetails();
+      } else {
+        return "<no-source> " + getMismatchDetails();
+      }
+    }
+
+    abstract String getMismatchDetails();
+
+    public static class MissingClass extends Mismatch {
+      final String className;
+
+      public MissingClass(Source[] sources, String className) {
+        super(sources);
+        this.className = className;
+      }
+
+      @Override
+      String getMismatchDetails() {
+        return "Missing class " + className;
+      }
+    }
+  }
+}

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/ReferenceMatcher.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/ReferenceMatcher.java
@@ -1,0 +1,113 @@
+package datadog.trace.agent.tooling.muzzle;
+
+import static net.bytebuddy.dynamic.loading.ClassLoadingStrategy.BOOTSTRAP_LOADER;
+
+import datadog.trace.agent.tooling.Utils;
+import java.security.ProtectionDomain;
+import java.util.*;
+import net.bytebuddy.agent.builder.AgentBuilder;
+import net.bytebuddy.agent.builder.AgentBuilder.Transformer;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.dynamic.DynamicType;
+import net.bytebuddy.utility.JavaModule;
+
+/**
+ * A bytebuddy matcher that matches if expected references (classes, fields, methods, visibility)
+ * are present on the classpath.
+ */
+public class ReferenceMatcher implements AgentBuilder.RawMatcher {
+  // TODO: Cache safe and unsafe classloaders
+
+  // list of unique references (by class name)
+  Map<String, Reference> references = new HashMap<>();
+  Set<String> referenceSources = new HashSet<>();
+
+  // take a list of references
+  public ReferenceMatcher() {
+    // TODO: pass in references
+  }
+
+  @Override
+  public boolean matches(
+      TypeDescription typeDescription,
+      ClassLoader classLoader,
+      JavaModule module,
+      Class<?> classBeingRedefined,
+      ProtectionDomain protectionDomain) {
+    return matches(classLoader);
+  }
+
+  public boolean matches(ClassLoader loader) {
+    return getMismatchedReferenceSources(loader).size() == 0;
+  }
+
+  public List<Reference.Mismatch> getMismatchedReferenceSources(ClassLoader loader) {
+    if (loader == BOOTSTRAP_LOADER) {
+      loader = Utils.getBootstrapProxy();
+    }
+    final List<Reference.Mismatch> mismatchedReferences = new ArrayList<>(0);
+    for (Reference reference : references.values()) {
+      mismatchedReferences.addAll(reference.checkMatch(loader));
+    }
+    // TODO: log mismatches
+    /*
+    if (mismatchedReferences.size() > 0) {
+      System.out.println(mismatchedReferences.size() + " mismatches on classloader " + loader);
+      for (Reference.Mismatch mismatch : mismatchedReferences) {
+        // TODO: log more info about why mismatch occurred. Missing method, missing field, signature mismatch.
+        System.out.println("--" + mismatch.toString());
+      }
+    }
+    */
+    return mismatchedReferences;
+  }
+
+  public Transformer assertSafeTransformation(String... adviceClassNames) {
+    // load or check cache for advice class names
+    for (String adviceClass : adviceClassNames) {
+      if (!referenceSources.contains(adviceClass)) {
+        referenceSources.add(adviceClass);
+        for (Map.Entry<String, Reference> entry :
+            AdviceReferenceVisitor.createReferencesFrom(
+                    adviceClass, ReferenceMatcher.class.getClassLoader())
+                .entrySet()) {
+          if (references.containsKey(entry.getKey())) {
+            references.put(entry.getKey(), references.get(entry.getKey()).merge(entry.getValue()));
+          } else {
+            references.put(entry.getKey(), entry.getValue());
+          }
+        }
+      }
+    }
+
+    return new Transformer() {
+      @Override
+      public DynamicType.Builder<?> transform(
+          DynamicType.Builder<?> builder,
+          TypeDescription typeDescription,
+          ClassLoader classLoader,
+          JavaModule module) {
+        final List<Reference.Mismatch> mismatches = getMismatchedReferenceSources(classLoader);
+        if (mismatches.size() == 0) {
+          return builder;
+        } else {
+          // TODO: make mismatch exception type and add more descriptive logging at listener level.
+          throw new MismatchException(classLoader, mismatches);
+        }
+      }
+    };
+  }
+
+  public static class MismatchException extends RuntimeException {
+    private final List<Reference.Mismatch> mismatches;
+
+    public MismatchException(ClassLoader classLoader, List<Reference.Mismatch> mismatches) {
+      super(mismatches.size() + " mismatches on classloader: " + classLoader);
+      this.mismatches = mismatches;
+    }
+
+    public List<Reference.Mismatch> getMismatches() {
+      return this.mismatches;
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/instrumentation.gradle
+++ b/dd-java-agent/instrumentation/instrumentation.gradle
@@ -1,14 +1,27 @@
 // this project will run in isolation under the agent's classloader
+buildscript {
+  dependencies {
+    classpath "net.bytebuddy:byte-buddy-gradle-plugin:${versions.bytebuddy}"
+  }
+}
 plugins {
   id "com.github.johnrengelman.shadow"
 }
-
 apply from: "${rootDir}/gradle/java.gradle"
 
 // add all subprojects under 'instrumentation' to the agent's dependencies
 Project instr_project = project
 subprojects { subProj ->
   if (subProj.getParent() == instr_project) {
+    apply plugin: "net.bytebuddy.byte-buddy"
+    subProj.byteBuddy {
+      transformation {
+        tasks = ["compileJava"]
+        plugin = "datadog.trace.agent.tooling.muzzle.MuzzleGradlePlugin"
+        classPath = project(':dd-java-agent:agent-tooling').configurations.instrumentationMuzzle
+      }
+    }
+
     instr_project.dependencies {
       compile(project(subProj.getPath()))
     }

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/ExecutorInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/ExecutorInstrumentation.java
@@ -12,7 +12,6 @@ import datadog.trace.agent.tooling.DDAdvice;
 import datadog.trace.agent.tooling.DDTransformers;
 import datadog.trace.agent.tooling.HelperInjector;
 import datadog.trace.agent.tooling.Instrumenter;
-import datadog.trace.agent.tooling.muzzle.ReferenceMatcher;
 import datadog.trace.context.TraceScope;
 import io.opentracing.Scope;
 import io.opentracing.util.GlobalTracer;
@@ -132,8 +131,6 @@ public final class ExecutorInstrumentation extends Instrumenter.Configurable {
                 .advice(
                     nameMatches("invoke(Any|All)$").and(takesArgument(0, Callable.class)),
                     WrapCallableCollectionAdvice.class.getName()))
-        .transform(
-            new ReferenceMatcher().assertSafeTransformation(WrapRunnableAdvice.class.getName()))
         .asDecorator();
   }
 

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/ExecutorInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/ExecutorInstrumentation.java
@@ -12,6 +12,7 @@ import datadog.trace.agent.tooling.DDAdvice;
 import datadog.trace.agent.tooling.DDTransformers;
 import datadog.trace.agent.tooling.HelperInjector;
 import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.agent.tooling.muzzle.ReferenceMatcher;
 import datadog.trace.context.TraceScope;
 import io.opentracing.Scope;
 import io.opentracing.util.GlobalTracer;
@@ -131,6 +132,8 @@ public final class ExecutorInstrumentation extends Instrumenter.Configurable {
                 .advice(
                     nameMatches("invoke(Any|All)$").and(takesArgument(0, Callable.class)),
                     WrapCallableCollectionAdvice.class.getName()))
+        .transform(
+            new ReferenceMatcher().assertSafeTransformation(WrapRunnableAdvice.class.getName()))
         .asDecorator();
   }
 

--- a/dd-java-agent/testing/src/main/java/datadog/trace/agent/test/SpockRunner.java
+++ b/dd-java-agent/testing/src/main/java/datadog/trace/agent/test/SpockRunner.java
@@ -3,6 +3,7 @@ package datadog.trace.agent.test;
 import static datadog.trace.agent.tooling.Utils.BOOTSTRAP_PACKAGE_PREFIXES;
 
 import com.google.common.reflect.ClassPath;
+import datadog.trace.agent.tooling.Utils;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
@@ -94,6 +95,7 @@ public class SpockRunner extends Sputnik {
       final File bootstrapJar = createBootstrapJar();
       ByteBuddyAgent.getInstrumentation()
           .appendToBootstrapClassLoaderSearch(new JarFile(bootstrapJar));
+      Utils.getBootstrapProxy().addURL(bootstrapJar.toURI().toURL());
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/dd-java-agent/testing/src/test/groovy/muzzle/AdviceReferenceVisitorTest.groovy
+++ b/dd-java-agent/testing/src/test/groovy/muzzle/AdviceReferenceVisitorTest.groovy
@@ -1,0 +1,38 @@
+package muzzle
+
+import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.agent.test.TestUtils
+import datadog.trace.agent.tooling.muzzle.AdviceReferenceVisitor
+import datadog.trace.agent.tooling.muzzle.ReferenceMatcher
+
+class AdviceReferenceVisitorTest extends AgentTestRunner {
+
+  def "methods body references"() {
+    setup:
+    Map<String, Reference> references = AdviceReferenceVisitor.createReferencesFrom(AdviceClass.getName(), this.getClass().getClassLoader())
+
+    expect:
+    references.get('java.lang.Object') != null
+    references.get('muzzle.AdviceClass$A') != null
+    references.get('muzzle.AdviceClass$SomeInterface') != null
+    references.get('muzzle.AdviceClass$SomeImplementation') != null
+    references.keySet().size() == 4
+  }
+
+  def "match safe classpaths"() {
+    setup:
+    ReferenceMatcher refMatcher = new ReferenceMatcher()
+    refMatcher.assertSafeTransformation(AdviceClass.getName())
+    ClassLoader safeClassloader = new URLClassLoader([TestUtils.createJarWithClasses(AdviceClass$A,
+                                                                                     AdviceClass$SomeInterface,
+                                                                                     AdviceClass$SomeImplementation)] as URL[],
+                                                     (ClassLoader) null)
+    ClassLoader unsafeClassloader = new URLClassLoader([TestUtils.createJarWithClasses(AdviceClass$SomeInterface,
+                                                                                       AdviceClass$SomeImplementation)] as URL[],
+                                                       (ClassLoader) null)
+
+    expect:
+    refMatcher.getMismatchedReferenceSources(safeClassloader).size() == 0
+    refMatcher.getMismatchedReferenceSources(unsafeClassloader).size() == 1
+  }
+}

--- a/dd-java-agent/testing/src/test/java/muzzle/AdviceClass.java
+++ b/dd-java-agent/testing/src/test/java/muzzle/AdviceClass.java
@@ -1,0 +1,24 @@
+package muzzle;
+
+import net.bytebuddy.asm.Advice;
+
+public class AdviceClass {
+
+  @Advice.OnMethodEnter
+  public static void advice() {
+    A a = new A();
+    SomeInterface inter = new SomeImplementation();
+    inter.someMethod();
+  }
+
+  public static class A {}
+
+  public interface SomeInterface {
+    void someMethod();
+  }
+
+  public static class SomeImplementation implements SomeInterface {
+    @Override
+    public void someMethod() {}
+  }
+}


### PR DESCRIPTION
(merging to integration branch)

First PR for instrumentation muzzle. Use Bytebuddy gradle plugin to add instrumentation muzzle field and transformation checker to each instrumentation class.