### PR TITLE
Name service based on servlet context

### DIFF
--- a/dd-java-agent-ittests/src/test/groovy/datadog/trace/agent/integration/httpclient/ApacheHttpClientTest.groovy
+++ b/dd-java-agent-ittests/src/test/groovy/datadog/trace/agent/integration/httpclient/ApacheHttpClientTest.groovy
@@ -64,7 +64,7 @@ class ApacheHttpClientTest extends Specification {
     final DDSpan localSpan = clientTrace.get(1)
     localSpan.getType() == null
     localSpan.getTags()[Tags.COMPONENT.getKey()] == "apache-httpclient"
-    localSpan.getOperationName() == "http.request"
+    localSpan.getOperationName() == "apache.http"
 
     final DDSpan clientSpan = clientTrace.get(2)
     clientSpan.getOperationName() == "http.request"
@@ -109,7 +109,7 @@ class ApacheHttpClientTest extends Specification {
     // our instrumentation makes 2 spans for apache-httpclient
     final DDSpan localSpan = clientTrace.get(1)
     localSpan.getTags()[Tags.COMPONENT.getKey()] == "apache-httpclient"
-    localSpan.getOperationName() == "http.request"
+    localSpan.getOperationName() == "apache.http"
 
     final DDSpan clientSpan = clientTrace.get(2)
     clientSpan.getOperationName() == "http.request"

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Instrumenter.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Instrumenter.java
@@ -52,5 +52,13 @@ public interface Instrumenter {
     }
 
     protected abstract AgentBuilder apply(AgentBuilder agentBuilder);
+
+    protected static String getPropOrEnv(final String name) {
+      return System.getProperty(name, System.getenv(propToEnvName(name)));
+    }
+
+    private static String propToEnvName(final String name) {
+      return name.toUpperCase().replace(".", "_");
+    }
   }
 }

--- a/dd-java-agent/instrumentation/aws-sdk/src/test/groovy/AWSClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-sdk/src/test/groovy/AWSClientTest.groovy
@@ -100,9 +100,9 @@ class AWSClientTest extends AgentTestRunner {
     and: // span 0 - from apache-httpclient instrumentation
     def span1 = trace[0]
 
-    span1.context().operationName == "http.request"
+    span1.context().operationName == "apache.http"
     span1.serviceName == "unnamed-java-app"
-    span1.resourceName == "http.request"
+    span1.resourceName == "apache.http"
     span1.type == null
     !span1.context().getErrorFlag()
     span1.context().parentId == 0

--- a/dd-java-agent/instrumentation/jax-rs-client/src/test/groovy/JaxRsClientTest.groovy
+++ b/dd-java-agent/instrumentation/jax-rs-client/src/test/groovy/JaxRsClientTest.groovy
@@ -58,7 +58,7 @@ class JaxRsClientTest extends AgentTestRunner {
 
     span.context().operationName == "jax-rs.client.call"
     span.serviceName == "unnamed-java-app"
-    span.resourceName == "GET jax-rs.client.call"
+    span.resourceName == "GET /ping"
     span.type == "http"
     !span.context().getErrorFlag()
     span.context().parentId == 0

--- a/dd-java-agent/instrumentation/okhttp-3/src/test/groovy/OkHttp3Test.groovy
+++ b/dd-java-agent/instrumentation/okhttp-3/src/test/groovy/OkHttp3Test.groovy
@@ -1,4 +1,5 @@
 import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import io.opentracing.tag.Tags
 import okhttp3.OkHttpClient
@@ -39,19 +40,20 @@ class OkHttp3Test extends AgentTestRunner {
     and: // span 0
     def span1 = trace[0]
 
-    span1.context().operationName == "http.request"
-    span1.serviceName == "unnamed-java-app"
-    span1.resourceName == "http.request"
-    span1.type == null
+    span1.context().operationName == "okhttp.http"
+    span1.serviceName == "okhttp"
+    span1.resourceName == "okhttp.http"
+    span1.type == DDSpanTypes.WEB_SERVLET
     !span1.context().getErrorFlag()
     span1.context().parentId == 0
 
 
     def tags1 = span1.context().tags
     tags1["component"] == "okhttp"
+    tags1["span.type"] == DDSpanTypes.WEB_SERVLET
     tags1["thread.name"] != null
     tags1["thread.id"] != null
-    tags1.size() == 3
+    tags1.size() == 4
 
     and: // span 1
     def span2 = trace[1]

--- a/dd-java-agent/instrumentation/servlet-2/src/main/java/datadog/trace/instrumentation/servlet2/FilterChain2Instrumentation.java
+++ b/dd-java-agent/instrumentation/servlet-2/src/main/java/datadog/trace/instrumentation/servlet2/FilterChain2Instrumentation.java
@@ -83,6 +83,7 @@ public final class FilterChain2Instrumentation extends Instrumenter.Configurable
               .asChildOf(extractedContext)
               .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_SERVER)
               .withTag(DDTags.SPAN_TYPE, DDSpanTypes.WEB_SERVLET)
+              .withTag("servlet.context", ((HttpServletRequest) req).getContextPath())
               .startActive(true);
 
       if (scope instanceof TraceScope) {

--- a/dd-java-agent/instrumentation/servlet-2/src/main/java/datadog/trace/instrumentation/servlet2/HttpServlet2Instrumentation.java
+++ b/dd-java-agent/instrumentation/servlet-2/src/main/java/datadog/trace/instrumentation/servlet2/HttpServlet2Instrumentation.java
@@ -85,6 +85,7 @@ public final class HttpServlet2Instrumentation extends Instrumenter.Configurable
               .asChildOf(extractedContext)
               .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_SERVER)
               .withTag(DDTags.SPAN_TYPE, DDSpanTypes.WEB_SERVLET)
+              .withTag("servlet.context", req.getContextPath())
               .startActive(true);
 
       if (scope instanceof TraceScope) {

--- a/dd-java-agent/instrumentation/servlet-2/src/test/groovy/JettyServlet2Test.groovy
+++ b/dd-java-agent/instrumentation/servlet-2/src/test/groovy/JettyServlet2Test.groovy
@@ -106,6 +106,7 @@ class JettyServlet2Test extends AgentTestRunner {
             "span.kind" "server"
             "component" "java-web-servlet"
             "span.type" DDSpanTypes.WEB_SERVLET
+            "servlet.context" ""
             defaultTags()
           }
         }
@@ -143,6 +144,7 @@ class JettyServlet2Test extends AgentTestRunner {
             "span.kind" "server"
             "component" "java-web-servlet"
             "span.type" DDSpanTypes.WEB_SERVLET
+            "servlet.context" ""
             errorTags(RuntimeException, "some $path error")
             defaultTags()
           }
@@ -182,6 +184,7 @@ class JettyServlet2Test extends AgentTestRunner {
             "span.kind" "server"
             "component" "java-web-servlet"
             "span.type" DDSpanTypes.WEB_SERVLET
+            "servlet.context" ""
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/servlet-3/src/main/java/datadog/trace/instrumentation/servlet3/FilterChain3Instrumentation.java
+++ b/dd-java-agent/instrumentation/servlet-3/src/main/java/datadog/trace/instrumentation/servlet3/FilterChain3Instrumentation.java
@@ -88,6 +88,7 @@ public final class FilterChain3Instrumentation extends Instrumenter.Configurable
               .asChildOf(extractedContext)
               .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_SERVER)
               .withTag(DDTags.SPAN_TYPE, DDSpanTypes.WEB_SERVLET)
+              .withTag("servlet.context", ((HttpServletRequest) req).getContextPath())
               .startActive(false);
 
       if (scope instanceof TraceScope) {

--- a/dd-java-agent/instrumentation/servlet-3/src/main/java/datadog/trace/instrumentation/servlet3/HttpServlet3Instrumentation.java
+++ b/dd-java-agent/instrumentation/servlet-3/src/main/java/datadog/trace/instrumentation/servlet3/HttpServlet3Instrumentation.java
@@ -84,6 +84,7 @@ public final class HttpServlet3Instrumentation extends Instrumenter.Configurable
               .asChildOf(extractedContext)
               .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_SERVER)
               .withTag(DDTags.SPAN_TYPE, DDSpanTypes.WEB_SERVLET)
+              .withTag("servlet.context", req.getContextPath())
               .startActive(false);
 
       if (scope instanceof TraceScope) {

--- a/dd-java-agent/instrumentation/servlet-3/src/test/groovy/JettyServlet3Test.groovy
+++ b/dd-java-agent/instrumentation/servlet-3/src/test/groovy/JettyServlet3Test.groovy
@@ -108,6 +108,7 @@ class JettyServlet3Test extends AgentTestRunner {
             "span.kind" "server"
             "component" "java-web-servlet"
             "span.type" DDSpanTypes.WEB_SERVLET
+            "servlet.context" ""
             "http.status_code" 200
             defaultTags()
           }
@@ -147,6 +148,7 @@ class JettyServlet3Test extends AgentTestRunner {
             "span.kind" "server"
             "component" "java-web-servlet"
             "span.type" DDSpanTypes.WEB_SERVLET
+            "servlet.context" ""
             "http.status_code" 500
             errorTags(RuntimeException, "some $path error")
             defaultTags()
@@ -187,6 +189,7 @@ class JettyServlet3Test extends AgentTestRunner {
             "span.kind" "server"
             "component" "java-web-servlet"
             "span.type" DDSpanTypes.WEB_SERVLET
+            "servlet.context" ""
             "http.status_code" 500
             "error" true
             defaultTags()

--- a/dd-java-agent/instrumentation/servlet-3/src/test/groovy/TomcatServlet3Test.groovy
+++ b/dd-java-agent/instrumentation/servlet-3/src/test/groovy/TomcatServlet3Test.groovy
@@ -44,7 +44,7 @@ class TomcatServlet3Test extends AgentTestRunner {
     if (!applicationDir.exists()) {
       applicationDir.mkdirs()
     }
-    appContext = tomcatServer.addWebapp("", applicationDir.getAbsolutePath())
+    appContext = tomcatServer.addWebapp("/my-context", applicationDir.getAbsolutePath())
     // Speed up startup by disabling jar scanning:
     appContext.getJarScanner().setJarScanFilter(new JarScanFilter() {
       @Override
@@ -84,7 +84,7 @@ class TomcatServlet3Test extends AgentTestRunner {
   def "test #path servlet call"() {
     setup:
     def request = new Request.Builder()
-      .url("http://localhost:$PORT/$path")
+      .url("http://localhost:$PORT/my-context/$path")
       .get()
       .build()
     def response = client.newCall(request).execute()
@@ -95,18 +95,19 @@ class TomcatServlet3Test extends AgentTestRunner {
     assertTraces(writer, 1) {
       trace(0, 1) {
         span(0) {
-          serviceName "unnamed-java-app"
+          serviceName "my-context"
           operationName "servlet.request"
-          resourceName "GET /$path"
+          resourceName "GET /my-context/$path"
           spanType DDSpanTypes.WEB_SERVLET
           errored false
           parent()
           tags {
-            "http.url" "http://localhost:$PORT/$path"
+            "http.url" "http://localhost:$PORT/my-context/$path"
             "http.method" "GET"
             "span.kind" "server"
             "component" "java-web-servlet"
             "span.type" DDSpanTypes.WEB_SERVLET
+            "servlet.context" "/my-context"
             "http.status_code" 200
             defaultTags()
           }
@@ -123,7 +124,7 @@ class TomcatServlet3Test extends AgentTestRunner {
   def "test #path error servlet call"() {
     setup:
     def request = new Request.Builder()
-      .url("http://localhost:$PORT/$path?error=true")
+      .url("http://localhost:$PORT/my-context/$path?error=true")
       .get()
       .build()
     def response = client.newCall(request).execute()
@@ -134,18 +135,19 @@ class TomcatServlet3Test extends AgentTestRunner {
     assertTraces(writer, 1) {
       trace(0, 1) {
         span(0) {
-          serviceName "unnamed-java-app"
+          serviceName "my-context"
           operationName "servlet.request"
-          resourceName "GET /$path"
+          resourceName "GET /my-context/$path"
           spanType DDSpanTypes.WEB_SERVLET
           errored true
           parent()
           tags {
-            "http.url" "http://localhost:$PORT/$path"
+            "http.url" "http://localhost:$PORT/my-context/$path"
             "http.method" "GET"
             "span.kind" "server"
             "component" "java-web-servlet"
             "span.type" DDSpanTypes.WEB_SERVLET
+            "servlet.context" "/my-context"
             "http.status_code" 500
             errorTags(RuntimeException, "some $path error")
             defaultTags()
@@ -163,7 +165,7 @@ class TomcatServlet3Test extends AgentTestRunner {
   def "test #path error servlet call for non-throwing error"() {
     setup:
     def request = new Request.Builder()
-      .url("http://localhost:$PORT/$path?non-throwing-error=true")
+      .url("http://localhost:$PORT/my-context/$path?non-throwing-error=true")
       .get()
       .build()
     def response = client.newCall(request).execute()
@@ -174,18 +176,19 @@ class TomcatServlet3Test extends AgentTestRunner {
     assertTraces(writer, 1) {
       trace(0, 1) {
         span(0) {
-          serviceName "unnamed-java-app"
+          serviceName "my-context"
           operationName "servlet.request"
-          resourceName "GET /$path"
+          resourceName "GET /my-context/$path"
           spanType DDSpanTypes.WEB_SERVLET
           errored true
           parent()
           tags {
-            "http.url" "http://localhost:$PORT/$path"
+            "http.url" "http://localhost:$PORT/my-context/$path"
             "http.method" "GET"
             "span.kind" "server"
             "component" "java-web-servlet"
             "span.type" DDSpanTypes.WEB_SERVLET
+            "servlet.context" "/my-context"
             "http.status_code" 500
             "error" true
             defaultTags()

--- a/dd-java-agent/instrumentation/spring-web/src/test/groovy/test/SpringBootBasedTest.groovy
+++ b/dd-java-agent/instrumentation/spring-web/src/test/groovy/test/SpringBootBasedTest.groovy
@@ -49,10 +49,11 @@ class SpringBootBasedTest extends AgentTestRunner {
     span.context().tags["span.kind"] == "server"
     span.context().tags["span.type"] == "web"
     span.context().tags["component"] == "java-web-servlet"
+    span.context().tags["servlet.context"] == ""
     span.context().tags["http.status_code"] == 200
     span.context().tags["thread.name"] != null
     span.context().tags["thread.id"] != null
-    span.context().tags.size() == 8
+    span.context().tags.size() == 9
   }
 
   def "generates 404 spans"() {
@@ -78,10 +79,11 @@ class SpringBootBasedTest extends AgentTestRunner {
     span0.context().tags["span.kind"] == "server"
     span0.context().tags["span.type"] == "web"
     span0.context().tags["component"] == "java-web-servlet"
+    span0.context().tags["servlet.context"] == ""
     span0.context().tags["http.status_code"] == 404
     span0.context().tags["thread.name"] != null
     span0.context().tags["thread.id"] != null
-    span0.context().tags.size() == 8
+    span0.context().tags.size() == 9
 
     and: // trace 1
     def trace1 = TEST_WRITER.get(1)
@@ -98,10 +100,11 @@ class SpringBootBasedTest extends AgentTestRunner {
     span1.context().tags["span.kind"] == "server"
     span1.context().tags["span.type"] == "web"
     span1.context().tags["component"] == "java-web-servlet"
+    span1.context().tags["servlet.context"] == ""
     span1.context().tags["http.status_code"] == 404
     span1.context().tags["thread.name"] != null
     span1.context().tags["thread.id"] != null
-    span1.context().tags.size() == 8
+    span1.context().tags.size() == 9
   }
 
   def "generates error spans"() {
@@ -129,6 +132,7 @@ class SpringBootBasedTest extends AgentTestRunner {
     span0.context().tags["span.kind"] == "server"
     span0.context().tags["span.type"] == "web"
     span0.context().tags["component"] == "java-web-servlet"
+    span0.context().tags["servlet.context"] == ""
     span0.context().tags["http.status_code"] == 500
     span0.context().tags["thread.name"] != null
     span0.context().tags["thread.id"] != null
@@ -136,7 +140,7 @@ class SpringBootBasedTest extends AgentTestRunner {
     span0.context().tags["error.msg"] == "Request processing failed; nested exception is java.lang.RuntimeException: qwerty"
     span0.context().tags["error.type"] == NestedServletException.getName()
     span0.context().tags["error.stack"] != null
-    span0.context().tags.size() == 12
+    span0.context().tags.size() == 13
 
     and: // trace 1
     def trace1 = TEST_WRITER.get(1)
@@ -152,11 +156,12 @@ class SpringBootBasedTest extends AgentTestRunner {
     span1.context().tags["span.kind"] == "server"
     span1.context().tags["span.type"] == "web"
     span1.context().tags["component"] == "java-web-servlet"
+    span1.context().tags["servlet.context"] == ""
     span1.context().tags["http.status_code"] == 500
     span1.context().getErrorFlag()
     span1.context().tags["thread.name"] != null
     span1.context().tags["thread.id"] != null
-    span1.context().tags.size() == 9
+    span1.context().tags.size() == 10
   }
 
   def "validated form"() {
@@ -179,10 +184,11 @@ class SpringBootBasedTest extends AgentTestRunner {
     span.context().tags["span.kind"] == "server"
     span.context().tags["span.type"] == "web"
     span.context().tags["component"] == "java-web-servlet"
+    span.context().tags["servlet.context"] == ""
     span.context().tags["http.status_code"] == 200
     span.context().tags["thread.name"] != null
     span.context().tags["thread.id"] != null
-    span.context().tags.size() == 8
+    span.context().tags.size() == 9
   }
 
   def "invalid form"() {
@@ -210,6 +216,7 @@ class SpringBootBasedTest extends AgentTestRunner {
     span0.context().tags["span.kind"] == "server"
     span0.context().tags["span.type"] == "web"
     span0.context().tags["component"] == "java-web-servlet"
+    span0.context().tags["servlet.context"] == ""
     span0.context().tags["http.status_code"] == 400
     span0.context().tags["thread.name"] != null
     span0.context().tags["thread.id"] != null
@@ -217,7 +224,7 @@ class SpringBootBasedTest extends AgentTestRunner {
     span0.context().tags["error.msg"].toString().startsWith("Validation failed")
     span0.context().tags["error.type"] == MethodArgumentNotValidException.getName()
     span0.context().tags["error.stack"] != null
-    span0.context().tags.size() == 12
+    span0.context().tags.size() == 13
 
     and: // trace 1
     def trace1 = TEST_WRITER.get(1)
@@ -234,9 +241,10 @@ class SpringBootBasedTest extends AgentTestRunner {
     span1.context().tags["span.kind"] == "server"
     span1.context().tags["span.type"] == "web"
     span1.context().tags["component"] == "java-web-servlet"
+    span1.context().tags["servlet.context"] == ""
     span1.context().tags["http.status_code"] == 400
     span1.context().tags["thread.name"] != null
     span1.context().tags["thread.id"] != null
-    span1.context().tags.size() == 8
+    span1.context().tags.size() == 9
   }
 }

--- a/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceAnnotationsInstrumentation.java
+++ b/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceAnnotationsInstrumentation.java
@@ -86,12 +86,4 @@ public final class TraceAnnotationsInstrumentation extends Instrumenter.Configur
                 .advice(isAnnotatedWith(methodTraceMatcher), TraceAdvice.class.getName()))
         .asDecorator();
   }
-
-  private String getPropOrEnv(final String name) {
-    return System.getProperty(name, System.getenv(propToEnvName(name)));
-  }
-
-  static String propToEnvName(final String name) {
-    return name.toUpperCase().replace(".", "_");
-  }
 }

--- a/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceConfigInstrumentation.java
+++ b/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceConfigInstrumentation.java
@@ -102,12 +102,4 @@ public class TraceConfigInstrumentation extends Instrumenter.Configurable {
     }
     return builder;
   }
-
-  private String getPropOrEnv(final String name) {
-    return System.getProperty(name, System.getenv(propToEnvName(name)));
-  }
-
-  static String propToEnvName(final String name) {
-    return name.toUpperCase().replace(".", "_");
-  }
 }

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/TagsAssert.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/TagsAssert.groovy
@@ -4,10 +4,10 @@ import datadog.opentracing.DDSpan
 
 class TagsAssert {
   private final Map<String, Object> tags
-  private final Set<String> assertedTags = new HashSet<>()
+  private final Set<String> assertedTags = new TreeSet<>()
 
   private TagsAssert(DDSpan span) {
-    this.tags = span.tags
+    this.tags = new TreeMap(span.tags)
   }
 
   static TagsAssert assertTags(DDSpan span,

--- a/dd-trace-ot/src/main/java/datadog/opentracing/DDSpanContext.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/DDSpanContext.java
@@ -241,7 +241,7 @@ public class DDSpanContext implements io.opentracing.SpanContext {
 
     // Call decorators
     final List<AbstractDecorator> decorators = tracer.getSpanContextDecorators(tag);
-    if (decorators != null && value != null) {
+    if (decorators != null) {
       for (final AbstractDecorator decorator : decorators) {
         try {
           addTag &= decorator.shouldSetTag(this, tag, value);

--- a/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
@@ -7,7 +7,6 @@ import datadog.opentracing.propagation.ExtractedContext;
 import datadog.opentracing.propagation.HTTPCodec;
 import datadog.opentracing.scopemanager.ContextualScopeManager;
 import datadog.opentracing.scopemanager.ScopeContext;
-import datadog.trace.api.DDTags;
 import datadog.trace.api.interceptor.MutableSpan;
 import datadog.trace.api.interceptor.TraceInterceptor;
 import datadog.trace.api.sampling.PrioritySampling;
@@ -28,6 +27,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -369,15 +369,7 @@ public class DDTracer implements io.opentracing.Tracer {
 
     @Override
     public DDSpanBuilder withTag(final String tag, final String string) {
-      if (tag.equals(DDTags.SERVICE_NAME)) {
-        return withServiceName(string);
-      } else if (tag.equals(DDTags.RESOURCE_NAME)) {
-        return withResourceName(string);
-      } else if (tag.equals(DDTags.SPAN_TYPE)) {
-        return withSpanType(string);
-      } else {
-        return withTag(tag, (Object) string);
-      }
+      return withTag(tag, (Object) string);
     }
 
     @Override
@@ -523,6 +515,39 @@ public class DDTracer implements io.opentracing.Tracer {
               this.tags,
               parentTrace,
               DDTracer.this);
+
+      // Apply Decorators to handle any tags that may have been set via the builder.
+      for (final Iterator<Map.Entry<String, Object>> it = this.tags.entrySet().iterator();
+          it.hasNext();
+          ) {
+        final Map.Entry<String, Object> tag = it.next();
+        if (tag.getValue() == null) {
+          it.remove();
+          continue;
+        }
+
+        boolean addTag = true;
+
+        // Call decorators
+        final List<AbstractDecorator> decorators =
+            DDTracer.this.getSpanContextDecorators(tag.getKey());
+        if (decorators != null) {
+          for (final AbstractDecorator decorator : decorators) {
+            try {
+              addTag &= decorator.shouldSetTag(context, tag.getKey(), tag.getValue());
+            } catch (final Throwable ex) {
+              log.debug(
+                  "Could not decorate the span decorator={}: {}",
+                  decorator.getClass().getSimpleName(),
+                  ex.getMessage());
+            }
+          }
+        }
+
+        if (!addTag) {
+          it.remove();
+        }
+      }
 
       return context;
     }

--- a/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
@@ -27,7 +27,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -517,12 +516,9 @@ public class DDTracer implements io.opentracing.Tracer {
               DDTracer.this);
 
       // Apply Decorators to handle any tags that may have been set via the builder.
-      for (final Iterator<Map.Entry<String, Object>> it = this.tags.entrySet().iterator();
-          it.hasNext();
-          ) {
-        final Map.Entry<String, Object> tag = it.next();
+      for (final Map.Entry<String, Object> tag : this.tags.entrySet()) {
         if (tag.getValue() == null) {
-          it.remove();
+          context.setTag(tag.getKey(), null);
           continue;
         }
 
@@ -545,7 +541,7 @@ public class DDTracer implements io.opentracing.Tracer {
         }
 
         if (!addTag) {
-          it.remove();
+          context.setTag(tag.getKey(), null);
         }
       }
 

--- a/dd-trace-ot/src/main/java/datadog/opentracing/decorators/DDDecoratorsFactory.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/decorators/DDDecoratorsFactory.java
@@ -25,6 +25,7 @@ public class DDDecoratorsFactory {
         new OperationDecorator(),
         new ResourceNameDecorator(),
         new ServiceNameDecorator(mappings),
+        new ServletContextDecorator(),
         new SpanTypeDecorator(),
         new Status5XXDecorator(),
         new Status404Decorator(),

--- a/dd-trace-ot/src/main/java/datadog/opentracing/decorators/ServletContextDecorator.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/decorators/ServletContextDecorator.java
@@ -1,0 +1,31 @@
+package datadog.opentracing.decorators;
+
+import datadog.opentracing.DDSpanContext;
+import datadog.opentracing.DDTracer;
+
+public class ServletContextDecorator extends AbstractDecorator {
+
+  public ServletContextDecorator() {
+    super();
+    this.setMatchingTag("servlet.context");
+  }
+
+  @Override
+  public boolean shouldSetTag(final DDSpanContext context, final String tag, final Object value) {
+    String contextName = String.valueOf(value).trim();
+    if (contextName.equals("/")
+        || (!context.getServiceName().equals(DDTracer.UNASSIGNED_DEFAULT_SERVICE_NAME)
+            && !context.getServiceName().isEmpty())) {
+      return true;
+    }
+    if (contextName.startsWith("/")) {
+      if (contextName.length() > 1) {
+        contextName = contextName.substring(1);
+      }
+    }
+    if (!contextName.isEmpty()) {
+      context.setServiceName(contextName);
+    }
+    return true;
+  }
+}

--- a/dd-trace-ot/src/test/groovy/datadog/trace/DDTraceConfigTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/trace/DDTraceConfigTest.groovy
@@ -107,7 +107,7 @@ class DDTraceConfigTest extends Specification {
     tracer.sampler instanceof AllSampler
     tracer.writer.toString() == "DDAgentWriter { api=DDApi { tracesEndpoint=http://localhost:8126/v0.3/traces } }"
 
-    tracer.spanContextDecorators.size() == 9
+    tracer.spanContextDecorators.size() == 10
   }
 
   def "verify mapping configs on tracer"() {


### PR DESCRIPTION
This only applies if a service name hasn’t been set or is empty.

This is particularly useful for environments that deploy multiple war files to the same app server.

This is a potentially breaking change if someone hasn't configured a service name.