### PR TITLE
Flags, Fields, and Methods for Muzzle References

### DIFF
--- a/dd-java-agent-ittests/src/test/groovy/datadog/trace/agent/integration/muzzle/MuzzleBytecodeTransformTest.groovy
+++ b/dd-java-agent-ittests/src/test/groovy/datadog/trace/agent/integration/muzzle/MuzzleBytecodeTransformTest.groovy
@@ -1,6 +1,8 @@
 package datadog.trace.agent.integration.muzzle
 
 import datadog.trace.agent.test.IntegrationTestUtils
+import java.lang.reflect.Field
+import java.lang.reflect.Method
 import spock.lang.Specification
 
 
@@ -9,15 +11,38 @@ class MuzzleBytecodeTransformTest extends Specification {
   def "muzzle fields added to all instrumentation"() {
     setup:
     List<Class> unMuzzledClasses = []
+    List<Class> nonLazyFields = []
+    List<Class> unInitFields = []
     for (final Object instrumenter : ServiceLoader.load(IntegrationTestUtils.getAgentClassLoader().loadClass("datadog.trace.agent.tooling.Instrumenter"), IntegrationTestUtils.getAgentClassLoader())) {
+      Field f
+      Method m
       try {
-        instrumenter.getClass().getDeclaredField("instrumentationMuzzle")
-      } catch(NoSuchFieldException nsfe) {
+        f = instrumenter.getClass().getDeclaredField("instrumentationMuzzle")
+        f.setAccessible(true)
+        if (f.get(instrumenter) != null) {
+          nonLazyFields.add(instrumenter.getClass())
+        }
+        m = instrumenter.getClass().getDeclaredMethod("getInstrumentationMuzzle")
+        m.setAccessible(true)
+        m.invoke(instrumenter)
+        if (f.get(instrumenter) == null) {
+          unInitFields.add(instrumenter.getClass())
+        }
+      } catch(NoSuchFieldException | NoSuchMethodException e) {
         unMuzzledClasses.add(instrumenter.getClass())
+      } finally {
+        if (null != f) {
+          f.setAccessible(false)
+        }
+        if (null != m) {
+          m.setAccessible(false)
+        }
       }
     }
     expect:
     unMuzzledClasses == []
+    nonLazyFields == []
+    unInitFields == []
   }
 
 }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/AdviceReferenceVisitor.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/AdviceReferenceVisitor.java
@@ -72,11 +72,7 @@ public class AdviceReferenceVisitor extends ClassVisitor {
         final String descriptor,
         final boolean isInterface) {
       addReference(
-          new Reference(
-              new Reference.Source[] {new Reference.Source(refSourceClassName, currentLineNumber)},
-              Utils.getClassName(owner),
-              null,
-              null));
+          new Reference.Builder(owner).withSource(refSourceClassName, currentLineNumber).build());
     }
   }
 

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/MuzzleGradlePlugin.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/MuzzleGradlePlugin.java
@@ -8,17 +8,10 @@ import net.bytebuddy.dynamic.DynamicType.Builder;
 
 public class MuzzleGradlePlugin implements Plugin {
   // TODO:
-  // - PR1
-  //   - Make errorprone happy
-  //   - Unit tests
-  //   - Review design and ease of adding future features
-  //     - better checking
-  //     - versionScan
   // - Optimizations
   //   - Cache safe and unsafe classloaders
-  //   - Do reference checking at compile time
+  //   - Do reference generation at compile time
   //   - lazy-load reference muzzle field
-  //   - Also match interfaces which extend Instrumenter
   // - Additional references to check
   //   - Fields
   //   - methods
@@ -29,11 +22,9 @@ public class MuzzleGradlePlugin implements Plugin {
   //   - access flags (including implicit package-private)
   //   - supertypes
   // - Misc
+  //   - Also match interfaces which extend Instrumenter
   //   - Expose config instead of hardcoding datadog namespace (or reconfigure classpath)
-  //   - Throw checked exception for better logging of mismatches
   //   - Run muzzle in matching phase (may require a rewrite of the instrumentation api)
-  //   - Remove ReplaceIsSafeVisitor
-  //   - IntegrationTest: assert all instrumentation has matcher field
   //   - Documentation
 
   private static final TypeDescription InstrumenterTypeDesc =
@@ -57,5 +48,17 @@ public class MuzzleGradlePlugin implements Plugin {
   @Override
   public Builder<?> apply(Builder<?> builder, TypeDescription typeDescription) {
     return builder.visit(new MuzzleVisitor());
+  }
+
+  public static class NoOp implements Plugin {
+    @Override
+    public boolean matches(final TypeDescription target) {
+      return false;
+    }
+
+    @Override
+    public Builder<?> apply(Builder<?> builder, TypeDescription typeDescription) {
+      return builder;
+    }
   }
 }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/MuzzleVisitor.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/MuzzleVisitor.java
@@ -156,6 +156,29 @@ public class MuzzleVisitor implements AsmVisitorWrapper {
               "<init>",
               "(Ljava/lang/String;)V",
               false);
+          for (Reference.Source source : references[i].getSources()) {
+            mv.visitLdcInsn(source.getName());
+            mv.visitIntInsn(Opcodes.BIPUSH, source.getLine());
+            mv.visitMethodInsn(
+                Opcodes.INVOKEVIRTUAL,
+                "datadog/trace/agent/tooling/muzzle/Reference$Builder",
+                "withSource",
+                "(Ljava/lang/String;I)Ldatadog/trace/agent/tooling/muzzle/Reference$Builder;",
+                false);
+          }
+          for (Reference.Flag flag : references[i].getFlags()) {
+            mv.visitFieldInsn(
+                Opcodes.GETSTATIC,
+                "datadog/trace/agent/tooling/muzzle/Reference$Flag",
+                flag.name(),
+                "Ldatadog/trace/agent/tooling/muzzle/Reference$Flag;");
+            mv.visitMethodInsn(
+                Opcodes.INVOKEVIRTUAL,
+                "datadog/trace/agent/tooling/muzzle/Reference$Builder",
+                "withFlag",
+                "(Ldatadog/trace/agent/tooling/muzzle/Reference$Flag;)Ldatadog/trace/agent/tooling/muzzle/Reference$Builder;",
+                false);
+          }
           if (null != references[i].getSuperName()) {
             mv.visitLdcInsn(references[i].getSuperName());
             mv.visitMethodInsn(
@@ -174,14 +197,69 @@ public class MuzzleVisitor implements AsmVisitorWrapper {
                 "(Ljava/lang/String;)Ldatadog/trace/agent/tooling/muzzle/Reference$Builder;",
                 false);
           }
-          for (Reference.Source source : references[i].getSources()) {
-            mv.visitLdcInsn(source.getName());
-            mv.visitIntInsn(Opcodes.BIPUSH, source.getLine());
+          for (Reference.Field field : references[i].getFields()) {
+            mv.visitLdcInsn(field.getName());
+            mv.visitIntInsn(Opcodes.BIPUSH, field.getFlags().size());
+            mv.visitTypeInsn(
+                Opcodes.ANEWARRAY, "datadog/trace/agent/tooling/muzzle/Reference$Flag");
+
+            int j = 0;
+            for (Reference.Flag flag : field.getFlags()) {
+              mv.visitInsn(Opcodes.DUP);
+              mv.visitIntInsn(Opcodes.BIPUSH, j);
+              mv.visitFieldInsn(
+                  Opcodes.GETSTATIC,
+                  "datadog/trace/agent/tooling/muzzle/Reference$Flag",
+                  flag.name(),
+                  "Ldatadog/trace/agent/tooling/muzzle/Reference$Flag;");
+              mv.visitInsn(Opcodes.AASTORE);
+              ++j;
+            }
+
             mv.visitMethodInsn(
                 Opcodes.INVOKEVIRTUAL,
                 "datadog/trace/agent/tooling/muzzle/Reference$Builder",
-                "withSource",
-                "(Ljava/lang/String;I)Ldatadog/trace/agent/tooling/muzzle/Reference$Builder;",
+                "withField",
+                "(Ljava/lang/String;[Ldatadog/trace/agent/tooling/muzzle/Reference$Flag;)Ldatadog/trace/agent/tooling/muzzle/Reference$Builder;",
+                false);
+          }
+          for (Reference.Method method : references[i].getMethods()) {
+            mv.visitLdcInsn(method.getName());
+
+            mv.visitIntInsn(Opcodes.BIPUSH, method.getFlags().size());
+            mv.visitTypeInsn(
+                Opcodes.ANEWARRAY, "datadog/trace/agent/tooling/muzzle/Reference$Flag");
+            int j = 0;
+            for (Reference.Flag flag : method.getFlags()) {
+              mv.visitInsn(Opcodes.DUP);
+              mv.visitIntInsn(Opcodes.BIPUSH, j);
+              mv.visitFieldInsn(
+                  Opcodes.GETSTATIC,
+                  "datadog/trace/agent/tooling/muzzle/Reference$Flag",
+                  flag.name(),
+                  "Ldatadog/trace/agent/tooling/muzzle/Reference$Flag;");
+              mv.visitInsn(Opcodes.AASTORE);
+              ++j;
+            }
+
+            mv.visitLdcInsn(method.getReturnType());
+
+            mv.visitIntInsn(Opcodes.BIPUSH, method.getParameterTypes().size());
+            mv.visitTypeInsn(Opcodes.ANEWARRAY, "java/lang/String");
+
+            int k = 0;
+            for (String parameterType : method.getParameterTypes()) {
+              mv.visitInsn(Opcodes.DUP);
+              mv.visitIntInsn(Opcodes.BIPUSH, k);
+              mv.visitLdcInsn(parameterType);
+              mv.visitInsn(Opcodes.AASTORE);
+            }
+
+            mv.visitMethodInsn(
+                Opcodes.INVOKEVIRTUAL,
+                "datadog/trace/agent/tooling/muzzle/Reference$Builder",
+                "withMethod",
+                "(Ljava/lang/String;[Ldatadog/trace/agent/tooling/muzzle/Reference$Flag;Ljava/lang/String;[Ljava/lang/String;)Ldatadog/trace/agent/tooling/muzzle/Reference$Builder;",
                 false);
           }
           mv.visitMethodInsn(

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/Reference.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/Reference.java
@@ -26,6 +26,18 @@ public class Reference {
     return className;
   }
 
+  public String getSuperName() {
+    return superName;
+  }
+
+  public String[] getInterfaces() {
+    return interfaceNames;
+  }
+
+  public Source[] getSources() {
+    return sources;
+  }
+
   /**
    * TODO: doc
    *
@@ -136,6 +148,37 @@ public class Reference {
       String getMismatchDetails() {
         return "Missing class " + className;
       }
+    }
+  }
+
+  public static class Builder {
+    private final String className;
+    private String superName = null;
+    private Set<String> interfaces = new HashSet<>();
+    private Set<Source> sources = new HashSet<>();
+
+    public Builder(final String className) {
+      this.className = className;
+    }
+
+    public Builder withSuperName(String superName) {
+      this.superName = superName;
+      return this;
+    }
+
+    public Builder withInterface(String interfaceName) {
+      interfaces.add(interfaceName);
+      return this;
+    }
+
+    public Builder withSource(String sourceName, int line) {
+      sources.add(new Source(sourceName, line));
+      return this;
+    }
+
+    public Reference build() {
+      return new Reference(
+          sources.toArray(new Source[0]), className, superName, interfaces.toArray(new String[0]));
     }
   }
 }

--- a/dd-java-agent/instrumentation/instrumentation.gradle
+++ b/dd-java-agent/instrumentation/instrumentation.gradle
@@ -14,11 +14,22 @@ Project instr_project = project
 subprojects { subProj ->
   if (subProj.getParent() == instr_project) {
     apply plugin: "net.bytebuddy.byte-buddy"
+
     subProj.byteBuddy {
       transformation {
-        tasks = ["compileJava"]
-        plugin = "datadog.trace.agent.tooling.muzzle.MuzzleGradlePlugin"
-        classPath = project(':dd-java-agent:agent-tooling').configurations.instrumentationMuzzle
+        // Applying NoOp optimizes build by applying bytebuddy plugin to only compileJava task
+        tasks = ['compileJava']
+        plugin = 'datadog.trace.agent.tooling.muzzle.MuzzleGradlePlugin$NoOp'
+      }
+    }
+
+    subProj.afterEvaluate {
+      subProj.byteBuddy {
+        transformation {
+          tasks = ['compileJava']
+          plugin = 'datadog.trace.agent.tooling.muzzle.MuzzleGradlePlugin'
+          classPath = project(':dd-java-agent:agent-tooling').configurations.instrumentationMuzzle + subProj.configurations.compile + subProj.sourceSets.main.output
+        }
       }
     }
 

--- a/dd-java-agent/testing/src/test/groovy/muzzle/AdviceReferenceVisitorTest.groovy
+++ b/dd-java-agent/testing/src/test/groovy/muzzle/AdviceReferenceVisitorTest.groovy
@@ -4,6 +4,7 @@ import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.TestUtils
 import datadog.trace.agent.tooling.muzzle.AdviceReferenceVisitor
 import datadog.trace.agent.tooling.muzzle.ReferenceMatcher
+import datadog.trace.agent.tooling.muzzle.Reference
 
 class AdviceReferenceVisitorTest extends AgentTestRunner {
 
@@ -21,8 +22,9 @@ class AdviceReferenceVisitorTest extends AgentTestRunner {
 
   def "match safe classpaths"() {
     setup:
-    ReferenceMatcher refMatcher = new ReferenceMatcher()
-    refMatcher.assertSafeTransformation(AdviceClass.getName())
+    Reference[] refs = AdviceReferenceVisitor.createReferencesFrom(AdviceClass.getName(), this.getClass().getClassLoader()).values().toArray(new Reference[0])
+    ReferenceMatcher refMatcher = new ReferenceMatcher(refs)
+    refMatcher.assertSafeTransformation()
     ClassLoader safeClassloader = new URLClassLoader([TestUtils.createJarWithClasses(AdviceClass$A,
                                                                                      AdviceClass$SomeInterface,
                                                                                      AdviceClass$SomeImplementation)] as URL[],


### PR DESCRIPTION
(merge to integration branch)

Add flag, field, and method references to instrumentation muzzle.

They are not currently used in reference checking but the bytecode generation work is done.