### PR TITLE
Add Async Propogation to the Ratpack Scope and tests

### DIFF
--- a/dd-java-agent-ittests/dd-java-agent-ittests.gradle
+++ b/dd-java-agent-ittests/dd-java-agent-ittests.gradle
@@ -5,6 +5,9 @@ description = 'dd-java-agent-ittests'
 evaluationDependsOn(':dd-java-agent:agent-tooling')
 compileTestJava.dependsOn tasks.getByPath(':dd-java-agent:agent-tooling:testClasses')
 
+// These classes use Ratpack which requires Java 8. (Currently also incompatible with Java 9.)
+testJava8Only += ['**/ratpack/*.class']
+
 dependencies {
   testCompile project(':dd-trace-api')
   testCompile project(':dd-trace-ot')
@@ -19,12 +22,14 @@ dependencies {
 
   testCompile group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.3'
   testCompile group: 'com.squareup.okhttp3', name: 'okhttp', version: '3.6.0'
+  testCompile group: 'com.h2database', name: 'h2', version: '1.4.197'
 }
 
 tasks.withType(Test) {
   jvmArgs "-Ddd.writer.type=LogWriter", "-Ddd.service.name=java-app"
   jvmArgs "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=debug"
   jvmArgs "-Dorg.slf4j.simpleLogger.defaultLogLevel=debug"
+  jvmArgs "-Ddd.integration.ratpack.enabled=true"
 
   doFirst {
     // Defining here to allow jacoco to be first on the command line.

--- a/dd-java-agent-ittests/dd-java-agent-ittests.gradle
+++ b/dd-java-agent-ittests/dd-java-agent-ittests.gradle
@@ -29,7 +29,9 @@ tasks.withType(Test) {
   jvmArgs "-Ddd.writer.type=LogWriter", "-Ddd.service.name=java-app"
   jvmArgs "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=debug"
   jvmArgs "-Dorg.slf4j.simpleLogger.defaultLogLevel=debug"
-  jvmArgs "-Ddd.integration.ratpack.enabled=true"
+  if (!name.endsWith("Java7")) {
+    jvmArgs "-Ddd.integration.ratpack.enabled=true"
+  }
 
   doFirst {
     // Defining here to allow jacoco to be first on the command line.

--- a/dd-java-agent-ittests/src/test/groovy/datadog/trace/agent/integration/ratpack/RatpackInststrumentationTest.groovy
+++ b/dd-java-agent-ittests/src/test/groovy/datadog/trace/agent/integration/ratpack/RatpackInststrumentationTest.groovy
@@ -1,0 +1,113 @@
+package datadog.trace.agent.integration.ratpack
+
+import datadog.opentracing.DDSpan
+import datadog.opentracing.DDTracer
+import datadog.trace.agent.test.IntegrationTestUtils
+import datadog.trace.api.DDSpanTypes
+import datadog.trace.common.writer.ListWriter
+import io.opentracing.tag.Tags
+import org.apache.http.HttpResponse
+import org.apache.http.client.HttpClient
+import org.apache.http.client.methods.HttpGet
+import org.apache.http.impl.client.HttpClientBuilder
+import org.h2.Driver
+import ratpack.exec.Blocking
+import ratpack.groovy.test.embed.GroovyEmbeddedApp
+import spock.lang.Shared
+import spock.lang.Specification
+
+import java.sql.Connection
+import java.sql.ResultSet
+import java.sql.Statement
+
+class RatpackInststrumentationTest extends Specification {
+
+
+  @Shared
+  def writer = new ListWriter()
+  @Shared
+  def tracer = new DDTracer(writer)
+
+  @Shared
+  GroovyEmbeddedApp server
+
+  def setupSpec() {
+    IntegrationTestUtils.registerOrReplaceGlobalTracer(tracer)
+    server = GroovyEmbeddedApp.ratpack {
+      handlers {
+        get {
+          Blocking.get {
+            Connection h2Connection = new Driver().connect("jdbc:h2:mem:integ-test", null)
+            Statement statement = h2Connection.createStatement()
+            ResultSet resultSet = statement.executeQuery('SELECT 1')
+            resultSet.next()
+            resultSet.getInt(1)
+          } then {
+            context.render("success${it}")
+          }
+        }
+      }
+    }
+    server.server.start()
+  }
+
+  def cleanupSpec() {
+    server.server.stop()
+  }
+
+  def setup() {
+    writer.clear()
+  }
+
+  def "trace request with propagation"() {
+    setup:
+
+    final HttpClientBuilder builder = HttpClientBuilder.create()
+
+    final HttpClient client = builder.build()
+    IntegrationTestUtils.runUnderTrace("someTrace") {
+      try {
+        HttpResponse response =
+          client.execute(new HttpGet(server.address))
+        assert response.getStatusLine().getStatusCode() == 200
+      } catch (Exception e) {
+        e.printStackTrace()
+        throw new RuntimeException(e)
+      }
+    }
+    expect:
+    // one trace on the server, one trace on the client
+    writer.size() == 2
+    final List<DDSpan> serverTrace = writer.get(0)
+    serverTrace.size() == 2
+
+    final List<DDSpan> clientTrace = writer.get(1)
+    clientTrace.size() == 3
+    clientTrace.get(0).getOperationName() == "someTrace"
+    // our instrumentation makes 2 spans for apache-httpclient
+    final DDSpan localSpan = clientTrace.get(1)
+    localSpan.getType() == null
+    localSpan.getTags()[Tags.COMPONENT.getKey()] == "apache-httpclient"
+    localSpan.getOperationName() == "apache.http"
+
+    final DDSpan clientSpan = clientTrace.get(2)
+    clientSpan.getOperationName() == "http.request"
+    clientSpan.getType() == DDSpanTypes.HTTP_CLIENT
+    clientSpan.getTags()[Tags.HTTP_METHOD.getKey()] == "GET"
+    clientSpan.getTags()[Tags.HTTP_STATUS.getKey()] == 200
+    clientSpan.getTags()[Tags.HTTP_URL.getKey()] == server.address.toString()
+    clientSpan.getTags()[Tags.PEER_HOSTNAME.getKey()] == server.address.host
+    clientSpan.getTags()[Tags.PEER_PORT.getKey()] == server.address.port
+    clientSpan.getTags()[Tags.SPAN_KIND.getKey()] == Tags.SPAN_KIND_CLIENT
+
+    // ensure that the db query is in the trace
+    serverTrace.get(1).operationName == 'h2.query'
+
+    // client trace propagates to server
+    clientSpan.getTraceId() == serverTrace.get(0).getTraceId()
+    // server span is parented under http client
+    clientSpan.getSpanId() == serverTrace.get(0).getParentId()
+
+    serverTrace.get(1).parentId == serverTrace.get(0).spanId
+  }
+}

--- a/dd-java-agent/instrumentation/ratpack-1.4/ratpack-1.4.gradle
+++ b/dd-java-agent/instrumentation/ratpack-1.4/ratpack-1.4.gradle
@@ -59,6 +59,10 @@ dependencies {
   testCompile group: 'io.ratpack', name: 'ratpack-test', version: '1.4.0'
 
   testCompile group: 'com.squareup.okhttp3', name: 'okhttp', version: '3.6.0'
+  testCompile project(':dd-java-agent:instrumentation:apache-httpclient-4.3')
+  testCompile project(':dd-java-agent:instrumentation:jdbc')
+  testCompile group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.3'
+  testCompile group: 'com.h2database', name: 'h2', version: '1.4.196'
 }
 
 configurations.latestDepTestCompile {

--- a/dd-java-agent/instrumentation/ratpack-1.4/src/main/java8/datadog/trace/instrumentation/ratpack/impl/TracingHandler.java
+++ b/dd-java-agent/instrumentation/ratpack-1.4/src/main/java8/datadog/trace/instrumentation/ratpack/impl/TracingHandler.java
@@ -2,6 +2,7 @@ package datadog.trace.instrumentation.ratpack.impl;
 
 import datadog.trace.api.DDSpanTypes;
 import datadog.trace.api.DDTags;
+import datadog.trace.context.TraceScope;
 import io.opentracing.Scope;
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
@@ -36,7 +37,9 @@ public final class TracingHandler implements Handler {
             .withTag(Tags.HTTP_METHOD.getKey(), request.getMethod().getName())
             .withTag(Tags.HTTP_URL.getKey(), request.getUri())
             .startActive(true);
-
+    if (scope instanceof TraceScope) {
+      ((TraceScope) scope).setAsyncPropagation(true);
+    }
     ctx.getResponse()
         .beforeSend(
             response -> {

--- a/dd-java-agent/instrumentation/ratpack-1.4/src/test/groovy/RatpackTest.groovy
+++ b/dd-java-agent/instrumentation/ratpack-1.4/src/test/groovy/RatpackTest.groovy
@@ -7,6 +7,11 @@ import io.opentracing.util.GlobalTracer
 import okhttp3.HttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import org.apache.http.client.methods.HttpGet
+import org.apache.http.impl.client.CloseableHttpClient
+import org.apache.http.impl.client.HttpClients
+import org.h2.Driver
+import ratpack.exec.Blocking
 import ratpack.exec.Promise
 import ratpack.exec.util.ParallelBatch
 import ratpack.groovy.test.embed.GroovyEmbeddedApp
@@ -14,6 +19,10 @@ import ratpack.http.HttpUrlBuilder
 import ratpack.http.client.HttpClient
 import ratpack.path.PathBinding
 import ratpack.test.exec.ExecHarness
+
+import java.sql.Connection
+import java.sql.ResultSet
+import java.sql.Statement
 
 class RatpackTest extends AgentTestRunner {
   static {
@@ -63,6 +72,55 @@ class RatpackTest extends AgentTestRunner {
     span.context().tags["http.status_code"] == 200
     span.context().tags["thread.name"] != null
     span.context().tags["thread.id"] != null
+  }
+
+  def "test db call"() {
+    setup:
+    def app = GroovyEmbeddedApp.ratpack {
+      handlers {
+        get {
+          Blocking.get {
+            Connection h2Connection = new Driver().connect("jdbc:h2:mem:integ-test", null)
+            Statement statement = h2Connection.createStatement()
+            ResultSet resultSet = statement.executeQuery('SELECT 1')
+            resultSet.next()
+            resultSet.getInt(1)
+          } then {
+            context.render("success${it}")
+          }
+        }
+      }
+    }
+    def request = new Request.Builder()
+      .url(app.address.toURL())
+      .get()
+      .build()
+    when:
+    def resp = client.newCall(request).execute()
+    then:
+    resp.code() == 200
+    resp.body.string() == "success1"
+
+    TEST_WRITER.size() == 1
+    def trace = TEST_WRITER.firstTrace()
+    trace.size() == 2
+    def span = trace[0]
+
+    span.context().serviceName == "unnamed-java-app"
+    span.context().operationName == "ratpack.handler"
+    span.context().resourceName == "GET /"
+    span.context().tags["component"] == "handler"
+    span.context().spanType == DDSpanTypes.WEB_SERVLET
+    !span.context().getErrorFlag()
+    span.context().tags["http.url"] == "/"
+    span.context().tags["http.method"] == "GET"
+    span.context().tags["span.kind"] == "server"
+    span.context().tags["http.status_code"] == 200
+    span.context().tags["thread.name"] != null
+    span.context().tags["thread.id"] != null
+
+    def dbSpan = trace[1]
+    dbSpan.context().operationName == "h2.query"
   }
 
   def "test path with bindings call"() {
@@ -228,6 +286,152 @@ class RatpackTest extends AgentTestRunner {
     clientTrace2.context().tags["http.status_code"] == 200
     clientTrace2.context().tags["thread.name"] != null
     clientTrace2.context().tags["thread.id"] != null
+
+    def nestedTrace = TEST_WRITER.get(1)
+    nestedTrace.size() == 1
+    def nestedSpan = nestedTrace[0] // simulated external system, second call
+
+    nestedSpan.context().serviceName == "unnamed-java-app"
+    nestedSpan.context().operationName == "ratpack.handler"
+    nestedSpan.context().resourceName == "GET /nested2"
+    nestedSpan.context().tags["component"] == "handler"
+    nestedSpan.context().spanType == DDSpanTypes.WEB_SERVLET
+    !nestedSpan.context().getErrorFlag()
+    nestedSpan.context().tags["http.url"] == "/nested2"
+    nestedSpan.context().tags["http.method"] == "GET"
+    nestedSpan.context().tags["span.kind"] == "server"
+    nestedSpan.context().tags["http.status_code"] == 200
+    nestedSpan.context().tags["thread.name"] != null
+    nestedSpan.context().tags["thread.id"] != null
+
+    def nestedTrace2 = TEST_WRITER.get(0)
+    nestedTrace2.size() == 1
+    def nestedSpan2 = nestedTrace2[0] // simulated external system, first call
+
+    nestedSpan2.context().serviceName == "unnamed-java-app"
+    nestedSpan2.context().operationName == "ratpack.handler"
+    nestedSpan2.context().resourceName == "GET /nested"
+    nestedSpan2.context().tags["component"] == "handler"
+    nestedSpan2.context().spanType == DDSpanTypes.WEB_SERVLET
+    !nestedSpan2.context().getErrorFlag()
+    nestedSpan2.context().tags["http.url"] == "/nested"
+    nestedSpan2.context().tags["http.method"] == "GET"
+    nestedSpan2.context().tags["span.kind"] == "server"
+    nestedSpan2.context().tags["http.status_code"] == 200
+    nestedSpan2.context().tags["thread.name"] != null
+    nestedSpan2.context().tags["thread.id"] != null
+  }
+
+  def "test path call using apache http client"() {
+    setup:
+
+    def external = GroovyEmbeddedApp.ratpack {
+      handlers {
+        get("nested") {
+          context.render("succ")
+        }
+        get("nested2") {
+          context.render("ess")
+        }
+      }
+    }
+
+    def app = GroovyEmbeddedApp.ratpack {
+      handlers {
+        get {
+          // 1st internal http client call to nested
+          CloseableHttpClient httpClient = HttpClients.createDefault()
+          Blocking.get {
+            def httpGet = new HttpGet(HttpUrlBuilder.base(external.address).path("nested").build())
+            def is = httpClient.execute(httpGet).entity.content
+            is.getText()
+          }.map { it }
+            .blockingMap { t ->
+            // make a 2nd http request and concatenate the two bodies together
+            def httpGet = new HttpGet(HttpUrlBuilder.base(external.address).path("nested2").build())
+            def is = httpClient.execute(httpGet).entity.content
+            "${t}${is.getText()}"
+          }
+          .close(httpClient)
+          .then {
+            context.render(it)
+          }
+        }
+      }
+    }
+    def request = new Request.Builder()
+      .url(app.address.toURL())
+      .get()
+      .build()
+    when:
+    def resp = client.newCall(request).execute()
+    then:
+    resp.code() == 200
+    resp.body().string() == "success"
+
+    // 3rd is the three traces, ratpack, http client 2 and http client 1
+    // 2nd is nested2 from the external server (the result of the 2nd internal http client call)
+    // 1st is nested from the external server (the result of the 1st internal http client call)
+    TEST_WRITER.size() == 3
+    def trace = TEST_WRITER.get(2)
+    trace.size() == 5
+    def span = trace[0]
+
+    span.context().serviceName == "unnamed-java-app"
+    span.context().operationName == "ratpack.handler"
+    span.context().resourceName == "GET /"
+    span.context().tags["component"] == "handler"
+    span.context().spanType == DDSpanTypes.WEB_SERVLET
+    !span.context().getErrorFlag()
+    span.context().tags["http.url"] == "/"
+    span.context().tags["http.method"] == "GET"
+    span.context().tags["span.kind"] == "server"
+    span.context().tags["http.status_code"] == 200
+    span.context().tags["thread.name"] != null
+    span.context().tags["thread.id"] != null
+
+    def clientTrace1 = trace[1] // Second http client call that receives the 'ess' of Success
+
+    clientTrace1.context().serviceName == "unnamed-java-app"
+    clientTrace1.context().operationName == "apache.http"
+    clientTrace1.context().tags["component"] == "apache-httpclient"
+    !clientTrace1.context().getErrorFlag()
+    clientTrace1.context().tags["thread.name"] != null
+    clientTrace1.context().tags["thread.id"] != null
+
+    def httpTrace1 = trace[2] // Second http client call that receives the 'ess' of Success
+
+    httpTrace1.context().serviceName == "unnamed-java-app"
+    httpTrace1.context().operationName == "http.request"
+    !httpTrace1.context().getErrorFlag()
+    httpTrace1.context().tags["http.method"] == "GET"
+    httpTrace1.context().tags["http.url"] == "${external.address}nested2"
+    httpTrace1.context().tags["span.kind"] == "client"
+    httpTrace1.context().tags["http.status_code"] == 200
+    httpTrace1.context().tags["thread.name"] != null
+    httpTrace1.context().tags["thread.id"] != null
+
+    def clientTrace2 = trace[3] // First http client call that receives the 'Succ' of Success
+
+    clientTrace2.context().serviceName == "unnamed-java-app"
+    clientTrace2.context().operationName == "apache.http"
+    clientTrace2.context().tags["component"] == "apache-httpclient"
+    !clientTrace2.context().getErrorFlag()
+    clientTrace2.context().tags["thread.name"] != null
+    clientTrace2.context().tags["thread.id"] != null
+
+
+    def httpTrace2 = trace[4] // Second http client call that receives the 'ess' of Success
+
+    httpTrace2.context().serviceName == "unnamed-java-app"
+    httpTrace2.context().operationName == "http.request"
+    !httpTrace2.context().getErrorFlag()
+    httpTrace2.context().tags["http.method"] == "GET"
+    httpTrace2.context().tags["http.url"] == "${external.address}nested"
+    httpTrace2.context().tags["span.kind"] == "client"
+    httpTrace2.context().tags["http.status_code"] == 200
+    httpTrace2.context().tags["thread.name"] != null
+    httpTrace2.context().tags["thread.id"] != null
 
     def nestedTrace = TEST_WRITER.get(1)
     nestedTrace.size() == 1


### PR DESCRIPTION
Scopes were not propagating correctly causing many unrelated traces to be recorded when using the Ratpack integration. This PR fixes that.

The real change here is in TracingHandler calling setAsyncPropagation(true)

I've added unit and integration tests to cover the scenarios we were seeing where traces did not propagate.