### PR TITLE
Clear TEST_WRITER before waiting to ensure accurate timing

### DIFF
--- a/dd-java-agent/instrumentation/elasticsearch-transport-2/src/test/groovy/Elasticsearch2NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch-transport-2/src/test/groovy/Elasticsearch2NodeClientTest.groovy
@@ -39,6 +39,7 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
       .build()
     testNode = NodeBuilder.newInstance().clusterName("test-cluster").settings(settings).build()
     testNode.start()
+    TEST_WRITER.clear()
     testNode.client().admin().cluster().prepareHealth().setWaitForYellowStatus().execute().actionGet(5000)
     TEST_WRITER.waitForTraces(1)
   }

--- a/dd-java-agent/instrumentation/elasticsearch-transport-2/src/test/groovy/Elasticsearch2TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch-transport-2/src/test/groovy/Elasticsearch2TransportClientTest.groovy
@@ -50,6 +50,7 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
         .build()
     ).build()
     client.addTransportAddress(new InetSocketTransportAddress(InetAddress.getByName("localhost"), TCP_PORT))
+    TEST_WRITER.clear()
     client.admin().cluster().prepareHealth().setWaitForYellowStatus().execute().actionGet(5000)
     TEST_WRITER.waitForTraces(1)
   }

--- a/dd-java-agent/instrumentation/elasticsearch-transport-5/src/test/groovy/Elasticsearch5NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch-transport-5/src/test/groovy/Elasticsearch5NodeClientTest.groovy
@@ -45,6 +45,7 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
       .build()
     testNode = new Node(new Environment(InternalSettingsPreparer.prepareSettings(settings)), [Netty3Plugin])
     testNode.start()
+    TEST_WRITER.clear()
     testNode.client().admin().cluster().prepareHealth().setWaitForYellowStatus().execute().actionGet(5000)
     TEST_WRITER.waitForTraces(1)
   }

--- a/dd-java-agent/instrumentation/elasticsearch-transport-5/src/test/groovy/Elasticsearch5TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch-transport-5/src/test/groovy/Elasticsearch5TransportClientTest.groovy
@@ -57,6 +57,7 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
         .build()
     )
     client.addTransportAddress(new InetSocketTransportAddress(InetAddress.getByName("localhost"), TCP_PORT))
+    TEST_WRITER.clear()
     client.admin().cluster().prepareHealth().setWaitForYellowStatus().execute().actionGet(5000)
     TEST_WRITER.waitForTraces(1)
   }

--- a/dd-java-agent/instrumentation/elasticsearch-transport-6/src/test/groovy/Elasticsearch6NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch-transport-6/src/test/groovy/Elasticsearch6NodeClientTest.groovy
@@ -42,6 +42,7 @@ class Elasticsearch6NodeClientTest extends AgentTestRunner {
       .build()
     testNode = new Node(InternalSettingsPreparer.prepareEnvironment(settings, null), [Netty4Plugin])
     testNode.start()
+    TEST_WRITER.clear()
     testNode.client().admin().cluster().prepareHealth().setWaitForYellowStatus().execute().actionGet(5000)
     TEST_WRITER.waitForTraces(1)
   }

--- a/dd-java-agent/instrumentation/elasticsearch-transport-6/src/test/groovy/Elasticsearch6TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch-transport-6/src/test/groovy/Elasticsearch6TransportClientTest.groovy
@@ -54,6 +54,7 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
         .build()
     )
     client.addTransportAddress(new TransportAddress(InetAddress.getByName("localhost"), TCP_PORT))
+    TEST_WRITER.clear()
     client.admin().cluster().prepareHealth().setWaitForYellowStatus().execute().actionGet(5000)
     TEST_WRITER.waitForTraces(1)
   }


### PR DESCRIPTION
Otherwise the waitForTraces at the end might be triggered prematurely.

I think this should help the test errors.