### PR TITLE
Fix applications not exiting without explicit exit statement.

### DIFF
--- a/dd-trace-ot/src/main/java/datadog/opentracing/PendingTrace.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/PendingTrace.java
@@ -184,7 +184,9 @@ public class PendingTrace extends ConcurrentLinkedDeque<DDSpan> {
         new ThreadFactory() {
           @Override
           public Thread newThread(final Runnable r) {
-            return new Thread(r, "dd-span-cleaner");
+            final Thread thread = new Thread(r, "dd-span-cleaner");
+            thread.setDaemon(true);
+            return thread;
           }
         };
 


### PR DESCRIPTION
Set span cleaner threads to be daemon threads so that applications can exit without explicit exit statement.