### PR TITLE
Fix span time boundaries

### DIFF
--- a/dd-trace-ot/src/main/java/datadog/opentracing/PendingTrace.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/PendingTrace.java
@@ -30,6 +30,7 @@ public class PendingTrace extends ConcurrentLinkedDeque<DDSpan> {
   private final DDTracer tracer;
   private final long traceId;
 
+  // TODO: consider moving these time fields into DDTracer to ensure that traces have precise relative time
   /** Trace start time in nano seconds measured up to a millisecond accuracy */
   private final long startTimeNano;
   /** Nano second ticks value at trace start */

--- a/dd-trace-ot/src/main/java/datadog/trace/common/util/Clock.java
+++ b/dd-trace-ot/src/main/java/datadog/trace/common/util/Clock.java
@@ -26,7 +26,7 @@ public class Clock {
    *
    * @return The current nanos ticks
    */
-  public static synchronized long currentNanoTicks() {
+  public static long currentNanoTicks() {
     return System.nanoTime();
   }
 
@@ -35,7 +35,17 @@ public class Clock {
    *
    * @return the current epoch time in micros
    */
-  public static synchronized long currentMicroTime() {
+  public static long currentMicroTime() {
     return TimeUnit.MILLISECONDS.toMicros(System.currentTimeMillis());
+  }
+
+  /**
+   * Get the current time in nanos. The actual precision is the millis Note: this will overflow in
+   * ~290 years after epoch
+   *
+   * @return the current epoch time in nanos
+   */
+  public static long currentNanoTime() {
+    return TimeUnit.MILLISECONDS.toNanos(System.currentTimeMillis());
   }
 }

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/DDSpanTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/DDSpanTest.groovy
@@ -103,6 +103,8 @@ class DDSpanTest extends Specification {
     def total = System.nanoTime() - start
 
     expect:
+    // Generous 5 seconds to execute this test
+    Math.abs(TimeUnit.NANOSECONDS.toSeconds(span.startTime) - TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis())) < 5
     span.durationNano > betweenDur
     span.durationNano < total
     span.durationNano % mod > 0 // Very slim chance of a false negative.
@@ -121,6 +123,8 @@ class DDSpanTest extends Specification {
     def total = Math.max(1, System.currentTimeMillis() - start)
 
     expect:
+    // Generous 5 seconds to execute this test
+    Math.abs(TimeUnit.NANOSECONDS.toSeconds(span.startTime) - TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis())) < 5
     span.durationNano >= TimeUnit.MILLISECONDS.toNanos(betweenDur)
     span.durationNano <= TimeUnit.MILLISECONDS.toNanos(total)
     span.durationNano % mod == 0 || span.durationNano == 1
@@ -138,6 +142,8 @@ class DDSpanTest extends Specification {
     def total = System.currentTimeMillis() - start + 1
 
     expect:
+    // Generous 5 seconds to execute this test
+    Math.abs(TimeUnit.NANOSECONDS.toSeconds(span.startTime) - TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis())) < 5
     span.durationNano >= TimeUnit.MILLISECONDS.toNanos(betweenDur)
     span.durationNano <= TimeUnit.MILLISECONDS.toNanos(total)
     span.durationNano % mod == 0

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/PendingTraceTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/PendingTraceTest.groovy
@@ -4,6 +4,8 @@ import datadog.trace.common.writer.ListWriter
 import spock.lang.Specification
 import spock.lang.Subject
 
+import java.util.concurrent.TimeUnit
+
 
 class PendingTraceTest extends Specification {
   def writer = new ListWriter()
@@ -150,7 +152,7 @@ class PendingTraceTest extends Specification {
   }
 
 
-  def "child spans created after trace written" () {
+  def "child spans created after trace written"() {
     setup:
     rootSpan.finish()
     // this shouldn't happen, but it's possible users of the api
@@ -163,5 +165,11 @@ class PendingTraceTest extends Specification {
     trace.pendingReferenceCount.get() == 0
     trace.asList() == [rootSpan]
     writer == [[rootSpan]]
+  }
+
+  def "test getCurrentTimeNano"() {
+    expect:
+    // Generous 5 seconds to execute this test
+    Math.abs(TimeUnit.NANOSECONDS.toSeconds(trace.currentTimeNano) - TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis())) < 5
   }
 }


### PR DESCRIPTION
Currently `span`'s start times are created with millisecond precision and `span` duration has nanosecond precision. This causes problems for very short `span`s where parent's and child's boundaries may become confusing because parent `span` finishes before child `span` even starts.

This PR changes this logic to get single nanosecond-formatted millisecond precision time when `trace` is started and then measuring both duration and start time of `span`s using that start time. This makes `span`s start time and duration time come from the same source which makes them consistent.