### PR TITLE
 Enable coverage checks in CI for java8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,7 +131,7 @@ jobs:
     docker:
       - image: circleci/openjdk:8-jdk
       - image: datadog/docker-dd-agent
-        env:
+        environment:
           - DD_APM_ENABLED=true
           - DD_BIND_HOST=0.0.0.0
           - DD_API_KEY=invalid_key_but_this_is_fine

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,7 +116,8 @@ jobs:
     <<: *default_test_job
     environment:
       - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-      - TEST_TASK: test latestDepTest
+      # Tests under Java8 should have complete coverage.
+      - TEST_TASK: test latestDepTest jacocoTestCoverageVerification jacocoTestReport
 
   test_9:
     <<: *default_test_job
@@ -124,7 +125,6 @@ jobs:
       - JAVA9_HOME: /usr/lib/jvm/zulu-9-amd64
       - TEST_TASK: testJava9 latestDepTestJava9
       - INSTALL_ZULU: zulu-9
-
 
   agent_integration_tests:
     <<: *defaults

--- a/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/LettuceAsyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/LettuceAsyncClientTest.groovy
@@ -55,6 +55,8 @@ class LettuceAsyncClientTest extends AgentTestRunner {
   RedisClient redisClient = RedisClient.create(EMBEDDED_DB_URI)
 
   @Shared
+  StatefulConnection connection
+  @Shared
   RedisAsyncCommands<String, ?> asyncCommands = null
 
   @Shared
@@ -67,11 +69,14 @@ class LettuceAsyncClientTest extends AgentTestRunner {
   def setupSpec() {
     println "Using redis: $redisServer.args"
     redisServer.start()
-    StatefulConnection connection = redisClient.connect()
+    connection = redisClient.connect()
     asyncCommands = connection.async()
+    TEST_WRITER.waitForTraces(1)
+    TEST_WRITER.clear()
   }
 
   def cleanupSpec() {
+    connection.close()
     redisServer.stop()
   }
 

--- a/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/LettuceReactiveClientTest.groovy
+++ b/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/LettuceReactiveClientTest.groovy
@@ -38,16 +38,21 @@ class LettuceReactiveClientTest extends AgentTestRunner {
   RedisClient redisClient = RedisClient.create(EMBEDDED_DB_URI)
 
   @Shared
+  StatefulConnection connection
+  @Shared
   RedisReactiveCommands<String, ?> reactiveCommands = null
 
   def setupSpec() {
     println "Using redis: $redisServer.args"
     redisServer.start()
-    StatefulConnection connection = redisClient.connect()
+    connection = redisClient.connect()
     reactiveCommands = connection.reactive()
+    TEST_WRITER.waitForTraces(1)
+    TEST_WRITER.clear()
   }
 
   def cleanupSpec() {
+    connection.close()
     redisServer.stop()
   }
   

--- a/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/LettuceSyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/LettuceSyncClientTest.groovy
@@ -56,6 +56,8 @@ class LettuceSyncClientTest extends AgentTestRunner {
     redisServer.start()
     StatefulConnection connection = redisClient.connect()
     syncCommands = connection.sync()
+    TEST_WRITER.waitForTraces(1)
+    TEST_WRITER.clear()
   }
 
   def cleanupSpec() {

--- a/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/LettuceSyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/LettuceSyncClientTest.groovy
@@ -43,6 +43,8 @@ class LettuceSyncClientTest extends AgentTestRunner {
   RedisClient redisClient = RedisClient.create(EMBEDDED_DB_URI)
 
   @Shared
+  StatefulConnection connection
+  @Shared
   RedisCommands<String, ?> syncCommands = null
 
   @Shared
@@ -54,13 +56,14 @@ class LettuceSyncClientTest extends AgentTestRunner {
 
   def setupSpec() {
     redisServer.start()
-    StatefulConnection connection = redisClient.connect()
+    connection = redisClient.connect()
     syncCommands = connection.sync()
     TEST_WRITER.waitForTraces(1)
     TEST_WRITER.clear()
   }
 
   def cleanupSpec() {
+    connection.close()
     redisServer.stop()
   }
 


### PR DESCRIPTION
This enabled coverage checks in CI.
Unfortunately this is not really bullet proof, for example checks will not be performed if there are no tests, e.g.: mongo-async-3.3.