### PR TITLE
Close Jetty Handler scope

### DIFF
--- a/dd-java-agent/instrumentation/jetty-8/src/main/java/datadog/trace/instrumentation/jetty8/HandlerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-8/src/main/java/datadog/trace/instrumentation/jetty8/HandlerInstrumentation.java
@@ -129,6 +129,7 @@ public final class HandlerInstrumentation extends Instrumenter.Configurable {
           final AtomicBoolean activated = new AtomicBoolean(false);
           // what if async is already finished? This would not be called
           req.getAsyncContext().addListener(new TagSettingAsyncListener(activated, span));
+          scope.close();
         } else {
           Tags.HTTP_STATUS.set(span, resp.getStatus());
           scope.close();


### PR DESCRIPTION
@tylerbenson The jetty handler instrumentation has the same scope-close bug as the servlet.

I'm trying to write a test for this, but I'm not sure how to do async in the Handler API. Any idea what the correct way to do that is?