### PR TITLE
Increase timeouts in UrlConnection test

### DIFF
--- a/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/UrlConnectionTest.groovy
+++ b/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/UrlConnectionTest.groovy
@@ -19,8 +19,8 @@ class UrlConnectionTest extends AgentTestRunner {
     when:
     runUnderTrace("someTrace") {
       URLConnection connection = url.openConnection()
-      connection.setConnectTimeout(10)
-      connection.setReadTimeout(10)
+      connection.setConnectTimeout(10000)
+      connection.setReadTimeout(10000)
       assert GlobalTracer.get().scopeManager().active() != null
       connection.inputStream
     }


### PR DESCRIPTION
Before those timeouts where set to 10ms which legitimatelly can come
before server (even localhost) has a chance to reply with 'connection
refused'.

This should fix flaky test.