### PR TITLE
Remove most shadow relocates

### DIFF
--- a/dd-java-agent-ittests/src/test/groovy/datadog/trace/agent/integration/classloading/ShadowPackageRenamingTest.groovy
+++ b/dd-java-agent-ittests/src/test/groovy/datadog/trace/agent/integration/classloading/ShadowPackageRenamingTest.groovy
@@ -19,7 +19,7 @@ class ShadowPackageRenamingTest extends Specification {
     final String agentGuavaDep =
       ddClass
         .getClassLoader()
-        .loadClass("datadog.trace.agent.deps.google.common.collect.MapMaker")
+        .loadClass("com.google.common.collect.MapMaker")
         .getProtectionDomain()
         .getCodeSource()
         .getLocation()
@@ -99,7 +99,6 @@ class ShadowPackageRenamingTest extends Specification {
    expect:
    duplicateClassFile == []
    badBootstrapPrefixes == []
-    // ListenableFuture is skipped from shadow due to cassandra instrumentation.
-   badAgentPrefixes == ['com.google.common.util.concurrent.ListenableFuture']
+   badAgentPrefixes == []
   }
 }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Utils.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Utils.java
@@ -16,10 +16,21 @@ public class Utils {
     "datadog.trace.context"
   };
   public static final String[] AGENT_PACKAGE_PREFIXES = {
-    "datadog.trace.agent",
-    "datadog.opentracing",
     "datadog.trace.common",
-    "datadog.trace.instrumentation"
+    "datadog.trace.agent",
+    "datadog.trace.instrumentation",
+    // guava
+    "com.google.auto",
+    "com.google.common",
+    "com.google.thirdparty.publicsuffix",
+    // bytebuddy
+    "net.bytebuddy",
+    // OT contribs for dd trace resolver
+    "io.opentracing.contrib",
+    // jackson
+    "org.msgpack",
+    "com.fasterxml.jackson",
+    "org.yaml.snakeyaml"
   };
 
   private static Method findLoadedClassMethod = null;

--- a/dd-java-agent/dd-java-agent.gradle
+++ b/dd-java-agent/dd-java-agent.gradle
@@ -41,23 +41,9 @@ def includeShadowJar(subproject, jarname) {
       relocate 'java.util.logging.Logger', 'datadog.trace.bootstrap.PatchLogger'
 
       if (!project.hasProperty("disableShadowRelocate") || !disableShadowRelocate) {
+        // shadow OT impl to prevent casts to implementation
         relocate 'datadog.trace.common', 'datadog.trace.agent.common'
         relocate 'datadog.opentracing', 'datadog.trace.agent.ot'
-
-        relocate('io.opentracing.contrib', 'datadog.trace.agent.opentracing.contrib') {
-          // Don't want to change the annotation we're looking for.
-          exclude 'io.opentracing.contrib.dropwizard.Trace'
-        }
-
-        relocate 'org.yaml', 'datadog.trace.agent.deps.yaml'
-        relocate 'org.msgpack', 'datadog.trace.agent.deps.msgpack'
-        relocate 'com.fasterxml', 'datadog.trace.agent.deps.fasterxml'
-
-        relocate 'net.bytebuddy', 'datadog.trace.agent.deps.bytebuddy'
-        relocate('com.google', 'datadog.trace.agent.deps.google') {
-          // This is used in the Cassandra Cluster.connectAsync signature so we can't relocate it. :fingers_crossed:
-          exclude 'com.google.common.util.concurrent.ListenableFuture'
-        }
       }
     }
   }


### PR DESCRIPTION
Most shadow relocates are a holdover from before our bootstrapping process. This PR removes the unneeded shadows to fix subtle instrumentation bugs which can happen when instrumentation references a class which is later relocated.