### PR TITLE
Add test build for Java 10.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,6 +125,13 @@ jobs:
       - TEST_TASK: testJava9 latestDepTestJava9 jacocoTestReport jacocoTestCoverageVerification
       - INSTALL_ZULU: zulu-9
 
+  test_10:
+    <<: *default_test_job
+    environment:
+      - JAVA10_HOME: /usr/lib/jvm/zulu-10-amd64
+      - TEST_TASK: testJava10 latestDepTestJava10 jacocoTestReport jacocoTestCoverageVerification
+      - INSTALL_ZULU: zulu-10
+
   agent_integration_tests:
     <<: *defaults
     docker:
@@ -245,6 +252,12 @@ workflows:
           filters:
             tags:
               only: /.*/
+      - test_10:
+          requires:
+            - build
+          filters:
+            tags:
+              only: /.*/
 
       - agent_integration_tests:
           requires:
@@ -265,6 +278,7 @@ workflows:
             - test_7
             - test_8
             - test_9
+            - test_10
             - agent_integration_tests
           filters:
             branches:
@@ -277,6 +291,7 @@ workflows:
             - test_7
             - test_8
             - test_9
+            - test_10
             - agent_integration_tests
           filters:
             branches:

--- a/dd-trace-java.gradle
+++ b/dd-trace-java.gradle
@@ -38,7 +38,6 @@ description = 'dd-trace-java'
 
 task traceAgentTest {}
 task latestDepTest {}
-task latestDepTestJava9 {}
 
 // Applied here to allow publishing of artifactory build info
 apply from: "${rootDir}/gradle/publish.gradle"

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -44,7 +44,7 @@ repositories {
 dependencies {
   testCompile deps.junit
   testCompile group: 'org.assertj', name: 'assertj-core', version: '2.9.+'
-  testCompile group: 'org.mockito', name: 'mockito-core', version: '2.7.22'
+  testCompile group: 'org.mockito', name: 'mockito-core', version: '2.19.0'
 
   testCompile deps.spock
   testCompile deps.groovy
@@ -118,7 +118,7 @@ project.ext.testJava8Only = []
 project.ext.testJava8Minimum = []
 
 tasks.withType(Test) {
-  if (name.endsWith("Java7") || name.endsWith("Java9")) {
+  if (name.endsWith("Java7") || name.endsWith("Java9") || name.endsWith("Java10")) {
     return
   }
 
@@ -151,6 +151,21 @@ tasks.withType(Test) {
       }
     }
     tasks.check.dependsOn testJ9
+  }
+
+  def java10Home = System.getenv("JAVA10_HOME")
+  if (java10Home != null) {
+    def testJ10 = task "${cloned.name}Java10"(type: cloned.class) {
+      description "Runs $cloned.name under java 10"
+      // TODO: Pull from environment variable:
+      executable = "$java10Home/bin/java"
+      jvmArgs '--add-opens'
+      jvmArgs 'java.base/jdk.internal.loader=ALL-UNNAMED'
+      project.afterEvaluate {
+        exclude project.testJava8Only
+      }
+    }
+    tasks.check.dependsOn testJ10
   }
 }
 


### PR DESCRIPTION
We still require `--add-opens java.base/jdk.internal.loader=ALL-UNNAMED` to be set.  Something we should look into fixing somehow.