### PR TITLE
Do not use advice class names in Lettuce instrumentation directly

### DIFF
--- a/dd-java-agent/instrumentation/lettuce-5/src/main/java/datadog/trace/instrumentation/lettuce/LettuceAsyncCommandsInstrumentation.java
+++ b/dd-java-agent/instrumentation/lettuce-5/src/main/java/datadog/trace/instrumentation/lettuce/LettuceAsyncCommandsInstrumentation.java
@@ -12,6 +12,9 @@ import net.bytebuddy.matcher.ElementMatcher;
 @AutoService(Instrumenter.class)
 public class LettuceAsyncCommandsInstrumentation extends Instrumenter.Default {
 
+  public static final String PACKAGE =
+      LettuceAsyncCommandsInstrumentation.class.getPackage().getName();
+
   public LettuceAsyncCommandsInstrumentation() {
     super("lettuce", "lettuce-5-async");
   }
@@ -29,9 +32,7 @@ public class LettuceAsyncCommandsInstrumentation extends Instrumenter.Default {
   @Override
   public String[] helperClassNames() {
     return new String[] {
-      LettuceAsyncCommandsInstrumentation.class.getPackage().getName() + ".LettuceAsyncBiFunction",
-      LettuceAsyncCommandsInstrumentation.class.getPackage().getName()
-          + ".LettuceInstrumentationUtil"
+      PACKAGE + ".LettuceAsyncBiFunction", PACKAGE + ".LettuceInstrumentationUtil"
     };
   }
 
@@ -42,7 +43,8 @@ public class LettuceAsyncCommandsInstrumentation extends Instrumenter.Default {
         isMethod()
             .and(named("dispatch"))
             .and(takesArgument(0, named("io.lettuce.core.protocol.RedisCommand"))),
-        LettuceAsyncCommandsAdvice.class.getName());
+        // Cannot reference class directly here because this would lead to class load failure on Java7
+        PACKAGE + ".LettuceAsyncCommandsAdvice");
     return transformers;
   }
 }

--- a/dd-java-agent/instrumentation/lettuce-5/src/main/java/datadog/trace/instrumentation/lettuce/LettuceClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/lettuce-5/src/main/java/datadog/trace/instrumentation/lettuce/LettuceClientInstrumentation.java
@@ -12,11 +12,13 @@ import net.bytebuddy.matcher.ElementMatcher;
 @AutoService(Instrumenter.class)
 public final class LettuceClientInstrumentation extends Instrumenter.Default {
 
+  public static final String PACKAGE = LettuceClientInstrumentation.class.getPackage().getName();
+
   private static final String[] HELPER_CLASS_NAMES =
       new String[] {
         LettuceReactiveCommandsInstrumentation.class.getPackage().getName()
             + ".LettuceInstrumentationUtil",
-        LettuceClientInstrumentation.class.getPackage().getName() + ".LettuceAsyncBiFunction"
+        PACKAGE + ".LettuceAsyncBiFunction"
       };
 
   public LettuceClientInstrumentation() {
@@ -48,7 +50,8 @@ public final class LettuceClientInstrumentation extends Instrumenter.Default {
             .and(nameStartsWith("connect"))
             .and(nameEndsWith("Async"))
             .and(takesArgument(1, named("io.lettuce.core.RedisURI"))),
-        ConnectionFutureAdvice.class.getName());
+        // Cannot reference class directly here because this would lead to class load failure on Java7
+        PACKAGE + ".ConnectionFutureAdvice");
     return transformers;
   }
 }

--- a/dd-java-agent/instrumentation/lettuce-5/src/main/java/datadog/trace/instrumentation/lettuce/LettuceReactiveCommandsInstrumentation.java
+++ b/dd-java-agent/instrumentation/lettuce-5/src/main/java/datadog/trace/instrumentation/lettuce/LettuceReactiveCommandsInstrumentation.java
@@ -5,14 +5,15 @@ import static net.bytebuddy.matcher.ElementMatchers.*;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
-import datadog.trace.instrumentation.lettuce.rx.LettuceFluxCreationAdvice;
-import datadog.trace.instrumentation.lettuce.rx.LettuceMonoCreationAdvice;
 import java.util.HashMap;
 import java.util.Map;
 import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(Instrumenter.class)
 public class LettuceReactiveCommandsInstrumentation extends Instrumenter.Default {
+
+  public static final String PACKAGE =
+      LettuceReactiveCommandsInstrumentation.class.getPackage().getName();
 
   public LettuceReactiveCommandsInstrumentation() {
     super("lettuce", "lettuce-5-rx");
@@ -31,18 +32,12 @@ public class LettuceReactiveCommandsInstrumentation extends Instrumenter.Default
   @Override
   public String[] helperClassNames() {
     return new String[] {
-      LettuceReactiveCommandsInstrumentation.class.getPackage().getName()
-          + ".LettuceInstrumentationUtil",
-      LettuceReactiveCommandsInstrumentation.class.getPackage().getName()
-          + ".rx.LettuceMonoCreationAdvice",
-      LettuceReactiveCommandsInstrumentation.class.getPackage().getName()
-          + ".rx.LettuceMonoDualConsumer",
-      LettuceReactiveCommandsInstrumentation.class.getPackage().getName()
-          + ".rx.LettuceFluxCreationAdvice",
-      LettuceReactiveCommandsInstrumentation.class.getPackage().getName()
-          + ".rx.LettuceFluxTerminationRunnable",
-      LettuceReactiveCommandsInstrumentation.class.getPackage().getName()
-          + ".rx.LettuceFluxTerminationRunnable$FluxOnSubscribeConsumer"
+      PACKAGE + ".LettuceInstrumentationUtil",
+      PACKAGE + ".rx.LettuceMonoCreationAdvice",
+      PACKAGE + ".rx.LettuceMonoDualConsumer",
+      PACKAGE + ".rx.LettuceFluxCreationAdvice",
+      PACKAGE + ".rx.LettuceFluxTerminationRunnable",
+      PACKAGE + ".rx.LettuceFluxTerminationRunnable$FluxOnSubscribeConsumer"
     };
   }
 
@@ -54,14 +49,16 @@ public class LettuceReactiveCommandsInstrumentation extends Instrumenter.Default
             .and(named("createMono"))
             .and(takesArgument(0, named("java.util.function.Supplier")))
             .and(returns(named("reactor.core.publisher.Mono"))),
-        LettuceMonoCreationAdvice.class.getName());
+        // Cannot reference class directly here because this would lead to class load failure on Java7
+        PACKAGE + ".rx.LettuceMonoCreationAdvice");
     transformers.put(
         isMethod()
             .and(nameStartsWith("create"))
             .and(nameEndsWith("Flux"))
             .and(takesArgument(0, named("java.util.function.Supplier")))
             .and(returns(named(("reactor.core.publisher.Flux")))),
-        LettuceFluxCreationAdvice.class.getName());
+        // Cannot reference class directly here because this would lead to class load failure on Java7
+        PACKAGE + ".rx.LettuceFluxCreationAdvice");
 
     return transformers;
   }


### PR DESCRIPTION
Since this leads to Java8 code loaded into Java7 JVM in tests.
Insted reference class names by string.