### PR TITLE
Mar kolya/improve random port handling

### DIFF
--- a/dd-java-agent/instrumentation/elasticsearch-transport-2/src/test/groovy/Elasticsearch2NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch-transport-2/src/test/groovy/Elasticsearch2NodeClientTest.groovy
@@ -16,19 +16,22 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
     System.setProperty("dd.integration.elasticsearch.enabled", "true")
   }
 
-  static final int HTTP_PORT = TestUtils.randomOpenPort()
-  static final int TCP_PORT = TestUtils.randomOpenPort()
-
   @Shared
-  static Node testNode
-  static File esWorkingDir
+  int httpPort
+  @Shared
+  int tcpPort
+  @Shared
+  Node testNode
+  @Shared
+  File esWorkingDir
 
   def client = testNode.client()
 
   def setupSpec() {
-    esWorkingDir = File.createTempFile("test-es-working-dir-", "")
-    esWorkingDir.delete()
-    esWorkingDir.mkdir()
+    httpPort = TestUtils.randomOpenPort()
+    tcpPort = TestUtils.randomOpenPort()
+
+    esWorkingDir = File.createTempDir("test-es-working-dir-", "")
     esWorkingDir.deleteOnExit()
     println "ES work dir: $esWorkingDir"
 
@@ -36,8 +39,8 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
       .put("path.home", esWorkingDir.path)
       // Since we use listeners to close spans this should make our span closing deterministic which is good for tests
       .put("thread_pool.listener.size", 1)
-      .put("http.port", HTTP_PORT)
-      .put("transport.tcp.port", TCP_PORT)
+      .put("http.port", httpPort)
+      .put("transport.tcp.port", tcpPort)
       .build()
     testNode = NodeBuilder.newInstance().local(true).clusterName("test-cluster").settings(settings).build()
     testNode.start()

--- a/dd-java-agent/instrumentation/elasticsearch-transport-2/src/test/groovy/Elasticsearch2SpringTemplateTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch-transport-2/src/test/groovy/Elasticsearch2SpringTemplateTest.groovy
@@ -26,20 +26,23 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
     System.setProperty("dd.integration.elasticsearch.enabled", "true")
   }
 
-  static final int HTTP_PORT = TestUtils.randomOpenPort()
-  static final int TCP_PORT = TestUtils.randomOpenPort()
+  @Shared
+  int httpPort
+  @Shared
+  int tcpPort
+  @Shared
+  Node testNode
+  @Shared
+  File esWorkingDir
 
   @Shared
-  static Node testNode
-  static File esWorkingDir
-
-  @Shared
-  static ElasticsearchTemplate template
+  ElasticsearchTemplate template
 
   def setupSpec() {
-    esWorkingDir = File.createTempFile("test-es-working-dir-", "")
-    esWorkingDir.delete()
-    esWorkingDir.mkdir()
+    httpPort = TestUtils.randomOpenPort()
+    tcpPort = TestUtils.randomOpenPort()
+
+    esWorkingDir = File.createTempDir("test-es-working-dir-", "")
     esWorkingDir.deleteOnExit()
     println "ES work dir: $esWorkingDir"
 
@@ -47,8 +50,8 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
       .put("path.home", esWorkingDir.path)
       // Since we use listeners to close spans this should make our span closing deterministic which is good for tests
       .put("thread_pool.listener.size", 1)
-      .put("http.port", HTTP_PORT)
-      .put("transport.tcp.port", TCP_PORT)
+      .put("http.port", httpPort)
+      .put("transport.tcp.port", tcpPort)
       .build()
     testNode = NodeBuilder.newInstance().local(true).clusterName("test-cluster").settings(settings).build()
     testNode.start()

--- a/dd-java-agent/instrumentation/elasticsearch-transport-2/src/test/groovy/Elasticsearch2TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch-transport-2/src/test/groovy/Elasticsearch2TransportClientTest.groovy
@@ -19,27 +19,30 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
     System.setProperty("dd.integration.elasticsearch.enabled", "true")
   }
 
-  static final int HTTP_PORT = TestUtils.randomOpenPort()
-  static final int TCP_PORT = TestUtils.randomOpenPort()
+  @Shared
+  int httpPort
+  @Shared
+  int tcpPort
+  @Shared
+  Node testNode
+  @Shared
+  File esWorkingDir
 
   @Shared
-  static Node testNode
-  static File esWorkingDir
-
-  @Shared
-  static TransportClient client
+  TransportClient client
 
   def setupSpec() {
-    esWorkingDir = File.createTempFile("test-es-working-dir-", "")
-    esWorkingDir.delete()
-    esWorkingDir.mkdir()
+    httpPort = TestUtils.randomOpenPort()
+    tcpPort = TestUtils.randomOpenPort()
+
+    esWorkingDir = File.createTempDir("test-es-working-dir-", "")
     esWorkingDir.deleteOnExit()
     println "ES work dir: $esWorkingDir"
 
     def settings = Settings.builder()
       .put("path.home", esWorkingDir.path)
-      .put("http.port", HTTP_PORT)
-      .put("transport.tcp.port", TCP_PORT)
+      .put("http.port", httpPort)
+      .put("transport.tcp.port", tcpPort)
       .build()
     testNode = NodeBuilder.newInstance().clusterName("test-cluster").settings(settings).build()
     testNode.start()
@@ -51,7 +54,7 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
         .put("cluster.name", "test-cluster")
         .build()
     ).build()
-    client.addTransportAddress(new InetSocketTransportAddress(InetAddress.getByName("localhost"), TCP_PORT))
+    client.addTransportAddress(new InetSocketTransportAddress(InetAddress.getByName("localhost"), tcpPort))
     TEST_WRITER.clear()
     client.admin().cluster().prepareHealth().setWaitForYellowStatus().execute().actionGet(5000)
     TEST_WRITER.waitForTraces(1)
@@ -87,7 +90,7 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME.key" "127.0.0.1"
             "$Tags.PEER_HOST_IPV4.key" "127.0.0.1"
-            "$Tags.PEER_PORT.key" TCP_PORT
+            "$Tags.PEER_PORT.key" tcpPort
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
             defaultTags()
@@ -185,7 +188,7 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
             "elasticsearch.request.indices" indexName
             "$Tags.PEER_HOSTNAME.key" "127.0.0.1"
             "$Tags.PEER_HOST_IPV4.key" "127.0.0.1"
-            "$Tags.PEER_PORT.key" TCP_PORT
+            "$Tags.PEER_PORT.key" tcpPort
             defaultTags()
           }
         }
@@ -203,7 +206,7 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
             "elasticsearch.request" "ClusterHealthRequest"
             "$Tags.PEER_HOSTNAME.key" "127.0.0.1"
             "$Tags.PEER_HOST_IPV4.key" "127.0.0.1"
-            "$Tags.PEER_PORT.key" TCP_PORT
+            "$Tags.PEER_PORT.key" tcpPort
             defaultTags()
           }
         }
@@ -219,7 +222,7 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME.key" "127.0.0.1"
             "$Tags.PEER_HOST_IPV4.key" "127.0.0.1"
-            "$Tags.PEER_PORT.key" TCP_PORT
+            "$Tags.PEER_PORT.key" tcpPort
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -257,7 +260,7 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME.key" "127.0.0.1"
             "$Tags.PEER_HOST_IPV4.key" "127.0.0.1"
-            "$Tags.PEER_PORT.key" TCP_PORT
+            "$Tags.PEER_PORT.key" tcpPort
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
@@ -277,7 +280,7 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME.key" "127.0.0.1"
             "$Tags.PEER_HOST_IPV4.key" "127.0.0.1"
-            "$Tags.PEER_PORT.key" TCP_PORT
+            "$Tags.PEER_PORT.key" tcpPort
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName

--- a/dd-java-agent/instrumentation/elasticsearch-transport-5/src/test/groovy/Elasticsearch5NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch-transport-5/src/test/groovy/Elasticsearch5NodeClientTest.groovy
@@ -19,19 +19,22 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
     System.setProperty("dd.integration.elasticsearch.enabled", "true")
   }
 
-  static final int HTTP_PORT = TestUtils.randomOpenPort()
-  static final int TCP_PORT = TestUtils.randomOpenPort()
-
   @Shared
-  static Node testNode
-  static File esWorkingDir
+  int httpPort
+  @Shared
+  int tcpPort
+  @Shared
+  Node testNode
+  @Shared
+  File esWorkingDir
 
   def client = testNode.client()
 
   def setupSpec() {
-    esWorkingDir = File.createTempFile("test-es-working-dir-", "")
-    esWorkingDir.delete()
-    esWorkingDir.mkdir()
+    httpPort = TestUtils.randomOpenPort()
+    tcpPort = TestUtils.randomOpenPort()
+
+    esWorkingDir = File.createTempDir("test-es-working-dir-", "")
     esWorkingDir.deleteOnExit()
     println "ES work dir: $esWorkingDir"
 
@@ -39,8 +42,8 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
       .put("path.home", esWorkingDir.path)
       // Since we use listeners to close spans this should make our span closing deterministic which is good for tests
       .put("thread_pool.listener.size", 1)
-      .put("http.port", HTTP_PORT)
-      .put("transport.tcp.port", TCP_PORT)
+      .put("http.port", httpPort)
+      .put("transport.tcp.port", tcpPort)
       .put("transport.type", "netty3")
       .put("http.type", "netty3")
       .put(CLUSTER_NAME_SETTING.getKey(), "test-cluster")

--- a/dd-java-agent/instrumentation/elasticsearch-transport-5/src/test/groovy/Elasticsearch5TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch-transport-5/src/test/groovy/Elasticsearch5TransportClientTest.groovy
@@ -23,27 +23,30 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
     System.setProperty("dd.integration.elasticsearch.enabled", "true")
   }
 
-  static final int HTTP_PORT = TestUtils.randomOpenPort()
-  static final int TCP_PORT = TestUtils.randomOpenPort()
+  @Shared
+  int httpPort
+  @Shared
+  int tcpPort
+  @Shared
+  Node testNode
+  @Shared
+  File esWorkingDir
 
   @Shared
-  static Node testNode
-  static File esWorkingDir
-
-  @Shared
-  static TransportClient client
+  TransportClient client
 
   def setupSpec() {
-    esWorkingDir = File.createTempFile("test-es-working-dir-", "")
-    esWorkingDir.delete()
-    esWorkingDir.mkdir()
+    httpPort = TestUtils.randomOpenPort()
+    tcpPort = TestUtils.randomOpenPort()
+
+    esWorkingDir = File.createTempDir("test-es-working-dir-", "")
     esWorkingDir.deleteOnExit()
     println "ES work dir: $esWorkingDir"
 
     def settings = Settings.builder()
       .put("path.home", esWorkingDir.path)
-      .put("http.port", HTTP_PORT)
-      .put("transport.tcp.port", TCP_PORT)
+      .put("http.port", httpPort)
+      .put("transport.tcp.port", tcpPort)
       .put("transport.type", "netty3")
       .put("http.type", "netty3")
       .put(CLUSTER_NAME_SETTING.getKey(), "test-cluster")
@@ -58,7 +61,7 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
         .put(CLUSTER_NAME_SETTING.getKey(), "test-cluster")
         .build()
     )
-    client.addTransportAddress(new InetSocketTransportAddress(InetAddress.getByName("localhost"), TCP_PORT))
+    client.addTransportAddress(new InetSocketTransportAddress(InetAddress.getByName("localhost"), tcpPort))
     TEST_WRITER.clear()
     client.admin().cluster().prepareHealth().setWaitForYellowStatus().execute().actionGet(5000)
     TEST_WRITER.waitForTraces(1)
@@ -94,7 +97,7 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME.key" "127.0.0.1"
             "$Tags.PEER_HOST_IPV4.key" "127.0.0.1"
-            "$Tags.PEER_PORT.key" TCP_PORT
+            "$Tags.PEER_PORT.key" tcpPort
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
             defaultTags()
@@ -192,7 +195,7 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
             "elasticsearch.request.indices" indexName
             "$Tags.PEER_HOSTNAME.key" "127.0.0.1"
             "$Tags.PEER_HOST_IPV4.key" "127.0.0.1"
-            "$Tags.PEER_PORT.key" TCP_PORT
+            "$Tags.PEER_PORT.key" tcpPort
             defaultTags()
           }
         }
@@ -208,7 +211,7 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME.key" "127.0.0.1"
             "$Tags.PEER_HOST_IPV4.key" "127.0.0.1"
-            "$Tags.PEER_PORT.key" TCP_PORT
+            "$Tags.PEER_PORT.key" tcpPort
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -245,7 +248,7 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME.key" "127.0.0.1"
             "$Tags.PEER_HOST_IPV4.key" "127.0.0.1"
-            "$Tags.PEER_PORT.key" TCP_PORT
+            "$Tags.PEER_PORT.key" tcpPort
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
@@ -270,7 +273,7 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME.key" "127.0.0.1"
             "$Tags.PEER_HOST_IPV4.key" "127.0.0.1"
-            "$Tags.PEER_PORT.key" TCP_PORT
+            "$Tags.PEER_PORT.key" tcpPort
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName

--- a/dd-java-agent/instrumentation/elasticsearch-transport-6/src/test/groovy/Elasticsearch6NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch-transport-6/src/test/groovy/Elasticsearch6NodeClientTest.groovy
@@ -18,19 +18,22 @@ class Elasticsearch6NodeClientTest extends AgentTestRunner {
     System.setProperty("dd.integration.elasticsearch.enabled", "true")
   }
 
-  static final int HTTP_PORT = TestUtils.randomOpenPort()
-  static final int TCP_PORT = TestUtils.randomOpenPort()
-
   @Shared
-  static Node testNode
-  static File esWorkingDir
+  int httpPort
+  @Shared
+  int tcpPort
+  @Shared
+  Node testNode
+  @Shared
+  File esWorkingDir
 
   def client = testNode.client()
 
   def setupSpec() {
-    esWorkingDir = File.createTempFile("test-es-working-dir-", "")
-    esWorkingDir.delete()
-    esWorkingDir.mkdir()
+    httpPort = TestUtils.randomOpenPort()
+    tcpPort = TestUtils.randomOpenPort()
+
+    esWorkingDir = File.createTempDir("test-es-working-dir-", "")
     esWorkingDir.deleteOnExit()
     println "ES work dir: $esWorkingDir"
 
@@ -38,8 +41,8 @@ class Elasticsearch6NodeClientTest extends AgentTestRunner {
       .put("path.home", esWorkingDir.path)
       // Since we use listeners to close spans this should make our span closing deterministic which is good for tests
       .put("thread_pool.listener.size", 1)
-      .put("http.port", HTTP_PORT)
-      .put("transport.tcp.port", TCP_PORT)
+      .put("http.port", httpPort)
+      .put("transport.tcp.port", tcpPort)
       .put(CLUSTER_NAME_SETTING.getKey(), "test-cluster")
       .build()
     testNode = new Node(InternalSettingsPreparer.prepareEnvironment(settings, null), [Netty4Plugin])

--- a/dd-java-agent/instrumentation/elasticsearch-transport-6/src/test/groovy/Elasticsearch6TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch-transport-6/src/test/groovy/Elasticsearch6TransportClientTest.groovy
@@ -22,27 +22,30 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
     System.setProperty("dd.integration.elasticsearch.enabled", "true")
   }
 
-  static final int HTTP_PORT = TestUtils.randomOpenPort()
-  static final int TCP_PORT = TestUtils.randomOpenPort()
+  @Shared
+  int httpPort
+  @Shared
+  int tcpPort
+  @Shared
+  Node testNode
+  @Shared
+  File esWorkingDir
 
   @Shared
-  static Node testNode
-  static File esWorkingDir
-
-  @Shared
-  static TransportClient client
+  TransportClient client
 
   def setupSpec() {
-    esWorkingDir = File.createTempFile("test-es-working-dir-", "")
-    esWorkingDir.delete()
-    esWorkingDir.mkdir()
+    httpPort = TestUtils.randomOpenPort()
+    tcpPort = TestUtils.randomOpenPort()
+
+    esWorkingDir = File.createTempDir("test-es-working-dir-", "")
     esWorkingDir.deleteOnExit()
     println "ES work dir: $esWorkingDir"
 
     def settings = Settings.builder()
       .put("path.home", esWorkingDir.path)
-      .put("http.port", HTTP_PORT)
-      .put("transport.tcp.port", TCP_PORT)
+      .put("http.port", httpPort)
+      .put("transport.tcp.port", tcpPort)
       .put(CLUSTER_NAME_SETTING.getKey(), "test-cluster")
       .build()
     testNode = new Node(InternalSettingsPreparer.prepareEnvironment(settings, null), [Netty4Plugin])
@@ -55,7 +58,7 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
         .put(CLUSTER_NAME_SETTING.getKey(), "test-cluster")
         .build()
     )
-    client.addTransportAddress(new TransportAddress(InetAddress.getByName("localhost"), TCP_PORT))
+    client.addTransportAddress(new TransportAddress(InetAddress.getByName("localhost"), tcpPort))
     TEST_WRITER.clear()
     client.admin().cluster().prepareHealth().setWaitForYellowStatus().execute().actionGet(5000)
     TEST_WRITER.waitForTraces(1)
@@ -90,7 +93,7 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME.key" "localhost"
             "$Tags.PEER_HOST_IPV4.key" "127.0.0.1"
-            "$Tags.PEER_PORT.key" TCP_PORT
+            "$Tags.PEER_PORT.key" tcpPort
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
             defaultTags()
@@ -185,7 +188,7 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME.key" "localhost"
             "$Tags.PEER_HOST_IPV4.key" "127.0.0.1"
-            "$Tags.PEER_PORT.key" TCP_PORT
+            "$Tags.PEER_PORT.key" tcpPort
             "elasticsearch.action" "CreateIndexAction"
             "elasticsearch.request" "CreateIndexRequest"
             "elasticsearch.request.indices" indexName
@@ -204,7 +207,7 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME.key" "localhost"
             "$Tags.PEER_HOST_IPV4.key" "127.0.0.1"
-            "$Tags.PEER_PORT.key" TCP_PORT
+            "$Tags.PEER_PORT.key" tcpPort
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -241,7 +244,7 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME.key" "localhost"
             "$Tags.PEER_HOST_IPV4.key" "127.0.0.1"
-            "$Tags.PEER_PORT.key" TCP_PORT
+            "$Tags.PEER_PORT.key" tcpPort
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
@@ -267,7 +270,7 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME.key" "localhost"
             "$Tags.PEER_HOST_IPV4.key" "127.0.0.1"
-            "$Tags.PEER_PORT.key" TCP_PORT
+            "$Tags.PEER_PORT.key" tcpPort
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName

--- a/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/LettuceSyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/LettuceSyncClientTest.groovy
@@ -15,23 +15,25 @@ import static datadog.trace.instrumentation.lettuce.LettuceInstrumentationUtil.A
 
 class LettuceSyncClientTest extends AgentTestRunner {
   public static final String HOST = "127.0.0.1"
-  public static final int PORT = TestUtils.randomOpenPort()
-  public static final int INCORRECT_PORT = TestUtils.randomOpenPort()
   public static final int DB_INDEX = 0
-  public static final String DB_ADDR = HOST + ":" + PORT + "/" + DB_INDEX
-  public static final String DB_ADDR_NON_EXISTENT = HOST + ":" + INCORRECT_PORT + "/" + DB_INDEX
-  public static final String DB_URI_NON_EXISTENT = "redis://" + DB_ADDR_NON_EXISTENT
-  public static final String EMBEDDED_DB_URI = "redis://" + DB_ADDR
   // Disable autoreconnect so we do not get stray traces popping up on server shutdown
   public static final ClientOptions CLIENT_OPTIONS = ClientOptions.builder().autoReconnect(false).build()
 
   @Shared
-  RedisServer redisServer = RedisServer.builder()
-    // bind to localhost to avoid firewall popup
-    .setting("bind " + HOST)
-    // set max memory to avoid problems in CI
-    .setting("maxmemory 128M")
-    .port(PORT).build()
+  int port
+  @Shared
+  int incorrectPort
+  @Shared
+  String dbAddr
+  @Shared
+  String dbAddrNonExistent
+  @Shared
+  String dbUriNonExistent
+  @Shared
+  String embeddedDbUri
+
+  @Shared
+  RedisServer redisServer
 
   @Shared
   Map<String, String> testHashMap = [
@@ -40,11 +42,29 @@ class LettuceSyncClientTest extends AgentTestRunner {
           age:       "53"
   ]
 
-  RedisClient redisClient = RedisClient.create(EMBEDDED_DB_URI)
+  RedisClient redisClient
   StatefulConnection connection
   RedisCommands<String, ?> syncCommands
 
+  def setupSpec() {
+    port = TestUtils.randomOpenPort()
+    incorrectPort = TestUtils.randomOpenPort()
+    dbAddr = HOST + ":" + port + "/" + DB_INDEX
+    dbAddrNonExistent = HOST + ":" + incorrectPort + "/" + DB_INDEX
+    dbUriNonExistent = "redis://" + dbAddrNonExistent
+    embeddedDbUri = "redis://" + dbAddr
+
+    redisServer = RedisServer.builder()
+      // bind to localhost to avoid firewall popup
+      .setting("bind " + HOST)
+      // set max memory to avoid problems in CI
+      .setting("maxmemory 128M")
+      .port(port).build()
+  }
+
   def setup() {
+    redisClient = RedisClient.create(embeddedDbUri)
+
     redisServer.start()
     connection = redisClient.connect()
     syncCommands = connection.sync()
@@ -64,7 +84,7 @@ class LettuceSyncClientTest extends AgentTestRunner {
 
   def "connect"() {
     setup:
-    RedisClient testConnectionClient = RedisClient.create(EMBEDDED_DB_URI)
+    RedisClient testConnectionClient = RedisClient.create(embeddedDbUri)
     testConnectionClient.setOptions(CLIENT_OPTIONS)
 
     when:
@@ -77,17 +97,17 @@ class LettuceSyncClientTest extends AgentTestRunner {
           serviceName "redis"
           operationName "redis.query"
           spanType "redis"
-          resourceName "CONNECT:" + DB_ADDR
+          resourceName "CONNECT:" + dbAddr
           errored false
 
           tags {
             defaultTags()
             "component" "redis-client"
-            "db.redis.url" DB_ADDR
+            "db.redis.url" dbAddr
             "db.redis.dbIndex" 0
             "db.type" "redis"
             "peer.hostname" HOST
-            "peer.port" PORT
+            "peer.port" port
             "span.kind" "client"
             "span.type" "redis"
           }
@@ -101,7 +121,7 @@ class LettuceSyncClientTest extends AgentTestRunner {
 
   def "connect exception"() {
     setup:
-    RedisClient testConnectionClient = RedisClient.create(DB_URI_NON_EXISTENT)
+    RedisClient testConnectionClient = RedisClient.create(dbUriNonExistent)
     testConnectionClient.setOptions(CLIENT_OPTIONS)
 
     when:
@@ -115,18 +135,18 @@ class LettuceSyncClientTest extends AgentTestRunner {
           serviceName "redis"
           operationName "redis.query"
           spanType "redis"
-          resourceName "CONNECT:" + DB_ADDR_NON_EXISTENT
+          resourceName "CONNECT:" + dbAddrNonExistent
           errored true
 
           tags {
             defaultTags()
             "component" "redis-client"
-            "db.redis.url" DB_ADDR_NON_EXISTENT
+            "db.redis.url" dbAddrNonExistent
             "db.redis.dbIndex" 0
             "db.type" "redis"
             errorTags CompletionException, String
             "peer.hostname" HOST
-            "peer.port" INCORRECT_PORT
+            "peer.port" incorrectPort
             "span.kind" "client"
             "span.type" "redis"
           }

--- a/dd-java-agent/instrumentation/netty-4.0/src/test/groovy/Netty40ClientTest.groovy
+++ b/dd-java-agent/instrumentation/netty-4.0/src/test/groovy/Netty40ClientTest.groovy
@@ -22,10 +22,10 @@ class Netty40ClientTest extends AgentTestRunner {
     System.setProperty("dd.integration.netty.enabled", "true")
   }
 
-  static final PORT = TestUtils.randomOpenPort()
-
   @Shared
-  Server server = new Server(PORT)
+  int port
+  @Shared
+  Server server
   @Shared
   AsyncHttpClient asyncHttpClient = asyncHttpClient()
 //    DefaultAsyncHttpClientConfig.Builder.newInstance().setRequestTimeout(Integer.MAX_VALUE).build())
@@ -34,6 +34,9 @@ class Netty40ClientTest extends AgentTestRunner {
 
 
   def setupSpec() {
+    port = TestUtils.randomOpenPort()
+    server = new Server(port)
+
     Handler handler = [
       handle: { String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response ->
         request.getHeaderNames().each {
@@ -59,7 +62,7 @@ class Netty40ClientTest extends AgentTestRunner {
 
   def "test server request/response"() {
     setup:
-    def responseFuture = asyncHttpClient.prepareGet("http://localhost:$PORT/").execute()
+    def responseFuture = asyncHttpClient.prepareGet("http://localhost:$port/").execute()
     def response = responseFuture.get()
 
     expect:
@@ -79,7 +82,7 @@ class Netty40ClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "netty-client"
             "$Tags.HTTP_METHOD.key" "GET"
             "$Tags.HTTP_STATUS.key" 200
-            "$Tags.HTTP_URL.key" "http://localhost:$PORT/"
+            "$Tags.HTTP_URL.key" "http://localhost:$port/"
             "$Tags.PEER_HOSTNAME.key" "localhost"
             "$Tags.PEER_PORT.key" Integer
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT

--- a/dd-java-agent/instrumentation/netty-4.1/src/test/groovy/Netty41ClientTest.groovy
+++ b/dd-java-agent/instrumentation/netty-4.1/src/test/groovy/Netty41ClientTest.groovy
@@ -22,10 +22,10 @@ class Netty41ClientTest extends AgentTestRunner {
     System.setProperty("dd.integration.netty.enabled", "true")
   }
 
-  static final PORT = TestUtils.randomOpenPort()
-
   @Shared
-  Server server = new Server(PORT)
+  int port
+  @Shared
+  Server server
   @Shared
   AsyncHttpClient asyncHttpClient = asyncHttpClient()
 //    DefaultAsyncHttpClientConfig.Builder.newInstance().setRequestTimeout(Integer.MAX_VALUE).build())
@@ -34,6 +34,9 @@ class Netty41ClientTest extends AgentTestRunner {
 
 
   def setupSpec() {
+    port = TestUtils.randomOpenPort()
+    server = new Server(port)
+
     Handler handler = [
       handle: { String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response ->
         request.getHeaderNames().each {
@@ -59,7 +62,7 @@ class Netty41ClientTest extends AgentTestRunner {
 
   def "test server request/response"() {
     setup:
-    def responseFuture = asyncHttpClient.prepareGet("http://localhost:$PORT/").execute()
+    def responseFuture = asyncHttpClient.prepareGet("http://localhost:$port/").execute()
     def response = responseFuture.get()
 
     expect:
@@ -79,7 +82,7 @@ class Netty41ClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "netty-client"
             "$Tags.HTTP_METHOD.key" "GET"
             "$Tags.HTTP_STATUS.key" 200
-            "$Tags.HTTP_URL.key" "http://localhost:$PORT/"
+            "$Tags.HTTP_URL.key" "http://localhost:$port/"
             "$Tags.PEER_HOSTNAME.key" "localhost"
             "$Tags.PEER_PORT.key" Integer
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT

--- a/dd-java-agent/instrumentation/play-2.4/src/latestDepTest/groovy/Play26Test.groovy
+++ b/dd-java-agent/instrumentation/play-2.4/src/latestDepTest/groovy/Play26Test.groovy
@@ -14,11 +14,12 @@ class Play26Test extends AgentTestRunner {
   }
 
   @Shared
-  int port = TestUtils.randomOpenPort()
+  int port
   @Shared
   TestServer testServer
 
   def setupSpec() {
+    port = TestUtils.randomOpenPort()
     testServer = Helpers.testServer(port, Play26TestUtils.buildTestApp())
     testServer.start()
   }

--- a/dd-java-agent/instrumentation/play-2.4/src/test/groovy/Play24Test.groovy
+++ b/dd-java-agent/instrumentation/play-2.4/src/test/groovy/Play24Test.groovy
@@ -9,11 +9,12 @@ import spock.lang.Shared
 
 class Play24Test extends AgentTestRunner {
   @Shared
-  int port = TestUtils.randomOpenPort()
+  int port
   @Shared
   TestServer testServer
 
   def setupSpec() {
+    port = TestUtils.randomOpenPort()
     testServer = Helpers.testServer(port, Play24TestUtils.buildTestApp())
     testServer.start()
   }

--- a/dd-java-agent/instrumentation/servlet-3/src/test/groovy/JettyServlet3Test.groovy
+++ b/dd-java-agent/instrumentation/servlet-3/src/test/groovy/JettyServlet3Test.groovy
@@ -28,10 +28,10 @@ import static datadog.trace.agent.test.ListWriterAssert.assertTraces
 
 class JettyServlet3Test extends AgentTestRunner {
 
-  static final int PORT = TestUtils.randomOpenPort()
-
   // Jetty needs this to ensure consistent ordering for async.
   CountDownLatch latch = new CountDownLatch(1)
+
+  int port
 
   OkHttpClient client = new OkHttpClient.Builder()
     .addNetworkInterceptor(new Interceptor() {
@@ -61,7 +61,8 @@ class JettyServlet3Test extends AgentTestRunner {
   DDTracer tracer = new DDTracer(writer)
 
   def setup() {
-    jettyServer = new Server(PORT)
+    port = TestUtils.randomOpenPort()
+    jettyServer = new Server(port)
     servletContext = new ServletContextHandler()
 
     ConstraintSecurityHandler security = setupAuthentication(jettyServer)
@@ -76,7 +77,7 @@ class JettyServlet3Test extends AgentTestRunner {
     jettyServer.start()
 
     System.out.println(
-      "Jetty server: http://localhost:" + PORT + "/")
+      "Jetty server: http://localhost:" + port + "/")
 
     try {
       GlobalTracer.register(tracer)
@@ -98,7 +99,7 @@ class JettyServlet3Test extends AgentTestRunner {
   def "test #path servlet call"() {
     setup:
     def requestBuilder = new Request.Builder()
-      .url("http://localhost:$PORT/$path")
+      .url("http://localhost:$port/$path")
       .get()
     if (auth) {
       requestBuilder.header(HttpHeaders.AUTHORIZATION, Credentials.basic("user", "password"))
@@ -118,7 +119,7 @@ class JettyServlet3Test extends AgentTestRunner {
           errored false
           parent()
           tags {
-            "http.url" "http://localhost:$PORT/$path"
+            "http.url" "http://localhost:$port/$path"
             "http.method" "GET"
             "span.kind" "server"
             "component" "java-web-servlet"
@@ -145,7 +146,7 @@ class JettyServlet3Test extends AgentTestRunner {
   def "servlet instrumentation clears state after async request"() {
     setup:
     def request = new Request.Builder()
-      .url("http://localhost:$PORT/async")
+      .url("http://localhost:$port/async")
       .get()
       .build()
     def numTraces = 5
@@ -170,7 +171,7 @@ class JettyServlet3Test extends AgentTestRunner {
   def "test #path error servlet call"() {
     setup:
     def request = new Request.Builder()
-      .url("http://localhost:$PORT/$path?error=true")
+      .url("http://localhost:$port/$path?error=true")
       .get()
       .build()
     def response = client.newCall(request).execute()
@@ -188,7 +189,7 @@ class JettyServlet3Test extends AgentTestRunner {
           errored true
           parent()
           tags {
-            "http.url" "http://localhost:$PORT/$path"
+            "http.url" "http://localhost:$port/$path"
             "http.method" "GET"
             "span.kind" "server"
             "component" "java-web-servlet"
@@ -211,7 +212,7 @@ class JettyServlet3Test extends AgentTestRunner {
   def "test #path non-throwing-error servlet call"() {
     setup:
     def request = new Request.Builder()
-      .url("http://localhost:$PORT/$path?non-throwing-error=true")
+      .url("http://localhost:$port/$path?non-throwing-error=true")
       .get()
       .build()
     def response = client.newCall(request).execute()
@@ -229,7 +230,7 @@ class JettyServlet3Test extends AgentTestRunner {
           errored true
           parent()
           tags {
-            "http.url" "http://localhost:$PORT/$path"
+            "http.url" "http://localhost:$port/$path"
             "http.method" "GET"
             "span.kind" "server"
             "component" "java-web-servlet"

--- a/dd-java-agent/instrumentation/servlet-3/src/test/groovy/TomcatServlet3Test.groovy
+++ b/dd-java-agent/instrumentation/servlet-3/src/test/groovy/TomcatServlet3Test.groovy
@@ -18,7 +18,7 @@ import static datadog.trace.agent.test.ListWriterAssert.assertTraces
 
 class TomcatServlet3Test extends AgentTestRunner {
 
-  static final int PORT = TestUtils.randomOpenPort()
+  int port
   OkHttpClient client = new OkHttpClient.Builder()
   // Uncomment when debugging:
 //    .connectTimeout(1, TimeUnit.HOURS)
@@ -33,8 +33,9 @@ class TomcatServlet3Test extends AgentTestRunner {
   DDTracer tracer = new DDTracer(writer)
 
   def setup() {
+    port = TestUtils.randomOpenPort()
     tomcatServer = new Tomcat()
-    tomcatServer.setPort(PORT)
+    tomcatServer.setPort(port)
 
     def baseDir = Files.createTempDir()
     baseDir.deleteOnExit()
@@ -61,7 +62,7 @@ class TomcatServlet3Test extends AgentTestRunner {
 
     tomcatServer.start()
     System.out.println(
-      "Tomcat server: http://" + tomcatServer.getHost().getName() + ":" + PORT + "/")
+      "Tomcat server: http://" + tomcatServer.getHost().getName() + ":" + port + "/")
 
 
     try {
@@ -84,7 +85,7 @@ class TomcatServlet3Test extends AgentTestRunner {
   def "test #path servlet call"() {
     setup:
     def request = new Request.Builder()
-      .url("http://localhost:$PORT/my-context/$path")
+      .url("http://localhost:$port/my-context/$path")
       .get()
       .build()
     def response = client.newCall(request).execute()
@@ -102,7 +103,7 @@ class TomcatServlet3Test extends AgentTestRunner {
           errored false
           parent()
           tags {
-            "http.url" "http://localhost:$PORT/my-context/$path"
+            "http.url" "http://localhost:$port/my-context/$path"
             "http.method" "GET"
             "span.kind" "server"
             "component" "java-web-servlet"
@@ -124,7 +125,7 @@ class TomcatServlet3Test extends AgentTestRunner {
   def "test #path error servlet call"() {
     setup:
     def request = new Request.Builder()
-      .url("http://localhost:$PORT/my-context/$path?error=true")
+      .url("http://localhost:$port/my-context/$path?error=true")
       .get()
       .build()
     def response = client.newCall(request).execute()
@@ -142,7 +143,7 @@ class TomcatServlet3Test extends AgentTestRunner {
           errored true
           parent()
           tags {
-            "http.url" "http://localhost:$PORT/my-context/$path"
+            "http.url" "http://localhost:$port/my-context/$path"
             "http.method" "GET"
             "span.kind" "server"
             "component" "java-web-servlet"
@@ -165,7 +166,7 @@ class TomcatServlet3Test extends AgentTestRunner {
   def "test #path error servlet call for non-throwing error"() {
     setup:
     def request = new Request.Builder()
-      .url("http://localhost:$PORT/my-context/$path?non-throwing-error=true")
+      .url("http://localhost:$port/my-context/$path?non-throwing-error=true")
       .get()
       .build()
     def response = client.newCall(request).execute()
@@ -183,7 +184,7 @@ class TomcatServlet3Test extends AgentTestRunner {
           errored true
           parent()
           tags {
-            "http.url" "http://localhost:$PORT/my-context/$path"
+            "http.url" "http://localhost:$port/my-context/$path"
             "http.method" "GET"
             "span.kind" "server"
             "component" "java-web-servlet"


### PR DESCRIPTION
Stop using static fields for random ports in tests. It is possible that those fields are initialized much-much earlier than actual server is started and port is actually used. This might lead to 'port reuse' before port has a chance to get used.

The aim here is to improve stability of the build.