### PR TITLE
Allow service name mapping to apply without setting the tag.

### DIFF
--- a/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
@@ -509,7 +509,7 @@ public class DDTracer implements io.opentracing.Tracer {
         if (!ddsc.getTags().isEmpty()) {
           tags.putAll(ddsc.getTags());
         }
-        parentTrace = new PendingTrace(DDTracer.this, traceId);
+        parentTrace = new PendingTrace(DDTracer.this, traceId, serviceNameMappings);
         samplingPriority = ddsc.getSamplingPriority();
 
         // Start a new trace
@@ -517,16 +517,12 @@ public class DDTracer implements io.opentracing.Tracer {
         traceId = generateNewId();
         parentSpanId = 0L;
         baggage = null;
-        parentTrace = new PendingTrace(DDTracer.this, traceId);
+        parentTrace = new PendingTrace(DDTracer.this, traceId, serviceNameMappings);
         samplingPriority = PrioritySampling.UNSET;
       }
 
       if (serviceName == null) {
         serviceName = DDTracer.this.serviceName;
-      }
-
-      if (serviceNameMappings.containsKey(serviceName)) {
-        serviceName = serviceNameMappings.get(serviceName);
       }
 
       final String operationName =

--- a/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
@@ -57,6 +57,8 @@ public class DDTracer implements io.opentracing.Tracer {
 
   /** A set of tags that are added to every span */
   private final Map<String, String> spanTags;
+  /** A configured mapping of service names to update with new values */
+  private final Map<String, String> serviceNameMappings;
 
   /** Span context decorators */
   private final Map<String, List<AbstractDecorator>> spanContextDecorators =
@@ -116,6 +118,7 @@ public class DDTracer implements io.opentracing.Tracer {
     this.writer.start();
     this.sampler = sampler;
     this.spanTags = defaultSpanTags;
+    this.serviceNameMappings = serviceNameMappings;
 
     try {
       Runtime.getRuntime()
@@ -520,6 +523,10 @@ public class DDTracer implements io.opentracing.Tracer {
 
       if (serviceName == null) {
         serviceName = DDTracer.this.serviceName;
+      }
+
+      if (serviceNameMappings.containsKey(serviceName)) {
+        serviceName = serviceNameMappings.get(serviceName);
       }
 
       final String operationName =

--- a/dd-trace-ot/src/main/java/datadog/opentracing/decorators/DDDecoratorsFactory.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/decorators/DDDecoratorsFactory.java
@@ -24,7 +24,7 @@ public class DDDecoratorsFactory {
         httpDecorator2,
         new OperationDecorator(),
         new ResourceNameDecorator(),
-        new ServiceNameDecorator(mappings),
+        new ServiceNameDecorator(),
         new ServletContextDecorator(),
         new SpanTypeDecorator(),
         new Status5XXDecorator(),

--- a/dd-trace-ot/src/main/java/datadog/opentracing/decorators/ServiceNameDecorator.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/decorators/ServiceNameDecorator.java
@@ -2,25 +2,17 @@ package datadog.opentracing.decorators;
 
 import datadog.opentracing.DDSpanContext;
 import datadog.trace.api.DDTags;
-import java.util.Map;
 
 public class ServiceNameDecorator extends AbstractDecorator {
 
-  private final Map<String, String> mappings;
-
-  public ServiceNameDecorator(final Map<String, String> mappings) {
+  public ServiceNameDecorator() {
     super();
     this.setMatchingTag(DDTags.SERVICE_NAME);
-    this.mappings = mappings;
   }
 
   @Override
   public boolean shouldSetTag(final DDSpanContext context, final String tag, final Object value) {
-    if (mappings.containsKey(String.valueOf(value))) {
-      context.setServiceName(mappings.get(String.valueOf(value)));
-    } else {
-      context.setServiceName(String.valueOf(value));
-    }
+    context.setServiceName(String.valueOf(value));
     return false;
   }
 }

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/DDSpanBuilderTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/DDSpanBuilderTest.groovy
@@ -120,7 +120,7 @@ class DDSpanBuilderTest extends Specification {
 
     when(mockedContext.getSpanId()).thenReturn(spanId)
     when(mockedContext.getServiceName()).thenReturn("foo")
-    when(mockedContext.getTrace()).thenReturn(new PendingTrace(tracer, 1L))
+    when(mockedContext.getTrace()).thenReturn(new PendingTrace(tracer, 1L, [:]))
 
     final String expectedName = "fakeName"
 

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/DDSpanSerializationTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/DDSpanSerializationTest.groovy
@@ -50,7 +50,7 @@ class DDSpanSerializationTest extends Specification {
         false,
         "type",
         tags,
-        new PendingTrace(tracer, 1L),
+        new PendingTrace(tracer, 1L, [:]),
         tracer)
 
     baggage.put(DDTags.THREAD_NAME, Thread.currentThread().getName())

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/DDSpanTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/DDSpanTest.groovy
@@ -26,7 +26,7 @@ class DDSpanTest extends Specification {
         false,
         "fakeType",
         null,
-        new PendingTrace(tracer, 1L),
+        new PendingTrace(tracer, 1L, [:]),
         tracer)
 
     final DDSpan span = new DDSpan(1L, context)
@@ -159,7 +159,7 @@ class DDSpanTest extends Specification {
     span.durationNano == 1
   }
 
-  def "priority sampling metric set only on root span" () {
+  def "priority sampling metric set only on root span"() {
     setup:
     def parent = tracer.buildSpan("testParent").start()
     def child1 = tracer.buildSpan("testChild1").asChildOf(parent).start()

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/PendingTraceTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/PendingTraceTest.groovy
@@ -15,7 +15,7 @@ class PendingTraceTest extends Specification {
   def traceId = System.identityHashCode(this)
 
   @Subject
-  PendingTrace trace = new PendingTrace(tracer, traceId)
+  PendingTrace trace = new PendingTrace(tracer, traceId, [:])
 
   DDSpan rootSpan = SpanFactory.newSpanOf(trace)
 
@@ -130,7 +130,7 @@ class PendingTraceTest extends Specification {
 
   def "register span to wrong trace fails"() {
     setup:
-    def otherTrace = new PendingTrace(tracer, traceId - 10)
+    def otherTrace = new PendingTrace(tracer, traceId - 10, [:])
     otherTrace.registerSpan(new DDSpan(0, rootSpan.context()))
 
     expect:
@@ -141,7 +141,7 @@ class PendingTraceTest extends Specification {
 
   def "add span to wrong trace fails"() {
     setup:
-    def otherTrace = new PendingTrace(tracer, traceId - 10)
+    def otherTrace = new PendingTrace(tracer, traceId - 10, [:])
     rootSpan.finish()
     otherTrace.addSpan(rootSpan)
 

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/SpanFactory.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/SpanFactory.groovy
@@ -19,7 +19,7 @@ class SpanFactory {
       false,
       "fakeType",
       Collections.emptyMap(),
-      new PendingTrace(tracer, 1L),
+      new PendingTrace(tracer, 1L, [:]),
       tracer)
     return new DDSpan(timestampMicro, context)
   }
@@ -37,7 +37,7 @@ class SpanFactory {
       false,
       "fakeType",
       Collections.emptyMap(),
-      new PendingTrace(tracer, 1L),
+      new PendingTrace(tracer, 1L, [:]),
       tracer)
     return new DDSpan(1, context)
   }
@@ -75,7 +75,7 @@ class SpanFactory {
       false,
       "fakeType",
       Collections.emptyMap(),
-      new PendingTrace(tracer, 1L),
+      new PendingTrace(tracer, 1L, [:]),
       tracer)
     context.setTag("env", envName)
     return new DDSpan(0l, context)

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/decorators/SpanDecoratorTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/decorators/SpanDecoratorTest.groovy
@@ -42,10 +42,11 @@ class SpanDecoratorTest extends Specification {
 
   def "set service name"() {
     setup:
-    tracer.addDecorator(new ServiceNameDecorator(mapping))
+    tracer = new DDTracer("wrong-service", new LoggingWriter(), new AllSampler(), emptyMap(), mapping, emptyMap())
 
     when:
-    span.setTag(DDTags.SERVICE_NAME, name)
+    def span = tracer.buildSpan("some span").withTag(DDTags.SERVICE_NAME, name).start()
+    span.finish()
 
     then:
     span.getServiceName() == expected

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/decorators/URLAsResourceNameTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/decorators/URLAsResourceNameTest.groovy
@@ -98,7 +98,7 @@ class URLAsResourceNameTest extends Specification {
         false,
         "fakeType",
         tags,
-        new PendingTrace(tracer, 1L),
+        new PendingTrace(tracer, 1L, [:]),
         tracer)
 
     then:

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/propagation/HTTPCodecTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/propagation/HTTPCodecTest.groovy
@@ -44,7 +44,7 @@ class HTTPCodecTest extends Specification {
         false,
         "fakeType",
         null,
-        new PendingTrace(tracer, 1L),
+        new PendingTrace(tracer, 1L, [:]),
         tracer)
 
     final Map<String, String> carrier = new HashMap<>()

--- a/dd-trace-ot/src/test/groovy/datadog/trace/DDTraceConfigTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/trace/DDTraceConfigTest.groovy
@@ -1,7 +1,6 @@
 package datadog.trace
 
 import datadog.opentracing.DDTracer
-import datadog.opentracing.decorators.ServiceNameDecorator
 import datadog.trace.common.DDTraceConfig
 import datadog.trace.common.sampling.AllSampler
 import datadog.trace.common.writer.DDAgentWriter
@@ -119,14 +118,11 @@ class DDTraceConfigTest extends Specification {
 
     when:
     def tracer = new DDTracer()
-    ServiceNameDecorator decorator = tracer.spanContextDecorators.values().flatten().find {
-      it instanceof ServiceNameDecorator
-    }
     def taggedHeaders = tracer.registry.codecs.values().first().taggedHeaders
 
     then:
     tracer.spanTags == map
-    decorator.mappings == map
+    tracer.serviceNameMappings == map
     taggedHeaders == map
 
     where:

--- a/dd-trace-ot/src/traceAgentTest/groovy/DDApiIntegrationTest.groovy
+++ b/dd-trace-ot/src/traceAgentTest/groovy/DDApiIntegrationTest.groovy
@@ -28,7 +28,7 @@ class DDApiIntegrationTest {
       false,
       "fakeType",
       Collections.emptyMap(),
-      new PendingTrace(TRACER, 1L),
+      new PendingTrace(TRACER, 1L, [:]),
       TRACER)
 
     def api = new DDApi(DDAgentWriter.DEFAULT_HOSTNAME, DDAgentWriter.DEFAULT_PORT, v4())


### PR DESCRIPTION
Previously the mapping only applied when the `service.name` tag was set, not on the default or configured service name.