### PR TITLE
Disable coverage checks for LoggingWriter

### DIFF
--- a/dd-trace-ot/dd-trace-ot.gradle
+++ b/dd-trace-ot/dd-trace-ot.gradle
@@ -11,6 +11,7 @@ minimumBranchCoverage = 0.5
 minimumInstructionCoverage = 0.6
 excludedClassesConverage += [
   'datadog.trace.common.writer.ListWriter',
+  'datadog.trace.common.writer.LoggingWriter',
   'datadog.trace.common.sampling.PrioritySampling'
 ]
 


### PR DESCRIPTION
The build fails from time to time complaining about this class not
being tested. Looks like randomness of thi is due to Gradle's caching.

Ideally we would like to have this class tested, but Lombok injecting
logger doesn't really provide much of a room to test there.