### PR TITLE
Don’t use cache across versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,6 @@ cache_keys: &cache_keys
     - dd-trace-java-{{ checksum "dd-trace-java.gradle" }}-{{ .Branch }}-{{ .Revision }}
     - dd-trace-java-{{ checksum "dd-trace-java.gradle" }}-{{ .Branch }}
     - dd-trace-java-{{ checksum "dd-trace-java.gradle" }}
-    - dd-trace-java
 
 
 jobs:
@@ -153,7 +152,6 @@ jobs:
             - dd-trace-java-{{ checksum "dd-trace-java.gradle" }}-{{ .Branch }}-{{ .Revision }}
             - dd-trace-java-{{ checksum "dd-trace-java.gradle" }}-{{ .Branch }}
             - dd-trace-java-{{ checksum "dd-trace-java.gradle" }}
-            - dd-trace-java
 
       - run:
           name: Run Trace Agent Tests

--- a/dd-trace-java.gradle
+++ b/dd-trace-java.gradle
@@ -12,7 +12,7 @@ buildscript {
 }
 
 plugins {
-  id 'com.gradle.build-scan' version '1.14'
+  id 'com.gradle.build-scan' version '1.15.1'
   id 'com.github.sherter.google-java-format' version '0.7.1'
   id 'com.dorongold.task-tree' version '1.3'
 }


### PR DESCRIPTION
Cache is growing too big and causing slower build times.

(include minor upgrade to trigger a cache miss.)