### PR TITLE
Don't check for helper classes in muzzle reference check

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/Reference.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/Reference.java
@@ -120,11 +120,7 @@ public class Reference {
   private boolean onClasspath(final String className, final ClassLoader loader) {
     final String resourceName = Utils.getResourceName(className);
     return loader.getResource(resourceName) != null
-        // helper classes are not on the resource path because they are loaded with reflection (See
-        // HelperInjector)
-        || (className.startsWith("datadog.trace.")
-            && Utils.findLoadedClass(className, loader) != null)
-        // bootstrap class
+        // we can also reach bootstrap classes
         || Utils.getBootstrapProxy().getResource(resourceName) != null;
   }
 


### PR DESCRIPTION
@mar-kolya Since we're already checking for helper classes in the Reference Matcher we can skip the additional check in `onClasspath` (https://github.com/datadog/dd-trace-java/blob/master/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/ReferenceMatcher.java#L51).