### PR TITLE
muzzle useability

### DIFF
--- a/buildSrc/src/main/groovy/MuzzlePlugin.groovy
+++ b/buildSrc/src/main/groovy/MuzzlePlugin.groovy
@@ -14,48 +14,76 @@ class MuzzlePlugin implements Plugin<Project> {
     def bootstrapProject = project.rootProject.getChildProjects().get('dd-java-agent').getChildProjects().get('agent-bootstrap')
     def toolingProject = project.rootProject.getChildProjects().get('dd-java-agent').getChildProjects().get('agent-tooling')
     project.extensions.create("muzzle", MuzzleExtension)
+    def compileMuzzle = project.task('compileMuzzle') {
+      // not adding user and group to hide this from `gradle tasks`
+    }
     def muzzle = project.task('muzzle') {
       group = 'Muzzle'
       description = "Run instrumentation muzzle on compile time dependencies"
       doLast {
-        List<URL> userUrls = new ArrayList<>()
-        project.getLogger().info("Creating user classpath for: " + project.getName())
-        for (File f : project.configurations.compileOnly.getFiles()) {
-          project.getLogger().info('--' + f)
-          userUrls.add(f.toURI().toURL())
-        }
-        for (File f : bootstrapProject.sourceSets.main.runtimeClasspath.getFiles()) {
-          project.getLogger().info('--' + f)
-          userUrls.add(f.toURI().toURL())
-        }
-        final ClassLoader userCL = new URLClassLoader(userUrls.toArray(new URL[0]), (ClassLoader) null)
-
-        project.getLogger().info("Creating dd classpath for: " + project.getName())
-        Set<URL> ddUrls = new HashSet<>()
-        for (File f : toolingProject.sourceSets.main.runtimeClasspath.getFiles()) {
-          project.getLogger().info('--' + f)
-          ddUrls.add(f.toURI().toURL())
-        }
-        for (File f : project.sourceSets.main.runtimeClasspath.getFiles()) {
-          project.getLogger().info('--' + f)
-          ddUrls.add(f.toURI().toURL())
-        }
-
-        final ClassLoader agentCL = new URLClassLoader(ddUrls.toArray(new URL[0]), (ClassLoader) null)
+        final ClassLoader userCL = createUserClassLoader(project, bootstrapProject)
+        final ClassLoader agentCL = createDDClassloader(project, toolingProject)
         // find all instrumenters, get muzzle, and assert
         Method assertionMethod = agentCL.loadClass('datadog.trace.agent.tooling.muzzle.MuzzleVersionScanPlugin')
           .getMethod('assertInstrumentationNotMuzzled', ClassLoader.class)
         assertionMethod.invoke(null, userCL)
       }
     }
-    // project.tasks.muzzle.dependsOn(bootstrapProject.tasks.shadowJar)
-    project.tasks.muzzle.dependsOn(bootstrapProject.tasks.compileJava)
-    project.tasks.muzzle.dependsOn(toolingProject.tasks.compileJava)
-    project.afterEvaluate {
-      project.tasks.muzzle.dependsOn(project.tasks.compileJava)
-      if (project.tasks.getNames().contains("compileScala")) {
-        project.tasks.muzzle.dependsOn(project.tasks.compileScala)
+    def printReferences = project.task('printReferences') {
+      group = 'Muzzle'
+      description = "Print references created by instrumentation muzzle"
+      doLast {
+        final ClassLoader agentCL = createDDClassloader(project, toolingProject)
+        Method assertionMethod = agentCL.loadClass('datadog.trace.agent.tooling.muzzle.MuzzleVersionScanPlugin')
+          .getMethod('printMuzzleReferences')
+        assertionMethod.invoke(null)
       }
     }
+    project.tasks.compileMuzzle.dependsOn(bootstrapProject.tasks.compileJava)
+    project.tasks.compileMuzzle.dependsOn(toolingProject.tasks.compileJava)
+    project.afterEvaluate {
+      project.tasks.compileMuzzle.dependsOn(project.tasks.compileJava)
+      if (project.tasks.getNames().contains("compileScala")) {
+        project.tasks.compileMuzzle.dependsOn(project.tasks.compileScala)
+      }
+    }
+
+    project.tasks.muzzle.dependsOn(project.tasks.compileMuzzle)
+    project.tasks.printReferences.dependsOn(project.tasks.compileMuzzle)
+  }
+
+  /**
+   * Create a classloader with core agent classes and project instrumentation on the classpath.
+   */
+  private ClassLoader createDDClassloader(Project project, Project toolingProject) {
+    project.getLogger().info("Creating dd classpath for: " + project.getName())
+    Set<URL> ddUrls = new HashSet<>()
+    for (File f : toolingProject.sourceSets.main.runtimeClasspath.getFiles()) {
+      project.getLogger().info('--' + f)
+      ddUrls.add(f.toURI().toURL())
+    }
+    for (File f : project.sourceSets.main.runtimeClasspath.getFiles()) {
+      project.getLogger().info('--' + f)
+      ddUrls.add(f.toURI().toURL())
+    }
+
+    return new URLClassLoader(ddUrls.toArray(new URL[0]), (ClassLoader) null)
+  }
+
+  /**
+   * Create a classloader with user/library classes on the classpath.
+   */
+  private ClassLoader createUserClassLoader(Project project, Project bootstrapProject) {
+    List<URL> userUrls = new ArrayList<>()
+    project.getLogger().info("Creating user classpath for: " + project.getName())
+    for (File f : project.configurations.compileOnly.getFiles()) {
+      project.getLogger().info('--' + f)
+      userUrls.add(f.toURI().toURL())
+    }
+    for (File f : bootstrapProject.sourceSets.main.runtimeClasspath.getFiles()) {
+      project.getLogger().info('--' + f)
+      userUrls.add(f.toURI().toURL())
+    }
+    return new URLClassLoader(userUrls.toArray(new URL[0]), (ClassLoader) null)
   }
 }

--- a/buildSrc/src/main/groovy/MuzzlePlugin.groovy
+++ b/buildSrc/src/main/groovy/MuzzlePlugin.groovy
@@ -53,6 +53,9 @@ class MuzzlePlugin implements Plugin<Project> {
     project.tasks.muzzle.dependsOn(toolingProject.tasks.compileJava)
     project.afterEvaluate {
       project.tasks.muzzle.dependsOn(project.tasks.compileJava)
+      if (project.tasks.getNames().contains("compileScala")) {
+        project.tasks.muzzle.dependsOn(project.tasks.compileScala)
+      }
     }
   }
 }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/ReferenceMatcher.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/ReferenceMatcher.java
@@ -37,6 +37,10 @@ public class ReferenceMatcher {
     this.helperClassNames = new HashSet<>(Arrays.asList(helperClassNames));
   }
 
+  public Reference[] getReferences() {
+    return references;
+  }
+
   /**
    * @param loader Classloader to validate against (or null for bootstrap)
    * @return true if all references match the classpath of loader


### PR DESCRIPTION
* muzzle plugin dependsOn compileScala
* bytebuddy plugin: regenerate muzzle bytecode when run multiple times (fix muzzle invocation bug)
* pretty-print muzzle references