### PR TITLE
 Add span representing the spring web controller execution

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
@@ -68,6 +68,7 @@ public class AgentInstaller {
             .or(nameStartsWith("org.groovy."))
             .or(nameStartsWith("com.p6spy."))
             .or(nameStartsWith("org.slf4j."))
+            .or(nameStartsWith("com.newrelic."))
             .or(nameContains("javassist"))
             .or(nameContains(".asm."))
             .or(nameMatches("com\\.mchange\\.v2\\.c3p0\\..*Proxy"));

--- a/dd-java-agent/instrumentation/servlet-2/src/main/java/datadog/trace/instrumentation/servlet2/Servlet2Advice.java
+++ b/dd-java-agent/instrumentation/servlet-2/src/main/java/datadog/trace/instrumentation/servlet2/Servlet2Advice.java
@@ -39,6 +39,9 @@ public class Servlet2Advice {
         GlobalTracer.get()
             .buildSpan("servlet.request")
             .asChildOf(extractedContext)
+            .withTag(Tags.COMPONENT.getKey(), "java-web-servlet")
+            .withTag(Tags.HTTP_METHOD.getKey(), httpServletRequest.getMethod())
+            .withTag(Tags.HTTP_URL.getKey(), httpServletRequest.getRequestURL().toString())
             .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_SERVER)
             .withTag(DDTags.SPAN_TYPE, DDSpanTypes.WEB_SERVLET)
             .withTag("servlet.context", httpServletRequest.getContextPath())
@@ -48,12 +51,8 @@ public class Servlet2Advice {
       ((TraceScope) scope).setAsyncPropagation(true);
     }
 
-    final Span span = scope.span();
-    Tags.COMPONENT.set(span, "java-web-servlet");
-    Tags.HTTP_METHOD.set(span, httpServletRequest.getMethod());
-    Tags.HTTP_URL.set(span, httpServletRequest.getRequestURL().toString());
     if (httpServletRequest.getUserPrincipal() != null) {
-      span.setTag("user.principal", httpServletRequest.getUserPrincipal().getName());
+      scope.span().setTag("user.principal", httpServletRequest.getUserPrincipal().getName());
     }
     return scope;
   }

--- a/dd-java-agent/instrumentation/servlet-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Advice.java
+++ b/dd-java-agent/instrumentation/servlet-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Advice.java
@@ -39,6 +39,9 @@ public class Servlet3Advice {
         GlobalTracer.get()
             .buildSpan("servlet.request")
             .asChildOf(extractedContext)
+            .withTag(Tags.COMPONENT.getKey(), "java-web-servlet")
+            .withTag(Tags.HTTP_METHOD.getKey(), httpServletRequest.getMethod())
+            .withTag(Tags.HTTP_URL.getKey(), httpServletRequest.getRequestURL().toString())
             .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_SERVER)
             .withTag(DDTags.SPAN_TYPE, DDSpanTypes.WEB_SERVLET)
             .withTag("servlet.context", httpServletRequest.getContextPath())
@@ -48,12 +51,8 @@ public class Servlet3Advice {
       ((TraceScope) scope).setAsyncPropagation(true);
     }
 
-    final Span span = scope.span();
-    Tags.COMPONENT.set(span, "java-web-servlet");
-    Tags.HTTP_METHOD.set(span, httpServletRequest.getMethod());
-    Tags.HTTP_URL.set(span, httpServletRequest.getRequestURL().toString());
     if (httpServletRequest.getUserPrincipal() != null) {
-      span.setTag("user.principal", httpServletRequest.getUserPrincipal().getName());
+      scope.span().setTag("user.principal", httpServletRequest.getUserPrincipal().getName());
     }
     return scope;
   }

--- a/dd-java-agent/instrumentation/spring-web/src/main/java/datadog/trace/instrumentation/springweb/DispatcherServletInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-web/src/main/java/datadog/trace/instrumentation/springweb/DispatcherServletInstrumentation.java
@@ -1,18 +1,17 @@
 package datadog.trace.instrumentation.springweb;
 
 import static io.opentracing.log.Fields.ERROR_OBJECT;
-import static net.bytebuddy.matcher.ElementMatchers.isInterface;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.isProtected;
 import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;
 import static net.bytebuddy.matcher.ElementMatchers.named;
-import static net.bytebuddy.matcher.ElementMatchers.not;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import io.opentracing.Scope;
 import io.opentracing.Span;
+import io.opentracing.Tracer;
 import io.opentracing.tag.Tags;
 import io.opentracing.util.GlobalTracer;
 import java.util.Collections;
@@ -21,17 +20,18 @@ import java.util.Map;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
+import org.springframework.web.servlet.ModelAndView;
 
 @AutoService(Instrumenter.class)
-public final class SpringWebErrorInstrumentation extends Instrumenter.Default {
+public final class DispatcherServletInstrumentation extends Instrumenter.Default {
 
-  public SpringWebErrorInstrumentation() {
+  public DispatcherServletInstrumentation() {
     super("spring-web");
   }
 
   @Override
   public ElementMatcher<TypeDescription> typeMatcher() {
-    return not(isInterface()).and(named("org.springframework.web.servlet.DispatcherServlet"));
+    return named("org.springframework.web.servlet.DispatcherServlet");
   }
 
   @Override
@@ -40,13 +40,50 @@ public final class SpringWebErrorInstrumentation extends Instrumenter.Default {
     transformers.put(
         isMethod()
             .and(isProtected())
+            .and(named("render"))
+            .and(takesArgument(0, named("org.springframework.web.servlet.ModelAndView"))),
+        DispatcherAdvice.class.getName());
+    transformers.put(
+        isMethod()
+            .and(isProtected())
             .and(nameStartsWith("processHandlerException"))
             .and(takesArgument(3, Exception.class)),
-        SpringWebErrorHandlerAdvice.class.getName());
+        ErrorHandlerAdvice.class.getName());
     return transformers;
   }
 
-  public static class SpringWebErrorHandlerAdvice {
+  public static class DispatcherAdvice {
+
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static Scope startSpan(@Advice.Argument(0) final ModelAndView mv) {
+
+      final Tracer.SpanBuilder builder =
+          GlobalTracer.get()
+              .buildSpan("response.render")
+              .withTag(Tags.COMPONENT.getKey(), "spring-webmvc");
+      if (mv.getViewName() != null) {
+        builder.withTag("view.name", mv.getViewName());
+      }
+      if (mv.getView() != null) {
+        builder.withTag("view.type", mv.getView().getClass().getName());
+      }
+      return builder.startActive(true);
+    }
+
+    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
+    public static void stopSpan(
+        @Advice.Enter final Scope scope, @Advice.Thrown final Throwable throwable) {
+
+      if (throwable != null) {
+        final Span span = scope.span();
+        Tags.ERROR.set(span, true);
+        span.log(Collections.singletonMap(ERROR_OBJECT, throwable));
+      }
+      scope.close();
+    }
+  }
+
+  public static class ErrorHandlerAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static void nameResource(@Advice.Argument(3) final Exception exception) {
       final Scope scope = GlobalTracer.get().scopeManager().active();

--- a/dd-java-agent/instrumentation/spring-web/src/main/java/datadog/trace/instrumentation/springweb/HandlerAdapterInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-web/src/main/java/datadog/trace/instrumentation/springweb/HandlerAdapterInstrumentation.java
@@ -22,7 +22,6 @@ import io.opentracing.tag.Tags;
 import io.opentracing.util.GlobalTracer;
 import java.lang.reflect.Method;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import javax.servlet.Servlet;
 import javax.servlet.http.HttpServletRequest;
@@ -35,9 +34,9 @@ import org.springframework.web.servlet.HandlerMapping;
 import org.springframework.web.servlet.mvc.Controller;
 
 @AutoService(Instrumenter.class)
-public final class SpringWebInstrumentation extends Instrumenter.Default {
+public final class HandlerAdapterInstrumentation extends Instrumenter.Default {
 
-  public SpringWebInstrumentation() {
+  public HandlerAdapterInstrumentation() {
     super("spring-web");
   }
 
@@ -55,15 +54,13 @@ public final class SpringWebInstrumentation extends Instrumenter.Default {
 
   @Override
   public Map<ElementMatcher, String> transformers() {
-    final Map<ElementMatcher, String> transformers = new HashMap<>();
-    transformers.put(
+    return Collections.<ElementMatcher, String>singletonMap(
         isMethod()
             .and(isPublic())
             .and(nameStartsWith("handle"))
             .and(takesArgument(0, named("javax.servlet.http.HttpServletRequest")))
             .and(takesArguments(3)),
         ControllerAdvice.class.getName());
-    return transformers;
   }
 
   public static class ControllerAdvice {

--- a/dd-java-agent/instrumentation/spring-web/src/main/java/datadog/trace/instrumentation/springweb/SpringWebErrorInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-web/src/main/java/datadog/trace/instrumentation/springweb/SpringWebErrorInstrumentation.java
@@ -1,0 +1,62 @@
+package datadog.trace.instrumentation.springweb;
+
+import static io.opentracing.log.Fields.ERROR_OBJECT;
+import static net.bytebuddy.matcher.ElementMatchers.isInterface;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.isProtected;
+import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.not;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import io.opentracing.Scope;
+import io.opentracing.Span;
+import io.opentracing.tag.Tags;
+import io.opentracing.util.GlobalTracer;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+@AutoService(Instrumenter.class)
+public final class SpringWebErrorInstrumentation extends Instrumenter.Default {
+
+  public SpringWebErrorInstrumentation() {
+    super("spring-web");
+  }
+
+  @Override
+  public ElementMatcher<TypeDescription> typeMatcher() {
+    return not(isInterface()).and(named("org.springframework.web.servlet.DispatcherServlet"));
+  }
+
+  @Override
+  public Map<ElementMatcher, String> transformers() {
+    final Map<ElementMatcher, String> transformers = new HashMap<>();
+    transformers.put(
+        isMethod()
+            .and(isProtected())
+            .and(nameStartsWith("processHandlerException"))
+            .and(takesArgument(3, Exception.class)),
+        SpringWebErrorHandlerAdvice.class.getName());
+    return transformers;
+  }
+
+  public static class SpringWebErrorHandlerAdvice {
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static void nameResource(@Advice.Argument(3) final Exception exception) {
+      final Scope scope = GlobalTracer.get().scopeManager().active();
+      if (scope != null && exception != null) {
+        final Span span = scope.span();
+        span.log(Collections.singletonMap(ERROR_OBJECT, exception));
+        // We want to capture the stacktrace, but that doesn't mean it should be an error.
+        // We rely on a decorator to set the error state based on response code. (5xx -> error)
+        Tags.ERROR.set(span, false);
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/spring-web/src/main/java/datadog/trace/instrumentation/springweb/SpringWebInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-web/src/main/java/datadog/trace/instrumentation/springweb/SpringWebInstrumentation.java
@@ -2,6 +2,7 @@ package datadog.trace.instrumentation.springweb;
 
 import static datadog.trace.agent.tooling.ByteBuddyElementMatchers.safeHasSuperType;
 import static datadog.trace.agent.tooling.ClassLoaderMatcher.classLoaderHasClassWithField;
+import static io.opentracing.log.Fields.ERROR_OBJECT;
 import static net.bytebuddy.matcher.ElementMatchers.isInterface;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
@@ -9,20 +10,29 @@ import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.not;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.DDSpanTypes;
 import datadog.trace.api.DDTags;
 import io.opentracing.Scope;
+import io.opentracing.Span;
+import io.opentracing.tag.Tags;
 import io.opentracing.util.GlobalTracer;
+import java.lang.reflect.Method;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import javax.servlet.Servlet;
 import javax.servlet.http.HttpServletRequest;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
+import org.springframework.web.HttpRequestHandler;
+import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.HandlerMapping;
+import org.springframework.web.servlet.mvc.Controller;
 
 @AutoService(Instrumenter.class)
 public final class SpringWebInstrumentation extends Instrumenter.Default {
@@ -50,26 +60,88 @@ public final class SpringWebInstrumentation extends Instrumenter.Default {
         isMethod()
             .and(isPublic())
             .and(nameStartsWith("handle"))
-            .and(takesArgument(0, named("javax.servlet.http.HttpServletRequest"))),
-        SpringWebNamingAdvice.class.getName());
+            .and(takesArgument(0, named("javax.servlet.http.HttpServletRequest")))
+            .and(takesArguments(3)),
+        ControllerAdvice.class.getName());
     return transformers;
   }
 
-  public static class SpringWebNamingAdvice {
+  public static class ControllerAdvice {
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static void nameResource(@Advice.Argument(0) final HttpServletRequest request) {
-      final Scope scope = GlobalTracer.get().scopeManager().active();
-      if (scope != null && request != null) {
+    public static Scope nameResourceAndStartSpan(
+        @Advice.Argument(0) final HttpServletRequest request,
+        @Advice.Argument(2) final Object handler) {
+      // Name the parent span based on the matching pattern
+      // This is likely the servlet.request span.
+      final Scope parentScope = GlobalTracer.get().scopeManager().active();
+      if (parentScope != null && request != null) {
         final String method = request.getMethod();
         final Object bestMatchingPattern =
             request.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE);
         if (method != null && bestMatchingPattern != null) {
           final String resourceName = method + " " + bestMatchingPattern;
-          scope.span().setTag(DDTags.RESOURCE_NAME, resourceName);
-          scope.span().setTag(DDTags.SPAN_TYPE, DDSpanTypes.WEB_SERVLET);
+          parentScope.span().setTag(DDTags.RESOURCE_NAME, resourceName);
+          parentScope.span().setTag(DDTags.SPAN_TYPE, DDSpanTypes.WEB_SERVLET);
         }
       }
+
+      // Now create a span for controller execution.
+
+      final Class<?> clazz;
+      final String methodName;
+
+      if (handler instanceof HandlerMethod) {
+        // name span based on the class and method name defined in the handler
+        final Method method = ((HandlerMethod) handler).getMethod();
+        clazz = method.getDeclaringClass();
+        methodName = method.getName();
+      } else if (handler instanceof HttpRequestHandler) {
+        // org.springframework.web.servlet.mvc.HttpRequestHandlerAdapter
+        clazz = handler.getClass();
+        methodName = "handleRequest";
+      } else if (handler instanceof Controller) {
+        // org.springframework.web.servlet.mvc.SimpleControllerHandlerAdapter
+        clazz = handler.getClass();
+        methodName = "handleRequest";
+      } else if (handler instanceof Servlet) {
+        // org.springframework.web.servlet.handler.SimpleServletHandlerAdapter
+        clazz = handler.getClass();
+        methodName = "service";
+      } else {
+        // perhaps org.springframework.web.servlet.mvc.annotation.AnnotationMethodHandlerAdapter
+        clazz = handler.getClass();
+        methodName = "<annotation>";
+      }
+
+      String className = clazz.getSimpleName();
+      if (className.isEmpty()) {
+        className = clazz.getName();
+        if (clazz.getPackage() != null) {
+          final String pkgName = clazz.getPackage().getName();
+          if (!pkgName.isEmpty()) {
+            className = clazz.getName().replace(pkgName, "").substring(1);
+          }
+        }
+      }
+
+      final String operationName = className + "." + methodName;
+
+      return GlobalTracer.get()
+          .buildSpan(operationName)
+          .withTag(Tags.COMPONENT.getKey(), "spring-web-controller")
+          .startActive(true);
+    }
+
+    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
+    public static void stopSpan(
+        @Advice.Enter final Scope scope, @Advice.Thrown final Throwable throwable) {
+      if (throwable != null) {
+        final Span span = scope.span();
+        Tags.ERROR.set(span, true);
+        span.log(Collections.singletonMap(ERROR_OBJECT, throwable));
+      }
+      scope.close();
     }
   }
 }

--- a/dd-java-agent/instrumentation/spring-web/src/test/groovy/test/SpringBootBasedTest.groovy
+++ b/dd-java-agent/instrumentation/spring-web/src/test/groovy/test/SpringBootBasedTest.groovy
@@ -30,8 +30,27 @@ class SpringBootBasedTest extends AgentTestRunner {
     restTemplate.getForObject("http://localhost:$port/", String) == "Hello World"
 
     and:
-    TEST_WRITER.waitForTraces(1)
-    TEST_WRITER.size() == 1
+    assertTraces(TEST_WRITER, 1) {
+      trace(0, 2) {
+        span(0) {
+          operationName "servlet.request"
+          resourceName "GET /"
+          spanType DDSpanTypes.WEB_SERVLET
+          parent()
+          errored false
+          tags {
+            "http.url" "http://localhost:$port/"
+            "http.method" "GET"
+            "span.kind" "server"
+            "span.type" "web"
+            "component" "java-web-servlet"
+            "http.status_code" 200
+            defaultTags()
+          }
+        }
+        controllerSpan(it, 1, "TestController.greeting")
+      }
+    }
   }
 
   def "generates spans"() {

--- a/dd-trace-ot/src/main/java/datadog/opentracing/DDSpan.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/DDSpan.java
@@ -87,6 +87,7 @@ public class DDSpan implements Span, MutableSpan {
   private void finishAndAddToTrace(final long durationNano) {
     // ensure a min duration of 1
     if (this.durationNano.compareAndSet(0, Math.max(1, durationNano))) {
+      log.debug("Finished: {}", this);
       context.getTrace().addSpan(this);
     } else {
       log.debug("{} - already finished!", this);
@@ -149,7 +150,7 @@ public class DDSpan implements Span, MutableSpan {
    */
   @Override
   public final DDSpan setTag(final String tag, final String value) {
-    this.context().setTag(tag, (Object) value);
+    context().setTag(tag, (Object) value);
     return this;
   }
 
@@ -158,7 +159,7 @@ public class DDSpan implements Span, MutableSpan {
    */
   @Override
   public final DDSpan setTag(final String tag, final boolean value) {
-    this.context().setTag(tag, (Object) value);
+    context().setTag(tag, (Object) value);
     return this;
   }
 
@@ -167,7 +168,7 @@ public class DDSpan implements Span, MutableSpan {
    */
   @Override
   public final DDSpan setTag(final String tag, final Number value) {
-    this.context().setTag(tag, (Object) value);
+    context().setTag(tag, (Object) value);
     return this;
   }
 
@@ -176,7 +177,7 @@ public class DDSpan implements Span, MutableSpan {
    */
   @Override
   public final DDSpanContext context() {
-    return this.context;
+    return context;
   }
 
   /* (non-Javadoc)
@@ -184,7 +185,7 @@ public class DDSpan implements Span, MutableSpan {
    */
   @Override
   public final String getBaggageItem(final String key) {
-    return this.context.getBaggageItem(key);
+    return context.getBaggageItem(key);
   }
 
   /* (non-Javadoc)
@@ -192,7 +193,7 @@ public class DDSpan implements Span, MutableSpan {
    */
   @Override
   public final DDSpan setBaggageItem(final String key, final String value) {
-    this.context.setBaggageItem(key, value);
+    context.setBaggageItem(key, value);
     return this;
   }
 
@@ -201,7 +202,7 @@ public class DDSpan implements Span, MutableSpan {
    */
   @Override
   public final DDSpan setOperationName(final String operationName) {
-    this.context().setOperationName(operationName);
+    context().setOperationName(operationName);
     return this;
   }
 
@@ -247,13 +248,13 @@ public class DDSpan implements Span, MutableSpan {
 
   @Override
   public final DDSpan setServiceName(final String serviceName) {
-    this.context().setServiceName(serviceName);
+    context().setServiceName(serviceName);
     return this;
   }
 
   @Override
   public final DDSpan setResourceName(final String resourceName) {
-    this.context().setResourceName(resourceName);
+    context().setResourceName(resourceName);
     return this;
   }
 
@@ -264,13 +265,13 @@ public class DDSpan implements Span, MutableSpan {
    */
   @Override
   public final DDSpan setSamplingPriority(final int newPriority) {
-    this.context().setSamplingPriority(newPriority);
+    context().setSamplingPriority(newPriority);
     return this;
   }
 
   @Override
   public final DDSpan setSpanType(final String type) {
-    this.context().setSpanType(type);
+    context().setSpanType(type);
     return this;
   }
 
@@ -371,7 +372,7 @@ public class DDSpan implements Span, MutableSpan {
   @Override
   @JsonIgnore
   public Map<String, Object> getTags() {
-    return this.context().getTags();
+    return context().getTags();
   }
 
   @JsonGetter
@@ -405,12 +406,13 @@ public class DDSpan implements Span, MutableSpan {
       this(null);
     }
 
-    public UInt64IDStringSerializer(Class<String> stringClass) {
+    public UInt64IDStringSerializer(final Class<String> stringClass) {
       super(stringClass);
     }
 
     @Override
-    public void serialize(String value, JsonGenerator gen, SerializerProvider provider)
+    public void serialize(
+        final String value, final JsonGenerator gen, final SerializerProvider provider)
         throws IOException {
       gen.writeNumber(value);
     }

--- a/dd-trace-ot/src/main/java/datadog/opentracing/DDSpanContext.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/DDSpanContext.java
@@ -325,7 +325,7 @@ public class DDSpanContext implements io.opentracing.SpanContext {
   public String toString() {
     final StringBuilder s =
         new StringBuilder()
-            .append("Span [ t_id=")
+            .append("DDSpan [ t_id=")
             .append(traceId)
             .append(", s_id=")
             .append(spanId)

--- a/dd-trace-ot/src/main/java/datadog/opentracing/scopemanager/ContinuableScope.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/scopemanager/ContinuableScope.java
@@ -48,7 +48,7 @@ public class ContinuableScope implements Scope, TraceScope {
     this.continuation = continuation;
     this.spanUnderScope = spanUnderScope;
     this.finishOnClose = finishOnClose;
-    this.toRestore = scopeManager.tlsScope.get();
+    toRestore = scopeManager.tlsScope.get();
     scopeManager.tlsScope.set(this);
   }
 
@@ -94,6 +94,11 @@ public class ContinuableScope implements Scope, TraceScope {
     } else {
       return null;
     }
+  }
+
+  @Override
+  public String toString() {
+    return super.toString() + "->" + spanUnderScope;
   }
 
   public class Continuation implements Closeable, TraceScope.Continuation {

--- a/dd-trace-ot/src/test/groovy/datadog/trace/DDSpanContextTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/trace/DDSpanContextTest.groovy
@@ -18,7 +18,7 @@ class DDSpanContextTest extends Specification {
     context.serviceName == "fakeService"
     context.resourceName == "fakeResource"
     context.spanType == "fakeType"
-    context.toString() == "Span [ t_id=1, s_id=1, p_id=0] trace=fakeService/fakeOperation/fakeResource metrics={} *errored* tags={${extra}span.type=${context.getSpanType()}, thread.id=${Thread.currentThread().id}, thread.name=${Thread.currentThread().name}}"
+    context.toString() == "DDSpan [ t_id=1, s_id=1, p_id=0] trace=fakeService/fakeOperation/fakeResource metrics={} *errored* tags={${extra}span.type=${context.getSpanType()}, thread.id=${Thread.currentThread().id}, thread.name=${Thread.currentThread().name}}"
 
     where:
     name                 | extra             | tags
@@ -35,7 +35,7 @@ class DDSpanContextTest extends Specification {
     def thread = Thread.currentThread()
 
     def expectedTags = [(DDTags.THREAD_NAME): thread.name, (DDTags.THREAD_ID): thread.id, (DDTags.SPAN_TYPE): context.getSpanType()]
-    def expectedTrace = "Span [ t_id=1, s_id=1, p_id=0] trace=$details metrics={} tags={span.type=${context.getSpanType()}, thread.id=$thread.id, thread.name=$thread.name}"
+    def expectedTrace = "DDSpan [ t_id=1, s_id=1, p_id=0] trace=$details metrics={} tags={span.type=${context.getSpanType()}, thread.id=$thread.id, thread.name=$thread.name}"
 
     expect:
     context.getTags() == expectedTags
@@ -62,7 +62,7 @@ class DDSpanContextTest extends Specification {
       (DDTags.THREAD_NAME): thread.name,
       (DDTags.THREAD_ID)  : thread.id
     ]
-    context.toString() == "Span [ t_id=1, s_id=1, p_id=0] trace=fakeService/fakeOperation/fakeResource metrics={} tags={span.type=${context.getSpanType()}, $name=$value, thread.id=$thread.id, thread.name=$thread.name}"
+    context.toString() == "DDSpan [ t_id=1, s_id=1, p_id=0] trace=fakeService/fakeOperation/fakeResource metrics={} tags={span.type=${context.getSpanType()}, $name=$value, thread.id=$thread.id, thread.name=$thread.name}"
 
     where:
     name             | value


### PR DESCRIPTION
Previously we only renamed the servlet span based on the URL pattern.  This provides more details which controller executed.

Primary change is in the last commit.  Other commits were updating the tests and instrumentation, but maintaining functionality.