### PR TITLE
 Add span for jax-rs representing controller execution

### DIFF
--- a/dd-java-agent/instrumentation/jax-rs-annotations/src/main/java/datadog/trace/instrumentation/jaxrs/JaxRsAnnotationsInstrumentation.java
+++ b/dd-java-agent/instrumentation/jax-rs-annotations/src/main/java/datadog/trace/instrumentation/jaxrs/JaxRsAnnotationsInstrumentation.java
@@ -1,6 +1,7 @@
 package datadog.trace.instrumentation.jaxrs;
 
 import static datadog.trace.agent.tooling.ByteBuddyElementMatchers.safeHasSuperType;
+import static io.opentracing.log.Fields.ERROR_OBJECT;
 import static net.bytebuddy.matcher.ElementMatchers.declaresMethod;
 import static net.bytebuddy.matcher.ElementMatchers.isAnnotatedWith;
 import static net.bytebuddy.matcher.ElementMatchers.named;
@@ -9,10 +10,12 @@ import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.DDTags;
 import io.opentracing.Scope;
+import io.opentracing.Span;
 import io.opentracing.tag.Tags;
 import io.opentracing.util.GlobalTracer;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Map;
@@ -54,11 +57,11 @@ public final class JaxRsAnnotationsInstrumentation extends Instrumenter.Default 
   public static class JaxRsAnnotationsAdvice {
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static void nameSpan(@Advice.This final Object obj, @Advice.Origin final Method method) {
-      // TODO: do we need caching for this?
+    public static Scope nameSpan(@Advice.Origin final Method method) {
 
+      // TODO: do we need caching for this?
       final LinkedList<Path> classPaths = new LinkedList<>();
-      Class<?> target = obj.getClass();
+      Class<?> target = method.getDeclaringClass();
       while (target != Object.class) {
         final Path annotation = target.getAnnotation(Path.class);
         if (annotation != null) {
@@ -92,6 +95,40 @@ public final class JaxRsAnnotationsInstrumentation extends Instrumenter.Default 
         scope.span().setTag(DDTags.RESOURCE_NAME, resourceName);
         Tags.COMPONENT.set(scope.span(), "jax-rs");
       }
+
+      // Now create a span representing the method execution.
+
+      final Class<?> clazz = method.getDeclaringClass();
+      final String methodName = method.getName();
+
+      String className = clazz.getSimpleName();
+      if (className.isEmpty()) {
+        className = clazz.getName();
+        if (clazz.getPackage() != null) {
+          final String pkgName = clazz.getPackage().getName();
+          if (!pkgName.isEmpty()) {
+            className = clazz.getName().replace(pkgName, "").substring(1);
+          }
+        }
+      }
+
+      final String operationName = className + "." + methodName;
+
+      return GlobalTracer.get()
+          .buildSpan(operationName)
+          .withTag(Tags.COMPONENT.getKey(), "jax-rs-controller")
+          .startActive(true);
+    }
+
+    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
+    public static void stopSpan(
+        @Advice.Enter final Scope scope, @Advice.Thrown final Throwable throwable) {
+      if (throwable != null) {
+        final Span span = scope.span();
+        Tags.ERROR.set(span, true);
+        span.log(Collections.singletonMap(ERROR_OBJECT, throwable));
+      }
+      scope.close();
     }
   }
 }

--- a/dd-java-agent/instrumentation/jsp-2.3/src/main/java/datadog/trace/instrumentation/jsp/JSPInstrumentation.java
+++ b/dd-java-agent/instrumentation/jsp-2.3/src/main/java/datadog/trace/instrumentation/jsp/JSPInstrumentation.java
@@ -57,12 +57,14 @@ public final class JSPInstrumentation extends Instrumenter.Default {
   public static class HttpJspPageAdvice {
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static Scope startSpan(@Advice.Argument(0) final HttpServletRequest req) {
+    public static Scope startSpan(
+        @Advice.This final Object obj, @Advice.Argument(0) final HttpServletRequest req) {
       final Scope scope =
           GlobalTracer.get()
               .buildSpan("jsp.render")
               .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_SERVER)
               .withTag(DDTags.SPAN_TYPE, DDSpanTypes.WEB_SERVLET)
+              .withTag("span.origin.type", obj.getClass().getSimpleName())
               .withTag("servlet.context", req.getContextPath())
               .startActive(true);
 

--- a/dd-java-agent/instrumentation/jsp-2.3/src/test/groovy/JSPInstrumentationBasicTests.groovy
+++ b/dd-java-agent/instrumentation/jsp-2.3/src/test/groovy/JSPInstrumentationBasicTests.groovy
@@ -98,6 +98,7 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
             "span.kind" "server"
             "component" "java-web-servlet"
             "span.type" DDSpanTypes.WEB_SERVLET
+            "span.origin.type" "org.apache.catalina.core.ApplicationFilterChain"
             "servlet.context" "/$jspWebappContext"
             "http.status_code" 200
             defaultTags()
@@ -114,6 +115,7 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
             "span.kind" "server"
             "component" "jsp-http-servlet"
             "span.type" DDSpanTypes.WEB_SERVLET
+            "span.origin.type" jspClassName
             "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl
             defaultTags()
@@ -175,6 +177,7 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
             "span.kind" "server"
             "component" "java-web-servlet"
             "span.type" DDSpanTypes.WEB_SERVLET
+            "span.origin.type" "org.apache.catalina.core.ApplicationFilterChain"
             "servlet.context" "/$jspWebappContext"
             "http.status_code" 200
             defaultTags()
@@ -191,6 +194,7 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
             "span.kind" "server"
             "component" "jsp-http-servlet"
             "span.type" DDSpanTypes.WEB_SERVLET
+            "span.origin.type" "getQuery_jsp"
             "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl
             defaultTags()
@@ -249,6 +253,7 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
             "span.kind" "server"
             "component" "java-web-servlet"
             "span.type" DDSpanTypes.WEB_SERVLET
+            "span.origin.type" "org.apache.catalina.core.ApplicationFilterChain"
             "servlet.context" "/$jspWebappContext"
             "http.status_code" 200
             defaultTags()
@@ -265,6 +270,7 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
             "span.kind" "server"
             "component" "jsp-http-servlet"
             "span.type" DDSpanTypes.WEB_SERVLET
+            "span.origin.type" "post_jsp"
             "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl
             defaultTags()
@@ -320,6 +326,7 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
             "span.kind" "server"
             "component" "java-web-servlet"
             "span.type" DDSpanTypes.WEB_SERVLET
+            "span.origin.type" "org.apache.catalina.core.ApplicationFilterChain"
             "servlet.context" "/$jspWebappContext"
             "http.status_code" 500
             errorTags(JasperException, String)
@@ -337,6 +344,7 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
             "span.kind" "server"
             "component" "jsp-http-servlet"
             "span.type" DDSpanTypes.WEB_SERVLET
+            "span.origin.type" jspClassName
             "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl
             errorTags(exceptionClass, errorMessage)
@@ -398,6 +406,7 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
             "span.kind" "server"
             "component" "java-web-servlet"
             "span.type" DDSpanTypes.WEB_SERVLET
+            "span.origin.type" "org.apache.catalina.core.ApplicationFilterChain"
             "servlet.context" "/$jspWebappContext"
             "http.status_code" 200
             defaultTags()
@@ -414,6 +423,7 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
             "span.kind" "server"
             "component" "jsp-http-servlet"
             "span.type" DDSpanTypes.WEB_SERVLET
+            "span.origin.type" "includeHtml_jsp"
             "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl
             defaultTags()
@@ -468,6 +478,7 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
             "span.kind" "server"
             "component" "java-web-servlet"
             "span.type" DDSpanTypes.WEB_SERVLET
+            "span.origin.type" "org.apache.catalina.core.ApplicationFilterChain"
             "servlet.context" "/$jspWebappContext"
             "http.status_code" 200
             defaultTags()
@@ -484,6 +495,7 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
             "span.kind" "server"
             "component" "jsp-http-servlet"
             "span.type" DDSpanTypes.WEB_SERVLET
+            "span.origin.type" "includeMulti_jsp"
             "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl
             defaultTags()
@@ -500,6 +512,7 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
             "span.kind" "server"
             "component" "jsp-http-servlet"
             "span.type" DDSpanTypes.WEB_SERVLET
+            "span.origin.type" "javaLoopH2_jsp"
             "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl
             defaultTags()
@@ -533,6 +546,7 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
             "span.kind" "server"
             "component" "jsp-http-servlet"
             "span.type" DDSpanTypes.WEB_SERVLET
+            "span.origin.type" "javaLoopH2_jsp"
             "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl
             defaultTags()
@@ -604,6 +618,7 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
             "span.kind" "server"
             "component" "java-web-servlet"
             "span.type" DDSpanTypes.WEB_SERVLET
+            "span.origin.type" "org.apache.catalina.core.ApplicationFilterChain"
             "servlet.context" "/$jspWebappContext"
             "http.status_code" 500
             errorTags(JasperException, String)

--- a/dd-java-agent/instrumentation/jsp-2.3/src/test/groovy/JSPInstrumentationForwardTests.groovy
+++ b/dd-java-agent/instrumentation/jsp-2.3/src/test/groovy/JSPInstrumentationForwardTests.groovy
@@ -96,6 +96,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
             "span.kind" "server"
             "component" "java-web-servlet"
             "span.type" DDSpanTypes.WEB_SERVLET
+            "span.origin.type" "org.apache.catalina.core.ApplicationFilterChain"
             "servlet.context" "/$jspWebappContext"
             "http.status_code" 200
             defaultTags()
@@ -112,6 +113,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
             "span.kind" "server"
             "component" "jsp-http-servlet"
             "span.type" DDSpanTypes.WEB_SERVLET
+            "span.origin.type" jspForwardFromClassName
             "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl
             defaultTags()
@@ -128,6 +130,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
             "span.kind" "server"
             "component" "jsp-http-servlet"
             "span.type" DDSpanTypes.WEB_SERVLET
+            "span.origin.type" jspForwardDestClassName
             "servlet.context" "/$jspWebappContext"
             "jsp.forwardOrigin" "/$forwardFromFileName"
             "jsp.requestURL" baseUrl + "/$forwardDestFileName"
@@ -205,6 +208,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
             "span.kind" "server"
             "component" "java-web-servlet"
             "span.type" DDSpanTypes.WEB_SERVLET
+            "span.origin.type" "org.apache.catalina.core.ApplicationFilterChain"
             "servlet.context" "/$jspWebappContext"
             "http.status_code" 200
             defaultTags()
@@ -221,6 +225,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
             "span.kind" "server"
             "component" "jsp-http-servlet"
             "span.type" DDSpanTypes.WEB_SERVLET
+            "span.origin.type" "forwardToHtml_jsp"
             "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl
             defaultTags()
@@ -275,6 +280,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
             "span.kind" "server"
             "component" "java-web-servlet"
             "span.type" DDSpanTypes.WEB_SERVLET
+            "span.origin.type" "org.apache.catalina.core.ApplicationFilterChain"
             "servlet.context" "/$jspWebappContext"
             "http.status_code" 200
             defaultTags()
@@ -291,6 +297,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
             "span.kind" "server"
             "component" "jsp-http-servlet"
             "span.type" DDSpanTypes.WEB_SERVLET
+            "span.origin.type" "forwardToIncludeMulti_jsp"
             "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl
             defaultTags()
@@ -307,6 +314,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
             "span.kind" "server"
             "component" "jsp-http-servlet"
             "span.type" DDSpanTypes.WEB_SERVLET
+            "span.origin.type" "includeMulti_jsp"
             "servlet.context" "/$jspWebappContext"
             "jsp.forwardOrigin" "/forwards/forwardToIncludeMulti.jsp"
             "jsp.requestURL" baseUrl + "/includes/includeMulti.jsp"
@@ -324,6 +332,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
             "span.kind" "server"
             "component" "jsp-http-servlet"
             "span.type" DDSpanTypes.WEB_SERVLET
+            "span.origin.type" "javaLoopH2_jsp"
             "servlet.context" "/$jspWebappContext"
             "jsp.forwardOrigin" "/forwards/forwardToIncludeMulti.jsp"
             "jsp.requestURL" baseUrl + "/includes/includeMulti.jsp"
@@ -358,6 +367,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
             "span.kind" "server"
             "component" "jsp-http-servlet"
             "span.type" DDSpanTypes.WEB_SERVLET
+            "span.origin.type" "javaLoopH2_jsp"
             "servlet.context" "/$jspWebappContext"
             "jsp.forwardOrigin" "/forwards/forwardToIncludeMulti.jsp"
             "jsp.requestURL" baseUrl + "/includes/includeMulti.jsp"
@@ -447,6 +457,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
             "span.kind" "server"
             "component" "java-web-servlet"
             "span.type" DDSpanTypes.WEB_SERVLET
+            "span.origin.type" "org.apache.catalina.core.ApplicationFilterChain"
             "servlet.context" "/$jspWebappContext"
             "http.status_code" 200
             defaultTags()
@@ -463,6 +474,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
             "span.kind" "server"
             "component" "jsp-http-servlet"
             "span.type" DDSpanTypes.WEB_SERVLET
+            "span.origin.type" "forwardToJspForward_jsp"
             "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl
             defaultTags()
@@ -479,6 +491,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
             "span.kind" "server"
             "component" "jsp-http-servlet"
             "span.type" DDSpanTypes.WEB_SERVLET
+            "span.origin.type" "forwardToSimpleJava_jsp"
             "servlet.context" "/$jspWebappContext"
             "jsp.forwardOrigin" "/forwards/forwardToJspForward.jsp"
             "jsp.requestURL" baseUrl + "/forwards/forwardToSimpleJava.jsp"
@@ -496,6 +509,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
             "span.kind" "server"
             "component" "jsp-http-servlet"
             "span.type" DDSpanTypes.WEB_SERVLET
+            "span.origin.type" "loop_jsp"
             "servlet.context" "/$jspWebappContext"
             "jsp.forwardOrigin" "/forwards/forwardToJspForward.jsp"
             "jsp.requestURL" baseUrl + "/common/loop.jsp"
@@ -585,6 +599,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
             "span.kind" "server"
             "component" "java-web-servlet"
             "span.type" DDSpanTypes.WEB_SERVLET
+            "span.origin.type" "org.apache.catalina.core.ApplicationFilterChain"
             "servlet.context" "/$jspWebappContext"
             "http.status_code" 500
             errorTags(JasperException, String)
@@ -602,6 +617,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
             "span.kind" "server"
             "component" "jsp-http-servlet"
             "span.type" DDSpanTypes.WEB_SERVLET
+            "span.origin.type" "forwardToCompileError_jsp"
             "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl
             errorTags(JasperException, String)
@@ -677,6 +693,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
             "span.kind" "server"
             "component" "java-web-servlet"
             "span.type" DDSpanTypes.WEB_SERVLET
+            "span.origin.type" "org.apache.catalina.core.ApplicationFilterChain"
             "servlet.context" "/$jspWebappContext"
             "http.status_code" 404
             defaultTags()
@@ -693,6 +710,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
             "span.kind" "server"
             "component" "jsp-http-servlet"
             "span.type" DDSpanTypes.WEB_SERVLET
+            "span.origin.type" "forwardToNonExistent_jsp"
             "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl
             defaultTags()

--- a/dd-java-agent/instrumentation/servlet-2/src/main/java/datadog/trace/instrumentation/servlet2/Servlet2Advice.java
+++ b/dd-java-agent/instrumentation/servlet-2/src/main/java/datadog/trace/instrumentation/servlet2/Servlet2Advice.java
@@ -21,9 +21,9 @@ import net.bytebuddy.asm.Advice;
 public class Servlet2Advice {
 
   @Advice.OnMethodEnter(suppress = Throwable.class)
-  public static Scope startSpan(@Advice.Argument(0) final ServletRequest req) {
-    if (GlobalTracer.get().scopeManager().active() != null
-        || !(req instanceof HttpServletRequest)) {
+  public static Scope startSpan(
+      @Advice.This final Object servlet, @Advice.Argument(0) final ServletRequest req) {
+    if (GlobalTracer.get().activeSpan() != null || !(req instanceof HttpServletRequest)) {
       // Tracing might already be applied by the FilterChain.  If so ignore this.
       return null;
     }
@@ -44,6 +44,7 @@ public class Servlet2Advice {
             .withTag(Tags.HTTP_URL.getKey(), httpServletRequest.getRequestURL().toString())
             .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_SERVER)
             .withTag(DDTags.SPAN_TYPE, DDSpanTypes.WEB_SERVLET)
+            .withTag("span.origin.type", servlet.getClass().getName())
             .withTag("servlet.context", httpServletRequest.getContextPath())
             .startActive(true);
 

--- a/dd-java-agent/instrumentation/servlet-2/src/test/groovy/JettyServlet2Test.groovy
+++ b/dd-java-agent/instrumentation/servlet-2/src/test/groovy/JettyServlet2Test.groovy
@@ -86,6 +86,7 @@ class JettyServlet2Test extends AgentTestRunner {
             "http.method" "GET"
             "span.kind" "server"
             "component" "java-web-servlet"
+            "span.origin.type" "TestServlet2\$Sync"
             "span.type" DDSpanTypes.WEB_SERVLET
             "servlet.context" "/ctx"
             if (auth) {
@@ -129,6 +130,7 @@ class JettyServlet2Test extends AgentTestRunner {
             "span.kind" "server"
             "component" "java-web-servlet"
             "span.type" DDSpanTypes.WEB_SERVLET
+            "span.origin.type" "TestServlet2\$Sync"
             "servlet.context" "/ctx"
             errorTags(RuntimeException, "some $path error")
             defaultTags()
@@ -169,6 +171,7 @@ class JettyServlet2Test extends AgentTestRunner {
             "span.kind" "server"
             "component" "java-web-servlet"
             "span.type" DDSpanTypes.WEB_SERVLET
+            "span.origin.type" "TestServlet2\$Sync"
             "servlet.context" "/ctx"
             defaultTags()
           }

--- a/dd-java-agent/instrumentation/servlet-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Advice.java
+++ b/dd-java-agent/instrumentation/servlet-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Advice.java
@@ -22,7 +22,8 @@ import net.bytebuddy.asm.Advice;
 public class Servlet3Advice {
 
   @Advice.OnMethodEnter(suppress = Throwable.class)
-  public static Scope startSpan(@Advice.Argument(0) final ServletRequest req) {
+  public static Scope startSpan(
+      @Advice.This final Object servlet, @Advice.Argument(0) final ServletRequest req) {
     if (GlobalTracer.get().activeSpan() != null || !(req instanceof HttpServletRequest)) {
       // Tracing might already be applied by the FilterChain.  If so ignore this.
       return null;
@@ -44,6 +45,7 @@ public class Servlet3Advice {
             .withTag(Tags.HTTP_URL.getKey(), httpServletRequest.getRequestURL().toString())
             .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_SERVER)
             .withTag(DDTags.SPAN_TYPE, DDSpanTypes.WEB_SERVLET)
+            .withTag("span.origin.type", servlet.getClass().getName())
             .withTag("servlet.context", httpServletRequest.getContextPath())
             .startActive(false);
 

--- a/dd-java-agent/instrumentation/servlet-3/src/test/groovy/JettyServlet3Test.groovy
+++ b/dd-java-agent/instrumentation/servlet-3/src/test/groovy/JettyServlet3Test.groovy
@@ -87,6 +87,7 @@ class JettyServlet3Test extends AgentTestRunner {
             "http.method" "GET"
             "span.kind" "server"
             "component" "java-web-servlet"
+            "span.origin.type" "TestServlet3\$$origin"
             "span.type" DDSpanTypes.WEB_SERVLET
             "http.status_code" 200
             if (auth) {
@@ -99,11 +100,11 @@ class JettyServlet3Test extends AgentTestRunner {
     }
 
     where:
-    path         | expectedResponse | auth
-    "async"      | "Hello Async"    | false
-    "sync"       | "Hello Sync"     | false
-    "auth/async" | "Hello Async"    | true
-    "auth/sync"  | "Hello Sync"     | true
+    path         | expectedResponse | auth  | origin
+    "async"      | "Hello Async"    | false | "Async"
+    "sync"       | "Hello Sync"     | false | "Sync"
+    "auth/async" | "Hello Async"    | true  | "Async"
+    "auth/sync"  | "Hello Sync"     | true  | "Sync"
   }
 
   def "servlet instrumentation clears state after async request"() {
@@ -157,6 +158,7 @@ class JettyServlet3Test extends AgentTestRunner {
             "span.kind" "server"
             "component" "java-web-servlet"
             "span.type" DDSpanTypes.WEB_SERVLET
+            "span.origin.type" "TestServlet3\$Sync"
             "http.status_code" 500
             errorTags(RuntimeException, "some $path error")
             defaultTags()
@@ -197,6 +199,7 @@ class JettyServlet3Test extends AgentTestRunner {
             "span.kind" "server"
             "component" "java-web-servlet"
             "span.type" DDSpanTypes.WEB_SERVLET
+            "span.origin.type" "TestServlet3\$Sync"
             "http.status_code" 500
             "error" true
             defaultTags()

--- a/dd-java-agent/instrumentation/servlet-3/src/test/groovy/TomcatServlet3Test.groovy
+++ b/dd-java-agent/instrumentation/servlet-3/src/test/groovy/TomcatServlet3Test.groovy
@@ -6,6 +6,7 @@ import datadog.trace.api.DDSpanTypes
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import org.apache.catalina.Context
+import org.apache.catalina.core.ApplicationFilterChain
 import org.apache.catalina.startup.Tomcat
 import org.apache.tomcat.JarScanFilter
 import org.apache.tomcat.JarScanType
@@ -84,6 +85,7 @@ class TomcatServlet3Test extends AgentTestRunner {
             "span.kind" "server"
             "component" "java-web-servlet"
             "span.type" DDSpanTypes.WEB_SERVLET
+            "span.origin.type" ApplicationFilterChain.name
             "servlet.context" "/my-context"
             "http.status_code" 200
             defaultTags()
@@ -124,6 +126,7 @@ class TomcatServlet3Test extends AgentTestRunner {
             "span.kind" "server"
             "component" "java-web-servlet"
             "span.type" DDSpanTypes.WEB_SERVLET
+            "span.origin.type" ApplicationFilterChain.name
             "servlet.context" "/my-context"
             "http.status_code" 500
             errorTags(RuntimeException, "some $path error")
@@ -165,6 +168,7 @@ class TomcatServlet3Test extends AgentTestRunner {
             "span.kind" "server"
             "component" "java-web-servlet"
             "span.type" DDSpanTypes.WEB_SERVLET
+            "span.origin.type" ApplicationFilterChain.name
             "servlet.context" "/my-context"
             "http.status_code" 500
             "error" true

--- a/dd-java-agent/instrumentation/spring-web/src/test/groovy/test/SpringBootBasedTest.groovy
+++ b/dd-java-agent/instrumentation/spring-web/src/test/groovy/test/SpringBootBasedTest.groovy
@@ -43,6 +43,7 @@ class SpringBootBasedTest extends AgentTestRunner {
             "http.method" "GET"
             "span.kind" "server"
             "span.type" "web"
+            "span.origin.type" "org.apache.catalina.core.ApplicationFilterChain"
             "component" "java-web-servlet"
             "http.status_code" 200
             defaultTags()
@@ -70,6 +71,7 @@ class SpringBootBasedTest extends AgentTestRunner {
             "http.method" "GET"
             "span.kind" "server"
             "span.type" "web"
+            "span.origin.type" "org.apache.catalina.core.ApplicationFilterChain"
             "component" "java-web-servlet"
             "http.status_code" 200
             defaultTags()
@@ -101,6 +103,7 @@ class SpringBootBasedTest extends AgentTestRunner {
             "http.method" "GET"
             "span.kind" "server"
             "span.type" "web"
+            "span.origin.type" "org.apache.catalina.core.ApplicationFilterChain"
             "component" "java-web-servlet"
             "http.status_code" 404
             defaultTags()
@@ -120,6 +123,7 @@ class SpringBootBasedTest extends AgentTestRunner {
             "http.method" "GET"
             "span.kind" "server"
             "span.type" "web"
+            "span.origin.type" "org.apache.catalina.core.ApplicationFilterChain"
             "component" "java-web-servlet"
             "http.status_code" 404
             defaultTags()
@@ -153,6 +157,7 @@ class SpringBootBasedTest extends AgentTestRunner {
             "http.method" "GET"
             "span.kind" "server"
             "span.type" "web"
+            "span.origin.type" "org.apache.catalina.core.ApplicationFilterChain"
             "component" "java-web-servlet"
             "http.status_code" 500
             errorTags NestedServletException, "Request processing failed; nested exception is java.lang.RuntimeException: qwerty"
@@ -173,6 +178,7 @@ class SpringBootBasedTest extends AgentTestRunner {
             "http.method" "GET"
             "span.kind" "server"
             "span.type" "web"
+            "span.origin.type" "org.apache.catalina.core.ApplicationFilterChain"
             "component" "java-web-servlet"
             "http.status_code" 500
             "error" true
@@ -201,6 +207,7 @@ class SpringBootBasedTest extends AgentTestRunner {
             "http.method" "POST"
             "span.kind" "server"
             "span.type" "web"
+            "span.origin.type" "org.apache.catalina.core.ApplicationFilterChain"
             "component" "java-web-servlet"
             "http.status_code" 200
             defaultTags()
@@ -234,6 +241,7 @@ class SpringBootBasedTest extends AgentTestRunner {
             "http.method" "POST"
             "span.kind" "server"
             "span.type" "web"
+            "span.origin.type" "org.apache.catalina.core.ApplicationFilterChain"
             "component" "java-web-servlet"
             "http.status_code" 400
             "error" false
@@ -257,6 +265,7 @@ class SpringBootBasedTest extends AgentTestRunner {
             "http.method" "POST"
             "span.kind" "server"
             "span.type" "web"
+            "span.origin.type" "org.apache.catalina.core.ApplicationFilterChain"
             "component" "java-web-servlet"
             "http.status_code" 400
             defaultTags()


### PR DESCRIPTION
Also add additional `span.origin.type` tags for better visibility.

Similar concept as #430, but for jax-rs.

#305 