### PR TITLE
Register Datadog classloader as parallel capable

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/DatadogClassLoader.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/DatadogClassLoader.java
@@ -28,12 +28,6 @@ public class DatadogClassLoader extends URLClassLoader {
     bootstrapProxy = new BootstrapClassLoaderProxy(new URL[] {bootstrapJarLocation}, null);
   }
 
-  /** Public for testing only */
-  @Override
-  public Object getClassLoadingLock(String className) {
-    return super.getClassLoadingLock(className);
-  }
-
   @Override
   public URL getResource(String resourceName) {
     final URL bootstrapResource = bootstrapProxy.getResource(resourceName);

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/DatadogClassLoader.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/DatadogClassLoader.java
@@ -5,6 +5,10 @@ import java.net.URLClassLoader;
 
 /** Classloader used to run the core datadog agent. */
 public class DatadogClassLoader extends URLClassLoader {
+  static {
+    ClassLoader.registerAsParallelCapable();
+  }
+
   // Calling java.lang.instrument.Instrumentation#appendToBootstrapClassLoaderSearch
   // adds a jar to the bootstrap class lookup, but not to the resource lookup.
   // As a workaround, we keep a reference to the bootstrap jar
@@ -22,6 +26,12 @@ public class DatadogClassLoader extends URLClassLoader {
   public DatadogClassLoader(URL bootstrapJarLocation, URL agentJarLocation, ClassLoader parent) {
     super(new URL[] {agentJarLocation}, parent);
     bootstrapProxy = new BootstrapClassLoaderProxy(new URL[] {bootstrapJarLocation}, null);
+  }
+
+  /** Public for testing only */
+  @Override
+  public Object getClassLoadingLock(String className) {
+    return super.getClassLoadingLock(className);
   }
 
   @Override
@@ -45,6 +55,10 @@ public class DatadogClassLoader extends URLClassLoader {
    * <p>This class is thread safe.
    */
   public static final class BootstrapClassLoaderProxy extends URLClassLoader {
+    static {
+      ClassLoader.registerAsParallelCapable();
+    }
+
     public BootstrapClassLoaderProxy(URL[] urls, ClassLoader parent) {
       super(urls, parent);
     }

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/DatadogClassLoaderTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/DatadogClassLoaderTest.groovy
@@ -1,0 +1,39 @@
+package datadog.trace.bootstrap
+
+import spock.lang.Specification
+
+import java.util.concurrent.Phaser
+
+class DatadogClassLoaderTest extends Specification {
+  def "DD classloader does not lock classloading around instance" () {
+    setup:
+    def className1 = 'some/class/Name1'
+    def className2 = 'some/class/Name2'
+    final URL loc = getClass().getProtectionDomain().getCodeSource().getLocation()
+    final DatadogClassLoader ddLoader = new DatadogClassLoader(loc, loc, (ClassLoader) null)
+    final Phaser threadHoldLockPhase = new Phaser(2)
+    final Phaser acquireLockFromMainThreadPhase = new Phaser(2)
+
+    when:
+    final Thread thread = new Thread() {
+      @Override
+      void run() {
+        synchronized (ddLoader.getClassLoadingLock(className1)) {
+          threadHoldLockPhase.arrive()
+          acquireLockFromMainThreadPhase.arriveAndAwaitAdvance()
+        }
+      }
+    }
+    thread.start()
+
+    threadHoldLockPhase.arriveAndAwaitAdvance()
+    synchronized (ddLoader.getClassLoadingLock(className2)) {
+      acquireLockFromMainThreadPhase.arrive()
+    }
+    thread.join()
+    boolean applicationDidNotDeadlock = true
+
+    then:
+    applicationDidNotDeadlock
+  }
+}


### PR DESCRIPTION
- Register Datadog classloader as parallel capable and add a test to assert instance is not locked on during classloading