### PR TITLE
Fix dd-trace-api tracer registration in test runner

### DIFF
--- a/dd-java-agent/testing/src/main/java/datadog/trace/agent/test/AgentTestRunner.java
+++ b/dd-java-agent/testing/src/main/java/datadog/trace/agent/test/AgentTestRunner.java
@@ -85,7 +85,7 @@ public abstract class AgentTestRunner extends Specification {
         };
     TEST_TRACER = new DDTracer(TEST_WRITER);
     TestUtils.registerOrReplaceGlobalTracer((Tracer) TEST_TRACER);
-    GlobalTracer.registerIfAbsent((DDTracer) TEST_TRACER);
+    GlobalTracer.registerIfAbsent((datadog.trace.api.Tracer) TEST_TRACER);
   }
 
   protected static Tracer getTestTracer() {

--- a/dd-java-agent/testing/src/test/groovy/AgentTestRunnerTest.groovy
+++ b/dd-java-agent/testing/src/test/groovy/AgentTestRunnerTest.groovy
@@ -10,6 +10,8 @@ class AgentTestRunnerTest extends AgentTestRunner {
   private static final boolean AGENT_INSTALLED_IN_CLINIT
   // having opentracing class in test field should not cause problems
   private static final Tracer A_TRACER = null
+  // having dd tracer api class in test field should not cause problems
+  private static final datadog.trace.api.Tracer DD_API_TRACER = null
 
   static {
     // when test class initializes, opentracing should be set up, but not the agent.
@@ -20,11 +22,13 @@ class AgentTestRunnerTest extends AgentTestRunner {
   def "classpath setup"() {
     expect:
     A_TRACER == null
+    DD_API_TRACER  == null
     OT_LOADER == BOOTSTRAP_CLASSLOADER
     !AGENT_INSTALLED_IN_CLINIT
     getTestTracer() == TestUtils.getUnderlyingGlobalTracer()
     getAgentTransformer() != null
     datadog.trace.api.Trace.getClassLoader() == BOOTSTRAP_CLASSLOADER
+    TestUtils.getUnderlyingGlobalTracer() == datadog.trace.api.GlobalTracer.get()
   }
 
   def "logging works"() {


### PR DESCRIPTION
* Cast to `datadog.trace.api.Tracer` in test-runner's tracer setup to prevent linkage errors when used with idea's debugger