### PR TITLE
Configure Spring Couchbase client with proper couchbase environment

### DIFF
--- a/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/springdata/CouchbaseConfig.groovy
+++ b/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/springdata/CouchbaseConfig.groovy
@@ -1,14 +1,25 @@
 package springdata
 
+import com.couchbase.client.java.env.CouchbaseEnvironment
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.Configuration
 import org.springframework.data.couchbase.config.AbstractCouchbaseConfiguration
 import org.springframework.data.couchbase.repository.config.EnableCouchbaseRepositories
 
+import static com.google.common.base.Preconditions.checkNotNull
+
 @Configuration
 @EnableCouchbaseRepositories(basePackages = "springdata")
 @ComponentScan(basePackages = "springdata")
 class CouchbaseConfig extends AbstractCouchbaseConfiguration {
+
+  // This needs to be set before this class can be used by Spring
+  static CouchbaseEnvironment environment
+
+  @Override
+  protected CouchbaseEnvironment getEnvironment() {
+    return checkNotNull(environment)
+  }
 
   @Override
   protected List<String> getBootstrapHosts() {
@@ -24,4 +35,5 @@ class CouchbaseConfig extends AbstractCouchbaseConfiguration {
   protected String getBucketPassword() {
     return "test-pass"
   }
+
 }

--- a/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/springdata/CouchbaseSpringRepositoryTest.groovy
+++ b/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/springdata/CouchbaseSpringRepositoryTest.groovy
@@ -1,5 +1,6 @@
 package springdata
 
+
 import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import org.springframework.data.repository.CrudRepository
@@ -29,6 +30,8 @@ class CouchbaseSpringRepositoryTest extends AbstractCouchbaseTest {
   DocRepository repo
 
   def setupSpec() {
+    CouchbaseConfig.setEnvironment(environment)
+
     // Close all buckets and disconnect
     cluster.disconnect()
 


### PR DESCRIPTION
It looks like Couchbase container may have some of the ports mapped
randomly. This means it is possible default environment settings might
not work - and this is what Spring is using by default. This change
makes Spring use environment provided by cluster container. This fixes
tests when they are run locally (at least for macos).