### PR TITLE
Speed up test by only uploading on failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ jobs:
 
       - run:
           name: Collect Reports
-          when: always
+          when: on_fail
           command: .circleci/collect_reports.sh
 
       - store_artifacts:
@@ -159,7 +159,7 @@ jobs:
 
       - run:
           name: Collect Reports
-          when: always
+          when: on_fail
           command: .circleci/collect_reports.sh
 
       - store_artifacts:


### PR DESCRIPTION
full reports can take several minutes to upload.