### PR TITLE
Enable and muzzle elasticsearch instrumentation

### DIFF
--- a/dd-java-agent/instrumentation/elasticsearch-rest-5/elasticsearch-rest-5.gradle
+++ b/dd-java-agent/instrumentation/elasticsearch-rest-5/elasticsearch-rest-5.gradle
@@ -1,17 +1,11 @@
-//apply plugin: 'version-scan'
-//
-//versionScan {
-//  group = "org.elasticsearch.client"
-////  module = "transport"
-//  module = "rest"
-//  versions = "[5.0,)"
-//  legacyGroup = "org.elasticsearch"
-//  legacyModule = "elasticsearch"
-//  scanDependencies = true
-//  verifyPresent = [
-//    "org.elasticsearch.percolator.TransportMultiPercolateAction": null,
-//  ]
-//}
+muzzle {
+  pass {
+    group = "org.elasticsearch.client"
+    module = "rest"
+    versions = "[5.0,)"
+    assertInverse = true
+  }
+}
 
 apply from: "${rootDir}/gradle/java.gradle"
 

--- a/dd-java-agent/instrumentation/elasticsearch-rest-5/src/latestDepTest/groovy/Elasticsearch6RestClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch-rest-5/src/latestDepTest/groovy/Elasticsearch6RestClientTest.groovy
@@ -20,10 +20,6 @@ import spock.lang.Shared
 import static datadog.trace.agent.test.asserts.ListWriterAssert.assertTraces
 
 class Elasticsearch6RestClientTest extends AgentTestRunner {
-  static {
-    System.setProperty("dd.integration.elasticsearch.enabled", "true")
-  }
-
   @Shared
   int httpPort
   @Shared

--- a/dd-java-agent/instrumentation/elasticsearch-rest-5/src/main/java/datadog/trace/instrumentation/elasticsearch5/Elasticsearch5RestClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/elasticsearch-rest-5/src/main/java/datadog/trace/instrumentation/elasticsearch5/Elasticsearch5RestClientInstrumentation.java
@@ -33,11 +33,6 @@ public class Elasticsearch5RestClientInstrumentation extends Instrumenter.Defaul
   }
 
   @Override
-  protected boolean defaultEnabled() {
-    return false;
-  }
-
-  @Override
   public String[] helperClassNames() {
     return new String[] {"datadog.trace.instrumentation.elasticsearch5.RestResponseListener"};
   }

--- a/dd-java-agent/instrumentation/elasticsearch-rest-5/src/test/groovy/Elasticsearch5RestClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch-rest-5/src/test/groovy/Elasticsearch5RestClientTest.groovy
@@ -22,10 +22,6 @@ import static datadog.trace.agent.test.asserts.ListWriterAssert.assertTraces
 import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
 
 class Elasticsearch5RestClientTest extends AgentTestRunner {
-  static {
-    System.setProperty("dd.integration.elasticsearch.enabled", "true")
-  }
-
   @Shared
   int httpPort
   @Shared

--- a/dd-java-agent/instrumentation/elasticsearch-transport-2/elasticsearch-transport-2.gradle
+++ b/dd-java-agent/instrumentation/elasticsearch-transport-2/elasticsearch-transport-2.gradle
@@ -1,12 +1,10 @@
-apply plugin: 'version-scan'
-
-versionScan {
-  group = "org.elasticsearch"
-  module = "elasticsearch"
-  versions = "[2.0,3)"
-  verifyPresent = [
-    "org.elasticsearch.plugins.SitePlugin": null,
-  ]
+muzzle {
+  pass {
+    group = "org.elasticsearch"
+    module = "elasticsearch"
+    versions = "[2.0,3)"
+    assertInverse = true
+  }
 }
 
 apply from: "${rootDir}/gradle/java.gradle"

--- a/dd-java-agent/instrumentation/elasticsearch-transport-2/src/main/java/datadog/trace/instrumentation/elasticsearch2/Elasticsearch2TransportClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/elasticsearch-transport-2/src/main/java/datadog/trace/instrumentation/elasticsearch2/Elasticsearch2TransportClientInstrumentation.java
@@ -1,6 +1,5 @@
 package datadog.trace.instrumentation.elasticsearch2;
 
-import static datadog.trace.agent.tooling.ClassLoaderMatcher.classLoaderHasClasses;
 import static io.opentracing.log.Fields.ERROR_OBJECT;
 import static net.bytebuddy.matcher.ElementMatchers.isInterface;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
@@ -35,20 +34,10 @@ public class Elasticsearch2TransportClientInstrumentation extends Instrumenter.D
   }
 
   @Override
-  protected boolean defaultEnabled() {
-    return false;
-  }
-
-  @Override
   public ElementMatcher<TypeDescription> typeMatcher() {
     // If we want to be more generic, we could instrument the interface instead:
     // .and(safeHasSuperType(named("org.elasticsearch.client.ElasticsearchClient"))))
     return not(isInterface()).and(named("org.elasticsearch.client.support.AbstractClient"));
-  }
-
-  @Override
-  public ElementMatcher<ClassLoader> classLoaderMatcher() {
-    return classLoaderHasClasses("org.elasticsearch.plugins.SitePlugin");
   }
 
   @Override

--- a/dd-java-agent/instrumentation/elasticsearch-transport-2/src/test/groovy/Elasticsearch2NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch-transport-2/src/test/groovy/Elasticsearch2NodeClientTest.groovy
@@ -15,10 +15,6 @@ import static datadog.trace.agent.test.TestUtils.runUnderTrace
 import static datadog.trace.agent.test.asserts.ListWriterAssert.assertTraces
 
 class Elasticsearch2NodeClientTest extends AgentTestRunner {
-  static {
-    System.setProperty("dd.integration.elasticsearch.enabled", "true")
-  }
-
   public static final long TIMEOUT = 10000; // 10 seconds
 
   @Shared

--- a/dd-java-agent/instrumentation/elasticsearch-transport-2/src/test/groovy/Elasticsearch2SpringTemplateTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch-transport-2/src/test/groovy/Elasticsearch2SpringTemplateTest.groovy
@@ -24,10 +24,6 @@ import java.util.concurrent.atomic.AtomicLong
 import static datadog.trace.agent.test.asserts.ListWriterAssert.assertTraces
 
 class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
-  static {
-    System.setProperty("dd.integration.elasticsearch.enabled", "true")
-  }
-
   public static final long TIMEOUT = 10000; // 10 seconds
 
   @Shared

--- a/dd-java-agent/instrumentation/elasticsearch-transport-2/src/test/groovy/Elasticsearch2TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch-transport-2/src/test/groovy/Elasticsearch2TransportClientTest.groovy
@@ -18,10 +18,6 @@ import static datadog.trace.agent.test.TestUtils.runUnderTrace
 import static datadog.trace.agent.test.asserts.ListWriterAssert.assertTraces
 
 class Elasticsearch2TransportClientTest extends AgentTestRunner {
-  static {
-    System.setProperty("dd.integration.elasticsearch.enabled", "true")
-  }
-
   public static final long TIMEOUT = 10000; // 10 seconds
 
   @Shared

--- a/dd-java-agent/instrumentation/elasticsearch-transport-2/src/test/groovy/springdata/Elasticsearch2SpringRepositoryTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch-transport-2/src/test/groovy/springdata/Elasticsearch2SpringRepositoryTest.groovy
@@ -11,10 +11,6 @@ import spock.lang.Shared
 import static datadog.trace.agent.test.asserts.ListWriterAssert.assertTraces
 
 class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
-  static {
-    System.setProperty("dd.integration.elasticsearch.enabled", "true")
-  }
-
   @Shared
   ApplicationContext applicationContext = new AnnotationConfigApplicationContext(Config)
 

--- a/dd-java-agent/instrumentation/elasticsearch-transport-5/elasticsearch-transport-5.gradle
+++ b/dd-java-agent/instrumentation/elasticsearch-transport-5/elasticsearch-transport-5.gradle
@@ -1,15 +1,16 @@
-apply plugin: 'version-scan'
-
-versionScan {
-  group = "org.elasticsearch.client"
-  module = "transport"
-  versions = "[5.0,6)"
-  legacyGroup = "org.elasticsearch"
-  legacyModule = "elasticsearch"
-  scanDependencies = true
-  verifyPresent = [
-    "org.elasticsearch.percolator.TransportMultiPercolateAction": null,
-  ]
+muzzle {
+  pass {
+    group = "org.elasticsearch.client"
+    module = "transport"
+    versions = "[5.0.0,5.3.0)"
+    assertInverse = true
+  }
+  pass {
+    group = "org.elasticsearch"
+    module = "elasticsearch"
+    versions = "[5.0.0,5.3.0)"
+    assertInverse = true
+  }
 }
 
 apply from: "${rootDir}/gradle/java.gradle"

--- a/dd-java-agent/instrumentation/elasticsearch-transport-5/src/main/java/datadog/trace/instrumentation/elasticsearch5/Elasticsearch5TransportClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/elasticsearch-transport-5/src/main/java/datadog/trace/instrumentation/elasticsearch5/Elasticsearch5TransportClientInstrumentation.java
@@ -35,11 +35,6 @@ public class Elasticsearch5TransportClientInstrumentation extends Instrumenter.D
   }
 
   @Override
-  protected boolean defaultEnabled() {
-    return false;
-  }
-
-  @Override
   public ElementMatcher<TypeDescription> typeMatcher() {
     // If we want to be more generic, we could instrument the interface instead:
     // .and(safeHasSuperType(named("org.elasticsearch.client.ElasticsearchClient"))))

--- a/dd-java-agent/instrumentation/elasticsearch-transport-5/src/test/groovy/Elasticsearch5NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch-transport-5/src/test/groovy/Elasticsearch5NodeClientTest.groovy
@@ -18,10 +18,6 @@ import static datadog.trace.agent.test.asserts.ListWriterAssert.assertTraces
 import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
 
 class Elasticsearch5NodeClientTest extends AgentTestRunner {
-  static {
-    System.setProperty("dd.integration.elasticsearch.enabled", "true")
-  }
-
   public static final long TIMEOUT = 10000; // 10 seconds
 
   @Shared

--- a/dd-java-agent/instrumentation/elasticsearch-transport-5/src/test/groovy/Elasticsearch5TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch-transport-5/src/test/groovy/Elasticsearch5TransportClientTest.groovy
@@ -22,10 +22,6 @@ import static datadog.trace.agent.test.asserts.ListWriterAssert.assertTraces
 import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
 
 class Elasticsearch5TransportClientTest extends AgentTestRunner {
-  static {
-    System.setProperty("dd.integration.elasticsearch.enabled", "true")
-  }
-
   public static final long TIMEOUT = 10000; // 10 seconds
 
   @Shared

--- a/dd-java-agent/instrumentation/elasticsearch-transport-6/elasticsearch-transport-6.gradle
+++ b/dd-java-agent/instrumentation/elasticsearch-transport-6/elasticsearch-transport-6.gradle
@@ -1,15 +1,16 @@
-apply plugin: 'version-scan'
-
-versionScan {
-  group = "org.elasticsearch.client"
-  module = "transport"
-  versions = "[6.0,)"
-  legacyGroup = "org.elasticsearch"
-  legacyModule = "elasticsearch"
-  scanDependencies = true
-  verifyPresent = [
-    "org.elasticsearch.client.RestClientBuilder\$2": null,
-  ]
+muzzle {
+  pass {
+    group = "org.elasticsearch.client"
+    module = "transport"
+    versions = "[6.0.0,)"
+    assertInverse = true
+  }
+  pass {
+    group = "org.elasticsearch"
+    module = "elasticsearch"
+    versions = "[6.0.0,)"
+    assertInverse = true
+  }
 }
 
 apply from: "${rootDir}/gradle/java.gradle"

--- a/dd-java-agent/instrumentation/elasticsearch-transport-6/src/main/java/datadog/trace/instrumentation/elasticsearch6/Elasticsearch6TransportClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/elasticsearch-transport-6/src/main/java/datadog/trace/instrumentation/elasticsearch6/Elasticsearch6TransportClientInstrumentation.java
@@ -1,6 +1,5 @@
 package datadog.trace.instrumentation.elasticsearch6;
 
-import static datadog.trace.agent.tooling.ClassLoaderMatcher.classLoaderHasClasses;
 import static io.opentracing.log.Fields.ERROR_OBJECT;
 import static net.bytebuddy.matcher.ElementMatchers.isInterface;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
@@ -39,20 +38,10 @@ public class Elasticsearch6TransportClientInstrumentation extends Instrumenter.D
   }
 
   @Override
-  protected boolean defaultEnabled() {
-    return false;
-  }
-
-  @Override
   public ElementMatcher<TypeDescription> typeMatcher() {
     // If we want to be more generic, we could instrument the interface instead:
     // .and(safeHasSuperType(named("org.elasticsearch.client.ElasticsearchClient"))))
     return not(isInterface()).and(named("org.elasticsearch.client.support.AbstractClient"));
-  }
-
-  @Override
-  public ElementMatcher<ClassLoader> classLoaderMatcher() {
-    return classLoaderHasClasses("org.elasticsearch.client.RestClientBuilder$2");
   }
 
   @Override

--- a/dd-java-agent/instrumentation/elasticsearch-transport-6/src/test/groovy/Elasticsearch6NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch-transport-6/src/test/groovy/Elasticsearch6NodeClientTest.groovy
@@ -17,10 +17,6 @@ import static datadog.trace.agent.test.asserts.ListWriterAssert.assertTraces
 import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
 
 class Elasticsearch6NodeClientTest extends AgentTestRunner {
-  static {
-    System.setProperty("dd.integration.elasticsearch.enabled", "true")
-  }
-
   public static final long TIMEOUT = 10000; // 10 seconds
 
   @Shared

--- a/dd-java-agent/instrumentation/elasticsearch-transport-6/src/test/groovy/Elasticsearch6TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch-transport-6/src/test/groovy/Elasticsearch6TransportClientTest.groovy
@@ -21,10 +21,6 @@ import static datadog.trace.agent.test.asserts.ListWriterAssert.assertTraces
 import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
 
 class Elasticsearch6TransportClientTest extends AgentTestRunner {
-  static {
-    System.setProperty("dd.integration.elasticsearch.enabled", "true")
-  }
-
   public static final long TIMEOUT = 10000; // 10 seconds
 
   @Shared


### PR DESCRIPTION
* add muzzle blocks and enable elasticsearch instrumentation by default

I'm seeing muzzle failures in the transport instrumentation from `5.3.0`up to `6.0`.

```
FAILED MUZZLE VALIDATION: datadog.trace.instrumentation.elasticsearch5.Elasticsearch5TransportClientInstrumentation mismatches:
-- datadog.trace.instrumentation.elasticsearch5.TransportActionListener:51 Missing class org.elasticsearch.action.DocumentRequest

```

@tylerbenson Is it possible the `DocumentRequest` class is still available in 5.3.0 somehow (maybe in a provided dependency)?