### PR TITLE
Better error handling for older JDBC drivers

### DIFF
--- a/dd-java-agent/instrumentation/jdbc/jdbc.gradle
+++ b/dd-java-agent/instrumentation/jdbc/jdbc.gradle
@@ -18,9 +18,9 @@ dependencies {
 
   testCompile project(':dd-java-agent:testing')
   // jdbc unit testing
-  testCompile group: 'com.h2database', name: 'h2', version: '1.4.197'
-  testCompile group: 'org.apache.derby', name: 'derby', version: '10.12.1.1'
-  testCompile group: 'org.hsqldb', name: 'hsqldb', version: '2.3.+'
+  testCompile group: 'com.h2database', name: 'h2', version: '1.3.169' // first version jdk 1.6 compatible
+  testCompile group: 'org.apache.derby', name: 'derby', version: '10.6.1.0'
+  testCompile group: 'org.hsqldb', name: 'hsqldb', version: '2.0.0'
 
   testCompile group: 'org.apache.tomcat', name: 'tomcat-jdbc', version: '7.0.19'
   // tomcat needs this to run

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/PreparedStatementInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/PreparedStatementInstrumentation.java
@@ -62,10 +62,16 @@ public final class PreparedStatementInstrumentation extends Instrumenter.Default
       Connection connection;
       try {
         connection = statement.getConnection();
-        // unwrap the connection to cache the underlying actual connection and to not cache proxy
-        // objects
-        if (connection.isWrapperFor(Connection.class)) {
-          connection = connection.unwrap(Connection.class);
+        try {
+          // unwrap the connection to cache the underlying actual connection and to not cache proxy
+          // objects
+          if (connection.isWrapperFor(Connection.class)) {
+            connection = connection.unwrap(Connection.class);
+          }
+        } catch (final Exception e) {
+          // perhaps wrapping isn't supported?
+          // ex: org.h2.jdbc.JdbcConnection v1.3.175
+          // Stick with original connection.
         }
       } catch (final Throwable e) {
         // Had some problem getting the connection.

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/StatementInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/StatementInstrumentation.java
@@ -63,10 +63,16 @@ public final class StatementInstrumentation extends Instrumenter.Default {
       Connection connection;
       try {
         connection = statement.getConnection();
-        if (connection.isWrapperFor(Connection.class)) {
+        try {
           // unwrap the connection to cache the underlying actual connection and to not cache proxy
           // objects
-          connection = connection.unwrap(Connection.class);
+          if (connection.isWrapperFor(Connection.class)) {
+            connection = connection.unwrap(Connection.class);
+          }
+        } catch (final Exception e) {
+          // perhaps wrapping isn't supported?
+          // ex: org.h2.jdbc.JdbcConnection v1.3.175
+          // Stick with original connection.
         }
       } catch (final Throwable e) {
         // Had some problem getting the connection.


### PR DESCRIPTION
that don’t support unwrapping (pre JDK 1.6).