### PR TITLE
Ignore byte buddy classes

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
@@ -55,6 +55,7 @@ public class AgentInstaller {
             .or(nameStartsWith("datadog.trace."))
             .or(nameStartsWith("datadog.opentracing."))
             .or(nameStartsWith("datadog.slf4j."))
+            .or(nameStartsWith("net.bytebuddy."))
             .or(
                 nameStartsWith("java.")
                     .and(


### PR DESCRIPTION
not having this produced the following error on startup:

```
Cannot resolve type description for net.bytebuddy.dynamic.Nexus
```