### PR TITLE
Disable Executor instrumentation ThreadPoolExecutor instances

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Instrumenter.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Instrumenter.java
@@ -43,7 +43,7 @@ public interface Instrumenter {
   /** @return Class names of helpers to inject into the user's classloader */
   String[] helperClassNames();
 
-  Map<ElementMatcher, String> transformers();
+  Map<? extends ElementMatcher, String> transformers();
 
   @Slf4j
   abstract class Default implements Instrumenter {
@@ -110,7 +110,7 @@ public interface Instrumenter {
 
     private AgentBuilder.Identified.Extendable applyInstrumentationTransformers(
         AgentBuilder.Identified.Extendable agentBuilder) {
-      for (final Map.Entry<ElementMatcher, String> entry : transformers().entrySet()) {
+      for (final Map.Entry<? extends ElementMatcher, String> entry : transformers().entrySet()) {
         agentBuilder =
             agentBuilder.transform(
                 new AgentBuilder.Transformer.ForAdvice()
@@ -185,7 +185,7 @@ public interface Instrumenter {
     public abstract ElementMatcher<? super TypeDescription> typeMatcher();
 
     @Override
-    public abstract Map<ElementMatcher, String> transformers();
+    public abstract Map<? extends ElementMatcher, String> transformers();
 
     protected boolean defaultEnabled() {
       return getConfigEnabled("dd.integrations.enabled", true);

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/ThreadPoolExecutorInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/ThreadPoolExecutorInstrumentation.java
@@ -1,0 +1,72 @@
+package datadog.trace.instrumentation.java.concurrent;
+
+import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import lombok.extern.slf4j.Slf4j;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+@Slf4j
+@AutoService(Instrumenter.class)
+public class ThreadPoolExecutorInstrumentation extends Instrumenter.Default {
+
+  public ThreadPoolExecutorInstrumentation() {
+    super(ExecutorInstrumentation.EXEC_NAME);
+  }
+
+  @Override
+  public ElementMatcher<? super TypeDescription> typeMatcher() {
+    return named("java.util.concurrent.ThreadPoolExecutor");
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {
+      ExecutorInstrumentation.class.getName() + "$ConcurrentUtils",
+      ThreadPoolExecutorInstrumentation.class.getName() + "$GenericRunnable",
+    };
+  }
+
+  @Override
+  public Map<? extends ElementMatcher, String> transformers() {
+    return Collections.singletonMap(
+        isConstructor()
+            .and(takesArgument(4, named("java.util.concurrent.BlockingQueue")))
+            .and(takesArguments(7)),
+        ThreadPoolExecutorAdvice.class.getName());
+  }
+
+  public static class ThreadPoolExecutorAdvice {
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    public static void disableIfQueueWrongType(
+        @Advice.This final ThreadPoolExecutor executor,
+        @Advice.Argument(4) final BlockingQueue queue) {
+
+      if (queue.size() == 0) {
+        try {
+          queue.add(new GenericRunnable());
+          System.err.println("ADDED to queue " + queue.getClass());
+          queue.clear(); // Remove the Runnable we just added.
+        } catch (final ClassCastException e) {
+          ExecutorInstrumentation.ConcurrentUtils.disableExecutor(executor);
+        }
+      }
+    }
+  }
+
+  public static class GenericRunnable implements Runnable {
+
+    @Override
+    public void run() {}
+  }
+}

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/ThreadPoolExecutorInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/ThreadPoolExecutorInstrumentation.java
@@ -55,7 +55,6 @@ public class ThreadPoolExecutorInstrumentation extends Instrumenter.Default {
       if (queue.size() == 0) {
         try {
           queue.add(new GenericRunnable());
-          System.err.println("ADDED to queue " + queue.getClass());
           queue.clear(); // Remove the Runnable we just added.
         } catch (final ClassCastException e) {
           ExecutorInstrumentation.ConcurrentUtils.disableExecutor(executor);

--- a/dd-java-agent/instrumentation/java-concurrent/src/slickTest/groovy/SlickTest.groovy
+++ b/dd-java-agent/instrumentation/java-concurrent/src/slickTest/groovy/SlickTest.groovy
@@ -2,13 +2,13 @@ import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import io.opentracing.tag.Tags
-import spock.lang.Shared
 
 import static datadog.trace.agent.test.asserts.ListWriterAssert.assertTraces
 
 class SlickTest extends AgentTestRunner {
 
-  @Shared
+  // Can't be @Shared, otherwise the work queue is initialized before the instrumentation is applied
+  //  @Shared
   def database = new SlickUtils()
 
   def "Basic statement generates spans"() {

--- a/dd-java-agent/instrumentation/java-concurrent/src/slickTest/scala/SlickUtils.scala
+++ b/dd-java-agent/instrumentation/java-concurrent/src/slickTest/scala/SlickUtils.scala
@@ -18,7 +18,7 @@ class SlickUtils {
     // wrapped runnables.
     executor = AsyncExecutor("test", numThreads = 1, queueSize = 1000)
   )
-  Await.result(database.run(sqlu"""CREATE ALIAS SLEEP FOR "java.lang.Thread.sleep(long)""""), Duration.Inf)
+  Await.result(database.run(sqlu"""CREATE ALIAS IF NOT EXISTS SLEEP FOR "java.lang.Thread.sleep(long)""""), Duration.Inf)
 
   @Trace
   def startQuery(query: String): Future[Vector[Int]] = {

--- a/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/ExecutorInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/ExecutorInstrumentationTest.groovy
@@ -23,10 +23,6 @@ class ExecutorInstrumentationTest extends AgentTestRunner {
   @Shared
   Method executeMethod
 
-  static {
-    System.setProperty("dd.integration.java_concurrent.enabled", "true")
-  }
-
   def setupSpec() {
     executeMethod = Executor.getMethod("execute", Runnable)
     submitMethod = ExecutorService.getMethod("submit", Callable)

--- a/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/ExecutorInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/ExecutorInstrumentationTest.groovy
@@ -13,7 +13,6 @@ import java.util.concurrent.ExecutorService
 import java.util.concurrent.ForkJoinPool
 import java.util.concurrent.Future
 import java.util.concurrent.RejectedExecutionException
-import java.util.concurrent.ScheduledThreadPoolExecutor
 import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 
@@ -67,8 +66,6 @@ class ExecutorInstrumentationTest extends AgentTestRunner {
     new ForkJoinPool()                                                                            | executeMethod
     new ThreadPoolExecutor(1, 1, 1000, TimeUnit.NANOSECONDS, new ArrayBlockingQueue<Runnable>(1)) | submitMethod
     new ThreadPoolExecutor(1, 1, 1000, TimeUnit.NANOSECONDS, new ArrayBlockingQueue<Runnable>(1)) | executeMethod
-    new ScheduledThreadPoolExecutor(1)                                                            | submitMethod
-    new ScheduledThreadPoolExecutor(1)                                                            | executeMethod
   }
 
   // more useful name breaks java9 javac
@@ -108,6 +105,5 @@ class ExecutorInstrumentationTest extends AgentTestRunner {
     poolImpl                                                                                      | _
     new ForkJoinPool()                                                                            | _
     new ThreadPoolExecutor(1, 1, 1000, TimeUnit.NANOSECONDS, new ArrayBlockingQueue<Runnable>(1)) | _
-    new ScheduledThreadPoolExecutor(1)                                                            | _
   }
 }


### PR DESCRIPTION
If we can’t add generic runnables to the queue.

We need to be able to do this if the runnable wrapper is going to not cause errors.

This won’t solve the problem for all cases, but it will help with some.

Tests forthcoming.