### PR TITLE
Cleanup created indexes to allow RetryOnFailure

### DIFF
--- a/dd-java-agent/instrumentation/elasticsearch-transport-2/src/latestDepTest/groovy/Elasticsearch2NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch-transport-2/src/latestDepTest/groovy/Elasticsearch2NodeClientTest.groovy
@@ -15,6 +15,7 @@ import spock.lang.Shared
 import static datadog.trace.agent.test.TestUtils.runUnderTrace
 import static datadog.trace.agent.test.asserts.ListWriterAssert.assertTraces
 
+@RetryOnFailure
 class Elasticsearch2NodeClientTest extends AgentTestRunner {
   public static final long TIMEOUT = 10000; // 10 seconds
 
@@ -62,7 +63,6 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
     }
   }
 
-  @RetryOnFailure
   def "test elasticsearch status"() {
     setup:
     def result = client.admin().cluster().health(new ClusterHealthRequest(new String[0]))
@@ -92,7 +92,6 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
     }
   }
 
-  @RetryOnFailure
   def "test elasticsearch error"() {
     when:
     client.prepareGet(indexName, indexType, id).get()
@@ -284,6 +283,9 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
         }
       }
     }
+
+    cleanup:
+    client.admin().indices().prepareDelete(indexName).get()
 
     where:
     indexName = "test-index"

--- a/dd-java-agent/instrumentation/elasticsearch-transport-2/src/latestDepTest/groovy/Elasticsearch2TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch-transport-2/src/latestDepTest/groovy/Elasticsearch2TransportClientTest.groovy
@@ -18,6 +18,7 @@ import spock.lang.Shared
 import static datadog.trace.agent.test.TestUtils.runUnderTrace
 import static datadog.trace.agent.test.asserts.ListWriterAssert.assertTraces
 
+@RetryOnFailure
 class Elasticsearch2TransportClientTest extends AgentTestRunner {
   public static final long TIMEOUT = 10000; // 10 seconds
 
@@ -73,7 +74,6 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
     }
   }
 
-  @RetryOnFailure
   def "test elasticsearch status"() {
     setup:
     def result = client.admin().cluster().health(new ClusterHealthRequest(new String[0]))
@@ -106,7 +106,6 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
     }
   }
 
-  @RetryOnFailure
   def "test elasticsearch error"() {
     when:
     client.prepareGet(indexName, indexType, id).get()
@@ -313,6 +312,9 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
         }
       }
     }
+
+    cleanup:
+    client.admin().indices().prepareDelete(indexName).get()
 
     where:
     indexName = "test-index"

--- a/dd-java-agent/instrumentation/elasticsearch-transport-2/src/latestDepTest/groovy/springdata/Elasticsearch2SpringRepositoryTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch-transport-2/src/latestDepTest/groovy/springdata/Elasticsearch2SpringRepositoryTest.groovy
@@ -71,24 +71,8 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
     repo.index(doc) == doc
 
     and:
-    assertTraces(TEST_WRITER, 3) {
+    assertTraces(TEST_WRITER, 2) {
       trace(0, 1) {
-        span(0) {
-          resourceName "PutMappingAction"
-          operationName "elasticsearch.query"
-          spanType DDSpanTypes.ELASTICSEARCH
-          tags {
-            "$Tags.COMPONENT.key" "elasticsearch-java"
-            "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
-            "elasticsearch.action" "PutMappingAction"
-            "elasticsearch.request" "PutMappingRequest"
-            "elasticsearch.request.indices" indexName
-            defaultTags()
-          }
-        }
-      }
-      trace(1, 1) {
         span(0) {
           resourceName "IndexAction"
           operationName "elasticsearch.query"
@@ -105,7 +89,7 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           }
         }
       }
-      trace(2, 1) {
+      trace(1, 1) {
         span(0) {
           resourceName "RefreshAction"
           operationName "elasticsearch.query"
@@ -147,7 +131,7 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
             "elasticsearch.request.indices" indexName
             "elasticsearch.type" "doc"
             "elasticsearch.id" "1"
-            "elasticsearch.version" 1
+            "elasticsearch.version" Number
             defaultTags()
           }
         }
@@ -215,7 +199,7 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
             "elasticsearch.request.indices" indexName
             "elasticsearch.type" "doc"
             "elasticsearch.id" "1"
-            "elasticsearch.version" 2
+            "elasticsearch.version" Number
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/elasticsearch-transport-2/src/latestDepTest/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch-transport-2/src/latestDepTest/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
@@ -25,6 +25,7 @@ import java.util.concurrent.atomic.AtomicLong
 
 import static datadog.trace.agent.test.asserts.ListWriterAssert.assertTraces
 
+@RetryOnFailure
 class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
   public static final long TIMEOUT = 10000; // 10 seconds
 
@@ -267,6 +268,9 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
       }
     }
 
+    cleanup:
+    template.deleteIndex(indexName)
+
     where:
     indexName = "test-index"
     indexType = "test-type"
@@ -342,6 +346,9 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
         }
       }
     }
+
+    cleanup:
+    template.deleteIndex(indexName)
 
     where:
     indexName = "test-index-extract"

--- a/dd-java-agent/instrumentation/elasticsearch-transport-2/src/test/groovy/Elasticsearch2NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch-transport-2/src/test/groovy/Elasticsearch2NodeClientTest.groovy
@@ -15,6 +15,7 @@ import spock.lang.Shared
 import static datadog.trace.agent.test.TestUtils.runUnderTrace
 import static datadog.trace.agent.test.asserts.ListWriterAssert.assertTraces
 
+@RetryOnFailure
 class Elasticsearch2NodeClientTest extends AgentTestRunner {
   public static final long TIMEOUT = 10000; // 10 seconds
 
@@ -62,7 +63,6 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
     }
   }
 
-  @RetryOnFailure
   def "test elasticsearch status"() {
     setup:
     def result = client.admin().cluster().health(new ClusterHealthRequest(new String[0]))
@@ -92,7 +92,6 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
     }
   }
 
-  @RetryOnFailure
   def "test elasticsearch error"() {
     when:
     client.prepareGet(indexName, indexType, id).get()
@@ -293,6 +292,9 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
         }
       }
     }
+
+    cleanup:
+    client.admin().indices().prepareDelete(indexName).get()
 
     where:
     indexName = "test-index"

--- a/dd-java-agent/instrumentation/elasticsearch-transport-2/src/test/groovy/Elasticsearch2TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch-transport-2/src/test/groovy/Elasticsearch2TransportClientTest.groovy
@@ -18,6 +18,7 @@ import spock.lang.Shared
 import static datadog.trace.agent.test.TestUtils.runUnderTrace
 import static datadog.trace.agent.test.asserts.ListWriterAssert.assertTraces
 
+@RetryOnFailure
 class Elasticsearch2TransportClientTest extends AgentTestRunner {
   public static final long TIMEOUT = 10000; // 10 seconds
 
@@ -73,7 +74,6 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
     }
   }
 
-  @RetryOnFailure
   def "test elasticsearch status"() {
     setup:
     def result = client.admin().cluster().health(new ClusterHealthRequest(new String[0]))
@@ -106,7 +106,6 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
     }
   }
 
-  @RetryOnFailure
   def "test elasticsearch error"() {
     when:
     client.prepareGet(indexName, indexType, id).get()
@@ -313,6 +312,9 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
         }
       }
     }
+
+    cleanup:
+    client.admin().indices().prepareDelete(indexName).get()
 
     where:
     indexName = "test-index"

--- a/dd-java-agent/instrumentation/elasticsearch-transport-2/src/test/groovy/springdata/Elasticsearch2SpringRepositoryTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch-transport-2/src/test/groovy/springdata/Elasticsearch2SpringRepositoryTest.groovy
@@ -71,24 +71,8 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
     repo.index(doc) == doc
 
     and:
-    assertTraces(TEST_WRITER, 3) {
+    assertTraces(TEST_WRITER, 2) {
       trace(0, 1) {
-        span(0) {
-          resourceName "PutMappingAction"
-          operationName "elasticsearch.query"
-          spanType DDSpanTypes.ELASTICSEARCH
-          tags {
-            "$Tags.COMPONENT.key" "elasticsearch-java"
-            "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
-            "elasticsearch.action" "PutMappingAction"
-            "elasticsearch.request" "PutMappingRequest"
-            "elasticsearch.request.indices" indexName
-            defaultTags()
-          }
-        }
-      }
-      trace(1, 1) {
         span(0) {
           resourceName "IndexAction"
           operationName "elasticsearch.query"
@@ -108,7 +92,7 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           }
         }
       }
-      trace(2, 1) {
+      trace(1, 1) {
         span(0) {
           resourceName "RefreshAction"
           operationName "elasticsearch.query"
@@ -153,7 +137,7 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
             "elasticsearch.request.indices" indexName
             "elasticsearch.type" "doc"
             "elasticsearch.id" "1"
-            "elasticsearch.version" 1
+            "elasticsearch.version" Number
             defaultTags()
           }
         }
@@ -227,7 +211,7 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
             "elasticsearch.request.indices" indexName
             "elasticsearch.type" "doc"
             "elasticsearch.id" "1"
-            "elasticsearch.version" 2
+            "elasticsearch.version" Number
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/elasticsearch-transport-2/src/test/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch-transport-2/src/test/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
@@ -25,6 +25,7 @@ import java.util.concurrent.atomic.AtomicLong
 
 import static datadog.trace.agent.test.asserts.ListWriterAssert.assertTraces
 
+@RetryOnFailure
 class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
   public static final long TIMEOUT = 10000; // 10 seconds
 
@@ -270,6 +271,9 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
       }
     }
 
+    cleanup:
+    template.deleteIndex(indexName)
+
     where:
     indexName = "test-index"
     indexType = "test-type"
@@ -345,6 +349,9 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
         }
       }
     }
+
+    cleanup:
+    template.deleteIndex(indexName)
 
     where:
     indexName = "test-index-extract"

--- a/dd-java-agent/instrumentation/elasticsearch-transport-5.3/src/test/groovy/Elasticsearch53NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch-transport-5.3/src/test/groovy/Elasticsearch53NodeClientTest.groovy
@@ -18,6 +18,7 @@ import static datadog.trace.agent.test.TestUtils.runUnderTrace
 import static datadog.trace.agent.test.asserts.ListWriterAssert.assertTraces
 import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
 
+@RetryOnFailure
 class Elasticsearch53NodeClientTest extends AgentTestRunner {
   public static final long TIMEOUT = 10000; // 10 seconds
 
@@ -68,7 +69,6 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
     }
   }
 
-  @RetryOnFailure
   def "test elasticsearch status"() {
     setup:
     def result = client.admin().cluster().health(new ClusterHealthRequest())
@@ -98,7 +98,6 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
     }
   }
 
-  @RetryOnFailure
   def "test elasticsearch error"() {
     when:
     client.prepareGet(indexName, indexType, id).get()
@@ -295,6 +294,9 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
         }
       }
     }
+
+    cleanup:
+    client.admin().indices().prepareDelete(indexName).get()
 
     where:
     indexName = "test-index"

--- a/dd-java-agent/instrumentation/elasticsearch-transport-5.3/src/test/groovy/Elasticsearch53TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch-transport-5.3/src/test/groovy/Elasticsearch53TransportClientTest.groovy
@@ -22,6 +22,7 @@ import static datadog.trace.agent.test.TestUtils.runUnderTrace
 import static datadog.trace.agent.test.asserts.ListWriterAssert.assertTraces
 import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
 
+@RetryOnFailure
 class Elasticsearch53TransportClientTest extends AgentTestRunner {
   public static final long TIMEOUT = 10000; // 10 seconds
 
@@ -112,7 +113,6 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
     }
   }
 
-  @RetryOnFailure
   def "test elasticsearch error"() {
     when:
     client.prepareGet(indexName, indexType, id).get()
@@ -304,6 +304,9 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
         }
       }
     }
+
+    cleanup:
+    client.admin().indices().prepareDelete(indexName).get()
 
     where:
     indexName = "test-index"

--- a/dd-java-agent/instrumentation/elasticsearch-transport-5.3/src/test/groovy/springdata/Elasticsearch53SpringTemplateTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch-transport-5.3/src/test/groovy/springdata/Elasticsearch53SpringTemplateTest.groovy
@@ -29,6 +29,7 @@ import static datadog.trace.agent.test.TestUtils.runUnderTrace
 import static datadog.trace.agent.test.asserts.ListWriterAssert.assertTraces
 import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
 
+@RetryOnFailure
 class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
   public static final long TIMEOUT = 10000; // 10 seconds
 
@@ -284,6 +285,9 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
       }
     }
 
+    cleanup:
+    template.deleteIndex(indexName)
+
     where:
     indexName = "test-index"
     indexType = "test-type"
@@ -359,6 +363,9 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
         }
       }
     }
+
+    cleanup:
+    template.deleteIndex(indexName)
 
     where:
     indexName = "test-index-extract"

--- a/dd-java-agent/instrumentation/elasticsearch-transport-5/src/latestDepTest/groovy/Elasticsearch5NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch-transport-5/src/latestDepTest/groovy/Elasticsearch5NodeClientTest.groovy
@@ -18,6 +18,7 @@ import static datadog.trace.agent.test.TestUtils.runUnderTrace
 import static datadog.trace.agent.test.asserts.ListWriterAssert.assertTraces
 import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
 
+@RetryOnFailure
 class Elasticsearch5NodeClientTest extends AgentTestRunner {
   public static final long TIMEOUT = 10000; // 10 seconds
 
@@ -68,7 +69,6 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
     }
   }
 
-  @RetryOnFailure
   def "test elasticsearch status"() {
     setup:
     def result = client.admin().cluster().health(new ClusterHealthRequest())
@@ -98,7 +98,6 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
     }
   }
 
-  @RetryOnFailure
   def "test elasticsearch error"() {
     when:
     client.prepareGet(indexName, indexType, id).get()
@@ -294,6 +293,9 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
         }
       }
     }
+
+    cleanup:
+    client.admin().indices().prepareDelete(indexName).get()
 
     where:
     indexName = "test-index"

--- a/dd-java-agent/instrumentation/elasticsearch-transport-5/src/latestDepTest/groovy/Elasticsearch5TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch-transport-5/src/latestDepTest/groovy/Elasticsearch5TransportClientTest.groovy
@@ -22,6 +22,7 @@ import static datadog.trace.agent.test.TestUtils.runUnderTrace
 import static datadog.trace.agent.test.asserts.ListWriterAssert.assertTraces
 import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
 
+@RetryOnFailure
 class Elasticsearch5TransportClientTest extends AgentTestRunner {
   public static final long TIMEOUT = 10000; // 10 seconds
 
@@ -113,7 +114,6 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
     }
   }
 
-  @RetryOnFailure
   def "test elasticsearch error"() {
     when:
     client.prepareGet(indexName, indexType, id).get()
@@ -304,6 +304,9 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
         }
       }
     }
+
+    cleanup:
+    client.admin().indices().prepareDelete(indexName).get()
 
     where:
     indexName = "test-index"

--- a/dd-java-agent/instrumentation/elasticsearch-transport-5/src/test/groovy/Elasticsearch5NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch-transport-5/src/test/groovy/Elasticsearch5NodeClientTest.groovy
@@ -18,6 +18,7 @@ import static datadog.trace.agent.test.TestUtils.runUnderTrace
 import static datadog.trace.agent.test.asserts.ListWriterAssert.assertTraces
 import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
 
+@RetryOnFailure
 class Elasticsearch5NodeClientTest extends AgentTestRunner {
   public static final long TIMEOUT = 10000; // 10 seconds
 
@@ -68,7 +69,6 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
     }
   }
 
-  @RetryOnFailure
   def "test elasticsearch status"() {
     setup:
     def result = client.admin().cluster().health(new ClusterHealthRequest())
@@ -98,7 +98,6 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
     }
   }
 
-  @RetryOnFailure
   def "test elasticsearch error"() {
     when:
     client.prepareGet(indexName, indexType, id).get()
@@ -294,6 +293,9 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
         }
       }
     }
+
+    cleanup:
+    client.admin().indices().prepareDelete(indexName).get()
 
     where:
     indexName = "test-index"

--- a/dd-java-agent/instrumentation/elasticsearch-transport-5/src/test/groovy/Elasticsearch5TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch-transport-5/src/test/groovy/Elasticsearch5TransportClientTest.groovy
@@ -22,6 +22,7 @@ import static datadog.trace.agent.test.TestUtils.runUnderTrace
 import static datadog.trace.agent.test.asserts.ListWriterAssert.assertTraces
 import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
 
+@RetryOnFailure
 class Elasticsearch5TransportClientTest extends AgentTestRunner {
   public static final long TIMEOUT = 10000; // 10 seconds
 
@@ -80,7 +81,6 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
     }
   }
 
-  @RetryOnFailure
   def "test elasticsearch status"() {
     setup:
     def result = client.admin().cluster().health(new ClusterHealthRequest())
@@ -113,7 +113,6 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
     }
   }
 
-  @RetryOnFailure
   def "test elasticsearch error"() {
     when:
     client.prepareGet(indexName, indexType, id).get()
@@ -304,6 +303,9 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
         }
       }
     }
+
+    cleanup:
+    client.admin().indices().prepareDelete(indexName).get()
 
     where:
     indexName = "test-index"

--- a/dd-java-agent/instrumentation/elasticsearch-transport-6/src/test/groovy/Elasticsearch6NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch-transport-6/src/test/groovy/Elasticsearch6NodeClientTest.groovy
@@ -275,6 +275,9 @@ class Elasticsearch6NodeClientTest extends AgentTestRunner {
       }
     }
 
+    cleanup:
+    client.admin().indices().prepareDelete(indexName).get()
+
     where:
     indexName = "test-index"
     indexType = "test-type"

--- a/dd-java-agent/instrumentation/elasticsearch-transport-6/src/test/groovy/Elasticsearch6TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch-transport-6/src/test/groovy/Elasticsearch6TransportClientTest.groovy
@@ -302,6 +302,9 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
       }
     }
 
+    cleanup:
+    client.admin().indices().prepareDelete(indexName).get()
+
     where:
     indexName = "test-index"
     indexType = "test-type"


### PR DESCRIPTION
Fighting the good fight to try to make ES tests fail less.