### PR TITLE
lock version of spring-data-es to avoid upgrading ES to 6.x.x in 5.3 …

### DIFF
--- a/dd-java-agent/instrumentation/elasticsearch-transport-5.3/elasticsearch-transport-5.3.gradle
+++ b/dd-java-agent/instrumentation/elasticsearch-transport-5.3/elasticsearch-transport-5.3.gradle
@@ -48,5 +48,5 @@ dependencies {
 
   latestDepTestCompile group: 'org.elasticsearch.plugin', name: 'transport-netty3-client', version: '5.+'
   latestDepTestCompile group: 'org.elasticsearch.client', name: 'transport', version: '5.+'
-  latestDepTestCompile group: 'org.springframework.data', name: 'spring-data-elasticsearch', version: '3.+'
+  latestDepTestCompile group: 'org.springframework.data', name: 'spring-data-elasticsearch', version: '3.0.+'
 }


### PR DESCRIPTION
…instrumentation