### PR TITLE
Fix issue with saving tags when not propagating trace.

### DIFF
--- a/dd-java-agent/instrumentation/play-2.4/src/latestDepTest/groovy/Play26Test.groovy
+++ b/dd-java-agent/instrumentation/play-2.4/src/latestDepTest/groovy/Play26Test.groovy
@@ -54,7 +54,7 @@ class Play26Test extends AgentTestRunner {
           spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
-            defaultTags()
+            defaultTags(true)
             "http.status_code" 200
             "http.url" "http://localhost:$port/helloplay/spock"
             "http.method" "GET"

--- a/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
@@ -5,6 +5,7 @@ import datadog.opentracing.decorators.DDDecoratorsFactory;
 import datadog.opentracing.propagation.Codec;
 import datadog.opentracing.propagation.ExtractedContext;
 import datadog.opentracing.propagation.HTTPCodec;
+import datadog.opentracing.propagation.TagContext;
 import datadog.opentracing.scopemanager.ContextualScopeManager;
 import datadog.opentracing.scopemanager.ScopeContext;
 import datadog.trace.api.Config;
@@ -545,25 +546,36 @@ public class DDTracer implements io.opentracing.Tracer, Closeable, datadog.trace
           spanType = ddsc.getSpanType();
         }
 
-        // Propagate external trace
-      } else if (parentContext instanceof ExtractedContext) {
-        final ExtractedContext ddsc = (ExtractedContext) parentContext;
-        traceId = ddsc.getTraceId();
-        parentSpanId = ddsc.getSpanId();
-        baggage = ddsc.getBaggage();
-        tags.putAll(ddsc.getTags());
-        tags.put(Config.RUNTIME_ID_TAG, runtimeId);
-        parentTrace = new PendingTrace(DDTracer.this, traceId, serviceNameMappings);
-        samplingPriority = ddsc.getSamplingPriority();
-
-        // Start a new trace
       } else {
-        traceId = generateNewId();
-        parentSpanId = "0";
-        baggage = null;
+        if (parentContext instanceof ExtractedContext) {
+          // Propagate external trace
+          final ExtractedContext extractedContext = (ExtractedContext) parentContext;
+          traceId = extractedContext.getTraceId();
+          parentSpanId = extractedContext.getSpanId();
+          samplingPriority = extractedContext.getSamplingPriority();
+          baggage = extractedContext.getBaggage();
+        } else {
+          // Start a new trace
+          traceId = generateNewId();
+          parentSpanId = "0";
+          samplingPriority = PrioritySampling.UNSET;
+          baggage = null;
+        }
+
+        // Get header tags whether propagating or not.
+        if (parentContext instanceof TagContext) {
+          final TagContext tagContext = (TagContext) parentContext;
+
+          if (tags.isEmpty() && !tagContext.getTags().isEmpty()) {
+            tags = new HashMap<>();
+          }
+          if (!tagContext.getTags().isEmpty()) {
+            tags.putAll(tagContext.getTags());
+          }
+        }
         tags.put(Config.RUNTIME_ID_TAG, runtimeId);
+
         parentTrace = new PendingTrace(DDTracer.this, traceId, serviceNameMappings);
-        samplingPriority = PrioritySampling.UNSET;
       }
 
       if (serviceName == null) {

--- a/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
@@ -564,14 +564,7 @@ public class DDTracer implements io.opentracing.Tracer, Closeable, datadog.trace
 
         // Get header tags whether propagating or not.
         if (parentContext instanceof TagContext) {
-          final TagContext tagContext = (TagContext) parentContext;
-
-          if (tags.isEmpty() && !tagContext.getTags().isEmpty()) {
-            tags = new HashMap<>();
-          }
-          if (!tagContext.getTags().isEmpty()) {
-            tags.putAll(tagContext.getTags());
-          }
+          tags.putAll(((TagContext) parentContext).getTags());
         }
         tags.put(Config.RUNTIME_ID_TAG, runtimeId);
 

--- a/dd-trace-ot/src/main/java/datadog/opentracing/propagation/Codec.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/propagation/Codec.java
@@ -22,6 +22,7 @@
 package datadog.opentracing.propagation;
 
 import datadog.opentracing.DDSpanContext;
+import io.opentracing.SpanContext;
 
 /** A codec is a simple object that can encode and decode a span context through a carrier */
 public interface Codec<T> {
@@ -41,5 +42,5 @@ public interface Codec<T> {
    * @param carrier
    * @return the span context
    */
-  ExtractedContext extract(T carrier);
+  SpanContext extract(T carrier);
 }

--- a/dd-trace-ot/src/main/java/datadog/opentracing/propagation/ExtractedContext.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/propagation/ExtractedContext.java
@@ -1,15 +1,13 @@
 package datadog.opentracing.propagation;
 
-import io.opentracing.SpanContext;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-public class ExtractedContext implements SpanContext {
+public class ExtractedContext extends TagContext {
   private final String traceId;
   private final String spanId;
   private final int samplingPriority;
   private final Map<String, String> baggage;
-  private final Map<String, String> tags;
   private final AtomicBoolean samplingPriorityLocked = new AtomicBoolean(false);
 
   public ExtractedContext(
@@ -18,11 +16,11 @@ public class ExtractedContext implements SpanContext {
       final int samplingPriority,
       final Map<String, String> baggage,
       final Map<String, String> tags) {
+    super(tags);
     this.traceId = traceId;
     this.spanId = spanId;
     this.samplingPriority = samplingPriority;
     this.baggage = baggage;
-    this.tags = tags;
   }
 
   @Override
@@ -48,10 +46,6 @@ public class ExtractedContext implements SpanContext {
 
   public Map<String, String> getBaggage() {
     return baggage;
-  }
-
-  public Map<String, String> getTags() {
-    return tags;
   }
 
   public boolean getSamplingPriorityLocked() {

--- a/dd-trace-ot/src/main/java/datadog/opentracing/propagation/ExtractedContext.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/propagation/ExtractedContext.java
@@ -3,6 +3,9 @@ package datadog.opentracing.propagation;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+/**
+ * Propagated data resulting from calling tracer.extract with header data from an incoming request.
+ */
 public class ExtractedContext extends TagContext {
   private final String traceId;
   private final String spanId;

--- a/dd-trace-ot/src/main/java/datadog/opentracing/propagation/TagContext.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/propagation/TagContext.java
@@ -1,0 +1,22 @@
+package datadog.opentracing.propagation;
+
+import io.opentracing.SpanContext;
+import java.util.Collections;
+import java.util.Map;
+
+public class TagContext implements SpanContext {
+  private final Map<String, String> tags;
+
+  public TagContext(final Map<String, String> tags) {
+    this.tags = tags;
+  }
+
+  public Map<String, String> getTags() {
+    return tags;
+  }
+
+  @Override
+  public Iterable<Map.Entry<String, String>> baggageItems() {
+    return Collections.emptyList();
+  }
+}

--- a/dd-trace-ot/src/main/java/datadog/opentracing/propagation/TagContext.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/propagation/TagContext.java
@@ -4,6 +4,10 @@ import io.opentracing.SpanContext;
 import java.util.Collections;
 import java.util.Map;
 
+/**
+ * When calling extract, we allow for grabbing other configured headers as tags. Those tags are
+ * returned here even if the rest of the request would have returned null.
+ */
 public class TagContext implements SpanContext {
   private final Map<String, String> tags;
 

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/propagation/HTTPCodecTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/propagation/HTTPCodecTest.groovy
@@ -186,6 +186,24 @@ class HTTPCodecTest extends Specification {
     PrioritySampling.SAMPLER_KEEP | _
   }
 
+  def "extract header tags with no propagation"() {
+    setup:
+    final Map<String, String> actual = [
+      SOME_HEADER: "my-interesting-info",
+    ]
+
+    TagContext context = codec.extract(new TextMapExtractAdapter(actual))
+
+    expect:
+    !(context instanceof ExtractedContext)
+    context.getTags() == ["some-tag": "my-interesting-info"]
+  }
+
+  def "extract empty headers returns null"() {
+    expect:
+    codec.extract(new TextMapExtractAdapter(["ignored-header": "ignored-value"])) == null
+  }
+
   def "extract http headers with larger than Java long IDs"() {
     setup:
     String largeTraceId = "9523372036854775807"


### PR DESCRIPTION
Previously, when setting headers as tags, the tags would only be saved if the request was propagated from another trace.