### PR TITLE
Disable async propagation for finished spans

### DIFF
--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/ExecutorInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/ExecutorInstrumentation.java
@@ -9,6 +9,7 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.api.interceptor.MutableSpan;
 import datadog.trace.bootstrap.CallDepthThreadLocalMap;
 import datadog.trace.bootstrap.WeakMap;
 import datadog.trace.context.TraceScope;
@@ -212,6 +213,7 @@ public final class ExecutorInstrumentation extends Instrumenter.Default {
       final Scope scope = GlobalTracer.get().scopeManager().active();
       if (scope instanceof TraceScope
           && ((TraceScope) scope).isAsyncPropagating()
+          && !((MutableSpan) scope.span()).isFinished()
           && tasks != null
           && DatadogWrapper.isTopLevelCall(executor)) {
         final Collection<Callable<?>> wrappedTasks = new ArrayList<>(tasks.size());
@@ -288,6 +290,7 @@ public final class ExecutorInstrumentation extends Instrumenter.Default {
       final Scope scope = GlobalTracer.get().scopeManager().active();
       return (scope instanceof TraceScope
           && ((TraceScope) scope).isAsyncPropagating()
+          && !((MutableSpan) scope.span()).isFinished()
           && task != null
           && !(task instanceof DatadogWrapper)
           && isTopLevelCall(executor)

--- a/dd-java-agent/instrumentation/servlet-3/servlet-3.gradle
+++ b/dd-java-agent/instrumentation/servlet-3/servlet-3.gradle
@@ -36,6 +36,7 @@ dependencies {
   testCompile(project(':dd-java-agent:testing')) {
     exclude group: 'org.eclipse.jetty', module: 'jetty-server'
   }
+  testCompile project(':dd-java-agent:instrumentation:java-concurrent')
   testCompile project(':dd-java-agent:instrumentation:jetty-8') // See if there's any conflicts.
   testCompile group: 'org.eclipse.jetty', name: 'jetty-server', version: '8.2.0.v20160908'
   testCompile group: 'org.eclipse.jetty', name: 'jetty-servlet', version: '8.2.0.v20160908'

--- a/dd-java-agent/instrumentation/servlet-3/src/test/groovy/TestServlet3.groovy
+++ b/dd-java-agent/instrumentation/servlet-3/src/test/groovy/TestServlet3.groovy
@@ -1,4 +1,5 @@
 import datadog.trace.agent.test.TestUtils
+import datadog.trace.api.interceptor.MutableSpan
 import datadog.trace.context.TraceScope
 import groovy.servlet.AbstractHttpServlet
 import io.opentracing.util.GlobalTracer
@@ -52,6 +53,10 @@ class TestServlet3 {
         scope.setAsyncPropagation(true)
         resp.writer.print("AsyncWithBackground")
         context.complete()
+        MutableSpan rootSpan = (MutableSpan) GlobalTracer.get().scopeManager().active().span()
+        while (!rootSpan.isFinished()) {
+          // await servlet span finish before submitting async
+        }
         POOL.submit {
           TestUtils.runUnderTrace("not-http") {
             // This should not report as part of the servlet trace because http response is written.

--- a/dd-java-agent/instrumentation/servlet-3/src/test/groovy/TestServlet3.groovy
+++ b/dd-java-agent/instrumentation/servlet-3/src/test/groovy/TestServlet3.groovy
@@ -1,8 +1,12 @@
+import datadog.trace.agent.test.TestUtils
+import datadog.trace.context.TraceScope
 import groovy.servlet.AbstractHttpServlet
+import io.opentracing.util.GlobalTracer
 
 import javax.servlet.annotation.WebServlet
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
+import java.util.concurrent.ForkJoinPool
 
 class TestServlet3 {
 
@@ -29,6 +33,31 @@ class TestServlet3 {
       context.start {
         resp.writer.print("Hello Async")
         context.complete()
+      }
+    }
+  }
+
+
+  @WebServlet(asyncSupported = true)
+  static class AsyncWithBackgroundWork extends AbstractHttpServlet {
+    private static final POOL = new ForkJoinPool()
+
+    @Override
+    void doGet(HttpServletRequest req, HttpServletResponse resp) {
+      def context = req.startAsync()
+
+      final TraceScope.Continuation continuation = ((TraceScope) GlobalTracer.get().scopeManager().active()).capture()
+      context.start {
+        final TraceScope scope = continuation.activate()
+        scope.setAsyncPropagation(true)
+        resp.writer.print("AsyncWithBackground")
+        context.complete()
+        POOL.submit {
+          TestUtils.runUnderTrace("not-http") {
+            // This should not report as part of the servlet trace because http response is written.
+          }
+        }
+        scope.close()
       }
     }
   }

--- a/dd-trace-api/src/main/java/datadog/trace/api/interceptor/MutableSpan.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/interceptor/MutableSpan.java
@@ -43,4 +43,6 @@ public interface MutableSpan {
   MutableSpan setError(boolean value);
 
   MutableSpan getRootSpan();
+
+  boolean isFinished();
 }

--- a/dd-trace-ot/src/main/java/datadog/opentracing/DDSpan.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/DDSpan.java
@@ -80,6 +80,7 @@ public class DDSpan implements Span, MutableSpan {
     context.getTrace().registerSpan(this);
   }
 
+  @Override
   @JsonIgnore
   public boolean isFinished() {
     return durationNano.get() != 0;


### PR DESCRIPTION
The servlet instrumentation's use of async is broken. The callback to stop async propagation is non-blocking and happens in another thread. This prevents us from correctly disabling async propagation even though the span is finished.

This fixes the problem by only allowing for async propagation in the executor instrumentation when the underlying span is not finished.