### PR TITLE
Skip buildscan for muzzle CI runs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -205,7 +205,7 @@ jobs:
         # Note: we do not have `--max-workers` here to have number of workers (threads) equal to number of CPUs (32 currently).
         # This should speed things up slightly because muzzle may do a lot of IO bound work: reading off disk and downloading
         # dependencies.
-        command: GRADLE_OPTS="-Dorg.gradle.jvmargs=-Xmx8G -Xms64M" ./gradlew muzzle --parallel --stacktrace --no-daemon
+        command: SKIP_BUILDSCAN="true" GRADLE_OPTS="-Dorg.gradle.jvmargs=-Xmx8G -Xms64M" ./gradlew muzzle --parallel --stacktrace --no-daemon
 
     - save_cache:
         key: dd-trace-java-muzzle-{{ checksum "dd-trace-java.gradle" }}

--- a/dd-trace-java.gradle
+++ b/dd-trace-java.gradle
@@ -39,11 +39,13 @@ task latestDepTest {}
 // Applied here to allow publishing of artifactory build info
 apply from: "${rootDir}/gradle/publish.gradle"
 
+def skipBuildscan = Boolean.valueOf(System.getenv("SKIP_BUILDSCAN"))
+
 buildScan {
   termsOfServiceUrl = 'https://gradle.com/terms-of-service'
   termsOfServiceAgree = 'yes'
 
-  if (isCI) {
+  if (isCI && !skipBuildscan) {
     publishAlways()
     tag 'CI'
   }


### PR DESCRIPTION
Buildscan upload has been failing since muzzle started version-scanning hundreds of dependencies.