### PR TITLE
Catch `AbstractMethodError` when trying to unwrap jdbc connection

### DIFF
--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/PreparedStatementInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/PreparedStatementInstrumentation.java
@@ -70,9 +70,10 @@ public final class PreparedStatementInstrumentation extends Instrumenter.Default
           if (connection.isWrapperFor(Connection.class)) {
             connection = connection.unwrap(Connection.class);
           }
-        } catch (final Exception e) {
+        } catch (final Exception | AbstractMethodError e) {
           // perhaps wrapping isn't supported?
           // ex: org.h2.jdbc.JdbcConnection v1.3.175
+          // or: jdts.jdbc which always throws `AbstractMethodError` (at least up to version 1.3)
           // Stick with original connection.
         }
       } catch (final Throwable e) {

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/StatementInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/StatementInstrumentation.java
@@ -71,9 +71,10 @@ public final class StatementInstrumentation extends Instrumenter.Default {
           if (connection.isWrapperFor(Connection.class)) {
             connection = connection.unwrap(Connection.class);
           }
-        } catch (final Exception e) {
+        } catch (final Exception | AbstractMethodError e) {
           // perhaps wrapping isn't supported?
           // ex: org.h2.jdbc.JdbcConnection v1.3.175
+          // or: jdts.jdbc which always throws `AbstractMethodError` (at least up to version 1.3)
           // Stick with original connection.
         }
       } catch (final Throwable e) {


### PR DESCRIPTION
jdts throws this exception since they just have 'stub' umplementation.