### PR TITLE
Limit AMQP LatestDepTest to use last working version

### DIFF
--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/rabbitmq-amqp-2.7.gradle
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/rabbitmq-amqp-2.7.gradle
@@ -37,7 +37,9 @@ dependencies {
   testCompile deps.testcontainers
 
   latestDepTestCompile group: 'com.rabbitmq', name: 'amqp-client', version: '+'
-  latestDepTestCompile group: 'org.springframework.amqp', name: 'spring-rabbit', version: '+'
+  // TODO: check next version of amqp to make sure the dependencies can be downloaded from maven and 
+  // revert back to using latest
+  latestDepTestCompile group: 'org.springframework.amqp', name: 'spring-rabbit', version: '2.1.0.RELEASE'
 }
 
 configurations.testRuntime {


### PR DESCRIPTION
Makes AMQP LatestDepTest not use the latest version because it uses a snapshot version of spring, causing error when downloading.