### PR TITLE
implementing add reference to work with opentracing-spring-cloud-starter

### DIFF
--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/DDSpanBuilderTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/DDSpanBuilderTest.groovy
@@ -224,6 +224,130 @@ class DDSpanBuilderTest extends Specification {
     span.context().getResourceName() == expectedChildResourceName
     span.context().getSpanType() == expectedChildType
   }
+  
+  
+    def "should inherit the DD parent attributes addReference CHILD_OF"() {
+    setup:
+    def expectedName = "fakeName"
+    def expectedParentServiceName = "fakeServiceName"
+    def expectedParentResourceName = "fakeResourceName"
+    def expectedParentType = "fakeType"
+    def expectedChildServiceName = "fakeServiceName-child"
+    def expectedChildResourceName = "fakeResourceName-child"
+    def expectedChildType = "fakeType-child"
+    def expectedBaggageItemKey = "fakeKey"
+    def expectedBaggageItemValue = "fakeValue"
+
+    final DDSpan parent =
+      tracer
+        .buildSpan(expectedName)
+        .withServiceName("foo")
+        .withResourceName(expectedParentResourceName)
+        .withSpanType(expectedParentType)
+        .start()
+
+    parent.setBaggageItem(expectedBaggageItemKey, expectedBaggageItemValue)
+
+    // ServiceName and SpanType are always set by the parent  if they are not present in the child
+    DDSpan span =
+      tracer
+        .buildSpan(expectedName)
+        .withServiceName(expectedParentServiceName)
+        .addReference("child_of", parent.context())
+        .start()
+
+    println span.getBaggageItem(expectedBaggageItemKey)
+    println expectedBaggageItemValue
+    println span.context().getSpanType()
+    println expectedParentType
+
+    expect:
+    span.getOperationName() == expectedName
+    span.getBaggageItem(expectedBaggageItemKey) == expectedBaggageItemValue
+    span.context().getServiceName() == expectedParentServiceName
+    span.context().getResourceName() == expectedName
+    span.context().getSpanType() == expectedParentType
+
+    when:
+    // ServiceName and SpanType are always overwritten by the child  if they are present
+    span =
+      tracer
+        .buildSpan(expectedName)
+        .withServiceName(expectedChildServiceName)
+        .withResourceName(expectedChildResourceName)
+        .withSpanType(expectedChildType)
+        .addReference("child_of", parent.context())
+        .start()
+
+    then:
+    span.getOperationName() == expectedName
+    span.getBaggageItem(expectedBaggageItemKey) == expectedBaggageItemValue
+    span.context().getServiceName() == expectedChildServiceName
+    span.context().getResourceName() == expectedChildResourceName
+    span.context().getSpanType() == expectedChildType
+  }
+  
+  
+    def "should inherit the DD parent attributes add reference FOLLOWS_FROM"() {
+    setup:
+    def expectedName = "fakeName"
+    def expectedParentServiceName = "fakeServiceName"
+    def expectedParentResourceName = "fakeResourceName"
+    def expectedParentType = "fakeType"
+    def expectedChildServiceName = "fakeServiceName-child"
+    def expectedChildResourceName = "fakeResourceName-child"
+    def expectedChildType = "fakeType-child"
+    def expectedBaggageItemKey = "fakeKey"
+    def expectedBaggageItemValue = "fakeValue"
+
+    final DDSpan parent =
+      tracer
+        .buildSpan(expectedName)
+        .withServiceName("foo")
+        .withResourceName(expectedParentResourceName)
+        .withSpanType(expectedParentType)
+        .start()
+
+    parent.setBaggageItem(expectedBaggageItemKey, expectedBaggageItemValue)
+
+    // ServiceName and SpanType are always set by the parent  if they are not present in the child
+    DDSpan span =
+      tracer
+        .buildSpan(expectedName)
+        .withServiceName(expectedParentServiceName)
+        .addReference("follows_from", parent.context())
+        .start()
+
+    println span.getBaggageItem(expectedBaggageItemKey)
+    println expectedBaggageItemValue
+    println span.context().getSpanType()
+    println expectedParentType
+
+    expect:
+    span.getOperationName() == expectedName
+    span.getBaggageItem(expectedBaggageItemKey) == expectedBaggageItemValue
+    span.context().getServiceName() == expectedParentServiceName
+    span.context().getResourceName() == expectedName
+    span.context().getSpanType() == expectedParentType
+
+    when:
+    // ServiceName and SpanType are always overwritten by the child  if they are present
+    span =
+      tracer
+        .buildSpan(expectedName)
+        .withServiceName(expectedChildServiceName)
+        .withResourceName(expectedChildResourceName)
+        .withSpanType(expectedChildType)
+        .addReference("follows_from", parent.context())
+        .start()
+
+    then:
+    span.getOperationName() == expectedName
+    span.getBaggageItem(expectedBaggageItemKey) == expectedBaggageItemValue
+    span.context().getServiceName() == expectedChildServiceName
+    span.context().getResourceName() == expectedChildResourceName
+    span.context().getSpanType() == expectedChildType
+  }
 
   def "should track all spans in trace"() {
     setup:


### PR DESCRIPTION
This is in regards to support ticket #164652

While using opentracing-spring-cloud-starter project as well as spring-messaging we noticed that traces would not go across message queues. Meaning that a trace from service a is put onto a queue and picked up by service b, in the datadog apm ui we would see this as two separate traces. digging into the logs we noticed that the original trace id was coming across to service b but then was getting tossed away. We also noticed that the 'addReference' method was being called but was not implemented. This implementation of the method allows us to see these as one trace.

This is what the trace looks like before this change:
![image 3](https://user-images.githubusercontent.com/24701548/48866165-7561fa00-ed97-11e8-8e9c-f828322d1cac.PNG)

This is what the trace looks like after this change:
![image 2](https://user-images.githubusercontent.com/24701548/48866064-1dc38e80-ed97-11e8-8158-a07c4149be1d.png)


let me know if there is anything that you would like me to change.