### PR TITLE
Servlet3 instrumentation race condition fixes

### DIFF
--- a/dd-java-agent/instrumentation/servlet-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Advice.java
+++ b/dd-java-agent/instrumentation/servlet-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Advice.java
@@ -88,10 +88,6 @@ public class Servlet3Advice {
           }
           Tags.ERROR.set(span, Boolean.TRUE);
           span.log(Collections.singletonMap(ERROR_OBJECT, throwable));
-          if (scope instanceof TraceScope) {
-            ((TraceScope) scope).setAsyncPropagation(false);
-          }
-          scope.close();
           req.removeAttribute(SERVLET_SPAN);
           span.finish(); // Finish the span manually since finishSpanOnClose was false
         } else {
@@ -102,14 +98,11 @@ public class Servlet3Advice {
           // Check again in case the request finished before adding the listener.
           if (!req.isAsyncStarted() && activated.compareAndSet(false, true)) {
             Tags.HTTP_STATUS.set(span, resp.getStatus());
-            if (scope instanceof TraceScope) {
-              ((TraceScope) scope).setAsyncPropagation(false);
-            }
             req.removeAttribute(SERVLET_SPAN);
             span.finish(); // Finish the span manually since finishSpanOnClose was false
           }
-          scope.close();
         }
+        scope.close();
       }
     }
   }


### PR DESCRIPTION
* Do not set `asyncPropagate` on scope since it will be closed anyway.
* Close span once done with it in `TagSettingAsyncListener`.
* No point in explicit finishing span in 'finishOnClose' scope.
* Do not reattach listener in
  `TagSettingAsyncListener#onStartAsync`. Listener is attached each
  time by `Servlet3Advice#stopSpan` and reattaching listener in
  `TagSettingAsyncListener#onStartAsync` causes multiple listeners to
  be attached and race conditions to happen.
* Do not close span in `AsyncContextInstrumentation`. This leads to
  span being written prematurely. This span will be closed in
  `TagSettingAsyncListener` anyway, along with adding proper status code.