### PR TITLE
Revert "Add service name to default jmx tags"

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/Config.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/Config.java
@@ -171,7 +171,6 @@ public class Config {
     result.putAll(globalTags);
     result.putAll(jmxTags);
     result.put(RUNTIME_ID_TAG, runtimeId);
-    result.put(SERVICE_NAME, serviceName);
     return Collections.unmodifiableMap(result);
   }
 

--- a/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -35,7 +35,7 @@ class ConfigTest extends Specification {
     config.traceResolverEnabled == true
     config.serviceMapping == [:]
     config.mergedSpanTags == [:]
-    config.mergedJmxTags == [(RUNTIME_ID_TAG): config.getRuntimeId(), (SERVICE_NAME): config.serviceName]
+    config.mergedJmxTags == [(RUNTIME_ID_TAG): config.getRuntimeId()]
     config.headerTags == [:]
     config.jmxFetchEnabled == false
     config.jmxFetchMetricsConfigs == []
@@ -79,7 +79,7 @@ class ConfigTest extends Specification {
     config.traceResolverEnabled == false
     config.serviceMapping == [a: "1"]
     config.mergedSpanTags == [b: "2", c: "3"]
-    config.mergedJmxTags == [b: "2", d: "4", (RUNTIME_ID_TAG): config.getRuntimeId(), (SERVICE_NAME): config.serviceName]
+    config.mergedJmxTags == [b: "2", d: "4", (RUNTIME_ID_TAG): config.getRuntimeId()]
     config.headerTags == [e: "5"]
     config.jmxFetchEnabled == true
     config.jmxFetchMetricsConfigs == ["/foo.yaml", "/bar.yaml"]
@@ -199,7 +199,7 @@ class ConfigTest extends Specification {
     config.traceResolverEnabled == false
     config.serviceMapping == [a: "1"]
     config.mergedSpanTags == [b: "2", c: "3"]
-    config.mergedJmxTags == [b: "2", d: "4", (RUNTIME_ID_TAG): config.getRuntimeId(), (SERVICE_NAME): config.serviceName]
+    config.mergedJmxTags == [b: "2", d: "4", (RUNTIME_ID_TAG): config.getRuntimeId()]
     config.headerTags == [e: "5"]
     config.jmxFetchMetricsConfigs == ["/foo.yaml", "/bar.yaml"]
     config.jmxFetchCheckPeriod == 100


### PR DESCRIPTION
This reverts commit 1d2cc527474f464bb9a4d0c372f9805478b4ecef.

Datadog's new plan is to handle service tagging for JMX at the agent level instead of in the tracer.