### PR TITLE
Improve error handling for ThreadPoolExecutorInstrumentation

### DIFF
--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/ThreadPoolExecutorInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/ThreadPoolExecutorInstrumentation.java
@@ -57,7 +57,12 @@ public class ThreadPoolExecutorInstrumentation extends Instrumenter.Default {
           queue.offer(new GenericRunnable());
           queue.clear(); // Remove the Runnable we just added.
         } catch (final ClassCastException | IllegalArgumentException e) {
+          // These errors indicate the queue is fundamentally incompatible with wrapped runnables.
+          // We must disable the executor instance to avoid passing wrapped runnables later.
           ExecutorInstrumentation.ConcurrentUtils.disableExecutor(executor);
+        } catch (final Exception e) {
+          // Other errors might indicate the queue is not fully initialized.
+          // We might want to disable for those too, but for now just ignore.
         }
       }
     }


### PR DESCRIPTION
If other exceptions are thrown when trying to test the queue, it generates lots of log noise.  This should handle it better.