### PR TITLE
Fix Muzzle Gradle Plugin Memory leak and optimize JVM for muzzle runs

### DIFF
--- a/buildSrc/src/main/groovy/MuzzlePlugin.groovy
+++ b/buildSrc/src/main/groovy/MuzzlePlugin.groovy
@@ -22,6 +22,7 @@ import org.gradle.api.Task
 import org.gradle.api.model.ObjectFactory
 
 import java.lang.reflect.Method
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * muzzle task plugin which runs muzzle validation against a range of dependencies.
@@ -31,6 +32,7 @@ class MuzzlePlugin implements Plugin<Project> {
    * Remote repositories used to query version ranges and fetch dependencies
    */
   private static final List<RemoteRepository> MUZZLE_REPOS
+  private static final AtomicReference<ClassLoader> TOOLING_LOADER = new AtomicReference<>()
   static {
     RemoteRepository central = new RemoteRepository.Builder("central", "default", "http://central.maven.org/maven2/").build()
     MUZZLE_REPOS = new ArrayList<RemoteRepository>(Arrays.asList(central))
@@ -52,10 +54,10 @@ class MuzzlePlugin implements Plugin<Project> {
         if (!project.muzzle.directives.any { it.assertPass }) {
           project.getLogger().info('No muzzle pass directives configured. Asserting pass against instrumentation compile-time dependencies')
           final ClassLoader userCL = createCompileDepsClassLoader(project, bootstrapProject)
-          final ClassLoader agentCL = createDDClassloader(project, toolingProject)
-          Method assertionMethod = agentCL.loadClass('datadog.trace.agent.tooling.muzzle.MuzzleVersionScanPlugin')
-            .getMethod('assertInstrumentationMuzzled', ClassLoader.class, boolean.class)
-          assertionMethod.invoke(null, userCL, true)
+          final ClassLoader instrumentationCL = createInstrumentationClassloader(project, toolingProject)
+          Method assertionMethod = instrumentationCL.loadClass('datadog.trace.agent.tooling.muzzle.MuzzleVersionScanPlugin')
+            .getMethod('assertInstrumentationMuzzled', ClassLoader.class, ClassLoader.class, boolean.class)
+          assertionMethod.invoke(null, instrumentationCL, userCL, true)
         }
       }
     }
@@ -63,10 +65,10 @@ class MuzzlePlugin implements Plugin<Project> {
       group = 'Muzzle'
       description = "Print references created by instrumentation muzzle"
       doLast {
-        final ClassLoader agentCL = createDDClassloader(project, toolingProject)
-        Method assertionMethod = agentCL.loadClass('datadog.trace.agent.tooling.muzzle.MuzzleVersionScanPlugin')
-          .getMethod('printMuzzleReferences')
-        assertionMethod.invoke(null)
+        final ClassLoader instrumentationCL = createInstrumentationClassloader(project, toolingProject)
+        Method assertionMethod = instrumentationCL.loadClass('datadog.trace.agent.tooling.muzzle.MuzzleVersionScanPlugin')
+          .getMethod('printMuzzleReferences', ClassLoader.class)
+        assertionMethod.invoke(null, instrumentationCL)
       }
     }
     project.tasks.compileMuzzle.dependsOn(bootstrapProject.tasks.compileJava)
@@ -90,6 +92,18 @@ class MuzzlePlugin implements Plugin<Project> {
       // Adding muzzle dependencies has a large config overhead. Stop unless muzzle is explicitly run.
       return
     }
+
+    if (!project.rootProject.tasks.getNames().contains('muzzleCleanup')) {
+      def muzzleCleanup = project.rootProject.task('muzzleCleanup') {
+        group = 'Muzzle'
+        doLast {
+          project.rootProject.getLogger().info("Cleaning up global tooling loader")
+          TOOLING_LOADER.set(null)
+        }
+      }
+      muzzleCleanup.outputs.upToDateWhen { false }
+    }
+    project.tasks.muzzle.finalizedBy(project.rootProject.tasks.muzzleCleanup)
 
     final RepositorySystem system = newRepositorySystem()
     final RepositorySystemSession session = newRepositorySystemSession(system)
@@ -115,22 +129,34 @@ class MuzzlePlugin implements Plugin<Project> {
     }
   }
 
+  private static ClassLoader getOrCreateToolingLoader(Project toolingProject) {
+    final ClassLoader toolingLoader = TOOLING_LOADER.get()
+    if (toolingLoader == null) {
+      Set<URL> ddUrls = new HashSet<>()
+      toolingProject.getLogger().info('creating classpath for agent-tooling')
+      for (File f : toolingProject.sourceSets.main.runtimeClasspath.getFiles()) {
+        toolingProject.getLogger().info('--' + f)
+        ddUrls.add(f.toURI().toURL())
+      }
+      TOOLING_LOADER.compareAndSet(null, new URLClassLoader(ddUrls.toArray(new URL[0]), (ClassLoader) null))
+      return TOOLING_LOADER.get()
+    } else {
+      return toolingLoader
+    }
+  }
+
   /**
    * Create a classloader with core agent classes and project instrumentation on the classpath.
    */
-  private static ClassLoader createDDClassloader(Project project, Project toolingProject) {
-    project.getLogger().info("Creating dd classpath for: " + project.getName())
+  private static ClassLoader createInstrumentationClassloader(Project project, Project toolingProject) {
+    project.getLogger().info("Creating instrumentation classpath for: " + project.getName())
     Set<URL> ddUrls = new HashSet<>()
-    for (File f : toolingProject.sourceSets.main.runtimeClasspath.getFiles()) {
-      project.getLogger().info('--' + f)
-      ddUrls.add(f.toURI().toURL())
-    }
     for (File f : project.sourceSets.main.runtimeClasspath.getFiles()) {
       project.getLogger().info('--' + f)
       ddUrls.add(f.toURI().toURL())
     }
 
-    return new URLClassLoader(ddUrls.toArray(new URL[0]), (ClassLoader) null)
+    return new URLClassLoader(ddUrls.toArray(new URL[0]), getOrCreateToolingLoader(toolingProject))
   }
 
   /**
@@ -248,11 +274,11 @@ class MuzzlePlugin implements Plugin<Project> {
     def muzzleTask = instrumentationProject.task(taskName) {
       doLast {
         final ClassLoader userCL = createClassLoaderForTask(instrumentationProject, bootstrapProject, taskName)
-        final ClassLoader agentCL = createDDClassloader(instrumentationProject, toolingProject)
+        final ClassLoader instrumentationCL = createInstrumentationClassloader(instrumentationProject, toolingProject)
         // find all instrumenters, get muzzle, and assert
-        Method assertionMethod = agentCL.loadClass('datadog.trace.agent.tooling.muzzle.MuzzleVersionScanPlugin')
-          .getMethod('assertInstrumentationMuzzled', ClassLoader.class, boolean.class)
-        assertionMethod.invoke(null, userCL, muzzleDirective.assertPass)
+        Method assertionMethod = instrumentationCL.loadClass('datadog.trace.agent.tooling.muzzle.MuzzleVersionScanPlugin')
+          .getMethod('assertInstrumentationMuzzled', ClassLoader.class, ClassLoader.class, boolean.class)
+        assertionMethod.invoke(null, instrumentationCL, userCL, muzzleDirective.assertPass)
 
         for (Thread thread : Thread.getThreads()) {
           if (thread.getName().startsWith("dd-")) {

--- a/buildSrc/src/main/groovy/MuzzlePlugin.groovy
+++ b/buildSrc/src/main/groovy/MuzzlePlugin.groovy
@@ -220,7 +220,6 @@ class MuzzlePlugin implements Plugin<Project> {
     return inverseDirectives
   }
 
-
   /**
    * Configure a muzzle task to pass or fail a given version.
    *
@@ -315,6 +314,7 @@ class MuzzleDirective {
   List<String> additionalDependencies = new ArrayList<>()
   boolean assertPass
   boolean assertInverse = false
+
   void extraDependency(String compileString) {
     additionalDependencies.add(compileString)
   }

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/WeakMap.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/WeakMap.java
@@ -26,6 +26,10 @@ public interface WeakMap<K, V> {
       }
     }
 
+    public static boolean isProviderRegistered() {
+      return Provider.provider.get() != null;
+    }
+
     public static <K, V> WeakMap<K, V> newWeakMap() {
       return provider.get().get();
     }

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/WeakMap.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/WeakMap.java
@@ -16,18 +16,21 @@ public interface WeakMap<K, V> {
 
   void put(K key, V value);
 
+  @Slf4j
   class Provider {
     private static final AtomicReference<Supplier> provider =
         new AtomicReference<>(Supplier.DEFAULT);
 
     public static void registerIfAbsent(final Supplier provider) {
       if (provider != null && provider != Supplier.DEFAULT) {
-        Provider.provider.compareAndSet(Supplier.DEFAULT, provider);
+        if (Provider.provider.compareAndSet(Supplier.DEFAULT, provider)) {
+          log.debug("Weak map provider set to {}", provider);
+        }
       }
     }
 
     public static boolean isProviderRegistered() {
-      return Provider.provider.get() != null;
+      return provider.get() != Supplier.DEFAULT;
     }
 
     public static <K, V> WeakMap<K, V> newWeakMap() {

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
@@ -98,7 +98,9 @@ public class AgentInstaller {
   }
 
   private static void registerWeakMapProvider() {
-    WeakMap.Provider.registerIfAbsent(new WeakMapSuppliers.WeakConcurrent());
+    if (!WeakMap.Provider.isProviderRegistered()) {
+      WeakMap.Provider.registerIfAbsent(new WeakMapSuppliers.WeakConcurrent());
+    }
     //    WeakMap.Provider.registerIfAbsent(new WeakMapSuppliers.WeakConcurrent.Inline());
     //    WeakMap.Provider.registerIfAbsent(new WeakMapSuppliers.Guava());
   }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.jvmargs=-XX:MaxMetaspaceSize=512m


### PR DESCRIPTION
* Fixes a bug in the muzzle gradle plugin
* Sets JVM metaspace parameter for the gradle daemon

## The bug

Muzzle creates a lot of dynamic classes. Each assert creates a custom datadog classloader containing the instrumenter.

Normally after muzzle runs these classes and the dynamic loader are eligible for GC. These classes were not being collected and eventually the JVM's metaspace leaked to the point of crashing the JVM.

This line is the root cause:

```
WeakMap.Provider.registerIfAbsent(new WeakMapSuppliers.WeakConcurrent());
```

That line looks like a no-op because another provider is already registered at that point, but `WeakConcurrent` spins up a background thread in its constructor. This thread creates a GC root which holds the classloader, which holds all the dynamic classes.

## Metaspace Optimization

In testing I found that setting a max metaspace size caused the JVM to more aggressively clean out the metaspace, which adds a huge performance gain because most of that space is reclaimable and the JVM wastes less time trying to clean the standard heap.

Testing locally with a max metaspace of 512M a full muzzle task takes 9 minutes. Without that max the same full task takes 49 minutes.

Metaspace optimization is set in `gradle.properties`. This seemed like a good option to use everywhere (so similar dynamic class generation doesn't slow us down). We could the option to just the CI config instead.