### PR TITLE
Consumer delegate should rethrow the exception

### DIFF
--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/TracedDelegatingConsumer.java
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/TracedDelegatingConsumer.java
@@ -53,7 +53,7 @@ public class TracedDelegatingConsumer implements Consumer {
   }
 
   @Override
-  public void handleRecoverOk(String consumerTag) {
+  public void handleRecoverOk(final String consumerTag) {
     delegate.handleRecoverOk(consumerTag);
   }
 
@@ -105,6 +105,7 @@ public class TracedDelegatingConsumer implements Consumer {
         final Span span = scope.span();
         Tags.ERROR.set(span, true);
         span.log(Collections.singletonMap(ERROR_OBJECT, throwable));
+        throw throwable;
       } finally {
         scope.close();
       }


### PR DESCRIPTION
Previously the delegate would swallow the exception and not rethrow.

I also added a test to attempt to verify, but the exception doesn’t seem to be observable in the test.

(See #602)