### PR TITLE
Configure jmxfetch to use new gc metrics

### DIFF
--- a/dd-java-agent/agent-jmxfetch/src/main/resources/jmxfetch-config.yaml
+++ b/dd-java-agent/agent-jmxfetch/src/main/resources/jmxfetch-config.yaml
@@ -1,5 +1,6 @@
 init_config:
   is_jmx: true
+  new_gc_metrics: true
 
 instances:
 - jmx_url: service:jmx:local:///


### PR DESCRIPTION
This won't have any effect on jmx behavior. The next jmxfetch update puts our desired metric names behind this feature flag. Enabling now so we don't forget the next time we refresh jmxfetch.