### PR TITLE
Restore RabbitMQ latestDepTest to use latest version

### DIFF
--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/rabbitmq-amqp-2.7.gradle
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/rabbitmq-amqp-2.7.gradle
@@ -37,9 +37,7 @@ dependencies {
   testCompile deps.testcontainers
 
   latestDepTestCompile group: 'com.rabbitmq', name: 'amqp-client', version: '+'
-  // TODO: check next version of amqp to make sure the dependencies can be downloaded from maven and 
-  // revert back to using latest
-  latestDepTestCompile group: 'org.springframework.amqp', name: 'spring-rabbit', version: '2.1.0.RELEASE'
+  latestDepTestCompile group: 'org.springframework.amqp', name: 'spring-rabbit', version: '+'
 }
 
 configurations.testRuntime {


### PR DESCRIPTION
Since spring-rabbit no longer uses a dependency with a snapshot build.