### PR TITLE
Fix Flaky Ratpack Fork Test

### DIFF
--- a/dd-java-agent/instrumentation/ratpack-1.4/src/test/groovy/RatpackTest.groovy
+++ b/dd-java-agent/instrumentation/ratpack-1.4/src/test/groovy/RatpackTest.groovy
@@ -320,12 +320,16 @@ class RatpackTest extends AgentTestRunner {
             ((TraceScope) scope).setAsyncPropagation(true)
           }
           scope.span().setBaggageItem("test-baggage", "foo")
-          context.render(testPromise().fork())
 
-          if (startSpanInHandler) {
-            ((TraceScope) scope).setAsyncPropagation(false)
+          context.onClose {
+            if (startSpanInHandler) {
+              final Scope activeScope = GlobalTracer.get().scopeManager().active()
+              ((TraceScope) activeScope).setAsyncPropagation(false)
+              activeScope.close()
+            }
           }
-          scope.close()
+
+          context.render(testPromise().fork())
         }
       }
     }


### PR DESCRIPTION
Ratpack tests occasionally fail with the handler span and manually started span out of order. This will ensure that if a span is manually started inside of the handler then it will be finished after the handler span is finished, which is when the request has been responded to.