### PR TITLE
Revert "Revert "Add service name to default jmx tags""

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/Config.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/Config.java
@@ -184,6 +184,7 @@ public class Config {
     result.putAll(globalTags);
     result.putAll(jmxTags);
     result.put(RUNTIME_ID_TAG, runtimeId);
+    result.put(SERVICE_NAME, serviceName);
     return Collections.unmodifiableMap(result);
   }
 

--- a/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -35,7 +35,7 @@ class ConfigTest extends Specification {
     config.traceResolverEnabled == true
     config.serviceMapping == [:]
     config.mergedSpanTags == [:]
-    config.mergedJmxTags == [(RUNTIME_ID_TAG): config.getRuntimeId()]
+    config.mergedJmxTags == [(RUNTIME_ID_TAG): config.getRuntimeId(), (SERVICE_NAME): config.serviceName]
     config.headerTags == [:]
     config.runtimeContextFieldInjection == true
     config.jmxFetchEnabled == false
@@ -81,7 +81,7 @@ class ConfigTest extends Specification {
     config.traceResolverEnabled == false
     config.serviceMapping == [a: "1"]
     config.mergedSpanTags == [b: "2", c: "3"]
-    config.mergedJmxTags == [b: "2", d: "4", (RUNTIME_ID_TAG): config.getRuntimeId()]
+    config.mergedJmxTags == [b: "2", d: "4", (RUNTIME_ID_TAG): config.getRuntimeId(), (SERVICE_NAME): config.serviceName]
     config.headerTags == [e: "5"]
     config.runtimeContextFieldInjection == false
     config.jmxFetchEnabled == true
@@ -202,7 +202,7 @@ class ConfigTest extends Specification {
     config.traceResolverEnabled == false
     config.serviceMapping == [a: "1"]
     config.mergedSpanTags == [b: "2", c: "3"]
-    config.mergedJmxTags == [b: "2", d: "4", (RUNTIME_ID_TAG): config.getRuntimeId()]
+    config.mergedJmxTags == [b: "2", d: "4", (RUNTIME_ID_TAG): config.getRuntimeId(), (SERVICE_NAME): config.serviceName]
     config.headerTags == [e: "5"]
     config.jmxFetchMetricsConfigs == ["/foo.yaml", "/bar.yaml"]
     config.jmxFetchCheckPeriod == 100


### PR DESCRIPTION
This reverts commit 069880105d3122f2f0196b6fd105cf4282f4231c.

Rather than wait for agent-level service tagging we're going back to tagging jmx metrics by service at the tracer level.