### PR TITLE
Do not set the sampler rate for RateByServiceSampler

### DIFF
--- a/dd-trace-ot/src/main/java/datadog/trace/common/sampling/RateByServiceSampler.java
+++ b/dd-trace-ot/src/main/java/datadog/trace/common/sampling/RateByServiceSampler.java
@@ -2,7 +2,6 @@ package datadog.trace.common.sampling;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import datadog.opentracing.DDSpan;
-import datadog.opentracing.DDSpanContext;
 import datadog.trace.api.sampling.PrioritySampling;
 import datadog.trace.common.writer.DDApi.ResponseListener;
 import java.util.HashMap;
@@ -58,7 +57,6 @@ public class RateByServiceSampler implements Sampler, ResponseListener {
     } else {
       span.setSamplingPriority(PrioritySampling.SAMPLER_DROP);
     }
-    span.context().setMetric(DDSpanContext.SAMPLE_RATE_KEY, sampler.getSampleRate());
   }
 
   private static String getSpanEnv(DDSpan span) {

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/DDSpanTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/DDSpanTest.groovy
@@ -177,13 +177,10 @@ class DDSpanTest extends Specification {
     expect:
     parent.context().samplingPriority == PrioritySampling.SAMPLER_KEEP
     parent.getMetrics().get(DDSpanContext.PRIORITY_SAMPLING_KEY) == PrioritySampling.SAMPLER_KEEP
-    parent.getMetrics().get(DDSpanContext.SAMPLE_RATE_KEY) == 1.0
     child1.getSamplingPriority() == parent.getSamplingPriority()
     child1.getMetrics().get(DDSpanContext.PRIORITY_SAMPLING_KEY) == null
-    child1.getMetrics().get(DDSpanContext.SAMPLE_RATE_KEY) == null
     child2.getSamplingPriority() == parent.getSamplingPriority()
     child2.getMetrics().get(DDSpanContext.PRIORITY_SAMPLING_KEY) == null
-    child2.getMetrics().get(DDSpanContext.SAMPLE_RATE_KEY) == null
   }
 
   def "getRootSpan returns the root span"() {

--- a/dd-trace-ot/src/test/groovy/datadog/trace/api/sampling/RateByServiceSamplerTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/trace/api/sampling/RateByServiceSamplerTest.groovy
@@ -65,6 +65,7 @@ class RateByServiceSamplerTest extends Specification {
     expect:
     // sets correctly on root span
     span.getSamplingPriority() == PrioritySampling.SAMPLER_KEEP
-    span.getMetrics().get("_sample_rate") == 1.0
+    // RateByServiceSamler must not set the sample rate
+    span.getMetrics().get("_sample_rate") == null
   }
 }


### PR DESCRIPTION
Stop incorrectly setting the sample rate key on the RateByServiceSampler. Setting this key causes the backend to mess up the throughput numbers even if the trace totals are correct.