### PR TITLE
Add languages tag to jmx/runtime tags

### DIFF
--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTest.groovy
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTest.groovy
@@ -1,5 +1,4 @@
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.api.Config
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.junit.ClassRule
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory
@@ -75,59 +74,49 @@ class KafkaClientTest extends AgentTestRunner {
     received.value() == greeting
     received.key() == null
 
-    TEST_WRITER.waitForTraces(2)
-    TEST_WRITER.size() == 2
-
-    def t1 = TEST_WRITER.get(0)
-    t1.size() == 1
-    def t2 = TEST_WRITER.get(1)
-    t2.size() == 1
-
-    and: // PRODUCER span 0
-    def t1span1 = t1[0]
-
-    t1span1.context().operationName == "kafka.produce"
-    t1span1.serviceName == "kafka"
-    t1span1.resourceName == "Produce Topic $SHARED_TOPIC"
-    t1span1.type == "queue"
-    !t1span1.context().getErrorFlag()
-    t1span1.context().parentId == "0"
-
-    def t1tags1 = t1span1.context().tags
-    t1tags1["component"] == "java-kafka"
-    t1tags1["span.kind"] == "producer"
-    t1tags1["span.type"] == "queue"
-    t1tags1["thread.name"] != null
-    t1tags1["thread.id"] != null
-    t1tags1[Config.RUNTIME_ID_TAG] == Config.get().runtimeId
-    t1tags1.size() == 6
-
-    and: // CONSUMER span 0
-    def t2span1 = t2[0]
-
-    t2span1.context().operationName == "kafka.consume"
-    t2span1.serviceName == "kafka"
-    t2span1.resourceName == "Consume Topic $SHARED_TOPIC"
-    t2span1.type == "queue"
-    !t2span1.context().getErrorFlag()
-    t2span1.context().parentId == t1span1.context().spanId
-
-    def t2tags1 = t2span1.context().tags
-    t2tags1["component"] == "java-kafka"
-    t2tags1["span.kind"] == "consumer"
-    t1tags1["span.type"] == "queue"
-    t2tags1["partition"] >= 0
-    t2tags1["offset"] == 0
-    t2tags1["thread.name"] != null
-    t2tags1["thread.id"] != null
-    t2tags1[Config.RUNTIME_ID_TAG] == Config.get().runtimeId
-    t2tags1.size() == 8
+    assertTraces(2) {
+      trace(0, 1) {
+        // PRODUCER span 0
+        span(0) {
+          serviceName "kafka"
+          operationName "kafka.produce"
+          resourceName "Produce Topic $SHARED_TOPIC"
+          spanType "queue"
+          errored false
+          parent()
+          tags {
+            "component" "java-kafka"
+            "span.kind" "producer"
+            "span.type" "queue"
+            defaultTags()
+          }
+        }
+      }
+      trace(1, 1) {
+        // CONSUMER span 0
+        span(0) {
+          serviceName "kafka"
+          operationName "kafka.consume"
+          resourceName "Consume Topic $SHARED_TOPIC"
+          spanType "queue"
+          errored false
+          childOf TEST_WRITER[0][0]
+          tags {
+            "component" "java-kafka"
+            "span.kind" "consumer"
+            "span.type" "queue"
+            "partition" { it >= 0 }
+            "offset" 0
+            defaultTags(true)
+          }
+        }
+      }
+    }
 
     def headers = received.headers()
     headers.iterator().hasNext()
-    new String(headers.headers("x-datadog-trace-id").iterator().next().value()) == "$t1span1.traceId"
-    new String(headers.headers("x-datadog-parent-id").iterator().next().value()) == "$t1span1.spanId"
-
+    new String(headers.headers("x-datadog-trace-id").iterator().next().value()) == "${TEST_WRITER[0][0].traceId}"
+    new String(headers.headers("x-datadog-parent-id").iterator().next().value()) == "${TEST_WRITER[0][0].spanId}"
 
     cleanup:
     producerFactory.stop()

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/TagsAssert.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/TagsAssert.groovy
@@ -33,13 +33,16 @@ class TagsAssert {
     assertedTags.add("thread.name")
     assertedTags.add("thread.id")
     assertedTags.add(Config.RUNTIME_ID_TAG)
+    assertedTags.add(Config.LANGUAGE_TAG_KEY)
 
     assert tags["thread.name"] != null
     assert tags["thread.id"] != null
     if ("0" == spanParentId || distributedRootSpan) {
       assert tags[Config.RUNTIME_ID_TAG] == Config.get().runtimeId
+      assert tags[Config.LANGUAGE_TAG_KEY] == Config.LANGUAGE_TAG_VALUE
     } else {
       assert tags[Config.RUNTIME_ID_TAG] == null
+      assert tags[Config.LANGUAGE_TAG_KEY] == null
     }
   }
 

--- a/dd-trace-api/src/main/java/datadog/trace/api/Config.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/Config.java
@@ -50,6 +50,8 @@ public class Config {
   public static final String JMX_FETCH_STATSD_PORT = "jmxfetch.statsd.port";
 
   public static final String RUNTIME_ID_TAG = "runtime-id";
+  public static final String LANGUAGES_TAG_KEY = "languages";
+  public static final String LANGUAGES_TAG_VALUE = "jvm";
   public static final String DEFAULT_SERVICE_NAME = "unnamed-java-app";
 
   public static final String DD_AGENT_WRITER_TYPE = "DDAgentWriter";
@@ -183,8 +185,26 @@ public class Config {
     final Map<String, String> result = newHashMap(globalTags.size() + jmxTags.size() + 1);
     result.putAll(globalTags);
     result.putAll(jmxTags);
-    result.put(RUNTIME_ID_TAG, runtimeId);
+    result.putAll(getRuntimeTags());
+    // service name set here instead of getRuntimeTags because apm already manages the service tag
+    // and may chose to override it.
     result.put(SERVICE_NAME, serviceName);
+    return Collections.unmodifiableMap(result);
+  }
+
+  /**
+   * Return a map of tags required by the datadog backend to link runtime metrics (i.e. jmx) and
+   * traces.
+   *
+   * <p>These tags must be applied to every runtime metrics and placed on the root span of every
+   * trace.
+   *
+   * @return A map of tag-name -> tag-value
+   */
+  public Map<String, String> getRuntimeTags() {
+    final Map<String, String> result = newHashMap(3);
+    result.put(RUNTIME_ID_TAG, runtimeId);
+    result.put(LANGUAGES_TAG_KEY, LANGUAGES_TAG_VALUE);
     return Collections.unmodifiableMap(result);
   }
 

--- a/dd-trace-api/src/main/java/datadog/trace/api/Config.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/Config.java
@@ -50,8 +50,8 @@ public class Config {
   public static final String JMX_FETCH_STATSD_PORT = "jmxfetch.statsd.port";
 
   public static final String RUNTIME_ID_TAG = "runtime-id";
-  public static final String LANGUAGES_TAG_KEY = "languages";
-  public static final String LANGUAGES_TAG_VALUE = "jvm";
+  public static final String LANGUAGE_TAG_KEY = "language";
+  public static final String LANGUAGE_TAG_VALUE = "jvm";
   public static final String DEFAULT_SERVICE_NAME = "unnamed-java-app";
 
   public static final String DD_AGENT_WRITER_TYPE = "DDAgentWriter";
@@ -202,9 +202,9 @@ public class Config {
    * @return A map of tag-name -> tag-value
    */
   public Map<String, String> getRuntimeTags() {
-    final Map<String, String> result = newHashMap(3);
+    final Map<String, String> result = newHashMap(2);
     result.put(RUNTIME_ID_TAG, runtimeId);
-    result.put(LANGUAGES_TAG_KEY, LANGUAGES_TAG_VALUE);
+    result.put(LANGUAGE_TAG_KEY, LANGUAGE_TAG_VALUE);
     return Collections.unmodifiableMap(result);
   }
 

--- a/dd-trace-api/src/main/java/datadog/trace/api/Config.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/Config.java
@@ -182,10 +182,13 @@ public class Config {
   }
 
   public Map<String, String> getMergedJmxTags() {
-    final Map<String, String> result = newHashMap(globalTags.size() + jmxTags.size() + 1);
+    final Map<String, String> runtimeTags = getRuntimeTags();
+    final Map<String, String> result =
+        newHashMap(
+            globalTags.size() + jmxTags.size() + runtimeTags.size() + 1 /* for serviceName */);
     result.putAll(globalTags);
     result.putAll(jmxTags);
-    result.putAll(getRuntimeTags());
+    result.putAll(runtimeTags);
     // service name set here instead of getRuntimeTags because apm already manages the service tag
     // and may chose to override it.
     result.put(SERVICE_NAME, serviceName);

--- a/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -35,7 +35,7 @@ class ConfigTest extends Specification {
     config.traceResolverEnabled == true
     config.serviceMapping == [:]
     config.mergedSpanTags == [:]
-    config.mergedJmxTags == [(RUNTIME_ID_TAG): config.getRuntimeId(), (SERVICE_NAME): config.serviceName, (LANGUAGES_TAG_KEY): LANGUAGES_TAG_VALUE]
+    config.mergedJmxTags == [(RUNTIME_ID_TAG): config.getRuntimeId(), (SERVICE_NAME): config.serviceName, (LANGUAGE_TAG_KEY): LANGUAGE_TAG_VALUE]
     config.headerTags == [:]
     config.runtimeContextFieldInjection == true
     config.jmxFetchEnabled == false
@@ -81,7 +81,7 @@ class ConfigTest extends Specification {
     config.traceResolverEnabled == false
     config.serviceMapping == [a: "1"]
     config.mergedSpanTags == [b: "2", c: "3"]
-    config.mergedJmxTags == [b: "2", d: "4", (RUNTIME_ID_TAG): config.getRuntimeId(), (SERVICE_NAME): config.serviceName, (LANGUAGES_TAG_KEY): LANGUAGES_TAG_VALUE]
+    config.mergedJmxTags == [b: "2", d: "4", (RUNTIME_ID_TAG): config.getRuntimeId(), (SERVICE_NAME): config.serviceName, (LANGUAGE_TAG_KEY): LANGUAGE_TAG_VALUE]
     config.headerTags == [e: "5"]
     config.runtimeContextFieldInjection == false
     config.jmxFetchEnabled == true
@@ -202,7 +202,7 @@ class ConfigTest extends Specification {
     config.traceResolverEnabled == false
     config.serviceMapping == [a: "1"]
     config.mergedSpanTags == [b: "2", c: "3"]
-    config.mergedJmxTags == [b: "2", d: "4", (RUNTIME_ID_TAG): config.getRuntimeId(), (SERVICE_NAME): config.serviceName, (LANGUAGES_TAG_KEY): LANGUAGES_TAG_VALUE]
+    config.mergedJmxTags == [b: "2", d: "4", (RUNTIME_ID_TAG): config.getRuntimeId(), (SERVICE_NAME): config.serviceName, (LANGUAGE_TAG_KEY): LANGUAGE_TAG_VALUE]
     config.headerTags == [e: "5"]
     config.jmxFetchMetricsConfigs == ["/foo.yaml", "/bar.yaml"]
     config.jmxFetchCheckPeriod == 100

--- a/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -35,7 +35,7 @@ class ConfigTest extends Specification {
     config.traceResolverEnabled == true
     config.serviceMapping == [:]
     config.mergedSpanTags == [:]
-    config.mergedJmxTags == [(RUNTIME_ID_TAG): config.getRuntimeId(), (SERVICE_NAME): config.serviceName]
+    config.mergedJmxTags == [(RUNTIME_ID_TAG): config.getRuntimeId(), (SERVICE_NAME): config.serviceName, (LANGUAGES_TAG_KEY): LANGUAGES_TAG_VALUE]
     config.headerTags == [:]
     config.runtimeContextFieldInjection == true
     config.jmxFetchEnabled == false
@@ -81,7 +81,7 @@ class ConfigTest extends Specification {
     config.traceResolverEnabled == false
     config.serviceMapping == [a: "1"]
     config.mergedSpanTags == [b: "2", c: "3"]
-    config.mergedJmxTags == [b: "2", d: "4", (RUNTIME_ID_TAG): config.getRuntimeId(), (SERVICE_NAME): config.serviceName]
+    config.mergedJmxTags == [b: "2", d: "4", (RUNTIME_ID_TAG): config.getRuntimeId(), (SERVICE_NAME): config.serviceName, (LANGUAGES_TAG_KEY): LANGUAGES_TAG_VALUE]
     config.headerTags == [e: "5"]
     config.runtimeContextFieldInjection == false
     config.jmxFetchEnabled == true
@@ -202,7 +202,7 @@ class ConfigTest extends Specification {
     config.traceResolverEnabled == false
     config.serviceMapping == [a: "1"]
     config.mergedSpanTags == [b: "2", c: "3"]
-    config.mergedJmxTags == [b: "2", d: "4", (RUNTIME_ID_TAG): config.getRuntimeId(), (SERVICE_NAME): config.serviceName]
+    config.mergedJmxTags == [b: "2", d: "4", (RUNTIME_ID_TAG): config.getRuntimeId(), (SERVICE_NAME): config.serviceName, (LANGUAGES_TAG_KEY): LANGUAGES_TAG_VALUE]
     config.headerTags == [e: "5"]
     config.jmxFetchMetricsConfigs == ["/foo.yaml", "/bar.yaml"]
     config.jmxFetchCheckPeriod == 100

--- a/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
@@ -54,7 +54,7 @@ public class DDTracer implements io.opentracing.Tracer, Closeable, datadog.trace
   /** Scope manager is in charge of managing the scopes from which spans are created */
   final ContextualScopeManager scopeManager = new ContextualScopeManager();
 
-  /** Tags required to link apm trades to runtime metrics */
+  /** Tags required to link apm traces to runtime metrics */
   final Map<String, String> runtimeTags;
   /** A set of tags that are added to every span */
   private final Map<String, String> defaultSpanTags;
@@ -627,7 +627,7 @@ public class DDTracer implements io.opentracing.Tracer, Closeable, datadog.trace
           tags.putAll(((TagContext) parentContext).getTags());
         }
         // add runtime tags to the root span
-        for (Map.Entry<String, String> runtimeTag : runtimeTags.entrySet()) {
+        for (final Map.Entry<String, String> runtimeTag : runtimeTags.entrySet()) {
           tags.put(runtimeTag.getKey(), runtimeTag.getValue());
         }
 

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/DDSpanBuilderTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/DDSpanBuilderTest.groovy
@@ -52,9 +52,10 @@ class DDSpanBuilderTest extends Specification {
 
     then:
     span.getTags() == [
-      (DDTags.THREAD_NAME)   : Thread.currentThread().getName(),
-      (DDTags.THREAD_ID)     : Thread.currentThread().getId(),
-      (Config.RUNTIME_ID_TAG): config.getRuntimeId()
+      (DDTags.THREAD_NAME)     : Thread.currentThread().getName(),
+      (DDTags.THREAD_ID)       : Thread.currentThread().getId(),
+      (Config.RUNTIME_ID_TAG)  : config.getRuntimeId(),
+      (Config.LANGUAGE_TAG_KEY): Config.LANGUAGE_TAG_VALUE,
     ]
 
     when:
@@ -224,9 +225,9 @@ class DDSpanBuilderTest extends Specification {
     span.context().getResourceName() == expectedChildResourceName
     span.context().getSpanType() == expectedChildType
   }
-  
-  
-    def "should inherit the DD parent attributes addReference CHILD_OF"() {
+
+
+  def "should inherit the DD parent attributes addReference CHILD_OF"() {
     setup:
     def expectedName = "fakeName"
     def expectedParentServiceName = "fakeServiceName"
@@ -286,9 +287,9 @@ class DDSpanBuilderTest extends Specification {
     span.context().getResourceName() == expectedChildResourceName
     span.context().getSpanType() == expectedChildType
   }
-  
-  
-    def "should inherit the DD parent attributes add reference FOLLOWS_FROM"() {
+
+
+  def "should inherit the DD parent attributes add reference FOLLOWS_FROM"() {
     setup:
     def expectedName = "fakeName"
     def expectedParentServiceName = "fakeServiceName"
@@ -389,7 +390,8 @@ class DDSpanBuilderTest extends Specification {
     span.parentId == extractedContext.spanId
     span.samplingPriority == extractedContext.samplingPriority
     span.context().baggageItems == extractedContext.baggage
-    span.context().@tags == extractedContext.tags + [(Config.RUNTIME_ID_TAG): config.getRuntimeId()]
+    span.context().@tags == extractedContext.tags + [(Config.RUNTIME_ID_TAG)  : config.getRuntimeId(),
+                                                     (Config.LANGUAGE_TAG_KEY): Config.LANGUAGE_TAG_VALUE,]
 
     where:
     extractedContext                                                      | _
@@ -406,9 +408,10 @@ class DDSpanBuilderTest extends Specification {
 
     expect:
     span.tags == tags + [
-      (DDTags.THREAD_NAME)   : Thread.currentThread().getName(),
-      (DDTags.THREAD_ID)     : Thread.currentThread().getId(),
-      (Config.RUNTIME_ID_TAG): config.getRuntimeId()
+      (DDTags.THREAD_NAME)     : Thread.currentThread().getName(),
+      (DDTags.THREAD_ID)       : Thread.currentThread().getId(),
+      (Config.RUNTIME_ID_TAG)  : config.getRuntimeId(),
+      (Config.LANGUAGE_TAG_KEY): Config.LANGUAGE_TAG_VALUE,
     ]
 
     cleanup:

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/DDSpanTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/DDSpanTest.groovy
@@ -11,7 +11,7 @@ import static datadog.trace.api.Config.DEFAULT_SERVICE_NAME
 
 class DDSpanTest extends Specification {
   def writer = new ListWriter()
-  def tracer = new DDTracer(DEFAULT_SERVICE_NAME, writer, new RateByServiceSampler(), "some-runtime-id")
+  def tracer = new DDTracer(DEFAULT_SERVICE_NAME, writer, new RateByServiceSampler(), [:])
 
   def "getters and setters"() {
     setup:

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/TraceInterceptorTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/TraceInterceptorTest.groovy
@@ -143,7 +143,8 @@ class TraceInterceptorTest extends Specification {
     tags["thread.name"] != null
     tags["thread.id"] != null
     tags["runtime-id"] != null
-    tags.size() == 7
+    tags["language"] != null
+    tags.size() == 8
   }
 
   def "register interceptor through bridge"() {

--- a/dd-trace-ot/src/test/groovy/datadog/trace/DDTracerTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/trace/DDTracerTest.groovy
@@ -121,7 +121,8 @@ class DDTracerTest extends Specification {
     tracer.serviceName == DEFAULT_SERVICE_NAME
     tracer.sampler == sampler
     tracer.writer == writer
-    tracer.runtimeTags.size() > 0
+    tracer.runtimeTags[Config.RUNTIME_ID_TAG].size() > 0 // not null or empty
+    tracer.runtimeTags[Config.LANGUAGE_TAG_KEY] == Config.LANGUAGE_TAG_VALUE
   }
 
   def "Shares TraceCount with DDApi with #key = #value"() {
@@ -134,7 +135,7 @@ class DDTracerTest extends Specification {
     tracer.traceCount.is(((DDAgentWriter) tracer.writer).getApi().traceCount)
 
     where:
-    key                      | value
+    key               | value
     PRIORITY_SAMPLING | "true"
     PRIORITY_SAMPLING | "false"
   }

--- a/dd-trace-ot/src/test/groovy/datadog/trace/DDTracerTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/trace/DDTracerTest.groovy
@@ -121,7 +121,7 @@ class DDTracerTest extends Specification {
     tracer.serviceName == DEFAULT_SERVICE_NAME
     tracer.sampler == sampler
     tracer.writer == writer
-    tracer.runtimeId.length() > 0
+    tracer.runtimeTags.size() > 0
   }
 
   def "Shares TraceCount with DDApi with #key = #value"() {


### PR DESCRIPTION
Add `languages` tag to default jmx/runtime tags.

wip: Still need to update some of the tests with the new tags.

@mar-kolya To save wasteful editing do you mind reviewing the core changes before I copy-paste the new tags everywhere?