### PR TITLE
Properly capture callable statement queries

### DIFF
--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/ConnectionInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/ConnectionInstrumentation.java
@@ -2,7 +2,6 @@ package datadog.trace.instrumentation.jdbc;
 
 import static datadog.trace.agent.tooling.ByteBuddyElementMatchers.safeHasSuperType;
 import static net.bytebuddy.matcher.ElementMatchers.isInterface;
-import static net.bytebuddy.matcher.ElementMatchers.isSubTypeOf;
 import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.not;
@@ -38,7 +37,7 @@ public final class ConnectionInstrumentation extends Instrumenter.Default {
         nameStartsWith("prepare")
             .and(takesArgument(0, String.class))
             // Also include CallableStatement, which is a sub type of PreparedStatement
-            .and(returns(isSubTypeOf(PreparedStatement.class))),
+            .and(returns(safeHasSuperType(named(PreparedStatement.class.getName())))),
         ConnectionPrepareAdvice.class.getName());
     return transformers;
   }

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/ConnectionInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/ConnectionInstrumentation.java
@@ -2,6 +2,7 @@ package datadog.trace.instrumentation.jdbc;
 
 import static datadog.trace.agent.tooling.ByteBuddyElementMatchers.safeHasSuperType;
 import static net.bytebuddy.matcher.ElementMatchers.isInterface;
+import static net.bytebuddy.matcher.ElementMatchers.isSubTypeOf;
 import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.not;
@@ -36,7 +37,8 @@ public final class ConnectionInstrumentation extends Instrumenter.Default {
     transformers.put(
         nameStartsWith("prepare")
             .and(takesArgument(0, String.class))
-            .and(returns(PreparedStatement.class)),
+            // Also include CallableStatement, which is a sub type of PreparedStatement
+            .and(returns(isSubTypeOf(PreparedStatement.class))),
         ConnectionPrepareAdvice.class.getName());
     return transformers;
   }


### PR DESCRIPTION
CallableStatement is a sub type of PreparedStatement.  Previously we were only matching methods that returned exactly PreparedStatement.

Reported in #633