### PR TITLE
Reduce AWS deps and Increase Max Metaspace Size

### DIFF
--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/aws-java-sdk-1.11.0.gradle
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/aws-java-sdk-1.11.0.gradle
@@ -49,13 +49,19 @@ dependencies {
   testCompile project(':dd-java-agent:testing')
   // Include httpclient instrumentation for testing because it is a dependency for aws-sdk.
   testCompile project(':dd-java-agent:instrumentation:apache-httpclient-4')
-  testCompile group: 'com.amazonaws', name: 'aws-java-sdk', version: '1.11.0'
+  testCompile group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.11.0'
+  testCompile group: 'com.amazonaws', name: 'aws-java-sdk-rds', version: '1.11.0'
+  testCompile group: 'com.amazonaws', name: 'aws-java-sdk-ec2', version: '1.11.0'
 
   test_1_11_106Compile project(':dd-java-agent:testing')
   test_1_11_106Compile project(':dd-java-agent:instrumentation:apache-httpclient-4')
-  test_1_11_106Compile group: 'com.amazonaws', name: 'aws-java-sdk', version: '1.11.106'
+  test_1_11_106Compile group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.11.106'
+  test_1_11_106Compile group: 'com.amazonaws', name: 'aws-java-sdk-rds', version: '1.11.106'
+  test_1_11_106Compile group: 'com.amazonaws', name: 'aws-java-sdk-ec2', version: '1.11.106'
 
   latestDepTestCompile project(':dd-java-agent:testing')
   latestDepTestCompile project(':dd-java-agent:instrumentation:apache-httpclient-4')
-  latestDepTestCompile group: 'com.amazonaws', name: 'aws-java-sdk', version: '+'
+  latestDepTestCompile group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '+'
+  latestDepTestCompile group: 'com.amazonaws', name: 'aws-java-sdk-rds', version: '+'
+  latestDepTestCompile group: 'com.amazonaws', name: 'aws-java-sdk-ec2', version: '+'
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-org.gradle.jvmargs=-XX:MaxMetaspaceSize=512m
+org.gradle.jvmargs=-XX:MaxMetaspaceSize=1g


### PR DESCRIPTION
aws-sdk has tons of dependencies that change frequently, resulting in long times to refresh gradle.  This attempts to reduce that.

Also trying to band-aid the metaspace size issue.