### PR TITLE
Workaround LogManager startup issue and add springboot test

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
@@ -80,7 +80,13 @@ public class AgentInstaller {
                             named("java.net.URL")
                                 .or(named("java.net.HttpURLConnection"))
                                 .or(nameStartsWith("java.util.concurrent."))
-                                .or(nameStartsWith("java.util.logging.")))))
+                                .or(
+                                    nameStartsWith("java.util.logging.")
+                                        // Concurrent instrumentation modifies the strucutre of
+                                        // Cleaner class incompaibly with java9+ modules.
+                                        // Working around until a long-term fix for modules can be
+                                        // put in place.
+                                        .and(not(named("java.util.logging.LogManager$Cleaner")))))))
             .or(nameStartsWith("com.sun.").and(not(nameStartsWith("com.sun.messaging."))))
             .or(
                 nameStartsWith("sun.")

--- a/dd-smoke-tests/README.md
+++ b/dd-smoke-tests/README.md
@@ -1,0 +1,8 @@
+# Datadog Smoke Tests
+Assert that various application servers will start up with the Datadog JavaAgent without any obvious ill effects.
+
+Each subproject underneath `dd-smoke-tests` is a single smoke test. Each test does the following
+* Launch the app server with stdout and stderr logged to `$buildDir/reports/server.log`
+* Run a spock test which does 200 requests to an endpoint on the server and asserts on an expected response.
+
+Note that there is nothing special about doing 200 requests. 200 is simply an arbitrarily large number to exercise the server.

--- a/dd-smoke-tests/dd-smoke-tests.gradle
+++ b/dd-smoke-tests/dd-smoke-tests.gradle
@@ -1,9 +1,1 @@
-// Set properties before any plugins get loaded
-project.ext {
-  // Execute tests on all JVMs, even rare and outdated ones
-  integrationTests = true
-}
-
-apply from: "${rootDir}/gradle/java.gradle"
-
 description = 'dd-smoke-tests'

--- a/dd-smoke-tests/play/play.gradle
+++ b/dd-smoke-tests/play/play.gradle
@@ -84,6 +84,7 @@ def randomOpenPort() {
 }
 
 task startServer(type: com.github.psxpaul.task.ExecFork) {
+  dependsOn project(':dd-java-agent').shadowJar
   playHttpPort = randomOpenPort()
 
   if (playHttpPort == -1) {
@@ -93,6 +94,7 @@ task startServer(type: com.github.psxpaul.task.ExecFork) {
   workingDir = "${buildDir}/stage/playBinary"
   commandLine = "${workingDir}/bin/playBinary"
   stopAfter = test
+  standardOutput "${buildDir}/reports/server.log"
   // these params tells the ExecFork plugin to block on startServer task until the port is opened or the string is seen in the ouput
   waitForPort = playHttpPort
   waitForOutput = "Listening for HTTP on /127.0.0.1:${playHttpPort}"
@@ -120,7 +122,7 @@ tasks.withType(Test) {
     events "started"
   }
 
-  dependsOn project(':dd-java-agent').shadowJar, startServer
+  dependsOn startServer
 }
 
 // clean up the PID file from the server

--- a/dd-smoke-tests/play/play.gradle
+++ b/dd-smoke-tests/play/play.gradle
@@ -69,20 +69,6 @@ dependencies {
   testCompile group: 'com.squareup.okhttp3', name: 'okhttp', version: '3.6.0'
 }
 
-/** Open up a random, reusable port. */
-def randomOpenPort() {
-  final ServerSocket socket
-  try {
-    socket = new ServerSocket(0)
-    socket.setReuseAddress(true)
-    socket.close()
-    return socket.getLocalPort()
-  } catch (final IOException ioe) {
-    ioe.printStackTrace()
-    return -1
-  }
-}
-
 task startServer(type: com.github.psxpaul.task.ExecFork) {
   dependsOn project(':dd-java-agent').shadowJar
   playHttpPort = randomOpenPort()

--- a/dd-smoke-tests/springboot/springboot.gradle
+++ b/dd-smoke-tests/springboot/springboot.gradle
@@ -20,22 +20,6 @@ jar {
   }
 }
 
-
-// TODO: move to common util
-/** Open up a random, reusable port. */
-def randomOpenPort() {
-  final ServerSocket socket
-  try {
-    socket = new ServerSocket(0)
-    socket.setReuseAddress(true)
-    socket.close()
-    return socket.getLocalPort()
-  } catch (final IOException ioe) {
-    ioe.printStackTrace()
-    return -1
-  }
-}
-
 dependencies {
   compile group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: '1.5.18.RELEASE'
 

--- a/dd-smoke-tests/springboot/springboot.gradle
+++ b/dd-smoke-tests/springboot/springboot.gradle
@@ -1,0 +1,74 @@
+plugins {
+  id "com.github.johnrengelman.shadow" version "4.0.1"
+  id 'com.github.psxpaul.execfork' version '0.1.8'
+}
+apply from: "${rootDir}/gradle/java.gradle"
+description = 'SpringBoot Smoke Tests.'
+
+
+ext {
+  springbootHttpPort = 8080
+}
+
+// The standard spring-boot plugin doesn't play nice with our project
+// so we'll build a fat jar instead
+jar {
+  manifest {
+    attributes(
+      'Main-Class': 'datadog.smoketest.springboot.SpringbootApplication'
+    )
+  }
+}
+
+
+// TODO: move to common util
+/** Open up a random, reusable port. */
+def randomOpenPort() {
+  final ServerSocket socket
+  try {
+    socket = new ServerSocket(0)
+    socket.setReuseAddress(true)
+    socket.close()
+    return socket.getLocalPort()
+  } catch (final IOException ioe) {
+    ioe.printStackTrace()
+    return -1
+  }
+}
+
+dependencies {
+  compile group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: '1.5.18.RELEASE'
+
+  testCompile project(':dd-trace-api')
+  testCompile project(':dd-trace-ot')
+  testCompile project(':dd-java-agent:testing')
+  testCompile group: 'com.squareup.okhttp3', name: 'okhttp', version: '3.6.0'
+}
+
+task startServer(type: com.github.psxpaul.task.ExecFork) {
+  springbootHttpPort = randomOpenPort()
+  dependsOn project(':dd-java-agent').shadowJar, shadowJar
+
+  if (springbootHttpPort == -1) {
+    throw new GradleException("Failed to get random port to start springboot")
+  }
+  workingDir = "${buildDir}"
+  commandLine = "java"
+  args = ["-javaagent:${project(':dd-java-agent').tasks.shadowJar.archivePath}",
+          "-Ddd.writer.type=LoggingWriter",
+          "-Ddd.service.name=java-app",
+          "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=debug",
+          "-jar",
+          "${tasks.shadowJar.archivePath}",
+          "--server.port=$springbootHttpPort"]
+  standardOutput "${buildDir}/reports/server.log"
+  waitForPort = springbootHttpPort
+  waitForOutput = "datadog.smoketest.springboot.SpringbootApplication - Started SpringbootApplication"
+  stopAfter = test
+}
+
+tasks.withType(Test) {
+  jvmArgs "-Ddatadog.smoketest.server.port=${springbootHttpPort}"
+
+  dependsOn startServer
+}

--- a/dd-smoke-tests/springboot/src/main/java/datadog/smoketest/springboot/SpringbootApplication.java
+++ b/dd-smoke-tests/springboot/src/main/java/datadog/smoketest/springboot/SpringbootApplication.java
@@ -1,0 +1,12 @@
+package datadog.smoketest.springboot;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class SpringbootApplication {
+
+  public static void main(String[] args) {
+    SpringApplication.run(SpringbootApplication.class, args);
+  }
+}

--- a/dd-smoke-tests/springboot/src/main/java/datadog/smoketest/springboot/controller/WebController.java
+++ b/dd-smoke-tests/springboot/src/main/java/datadog/smoketest/springboot/controller/WebController.java
@@ -1,0 +1,12 @@
+package datadog.smoketest.springboot.controller;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class WebController {
+  @RequestMapping("/greeting")
+  public String greeting() {
+    return "Sup Dawg";
+  }
+}

--- a/dd-smoke-tests/springboot/src/main/resources/application.properties
+++ b/dd-smoke-tests/springboot/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+logging.level.root=WARN

--- a/dd-smoke-tests/springboot/src/test/groovy/datadog/trace/agent/SpringBootSmokeTest.groovy
+++ b/dd-smoke-tests/springboot/src/test/groovy/datadog/trace/agent/SpringBootSmokeTest.groovy
@@ -1,0 +1,31 @@
+package datadog.trace.agent
+
+import datadog.trace.agent.test.utils.OkHttpUtils
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import spock.lang.Specification
+
+class SpringBootSmokeTest extends Specification {
+
+  private OkHttpClient client = OkHttpUtils.client()
+  private int port = Integer.parseInt(System.getProperty("datadog.smoketest.server.port", "8080"))
+
+  def "default home page #n th time"() {
+    setup:
+    String url = "http://localhost:$port/greeting"
+    def request = new Request.Builder().url(url).get().build()
+
+    when:
+    def response = client.newCall(request).execute()
+
+    then:
+    def responseBodyStr = response.body().string()
+    responseBodyStr != null
+    responseBodyStr.contains("Sup Dawg")
+    response.body().contentType().toString().contains("text/plain")
+    response.code() == 200
+
+    where:
+    n << (1..200)
+  }
+}

--- a/dd-smoke-tests/wildfly/wildfly.gradle
+++ b/dd-smoke-tests/wildfly/wildfly.gradle
@@ -36,20 +36,6 @@ dependencies {
   testCompile group: 'com.squareup.okhttp3', name: 'okhttp', version: '3.6.0'
 }
 
-/** Open up a random, reusable port. */
-def randomOpenPort() {
-  final ServerSocket socket
-  try {
-    socket = new ServerSocket(0)
-    socket.setReuseAddress(true)
-    socket.close()
-    return socket.getLocalPort()
-  } catch (final IOException ioe) {
-    ioe.printStackTrace()
-    return -1
-  }
-}
-
 task unzip(type: Copy) {
   def zipFileNamePrefix = "servlet"
   def zipPath = project.configurations.compile.find {

--- a/dd-smoke-tests/wildfly/wildfly.gradle
+++ b/dd-smoke-tests/wildfly/wildfly.gradle
@@ -67,6 +67,8 @@ task unzip(type: Copy) {
 }
 
 task startServer(type: com.github.psxpaul.task.ExecFork) {
+  dependsOn project(':dd-java-agent').shadowJar
+
   wildflyHttpPort = randomOpenPort()
   // not used, but to ensure https default port 8443 won't clash
   int httpsPort = randomOpenPort()
@@ -80,6 +82,7 @@ task startServer(type: com.github.psxpaul.task.ExecFork) {
   commandLine = "${workingDir}/bin/standalone.sh"
   // ideally this should be good enough to use to stop wildfly, but wildfly needs to gracefully shutdown from jboss-cli.sh
   // stopAfter = test
+  standardOutput "${buildDir}/reports/server.log"
   // these params tells the ExecFork plugin to block on startServer task until the port is opened or the string is seen in the ouput
   waitForPort = wildflyHttpPort
   waitForOutput = "Undertow HTTP listener default listening on 127.0.0.1:${wildflyHttpPort}"
@@ -112,7 +115,7 @@ tasks.withType(Test) {
     events "started"
   }
 
-  dependsOn project(':dd-java-agent').shadowJar, startServer
+  dependsOn startServer
 }
 
 // ensure that the wildfly server gets shutdown

--- a/dd-trace-java.gradle
+++ b/dd-trace-java.gradle
@@ -22,6 +22,7 @@ allprojects {
   }
 
   apply from: "${rootDir}/gradle/dependencies.gradle"
+  apply from: "${rootDir}/gradle/util.gradle"
 }
 
 repositories {

--- a/gradle/util.gradle
+++ b/gradle/util.gradle
@@ -11,3 +11,17 @@ task artifacts {
     }
   }
 }
+
+/** Find a random, reusable port. */
+ext.randomOpenPort = { ->
+  final ServerSocket socket
+  try {
+    socket = new ServerSocket(0)
+    socket.setReuseAddress(true)
+    socket.close()
+    return socket.getLocalPort()
+  } catch (final IOException ioe) {
+    ioe.printStackTrace()
+    return -1
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -18,8 +18,9 @@ include ':dd-java-agent:agent-jmxfetch'
 include ':dd-java-agent:testing'
 
 // smoke tests
-include ':dd-smoke-tests:wildfly'
 include ':dd-smoke-tests:play'
+include ':dd-smoke-tests:springboot'
+include ':dd-smoke-tests:wildfly'
 
 // instrumentation:
 include ':dd-java-agent:instrumentation:akka-http-10.0'


### PR DESCRIPTION
* Skip instrumentation for `LogManager$Cleaner`
* Add springboot smoke test

A long-term fix for java modules is still needed but this will prevent future regressions against springboot and workaround an immediate sore spot.