### PR TITLE
Implement mutable spans

### DIFF
--- a/dd-trace/src/main/java/datadog/trace/tracer/AbstractSpan.java
+++ b/dd-trace/src/main/java/datadog/trace/tracer/AbstractSpan.java
@@ -1,0 +1,250 @@
+package datadog.trace.tracer;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import datadog.trace.api.DDTags;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.math.BigInteger;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Abstract span. The main purpose of this class is to define Span's JSON rendering config and provde funtionality that is common for different span implementations.
+ *
+ * <p>This class is not thread safe.</p>
+ */
+// Disable autodetection of fields and accessors
+@JsonAutoDetect(
+  fieldVisibility = Visibility.NONE,
+  setterVisibility = Visibility.NONE,
+  getterVisibility = Visibility.NONE,
+  isGetterVisibility = Visibility.NONE,
+  creatorVisibility = Visibility.NONE)
+abstract class AbstractSpan implements Span {
+
+  private final TraceInternal trace;
+
+  private final SpanContext context;
+  private final Timestamp startTimestamp;
+
+  private Long duration = null;
+
+  private String service;
+  private String resource;
+  private String type;
+  private String name;
+  private boolean errored = false;
+
+  private final Map<String, Object> meta = new HashMap<>();
+
+  AbstractSpan(final TraceInternal trace, final SpanContext context, final Timestamp startTimestamp) {
+    this.trace = trace;
+    this.context = context;
+
+    if (startTimestamp == null) {
+      throw new TraceException(String.format("Cannot create span without timestamp: %s", trace));
+    }
+    this.startTimestamp = startTimestamp;
+  }
+
+  protected AbstractSpan(final TraceInternal trace, final Span span) {
+    this.trace = trace;
+
+    context = span.getContext();
+    startTimestamp = span.getStartTimestamp();
+
+    duration = span.getDuration();
+
+    service = span.getService();
+    resource = span.getResource();
+    type = span.getType();
+    name = span.getName();
+    errored = span.isErrored();
+
+    // TODO: is there a good way to avoid copying map here? Alternative might be to not copy spans if there are no interceptors
+    meta.putAll(span.getMeta());
+  }
+
+  @Override
+  public TraceInternal getTrace() {
+    return trace;
+  }
+
+  @Override
+  public SpanContext getContext() {
+    return context;
+  }
+
+  @JsonGetter("trace_id")
+  @JsonSerialize(using = UInt64IDStringSerializer.class)
+  protected String getTraceId() {
+    return context.getTraceId();
+  }
+
+  @JsonGetter("span_id")
+  @JsonSerialize(using = UInt64IDStringSerializer.class)
+  protected String getSpanId() {
+    return context.getSpanId();
+  }
+
+  @JsonGetter("parent_id")
+  @JsonSerialize(using = UInt64IDStringSerializer.class)
+  protected String getParentId() {
+    return context.getParentId();
+  }
+
+  @Override
+  @JsonGetter("start")
+  public Timestamp getStartTimestamp() {
+    return startTimestamp;
+  }
+
+  @Override
+  @JsonGetter("duration")
+  public Long getDuration() {
+    return duration;
+  }
+
+  protected void setDuration(final long duration) {
+    this.duration = duration;
+  }
+
+  @Override
+  public boolean isFinished() {
+    return duration != null;
+  }
+
+  @Override
+  @JsonGetter("service")
+  public String getService() {
+    return service;
+  }
+
+  @Override
+  public void setService(final String service) {
+    this.service = service;
+  }
+
+  @Override
+  @JsonGetter("resource")
+  public String getResource() {
+    return resource;
+  }
+
+  @Override
+  public void setResource(final String resource) {
+    this.resource = resource;
+  }
+
+  @Override
+  @JsonGetter("type")
+  public String getType() {
+    return type;
+  }
+
+  @Override
+  public void setType(final String type) {
+    this.type = type;
+  }
+
+  @Override
+  @JsonGetter("name")
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public void setName(final String name) {
+    this.name = name;
+  }
+
+  @Override
+  @JsonGetter("error")
+  @JsonFormat(shape = JsonFormat.Shape.NUMBER)
+  public boolean isErrored() {
+    return errored;
+  }
+
+  @Override
+  public void attachThrowable(final Throwable throwable) {
+    setErrored(true);
+
+    setMeta(DDTags.ERROR_MSG, throwable.getMessage());
+    setMeta(DDTags.ERROR_TYPE, throwable.getClass().getName());
+
+    final StringWriter errorString = new StringWriter();
+    throwable.printStackTrace(new PrintWriter(errorString));
+    setMeta(DDTags.ERROR_STACK, errorString.toString());
+  }
+
+  @Override
+  public void setErrored(final boolean errored) {
+    this.errored = errored;
+  }
+
+  @Override
+  public Map<String, Object> getMeta() {
+    return Collections.unmodifiableMap(meta);
+  }
+
+  @JsonGetter("meta")
+  protected Map<String, String> getMetaJsonified() {
+    final Map<String, String> result = new HashMap<>(meta.size());
+    for (final Map.Entry<String, Object> entry : meta.entrySet()) {
+      result.put(entry.getKey(), String.valueOf(entry.getValue()));
+    }
+    return result;
+  }
+
+  @Override
+  public Object getMeta(final String key) {
+    return meta.get(key);
+  }
+
+  protected void setMeta(final String key, final Object value) {
+    if (value == null) {
+      meta.remove(key);
+    } else {
+      meta.put(key, value);
+    }
+  }
+
+  @Override
+  public void setMeta(final String key, final String value) {
+    setMeta(key, (Object) value);
+  }
+
+  @Override
+  public void setMeta(final String key, final Boolean value) {
+    setMeta(key, (Object) value);
+  }
+
+  @Override
+  public void setMeta(final String key, final Number value) {
+    setMeta(key, (Object) value);
+  }
+
+  /** Helper to serialize string value as 64 bit unsigned integer */
+  private static class UInt64IDStringSerializer extends StdSerializer<String> {
+
+    public UInt64IDStringSerializer() {
+      super(String.class);
+    }
+
+    @Override
+    public void serialize(
+      final String value, final JsonGenerator jsonGenerator, final SerializerProvider provider)
+      throws IOException {
+      jsonGenerator.writeNumber(new BigInteger(value));
+    }
+  }
+}

--- a/dd-trace/src/main/java/datadog/trace/tracer/Interceptor.java
+++ b/dd-trace/src/main/java/datadog/trace/tracer/Interceptor.java
@@ -1,5 +1,7 @@
 package datadog.trace.tracer;
 
+import java.util.List;
+
 /**
  * An Interceptor allows adding hooks to particular events of a span starting and finishing and also
  * trace being written to backend.
@@ -22,8 +24,8 @@ public interface Interceptor {
   /**
    * Invoked when a trace is eligible for writing but hasn't been handed off to its writer yet.
    *
-   * @param trace The intercepted trace.
+   * @param spans The list of spans from the intercepted trace.
    * @return modified trace. Null if trace is to be dropped.
    */
-  Trace beforeTraceWritten(Trace trace);
+  List<Span> beforeTraceWritten(List<Span> spans);
 }

--- a/dd-trace/src/main/java/datadog/trace/tracer/MutableSpanImpl.java
+++ b/dd-trace/src/main/java/datadog/trace/tracer/MutableSpanImpl.java
@@ -1,0 +1,19 @@
+package datadog.trace.tracer;
+
+public class MutableSpanImpl extends AbstractSpan {
+
+  MutableSpanImpl(final TraceInternal trace, final Span span) {
+    super(trace, span);
+  }
+
+  @Override
+  public void finish() {
+    // TODO throw an exception?
+  }
+
+  @Override
+  public void finish(final long finishTimestampNanoseconds) {
+    // TODO throw an exception?
+  }
+
+}

--- a/dd-trace/src/main/java/datadog/trace/tracer/Span.java
+++ b/dd-trace/src/main/java/datadog/trace/tracer/Span.java
@@ -1,9 +1,9 @@
 package datadog.trace.tracer;
 
+import java.util.Map;
+
 /**
  * A single measurement of time with arbitrary key-value attributes.
- *
- * <p>All spans are thread safe.
  *
  * <p>To create a Span, see {@link Trace#createSpan(SpanContext parentContext, Timestamp
  * startTimestamp)}
@@ -94,6 +94,13 @@ public interface Span {
    * @param throwable throwable to attach
    */
   void attachThrowable(Throwable throwable);
+
+  /**
+   * Get map containing all meta values.
+   *
+   * @return Map containing all meta information
+   */
+  Map<String, Object> getMeta();
 
   /**
    * Get a meta value on a span.

--- a/dd-trace/src/main/java/datadog/trace/tracer/Trace.java
+++ b/dd-trace/src/main/java/datadog/trace/tracer/Trace.java
@@ -32,6 +32,8 @@ public interface Trace {
   /**
    * Create a new span in this trace as a child of the given parent context.
    *
+   * <p>Returned span is thread-safe.</p>
+   *
    * @param parentContext the parent to use. Must be a span in this trace.
    * @return the new span. It is the caller's responsibility to ensure {@link Span#finish()} is
    *     eventually invoked on this span.
@@ -40,6 +42,8 @@ public interface Trace {
 
   /**
    * Create a new span in this trace as a child of the given parent context.
+   *
+   * <p>Returned span is thread-safe.</p>
    *
    * @param parentContext the parent to use. Must be a span in this trace.
    * @param startTimestamp timestamp to use as start timestamp for a new span.

--- a/dd-trace/src/test/groovy/datadog/trace/tracer/JsonSpan.groovy
+++ b/dd-trace/src/test/groovy/datadog/trace/tracer/JsonSpan.groovy
@@ -54,6 +54,6 @@ class JsonSpan {
 
     error = span.isErrored()
 
-    meta = span.getMeta()
+    meta = span.getMetaJsonified()
   }
 }

--- a/dd-trace/src/test/groovy/datadog/trace/tracer/SpanImplTest.groovy
+++ b/dd-trace/src/test/groovy/datadog/trace/tracer/SpanImplTest.groovy
@@ -129,7 +129,7 @@ class SpanImplTest extends Specification {
     span.setMeta("boolean.key", true)
 
     then:
-    span.getMeta() == ["number.key": "123", "string.key": "meta string", "boolean.key": "true"]
+    span.getMetaJsonified() == ["number.key": "123", "string.key": "meta string", "boolean.key": "true"]
   }
 
   def "test meta setter on finished span for #key"() {

--- a/dd-trace/src/test/groovy/datadog/trace/tracer/TraceImplTest.groovy
+++ b/dd-trace/src/test/groovy/datadog/trace/tracer/TraceImplTest.groovy
@@ -90,7 +90,7 @@ class TraceImplTest extends Specification {
     then: "interceptors get called"
     interceptors.reverseEach({ interceptor ->
       then:
-      1 * interceptor.beforeTraceWritten(trace) >> trace
+      1 * interceptor.beforeTraceWritten(spans) >> spans
     })
     then: "trace gets sampled"
     1 * sampler.sample(trace) >> { true }
@@ -124,7 +124,7 @@ class TraceImplTest extends Specification {
     then: "interceptors get called"
     interceptors.reverseEach({ interceptor ->
       then:
-      1 * interceptor.beforeTraceWritten(trace) >> trace
+      1 * interceptor.beforeTraceWritten(spans) >> trace
     })
     then: "trace gets sampled"
     1 * sampler.sample(trace) >> { true }


### PR DESCRIPTION
@realark @tylerbenson This is an attempt to implement a way to mute traces/spans before they are being written.

Currently it is implemented as following:
* New span implementation is created that allows span to be mutated after it is finished.
* Trace interceptor's 'before trace is written' method now accepts and returns list of spans (as opposed to a trace).
* Trace creates a copy of list of spans as list of mutable spans and passes them to interceptors before it is written.

This design looks slightly awkward but I've tried thinking through alternatives and they all seem to have other issues:
* In this design interceptor may potentially return list of mutable spans that references other traces. This should not be a problem because trace reference is not actually used for json rendering.
* Currently we need to copy spans into mutable spans (and metadata fr each span into mutable span). This might affect performance. On positive side we avoid doing that if there are no interceptors.
* Currently interceptors see a list of spans instead of a top level trace. This one is kind of complicated. Ideally we would need to have some sort of 'mutable trace' API to allow interceptors to receive it and be able to mutate trace the way they see fit. This would have been more future-proof in a sense that if we ever wanted to send any data attached to traces (and not to individual spans) then having mutable traces would allow interceptors to see/modify that additional data. Unfortunately doing that brings up some other complications, e.g. writers would need to be able to write 'mutable trace' - and it is harder to reconcile trace and mutable trace api under 'one roof' like we can for spans.

This is by no means a finished PR, more like an RFC and I would like to see your comments on the implementation/design. Tests are known to fail/be not yet implemented for now.