### PR TITLE
Fix JsonSpan boolean conversion problem

### DIFF
--- a/dd-trace/src/test/groovy/datadog/trace/tracer/JsonSpan.groovy
+++ b/dd-trace/src/test/groovy/datadog/trace/tracer/JsonSpan.groovy
@@ -3,11 +3,13 @@ package datadog.trace.tracer
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonProperty
 import groovy.transform.EqualsAndHashCode
+import groovy.transform.ToString
 
 /**
  * Helper class to parse serialized span to verify serialization logic
  */
 @EqualsAndHashCode
+@ToString
 class JsonSpan {
   @JsonProperty("trace_id")
   BigInteger traceId
@@ -31,7 +33,9 @@ class JsonSpan {
   String name
 
   @JsonProperty("error")
-  boolean error
+  // Somehow MsgPack formatter can not convert number to boolean with newer jackson so we have to do this manually
+  //@JsonFormat(shape = JsonFormat.Shape.NUMBER)
+  int error
 
   @JsonProperty("meta")
   Map<String, String> meta
@@ -52,7 +56,7 @@ class JsonSpan {
     type = span.getType()
     name = span.getName()
 
-    error = span.isErrored()
+    error = span.isErrored() ? 1 : 0
 
     meta = span.getMeta()
   }

--- a/dd-trace/src/test/groovy/datadog/trace/tracer/writer/AgentClientTest.groovy
+++ b/dd-trace/src/test/groovy/datadog/trace/tracer/writer/AgentClientTest.groovy
@@ -72,6 +72,7 @@ class AgentClientTest extends Specification {
     response.getRate("another test") == 0.2d
     response.getRate("doesn't exist") == null
     and: "request got expected parameters"
+    byte[] requestBody = null
     verify(putRequestedFor(urlEqualTo(AgentClient.TRACES_ENDPOINT))
       .withHeader(AgentClient.CONTENT_TYPE, equalTo(AgentClient.MSGPACK))
       .withHeader(AgentClient.DATADOG_META_LANG, equalTo("java"))
@@ -81,9 +82,12 @@ class AgentClientTest extends Specification {
       // .withHeader(AgentClient.DATADOG_META_TRACER_VERSION, equalTo("java"))
       .withHeader(AgentClient.X_DATADOG_TRACE_COUNT, equalTo(Integer.toString(TRACE_COUNT)))
       .andMatching({ Request request ->
-        // Note: it is hard to see what's wrong when this fails... is there a better way?
-        MatchResult.of(objectMapper.readValue(request.getBody(), new TypeReference<List<List<JsonSpan>>>() {}) == traces.collect {it.getSpans().collect {new JsonSpan(it)}})
+      requestBody = request.getBody()
+      MatchResult.of(true)
       }))
+    objectMapper.readValue(requestBody, new TypeReference<List<List<JsonSpan>>>() {}) == traces.collect {
+      it.getSpans().collect { new JsonSpan(it) }
+    }
   }
 
   def "test send empty list"() {


### PR DESCRIPTION
It looks like with newer Jackson we cannot convert number to boolean
anymore. So we have to do this manually.