### PR TITLE
Revert "Update test-sets plugin to 2.1.1"

### DIFF
--- a/dd-trace-java.gradle
+++ b/dd-trace-java.gradle
@@ -2,7 +2,7 @@ plugins {
   id 'io.franzbecker.gradle-lombok' version '1.14'
   id 'com.jfrog.artifactory' version '4.8.1'
   id 'com.jfrog.bintray' version '1.8.4'
-  id 'org.unbroken-dome.test-sets' version '2.1.1'
+  id 'org.unbroken-dome.test-sets' version '1.5.2'
 
   id 'com.gradle.build-scan' version '1.16' // 2.0+ requires gradle 5
   // Not applying google java format by default because it gets confused by stray java build


### PR DESCRIPTION
Reverts DataDog/dd-trace-java#663

It was causing the following error when compiling in Idea:
```
Error:scalac: Output path .../dd-trace-java/dd-trace-ot/out/test/classes is shared between: Module 'dd-trace-ot_test' tests, Module 'dd-trace-ot_traceAgentTest' tests
Output path .../dd-trace-java/dd-java-agent/instrumentation/jms/out/test/classes is shared between: Module 'jms_latestDepTest' tests, Module 'jms_test' tests
Output path .../dd-trace-java/dd-java-agent/instrumentation/elasticsearch-transport-2/out/test/classes is shared between: Module 'elasticsearch-transport-2_latestDepTest' tests, Module 'elasticsearch-transport-2_test' tests
Output path .../dd-trace-java/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/out/test/classes is shared between: Module 'aws-java-sdk-1.11.0_latestDepTest' tests, Module 'aws-java-sdk-1.11.0_test' tests
Output path .../dd-trace-java/dd-java-agent/instrumentation/apache-httpclient-4/out/test/classes is shared between: Module 'apache-httpclient-4_latestDepTest' tests, Module 'apache-httpclient-4_test' tests
Output path .../dd-trace-java/dd-java-agent/instrumentation/elasticsearch-rest-5/out/test/classes is shared between: Module 'elasticsearch-rest-5_latestDepTest' tests, Module 'elasticsearch-rest-5_test' tests
Output path .../dd-trace-java/dd-java-agent/instrumentation/java-concurrent/out/test/classes is shared between: Module 'java-concurrent_slickTest' tests, Module 'java-concurrent_test' tests
Please configure separate output paths to proceed with the compilation.
TIP: you can use Project Artifacts to combine compiled classes if needed.
```