### PR TITLE
 Ensure the copyMetricConfigs task runs after processResources

### DIFF
--- a/.circleci/collect_libs.sh
+++ b/.circleci/collect_libs.sh
@@ -3,12 +3,13 @@
 # Save all important libs into (project-root)/libs
 # This folder will be saved by circleci and available after test runs.
 
+set -x
 set -e
 
 LIBS_DIR=./libs/
 mkdir -p $LIBS_DIR >/dev/null 2>&1
 
-for lib_path in workspace/**/build/libs; do
+for lib_path in workspace/*/build/libs; do
     echo "saving libs in $lib_path"
     cp $lib_path/*.jar $LIBS_DIR/
 done

--- a/dd-java-agent/agent-jmxfetch/agent-jmxfetch.gradle
+++ b/dd-java-agent/agent-jmxfetch/agent-jmxfetch.gradle
@@ -44,6 +44,8 @@ task copyMetricConfigs(type:Exec) {
   }
 }
 
-processResources.dependsOn copyMetricConfigs
 copyMetricConfigs.dependsOn submodulesUpdate
-// Runs the copy task before processResources, so duplicate files in the local repo would overwrite imported ones.
+processResources.finalizedBy copyMetricConfigs
+copyMetricConfigs.mustRunAfter processResources
+// In CI, there seems to be a race condition where processResources overwrites the copied metric config files.
+// Ensure that task runs last to avoid this problem.

--- a/dd-java-agent/agent-jmxfetch/copy-metric-configs.sh
+++ b/dd-java-agent/agent-jmxfetch/copy-metric-configs.sh
@@ -4,7 +4,7 @@
 set -e
 
 # Debug mode:
-# set -x
+set -x
 
 function print_usage() {
   echo "Usage: $0 search_directory build_resources_output_directory"


### PR DESCRIPTION
Otherwise there seems to be a race condition which results in the metric config files being overwritten.
