### PR TITLE
Replace jboss classpath check with ENV check for jmxfetch delay

### DIFF
--- a/dd-java-agent/src/main/java/datadog/trace/agent/TracingAgent.java
+++ b/dd-java-agent/src/main/java/datadog/trace/agent/TracingAgent.java
@@ -263,7 +263,11 @@ public class TracingAgent {
         // Allow setting to skip these automatic checks:
         || ((customLogManagerProp == null && customLogManagerEnv == null)
             && (
-            // JBoss/Wildfly known to set custom log manager
+            // JBoss/Wildfly is known to set a custom log manager
+            // Originally we were checking for the presence of a jboss class,
+            // but it turns out other non-jboss applications have jboss classes on the classpath.
+            // This would cause jmxfetch initialization to be delayed indefinitely.
+            // Checking for an environment variable required by jboss instead.
             System.getenv("JBOSS_HOME") != null));
   }
 

--- a/dd-java-agent/src/main/java/datadog/trace/agent/TracingAgent.java
+++ b/dd-java-agent/src/main/java/datadog/trace/agent/TracingAgent.java
@@ -245,25 +245,24 @@ public class TracingAgent {
    */
   private static boolean isAppUsingCustomLogManager() {
     final String tracerCustomLogManSysprop = "dd.app.customlogmanager";
+    final String customLogManagerProp = System.getProperty(tracerCustomLogManSysprop);
+    final String customLogManagerEnv =
+        System.getenv(tracerCustomLogManSysprop.replace('.', '_').toUpperCase());
+
     if ("debug"
         .equalsIgnoreCase(System.getProperty("datadog.slf4j.simpleLogger.defaultLogLevel"))) {
       System.out.println(
           "Prop - logging.manager: " + System.getProperty("java.util.logging.manager"));
-      System.out.println(
-          "Prop - customlogmanager: " + System.getProperty(tracerCustomLogManSysprop));
-      System.out.println(
-          "Env - customlogmanager: "
-              + System.getenv(tracerCustomLogManSysprop.replace('.', '_').toUpperCase()));
-      System.out.println(
-          "Classpath - jboss: " + ClassLoader.getSystemResource("org/jboss/modules/Main.class")
-              != null);
+      System.out.println("Prop - customlogmanager: " + customLogManagerProp);
+      System.out.println("Env - customlogmanager: " + customLogManagerEnv);
+      System.out.println("ENV - jboss: " + System.getenv("JBOSS_HOME"));
     }
+
     return System.getProperty("java.util.logging.manager") != null
-        || Boolean.parseBoolean(System.getProperty(tracerCustomLogManSysprop))
-        || Boolean.parseBoolean(
-            System.getenv(tracerCustomLogManSysprop.replace('.', '_').toUpperCase()))
-        // Classes known to set a custom log mananger
-        || ClassLoader.getSystemResource("org/jboss/modules/Main.class") != null;
+        || Boolean.parseBoolean(customLogManagerProp)
+        || Boolean.parseBoolean(customLogManagerEnv)
+        // JBoss/Wildfly known to set custom log manager
+        || System.getenv("JBOSS_HOME") != null;
   }
 
   /**

--- a/dd-java-agent/src/main/java/datadog/trace/agent/TracingAgent.java
+++ b/dd-java-agent/src/main/java/datadog/trace/agent/TracingAgent.java
@@ -46,7 +46,7 @@ public class TracingAgent {
       throws Exception {
     startDatadogAgent(agentArgs, inst);
     if (isAppUsingCustomLogManager()) {
-      System.out.println("Custom logger found.  Delaying JMXFetch initialization.");
+      System.out.println("Custom logger detected.  Delaying JMXFetch initialization.");
       /*
        * java.util.logging.LogManager maintains a final static LogManager, which is created during class initialization.
        *
@@ -112,7 +112,6 @@ public class TracingAgent {
   }
 
   public static synchronized void startJmxFetch() throws Exception {
-    System.out.println("Starting JMXFetch.");
     initializeJars();
     if (JMXFETCH_CLASSLOADER == null) {
       final ClassLoader jmxFetchClassLoader = createDatadogClassLoader(bootstrapJar, jmxFetchJar);
@@ -261,8 +260,11 @@ public class TracingAgent {
     return System.getProperty("java.util.logging.manager") != null
         || Boolean.parseBoolean(customLogManagerProp)
         || Boolean.parseBoolean(customLogManagerEnv)
-        // JBoss/Wildfly known to set custom log manager
-        || System.getenv("JBOSS_HOME") != null;
+        // Allow setting to skip these automatic checks:
+        || ((customLogManagerProp == null && customLogManagerEnv == null)
+            && (
+            // JBoss/Wildfly known to set custom log manager
+            System.getenv("JBOSS_HOME") != null));
   }
 
   /**


### PR DESCRIPTION
Some applications seem to have this jboss class on the classpath, but don’t actually use it.  When coupled with not actually using JUL, this means that we may never actually start JMXFetch.

Checking for JBOSS_HOME instead should be safer.