### PR TITLE
Don't break Clojure's protocols

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/ClassLoaderMatcher.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/ClassLoaderMatcher.java
@@ -52,6 +52,7 @@ public class ClassLoaderMatcher {
       classesToSkip.add("org.codehaus.groovy.runtime.callsite.CallSiteClassLoader");
       classesToSkip.add("sun.reflect.DelegatingClassLoader");
       classesToSkip.add("jdk.internal.reflect.DelegatingClassLoader");
+      classesToSkip.add("clojure.lang.DynamicClassLoader");
       classesToSkip.add(DatadogClassLoader.class.getName());
       CLASSLOADER_CLASSES_TO_SKIP = Collections.unmodifiableSet(classesToSkip);
     }


### PR DESCRIPTION
Using dd-java-agent with our Clojure applications, they will fail to start with a ClassNotFoundException when loading a Clojure protocol class.  Skipping instrumentation of the `clojure.lang.DynamicClassLoader` class seems to resolve the issue for us.

However, if there is a better way to resolve this problem, we are open to investigating it further.