### PR TITLE
 Add setting to set service name by domain for http clients

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Instrumenter.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Instrumenter.java
@@ -227,15 +227,5 @@ public interface Instrumenter {
     protected boolean defaultEnabled() {
       return getConfigEnabled("dd.integrations.enabled", true);
     }
-
-    // TODO: move common config helpers to Utils
-
-    public static String getPropOrEnv(final String name) {
-      return System.getProperty(name, System.getenv(propToEnvName(name)));
-    }
-
-    public static String propToEnvName(final String name) {
-      return name.toUpperCase().replace(".", "_");
-    }
   }
 }

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/scala/datadog/trace/instrumentation/akkahttp/AkkaHttpClientTransformFlow.scala
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/scala/datadog/trace/instrumentation/akkahttp/AkkaHttpClientTransformFlow.scala
@@ -30,7 +30,9 @@ object AkkaHttpClientTransformFlow {
         .withTag(Tags.COMPONENT.getKey, "akka-http-client")
         .withTag(Tags.HTTP_URL.getKey, request.getUri.toString)
         .start()
-      if (Config.get.isHttpClientSplitByDomain) span.setTag(DDTags.SERVICE_NAME, request.getUri.host.address)
+      if (Config.get.isHttpClientSplitByDomain) {
+        span.setTag(DDTags.SERVICE_NAME, request.getUri.host.address)
+      }
       val headers = new AkkaHttpClientInstrumentation.AkkaHttpHeaders(request)
       GlobalTracer.get.inject(span.context, Format.Builtin.HTTP_HEADERS, headers)
       (headers.getRequest, data)

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/scala/datadog/trace/instrumentation/akkahttp/AkkaHttpClientTransformFlow.scala
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/scala/datadog/trace/instrumentation/akkahttp/AkkaHttpClientTransformFlow.scala
@@ -5,7 +5,7 @@ import java.util.Collections
 import akka.NotUsed
 import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
 import akka.stream.scaladsl.Flow
-import datadog.trace.api.{DDSpanTypes, DDTags}
+import datadog.trace.api.{Config, DDSpanTypes, DDTags}
 import io.opentracing.Span
 import io.opentracing.log.Fields.ERROR_OBJECT
 import io.opentracing.propagation.Format
@@ -20,18 +20,19 @@ object AkkaHttpClientTransformFlow {
 
     Flow.fromFunction((input: (HttpRequest, T)) => {
       val (request, data) = input
-      val scope = GlobalTracer.get
+      span = GlobalTracer.get
         .buildSpan("akka-http.request")
         .withTag(Tags.SPAN_KIND.getKey, Tags.SPAN_KIND_CLIENT)
         .withTag(Tags.HTTP_METHOD.getKey, request.method.value)
+        .withTag(Tags.PEER_HOSTNAME.getKey, request.getUri().host().address())
+        .withTag(Tags.PEER_PORT.getKey, request.getUri().port())
         .withTag(DDTags.SPAN_TYPE, DDSpanTypes.HTTP_CLIENT)
         .withTag(Tags.COMPONENT.getKey, "akka-http-client")
         .withTag(Tags.HTTP_URL.getKey, request.getUri.toString)
-        .startActive(false)
+        .start()
+      if (Config.get.isHttpClientSplitByDomain) span.setTag(DDTags.SERVICE_NAME, request.getUri.host.address)
       val headers = new AkkaHttpClientInstrumentation.AkkaHttpHeaders(request)
-      GlobalTracer.get.inject(scope.span.context, Format.Builtin.HTTP_HEADERS, headers)
-      span = scope.span
-      scope.close()
+      GlobalTracer.get.inject(span.context, Format.Builtin.HTTP_HEADERS, headers)
       (headers.getRequest, data)
     }).via(flow).map(output => {
       output._1 match {

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/test/scala/AkkaHttpTestWebServer.scala
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/test/scala/AkkaHttpTestWebServer.scala
@@ -4,13 +4,13 @@ import akka.http.scaladsl.Http.ServerBinding
 import akka.http.scaladsl.model.HttpMethods.GET
 import akka.http.scaladsl.model._
 import akka.stream.ActorMaterializer
-import datadog.trace.agent.test.TestUtils
+import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.Trace
 
 import scala.concurrent.{Await, Future}
 
 object AkkaHttpTestAsyncWebServer {
-  val port = TestUtils.randomOpenPort()
+  val port = PortUtils.randomOpenPort()
   implicit val system = ActorSystem("my-system")
   implicit val materializer = ActorMaterializer()
   // needed for the future flatMap/onComplete in the end
@@ -60,7 +60,7 @@ object AkkaHttpTestAsyncWebServer {
 }
 
 object AkkaHttpTestSyncWebServer {
-  val port = TestUtils.randomOpenPort()
+  val port = PortUtils.randomOpenPort()
   implicit val system = ActorSystem("my-system")
   implicit val materializer = ActorMaterializer()
   // needed for the future flatMap/onComplete in the end

--- a/dd-java-agent/instrumentation/apache-httpclient-4/src/latestDepTest/groovy/ApacheHttpClientTest.groovy
+++ b/dd-java-agent/instrumentation/apache-httpclient-4/src/latestDepTest/groovy/ApacheHttpClientTest.groovy
@@ -16,11 +16,9 @@ import org.apache.http.message.BasicHeader
 import spock.lang.AutoCleanup
 import spock.lang.Shared
 
-import static datadog.trace.agent.test.TestUtils.runUnderTrace
-import static datadog.trace.agent.test.TestUtils.setFinal
-import static datadog.trace.agent.test.TestUtils.setFinalStatic
-import static datadog.trace.agent.test.TestUtils.withSystemProperty
 import static datadog.trace.agent.test.server.http.TestHttpServer.httpServer
+import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
+import static datadog.trace.agent.test.utils.TraceUtils.withConfigOverride
 
 class ApacheHttpClientTest extends AgentTestRunner {
 
@@ -60,9 +58,7 @@ class ApacheHttpClientTest extends AgentTestRunner {
   def "trace request with propagation"() {
     when:
 
-    String response = withSystemProperty("dd.$Config.HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN", "$renameService") {
-      resetConfig()
-      
+    String response = withConfigOverride("dd.$Config.HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN", "$renameService") {
       runUnderTrace("parent") {
         if (responseHandler) {
           client.execute(new HttpGet(successUrl), responseHandler)
@@ -97,9 +93,7 @@ class ApacheHttpClientTest extends AgentTestRunner {
     request.setConfig(requestConfigBuilder.build())
 
     when:
-    HttpResponse response = withSystemProperty("dd.$Config.HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN", "$renameService") {
-      resetConfig()
-
+    HttpResponse response = withConfigOverride("dd.$Config.HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN", "$renameService") {
       runUnderTrace("parent") {
         client.execute(request)
       }
@@ -129,9 +123,7 @@ class ApacheHttpClientTest extends AgentTestRunner {
     request.setConfig(requestConfigBuilder.build())
 
     when:
-    HttpResponse response = withSystemProperty("dd.$Config.HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN", "$renameService") {
-      resetConfig()
-
+    HttpResponse response = withConfigOverride("dd.$Config.HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN", "$renameService") {
       runUnderTrace("parent") {
         client.execute(request)
       }
@@ -162,9 +154,7 @@ class ApacheHttpClientTest extends AgentTestRunner {
     request.setConfig(requestConfigBuilder.build())
 
     when:
-    withSystemProperty("dd.$Config.HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN", "$renameService") {
-      resetConfig()
-
+    withConfigOverride("dd.$Config.HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN", "$renameService") {
       runUnderTrace("parent") {
         client.execute(request)
       }
@@ -192,9 +182,7 @@ class ApacheHttpClientTest extends AgentTestRunner {
     request.addHeader(new BasicHeader("is-dd-server", "false"))
 
     when:
-    HttpResponse response = withSystemProperty("dd.$Config.HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN", "$renameService") {
-      resetConfig()
-
+    HttpResponse response = withConfigOverride("dd.$Config.HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN", "$renameService") {
       runUnderTrace("parent") {
         client.execute(request)
       }
@@ -252,11 +240,5 @@ class ApacheHttpClientTest extends AgentTestRunner {
         "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_CLIENT
       }
     }
-  }
-
-  def resetConfig() {
-    def runtimeId = Config.get().runtimeId
-    setFinalStatic(Config.getDeclaredField("INSTANCE"), new Config())
-    setFinal(Config.getDeclaredField("runtimeId"), Config.get(), runtimeId)
   }
 }

--- a/dd-java-agent/instrumentation/apache-httpclient-4/src/latestDepTest/groovy/ApacheHttpClientTest.groovy
+++ b/dd-java-agent/instrumentation/apache-httpclient-4/src/latestDepTest/groovy/ApacheHttpClientTest.groovy
@@ -1,6 +1,7 @@
 import datadog.opentracing.DDSpan
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.asserts.TraceAssert
+import datadog.trace.api.Config
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import io.opentracing.tag.Tags
@@ -16,6 +17,9 @@ import spock.lang.AutoCleanup
 import spock.lang.Shared
 
 import static datadog.trace.agent.test.TestUtils.runUnderTrace
+import static datadog.trace.agent.test.TestUtils.setFinal
+import static datadog.trace.agent.test.TestUtils.setFinalStatic
+import static datadog.trace.agent.test.TestUtils.withSystemProperty
 import static datadog.trace.agent.test.server.http.TestHttpServer.httpServer
 
 class ApacheHttpClientTest extends AgentTestRunner {
@@ -55,11 +59,16 @@ class ApacheHttpClientTest extends AgentTestRunner {
 
   def "trace request with propagation"() {
     when:
-    String response = runUnderTrace("parent") {
-      if (responseHandler) {
-        client.execute(new HttpGet(successUrl), responseHandler)
-      } else {
-        client.execute(new HttpGet(successUrl)).entity.content.text
+
+    String response = withSystemProperty("dd.$Config.HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN", "$renameService") {
+      resetConfig()
+      
+      runUnderTrace("parent") {
+        if (responseHandler) {
+          client.execute(new HttpGet(successUrl), responseHandler)
+        } else {
+          client.execute(new HttpGet(successUrl)).entity.content.text
+        }
       }
     }
 
@@ -70,12 +79,13 @@ class ApacheHttpClientTest extends AgentTestRunner {
       server.distributedRequestTrace(it, 0, TEST_WRITER[1][1])
       trace(1, 2) {
         parentSpan(it, 0)
-        successClientSpan(it, 1, span(0))
+        successClientSpan(it, 1, span(0), renameService)
       }
     }
 
     where:
     responseHandler << [null, handler]
+    renameService << [false, true]
   }
 
   def "trace redirected request with propagation many redirects allowed"() {
@@ -87,8 +97,12 @@ class ApacheHttpClientTest extends AgentTestRunner {
     request.setConfig(requestConfigBuilder.build())
 
     when:
-    HttpResponse response = runUnderTrace("parent") {
-      client.execute(request)
+    HttpResponse response = withSystemProperty("dd.$Config.HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN", "$renameService") {
+      resetConfig()
+
+      runUnderTrace("parent") {
+        client.execute(request)
+      }
     }
 
     then:
@@ -99,9 +113,12 @@ class ApacheHttpClientTest extends AgentTestRunner {
       server.distributedRequestTrace(it, 1, TEST_WRITER[2][1])
       trace(2, 2) {
         parentSpan(it, 0)
-        successClientSpan(it, 1, span(0), 200, "redirect")
+        successClientSpan(it, 1, span(0), renameService, 200, "redirect")
       }
     }
+
+    where:
+    renameService << [false, true]
   }
 
   def "trace redirected request with propagation 1 redirect allowed"() {
@@ -112,8 +129,12 @@ class ApacheHttpClientTest extends AgentTestRunner {
     request.setConfig(requestConfigBuilder.build())
 
     when:
-    HttpResponse response = runUnderTrace("parent") {
-      client.execute(request)
+    HttpResponse response = withSystemProperty("dd.$Config.HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN", "$renameService") {
+      resetConfig()
+
+      runUnderTrace("parent") {
+        client.execute(request)
+      }
     }
 
     then:
@@ -124,9 +145,12 @@ class ApacheHttpClientTest extends AgentTestRunner {
       server.distributedRequestTrace(it, 1, TEST_WRITER[2][1])
       trace(2, 2) {
         parentSpan(it, 0)
-        successClientSpan(it, 1, span(0), 200, "redirect")
+        successClientSpan(it, 1, span(0), renameService, 200, "redirect")
       }
     }
+
+    where:
+    renameService << [false, true]
   }
 
   def "trace redirected request with propagation too many redirects"() {
@@ -138,8 +162,12 @@ class ApacheHttpClientTest extends AgentTestRunner {
     request.setConfig(requestConfigBuilder.build())
 
     when:
-    runUnderTrace("parent") {
-      client.execute(request)
+    withSystemProperty("dd.$Config.HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN", "$renameService") {
+      resetConfig()
+
+      runUnderTrace("parent") {
+        client.execute(request)
+      }
     }
 
     then:
@@ -150,9 +178,12 @@ class ApacheHttpClientTest extends AgentTestRunner {
       server.distributedRequestTrace(it, 1, TEST_WRITER[2][1])
       trace(2, 2) {
         parentSpan(it, 0, exception)
-        successClientSpan(it, 1, span(0), null, "another-redirect", exception)
+        successClientSpan(it, 1, span(0), renameService, null, "another-redirect", exception)
       }
     }
+
+    where:
+    renameService << [false, true]
   }
 
   def "trace request without propagation"() {
@@ -161,8 +192,12 @@ class ApacheHttpClientTest extends AgentTestRunner {
     request.addHeader(new BasicHeader("is-dd-server", "false"))
 
     when:
-    HttpResponse response = runUnderTrace("parent") {
-      client.execute(request)
+    HttpResponse response = withSystemProperty("dd.$Config.HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN", "$renameService") {
+      resetConfig()
+
+      runUnderTrace("parent") {
+        client.execute(request)
+      }
     }
 
     then:
@@ -171,9 +206,12 @@ class ApacheHttpClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 2) {
         parentSpan(it, 0)
-        successClientSpan(it, 1, span(0))
+        successClientSpan(it, 1, span(0), renameService)
       }
     }
+
+    where:
+    renameService << [false, true]
   }
 
   def parentSpan(TraceAssert trace, int index, Throwable exception = null) {
@@ -192,10 +230,10 @@ class ApacheHttpClientTest extends AgentTestRunner {
     }
   }
 
-  def successClientSpan(TraceAssert trace, int index, DDSpan parent, status = 200, route = "success", Throwable exception = null) {
+  def successClientSpan(TraceAssert trace, int index, DDSpan parent, boolean renameService, status = 200, route = "success", Throwable exception = null) {
     trace.span(index) {
       childOf parent
-      serviceName "unnamed-java-app"
+      serviceName renameService ? "localhost" : "unnamed-java-app"
       operationName "http.request"
       resourceName "GET /$route"
       errored exception != null
@@ -208,11 +246,17 @@ class ApacheHttpClientTest extends AgentTestRunner {
         "$Tags.HTTP_STATUS.key" status
         "$Tags.HTTP_URL.key" "http://localhost:$port/$route"
         "$Tags.PEER_HOSTNAME.key" "localhost"
-        "$Tags.PEER_PORT.key" server.getAddress().port
+        "$Tags.PEER_PORT.key" server.address.port
         "$Tags.HTTP_METHOD.key" "GET"
         "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
         "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_CLIENT
       }
     }
+  }
+
+  def resetConfig() {
+    def runtimeId = Config.get().runtimeId
+    setFinalStatic(Config.getDeclaredField("INSTANCE"), new Config())
+    setFinal(Config.getDeclaredField("runtimeId"), Config.get(), runtimeId)
   }
 }

--- a/dd-java-agent/instrumentation/apache-httpclient-4/src/main/java/datadog/trace/instrumentation/apachehttpclient/ApacheHttpClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/apache-httpclient-4/src/main/java/datadog/trace/instrumentation/apachehttpclient/ApacheHttpClientInstrumentation.java
@@ -11,6 +11,7 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.api.Config;
 import datadog.trace.api.DDSpanTypes;
 import datadog.trace.api.DDTags;
 import datadog.trace.bootstrap.CallDepthThreadLocalMap;
@@ -120,6 +121,9 @@ public class ApacheHttpClientInstrumentation extends Instrumenter.Default {
       if (null != uri) {
         Tags.PEER_PORT.set(span, uri.getPort() == -1 ? 80 : uri.getPort());
         Tags.PEER_HOSTNAME.set(span, uri.getHost());
+        if (Config.get().isHttpClientSplitByDomain()) {
+          span.setTag(DDTags.SERVICE_NAME, uri.getHost());
+        }
       }
       return scope;
     }

--- a/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/util/AbstractCouchbaseTest.groovy
+++ b/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/util/AbstractCouchbaseTest.groovy
@@ -15,7 +15,7 @@ import com.couchbase.mock.BucketConfiguration
 import com.couchbase.mock.CouchbaseMock
 import com.couchbase.mock.http.query.QueryServer
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.TestUtils
+import datadog.trace.agent.test.utils.PortUtils
 import spock.lang.Shared
 
 import java.util.concurrent.RejectedExecutionException
@@ -27,7 +27,7 @@ abstract class AbstractCouchbaseTest extends AgentTestRunner {
   private static final PASSWORD = "password"
 
   @Shared
-  private int port = TestUtils.randomOpenPort()
+  private int port = PortUtils.randomOpenPort()
 
   @Shared
   private String testBucketName = this.getClass().simpleName

--- a/dd-java-agent/instrumentation/elasticsearch-rest-5/src/latestDepTest/groovy/Elasticsearch6RestClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch-rest-5/src/latestDepTest/groovy/Elasticsearch6RestClientTest.groovy
@@ -1,6 +1,6 @@
 import com.anotherchrisberry.spock.extensions.retry.RetryOnFailure
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.TestUtils
+import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import groovy.json.JsonSlurper
@@ -33,8 +33,8 @@ class Elasticsearch6RestClientTest extends AgentTestRunner {
   RestClient client
 
   def setupSpec() {
-    httpPort = TestUtils.randomOpenPort()
-    tcpPort = TestUtils.randomOpenPort()
+    httpPort = PortUtils.randomOpenPort()
+    tcpPort = PortUtils.randomOpenPort()
 
     esWorkingDir = File.createTempDir("test-es-working-dir-", "")
     esWorkingDir.deleteOnExit()

--- a/dd-java-agent/instrumentation/elasticsearch-rest-5/src/test/groovy/Elasticsearch5RestClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch-rest-5/src/test/groovy/Elasticsearch5RestClientTest.groovy
@@ -1,6 +1,6 @@
 import com.anotherchrisberry.spock.extensions.retry.RetryOnFailure
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.TestUtils
+import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import groovy.json.JsonSlurper
@@ -36,8 +36,8 @@ class Elasticsearch5RestClientTest extends AgentTestRunner {
   static RestClient client
 
   def setupSpec() {
-    httpPort = TestUtils.randomOpenPort()
-    tcpPort = TestUtils.randomOpenPort()
+    httpPort = PortUtils.randomOpenPort()
+    tcpPort = PortUtils.randomOpenPort()
 
     esWorkingDir = File.createTempDir("test-es-working-dir-", "")
     esWorkingDir.deleteOnExit()

--- a/dd-java-agent/instrumentation/elasticsearch-rest-6.4/src/latestDepTest/groovy/Elasticsearch6RestClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch-rest-6.4/src/latestDepTest/groovy/Elasticsearch6RestClientTest.groovy
@@ -1,6 +1,6 @@
 import com.anotherchrisberry.spock.extensions.retry.RetryOnFailure
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.TestUtils
+import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import groovy.json.JsonSlurper
@@ -36,8 +36,8 @@ class Elasticsearch6RestClientTest extends AgentTestRunner {
   RestClient client
 
   def setupSpec() {
-    httpPort = TestUtils.randomOpenPort()
-    tcpPort = TestUtils.randomOpenPort()
+    httpPort = PortUtils.randomOpenPort()
+    tcpPort = PortUtils.randomOpenPort()
 
     esWorkingDir = File.createTempDir("test-es-working-dir-", "")
     esWorkingDir.deleteOnExit()

--- a/dd-java-agent/instrumentation/elasticsearch-rest-6.4/src/test/groovy/Elasticsearch6RestClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch-rest-6.4/src/test/groovy/Elasticsearch6RestClientTest.groovy
@@ -1,6 +1,6 @@
 import com.anotherchrisberry.spock.extensions.retry.RetryOnFailure
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.TestUtils
+import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import groovy.json.JsonSlurper
@@ -33,8 +33,8 @@ class Elasticsearch6RestClientTest extends AgentTestRunner {
   RestClient client
 
   def setupSpec() {
-    httpPort = TestUtils.randomOpenPort()
-    tcpPort = TestUtils.randomOpenPort()
+    httpPort = PortUtils.randomOpenPort()
+    tcpPort = PortUtils.randomOpenPort()
 
     esWorkingDir = File.createTempDir("test-es-working-dir-", "")
     esWorkingDir.deleteOnExit()

--- a/dd-java-agent/instrumentation/elasticsearch-transport-2/src/latestDepTest/groovy/Elasticsearch2NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch-transport-2/src/latestDepTest/groovy/Elasticsearch2NodeClientTest.groovy
@@ -1,6 +1,6 @@
 import com.anotherchrisberry.spock.extensions.retry.RetryOnFailure
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.TestUtils
+import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import io.opentracing.tag.Tags
@@ -12,7 +12,7 @@ import org.elasticsearch.node.Node
 import org.elasticsearch.node.NodeBuilder
 import spock.lang.Shared
 
-import static datadog.trace.agent.test.TestUtils.runUnderTrace
+import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 
 @RetryOnFailure(times = 3, delaySeconds = 1)
 class Elasticsearch2NodeClientTest extends AgentTestRunner {
@@ -30,8 +30,8 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
   def client = testNode.client()
 
   def setupSpec() {
-    httpPort = TestUtils.randomOpenPort()
-    tcpPort = TestUtils.randomOpenPort()
+    httpPort = PortUtils.randomOpenPort()
+    tcpPort = PortUtils.randomOpenPort()
 
     esWorkingDir = File.createTempDir("test-es-working-dir-", "")
     esWorkingDir.deleteOnExit()

--- a/dd-java-agent/instrumentation/elasticsearch-transport-2/src/latestDepTest/groovy/Elasticsearch2TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch-transport-2/src/latestDepTest/groovy/Elasticsearch2TransportClientTest.groovy
@@ -1,6 +1,6 @@
 import com.anotherchrisberry.spock.extensions.retry.RetryOnFailure
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.TestUtils
+import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import io.opentracing.tag.Tags
@@ -15,7 +15,7 @@ import org.elasticsearch.node.NodeBuilder
 import org.elasticsearch.transport.RemoteTransportException
 import spock.lang.Shared
 
-import static datadog.trace.agent.test.TestUtils.runUnderTrace
+import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 
 @RetryOnFailure(times = 3, delaySeconds = 1)
 class Elasticsearch2TransportClientTest extends AgentTestRunner {
@@ -34,8 +34,8 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
   TransportClient client
 
   def setupSpec() {
-    httpPort = TestUtils.randomOpenPort()
-    tcpPort = TestUtils.randomOpenPort()
+    httpPort = PortUtils.randomOpenPort()
+    tcpPort = PortUtils.randomOpenPort()
 
     esWorkingDir = File.createTempDir("test-es-working-dir-", "")
     esWorkingDir.deleteOnExit()

--- a/dd-java-agent/instrumentation/elasticsearch-transport-2/src/latestDepTest/groovy/springdata/Elasticsearch2SpringRepositoryTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch-transport-2/src/latestDepTest/groovy/springdata/Elasticsearch2SpringRepositoryTest.groovy
@@ -9,7 +9,7 @@ import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import spock.lang.Shared
 
-import static datadog.trace.agent.test.TestUtils.runUnderTrace
+import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 
 @RetryOnFailure(times = 3, delaySeconds = 1)
 class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {

--- a/dd-java-agent/instrumentation/elasticsearch-transport-2/src/latestDepTest/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch-transport-2/src/latestDepTest/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
@@ -2,7 +2,7 @@ package springdata
 
 import com.anotherchrisberry.spock.extensions.retry.RetryOnFailure
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.TestUtils
+import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import io.opentracing.tag.Tags
@@ -40,8 +40,8 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
   ElasticsearchTemplate template
 
   def setupSpec() {
-    httpPort = TestUtils.randomOpenPort()
-    tcpPort = TestUtils.randomOpenPort()
+    httpPort = PortUtils.randomOpenPort()
+    tcpPort = PortUtils.randomOpenPort()
 
     esWorkingDir = File.createTempDir("test-es-working-dir-", "")
     esWorkingDir.deleteOnExit()

--- a/dd-java-agent/instrumentation/elasticsearch-transport-2/src/test/groovy/Elasticsearch2NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch-transport-2/src/test/groovy/Elasticsearch2NodeClientTest.groovy
@@ -1,6 +1,6 @@
 import com.anotherchrisberry.spock.extensions.retry.RetryOnFailure
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.TestUtils
+import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import io.opentracing.tag.Tags
@@ -12,7 +12,7 @@ import org.elasticsearch.node.Node
 import org.elasticsearch.node.NodeBuilder
 import spock.lang.Shared
 
-import static datadog.trace.agent.test.TestUtils.runUnderTrace
+import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 
 @RetryOnFailure(times = 3, delaySeconds = 1)
 class Elasticsearch2NodeClientTest extends AgentTestRunner {
@@ -30,8 +30,8 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
   def client = testNode.client()
 
   def setupSpec() {
-    httpPort = TestUtils.randomOpenPort()
-    tcpPort = TestUtils.randomOpenPort()
+    httpPort = PortUtils.randomOpenPort()
+    tcpPort = PortUtils.randomOpenPort()
 
     esWorkingDir = File.createTempDir("test-es-working-dir-", "")
     esWorkingDir.deleteOnExit()

--- a/dd-java-agent/instrumentation/elasticsearch-transport-2/src/test/groovy/Elasticsearch2TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch-transport-2/src/test/groovy/Elasticsearch2TransportClientTest.groovy
@@ -1,6 +1,6 @@
 import com.anotherchrisberry.spock.extensions.retry.RetryOnFailure
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.TestUtils
+import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import io.opentracing.tag.Tags
@@ -15,7 +15,7 @@ import org.elasticsearch.node.NodeBuilder
 import org.elasticsearch.transport.RemoteTransportException
 import spock.lang.Shared
 
-import static datadog.trace.agent.test.TestUtils.runUnderTrace
+import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 
 @RetryOnFailure(times = 3, delaySeconds = 1)
 class Elasticsearch2TransportClientTest extends AgentTestRunner {
@@ -34,8 +34,8 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
   TransportClient client
 
   def setupSpec() {
-    httpPort = TestUtils.randomOpenPort()
-    tcpPort = TestUtils.randomOpenPort()
+    httpPort = PortUtils.randomOpenPort()
+    tcpPort = PortUtils.randomOpenPort()
 
     esWorkingDir = File.createTempDir("test-es-working-dir-", "")
     esWorkingDir.deleteOnExit()

--- a/dd-java-agent/instrumentation/elasticsearch-transport-2/src/test/groovy/springdata/Elasticsearch2SpringRepositoryTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch-transport-2/src/test/groovy/springdata/Elasticsearch2SpringRepositoryTest.groovy
@@ -9,7 +9,7 @@ import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import spock.lang.Shared
 
-import static datadog.trace.agent.test.TestUtils.runUnderTrace
+import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 
 @RetryOnFailure(times = 3, delaySeconds = 1)
 class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {

--- a/dd-java-agent/instrumentation/elasticsearch-transport-2/src/test/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch-transport-2/src/test/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
@@ -2,7 +2,7 @@ package springdata
 
 import com.anotherchrisberry.spock.extensions.retry.RetryOnFailure
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.TestUtils
+import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import io.opentracing.tag.Tags
@@ -40,8 +40,8 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
   ElasticsearchTemplate template
 
   def setupSpec() {
-    httpPort = TestUtils.randomOpenPort()
-    tcpPort = TestUtils.randomOpenPort()
+    httpPort = PortUtils.randomOpenPort()
+    tcpPort = PortUtils.randomOpenPort()
 
     esWorkingDir = File.createTempDir("test-es-working-dir-", "")
     esWorkingDir.deleteOnExit()

--- a/dd-java-agent/instrumentation/elasticsearch-transport-5.3/src/test/groovy/Elasticsearch53NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch-transport-5.3/src/test/groovy/Elasticsearch53NodeClientTest.groovy
@@ -1,6 +1,6 @@
 import com.anotherchrisberry.spock.extensions.retry.RetryOnFailure
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.TestUtils
+import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import io.opentracing.tag.Tags
@@ -14,7 +14,7 @@ import org.elasticsearch.node.Node
 import org.elasticsearch.transport.Netty3Plugin
 import spock.lang.Shared
 
-import static datadog.trace.agent.test.TestUtils.runUnderTrace
+import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
 
 @RetryOnFailure(times = 3, delaySeconds = 1)
@@ -33,8 +33,8 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
   def client = testNode.client()
 
   def setupSpec() {
-    httpPort = TestUtils.randomOpenPort()
-    tcpPort = TestUtils.randomOpenPort()
+    httpPort = PortUtils.randomOpenPort()
+    tcpPort = PortUtils.randomOpenPort()
 
     esWorkingDir = File.createTempDir("test-es-working-dir-", "")
     esWorkingDir.deleteOnExit()

--- a/dd-java-agent/instrumentation/elasticsearch-transport-5.3/src/test/groovy/Elasticsearch53TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch-transport-5.3/src/test/groovy/Elasticsearch53TransportClientTest.groovy
@@ -1,6 +1,6 @@
 import com.anotherchrisberry.spock.extensions.retry.RetryOnFailure
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.TestUtils
+import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import io.opentracing.tag.Tags
@@ -18,7 +18,7 @@ import org.elasticsearch.transport.RemoteTransportException
 import org.elasticsearch.transport.client.PreBuiltTransportClient
 import spock.lang.Shared
 
-import static datadog.trace.agent.test.TestUtils.runUnderTrace
+import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
 
 @RetryOnFailure(times = 3, delaySeconds = 1)
@@ -38,8 +38,8 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
   TransportClient client
 
   def setupSpec() {
-    httpPort = TestUtils.randomOpenPort()
-    tcpPort = TestUtils.randomOpenPort()
+    httpPort = PortUtils.randomOpenPort()
+    tcpPort = PortUtils.randomOpenPort()
 
     esWorkingDir = File.createTempDir("test-es-working-dir-", "")
     esWorkingDir.deleteOnExit()

--- a/dd-java-agent/instrumentation/elasticsearch-transport-5.3/src/test/groovy/springdata/Elasticsearch53SpringRepositoryTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch-transport-5.3/src/test/groovy/springdata/Elasticsearch53SpringRepositoryTest.groovy
@@ -9,7 +9,7 @@ import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import spock.lang.Shared
 
-import static datadog.trace.agent.test.TestUtils.runUnderTrace
+import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 
 @RetryOnFailure(times = 3, delaySeconds = 1)
 class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {

--- a/dd-java-agent/instrumentation/elasticsearch-transport-5.3/src/test/groovy/springdata/Elasticsearch53SpringTemplateTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch-transport-5.3/src/test/groovy/springdata/Elasticsearch53SpringTemplateTest.groovy
@@ -3,7 +3,7 @@ package springdata
 import com.anotherchrisberry.spock.extensions.retry.RetryOnFailure
 import com.google.common.collect.ImmutableSet
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.TestUtils
+import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import io.opentracing.tag.Tags
@@ -26,7 +26,7 @@ import spock.lang.Shared
 
 import java.util.concurrent.atomic.AtomicLong
 
-import static datadog.trace.agent.test.TestUtils.runUnderTrace
+import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
 
 @RetryOnFailure(times = 3, delaySeconds = 1)
@@ -51,8 +51,8 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
   ElasticsearchTemplate template
 
   def setupSpec() {
-    httpPort = TestUtils.randomOpenPort()
-    tcpPort = TestUtils.randomOpenPort()
+    httpPort = PortUtils.randomOpenPort()
+    tcpPort = PortUtils.randomOpenPort()
 
     esWorkingDir = File.createTempDir("test-es-working-dir-", "")
     esWorkingDir.deleteOnExit()

--- a/dd-java-agent/instrumentation/elasticsearch-transport-5/src/test/groovy/Elasticsearch5NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch-transport-5/src/test/groovy/Elasticsearch5NodeClientTest.groovy
@@ -1,6 +1,6 @@
 import com.anotherchrisberry.spock.extensions.retry.RetryOnFailure
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.TestUtils
+import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import io.opentracing.tag.Tags
@@ -14,7 +14,7 @@ import org.elasticsearch.node.internal.InternalSettingsPreparer
 import org.elasticsearch.transport.Netty3Plugin
 import spock.lang.Shared
 
-import static datadog.trace.agent.test.TestUtils.runUnderTrace
+import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
 
 @RetryOnFailure(times = 3, delaySeconds = 1)
@@ -33,8 +33,8 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
   def client = testNode.client()
 
   def setupSpec() {
-    httpPort = TestUtils.randomOpenPort()
-    tcpPort = TestUtils.randomOpenPort()
+    httpPort = PortUtils.randomOpenPort()
+    tcpPort = PortUtils.randomOpenPort()
 
     esWorkingDir = File.createTempDir("test-es-working-dir-", "")
     esWorkingDir.deleteOnExit()

--- a/dd-java-agent/instrumentation/elasticsearch-transport-5/src/test/groovy/Elasticsearch5TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch-transport-5/src/test/groovy/Elasticsearch5TransportClientTest.groovy
@@ -1,6 +1,6 @@
 import com.anotherchrisberry.spock.extensions.retry.RetryOnFailure
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.TestUtils
+import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import io.opentracing.tag.Tags
@@ -18,7 +18,7 @@ import org.elasticsearch.transport.RemoteTransportException
 import org.elasticsearch.transport.client.PreBuiltTransportClient
 import spock.lang.Shared
 
-import static datadog.trace.agent.test.TestUtils.runUnderTrace
+import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
 
 @RetryOnFailure(times = 3, delaySeconds = 1)
@@ -38,8 +38,8 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
   TransportClient client
 
   def setupSpec() {
-    httpPort = TestUtils.randomOpenPort()
-    tcpPort = TestUtils.randomOpenPort()
+    httpPort = PortUtils.randomOpenPort()
+    tcpPort = PortUtils.randomOpenPort()
 
     esWorkingDir = File.createTempDir("test-es-working-dir-", "")
     esWorkingDir.deleteOnExit()

--- a/dd-java-agent/instrumentation/elasticsearch-transport-6/src/test/groovy/Elasticsearch6NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch-transport-6/src/test/groovy/Elasticsearch6NodeClientTest.groovy
@@ -1,6 +1,6 @@
 import com.anotherchrisberry.spock.extensions.retry.RetryOnFailure
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.TestUtils
+import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import io.opentracing.tag.Tags
@@ -13,7 +13,7 @@ import org.elasticsearch.node.Node
 import org.elasticsearch.transport.Netty4Plugin
 import spock.lang.Shared
 
-import static datadog.trace.agent.test.TestUtils.runUnderTrace
+import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
 
 @RetryOnFailure(times = 3, delaySeconds = 1)
@@ -32,8 +32,8 @@ class Elasticsearch6NodeClientTest extends AgentTestRunner {
   def client = testNode.client()
 
   def setupSpec() {
-    httpPort = TestUtils.randomOpenPort()
-    tcpPort = TestUtils.randomOpenPort()
+    httpPort = PortUtils.randomOpenPort()
+    tcpPort = PortUtils.randomOpenPort()
 
     esWorkingDir = File.createTempDir("test-es-working-dir-", "")
     esWorkingDir.deleteOnExit()

--- a/dd-java-agent/instrumentation/elasticsearch-transport-6/src/test/groovy/Elasticsearch6TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch-transport-6/src/test/groovy/Elasticsearch6TransportClientTest.groovy
@@ -1,6 +1,6 @@
 import com.anotherchrisberry.spock.extensions.retry.RetryOnFailure
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.TestUtils
+import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import io.opentracing.tag.Tags
@@ -17,7 +17,7 @@ import org.elasticsearch.transport.RemoteTransportException
 import org.elasticsearch.transport.client.PreBuiltTransportClient
 import spock.lang.Shared
 
-import static datadog.trace.agent.test.TestUtils.runUnderTrace
+import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
 
 @RetryOnFailure(times = 3, delaySeconds = 1)
@@ -37,8 +37,8 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
   TransportClient client
 
   def setupSpec() {
-    httpPort = TestUtils.randomOpenPort()
-    tcpPort = TestUtils.randomOpenPort()
+    httpPort = PortUtils.randomOpenPort()
+    tcpPort = PortUtils.randomOpenPort()
 
     esWorkingDir = File.createTempDir("test-es-working-dir-", "")
     esWorkingDir.deleteOnExit()

--- a/dd-java-agent/instrumentation/http-url-connection/src/main/java/datadog/trace/instrumentation/http_url_connection/HttpUrlConnectionInstrumentation.java
+++ b/dd-java-agent/instrumentation/http-url-connection/src/main/java/datadog/trace/instrumentation/http_url_connection/HttpUrlConnectionInstrumentation.java
@@ -10,12 +10,12 @@ import static net.bytebuddy.matcher.ElementMatchers.not;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.api.Config;
 import datadog.trace.api.DDSpanTypes;
 import datadog.trace.api.DDTags;
 import datadog.trace.bootstrap.CallDepthThreadLocalMap;
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.InstrumentationContext;
-import io.opentracing.Scope;
 import io.opentracing.Span;
 import io.opentracing.Tracer;
 import io.opentracing.propagation.Format;
@@ -184,22 +184,24 @@ public class HttpUrlConnectionInstrumentation extends Instrumenter.Default {
               .buildSpan(OPERATION_NAME)
               .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_CLIENT)
               .withTag(DDTags.SPAN_TYPE, DDSpanTypes.HTTP_CLIENT);
-      try (final Scope scope = builder.startActive(false)) {
-        span = scope.span();
-        final URL url = connection.getURL();
-        Tags.COMPONENT.set(span, COMPONENT_NAME);
-        Tags.HTTP_URL.set(span, url.toString());
-        Tags.PEER_HOSTNAME.set(span, url.getHost());
-        if (url.getPort() > 0) {
-          Tags.PEER_PORT.set(span, url.getPort());
-        } else if (connection instanceof HttpsURLConnection) {
-          Tags.PEER_PORT.set(span, 443);
-        } else {
-          Tags.PEER_PORT.set(span, 80);
-        }
-        Tags.HTTP_METHOD.set(span, connection.getRequestMethod());
-        return span;
+      span = builder.start();
+      final URL url = connection.getURL();
+      Tags.COMPONENT.set(span, COMPONENT_NAME);
+      Tags.HTTP_URL.set(span, url.toString());
+      Tags.PEER_HOSTNAME.set(span, url.getHost());
+      if (Config.get().isHttpClientSplitByDomain()) {
+        span.setTag(DDTags.SERVICE_NAME, url.getHost());
       }
+
+      if (url.getPort() > 0) {
+        Tags.PEER_PORT.set(span, url.getPort());
+      } else if (connection instanceof HttpsURLConnection) {
+        Tags.PEER_PORT.set(span, 443);
+      } else {
+        Tags.PEER_PORT.set(span, 80);
+      }
+      Tags.HTTP_METHOD.set(span, connection.getRequestMethod());
+      return span;
     }
 
     public boolean hasSpan() {
@@ -215,10 +217,9 @@ public class HttpUrlConnectionInstrumentation extends Instrumenter.Default {
     }
 
     public void finishSpan(final Throwable throwable) {
-      try (final Scope scope = GlobalTracer.get().scopeManager().activate(span, true)) {
-        Tags.ERROR.set(span, true);
-        span.log(singletonMap(ERROR_OBJECT, throwable));
-      }
+      Tags.ERROR.set(span, true);
+      span.log(singletonMap(ERROR_OBJECT, throwable));
+      span.finish();
       span = null;
       finished = true;
     }
@@ -230,11 +231,10 @@ public class HttpUrlConnectionInstrumentation extends Instrumenter.Default {
        * (e.g. breaks getOutputStream).
        */
       if (responseCode > 0) {
-        try (final Scope scope = GlobalTracer.get().scopeManager().activate(span, true)) {
-          Tags.HTTP_STATUS.set(span, responseCode);
-          span = null;
-          finished = true;
-        }
+        Tags.HTTP_STATUS.set(span, responseCode);
+        span.finish();
+        span = null;
+        finished = true;
       }
     }
   }

--- a/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionTest.groovy
+++ b/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionTest.groovy
@@ -1,4 +1,5 @@
 import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.api.Config
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import io.opentracing.tag.Tags
@@ -8,6 +9,9 @@ import spock.lang.AutoCleanup
 import spock.lang.Shared
 
 import static datadog.trace.agent.test.TestUtils.runUnderTrace
+import static datadog.trace.agent.test.TestUtils.setFinal
+import static datadog.trace.agent.test.TestUtils.setFinalStatic
+import static datadog.trace.agent.test.TestUtils.withSystemProperty
 import static datadog.trace.agent.test.server.http.TestHttpServer.httpServer
 import static datadog.trace.instrumentation.http_url_connection.HttpUrlConnectionInstrumentation.HttpUrlState.COMPONENT_NAME
 import static datadog.trace.instrumentation.http_url_connection.HttpUrlConnectionInstrumentation.HttpUrlState.OPERATION_NAME
@@ -31,26 +35,30 @@ class HttpUrlConnectionTest extends AgentTestRunner {
 
   def "trace request with propagation (useCaches: #useCaches)"() {
     setup:
-    runUnderTrace("someTrace") {
-      HttpURLConnection connection = server.address.toURL().openConnection()
-      connection.useCaches = useCaches
-      assert GlobalTracer.get().scopeManager().active() != null
-      def stream = connection.inputStream
-      def lines = stream.readLines()
-      stream.close()
-      assert connection.getResponseCode() == STATUS
-      assert lines == [RESPONSE]
+    withSystemProperty("dd.$Config.HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN", "$renameService") {
+      resetConfig()
 
-      // call again to ensure the cycling is ok
-      connection = server.getAddress().toURL().openConnection()
-      connection.useCaches = useCaches
-      assert GlobalTracer.get().scopeManager().active() != null
-      assert connection.getResponseCode() == STATUS // call before input stream to test alternate behavior
-      connection.inputStream
-      stream = connection.inputStream // one more to ensure state is working
-      lines = stream.readLines()
-      stream.close()
-      assert lines == [RESPONSE]
+      runUnderTrace("someTrace") {
+        HttpURLConnection connection = server.address.toURL().openConnection()
+        connection.useCaches = useCaches
+        assert GlobalTracer.get().scopeManager().active() != null
+        def stream = connection.inputStream
+        def lines = stream.readLines()
+        stream.close()
+        assert connection.getResponseCode() == STATUS
+        assert lines == [RESPONSE]
+
+        // call again to ensure the cycling is ok
+        connection = server.getAddress().toURL().openConnection()
+        connection.useCaches = useCaches
+        assert GlobalTracer.get().scopeManager().active() != null
+        assert connection.getResponseCode() == STATUS // call before input stream to test alternate behavior
+        connection.inputStream
+        stream = connection.inputStream // one more to ensure state is working
+        lines = stream.readLines()
+        stream.close()
+        assert lines == [RESPONSE]
+      }
     }
 
     expect:
@@ -67,6 +75,7 @@ class HttpUrlConnectionTest extends AgentTestRunner {
           }
         }
         span(1) {
+          serviceName renameService ? "localhost" : "unnamed-java-app"
           operationName OPERATION_NAME
           childOf span(0)
           errored false
@@ -83,6 +92,7 @@ class HttpUrlConnectionTest extends AgentTestRunner {
           }
         }
         span(2) {
+          serviceName renameService ? "localhost" : "unnamed-java-app"
           operationName OPERATION_NAME
           childOf span(0)
           errored false
@@ -103,32 +113,37 @@ class HttpUrlConnectionTest extends AgentTestRunner {
 
     where:
     useCaches << [false, true]
+    renameService << [true, false]
   }
 
   def "trace request without propagation (useCaches: #useCaches)"() {
     setup:
-    runUnderTrace("someTrace") {
-      HttpURLConnection connection = server.address.toURL().openConnection()
-      connection.useCaches = useCaches
-      connection.addRequestProperty("is-dd-server", "false")
-      assert GlobalTracer.get().scopeManager().active() != null
-      def stream = connection.inputStream
-      connection.inputStream // one more to ensure state is working
-      def lines = stream.readLines()
-      stream.close()
-      assert connection.getResponseCode() == STATUS
-      assert lines == [RESPONSE]
+    withSystemProperty("dd.$Config.HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN", "$renameService") {
+      resetConfig()
 
-      // call again to ensure the cycling is ok
-      connection = server.getAddress().toURL().openConnection()
-      connection.useCaches = useCaches
-      connection.addRequestProperty("is-dd-server", "false")
-      assert GlobalTracer.get().scopeManager().active() != null
-      assert connection.getResponseCode() == STATUS // call before input stream to test alternate behavior
-      stream = connection.inputStream
-      lines = stream.readLines()
-      stream.close()
-      assert lines == [RESPONSE]
+      runUnderTrace("someTrace") {
+        HttpURLConnection connection = server.address.toURL().openConnection()
+        connection.useCaches = useCaches
+        connection.addRequestProperty("is-dd-server", "false")
+        assert GlobalTracer.get().scopeManager().active() != null
+        def stream = connection.inputStream
+        connection.inputStream // one more to ensure state is working
+        def lines = stream.readLines()
+        stream.close()
+        assert connection.getResponseCode() == STATUS
+        assert lines == [RESPONSE]
+
+        // call again to ensure the cycling is ok
+        connection = server.getAddress().toURL().openConnection()
+        connection.useCaches = useCaches
+        connection.addRequestProperty("is-dd-server", "false")
+        assert GlobalTracer.get().scopeManager().active() != null
+        assert connection.getResponseCode() == STATUS // call before input stream to test alternate behavior
+        stream = connection.inputStream
+        lines = stream.readLines()
+        stream.close()
+        assert lines == [RESPONSE]
+      }
     }
 
     expect:
@@ -143,6 +158,7 @@ class HttpUrlConnectionTest extends AgentTestRunner {
           }
         }
         span(1) {
+          serviceName renameService ? "localhost" : "unnamed-java-app"
           operationName OPERATION_NAME
           childOf span(0)
           errored false
@@ -159,6 +175,7 @@ class HttpUrlConnectionTest extends AgentTestRunner {
           }
         }
         span(2) {
+          serviceName renameService ? "localhost" : "unnamed-java-app"
           operationName OPERATION_NAME
           childOf span(0)
           errored false
@@ -179,16 +196,21 @@ class HttpUrlConnectionTest extends AgentTestRunner {
 
     where:
     useCaches << [false, true]
+    renameService << [false, true]
   }
 
   def "test response code"() {
     setup:
-    runUnderTrace("someTrace") {
-      HttpURLConnection connection = server.address.toURL().openConnection()
-      connection.setRequestMethod("HEAD")
-      connection.addRequestProperty("is-dd-server", "false")
-      assert GlobalTracer.get().scopeManager().active() != null
-      assert connection.getResponseCode() == STATUS
+    withSystemProperty("dd.$Config.HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN", "$renameService") {
+      resetConfig()
+
+      runUnderTrace("someTrace") {
+        HttpURLConnection connection = server.address.toURL().openConnection()
+        connection.setRequestMethod("HEAD")
+        connection.addRequestProperty("is-dd-server", "false")
+        assert GlobalTracer.get().scopeManager().active() != null
+        assert connection.getResponseCode() == STATUS
+      }
     }
 
     expect:
@@ -203,6 +225,7 @@ class HttpUrlConnectionTest extends AgentTestRunner {
           }
         }
         span(1) {
+          serviceName renameService ? "localhost" : "unnamed-java-app"
           operationName OPERATION_NAME
           childOf span(0)
           errored false
@@ -220,17 +243,24 @@ class HttpUrlConnectionTest extends AgentTestRunner {
         }
       }
     }
+
+    where:
+    renameService << [false, true]
   }
 
   def "test broken API usage"() {
     setup:
-    HttpURLConnection conn = runUnderTrace("someTrace") {
-      HttpURLConnection connection = server.address.toURL().openConnection()
-      connection.setRequestProperty("Connection", "close")
-      connection.addRequestProperty("is-dd-server", "false")
-      assert GlobalTracer.get().scopeManager().active() != null
-      assert connection.getResponseCode() == STATUS
-      return connection
+    HttpURLConnection conn = withSystemProperty("dd.$Config.HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN", "$renameService") {
+      resetConfig()
+
+      runUnderTrace("someTrace") {
+        HttpURLConnection connection = server.address.toURL().openConnection()
+        connection.setRequestProperty("Connection", "close")
+        connection.addRequestProperty("is-dd-server", "false")
+        assert GlobalTracer.get().scopeManager().active() != null
+        assert connection.getResponseCode() == STATUS
+        return connection
+      }
     }
 
     expect:
@@ -245,6 +275,7 @@ class HttpUrlConnectionTest extends AgentTestRunner {
           }
         }
         span(1) {
+          serviceName renameService ? "localhost" : "unnamed-java-app"
           operationName OPERATION_NAME
           childOf span(0)
           errored false
@@ -268,29 +299,34 @@ class HttpUrlConnectionTest extends AgentTestRunner {
 
     where:
     iteration << (1..10)
+    renameService = (iteration % 2 == 0) // alternate even/odd
   }
 
   def "test post request"() {
     setup:
-    runUnderTrace("someTrace") {
-      HttpURLConnection connection = server.address.toURL().openConnection()
-      connection.setRequestMethod("POST")
+    withSystemProperty("dd.$Config.HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN", "$renameService") {
+      resetConfig()
 
-      String urlParameters = "q=ASDF&w=&e=&r=12345&t="
+      runUnderTrace("someTrace") {
+        HttpURLConnection connection = server.address.toURL().openConnection()
+        connection.setRequestMethod("POST")
 
-      // Send post request
-      connection.setDoOutput(true)
-      DataOutputStream wr = new DataOutputStream(connection.getOutputStream())
-      wr.writeBytes(urlParameters)
-      wr.flush()
-      wr.close()
+        String urlParameters = "q=ASDF&w=&e=&r=12345&t="
 
-      assert connection.getResponseCode() == STATUS
+        // Send post request
+        connection.setDoOutput(true)
+        DataOutputStream wr = new DataOutputStream(connection.getOutputStream())
+        wr.writeBytes(urlParameters)
+        wr.flush()
+        wr.close()
 
-      def stream = connection.inputStream
-      def lines = stream.readLines()
-      stream.close()
-      assert lines == [RESPONSE]
+        assert connection.getResponseCode() == STATUS
+
+        def stream = connection.inputStream
+        def lines = stream.readLines()
+        stream.close()
+        assert lines == [RESPONSE]
+      }
     }
 
     expect:
@@ -306,6 +342,7 @@ class HttpUrlConnectionTest extends AgentTestRunner {
           }
         }
         span(1) {
+          serviceName renameService ? "localhost" : "unnamed-java-app"
           operationName OPERATION_NAME
           childOf span(0)
           errored false
@@ -323,6 +360,9 @@ class HttpUrlConnectionTest extends AgentTestRunner {
         }
       }
     }
+
+    where:
+    renameService << [false, true]
   }
 
   def "request that looks like a trace submission is ignored"() {
@@ -355,18 +395,23 @@ class HttpUrlConnectionTest extends AgentTestRunner {
 
   def "top level httpurlconnection tracing disabled"() {
     setup:
-    HttpURLConnection connection = server.address.toURL().openConnection()
-    connection.addRequestProperty("is-dd-server", "false")
-    def stream = connection.inputStream
-    def lines = stream.readLines()
-    stream.close()
-    assert connection.getResponseCode() == STATUS
-    assert lines == [RESPONSE]
+    withSystemProperty("dd.$Config.HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN", "$renameService") {
+      resetConfig()
+
+      HttpURLConnection connection = server.address.toURL().openConnection()
+      connection.addRequestProperty("is-dd-server", "false")
+      def stream = connection.inputStream
+      def lines = stream.readLines()
+      stream.close()
+      assert connection.getResponseCode() == STATUS
+      assert lines == [RESPONSE]
+    }
 
     expect:
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
+          serviceName renameService ? "localhost" : "unnamed-java-app"
           operationName OPERATION_NAME
           parent()
           errored false
@@ -384,14 +429,21 @@ class HttpUrlConnectionTest extends AgentTestRunner {
         }
       }
     }
+
+    where:
+    renameService << [false, true]
   }
 
   def "rest template"() {
     setup:
-    runUnderTrace("someTrace") {
-      RestTemplate restTemplate = new RestTemplate()
-      String res = restTemplate.postForObject(server.address.toString(), "Hello", String)
-      assert res == "$RESPONSE"
+    withSystemProperty("dd.$Config.HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN", "$renameService") {
+      resetConfig()
+
+      runUnderTrace("someTrace") {
+        RestTemplate restTemplate = new RestTemplate()
+        String res = restTemplate.postForObject(server.address.toString(), "Hello", String)
+        assert res == "$RESPONSE"
+      }
     }
 
     expect:
@@ -407,6 +459,7 @@ class HttpUrlConnectionTest extends AgentTestRunner {
           }
         }
         span(1) {
+          serviceName renameService ? "localhost" : "unnamed-java-app"
           operationName OPERATION_NAME
           childOf span(0)
           errored false
@@ -424,5 +477,14 @@ class HttpUrlConnectionTest extends AgentTestRunner {
         }
       }
     }
+
+    where:
+    renameService << [false, true]
+  }
+
+  def resetConfig() {
+    def runtimeId = Config.get().runtimeId
+    setFinalStatic(Config.getDeclaredField("INSTANCE"), new Config())
+    setFinal(Config.getDeclaredField("runtimeId"), Config.get(), runtimeId)
   }
 }

--- a/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/UrlConnectionTest.groovy
+++ b/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/UrlConnectionTest.groovy
@@ -1,5 +1,4 @@
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.TestUtils
 import datadog.trace.api.Config
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
@@ -7,22 +6,18 @@ import datadog.trace.instrumentation.http_url_connection.UrlInstrumentation
 import io.opentracing.tag.Tags
 import io.opentracing.util.GlobalTracer
 
-import static datadog.trace.agent.test.TestUtils.runUnderTrace
-import static datadog.trace.agent.test.TestUtils.setFinal
-import static datadog.trace.agent.test.TestUtils.setFinalStatic
-import static datadog.trace.agent.test.TestUtils.withSystemProperty
+import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
+import static datadog.trace.agent.test.utils.TraceUtils.withConfigOverride
 import static datadog.trace.instrumentation.http_url_connection.HttpUrlConnectionInstrumentation.HttpUrlState.COMPONENT_NAME
 import static datadog.trace.instrumentation.http_url_connection.HttpUrlConnectionInstrumentation.HttpUrlState.OPERATION_NAME
 
 class UrlConnectionTest extends AgentTestRunner {
 
-  private static final int INVALID_PORT = TestUtils.randomOpenPort()
+  private static final int UNUSED_PORT = 61 // this port should always be closed
 
   def "trace request with connection failure #scheme"() {
     when:
-    withSystemProperty("dd.$Config.HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN", "$renameService") {
-      resetConfig()
-
+    withConfigOverride("dd.$Config.HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN", "$renameService") {
       runUnderTrace("someTrace") {
         URLConnection connection = url.openConnection()
         connection.setConnectTimeout(10000)
@@ -59,7 +54,7 @@ class UrlConnectionTest extends AgentTestRunner {
             "$Tags.HTTP_URL.key" "$url"
             "$Tags.HTTP_METHOD.key" "GET"
             "$Tags.PEER_HOSTNAME.key" "localhost"
-            "$Tags.PEER_PORT.key" INVALID_PORT
+            "$Tags.PEER_PORT.key" UNUSED_PORT
             errorTags ConnectException, String
             defaultTags()
           }
@@ -72,7 +67,7 @@ class UrlConnectionTest extends AgentTestRunner {
     "http"  | true
     "https" | false
 
-    url = new URI("$scheme://localhost:$INVALID_PORT").toURL()
+    url = new URI("$scheme://localhost:$UNUSED_PORT").toURL()
   }
 
   def "trace request with connection failure to a local file with broken url path"() {
@@ -80,9 +75,7 @@ class UrlConnectionTest extends AgentTestRunner {
     def url = new URI("file:/some-random-file%abc").toURL()
 
     when:
-    withSystemProperty("dd.$Config.HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN", "$renameService") {
-      resetConfig()
-
+    withConfigOverride("dd.$Config.HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN", "$renameService") {
       runUnderTrace("someTrace") {
         url.openConnection()
       }
@@ -124,11 +117,5 @@ class UrlConnectionTest extends AgentTestRunner {
 
     where:
     renameService << [false, true]
-  }
-
-  def resetConfig() {
-    def runtimeId = Config.get().runtimeId
-    setFinalStatic(Config.getDeclaredField("INSTANCE"), new Config())
-    setFinal(Config.getDeclaredField("runtimeId"), Config.get(), runtimeId)
   }
 }

--- a/dd-java-agent/instrumentation/hystrix-1.4/src/test/groovy/HystrixTest.groovy
+++ b/dd-java-agent/instrumentation/hystrix-1.4/src/test/groovy/HystrixTest.groovy
@@ -7,7 +7,7 @@ import java.util.concurrent.BlockingQueue
 import java.util.concurrent.LinkedBlockingQueue
 
 import static com.netflix.hystrix.HystrixCommandGroupKey.Factory.asKey
-import static datadog.trace.agent.test.TestUtils.runUnderTrace
+import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 
 class HystrixTest extends AgentTestRunner {
   // Uncomment for debugging:

--- a/dd-java-agent/instrumentation/jax-rs-annotations/src/test/groovy/JaxRsAnnotationsInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/jax-rs-annotations/src/test/groovy/JaxRsAnnotationsInstrumentationTest.groovy
@@ -9,7 +9,7 @@ import javax.ws.rs.POST
 import javax.ws.rs.PUT
 import javax.ws.rs.Path
 
-import static datadog.trace.agent.test.TestUtils.runUnderTrace
+import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 
 class JaxRsAnnotationsInstrumentationTest extends AgentTestRunner {
 

--- a/dd-java-agent/instrumentation/jax-rs-annotations/src/test/groovy/JerseyTest.groovy
+++ b/dd-java-agent/instrumentation/jax-rs-annotations/src/test/groovy/JerseyTest.groovy
@@ -3,7 +3,7 @@ import io.dropwizard.testing.junit.ResourceTestRule
 import org.junit.ClassRule
 import spock.lang.Shared
 
-import static datadog.trace.agent.test.TestUtils.runUnderTrace
+import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 
 class JerseyTest extends AgentTestRunner {
 

--- a/dd-java-agent/instrumentation/jax-rs-client/src/test/groovy/JaxRsClientTest.groovy
+++ b/dd-java-agent/instrumentation/jax-rs-client/src/test/groovy/JaxRsClientTest.groovy
@@ -1,5 +1,5 @@
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.TestUtils
+import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import io.opentracing.tag.Tags
@@ -23,7 +23,7 @@ import static datadog.trace.agent.test.server.http.TestHttpServer.httpServer
 class JaxRsClientTest extends AgentTestRunner {
 
   @Shared
-  def emptyPort = TestUtils.randomOpenPort()
+  def emptyPort = PortUtils.randomOpenPort()
 
   @AutoCleanup
   @Shared

--- a/dd-java-agent/instrumentation/jdbc/src/test/groovy/JDBCInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/jdbc/src/test/groovy/JDBCInstrumentationTest.groovy
@@ -17,7 +17,7 @@ import java.sql.PreparedStatement
 import java.sql.ResultSet
 import java.sql.Statement
 
-import static datadog.trace.agent.test.TestUtils.runUnderTrace
+import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 
 class JDBCInstrumentationTest extends AgentTestRunner {
 

--- a/dd-java-agent/instrumentation/jetty-8/src/test/groovy/JettyHandlerTest.groovy
+++ b/dd-java-agent/instrumentation/jetty-8/src/test/groovy/JettyHandlerTest.groovy
@@ -1,6 +1,6 @@
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.TestUtils
 import datadog.trace.agent.test.utils.OkHttpUtils
+import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import okhttp3.OkHttpClient
@@ -23,7 +23,7 @@ class JettyHandlerTest extends AgentTestRunner {
     System.setProperty("dd.integration.jetty.enabled", "true")
   }
 
-  int port = TestUtils.randomOpenPort()
+  int port = PortUtils.randomOpenPort()
   Server server = new Server(port)
 
   OkHttpClient client = OkHttpUtils.client()

--- a/dd-java-agent/instrumentation/jsp-2.3/src/test/groovy/JSPInstrumentationBasicTests.groovy
+++ b/dd-java-agent/instrumentation/jsp-2.3/src/test/groovy/JSPInstrumentationBasicTests.groovy
@@ -1,7 +1,7 @@
 import com.google.common.io.Files
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.TestUtils
 import datadog.trace.agent.test.utils.OkHttpUtils
+import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
 import okhttp3.MultipartBody
 import okhttp3.OkHttpClient
@@ -49,7 +49,7 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
     baseDir.deleteOnExit()
     expectedJspClassFilesDir = baseDir.getCanonicalFile().getAbsolutePath() + expectedJspClassFilesDir
 
-    port = TestUtils.randomOpenPort()
+    port = PortUtils.randomOpenPort()
 
     tomcatServer = new Tomcat()
     tomcatServer.setBaseDir(baseDir.getAbsolutePath())

--- a/dd-java-agent/instrumentation/jsp-2.3/src/test/groovy/JSPInstrumentationForwardTests.groovy
+++ b/dd-java-agent/instrumentation/jsp-2.3/src/test/groovy/JSPInstrumentationForwardTests.groovy
@@ -1,7 +1,7 @@
 import com.google.common.io.Files
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.TestUtils
 import datadog.trace.agent.test.utils.OkHttpUtils
+import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -47,7 +47,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
     baseDir.deleteOnExit()
     expectedJspClassFilesDir = baseDir.getCanonicalFile().getAbsolutePath() + expectedJspClassFilesDir
 
-    port = TestUtils.randomOpenPort()
+    port = PortUtils.randomOpenPort()
 
     tomcatServer = new Tomcat()
     tomcatServer.setBaseDir(baseDir.getAbsolutePath())

--- a/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/LettuceAsyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/LettuceAsyncClientTest.groovy
@@ -1,5 +1,5 @@
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.TestUtils
+import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import io.lettuce.core.ClientOptions
@@ -62,8 +62,8 @@ class LettuceAsyncClientTest extends AgentTestRunner {
   RedisCommands<String, ?> syncCommands
 
   def setupSpec() {
-    port = TestUtils.randomOpenPort()
-    incorrectPort = TestUtils.randomOpenPort()
+    port = PortUtils.randomOpenPort()
+    incorrectPort = PortUtils.randomOpenPort()
     dbAddr = HOST + ":" + port + "/" + DB_INDEX
     dbAddrNonExistent = HOST + ":" + incorrectPort + "/" + DB_INDEX
     dbUriNonExistent = "redis://" + dbAddrNonExistent

--- a/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/LettuceReactiveClientTest.groovy
+++ b/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/LettuceReactiveClientTest.groovy
@@ -1,5 +1,5 @@
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.TestUtils
+import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import io.lettuce.core.ClientOptions
@@ -33,7 +33,7 @@ class LettuceReactiveClientTest extends AgentTestRunner {
   RedisCommands<String, ?> syncCommands
 
   def setupSpec() {
-    int port = TestUtils.randomOpenPort()
+    int port = PortUtils.randomOpenPort()
     String dbAddr = HOST + ":" + port + "/" + DB_INDEX
     embeddedDbUri = "redis://" + dbAddr
 

--- a/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/LettuceSyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/LettuceSyncClientTest.groovy
@@ -1,5 +1,5 @@
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.TestUtils
+import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import io.lettuce.core.ClientOptions
@@ -48,8 +48,8 @@ class LettuceSyncClientTest extends AgentTestRunner {
   RedisCommands<String, ?> syncCommands
 
   def setupSpec() {
-    port = TestUtils.randomOpenPort()
-    incorrectPort = TestUtils.randomOpenPort()
+    port = PortUtils.randomOpenPort()
+    incorrectPort = PortUtils.randomOpenPort()
     dbAddr = HOST + ":" + port + "/" + DB_INDEX
     dbAddrNonExistent = HOST + ":" + incorrectPort + "/" + DB_INDEX
     dbUriNonExistent = "redis://" + dbAddrNonExistent

--- a/dd-java-agent/instrumentation/netty-4.0/src/test/groovy/Netty40ClientTest.groovy
+++ b/dd-java-agent/instrumentation/netty-4.0/src/test/groovy/Netty40ClientTest.groovy
@@ -1,5 +1,5 @@
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.TestUtils
+import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import io.opentracing.tag.Tags
@@ -11,8 +11,8 @@ import spock.lang.Shared
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.TimeUnit
 
-import static datadog.trace.agent.test.TestUtils.runUnderTrace
 import static datadog.trace.agent.test.server.http.TestHttpServer.httpServer
+import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 import static org.asynchttpclient.Dsl.asyncHttpClient
 
 class Netty40ClientTest extends AgentTestRunner {
@@ -78,7 +78,7 @@ class Netty40ClientTest extends AgentTestRunner {
 
   def "test connection failure"() {
     setup:
-    def invalidPort = TestUtils.randomOpenPort()
+    def invalidPort = PortUtils.randomOpenPort()
 
     def responseFuture = runUnderTrace("parent") {
       asyncHttpClient.prepareGet("http://localhost:$invalidPort/").execute()

--- a/dd-java-agent/instrumentation/netty-4.0/src/test/groovy/Netty40ServerTest.groovy
+++ b/dd-java-agent/instrumentation/netty-4.0/src/test/groovy/Netty40ServerTest.groovy
@@ -1,6 +1,6 @@
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.TestUtils
 import datadog.trace.agent.test.utils.OkHttpUtils
+import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import io.netty.bootstrap.ServerBootstrap
@@ -35,7 +35,7 @@ class Netty40ServerTest extends AgentTestRunner {
   def "test server request/response"() {
     setup:
     EventLoopGroup eventLoopGroup = new NioEventLoopGroup()
-    int port = TestUtils.randomOpenPort()
+    int port = PortUtils.randomOpenPort()
     initializeServer(eventLoopGroup, port, handlers, HttpResponseStatus.OK)
 
     def request = new Request.Builder()
@@ -88,7 +88,7 @@ class Netty40ServerTest extends AgentTestRunner {
   def "test #responseCode response handling"() {
     setup:
     EventLoopGroup eventLoopGroup = new NioEventLoopGroup()
-    int port = TestUtils.randomOpenPort()
+    int port = PortUtils.randomOpenPort()
     initializeServer(eventLoopGroup, port, new HttpServerCodec(), responseCode)
 
     def request = new Request.Builder().url("http://localhost:$port/").get().build()

--- a/dd-java-agent/instrumentation/netty-4.1/src/test/groovy/Netty41ClientTest.groovy
+++ b/dd-java-agent/instrumentation/netty-4.1/src/test/groovy/Netty41ClientTest.groovy
@@ -1,5 +1,5 @@
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.TestUtils
+import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import io.netty.channel.AbstractChannel
@@ -12,8 +12,8 @@ import spock.lang.Shared
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.TimeUnit
 
-import static datadog.trace.agent.test.TestUtils.runUnderTrace
 import static datadog.trace.agent.test.server.http.TestHttpServer.httpServer
+import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 import static org.asynchttpclient.Dsl.asyncHttpClient
 
 class Netty41ClientTest extends AgentTestRunner {
@@ -79,7 +79,7 @@ class Netty41ClientTest extends AgentTestRunner {
 
   def "test connection failure"() {
     setup:
-    def invalidPort = TestUtils.randomOpenPort()
+    def invalidPort = PortUtils.randomOpenPort()
 
     def responseFuture = runUnderTrace("parent") {
       asyncHttpClient.prepareGet("http://localhost:$invalidPort/").execute()

--- a/dd-java-agent/instrumentation/netty-4.1/src/test/groovy/Netty41ServerTest.groovy
+++ b/dd-java-agent/instrumentation/netty-4.1/src/test/groovy/Netty41ServerTest.groovy
@@ -1,6 +1,6 @@
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.TestUtils
 import datadog.trace.agent.test.utils.OkHttpUtils
+import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import io.netty.bootstrap.ServerBootstrap
@@ -37,7 +37,7 @@ class Netty41ServerTest extends AgentTestRunner {
   def "test server request/response"() {
     setup:
     EventLoopGroup eventLoopGroup = new NioEventLoopGroup()
-    int port = TestUtils.randomOpenPort()
+    int port = PortUtils.randomOpenPort()
     initializeServer(eventLoopGroup, port, handlers, HttpResponseStatus.OK)
 
     def request = new Request.Builder()
@@ -90,7 +90,7 @@ class Netty41ServerTest extends AgentTestRunner {
   def "test #responseCode response handling"() {
     setup:
     EventLoopGroup eventLoopGroup = new NioEventLoopGroup()
-    int port = TestUtils.randomOpenPort()
+    int port = PortUtils.randomOpenPort()
     initializeServer(eventLoopGroup, port, new HttpServerCodec(), responseCode)
 
     def request = new Request.Builder().url("http://localhost:$port/").get().build()

--- a/dd-java-agent/instrumentation/okhttp-3/src/main/java/datadog/trace/instrumentation/okhttp3/OkHttpClientSpanDecorator.java
+++ b/dd-java-agent/instrumentation/okhttp-3/src/main/java/datadog/trace/instrumentation/okhttp3/OkHttpClientSpanDecorator.java
@@ -2,6 +2,8 @@ package datadog.trace.instrumentation.okhttp3;
 
 import static io.opentracing.log.Fields.ERROR_OBJECT;
 
+import datadog.trace.api.Config;
+import datadog.trace.api.DDTags;
 import io.opentracing.Span;
 import io.opentracing.tag.Tags;
 import java.net.Inet6Address;
@@ -60,6 +62,9 @@ public interface OkHttpClientSpanDecorator {
           Tags.COMPONENT.set(span, TracingCallFactory.COMPONENT_NAME);
           Tags.HTTP_METHOD.set(span, request.method());
           Tags.HTTP_URL.set(span, request.url().toString());
+          if (Config.get().isHttpClientSplitByDomain()) {
+            span.setTag(DDTags.SERVICE_NAME, request.url().host());
+          }
         }
 
         @Override

--- a/dd-java-agent/instrumentation/okhttp-3/src/main/java/datadog/trace/instrumentation/okhttp3/TracingCallFactory.java
+++ b/dd-java-agent/instrumentation/okhttp-3/src/main/java/datadog/trace/instrumentation/okhttp3/TracingCallFactory.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.okhttp3;
 
+import datadog.trace.api.Config;
 import datadog.trace.api.DDSpanTypes;
 import datadog.trace.api.DDTags;
 import io.opentracing.Scope;
@@ -54,6 +55,10 @@ public class TracingCallFactory implements Call.Factory {
               .withTag(DDTags.SERVICE_NAME, COMPONENT_NAME)
               .withTag(DDTags.SPAN_TYPE, DDSpanTypes.HTTP_CLIENT)
               .startActive(false);
+
+      if (Config.get().isHttpClientSplitByDomain()) {
+        scope.span().setTag(DDTags.SERVICE_NAME, request.url().host());
+      }
 
       /** In case of exception network interceptor is not called */
       final OkHttpClient.Builder okBuilder = okHttpClient.newBuilder();

--- a/dd-java-agent/instrumentation/okhttp-3/src/test/groovy/OkHttp3Test.groovy
+++ b/dd-java-agent/instrumentation/okhttp-3/src/test/groovy/OkHttp3Test.groovy
@@ -5,10 +5,8 @@ import io.opentracing.tag.Tags
 import okhttp3.OkHttpClient
 import okhttp3.Request
 
-import static datadog.trace.agent.test.TestUtils.setFinal
-import static datadog.trace.agent.test.TestUtils.setFinalStatic
-import static datadog.trace.agent.test.TestUtils.withSystemProperty
 import static datadog.trace.agent.test.server.http.TestHttpServer.httpServer
+import static datadog.trace.agent.test.utils.TraceUtils.withConfigOverride
 
 class OkHttp3Test extends AgentTestRunner {
 
@@ -26,8 +24,7 @@ class OkHttp3Test extends AgentTestRunner {
       .url("http://localhost:$server.address.port/ping")
       .build()
 
-    def response = withSystemProperty("dd.$Config.HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN", "$renameService") {
-      resetConfig()
+    def response = withConfigOverride("dd.$Config.HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN", "$renameService") {
       client.newCall(request).execute()
     }
 
@@ -78,11 +75,5 @@ class OkHttp3Test extends AgentTestRunner {
 
     where:
     renameService << [false, true]
-  }
-
-  def resetConfig() {
-    def runtimeId = Config.get().runtimeId
-    setFinalStatic(Config.getDeclaredField("INSTANCE"), new Config())
-    setFinal(Config.getDeclaredField("runtimeId"), Config.get(), runtimeId)
   }
 }

--- a/dd-java-agent/instrumentation/play-2.4/src/latestDepTest/groovy/Play26Test.groovy
+++ b/dd-java-agent/instrumentation/play-2.4/src/latestDepTest/groovy/Play26Test.groovy
@@ -1,6 +1,6 @@
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.TestUtils
 import datadog.trace.agent.test.utils.OkHttpUtils
+import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
 import okhttp3.Request
 import play.api.test.TestServer
@@ -21,7 +21,7 @@ class Play26Test extends AgentTestRunner {
   def client = OkHttpUtils.client()
 
   def setupSpec() {
-    port = TestUtils.randomOpenPort()
+    port = PortUtils.randomOpenPort()
     testServer = Helpers.testServer(port, Play26TestUtils.buildTestApp())
     testServer.start()
   }

--- a/dd-java-agent/instrumentation/play-2.4/src/test/groovy/Play24Test.groovy
+++ b/dd-java-agent/instrumentation/play-2.4/src/test/groovy/Play24Test.groovy
@@ -1,7 +1,7 @@
 import datadog.opentracing.DDSpan
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.TestUtils
 import datadog.trace.agent.test.utils.OkHttpUtils
+import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
 import okhttp3.Request
 import play.api.test.TestServer
@@ -18,7 +18,7 @@ class Play24Test extends AgentTestRunner {
   def client = OkHttpUtils.client()
 
   def setupSpec() {
-    port = TestUtils.randomOpenPort()
+    port = PortUtils.randomOpenPort()
     testServer = Helpers.testServer(port, Play24TestUtils.buildTestApp())
     testServer.start()
   }

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/test/groovy/RabbitMQTest.groovy
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/test/groovy/RabbitMQTest.groovy
@@ -25,7 +25,7 @@ import spock.lang.Shared
 
 import java.util.concurrent.Phaser
 
-import static datadog.trace.agent.test.TestUtils.runUnderTrace
+import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 
 // Do not run tests locally on Java7 since testcontainers are not compatible with Java7
 // It is fine to run on CI because CI provides rabbitmq externally, not through testcontainers

--- a/dd-java-agent/instrumentation/servlet-2/src/test/groovy/JettyServlet2Test.groovy
+++ b/dd-java-agent/instrumentation/servlet-2/src/test/groovy/JettyServlet2Test.groovy
@@ -1,6 +1,6 @@
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.TestUtils
 import datadog.trace.agent.test.utils.OkHttpUtils
+import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import okhttp3.Credentials
@@ -35,7 +35,7 @@ class JettyServlet2Test extends AgentTestRunner {
   private ServletContextHandler servletContext
 
   def setup() {
-    port = TestUtils.randomOpenPort()
+    port = PortUtils.randomOpenPort()
     jettyServer = new Server(port)
     servletContext = new ServletContextHandler()
     servletContext.contextPath = "/ctx"

--- a/dd-java-agent/instrumentation/servlet-3/src/test/groovy/AbstractServlet3Test.groovy
+++ b/dd-java-agent/instrumentation/servlet-3/src/test/groovy/AbstractServlet3Test.groovy
@@ -1,6 +1,6 @@
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.TestUtils
 import datadog.trace.agent.test.utils.OkHttpUtils
+import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import okhttp3.Credentials
@@ -30,7 +30,7 @@ abstract class AbstractServlet3Test<CONTEXT> extends AgentTestRunner {
     .build()
 
   @Shared
-  int port = TestUtils.randomOpenPort()
+  int port = PortUtils.randomOpenPort()
   @Shared
   protected String user = "user"
   @Shared

--- a/dd-java-agent/instrumentation/servlet-3/src/test/groovy/JettyServlet3Test.groovy
+++ b/dd-java-agent/instrumentation/servlet-3/src/test/groovy/JettyServlet3Test.groovy
@@ -1,4 +1,4 @@
-import datadog.trace.agent.test.TestUtils
+import datadog.trace.agent.test.utils.PortUtils
 import org.eclipse.jetty.security.ConstraintMapping
 import org.eclipse.jetty.security.ConstraintSecurityHandler
 import org.eclipse.jetty.security.HashLoginService
@@ -17,7 +17,7 @@ class JettyServlet3Test extends AbstractServlet3Test<ServletContextHandler> {
   private Server jettyServer
 
   def setupSpec() {
-    port = TestUtils.randomOpenPort()
+    port = PortUtils.randomOpenPort()
     jettyServer = new Server(port)
 
     ServletContextHandler servletContext = new ServletContextHandler(null, "/$context")

--- a/dd-java-agent/instrumentation/slf4j-mdc/src/main/java/datadog/trace/instrumentation/slf4j/mdc/MDCInjectionInstrumentation.java
+++ b/dd-java-agent/instrumentation/slf4j-mdc/src/main/java/datadog/trace/instrumentation/slf4j/mdc/MDCInjectionInstrumentation.java
@@ -34,10 +34,8 @@ public class MDCInjectionInstrumentation extends Instrumenter.Default {
 
   @Override
   protected boolean defaultEnabled() {
-    final String enableInjection = getPropOrEnv("dd." + Config.LOGS_INJECTION_ENABLED);
-    return null == enableInjection
-        ? Config.DEFAULT_LOGS_INJECTION_ENABLED
-        : Boolean.parseBoolean(enableInjection);
+    return Config.getBooleanSettingFromEnvironment(
+        Config.LOGS_INJECTION_ENABLED, Config.DEFAULT_LOGS_INJECTION_ENABLED);
   }
 
   @Override

--- a/dd-java-agent/instrumentation/sparkjava-2.3/src/test/groovy/SparkJavaBasedTest.groovy
+++ b/dd-java-agent/instrumentation/sparkjava-2.3/src/test/groovy/SparkJavaBasedTest.groovy
@@ -1,6 +1,6 @@
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.TestUtils
 import datadog.trace.agent.test.utils.OkHttpUtils
+import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import okhttp3.OkHttpClient
@@ -21,7 +21,7 @@ class SparkJavaBasedTest extends AgentTestRunner {
   OkHttpClient client = OkHttpUtils.client()
 
   def setupSpec() {
-    port = TestUtils.randomOpenPort()
+    port = PortUtils.randomOpenPort()
     TestSparkJavaApplication.initSpark(port)
   }
 

--- a/dd-java-agent/instrumentation/spymemcached-2.12/src/test/groovy/datadog/trace/instrumentation/spymemcached/SpymemcachedTest.groovy
+++ b/dd-java-agent/instrumentation/spymemcached-2.12/src/test/groovy/datadog/trace/instrumentation/spymemcached/SpymemcachedTest.groovy
@@ -26,7 +26,7 @@ import java.util.concurrent.locks.ReentrantLock
 import static CompletionListener.COMPONENT_NAME
 import static CompletionListener.OPERATION_NAME
 import static CompletionListener.SERVICE_NAME
-import static datadog.trace.agent.test.TestUtils.runUnderTrace
+import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 import static net.spy.memcached.ConnectionFactoryBuilder.Protocol.BINARY
 
 // Do not run tests locally on Java7 since testcontainers are not compatible with Java7

--- a/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceAnnotationsInstrumentation.java
+++ b/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceAnnotationsInstrumentation.java
@@ -10,6 +10,7 @@ import static net.bytebuddy.matcher.ElementMatchers.named;
 import com.google.auto.service.AutoService;
 import com.google.common.collect.Sets;
 import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.api.Config;
 import datadog.trace.api.Trace;
 import java.util.Collections;
 import java.util.Map;
@@ -23,7 +24,6 @@ import net.bytebuddy.matcher.ElementMatcher;
 @Slf4j
 @AutoService(Instrumenter.class)
 public final class TraceAnnotationsInstrumentation extends Instrumenter.Default {
-  private static final String CONFIG_NAME = "dd.trace.annotations";
 
   static final String CONFIG_FORMAT =
       "(?:\\s*"
@@ -47,7 +47,7 @@ public final class TraceAnnotationsInstrumentation extends Instrumenter.Default 
   public TraceAnnotationsInstrumentation() {
     super("trace", "trace-annotation");
 
-    final String configString = getPropOrEnv(CONFIG_NAME);
+    final String configString = Config.getSettingFromEnvironment(Config.TRACE_ANNOTATIONS, null);
     if (configString == null) {
       additionalTraceAnnotations =
           Collections.unmodifiableSet(Sets.<String>newHashSet(DEFAULT_ANNOTATIONS));

--- a/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceConfigInstrumentation.java
+++ b/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceConfigInstrumentation.java
@@ -7,6 +7,7 @@ import com.google.auto.service.AutoService;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.api.Config;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -29,7 +30,6 @@ import net.bytebuddy.matcher.ElementMatcher;
 @Slf4j
 @AutoService(Instrumenter.class)
 public class TraceConfigInstrumentation implements Instrumenter {
-  private static final String CONFIG_NAME = "dd.trace.methods";
 
   static final String PACKAGE_CLASS_NAME_REGEX = "[\\w.\\$]+";
   private static final String METHOD_LIST_REGEX = "\\s*(?:\\w+\\s*,)*\\s*(?:\\w+\\s*,?)\\s*";
@@ -47,7 +47,7 @@ public class TraceConfigInstrumentation implements Instrumenter {
   private final Map<String, Set<String>> classMethodsToTrace;
 
   public TraceConfigInstrumentation() {
-    final String configString = Default.getPropOrEnv(CONFIG_NAME);
+    final String configString = Config.getSettingFromEnvironment(Config.TRACE_METHODS, null);
     if (configString == null || configString.trim().isEmpty()) {
       classMethodsToTrace = Collections.emptyMap();
 

--- a/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/ConfiguredTraceAnnotationsTest.groovy
+++ b/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/ConfiguredTraceAnnotationsTest.groovy
@@ -5,7 +5,7 @@ import dd.test.trace.annotation.SayTracedHello
 import java.util.concurrent.Callable
 
 import static TraceAnnotationsInstrumentation.DEFAULT_ANNOTATIONS
-import static datadog.trace.agent.test.TestUtils.withSystemProperty
+import static datadog.trace.agent.test.utils.TraceUtils.withSystemProperty
 
 class ConfiguredTraceAnnotationsTest extends AgentTestRunner {
 

--- a/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/TraceConfigTest.groovy
+++ b/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/TraceConfigTest.groovy
@@ -3,7 +3,7 @@ import datadog.trace.instrumentation.trace_annotation.TraceConfigInstrumentation
 
 import java.util.concurrent.Callable
 
-import static datadog.trace.agent.test.TestUtils.withSystemProperty
+import static datadog.trace.agent.test.utils.TraceUtils.withSystemProperty
 
 class TraceConfigTest extends AgentTestRunner {
 

--- a/dd-java-agent/instrumentation/vertx/src/test/groovy/VertxHttpClientTest.groovy
+++ b/dd-java-agent/instrumentation/vertx/src/test/groovy/VertxHttpClientTest.groovy
@@ -1,5 +1,5 @@
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.TestUtils
+import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import io.netty.channel.AbstractChannel
@@ -15,8 +15,8 @@ import spock.lang.Shared
 
 import java.util.concurrent.CompletableFuture
 
-import static datadog.trace.agent.test.TestUtils.runUnderTrace
 import static datadog.trace.agent.test.server.http.TestHttpServer.httpServer
+import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 
 class VertxHttpClientTest extends AgentTestRunner {
 
@@ -50,10 +50,10 @@ class VertxHttpClientTest extends AgentTestRunner {
     def responseFuture = new CompletableFuture<HttpClientResponse>()
     def messageFuture = new CompletableFuture<String>()
     httpClient.getNow(server.address.port, server.address.host, "/" + route, { response ->
-        responseFuture.complete(response)
-        response.bodyHandler({buffer ->
-          messageFuture.complete(buffer.toString())
-        })
+      responseFuture.complete(response)
+      response.bodyHandler({ buffer ->
+        messageFuture.complete(buffer.toString())
+      })
     })
 
     when:
@@ -102,7 +102,7 @@ class VertxHttpClientTest extends AgentTestRunner {
 
   def "test connection failure"() {
     setup:
-    def invalidPort = TestUtils.randomOpenPort()
+    def invalidPort = PortUtils.randomOpenPort()
 
     def errorFuture = new CompletableFuture<Throwable>()
 

--- a/dd-java-agent/instrumentation/vertx/src/test/groovy/VertxServerTest.groovy
+++ b/dd-java-agent/instrumentation/vertx/src/test/groovy/VertxServerTest.groovy
@@ -1,6 +1,6 @@
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.TestUtils
 import datadog.trace.agent.test.utils.OkHttpUtils
+import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import io.netty.handler.codec.http.HttpResponseStatus
@@ -21,7 +21,7 @@ class VertxServerTest extends AgentTestRunner {
   Vertx server
 
   def setupSpec() {
-    port = TestUtils.randomOpenPort()
+    port = PortUtils.randomOpenPort()
     server = VertxWebTestServer.start(port)
   }
 
@@ -110,7 +110,7 @@ class VertxServerTest extends AgentTestRunner {
     }
 
     where:
-    responseCode                             | name         | path           | error
+    responseCode                             | name         | path          | error
     HttpResponseStatus.OK                    | "GET /"      | ""            | false
     HttpResponseStatus.NOT_FOUND             | "404"        | "doesnt-exit" | false
     HttpResponseStatus.INTERNAL_SERVER_ERROR | "GET /error" | "error"       | true

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/AgentTestRunner.java
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/AgentTestRunner.java
@@ -6,6 +6,7 @@ import com.google.common.collect.Sets;
 import datadog.opentracing.DDSpan;
 import datadog.opentracing.DDTracer;
 import datadog.trace.agent.test.asserts.ListWriterAssert;
+import datadog.trace.agent.test.utils.GlobalTracerUtils;
 import datadog.trace.agent.tooling.AgentInstaller;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.GlobalTracer;
@@ -88,7 +89,7 @@ public abstract class AgentTestRunner extends Specification {
           }
         };
     TEST_TRACER = new DDTracer(TEST_WRITER);
-    TestUtils.registerOrReplaceGlobalTracer((Tracer) TEST_TRACER);
+    GlobalTracerUtils.registerOrReplaceGlobalTracer((Tracer) TEST_TRACER);
     GlobalTracer.registerIfAbsent((datadog.trace.api.Tracer) TEST_TRACER);
   }
 

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/SpockRunner.java
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/SpockRunner.java
@@ -1,6 +1,7 @@
 package datadog.trace.agent.test;
 
 import com.google.common.reflect.ClassPath;
+import datadog.trace.agent.test.utils.ClasspathUtils;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
@@ -148,14 +149,14 @@ public class SpockRunner extends Sputnik {
 
   private static File createBootstrapJar() throws IOException {
     final Set<String> bootstrapClasses = new HashSet<>();
-    for (final ClassPath.ClassInfo info : TestUtils.getTestClasspath().getAllClasses()) {
+    for (final ClassPath.ClassInfo info : ClasspathUtils.getTestClasspath().getAllClasses()) {
       // if info starts with bootstrap prefix: add to bootstrap jar
       if (isBootstrapClass(info.getName())) {
         bootstrapClasses.add(info.getResourceName());
       }
     }
     return new File(
-        TestUtils.createJarWithClasses(
+        ClasspathUtils.createJarWithClasses(
                 AgentTestRunner.class.getClassLoader(), bootstrapClasses.toArray(new String[0]))
             .getFile());
   }

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/server/http/TestHttpServer.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/server/http/TestHttpServer.groovy
@@ -1,8 +1,8 @@
 package datadog.trace.agent.test.server.http
 
 import datadog.opentracing.DDSpan
-import datadog.trace.agent.test.TestUtils
 import datadog.trace.agent.test.asserts.ListWriterAssert
+import datadog.trace.agent.test.utils.PortUtils
 import io.opentracing.SpanContext
 import io.opentracing.Tracer
 import io.opentracing.propagation.Format
@@ -45,7 +45,7 @@ class TestHttpServer implements AutoCloseable {
   private final AtomicReference<HandlerApi.RequestApi> last = new AtomicReference<>()
 
   private TestHttpServer() {
-    int port = TestUtils.randomOpenPort()
+    int port = PortUtils.randomOpenPort()
     internalServer = new Server(port)
     internalServer.stopAtShutdown = true
     address = new URI("http://localhost:$port")

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/utils/ClasspathUtils.java
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/utils/ClasspathUtils.java
@@ -1,129 +1,28 @@
-package datadog.trace.agent.test;
+package datadog.trace.agent.test.utils;
 
 import static com.google.common.base.StandardSystemProperty.JAVA_CLASS_PATH;
 import static com.google.common.base.StandardSystemProperty.PATH_SEPARATOR;
-import static io.opentracing.log.Fields.ERROR_OBJECT;
 
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.reflect.ClassPath;
+import datadog.trace.agent.test.AgentTestRunner;
 import datadog.trace.agent.tooling.Utils;
-import datadog.trace.context.TraceScope;
-import io.opentracing.Scope;
-import io.opentracing.Span;
-import io.opentracing.Tracer;
-import io.opentracing.tag.Tags;
-import io.opentracing.util.GlobalTracer;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
 import java.net.MalformedURLException;
-import java.net.ServerSocket;
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.util.Collections;
 import java.util.UUID;
-import java.util.concurrent.Callable;
 import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
 import java.util.jar.Manifest;
-import lombok.SneakyThrows;
 
-public class TestUtils {
+public class ClasspathUtils {
   private static final ClassPath testClasspath = computeTestClasspath();
-
-  public static void registerOrReplaceGlobalTracer(final Tracer tracer) {
-    try {
-      GlobalTracer.register(tracer);
-    } catch (final Exception e) {
-      // Force it anyway using reflection
-      Field field = null;
-      try {
-        field = GlobalTracer.class.getDeclaredField("tracer");
-        field.setAccessible(true);
-        field.set(null, tracer);
-      } catch (final Exception e2) {
-        throw new IllegalStateException(e2);
-      } finally {
-        if (null != field) {
-          field.setAccessible(false);
-        }
-      }
-    }
-
-    if (!GlobalTracer.isRegistered()) {
-      throw new RuntimeException("Unable to register the global tracer.");
-    }
-  }
-
-  /** Get the tracer implementation out of the GlobalTracer */
-  public static Tracer getUnderlyingGlobalTracer() {
-    Field field = null;
-    try {
-      field = GlobalTracer.class.getDeclaredField("tracer");
-      field.setAccessible(true);
-      return (Tracer) field.get(GlobalTracer.get());
-    } catch (final Exception e2) {
-      throw new IllegalStateException(e2);
-    } finally {
-      if (null != field) {
-        field.setAccessible(false);
-      }
-    }
-  }
-
-  public static void setFinalStatic(final Field field, final Object newValue) throws Exception {
-    setFinal(field, null, newValue);
-  }
-
-  public static void setFinal(final Field field, final Object instance, final Object newValue)
-      throws Exception {
-    field.setAccessible(true);
-
-    final Field modifiersField = Field.class.getDeclaredField("modifiers");
-    modifiersField.setAccessible(true);
-    modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
-
-    field.set(instance, newValue);
-  }
-
-  @SneakyThrows
-  public static <T extends Object> Object withSystemProperty(
-      final String name, final String value, final Callable<T> r) {
-    if (value == null) {
-      System.clearProperty(name);
-    } else {
-      System.setProperty(name, value);
-    }
-    try {
-      return r.call();
-    } finally {
-      System.clearProperty(name);
-    }
-  }
-
-  public static <T extends Object> Object runUnderTrace(
-      final String rootOperationName, final Callable<T> r) throws Exception {
-    final Scope scope = GlobalTracer.get().buildSpan(rootOperationName).startActive(true);
-    ((TraceScope) scope).setAsyncPropagation(true);
-
-    try {
-      return r.call();
-    } catch (final Exception e) {
-      final Span span = scope.span();
-      Tags.ERROR.set(span, true);
-      span.log(Collections.singletonMap(ERROR_OBJECT, e));
-
-      throw e;
-    } finally {
-      ((TraceScope) scope).setAsyncPropagation(false);
-      scope.close();
-    }
-  }
 
   public static byte[] convertToByteArray(final InputStream resource) throws IOException {
     final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
@@ -217,20 +116,6 @@ public class TestUtils {
     jarOutputStream.putNextEntry(entry);
     jarOutputStream.write(bytes, 0, bytes.length);
     jarOutputStream.closeEntry();
-  }
-
-  /** Open up a random, reusable port. */
-  public static int randomOpenPort() {
-    final ServerSocket socket;
-    try {
-      socket = new ServerSocket(0);
-      socket.setReuseAddress(true);
-      socket.close();
-      return socket.getLocalPort();
-    } catch (final IOException ioe) {
-      ioe.printStackTrace();
-      return -1;
-    }
   }
 
   public static ClassPath getTestClasspath() {

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/utils/GlobalTracerUtils.java
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/utils/GlobalTracerUtils.java
@@ -1,0 +1,47 @@
+package datadog.trace.agent.test.utils;
+
+import io.opentracing.Tracer;
+import io.opentracing.util.GlobalTracer;
+import java.lang.reflect.Field;
+
+public class GlobalTracerUtils {
+  public static void registerOrReplaceGlobalTracer(final Tracer tracer) {
+    try {
+      GlobalTracer.register(tracer);
+    } catch (final Exception e) {
+      // Force it anyway using reflection
+      Field field = null;
+      try {
+        field = GlobalTracer.class.getDeclaredField("tracer");
+        field.setAccessible(true);
+        field.set(null, tracer);
+      } catch (final Exception e2) {
+        throw new IllegalStateException(e2);
+      } finally {
+        if (null != field) {
+          field.setAccessible(false);
+        }
+      }
+    }
+
+    if (!GlobalTracer.isRegistered()) {
+      throw new RuntimeException("Unable to register the global tracer.");
+    }
+  }
+
+  /** Get the tracer implementation out of the GlobalTracer */
+  public static Tracer getUnderlyingGlobalTracer() {
+    Field field = null;
+    try {
+      field = GlobalTracer.class.getDeclaredField("tracer");
+      field.setAccessible(true);
+      return (Tracer) field.get(GlobalTracer.get());
+    } catch (final Exception e2) {
+      throw new IllegalStateException(e2);
+    } finally {
+      if (null != field) {
+        field.setAccessible(false);
+      }
+    }
+  }
+}

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/utils/PortUtils.java
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/utils/PortUtils.java
@@ -1,0 +1,21 @@
+package datadog.trace.agent.test.utils;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+
+public class PortUtils {
+
+  /** Open up a random, reusable port. */
+  public static int randomOpenPort() {
+    final ServerSocket socket;
+    try {
+      socket = new ServerSocket(0);
+      socket.setReuseAddress(true);
+      socket.close();
+      return socket.getLocalPort();
+    } catch (final IOException ioe) {
+      ioe.printStackTrace();
+      return -1;
+    }
+  }
+}

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/utils/TraceUtils.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/utils/TraceUtils.groovy
@@ -70,7 +70,7 @@ class TraceUtils {
   private static void setFinal(final Field field, final Object instance, final Object newValue) throws Exception {
     field.setAccessible(true)
 
-    final Field modifiersField = Field.class.getDeclaredField("modifiers")
+    final Field modifiersField = Field.getDeclaredField("modifiers")
     modifiersField.setAccessible(true)
     modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL)
 

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/utils/TraceUtils.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/utils/TraceUtils.groovy
@@ -1,0 +1,79 @@
+package datadog.trace.agent.test.utils
+
+import datadog.trace.api.Config
+import datadog.trace.context.TraceScope
+import io.opentracing.Scope
+import io.opentracing.Span
+import io.opentracing.tag.Tags
+import io.opentracing.util.GlobalTracer
+import lombok.SneakyThrows
+
+import java.lang.reflect.Field
+import java.lang.reflect.Modifier
+import java.util.concurrent.Callable
+
+import static io.opentracing.log.Fields.ERROR_OBJECT
+
+class TraceUtils {
+
+  @SneakyThrows
+  static <T extends Object> Object runUnderTrace(final String rootOperationName, final Callable<T> r) {
+    final Scope scope = GlobalTracer.get().buildSpan(rootOperationName).startActive(true)
+    ((TraceScope) scope).setAsyncPropagation(true)
+
+    try {
+      return r.call()
+    } catch (final Exception e) {
+      final Span span = scope.span()
+      Tags.ERROR.set(span, true)
+      span.log(Collections.singletonMap(ERROR_OBJECT, e))
+
+      throw e
+    } finally {
+      ((TraceScope) scope).setAsyncPropagation(false)
+      scope.close()
+    }
+  }
+
+  @SneakyThrows
+  static <T extends Object> Object withSystemProperty(final String name, final String value, final Callable<T> r) {
+    if (value == null) {
+      System.clearProperty(name)
+    } else {
+      System.setProperty(name, value)
+    }
+    try {
+      return r.call()
+    } finally {
+      System.clearProperty(name)
+    }
+  }
+
+  @SneakyThrows
+  static <T extends Object> Object withConfigOverride(final String name, final String value, final Callable<T> r) {
+    return withSystemProperty(name, value) {
+      def existingConfig = Config.get()  // We can't reference INSTANCE directly or the reflection below will fail.
+      setFinalStatic(Config.getDeclaredField("INSTANCE"), new Config())
+      setFinal(Config.getDeclaredField("runtimeId"), Config.get(), existingConfig.runtimeId)
+      try {
+        return r.call()
+      } finally {
+        setFinalStatic(Config.getDeclaredField("INSTANCE"), existingConfig)
+      }
+    }
+  }
+
+  private static void setFinalStatic(final Field field, final Object newValue) throws Exception {
+    setFinal(field, null, newValue)
+  }
+
+  private static void setFinal(final Field field, final Object instance, final Object newValue) throws Exception {
+    field.setAccessible(true)
+
+    final Field modifiersField = Field.class.getDeclaredField("modifiers")
+    modifiersField.setAccessible(true)
+    modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL)
+
+    field.set(instance, newValue)
+  }
+}

--- a/dd-java-agent/testing/src/test/groovy/AgentTestRunnerTest.groovy
+++ b/dd-java-agent/testing/src/test/groovy/AgentTestRunnerTest.groovy
@@ -1,7 +1,8 @@
 import com.google.common.reflect.ClassPath
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.SpockRunner
-import datadog.trace.agent.test.TestUtils
+import datadog.trace.agent.test.utils.ClasspathUtils
+import datadog.trace.agent.test.utils.GlobalTracerUtils
 import datadog.trace.agent.tooling.Constants
 import io.opentracing.Span
 import io.opentracing.Tracer
@@ -35,7 +36,7 @@ class AgentTestRunnerTest extends AgentTestRunner {
   def "classpath setup"() {
     setup:
     final List<String> bootstrapClassesIncorrectlyLoaded = []
-    for (ClassPath.ClassInfo info : TestUtils.getTestClasspath().getAllClasses()) {
+    for (ClassPath.ClassInfo info : ClasspathUtils.getTestClasspath().getAllClasses()) {
       for (int i = 0; i < Constants.BOOTSTRAP_PACKAGE_PREFIXES.length; ++i) {
         if (info.getName().startsWith(Constants.BOOTSTRAP_PACKAGE_PREFIXES[i])) {
           Class<?> bootstrapClass = Class.forName(info.getName())
@@ -52,9 +53,9 @@ class AgentTestRunnerTest extends AgentTestRunner {
     sharedSpanClass.getClassLoader() == BOOTSTRAP_CLASSLOADER
     Tracer.getClassLoader() == BOOTSTRAP_CLASSLOADER
     !AGENT_INSTALLED_IN_CLINIT
-    getTestTracer() == TestUtils.getUnderlyingGlobalTracer()
+    getTestTracer() == GlobalTracerUtils.getUnderlyingGlobalTracer()
     getAgentTransformer() != null
-    TestUtils.getUnderlyingGlobalTracer() == datadog.trace.api.GlobalTracer.get()
+    GlobalTracerUtils.getUnderlyingGlobalTracer() == datadog.trace.api.GlobalTracer.get()
     bootstrapClassesIncorrectlyLoaded == []
   }
 

--- a/dd-java-agent/testing/src/test/groovy/context/FieldBackedProviderTest.groovy
+++ b/dd-java-agent/testing/src/test/groovy/context/FieldBackedProviderTest.groovy
@@ -1,7 +1,7 @@
 package context
 
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.TestUtils
+import datadog.trace.agent.test.utils.ClasspathUtils
 import datadog.trace.api.Config
 import datadog.trace.util.gc.GCUtils
 import net.bytebuddy.agent.ByteBuddyAgent
@@ -128,8 +128,8 @@ class FieldBackedProviderTest extends AgentTestRunner {
 
   def "context classes are redefine safe"() {
     when:
-    ByteBuddyAgent.getInstrumentation().redefineClasses(new ClassDefinition(KeyClass, TestUtils.convertToByteArray(KeyClass)))
-    ByteBuddyAgent.getInstrumentation().redefineClasses(new ClassDefinition(UntransformableKeyClass, TestUtils.convertToByteArray(UntransformableKeyClass)))
+    ByteBuddyAgent.getInstrumentation().redefineClasses(new ClassDefinition(KeyClass, ClasspathUtils.convertToByteArray(KeyClass)))
+    ByteBuddyAgent.getInstrumentation().redefineClasses(new ClassDefinition(UntransformableKeyClass, ClasspathUtils.convertToByteArray(UntransformableKeyClass)))
 
     then:
     new KeyClass().isInstrumented()

--- a/dd-java-agent/testing/src/test/groovy/muzzle/ReferenceMatcherTest.groovy
+++ b/dd-java-agent/testing/src/test/groovy/muzzle/ReferenceMatcherTest.groovy
@@ -1,7 +1,7 @@
 package muzzle
 
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.TestUtils
+import datadog.trace.agent.test.utils.ClasspathUtils
 import datadog.trace.agent.tooling.muzzle.Reference
 import datadog.trace.agent.tooling.muzzle.Reference.Source
 import datadog.trace.agent.tooling.muzzle.ReferenceCreator
@@ -24,14 +24,14 @@ import static muzzle.TestClasses.MethodBodyAdvice
 class ReferenceMatcherTest extends AgentTestRunner {
 
   @Shared
-  ClassLoader safeClasspath = new URLClassLoader([TestUtils.createJarWithClasses(MethodBodyAdvice.A,
+  ClassLoader safeClasspath = new URLClassLoader([ClasspathUtils.createJarWithClasses(MethodBodyAdvice.A,
     MethodBodyAdvice.B,
     MethodBodyAdvice.SomeInterface,
     MethodBodyAdvice.SomeImplementation)] as URL[],
     (ClassLoader) null)
 
   @Shared
-  ClassLoader unsafeClasspath = new URLClassLoader([TestUtils.createJarWithClasses(MethodBodyAdvice.A,
+  ClassLoader unsafeClasspath = new URLClassLoader([ClasspathUtils.createJarWithClasses(MethodBodyAdvice.A,
     MethodBodyAdvice.SomeInterface,
     MethodBodyAdvice.SomeImplementation)] as URL[],
     (ClassLoader) null)
@@ -68,7 +68,7 @@ class ReferenceMatcherTest extends AgentTestRunner {
   def "muzzle type pool caches"() {
     setup:
     ClassLoader cl = new CountingClassLoader(
-      [TestUtils.createJarWithClasses(MethodBodyAdvice.A,
+      [ClasspathUtils.createJarWithClasses(MethodBodyAdvice.A,
         MethodBodyAdvice.B,
         MethodBodyAdvice.SomeInterface,
         MethodBodyAdvice.SomeImplementation)] as URL[],

--- a/dd-java-agent/testing/testing.gradle
+++ b/dd-java-agent/testing/testing.gradle
@@ -5,8 +5,7 @@ minimumInstructionCoverage = 0.5
 excludedClassesConverage += [
   'datadog.trace.agent.test.asserts.*Assert',
   'datadog.trace.agent.test.AgentTestRunner.ErrorCountingListener',
-  'datadog.trace.agent.test.OkHttpUtils',
-  'datadog.trace.agent.test.TestUtils',
+  'datadog.trace.agent.test.utils.*',
   // Avoid applying jacoco instrumentation to classes instrumented by tested agent
   'context.ContextTestInstrumentation**',
 ]

--- a/dd-trace-api/src/main/java/datadog/trace/api/Config.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/Config.java
@@ -41,6 +41,7 @@ public class Config {
   public static final String SPAN_TAGS = "trace.span.tags";
   public static final String JMX_TAGS = "trace.jmx.tags";
   public static final String HEADER_TAGS = "trace.header.tags";
+  public static final String HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN = "trace.http.client.split-by-domain";
   public static final String PARTIAL_FLUSH_MIN_SPANS = "trace.partial.flush.min.spans";
   public static final String RUNTIME_CONTEXT_FIELD_INJECTION =
       "trace.runtime.context.field.injection";
@@ -71,6 +72,7 @@ public class Config {
 
   private static final boolean DEFAULT_PRIORITY_SAMPLING_ENABLED = true;
   private static final boolean DEFAULT_TRACE_RESOLVER_ENABLED = true;
+  private static final boolean DEFAULT_HTTP_CLIENT_SPLIT_BY_DOMAIN = false;
   private static final int DEFAULT_MAX_TRACE_SIZE_BEFORE_PARTIAL_FLUSH = 0;
   private static final boolean DEFAULT_JMX_FETCH_ENABLED = false;
 
@@ -95,6 +97,7 @@ public class Config {
   private final Map<String, String> spanTags;
   private final Map<String, String> jmxTags;
   @Getter private final Map<String, String> headerTags;
+  @Getter private final boolean httpClientSplitByDomain;
   @Getter private final Integer partialFlushMinSpans;
   @Getter private final boolean runtimeContextFieldInjection;
   @Getter private final boolean jmxFetchEnabled;
@@ -128,6 +131,10 @@ public class Config {
     spanTags = getMapSettingFromEnvironment(SPAN_TAGS, null);
     jmxTags = getMapSettingFromEnvironment(JMX_TAGS, null);
     headerTags = getMapSettingFromEnvironment(HEADER_TAGS, null);
+
+    httpClientSplitByDomain =
+        getBooleanSettingFromEnvironment(
+            HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN, DEFAULT_HTTP_CLIENT_SPLIT_BY_DOMAIN);
 
     partialFlushMinSpans =
         getIntegerSettingFromEnvironment(
@@ -176,6 +183,10 @@ public class Config {
     spanTags = getPropertyMapValue(properties, SPAN_TAGS, parent.spanTags);
     jmxTags = getPropertyMapValue(properties, JMX_TAGS, parent.jmxTags);
     headerTags = getPropertyMapValue(properties, HEADER_TAGS, parent.headerTags);
+
+    httpClientSplitByDomain =
+        getBooleanSettingFromEnvironment(
+            HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN, DEFAULT_HTTP_CLIENT_SPLIT_BY_DOMAIN);
 
     partialFlushMinSpans =
         getPropertyIntegerValue(properties, PARTIAL_FLUSH_MIN_SPANS, parent.partialFlushMinSpans);
@@ -243,7 +254,7 @@ public class Config {
     return Collections.unmodifiableMap(result);
   }
 
-  private static String getSettingFromEnvironment(final String name, final String defaultValue) {
+  public static String getSettingFromEnvironment(final String name, final String defaultValue) {
     final String completeName = PREFIX + name;
     final String value =
         System.getProperties()
@@ -261,7 +272,7 @@ public class Config {
     return parseList(getSettingFromEnvironment(name, defaultValue));
   }
 
-  private static Boolean getBooleanSettingFromEnvironment(
+  public static Boolean getBooleanSettingFromEnvironment(
       final String name, final Boolean defaultValue) {
     final String value = getSettingFromEnvironment(name, null);
     return value == null ? defaultValue : Boolean.valueOf(value);

--- a/dd-trace-api/src/main/java/datadog/trace/api/Config.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/Config.java
@@ -40,6 +40,8 @@ public class Config {
   public static final String GLOBAL_TAGS = "trace.global.tags";
   public static final String SPAN_TAGS = "trace.span.tags";
   public static final String JMX_TAGS = "trace.jmx.tags";
+  public static final String TRACE_ANNOTATIONS = "trace.annotations";
+  public static final String TRACE_METHODS = "trace.methods";
   public static final String HEADER_TAGS = "trace.header.tags";
   public static final String HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN = "trace.http.client.split-by-domain";
   public static final String PARTIAL_FLUSH_MIN_SPANS = "trace.partial.flush.min.spans";

--- a/dd-trace-api/src/main/java/datadog/trace/api/Config.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/Config.java
@@ -256,6 +256,15 @@ public class Config {
     return Collections.unmodifiableMap(result);
   }
 
+  /**
+   * Helper method that takes the name, adds a "dd." prefix then checks for System Properties of
+   * that name. If none found, the name is converted to an Environment Variable and used to check
+   * the env. If setting not configured in either location, defaultValue is returned.
+   *
+   * @param name
+   * @param defaultValue
+   * @return
+   */
   public static String getSettingFromEnvironment(final String name, final String defaultValue) {
     final String completeName = PREFIX + name;
     final String value =
@@ -274,6 +283,13 @@ public class Config {
     return parseList(getSettingFromEnvironment(name, defaultValue));
   }
 
+  /**
+   * Calls {@link #getSettingFromEnvironment(String, String)} and converts the result to a Boolean.
+   *
+   * @param name
+   * @param defaultValue
+   * @return
+   */
   public static Boolean getBooleanSettingFromEnvironment(
       final String name, final Boolean defaultValue) {
     final String value = getSettingFromEnvironment(name, null);


### PR DESCRIPTION
This will allow better metric collection and identification of trends for individual services/hosts.

This is not enabled by default because it can result in a high cardinality of services.