### PR TITLE
JMXFetch bundled integrations disabled by default

### DIFF
--- a/dd-java-agent/agent-jmxfetch/src/main/java/datadog/trace/agent/jmxfetch/JMXFetch.java
+++ b/dd-java-agent/agent-jmxfetch/src/main/java/datadog/trace/agent/jmxfetch/JMXFetch.java
@@ -117,8 +117,11 @@ public class JMXFetch {
         final String[] split = configs.split("\n");
         final List<String> result = new ArrayList<>(split.length);
         for (final String config : split) {
-          final URL resource = JMXFetch.class.getResource("metricconfigs/" + config);
-          result.add(resource.getPath().split("\\.jar!/")[1]);
+          if (Config.integrationEnabled(
+              Collections.singleton(config.replace(".yaml", "")), false)) {
+            final URL resource = JMXFetch.class.getResource("metricconfigs/" + config);
+            result.add(resource.getPath().split("\\.jar!/")[1]);
+          }
         }
         return result;
       }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Instrumenter.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Instrumenter.java
@@ -1,13 +1,13 @@
 package datadog.trace.agent.tooling;
 
 import static datadog.trace.agent.tooling.ByteBuddyElementMatchers.failSafe;
-import static datadog.trace.agent.tooling.Utils.getConfigEnabled;
 import static net.bytebuddy.matcher.ElementMatchers.any;
 
 import datadog.trace.agent.tooling.context.FieldBackedProvider;
 import datadog.trace.agent.tooling.context.InstrumentationContextProvider;
 import datadog.trace.agent.tooling.muzzle.Reference;
 import datadog.trace.agent.tooling.muzzle.ReferenceMatcher;
+import datadog.trace.api.Config;
 import java.security.ProtectionDomain;
 import java.util.Arrays;
 import java.util.Collections;
@@ -52,20 +52,7 @@ public interface Instrumenter {
       instrumentationNames.add(instrumentationName);
       instrumentationPrimaryName = instrumentationName;
 
-      // If default is enabled, we want to enable individually,
-      // if default is disabled, we want to disable individually.
-      final boolean defaultEnabled = defaultEnabled();
-      boolean anyEnabled = defaultEnabled;
-      for (final String name : instrumentationNames) {
-        final boolean configEnabled =
-            getConfigEnabled("dd.integration." + name + ".enabled", defaultEnabled);
-        if (defaultEnabled) {
-          anyEnabled &= configEnabled;
-        } else {
-          anyEnabled |= configEnabled;
-        }
-      }
-      enabled = anyEnabled;
+      enabled = Config.integrationEnabled(instrumentationNames, defaultEnabled());
       contextProvider = new FieldBackedProvider(this);
     }
 
@@ -225,7 +212,7 @@ public interface Instrumenter {
     }
 
     protected boolean defaultEnabled() {
-      return getConfigEnabled("dd.integrations.enabled", true);
+      return Config.getBooleanSettingFromEnvironment("integrations.enabled", true);
     }
   }
 }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Utils.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Utils.java
@@ -84,12 +84,5 @@ public class Utils {
     return type.getDeclaredMethods().filter(named(methodName)).getOnly();
   }
 
-  static boolean getConfigEnabled(final String name, final boolean fallback) {
-    final String property =
-        System.getProperty(
-            name, System.getenv(name.toUpperCase().replaceAll("[^a-zA-Z0-9_]", "_")));
-    return property == null ? fallback : Boolean.parseBoolean(property);
-  }
-
   private Utils() {}
 }

--- a/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -281,6 +281,40 @@ class ConfigTest extends Specification {
     config.writerType == "DDAgentWriter"
   }
 
+  def "verify integration config"() {
+    setup:
+    environmentVariables.set("DD_INTEGRATION_ORDER_ENABLED", "false")
+    environmentVariables.set("DD_INTEGRATION_TEST_ENV_ENABLED", "true")
+    environmentVariables.set("DD_INTEGRATION_DISABLED_ENV_ENABLED", "false")
+
+    System.setProperty("dd.integration.order.enabled", "true")
+    System.setProperty("dd.integration.test-prop.enabled", "true")
+    System.setProperty("dd.integration.disabled-prop.enabled", "false")
+
+    expect:
+    Config.integrationEnabled(integrationNames, defaultEnabled) == expected
+
+    where:
+    names                          | defaultEnabled | expected
+    []                             | true           | true
+    []                             | false          | false
+    ["invalid"]                    | true           | true
+    ["invalid"]                    | false          | false
+    ["test-prop"]                  | false          | true
+    ["test-env"]                   | false          | true
+    ["disabled-prop"]              | true           | false
+    ["disabled-env"]               | true           | false
+    ["other", "test-prop"]         | false          | true
+    ["other", "test-env"]          | false          | true
+    ["order"]                      | false          | true
+    ["test-prop", "disabled-prop"] | false          | true
+    ["disabled-env", "test-env"]   | false          | true
+    ["test-prop", "disabled-prop"] | true           | false
+    ["disabled-env", "test-env"]   | true           | false
+
+    integrationNames = names.toSet()
+  }
+
   def "verify mapping configs on tracer"() {
     setup:
     System.setProperty(PREFIX + SERVICE_MAPPING, mapString)


### PR DESCRIPTION
Enable each individually by setting `-Ddd.integration.<integration_name>.enabled=true`.