### PR TITLE
Allow non-wrapped tasks in disabled executors

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/State.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/State.java
@@ -36,7 +36,9 @@ public class State {
   public void closeContinuation() {
     final TraceScope.Continuation continuation = continuationRef.getAndSet(null);
     if (continuation != null) {
-      continuation.close();
+      // We have opened this continuation, we shall not close parent scope when we close it,
+      // otherwise owners of that scope will get confused.
+      continuation.close(false);
     }
   }
 

--- a/dd-java-agent/instrumentation/java-concurrent/scala-testing/src/test/groovy/ScalaExecutorInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/java-concurrent/scala-testing/src/test/groovy/ScalaExecutorInstrumentationTest.groovy
@@ -8,11 +8,8 @@ import scala.concurrent.forkjoin.ForkJoinTask
 import spock.lang.Shared
 
 import java.lang.reflect.InvocationTargetException
-import java.lang.reflect.Method
 import java.util.concurrent.ArrayBlockingQueue
 import java.util.concurrent.Callable
-import java.util.concurrent.Executor
-import java.util.concurrent.ExecutorService
 import java.util.concurrent.Future
 import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.ThreadPoolExecutor
@@ -23,31 +20,21 @@ import java.util.concurrent.TimeUnit
  * This is to large extent a copy of ExecutorInstrumentationTest.
  */
 class ScalaExecutorInstrumentationTest extends AgentTestRunner {
-  @Shared
-  Method executeRunnableMethod
-  @Shared
-  Method scalaExecuteForkJoinTaskMethod
-  @Shared
-  Method submitRunnableMethod
-  @Shared
-  Method submitCallableMethod
-  @Shared
-  Method scalaSubmitForkJoinTaskMethod
-  @Shared
-  Method scalaInvokeForkJoinTaskMethod
 
-  def setupSpec() {
-    executeRunnableMethod = Executor.getMethod("execute", Runnable)
-    scalaExecuteForkJoinTaskMethod = ForkJoinPool.getMethod("execute", ForkJoinTask)
-    submitRunnableMethod = ExecutorService.getMethod("submit", Runnable)
-    submitCallableMethod = ExecutorService.getMethod("submit", Callable)
-    scalaSubmitForkJoinTaskMethod = ForkJoinPool.getMethod("submit", ForkJoinTask)
-    scalaInvokeForkJoinTaskMethod = ForkJoinPool.getMethod("invoke", ForkJoinTask)
-  }
+  @Shared
+  def executeRunnable = { e, c -> e.execute((Runnable) c) }
+  @Shared
+  def scalaExecuteForkJoinTask = { e, c -> e.execute((ForkJoinTask) c) }
+  @Shared
+  def submitRunnable = { e, c -> e.submit((Runnable) c) }
+  @Shared
+  def submitCallable = { e, c -> e.submit((Callable) c) }
+  @Shared
+  def scalaSubmitForkJoinTask = { e, c -> e.submit((ForkJoinTask) c) }
+  @Shared
+  def scalaInvokeForkJoinTask = { e, c -> e.invoke((ForkJoinTask) c) }
 
-  // more useful name breaks java9 javac
-  // def "#poolImpl.getClass().getSimpleName() #method.getName() propagates"()
-  def "#poolImpl #method propagates"() {
+  def "#poolImpl '#name' propagates"() {
     setup:
     def pool = poolImpl
     def m = method
@@ -58,9 +45,9 @@ class ScalaExecutorInstrumentationTest extends AgentTestRunner {
       void run() {
         ((ContinuableScope) GlobalTracer.get().scopeManager().active()).setAsyncPropagation(true)
         // this child will have a span
-        m.invoke(pool, new ScalaAsyncChild())
+        m(pool, new ScalaAsyncChild())
         // this child won't
-        m.invoke(pool, new ScalaAsyncChild(false, false))
+        m(pool, new ScalaAsyncChild(false, false))
       }
     }.run()
 
@@ -79,22 +66,21 @@ class ScalaExecutorInstrumentationTest extends AgentTestRunner {
 
     // Unfortunately, there's no simple way to test the cross product of methods/pools.
     where:
-    poolImpl                                                                                      | method
-    new ForkJoinPool()                                                                            | executeRunnableMethod
-    new ForkJoinPool()                                                                            | scalaExecuteForkJoinTaskMethod
-    new ForkJoinPool()                                                                            | submitRunnableMethod
-    new ForkJoinPool()                                                                            | submitCallableMethod
-    new ForkJoinPool()                                                                            | scalaSubmitForkJoinTaskMethod
-    new ForkJoinPool()                                                                            | scalaInvokeForkJoinTaskMethod
+    name                   | method                   | poolImpl
+    "execute Runnable"     | executeRunnable          | new ThreadPoolExecutor(1, 1, 1000, TimeUnit.NANOSECONDS, new ArrayBlockingQueue<Runnable>(1))
+    "submit Runnable"      | submitRunnable           | new ThreadPoolExecutor(1, 1, 1000, TimeUnit.NANOSECONDS, new ArrayBlockingQueue<Runnable>(1))
+    "submit Callable"      | submitCallable           | new ThreadPoolExecutor(1, 1, 1000, TimeUnit.NANOSECONDS, new ArrayBlockingQueue<Runnable>(1))
 
-    new ThreadPoolExecutor(1, 1, 1000, TimeUnit.NANOSECONDS, new ArrayBlockingQueue<Runnable>(1)) | executeRunnableMethod
-    new ThreadPoolExecutor(1, 1, 1000, TimeUnit.NANOSECONDS, new ArrayBlockingQueue<Runnable>(1)) | submitRunnableMethod
-    new ThreadPoolExecutor(1, 1, 1000, TimeUnit.NANOSECONDS, new ArrayBlockingQueue<Runnable>(1)) | submitCallableMethod
+    // ForkJoinPool has additional set of method overloads for ForkJoinTask to deal with
+    "execute Runnable"     | executeRunnable          | new ForkJoinPool()
+    "execute ForkJoinTask" | scalaExecuteForkJoinTask | new ForkJoinPool()
+    "submit Runnable"      | submitRunnable           | new ForkJoinPool()
+    "submit Callable"      | submitCallable           | new ForkJoinPool()
+    "submit ForkJoinTask"  | scalaSubmitForkJoinTask  | new ForkJoinPool()
+    "invoke ForkJoinTask"  | scalaInvokeForkJoinTask  | new ForkJoinPool()
   }
 
-  // more useful name breaks java9 javac
-  // def "#poolImpl.getClass().getSimpleName() #method.getName() propagates"()
-  def "#poolImpl reports after canceled jobs"() {
+  def "#poolImpl '#name' reports after canceled jobs"() {
     setup:
     def pool = poolImpl
     def m = method
@@ -117,7 +103,7 @@ class ScalaExecutorInstrumentationTest extends AgentTestRunner {
             final ScalaAsyncChild child = new ScalaAsyncChild(true, true)
             children.add(child)
             try {
-              Future f = m.invoke(pool, new ScalaAsyncChild())
+              Future f = m(pool, new ScalaAsyncChild())
               jobFutures.add(f)
             } catch (InvocationTargetException e) {
               throw e.getCause()
@@ -142,8 +128,8 @@ class ScalaExecutorInstrumentationTest extends AgentTestRunner {
     TEST_WRITER.size() == 1
 
     where:
-    poolImpl           | method
-    new ForkJoinPool() | submitRunnableMethod
-    new ForkJoinPool() | submitCallableMethod
+    name              | method         | poolImpl
+    "submit Runnable" | submitRunnable | new ForkJoinPool()
+    "submit Callable" | submitCallable | new ForkJoinPool()
   }
 }

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/FutureInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/FutureInstrumentation.java
@@ -61,7 +61,8 @@ public final class FutureInstrumentation extends Instrumenter.Default {
       "akka.dispatch.ForkJoinExecutorConfigurator$AkkaForkJoinTask",
       "com.google.common.util.concurrent.SettableFuture",
       "com.google.common.util.concurrent.AbstractFuture$TrustedFuture",
-      "com.google.common.util.concurrent.AbstractFuture"
+      "com.google.common.util.concurrent.AbstractFuture",
+      "io.netty.util.concurrent.ScheduledFutureTask"
     };
     WHITELISTED_FUTURES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(whitelist)));
   }

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/FutureInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/FutureInstrumentation.java
@@ -102,15 +102,15 @@ public final class FutureInstrumentation extends Instrumenter.Default {
 
   public static class CanceledFutureAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
-    public static void exit(
-        @Advice.This final Future<?> future, @Advice.Return final boolean canceled) {
-      if (canceled) {
-        final ContextStore<Future, State> contextStore =
-            InstrumentationContext.get(Future.class, State.class);
-        final State state = contextStore.get(future);
-        if (state != null) {
-          state.closeContinuation();
-        }
+    public static void exit(@Advice.This final Future<?> future) {
+      // Try to close continuation even if future was not cancelled:
+      // the expectation is that continuation should be closed after 'cancel'
+      // is called, one way or another
+      final ContextStore<Future, State> contextStore =
+          InstrumentationContext.get(Future.class, State.class);
+      final State state = contextStore.get(future);
+      if (state != null) {
+        state.closeContinuation();
       }
     }
   }

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/ThreadPoolExecutorInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/ThreadPoolExecutorInstrumentation.java
@@ -66,7 +66,7 @@ public class ThreadPoolExecutorInstrumentation extends Instrumenter.Default {
         } catch (final ClassCastException | IllegalArgumentException e) {
           // These errors indicate the queue is fundamentally incompatible with wrapped runnables.
           // We must disable the executor instance to avoid passing wrapped runnables later.
-          ExecutorInstrumentationUtils.disableExecutor(executor);
+          ExecutorInstrumentationUtils.disableExecutorForWrappedTasks(executor);
         } catch (final Exception e) {
           // Other errors might indicate the queue is not fully initialized.
           // We might want to disable for those too, but for now just ignore.

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/utils/TraceUtils.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/utils/TraceUtils.groovy
@@ -30,7 +30,6 @@ class TraceUtils {
 
       throw e
     } finally {
-      ((TraceScope) scope).setAsyncPropagation(false)
       scope.close()
     }
   }

--- a/dd-trace-ot/src/main/java/datadog/opentracing/scopemanager/ContinuableScope.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/scopemanager/ContinuableScope.java
@@ -159,7 +159,7 @@ public class ContinuableScope implements Scope, TraceScope {
         if (closeContinuationScope) {
           ContinuableScope.this.close();
         } else {
-          // Same in in 'close()' above.
+          // Same as in 'close()' above.
           if (openCount.decrementAndGet() == 0 && finishOnClose) {
             spanUnderScope.finish();
           }

--- a/dd-trace-ot/src/main/java/datadog/opentracing/scopemanager/ContinuableScope.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/scopemanager/ContinuableScope.java
@@ -159,7 +159,10 @@ public class ContinuableScope implements Scope, TraceScope {
         if (closeContinuationScope) {
           ContinuableScope.this.close();
         } else {
-          openCount.decrementAndGet();
+          // Same in in 'close()' above.
+          if (openCount.decrementAndGet() == 0 && finishOnClose) {
+            spanUnderScope.finish();
+          }
         }
       } else {
         log.debug("Failed to close continuation {}. Already used.", this);


### PR DESCRIPTION
Some executors cannot handle tasks that have been wrapped into
`{Runnable,Callable}Wrapper` because they require certain subclass of
`{Callable,Runnable}` in order to work. We have a test that
effectively disables instrumentation for such executors.

This change makes sure that tasks that do not need to be
wrapped (which essentially means anything that is not lambda) still
get traced in such executors. One notable example of affected executor
type is `ScheduledThreadPoolExecutor`.