### PR TITLE
Exclude several type identifications from instrumentation

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
@@ -18,6 +18,7 @@ import net.bytebuddy.agent.builder.AgentBuilder;
 import net.bytebuddy.agent.builder.ResettableClassFileTransformer;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.dynamic.DynamicType;
+import net.bytebuddy.matcher.ElementMatchers;
 import net.bytebuddy.utility.JavaModule;
 
 @Slf4j
@@ -64,6 +65,12 @@ public class AgentInstaller {
             // https://github.com/raphw/byte-buddy/issues/558
             // .with(AgentBuilder.LambdaInstrumentationStrategy.ENABLED)
             .ignore(any(), skipClassLoader())
+            // Unlikely to ever need to instrument an annotation:
+            .or(ElementMatchers.<TypeDescription>isAnnotation())
+            // Unlikely to ever need to instrument an enum:
+            .or(ElementMatchers.<TypeDescription>isEnum())
+            // Exclude generated classes like proxies:
+            .or(ElementMatchers.<TypeDescription>isSynthetic())
             .or(
                 nameStartsWith("datadog.trace.")
                     // FIXME: We should remove this once

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
@@ -69,8 +69,6 @@ public class AgentInstaller {
             .or(ElementMatchers.<TypeDescription>isAnnotation())
             // Unlikely to ever need to instrument an enum:
             .or(ElementMatchers.<TypeDescription>isEnum())
-            // Exclude generated classes like proxies:
-            .or(ElementMatchers.<TypeDescription>isSynthetic())
             .or(
                 nameStartsWith("datadog.trace.")
                     // FIXME: We should remove this once


### PR DESCRIPTION
I considered excluding Interfaces too, but that would break people that added `@Trace` to their default methods.

Just a hunch, but I don’t think we want to instrument classes marked as synthetic, for example proxies.  We may want to extend this to our method matchers (and maybe exclude native methods too).

We might want to instrument enums/annotations, but that seems unlikely.