### PR TITLE
Limit ES-rest tests to 6.x.x versions

### DIFF
--- a/dd-java-agent/instrumentation/elasticsearch-rest-6.4/elasticsearch-rest-6.4.gradle
+++ b/dd-java-agent/instrumentation/elasticsearch-rest-6.4/elasticsearch-rest-6.4.gradle
@@ -50,7 +50,7 @@ dependencies {
   testCompile group: 'org.elasticsearch', name: 'elasticsearch', version: '6.4.0'
   testCompile group: 'org.elasticsearch.plugin', name: 'transport-netty4-client', version: '6.4.0'
 
-  latestDepTestCompile group: 'org.elasticsearch.client', name: 'elasticsearch-rest-client', version: '+'
+  latestDepTestCompile group: 'org.elasticsearch.client', name: 'elasticsearch-rest-client', version: '6.+'
   latestDepTestCompile group: 'org.elasticsearch.client', name: 'transport', version: '6.+'
   latestDepTestCompile group: 'org.elasticsearch', name: 'elasticsearch', version: '6.+'
   latestDepTestCompile group: 'org.elasticsearch.plugin', name: 'transport-netty4-client', version: '6.+'


### PR DESCRIPTION
It looks like beta 7.x.x was released and our instrumentation doesn't
work with it at the moment.