### PR TITLE
Exclude tests generated by “test-sets” plugin from alternate JVM tests

### DIFF
--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -228,7 +228,9 @@ for (def env : System.getenv().entrySet()) {
   tasks.check.dependsOn parentTask
 
   tasks.withType(Test).configureEach {
-    if (name.endsWith("Generated")) {
+//    if (name.endsWith("Generated")) {
+    if (!name.equals("test")) {
+      // The way we're copying the test doesn't currently work with "test-sets" generated tests.
       return
     }
 


### PR DESCRIPTION
Tests run under regular classpath, not the custom one defined by the plugin.  This works for some tests where this is expected, but other tests it’s just retesting the `test` sourceset tests, not the custom provided ones (ex: slickTest).