### PR TITLE
Exclude groovy macro package from instrumentation

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
@@ -107,6 +107,7 @@ public class AgentInstaller {
             .or(nameStartsWith("jdk."))
             .or(nameStartsWith("org.aspectj."))
             .or(nameStartsWith("org.groovy."))
+            .or(nameStartsWith("org.codehaus.groovy.macro."))
             .or(nameStartsWith("com.p6spy."))
             .or(nameStartsWith("com.newrelic."))
             .or(nameContains("javassist"))


### PR DESCRIPTION
It generates a lot of noise when running tests and likely shouldn’t be instrumented.