### PR TITLE
Hystrix metadata added to tags and Command Group included in resource name

### DIFF
--- a/dd-java-agent/instrumentation/hystrix-1.4/hystrix-1.4.gradle
+++ b/dd-java-agent/instrumentation/hystrix-1.4/hystrix-1.4.gradle
@@ -17,7 +17,7 @@ testSets {
 }
 
 dependencies {
-//  compileOnly group: 'com.netflix.hystrix', name: 'hystrix-core', version: '1.5.12'
+  compileOnly group: 'com.netflix.hystrix', name: 'hystrix-core', version: '1.4.0'
 
   compile project(':dd-trace-ot')
   compile project(':dd-java-agent:agent-tooling')

--- a/dd-java-agent/instrumentation/hystrix-1.4/src/main/java/datadog/trace/instrumentation/hystrix/HystrixCommandInstrumentation.java
+++ b/dd-java-agent/instrumentation/hystrix-1.4/src/main/java/datadog/trace/instrumentation/hystrix/HystrixCommandInstrumentation.java
@@ -16,7 +16,6 @@ import io.opentracing.Scope;
 import io.opentracing.Span;
 import io.opentracing.tag.Tags;
 import io.opentracing.util.GlobalTracer;
-import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
@@ -49,13 +48,15 @@ public class HystrixCommandInstrumentation extends Instrumenter.Default {
   public static class TraceAdvice {
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static Scope startSpan(@Advice.This final HystrixCommand<?> command, @Advice.Origin final Method method) {
+    public static Scope startSpan(
+        @Advice.This final HystrixCommand<?> command,
+        @Advice.Origin("#m") final String methodName) {
 
       final String commandName = command.getCommandKey().name();
       final String groupName = command.getCommandGroup().name();
       final boolean circuitOpen = command.isCircuitBreakerOpen();
 
-      final String resourceName = groupName + "." + commandName + "." + method.getName();
+      final String resourceName = groupName + "." + commandName + "." + methodName;
 
       return GlobalTracer.get()
           .buildSpan(OPERATION_NAME)

--- a/dd-java-agent/instrumentation/hystrix-1.4/src/main/java/datadog/trace/instrumentation/hystrix/HystrixCommandInstrumentation.java
+++ b/dd-java-agent/instrumentation/hystrix-1.4/src/main/java/datadog/trace/instrumentation/hystrix/HystrixCommandInstrumentation.java
@@ -9,6 +9,7 @@ import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.not;
 
 import com.google.auto.service.AutoService;
+import com.netflix.hystrix.HystrixCommand;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.DDTags;
 import io.opentracing.Scope;
@@ -48,24 +49,21 @@ public class HystrixCommandInstrumentation extends Instrumenter.Default {
   public static class TraceAdvice {
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static Scope startSpan(@Advice.Origin final Method method) {
-      final Class<?> declaringClass = method.getDeclaringClass();
-      String className = declaringClass.getSimpleName();
-      if (className.isEmpty()) {
-        className = declaringClass.getName();
-        if (declaringClass.getPackage() != null) {
-          final String pkgName = declaringClass.getPackage().getName();
-          if (!pkgName.isEmpty()) {
-            className = declaringClass.getName().replace(pkgName, "").substring(1);
-          }
-        }
-      }
-      final String resourceName = className + "." + method.getName();
+    public static Scope startSpan(@Advice.This final HystrixCommand<?> command, @Advice.Origin final Method method) {
+
+      final String commandName = command.getCommandKey().name();
+      final String groupName = command.getCommandGroup().name();
+      final boolean circuitOpen = command.isCircuitBreakerOpen();
+
+      final String resourceName = groupName + "." + commandName + "." + method.getName();
 
       return GlobalTracer.get()
           .buildSpan(OPERATION_NAME)
           .withTag(DDTags.RESOURCE_NAME, resourceName)
           .withTag(Tags.COMPONENT.getKey(), "hystrix")
+          .withTag("hystrix.command", commandName)
+          .withTag("hystrix.group", groupName)
+          .withTag("hystrix.circuit-open", circuitOpen)
           .startActive(true);
     }
 

--- a/dd-java-agent/instrumentation/hystrix-1.4/src/test/groovy/HystrixTest.groovy
+++ b/dd-java-agent/instrumentation/hystrix-1.4/src/test/groovy/HystrixTest.groovy
@@ -52,11 +52,14 @@ class HystrixTest extends AgentTestRunner {
         span(1) {
           serviceName "unnamed-java-app"
           operationName "hystrix.cmd"
-          resourceName "HystrixTest\$1.run"
+          resourceName "ExampleGroup.HystrixTest\$1.run"
           spanType null
           childOf span(0)
           errored false
           tags {
+            "hystrix.command" "HystrixTest\$1"
+            "hystrix.group" "ExampleGroup"
+            "hystrix.circuit-open" false
             "$Tags.COMPONENT.key" "hystrix"
             defaultTags()
           }
@@ -126,11 +129,14 @@ class HystrixTest extends AgentTestRunner {
         span(1) {
           serviceName "unnamed-java-app"
           operationName "hystrix.cmd"
-          resourceName "HystrixTest\$2.getFallback"
+          resourceName "ExampleGroup.HystrixTest\$2.getFallback"
           spanType null
           childOf span(0)
           errored false
           tags {
+            "hystrix.command" "HystrixTest\$2"
+            "hystrix.group" "ExampleGroup"
+            "hystrix.circuit-open" false
             "$Tags.COMPONENT.key" "hystrix"
             defaultTags()
           }
@@ -138,11 +144,14 @@ class HystrixTest extends AgentTestRunner {
         span(2) {
           serviceName "unnamed-java-app"
           operationName "hystrix.cmd"
-          resourceName "HystrixTest\$2.run"
+          resourceName "ExampleGroup.HystrixTest\$2.run"
           spanType null
           childOf span(0)
           errored true
           tags {
+            "hystrix.command" "HystrixTest\$2"
+            "hystrix.group" "ExampleGroup"
+            "hystrix.circuit-open" false
             "$Tags.COMPONENT.key" "hystrix"
             errorTags(IllegalArgumentException)
             defaultTags()


### PR DESCRIPTION
Related to issue #707 

Changes:
- Added hystrix `Command Group` to resource name for a better grouping of commands.
- Added `Command Key`, `Command Group` and "is Circuit Breaker Open" as tags.

Example of resource name change:

Old name: `ExampleCommand.run`
New name: `ExampleGroup.ExampleCommand.run`