### PR TITLE
Increase time we wait for smoke tests servers to start up

### DIFF
--- a/dd-smoke-tests/play/play.gradle
+++ b/dd-smoke-tests/play/play.gradle
@@ -84,9 +84,10 @@ tasks.register("startServer", com.github.psxpaul.task.ExecFork) {
   // these params tells the ExecFork plugin to block on startServer task until the port is opened or the string is seen in the ouput
   waitForPort = playHttpPort
   waitForOutput = "Listening for HTTP on /127.0.0.1:${playHttpPort}"
+  timeout = 240
   environment = [
     'JAVA_OPTS' :  "-javaagent:${project(':dd-java-agent').tasks.shadowJar.archivePath}"
-    + " -Ddd.writer.type=LoggingWriter" + " -Ddd.service.name=java-app"
+      + " -Ddd.writer.type=LoggingWriter" + " -Ddd.service.name=java-app"
       + " -Ddatadog.slf4j.simpleLogger.defaultLogLevel=debug"
       + " -Dorg.slf4j.simpleLogger.defaultLogLevel=debug"
       + " -Dconfig.file=${workingDir}/conf/application.conf -Dhttp.port=${playHttpPort}"

--- a/dd-smoke-tests/springboot/springboot.gradle
+++ b/dd-smoke-tests/springboot/springboot.gradle
@@ -48,6 +48,7 @@ tasks.register("startServer", com.github.psxpaul.task.ExecFork) {
   standardOutput "${buildDir}/reports/server.log"
   waitForPort = springbootHttpPort
   waitForOutput = "datadog.smoketest.springboot.SpringbootApplication - Started SpringbootApplication"
+  timeout = 240
   stopAfter = test
 }
 

--- a/dd-smoke-tests/wildfly/wildfly.gradle
+++ b/dd-smoke-tests/wildfly/wildfly.gradle
@@ -72,6 +72,7 @@ tasks.register("startServer", com.github.psxpaul.task.ExecFork) {
   // these params tells the ExecFork plugin to block on startServer task until the port is opened or the string is seen in the ouput
   waitForPort = wildflyHttpPort
   waitForOutput = "Undertow HTTP listener default listening on 127.0.0.1:${wildflyHttpPort}"
+  timeout = 240
   environment = [
     'JAVA_OPTS': "-javaagent:${project(':dd-java-agent').tasks.shadowJar.archivePath}"
       + " -Ddd.writer.type=LoggingWriter" + " -Ddd.service.name=java-app"


### PR DESCRIPTION
Default 60 seconds often pass when run on laptop in paralle mode.