### PR TITLE
Span type should only be an attribute and not inherited

### DIFF
--- a/dd-java-agent/instrumentation/akka-http-10.0/src/lagomTest/groovy/LagomTest.groovy
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/lagomTest/groovy/LagomTest.groovy
@@ -4,7 +4,6 @@ import akka.stream.testkit.TestSubscriber.Probe
 import akka.stream.testkit.javadsl.TestSink
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.DDSpanTypes
-import datadog.trace.api.DDTags
 import io.opentracing.tag.Tags
 import play.inject.guice.GuiceApplicationBuilder
 import spock.lang.Shared
@@ -63,6 +62,7 @@ class LagomTest extends AgentTestRunner {
           serviceName "unnamed-java-app"
           operationName "akka-http.request"
           resourceName "GET ws://?/echo"
+          spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
             defaultTags()
@@ -72,7 +72,6 @@ class LagomTest extends AgentTestRunner {
             "$Tags.PEER_HOSTNAME.key" "localhost"
             "$Tags.PEER_PORT.key" server.port()
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_SERVER
             "$Tags.COMPONENT.key" "akka-http-server"
           }
         }
@@ -103,6 +102,7 @@ class LagomTest extends AgentTestRunner {
           serviceName "unnamed-java-app"
           operationName "akka-http.request"
           resourceName "GET ws://?/error"
+          spanType DDSpanTypes.HTTP_SERVER
           errored true
           tags {
             defaultTags()
@@ -112,7 +112,6 @@ class LagomTest extends AgentTestRunner {
             "$Tags.PEER_HOSTNAME.key" "localhost"
             "$Tags.PEER_PORT.key" server.port()
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_SERVER
             "$Tags.COMPONENT.key" "akka-http-server"
             "$Tags.ERROR.key" true
           }

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpClientInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpClientInstrumentationTest.groovy
@@ -10,7 +10,6 @@ import akka.stream.javadsl.Source
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.Config
 import datadog.trace.api.DDSpanTypes
-import datadog.trace.api.DDTags
 import io.opentracing.tag.Tags
 import scala.util.Try
 import spock.lang.AutoCleanup
@@ -89,7 +88,6 @@ class AkkaHttpClientInstrumentationTest extends AgentTestRunner {
             "$Tags.HTTP_URL.key" "${server.address}/$route"
             "$Tags.HTTP_METHOD.key" "GET"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_CLIENT
             "$Tags.PEER_HOSTNAME.key" server.address.host
             "$Tags.PEER_PORT.key" server.address.port
             "$Tags.COMPONENT.key" "akka-http-client"
@@ -137,7 +135,6 @@ class AkkaHttpClientInstrumentationTest extends AgentTestRunner {
             "$Tags.HTTP_URL.key" url.toString()
             "$Tags.HTTP_METHOD.key" "GET"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_CLIENT
             "$Tags.PEER_HOSTNAME.key" server.address.host
             "$Tags.PEER_PORT.key" UNUSABLE_PORT
             "$Tags.COMPONENT.key" "akka-http-client"
@@ -171,7 +168,6 @@ class AkkaHttpClientInstrumentationTest extends AgentTestRunner {
           tags {
             defaultTags()
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_CLIENT
             "$Tags.COMPONENT.key" "akka-http-client"
             "$Tags.ERROR.key" true
             errorTags(NullPointerException)
@@ -220,7 +216,6 @@ class AkkaHttpClientInstrumentationTest extends AgentTestRunner {
             "$Tags.HTTP_URL.key" "${server.address}/$route"
             "$Tags.HTTP_METHOD.key" "GET"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_CLIENT
             "$Tags.PEER_HOSTNAME.key" server.address.host
             "$Tags.PEER_PORT.key" server.address.port
             "$Tags.COMPONENT.key" "akka-http-client"
@@ -270,7 +265,6 @@ class AkkaHttpClientInstrumentationTest extends AgentTestRunner {
             "$Tags.HTTP_URL.key" url.toString()
             "$Tags.HTTP_METHOD.key" "GET"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_CLIENT
             "$Tags.PEER_HOSTNAME.key" server.address.host
             "$Tags.PEER_PORT.key" UNUSABLE_PORT
             "$Tags.COMPONENT.key" "akka-http-client"

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpServerInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpServerInstrumentationTest.groovy
@@ -1,7 +1,6 @@
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.utils.OkHttpUtils
 import datadog.trace.api.DDSpanTypes
-import datadog.trace.api.DDTags
 import io.opentracing.tag.Tags
 import okhttp3.Request
 import spock.lang.Shared
@@ -59,7 +58,6 @@ class AkkaHttpServerInstrumentationTest extends AgentTestRunner {
             "$Tags.PEER_HOSTNAME.key" "localhost"
             "$Tags.PEER_PORT.key" port
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_SERVER
             "$Tags.COMPONENT.key" "akka-http-server"
           }
         }
@@ -103,7 +101,6 @@ class AkkaHttpServerInstrumentationTest extends AgentTestRunner {
             "$Tags.PEER_HOSTNAME.key" "localhost"
             "$Tags.PEER_PORT.key" port
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_SERVER
             "$Tags.COMPONENT.key" "akka-http-server"
             errorTags RuntimeException, errorMessage
           }
@@ -145,7 +142,6 @@ class AkkaHttpServerInstrumentationTest extends AgentTestRunner {
             "$Tags.PEER_HOSTNAME.key" "localhost"
             "$Tags.PEER_PORT.key" port
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_SERVER
             "$Tags.COMPONENT.key" "akka-http-server"
             "$Tags.ERROR.key" true
           }
@@ -186,7 +182,6 @@ class AkkaHttpServerInstrumentationTest extends AgentTestRunner {
             "$Tags.PEER_HOSTNAME.key" "localhost"
             "$Tags.PEER_PORT.key" port
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_SERVER
             "$Tags.COMPONENT.key" "akka-http-server"
           }
         }

--- a/dd-java-agent/instrumentation/apache-httpclient-4/src/latestDepTest/groovy/ApacheHttpClientTest.groovy
+++ b/dd-java-agent/instrumentation/apache-httpclient-4/src/latestDepTest/groovy/ApacheHttpClientTest.groovy
@@ -3,7 +3,6 @@ import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.api.Config
 import datadog.trace.api.DDSpanTypes
-import datadog.trace.api.DDTags
 import io.opentracing.tag.Tags
 import org.apache.http.HttpResponse
 import org.apache.http.client.ClientProtocolException
@@ -224,6 +223,7 @@ class ApacheHttpClientTest extends AgentTestRunner {
       serviceName renameService ? "localhost" : "unnamed-java-app"
       operationName "http.request"
       resourceName "GET /$route"
+      spanType DDSpanTypes.HTTP_CLIENT
       errored exception != null
       tags {
         defaultTags()
@@ -237,7 +237,6 @@ class ApacheHttpClientTest extends AgentTestRunner {
         "$Tags.PEER_PORT.key" server.address.port
         "$Tags.HTTP_METHOD.key" "GET"
         "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-        "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_CLIENT
       }
     }
   }

--- a/dd-java-agent/instrumentation/apache-httpclient-4/src/test/groovy/ApacheHttpClientTest.groovy
+++ b/dd-java-agent/instrumentation/apache-httpclient-4/src/test/groovy/ApacheHttpClientTest.groovy
@@ -3,7 +3,6 @@ import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.api.Config
 import datadog.trace.api.DDSpanTypes
-import datadog.trace.api.DDTags
 import io.opentracing.tag.Tags
 import org.apache.http.HttpResponse
 import org.apache.http.client.HttpClient
@@ -129,6 +128,7 @@ class ApacheHttpClientTest extends AgentTestRunner {
       serviceName renameService ? "localhost" : "unnamed-java-app"
       operationName "http.request"
       resourceName "GET /$route"
+      spanType DDSpanTypes.HTTP_CLIENT
       errored exception != null
       tags {
         defaultTags()
@@ -142,7 +142,6 @@ class ApacheHttpClientTest extends AgentTestRunner {
         "$Tags.PEER_PORT.key" server.address.port
         "$Tags.HTTP_METHOD.key" "GET"
         "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-        "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_CLIENT
       }
     }
   }

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test/groovy/AWSClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test/groovy/AWSClientTest.groovy
@@ -8,7 +8,6 @@ import com.amazonaws.services.s3.AmazonS3Client
 import com.amazonaws.services.s3.S3ClientOptions
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.DDSpanTypes
-import datadog.trace.api.DDTags
 import io.opentracing.tag.Tags
 import spock.lang.AutoCleanup
 import spock.lang.Shared
@@ -79,6 +78,7 @@ class AWSClientTest extends AgentTestRunner {
           serviceName "java-aws-sdk"
           operationName "aws.http"
           resourceName "$service.$operation"
+          spanType DDSpanTypes.HTTP_CLIENT
           errored false
           parent()
           tags {
@@ -87,7 +87,6 @@ class AWSClientTest extends AgentTestRunner {
             "$Tags.HTTP_URL.key" "$server.address"
             "$Tags.HTTP_METHOD.key" "$method"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_CLIENT
             "aws.service" { it.contains(service) }
             "aws.endpoint" "$server.address"
             "aws.operation" "${operation}Request"
@@ -98,6 +97,7 @@ class AWSClientTest extends AgentTestRunner {
         span(1) {
           operationName "http.request"
           resourceName "$method /$url"
+          spanType DDSpanTypes.HTTP_CLIENT
           errored false
           childOf(span(0))
           tags {
@@ -108,7 +108,6 @@ class AWSClientTest extends AgentTestRunner {
             "$Tags.PEER_PORT.key" server.address.port
             "$Tags.HTTP_METHOD.key" "$method"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_CLIENT
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test_1_11_106/groovy/AWSClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test_1_11_106/groovy/AWSClientTest.groovy
@@ -13,7 +13,6 @@ import com.amazonaws.services.s3.AmazonS3Client
 import com.amazonaws.services.s3.AmazonS3ClientBuilder
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.DDSpanTypes
-import datadog.trace.api.DDTags
 import io.opentracing.tag.Tags
 import spock.lang.AutoCleanup
 import spock.lang.Shared
@@ -108,6 +107,7 @@ class AWSClientTest extends AgentTestRunner {
           serviceName "java-aws-sdk"
           operationName "aws.http"
           resourceName "$service.$operation"
+          spanType DDSpanTypes.HTTP_CLIENT
           errored false
           parent()
           tags {
@@ -116,7 +116,6 @@ class AWSClientTest extends AgentTestRunner {
             "$Tags.HTTP_URL.key" "$server.address"
             "$Tags.HTTP_METHOD.key" "$method"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_CLIENT
             "aws.service" { it.contains(service) }
             "aws.endpoint" "$server.address"
             "aws.operation" "${operation}Request"
@@ -127,6 +126,7 @@ class AWSClientTest extends AgentTestRunner {
         span(1) {
           operationName "http.request"
           resourceName "$method /$url"
+          spanType DDSpanTypes.HTTP_CLIENT
           errored false
           childOf(span(0))
           tags {
@@ -137,7 +137,6 @@ class AWSClientTest extends AgentTestRunner {
             "$Tags.PEER_PORT.key" server.address.port
             "$Tags.HTTP_METHOD.key" "$method"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_CLIENT
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/test/groovy/AwsClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/test/groovy/AwsClientTest.groovy
@@ -1,6 +1,5 @@
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.DDSpanTypes
-import datadog.trace.api.DDTags
 import io.opentracing.tag.Tags
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
@@ -69,6 +68,7 @@ class AwsClientTest extends AgentTestRunner {
           serviceName "java-aws-sdk"
           operationName "aws.http"
           resourceName "$service.$operation"
+          spanType DDSpanTypes.HTTP_CLIENT
           errored false
           parent()
           tags {
@@ -79,7 +79,6 @@ class AwsClientTest extends AgentTestRunner {
             "$Tags.PEER_HOSTNAME.key" "localhost"
             "$Tags.PEER_PORT.key" server.address.port
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_CLIENT
             "aws.service" "$service"
             "aws.operation" "${operation}"
             "aws.agent" "java-aws-sdk"
@@ -90,6 +89,7 @@ class AwsClientTest extends AgentTestRunner {
         span(1) {
           operationName "http.request"
           resourceName "$method $path"
+          spanType DDSpanTypes.HTTP_CLIENT
           errored false
           childOf(span(0))
           tags {
@@ -100,7 +100,6 @@ class AwsClientTest extends AgentTestRunner {
             "$Tags.PEER_PORT.key" server.address.port
             "$Tags.HTTP_METHOD.key" "$method"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_CLIENT
             defaultTags()
           }
         }
@@ -162,6 +161,7 @@ class AwsClientTest extends AgentTestRunner {
           serviceName "java-aws-sdk"
           operationName "aws.http"
           resourceName "$service.$operation"
+          spanType DDSpanTypes.HTTP_CLIENT
           errored false
           parent()
           tags {
@@ -172,7 +172,6 @@ class AwsClientTest extends AgentTestRunner {
             "$Tags.PEER_HOSTNAME.key" "localhost"
             "$Tags.PEER_PORT.key" server.address.port
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_CLIENT
             "aws.service" "$service"
             "aws.operation" "${operation}"
             "aws.agent" "java-aws-sdk"
@@ -186,6 +185,7 @@ class AwsClientTest extends AgentTestRunner {
         span(0) {
           operationName "netty.client.request"
           resourceName "$method $path"
+          spanType DDSpanTypes.HTTP_CLIENT
           errored false
           parent()
           tags {
@@ -196,7 +196,6 @@ class AwsClientTest extends AgentTestRunner {
             "$Tags.PEER_PORT.key" server.address.port
             "$Tags.HTTP_METHOD.key" "$method"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_CLIENT
             defaultTags()
           }
         }
@@ -222,7 +221,7 @@ class AwsClientTest extends AgentTestRunner {
             <RequestId>0ac9cda2-bbf4-11d3-f92b-31fa5e8dbc99</RequestId>
           </ResponseMetadata>
         </DeleteOptionGroupResponse>
-      """          | RdsAsyncClient.builder()
+      """       | RdsAsyncClient.builder()
   }
 
   // TODO: add timeout tests?

--- a/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/CouchbaseClientTest.groovy
+++ b/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/CouchbaseClientTest.groovy
@@ -3,7 +3,6 @@ import com.couchbase.client.java.document.JsonDocument
 import com.couchbase.client.java.document.json.JsonObject
 import com.couchbase.client.java.query.N1qlQuery
 import datadog.trace.api.DDSpanTypes
-import datadog.trace.api.DDTags
 import io.opentracing.tag.Tags
 import util.AbstractCouchbaseTest
 
@@ -20,10 +19,10 @@ class CouchbaseClientTest extends AbstractCouchbaseTest {
           serviceName "couchbase"
           resourceName "ClusterManager.hasBucket"
           operationName "couchbase.call"
+          spanType DDSpanTypes.COUCHBASE
           errored false
           parent()
           tags {
-            "$DDTags.SPAN_TYPE" DDSpanTypes.COUCHBASE
             "$Tags.COMPONENT.key" "couchbase-client"
             "$Tags.DB_TYPE.key" "couchbase"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
@@ -49,10 +48,10 @@ class CouchbaseClientTest extends AbstractCouchbaseTest {
           serviceName "couchbase"
           resourceName "Bucket.upsert"
           operationName "couchbase.call"
+          spanType DDSpanTypes.COUCHBASE
           errored false
           parent()
           tags {
-            "$DDTags.SPAN_TYPE" DDSpanTypes.COUCHBASE
             "$Tags.COMPONENT.key" "couchbase-client"
             "$Tags.DB_TYPE.key" "couchbase"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
@@ -78,10 +77,10 @@ class CouchbaseClientTest extends AbstractCouchbaseTest {
           serviceName "couchbase"
           resourceName "Bucket.get"
           operationName "couchbase.call"
+          spanType DDSpanTypes.COUCHBASE
           errored false
           parent()
           tags {
-            "$DDTags.SPAN_TYPE" DDSpanTypes.COUCHBASE
             "$Tags.COMPONENT.key" "couchbase-client"
             "$Tags.DB_TYPE.key" "couchbase"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
@@ -123,10 +122,10 @@ class CouchbaseClientTest extends AbstractCouchbaseTest {
           serviceName "couchbase"
           resourceName "Bucket.query"
           operationName "couchbase.call"
+          spanType DDSpanTypes.COUCHBASE
           errored false
           parent()
           tags {
-            "$DDTags.SPAN_TYPE" DDSpanTypes.COUCHBASE
             "$Tags.COMPONENT.key" "couchbase-client"
             "$Tags.DB_TYPE.key" "couchbase"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT

--- a/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/springdata/CouchbaseSpringRepositoryTest.groovy
+++ b/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/springdata/CouchbaseSpringRepositoryTest.groovy
@@ -3,7 +3,6 @@ package springdata
 import com.couchbase.client.java.view.DefaultView
 import com.couchbase.client.java.view.DesignDocument
 import datadog.trace.api.DDSpanTypes
-import datadog.trace.api.DDTags
 import io.opentracing.tag.Tags
 import org.springframework.context.ConfigurableApplicationContext
 import org.springframework.context.annotation.AnnotationConfigApplicationContext
@@ -80,10 +79,10 @@ class CouchbaseSpringRepositoryTest extends AbstractCouchbaseTest {
           serviceName "couchbase"
           resourceName "Bucket.query"
           operationName "couchbase.call"
+          spanType DDSpanTypes.COUCHBASE
           errored false
           parent()
           tags {
-            "$DDTags.SPAN_TYPE" DDSpanTypes.COUCHBASE
             "$Tags.COMPONENT.key" "couchbase-client"
             "$Tags.DB_TYPE.key" "couchbase"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
@@ -112,10 +111,10 @@ class CouchbaseSpringRepositoryTest extends AbstractCouchbaseTest {
           serviceName "couchbase"
           resourceName "Bucket.upsert"
           operationName "couchbase.call"
+          spanType DDSpanTypes.COUCHBASE
           errored false
           parent()
           tags {
-            "$DDTags.SPAN_TYPE" DDSpanTypes.COUCHBASE
             "$Tags.COMPONENT.key" "couchbase-client"
             "$Tags.DB_TYPE.key" "couchbase"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
@@ -137,10 +136,10 @@ class CouchbaseSpringRepositoryTest extends AbstractCouchbaseTest {
           serviceName "couchbase"
           resourceName "Bucket.get"
           operationName "couchbase.call"
+          spanType DDSpanTypes.COUCHBASE
           errored false
           parent()
           tags {
-            "$DDTags.SPAN_TYPE" DDSpanTypes.COUCHBASE
             "$Tags.COMPONENT.key" "couchbase-client"
             "$Tags.DB_TYPE.key" "couchbase"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
@@ -165,10 +164,10 @@ class CouchbaseSpringRepositoryTest extends AbstractCouchbaseTest {
           serviceName "couchbase"
           resourceName "Bucket.upsert"
           operationName "couchbase.call"
+          spanType DDSpanTypes.COUCHBASE
           errored false
           parent()
           tags {
-            "$DDTags.SPAN_TYPE" DDSpanTypes.COUCHBASE
             "$Tags.COMPONENT.key" "couchbase-client"
             "$Tags.DB_TYPE.key" "couchbase"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
@@ -182,10 +181,10 @@ class CouchbaseSpringRepositoryTest extends AbstractCouchbaseTest {
           serviceName "couchbase"
           resourceName "Bucket.query"
           operationName "couchbase.call"
+          spanType DDSpanTypes.COUCHBASE
           errored false
           parent()
           tags {
-            "$DDTags.SPAN_TYPE" DDSpanTypes.COUCHBASE
             "$Tags.COMPONENT.key" "couchbase-client"
             "$Tags.DB_TYPE.key" "couchbase"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
@@ -199,10 +198,10 @@ class CouchbaseSpringRepositoryTest extends AbstractCouchbaseTest {
           serviceName "couchbase"
           resourceName "Bucket.get"
           operationName "couchbase.call"
+          spanType DDSpanTypes.COUCHBASE
           errored false
           parent()
           tags {
-            "$DDTags.SPAN_TYPE" DDSpanTypes.COUCHBASE
             "$Tags.COMPONENT.key" "couchbase-client"
             "$Tags.DB_TYPE.key" "couchbase"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
@@ -227,10 +226,10 @@ class CouchbaseSpringRepositoryTest extends AbstractCouchbaseTest {
           serviceName "couchbase"
           resourceName "Bucket.remove"
           operationName "couchbase.call"
+          spanType DDSpanTypes.COUCHBASE
           errored false
           parent()
           tags {
-            "$DDTags.SPAN_TYPE" DDSpanTypes.COUCHBASE
             "$Tags.COMPONENT.key" "couchbase-client"
             "$Tags.DB_TYPE.key" "couchbase"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
@@ -244,10 +243,10 @@ class CouchbaseSpringRepositoryTest extends AbstractCouchbaseTest {
           serviceName "couchbase"
           resourceName "Bucket.query"
           operationName "couchbase.call"
+          spanType DDSpanTypes.COUCHBASE
           errored false
           parent()
           tags {
-            "$DDTags.SPAN_TYPE" DDSpanTypes.COUCHBASE
             "$Tags.COMPONENT.key" "couchbase-client"
             "$Tags.DB_TYPE.key" "couchbase"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT

--- a/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/springdata/CouchbaseSpringTemplateTest.groovy
+++ b/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/springdata/CouchbaseSpringTemplateTest.groovy
@@ -1,9 +1,7 @@
 package springdata
 
-
 import com.couchbase.client.java.Bucket
 import datadog.trace.api.DDSpanTypes
-import datadog.trace.api.DDTags
 import io.opentracing.tag.Tags
 import org.springframework.data.couchbase.core.CouchbaseTemplate
 import spock.lang.Shared
@@ -46,10 +44,10 @@ class CouchbaseSpringTemplateTest extends AbstractCouchbaseTest {
           serviceName "couchbase"
           resourceName "Bucket.upsert"
           operationName "couchbase.call"
+          spanType DDSpanTypes.COUCHBASE
           errored false
           parent()
           tags {
-            "$DDTags.SPAN_TYPE" DDSpanTypes.COUCHBASE
             "$Tags.COMPONENT.key" "couchbase-client"
             "$Tags.DB_TYPE.key" "couchbase"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
@@ -63,10 +61,10 @@ class CouchbaseSpringTemplateTest extends AbstractCouchbaseTest {
           serviceName "couchbase"
           resourceName "Bucket.get"
           operationName "couchbase.call"
+          spanType DDSpanTypes.COUCHBASE
           errored false
           parent()
           tags {
-            "$DDTags.SPAN_TYPE" DDSpanTypes.COUCHBASE
             "$Tags.COMPONENT.key" "couchbase-client"
             "$Tags.DB_TYPE.key" "couchbase"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
@@ -80,10 +78,10 @@ class CouchbaseSpringTemplateTest extends AbstractCouchbaseTest {
           serviceName "couchbase"
           resourceName "Bucket.remove"
           operationName "couchbase.call"
+          spanType DDSpanTypes.COUCHBASE
           errored false
           parent()
           tags {
-            "$DDTags.SPAN_TYPE" DDSpanTypes.COUCHBASE
             "$Tags.COMPONENT.key" "couchbase-client"
             "$Tags.DB_TYPE.key" "couchbase"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
@@ -97,10 +95,10 @@ class CouchbaseSpringTemplateTest extends AbstractCouchbaseTest {
           serviceName "couchbase"
           resourceName "Bucket.get"
           operationName "couchbase.call"
+          spanType DDSpanTypes.COUCHBASE
           errored false
           parent()
           tags {
-            "$DDTags.SPAN_TYPE" DDSpanTypes.COUCHBASE
             "$Tags.COMPONENT.key" "couchbase-client"
             "$Tags.DB_TYPE.key" "couchbase"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT

--- a/dd-java-agent/instrumentation/datastax-cassandra-2.3/src/test/groovy/CassandraClientTest.groovy
+++ b/dd-java-agent/instrumentation/datastax-cassandra-2.3/src/test/groovy/CassandraClientTest.groovy
@@ -2,7 +2,7 @@ import com.datastax.driver.core.Cluster
 import com.datastax.driver.core.Session
 import datadog.opentracing.DDSpan
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.api.DDTags
+import datadog.trace.api.DDSpanTypes
 import io.opentracing.tag.Tags
 import org.cassandraunit.utils.EmbeddedCassandraServerHelper
 import spock.lang.Shared
@@ -55,6 +55,7 @@ class CassandraClientTest extends AgentTestRunner {
     selectTrace.getServiceName() == "cassandra"
     selectTrace.getOperationName() == "cassandra.query"
     selectTrace.getResourceName() == query
+    selectTrace.getSpanType() == DDSpanTypes.CASSANDRA
 
     selectTrace.getTags().get(Tags.COMPONENT.getKey()) == "java-cassandra"
     selectTrace.getTags().get(Tags.DB_TYPE.getKey()) == "cassandra"
@@ -63,7 +64,6 @@ class CassandraClientTest extends AgentTestRunner {
     selectTrace.getTags().get(Tags.PEER_HOST_IPV4.getKey()) == 2130706433
     selectTrace.getTags().get(Tags.PEER_PORT.getKey()) == 9142
     selectTrace.getTags().get(Tags.SPAN_KIND.getKey()) == "client"
-    selectTrace.getTags().get(DDTags.SPAN_TYPE) == "cassandra"
   }
 
   def "async traces"() {
@@ -92,6 +92,7 @@ class CassandraClientTest extends AgentTestRunner {
     selectTrace.getServiceName() == "cassandra"
     selectTrace.getOperationName() == "cassandra.query"
     selectTrace.getResourceName() == query
+    selectTrace.getSpanType() == DDSpanTypes.CASSANDRA
 
     selectTrace.getTags().get(Tags.COMPONENT.getKey()) == "java-cassandra"
     selectTrace.getTags().get(Tags.DB_TYPE.getKey()) == "cassandra"
@@ -100,6 +101,5 @@ class CassandraClientTest extends AgentTestRunner {
     selectTrace.getTags().get(Tags.PEER_HOST_IPV4.getKey()) == 2130706433
     selectTrace.getTags().get(Tags.PEER_PORT.getKey()) == 9142
     selectTrace.getTags().get(Tags.SPAN_KIND.getKey()) == "client"
-    selectTrace.getTags().get(DDTags.SPAN_TYPE) == "cassandra"
   }
 }

--- a/dd-java-agent/instrumentation/dropwizard/dropwizard-views/src/main/java/datadog/trace/instrumentation/dropwizard/view/DropwizardViewInstrumentation.java
+++ b/dd-java-agent/instrumentation/dropwizard/dropwizard-views/src/main/java/datadog/trace/instrumentation/dropwizard/view/DropwizardViewInstrumentation.java
@@ -12,7 +12,6 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
-import datadog.trace.api.DDSpanTypes;
 import datadog.trace.api.DDTags;
 import io.dropwizard.views.View;
 import io.opentracing.Scope;
@@ -59,7 +58,6 @@ public final class DropwizardViewInstrumentation extends Instrumenter.Default {
               .withTag(DDTags.RESOURCE_NAME, "View " + view.getTemplateName())
               .withTag(Tags.COMPONENT.getKey(), "dropwizard-view")
               .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_SERVER)
-              .withTag(DDTags.SPAN_TYPE, DDSpanTypes.HTTP_SERVER)
               .withTag("span.origin.type", obj.getClass().getSimpleName())
               .startActive(true);
 

--- a/dd-java-agent/instrumentation/dropwizard/dropwizard-views/src/test/groovy/ViewRenderTest.groovy
+++ b/dd-java-agent/instrumentation/dropwizard/dropwizard-views/src/test/groovy/ViewRenderTest.groovy
@@ -27,7 +27,6 @@ class ViewRenderTest extends AgentTestRunner {
             "component" "dropwizard-view"
             "span.origin.type" renderer.class.simpleName
             "span.kind" "server"
-            "span.type" "web"
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/elasticsearch/rest-5/src/latestDepTest/groovy/Elasticsearch6RestClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/rest-5/src/latestDepTest/groovy/Elasticsearch6RestClientTest.groovy
@@ -2,7 +2,6 @@ import com.anotherchrisberry.spock.extensions.retry.RetryOnFailure
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
-import datadog.trace.api.DDTags
 import groovy.json.JsonSlurper
 import io.opentracing.tag.Tags
 import org.apache.http.HttpHost
@@ -90,7 +89,6 @@ class Elasticsearch6RestClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "$Tags.HTTP_METHOD.key" "GET"
             "$Tags.HTTP_URL.key" "_cluster/health"
             "$Tags.PEER_HOSTNAME.key" "localhost"

--- a/dd-java-agent/instrumentation/elasticsearch/rest-5/src/test/groovy/Elasticsearch5RestClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/rest-5/src/test/groovy/Elasticsearch5RestClientTest.groovy
@@ -2,7 +2,6 @@ import com.anotherchrisberry.spock.extensions.retry.RetryOnFailure
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
-import datadog.trace.api.DDTags
 import groovy.json.JsonSlurper
 import io.opentracing.tag.Tags
 import org.apache.http.HttpHost
@@ -95,7 +94,6 @@ class Elasticsearch5RestClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "$Tags.HTTP_METHOD.key" "GET"
             "$Tags.HTTP_URL.key" "_cluster/health"
             "$Tags.PEER_HOSTNAME.key" "localhost"

--- a/dd-java-agent/instrumentation/elasticsearch/rest-6.4/src/latestDepTest/groovy/Elasticsearch6RestClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/rest-6.4/src/latestDepTest/groovy/Elasticsearch6RestClientTest.groovy
@@ -2,7 +2,6 @@ import com.anotherchrisberry.spock.extensions.retry.RetryOnFailure
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
-import datadog.trace.api.DDTags
 import groovy.json.JsonSlurper
 import io.opentracing.tag.Tags
 import org.apache.http.HttpHost
@@ -94,7 +93,6 @@ class Elasticsearch6RestClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "$Tags.HTTP_METHOD.key" "GET"
             "$Tags.HTTP_URL.key" "_cluster/health"
             "$Tags.PEER_HOSTNAME.key" "localhost"

--- a/dd-java-agent/instrumentation/elasticsearch/rest-6.4/src/test/groovy/Elasticsearch6RestClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/rest-6.4/src/test/groovy/Elasticsearch6RestClientTest.groovy
@@ -2,7 +2,6 @@ import com.anotherchrisberry.spock.extensions.retry.RetryOnFailure
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
-import datadog.trace.api.DDTags
 import groovy.json.JsonSlurper
 import io.opentracing.tag.Tags
 import org.apache.http.HttpHost
@@ -90,7 +89,6 @@ class Elasticsearch6RestClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "$Tags.HTTP_METHOD.key" "GET"
             "$Tags.HTTP_URL.key" "_cluster/health"
             "$Tags.PEER_HOSTNAME.key" "localhost"

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/Elasticsearch2NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/Elasticsearch2NodeClientTest.groovy
@@ -2,7 +2,6 @@ import com.anotherchrisberry.spock.extensions.retry.RetryOnFailure
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
-import datadog.trace.api.DDTags
 import io.opentracing.tag.Tags
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest
 import org.elasticsearch.common.io.FileSystemUtils
@@ -82,7 +81,6 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
             defaultTags()
@@ -112,7 +110,6 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -185,7 +182,6 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "CreateIndexAction"
             "elasticsearch.request" "CreateIndexRequest"
             "elasticsearch.request.indices" indexName
@@ -203,7 +199,6 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
             defaultTags()
@@ -220,7 +215,6 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -241,7 +235,6 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "PutMappingAction"
             "elasticsearch.request" "PutMappingRequest"
             "elasticsearch.request.indices" indexName
@@ -259,7 +252,6 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
@@ -278,7 +270,6 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/Elasticsearch2TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/Elasticsearch2TransportClientTest.groovy
@@ -2,7 +2,6 @@ import com.anotherchrisberry.spock.extensions.retry.RetryOnFailure
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
-import datadog.trace.api.DDTags
 import io.opentracing.tag.Tags
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest
 import org.elasticsearch.client.transport.TransportClient
@@ -93,7 +92,6 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "$Tags.PEER_HOSTNAME.key" "localhost"
             "$Tags.PEER_HOST_IPV4.key" "127.0.0.1"
             "$Tags.PEER_PORT.key" tcpPort
@@ -126,7 +124,6 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -199,7 +196,6 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "CreateIndexAction"
             "elasticsearch.request" "CreateIndexRequest"
             "elasticsearch.request.indices" indexName
@@ -220,7 +216,6 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
             "$Tags.PEER_HOSTNAME.key" "localhost"
@@ -240,7 +235,6 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "$Tags.PEER_HOSTNAME.key" "localhost"
             "$Tags.PEER_HOST_IPV4.key" "127.0.0.1"
             "$Tags.PEER_PORT.key" tcpPort
@@ -264,7 +258,6 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "PutMappingAction"
             "elasticsearch.request" "PutMappingRequest"
             "elasticsearch.request.indices" indexName
@@ -282,7 +275,6 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "$Tags.PEER_HOSTNAME.key" "localhost"
             "$Tags.PEER_HOST_IPV4.key" "127.0.0.1"
             "$Tags.PEER_PORT.key" tcpPort
@@ -304,7 +296,6 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "$Tags.PEER_HOSTNAME.key" "localhost"
             "$Tags.PEER_HOST_IPV4.key" "127.0.0.1"
             "$Tags.PEER_PORT.key" tcpPort

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/springdata/Elasticsearch2SpringRepositoryTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/springdata/Elasticsearch2SpringRepositoryTest.groovy
@@ -3,7 +3,6 @@ package springdata
 import com.anotherchrisberry.spock.extensions.retry.RetryOnFailure
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.DDSpanTypes
-import datadog.trace.api.DDTags
 import io.opentracing.tag.Tags
 import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.AnnotationConfigApplicationContext
@@ -48,7 +47,6 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "SearchAction"
             "elasticsearch.request" "SearchRequest"
             "elasticsearch.request.indices" indexName
@@ -81,7 +79,6 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
@@ -99,7 +96,6 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "RefreshAction"
             "elasticsearch.request" "RefreshRequest"
             "elasticsearch.request.indices" indexName
@@ -128,7 +124,6 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -160,7 +155,6 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
@@ -178,7 +172,6 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "RefreshAction"
             "elasticsearch.request" "RefreshRequest"
             "elasticsearch.request.indices" indexName
@@ -199,7 +192,6 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -230,7 +222,6 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "DeleteAction"
             "elasticsearch.request" "DeleteRequest"
             "elasticsearch.request.indices" indexName
@@ -248,7 +239,6 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "RefreshAction"
             "elasticsearch.request" "RefreshRequest"
             "elasticsearch.request.indices" indexName
@@ -269,7 +259,6 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "SearchAction"
             "elasticsearch.request" "SearchRequest"
             "elasticsearch.request.indices" indexName

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
@@ -4,7 +4,6 @@ import com.anotherchrisberry.spock.extensions.retry.RetryOnFailure
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
-import datadog.trace.api.DDTags
 import io.opentracing.tag.Tags
 import org.elasticsearch.action.search.SearchResponse
 import org.elasticsearch.common.io.FileSystemUtils
@@ -88,7 +87,6 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "RefreshAction"
             "elasticsearch.request" "RefreshRequest"
             "elasticsearch.request.indices" indexName
@@ -152,7 +150,6 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "CreateIndexAction"
             "elasticsearch.request" "CreateIndexRequest"
             "elasticsearch.request.indices" indexName
@@ -170,7 +167,6 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
             defaultTags()
@@ -187,7 +183,6 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "SearchAction"
             "elasticsearch.request" "SearchRequest"
             "elasticsearch.request.indices" indexName
@@ -206,7 +201,6 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "PutMappingAction"
             "elasticsearch.request" "PutMappingRequest"
             "elasticsearch.request.indices" indexName
@@ -224,7 +218,6 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
@@ -243,7 +236,6 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "RefreshAction"
             "elasticsearch.request" "RefreshRequest"
             "elasticsearch.request.indices" indexName
@@ -264,7 +256,6 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "SearchAction"
             "elasticsearch.request" "SearchRequest"
             "elasticsearch.request.indices" indexName
@@ -344,11 +335,11 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           serviceName "elasticsearch"
           resourceName "SearchAction"
           operationName "elasticsearch.query"
+          spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "SearchAction"
             "elasticsearch.request" "SearchRequest"
             "elasticsearch.request.indices" indexName

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/Elasticsearch2NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/Elasticsearch2NodeClientTest.groovy
@@ -2,7 +2,6 @@ import com.anotherchrisberry.spock.extensions.retry.RetryOnFailure
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
-import datadog.trace.api.DDTags
 import io.opentracing.tag.Tags
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest
 import org.elasticsearch.common.io.FileSystemUtils
@@ -82,7 +81,6 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
             defaultTags()
@@ -112,7 +110,6 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -185,7 +182,6 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "CreateIndexAction"
             "elasticsearch.request" "CreateIndexRequest"
             "elasticsearch.request.indices" indexName
@@ -203,7 +199,6 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
             defaultTags()
@@ -220,7 +215,6 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "$Tags.PEER_HOSTNAME.key" "local"
             "$Tags.PEER_HOST_IPV4.key" "0.0.0.0"
             "$Tags.PEER_PORT.key" 0
@@ -244,7 +238,6 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "PutMappingAction"
             "elasticsearch.request" "PutMappingRequest"
             "elasticsearch.request.indices" indexName
@@ -262,7 +255,6 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "$Tags.PEER_HOSTNAME.key" "local"
             "$Tags.PEER_HOST_IPV4.key" "0.0.0.0"
             "$Tags.PEER_PORT.key" 0
@@ -284,7 +276,6 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "$Tags.PEER_HOSTNAME.key" "local"
             "$Tags.PEER_HOST_IPV4.key" "0.0.0.0"
             "$Tags.PEER_PORT.key" 0

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/Elasticsearch2TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/Elasticsearch2TransportClientTest.groovy
@@ -2,7 +2,6 @@ import com.anotherchrisberry.spock.extensions.retry.RetryOnFailure
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
-import datadog.trace.api.DDTags
 import io.opentracing.tag.Tags
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest
 import org.elasticsearch.client.transport.TransportClient
@@ -93,7 +92,6 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "$Tags.PEER_HOSTNAME.key" "127.0.0.1"
             "$Tags.PEER_HOST_IPV4.key" "127.0.0.1"
             "$Tags.PEER_PORT.key" tcpPort
@@ -126,7 +124,6 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -199,7 +196,6 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "CreateIndexAction"
             "elasticsearch.request" "CreateIndexRequest"
             "elasticsearch.request.indices" indexName
@@ -220,7 +216,6 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
             "$Tags.PEER_HOSTNAME.key" "127.0.0.1"
@@ -240,7 +235,6 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "$Tags.PEER_HOSTNAME.key" "127.0.0.1"
             "$Tags.PEER_HOST_IPV4.key" "127.0.0.1"
             "$Tags.PEER_PORT.key" tcpPort
@@ -264,7 +258,6 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "PutMappingAction"
             "elasticsearch.request" "PutMappingRequest"
             "elasticsearch.request.indices" indexName
@@ -282,7 +275,6 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "$Tags.PEER_HOSTNAME.key" "127.0.0.1"
             "$Tags.PEER_HOST_IPV4.key" "127.0.0.1"
             "$Tags.PEER_PORT.key" tcpPort
@@ -304,7 +296,6 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "$Tags.PEER_HOSTNAME.key" "127.0.0.1"
             "$Tags.PEER_HOST_IPV4.key" "127.0.0.1"
             "$Tags.PEER_PORT.key" tcpPort

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/springdata/Elasticsearch2SpringRepositoryTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/springdata/Elasticsearch2SpringRepositoryTest.groovy
@@ -3,7 +3,6 @@ package springdata
 import com.anotherchrisberry.spock.extensions.retry.RetryOnFailure
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.DDSpanTypes
-import datadog.trace.api.DDTags
 import io.opentracing.tag.Tags
 import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.AnnotationConfigApplicationContext
@@ -48,7 +47,6 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "SearchAction"
             "elasticsearch.request" "SearchRequest"
             "elasticsearch.request.indices" indexName
@@ -81,7 +79,6 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "$Tags.PEER_HOSTNAME.key" "local"
             "$Tags.PEER_HOST_IPV4.key" "0.0.0.0"
             "$Tags.PEER_PORT.key" 0
@@ -102,7 +99,6 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "RefreshAction"
             "elasticsearch.request" "RefreshRequest"
             "elasticsearch.request.indices" indexName
@@ -131,7 +127,6 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "$Tags.PEER_HOSTNAME.key" "local"
             "$Tags.PEER_HOST_IPV4.key" "0.0.0.0"
             "$Tags.PEER_PORT.key" 0
@@ -166,7 +161,6 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "$Tags.PEER_HOSTNAME.key" "local"
             "$Tags.PEER_HOST_IPV4.key" "0.0.0.0"
             "$Tags.PEER_PORT.key" 0
@@ -187,7 +181,6 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "RefreshAction"
             "elasticsearch.request" "RefreshRequest"
             "elasticsearch.request.indices" indexName
@@ -208,7 +201,6 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "$Tags.PEER_HOSTNAME.key" "local"
             "$Tags.PEER_HOST_IPV4.key" "0.0.0.0"
             "$Tags.PEER_PORT.key" 0
@@ -242,7 +234,6 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "$Tags.PEER_HOSTNAME.key" "local"
             "$Tags.PEER_HOST_IPV4.key" "0.0.0.0"
             "$Tags.PEER_PORT.key" 0
@@ -263,7 +254,6 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "RefreshAction"
             "elasticsearch.request" "RefreshRequest"
             "elasticsearch.request.indices" indexName
@@ -284,7 +274,6 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "SearchAction"
             "elasticsearch.request" "SearchRequest"
             "elasticsearch.request.indices" indexName

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
@@ -4,7 +4,6 @@ import com.anotherchrisberry.spock.extensions.retry.RetryOnFailure
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
-import datadog.trace.api.DDTags
 import io.opentracing.tag.Tags
 import org.elasticsearch.action.search.SearchResponse
 import org.elasticsearch.common.io.FileSystemUtils
@@ -88,7 +87,6 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "RefreshAction"
             "elasticsearch.request" "RefreshRequest"
             "elasticsearch.request.indices" indexName
@@ -152,7 +150,6 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "CreateIndexAction"
             "elasticsearch.request" "CreateIndexRequest"
             "elasticsearch.request.indices" indexName
@@ -170,7 +167,6 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
             defaultTags()
@@ -187,7 +183,6 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "SearchAction"
             "elasticsearch.request" "SearchRequest"
             "elasticsearch.request.indices" indexName
@@ -206,7 +201,6 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "PutMappingAction"
             "elasticsearch.request" "PutMappingRequest"
             "elasticsearch.request.indices" indexName
@@ -224,7 +218,6 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "$Tags.PEER_HOSTNAME.key" "local"
             "$Tags.PEER_HOST_IPV4.key" "0.0.0.0"
             "$Tags.PEER_PORT.key" 0
@@ -246,7 +239,6 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "RefreshAction"
             "elasticsearch.request" "RefreshRequest"
             "elasticsearch.request.indices" indexName
@@ -267,7 +259,6 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "SearchAction"
             "elasticsearch.request" "SearchRequest"
             "elasticsearch.request.indices" indexName
@@ -344,11 +335,11 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           serviceName "elasticsearch"
           resourceName "SearchAction"
           operationName "elasticsearch.query"
+          spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "SearchAction"
             "elasticsearch.request" "SearchRequest"
             "elasticsearch.request.indices" indexName

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/Elasticsearch53NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/Elasticsearch53NodeClientTest.groovy
@@ -2,7 +2,6 @@ import com.anotherchrisberry.spock.extensions.retry.RetryOnFailure
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
-import datadog.trace.api.DDTags
 import io.opentracing.tag.Tags
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest
 import org.elasticsearch.common.io.FileSystemUtils
@@ -88,7 +87,6 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
             defaultTags()
@@ -118,7 +116,6 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -192,7 +189,6 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "CreateIndexAction"
             "elasticsearch.request" "CreateIndexRequest"
             "elasticsearch.request.indices" indexName
@@ -210,7 +206,6 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
             defaultTags()
@@ -227,7 +222,6 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -248,7 +242,6 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "PutMappingAction"
             "elasticsearch.request" "PutMappingRequest"
             defaultTags()
@@ -265,7 +258,6 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
@@ -289,7 +281,6 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/Elasticsearch53TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/Elasticsearch53TransportClientTest.groovy
@@ -2,7 +2,6 @@ import com.anotherchrisberry.spock.extensions.retry.RetryOnFailure
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
-import datadog.trace.api.DDTags
 import io.opentracing.tag.Tags
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest
 import org.elasticsearch.client.transport.TransportClient
@@ -100,7 +99,6 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "$Tags.PEER_HOSTNAME.key" "localhost"
             "$Tags.PEER_HOST_IPV4.key" "127.0.0.1"
             "$Tags.PEER_PORT.key" tcpPort
@@ -133,7 +131,6 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -206,7 +203,6 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "$Tags.PEER_HOSTNAME.key" "localhost"
             "$Tags.PEER_HOST_IPV4.key" "127.0.0.1"
             "$Tags.PEER_PORT.key" tcpPort
@@ -227,7 +223,6 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "$Tags.PEER_HOSTNAME.key" "localhost"
             "$Tags.PEER_HOST_IPV4.key" "127.0.0.1"
             "$Tags.PEER_PORT.key" tcpPort
@@ -251,7 +246,6 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "PutMappingAction"
             "elasticsearch.request" "PutMappingRequest"
             defaultTags()
@@ -268,7 +262,6 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "$Tags.PEER_HOSTNAME.key" "localhost"
             "$Tags.PEER_HOST_IPV4.key" "127.0.0.1"
             "$Tags.PEER_PORT.key" tcpPort
@@ -295,7 +288,6 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "$Tags.PEER_HOSTNAME.key" "localhost"
             "$Tags.PEER_HOST_IPV4.key" "127.0.0.1"
             "$Tags.PEER_PORT.key" tcpPort

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/springdata/Elasticsearch53SpringRepositoryTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/springdata/Elasticsearch53SpringRepositoryTest.groovy
@@ -3,7 +3,6 @@ package springdata
 import com.anotherchrisberry.spock.extensions.retry.RetryOnFailure
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.DDSpanTypes
-import datadog.trace.api.DDTags
 import io.opentracing.tag.Tags
 import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.AnnotationConfigApplicationContext
@@ -48,7 +47,6 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "SearchAction"
             "elasticsearch.request" "SearchRequest"
             "elasticsearch.request.indices" indexName
@@ -81,7 +79,6 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
@@ -104,7 +101,6 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "RefreshAction"
             "elasticsearch.request" "RefreshRequest"
             "elasticsearch.request.indices" indexName
@@ -133,7 +129,6 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -165,7 +160,6 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
@@ -188,7 +182,6 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "RefreshAction"
             "elasticsearch.request" "RefreshRequest"
             "elasticsearch.request.indices" indexName
@@ -209,7 +202,6 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -240,7 +232,6 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "DeleteAction"
             "elasticsearch.request" "DeleteRequest"
             "elasticsearch.request.indices" indexName
@@ -262,7 +253,6 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "RefreshAction"
             "elasticsearch.request" "RefreshRequest"
             "elasticsearch.request.indices" indexName
@@ -283,7 +273,6 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "SearchAction"
             "elasticsearch.request" "SearchRequest"
             "elasticsearch.request.indices" indexName

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/springdata/Elasticsearch53SpringTemplateTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/springdata/Elasticsearch53SpringTemplateTest.groovy
@@ -5,7 +5,6 @@ import com.google.common.collect.ImmutableSet
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
-import datadog.trace.api.DDTags
 import io.opentracing.tag.Tags
 import org.elasticsearch.action.search.SearchResponse
 import org.elasticsearch.common.io.FileSystemUtils
@@ -108,7 +107,6 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "RefreshAction"
             "elasticsearch.request" "RefreshRequest"
             "elasticsearch.request.indices" indexName
@@ -176,7 +174,6 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "CreateIndexAction"
             "elasticsearch.request" "CreateIndexRequest"
             "elasticsearch.request.indices" indexName
@@ -194,7 +191,6 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
             defaultTags()
@@ -211,7 +207,6 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "SearchAction"
             "elasticsearch.request" "SearchRequest"
             "elasticsearch.request.indices" indexName
@@ -230,7 +225,6 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "PutMappingAction"
             "elasticsearch.request" "PutMappingRequest"
             defaultTags()
@@ -247,7 +241,6 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
@@ -271,7 +264,6 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "RefreshAction"
             "elasticsearch.request" "RefreshRequest"
             "elasticsearch.request.indices" indexName
@@ -292,7 +284,6 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "SearchAction"
             "elasticsearch.request" "SearchRequest"
             "elasticsearch.request.indices" indexName
@@ -372,11 +363,11 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
           serviceName "elasticsearch"
           resourceName "SearchAction"
           operationName "elasticsearch.query"
+          spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "SearchAction"
             "elasticsearch.request" "SearchRequest"
             "elasticsearch.request.indices" indexName

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5/src/latestDepTest/groovy/Elasticsearch5NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5/src/latestDepTest/groovy/Elasticsearch5NodeClientTest.groovy
@@ -2,7 +2,6 @@ import com.anotherchrisberry.spock.extensions.retry.RetryOnFailure
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.TestUtils
 import datadog.trace.api.DDSpanTypes
-import datadog.trace.api.DDTags
 import io.opentracing.tag.Tags
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest
 import org.elasticsearch.common.io.FileSystemUtils
@@ -88,7 +87,6 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
             defaultTags()
@@ -118,7 +116,6 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -192,7 +189,6 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "CreateIndexAction"
             "elasticsearch.request" "CreateIndexRequest"
             "elasticsearch.request.indices" indexName
@@ -210,7 +206,6 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
             defaultTags()
@@ -227,7 +222,6 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -248,7 +242,6 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "PutMappingAction"
             "elasticsearch.request" "PutMappingRequest"
             defaultTags()
@@ -265,7 +258,6 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
@@ -288,7 +280,6 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5/src/latestDepTest/groovy/Elasticsearch5TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5/src/latestDepTest/groovy/Elasticsearch5TransportClientTest.groovy
@@ -2,7 +2,6 @@ import com.anotherchrisberry.spock.extensions.retry.RetryOnFailure
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.TestUtils
 import datadog.trace.api.DDSpanTypes
-import datadog.trace.api.DDTags
 import io.opentracing.tag.Tags
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest
 import org.elasticsearch.client.transport.TransportClient
@@ -100,7 +99,6 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "$Tags.PEER_HOSTNAME.key" "localhost"
             "$Tags.PEER_HOST_IPV4.key" "127.0.0.1"
             "$Tags.PEER_PORT.key" tcpPort
@@ -133,7 +131,6 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -206,7 +203,6 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "CreateIndexAction"
             "elasticsearch.request" "CreateIndexRequest"
             "elasticsearch.request.indices" indexName
@@ -227,7 +223,6 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "$Tags.PEER_HOSTNAME.key" "localhost"
             "$Tags.PEER_HOST_IPV4.key" "127.0.0.1"
             "$Tags.PEER_PORT.key" tcpPort
@@ -251,7 +246,6 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "PutMappingAction"
             "elasticsearch.request" "PutMappingRequest"
             defaultTags()
@@ -268,7 +262,6 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "$Tags.PEER_HOSTNAME.key" "localhost"
             "$Tags.PEER_HOST_IPV4.key" "127.0.0.1"
             "$Tags.PEER_PORT.key" tcpPort
@@ -294,7 +287,6 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "$Tags.PEER_HOSTNAME.key" "localhost"
             "$Tags.PEER_HOST_IPV4.key" "127.0.0.1"
             "$Tags.PEER_PORT.key" tcpPort

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5/src/test/groovy/Elasticsearch5NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5/src/test/groovy/Elasticsearch5NodeClientTest.groovy
@@ -2,7 +2,6 @@ import com.anotherchrisberry.spock.extensions.retry.RetryOnFailure
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
-import datadog.trace.api.DDTags
 import io.opentracing.tag.Tags
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest
 import org.elasticsearch.common.io.FileSystemUtils
@@ -88,7 +87,6 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
             defaultTags()
@@ -118,7 +116,6 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -192,7 +189,6 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "CreateIndexAction"
             "elasticsearch.request" "CreateIndexRequest"
             "elasticsearch.request.indices" indexName
@@ -210,7 +206,6 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
             defaultTags()
@@ -227,7 +222,6 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -248,7 +242,6 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "PutMappingAction"
             "elasticsearch.request" "PutMappingRequest"
             defaultTags()
@@ -265,7 +258,6 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
@@ -288,7 +280,6 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5/src/test/groovy/Elasticsearch5TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5/src/test/groovy/Elasticsearch5TransportClientTest.groovy
@@ -2,7 +2,6 @@ import com.anotherchrisberry.spock.extensions.retry.RetryOnFailure
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
-import datadog.trace.api.DDTags
 import io.opentracing.tag.Tags
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest
 import org.elasticsearch.client.transport.TransportClient
@@ -100,7 +99,6 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "$Tags.PEER_HOSTNAME.key" String
             "$Tags.PEER_HOST_IPV4.key" "127.0.0.1"
             "$Tags.PEER_PORT.key" tcpPort
@@ -133,7 +131,6 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -206,7 +203,6 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "CreateIndexAction"
             "elasticsearch.request" "CreateIndexRequest"
             "elasticsearch.request.indices" indexName
@@ -227,7 +223,6 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "$Tags.PEER_HOSTNAME.key" String
             "$Tags.PEER_HOST_IPV4.key" "127.0.0.1"
             "$Tags.PEER_PORT.key" tcpPort
@@ -251,7 +246,6 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "PutMappingAction"
             "elasticsearch.request" "PutMappingRequest"
             defaultTags()
@@ -268,7 +262,6 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "$Tags.PEER_HOSTNAME.key" String
             "$Tags.PEER_HOST_IPV4.key" "127.0.0.1"
             "$Tags.PEER_PORT.key" tcpPort
@@ -294,7 +287,6 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "$Tags.PEER_HOSTNAME.key" String
             "$Tags.PEER_HOST_IPV4.key" "127.0.0.1"
             "$Tags.PEER_PORT.key" tcpPort

--- a/dd-java-agent/instrumentation/elasticsearch/transport-6/src/test/groovy/Elasticsearch6NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-6/src/test/groovy/Elasticsearch6NodeClientTest.groovy
@@ -2,7 +2,6 @@ import com.anotherchrisberry.spock.extensions.retry.RetryOnFailure
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
-import datadog.trace.api.DDTags
 import io.opentracing.tag.Tags
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest
 import org.elasticsearch.common.io.FileSystemUtils
@@ -85,7 +84,6 @@ class Elasticsearch6NodeClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
             defaultTags()
@@ -115,7 +113,6 @@ class Elasticsearch6NodeClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -188,7 +185,6 @@ class Elasticsearch6NodeClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "CreateIndexAction"
             "elasticsearch.request" "CreateIndexRequest"
             "elasticsearch.request.indices" indexName
@@ -206,7 +202,6 @@ class Elasticsearch6NodeClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -227,7 +222,6 @@ class Elasticsearch6NodeClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "PutMappingAction"
             "elasticsearch.request" "PutMappingRequest"
             defaultTags()
@@ -244,7 +238,6 @@ class Elasticsearch6NodeClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
@@ -268,7 +261,6 @@ class Elasticsearch6NodeClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName

--- a/dd-java-agent/instrumentation/elasticsearch/transport-6/src/test/groovy/Elasticsearch6TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-6/src/test/groovy/Elasticsearch6TransportClientTest.groovy
@@ -2,7 +2,6 @@ import com.anotherchrisberry.spock.extensions.retry.RetryOnFailure
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
-import datadog.trace.api.DDTags
 import io.opentracing.tag.Tags
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest
 import org.elasticsearch.client.transport.TransportClient
@@ -97,7 +96,6 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "$Tags.PEER_HOSTNAME.key" "localhost"
             "$Tags.PEER_HOST_IPV4.key" "127.0.0.1"
             "$Tags.PEER_PORT.key" tcpPort
@@ -130,7 +128,6 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -203,7 +200,6 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "$Tags.PEER_HOSTNAME.key" "localhost"
             "$Tags.PEER_HOST_IPV4.key" "127.0.0.1"
             "$Tags.PEER_PORT.key" tcpPort
@@ -224,7 +220,6 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "$Tags.PEER_HOSTNAME.key" "localhost"
             "$Tags.PEER_HOST_IPV4.key" "127.0.0.1"
             "$Tags.PEER_PORT.key" tcpPort
@@ -248,7 +243,6 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "elasticsearch.action" "PutMappingAction"
             "elasticsearch.request" "PutMappingRequest"
             defaultTags()
@@ -265,7 +259,6 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "$Tags.PEER_HOSTNAME.key" "localhost"
             "$Tags.PEER_HOST_IPV4.key" "127.0.0.1"
             "$Tags.PEER_PORT.key" tcpPort
@@ -292,7 +285,6 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "elasticsearch-java"
             "$Tags.DB_TYPE.key" "elasticsearch"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "$Tags.PEER_HOSTNAME.key" "localhost"
             "$Tags.PEER_HOST_IPV4.key" "127.0.0.1"
             "$Tags.PEER_PORT.key" tcpPort

--- a/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcStreamingTest.groovy
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcStreamingTest.groovy
@@ -1,6 +1,5 @@
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.DDSpanTypes
-import datadog.trace.api.DDTags
 import example.GreeterGrpc
 import example.Helloworld
 import io.grpc.BindableService
@@ -93,7 +92,6 @@ class GrpcStreamingTest extends AgentTestRunner {
           errored false
           tags {
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
-            "$DDTags.SPAN_TYPE" DDSpanTypes.RPC
             "$Tags.COMPONENT.key" "grpc-server"
             defaultTags(true)
           }
@@ -108,7 +106,6 @@ class GrpcStreamingTest extends AgentTestRunner {
             errored false
             tags {
               "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
-              "$DDTags.SPAN_TYPE" DDSpanTypes.RPC
               "$Tags.COMPONENT.key" "grpc-server"
               "message.type" "example.Helloworld\$Response"
               defaultTags()
@@ -127,7 +124,6 @@ class GrpcStreamingTest extends AgentTestRunner {
           tags {
             "status.code" "OK"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.RPC
             "$Tags.COMPONENT.key" "grpc-client"
             defaultTags()
           }
@@ -142,7 +138,6 @@ class GrpcStreamingTest extends AgentTestRunner {
             errored false
             tags {
               "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-              "$DDTags.SPAN_TYPE" DDSpanTypes.RPC
               "$Tags.COMPONENT.key" "grpc-client"
               "message.type" "example.Helloworld\$Response"
               defaultTags()

--- a/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcTest.groovy
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcTest.groovy
@@ -1,6 +1,5 @@
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.DDSpanTypes
-import datadog.trace.api.DDTags
 import example.GreeterGrpc
 import example.Helloworld
 import io.grpc.BindableService
@@ -49,7 +48,6 @@ class GrpcTest extends AgentTestRunner {
           errored false
           tags {
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
-            "$DDTags.SPAN_TYPE" DDSpanTypes.RPC
             "$Tags.COMPONENT.key" "grpc-server"
             defaultTags(true)
           }
@@ -63,7 +61,6 @@ class GrpcTest extends AgentTestRunner {
           errored false
           tags {
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
-            "$DDTags.SPAN_TYPE" DDSpanTypes.RPC
             "$Tags.COMPONENT.key" "grpc-server"
             "message.type" "example.Helloworld\$Request"
             defaultTags()
@@ -81,7 +78,6 @@ class GrpcTest extends AgentTestRunner {
           tags {
             "status.code" "OK"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.RPC
             "$Tags.COMPONENT.key" "grpc-client"
             defaultTags()
           }
@@ -95,7 +91,6 @@ class GrpcTest extends AgentTestRunner {
           errored false
           tags {
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.RPC
             "$Tags.COMPONENT.key" "grpc-client"
             "message.type" "example.Helloworld\$Response"
             defaultTags()
@@ -144,7 +139,6 @@ class GrpcTest extends AgentTestRunner {
           errored false
           tags {
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
-            "$DDTags.SPAN_TYPE" DDSpanTypes.RPC
             "$Tags.COMPONENT.key" "grpc-server"
             defaultTags(true)
           }
@@ -158,7 +152,6 @@ class GrpcTest extends AgentTestRunner {
           errored false
           tags {
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
-            "$DDTags.SPAN_TYPE" DDSpanTypes.RPC
             "$Tags.COMPONENT.key" "grpc-server"
             "message.type" "example.Helloworld\$Request"
             defaultTags()
@@ -177,7 +170,6 @@ class GrpcTest extends AgentTestRunner {
             "status.code" "${status.code.name()}"
             "status.description" description
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.RPC
             "$Tags.COMPONENT.key" "grpc-client"
             tag "error", true
             defaultTags()
@@ -232,7 +224,6 @@ class GrpcTest extends AgentTestRunner {
           errored true
           tags {
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
-            "$DDTags.SPAN_TYPE" DDSpanTypes.RPC
             "$Tags.COMPONENT.key" "grpc-server"
             errorTags error.class, error.message
             defaultTags(true)
@@ -247,7 +238,6 @@ class GrpcTest extends AgentTestRunner {
           errored false
           tags {
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
-            "$DDTags.SPAN_TYPE" DDSpanTypes.RPC
             "$Tags.COMPONENT.key" "grpc-server"
             "message.type" "example.Helloworld\$Request"
             defaultTags()
@@ -265,7 +255,6 @@ class GrpcTest extends AgentTestRunner {
           tags {
             "status.code" "UNKNOWN"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.RPC
             "$Tags.COMPONENT.key" "grpc-client"
             tag "error", true
             defaultTags()

--- a/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionTest.groovy
+++ b/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionTest.groovy
@@ -1,7 +1,6 @@
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.Config
 import datadog.trace.api.DDSpanTypes
-import datadog.trace.api.DDTags
 import io.opentracing.tag.Tags
 import io.opentracing.util.GlobalTracer
 import org.springframework.web.client.RestTemplate
@@ -72,12 +71,13 @@ class HttpUrlConnectionTest extends AgentTestRunner {
         span(1) {
           serviceName renameService ? "localhost" : "unnamed-java-app"
           operationName OPERATION_NAME
+          resourceName "GET /"
+          spanType DDSpanTypes.HTTP_CLIENT
           childOf span(0)
           errored false
           tags {
             "$Tags.COMPONENT.key" "http-url-connection"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_CLIENT
             "$Tags.HTTP_URL.key" "$server.address"
             "$Tags.HTTP_METHOD.key" "GET"
             "$Tags.HTTP_STATUS.key" STATUS
@@ -89,12 +89,13 @@ class HttpUrlConnectionTest extends AgentTestRunner {
         span(2) {
           serviceName renameService ? "localhost" : "unnamed-java-app"
           operationName OPERATION_NAME
+          resourceName "GET /"
+          spanType DDSpanTypes.HTTP_CLIENT
           childOf span(0)
           errored false
           tags {
             "$Tags.COMPONENT.key" "http-url-connection"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_CLIENT
             "$Tags.HTTP_URL.key" "$server.address"
             "$Tags.HTTP_METHOD.key" "GET"
             "$Tags.HTTP_STATUS.key" STATUS
@@ -153,12 +154,13 @@ class HttpUrlConnectionTest extends AgentTestRunner {
         span(1) {
           serviceName renameService ? "localhost" : "unnamed-java-app"
           operationName OPERATION_NAME
+          resourceName "GET /"
+          spanType DDSpanTypes.HTTP_CLIENT
           childOf span(0)
           errored false
           tags {
             "$Tags.COMPONENT.key" "http-url-connection"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_CLIENT
             "$Tags.HTTP_URL.key" "$server.address"
             "$Tags.HTTP_METHOD.key" "GET"
             "$Tags.HTTP_STATUS.key" STATUS
@@ -170,12 +172,13 @@ class HttpUrlConnectionTest extends AgentTestRunner {
         span(2) {
           serviceName renameService ? "localhost" : "unnamed-java-app"
           operationName OPERATION_NAME
+          resourceName "GET /"
+          spanType DDSpanTypes.HTTP_CLIENT
           childOf span(0)
           errored false
           tags {
             "$Tags.COMPONENT.key" "http-url-connection"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_CLIENT
             "$Tags.HTTP_URL.key" "$server.address"
             "$Tags.HTTP_METHOD.key" "GET"
             "$Tags.HTTP_STATUS.key" STATUS
@@ -218,12 +221,13 @@ class HttpUrlConnectionTest extends AgentTestRunner {
         span(1) {
           serviceName renameService ? "localhost" : "unnamed-java-app"
           operationName OPERATION_NAME
+          resourceName "HEAD /"
+          spanType DDSpanTypes.HTTP_CLIENT
           childOf span(0)
           errored false
           tags {
             "$Tags.COMPONENT.key" "http-url-connection"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_CLIENT
             "$Tags.HTTP_URL.key" "$server.address"
             "$Tags.HTTP_METHOD.key" "HEAD"
             "$Tags.HTTP_STATUS.key" STATUS
@@ -266,12 +270,13 @@ class HttpUrlConnectionTest extends AgentTestRunner {
         span(1) {
           serviceName renameService ? "localhost" : "unnamed-java-app"
           operationName OPERATION_NAME
+          resourceName "GET /"
+          spanType DDSpanTypes.HTTP_CLIENT
           childOf span(0)
           errored false
           tags {
             "$Tags.COMPONENT.key" "http-url-connection"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_CLIENT
             "$Tags.HTTP_URL.key" "$server.address"
             "$Tags.HTTP_METHOD.key" "GET"
             "$Tags.HTTP_STATUS.key" STATUS
@@ -331,12 +336,13 @@ class HttpUrlConnectionTest extends AgentTestRunner {
         span(1) {
           serviceName renameService ? "localhost" : "unnamed-java-app"
           operationName OPERATION_NAME
+          resourceName "POST /"
+          spanType DDSpanTypes.HTTP_CLIENT
           childOf span(0)
           errored false
           tags {
             "$Tags.COMPONENT.key" "http-url-connection"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_CLIENT
             "$Tags.HTTP_URL.key" "$server.address"
             "$Tags.HTTP_METHOD.key" "POST"
             "$Tags.HTTP_STATUS.key" STATUS
@@ -398,12 +404,13 @@ class HttpUrlConnectionTest extends AgentTestRunner {
         span(0) {
           serviceName renameService ? "localhost" : "unnamed-java-app"
           operationName OPERATION_NAME
+          resourceName "GET /"
+          spanType DDSpanTypes.HTTP_CLIENT
           parent()
           errored false
           tags {
             "$Tags.COMPONENT.key" "http-url-connection"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_CLIENT
             "$Tags.HTTP_URL.key" "$server.address"
             "$Tags.HTTP_METHOD.key" "GET"
             "$Tags.HTTP_STATUS.key" STATUS
@@ -444,12 +451,13 @@ class HttpUrlConnectionTest extends AgentTestRunner {
         span(1) {
           serviceName renameService ? "localhost" : "unnamed-java-app"
           operationName OPERATION_NAME
+          resourceName "POST /"
+          spanType DDSpanTypes.HTTP_CLIENT
           childOf span(0)
           errored false
           tags {
             "$Tags.COMPONENT.key" "http-url-connection"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_CLIENT
             "$Tags.HTTP_URL.key" "$server.address"
             "$Tags.HTTP_METHOD.key" "POST"
             "$Tags.HTTP_STATUS.key" STATUS

--- a/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/UrlConnectionTest.groovy
+++ b/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/UrlConnectionTest.groovy
@@ -1,7 +1,6 @@
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.Config
 import datadog.trace.api.DDSpanTypes
-import datadog.trace.api.DDTags
 import datadog.trace.instrumentation.http_url_connection.UrlInstrumentation
 import io.opentracing.tag.Tags
 import io.opentracing.util.GlobalTracer
@@ -43,12 +42,13 @@ class UrlConnectionTest extends AgentTestRunner {
         span(1) {
           serviceName renameService ? "localhost" : "unnamed-java-app"
           operationName OPERATION_NAME
+          resourceName "GET /"
+          spanType DDSpanTypes.HTTP_CLIENT
           childOf span(0)
           errored true
           tags {
             "$Tags.COMPONENT.key" "http-url-connection"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_CLIENT
             "$Tags.HTTP_URL.key" "$url"
             "$Tags.HTTP_METHOD.key" "GET"
             "$Tags.PEER_HOSTNAME.key" "localhost"
@@ -97,13 +97,14 @@ class UrlConnectionTest extends AgentTestRunner {
         span(1) {
           serviceName "unnamed-java-app"
           operationName "file.request"
+          resourceName "$url.path"
+          spanType DDSpanTypes.HTTP_CLIENT
           childOf span(0)
           errored true
           tags {
             "$Tags.COMPONENT.key" UrlInstrumentation.COMPONENT
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
             // FIXME: These tags really make no sense for non-http connections, why do we set them?
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_CLIENT
             "$Tags.HTTP_URL.key" "$url"
             "$Tags.PEER_PORT.key" 80
             errorTags IllegalArgumentException, String

--- a/dd-java-agent/instrumentation/java-concurrent/src/slickTest/groovy/SlickTest.groovy
+++ b/dd-java-agent/instrumentation/java-concurrent/src/slickTest/groovy/SlickTest.groovy
@@ -1,6 +1,5 @@
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.DDSpanTypes
-import datadog.trace.api.DDTags
 import io.opentracing.tag.Tags
 
 class SlickTest extends AgentTestRunner {
@@ -33,12 +32,12 @@ class SlickTest extends AgentTestRunner {
           operationName "${SlickUtils.Driver()}.query"
           serviceName SlickUtils.Driver()
           resourceName SlickUtils.TestQuery()
+          spanType DDSpanTypes.SQL
           childOf span(0)
           errored false
           tags {
             "$Tags.COMPONENT.key" "java-jdbc-prepared_statement"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.SQL
 
             "$Tags.DB_TYPE.key" SlickUtils.Driver()
             "$Tags.DB_USER.key" SlickUtils.Username()
@@ -69,11 +68,11 @@ class SlickTest extends AgentTestRunner {
     assertTraces(2) {
       trace(0, 2, {
         span(0) {}
-        span(1) {}
+        span(1) { spanType DDSpanTypes.SQL }
       })
       trace(1, 2, {
         span(0) {}
-        span(1) {}
+        span(1) { spanType DDSpanTypes.SQL }
       })
     }
   }

--- a/dd-java-agent/instrumentation/jax-rs-client/src/test/groovy/JaxRsClientTest.groovy
+++ b/dd-java-agent/instrumentation/jax-rs-client/src/test/groovy/JaxRsClientTest.groovy
@@ -1,6 +1,4 @@
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.api.DDSpanTypes
-import datadog.trace.api.DDTags
 import io.opentracing.tag.Tags
 import org.apache.cxf.jaxrs.client.spec.ClientBuilderImpl
 import org.glassfish.jersey.client.JerseyClientBuilder
@@ -65,7 +63,6 @@ class JaxRsClientTest extends AgentTestRunner {
             "$Tags.HTTP_URL.key" "$server.address/ping"
             "$Tags.PEER_HOSTNAME.key" "localhost"
             "$Tags.PEER_PORT.key" server.address.port
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_CLIENT
             defaultTags()
           }
         }
@@ -116,7 +113,6 @@ class JaxRsClientTest extends AgentTestRunner {
             "$Tags.HTTP_URL.key" "http://localhost:$UNUSABLE_PORT/ping"
             "$Tags.PEER_HOSTNAME.key" "localhost"
             "$Tags.PEER_PORT.key" UNUSABLE_PORT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_CLIENT
             errorTags ProcessingException, String
             defaultTags()
           }

--- a/dd-java-agent/instrumentation/jdbc/src/test/groovy/JDBCInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/jdbc/src/test/groovy/JDBCInstrumentationTest.groovy
@@ -169,7 +169,6 @@ class JDBCInstrumentationTest extends AgentTestRunner {
               "db.user" username
             }
             "span.kind" Tags.SPAN_KIND_CLIENT
-            "span.type" DDSpanTypes.SQL
             "component" "java-jdbc-statement"
             "db.instance" jdbcUrls.get(driver)
             "span.origin.type" String
@@ -230,7 +229,6 @@ class JDBCInstrumentationTest extends AgentTestRunner {
               "db.user" username
             }
             "span.kind" Tags.SPAN_KIND_CLIENT
-            "span.type" DDSpanTypes.SQL
             "component" "java-jdbc-prepared_statement"
             "db.instance" jdbcUrls.get(driver)
             "span.origin.type" String
@@ -286,7 +284,6 @@ class JDBCInstrumentationTest extends AgentTestRunner {
               "db.user" username
             }
             "span.kind" Tags.SPAN_KIND_CLIENT
-            "span.type" DDSpanTypes.SQL
             "component" "java-jdbc-prepared_statement"
             "db.instance" jdbcUrls.get(driver)
             "span.origin.type" String
@@ -342,7 +339,6 @@ class JDBCInstrumentationTest extends AgentTestRunner {
               "db.user" username
             }
             "span.kind" Tags.SPAN_KIND_CLIENT
-            "span.type" DDSpanTypes.SQL
             "component" "java-jdbc-prepared_statement"
             "db.instance" jdbcUrls.get(driver)
             "span.origin.type" String
@@ -398,7 +394,6 @@ class JDBCInstrumentationTest extends AgentTestRunner {
               "db.user" username
             }
             "span.kind" Tags.SPAN_KIND_CLIENT
-            "span.type" DDSpanTypes.SQL
             "component" "java-jdbc-statement"
             "db.instance" jdbcUrls.get(driver)
             "span.origin.type" String
@@ -457,7 +452,6 @@ class JDBCInstrumentationTest extends AgentTestRunner {
               "db.user" username
             }
             "span.kind" Tags.SPAN_KIND_CLIENT
-            "span.type" DDSpanTypes.SQL
             "component" "java-jdbc-prepared_statement"
             "db.instance" jdbcUrls.get(driver)
             "span.origin.type" String
@@ -534,7 +528,6 @@ class JDBCInstrumentationTest extends AgentTestRunner {
               "component" "java-jdbc-statement"
             }
             "span.kind" Tags.SPAN_KIND_CLIENT
-            "span.type" DDSpanTypes.SQL
             "db.instance" jdbcUrls.get(driver)
             "span.origin.type" String
             defaultTags()
@@ -604,7 +597,6 @@ class JDBCInstrumentationTest extends AgentTestRunner {
             "db.user" "SA"
             "component" "java-jdbc-prepared_statement"
             "span.kind" Tags.SPAN_KIND_CLIENT
-            "span.type" DDSpanTypes.SQL
             "db.instance" jdbcUrls.get(dbType)
             "span.origin.type" String
             defaultTags()
@@ -622,7 +614,6 @@ class JDBCInstrumentationTest extends AgentTestRunner {
             "db.user" "SA"
             "component" "java-jdbc-statement"
             "span.kind" Tags.SPAN_KIND_CLIENT
-            "span.type" DDSpanTypes.SQL
             "db.instance" jdbcUrls.get(dbType)
             "span.origin.type" String
             defaultTags()
@@ -642,7 +633,6 @@ class JDBCInstrumentationTest extends AgentTestRunner {
               "db.user" "SA"
               "component" "java-jdbc-prepared_statement"
               "span.kind" Tags.SPAN_KIND_CLIENT
-              "span.type" DDSpanTypes.SQL
               "db.instance" jdbcUrls.get(dbType)
               "span.origin.type" String
               defaultTags()

--- a/dd-java-agent/instrumentation/jedis-1.4/src/test/groovy/JedisClientTest.groovy
+++ b/dd-java-agent/instrumentation/jedis-1.4/src/test/groovy/JedisClientTest.groovy
@@ -1,6 +1,5 @@
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.DDSpanTypes
-import datadog.trace.api.DDTags
 import io.opentracing.tag.Tags
 import redis.clients.jedis.Jedis
 import redis.embedded.RedisServer
@@ -51,7 +50,6 @@ class JedisClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "redis-command"
             "$Tags.DB_TYPE.key" "redis"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.REDIS
             defaultTags()
           }
         }
@@ -78,7 +76,6 @@ class JedisClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "redis-command"
             "$Tags.DB_TYPE.key" "redis"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.REDIS
             defaultTags()
           }
         }
@@ -93,7 +90,6 @@ class JedisClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "redis-command"
             "$Tags.DB_TYPE.key" "redis"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.REDIS
             defaultTags()
           }
         }
@@ -120,7 +116,6 @@ class JedisClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "redis-command"
             "$Tags.DB_TYPE.key" "redis"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.REDIS
             defaultTags()
           }
         }
@@ -135,7 +130,6 @@ class JedisClientTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "redis-command"
             "$Tags.DB_TYPE.key" "redis"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.REDIS
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/jetty-8/src/test/groovy/JettyHandlerTest.groovy
+++ b/dd-java-agent/instrumentation/jetty-8/src/test/groovy/JettyHandlerTest.groovy
@@ -2,7 +2,6 @@ import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.utils.OkHttpUtils
 import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
-import datadog.trace.api.DDTags
 import okhttp3.OkHttpClient
 import org.eclipse.jetty.continuation.Continuation
 import org.eclipse.jetty.continuation.ContinuationSupport
@@ -69,7 +68,6 @@ class JettyHandlerTest extends AgentTestRunner {
             "span.kind" "server"
             "component" "jetty-handler"
             "span.origin.type" handler.class.name
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_SERVER
             "http.status_code" 200
             defaultTags()
           }
@@ -117,6 +115,7 @@ class JettyHandlerTest extends AgentTestRunner {
             serviceName "unnamed-java-app"
             operationName "jetty.request"
             resourceName "GET ${handler.class.name}"
+            spanType DDSpanTypes.HTTP_SERVER
           }
         }
       }
@@ -163,7 +162,6 @@ class JettyHandlerTest extends AgentTestRunner {
             "span.kind" "server"
             "component" "jetty-handler"
             "span.origin.type" handler.class.name
-            "span.type" DDSpanTypes.HTTP_SERVER
             "http.status_code" 500
             errorTags RuntimeException
             defaultTags()
@@ -185,7 +183,6 @@ class JettyHandlerTest extends AgentTestRunner {
               "span.kind" "server"
               "component" "jetty-handler"
               "span.origin.type" handler.class.name
-              "span.type" DDSpanTypes.HTTP_SERVER
               "http.status_code" 500
               "error" true
               defaultTags()

--- a/dd-java-agent/instrumentation/jms/src/latestDepTest/groovy/JMS2Test.groovy
+++ b/dd-java-agent/instrumentation/jms/src/latestDepTest/groovy/JMS2Test.groovy
@@ -3,7 +3,6 @@ import datadog.opentracing.DDSpan
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.asserts.ListWriterAssert
 import datadog.trace.api.DDSpanTypes
-import datadog.trace.api.DDTags
 import io.opentracing.tag.Tags
 import org.hornetq.api.core.TransportConfiguration
 import org.hornetq.api.core.client.HornetQClient
@@ -165,7 +164,6 @@ class JMS2Test extends AgentTestRunner {
 
           tags {
             defaultTags()
-            "${DDTags.SPAN_TYPE}" DDSpanTypes.MESSAGE_CONSUMER
             "${Tags.COMPONENT.key}" "jms"
             "${Tags.SPAN_KIND.key}" "consumer"
             "span.origin.type" HornetQMessageConsumer.name
@@ -204,7 +202,6 @@ class JMS2Test extends AgentTestRunner {
 
           tags {
             defaultTags()
-            "${DDTags.SPAN_TYPE}" DDSpanTypes.MESSAGE_CONSUMER
             "${Tags.COMPONENT.key}" "jms"
             "${Tags.SPAN_KIND.key}" "consumer"
             "span.origin.type" HornetQMessageConsumer.name
@@ -234,7 +231,6 @@ class JMS2Test extends AgentTestRunner {
 
         tags {
           defaultTags()
-          "${DDTags.SPAN_TYPE}" DDSpanTypes.MESSAGE_PRODUCER
           "${Tags.COMPONENT.key}" "jms"
           "${Tags.SPAN_KIND.key}" "producer"
           "span.origin.type" HornetQMessageProducer.name
@@ -255,12 +251,11 @@ class JMS2Test extends AgentTestRunner {
           operationName "jms.consume"
           resourceName "Consumed from $jmsResourceName"
         }
-        spanType DDSpanTypes.MESSAGE_PRODUCER
+        spanType DDSpanTypes.MESSAGE_CONSUMER
         errored false
 
         tags {
           defaultTags(true)
-          "${DDTags.SPAN_TYPE}" DDSpanTypes.MESSAGE_CONSUMER
           "${Tags.COMPONENT.key}" "jms"
           "${Tags.SPAN_KIND.key}" "consumer"
           "span.origin.type" origin.name

--- a/dd-java-agent/instrumentation/jms/src/test/groovy/JMS1Test.groovy
+++ b/dd-java-agent/instrumentation/jms/src/test/groovy/JMS1Test.groovy
@@ -2,7 +2,6 @@ import datadog.opentracing.DDSpan
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.asserts.ListWriterAssert
 import datadog.trace.api.DDSpanTypes
-import datadog.trace.api.DDTags
 import io.opentracing.tag.Tags
 import org.apache.activemq.ActiveMQConnectionFactory
 import org.apache.activemq.ActiveMQMessageConsumer
@@ -123,12 +122,11 @@ class JMS1Test extends AgentTestRunner {
           serviceName "jms"
           operationName "jms.consume"
           resourceName "JMS receiveNoWait"
-          spanType DDSpanTypes.MESSAGE_PRODUCER
+          spanType DDSpanTypes.MESSAGE_CONSUMER
           errored false
 
           tags {
             defaultTags()
-            "${DDTags.SPAN_TYPE}" DDSpanTypes.MESSAGE_CONSUMER
             "${Tags.COMPONENT.key}" "jms"
             "${Tags.SPAN_KIND.key}" "consumer"
             "span.origin.type" ActiveMQMessageConsumer.name
@@ -162,12 +160,11 @@ class JMS1Test extends AgentTestRunner {
           serviceName "jms"
           operationName "jms.consume"
           resourceName "JMS receive"
-          spanType DDSpanTypes.MESSAGE_PRODUCER
+          spanType DDSpanTypes.MESSAGE_CONSUMER
           errored false
 
           tags {
             defaultTags()
-            "${DDTags.SPAN_TYPE}" DDSpanTypes.MESSAGE_CONSUMER
             "${Tags.COMPONENT.key}" "jms"
             "${Tags.SPAN_KIND.key}" "consumer"
             "span.origin.type" ActiveMQMessageConsumer.name
@@ -214,12 +211,11 @@ class JMS1Test extends AgentTestRunner {
           serviceName "jms"
           operationName "jms.consume"
           resourceName "Consumed from $jmsResourceName"
-          spanType DDSpanTypes.MESSAGE_PRODUCER
+          spanType DDSpanTypes.MESSAGE_CONSUMER
           errored false
 
           tags {
             defaultTags()
-            "${DDTags.SPAN_TYPE}" DDSpanTypes.MESSAGE_CONSUMER
             "${Tags.COMPONENT.key}" "jms"
             "${Tags.SPAN_KIND.key}" "consumer"
             "span.origin.type" ActiveMQMessageConsumer.name
@@ -252,7 +248,6 @@ class JMS1Test extends AgentTestRunner {
 
         tags {
           defaultTags()
-          "${DDTags.SPAN_TYPE}" DDSpanTypes.MESSAGE_PRODUCER
           "${Tags.COMPONENT.key}" "jms"
           "${Tags.SPAN_KIND.key}" "producer"
           "span.origin.type" ActiveMQMessageProducer.name
@@ -272,13 +267,12 @@ class JMS1Test extends AgentTestRunner {
           operationName "jms.consume"
           resourceName "Consumed from $jmsResourceName"
         }
-        spanType DDSpanTypes.MESSAGE_PRODUCER
+        spanType DDSpanTypes.MESSAGE_CONSUMER
         errored false
         childOf parentSpan
 
         tags {
           defaultTags(true)
-          "${DDTags.SPAN_TYPE}" DDSpanTypes.MESSAGE_CONSUMER
           "${Tags.COMPONENT.key}" "jms"
           "${Tags.SPAN_KIND.key}" "consumer"
           "span.origin.type" origin.name

--- a/dd-java-agent/instrumentation/jsp-2.3/src/test/groovy/JSPInstrumentationBasicTests.groovy
+++ b/dd-java-agent/instrumentation/jsp-2.3/src/test/groovy/JSPInstrumentationBasicTests.groovy
@@ -102,7 +102,6 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
             "peer.port" port
             "span.kind" "server"
             "component" "java-web-servlet"
-            "span.type" DDSpanTypes.HTTP_SERVER
             "span.origin.type" "org.apache.catalina.core.ApplicationFilterChain"
             "servlet.context" "/$jspWebappContext"
             "http.status_code" 200
@@ -119,7 +118,6 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           tags {
             "span.kind" "server"
             "component" "jsp-http-servlet"
-            "span.type" DDSpanTypes.HTTP_SERVER
             "span.origin.type" jspClassName
             "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl
@@ -136,7 +134,6 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           tags {
             "span.kind" "server"
             "component" "jsp-http-servlet"
-            "span.type" DDSpanTypes.HTTP_SERVER
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.$jspClassNamePrefix$jspClassName"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -183,7 +180,6 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
             "peer.port" port
             "span.kind" "server"
             "component" "java-web-servlet"
-            "span.type" DDSpanTypes.HTTP_SERVER
             "span.origin.type" "org.apache.catalina.core.ApplicationFilterChain"
             "servlet.context" "/$jspWebappContext"
             "http.status_code" 200
@@ -200,7 +196,6 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           tags {
             "span.kind" "server"
             "component" "jsp-http-servlet"
-            "span.type" DDSpanTypes.HTTP_SERVER
             "span.origin.type" "getQuery_jsp"
             "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl
@@ -217,7 +212,6 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           tags {
             "span.kind" "server"
             "component" "jsp-http-servlet"
-            "span.type" DDSpanTypes.HTTP_SERVER
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.getQuery_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -261,7 +255,6 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
             "peer.port" port
             "span.kind" "server"
             "component" "java-web-servlet"
-            "span.type" DDSpanTypes.HTTP_SERVER
             "span.origin.type" "org.apache.catalina.core.ApplicationFilterChain"
             "servlet.context" "/$jspWebappContext"
             "http.status_code" 200
@@ -278,7 +271,6 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           tags {
             "span.kind" "server"
             "component" "jsp-http-servlet"
-            "span.type" DDSpanTypes.HTTP_SERVER
             "span.origin.type" "post_jsp"
             "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl
@@ -295,7 +287,6 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           tags {
             "span.kind" "server"
             "component" "jsp-http-servlet"
-            "span.type" DDSpanTypes.HTTP_SERVER
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.post_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -336,7 +327,6 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
             "peer.port" port
             "span.kind" "server"
             "component" "java-web-servlet"
-            "span.type" DDSpanTypes.HTTP_SERVER
             "span.origin.type" "org.apache.catalina.core.ApplicationFilterChain"
             "servlet.context" "/$jspWebappContext"
             "http.status_code" 500
@@ -354,7 +344,6 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           tags {
             "span.kind" "server"
             "component" "jsp-http-servlet"
-            "span.type" DDSpanTypes.HTTP_SERVER
             "span.origin.type" jspClassName
             "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl
@@ -379,7 +368,6 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           tags {
             "span.kind" "server"
             "component" "jsp-http-servlet"
-            "span.type" DDSpanTypes.HTTP_SERVER
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.$jspClassName"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -425,7 +413,6 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
             "peer.port" port
             "span.kind" "server"
             "component" "java-web-servlet"
-            "span.type" DDSpanTypes.HTTP_SERVER
             "span.origin.type" "org.apache.catalina.core.ApplicationFilterChain"
             "servlet.context" "/$jspWebappContext"
             "http.status_code" 200
@@ -442,7 +429,6 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           tags {
             "span.kind" "server"
             "component" "jsp-http-servlet"
-            "span.type" DDSpanTypes.HTTP_SERVER
             "span.origin.type" "includeHtml_jsp"
             "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl
@@ -459,7 +445,6 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           tags {
             "span.kind" "server"
             "component" "jsp-http-servlet"
-            "span.type" DDSpanTypes.HTTP_SERVER
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.includes.includeHtml_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -499,7 +484,6 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
             "peer.port" port
             "span.kind" "server"
             "component" "java-web-servlet"
-            "span.type" DDSpanTypes.HTTP_SERVER
             "span.origin.type" "org.apache.catalina.core.ApplicationFilterChain"
             "servlet.context" "/$jspWebappContext"
             "http.status_code" 200
@@ -516,7 +500,6 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           tags {
             "span.kind" "server"
             "component" "jsp-http-servlet"
-            "span.type" DDSpanTypes.HTTP_SERVER
             "span.origin.type" "includeMulti_jsp"
             "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl
@@ -533,7 +516,6 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           tags {
             "span.kind" "server"
             "component" "jsp-http-servlet"
-            "span.type" DDSpanTypes.HTTP_SERVER
             "span.origin.type" "javaLoopH2_jsp"
             "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl
@@ -550,7 +532,6 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           tags {
             "span.kind" "server"
             "component" "jsp-http-servlet"
-            "span.type" DDSpanTypes.HTTP_SERVER
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.common.javaLoopH2_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -567,7 +548,6 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           tags {
             "span.kind" "server"
             "component" "jsp-http-servlet"
-            "span.type" DDSpanTypes.HTTP_SERVER
             "span.origin.type" "javaLoopH2_jsp"
             "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl
@@ -584,7 +564,6 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           tags {
             "span.kind" "server"
             "component" "jsp-http-servlet"
-            "span.type" DDSpanTypes.HTTP_SERVER
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.common.javaLoopH2_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -601,7 +580,6 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           tags {
             "span.kind" "server"
             "component" "jsp-http-servlet"
-            "span.type" DDSpanTypes.HTTP_SERVER
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.includes.includeMulti_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -641,7 +619,6 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
             "peer.port" port
             "span.kind" "server"
             "component" "java-web-servlet"
-            "span.type" DDSpanTypes.HTTP_SERVER
             "span.origin.type" "org.apache.catalina.core.ApplicationFilterChain"
             "servlet.context" "/$jspWebappContext"
             "http.status_code" 500
@@ -659,7 +636,6 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           tags {
             "span.kind" "server"
             "component" "jsp-http-servlet"
-            "span.type" DDSpanTypes.HTTP_SERVER
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.$jspClassNamePrefix$jspClassName"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"

--- a/dd-java-agent/instrumentation/jsp-2.3/src/test/groovy/JSPInstrumentationForwardTests.groovy
+++ b/dd-java-agent/instrumentation/jsp-2.3/src/test/groovy/JSPInstrumentationForwardTests.groovy
@@ -101,7 +101,6 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
             "peer.port" port
             "span.kind" "server"
             "component" "java-web-servlet"
-            "span.type" DDSpanTypes.HTTP_SERVER
             "span.origin.type" "org.apache.catalina.core.ApplicationFilterChain"
             "servlet.context" "/$jspWebappContext"
             "http.status_code" 200
@@ -118,7 +117,6 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           tags {
             "span.kind" "server"
             "component" "jsp-http-servlet"
-            "span.type" DDSpanTypes.HTTP_SERVER
             "span.origin.type" jspForwardFromClassName
             "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl
@@ -135,7 +133,6 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           tags {
             "span.kind" "server"
             "component" "jsp-http-servlet"
-            "span.type" DDSpanTypes.HTTP_SERVER
             "span.origin.type" jspForwardDestClassName
             "servlet.context" "/$jspWebappContext"
             "jsp.forwardOrigin" "/$forwardFromFileName"
@@ -153,7 +150,6 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           tags {
             "span.kind" "server"
             "component" "jsp-http-servlet"
-            "span.type" DDSpanTypes.HTTP_SERVER
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.$jspForwardDestClassPrefix$jspForwardDestClassName"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -170,7 +166,6 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           tags {
             "span.kind" "server"
             "component" "jsp-http-servlet"
-            "span.type" DDSpanTypes.HTTP_SERVER
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.$jspForwardFromClassPrefix$jspForwardFromClassName"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -215,7 +210,6 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
             "peer.port" port
             "span.kind" "server"
             "component" "java-web-servlet"
-            "span.type" DDSpanTypes.HTTP_SERVER
             "span.origin.type" "org.apache.catalina.core.ApplicationFilterChain"
             "servlet.context" "/$jspWebappContext"
             "http.status_code" 200
@@ -232,7 +226,6 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           tags {
             "span.kind" "server"
             "component" "jsp-http-servlet"
-            "span.type" DDSpanTypes.HTTP_SERVER
             "span.origin.type" "forwardToHtml_jsp"
             "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl
@@ -249,7 +242,6 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           tags {
             "span.kind" "server"
             "component" "jsp-http-servlet"
-            "span.type" DDSpanTypes.HTTP_SERVER
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.forwards.forwardToHtml_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -289,7 +281,6 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
             "peer.port" port
             "span.kind" "server"
             "component" "java-web-servlet"
-            "span.type" DDSpanTypes.HTTP_SERVER
             "span.origin.type" "org.apache.catalina.core.ApplicationFilterChain"
             "servlet.context" "/$jspWebappContext"
             "http.status_code" 200
@@ -306,7 +297,6 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           tags {
             "span.kind" "server"
             "component" "jsp-http-servlet"
-            "span.type" DDSpanTypes.HTTP_SERVER
             "span.origin.type" "forwardToIncludeMulti_jsp"
             "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl
@@ -323,7 +313,6 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           tags {
             "span.kind" "server"
             "component" "jsp-http-servlet"
-            "span.type" DDSpanTypes.HTTP_SERVER
             "span.origin.type" "includeMulti_jsp"
             "servlet.context" "/$jspWebappContext"
             "jsp.forwardOrigin" "/forwards/forwardToIncludeMulti.jsp"
@@ -341,7 +330,6 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           tags {
             "span.kind" "server"
             "component" "jsp-http-servlet"
-            "span.type" DDSpanTypes.HTTP_SERVER
             "span.origin.type" "javaLoopH2_jsp"
             "servlet.context" "/$jspWebappContext"
             "jsp.forwardOrigin" "/forwards/forwardToIncludeMulti.jsp"
@@ -359,7 +347,6 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           tags {
             "span.kind" "server"
             "component" "jsp-http-servlet"
-            "span.type" DDSpanTypes.HTTP_SERVER
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.common.javaLoopH2_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -376,7 +363,6 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           tags {
             "span.kind" "server"
             "component" "jsp-http-servlet"
-            "span.type" DDSpanTypes.HTTP_SERVER
             "span.origin.type" "javaLoopH2_jsp"
             "servlet.context" "/$jspWebappContext"
             "jsp.forwardOrigin" "/forwards/forwardToIncludeMulti.jsp"
@@ -394,7 +380,6 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           tags {
             "span.kind" "server"
             "component" "jsp-http-servlet"
-            "span.type" DDSpanTypes.HTTP_SERVER
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.common.javaLoopH2_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -411,7 +396,6 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           tags {
             "span.kind" "server"
             "component" "jsp-http-servlet"
-            "span.type" DDSpanTypes.HTTP_SERVER
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.includes.includeMulti_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -428,7 +412,6 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           tags {
             "span.kind" "server"
             "component" "jsp-http-servlet"
-            "span.type" DDSpanTypes.HTTP_SERVER
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.forwards.forwardToIncludeMulti_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -468,7 +451,6 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
             "peer.port" port
             "span.kind" "server"
             "component" "java-web-servlet"
-            "span.type" DDSpanTypes.HTTP_SERVER
             "span.origin.type" "org.apache.catalina.core.ApplicationFilterChain"
             "servlet.context" "/$jspWebappContext"
             "http.status_code" 200
@@ -485,7 +467,6 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           tags {
             "span.kind" "server"
             "component" "jsp-http-servlet"
-            "span.type" DDSpanTypes.HTTP_SERVER
             "span.origin.type" "forwardToJspForward_jsp"
             "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl
@@ -502,7 +483,6 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           tags {
             "span.kind" "server"
             "component" "jsp-http-servlet"
-            "span.type" DDSpanTypes.HTTP_SERVER
             "span.origin.type" "forwardToSimpleJava_jsp"
             "servlet.context" "/$jspWebappContext"
             "jsp.forwardOrigin" "/forwards/forwardToJspForward.jsp"
@@ -520,7 +500,6 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           tags {
             "span.kind" "server"
             "component" "jsp-http-servlet"
-            "span.type" DDSpanTypes.HTTP_SERVER
             "span.origin.type" "loop_jsp"
             "servlet.context" "/$jspWebappContext"
             "jsp.forwardOrigin" "/forwards/forwardToJspForward.jsp"
@@ -538,7 +517,6 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           tags {
             "span.kind" "server"
             "component" "jsp-http-servlet"
-            "span.type" DDSpanTypes.HTTP_SERVER
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.common.loop_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -555,7 +533,6 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           tags {
             "span.kind" "server"
             "component" "jsp-http-servlet"
-            "span.type" DDSpanTypes.HTTP_SERVER
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.forwards.forwardToSimpleJava_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -572,7 +549,6 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           tags {
             "span.kind" "server"
             "component" "jsp-http-servlet"
-            "span.type" DDSpanTypes.HTTP_SERVER
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.forwards.forwardToJspForward_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -612,7 +588,6 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
             "peer.port" port
             "span.kind" "server"
             "component" "java-web-servlet"
-            "span.type" DDSpanTypes.HTTP_SERVER
             "span.origin.type" "org.apache.catalina.core.ApplicationFilterChain"
             "servlet.context" "/$jspWebappContext"
             "http.status_code" 500
@@ -630,7 +605,6 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           tags {
             "span.kind" "server"
             "component" "jsp-http-servlet"
-            "span.type" DDSpanTypes.HTTP_SERVER
             "span.origin.type" "forwardToCompileError_jsp"
             "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl
@@ -648,7 +622,6 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           tags {
             "span.kind" "server"
             "component" "jsp-http-servlet"
-            "span.type" DDSpanTypes.HTTP_SERVER
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.compileError_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -668,7 +641,6 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           tags {
             "span.kind" "server"
             "component" "jsp-http-servlet"
-            "span.type" DDSpanTypes.HTTP_SERVER
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.forwards.forwardToCompileError_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -708,7 +680,6 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
             "peer.port" port
             "span.kind" "server"
             "component" "java-web-servlet"
-            "span.type" DDSpanTypes.HTTP_SERVER
             "span.origin.type" "org.apache.catalina.core.ApplicationFilterChain"
             "servlet.context" "/$jspWebappContext"
             "http.status_code" 404
@@ -725,7 +696,6 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           tags {
             "span.kind" "server"
             "component" "jsp-http-servlet"
-            "span.type" DDSpanTypes.HTTP_SERVER
             "span.origin.type" "forwardToNonExistent_jsp"
             "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl
@@ -742,7 +712,6 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           tags {
             "span.kind" "server"
             "component" "jsp-http-servlet"
-            "span.type" DDSpanTypes.HTTP_SERVER
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.forwards.forwardToNonExistent_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTest.groovy
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTest.groovy
@@ -87,7 +87,6 @@ class KafkaClientTest extends AgentTestRunner {
           tags {
             "component" "java-kafka"
             "span.kind" "producer"
-            "span.type" "queue"
             defaultTags()
           }
         }
@@ -104,7 +103,6 @@ class KafkaClientTest extends AgentTestRunner {
           tags {
             "component" "java-kafka"
             "span.kind" "consumer"
-            "span.type" "queue"
             "partition" { it >= 0 }
             "offset" 0
             defaultTags(true)

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/src/test/groovy/KafkaStreamsTest.groovy
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/src/test/groovy/KafkaStreamsTest.groovy
@@ -128,7 +128,6 @@ class KafkaStreamsTest extends AgentTestRunner {
           tags {
             "component" "java-kafka"
             "span.kind" "producer"
-            "span.type" "queue"
             defaultTags()
           }
         }
@@ -147,7 +146,6 @@ class KafkaStreamsTest extends AgentTestRunner {
           tags {
             "component" "java-kafka"
             "span.kind" "producer"
-            "span.type" "queue"
             defaultTags()
           }
         }
@@ -164,7 +162,6 @@ class KafkaStreamsTest extends AgentTestRunner {
           tags {
             "component" "java-kafka"
             "span.kind" "consumer"
-            "span.type" "queue"
             "partition" { it >= 0 }
             "offset" 0
             defaultTags(true)
@@ -184,7 +181,6 @@ class KafkaStreamsTest extends AgentTestRunner {
           tags {
             "component" "java-kafka"
             "span.kind" "consumer"
-            "span.type" "queue"
             "partition" { it >= 0 }
             "offset" 0
             defaultTags(true)

--- a/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/LettuceAsyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/LettuceAsyncClientTest.groovy
@@ -1,7 +1,6 @@
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
-import datadog.trace.api.DDTags
 import io.lettuce.core.ClientOptions
 import io.lettuce.core.ConnectionFuture
 import io.lettuce.core.RedisClient
@@ -130,7 +129,6 @@ class LettuceAsyncClientTest extends AgentTestRunner {
             "peer.hostname" HOST
             "peer.port" port
             "span.kind" "client"
-            "$DDTags.SPAN_TYPE" DDSpanTypes.REDIS
           }
         }
       }
@@ -172,7 +170,6 @@ class LettuceAsyncClientTest extends AgentTestRunner {
             "peer.hostname" HOST
             "peer.port" incorrectPort
             "span.kind" "client"
-            "$DDTags.SPAN_TYPE" DDSpanTypes.REDIS
           }
         }
       }
@@ -200,7 +197,6 @@ class LettuceAsyncClientTest extends AgentTestRunner {
             "component" "redis-client"
             "db.type" "redis"
             "span.kind" "client"
-            "$DDTags.SPAN_TYPE" DDSpanTypes.REDIS
           }
         }
       }
@@ -239,7 +235,6 @@ class LettuceAsyncClientTest extends AgentTestRunner {
             "component" "redis-client"
             "db.type" "redis"
             "span.kind" "client"
-            "$DDTags.SPAN_TYPE" DDSpanTypes.REDIS
           }
         }
       }
@@ -292,7 +287,6 @@ class LettuceAsyncClientTest extends AgentTestRunner {
             "component" "redis-client"
             "db.type" "redis"
             "span.kind" "client"
-            "$DDTags.SPAN_TYPE" DDSpanTypes.REDIS
           }
         }
       }
@@ -331,7 +325,6 @@ class LettuceAsyncClientTest extends AgentTestRunner {
             "component" "redis-client"
             "db.type" "redis"
             "span.kind" "client"
-            "$DDTags.SPAN_TYPE" DDSpanTypes.REDIS
           }
         }
       }
@@ -389,7 +382,6 @@ class LettuceAsyncClientTest extends AgentTestRunner {
             "component" "redis-client"
             "db.type" "redis"
             "span.kind" "client"
-            "$DDTags.SPAN_TYPE" DDSpanTypes.REDIS
           }
         }
       }
@@ -406,7 +398,6 @@ class LettuceAsyncClientTest extends AgentTestRunner {
             "component" "redis-client"
             "db.type" "redis"
             "span.kind" "client"
-            "$DDTags.SPAN_TYPE" DDSpanTypes.REDIS
           }
         }
       }
@@ -454,7 +445,6 @@ class LettuceAsyncClientTest extends AgentTestRunner {
             "db.type" "redis"
             errorTags(IllegalStateException, "TestException")
             "span.kind" "client"
-            "$DDTags.SPAN_TYPE" DDSpanTypes.REDIS
           }
         }
       }
@@ -496,7 +486,6 @@ class LettuceAsyncClientTest extends AgentTestRunner {
             "db.type" "redis"
             "db.command.cancelled" true
             "span.kind" "client"
-            "$DDTags.SPAN_TYPE" DDSpanTypes.REDIS
           }
         }
       }
@@ -522,7 +511,6 @@ class LettuceAsyncClientTest extends AgentTestRunner {
             "component" "redis-client"
             "db.type" "redis"
             "span.kind" "client"
-            "$DDTags.SPAN_TYPE" DDSpanTypes.REDIS
           }
         }
       }
@@ -549,7 +537,6 @@ class LettuceAsyncClientTest extends AgentTestRunner {
             "component" "redis-client"
             "db.type" "redis"
             "span.kind" "client"
-            "$DDTags.SPAN_TYPE" DDSpanTypes.REDIS
           }
         }
       }

--- a/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/LettuceReactiveClientTest.groovy
+++ b/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/LettuceReactiveClientTest.groovy
@@ -1,7 +1,6 @@
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
-import datadog.trace.api.DDTags
 import io.lettuce.core.ClientOptions
 import io.lettuce.core.RedisClient
 import io.lettuce.core.api.StatefulConnection
@@ -99,7 +98,6 @@ class LettuceReactiveClientTest extends AgentTestRunner {
             "component" "redis-client"
             "db.type" "redis"
             "span.kind" "client"
-            "$DDTags.SPAN_TYPE" DDSpanTypes.REDIS
           }
         }
       }
@@ -129,7 +127,6 @@ class LettuceReactiveClientTest extends AgentTestRunner {
             "component" "redis-client"
             "db.type" "redis"
             "span.kind" "client"
-            "$DDTags.SPAN_TYPE" DDSpanTypes.REDIS
           }
         }
       }
@@ -167,7 +164,6 @@ class LettuceReactiveClientTest extends AgentTestRunner {
             "component" "redis-client"
             "db.type" "redis"
             "span.kind" "client"
-            "$DDTags.SPAN_TYPE" DDSpanTypes.REDIS
           }
         }
       }
@@ -203,7 +199,6 @@ class LettuceReactiveClientTest extends AgentTestRunner {
             "component" "redis-client"
             "db.type" "redis"
             "span.kind" "client"
-            "$DDTags.SPAN_TYPE" DDSpanTypes.REDIS
           }
         }
       }
@@ -230,7 +225,6 @@ class LettuceReactiveClientTest extends AgentTestRunner {
             "db.type" "redis"
             "db.command.results.count" 157
             "span.kind" "client"
-            "$DDTags.SPAN_TYPE" DDSpanTypes.REDIS
           }
         }
       }
@@ -258,7 +252,6 @@ class LettuceReactiveClientTest extends AgentTestRunner {
             "db.command.cancelled" true
             "db.command.results.count" 2
             "span.kind" "client"
-            "$DDTags.SPAN_TYPE" DDSpanTypes.REDIS
           }
         }
       }
@@ -296,7 +289,6 @@ class LettuceReactiveClientTest extends AgentTestRunner {
             "component" "redis-client"
             "db.type" "redis"
             "span.kind" "client"
-            "$DDTags.SPAN_TYPE" DDSpanTypes.REDIS
           }
         }
       }
@@ -322,7 +314,6 @@ class LettuceReactiveClientTest extends AgentTestRunner {
             "component" "redis-client"
             "db.type" "redis"
             "span.kind" "client"
-            "$DDTags.SPAN_TYPE" DDSpanTypes.REDIS
           }
         }
       }

--- a/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/LettuceSyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/LettuceSyncClientTest.groovy
@@ -1,7 +1,6 @@
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
-import datadog.trace.api.DDTags
 import io.lettuce.core.ClientOptions
 import io.lettuce.core.RedisClient
 import io.lettuce.core.RedisConnectionException
@@ -110,7 +109,6 @@ class LettuceSyncClientTest extends AgentTestRunner {
             "peer.hostname" HOST
             "peer.port" port
             "span.kind" "client"
-            "$DDTags.SPAN_TYPE" DDSpanTypes.REDIS
           }
         }
       }
@@ -149,7 +147,6 @@ class LettuceSyncClientTest extends AgentTestRunner {
             "peer.hostname" HOST
             "peer.port" incorrectPort
             "span.kind" "client"
-            "$DDTags.SPAN_TYPE" DDSpanTypes.REDIS
           }
         }
       }
@@ -176,7 +173,6 @@ class LettuceSyncClientTest extends AgentTestRunner {
             "component" "redis-client"
             "db.type" "redis"
             "span.kind" "client"
-            "$DDTags.SPAN_TYPE" DDSpanTypes.REDIS
           }
         }
       }
@@ -203,7 +199,6 @@ class LettuceSyncClientTest extends AgentTestRunner {
             "component" "redis-client"
             "db.type" "redis"
             "span.kind" "client"
-            "$DDTags.SPAN_TYPE" DDSpanTypes.REDIS
           }
         }
       }
@@ -230,7 +225,6 @@ class LettuceSyncClientTest extends AgentTestRunner {
             "component" "redis-client"
             "db.type" "redis"
             "span.kind" "client"
-            "$DDTags.SPAN_TYPE" DDSpanTypes.REDIS
           }
         }
       }
@@ -257,7 +251,6 @@ class LettuceSyncClientTest extends AgentTestRunner {
             "component" "redis-client"
             "db.type" "redis"
             "span.kind" "client"
-            "$DDTags.SPAN_TYPE" DDSpanTypes.REDIS
           }
         }
       }
@@ -284,7 +277,6 @@ class LettuceSyncClientTest extends AgentTestRunner {
             "component" "redis-client"
             "db.type" "redis"
             "span.kind" "client"
-            "$DDTags.SPAN_TYPE" DDSpanTypes.REDIS
           }
         }
       }
@@ -311,7 +303,6 @@ class LettuceSyncClientTest extends AgentTestRunner {
             "component" "redis-client"
             "db.type" "redis"
             "span.kind" "client"
-            "$DDTags.SPAN_TYPE" DDSpanTypes.REDIS
           }
         }
       }
@@ -338,7 +329,6 @@ class LettuceSyncClientTest extends AgentTestRunner {
             "component" "redis-client"
             "db.type" "redis"
             "span.kind" "client"
-            "$DDTags.SPAN_TYPE" DDSpanTypes.REDIS
           }
         }
       }
@@ -364,7 +354,6 @@ class LettuceSyncClientTest extends AgentTestRunner {
             "component" "redis-client"
             "db.type" "redis"
             "span.kind" "client"
-            "$DDTags.SPAN_TYPE" DDSpanTypes.REDIS
           }
         }
       }
@@ -390,7 +379,6 @@ class LettuceSyncClientTest extends AgentTestRunner {
             "component" "redis-client"
             "db.type" "redis"
             "span.kind" "client"
-            "$DDTags.SPAN_TYPE" DDSpanTypes.REDIS
           }
         }
       }

--- a/dd-java-agent/instrumentation/netty-4.0/src/test/groovy/Netty40ClientTest.groovy
+++ b/dd-java-agent/instrumentation/netty-4.0/src/test/groovy/Netty40ClientTest.groovy
@@ -1,7 +1,6 @@
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
-import datadog.trace.api.DDTags
 import io.opentracing.tag.Tags
 import org.asynchttpclient.AsyncHttpClient
 import org.asynchttpclient.DefaultAsyncHttpClientConfig
@@ -60,7 +59,6 @@ class Netty40ClientTest extends AgentTestRunner {
             "$Tags.PEER_HOSTNAME.key" "localhost"
             "$Tags.PEER_PORT.key" Integer
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_CLIENT
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/netty-4.0/src/test/groovy/Netty40ServerTest.groovy
+++ b/dd-java-agent/instrumentation/netty-4.0/src/test/groovy/Netty40ServerTest.groovy
@@ -2,7 +2,6 @@ import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.utils.OkHttpUtils
 import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
-import datadog.trace.api.DDTags
 import io.netty.bootstrap.ServerBootstrap
 import io.netty.buffer.ByteBuf
 import io.netty.buffer.Unpooled
@@ -69,7 +68,6 @@ class Netty40ServerTest extends AgentTestRunner {
             "$Tags.PEER_HOSTNAME.key" "localhost"
             "$Tags.PEER_PORT.key" Integer
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_SERVER
             defaultTags(true)
           }
         }
@@ -115,7 +113,6 @@ class Netty40ServerTest extends AgentTestRunner {
             "$Tags.PEER_HOSTNAME.key" "localhost"
             "$Tags.PEER_PORT.key" Integer
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_SERVER
             if (error) {
               tag("error", true)
             }

--- a/dd-java-agent/instrumentation/netty-4.1/src/test/groovy/Netty41ClientTest.groovy
+++ b/dd-java-agent/instrumentation/netty-4.1/src/test/groovy/Netty41ClientTest.groovy
@@ -1,7 +1,6 @@
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
-import datadog.trace.api.DDTags
 import io.netty.channel.AbstractChannel
 import io.opentracing.tag.Tags
 import org.asynchttpclient.AsyncHttpClient
@@ -61,7 +60,6 @@ class Netty41ClientTest extends AgentTestRunner {
             "$Tags.PEER_HOSTNAME.key" "localhost"
             "$Tags.PEER_PORT.key" Integer
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_CLIENT
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/netty-4.1/src/test/groovy/Netty41ServerTest.groovy
+++ b/dd-java-agent/instrumentation/netty-4.1/src/test/groovy/Netty41ServerTest.groovy
@@ -2,7 +2,6 @@ import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.utils.OkHttpUtils
 import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
-import datadog.trace.api.DDTags
 import io.netty.bootstrap.ServerBootstrap
 import io.netty.buffer.ByteBuf
 import io.netty.buffer.Unpooled
@@ -71,7 +70,6 @@ class Netty41ServerTest extends AgentTestRunner {
             "$Tags.PEER_HOSTNAME.key" "localhost"
             "$Tags.PEER_PORT.key" Integer
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_SERVER
             defaultTags(true)
           }
         }
@@ -117,7 +115,6 @@ class Netty41ServerTest extends AgentTestRunner {
             "$Tags.PEER_HOSTNAME.key" "localhost"
             "$Tags.PEER_PORT.key" Integer
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_SERVER
             if (error) {
               tag("error", true)
             }

--- a/dd-java-agent/instrumentation/okhttp-3/src/test/groovy/OkHttp3Test.groovy
+++ b/dd-java-agent/instrumentation/okhttp-3/src/test/groovy/OkHttp3Test.groovy
@@ -41,7 +41,6 @@ class OkHttp3Test extends AgentTestRunner {
           parent()
           tags {
             "component" "okhttp"
-            "span.type" DDSpanTypes.HTTP_CLIENT
             defaultTags()
           }
         }
@@ -49,12 +48,12 @@ class OkHttp3Test extends AgentTestRunner {
           operationName "okhttp.http"
           serviceName renameService ? "localhost" : "okhttp"
           resourceName "GET /ping"
+          spanType DDSpanTypes.HTTP_CLIENT
           errored false
           childOf(span(0))
           tags {
             defaultTags()
             "component" "okhttp"
-            "span.type" DDSpanTypes.HTTP_CLIENT
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
             "$Tags.HTTP_METHOD.key" "GET"
             "$Tags.HTTP_STATUS.key" 200

--- a/dd-java-agent/instrumentation/play-2.4/src/latestDepTest/groovy/Play26Test.groovy
+++ b/dd-java-agent/instrumentation/play-2.4/src/latestDepTest/groovy/Play26Test.groovy
@@ -61,7 +61,6 @@ class Play26Test extends AgentTestRunner {
             "peer.hostname" "localhost"
             "peer.port" port
             "span.kind" "server"
-            "span.type" DDSpanTypes.HTTP_SERVER
             "component" "akka-http-server"
           }
         }
@@ -76,7 +75,6 @@ class Play26Test extends AgentTestRunner {
             "http.url" "/helloplay/:from"
             "http.method" "GET"
             "span.kind" "server"
-            "span.type" DDSpanTypes.HTTP_SERVER
             "component" "play-action"
           }
         }
@@ -114,7 +112,6 @@ class Play26Test extends AgentTestRunner {
             "peer.hostname" "localhost"
             "peer.port" port
             "span.kind" "server"
-            "span.type" DDSpanTypes.HTTP_SERVER
             "component" "akka-http-server"
             "error" true
           }
@@ -131,7 +128,6 @@ class Play26Test extends AgentTestRunner {
             "http.url" "/make-error"
             "http.method" "GET"
             "span.kind" "server"
-            "span.type" DDSpanTypes.HTTP_SERVER
             "component" "play-action"
             "error" true
           }
@@ -167,7 +163,6 @@ class Play26Test extends AgentTestRunner {
             "peer.hostname" "localhost"
             "peer.port" port
             "span.kind" "server"
-            "span.type" DDSpanTypes.HTTP_SERVER
             "component" "akka-http-server"
             "error" true
           }
@@ -184,7 +179,6 @@ class Play26Test extends AgentTestRunner {
             "http.url" "/exception"
             "http.method" "GET"
             "span.kind" "server"
-            "span.type" DDSpanTypes.HTTP_SERVER
             "component" "play-action"
             "error" true
             "error.msg" "oh no"
@@ -223,7 +217,6 @@ class Play26Test extends AgentTestRunner {
             "peer.hostname" "localhost"
             "peer.port" port
             "span.kind" "server"
-            "span.type" DDSpanTypes.HTTP_SERVER
             "component" "akka-http-server"
           }
         }
@@ -238,7 +231,6 @@ class Play26Test extends AgentTestRunner {
             "http.status_code" 404
             "http.method" "GET"
             "span.kind" "server"
-            "span.type" DDSpanTypes.HTTP_SERVER
             "component" "play-action"
           }
         }

--- a/dd-java-agent/instrumentation/ratpack-1.4/src/test/groovy/RatpackTest.groovy
+++ b/dd-java-agent/instrumentation/ratpack-1.4/src/test/groovy/RatpackTest.groovy
@@ -59,7 +59,6 @@ class RatpackTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT.key" "ratpack"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_SERVER
             "$Tags.HTTP_METHOD.key" "GET"
             "$Tags.HTTP_STATUS.key" 200
             "$Tags.HTTP_URL.key" "/"
@@ -105,7 +104,6 @@ class RatpackTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT.key" "ratpack"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_SERVER
             "$Tags.HTTP_METHOD.key" "GET"
             "$Tags.HTTP_STATUS.key" 200
             "$Tags.HTTP_URL.key" "/a/b/baz"
@@ -148,7 +146,6 @@ class RatpackTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT.key" "ratpack"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_SERVER
             "$Tags.HTTP_METHOD.key" "GET"
             "$Tags.HTTP_STATUS.key" 500
             "$Tags.HTTP_URL.key" "/"
@@ -219,7 +216,6 @@ class RatpackTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT.key" "ratpack"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_SERVER
             "$Tags.HTTP_METHOD.key" "GET"
             "$Tags.HTTP_STATUS.key" 200
             "$Tags.HTTP_URL.key" "/nested"
@@ -239,7 +235,6 @@ class RatpackTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT.key" "ratpack"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_SERVER
             "$Tags.HTTP_METHOD.key" "GET"
             "$Tags.HTTP_STATUS.key" 200
             "$Tags.HTTP_URL.key" "/nested2"
@@ -259,7 +254,6 @@ class RatpackTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT.key" "ratpack"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_SERVER
             "$Tags.HTTP_METHOD.key" "GET"
             "$Tags.HTTP_STATUS.key" 200
             "$Tags.HTTP_URL.key" "/"
@@ -277,7 +271,6 @@ class RatpackTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT.key" "ratpack-httpclient"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_CLIENT
             "$Tags.HTTP_METHOD.key" "GET"
             "$Tags.HTTP_STATUS.key" 200
             "$Tags.HTTP_URL.key" "${external.address}nested2"
@@ -295,7 +288,6 @@ class RatpackTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT.key" "ratpack-httpclient"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_CLIENT
             "$Tags.HTTP_METHOD.key" "GET"
             "$Tags.HTTP_STATUS.key" 200
             "$Tags.HTTP_URL.key" "${external.address}nested"
@@ -326,7 +318,7 @@ class RatpackTest extends AgentTestRunner {
           if (startSpanInHandler) {
             scope.close()
             context.onClose {
-                startedSpan.finish()
+              startedSpan.finish()
             }
           }
 
@@ -358,7 +350,6 @@ class RatpackTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT.key" "ratpack"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_SERVER
             "$Tags.HTTP_METHOD.key" "GET"
             "$Tags.HTTP_STATUS.key" 200
             "$Tags.HTTP_URL.key" "/"
@@ -370,11 +361,9 @@ class RatpackTest extends AgentTestRunner {
             resourceName "INSIDE-TEST"
             serviceName "unnamed-java-app"
             operationName "ratpack.exec-test"
-            spanType DDSpanTypes.HTTP_SERVER
             childOf(span(1))
             errored false
             tags {
-              "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_SERVER
               defaultTags()
             }
           }

--- a/dd-java-agent/instrumentation/servlet-2/src/test/groovy/JettyServlet2Test.groovy
+++ b/dd-java-agent/instrumentation/servlet-2/src/test/groovy/JettyServlet2Test.groovy
@@ -93,7 +93,6 @@ class JettyServlet2Test extends AgentTestRunner {
             "component" "java-web-servlet"
             "peer.hostname" "localhost"
             "peer.port" port
-            "span.type" DDSpanTypes.HTTP_SERVER
             "span.origin.type" "TestServlet2\$Sync"
             "servlet.context" "/ctx"
             if (auth) {
@@ -140,7 +139,6 @@ class JettyServlet2Test extends AgentTestRunner {
             "component" "java-web-servlet"
             "peer.hostname" "localhost"
             "peer.port" port
-            "span.type" DDSpanTypes.HTTP_SERVER
             "span.origin.type" "TestServlet2\$Sync"
             "servlet.context" "/ctx"
             errorTags(RuntimeException, "some $path error")
@@ -183,7 +181,6 @@ class JettyServlet2Test extends AgentTestRunner {
             "component" "java-web-servlet"
             "peer.hostname" "localhost"
             "peer.port" port
-            "span.type" DDSpanTypes.HTTP_SERVER
             "span.origin.type" "TestServlet2\$Sync"
             "servlet.context" "/ctx"
             defaultTags()

--- a/dd-java-agent/instrumentation/servlet-3/src/test/groovy/AbstractServlet3Test.groovy
+++ b/dd-java-agent/instrumentation/servlet-3/src/test/groovy/AbstractServlet3Test.groovy
@@ -91,7 +91,6 @@ abstract class AbstractServlet3Test<CONTEXT> extends AgentTestRunner {
             "component" "java-web-servlet"
             "peer.hostname" "localhost"
             "peer.port" port
-            "span.type" DDSpanTypes.HTTP_SERVER
             "span.origin.type" { it == "TestServlet3\$$origin" || it == ApplicationFilterChain.name }
             "servlet.context" "/$context"
             "http.status_code" 200
@@ -159,7 +158,6 @@ abstract class AbstractServlet3Test<CONTEXT> extends AgentTestRunner {
               "component" "java-web-servlet"
               "peer.hostname" "localhost"
               "peer.port" port
-              "span.type" DDSpanTypes.HTTP_SERVER
               "span.origin.type" { it == "TestServlet3\$Dispatch$origin" || it == ApplicationFilterChain.name }
               "http.status_code" 200
               "servlet.context" "/$context"
@@ -185,7 +183,6 @@ abstract class AbstractServlet3Test<CONTEXT> extends AgentTestRunner {
             "component" "java-web-servlet"
             "peer.hostname" "localhost"
             "peer.port" port
-            "span.type" DDSpanTypes.HTTP_SERVER
             "span.origin.type" {
               it == "TestServlet3\$$origin" || it == "TestServlet3\$DispatchRecursive" || it == ApplicationFilterChain.name
             }
@@ -219,7 +216,6 @@ abstract class AbstractServlet3Test<CONTEXT> extends AgentTestRunner {
             "component" "java-web-servlet"
             "peer.hostname" "localhost"
             "peer.port" port
-            "span.type" DDSpanTypes.HTTP_SERVER
             "span.origin.type" { it == "TestServlet3\$Dispatch$origin" || it == ApplicationFilterChain.name }
             "http.status_code" 200
             "servlet.context" "/$context"
@@ -279,7 +275,6 @@ abstract class AbstractServlet3Test<CONTEXT> extends AgentTestRunner {
             "component" "java-web-servlet"
             "peer.hostname" "localhost"
             "peer.port" port
-            "span.type" DDSpanTypes.HTTP_SERVER
             "span.origin.type" { it == "TestServlet3\$Dispatch$origin" || it == ApplicationFilterChain.name }
             "http.status_code" 200
             "servlet.context" "/$context"
@@ -303,7 +298,6 @@ abstract class AbstractServlet3Test<CONTEXT> extends AgentTestRunner {
             "component" "java-web-servlet"
             "peer.hostname" "localhost"
             "peer.port" port
-            "span.type" DDSpanTypes.HTTP_SERVER
             "span.origin.type" {
               it == "TestServlet3\$$origin" || it == "TestServlet3\$DispatchRecursive" || it == ApplicationFilterChain.name
             }
@@ -342,6 +336,7 @@ abstract class AbstractServlet3Test<CONTEXT> extends AgentTestRunner {
             span(0) {
               operationName "servlet.request"
               resourceName "GET /$context/dispatch/async"
+              spanType DDSpanTypes.HTTP_SERVER
               parent()
             }
           }
@@ -350,6 +345,7 @@ abstract class AbstractServlet3Test<CONTEXT> extends AgentTestRunner {
           span(0) {
             operationName "servlet.request"
             resourceName "GET /$context/async"
+            spanType DDSpanTypes.HTTP_SERVER
             if (dispatched) {
               childOf TEST_WRITER[i][0]
             } else {
@@ -393,7 +389,6 @@ abstract class AbstractServlet3Test<CONTEXT> extends AgentTestRunner {
             "component" "java-web-servlet"
             "peer.hostname" "localhost"
             "peer.port" port
-            "span.type" DDSpanTypes.HTTP_SERVER
             "span.origin.type" { it == "TestServlet3\$$origin" || it == ApplicationFilterChain.name }
             "servlet.context" "/$context"
             "http.status_code" 500
@@ -439,7 +434,6 @@ abstract class AbstractServlet3Test<CONTEXT> extends AgentTestRunner {
             "component" "java-web-servlet"
             "peer.hostname" "localhost"
             "peer.port" port
-            "span.type" DDSpanTypes.HTTP_SERVER
             "span.origin.type" { it == "TestServlet3\$$origin" || it == ApplicationFilterChain.name }
             "servlet.context" "/$context"
             "http.status_code" 500

--- a/dd-java-agent/instrumentation/sparkjava-2.3/src/test/groovy/SparkJavaBasedTest.groovy
+++ b/dd-java-agent/instrumentation/sparkjava-2.3/src/test/groovy/SparkJavaBasedTest.groovy
@@ -2,7 +2,6 @@ import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.utils.OkHttpUtils
 import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
-import datadog.trace.api.DDTags
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import spark.Spark
@@ -56,7 +55,6 @@ class SparkJavaBasedTest extends AgentTestRunner {
             "span.kind" "server"
             "component" "jetty-handler"
             "span.origin.type" spark.embeddedserver.jetty.JettyHandler.name
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_SERVER
             "http.status_code" 200
             defaultTags()
           }

--- a/dd-java-agent/instrumentation/spring-web/src/test/groovy/test/SpringBootBasedTest.groovy
+++ b/dd-java-agent/instrumentation/spring-web/src/test/groovy/test/SpringBootBasedTest.groovy
@@ -47,7 +47,6 @@ class SpringBootBasedTest extends AgentTestRunner {
             "peer.hostname" "localhost"
             "peer.port" port
             "span.kind" "server"
-            "span.type" "web"
             "span.origin.type" "org.apache.catalina.core.ApplicationFilterChain"
             "component" "java-web-servlet"
             "http.status_code" 200
@@ -85,7 +84,6 @@ class SpringBootBasedTest extends AgentTestRunner {
             "peer.hostname" "localhost"
             "peer.port" port
             "span.kind" "server"
-            "span.type" "web"
             "span.origin.type" "org.apache.catalina.core.ApplicationFilterChain"
             "component" "java-web-servlet"
             "http.status_code" status.value
@@ -125,7 +123,6 @@ class SpringBootBasedTest extends AgentTestRunner {
             "peer.hostname" "localhost"
             "peer.port" port
             "span.kind" "server"
-            "span.type" "web"
             "span.origin.type" "org.apache.catalina.core.ApplicationFilterChain"
             "component" "java-web-servlet"
             "http.status_code" 401
@@ -146,7 +143,6 @@ class SpringBootBasedTest extends AgentTestRunner {
             "peer.hostname" "localhost"
             "peer.port" port
             "span.kind" "server"
-            "span.type" "web"
             "span.origin.type" "org.apache.catalina.core.ApplicationFilterChain"
             "component" "java-web-servlet"
             "http.status_code" 401
@@ -181,7 +177,6 @@ class SpringBootBasedTest extends AgentTestRunner {
             "peer.hostname" "localhost"
             "peer.port" port
             "span.kind" "server"
-            "span.type" "web"
             "span.origin.type" "org.apache.catalina.core.ApplicationFilterChain"
             "component" "java-web-servlet"
             "http.status_code" 404
@@ -204,7 +199,6 @@ class SpringBootBasedTest extends AgentTestRunner {
             "peer.hostname" "localhost"
             "peer.port" port
             "span.kind" "server"
-            "span.type" "web"
             "span.origin.type" "org.apache.catalina.core.ApplicationFilterChain"
             "component" "java-web-servlet"
             "http.status_code" 404
@@ -241,7 +235,6 @@ class SpringBootBasedTest extends AgentTestRunner {
             "peer.hostname" "localhost"
             "peer.port" port
             "span.kind" "server"
-            "span.type" "web"
             "span.origin.type" "org.apache.catalina.core.ApplicationFilterChain"
             "component" "java-web-servlet"
             "http.status_code" 500
@@ -265,7 +258,6 @@ class SpringBootBasedTest extends AgentTestRunner {
             "peer.hostname" "localhost"
             "peer.port" port
             "span.kind" "server"
-            "span.type" "web"
             "span.origin.type" "org.apache.catalina.core.ApplicationFilterChain"
             "component" "java-web-servlet"
             "http.status_code" 500
@@ -297,7 +289,6 @@ class SpringBootBasedTest extends AgentTestRunner {
             "peer.hostname" "localhost"
             "peer.port" port
             "span.kind" "server"
-            "span.type" "web"
             "span.origin.type" "org.apache.catalina.core.ApplicationFilterChain"
             "component" "java-web-servlet"
             "http.status_code" 200
@@ -335,7 +326,6 @@ class SpringBootBasedTest extends AgentTestRunner {
             "peer.hostname" "localhost"
             "peer.port" port
             "span.kind" "server"
-            "span.type" "web"
             "span.origin.type" "org.apache.catalina.core.ApplicationFilterChain"
             "component" "java-web-servlet"
             "http.status_code" 400
@@ -362,7 +352,6 @@ class SpringBootBasedTest extends AgentTestRunner {
             "peer.hostname" "localhost"
             "peer.port" port
             "span.kind" "server"
-            "span.type" "web"
             "span.origin.type" "org.apache.catalina.core.ApplicationFilterChain"
             "component" "java-web-servlet"
             "http.status_code" 400
@@ -382,7 +371,6 @@ class SpringBootBasedTest extends AgentTestRunner {
       childOf(trace.span(0))
       errored errorType != null
       tags {
-        "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_SERVER
         "$Tags.COMPONENT.key" "spring-web-controller"
         if (errorType) {
           "error.msg" String

--- a/dd-java-agent/instrumentation/spring-webflux/src/test/groovy/SpringWebfluxTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webflux/src/test/groovy/SpringWebfluxTest.groovy
@@ -1,7 +1,6 @@
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.utils.OkHttpUtils
 import datadog.trace.api.DDSpanTypes
-import datadog.trace.api.DDTags
 import dd.trace.instrumentation.springwebflux.EchoHandlerFunction
 import dd.trace.instrumentation.springwebflux.FooModel
 import dd.trace.instrumentation.springwebflux.SpringWebFluxTestApplication
@@ -63,7 +62,6 @@ class SpringWebfluxTest extends AgentTestRunner {
           childOf(span(1))
           tags {
             "$Tags.COMPONENT.key" "spring-webflux-controller"
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_SERVER
             if (annotatedMethod == null) {
               // Functional API
               "request.predicate" "(GET && $urlPathWithVariables)"
@@ -85,7 +83,6 @@ class SpringWebfluxTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT.key" "netty"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_SERVER
             "$Tags.PEER_HOSTNAME.key" "localhost"
             "$Tags.PEER_PORT.key" Integer
             "$Tags.HTTP_METHOD.key" "GET"
@@ -137,7 +134,6 @@ class SpringWebfluxTest extends AgentTestRunner {
           childOf(span(1))
           tags {
             "$Tags.COMPONENT.key" "spring-webflux-controller"
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_SERVER
             if (annotatedMethod == null) {
               // Functional API
               "request.predicate" "(GET && $urlPathWithVariables)"
@@ -159,7 +155,6 @@ class SpringWebfluxTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT.key" "netty"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_SERVER
             "$Tags.PEER_HOSTNAME.key" "localhost"
             "$Tags.PEER_PORT.key" Integer
             "$Tags.HTTP_METHOD.key" "GET"
@@ -183,7 +178,6 @@ class SpringWebfluxTest extends AgentTestRunner {
           errored false
           tags {
             "$Tags.COMPONENT.key" "trace"
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_SERVER
             defaultTags()
           }
         }
@@ -221,7 +215,6 @@ class SpringWebfluxTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT.key" "netty"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_SERVER
             "$Tags.PEER_HOSTNAME.key" "localhost"
             "$Tags.PEER_PORT.key" Integer
             "$Tags.HTTP_METHOD.key" "GET"
@@ -238,7 +231,6 @@ class SpringWebfluxTest extends AgentTestRunner {
           errored true
           tags {
             "$Tags.COMPONENT.key" "spring-webflux-controller"
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_SERVER
             "handler.type" "org.springframework.web.reactive.resource.ResourceWebHandler"
             errorTags(ResponseStatusException, String)
             defaultTags()
@@ -270,7 +262,6 @@ class SpringWebfluxTest extends AgentTestRunner {
           childOf(span(1))
           tags {
             "$Tags.COMPONENT.key" "spring-webflux-controller"
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_SERVER
             "request.predicate" "(POST && /echo)"
             "handler.type" { String tagVal ->
               return tagVal.contains(EchoHandlerFunction.getName())
@@ -286,7 +277,6 @@ class SpringWebfluxTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT.key" "netty"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_SERVER
             "$Tags.PEER_HOSTNAME.key" "localhost"
             "$Tags.PEER_PORT.key" Integer
             "$Tags.HTTP_METHOD.key" "POST"
@@ -301,7 +291,6 @@ class SpringWebfluxTest extends AgentTestRunner {
           childOf(span(0))
           tags {
             "$Tags.COMPONENT.key" "trace"
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_SERVER
             defaultTags()
           }
         }
@@ -330,7 +319,6 @@ class SpringWebfluxTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT.key" "netty"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_SERVER
             "$Tags.PEER_HOSTNAME.key" "localhost"
             "$Tags.PEER_PORT.key" Integer
             "$Tags.HTTP_METHOD.key" "GET"
@@ -355,7 +343,6 @@ class SpringWebfluxTest extends AgentTestRunner {
           errored true
           tags {
             "$Tags.COMPONENT.key" "spring-webflux-controller"
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_SERVER
             if (annotatedMethod == null) {
               // Functional API
               "request.predicate" "(GET && $urlPathWithVariables)"
@@ -404,7 +391,6 @@ class SpringWebfluxTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT.key" "netty"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_SERVER
             "$Tags.PEER_HOSTNAME.key" "localhost"
             "$Tags.PEER_PORT.key" Integer
             "$Tags.HTTP_METHOD.key" "GET"
@@ -420,7 +406,6 @@ class SpringWebfluxTest extends AgentTestRunner {
           childOf(span(0))
           tags {
             "$Tags.COMPONENT.key" "spring-webflux-controller"
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_SERVER
             "request.predicate" "(GET && /double-greet-redirect)"
             "handler.type" { String tagVal ->
               return (tagVal.contains(INNER_HANDLER_FUNCTION_CLASS_TAG_PREFIX)
@@ -438,7 +423,6 @@ class SpringWebfluxTest extends AgentTestRunner {
           childOf(span(1))
           tags {
             "$Tags.COMPONENT.key" "spring-webflux-controller"
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_SERVER
             "request.predicate" "(GET && /double-greet)"
             "handler.type" { String tagVal ->
               return tagVal.contains(INNER_HANDLER_FUNCTION_CLASS_TAG_PREFIX)
@@ -454,7 +438,6 @@ class SpringWebfluxTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT.key" "netty"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_SERVER
             "$Tags.PEER_HOSTNAME.key" "localhost"
             "$Tags.PEER_PORT.key" Integer
             "$Tags.HTTP_METHOD.key" "GET"
@@ -495,7 +478,6 @@ class SpringWebfluxTest extends AgentTestRunner {
             childOf(span(1))
             tags {
               "$Tags.COMPONENT.key" "spring-webflux-controller"
-              "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_SERVER
               if (annotatedMethod == null) {
                 // Functional API
                 "request.predicate" "(GET && $urlPathWithVariables)"
@@ -517,7 +499,6 @@ class SpringWebfluxTest extends AgentTestRunner {
             tags {
               "$Tags.COMPONENT.key" "netty"
               "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
-              "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_SERVER
               "$Tags.PEER_HOSTNAME.key" "localhost"
               "$Tags.PEER_PORT.key" Integer
               "$Tags.HTTP_METHOD.key" "GET"

--- a/dd-java-agent/instrumentation/spymemcached-2.12/src/test/groovy/datadog/trace/instrumentation/spymemcached/SpymemcachedTest.groovy
+++ b/dd-java-agent/instrumentation/spymemcached-2.12/src/test/groovy/datadog/trace/instrumentation/spymemcached/SpymemcachedTest.groovy
@@ -4,7 +4,6 @@ import com.google.common.util.concurrent.MoreExecutors
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.api.DDSpanTypes
-import datadog.trace.api.DDTags
 import io.opentracing.tag.Tags
 import net.spy.memcached.CASResponse
 import net.spy.memcached.ConnectionFactory
@@ -631,7 +630,6 @@ class SpymemcachedTest extends AgentTestRunner {
 
       tags {
         defaultTags()
-        "${DDTags.SPAN_TYPE}" DDSpanTypes.MEMCACHED
         "${Tags.COMPONENT.key}" COMPONENT_NAME
         "${Tags.SPAN_KIND.key}" Tags.SPAN_KIND_CLIENT
         "${Tags.DB_TYPE.key}" CompletionListener.DB_TYPE

--- a/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/TraceAnnotationsTest.groovy
+++ b/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/TraceAnnotationsTest.groovy
@@ -61,7 +61,6 @@ class TraceAnnotationsTest extends AgentTestRunner {
           errored false
           tags {
             "$Tags.COMPONENT.key" "trace"
-            "span.type" "DB"
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/vertx/src/test/groovy/VertxHttpClientTest.groovy
+++ b/dd-java-agent/instrumentation/vertx/src/test/groovy/VertxHttpClientTest.groovy
@@ -1,7 +1,6 @@
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
-import datadog.trace.api.DDTags
 import io.netty.channel.AbstractChannel
 import io.opentracing.tag.Tags
 import io.vertx.core.Vertx
@@ -84,7 +83,6 @@ class VertxHttpClientTest extends AgentTestRunner {
             "$Tags.PEER_PORT.key" server.address.port
             "$Tags.HTTP_METHOD.key" "GET"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_CLIENT
             "$Tags.COMPONENT.key" "netty-client"
             if (expectedError) {
               "$Tags.ERROR.key" true

--- a/dd-java-agent/instrumentation/vertx/src/test/groovy/VertxServerTest.groovy
+++ b/dd-java-agent/instrumentation/vertx/src/test/groovy/VertxServerTest.groovy
@@ -2,7 +2,6 @@ import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.utils.OkHttpUtils
 import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
-import datadog.trace.api.DDTags
 import io.netty.handler.codec.http.HttpResponseStatus
 import io.opentracing.tag.Tags
 import io.vertx.core.Vertx
@@ -62,7 +61,6 @@ class VertxServerTest extends AgentTestRunner {
             "$Tags.PEER_HOSTNAME.key" "localhost"
             "$Tags.PEER_PORT.key" Integer
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_SERVER
             defaultTags(true)
           }
         }
@@ -99,7 +97,6 @@ class VertxServerTest extends AgentTestRunner {
             "$Tags.PEER_HOSTNAME.key" "localhost"
             "$Tags.PEER_PORT.key" Integer
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_SERVER
             if (error) {
               tag("error", true)
             }

--- a/dd-trace-ot/src/main/java/datadog/opentracing/DDSpanContext.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/DDSpanContext.java
@@ -121,9 +121,6 @@ public class DDSpanContext implements io.opentracing.SpanContext {
       setSamplingPriority(samplingPriority);
     }
 
-    if (spanType != null) {
-      this.tags.put(DDTags.SPAN_TYPE, spanType);
-    }
     if (origin != null) {
       this.tags.put(ORIGIN_KEY, origin);
     }
@@ -181,11 +178,6 @@ public class DDSpanContext implements io.opentracing.SpanContext {
 
   public void setSpanType(final String spanType) {
     this.spanType = spanType;
-    if (spanType == null) {
-      tags.remove(DDTags.SPAN_TYPE);
-    } else {
-      tags.put(DDTags.SPAN_TYPE, spanType);
-    }
   }
 
   public void setSamplingPriority(final int newPriority) {

--- a/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
@@ -634,9 +634,6 @@ public class DDTracer implements io.opentracing.Tracer, Closeable, datadog.trace
         if (serviceName == null) {
           serviceName = ddsc.getServiceName();
         }
-        if (spanType == null) {
-          spanType = ddsc.getSpanType();
-        }
 
       } else {
         if (parentContext instanceof ExtractedContext) {

--- a/dd-trace-ot/src/main/java/datadog/opentracing/decorators/SpanTypeDecorator.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/decorators/SpanTypeDecorator.java
@@ -13,7 +13,6 @@ public class SpanTypeDecorator extends AbstractDecorator {
   @Override
   public boolean shouldSetTag(final DDSpanContext context, final String tag, final Object value) {
     context.setSpanType(String.valueOf(value));
-    // TODO: Do we really want a span type tag since it already exists on the span?
-    return true;
+    return false;
   }
 }

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/DDSpanBuilderTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/DDSpanBuilderTest.groovy
@@ -208,7 +208,7 @@ class DDSpanBuilderTest extends Specification {
     span.getBaggageItem(expectedBaggageItemKey) == expectedBaggageItemValue
     span.context().getServiceName() == expectedParentServiceName
     span.context().getResourceName() == expectedName
-    span.context().getSpanType() == expectedParentType
+    span.context().getSpanType() == null
 
     when:
     // ServiceName and SpanType are always overwritten by the child  if they are present
@@ -270,7 +270,7 @@ class DDSpanBuilderTest extends Specification {
     span.getBaggageItem(expectedBaggageItemKey) == expectedBaggageItemValue
     span.context().getServiceName() == expectedParentServiceName
     span.context().getResourceName() == expectedName
-    span.context().getSpanType() == expectedParentType
+    span.context().getSpanType() == null
 
     when:
     // ServiceName and SpanType are always overwritten by the child  if they are present
@@ -332,7 +332,7 @@ class DDSpanBuilderTest extends Specification {
     span.getBaggageItem(expectedBaggageItemKey) == expectedBaggageItemValue
     span.context().getServiceName() == expectedParentServiceName
     span.context().getResourceName() == expectedName
-    span.context().getSpanType() == expectedParentType
+    span.context().getSpanType() == null
 
     when:
     // ServiceName and SpanType are always overwritten by the child  if they are present

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/DDSpanSerializationTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/DDSpanSerializationTest.groovy
@@ -1,5 +1,6 @@
 package datadog.opentracing
 
+
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.google.common.collect.Maps
 import datadog.trace.api.DDTags
@@ -60,7 +61,6 @@ class DDSpanSerializationTest extends Specification {
 
     baggage.put(DDTags.THREAD_NAME, Thread.currentThread().getName())
     baggage.put(DDTags.THREAD_ID, String.valueOf(Thread.currentThread().getId()))
-    baggage.put(DDTags.SPAN_TYPE, context.getSpanType())
 
     DDSpan span = new DDSpan(100L, context)
     if (samplingPriority != PrioritySampling.UNSET) {
@@ -69,8 +69,10 @@ class DDSpanSerializationTest extends Specification {
     span.finish(133L)
     ObjectMapper serializer = new ObjectMapper()
 
+    def actualTree = serializer.readTree(serializer.writeValueAsString(span))
+    def expectedTree = serializer.readTree(serializer.writeValueAsString(expected))
     expect:
-    serializer.readTree(serializer.writeValueAsString(span)) == serializer.readTree(serializer.writeValueAsString(expected))
+    actualTree == expectedTree
 
     where:
     samplingPriority              | _

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/TraceInterceptorTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/TraceInterceptorTest.groovy
@@ -139,12 +139,11 @@ class TraceInterceptorTest extends Specification {
     tags["number-tag"] == 5.0
     tags["string-tag"] == "howdy"
 
-    tags["span.type"] == "modifiedST-null"
     tags["thread.name"] != null
     tags["thread.id"] != null
     tags["runtime-id"] != null
     tags["language"] != null
-    tags.size() == 8
+    tags.size() == 7
   }
 
   def "register interceptor through bridge"() {

--- a/dd-trace-ot/src/test/groovy/datadog/trace/DDSpanContextTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/trace/DDSpanContextTest.groovy
@@ -22,10 +22,10 @@ class DDSpanContextTest extends Specification {
 
     where:
     name                 | extra             | tags
-    DDTags.SERVICE_NAME  | "some.tag=asdf, " | ["some.tag": "asdf", (DDTags.SPAN_TYPE): "fakeType", (DDTags.THREAD_NAME): Thread.currentThread().name, (DDTags.THREAD_ID): Thread.currentThread().id]
-    DDTags.RESOURCE_NAME | "some.tag=asdf, " | ["some.tag": "asdf", (DDTags.SPAN_TYPE): "fakeType", (DDTags.THREAD_NAME): Thread.currentThread().name, (DDTags.THREAD_ID): Thread.currentThread().id]
+    DDTags.SERVICE_NAME  | "some.tag=asdf, " | ["some.tag": "asdf", (DDTags.THREAD_NAME): Thread.currentThread().name, (DDTags.THREAD_ID): Thread.currentThread().id]
+    DDTags.RESOURCE_NAME | "some.tag=asdf, " | ["some.tag": "asdf", (DDTags.THREAD_NAME): Thread.currentThread().name, (DDTags.THREAD_ID): Thread.currentThread().id]
     DDTags.SPAN_TYPE     | "some.tag=asdf, " | ["some.tag": "asdf", (DDTags.THREAD_NAME): Thread.currentThread().name, (DDTags.THREAD_ID): Thread.currentThread().id]
-    "some.tag"           | ""                | [(DDTags.SPAN_TYPE): "fakeType", (DDTags.THREAD_NAME): Thread.currentThread().name, (DDTags.THREAD_ID): Thread.currentThread().id]
+    "some.tag"           | ""                | [(DDTags.THREAD_NAME): Thread.currentThread().name, (DDTags.THREAD_ID): Thread.currentThread().id]
   }
 
   def "special tags set certain values"() {
@@ -34,8 +34,8 @@ class DDSpanContextTest extends Specification {
     context.setTag(name, value)
     def thread = Thread.currentThread()
 
-    def expectedTags = [(DDTags.THREAD_NAME): thread.name, (DDTags.THREAD_ID): thread.id, (DDTags.SPAN_TYPE): context.getSpanType()]
-    def expectedTrace = "DDSpan [ t_id=1, s_id=1, p_id=0] trace=$details metrics={} tags={span.type=${context.getSpanType()}, thread.id=$thread.id, thread.name=$thread.name}"
+    def expectedTags = [(DDTags.THREAD_NAME): thread.name, (DDTags.THREAD_ID): thread.id]
+    def expectedTrace = "DDSpan [ t_id=1, s_id=1, p_id=0] trace=$details metrics={} tags={thread.id=$thread.id, thread.name=$thread.name}"
 
     expect:
     context.getTags() == expectedTags
@@ -58,11 +58,10 @@ class DDSpanContextTest extends Specification {
     expect:
     context.getTags() == [
       (name)              : value,
-      (DDTags.SPAN_TYPE)  : context.getSpanType(),
       (DDTags.THREAD_NAME): thread.name,
       (DDTags.THREAD_ID)  : thread.id
     ]
-    context.toString() == "DDSpan [ t_id=1, s_id=1, p_id=0] trace=fakeService/fakeOperation/fakeResource metrics={} tags={span.type=${context.getSpanType()}, $name=$value, thread.id=$thread.id, thread.name=$thread.name}"
+    context.toString() == "DDSpan [ t_id=1, s_id=1, p_id=0] trace=fakeService/fakeOperation/fakeResource metrics={} tags={$name=$value, thread.id=$thread.id, thread.name=$thread.name}"
 
     where:
     name             | value

--- a/dd-trace-ot/src/test/groovy/datadog/trace/api/writer/DDApiTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/trace/api/writer/DDApiTest.groovy
@@ -87,7 +87,7 @@ class DDApiTest extends Specification {
     [SpanFactory.newSpanOf(1L).setTag("service.name", "my-service")]     | [new TreeMap<>([
       "duration" : 0,
       "error"    : 0,
-      "meta"     : ["span.type": "fakeType", "thread.name": Thread.currentThread().getName(), "thread.id": "${Thread.currentThread().id}"],
+      "meta"     : ["thread.name": Thread.currentThread().getName(), "thread.id": "${Thread.currentThread().id}"],
       "metrics"  : [:],
       "name"     : "fakeOperation",
       "parent_id": 0,
@@ -101,7 +101,7 @@ class DDApiTest extends Specification {
     [SpanFactory.newSpanOf(100L).setTag("resource.name", "my-resource")] | [new TreeMap<>([
       "duration" : 0,
       "error"    : 0,
-      "meta"     : ["span.type": "fakeType", "thread.name": Thread.currentThread().getName(), "thread.id": "${Thread.currentThread().id}"],
+      "meta"     : ["thread.name": Thread.currentThread().getName(), "thread.id": "${Thread.currentThread().id}"],
       "metrics"  : [:],
       "name"     : "fakeOperation",
       "parent_id": 0,


### PR DESCRIPTION
Previously we were inheriting from the parent and also often setting as a tag.

Apply default span assertion to verify the spanType is being checked properly. (Include error state too.)