### PR TITLE
Migrate JSP instrumentation to Decorator

### DIFF
--- a/dd-java-agent/instrumentation/jsp-2.3/src/main/java/datadog/trace/instrumentation/jsp/JSPDecorator.java
+++ b/dd-java-agent/instrumentation/jsp-2.3/src/main/java/datadog/trace/instrumentation/jsp/JSPDecorator.java
@@ -1,0 +1,76 @@
+package datadog.trace.instrumentation.jsp;
+
+import datadog.trace.agent.decorator.BaseDecorator;
+import datadog.trace.api.DDTags;
+import io.opentracing.Scope;
+import io.opentracing.Span;
+import java.net.URI;
+import java.net.URISyntaxException;
+import javax.servlet.RequestDispatcher;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.jsp.HttpJspPage;
+import org.apache.jasper.JspCompilationContext;
+import org.slf4j.LoggerFactory;
+
+public class JSPDecorator extends BaseDecorator {
+  public static JSPDecorator DECORATE = new JSPDecorator();
+
+  @Override
+  protected String[] instrumentationNames() {
+    return new String[] {"jsp"};
+  }
+
+  @Override
+  protected String spanType() {
+    return null;
+  }
+
+  @Override
+  protected String component() {
+    return "jsp-http-servlet";
+  }
+
+  public void onCompile(final Scope scope, final JspCompilationContext jspCompilationContext) {
+    if (jspCompilationContext != null) {
+      final Span span = scope.span();
+      span.setTag(DDTags.RESOURCE_NAME, jspCompilationContext.getJspFile());
+
+      if (jspCompilationContext.getServletContext() != null) {
+        span.setTag("servlet.context", jspCompilationContext.getServletContext().getContextPath());
+      }
+
+      if (jspCompilationContext.getCompiler() != null) {
+        span.setTag("jsp.compiler", jspCompilationContext.getCompiler().getClass().getName());
+      }
+      span.setTag("jsp.classFQCN", jspCompilationContext.getFQCN());
+    }
+  }
+
+  public void onRender(final Scope scope, final HttpServletRequest req) {
+    final Span span = scope.span();
+    // get the JSP file name being rendered in an include action
+    final Object includeServletPath = req.getAttribute(RequestDispatcher.INCLUDE_SERVLET_PATH);
+    String resourceName = req.getServletPath();
+    if (includeServletPath instanceof String) {
+      resourceName = includeServletPath.toString();
+    }
+    span.setTag(DDTags.RESOURCE_NAME, resourceName);
+
+    final Object forwardOrigin = req.getAttribute(RequestDispatcher.FORWARD_SERVLET_PATH);
+    if (forwardOrigin instanceof String) {
+      span.setTag("jsp.forwardOrigin", forwardOrigin.toString());
+    }
+
+    // add the request URL as a tag to provide better context when looking at spans produced by
+    // actions. Tomcat 9 has relative path symbols in the value returned from
+    // HttpServletRequest#getRequestURL(),
+    // normalizing the URL should remove those symbols for readability and consistency
+    try {
+      span.setTag(
+          "jsp.requestURL", (new URI(req.getRequestURL().toString())).normalize().toString());
+    } catch (final URISyntaxException uriSE) {
+      LoggerFactory.getLogger(HttpJspPage.class)
+          .warn("Failed to get and normalize request URL: " + uriSE.getMessage());
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/jsp-2.3/src/test/groovy/JSPInstrumentationBasicTests.groovy
+++ b/dd-java-agent/instrumentation/jsp-2.3/src/test/groovy/JSPInstrumentationBasicTests.groovy
@@ -39,15 +39,12 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
   File baseDir
   @Shared
   String baseUrl
-  @Shared
-  String expectedJspClassFilesDir = "/work/Tomcat/localhost/$jspWebappContext/org/apache/jsp/"
-
+  
   OkHttpClient client = OkHttpUtils.client()
 
   def setupSpec() {
     baseDir = Files.createTempDir()
     baseDir.deleteOnExit()
-    expectedJspClassFilesDir = baseDir.getCanonicalFile().getAbsolutePath() + expectedJspClassFilesDir
 
     port = PortUtils.randomOpenPort()
 
@@ -113,10 +110,8 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           serviceName jspWebappContext
           operationName "jsp.render"
           resourceName "/$jspFileName"
-          spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
-            "span.kind" "server"
             "component" "jsp-http-servlet"
             "span.origin.type" jspClassName
             "servlet.context" "/$jspWebappContext"
@@ -129,10 +124,8 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           serviceName jspWebappContext
           operationName "jsp.compile"
           resourceName "/$jspFileName"
-          spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
-            "span.kind" "server"
             "component" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.$jspClassNamePrefix$jspClassName"
@@ -191,10 +184,8 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           serviceName jspWebappContext
           operationName "jsp.render"
           resourceName "/getQuery.jsp"
-          spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
-            "span.kind" "server"
             "component" "jsp-http-servlet"
             "span.origin.type" "getQuery_jsp"
             "servlet.context" "/$jspWebappContext"
@@ -207,10 +198,8 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           serviceName jspWebappContext
           operationName "jsp.compile"
           resourceName "/getQuery.jsp"
-          spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
-            "span.kind" "server"
             "component" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.getQuery_jsp"
@@ -266,10 +255,8 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           serviceName jspWebappContext
           operationName "jsp.render"
           resourceName "/post.jsp"
-          spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
-            "span.kind" "server"
             "component" "jsp-http-servlet"
             "span.origin.type" "post_jsp"
             "servlet.context" "/$jspWebappContext"
@@ -282,10 +269,8 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           serviceName jspWebappContext
           operationName "jsp.compile"
           resourceName "/post.jsp"
-          spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
-            "span.kind" "server"
             "component" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.post_jsp"
@@ -339,10 +324,8 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           serviceName jspWebappContext
           operationName "jsp.render"
           resourceName "/$jspFileName"
-          spanType DDSpanTypes.HTTP_SERVER
           errored true
           tags {
-            "span.kind" "server"
             "component" "jsp-http-servlet"
             "span.origin.type" jspClassName
             "servlet.context" "/$jspWebappContext"
@@ -363,10 +346,8 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           serviceName jspWebappContext
           operationName "jsp.compile"
           resourceName "/$jspFileName"
-          spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
-            "span.kind" "server"
             "component" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.$jspClassName"
@@ -424,10 +405,8 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           serviceName jspWebappContext
           operationName "jsp.render"
           resourceName "/includes/includeHtml.jsp"
-          spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
-            "span.kind" "server"
             "component" "jsp-http-servlet"
             "span.origin.type" "includeHtml_jsp"
             "servlet.context" "/$jspWebappContext"
@@ -440,10 +419,8 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           serviceName jspWebappContext
           operationName "jsp.compile"
           resourceName "/includes/includeHtml.jsp"
-          spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
-            "span.kind" "server"
             "component" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.includes.includeHtml_jsp"
@@ -495,10 +472,8 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           serviceName jspWebappContext
           operationName "jsp.render"
           resourceName "/includes/includeMulti.jsp"
-          spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
-            "span.kind" "server"
             "component" "jsp-http-servlet"
             "span.origin.type" "includeMulti_jsp"
             "servlet.context" "/$jspWebappContext"
@@ -511,10 +486,8 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           serviceName jspWebappContext
           operationName "jsp.render"
           resourceName "/common/javaLoopH2.jsp"
-          spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
-            "span.kind" "server"
             "component" "jsp-http-servlet"
             "span.origin.type" "javaLoopH2_jsp"
             "servlet.context" "/$jspWebappContext"
@@ -527,10 +500,8 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           serviceName jspWebappContext
           operationName "jsp.compile"
           resourceName "/common/javaLoopH2.jsp"
-          spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
-            "span.kind" "server"
             "component" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.common.javaLoopH2_jsp"
@@ -543,10 +514,8 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           serviceName jspWebappContext
           operationName "jsp.render"
           resourceName "/common/javaLoopH2.jsp"
-          spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
-            "span.kind" "server"
             "component" "jsp-http-servlet"
             "span.origin.type" "javaLoopH2_jsp"
             "servlet.context" "/$jspWebappContext"
@@ -559,10 +528,8 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           serviceName jspWebappContext
           operationName "jsp.compile"
           resourceName "/common/javaLoopH2.jsp"
-          spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
-            "span.kind" "server"
             "component" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.common.javaLoopH2_jsp"
@@ -575,10 +542,8 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           serviceName jspWebappContext
           operationName "jsp.compile"
           resourceName "/includes/includeMulti.jsp"
-          spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
-            "span.kind" "server"
             "component" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.includes.includeMulti_jsp"
@@ -631,16 +596,12 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           serviceName jspWebappContext
           operationName "jsp.compile"
           resourceName "/$jspFileName"
-          spanType DDSpanTypes.HTTP_SERVER
           errored true
           tags {
-            "span.kind" "server"
             "component" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.$jspClassNamePrefix$jspClassName"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
-            "jsp.javaFile" expectedJspClassFilesDir + jspClassNamePrefix.replace('.', '/') + jspClassName + ".java"
-            "jsp.classpath" String
             errorTags(JasperException, String)
             defaultTags()
           }

--- a/dd-java-agent/instrumentation/jsp-2.3/src/test/groovy/JSPInstrumentationForwardTests.groovy
+++ b/dd-java-agent/instrumentation/jsp-2.3/src/test/groovy/JSPInstrumentationForwardTests.groovy
@@ -37,15 +37,12 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
   File baseDir
   @Shared
   String baseUrl
-  @Shared
-  String expectedJspClassFilesDir = "/work/Tomcat/localhost/$jspWebappContext/org/apache/jsp/"
 
   OkHttpClient client = OkHttpUtils.client()
 
   def setupSpec() {
     baseDir = Files.createTempDir()
     baseDir.deleteOnExit()
-    expectedJspClassFilesDir = baseDir.getCanonicalFile().getAbsolutePath() + expectedJspClassFilesDir
 
     port = PortUtils.randomOpenPort()
 
@@ -112,10 +109,8 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           serviceName jspWebappContext
           operationName "jsp.render"
           resourceName "/$forwardFromFileName"
-          spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
-            "span.kind" "server"
             "component" "jsp-http-servlet"
             "span.origin.type" jspForwardFromClassName
             "servlet.context" "/$jspWebappContext"
@@ -128,10 +123,8 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           serviceName jspWebappContext
           operationName "jsp.render"
           resourceName "/$forwardDestFileName"
-          spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
-            "span.kind" "server"
             "component" "jsp-http-servlet"
             "span.origin.type" jspForwardDestClassName
             "servlet.context" "/$jspWebappContext"
@@ -145,10 +138,8 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           serviceName jspWebappContext
           operationName "jsp.compile"
           resourceName "/$forwardDestFileName"
-          spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
-            "span.kind" "server"
             "component" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.$jspForwardDestClassPrefix$jspForwardDestClassName"
@@ -161,10 +152,8 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           serviceName jspWebappContext
           operationName "jsp.compile"
           resourceName "/$forwardFromFileName"
-          spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
-            "span.kind" "server"
             "component" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.$jspForwardFromClassPrefix$jspForwardFromClassName"
@@ -221,10 +210,8 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           serviceName jspWebappContext
           operationName "jsp.render"
           resourceName "/forwards/forwardToHtml.jsp"
-          spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
-            "span.kind" "server"
             "component" "jsp-http-servlet"
             "span.origin.type" "forwardToHtml_jsp"
             "servlet.context" "/$jspWebappContext"
@@ -237,10 +224,8 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           serviceName jspWebappContext
           operationName "jsp.compile"
           resourceName "/forwards/forwardToHtml.jsp"
-          spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
-            "span.kind" "server"
             "component" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.forwards.forwardToHtml_jsp"
@@ -292,10 +277,8 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           serviceName jspWebappContext
           operationName "jsp.render"
           resourceName "/forwards/forwardToIncludeMulti.jsp"
-          spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
-            "span.kind" "server"
             "component" "jsp-http-servlet"
             "span.origin.type" "forwardToIncludeMulti_jsp"
             "servlet.context" "/$jspWebappContext"
@@ -308,10 +291,8 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           serviceName jspWebappContext
           operationName "jsp.render"
           resourceName "/includes/includeMulti.jsp"
-          spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
-            "span.kind" "server"
             "component" "jsp-http-servlet"
             "span.origin.type" "includeMulti_jsp"
             "servlet.context" "/$jspWebappContext"
@@ -325,10 +306,8 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           serviceName jspWebappContext
           operationName "jsp.render"
           resourceName "/common/javaLoopH2.jsp"
-          spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
-            "span.kind" "server"
             "component" "jsp-http-servlet"
             "span.origin.type" "javaLoopH2_jsp"
             "servlet.context" "/$jspWebappContext"
@@ -342,10 +321,8 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           serviceName jspWebappContext
           operationName "jsp.compile"
           resourceName "/common/javaLoopH2.jsp"
-          spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
-            "span.kind" "server"
             "component" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.common.javaLoopH2_jsp"
@@ -358,10 +335,8 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           serviceName jspWebappContext
           operationName "jsp.render"
           resourceName "/common/javaLoopH2.jsp"
-          spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
-            "span.kind" "server"
             "component" "jsp-http-servlet"
             "span.origin.type" "javaLoopH2_jsp"
             "servlet.context" "/$jspWebappContext"
@@ -375,10 +350,8 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           serviceName jspWebappContext
           operationName "jsp.compile"
           resourceName "/common/javaLoopH2.jsp"
-          spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
-            "span.kind" "server"
             "component" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.common.javaLoopH2_jsp"
@@ -391,10 +364,8 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           serviceName jspWebappContext
           operationName "jsp.compile"
           resourceName "/includes/includeMulti.jsp"
-          spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
-            "span.kind" "server"
             "component" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.includes.includeMulti_jsp"
@@ -407,10 +378,8 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           serviceName jspWebappContext
           operationName "jsp.compile"
           resourceName "/forwards/forwardToIncludeMulti.jsp"
-          spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
-            "span.kind" "server"
             "component" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.forwards.forwardToIncludeMulti_jsp"
@@ -462,10 +431,8 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           serviceName jspWebappContext
           operationName "jsp.render"
           resourceName "/forwards/forwardToJspForward.jsp"
-          spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
-            "span.kind" "server"
             "component" "jsp-http-servlet"
             "span.origin.type" "forwardToJspForward_jsp"
             "servlet.context" "/$jspWebappContext"
@@ -478,10 +445,8 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           serviceName jspWebappContext
           operationName "jsp.render"
           resourceName "/forwards/forwardToSimpleJava.jsp"
-          spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
-            "span.kind" "server"
             "component" "jsp-http-servlet"
             "span.origin.type" "forwardToSimpleJava_jsp"
             "servlet.context" "/$jspWebappContext"
@@ -495,10 +460,8 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           serviceName jspWebappContext
           operationName "jsp.render"
           resourceName "/common/loop.jsp"
-          spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
-            "span.kind" "server"
             "component" "jsp-http-servlet"
             "span.origin.type" "loop_jsp"
             "servlet.context" "/$jspWebappContext"
@@ -512,10 +475,8 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           serviceName jspWebappContext
           operationName "jsp.compile"
           resourceName "/common/loop.jsp"
-          spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
-            "span.kind" "server"
             "component" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.common.loop_jsp"
@@ -528,10 +489,8 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           serviceName jspWebappContext
           operationName "jsp.compile"
           resourceName "/forwards/forwardToSimpleJava.jsp"
-          spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
-            "span.kind" "server"
             "component" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.forwards.forwardToSimpleJava_jsp"
@@ -544,10 +503,8 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           serviceName jspWebappContext
           operationName "jsp.compile"
           resourceName "/forwards/forwardToJspForward.jsp"
-          spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
-            "span.kind" "server"
             "component" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.forwards.forwardToJspForward_jsp"
@@ -600,10 +557,8 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           serviceName jspWebappContext
           operationName "jsp.render"
           resourceName "/forwards/forwardToCompileError.jsp"
-          spanType DDSpanTypes.HTTP_SERVER
           errored true
           tags {
-            "span.kind" "server"
             "component" "jsp-http-servlet"
             "span.origin.type" "forwardToCompileError_jsp"
             "servlet.context" "/$jspWebappContext"
@@ -617,16 +572,12 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           serviceName jspWebappContext
           operationName "jsp.compile"
           resourceName "/compileError.jsp"
-          spanType DDSpanTypes.HTTP_SERVER
           errored true
           tags {
-            "span.kind" "server"
             "component" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.compileError_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
-            "jsp.javaFile" expectedJspClassFilesDir + "compileError_jsp.java"
-            "jsp.classpath" String
             errorTags(JasperException, String)
             defaultTags()
           }
@@ -636,10 +587,8 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           serviceName jspWebappContext
           operationName "jsp.compile"
           resourceName "/forwards/forwardToCompileError.jsp"
-          spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
-            "span.kind" "server"
             "component" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.forwards.forwardToCompileError_jsp"
@@ -691,10 +640,8 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           serviceName jspWebappContext
           operationName "jsp.render"
           resourceName "/forwards/forwardToNonExistent.jsp"
-          spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
-            "span.kind" "server"
             "component" "jsp-http-servlet"
             "span.origin.type" "forwardToNonExistent_jsp"
             "servlet.context" "/$jspWebappContext"
@@ -707,10 +654,8 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           serviceName jspWebappContext
           operationName "jsp.compile"
           resourceName "/forwards/forwardToNonExistent.jsp"
-          spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
-            "span.kind" "server"
             "component" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.forwards.forwardToNonExistent_jsp"


### PR DESCRIPTION
Remove span kind and type from generated spans since these classify more as specialized @Trace spans.