### PR TITLE
Remove trace injection into AWS requests

### DIFF
--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/TracingRequestHandler.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/TracingRequestHandler.java
@@ -8,8 +8,6 @@ import com.amazonaws.Response;
 import com.amazonaws.handlers.HandlerContextKey;
 import com.amazonaws.handlers.RequestHandler2;
 import io.opentracing.Scope;
-import io.opentracing.propagation.Format;
-import io.opentracing.propagation.TextMapInjectAdapter;
 import io.opentracing.util.GlobalTracer;
 
 /** Tracing Request Handler */
@@ -31,15 +29,6 @@ public class TracingRequestHandler extends RequestHandler2 {
     final Scope scope = GlobalTracer.get().buildSpan("aws.command").startActive(true);
     DECORATE.afterStart(scope.span());
     DECORATE.onRequest(scope.span(), request);
-
-    // We inject headers at aws-client level because aws requests may be signed and adding headers
-    // on http-client level may break signature.
-    GlobalTracer.get()
-        .inject(
-            scope.span().context(),
-            Format.Builtin.HTTP_HEADERS,
-            new TextMapInjectAdapter(request.getHeaders()));
-
     request.addHandlerContext(SCOPE_CONTEXT_KEY, scope);
   }
 

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test/groovy/AWSClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test/groovy/AWSClientTest.groovy
@@ -113,8 +113,8 @@ class AWSClientTest extends AgentTestRunner {
         }
       }
     }
-    server.lastRequest.headers.get("x-datadog-trace-id") == TEST_WRITER[0][0].traceId
-    server.lastRequest.headers.get("x-datadog-parent-id") == TEST_WRITER[0][0].spanId
+    server.lastRequest.headers.get("x-datadog-trace-id") == null
+    server.lastRequest.headers.get("x-datadog-parent-id") == null
 
     where:
     service | operation           | method | url                  | handlerCount | call                                                                                                                                   | body               | client

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test_1_11_106/groovy/AWSClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test_1_11_106/groovy/AWSClientTest.groovy
@@ -142,8 +142,8 @@ class AWSClientTest extends AgentTestRunner {
         }
       }
     }
-    server.lastRequest.headers.get("x-datadog-trace-id") == TEST_WRITER[0][0].traceId
-    server.lastRequest.headers.get("x-datadog-parent-id") == TEST_WRITER[0][0].spanId
+    server.lastRequest.headers.get("x-datadog-trace-id") == null
+    server.lastRequest.headers.get("x-datadog-parent-id") == null
 
     where:
     service | operation           | method | url                  | handlerCount | call                                                                   | body               | client

--- a/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java8/datadog/trace/instrumentation/aws/v2/TracingExecutionInterceptor.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java8/datadog/trace/instrumentation/aws/v2/TracingExecutionInterceptor.java
@@ -5,8 +5,6 @@ import static datadog.trace.instrumentation.aws.v2.AwsSdkClientDecorator.DECORAT
 import datadog.trace.context.TraceScope;
 import io.opentracing.Scope;
 import io.opentracing.Span;
-import io.opentracing.Tracer;
-import io.opentracing.propagation.Format;
 import io.opentracing.propagation.TextMap;
 import io.opentracing.util.GlobalTracer;
 import java.util.Iterator;
@@ -47,16 +45,6 @@ public class TracingExecutionInterceptor implements ExecutionInterceptor {
 
     DECORATE.onRequest(span, httpRequest);
     DECORATE.onAttributes(span, executionAttributes);
-  }
-
-  @Override
-  public SdkHttpRequest modifyHttpRequest(
-      final Context.ModifyHttpRequest context, final ExecutionAttributes executionAttributes) {
-    final Tracer tracer = GlobalTracer.get();
-    final Span span = executionAttributes.getAttribute(SPAN_ATTRIBUTE);
-    final SdkHttpRequest.Builder builder = context.httpRequest().toBuilder();
-    tracer.inject(span.context(), Format.Builtin.HTTP_HEADERS, new InjectAdapter(builder));
-    return builder.build();
   }
 
   @Override

--- a/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/test/groovy/AwsClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/test/groovy/AwsClientTest.groovy
@@ -105,8 +105,8 @@ class AwsClientTest extends AgentTestRunner {
         }
       }
     }
-    server.lastRequest.headers.get("x-datadog-trace-id") == TEST_WRITER[0][0].traceId
-    server.lastRequest.headers.get("x-datadog-parent-id") == TEST_WRITER[0][0].spanId
+    server.lastRequest.headers.get("x-datadog-trace-id") == null
+    server.lastRequest.headers.get("x-datadog-parent-id") == null
 
     where:
     service | operation           | method | path                  | requestId                              | call                                                                                         | body               | builder
@@ -202,8 +202,8 @@ class AwsClientTest extends AgentTestRunner {
         }
       }
     }
-    server.lastRequest.headers.get("x-datadog-trace-id") == TEST_WRITER[0][0].traceId
-    server.lastRequest.headers.get("x-datadog-parent-id") == TEST_WRITER[0][0].spanId
+    server.lastRequest.headers.get("x-datadog-trace-id") == null
+    server.lastRequest.headers.get("x-datadog-parent-id") == null
 
     where:
     service | operation           | method | path                  | requestId                              | call                                                                                                                             | body               | builder


### PR DESCRIPTION
I don’t think these are helping us and we may still risk messing up the signed request if this happens too late.