### PR TITLE
Implement B3 headers extraction and injection

### DIFF
--- a/dd-trace-api/dd-trace-api.gradle
+++ b/dd-trace-api/dd-trace-api.gradle
@@ -1,6 +1,8 @@
 apply from: "${rootDir}/gradle/java.gradle"
 apply from: "${rootDir}/gradle/publish.gradle"
 
+minimumBranchCoverage = 0.8
+
 // These are tested outside of this module since this module mainly just defines 'API'
 excludedClassesConverage += [
   'datadog.trace.api.DDSpanTypes',

--- a/dd-trace-api/src/main/java/datadog/trace/api/Config.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/Config.java
@@ -549,9 +549,7 @@ public class Config {
 
   private static Set<Integer> parseIntegerRangeSet(String str, final String settingName)
       throws NumberFormatException {
-    if (str == null) {
-      str = "";
-    }
+    assert str != null;
     str = str.replaceAll("\\s", "");
     if (!str.matches("\\d{3}(?:-\\d{3})?(?:,\\d{3}(?:-\\d{3})?)*")) {
       log.warn(

--- a/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -24,6 +24,8 @@ import static datadog.trace.api.Config.LANGUAGE_TAG_VALUE
 import static datadog.trace.api.Config.PARTIAL_FLUSH_MIN_SPANS
 import static datadog.trace.api.Config.PREFIX
 import static datadog.trace.api.Config.PRIORITY_SAMPLING
+import static datadog.trace.api.Config.PROPAGATION_STYLE_EXTRACT
+import static datadog.trace.api.Config.PROPAGATION_STYLE_INJECT
 import static datadog.trace.api.Config.RUNTIME_CONTEXT_FIELD_INJECTION
 import static datadog.trace.api.Config.RUNTIME_ID_TAG
 import static datadog.trace.api.Config.SERVICE
@@ -45,6 +47,8 @@ class ConfigTest extends Specification {
   private static final DD_SERVICE_MAPPING_ENV = "DD_SERVICE_MAPPING"
   private static final DD_SPAN_TAGS_ENV = "DD_SPAN_TAGS"
   private static final DD_HEADER_TAGS_ENV = "DD_HEADER_TAGS"
+  private static final DD_PROPAGATION_STYLE_EXTRACT = "DD_PROPAGATION_STYLE_EXTRACT"
+  private static final DD_PROPAGATION_STYLE_INJECT = "DD_PROPAGATION_STYLE_INJECT"
   private static final DD_JMXFETCH_METRICS_CONFIGS_ENV = "DD_JMXFETCH_METRICS_CONFIGS"
   private static final DD_TRACE_AGENT_PORT_ENV = "DD_TRACE_AGENT_PORT"
   private static final DD_AGENT_PORT_LEGACY_ENV = "DD_AGENT_PORT"
@@ -68,6 +72,10 @@ class ConfigTest extends Specification {
     config.httpClientSplitByDomain == false
     config.partialFlushMinSpans == 0
     config.runtimeContextFieldInjection == true
+    config.extractDatadogHeaders == true
+    config.extractB3Headers == true
+    config.injectDatadogHeaders == true
+    config.injectB3Headers == true
     config.jmxFetchEnabled == false
     config.jmxFetchMetricsConfigs == []
     config.jmxFetchCheckPeriod == null
@@ -95,6 +103,8 @@ class ConfigTest extends Specification {
     System.setProperty(PREFIX + HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN, "true")
     System.setProperty(PREFIX + PARTIAL_FLUSH_MIN_SPANS, "15")
     System.setProperty(PREFIX + RUNTIME_CONTEXT_FIELD_INJECTION, "false")
+    System.setProperty(PREFIX + PROPAGATION_STYLE_EXTRACT, "Datadog")
+    System.setProperty(PREFIX + PROPAGATION_STYLE_INJECT, "B3")
     System.setProperty(PREFIX + JMX_FETCH_ENABLED, "true")
     System.setProperty(PREFIX + JMX_FETCH_METRICS_CONFIGS, "/foo.yaml,/bar.yaml")
     System.setProperty(PREFIX + JMX_FETCH_CHECK_PERIOD, "100")
@@ -120,6 +130,10 @@ class ConfigTest extends Specification {
     config.httpClientSplitByDomain == true
     config.partialFlushMinSpans == 15
     config.runtimeContextFieldInjection == false
+    config.extractDatadogHeaders == true
+    config.extractB3Headers == false
+    config.injectDatadogHeaders == false
+    config.injectB3Headers == true
     config.jmxFetchEnabled == true
     config.jmxFetchMetricsConfigs == ["/foo.yaml", "/bar.yaml"]
     config.jmxFetchCheckPeriod == 100
@@ -132,6 +146,8 @@ class ConfigTest extends Specification {
     setup:
     environmentVariables.set(DD_SERVICE_NAME_ENV, "still something else")
     environmentVariables.set(DD_WRITER_TYPE_ENV, "LoggingWriter")
+    environmentVariables.set(DD_PROPAGATION_STYLE_EXTRACT, "B3")
+    environmentVariables.set(DD_PROPAGATION_STYLE_INJECT, "Datadog")
     environmentVariables.set(DD_JMXFETCH_METRICS_CONFIGS_ENV, "some/file")
 
     when:
@@ -140,6 +156,10 @@ class ConfigTest extends Specification {
     then:
     config.serviceName == "still something else"
     config.writerType == "LoggingWriter"
+    config.extractDatadogHeaders == false
+    config.extractB3Headers == true
+    config.injectDatadogHeaders == true
+    config.injectB3Headers == false
     config.jmxFetchMetricsConfigs == ["some/file"]
   }
 
@@ -177,6 +197,8 @@ class ConfigTest extends Specification {
     System.setProperty(PREFIX + HEADER_TAGS, "1")
     System.setProperty(PREFIX + SPAN_TAGS, "invalid")
     System.setProperty(PREFIX + HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN, "invalid")
+    System.setProperty(PREFIX + PROPAGATION_STYLE_EXTRACT, "")
+    System.setProperty(PREFIX + PROPAGATION_STYLE_INJECT, " ")
 
     when:
     def config = new Config()
@@ -192,6 +214,10 @@ class ConfigTest extends Specification {
     config.mergedSpanTags == [:]
     config.headerTags == [:]
     config.httpClientSplitByDomain == false
+    config.extractDatadogHeaders == true
+    config.extractB3Headers == true
+    config.injectDatadogHeaders == true
+    config.injectB3Headers == true
   }
 
   def "sys props and env vars overrides for trace_agent_port and agent_port_legacy as expected"() {
@@ -253,6 +279,8 @@ class ConfigTest extends Specification {
     properties.setProperty(HEADER_TAGS, "e:5")
     properties.setProperty(HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN, "true")
     properties.setProperty(PARTIAL_FLUSH_MIN_SPANS, "15")
+    properties.setProperty(PROPAGATION_STYLE_EXTRACT, "Datadog")
+    properties.setProperty(PROPAGATION_STYLE_INJECT, "B3")
     properties.setProperty(JMX_FETCH_METRICS_CONFIGS, "/foo.yaml,/bar.yaml")
     properties.setProperty(JMX_FETCH_CHECK_PERIOD, "100")
     properties.setProperty(JMX_FETCH_REFRESH_BEANS_PERIOD, "200")
@@ -276,6 +304,10 @@ class ConfigTest extends Specification {
     config.headerTags == [e: "5"]
     config.httpClientSplitByDomain == true
     config.partialFlushMinSpans == 15
+    config.extractDatadogHeaders == true
+    config.extractB3Headers == false
+    config.injectDatadogHeaders == false
+    config.injectB3Headers == true
     config.jmxFetchMetricsConfigs == ["/foo.yaml", "/bar.yaml"]
     config.jmxFetchCheckPeriod == 100
     config.jmxFetchRefreshBeansPeriod == 200

--- a/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
@@ -2,8 +2,8 @@ package datadog.opentracing;
 
 import datadog.opentracing.decorators.AbstractDecorator;
 import datadog.opentracing.decorators.DDDecoratorsFactory;
-import datadog.opentracing.propagation.DatadogHttpCodec;
 import datadog.opentracing.propagation.ExtractedContext;
+import datadog.opentracing.propagation.HttpCodec;
 import datadog.opentracing.propagation.TagContext;
 import datadog.opentracing.scopemanager.ContextualScopeManager;
 import datadog.opentracing.scopemanager.ScopeContext;
@@ -85,8 +85,8 @@ public class DDTracer implements io.opentracing.Tracer, Closeable, datadog.trace
             }
           });
 
-  private final DatadogHttpCodec.Injector injector;
-  private final DatadogHttpCodec.Extractor extractor;
+  private final HttpCodec.Injector injector;
+  private final HttpCodec.Extractor extractor;
 
   /** By default, report to local agent and collect all traces. */
   public DDTracer() {
@@ -232,8 +232,9 @@ public class DDTracer implements io.opentracing.Tracer, Closeable, datadog.trace
       // The JVM is already shutting down.
     }
 
-    injector = new DatadogHttpCodec.Injector();
-    extractor = new DatadogHttpCodec.Extractor(taggedHeaders);
+    // TODO: we have too many constructors, we should move to some sort of builder approach
+    injector = HttpCodec.createInjector(Config.get());
+    extractor = HttpCodec.createExtractor(Config.get(), taggedHeaders);
 
     if (this.writer instanceof DDAgentWriter) {
       final DDApi api = ((DDAgentWriter) this.writer).getApi();

--- a/dd-trace-ot/src/main/java/datadog/opentracing/propagation/B3HttpCodec.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/propagation/B3HttpCodec.java
@@ -1,0 +1,112 @@
+package datadog.opentracing.propagation;
+
+import static datadog.opentracing.propagation.HttpCodec.ZERO;
+import static datadog.opentracing.propagation.HttpCodec.validateUInt64BitsID;
+
+import datadog.opentracing.DDSpanContext;
+import datadog.trace.api.sampling.PrioritySampling;
+import io.opentracing.SpanContext;
+import io.opentracing.propagation.TextMap;
+import java.math.BigInteger;
+import java.util.Collections;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+
+/** A codec designed for HTTP transport via headers using B3 headers */
+@Slf4j
+class B3HttpCodec {
+
+  private static final String TRACE_ID_KEY = "X-B3-TraceId";
+  private static final String SPAN_ID_KEY = "X-B3-SpanId";
+  private static final String SAMPLING_PRIORITY_KEY = "X-B3-Sampled";
+  private static final String SAMPLING_PRIORITY_ACCEPT = String.valueOf(1);
+  private static final String SAMPLING_PRIORITY_DROP = String.valueOf(0);
+  private static final int HEX_RADIX = 16;
+
+  private B3HttpCodec() {
+    // This class should not be created. This also makes code coverage checks happy.
+  }
+
+  public static class Injector implements HttpCodec.Injector {
+
+    @Override
+    public void inject(final DDSpanContext context, final TextMap carrier) {
+
+      try {
+        // TODO: should we better store ids as BigInteger in context to avoid parsing it twice.
+        final BigInteger traceId = new BigInteger(context.getTraceId());
+        final BigInteger spanId = new BigInteger(context.getSpanId());
+
+        carrier.put(TRACE_ID_KEY, traceId.toString(HEX_RADIX).toLowerCase());
+        carrier.put(SPAN_ID_KEY, spanId.toString(HEX_RADIX).toLowerCase());
+
+        if (context.lockSamplingPriority()) {
+          carrier.put(
+              SAMPLING_PRIORITY_KEY, convertSamplingPriority(context.getSamplingPriority()));
+        }
+        log.debug("{} - B3 parent context injected", context.getTraceId());
+      } catch (final NumberFormatException e) {
+        log.debug(
+            "Cannot parse context id(s): {} {}", context.getTraceId(), context.getSpanId(), e);
+      }
+    }
+
+    private String convertSamplingPriority(final int samplingPriority) {
+      return samplingPriority > 0 ? SAMPLING_PRIORITY_ACCEPT : SAMPLING_PRIORITY_DROP;
+    }
+  }
+
+  public static class Extractor implements HttpCodec.Extractor {
+
+    @Override
+    public SpanContext extract(final TextMap carrier) {
+      try {
+        String traceId = ZERO;
+        String spanId = ZERO;
+        int samplingPriority = PrioritySampling.UNSET;
+
+        for (final Map.Entry<String, String> entry : carrier) {
+          final String key = entry.getKey().toLowerCase();
+          final String value = entry.getValue();
+
+          if (value == null) {
+            continue;
+          }
+
+          if (TRACE_ID_KEY.equalsIgnoreCase(key)) {
+            traceId = validateUInt64BitsID(value, HEX_RADIX);
+          } else if (SPAN_ID_KEY.equalsIgnoreCase(key)) {
+            spanId = validateUInt64BitsID(value, HEX_RADIX);
+          } else if (SAMPLING_PRIORITY_KEY.equalsIgnoreCase(key)) {
+            samplingPriority = convertSamplingPriority(value);
+          }
+        }
+
+        if (!ZERO.equals(traceId)) {
+          final ExtractedContext context =
+              new ExtractedContext(
+                  traceId,
+                  spanId,
+                  samplingPriority,
+                  null,
+                  Collections.<String, String>emptyMap(),
+                  Collections.<String, String>emptyMap());
+          context.lockSamplingPriority();
+
+          log.debug("{} - Parent context extracted", context.getTraceId());
+          return context;
+        }
+      } catch (final RuntimeException e) {
+        log.debug("Exception when extracting context", e);
+      }
+
+      return null;
+    }
+
+    private int convertSamplingPriority(final String samplingPriority) {
+      return Integer.parseInt(samplingPriority) == 1
+          ? PrioritySampling.SAMPLER_KEEP
+          : PrioritySampling.SAMPLER_DROP;
+    }
+  }
+}

--- a/dd-trace-ot/src/main/java/datadog/opentracing/propagation/DatadogHttpCodec.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/propagation/DatadogHttpCodec.java
@@ -1,11 +1,13 @@
 package datadog.opentracing.propagation;
 
+import static datadog.opentracing.propagation.HttpCodec.ZERO;
+import static datadog.opentracing.propagation.HttpCodec.validateUInt64BitsID;
+
 import datadog.opentracing.DDSpanContext;
 import datadog.trace.api.sampling.PrioritySampling;
 import io.opentracing.SpanContext;
 import io.opentracing.propagation.TextMap;
 import java.io.UnsupportedEncodingException;
-import java.math.BigInteger;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.util.Collections;
@@ -13,13 +15,9 @@ import java.util.HashMap;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 
-/** A codec designed for HTTP transport via headers */
+/** A codec designed for HTTP transport via headers using Datadog headers */
 @Slf4j
-public class DatadogHttpCodec {
-
-  // uint 64 bits max value, 2^64 - 1
-  static final BigInteger BIG_INTEGER_UINT64_MAX =
-      new BigInteger("2").pow(64).subtract(BigInteger.ONE);
+class DatadogHttpCodec {
 
   private static final String OT_BAGGAGE_PREFIX = "ot-baggage-";
   private static final String TRACE_ID_KEY = "x-datadog-trace-id";
@@ -27,11 +25,16 @@ public class DatadogHttpCodec {
   private static final String SAMPLING_PRIORITY_KEY = "x-datadog-sampling-priority";
   private static final String ORIGIN_KEY = "x-datadog-origin";
 
-  public static class Injector {
+  private DatadogHttpCodec() {
+    // This class should not be created. This also makes code coverage checks happy.
+  }
 
+  public static class Injector implements HttpCodec.Injector {
+
+    @Override
     public void inject(final DDSpanContext context, final TextMap carrier) {
-      carrier.put(TRACE_ID_KEY, String.valueOf(context.getTraceId()));
-      carrier.put(SPAN_ID_KEY, String.valueOf(context.getSpanId()));
+      carrier.put(TRACE_ID_KEY, context.getTraceId());
+      carrier.put(SPAN_ID_KEY, context.getSpanId());
       if (context.lockSamplingPriority()) {
         carrier.put(SAMPLING_PRIORITY_KEY, String.valueOf(context.getSamplingPriority()));
       }
@@ -43,7 +46,7 @@ public class DatadogHttpCodec {
       for (final Map.Entry<String, String> entry : context.baggageItems()) {
         carrier.put(OT_BAGGAGE_PREFIX + entry.getKey(), encode(entry.getValue()));
       }
-      log.debug("{} - Parent context injected", context.getTraceId());
+      log.debug("{} - Datadog parent context injected", context.getTraceId());
     }
 
     private String encode(final String value) {
@@ -57,7 +60,7 @@ public class DatadogHttpCodec {
     }
   }
 
-  public static class Extractor {
+  public static class Extractor implements HttpCodec.Extractor {
     private final Map<String, String> taggedHeaders;
 
     public Extractor(final Map<String, String> taggedHeaders) {
@@ -67,59 +70,63 @@ public class DatadogHttpCodec {
       }
     }
 
+    @Override
     public SpanContext extract(final TextMap carrier) {
+      try {
+        Map<String, String> baggage = Collections.emptyMap();
+        Map<String, String> tags = Collections.emptyMap();
+        String traceId = ZERO;
+        String spanId = ZERO;
+        int samplingPriority = PrioritySampling.UNSET;
+        String origin = null;
 
-      Map<String, String> baggage = Collections.emptyMap();
-      Map<String, String> tags = Collections.emptyMap();
-      String traceId = "0";
-      String spanId = "0";
-      int samplingPriority = PrioritySampling.UNSET;
-      String origin = null;
+        for (final Map.Entry<String, String> entry : carrier) {
+          final String key = entry.getKey().toLowerCase();
+          final String value = entry.getValue();
 
-      for (final Map.Entry<String, String> entry : carrier) {
-        final String key = entry.getKey().toLowerCase();
-        final String val = entry.getValue();
-
-        if (val == null) {
-          continue;
-        }
-
-        if (TRACE_ID_KEY.equalsIgnoreCase(key)) {
-          traceId = validateUInt64BitsID(val);
-        } else if (SPAN_ID_KEY.equalsIgnoreCase(key)) {
-          spanId = validateUInt64BitsID(val);
-        } else if (SAMPLING_PRIORITY_KEY.equalsIgnoreCase(key)) {
-          samplingPriority = Integer.parseInt(val);
-        } else if (ORIGIN_KEY.equalsIgnoreCase(key)) {
-          origin = val;
-        } else if (key.startsWith(OT_BAGGAGE_PREFIX)) {
-          if (baggage.isEmpty()) {
-            baggage = new HashMap<>();
+          if (value == null) {
+            continue;
           }
-          baggage.put(key.replace(OT_BAGGAGE_PREFIX, ""), decode(val));
+
+          if (TRACE_ID_KEY.equalsIgnoreCase(key)) {
+            traceId = validateUInt64BitsID(value, 10);
+          } else if (SPAN_ID_KEY.equalsIgnoreCase(key)) {
+            spanId = validateUInt64BitsID(value, 10);
+          } else if (SAMPLING_PRIORITY_KEY.equalsIgnoreCase(key)) {
+            samplingPriority = Integer.parseInt(value);
+          } else if (ORIGIN_KEY.equalsIgnoreCase(key)) {
+            origin = value;
+          } else if (key.startsWith(OT_BAGGAGE_PREFIX)) {
+            if (baggage.isEmpty()) {
+              baggage = new HashMap<>();
+            }
+            baggage.put(key.replace(OT_BAGGAGE_PREFIX, ""), decode(value));
+          }
+
+          if (taggedHeaders.containsKey(key)) {
+            if (tags.isEmpty()) {
+              tags = new HashMap<>();
+            }
+            tags.put(taggedHeaders.get(key), decode(value));
+          }
         }
 
-        if (taggedHeaders.containsKey(key)) {
-          if (tags.isEmpty()) {
-            tags = new HashMap<>();
-          }
-          tags.put(taggedHeaders.get(key), decode(val));
+        if (!ZERO.equals(traceId)) {
+          final ExtractedContext context =
+              new ExtractedContext(traceId, spanId, samplingPriority, origin, baggage, tags);
+          context.lockSamplingPriority();
+
+          log.debug("{} - Parent context extracted", context.getTraceId());
+          return context;
+        } else if (origin != null || !tags.isEmpty()) {
+          log.debug("Tags context extracted");
+          return new TagContext(origin, tags);
         }
+      } catch (final RuntimeException e) {
+        log.debug("Exception when extracting context", e);
       }
 
-      SpanContext context = null;
-      if (!"0".equals(traceId)) {
-        final ExtractedContext ctx =
-            new ExtractedContext(traceId, spanId, samplingPriority, origin, baggage, tags);
-        ctx.lockSamplingPriority();
-
-        log.debug("{} - Parent context extracted", ctx.getTraceId());
-        context = ctx;
-      } else if (origin != null || !tags.isEmpty()) {
-        context = new TagContext(origin, tags);
-      }
-
-      return context;
+      return null;
     }
 
     private String decode(final String value) {
@@ -130,29 +137,6 @@ public class DatadogHttpCodec {
         log.info("Failed to decode value - {}", value);
       }
       return decoded;
-    }
-
-    /**
-     * Helper method to validate an ID String to verify that it is an unsigned 64 bits number and is
-     * within range.
-     *
-     * @param val the String that contains the ID
-     * @return the ID in String format if it passes validations
-     * @throws IllegalArgumentException if val is not a number or if the number is out of range
-     */
-    private String validateUInt64BitsID(final String val) throws IllegalArgumentException {
-      try {
-        final BigInteger validate = new BigInteger(val);
-        if (validate.compareTo(BigInteger.ZERO) == -1
-            || validate.compareTo(BIG_INTEGER_UINT64_MAX) == 1) {
-          throw new IllegalArgumentException(
-              "ID out of range, must be between 0 and 2^64-1, got: " + val);
-        }
-        return val;
-      } catch (final NumberFormatException nfe) {
-        throw new IllegalArgumentException(
-            "Expecting a number for trace ID or span ID, but got: " + val, nfe);
-      }
     }
   }
 }

--- a/dd-trace-ot/src/main/java/datadog/opentracing/propagation/DatadogHttpCodec.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/propagation/DatadogHttpCodec.java
@@ -7,9 +7,6 @@ import datadog.opentracing.DDSpanContext;
 import datadog.trace.api.sampling.PrioritySampling;
 import io.opentracing.SpanContext;
 import io.opentracing.propagation.TextMap;
-import java.io.UnsupportedEncodingException;
-import java.net.URLDecoder;
-import java.net.URLEncoder;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -44,19 +41,9 @@ class DatadogHttpCodec {
       }
 
       for (final Map.Entry<String, String> entry : context.baggageItems()) {
-        carrier.put(OT_BAGGAGE_PREFIX + entry.getKey(), encode(entry.getValue()));
+        carrier.put(OT_BAGGAGE_PREFIX + entry.getKey(), HttpCodec.encode(entry.getValue()));
       }
       log.debug("{} - Datadog parent context injected", context.getTraceId());
-    }
-
-    private String encode(final String value) {
-      String encoded = value;
-      try {
-        encoded = URLEncoder.encode(value, "UTF-8");
-      } catch (final UnsupportedEncodingException e) {
-        log.info("Failed to encode value - {}", value);
-      }
-      return encoded;
     }
   }
 
@@ -100,14 +87,14 @@ class DatadogHttpCodec {
             if (baggage.isEmpty()) {
               baggage = new HashMap<>();
             }
-            baggage.put(key.replace(OT_BAGGAGE_PREFIX, ""), decode(value));
+            baggage.put(key.replace(OT_BAGGAGE_PREFIX, ""), HttpCodec.decode(value));
           }
 
           if (taggedHeaders.containsKey(key)) {
             if (tags.isEmpty()) {
               tags = new HashMap<>();
             }
-            tags.put(taggedHeaders.get(key), decode(value));
+            tags.put(taggedHeaders.get(key), HttpCodec.decode(value));
           }
         }
 
@@ -127,16 +114,6 @@ class DatadogHttpCodec {
       }
 
       return null;
-    }
-
-    private String decode(final String value) {
-      String decoded = value;
-      try {
-        decoded = URLDecoder.decode(value, "UTF-8");
-      } catch (final UnsupportedEncodingException e) {
-        log.info("Failed to decode value - {}", value);
-      }
-      return decoded;
     }
   }
 }

--- a/dd-trace-ot/src/main/java/datadog/opentracing/propagation/HttpCodec.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/propagation/HttpCodec.java
@@ -1,0 +1,109 @@
+package datadog.opentracing.propagation;
+
+import datadog.opentracing.DDSpanContext;
+import datadog.trace.api.Config;
+import io.opentracing.SpanContext;
+import io.opentracing.propagation.TextMap;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class HttpCodec {
+
+  // uint 64 bits max value, 2^64 - 1
+  static final BigInteger UINT64_MAX = new BigInteger("2").pow(64).subtract(BigInteger.ONE);
+  static final String ZERO = "0";
+
+  public interface Injector {
+
+    void inject(final DDSpanContext context, final TextMap carrier);
+  }
+
+  public interface Extractor {
+
+    SpanContext extract(final TextMap carrier);
+  }
+
+  public static Injector createInjector(final Config config) {
+    final List<Injector> injectors = new ArrayList<>();
+    if (config.isInjectDatadogHeaders()) {
+      injectors.add(new DatadogHttpCodec.Injector());
+    }
+    if (config.isInjectB3Headers()) {
+      injectors.add(new B3HttpCodec.Injector());
+    }
+    return new CompoundInjector(injectors);
+  }
+
+  public static Extractor createExtractor(
+      final Config config, final Map<String, String> taggedHeaders) {
+    final List<Extractor> extractors = new ArrayList<>();
+    if (config.isExtractDatadogHeaders()) {
+      extractors.add(new DatadogHttpCodec.Extractor(taggedHeaders));
+    }
+    if (config.isExtractB3Headers()) {
+      extractors.add(new B3HttpCodec.Extractor());
+    }
+    return new CompoundExtractor(extractors);
+  }
+
+  public static class CompoundInjector implements Injector {
+
+    private final List<Injector> injectors;
+
+    public CompoundInjector(final List<Injector> injectors) {
+      this.injectors = injectors;
+    }
+
+    @Override
+    public void inject(final DDSpanContext context, final TextMap carrier) {
+      for (final Injector injector : injectors) {
+        injector.inject(context, carrier);
+      }
+    }
+  }
+
+  public static class CompoundExtractor implements Extractor {
+
+    private final List<Extractor> extractors;
+
+    public CompoundExtractor(final List<Extractor> extractors) {
+      this.extractors = extractors;
+    }
+
+    @Override
+    public SpanContext extract(final TextMap carrier) {
+      for (final Extractor extractor : extractors) {
+        final SpanContext context = extractor.extract(carrier);
+        if (context != null) {
+          return context;
+        }
+      }
+      return null;
+    }
+  }
+
+  /**
+   * Helper method to validate an ID String to verify that it is an unsigned 64 bits number and is
+   * within range.
+   *
+   * @param value the String that contains the ID
+   * @param radix radix to use to parse the ID
+   * @return the ID in String format if it passes validations, "0" otherwise
+   * @throws IllegalArgumentException if value cannot be converted to integer or doesn't conform to
+   *     required boundaries
+   */
+  static String validateUInt64BitsID(final String value, final int radix)
+      throws IllegalArgumentException {
+    final BigInteger parsedValue = new BigInteger(value, radix);
+    if (parsedValue.compareTo(BigInteger.ZERO) == -1 || parsedValue.compareTo(UINT64_MAX) == 1) {
+      throw new IllegalArgumentException(
+          "ID out of range, must be between 0 and 2^64-1, got: " + value);
+    }
+    // We use decimals
+    return parsedValue.toString();
+  }
+}

--- a/dd-trace-ot/src/main/java/datadog/opentracing/propagation/HttpCodec.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/propagation/HttpCodec.java
@@ -29,11 +29,16 @@ public class HttpCodec {
 
   public static Injector createInjector(final Config config) {
     final List<Injector> injectors = new ArrayList<>();
-    if (config.isInjectDatadogHeaders()) {
-      injectors.add(new DatadogHttpCodec.Injector());
-    }
-    if (config.isInjectB3Headers()) {
-      injectors.add(new B3HttpCodec.Injector());
+    for (final Config.PropagationStyle style : config.getPropagationStylesToInject()) {
+      if (style == Config.PropagationStyle.DATADOG) {
+        injectors.add(new DatadogHttpCodec.Injector());
+        continue;
+      }
+      if (style == Config.PropagationStyle.B3) {
+        injectors.add(new B3HttpCodec.Injector());
+        continue;
+      }
+      log.debug("No implementation found to inject propagation style: {}", style);
     }
     return new CompoundInjector(injectors);
   }
@@ -41,11 +46,16 @@ public class HttpCodec {
   public static Extractor createExtractor(
       final Config config, final Map<String, String> taggedHeaders) {
     final List<Extractor> extractors = new ArrayList<>();
-    if (config.isExtractDatadogHeaders()) {
-      extractors.add(new DatadogHttpCodec.Extractor(taggedHeaders));
-    }
-    if (config.isExtractB3Headers()) {
-      extractors.add(new B3HttpCodec.Extractor());
+    for (final Config.PropagationStyle style : config.getPropagationStylesToExtract()) {
+      if (style == Config.PropagationStyle.DATADOG) {
+        extractors.add(new DatadogHttpCodec.Extractor(taggedHeaders));
+        continue;
+      }
+      if (style == Config.PropagationStyle.B3) {
+        extractors.add(new B3HttpCodec.Extractor());
+        continue;
+      }
+      log.debug("No implementation found to extract propagation style: {}", style);
     }
     return new CompoundExtractor(extractors);
   }

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/propagation/B3HttpExtractorTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/propagation/B3HttpExtractorTest.groovy
@@ -65,20 +65,20 @@ class B3HttpExtractorTest extends Specification {
     }
 
     where:
-    traceId                            | spanId                   | expectedTraceId       | expectedSpanId
-    "-1"                               | "1"                      | null                  | "0"
-    "1"                                | "-1"                     | null                  | "0"
-    "0"                                | "1"                      | null                  | "0"
-    "00001"                            | "00001"                  | "1"                   | "1"
-    "463ac35c9f6413ad"                 | "463ac35c9f6413ad"       | "5060571933882717101" | "5060571933882717101"
-    "463ac35c9f6413ad48485a3953bb6124" | "1"                      | "5208512171318403364" | "1"
-    "f".multiply(16)                   | "1"                      | "$UINT64_MAX"         | "1"
-    "f".multiply(32)                   | "1"                      | "$UINT64_MAX"         | "1"
-    "1" + "f".multiply(32)             | "1"                      | null                  | "1"
-    "0" + "f".multiply(32)             | "1"                      | null                  | "1"
-    "1"                                | "f".multiply(16)         | "1"                   | "$UINT64_MAX"
-    "1"                                | "1" + "f".multiply(16)   | null                  | "0"
-    "1"                                | "000" + "f".multiply(16) | "1"                   | "$UINT64_MAX"
+    traceId                             | spanId                   | expectedTraceId       | expectedSpanId
+    "-1"                                | "1"                      | null                  | "0"
+    "1"                                 | "-1"                     | null                  | "0"
+    "0"                                 | "1"                      | null                  | "0"
+    "00001"                             | "00001"                  | "1"                   | "1"
+    "463ac35c9f6413ad"                  | "463ac35c9f6413ad"       | "5060571933882717101" | "5060571933882717101"
+    "463ac35c9f6413ad48485a3953bb6124"  | "1"                      | "5208512171318403364" | "1"
+    "f".multiply(16)                    | "1"                      | "$UINT64_MAX"         | "1"
+    "a".multiply(16) + "f".multiply(16) | "1"                      | "$UINT64_MAX"         | "1"
+    "1" + "f".multiply(32)              | "1"                      | null                  | "1"
+    "0" + "f".multiply(32)              | "1"                      | null                  | "1"
+    "1"                                 | "f".multiply(16)         | "1"                   | "$UINT64_MAX"
+    "1"                                 | "1" + "f".multiply(16)   | null                  | "0"
+    "1"                                 | "000" + "f".multiply(16) | "1"                   | "$UINT64_MAX"
   }
 
   def "extract header tags with no propagation"() {

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/propagation/B3HttpExtractorTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/propagation/B3HttpExtractorTest.groovy
@@ -1,0 +1,99 @@
+package datadog.opentracing.propagation
+
+import datadog.trace.api.sampling.PrioritySampling
+import io.opentracing.SpanContext
+import io.opentracing.propagation.TextMapExtractAdapter
+import spock.lang.Specification
+
+import static datadog.opentracing.propagation.B3HttpCodec.SAMPLING_PRIORITY_KEY
+import static datadog.opentracing.propagation.B3HttpCodec.SPAN_ID_KEY
+import static datadog.opentracing.propagation.B3HttpCodec.TRACE_ID_KEY
+import static datadog.opentracing.propagation.HttpCodec.UINT64_MAX
+
+class B3HttpExtractorTest extends Specification {
+
+  HttpCodec.Extractor extractor = new B3HttpCodec.Extractor()
+
+  def "extract http headers"() {
+    setup:
+    final Map<String, String> actual = [
+      (TRACE_ID_KEY.toUpperCase()): traceId.toString(16).toLowerCase(),
+      (SPAN_ID_KEY.toUpperCase()) : spanId.toString(16).toLowerCase(),
+    ]
+
+    if (samplingPriority != null) {
+      actual.put(SAMPLING_PRIORITY_KEY, "$samplingPriority".toString())
+    }
+
+    when:
+    final ExtractedContext context = extractor.extract(new TextMapExtractAdapter(actual))
+
+    then:
+    context.traceId == traceId.toString()
+    context.spanId == spanId.toString()
+    context.baggage == [:]
+    context.tags == [:]
+    context.samplingPriority == expectedSamplingPriority
+    context.origin == null
+
+    where:
+    traceId             | spanId              | samplingPriority | expectedSamplingPriority
+    1G                  | 2G                  | null             | PrioritySampling.UNSET
+    2G                  | 3G                  | 1                | PrioritySampling.SAMPLER_KEEP
+    3G                  | 4G                  | 0                | PrioritySampling.SAMPLER_DROP
+    UINT64_MAX          | UINT64_MAX.minus(1) | 0                | PrioritySampling.SAMPLER_DROP
+    UINT64_MAX.minus(1) | UINT64_MAX          | 1                | PrioritySampling.SAMPLER_KEEP
+  }
+
+  def "extract empty headers returns null"() {
+    expect:
+    extractor.extract(new TextMapExtractAdapter(["ignored-header": "ignored-value"])) == null
+  }
+
+  def "extract http headers with invalid non-numeric ID"() {
+    setup:
+    final Map<String, String> actual = [
+      (TRACE_ID_KEY.toUpperCase()): "traceId",
+      (SPAN_ID_KEY.toUpperCase()) : "spanId",
+      SOME_HEADER                 : "my-interesting-info",
+    ]
+
+    when:
+    SpanContext context = extractor.extract(new TextMapExtractAdapter(actual))
+
+    then:
+    context == null
+  }
+
+  def "extract http headers with out of range trace ID"() {
+    setup:
+    String outOfRangeTraceId = UINT64_MAX.add(BigInteger.ONE).toString()
+    final Map<String, String> actual = [
+      (TRACE_ID_KEY.toUpperCase()): outOfRangeTraceId,
+      (SPAN_ID_KEY.toUpperCase()) : "0",
+      SOME_HEADER                 : "my-interesting-info",
+    ]
+
+    when:
+    SpanContext context = extractor.extract(new TextMapExtractAdapter(actual))
+
+    then:
+    context == null
+  }
+
+  def "extract http headers with out of range span ID"() {
+    setup:
+    final Map<String, String> actual = [
+      (TRACE_ID_KEY.toUpperCase()): "0",
+      (SPAN_ID_KEY.toUpperCase()) : "-1",
+      SOME_HEADER                 : "my-interesting-info",
+    ]
+
+
+    when:
+    SpanContext context = extractor.extract(new TextMapExtractAdapter(actual))
+
+    then:
+    context == null
+  }
+}

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/propagation/B3HttpInjectorTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/propagation/B3HttpInjectorTest.groovy
@@ -1,0 +1,109 @@
+package datadog.opentracing.propagation
+
+import datadog.opentracing.DDSpanContext
+import datadog.opentracing.DDTracer
+import datadog.opentracing.PendingTrace
+import datadog.trace.api.sampling.PrioritySampling
+import datadog.trace.common.writer.ListWriter
+import io.opentracing.propagation.TextMapInjectAdapter
+import spock.lang.Specification
+
+import static datadog.opentracing.propagation.B3HttpCodec.SAMPLING_PRIORITY_KEY
+import static datadog.opentracing.propagation.B3HttpCodec.SPAN_ID_KEY
+import static datadog.opentracing.propagation.B3HttpCodec.TRACE_ID_KEY
+import static datadog.opentracing.propagation.HttpCodec.UINT64_MAX
+
+class B3HttpInjectorTest extends Specification {
+
+  HttpCodec.Injector injector = new B3HttpCodec.Injector()
+
+  def "inject http headers"() {
+    setup:
+    def writer = new ListWriter()
+    def tracer = new DDTracer(writer)
+    final DDSpanContext mockedContext =
+      new DDSpanContext(
+        traceId,
+        spanId,
+        "0",
+        "fakeService",
+        "fakeOperation",
+        "fakeResource",
+        samplingPriority,
+        "fakeOrigin",
+        new HashMap<String, String>() {
+          {
+            put("k1", "v1")
+            put("k2", "v2")
+          }
+        },
+        false,
+        "fakeType",
+        null,
+        new PendingTrace(tracer, "1", [:]),
+        tracer)
+
+    final Map<String, String> carrier = Mock()
+
+    when:
+    injector.inject(mockedContext, new TextMapInjectAdapter(carrier))
+
+    then:
+    1 * carrier.put(TRACE_ID_KEY, new BigInteger(traceId).toString(16).toLowerCase())
+    1 * carrier.put(SPAN_ID_KEY, new BigInteger(spanId).toString(16).toLowerCase())
+    if (expectedSamplingPriority != null) {
+      1 * carrier.put(SAMPLING_PRIORITY_KEY, "$expectedSamplingPriority")
+    }
+    0 * _
+
+    where:
+    traceId                        | spanId                         | samplingPriority              | expectedSamplingPriority
+    "1"                            | "2"                            | PrioritySampling.UNSET        | null
+    "2"                            | "3"                            | PrioritySampling.SAMPLER_KEEP | 1
+    "4"                            | "5"                            | PrioritySampling.SAMPLER_DROP | 0
+    "5"                            | "6"                            | PrioritySampling.USER_KEEP    | 1
+    "6"                            | "7"                            | PrioritySampling.USER_DROP    | 0
+    UINT64_MAX.toString()          | UINT64_MAX.minus(1).toString() | PrioritySampling.UNSET        | null
+    UINT64_MAX.minus(1).toString() | UINT64_MAX.toString()          | PrioritySampling.SAMPLER_KEEP | 1
+  }
+
+  def "unparseable ids"() {
+    setup:
+    def writer = new ListWriter()
+    def tracer = new DDTracer(writer)
+    final DDSpanContext mockedContext =
+      new DDSpanContext(
+        traceId,
+        spanId,
+        "0",
+        "fakeService",
+        "fakeOperation",
+        "fakeResource",
+        samplingPriority,
+        "fakeOrigin",
+        new HashMap<String, String>() {
+          {
+            put("k1", "v1")
+            put("k2", "v2")
+          }
+        },
+        false,
+        "fakeType",
+        null,
+        new PendingTrace(tracer, "1", [:]),
+        tracer)
+
+    final Map<String, String> carrier = Mock()
+
+    when:
+    injector.inject(mockedContext, new TextMapInjectAdapter(carrier))
+
+    then:
+    0 * _
+
+    where:
+    traceId | spanId | samplingPriority
+    "abc"   | "1"    | PrioritySampling.UNSET
+    "1"     | "cbd"  | PrioritySampling.SAMPLER_KEEP
+  }
+}

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/propagation/HttpExtractorTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/propagation/HttpExtractorTest.groovy
@@ -1,0 +1,80 @@
+package datadog.opentracing.propagation
+
+import datadog.trace.api.Config
+import io.opentracing.SpanContext
+import io.opentracing.propagation.TextMapExtractAdapter
+import spock.lang.Shared
+import spock.lang.Specification
+
+import static datadog.opentracing.propagation.HttpCodec.UINT64_MAX
+
+class HttpExtractorTest extends Specification {
+
+  @Shared
+  String outOfRangeTraceId = UINT64_MAX.add(BigInteger.ONE)
+
+  def "extract http headers"() {
+    setup:
+    Config config = Mock(Config) {
+      isExtractDatadogHeaders() >> datadogEnabled
+      isExtractB3Headers() >> b3Enabled
+    }
+    HttpCodec.Extractor extractor = HttpCodec.createExtractor(config, ["SOME_HEADER": "some-tag"])
+
+    final Map<String, String> actual = [:]
+    if (datadogTraceId != null) {
+      actual.put(DatadogHttpCodec.TRACE_ID_KEY.toUpperCase(), datadogTraceId)
+    }
+    if (datadogSpanId != null) {
+      actual.put(DatadogHttpCodec.SPAN_ID_KEY.toUpperCase(), datadogSpanId)
+    }
+    if (b3TraceId != null) {
+      actual.put(B3HttpCodec.TRACE_ID_KEY.toUpperCase(), b3TraceId)
+    }
+    if (b3SpanId != null) {
+      actual.put(B3HttpCodec.SPAN_ID_KEY.toUpperCase(), b3SpanId)
+    }
+
+    if (putDatadogFields) {
+      actual.put("SOME_HEADER", "my-interesting-info")
+    }
+
+    when:
+    final SpanContext context = extractor.extract(new TextMapExtractAdapter(actual))
+
+    then:
+    if (tagContext) {
+      assert context instanceof TagContext
+    } else {
+      if (expectedTraceId == null) {
+        assert context == null
+      } else {
+        assert context.traceId == expectedTraceId
+        assert context.spanId == expectedSpanId
+      }
+    }
+
+    if (expectDatadogFields) {
+      assert context.tags == ["some-tag": "my-interesting-info"]
+    }
+
+    where:
+    datadogEnabled | b3Enabled | datadogTraceId               | datadogSpanId                | b3TraceId                    | b3SpanId                     | expectedTraceId | expectedSpanId | putDatadogFields | expectDatadogFields | tagContext
+    true           | true      | "1"                          | "2"                          | "a"                          | "b"                          | "1"             | "2"            | true             | true                | false
+    true           | true      | null                         | null                         | "a"                          | "b"                          | "a"             | "b"            | false            | false               | true
+    true           | true      | null                         | null                         | "a"                          | "b"                          | null            | null           | true             | true                | true
+    true           | false     | "1"                          | "2"                          | "a"                          | "b"                          | "1"             | "2"            | true             | true                | false
+    false          | true      | "1"                          | "2"                          | "a"                          | "b"                          | "10"            | "11"           | false            | false               | false
+    false          | false     | "1"                          | "2"                          | "a"                          | "b"                          | null            | null           | false            | false               | false
+    true           | true      | "abc"                        | "2"                          | "a"                          | "b"                          | "10"            | "11"           | false            | false               | false
+    true           | false     | "abc"                        | "2"                          | "a"                          | "b"                          | null            | null           | false            | false               | false
+
+    true           | true      | outOfRangeTraceId.toString() | "2"                          | "a"                          | "b"                          | "10"            | "11"           | false            | false               | false
+    true           | true      | "1"                          | outOfRangeTraceId.toString() | "a"                          | "b"                          | "10"            | "11"           | false            | false               | false
+    true           | false     | outOfRangeTraceId.toString() | "2"                          | "a"                          | "b"                          | null            | null           | false            | false               | false
+    true           | false     | "1"                          | outOfRangeTraceId.toString() | "a"                          | "b"                          | null            | null           | false            | false               | false
+    true           | true      | "1"                          | "2"                          | outOfRangeTraceId.toString() | "b"                          | "1"             | "2"            | true             | false               | false
+    true           | true      | "1"                          | "2"                          | "a"                          | outOfRangeTraceId.toString() | "1"             | "2"            | true             | false               | false
+  }
+
+}

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/propagation/HttpInjectorTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/propagation/HttpInjectorTest.groovy
@@ -1,0 +1,85 @@
+package datadog.opentracing.propagation
+
+import datadog.opentracing.DDSpanContext
+import datadog.opentracing.DDTracer
+import datadog.opentracing.PendingTrace
+import datadog.trace.api.Config
+import datadog.trace.api.sampling.PrioritySampling
+import datadog.trace.common.writer.ListWriter
+import io.opentracing.propagation.TextMapInjectAdapter
+import spock.lang.Specification
+
+class HttpInjectorTest extends Specification {
+
+  def "inject http headers"() {
+    setup:
+    Config config = Mock(Config) {
+      isInjectDatadogHeaders() >> datadogEnabled
+      isInjectB3Headers() >> b3Enabled
+    }
+    HttpCodec.Injector injector = HttpCodec.createInjector(config)
+
+    def traceId = "1"
+    def spanId = "2"
+
+    def writer = new ListWriter()
+    def tracer = new DDTracer(writer)
+    final DDSpanContext mockedContext =
+      new DDSpanContext(
+        traceId,
+        spanId,
+        "0",
+        "fakeService",
+        "fakeOperation",
+        "fakeResource",
+        samplingPriority,
+        origin,
+        new HashMap<String, String>() {
+          {
+            put("k1", "v1")
+            put("k2", "v2")
+          }
+        },
+        false,
+        "fakeType",
+        null,
+        new PendingTrace(tracer, "1", [:]),
+        tracer)
+
+    final Map<String, String> carrier = Mock()
+
+    when:
+    injector.inject(mockedContext, new TextMapInjectAdapter(carrier))
+
+    then:
+    if (datadogEnabled) {
+      1 * carrier.put(DatadogHttpCodec.TRACE_ID_KEY, traceId)
+      1 * carrier.put(DatadogHttpCodec.SPAN_ID_KEY, spanId)
+      1 * carrier.put(DatadogHttpCodec.OT_BAGGAGE_PREFIX + "k1", "v1")
+      1 * carrier.put(DatadogHttpCodec.OT_BAGGAGE_PREFIX + "k2", "v2")
+      if (samplingPriority != PrioritySampling.UNSET) {
+        1 * carrier.put(DatadogHttpCodec.SAMPLING_PRIORITY_KEY, "$samplingPriority")
+      }
+      if (origin) {
+        1 * carrier.put(DatadogHttpCodec.ORIGIN_KEY, origin)
+      }
+    }
+    if (b3Enabled) {
+      1 * carrier.put(B3HttpCodec.TRACE_ID_KEY, traceId)
+      1 * carrier.put(B3HttpCodec.SPAN_ID_KEY, spanId)
+      if (samplingPriority != PrioritySampling.UNSET) {
+        1 * carrier.put(B3HttpCodec.SAMPLING_PRIORITY_KEY, "1")
+      }
+    }
+    0 * _
+
+    where:
+    datadogEnabled | b3Enabled | samplingPriority              | origin
+    true           | true      | PrioritySampling.UNSET        | null
+    true           | true      | PrioritySampling.SAMPLER_KEEP | "saipan"
+    true           | false     | PrioritySampling.UNSET        | null
+    true           | false     | PrioritySampling.SAMPLER_KEEP | "saipan"
+    false          | true      | PrioritySampling.UNSET        | null
+    false          | true      | PrioritySampling.SAMPLER_KEEP | "saipan"
+  }
+}

--- a/dd-trace-ot/src/test/groovy/datadog/trace/DDTracerTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/trace/DDTracerTest.groovy
@@ -1,6 +1,7 @@
 package datadog.trace
 
 import datadog.opentracing.DDTracer
+import datadog.opentracing.propagation.HttpCodec
 import datadog.trace.api.Config
 import datadog.trace.common.sampling.AllSampler
 import datadog.trace.common.sampling.RateByServiceSampler
@@ -46,6 +47,9 @@ class DDTracerTest extends Specification {
     tracer.writer.toString() == "DDAgentWriter { api=DDApi { tracesUrl=http://localhost:8126/v0.3/traces } }"
 
     tracer.spanContextDecorators.size() == 13
+
+    tracer.injector instanceof HttpCodec.CompoundInjector
+    tracer.extractor instanceof HttpCodec.CompoundExtractor
   }
 
 
@@ -78,7 +82,8 @@ class DDTracerTest extends Specification {
     when:
     def config = new Config()
     def tracer = new DDTracer(config)
-    def taggedHeaders = tracer.extractor.taggedHeaders
+    // Datadog extractor gets placed first
+    def taggedHeaders = tracer.extractor.extractors[0].taggedHeaders
 
     then:
     tracer.defaultSpanTags == map


### PR DESCRIPTION
Support extracting and injecting B3 headers.

By default  only Datadog headers are used. Configuration is done with `dd.propagation.style.extract` and `dd.propagation.style.inject` system properties for extraction and injection respectively. These system properties contain comma (or space) separated lists of propagation style to enable. For Datadog it is 'Datadog' for B3 the value is 'B3'. So to enable both styles one sets these properties to `Datadog B3'.

For extraction the order in which styles are specified is used when extracting and first headers successfully extracted are used.
