### PR TITLE
Support unix domain sockets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,7 @@ jobs:
   test_ibm8:
     <<: *default_test_job
     environment:
-      - TEST_TASK: testJavaIBM8
+    - TEST_TASK: testJavaIBM8
 
   test_9:
     <<: *default_test_job
@@ -246,7 +246,7 @@ workflows:
             only: /.*/
     - test_ibm8:
         requires:
-          - build
+        - build
         filters:
           tags:
             only: /.*/

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/PatchLogger.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/PatchLogger.java
@@ -13,11 +13,11 @@ import java.util.logging.LogRecord;
 public class PatchLogger {
   private static final PatchLogger SAFE_LOGGER = new PatchLogger("datadogSafeLogger", "bundle");
 
-  public static PatchLogger getLogger(String name) {
+  public static PatchLogger getLogger(final String name) {
     return SAFE_LOGGER;
   }
 
-  public static PatchLogger getLogger(String name, String resourceBundleName) {
+  public static PatchLogger getLogger(final String name, final String resourceBundleName) {
     return SAFE_LOGGER;
   }
 
@@ -25,95 +25,117 @@ public class PatchLogger {
     return SAFE_LOGGER;
   }
 
-  public static PatchLogger getAnonymousLogger(String resourceBundleName) {
+  public static PatchLogger getAnonymousLogger(final String resourceBundleName) {
     return SAFE_LOGGER;
   }
 
-  protected PatchLogger(String name, String resourceBundleName) {
+  protected PatchLogger(final String name, final String resourceBundleName) {
     // super(name, resourceBundleName);
   }
 
   // providing a bunch of empty log methods
 
-  public void log(LogRecord record) {}
+  public void log(final LogRecord record) {}
 
-  public void log(Level level, String msg) {}
+  public void log(final Level level, final String msg) {}
 
-  public void log(Level level, String msg, Object param1) {}
+  public void log(final Level level, final String msg, final Object param1) {}
 
-  public void log(Level level, String msg, Object params[]) {}
+  public void log(final Level level, final String msg, final Object[] params) {}
 
-  public void log(Level level, String msg, Throwable thrown) {}
-
-  public void logp(Level level, String sourceClass, String sourceMethod, String msg) {}
+  public void log(final Level level, final String msg, final Throwable thrown) {}
 
   public void logp(
-      Level level, String sourceClass, String sourceMethod, String msg, Object param1) {}
+      final Level level, final String sourceClass, final String sourceMethod, final String msg) {}
 
   public void logp(
-      Level level, String sourceClass, String sourceMethod, String msg, Object params[]) {}
+      final Level level,
+      final String sourceClass,
+      final String sourceMethod,
+      final String msg,
+      final Object param1) {}
 
   public void logp(
-      Level level, String sourceClass, String sourceMethod, String msg, Throwable thrown) {}
+      final Level level,
+      final String sourceClass,
+      final String sourceMethod,
+      final String msg,
+      final Object[] params) {}
+
+  public void logp(
+      final Level level,
+      final String sourceClass,
+      final String sourceMethod,
+      final String msg,
+      final Throwable thrown) {}
 
   public void logrb(
-      Level level, String sourceClass, String sourceMethod, String bundleName, String msg) {}
+      final Level level,
+      final String sourceClass,
+      final String sourceMethod,
+      final String bundleName,
+      final String msg) {}
 
   public void logrb(
-      Level level,
-      String sourceClass,
-      String sourceMethod,
-      String bundleName,
-      String msg,
-      Object param1) {}
+      final Level level,
+      final String sourceClass,
+      final String sourceMethod,
+      final String bundleName,
+      final String msg,
+      final Object param1) {}
 
   public void logrb(
-      Level level,
-      String sourceClass,
-      String sourceMethod,
-      String bundleName,
-      String msg,
-      Object params[]) {}
+      final Level level,
+      final String sourceClass,
+      final String sourceMethod,
+      final String bundleName,
+      final String msg,
+      final Object[] params) {}
 
   public void logrb(
-      Level level,
-      String sourceClass,
-      String sourceMethod,
-      ResourceBundle bundle,
-      String msg,
-      Object... params) {}
+      final Level level,
+      final String sourceClass,
+      final String sourceMethod,
+      final ResourceBundle bundle,
+      final String msg,
+      final Object... params) {}
 
   public void logrb(
-      Level level,
-      String sourceClass,
-      String sourceMethod,
-      String bundleName,
-      String msg,
-      Throwable thrown) {}
+      final Level level,
+      final String sourceClass,
+      final String sourceMethod,
+      final String bundleName,
+      final String msg,
+      final Throwable thrown) {}
 
   public void logrb(
-      Level level,
-      String sourceClass,
-      String sourceMethod,
-      ResourceBundle bundle,
-      String msg,
-      Throwable thrown) {}
+      final Level level,
+      final String sourceClass,
+      final String sourceMethod,
+      final ResourceBundle bundle,
+      final String msg,
+      final Throwable thrown) {}
 
-  public void severe(String msg) {}
+  public void severe(final String msg) {}
 
-  public void warning(String msg) {}
+  public void warning(final String msg) {}
 
-  public void info(String msg) {}
+  public void info(final String msg) {}
 
-  public void config(String msg) {}
+  public void config(final String msg) {}
 
-  public void fine(String msg) {}
+  public void fine(final String msg) {}
 
-  public void finer(String msg) {}
+  public void finer(final String msg) {}
 
-  public void finest(String msg) {}
+  public void finest(final String msg) {}
 
-  public void throwing(String sourceClass, String sourceMethod, Throwable thrown) {}
+  public void throwing(
+      final String sourceClass, final String sourceMethod, final Throwable thrown) {}
 
-  public void setLevel(Level newLevel) throws SecurityException {}
+  public void setLevel(final Level newLevel) throws SecurityException {}
+
+  public boolean isLoggable(final Level level) {
+    return false;
+  }
 }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Constants.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Constants.java
@@ -39,6 +39,12 @@ public final class Constants {
     "org.msgpack",
     "com.fasterxml.jackson",
     "org.yaml.snakeyaml",
+    // okHttp
+    "okhttp3",
+    "okio",
+    "jnr",
+    "org.objectweb.asm",
+    "com.kenai"
   };
 
   private Constants() {}

--- a/dd-java-agent/instrumentation/okhttp-3/src/main/java/datadog/trace/instrumentation/okhttp3/TracingInterceptor.java
+++ b/dd-java-agent/instrumentation/okhttp-3/src/main/java/datadog/trace/instrumentation/okhttp3/TracingInterceptor.java
@@ -15,6 +15,10 @@ public class TracingInterceptor implements Interceptor {
 
   @Override
   public Response intercept(final Chain chain) throws IOException {
+    if (chain.request().header("Datadog-Meta-Lang") != null) {
+      return chain.proceed(chain.request());
+    }
+
     Response response = null;
 
     // application interceptor?

--- a/dd-java-agent/instrumentation/okhttp-3/src/test/groovy/OkHttp3Test.groovy
+++ b/dd-java-agent/instrumentation/okhttp-3/src/test/groovy/OkHttp3Test.groovy
@@ -33,15 +33,18 @@ class OkHttp3Test extends AgentTestRunner {
 
   def "sending a request creates spans and sends headers"() {
     setup:
-    def request = new Request.Builder()
+    def requestBulder = new Request.Builder()
       .url("http://localhost:$server.address.port/ping")
-      .build()
+    if (agentRequest) {
+      requestBulder.addHeader("Datadog-Meta-Lang", "java")
+    }
+    def request = requestBulder.build()
 
     Response response = withConfigOverride(Config.HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN, "$renameService") {
       if (!async) {
         return client.newCall(request).execute()
       }
-      
+
       AtomicReference<Response> responseRef = new AtomicReference()
       def latch = new CountDownLatch(1)
 
@@ -61,52 +64,60 @@ class OkHttp3Test extends AgentTestRunner {
 
     expect:
     response.body.string() == "pong"
-    assertTraces(1) {
-      trace(0, 2) {
-        span(0) {
-          operationName "okhttp.http"
-          serviceName "okhttp"
-          resourceName "okhttp.http"
-          spanType DDSpanTypes.HTTP_CLIENT
-          errored false
-          parent()
-          tags {
-            "$Tags.COMPONENT.key" "okhttp"
-            "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            defaultTags()
+    if (agentRequest) {
+      assert TEST_WRITER.size() == 0
+      assert server.lastRequest.headers.get("x-datadog-trace-id") == null
+      assert server.lastRequest.headers.get("x-datadog-parent-id") == null
+    } else {
+      assertTraces(1) {
+        trace(0, 2) {
+          span(0) {
+            operationName "okhttp.http"
+            serviceName "okhttp"
+            resourceName "okhttp.http"
+            spanType DDSpanTypes.HTTP_CLIENT
+            errored false
+            parent()
+            tags {
+              "$Tags.COMPONENT.key" "okhttp"
+              "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
+              defaultTags()
+            }
           }
-        }
-        span(1) {
-          operationName "okhttp.http"
-          serviceName renameService ? "localhost" : "okhttp"
-          resourceName "GET /ping"
-          spanType DDSpanTypes.HTTP_CLIENT
-          errored false
-          childOf(span(0))
-          tags {
-            defaultTags()
-            "$Tags.COMPONENT.key" "okhttp-network"
-            "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$Tags.HTTP_METHOD.key" "GET"
-            "$Tags.HTTP_STATUS.key" 200
-            "$Tags.HTTP_URL.key" "http://localhost:$server.address.port/ping"
-            "$Tags.PEER_HOSTNAME.key" "localhost"
-            "$Tags.PEER_PORT.key" server.address.port
-            "$Tags.PEER_HOST_IPV4.key" "127.0.0.1"
+          span(1) {
+            operationName "okhttp.http"
+            serviceName renameService ? "localhost" : "okhttp"
+            resourceName "GET /ping"
+            spanType DDSpanTypes.HTTP_CLIENT
+            errored false
+            childOf(span(0))
+            tags {
+              defaultTags()
+              "$Tags.COMPONENT.key" "okhttp-network"
+              "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
+              "$Tags.HTTP_METHOD.key" "GET"
+              "$Tags.HTTP_STATUS.key" 200
+              "$Tags.HTTP_URL.key" "http://localhost:$server.address.port/ping"
+              "$Tags.PEER_HOSTNAME.key" "localhost"
+              "$Tags.PEER_PORT.key" server.address.port
+              "$Tags.PEER_HOST_IPV4.key" "127.0.0.1"
+            }
           }
         }
       }
+
+      assert server.lastRequest.headers.get("x-datadog-trace-id") == TEST_WRITER[0][1].traceId
+      assert server.lastRequest.headers.get("x-datadog-parent-id") == TEST_WRITER[0][1].spanId
     }
 
-    server.lastRequest.headers.get("x-datadog-trace-id") == TEST_WRITER[0][1].traceId
-    server.lastRequest.headers.get("x-datadog-parent-id") == TEST_WRITER[0][1].spanId
-
     where:
-    renameService | async
-    false         | false
-    true          | false
-    false         | true
-    true          | true
+    renameService | async | agentRequest
+    false         | false | false
+    true          | false | false
+    false         | true  | false
+    true          | true  | false
+    false         | false | true
+    false         | false | true
   }
 
   def "sending an invalid request creates an error span"() {

--- a/dd-java-agent/src/test/groovy/datadog/trace/agent/CustomLogManagerTest.groovy
+++ b/dd-java-agent/src/test/groovy/datadog/trace/agent/CustomLogManagerTest.groovy
@@ -2,12 +2,15 @@ package datadog.trace.agent
 
 import datadog.trace.agent.test.IntegrationTestUtils
 import jvmbootstraptest.LogManagerSetter
+import spock.lang.Requires
 import spock.lang.Shared
 import spock.lang.Specification
 
 import java.lang.management.ManagementFactory
 import java.lang.management.RuntimeMXBean
 
+// Note: this test is fails on IBM JVM, we would need to investigate this at some point
+@Requires({ !System.getProperty("java.vm.name").contains("IBM J9 VM") })
 class CustomLogManagerTest extends Specification {
   // Run all tests using forked jvm because groovy has already set the global log manager
 

--- a/dd-trace-api/src/main/java/datadog/trace/api/Config.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/Config.java
@@ -38,6 +38,7 @@ public class Config {
   public static final String AGENT_HOST = "agent.host";
   public static final String TRACE_AGENT_PORT = "trace.agent.port";
   public static final String AGENT_PORT_LEGACY = "agent.port";
+  public static final String AGENT_UNIX_DOMAIN_SOCKET = "trace.agent.unix.domain.socket";
   public static final String PRIORITY_SAMPLING = "priority.sampling";
   public static final String TRACE_RESOLVER_ENABLED = "trace.resolver.enabled";
   public static final String SERVICE_MAPPING = "service.mapping";
@@ -71,6 +72,7 @@ public class Config {
 
   public static final String DEFAULT_AGENT_HOST = "localhost";
   public static final int DEFAULT_TRACE_AGENT_PORT = 8126;
+  public static final String DEFAULT_AGENT_UNIX_DOMAIN_SOCKET = null;
 
   public static final String LOGS_INJECTION_ENABLED = "logs.injection";
   public static final boolean DEFAULT_LOGS_INJECTION_ENABLED = false;
@@ -97,6 +99,7 @@ public class Config {
   @Getter private final String writerType;
   @Getter private final String agentHost;
   @Getter private final int agentPort;
+  @Getter private final String agentUnixDomainSocket;
   @Getter private final boolean prioritySamplingEnabled;
   @Getter private final boolean traceResolverEnabled;
   @Getter private final Map<String, String> serviceMapping;
@@ -128,6 +131,8 @@ public class Config {
         getIntegerSettingFromEnvironment(
             TRACE_AGENT_PORT,
             getIntegerSettingFromEnvironment(AGENT_PORT_LEGACY, DEFAULT_TRACE_AGENT_PORT));
+    agentUnixDomainSocket =
+        getSettingFromEnvironment(AGENT_UNIX_DOMAIN_SOCKET, DEFAULT_AGENT_UNIX_DOMAIN_SOCKET);
     prioritySamplingEnabled =
         getBooleanSettingFromEnvironment(PRIORITY_SAMPLING, DEFAULT_PRIORITY_SAMPLING_ENABLED);
     traceResolverEnabled =
@@ -179,6 +184,8 @@ public class Config {
             properties,
             TRACE_AGENT_PORT,
             getPropertyIntegerValue(properties, AGENT_PORT_LEGACY, parent.agentPort));
+    agentUnixDomainSocket =
+        properties.getProperty(AGENT_UNIX_DOMAIN_SOCKET, parent.agentUnixDomainSocket);
     prioritySamplingEnabled =
         getPropertyBooleanValue(properties, PRIORITY_SAMPLING, parent.prioritySamplingEnabled);
     traceResolverEnabled =

--- a/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -7,6 +7,7 @@ import spock.lang.Specification
 
 import static datadog.trace.api.Config.AGENT_HOST
 import static datadog.trace.api.Config.AGENT_PORT_LEGACY
+import static datadog.trace.api.Config.AGENT_UNIX_DOMAIN_SOCKET
 import static datadog.trace.api.Config.DEFAULT_JMX_FETCH_STATSD_PORT
 import static datadog.trace.api.Config.GLOBAL_TAGS
 import static datadog.trace.api.Config.HEADER_TAGS
@@ -57,6 +58,7 @@ class ConfigTest extends Specification {
     config.writerType == "DDAgentWriter"
     config.agentHost == "localhost"
     config.agentPort == 8126
+    config.agentUnixDomainSocket == null
     config.prioritySamplingEnabled == true
     config.traceResolverEnabled == true
     config.serviceMapping == [:]
@@ -81,6 +83,7 @@ class ConfigTest extends Specification {
     System.setProperty(PREFIX + WRITER_TYPE, "LoggingWriter")
     System.setProperty(PREFIX + AGENT_HOST, "somehost")
     System.setProperty(PREFIX + TRACE_AGENT_PORT, "123")
+    System.setProperty(PREFIX + AGENT_UNIX_DOMAIN_SOCKET, "somepath")
     System.setProperty(PREFIX + AGENT_PORT_LEGACY, "456")
     System.setProperty(PREFIX + PRIORITY_SAMPLING, "false")
     System.setProperty(PREFIX + TRACE_RESOLVER_ENABLED, "false")
@@ -107,6 +110,7 @@ class ConfigTest extends Specification {
     config.writerType == "LoggingWriter"
     config.agentHost == "somehost"
     config.agentPort == 123
+    config.agentUnixDomainSocket == "somepath"
     config.prioritySamplingEnabled == false
     config.traceResolverEnabled == false
     config.serviceMapping == [a: "1"]
@@ -239,6 +243,7 @@ class ConfigTest extends Specification {
     properties.setProperty(WRITER_TYPE, "LoggingWriter")
     properties.setProperty(AGENT_HOST, "somehost")
     properties.setProperty(TRACE_AGENT_PORT, "123")
+    properties.setProperty(AGENT_UNIX_DOMAIN_SOCKET, "somepath")
     properties.setProperty(PRIORITY_SAMPLING, "false")
     properties.setProperty(TRACE_RESOLVER_ENABLED, "false")
     properties.setProperty(SERVICE_MAPPING, "a:1")
@@ -262,6 +267,7 @@ class ConfigTest extends Specification {
     config.writerType == "LoggingWriter"
     config.agentHost == "somehost"
     config.agentPort == 123
+    config.agentUnixDomainSocket == "somepath"
     config.prioritySamplingEnabled == false
     config.traceResolverEnabled == false
     config.serviceMapping == [a: "1"]

--- a/dd-trace-java.gradle
+++ b/dd-trace-java.gradle
@@ -32,7 +32,6 @@ repositories {
 
 description = 'dd-trace-java'
 
-tasks.register("traceAgentTest")
 tasks.register("latestDepTest")
 
 // Applied here to allow publishing of artifactory build info

--- a/dd-trace-ot/dd-trace-ot.gradle
+++ b/dd-trace-ot/dd-trace-ot.gradle
@@ -12,7 +12,10 @@ minimumInstructionCoverage = 0.6
 excludedClassesConverage += [
   'datadog.trace.common.writer.ListWriter',
   'datadog.trace.common.writer.LoggingWriter',
-  'datadog.trace.common.sampling.PrioritySampling'
+  'datadog.trace.common.sampling.PrioritySampling',
+  // This code is copied from okHttp samples and we have integration tests to verify that it works.
+  'datadog.trace.common.writer.unixdomainsockets.TunnelingUnixSocket',
+  'datadog.trace.common.writer.unixdomainsockets.UnixDomainSocketFactory'
 ]
 
 apply plugin: 'org.unbroken-dome.test-sets'
@@ -32,6 +35,8 @@ dependencies {
   compile deps.jackson
   compile deps.slf4j
   compile group: 'org.msgpack', name: 'jackson-dataformat-msgpack', version: '0.8.16'
+  compile group: 'com.squareup.okhttp3', name: 'okhttp', version: '3.11.0' // Last version to support Java7
+  compile group: 'com.github.jnr', name: 'jnr-unixsocket', version: '0.22'
 
   // We have autoservices defined in test subtree, looks like we need this to be able to properly rebuild this
   testAnnotationProcessor deps.autoservice
@@ -43,7 +48,9 @@ dependencies {
   testCompile group: 'org.mockito', name: 'mockito-core', version: '2.19.0'
   testCompile group: 'org.objenesis', name: 'objenesis', version: '2.6' // Last version to support Java7
   testCompile group: 'cglib', name: 'cglib-nodep', version: '3.2.5'
-  testCompile 'com.github.stefanbirkner:system-rules:1.17.1'
+  testCompile group: 'com.github.stefanbirkner', name: 'system-rules', version: '1.17.1'
+
+  traceAgentTestCompile deps.testcontainers
 }
 
 jmh {

--- a/dd-trace-ot/src/main/java/datadog/trace/common/writer/DDAgentWriter.java
+++ b/dd-trace-ot/src/main/java/datadog/trace/common/writer/DDAgentWriter.java
@@ -1,6 +1,7 @@
 package datadog.trace.common.writer;
 
 import static datadog.trace.api.Config.DEFAULT_AGENT_HOST;
+import static datadog.trace.api.Config.DEFAULT_AGENT_UNIX_DOMAIN_SOCKET;
 import static datadog.trace.api.Config.DEFAULT_TRACE_AGENT_PORT;
 
 import datadog.opentracing.DDSpan;
@@ -64,7 +65,7 @@ public class DDAgentWriter implements Writer {
   private boolean queueFullReported = false;
 
   public DDAgentWriter() {
-    this(new DDApi(DEFAULT_AGENT_HOST, DEFAULT_TRACE_AGENT_PORT));
+    this(new DDApi(DEFAULT_AGENT_HOST, DEFAULT_TRACE_AGENT_PORT, DEFAULT_AGENT_UNIX_DOMAIN_SOCKET));
   }
 
   public DDAgentWriter(final DDApi api) {

--- a/dd-trace-ot/src/main/java/datadog/trace/common/writer/DDApi.java
+++ b/dd-trace-ot/src/main/java/datadog/trace/common/writer/DDApi.java
@@ -1,22 +1,25 @@
 package datadog.trace.common.writer;
 
+import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import datadog.opentracing.DDSpan;
 import datadog.opentracing.DDTraceOTInfo;
-import java.io.BufferedReader;
+import datadog.trace.common.writer.unixdomainsockets.UnixDomainSocketFactory;
+import java.io.File;
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.OutputStream;
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import lombok.extern.slf4j.Slf4j;
+import okhttp3.HttpUrl;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
 import org.msgpack.jackson.dataformat.MessagePackFactory;
 
 /** The API pointing to a DD agent */
@@ -28,28 +31,41 @@ public class DDApi {
   private static final String DATADOG_META_TRACER_VERSION = "Datadog-Meta-Tracer-Version";
   private static final String X_DATADOG_TRACE_COUNT = "X-Datadog-Trace-Count";
 
-  private static final String TRACES_ENDPOINT_V3 = "/v0.3/traces";
-  private static final String TRACES_ENDPOINT_V4 = "/v0.4/traces";
+  private static final String TRACES_ENDPOINT_V3 = "v0.3/traces";
+  private static final String TRACES_ENDPOINT_V4 = "v0.4/traces";
   private static final long MILLISECONDS_BETWEEN_ERROR_LOG = TimeUnit.MINUTES.toMillis(5);
 
-  private final String tracesEndpoint;
   private final List<ResponseListener> responseListeners = new ArrayList<>();
 
   private final AtomicInteger traceCount = new AtomicInteger(0);
   private volatile long nextAllowedLogTime = 0;
 
-  private static final ObjectMapper objectMapper = new ObjectMapper(new MessagePackFactory());
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper(new MessagePackFactory());
+  private static final MediaType MSGPACK = MediaType.get("application/msgpack");
 
-  public DDApi(final String host, final int port) {
-    this(host, port, traceEndpointAvailable("http://" + host + ":" + port + TRACES_ENDPOINT_V4));
+  private final OkHttpClient httpClient;
+  private final HttpUrl tracesUrl;
+
+  public DDApi(final String host, final int port, final String unixDomainSocketPath) {
+    this(
+        host,
+        port,
+        traceEndpointAvailable(getUrl(host, port, TRACES_ENDPOINT_V4), unixDomainSocketPath),
+        unixDomainSocketPath);
   }
 
-  DDApi(final String host, final int port, final boolean v4EndpointsAvailable) {
+  DDApi(
+      final String host,
+      final int port,
+      final boolean v4EndpointsAvailable,
+      final String unixDomainSocketPath) {
+    httpClient = buildHttpClient(unixDomainSocketPath, false);
+
     if (v4EndpointsAvailable) {
-      this.tracesEndpoint = "http://" + host + ":" + port + TRACES_ENDPOINT_V4;
+      tracesUrl = getUrl(host, port, TRACES_ENDPOINT_V4);
     } else {
       log.debug("API v0.4 endpoints not available. Downgrading to v0.3");
-      this.tracesEndpoint = "http://" + host + ":" + port + TRACES_ENDPOINT_V3;
+      tracesUrl = getUrl(host, port, TRACES_ENDPOINT_V3);
     }
   }
 
@@ -70,70 +86,52 @@ public class DDApi {
    * @return the staus code returned
    */
   public boolean sendTraces(final List<List<DDSpan>> traces) {
-    final int totalSize = traceCount == null ? traces.size() : traceCount.getAndSet(0);
+    final int totalSize = traceCount.getAndSet(0);
     try {
-      final HttpURLConnection httpCon = getHttpURLConnection(tracesEndpoint);
-      httpCon.setRequestProperty(X_DATADOG_TRACE_COUNT, String.valueOf(totalSize));
+      final RequestBody body = RequestBody.create(MSGPACK, OBJECT_MAPPER.writeValueAsBytes(traces));
+      final Request request =
+          prepareRequest(tracesUrl)
+              .addHeader(X_DATADOG_TRACE_COUNT, String.valueOf(totalSize))
+              .put(body)
+              .build();
 
-      final OutputStream out = httpCon.getOutputStream();
-      objectMapper.writeValue(out, traces);
-      out.flush();
-      out.close();
-
-      String responseString = null;
-      {
-        final BufferedReader responseReader =
-            new BufferedReader(
-                new InputStreamReader(httpCon.getInputStream(), StandardCharsets.UTF_8));
-        final StringBuilder sb = new StringBuilder();
-
-        String line = null;
-        while ((line = responseReader.readLine()) != null) {
-          sb.append(line);
-        }
-        responseReader.close();
-
-        responseString = sb.toString();
-      }
-
-      final int responseCode = httpCon.getResponseCode();
-      if (responseCode != 200) {
-        if (log.isDebugEnabled()) {
-          log.debug(
-              "Error while sending {} of {} traces to the DD agent. Status: {}, ResponseMessage: ",
-              traces.size(),
-              totalSize,
-              responseCode,
-              httpCon.getResponseMessage());
-        } else if (nextAllowedLogTime < System.currentTimeMillis()) {
-          nextAllowedLogTime = System.currentTimeMillis() + MILLISECONDS_BETWEEN_ERROR_LOG;
-          log.warn(
-              "Error while sending {} of {} traces to the DD agent. Status: {} (going silent for {} seconds)",
-              traces.size(),
-              totalSize,
-              responseCode,
-              httpCon.getResponseMessage(),
-              TimeUnit.MILLISECONDS.toMinutes(MILLISECONDS_BETWEEN_ERROR_LOG));
-        }
-        return false;
-      }
-
-      log.debug("Successfully sent {} of {} traces to the DD agent.", traces.size(), totalSize);
-
-      try {
-        if (null != responseString
-            && !"".equals(responseString.trim())
-            && !"OK".equalsIgnoreCase(responseString.trim())) {
-          final JsonNode response = objectMapper.readTree(responseString);
-          for (final ResponseListener listener : responseListeners) {
-            listener.onResponse(tracesEndpoint, response);
+      try (final Response response = httpClient.newCall(request).execute()) {
+        if (response.code() != 200) {
+          if (log.isDebugEnabled()) {
+            log.debug(
+                "Error while sending {} of {} traces to the DD agent. Status: {}, ResponseMessage: ",
+                traces.size(),
+                totalSize,
+                response.code(),
+                response.message());
+          } else if (nextAllowedLogTime < System.currentTimeMillis()) {
+            nextAllowedLogTime = System.currentTimeMillis() + MILLISECONDS_BETWEEN_ERROR_LOG;
+            log.warn(
+                "Error while sending {} of {} traces to the DD agent. Status: {} (going silent for {} seconds)",
+                traces.size(),
+                totalSize,
+                response.code(),
+                response.message(),
+                TimeUnit.MILLISECONDS.toMinutes(MILLISECONDS_BETWEEN_ERROR_LOG));
           }
+          return false;
         }
-      } catch (final IOException e) {
-        log.debug("Failed to parse DD agent response: " + responseString, e);
-      }
-      return true;
 
+        log.debug("Successfully sent {} of {} traces to the DD agent.", traces.size(), totalSize);
+
+        final String responseString = response.body().string().trim();
+        try {
+          if (!"".equals(responseString) && !"OK".equalsIgnoreCase(responseString)) {
+            final JsonNode parsedResponse = OBJECT_MAPPER.readTree(responseString);
+            for (final ResponseListener listener : responseListeners) {
+              listener.onResponse(tracesUrl.toString(), parsedResponse);
+            }
+          }
+        } catch (final JsonParseException e) {
+          log.debug("Failed to parse DD agent response: " + responseString, e);
+        }
+        return true;
+      }
     } catch (final IOException e) {
       if (log.isDebugEnabled()) {
         log.debug(
@@ -157,56 +155,70 @@ public class DDApi {
     }
   }
 
-  private static boolean traceEndpointAvailable(final String endpoint) {
-    return endpointAvailable(endpoint, Collections.emptyList(), true);
-  }
-
-  private static boolean serviceEndpointAvailable(final String endpoint) {
-    return endpointAvailable(endpoint, Collections.emptyMap(), true);
+  private static boolean traceEndpointAvailable(
+      final HttpUrl url, final String unixDomainSocketPath) {
+    return endpointAvailable(url, unixDomainSocketPath, Collections.emptyList(), true);
   }
 
   private static boolean endpointAvailable(
-      final String endpoint, final Object data, final boolean retry) {
+      final HttpUrl url,
+      final String unixDomainSocketPath,
+      final Object data,
+      final boolean retry) {
     try {
-      final HttpURLConnection httpCon = getHttpURLConnection(endpoint);
-
       // This is potentially called in premain, so we want to fail fast.
-      httpCon.setConnectTimeout((int) TimeUnit.SECONDS.toMillis(1));
-      httpCon.setReadTimeout((int) TimeUnit.SECONDS.toMillis(1));
+      final OkHttpClient client = buildHttpClient(unixDomainSocketPath, true);
+      final RequestBody body = RequestBody.create(MSGPACK, OBJECT_MAPPER.writeValueAsBytes(data));
+      final Request request = prepareRequest(url).put(body).build();
 
-      final OutputStream out = httpCon.getOutputStream();
-      objectMapper.writeValue(out, data);
-      out.flush();
-      out.close();
-
-      return httpCon.getResponseCode() == 200;
+      try (final Response response = client.newCall(request).execute()) {
+        return response.code() == 200;
+      }
     } catch (final IOException e) {
       if (retry) {
-        return endpointAvailable(endpoint, data, false);
+        return endpointAvailable(url, unixDomainSocketPath, data, false);
       }
     }
     return false;
   }
 
-  private static HttpURLConnection getHttpURLConnection(final String endpoint) throws IOException {
-    final HttpURLConnection httpCon;
-    final URL url = new URL(endpoint);
-    httpCon = (HttpURLConnection) url.openConnection();
-    httpCon.setDoOutput(true);
-    httpCon.setDoInput(true);
-    httpCon.setRequestMethod("PUT");
-    httpCon.setRequestProperty("Content-Type", "application/msgpack");
-    httpCon.setRequestProperty(DATADOG_META_LANG, "java");
-    httpCon.setRequestProperty(DATADOG_META_LANG_VERSION, DDTraceOTInfo.JAVA_VERSION);
-    httpCon.setRequestProperty(DATADOG_META_LANG_INTERPRETER, DDTraceOTInfo.JAVA_VM_NAME);
-    httpCon.setRequestProperty(DATADOG_META_TRACER_VERSION, DDTraceOTInfo.VERSION);
+  private static OkHttpClient buildHttpClient(
+      final String unixDomainSocketPath, final boolean setTimeouts) {
+    OkHttpClient.Builder builder = new OkHttpClient.Builder();
+    if (unixDomainSocketPath != null) {
+      builder = builder.socketFactory(new UnixDomainSocketFactory(new File(unixDomainSocketPath)));
+    }
+    if (setTimeouts) {
+      builder =
+          builder
+              .connectTimeout(1, TimeUnit.SECONDS)
+              .writeTimeout(1, TimeUnit.SECONDS)
+              .readTimeout(1, TimeUnit.SECONDS);
+    }
+    return builder.build();
+  }
 
-    return httpCon;
+  private static HttpUrl getUrl(final String host, final int port, final String endPoint) {
+    return new HttpUrl.Builder()
+        .scheme("http")
+        .host(host)
+        .port(port)
+        .addEncodedPathSegments(endPoint)
+        .build();
+  }
+
+  private static Request.Builder prepareRequest(final HttpUrl url) {
+    return new Request.Builder()
+        .url(url)
+        .addHeader(DATADOG_META_LANG, "java")
+        .addHeader(DATADOG_META_LANG_VERSION, DDTraceOTInfo.JAVA_VERSION)
+        .addHeader(DATADOG_META_LANG_INTERPRETER, DDTraceOTInfo.JAVA_VM_NAME)
+        .addHeader(DATADOG_META_TRACER_VERSION, DDTraceOTInfo.VERSION);
   }
 
   @Override
   public String toString() {
-    return "DDApi { tracesEndpoint=" + tracesEndpoint + " }";
+    return "DDApi { tracesUrl=" + tracesUrl + " }";
   }
 
   public interface ResponseListener {

--- a/dd-trace-ot/src/main/java/datadog/trace/common/writer/Writer.java
+++ b/dd-trace-ot/src/main/java/datadog/trace/common/writer/Writer.java
@@ -57,7 +57,9 @@ public interface Writer {
     }
 
     private static Writer createAgentWriter(final Config config) {
-      return new DDAgentWriter(new DDApi(config.getAgentHost(), config.getAgentPort()));
+      return new DDAgentWriter(
+          new DDApi(
+              config.getAgentHost(), config.getAgentPort(), config.getAgentUnixDomainSocket()));
     }
 
     private Builder() {}

--- a/dd-trace-ot/src/main/java/datadog/trace/common/writer/unixdomainsockets/TunnelingUnixSocket.java
+++ b/dd-trace-ot/src/main/java/datadog/trace/common/writer/unixdomainsockets/TunnelingUnixSocket.java
@@ -1,0 +1,51 @@
+package datadog.trace.common.writer.unixdomainsockets;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import jnr.unixsocket.UnixSocket;
+import jnr.unixsocket.UnixSocketAddress;
+import jnr.unixsocket.UnixSocketChannel;
+
+/**
+ * Subtype UNIX socket for a higher-fidelity impersonation of TCP sockets. This is named "tunneling"
+ * because it assumes the ultimate destination has a hostname and port.
+ *
+ * <p>Copied from <a
+ * href="https://github.com/square/okhttp/blob/master/samples/unixdomainsockets/src/main/java/okhttp3/unixdomainsockets/UnixDomainServerSocketFactory.java">okHttp
+ * examples</a>.
+ */
+final class TunnelingUnixSocket extends UnixSocket {
+  private final File path;
+  private InetSocketAddress inetSocketAddress;
+
+  TunnelingUnixSocket(final File path, final UnixSocketChannel channel) {
+    super(channel);
+    this.path = path;
+  }
+
+  TunnelingUnixSocket(
+      final File path, final UnixSocketChannel channel, final InetSocketAddress address) {
+    this(path, channel);
+    inetSocketAddress = address;
+  }
+
+  @Override
+  public void connect(final SocketAddress endpoint) throws IOException {
+    inetSocketAddress = (InetSocketAddress) endpoint;
+    super.connect(new UnixSocketAddress(path), 0);
+  }
+
+  @Override
+  public void connect(final SocketAddress endpoint, final int timeout) throws IOException {
+    inetSocketAddress = (InetSocketAddress) endpoint;
+    super.connect(new UnixSocketAddress(path), timeout);
+  }
+
+  @Override
+  public InetAddress getInetAddress() {
+    return inetSocketAddress.getAddress();
+  }
+}

--- a/dd-trace-ot/src/main/java/datadog/trace/common/writer/unixdomainsockets/UnixDomainSocketFactory.java
+++ b/dd-trace-ot/src/main/java/datadog/trace/common/writer/unixdomainsockets/UnixDomainSocketFactory.java
@@ -1,0 +1,58 @@
+package datadog.trace.common.writer.unixdomainsockets;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import javax.net.SocketFactory;
+import jnr.unixsocket.UnixSocketChannel;
+
+/**
+ * Impersonate TCP-style SocketFactory over UNIX domain sockets.
+ *
+ * <p>Copied from <a
+ * href="https://github.com/square/okhttp/blob/master/samples/unixdomainsockets/src/main/java/okhttp3/unixdomainsockets/UnixDomainSocketFactory.java">okHttp
+ * examples</a>.
+ */
+public final class UnixDomainSocketFactory extends SocketFactory {
+  private final File path;
+
+  public UnixDomainSocketFactory(final File path) {
+    this.path = path;
+  }
+
+  @Override
+  public Socket createSocket() throws IOException {
+    final UnixSocketChannel channel = UnixSocketChannel.open();
+    return new TunnelingUnixSocket(path, channel);
+  }
+
+  @Override
+  public Socket createSocket(final String host, final int port) throws IOException {
+    final Socket result = createSocket();
+    result.connect(new InetSocketAddress(host, port));
+    return result;
+  }
+
+  @Override
+  public Socket createSocket(
+      final String host, final int port, final InetAddress localHost, final int localPort)
+      throws IOException {
+    return createSocket(host, port);
+  }
+
+  @Override
+  public Socket createSocket(final InetAddress host, final int port) throws IOException {
+    final Socket result = createSocket();
+    result.connect(new InetSocketAddress(host, port));
+    return result;
+  }
+
+  @Override
+  public Socket createSocket(
+      final InetAddress host, final int port, final InetAddress localAddress, final int localPort)
+      throws IOException {
+    return createSocket(host, port);
+  }
+}

--- a/dd-trace-ot/src/test/groovy/datadog/trace/DDTracerTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/trace/DDTracerTest.groovy
@@ -43,7 +43,7 @@ class DDTracerTest extends Specification {
     then:
     tracer.serviceName == "unnamed-java-app"
     tracer.sampler instanceof RateByServiceSampler
-    tracer.writer.toString() == "DDAgentWriter { api=DDApi { tracesEndpoint=http://localhost:8126/v0.3/traces } }"
+    tracer.writer.toString() == "DDAgentWriter { api=DDApi { tracesUrl=http://localhost:8126/v0.3/traces } }"
 
     tracer.spanContextDecorators.size() == 13
   }
@@ -102,11 +102,11 @@ class DDTracerTest extends Specification {
     where:
 
     source   | key                | value           | expected
-    "writer" | "default"          | "default"       | "DDAgentWriter { api=DDApi { tracesEndpoint=http://localhost:8126/v0.3/traces } }"
+    "writer" | "default"          | "default"       | "DDAgentWriter { api=DDApi { tracesUrl=http://localhost:8126/v0.3/traces } }"
     "writer" | "writer.type"      | "LoggingWriter" | "LoggingWriter { }"
-    "writer" | "agent.host"       | "somethingelse" | "DDAgentWriter { api=DDApi { tracesEndpoint=http://somethingelse:8126/v0.3/traces } }"
-    "writer" | "agent.port"       | "777"           | "DDAgentWriter { api=DDApi { tracesEndpoint=http://localhost:777/v0.3/traces } }"
-    "writer" | "trace.agent.port" | "9999"          | "DDAgentWriter { api=DDApi { tracesEndpoint=http://localhost:9999/v0.3/traces } }"
+    "writer" | "agent.host"       | "somethingelse" | "DDAgentWriter { api=DDApi { tracesUrl=http://somethingelse:8126/v0.3/traces } }"
+    "writer" | "agent.port"       | "777"           | "DDAgentWriter { api=DDApi { tracesUrl=http://localhost:777/v0.3/traces } }"
+    "writer" | "trace.agent.port" | "9999"          | "DDAgentWriter { api=DDApi { tracesUrl=http://localhost:9999/v0.3/traces } }"
   }
 
   def "verify sampler/writer constructor"() {

--- a/dd-trace-ot/src/test/groovy/datadog/trace/api/writer/DDApiTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/trace/api/writer/DDApiTest.groovy
@@ -26,10 +26,10 @@ class DDApiTest extends Specification {
         }
       }
     }
-    def client = new DDApi("localhost", agent.address.port)
+    def client = new DDApi("localhost", agent.address.port, null)
 
     expect:
-    client.tracesEndpoint == "http://localhost:${agent.address.port}/v0.4/traces"
+    client.tracesUrl.toString() == "http://localhost:${agent.address.port}/v0.4/traces"
     client.sendTraces([])
 
     cleanup:
@@ -45,10 +45,10 @@ class DDApiTest extends Specification {
         }
       }
     }
-    def client = new DDApi("localhost", agent.address.port)
+    def client = new DDApi("localhost", agent.address.port, null)
 
     expect:
-    client.tracesEndpoint == "http://localhost:${agent.address.port}/v0.3/traces"
+    client.tracesUrl.toString() == "http://localhost:${agent.address.port}/v0.3/traces"
     !client.sendTraces([])
 
     cleanup:
@@ -64,10 +64,10 @@ class DDApiTest extends Specification {
         }
       }
     }
-    def client = new DDApi("localhost", agent.address.port)
+    def client = new DDApi("localhost", agent.address.port, null)
 
     expect:
-    client.tracesEndpoint == "http://localhost:${agent.address.port}/v0.4/traces"
+    client.tracesUrl.toString() == "http://localhost:${agent.address.port}/v0.4/traces"
     client.getTraceCounter().addAndGet(traces.size()) >= 0
     client.sendTraces(traces)
     agent.lastRequest.contentType == "application/msgpack"
@@ -128,7 +128,7 @@ class DDApiTest extends Specification {
         }
       }
     }
-    def client = new DDApi("localhost", agent.address.port)
+    def client = new DDApi("localhost", agent.address.port, null)
     client.addResponseListener(responseListener)
     def traceCounter = client.getTraceCounter()
     traceCounter.set(3)
@@ -157,10 +157,10 @@ class DDApiTest extends Specification {
         }
       }
     }
-    def client = new DDApi("localhost", v3Agent.address.port)
+    def client = new DDApi("localhost", v3Agent.address.port, null)
 
     expect:
-    client.tracesEndpoint == "http://localhost:${v3Agent.address.port}/v0.3/traces"
+    client.tracesUrl.toString() == "http://localhost:${v3Agent.address.port}/v0.3/traces"
     client.sendTraces([])
 
     cleanup:
@@ -184,10 +184,10 @@ class DDApiTest extends Specification {
       }
     }
     def port = badPort ? 999 : agent.address.port
-    def client = new DDApi("localhost", port)
+    def client = new DDApi("localhost", port, null)
 
     expect:
-    client.tracesEndpoint == "http://localhost:${port}/$endpointVersion/traces"
+    client.tracesUrl.toString() == "http://localhost:${port}/$endpointVersion/traces"
 
     cleanup:
     agent.close()

--- a/dd-trace-ot/src/traceAgentTest/groovy/DDApiIntegrationTest.groovy
+++ b/dd-trace-ot/src/traceAgentTest/groovy/DDApiIntegrationTest.groovy
@@ -6,15 +6,20 @@ import datadog.opentracing.PendingTrace
 import datadog.trace.api.sampling.PrioritySampling
 import datadog.trace.common.writer.DDApi
 import datadog.trace.common.writer.ListWriter
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.startupcheck.MinimumDurationRunningStartupCheckStrategy
+import spock.lang.Requires
+import spock.lang.Shared
 import spock.lang.Specification
 
+import java.time.Duration
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
 
-import static datadog.trace.api.Config.DEFAULT_AGENT_HOST
-import static datadog.trace.api.Config.DEFAULT_TRACE_AGENT_PORT
-
 class DDApiIntegrationTest {
+  // Do not run tests locally on Java7 since testcontainers are not compatible with Java7
+  // It is fine to run on CI because CI provides rabbitmq externally, not through testcontainers
+  @Requires({ "true" == System.getenv("CI") || jvm.java8Compatible })
   static class DDApiIntegrationV4Test extends Specification {
     static final WRITER = new ListWriter()
     static final TRACER = new DDTracer(WRITER)
@@ -34,7 +39,27 @@ class DDApiIntegrationTest {
       new PendingTrace(TRACER, "1", [:]),
       TRACER)
 
-    def api = new DDApi(DEFAULT_AGENT_HOST, DEFAULT_TRACE_AGENT_PORT, v4())
+    // Looks like okHttp needs to resolve this, even for connection over socket
+    static final SOMEHOST = "datadoghq.com"
+    static final SOMEPORT = 123
+
+    /*
+    Note: type here has to stay undefined, otherwise tests will fail in CI in Java 7 because
+    'testcontainers' are built for Java 8 and Java 7 cannot load this class.
+   */
+    @Shared
+    def agentContainer
+    @Shared
+    def agentContainerHost = "localhost"
+    @Shared
+    def agentContainerPort = 8126
+    @Shared
+    Process process
+    @Shared
+    File socketPath
+
+    def api
+    def unixDomainSocketApi
 
     def endpoint = new AtomicReference<String>(null)
     def agentResponse = new AtomicReference<String>(null)
@@ -44,8 +69,51 @@ class DDApiIntegrationTest {
       agentResponse.set(responseJson.toString())
     }
 
+    def setupSpec() {
+
+      /*
+        CI will provide us with rabbitmq container running along side our build.
+        When building locally, however, we need to take matters into our own hands
+        and we use 'testcontainers' for this.
+       */
+      if ("true" != System.getenv("CI")) {
+        agentContainer = new GenericContainer("datadog/docker-dd-agent:latest")
+          .withEnv(["DD_APM_ENABLED": "true",
+                    "DD_BIND_HOST"  : "0.0.0.0",
+                    "DD_API_KEY"    : "invalid_key_but_this_is_fine",
+                    "DD_LOGS_STDOUT": "yes"])
+          .withExposedPorts(datadog.trace.api.Config.DEFAULT_TRACE_AGENT_PORT)
+          .withStartupTimeout(Duration.ofSeconds(120))
+        // Apparently we need to sleep for a bit so agent's response `{"service:,env:":1}` in rate_by_service.
+        // This is clearly a race-condition and maybe we should av oid verifying complete response
+          .withStartupCheckStrategy(new MinimumDurationRunningStartupCheckStrategy(Duration.ofSeconds(10)))
+        //        .withLogConsumer { output ->
+        //        print output.utf8String
+        //      }
+        agentContainer.start()
+        agentContainerHost = agentContainer.containerIpAddress
+        agentContainerPort = agentContainer.getMappedPort(datadog.trace.api.Config.DEFAULT_TRACE_AGENT_PORT)
+      }
+
+      File tmpDir = File.createTempDir()
+      tmpDir.deleteOnExit()
+      socketPath = new File(tmpDir, "socket")
+      process = Runtime.getRuntime().exec("socat UNIX-LISTEN:${socketPath},reuseaddr,fork TCP-CONNECT:${agentContainerHost}:${agentContainerPort}")
+    }
+
+    def cleanupSpec() {
+      if (agentContainer) {
+        agentContainer.stop()
+      }
+      process.destroy()
+    }
+
     def setup() {
+      api = new DDApi(agentContainerHost, agentContainerPort, v4(), null)
       api.addResponseListener(responseListener)
+
+      unixDomainSocketApi = new DDApi(SOMEHOST, SOMEPORT, v4(), socketPath.toString())
+      unixDomainSocketApi.addResponseListener(responseListener)
     }
 
     boolean v4() {
@@ -56,8 +124,24 @@ class DDApiIntegrationTest {
       expect:
       api.sendTraces(traces)
       if (v4()) {
-        endpoint.get() == "http://localhost:8126/v0.4/traces"
-        agentResponse.get() == '{"rate_by_service":{"service:,env:":1}}'
+        assert endpoint.get() == "http://${agentContainerHost}:${agentContainerPort}/v0.4/traces"
+        assert agentResponse.get() == '{"rate_by_service":{"service:,env:":1}}'
+      }
+
+      where:
+      traces                                                                              | test
+      []                                                                                  | 1
+      [[], []]                                                                            | 2
+      [[new DDSpan(1, CONTEXT)]]                                                          | 3
+      [[new DDSpan(TimeUnit.MILLISECONDS.toMicros(System.currentTimeMillis()), CONTEXT)]] | 4
+    }
+
+    def "Sending traces to unix domain socket succeeds (test #test)"() {
+      expect:
+      unixDomainSocketApi.sendTraces(traces)
+      if (v4()) {
+        assert endpoint.get() == "http://${SOMEHOST}:${SOMEPORT}/v0.4/traces"
+        assert agentResponse.get() == '{"rate_by_service":{"service:,env:":1}}'
       }
 
       where:
@@ -81,6 +165,7 @@ class DDApiIntegrationTest {
     }
   }
 
+  @Requires({ "true" == System.getenv("CI") || jvm.java8Compatible })
   static class DDApiIntegrationV3Test extends DDApiIntegrationV4Test {
     boolean v4() {
       return false


### PR DESCRIPTION
Users can now provide path to Unix Domain Socket using `dd.trace.agent.unix.domain.socket` system property. This is be used to communicate with Datadog agent to send traces. Main intended use case is to be able to direct traces traffic to some sort of proxy to later be sent to potentially remote Datadog agent.
