### PR TITLE
Fix Trace Search + Analytics integration config key

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/decorator/BaseDecorator.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/decorator/BaseDecorator.java
@@ -29,9 +29,7 @@ public abstract class BaseDecorator {
                 new TreeSet<>(Arrays.asList(instrumentationNames)), traceAnalyticsDefault());
     float rate = 1.0f;
     for (final String name : instrumentationNames) {
-      rate =
-          Config.getFloatSettingFromEnvironment(
-              "integration." + name + ".analytics.sample-rate", rate);
+      rate = Config.getFloatSettingFromEnvironment(name + ".analytics.sample-rate", rate);
     }
     traceAnalyticsSampleRate = rate;
   }

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/decorator/BaseDecoratorTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/decorator/BaseDecoratorTest.groovy
@@ -164,8 +164,8 @@ class BaseDecoratorTest extends Specification {
 
   def "test analytics rate enabled"() {
     when:
-    BaseDecorator dec = withSystemProperty("dd.integration.${integName}.analytics.enabled", "true") {
-      withSystemProperty("dd.integration.${integName}.analytics.sample-rate", "$sampleRate") {
+    BaseDecorator dec = withSystemProperty("dd.${integName}.analytics.enabled", "true") {
+      withSystemProperty("dd.${integName}.analytics.sample-rate", "$sampleRate") {
         newDecorator(enabled)
       }
     }

--- a/dd-trace-api/src/main/java/datadog/trace/api/Config.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/Config.java
@@ -284,8 +284,7 @@ public class Config {
     boolean anyEnabled = defaultEnabled;
     for (final String name : integrationNames) {
       final boolean configEnabled =
-          getBooleanSettingFromEnvironment(
-              "integration." + name + ".analytics.enabled", defaultEnabled);
+          getBooleanSettingFromEnvironment(name + ".analytics.enabled", defaultEnabled);
       if (defaultEnabled) {
         anyEnabled &= configEnabled;
       } else {

--- a/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -347,13 +347,13 @@ class ConfigTest extends Specification {
 
   def "verify integration trace analytics config"() {
     setup:
-    environmentVariables.set("DD_INTEGRATION_ORDER_ANALYTICS_ENABLED", "false")
-    environmentVariables.set("DD_INTEGRATION_TEST_ENV_ANALYTICS_ENABLED", "true")
-    environmentVariables.set("DD_INTEGRATION_DISABLED_ENV_ANALYTICS_ENABLED", "false")
+    environmentVariables.set("DD_ORDER_ANALYTICS_ENABLED", "false")
+    environmentVariables.set("DD_TEST_ENV_ANALYTICS_ENABLED", "true")
+    environmentVariables.set("DD_DISABLED_ENV_ANALYTICS_ENABLED", "false")
 
-    System.setProperty("dd.integration.order.analytics.enabled", "true")
-    System.setProperty("dd.integration.test-prop.analytics.enabled", "true")
-    System.setProperty("dd.integration.disabled-prop.analytics.enabled", "false")
+    System.setProperty("dd.order.analytics.enabled", "true")
+    System.setProperty("dd.test-prop.analytics.enabled", "true")
+    System.setProperty("dd.disabled-prop.analytics.enabled", "false")
 
     expect:
     Config.traceAnalyticsIntegrationEnabled(integrationNames, defaultEnabled) == expected


### PR DESCRIPTION
This now aligns with the config key used by other language tracers.