### PR TITLE
Agent doesn’t like getting floats.

### DIFF
--- a/dd-java-agent/src/test/groovy/datadog/trace/agent/CustomLogManagerTest.groovy
+++ b/dd-java-agent/src/test/groovy/datadog/trace/agent/CustomLogManagerTest.groovy
@@ -2,12 +2,16 @@ package datadog.trace.agent
 
 import datadog.trace.agent.test.IntegrationTestUtils
 import jvmbootstraptest.LogManagerSetter
+import spock.lang.Retry
 import spock.lang.Shared
 import spock.lang.Specification
+import spock.lang.Timeout
 
 import java.lang.management.ManagementFactory
 import java.lang.management.RuntimeMXBean
 
+@Retry
+@Timeout(30)
 class CustomLogManagerTest extends Specification {
   // Run all tests using forked jvm because groovy has already set the global log manager
 

--- a/dd-trace-ot/src/main/java/datadog/opentracing/DDSpanContext.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/DDSpanContext.java
@@ -295,7 +295,11 @@ public class DDSpanContext implements io.opentracing.SpanContext {
     if (metrics.get() == null) {
       metrics.compareAndSet(null, new ConcurrentHashMap<String, Number>());
     }
-    metrics.get().put(key, value);
+    if (value instanceof Float) {
+      metrics.get().put(key, value.doubleValue());
+    } else {
+      metrics.get().put(key, value);
+    }
   }
   /**
    * Add a tag to the span. Tags are not propagated to the children

--- a/dd-trace-ot/src/test/groovy/datadog/trace/DDSpanContextTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/trace/DDSpanContextTest.groovy
@@ -70,4 +70,32 @@ class DDSpanContextTest extends Specification {
     "tag-with-bool"  | false
     "tag_with_float" | 0.321
   }
+
+  def "metrics use the expected types"() {
+    // floats should be converted to doubles.
+    setup:
+    def context = SpanFactory.newSpanOf(0).context
+    context.setMetric("test", value)
+    def metrics = context.getMetrics()
+
+    expect:
+    type.isInstance(metrics["test"])
+
+    where:
+    type    | value
+    Integer | 0
+    Integer | Integer.MAX_VALUE
+    Integer | Integer.MIN_VALUE
+    Short   | Short.MAX_VALUE
+    Short   | Short.MIN_VALUE
+    Double  | Float.MAX_VALUE
+    Double  | Float.MIN_VALUE
+    Double  | Double.MAX_VALUE
+    Double  | Double.MIN_VALUE
+    Double  | 1f
+    Double  | 1d
+    Double  | 0.5f
+    Double  | 0.5d
+    Integer | 0x55
+  }
 }


### PR DESCRIPTION
Convert to doubles instead.

Agent was throwing the following error on ingest:
```
cannot decode v0.4 traces payload: msgp: attempted to decode type "float32" with method for "float64"
```

This is because [this method](https://github.com/DataDog/datadog-agent/blob/6.10.1/pkg/trace/pb/decoder.go#L39) doesn't handle floats, only integers and doubles.