### PR TITLE
Fix content length calculation for larger trace counts

### DIFF
--- a/dd-trace-ot/src/main/java/datadog/trace/common/writer/DDApi.java
+++ b/dd-trace-ot/src/main/java/datadog/trace/common/writer/DDApi.java
@@ -122,9 +122,9 @@ public class DDApi {
               if (traceCount < (1 << 4)) {
                 return sizeInBytes + 1; // byte
               } else if (traceCount < (1 << 16)) {
-                return sizeInBytes + 2; // short
+                return sizeInBytes + 3; // byte + short
               } else {
-                return sizeInBytes + 4; // int
+                return sizeInBytes + 5; // byte + int
               }
             }
 

--- a/dd-trace-ot/src/traceAgentTest/groovy/DDApiIntegrationTest.groovy
+++ b/dd-trace-ot/src/traceAgentTest/groovy/DDApiIntegrationTest.groovy
@@ -134,6 +134,11 @@ class DDApiIntegrationTest {
       [[], []]                                                                            | 2
       [[new DDSpan(1, CONTEXT)]]                                                          | 3
       [[new DDSpan(TimeUnit.MILLISECONDS.toMicros(System.currentTimeMillis()), CONTEXT)]] | 4
+      (1..15).collect { [] }                                                              | 5
+      (1..16).collect { [] }                                                              | 6
+      // Larger traces take more than 1 second to send to the agent and get a timeout exception:
+//      (1..((1 << 16) - 1)).collect { [] }                                                 | 7
+//      (1..(1 << 16)).collect { [] }                                                       | 8
     }
 
     def "Sending traces to unix domain socket succeeds (test #test)"() {

--- a/dd-trace/src/test/groovy/datadog/trace/tracer/writer/AgentWriterTest.groovy
+++ b/dd-trace/src/test/groovy/datadog/trace/tracer/writer/AgentWriterTest.groovy
@@ -1,6 +1,7 @@
 package datadog.trace.tracer.writer
 
 import datadog.trace.tracer.Trace
+import spock.lang.Retry
 import spock.lang.Specification
 
 import java.util.concurrent.ExecutorService
@@ -138,6 +139,7 @@ class AgentWriterTest extends Specification {
     sampleRateByService == SampleRateByService.EMPTY_INSTANCE
   }
 
+  @Retry
   def "test start/#closeMethod"() {
     setup:
     def writer = new AgentWriter(client)
@@ -178,6 +180,7 @@ class AgentWriterTest extends Specification {
   }
 
   boolean isWriterThreadRunning() {
+    // This is known to fail sometimes.
     return Thread.getAllStackTraces().keySet().any { t -> t.getName() == "dd-agent-writer" }
   }
 }


### PR DESCRIPTION
Failure to calculate this correctly causes the agent to drop the request.