### PR TITLE
 Have cassandra integration to work with recent versions of Guava

### DIFF
--- a/buildSrc/src/main/groovy/MuzzlePlugin.groovy
+++ b/buildSrc/src/main/groovy/MuzzlePlugin.groovy
@@ -369,7 +369,7 @@ class MuzzleDirective {
   }
 
   /**
-   * Slug of a directive name.
+   * Slug of directive name.
    *
    * @return
    */

--- a/buildSrc/src/main/groovy/MuzzlePlugin.groovy
+++ b/buildSrc/src/main/groovy/MuzzlePlugin.groovy
@@ -371,7 +371,7 @@ class MuzzleDirective {
   /**
    * Slug of directive name.
    *
-   * @return
+   * @return A slug of the name or an empty string if name is empty. E.g. 'My Directive' --> 'My-Directive'
    */
   String getNameSlug() {
     if (null == name) {

--- a/dd-java-agent/instrumentation/datastax-cassandra-3/datastax-cassandra-3.gradle
+++ b/dd-java-agent/instrumentation/datastax-cassandra-3/datastax-cassandra-3.gradle
@@ -14,8 +14,8 @@ muzzle {
     module = "cassandra-driver-core"
     versions = cassandraDriverTestVersions
     assertInverse = true
-    // Older versions of cassandra-driver-core require an older guava dependency (0.16.0). guava <20 is not
-    // compatible with Java 7, so we declare the dependency on 20 in our top level dependencies.gradle.
+    // Older versions of cassandra-driver-core require an older guava dependency (0.16.0). guava >20.0 is not
+    // compatible with Java 7, so we declare the dependency on 20.0 in our top level dependencies.gradle.
     // Ideally our muzzle plugin should take into account those versions declaration, instead it does not so we would
     // end up with testing compatibility with guava 0.16 which lacks the method invocation added to be compatible with
     // most recent versions of guava (27+). While the long term solution is to make the muzzle plugin aware of upstream

--- a/dd-java-agent/instrumentation/datastax-cassandra-3/datastax-cassandra-3.gradle
+++ b/dd-java-agent/instrumentation/datastax-cassandra-3/datastax-cassandra-3.gradle
@@ -3,14 +3,35 @@ ext {
   // Test use Cassandra 3 which requires Java 8. (Currently incompatible with Java 9.)
   minJavaVersionForTests = JavaVersion.VERSION_1_8
   maxJavaVersionForTests = JavaVersion.VERSION_1_8
+  cassandraDriverTestVersions = "[3.0,4.0)"
 }
 
+
 muzzle {
+
   pass {
     group = "com.datastax.cassandra"
     module = "cassandra-driver-core"
-    versions = "[3.0,4.0)"
+    versions = cassandraDriverTestVersions
     assertInverse = true
+    // Older versions of cassandra-driver-core require an older guava dependency (0.16.0). guava <20 is not
+    // compatible with Java 7, so we declare the dependency on 20 in our top level dependencies.gradle.
+    // Ideally our muzzle plugin should take into account those versions declaration, instead it does not so we would
+    // end up with testing compatibility with guava 0.16 which lacks the method invocation added to be compatible with
+    // most recent versions of guava (27+). While the long term solution is to make the muzzle plugin of upstream
+    // declared dependencies, for now we just make sure that we use the proper ones.
+    extraDependency "com.google.guava:guava:20.0"
+  }
+
+  // Making sure that instrumentation works with recent versions of Guava which removed method
+  // Futures::transform(input, function) in favor of Futures::transform(input, function, executor)
+  pass {
+    name = "Newest versions of Guava"
+    group = "com.datastax.cassandra"
+    module = "cassandra-driver-core"
+    versions = cassandraDriverTestVersions
+    // While com.datastax.cassandra uses old versions of Guava, users may depends themselves on newer versions of Guava
+    extraDependency "com.google.guava:guava:27.0-jre"
   }
 }
 

--- a/dd-java-agent/instrumentation/datastax-cassandra-3/datastax-cassandra-3.gradle
+++ b/dd-java-agent/instrumentation/datastax-cassandra-3/datastax-cassandra-3.gradle
@@ -18,7 +18,7 @@ muzzle {
     // compatible with Java 7, so we declare the dependency on 20 in our top level dependencies.gradle.
     // Ideally our muzzle plugin should take into account those versions declaration, instead it does not so we would
     // end up with testing compatibility with guava 0.16 which lacks the method invocation added to be compatible with
-    // most recent versions of guava (27+). While the long term solution is to make the muzzle plugin of upstream
+    // most recent versions of guava (27+). While the long term solution is to make the muzzle plugin aware of upstream
     // declared dependencies, for now we just make sure that we use the proper ones.
     extraDependency "com.google.guava:guava:20.0"
   }

--- a/dd-java-agent/instrumentation/datastax-cassandra-3/src/main/java/datadog/trace/instrumentation/datastax/cassandra/TracingSession.java
+++ b/dd-java-agent/instrumentation/datastax-cassandra-3/src/main/java/datadog/trace/instrumentation/datastax/cassandra/TracingSession.java
@@ -53,8 +53,7 @@ public class TracingSession implements Session {
             return new TracingSession(session, tracer);
           }
         },
-        directExecutor()
-    );
+        directExecutor());
   }
 
   @Override

--- a/dd-java-agent/instrumentation/datastax-cassandra-3/src/main/java/datadog/trace/instrumentation/datastax/cassandra/TracingSession.java
+++ b/dd-java-agent/instrumentation/datastax-cassandra-3/src/main/java/datadog/trace/instrumentation/datastax/cassandra/TracingSession.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.datastax.cassandra;
 
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static datadog.trace.instrumentation.datastax.cassandra.CassandraClientDecorator.DECORATE;
 
 import com.datastax.driver.core.BoundStatement;
@@ -51,7 +52,9 @@ public class TracingSession implements Session {
           public Session apply(final Session session) {
             return new TracingSession(session, tracer);
           }
-        });
+        },
+        directExecutor()
+    );
   }
 
   @Override


### PR DESCRIPTION
Recent versions of Guava removed method `Futures::transform(input, function)` in favor of `Futures::transform(input, function, executor)`.

Guava is one of the dependencies that we declare in `gradle/dependencies.gradle` and is pinned to `20.0` for Java 7 compatibility. This version is then used by the cassandra driver even if older versions are declared:

```
$ gradle -q :dd-java-agent:instrumentation:datastax-cassandra-3:dependencyInsight --dependency guava

com.google.guava:guava:20.0
   variant "default+runtime" [
      org.gradle.status = release (not requested)
      Requested attributes not found in the selected variant:
         org.gradle.usage  = java-api
   ]
   Selection reasons:
      - Was requested
      - By conflict resolution : between versions 20.0, 16.0.1 and 19.0

com.google.guava:guava:20.0
\--- compileClasspath

com.google.guava:guava:16.0.1 -> 20.0
\--- com.datastax.cassandra:cassandra-driver-core:3.0.0
     \--- compileClasspath

com.google.guava:guava:19.0 -> 20.0
+--- com.google.auto:auto-common:0.8
|    +--- compileClasspath
|    \--- com.google.auto.service:auto-service:1.0-rc3
|         \--- compileClasspath
\--- com.google.auto.service:auto-service:1.0-rc3 (*)
```

This PR manually retrieves the executor as it was done in Guava 20 in the overloaded method so this is now compatible with Guava 27.0.
See: https://github.com/google/guava/blob/65f6b4f4b132a051616403bcf74e4034a19d92a1/guava/src/com/google/common/util/concurrent/AbstractTransformFuture.java#L58

In order to verify the change and to make sure we had an automatic test to detect it, we had to apply some changes to the muzzle plugin as well.

The muzzle plugin creates a config for each of the dependencies under test with name '...-<group_id>-<artifact_id>-<version>'. The problem is that if we want to test multiple times the same configuration under different conditions, e.g. with different extra dependencies, the plugin would throw an error as it would try to create several times the same config.

Now directives can define an optional name that defaults to `null`. If a name is provided then a slug of it is used to further specialize the gradle configuration name.

Please note that this is a temporary workaround, as the muzzle plugin should always try to use dependency versions as pinned in our `dependencies.gradle` files.