### PR TITLE
Fix AWS instrumentation warning in Idea

### DIFF
--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/aws-java-sdk-1.11.0.gradle
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/aws-java-sdk-1.11.0.gradle
@@ -19,20 +19,18 @@ apply from: "${rootDir}/gradle/java.gradle"
 apply plugin: 'org.unbroken-dome.test-sets'
 
 testSets {
-  // features used in test_1_11_106 (builder) is available since 1.11.84, but
+  // Features used in test_1_11_106 (builder) is available since 1.11.84, but
   // using 1.11.106 because of previous concerns with byte code differences
   // in 1.11.106, also, the DeleteOptionGroup request generates more spans
-  // in 1.11.106 than 1.11.84
-  test_1_11_106
+  // in 1.11.106 than 1.11.84.
+  // We test older version in separate test set to test newer version and latest deps in the 'default'
+  // test dir. Otherwise we get strange warnings in Idea.
+  test_before_1_11_106 {
+    dirName = 'test_before_1_11_106'
+  }
 
   latestDepTest {
-    dirName = 'test_1_11_106'
-  }
-}
-
-configurations.test_1_11_106Compile {
-  resolutionStrategy {
-    force group: 'com.amazonaws', name: 'aws-java-sdk', version: '1.11.106'
+    dirName = 'test'
   }
 }
 
@@ -49,19 +47,23 @@ dependencies {
   testCompile project(':dd-java-agent:testing')
   // Include httpclient instrumentation for testing because it is a dependency for aws-sdk.
   testCompile project(':dd-java-agent:instrumentation:apache-httpclient-4')
-  testCompile group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.11.0'
-  testCompile group: 'com.amazonaws', name: 'aws-java-sdk-rds', version: '1.11.0'
-  testCompile group: 'com.amazonaws', name: 'aws-java-sdk-ec2', version: '1.11.0'
+  testCompile group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.11.106'
+  testCompile group: 'com.amazonaws', name: 'aws-java-sdk-rds', version: '1.11.106'
+  testCompile group: 'com.amazonaws', name: 'aws-java-sdk-ec2', version: '1.11.106'
 
-  test_1_11_106Compile project(':dd-java-agent:testing')
-  test_1_11_106Compile project(':dd-java-agent:instrumentation:apache-httpclient-4')
-  test_1_11_106Compile group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.11.106'
-  test_1_11_106Compile group: 'com.amazonaws', name: 'aws-java-sdk-rds', version: '1.11.106'
-  test_1_11_106Compile group: 'com.amazonaws', name: 'aws-java-sdk-ec2', version: '1.11.106'
+  test_before_1_11_106Compile(group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.11.0') {
+    force = true
+  }
+  test_before_1_11_106Compile(group: 'com.amazonaws', name: 'aws-java-sdk-rds', version: '1.11.0') {
+    force = true
+  }
+  test_before_1_11_106Compile(group: 'com.amazonaws', name: 'aws-java-sdk-ec2', version: '1.11.0') {
+    force = true
+  }
 
-  latestDepTestCompile project(':dd-java-agent:testing')
-  latestDepTestCompile project(':dd-java-agent:instrumentation:apache-httpclient-4')
   latestDepTestCompile group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '+'
   latestDepTestCompile group: 'com.amazonaws', name: 'aws-java-sdk-rds', version: '+'
   latestDepTestCompile group: 'com.amazonaws', name: 'aws-java-sdk-ec2', version: '+'
 }
+
+test.dependsOn test_before_1_11_106

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test_before_1_11_106/groovy/AWSClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test_before_1_11_106/groovy/AWSClientTest.groovy
@@ -1,26 +1,20 @@
 import com.amazonaws.AmazonClientException
-import com.amazonaws.AmazonWebServiceClient
 import com.amazonaws.ClientConfiguration
 import com.amazonaws.Request
 import com.amazonaws.SDKGlobalConfiguration
-import com.amazonaws.SdkClientException
 import com.amazonaws.auth.AWSCredentialsProviderChain
-import com.amazonaws.auth.AWSStaticCredentialsProvider
-import com.amazonaws.auth.AnonymousAWSCredentials
 import com.amazonaws.auth.BasicAWSCredentials
 import com.amazonaws.auth.EnvironmentVariableCredentialsProvider
 import com.amazonaws.auth.InstanceProfileCredentialsProvider
 import com.amazonaws.auth.SystemPropertiesCredentialsProvider
 import com.amazonaws.auth.profile.ProfileCredentialsProvider
-import com.amazonaws.client.builder.AwsClientBuilder
 import com.amazonaws.handlers.RequestHandler2
-import com.amazonaws.regions.Regions
 import com.amazonaws.retry.PredefinedRetryPolicies
-import com.amazonaws.services.ec2.AmazonEC2ClientBuilder
-import com.amazonaws.services.rds.AmazonRDSClientBuilder
+import com.amazonaws.services.ec2.AmazonEC2Client
+import com.amazonaws.services.rds.AmazonRDSClient
 import com.amazonaws.services.rds.model.DeleteOptionGroupRequest
 import com.amazonaws.services.s3.AmazonS3Client
-import com.amazonaws.services.s3.AmazonS3ClientBuilder
+import com.amazonaws.services.s3.S3ClientOptions
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.DDSpanTypes
 import io.opentracing.Tracer
@@ -54,8 +48,6 @@ class AWSClientTest extends AgentTestRunner {
   }
 
   @Shared
-  def credentialsProvider = new AWSStaticCredentialsProvider(new AnonymousAWSCredentials())
-  @Shared
   def responseBody = new AtomicReference<String>()
   @AutoCleanup
   @Shared
@@ -65,28 +57,6 @@ class AWSClientTest extends AgentTestRunner {
         response.status(200).send(responseBody.get())
       }
     }
-  }
-  @Shared
-  def endpoint = new AwsClientBuilder.EndpointConfiguration("http://localhost:$server.address.port", "us-west-2")
-
-  def "request handler is hooked up with builder"() {
-    setup:
-    def builder = AmazonS3ClientBuilder.standard()
-      .withRegion(Regions.US_EAST_1)
-    if (addHandler) {
-      builder.withRequestHandlers(new RequestHandler2() {})
-    }
-    AmazonWebServiceClient client = builder.build()
-
-    expect:
-    client.requestHandler2s != null
-    client.requestHandler2s.size() == size
-    client.requestHandler2s.get(position).getClass().getSimpleName() == "TracingRequestHandler"
-
-    where:
-    addHandler | size | position
-    true       | 2    | 1
-    false      | 1    | 0
   }
 
   def "request handler is hooked up with constructor"() {
@@ -103,7 +73,7 @@ class AWSClientTest extends AgentTestRunner {
     client.requestHandler2s != null
     client.requestHandler2s.size() == size
     client.requestHandler2s.get(0).getClass().getSimpleName() == "TracingRequestHandler"
-
+    
     where:
     addHandler | size
     true       | 2
@@ -169,23 +139,23 @@ class AWSClientTest extends AgentTestRunner {
     server.lastRequest.headers.get("x-datadog-parent-id") == null
 
     where:
-    service | operation           | method | url                  | handlerCount | call                                                                   | body               | client
-    "S3"    | "CreateBucket"      | "PUT"  | "testbucket/"        | 1            | { client -> client.createBucket("testbucket") }                        | ""                 | AmazonS3ClientBuilder.standard().withPathStyleAccessEnabled(true).withEndpointConfiguration(endpoint).withCredentials(credentialsProvider).build()
-    "S3"    | "GetObject"         | "GET"  | "someBucket/someKey" | 1            | { client -> client.getObject("someBucket", "someKey") }                | ""                 | AmazonS3ClientBuilder.standard().withPathStyleAccessEnabled(true).withEndpointConfiguration(endpoint).withCredentials(credentialsProvider).build()
-    "EC2"   | "AllocateAddress"   | "POST" | ""                   | 4            | { client -> client.allocateAddress() }                                 | """
+    service | operation           | method | url                  | handlerCount | call                                                                                                                                   | body               | client
+    "S3"    | "CreateBucket"      | "PUT"  | "testbucket/"        | 1            | { client -> client.setS3ClientOptions(S3ClientOptions.builder().setPathStyleAccess(true).build()); client.createBucket("testbucket") } | ""                 | new AmazonS3Client().withEndpoint("http://localhost:$server.address.port")
+    "S3"    | "GetObject"         | "GET"  | "someBucket/someKey" | 1            | { client -> client.getObject("someBucket", "someKey") }                                                                                | ""                 | new AmazonS3Client().withEndpoint("http://localhost:$server.address.port")
+    "EC2"   | "AllocateAddress"   | "POST" | ""                   | 4            | { client -> client.allocateAddress() }                                                                                                 | """
             <AllocateAddressResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
                <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId> 
                <publicIp>192.0.2.1</publicIp>
                <domain>standard</domain>
             </AllocateAddressResponse>
-            """ | AmazonEC2ClientBuilder.standard().withEndpointConfiguration(endpoint).withCredentials(credentialsProvider).build()
-    "RDS"   | "DeleteOptionGroup" | "POST" | ""                   | 5            | { client -> client.deleteOptionGroup(new DeleteOptionGroupRequest()) } | """
+            """ | new AmazonEC2Client().withEndpoint("http://localhost:$server.address.port")
+    "RDS"   | "DeleteOptionGroup" | "POST" | ""                   | 1            | { client -> client.deleteOptionGroup(new DeleteOptionGroupRequest()) }                                                                 | """
         <DeleteOptionGroupResponse xmlns="http://rds.amazonaws.com/doc/2014-09-01/">
           <ResponseMetadata>
             <RequestId>0ac9cda2-bbf4-11d3-f92b-31fa5e8dbc99</RequestId>
           </ResponseMetadata>
         </DeleteOptionGroupResponse>
-      """       | AmazonRDSClientBuilder.standard().withEndpointConfiguration(endpoint).withCredentials(credentialsProvider).build()
+      """       | new AmazonRDSClient().withEndpoint("http://localhost:$server.address.port")
   }
 
   def "send #operation request to closed port"() {
@@ -196,7 +166,7 @@ class AWSClientTest extends AgentTestRunner {
     call.call(client)
 
     then:
-    thrown SdkClientException
+    thrown AmazonClientException
 
     assertTraces(1) {
       trace(0, 2) {
@@ -216,7 +186,7 @@ class AWSClientTest extends AgentTestRunner {
             "aws.endpoint" "http://localhost:${UNUSABLE_PORT}"
             "aws.operation" "${operation}Request"
             "aws.agent" "java-aws-sdk"
-            errorTags SdkClientException, ~/Unable to execute HTTP request/
+            errorTags AmazonClientException, ~/Unable to execute HTTP request/
             defaultTags()
           }
         }
@@ -266,18 +236,18 @@ class AWSClientTest extends AgentTestRunner {
         span(0) {
           serviceName "java-aws-sdk"
           operationName "aws.http"
-          resourceName "S3.HeadBucket"
+          resourceName "S3.GetObject"
           spanType DDSpanTypes.HTTP_CLIENT
           errored true
           parent()
           tags {
             "$Tags.COMPONENT.key" "java-aws-sdk"
             "$Tags.HTTP_URL.key" "https://s3.amazonaws.com"
-            "$Tags.HTTP_METHOD.key" "HEAD"
+            "$Tags.HTTP_METHOD.key" "GET"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
             "aws.service" "Amazon S3"
             "aws.endpoint" "https://s3.amazonaws.com"
-            "aws.operation" "HeadBucketRequest"
+            "aws.operation" "GetObjectRequest"
             "aws.agent" "java-aws-sdk"
             errorTags RuntimeException, "bad handler"
             defaultTags()
@@ -325,11 +295,7 @@ class AWSClientTest extends AgentTestRunner {
             "aws.endpoint" "http://localhost:$server.address.port"
             "aws.operation" "GetObjectRequest"
             "aws.agent" "java-aws-sdk"
-            try {
-              errorTags AmazonClientException, ~/Unable to execute HTTP request/
-            } catch (AssertionError e) {
-              errorTags SdkClientException, "Unable to execute HTTP request: Request did not complete before the request timeout configuration."
-            }
+            errorTags AmazonClientException, ~/Unable to execute HTTP request/
             defaultTags()
           }
         }


### PR DESCRIPTION
Idea complains about duplicates root because we run latest dep tests
and 'later version' tests from the same dir. This is ultimately
TestSetd plugin bug by the looks of it, but we can work around it by
swapping old and new version tests.

Also run both old and new version tests under 'test' task.