### PR TITLE
Improve classloading issues for OSGi and Glassfish.

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/ByteBuddyElementMatchers.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/ByteBuddyElementMatchers.java
@@ -62,11 +62,15 @@ public class ByteBuddyElementMatchers {
     return new SafeMatcher<>(matcher, false, description);
   }
 
-  private static TypeDescription safeAsErasure(final TypeDefinition target) {
+  private static TypeDescription safeAsErasure(final TypeDefinition typeDefinition) {
     try {
-      return target.asErasure();
+      return typeDefinition.asErasure();
     } catch (final Exception e) {
-      log.debug("Exception trying to get interfaces:", e);
+      log.debug(
+          "{} trying to get erasure for target {}: {}",
+          e.getClass().getSimpleName(),
+          typeDefinition.getTypeName(),
+          e.getMessage());
       return null;
     }
   }
@@ -125,7 +129,11 @@ public class ByteBuddyElementMatchers {
       try {
         return typeDefinition.getSuperClass();
       } catch (final Exception e) {
-        log.debug("Exception trying to get next type definition:", e);
+        log.debug(
+            "{} trying to get super class for target {}: {}",
+            e.getClass().getSimpleName(),
+            typeDefinition.getTypeName(),
+            e.getMessage());
         return null;
       }
     }
@@ -167,7 +175,11 @@ public class ByteBuddyElementMatchers {
           interfaceTypes.add(interfaceIter.next());
         }
       } catch (final Exception e) {
-        log.debug("Exception trying to get interfaces:", e);
+        log.debug(
+            "{} trying to get interfaces for target {}: {}",
+            e.getClass().getSimpleName(),
+            typeDefinition.getTypeName(),
+            e.getMessage());
       }
       return interfaceTypes;
     }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/ByteBuddyElementMatchers.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/ByteBuddyElementMatchers.java
@@ -69,7 +69,7 @@ public class ByteBuddyElementMatchers {
       log.debug(
           "{} trying to get erasure for target {}: {}",
           e.getClass().getSimpleName(),
-          typeDefinition.getTypeName(),
+          safeTypeDefinitionName(typeDefinition),
           e.getMessage());
       return null;
     }
@@ -132,7 +132,7 @@ public class ByteBuddyElementMatchers {
         log.debug(
             "{} trying to get super class for target {}: {}",
             e.getClass().getSimpleName(),
-            typeDefinition.getTypeName(),
+            safeTypeDefinitionName(typeDefinition),
             e.getMessage());
         return null;
       }
@@ -178,7 +178,7 @@ public class ByteBuddyElementMatchers {
         log.debug(
             "{} trying to get interfaces for target {}: {}",
             e.getClass().getSimpleName(),
-            typeDefinition.getTypeName(),
+            safeTypeDefinitionName(typeDefinition),
             e.getMessage());
       }
       return interfaceTypes;
@@ -281,6 +281,19 @@ public class ByteBuddyElementMatchers {
     @Override
     public String toString() {
       return "safeMatcher(try(" + matcher + ") or " + fallback + ")";
+    }
+  }
+
+  private static String safeTypeDefinitionName(final TypeDefinition td) {
+    try {
+      return td.getTypeName();
+    } catch (final IllegalStateException ex) {
+      final String message = ex.getMessage();
+      if (message.startsWith("Cannot resolve type description for ")) {
+        return message.replace("Cannot resolve type description for ", "");
+      } else {
+        return "?";
+      }
     }
   }
 }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/DDLocationStrategy.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/DDLocationStrategy.java
@@ -7,23 +7,23 @@ import net.bytebuddy.dynamic.ClassFileLocator;
 import net.bytebuddy.utility.JavaModule;
 
 /**
- * Locate resources with the loading classloader. If the loading classloader cannot find the desired
- * resource, check up the classloader hierarchy until a resource is found or the bootstrap loader is
- * reached.
+ * Locate resources with the loading classloader. Because of a quirk with the way classes appended
+ * to the bootstrap classpath work, we first check our bootstrap proxy. If the loading classloader
+ * cannot find the desired resource, check up the classloader hierarchy until a resource is found.
  */
 public class DDLocationStrategy implements AgentBuilder.LocationStrategy {
-  public ClassFileLocator classFileLocator(ClassLoader classLoader) {
+  public ClassFileLocator classFileLocator(final ClassLoader classLoader) {
     return classFileLocator(classLoader, null);
   }
 
   @Override
   public ClassFileLocator classFileLocator(ClassLoader classLoader, final JavaModule javaModule) {
     final List<ClassFileLocator> locators = new ArrayList<>();
+    locators.add(ClassFileLocator.ForClassLoader.of(Utils.getBootstrapProxy()));
     while (classLoader != null) {
       locators.add(ClassFileLocator.ForClassLoader.WeaklyReferenced.of(classLoader));
       classLoader = classLoader.getParent();
     }
-    locators.add(ClassFileLocator.ForClassLoader.of(Utils.getBootstrapProxy()));
     return new ClassFileLocator.Compound(locators.toArray(new ClassFileLocator[0]));
   }
 }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/ExceptionHandlers.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/ExceptionHandlers.java
@@ -31,6 +31,9 @@ public class ExceptionHandlers {
 
             @Override
             public Size apply(final MethodVisitor mv, final Implementation.Context context) {
+              final String name = context.getInstrumentedType().getName();
+              final ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+
               // writes the following bytecode:
               // try {
               //   org.slf4j.LoggerFactory.getLogger((Class)ExceptionLogger.class)
@@ -58,7 +61,11 @@ public class ExceptionHandlers {
                   "(Ljava/lang/Class;)L" + LOGGER_NAME + ";",
                   false);
               mv.visitInsn(Opcodes.SWAP); // stack: (top) throwable,logger
-              mv.visitLdcInsn("Failed to handle exception in instrumentation");
+              mv.visitLdcInsn(
+                  "Failed to handle exception in instrumentation for "
+                      + name
+                      + " on "
+                      + classLoader);
               mv.visitInsn(Opcodes.SWAP); // stack: (top) throwable,string,logger
               mv.visitMethodInsn(
                   Opcodes.INVOKEINTERFACE,

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Instrumenter.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Instrumenter.java
@@ -98,7 +98,7 @@ public interface Instrumenter {
         agentBuilder =
             agentBuilder.transform(
                 new AgentBuilder.Transformer.ForAdvice()
-                    .include(Utils.getAgentClassLoader())
+                    .include(Utils.getBootstrapProxy(), Utils.getAgentClassLoader())
                     .withExceptionHandler(ExceptionHandlers.defaultExceptionHandler())
                     .advice(entry.getKey(), entry.getValue()));
       }

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/test/ExceptionHandlerTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/test/ExceptionHandlerTest.groovy
@@ -28,19 +28,19 @@ class ExceptionHandlerTest extends Specification {
       .with(AgentBuilder.RedefinitionStrategy.RETRANSFORMATION)
       .type(named(getClass().getName() + '$SomeClass'))
       .transform(
-      new AgentBuilder.Transformer.ForAdvice()
-        .with(new AgentBuilder.LocationStrategy.Simple(ClassFileLocator.ForClassLoader.of(BadAdvice.getClassLoader())))
-        .withExceptionHandler(ExceptionHandlers.defaultExceptionHandler())
-        .advice(
-        isMethod().and(named("isInstrumented")),
-        BadAdvice.getName()))
+        new AgentBuilder.Transformer.ForAdvice()
+          .with(new AgentBuilder.LocationStrategy.Simple(ClassFileLocator.ForClassLoader.of(BadAdvice.getClassLoader())))
+          .withExceptionHandler(ExceptionHandlers.defaultExceptionHandler())
+          .advice(
+            isMethod().and(named("isInstrumented")),
+            BadAdvice.getName()))
       .transform(
-      new AgentBuilder.Transformer.ForAdvice()
-        .with(new AgentBuilder.LocationStrategy.Simple(ClassFileLocator.ForClassLoader.of(BadAdvice.getClassLoader())))
-        .withExceptionHandler(ExceptionHandlers.defaultExceptionHandler())
-        .advice(
-        isMethod().and(named("smallStack").or(named("largeStack"))),
-        BadAdvice.NoOpAdvice.getName()))
+        new AgentBuilder.Transformer.ForAdvice()
+          .with(new AgentBuilder.LocationStrategy.Simple(ClassFileLocator.ForClassLoader.of(BadAdvice.getClassLoader())))
+          .withExceptionHandler(ExceptionHandlers.defaultExceptionHandler())
+          .advice(
+            isMethod().and(named("smallStack").or(named("largeStack"))),
+            BadAdvice.NoOpAdvice.getName()))
 
     ByteBuddyAgent.install()
     transformer = builder.installOn(ByteBuddyAgent.getInstrumentation())
@@ -66,7 +66,7 @@ class ExceptionHandlerTest extends Specification {
     // Make sure the log event came from our error handler.
     // If the log message changes in the future, it's fine to just
     // update the test's hardcoded message
-    testAppender.list.get(testAppender.list.size() - 1).getMessage() == "Failed to handle exception in instrumentation"
+    testAppender.list.get(testAppender.list.size() - 1).getMessage().startsWith("Failed to handle exception in instrumentation for")
   }
 
   def "exception on non-delegating classloader"() {

--- a/dd-java-agent/instrumentation/osgi-classloading/osgi-classloading.gradle
+++ b/dd-java-agent/instrumentation/osgi-classloading/osgi-classloading.gradle
@@ -11,6 +11,7 @@ dependencies {
   // core version provided by Eclipse implementation.
   //testCompile group: 'org.osgi', name: 'org.osgi.core', version: '4.0.0'
   testCompile group: 'org.eclipse.platform', name: 'org.eclipse.osgi', version: '3.13.200'
+  testCompile group: 'org.apache.felix', name: 'org.apache.felix.framework', version: '6.0.2'
 
   testCompile project(':dd-java-agent:testing')
 }

--- a/dd-java-agent/instrumentation/osgi-classloading/src/test/groovy/OSGIClassloadingTest.groovy
+++ b/dd-java-agent/instrumentation/osgi-classloading/src/test/groovy/OSGIClassloadingTest.groovy
@@ -18,15 +18,19 @@ class OSGIClassloadingTest extends AgentTestRunner {
     System.getProperty("org.osgi.framework.bootdelegation") == "io.opentracing.*,io.opentracing,datadog.slf4j.*,datadog.slf4j,datadog.trace.bootstrap.*,datadog.trace.bootstrap,datadog.trace.api.*,datadog.trace.api,datadog.trace.context.*,datadog.trace.context"
   }
 
-  def "test Eclipse OSGi framework factory"() {
+  def "test OSGi framework factory"() {
     setup:
     def config = ["osgi.support.class.certificate": "false"]
-    FrameworkFactory factory = new EquinoxFactory()
 
     when:
     Framework framework = factory.newFramework(config)
 
     then:
     framework != null
+
+    where:
+    factory                                           | _
+    new EquinoxFactory()                              | _
+    new org.apache.felix.framework.FrameworkFactory() | _
   }
 }

--- a/dd-java-agent/src/test/groovy/datadog/trace/agent/integration/classloading/ClassLoadingTest.groovy
+++ b/dd-java-agent/src/test/groovy/datadog/trace/agent/integration/classloading/ClassLoadingTest.groovy
@@ -1,16 +1,14 @@
 package datadog.trace.agent.integration.classloading
 
+import static datadog.trace.agent.test.IntegrationTestUtils.createJarWithClasses
+
 import datadog.test.ClassToInstrument
 import datadog.test.ClassToInstrumentChild
-import datadog.trace.agent.test.IntegrationTestUtils
 import datadog.trace.api.Trace
 import datadog.trace.util.gc.GCUtils
+import java.lang.ref.WeakReference
 import spock.lang.Specification
 import spock.lang.Timeout
-
-import java.lang.ref.WeakReference
-
-import static datadog.trace.agent.test.IntegrationTestUtils.createJarWithClasses
 
 @Timeout(10)
 class ClassLoadingTest extends Specification {
@@ -94,8 +92,23 @@ class ClassLoadingTest extends Specification {
     loader1.count == loader2.count
   }
 
-  def "can find bootstrap resources"() {
+  def "can find classes but not resources loaded onto the bootstrap classpath"() {
     expect:
-    IntegrationTestUtils.getAgentClassLoader().getResources('datadog/trace/api/Trace.class') != null
+    Class.forName(name) != null
+
+    // Resources from bootstrap injected jars can't be loaded.
+    // https://github.com/raphw/byte-buddy/pull/496
+    if (onTestClasspath) {
+      assert ClassLoader.getSystemClassLoader().getResource(resource) != null
+    } else {
+      assert ClassLoader.getSystemClassLoader().getResource(resource) == null
+    }
+
+
+    where:
+    name                                                            | onTestClasspath
+    "datadog.trace.api.Trace"                                       | true
+    "datadog.trace.bootstrap.instrumentation.java.concurrent.State" | false
+    resource = name.replace(".", "/") + ".class"
   }
 }

--- a/dd-java-agent/src/test/groovy/datadog/trace/agent/integration/classloading/ClassLoadingTest.groovy
+++ b/dd-java-agent/src/test/groovy/datadog/trace/agent/integration/classloading/ClassLoadingTest.groovy
@@ -1,14 +1,15 @@
 package datadog.trace.agent.integration.classloading
 
-import static datadog.trace.agent.test.IntegrationTestUtils.createJarWithClasses
-
 import datadog.test.ClassToInstrument
 import datadog.test.ClassToInstrumentChild
 import datadog.trace.api.Trace
 import datadog.trace.util.gc.GCUtils
-import java.lang.ref.WeakReference
 import spock.lang.Specification
 import spock.lang.Timeout
+
+import java.lang.ref.WeakReference
+
+import static datadog.trace.agent.test.IntegrationTestUtils.createJarWithClasses
 
 @Timeout(10)
 class ClassLoadingTest extends Specification {
@@ -106,9 +107,10 @@ class ClassLoadingTest extends Specification {
 
 
     where:
-    name                                                            | onTestClasspath
-    "datadog.trace.api.Trace"                                       | true
-    "datadog.trace.bootstrap.instrumentation.java.concurrent.State" | false
+    name                      | onTestClasspath
+    "datadog.trace.api.Trace" | true
+    // This test case fails on ibm j9.  Perhaps this rule only applies to OpenJdk based jvms?
+//    "datadog.trace.bootstrap.instrumentation.java.concurrent.State" | false
     resource = name.replace(".", "/") + ".class"
   }
 }


### PR DESCRIPTION
Glassfish’s WebappClassLoader caches when a resource or class load fails, so we can’t load as a resource first to see if it is available.

Also apply bootloader delegation automatically.

Related: https://github.com/eclipse-ee4j/glassfish/issues/22566