### PR TITLE
Add transient modifier to added context fields.

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/context/FieldBackedProvider.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/context/FieldBackedProvider.java
@@ -469,7 +469,11 @@ public class FieldBackedProvider implements InstrumentationContextProvider {
 
           @Override
           public MethodVisitor visitMethod(
-              int access, String name, String descriptor, String signature, String[] exceptions) {
+              final int access,
+              final String name,
+              final String descriptor,
+              final String signature,
+              final String[] exceptions) {
             if (name.equals(getterMethodName)) {
               foundGetter = true;
             }
@@ -487,7 +491,12 @@ public class FieldBackedProvider implements InstrumentationContextProvider {
             // For this reason we check separately for the field and for the two accessors.
             if (!foundField) {
               cv.visitField(
-                  Opcodes.ACC_PRIVATE, fieldName, contextType.getDescriptor(), null, null);
+                  // Field should be transient to avoid being serialized with the object.
+                  Opcodes.ACC_PRIVATE | Opcodes.ACC_TRANSIENT,
+                  fieldName,
+                  contextType.getDescriptor(),
+                  null,
+                  null);
             }
             if (!foundGetter) {
               addGetter();

--- a/dd-java-agent/testing/src/test/groovy/context/FieldBackedProviderTest.groovy
+++ b/dd-java-agent/testing/src/test/groovy/context/FieldBackedProviderTest.groovy
@@ -15,6 +15,7 @@ import java.lang.instrument.ClassDefinition
 import java.lang.ref.WeakReference
 import java.lang.reflect.Field
 import java.lang.reflect.Method
+import java.lang.reflect.Modifier
 import java.util.concurrent.atomic.AtomicReference
 
 import static context.ContextTestInstrumentation.IncorrectCallUsageKeyClass
@@ -44,8 +45,12 @@ class FieldBackedProviderTest extends AgentTestRunner {
   def "#keyClassName structure modified = #shouldModifyStructure"() {
     setup:
     boolean hasField = false
+    boolean isPrivate = false
+    boolean isTransient = false
     for (Field field : keyClass.getDeclaredFields()) {
       if (field.getName().startsWith("__datadog")) {
+        isPrivate = Modifier.isPrivate(field.getModifiers())
+        isTransient = Modifier.isTransient(field.getModifiers())
         hasField = true
         break
       }
@@ -64,6 +69,8 @@ class FieldBackedProviderTest extends AgentTestRunner {
 
     expect:
     hasField == shouldModifyStructure
+    isPrivate == shouldModifyStructure
+    isTransient == shouldModifyStructure
     hasMarkerInterface == shouldModifyStructure
     hasAccessorInterface == shouldModifyStructure
     keyClass.newInstance().isInstrumented() == shouldModifyStructure


### PR DESCRIPTION
This should prevent the field from being serialized with the object.

@mar-kolya do you think it should be marked as volatile too?