### PR TITLE
Fix resource name for Ratpack

### DIFF
--- a/dd-java-agent/instrumentation/ratpack-1.4/src/main/java8/datadog/trace/instrumentation/ratpack/RatpackServerDecorator.java
+++ b/dd-java-agent/instrumentation/ratpack-1.4/src/main/java8/datadog/trace/instrumentation/ratpack/RatpackServerDecorator.java
@@ -69,9 +69,8 @@ public class RatpackServerDecorator extends HttpServerDecorator<Request, Request
 
     String description = ctx.getPathBinding().getDescription();
     if (description == null || description.isEmpty()) {
-      description = ctx.getRequest().getUri();
-    }
-    if (!description.startsWith("/")) {
+      description = "/";
+    } else if (!description.startsWith("/")) {
       description = "/" + description;
     }
 


### PR DESCRIPTION
Previous fallback would inadvertently include query parameters in the resource name.