### PR TITLE
Do not send headers to old kafka servers

### DIFF
--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerInstrumentation.java
@@ -73,6 +73,8 @@ public final class KafkaProducerInstrumentation extends Instrumenter.Default {
       callback = new ProducerCallback(callback, scope);
 
       // Do not inject headers for batch versions below 2
+      // This is how similar check is being done in Kafka client itself:
+      // https://github.com/apache/kafka/blob/05fcfde8f69b0349216553f711fdfc3f0259c601/clients/src/main/java/org/apache/kafka/common/record/MemoryRecordsBuilder.java#L411-L412
       if (apiVersions.maxUsableProduceMagic() >= RecordBatch.MAGIC_VALUE_V2) {
         try {
           GlobalTracer.get()


### PR DESCRIPTION
Kafka message bundles with versions below 2 (e.d. 0.10) do not support
headers so do not inject them. Otherwise client gets really upset.