### PR TITLE
Enable JMXFetch by default and add configs for more standard custom metrics

### DIFF
--- a/dd-java-agent/agent-jmxfetch/agent-jmxfetch.gradle
+++ b/dd-java-agent/agent-jmxfetch/agent-jmxfetch.gradle
@@ -35,8 +35,15 @@ tasks.register("submodulesUpdate", Exec) {
   group 'Build Setup'
   description 'Initializes and updates integrations-core git submodule'
   commandLine 'git', 'submodule', 'update', '--init', 'integrations-core'
-  inputs.file file("${project.rootDir}/.git/modules/dd-java-agent/agent-jmxfetch/integrations-core/HEAD")
-  outputs.dir file("$projectDir/integrations-core")
+  def submoduleHead = file("${project.rootDir}/.git/modules/dd-java-agent/agent-jmxfetch/integrations-core/HEAD")
+  if (submoduleHead.exists()) {
+    inputs.file "${project.rootDir}/.git/modules/dd-java-agent/agent-jmxfetch/integrations-core/HEAD"
+  }
+  def integrationsCore = file("$projectDir/integrations-core")
+  outputs.dir integrationsCore
+  if (integrationsCore.list().length == 0) {
+    outputs.upToDateWhen { false }
+  }
 }
 
 tasks.register("copyMetricConfigs", Exec) {

--- a/dd-java-agent/agent-jmxfetch/agent-jmxfetch.gradle
+++ b/dd-java-agent/agent-jmxfetch/agent-jmxfetch.gradle
@@ -4,7 +4,10 @@ plugins {
 apply from: "${rootDir}/gradle/java.gradle"
 
 dependencies {
-  compile 'com.datadoghq:jmxfetch:0.27.0'
+  compile('com.datadoghq:jmxfetch:0.29.0'){
+    exclude group: 'org.slf4j', module: 'slf4j-log4j12'
+    exclude group: 'log4j', module: 'log4j'
+  }
   compile deps.slf4j
   compile project(':dd-trace-api')
 }
@@ -32,12 +35,16 @@ tasks.register("submodulesUpdate", Exec) {
   group 'Build Setup'
   description 'Initializes and updates integrations-core git submodule'
   commandLine 'git', 'submodule', 'update', '--init', 'integrations-core'
+  inputs.file file("${project.rootDir}/.git/modules/dd-java-agent/agent-jmxfetch/integrations-core/HEAD")
+  outputs.dir file("$projectDir/integrations-core")
 }
 
 tasks.register("copyMetricConfigs", Exec) {
   group 'Build Setup'
   description 'Copy metrics.yaml files from integrations-core into resources'
   commandLine './copy-metric-configs.sh', 'integrations-core', sourceSets.main.output.resourcesDir
+  inputs.dir file("$projectDir/integrations-core")
+  outputs.dir sourceSets.main.output.resourcesDir
   doFirst {
     // Ensure the resources directory is available.
     file(sourceSets.main.output.resourcesDir).mkdirs()

--- a/dd-java-agent/agent-jmxfetch/src/main/java/datadog/trace/agent/jmxfetch/JMXFetch.java
+++ b/dd-java-agent/agent-jmxfetch/src/main/java/datadog/trace/agent/jmxfetch/JMXFetch.java
@@ -47,7 +47,7 @@ public class JMXFetch {
       System.setProperty("org.slf4j.simpleLogger.log.org.datadog.jmxfetch", "warn");
     }
 
-    final String agentConfDPath = config.getAgentConfDPath();
+    final String jmxFetchConfigDir = config.getJmxFetchConfigDir();
     final List<String> jmxFetchConfigs = config.getJmxFetchConfigs();
     final List<String> internalMetricsConfigs = getInternalMetricFiles();
     final List<String> metricsConfigs = config.getJmxFetchMetricsConfigs();
@@ -60,7 +60,7 @@ public class JMXFetch {
 
     log.info(
         "JMXFetch config: {} {} {} {} {} {} {} {} {} {}",
-        agentConfDPath,
+        jmxFetchConfigDir,
         jmxFetchConfigs,
         internalMetricsConfigs,
         metricsConfigs,
@@ -74,7 +74,7 @@ public class JMXFetch {
     final AppConfig.AppConfigBuilder configBuilder =
         AppConfig.builder()
             .action(ImmutableList.of(ACTION_COLLECT))
-            .confdDirectory(agentConfDPath)
+            .confdDirectory(jmxFetchConfigDir)
             .yamlFileList(jmxFetchConfigs)
             .targetDirectInstances(true)
             .instanceConfigResources(DEFAULT_CONFIGS)
@@ -151,7 +151,7 @@ public class JMXFetch {
         for (final String config : split) {
           integrationName.clear();
           integrationName.add(config.replace(".yaml", ""));
-          if (Config.integrationEnabled(integrationName, false)) {
+          if (Config.jmxFetchIntegrationEnabled(integrationName, false)) {
             final URL resource = JMXFetch.class.getResource("metricconfigs/" + config);
             result.add(resource.getPath().split("\\.jar!/")[1]);
           }

--- a/dd-java-agent/agent-jmxfetch/src/main/java/datadog/trace/agent/jmxfetch/JMXFetch.java
+++ b/dd-java-agent/agent-jmxfetch/src/main/java/datadog/trace/agent/jmxfetch/JMXFetch.java
@@ -1,5 +1,7 @@
 package datadog.trace.agent.jmxfetch;
 
+import static org.datadog.jmxfetch.AppConfig.ACTION_COLLECT;
+
 import com.google.common.collect.ImmutableList;
 import datadog.trace.api.Config;
 import java.io.IOException;
@@ -16,6 +18,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;
 import org.datadog.jmxfetch.App;
 import org.datadog.jmxfetch.AppConfig;
+import org.datadog.jmxfetch.reporter.ReporterFactory;
 
 @Slf4j
 public class JMXFetch {
@@ -38,6 +41,14 @@ public class JMXFetch {
       return;
     }
 
+    if (!log.isDebugEnabled()
+        && System.getProperty("org.slf4j.simpleLogger.log.org.datadog.jmxfetch") == null) {
+      // Reduce noisiness of jmxfetch logging.
+      System.setProperty("org.slf4j.simpleLogger.log.org.datadog.jmxfetch", "warn");
+    }
+
+    final String agentConfDPath = config.getAgentConfDPath();
+    final List<String> jmxFetchConfigs = config.getJmxFetchConfigs();
     final List<String> internalMetricsConfigs = getInternalMetricFiles();
     final List<String> metricsConfigs = config.getJmxFetchMetricsConfigs();
     final Integer checkPeriod = config.getJmxFetchCheckPeriod();
@@ -48,7 +59,9 @@ public class JMXFetch {
     final String logLevel = getLogLevel();
 
     log.info(
-        "JMXFetch config: {} {} {} {} {} {} {} {}",
+        "JMXFetch config: {} {} {} {} {} {} {} {} {} {}",
+        agentConfDPath,
+        jmxFetchConfigs,
         internalMetricsConfigs,
         metricsConfigs,
         checkPeriod,
@@ -57,17 +70,24 @@ public class JMXFetch {
         reporter,
         logLocation,
         logLevel);
-    final AppConfig appConfig =
-        AppConfig.create(
-            DEFAULT_CONFIGS,
-            internalMetricsConfigs,
-            metricsConfigs,
-            checkPeriod,
-            refreshBeansPeriod,
-            globalTags,
-            reporter,
-            logLocation,
-            logLevel);
+
+    final AppConfig.AppConfigBuilder configBuilder =
+        AppConfig.builder()
+            .action(ImmutableList.of(ACTION_COLLECT))
+            .confdDirectory(agentConfDPath)
+            .yamlFileList(jmxFetchConfigs)
+            .targetDirectInstances(true)
+            .instanceConfigResources(DEFAULT_CONFIGS)
+            .metricConfigResources(internalMetricsConfigs)
+            .metricConfigFiles(metricsConfigs)
+            .refreshBeansPeriod(refreshBeansPeriod)
+            .globalTags(globalTags)
+            .reporter(ReporterFactory.getReporter(reporter));
+
+    if (checkPeriod != null) {
+      configBuilder.checkPeriod(checkPeriod);
+    }
+    final AppConfig appConfig = configBuilder.build();
 
     final Thread thread =
         new Thread(

--- a/dd-java-agent/agent-jmxfetch/src/main/resources/jmxfetch-config.yaml
+++ b/dd-java-agent/agent-jmxfetch/src/main/resources/jmxfetch-config.yaml
@@ -3,6 +3,6 @@ init_config:
   new_gc_metrics: true
 
 instances:
-- jmx_url: service:jmx:local:///
-  conf:
-    # Intentionally left empty for now
+  - jvm_direct: true
+    name: dd-java-agent default
+    conf: [] # Intentionally left empty for now

--- a/dd-java-agent/dd-java-agent.gradle
+++ b/dd-java-agent/dd-java-agent.gradle
@@ -109,8 +109,9 @@ dependencies {
 tasks.withType(Test).configureEach {
   jvmArgs "-Ddd.service.name=java-agent-tests"
   jvmArgs "-Ddd.writer.type=LoggingWriter"
-  jvmArgs "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=debug"
-  jvmArgs "-Dorg.slf4j.simpleLogger.defaultLogLevel=debug"
+  // Multi-threaded logging seems to be causing deadlocks with Gradle's log capture.
+//  jvmArgs "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=debug"
+//  jvmArgs "-Dorg.slf4j.simpleLogger.defaultLogLevel=debug"
 
   doFirst {
     // Defining here to allow jacoco to be first on the command line.

--- a/dd-java-agent/dd-java-agent.gradle
+++ b/dd-java-agent/dd-java-agent.gradle
@@ -107,7 +107,8 @@ dependencies {
 }
 
 tasks.withType(Test).configureEach {
-  jvmArgs "-Ddd.writer.type=LogWriter", "-Ddd.service.name=java-app"
+  jvmArgs "-Ddd.service.name=java-agent-tests"
+  jvmArgs "-Ddd.writer.type=LoggingWriter"
   jvmArgs "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=debug"
   jvmArgs "-Dorg.slf4j.simpleLogger.defaultLogLevel=debug"
 

--- a/dd-java-agent/src/test/groovy/datadog/trace/agent/JMXFetchTest.groovy
+++ b/dd-java-agent/src/test/groovy/datadog/trace/agent/JMXFetchTest.groovy
@@ -52,7 +52,7 @@ class JMXFetchTest extends Specification {
   def "test jmxfetch config"() {
     setup:
     names.each {
-      System.setProperty("dd.integration.${it}.enabled", "$enable")
+      System.setProperty("dd.jmxfetch.${it}.enabled", "$enable")
     }
     def classLoader = IntegrationTestUtils.getJmxFetchClassLoader()
     // Have to set this so JMXFetch knows where to find resources

--- a/dd-trace-api/src/main/java/datadog/trace/api/Config.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/Config.java
@@ -102,7 +102,7 @@ public class Config {
   private static final int DEFAULT_PARTIAL_FLUSH_MIN_SPANS = 1000;
   private static final String DEFAULT_PROPAGATION_STYLE_EXTRACT = PropagationStyle.DATADOG.name();
   private static final String DEFAULT_PROPAGATION_STYLE_INJECT = PropagationStyle.DATADOG.name();
-  private static final boolean DEFAULT_JMX_FETCH_ENABLED = false;
+  private static final boolean DEFAULT_JMX_FETCH_ENABLED = true;
 
   public static final int DEFAULT_JMX_FETCH_STATSD_PORT = 8125;
 

--- a/dd-trace-api/src/main/java/datadog/trace/api/Config.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/Config.java
@@ -64,7 +64,9 @@ public class Config {
   public static final String PROPAGATION_STYLE_EXTRACT = "propagation.style.extract";
   public static final String PROPAGATION_STYLE_INJECT = "propagation.style.inject";
 
+  public static final String AGENT_CONF_D = "agent.conf.d";
   public static final String JMX_FETCH_ENABLED = "jmxfetch.enabled";
+  public static final String JMX_FETCH_CONFIGS = "jmxfetch.configs";
   public static final String JMX_FETCH_METRICS_CONFIGS = "jmxfetch.metrics-configs";
   public static final String JMX_FETCH_CHECK_PERIOD = "jmxfetch.check-period";
   public static final String JMX_FETCH_REFRESH_BEANS_PERIOD = "jmxfetch.refresh-beans-period";
@@ -146,8 +148,10 @@ public class Config {
   @Getter private final Set<PropagationStyle> propagationStylesToExtract;
   @Getter private final Set<PropagationStyle> propagationStylesToInject;
 
+  @Getter private final String agentConfDPath;
   @Getter private final boolean jmxFetchEnabled;
-  @Getter private final List<String> jmxFetchMetricsConfigs;
+  @Getter private final List<String> jmxFetchConfigs;
+  @Deprecated @Getter private final List<String> jmxFetchMetricsConfigs;
   @Getter private final Integer jmxFetchCheckPeriod;
   @Getter private final Integer jmxFetchRefreshBeansPeriod;
   @Getter private final String jmxFetchStatsdHost;
@@ -218,8 +222,10 @@ public class Config {
             PropagationStyle.class,
             true);
 
+    agentConfDPath = getSettingFromEnvironment(AGENT_CONF_D, null);
     jmxFetchEnabled =
         getBooleanSettingFromEnvironment(JMX_FETCH_ENABLED, DEFAULT_JMX_FETCH_ENABLED);
+    jmxFetchConfigs = getListSettingFromEnvironment(JMX_FETCH_CONFIGS, null);
     jmxFetchMetricsConfigs = getListSettingFromEnvironment(JMX_FETCH_METRICS_CONFIGS, null);
     jmxFetchCheckPeriod = getIntegerSettingFromEnvironment(JMX_FETCH_CHECK_PERIOD, null);
     jmxFetchRefreshBeansPeriod =
@@ -298,8 +304,10 @@ public class Config {
             ? parent.propagationStylesToInject
             : parsedPropagationStylesToInject;
 
+    agentConfDPath = properties.getProperty(AGENT_CONF_D, parent.agentConfDPath);
     jmxFetchEnabled =
         getPropertyBooleanValue(properties, JMX_FETCH_ENABLED, parent.jmxFetchEnabled);
+    jmxFetchConfigs = getPropertyListValue(properties, JMX_FETCH_CONFIGS, parent.jmxFetchConfigs);
     jmxFetchMetricsConfigs =
         getPropertyListValue(properties, JMX_FETCH_METRICS_CONFIGS, parent.jmxFetchMetricsConfigs);
     jmxFetchCheckPeriod =

--- a/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -84,7 +84,7 @@ class ConfigTest extends Specification {
     config.runtimeContextFieldInjection == true
     config.propagationStylesToExtract.toList() == [Config.PropagationStyle.DATADOG]
     config.propagationStylesToInject.toList() == [Config.PropagationStyle.DATADOG]
-    config.jmxFetchEnabled == false
+    config.jmxFetchEnabled == true
     config.jmxFetchMetricsConfigs == []
     config.jmxFetchCheckPeriod == null
     config.jmxFetchRefreshBeansPeriod == null
@@ -125,7 +125,7 @@ class ConfigTest extends Specification {
     prop.setProperty(RUNTIME_CONTEXT_FIELD_INJECTION, "false")
     prop.setProperty(PROPAGATION_STYLE_EXTRACT, "Datadog, B3")
     prop.setProperty(PROPAGATION_STYLE_INJECT, "B3, Datadog")
-    prop.setProperty(JMX_FETCH_ENABLED, "true")
+    prop.setProperty(JMX_FETCH_ENABLED, "false")
     prop.setProperty(JMX_FETCH_METRICS_CONFIGS, "/foo.yaml,/bar.yaml")
     prop.setProperty(JMX_FETCH_CHECK_PERIOD, "100")
     prop.setProperty(JMX_FETCH_REFRESH_BEANS_PERIOD, "200")
@@ -156,7 +156,7 @@ class ConfigTest extends Specification {
     config.runtimeContextFieldInjection == false
     config.propagationStylesToExtract.toList() == [Config.PropagationStyle.DATADOG, Config.PropagationStyle.B3]
     config.propagationStylesToInject.toList() == [Config.PropagationStyle.B3, Config.PropagationStyle.DATADOG]
-    config.jmxFetchEnabled == true
+    config.jmxFetchEnabled == false
     config.jmxFetchMetricsConfigs == ["/foo.yaml", "/bar.yaml"]
     config.jmxFetchCheckPeriod == 100
     config.jmxFetchRefreshBeansPeriod == 200
@@ -188,7 +188,7 @@ class ConfigTest extends Specification {
     System.setProperty(PREFIX + RUNTIME_CONTEXT_FIELD_INJECTION, "false")
     System.setProperty(PREFIX + PROPAGATION_STYLE_EXTRACT, "Datadog, B3")
     System.setProperty(PREFIX + PROPAGATION_STYLE_INJECT, "B3, Datadog")
-    System.setProperty(PREFIX + JMX_FETCH_ENABLED, "true")
+    System.setProperty(PREFIX + JMX_FETCH_ENABLED, "false")
     System.setProperty(PREFIX + JMX_FETCH_METRICS_CONFIGS, "/foo.yaml,/bar.yaml")
     System.setProperty(PREFIX + JMX_FETCH_CHECK_PERIOD, "100")
     System.setProperty(PREFIX + JMX_FETCH_REFRESH_BEANS_PERIOD, "200")
@@ -219,7 +219,7 @@ class ConfigTest extends Specification {
     config.runtimeContextFieldInjection == false
     config.propagationStylesToExtract.toList() == [Config.PropagationStyle.DATADOG, Config.PropagationStyle.B3]
     config.propagationStylesToInject.toList() == [Config.PropagationStyle.B3, Config.PropagationStyle.DATADOG]
-    config.jmxFetchEnabled == true
+    config.jmxFetchEnabled == false
     config.jmxFetchMetricsConfigs == ["/foo.yaml", "/bar.yaml"]
     config.jmxFetchCheckPeriod == 100
     config.jmxFetchRefreshBeansPeriod == 200

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -1,3 +1,5 @@
+import java.time.Duration
+
 apply plugin: 'java'
 apply plugin: 'groovy'
 
@@ -301,8 +303,11 @@ for (def env : System.getenv().entrySet()) {
   }
 }
 
-// Disable all tests if skipTests property was specified
 tasks.withType(Test).configureEach {
+  // All tests must complete within 2 minutes.
+  timeout = Duration.ofMinutes(2)
+  
+  // Disable all tests if skipTests property was specified
   onlyIf { !project.rootProject.hasProperty("skipTests") }
 }
 


### PR DESCRIPTION
JMXFetch is now enabled by default.  It can be disabled by adding the following:
* System Property: `dd.jmxfetch.enabled=false`
* Environment Variable: `DD_JMXFETCH_ENABLED=false`

Bundled jmx integrations must now be configured via (default still disabled):
* System Property `dd.jmxfetch.<integration>.enabled=true`
* Environment Variable `DD_JMXFETCH_<INTEGRATION>_ENABLED=true`

Expose new options for configuring JMXFetch with standard datadog-agent config files with `jvm_direct: true` set as an instance attribute (this will be ignored by the datadog-agent).

For Example:
* `dd.jmxfetch.config.dir=/opt/datadog-agent/etc/conf.d`
* `dd.jmxfetch.config=activemq.d/conf.yaml,jmx.d/conf.yaml`
will load jmx configs in those two files that have `jvm_direct: true` in their `instance` setup.

Environment variables can also be used: `DD_JMXFETCH_CONFIG_DIR` and `DD_JMXFETCH_CONFIG`

Also updated to https://github.com/DataDog/integrations-core/releases/tag/6.11.2 to get the latest built in jmx metric configs.