### PR TITLE
Undo Couchbase gradle hack

### DIFF
--- a/dd-java-agent/instrumentation/couchbase-2.0/couchbase-2.0.gradle
+++ b/dd-java-agent/instrumentation/couchbase-2.0/couchbase-2.0.gradle
@@ -17,15 +17,8 @@ muzzle {
   pass {
     group = 'com.couchbase.client'
     module = 'java-client'
-    // Looks like 2.7.5 was just released and didn't sync up with mirrors properly causing build failures
-    // TODO: remove this on a few days.
-    versions = "[2.0.0,2.7.5)"
-//    assertInverse = true
-  }
-  fail {
-    group = 'com.couchbase.client'
-    module = 'java-client'
-    versions = "(,2.0.0)"
+    versions = "[2.0.0,)"
+    assertInverse = true
   }
   fail {
     group = 'com.couchbase.client'
@@ -53,8 +46,6 @@ dependencies {
   testCompile group: 'com.couchbase.client', name: 'java-client', version: '2.5.0'
 
   latestDepTestCompile group: 'org.springframework.data', name: 'spring-data-couchbase', version: '3.+'
-  // Looks like 2.7.5 was just released and didn't sync up with mirrors properly causing build failures
-  // TODO: remove this on a few days.
-  latestDepTestCompile group: 'com.couchbase.client', name: 'java-client', version: '2.7.4'
-  latestDepTestCompile group: 'com.couchbase.client', name: 'encryption', version: '1.0.0'
+  latestDepTestCompile group: 'com.couchbase.client', name: 'java-client', version: '2.6+'
+  latestDepTestCompile group: 'com.couchbase.client', name: 'encryption', version: '+'
 }

--- a/dd-java-agent/instrumentation/couchbase-2.0/couchbase-2.0.gradle
+++ b/dd-java-agent/instrumentation/couchbase-2.0/couchbase-2.0.gradle
@@ -14,11 +14,22 @@ testSets {
 }
 
 muzzle {
+  // Version 2.7.5 was not released properly and muzzle cannot test against it causing failure.
+  // So we have to skip it resulting in this verbose setup.
+  fail {
+    group = 'com.couchbase.client'
+    module = 'java-client'
+    versions = "[,2.0.0)"
+  }
   pass {
     group = 'com.couchbase.client'
     module = 'java-client'
-    versions = "[2.0.0,)"
-    assertInverse = true
+    versions = "[2.0.0,2.7.5)"
+  }
+  pass {
+    group = 'com.couchbase.client'
+    module = 'java-client'
+    versions = "[2.7.6,)"
   }
   fail {
     group = 'com.couchbase.client'


### PR DESCRIPTION
Looks like 2.7.5 has now fully propagated through the mirrors so we
can revert hack that made things compile.