### PR TITLE
Set kafka client service name to application default service name.

### DIFF
--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaDecorator.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaDecorator.java
@@ -13,6 +13,11 @@ public abstract class KafkaDecorator extends ClientDecorator {
   public static final KafkaDecorator PRODUCER_DECORATE =
       new KafkaDecorator() {
         @Override
+        protected String service() {
+          return "kafka";
+        }
+
+        @Override
         protected String spanKind() {
           return Tags.SPAN_KIND_PRODUCER;
         }
@@ -25,6 +30,16 @@ public abstract class KafkaDecorator extends ClientDecorator {
 
   public static final KafkaDecorator CONSUMER_DECORATE =
       new KafkaDecorator() {
+        @Override
+        protected String service() {
+          /*
+            Use default service name. Common use-case here is to have consumer span parent
+            children spans in instrumented application. Since service name is inherited it makes
+            sense to default that to application service name rather than 'kafka'.
+          */
+          return null;
+        }
+
         @Override
         protected String spanKind() {
           return Tags.SPAN_KIND_CONSUMER;
@@ -39,11 +54,6 @@ public abstract class KafkaDecorator extends ClientDecorator {
   @Override
   protected String[] instrumentationNames() {
     return new String[] {"kafka"};
-  }
-
-  @Override
-  protected String service() {
-    return "kafka";
   }
 
   @Override

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTest.groovy
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTest.groovy
@@ -94,7 +94,7 @@ class KafkaClientTest extends AgentTestRunner {
       trace(1, 1) {
         // CONSUMER span 0
         span(0) {
-          serviceName "kafka"
+          serviceName "unnamed-java-app"
           operationName "kafka.consume"
           resourceName "Consume Topic $SHARED_TOPIC"
           spanType "queue"

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/src/test/groovy/KafkaStreamsTest.groovy
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/src/test/groovy/KafkaStreamsTest.groovy
@@ -80,13 +80,13 @@ class KafkaStreamsTest extends AgentTestRunner {
     KStream<String, String> textLines = builder.stream(STREAM_PENDING)
     def values = textLines
       .mapValues(new ValueMapper<String, String>() {
-      @Override
-      String apply(String textLine) {
-        TEST_WRITER.waitForTraces(1) // ensure consistent ordering of traces
-        getTestTracer().activeSpan().setTag("asdf", "testing")
-        return textLine.toLowerCase()
-      }
-    })
+        @Override
+        String apply(String textLine) {
+          TEST_WRITER.waitForTraces(1) // ensure consistent ordering of traces
+          getTestTracer().activeSpan().setTag("asdf", "testing")
+          return textLine.toLowerCase()
+        }
+      })
 
     KafkaStreams streams
     try {
@@ -172,7 +172,7 @@ class KafkaStreamsTest extends AgentTestRunner {
       trace(2, 1) {
         // CONSUMER span 0
         span(0) {
-          serviceName "kafka"
+          serviceName "unnamed-java-app"
           operationName "kafka.consume"
           resourceName "Consume Topic $STREAM_PROCESSED"
           spanType "queue"


### PR DESCRIPTION
So that spans inheriting from that client span have application
service name rather than 'kafka'