### PR TITLE
Use default service name for RabbitMQ consumer

### DIFF
--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitDecorator.java
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitDecorator.java
@@ -28,6 +28,16 @@ public class RabbitDecorator extends ClientDecorator {
   public static final RabbitDecorator CONSUMER_DECORATE =
       new RabbitDecorator() {
         @Override
+        protected String service() {
+          /*
+            Use default service name. Common use-case here is to have consumer span parent
+            children spans in instrumented application. Since service name is inherited it makes
+            sense to default that to application service name rather than 'rabbitmq'.
+          */
+          return null;
+        }
+
+        @Override
         protected String spanKind() {
           return Tags.SPAN_KIND_CONSUMER;
         }

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/test/groovy/RabbitMQTest.groovy
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/test/groovy/RabbitMQTest.groovy
@@ -341,7 +341,14 @@ class RabbitMQTest extends AgentTestRunner {
     String errorMsg = null
   ) {
     trace.span(index) {
-      serviceName "rabbitmq"
+      switch (span.tags["amqp.command"]) {
+        case "basic.get":
+        case "basic.deliver":
+          serviceName "unnamed-java-app"
+          break
+        default:
+          serviceName "rabbitmq"
+      }
       operationName "amqp.command"
       resourceName resource
       switch (span.tags["amqp.command"]) {


### PR DESCRIPTION
So spans parented by consumer span had reasonable service name