### PR TITLE
 Add http.query.string tag when enabled

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/decorator/BaseDecorator.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/decorator/BaseDecorator.java
@@ -1,6 +1,7 @@
 package datadog.trace.agent.decorator;
 
 import static io.opentracing.log.Fields.ERROR_OBJECT;
+import static java.util.Collections.singletonMap;
 
 import datadog.trace.api.Config;
 import datadog.trace.api.DDTags;
@@ -13,8 +14,8 @@ import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.TreeSet;
+import java.util.concurrent.ExecutionException;
 
 public abstract class BaseDecorator {
 
@@ -83,7 +84,10 @@ public abstract class BaseDecorator {
     assert span != null;
     if (throwable != null) {
       Tags.ERROR.set(span, true);
-      span.log(Collections.singletonMap(ERROR_OBJECT, throwable));
+      span.log(
+          singletonMap(
+              ERROR_OBJECT,
+              throwable instanceof ExecutionException ? throwable.getCause() : throwable));
     }
     return span;
   }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/decorator/HttpClientDecorator.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/decorator/HttpClientDecorator.java
@@ -61,6 +61,11 @@ public abstract class HttpClientDecorator<REQUEST, RESPONSE> extends ClientDecor
           }
 
           Tags.HTTP_URL.set(span, urlNoParams.toString());
+
+          if (Config.get().isHttpClientTagQueryString()) {
+            span.setTag("http.query.string", url.getQuery());
+            span.setTag("http.fragment.string", url.getFragment());
+          }
         }
       } catch (final Exception e) {
         log.debug("Error tagging url", e);

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/decorator/HttpServerDecorator.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/decorator/HttpServerDecorator.java
@@ -67,6 +67,11 @@ public abstract class HttpServerDecorator<REQUEST, CONNECTION, RESPONSE> extends
           }
 
           Tags.HTTP_URL.set(span, urlNoParams.toString());
+
+          if (Config.get().isHttpServerTagQueryString()) {
+            span.setTag("http.query.string", url.getQuery());
+            span.setTag("http.fragment.string", url.getFragment());
+          }
         }
       } catch (final Exception e) {
         log.debug("Error tagging url", e);

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/decorator/BaseDecoratorTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/decorator/BaseDecoratorTest.groovy
@@ -1,5 +1,7 @@
 package datadog.trace.agent.decorator
 
+
+import datadog.trace.agent.test.utils.ConfigUtils
 import datadog.trace.api.DDTags
 import io.opentracing.Scope
 import io.opentracing.Span
@@ -7,10 +9,14 @@ import io.opentracing.tag.Tags
 import spock.lang.Shared
 import spock.lang.Specification
 
-import static datadog.trace.agent.test.utils.TraceUtils.withSystemProperty
+import static datadog.trace.agent.test.utils.ConfigUtils.withSystemProperty
 import static io.opentracing.log.Fields.ERROR_OBJECT
 
 class BaseDecoratorTest extends Specification {
+
+  static {
+    ConfigUtils.makeConfigInstanceModifiable()
+  }
 
   @Shared
   def decorator = newDecorator()
@@ -268,10 +274,12 @@ class BaseDecoratorTest extends Specification {
   }
 
   class SomeInnerClass implements Runnable {
-    void run() {}
+    void run() {
+    }
   }
 
   static class SomeNestedClass implements Runnable {
-    void run() {}
+    void run() {
+    }
   }
 }

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/decorator/HttpClientDecoratorTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/decorator/HttpClientDecoratorTest.groovy
@@ -6,7 +6,7 @@ import io.opentracing.Span
 import io.opentracing.tag.Tags
 import spock.lang.Shared
 
-import static datadog.trace.agent.test.utils.TraceUtils.withConfigOverride
+import static datadog.trace.agent.test.utils.ConfigUtils.withConfigOverride
 
 class HttpClientDecoratorTest extends ClientDecoratorTest {
 

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/decorator/HttpClientDecoratorTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/decorator/HttpClientDecoratorTest.groovy
@@ -44,16 +44,22 @@ class HttpClientDecoratorTest extends ClientDecoratorTest {
     true          | [method: "test-method", url: testUrl, host: "test-host", port: 555]
   }
 
-  def "test url handling"() {
+  def "test url handling for #url"() {
     setup:
     def decorator = newDecorator()
 
     when:
-    decorator.onRequest(span, req)
+    withConfigOverride(Config.HTTP_CLIENT_TAG_QUERY_STRING, "$tagQueryString") {
+      decorator.onRequest(span, req)
+    }
 
     then:
-    if (expected) {
-      1 * span.setTag(Tags.HTTP_URL.key, expected)
+    if (expectedUrl) {
+      1 * span.setTag(Tags.HTTP_URL.key, expectedUrl)
+    }
+    if (expectedUrl && tagQueryString) {
+      1 * span.setTag("http.query.string", expectedQuery)
+      1 * span.setTag("http.fragment.string", expectedFragment)
     }
     1 * span.setTag(Tags.HTTP_METHOD.key, null)
     1 * span.setTag(Tags.PEER_HOSTNAME.key, null)
@@ -61,13 +67,19 @@ class HttpClientDecoratorTest extends ClientDecoratorTest {
     0 * _
 
     where:
-    url                                  | expected
-    null                                 | null
-    ""                                   | "/"
-    "/path?query"                        | "/path"
-    "https://host:0"                     | "https://host/"
-    "https://host/path"                  | "https://host/path"
-    "http://host:99/path?query#fragment" | "http://host:99/path"
+    tagQueryString | url                                                   | expectedUrl           | expectedQuery      | expectedFragment
+    false          | null                                                  | null                  | null               | null
+    false          | ""                                                    | "/"                   | ""                 | null
+    false          | "/path?query"                                         | "/path"               | ""                 | null
+    false          | "https://host:0"                                      | "https://host/"       | ""                 | null
+    false          | "https://host/path"                                   | "https://host/path"   | ""                 | null
+    false          | "http://host:99/path?query#fragment"                  | "http://host:99/path" | ""                 | null
+    true           | null                                                  | null                  | null               | null
+    true           | ""                                                    | "/"                   | null               | null
+    true           | "/path?encoded+%28query%29%3F"                        | "/path"               | "encoded+(query)?" | null
+    true           | "https://host:0"                                      | "https://host/"       | null               | null
+    true           | "https://host/path"                                   | "https://host/path"   | null               | null
+    true           | "http://host:99/path?query#encoded+%28fragment%29%3F" | "http://host:99/path" | "query"            | "encoded+(fragment)?"
 
     req = [url: url == null ? null : new URI(url)]
   }

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/decorator/HttpServerDecoratorTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/decorator/HttpServerDecoratorTest.groovy
@@ -4,7 +4,7 @@ import datadog.trace.api.Config
 import io.opentracing.Span
 import io.opentracing.tag.Tags
 
-import static datadog.trace.agent.test.utils.TraceUtils.withConfigOverride
+import static datadog.trace.agent.test.utils.ConfigUtils.withConfigOverride
 
 class HttpServerDecoratorTest extends ServerDecoratorTest {
 

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/decorator/HttpServerDecoratorTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/decorator/HttpServerDecoratorTest.groovy
@@ -55,19 +55,20 @@ class HttpServerDecoratorTest extends ServerDecoratorTest {
     0 * _
 
     where:
-    tagQueryString | url                                                   | expectedUrl           | expectedQuery      | expectedFragment
-    false          | null                                                  | null                  | null               | null
-    false          | ""                                                    | "/"                   | ""                 | null
-    false          | "/path?query"                                         | "/path"               | ""                 | null
-    false          | "https://host:0"                                      | "https://host/"       | ""                 | null
-    false          | "https://host/path"                                   | "https://host/path"   | ""                 | null
-    false          | "http://host:99/path?query#fragment"                  | "http://host:99/path" | ""                 | null
-    true           | null                                                  | null                  | null               | null
-    true           | ""                                                    | "/"                   | null               | null
-    true           | "/path?encoded+%28query%29%3F"                        | "/path"               | "encoded+(query)?" | null
-    true           | "https://host:0"                                      | "https://host/"       | null               | null
-    true           | "https://host/path"                                   | "https://host/path"   | null               | null
-    true           | "http://host:99/path?query#encoded+%28fragment%29%3F" | "http://host:99/path" | "query"            | "encoded+(fragment)?"
+    tagQueryString | url                                                    | expectedUrl           | expectedQuery       | expectedFragment
+    false          | null                                                   | null                  | null                | null
+    false          | ""                                                     | "/"                   | ""                  | null
+    false          | "/path?query"                                          | "/path"               | ""                  | null
+    false          | "https://host:0"                                       | "https://host/"       | ""                  | null
+    false          | "https://host/path"                                    | "https://host/path"   | ""                  | null
+    false          | "http://host:99/path?query#fragment"                   | "http://host:99/path" | ""                  | null
+    true           | null                                                   | null                  | null                | null
+    true           | ""                                                     | "/"                   | null                | null
+    true           | "/path?encoded+%28query%29%3F?"                        | "/path"               | "encoded+(query)??" | null
+    true           | "https://host:0"                                       | "https://host/"       | null                | null
+    true           | "https://host/path"                                    | "https://host/path"   | null                | null
+    true           | "http://host:99/path?query#enc+%28fragment%29%3F"      | "http://host:99/path" | "query"             | "enc+(fragment)?"
+    true           | "http://host:99/path?query#enc+%28fragment%29%3F?tail" | "http://host:99/path" | "query"             | "enc+(fragment)??tail"
 
     req = [url: url == null ? null : new URI(url)]
   }

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/decorator/HttpServerDecoratorTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/decorator/HttpServerDecoratorTest.groovy
@@ -34,28 +34,40 @@ class HttpServerDecoratorTest extends ServerDecoratorTest {
     [method: "test-method", url: URI.create("http://123:8080/some/path")]  | "http://123:8080/some/path"
   }
 
-  def "test url handling"() {
+  def "test url handling for #url"() {
     setup:
     def decorator = newDecorator()
 
     when:
-    decorator.onRequest(span, req)
+    withConfigOverride(Config.HTTP_SERVER_TAG_QUERY_STRING, "$tagQueryString") {
+      decorator.onRequest(span, req)
+    }
 
     then:
-    if (expected) {
-      1 * span.setTag(Tags.HTTP_URL.key, expected)
+    if (expectedUrl) {
+      1 * span.setTag(Tags.HTTP_URL.key, expectedUrl)
+    }
+    if (expectedUrl && tagQueryString) {
+      1 * span.setTag("http.query.string", expectedQuery)
+      1 * span.setTag("http.fragment.string", expectedFragment)
     }
     1 * span.setTag(Tags.HTTP_METHOD.key, null)
     0 * _
 
     where:
-    url                                  | expected
-    null                                 | null
-    ""                                   | "/"
-    "/path?query"                        | "/path"
-    "https://host:0"                     | "https://host/"
-    "https://host/path"                  | "https://host/path"
-    "http://host:99/path?query#fragment" | "http://host:99/path"
+    tagQueryString | url                                                   | expectedUrl           | expectedQuery      | expectedFragment
+    false          | null                                                  | null                  | null               | null
+    false          | ""                                                    | "/"                   | ""                 | null
+    false          | "/path?query"                                         | "/path"               | ""                 | null
+    false          | "https://host:0"                                      | "https://host/"       | ""                 | null
+    false          | "https://host/path"                                   | "https://host/path"   | ""                 | null
+    false          | "http://host:99/path?query#fragment"                  | "http://host:99/path" | ""                 | null
+    true           | null                                                  | null                  | null               | null
+    true           | ""                                                    | "/"                   | null               | null
+    true           | "/path?encoded+%28query%29%3F"                        | "/path"               | "encoded+(query)?" | null
+    true           | "https://host:0"                                      | "https://host/"       | null               | null
+    true           | "https://host/path"                                   | "https://host/path"   | null               | null
+    true           | "http://host:99/path?query#encoded+%28fragment%29%3F" | "http://host:99/path" | "query"            | "encoded+(fragment)?"
 
     req = [url: url == null ? null : new URI(url)]
   }

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/test/DefaultInstrumenterTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/test/DefaultInstrumenterTest.groovy
@@ -1,5 +1,6 @@
 package datadog.trace.agent.test
 
+import datadog.trace.agent.test.utils.ConfigUtils
 import datadog.trace.agent.tooling.Instrumenter
 import net.bytebuddy.agent.builder.AgentBuilder
 import net.bytebuddy.description.type.TypeDescription
@@ -10,6 +11,10 @@ import org.junit.contrib.java.lang.system.RestoreSystemProperties
 import spock.lang.Specification
 
 class DefaultInstrumenterTest extends Specification {
+  static {
+    ConfigUtils.makeConfigInstanceModifiable()
+  }
+
   @Rule
   public final RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties()
   @Rule

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/test/HelperInjectionTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/test/HelperInjectionTest.groovy
@@ -1,6 +1,6 @@
 package datadog.trace.agent.test
 
-
+import datadog.trace.agent.test.utils.ConfigUtils
 import datadog.trace.agent.tooling.AgentInstaller
 import datadog.trace.agent.tooling.HelperInjector
 import datadog.trace.agent.tooling.Utils
@@ -19,6 +19,9 @@ import static datadog.trace.agent.tooling.ClassLoaderMatcher.BOOTSTRAP_CLASSLOAD
 import static datadog.trace.util.gc.GCUtils.awaitGC
 
 class HelperInjectionTest extends Specification {
+  static {
+    ConfigUtils.makeConfigInstanceModifiable()
+  }
 
   @Timeout(10)
   def "helpers injected to non-delegating classloader"() {

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpClientInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpClientInstrumentationTest.groovy
@@ -11,7 +11,6 @@ import io.opentracing.tag.Tags
 import spock.lang.Shared
 
 class AkkaHttpClientInstrumentationTest extends HttpClientTest<AkkaHttpClientDecorator> {
-  private static final long TIMEOUT = 10000L
 
   @Shared
   ActorSystem system = ActorSystem.create()

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpClientInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpClientInstrumentationTest.groovy
@@ -28,6 +28,7 @@ class AkkaHttpClientInstrumentationTest extends HttpClientTest<AkkaHttpClientDec
       .addHeaders(headers.collect { RawHeader.create(it.key, it.value) })
 
     def response = Http.get(system).singleRequest(request, materializer).toCompletableFuture().get()
+    blockUntilChildSpansFinished(1)
     callback?.call()
     return response.status().intValue()
   }

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpClientInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpClientInstrumentationTest.groovy
@@ -17,10 +17,6 @@ class AkkaHttpClientInstrumentationTest extends HttpClientTest<AkkaHttpClientDec
   @Shared
   ActorMaterializer materializer = ActorMaterializer.create(system)
 
-//  String readMessage(HttpResponse response) {
-//    response.entity().toStrict(TIMEOUT, materializer).toCompletableFuture().get().getData().utf8String()
-//  }
-
   @Override
   int doRequest(String method, URI uri, Map<String, String> headers, Closure callback) {
     def request = HttpRequest.create(uri.toString())

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpClientPoolInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpClientPoolInstrumentationTest.groovy
@@ -22,11 +22,6 @@ class AkkaHttpClientPoolInstrumentationTest extends HttpClientTest<AkkaHttpClien
 
   def pool = Http.get(system).superPool(materializer)
 
-
-//  String readMessage(HttpResponse response) {
-//    response.entity().toStrict(TIMEOUT, materializer).toCompletableFuture().get().getData().utf8String()
-//  }
-
   @Override
   int doRequest(String method, URI uri, Map<String, String> headers, Closure callback) {
     def request = HttpRequest.create(uri.toString())

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpClientPoolInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpClientPoolInstrumentationTest.groovy
@@ -2,21 +2,27 @@ import akka.actor.ActorSystem
 import akka.http.javadsl.Http
 import akka.http.javadsl.model.HttpMethods
 import akka.http.javadsl.model.HttpRequest
+import akka.http.javadsl.model.HttpResponse
 import akka.http.javadsl.model.headers.RawHeader
+import akka.japi.Pair
 import akka.stream.ActorMaterializer
+import akka.stream.javadsl.Sink
+import akka.stream.javadsl.Source
 import datadog.trace.agent.test.base.HttpClientTest
-import datadog.trace.api.DDSpanTypes
 import datadog.trace.instrumentation.akkahttp.AkkaHttpClientDecorator
-import io.opentracing.tag.Tags
+import scala.util.Try
 import spock.lang.Shared
 
-class AkkaHttpClientInstrumentationTest extends HttpClientTest<AkkaHttpClientDecorator> {
+class AkkaHttpClientPoolInstrumentationTest extends HttpClientTest<AkkaHttpClientDecorator> {
   private static final long TIMEOUT = 10000L
 
   @Shared
   ActorSystem system = ActorSystem.create()
   @Shared
   ActorMaterializer materializer = ActorMaterializer.create(system)
+
+  def pool = Http.get(system).superPool(materializer)
+
 
 //  String readMessage(HttpResponse response) {
 //    response.entity().toStrict(TIMEOUT, materializer).toCompletableFuture().get().getData().utf8String()
@@ -28,7 +34,11 @@ class AkkaHttpClientInstrumentationTest extends HttpClientTest<AkkaHttpClientDec
       .withMethod(HttpMethods.lookup(method).get())
       .addHeaders(headers.collect { RawHeader.create(it.key, it.value) })
 
-    def response = Http.get(system).singleRequest(request, materializer).toCompletableFuture().get()
+    def response = Source
+      .<Pair<HttpRequest, Integer>> single(new Pair(request, 1))
+      .via(pool)
+      .runWith(Sink.<Pair<Try<HttpResponse>, Integer>> head(), materializer)
+      .toCompletableFuture().get().first().get()
     callback?.call()
     return response.status().intValue()
   }
@@ -45,36 +55,5 @@ class AkkaHttpClientInstrumentationTest extends HttpClientTest<AkkaHttpClientDec
 
   boolean testRedirects() {
     false
-  }
-
-  def "singleRequest exception trace"() {
-    when:
-    // Passing null causes NPE in singleRequest
-    Http.get(system).singleRequest(null, materializer)
-
-    then:
-    thrown NullPointerException
-    assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
-          parent()
-          serviceName "unnamed-java-app"
-          operationName "akka-http.request"
-          resourceName "akka-http.request"
-          spanType DDSpanTypes.HTTP_CLIENT
-          errored true
-          tags {
-            defaultTags()
-            "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$Tags.COMPONENT.key" "akka-http-client"
-            "$Tags.ERROR.key" true
-            errorTags(NullPointerException)
-          }
-        }
-      }
-    }
-
-    where:
-    renameService << [false, true]
   }
 }

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpClientPoolInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpClientPoolInstrumentationTest.groovy
@@ -14,7 +14,6 @@ import scala.util.Try
 import spock.lang.Shared
 
 class AkkaHttpClientPoolInstrumentationTest extends HttpClientTest<AkkaHttpClientDecorator> {
-  private static final long TIMEOUT = 10000L
 
   @Shared
   ActorSystem system = ActorSystem.create()

--- a/dd-java-agent/instrumentation/apache-httpasyncclient-4/apache-httpasyncclient-4.gradle
+++ b/dd-java-agent/instrumentation/apache-httpasyncclient-4/apache-httpasyncclient-4.gradle
@@ -32,6 +32,8 @@ dependencies {
   implementation deps.autoservice
 
   testCompile project(':dd-java-agent:testing')
+  testCompile project(':dd-java-agent:instrumentation:java-concurrent')
+  
   testCompile group: 'org.apache.httpcomponents', name: 'httpasyncclient', version: '4.0'
 
   latestDepTestCompile group: 'org.apache.httpcomponents', name: 'httpasyncclient', version: '+'

--- a/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/test/groovy/ApacheHttpAsyncClientCallbackTest.groovy
+++ b/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/test/groovy/ApacheHttpAsyncClientCallbackTest.groovy
@@ -2,7 +2,6 @@ import datadog.trace.agent.test.base.HttpClientTest
 import datadog.trace.instrumentation.apachehttpasyncclient.ApacheHttpAsyncClientDecorator
 import io.opentracing.util.GlobalTracer
 import org.apache.http.HttpResponse
-import org.apache.http.client.methods.HttpGet
 import org.apache.http.concurrent.FutureCallback
 import org.apache.http.impl.nio.client.HttpAsyncClients
 import org.apache.http.message.BasicHeader
@@ -23,11 +22,9 @@ class ApacheHttpAsyncClientCallbackTest extends HttpClientTest<ApacheHttpAsyncCl
 
   @Override
   int doRequest(String method, URI uri, Map<String, String> headers, Closure callback) {
-    assert method == "GET"
-
     def hasParent = GlobalTracer.get().activeSpan() != null
 
-    HttpGet request = new HttpGet(uri)
+    def request = new HttpUriRequest(method, uri)
     headers.entrySet().each {
       request.addHeader(new BasicHeader(it.key, it.value))
     }

--- a/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/test/groovy/ApacheHttpAsyncClientNullCallbackTest.groovy
+++ b/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/test/groovy/ApacheHttpAsyncClientNullCallbackTest.groovy
@@ -1,6 +1,5 @@
 import datadog.trace.agent.test.base.HttpClientTest
 import datadog.trace.instrumentation.apachehttpasyncclient.ApacheHttpAsyncClientDecorator
-import org.apache.http.client.methods.HttpGet
 import org.apache.http.impl.nio.client.HttpAsyncClients
 import org.apache.http.message.BasicHeader
 import spock.lang.AutoCleanup
@@ -20,9 +19,7 @@ class ApacheHttpAsyncClientNullCallbackTest extends HttpClientTest<ApacheHttpAsy
 
   @Override
   int doRequest(String method, URI uri, Map<String, String> headers, Closure callback) {
-    assert method == "GET"
-
-    HttpGet request = new HttpGet(uri)
+    def request = new HttpUriRequest(method, uri)
     headers.entrySet().each {
       request.addHeader(new BasicHeader(it.key, it.value))
     }

--- a/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/test/groovy/ApacheHttpAsyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/test/groovy/ApacheHttpAsyncClientTest.groovy
@@ -1,7 +1,6 @@
 import datadog.trace.agent.test.base.HttpClientTest
 import datadog.trace.instrumentation.apachehttpasyncclient.ApacheHttpAsyncClientDecorator
 import org.apache.http.HttpResponse
-import org.apache.http.client.methods.HttpGet
 import org.apache.http.concurrent.FutureCallback
 import org.apache.http.impl.nio.client.HttpAsyncClients
 import org.apache.http.message.BasicHeader
@@ -20,8 +19,7 @@ class ApacheHttpAsyncClientTest extends HttpClientTest<ApacheHttpAsyncClientDeco
 
   @Override
   int doRequest(String method, URI uri, Map<String, String> headers, Closure callback) {
-    assert method == "GET"
-    HttpGet request = new HttpGet(uri)
+    def request = new HttpUriRequest(method, uri)
     headers.entrySet().each {
       request.addHeader(new BasicHeader(it.key, it.value))
     }
@@ -43,7 +41,7 @@ class ApacheHttpAsyncClientTest extends HttpClientTest<ApacheHttpAsyncClientDeco
     }
 
     def response = client.execute(request, handler).get()
-    response.entity.getContent().close() // Make sure the connection is closed.
+    response.entity?.content?.close() // Make sure the connection is closed.
     response.statusLine.statusCode
   }
 

--- a/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/test/groovy/HttpUriRequest.groovy
+++ b/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/test/groovy/HttpUriRequest.groovy
@@ -2,15 +2,15 @@ import org.apache.http.client.methods.HttpRequestBase
 
 class HttpUriRequest extends HttpRequestBase {
 
-  private final String methodName;
+  private final String methodName
 
   HttpUriRequest(final String methodName, final URI uri) {
-    this.methodName = methodName;
-    setURI(uri);
+    this.methodName = methodName
+    setURI(uri)
   }
 
   @Override
   String getMethod() {
-    return methodName;
+    return methodName
   }
 }

--- a/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/test/groovy/HttpUriRequest.groovy
+++ b/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/test/groovy/HttpUriRequest.groovy
@@ -1,0 +1,16 @@
+import org.apache.http.client.methods.HttpRequestBase
+
+class HttpUriRequest extends HttpRequestBase {
+
+  private final String methodName;
+
+  HttpUriRequest(final String methodName, final URI uri) {
+    this.methodName = methodName;
+    setURI(uri);
+  }
+
+  @Override
+  String getMethod() {
+    return methodName;
+  }
+}

--- a/dd-java-agent/instrumentation/apache-httpclient-4/src/test/groovy/ApacheHttpClientResponseHandlerTest.groovy
+++ b/dd-java-agent/instrumentation/apache-httpclient-4/src/test/groovy/ApacheHttpClientResponseHandlerTest.groovy
@@ -2,7 +2,6 @@ import datadog.trace.agent.test.base.HttpClientTest
 import datadog.trace.instrumentation.apachehttpclient.ApacheHttpClientDecorator
 import org.apache.http.HttpResponse
 import org.apache.http.client.ResponseHandler
-import org.apache.http.client.methods.HttpGet
 import org.apache.http.impl.client.DefaultHttpClient
 import org.apache.http.message.BasicHeader
 import spock.lang.Shared
@@ -22,8 +21,7 @@ class ApacheHttpClientResponseHandlerTest extends HttpClientTest<ApacheHttpClien
 
   @Override
   int doRequest(String method, URI uri, Map<String, String> headers, Closure callback) {
-    assert method == "GET"
-    HttpGet request = new HttpGet(uri)
+    def request = new HttpUriRequest(method, uri)
     headers.entrySet().each {
       request.addHeader(new BasicHeader(it.key, it.value))
     }

--- a/dd-java-agent/instrumentation/apache-httpclient-4/src/test/groovy/ApacheHttpClientTest.groovy
+++ b/dd-java-agent/instrumentation/apache-httpclient-4/src/test/groovy/ApacheHttpClientTest.groovy
@@ -1,6 +1,5 @@
 import datadog.trace.agent.test.base.HttpClientTest
 import datadog.trace.instrumentation.apachehttpclient.ApacheHttpClientDecorator
-import org.apache.http.client.methods.HttpGet
 import org.apache.http.impl.client.DefaultHttpClient
 import org.apache.http.message.BasicHeader
 import spock.lang.Shared
@@ -12,16 +11,16 @@ class ApacheHttpClientTest extends HttpClientTest<ApacheHttpClientDecorator> {
 
   @Override
   int doRequest(String method, URI uri, Map<String, String> headers, Closure callback) {
-    assert method == "GET"
-    HttpGet request = new HttpGet(uri)
+    def request = new HttpUriRequest(method, uri)
     headers.entrySet().each {
       request.addHeader(new BasicHeader(it.key, it.value))
     }
 
     def response = client.execute(request)
     callback?.call()
-    response.entity.getContent().close() // Make sure the connection is closed.
-    response.statusLine.statusCode
+    response.entity?.content?.close() // Make sure the connection is closed.
+
+    return response.statusLine.statusCode
   }
 
   @Override

--- a/dd-java-agent/instrumentation/apache-httpclient-4/src/test/groovy/HttpUriRequest.groovy
+++ b/dd-java-agent/instrumentation/apache-httpclient-4/src/test/groovy/HttpUriRequest.groovy
@@ -2,15 +2,15 @@ import org.apache.http.client.methods.HttpRequestBase
 
 class HttpUriRequest extends HttpRequestBase {
 
-  private final String methodName;
+  private final String methodName
 
   HttpUriRequest(final String methodName, final URI uri) {
-    this.methodName = methodName;
-    setURI(uri);
+    this.methodName = methodName
+    setURI(uri)
   }
 
   @Override
   String getMethod() {
-    return methodName;
+    return methodName
   }
 }

--- a/dd-java-agent/instrumentation/apache-httpclient-4/src/test/groovy/HttpUriRequest.groovy
+++ b/dd-java-agent/instrumentation/apache-httpclient-4/src/test/groovy/HttpUriRequest.groovy
@@ -1,0 +1,16 @@
+import org.apache.http.client.methods.HttpRequestBase
+
+class HttpUriRequest extends HttpRequestBase {
+
+  private final String methodName;
+
+  HttpUriRequest(final String methodName, final URI uri) {
+    this.methodName = methodName;
+    setURI(uri);
+  }
+
+  @Override
+  String getMethod() {
+    return methodName;
+  }
+}

--- a/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionResponseCodeOnlyTest.groovy
+++ b/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionResponseCodeOnlyTest.groovy
@@ -1,0 +1,29 @@
+import datadog.trace.agent.test.base.HttpClientTest
+import datadog.trace.instrumentation.http_url_connection.HttpUrlConnectionDecorator
+
+class HttpUrlConnectionResponseCodeOnlyTest extends HttpClientTest<HttpUrlConnectionDecorator> {
+
+  @Override
+  int doRequest(String method, URI uri, Map<String, String> headers, Closure callback) {
+    HttpURLConnection connection = uri.toURL().openConnection()
+    try {
+      connection.setRequestMethod(method)
+      headers.each { connection.setRequestProperty(it.key, it.value) }
+      connection.setRequestProperty("Connection", "close")
+      return connection.getResponseCode()
+    } finally {
+      callback?.call()
+      connection.disconnect()
+    }
+  }
+
+  @Override
+  HttpUrlConnectionDecorator decorator() {
+    return HttpUrlConnectionDecorator.DECORATE
+  }
+
+  @Override
+  boolean testRedirects() {
+    false
+  }
+}

--- a/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionTest.groovy
+++ b/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionTest.groovy
@@ -1,41 +1,59 @@
-import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.agent.test.base.HttpClientTest
 import datadog.trace.api.Config
 import datadog.trace.api.DDSpanTypes
+import datadog.trace.instrumentation.http_url_connection.HttpUrlConnectionDecorator
 import io.opentracing.tag.Tags
 import io.opentracing.util.GlobalTracer
-import org.springframework.web.client.RestTemplate
-import spock.lang.AutoCleanup
+import spock.lang.Ignore
 import spock.lang.Requires
-import spock.lang.Shared
 import sun.net.www.protocol.https.HttpsURLConnectionImpl
 
-import static datadog.trace.agent.test.server.http.TestHttpServer.httpServer
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 import static datadog.trace.agent.test.utils.TraceUtils.withConfigOverride
 import static datadog.trace.instrumentation.http_url_connection.HttpUrlConnectionInstrumentation.HttpUrlState.OPERATION_NAME
 
-class HttpUrlConnectionTest extends AgentTestRunner {
+class HttpUrlConnectionTest extends HttpClientTest<HttpUrlConnectionDecorator> {
 
-  static final RESPONSE = "<html><body><h1>Hello test.</h1>"
-  static final STATUS = 202
+  static final RESPONSE = "Hello."
+  static final STATUS = 200
 
-  @AutoCleanup
-  @Shared
-  def server = httpServer {
-    handlers {
-      all {
-        handleDistributedRequest()
-
-        response.status(STATUS).send(RESPONSE)
-      }
+  @Override
+  int doRequest(String method, URI uri, Map<String, String> headers, Closure callback) {
+    HttpURLConnection connection = uri.toURL().openConnection()
+    try {
+      connection.setRequestMethod(method)
+      headers.each { connection.setRequestProperty(it.key, it.value) }
+      connection.setRequestProperty("Connection", "close")
+      connection.useCaches = true
+      def parentSpan = GlobalTracer.get().scopeManager().active()
+      def stream = connection.inputStream
+      assert GlobalTracer.get().scopeManager().active() == parentSpan
+      stream.readLines()
+      stream.close()
+      callback?.call()
+      return connection.getResponseCode()
+    } finally {
+      connection.disconnect()
     }
   }
 
+  @Override
+  HttpUrlConnectionDecorator decorator() {
+    return HttpUrlConnectionDecorator.DECORATE
+  }
+
+  @Override
+  boolean testRedirects() {
+    false
+  }
+
+  @Ignore
   def "trace request with propagation (useCaches: #useCaches)"() {
     setup:
+    def url = server.address.resolve("/success").toURL()
     withConfigOverride(Config.HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN, "$renameService") {
       runUnderTrace("someTrace") {
-        HttpURLConnection connection = server.address.toURL().openConnection()
+        HttpURLConnection connection = url.openConnection()
         connection.useCaches = useCaches
         assert GlobalTracer.get().scopeManager().active() != null
         def stream = connection.inputStream
@@ -45,7 +63,7 @@ class HttpUrlConnectionTest extends AgentTestRunner {
         assert lines == [RESPONSE]
 
         // call again to ensure the cycling is ok
-        connection = server.getAddress().toURL().openConnection()
+        connection = url.openConnection()
         connection.useCaches = useCaches
         assert GlobalTracer.get().scopeManager().active() != null
         assert connection.getResponseCode() == STATUS // call before input stream to test alternate behavior
@@ -73,14 +91,14 @@ class HttpUrlConnectionTest extends AgentTestRunner {
         span(1) {
           serviceName renameService ? "localhost" : "unnamed-java-app"
           operationName OPERATION_NAME
-          resourceName "GET /"
+          resourceName "GET $url.path"
           spanType DDSpanTypes.HTTP_CLIENT
           childOf span(0)
           errored false
           tags {
             "$Tags.COMPONENT.key" "http-url-connection"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$Tags.HTTP_URL.key" "$server.address/"
+            "$Tags.HTTP_URL.key" "$url"
             "$Tags.HTTP_METHOD.key" "GET"
             "$Tags.HTTP_STATUS.key" STATUS
             "$Tags.PEER_HOSTNAME.key" "localhost"
@@ -91,14 +109,14 @@ class HttpUrlConnectionTest extends AgentTestRunner {
         span(2) {
           serviceName renameService ? "localhost" : "unnamed-java-app"
           operationName OPERATION_NAME
-          resourceName "GET /"
+          resourceName "GET $url.path"
           spanType DDSpanTypes.HTTP_CLIENT
           childOf span(0)
           errored false
           tags {
             "$Tags.COMPONENT.key" "http-url-connection"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$Tags.HTTP_URL.key" "$server.address/"
+            "$Tags.HTTP_URL.key" "$url"
             "$Tags.HTTP_METHOD.key" "GET"
             "$Tags.HTTP_STATUS.key" STATUS
             "$Tags.PEER_HOSTNAME.key" "localhost"
@@ -114,11 +132,13 @@ class HttpUrlConnectionTest extends AgentTestRunner {
     renameService << [true, false]
   }
 
+  @Ignore
   def "trace request without propagation (useCaches: #useCaches)"() {
     setup:
+    def url = server.address.resolve("/success").toURL()
     withConfigOverride(Config.HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN, "$renameService") {
       runUnderTrace("someTrace") {
-        HttpURLConnection connection = server.address.toURL().openConnection()
+        HttpURLConnection connection = url.openConnection()
         connection.useCaches = useCaches
         connection.addRequestProperty("is-dd-server", "false")
         assert GlobalTracer.get().scopeManager().active() != null
@@ -130,7 +150,7 @@ class HttpUrlConnectionTest extends AgentTestRunner {
         assert lines == [RESPONSE]
 
         // call again to ensure the cycling is ok
-        connection = server.getAddress().toURL().openConnection()
+        connection = url.openConnection()
         connection.useCaches = useCaches
         connection.addRequestProperty("is-dd-server", "false")
         assert GlobalTracer.get().scopeManager().active() != null
@@ -156,14 +176,14 @@ class HttpUrlConnectionTest extends AgentTestRunner {
         span(1) {
           serviceName renameService ? "localhost" : "unnamed-java-app"
           operationName OPERATION_NAME
-          resourceName "GET /"
+          resourceName "GET $url.path"
           spanType DDSpanTypes.HTTP_CLIENT
           childOf span(0)
           errored false
           tags {
             "$Tags.COMPONENT.key" "http-url-connection"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$Tags.HTTP_URL.key" "$server.address/"
+            "$Tags.HTTP_URL.key" "$url"
             "$Tags.HTTP_METHOD.key" "GET"
             "$Tags.HTTP_STATUS.key" STATUS
             "$Tags.PEER_HOSTNAME.key" "localhost"
@@ -174,14 +194,14 @@ class HttpUrlConnectionTest extends AgentTestRunner {
         span(2) {
           serviceName renameService ? "localhost" : "unnamed-java-app"
           operationName OPERATION_NAME
-          resourceName "GET /"
+          resourceName "GET $url.path"
           spanType DDSpanTypes.HTTP_CLIENT
           childOf span(0)
           errored false
           tags {
             "$Tags.COMPONENT.key" "http-url-connection"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$Tags.HTTP_URL.key" "$server.address/"
+            "$Tags.HTTP_URL.key" "$url"
             "$Tags.HTTP_METHOD.key" "GET"
             "$Tags.HTTP_STATUS.key" STATUS
             "$Tags.PEER_HOSTNAME.key" "localhost"
@@ -197,59 +217,13 @@ class HttpUrlConnectionTest extends AgentTestRunner {
     renameService << [false, true]
   }
 
-  def "test response code"() {
-    setup:
-    withConfigOverride(Config.HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN, "$renameService") {
-      runUnderTrace("someTrace") {
-        HttpURLConnection connection = server.address.toURL().openConnection()
-        connection.setRequestMethod("HEAD")
-        connection.addRequestProperty("is-dd-server", "false")
-        assert GlobalTracer.get().scopeManager().active() != null
-        assert connection.getResponseCode() == STATUS
-      }
-    }
-
-    expect:
-    assertTraces(1) {
-      trace(0, 2) {
-        span(0) {
-          operationName "someTrace"
-          parent()
-          errored false
-          tags {
-            defaultTags()
-          }
-        }
-        span(1) {
-          serviceName renameService ? "localhost" : "unnamed-java-app"
-          operationName OPERATION_NAME
-          resourceName "HEAD /"
-          spanType DDSpanTypes.HTTP_CLIENT
-          childOf span(0)
-          errored false
-          tags {
-            "$Tags.COMPONENT.key" "http-url-connection"
-            "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$Tags.HTTP_URL.key" "$server.address/"
-            "$Tags.HTTP_METHOD.key" "HEAD"
-            "$Tags.HTTP_STATUS.key" STATUS
-            "$Tags.PEER_HOSTNAME.key" "localhost"
-            "$Tags.PEER_PORT.key" server.address.port
-            defaultTags()
-          }
-        }
-      }
-    }
-
-    where:
-    renameService << [false, true]
-  }
-
+  @Ignore
   def "test broken API usage"() {
     setup:
+    def url = server.address.resolve("/success").toURL()
     HttpURLConnection conn = withConfigOverride(Config.HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN, "$renameService") {
       runUnderTrace("someTrace") {
-        HttpURLConnection connection = server.address.toURL().openConnection()
+        HttpURLConnection connection = url.openConnection()
         connection.setRequestProperty("Connection", "close")
         connection.addRequestProperty("is-dd-server", "false")
         assert GlobalTracer.get().scopeManager().active() != null
@@ -272,14 +246,14 @@ class HttpUrlConnectionTest extends AgentTestRunner {
         span(1) {
           serviceName renameService ? "localhost" : "unnamed-java-app"
           operationName OPERATION_NAME
-          resourceName "GET /"
+          resourceName "GET $url.path"
           spanType DDSpanTypes.HTTP_CLIENT
           childOf span(0)
           errored false
           tags {
             "$Tags.COMPONENT.key" "http-url-connection"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$Tags.HTTP_URL.key" "$server.address/"
+            "$Tags.HTTP_URL.key" "$url"
             "$Tags.HTTP_METHOD.key" "GET"
             "$Tags.HTTP_STATUS.key" STATUS
             "$Tags.PEER_HOSTNAME.key" "localhost"
@@ -298,11 +272,13 @@ class HttpUrlConnectionTest extends AgentTestRunner {
     renameService = (iteration % 2 == 0) // alternate even/odd
   }
 
+  @Ignore
   def "test post request"() {
     setup:
+    def url = server.address.resolve("/success").toURL()
     withConfigOverride(Config.HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN, "$renameService") {
       runUnderTrace("someTrace") {
-        HttpURLConnection connection = server.address.toURL().openConnection()
+        HttpURLConnection connection = url.openConnection()
         connection.setRequestMethod("POST")
 
         String urlParameters = "q=ASDF&w=&e=&r=12345&t="
@@ -338,129 +314,14 @@ class HttpUrlConnectionTest extends AgentTestRunner {
         span(1) {
           serviceName renameService ? "localhost" : "unnamed-java-app"
           operationName OPERATION_NAME
-          resourceName "POST /"
+          resourceName "POST $url.path"
           spanType DDSpanTypes.HTTP_CLIENT
           childOf span(0)
           errored false
           tags {
             "$Tags.COMPONENT.key" "http-url-connection"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$Tags.HTTP_URL.key" "$server.address/"
-            "$Tags.HTTP_METHOD.key" "POST"
-            "$Tags.HTTP_STATUS.key" STATUS
-            "$Tags.PEER_HOSTNAME.key" "localhost"
-            "$Tags.PEER_PORT.key" server.address.port
-            defaultTags()
-          }
-        }
-      }
-    }
-
-    where:
-    renameService << [false, true]
-  }
-
-  def "request that looks like a trace submission is ignored"() {
-    setup:
-    runUnderTrace("someTrace") {
-      HttpURLConnection connection = server.address.toURL().openConnection()
-      connection.addRequestProperty("Datadog-Meta-Lang", "false")
-      connection.addRequestProperty("is-dd-server", "false")
-      def stream = connection.inputStream
-      def lines = stream.readLines()
-      stream.close()
-      assert connection.getResponseCode() == STATUS
-      assert lines == [RESPONSE]
-    }
-
-    expect:
-    assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
-          operationName "someTrace"
-          parent()
-          errored false
-          tags {
-            defaultTags()
-          }
-        }
-      }
-    }
-  }
-
-  def "top level httpurlconnection tracing disabled"() {
-    setup:
-    withConfigOverride(Config.HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN, "$renameService") {
-      HttpURLConnection connection = server.address.toURL().openConnection()
-      connection.addRequestProperty("is-dd-server", "false")
-      def stream = connection.inputStream
-      def lines = stream.readLines()
-      stream.close()
-      assert connection.getResponseCode() == STATUS
-      assert lines == [RESPONSE]
-    }
-
-    expect:
-    assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
-          serviceName renameService ? "localhost" : "unnamed-java-app"
-          operationName OPERATION_NAME
-          resourceName "GET /"
-          spanType DDSpanTypes.HTTP_CLIENT
-          parent()
-          errored false
-          tags {
-            "$Tags.COMPONENT.key" "http-url-connection"
-            "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$Tags.HTTP_URL.key" "$server.address/"
-            "$Tags.HTTP_METHOD.key" "GET"
-            "$Tags.HTTP_STATUS.key" STATUS
-            "$Tags.PEER_HOSTNAME.key" "localhost"
-            "$Tags.PEER_PORT.key" server.address.port
-            defaultTags()
-          }
-        }
-      }
-    }
-
-    where:
-    renameService << [false, true]
-  }
-
-  def "rest template"() {
-    setup:
-    withConfigOverride(Config.HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN, "$renameService") {
-      runUnderTrace("someTrace") {
-        RestTemplate restTemplate = new RestTemplate()
-        String res = restTemplate.postForObject(server.address.toString(), "Hello", String)
-        assert res == "$RESPONSE"
-      }
-    }
-
-    expect:
-    assertTraces(2) {
-      server.distributedRequestTrace(it, 0, TEST_WRITER[1][1])
-      trace(1, 2) {
-        span(0) {
-          operationName "someTrace"
-          parent()
-          errored false
-          tags {
-            defaultTags()
-          }
-        }
-        span(1) {
-          serviceName renameService ? "localhost" : "unnamed-java-app"
-          operationName OPERATION_NAME
-          resourceName "POST /"
-          spanType DDSpanTypes.HTTP_CLIENT
-          childOf span(0)
-          errored false
-          tags {
-            "$Tags.COMPONENT.key" "http-url-connection"
-            "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$Tags.HTTP_URL.key" "$server.address/"
+            "$Tags.HTTP_URL.key" "$url"
             "$Tags.HTTP_METHOD.key" "POST"
             "$Tags.HTTP_STATUS.key" STATUS
             "$Tags.PEER_HOSTNAME.key" "localhost"

--- a/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionTest.groovy
+++ b/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionTest.groovy
@@ -8,8 +8,8 @@ import spock.lang.Ignore
 import spock.lang.Requires
 import sun.net.www.protocol.https.HttpsURLConnectionImpl
 
+import static datadog.trace.agent.test.utils.ConfigUtils.withConfigOverride
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
-import static datadog.trace.agent.test.utils.TraceUtils.withConfigOverride
 import static datadog.trace.instrumentation.http_url_connection.HttpUrlConnectionInstrumentation.HttpUrlState.OPERATION_NAME
 
 class HttpUrlConnectionTest extends HttpClientTest<HttpUrlConnectionDecorator> {

--- a/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionUseCachesFalseTest.groovy
+++ b/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionUseCachesFalseTest.groovy
@@ -1,0 +1,36 @@
+import datadog.trace.agent.test.base.HttpClientTest
+import datadog.trace.instrumentation.http_url_connection.HttpUrlConnectionDecorator
+import io.opentracing.util.GlobalTracer
+
+class HttpUrlConnectionUseCachesFalseTest extends HttpClientTest<HttpUrlConnectionDecorator> {
+
+  @Override
+  int doRequest(String method, URI uri, Map<String, String> headers, Closure callback) {
+    HttpURLConnection connection = uri.toURL().openConnection()
+    try {
+      connection.setRequestMethod(method)
+      headers.each { connection.setRequestProperty(it.key, it.value) }
+      connection.setRequestProperty("Connection", "close")
+      connection.useCaches = false
+      def parentSpan = GlobalTracer.get().scopeManager().active()
+      def stream = connection.inputStream
+      assert GlobalTracer.get().scopeManager().active() == parentSpan
+      stream.readLines()
+      stream.close()
+      callback?.call()
+      return connection.getResponseCode()
+    } finally {
+      connection.disconnect()
+    }
+  }
+
+  @Override
+  HttpUrlConnectionDecorator decorator() {
+    return HttpUrlConnectionDecorator.DECORATE
+  }
+
+  @Override
+  boolean testRedirects() {
+    false
+  }
+}

--- a/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/SpringRestTemplateTest.groovy
+++ b/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/SpringRestTemplateTest.groovy
@@ -16,7 +16,7 @@ class SpringRestTemplateTest extends HttpClientTest<HttpUrlConnectionDecorator> 
   int doRequest(String method, URI uri, Map<String, String> headers, Closure callback) {
     def httpHeaders = new HttpHeaders()
     headers.each { httpHeaders.put(it.key, [it.value]) }
-    def request = new HttpEntity<String>(httpHeaders);
+    def request = new HttpEntity<String>(httpHeaders)
     ResponseEntity<String> response = restTemplate.exchange(uri, HttpMethod.resolve(method), request, String)
     callback?.call()
     return response.statusCode.value()

--- a/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/SpringRestTemplateTest.groovy
+++ b/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/SpringRestTemplateTest.groovy
@@ -1,0 +1,39 @@
+import datadog.trace.agent.test.base.HttpClientTest
+import datadog.trace.instrumentation.http_url_connection.HttpUrlConnectionDecorator
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpMethod
+import org.springframework.http.ResponseEntity
+import org.springframework.web.client.RestTemplate
+import spock.lang.Shared
+
+class SpringRestTemplateTest extends HttpClientTest<HttpUrlConnectionDecorator> {
+
+  @Shared
+  RestTemplate restTemplate = new RestTemplate()
+
+  @Override
+  int doRequest(String method, URI uri, Map<String, String> headers, Closure callback) {
+    def httpHeaders = new HttpHeaders()
+    headers.each { httpHeaders.put(it.key, [it.value]) }
+    def request = new HttpEntity<String>(httpHeaders);
+    ResponseEntity<String> response = restTemplate.exchange(uri, HttpMethod.resolve(method), request, String)
+    callback?.call()
+    return response.statusCode.value()
+  }
+
+  @Override
+  HttpUrlConnectionDecorator decorator() {
+    return HttpUrlConnectionDecorator.DECORATE
+  }
+
+  @Override
+  boolean testRedirects() {
+    false
+  }
+
+  @Override
+  boolean testConnectionFailure() {
+    false
+  }
+}

--- a/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/UrlConnectionTest.groovy
+++ b/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/UrlConnectionTest.groovy
@@ -5,9 +5,9 @@ import datadog.trace.instrumentation.http_url_connection.UrlInstrumentation
 import io.opentracing.tag.Tags
 import io.opentracing.util.GlobalTracer
 
+import static datadog.trace.agent.test.utils.ConfigUtils.withConfigOverride
 import static datadog.trace.agent.test.utils.PortUtils.UNUSABLE_PORT
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
-import static datadog.trace.agent.test.utils.TraceUtils.withConfigOverride
 import static datadog.trace.instrumentation.http_url_connection.HttpUrlConnectionInstrumentation.HttpUrlState.OPERATION_NAME
 
 class UrlConnectionTest extends AgentTestRunner {

--- a/dd-java-agent/instrumentation/jax-rs-client/jax-rs-client.gradle
+++ b/dd-java-agent/instrumentation/jax-rs-client/jax-rs-client.gradle
@@ -35,6 +35,7 @@ dependencies {
   compile project(':dd-java-agent:agent-tooling')
 
   testCompile project(':dd-java-agent:testing')
+  testCompile project(':dd-java-agent:instrumentation:java-concurrent')
 
   testCompile project(':dd-java-agent:instrumentation:jax-rs-client:connection-error-handling-jersey')
   testCompile project(':dd-java-agent:instrumentation:jax-rs-client:connection-error-handling-resteasy')

--- a/dd-java-agent/instrumentation/jax-rs-client/src/test/groovy/JaxRsClientAsyncTest.groovy
+++ b/dd-java-agent/instrumentation/jax-rs-client/src/test/groovy/JaxRsClientAsyncTest.groovy
@@ -1,8 +1,8 @@
 import datadog.trace.agent.test.base.HttpClientTest
 import datadog.trace.instrumentation.jaxrs.JaxRsClientDecorator
+import javax.ws.rs.client.AsyncInvoker
 import javax.ws.rs.client.Client
 import javax.ws.rs.client.ClientBuilder
-import javax.ws.rs.client.Invocation
 import javax.ws.rs.client.WebTarget
 import javax.ws.rs.core.MediaType
 import javax.ws.rs.core.Response
@@ -10,16 +10,17 @@ import org.apache.cxf.jaxrs.client.spec.ClientBuilderImpl
 import org.glassfish.jersey.client.JerseyClientBuilder
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder
 
-abstract class JaxRsClientTest extends HttpClientTest<JaxRsClientDecorator> {
+abstract class JaxRsClientAsyncTest extends HttpClientTest<JaxRsClientDecorator> {
 
   @Override
   int doRequest(String method, URI uri, Map<String, String> headers, Closure callback) {
-
     Client client = builder().build()
     WebTarget service = client.target(uri)
-    Invocation.Builder request = service.request(MediaType.TEXT_PLAIN)
-    headers.each { request.header(it.key, it.value) }
-    Response response = request.method(method)
+    def builder = service.request(MediaType.TEXT_PLAIN)
+    headers.each { builder.header(it.key, it.value) }
+    AsyncInvoker request = builder.async()
+    
+    Response response = request.method(method).get()
     callback?.call()
 
     return response.status
@@ -42,7 +43,7 @@ abstract class JaxRsClientTest extends HttpClientTest<JaxRsClientDecorator> {
   abstract ClientBuilder builder()
 }
 
-class JerseyClientTest extends JaxRsClientTest {
+class JerseyClientAsyncTest extends JaxRsClientAsyncTest {
 
   @Override
   ClientBuilder builder() {
@@ -50,7 +51,7 @@ class JerseyClientTest extends JaxRsClientTest {
   }
 }
 
-class ResteasyClientTest extends JaxRsClientTest {
+class ResteasyClientAsyncTest extends JaxRsClientAsyncTest {
 
   @Override
   ClientBuilder builder() {
@@ -58,7 +59,7 @@ class ResteasyClientTest extends JaxRsClientTest {
   }
 }
 
-class CxfClientTest extends JaxRsClientTest {
+class CxfClientAsyncTest extends JaxRsClientAsyncTest {
 
   @Override
   ClientBuilder builder() {

--- a/dd-java-agent/instrumentation/jax-rs-client/src/test/groovy/JaxRsClientAsyncTest.groovy
+++ b/dd-java-agent/instrumentation/jax-rs-client/src/test/groovy/JaxRsClientAsyncTest.groovy
@@ -3,6 +3,7 @@ import datadog.trace.instrumentation.jaxrs.JaxRsClientDecorator
 import javax.ws.rs.client.AsyncInvoker
 import javax.ws.rs.client.Client
 import javax.ws.rs.client.ClientBuilder
+import javax.ws.rs.client.Entity
 import javax.ws.rs.client.WebTarget
 import javax.ws.rs.core.MediaType
 import javax.ws.rs.core.Response
@@ -19,8 +20,9 @@ abstract class JaxRsClientAsyncTest extends HttpClientTest<JaxRsClientDecorator>
     def builder = service.request(MediaType.TEXT_PLAIN)
     headers.each { builder.header(it.key, it.value) }
     AsyncInvoker request = builder.async()
-    
-    Response response = request.method(method).get()
+
+    def body = BODY_METHODS.contains(method) ? Entity.text("") : null
+    Response response = request.method(method, (Entity) body).get()
     callback?.call()
 
     return response.status

--- a/dd-java-agent/instrumentation/jax-rs-client/src/test/groovy/JaxRsClientTest.groovy
+++ b/dd-java-agent/instrumentation/jax-rs-client/src/test/groovy/JaxRsClientTest.groovy
@@ -2,6 +2,7 @@ import datadog.trace.agent.test.base.HttpClientTest
 import datadog.trace.instrumentation.jaxrs.JaxRsClientDecorator
 import javax.ws.rs.client.Client
 import javax.ws.rs.client.ClientBuilder
+import javax.ws.rs.client.Entity
 import javax.ws.rs.client.Invocation
 import javax.ws.rs.client.WebTarget
 import javax.ws.rs.core.MediaType
@@ -19,7 +20,8 @@ abstract class JaxRsClientTest extends HttpClientTest<JaxRsClientDecorator> {
     WebTarget service = client.target(uri)
     Invocation.Builder request = service.request(MediaType.TEXT_PLAIN)
     headers.each { request.header(it.key, it.value) }
-    Response response = request.method(method)
+    def body = BODY_METHODS.contains(method) ? Entity.text("") : null
+    Response response = request.method(method, (Entity) body)
     callback?.call()
 
     return response.status

--- a/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/client/NettyHttpClientDecorator.java
+++ b/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/client/NettyHttpClientDecorator.java
@@ -39,13 +39,32 @@ public class NettyHttpClientDecorator extends HttpClientDecorator<HttpRequest, H
   }
 
   @Override
-  protected String hostname(final HttpRequest httpRequest) {
-    return null;
+  protected String hostname(final HttpRequest request) {
+    try {
+      final URI uri = new URI(request.getUri());
+      if ((uri.getHost() == null || uri.getHost().equals("")) && request.headers().contains(HOST)) {
+        return request.headers().get(HOST).split(":")[0];
+      } else {
+        return uri.getHost();
+      }
+    } catch (final Exception e) {
+      return null;
+    }
   }
 
   @Override
-  protected Integer port(final HttpRequest httpRequest) {
-    return null;
+  protected Integer port(final HttpRequest request) {
+    try {
+      final URI uri = new URI(request.getUri());
+      if ((uri.getHost() == null || uri.getHost().equals("")) && request.headers().contains(HOST)) {
+        final String[] hostPort = request.headers().get(HOST).split(":");
+        return hostPort.length == 2 ? Integer.parseInt(hostPort[1]) : null;
+      } else {
+        return uri.getPort();
+      }
+    } catch (final Exception e) {
+      return null;
+    }
   }
 
   @Override

--- a/dd-java-agent/instrumentation/netty-4.0/src/test/groovy/Netty40ClientTest.groovy
+++ b/dd-java-agent/instrumentation/netty-4.0/src/test/groovy/Netty40ClientTest.groovy
@@ -1,102 +1,72 @@
-import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.utils.PortUtils
-import datadog.trace.api.DDSpanTypes
+import datadog.trace.agent.test.base.HttpClientTest
+import datadog.trace.instrumentation.netty40.client.NettyHttpClientDecorator
 import io.opentracing.tag.Tags
 import org.asynchttpclient.AsyncHttpClient
 import org.asynchttpclient.DefaultAsyncHttpClientConfig
-import spock.lang.AutoCleanup
 import spock.lang.Shared
 
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.TimeUnit
 
-import static datadog.trace.agent.test.server.http.TestHttpServer.httpServer
+import static datadog.trace.agent.test.utils.PortUtils.UNUSABLE_PORT
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 import static org.asynchttpclient.Dsl.asyncHttpClient
 
-class Netty40ClientTest extends AgentTestRunner {
+class Netty40ClientTest extends HttpClientTest<NettyHttpClientDecorator> {
 
-  @AutoCleanup
-  @Shared
-  def server = httpServer {
-    handlers {
-      all {
-        response.send("Hello World")
-      }
-    }
-  }
   @Shared
   def clientConfig = DefaultAsyncHttpClientConfig.Builder.newInstance().setRequestTimeout(TimeUnit.SECONDS.toMillis(10).toInteger())
   @Shared
   AsyncHttpClient asyncHttpClient = asyncHttpClient(clientConfig)
 
-  def "test server request/response"() {
-    setup:
-    def responseFuture = runUnderTrace("parent") {
-      asyncHttpClient.prepareGet("$server.address").execute()
-    }
-    def response = responseFuture.get()
-
-    expect:
-    response.statusCode == 200
-    response.responseBody == "Hello World"
-
-    and:
-    assertTraces(1) {
-      trace(0, 2) {
-        span(0) {
-          serviceName "unnamed-java-app"
-          operationName "netty.client.request"
-          resourceName "GET /"
-          spanType DDSpanTypes.HTTP_CLIENT
-          childOf span(1)
-          errored false
-          tags {
-            "$Tags.COMPONENT.key" "netty-client"
-            "$Tags.HTTP_METHOD.key" "GET"
-            "$Tags.HTTP_STATUS.key" 200
-            "$Tags.HTTP_URL.key" "$server.address/"
-            "$Tags.PEER_HOSTNAME.key" "localhost"
-            "$Tags.PEER_HOST_IPV4.key" "127.0.0.1"
-            "$Tags.PEER_PORT.key" server.address.port
-            "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            defaultTags()
-          }
-        }
-        span(1) {
-          operationName "parent"
-          parent()
-        }
-      }
-    }
-
-    and:
-    server.lastRequest.headers.get("x-datadog-trace-id") == "${TEST_WRITER.get(0).get(0).traceId}"
-    server.lastRequest.headers.get("x-datadog-parent-id") == "${TEST_WRITER.get(0).get(0).spanId}"
+  @Override
+  int doRequest(String method, URI uri, Map<String, String> headers, Closure callback) {
+    def methodName = "prepare" + method.toLowerCase().capitalize()
+    def requestBuilder = asyncHttpClient."$methodName"(uri.toString())
+    headers.each { requestBuilder.setHeader(it.key, it.value) }
+    def response = requestBuilder.execute().get()
+    callback?.call()
+    return response.statusCode
   }
 
-  def "test connection failure"() {
-    setup:
-    def invalidPort = PortUtils.randomOpenPort()
+  @Override
+  NettyHttpClientDecorator decorator() {
+    return NettyHttpClientDecorator.DECORATE
+  }
 
-    def responseFuture = runUnderTrace("parent") {
-      asyncHttpClient.prepareGet("http://localhost:$invalidPort/").execute()
-    }
+  @Override
+  String expectedOperationName() {
+    return "netty.client.request"
+  }
+
+  @Override
+  boolean testRedirects() {
+    false
+  }
+
+  @Override
+  boolean testConnectionFailure() {
+    false
+  }
+
+  def "connection error (unopened port)"() {
+    given:
+    def uri = new URI("http://localhost:$UNUSABLE_PORT/")
 
     when:
-    responseFuture.get()
+    runUnderTrace("parent") {
+      doRequest(method, uri)
+    }
 
     then:
-    def throwable = thrown(ExecutionException)
-    throwable.cause instanceof ConnectException
+    def ex = thrown(Exception)
+    def thrownException = ex instanceof ExecutionException ? ex.cause : ex
 
     and:
     assertTraces(1) {
       trace(0, 2) {
-        span(0) {
-          operationName "parent"
-          parent()
-        }
+        parentSpan(it, 0, thrownException)
+
         span(1) {
           operationName "netty.connect"
           resourceName "netty.connect"
@@ -110,11 +80,14 @@ class Netty40ClientTest extends AgentTestRunner {
             } catch (ClassNotFoundException e) {
               // Older versions use 'java.net.ConnectException' and do not have 'io.netty.channel.AbstractChannel$AnnotatedConnectException'
             }
-            errorTags errorClass, "Connection refused: localhost/127.0.0.1:$invalidPort"
+            errorTags errorClass, "Connection refused: localhost/127.0.0.1:$UNUSABLE_PORT"
             defaultTags()
           }
         }
       }
     }
+
+    where:
+    method = "GET"
   }
 }

--- a/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/client/NettyHttpClientDecorator.java
+++ b/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/client/NettyHttpClientDecorator.java
@@ -39,13 +39,32 @@ public class NettyHttpClientDecorator extends HttpClientDecorator<HttpRequest, H
   }
 
   @Override
-  protected String hostname(final HttpRequest httpRequest) {
-    return null;
+  protected String hostname(final HttpRequest request) {
+    try {
+      final URI uri = new URI(request.uri());
+      if ((uri.getHost() == null || uri.getHost().equals("")) && request.headers().contains(HOST)) {
+        return request.headers().get(HOST).split(":")[0];
+      } else {
+        return uri.getHost();
+      }
+    } catch (final Exception e) {
+      return null;
+    }
   }
 
   @Override
-  protected Integer port(final HttpRequest httpRequest) {
-    return null;
+  protected Integer port(final HttpRequest request) {
+    try {
+      final URI uri = new URI(request.uri());
+      if ((uri.getHost() == null || uri.getHost().equals("")) && request.headers().contains(HOST)) {
+        final String[] hostPort = request.headers().get(HOST).split(":");
+        return hostPort.length == 2 ? Integer.parseInt(hostPort[1]) : null;
+      } else {
+        return uri.getPort();
+      }
+    } catch (final Exception e) {
+      return null;
+    }
   }
 
   @Override

--- a/dd-java-agent/instrumentation/netty-4.1/src/test/groovy/Netty41ClientTest.groovy
+++ b/dd-java-agent/instrumentation/netty-4.1/src/test/groovy/Netty41ClientTest.groovy
@@ -1,103 +1,74 @@
-import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.utils.PortUtils
-import datadog.trace.api.DDSpanTypes
+import datadog.trace.agent.test.base.HttpClientTest
+import datadog.trace.instrumentation.netty41.client.NettyHttpClientDecorator
 import io.netty.channel.AbstractChannel
 import io.opentracing.tag.Tags
 import org.asynchttpclient.AsyncHttpClient
 import org.asynchttpclient.DefaultAsyncHttpClientConfig
-import spock.lang.AutoCleanup
 import spock.lang.Shared
 
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.TimeUnit
 
-import static datadog.trace.agent.test.server.http.TestHttpServer.httpServer
+import static datadog.trace.agent.test.utils.PortUtils.UNUSABLE_PORT
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 import static org.asynchttpclient.Dsl.asyncHttpClient
 
-class Netty41ClientTest extends AgentTestRunner {
+class Netty41ClientTest extends HttpClientTest<NettyHttpClientDecorator> {
 
-  @AutoCleanup
-  @Shared
-  def server = httpServer {
-    handlers {
-      all {
-        response.send("Hello World")
-      }
-    }
-  }
   @Shared
   def clientConfig = DefaultAsyncHttpClientConfig.Builder.newInstance().setRequestTimeout(TimeUnit.SECONDS.toMillis(10).toInteger())
   @Shared
   AsyncHttpClient asyncHttpClient = asyncHttpClient(clientConfig)
 
-  def "test server request/response"() {
-    setup:
-    def responseFuture = runUnderTrace("parent") {
-      asyncHttpClient.prepareGet("$server.address").execute()
-    }
-    def response = responseFuture.get()
-
-    expect:
-    response.statusCode == 200
-    response.responseBody == "Hello World"
-
-    and:
-    assertTraces(1) {
-      trace(0, 2) {
-        span(0) {
-          serviceName "unnamed-java-app"
-          operationName "netty.client.request"
-          resourceName "GET /"
-          spanType DDSpanTypes.HTTP_CLIENT
-          childOf span(1)
-          errored false
-          tags {
-            "$Tags.COMPONENT.key" "netty-client"
-            "$Tags.HTTP_METHOD.key" "GET"
-            "$Tags.HTTP_STATUS.key" 200
-            "$Tags.HTTP_URL.key" "$server.address/"
-            "$Tags.PEER_HOSTNAME.key" "localhost"
-            "$Tags.PEER_HOST_IPV4.key" "127.0.0.1"
-            "$Tags.PEER_PORT.key" server.address.port
-            "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            defaultTags()
-          }
-        }
-        span(1) {
-          operationName "parent"
-          parent()
-        }
-      }
-    }
-
-    and:
-    server.lastRequest.headers.get("x-datadog-trace-id") == "${TEST_WRITER.get(0).get(0).traceId}"
-    server.lastRequest.headers.get("x-datadog-parent-id") == "${TEST_WRITER.get(0).get(0).spanId}"
+  @Override
+  int doRequest(String method, URI uri, Map<String, String> headers, Closure callback) {
+    def methodName = "prepare" + method.toLowerCase().capitalize()
+    def requestBuilder = asyncHttpClient."$methodName"(uri.toString())
+    headers.each { requestBuilder.setHeader(it.key, it.value) }
+    def response = requestBuilder.execute().get()
+    callback?.call()
+    return response.statusCode
   }
 
-  def "test connection failure"() {
-    setup:
-    def invalidPort = PortUtils.randomOpenPort()
+  @Override
+  NettyHttpClientDecorator decorator() {
+    return NettyHttpClientDecorator.DECORATE
+  }
 
-    def responseFuture = runUnderTrace("parent") {
-      asyncHttpClient.prepareGet("http://localhost:$invalidPort/").execute()
-    }
+  @Override
+  String expectedOperationName() {
+    return "netty.client.request"
+  }
+
+  @Override
+  boolean testRedirects() {
+    false
+  }
+
+  @Override
+  boolean testConnectionFailure() {
+    false
+  }
+
+  def "connection error (unopened port)"() {
+    given:
+    def uri = new URI("http://localhost:$UNUSABLE_PORT/")
 
     when:
-    responseFuture.get()
+    runUnderTrace("parent") {
+      doRequest(method, uri)
+    }
 
     then:
-    def throwable = thrown(ExecutionException)
-    throwable.cause instanceof ConnectException
+    def ex = thrown(Exception)
+    ex.cause instanceof ConnectException
+    def thrownException = ex instanceof ExecutionException ? ex.cause : ex
 
     and:
     assertTraces(1) {
       trace(0, 2) {
-        span(0) {
-          operationName "parent"
-          parent()
-        }
+        parentSpan(it, 0, thrownException)
+
         span(1) {
           operationName "netty.connect"
           resourceName "netty.connect"
@@ -105,11 +76,14 @@ class Netty41ClientTest extends AgentTestRunner {
           errored true
           tags {
             "$Tags.COMPONENT.key" "netty"
-            errorTags AbstractChannel.AnnotatedConnectException, "Connection refused: localhost/127.0.0.1:$invalidPort"
+            errorTags AbstractChannel.AnnotatedConnectException, "Connection refused: localhost/127.0.0.1:$UNUSABLE_PORT"
             defaultTags()
           }
         }
       }
     }
+
+    where:
+    method = "GET"
   }
 }

--- a/dd-java-agent/instrumentation/okhttp-3/okhttp-3.gradle
+++ b/dd-java-agent/instrumentation/okhttp-3/okhttp-3.gradle
@@ -30,6 +30,7 @@ dependencies {
   testCompile(project(':dd-java-agent:testing')) {
     exclude module: 'okhttp'
   }
+  testCompile project(':dd-java-agent:instrumentation:java-concurrent')
   testCompile group: 'com.squareup.okhttp3', name: 'okhttp', version: '3.0.0'
 
   // 4.x.x-alpha has been released and it looks like there are lots of incompatible changes

--- a/dd-java-agent/instrumentation/okhttp-3/src/test/groovy/OkHttp3AsyncTest.groovy
+++ b/dd-java-agent/instrumentation/okhttp-3/src/test/groovy/OkHttp3AsyncTest.groovy
@@ -1,0 +1,48 @@
+import okhttp3.Call
+import okhttp3.Callback
+import okhttp3.Headers
+import okhttp3.MediaType
+import okhttp3.Request
+import okhttp3.RequestBody
+import okhttp3.Response
+import okhttp3.internal.http.HttpMethod
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.atomic.AtomicReference
+
+import static java.util.concurrent.TimeUnit.SECONDS
+
+class OkHttp3AsyncTest extends OkHttp3Test {
+
+  @Override
+  int doRequest(String method, URI uri, Map<String, String> headers, Closure callback) {
+    def body = HttpMethod.requiresRequestBody(method) ? RequestBody.create(MediaType.parse("text/plain"), "") : null
+    def request = new Request.Builder()
+      .url(uri.toURL())
+      .method(method, body)
+      .headers(Headers.of(headers))
+      .build()
+
+    AtomicReference<Response> responseRef = new AtomicReference()
+    AtomicReference<Exception> exRef = new AtomicReference()
+    def latch = new CountDownLatch(1)
+
+    client.newCall(request).enqueue(new Callback() {
+      void onResponse(Call call, Response response) {
+        responseRef.set(response)
+        callback?.call()
+        latch.countDown()
+      }
+
+      void onFailure(Call call, IOException e) {
+        exRef.set(e)
+        latch.countDown()
+      }
+    })
+    latch.await(10, SECONDS)
+    if (exRef.get() != null) {
+      throw exRef.get()
+    }
+    return responseRef.get().code()
+  }
+}

--- a/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/ConfiguredTraceAnnotationsTest.groovy
+++ b/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/ConfiguredTraceAnnotationsTest.groovy
@@ -4,7 +4,7 @@ import dd.test.trace.annotation.SayTracedHello
 
 import java.util.concurrent.Callable
 
-import static datadog.trace.agent.test.utils.TraceUtils.withSystemProperty
+import static datadog.trace.agent.test.utils.ConfigUtils.withSystemProperty
 import static datadog.trace.instrumentation.trace_annotation.TraceAnnotationsInstrumentation.DEFAULT_ANNOTATIONS
 
 class ConfiguredTraceAnnotationsTest extends AgentTestRunner {

--- a/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/TraceConfigTest.groovy
+++ b/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/TraceConfigTest.groovy
@@ -3,7 +3,7 @@ import datadog.trace.instrumentation.trace_annotation.TraceConfigInstrumentation
 
 import java.util.concurrent.Callable
 
-import static datadog.trace.agent.test.utils.TraceUtils.withSystemProperty
+import static datadog.trace.agent.test.utils.ConfigUtils.withSystemProperty
 
 class TraceConfigTest extends AgentTestRunner {
 

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/AgentTestRunner.java
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/AgentTestRunner.java
@@ -1,8 +1,5 @@
 package datadog.trace.agent.test;
 
-import static net.bytebuddy.matcher.ElementMatchers.named;
-import static net.bytebuddy.matcher.ElementMatchers.none;
-
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import com.google.common.collect.Sets;
@@ -10,10 +7,10 @@ import datadog.opentracing.DDSpan;
 import datadog.opentracing.DDTracer;
 import datadog.opentracing.PendingTrace;
 import datadog.trace.agent.test.asserts.ListWriterAssert;
+import datadog.trace.agent.test.utils.ConfigUtils;
 import datadog.trace.agent.test.utils.GlobalTracerUtils;
 import datadog.trace.agent.tooling.AgentInstaller;
 import datadog.trace.agent.tooling.Instrumenter;
-import datadog.trace.api.Config;
 import datadog.trace.api.GlobalTracer;
 import datadog.trace.common.writer.ListWriter;
 import datadog.trace.common.writer.Writer;
@@ -24,8 +21,6 @@ import groovy.transform.stc.SimpleType;
 import io.opentracing.Tracer;
 import java.lang.instrument.ClassFileTransformer;
 import java.lang.instrument.Instrumentation;
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
 import java.util.List;
 import java.util.ServiceLoader;
 import java.util.Set;
@@ -34,14 +29,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import lombok.extern.slf4j.Slf4j;
 import net.bytebuddy.agent.ByteBuddyAgent;
 import net.bytebuddy.agent.builder.AgentBuilder;
-import net.bytebuddy.agent.builder.ResettableClassFileTransformer;
-import net.bytebuddy.description.modifier.FieldManifestation;
-import net.bytebuddy.description.modifier.Ownership;
-import net.bytebuddy.description.modifier.Visibility;
 import net.bytebuddy.description.type.TypeDescription;
-import net.bytebuddy.dynamic.ClassFileLocator;
 import net.bytebuddy.dynamic.DynamicType;
-import net.bytebuddy.dynamic.Transformer;
 import net.bytebuddy.utility.JavaModule;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -95,11 +84,7 @@ public abstract class AgentTestRunner extends Specification {
     ((Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME)).setLevel(Level.WARN);
     ((Logger) LoggerFactory.getLogger("datadog")).setLevel(Level.DEBUG);
 
-    try {
-      makeConfigInstanceModifiable();
-    } catch (final Exception e) {
-      throw new RuntimeException(e);
-    }
+    ConfigUtils.makeConfigInstanceModifiable();
 
     TEST_WRITER =
         new ListWriter() {
@@ -204,44 +189,6 @@ public abstract class AgentTestRunner extends Specification {
     // Cleanup before assertion.
     assert INSTRUMENTATION_ERROR_COUNT.get() == 0
         : INSTRUMENTATION_ERROR_COUNT.get() + " Instrumentation errors during test";
-  }
-
-  private static void makeConfigInstanceModifiable()
-      throws ClassNotFoundException, NoSuchFieldException {
-    final ResettableClassFileTransformer transformer =
-        new AgentBuilder.Default()
-            // Config is injected into the bootstrap, so we need to provide a locator.
-            .with(
-                new AgentBuilder.LocationStrategy.Simple(
-                    ClassFileLocator.ForClassLoader.ofSystemLoader()))
-            .ignore(none()) // Allow transforming boostrap classes
-            .type(named("datadog.trace.api.Config"))
-            .transform(
-                new AgentBuilder.Transformer() {
-                  @Override
-                  public DynamicType.Builder<?> transform(
-                      final DynamicType.Builder<?> builder,
-                      final TypeDescription typeDescription,
-                      final ClassLoader classLoader,
-                      final JavaModule module) {
-                    // Add transformer to modify INSTANCE field access.
-                    return builder
-                        .field(named("INSTANCE"))
-                        .transform(
-                            Transformer.ForField.withModifiers(
-                                Visibility.PUBLIC, Ownership.STATIC, FieldManifestation.VOLATILE));
-                  }
-                })
-            .installOn(INSTRUMENTATION);
-
-    final Field field = Config.class.getDeclaredField("INSTANCE");
-    assert Modifier.isPublic(field.getModifiers());
-    assert Modifier.isStatic(field.getModifiers());
-    assert Modifier.isVolatile(field.getModifiers());
-    assert !Modifier.isFinal(field.getModifiers());
-
-    // No longer needed (Unless class gets retransformed somehow).
-    INSTRUMENTATION.removeTransformer(transformer);
   }
 
   public static void assertTraces(

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
@@ -9,14 +9,18 @@ import datadog.trace.api.DDSpanTypes
 import io.opentracing.tag.Tags
 import spock.lang.AutoCleanup
 import spock.lang.Shared
+import spock.lang.Unroll
 
 import java.util.concurrent.ExecutionException
 
 import static datadog.trace.agent.test.server.http.TestHttpServer.httpServer
+import static datadog.trace.agent.test.utils.PortUtils.UNUSABLE_PORT
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 import static datadog.trace.agent.test.utils.TraceUtils.withConfigOverride
+import static org.junit.Assume.assumeTrue
 
 abstract class HttpClientTest<T extends HttpClientDecorator> extends AgentTestRunner {
+  protected static final BODY_METHODS = ["POST", "PUT"]
 
   @AutoCleanup
   @Shared
@@ -63,24 +67,34 @@ abstract class HttpClientTest<T extends HttpClientDecorator> extends AgentTestRu
     return null
   }
 
-  def "basic #method request"() {
+  @Unroll
+  def "basic #method request #url"() {
     when:
     def status = doRequest(method, server.address.resolve(url))
 
     then:
     status == 200
     assertTraces(2) {
-      server.distributedRequestTrace(it, 0, trace(1).get(0))
-      trace(1, 1) {
-        clientSpan(it, 0, null, false)
+      server.distributedRequestTrace(it, 0, trace(1).last())
+      trace(1, size(1)) {
+        clientSpan(it, 0, null, method, false, tagQueryString, url)
       }
     }
 
     where:
+    path                                | tagQueryString
+    "/success"                          | false
+    "/success"                          | true
+    "/success?with=params"              | false
+    "/success?with=params"              | true
+    "/success#with+fragment"            | true
+    "/success?with=params#and=fragment" | true
+
     method = "GET"
-    url << ["/success", "/success?with=params"]
+    url = server.address.resolve(path)
   }
 
+  @Unroll
   def "basic #method request with parent"() {
     when:
     def status = runUnderTrace("parent") {
@@ -90,17 +104,18 @@ abstract class HttpClientTest<T extends HttpClientDecorator> extends AgentTestRu
     then:
     status == 200
     assertTraces(2) {
-      server.distributedRequestTrace(it, 0, trace(1).get(1))
-      trace(1, 2) {
+      server.distributedRequestTrace(it, 0, trace(1).last())
+      trace(1, size(2)) {
         parentSpan(it, 0)
-        clientSpan(it, 1, span(0), false)
+        clientSpan(it, 1, span(0), method, false)
       }
     }
 
     where:
-    method = "GET"
+    method << BODY_METHODS
   }
 
+  @Unroll
   def "basic #method request with split-by-domain"() {
     when:
     def status = withConfigOverride(Config.HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN, "true") {
@@ -110,14 +125,14 @@ abstract class HttpClientTest<T extends HttpClientDecorator> extends AgentTestRu
     then:
     status == 200
     assertTraces(2) {
-      server.distributedRequestTrace(it, 0, trace(1).get(0))
-      trace(1, 1) {
-        clientSpan(it, 0, null, true)
+      server.distributedRequestTrace(it, 0, trace(1).last())
+      trace(1, size(1)) {
+        clientSpan(it, 0, null, method, true)
       }
     }
 
     where:
-    method = "GET"
+    method = "HEAD"
   }
 
   def "trace request without propagation"() {
@@ -132,9 +147,9 @@ abstract class HttpClientTest<T extends HttpClientDecorator> extends AgentTestRu
     status == 200
     // only one trace (client).
     assertTraces(1) {
-      trace(0, 2) {
+      trace(0, size(2)) {
         parentSpan(it, 0)
-        clientSpan(it, 1, span(0), renameService)
+        clientSpan(it, 1, span(0), method, renameService)
       }
     }
 
@@ -155,13 +170,13 @@ abstract class HttpClientTest<T extends HttpClientDecorator> extends AgentTestRu
     status == 200
     // only one trace (client).
     assertTraces(1) {
-      trace(0, 3) {
+      trace(0, size(3)) {
         parentSpan(it, 0)
         span(1) {
           operationName "child"
           childOf span(0)
         }
-        clientSpan(it, 2, span(0), false)
+        clientSpan(it, 2, span(0), method, false)
       }
     }
 
@@ -182,8 +197,8 @@ abstract class HttpClientTest<T extends HttpClientDecorator> extends AgentTestRu
     status == 200
     // only one trace (client).
     assertTraces(2) {
-      trace(0, 1) {
-        clientSpan(it, 0, null, false)
+      trace(0, size(1)) {
+        clientSpan(it, 0, null, method, false)
       }
       trace(1, 1) {
         span(0) {
@@ -197,8 +212,10 @@ abstract class HttpClientTest<T extends HttpClientDecorator> extends AgentTestRu
     method = "GET"
   }
 
+  @Unroll
   def "basic #method request with 1 redirect"() {
-    setup:
+    given:
+    assumeTrue(testRedirects())
     def uri = server.address.resolve("/redirect")
 
     when:
@@ -207,10 +224,10 @@ abstract class HttpClientTest<T extends HttpClientDecorator> extends AgentTestRu
     then:
     status == 200
     assertTraces(3) {
-      server.distributedRequestTrace(it, 0, trace(2).get(0))
-      server.distributedRequestTrace(it, 1, trace(2).get(0))
-      trace(2, 1) {
-        clientSpan(it, 0, null, false, uri)
+      server.distributedRequestTrace(it, 0, trace(2).last())
+      server.distributedRequestTrace(it, 1, trace(2).last())
+      trace(2, size(1)) {
+        clientSpan(it, 0, null, method, false, false, uri)
       }
     }
 
@@ -218,8 +235,10 @@ abstract class HttpClientTest<T extends HttpClientDecorator> extends AgentTestRu
     method = "GET"
   }
 
+  @Unroll
   def "basic #method request with 2 redirects"() {
-    setup:
+    given:
+    assumeTrue(testRedirects())
     def uri = server.address.resolve("/another-redirect")
 
     when:
@@ -228,11 +247,11 @@ abstract class HttpClientTest<T extends HttpClientDecorator> extends AgentTestRu
     then:
     status == 200
     assertTraces(4) {
-      server.distributedRequestTrace(it, 0, trace(3).get(0))
-      server.distributedRequestTrace(it, 1, trace(3).get(0))
-      server.distributedRequestTrace(it, 2, trace(3).get(0))
-      trace(3, 1) {
-        clientSpan(it, 0, null, false, uri)
+      server.distributedRequestTrace(it, 0, trace(3).last())
+      server.distributedRequestTrace(it, 1, trace(3).last())
+      server.distributedRequestTrace(it, 2, trace(3).last())
+      trace(3, size(1)) {
+        clientSpan(it, 0, null, method, false, false, uri)
       }
     }
 
@@ -240,8 +259,10 @@ abstract class HttpClientTest<T extends HttpClientDecorator> extends AgentTestRu
     method = "GET"
   }
 
+  @Unroll
   def "basic #method request with circular redirects"() {
-    setup:
+    given:
+    assumeTrue(testRedirects())
     def uri = server.address.resolve("/circular-redirect")
 
     when:
@@ -253,10 +274,36 @@ abstract class HttpClientTest<T extends HttpClientDecorator> extends AgentTestRu
 
     and:
     assertTraces(3) {
-      server.distributedRequestTrace(it, 0, trace(2).get(0))
-      server.distributedRequestTrace(it, 1, trace(2).get(0))
-      trace(2, 1) {
-        clientSpan(it, 0, null, false, uri, statusOnRedirectError(), thrownException)
+      server.distributedRequestTrace(it, 0, trace(2).last())
+      server.distributedRequestTrace(it, 1, trace(2).last())
+      trace(2, size(1)) {
+        clientSpan(it, 0, null, method, false, false, uri, statusOnRedirectError(), thrownException)
+      }
+    }
+
+    where:
+    method = "GET"
+  }
+
+  def "connection error (unopened port)"() {
+    given:
+    assumeTrue(testConnectionFailure())
+    def uri = new URI("http://localhost:$UNUSABLE_PORT/")
+
+    when:
+    runUnderTrace("parent") {
+      doRequest(method, uri)
+    }
+
+    then:
+    def ex = thrown(Exception)
+    def thrownException = ex instanceof ExecutionException ? ex.cause : ex
+
+    and:
+    assertTraces(1) {
+      trace(0, 2) {
+        parentSpan(it, 0, thrownException)
+        clientSpan(it, 1, span(0), method, false, false, uri, null, thrownException)
       }
     }
 
@@ -274,14 +321,14 @@ abstract class HttpClientTest<T extends HttpClientDecorator> extends AgentTestRu
       tags {
         defaultTags()
         if (exception) {
-          errorTags(exception.class)
+          errorTags(exception.class, exception.message)
         }
       }
     }
   }
 
   // parent span must be cast otherwise it breaks debugging classloading (junit loads it early)
-  void clientSpan(TraceAssert trace, int index, Object parentSpan, boolean renameService, URI uri = server.address.resolve("/success"), Integer status = 200, Throwable exception = null) {
+  void clientSpan(TraceAssert trace, int index, Object parentSpan, String method = "GET", boolean renameService = false, boolean tagQueryString = false, URI uri = server.address.resolve("/success"), Integer status = 200, Throwable exception = null) {
     trace.span(index) {
       if (parentSpan == null) {
         parent()
@@ -289,8 +336,8 @@ abstract class HttpClientTest<T extends HttpClientDecorator> extends AgentTestRu
         childOf((DDSpan) parentSpan)
       }
       serviceName renameService ? "localhost" : "unnamed-java-app"
-      operationName "http.request"
-      resourceName "GET $uri.path"
+      operationName expectedOperationName()
+      resourceName "$method $uri.path"
       spanType DDSpanTypes.HTTP_CLIENT
       errored exception != null
       tags {
@@ -302,12 +349,29 @@ abstract class HttpClientTest<T extends HttpClientDecorator> extends AgentTestRu
         if (status) {
           "$Tags.HTTP_STATUS.key" status
         }
-        "$Tags.HTTP_URL.key" "$uri"
+        "$Tags.HTTP_URL.key" "${uri.resolve(uri.path)}"
         "$Tags.PEER_HOSTNAME.key" "localhost"
-        "$Tags.PEER_PORT.key" server.address.port
-        "$Tags.HTTP_METHOD.key" "GET"
+        "$Tags.PEER_PORT.key" uri.port
+        "$Tags.PEER_HOST_IPV4.key" { it == null || it == "127.0.0.1" } // Optional
+        "$Tags.HTTP_METHOD.key" method
         "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
       }
     }
+  }
+
+  String expectedOperationName() {
+    return "http.request"
+  }
+
+  int size(int size) {
+    size
+  }
+
+  boolean testRedirects() {
+    true
+  }
+
+  boolean testConnectionFailure() {
+    true
   }
 }

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
@@ -68,7 +68,7 @@ abstract class HttpClientTest<T extends HttpClientDecorator> extends AgentTestRu
   }
 
   @Unroll
-  def "basic #method request #url"() {
+  def "basic #method request #url - tagQueryString=#tagQueryString"() {
     when:
     def status = withConfigOverride(Config.HTTP_CLIENT_TAG_QUERY_STRING, "$tagQueryString") {
       doRequest(method, url)

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
@@ -14,9 +14,9 @@ import spock.lang.Unroll
 import java.util.concurrent.ExecutionException
 
 import static datadog.trace.agent.test.server.http.TestHttpServer.httpServer
+import static datadog.trace.agent.test.utils.ConfigUtils.withConfigOverride
 import static datadog.trace.agent.test.utils.PortUtils.UNUSABLE_PORT
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
-import static datadog.trace.agent.test.utils.TraceUtils.withConfigOverride
 import static org.junit.Assume.assumeTrue
 
 abstract class HttpClientTest<T extends HttpClientDecorator> extends AgentTestRunner {

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
@@ -70,7 +70,9 @@ abstract class HttpClientTest<T extends HttpClientDecorator> extends AgentTestRu
   @Unroll
   def "basic #method request #url"() {
     when:
-    def status = doRequest(method, server.address.resolve(url))
+    def status = withConfigOverride(Config.HTTP_CLIENT_TAG_QUERY_STRING, "$tagQueryString") {
+      doRequest(method, url)
+    }
 
     then:
     status == 200
@@ -350,6 +352,10 @@ abstract class HttpClientTest<T extends HttpClientDecorator> extends AgentTestRu
           "$Tags.HTTP_STATUS.key" status
         }
         "$Tags.HTTP_URL.key" "${uri.resolve(uri.path)}"
+        if (tagQueryString) {
+          "http.query.string" uri.query
+          "http.fragment.string" { it == null || it == uri.fragment } // Optional
+        }
         "$Tags.PEER_HOSTNAME.key" "localhost"
         "$Tags.PEER_PORT.key" uri.port
         "$Tags.PEER_HOST_IPV4.key" { it == null || it == "127.0.0.1" } // Optional

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/utils/ConfigUtils.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/utils/ConfigUtils.groovy
@@ -1,0 +1,102 @@
+package datadog.trace.agent.test.utils
+
+import datadog.trace.api.Config
+import lombok.SneakyThrows
+import net.bytebuddy.agent.ByteBuddyAgent
+import net.bytebuddy.agent.builder.AgentBuilder
+import net.bytebuddy.dynamic.ClassFileLocator
+import net.bytebuddy.dynamic.Transformer
+
+import java.lang.reflect.Modifier
+import java.util.concurrent.Callable
+
+import static net.bytebuddy.description.modifier.FieldManifestation.VOLATILE
+import static net.bytebuddy.description.modifier.Ownership.STATIC
+import static net.bytebuddy.description.modifier.Visibility.PUBLIC
+import static net.bytebuddy.matcher.ElementMatchers.named
+import static net.bytebuddy.matcher.ElementMatchers.none
+
+class ConfigUtils {
+  private static class ConfigInstance {
+    // Wrapped in a static class to lazy load.
+    static final FIELD = Config.getDeclaredField("INSTANCE")
+  }
+
+  // TODO: ideally all users of this should switch to using Config object (and withConfigOverride) instead.
+  @Deprecated
+  @SneakyThrows
+  static <T extends Object> Object withSystemProperty(final String name, final String value, final Callable<T> r) {
+    if (value == null) {
+      System.clearProperty(name)
+    } else {
+      System.setProperty(name, value)
+    }
+    try {
+      return r.call()
+    } finally {
+      System.clearProperty(name)
+    }
+  }
+
+  @SneakyThrows
+  synchronized static <T extends Object> Object withConfigOverride(final String name, final String value, final Callable<T> r) {
+    // Ensure the class was retransformed properly in AgentTestRunner.makeConfigInstanceModifiable()
+    assert Modifier.isPublic(ConfigInstance.FIELD.getModifiers())
+    assert Modifier.isStatic(ConfigInstance.FIELD.getModifiers())
+    assert Modifier.isVolatile(ConfigInstance.FIELD.getModifiers())
+    assert !Modifier.isFinal(ConfigInstance.FIELD.getModifiers())
+
+    def existingConfig = Config.get()
+    Properties properties = new Properties()
+    properties.put(name, value)
+    ConfigInstance.FIELD.set(null, new Config(properties, existingConfig))
+    assert Config.get() != existingConfig
+    try {
+      return r.call()
+    } finally {
+      ConfigInstance.FIELD.set(null, existingConfig)
+    }
+  }
+
+  /**
+   * Calling will reset the runtimeId too, so it might cause problems around runtimeId verification.
+   */
+  static void resetConfig() {
+    // Ensure the class was retransformed properly in AgentTestRunner.makeConfigInstanceModifiable()
+    assert Modifier.isPublic(ConfigInstance.FIELD.getModifiers())
+    assert Modifier.isStatic(ConfigInstance.FIELD.getModifiers())
+    assert Modifier.isVolatile(ConfigInstance.FIELD.getModifiers())
+    assert !Modifier.isFinal(ConfigInstance.FIELD.getModifiers())
+
+    ConfigInstance.FIELD.set(null, new Config())
+  }
+
+  static void makeConfigInstanceModifiable() {
+    def instrumentation = ByteBuddyAgent.install()
+    final transformer =
+      new AgentBuilder.Default()
+        .with(AgentBuilder.RedefinitionStrategy.RETRANSFORMATION)
+        .with(AgentBuilder.RedefinitionStrategy.Listener.ErrorEscalating.FAIL_FAST)
+      // Config is injected into the bootstrap, so we need to provide a locator.
+        .with(
+          new AgentBuilder.LocationStrategy.Simple(
+            ClassFileLocator.ForClassLoader.ofSystemLoader()))
+        .ignore(none()) // Allow transforming boostrap classes
+        .type(named("datadog.trace.api.Config"))
+        .transform { builder, typeDescription, classLoader, module ->
+          builder
+            .field(named("INSTANCE"))
+            .transform(Transformer.ForField.withModifiers(PUBLIC, STATIC, VOLATILE))
+        }
+        .installOn(instrumentation)
+
+    final field = ConfigInstance.FIELD
+    assert Modifier.isPublic(field.getModifiers())
+    assert Modifier.isStatic(field.getModifiers())
+    assert Modifier.isVolatile(field.getModifiers())
+    assert !Modifier.isFinal(field.getModifiers())
+
+    // No longer needed (Unless class gets retransformed somehow).
+    instrumentation.removeTransformer(transformer)
+  }
+}

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/utils/TraceUtils.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/utils/TraceUtils.groovy
@@ -60,7 +60,7 @@ class TraceUtils {
   }
 
   @SneakyThrows
-  static <T extends Object> Object withConfigOverride(final String name, final String value, final Callable<T> r) {
+  synchronized static <T extends Object> Object withConfigOverride(final String name, final String value, final Callable<T> r) {
     def existingConfig = Config.get()  // We can't reference INSTANCE directly or the reflection below will fail.
     Properties properties = new Properties()
     properties.put(name, value)

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/utils/TraceUtils.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/utils/TraceUtils.groovy
@@ -1,17 +1,14 @@
 package datadog.trace.agent.test.utils
 
 import datadog.trace.agent.decorator.BaseDecorator
-import datadog.trace.api.Config
 import datadog.trace.context.TraceScope
 import io.opentracing.Scope
 import io.opentracing.util.GlobalTracer
 import lombok.SneakyThrows
 
-import java.lang.reflect.Modifier
 import java.util.concurrent.Callable
 
 class TraceUtils {
-  static final def CONFIG_INSTANCE_FIELD = Config.getDeclaredField("INSTANCE")
 
   private static final BaseDecorator DECORATOR = new BaseDecorator() {
     protected String[] instrumentationNames() {
@@ -43,53 +40,5 @@ class TraceUtils {
       DECORATOR.beforeFinish(scope)
       scope.close()
     }
-  }
-
-  // TODO: ideally all users of this should switch to using Config object (and withConfigOverride) instead.
-  @SneakyThrows
-  static <T extends Object> Object withSystemProperty(final String name, final String value, final Callable<T> r) {
-    if (value == null) {
-      System.clearProperty(name)
-    } else {
-      System.setProperty(name, value)
-    }
-    try {
-      return r.call()
-    } finally {
-      System.clearProperty(name)
-    }
-  }
-
-  @SneakyThrows
-  synchronized static <T extends Object> Object withConfigOverride(final String name, final String value, final Callable<T> r) {
-    // Ensure the class was retransformed properly in AgentTestRunner.makeConfigInstanceModifiable()
-    assert Modifier.isPublic(CONFIG_INSTANCE_FIELD.getModifiers())
-    assert Modifier.isStatic(CONFIG_INSTANCE_FIELD.getModifiers())
-    assert Modifier.isVolatile(CONFIG_INSTANCE_FIELD.getModifiers())
-    assert !Modifier.isFinal(CONFIG_INSTANCE_FIELD.getModifiers())
-
-    def existingConfig = Config.get()
-    Properties properties = new Properties()
-    properties.put(name, value)
-    CONFIG_INSTANCE_FIELD.set(null, new Config(properties, existingConfig))
-    assert Config.get() != existingConfig
-    try {
-      return r.call()
-    } finally {
-      CONFIG_INSTANCE_FIELD.set(null, existingConfig)
-    }
-  }
-
-  /**
-   * Calling will reset the runtimeId too, so it might cause problems around runtimeId verification.
-   */
-  static void resetConfig() {
-    // Ensure the class was retransformed properly in AgentTestRunner.makeConfigInstanceModifiable()
-    assert Modifier.isPublic(CONFIG_INSTANCE_FIELD.getModifiers())
-    assert Modifier.isStatic(CONFIG_INSTANCE_FIELD.getModifiers())
-    assert Modifier.isVolatile(CONFIG_INSTANCE_FIELD.getModifiers())
-    assert !Modifier.isFinal(CONFIG_INSTANCE_FIELD.getModifiers())
-
-    CONFIG_INSTANCE_FIELD.set(null, new Config())
   }
 }

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/utils/TraceUtils.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/utils/TraceUtils.groovy
@@ -20,7 +20,6 @@ class TraceUtils {
     }
 
     protected String component() {
-//      return "runUnderTrace"
       return null
     }
   }

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/utils/TraceUtils.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/utils/TraceUtils.groovy
@@ -1,10 +1,9 @@
 package datadog.trace.agent.test.utils
 
+import datadog.trace.agent.decorator.BaseDecorator
 import datadog.trace.api.Config
 import datadog.trace.context.TraceScope
 import io.opentracing.Scope
-import io.opentracing.Span
-import io.opentracing.tag.Tags
 import io.opentracing.util.GlobalTracer
 import lombok.SneakyThrows
 
@@ -12,24 +11,35 @@ import java.lang.reflect.Field
 import java.lang.reflect.Modifier
 import java.util.concurrent.Callable
 
-import static io.opentracing.log.Fields.ERROR_OBJECT
-
 class TraceUtils {
+  private static final BaseDecorator DECORATOR = new BaseDecorator() {
+    protected String[] instrumentationNames() {
+      return new String[0]
+    }
+
+    protected String spanType() {
+      return null
+    }
+
+    protected String component() {
+//      return "runUnderTrace"
+      return null
+    }
+  }
 
   @SneakyThrows
   static <T extends Object> Object runUnderTrace(final String rootOperationName, final Callable<T> r) {
     final Scope scope = GlobalTracer.get().buildSpan(rootOperationName).startActive(true)
+    DECORATOR.afterStart(scope)
     ((TraceScope) scope).setAsyncPropagation(true)
 
     try {
       return r.call()
     } catch (final Exception e) {
-      final Span span = scope.span()
-      Tags.ERROR.set(span, true)
-      span.log(Collections.singletonMap(ERROR_OBJECT, e))
-
+      DECORATOR.onError(scope, e)
       throw e
     } finally {
+      DECORATOR.beforeFinish(scope)
       scope.close()
     }
   }

--- a/dd-java-agent/testing/src/test/groovy/AgentTestRunnerTest.groovy
+++ b/dd-java-agent/testing/src/test/groovy/AgentTestRunnerTest.groovy
@@ -10,7 +10,7 @@ import spock.lang.Shared
 
 import java.lang.reflect.Field
 
-import static datadog.trace.agent.test.utils.TraceUtils.resetConfig
+import static datadog.trace.agent.test.utils.ConfigUtils.resetConfig
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 import static datadog.trace.api.Config.TRACE_CLASSES_EXCLUDE
 

--- a/dd-trace-api/src/main/java/datadog/trace/api/Config.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/Config.java
@@ -57,6 +57,8 @@ public class Config {
   public static final String HEADER_TAGS = "trace.header.tags";
   public static final String HTTP_SERVER_ERROR_STATUSES = "http.server.error.statuses";
   public static final String HTTP_CLIENT_ERROR_STATUSES = "http.client.error.statuses";
+  public static final String HTTP_SERVER_TAG_QUERY_STRING = "http.server.tag.query-string";
+  public static final String HTTP_CLIENT_TAG_QUERY_STRING = "http.client.tag.query-string";
   public static final String HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN = "trace.http.client.split-by-domain";
   public static final String PARTIAL_FLUSH_MIN_SPANS = "trace.partial.flush.min.spans";
   public static final String RUNTIME_CONTEXT_FIELD_INJECTION =
@@ -98,6 +100,8 @@ public class Config {
       parseIntegerRangeSet("500-599", "default");
   private static final Set<Integer> DEFAULT_HTTP_CLIENT_ERROR_STATUSES =
       parseIntegerRangeSet("400-499", "default");
+  private static final boolean DEFAULT_HTTP_SERVER_TAG_QUERY_STRING = true;
+  private static final boolean DEFAULT_HTTP_CLIENT_TAG_QUERY_STRING = true;
   private static final boolean DEFAULT_HTTP_CLIENT_SPLIT_BY_DOMAIN = false;
   private static final int DEFAULT_PARTIAL_FLUSH_MIN_SPANS = 1000;
   private static final String DEFAULT_PROPAGATION_STYLE_EXTRACT = PropagationStyle.DATADOG.name();
@@ -142,6 +146,8 @@ public class Config {
   @Getter private final Map<String, String> headerTags;
   @Getter private final Set<Integer> httpServerErrorStatuses;
   @Getter private final Set<Integer> httpClientErrorStatuses;
+  @Getter private final boolean httpServerTagQueryString;
+  @Getter private final boolean httpClientTagQueryString;
   @Getter private final boolean httpClientSplitByDomain;
   @Getter private final Integer partialFlushMinSpans;
   @Getter private final boolean runtimeContextFieldInjection;
@@ -197,6 +203,14 @@ public class Config {
     httpClientErrorStatuses =
         getIntegerRangeSettingFromEnvironment(
             HTTP_CLIENT_ERROR_STATUSES, DEFAULT_HTTP_CLIENT_ERROR_STATUSES);
+
+    httpServerTagQueryString =
+        getBooleanSettingFromEnvironment(
+            HTTP_SERVER_TAG_QUERY_STRING, DEFAULT_HTTP_SERVER_TAG_QUERY_STRING);
+
+    httpClientTagQueryString =
+        getBooleanSettingFromEnvironment(
+            HTTP_CLIENT_TAG_QUERY_STRING, DEFAULT_HTTP_CLIENT_TAG_QUERY_STRING);
 
     httpClientSplitByDomain =
         getBooleanSettingFromEnvironment(
@@ -279,6 +293,14 @@ public class Config {
     httpClientErrorStatuses =
         getPropertyIntegerRangeValue(
             properties, HTTP_CLIENT_ERROR_STATUSES, parent.httpClientErrorStatuses);
+
+    httpServerTagQueryString =
+        getPropertyBooleanValue(
+            properties, HTTP_SERVER_TAG_QUERY_STRING, parent.httpServerTagQueryString);
+
+    httpClientTagQueryString =
+        getPropertyBooleanValue(
+            properties, HTTP_CLIENT_TAG_QUERY_STRING, parent.httpClientTagQueryString);
 
     httpClientSplitByDomain =
         getPropertyBooleanValue(

--- a/dd-trace-api/src/main/java/datadog/trace/api/Config.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/Config.java
@@ -100,8 +100,8 @@ public class Config {
       parseIntegerRangeSet("500-599", "default");
   private static final Set<Integer> DEFAULT_HTTP_CLIENT_ERROR_STATUSES =
       parseIntegerRangeSet("400-499", "default");
-  private static final boolean DEFAULT_HTTP_SERVER_TAG_QUERY_STRING = true;
-  private static final boolean DEFAULT_HTTP_CLIENT_TAG_QUERY_STRING = true;
+  private static final boolean DEFAULT_HTTP_SERVER_TAG_QUERY_STRING = false;
+  private static final boolean DEFAULT_HTTP_CLIENT_TAG_QUERY_STRING = false;
   private static final boolean DEFAULT_HTTP_CLIENT_SPLIT_BY_DOMAIN = false;
   private static final int DEFAULT_PARTIAL_FLUSH_MIN_SPANS = 1000;
   private static final String DEFAULT_PROPAGATION_STYLE_EXTRACT = PropagationStyle.DATADOG.name();


### PR DESCRIPTION
Disabled by default.

Enable for http servers with:
* System Property: `dd.http.server.tag.query-string=true`
* Environment Variable: `DD_HTTP_SERVER_TAG_QUERY_STRING=true`

Enable for http clients with:
* System Property: `dd.http.client.tag.query-string=true`
* Environment Variable: `DD_HTTP_CLIENT_TAG_QUERY_STRING=true`

Also contains a big commit that refactors all the http client unit tests to extend from the base `HttpTestClient`.  Eventually it would be nice to reduce the need for all the inconsistencies.