### PR TITLE
Make agent-tooling compile-depend on dd-tracing-ot directly

### DIFF
--- a/dd-java-agent/agent-tooling/agent-tooling.gradle
+++ b/dd-java-agent/agent-tooling/agent-tooling.gradle
@@ -16,7 +16,7 @@ dependencies {
   annotationProcessor deps.autoservice
   implementation deps.autoservice
 
-  compileOnly project(':dd-trace-ot')
+  compile project(':dd-trace-ot')
 
   testCompile deps.opentracing
   testCompile project(':dd-java-agent:testing')

--- a/dd-java-agent/instrumentation/glassfish/glassfish.gradle
+++ b/dd-java-agent/instrumentation/glassfish/glassfish.gradle
@@ -19,7 +19,6 @@ testSets {
 
 dependencies {
 
-  compile project(':dd-trace-ot')
   compile project(':dd-java-agent:agent-tooling')
 
   compile deps.bytebuddy

--- a/dd-java-agent/instrumentation/grpc-1.5/grpc-1.5.gradle
+++ b/dd-java-agent/instrumentation/grpc-1.5/grpc-1.5.gradle
@@ -44,7 +44,6 @@ testSets {
 dependencies {
   compileOnly group: 'io.grpc', name: 'grpc-core', version: grpcVersion
 
-  compile project(':dd-trace-ot')
   compile project(':dd-java-agent:agent-tooling')
 
   compile deps.bytebuddy

--- a/dd-java-agent/instrumentation/hystrix-1.4/hystrix-1.4.gradle
+++ b/dd-java-agent/instrumentation/hystrix-1.4/hystrix-1.4.gradle
@@ -20,7 +20,6 @@ dependencies {
   compileOnly group: 'com.netflix.hystrix', name: 'hystrix-core', version: '1.4.0'
   compileOnly group: 'io.reactivex', name: 'rxjava', version: '1.0.7'
 
-  compile project(':dd-trace-ot')
   compile project(':dd-java-agent:agent-tooling')
 
   compile deps.bytebuddy

--- a/dd-java-agent/instrumentation/instrumentation.gradle
+++ b/dd-java-agent/instrumentation/instrumentation.gradle
@@ -1,10 +1,10 @@
 // this project will run in isolation under the agent's classloader
 buildscript {
-  
+
   repositories {
     mavenCentral()
   }
-  
+
   dependencies {
     classpath "net.bytebuddy:byte-buddy-gradle-plugin:${versions.bytebuddy}"
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"

--- a/dd-java-agent/instrumentation/java-concurrent/akka-2.5-testing/akka-2.5-testing.gradle
+++ b/dd-java-agent/instrumentation/java-concurrent/akka-2.5-testing/akka-2.5-testing.gradle
@@ -12,7 +12,6 @@ dependencies {
   compileOnly deps.scala
 
   testCompile project(':dd-trace-api')
-  testCompile project(':dd-trace-ot')
   testCompile deps.scala
   testCompile group: 'com.typesafe.akka', name: 'akka-actor_2.11', version: '2.5.0'
 

--- a/dd-java-agent/instrumentation/java-concurrent/akka-testing/akka-testing.gradle
+++ b/dd-java-agent/instrumentation/java-concurrent/akka-testing/akka-testing.gradle
@@ -9,9 +9,8 @@ apply from: "${rootDir}/gradle/test-with-scala.gradle"
 
 dependencies {
   compileOnly deps.scala
-  
+
   testCompile project(':dd-trace-api')
-  testCompile project(':dd-trace-ot')
   testCompile deps.scala
   testCompile group: 'com.typesafe.akka', name: 'akka-actor_2.11', version: '2.3.16'
   testCompile group: 'com.typesafe.akka', name: 'akka-testkit_2.11', version: '2.3.16'

--- a/dd-java-agent/instrumentation/java-concurrent/kotlin-testing/kotlin-testing.gradle
+++ b/dd-java-agent/instrumentation/java-concurrent/kotlin-testing/kotlin-testing.gradle
@@ -3,7 +3,8 @@ apply from: "${rootDir}/gradle/test-with-kotlin.gradle"
 
 dependencies {
   testCompile project(':dd-trace-api')
-  testCompile project(':dd-trace-ot')
+  
+  
   testCompile deps.kotlin
   testCompile deps.coroutines
 

--- a/dd-java-agent/instrumentation/java-concurrent/scala-testing/scala-testing.gradle
+++ b/dd-java-agent/instrumentation/java-concurrent/scala-testing/scala-testing.gradle
@@ -11,7 +11,6 @@ dependencies {
   compileOnly deps.scala
 
   testCompile project(':dd-trace-api')
-  testCompile project(':dd-trace-ot')
   testCompile deps.scala
 
   testCompile project(':dd-java-agent:testing')

--- a/dd-java-agent/instrumentation/jetty-8/jetty-8.gradle
+++ b/dd-java-agent/instrumentation/jetty-8/jetty-8.gradle
@@ -20,7 +20,6 @@ testSets {
 dependencies {
   compileOnly group: 'javax.servlet', name: 'javax.servlet-api', version: '3.0.1'
 
-  compile project(':dd-trace-ot')
   compile project(':dd-java-agent:agent-tooling')
 
   compile deps.bytebuddy

--- a/dd-java-agent/instrumentation/jsp-2.3/jsp-2.3.gradle
+++ b/dd-java-agent/instrumentation/jsp-2.3/jsp-2.3.gradle
@@ -23,7 +23,6 @@ dependencies {
   compileOnly group: 'javax.servlet.jsp', name: 'javax.servlet.jsp-api', version: '2.3.0'
   compileOnly group: 'javax.servlet', name: 'javax.servlet-api', version: '3.1.0'
 
-  compile project(':dd-trace-ot')
   compile project(':dd-java-agent:agent-tooling')
 
   compile deps.bytebuddy

--- a/dd-java-agent/instrumentation/okhttp-3/okhttp-3.gradle
+++ b/dd-java-agent/instrumentation/okhttp-3/okhttp-3.gradle
@@ -17,10 +17,21 @@ testSets {
   }
 }
 
+/*
+Note: there is a bit of dependency exclusion magic goin on.
+We have to exclude all transitive dependencies on 'okhttp' because we would like to force
+specific version. We cannot use . Unfortunately we cannot just force version on
+a dependency because this doesn't work well with version ranges - it doesn't select latest.
+And we cannot use configurations to exclude this dependency from everywhere in one go
+because it looks like exclusions using configurations excludes dependency even if it explicit
+not transitive.
+ */
 dependencies {
-  compileOnly group: 'com.squareup.okhttp3', name: 'okhttp', version: '3.0.0'
+  compileOnly(group: 'com.squareup.okhttp3', name: 'okhttp', version: '3.0.0')
 
-  compile project(':dd-java-agent:agent-tooling')
+  compile(project(':dd-java-agent:agent-tooling')) {
+    exclude module: 'okhttp'
+  }
 
   compile deps.bytebuddy
   compile deps.opentracing
@@ -30,7 +41,9 @@ dependencies {
   testCompile(project(':dd-java-agent:testing')) {
     exclude module: 'okhttp'
   }
-  testCompile project(':dd-java-agent:instrumentation:java-concurrent')
+  testCompile(project(':dd-java-agent:instrumentation:java-concurrent')) {
+    exclude module: 'okhttp'
+  }
   testCompile group: 'com.squareup.okhttp3', name: 'okhttp', version: '3.0.0'
 
   // 4.x.x-alpha has been released and it looks like there are lots of incompatible changes

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/rabbitmq-amqp-2.7.gradle
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/rabbitmq-amqp-2.7.gradle
@@ -20,7 +20,6 @@ testSets {
 dependencies {
   compileOnly group: 'com.rabbitmq', name: 'amqp-client', version: '2.7.0'
 
-  compile project(':dd-trace-ot')
   compile project(':dd-java-agent:agent-tooling')
 
   compile deps.bytebuddy

--- a/dd-java-agent/instrumentation/servlet-3/servlet-3.gradle
+++ b/dd-java-agent/instrumentation/servlet-3/servlet-3.gradle
@@ -25,7 +25,6 @@ testSets {
 dependencies {
   compileOnly group: 'javax.servlet', name: 'javax.servlet-api', version: '3.0.1'
 
-  compile project(':dd-trace-ot')
   compile project(':dd-java-agent:agent-tooling')
 
   compile deps.bytebuddy

--- a/dd-java-agent/testing/testing.gradle
+++ b/dd-java-agent/testing/testing.gradle
@@ -22,9 +22,6 @@ dependencies {
 
   compile group: 'org.eclipse.jetty', name: 'jetty-server', version: '8.0.0.v20110901'
 
-  compile group: 'com.squareup.okhttp3', name: 'okhttp', version: '3.11.0'
-
-  compile project(':dd-trace-ot')
   compile project(':dd-java-agent:agent-tooling')
 
   annotationProcessor deps.autoservice


### PR DESCRIPTION
This ensures that `dd-tracng-ot` gets included into shadow jar.
Before this patch it was included only 'by accident' via some
transitive dependencies of some instrumentations.