### PR TITLE
Make Akka client test more stable

### DIFF
--- a/dd-java-agent/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpClientInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpClientInstrumentationTest.groovy
@@ -23,8 +23,12 @@ class AkkaHttpClientInstrumentationTest extends HttpClientTest<AkkaHttpClientDec
       .withMethod(HttpMethods.lookup(method).get())
       .addHeaders(headers.collect { RawHeader.create(it.key, it.value) })
 
-    def response = Http.get(system).singleRequest(request, materializer).toCompletableFuture().get()
-    blockUntilChildSpansFinished(1)
+    def response
+    try {
+      response = Http.get(system).singleRequest(request, materializer).toCompletableFuture().get()
+    } finally {
+      blockUntilChildSpansFinished(1)
+    }
     callback?.call()
     return response.status().intValue()
   }


### PR DESCRIPTION
We already have a hack to wait for client span to close after the
request because it is closed on separate thread. This patch extends
that hack to handle cases when original request throws an exception.