### PR TITLE
Support context propagation in akka scheduler

### DIFF
--- a/dd-java-agent/instrumentation/akka-http-10.0/akka-http-10.0.gradle
+++ b/dd-java-agent/instrumentation/akka-http-10.0/akka-http-10.0.gradle
@@ -105,7 +105,7 @@ dependencies {
   latestDepTestCompile project(':dd-java-agent:instrumentation:trace-annotation')
 }
 
-test.dependsOn lagomTest
+//test.dependsOn lagomTest
 test.dependsOn version101Test
 
 compileVersion101TestGroovy {
@@ -116,4 +116,24 @@ compileVersion101TestGroovy {
 compileLatestDepTestGroovy {
   classpath = classpath.plus(files(compileLatestDepTestScala.destinationDir))
   dependsOn compileLatestDepTestScala
+}
+
+test {
+  testLogging {
+    // Make sure output from
+    // standard out or error is shown
+    // in Gradle output.
+    showStandardStreams = true
+
+    // Or we use events method:
+    // events 'standard_out', 'standard_error'
+
+    // Or set property events:
+    // events = ['standard_out', 'standard_error']
+
+    // Instead of string values we can
+    // use enum values:
+    // events org.gradle.api.tasks.testing.logging.TestLogEvent.STANDARD_OUT,
+    //        org.gradle.api.tasks.testing.logging.TestLogEvent.STANDARD_ERROR,
+  }
 }

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpServerInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpServerInstrumentationTest.groovy
@@ -69,165 +69,165 @@ class AkkaHttpServerInstrumentationTest extends AgentTestRunner {
     "async" | asyncPort
     "sync"  | syncPort
   }
-
-  def "#server 200 request trace with distributed tracing propagation"() {
-    setup:
-    def request = new Request.Builder()
-      .url("http://localhost:$port/test")
-      .header("x-datadog-trace-id", "123")
-      .header("x-datadog-parent-id", "456")
-      .get()
-      .build()
-    def response = client.newCall(request).execute()
-
-    expect:
-    response.code() == 200
-
-    assertTraces(1) {
-      trace(0, 2) {
-        span(0) {
-          traceId "123"
-          parentId "456"
-          serviceName "unnamed-java-app"
-          operationName "akka-http.request"
-          resourceName "GET /test"
-          spanType DDSpanTypes.HTTP_SERVER
-          errored false
-          tags {
-            defaultTags(true)
-            "$Tags.HTTP_STATUS.key" 200
-            "$Tags.HTTP_URL.key" "http://localhost:$port/test"
-            "$Tags.HTTP_METHOD.key" "GET"
-            "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
-            "$Tags.COMPONENT.key" "akka-http-server"
-          }
-        }
-        span(1) {
-          childOf span(0)
-          assert span(1).operationName.endsWith('.tracedMethod')
-        }
-      }
-    }
-
-    where:
-    server  | port
-    "async" | asyncPort
-    "sync"  | syncPort
-  }
-
-  def "#server exceptions trace for #endpoint"() {
-    setup:
-    def request = new Request.Builder()
-      .url("http://localhost:$port/$endpoint")
-      .get()
-      .build()
-    def response = client.newCall(request).execute()
-
-    expect:
-    response.code() == 500
-
-    assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
-          serviceName "unnamed-java-app"
-          operationName "akka-http.request"
-          resourceName "GET /$endpoint"
-          spanType DDSpanTypes.HTTP_SERVER
-          errored true
-          tags {
-            defaultTags()
-            "$Tags.HTTP_STATUS.key" 500
-            "$Tags.HTTP_URL.key" "http://localhost:$port/$endpoint"
-            "$Tags.HTTP_METHOD.key" "GET"
-            "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
-            "$Tags.COMPONENT.key" "akka-http-server"
-            errorTags RuntimeException, errorMessage
-          }
-        }
-      }
-    }
-
-    where:
-    server  | port      | endpoint         | errorMessage
-    "async" | asyncPort | "throw-handler"  | "Oh no handler"
-    "async" | asyncPort | "throw-callback" | "Oh no callback"
-    "sync"  | syncPort  | "throw-handler"  | "Oh no handler"
-  }
-
-  def "#server 5xx trace"() {
-    setup:
-    def request = new Request.Builder()
-      .url("http://localhost:$port/server-error")
-      .get()
-      .build()
-    def response = client.newCall(request).execute()
-
-    expect:
-    response.code() == 500
-
-    assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
-          serviceName "unnamed-java-app"
-          operationName "akka-http.request"
-          resourceName "GET /server-error"
-          spanType DDSpanTypes.HTTP_SERVER
-          errored true
-          tags {
-            defaultTags()
-            "$Tags.HTTP_STATUS.key" 500
-            "$Tags.HTTP_URL.key" "http://localhost:$port/server-error"
-            "$Tags.HTTP_METHOD.key" "GET"
-            "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
-            "$Tags.COMPONENT.key" "akka-http-server"
-            "$Tags.ERROR.key" true
-          }
-        }
-      }
-    }
-
-    where:
-    server  | port
-    "async" | asyncPort
-    "sync"  | syncPort
-  }
-
-  def "#server 4xx trace"() {
-    setup:
-    def request = new Request.Builder()
-      .url("http://localhost:$port/not-found")
-      .get()
-      .build()
-    def response = client.newCall(request).execute()
-
-    expect:
-    response.code() == 404
-
-    assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
-          serviceName "unnamed-java-app"
-          operationName "akka-http.request"
-          resourceName "404"
-          spanType DDSpanTypes.HTTP_SERVER
-          errored false
-          tags {
-            defaultTags()
-            "$Tags.HTTP_STATUS.key" 404
-            "$Tags.HTTP_URL.key" "http://localhost:$port/not-found"
-            "$Tags.HTTP_METHOD.key" "GET"
-            "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
-            "$Tags.COMPONENT.key" "akka-http-server"
-          }
-        }
-      }
-    }
-
-    where:
-    server  | port
-    "async" | asyncPort
-    "sync"  | syncPort
-  }
+//
+//  def "#server 200 request trace with distributed tracing propagation"() {
+//    setup:
+//    def request = new Request.Builder()
+//      .url("http://localhost:$port/test")
+//      .header("x-datadog-trace-id", "123")
+//      .header("x-datadog-parent-id", "456")
+//      .get()
+//      .build()
+//    def response = client.newCall(request).execute()
+//
+//    expect:
+//    response.code() == 200
+//
+//    assertTraces(1) {
+//      trace(0, 2) {
+//        span(0) {
+//          traceId "123"
+//          parentId "456"
+//          serviceName "unnamed-java-app"
+//          operationName "akka-http.request"
+//          resourceName "GET /test"
+//          spanType DDSpanTypes.HTTP_SERVER
+//          errored false
+//          tags {
+//            defaultTags(true)
+//            "$Tags.HTTP_STATUS.key" 200
+//            "$Tags.HTTP_URL.key" "http://localhost:$port/test"
+//            "$Tags.HTTP_METHOD.key" "GET"
+//            "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
+//            "$Tags.COMPONENT.key" "akka-http-server"
+//          }
+//        }
+//        span(1) {
+//          childOf span(0)
+//          assert span(1).operationName.endsWith('.tracedMethod')
+//        }
+//      }
+//    }
+//
+//    where:
+//    server  | port
+//    "async" | asyncPort
+//    "sync"  | syncPort
+//  }
+//
+//  def "#server exceptions trace for #endpoint"() {
+//    setup:
+//    def request = new Request.Builder()
+//      .url("http://localhost:$port/$endpoint")
+//      .get()
+//      .build()
+//    def response = client.newCall(request).execute()
+//
+//    expect:
+//    response.code() == 500
+//
+//    assertTraces(1) {
+//      trace(0, 1) {
+//        span(0) {
+//          serviceName "unnamed-java-app"
+//          operationName "akka-http.request"
+//          resourceName "GET /$endpoint"
+//          spanType DDSpanTypes.HTTP_SERVER
+//          errored true
+//          tags {
+//            defaultTags()
+//            "$Tags.HTTP_STATUS.key" 500
+//            "$Tags.HTTP_URL.key" "http://localhost:$port/$endpoint"
+//            "$Tags.HTTP_METHOD.key" "GET"
+//            "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
+//            "$Tags.COMPONENT.key" "akka-http-server"
+//            errorTags RuntimeException, errorMessage
+//          }
+//        }
+//      }
+//    }
+//
+//    where:
+//    server  | port      | endpoint         | errorMessage
+//    "async" | asyncPort | "throw-handler"  | "Oh no handler"
+//    "async" | asyncPort | "throw-callback" | "Oh no callback"
+//    "sync"  | syncPort  | "throw-handler"  | "Oh no handler"
+//  }
+//
+//  def "#server 5xx trace"() {
+//    setup:
+//    def request = new Request.Builder()
+//      .url("http://localhost:$port/server-error")
+//      .get()
+//      .build()
+//    def response = client.newCall(request).execute()
+//
+//    expect:
+//    response.code() == 500
+//
+//    assertTraces(1) {
+//      trace(0, 1) {
+//        span(0) {
+//          serviceName "unnamed-java-app"
+//          operationName "akka-http.request"
+//          resourceName "GET /server-error"
+//          spanType DDSpanTypes.HTTP_SERVER
+//          errored true
+//          tags {
+//            defaultTags()
+//            "$Tags.HTTP_STATUS.key" 500
+//            "$Tags.HTTP_URL.key" "http://localhost:$port/server-error"
+//            "$Tags.HTTP_METHOD.key" "GET"
+//            "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
+//            "$Tags.COMPONENT.key" "akka-http-server"
+//            "$Tags.ERROR.key" true
+//          }
+//        }
+//      }
+//    }
+//
+//    where:
+//    server  | port
+//    "async" | asyncPort
+//    "sync"  | syncPort
+//  }
+//
+//  def "#server 4xx trace"() {
+//    setup:
+//    def request = new Request.Builder()
+//      .url("http://localhost:$port/not-found")
+//      .get()
+//      .build()
+//    def response = client.newCall(request).execute()
+//
+//    expect:
+//    response.code() == 404
+//
+//    assertTraces(1) {
+//      trace(0, 1) {
+//        span(0) {
+//          serviceName "unnamed-java-app"
+//          operationName "akka-http.request"
+//          resourceName "404"
+//          spanType DDSpanTypes.HTTP_SERVER
+//          errored false
+//          tags {
+//            defaultTags()
+//            "$Tags.HTTP_STATUS.key" 404
+//            "$Tags.HTTP_URL.key" "http://localhost:$port/not-found"
+//            "$Tags.HTTP_METHOD.key" "GET"
+//            "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
+//            "$Tags.COMPONENT.key" "akka-http-server"
+//          }
+//        }
+//      }
+//    }
+//
+//    where:
+//    server  | port
+//    "async" | asyncPort
+//    "sync"  | syncPort
+//  }
 //
 //  def "server scheduling tasks via scala scheduler"() {
 //    setup:

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpServerInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpServerInstrumentationTest.groovy
@@ -27,190 +27,31 @@ class AkkaHttpServerInstrumentationTest extends AgentTestRunner {
     AkkaHttpTestSyncWebServer.stop()
   }
 
-//  def "#server 200 request trace"() {
-//    setup:
-//    def request = new Request.Builder()
-//      .url("http://localhost:$port/test")
-//      .header("x-datadog-trace-id", "123")
-//      .header("x-datadog-parent-id", "456")
-//      .get()
-//      .build()
-//    def response = client.newCall(request).execute()
-//
-//    expect:
-//    response.code() == 200
-//
-//    assertTraces(1) {
-//      trace(0, 2) {
-//        span(0) {
-//          traceId "123"
-//          parentId "456"
-//          serviceName "unnamed-java-app"
-//          operationName "akka-http.request"
-//          resourceName "GET /test"
-//          spanType DDSpanTypes.HTTP_SERVER
-//          errored false
-//          tags {
-//            defaultTags(true)
-//            "$Tags.HTTP_STATUS.key" 200
-//            "$Tags.HTTP_URL.key" "http://localhost:$port/test"
-//            "$Tags.HTTP_METHOD.key" "GET"
-//            "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
-//            "$Tags.COMPONENT.key" "akka-http-server"
-//          }
-//        }
-//        span(1) {
-//          childOf span(0)
-//          assert span(1).operationName.endsWith('.tracedMethod')
-//        }
-//      }
-//    }
-//
-//    where:
-//    server  | port
-//    "async" | asyncPort
-//    "sync"  | syncPort
-//  }
-//
-//  def "#server exceptions trace for #endpoint"() {
-//    setup:
-//    def request = new Request.Builder()
-//      .url("http://localhost:$port/$endpoint")
-//      .get()
-//      .build()
-//    def response = client.newCall(request).execute()
-//
-//    expect:
-//    response.code() == 500
-//
-//    assertTraces(1) {
-//      trace(0, 1) {
-//        span(0) {
-//          serviceName "unnamed-java-app"
-//          operationName "akka-http.request"
-//          resourceName "GET /$endpoint"
-//          spanType DDSpanTypes.HTTP_SERVER
-//          errored true
-//          tags {
-//            defaultTags()
-//            "$Tags.HTTP_STATUS.key" 500
-//            "$Tags.HTTP_URL.key" "http://localhost:$port/$endpoint"
-//            "$Tags.HTTP_METHOD.key" "GET"
-//            "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
-//            "$Tags.COMPONENT.key" "akka-http-server"
-//            errorTags RuntimeException, errorMessage
-//          }
-//        }
-//      }
-//    }
-//
-//    where:
-//    server  | port      | endpoint         | errorMessage
-//    "async" | asyncPort | "throw-handler"  | "Oh no handler"
-//    "async" | asyncPort | "throw-callback" | "Oh no callback"
-//    "sync"  | syncPort  | "throw-handler"  | "Oh no handler"
-//  }
-//
-//  def "#server 5xx trace"() {
-//    setup:
-//    def request = new Request.Builder()
-//      .url("http://localhost:$port/server-error")
-//      .get()
-//      .build()
-//    def response = client.newCall(request).execute()
-//
-//    expect:
-//    response.code() == 500
-//
-//    assertTraces(1) {
-//      trace(0, 1) {
-//        span(0) {
-//          serviceName "unnamed-java-app"
-//          operationName "akka-http.request"
-//          resourceName "GET /server-error"
-//          spanType DDSpanTypes.HTTP_SERVER
-//          errored true
-//          tags {
-//            defaultTags()
-//            "$Tags.HTTP_STATUS.key" 500
-//            "$Tags.HTTP_URL.key" "http://localhost:$port/server-error"
-//            "$Tags.HTTP_METHOD.key" "GET"
-//            "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
-//            "$Tags.COMPONENT.key" "akka-http-server"
-//            "$Tags.ERROR.key" true
-//          }
-//        }
-//      }
-//    }
-//
-//    where:
-//    server  | port
-//    "async" | asyncPort
-//    "sync"  | syncPort
-//  }
-//
-//  def "#server 4xx trace"() {
-//    setup:
-//    def request = new Request.Builder()
-//      .url("http://localhost:$port/not-found")
-//      .get()
-//      .build()
-//    def response = client.newCall(request).execute()
-//
-//    expect:
-//    response.code() == 404
-//
-//    assertTraces(1) {
-//      trace(0, 1) {
-//        span(0) {
-//          serviceName "unnamed-java-app"
-//          operationName "akka-http.request"
-//          resourceName "404"
-//          spanType DDSpanTypes.HTTP_SERVER
-//          errored false
-//          tags {
-//            defaultTags()
-//            "$Tags.HTTP_STATUS.key" 404
-//            "$Tags.HTTP_URL.key" "http://localhost:$port/not-found"
-//            "$Tags.HTTP_METHOD.key" "GET"
-//            "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
-//            "$Tags.COMPONENT.key" "akka-http-server"
-//          }
-//        }
-//      }
-//    }
-//
-//    where:
-//    server  | port
-//    "async" | asyncPort
-//    "sync"  | syncPort
-//  }
-
-  def "server scheduling tasks via scala scheduler"() {
+  def "#server 200 request trace"() {
     setup:
     def request = new Request.Builder()
-      .url("http://localhost:$asyncPort/scheduler")
+      .url("http://localhost:$port/test")
       .get()
       .build()
     def response = client.newCall(request).execute()
 
     expect:
     response.code() == 200
-//    response.body().string() == 'aaa'
 
     assertTraces(1) {
       trace(0, 2) {
         span(0) {
-          parentId "0"
+//          traceId "123"
+//          parentId "456"
           serviceName "unnamed-java-app"
           operationName "akka-http.request"
-          resourceName "GET /scheduler"
+          resourceName "GET /test"
           spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
             defaultTags(true)
             "$Tags.HTTP_STATUS.key" 200
-            "$Tags.HTTP_URL.key" "http://localhost:$asyncPort/scheduler"
+            "$Tags.HTTP_URL.key" "http://localhost:$port/test"
             "$Tags.HTTP_METHOD.key" "GET"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
             "$Tags.COMPONENT.key" "akka-http-server"
@@ -222,5 +63,207 @@ class AkkaHttpServerInstrumentationTest extends AgentTestRunner {
         }
       }
     }
+
+    where:
+    server  | port
+    "async" | asyncPort
+    "sync"  | syncPort
   }
+
+  def "#server 200 request trace with distributed tracing propagation"() {
+    setup:
+    def request = new Request.Builder()
+      .url("http://localhost:$port/test")
+      .header("x-datadog-trace-id", "123")
+      .header("x-datadog-parent-id", "456")
+      .get()
+      .build()
+    def response = client.newCall(request).execute()
+
+    expect:
+    response.code() == 200
+
+    assertTraces(1) {
+      trace(0, 2) {
+        span(0) {
+          traceId "123"
+          parentId "456"
+          serviceName "unnamed-java-app"
+          operationName "akka-http.request"
+          resourceName "GET /test"
+          spanType DDSpanTypes.HTTP_SERVER
+          errored false
+          tags {
+            defaultTags(true)
+            "$Tags.HTTP_STATUS.key" 200
+            "$Tags.HTTP_URL.key" "http://localhost:$port/test"
+            "$Tags.HTTP_METHOD.key" "GET"
+            "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
+            "$Tags.COMPONENT.key" "akka-http-server"
+          }
+        }
+        span(1) {
+          childOf span(0)
+          assert span(1).operationName.endsWith('.tracedMethod')
+        }
+      }
+    }
+
+    where:
+    server  | port
+    "async" | asyncPort
+    "sync"  | syncPort
+  }
+
+  def "#server exceptions trace for #endpoint"() {
+    setup:
+    def request = new Request.Builder()
+      .url("http://localhost:$port/$endpoint")
+      .get()
+      .build()
+    def response = client.newCall(request).execute()
+
+    expect:
+    response.code() == 500
+
+    assertTraces(1) {
+      trace(0, 1) {
+        span(0) {
+          serviceName "unnamed-java-app"
+          operationName "akka-http.request"
+          resourceName "GET /$endpoint"
+          spanType DDSpanTypes.HTTP_SERVER
+          errored true
+          tags {
+            defaultTags()
+            "$Tags.HTTP_STATUS.key" 500
+            "$Tags.HTTP_URL.key" "http://localhost:$port/$endpoint"
+            "$Tags.HTTP_METHOD.key" "GET"
+            "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
+            "$Tags.COMPONENT.key" "akka-http-server"
+            errorTags RuntimeException, errorMessage
+          }
+        }
+      }
+    }
+
+    where:
+    server  | port      | endpoint         | errorMessage
+    "async" | asyncPort | "throw-handler"  | "Oh no handler"
+    "async" | asyncPort | "throw-callback" | "Oh no callback"
+    "sync"  | syncPort  | "throw-handler"  | "Oh no handler"
+  }
+
+  def "#server 5xx trace"() {
+    setup:
+    def request = new Request.Builder()
+      .url("http://localhost:$port/server-error")
+      .get()
+      .build()
+    def response = client.newCall(request).execute()
+
+    expect:
+    response.code() == 500
+
+    assertTraces(1) {
+      trace(0, 1) {
+        span(0) {
+          serviceName "unnamed-java-app"
+          operationName "akka-http.request"
+          resourceName "GET /server-error"
+          spanType DDSpanTypes.HTTP_SERVER
+          errored true
+          tags {
+            defaultTags()
+            "$Tags.HTTP_STATUS.key" 500
+            "$Tags.HTTP_URL.key" "http://localhost:$port/server-error"
+            "$Tags.HTTP_METHOD.key" "GET"
+            "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
+            "$Tags.COMPONENT.key" "akka-http-server"
+            "$Tags.ERROR.key" true
+          }
+        }
+      }
+    }
+
+    where:
+    server  | port
+    "async" | asyncPort
+    "sync"  | syncPort
+  }
+
+  def "#server 4xx trace"() {
+    setup:
+    def request = new Request.Builder()
+      .url("http://localhost:$port/not-found")
+      .get()
+      .build()
+    def response = client.newCall(request).execute()
+
+    expect:
+    response.code() == 404
+
+    assertTraces(1) {
+      trace(0, 1) {
+        span(0) {
+          serviceName "unnamed-java-app"
+          operationName "akka-http.request"
+          resourceName "404"
+          spanType DDSpanTypes.HTTP_SERVER
+          errored false
+          tags {
+            defaultTags()
+            "$Tags.HTTP_STATUS.key" 404
+            "$Tags.HTTP_URL.key" "http://localhost:$port/not-found"
+            "$Tags.HTTP_METHOD.key" "GET"
+            "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
+            "$Tags.COMPONENT.key" "akka-http-server"
+          }
+        }
+      }
+    }
+
+    where:
+    server  | port
+    "async" | asyncPort
+    "sync"  | syncPort
+  }
+//
+//  def "server scheduling tasks via scala scheduler"() {
+//    setup:
+//    def request = new Request.Builder()
+//      .url("http://localhost:$asyncPort/scheduler")
+//      .get()
+//      .build()
+//    def response = client.newCall(request).execute()
+//
+//    expect:
+//    response.code() == 200
+////    response.body().string() == 'aaa'
+//
+//    assertTraces(1) {
+//      trace(0, 2) {
+//        span(0) {
+//          parentId "0"
+//          serviceName "unnamed-java-app"
+//          operationName "akka-http.request"
+//          resourceName "GET /scheduler"
+//          spanType DDSpanTypes.HTTP_SERVER
+//          errored false
+//          tags {
+//            defaultTags(true)
+//            "$Tags.HTTP_STATUS.key" 200
+//            "$Tags.HTTP_URL.key" "http://localhost:$asyncPort/scheduler"
+//            "$Tags.HTTP_METHOD.key" "GET"
+//            "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
+//            "$Tags.COMPONENT.key" "akka-http-server"
+//          }
+//        }
+//        span(1) {
+//          childOf span(0)
+//          assert span(1).operationName.endsWith('.tracedMethod')
+//        }
+//      }
+//    }
+//  }
 }

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpServerInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpServerInstrumentationTest.groovy
@@ -27,164 +27,164 @@ class AkkaHttpServerInstrumentationTest extends AgentTestRunner {
     AkkaHttpTestSyncWebServer.stop()
   }
 
-  def "#server 200 request trace"() {
-    setup:
-    def request = new Request.Builder()
-      .url("http://localhost:$port/test")
-      .header("x-datadog-trace-id", "123")
-      .header("x-datadog-parent-id", "456")
-      .get()
-      .build()
-    def response = client.newCall(request).execute()
-
-    expect:
-    response.code() == 200
-
-    assertTraces(1) {
-      trace(0, 2) {
-        span(0) {
-          traceId "123"
-          parentId "456"
-          serviceName "unnamed-java-app"
-          operationName "akka-http.request"
-          resourceName "GET /test"
-          spanType DDSpanTypes.HTTP_SERVER
-          errored false
-          tags {
-            defaultTags(true)
-            "$Tags.HTTP_STATUS.key" 200
-            "$Tags.HTTP_URL.key" "http://localhost:$port/test"
-            "$Tags.HTTP_METHOD.key" "GET"
-            "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
-            "$Tags.COMPONENT.key" "akka-http-server"
-          }
-        }
-        span(1) {
-          childOf span(0)
-          assert span(1).operationName.endsWith('.tracedMethod')
-        }
-      }
-    }
-
-    where:
-    server  | port
-    "async" | asyncPort
-    "sync"  | syncPort
-  }
-
-  def "#server exceptions trace for #endpoint"() {
-    setup:
-    def request = new Request.Builder()
-      .url("http://localhost:$port/$endpoint")
-      .get()
-      .build()
-    def response = client.newCall(request).execute()
-
-    expect:
-    response.code() == 500
-
-    assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
-          serviceName "unnamed-java-app"
-          operationName "akka-http.request"
-          resourceName "GET /$endpoint"
-          spanType DDSpanTypes.HTTP_SERVER
-          errored true
-          tags {
-            defaultTags()
-            "$Tags.HTTP_STATUS.key" 500
-            "$Tags.HTTP_URL.key" "http://localhost:$port/$endpoint"
-            "$Tags.HTTP_METHOD.key" "GET"
-            "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
-            "$Tags.COMPONENT.key" "akka-http-server"
-            errorTags RuntimeException, errorMessage
-          }
-        }
-      }
-    }
-
-    where:
-    server  | port      | endpoint         | errorMessage
-    "async" | asyncPort | "throw-handler"  | "Oh no handler"
-    "async" | asyncPort | "throw-callback" | "Oh no callback"
-    "sync"  | syncPort  | "throw-handler"  | "Oh no handler"
-  }
-
-  def "#server 5xx trace"() {
-    setup:
-    def request = new Request.Builder()
-      .url("http://localhost:$port/server-error")
-      .get()
-      .build()
-    def response = client.newCall(request).execute()
-
-    expect:
-    response.code() == 500
-
-    assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
-          serviceName "unnamed-java-app"
-          operationName "akka-http.request"
-          resourceName "GET /server-error"
-          spanType DDSpanTypes.HTTP_SERVER
-          errored true
-          tags {
-            defaultTags()
-            "$Tags.HTTP_STATUS.key" 500
-            "$Tags.HTTP_URL.key" "http://localhost:$port/server-error"
-            "$Tags.HTTP_METHOD.key" "GET"
-            "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
-            "$Tags.COMPONENT.key" "akka-http-server"
-            "$Tags.ERROR.key" true
-          }
-        }
-      }
-    }
-
-    where:
-    server  | port
-    "async" | asyncPort
-    "sync"  | syncPort
-  }
-
-  def "#server 4xx trace"() {
-    setup:
-    def request = new Request.Builder()
-      .url("http://localhost:$port/not-found")
-      .get()
-      .build()
-    def response = client.newCall(request).execute()
-
-    expect:
-    response.code() == 404
-
-    assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
-          serviceName "unnamed-java-app"
-          operationName "akka-http.request"
-          resourceName "404"
-          spanType DDSpanTypes.HTTP_SERVER
-          errored false
-          tags {
-            defaultTags()
-            "$Tags.HTTP_STATUS.key" 404
-            "$Tags.HTTP_URL.key" "http://localhost:$port/not-found"
-            "$Tags.HTTP_METHOD.key" "GET"
-            "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
-            "$Tags.COMPONENT.key" "akka-http-server"
-          }
-        }
-      }
-    }
-
-    where:
-    server  | port
-    "async" | asyncPort
-    "sync"  | syncPort
-  }
+//  def "#server 200 request trace"() {
+//    setup:
+//    def request = new Request.Builder()
+//      .url("http://localhost:$port/test")
+//      .header("x-datadog-trace-id", "123")
+//      .header("x-datadog-parent-id", "456")
+//      .get()
+//      .build()
+//    def response = client.newCall(request).execute()
+//
+//    expect:
+//    response.code() == 200
+//
+//    assertTraces(1) {
+//      trace(0, 2) {
+//        span(0) {
+//          traceId "123"
+//          parentId "456"
+//          serviceName "unnamed-java-app"
+//          operationName "akka-http.request"
+//          resourceName "GET /test"
+//          spanType DDSpanTypes.HTTP_SERVER
+//          errored false
+//          tags {
+//            defaultTags(true)
+//            "$Tags.HTTP_STATUS.key" 200
+//            "$Tags.HTTP_URL.key" "http://localhost:$port/test"
+//            "$Tags.HTTP_METHOD.key" "GET"
+//            "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
+//            "$Tags.COMPONENT.key" "akka-http-server"
+//          }
+//        }
+//        span(1) {
+//          childOf span(0)
+//          assert span(1).operationName.endsWith('.tracedMethod')
+//        }
+//      }
+//    }
+//
+//    where:
+//    server  | port
+//    "async" | asyncPort
+//    "sync"  | syncPort
+//  }
+//
+//  def "#server exceptions trace for #endpoint"() {
+//    setup:
+//    def request = new Request.Builder()
+//      .url("http://localhost:$port/$endpoint")
+//      .get()
+//      .build()
+//    def response = client.newCall(request).execute()
+//
+//    expect:
+//    response.code() == 500
+//
+//    assertTraces(1) {
+//      trace(0, 1) {
+//        span(0) {
+//          serviceName "unnamed-java-app"
+//          operationName "akka-http.request"
+//          resourceName "GET /$endpoint"
+//          spanType DDSpanTypes.HTTP_SERVER
+//          errored true
+//          tags {
+//            defaultTags()
+//            "$Tags.HTTP_STATUS.key" 500
+//            "$Tags.HTTP_URL.key" "http://localhost:$port/$endpoint"
+//            "$Tags.HTTP_METHOD.key" "GET"
+//            "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
+//            "$Tags.COMPONENT.key" "akka-http-server"
+//            errorTags RuntimeException, errorMessage
+//          }
+//        }
+//      }
+//    }
+//
+//    where:
+//    server  | port      | endpoint         | errorMessage
+//    "async" | asyncPort | "throw-handler"  | "Oh no handler"
+//    "async" | asyncPort | "throw-callback" | "Oh no callback"
+//    "sync"  | syncPort  | "throw-handler"  | "Oh no handler"
+//  }
+//
+//  def "#server 5xx trace"() {
+//    setup:
+//    def request = new Request.Builder()
+//      .url("http://localhost:$port/server-error")
+//      .get()
+//      .build()
+//    def response = client.newCall(request).execute()
+//
+//    expect:
+//    response.code() == 500
+//
+//    assertTraces(1) {
+//      trace(0, 1) {
+//        span(0) {
+//          serviceName "unnamed-java-app"
+//          operationName "akka-http.request"
+//          resourceName "GET /server-error"
+//          spanType DDSpanTypes.HTTP_SERVER
+//          errored true
+//          tags {
+//            defaultTags()
+//            "$Tags.HTTP_STATUS.key" 500
+//            "$Tags.HTTP_URL.key" "http://localhost:$port/server-error"
+//            "$Tags.HTTP_METHOD.key" "GET"
+//            "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
+//            "$Tags.COMPONENT.key" "akka-http-server"
+//            "$Tags.ERROR.key" true
+//          }
+//        }
+//      }
+//    }
+//
+//    where:
+//    server  | port
+//    "async" | asyncPort
+//    "sync"  | syncPort
+//  }
+//
+//  def "#server 4xx trace"() {
+//    setup:
+//    def request = new Request.Builder()
+//      .url("http://localhost:$port/not-found")
+//      .get()
+//      .build()
+//    def response = client.newCall(request).execute()
+//
+//    expect:
+//    response.code() == 404
+//
+//    assertTraces(1) {
+//      trace(0, 1) {
+//        span(0) {
+//          serviceName "unnamed-java-app"
+//          operationName "akka-http.request"
+//          resourceName "404"
+//          spanType DDSpanTypes.HTTP_SERVER
+//          errored false
+//          tags {
+//            defaultTags()
+//            "$Tags.HTTP_STATUS.key" 404
+//            "$Tags.HTTP_URL.key" "http://localhost:$port/not-found"
+//            "$Tags.HTTP_METHOD.key" "GET"
+//            "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
+//            "$Tags.COMPONENT.key" "akka-http-server"
+//          }
+//        }
+//      }
+//    }
+//
+//    where:
+//    server  | port
+//    "async" | asyncPort
+//    "sync"  | syncPort
+//  }
 
   def "server scheduling tasks via scala scheduler"() {
     setup:
@@ -196,12 +196,12 @@ class AkkaHttpServerInstrumentationTest extends AgentTestRunner {
 
     expect:
     response.code() == 200
+//    response.body().string() == 'aaa'
 
     assertTraces(1) {
       trace(0, 2) {
         span(0) {
-          traceId "123"
-          parentId "456"
+          parentId "0"
           serviceName "unnamed-java-app"
           operationName "akka-http.request"
           resourceName "GET /scheduler"

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/test/scala/AkkaHttpTestWebServer.scala
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/test/scala/AkkaHttpTestWebServer.scala
@@ -24,10 +24,12 @@ object AkkaHttpTestAsyncWebServer {
       }
     case HttpRequest(GET, Uri.Path("/scheduler"), _, _, _) =>
       Future {
-        system.scheduler.scheduleOnce(50 milliseconds) {
+
+        system.scheduler.scheduleOnce(200 milliseconds) {
+          System.out.println("BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBb " + system.scheduler.getClass().getCanonicalName)
           tracedMethod()
         }
-        Thread.sleep(100)
+        Thread.sleep(300)
         HttpResponse(entity = "Scheduled.")
       }
     case HttpRequest(GET, Uri.Path("/throw-handler"), _, _, _) =>

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/test/scala/AkkaHttpTestWebServer.scala
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/test/scala/AkkaHttpTestWebServer.scala
@@ -7,8 +7,8 @@ import akka.stream.ActorMaterializer
 import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.Trace
 
-import scala.concurrent.{Await, Future}
-import scala.concurrent.duration._
+import scala.concurrent.{Await, ExecutionContext, Future}
+//import scala.concurrent.duration._
 
 object AkkaHttpTestAsyncWebServer {
   val port = PortUtils.randomOpenPort()
@@ -16,22 +16,23 @@ object AkkaHttpTestAsyncWebServer {
   implicit val materializer = ActorMaterializer()
   // needed for the future flatMap/onComplete in the end
   implicit val executionContext = system.dispatcher
+
   val asyncHandler: HttpRequest => Future[HttpResponse] = {
     case HttpRequest(GET, Uri.Path("/test"), _, _, _) =>
       Future {
         tracedMethod()
         HttpResponse(entity = "Hello unit test.")
       }
-    case HttpRequest(GET, Uri.Path("/scheduler"), _, _, _) =>
-      Future {
-
-        system.scheduler.scheduleOnce(200 milliseconds) {
-          System.out.println("BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBb " + system.scheduler.getClass().getCanonicalName)
-          tracedMethod()
-        }
-        Thread.sleep(300)
-        HttpResponse(entity = "Scheduled.")
-      }
+//    case HttpRequest(GET, Uri.Path("/scheduler"), _, _, _) =>
+//      Future {
+//
+//        system.scheduler.scheduleOnce(200 milliseconds) {
+//          System.out.println("BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBb " + system.scheduler.getClass().getCanonicalName)
+//          tracedMethod()
+//        }
+//        Thread.sleep(300)
+//        HttpResponse(entity = "Scheduled.")
+//      }
     case HttpRequest(GET, Uri.Path("/throw-handler"), _, _, _) =>
       sys.error("Oh no handler")
     case HttpRequest(GET, Uri.Path("/throw-callback"), _, _, _) =>
@@ -68,6 +69,8 @@ object AkkaHttpTestAsyncWebServer {
   @Trace
   def tracedMethod(): Unit = {
   }
+
+  def methodTracedWithFuture
 }
 
 object AkkaHttpTestSyncWebServer {

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/test/scala/AkkaHttpTestWebServer.scala
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/test/scala/AkkaHttpTestWebServer.scala
@@ -49,12 +49,20 @@ object AkkaHttpTestAsyncWebServer {
       }
   }
 
+  def requestHandler(request: HttpRequest)(implicit executionContext: ExecutionContext): Future[HttpResponse] = {
+    def callAService(): Future[HttpResponse] = Future {
+      tracedMethod()
+      HttpResponse(entity = "Hello!")
+    }
+    callAService()
+  }
+
   private var binding: ServerBinding = null
 
   def start(): Unit = synchronized {
     if (null == binding) {
       import scala.concurrent.duration._
-      binding = Await.result(Http().bindAndHandleAsync(asyncHandler, "localhost", port), 10 seconds)
+      binding = Await.result(Http().bindAndHandleAsync(requestHandler, "localhost", port), 10 seconds)
     }
   }
 
@@ -69,8 +77,6 @@ object AkkaHttpTestAsyncWebServer {
   @Trace
   def tracedMethod(): Unit = {
   }
-
-  def methodTracedWithFuture
 }
 
 object AkkaHttpTestSyncWebServer {

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/test/scala/AkkaHttpTestWebServer.scala
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/test/scala/AkkaHttpTestWebServer.scala
@@ -8,6 +8,7 @@ import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.Trace
 
 import scala.concurrent.{Await, Future}
+import scala.concurrent.duration._
 
 object AkkaHttpTestAsyncWebServer {
   val port = PortUtils.randomOpenPort()
@@ -20,6 +21,14 @@ object AkkaHttpTestAsyncWebServer {
       Future {
         tracedMethod()
         HttpResponse(entity = "Hello unit test.")
+      }
+    case HttpRequest(GET, Uri.Path("/scheduler"), _, _, _) =>
+      Future {
+        system.scheduler.scheduleOnce(50 milliseconds) {
+          tracedMethod()
+        }
+        Thread.sleep(100)
+        HttpResponse(entity = "Scheduled.")
       }
     case HttpRequest(GET, Uri.Path("/throw-handler"), _, _, _) =>
       sys.error("Oh no handler")

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/AbstractExecutorInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/AbstractExecutorInstrumentation.java
@@ -53,6 +53,7 @@ public abstract class AbstractExecutorInstrumentation extends Instrumenter.Defau
         "javax.management.NotificationBroadcasterSupport$1",
         "kotlinx.coroutines.scheduling.CoroutineScheduler",
         "scala.concurrent.Future$InternalCallbackExecutor$",
+        "scala.concurrent.ExecutionContext",
         "scala.concurrent.impl.ExecutionContextImpl",
         "scala.concurrent.impl.ExecutionContextImpl$$anon$1",
         "scala.concurrent.forkjoin.ForkJoinPool",
@@ -103,7 +104,8 @@ public abstract class AbstractExecutorInstrumentation extends Instrumenter.Defau
   public ElementMatcher<TypeDescription> typeMatcher() {
     final ElementMatcher.Junction<TypeDescription> matcher =
         not(isInterface()).and(safeHasSuperType(named(Executor.class.getName())));
-    if (TRACE_ALL_EXECUTORS) {
+    if (true) {
+//    if (TRACE_ALL_EXECUTORS) {
       return matcher;
     }
     return matcher.and(

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/ExecutionContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/ExecutionContextInstrumentation.java
@@ -1,0 +1,105 @@
+package datadog.trace.instrumentation.java.concurrent;
+
+import static datadog.trace.agent.tooling.ByteBuddyElementMatchers.safeHasSuperType;
+import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
+import static net.bytebuddy.matcher.ElementMatchers.isInterface;
+import static net.bytebuddy.matcher.ElementMatchers.isPublic;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.not;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import akka.actor.Scheduler;
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.bootstrap.ContextStore;
+import datadog.trace.bootstrap.InstrumentationContext;
+import datadog.trace.bootstrap.instrumentation.java.concurrent.State;
+import datadog.trace.context.TraceScope;
+import io.opentracing.Scope;
+import io.opentracing.util.GlobalTracer;
+import lombok.extern.slf4j.Slf4j;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import scala.concurrent.ExecutionContext;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Executor;
+
+@Slf4j
+@AutoService(Instrumenter.class)
+public final class ExecutionContextInstrumentation extends Instrumenter.Default {
+
+  public ExecutionContextInstrumentation() {
+    super(AbstractExecutorInstrumentation.EXEC_NAME);
+  }
+
+  @Override
+  public ElementMatcher<TypeDescription> typeMatcher() {
+//    return named("akka.actor.LightArrayRevolverScheduler");
+    return not(isInterface())
+        .and(safeHasSuperType(named(ExecutionContext.class.getName())));
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {
+      AbstractExecutorInstrumentation.class.getPackage().getName() + ".ExecutorInstrumentationUtils"
+    };
+  }
+
+  @Override
+  public Map<String, String> contextStore() {
+    final Map<String, String> map = new HashMap<>();
+    map.put(Runnable.class.getName(), State.class.getName());
+    return Collections.unmodifiableMap(map);
+  }
+
+  @Override
+  public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
+    System.out.println("JJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJ");
+    final Map<ElementMatcher<? super MethodDescription>, String> transformers = new HashMap<>();
+//    transformers.put(
+//      named("scheduleOnce")
+//        .and(takesArgument(1, named(Runnable.class.getName()))),
+//      RunnableTaskStateAdvice.class.getName());
+    transformers.put(
+      named("execute")
+        .and(takesArgument(0, named(Runnable.class.getName()))),
+      RunnableTaskStateAdvice.class.getName());
+    return transformers;
+  }
+
+
+  public static class RunnableTaskStateAdvice {
+
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static State enterJobSubmit(
+      @Advice.Argument(value = 0, readOnly = false) final Runnable task) {
+//      @Advice.Argument(value = 1, readOnly = false) final Runnable task) {
+      System.out.println("SUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUU");
+      final Scope scope = GlobalTracer.get().scopeManager().active();
+      if (scope != null) {
+        final ContextStore<Runnable, State> contextStore =
+          InstrumentationContext.get(Runnable.class, State.class);
+        return ExecutorInstrumentationUtils.setupState(contextStore, task, (TraceScope) scope);
+      }
+      return null;
+//      if (ExecutorInstrumentationUtils.shouldAttachStateToTask(task, executor)) {
+//      }
+    }
+
+    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
+    public static void exitJobSubmit(
+      @Advice.Enter final State state,
+      @Advice.Thrown final Throwable throwable) {
+      if (null != state && null != throwable) {
+        // state.closeContinuation();
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/ExecutionContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/ExecutionContextInstrumentation.java
@@ -30,76 +30,76 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Executor;
 
-@Slf4j
-@AutoService(Instrumenter.class)
-public final class ExecutionContextInstrumentation extends Instrumenter.Default {
-
-  public ExecutionContextInstrumentation() {
-    super(AbstractExecutorInstrumentation.EXEC_NAME);
-  }
-
-  @Override
-  public ElementMatcher<TypeDescription> typeMatcher() {
-//    return named("akka.actor.LightArrayRevolverScheduler");
-    return not(isInterface())
-        .and(safeHasSuperType(named(ExecutionContext.class.getName())));
-  }
-
-  @Override
-  public String[] helperClassNames() {
-    return new String[] {
-      AbstractExecutorInstrumentation.class.getPackage().getName() + ".ExecutorInstrumentationUtils"
-    };
-  }
-
-  @Override
-  public Map<String, String> contextStore() {
-    final Map<String, String> map = new HashMap<>();
-    map.put(Runnable.class.getName(), State.class.getName());
-    return Collections.unmodifiableMap(map);
-  }
-
-  @Override
-  public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
-    System.out.println("JJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJ");
-    final Map<ElementMatcher<? super MethodDescription>, String> transformers = new HashMap<>();
+//@Slf4j
+////@AutoService(Instrumenter.class)
+//public final class ExecutionContextInstrumentation extends Instrumenter.Default {
+//
+//  public ExecutionContextInstrumentation() {
+//    super(AbstractExecutorInstrumentation.EXEC_NAME);
+//  }
+//
+//  @Override
+//  public ElementMatcher<TypeDescription> typeMatcher() {
+////    return named("akka.actor.LightArrayRevolverScheduler");
+//    return not(isInterface())
+//        .and(safeHasSuperType(named(ExecutionContext.class.getName())));
+//  }
+//
+//  @Override
+//  public String[] helperClassNames() {
+//    return new String[] {
+//      AbstractExecutorInstrumentation.class.getPackage().getName() + ".ExecutorInstrumentationUtils"
+//    };
+//  }
+//
+//  @Override
+//  public Map<String, String> contextStore() {
+//    final Map<String, String> map = new HashMap<>();
+//    map.put(Runnable.class.getName(), State.class.getName());
+//    return Collections.unmodifiableMap(map);
+//  }
+//
+//  @Override
+//  public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
+////    System.out.println("JJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJ");
+//    final Map<ElementMatcher<? super MethodDescription>, String> transformers = new HashMap<>();
+////    transformers.put(
+////      named("scheduleOnce")
+////        .and(takesArgument(1, named(Runnable.class.getName()))),
+////      RunnableTaskStateAdvice.class.getName());
 //    transformers.put(
-//      named("scheduleOnce")
-//        .and(takesArgument(1, named(Runnable.class.getName()))),
+//      named("execute")
+//        .and(takesArgument(0, named(Runnable.class.getName()))),
 //      RunnableTaskStateAdvice.class.getName());
-    transformers.put(
-      named("execute")
-        .and(takesArgument(0, named(Runnable.class.getName()))),
-      RunnableTaskStateAdvice.class.getName());
-    return transformers;
-  }
-
-
-  public static class RunnableTaskStateAdvice {
-
-    @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static State enterJobSubmit(
-      @Advice.Argument(value = 0, readOnly = false) final Runnable task) {
-//      @Advice.Argument(value = 1, readOnly = false) final Runnable task) {
-      System.out.println("SUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUU");
-      final Scope scope = GlobalTracer.get().scopeManager().active();
-      if (scope != null) {
-        final ContextStore<Runnable, State> contextStore =
-          InstrumentationContext.get(Runnable.class, State.class);
-        return ExecutorInstrumentationUtils.setupState(contextStore, task, (TraceScope) scope);
-      }
-      return null;
-//      if (ExecutorInstrumentationUtils.shouldAttachStateToTask(task, executor)) {
+//    return transformers;
+//  }
+//
+//
+//  public static class RunnableTaskStateAdvice {
+//
+//    @Advice.OnMethodEnter(suppress = Throwable.class)
+//    public static State enterJobSubmit(
+//      @Advice.Argument(value = 0, readOnly = false) final Runnable task) {
+////      @Advice.Argument(value = 1, readOnly = false) final Runnable task) {
+////      System.out.println("SUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUU");
+//      final Scope scope = GlobalTracer.get().scopeManager().active();
+//      if (scope != null) {
+//        final ContextStore<Runnable, State> contextStore =
+//          InstrumentationContext.get(Runnable.class, State.class);
+//        return ExecutorInstrumentationUtils.setupState(contextStore, task, (TraceScope) scope);
 //      }
-    }
-
-    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
-    public static void exitJobSubmit(
-      @Advice.Enter final State state,
-      @Advice.Thrown final Throwable throwable) {
-      if (null != state && null != throwable) {
-        // state.closeContinuation();
-      }
-    }
-  }
-}
+//      return null;
+////      if (ExecutorInstrumentationUtils.shouldAttachStateToTask(task, executor)) {
+////      }
+//    }
+//
+//    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
+//    public static void exitJobSubmit(
+//      @Advice.Enter final State state,
+//      @Advice.Thrown final Throwable throwable) {
+//      if (null != state && null != throwable) {
+//        // state.closeContinuation();
+//      }
+//    }
+//  }
+//}

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/ScalaExecutorInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/ScalaExecutorInstrumentation.java
@@ -12,7 +12,6 @@ import datadog.trace.bootstrap.instrumentation.java.concurrent.State;
 import datadog.trace.context.TraceScope;
 import io.opentracing.Scope;
 import io.opentracing.util.GlobalTracer;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Executor;
@@ -32,8 +31,10 @@ public final class ScalaExecutorInstrumentation extends AbstractExecutorInstrume
 
   @Override
   public Map<String, String> contextStore() {
-    return Collections.singletonMap(
-        ScalaForkJoinTaskInstrumentation.TASK_CLASS_NAME, State.class.getName());
+    Map<String, String> map = new HashMap<>();
+    map.put(ScalaForkJoinTaskInstrumentation.TASK_CLASS_NAME, State.class.getName());
+    map.put(Runnable.class.getName(), State.class.getName());
+    return map;
   }
 
   @Override

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/AgentTestRunner.java
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/AgentTestRunner.java
@@ -266,6 +266,7 @@ public abstract class AgentTestRunner extends Specification {
         for (final AgentTestRunner testRunner : activeTests) {
           if (testRunner.onInstrumentationError(typeName, classLoader, module, loaded, throwable)) {
             INSTRUMENTATION_ERROR_COUNT.incrementAndGet();
+            log.error("Error while instrumenting", throwable);
             break;
           }
         }


### PR DESCRIPTION
In the current state, just added a simple test to demonstrate that we are reproducing a similar scenario.

About to discuss what is the best way to support propagation happening in compiled code.