### PR TITLE
Change the scope for the netty client callback

### DIFF
--- a/dd-java-agent/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpClientInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpClientInstrumentationTest.groovy
@@ -25,8 +25,16 @@ class AkkaHttpClientInstrumentationTest extends HttpClientTest<AkkaHttpClientDec
 
     def response
     try {
-      response = Http.get(system).singleRequest(request, materializer).toCompletableFuture().get()
+      response = Http.get(system)
+        .singleRequest(request, materializer)
+        //.whenComplete { result, error ->
+            // FIXME: Callback should be here instead.
+        //  callback?.call()
+        //}
+        .toCompletableFuture()
+        .get()
     } finally {
+      // FIXME: remove this when callback above works.
       blockUntilChildSpansFinished(1)
     }
     callback?.call()

--- a/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/test/groovy/ApacheHttpAsyncClientCallbackTest.groovy
+++ b/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/test/groovy/ApacheHttpAsyncClientCallbackTest.groovy
@@ -1,6 +1,5 @@
 import datadog.trace.agent.test.base.HttpClientTest
 import datadog.trace.instrumentation.apachehttpasyncclient.ApacheHttpAsyncClientDecorator
-import io.opentracing.util.GlobalTracer
 import org.apache.http.HttpResponse
 import org.apache.http.concurrent.FutureCallback
 import org.apache.http.impl.nio.client.HttpAsyncClients
@@ -22,8 +21,6 @@ class ApacheHttpAsyncClientCallbackTest extends HttpClientTest<ApacheHttpAsyncCl
 
   @Override
   int doRequest(String method, URI uri, Map<String, String> headers, Closure callback) {
-    def hasParent = GlobalTracer.get().activeSpan() != null
-
     def request = new HttpUriRequest(method, uri)
     headers.entrySet().each {
       request.addHeader(new BasicHeader(it.key, it.value))
@@ -35,21 +32,13 @@ class ApacheHttpAsyncClientCallbackTest extends HttpClientTest<ApacheHttpAsyncCl
 
       @Override
       void completed(HttpResponse result) {
-        if (hasParent && GlobalTracer.get().activeSpan() == null) {
-          responseFuture.completeExceptionally(new Exception("Missing span in scope"))
-        } else {
-          responseFuture.complete(result.statusLine.statusCode)
-        }
+        responseFuture.complete(result.statusLine.statusCode)
         callback?.call()
       }
 
       @Override
       void failed(Exception ex) {
-        if (hasParent && GlobalTracer.get().activeSpan() == null) {
-          responseFuture.completeExceptionally(new Exception("Missing span in scope"))
-        } else {
-          responseFuture.completeExceptionally(ex)
-        }
+        responseFuture.completeExceptionally(ex)
       }
 
       @Override

--- a/dd-java-agent/instrumentation/jax-rs-client-2.0/src/test/groovy/JaxRsClientAsyncTest.groovy
+++ b/dd-java-agent/instrumentation/jax-rs-client-2.0/src/test/groovy/JaxRsClientAsyncTest.groovy
@@ -4,6 +4,7 @@ import javax.ws.rs.client.AsyncInvoker
 import javax.ws.rs.client.Client
 import javax.ws.rs.client.ClientBuilder
 import javax.ws.rs.client.Entity
+import javax.ws.rs.client.InvocationCallback
 import javax.ws.rs.client.WebTarget
 import javax.ws.rs.core.MediaType
 import javax.ws.rs.core.Response
@@ -22,8 +23,16 @@ abstract class JaxRsClientAsyncTest extends HttpClientTest<JaxRsClientDecorator>
     AsyncInvoker request = builder.async()
 
     def body = BODY_METHODS.contains(method) ? Entity.text("") : null
-    Response response = request.method(method, (Entity) body).get()
-    callback?.call()
+    Response response = request.method(method, (Entity) body, new InvocationCallback<Response>(){
+      @Override
+      void completed(Response s) {
+        callback?.call()
+      }
+
+      @Override
+      void failed(Throwable throwable) {
+      }
+    }).get()
 
     return response.status
   }

--- a/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/AttributeKeys.java
+++ b/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/AttributeKeys.java
@@ -16,4 +16,7 @@ public class AttributeKeys {
 
   public static final AttributeKey<Span> CLIENT_ATTRIBUTE_KEY =
       new AttributeKey<>(HttpClientTracingHandler.class.getName() + ".span");
+
+  public static final AttributeKey<Span> CLIENT_PARENT_ATTRIBUTE_KEY =
+      new AttributeKey<>(HttpClientTracingHandler.class.getName() + ".parent");
 }

--- a/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/client/HttpClientResponseTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/client/HttpClientResponseTracingHandler.java
@@ -7,35 +7,37 @@ import datadog.trace.instrumentation.netty40.AttributeKeys;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.codec.http.HttpResponse;
+import io.netty.util.Attribute;
 import io.opentracing.Scope;
 import io.opentracing.Span;
+import io.opentracing.noop.NoopSpan;
 import io.opentracing.util.GlobalTracer;
 
 public class HttpClientResponseTracingHandler extends ChannelInboundHandlerAdapter {
 
   @Override
   public void channelRead(final ChannelHandlerContext ctx, final Object msg) {
-    final Span parent = ctx.channel().attr(AttributeKeys.CLIENT_PARENT_ATTRIBUTE_KEY).get();
+    final Attribute<Span> parentAttr =
+        ctx.channel().attr(AttributeKeys.CLIENT_PARENT_ATTRIBUTE_KEY);
+    parentAttr.setIfAbsent(NoopSpan.INSTANCE);
+    final Span parent = parentAttr.get();
     final Span span = ctx.channel().attr(AttributeKeys.CLIENT_ATTRIBUTE_KEY).get();
 
     final boolean finishSpan = msg instanceof HttpResponse;
 
     if (span != null && finishSpan) {
-      try (final Scope scope = GlobalTracer.get().scopeManager().activate(span, true)) {
+      try (final Scope scope = GlobalTracer.get().scopeManager().activate(span, false)) {
         DECORATE.onResponse(span, (HttpResponse) msg);
         DECORATE.beforeFinish(span);
+        span.finish();
       }
     }
 
     // We want the callback in the scope of the parent, not the client span
-    if (parent != null) {
-      try (final Scope scope = GlobalTracer.get().scopeManager().activate(parent, false)) {
-        if (scope instanceof TraceScope) {
-          ((TraceScope) scope).setAsyncPropagation(true);
-        }
-        ctx.fireChannelRead(msg);
+    try (final Scope scope = GlobalTracer.get().scopeManager().activate(parent, false)) {
+      if (scope instanceof TraceScope) {
+        ((TraceScope) scope).setAsyncPropagation(true);
       }
-    } else {
       ctx.fireChannelRead(msg);
     }
   }

--- a/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/client/HttpClientResponseTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/client/HttpClientResponseTracingHandler.java
@@ -9,42 +9,34 @@ import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.codec.http.HttpResponse;
 import io.opentracing.Scope;
 import io.opentracing.Span;
-import io.opentracing.tag.Tags;
 import io.opentracing.util.GlobalTracer;
 
 public class HttpClientResponseTracingHandler extends ChannelInboundHandlerAdapter {
 
   @Override
   public void channelRead(final ChannelHandlerContext ctx, final Object msg) {
+    final Span parent = ctx.channel().attr(AttributeKeys.CLIENT_PARENT_ATTRIBUTE_KEY).get();
     final Span span = ctx.channel().attr(AttributeKeys.CLIENT_ATTRIBUTE_KEY).get();
-    if (span == null) {
-      ctx.fireChannelRead(msg);
-      return;
-    }
 
-    try (final Scope scope = GlobalTracer.get().scopeManager().activate(span, false)) {
-      final boolean finishSpan = msg instanceof HttpResponse;
+    final boolean finishSpan = msg instanceof HttpResponse;
 
-      if (scope instanceof TraceScope) {
-        ((TraceScope) scope).setAsyncPropagation(true);
-      }
-      try {
-        ctx.fireChannelRead(msg);
-      } catch (final Throwable throwable) {
-        if (finishSpan) {
-          DECORATE.onError(span, throwable);
-          DECORATE.beforeFinish(span);
-          Tags.HTTP_STATUS.set(span, 500);
-          span.finish(); // Finish the span manually since finishSpanOnClose was false
-          throw throwable;
-        }
-      }
-
-      if (finishSpan) {
+    if (span != null && finishSpan) {
+      try (final Scope scope = GlobalTracer.get().scopeManager().activate(span, true)) {
         DECORATE.onResponse(span, (HttpResponse) msg);
         DECORATE.beforeFinish(span);
-        span.finish(); // Finish the span manually since finishSpanOnClose was false
       }
+    }
+
+    // We want the callback in the scope of the parent, not the client span
+    if (parent != null) {
+      try (final Scope scope = GlobalTracer.get().scopeManager().activate(parent, false)) {
+        if (scope instanceof TraceScope) {
+          ((TraceScope) scope).setAsyncPropagation(true);
+        }
+        ctx.fireChannelRead(msg);
+      }
+    } else {
+      ctx.fireChannelRead(msg);
     }
   }
 }

--- a/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/AttributeKeys.java
+++ b/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/AttributeKeys.java
@@ -20,4 +20,7 @@ public class AttributeKeys {
 
   public static final AttributeKey<Span> CLIENT_ATTRIBUTE_KEY =
       AttributeKey.valueOf(HttpClientTracingHandler.class.getName() + ".span");
+
+  public static final AttributeKey<Span> CLIENT_PARENT_ATTRIBUTE_KEY =
+      AttributeKey.valueOf(HttpClientTracingHandler.class.getName() + ".parent");
 }

--- a/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/client/HttpClientResponseTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/client/HttpClientResponseTracingHandler.java
@@ -7,35 +7,37 @@ import datadog.trace.instrumentation.netty41.AttributeKeys;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.codec.http.HttpResponse;
+import io.netty.util.Attribute;
 import io.opentracing.Scope;
 import io.opentracing.Span;
+import io.opentracing.noop.NoopSpan;
 import io.opentracing.util.GlobalTracer;
 
 public class HttpClientResponseTracingHandler extends ChannelInboundHandlerAdapter {
 
   @Override
   public void channelRead(final ChannelHandlerContext ctx, final Object msg) {
-    final Span parent = ctx.channel().attr(AttributeKeys.CLIENT_PARENT_ATTRIBUTE_KEY).get();
+    final Attribute<Span> parentAttr =
+        ctx.channel().attr(AttributeKeys.CLIENT_PARENT_ATTRIBUTE_KEY);
+    parentAttr.setIfAbsent(NoopSpan.INSTANCE);
+    final Span parent = parentAttr.get();
     final Span span = ctx.channel().attr(AttributeKeys.CLIENT_ATTRIBUTE_KEY).get();
 
     final boolean finishSpan = msg instanceof HttpResponse;
 
     if (span != null && finishSpan) {
-      try (final Scope scope = GlobalTracer.get().scopeManager().activate(span, true)) {
+      try (final Scope scope = GlobalTracer.get().scopeManager().activate(span, false)) {
         DECORATE.onResponse(span, (HttpResponse) msg);
         DECORATE.beforeFinish(span);
+        span.finish();
       }
     }
 
     // We want the callback in the scope of the parent, not the client span
-    if (parent != null) {
-      try (final Scope scope = GlobalTracer.get().scopeManager().activate(parent, false)) {
-        if (scope instanceof TraceScope) {
-          ((TraceScope) scope).setAsyncPropagation(true);
-        }
-        ctx.fireChannelRead(msg);
+    try (final Scope scope = GlobalTracer.get().scopeManager().activate(parent, false)) {
+      if (scope instanceof TraceScope) {
+        ((TraceScope) scope).setAsyncPropagation(true);
       }
-    } else {
       ctx.fireChannelRead(msg);
     }
   }

--- a/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/client/HttpClientResponseTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/client/HttpClientResponseTracingHandler.java
@@ -9,42 +9,34 @@ import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.codec.http.HttpResponse;
 import io.opentracing.Scope;
 import io.opentracing.Span;
-import io.opentracing.tag.Tags;
 import io.opentracing.util.GlobalTracer;
 
 public class HttpClientResponseTracingHandler extends ChannelInboundHandlerAdapter {
 
   @Override
   public void channelRead(final ChannelHandlerContext ctx, final Object msg) {
+    final Span parent = ctx.channel().attr(AttributeKeys.CLIENT_PARENT_ATTRIBUTE_KEY).get();
     final Span span = ctx.channel().attr(AttributeKeys.CLIENT_ATTRIBUTE_KEY).get();
-    if (span == null) {
-      ctx.fireChannelRead(msg);
-      return;
-    }
 
-    try (final Scope scope = GlobalTracer.get().scopeManager().activate(span, false)) {
-      final boolean finishSpan = msg instanceof HttpResponse;
+    final boolean finishSpan = msg instanceof HttpResponse;
 
-      if (scope instanceof TraceScope) {
-        ((TraceScope) scope).setAsyncPropagation(true);
-      }
-      try {
-        ctx.fireChannelRead(msg);
-      } catch (final Throwable throwable) {
-        if (finishSpan) {
-          DECORATE.onError(span, throwable);
-          DECORATE.beforeFinish(span);
-          Tags.HTTP_STATUS.set(span, 500);
-          span.finish(); // Finish the span manually since finishSpanOnClose was false
-          throw throwable;
-        }
-      }
-
-      if (finishSpan) {
+    if (span != null && finishSpan) {
+      try (final Scope scope = GlobalTracer.get().scopeManager().activate(span, true)) {
         DECORATE.onResponse(span, (HttpResponse) msg);
         DECORATE.beforeFinish(span);
-        span.finish(); // Finish the span manually since finishSpanOnClose was false
       }
+    }
+
+    // We want the callback in the scope of the parent, not the client span
+    if (parent != null) {
+      try (final Scope scope = GlobalTracer.get().scopeManager().activate(parent, false)) {
+        if (scope instanceof TraceScope) {
+          ((TraceScope) scope).setAsyncPropagation(true);
+        }
+        ctx.fireChannelRead(msg);
+      }
+    } else {
+      ctx.fireChannelRead(msg);
     }
   }
 }

--- a/dd-java-agent/instrumentation/ratpack-1.4/src/test/groovy/RatpackTest.groovy
+++ b/dd-java-agent/instrumentation/ratpack-1.4/src/test/groovy/RatpackTest.groovy
@@ -429,7 +429,7 @@ class RatpackTest extends AgentTestRunner {
           serviceName "unnamed-java-app"
           operationName "netty.client.request"
           spanType DDSpanTypes.HTTP_CLIENT
-          childOf(span(3))
+          childOf(span(1))
           errored false
           tags {
             "$Tags.COMPONENT.key" "netty-client"

--- a/dd-java-agent/instrumentation/vertx/src/test/groovy/VertxHttpClientTest.groovy
+++ b/dd-java-agent/instrumentation/vertx/src/test/groovy/VertxHttpClientTest.groovy
@@ -1,151 +1,54 @@
-import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.utils.PortUtils
-import datadog.trace.api.DDSpanTypes
-import io.netty.channel.AbstractChannel
-import io.opentracing.tag.Tags
+import datadog.trace.agent.test.base.HttpClientTest
+import datadog.trace.instrumentation.netty41.client.NettyHttpClientDecorator
 import io.vertx.core.Vertx
 import io.vertx.core.VertxOptions
 import io.vertx.core.http.HttpClient
-import io.vertx.core.http.HttpClientRequest
 import io.vertx.core.http.HttpClientResponse
 import io.vertx.core.http.HttpMethod
-import spock.lang.AutoCleanup
 import spock.lang.Shared
+import spock.lang.Timeout
 
 import java.util.concurrent.CompletableFuture
 
-import static datadog.trace.agent.test.server.http.TestHttpServer.httpServer
-import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
-
-class VertxHttpClientTest extends AgentTestRunner {
-
-  private static final String MESSAGE = "hello world"
-
-  @AutoCleanup
-  @Shared
-  def server = httpServer {
-    handlers {
-      prefix("success") {
-        handleDistributedRequest()
-
-        response.status(200).send(MESSAGE)
-      }
-
-      prefix("error") {
-        handleDistributedRequest()
-
-        throw new RuntimeException("error")
-      }
-    }
-  }
+@Timeout(10)
+class VertxHttpClientTest extends HttpClientTest<NettyHttpClientDecorator> {
 
   @Shared
   Vertx vertx = Vertx.vertx(new VertxOptions())
   @Shared
   HttpClient httpClient = vertx.createHttpClient()
 
-  def "#route request trace"() {
-    setup:
-    def responseFuture = new CompletableFuture<HttpClientResponse>()
-    def messageFuture = new CompletableFuture<String>()
-    httpClient.getNow(server.address.port, server.address.host, "/" + route, { response ->
-      responseFuture.complete(response)
-      response.bodyHandler({ buffer ->
-        messageFuture.complete(buffer.toString())
-      })
-    })
-
-    when:
-    HttpClientResponse response = responseFuture.get()
-    String message = messageFuture.get()
-
-    then:
-    response.statusCode() == expectedStatus
-    if (expectedMessage != null) {
-      message == expectedMessage
+  @Override
+  int doRequest(String method, URI uri, Map<String, String> headers, Closure callback) {
+    CompletableFuture<HttpClientResponse> future = new CompletableFuture<>()
+    def request = httpClient.request(HttpMethod.valueOf(method), uri.port, uri.host, "$uri")
+    headers.each { request.putHeader(it.key, it.value) }
+    request.handler { response ->
+      callback?.call()
+      future.complete(response)
     }
+    request.end()
 
-    assertTraces(2) {
-      server.distributedRequestTrace(it, 0, TEST_WRITER[1][0])
-      trace(1, 1) {
-        span(0) {
-          parent()
-          serviceName "unnamed-java-app"
-          operationName "netty.client.request"
-          resourceName "GET /$route"
-          spanType DDSpanTypes.HTTP_CLIENT
-          errored expectedError
-          tags {
-            defaultTags()
-            "$Tags.HTTP_STATUS.key" expectedStatus
-            "$Tags.HTTP_URL.key" "${server.address}/$route"
-            "$Tags.PEER_HOSTNAME.key" server.address.host
-            "$Tags.PEER_HOST_IPV4.key" "127.0.0.1"
-            "$Tags.PEER_PORT.key" server.address.port
-            "$Tags.HTTP_METHOD.key" "GET"
-            "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
-            "$Tags.COMPONENT.key" "netty-client"
-            if (expectedError) {
-              "$Tags.ERROR.key" true
-            }
-          }
-        }
-      }
-    }
-
-    where:
-    route     | expectedStatus | expectedError | expectedMessage
-    "success" | 200            | false         | MESSAGE
-    "error"   | 500            | true          | null
+    return future.get().statusCode()
   }
 
-  def "test connection failure"() {
-    setup:
-    def invalidPort = PortUtils.randomOpenPort()
+  @Override
+  NettyHttpClientDecorator decorator() {
+    return NettyHttpClientDecorator.DECORATE
+  }
 
-    def errorFuture = new CompletableFuture<Throwable>()
+  @Override
+  String expectedOperationName() {
+    return "netty.client.request"
+  }
 
-    runUnderTrace("parent") {
-      HttpClientRequest request = httpClient.request(
-        HttpMethod.GET,
-        invalidPort,
-        server.address.host,
-        "/",
-        { response ->
-          // We expect to never get here since our request is expected to fail
-          errorFuture.complete(null)
-        })
-      request.exceptionHandler({ error ->
-        errorFuture.complete(error)
-      })
-      request.end()
-    }
+  @Override
+  boolean testRedirects() {
+    false
+  }
 
-    when:
-    def throwable = errorFuture.get()
-
-    then:
-    throwable.cause instanceof ConnectException
-
-    and:
-    assertTraces(1) {
-      trace(0, 2) {
-        span(0) {
-          operationName "parent"
-          parent()
-        }
-        span(1) {
-          operationName "netty.connect"
-          resourceName "netty.connect"
-          childOf span(0)
-          errored true
-          tags {
-            "$Tags.COMPONENT.key" "netty"
-            errorTags AbstractChannel.AnnotatedConnectException, "Connection refused: localhost/127.0.0.1:$invalidPort"
-            defaultTags()
-          }
-        }
-      }
-    }
+  @Override
+  boolean testConnectionFailure() {
+    false
   }
 }

--- a/dd-java-agent/instrumentation/vertx/src/test/groovy/VertxRxServerTest.groovy
+++ b/dd-java-agent/instrumentation/vertx/src/test/groovy/VertxRxServerTest.groovy
@@ -1,0 +1,157 @@
+import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.agent.test.utils.OkHttpUtils
+import datadog.trace.agent.test.utils.PortUtils
+import datadog.trace.api.DDSpanTypes
+import io.netty.handler.codec.http.HttpResponseStatus
+import io.opentracing.tag.Tags
+import io.vertx.core.Vertx
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import spock.lang.Shared
+
+class VertxRxServerTest extends AgentTestRunner {
+
+  @Shared
+  OkHttpClient client = OkHttpUtils.client()
+
+  @Shared
+  int port
+  @Shared
+  Vertx server
+
+  def setupSpec() {
+    port = PortUtils.randomOpenPort()
+    server = VertxRxWebTestServer.start(port)
+  }
+
+  def cleanupSpec() {
+    server.close()
+  }
+
+  def "test server request/response"() {
+    setup:
+    def request = new Request.Builder()
+      .url("http://localhost:$port/proxy")
+      .header("x-datadog-trace-id", "123")
+      .header("x-datadog-parent-id", "456")
+      .get()
+      .build()
+    def response = client.newCall(request).execute()
+
+    expect:
+    response.code() == 200
+    response.body().string() == "Hello World"
+
+    and:
+    assertTraces(2) {
+      trace(0, 2) {
+        span(0) {
+          serviceName "unnamed-java-app"
+          operationName "netty.request"
+          resourceName "GET /test"
+          childOf(trace(1).get(1))
+          spanType DDSpanTypes.HTTP_SERVER
+          errored false
+          tags {
+            "$Tags.COMPONENT.key" "netty"
+            "$Tags.HTTP_METHOD.key" "GET"
+            "$Tags.HTTP_STATUS.key" 200
+            "$Tags.HTTP_URL.key" "http://localhost:$port/test"
+            "$Tags.PEER_HOSTNAME.key" "localhost"
+            "$Tags.PEER_HOST_IPV4.key" "127.0.0.1"
+            "$Tags.PEER_PORT.key" Integer
+            "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
+            defaultTags(true)
+          }
+        }
+        span(1) {
+          childOf span(0)
+          assert span(1).operationName.endsWith('.tracedMethod')
+        }
+      }
+      trace(1, 2) {
+        span(0) {
+          serviceName "unnamed-java-app"
+          operationName "netty.request"
+          resourceName "GET /proxy"
+          traceId "123"
+          parentId "456"
+          spanType DDSpanTypes.HTTP_SERVER
+          errored false
+          tags {
+            "$Tags.COMPONENT.key" "netty"
+            "$Tags.HTTP_METHOD.key" "GET"
+            "$Tags.HTTP_STATUS.key" 200
+            "$Tags.HTTP_URL.key" "http://localhost:$port/proxy"
+            "$Tags.PEER_HOSTNAME.key" "localhost"
+            "$Tags.PEER_HOST_IPV4.key" "127.0.0.1"
+            "$Tags.PEER_PORT.key" Integer
+            "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
+            defaultTags(true)
+          }
+        }
+        span(1) {
+          serviceName "unnamed-java-app"
+          operationName "netty.client.request"
+          resourceName "GET /test"
+          childOf(span(0))
+          spanType DDSpanTypes.HTTP_CLIENT
+          errored false
+          tags {
+            "$Tags.COMPONENT.key" "netty-client"
+            "$Tags.HTTP_METHOD.key" "GET"
+            "$Tags.HTTP_STATUS.key" 200
+            "$Tags.HTTP_URL.key" "http://localhost:$port/test"
+            "$Tags.PEER_HOSTNAME.key" "localhost"
+            "$Tags.PEER_HOST_IPV4.key" "127.0.0.1"
+            "$Tags.PEER_PORT.key" Integer
+            "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
+            defaultTags()
+          }
+        }
+      }
+    }
+  }
+
+  def "test #responseCode response handling"() {
+    setup:
+    def request = new Request.Builder().url("http://localhost:$port/$path").get().build()
+    def response = client.newCall(request).execute()
+
+    expect:
+    response.code() == responseCode.code()
+
+    and:
+    assertTraces(1) {
+      trace(0, 1) {
+        span(0) {
+          serviceName "unnamed-java-app"
+          operationName "netty.request"
+          resourceName name
+          spanType DDSpanTypes.HTTP_SERVER
+          errored error
+          tags {
+            "$Tags.COMPONENT.key" "netty"
+            "$Tags.HTTP_METHOD.key" "GET"
+            "$Tags.HTTP_STATUS.key" responseCode.code()
+            "$Tags.HTTP_URL.key" "http://localhost:$port/$path"
+            "$Tags.PEER_HOSTNAME.key" "localhost"
+            "$Tags.PEER_HOST_IPV4.key" "127.0.0.1"
+            "$Tags.PEER_PORT.key" Integer
+            "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
+            if (error) {
+              tag("error", true)
+            }
+            defaultTags()
+          }
+        }
+      }
+    }
+
+    where:
+    responseCode                             | name         | path          | error
+    HttpResponseStatus.OK                    | "GET /"      | ""            | false
+    HttpResponseStatus.NOT_FOUND             | "404"        | "doesnt-exit" | false
+    HttpResponseStatus.INTERNAL_SERVER_ERROR | "GET /error" | "error"       | true
+  }
+}

--- a/dd-java-agent/instrumentation/vertx/src/test/groovy/VertxRxWebClientTest.groovy
+++ b/dd-java-agent/instrumentation/vertx/src/test/groovy/VertxRxWebClientTest.groovy
@@ -13,7 +13,7 @@ class VertxRxWebClientTest extends HttpClientTest<NettyHttpClientDecorator> {
   @Shared
   Vertx vertx = Vertx.vertx(new VertxOptions())
   @Shared
-  WebClient client = WebClient.create(vertx);
+  WebClient client = WebClient.create(vertx)
 
   @Override
   int doRequest(String method, URI uri, Map<String, String> headers, Closure callback) {

--- a/dd-java-agent/instrumentation/vertx/src/test/groovy/VertxRxWebClientTest.groovy
+++ b/dd-java-agent/instrumentation/vertx/src/test/groovy/VertxRxWebClientTest.groovy
@@ -1,0 +1,49 @@
+import datadog.trace.agent.test.base.HttpClientTest
+import datadog.trace.instrumentation.netty41.client.NettyHttpClientDecorator
+import io.vertx.core.VertxOptions
+import io.vertx.core.http.HttpMethod
+import io.vertx.reactivex.core.Vertx
+import io.vertx.reactivex.ext.web.client.WebClient
+import spock.lang.Shared
+import spock.lang.Timeout
+
+@Timeout(10)
+class VertxRxWebClientTest extends HttpClientTest<NettyHttpClientDecorator> {
+
+  @Shared
+  Vertx vertx = Vertx.vertx(new VertxOptions())
+  @Shared
+  WebClient client = WebClient.create(vertx);
+
+  @Override
+  int doRequest(String method, URI uri, Map<String, String> headers, Closure callback) {
+    def request = client.request(HttpMethod.valueOf(method), uri.port, uri.host, "$uri")
+    headers.each { request.putHeader(it.key, it.value) }
+    return request
+      .rxSend()
+      .doOnSuccess { response -> callback?.call() }
+      .map { it.statusCode() }
+      .toObservable()
+      .blockingFirst()
+  }
+
+  @Override
+  NettyHttpClientDecorator decorator() {
+    return NettyHttpClientDecorator.DECORATE
+  }
+
+  @Override
+  String expectedOperationName() {
+    return "netty.client.request"
+  }
+
+  @Override
+  boolean testRedirects() {
+    false
+  }
+
+  @Override
+  boolean testConnectionFailure() {
+    false
+  }
+}

--- a/dd-java-agent/instrumentation/vertx/src/test/java/VertxRxWebTestServer.java
+++ b/dd-java-agent/instrumentation/vertx/src/test/java/VertxRxWebTestServer.java
@@ -1,0 +1,112 @@
+import datadog.trace.api.Trace;
+import io.vertx.circuitbreaker.CircuitBreakerOptions;
+import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
+import io.vertx.core.json.JsonObject;
+import io.vertx.reactivex.circuitbreaker.CircuitBreaker;
+import io.vertx.reactivex.core.AbstractVerticle;
+import io.vertx.reactivex.core.buffer.Buffer;
+import io.vertx.reactivex.ext.web.Router;
+import io.vertx.reactivex.ext.web.RoutingContext;
+import io.vertx.reactivex.ext.web.client.WebClient;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+public class VertxRxWebTestServer extends AbstractVerticle {
+  public static final String CONFIG_HTTP_SERVER_PORT = "http.server.port";
+
+  public static Vertx start(final int port) throws ExecutionException, InterruptedException {
+    /* This is highly against Vertx ideas, but our tests are synchronous
+    so we have to make sure server is up and running */
+    final CompletableFuture<Void> future = new CompletableFuture<>();
+
+    final Vertx vertx = Vertx.vertx(new VertxOptions().setClusterPort(port));
+
+    vertx.deployVerticle(
+      VertxRxWebTestServer.class.getName(),
+      new DeploymentOptions()
+        .setConfig(new JsonObject().put(CONFIG_HTTP_SERVER_PORT, port))
+        .setInstances(3),
+      res -> {
+        if (!res.succeeded()) {
+          throw new RuntimeException("Cannot deploy server Verticle", res.cause());
+        }
+        future.complete(null);
+      });
+
+    future.get();
+
+    return vertx;
+  }
+
+  @Override
+  public void start(final Future<Void> startFuture) {
+//    final io.vertx.reactivex.core.Vertx vertx = new io.vertx.reactivex.core.Vertx(this.vertx);
+    final WebClient client = WebClient.create(vertx);
+
+    final int port = config().getInteger(CONFIG_HTTP_SERVER_PORT);
+
+    final Router router = Router.router(vertx);
+    final CircuitBreaker breaker = CircuitBreaker.create("my-circuit-breaker", vertx,
+      new CircuitBreakerOptions()
+        .setMaxFailures(5) // number of failure before opening the circuit
+        .setTimeout(2000) // consider a failure if the operation does not succeed in time
+//        .setFallbackOnFailure(true) // do we call the fallback on failure
+        .setResetTimeout(10000) // time spent in open state before attempting to re-try
+    );
+
+    router
+      .route("/")
+      .handler(
+        routingContext -> {
+          routingContext.response().putHeader("content-type", "text/html").end("Hello World");
+        });
+    router
+      .route("/error")
+      .handler(
+        routingContext -> {
+          routingContext.response().setStatusCode(500).end();
+        });
+    router
+      .route("/proxy")
+      .handler(
+        routingContext -> {
+          breaker.execute(
+            ctx -> {
+              client.get(port, "localhost", "/test")
+                .rxSendBuffer(Optional.ofNullable(routingContext.getBody()).orElse(Buffer.buffer()))
+                .subscribe(
+                  response -> {
+                    routingContext
+                      .response()
+                      .setStatusCode(response.statusCode())
+                      .end(response.body());
+                  });
+            });
+        });
+    router
+      .route("/test")
+      .handler(
+        routingContext -> {
+          tracedMethod();
+          routingContext.next();
+        })
+      .blockingHandler(RoutingContext::next)
+      .handler(
+        routingContext -> {
+          routingContext.response().putHeader("content-type", "text/html").end("Hello World");
+        });
+
+    vertx
+      .createHttpServer()
+      .requestHandler(router::accept)
+      .listen(port, h -> startFuture.complete());
+  }
+
+  @Trace
+  private void tracedMethod() {
+  }
+}

--- a/dd-java-agent/instrumentation/vertx/vertx.gradle
+++ b/dd-java-agent/instrumentation/vertx/vertx.gradle
@@ -48,6 +48,12 @@ dependencies {
 
   // Tests seem to fail before 3.5... maybe a problem with some of the tests?
   testCompile group: 'io.vertx', name: 'vertx-web', version: '3.5.0'
+  testCompile group: 'io.vertx', name: 'vertx-web-client', version: '3.5.0'
+  testCompile group: 'io.vertx', name: 'vertx-circuit-breaker', version: '3.5.0'
+  testCompile group: 'io.vertx', name: 'vertx-rx-java2', version: '3.5.0'
 
   latestDepTestCompile group: 'io.vertx', name: 'vertx-web', version: '+'
+  latestDepTestCompile group: 'io.vertx', name: 'vertx-web-client', version: '+'
+  latestDepTestCompile group: 'io.vertx', name: 'vertx-circuit-breaker', version: '+'
+  latestDepTestCompile group: 'io.vertx', name: 'vertx-rx-java2', version: '+'
 }

--- a/dd-java-agent/instrumentation/vertx/vertx.gradle
+++ b/dd-java-agent/instrumentation/vertx/vertx.gradle
@@ -42,9 +42,11 @@ dependencies {
   implementation deps.autoservice
 
   testCompile project(':dd-java-agent:testing')
+  testCompile project(':dd-java-agent:instrumentation:netty-4.1')
   testCompile project(':dd-java-agent:instrumentation:java-concurrent')
   testCompile project(':dd-java-agent:instrumentation:trace-annotation')
-  testCompile project(':dd-java-agent:instrumentation:netty-4.1')
+
+  // Tests seem to fail before 3.5... maybe a problem with some of the tests?
   testCompile group: 'io.vertx', name: 'vertx-web', version: '3.5.0'
 
   latestDepTestCompile group: 'io.vertx', name: 'vertx-web', version: '+'

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
@@ -176,10 +176,7 @@ abstract class HttpClientTest<T extends HttpClientDecorator> extends AgentTestRu
     assertTraces(1) {
       trace(0, size(3)) {
         basicSpan(it, 0, "parent")
-        span(1) {
-          operationName "child"
-          childOf span(0)
-        }
+        basicSpan(it, 1, "child", span(0))
         clientSpan(it, 2, span(0), method, false)
       }
     }
@@ -205,10 +202,7 @@ abstract class HttpClientTest<T extends HttpClientDecorator> extends AgentTestRu
         clientSpan(it, 0, null, method, false)
       }
       trace(1, 1) {
-        span(0) {
-          operationName "child"
-          parent()
-        }
+        basicSpan(it, 0, "child")
       }
     }
 
@@ -306,7 +300,7 @@ abstract class HttpClientTest<T extends HttpClientDecorator> extends AgentTestRu
     and:
     assertTraces(1) {
       trace(0, 2) {
-        basicSpan(it, 0, "parent", thrownException)
+        basicSpan(it, 0, "parent", null, thrownException)
         clientSpan(it, 1, span(0), method, false, false, uri, null, thrownException)
       }
     }

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/utils/TraceUtils.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/utils/TraceUtils.groovy
@@ -1,5 +1,6 @@
 package datadog.trace.agent.test.utils
 
+import datadog.opentracing.DDSpan
 import datadog.trace.agent.decorator.BaseDecorator
 import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.context.TraceScope
@@ -42,9 +43,13 @@ class TraceUtils {
     }
   }
 
-  static basicSpan(TraceAssert trace, int index, String spanName, Throwable exception = null) {
+  static basicSpan(TraceAssert trace, int index, String spanName, Object parentSpan = null, Throwable exception = null) {
     trace.span(index) {
-      parent()
+      if (parentSpan == null) {
+        parent()
+      } else {
+        childOf((DDSpan) parentSpan)
+      }
       serviceName "unnamed-java-app"
       operationName spanName
       resourceName spanName


### PR DESCRIPTION
Previously the scope was the http client span, which could result in deep nesting.  Now it is the parent span.

Before
```
[--------------Parent--------------]
  [ ^-----------Client------------]
               [ ^---Callback---]
````
Now:
```
[--------------Parent--------------]
  [ ^ --Client----] [ ^--Callback--]
```
Also improve the tests.