### PR TITLE
Make test setup more flexible

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,6 +107,11 @@ jobs:
     environment:
     - TEST_TASK: testJavaIBM8
 
+  test_zulu8:
+    <<: *default_test_job
+    environment:
+    - TEST_TASK: testJavaZULU8
+
   test_9:
     <<: *default_test_job
     environment:
@@ -268,6 +273,12 @@ workflows:
         filters:
           tags:
             only: /.*/
+    - test_zulu8:
+        requires:
+        - build
+        filters:
+          tags:
+            only: /.*/
     - test_9:
         requires:
         - build
@@ -320,6 +331,7 @@ workflows:
         - test_8
         - test_latest8
         - test_ibm8
+        - test_zulu8
         - test_9
         - test_10
         - test_11

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -219,6 +219,10 @@ def isJavaVersionAllowed(JavaVersion version) {
   return true
 }
 
+def isJdkForced(String javaName) {
+  return (project.hasProperty('forceJdk') && project.getProperty('forceJdk').contains(javaName))
+}
+
 // JVM names we would like to run complete test suite on
 // Note: complete test suite is always run on JVM used for compilation
 // Note2: apparently there is no way to have a 'global' variable, so instead we have per project
@@ -290,7 +294,7 @@ for (def env : System.getenv().entrySet()) {
         jvmArgs '-XX:CompileCommand=exclude,net.bytebuddy.description.type.TypeDescription$Generic$Visitor$Substitutor::onParameterizedType'
       }
 
-      onlyIf { isJavaVersionAllowed(javaVersion) && isTestingEnabled(javaName) }
+      onlyIf { (isJavaVersionAllowed(javaVersion) && isTestingEnabled(javaName)) || isJdkForced(javaName) }
       if (applyCodeCoverage) {
         jacoco {
           // Disable jacoco for additional JVM tests to speed things up a bit


### PR DESCRIPTION
This change allows submodules to set `forceJdk` property to an array of JVM names that this module would want tests to be run on. For example setting that to `IBM8` would run tests on `IBM JVM` even if they otherwise would not (because for example they are java11 only).