### PR TITLE
Add "http.query.string" and "http.fragment.string" to DDTags

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/decorator/HttpClientDecorator.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/decorator/HttpClientDecorator.java
@@ -5,7 +5,6 @@ import datadog.trace.api.DDSpanTypes;
 import datadog.trace.api.DDTags;
 import io.opentracing.Span;
 import io.opentracing.tag.Tags;
-
 import java.net.URI;
 import java.net.URISyntaxException;
 import lombok.extern.slf4j.Slf4j;

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/decorator/HttpClientDecorator.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/decorator/HttpClientDecorator.java
@@ -5,9 +5,10 @@ import datadog.trace.api.DDSpanTypes;
 import datadog.trace.api.DDTags;
 import io.opentracing.Span;
 import io.opentracing.tag.Tags;
+import lombok.extern.slf4j.Slf4j;
+
 import java.net.URI;
 import java.net.URISyntaxException;
-import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public abstract class HttpClientDecorator<REQUEST, RESPONSE> extends ClientDecorator {
@@ -63,8 +64,8 @@ public abstract class HttpClientDecorator<REQUEST, RESPONSE> extends ClientDecor
           Tags.HTTP_URL.set(span, urlNoParams.toString());
 
           if (Config.get().isHttpClientTagQueryString()) {
-            span.setTag("http.query.string", url.getQuery());
-            span.setTag("http.fragment.string", url.getFragment());
+            span.setTag(DDTags.HTTP_QUERY, url.getQuery());
+            span.setTag(DDTags.HTTP_FRAGMENT, url.getFragment());
           }
         }
       } catch (final Exception e) {

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/decorator/HttpClientDecorator.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/decorator/HttpClientDecorator.java
@@ -5,10 +5,10 @@ import datadog.trace.api.DDSpanTypes;
 import datadog.trace.api.DDTags;
 import io.opentracing.Span;
 import io.opentracing.tag.Tags;
-import lombok.extern.slf4j.Slf4j;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public abstract class HttpClientDecorator<REQUEST, RESPONSE> extends ClientDecorator {

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/decorator/HttpServerDecorator.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/decorator/HttpServerDecorator.java
@@ -2,12 +2,14 @@ package datadog.trace.agent.decorator;
 
 import datadog.trace.api.Config;
 import datadog.trace.api.DDSpanTypes;
+import datadog.trace.api.DDTags;
 import io.opentracing.Span;
 import io.opentracing.tag.Tags;
+import lombok.extern.slf4j.Slf4j;
+
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.regex.Pattern;
-import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public abstract class HttpServerDecorator<REQUEST, CONNECTION, RESPONSE> extends ServerDecorator {
@@ -69,8 +71,8 @@ public abstract class HttpServerDecorator<REQUEST, CONNECTION, RESPONSE> extends
           Tags.HTTP_URL.set(span, urlNoParams.toString());
 
           if (Config.get().isHttpServerTagQueryString()) {
-            span.setTag("http.query.string", url.getQuery());
-            span.setTag("http.fragment.string", url.getFragment());
+            span.setTag(DDTags.HTTP_QUERY, url.getQuery());
+            span.setTag(DDTags.HTTP_FRAGMENT, url.getFragment());
           }
         }
       } catch (final Exception e) {

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/decorator/HttpServerDecorator.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/decorator/HttpServerDecorator.java
@@ -5,7 +5,6 @@ import datadog.trace.api.DDSpanTypes;
 import datadog.trace.api.DDTags;
 import io.opentracing.Span;
 import io.opentracing.tag.Tags;
-
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.regex.Pattern;

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/decorator/HttpServerDecorator.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/decorator/HttpServerDecorator.java
@@ -5,11 +5,11 @@ import datadog.trace.api.DDSpanTypes;
 import datadog.trace.api.DDTags;
 import io.opentracing.Span;
 import io.opentracing.tag.Tags;
-import lombok.extern.slf4j.Slf4j;
 
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.regex.Pattern;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public abstract class HttpServerDecorator<REQUEST, CONNECTION, RESPONSE> extends ServerDecorator {

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/decorator/HttpClientDecoratorTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/decorator/HttpClientDecoratorTest.groovy
@@ -58,8 +58,8 @@ class HttpClientDecoratorTest extends ClientDecoratorTest {
       1 * span.setTag(Tags.HTTP_URL.key, expectedUrl)
     }
     if (expectedUrl && tagQueryString) {
-      1 * span.setTag("http.query.string", expectedQuery)
-      1 * span.setTag("http.fragment.string", expectedFragment)
+      1 * span.setTag(DDTags.HTTP_QUERY, expectedQuery)
+      1 * span.setTag(DDTags.HTTP_FRAGMENT, expectedFragment)
     }
     1 * span.setTag(Tags.HTTP_METHOD.key, null)
     1 * span.setTag(Tags.PEER_HOSTNAME.key, null)

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/decorator/HttpServerDecoratorTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/decorator/HttpServerDecoratorTest.groovy
@@ -1,6 +1,7 @@
 package datadog.trace.agent.decorator
 
 import datadog.trace.api.Config
+import datadog.trace.api.DDTags
 import io.opentracing.Span
 import io.opentracing.tag.Tags
 
@@ -48,8 +49,8 @@ class HttpServerDecoratorTest extends ServerDecoratorTest {
       1 * span.setTag(Tags.HTTP_URL.key, expectedUrl)
     }
     if (expectedUrl && tagQueryString) {
-      1 * span.setTag("http.query.string", expectedQuery)
-      1 * span.setTag("http.fragment.string", expectedFragment)
+      1 * span.setTag(DDTags.HTTP_QUERY, expectedQuery)
+      1 * span.setTag(DDTags.HTTP_FRAGMENT, expectedFragment)
     }
     1 * span.setTag(Tags.HTTP_METHOD.key, null)
     0 * _

--- a/dd-java-agent/instrumentation/okhttp-3/src/test/groovy/OkHttp3Test.groovy
+++ b/dd-java-agent/instrumentation/okhttp-3/src/test/groovy/OkHttp3Test.groovy
@@ -5,7 +5,11 @@ import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import datadog.trace.instrumentation.okhttp3.OkHttpClientDecorator
 import io.opentracing.tag.Tags
-import okhttp3.*
+import okhttp3.Headers
+import okhttp3.MediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody
 import okhttp3.internal.http.HttpMethod
 
 import static datadog.trace.instrumentation.okhttp3.OkHttpClientDecorator.NETWORK_DECORATE

--- a/dd-java-agent/instrumentation/okhttp-3/src/test/groovy/OkHttp3Test.groovy
+++ b/dd-java-agent/instrumentation/okhttp-3/src/test/groovy/OkHttp3Test.groovy
@@ -2,13 +2,10 @@ import datadog.opentracing.DDSpan
 import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.agent.test.base.HttpClientTest
 import datadog.trace.api.DDSpanTypes
+import datadog.trace.api.DDTags
 import datadog.trace.instrumentation.okhttp3.OkHttpClientDecorator
 import io.opentracing.tag.Tags
-import okhttp3.Headers
-import okhttp3.MediaType
-import okhttp3.OkHttpClient
-import okhttp3.Request
-import okhttp3.RequestBody
+import okhttp3.*
 import okhttp3.internal.http.HttpMethod
 
 import static datadog.trace.instrumentation.okhttp3.OkHttpClientDecorator.NETWORK_DECORATE
@@ -77,8 +74,8 @@ class OkHttp3Test extends HttpClientTest<OkHttpClientDecorator> {
           }
           "$Tags.HTTP_URL.key" "${uri.resolve(uri.path)}"
           if (tagQueryString) {
-            "http.query.string" uri.query
-            "http.fragment.string" uri.fragment
+            "$DDTags.HTTP_QUERY" uri.query
+            "$DDTags.HTTP_FRAGMENT" uri.fragment
           }
           "$Tags.PEER_HOSTNAME.key" "localhost"
           "$Tags.PEER_PORT.key" server.address.port

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
@@ -6,6 +6,7 @@ import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.api.Config
 import datadog.trace.api.DDSpanTypes
+import datadog.trace.api.DDTags
 import io.opentracing.tag.Tags
 import spock.lang.AutoCleanup
 import spock.lang.Shared
@@ -338,8 +339,8 @@ abstract class HttpClientTest<T extends HttpClientDecorator> extends AgentTestRu
         }
         "$Tags.HTTP_URL.key" "${uri.resolve(uri.path)}"
         if (tagQueryString) {
-          "http.query.string" uri.query
-          "http.fragment.string" { it == null || it == uri.fragment } // Optional
+          "$DDTags.HTTP_QUERY" uri.query
+          "$DDTags.HTTP_FRAGMENT" { it == null || it == uri.fragment } // Optional
         }
         "$Tags.PEER_HOSTNAME.key" "localhost"
         "$Tags.PEER_PORT.key" uri.port

--- a/dd-trace-api/src/main/java/datadog/trace/api/DDTags.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/DDTags.java
@@ -8,6 +8,9 @@ public class DDTags {
   public static final String THREAD_ID = "thread.id";
   public static final String DB_STATEMENT = "sql.query";
 
+  public static final String HTTP_QUERY = "http.query.string";
+  public static final String HTTP_FRAGMENT = "http.fragment.string";
+
   public static final String USER_NAME = "user.principal";
 
   public static final String ERROR_MSG = "error.msg"; // string representing the error message


### PR DESCRIPTION
Removes duplicate strings in HttpServerDecorator and HttpClientDecorator by replacing with a constant in DDTags