### PR TITLE
Run JmxFetch app as a daemon

### DIFF
--- a/dd-java-agent/agent-jmxfetch/agent-jmxfetch.gradle
+++ b/dd-java-agent/agent-jmxfetch/agent-jmxfetch.gradle
@@ -4,7 +4,7 @@ plugins {
 apply from: "${rootDir}/gradle/java.gradle"
 
 dependencies {
-  compile('com.datadoghq:jmxfetch:0.30.0--------------yet-to-be-released'){
+  compile('com.datadoghq:jmxfetch:0.30.0'){
     exclude group: 'org.slf4j', module: 'slf4j-log4j12'
     exclude group: 'log4j', module: 'log4j'
   }

--- a/dd-java-agent/agent-jmxfetch/agent-jmxfetch.gradle
+++ b/dd-java-agent/agent-jmxfetch/agent-jmxfetch.gradle
@@ -4,7 +4,7 @@ plugins {
 apply from: "${rootDir}/gradle/java.gradle"
 
 dependencies {
-  compile('com.datadoghq:jmxfetch:0.29.0'){
+  compile('com.datadoghq:jmxfetch:0.30.0--------------yet-to-be-released'){
     exclude group: 'org.slf4j', module: 'slf4j-log4j12'
     exclude group: 'log4j', module: 'log4j'
   }

--- a/dd-java-agent/agent-jmxfetch/src/main/java/datadog/trace/agent/jmxfetch/JMXFetch.java
+++ b/dd-java-agent/agent-jmxfetch/src/main/java/datadog/trace/agent/jmxfetch/JMXFetch.java
@@ -74,6 +74,8 @@ public class JMXFetch {
     final AppConfig.AppConfigBuilder configBuilder =
         AppConfig.builder()
             .action(ImmutableList.of(ACTION_COLLECT))
+            // App should be run as daemon otherwise CLI apps would not exit once main method exits.
+            .daemon(true)
             .confdDirectory(jmxFetchConfigDir)
             .yamlFileList(jmxFetchConfigs)
             .targetDirectInstances(true)


### PR DESCRIPTION
This PR applies changes required to run JmxFetch application as a daemon. Before when CLI apps were running with Jmx fetch enabled they would not exit and hangs forever in some cases.

https://github.com/DataDog/jmxfetch/pull/237