### PR TITLE
Revert "Trace 'records(TopicPartitions)` in kafka consumer"

### DIFF
--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaConsumerInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaConsumerInstrumentation.java
@@ -52,9 +52,7 @@ public final class KafkaConsumerInstrumentation extends Instrumenter.Default {
         isMethod()
             .and(isPublic())
             .and(named("records"))
-            .and(
-                takesArgument(0, String.class)
-                    .or(takesArgument(0, named("org.apache.kafka.common.TopicPartition"))))
+            .and(takesArgument(0, String.class))
             .and(returns(Iterable.class)),
         IterableAdvice.class.getName());
     transformers.put(


### PR DESCRIPTION
Reverts DataDog/dd-trace-java#908

It doesn't work and this might cause confusion.