### PR TITLE
Avoid Jetty 10

### DIFF
--- a/dd-java-agent/instrumentation/jetty-8/jetty-8.gradle
+++ b/dd-java-agent/instrumentation/jetty-8/jetty-8.gradle
@@ -34,7 +34,9 @@ dependencies {
   testCompile group: 'org.eclipse.jetty', name: 'jetty-servlet', version: '8.0.0.v20110901'
   testCompile group: 'org.eclipse.jetty', name: 'jetty-continuation', version: '8.0.0.v20110901'
 
-  latestDepTestCompile group: 'org.eclipse.jetty', name: 'jetty-server', version: '+'
-  latestDepTestCompile group: 'org.eclipse.jetty', name: 'jetty-servlet', version: '+'
-  latestDepTestCompile group: 'org.eclipse.jetty', name: 'jetty-continuation', version: '+'
+  // Jetty 10 seems to refuse to run on java8.
+  // TODO: we need to setup separate test for Jetty 10 when that is released.
+  latestDepTestCompile group: 'org.eclipse.jetty', name: 'jetty-server', version: '9.+'
+  latestDepTestCompile group: 'org.eclipse.jetty', name: 'jetty-servlet', version: '9.+'
+  latestDepTestCompile group: 'org.eclipse.jetty', name: 'jetty-continuation', version: '9.+'
 }

--- a/dd-java-agent/instrumentation/servlet-3/servlet-3.gradle
+++ b/dd-java-agent/instrumentation/servlet-3/servlet-3.gradle
@@ -41,8 +41,10 @@ dependencies {
   testCompile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '8.0.41'
   testCompile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-jasper', version: '8.0.41'
 
-  latestDepTestCompile group: 'org.eclipse.jetty', name: 'jetty-server', version: '+'
-  latestDepTestCompile group: 'org.eclipse.jetty', name: 'jetty-servlet', version: '+'
+  // Jetty 10 seems to refuse to run on java8.
+  // TODO: we need to setup separate test for Jetty 10 when that is released.
+  latestDepTestCompile group: 'org.eclipse.jetty', name: 'jetty-server', version: '9.+'
+  latestDepTestCompile group: 'org.eclipse.jetty', name: 'jetty-servlet', version: '9.+'
   latestDepTestCompile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '+'
   latestDepTestCompile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-jasper', version: '+'
 }


### PR DESCRIPTION
Alpha version of Jetty 1 was released and it seems to be compiled for
java versions above 8 so tests fail on java8.

Limit latest dep Jetty tests to Jetty 9 for now.