### PR TITLE
Remove default instance

### DIFF
--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/JDBCConnectionUrlParser.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/JDBCConnectionUrlParser.java
@@ -295,7 +295,6 @@ public enum JDBCConnectionUrlParser {
   MSSQLSERVER("microsoft", "sqlserver") {
     private static final String DEFAULT_HOST = "localhost";
     private static final int DEFAULT_PORT = 1433;
-    private static final String DEFAULT_INSTANCE = "MSSQLSERVER";
 
     @Override
     DBInfo.Builder doParse(String jdbcUrl, final DBInfo.Builder builder) {
@@ -307,9 +306,6 @@ public enum JDBCConnectionUrlParser {
       }
       builder.type("sqlserver");
       final DBInfo dbInfo = builder.build();
-      if (dbInfo.getInstance() == null) {
-        builder.instance(DEFAULT_INSTANCE);
-      }
       if (dbInfo.getHost() == null) {
         builder.host(DEFAULT_HOST);
       }

--- a/dd-java-agent/instrumentation/jdbc/src/test/groovy/JDBCConnectionUrlParserTest.groovy
+++ b/dd-java-agent/instrumentation/jdbc/src/test/groovy/JDBCConnectionUrlParserTest.groovy
@@ -88,12 +88,12 @@ class JDBCConnectionUrlParserTest extends Specification {
       "address=(host=anotherhost)(port=3306)(user=wrong)(password=PW)/mdbdb?user=mdbuser&password=PW" | null     | "mysql"      | "replication" | "mdbuser"     | "mdb.host"                                | 3306  | null                               | "mdbdb"
 
     //https://docs.microsoft.com/en-us/sql/connect/jdbc/building-the-connection-url
-    "jdbc:microsoft:sqlserver://;"                                                                    | null     | "sqlserver"  | null          | null          | "localhost"                               | 1433  | "MSSQLSERVER"                      | null
-    "jdbc:microsoft:sqlserver://;"                                                                    | stdProps | "sqlserver"  | null          | "stdUserName" | "stdServerName"                           | 9999  | "MSSQLSERVER"                      | "stdDatabaseName"
+    "jdbc:microsoft:sqlserver://;"                                                                    | null     | "sqlserver"  | null          | null          | "localhost"                               | 1433  | null                               | null
+    "jdbc:microsoft:sqlserver://;"                                                                    | stdProps | "sqlserver"  | null          | "stdUserName" | "stdServerName"                           | 9999  | null                               | "stdDatabaseName"
     "jdbc:sqlserver://ss.host\\ssinstance:44;databaseName=ssdb;user=ssuser;password=pw"               | null     | "sqlserver"  | null          | "ssuser"      | "ss.host"                                 | 44    | "ssinstance"                       | "ssdb"
     "jdbc:sqlserver://;serverName=ss.host\\ssinstance:44;DatabaseName=;"                              | null     | "sqlserver"  | null          | null          | "ss.host"                                 | 44    | "ssinstance"                       | null
-    "jdbc:sqlserver://ss.host;serverName=althost;DatabaseName=ssdb;"                                  | null     | "sqlserver"  | null          | null          | "ss.host"                                 | 1433  | "MSSQLSERVER"                      | "ssdb"
-    "jdbc:microsoft:sqlserver://ss.host:44;DatabaseName=ssdb;user=ssuser;password=pw;user=ssuser2;"   | null     | "sqlserver"  | null          | "ssuser"      | "ss.host"                                 | 44    | "MSSQLSERVER"                      | "ssdb"
+    "jdbc:sqlserver://ss.host;serverName=althost;DatabaseName=ssdb;"                                  | null     | "sqlserver"  | null          | null          | "ss.host"                                 | 1433  | null                               | "ssdb"
+    "jdbc:microsoft:sqlserver://ss.host:44;DatabaseName=ssdb;user=ssuser;password=pw;user=ssuser2;"   | null     | "sqlserver"  | null          | "ssuser"      | "ss.host"                                 | 44    | null                               | "ssdb"
 
     // https://docs.oracle.com/cd/B28359_01/java.111/b31224/urls.htm
     // https://docs.oracle.com/cd/B28359_01/java.111/b31224/jdbcthin.htm


### PR DESCRIPTION
It’s not very interesting and breaks the definition of “instance” when we want to see the db name when no instance name is defined.