### PR TITLE
Assert span in scope can't be null and add tests to verify

### DIFF
--- a/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
@@ -619,7 +619,7 @@ public class DDTracer implements io.opentracing.Tracer, Closeable, datadog.trace
       if (parentContext == null && !ignoreScope) {
         // use the Scope as parent unless overridden or ignored.
         final Scope scope = scopeManager.active();
-        if (scope != null && scope.span() != null) {
+        if (scope != null) {
           parentContext = scope.span().context();
         }
       }

--- a/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
@@ -619,7 +619,7 @@ public class DDTracer implements io.opentracing.Tracer, Closeable, datadog.trace
       if (parentContext == null && !ignoreScope) {
         // use the Scope as parent unless overridden or ignored.
         final Scope scope = scopeManager.active();
-        if (scope != null) {
+        if (scope != null && scope.span() != null) {
           parentContext = scope.span().context();
         }
       }

--- a/dd-trace-ot/src/main/java/datadog/opentracing/scopemanager/ContinuableScope.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/scopemanager/ContinuableScope.java
@@ -48,7 +48,7 @@ public class ContinuableScope implements Scope, TraceScope {
     this.openCount = openCount;
     this.continuation = continuation;
     this.spanUnderScope = spanUnderScope;
-    this.finishOnClose = finishOnClose;
+    this.finishOnClose = finishOnClose && spanUnderScope != null;
     toRestore = scopeManager.tlsScope.get();
     scopeManager.tlsScope.set(this);
     for (final ScopeListener listener : scopeManager.scopeListeners) {

--- a/dd-trace-ot/src/main/java/datadog/opentracing/scopemanager/ContinuableScope.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/scopemanager/ContinuableScope.java
@@ -44,11 +44,12 @@ public class ContinuableScope implements Scope, TraceScope {
       final Continuation continuation,
       final DDSpan spanUnderScope,
       final boolean finishOnClose) {
+    assert spanUnderScope != null : "span must not be null";
     this.scopeManager = scopeManager;
     this.openCount = openCount;
     this.continuation = continuation;
     this.spanUnderScope = spanUnderScope;
-    this.finishOnClose = finishOnClose && spanUnderScope != null;
+    this.finishOnClose = finishOnClose;
     toRestore = scopeManager.tlsScope.get();
     scopeManager.tlsScope.set(this);
     for (final ScopeListener listener : scopeManager.scopeListeners) {

--- a/dd-trace-ot/src/main/java/datadog/opentracing/scopemanager/SimpleScope.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/scopemanager/SimpleScope.java
@@ -17,8 +17,8 @@ public class SimpleScope implements Scope {
       final boolean finishOnClose) {
     this.scopeManager = scopeManager;
     this.spanUnderScope = spanUnderScope;
-    this.finishOnClose = finishOnClose;
-    this.toRestore = scopeManager.tlsScope.get();
+    this.finishOnClose = finishOnClose && spanUnderScope != null;
+    toRestore = scopeManager.tlsScope.get();
     scopeManager.tlsScope.set(this);
     for (final ScopeListener listener : scopeManager.scopeListeners) {
       listener.afterScopeActivated();

--- a/dd-trace-ot/src/main/java/datadog/opentracing/scopemanager/SimpleScope.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/scopemanager/SimpleScope.java
@@ -15,9 +15,10 @@ public class SimpleScope implements Scope {
       final ContextualScopeManager scopeManager,
       final Span spanUnderScope,
       final boolean finishOnClose) {
+    assert spanUnderScope != null : "span must not be null";
     this.scopeManager = scopeManager;
     this.spanUnderScope = spanUnderScope;
-    this.finishOnClose = finishOnClose && spanUnderScope != null;
+    this.finishOnClose = finishOnClose;
     toRestore = scopeManager.tlsScope.get();
     scopeManager.tlsScope.set(this);
     for (final ScopeListener listener : scopeManager.scopeListeners) {

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/DDSpanBuilderTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/DDSpanBuilderTest.groovy
@@ -7,6 +7,7 @@ import datadog.trace.api.DDTags
 import datadog.trace.api.sampling.PrioritySampling
 import datadog.trace.common.writer.ListWriter
 import io.opentracing.Scope
+import io.opentracing.noop.NoopSpan
 import spock.lang.Specification
 
 import static datadog.opentracing.DDSpanContext.ORIGIN_KEY
@@ -176,12 +177,12 @@ class DDSpanBuilderTest extends Specification {
 
   def "should link to parent span implicitly"() {
     setup:
-    final Scope parent = nullParent ?
-      tracer.scopeManager().activate(null, false) :
+    final Scope parent = noopParent ?
+      tracer.scopeManager().activate(NoopSpan.INSTANCE, false) :
       tracer.buildSpan("parent")
         .startActive(false)
 
-    final String expectedParentId = nullParent ? "0" : parent.span().context().getSpanId()
+    final String expectedParentId = noopParent ? "0" : parent.span().context().getSpanId()
 
     final String expectedName = "fakeName"
 
@@ -198,7 +199,7 @@ class DDSpanBuilderTest extends Specification {
     parent.close()
 
     where:
-    nullParent << [false, true]
+    noopParent << [false, true]
   }
 
   def "should inherit the DD parent attributes"() {


### PR DESCRIPTION
We want to be able to use `NoopSpan` to temporarily remove the current trace from scope for a period. 

In our instrumentation, we sometimes capture the parent span on one thread to restore as the parent on a different thread.  If that parent is null, we should be able to indicate that state. We will do so with a `NoopSpan`.

For example:
We have an async http client request that starts in one thread and finishes in another thread.  We want the callback to have the correct trace context, but not necessarily be a child of the client span, so the best option is to provide the parent span as the scope for the callback. If there is no parent, we need to identify such even if there's an existing trace for some reason where the callback is being executed.