### PR TITLE
Remove version from gradle wrapper definition

### DIFF
--- a/dd-trace-java.gradle
+++ b/dd-trace-java.gradle
@@ -52,7 +52,6 @@ buildScan {
 
 wrapper {
   distributionType = Wrapper.DistributionType.ALL
-  version = '5.5.1'
 }
 
 allprojects {


### PR DESCRIPTION
It doesn't look like it is doing anything useful but instead it seems
to set version in resulting build jar which is not expected.