### PR TITLE
Cli Application Smoke Test

### DIFF
--- a/dd-smoke-tests/README.md
+++ b/dd-smoke-tests/README.md
@@ -1,8 +1,8 @@
 # Datadog Smoke Tests
-Assert that various application servers will start up with the Datadog JavaAgent without any obvious ill effects.
+Assert that various applications will start up with the Datadog JavaAgent without any obvious ill effects.
 
 Each subproject underneath `dd-smoke-tests` is a single smoke test. Each test does the following
-* Launch the app server with stdout and stderr logged to `$buildDir/reports/server.log`
-* Run a spock test which does 200 requests to an endpoint on the server and asserts on an expected response.
+* Launch the application with stdout and stderr logged to `$buildDir/reports/server.log`
+* For web servers, run a spock test which does 200 requests to an endpoint on the server and asserts on an expected response.
 
 Note that there is nothing special about doing 200 requests. 200 is simply an arbitrarily large number to exercise the server.

--- a/dd-smoke-tests/cli/cli.gradle
+++ b/dd-smoke-tests/cli/cli.gradle
@@ -1,0 +1,23 @@
+plugins {
+  id "com.github.johnrengelman.shadow" version "4.0.4"
+}
+apply from: "${rootDir}/gradle/java.gradle"
+description = 'Command Line Application Smoke Tests.'
+
+jar {
+  manifest {
+    attributes(
+      'Main-Class': 'datadog.smoketest.cli.CliApplication'
+    )
+  }
+}
+
+dependencies {
+  testCompile project(':dd-smoke-tests')
+}
+
+tasks.withType(Test).configureEach {
+  dependsOn shadowJar
+
+  jvmArgs "-Ddatadog.smoketest.cli.shadowJar.path=${tasks.shadowJar.archivePath}"
+}

--- a/dd-smoke-tests/cli/cli.gradle
+++ b/dd-smoke-tests/cli/cli.gradle
@@ -13,6 +13,8 @@ jar {
 }
 
 dependencies {
+  compile project(':dd-trace-api')
+
   testCompile project(':dd-smoke-tests')
 }
 

--- a/dd-smoke-tests/cli/src/main/java/datadog/smoketest/cli/CliApplication.java
+++ b/dd-smoke-tests/cli/src/main/java/datadog/smoketest/cli/CliApplication.java
@@ -1,0 +1,16 @@
+package datadog.smoketest.cli;
+
+/** Simple application that sleeps for a bit than quits. */
+public class CliApplication {
+
+  /** @param args Only argument is the sleep delay (in seconds) */
+  public static void main(final String[] args) throws InterruptedException {
+    final int delay = Integer.parseInt(args[0]);
+
+    System.out.println("Going to shut down after " + delay + "seconds");
+
+    Thread.sleep(delay * 1000);
+
+    System.out.println("Shutting down");
+  }
+}

--- a/dd-smoke-tests/cli/src/main/java/datadog/smoketest/cli/CliApplication.java
+++ b/dd-smoke-tests/cli/src/main/java/datadog/smoketest/cli/CliApplication.java
@@ -1,16 +1,33 @@
 package datadog.smoketest.cli;
 
-/** Simple application that sleeps for a bit than quits. */
+import datadog.trace.api.Trace;
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLConnection;
+
+/** Simple application that makes a request to example.com then quits. */
 public class CliApplication {
 
-  /** @param args Only argument is the sleep delay (in seconds) */
   public static void main(final String[] args) throws InterruptedException {
-    final int delay = Integer.parseInt(args[0]);
+    final CliApplication app = new CliApplication();
 
-    System.out.println("Going to shut down after " + delay + "seconds");
+    System.out.println("Making request");
 
-    Thread.sleep(delay * 1000);
+    app.makeRequest();
 
-    System.out.println("Shutting down");
+    System.out.println("Finished making request");
+  }
+
+  @Trace(operationName = "example")
+  public void makeRequest() {
+    try {
+      final URL url = new URL("http://www.example.com/");
+      final URLConnection connection = url.openConnection();
+      connection.setConnectTimeout(1000);
+      connection.connect();
+      connection.getInputStream();
+    } catch (final IOException e) {
+      // Ignore.  The goal of this app is to attempt the connection not necessarily to succeed
+    }
   }
 }

--- a/dd-smoke-tests/cli/src/main/java/datadog/smoketest/cli/CliApplication.java
+++ b/dd-smoke-tests/cli/src/main/java/datadog/smoketest/cli/CliApplication.java
@@ -11,6 +11,9 @@ public class CliApplication {
   public static void main(final String[] args) throws InterruptedException {
     final CliApplication app = new CliApplication();
 
+    // Sleep to ensure all of the processes are running
+    Thread.sleep(5000);
+
     System.out.println("Making request");
 
     app.makeRequest();

--- a/dd-smoke-tests/cli/src/main/java/datadog/smoketest/cli/CliApplication.java
+++ b/dd-smoke-tests/cli/src/main/java/datadog/smoketest/cli/CliApplication.java
@@ -1,11 +1,8 @@
 package datadog.smoketest.cli;
 
 import datadog.trace.api.Trace;
-import java.io.IOException;
-import java.net.URL;
-import java.net.URLConnection;
 
-/** Simple application that makes a request to example.com then quits. */
+/** Simple application that sleeps then quits. */
 public class CliApplication {
 
   public static void main(final String[] args) throws InterruptedException {
@@ -14,23 +11,15 @@ public class CliApplication {
     // Sleep to ensure all of the processes are running
     Thread.sleep(5000);
 
-    System.out.println("Making request");
+    System.out.println("Calling example trace");
 
-    app.makeRequest();
+    app.exampleTrace();
 
-    System.out.println("Finished making request");
+    System.out.println("Finished calling example trace");
   }
 
   @Trace(operationName = "example")
-  public void makeRequest() {
-    try {
-      final URL url = new URL("http://www.example.com/");
-      final URLConnection connection = url.openConnection();
-      connection.setConnectTimeout(1000);
-      connection.connect();
-      connection.getInputStream();
-    } catch (final IOException e) {
-      // Ignore.  The goal of this app is to attempt the connection not necessarily to succeed
-    }
+  public void exampleTrace() throws InterruptedException {
+    Thread.sleep(500);
   }
 }

--- a/dd-smoke-tests/cli/src/test/groovy/datadog/smoketest/CliApplicationSmokeTest.groovy
+++ b/dd-smoke-tests/cli/src/test/groovy/datadog/smoketest/CliApplicationSmokeTest.groovy
@@ -6,7 +6,7 @@ import java.util.concurrent.TimeUnit
 
 class CliApplicationSmokeTest extends AbstractSmokeTest {
   // Estimate for the amount of time instrumentation, plus request, plus some extra
-  private static final int TIMEOUT_SECS = 10
+  private static final int TIMEOUT_SECS = 15
 
   @Override
   ProcessBuilder createProcessBuilder() {

--- a/dd-smoke-tests/cli/src/test/groovy/datadog/smoketest/CliApplicationSmokeTest.groovy
+++ b/dd-smoke-tests/cli/src/test/groovy/datadog/smoketest/CliApplicationSmokeTest.groovy
@@ -1,11 +1,12 @@
 package datadog.smoketest
 
+import spock.lang.Timeout
 
 import java.util.concurrent.TimeUnit
 
 class CliApplicationSmokeTest extends AbstractSmokeTest {
   // Estimate for the amount of time instrumentation, plus request, plus some extra
-  private static final long TIMEOUT_SECS = 10
+  private static final int TIMEOUT_SECS = 10
 
   @Override
   ProcessBuilder createProcessBuilder() {
@@ -19,10 +20,9 @@ class CliApplicationSmokeTest extends AbstractSmokeTest {
     processBuilder.directory(new File(buildDirectory))
   }
 
+  @Timeout(value = TIMEOUT_SECS, unit = TimeUnit.SECONDS)
   def "Cli application process ends before timeout"() {
     expect:
-    assert serverProcess.waitFor(TIMEOUT_SECS, TimeUnit.SECONDS)
-
-    assert serverProcess.exitValue() == 0
+    assert serverProcess.waitFor() == 0
   }
 }

--- a/dd-smoke-tests/cli/src/test/groovy/datadog/smoketest/CliApplicationSmokeTest.groovy
+++ b/dd-smoke-tests/cli/src/test/groovy/datadog/smoketest/CliApplicationSmokeTest.groovy
@@ -5,7 +5,7 @@ import java.util.concurrent.TimeUnit
 
 class CliApplicationSmokeTest extends AbstractSmokeTest {
   // Estimate for the amount of time instrumentation, plus request, plus some extra
-  private static final int TIMEOUT_SECS = 10
+  private static final long TIMEOUT_SECS = 10
 
   @Override
   ProcessBuilder createProcessBuilder() {

--- a/dd-smoke-tests/cli/src/test/groovy/datadog/smoketest/CliApplicationSmokeTest.groovy
+++ b/dd-smoke-tests/cli/src/test/groovy/datadog/smoketest/CliApplicationSmokeTest.groovy
@@ -1,0 +1,34 @@
+package datadog.smoketest
+
+import spock.util.concurrent.PollingConditions
+
+class CliApplicationSmokeTest extends AbstractSmokeTest {
+  // Estimate for the amount of time instrumentation takes plus a little extra
+  private static final int INSTRUMENTATION_DELAY = 6 + 5
+
+  private static final int SHUTDOWN_DELAY = 2
+  
+  @Override
+  ProcessBuilder createProcessBuilder() {
+    String cliShadowJar = System.getProperty("datadog.smoketest.cli.shadowJar.path")
+
+    List<String> command = new ArrayList<>()
+    command.add(javaPath())
+    command.addAll(defaultJavaProperties)
+    command.addAll((String[]) ["-jar", cliShadowJar, String.valueOf(SHUTDOWN_DELAY)])
+    ProcessBuilder processBuilder = new ProcessBuilder(command)
+    processBuilder.directory(new File(buildDirectory))
+  }
+
+  def "Cli application process ends before timeout"() {
+    setup:
+    def conditions = new PollingConditions(timeout: INSTRUMENTATION_DELAY, initialDelay: SHUTDOWN_DELAY)
+
+    expect:
+    serverProcess.isAlive()
+
+    conditions.eventually {
+      assert !serverProcess.isAlive()
+    }
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -22,6 +22,7 @@ include ':utils:gc-utils'
 include ':dd-smoke-tests:play'
 include ':dd-smoke-tests:springboot'
 include ':dd-smoke-tests:wildfly'
+include ':dd-smoke-tests:cli'
 
 // instrumentation:
 include ':dd-java-agent:instrumentation:akka-http-10.0'


### PR DESCRIPTION
This adds a smoke test that ensures CLI applications correctly exit when running under the java agent.  There are 2 parts:

1. A simple cli application that quits after a delay
2. The smoke test that checks to make sure that the cli application exits

I also manually tested and ensured that the test failed when JMXFetch.daemon = false.  This was the issue that prompted the creation of the test.