### PR TITLE
Better hostname detection

### DIFF
--- a/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -724,7 +724,7 @@ class ConfigTest extends Specification {
     def config = Config.get(properties)
 
     then:
-    config.localRootSpanTags.get('_dd.hostname') == InetAddress.localHost.hostName
+    config.localRootSpanTags.containsKey('_dd.hostname')
   }
 
   def "verify fallback to properties file"() {


### PR DESCRIPTION
Attempt to get hostname in the following way:

1. Using environment variables
2. Using the `hostname` command
3. Using `InetAddress.getLocalHost().getHostName()` (network/DNS)

This method is faster, and generally more accurate (See [this discussion](https://stackoverflow.com/questions/7348711/recommended-way-to-get-hostname-in-java?answertab=votes#tab-top)).  Although almost always the same, when the environment vars and network disagree, the environment vars are usually more correct.

Marked as a *breaking change* because there could be situations where environment variables and network are not the same and the user expects it to use the network hostname.

**Testing**
This is inherently difficult to test in an automated fashion: Windows/Mac/Linux differences; Spock in an IDE gives a different result than Spock on the command line (intellij doesn't forward environment vars).  I did manually test in different environments.