### PR TITLE
Limit Vert.x tests to 3.x

### DIFF
--- a/dd-java-agent/instrumentation/vertx/vertx.gradle
+++ b/dd-java-agent/instrumentation/vertx/vertx.gradle
@@ -52,8 +52,9 @@ dependencies {
   testCompile group: 'io.vertx', name: 'vertx-circuit-breaker', version: '3.5.0'
   testCompile group: 'io.vertx', name: 'vertx-rx-java2', version: '3.5.0'
 
-  latestDepTestCompile group: 'io.vertx', name: 'vertx-web', version: '+'
-  latestDepTestCompile group: 'io.vertx', name: 'vertx-web-client', version: '+'
-  latestDepTestCompile group: 'io.vertx', name: 'vertx-circuit-breaker', version: '+'
-  latestDepTestCompile group: 'io.vertx', name: 'vertx-rx-java2', version: '+'
+  // Vert.x 4.0 is incompatible with our tests.
+  latestDepTestCompile group: 'io.vertx', name: 'vertx-web', version: '3.+'
+  latestDepTestCompile group: 'io.vertx', name: 'vertx-web-client', version: '3.+'
+  latestDepTestCompile group: 'io.vertx', name: 'vertx-circuit-breaker', version: '3.+'
+  latestDepTestCompile group: 'io.vertx', name: 'vertx-rx-java2', version: '3.+'
 }


### PR DESCRIPTION
4.0.0-milestone1 was just released and is incompatible.