### PR TITLE
Eliminate temporary jars for instrumentation, jmxfetch, and bootstrap

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/DatadogClassLoader.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/DatadogClassLoader.java
@@ -34,7 +34,6 @@ public class DatadogClassLoader extends URLClassLoader {
   // As a workaround, we keep a reference to the bootstrap jar
   // to use only for resource lookups.
   private final BootstrapClassLoaderProxy bootstrapProxy;
-
   /**
    * Construct a new DatadogClassLoader
    *
@@ -44,25 +43,23 @@ public class DatadogClassLoader extends URLClassLoader {
    *     9+.
    */
   public DatadogClassLoader(
-      final URL bootstrapJarLocation,
-      final String internalJarFileName,
-      final ClassLoader classloaderForJarResource,
-      final ClassLoader parent) {
+      final URL bootstrapJarLocation, final String internalJarFileName, final ClassLoader parent) {
     super(new URL[] {}, parent);
     bootstrapProxy = new BootstrapClassLoaderProxy(new URL[] {bootstrapJarLocation});
 
-    if (classloaderForJarResource != null) { // Some tests pass null
+    if (internalJarFileName != null) { // some tests pass null
       try {
         // The fields of the URL are mostly dummy.  InternalJarURLHandler is the only important
         // field.  If extending this class from Classloader instead of URLClassloader required less
         // boilerplate it could be used and the need for dummy fields would be reduced
+
         final URL internalJarURL =
             new URL(
                 "x-internal-jar",
                 null,
                 0,
                 "/",
-                new InternalJarURLHandler(internalJarFileName, classloaderForJarResource));
+                new InternalJarURLHandler(internalJarFileName, bootstrapProxy));
 
         addURL(internalJarURL);
       } catch (final MalformedURLException e) {

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/DatadogClassLoader.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/DatadogClassLoader.java
@@ -1,9 +1,28 @@
 package datadog.trace.bootstrap;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.net.URLConnection;
+import java.net.URLStreamHandler;
+import java.nio.file.NoSuchFileException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.jar.JarEntry;
+import java.util.jar.JarInputStream;
+import lombok.extern.slf4j.Slf4j;
 
-/** Classloader used to run the core datadog agent. */
+/**
+ * Classloader used to run the core datadog agent.
+ *
+ * <p>It is built around the concept of a jar inside another jar. This classloader loads the files
+ * of the internal jar to load classes and resources.
+ */
+@Slf4j
 public class DatadogClassLoader extends URLClassLoader {
   static {
     ClassLoader.registerAsParallelCapable();
@@ -19,17 +38,41 @@ public class DatadogClassLoader extends URLClassLoader {
    * Construct a new DatadogClassLoader
    *
    * @param bootstrapJarLocation Used for resource lookups.
-   * @param agentJarLocation Classpath of this classloader.
+   * @param internalJarFileName File name of the internal jar
    * @param parent Classloader parent. Should null (bootstrap), or the platform classloader for java
    *     9+.
    */
-  public DatadogClassLoader(URL bootstrapJarLocation, URL agentJarLocation, ClassLoader parent) {
-    super(new URL[] {agentJarLocation}, parent);
-    bootstrapProxy = new BootstrapClassLoaderProxy(new URL[] {bootstrapJarLocation}, null);
+  public DatadogClassLoader(
+      final URL bootstrapJarLocation,
+      final String internalJarFileName,
+      final ClassLoader classloaderForJarResource,
+      final ClassLoader parent) {
+    super(new URL[] {}, parent);
+    bootstrapProxy = new BootstrapClassLoaderProxy(new URL[] {bootstrapJarLocation});
+
+    if (classloaderForJarResource != null) { // Some tests pass null
+      try {
+        // The fields of the URL are mostly dummy.  InternalJarURLHandler is the only important
+        // field.  If extending this class from Classloader instead of URLClassloader required less
+        // boilerplate it could be used and the need for dummy fields would be reduced
+        final URL internalJarURL =
+            new URL(
+                "x-internal-jar",
+                null,
+                0,
+                "/",
+                new InternalJarURLHandler(internalJarFileName, classloaderForJarResource));
+
+        addURL(internalJarURL);
+      } catch (final MalformedURLException e) {
+        // This can't happen with current URL constructor
+        log.error("URL malformed.  Unsupported JDK?", e);
+      }
+    }
   }
 
   @Override
-  public URL getResource(String resourceName) {
+  public URL getResource(final String resourceName) {
     final URL bootstrapResource = bootstrapProxy.getResource(resourceName);
     if (null == bootstrapResource) {
       return super.getResource(resourceName);
@@ -61,18 +104,103 @@ public class DatadogClassLoader extends URLClassLoader {
       ClassLoader.registerAsParallelCapable();
     }
 
-    public BootstrapClassLoaderProxy(URL[] urls, ClassLoader parent) {
-      super(urls, parent);
+    public BootstrapClassLoaderProxy(final URL[] urls) {
+      super(urls);
     }
 
     @Override
-    public void addURL(URL url) {
+    public void addURL(final URL url) {
       super.addURL(url);
     }
 
     @Override
-    protected Class<?> findClass(String name) throws ClassNotFoundException {
+    protected Class<?> findClass(final String name) throws ClassNotFoundException {
       throw new ClassNotFoundException(name);
+    }
+  }
+
+  private static class InternalJarURLHandler extends URLStreamHandler {
+    private final Map<String, byte[]> filenameToBytes = new HashMap<>();
+
+    public InternalJarURLHandler(
+        final String internalJarFileName, final ClassLoader classloaderForJarResource) {
+
+      final InputStream jarStream =
+          classloaderForJarResource.getResourceAsStream(internalJarFileName);
+
+      if (jarStream != null) {
+        try (final JarInputStream inputStream = new JarInputStream(jarStream)) {
+          JarEntry entry = inputStream.getNextJarEntry();
+
+          while (entry != null) {
+            filenameToBytes.put("/" + entry.getName(), getBytes(inputStream));
+
+            entry = inputStream.getNextJarEntry();
+          }
+
+        } catch (final IOException e) {
+          log.error("Unable to read internal jar", e);
+        }
+      } else {
+        log.error("Internal jar not found");
+      }
+    }
+
+    @Override
+    protected URLConnection openConnection(final URL url) throws IOException {
+      final byte[] bytes = filenameToBytes.get(url.getFile());
+
+      if (bytes == null) {
+        throw new NoSuchFileException(url.getFile());
+      }
+
+      return new InternalJarURLConnection(url, bytes);
+    }
+  }
+
+  private static class InternalJarURLConnection extends URLConnection {
+    private final byte[] bytes;
+
+    private InternalJarURLConnection(final URL url, final byte[] bytes) {
+      super(url);
+      this.bytes = bytes;
+    }
+
+    @Override
+    public void connect() throws IOException {
+      connected = true;
+    }
+
+    @Override
+    public InputStream getInputStream() throws IOException {
+      return new ByteArrayInputStream(bytes);
+    }
+  }
+
+  /**
+   * Standard "copy InputStream to byte[]" implementation using a ByteArrayOutputStream
+   *
+   * <p>IOUtils.toByteArray() or Java 9's InputStream.readAllBytes() could be replacements if they
+   * were available
+   *
+   * <p>This can be optimized using the JarEntry's size(), but its not always available
+   *
+   * @param inputStream
+   * @return a byte[] from the inputstream
+   * @throws IOException
+   */
+  private static byte[] getBytes(final InputStream inputStream) throws IOException {
+    final byte[] buffer = new byte[4096];
+
+    int bytesRead = inputStream.read(buffer, 0, buffer.length);
+    try (final ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+      while (bytesRead != -1) {
+        outputStream.write(buffer, 0, bytesRead);
+
+        bytesRead = inputStream.read(buffer, 0, buffer.length);
+      }
+
+      return outputStream.toByteArray();
     }
   }
 }

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/DatadogClassLoader.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/DatadogClassLoader.java
@@ -105,7 +105,7 @@ public class DatadogClassLoader extends URLClassLoader {
     }
 
     public BootstrapClassLoaderProxy(final URL[] urls) {
-      super(urls);
+      super(urls, null);
     }
 
     @Override

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/DatadogClassLoaderTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/DatadogClassLoaderTest.groovy
@@ -13,7 +13,7 @@ class DatadogClassLoaderTest extends Specification {
     def className1 = 'some/class/Name1'
     def className2 = 'some/class/Name2'
     final URL loc = getClass().getProtectionDomain().getCodeSource().getLocation()
-    final DatadogClassLoader ddLoader = new DatadogClassLoader(loc, null, null, null)
+    final DatadogClassLoader ddLoader = new DatadogClassLoader(loc, null, null)
     final Phaser threadHoldLockPhase = new Phaser(2)
     final Phaser acquireLockFromMainThreadPhase = new Phaser(2)
 

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/DatadogClassLoaderTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/DatadogClassLoaderTest.groovy
@@ -13,7 +13,7 @@ class DatadogClassLoaderTest extends Specification {
     def className1 = 'some/class/Name1'
     def className2 = 'some/class/Name2'
     final URL loc = getClass().getProtectionDomain().getCodeSource().getLocation()
-    final DatadogClassLoader ddLoader = new DatadogClassLoader(loc, loc, (ClassLoader) null)
+    final DatadogClassLoader ddLoader = new DatadogClassLoader(loc, null, null, null)
     final Phaser threadHoldLockPhase = new Phaser(2)
     final Phaser acquireLockFromMainThreadPhase = new Phaser(2)
 

--- a/dd-java-agent/agent-jmxfetch/src/main/java/datadog/trace/agent/jmxfetch/JMXFetch.java
+++ b/dd-java-agent/agent-jmxfetch/src/main/java/datadog/trace/agent/jmxfetch/JMXFetch.java
@@ -155,7 +155,15 @@ public class JMXFetch {
           integrationName.add(config.replace(".yaml", ""));
           if (Config.get().isJmxFetchIntegrationEnabled(integrationName, false)) {
             final URL resource = JMXFetch.class.getResource("metricconfigs/" + config);
-            result.add(resource.getPath().split("\\.jar!/")[1]);
+
+            // jar!/ means a file internal to a jar, only add the part after if it exists
+            final String path = resource.getPath();
+            final int filenameIndex = path.indexOf("jar!/");
+            if (filenameIndex != -1) {
+              result.add(path.substring(filenameIndex + 5));
+            } else {
+              result.add(path.substring(1));
+            }
           }
         }
         return result;

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Constants.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Constants.java
@@ -14,6 +14,7 @@ public final class Constants {
    */
   public static final String[] BOOTSTRAP_PACKAGE_PREFIXES = {
     "datadog.slf4j",
+    "datadog.trace.agent.TracingAgent",
     "datadog.trace.api",
     "datadog.trace.bootstrap",
     "datadog.trace.context",

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Utils.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Utils.java
@@ -15,7 +15,7 @@ public class Utils {
   private static Method findLoadedClassMethod = null;
 
   private static final BootstrapClassLoaderProxy unitTestBootstrapProxy =
-      new BootstrapClassLoaderProxy(new URL[0], null);
+      new BootstrapClassLoaderProxy(new URL[0]);
 
   static {
     try {

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/test/ClassLoaderMatcherTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/test/ClassLoaderMatcherTest.groovy
@@ -16,7 +16,7 @@ class ClassLoaderMatcherTest extends Specification {
   def "skips agent classloader"() {
     setup:
     URL root = new URL("file://")
-    final URLClassLoader agentLoader = new DatadogClassLoader(root, null, null, null)
+    final URLClassLoader agentLoader = new DatadogClassLoader(root, null, null)
     expect:
     ClassLoaderMatcher.skipClassLoader().matches(agentLoader)
   }

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/test/ClassLoaderMatcherTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/test/ClassLoaderMatcherTest.groovy
@@ -16,7 +16,7 @@ class ClassLoaderMatcherTest extends Specification {
   def "skips agent classloader"() {
     setup:
     URL root = new URL("file://")
-    final URLClassLoader agentLoader = new DatadogClassLoader(root, root, null)
+    final URLClassLoader agentLoader = new DatadogClassLoader(root, null, null, null)
     expect:
     ClassLoaderMatcher.skipClassLoader().matches(agentLoader)
   }

--- a/dd-java-agent/dd-java-agent.gradle
+++ b/dd-java-agent/dd-java-agent.gradle
@@ -78,7 +78,7 @@ jar {
 
 shadowJar {
   configurations = [project.configurations.shadowInclude]
-  
+
   classifier null
 
   mergeServiceFiles()
@@ -114,21 +114,17 @@ dependencies {
   testCompile deps.opentracingMock
   testCompile deps.testLogging
   testCompile deps.guava
-  
+
   shadowInclude project(':dd-java-agent:agent-bootstrap')
 }
 
 tasks.withType(Test).configureEach {
   jvmArgs "-Ddd.service.name=java-agent-tests"
   jvmArgs "-Ddd.writer.type=LoggingWriter"
+  jvmArgs "-Dagent.jar.to.forward=${shadowJar.archivePath}"
   // Multi-threaded logging seems to be causing deadlocks with Gradle's log capture.
 //  jvmArgs "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=debug"
 //  jvmArgs "-Dorg.slf4j.simpleLogger.defaultLogLevel=debug"
-
-  doFirst {
-    // Defining here to allow jacoco to be first on the command line.
-    jvmArgs "-javaagent:${shadowJar.archivePath}"
-  }
 
   testLogging {
     events "started"

--- a/dd-java-agent/dd-java-agent.gradle
+++ b/dd-java-agent/dd-java-agent.gradle
@@ -121,7 +121,6 @@ dependencies {
 tasks.withType(Test).configureEach {
   jvmArgs "-Ddd.service.name=java-agent-tests"
   jvmArgs "-Ddd.writer.type=LoggingWriter"
-  jvmArgs "-Dagent.jar.to.forward=${shadowJar.archivePath}"
   // Multi-threaded logging seems to be causing deadlocks with Gradle's log capture.
 //  jvmArgs "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=debug"
 //  jvmArgs "-Dorg.slf4j.simpleLogger.defaultLogLevel=debug"

--- a/dd-java-agent/dd-java-agent.gradle
+++ b/dd-java-agent/dd-java-agent.gradle
@@ -13,6 +13,9 @@ description = 'dd-java-agent'
 apply from: "${rootDir}/gradle/java.gradle"
 apply from: "${rootDir}/gradle/publish.gradle"
 
+configurations {
+  shadowInclude
+}
 /*
  * Include subproject's shadowJar in the dd-java-agent jar.
  * Note jarname must end in .zip, or its classes will be on the classpath of
@@ -56,7 +59,6 @@ def includeShadowJar(subproject, jarname) {
   }
 }
 
-includeShadowJar(project(':dd-java-agent:agent-bootstrap'), 'agent-bootstrap.jar.zip')
 includeShadowJar(project(':dd-java-agent:instrumentation'), 'agent-tooling-and-instrumentation.jar.zip')
 includeShadowJar(project(':dd-java-agent:agent-jmxfetch'), 'agent-jmxfetch.jar.zip')
 
@@ -75,12 +77,27 @@ jar {
 }
 
 shadowJar {
+  configurations = [project.configurations.shadowInclude]
+  
   classifier null
 
   mergeServiceFiles()
 
+  exclude '**/module-info.class'
+
   dependencies {
     exclude(dependency("org.projectlombok:lombok:$versions.lombok"))
+  }
+
+  // Prevents conflict with other SLF4J instances. Important for premain.
+  relocate 'org.slf4j', 'datadog.slf4j'
+  // rewrite dependencies calling Logger.getLogger
+  relocate 'java.util.logging.Logger', 'datadog.trace.bootstrap.PatchLogger'
+
+  if (!project.hasProperty("disableShadowRelocate") || !disableShadowRelocate) {
+    // shadow OT impl to prevent casts to implementation
+    relocate 'datadog.trace.common', 'datadog.trace.agent.common'
+    relocate 'datadog.opentracing', 'datadog.trace.agent.ot'
   }
 }
 
@@ -97,6 +114,8 @@ dependencies {
   testCompile deps.opentracingMock
   testCompile deps.testLogging
   testCompile deps.guava
+  
+  shadowInclude project(':dd-java-agent:agent-bootstrap')
 }
 
 tasks.withType(Test).configureEach {

--- a/dd-java-agent/dd-java-agent.gradle
+++ b/dd-java-agent/dd-java-agent.gradle
@@ -126,6 +126,11 @@ tasks.withType(Test).configureEach {
 //  jvmArgs "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=debug"
 //  jvmArgs "-Dorg.slf4j.simpleLogger.defaultLogLevel=debug"
 
+  doFirst {
+    // Defining here to allow jacoco to be first on the command line.
+    jvmArgs "-javaagent:${shadowJar.archivePath}"
+  }
+
   testLogging {
     events "started"
   }

--- a/dd-java-agent/instrumentation/couchbase-2.0/couchbase-2.0.gradle
+++ b/dd-java-agent/instrumentation/couchbase-2.0/couchbase-2.0.gradle
@@ -14,8 +14,8 @@ testSets {
 }
 
 muzzle {
-  // Version 2.7.5 was not released properly and muzzle cannot test against it causing failure.
-  // So we have to skip it resulting in this verbose setup.
+  // Version 2.7.5 and 2.7.8 were not released properly and muzzle cannot test against it causing failure.
+  // So we have to skip them resulting in this verbose setup.
   fail {
     group = 'com.couchbase.client'
     module = 'java-client'
@@ -29,7 +29,12 @@ muzzle {
   pass {
     group = 'com.couchbase.client'
     module = 'java-client'
-    versions = "[2.7.6,)"
+    versions = "[2.7.6,2.7.8)"
+  }
+  pass {
+    group = 'com.couchbase.client'
+    module = 'java-client'
+    versions = "[2.7.9,)"
   }
   fail {
     group = 'com.couchbase.client'

--- a/dd-java-agent/instrumentation/jboss-classloading/src/test/groovy/JBossClassloadingTest.groovy
+++ b/dd-java-agent/instrumentation/jboss-classloading/src/test/groovy/JBossClassloadingTest.groovy
@@ -1,4 +1,5 @@
 import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.agent.tooling.Constants
 
 class JBossClassloadingTest extends AgentTestRunner {
   def "delegation property set on module load"() {
@@ -6,6 +7,6 @@ class JBossClassloadingTest extends AgentTestRunner {
     org.jboss.modules.Module.getName()
 
     expect:
-    System.getProperty("jboss.modules.system.pkgs") == "datadog.slf4j,datadog.trace.api,datadog.trace.bootstrap,datadog.trace.context,io.opentracing"
+    assert Arrays.asList(System.getProperty("jboss.modules.system.pkgs").split(",")).containsAll(Constants.BOOTSTRAP_PACKAGE_PREFIXES)
   }
 }

--- a/dd-java-agent/instrumentation/osgi-classloading/src/test/groovy/OSGIClassloadingTest.groovy
+++ b/dd-java-agent/instrumentation/osgi-classloading/src/test/groovy/OSGIClassloadingTest.groovy
@@ -3,7 +3,6 @@ import org.eclipse.osgi.launch.EquinoxFactory
 import org.junit.Rule
 import org.junit.contrib.java.lang.system.RestoreSystemProperties
 import org.osgi.framework.launch.Framework
-import org.osgi.framework.launch.FrameworkFactory
 
 class OSGIClassloadingTest extends AgentTestRunner {
 
@@ -15,7 +14,7 @@ class OSGIClassloadingTest extends AgentTestRunner {
     org.osgi.framework.Bundle.getName()
 
     then:
-    System.getProperty("org.osgi.framework.bootdelegation") == "datadog.slf4j.*,datadog.slf4j,datadog.trace.api.*,datadog.trace.api,datadog.trace.bootstrap.*,datadog.trace.bootstrap,datadog.trace.context.*,datadog.trace.context,io.opentracing.*,io.opentracing"
+    System.getProperty("org.osgi.framework.bootdelegation") == "datadog.slf4j.*,datadog.slf4j,datadog.trace.agent.TracingAgent.*,datadog.trace.agent.TracingAgent,datadog.trace.api.*,datadog.trace.api,datadog.trace.bootstrap.*,datadog.trace.bootstrap,datadog.trace.context.*,datadog.trace.context,io.opentracing.*,io.opentracing"
   }
 
   def "test OSGi framework factory"() {

--- a/dd-java-agent/src/main/java/datadog/trace/agent/TracingAgent.java
+++ b/dd-java-agent/src/main/java/datadog/trace/agent/TracingAgent.java
@@ -53,20 +53,26 @@ public class TracingAgent {
       final Method registerCallbackMethod =
           agentInstallerClass.getMethod("registerClassLoadCallback", String.class, Runnable.class);
       registerCallbackMethod.invoke(
-          null,
-          "java.util.logging.LogManager",
-          new Runnable() {
-            @Override
-            public void run() {
-              try {
-                startJmxFetch(inst);
-              } catch (final Exception e) {
-                throw new RuntimeException(e);
-              }
-            }
-          });
+          null, "java.util.logging.LogManager", new LoggingCallback(inst));
     } else {
       startJmxFetch(inst);
+    }
+  }
+
+  protected static class LoggingCallback implements Runnable {
+    private final Instrumentation inst;
+
+    public LoggingCallback(final Instrumentation inst) {
+      this.inst = inst;
+    }
+
+    @Override
+    public void run() {
+      try {
+        startJmxFetch(inst);
+      } catch (final Exception e) {
+        throw new RuntimeException(e);
+      }
     }
   }
 

--- a/dd-java-agent/src/main/java/datadog/trace/agent/TracingAgent.java
+++ b/dd-java-agent/src/main/java/datadog/trace/agent/TracingAgent.java
@@ -44,12 +44,10 @@ public class TracingAgent {
       throws Exception {
     configureLogger();
 
-    final boolean usingCustomLogManager = isAppUsingCustomLogManager();
-
-    final URL bootstrapURL = installBootstrapJar(inst, usingCustomLogManager);
+    final URL bootstrapURL = installBootstrapJar(inst);
 
     startDatadogAgent(inst, bootstrapURL);
-    if (usingCustomLogManager) {
+    if (isAppUsingCustomLogManager()) {
       System.out.println("Custom logger detected. Delaying JMXFetch initialization.");
       /*
        * java.util.logging.LogManager maintains a final static LogManager, which is created during class initialization.
@@ -155,8 +153,7 @@ public class TracingAgent {
     }
   }
 
-  private static synchronized URL installBootstrapJar(
-      final Instrumentation inst, final boolean usingCustomLogManager)
+  private static synchronized URL installBootstrapJar(final Instrumentation inst)
       throws IOException, URISyntaxException {
     URL bootstrapURL = null;
 
@@ -180,13 +177,7 @@ public class TracingAgent {
     // - On IBM-based JDKs since at least 1.7
     // This prevents custom log managers from working correctly
     // Use reflection to bypass the loading of the class
-    final List<String> arguments;
-    if (usingCustomLogManager) {
-      System.out.println("Custom log manager detected: getting vm args through reflection");
-      arguments = getVMArgumentsThroughReflection();
-    } else {
-      arguments = ManagementFactory.getRuntimeMXBean().getInputArguments();
-    }
+    final List<String> arguments = getVMArgumentsThroughReflection();
 
     String agentArgument = null;
     for (final String arg : arguments) {

--- a/dd-java-agent/src/main/java/datadog/trace/agent/TracingAgent.java
+++ b/dd-java-agent/src/main/java/datadog/trace/agent/TracingAgent.java
@@ -3,6 +3,7 @@ package datadog.trace.agent;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
@@ -11,6 +12,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.jar.JarFile;
 
 /** Entry point for initializing the agent. */
@@ -317,26 +319,19 @@ public class TracingAgent {
    *
    * @return Agent version
    */
-  public static String getAgentVersion() throws Exception {
-    BufferedReader output = null;
-    InputStreamReader input = null;
+  public static String getAgentVersion() throws IOException {
     final StringBuilder sb = new StringBuilder();
-    try {
-      input =
-          new InputStreamReader(
-              TracingAgent.class.getResourceAsStream("/dd-java-agent.version"), "UTF-8");
-      output = new BufferedReader(input);
-      for (int c = output.read(); c != -1; c = output.read()) {
+    try (final BufferedReader reader =
+        new BufferedReader(
+            new InputStreamReader(
+                TracingAgent.class.getResourceAsStream("/dd-java-agent.version"),
+                StandardCharsets.UTF_8))) {
+
+      for (int c = reader.read(); c != -1; c = reader.read()) {
         sb.append((char) c);
       }
-    } finally {
-      if (null != input) {
-        input.close();
-      }
-      if (null != output) {
-        output.close();
-      }
     }
+
     return sb.toString().trim();
   }
 }

--- a/dd-java-agent/src/main/java/datadog/trace/agent/TracingAgent.java
+++ b/dd-java-agent/src/main/java/datadog/trace/agent/TracingAgent.java
@@ -5,20 +5,14 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.lang.instrument.Instrumentation;
-import java.lang.management.ManagementFactory;
 import java.lang.reflect.Constructor;
-import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.List;
+import java.security.CodeSource;
 import java.util.jar.JarFile;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /** Entry point for initializing the agent. */
 public class TracingAgent {
@@ -157,86 +151,33 @@ public class TracingAgent {
 
   private static synchronized URL installBootstrapJar(
       final Instrumentation inst, final boolean usingCustomLogManager)
-      throws IOException, URISyntaxException {
+      throws IOException, URISyntaxException, ClassNotFoundException {
     URL bootstrapURL = null;
-    final List<String> arguments;
+    File bootstrapFile = null;
 
-    // ManagementFactory indirectly references java.util.logging.LogManager
-    // - On Oracle-based JDKs after 1.8
-    // - On IBM-based JDKs since at least 1.7
-    // This prevents custom log managers from working correctly
-    // Use reflection to bypass the loading of the class
-    if (usingCustomLogManager) {
-      System.out.println("Custom log manager detected: getting vm args through reflection");
-      arguments = getVMArgumentsThroughReflection();
-    } else {
-      arguments = ManagementFactory.getRuntimeMXBean().getInputArguments();
+    final CodeSource codeSource = TracingAgent.class.getProtectionDomain().getCodeSource();
+    if (codeSource != null) {
+      bootstrapURL = codeSource.getLocation();
+
+      bootstrapFile = new File(bootstrapURL.toURI());
     }
 
-    for (final String arg : arguments) {
-      if (arg.startsWith("-javaagent")) {
-        // argument is of the form -javaagent:/path/to/dd-java-agent.jar=optionalargumentstring
-        final Matcher matcher = Pattern.compile("-javaagent:([^=]+).*").matcher(arg);
+    if (bootstrapFile == null || bootstrapFile.isDirectory()) {
+      // At most one of ( DatadogClassLoader.class , TracingAgent.class ) has a CodeSource that
+      // doesn't lead to the agent jar
 
-        if (!matcher.matches()) {
-          throw new RuntimeException("Unable to parse javaagent parameter: " + arg);
-        }
+      bootstrapURL =
+          ClassLoader.getSystemClassLoader()
+              .loadClass("datadog.trace.bootstrap.DatadogClassLoader")
+              .getProtectionDomain()
+              .getCodeSource()
+              .getLocation();
 
-        try {
-          bootstrapURL = new URL("file:" + matcher.group(1));
-
-        } catch (final MalformedURLException e) {
-          throw new RuntimeException("Malformed javaagent parameter: " + arg);
-        }
-      }
+      bootstrapFile = new File(bootstrapURL.toURI());
     }
 
-    if (bootstrapURL != null) {
-      inst.appendToBootstrapClassLoaderSearch(new JarFile(new File(bootstrapURL.toURI())));
-      return bootstrapURL;
-    } else {
-      throw new RuntimeException(
-          "Unable to install bootstrap jar.  -javaagent parameter not parsable");
-    }
-  }
-
-  private static List<String> getVMArgumentsThroughReflection() {
-    try {
-      // Try Oracle-based
-      final Class managementFactoryHelperClass =
-          TracingAgent.class.getClassLoader().loadClass("sun.management.ManagementFactoryHelper");
-
-      final Class vmManagementClass =
-          TracingAgent.class.getClassLoader().loadClass("sun.management.VMManagement");
-
-      Object vmManagement;
-
-      try {
-        vmManagement =
-            managementFactoryHelperClass.getDeclaredMethod("getVMManagement").invoke(null);
-      } catch (final NoSuchMethodException e) {
-        // Older vm before getVMManagement() existed
-        final Field field = managementFactoryHelperClass.getDeclaredField("jvm");
-        field.setAccessible(true);
-        vmManagement = field.get(null);
-        field.setAccessible(false);
-      }
-
-      return (List<String>) vmManagementClass.getMethod("getVmArguments").invoke(vmManagement);
-
-    } catch (final ReflectiveOperationException e) {
-      try { // Try IBM-based.
-        final Class VMClass = TracingAgent.class.getClassLoader().loadClass("com.ibm.oti.vm.VM");
-        final String[] argArray = (String[]) VMClass.getMethod("getVMArgs").invoke(null);
-        return Arrays.asList(argArray);
-      } catch (final ReflectiveOperationException e1) {
-        // Fallback to default
-        System.out.println(
-            "WARNING: Unable to get VM args through reflection.  A custom java.util.logging.LogManager may not work correctly");
-
-        return ManagementFactory.getRuntimeMXBean().getInputArguments();
-      }
-    }
+    inst.appendToBootstrapClassLoaderSearch(new JarFile(bootstrapFile));
+    return bootstrapURL;
   }
 
   /**

--- a/dd-java-agent/src/test/groovy/datadog/trace/agent/AgentLoadedIntoBootstrapTest.groovy
+++ b/dd-java-agent/src/test/groovy/datadog/trace/agent/AgentLoadedIntoBootstrapTest.groovy
@@ -5,8 +5,7 @@ import jvmbootstraptest.AgentLoadedChecker
 import spock.lang.Specification
 
 class AgentLoadedIntoBootstrapTest extends Specification {
-
-
+  
   def "Agent loads in when separate jvm is launched"() {
     expect:
     IntegrationTestUtils.runOnSeparateJvm(AgentLoadedChecker.getName()

--- a/dd-java-agent/src/test/groovy/datadog/trace/agent/AgentLoadedIntoBootstrapTest.groovy
+++ b/dd-java-agent/src/test/groovy/datadog/trace/agent/AgentLoadedIntoBootstrapTest.groovy
@@ -1,0 +1,34 @@
+package datadog.trace.agent
+
+import datadog.trace.agent.test.IntegrationTestUtils
+import jvmbootstraptest.AgentLoadedChecker
+import spock.lang.Shared
+import spock.lang.Specification
+
+import java.lang.management.ManagementFactory
+import java.lang.management.RuntimeMXBean
+
+class AgentLoadedIntoBootstrapTest extends Specification {
+  @Shared
+  private agentArg
+
+  def setupSpec() {
+    final RuntimeMXBean runtimeMxBean = ManagementFactory.getRuntimeMXBean()
+    for (String arg : runtimeMxBean.getInputArguments()) {
+      if (arg.startsWith("-javaagent")) {
+        agentArg = arg
+        break
+      }
+    }
+    assert agentArg != null
+  }
+
+  def "Agent loads in when separate jvm is launched"() {
+    expect:
+    IntegrationTestUtils.runOnSeparateJvm(AgentLoadedChecker.getName()
+      , [agentArg] as String[]
+      , "" as String[]
+      , [:]
+      , true) == 0
+  }
+}

--- a/dd-java-agent/src/test/groovy/datadog/trace/agent/AgentLoadedIntoBootstrapTest.groovy
+++ b/dd-java-agent/src/test/groovy/datadog/trace/agent/AgentLoadedIntoBootstrapTest.groovy
@@ -2,31 +2,15 @@ package datadog.trace.agent
 
 import datadog.trace.agent.test.IntegrationTestUtils
 import jvmbootstraptest.AgentLoadedChecker
-import spock.lang.Shared
 import spock.lang.Specification
 
-import java.lang.management.ManagementFactory
-import java.lang.management.RuntimeMXBean
-
 class AgentLoadedIntoBootstrapTest extends Specification {
-  @Shared
-  private agentArg
 
-  def setupSpec() {
-    final RuntimeMXBean runtimeMxBean = ManagementFactory.getRuntimeMXBean()
-    for (String arg : runtimeMxBean.getInputArguments()) {
-      if (arg.startsWith("-javaagent")) {
-        agentArg = arg
-        break
-      }
-    }
-    assert agentArg != null
-  }
 
   def "Agent loads in when separate jvm is launched"() {
     expect:
     IntegrationTestUtils.runOnSeparateJvm(AgentLoadedChecker.getName()
-      , [agentArg] as String[]
+      , "" as String[]
       , "" as String[]
       , [:]
       , true) == 0

--- a/dd-java-agent/src/test/groovy/datadog/trace/agent/CustomLogManagerTest.groovy
+++ b/dd-java-agent/src/test/groovy/datadog/trace/agent/CustomLogManagerTest.groovy
@@ -4,12 +4,8 @@ import datadog.trace.agent.test.IntegrationTestUtils
 import jvmbootstraptest.LogManagerSetter
 import spock.lang.Requires
 import spock.lang.Retry
-import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Timeout
-
-import java.lang.management.ManagementFactory
-import java.lang.management.RuntimeMXBean
 
 // Note: this test is fails on IBM JVM, we would need to investigate this at some point
 @Requires({ !System.getProperty("java.vm.name").contains("IBM J9 VM") })
@@ -17,25 +13,10 @@ import java.lang.management.RuntimeMXBean
 @Timeout(30)
 class CustomLogManagerTest extends Specification {
   // Run all tests using forked jvm because groovy has already set the global log manager
-
-  @Shared
-  private agentArg
-
-  def setupSpec() {
-    final RuntimeMXBean runtimeMxBean = ManagementFactory.getRuntimeMXBean()
-    for (String arg : runtimeMxBean.getInputArguments()) {
-      if (arg.startsWith("-javaagent")) {
-        agentArg = arg
-        break
-      }
-    }
-    assert agentArg != null
-  }
-
   def "jmxfetch starts up in premain with no custom log manager set"() {
     expect:
     IntegrationTestUtils.runOnSeparateJvm(LogManagerSetter.getName()
-      , [agentArg, "-Ddd.jmxfetch.enabled=true", "-Ddd.jmxfetch.refresh-beans-period=1", "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=off"] as String[]
+      , ["-Ddd.jmxfetch.enabled=true", "-Ddd.jmxfetch.refresh-beans-period=1", "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=off"] as String[]
       , "" as String[]
       , [:]
       , true) == 0
@@ -44,7 +25,7 @@ class CustomLogManagerTest extends Specification {
   def "jmxfetch starts up in premain if configured log manager on system classpath"() {
     expect:
     IntegrationTestUtils.runOnSeparateJvm(LogManagerSetter.getName()
-      , [agentArg, "-Ddd.jmxfetch.enabled=true", "-Ddd.jmxfetch.refresh-beans-period=1", "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=off", "-Djava.util.logging.manager=jvmbootstraptest.CustomLogManager"] as String[]
+      , ["-Ddd.jmxfetch.enabled=true", "-Ddd.jmxfetch.refresh-beans-period=1", "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=off", "-Djava.util.logging.manager=jvmbootstraptest.CustomLogManager"] as String[]
       , "" as String[]
       , [:]
       , true) == 0
@@ -53,7 +34,7 @@ class CustomLogManagerTest extends Specification {
   def "jmxfetch startup is delayed with java.util.logging.manager sysprop"() {
     expect:
     IntegrationTestUtils.runOnSeparateJvm(LogManagerSetter.getName()
-      , [agentArg, "-Ddd.jmxfetch.enabled=true", "-Ddd.jmxfetch.refresh-beans-period=1", "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=off", "-Djava.util.logging.manager=jvmbootstraptest.MissingLogManager"] as String[]
+      , ["-Ddd.jmxfetch.enabled=true", "-Ddd.jmxfetch.refresh-beans-period=1", "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=off", "-Djava.util.logging.manager=jvmbootstraptest.MissingLogManager"] as String[]
       , "" as String[]
       , [:]
       , true) == 0
@@ -62,7 +43,7 @@ class CustomLogManagerTest extends Specification {
   def "jmxfetch startup delayed with tracer custom log manager setting"() {
     expect:
     IntegrationTestUtils.runOnSeparateJvm(LogManagerSetter.getName()
-      , [agentArg, "-Ddd.jmxfetch.enabled=true", "-Ddd.jmxfetch.refresh-beans-period=1", "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=off", "-Ddd.app.customlogmanager=true"] as String[]
+      , ["-Ddd.jmxfetch.enabled=true", "-Ddd.jmxfetch.refresh-beans-period=1", "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=off", "-Ddd.app.customlogmanager=true"] as String[]
       , "" as String[]
       , [:]
       , true) == 0
@@ -71,7 +52,7 @@ class CustomLogManagerTest extends Specification {
   def "jmxfetch startup delayed with JBOSS_HOME environment variable"() {
     expect:
     IntegrationTestUtils.runOnSeparateJvm(LogManagerSetter.getName()
-      , [agentArg, "-Ddd.jmxfetch.enabled=true", "-Ddd.jmxfetch.refresh-beans-period=1", "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=off", "-Ddd.app.customlogmanager=true"] as String[]
+      , ["-Ddd.jmxfetch.enabled=true", "-Ddd.jmxfetch.refresh-beans-period=1", "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=off", "-Ddd.app.customlogmanager=true"] as String[]
       , "" as String[]
       , ["JBOSS_HOME": "/"]
       , true) == 0
@@ -80,7 +61,7 @@ class CustomLogManagerTest extends Specification {
   def "jmxfetch startup in premain forced by customlogmanager=false"() {
     expect:
     IntegrationTestUtils.runOnSeparateJvm(LogManagerSetter.getName()
-      , [agentArg, "-Ddd.jmxfetch.enabled=true", "-Ddd.jmxfetch.refresh-beans-period=1", "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=off", "-Ddd.app.customlogmanager=false", "-Djava.util.logging.manager=jvmbootstraptest.CustomLogManager"] as String[]
+      , ["-Ddd.jmxfetch.enabled=true", "-Ddd.jmxfetch.refresh-beans-period=1", "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=off", "-Ddd.app.customlogmanager=false", "-Djava.util.logging.manager=jvmbootstraptest.CustomLogManager"] as String[]
       , "" as String[]
       , ["JBOSS_HOME": "/"]
       , true) == 0

--- a/dd-java-agent/src/test/groovy/datadog/trace/agent/integration/classloading/ShadowPackageRenamingTest.groovy
+++ b/dd-java-agent/src/test/groovy/datadog/trace/agent/integration/classloading/ShadowPackageRenamingTest.groovy
@@ -14,23 +14,23 @@ class ShadowPackageRenamingTest extends Specification {
     final Class<?> ddClass =
       IntegrationTestUtils.getAgentClassLoader()
         .loadClass("datadog.trace.agent.tooling.AgentInstaller")
-    final String userGuava =
-      MapMaker.getProtectionDomain().getCodeSource().getLocation().getFile()
-    final String agentGuavaDep =
+    final URL userGuava =
+      MapMaker.getProtectionDomain().getCodeSource().getLocation()
+    final URL agentGuavaDep =
       ddClass
         .getClassLoader()
         .loadClass("com.google.common.collect.MapMaker")
         .getProtectionDomain()
         .getCodeSource()
         .getLocation()
-        .getFile()
-    final String agentSource =
-      ddClass.getProtectionDomain().getCodeSource().getLocation().getFile()
+    final URL agentSource =
+      ddClass.getProtectionDomain().getCodeSource().getLocation()
 
     expect:
-    agentSource.matches(".*/agent-tooling-and-instrumentation[^/]*.jar")
+    agentSource.getFile() == "/"
+    agentSource.getProtocol() == "x-internal-jar"
     agentSource == agentGuavaDep
-    agentSource != userGuava
+    agentSource.getFile() != userGuava.getFile()
   }
 
   def "java getLogger rewritten to safe logger"() {

--- a/dd-java-agent/src/test/java/datadog/trace/agent/test/IntegrationTestUtils.java
+++ b/dd-java-agent/src/test/java/datadog/trace/agent/test/IntegrationTestUtils.java
@@ -190,16 +190,29 @@ public class IntegrationTestUtils {
       final Map<String, String> envVars,
       final boolean printOutputStreams)
       throws Exception {
+
     final String separator = System.getProperty("file.separator");
-    final String classpath = System.getProperty("java.class.path");
+    final String agentJar = System.getProperty("agent.jar.to.forward");
+
+    if (agentJar == null) {
+      throw new RuntimeException("agent.jar.to.forward property must be set");
+    }
+
+    final String classpath =
+        agentJar + System.getProperty("path.separator") + System.getProperty("java.class.path");
     final String path = System.getProperty("java.home") + separator + "bin" + separator + "java";
+
+    final List<String> vmArgsList = new ArrayList<>(Arrays.asList(jvmArgs));
+    vmArgsList.add("-javaagent:" + agentJar);
+
     final List<String> commands = new ArrayList<>();
     commands.add(path);
-    commands.addAll(Arrays.asList(jvmArgs));
+    commands.addAll(vmArgsList);
     commands.add("-cp");
     commands.add(classpath);
     commands.add(mainClassName);
     commands.addAll(Arrays.asList(mainMethodArgs));
+
     final ProcessBuilder processBuilder = new ProcessBuilder(commands.toArray(new String[0]));
     processBuilder.environment().putAll(envVars);
     final Process process = processBuilder.start();

--- a/dd-java-agent/src/test/java/jvmbootstraptest/AgentLoadedChecker.java
+++ b/dd-java-agent/src/test/java/jvmbootstraptest/AgentLoadedChecker.java
@@ -1,0 +1,21 @@
+package jvmbootstraptest;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Arrays;
+
+public class AgentLoadedChecker {
+  public static void main(final String[] args) throws ClassNotFoundException {
+    System.out.println(Arrays.toString(args));
+
+    // Empty classloader that delegates to bootstrap
+    final URLClassLoader emptyClassLoader = new URLClassLoader(new URL[] {}, null);
+    final Class agentClass = emptyClassLoader.loadClass("datadog.trace.agent.TracingAgent");
+
+    if (agentClass.getClassLoader() != null) {
+      throw new RuntimeException(
+          "TracingAgent loaded into classloader other than bootstrap: "
+              + agentClass.getClassLoader());
+    }
+  }
+}

--- a/dd-java-agent/src/test/java/jvmbootstraptest/AgentLoadedChecker.java
+++ b/dd-java-agent/src/test/java/jvmbootstraptest/AgentLoadedChecker.java
@@ -2,12 +2,9 @@ package jvmbootstraptest;
 
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.util.Arrays;
 
 public class AgentLoadedChecker {
   public static void main(final String[] args) throws ClassNotFoundException {
-    System.out.println(Arrays.toString(args));
-
     // Empty classloader that delegates to bootstrap
     final URLClassLoader emptyClassLoader = new URLClassLoader(new URL[] {}, null);
     final Class agentClass = emptyClassLoader.loadClass("datadog.trace.agent.TracingAgent");

--- a/dd-java-agent/src/test/java/jvmbootstraptest/LogManagerSetter.java
+++ b/dd-java-agent/src/test/java/jvmbootstraptest/LogManagerSetter.java
@@ -43,6 +43,11 @@ public class LogManagerSetter {
             "jmxfetch should start in premain when custom log manager found on classpath.");
       }
     } else if (System.getenv("JBOSS_HOME") != null) {
+      customAssert(
+          isJmxfetchStarted(),
+          false,
+          "jmxfetch startup must be delayed when JBOSS_HOME property is present.");
+
       System.setProperty("java.util.logging.manager", CustomLogManager.class.getName());
       customAssert(
           LogManager.getLogManager().getClass(),
@@ -50,7 +55,8 @@ public class LogManagerSetter {
               .getClassLoader()
               .loadClass(System.getProperty("java.util.logging.manager")),
           "Javaagent should not prevent setting a custom log manager");
-
+      customAssert(
+          isJmxfetchStarted(), true, "jmxfetch should start after loading with JBOSS_HOME SET.");
     } else {
       customAssert(
           isJmxfetchStarted(),

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/SpockRunner.java
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/SpockRunner.java
@@ -32,6 +32,7 @@ public class SpockRunner extends Sputnik {
    */
   public static final String[] BOOTSTRAP_PACKAGE_PREFIXES_COPY = {
     "datadog.slf4j",
+    "datadog.trace.agent.TracingAgent",
     "datadog.trace.api",
     "datadog.trace.bootstrap",
     "datadog.trace.context",


### PR DESCRIPTION
This pull request removes the need for some temporary jars by doing the following:

* Modifying `DatadogClassloader` to directly load from an internal jar without extracting the internal jar
* Combining `agent-bootstrap` with the main `dd-java-agent` jar at compile time and appending the combo to the bootstrap classpath at runtime

This helps with #429.  However, ByteBuddy still creates temp jars for dynamic injection