### PR TITLE
ByteBuddy TypeDefinition cache optimization

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/WeakMap.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/WeakMap.java
@@ -1,6 +1,7 @@
 package datadog.trace.bootstrap;
 
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.WeakHashMap;
 import java.util.concurrent.atomic.AtomicReference;
@@ -18,7 +19,10 @@ public interface WeakMap<K, V> {
 
   void putIfAbsent(K key, V value);
 
+
   V getOrCreate(K key, ValueSupplier<V> supplier);
+
+  Iterator<Map.Entry<K, V>> iterator();
 
   @Slf4j
   class Provider {
@@ -117,6 +121,11 @@ public interface WeakMap<K, V> {
       }
 
       return map.get(key);
+    }
+
+    @Override
+    public Iterator<Map.Entry<K, V>> iterator() {
+      return map.entrySet().iterator();
     }
 
     @Override

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/WeakMap.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/WeakMap.java
@@ -7,7 +7,7 @@ import java.util.WeakHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 import lombok.extern.slf4j.Slf4j;
 
-public interface WeakMap<K, V> {
+public interface WeakMap<K, V> extends Iterable<Map.Entry<K, V>> {
 
   int size();
 
@@ -20,8 +20,6 @@ public interface WeakMap<K, V> {
   void putIfAbsent(K key, V value);
 
   V getOrCreate(K key, ValueSupplier<V> supplier);
-
-  Iterator<Map.Entry<K, V>> iterator();
 
   @Slf4j
   class Provider {

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/WeakMap.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/WeakMap.java
@@ -19,7 +19,6 @@ public interface WeakMap<K, V> {
 
   void putIfAbsent(K key, V value);
 
-
   V getOrCreate(K key, ValueSupplier<V> supplier);
 
   Iterator<Map.Entry<K, V>> iterator();

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
@@ -36,7 +36,7 @@ public class AgentInstaller {
   }
 
   public static final DDLocationStrategy LOCATION_STRATEGY = new DDLocationStrategy();
-  public static final AgentBuilder.PoolStrategy POOL_STRATEGY = new DDCachingPoolStrategy();
+  public static final DDCachingPoolStrategy POOL_STRATEGY = new DDCachingPoolStrategy();
   private static volatile Instrumentation INSTRUMENTATION;
 
   public static Instrumentation getInstrumentation() {
@@ -152,7 +152,11 @@ public class AgentInstaller {
     }
     log.debug("Installed {} instrumenter(s)", numInstrumenters);
 
-    return agentBuilder.installOn(inst);
+    ResettableClassFileTransformer transformer = agentBuilder.installOn(inst);
+
+    POOL_STRATEGY.startCleanUpThread();
+
+    return transformer;
   }
 
   private static ElementMatcher.Junction<Object> matchesConfiguredExcludes() {

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/DDCachingPoolStrategy.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/DDCachingPoolStrategy.java
@@ -45,6 +45,7 @@ public class DDCachingPoolStrategy implements PoolStrategy {
             public Thread newThread(Runnable r) {
               Thread thread = new Thread(r);
               thread.setDaemon(true);
+              thread.setName("dd-cache-pool-cleaner");
               return thread;
             }
           });
@@ -76,11 +77,7 @@ public class DDCachingPoolStrategy implements PoolStrategy {
   }
 
   public void startCleanUpThread() {
-    cleaner.scheduleAtFixedRate(cleanupProcess, 0, 30, TimeUnit.SECONDS);
-  }
-
-  public void shutdownCleanUpThread() {
-    cleaner.shutdown();
+    cleaner.scheduleAtFixedRate(cleanupProcess, 0, 1, TimeUnit.MINUTES);
   }
 
   public void clear() {

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/DDCachingPoolStrategy.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/DDCachingPoolStrategy.java
@@ -5,10 +5,7 @@ import static net.bytebuddy.agent.builder.AgentBuilder.PoolStrategy;
 
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.RemovalListener;
-import com.google.common.cache.RemovalNotification;
 import datadog.trace.bootstrap.WeakMap;
-
 import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -16,7 +13,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-
 import lombok.extern.slf4j.Slf4j;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.dynamic.ClassFileLocator;
@@ -37,16 +33,18 @@ import net.bytebuddy.pool.TypePool;
  * <p>See eviction policy below.
  */
 public class DDCachingPoolStrategy implements PoolStrategy {
-  private static final WeakMap<ClassLoader, TypePool.CacheProvider> typePoolCache = WeakMap.Provider.newWeakMap();
+  private static final WeakMap<ClassLoader, TypePool.CacheProvider> typePoolCache =
+      WeakMap.Provider.newWeakMap();
 
   ScheduledExecutorService cleaner = Executors.newScheduledThreadPool(1);
 
-  Runnable cleanupProcess = new Runnable() {
-    @Override
-    public void run() {
-      clear();
-    }
-  };
+  Runnable cleanupProcess =
+      new Runnable() {
+        @Override
+        public void run() {
+          clear();
+        }
+      };
 
   @Override
   public TypePool typePool(final ClassFileLocator classFileLocator, final ClassLoader classLoader) {
@@ -76,7 +74,7 @@ public class DDCachingPoolStrategy implements PoolStrategy {
 
   public void clear() {
     Iterator<Map.Entry<ClassLoader, TypePool.CacheProvider>> iterator = typePoolCache.iterator();
-    while(iterator.hasNext()) {
+    while (iterator.hasNext()) {
       Map.Entry<ClassLoader, TypePool.CacheProvider> next = iterator.next();
       next.getValue().clear();
     }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/WeakMapSuppliers.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/WeakMapSuppliers.java
@@ -6,7 +6,9 @@ import com.google.common.collect.MapMaker;
 import datadog.trace.bootstrap.WeakMap;
 import java.lang.ref.WeakReference;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Queue;
+import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -187,6 +189,11 @@ class WeakMapSuppliers {
         }
 
         return map.get(key);
+      }
+
+      @Override
+      public Iterator<Map.Entry<K, V>> iterator() {
+        return map.iterator();
       }
     }
 

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/WeakMapSuppliers.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/WeakMapSuppliers.java
@@ -8,7 +8,6 @@ import java.lang.ref.WeakReference;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Queue;
-import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/DDCachingPoolStrategyTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/DDCachingPoolStrategyTest.groovy
@@ -1,0 +1,110 @@
+package datadog.trace.agent.tooling
+
+import com.google.common.io.ByteStreams
+import datadog.trace.agent.test.tooling.DummyService
+import lombok.extern.slf4j.Slf4j
+import net.bytebuddy.dynamic.ClassFileLocator
+import net.bytebuddy.pool.TypePool
+import spock.lang.Specification
+
+import java.util.concurrent.TimeUnit
+
+class DDCachingPoolStrategyTest extends Specification {
+
+  def classLoader = new URLClassLoader()
+  def classFileLocator = new DummyClassFileLocator()
+
+  def "aaa()"() {
+    setup:
+    def typePoolCacheProvider = new TypePool.CacheProvider() {
+
+      @Override
+      TypePool.Resolution find(String name) {
+        println "Find $name"
+        return null
+      }
+
+      @Override
+      TypePool.Resolution register(String name, TypePool.Resolution resolution) {
+        println "Register $name"
+        return null
+      }
+
+      @Override
+      void clear() {
+        println "Clear"
+      }
+    }
+
+    def typePool = new TypePool.Default.WithLazyResolution(
+      typePoolCacheProvider, classFileLocator, TypePool.Default.ReaderMode.FAST)
+
+    def described = typePool.describe(DummyService.name)
+    def luca = described.isResolved()
+    def aaa = described.resolve()
+  }
+
+//  def "with no cleanup thread cache is still expired()"() {
+//    setup:
+//    def poolStrategy = new DDCachingPoolStrategy(1, 1, TimeUnit.SECONDS)
+//
+//    when:
+//    def pool1 = poolStrategy.typePool(classFileLocator, classLoader)
+//    def resolutionInvocation1 = pool1.describe(DummyService.getName())
+//    resolutionInvocation1.resolve()
+////    resolutionInvocation1.declaredMethods
+////    def pool2 = poolStrategy.typePool(classFileLocator, classLoader)
+////    def resolutionInvocation2 = pool2.describe(DummyService.getName()).resolve()
+////    resolutionInvocation2.declaredMethods
+////    def a = new DummyService()
+//
+//    then:
+//    1 == 1
+////    resolutionInvocation1 == resolutionInvocation2
+//
+////    when:
+////    sleep(100)
+////    def poolBeforeExpire = poolStrategy.typePool(classFileLocator, classLoader)
+////    def resolutionInvocationBeforeExpire = poolBeforeExpire.describe(DummyService.getName()).resolve()
+////    resolutionInvocationBeforeExpire.declaredMethods
+////
+////    then:
+////    resolutionInvocation1 == resolutionInvocationBeforeExpire
+////
+////    when:
+////    sleep(1500)
+////    def poolAfterExpire = poolStrategy.typePool(classFileLocator, classLoader)
+////    def resolutionInvocationAfterExpire = poolAfterExpire.describe(DummyService.getName()).resolve()
+////    resolutionInvocationAfterExpire.declaredMethods
+////
+////    then:
+////    resolutionInvocation1 != resolutionInvocationAfterExpire
+//  }
+
+  class DummyClassFileLocator implements ClassFileLocator {
+
+    @Override
+    Resolution locate(String name) throws IOException {
+      return new DummyResolution()
+    }
+
+    @Override
+    void close() throws IOException {}
+  }
+
+  class DummyResolution implements ClassFileLocator.Resolution {
+
+    @Override
+    boolean isResolved() {
+      return false
+    }
+
+    @Override
+    byte[] resolve() {
+      String className = DummyService.name
+      String classAsPath = className.replace('.', '/') + ".class"
+      InputStream stream = DummyService.getClassLoader().getResourceAsStream(classAsPath)
+      return ByteStreams.toByteArray(stream)
+    }
+  }
+}

--- a/dd-java-agent/agent-tooling/src/test/java/datadog/trace/agent/test/tooling/DummyService.java
+++ b/dd-java-agent/agent-tooling/src/test/java/datadog/trace/agent/test/tooling/DummyService.java
@@ -1,0 +1,4 @@
+package datadog.trace.agent.test.tooling;
+
+public class DummyService {
+}

--- a/tooling/dd_jvm_stats.sh
+++ b/tooling/dd_jvm_stats.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+
+set -e
+
+OUTPUT_ROOT=$(pwd)
+
+# Thread dump interval defaults to 10 mins
+THREAD_DUMP_INTERVAL_SECS=600
+# Heap dump interval defaults to 30 mins
+HEAP_DUMP_INTERVAL_SECS=1800
+# GC usage interval defaults to 30 secs
+GC_INTERVAL_SECS=30
+# Runtime stats interval defaults to 10 secs
+RUNTIME_INTERVAL_SECS=10
+# Default runs continuously
+STOP_AFTER_SECS=0
+
+function usage {
+  echo "Usage: ./dd_jvm_stats --pid <PID> [--STOP_AFTER_SECS <SECS:0>] [--runtime-interval <SECS:10>] [--thread-interval <SECS:600>] [--heap-interval <SECS:1800>] [--gc-interval <SECS:30>] [--runtime-interval <SECS:10>] [--output <PATH:./>]"
+}
+
+while [[ "$1" != "" ]]; do
+    case $1 in
+        --pid )                 shift
+                                PROCESS_IDENTIFIER=$1
+                                ;;
+        --output )              shift
+                                OUTPUT_ROOT=$1
+                                ;;
+        --thread-interval )     shift
+                                THREAD_DUMP_INTERVAL_SECS=$1
+                                ;;
+        --heap-interval )       shift
+                                HEAP_DUMP_INTERVAL_SECS=$1
+                                ;;
+        --gc-interval )         shift
+                                GC_INTERVAL_SECS=$1
+                                ;;
+        --runtime-interval )    shift
+                                RUNTIME_INTERVAL_SECS=$1
+                                ;;
+        --stop-after )          shift
+                                STOP_AFTER_SECS=$1
+                                ;;
+        --help )                usage
+                                exit
+                                ;;
+        * )                     usage
+                                exit 1
+    esac
+    shift
+done
+
+# At least PID has to be provided
+if [[ -z "$PROCESS_IDENTIFIER" ]]
+then
+      usage
+      echo "Provide the correct process id:"
+      jcmd
+      exit 1
+fi
+
+HUMAN_READABLE_FORMAT='+%Y-%m-%d %H:%M:%S'
+FILESYSTEM_READABLE_FORMAT='+%Y%m%d_%H%M%S'
+OUTPUT_FOLDER="${OUTPUT_ROOT}/monitoring_session_started_$(date "$FILESYSTEM_READABLE_FORMAT")"
+THREAD_DUMP_FOLDER="$OUTPUT_FOLDER/thread_dumps"
+HEAP_DUMP_FOLDER="$OUTPUT_FOLDER/heap_dumps"
+GC_STATS_FILE="$OUTPUT_FOLDER/gc_stats.csv"
+RUNTIME_STATS_FILE="$OUTPUT_FOLDER/runtime_stats.csv"
+JVM_INFO_FILE="$OUTPUT_FOLDER/jvm_info.txt"
+
+# Preparing output folders
+echo "Data will be saved to $OUTPUT_FOLDER"
+mkdir -p ${OUTPUT_FOLDER}
+mkdir -p ${THREAD_DUMP_FOLDER}
+mkdir -p ${HEAP_DUMP_FOLDER}
+
+# Dumping JVM INFO
+echo "JVM version $(jcmd ${PROCESS_IDENTIFIER} VM.version)" > ${JVM_INFO_FILE}
+echo "" >> ${JVM_INFO_FILE}
+echo "JVM uptime $(jcmd ${PROCESS_IDENTIFIER} VM.uptime)" >> ${JVM_INFO_FILE}
+echo "" >> ${JVM_INFO_FILE}
+echo "JVM command line $(jcmd ${PROCESS_IDENTIFIER} VM.command_line)" >> ${JVM_INFO_FILE}
+echo "" >> ${JVM_INFO_FILE}
+
+# Initializing files
+echo "Date,CPU%,S0C,S1C,S0U,S1U,EC,EU,OC,OU,MC,MU,CCSC,CCSU,YGC,YGCT,FGC,FGCT,GCT" > ${RUNTIME_STATS_FILE}
+
+START=$(date +"%s")
+
+GC_LOGS_FILE=$(jcmd ${PROCESS_IDENTIFIER} VM.command_line | grep jvm_args | sed 's/^.*Xlog[:]*gc:\([^\s]*\) .*$/\1/')
+
+if [[ -z "$GC_LOGS_FILE" ]]; then
+  echo "GC logs file was not found, did you set jvm args for GC logs?: for JDK 9+ '-Xlog:gc:/path/to/gc.log', JDK 8 '-Xloggc:/path/to/gc.log -XX:+PrintGC -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps'"
+else
+  echo "Found GC logs file: $GC_LOGS_FILE"
+fi
+
+LAST_GC=0
+LAST_CPU=0
+LAST_RUNTIME=0
+LAST_HEAP=${START}
+LAST_THREAD=${START}
+
+function tick() {
+  NOW=$(date +"%s")
+  NOW_HUMAN=$(date "${HUMAN_READABLE_FORMAT}")
+  NOW_FILESYSTEM=$(date "${FILESYSTEM_READABLE_FORMAT}")
+
+  # We can set a stop after a number of seconds
+  if [[ "$STOP_AFTER_SECS" -gt "0" ]] && [[ "$NOW" -gt $(( $START + $STOP_AFTER_SECS )) ]]; then
+    echo "Maximum running time reached: job completed successfully."
+    exit 0
+  fi
+
+  # Runtime live
+  if [[ "$NOW" -ge $(( $LAST_RUNTIME + $RUNTIME_INTERVAL_SECS )) ]]; then
+    CPU_USAGE=$(ps -p ${PROCESS_IDENTIFIER} -o %cpu | grep '\.')
+    MEMORY_USAGE=$(jstat -gc ${PROCESS_IDENTIFIER} | grep '\.' | sed -E 's/ +/,/g')
+    echo "$NOW_HUMAN,$CPU_USAGE,$MEMORY_USAGE" >> ${RUNTIME_STATS_FILE}
+    LAST_RUNTIME=${NOW}
+  fi
+
+  # GC logs
+  if [[ "$NOW" -ge $(( $LAST_GC + $GC_INTERVAL_SECS )) ]] && [[ ! -z "$GC_LOGS_FILE" ]]; then
+    cp ${GC_LOGS_FILE} ${GC_STATS_FILE}
+    LAST_GC=${NOW}
+  fi
+
+  # Thread dump
+  if [[ "$NOW" -ge $(( $LAST_THREAD + $THREAD_DUMP_INTERVAL_SECS )) ]]; then
+    THREAD_FILE="${THREAD_DUMP_FOLDER}/thread-dump-${NOW_FILESYSTEM}"
+    jcmd ${PROCESS_IDENTIFIER} Thread.print > ${THREAD_FILE}
+    LAST_THREAD=${NOW}
+    echo "${NOW_HUMAN} - Thread dump saved to: $THREAD_FILE"
+  fi
+
+  # Heap dump
+  if [[ "$NOW" -ge $(( $LAST_HEAP + $HEAP_DUMP_INTERVAL_SECS )) ]]; then
+    HEAP_FILE="${HEAP_DUMP_FOLDER}/heap-dump-${NOW_FILESYSTEM}.hprof"
+    jcmd ${PROCESS_IDENTIFIER} GC.heap_dump ${HEAP_FILE}
+    LAST_HEAP=${NOW}
+    echo "${NOW_HUMAN} - Heap dump saved to: $HEAP_FILE"
+  fi
+}
+
+while sleep 1; do tick; done


### PR DESCRIPTION
This PR adds a scheduler to our cached pool strategy that really cleanup all the `TypeDefinition`s cache every 30 secs. The motivation for this is that the underlying google cache do not automatically (and deterministically) frees memory when items are expired. This typically happens (but is not guaranteed to) on writes. The point is that most of the write happens at the begin, so we had a high share of memory (especially on very optimized apps) that was held and not used.

We extensively tested the impact of this change and the only _con_ is a slightly sort peak of higher CPU usage at the very begin, then quickly fades out. 