### PR TITLE
Remove common (redundant) dependencies

### DIFF
--- a/dd-java-agent/instrumentation/apache-httpasyncclient-4/apache-httpasyncclient-4.gradle
+++ b/dd-java-agent/instrumentation/apache-httpasyncclient-4/apache-httpasyncclient-4.gradle
@@ -23,17 +23,8 @@ testSets {
 dependencies {
   compileOnly group: 'org.apache.httpcomponents', name: 'httpasyncclient', version: '4.0'
 
-
-  compile project(':dd-java-agent:agent-tooling')
-
-  compile deps.bytebuddy
-  compile deps.opentracing
-  annotationProcessor deps.autoservice
-  implementation deps.autoservice
-
-  testCompile project(':dd-java-agent:testing')
   testCompile project(':dd-java-agent:instrumentation:java-concurrent')
-  
+
   testCompile group: 'org.apache.httpcomponents', name: 'httpasyncclient', version: '4.0'
 
   latestDepTestCompile group: 'org.apache.httpcomponents', name: 'httpasyncclient', version: '+'

--- a/dd-java-agent/instrumentation/apache-httpclient-4/apache-httpclient-4.gradle
+++ b/dd-java-agent/instrumentation/apache-httpclient-4/apache-httpclient-4.gradle
@@ -31,14 +31,6 @@ testSets {
 dependencies {
   compileOnly group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.0'
 
-  compile project(':dd-java-agent:agent-tooling')
-
-  compile deps.bytebuddy
-  compile deps.opentracing
-  annotationProcessor deps.autoservice
-  implementation deps.autoservice
-
-  testCompile project(':dd-java-agent:testing')
   testCompile group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.0'
 
   latestDepTestCompile group: 'org.apache.httpcomponents', name: 'httpclient', version: '+'

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/aws-java-sdk-1.11.0.gradle
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/aws-java-sdk-1.11.0.gradle
@@ -37,14 +37,6 @@ testSets {
 dependencies {
   compileOnly group: 'com.amazonaws', name: 'aws-java-sdk-core', version: '1.11.0'
 
-  compile project(':dd-java-agent:agent-tooling')
-
-  compile deps.bytebuddy
-  compile deps.opentracing
-  annotationProcessor deps.autoservice
-  implementation deps.autoservice
-
-  testCompile project(':dd-java-agent:testing')
   // Include httpclient instrumentation for testing because it is a dependency for aws-sdk.
   testCompile project(':dd-java-agent:instrumentation:apache-httpclient-4')
   testCompile group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.11.106'

--- a/dd-java-agent/instrumentation/aws-java-sdk-2.2/aws-java-sdk-2.2.gradle
+++ b/dd-java-agent/instrumentation/aws-java-sdk-2.2/aws-java-sdk-2.2.gradle
@@ -41,10 +41,6 @@ dependencies {
   compileOnly sourceSets.main_java8.compileClasspath
   compile sourceSets.main_java8.output
 
-  annotationProcessor deps.autoservice
-  implementation deps.autoservice
-
-  testCompile project(':dd-java-agent:testing')
   // Include httpclient instrumentation for testing because it is a dependency for aws-sdk.
   testCompile project(':dd-java-agent:instrumentation:apache-httpclient-4')
   // Also include netty instrumentation because it is used by aws async client

--- a/dd-java-agent/instrumentation/couchbase-2.0/couchbase-2.0.gradle
+++ b/dd-java-agent/instrumentation/couchbase-2.0/couchbase-2.0.gradle
@@ -41,15 +41,6 @@ muzzle {
 dependencies {
   compileOnly group: 'com.couchbase.client', name: 'java-client', version: '2.0.0'
 
-  compile project(':dd-java-agent:agent-tooling')
-
-  compile deps.bytebuddy
-  compile deps.opentracing
-  annotationProcessor deps.autoservice
-  implementation deps.autoservice
-
-  testCompile project(':dd-java-agent:testing')
-
   testCompile group: 'com.couchbase.mock', name: 'CouchbaseMock', version: '1.5.19'
 
   testCompile group: 'org.springframework.data', name: 'spring-data-couchbase', version: '2.0.0.RELEASE'

--- a/dd-java-agent/instrumentation/datastax-cassandra-3/datastax-cassandra-3.gradle
+++ b/dd-java-agent/instrumentation/datastax-cassandra-3/datastax-cassandra-3.gradle
@@ -48,14 +48,6 @@ testSets {
 dependencies {
   compileOnly group: 'com.datastax.cassandra', name: 'cassandra-driver-core', version: '3.0.0'
 
-  compile project(':dd-java-agent:agent-tooling')
-
-  compile deps.bytebuddy
-  compile deps.opentracing
-  annotationProcessor deps.autoservice
-  implementation deps.autoservice
-
-  testCompile project(':dd-java-agent:testing')
   testCompile group: 'com.datastax.cassandra', name: 'cassandra-driver-core', version: '3.2.0'
   testCompile group: 'org.cassandraunit', name: 'cassandra-unit', version: '3.1.3.2'
 

--- a/dd-java-agent/instrumentation/dropwizard/dropwizard-views/dropwizard-views.gradle
+++ b/dd-java-agent/instrumentation/dropwizard/dropwizard-views/dropwizard-views.gradle
@@ -11,15 +11,6 @@ apply from: "${rootDir}/gradle/java.gradle"
 dependencies {
   compileOnly group: 'io.dropwizard', name: 'dropwizard-views', version: '0.7.0'
 
-  compile project(':dd-java-agent:agent-tooling')
-
-  compile deps.bytebuddy
-  compile deps.opentracing
-  annotationProcessor deps.autoservice
-  implementation deps.autoservice
-  
-  testCompile project(':dd-java-agent:testing')
-
   testCompile group: 'io.dropwizard', name: 'dropwizard-views-freemarker', version: '0.7.0'
   testCompile group: 'io.dropwizard', name: 'dropwizard-views-mustache', version: '0.7.0'
 }

--- a/dd-java-agent/instrumentation/elasticsearch/rest-5/rest-5.gradle
+++ b/dd-java-agent/instrumentation/elasticsearch/rest-5/rest-5.gradle
@@ -29,15 +29,8 @@ testSets {
 dependencies {
   compileOnly group: 'org.elasticsearch.client', name: 'rest', version: '5.0.0'
 
-  compile project(':dd-java-agent:agent-tooling')
   compile project(':dd-java-agent:instrumentation:elasticsearch')
 
-  compile deps.bytebuddy
-  compile deps.opentracing
-  annotationProcessor deps.autoservice
-  implementation deps.autoservice
-
-  testCompile project(':dd-java-agent:testing')
   testCompile project(':dd-java-agent:instrumentation:apache-httpclient-4')
   testCompile project(':dd-java-agent:instrumentation:apache-httpasyncclient-4')
 

--- a/dd-java-agent/instrumentation/elasticsearch/rest-6.4/rest-6.4.gradle
+++ b/dd-java-agent/instrumentation/elasticsearch/rest-6.4/rest-6.4.gradle
@@ -30,15 +30,8 @@ testSets {
 dependencies {
   compileOnly group: 'org.elasticsearch.client', name: 'elasticsearch-rest-client', version: '6.4.0'
 
-  compile project(':dd-java-agent:agent-tooling')
   compile project(':dd-java-agent:instrumentation:elasticsearch')
 
-  compile deps.bytebuddy
-  compile deps.opentracing
-  annotationProcessor deps.autoservice
-  implementation deps.autoservice
-
-  testCompile project(':dd-java-agent:testing')
   testCompile project(':dd-java-agent:instrumentation:apache-httpclient-4')
   testCompile project(':dd-java-agent:instrumentation:apache-httpasyncclient-4')
   // Netty is used, but it adds complexity to the tests since we're using embedded ES.

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/transport-2.gradle
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/transport-2.gradle
@@ -24,15 +24,8 @@ testSets {
 dependencies {
   compileOnly group: 'org.elasticsearch', name: 'elasticsearch', version: '2.0.0'
 
-  compile project(':dd-java-agent:agent-tooling')
   compile project(':dd-java-agent:instrumentation:elasticsearch')
 
-  compile deps.bytebuddy
-  compile deps.opentracing
-  annotationProcessor deps.autoservice
-  implementation deps.autoservice
-
-  testCompile project(':dd-java-agent:testing')
   // Ensure no cross interference
   testCompile project(':dd-java-agent:instrumentation:elasticsearch:rest-5')
   testCompile project(':dd-java-agent:instrumentation:elasticsearch:transport-5')

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5.3/transport-5.3.gradle
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5.3/transport-5.3.gradle
@@ -31,15 +31,8 @@ testSets {
 dependencies {
   compileOnly group: 'org.elasticsearch.client', name: 'transport', version: '5.3.0'
 
-  compile project(':dd-java-agent:agent-tooling')
   compile project(':dd-java-agent:instrumentation:elasticsearch')
 
-  compile deps.bytebuddy
-  compile deps.opentracing
-  annotationProcessor deps.autoservice
-  implementation deps.autoservice
-
-  testCompile project(':dd-java-agent:testing')
   testCompile project(':dd-java-agent:instrumentation:apache-httpasyncclient-4')
   testCompile project(':dd-java-agent:instrumentation:netty-4.1')
 

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5/transport-5.gradle
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5/transport-5.gradle
@@ -23,15 +23,8 @@ apply from: "${rootDir}/gradle/java.gradle"
 dependencies {
   compileOnly group: 'org.elasticsearch.client', name: 'transport', version: '5.0.0'
 
-  compile project(':dd-java-agent:agent-tooling')
   compile project(':dd-java-agent:instrumentation:elasticsearch')
 
-  compile deps.bytebuddy
-  compile deps.opentracing
-  annotationProcessor deps.autoservice
-  implementation deps.autoservice
-
-  testCompile project(':dd-java-agent:testing')
   // Ensure no cross interference
   testCompile project(':dd-java-agent:instrumentation:elasticsearch:rest-5')
   testCompile project(':dd-java-agent:instrumentation:apache-httpasyncclient-4')

--- a/dd-java-agent/instrumentation/elasticsearch/transport-6/transport-6.gradle
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-6/transport-6.gradle
@@ -31,15 +31,8 @@ testSets {
 dependencies {
   compileOnly group: 'org.elasticsearch.client', name: 'transport', version: '6.0.0'
 
-  compile project(':dd-java-agent:agent-tooling')
   compile project(':dd-java-agent:instrumentation:elasticsearch')
 
-  compile deps.bytebuddy
-  compile deps.opentracing
-  annotationProcessor deps.autoservice
-  implementation deps.autoservice
-
-  testCompile project(':dd-java-agent:testing')
   // Ensure no cross interference
   testCompile project(':dd-java-agent:instrumentation:elasticsearch:rest-5')
   testCompile project(':dd-java-agent:instrumentation:apache-httpasyncclient-4')

--- a/dd-java-agent/instrumentation/glassfish/glassfish.gradle
+++ b/dd-java-agent/instrumentation/glassfish/glassfish.gradle
@@ -21,13 +21,6 @@ dependencies {
 
   compile project(':dd-java-agent:agent-tooling')
 
-  compile deps.bytebuddy
-  compile deps.opentracing
-  compile deps.autoservice
-  annotationProcessor deps.autoservice
-  implementation deps.autoservice
-
-  testCompile project(':dd-java-agent:testing')
   testCompile group: 'org.glassfish.main.extras', name: 'glassfish-embedded-all', version: '4.1.2'
 
   latestDepTestCompile sourceSets.test.output

--- a/dd-java-agent/instrumentation/google-http-client/google-http-client.gradle
+++ b/dd-java-agent/instrumentation/google-http-client/google-http-client.gradle
@@ -20,14 +20,6 @@ testSets {
 dependencies {
   compileOnly group: 'com.google.http-client', name: 'google-http-client', version: '1.19.0'
 
-  compile project(':dd-java-agent:agent-tooling')
-
-  compile deps.bytebuddy
-  compile deps.opentracing
-  annotationProcessor deps.autoservice
-  implementation deps.autoservice
-
-  testCompile project(':dd-java-agent:testing')
   testCompile group: 'com.google.http-client', name: 'google-http-client', version: '1.19.0'
 
   latestDepTestCompile group: 'com.google.http-client', name: 'google-http-client', version: '+'

--- a/dd-java-agent/instrumentation/grpc-1.5/grpc-1.5.gradle
+++ b/dd-java-agent/instrumentation/grpc-1.5/grpc-1.5.gradle
@@ -44,16 +44,6 @@ testSets {
 dependencies {
   compileOnly group: 'io.grpc', name: 'grpc-core', version: grpcVersion
 
-  compile project(':dd-java-agent:agent-tooling')
-
-  compile deps.bytebuddy
-  compile deps.opentracing
-  compile deps.autoservice
-  annotationProcessor deps.autoservice
-  implementation deps.autoservice
-
-  testCompile project(':dd-java-agent:testing')
-
   testCompile group: 'io.grpc', name: 'grpc-netty', version: grpcVersion
   testCompile group: 'io.grpc', name: 'grpc-protobuf', version: grpcVersion
   testCompile group: 'io.grpc', name: 'grpc-stub', version: grpcVersion

--- a/dd-java-agent/instrumentation/hibernate/core-3.3/core-3.3.gradle
+++ b/dd-java-agent/instrumentation/hibernate/core-3.3/core-3.3.gradle
@@ -34,15 +34,8 @@ testSets {
 dependencies {
   compileOnly group: 'org.hibernate', name: 'hibernate-core', version: '3.3.0.GA'
 
-  compile project(':dd-java-agent:agent-tooling')
   compile project(':dd-java-agent:instrumentation:hibernate')
 
-  compile deps.bytebuddy
-  compile deps.opentracing
-  annotationProcessor deps.autoservice
-  implementation deps.autoservice
-
-  testCompile project(':dd-java-agent:testing')
   testCompile project(':dd-java-agent:instrumentation:jdbc')
   // Added to ensure cross compatibility:
   testCompile project(':dd-java-agent:instrumentation:hibernate:core-4.0')

--- a/dd-java-agent/instrumentation/hibernate/core-4.0/core-4.0.gradle
+++ b/dd-java-agent/instrumentation/hibernate/core-4.0/core-4.0.gradle
@@ -27,15 +27,8 @@ testSets {
 dependencies {
   compileOnly group: 'org.hibernate', name: 'hibernate-core', version: '4.0.0.Final'
 
-  compile project(':dd-java-agent:agent-tooling')
   compile project(':dd-java-agent:instrumentation:hibernate')
 
-  compile deps.bytebuddy
-  compile deps.opentracing
-  annotationProcessor deps.autoservice
-  implementation deps.autoservice
-
-  testCompile project(':dd-java-agent:testing')
   testCompile project(':dd-java-agent:instrumentation:jdbc')
   // Added to ensure cross compatibility:
   testCompile project(':dd-java-agent:instrumentation:hibernate:core-3.3')

--- a/dd-java-agent/instrumentation/hibernate/core-4.3/core-4.3.gradle
+++ b/dd-java-agent/instrumentation/hibernate/core-4.3/core-4.3.gradle
@@ -27,15 +27,8 @@ testSets {
 dependencies {
   compileOnly group: 'org.hibernate', name: 'hibernate-core', version: '4.3.0.Final'
 
-  compile project(':dd-java-agent:agent-tooling')
   compile project(':dd-java-agent:instrumentation:hibernate')
 
-  compile deps.bytebuddy
-  compile deps.opentracing
-  annotationProcessor deps.autoservice
-  implementation deps.autoservice
-
-  testCompile project(':dd-java-agent:testing')
   testCompile project(':dd-java-agent:instrumentation:jdbc')
   // Added to ensure cross compatibility:
   testCompile project(':dd-java-agent:instrumentation:hibernate:core-3.3')

--- a/dd-java-agent/instrumentation/hibernate/hibernate.gradle
+++ b/dd-java-agent/instrumentation/hibernate/hibernate.gradle
@@ -3,12 +3,3 @@
  */
 
 apply from: "${rootDir}/gradle/java.gradle"
-
-dependencies {
-  compile project(':dd-java-agent:agent-tooling')
-
-  compile deps.bytebuddy
-  compile deps.opentracing
-  annotationProcessor deps.autoservice
-  implementation deps.autoservice
-}

--- a/dd-java-agent/instrumentation/http-url-connection/http-url-connection.gradle
+++ b/dd-java-agent/instrumentation/http-url-connection/http-url-connection.gradle
@@ -7,13 +7,5 @@ project.ext {
 apply from: "${rootDir}/gradle/java.gradle"
 
 dependencies {
-  compile project(':dd-java-agent:agent-tooling')
-
-  compile deps.bytebuddy
-  compile deps.opentracing
-  annotationProcessor deps.autoservice
-  implementation deps.autoservice
-
-  testCompile project(':dd-java-agent:testing')
   testCompile group: 'org.springframework', name: 'spring-web', version: '4.3.7.RELEASE'
 }

--- a/dd-java-agent/instrumentation/hystrix-1.4/hystrix-1.4.gradle
+++ b/dd-java-agent/instrumentation/hystrix-1.4/hystrix-1.4.gradle
@@ -20,15 +20,6 @@ dependencies {
   compileOnly group: 'com.netflix.hystrix', name: 'hystrix-core', version: '1.4.0'
   compileOnly group: 'io.reactivex', name: 'rxjava', version: '1.0.7'
 
-  compile project(':dd-java-agent:agent-tooling')
-
-  compile deps.bytebuddy
-  compile deps.opentracing
-  compile deps.autoservice
-  annotationProcessor deps.autoservice
-  implementation deps.autoservice
-
-  testCompile project(':dd-java-agent:testing')
   testCompile project(':dd-java-agent:instrumentation:java-concurrent')
   testCompile project(':dd-java-agent:instrumentation:trace-annotation')
   testCompile group: 'io.reactivex', name: 'rxjava', version: '1.0.7'

--- a/dd-java-agent/instrumentation/instrumentation.gradle
+++ b/dd-java-agent/instrumentation/instrumentation.gradle
@@ -39,6 +39,7 @@ subprojects {Project subProj ->
 
     dependencies {
       // Apply common dependencies for instrumentation.
+      compile project(':dd-trace-api')
       compile project(':dd-java-agent:agent-tooling')
       compile deps.bytebuddy
       compile deps.opentracing

--- a/dd-java-agent/instrumentation/java-concurrent/java-concurrent.gradle
+++ b/dd-java-agent/instrumentation/java-concurrent/java-concurrent.gradle
@@ -25,15 +25,6 @@ dependencies {
   // This is needed for Akka ForJoinTask/Pool instrumentation
   compileOnly group: 'com.typesafe.akka', name: 'akka-actor_2.11', version: '2.5.0'
 
-  compile project(':dd-trace-api')
-  compile project(':dd-java-agent:agent-tooling')
-
-  compile deps.bytebuddy
-  compile deps.opentracing
-  annotationProcessor deps.autoservice
-  implementation deps.autoservice
-
-  testCompile project(':dd-java-agent:testing')
   testCompile project(':dd-java-agent:instrumentation:trace-annotation')
 
   slickTestCompile project(':dd-java-agent:testing')

--- a/dd-java-agent/instrumentation/jax-rs-annotations/jax-rs-annotations.gradle
+++ b/dd-java-agent/instrumentation/jax-rs-annotations/jax-rs-annotations.gradle
@@ -11,14 +11,6 @@ apply from: "${rootDir}/gradle/java.gradle"
 dependencies {
   compileOnly group: 'javax.ws.rs', name: 'jsr311-api', version: '1.1.1'
 
-  compile deps.bytebuddy
-  compile deps.opentracing
-  annotationProcessor deps.autoservice
-  implementation deps.autoservice
-
-  compile project(':dd-java-agent:agent-tooling')
-
-  testCompile project(':dd-java-agent:testing')
   testCompile group: 'com.sun.jersey', name: 'jersey-core', version: '1.19.4'
   testCompile group: 'com.sun.jersey', name: 'jersey-servlet', version: '1.19.4'
   testCompile group: 'io.dropwizard', name: 'dropwizard-testing', version: '0.7.1'

--- a/dd-java-agent/instrumentation/jax-rs-client-1.9/jax-rs-client-1.9.gradle
+++ b/dd-java-agent/instrumentation/jax-rs-client-1.9/jax-rs-client-1.9.gradle
@@ -25,15 +25,6 @@ testSets {
 dependencies {
   compileOnly group: 'com.sun.jersey', name: 'jersey-client', version: '1.9'
 
-  compile deps.bytebuddy
-  compile deps.opentracing
-  annotationProcessor deps.autoservice
-  implementation deps.autoservice
-
-  compile project(':dd-java-agent:agent-tooling')
-
-  testCompile project(':dd-java-agent:testing')
-
   testCompile group: 'com.sun.jersey', name: 'jersey-client', version: '1.9'
 
   latestDepTestCompile group: 'com.sun.jersey', name: 'jersey-client', version: '+'

--- a/dd-java-agent/instrumentation/jax-rs-client-2.0/connection-error-handling-jersey/connection-error-handling-jersey.gradle
+++ b/dd-java-agent/instrumentation/jax-rs-client-2.0/connection-error-handling-jersey/connection-error-handling-jersey.gradle
@@ -11,12 +11,5 @@ apply from: "${rootDir}/gradle/java.gradle"
 dependencies {
   compileOnly group: 'org.glassfish.jersey.core', name: 'jersey-client', version: '2.0'
 
-  compile deps.bytebuddy
-  compile deps.opentracing
-  annotationProcessor deps.autoservice
-  implementation deps.autoservice
-
-  compile project(':dd-java-agent:agent-tooling')
-
   compileOnly project(':dd-java-agent:instrumentation:jax-rs-client-2.0')
 }

--- a/dd-java-agent/instrumentation/jax-rs-client-2.0/connection-error-handling-resteasy/connection-error-handling-resteasy.gradle
+++ b/dd-java-agent/instrumentation/jax-rs-client-2.0/connection-error-handling-resteasy/connection-error-handling-resteasy.gradle
@@ -11,12 +11,5 @@ apply from: "${rootDir}/gradle/java.gradle"
 dependencies {
   compileOnly group: 'org.jboss.resteasy', name: 'resteasy-client', version: '3.0.0.Final'
 
-  compile deps.bytebuddy
-  compile deps.opentracing
-  annotationProcessor deps.autoservice
-  implementation deps.autoservice
-
-  compile project(':dd-java-agent:agent-tooling')
-
   compileOnly project(':dd-java-agent:instrumentation:jax-rs-client-2.0')
 }

--- a/dd-java-agent/instrumentation/jax-rs-client-2.0/jax-rs-client-2.0.gradle
+++ b/dd-java-agent/instrumentation/jax-rs-client-2.0/jax-rs-client-2.0.gradle
@@ -27,14 +27,6 @@ dependencies {
   compileOnly group: 'javax.ws.rs', name: 'javax.ws.rs-api', version: '2.0.1'
   compileOnly group: 'javax.annotation', name: 'javax.annotation-api', version: '1.2'
 
-  compile deps.bytebuddy
-  compile deps.opentracing
-  annotationProcessor deps.autoservice
-  implementation deps.autoservice
-
-  compile project(':dd-java-agent:agent-tooling')
-
-  testCompile project(':dd-java-agent:testing')
   testCompile project(':dd-java-agent:instrumentation:java-concurrent')
 
   testCompile project(':dd-java-agent:instrumentation:jax-rs-client-2.0:connection-error-handling-jersey')

--- a/dd-java-agent/instrumentation/jboss-classloading/jboss-classloading.gradle
+++ b/dd-java-agent/instrumentation/jboss-classloading/jboss-classloading.gradle
@@ -1,11 +1,5 @@
 apply from: "${rootDir}/gradle/java.gradle"
 
 dependencies {
-  compile project(':dd-java-agent:agent-tooling')
-  compile deps.bytebuddy
-  annotationProcessor deps.autoservice
-  implementation deps.autoservice
-
   testCompile group: 'org.jboss.modules', name: 'jboss-modules', version: '1.3.10.Final'
-  testCompile project(':dd-java-agent:testing')
 }

--- a/dd-java-agent/instrumentation/jdbc/jdbc.gradle
+++ b/dd-java-agent/instrumentation/jdbc/jdbc.gradle
@@ -15,14 +15,6 @@ testSets {
 }
 
 dependencies {
-  compile project(':dd-java-agent:agent-tooling')
-
-  compile deps.bytebuddy
-  compile deps.opentracing
-  annotationProcessor deps.autoservice
-  implementation deps.autoservice
-
-  testCompile project(':dd-java-agent:testing')
   // jdbc unit testing
   testCompile group: 'com.h2database', name: 'h2', version: '1.3.169' // first version jdk 1.6 compatible
   testCompile group: 'org.apache.derby', name: 'derby', version: '10.6.1.0'

--- a/dd-java-agent/instrumentation/jedis-1.4/jedis-1.4.gradle
+++ b/dd-java-agent/instrumentation/jedis-1.4/jedis-1.4.gradle
@@ -20,14 +20,6 @@ testSets {
 dependencies {
   compileOnly group: 'redis.clients', name: 'jedis', version: '1.4.0'
 
-  compile project(':dd-java-agent:agent-tooling')
-
-  compile deps.bytebuddy
-  compile deps.opentracing
-  annotationProcessor deps.autoservice
-  implementation deps.autoservice
-
-  testCompile project(':dd-java-agent:testing')
   testCompile group: 'com.github.kstyrc', name: 'embedded-redis', version: '0.6'
   testCompile group: 'redis.clients', name: 'jedis', version: '1.4.0'
 

--- a/dd-java-agent/instrumentation/jetty-8/jetty-8.gradle
+++ b/dd-java-agent/instrumentation/jetty-8/jetty-8.gradle
@@ -18,15 +18,9 @@ testSets {
 }
 
 dependencies {
-  compileOnly group: 'javax.servlet', name: 'javax.servlet-api', version: '3.0.1'
+  compileOnly group: 'org.eclipse.jetty', name: 'jetty-server', version: '8.0.0.v20110901'
 
-  compile project(':dd-java-agent:agent-tooling')
-
-  compile deps.bytebuddy
-  compile deps.opentracing
-  annotationProcessor deps.autoservice
-  implementation deps.autoservice
-
+  // Don't want to conflict with jetty from the test server.
   testCompile(project(':dd-java-agent:testing')) {
     exclude group: 'org.eclipse.jetty', module: 'jetty-server'
   }

--- a/dd-java-agent/instrumentation/jms/jms.gradle
+++ b/dd-java-agent/instrumentation/jms/jms.gradle
@@ -23,14 +23,6 @@ testSets {
 dependencies {
   compileOnly group: 'javax.jms', name: 'jms-api', version: '1.1-rev-1'
 
-  compile deps.bytebuddy
-  compile deps.opentracing
-  annotationProcessor deps.autoservice
-  implementation deps.autoservice
-
-  compile project(':dd-java-agent:agent-tooling')
-
-  testCompile project(':dd-java-agent:testing')
   testCompile group: 'org.apache.activemq.tooling', name: 'activemq-junit', version: '5.14.5'
   testCompile group: 'org.apache.activemq', name: 'activemq-pool', version: '5.14.5'
   testCompile group: 'org.apache.activemq', name: 'activemq-broker', version: '5.14.5'

--- a/dd-java-agent/instrumentation/jsp-2.3/jsp-2.3.gradle
+++ b/dd-java-agent/instrumentation/jsp-2.3/jsp-2.3.gradle
@@ -23,14 +23,6 @@ dependencies {
   compileOnly group: 'javax.servlet.jsp', name: 'javax.servlet.jsp-api', version: '2.3.0'
   compileOnly group: 'javax.servlet', name: 'javax.servlet-api', version: '3.1.0'
 
-  compile project(':dd-java-agent:agent-tooling')
-
-  compile deps.bytebuddy
-  compile deps.opentracing
-  annotationProcessor deps.autoservice
-  implementation deps.autoservice
-
-  testCompile project(':dd-java-agent:testing')
   testCompile project(':dd-java-agent:instrumentation:servlet-3')
   // using tomcat 7.0.37 because there seems to be some issues with Tomcat's jar scanning in versions < 7.0.37
   // https://stackoverflow.com/questions/23484098/org-apache-tomcat-util-bcel-classfile-classformatexception-invalid-byte-tag-in

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/kafka-clients-0.11.gradle
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/kafka-clients-0.11.gradle
@@ -20,14 +20,6 @@ testSets {
 dependencies {
   compileOnly group: 'org.apache.kafka', name: 'kafka-clients', version: '0.11.0.0'
 
-  compile project(':dd-java-agent:agent-tooling')
-
-  compile deps.bytebuddy
-  compile deps.opentracing
-  annotationProcessor deps.autoservice
-  implementation deps.autoservice
-
-  testCompile project(':dd-java-agent:testing')
   testCompile group: 'org.apache.kafka', name: 'kafka-clients', version: '0.11.0.0'
   testCompile group: 'org.springframework.kafka', name: 'spring-kafka', version: '1.3.3.RELEASE'
   testCompile group: 'org.springframework.kafka', name: 'spring-kafka-test', version: '1.3.3.RELEASE'

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/kafka-streams-0.11.gradle
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/kafka-streams-0.11.gradle
@@ -19,14 +19,6 @@ testSets {
 dependencies {
   compileOnly group: 'org.apache.kafka', name: 'kafka-streams', version: '0.11.0.0'
 
-  compile project(':dd-java-agent:agent-tooling')
-
-  compile deps.bytebuddy
-  compile deps.opentracing
-  annotationProcessor deps.autoservice
-  implementation deps.autoservice
-
-  testCompile project(':dd-java-agent:testing')
   // Include kafka-clients instrumentation for tests.
   testCompile project(':dd-java-agent:instrumentation:kafka-clients-0.11')
 

--- a/dd-java-agent/instrumentation/lettuce-5/lettuce-5.gradle
+++ b/dd-java-agent/instrumentation/lettuce-5/lettuce-5.gradle
@@ -48,15 +48,6 @@ dependencies {
 
   compileOnly group: 'io.lettuce', name: 'lettuce-core', version: '5.0.0.RELEASE'
 
-  compile project(':dd-java-agent:agent-tooling')
-
-  compile deps.bytebuddy
-  compile deps.opentracing
-  annotationProcessor deps.autoservice
-  implementation deps.autoservice
-
-  testCompile project(':dd-java-agent:testing')
-
   testCompile group: 'com.github.kstyrc', name: 'embedded-redis', version: '0.6'
   testCompile group: 'io.lettuce', name: 'lettuce-core', version: '5.0.0.RELEASE'
 

--- a/dd-java-agent/instrumentation/log4j1/log4j1.gradle
+++ b/dd-java-agent/instrumentation/log4j1/log4j1.gradle
@@ -23,15 +23,5 @@ configurations {
 }
 
 dependencies {
-  compile project(':dd-trace-api')
-  compile project(':dd-java-agent:agent-tooling')
-
   testCompile group: 'log4j', name: 'log4j', version: log4jVersion
-
-  compile deps.bytebuddy
-  compile deps.opentracing
-  annotationProcessor deps.autoservice
-  implementation deps.autoservice
-
-  testCompile project(':dd-java-agent:testing')
 }

--- a/dd-java-agent/instrumentation/log4j2/log4j2.gradle
+++ b/dd-java-agent/instrumentation/log4j2/log4j2.gradle
@@ -26,15 +26,6 @@ muzzle {
 }
 
 dependencies {
-  compile project(':dd-trace-api')
-  compile project(':dd-java-agent:agent-tooling')
-
-  compile deps.bytebuddy
-  compile deps.opentracing
-  annotationProcessor deps.autoservice
-  implementation deps.autoservice
-
-  testCompile project(':dd-java-agent:testing')
   testCompile group: 'org.apache.logging.log4j', name: 'log4j-core', version: log4jVersion
   testCompile group: 'org.apache.logging.log4j', name: 'log4j-api', version: log4jVersion
 }

--- a/dd-java-agent/instrumentation/mongo/driver-3.1/driver-3.1.gradle
+++ b/dd-java-agent/instrumentation/mongo/driver-3.1/driver-3.1.gradle
@@ -20,14 +20,6 @@ testSets {
 dependencies {
   compileOnly group: 'org.mongodb', name: 'mongo-java-driver', version: '3.1.0'
 
-  compile project(':dd-java-agent:agent-tooling')
-
-  compile deps.bytebuddy
-  compile deps.opentracing
-  annotationProcessor deps.autoservice
-  implementation deps.autoservice
-
-  testCompile project(':dd-java-agent:testing')
   testCompile project(':dd-java-agent:instrumentation:mongo').sourceSets.test.output
   testCompile group: 'de.flapdoodle.embed', name: 'de.flapdoodle.embed.mongo', version: '1.50.5'
 

--- a/dd-java-agent/instrumentation/mongo/driver-async-3.3/driver-async-3.3.gradle
+++ b/dd-java-agent/instrumentation/mongo/driver-async-3.3/driver-async-3.3.gradle
@@ -31,14 +31,6 @@ dependencies {
   }
   compileOnly group: 'org.mongodb', name: 'mongodb-driver-async', version: '3.3.0'
 
-  compile project(':dd-java-agent:agent-tooling')
-
-  compile deps.bytebuddy
-  compile deps.opentracing
-  annotationProcessor deps.autoservice
-  implementation deps.autoservice
-
-  testCompile project(':dd-java-agent:testing')
   testCompile project(':dd-java-agent:instrumentation:mongo').sourceSets.test.output
   testCompile group: 'de.flapdoodle.embed', name: 'de.flapdoodle.embed.mongo', version: '1.50.5'
 

--- a/dd-java-agent/instrumentation/okhttp-3/okhttp-3.gradle
+++ b/dd-java-agent/instrumentation/okhttp-3/okhttp-3.gradle
@@ -33,11 +33,6 @@ dependencies {
     exclude module: 'okhttp'
   }
 
-  compile deps.bytebuddy
-  compile deps.opentracing
-  annotationProcessor deps.autoservice
-  implementation deps.autoservice
-
   testCompile(project(':dd-java-agent:testing')) {
     exclude module: 'okhttp'
   }

--- a/dd-java-agent/instrumentation/osgi-classloading/osgi-classloading.gradle
+++ b/dd-java-agent/instrumentation/osgi-classloading/osgi-classloading.gradle
@@ -1,10 +1,6 @@
 apply from: "${rootDir}/gradle/java.gradle"
 
 dependencies {
-  compile project(':dd-java-agent:agent-tooling')
-  compile deps.bytebuddy
-  annotationProcessor deps.autoservice
-  implementation deps.autoservice
 
   // TODO: we should separate core and Eclipse tests at some point,
   // but right now core-specific tests are quite dump and are run with
@@ -12,6 +8,4 @@ dependencies {
   //testCompile group: 'org.osgi', name: 'org.osgi.core', version: '4.0.0'
   testCompile group: 'org.eclipse.platform', name: 'org.eclipse.osgi', version: '3.13.200'
   testCompile group: 'org.apache.felix', name: 'org.apache.felix.framework', version: '6.0.2'
-
-  testCompile project(':dd-java-agent:testing')
 }

--- a/dd-java-agent/instrumentation/play-2.4/play-2.4.gradle
+++ b/dd-java-agent/instrumentation/play-2.4/play-2.4.gradle
@@ -28,19 +28,11 @@ muzzle {
 dependencies {
   compileOnly group: 'com.typesafe.play', name: 'play_2.11', version: '2.4.0'
 
-  compile project(':dd-trace-api')
-  compile project(':dd-java-agent:agent-tooling')
-  compile deps.bytebuddy
-  compile deps.opentracing
-  annotationProcessor deps.autoservice
-  implementation deps.autoservice
-
   testCompile deps.scala
   testCompile group: 'com.typesafe.play', name: 'play_2.11', version: '2.4.0'
   testCompile group: 'com.typesafe.play', name: 'play-test_2.11', version: '2.4.0'
   testCompile group: 'com.typesafe.play', name: 'play-ws_2.11', version: '2.4.0'
 
-  testCompile project(':dd-java-agent:testing')
   testCompile project(':dd-java-agent:instrumentation:java-concurrent')
   testCompile project(':dd-java-agent:instrumentation:trace-annotation')
   testCompile project(':dd-java-agent:instrumentation:akka-http-10.0')

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/rabbitmq-amqp-2.7.gradle
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/rabbitmq-amqp-2.7.gradle
@@ -20,16 +20,6 @@ testSets {
 dependencies {
   compileOnly group: 'com.rabbitmq', name: 'amqp-client', version: '2.7.0'
 
-  compile project(':dd-java-agent:agent-tooling')
-
-  compile deps.bytebuddy
-  compile deps.opentracing
-  compile deps.autoservice
-  annotationProcessor deps.autoservice
-  implementation deps.autoservice
-
-  testCompile project(':dd-java-agent:testing')
-
   testCompile group: 'com.rabbitmq', name: 'amqp-client', version: '2.7.0'
   testCompile group: 'org.springframework.amqp', name: 'spring-rabbit', version: '1.1.0.RELEASE'
 

--- a/dd-java-agent/instrumentation/reactor-core-3.1/reactor-core-3.1.gradle
+++ b/dd-java-agent/instrumentation/reactor-core-3.1/reactor-core-3.1.gradle
@@ -62,14 +62,6 @@ dependencies {
 
   compile sourceSets.main_java8.output
 
-  compile project(':dd-java-agent:agent-tooling')
-
-  compile deps.bytebuddy
-  compile deps.opentracing
-  annotationProcessor deps.autoservice
-  implementation deps.autoservice
-
-  testCompile project(':dd-java-agent:testing')
   testCompile project(':dd-java-agent:instrumentation:trace-annotation')
   testCompile project(':dd-java-agent:instrumentation:java-concurrent')
 

--- a/dd-java-agent/instrumentation/servlet-2/servlet-2.gradle
+++ b/dd-java-agent/instrumentation/servlet-2/servlet-2.gradle
@@ -14,13 +14,6 @@ apply from: "${rootDir}/gradle/java.gradle"
 dependencies {
   compileOnly group: 'javax.servlet', name: 'servlet-api', version: '2.3'
 
-  compile project(':dd-java-agent:agent-tooling')
-
-  compile deps.bytebuddy
-  compile deps.opentracing
-  annotationProcessor deps.autoservice
-  implementation deps.autoservice
-
   testCompile(project(':dd-java-agent:testing')) {
     exclude group: 'org.eclipse.jetty', module: 'jetty-server'
   }

--- a/dd-java-agent/instrumentation/servlet-3/servlet-3.gradle
+++ b/dd-java-agent/instrumentation/servlet-3/servlet-3.gradle
@@ -25,13 +25,6 @@ testSets {
 dependencies {
   compileOnly group: 'javax.servlet', name: 'javax.servlet-api', version: '3.0.1'
 
-  compile project(':dd-java-agent:agent-tooling')
-
-  compile deps.bytebuddy
-  compile deps.opentracing
-  annotationProcessor deps.autoservice
-  implementation deps.autoservice
-
   testCompile(project(':dd-java-agent:testing')) {
     exclude group: 'org.eclipse.jetty', module: 'jetty-server'
   }

--- a/dd-java-agent/instrumentation/slf4j-mdc/slf4j-mdc.gradle
+++ b/dd-java-agent/instrumentation/slf4j-mdc/slf4j-mdc.gradle
@@ -9,15 +9,5 @@ muzzle {
 }
 
 dependencies {
-  compile project(':dd-trace-api')
-  compile project(':dd-java-agent:agent-tooling')
-
   // no need to compileOnly against slf4j. Included with transitive dependency.
-
-  compile deps.bytebuddy
-  compile deps.opentracing
-  annotationProcessor deps.autoservice
-  implementation deps.autoservice
-
-  testCompile project(':dd-java-agent:testing')
 }

--- a/dd-java-agent/instrumentation/sparkjava-2.3/sparkjava-2.3.gradle
+++ b/dd-java-agent/instrumentation/sparkjava-2.3/sparkjava-2.3.gradle
@@ -41,14 +41,7 @@ compileJava {
 dependencies {
   compileOnly group: 'com.sparkjava', name: 'spark-core', version: '2.3'
 
-  compile project(':dd-java-agent:agent-tooling')
-  compile deps.bytebuddy
-  compile deps.opentracing
-  annotationProcessor deps.autoservice
-  implementation deps.autoservice
-
   testCompile project(':dd-java-agent:instrumentation:jetty-8')
-  testCompile project(':dd-java-agent:testing')
 
   testCompile group: 'com.sparkjava', name: 'spark-core', version: '2.4'
 

--- a/dd-java-agent/instrumentation/spring-web/spring-web.gradle
+++ b/dd-java-agent/instrumentation/spring-web/spring-web.gradle
@@ -15,13 +15,6 @@ dependencies {
 //  compileOnly group: 'org.springframework', name: 'spring-webmvc', version: '2.5.6'
 //  compileOnly group: 'javax.servlet', name: 'servlet-api', version: '2.4'
 
-  compile project(':dd-java-agent:agent-tooling')
-
-  compile deps.bytebuddy
-  compile deps.opentracing
-  annotationProcessor deps.autoservice
-  implementation deps.autoservice
-
   testCompile(project(':dd-java-agent:testing')){
     exclude(module: 'jetty-server') // incompatable servlet api
   }

--- a/dd-java-agent/instrumentation/spring-webflux/spring-webflux.gradle
+++ b/dd-java-agent/instrumentation/spring-webflux/spring-webflux.gradle
@@ -62,17 +62,10 @@ dependencies {
   compileOnly sourceSets.main_java8.compileClasspath
   compile sourceSets.main_java8.output
 
-  compile project(':dd-java-agent:agent-tooling')
   // We are using utils class from reactor-core instrumentation.
   // TODO: It is unclear why we need to use `compile` here (instead of 'compileOnly')
   compile project(':dd-java-agent:instrumentation:reactor-core-3.1')
 
-  compile deps.bytebuddy
-  compile deps.opentracing
-  annotationProcessor deps.autoservice
-  implementation deps.autoservice
-
-  testCompile project(':dd-java-agent:testing')
   testCompile project(':dd-java-agent:instrumentation:java-concurrent')
   testCompile project(':dd-java-agent:instrumentation:trace-annotation')
   testCompile project(':dd-java-agent:instrumentation:netty-4.1')

--- a/dd-java-agent/instrumentation/spymemcached-2.12/spymemcached-2.12.gradle
+++ b/dd-java-agent/instrumentation/spymemcached-2.12/spymemcached-2.12.gradle
@@ -20,15 +20,6 @@ testSets {
 dependencies {
   compileOnly group: 'net.spy', name: 'spymemcached', version: '2.12.0'
 
-  compile project(':dd-java-agent:agent-tooling')
-
-  compile deps.bytebuddy
-  compile deps.opentracing
-  annotationProcessor deps.autoservice
-  implementation deps.autoservice
-
-  testCompile project(':dd-java-agent:testing')
-
   testCompile group: 'net.spy', name: 'spymemcached', version: '2.12.0'
   testCompile deps.testcontainers
 

--- a/dd-java-agent/instrumentation/tomcat-classloading/tomcat-classloading.gradle
+++ b/dd-java-agent/instrumentation/tomcat-classloading/tomcat-classloading.gradle
@@ -19,13 +19,6 @@ testSets {
 }
 
 dependencies {
-  compile project(':dd-java-agent:agent-tooling')
-  compile deps.bytebuddy
-  annotationProcessor deps.autoservice
-  implementation deps.autoservice
-
-  testCompile project(':dd-java-agent:testing')
-
   //This seems to be the earliest version that has org.apache.catalina.loader.WebappClassLoaderBase
   //Older versions would require slightly different instrumentation.
   testCompile group: 'org.apache.tomcat', name: 'tomcat-catalina', version: '8.0.14'

--- a/dd-java-agent/instrumentation/trace-annotation/trace-annotation.gradle
+++ b/dd-java-agent/instrumentation/trace-annotation/trace-annotation.gradle
@@ -1,14 +1,5 @@
 apply from: "${rootDir}/gradle/java.gradle"
 
 dependencies {
-  compile project(':dd-trace-api')
-  compile project(':dd-java-agent:agent-tooling')
-
-  compile deps.bytebuddy
-  compile deps.opentracing
-  annotationProcessor deps.autoservice
-  implementation deps.autoservice
-
-  testCompile project(':dd-java-agent:testing')
   testCompile group: 'com.newrelic.agent.java', name: 'newrelic-api', version: '+'
 }

--- a/dd-java-agent/instrumentation/twilio/twilio.gradle
+++ b/dd-java-agent/instrumentation/twilio/twilio.gradle
@@ -17,15 +17,7 @@ testSets {
 dependencies {
   compileOnly group: 'com.twilio.sdk', name: 'twilio', version: '0.0.1'
 
-  compile project(':dd-java-agent:agent-tooling')
-
-  compile deps.bytebuddy
-  compile deps.opentracing
-  annotationProcessor deps.autoservice
-  implementation deps.autoservice
-
   testCompile group: 'com.twilio.sdk', name: 'twilio', version: '0.0.1'
-  testCompile project(':dd-java-agent:testing')
   testCompile project(':dd-java-agent:instrumentation:apache-httpclient-4')
   testCompile project(':dd-java-agent:instrumentation:java-concurrent')
   testCompile group: 'org.objenesis', name: 'objenesis', version: '2.6' // Last version to support Java7

--- a/dd-java-agent/instrumentation/vertx/vertx.gradle
+++ b/dd-java-agent/instrumentation/vertx/vertx.gradle
@@ -32,16 +32,8 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 dependencies {
-  compileOnly group: 'io.vertx', name: 'vertx-web', version: '3.5.0'
+//  compileOnly group: 'io.vertx', name: 'vertx-web', version: '3.5.0'
 
-  compile project(':dd-java-agent:agent-tooling')
-
-  compile deps.bytebuddy
-  compile deps.opentracing
-  annotationProcessor deps.autoservice
-  implementation deps.autoservice
-
-  testCompile project(':dd-java-agent:testing')
   testCompile project(':dd-java-agent:instrumentation:netty-4.1')
   testCompile project(':dd-java-agent:instrumentation:java-concurrent')
   testCompile project(':dd-java-agent:instrumentation:trace-annotation')


### PR DESCRIPTION
These dependencies are provided by the parent (instrumentation) project, and don't need to be manually added each time.