### PR TITLE
Update Jackson to 2.9.9.3

### DIFF
--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/transport-2.gradle
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/transport-2.gradle
@@ -39,9 +39,8 @@ dependencies {
   testCompile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.11.0'
   testCompile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.11.0'
   
-  testCompile group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-smile', version: versions.jackson
+  testCompile group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-smile', version: '2.9.9'
   // ^ is needed because we are using a newer version of jackson that isn't compatible without this.
-
 
   latestDepTestCompile group: 'org.elasticsearch', name: 'elasticsearch', version: '2.4.6'
   latestDepTestCompile group: 'org.springframework.data', name: 'spring-data-elasticsearch', version: '2.1.15.RELEASE'

--- a/dd-trace-ot/dd-trace-ot.gradle
+++ b/dd-trace-ot/dd-trace-ot.gradle
@@ -34,7 +34,6 @@ dependencies {
 
   compile deps.jackson
   compile deps.slf4j
-  compile group: 'org.msgpack', name: 'jackson-dataformat-msgpack', version: '0.8.16'
   compile group: 'com.squareup.okhttp3', name: 'okhttp', version: '3.11.0' // Last version to support Java7
   compile group: 'com.github.jnr', name: 'jnr-unixsocket', version: '0.22'
   compile group: 'com.lmax', name: 'disruptor', version: '3.4.2'

--- a/dd-trace/dd-trace.gradle
+++ b/dd-trace/dd-trace.gradle
@@ -16,7 +16,6 @@ dependencies {
 
   compile deps.slf4j
   compile deps.jackson
-  compile group: 'org.msgpack', name: 'jackson-dataformat-msgpack', version: '0.8.16'
 
   compile project(':utils:gc-utils')
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -7,7 +7,7 @@ ext {
 
     slf4j      : "1.7.25",
     guava      : "20.0", // Last version to support Java 7
-    jackson    : "2.9.9", // https://nvd.nist.gov/vuln/detail/CVE-2019-12086
+    jackson    : "2.9.9.3", // https://nvd.nist.gov/vuln/detail/CVE-2019-14379
 
     spock      : "1.3-groovy-$spockGroovyVer",
     groovy     : groovyVer,
@@ -35,7 +35,7 @@ ext {
     guava          : "com.google.guava:guava:$versions.guava",
     jackson        : [
       dependencies.create(group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: versions.jackson),
-      dependencies.create(group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: versions.jackson),
+      dependencies.create(group: 'org.msgpack', name: 'jackson-dataformat-msgpack', version: '0.8.17'),
     ],
     bytebuddy      : dependencies.create(group: 'net.bytebuddy', name: 'byte-buddy', version: "${versions.bytebuddy}"),
     autoservice    : [


### PR DESCRIPTION
As recommended by https://nvd.nist.gov/vuln/detail/CVE-2019-14379