### PR TITLE
Add cleaner thread to EvictingCacheProvider’s cache

### DIFF
--- a/buildSrc/src/main/groovy/MuzzlePlugin.groovy
+++ b/buildSrc/src/main/groovy/MuzzlePlugin.groovy
@@ -22,6 +22,7 @@ import org.gradle.api.Task
 import org.gradle.api.model.ObjectFactory
 
 import java.lang.reflect.Method
+import java.security.SecureClassLoader
 import java.util.concurrent.atomic.AtomicReference
 
 /**
@@ -33,7 +34,6 @@ class MuzzlePlugin implements Plugin<Project> {
    */
   private static final List<RemoteRepository> MUZZLE_REPOS
   private static final AtomicReference<ClassLoader> TOOLING_LOADER = new AtomicReference<>()
-  private static final AtomicReference<Set<Thread>> ALLOWED_THREADS = new AtomicReference<>()
   static {
     RemoteRepository central = new RemoteRepository.Builder("central", "default", "http://central.maven.org/maven2/").build()
     MUZZLE_REPOS = new ArrayList<RemoteRepository>(Arrays.asList(central))
@@ -132,8 +132,6 @@ class MuzzlePlugin implements Plugin<Project> {
         def loader = new URLClassLoader(ddUrls.toArray(new URL[0]), (ClassLoader) null)
         assert TOOLING_LOADER.compareAndSet(null, loader)
         loader.loadClass("datadog.trace.agent.tooling.AgentTooling").getMethod("init").invoke(null)
-        assert ALLOWED_THREADS.compareAndSet(null, new HashSet<Thread>(Arrays.asList(Thread.getThreads())))
-        assert ALLOWED_THREADS.get().size() > 0
         return TOOLING_LOADER.get()
       } else {
         return toolingLoader
@@ -275,16 +273,23 @@ class MuzzlePlugin implements Plugin<Project> {
 
     def muzzleTask = instrumentationProject.task(taskName) {
       doLast {
-        final ClassLoader userCL = createClassLoaderForTask(instrumentationProject, bootstrapProject, taskName)
         final ClassLoader instrumentationCL = createInstrumentationClassloader(instrumentationProject, toolingProject)
-        // find all instrumenters, get muzzle, and assert
-        Method assertionMethod = instrumentationCL.loadClass('datadog.trace.agent.tooling.muzzle.MuzzleVersionScanPlugin')
-          .getMethod('assertInstrumentationMuzzled', ClassLoader.class, ClassLoader.class, boolean.class)
-        assertionMethod.invoke(null, instrumentationCL, userCL, muzzleDirective.assertPass)
+        def ccl = Thread.currentThread().contextClassLoader
+        def bogusLoader = new SecureClassLoader()
+        Thread.currentThread().contextClassLoader = bogusLoader
+        final ClassLoader userCL = createClassLoaderForTask(instrumentationProject, bootstrapProject, taskName)
+        try {
+          // find all instrumenters, get muzzle, and assert
+          Method assertionMethod = instrumentationCL.loadClass('datadog.trace.agent.tooling.muzzle.MuzzleVersionScanPlugin')
+            .getMethod('assertInstrumentationMuzzled', ClassLoader.class, ClassLoader.class, boolean.class)
+          assertionMethod.invoke(null, instrumentationCL, userCL, muzzleDirective.assertPass)
+        } finally {
+          Thread.currentThread().contextClassLoader = ccl
+        }
 
         for (Thread thread : Thread.getThreads()) {
-          if (!ALLOWED_THREADS.get().contains(thread)) {
-            throw new GradleException("Task $taskName has spawned a thread: $thread. This will prevent GC of dynamic muzzle classes. Aborting muzzle run.")
+          if (thread.contextClassLoader == bogusLoader || thread.contextClassLoader == instrumentationCL || thread.contextClassLoader == userCL) {
+            throw new GradleException("Task $taskName has spawned a thread: $thread with classloader $thread.contextClassLoader. This will prevent GC of dynamic muzzle classes. Aborting muzzle run.")
           }
         }
       }

--- a/buildSrc/src/main/groovy/MuzzlePlugin.groovy
+++ b/buildSrc/src/main/groovy/MuzzlePlugin.groovy
@@ -33,6 +33,7 @@ class MuzzlePlugin implements Plugin<Project> {
    */
   private static final List<RemoteRepository> MUZZLE_REPOS
   private static final AtomicReference<ClassLoader> TOOLING_LOADER = new AtomicReference<>()
+  private static final AtomicReference<Set<Thread>> ALLOWED_THREADS = new AtomicReference<>()
   static {
     RemoteRepository central = new RemoteRepository.Builder("central", "default", "http://central.maven.org/maven2/").build()
     MUZZLE_REPOS = new ArrayList<RemoteRepository>(Arrays.asList(central))
@@ -94,18 +95,6 @@ class MuzzlePlugin implements Plugin<Project> {
       return
     }
 
-    if (!project.rootProject.tasks.getNames().contains('muzzleCleanup')) {
-      def muzzleCleanup = project.rootProject.task('muzzleCleanup') {
-        group = 'Muzzle'
-        doLast {
-          project.rootProject.getLogger().info("Cleaning up global tooling loader")
-          TOOLING_LOADER.set(null)
-        }
-      }
-      muzzleCleanup.outputs.upToDateWhen { false }
-    }
-    project.tasks.muzzle.finalizedBy(project.rootProject.tasks.muzzleCleanup)
-
     final RepositorySystem system = newRepositorySystem()
     final RepositorySystemSession session = newRepositorySystemSession(system)
 
@@ -131,18 +120,24 @@ class MuzzlePlugin implements Plugin<Project> {
   }
 
   private static ClassLoader getOrCreateToolingLoader(Project toolingProject) {
-    final ClassLoader toolingLoader = TOOLING_LOADER.get()
-    if (toolingLoader == null) {
-      Set<URL> ddUrls = new HashSet<>()
-      toolingProject.getLogger().info('creating classpath for agent-tooling')
-      for (File f : toolingProject.sourceSets.main.runtimeClasspath.getFiles()) {
-        toolingProject.getLogger().info('--' + f)
-        ddUrls.add(f.toURI().toURL())
+    synchronized (TOOLING_LOADER) {
+      final ClassLoader toolingLoader = TOOLING_LOADER.get()
+      if (toolingLoader == null) {
+        Set<URL> ddUrls = new HashSet<>()
+        toolingProject.getLogger().info('creating classpath for agent-tooling')
+        for (File f : toolingProject.sourceSets.main.runtimeClasspath.getFiles()) {
+          toolingProject.getLogger().info('--' + f)
+          ddUrls.add(f.toURI().toURL())
+        }
+        def loader = new URLClassLoader(ddUrls.toArray(new URL[0]), (ClassLoader) null)
+        assert TOOLING_LOADER.compareAndSet(null, loader)
+        loader.loadClass("datadog.trace.agent.tooling.AgentTooling").getMethod("init").invoke(null)
+        assert ALLOWED_THREADS.compareAndSet(null, new HashSet<Thread>(Arrays.asList(Thread.getThreads())))
+        assert ALLOWED_THREADS.get().size() > 0
+        return TOOLING_LOADER.get()
+      } else {
+        return toolingLoader
       }
-      TOOLING_LOADER.compareAndSet(null, new URLClassLoader(ddUrls.toArray(new URL[0]), (ClassLoader) null))
-      return TOOLING_LOADER.get()
-    } else {
-      return toolingLoader
     }
   }
 
@@ -263,7 +258,7 @@ class MuzzlePlugin implements Plugin<Project> {
   private static Task addMuzzleTask(MuzzleDirective muzzleDirective, Artifact versionArtifact, Project instrumentationProject, Task runAfter, Project bootstrapProject, Project toolingProject) {
     def taskName = "muzzle-Assert${muzzleDirective.assertPass ? "Pass" : "Fail"}-$versionArtifact.groupId-$versionArtifact.artifactId-$versionArtifact.version${muzzleDirective.name ? "-${muzzleDirective.getNameSlug()}" : ""}"
     def config = instrumentationProject.configurations.create(taskName)
-    def dep =  instrumentationProject.dependencies.create("$versionArtifact.groupId:$versionArtifact.artifactId:$versionArtifact.version") {
+    def dep = instrumentationProject.dependencies.create("$versionArtifact.groupId:$versionArtifact.artifactId:$versionArtifact.version") {
       transitive = true
     }
     // The following optional transitive dependencies are brought in by some legacy module such as log4j 1.x but are no
@@ -288,7 +283,7 @@ class MuzzlePlugin implements Plugin<Project> {
         assertionMethod.invoke(null, instrumentationCL, userCL, muzzleDirective.assertPass)
 
         for (Thread thread : Thread.getThreads()) {
-          if (thread.getName().startsWith("dd-")) {
+          if (!ALLOWED_THREADS.get().contains(thread)) {
             throw new GradleException("Task $taskName has spawned a thread: $thread. This will prevent GC of dynamic muzzle classes. Aborting muzzle run.")
           }
         }

--- a/buildSrc/src/main/resources/META-INF/gradle-plugins/version-scan.properties
+++ b/buildSrc/src/main/resources/META-INF/gradle-plugins/version-scan.properties
@@ -1,1 +1,0 @@
-implementation-class=VersionScanPlugin

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/WeakMap.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/WeakMap.java
@@ -107,7 +107,7 @@ public interface WeakMap<K, V> {
     }
 
     @Override
-    public V getOrCreate(K key, ValueSupplier<V> supplier) {
+    public V getOrCreate(final K key, final ValueSupplier<V> supplier) {
       if (!map.containsKey(key)) {
         synchronized (this) {
           if (!map.containsKey(key)) {

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
@@ -10,7 +10,6 @@ import static net.bytebuddy.matcher.ElementMatchers.none;
 import static net.bytebuddy.matcher.ElementMatchers.not;
 
 import datadog.trace.api.Config;
-import datadog.trace.bootstrap.WeakMap;
 import java.lang.instrument.Instrumentation;
 import java.util.Collections;
 import java.util.List;
@@ -29,15 +28,6 @@ import net.bytebuddy.utility.JavaModule;
 @Slf4j
 public class AgentInstaller {
   private static final Map<String, Runnable> classLoadCallbacks = new ConcurrentHashMap<>();
-  public static final Cleaner CLEANER = new Cleaner();
-
-  static {
-    // WeakMap is used by other classes below, so we need to register the provider first.
-    registerWeakMapProvider(CLEANER);
-  }
-
-  public static final DDLocationStrategy LOCATION_STRATEGY = new DDLocationStrategy();
-  public static final AgentBuilder.PoolStrategy POOL_STRATEGY = new DDCachingPoolStrategy(CLEANER);
   private static volatile Instrumentation INSTRUMENTATION;
 
   public static Instrumentation getInstrumentation() {
@@ -68,10 +58,10 @@ public class AgentInstaller {
             .with(AgentBuilder.RedefinitionStrategy.RETRANSFORMATION)
             .with(new RedefinitionLoggingListener())
             .with(AgentBuilder.DescriptionStrategy.Default.POOL_ONLY)
-            .with(POOL_STRATEGY)
+            .with(AgentTooling.poolStrategy())
             .with(new TransformLoggingListener())
             .with(new ClassLoadListener())
-            .with(LOCATION_STRATEGY)
+            .with(AgentTooling.locationStrategy())
             // FIXME: we cannot enable it yet due to BB/JVM bug, see
             // https://github.com/raphw/byte-buddy/issues/558
             // .with(AgentBuilder.LambdaInstrumentationStrategy.ENABLED)
@@ -153,7 +143,6 @@ public class AgentInstaller {
     }
     log.debug("Installed {} instrumenter(s)", numInstrumenters);
 
-    CLEANER.start();
     return agentBuilder.installOn(inst);
   }
 
@@ -171,14 +160,6 @@ public class AgentInstaller {
       }
     }
     return matcher;
-  }
-
-  private static void registerWeakMapProvider(final Cleaner cleaner) {
-    if (!WeakMap.Provider.isProviderRegistered()) {
-      WeakMap.Provider.registerIfAbsent(new WeakMapSuppliers.WeakConcurrent(cleaner));
-      //    WeakMap.Provider.registerIfAbsent(new WeakMapSuppliers.WeakConcurrent.Inline());
-      //    WeakMap.Provider.registerIfAbsent(new WeakMapSuppliers.Guava());
-    }
   }
 
   @Slf4j

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentTooling.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentTooling.java
@@ -2,6 +2,11 @@ package datadog.trace.agent.tooling;
 
 import datadog.trace.bootstrap.WeakMap;
 
+/**
+ * This class contains class references for objects shared by the agent installer as well as muzzle
+ * (both compile and runtime). Extracted out from AgentInstaller to begin separating some of the
+ * logic out.
+ */
 public class AgentTooling {
   private static final Cleaner CLEANER = new Cleaner();
 

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentTooling.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentTooling.java
@@ -1,0 +1,35 @@
+package datadog.trace.agent.tooling;
+
+import datadog.trace.bootstrap.WeakMap;
+
+public class AgentTooling {
+  private static final Cleaner CLEANER = new Cleaner();
+
+  static {
+    // WeakMap is used by other classes below, so we need to register the provider first.
+    registerWeakMapProvider(CLEANER);
+  }
+
+  private static final DDLocationStrategy LOCATION_STRATEGY = new DDLocationStrategy();
+  private static final DDCachingPoolStrategy POOL_STRATEGY = new DDCachingPoolStrategy(CLEANER);
+
+  public static void init() {
+    // Only need to trigger static initializers for now.
+  }
+
+  public static DDLocationStrategy locationStrategy() {
+    return LOCATION_STRATEGY;
+  }
+
+  public static DDCachingPoolStrategy poolStrategy() {
+    return POOL_STRATEGY;
+  }
+
+  private static void registerWeakMapProvider(final Cleaner cleaner) {
+    if (!WeakMap.Provider.isProviderRegistered()) {
+      WeakMap.Provider.registerIfAbsent(new WeakMapSuppliers.WeakConcurrent(cleaner));
+      //    WeakMap.Provider.registerIfAbsent(new WeakMapSuppliers.WeakConcurrent.Inline());
+      //    WeakMap.Provider.registerIfAbsent(new WeakMapSuppliers.Guava());
+    }
+  }
+}

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Cleaner.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Cleaner.java
@@ -1,0 +1,124 @@
+package datadog.trace.agent.tooling;
+
+import java.lang.ref.WeakReference;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+class Cleaner {
+  // TODO: add unit tests for this class.
+
+  private static final long SHUTDOWN_WAIT_SECONDS = 5;
+
+  private static final ThreadFactory THREAD_FACTORY =
+      new ThreadFactory() {
+        @Override
+        public Thread newThread(final Runnable r) {
+          final Thread thread = new Thread(r, "dd-cleaner");
+          thread.setDaemon(true);
+          thread.setPriority(Thread.MIN_PRIORITY);
+          return thread;
+        }
+      };
+
+  private volatile ScheduledThreadPoolExecutor cleanerService = null;
+  private volatile Thread shutdownCallback = null;
+
+  <T> void scheduleCleaning(
+      final T target, final Adapter<T> adapter, final long frequency, final TimeUnit unit) {
+    final CleanupRunnable<T> command = new CleanupRunnable<>(target, adapter);
+    if (cleanerService == null) {
+      log.warn("Cleaning scheduled before starting cleaner. Target won't be cleaned {}", target);
+    } else {
+      command.setFuture(cleanerService.scheduleAtFixedRate(command, frequency, frequency, unit));
+    }
+  }
+
+  public void start() {
+    if (cleanerService == null) {
+      synchronized (this) {
+        if (cleanerService == null) {
+          cleanerService = new ScheduledThreadPoolExecutor(1, THREAD_FACTORY);
+          cleanerService.setRemoveOnCancelPolicy(true);
+          shutdownCallback = new ShutdownCallback(cleanerService);
+          try {
+            Runtime.getRuntime().addShutdownHook(shutdownCallback);
+          } catch (final IllegalStateException ex) {
+            // The JVM is already shutting down.
+          }
+        }
+      }
+    }
+  }
+
+  public void stop() {
+    if (cleanerService == null) {
+      synchronized (this) {
+        if (cleanerService == null) {
+          cleanerService.shutdown();
+          Runtime.getRuntime().removeShutdownHook(shutdownCallback);
+          cleanerService = null;
+          shutdownCallback = null;
+        }
+      }
+    }
+  }
+
+  @Override
+  public void finalize() {
+    // Do we really want this?
+    stop();
+  }
+
+  public interface Adapter<T> {
+    void clean(T target);
+  }
+
+  private static class CleanupRunnable<T> implements Runnable {
+    private final WeakReference<T> target;
+    private final Adapter<T> adapter;
+    private ScheduledFuture<?> future = null;
+
+    private CleanupRunnable(final T target, final Adapter<T> adapter) {
+      this.target = new WeakReference<>(target);
+      this.adapter = adapter;
+    }
+
+    @Override
+    public void run() {
+      final T t = target.get();
+      if (t != null) {
+        adapter.clean(t);
+      } else if (future != null) {
+        future.cancel(false);
+      }
+    }
+
+    public void setFuture(final ScheduledFuture<?> future) {
+      this.future = future;
+    }
+  }
+
+  private static final class ShutdownCallback extends Thread {
+
+    private final ScheduledExecutorService executorService;
+
+    public ShutdownCallback(final ScheduledExecutorService executorService) {
+      this.executorService = executorService;
+    }
+
+    @Override
+    public void run() {
+      try {
+        executorService.shutdownNow();
+        executorService.awaitTermination(SHUTDOWN_WAIT_SECONDS, TimeUnit.SECONDS);
+      } catch (final InterruptedException e) {
+        // Don't bother waiting then...
+      }
+    }
+  }
+}

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Cleaner.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Cleaner.java
@@ -11,8 +11,6 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 class Cleaner {
-  // TODO: add unit tests for this class.
-
   private static final long SHUTDOWN_WAIT_SECONDS = 5;
 
   private static final ThreadFactory THREAD_FACTORY =
@@ -47,6 +45,7 @@ class Cleaner {
       log.warn("Cleaning scheduled but cleaner is shutdown. Target won't be cleaned {}", target);
     } else {
       try {
+        // Schedule job and save future to allow job to be canceled if target is GC'd.
         command.setFuture(cleanerService.scheduleAtFixedRate(command, frequency, frequency, unit));
       } catch (final RejectedExecutionException e) {
         log.warn("Cleaning task rejected. Target won't be cleaned {}", target);
@@ -72,7 +71,7 @@ class Cleaner {
   private static class CleanupRunnable<T> implements Runnable {
     private final WeakReference<T> target;
     private final Adapter<T> adapter;
-    private ScheduledFuture<?> future = null;
+    private volatile ScheduledFuture<?> future = null;
 
     private CleanupRunnable(final T target, final Adapter<T> adapter) {
       this.target = new WeakReference<>(target);

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/DDCachingPoolStrategy.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/DDCachingPoolStrategy.java
@@ -28,7 +28,7 @@ import net.bytebuddy.pool.TypePool;
  * <p>See eviction policy below.
  */
 public class DDCachingPoolStrategy implements PoolStrategy {
-  private static final WeakMap<ClassLoader, TypePool.CacheProvider> typePoolCache =
+  private final WeakMap<ClassLoader, TypePool.CacheProvider> typePoolCache =
       WeakMap.Provider.newWeakMap();
   private final Cleaner cleaner;
 

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/DDCachingPoolStrategy.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/DDCachingPoolStrategy.java
@@ -45,7 +45,7 @@ public class DDCachingPoolStrategy implements PoolStrategy {
       synchronized (key) {
         cache = typePoolCache.get(key);
         if (null == cache) {
-          cache = EvictingCacheProvider.withObjectType(cleaner, 10, TimeUnit.SECONDS);
+          cache = EvictingCacheProvider.withObjectType(cleaner, 1, TimeUnit.MINUTES);
           typePoolCache.put(key, cache);
         }
       }
@@ -64,7 +64,7 @@ public class DDCachingPoolStrategy implements PoolStrategy {
         final Cleaner cleaner, final long expireDuration, final TimeUnit unit) {
       cache =
           CacheBuilder.newBuilder()
-              .initialCapacity(500)
+              .initialCapacity(1000)
               .maximumSize(10000)
               .expireAfterAccess(expireDuration, unit)
               .build();

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/DDCachingPoolStrategy.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/DDCachingPoolStrategy.java
@@ -73,13 +73,11 @@ public class DDCachingPoolStrategy implements PoolStrategy {
        * The cache only does cleanup on occasional reads and writes.
        * We want to ensure this happens more regularly, so we schedule a thread to do run cleanup manually.
        */
-      final long cleanFrequency = expireDuration / 2;
-      cleaner.scheduleCleaning(cache, CacheCleaner.CLEANER, cleanFrequency, unit);
+      cleaner.scheduleCleaning(cache, CacheCleaner.CLEANER, expireDuration, unit);
     }
 
     private static EvictingCacheProvider withObjectType(
         final Cleaner cleaner, final long expireDuration, final TimeUnit unit) {
-      assert expireDuration % 2 == 0 : "expireDuration must be even";
       final EvictingCacheProvider cacheProvider =
           new EvictingCacheProvider(cleaner, expireDuration, unit);
       cacheProvider.register(

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/MuzzleGradlePlugin.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/MuzzleGradlePlugin.java
@@ -1,7 +1,10 @@
 package datadog.trace.agent.tooling.muzzle;
 
 import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.bootstrap.WeakMap;
 import java.io.IOException;
+import java.util.Collections;
+import java.util.WeakHashMap;
 import net.bytebuddy.build.Plugin;
 import net.bytebuddy.description.type.TypeDefinition;
 import net.bytebuddy.description.type.TypeDescription;
@@ -10,6 +13,17 @@ import net.bytebuddy.dynamic.DynamicType;
 
 /** Bytebuddy gradle plugin which creates muzzle-references at compile time. */
 public class MuzzleGradlePlugin implements Plugin {
+  static {
+    // prevent WeakMap from logging warning while plugin is running
+    WeakMap.Provider.registerIfAbsent(
+        new WeakMap.Implementation() {
+          @Override
+          public <K, V> WeakMap<K, V> get() {
+            return new WeakMap.MapAdapter<>(Collections.synchronizedMap(new WeakHashMap<K, V>()));
+          }
+        });
+  }
+
   private static final TypeDescription DefaultInstrumenterTypeDesc =
       new TypeDescription.ForLoadedType(Instrumenter.Default.class);
 

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/MuzzleVersionScanPlugin.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/MuzzleVersionScanPlugin.java
@@ -1,16 +1,14 @@
 package datadog.trace.agent.tooling.muzzle;
 
+import datadog.trace.agent.tooling.AgentTooling;
 import datadog.trace.agent.tooling.HelperInjector;
 import datadog.trace.agent.tooling.Instrumenter;
-import datadog.trace.bootstrap.WeakMap;
 import java.io.IOException;
 import java.lang.reflect.Method;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
-import java.util.WeakHashMap;
 import net.bytebuddy.dynamic.ClassFileLocator;
 
 /**
@@ -23,14 +21,7 @@ import net.bytebuddy.dynamic.ClassFileLocator;
  */
 public class MuzzleVersionScanPlugin {
   static {
-    // prevent WeakMap from logging warning while plugin is running
-    WeakMap.Provider.registerIfAbsent(
-        new WeakMap.Implementation() {
-          @Override
-          public <K, V> WeakMap<K, V> get() {
-            return new WeakMap.MapAdapter<>(Collections.synchronizedMap(new WeakHashMap<K, V>()));
-          }
-        });
+    AgentTooling.init();
   }
 
   public static void assertInstrumentationMuzzled(
@@ -102,7 +93,7 @@ public class MuzzleVersionScanPlugin {
           // only default Instrumenters use muzzle. Skip custom instrumenters.
           continue;
         }
-        Instrumenter.Default defaultInstrumenter = (Instrumenter.Default) instrumenter;
+        final Instrumenter.Default defaultInstrumenter = (Instrumenter.Default) instrumenter;
         try {
           // verify helper injector works
           final String[] helperClassNames = defaultInstrumenter.helperClassNames();
@@ -119,7 +110,7 @@ public class MuzzleVersionScanPlugin {
     }
   }
 
-  private static Map<String, byte[]> createHelperMap(Instrumenter.Default instrumenter)
+  private static Map<String, byte[]> createHelperMap(final Instrumenter.Default instrumenter)
       throws IOException {
     final Map<String, byte[]> helperMap =
         new LinkedHashMap<>(instrumenter.helperClassNames().length);

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/ReferenceMatcher.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/ReferenceMatcher.java
@@ -3,7 +3,7 @@ package datadog.trace.agent.tooling.muzzle;
 import static datadog.trace.bootstrap.WeakMap.Provider.newWeakMap;
 import static net.bytebuddy.dynamic.loading.ClassLoadingStrategy.BOOTSTRAP_LOADER;
 
-import datadog.trace.agent.tooling.AgentInstaller;
+import datadog.trace.agent.tooling.AgentTooling;
 import datadog.trace.agent.tooling.Utils;
 import datadog.trace.agent.tooling.muzzle.Reference.Mismatch;
 import datadog.trace.agent.tooling.muzzle.Reference.Source;
@@ -84,8 +84,8 @@ public class ReferenceMatcher {
    */
   public static List<Reference.Mismatch> checkMatch(Reference reference, ClassLoader loader) {
     final TypePool typePool =
-        AgentInstaller.POOL_STRATEGY.typePool(
-            AgentInstaller.LOCATION_STRATEGY.classFileLocator(loader), loader);
+        AgentTooling.poolStrategy()
+            .typePool(AgentTooling.locationStrategy().classFileLocator(loader), loader);
     final List<Mismatch> mismatches = new ArrayList<>(0);
     try {
       final TypePool.Resolution resolution =

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/CleanerTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/CleanerTest.groovy
@@ -1,0 +1,100 @@
+package datadog.trace.agent.tooling
+
+import datadog.trace.util.gc.GCUtils
+import spock.lang.Specification
+import spock.lang.Subject
+
+import java.lang.ref.WeakReference
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.atomic.AtomicInteger
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS
+
+class CleanerTest extends Specification {
+
+  @Subject
+  def cleaner = new Cleaner()
+
+  def cleanup() {
+    cleaner.stop()
+  }
+
+  def "test scheduling"() {
+    setup:
+    def latch = new CountDownLatch(2)
+    def target = new Object()
+    def action = new Cleaner.Adapter<Object>() {
+      @Override
+      void clean(Object t) {
+        latch.countDown()
+      }
+    }
+
+    expect:
+    !cleaner.cleanerService.isShutdown()
+
+    when:
+    cleaner.scheduleCleaning(target, action, 10, MILLISECONDS)
+
+    then:
+    latch.await(100, MILLISECONDS)
+  }
+
+  def "test canceling"() {
+    setup:
+    def callCount = new AtomicInteger()
+    def target = new WeakReference(new Object())
+    def action = new Cleaner.Adapter<Object>() {
+      @Override
+      void clean(Object t) {
+        callCount.incrementAndGet()
+      }
+    }
+
+    expect:
+    !cleaner.cleanerService.isShutdown()
+
+    when:
+    cleaner.scheduleCleaning(target.get(), action, 10, MILLISECONDS)
+    GCUtils.awaitGC(target)
+    Thread.sleep(1)
+    def snapshot = callCount.get()
+    Thread.sleep(11)
+
+    then:
+    snapshot == callCount.get()
+  }
+
+  def "test null target"() {
+    setup:
+    def callCount = new AtomicInteger()
+    def action = new Cleaner.Adapter<Object>() {
+      @Override
+      void clean(Object t) {
+        callCount.incrementAndGet()
+      }
+    }
+
+    expect:
+    !cleaner.cleanerService.isShutdown()
+
+    when:
+    cleaner.scheduleCleaning(null, action, 10, MILLISECONDS)
+    Thread.sleep(11)
+
+    then:
+    callCount.get() == 0
+  }
+
+  def "test shutdown"() {
+    expect:
+    !cleaner.cleanerService.isShutdown()
+
+    when:
+    cleaner.stop()
+
+    then:
+    cleaner.cleanerService.awaitTermination(50, MILLISECONDS)
+    cleaner.cleanerService.isTerminated()
+  }
+}

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/EvictingCacheProviderTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/EvictingCacheProviderTest.groovy
@@ -9,13 +9,10 @@ import java.lang.ref.WeakReference
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
 
-import static datadog.trace.agent.tooling.AgentInstaller.CLEANER
+import static datadog.trace.agent.tooling.AgentTooling.CLEANER
 
 //@Timeout(5)
 class EvictingCacheProviderTest extends Specification {
-  static {
-    CLEANER.start()
-  }
 
   def "test provider"() {
     setup:

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/EvictingCacheProviderTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/EvictingCacheProviderTest.groovy
@@ -1,0 +1,85 @@
+package datadog.trace.agent.tooling
+
+import datadog.trace.util.gc.GCUtils
+import net.bytebuddy.description.type.TypeDescription
+import net.bytebuddy.pool.TypePool
+import spock.lang.Specification
+import spock.lang.Timeout
+
+import java.lang.ref.WeakReference
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+
+@Timeout(5)
+class EvictingCacheProviderTest extends Specification {
+  def "test provider"() {
+    setup:
+    def provider = new DDCachingPoolStrategy.EvictingCacheProvider(2, TimeUnit.MINUTES)
+
+    expect:
+    provider.size() == 0
+    provider.find(className) == null
+
+    when:
+    provider.register(className, new TypePool.Resolution.Simple(TypeDescription.VOID))
+
+    then:
+    provider.size() == 1
+    provider.find(className) == new TypePool.Resolution.Simple(TypeDescription.VOID)
+
+    when:
+    provider.clear()
+
+    then:
+    provider.size() == 0
+    provider.find(className) == null
+
+    where:
+    className = "SomeClass"
+  }
+
+  def "test timeout eviction"() {
+    setup:
+    def provider = new DDCachingPoolStrategy.EvictingCacheProvider(10, TimeUnit.MILLISECONDS)
+    def resolutionRef = new AtomicReference<TypePool.Resolution>(new TypePool.Resolution.Simple(TypeDescription.VOID))
+    def weakRef = new WeakReference(resolutionRef.get())
+
+    when:
+    provider.register(className, resolutionRef.get())
+
+    then:
+    provider.size() == 1
+    Thread.sleep(10)
+    provider.find(className) == null
+
+    when:
+    provider.register(className, resolutionRef.get())
+    resolutionRef.set(null)
+    GCUtils.awaitGC(weakRef)
+
+    then:
+    provider.size() == 0
+    weakRef.get() == null
+
+    where:
+    className = "SomeClass"
+  }
+
+  def "test size limit"() {
+    setup:
+    def provider = new DDCachingPoolStrategy.EvictingCacheProvider(2, TimeUnit.MINUTES)
+    def typeDef = new TypePool.Resolution.Simple(TypeDescription.VOID)
+    for (int i = 0; i < 20000; i++) {
+      provider.register("ClassName$i", typeDef)
+    }
+
+    expect:
+    provider.size() == 10000
+
+    when:
+    provider.clear()
+
+    then:
+    provider.size() == 0
+  }
+}

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/EvictingCacheProviderTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/EvictingCacheProviderTest.groovy
@@ -4,17 +4,22 @@ import datadog.trace.util.gc.GCUtils
 import net.bytebuddy.description.type.TypeDescription
 import net.bytebuddy.pool.TypePool
 import spock.lang.Specification
-import spock.lang.Timeout
 
 import java.lang.ref.WeakReference
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
 
-@Timeout(5)
+import static datadog.trace.agent.tooling.AgentInstaller.CLEANER
+
+//@Timeout(5)
 class EvictingCacheProviderTest extends Specification {
+  static {
+    CLEANER.start()
+  }
+
   def "test provider"() {
     setup:
-    def provider = new DDCachingPoolStrategy.EvictingCacheProvider(2, TimeUnit.MINUTES)
+    def provider = new DDCachingPoolStrategy.EvictingCacheProvider(CLEANER, 2, TimeUnit.MINUTES)
 
     expect:
     provider.size() == 0
@@ -40,16 +45,28 @@ class EvictingCacheProviderTest extends Specification {
 
   def "test timeout eviction"() {
     setup:
-    def provider = new DDCachingPoolStrategy.EvictingCacheProvider(10, TimeUnit.MILLISECONDS)
+    def provider = new DDCachingPoolStrategy.EvictingCacheProvider(CLEANER, timeout, TimeUnit.MILLISECONDS)
     def resolutionRef = new AtomicReference<TypePool.Resolution>(new TypePool.Resolution.Simple(TypeDescription.VOID))
     def weakRef = new WeakReference(resolutionRef.get())
 
     when:
+    def lastAccess = System.nanoTime()
     provider.register(className, resolutionRef.get())
 
     then:
-    provider.size() == 1
-    Thread.sleep(10)
+    // Ensure continued access prevents expiration.
+    for (int i = 0; i < timeout + 10; i++) {
+      assert TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - lastAccess) < timeout: "test took too long on " + i
+      assert provider.find(className) != null
+      assert provider.size() == 1
+      lastAccess = System.nanoTime()
+      Thread.sleep(1)
+    }
+
+    when:
+    Thread.sleep(timeout)
+
+    then:
     provider.find(className) == null
 
     when:
@@ -58,16 +75,18 @@ class EvictingCacheProviderTest extends Specification {
     GCUtils.awaitGC(weakRef)
 
     then:
+    // Verify properly GC'd
     provider.size() == 0
     weakRef.get() == null
 
     where:
     className = "SomeClass"
+    timeout = 500 // Takes about 50 ms locally, adding an order of magnitude for CI.
   }
 
   def "test size limit"() {
     setup:
-    def provider = new DDCachingPoolStrategy.EvictingCacheProvider(2, TimeUnit.MINUTES)
+    def provider = new DDCachingPoolStrategy.EvictingCacheProvider(CLEANER, 2, TimeUnit.MINUTES)
     def typeDef = new TypePool.Resolution.Simple(TypeDescription.VOID)
     for (int i = 0; i < 20000; i++) {
       provider.register("ClassName$i", typeDef)

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/EvictingCacheProviderTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/EvictingCacheProviderTest.groovy
@@ -4,6 +4,7 @@ import datadog.trace.util.gc.GCUtils
 import net.bytebuddy.description.type.TypeDescription
 import net.bytebuddy.pool.TypePool
 import spock.lang.Specification
+import spock.lang.Timeout
 
 import java.lang.ref.WeakReference
 import java.util.concurrent.TimeUnit
@@ -11,7 +12,7 @@ import java.util.concurrent.atomic.AtomicReference
 
 import static datadog.trace.agent.tooling.AgentTooling.CLEANER
 
-//@Timeout(5)
+@Timeout(5)
 class EvictingCacheProviderTest extends Specification {
 
   def "test provider"() {

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/WeakConcurrentSupplierTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/WeakConcurrentSupplierTest.groovy
@@ -9,14 +9,11 @@ import spock.lang.Specification
 import java.lang.ref.WeakReference
 import java.util.concurrent.TimeUnit
 
-import static datadog.trace.agent.tooling.AgentInstaller.CLEANER
+import static datadog.trace.agent.tooling.AgentTooling.CLEANER
 
 @Retry
 // These tests fail sometimes in CI.
 class WeakConcurrentSupplierTest extends Specification {
-  static {
-    CLEANER.start()
-  }
   @Shared
   def weakConcurrentSupplier = new WeakMapSuppliers.WeakConcurrent(CLEANER)
   @Shared

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/WeakConcurrentSupplierTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/WeakConcurrentSupplierTest.groovy
@@ -9,11 +9,16 @@ import spock.lang.Specification
 import java.lang.ref.WeakReference
 import java.util.concurrent.TimeUnit
 
+import static datadog.trace.agent.tooling.AgentInstaller.CLEANER
+
 @Retry
 // These tests fail sometimes in CI.
 class WeakConcurrentSupplierTest extends Specification {
+  static {
+    CLEANER.start()
+  }
   @Shared
-  def weakConcurrentSupplier = new WeakMapSuppliers.WeakConcurrent()
+  def weakConcurrentSupplier = new WeakMapSuppliers.WeakConcurrent(CLEANER)
   @Shared
   def weakInlineSupplier = new WeakMapSuppliers.WeakConcurrent.Inline()
   @Shared
@@ -57,7 +62,7 @@ class WeakConcurrentSupplierTest extends Specification {
 
     where:
     name             | supplierSupplier
-    "WeakConcurrent" | { -> new WeakMapSuppliers.WeakConcurrent() }
+    "WeakConcurrent" | { -> new WeakMapSuppliers.WeakConcurrent(CLEANER) }
     "WeakInline"     | { -> new WeakMapSuppliers.WeakConcurrent.Inline() }
     "Guava"          | { -> new WeakMapSuppliers.Guava() }
   }

--- a/dd-java-agent/instrumentation/servlet-3/servlet-3.gradle
+++ b/dd-java-agent/instrumentation/servlet-3/servlet-3.gradle
@@ -39,6 +39,8 @@ dependencies {
   // TODO: we need to setup separate test for Jetty 10 when that is released.
   latestDepTestCompile group: 'org.eclipse.jetty', name: 'jetty-server', version: '9.+'
   latestDepTestCompile group: 'org.eclipse.jetty', name: 'jetty-servlet', version: '9.+'
-  latestDepTestCompile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '+'
-  latestDepTestCompile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-jasper', version: '+'
+
+  // FIXME: 9.0.24 seems to have changed something...
+  latestDepTestCompile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.0.22'
+  latestDepTestCompile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-jasper', version: '9.0.22'
 }

--- a/tooling/dd_jvm_stats.sh
+++ b/tooling/dd_jvm_stats.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+
+set -e
+
+OUTPUT_ROOT=$(pwd)
+
+# Thread dump interval defaults to 10 mins
+THREAD_DUMP_INTERVAL_SECS=600
+# Heap dump interval defaults to 30 mins
+HEAP_DUMP_INTERVAL_SECS=1800
+# GC usage interval defaults to 30 secs
+GC_INTERVAL_SECS=30
+# Runtime stats interval defaults to 10 secs
+RUNTIME_INTERVAL_SECS=10
+# Default runs continuously
+STOP_AFTER_SECS=0
+
+function usage {
+  echo "Usage: ./dd_jvm_stats --pid <PID> [--STOP_AFTER_SECS <SECS:0>] [--runtime-interval <SECS:10>] [--thread-interval <SECS:600>] [--heap-interval <SECS:1800>] [--gc-interval <SECS:30>] [--runtime-interval <SECS:10>] [--output <PATH:./>]"
+}
+
+while [[ "$1" != "" ]]; do
+    case $1 in
+        --pid )                 shift
+                                PROCESS_IDENTIFIER=$1
+                                ;;
+        --output )              shift
+                                OUTPUT_ROOT=$1
+                                ;;
+        --thread-interval )     shift
+                                THREAD_DUMP_INTERVAL_SECS=$1
+                                ;;
+        --heap-interval )       shift
+                                HEAP_DUMP_INTERVAL_SECS=$1
+                                ;;
+        --gc-interval )         shift
+                                GC_INTERVAL_SECS=$1
+                                ;;
+        --runtime-interval )    shift
+                                RUNTIME_INTERVAL_SECS=$1
+                                ;;
+        --stop-after )          shift
+                                STOP_AFTER_SECS=$1
+                                ;;
+        --help )                usage
+                                exit
+                                ;;
+        * )                     usage
+                                exit 1
+    esac
+    shift
+done
+
+# At least PID has to be provided
+if [[ -z "$PROCESS_IDENTIFIER" ]]
+then
+      usage
+      echo "Provide the correct process id:"
+      jcmd
+      exit 1
+fi
+
+HUMAN_READABLE_FORMAT='+%Y-%m-%d %H:%M:%S'
+FILESYSTEM_READABLE_FORMAT='+%Y%m%d_%H%M%S'
+OUTPUT_FOLDER="${OUTPUT_ROOT}/monitoring_session_started_$(date "$FILESYSTEM_READABLE_FORMAT")"
+THREAD_DUMP_FOLDER="$OUTPUT_FOLDER/thread_dumps"
+HEAP_DUMP_FOLDER="$OUTPUT_FOLDER/heap_dumps"
+GC_STATS_FILE="$OUTPUT_FOLDER/gc_stats.csv"
+RUNTIME_STATS_FILE="$OUTPUT_FOLDER/runtime_stats.csv"
+JVM_INFO_FILE="$OUTPUT_FOLDER/jvm_info.txt"
+
+# Preparing output folders
+echo "Data will be saved to $OUTPUT_FOLDER"
+mkdir -p ${OUTPUT_FOLDER}
+mkdir -p ${THREAD_DUMP_FOLDER}
+mkdir -p ${HEAP_DUMP_FOLDER}
+
+# Dumping JVM INFO
+echo "JVM version $(jcmd ${PROCESS_IDENTIFIER} VM.version)" > ${JVM_INFO_FILE}
+echo "" >> ${JVM_INFO_FILE}
+echo "JVM uptime $(jcmd ${PROCESS_IDENTIFIER} VM.uptime)" >> ${JVM_INFO_FILE}
+echo "" >> ${JVM_INFO_FILE}
+echo "JVM command line $(jcmd ${PROCESS_IDENTIFIER} VM.command_line)" >> ${JVM_INFO_FILE}
+echo "" >> ${JVM_INFO_FILE}
+
+# Initializing files
+echo "Date,CPU%,S0C,S1C,S0U,S1U,EC,EU,OC,OU,MC,MU,CCSC,CCSU,YGC,YGCT,FGC,FGCT,GCT" > ${RUNTIME_STATS_FILE}
+
+START=$(date +"%s")
+
+GC_LOGS_FILE=$(jcmd ${PROCESS_IDENTIFIER} VM.command_line | grep jvm_args | sed 's/^.*Xlog[:]*gc:\([^\s]*\) .*$/\1/')
+
+if [[ -z "$GC_LOGS_FILE" ]]; then
+  echo "GC logs file was not found, did you set jvm args for GC logs?: for JDK 9+ '-Xlog:gc:/path/to/gc.log', JDK 8 '-Xloggc:/path/to/gc.log -XX:+PrintGC -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps'"
+else
+  echo "Found GC logs file: $GC_LOGS_FILE"
+fi
+
+LAST_GC=0
+LAST_CPU=0
+LAST_RUNTIME=0
+LAST_HEAP=${START}
+LAST_THREAD=${START}
+
+function tick() {
+  NOW=$(date +"%s")
+  NOW_HUMAN=$(date "${HUMAN_READABLE_FORMAT}")
+  NOW_FILESYSTEM=$(date "${FILESYSTEM_READABLE_FORMAT}")
+
+  # We can set a stop after a number of seconds
+  if [[ "$STOP_AFTER_SECS" -gt "0" ]] && [[ "$NOW" -gt $(( $START + $STOP_AFTER_SECS )) ]]; then
+    echo "Maximum running time reached: job completed successfully."
+    exit 0
+  fi
+
+  # Runtime live
+  if [[ "$NOW" -ge $(( $LAST_RUNTIME + $RUNTIME_INTERVAL_SECS )) ]]; then
+    CPU_USAGE=$(ps -p ${PROCESS_IDENTIFIER} -o %cpu | grep '\.')
+    MEMORY_USAGE=$(jstat -gc ${PROCESS_IDENTIFIER} | grep '\.' | sed -E 's/ +/,/g')
+    echo "$NOW_HUMAN,$CPU_USAGE,$MEMORY_USAGE" >> ${RUNTIME_STATS_FILE}
+    LAST_RUNTIME=${NOW}
+  fi
+
+  # GC logs
+  if [[ "$NOW" -ge $(( $LAST_GC + $GC_INTERVAL_SECS )) ]] && [[ ! -z "$GC_LOGS_FILE" ]]; then
+    cp ${GC_LOGS_FILE} ${GC_STATS_FILE}
+    LAST_GC=${NOW}
+  fi
+
+  # Thread dump
+  if [[ "$NOW" -ge $(( $LAST_THREAD + $THREAD_DUMP_INTERVAL_SECS )) ]]; then
+    THREAD_FILE="${THREAD_DUMP_FOLDER}/thread-dump-${NOW_FILESYSTEM}"
+    jcmd ${PROCESS_IDENTIFIER} Thread.print > ${THREAD_FILE}
+    LAST_THREAD=${NOW}
+    echo "${NOW_HUMAN} - Thread dump saved to: $THREAD_FILE"
+  fi
+
+  # Heap dump
+  if [[ "$NOW" -ge $(( $LAST_HEAP + $HEAP_DUMP_INTERVAL_SECS )) ]]; then
+    HEAP_FILE="${HEAP_DUMP_FOLDER}/heap-dump-${NOW_FILESYSTEM}.hprof"
+    jcmd ${PROCESS_IDENTIFIER} GC.heap_dump ${HEAP_FILE}
+    LAST_HEAP=${NOW}
+    echo "${NOW_HUMAN} - Heap dump saved to: $HEAP_FILE"
+  fi
+}
+
+while sleep 1; do tick; done


### PR DESCRIPTION
The guava cache used internally wasn’t cleaning (releasing references to) the expired entries properly, resulting in excessive memory overhead.

This PR also increases the size of the cache but reduces the last used expiration window.

I also added some tests to verify the expected behavior of the cache.