### PR TITLE
Lazy DatadogClassloader

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/DatadogClassLoader.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/DatadogClassLoader.java
@@ -33,27 +33,30 @@ public class DatadogClassLoader extends URLClassLoader {
   public DatadogClassLoader(
       final URL bootstrapJarLocation, final String internalJarFileName, final ClassLoader parent) {
     super(new URL[] {}, parent);
-    bootstrapProxy = new BootstrapClassLoaderProxy(new URL[] {bootstrapJarLocation});
 
-    if (internalJarFileName != null) { // some tests pass null
-      try {
-        // The fields of the URL are mostly dummy.  InternalJarURLHandler is the only important
-        // field.  If extending this class from Classloader instead of URLClassloader required less
-        // boilerplate it could be used and the need for dummy fields would be reduced
+    // some tests pass null
+    bootstrapProxy =
+        bootstrapJarLocation == null
+            ? new BootstrapClassLoaderProxy(new URL[0])
+            : new BootstrapClassLoaderProxy(new URL[] {bootstrapJarLocation});
 
-        final URL internalJarURL =
-            new URL(
-                "x-internal-jar",
-                null,
-                0,
-                "/",
-                new InternalJarURLHandler(internalJarFileName, bootstrapProxy));
+    try {
+      // The fields of the URL are mostly dummy.  InternalJarURLHandler is the only important
+      // field.  If extending this class from Classloader instead of URLClassloader required less
+      // boilerplate it could be used and the need for dummy fields would be reduced
 
-        addURL(internalJarURL);
-      } catch (final MalformedURLException e) {
-        // This can't happen with current URL constructor
-        log.error("URL malformed.  Unsupported JDK?", e);
-      }
+      final URL internalJarURL =
+          new URL(
+              "x-internal-jar",
+              null,
+              0,
+              "/",
+              new InternalJarURLHandler(internalJarFileName, bootstrapProxy));
+
+      addURL(internalJarURL);
+    } catch (final MalformedURLException e) {
+      // This can't happen with current URL constructor
+      log.error("URL malformed.  Unsupported JDK?", e);
     }
   }
 

--- a/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/UrlConnectionTest.groovy
+++ b/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/UrlConnectionTest.groovy
@@ -122,7 +122,7 @@ class UrlConnectionTest extends AgentTestRunner {
   def "DatadogClassloader ClassNotFoundException doesn't create span"() {
     given:
     ClassLoader datadogLoader = new DatadogClassLoader(null, null, null)
-    ClassLoader childLoader = new URLClassLoader(new URL[0], datadogLoader);
+    ClassLoader childLoader = new URLClassLoader(new URL[0], datadogLoader)
 
     when:
     runUnderTrace("someTrace") {

--- a/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/UrlConnectionTest.groovy
+++ b/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/UrlConnectionTest.groovy
@@ -1,6 +1,7 @@
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.Config
 import datadog.trace.api.DDSpanTypes
+import datadog.trace.bootstrap.DatadogClassLoader
 import datadog.trace.instrumentation.http_url_connection.UrlInstrumentation
 import io.opentracing.tag.Tags
 import io.opentracing.util.GlobalTracer
@@ -116,5 +117,34 @@ class UrlConnectionTest extends AgentTestRunner {
 
     where:
     renameService << [false, true]
+  }
+
+  def "DatadogClassloader ClassNotFoundException doesn't create span"() {
+    given:
+    ClassLoader datadogLoader = new DatadogClassLoader(null, null, null)
+    ClassLoader childLoader = new URLClassLoader(new URL[0], datadogLoader);
+
+    when:
+    runUnderTrace("someTrace") {
+      childLoader.loadClass("datadog.doesnotexist")
+    }
+
+    then:
+    thrown ClassNotFoundException
+
+    expect:
+    assertTraces(1) {
+      trace(0, 1) {
+        span(0) {
+          operationName "someTrace"
+          parent()
+          errored true
+          tags {
+            errorTags ClassNotFoundException, String
+            defaultTags()
+          }
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
This changes the `DatadogClassloader` to load classes on demand rather that loading all `byte[]`s at creation.

I also added a test for the span creation bug fixed in #952 .