### PR TITLE
Ensure injected modules can read helper class modules

### DIFF
--- a/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/ModuleInjectionTest.groovy
+++ b/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/ModuleInjectionTest.groovy
@@ -1,0 +1,21 @@
+import datadog.trace.agent.test.AgentTestRunner
+
+import javax.swing.*
+
+/**
+ * This class tests that we correctly add module references when instrumenting
+ */
+class ModuleInjectionTest extends AgentTestRunner {
+  /**
+   * There's nothing special about RepaintManager other than
+   * it's in a module (java.desktop) that doesn't read the "unnamed module" and it
+   * creates an instrumented runnable in its constructor
+   */
+  def "test instrumenting java.desktop class"() {
+    when:
+    RepaintManager repaintManager = new RepaintManager()
+
+    then:
+    noExceptionThrown()
+  }
+}


### PR DESCRIPTION
This fixes the bug where instrumented classes could not read helper classes because they belonged to a different module (Java 9+).

It creates a *read edge* from the instrumented class's module to the helper class's module.