### PR TITLE
Change packaging of internal jars

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/DatadogClassLoader.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/DatadogClassLoader.java
@@ -51,7 +51,7 @@ public class DatadogClassLoader extends URLClassLoader {
               null,
               0,
               "/",
-              new InternalJarURLHandler(internalJarFileName, bootstrapProxy));
+              new InternalJarURLHandler(internalJarFileName, bootstrapJarLocation));
 
       addURL(internalJarURL);
     } catch (final MalformedURLException e) {

--- a/dd-java-agent/dd-java-agent.gradle
+++ b/dd-java-agent/dd-java-agent.gradle
@@ -26,13 +26,12 @@ def includeShadowJar(subproject, jarname) {
   def agent_project = project
   subproject.afterEvaluate {
     agent_project.processResources {
-      from(subproject.tasks.shadowJar)
-      rename {
-        it.equals(subproject.shadowJar.archivePath.getName()) ?
-          jarname :
-          it
+      from(zipTree(subproject.tasks.shadowJar.archivePath)) {
+        into jarname
+        rename '(^.*)\\.class$', '$1.classdata'
       }
     }
+
     agent_project.processResources.dependsOn subproject.tasks.shadowJar
     subproject.shadowJar {
       classifier null
@@ -59,8 +58,8 @@ def includeShadowJar(subproject, jarname) {
   }
 }
 
-includeShadowJar(project(':dd-java-agent:instrumentation'), 'agent-tooling-and-instrumentation.jar.zip')
-includeShadowJar(project(':dd-java-agent:agent-jmxfetch'), 'agent-jmxfetch.jar.zip')
+includeShadowJar(project(':dd-java-agent:instrumentation'), 'agent-tooling-and-instrumentation.jar')
+includeShadowJar(project(':dd-java-agent:agent-jmxfetch'), 'agent-jmxfetch.jar')
 
 jar {
   classifier = 'unbundled'

--- a/dd-java-agent/dd-java-agent.gradle
+++ b/dd-java-agent/dd-java-agent.gradle
@@ -58,8 +58,8 @@ def includeShadowJar(subproject, jarname) {
   }
 }
 
-includeShadowJar(project(':dd-java-agent:instrumentation'), 'agent-tooling-and-instrumentation.jar')
-includeShadowJar(project(':dd-java-agent:agent-jmxfetch'), 'agent-jmxfetch.jar')
+includeShadowJar(project(':dd-java-agent:instrumentation'), 'agent-tooling-and-instrumentation.isolated')
+includeShadowJar(project(':dd-java-agent:agent-jmxfetch'), 'agent-jmxfetch.isolated')
 
 jar {
   classifier = 'unbundled'

--- a/dd-java-agent/src/main/java/datadog/trace/agent/TracingAgent.java
+++ b/dd-java-agent/src/main/java/datadog/trace/agent/TracingAgent.java
@@ -94,7 +94,7 @@ public class TracingAgent {
 
     if (AGENT_CLASSLOADER == null) {
       final ClassLoader agentClassLoader =
-          createDatadogClassLoader("agent-tooling-and-instrumentation.jar.zip", bootstrapURL);
+          createDatadogClassLoader("agent-tooling-and-instrumentation.jar", bootstrapURL);
       final ClassLoader contextLoader = Thread.currentThread().getContextClassLoader();
       try {
         Thread.currentThread().setContextClassLoader(agentClassLoader);
@@ -126,7 +126,7 @@ public class TracingAgent {
       throws Exception {
     if (JMXFETCH_CLASSLOADER == null) {
       final ClassLoader jmxFetchClassLoader =
-          createDatadogClassLoader("agent-jmxfetch.jar.zip", bootstrapURL);
+          createDatadogClassLoader("agent-jmxfetch.jar", bootstrapURL);
       final ClassLoader contextLoader = Thread.currentThread().getContextClassLoader();
       try {
         Thread.currentThread().setContextClassLoader(jmxFetchClassLoader);

--- a/dd-java-agent/src/main/java/datadog/trace/agent/TracingAgent.java
+++ b/dd-java-agent/src/main/java/datadog/trace/agent/TracingAgent.java
@@ -94,7 +94,7 @@ public class TracingAgent {
 
     if (AGENT_CLASSLOADER == null) {
       final ClassLoader agentClassLoader =
-          createDatadogClassLoader("agent-tooling-and-instrumentation.jar", bootstrapURL);
+          createDatadogClassLoader("agent-tooling-and-instrumentation.isolated", bootstrapURL);
       final ClassLoader contextLoader = Thread.currentThread().getContextClassLoader();
       try {
         Thread.currentThread().setContextClassLoader(agentClassLoader);
@@ -126,7 +126,7 @@ public class TracingAgent {
       throws Exception {
     if (JMXFETCH_CLASSLOADER == null) {
       final ClassLoader jmxFetchClassLoader =
-          createDatadogClassLoader("agent-jmxfetch.jar", bootstrapURL);
+          createDatadogClassLoader("agent-jmxfetch.isolated", bootstrapURL);
       final ClassLoader contextLoader = Thread.currentThread().getContextClassLoader();
       try {
         Thread.currentThread().setContextClassLoader(jmxFetchClassLoader);


### PR DESCRIPTION
The changes in #934 created an additional memory overhead of ~30MB because all internal jar files were kept in an in-memory map.  

With this pull request, only the `JarEntry` objects are kept in memory by packaging internal jars in their expanded state under a subfolder.

The `.class` extension has been changed to `.classdata` to prevent accidental classpath pollution.