### PR TITLE
Run all tests on all java versions

### DIFF
--- a/dd-java-agent/dd-java-agent.gradle
+++ b/dd-java-agent/dd-java-agent.gradle
@@ -2,12 +2,6 @@ plugins {
   id "com.github.johnrengelman.shadow" version "4.0.4"
 }
 
-// Set properties before any plugins get loaded
-project.ext {
-  // Execute tests on all JVMs, even rare and outdated ones
-  integrationTests = true
-}
-
 description = 'dd-java-agent'
 
 apply from: "${rootDir}/gradle/java.gradle"

--- a/dd-java-agent/instrumentation/hibernate/core-3.3/core-3.3.gradle
+++ b/dd-java-agent/instrumentation/hibernate/core-3.3/core-3.3.gradle
@@ -5,13 +5,6 @@
  * instrumentation isn't able to reference it.
  */
 
-// Set properties before any plugins get loaded
-project.ext {
-  // Execute tests on all JVMs, even rare and outdated ones
-  coreJavaInstrumentation = true
-  minJavaVersionForTests = JavaVersion.VERSION_1_7
-}
-
 muzzle {
   pass {
     group = "org.hibernate"

--- a/dd-java-agent/instrumentation/hibernate/core-4.0/core-4.0.gradle
+++ b/dd-java-agent/instrumentation/hibernate/core-4.0/core-4.0.gradle
@@ -1,10 +1,3 @@
-// Set properties before any plugins get loaded
-project.ext {
-  // Execute tests on all JVMs, even rare and outdated ones
-  coreJavaInstrumentation = true
-  minJavaVersionForTests = JavaVersion.VERSION_1_7
-}
-
 muzzle {
   pass {
     group = "org.hibernate"

--- a/dd-java-agent/instrumentation/hibernate/core-4.3/core-4.3.gradle
+++ b/dd-java-agent/instrumentation/hibernate/core-4.3/core-4.3.gradle
@@ -1,10 +1,3 @@
-// Set properties before any plugins get loaded
-project.ext {
-  // Execute tests on all JVMs, even rare and outdated ones
-  coreJavaInstrumentation = true
-  minJavaVersionForTests = JavaVersion.VERSION_1_7
-}
-
 muzzle {
   pass {
     group = "org.hibernate"

--- a/dd-java-agent/instrumentation/http-url-connection/http-url-connection.gradle
+++ b/dd-java-agent/instrumentation/http-url-connection/http-url-connection.gradle
@@ -1,9 +1,3 @@
-// Set properties before any plugins get loaded
-project.ext {
-  // Execute tests on all JVMs, even rare and outdated ones
-  coreJavaInstrumentation = true
-}
-
 apply from: "${rootDir}/gradle/java.gradle"
 
 dependencies {

--- a/dd-java-agent/instrumentation/java-concurrent/akka-2.5-testing/akka-2.5-testing.gradle
+++ b/dd-java-agent/instrumentation/java-concurrent/akka-2.5-testing/akka-2.5-testing.gradle
@@ -1,8 +1,6 @@
 // Set properties before any plugins get loaded
 ext {
   minJavaVersionForTests = JavaVersion.VERSION_1_8
-  // Execute tests on all JVMs, even rare and outdated ones
-  coreJavaInstrumentation = true
 }
 
 apply from: "${rootDir}/gradle/java.gradle"

--- a/dd-java-agent/instrumentation/java-concurrent/akka-testing/akka-testing.gradle
+++ b/dd-java-agent/instrumentation/java-concurrent/akka-testing/akka-testing.gradle
@@ -1,9 +1,3 @@
-// Set properties before any plugins get loaded
-ext {
-  // Execute tests on all JVMs, even rare and outdated ones
-  coreJavaInstrumentation = true
-}
-
 apply from: "${rootDir}/gradle/java.gradle"
 apply from: "${rootDir}/gradle/test-with-scala.gradle"
 

--- a/dd-java-agent/instrumentation/java-concurrent/java-concurrent.gradle
+++ b/dd-java-agent/instrumentation/java-concurrent/java-concurrent.gradle
@@ -1,9 +1,3 @@
-// Set properties before any plugins get loaded
-project.ext {
-  // Execute tests on all JVMs, even rare and outdated ones
-  coreJavaInstrumentation = true
-}
-
 apply from: "${rootDir}/gradle/java.gradle"
 apply from: "${rootDir}/gradle/test-with-scala.gradle"
 apply from: "${rootDir}/gradle/test-with-kotlin.gradle"

--- a/dd-java-agent/instrumentation/java-concurrent/scala-testing/scala-testing.gradle
+++ b/dd-java-agent/instrumentation/java-concurrent/scala-testing/scala-testing.gradle
@@ -1,9 +1,3 @@
-// Set properties before any plugins get loaded
-project.ext {
-  // Execute tests on all JVMs, even rare and outdated ones
-  coreJavaInstrumentation = true
-}
-
 apply from: "${rootDir}/gradle/java.gradle"
 apply from: "${rootDir}/gradle/test-with-scala.gradle"
 

--- a/dd-java-agent/instrumentation/jdbc/jdbc.gradle
+++ b/dd-java-agent/instrumentation/jdbc/jdbc.gradle
@@ -1,9 +1,3 @@
-// Set properties before any plugins get loaded
-project.ext {
-  // Execute tests on all JVMs, even rare and outdated ones
-  coreJavaInstrumentation = true
-}
-
 apply from: "${rootDir}/gradle/java.gradle"
 
 apply plugin: 'org.unbroken-dome.test-sets'

--- a/dd-trace/src/test/groovy/datadog/trace/tracer/SpanImplTest.groovy
+++ b/dd-trace/src/test/groovy/datadog/trace/tracer/SpanImplTest.groovy
@@ -346,9 +346,9 @@ class SpanImplTest extends Specification {
   def "test JSON rendering with big ID values"() {
     setup: "create span"
     def parentContext = new SpanContextImpl(
-      new BigInteger(2).pow(64).subtract(1).toString(),
+      BigInteger.valueOf(2).pow(64).subtract(1).toString(),
       "123",
-      new BigInteger(2).pow(64).subtract(2).toString())
+      BigInteger.valueOf(2).pow(64).subtract(2).toString())
     def span = new SpanImpl(trace, parentContext, startTimestamp)
     span.finish()
 

--- a/dd-trace/src/test/groovy/datadog/trace/tracer/TracerTest.groovy
+++ b/dd-trace/src/test/groovy/datadog/trace/tracer/TracerTest.groovy
@@ -7,6 +7,7 @@ import datadog.trace.tracer.writer.AgentWriter
 import datadog.trace.tracer.writer.SampleRateByService
 import datadog.trace.tracer.writer.Writer
 import datadog.trace.util.gc.GCUtils
+import spock.lang.Requires
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -14,6 +15,7 @@ import java.lang.ref.WeakReference
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 
+@Requires({ !System.getProperty("java.vm.name").contains("IBM J9 VM") })
 class TracerTest extends Specification {
 
   @Shared

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -255,22 +255,6 @@ def isJdkForced(String javaName) {
   return (project.hasProperty('forceJdk') && project.getProperty('forceJdk').contains(javaName))
 }
 
-// JVM names we would like to run complete test suite on
-// Note: complete test suite is always run on JVM used for compilation
-// Note2: apparently there is no way to have a 'global' variable, so instead we have per project
-// attribute that has same value in all projects
-project.ext.majorSupportedJVMs = ["7", "11"]
-
-def isTestingEnabled(String javaName) {
-  if (javaName in project.majorSupportedJVMs) {
-    return true
-  }
-  if (project.findProperty("coreJavaInstrumentation") || project.findProperty("integrationTests")) {
-    return true
-  }
-  return false
-}
-
 // Disable default test tasks if current JVM doesn't match version requirements
 tasks.withType(Test).configureEach {
   if (name.endsWith("Generated")) {
@@ -326,7 +310,7 @@ for (def env : System.getenv().entrySet()) {
         jvmArgs '-XX:CompileCommand=exclude,net.bytebuddy.description.type.TypeDescription$Generic$Visitor$Substitutor::onParameterizedType'
       }
 
-      onlyIf { (isJavaVersionAllowed(javaVersion) && isTestingEnabled(javaName)) || isJdkForced(javaName) }
+      onlyIf { isJavaVersionAllowed(javaVersion) || isJdkForced(javaName) }
       if (applyCodeCoverage) {
         jacoco {
           // Disable jacoco for additional JVM tests to speed things up a bit


### PR DESCRIPTION
Enables all tests on all jdk platforms unless:
* `minJavaVersionForTests` or `maxJavaVersionForTests` is specified in Gradle
* `@Requires` is specified in the test file

Previously, all tests were only run on Java 7, Java 11, and OpenJDK 8.  Only a small subset of tests were run on other jdks ( java 9, java 10, zulu 8, ibm 8, java 12).

Enabling everything has had no adverse affect on CircleCI workflow duration because of how jobs are run in parallel.