### PR TITLE
Ensure "client" spans do not set the language tag

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/decorator/ServerDecorator.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/decorator/ServerDecorator.java
@@ -1,8 +1,8 @@
 package datadog.trace.agent.decorator;
 
+import datadog.trace.api.Config;
 import io.opentracing.Span;
 import io.opentracing.tag.Tags;
-import datadog.trace.api.Config;
 
 public abstract class ServerDecorator extends BaseDecorator {
 

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/decorator/ServerDecorator.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/decorator/ServerDecorator.java
@@ -2,6 +2,7 @@ package datadog.trace.agent.decorator;
 
 import io.opentracing.Span;
 import io.opentracing.tag.Tags;
+import datadog.trace.api.Config;
 
 public abstract class ServerDecorator extends BaseDecorator {
 
@@ -9,6 +10,7 @@ public abstract class ServerDecorator extends BaseDecorator {
   public Span afterStart(final Span span) {
     assert span != null;
     Tags.SPAN_KIND.set(span, Tags.SPAN_KIND_SERVER);
+    span.setTag(Config.LANGUAGE_TAG_KEY, Config.LANGUAGE_TAG_VALUE);
     return super.afterStart(span);
   }
 }

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/decorator/ServerDecoratorTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/decorator/ServerDecoratorTest.groovy
@@ -1,5 +1,6 @@
 package datadog.trace.agent.decorator
 
+import datadog.trace.api.Config
 import datadog.trace.api.DDTags
 import io.opentracing.Span
 import io.opentracing.tag.Tags
@@ -14,6 +15,7 @@ class ServerDecoratorTest extends BaseDecoratorTest {
     decorator.afterStart(span)
 
     then:
+    1 * span.setTag(Config.LANGUAGE_TAG_KEY, Config.LANGUAGE_TAG_VALUE)
     1 * span.setTag(Tags.COMPONENT.key, "test-component")
     1 * span.setTag(Tags.SPAN_KIND.key, "server")
     1 * span.setTag(DDTags.SPAN_TYPE, decorator.spanType())

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/TagsAssert.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/TagsAssert.groovy
@@ -4,6 +4,7 @@ import datadog.opentracing.DDSpan
 import datadog.trace.api.Config
 import groovy.transform.stc.ClosureParams
 import groovy.transform.stc.SimpleType
+import io.opentracing.tag.Tags
 
 import java.util.regex.Pattern
 
@@ -39,11 +40,18 @@ class TagsAssert {
 
     assert tags["thread.name"] != null
     assert tags["thread.id"] != null
-    if ("0" == spanParentId || distributedRootSpan) {
+
+    boolean isRoot = ("0" == spanParentId)
+    if (isRoot || distributedRootSpan) {
       assert tags[Config.RUNTIME_ID_TAG] == Config.get().runtimeId
-      assert tags[Config.LANGUAGE_TAG_KEY] == Config.LANGUAGE_TAG_VALUE
     } else {
       assert tags[Config.RUNTIME_ID_TAG] == null
+    }
+
+    boolean isServer = (tags[Tags.SPAN_KIND.key] == Tags.SPAN_KIND_SERVER)
+    if (isRoot || distributedRootSpan || isServer) {
+      assert tags[Config.LANGUAGE_TAG_KEY] == Config.LANGUAGE_TAG_VALUE
+    } else {
       assert tags[Config.LANGUAGE_TAG_KEY] == null
     }
   }

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/TagsAssert.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/TagsAssert.groovy
@@ -41,6 +41,8 @@ class TagsAssert {
     assert tags["thread.name"] != null
     assert tags["thread.id"] != null
 
+    // FIXME: DQH - Too much conditional logic?  Maybe create specialized methods for client & server cases
+
     boolean isRoot = ("0" == spanParentId)
     if (isRoot || distributedRootSpan) {
       assert tags[Config.RUNTIME_ID_TAG] == Config.get().runtimeId

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/server/http/TestHttpServer.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/server/http/TestHttpServer.groovy
@@ -5,6 +5,7 @@ import datadog.trace.agent.test.asserts.ListWriterAssert
 import io.opentracing.SpanContext
 import io.opentracing.Tracer
 import io.opentracing.propagation.Format
+import io.opentracing.tag.Tags
 import io.opentracing.util.GlobalTracer
 import org.eclipse.jetty.http.HttpMethods
 import org.eclipse.jetty.server.Handler
@@ -104,6 +105,7 @@ class TestHttpServer implements AutoCloseable {
           childOf(parentSpan)
         }
         tags {
+          "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
           defaultTags(parentSpan != null)
         }
       }
@@ -235,6 +237,7 @@ class TestHttpServer implements AutoCloseable {
           tracer.extract(Format.Builtin.HTTP_HEADERS, new HttpServletRequestExtractAdapter(req))
         def builder = tracer
           .buildSpan("test-http-server")
+          .withTag(Tags.SPAN_KIND.key, Tags.SPAN_KIND_SERVER)
         if (extractedContext != null) {
           builder.asChildOf(extractedContext)
         }

--- a/dd-trace-api/src/main/java/datadog/trace/api/Config.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/Config.java
@@ -1,5 +1,9 @@
 package datadog.trace.api;
 
+import lombok.Getter;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -20,9 +24,6 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.UUID;
 import java.util.regex.Pattern;
-import lombok.Getter;
-import lombok.ToString;
-import lombok.extern.slf4j.Slf4j;
 
 /**
  * Config reads values with the following priority: 1) system properties, 2) environment variables,
@@ -463,9 +464,9 @@ public class Config {
    * Returns the sample rate for the specified instrumentation or {@link
    * #DEFAULT_ANALYTICS_SAMPLE_RATE} if none specified.
    */
-  public float getInstrumentationAnalyticsSampleRate(String... aliases) {
+  public float getInstrumentationAnalyticsSampleRate(final String... aliases) {
     for (final String alias : aliases) {
-      Float rate = getFloatSettingFromEnvironment(alias + ".analytics.sample-rate", null);
+      final Float rate = getFloatSettingFromEnvironment(alias + ".analytics.sample-rate", null);
       if (null != rate) {
         return rate;
       }
@@ -724,7 +725,7 @@ public class Config {
    * @param setting The setting name, e.g. `service.name`
    * @return The public facing system property name
    */
-  private static String propertyNameToSystemPropertyName(String setting) {
+  private static String propertyNameToSystemPropertyName(final String setting) {
     return PREFIX + setting;
   }
 
@@ -905,18 +906,18 @@ public class Config {
         configurationFilePath.replaceFirst("^~", System.getProperty("user.home"));
 
     // Configuration properties file is optional
-    File configurationFile = new File(configurationFilePath);
+    final File configurationFile = new File(configurationFilePath);
     if (!configurationFile.exists()) {
       log.error("Configuration file '{}' not found.", configurationFilePath);
       return properties;
     }
 
     try {
-      FileReader fileReader = new FileReader(configurationFile);
+      final FileReader fileReader = new FileReader(configurationFile);
       properties.load(fileReader);
-    } catch (FileNotFoundException fnf) {
+    } catch (final FileNotFoundException fnf) {
       log.error("Configuration file '{}' not found.", configurationFilePath);
-    } catch (IOException ioe) {
+    } catch (final IOException ioe) {
       log.error(
           "Configuration file '{}' cannot be accessed or correctly parsed.", configurationFilePath);
     }

--- a/dd-trace-api/src/main/java/datadog/trace/api/Config.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/Config.java
@@ -1,9 +1,5 @@
 package datadog.trace.api;
 
-import lombok.Getter;
-import lombok.ToString;
-import lombok.extern.slf4j.Slf4j;
-
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -24,6 +20,9 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.UUID;
 import java.util.regex.Pattern;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Config reads values with the following priority: 1) system properties, 2) environment variables,

--- a/dd-trace-api/src/main/java/datadog/trace/api/Config.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/Config.java
@@ -424,6 +424,7 @@ public class Config {
   public Map<String, String> getLocalRootSpanTags() {
     final Map<String, String> runtimeTags = getRuntimeTags();
     final Map<String, String> result = new HashMap<>(runtimeTags);
+    result.put(LANGUAGE_TAG_KEY, LANGUAGE_TAG_VALUE);
 
     if (reportHostName) {
       final String hostName = getHostName();
@@ -484,7 +485,6 @@ public class Config {
   private Map<String, String> getRuntimeTags() {
     final Map<String, String> result = newHashMap(2);
     result.put(RUNTIME_ID_TAG, runtimeId);
-    result.put(LANGUAGE_TAG_KEY, LANGUAGE_TAG_VALUE);
     return Collections.unmodifiableMap(result);
   }
 

--- a/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -23,8 +23,6 @@ import static datadog.trace.api.Config.JMX_FETCH_REFRESH_BEANS_PERIOD
 import static datadog.trace.api.Config.JMX_FETCH_STATSD_HOST
 import static datadog.trace.api.Config.JMX_FETCH_STATSD_PORT
 import static datadog.trace.api.Config.JMX_TAGS
-import static datadog.trace.api.Config.LANGUAGE_TAG_KEY
-import static datadog.trace.api.Config.LANGUAGE_TAG_VALUE
 import static datadog.trace.api.Config.PARTIAL_FLUSH_MIN_SPANS
 import static datadog.trace.api.Config.PREFIX
 import static datadog.trace.api.Config.PRIORITY_SAMPLING

--- a/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -76,7 +76,7 @@ class ConfigTest extends Specification {
     config.traceResolverEnabled == true
     config.serviceMapping == [:]
     config.mergedSpanTags == [:]
-    config.mergedJmxTags == [(RUNTIME_ID_TAG): config.getRuntimeId(), (SERVICE): config.serviceName, (LANGUAGE_TAG_KEY): LANGUAGE_TAG_VALUE]
+    config.mergedJmxTags == [(RUNTIME_ID_TAG): config.getRuntimeId(), (SERVICE): config.serviceName]
     config.headerTags == [:]
     config.httpServerErrorStatuses == (500..599).toSet()
     config.httpClientErrorStatuses == (400..499).toSet()
@@ -150,7 +150,7 @@ class ConfigTest extends Specification {
     config.traceResolverEnabled == false
     config.serviceMapping == [a: "1"]
     config.mergedSpanTags == [b: "2", c: "3"]
-    config.mergedJmxTags == [b: "2", d: "4", (RUNTIME_ID_TAG): config.getRuntimeId(), (SERVICE): config.serviceName, (LANGUAGE_TAG_KEY): LANGUAGE_TAG_VALUE]
+    config.mergedJmxTags == [b: "2", d: "4", (RUNTIME_ID_TAG): config.getRuntimeId(), (SERVICE): config.serviceName]
     config.headerTags == [e: "5"]
     config.httpServerErrorStatuses == (122..457).toSet()
     config.httpClientErrorStatuses == (111..111).toSet()
@@ -215,7 +215,7 @@ class ConfigTest extends Specification {
     config.traceResolverEnabled == false
     config.serviceMapping == [a: "1"]
     config.mergedSpanTags == [b: "2", c: "3"]
-    config.mergedJmxTags == [b: "2", d: "4", (RUNTIME_ID_TAG): config.getRuntimeId(), (SERVICE): config.serviceName, (LANGUAGE_TAG_KEY): LANGUAGE_TAG_VALUE]
+    config.mergedJmxTags == [b: "2", d: "4", (RUNTIME_ID_TAG): config.getRuntimeId(), (SERVICE): config.serviceName]
     config.headerTags == [e: "5"]
     config.httpServerErrorStatuses == (122..457).toSet()
     config.httpClientErrorStatuses == (111..111).toSet()
@@ -405,7 +405,7 @@ class ConfigTest extends Specification {
     config.traceResolverEnabled == false
     config.serviceMapping == [a: "1"]
     config.mergedSpanTags == [b: "2", c: "3"]
-    config.mergedJmxTags == [b: "2", d: "4", (RUNTIME_ID_TAG): config.getRuntimeId(), (SERVICE): config.serviceName, (LANGUAGE_TAG_KEY): LANGUAGE_TAG_VALUE]
+    config.mergedJmxTags == [b: "2", d: "4", (RUNTIME_ID_TAG): config.getRuntimeId(), (SERVICE): config.serviceName]
     config.headerTags == [e: "5"]
     config.httpServerErrorStatuses == (122..457).toSet()
     config.httpClientErrorStatuses == (111..111).toSet()


### PR DESCRIPTION
The core changes are in Config and ServerDecorator.

Moved default tagging from Config::getRuntimeTags to Config::getLocalRootSpanTags.  This changes the result of Config::getMergedJmxTags as well.

To preserve language for servers changed ServerDecorator::afterStart.

Other changes are in tests - the most complicated part is in TagsAssert::defaultTags.  This now contains a bit too much conditional logic for my liking.