### PR TITLE
Apply fixed default operation name for @Trace generated spans

### DIFF
--- a/dd-java-agent/instrumentation/akka-http-10.0/src/lagomTest/groovy/LagomTest.groovy
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/lagomTest/groovy/LagomTest.groovy
@@ -26,13 +26,13 @@ class LagomTest extends AgentTestRunner {
       .withCassandra(false)
       .withJdbc(false)
       .configureBuilder(
-      new Function<GuiceApplicationBuilder, GuiceApplicationBuilder>() {
-        @Override
-        GuiceApplicationBuilder apply(GuiceApplicationBuilder builder) {
-          return builder
-            .bindings(new ServiceTestModule())
-        }
-      }))
+        new Function<GuiceApplicationBuilder, GuiceApplicationBuilder>() {
+          @Override
+          GuiceApplicationBuilder apply(GuiceApplicationBuilder builder) {
+            return builder
+              .bindings(new ServiceTestModule())
+          }
+        }))
   }
 
   def cleanupSpec() {
@@ -75,7 +75,8 @@ class LagomTest extends AgentTestRunner {
         }
         span(1) {
           childOf span(0)
-          operationName 'EchoServiceImpl.tracedMethod'
+          operationName 'trace.annotation'
+          resourceName 'EchoServiceImpl.tracedMethod'
         }
       }
     }

--- a/dd-java-agent/instrumentation/hystrix-1.4/src/test/groovy/HystrixObservableChainTest.groovy
+++ b/dd-java-agent/instrumentation/hystrix-1.4/src/test/groovy/HystrixObservableChainTest.groovy
@@ -99,7 +99,7 @@ class HystrixObservableChainTest extends AgentTestRunner {
         }
         span(2) {
           serviceName "unnamed-java-app"
-          operationName "HystrixObservableChainTest\$2.tracedMethod"
+          operationName "trace.annotation"
           resourceName "HystrixObservableChainTest\$2.tracedMethod"
           spanType null
           childOf span(1)
@@ -126,7 +126,7 @@ class HystrixObservableChainTest extends AgentTestRunner {
         }
         span(4) {
           serviceName "unnamed-java-app"
-          operationName "HystrixObservableChainTest\$1.tracedMethod"
+          operationName "trace.annotation"
           resourceName "HystrixObservableChainTest\$1.tracedMethod"
           spanType null
           childOf span(3)

--- a/dd-java-agent/instrumentation/hystrix-1.4/src/test/groovy/HystrixObservableTest.groovy
+++ b/dd-java-agent/instrumentation/hystrix-1.4/src/test/groovy/HystrixObservableTest.groovy
@@ -91,7 +91,7 @@ class HystrixObservableTest extends AgentTestRunner {
         }
         span(2) {
           serviceName "unnamed-java-app"
-          operationName "HystrixObservableTest\$1.tracedMethod"
+          operationName "trace.annotation"
           resourceName "HystrixObservableTest\$1.tracedMethod"
           spanType null
           childOf span(1)

--- a/dd-java-agent/instrumentation/hystrix-1.4/src/test/groovy/HystrixTest.groovy
+++ b/dd-java-agent/instrumentation/hystrix-1.4/src/test/groovy/HystrixTest.groovy
@@ -71,7 +71,7 @@ class HystrixTest extends AgentTestRunner {
         }
         span(2) {
           serviceName "unnamed-java-app"
-          operationName "HystrixTest\$1.tracedMethod"
+          operationName "trace.annotation"
           resourceName "HystrixTest\$1.tracedMethod"
           spanType null
           childOf span(1)

--- a/dd-java-agent/instrumentation/java-concurrent/akka-testing/src/test/groovy/AkkaActorTest.groovy
+++ b/dd-java-agent/instrumentation/java-concurrent/akka-testing/src/test/groovy/AkkaActorTest.groovy
@@ -14,7 +14,7 @@ class AkkaActorTest extends AgentTestRunner {
     expect:
     TEST_WRITER.size() == 1
     trace.size() == 2
-    trace[0].getOperationName() == "AkkaActors.$testMethod"
+    trace[0].resourceName == "AkkaActors.$testMethod"
     findSpan(trace, "$expectedGreeting, Akka").context().getParentId() == trace[0].getSpanId()
 
     where:

--- a/dd-java-agent/instrumentation/java-concurrent/kotlin-testing/src/test/groovy/KotlinCoroutineInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/java-concurrent/kotlin-testing/src/test/groovy/KotlinCoroutineInstrumentationTest.groovy
@@ -9,7 +9,7 @@ class KotlinCoroutineInstrumentationTest extends AgentTestRunner {
     Dispatchers.Default,
     Dispatchers.IO,
     Dispatchers.Unconfined,
-    ThreadPoolDispatcherKt.newFixedThreadPoolContext(2,"Fixed-Thread-Pool"),
+    ThreadPoolDispatcherKt.newFixedThreadPoolContext(2, "Fixed-Thread-Pool"),
     ThreadPoolDispatcherKt.newSingleThreadContext("Single-Thread"),
   ]
 
@@ -22,7 +22,7 @@ class KotlinCoroutineInstrumentationTest extends AgentTestRunner {
 
     expect:
     trace.size() == expectedNumberOfSpans
-    trace[0].operationName == "KotlinCoroutineTests.tracedAcrossChannels"
+    trace[0].resourceName == "KotlinCoroutineTests.tracedAcrossChannels"
     findSpan(trace, "produce_2").context().getParentId() == trace[0].context().getSpanId()
     findSpan(trace, "consume_2").context().getParentId() == trace[0].context().getSpanId()
 
@@ -39,7 +39,7 @@ class KotlinCoroutineInstrumentationTest extends AgentTestRunner {
 
     expect:
     trace.size() == expectedNumberOfSpans
-    trace[0].operationName == "KotlinCoroutineTests.tracePreventedByCancellation"
+    trace[0].resourceName == "KotlinCoroutineTests.tracePreventedByCancellation"
     findSpan(trace, "preLaunch").context().getParentId() == trace[0].context().getSpanId()
     findSpan(trace, "postLaunch") == null
 
@@ -56,7 +56,7 @@ class KotlinCoroutineInstrumentationTest extends AgentTestRunner {
 
     expect:
     trace.size() == expectedNumberOfSpans
-    trace[0].operationName == "KotlinCoroutineTests.tracedAcrossThreadsWithNested"
+    trace[0].resourceName == "KotlinCoroutineTests.tracedAcrossThreadsWithNested"
     findSpan(trace, "nested").context().getParentId() == trace[0].context().getSpanId()
 
     where:
@@ -73,7 +73,7 @@ class KotlinCoroutineInstrumentationTest extends AgentTestRunner {
     expect:
     TEST_WRITER.size() == 1
     trace.size() == expectedNumberOfSpans
-    trace[0].operationName == "KotlinCoroutineTests.traceWithDeferred"
+    trace[0].resourceName == "KotlinCoroutineTests.traceWithDeferred"
     findSpan(trace, "keptPromise").context().getParentId() == trace[0].context().getSpanId()
     findSpan(trace, "keptPromise2").context().getParentId() == trace[0].context().getSpanId()
     findSpan(trace, "brokenPromise").context().getParentId() == trace[0].context().getSpanId()

--- a/dd-java-agent/instrumentation/java-concurrent/scala-testing/src/test/groovy/ScalaInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/java-concurrent/scala-testing/src/test/groovy/ScalaInstrumentationTest.groovy
@@ -12,7 +12,7 @@ class ScalaInstrumentationTest extends AgentTestRunner {
 
     expect:
     trace.size() == expectedNumberOfSpans
-    trace[0].operationName == "ScalaConcurrentTests.traceWithFutureAndCallbacks"
+    trace[0].resourceName == "ScalaConcurrentTests.traceWithFutureAndCallbacks"
     findSpan(trace, "goodFuture").context().getParentId() == trace[0].context().getSpanId()
     findSpan(trace, "badFuture").context().getParentId() == trace[0].context().getSpanId()
     findSpan(trace, "successCallback").context().getParentId() == trace[0].context().getSpanId()
@@ -28,7 +28,7 @@ class ScalaInstrumentationTest extends AgentTestRunner {
 
     expect:
     trace.size() == expectedNumberOfSpans
-    trace[0].operationName == "ScalaConcurrentTests.tracedAcrossThreadsWithNoTrace"
+    trace[0].resourceName == "ScalaConcurrentTests.tracedAcrossThreadsWithNoTrace"
     findSpan(trace, "callback").context().getParentId() == trace[0].context().getSpanId()
   }
 
@@ -42,7 +42,7 @@ class ScalaInstrumentationTest extends AgentTestRunner {
     expect:
     TEST_WRITER.size() == 1
     trace.size() == expectedNumberOfSpans
-    trace[0].operationName == "ScalaConcurrentTests.traceWithPromises"
+    trace[0].resourceName == "ScalaConcurrentTests.traceWithPromises"
     findSpan(trace, "keptPromise").context().getParentId() == trace[0].context().getSpanId()
     findSpan(trace, "keptPromise2").context().getParentId() == trace[0].context().getSpanId()
     findSpan(trace, "brokenPromise").context().getParentId() == trace[0].context().getSpanId()

--- a/dd-java-agent/instrumentation/java-concurrent/scala-testing/src/test/scala/ScalaAsyncChild.java
+++ b/dd-java-agent/instrumentation/java-concurrent/scala-testing/src/test/scala/ScalaAsyncChild.java
@@ -54,6 +54,6 @@ public class ScalaAsyncChild extends ForkJoinTask implements Runnable, Callable 
     }
   }
 
-  @Trace(operationName = "asyncChild")
+  @Trace(operationName = "asyncChild", resourceName = "asyncChild")
   private void asyncChild() {}
 }

--- a/dd-java-agent/instrumentation/java-concurrent/src/slickTest/groovy/SlickTest.groovy
+++ b/dd-java-agent/instrumentation/java-concurrent/src/slickTest/groovy/SlickTest.groovy
@@ -18,8 +18,8 @@ class SlickTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 2) {
         span(0) {
-          operationName "SlickUtils.startQuery"
           serviceName "unnamed-java-app"
+          operationName "trace.annotation"
           resourceName "SlickUtils.startQuery"
           parent()
           errored false

--- a/dd-java-agent/instrumentation/reactor-core-3.1/src/test/groovy/ReactorCoreTest.groovy
+++ b/dd-java-agent/instrumentation/reactor-core-3.1/src/test/groovy/ReactorCoreTest.groovy
@@ -201,7 +201,7 @@ class ReactorCoreTest extends AgentTestRunner {
     "basic flux" | Flux.fromIterable([5, 6])
   }
 
-  @Trace(operationName = "trace-parent")
+  @Trace(operationName = "trace-parent", resourceName = "trace-parent")
   def runUnderTrace(def publisher) {
     // This is important sequence of events:
     // We have a 'trace-parent' that covers whole span and then we have publisher-parent that overs only
@@ -221,7 +221,7 @@ class ReactorCoreTest extends AgentTestRunner {
     throw new RuntimeException("Unknown publisher: " + publisher)
   }
 
-  @Trace(operationName = "trace-parent")
+  @Trace(operationName = "trace-parent", resourceName = "trace-parent")
   def cancelUnderTrace(def publisher) {
     final Scope scope = GlobalTracer.get().buildSpan("publisher-parent").startActive(true)
     publisher = ReactorCoreAdviceUtils.setPublisherSpan(publisher, scope.span())
@@ -232,15 +232,18 @@ class ReactorCoreTest extends AgentTestRunner {
         subscription.cancel()
       }
 
-      void onNext(Integer t) {}
+      void onNext(Integer t) {
+      }
 
-      void onError(Throwable error) {}
+      void onError(Throwable error) {
+      }
 
-      void onComplete() {}
+      void onComplete() {
+      }
     })
   }
 
-  @Trace(operationName = "addOne")
+  @Trace(operationName = "addOne", resourceName = "addOne")
   def static addOneFunc(int i) {
     return i + 1
   }

--- a/dd-java-agent/instrumentation/spring-webflux/src/test/groovy/SpringWebfluxTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webflux/src/test/groovy/SpringWebfluxTest.groovy
@@ -172,11 +172,11 @@ class SpringWebfluxTest extends AgentTestRunner {
           if (annotatedMethod == null) {
             // Functional API
             resourceName "SpringWebFluxTestApplication.tracedMethod"
-            operationName "SpringWebFluxTestApplication.tracedMethod"
+            operationName "trace.annotation"
           } else {
             // Annotation API
             resourceName "TestController.tracedMethod"
-            operationName "TestController.tracedMethod"
+            operationName "trace.annotation"
           }
           childOf(span(0))
           errored false

--- a/dd-java-agent/instrumentation/spring-webflux/src/test/groovy/dd/trace/instrumentation/springwebflux/server/EchoHandler.groovy
+++ b/dd-java-agent/instrumentation/spring-webflux/src/test/groovy/dd/trace/instrumentation/springwebflux/server/EchoHandler.groovy
@@ -13,7 +13,7 @@ import reactor.core.publisher.Mono
  */
 @Component
 class EchoHandler {
-  @Trace(operationName = "echo")
+  @Trace(operationName = "echo", resourceName = "echo")
   Mono<ServerResponse> echo(ServerRequest request) {
     return ServerResponse.accepted().contentType(MediaType.TEXT_PLAIN)
       .body(request.bodyToMono(String), String)

--- a/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceAdvice.java
+++ b/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceAdvice.java
@@ -11,21 +11,23 @@ import java.lang.reflect.Method;
 import net.bytebuddy.asm.Advice;
 
 public class TraceAdvice {
+  private static final String DEFAULT_OPERATION_NAME = "trace.annotation";
 
   @Advice.OnMethodEnter(suppress = Throwable.class)
   public static Scope startSpan(@Advice.Origin final Method method) {
     final Trace traceAnnotation = method.getAnnotation(Trace.class);
     String operationName = traceAnnotation == null ? null : traceAnnotation.operationName();
     if (operationName == null || operationName.isEmpty()) {
-      operationName = DECORATE.spanNameForMethod(method);
+      operationName = DEFAULT_OPERATION_NAME;
     }
 
     Tracer.SpanBuilder spanBuilder = GlobalTracer.get().buildSpan(operationName);
 
-    final String resourceName = traceAnnotation == null ? null : traceAnnotation.resourceName();
-    if (resourceName != null && !resourceName.isEmpty()) {
-      spanBuilder = spanBuilder.withTag(DDTags.RESOURCE_NAME, resourceName);
+    String resourceName = traceAnnotation == null ? null : traceAnnotation.resourceName();
+    if (resourceName == null || resourceName.isEmpty()) {
+      resourceName = DECORATE.spanNameForMethod(method);
     }
+    spanBuilder = spanBuilder.withTag(DDTags.RESOURCE_NAME, resourceName);
 
     return DECORATE.afterStart(spanBuilder.startActive(true));
   }

--- a/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/ConfiguredTraceAnnotationsTest.groovy
+++ b/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/ConfiguredTraceAnnotationsTest.groovy
@@ -39,7 +39,7 @@ class ConfiguredTraceAnnotationsTest extends AgentTestRunner {
       trace(0, 1) {
         span(0) {
           resourceName "AnnotationTracedCallable.call"
-          operationName "AnnotationTracedCallable.call"
+          operationName "trace.annotation"
         }
       }
     }

--- a/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/TraceAnnotationsTest.groovy
+++ b/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/TraceAnnotationsTest.groovy
@@ -26,7 +26,7 @@ class TraceAnnotationsTest extends AgentTestRunner {
         span(0) {
           serviceName "test"
           resourceName "SayTracedHello.sayHello"
-          operationName "SayTracedHello.sayHello"
+          operationName "trace.annotation"
           parent()
           errored false
           tags {
@@ -48,7 +48,7 @@ class TraceAnnotationsTest extends AgentTestRunner {
       trace(0, 1) {
         span(0) {
           serviceName "test"
-          resourceName "SAY_HA"
+          resourceName "SayTracedHello.sayHA"
           operationName "SAY_HA"
           spanType "DB"
           parent()
@@ -73,7 +73,7 @@ class TraceAnnotationsTest extends AgentTestRunner {
         span(0) {
           serviceName "test"
           resourceName "WORLD"
-          operationName "SayTracedHello.sayHelloOnlyResourceSet"
+          operationName "trace.annotation"
           parent()
           errored false
           tags {
@@ -118,7 +118,7 @@ class TraceAnnotationsTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 3) {
         span(0) {
-          resourceName "NEW_TRACE"
+          resourceName "SayTracedHello.sayHELLOsayHA"
           operationName "NEW_TRACE"
           parent()
           errored false
@@ -128,7 +128,7 @@ class TraceAnnotationsTest extends AgentTestRunner {
           }
         }
         span(1) {
-          resourceName "SAY_HA"
+          resourceName "SayTracedHello.sayHA"
           operationName "SAY_HA"
           spanType "DB"
           childOf span(0)
@@ -141,7 +141,7 @@ class TraceAnnotationsTest extends AgentTestRunner {
         span(2) {
           serviceName "test"
           resourceName "SayTracedHello.sayHello"
-          operationName "SayTracedHello.sayHello"
+          operationName "trace.annotation"
           childOf span(0)
           errored false
           tags {
@@ -172,7 +172,7 @@ class TraceAnnotationsTest extends AgentTestRunner {
           }
         }
         span(1) {
-          resourceName "SAY_HA"
+          resourceName "SayTracedHello.sayHA"
           operationName "SAY_HA"
           spanType "DB"
           childOf span(0)
@@ -185,7 +185,7 @@ class TraceAnnotationsTest extends AgentTestRunner {
         span(2) {
           serviceName "test"
           resourceName "SayTracedHello.sayHello"
-          operationName "SayTracedHello.sayHello"
+          operationName "trace.annotation"
           childOf span(0)
           errored false
           tags {
@@ -229,7 +229,7 @@ class TraceAnnotationsTest extends AgentTestRunner {
         span(2) {
           serviceName "test"
           resourceName "SayTracedHello.sayHello"
-          operationName "SayTracedHello.sayHello"
+          operationName "trace.annotation"
           childOf span(0)
           errored false
           tags {
@@ -257,7 +257,7 @@ class TraceAnnotationsTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          resourceName "ERROR"
+          resourceName "SayTracedHello.sayERROR"
           operationName "ERROR"
           errored true
           tags {
@@ -309,7 +309,7 @@ class TraceAnnotationsTest extends AgentTestRunner {
       trace(0, 1) {
         span(0) {
           resourceName "SayTracedHello\$1.call"
-          operationName "SayTracedHello\$1.call"
+          operationName "trace.annotation"
         }
       }
     }
@@ -330,12 +330,12 @@ class TraceAnnotationsTest extends AgentTestRunner {
       trace(0, 1) {
         span(0) {
           resourceName "SayTracedHello\$1.call"
-          operationName "SayTracedHello\$1.call"
+          operationName "trace.annotation"
         }
         trace(1, 1) {
           span(0) {
             resourceName "TraceAnnotationsTest\$1.call"
-            operationName "TraceAnnotationsTest\$1.call"
+            operationName "trace.annotation"
           }
         }
       }

--- a/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/TraceConfigTest.groovy
+++ b/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/TraceConfigTest.groovy
@@ -37,7 +37,7 @@ class TraceConfigTest extends AgentTestRunner {
       trace(0, 1) {
         span(0) {
           resourceName "ConfigTracedCallable.call"
-          operationName "ConfigTracedCallable.call"
+          operationName "trace.annotation"
         }
       }
     }


### PR DESCRIPTION
This should help reduce issues with multiple top level spans.