### PR TITLE
Fix span error tagging in grpc server interceptor

### DIFF
--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/GrpcServerBuilderInstrumentation.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/GrpcServerBuilderInstrumentation.java
@@ -31,6 +31,7 @@ public class GrpcServerBuilderInstrumentation extends Instrumenter.Default {
   public String[] helperClassNames() {
     return new String[] {
       "datadog.trace.instrumentation.grpc.server.TracingServerInterceptor",
+      "datadog.trace.instrumentation.grpc.server.TracingServerInterceptor$TracingServerCall",
       "datadog.trace.instrumentation.grpc.server.TracingServerInterceptor$TracingServerCallListener",
       "datadog.trace.agent.decorator.BaseDecorator",
       "datadog.trace.agent.decorator.ServerDecorator",

--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/GrpcServerDecorator.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/GrpcServerDecorator.java
@@ -2,6 +2,9 @@ package datadog.trace.instrumentation.grpc.server;
 
 import datadog.trace.agent.decorator.ServerDecorator;
 import datadog.trace.api.DDSpanTypes;
+import io.grpc.Status;
+import io.opentracing.Span;
+import io.opentracing.tag.Tags;
 
 public class GrpcServerDecorator extends ServerDecorator {
   public static final GrpcServerDecorator DECORATE = new GrpcServerDecorator();
@@ -19,5 +22,18 @@ public class GrpcServerDecorator extends ServerDecorator {
   @Override
   protected String component() {
     return "grpc-server";
+  }
+
+  public Span onClose(final Span span, final Status status) {
+
+    span.setTag("status.code", status.getCode().name());
+    span.setTag("status.description", status.getDescription());
+
+    onError(span, status.getCause());
+    if (!status.isOk()) {
+      Tags.ERROR.set(span, true);
+    }
+
+    return span;
   }
 }

--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/TracingServerInterceptor.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/TracingServerInterceptor.java
@@ -7,10 +7,10 @@ import datadog.trace.context.TraceScope;
 import io.grpc.ForwardingServerCall;
 import io.grpc.ForwardingServerCallListener;
 import io.grpc.Metadata;
-import io.grpc.Status;
 import io.grpc.ServerCall;
 import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
+import io.grpc.Status;
 import io.opentracing.Scope;
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
@@ -64,7 +64,8 @@ public class TracingServerInterceptor implements ServerInterceptor {
     try {
       // Wrap the server call so that we can decorate the span
       // with the resulting status
-      TracingServerCall<ReqT, RespT> tracingServerCall = new TracingServerCall<>(tracer, span, call);
+      TracingServerCall<ReqT, RespT> tracingServerCall =
+          new TracingServerCall<>(tracer, span, call);
 
       // call other interceptors
       result = next.startCall(tracingServerCall, headers);
@@ -85,11 +86,12 @@ public class TracingServerInterceptor implements ServerInterceptor {
   }
 
   static final class TracingServerCall<ReqT, RespT>
-    extends ForwardingServerCall.SimpleForwardingServerCall<ReqT, RespT> {
+      extends ForwardingServerCall.SimpleForwardingServerCall<ReqT, RespT> {
     final Tracer tracer;
     final Span span;
 
-    TracingServerCall(final Tracer tracer, final Span span, final ServerCall<ReqT, RespT> delegate) {
+    TracingServerCall(
+        final Tracer tracer, final Span span, final ServerCall<ReqT, RespT> delegate) {
       super(delegate);
       this.tracer = tracer;
       this.span = span;
@@ -98,7 +100,6 @@ public class TracingServerInterceptor implements ServerInterceptor {
     @Override
     public void close(final Status status, final Metadata trailers) {
       DECORATE.onClose(span, status);
-      // Finishes span.
       try (final Scope scope = tracer.scopeManager().activate(span, false)) {
         if (scope instanceof TraceScope) {
           ((TraceScope) scope).setAsyncPropagation(true);
@@ -112,7 +113,6 @@ public class TracingServerInterceptor implements ServerInterceptor {
         throw e;
       }
     }
-
   }
 
   static final class TracingServerCallListener<ReqT>
@@ -214,7 +214,6 @@ public class TracingServerInterceptor implements ServerInterceptor {
         span.finish();
       }
     }
-
 
     @Override
     public void onReady() {

--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/TracingServerInterceptor.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/TracingServerInterceptor.java
@@ -62,8 +62,11 @@ public class TracingServerInterceptor implements ServerInterceptor {
 
     final ServerCall.Listener<ReqT> result;
     try {
-      // call other interceptors
+      // Wrap the server call so that we can decorate the span
+      // with the resulting status
       TracingServerCall<ReqT, RespT> tracingServerCall = new TracingServerCall<>(tracer, span, call);
+
+      // call other interceptors
       result = next.startCall(tracingServerCall, headers);
     } catch (final Throwable e) {
       DECORATE.onError(span, e);
@@ -107,9 +110,6 @@ public class TracingServerInterceptor implements ServerInterceptor {
       } catch (final Throwable e) {
         DECORATE.onError(span, e);
         throw e;
-      } finally {
-        DECORATE.beforeFinish(span);
-        span.finish();
       }
     }
 

--- a/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcStreamingTest.groovy
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcStreamingTest.groovy
@@ -91,6 +91,7 @@ class GrpcStreamingTest extends AgentTestRunner {
           childOf trace(1).get(0)
           errored false
           tags {
+            "status.code" "OK"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
             "$Tags.COMPONENT.key" "grpc-server"
             defaultTags(true)

--- a/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcTest.groovy
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcTest.groovy
@@ -136,10 +136,18 @@ class GrpcTest extends AgentTestRunner {
           resourceName "example.Greeter/SayHello"
           spanType DDSpanTypes.RPC
           childOf trace(1).get(0)
-          errored false
+          errored true
           tags {
+            "status.code" "${status.code.name()}"
+            "status.description" description
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
             "$Tags.COMPONENT.key" "grpc-server"
+            if(status.cause != null){
+              "error.msg" status.cause.message
+              "error.type" status.cause.class.canonicalName
+              "error.stack" String
+            }
+            tag "error", true
             defaultTags(true)
           }
         }

--- a/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcTest.groovy
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcTest.groovy
@@ -47,6 +47,7 @@ class GrpcTest extends AgentTestRunner {
           childOf trace(1).get(0)
           errored false
           tags {
+            "status.code" "OK"
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
             "$Tags.COMPONENT.key" "grpc-server"
             defaultTags(true)
@@ -143,11 +144,10 @@ class GrpcTest extends AgentTestRunner {
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
             "$Tags.COMPONENT.key" "grpc-server"
             if(status.cause != null){
-              "error.msg" status.cause.message
-              "error.type" status.cause.class.canonicalName
-              "error.stack" String
+              errorTags status.cause.class, status.cause.message
+            }else{
+              tag "error", true
             }
-            tag "error", true
             defaultTags(true)
           }
         }


### PR DESCRIPTION
At the moment there is a discrepancy with how spans are tagged in the client interceptor vs the server interceptor. This PR is meant to synchronize the behavior between the two. 

