### PR TITLE
Remove synchronization from RateByServiceSampler

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/ClassLoaderMatcher.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/ClassLoaderMatcher.java
@@ -150,9 +150,14 @@ public class ClassLoaderMatcher {
     @Override
     public boolean matches(final ClassLoader target) {
       if (target != null) {
+        Boolean result = cache.get(target);
+        if (result != null) {
+          return result;
+        }
         synchronized (target) {
-          if (cache.containsKey(target)) {
-            return cache.get(target);
+          result = cache.get(target);
+          if (result != null) {
+            return result;
           }
           for (final String name : names) {
             if (target.getResource(Utils.getResourceName(name)) == null) {
@@ -184,9 +189,14 @@ public class ClassLoaderMatcher {
     @Override
     public boolean matches(final ClassLoader target) {
       if (target != null) {
+        Boolean result = cache.get(target);
+        if (result != null) {
+          return result;
+        }
         synchronized (target) {
-          if (cache.containsKey(target)) {
-            return cache.get(target);
+          result = cache.get(target);
+          if (result != null) {
+            return result;
           }
           try {
             final Class<?> aClass = Class.forName(className, false, target);
@@ -225,9 +235,14 @@ public class ClassLoaderMatcher {
     @Override
     public boolean matches(final ClassLoader target) {
       if (target != null) {
+        Boolean result = cache.get(target);
+        if (result != null) {
+          return result;
+        }
         synchronized (target) {
-          if (cache.containsKey(target)) {
-            return cache.get(target);
+          result = cache.get(target);
+          if (result != null) {
+            return result;
           }
           try {
             final Class<?> aClass = Class.forName(className, false, target);

--- a/dd-trace-ot/src/main/java/datadog/trace/common/sampling/RateByServiceSampler.java
+++ b/dd-trace-ot/src/main/java/datadog/trace/common/sampling/RateByServiceSampler.java
@@ -8,6 +8,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -122,7 +123,7 @@ public class RateByServiceSampler implements Sampler, ResponseListener {
 
     @Override
     public boolean doSample(final DDSpan span) {
-      final boolean sample = Math.random() <= sampleRate;
+      final boolean sample = ThreadLocalRandom.current().nextFloat() <= sampleRate;
       log.debug("{} - Span is sampled: {}", span, sample);
       return sample;
     }

--- a/dd-trace-ot/src/main/java/datadog/trace/common/sampling/RateByServiceSampler.java
+++ b/dd-trace-ot/src/main/java/datadog/trace/common/sampling/RateByServiceSampler.java
@@ -90,9 +90,10 @@ public class RateByServiceSampler implements Sampler, ResponseListener {
           log.debug("Unable to parse new service rate {} -> {}", key, value);
         }
       }
-      if (!updatedServiceRates.isEmpty()) {
-        serviceRates = unmodifiableMap(updatedServiceRates);
+      if (!updatedServiceRates.containsKey(DEFAULT_KEY)) {
+        updatedServiceRates.put(DEFAULT_KEY, new RateSampler(DEFAULT_RATE));
       }
+      serviceRates = unmodifiableMap(updatedServiceRates);
     }
   }
 
@@ -107,16 +108,12 @@ public class RateByServiceSampler implements Sampler, ResponseListener {
     /** The sample rate used */
     private final double sampleRate;
 
-    public RateSampler(final String sampleRate) {
-      this(sampleRate == null ? 1 : Double.valueOf(sampleRate));
-    }
-
     /**
      * Build an instance of the sampler. The Sample rate is fixed for each instance.
      *
      * @param sampleRate a number [0,1] representing the rate ratio.
      */
-    public RateSampler(double sampleRate) {
+    private RateSampler(double sampleRate) {
 
       if (sampleRate < 0) {
         sampleRate = 1;

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/DDSpanTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/DDSpanTest.groovy
@@ -1,8 +1,11 @@
 package datadog.opentracing
 
+
+import com.fasterxml.jackson.databind.ObjectMapper
 import datadog.opentracing.propagation.ExtractedContext
 import datadog.opentracing.propagation.TagContext
 import datadog.trace.agent.test.utils.ConfigUtils
+import datadog.trace.api.DDTags
 import datadog.trace.api.sampling.PrioritySampling
 import datadog.trace.common.sampling.RateByServiceSampler
 import datadog.trace.common.writer.ListWriter
@@ -20,10 +23,16 @@ class DDSpanTest extends Specification {
   }
 
   def writer = new ListWriter()
-  def tracer = new DDTracer(DEFAULT_SERVICE_NAME, writer, new RateByServiceSampler(), [:])
+  def sampler = new RateByServiceSampler()
+  def tracer = new DDTracer(DEFAULT_SERVICE_NAME, writer, sampler, [:])
 
   @Shared
   def defaultSamplingPriority = PrioritySampling.SAMPLER_KEEP
+
+  def setup() {
+    sampler.onResponse("test", new ObjectMapper()
+      .readTree('{"rate_by_service":{"service:,env:":1.0,"service:spock,env:":0.0}}'))
+  }
 
   def "getters and setters"() {
     setup:
@@ -254,8 +263,29 @@ class DDSpanTest extends Specification {
     new ExtractedContext("123", "456", 1, "789", [:], [:]) | false
   }
 
-  def "setting forced tracing via tag"() {
+  def "sampling priority set on init"() {
+    setup:
+    def span = tracer.buildSpan("test").start()
 
+    expect:
+    span.getSamplingPriority() == PrioritySampling.SAMPLER_KEEP
+
+    when:
+    span.setTag(DDTags.SERVICE_NAME, "spock")
+
+    then:
+    // FIXME: priority currently only applies if service name set before span started.
+    span.getSamplingPriority() == PrioritySampling.SAMPLER_KEEP
+//    span.getSamplingPriority() == PrioritySampling.SAMPLER_DROP
+
+    when:
+    span = tracer.buildSpan("test").withTag(DDTags.SERVICE_NAME, "spock").start()
+
+    then:
+    span.getSamplingPriority() == PrioritySampling.SAMPLER_DROP
+  }
+
+  def "setting forced tracing via tag"() {
     setup:
     def span = tracer.buildSpan("root").start()
     if (tagName) {

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/decorators/SpanDecoratorTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/decorators/SpanDecoratorTest.groovy
@@ -19,6 +19,7 @@ import static java.util.Collections.emptyMap
 
 class SpanDecoratorTest extends Specification {
   static {
+    ConfigUtils.makeConfigInstanceModifiable()
     ConfigUtils.updateConfig {
       System.setProperty("dd.$Config.SPLIT_BY_TAGS", "sn.tag1,sn.tag2")
     }

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/propagation/HttpExtractorTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/propagation/HttpExtractorTest.groovy
@@ -1,5 +1,6 @@
 package datadog.opentracing.propagation
 
+import datadog.trace.agent.test.utils.ConfigUtils
 import datadog.trace.api.Config
 import io.opentracing.SpanContext
 import io.opentracing.propagation.TextMapExtractAdapter
@@ -11,6 +12,9 @@ import static datadog.trace.api.Config.PropagationStyle.B3
 import static datadog.trace.api.Config.PropagationStyle.DATADOG
 
 class HttpExtractorTest extends Specification {
+  static {
+    ConfigUtils.makeConfigInstanceModifiable()
+  }
 
   @Shared
   String outOfRangeTraceId = UINT64_MAX.add(BigInteger.ONE)

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/propagation/HttpInjectorTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/propagation/HttpInjectorTest.groovy
@@ -3,6 +3,7 @@ package datadog.opentracing.propagation
 import datadog.opentracing.DDSpanContext
 import datadog.opentracing.DDTracer
 import datadog.opentracing.PendingTrace
+import datadog.trace.agent.test.utils.ConfigUtils
 import datadog.trace.api.Config
 import datadog.trace.api.sampling.PrioritySampling
 import datadog.trace.common.writer.ListWriter
@@ -13,6 +14,9 @@ import static datadog.trace.api.Config.PropagationStyle.B3
 import static datadog.trace.api.Config.PropagationStyle.DATADOG
 
 class HttpInjectorTest extends Specification {
+  static {
+    ConfigUtils.makeConfigInstanceModifiable()
+  }
 
   def "inject http headers"() {
     setup:

--- a/dd-trace-ot/src/test/groovy/datadog/trace/api/sampling/RateByServiceSamplerTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/trace/api/sampling/RateByServiceSamplerTest.groovy
@@ -35,22 +35,20 @@ class RateByServiceSamplerTest extends Specification {
     ObjectMapper serializer = new ObjectMapper()
 
     when:
-    String response = '{"rate_by_service": {"service:,env:":1.0, "service:spock,env:test":0.000001}}'
+    String response = '{"rate_by_service": {"service:spock,env:test":0.0}}'
     serviceSampler.onResponse("traces", serializer.readTree(response))
     DDSpan span1 = SpanFactory.newSpanOf("foo", "bar")
     serviceSampler.initializeSamplingPriority(span1)
     then:
     span1.getSamplingPriority() == PrioritySampling.SAMPLER_KEEP
     serviceSampler.sample(span1)
-    // !serviceSampler.sample(SpanFactory.newSpanOf("spock", "test"))
 
     when:
-    response = '{"rate_by_service": {"service:,env:":0.000001, "service:spock,env:test":1.0}}'
+    response = '{"rate_by_service": {"service:spock,env:test":1.0}}'
     serviceSampler.onResponse("traces", serializer.readTree(response))
     DDSpan span2 = SpanFactory.newSpanOf("spock", "test")
     serviceSampler.initializeSamplingPriority(span2)
     then:
-    // !serviceSampler.sample(SpanFactory.newSpanOf("foo", "bar"))
     span2.getSamplingPriority() == PrioritySampling.SAMPLER_KEEP
     serviceSampler.sample(span2)
   }

--- a/dd-trace-ot/src/test/groovy/datadog/trace/api/sampling/RateByServiceSamplerTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/trace/api/sampling/RateByServiceSamplerTest.groovy
@@ -6,6 +6,8 @@ import datadog.opentracing.SpanFactory
 import datadog.trace.common.sampling.RateByServiceSampler
 import spock.lang.Specification
 
+import static datadog.trace.common.sampling.RateByServiceSampler.DEFAULT_KEY
+
 class RateByServiceSamplerTest extends Specification {
 
   def "invalid rate -> 1"() {
@@ -15,7 +17,7 @@ class RateByServiceSamplerTest extends Specification {
     String response = '{"rate_by_service": {"service:,env:":' + rate + '}}'
     serviceSampler.onResponse("traces", serializer.readTree(response))
     expect:
-    serviceSampler.baseSampler.sampleRate == expectedRate
+    serviceSampler.serviceRates[DEFAULT_KEY].sampleRate == expectedRate
 
     where:
     rate | expectedRate

--- a/dd-trace-ot/src/test/groovy/datadog/trace/api/sampling/RateByServiceSamplerTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/trace/api/sampling/RateByServiceSamplerTest.groovy
@@ -21,7 +21,7 @@ class RateByServiceSamplerTest extends Specification {
     rate | expectedRate
     null | 1
     1    | 1
-    0    | 1
+    0    | 0.0
     -5   | 1
     5    | 1
     0.5  | 0.5


### PR DESCRIPTION
This change avoids lock contention in a hot code path.

I also added double check locking in ClassLoaderMatcher to reduce the need of locking there.