### PR TITLE
Avoid deep nesting in DDSpanContext.setTag

### DIFF
--- a/dd-trace-ot/src/main/java/datadog/opentracing/DDSpanContext.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/DDSpanContext.java
@@ -268,9 +268,6 @@ public class DDSpanContext implements io.opentracing.SpanContext {
     return baggageItems;
   }
 
-  /* (non-Javadoc)
-   * @see io.opentracing.SpanContext#baggageItems()
-   */
   @Override
   public Iterable<Map.Entry<String, String>> baggageItems() {
     return baggageItems.entrySet();
@@ -331,6 +328,15 @@ public class DDSpanContext implements io.opentracing.SpanContext {
     }
 
     if (addTag) {
+      tags.put(tag, value);
+    }
+  }
+
+  /** Internal method used by decorators, should not ever be called from outside. */
+  public void setTagInternal(final String tag, final Object value) {
+    if (value == null || (value instanceof String && ((String) value).isEmpty())) {
+      tags.remove(tag);
+    } else {
       tags.put(tag, value);
     }
   }

--- a/dd-trace-ot/src/main/java/datadog/opentracing/decorators/AbstractDecorator.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/decorators/AbstractDecorator.java
@@ -17,12 +17,12 @@ public abstract class AbstractDecorator {
   private String replacementValue;
 
   public boolean shouldSetTag(final DDSpanContext context, final String tag, final Object value) {
-    if (this.getMatchingValue() == null || this.getMatchingValue().equals(value)) {
+    if (getMatchingValue() == null || getMatchingValue().equals(value)) {
       final String targetTag = getReplacementTag() == null ? tag : getReplacementTag();
       final String targetValue =
           getReplacementValue() == null ? String.valueOf(value) : getReplacementValue();
 
-      context.setTag(targetTag, targetValue);
+      context.setTagInternal(targetTag, targetValue);
       return false;
     } else {
       return true;
@@ -34,7 +34,7 @@ public abstract class AbstractDecorator {
   }
 
   public void setMatchingTag(final String tag) {
-    this.matchingTag = tag;
+    matchingTag = tag;
   }
 
   public Object getMatchingValue() {
@@ -42,7 +42,7 @@ public abstract class AbstractDecorator {
   }
 
   public void setMatchingValue(final Object value) {
-    this.matchingValue = value;
+    matchingValue = value;
   }
 
   public String getReplacementTag() {
@@ -50,7 +50,7 @@ public abstract class AbstractDecorator {
   }
 
   public void setReplacementTag(final String targetTag) {
-    this.replacementTag = targetTag;
+    replacementTag = targetTag;
   }
 
   public String getReplacementValue() {
@@ -58,6 +58,6 @@ public abstract class AbstractDecorator {
   }
 
   public void setReplacementValue(final String targetValue) {
-    this.replacementValue = targetValue;
+    replacementValue = targetValue;
   }
 }

--- a/dd-trace-ot/src/main/java/datadog/opentracing/decorators/DBStatementAsResourceName.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/decorators/DBStatementAsResourceName.java
@@ -8,8 +8,8 @@ public class DBStatementAsResourceName extends AbstractDecorator {
 
   public DBStatementAsResourceName() {
     super();
-    this.setMatchingTag(Tags.DB_STATEMENT.getKey());
-    this.setReplacementTag(DDTags.RESOURCE_NAME);
+    setMatchingTag(Tags.DB_STATEMENT.getKey());
+    setReplacementTag(DDTags.RESOURCE_NAME);
   }
 
   @Override
@@ -29,7 +29,7 @@ public class DBStatementAsResourceName extends AbstractDecorator {
       // by the Datadog Trace Agent as `sql.query`; here we're removing
       // a duplicate that will not be obfuscated with the current Datadog
       // Trace Agent version.
-      context.setTag(Tags.DB_STATEMENT.getKey(), null);
+      context.setTagInternal(Tags.DB_STATEMENT.getKey(), null);
       return false;
     }
     return true;

--- a/dd-trace-ot/src/main/java/datadog/opentracing/decorators/Status5XXDecorator.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/decorators/Status5XXDecorator.java
@@ -7,14 +7,14 @@ import io.opentracing.tag.Tags;
 public class Status5XXDecorator extends AbstractDecorator {
   public Status5XXDecorator() {
     super();
-    this.setMatchingTag(Tags.HTTP_STATUS.getKey());
+    setMatchingTag(Tags.HTTP_STATUS.getKey());
   }
 
   @Override
   public boolean shouldSetTag(final DDSpanContext context, final String tag, final Object value) {
     final int responseCode = Integer.parseInt(value.toString());
     if (500 <= responseCode && responseCode < 600) {
-      context.setTag(Tags.ERROR.getKey(), true);
+      context.setTagInternal(Tags.ERROR.getKey(), true);
     }
     return true;
   }


### PR DESCRIPTION
It looks like in some cases we may iterate over decorators many-many times.