### PR TITLE
Avoid unnecessary objects creation in Apache Http Client instrumnentation

### DIFF
--- a/dd-java-agent/instrumentation/apache-httpclient-4/src/main/java/datadog/trace/instrumentation/apachehttpclient/ApacheHttpClientDecorator.java
+++ b/dd-java-agent/instrumentation/apache-httpclient-4/src/main/java/datadog/trace/instrumentation/apachehttpclient/ApacheHttpClientDecorator.java
@@ -2,9 +2,7 @@ package datadog.trace.instrumentation.apachehttpclient;
 
 import datadog.trace.agent.decorator.HttpClientDecorator;
 import java.net.URI;
-import java.net.URISyntaxException;
 import org.apache.http.HttpResponse;
-import org.apache.http.RequestLine;
 import org.apache.http.client.methods.HttpUriRequest;
 
 public class ApacheHttpClientDecorator extends HttpClientDecorator<HttpUriRequest, HttpResponse> {
@@ -22,13 +20,12 @@ public class ApacheHttpClientDecorator extends HttpClientDecorator<HttpUriReques
 
   @Override
   protected String method(final HttpUriRequest httpRequest) {
-    return httpRequest.getRequestLine().getMethod();
+    return httpRequest.getMethod();
   }
 
   @Override
-  protected URI url(final HttpUriRequest request) throws URISyntaxException {
-    final RequestLine requestLine = request.getRequestLine();
-    return requestLine == null ? null : new URI(requestLine.getUri());
+  protected URI url(final HttpUriRequest request) {
+    return request.getURI();
   }
 
   @Override


### PR DESCRIPTION
This covers both Sync and Async versions.