### PR TITLE
Reduce overhead of URLAsResourceName decorator

### DIFF
--- a/dd-java-agent/instrumentation/akka-http-10.0/src/lagomTest/groovy/LagomTest.groovy
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/lagomTest/groovy/LagomTest.groovy
@@ -61,7 +61,7 @@ class LagomTest extends AgentTestRunner {
         span(0) {
           serviceName "unnamed-java-app"
           operationName "akka-http.request"
-          resourceName "GET ws://?/echo"
+          resourceName "GET /echo"
           spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
@@ -100,7 +100,7 @@ class LagomTest extends AgentTestRunner {
         span(0) {
           serviceName "unnamed-java-app"
           operationName "akka-http.request"
-          resourceName "GET ws://?/error"
+          resourceName "GET /error"
           spanType DDSpanTypes.HTTP_SERVER
           errored true
           tags {

--- a/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/UrlConnectionTest.groovy
+++ b/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/UrlConnectionTest.groovy
@@ -98,7 +98,7 @@ class UrlConnectionTest extends AgentTestRunner {
         span(1) {
           serviceName "unnamed-java-app"
           operationName "file.request"
-          resourceName "$url.path"
+          resourceName "file:$url.path"
           spanType DDSpanTypes.HTTP_CLIENT
           childOf span(0)
           errored true

--- a/dd-trace-ot/dd-trace-ot.gradle
+++ b/dd-trace-ot/dd-trace-ot.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "me.champeau.gradle.jmh" version "0.4.8"
+  id "me.champeau.gradle.jmh" version "0.5.0-rc-2"
 }
 
 description = 'dd-trace-ot'
@@ -54,27 +54,44 @@ dependencies {
 }
 
 jmh {
-  timeUnit = 'us' // Output time unit. Available time units are: [m, s, ms, us, ns].
-  benchmarkMode = ['thrpt', 'avgt']
-  timeOnIteration = '1s'
+//  include = [".*URLAsResourceNameBenchmark"]
+//  include = ['some regular expression'] // include pattern (regular expression) for benchmarks to be executed
+//  exclude = ['some regular expression'] // exclude pattern (regular expression) for benchmarks to be executed
   iterations = 1 // Number of measurement iterations to do.
-//  fork = 2 // How many times to forks a single benchmark. Use 0 to disable forking altogether
-  jvmArgs = []
-  failOnError = true // Should JMH fail immediately if any benchmark had experienced the unrecoverable error?
-  warmup = '2s' // Time to spend at each warmup iteration.
-  warmupIterations = 1 // Number of warmup iterations to do.
-//  warmupForks = 0 // How many warmup forks to make for a single benchmark. 0 to disable warmup forks.
-
-//  profilers = ['stack']
-  // Use profilers to collect additional data. Supported profilers: [cl, comp, gc, stack, perf, perfnorm, perfasm, xperf, xperfasm, hs_cl, hs_comp, hs_gc, hs_rt, hs_thr]
-
+  benchmarkMode = ['thrpt', 'avgt', 'ss']
+  // Benchmark mode. Available modes are: [Throughput/thrpt, AverageTime/avgt, SampleTime/sample, SingleShotTime/ss, All/all]
+  batchSize = 1
+  // Batch size: number of benchmark method calls per operation. (some benchmark modes can ignore this setting)
+  fork = 1 // How many times to forks a single benchmark. Use 0 to disable forking altogether
+  failOnError = false // Should JMH fail immediately if any benchmark had experienced the unrecoverable error?
+  forceGC = false // Should JMH force GC between iterations?
+//  jvm = 'myjvm' // Custom JVM to use when forking.
+//  jvmArgs = ['Custom JVM args to use when forking.']
+//  jvmArgsAppend = ['Custom JVM args to use when forking (append these)']
+//  jvmArgsPrepend =[ 'Custom JVM args to use when forking (prepend these)']
 //  humanOutputFile = project.file("${project.buildDir}/reports/jmh/human.txt") // human-readable output file
+//  resultsFile = project.file("${project.buildDir}/reports/jmh/results.txt") // results file
 //  operationsPerInvocation = 10 // Operations per invocation.
+//  benchmarkParameters =  [:] // Benchmark parameters.
+//  profilers = ['stack'] // Use profilers to collect additional data. Supported profilers: [cl, comp, gc, stack, perf, perfnorm, perfasm, xperf, xperfasm, hs_cl, hs_comp, hs_gc, hs_rt, hs_thr]
+  timeOnIteration = '1s' // Time to spend at each measurement iteration.
+//  resultFormat = 'CSV' // Result format type (one of CSV, JSON, NONE, SCSV, TEXT)
 //  synchronizeIterations = false // Synchronize iterations?
+//  threads = 2 // Number of worker threads to run with.
+//  threadGroups = [2,3,4] //Override thread group distribution for asymmetric benchmarks.
 //  timeout = '1s' // Timeout for benchmark iteration.
-//  includeTests = true
-  // Allows to include test sources into generate JMH jar, i.e. use it when benchmarks depend on the test classes.
+  timeUnit = 'us' // Output time unit. Available time units are: [m, s, ms, us, ns].
+//  verbosity = 'NORMAL' // Verbosity mode. Available modes are: [SILENT, NORMAL, EXTRA]
+  warmup = '2s' // Time to spend at each warmup iteration.
+//  warmupBatchSize = 10 // Warmup batch size: number of benchmark method calls per operation.
+  warmupForks = 1 // How many warmup forks to make for a single benchmark. 0 to disable warmup forks.
+  warmupIterations = 1 // Number of warmup iterations to do.
+//  warmupMode = 'INDI' // Warmup mode for warming up selected benchmarks. Warmup modes are: [INDI, BULK, BULK_INDI].
+//  warmupBenchmarks = ['.*Warmup'] // Warmup benchmarks to include in the run in addition to already selected. JMH will not measure these benchmarks, but only use them for the warmup.
 
-  duplicateClassesStrategy = 'fail'
-  jmhVersion = '1.19' // Specifies JMH version
+//  zip64 = true // Use ZIP64 format for bigger archives
+  jmhVersion = '1.21' // Specifies JMH version
+//  includeTests = true // Allows to include test sources into generate JMH jar, i.e. use it when benchmarks depend on the test classes.
+  duplicateClassesStrategy = 'warn'
+  // Strategy to apply when encountring duplicate classes during creation of the fat jar (i.e. while executing jmhJar task)
 }

--- a/dd-trace-ot/src/jmh/java/datadog/opentracing/decorators/URLAsResourceNameBenchmark.java
+++ b/dd-trace-ot/src/jmh/java/datadog/opentracing/decorators/URLAsResourceNameBenchmark.java
@@ -1,0 +1,34 @@
+package datadog.opentracing.decorators;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import datadog.opentracing.DDSpanContext;
+import datadog.opentracing.SpanFactory;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.slf4j.LoggerFactory;
+
+public class URLAsResourceNameBenchmark {
+  static {
+    ((Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME)).setLevel(Level.WARN);
+  }
+
+  @State(Scope.Benchmark)
+  public static class BenchmarkState {
+    private final AbstractDecorator base = new URLAsResourceName();
+
+    private final DDSpanContext ctx = SpanFactory.newSpanOf(0).context();
+  }
+
+  @Benchmark
+  public Object testPathOnly(final BenchmarkState state) {
+    return state.base.shouldSetTag(state.ctx, null, "/somepath/123/");
+  }
+
+  @Benchmark
+  public Object testFullUrl(final BenchmarkState state) {
+    return state.base.shouldSetTag(
+        state.ctx, null, "http://localhost:8080/somepath/123/?query=123#fragment");
+  }
+}

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/SpanFactory.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/SpanFactory.groovy
@@ -9,7 +9,7 @@ class SpanFactory {
     ConfigUtils.makeConfigInstanceModifiable()
   }
 
-  static newSpanOf(long timestampMicro, String threadName = Thread.currentThread().name) {
+  static DDSpan newSpanOf(long timestampMicro, String threadName = Thread.currentThread().name) {
     def writer = new ListWriter()
     def tracer = new DDTracer(writer)
     def currentThreadName = Thread.currentThread().getName()
@@ -33,7 +33,7 @@ class SpanFactory {
     return new DDSpan(timestampMicro, context)
   }
 
-  static newSpanOf(DDTracer tracer) {
+  static DDSpan newSpanOf(DDTracer tracer) {
     def context = new DDSpanContext(
       "1",
       "1",
@@ -52,7 +52,7 @@ class SpanFactory {
     return new DDSpan(1, context)
   }
 
-  static newSpanOf(PendingTrace trace) {
+  static DDSpan newSpanOf(PendingTrace trace) {
     def context = new DDSpanContext(
       trace.traceId,
       "1",


### PR DESCRIPTION
Using `new URL()` just to parse the path out was rather expensive.  This should improve the situation.