### PR TITLE
Flakey Tests: makeConfigInstanceModifiable and CleanerTest

### DIFF
--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/decorator/BaseDecoratorTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/decorator/BaseDecoratorTest.groovy
@@ -12,11 +12,6 @@ import spock.lang.Specification
 import static io.opentracing.log.Fields.ERROR_OBJECT
 
 class BaseDecoratorTest extends Specification {
-
-  static {
-    ConfigUtils.makeConfigInstanceModifiable()
-  }
-
   @Shared
   def decorator = newDecorator()
 

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/decorator/BaseDecoratorTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/decorator/BaseDecoratorTest.groovy
@@ -177,8 +177,10 @@ class BaseDecoratorTest extends Specification {
     dec.traceAnalyticsSampleRate == (Float) expectedRate
 
     cleanup:
-    System.clearProperty("dd.${integName}.analytics.enabled")
-    System.clearProperty("dd.${integName}.analytics.sample-rate")
+    ConfigUtils.updateConfig {
+      System.clearProperty("dd.${integName}.analytics.enabled")
+      System.clearProperty("dd.${integName}.analytics.sample-rate")
+    }
 
     where:
     enabled | integName | sampleRate | expectedEnabled | expectedRate

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/test/DefaultInstrumenterTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/test/DefaultInstrumenterTest.groovy
@@ -11,10 +11,6 @@ import org.junit.contrib.java.lang.system.RestoreSystemProperties
 import spock.lang.Specification
 
 class DefaultInstrumenterTest extends Specification {
-  static {
-    ConfigUtils.makeConfigInstanceModifiable()
-  }
-
   @Rule
   public final RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties()
   @Rule
@@ -99,8 +95,10 @@ class DefaultInstrumenterTest extends Specification {
 
   def "configure default env var as #value"() {
     setup:
-    environmentVariables.set("DD_INTEGRATIONS_ENABLED", value)
-    ConfigUtils.resetConfig()
+    ConfigUtils.updateConfig {
+      environmentVariables.set("DD_INTEGRATIONS_ENABLED", value)
+    }
+
     def target = new TestDefaultInstrumenter("test")
     target.instrument(new AgentBuilder.Default())
 

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/test/DefaultInstrumenterTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/test/DefaultInstrumenterTest.groovy
@@ -57,7 +57,9 @@ class DefaultInstrumenterTest extends Specification {
 
   def "default disabled can override to enabled"() {
     setup:
-    System.setProperty("dd.integration.test.enabled", "$enabled")
+    ConfigUtils.updateConfig {
+      System.setProperty("dd.integration.test.enabled", "$enabled")
+    }
     def target = new TestDefaultInstrumenter("test") {
       @Override
       protected boolean defaultEnabled() {
@@ -115,8 +117,10 @@ class DefaultInstrumenterTest extends Specification {
 
   def "configure sys prop enabled for #value when default is disabled"() {
     setup:
-    System.setProperty("dd.integrations.enabled", "false")
-    System.setProperty("dd.integration.${value}.enabled", "true")
+    ConfigUtils.updateConfig {
+      System.setProperty("dd.integrations.enabled", "false")
+      System.setProperty("dd.integration.${value}.enabled", "true")
+    }
     def target = new TestDefaultInstrumenter(name, altName)
     target.instrument(new AgentBuilder.Default())
 
@@ -137,8 +141,10 @@ class DefaultInstrumenterTest extends Specification {
 
   def "configure env var enabled for #value when default is disabled"() {
     setup:
-    environmentVariables.set("DD_INTEGRATIONS_ENABLED", "false")
-    environmentVariables.set("DD_INTEGRATION_${value}_ENABLED", "true")
+    ConfigUtils.updateConfig {
+      environmentVariables.set("DD_INTEGRATIONS_ENABLED", "false")
+      environmentVariables.set("DD_INTEGRATION_${value}_ENABLED", "true")
+    }
     def target = new TestDefaultInstrumenter(name, altName)
     target.instrument(new AgentBuilder.Default())
 

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/test/HelperInjectionTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/test/HelperInjectionTest.groovy
@@ -1,6 +1,6 @@
 package datadog.trace.agent.test
 
-import datadog.trace.agent.test.utils.ConfigUtils
+
 import datadog.trace.agent.tooling.AgentInstaller
 import datadog.trace.agent.tooling.HelperInjector
 import datadog.trace.agent.tooling.Utils
@@ -19,10 +19,6 @@ import static datadog.trace.agent.tooling.ClassLoaderMatcher.BOOTSTRAP_CLASSLOAD
 import static datadog.trace.util.gc.GCUtils.awaitGC
 
 class HelperInjectionTest extends Specification {
-  static {
-    ConfigUtils.makeConfigInstanceModifiable()
-  }
-
   @Timeout(10)
   def "helpers injected to non-delegating classloader"() {
     setup:

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/CleanerTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/CleanerTest.groovy
@@ -37,7 +37,7 @@ class CleanerTest extends Specification {
     cleaner.scheduleCleaning(target, action, 10, MILLISECONDS)
 
     then:
-    latch.await(100, MILLISECONDS)
+    latch.await(200, MILLISECONDS)
   }
 
   def "test canceling"() {

--- a/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/ConfiguredTraceAnnotationsTest.groovy
+++ b/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/ConfiguredTraceAnnotationsTest.groovy
@@ -15,8 +15,10 @@ class ConfiguredTraceAnnotationsTest extends AgentTestRunner {
     }
   }
 
-  def specCleanup() {
-    System.clearProperty("dd.trace.annotations")
+  def cleanupSpec() {
+    ConfigUtils.updateConfig {
+      System.clearProperty("dd.trace.annotations")
+    }
   }
 
   def "test disabled nr annotation"() {

--- a/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/TraceConfigTest.groovy
+++ b/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/TraceConfigTest.groovy
@@ -12,7 +12,7 @@ class TraceConfigTest extends AgentTestRunner {
     }
   }
 
-  def specCleanup() {
+  def cleanupSpec() {
     ConfigUtils.updateConfig {
       System.clearProperty("dd.trace.methods")
     }

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/AgentTestRunner.java
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/AgentTestRunner.java
@@ -7,7 +7,6 @@ import datadog.opentracing.DDSpan;
 import datadog.opentracing.DDTracer;
 import datadog.opentracing.PendingTrace;
 import datadog.trace.agent.test.asserts.ListWriterAssert;
-import datadog.trace.agent.test.utils.ConfigUtils;
 import datadog.trace.agent.test.utils.GlobalTracerUtils;
 import datadog.trace.agent.tooling.AgentInstaller;
 import datadog.trace.agent.tooling.Instrumenter;
@@ -85,8 +84,6 @@ public abstract class AgentTestRunner extends Specification {
 
     ((Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME)).setLevel(Level.WARN);
     ((Logger) LoggerFactory.getLogger("datadog")).setLevel(Level.DEBUG);
-
-    ConfigUtils.makeConfigInstanceModifiable();
 
     TEST_WRITER =
         new ListWriter() {

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/utils/ConfigUtils.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/utils/ConfigUtils.groovy
@@ -56,9 +56,9 @@ class ConfigUtils {
     // Sometime between Java8 and 12, Field.class was added to the fieldFilterMap of Reflection.class
     // so Field.getDeclaredField("modifiers") doesn't work.  This is a workaround
 
-    Method method = Class.class.getDeclaredMethod("getDeclaredFields0", Boolean.TYPE)
+    Method method = Class.getDeclaredMethod("getDeclaredFields0", Boolean.TYPE)
     method.setAccessible(true)
-    Field[] fields = (Field[]) method.invoke(Field.class, false)
+    Field[] fields = (Field[]) method.invoke(Field, false)
 
     for (Field field : fields) {
       if ("modifiers".equals(field.getName())) {

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/utils/ConfigUtils.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/utils/ConfigUtils.groovy
@@ -17,11 +17,7 @@ class ConfigUtils {
 
   @SneakyThrows
   synchronized static <T extends Object> Object withConfigOverride(final String name, final String value, final Callable<T> r) {
-    // Ensure the class was retransformed properly in AgentTestRunner.makeConfigInstanceModifiable()
-    assert Modifier.isPublic(ConfigInstance.FIELD.getModifiers())
-    assert Modifier.isStatic(ConfigInstance.FIELD.getModifiers())
-    assert Modifier.isVolatile(ConfigInstance.FIELD.getModifiers())
-    assert !Modifier.isFinal(ConfigInstance.FIELD.getModifiers())
+    makeConfigInstanceModifiable()
 
     def existingConfig = Config.get()
     Properties properties = new Properties()
@@ -44,23 +40,6 @@ class ConfigUtils {
   static updateConfig(final Callable r) {
     makeConfigInstanceModifiable()
     r.call()
-    resetConfig()
-  }
-
-  /**
-   * Reset the global configuration. Please note that Runtime ID is preserved to the pre-existing value.
-   */
-  static void resetConfig() {
-    // Ensure the class was re-transformed properly in AgentTestRunner.makeConfigInstanceModifiable()
-    assert Modifier.isPublic(ConfigInstance.FIELD.getModifiers())
-    assert Modifier.isStatic(ConfigInstance.FIELD.getModifiers())
-    assert Modifier.isVolatile(ConfigInstance.FIELD.getModifiers())
-    assert !Modifier.isFinal(ConfigInstance.FIELD.getModifiers())
-
-    assert Modifier.isPublic(ConfigInstance.RUNTIME_ID_FIELD.getModifiers())
-    assert !Modifier.isStatic(ConfigInstance.RUNTIME_ID_FIELD.getModifiers())
-    assert Modifier.isVolatile(ConfigInstance.RUNTIME_ID_FIELD.getModifiers())
-    assert !Modifier.isFinal(ConfigInstance.RUNTIME_ID_FIELD.getModifiers())
 
     def previousConfig = ConfigInstance.FIELD.get(null)
     def newConfig = new Config()
@@ -100,24 +79,26 @@ class ConfigUtils {
 
   private static void makeConfigInstanceModifiable() {
     if (isConfigInstanceModifiable) {
+      assertFieldState()
       return
     }
 
     changeModifiers(ConfigInstance.FIELD, Modifier.PUBLIC | Modifier.STATIC | Modifier.VOLATILE)
     changeModifiers(ConfigInstance.RUNTIME_ID_FIELD, Modifier.PUBLIC | Modifier.VOLATILE)
 
+    assertFieldState()
     isConfigInstanceModifiable = true
+  }
 
-    final field = ConfigInstance.FIELD
-    assert Modifier.isPublic(field.getModifiers())
-    assert Modifier.isStatic(field.getModifiers())
-    assert Modifier.isVolatile(field.getModifiers())
-    assert !Modifier.isFinal(field.getModifiers())
+  private static void assertFieldState() {
+    assert Modifier.isPublic(ConfigInstance.FIELD.getModifiers())
+    assert Modifier.isStatic(ConfigInstance.FIELD.getModifiers())
+    assert Modifier.isVolatile(ConfigInstance.FIELD.getModifiers())
+    assert !Modifier.isFinal(ConfigInstance.FIELD.getModifiers())
 
-    final runtimeIdField = ConfigInstance.RUNTIME_ID_FIELD
-    assert Modifier.isPublic(runtimeIdField.getModifiers())
+    assert Modifier.isPublic(ConfigInstance.RUNTIME_ID_FIELD.getModifiers())
     assert !Modifier.isStatic(ConfigInstance.RUNTIME_ID_FIELD.getModifiers())
-    assert Modifier.isVolatile(runtimeIdField.getModifiers())
-    assert !Modifier.isFinal(runtimeIdField.getModifiers())
+    assert Modifier.isVolatile(ConfigInstance.RUNTIME_ID_FIELD.getModifiers())
+    assert !Modifier.isFinal(ConfigInstance.RUNTIME_ID_FIELD.getModifiers())
   }
 }

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/utils/ConfigUtils.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/utils/ConfigUtils.groovy
@@ -23,7 +23,7 @@ class ConfigUtils {
     Properties properties = new Properties()
     properties.put(name, value)
     ConfigInstance.FIELD.set(null, new Config(properties, existingConfig))
-    assert Config.get() != existingConfig
+    assert !Config.get().is(existingConfig)
     try {
       return r.call()
     } finally {

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/DDSpanBuilderTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/DDSpanBuilderTest.groovy
@@ -2,7 +2,6 @@ package datadog.opentracing
 
 import datadog.opentracing.propagation.ExtractedContext
 import datadog.opentracing.propagation.TagContext
-import datadog.trace.agent.test.utils.ConfigUtils
 import datadog.trace.api.Config
 import datadog.trace.api.DDTags
 import datadog.trace.api.sampling.PrioritySampling
@@ -17,10 +16,6 @@ import static org.mockito.Mockito.mock
 import static org.mockito.Mockito.when
 
 class DDSpanBuilderTest extends Specification {
-  static {
-    ConfigUtils.makeConfigInstanceModifiable()
-  }
-
   def writer = new ListWriter()
   def config = Config.get()
   def tracer = new DDTracer(writer)

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/DDSpanSerializationTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/DDSpanSerializationTest.groovy
@@ -1,9 +1,7 @@
 package datadog.opentracing
 
-
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.google.common.collect.Maps
-import datadog.trace.agent.test.utils.ConfigUtils
 import datadog.trace.api.DDTags
 import datadog.trace.api.sampling.PrioritySampling
 import datadog.trace.common.writer.ListWriter
@@ -14,10 +12,6 @@ import org.msgpack.value.ValueType
 import spock.lang.Specification
 
 class DDSpanSerializationTest extends Specification {
-  static {
-    ConfigUtils.makeConfigInstanceModifiable()
-  }
-
   def "serialize spans with sampling #samplingPriority"() throws Exception {
     setup:
     final Map<String, String> baggage = new HashMap<>()

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/DDSpanTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/DDSpanTest.groovy
@@ -1,10 +1,8 @@
 package datadog.opentracing
 
-
 import com.fasterxml.jackson.databind.ObjectMapper
 import datadog.opentracing.propagation.ExtractedContext
 import datadog.opentracing.propagation.TagContext
-import datadog.trace.agent.test.utils.ConfigUtils
 import datadog.trace.api.DDTags
 import datadog.trace.api.sampling.PrioritySampling
 import datadog.trace.common.sampling.RateByServiceSampler
@@ -18,10 +16,6 @@ import java.util.concurrent.TimeUnit
 import static datadog.trace.api.Config.DEFAULT_SERVICE_NAME
 
 class DDSpanTest extends Specification {
-  static {
-    ConfigUtils.makeConfigInstanceModifiable()
-  }
-
   def writer = new ListWriter()
   def sampler = new RateByServiceSampler()
   def tracer = new DDTracer(DEFAULT_SERVICE_NAME, writer, sampler, [:])

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/PendingTraceTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/PendingTraceTest.groovy
@@ -1,6 +1,6 @@
 package datadog.opentracing
 
-import datadog.trace.agent.test.utils.ConfigUtils
+
 import datadog.trace.api.Config
 import datadog.trace.common.writer.ListWriter
 import datadog.trace.util.gc.GCUtils
@@ -15,10 +15,6 @@ import java.util.concurrent.atomic.AtomicInteger
 import static datadog.trace.api.Config.PARTIAL_FLUSH_MIN_SPANS
 
 class PendingTraceTest extends Specification {
-  static {
-    ConfigUtils.makeConfigInstanceModifiable()
-  }
-
   def traceCount = new AtomicInteger()
   def writer = new ListWriter() {
     @Override

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/SpanFactory.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/SpanFactory.groovy
@@ -1,14 +1,10 @@
 package datadog.opentracing
 
-import datadog.trace.agent.test.utils.ConfigUtils
+
 import datadog.trace.api.sampling.PrioritySampling
 import datadog.trace.common.writer.ListWriter
 
 class SpanFactory {
-  static {
-    ConfigUtils.makeConfigInstanceModifiable()
-  }
-
   static newSpanOf(long timestampMicro, String threadName = Thread.currentThread().name) {
     def writer = new ListWriter()
     def tracer = new DDTracer(writer)

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/TraceCorrelationTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/TraceCorrelationTest.groovy
@@ -1,15 +1,11 @@
 package datadog.opentracing
 
-import datadog.trace.agent.test.utils.ConfigUtils
+
 import datadog.trace.common.writer.ListWriter
 import spock.lang.Shared
 import spock.lang.Specification
 
 class TraceCorrelationTest extends Specification {
-  static {
-    ConfigUtils.makeConfigInstanceModifiable()
-  }
-
   static final WRITER = new ListWriter()
 
   @Shared

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/TraceInterceptorTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/TraceInterceptorTest.groovy
@@ -1,6 +1,6 @@
 package datadog.opentracing
 
-import datadog.trace.agent.test.utils.ConfigUtils
+
 import datadog.trace.api.GlobalTracer
 import datadog.trace.api.interceptor.MutableSpan
 import datadog.trace.api.interceptor.TraceInterceptor
@@ -10,10 +10,6 @@ import spock.lang.Specification
 import java.util.concurrent.atomic.AtomicBoolean
 
 class TraceInterceptorTest extends Specification {
-  static {
-    ConfigUtils.makeConfigInstanceModifiable()
-  }
-
   def writer = new ListWriter()
   def tracer = new DDTracer(writer)
 

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/decorators/SpanDecoratorTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/decorators/SpanDecoratorTest.groovy
@@ -18,7 +18,7 @@ import static datadog.trace.api.DDTags.EVENT_SAMPLE_RATE
 import static java.util.Collections.emptyMap
 
 class SpanDecoratorTest extends Specification {
-  static {
+  def setupSpec() {
     ConfigUtils.updateConfig {
       System.setProperty("dd.$Config.SPLIT_BY_TAGS", "sn.tag1,sn.tag2")
     }
@@ -29,8 +29,14 @@ class SpanDecoratorTest extends Specification {
       System.clearProperty("dd.$Config.SPLIT_BY_TAGS")
     }
   }
-  def tracer = new DDTracer(new LoggingWriter())
-  def span = SpanFactory.newSpanOf(tracer)
+
+  def tracer
+  def span
+
+  def setup() {
+    tracer = new DDTracer(new LoggingWriter())
+    span = SpanFactory.newSpanOf(tracer)
+  }
 
   def "adding span personalisation using Decorators"() {
     setup:

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/decorators/SpanDecoratorTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/decorators/SpanDecoratorTest.groovy
@@ -19,7 +19,6 @@ import static java.util.Collections.emptyMap
 
 class SpanDecoratorTest extends Specification {
   static {
-    ConfigUtils.makeConfigInstanceModifiable()
     ConfigUtils.updateConfig {
       System.setProperty("dd.$Config.SPLIT_BY_TAGS", "sn.tag1,sn.tag2")
     }

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/decorators/URLAsResourceNameTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/decorators/URLAsResourceNameTest.groovy
@@ -3,7 +3,6 @@ package datadog.opentracing.decorators
 import datadog.opentracing.DDSpanContext
 import datadog.opentracing.DDTracer
 import datadog.opentracing.PendingTrace
-import datadog.trace.agent.test.utils.ConfigUtils
 import datadog.trace.api.sampling.PrioritySampling
 import datadog.trace.common.writer.ListWriter
 import io.opentracing.tag.Tags
@@ -11,10 +10,6 @@ import spock.lang.Specification
 import spock.lang.Subject
 
 class URLAsResourceNameTest extends Specification {
-  static {
-    ConfigUtils.makeConfigInstanceModifiable()
-  }
-
   def writer = new ListWriter()
   def tracer = new DDTracer(writer)
 

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/propagation/HttpExtractorTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/propagation/HttpExtractorTest.groovy
@@ -1,6 +1,6 @@
 package datadog.opentracing.propagation
 
-import datadog.trace.agent.test.utils.ConfigUtils
+
 import datadog.trace.api.Config
 import io.opentracing.SpanContext
 import io.opentracing.propagation.TextMapExtractAdapter
@@ -12,10 +12,6 @@ import static datadog.trace.api.Config.PropagationStyle.B3
 import static datadog.trace.api.Config.PropagationStyle.DATADOG
 
 class HttpExtractorTest extends Specification {
-  static {
-    ConfigUtils.makeConfigInstanceModifiable()
-  }
-
   @Shared
   String outOfRangeTraceId = UINT64_MAX.add(BigInteger.ONE)
 

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/propagation/HttpInjectorTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/propagation/HttpInjectorTest.groovy
@@ -3,7 +3,6 @@ package datadog.opentracing.propagation
 import datadog.opentracing.DDSpanContext
 import datadog.opentracing.DDTracer
 import datadog.opentracing.PendingTrace
-import datadog.trace.agent.test.utils.ConfigUtils
 import datadog.trace.api.Config
 import datadog.trace.api.sampling.PrioritySampling
 import datadog.trace.common.writer.ListWriter
@@ -14,10 +13,6 @@ import static datadog.trace.api.Config.PropagationStyle.B3
 import static datadog.trace.api.Config.PropagationStyle.DATADOG
 
 class HttpInjectorTest extends Specification {
-  static {
-    ConfigUtils.makeConfigInstanceModifiable()
-  }
-
   def "inject http headers"() {
     setup:
     Config config = Mock(Config) {

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/resolver/DDTracerResolverTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/resolver/DDTracerResolverTest.groovy
@@ -1,16 +1,11 @@
 package datadog.opentracing.resolver
 
 import datadog.opentracing.DDTracer
-import datadog.trace.agent.test.utils.ConfigUtils
 import datadog.trace.api.Config
 import io.opentracing.contrib.tracerresolver.TracerResolver
 import spock.lang.Specification
 
 class DDTracerResolverTest extends Specification {
-  static {
-    ConfigUtils.makeConfigInstanceModifiable()
-  }
-
   def resolver = new DDTracerResolver()
 
   def "test resolveTracer"() {

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/scopemanager/ScopeManagerTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/scopemanager/ScopeManagerTest.groovy
@@ -3,7 +3,6 @@ package datadog.opentracing.scopemanager
 import datadog.opentracing.DDSpan
 import datadog.opentracing.DDSpanContext
 import datadog.opentracing.DDTracer
-import datadog.trace.agent.test.utils.ConfigUtils
 import datadog.trace.common.writer.ListWriter
 import datadog.trace.context.ScopeListener
 import datadog.trace.util.gc.GCUtils
@@ -23,9 +22,6 @@ import java.util.concurrent.atomic.AtomicReference
 import static java.util.concurrent.TimeUnit.SECONDS
 
 class ScopeManagerTest extends Specification {
-  static {
-    ConfigUtils.makeConfigInstanceModifiable()
-  }
   def latch
   def writer
   def tracer

--- a/dd-trace-ot/src/test/groovy/datadog/trace/DDTracerTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/trace/DDTracerTest.groovy
@@ -2,7 +2,6 @@ package datadog.trace
 
 import datadog.opentracing.DDTracer
 import datadog.opentracing.propagation.HttpCodec
-import datadog.trace.agent.test.utils.ConfigUtils
 import datadog.trace.api.Config
 import datadog.trace.common.sampling.AllSampler
 import datadog.trace.common.sampling.RateByServiceSampler
@@ -23,10 +22,6 @@ import static datadog.trace.api.Config.SPAN_TAGS
 import static datadog.trace.api.Config.WRITER_TYPE
 
 class DDTracerTest extends Specification {
-  static {
-    ConfigUtils.makeConfigInstanceModifiable()
-  }
-
   @Rule
   public final RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties()
   @Rule


### PR DESCRIPTION
This fixes two issues that caused tests to intermittently fail:

* For `CleanerTest`, the timeout was too low.  On my laptop, it failed 100% of the time with a 90ms timeout and ~10% of the time with a 100ms timeout.  There is some delay/warmup before the scheduledExecutor is up and running
* For `makeConfigInstanceModifiable`, the order that classes were loaded determined whether or not the ByteBuddy redefinition worked.  I replaced the class redefinition with old fashioned reflection.