### PR TITLE
Cleaner test timeout fix

### DIFF
--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/CleanerTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/CleanerTest.groovy
@@ -37,7 +37,7 @@ class CleanerTest extends Specification {
     cleaner.scheduleCleaning(target, action, 10, MILLISECONDS)
 
     then:
-    latch.await(100, MILLISECONDS)
+    latch.await(200, MILLISECONDS)
   }
 
   def "test canceling"() {


### PR DESCRIPTION
This increases the timeout in the `CleanerTest`. On my laptop, the test failed 100% of the time with a 90ms timeout and ~10% of the time with a 100ms timeout. There is some variable delay/warmup before the scheduledExecutor is up and running