### PR TITLE
Test config stability and cleanup

### DIFF
--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/test/HelperInjectionTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/test/HelperInjectionTest.groovy
@@ -1,6 +1,6 @@
 package datadog.trace.agent.test
 
-import datadog.trace.agent.test.utils.ConfigUtils
+
 import datadog.trace.agent.tooling.AgentInstaller
 import datadog.trace.agent.tooling.HelperInjector
 import datadog.trace.agent.tooling.Utils
@@ -19,10 +19,6 @@ import static datadog.trace.agent.tooling.ClassLoaderMatcher.BOOTSTRAP_CLASSLOAD
 import static datadog.trace.util.gc.GCUtils.awaitGC
 
 class HelperInjectionTest extends Specification {
-  static {
-    ConfigUtils.makeConfigInstanceModifiable()
-  }
-
   @Timeout(10)
   def "helpers injected to non-delegating classloader"() {
     setup:

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test/groovy/AWSClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test/groovy/AWSClientTest.groovy
@@ -43,14 +43,9 @@ class AWSClientTest extends AgentTestRunner {
     new ProfileCredentialsProvider(),
     new InstanceProfileCredentialsProvider())
 
-  def setupSpec() {
+  def setup() {
     System.setProperty(SDKGlobalConfiguration.ACCESS_KEY_SYSTEM_PROPERTY, "my-access-key")
     System.setProperty(SDKGlobalConfiguration.SECRET_KEY_SYSTEM_PROPERTY, "my-secret-key")
-  }
-
-  def cleanupSpec() {
-    System.clearProperty(SDKGlobalConfiguration.ACCESS_KEY_SYSTEM_PROPERTY)
-    System.clearProperty(SDKGlobalConfiguration.SECRET_KEY_SYSTEM_PROPERTY)
   }
 
   @Shared

--- a/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/ExecutorInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/ExecutorInstrumentationTest.groovy
@@ -1,7 +1,6 @@
 import datadog.opentracing.DDSpan
 import datadog.opentracing.scopemanager.ContinuableScope
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.utils.ConfigUtils
 import datadog.trace.api.Trace
 import datadog.trace.bootstrap.instrumentation.java.concurrent.CallableWrapper
 import datadog.trace.bootstrap.instrumentation.java.concurrent.RunnableWrapper
@@ -26,9 +25,7 @@ import java.util.concurrent.TimeoutException
 class ExecutorInstrumentationTest extends AgentTestRunner {
 
   static {
-    ConfigUtils.updateConfig {
-      System.setProperty("dd.trace.executors", "ExecutorInstrumentationTest\$CustomThreadPoolExecutor")
-    }
+    PRE_AGENT_SYS_PROPS = ["dd.trace.executors": "ExecutorInstrumentationTest\$CustomThreadPoolExecutor"]
   }
 
   @Shared

--- a/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/TraceAnnotationsTest.groovy
+++ b/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/TraceAnnotationsTest.groovy
@@ -8,11 +8,11 @@ import java.util.concurrent.Callable
 
 class TraceAnnotationsTest extends AgentTestRunner {
   def "test simple case annotations"() {
-    setup:
+    when:
     // Test single span in new trace
     SayTracedHello.sayHello()
 
-    expect:
+    then:
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
@@ -31,11 +31,11 @@ class TraceAnnotationsTest extends AgentTestRunner {
   }
 
   def "test simple case with only operation name set"() {
-    setup:
+    when:
     // Test single span in new trace
     SayTracedHello.sayHA()
 
-    expect:
+    then:
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
@@ -55,11 +55,11 @@ class TraceAnnotationsTest extends AgentTestRunner {
   }
 
   def "test simple case with only resource name set"() {
-    setup:
+    when:
     // Test single span in new trace
     SayTracedHello.sayHelloOnlyResourceSet()
 
-    expect:
+    then:
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
@@ -78,11 +78,11 @@ class TraceAnnotationsTest extends AgentTestRunner {
   }
 
   def "test simple case with both resource and operation name set"() {
-    setup:
+    when:
     // Test single span in new trace
     SayTracedHello.sayHAWithResource()
 
-    expect:
+    then:
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
@@ -235,17 +235,14 @@ class TraceAnnotationsTest extends AgentTestRunner {
 
   def "test exception exit"() {
     setup:
-
     TEST_TRACER.addDecorator(new ErrorFlag())
 
-    Throwable error = null
-    try {
-      SayTracedHello.sayERROR()
-    } catch (final Throwable ex) {
-      error = ex
-    }
+    when:
+    SayTracedHello.sayERROR()
 
-    expect:
+    then:
+    def ex = thrown(RuntimeException)
+
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
@@ -254,7 +251,7 @@ class TraceAnnotationsTest extends AgentTestRunner {
           errored true
           tags {
             "$Tags.COMPONENT.key" "trace"
-            errorTags(error.class)
+            errorTags(ex.class)
             defaultTags()
           }
         }
@@ -267,14 +264,12 @@ class TraceAnnotationsTest extends AgentTestRunner {
 
     TEST_TRACER.addDecorator(new ErrorFlag())
 
-    Throwable error = null
-    try {
-      SayTracedHello.sayERRORWithResource()
-    } catch (final Throwable ex) {
-      error = ex
-    }
+    when:
+    SayTracedHello.sayERRORWithResource()
 
-    expect:
+    then:
+    def ex = thrown(RuntimeException)
+
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
@@ -283,7 +278,7 @@ class TraceAnnotationsTest extends AgentTestRunner {
           errored true
           tags {
             "$Tags.COMPONENT.key" "trace"
-            errorTags(error.class)
+            errorTags(ex.class)
             defaultTags()
           }
         }
@@ -292,11 +287,11 @@ class TraceAnnotationsTest extends AgentTestRunner {
   }
 
   def "test annonymous class annotations"() {
-    setup:
+    when:
     // Test anonymous classes with package.
     SayTracedHello.fromCallable()
 
-    expect:
+    then:
     assertTraces(1) {
       trace(0, 1) {
         span(0) {

--- a/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/TraceAnnotationsTest.groovy
+++ b/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/TraceAnnotationsTest.groovy
@@ -292,6 +292,7 @@ class TraceAnnotationsTest extends AgentTestRunner {
     SayTracedHello.fromCallable()
 
     then:
+    System.getProperty("dd.trace.annotations") == null
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
@@ -313,6 +314,7 @@ class TraceAnnotationsTest extends AgentTestRunner {
     TEST_WRITER.waitForTraces(2)
 
     then:
+    System.getProperty("dd.trace.annotations") == null
     assertTraces(2) {
       trace(0, 1) {
         span(0) {

--- a/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/TraceAnnotationsTest.groovy
+++ b/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/TraceAnnotationsTest.groovy
@@ -1,6 +1,5 @@
 import datadog.opentracing.decorators.ErrorFlag
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.utils.ConfigUtils
 import datadog.trace.api.Trace
 import dd.test.trace.annotation.SayTracedHello
 import io.opentracing.tag.Tags
@@ -8,13 +7,6 @@ import io.opentracing.tag.Tags
 import java.util.concurrent.Callable
 
 class TraceAnnotationsTest extends AgentTestRunner {
-
-  static {
-    ConfigUtils.updateConfig {
-      System.clearProperty("dd.trace.annotations")
-    }
-  }
-
   def "test simple case annotations"() {
     setup:
     // Test single span in new trace

--- a/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/TraceConfigTest.groovy
+++ b/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/TraceConfigTest.groovy
@@ -17,11 +17,8 @@ class TraceConfigTest extends AgentTestRunner {
   }
 
   def "test configuration based trace"() {
-    expect:
-    new ConfigTracedCallable().call() == "Hello!"
-
     when:
-    TEST_WRITER.waitForTraces(1)
+    new ConfigTracedCallable().call() == "Hello!"
 
     then:
     assertTraces(1) {

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/log/injection/LogContextInjectionTestBase.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/log/injection/LogContextInjectionTestBase.groovy
@@ -1,7 +1,6 @@
 package datadog.trace.agent.test.log.injection
 
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.utils.ConfigUtils
 import datadog.trace.api.CorrelationIdentifier
 import io.opentracing.Scope
 import io.opentracing.util.GlobalTracer
@@ -13,7 +12,6 @@ import java.util.concurrent.atomic.AtomicReference
  * satisfy in order to support log injection.
  */
 abstract class LogContextInjectionTestBase extends AgentTestRunner {
-
   /**
    * Set in the framework-specific context the given value at the given key
    */
@@ -25,9 +23,7 @@ abstract class LogContextInjectionTestBase extends AgentTestRunner {
   abstract get(String key)
 
   static {
-    ConfigUtils.updateConfig {
-      System.setProperty("dd.logs.injection", "true")
-    }
+    PRE_AGENT_SYS_PROPS = ["dd.logs.injection": "true"]
   }
 
   def "Log context shows trace and span ids for active scope"() {
@@ -67,9 +63,6 @@ abstract class LogContextInjectionTestBase extends AgentTestRunner {
 
   def "Log context is scoped by thread"() {
     setup:
-    ConfigUtils.updateConfig {
-      System.setProperty("dd.logs.injection", "true")
-    }
     AtomicReference<String> thread1TraceId = new AtomicReference<>()
     AtomicReference<String> thread2TraceId = new AtomicReference<>()
 

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/utils/ConfigUtils.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/utils/ConfigUtils.groovy
@@ -2,128 +2,45 @@ package datadog.trace.agent.test.utils
 
 import datadog.trace.api.Config
 import lombok.SneakyThrows
-import net.bytebuddy.agent.ByteBuddyAgent
-import net.bytebuddy.agent.builder.AgentBuilder
-import net.bytebuddy.dynamic.ClassFileLocator
-import net.bytebuddy.dynamic.Transformer
 
-import java.lang.reflect.Modifier
 import java.util.concurrent.Callable
 
-import static net.bytebuddy.description.modifier.FieldManifestation.VOLATILE
-import static net.bytebuddy.description.modifier.Ownership.STATIC
-import static net.bytebuddy.description.modifier.Visibility.PUBLIC
-import static net.bytebuddy.matcher.ElementMatchers.named
-import static net.bytebuddy.matcher.ElementMatchers.none
-
 class ConfigUtils {
-  private static class ConfigInstance {
-    // Wrapped in a static class to lazy load.
-    static final FIELD = Config.getDeclaredField("INSTANCE")
-    static final RUNTIME_ID_FIELD = Config.getDeclaredField("runtimeId")
+  /**
+   * Runs the callable with a new config based on the current config
+   */
+  synchronized static <T extends Object> T withConfigOverride(final String name, final String value, final Callable r) {
+    return withConfigOverride(Collections.singletonMap(name, value), r)
+  }
+
+  /**
+   * Runs the callable with a new config based on the current config
+   */
+  synchronized static <T extends Object> T withConfigOverride(Map<String, String> overrides, final Callable r) {
+    Properties properties = new Properties()
+
+    // Can't use putAll.  Groovy puts GStringImpl and other such things in maps
+    overrides.each { k, v -> properties.put(k.toString(), v.toString()) }
+
+    return runWithConfig(r, new Config(properties, Config.get()))
+  }
+
+  /**
+   * Runs the callable with a new config generated from the current environment
+   */
+  synchronized static <T extends Object> T withNewConfig(final Callable<T> r) {
+    return runWithConfig(r, new Config())
   }
 
   @SneakyThrows
-  synchronized static <T extends Object> Object withConfigOverride(final String name, final String value, final Callable<T> r) {
-    // Ensure the class was retransformed properly in AgentTestRunner.makeConfigInstanceModifiable()
-    assert Modifier.isPublic(ConfigInstance.FIELD.getModifiers())
-    assert Modifier.isStatic(ConfigInstance.FIELD.getModifiers())
-    assert Modifier.isVolatile(ConfigInstance.FIELD.getModifiers())
-    assert !Modifier.isFinal(ConfigInstance.FIELD.getModifiers())
-
+  private synchronized static <T extends Object> T runWithConfig(Callable<T> r, Config newConfig) {
     def existingConfig = Config.get()
-    Properties properties = new Properties()
-    properties.put(name, value)
-    ConfigInstance.FIELD.set(null, new Config(properties, existingConfig))
-    assert Config.get() != existingConfig
+    Config.set(newConfig)
+
     try {
       return r.call()
     } finally {
-      ConfigInstance.FIELD.set(null, existingConfig)
+      Config.set(existingConfig)
     }
-  }
-
-  /**
-   * Provides an callback to set up the testing environment and reset the global configuration after system properties and envs are set.
-   *
-   * @param r
-   * @return
-   */
-  static updateConfig(final Callable r) {
-    makeConfigInstanceModifiable()
-    r.call()
-    resetConfig()
-  }
-
-  /**
-   * Reset the global configuration. Please note that Runtime ID is preserved to the pre-existing value.
-   */
-  static void resetConfig() {
-    // Ensure the class was re-transformed properly in AgentTestRunner.makeConfigInstanceModifiable()
-    assert Modifier.isPublic(ConfigInstance.FIELD.getModifiers())
-    assert Modifier.isStatic(ConfigInstance.FIELD.getModifiers())
-    assert Modifier.isVolatile(ConfigInstance.FIELD.getModifiers())
-    assert !Modifier.isFinal(ConfigInstance.FIELD.getModifiers())
-
-    assert Modifier.isPublic(ConfigInstance.RUNTIME_ID_FIELD.getModifiers())
-    assert !Modifier.isStatic(ConfigInstance.RUNTIME_ID_FIELD.getModifiers())
-    assert Modifier.isVolatile(ConfigInstance.RUNTIME_ID_FIELD.getModifiers())
-    assert !Modifier.isFinal(ConfigInstance.RUNTIME_ID_FIELD.getModifiers())
-
-    def previousConfig = ConfigInstance.FIELD.get(null)
-    def newConfig = new Config()
-    ConfigInstance.FIELD.set(null, newConfig)
-    if (previousConfig != null) {
-      ConfigInstance.RUNTIME_ID_FIELD.set(newConfig, ConfigInstance.RUNTIME_ID_FIELD.get(previousConfig))
-    }
-  }
-
-  // Keep track of config instance already made modifiable
-  private static isConfigInstanceModifiable = false
-
-  static void makeConfigInstanceModifiable() {
-    if (isConfigInstanceModifiable) {
-      return
-    }
-
-    def instrumentation = ByteBuddyAgent.install()
-    final transformer =
-      new AgentBuilder.Default()
-        .with(AgentBuilder.RedefinitionStrategy.RETRANSFORMATION)
-        .with(AgentBuilder.RedefinitionStrategy.Listener.ErrorEscalating.FAIL_FAST)
-        // Config is injected into the bootstrap, so we need to provide a locator.
-        .with(
-          new AgentBuilder.LocationStrategy.Simple(
-            ClassFileLocator.ForClassLoader.ofSystemLoader()))
-        .ignore(none()) // Allow transforming bootstrap classes
-        .type(named("datadog.trace.api.Config"))
-        .transform { builder, typeDescription, classLoader, module ->
-          builder
-            .field(named("INSTANCE"))
-            .transform(Transformer.ForField.withModifiers(PUBLIC, STATIC, VOLATILE))
-        }
-        // Making runtimeId modifiable so that it can be preserved when resetting config in tests
-        .transform { builder, typeDescription, classLoader, module ->
-          builder
-            .field(named("runtimeId"))
-            .transform(Transformer.ForField.withModifiers(PUBLIC, VOLATILE))
-        }
-        .installOn(instrumentation)
-    isConfigInstanceModifiable = true
-
-    final field = ConfigInstance.FIELD
-    assert Modifier.isPublic(field.getModifiers())
-    assert Modifier.isStatic(field.getModifiers())
-    assert Modifier.isVolatile(field.getModifiers())
-    assert !Modifier.isFinal(field.getModifiers())
-
-    final runtimeIdField = ConfigInstance.RUNTIME_ID_FIELD
-    assert Modifier.isPublic(runtimeIdField.getModifiers())
-    assert !Modifier.isStatic(ConfigInstance.RUNTIME_ID_FIELD.getModifiers())
-    assert Modifier.isVolatile(runtimeIdField.getModifiers())
-    assert !Modifier.isFinal(runtimeIdField.getModifiers())
-
-    // No longer needed (Unless class gets retransformed somehow).
-    instrumentation.removeTransformer(transformer)
   }
 }

--- a/dd-java-agent/testing/src/test/groovy/AgentTestRunnerTest.groovy
+++ b/dd-java-agent/testing/src/test/groovy/AgentTestRunnerTest.groovy
@@ -2,7 +2,6 @@ import com.google.common.reflect.ClassPath
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.SpockRunner
 import datadog.trace.agent.test.utils.ClasspathUtils
-import datadog.trace.agent.test.utils.ConfigUtils
 import datadog.trace.agent.test.utils.GlobalTracerUtils
 import datadog.trace.agent.tooling.Constants
 import io.opentracing.Span
@@ -24,9 +23,7 @@ class AgentTestRunnerTest extends AgentTestRunner {
   private Class sharedSpanClass
 
   static {
-    ConfigUtils.updateConfig {
-      System.setProperty("dd." + TRACE_CLASSES_EXCLUDE, "config.exclude.packagename.*, config.exclude.SomeClass,config.exclude.SomeClass\$NestedClass")
-    }
+    PRE_AGENT_SYS_PROPS = [("dd." + TRACE_CLASSES_EXCLUDE): "config.exclude.packagename.*, config.exclude.SomeClass,config.exclude.SomeClass\$NestedClass"]
 
     // when test class initializes, opentracing should be set up, but not the agent.
     OT_LOADER = io.opentracing.Tracer.getClassLoader()

--- a/dd-trace-api/src/main/java/datadog/trace/api/Config.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/Config.java
@@ -987,7 +987,7 @@ public class Config {
   }
 
   // This has to be placed after all other static fields to give them a chance to initialize
-  private static final Config INSTANCE = new Config();
+  private static Config INSTANCE = new Config();
 
   public static Config get() {
     return INSTANCE;
@@ -999,5 +999,10 @@ public class Config {
     } else {
       return new Config(properties, INSTANCE);
     }
+  }
+
+  /** For testing only */
+  static void set(final Config config) {
+    INSTANCE = config;
   }
 }

--- a/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -44,6 +44,7 @@ import static datadog.trace.api.Config.WRITER_TYPE
 class ConfigTest extends Specification {
   @Rule
   public final RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties()
+
   @Rule
   public final EnvironmentVariables environmentVariables = new EnvironmentVariables()
 
@@ -742,9 +743,6 @@ class ConfigTest extends Specification {
 
     then:
     config.serviceName == "set-in-properties"
-
-    cleanup:
-    System.clearProperty(PREFIX + CONFIGURATION_FILE)
   }
 
   def "verify fallback to properties file has lower priority than system property"() {
@@ -757,10 +755,6 @@ class ConfigTest extends Specification {
 
     then:
     config.serviceName == "set-in-system"
-
-    cleanup:
-    System.clearProperty(PREFIX + CONFIGURATION_FILE)
-    System.clearProperty(PREFIX + SERVICE_NAME)
   }
 
   def "verify fallback to properties file has lower priority than env var"() {
@@ -775,8 +769,6 @@ class ConfigTest extends Specification {
     config.serviceName == "set-in-env"
 
     cleanup:
-    System.clearProperty(PREFIX + CONFIGURATION_FILE)
-    System.clearProperty(PREFIX + SERVICE_NAME)
     environmentVariables.clear("DD_SERVICE_NAME")
   }
 
@@ -789,8 +781,5 @@ class ConfigTest extends Specification {
 
     then:
     config.serviceName == 'unnamed-java-app'
-
-    cleanup:
-    System.clearProperty(PREFIX + CONFIGURATION_FILE)
   }
 }

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/DDSpanBuilderTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/DDSpanBuilderTest.groovy
@@ -2,7 +2,6 @@ package datadog.opentracing
 
 import datadog.opentracing.propagation.ExtractedContext
 import datadog.opentracing.propagation.TagContext
-import datadog.trace.agent.test.utils.ConfigUtils
 import datadog.trace.api.Config
 import datadog.trace.api.DDTags
 import datadog.trace.api.sampling.PrioritySampling
@@ -17,10 +16,6 @@ import static org.mockito.Mockito.mock
 import static org.mockito.Mockito.when
 
 class DDSpanBuilderTest extends Specification {
-  static {
-    ConfigUtils.makeConfigInstanceModifiable()
-  }
-
   def writer = new ListWriter()
   def config = Config.get()
   def tracer = new DDTracer(writer)

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/DDSpanSerializationTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/DDSpanSerializationTest.groovy
@@ -1,9 +1,7 @@
 package datadog.opentracing
 
-
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.google.common.collect.Maps
-import datadog.trace.agent.test.utils.ConfigUtils
 import datadog.trace.api.DDTags
 import datadog.trace.api.sampling.PrioritySampling
 import datadog.trace.common.writer.ListWriter
@@ -14,9 +12,7 @@ import org.msgpack.value.ValueType
 import spock.lang.Specification
 
 class DDSpanSerializationTest extends Specification {
-  static {
-    ConfigUtils.makeConfigInstanceModifiable()
-  }
+
 
   def "serialize spans with sampling #samplingPriority"() throws Exception {
     setup:

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/DDSpanTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/DDSpanTest.groovy
@@ -1,10 +1,8 @@
 package datadog.opentracing
 
-
 import com.fasterxml.jackson.databind.ObjectMapper
 import datadog.opentracing.propagation.ExtractedContext
 import datadog.opentracing.propagation.TagContext
-import datadog.trace.agent.test.utils.ConfigUtils
 import datadog.trace.api.DDTags
 import datadog.trace.api.sampling.PrioritySampling
 import datadog.trace.common.sampling.RateByServiceSampler
@@ -18,10 +16,6 @@ import java.util.concurrent.TimeUnit
 import static datadog.trace.api.Config.DEFAULT_SERVICE_NAME
 
 class DDSpanTest extends Specification {
-  static {
-    ConfigUtils.makeConfigInstanceModifiable()
-  }
-
   def writer = new ListWriter()
   def sampler = new RateByServiceSampler()
   def tracer = new DDTracer(DEFAULT_SERVICE_NAME, writer, sampler, [:])

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/PendingTraceTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/PendingTraceTest.groovy
@@ -1,6 +1,6 @@
 package datadog.opentracing
 
-import datadog.trace.agent.test.utils.ConfigUtils
+
 import datadog.trace.api.Config
 import datadog.trace.common.writer.ListWriter
 import datadog.trace.util.gc.GCUtils
@@ -15,10 +15,6 @@ import java.util.concurrent.atomic.AtomicInteger
 import static datadog.trace.api.Config.PARTIAL_FLUSH_MIN_SPANS
 
 class PendingTraceTest extends Specification {
-  static {
-    ConfigUtils.makeConfigInstanceModifiable()
-  }
-
   def traceCount = new AtomicInteger()
   def writer = new ListWriter() {
     @Override

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/SpanFactory.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/SpanFactory.groovy
@@ -1,14 +1,10 @@
 package datadog.opentracing
 
-import datadog.trace.agent.test.utils.ConfigUtils
+
 import datadog.trace.api.sampling.PrioritySampling
 import datadog.trace.common.writer.ListWriter
 
 class SpanFactory {
-  static {
-    ConfigUtils.makeConfigInstanceModifiable()
-  }
-
   static DDSpan newSpanOf(long timestampMicro, String threadName = Thread.currentThread().name) {
     def writer = new ListWriter()
     def tracer = new DDTracer(writer)

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/TraceCorrelationTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/TraceCorrelationTest.groovy
@@ -1,15 +1,11 @@
 package datadog.opentracing
 
-import datadog.trace.agent.test.utils.ConfigUtils
+
 import datadog.trace.common.writer.ListWriter
 import spock.lang.Shared
 import spock.lang.Specification
 
 class TraceCorrelationTest extends Specification {
-  static {
-    ConfigUtils.makeConfigInstanceModifiable()
-  }
-
   static final WRITER = new ListWriter()
 
   @Shared

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/TraceInterceptorTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/TraceInterceptorTest.groovy
@@ -1,6 +1,6 @@
 package datadog.opentracing
 
-import datadog.trace.agent.test.utils.ConfigUtils
+
 import datadog.trace.api.GlobalTracer
 import datadog.trace.api.interceptor.MutableSpan
 import datadog.trace.api.interceptor.TraceInterceptor
@@ -10,10 +10,6 @@ import spock.lang.Specification
 import java.util.concurrent.atomic.AtomicBoolean
 
 class TraceInterceptorTest extends Specification {
-  static {
-    ConfigUtils.makeConfigInstanceModifiable()
-  }
-
   def writer = new ListWriter()
   def tracer = new DDTracer(writer)
 

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/decorators/SpanDecoratorTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/decorators/SpanDecoratorTest.groovy
@@ -1,5 +1,6 @@
 package datadog.opentracing.decorators
 
+import datadog.opentracing.DDSpan
 import datadog.opentracing.DDSpanContext
 import datadog.opentracing.DDTracer
 import datadog.opentracing.SpanFactory
@@ -11,6 +12,8 @@ import datadog.trace.common.sampling.AllSampler
 import datadog.trace.common.writer.LoggingWriter
 import io.opentracing.tag.StringTag
 import io.opentracing.tag.Tags
+import org.junit.Rule
+import org.junit.contrib.java.lang.system.RestoreSystemProperties
 import spock.lang.Specification
 
 import static datadog.trace.api.Config.DEFAULT_SERVICE_NAME
@@ -18,20 +21,20 @@ import static datadog.trace.api.DDTags.EVENT_SAMPLE_RATE
 import static java.util.Collections.emptyMap
 
 class SpanDecoratorTest extends Specification {
-  static {
-    ConfigUtils.makeConfigInstanceModifiable()
-    ConfigUtils.updateConfig {
-      System.setProperty("dd.$Config.SPLIT_BY_TAGS", "sn.tag1,sn.tag2")
-    }
-  }
+  @Rule
+  public final RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties()
 
-  def cleanupSpec() {
-    ConfigUtils.updateConfig {
-      System.clearProperty("dd.$Config.SPLIT_BY_TAGS")
+  DDTracer tracer
+  DDSpan span
+
+  def setup() {
+    System.setProperty("dd.$Config.SPLIT_BY_TAGS", "sn.tag1,sn.tag2")
+
+    tracer = ConfigUtils.withNewConfig {
+      new DDTracer(new LoggingWriter())
     }
+    span = SpanFactory.newSpanOf(tracer)
   }
-  def tracer = new DDTracer(new LoggingWriter())
-  def span = SpanFactory.newSpanOf(tracer)
 
   def "adding span personalisation using Decorators"() {
     setup:
@@ -55,16 +58,18 @@ class SpanDecoratorTest extends Specification {
 
   def "set service name"() {
     setup:
-    tracer = new DDTracer(
-      "wrong-service",
-      new LoggingWriter(),
-      new AllSampler(),
-      "some-runtime-id",
-      emptyMap(),
-      emptyMap(),
-      mapping,
-      emptyMap()
-    )
+    tracer = ConfigUtils.withNewConfig {
+      new DDTracer(
+        "wrong-service",
+        new LoggingWriter(),
+        new AllSampler(),
+        "some-runtime-id",
+        emptyMap(),
+        emptyMap(),
+        mapping,
+        emptyMap()
+      )
+    }
 
     when:
     def span = tracer.buildSpan("some span").withTag(tag, name).start()
@@ -138,16 +143,18 @@ class SpanDecoratorTest extends Specification {
 
   def "set service name from servlet.context with context '#context' for service #serviceName"() {
     setup:
-    tracer = new DDTracer(
-      serviceName,
-      new LoggingWriter(),
-      new AllSampler(),
-      "some-runtime-id",
-      emptyMap(),
-      emptyMap(),
-      mapping,
-      emptyMap()
-    )
+    tracer = ConfigUtils.withNewConfig {
+      new DDTracer(
+        serviceName,
+        new LoggingWriter(),
+        new AllSampler(),
+        "some-runtime-id",
+        emptyMap(),
+        emptyMap(),
+        mapping,
+        emptyMap()
+      )
+    }
 
     when:
     def span = tracer.buildSpan("some span").start()

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/decorators/URLAsResourceNameTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/decorators/URLAsResourceNameTest.groovy
@@ -3,7 +3,6 @@ package datadog.opentracing.decorators
 import datadog.opentracing.DDSpanContext
 import datadog.opentracing.DDTracer
 import datadog.opentracing.PendingTrace
-import datadog.trace.agent.test.utils.ConfigUtils
 import datadog.trace.api.sampling.PrioritySampling
 import datadog.trace.common.writer.ListWriter
 import io.opentracing.tag.Tags
@@ -11,10 +10,6 @@ import spock.lang.Specification
 import spock.lang.Subject
 
 class URLAsResourceNameTest extends Specification {
-  static {
-    ConfigUtils.makeConfigInstanceModifiable()
-  }
-
   def writer = new ListWriter()
   def tracer = new DDTracer(writer)
 

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/propagation/HttpExtractorTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/propagation/HttpExtractorTest.groovy
@@ -1,6 +1,6 @@
 package datadog.opentracing.propagation
 
-import datadog.trace.agent.test.utils.ConfigUtils
+
 import datadog.trace.api.Config
 import io.opentracing.SpanContext
 import io.opentracing.propagation.TextMapExtractAdapter
@@ -12,10 +12,6 @@ import static datadog.trace.api.Config.PropagationStyle.B3
 import static datadog.trace.api.Config.PropagationStyle.DATADOG
 
 class HttpExtractorTest extends Specification {
-  static {
-    ConfigUtils.makeConfigInstanceModifiable()
-  }
-
   @Shared
   String outOfRangeTraceId = UINT64_MAX.add(BigInteger.ONE)
 

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/propagation/HttpInjectorTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/propagation/HttpInjectorTest.groovy
@@ -3,7 +3,6 @@ package datadog.opentracing.propagation
 import datadog.opentracing.DDSpanContext
 import datadog.opentracing.DDTracer
 import datadog.opentracing.PendingTrace
-import datadog.trace.agent.test.utils.ConfigUtils
 import datadog.trace.api.Config
 import datadog.trace.api.sampling.PrioritySampling
 import datadog.trace.common.writer.ListWriter
@@ -14,10 +13,6 @@ import static datadog.trace.api.Config.PropagationStyle.B3
 import static datadog.trace.api.Config.PropagationStyle.DATADOG
 
 class HttpInjectorTest extends Specification {
-  static {
-    ConfigUtils.makeConfigInstanceModifiable()
-  }
-
   def "inject http headers"() {
     setup:
     Config config = Mock(Config) {

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/resolver/DDTracerResolverTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/resolver/DDTracerResolverTest.groovy
@@ -1,16 +1,11 @@
 package datadog.opentracing.resolver
 
 import datadog.opentracing.DDTracer
-import datadog.trace.agent.test.utils.ConfigUtils
 import datadog.trace.api.Config
 import io.opentracing.contrib.tracerresolver.TracerResolver
 import spock.lang.Specification
 
 class DDTracerResolverTest extends Specification {
-  static {
-    ConfigUtils.makeConfigInstanceModifiable()
-  }
-
   def resolver = new DDTracerResolver()
 
   def "test resolveTracer"() {

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/scopemanager/ScopeManagerTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/scopemanager/ScopeManagerTest.groovy
@@ -3,7 +3,6 @@ package datadog.opentracing.scopemanager
 import datadog.opentracing.DDSpan
 import datadog.opentracing.DDSpanContext
 import datadog.opentracing.DDTracer
-import datadog.trace.agent.test.utils.ConfigUtils
 import datadog.trace.common.writer.ListWriter
 import datadog.trace.context.ScopeListener
 import datadog.trace.util.gc.GCUtils
@@ -23,9 +22,6 @@ import java.util.concurrent.atomic.AtomicReference
 import static java.util.concurrent.TimeUnit.SECONDS
 
 class ScopeManagerTest extends Specification {
-  static {
-    ConfigUtils.makeConfigInstanceModifiable()
-  }
   def latch
   def writer
   def tracer

--- a/dd-trace-ot/src/test/groovy/datadog/trace/DDTracerTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/trace/DDTracerTest.groovy
@@ -2,7 +2,6 @@ package datadog.trace
 
 import datadog.opentracing.DDTracer
 import datadog.opentracing.propagation.HttpCodec
-import datadog.trace.agent.test.utils.ConfigUtils
 import datadog.trace.api.Config
 import datadog.trace.common.sampling.AllSampler
 import datadog.trace.common.sampling.RateByServiceSampler
@@ -23,10 +22,6 @@ import static datadog.trace.api.Config.SPAN_TAGS
 import static datadog.trace.api.Config.WRITER_TYPE
 
 class DDTracerTest extends Specification {
-  static {
-    ConfigUtils.makeConfigInstanceModifiable()
-  }
-
   @Rule
   public final RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties()
   @Rule


### PR DESCRIPTION
This pull request increases the stability of tests dealing with config and system properties:

### Simplified `ConfigUtils` interface
The public interface was reduced to two actions:
   * `withNewConfig`: runs the block with a completely new `Config` based on the current system properties
   * `withConfigOverride`: runs the block with a new `Config` based on the old config plus passed in overrides

In both cases, the old config is restored after the block is executed.  This eliminates problems arising from not calling `resetConfig` at the proper time or tests trying to override config in a static scope (nondeterministic)

### Consistent System Properties
The `RestoreSystemProperties` rule or annotation was added to all tests modifying system properties.  This ensures a consistent state and eliminates inadvertent execution order dependencies.  It also removes the need to manually call `clearProperty()`.

### Pre-agent Property Hook
Any class wanting to set system properties before the test agent is created can set `PRE_AGENT_SYS_PROPS` in a static scope.  The agent is then installed in a `withNewConfig` block.  Additionally, for each test class, the system properties are properly reset at the beginning of each test execution.

### Changing the mechanism to set `Config.INSTANCE`
Both reflection and instrumentation were unreliable.  A package private setter greatly simplifies the code required while making it clear its not part of the public interface.