### PR TITLE
Fix Couchbase tests: attempt i+1

### DIFF
--- a/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/springdata/CouchbaseSpringRepositoryTest.groovy
+++ b/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/springdata/CouchbaseSpringRepositoryTest.groovy
@@ -67,16 +67,6 @@ class CouchbaseSpringRepositoryTest extends AbstractCouchbaseTest {
     applicationContext.close()
   }
 
-  def setup() {
-    repo.deleteAll()
-    TEST_WRITER.waitForTraces(1) // There might be more if there were documents to delete
-    TEST_WRITER.clear()
-  }
-
-  def cleanup() {
-    repo.deleteAll()
-  }
-
   def "test empty repo"() {
     when:
     def result = repo.findAll()
@@ -106,6 +96,11 @@ class CouchbaseSpringRepositoryTest extends AbstractCouchbaseTest {
         assertCouchbaseCall(it, 0, "Bucket.upsert", bucketCouchbase.name())
       }
     }
+
+    cleanup:
+    TEST_WRITER.clear()
+    repo.deleteAll()
+    TEST_WRITER.waitForTraces(2)
   }
 
   def "test save and retrieve"() {
@@ -130,6 +125,11 @@ class CouchbaseSpringRepositoryTest extends AbstractCouchbaseTest {
         assertCouchbaseCall(it, 1, "Bucket.get", bucketCouchbase.name(), span(0))
       }
     }
+
+    cleanup:
+    TEST_WRITER.clear()
+    repo.deleteAll()
+    TEST_WRITER.waitForTraces(2)
   }
 
   def "test save and update"() {
@@ -154,6 +154,11 @@ class CouchbaseSpringRepositoryTest extends AbstractCouchbaseTest {
         assertCouchbaseCall(it, 2, "Bucket.upsert", bucketCouchbase.name(), span(0))
       }
     }
+
+    cleanup:
+    TEST_WRITER.clear()
+    repo.deleteAll()
+    TEST_WRITER.waitForTraces(2)
   }
 
   def "save and delete"() {


### PR DESCRIPTION
`repo.deleteAll()`  creates a variable number of traces depending on the state of the repo.  On an empty repo, it creates one trace; otherwise it creates "1+the number of objects in the repo".  The lead to a race condition between the traces returned by `setup()` and and invocation of `TEST_WRITER.clear()` that happened at the beginning of each test.

Instead of a generic setup()/cleanup(), each test is now responsible for cleaning up the repo and waiting for the appropriate number of traces.