### PR TITLE
Locking spring-kafka-test at 2.2

### DIFF
--- a/dd-java-agent/instrumentation/kafka-clients-0.11/kafka-clients-0.11.gradle
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/kafka-clients-0.11.gradle
@@ -31,7 +31,7 @@ dependencies {
   // This seems to help with jar compatibility hell.
   latestDepTestCompile group: 'org.apache.kafka', name: 'kafka_2.11', version: '+'
   latestDepTestCompile group: 'org.apache.kafka', name: 'kafka-clients', version: '+'
-  latestDepTestCompile group: 'org.springframework.kafka', name: 'spring-kafka', version: '+'
-  latestDepTestCompile group: 'org.springframework.kafka', name: 'spring-kafka-test', version: '+'
+  latestDepTestCompile group: 'org.springframework.kafka', name: 'spring-kafka', version: '(,2.2.*)'
+  latestDepTestCompile group: 'org.springframework.kafka', name: 'spring-kafka-test', version: '(,2.2.*)'
   latestDepTestCompile group: 'org.assertj', name: 'assertj-core', version: '3.+'
 }

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/kafka-clients-0.11.gradle
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/kafka-clients-0.11.gradle
@@ -31,7 +31,7 @@ dependencies {
   // This seems to help with jar compatibility hell.
   latestDepTestCompile group: 'org.apache.kafka', name: 'kafka_2.11', version: '+'
   latestDepTestCompile group: 'org.apache.kafka', name: 'kafka-clients', version: '+'
-  latestDepTestCompile group: 'org.springframework.kafka', name: 'spring-kafka', version: '(,2.2.*)'
-  latestDepTestCompile group: 'org.springframework.kafka', name: 'spring-kafka-test', version: '(,2.2.*)'
+  latestDepTestCompile group: 'org.springframework.kafka', name: 'spring-kafka', version: '(,2.2.+)'
+  latestDepTestCompile group: 'org.springframework.kafka', name: 'spring-kafka-test', version: '(,2.2.+)'
   latestDepTestCompile group: 'org.assertj', name: 'assertj-core', version: '3.+'
 }

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/kafka-streams-0.11.gradle
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/kafka-streams-0.11.gradle
@@ -36,7 +36,7 @@ dependencies {
   latestDepTestCompile group: 'org.apache.kafka', name: 'kafka_2.11', version: '+'
   latestDepTestCompile group: 'org.apache.kafka', name: 'kafka-clients', version: '+'
   latestDepTestCompile group: 'org.apache.kafka', name: 'kafka-streams', version: '+'
-  latestDepTestCompile group: 'org.springframework.kafka', name: 'spring-kafka', version: '+'
-  latestDepTestCompile group: 'org.springframework.kafka', name: 'spring-kafka-test', version: '+'
+  latestDepTestCompile group: 'org.springframework.kafka', name: 'spring-kafka', version: '(,2.2.*)'
+  latestDepTestCompile group: 'org.springframework.kafka', name: 'spring-kafka-test', version: '(,2.2.*)'
   latestDepTestCompile group: 'org.assertj', name: 'assertj-core', version: '3.+'
 }

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/kafka-streams-0.11.gradle
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/kafka-streams-0.11.gradle
@@ -36,7 +36,7 @@ dependencies {
   latestDepTestCompile group: 'org.apache.kafka', name: 'kafka_2.11', version: '+'
   latestDepTestCompile group: 'org.apache.kafka', name: 'kafka-clients', version: '+'
   latestDepTestCompile group: 'org.apache.kafka', name: 'kafka-streams', version: '+'
-  latestDepTestCompile group: 'org.springframework.kafka', name: 'spring-kafka', version: '(,2.2.*)'
-  latestDepTestCompile group: 'org.springframework.kafka', name: 'spring-kafka-test', version: '(,2.2.*)'
+  latestDepTestCompile group: 'org.springframework.kafka', name: 'spring-kafka', version: '(,2.2.+)'
+  latestDepTestCompile group: 'org.springframework.kafka', name: 'spring-kafka-test', version: '(,2.2.+)'
   latestDepTestCompile group: 'org.assertj', name: 'assertj-core', version: '3.+'
 }


### PR DESCRIPTION
spring-kafka-test 2.3 renamed ...rule.EmbeddedKafka to ...rule.EmbeddedKafkaRule

Setting upper bound of 2.2 for now