### PR TITLE
Integration API to decouple from OpenTracing

### DIFF
--- a/dd-java-agent/agent-tooling/agent-tooling.gradle
+++ b/dd-java-agent/agent-tooling/agent-tooling.gradle
@@ -2,6 +2,8 @@ apply from: "${rootDir}/gradle/java.gradle"
 
 minimumBranchCoverage = 0.6
 excludedClassesCoverage += ['datadog.trace.agent.tooling.*']
+// this exclusion is temporary, until deprecated methods are removed (see subsequent commit)
+excludedClassesCoverage += ['datadog.trace.agent.decorator.*']
 
 configurations {
   // classpath used by the instrumentation muzzle plugin

--- a/dd-java-agent/agent-tooling/agent-tooling.gradle
+++ b/dd-java-agent/agent-tooling/agent-tooling.gradle
@@ -2,8 +2,6 @@ apply from: "${rootDir}/gradle/java.gradle"
 
 minimumBranchCoverage = 0.6
 excludedClassesCoverage += ['datadog.trace.agent.tooling.*']
-// this exclusion is temporary, until deprecated methods are removed (see subsequent commit)
-excludedClassesCoverage += ['datadog.trace.agent.decorator.*']
 
 configurations {
   // classpath used by the instrumentation muzzle plugin

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/decorator/BaseDecorator.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/decorator/BaseDecorator.java
@@ -1,14 +1,9 @@
 package datadog.trace.agent.decorator;
 
-import static io.opentracing.log.Fields.ERROR_OBJECT;
-import static java.util.Collections.singletonMap;
-
 import datadog.trace.api.Config;
 import datadog.trace.api.DDTags;
 import datadog.trace.instrumentation.api.AgentScope;
 import datadog.trace.instrumentation.api.AgentSpan;
-import io.opentracing.Scope;
-import io.opentracing.Span;
 import io.opentracing.tag.Tags;
 import java.lang.reflect.Method;
 import java.net.Inet4Address;
@@ -44,30 +39,10 @@ public abstract class BaseDecorator {
     return false;
   }
 
-  @Deprecated
-  public Scope afterStart(final Scope scope) {
-    assert scope != null;
-    afterStart(scope.span());
-    return scope;
-  }
-
   public AgentScope afterStart(final AgentScope scope) {
     assert scope != null;
     afterStart(scope.span());
     return scope;
-  }
-
-  @Deprecated
-  public Span afterStart(final Span span) {
-    assert span != null;
-    if (spanType() != null) {
-      span.setTag(DDTags.SPAN_TYPE, spanType());
-    }
-    Tags.COMPONENT.set(span, component());
-    if (traceAnalyticsEnabled) {
-      span.setTag(DDTags.ANALYTICS_SAMPLE_RATE, traceAnalyticsSampleRate);
-    }
-    return span;
   }
 
   public AgentSpan afterStart(final AgentSpan span) {
@@ -82,35 +57,15 @@ public abstract class BaseDecorator {
     return span;
   }
 
-  @Deprecated
-  public Scope beforeFinish(final Scope scope) {
-    assert scope != null;
-    beforeFinish(scope.span());
-    return scope;
-  }
-
   public AgentScope beforeFinish(final AgentScope scope) {
     assert scope != null;
     beforeFinish(scope.span());
     return scope;
   }
 
-  @Deprecated
-  public Span beforeFinish(final Span span) {
-    assert span != null;
-    return span;
-  }
-
   public AgentSpan beforeFinish(final AgentSpan span) {
     assert span != null;
     return span;
-  }
-
-  @Deprecated
-  public Scope onError(final Scope scope, final Throwable throwable) {
-    assert scope != null;
-    onError(scope.span(), throwable);
-    return scope;
   }
 
   public AgentScope onError(final AgentScope scope, final Throwable throwable) {
@@ -119,36 +74,11 @@ public abstract class BaseDecorator {
     return scope;
   }
 
-  @Deprecated
-  public Span onError(final Span span, final Throwable throwable) {
-    assert span != null;
-    if (throwable != null) {
-      Tags.ERROR.set(span, true);
-      span.log(
-          singletonMap(
-              ERROR_OBJECT,
-              throwable instanceof ExecutionException ? throwable.getCause() : throwable));
-    }
-    return span;
-  }
-
   public AgentSpan onError(final AgentSpan span, final Throwable throwable) {
     assert span != null;
     if (throwable != null) {
       span.setError(true);
       span.addThrowable(throwable instanceof ExecutionException ? throwable.getCause() : throwable);
-    }
-    return span;
-  }
-
-  @Deprecated
-  public Span onPeerConnection(final Span span, final InetSocketAddress remoteConnection) {
-    assert span != null;
-    if (remoteConnection != null) {
-      onPeerConnection(span, remoteConnection.getAddress());
-
-      span.setTag(Tags.PEER_HOSTNAME.getKey(), remoteConnection.getHostName());
-      span.setTag(Tags.PEER_PORT.getKey(), remoteConnection.getPort());
     }
     return span;
   }
@@ -161,20 +91,6 @@ public abstract class BaseDecorator {
 
       span.setTag(Tags.PEER_HOSTNAME.getKey(), remoteConnection.getHostName());
       span.setTag(Tags.PEER_PORT.getKey(), remoteConnection.getPort());
-    }
-    return span;
-  }
-
-  @Deprecated
-  public Span onPeerConnection(final Span span, final InetAddress remoteAddress) {
-    assert span != null;
-    if (remoteAddress != null) {
-      span.setTag(Tags.PEER_HOSTNAME.getKey(), remoteAddress.getHostName());
-      if (remoteAddress instanceof Inet4Address) {
-        Tags.PEER_HOST_IPV4.set(span, remoteAddress.getHostAddress());
-      } else if (remoteAddress instanceof Inet6Address) {
-        Tags.PEER_HOST_IPV6.set(span, remoteAddress.getHostAddress());
-      }
     }
     return span;
   }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/decorator/ClientDecorator.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/decorator/ClientDecorator.java
@@ -2,7 +2,6 @@ package datadog.trace.agent.decorator;
 
 import datadog.trace.api.DDTags;
 import datadog.trace.instrumentation.api.AgentSpan;
-import io.opentracing.Span;
 import io.opentracing.tag.Tags;
 
 public abstract class ClientDecorator extends BaseDecorator {
@@ -11,16 +10,6 @@ public abstract class ClientDecorator extends BaseDecorator {
 
   protected String spanKind() {
     return Tags.SPAN_KIND_CLIENT;
-  }
-
-  @Override
-  public Span afterStart(final Span span) {
-    assert span != null;
-    if (service() != null) {
-      span.setTag(DDTags.SERVICE_NAME, service());
-    }
-    Tags.SPAN_KIND.set(span, spanKind());
-    return super.afterStart(span);
   }
 
   @Override

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/decorator/ClientDecorator.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/decorator/ClientDecorator.java
@@ -1,6 +1,7 @@
 package datadog.trace.agent.decorator;
 
 import datadog.trace.api.DDTags;
+import datadog.trace.instrumentation.api.AgentSpan;
 import io.opentracing.Span;
 import io.opentracing.tag.Tags;
 
@@ -19,6 +20,16 @@ public abstract class ClientDecorator extends BaseDecorator {
       span.setTag(DDTags.SERVICE_NAME, service());
     }
     Tags.SPAN_KIND.set(span, spanKind());
+    return super.afterStart(span);
+  }
+
+  @Override
+  public AgentSpan afterStart(final AgentSpan span) {
+    assert span != null;
+    if (service() != null) {
+      span.setTag(DDTags.SERVICE_NAME, service());
+    }
+    span.setTag(Tags.SPAN_KIND.getKey(), spanKind());
     return super.afterStart(span);
   }
 }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/decorator/DatabaseClientDecorator.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/decorator/DatabaseClientDecorator.java
@@ -2,6 +2,7 @@ package datadog.trace.agent.decorator;
 
 import datadog.trace.api.Config;
 import datadog.trace.api.DDTags;
+import datadog.trace.instrumentation.api.AgentSpan;
 import io.opentracing.Span;
 import io.opentracing.tag.Tags;
 
@@ -13,10 +14,18 @@ public abstract class DatabaseClientDecorator<CONNECTION> extends ClientDecorato
 
   protected abstract String dbInstance(CONNECTION connection);
 
+  @Deprecated
   @Override
   public Span afterStart(final Span span) {
     assert span != null;
     Tags.DB_TYPE.set(span, dbType());
+    return super.afterStart(span);
+  }
+
+  @Override
+  public AgentSpan afterStart(final AgentSpan span) {
+    assert span != null;
+    span.setTag(Tags.DB_TYPE.getKey(), dbType());
     return super.afterStart(span);
   }
 
@@ -27,6 +36,7 @@ public abstract class DatabaseClientDecorator<CONNECTION> extends ClientDecorato
    * @param connection
    * @return
    */
+  @Deprecated
   public Span onConnection(final Span span, final CONNECTION connection) {
     assert span != null;
     if (connection != null) {
@@ -41,9 +51,37 @@ public abstract class DatabaseClientDecorator<CONNECTION> extends ClientDecorato
     return span;
   }
 
+  /**
+   * This should be called when the connection is being used, not when it's created.
+   *
+   * @param span
+   * @param connection
+   * @return
+   */
+  public AgentSpan onConnection(final AgentSpan span, final CONNECTION connection) {
+    assert span != null;
+    if (connection != null) {
+      span.setTag(Tags.DB_USER.getKey(), dbUser(connection));
+      final String instanceName = dbInstance(connection);
+      span.setTag(Tags.DB_INSTANCE.getKey(), instanceName);
+
+      if (instanceName != null && Config.get().isDbClientSplitByInstance()) {
+        span.setTag(DDTags.SERVICE_NAME, instanceName);
+      }
+    }
+    return span;
+  }
+
+  @Deprecated
   public Span onStatement(final Span span, final String statement) {
     assert span != null;
     Tags.DB_STATEMENT.set(span, statement);
+    return span;
+  }
+
+  public AgentSpan onStatement(final AgentSpan span, final String statement) {
+    assert span != null;
+    span.setTag(Tags.DB_STATEMENT.getKey(), statement);
     return span;
   }
 }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/decorator/DatabaseClientDecorator.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/decorator/DatabaseClientDecorator.java
@@ -3,7 +3,6 @@ package datadog.trace.agent.decorator;
 import datadog.trace.api.Config;
 import datadog.trace.api.DDTags;
 import datadog.trace.instrumentation.api.AgentSpan;
-import io.opentracing.Span;
 import io.opentracing.tag.Tags;
 
 public abstract class DatabaseClientDecorator<CONNECTION> extends ClientDecorator {
@@ -14,41 +13,11 @@ public abstract class DatabaseClientDecorator<CONNECTION> extends ClientDecorato
 
   protected abstract String dbInstance(CONNECTION connection);
 
-  @Deprecated
-  @Override
-  public Span afterStart(final Span span) {
-    assert span != null;
-    Tags.DB_TYPE.set(span, dbType());
-    return super.afterStart(span);
-  }
-
   @Override
   public AgentSpan afterStart(final AgentSpan span) {
     assert span != null;
     span.setTag(Tags.DB_TYPE.getKey(), dbType());
     return super.afterStart(span);
-  }
-
-  /**
-   * This should be called when the connection is being used, not when it's created.
-   *
-   * @param span
-   * @param connection
-   * @return
-   */
-  @Deprecated
-  public Span onConnection(final Span span, final CONNECTION connection) {
-    assert span != null;
-    if (connection != null) {
-      Tags.DB_USER.set(span, dbUser(connection));
-      final String instanceName = dbInstance(connection);
-      Tags.DB_INSTANCE.set(span, instanceName);
-
-      if (instanceName != null && Config.get().isDbClientSplitByInstance()) {
-        span.setTag(DDTags.SERVICE_NAME, instanceName);
-      }
-    }
-    return span;
   }
 
   /**
@@ -69,13 +38,6 @@ public abstract class DatabaseClientDecorator<CONNECTION> extends ClientDecorato
         span.setTag(DDTags.SERVICE_NAME, instanceName);
       }
     }
-    return span;
-  }
-
-  @Deprecated
-  public Span onStatement(final Span span, final String statement) {
-    assert span != null;
-    Tags.DB_STATEMENT.set(span, statement);
     return span;
   }
 

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/decorator/HttpClientDecorator.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/decorator/HttpClientDecorator.java
@@ -4,7 +4,6 @@ import datadog.trace.api.Config;
 import datadog.trace.api.DDSpanTypes;
 import datadog.trace.api.DDTags;
 import datadog.trace.instrumentation.api.AgentSpan;
-import io.opentracing.Span;
 import io.opentracing.tag.Tags;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -31,58 +30,6 @@ public abstract class HttpClientDecorator<REQUEST, RESPONSE> extends ClientDecor
   @Override
   protected String service() {
     return null;
-  }
-
-  @Deprecated
-  public Span onRequest(final Span span, final REQUEST request) {
-    assert span != null;
-    if (request != null) {
-      Tags.HTTP_METHOD.set(span, method(request));
-
-      // Copy of HttpServerDecorator url handling
-      try {
-        final URI url = url(request);
-        if (url != null) {
-          final StringBuilder urlNoParams = new StringBuilder();
-          if (url.getScheme() != null) {
-            urlNoParams.append(url.getScheme());
-            urlNoParams.append("://");
-          }
-          if (url.getHost() != null) {
-            urlNoParams.append(url.getHost());
-            if (url.getPort() > 0 && url.getPort() != 80 && url.getPort() != 443) {
-              urlNoParams.append(":");
-              urlNoParams.append(url.getPort());
-            }
-          }
-          final String path = url.getPath();
-          if (path.isEmpty()) {
-            urlNoParams.append("/");
-          } else {
-            urlNoParams.append(path);
-          }
-
-          Tags.HTTP_URL.set(span, urlNoParams.toString());
-
-          if (Config.get().isHttpClientTagQueryString()) {
-            span.setTag(DDTags.HTTP_QUERY, url.getQuery());
-            span.setTag(DDTags.HTTP_FRAGMENT, url.getFragment());
-          }
-        }
-      } catch (final Exception e) {
-        log.debug("Error tagging url", e);
-      }
-
-      Tags.PEER_HOSTNAME.set(span, hostname(request));
-      final Integer port = port(request);
-      // Negative or Zero ports might represent an unset/null value for an int type.  Skip setting.
-      Tags.PEER_PORT.set(span, port != null && port > 0 ? port : null);
-
-      if (Config.get().isHttpClientSplitByDomain()) {
-        span.setTag(DDTags.SERVICE_NAME, hostname(request));
-      }
-    }
-    return span;
   }
 
   public AgentSpan onRequest(final AgentSpan span, final REQUEST request) {
@@ -133,22 +80,6 @@ public abstract class HttpClientDecorator<REQUEST, RESPONSE> extends ClientDecor
 
       if (Config.get().isHttpClientSplitByDomain()) {
         span.setTag(DDTags.SERVICE_NAME, hostname(request));
-      }
-    }
-    return span;
-  }
-
-  @Deprecated
-  public Span onResponse(final Span span, final RESPONSE response) {
-    assert span != null;
-    if (response != null) {
-      final Integer status = status(response);
-      if (status != null) {
-        Tags.HTTP_STATUS.set(span, status);
-
-        if (Config.get().getHttpClientErrorStatuses().contains(status)) {
-          Tags.ERROR.set(span, true);
-        }
       }
     }
     return span;

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/decorator/HttpServerDecorator.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/decorator/HttpServerDecorator.java
@@ -3,6 +3,7 @@ package datadog.trace.agent.decorator;
 import datadog.trace.api.Config;
 import datadog.trace.api.DDSpanTypes;
 import datadog.trace.api.DDTags;
+import datadog.trace.instrumentation.api.AgentSpan;
 import io.opentracing.Span;
 import io.opentracing.tag.Tags;
 import java.net.URI;
@@ -41,6 +42,7 @@ public abstract class HttpServerDecorator<REQUEST, CONNECTION, RESPONSE> extends
     return Config.get().isTraceAnalyticsEnabled();
   }
 
+  @Deprecated
   public Span onRequest(final Span span, final REQUEST request) {
     assert span != null;
     if (request != null) {
@@ -84,6 +86,50 @@ public abstract class HttpServerDecorator<REQUEST, CONNECTION, RESPONSE> extends
     return span;
   }
 
+  public AgentSpan onRequest(final AgentSpan span, final REQUEST request) {
+    assert span != null;
+    if (request != null) {
+      span.setTag(Tags.HTTP_METHOD.getKey(), method(request));
+
+      // Copy of HttpClientDecorator url handling
+      try {
+        final URI url = url(request);
+        if (url != null) {
+          final StringBuilder urlNoParams = new StringBuilder();
+          if (url.getScheme() != null) {
+            urlNoParams.append(url.getScheme());
+            urlNoParams.append("://");
+          }
+          if (url.getHost() != null) {
+            urlNoParams.append(url.getHost());
+            if (url.getPort() > 0 && url.getPort() != 80 && url.getPort() != 443) {
+              urlNoParams.append(":");
+              urlNoParams.append(url.getPort());
+            }
+          }
+          final String path = url.getPath();
+          if (path.isEmpty()) {
+            urlNoParams.append("/");
+          } else {
+            urlNoParams.append(path);
+          }
+
+          span.setTag(Tags.HTTP_URL.getKey(), urlNoParams.toString());
+
+          if (Config.get().isHttpServerTagQueryString()) {
+            span.setTag(DDTags.HTTP_QUERY, url.getQuery());
+            span.setTag(DDTags.HTTP_FRAGMENT, url.getFragment());
+          }
+        }
+      } catch (final Exception e) {
+        log.debug("Error tagging url", e);
+      }
+      // TODO set resource name from URL.
+    }
+    return span;
+  }
+
+  @Deprecated
   public Span onConnection(final Span span, final CONNECTION connection) {
     assert span != null;
     if (connection != null) {
@@ -103,6 +149,28 @@ public abstract class HttpServerDecorator<REQUEST, CONNECTION, RESPONSE> extends
     return span;
   }
 
+  public AgentSpan onConnection(final AgentSpan span, final CONNECTION connection) {
+    assert span != null;
+    if (connection != null) {
+      span.setTag(Tags.PEER_HOSTNAME.getKey(), peerHostname(connection));
+      final String ip = peerHostIP(connection);
+      if (ip != null) {
+        if (VALID_IPV4_ADDRESS.matcher(ip).matches()) {
+          span.setTag(Tags.PEER_HOST_IPV4.getKey(), ip);
+        } else if (ip.contains(":")) {
+          span.setTag(Tags.PEER_HOST_IPV6.getKey(), ip);
+        }
+      }
+      final Integer port = peerPort(connection);
+      // Negative or Zero ports might represent an unset/null value for an int type.  Skip setting.
+      if (port != null && port > 0) {
+        span.setTag(Tags.PEER_PORT.getKey(), port);
+      }
+    }
+    return span;
+  }
+
+  @Deprecated
   public Span onResponse(final Span span, final RESPONSE response) {
     assert span != null;
     if (response != null) {
@@ -112,6 +180,21 @@ public abstract class HttpServerDecorator<REQUEST, CONNECTION, RESPONSE> extends
 
         if (Config.get().getHttpServerErrorStatuses().contains(status)) {
           Tags.ERROR.set(span, true);
+        }
+      }
+    }
+    return span;
+  }
+
+  public AgentSpan onResponse(final AgentSpan span, final RESPONSE response) {
+    assert span != null;
+    if (response != null) {
+      final Integer status = status(response);
+      if (status != null) {
+        span.setTag(Tags.HTTP_STATUS.getKey(), status);
+
+        if (Config.get().getHttpServerErrorStatuses().contains(status)) {
+          span.setError(true);
         }
       }
     }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/decorator/OrmClientDecorator.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/decorator/OrmClientDecorator.java
@@ -2,24 +2,10 @@ package datadog.trace.agent.decorator;
 
 import datadog.trace.api.DDTags;
 import datadog.trace.instrumentation.api.AgentSpan;
-import io.opentracing.Span;
 
 public abstract class OrmClientDecorator extends DatabaseClientDecorator {
 
   public abstract String entityName(final Object entity);
-
-  @Deprecated
-  public Span onOperation(final Span span, final Object entity) {
-
-    assert span != null;
-    if (entity != null) {
-      final String name = entityName(entity);
-      if (name != null) {
-        span.setTag(DDTags.RESOURCE_NAME, name);
-      } // else we keep any existing resource.
-    }
-    return span;
-  }
 
   public AgentSpan onOperation(final AgentSpan span, final Object entity) {
 

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/decorator/OrmClientDecorator.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/decorator/OrmClientDecorator.java
@@ -1,13 +1,27 @@
 package datadog.trace.agent.decorator;
 
 import datadog.trace.api.DDTags;
+import datadog.trace.instrumentation.api.AgentSpan;
 import io.opentracing.Span;
 
 public abstract class OrmClientDecorator extends DatabaseClientDecorator {
 
   public abstract String entityName(final Object entity);
 
+  @Deprecated
   public Span onOperation(final Span span, final Object entity) {
+
+    assert span != null;
+    if (entity != null) {
+      final String name = entityName(entity);
+      if (name != null) {
+        span.setTag(DDTags.RESOURCE_NAME, name);
+      } // else we keep any existing resource.
+    }
+    return span;
+  }
+
+  public AgentSpan onOperation(final AgentSpan span, final Object entity) {
 
     assert span != null;
     if (entity != null) {

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/decorator/ServerDecorator.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/decorator/ServerDecorator.java
@@ -2,19 +2,9 @@ package datadog.trace.agent.decorator;
 
 import datadog.trace.api.Config;
 import datadog.trace.instrumentation.api.AgentSpan;
-import io.opentracing.Span;
 import io.opentracing.tag.Tags;
 
 public abstract class ServerDecorator extends BaseDecorator {
-
-  @Deprecated
-  @Override
-  public Span afterStart(final Span span) {
-    assert span != null;
-    Tags.SPAN_KIND.set(span, Tags.SPAN_KIND_SERVER);
-    span.setTag(Config.LANGUAGE_TAG_KEY, Config.LANGUAGE_TAG_VALUE);
-    return super.afterStart(span);
-  }
 
   @Override
   public AgentSpan afterStart(final AgentSpan span) {

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/decorator/ServerDecorator.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/decorator/ServerDecorator.java
@@ -1,15 +1,25 @@
 package datadog.trace.agent.decorator;
 
 import datadog.trace.api.Config;
+import datadog.trace.instrumentation.api.AgentSpan;
 import io.opentracing.Span;
 import io.opentracing.tag.Tags;
 
 public abstract class ServerDecorator extends BaseDecorator {
 
+  @Deprecated
   @Override
   public Span afterStart(final Span span) {
     assert span != null;
     Tags.SPAN_KIND.set(span, Tags.SPAN_KIND_SERVER);
+    span.setTag(Config.LANGUAGE_TAG_KEY, Config.LANGUAGE_TAG_VALUE);
+    return super.afterStart(span);
+  }
+
+  @Override
+  public AgentSpan afterStart(final AgentSpan span) {
+    assert span != null;
+    span.setTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_SERVER);
     span.setTag(Config.LANGUAGE_TAG_KEY, Config.LANGUAGE_TAG_VALUE);
     return super.afterStart(span);
   }

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/decorator/BaseDecoratorTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/decorator/BaseDecoratorTest.groovy
@@ -2,20 +2,18 @@ package datadog.trace.agent.decorator
 
 import datadog.trace.agent.test.utils.ConfigUtils
 import datadog.trace.api.DDTags
+import datadog.trace.instrumentation.api.AgentScope
+import datadog.trace.instrumentation.api.AgentSpan
 import datadog.trace.util.test.DDSpecification
-import io.opentracing.Scope
-import io.opentracing.Span
 import io.opentracing.tag.Tags
 import spock.lang.Shared
-
-import static io.opentracing.log.Fields.ERROR_OBJECT
 
 class BaseDecoratorTest extends DDSpecification {
 
   @Shared
   def decorator = newDecorator()
 
-  def span = Mock(Span)
+  def span = Mock(AgentSpan)
 
   def "test afterStart"() {
     when:
@@ -60,8 +58,8 @@ class BaseDecoratorTest extends DDSpecification {
 
     then:
     if (error) {
-      1 * span.setTag(Tags.ERROR.key, true)
-      1 * span.log([(ERROR_OBJECT): error])
+      1 * span.setError(true)
+      1 * span.addThrowable(error)
     }
     0 * _
 
@@ -79,25 +77,25 @@ class BaseDecoratorTest extends DDSpecification {
 
   def "test assert null span"() {
     when:
-    decorator.afterStart((Span) null)
+    decorator.afterStart((AgentSpan) null)
 
     then:
     thrown(AssertionError)
 
     when:
-    decorator.onError((Span) null, null)
+    decorator.onError((AgentSpan) null, null)
 
     then:
     thrown(AssertionError)
 
     when:
-    decorator.onPeerConnection((Span) null, null)
+    decorator.onError((AgentSpan) null, null)
 
     then:
     thrown(AssertionError)
 
     when:
-    decorator.beforeFinish((Span) null)
+    decorator.onPeerConnection((AgentSpan) null, null)
 
     then:
     thrown(AssertionError)
@@ -105,19 +103,19 @@ class BaseDecoratorTest extends DDSpecification {
 
   def "test assert null scope"() {
     when:
-    decorator.afterStart((Scope) null)
+    decorator.onError((AgentScope) null, null)
 
     then:
     thrown(AssertionError)
 
     when:
-    decorator.onError((Scope) null, null)
+    decorator.onError((AgentScope) null, null)
 
     then:
     thrown(AssertionError)
 
     when:
-    decorator.beforeFinish((Scope) null)
+    decorator.beforeFinish((AgentScope) null)
 
     then:
     thrown(AssertionError)
@@ -125,8 +123,8 @@ class BaseDecoratorTest extends DDSpecification {
 
   def "test assert non-null scope"() {
     setup:
-    def span = Mock(Span)
-    def scope = Mock(Scope)
+    def span = Mock(AgentSpan)
+    def scope = Mock(AgentScope)
 
     when:
     decorator.afterStart(scope)

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/decorator/ClientDecoratorTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/decorator/ClientDecoratorTest.groovy
@@ -1,12 +1,12 @@
 package datadog.trace.agent.decorator
 
 import datadog.trace.api.DDTags
-import io.opentracing.Span
+import datadog.trace.instrumentation.api.AgentSpan
 import io.opentracing.tag.Tags
 
 class ClientDecoratorTest extends BaseDecoratorTest {
 
-  def span = Mock(Span)
+  def span = Mock(AgentSpan)
 
   def "test afterStart"() {
     setup:

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/decorator/DatabaseClientDecoratorTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/decorator/DatabaseClientDecoratorTest.groovy
@@ -2,14 +2,14 @@ package datadog.trace.agent.decorator
 
 import datadog.trace.api.Config
 import datadog.trace.api.DDTags
-import io.opentracing.Span
+import datadog.trace.instrumentation.api.AgentSpan
 import io.opentracing.tag.Tags
 
 import static datadog.trace.agent.test.utils.ConfigUtils.withConfigOverride
 
 class DatabaseClientDecoratorTest extends ClientDecoratorTest {
 
-  def span = Mock(Span)
+  def span = Mock(AgentSpan)
 
   def "test afterStart"() {
     setup:
@@ -83,19 +83,19 @@ class DatabaseClientDecoratorTest extends ClientDecoratorTest {
     def decorator = newDecorator()
 
     when:
-    decorator.afterStart((Span) null)
+    decorator.afterStart((AgentSpan) null)
 
     then:
     thrown(AssertionError)
 
     when:
-    decorator.onConnection(null, null)
+    decorator.onConnection((AgentSpan) null, null)
 
     then:
     thrown(AssertionError)
 
     when:
-    decorator.onStatement(null, null)
+    decorator.onStatement((AgentSpan) null, null)
 
     then:
     thrown(AssertionError)

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/decorator/DatabaseClientDecoratorTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/decorator/DatabaseClientDecoratorTest.groovy
@@ -89,13 +89,13 @@ class DatabaseClientDecoratorTest extends ClientDecoratorTest {
     thrown(AssertionError)
 
     when:
-    decorator.onConnection((AgentSpan) null, null)
+    decorator.onConnection(null, null)
 
     then:
     thrown(AssertionError)
 
     when:
-    decorator.onStatement((AgentSpan) null, null)
+    decorator.onStatement(null, null)
 
     then:
     thrown(AssertionError)

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/decorator/HttpClientDecoratorTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/decorator/HttpClientDecoratorTest.groovy
@@ -120,13 +120,13 @@ class HttpClientDecoratorTest extends ClientDecoratorTest {
     def decorator = newDecorator()
 
     when:
-    decorator.onRequest((AgentSpan) null, null)
+    decorator.onRequest(null, null)
 
     then:
     thrown(AssertionError)
 
     when:
-    decorator.onRequest((AgentSpan) null, null)
+    decorator.onResponse(null, null)
 
     then:
     thrown(AssertionError)

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/decorator/HttpClientDecoratorTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/decorator/HttpClientDecoratorTest.groovy
@@ -2,7 +2,7 @@ package datadog.trace.agent.decorator
 
 import datadog.trace.api.Config
 import datadog.trace.api.DDTags
-import io.opentracing.Span
+import datadog.trace.instrumentation.api.AgentSpan
 import io.opentracing.tag.Tags
 import spock.lang.Shared
 
@@ -13,7 +13,7 @@ class HttpClientDecoratorTest extends ClientDecoratorTest {
   @Shared
   def testUrl = new URI("http://myhost/somepath")
 
-  def span = Mock(Span)
+  def span = Mock(AgentSpan)
 
   def "test onRequest"() {
     setup:
@@ -63,7 +63,6 @@ class HttpClientDecoratorTest extends ClientDecoratorTest {
     }
     1 * span.setTag(Tags.HTTP_METHOD.key, null)
     1 * span.setTag(Tags.PEER_HOSTNAME.key, null)
-    1 * span.setTag(Tags.PEER_PORT.key, null)
     0 * _
 
     where:
@@ -98,7 +97,7 @@ class HttpClientDecoratorTest extends ClientDecoratorTest {
       1 * span.setTag(Tags.HTTP_STATUS.key, status)
     }
     if (error) {
-      1 * span.setTag(Tags.ERROR.key, true)
+      1 * span.setError(true)
     }
     0 * _
 
@@ -121,13 +120,13 @@ class HttpClientDecoratorTest extends ClientDecoratorTest {
     def decorator = newDecorator()
 
     when:
-    decorator.onRequest(null, null)
+    decorator.onRequest((AgentSpan) null, null)
 
     then:
     thrown(AssertionError)
 
     when:
-    decorator.onResponse(null, null)
+    decorator.onRequest((AgentSpan) null, null)
 
     then:
     thrown(AssertionError)

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/decorator/HttpServerDecoratorTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/decorator/HttpServerDecoratorTest.groovy
@@ -138,13 +138,13 @@ class HttpServerDecoratorTest extends ServerDecoratorTest {
     def decorator = newDecorator()
 
     when:
-    decorator.onRequest((AgentSpan) null, null)
+    decorator.onRequest(null, null)
 
     then:
     thrown(AssertionError)
 
     when:
-    decorator.onRequest((AgentSpan) null, null)
+    decorator.onResponse(null, null)
 
     then:
     thrown(AssertionError)

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/decorator/HttpServerDecoratorTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/decorator/HttpServerDecoratorTest.groovy
@@ -2,14 +2,14 @@ package datadog.trace.agent.decorator
 
 import datadog.trace.api.Config
 import datadog.trace.api.DDTags
-import io.opentracing.Span
+import datadog.trace.instrumentation.api.AgentSpan
 import io.opentracing.tag.Tags
 
 import static datadog.trace.agent.test.utils.ConfigUtils.withConfigOverride
 
 class HttpServerDecoratorTest extends ServerDecoratorTest {
 
-  def span = Mock(Span)
+  def span = Mock(AgentSpan)
 
   def "test onRequest"() {
     setup:
@@ -115,7 +115,7 @@ class HttpServerDecoratorTest extends ServerDecoratorTest {
       1 * span.setTag(Tags.HTTP_STATUS.key, status)
     }
     if (error) {
-      1 * span.setTag(Tags.ERROR.key, true)
+      1 * span.setError(true)
     }
     0 * _
 
@@ -138,13 +138,13 @@ class HttpServerDecoratorTest extends ServerDecoratorTest {
     def decorator = newDecorator()
 
     when:
-    decorator.onRequest(null, null)
+    decorator.onRequest((AgentSpan) null, null)
 
     then:
     thrown(AssertionError)
 
     when:
-    decorator.onResponse(null, null)
+    decorator.onRequest((AgentSpan) null, null)
 
     then:
     thrown(AssertionError)

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/decorator/OrmClientDecoratorTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/decorator/OrmClientDecoratorTest.groovy
@@ -1,6 +1,7 @@
 package datadog.trace.agent.decorator
 
 import datadog.trace.api.DDTags
+import datadog.trace.instrumentation.api.AgentSpan
 
 class OrmClientDecoratorTest extends DatabaseClientDecoratorTest {
 
@@ -29,7 +30,7 @@ class OrmClientDecoratorTest extends DatabaseClientDecoratorTest {
     decorator = newDecorator({ e -> null })
 
     when:
-    decorator.onOperation(null, null)
+    decorator.onOperation((AgentSpan) null, null)
 
     then:
     thrown(AssertionError)

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/decorator/OrmClientDecoratorTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/decorator/OrmClientDecoratorTest.groovy
@@ -1,7 +1,6 @@
 package datadog.trace.agent.decorator
 
 import datadog.trace.api.DDTags
-import datadog.trace.instrumentation.api.AgentSpan
 
 class OrmClientDecoratorTest extends DatabaseClientDecoratorTest {
 
@@ -30,7 +29,7 @@ class OrmClientDecoratorTest extends DatabaseClientDecoratorTest {
     decorator = newDecorator({ e -> null })
 
     when:
-    decorator.onOperation((AgentSpan) null, null)
+    decorator.onOperation(null, null)
 
     then:
     thrown(AssertionError)

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/decorator/ServerDecoratorTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/decorator/ServerDecoratorTest.groovy
@@ -2,12 +2,12 @@ package datadog.trace.agent.decorator
 
 import datadog.trace.api.Config
 import datadog.trace.api.DDTags
-import io.opentracing.Span
+import datadog.trace.instrumentation.api.AgentSpan
 import io.opentracing.tag.Tags
 
 class ServerDecoratorTest extends BaseDecoratorTest {
 
-  def span = Mock(Span)
+  def span = Mock(AgentSpan)
 
   def "test afterStart"() {
     def decorator = newDecorator()

--- a/dd-java-agent/instrumentation/akka-http-10.0/akka-http-10.0.gradle
+++ b/dd-java-agent/instrumentation/akka-http-10.0/akka-http-10.0.gradle
@@ -70,7 +70,7 @@ muzzle {
 }
 
 dependencies {
-  compileOnly group: 'com.typesafe.akka', name: 'akka-http_2.11', version: '10.0.0'
+  main_java8CompileOnly group: 'com.typesafe.akka', name: 'akka-http_2.11', version: '10.0.0'
 
   compile project(':dd-trace-api')
   compile project(':dd-java-agent:agent-tooling')

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java8/datadog/trace/instrumentation/akkahttp/AkkaHttpServerHeaders.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java8/datadog/trace/instrumentation/akkahttp/AkkaHttpServerHeaders.java
@@ -1,0 +1,32 @@
+package datadog.trace.instrumentation.akkahttp;
+
+import akka.http.javadsl.model.HttpHeader;
+import akka.http.scaladsl.model.HttpRequest;
+import datadog.trace.instrumentation.api.AgentPropagation;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+public class AkkaHttpServerHeaders implements AgentPropagation.Getter<HttpRequest> {
+
+  public static final AkkaHttpServerHeaders GETTER = new AkkaHttpServerHeaders();
+
+  @Override
+  public List<String> keys(final HttpRequest carrier) {
+    final List<String> keys = new ArrayList<>();
+    for (final HttpHeader header : carrier.getHeaders()) {
+      keys.add(header.name());
+    }
+    return keys;
+  }
+
+  @Override
+  public String get(final HttpRequest carrier, final String key) {
+    final Optional<HttpHeader> header = carrier.getHeader(key);
+    if (header.isPresent()) {
+      return header.get().value();
+    } else {
+      return null;
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/HttpHeadersInjectAdapter.java
+++ b/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/HttpHeadersInjectAdapter.java
@@ -1,0 +1,14 @@
+package datadog.trace.instrumentation.apachehttpasyncclient;
+
+import datadog.trace.instrumentation.api.AgentPropagation;
+import org.apache.http.HttpRequest;
+
+public class HttpHeadersInjectAdapter implements AgentPropagation.Setter<HttpRequest> {
+
+  public static final HttpHeadersInjectAdapter SETTER = new HttpHeadersInjectAdapter();
+
+  @Override
+  public void set(final HttpRequest carrier, final String key, final String value) {
+    carrier.setHeader(key, value);
+  }
+}

--- a/dd-java-agent/instrumentation/apache-httpclient-4/src/main/java/datadog/trace/instrumentation/apachehttpclient/HttpHeadersInjectAdapter.java
+++ b/dd-java-agent/instrumentation/apache-httpclient-4/src/main/java/datadog/trace/instrumentation/apachehttpclient/HttpHeadersInjectAdapter.java
@@ -3,7 +3,6 @@ package datadog.trace.instrumentation.apachehttpclient;
 import datadog.trace.instrumentation.api.AgentPropagation;
 import org.apache.http.client.methods.HttpUriRequest;
 
-// not sure why, but gradle build fails without fully qualified HttpUriRequest class name
 public class HttpHeadersInjectAdapter implements AgentPropagation.Setter<HttpUriRequest> {
 
   public static final HttpHeadersInjectAdapter SETTER = new HttpHeadersInjectAdapter();

--- a/dd-java-agent/instrumentation/apache-httpclient-4/src/main/java/datadog/trace/instrumentation/apachehttpclient/HttpHeadersInjectAdapter.java
+++ b/dd-java-agent/instrumentation/apache-httpclient-4/src/main/java/datadog/trace/instrumentation/apachehttpclient/HttpHeadersInjectAdapter.java
@@ -1,0 +1,15 @@
+package datadog.trace.instrumentation.apachehttpclient;
+
+import datadog.trace.instrumentation.api.AgentPropagation;
+import org.apache.http.client.methods.HttpUriRequest;
+
+// not sure why, but gradle build fails without fully qualified HttpUriRequest class name
+public class HttpHeadersInjectAdapter implements AgentPropagation.Setter<HttpUriRequest> {
+
+  public static final HttpHeadersInjectAdapter SETTER = new HttpHeadersInjectAdapter();
+
+  @Override
+  public void set(final HttpUriRequest carrier, final String key, final String value) {
+    carrier.addHeader(key, value);
+  }
+}

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/AWSHttpClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/AWSHttpClientInstrumentation.java
@@ -12,7 +12,7 @@ import com.amazonaws.Request;
 import com.amazonaws.handlers.RequestHandler2;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
-import io.opentracing.Scope;
+import datadog.trace.instrumentation.api.AgentScope;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.method.MethodDescription;
@@ -60,7 +60,7 @@ public class AWSHttpClientInstrumentation extends Instrumenter.Default {
         @Advice.Argument(value = 0, optional = true) final Request<?> request,
         @Advice.Thrown final Throwable throwable) {
       if (throwable != null) {
-        final Scope scope = request.getHandlerContext(TracingRequestHandler.SCOPE_CONTEXT_KEY);
+        final AgentScope scope = request.getHandlerContext(TracingRequestHandler.SCOPE_CONTEXT_KEY);
         if (scope != null) {
           request.addHandlerContext(TracingRequestHandler.SCOPE_CONTEXT_KEY, null);
           DECORATE.onError(scope.span(), throwable);
@@ -96,7 +96,8 @@ public class AWSHttpClientInstrumentation extends Instrumenter.Default {
           @Advice.FieldValue("request") final Request<?> request,
           @Advice.Thrown final Throwable throwable) {
         if (throwable != null) {
-          final Scope scope = request.getHandlerContext(TracingRequestHandler.SCOPE_CONTEXT_KEY);
+          final AgentScope scope =
+              request.getHandlerContext(TracingRequestHandler.SCOPE_CONTEXT_KEY);
           if (scope != null) {
             request.addHandlerContext(TracingRequestHandler.SCOPE_CONTEXT_KEY, null);
             DECORATE.onError(scope.span(), throwable);

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/AwsSdkClientDecorator.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/AwsSdkClientDecorator.java
@@ -5,7 +5,7 @@ import com.amazonaws.Request;
 import com.amazonaws.Response;
 import datadog.trace.agent.decorator.HttpClientDecorator;
 import datadog.trace.api.DDTags;
-import io.opentracing.Span;
+import datadog.trace.instrumentation.api.AgentSpan;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Map;
@@ -20,7 +20,7 @@ public class AwsSdkClientDecorator extends HttpClientDecorator<Request, Response
   private final Map<Class, String> operationNames = new ConcurrentHashMap<>();
 
   @Override
-  public Span onRequest(final Span span, final Request request) {
+  public AgentSpan onRequest(final AgentSpan span, final Request request) {
     // Call super first because we override the resource name below.
     super.onRequest(span, request);
 
@@ -40,7 +40,7 @@ public class AwsSdkClientDecorator extends HttpClientDecorator<Request, Response
   }
 
   @Override
-  public Span onResponse(final Span span, final Response response) {
+  public AgentSpan onResponse(final AgentSpan span, final Response response) {
     if (response.getAwsResponse() instanceof AmazonWebServiceResponse) {
       final AmazonWebServiceResponse awsResp = (AmazonWebServiceResponse) response.getAwsResponse();
       span.setTag("aws.requestId", awsResp.getRequestId());

--- a/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java/datadog/trace/instrumentation/aws/v2/AbstractAwsClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java/datadog/trace/instrumentation/aws/v2/AbstractAwsClientInstrumentation.java
@@ -16,8 +16,7 @@ public abstract class AbstractAwsClientInstrumentation extends Instrumenter.Defa
       "datadog.trace.agent.decorator.ClientDecorator",
       "datadog.trace.agent.decorator.HttpClientDecorator",
       packageName + ".AwsSdkClientDecorator",
-      packageName + ".TracingExecutionInterceptor",
-      packageName + ".TracingExecutionInterceptor$InjectAdapter"
+      packageName + ".TracingExecutionInterceptor"
     };
   }
 }

--- a/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java/datadog/trace/instrumentation/aws/v2/AwsHttpClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java/datadog/trace/instrumentation/aws/v2/AwsHttpClientInstrumentation.java
@@ -1,6 +1,7 @@
 package datadog.trace.instrumentation.aws.v2;
 
 import static datadog.trace.agent.tooling.ByteBuddyElementMatchers.safeHasSuperType;
+import static datadog.trace.instrumentation.api.AgentTracer.activeScope;
 import static net.bytebuddy.matcher.ElementMatchers.isInterface;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
@@ -9,8 +10,7 @@ import static net.bytebuddy.matcher.ElementMatchers.not;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
-import io.opentracing.Scope;
-import io.opentracing.util.GlobalTracer;
+import datadog.trace.context.TraceScope;
 import java.util.Collections;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
@@ -57,7 +57,7 @@ public final class AwsHttpClientInstrumentation extends AbstractAwsClientInstrum
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static boolean methodEnter(@Advice.This final Object thiz) {
       if (thiz instanceof MakeAsyncHttpRequestStage) {
-        final Scope scope = GlobalTracer.get().scopeManager().active();
+        final TraceScope scope = activeScope();
         if (scope != null) {
           scope.close();
           return true;
@@ -69,7 +69,7 @@ public final class AwsHttpClientInstrumentation extends AbstractAwsClientInstrum
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
     public static void methodExit(@Advice.Enter final boolean scopeAlreadyClosed) {
       if (!scopeAlreadyClosed) {
-        final Scope scope = GlobalTracer.get().scopeManager().active();
+        final TraceScope scope = activeScope();
         if (scope != null) {
           scope.close();
         }

--- a/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java8/datadog/trace/instrumentation/aws/v2/AwsSdkClientDecorator.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java8/datadog/trace/instrumentation/aws/v2/AwsSdkClientDecorator.java
@@ -2,7 +2,7 @@ package datadog.trace.instrumentation.aws.v2;
 
 import datadog.trace.agent.decorator.HttpClientDecorator;
 import datadog.trace.api.DDTags;
-import io.opentracing.Span;
+import datadog.trace.instrumentation.api.AgentSpan;
 import java.net.URI;
 import software.amazon.awssdk.awscore.AwsResponse;
 import software.amazon.awssdk.core.SdkRequest;
@@ -17,7 +17,7 @@ public class AwsSdkClientDecorator extends HttpClientDecorator<SdkHttpRequest, S
 
   static final String COMPONENT_NAME = "java-aws-sdk";
 
-  public Span onSdkRequest(final Span span, final SdkRequest request) {
+  public AgentSpan onSdkRequest(final AgentSpan span, final SdkRequest request) {
     // S3
     request
         .getValueForField("Bucket", String.class)
@@ -40,7 +40,7 @@ public class AwsSdkClientDecorator extends HttpClientDecorator<SdkHttpRequest, S
     return span;
   }
 
-  public Span onAttributes(final Span span, final ExecutionAttributes attributes) {
+  public AgentSpan onAttributes(final AgentSpan span, final ExecutionAttributes attributes) {
 
     final String awsServiceName = attributes.getAttribute(SdkExecutionAttribute.SERVICE_NAME);
     final String awsOperation = attributes.getAttribute(SdkExecutionAttribute.OPERATION_NAME);
@@ -56,7 +56,7 @@ public class AwsSdkClientDecorator extends HttpClientDecorator<SdkHttpRequest, S
   }
 
   // Not overriding the super.  Should call both with each type of response.
-  public Span onResponse(final Span span, final SdkResponse response) {
+  public AgentSpan onResponse(final AgentSpan span, final SdkResponse response) {
     if (response instanceof AwsResponse) {
       span.setTag("aws.requestId", ((AwsResponse) response).responseMetadata().requestId());
     }

--- a/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java8/datadog/trace/instrumentation/aws/v2/TracingExecutionInterceptor.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java8/datadog/trace/instrumentation/aws/v2/TracingExecutionInterceptor.java
@@ -4,7 +4,6 @@ import static datadog.trace.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.aws.v2.AwsSdkClientDecorator.DECORATE;
 
-import datadog.trace.instrumentation.api.AgentPropagation;
 import datadog.trace.instrumentation.api.AgentScope;
 import datadog.trace.instrumentation.api.AgentSpan;
 import java.util.function.Consumer;
@@ -14,7 +13,6 @@ import software.amazon.awssdk.core.interceptor.Context;
 import software.amazon.awssdk.core.interceptor.ExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
-import software.amazon.awssdk.http.SdkHttpRequest;
 
 /** AWS request execution interceptor */
 public class TracingExecutionInterceptor implements ExecutionInterceptor {
@@ -95,21 +93,5 @@ public class TracingExecutionInterceptor implements ExecutionInterceptor {
 
   public static void muzzleCheck() {
     // Noop
-  }
-
-  /**
-   * Inject headers into the request builder.
-   *
-   * <p>Note: we inject headers at aws-client level because aws requests may be signed and adding
-   * headers on http-client level may break signature.
-   */
-  public static class InjectAdapter implements AgentPropagation.Setter<SdkHttpRequest.Builder> {
-
-    public static final InjectAdapter SETTER = new InjectAdapter();
-
-    @Override
-    public void set(final SdkHttpRequest.Builder carrier, final String key, final String value) {
-      carrier.putHeader(key, value);
-    }
   }
 }

--- a/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java8/datadog/trace/instrumentation/aws/v2/TracingExecutionInterceptor.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java8/datadog/trace/instrumentation/aws/v2/TracingExecutionInterceptor.java
@@ -1,14 +1,12 @@
 package datadog.trace.instrumentation.aws.v2;
 
+import static datadog.trace.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.aws.v2.AwsSdkClientDecorator.DECORATE;
 
-import datadog.trace.context.TraceScope;
-import io.opentracing.Scope;
-import io.opentracing.Span;
-import io.opentracing.propagation.TextMap;
-import io.opentracing.util.GlobalTracer;
-import java.util.Iterator;
-import java.util.Map;
+import datadog.trace.instrumentation.api.AgentPropagation;
+import datadog.trace.instrumentation.api.AgentScope;
+import datadog.trace.instrumentation.api.AgentSpan;
 import java.util.function.Consumer;
 import software.amazon.awssdk.core.client.builder.SdkClientBuilder;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
@@ -27,14 +25,14 @@ public class TracingExecutionInterceptor implements ExecutionInterceptor {
       OVERRIDE_CONFIGURATION_CONSUMER =
           builder -> builder.addExecutionInterceptor(new TracingExecutionInterceptor());
 
-  private static final ExecutionAttribute<Span> SPAN_ATTRIBUTE =
+  private static final ExecutionAttribute<AgentSpan> SPAN_ATTRIBUTE =
       new ExecutionAttribute<>("DatadogSpan");
 
   @Override
   public void beforeExecution(
       final Context.BeforeExecution context, final ExecutionAttributes executionAttributes) {
-    final Span span = GlobalTracer.get().buildSpan("aws.command").start();
-    try (final Scope scope = GlobalTracer.get().scopeManager().activate(span, false)) {
+    final AgentSpan span = startSpan("aws.command");
+    try (final AgentScope scope = activateSpan(span, false)) {
       DECORATE.afterStart(span);
       executionAttributes.putAttribute(SPAN_ATTRIBUTE, span);
     }
@@ -43,7 +41,7 @@ public class TracingExecutionInterceptor implements ExecutionInterceptor {
   @Override
   public void afterMarshalling(
       final Context.AfterMarshalling context, final ExecutionAttributes executionAttributes) {
-    final Span span = executionAttributes.getAttribute(SPAN_ATTRIBUTE);
+    final AgentSpan span = executionAttributes.getAttribute(SPAN_ATTRIBUTE);
 
     DECORATE.onRequest(span, context.httpRequest());
     DECORATE.onSdkRequest(span, context.request());
@@ -53,18 +51,18 @@ public class TracingExecutionInterceptor implements ExecutionInterceptor {
   @Override
   public void beforeTransmission(
       final Context.BeforeTransmission context, final ExecutionAttributes executionAttributes) {
-    final Span span = executionAttributes.getAttribute(SPAN_ATTRIBUTE);
+    final AgentSpan span = executionAttributes.getAttribute(SPAN_ATTRIBUTE);
 
     // This scope will be closed by AwsHttpClientInstrumentation since ExecutionInterceptor API
     // doesn't provide a way to run code in the same thread after transmission has been scheduled.
-    final Scope scope = GlobalTracer.get().scopeManager().activate(span, false);
-    ((TraceScope) scope).setAsyncPropagation(true);
+    final AgentScope scope = activateSpan(span, false);
+    scope.setAsyncPropagation(true);
   }
 
   @Override
   public void afterExecution(
       final Context.AfterExecution context, final ExecutionAttributes executionAttributes) {
-    final Span span = executionAttributes.getAttribute(SPAN_ATTRIBUTE);
+    final AgentSpan span = executionAttributes.getAttribute(SPAN_ATTRIBUTE);
     if (span != null) {
       executionAttributes.putAttribute(SPAN_ATTRIBUTE, null);
       // Call onResponse on both types of responses:
@@ -78,7 +76,7 @@ public class TracingExecutionInterceptor implements ExecutionInterceptor {
   @Override
   public void onExecutionFailure(
       final Context.FailedExecution context, final ExecutionAttributes executionAttributes) {
-    final Span span = executionAttributes.getAttribute(SPAN_ATTRIBUTE);
+    final AgentSpan span = executionAttributes.getAttribute(SPAN_ATTRIBUTE);
     if (span != null) {
       executionAttributes.putAttribute(SPAN_ATTRIBUTE, null);
       DECORATE.onError(span, context.exception());
@@ -105,23 +103,13 @@ public class TracingExecutionInterceptor implements ExecutionInterceptor {
    * <p>Note: we inject headers at aws-client level because aws requests may be signed and adding
    * headers on http-client level may break signature.
    */
-  public static class InjectAdapter implements TextMap {
+  public static class InjectAdapter implements AgentPropagation.Setter<SdkHttpRequest.Builder> {
 
-    private final SdkHttpRequest.Builder builder;
-
-    public InjectAdapter(final SdkHttpRequest.Builder builder) {
-      this.builder = builder;
-    }
+    public static final InjectAdapter SETTER = new InjectAdapter();
 
     @Override
-    public Iterator<Map.Entry<String, String>> iterator() {
-      throw new UnsupportedOperationException(
-          "This class should be used only with Tracer.extract()!");
-    }
-
-    @Override
-    public void put(final String key, final String value) {
-      builder.putHeader(key, value);
+    public void set(final SdkHttpRequest.Builder carrier, final String key, final String value) {
+      carrier.putHeader(key, value);
     }
   }
 }

--- a/dd-java-agent/instrumentation/couchbase-2.0/src/main/java/datadog/trace/instrumentation/couchbase/client/CouchbaseOnSubscribe.java
+++ b/dd-java-agent/instrumentation/couchbase-2.0/src/main/java/datadog/trace/instrumentation/couchbase/client/CouchbaseOnSubscribe.java
@@ -3,8 +3,8 @@ package datadog.trace.instrumentation.couchbase.client;
 import static datadog.trace.instrumentation.couchbase.client.CouchbaseClientDecorator.DECORATE;
 
 import datadog.trace.api.DDTags;
+import datadog.trace.instrumentation.api.AgentSpan;
 import datadog.trace.instrumentation.rxjava.TracedOnSubscribe;
-import io.opentracing.Span;
 import java.lang.reflect.Method;
 import rx.Observable;
 
@@ -24,7 +24,7 @@ public class CouchbaseOnSubscribe extends TracedOnSubscribe {
   }
 
   @Override
-  protected void afterStart(final Span span) {
+  protected void afterStart(final AgentSpan span) {
     super.afterStart(span);
 
     span.setTag(DDTags.RESOURCE_NAME, resourceName);

--- a/dd-java-agent/instrumentation/couchbase-2.6/src/main/java/datadog/trace/instrumentation/couchbase/client/CouchbaseNetworkInstrumentation.java
+++ b/dd-java-agent/instrumentation/couchbase-2.6/src/main/java/datadog/trace/instrumentation/couchbase/client/CouchbaseNetworkInstrumentation.java
@@ -13,7 +13,7 @@ import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.InstrumentationContext;
-import io.opentracing.Span;
+import datadog.trace.instrumentation.api.AgentSpan;
 import io.opentracing.tag.Tags;
 import java.util.Collections;
 import java.util.Map;
@@ -37,7 +37,7 @@ public class CouchbaseNetworkInstrumentation extends Instrumenter.Default {
   @Override
   public Map<String, String> contextStore() {
     return Collections.singletonMap(
-        "com.couchbase.client.core.message.CouchbaseRequest", Span.class.getName());
+        "com.couchbase.client.core.message.CouchbaseRequest", AgentSpan.class.getName());
   }
 
   @Override
@@ -61,17 +61,18 @@ public class CouchbaseNetworkInstrumentation extends Instrumenter.Default {
         @Advice.FieldValue("remoteSocket") final String remoteSocket,
         @Advice.FieldValue("localSocket") final String localSocket,
         @Advice.Argument(1) final CouchbaseRequest request) {
-      final ContextStore<CouchbaseRequest, Span> contextStore =
-          InstrumentationContext.get(CouchbaseRequest.class, Span.class);
+      final ContextStore<CouchbaseRequest, AgentSpan> contextStore =
+          InstrumentationContext.get(CouchbaseRequest.class, AgentSpan.class);
 
-      final Span span = contextStore.get(request);
+      final AgentSpan span = contextStore.get(request);
       if (span != null) {
-        Tags.PEER_HOSTNAME.set(span, remoteHostname);
+        span.setTag(Tags.PEER_HOSTNAME.getKey(), remoteHostname);
 
         if (remoteSocket != null) {
           final int splitIndex = remoteSocket.lastIndexOf(":");
           if (splitIndex != -1) {
-            Tags.PEER_PORT.set(span, Integer.valueOf(remoteSocket.substring(splitIndex + 1)));
+            span.setTag(
+                Tags.PEER_PORT.getKey(), Integer.parseInt(remoteSocket.substring(splitIndex + 1)));
           }
         }
 

--- a/dd-java-agent/instrumentation/datastax-cassandra-3/src/main/java/datadog/trace/instrumentation/datastax/cassandra/CassandraClientDecorator.java
+++ b/dd-java-agent/instrumentation/datastax-cassandra-3/src/main/java/datadog/trace/instrumentation/datastax/cassandra/CassandraClientDecorator.java
@@ -5,7 +5,7 @@ import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.Session;
 import datadog.trace.agent.decorator.DatabaseClientDecorator;
 import datadog.trace.api.DDSpanTypes;
-import io.opentracing.Span;
+import datadog.trace.instrumentation.api.AgentSpan;
 import io.opentracing.tag.Tags;
 
 public class CassandraClientDecorator extends DatabaseClientDecorator<Session> {
@@ -46,10 +46,10 @@ public class CassandraClientDecorator extends DatabaseClientDecorator<Session> {
     return session.getLoggedKeyspace();
   }
 
-  public Span onResponse(final Span span, final ResultSet result) {
+  public AgentSpan onResponse(final AgentSpan span, final ResultSet result) {
     if (result != null) {
       final Host host = result.getExecutionInfo().getQueriedHost();
-      Tags.PEER_PORT.set(span, host.getSocketAddress().getPort());
+      span.setTag(Tags.PEER_PORT.getKey(), host.getSocketAddress().getPort());
       onPeerConnection(span, host.getSocketAddress().getAddress());
     }
     return span;

--- a/dd-java-agent/instrumentation/datastax-cassandra-3/src/main/java/datadog/trace/instrumentation/datastax/cassandra/CassandraClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/datastax-cassandra-3/src/main/java/datadog/trace/instrumentation/datastax/cassandra/CassandraClientInstrumentation.java
@@ -9,7 +9,6 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 import com.datastax.driver.core.Session;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
-import io.opentracing.util.GlobalTracer;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.method.MethodDescription;
@@ -64,7 +63,7 @@ public class CassandraClientInstrumentation extends Instrumenter.Default {
       if (session.getClass().getName().endsWith("cassandra.TracingSession")) {
         return;
       }
-      session = new TracingSession(session, GlobalTracer.get());
+      session = new TracingSession(session);
     }
   }
 }

--- a/dd-java-agent/instrumentation/elasticsearch/rest-5/src/main/java/datadog/trace/instrumentation/elasticsearch5/RestResponseListener.java
+++ b/dd-java-agent/instrumentation/elasticsearch/rest-5/src/main/java/datadog/trace/instrumentation/elasticsearch5/RestResponseListener.java
@@ -2,16 +2,16 @@ package datadog.trace.instrumentation.elasticsearch5;
 
 import static datadog.trace.instrumentation.elasticsearch.ElasticsearchRestClientDecorator.DECORATE;
 
-import io.opentracing.Span;
+import datadog.trace.instrumentation.api.AgentSpan;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseListener;
 
 public class RestResponseListener implements ResponseListener {
 
   private final ResponseListener listener;
-  private final Span span;
+  private final AgentSpan span;
 
-  public RestResponseListener(final ResponseListener listener, final Span span) {
+  public RestResponseListener(final ResponseListener listener, final AgentSpan span) {
     this.listener = listener;
     this.span = span;
   }

--- a/dd-java-agent/instrumentation/elasticsearch/rest-6.4/src/main/java/datadog/trace/instrumentation/elasticsearch6_4/RestResponseListener.java
+++ b/dd-java-agent/instrumentation/elasticsearch/rest-6.4/src/main/java/datadog/trace/instrumentation/elasticsearch6_4/RestResponseListener.java
@@ -1,16 +1,16 @@
 package datadog.trace.instrumentation.elasticsearch6_4;
 
+import datadog.trace.instrumentation.api.AgentSpan;
 import datadog.trace.instrumentation.elasticsearch.ElasticsearchRestClientDecorator;
-import io.opentracing.Span;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseListener;
 
 public class RestResponseListener implements ResponseListener {
 
   private final ResponseListener listener;
-  private final Span span;
+  private final AgentSpan span;
 
-  public RestResponseListener(final ResponseListener listener, final Span span) {
+  public RestResponseListener(final ResponseListener listener, final AgentSpan span) {
     this.listener = listener;
     this.span = span;
   }

--- a/dd-java-agent/instrumentation/elasticsearch/src/main/java/datadog/trace/instrumentation/elasticsearch/ElasticsearchRestClientDecorator.java
+++ b/dd-java-agent/instrumentation/elasticsearch/src/main/java/datadog/trace/instrumentation/elasticsearch/ElasticsearchRestClientDecorator.java
@@ -2,7 +2,7 @@ package datadog.trace.instrumentation.elasticsearch;
 
 import datadog.trace.agent.decorator.DatabaseClientDecorator;
 import datadog.trace.api.DDSpanTypes;
-import io.opentracing.Span;
+import datadog.trace.instrumentation.api.AgentSpan;
 import io.opentracing.tag.Tags;
 import org.elasticsearch.client.Response;
 
@@ -45,16 +45,16 @@ public class ElasticsearchRestClientDecorator extends DatabaseClientDecorator {
     return null;
   }
 
-  public Span onRequest(final Span span, final String method, final String endpoint) {
-    Tags.HTTP_METHOD.set(span, method);
-    Tags.HTTP_URL.set(span, endpoint);
+  public AgentSpan onRequest(final AgentSpan span, final String method, final String endpoint) {
+    span.setTag(Tags.HTTP_METHOD.getKey(), method);
+    span.setTag(Tags.HTTP_URL.getKey(), endpoint);
     return span;
   }
 
-  public Span onResponse(final Span span, final Response response) {
+  public AgentSpan onResponse(final AgentSpan span, final Response response) {
     if (response != null && response.getHost() != null) {
-      Tags.PEER_HOSTNAME.set(span, response.getHost().getHostName());
-      Tags.PEER_PORT.set(span, response.getHost().getPort());
+      span.setTag(Tags.PEER_HOSTNAME.getKey(), response.getHost().getHostName());
+      span.setTag(Tags.PEER_PORT.getKey(), response.getHost().getPort());
     }
     return span;
   }

--- a/dd-java-agent/instrumentation/elasticsearch/src/main/java/datadog/trace/instrumentation/elasticsearch/ElasticsearchTransportClientDecorator.java
+++ b/dd-java-agent/instrumentation/elasticsearch/src/main/java/datadog/trace/instrumentation/elasticsearch/ElasticsearchTransportClientDecorator.java
@@ -3,7 +3,7 @@ package datadog.trace.instrumentation.elasticsearch;
 import datadog.trace.agent.decorator.DatabaseClientDecorator;
 import datadog.trace.api.DDSpanTypes;
 import datadog.trace.api.DDTags;
-import io.opentracing.Span;
+import datadog.trace.instrumentation.api.AgentSpan;
 
 public class ElasticsearchTransportClientDecorator extends DatabaseClientDecorator {
   public static final ElasticsearchTransportClientDecorator DECORATE =
@@ -44,7 +44,7 @@ public class ElasticsearchTransportClientDecorator extends DatabaseClientDecorat
     return null;
   }
 
-  public Span onRequest(final Span span, final Class action, final Class request) {
+  public AgentSpan onRequest(final AgentSpan span, final Class action, final Class request) {
     if (action != null) {
       span.setTag(DDTags.RESOURCE_NAME, action.getSimpleName());
       span.setTag("elasticsearch.action", action.getSimpleName());

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/main/java/datadog/trace/instrumentation/elasticsearch2/TransportActionListener.java
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/main/java/datadog/trace/instrumentation/elasticsearch2/TransportActionListener.java
@@ -3,7 +3,7 @@ package datadog.trace.instrumentation.elasticsearch2;
 import static datadog.trace.instrumentation.elasticsearch.ElasticsearchTransportClientDecorator.DECORATE;
 
 import com.google.common.base.Joiner;
-import io.opentracing.Span;
+import datadog.trace.instrumentation.api.AgentSpan;
 import io.opentracing.tag.Tags;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
@@ -19,10 +19,10 @@ import org.elasticsearch.action.support.nodes.BaseNodesResponse;
 public class TransportActionListener<T extends ActionResponse> implements ActionListener<T> {
 
   private final ActionListener<T> listener;
-  private final Span span;
+  private final AgentSpan span;
 
   public TransportActionListener(
-      final ActionRequest actionRequest, final ActionListener<T> listener, final Span span) {
+      final ActionRequest actionRequest, final ActionListener<T> listener, final AgentSpan span) {
     this.listener = listener;
     this.span = span;
     onRequest(actionRequest);
@@ -49,9 +49,9 @@ public class TransportActionListener<T extends ActionResponse> implements Action
   @Override
   public void onResponse(final T response) {
     if (response.remoteAddress() != null) {
-      Tags.PEER_HOSTNAME.set(span, response.remoteAddress().getHost());
-      Tags.PEER_HOST_IPV4.set(span, response.remoteAddress().getAddress());
-      Tags.PEER_PORT.set(span, response.remoteAddress().getPort());
+      span.setTag(Tags.PEER_HOSTNAME.getKey(), response.remoteAddress().getHost());
+      span.setTag(Tags.PEER_HOST_IPV4.getKey(), response.remoteAddress().getAddress());
+      span.setTag(Tags.PEER_PORT.getKey(), response.remoteAddress().getPort());
     }
 
     if (response instanceof GetResponse) {

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/main/java/datadog/trace/instrumentation/elasticsearch5_3/Elasticsearch53TransportClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/main/java/datadog/trace/instrumentation/elasticsearch5_3/Elasticsearch53TransportClientInstrumentation.java
@@ -1,5 +1,7 @@
 package datadog.trace.instrumentation.elasticsearch5_3;
 
+import static datadog.trace.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.elasticsearch.ElasticsearchTransportClientDecorator.DECORATE;
 import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isInterface;
@@ -10,9 +12,8 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
-import io.opentracing.Scope;
-import io.opentracing.Span;
-import io.opentracing.util.GlobalTracer;
+import datadog.trace.instrumentation.api.AgentScope;
+import datadog.trace.instrumentation.api.AgentSpan;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.method.MethodDescription;
@@ -68,25 +69,26 @@ public class Elasticsearch53TransportClientInstrumentation extends Instrumenter.
   public static class ElasticsearchTransportClientAdvice {
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static Scope startSpan(
+    public static AgentScope onEnter(
         @Advice.Argument(0) final Action action,
         @Advice.Argument(1) final ActionRequest actionRequest,
         @Advice.Argument(value = 2, readOnly = false)
             ActionListener<ActionResponse> actionListener) {
 
-      final Scope scope = GlobalTracer.get().buildSpan("elasticsearch.query").startActive(false);
-      DECORATE.afterStart(scope.span());
-      DECORATE.onRequest(scope.span(), action.getClass(), actionRequest.getClass());
+      final AgentSpan span = startSpan("elasticsearch.query");
+      DECORATE.afterStart(span);
+      DECORATE.onRequest(span, action.getClass(), actionRequest.getClass());
 
-      actionListener = new TransportActionListener<>(actionRequest, actionListener, scope.span());
-      return scope;
+      actionListener = new TransportActionListener<>(actionRequest, actionListener, span);
+
+      return activateSpan(span, false);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
     public static void stopSpan(
-        @Advice.Enter final Scope scope, @Advice.Thrown final Throwable throwable) {
+        @Advice.Enter final AgentScope scope, @Advice.Thrown final Throwable throwable) {
       if (throwable != null) {
-        final Span span = scope.span();
+        final AgentSpan span = scope.span();
         DECORATE.onError(span, throwable);
         DECORATE.beforeFinish(span);
         span.finish();

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/main/java/datadog/trace/instrumentation/elasticsearch5_3/TransportActionListener.java
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/main/java/datadog/trace/instrumentation/elasticsearch5_3/TransportActionListener.java
@@ -3,7 +3,7 @@ package datadog.trace.instrumentation.elasticsearch5_3;
 import static datadog.trace.instrumentation.elasticsearch.ElasticsearchTransportClientDecorator.DECORATE;
 
 import com.google.common.base.Joiner;
-import io.opentracing.Span;
+import datadog.trace.instrumentation.api.AgentSpan;
 import io.opentracing.tag.Tags;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
@@ -21,10 +21,10 @@ import org.elasticsearch.action.support.replication.ReplicationResponse;
 public class TransportActionListener<T extends ActionResponse> implements ActionListener<T> {
 
   private final ActionListener<T> listener;
-  private final Span span;
+  private final AgentSpan span;
 
   public TransportActionListener(
-      final ActionRequest actionRequest, final ActionListener<T> listener, final Span span) {
+      final ActionRequest actionRequest, final ActionListener<T> listener, final AgentSpan span) {
     this.listener = listener;
     this.span = span;
     onRequest(actionRequest);
@@ -52,9 +52,9 @@ public class TransportActionListener<T extends ActionResponse> implements Action
   @Override
   public void onResponse(final T response) {
     if (response.remoteAddress() != null) {
-      Tags.PEER_HOSTNAME.set(span, response.remoteAddress().getHost());
-      Tags.PEER_HOST_IPV4.set(span, response.remoteAddress().getAddress());
-      Tags.PEER_PORT.set(span, response.remoteAddress().getPort());
+      span.setTag(Tags.PEER_HOSTNAME.getKey(), response.remoteAddress().getHost());
+      span.setTag(Tags.PEER_HOST_IPV4.getKey(), response.remoteAddress().getAddress());
+      span.setTag(Tags.PEER_PORT.getKey(), response.remoteAddress().getPort());
     }
 
     if (response instanceof GetResponse) {

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5/src/main/java/datadog/trace/instrumentation/elasticsearch5/Elasticsearch5TransportClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5/src/main/java/datadog/trace/instrumentation/elasticsearch5/Elasticsearch5TransportClientInstrumentation.java
@@ -1,5 +1,7 @@
 package datadog.trace.instrumentation.elasticsearch5;
 
+import static datadog.trace.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.elasticsearch.ElasticsearchTransportClientDecorator.DECORATE;
 import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isInterface;
@@ -10,9 +12,8 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
-import io.opentracing.Scope;
-import io.opentracing.Span;
-import io.opentracing.util.GlobalTracer;
+import datadog.trace.instrumentation.api.AgentScope;
+import datadog.trace.instrumentation.api.AgentSpan;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.method.MethodDescription;
@@ -67,25 +68,26 @@ public class Elasticsearch5TransportClientInstrumentation extends Instrumenter.D
   public static class ElasticsearchTransportClientAdvice {
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static Scope startSpan(
+    public static AgentScope onEnter(
         @Advice.Argument(0) final Action action,
         @Advice.Argument(1) final ActionRequest actionRequest,
         @Advice.Argument(value = 2, readOnly = false)
             ActionListener<ActionResponse> actionListener) {
 
-      final Scope scope = GlobalTracer.get().buildSpan("elasticsearch.query").startActive(false);
-      DECORATE.afterStart(scope.span());
-      DECORATE.onRequest(scope.span(), action.getClass(), actionRequest.getClass());
+      final AgentSpan span = startSpan("elasticsearch.query");
+      DECORATE.afterStart(span);
+      DECORATE.onRequest(span, action.getClass(), actionRequest.getClass());
 
-      actionListener = new TransportActionListener<>(actionRequest, actionListener, scope.span());
-      return scope;
+      actionListener = new TransportActionListener<>(actionRequest, actionListener, span);
+
+      return activateSpan(span, false);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
     public static void stopSpan(
-        @Advice.Enter final Scope scope, @Advice.Thrown final Throwable throwable) {
+        @Advice.Enter final AgentScope scope, @Advice.Thrown final Throwable throwable) {
       if (throwable != null) {
-        final Span span = scope.span();
+        final AgentSpan span = scope.span();
         DECORATE.onError(span, throwable);
         DECORATE.beforeFinish(span);
         span.finish();

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5/src/main/java/datadog/trace/instrumentation/elasticsearch5/TransportActionListener.java
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5/src/main/java/datadog/trace/instrumentation/elasticsearch5/TransportActionListener.java
@@ -3,7 +3,7 @@ package datadog.trace.instrumentation.elasticsearch5;
 import static datadog.trace.instrumentation.elasticsearch.ElasticsearchTransportClientDecorator.DECORATE;
 
 import com.google.common.base.Joiner;
-import io.opentracing.Span;
+import datadog.trace.instrumentation.api.AgentSpan;
 import io.opentracing.tag.Tags;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
@@ -21,10 +21,10 @@ import org.elasticsearch.action.support.replication.ReplicationResponse;
 public class TransportActionListener<T extends ActionResponse> implements ActionListener<T> {
 
   private final ActionListener<T> listener;
-  private final Span span;
+  private final AgentSpan span;
 
   public TransportActionListener(
-      final ActionRequest actionRequest, final ActionListener<T> listener, final Span span) {
+      final ActionRequest actionRequest, final ActionListener<T> listener, final AgentSpan span) {
     this.listener = listener;
     this.span = span;
     onRequest(actionRequest);
@@ -51,9 +51,9 @@ public class TransportActionListener<T extends ActionResponse> implements Action
   @Override
   public void onResponse(final T response) {
     if (response.remoteAddress() != null) {
-      Tags.PEER_HOSTNAME.set(span, response.remoteAddress().getHost());
-      Tags.PEER_HOST_IPV4.set(span, response.remoteAddress().getAddress());
-      Tags.PEER_PORT.set(span, response.remoteAddress().getPort());
+      span.setTag(Tags.PEER_HOSTNAME.getKey(), response.remoteAddress().getHost());
+      span.setTag(Tags.PEER_HOST_IPV4.getKey(), response.remoteAddress().getAddress());
+      span.setTag(Tags.PEER_PORT.getKey(), response.remoteAddress().getPort());
     }
 
     if (response instanceof GetResponse) {

--- a/dd-java-agent/instrumentation/elasticsearch/transport-6/src/main/java/datadog/trace/instrumentation/elasticsearch6/Elasticsearch6TransportClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-6/src/main/java/datadog/trace/instrumentation/elasticsearch6/Elasticsearch6TransportClientInstrumentation.java
@@ -1,5 +1,7 @@
 package datadog.trace.instrumentation.elasticsearch6;
 
+import static datadog.trace.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.elasticsearch.ElasticsearchTransportClientDecorator.DECORATE;
 import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isInterface;
@@ -10,9 +12,8 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
-import io.opentracing.Scope;
-import io.opentracing.Span;
-import io.opentracing.util.GlobalTracer;
+import datadog.trace.instrumentation.api.AgentScope;
+import datadog.trace.instrumentation.api.AgentSpan;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.method.MethodDescription;
@@ -71,25 +72,26 @@ public class Elasticsearch6TransportClientInstrumentation extends Instrumenter.D
   public static class Elasticsearch6TransportClientAdvice {
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static Scope startSpan(
+    public static AgentScope onEnter(
         @Advice.Argument(0) final Action action,
         @Advice.Argument(1) final ActionRequest actionRequest,
         @Advice.Argument(value = 2, readOnly = false)
             ActionListener<ActionResponse> actionListener) {
 
-      final Scope scope = GlobalTracer.get().buildSpan("elasticsearch.query").startActive(false);
-      DECORATE.afterStart(scope.span());
-      DECORATE.onRequest(scope.span(), action.getClass(), actionRequest.getClass());
+      final AgentSpan span = startSpan("elasticsearch.query");
+      DECORATE.afterStart(span);
+      DECORATE.onRequest(span, action.getClass(), actionRequest.getClass());
 
-      actionListener = new TransportActionListener<>(actionRequest, actionListener, scope.span());
-      return scope;
+      actionListener = new TransportActionListener<>(actionRequest, actionListener, span);
+
+      return activateSpan(span, false);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
     public static void stopSpan(
-        @Advice.Enter final Scope scope, @Advice.Thrown final Throwable throwable) {
+        @Advice.Enter final AgentScope scope, @Advice.Thrown final Throwable throwable) {
       if (throwable != null) {
-        final Span span = scope.span();
+        final AgentSpan span = scope.span();
         DECORATE.onError(span, throwable);
         DECORATE.beforeFinish(span);
         span.finish();

--- a/dd-java-agent/instrumentation/elasticsearch/transport-6/src/main/java/datadog/trace/instrumentation/elasticsearch6/TransportActionListener.java
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-6/src/main/java/datadog/trace/instrumentation/elasticsearch6/TransportActionListener.java
@@ -3,7 +3,7 @@ package datadog.trace.instrumentation.elasticsearch6;
 import static datadog.trace.instrumentation.elasticsearch.ElasticsearchTransportClientDecorator.DECORATE;
 
 import com.google.common.base.Joiner;
-import io.opentracing.Span;
+import datadog.trace.instrumentation.api.AgentSpan;
 import io.opentracing.tag.Tags;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
@@ -25,10 +25,10 @@ import org.elasticsearch.action.support.replication.ReplicationResponse;
 public class TransportActionListener<T extends ActionResponse> implements ActionListener<T> {
 
   private final ActionListener<T> listener;
-  private final Span span;
+  private final AgentSpan span;
 
   public TransportActionListener(
-      final ActionRequest actionRequest, final ActionListener<T> listener, final Span span) {
+      final ActionRequest actionRequest, final ActionListener<T> listener, final AgentSpan span) {
     this.listener = listener;
     this.span = span;
     onRequest(actionRequest);
@@ -56,9 +56,9 @@ public class TransportActionListener<T extends ActionResponse> implements Action
   @Override
   public void onResponse(final T response) {
     if (response.remoteAddress() != null) {
-      Tags.PEER_HOSTNAME.set(span, response.remoteAddress().address().getHostName());
-      Tags.PEER_HOST_IPV4.set(span, response.remoteAddress().getAddress());
-      Tags.PEER_PORT.set(span, response.remoteAddress().getPort());
+      span.setTag(Tags.PEER_HOSTNAME.getKey(), response.remoteAddress().address().getHostName());
+      span.setTag(Tags.PEER_HOST_IPV4.getKey(), response.remoteAddress().getAddress());
+      span.setTag(Tags.PEER_PORT.getKey(), response.remoteAddress().getPort());
     }
 
     if (response instanceof GetResponse) {

--- a/dd-java-agent/instrumentation/google-http-client/src/main/java/datadog/trace/instrumentation/googlehttpclient/HeadersInjectAdapter.java
+++ b/dd-java-agent/instrumentation/google-http-client/src/main/java/datadog/trace/instrumentation/googlehttpclient/HeadersInjectAdapter.java
@@ -1,0 +1,14 @@
+package datadog.trace.instrumentation.googlehttpclient;
+
+import com.google.api.client.http.HttpRequest;
+import datadog.trace.instrumentation.api.AgentPropagation;
+
+public class HeadersInjectAdapter implements AgentPropagation.Setter<HttpRequest> {
+
+  public static final HeadersInjectAdapter SETTER = new HeadersInjectAdapter();
+
+  @Override
+  public void set(final HttpRequest carrier, final String key, final String value) {
+    carrier.getHeaders().put(key, value);
+  }
+}

--- a/dd-java-agent/instrumentation/google-http-client/src/main/java/datadog/trace/instrumentation/googlehttpclient/RequestState.java
+++ b/dd-java-agent/instrumentation/google-http-client/src/main/java/datadog/trace/instrumentation/googlehttpclient/RequestState.java
@@ -1,10 +1,10 @@
 package datadog.trace.instrumentation.googlehttpclient;
 
-import io.opentracing.Span;
+import datadog.trace.instrumentation.api.AgentSpan;
 import lombok.Data;
 import lombok.NonNull;
 
 @Data
 public class RequestState {
-  @NonNull public Span span;
+  @NonNull public AgentSpan span;
 }

--- a/dd-java-agent/instrumentation/grizzly-2/src/main/java/datadog/trace/instrumentation/grizzly/GrizzlyRequestExtractAdapter.java
+++ b/dd-java-agent/instrumentation/grizzly-2/src/main/java/datadog/trace/instrumentation/grizzly/GrizzlyRequestExtractAdapter.java
@@ -1,84 +1,19 @@
 package datadog.trace.instrumentation.grizzly;
 
-import io.opentracing.propagation.TextMap;
-import java.util.AbstractMap;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import datadog.trace.instrumentation.api.AgentPropagation;
 import org.glassfish.grizzly.http.server.Request;
 
-public class GrizzlyRequestExtractAdapter implements TextMap {
+public class GrizzlyRequestExtractAdapter implements AgentPropagation.Getter<Request> {
 
-  private final Map<String, List<String>> headers;
+  public static final GrizzlyRequestExtractAdapter GETTER = new GrizzlyRequestExtractAdapter();
 
-  public GrizzlyRequestExtractAdapter(final Request request) {
-    headers = headersToMultiMap(request);
+  @Override
+  public Iterable<String> keys(final Request carrier) {
+    return carrier.getHeaderNames();
   }
 
   @Override
-  public Iterator<Map.Entry<String, String>> iterator() {
-    return new MultivaluedMapFlatIterator<>(headers.entrySet());
-  }
-
-  @Override
-  public void put(final String key, final String value) {
-    throw new UnsupportedOperationException("This class should be used only with Tracer.inject()!");
-  }
-
-  protected Map<String, List<String>> headersToMultiMap(final Request request) {
-    final Map<String, List<String>> headersResult = new HashMap<>();
-
-    for (final String headerName : request.getHeaderNames()) {
-      final List<String> valuesList = new ArrayList<>(1);
-
-      for (final String values : request.getHeaders(headerName)) {
-        valuesList.add(values);
-      }
-      headersResult.put(headerName, valuesList);
-    }
-
-    return headersResult;
-  }
-
-  public static final class MultivaluedMapFlatIterator<K, V> implements Iterator<Map.Entry<K, V>> {
-
-    private final Iterator<Map.Entry<K, List<V>>> mapIterator;
-    private Map.Entry<K, List<V>> mapEntry;
-    private Iterator<V> listIterator;
-
-    public MultivaluedMapFlatIterator(final Set<Map.Entry<K, List<V>>> multiValuesEntrySet) {
-      mapIterator = multiValuesEntrySet.iterator();
-    }
-
-    @Override
-    public boolean hasNext() {
-      if (listIterator != null && listIterator.hasNext()) {
-        return true;
-      }
-
-      return mapIterator.hasNext();
-    }
-
-    @Override
-    public Map.Entry<K, V> next() {
-      if (mapEntry == null || (!listIterator.hasNext() && mapIterator.hasNext())) {
-        mapEntry = mapIterator.next();
-        listIterator = mapEntry.getValue().iterator();
-      }
-
-      if (listIterator.hasNext()) {
-        return new AbstractMap.SimpleImmutableEntry<>(mapEntry.getKey(), listIterator.next());
-      } else {
-        return new AbstractMap.SimpleImmutableEntry<>(mapEntry.getKey(), null);
-      }
-    }
-
-    @Override
-    public void remove() {
-      throw new UnsupportedOperationException();
-    }
+  public String get(final Request carrier, final String key) {
+    return carrier.getHeader(key);
   }
 }

--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/client/GrpcClientBuilderInstrumentation.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/client/GrpcClientBuilderInstrumentation.java
@@ -7,7 +7,6 @@ import static net.bytebuddy.matcher.ElementMatchers.named;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import io.grpc.ClientInterceptor;
-import io.opentracing.util.GlobalTracer;
 import java.util.List;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
@@ -58,7 +57,7 @@ public class GrpcClientBuilderInstrumentation extends Instrumenter.Default {
         }
       }
       if (shouldRegister) {
-        interceptors.add(0, new TracingClientInterceptor(GlobalTracer.get()));
+        interceptors.add(0, TracingClientInterceptor.INSTANCE);
       }
     }
   }

--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/client/GrpcClientDecorator.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/client/GrpcClientDecorator.java
@@ -2,9 +2,8 @@ package datadog.trace.instrumentation.grpc.client;
 
 import datadog.trace.agent.decorator.ClientDecorator;
 import datadog.trace.api.DDSpanTypes;
+import datadog.trace.instrumentation.api.AgentSpan;
 import io.grpc.Status;
-import io.opentracing.Span;
-import io.opentracing.tag.Tags;
 
 public class GrpcClientDecorator extends ClientDecorator {
   public static final GrpcClientDecorator DECORATE = new GrpcClientDecorator();
@@ -29,14 +28,14 @@ public class GrpcClientDecorator extends ClientDecorator {
     return null;
   }
 
-  public Span onClose(final Span span, final Status status) {
+  public AgentSpan onClose(final AgentSpan span, final Status status) {
 
     span.setTag("status.code", status.getCode().name());
     span.setTag("status.description", status.getDescription());
 
     onError(span, status.getCause());
     if (!status.isOk()) {
-      Tags.ERROR.set(span, true);
+      span.setError(true);
     }
 
     return span;

--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/client/GrpcInjectAdapter.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/client/GrpcInjectAdapter.java
@@ -1,25 +1,14 @@
 package datadog.trace.instrumentation.grpc.client;
 
+import datadog.trace.instrumentation.api.AgentPropagation;
 import io.grpc.Metadata;
-import io.opentracing.propagation.TextMap;
-import java.util.Iterator;
-import java.util.Map;
 
-public final class GrpcInjectAdapter implements TextMap {
-  private final Metadata metadata;
+public final class GrpcInjectAdapter implements AgentPropagation.Setter<Metadata> {
 
-  public GrpcInjectAdapter(final Metadata metadata) {
-    this.metadata = metadata;
-  }
+  public static final GrpcInjectAdapter SETTER = new GrpcInjectAdapter();
 
   @Override
-  public Iterator<Map.Entry<String, String>> iterator() {
-    throw new UnsupportedOperationException(
-        "GrpcInjectAdapter should only be used with Tracer.inject()");
-  }
-
-  @Override
-  public void put(final String key, final String value) {
-    this.metadata.put(Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER), value);
+  public void set(final Metadata carrier, final String key, final String value) {
+    carrier.put(Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER), value);
   }
 }

--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/GrpcExtractAdapter.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/GrpcExtractAdapter.java
@@ -1,0 +1,19 @@
+package datadog.trace.instrumentation.grpc.server;
+
+import datadog.trace.instrumentation.api.AgentPropagation;
+import io.grpc.Metadata;
+
+public final class GrpcExtractAdapter implements AgentPropagation.Getter<Metadata> {
+
+  public static final GrpcExtractAdapter GETTER = new GrpcExtractAdapter();
+
+  @Override
+  public Iterable<String> keys(final Metadata carrier) {
+    return carrier.keys();
+  }
+
+  @Override
+  public String get(final Metadata carrier, final String key) {
+    return carrier.get(Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER));
+  }
+}

--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/GrpcServerBuilderInstrumentation.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/GrpcServerBuilderInstrumentation.java
@@ -7,7 +7,6 @@ import static net.bytebuddy.matcher.ElementMatchers.named;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import io.grpc.ServerInterceptor;
-import io.opentracing.util.GlobalTracer;
 import java.util.List;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
@@ -36,6 +35,7 @@ public class GrpcServerBuilderInstrumentation extends Instrumenter.Default {
       "datadog.trace.agent.decorator.BaseDecorator",
       "datadog.trace.agent.decorator.ServerDecorator",
       packageName + ".GrpcServerDecorator",
+      packageName + ".GrpcExtractAdapter"
     };
   }
 
@@ -57,7 +57,7 @@ public class GrpcServerBuilderInstrumentation extends Instrumenter.Default {
         }
       }
       if (shouldRegister) {
-        interceptors.add(0, new TracingServerInterceptor(GlobalTracer.get()));
+        interceptors.add(0, TracingServerInterceptor.INSTANCE);
       }
     }
   }

--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/GrpcServerDecorator.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/GrpcServerDecorator.java
@@ -2,9 +2,8 @@ package datadog.trace.instrumentation.grpc.server;
 
 import datadog.trace.agent.decorator.ServerDecorator;
 import datadog.trace.api.DDSpanTypes;
+import datadog.trace.instrumentation.api.AgentSpan;
 import io.grpc.Status;
-import io.opentracing.Span;
-import io.opentracing.tag.Tags;
 
 public class GrpcServerDecorator extends ServerDecorator {
   public static final GrpcServerDecorator DECORATE = new GrpcServerDecorator();
@@ -24,14 +23,14 @@ public class GrpcServerDecorator extends ServerDecorator {
     return "grpc-server";
   }
 
-  public Span onClose(final Span span, final Status status) {
+  public AgentSpan onClose(final AgentSpan span, final Status status) {
 
     span.setTag("status.code", status.getCode().name());
     span.setTag("status.description", status.getDescription());
 
     onError(span, status.getCause());
     if (!status.isOk()) {
-      Tags.ERROR.set(span, true);
+      span.setError(true);
     }
 
     return span;

--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/TracingServerInterceptor.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/TracingServerInterceptor.java
@@ -1,9 +1,15 @@
 package datadog.trace.instrumentation.grpc.server;
 
+import static datadog.trace.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.instrumentation.api.AgentTracer.propagate;
+import static datadog.trace.instrumentation.api.AgentTracer.startSpan;
+import static datadog.trace.instrumentation.grpc.server.GrpcExtractAdapter.GETTER;
 import static datadog.trace.instrumentation.grpc.server.GrpcServerDecorator.DECORATE;
 
 import datadog.trace.api.DDTags;
-import datadog.trace.context.TraceScope;
+import datadog.trace.instrumentation.api.AgentScope;
+import datadog.trace.instrumentation.api.AgentSpan;
+import datadog.trace.instrumentation.api.AgentSpan.Context;
 import io.grpc.ForwardingServerCall;
 import io.grpc.ForwardingServerCallListener;
 import io.grpc.Metadata;
@@ -11,22 +17,12 @@ import io.grpc.ServerCall;
 import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
 import io.grpc.Status;
-import io.opentracing.Scope;
-import io.opentracing.Span;
-import io.opentracing.SpanContext;
-import io.opentracing.Tracer;
-import io.opentracing.propagation.Format;
-import io.opentracing.propagation.TextMapExtractAdapter;
-import java.util.HashMap;
-import java.util.Map;
 
 public class TracingServerInterceptor implements ServerInterceptor {
 
-  private final Tracer tracer;
+  public static final TracingServerInterceptor INSTANCE = new TracingServerInterceptor();
 
-  public TracingServerInterceptor(final Tracer tracer) {
-    this.tracer = tracer;
-  }
+  private TracingServerInterceptor() {}
 
   @Override
   public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
@@ -34,38 +30,20 @@ public class TracingServerInterceptor implements ServerInterceptor {
       final Metadata headers,
       final ServerCallHandler<ReqT, RespT> next) {
 
-    final Map<String, String> headerMap = new HashMap<>();
-    for (final String key : headers.keys()) {
-      if (!key.endsWith(Metadata.BINARY_HEADER_SUFFIX)) {
-        final String value = headers.get(Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER));
-        headerMap.put(key, value);
-      }
-    }
-    final SpanContext spanContext =
-        tracer.extract(Format.Builtin.TEXT_MAP_EXTRACT, new TextMapExtractAdapter(headerMap));
-
-    final Tracer.SpanBuilder spanBuilder =
-        tracer
-            .buildSpan("grpc.server")
-            .withTag(DDTags.RESOURCE_NAME, call.getMethodDescriptor().getFullMethodName());
-    if (spanContext != null) {
-      spanBuilder.asChildOf(spanContext);
-    }
-    final Scope scope = spanBuilder.startActive(false);
-
-    if (scope instanceof TraceScope) {
-      ((TraceScope) scope).setAsyncPropagation(true);
-    }
-
-    final Span span = scope.span();
+    final Context spanContext = propagate().extract(headers, GETTER);
+    final AgentSpan span =
+        startSpan("grpc.server", spanContext)
+            .setTag(DDTags.RESOURCE_NAME, call.getMethodDescriptor().getFullMethodName());
     DECORATE.afterStart(span);
+
+    final AgentScope scope = activateSpan(span, false);
+    scope.setAsyncPropagation(true);
 
     final ServerCall.Listener<ReqT> result;
     try {
       // Wrap the server call so that we can decorate the span
       // with the resulting status
-      TracingServerCall<ReqT, RespT> tracingServerCall =
-          new TracingServerCall<>(tracer, span, call);
+      final TracingServerCall<ReqT, RespT> tracingServerCall = new TracingServerCall<>(span, call);
 
       // call other interceptors
       result = next.startCall(tracingServerCall, headers);
@@ -75,39 +53,30 @@ public class TracingServerInterceptor implements ServerInterceptor {
       span.finish();
       throw e;
     } finally {
-      if (scope instanceof TraceScope) {
-        ((TraceScope) scope).setAsyncPropagation(false);
-      }
+      scope.setAsyncPropagation(false);
       scope.close();
     }
 
     // This ensures the server implementation can see the span in scope
-    return new TracingServerCallListener<>(tracer, span, result);
+    return new TracingServerCallListener<>(span, result);
   }
 
   static final class TracingServerCall<ReqT, RespT>
       extends ForwardingServerCall.SimpleForwardingServerCall<ReqT, RespT> {
-    final Tracer tracer;
-    final Span span;
+    final AgentSpan span;
 
-    TracingServerCall(
-        final Tracer tracer, final Span span, final ServerCall<ReqT, RespT> delegate) {
+    TracingServerCall(final AgentSpan span, final ServerCall<ReqT, RespT> delegate) {
       super(delegate);
-      this.tracer = tracer;
       this.span = span;
     }
 
     @Override
     public void close(final Status status, final Metadata trailers) {
       DECORATE.onClose(span, status);
-      try (final Scope scope = tracer.scopeManager().activate(span, false)) {
-        if (scope instanceof TraceScope) {
-          ((TraceScope) scope).setAsyncPropagation(true);
-        }
+      try (final AgentScope scope = activateSpan(span, false)) {
+        scope.setAsyncPropagation(true);
         delegate().close(status, trailers);
-        if (scope instanceof TraceScope) {
-          ((TraceScope) scope).setAsyncPropagation(false);
-        }
+        scope.setAsyncPropagation(false);
       } catch (final Throwable e) {
         DECORATE.onError(span, e);
         throw e;
@@ -117,55 +86,41 @@ public class TracingServerInterceptor implements ServerInterceptor {
 
   static final class TracingServerCallListener<ReqT>
       extends ForwardingServerCallListener.SimpleForwardingServerCallListener<ReqT> {
-    final Tracer tracer;
-    final Span span;
+    private final AgentSpan span;
 
-    TracingServerCallListener(
-        final Tracer tracer, final Span span, final ServerCall.Listener<ReqT> delegate) {
+    TracingServerCallListener(final AgentSpan span, final ServerCall.Listener<ReqT> delegate) {
       super(delegate);
-      this.tracer = tracer;
       this.span = span;
     }
 
     @Override
     public void onMessage(final ReqT message) {
-      final Scope scope =
-          tracer
-              .buildSpan("grpc.message")
-              .asChildOf(span)
-              .withTag("message.type", message.getClass().getName())
-              .startActive(true);
-      DECORATE.afterStart(scope.span());
-      if (scope instanceof TraceScope) {
-        ((TraceScope) scope).setAsyncPropagation(true);
-      }
+      final AgentSpan span =
+          startSpan("grpc.message", this.span.context())
+              .setTag("message.type", message.getClass().getName());
+      DECORATE.afterStart(span);
+      final AgentScope scope = activateSpan(span, true);
+      scope.setAsyncPropagation(true);
       try {
         delegate().onMessage(message);
       } catch (final Throwable e) {
-        final Span span = scope.span();
         DECORATE.onError(span, e);
         DECORATE.beforeFinish(span);
         this.span.finish();
         throw e;
       } finally {
-        if (scope instanceof TraceScope) {
-          ((TraceScope) scope).setAsyncPropagation(false);
-        }
-        DECORATE.afterStart(scope.span());
+        scope.setAsyncPropagation(false);
+        DECORATE.afterStart(span);
         scope.close();
       }
     }
 
     @Override
     public void onHalfClose() {
-      try (final Scope scope = tracer.scopeManager().activate(span, false)) {
-        if (scope instanceof TraceScope) {
-          ((TraceScope) scope).setAsyncPropagation(true);
-        }
+      try (final AgentScope scope = activateSpan(span, false)) {
+        scope.setAsyncPropagation(true);
         delegate().onHalfClose();
-        if (scope instanceof TraceScope) {
-          ((TraceScope) scope).setAsyncPropagation(false);
-        }
+        scope.setAsyncPropagation(false);
       } catch (final Throwable e) {
         DECORATE.onError(span, e);
         DECORATE.beforeFinish(span);
@@ -177,15 +132,11 @@ public class TracingServerInterceptor implements ServerInterceptor {
     @Override
     public void onCancel() {
       // Finishes span.
-      try (final Scope scope = tracer.scopeManager().activate(span, false)) {
-        if (scope instanceof TraceScope) {
-          ((TraceScope) scope).setAsyncPropagation(true);
-        }
+      try (final AgentScope scope = activateSpan(span, false)) {
+        scope.setAsyncPropagation(true);
         delegate().onCancel();
         span.setTag("canceled", true);
-        if (scope instanceof TraceScope) {
-          ((TraceScope) scope).setAsyncPropagation(false);
-        }
+        scope.setAsyncPropagation(false);
       } catch (final Throwable e) {
         DECORATE.onError(span, e);
         throw e;
@@ -198,14 +149,10 @@ public class TracingServerInterceptor implements ServerInterceptor {
     @Override
     public void onComplete() {
       // Finishes span.
-      try (final Scope scope = tracer.scopeManager().activate(span, false)) {
-        if (scope instanceof TraceScope) {
-          ((TraceScope) scope).setAsyncPropagation(true);
-        }
+      try (final AgentScope scope = activateSpan(span, false)) {
+        scope.setAsyncPropagation(true);
         delegate().onComplete();
-        if (scope instanceof TraceScope) {
-          ((TraceScope) scope).setAsyncPropagation(false);
-        }
+        scope.setAsyncPropagation(false);
       } catch (final Throwable e) {
         DECORATE.onError(span, e);
         throw e;
@@ -217,14 +164,10 @@ public class TracingServerInterceptor implements ServerInterceptor {
 
     @Override
     public void onReady() {
-      try (final Scope scope = tracer.scopeManager().activate(span, false)) {
-        if (scope instanceof TraceScope) {
-          ((TraceScope) scope).setAsyncPropagation(true);
-        }
+      try (final AgentScope scope = activateSpan(span, false)) {
+        scope.setAsyncPropagation(true);
         delegate().onReady();
-        if (scope instanceof TraceScope) {
-          ((TraceScope) scope).setAsyncPropagation(false);
-        }
+        scope.setAsyncPropagation(false);
       } catch (final Throwable e) {
         DECORATE.onError(span, e);
         DECORATE.beforeFinish(span);

--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/TracingServerInterceptor.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/TracingServerInterceptor.java
@@ -105,12 +105,12 @@ public class TracingServerInterceptor implements ServerInterceptor {
         delegate().onMessage(message);
       } catch (final Throwable e) {
         DECORATE.onError(span, e);
-        DECORATE.beforeFinish(span);
+        DECORATE.beforeFinish(this.span);
         this.span.finish();
         throw e;
       } finally {
         scope.setAsyncPropagation(false);
-        DECORATE.afterStart(span);
+        DECORATE.beforeFinish(span);
         scope.close();
       }
     }

--- a/dd-java-agent/instrumentation/hibernate/core-3.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v3_3/SessionFactoryInstrumentation.java
+++ b/dd-java-agent/instrumentation/hibernate/core-3.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v3_3/SessionFactoryInstrumentation.java
@@ -1,6 +1,7 @@
 package datadog.trace.instrumentation.hibernate.core.v3_3;
 
 import static datadog.trace.agent.tooling.ByteBuddyElementMatchers.safeHasSuperType;
+import static datadog.trace.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.hibernate.HibernateDecorator.DECORATOR;
 import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isInterface;
@@ -14,9 +15,8 @@ import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.InstrumentationContext;
+import datadog.trace.instrumentation.api.AgentSpan;
 import datadog.trace.instrumentation.hibernate.SessionState;
-import io.opentracing.Span;
-import io.opentracing.util.GlobalTracer;
 import java.util.HashMap;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
@@ -62,7 +62,7 @@ public class SessionFactoryInstrumentation extends AbstractHibernateInstrumentat
     @Advice.OnMethodExit(suppress = Throwable.class)
     public static void openSession(@Advice.Return final Object session) {
 
-      final Span span = GlobalTracer.get().buildSpan("hibernate.session").start();
+      final AgentSpan span = startSpan("hibernate.session");
       DECORATOR.afterStart(span);
       DECORATOR.onConnection(span, session);
 

--- a/dd-java-agent/instrumentation/hibernate/core-3.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v3_3/SessionInstrumentation.java
+++ b/dd-java-agent/instrumentation/hibernate/core-3.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v3_3/SessionInstrumentation.java
@@ -15,9 +15,9 @@ import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.InstrumentationContext;
+import datadog.trace.instrumentation.api.AgentSpan;
 import datadog.trace.instrumentation.hibernate.SessionMethodUtils;
 import datadog.trace.instrumentation.hibernate.SessionState;
-import io.opentracing.Span;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -131,7 +131,7 @@ public class SessionInstrumentation extends AbstractHibernateInstrumentation {
         state.getMethodScope().close();
       }
 
-      final Span span = state.getSessionSpan();
+      final AgentSpan span = state.getSessionSpan();
       DECORATOR.onError(span, throwable);
       DECORATOR.beforeFinish(span);
       span.finish();

--- a/dd-java-agent/instrumentation/hibernate/core-4.0/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_0/SessionFactoryInstrumentation.java
+++ b/dd-java-agent/instrumentation/hibernate/core-4.0/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_0/SessionFactoryInstrumentation.java
@@ -1,6 +1,7 @@
 package datadog.trace.instrumentation.hibernate.core.v4_0;
 
 import static datadog.trace.agent.tooling.ByteBuddyElementMatchers.safeHasSuperType;
+import static datadog.trace.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.hibernate.HibernateDecorator.DECORATOR;
 import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isInterface;
@@ -14,9 +15,8 @@ import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.InstrumentationContext;
+import datadog.trace.instrumentation.api.AgentSpan;
 import datadog.trace.instrumentation.hibernate.SessionState;
-import io.opentracing.Span;
-import io.opentracing.util.GlobalTracer;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.method.MethodDescription;
@@ -54,7 +54,7 @@ public class SessionFactoryInstrumentation extends AbstractHibernateInstrumentat
     @Advice.OnMethodExit(suppress = Throwable.class)
     public static void openSession(@Advice.Return final SharedSessionContract session) {
 
-      final Span span = GlobalTracer.get().buildSpan("hibernate.session").start();
+      final AgentSpan span = startSpan("hibernate.session");
       DECORATOR.afterStart(span);
       DECORATOR.onConnection(span, session);
 

--- a/dd-java-agent/instrumentation/hibernate/core-4.0/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_0/SessionInstrumentation.java
+++ b/dd-java-agent/instrumentation/hibernate/core-4.0/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_0/SessionInstrumentation.java
@@ -15,9 +15,9 @@ import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.InstrumentationContext;
+import datadog.trace.instrumentation.api.AgentSpan;
 import datadog.trace.instrumentation.hibernate.SessionMethodUtils;
 import datadog.trace.instrumentation.hibernate.SessionState;
-import io.opentracing.Span;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -119,7 +119,7 @@ public class SessionInstrumentation extends AbstractHibernateInstrumentation {
         state.getMethodScope().close();
       }
 
-      final Span span = state.getSessionSpan();
+      final AgentSpan span = state.getSessionSpan();
       DECORATOR.onError(span, throwable);
       DECORATOR.beforeFinish(span);
       span.finish();

--- a/dd-java-agent/instrumentation/hibernate/src/main/java/datadog/trace/instrumentation/hibernate/SessionState.java
+++ b/dd-java-agent/instrumentation/hibernate/src/main/java/datadog/trace/instrumentation/hibernate/SessionState.java
@@ -1,13 +1,13 @@
 package datadog.trace.instrumentation.hibernate;
 
-import io.opentracing.Scope;
-import io.opentracing.Span;
+import datadog.trace.instrumentation.api.AgentScope;
+import datadog.trace.instrumentation.api.AgentSpan;
 import lombok.Data;
 import lombok.NonNull;
 
 @Data
 public class SessionState {
-  @NonNull public Span sessionSpan;
-  public Scope methodScope;
+  @NonNull public AgentSpan sessionSpan;
+  public AgentScope methodScope;
   public boolean hasChildSpan = true;
 }

--- a/dd-java-agent/instrumentation/http-url-connection/src/main/java/datadog/trace/instrumentation/http_url_connection/HeadersInjectAdapter.java
+++ b/dd-java-agent/instrumentation/http-url-connection/src/main/java/datadog/trace/instrumentation/http_url_connection/HeadersInjectAdapter.java
@@ -1,0 +1,14 @@
+package datadog.trace.instrumentation.http_url_connection;
+
+import datadog.trace.instrumentation.api.AgentPropagation;
+import java.net.HttpURLConnection;
+
+public class HeadersInjectAdapter implements AgentPropagation.Setter<HttpURLConnection> {
+
+  public static final HeadersInjectAdapter SETTER = new HeadersInjectAdapter();
+
+  @Override
+  public void set(final HttpURLConnection carrier, final String key, final String value) {
+    carrier.setRequestProperty(key, value);
+  }
+}

--- a/dd-java-agent/instrumentation/hystrix-1.4/src/main/java/datadog/trace/instrumentation/hystrix/HystrixDecorator.java
+++ b/dd-java-agent/instrumentation/hystrix-1.4/src/main/java/datadog/trace/instrumentation/hystrix/HystrixDecorator.java
@@ -3,7 +3,7 @@ package datadog.trace.instrumentation.hystrix;
 import com.netflix.hystrix.HystrixInvokableInfo;
 import datadog.trace.agent.decorator.BaseDecorator;
 import datadog.trace.api.DDTags;
-import io.opentracing.Span;
+import datadog.trace.instrumentation.api.AgentSpan;
 
 public class HystrixDecorator extends BaseDecorator {
   public static HystrixDecorator DECORATE = new HystrixDecorator();
@@ -24,7 +24,7 @@ public class HystrixDecorator extends BaseDecorator {
   }
 
   public void onCommand(
-      final Span span, final HystrixInvokableInfo<?> command, final String methodName) {
+      final AgentSpan span, final HystrixInvokableInfo<?> command, final String methodName) {
     if (command != null) {
       final String commandName = command.getCommandKey().name();
       final String groupName = command.getCommandGroup().name();

--- a/dd-java-agent/instrumentation/hystrix-1.4/src/main/java/datadog/trace/instrumentation/hystrix/HystrixInstrumentation.java
+++ b/dd-java-agent/instrumentation/hystrix-1.4/src/main/java/datadog/trace/instrumentation/hystrix/HystrixInstrumentation.java
@@ -8,8 +8,8 @@ import static net.bytebuddy.matcher.ElementMatchers.returns;
 import com.google.auto.service.AutoService;
 import com.netflix.hystrix.HystrixInvokableInfo;
 import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.instrumentation.api.AgentSpan;
 import datadog.trace.instrumentation.rxjava.TracedOnSubscribe;
-import io.opentracing.Span;
 import java.util.HashMap;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
@@ -98,7 +98,7 @@ public class HystrixInstrumentation extends Instrumenter.Default {
     }
 
     @Override
-    protected void afterStart(final Span span) {
+    protected void afterStart(final AgentSpan span) {
       super.afterStart(span);
 
       DECORATE.onCommand(span, command, methodName);

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/AkkaExecutorInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/AkkaExecutorInstrumentation.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.java.concurrent;
 
+import static datadog.trace.instrumentation.api.AgentTracer.activeScope;
 import static net.bytebuddy.matcher.ElementMatchers.nameMatches;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
@@ -11,8 +12,6 @@ import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.State;
 import datadog.trace.context.TraceScope;
-import io.opentracing.Scope;
-import io.opentracing.util.GlobalTracer;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -60,11 +59,11 @@ public final class AkkaExecutorInstrumentation extends AbstractExecutorInstrumen
     public static State enterJobSubmit(
         @Advice.This final Executor executor,
         @Advice.Argument(value = 0, readOnly = false) final ForkJoinTask task) {
-      final Scope scope = GlobalTracer.get().scopeManager().active();
+      final TraceScope scope = activeScope();
       if (ExecutorInstrumentationUtils.shouldAttachStateToTask(task, executor)) {
         final ContextStore<ForkJoinTask, State> contextStore =
             InstrumentationContext.get(ForkJoinTask.class, State.class);
-        return ExecutorInstrumentationUtils.setupState(contextStore, task, (TraceScope) scope);
+        return ExecutorInstrumentationUtils.setupState(contextStore, task, scope);
       }
       return null;
     }

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/ExecutorInstrumentationUtils.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/ExecutorInstrumentationUtils.java
@@ -1,13 +1,13 @@
 package datadog.trace.instrumentation.java.concurrent;
 
+import static datadog.trace.instrumentation.api.AgentTracer.activeScope;
+
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.WeakMap;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.CallableWrapper;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.RunnableWrapper;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.State;
 import datadog.trace.context.TraceScope;
-import io.opentracing.Scope;
-import io.opentracing.util.GlobalTracer;
 import java.util.concurrent.Executor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -26,9 +26,9 @@ public class ExecutorInstrumentationUtils {
    * @return true iff given task object should be wrapped
    */
   public static boolean shouldAttachStateToTask(final Object task, final Executor executor) {
-    final Scope scope = GlobalTracer.get().scopeManager().active();
-    return (scope instanceof TraceScope
-        && ((TraceScope) scope).isAsyncPropagating()
+    final TraceScope scope = activeScope();
+    return (scope != null
+        && scope.isAsyncPropagating()
         && task != null
         && !ExecutorInstrumentationUtils.isExecutorDisabledForThisTask(executor, task));
   }

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/JavaExecutorInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/JavaExecutorInstrumentation.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.java.concurrent;
 
+import static datadog.trace.instrumentation.api.AgentTracer.activeScope;
 import static net.bytebuddy.matcher.ElementMatchers.nameMatches;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
@@ -12,8 +13,6 @@ import datadog.trace.bootstrap.instrumentation.java.concurrent.CallableWrapper;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.RunnableWrapper;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.State;
 import datadog.trace.context.TraceScope;
-import io.opentracing.Scope;
-import io.opentracing.util.GlobalTracer;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -79,7 +78,7 @@ public final class JavaExecutorInstrumentation extends AbstractExecutorInstrumen
     public static State enterJobSubmit(
         @Advice.This final Executor executor,
         @Advice.Argument(value = 0, readOnly = false) Runnable task) {
-      final Scope scope = GlobalTracer.get().scopeManager().active();
+      final TraceScope scope = activeScope();
       final Runnable newTask = RunnableWrapper.wrapIfNeeded(task);
       // It is important to check potentially wrapped task if we can instrument task in this
       // executor. Some executors do not support wrapped tasks.
@@ -87,7 +86,7 @@ public final class JavaExecutorInstrumentation extends AbstractExecutorInstrumen
         task = newTask;
         final ContextStore<Runnable, State> contextStore =
             InstrumentationContext.get(Runnable.class, State.class);
-        return ExecutorInstrumentationUtils.setupState(contextStore, newTask, (TraceScope) scope);
+        return ExecutorInstrumentationUtils.setupState(contextStore, newTask, scope);
       }
       return null;
     }
@@ -107,11 +106,11 @@ public final class JavaExecutorInstrumentation extends AbstractExecutorInstrumen
     public static State enterJobSubmit(
         @Advice.This final Executor executor,
         @Advice.Argument(value = 0, readOnly = false) final ForkJoinTask task) {
-      final Scope scope = GlobalTracer.get().scopeManager().active();
+      final TraceScope scope = activeScope();
       if (ExecutorInstrumentationUtils.shouldAttachStateToTask(task, executor)) {
         final ContextStore<ForkJoinTask, State> contextStore =
             InstrumentationContext.get(ForkJoinTask.class, State.class);
-        return ExecutorInstrumentationUtils.setupState(contextStore, task, (TraceScope) scope);
+        return ExecutorInstrumentationUtils.setupState(contextStore, task, scope);
       }
       return null;
     }
@@ -131,7 +130,7 @@ public final class JavaExecutorInstrumentation extends AbstractExecutorInstrumen
     public static State enterJobSubmit(
         @Advice.This final Executor executor,
         @Advice.Argument(value = 0, readOnly = false) Runnable task) {
-      final Scope scope = GlobalTracer.get().scopeManager().active();
+      final TraceScope scope = activeScope();
       final Runnable newTask = RunnableWrapper.wrapIfNeeded(task);
       // It is important to check potentially wrapped task if we can instrument task in this
       // executor. Some executors do not support wrapped tasks.
@@ -139,7 +138,7 @@ public final class JavaExecutorInstrumentation extends AbstractExecutorInstrumen
         task = newTask;
         final ContextStore<Runnable, State> contextStore =
             InstrumentationContext.get(Runnable.class, State.class);
-        return ExecutorInstrumentationUtils.setupState(contextStore, newTask, (TraceScope) scope);
+        return ExecutorInstrumentationUtils.setupState(contextStore, newTask, scope);
       }
       return null;
     }
@@ -165,7 +164,7 @@ public final class JavaExecutorInstrumentation extends AbstractExecutorInstrumen
     public static State enterJobSubmit(
         @Advice.This final Executor executor,
         @Advice.Argument(value = 0, readOnly = false) Callable task) {
-      final Scope scope = GlobalTracer.get().scopeManager().active();
+      final TraceScope scope = activeScope();
       final Callable newTask = CallableWrapper.wrapIfNeeded(task);
       // It is important to check potentially wrapped task if we can instrument task in this
       // executor. Some executors do not support wrapped tasks.
@@ -173,7 +172,7 @@ public final class JavaExecutorInstrumentation extends AbstractExecutorInstrumen
         task = newTask;
         final ContextStore<Callable, State> contextStore =
             InstrumentationContext.get(Callable.class, State.class);
-        return ExecutorInstrumentationUtils.setupState(contextStore, newTask, (TraceScope) scope);
+        return ExecutorInstrumentationUtils.setupState(contextStore, newTask, scope);
       }
       return null;
     }
@@ -199,10 +198,8 @@ public final class JavaExecutorInstrumentation extends AbstractExecutorInstrumen
     public static Collection<?> submitEnter(
         @Advice.This final Executor executor,
         @Advice.Argument(value = 0, readOnly = false) Collection<? extends Callable<?>> tasks) {
-      final Scope scope = GlobalTracer.get().scopeManager().active();
-      if (scope instanceof TraceScope
-          && ((TraceScope) scope).isAsyncPropagating()
-          && tasks != null) {
+      final TraceScope scope = activeScope();
+      if (scope != null && scope.isAsyncPropagating() && tasks != null) {
         final Collection<Callable<?>> wrappedTasks = new ArrayList<>(tasks.size());
         for (final Callable<?> task : tasks) {
           if (task != null) {
@@ -213,7 +210,7 @@ public final class JavaExecutorInstrumentation extends AbstractExecutorInstrumen
               wrappedTasks.add(newTask);
               final ContextStore<Callable, State> contextStore =
                   InstrumentationContext.get(Callable.class, State.class);
-              ExecutorInstrumentationUtils.setupState(contextStore, newTask, (TraceScope) scope);
+              ExecutorInstrumentationUtils.setupState(contextStore, newTask, scope);
             }
           }
         }

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/ScalaExecutorInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/ScalaExecutorInstrumentation.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.java.concurrent;
 
+import static datadog.trace.instrumentation.api.AgentTracer.activeScope;
 import static net.bytebuddy.matcher.ElementMatchers.nameMatches;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
@@ -10,8 +11,6 @@ import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.State;
 import datadog.trace.context.TraceScope;
-import io.opentracing.Scope;
-import io.opentracing.util.GlobalTracer;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -60,11 +59,11 @@ public final class ScalaExecutorInstrumentation extends AbstractExecutorInstrume
     public static State enterJobSubmit(
         @Advice.This final Executor executor,
         @Advice.Argument(value = 0, readOnly = false) final ForkJoinTask task) {
-      final Scope scope = GlobalTracer.get().scopeManager().active();
+      final TraceScope scope = activeScope();
       if (ExecutorInstrumentationUtils.shouldAttachStateToTask(task, executor)) {
         final ContextStore<ForkJoinTask, State> contextStore =
             InstrumentationContext.get(ForkJoinTask.class, State.class);
-        return ExecutorInstrumentationUtils.setupState(contextStore, task, (TraceScope) scope);
+        return ExecutorInstrumentationUtils.setupState(contextStore, task, scope);
       }
       return null;
     }

--- a/dd-java-agent/instrumentation/jax-rs-annotations-1/src/main/java/datadog/trace/instrumentation/jaxrs1/JaxRsAnnotationsDecorator.java
+++ b/dd-java-agent/instrumentation/jax-rs-annotations-1/src/main/java/datadog/trace/instrumentation/jaxrs1/JaxRsAnnotationsDecorator.java
@@ -6,8 +6,7 @@ import datadog.trace.agent.decorator.BaseDecorator;
 import datadog.trace.api.DDSpanTypes;
 import datadog.trace.api.DDTags;
 import datadog.trace.bootstrap.WeakMap;
-import io.opentracing.Scope;
-import io.opentracing.Span;
+import datadog.trace.instrumentation.api.AgentSpan;
 import io.opentracing.tag.Tags;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
@@ -37,11 +36,10 @@ public class JaxRsAnnotationsDecorator extends BaseDecorator {
     return "jax-rs-controller";
   }
 
-  public void onControllerStart(final Scope scope, final Scope parent, final Method method) {
+  public void onControllerStart(final AgentSpan span, final AgentSpan parent, final Method method) {
     final String resourceName = getPathResourceName(method);
     updateParent(parent, resourceName);
 
-    final Span span = scope.span();
     span.setTag(DDTags.SPAN_TYPE, DDSpanTypes.HTTP_SERVER);
 
     // When jax-rs is the root, we want to name using the path, otherwise use the class/method.
@@ -53,12 +51,11 @@ public class JaxRsAnnotationsDecorator extends BaseDecorator {
     }
   }
 
-  private void updateParent(final Scope scope, final String resourceName) {
-    if (scope == null) {
+  private void updateParent(final AgentSpan span, final String resourceName) {
+    if (span == null) {
       return;
     }
-    final Span span = scope.span();
-    Tags.COMPONENT.set(span, "jax-rs");
+    span.setTag(Tags.COMPONENT.getKey(), "jax-rs");
 
     if (!resourceName.isEmpty()) {
       span.setTag(DDTags.RESOURCE_NAME, resourceName);

--- a/dd-java-agent/instrumentation/jax-rs-annotations-2/src/main/java/datadog/trace/instrumentation/jaxrs2/JaxRsAnnotationsDecorator.java
+++ b/dd-java-agent/instrumentation/jax-rs-annotations-2/src/main/java/datadog/trace/instrumentation/jaxrs2/JaxRsAnnotationsDecorator.java
@@ -6,8 +6,7 @@ import datadog.trace.agent.decorator.BaseDecorator;
 import datadog.trace.api.DDSpanTypes;
 import datadog.trace.api.DDTags;
 import datadog.trace.bootstrap.WeakMap;
-import io.opentracing.Scope;
-import io.opentracing.Span;
+import datadog.trace.instrumentation.api.AgentSpan;
 import io.opentracing.tag.Tags;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
@@ -37,11 +36,10 @@ public class JaxRsAnnotationsDecorator extends BaseDecorator {
     return "jax-rs-controller";
   }
 
-  public void onControllerStart(final Scope scope, final Scope parent, final Method method) {
+  public void onControllerStart(final AgentSpan span, final AgentSpan parent, final Method method) {
     final String resourceName = getPathResourceName(method);
     updateParent(parent, resourceName);
 
-    final Span span = scope.span();
     span.setTag(DDTags.SPAN_TYPE, DDSpanTypes.HTTP_SERVER);
 
     // When jax-rs is the root, we want to name using the path, otherwise use the class/method.
@@ -53,12 +51,11 @@ public class JaxRsAnnotationsDecorator extends BaseDecorator {
     }
   }
 
-  private void updateParent(final Scope scope, final String resourceName) {
-    if (scope == null) {
+  private void updateParent(final AgentSpan span, final String resourceName) {
+    if (span == null) {
       return;
     }
-    final Span span = scope.span();
-    Tags.COMPONENT.set(span, "jax-rs");
+    span.setTag(Tags.COMPONENT.getKey(), "jax-rs");
 
     if (!resourceName.isEmpty()) {
       span.setTag(DDTags.RESOURCE_NAME, resourceName);

--- a/dd-java-agent/instrumentation/jax-rs-annotations-2/src/main/java/datadog/trace/instrumentation/jaxrs2/JaxRsAsyncResponseInstrumentation.java
+++ b/dd-java-agent/instrumentation/jax-rs-annotations-2/src/main/java/datadog/trace/instrumentation/jaxrs2/JaxRsAsyncResponseInstrumentation.java
@@ -10,7 +10,7 @@ import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.InstrumentationContext;
-import io.opentracing.Span;
+import datadog.trace.instrumentation.api.AgentSpan;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -29,7 +29,8 @@ public final class JaxRsAsyncResponseInstrumentation extends Instrumenter.Defaul
 
   @Override
   public Map<String, String> contextStore() {
-    return Collections.singletonMap("javax.ws.rs.container.AsyncResponse", Span.class.getName());
+    return Collections.singletonMap(
+        "javax.ws.rs.container.AsyncResponse", AgentSpan.class.getName());
   }
 
   @Override
@@ -62,10 +63,10 @@ public final class JaxRsAsyncResponseInstrumentation extends Instrumenter.Defaul
     @Advice.OnMethodExit(suppress = Throwable.class)
     public static void stopSpan(@Advice.This final AsyncResponse asyncResponse) {
 
-      final ContextStore<AsyncResponse, Span> contextStore =
-          InstrumentationContext.get(AsyncResponse.class, Span.class);
+      final ContextStore<AsyncResponse, AgentSpan> contextStore =
+          InstrumentationContext.get(AsyncResponse.class, AgentSpan.class);
 
-      final Span span = contextStore.get(asyncResponse);
+      final AgentSpan span = contextStore.get(asyncResponse);
       if (span != null) {
         contextStore.put(asyncResponse, null);
         DECORATE.beforeFinish(span);
@@ -81,10 +82,10 @@ public final class JaxRsAsyncResponseInstrumentation extends Instrumenter.Defaul
         @Advice.This final AsyncResponse asyncResponse,
         @Advice.Argument(0) final Throwable throwable) {
 
-      final ContextStore<AsyncResponse, Span> contextStore =
-          InstrumentationContext.get(AsyncResponse.class, Span.class);
+      final ContextStore<AsyncResponse, AgentSpan> contextStore =
+          InstrumentationContext.get(AsyncResponse.class, AgentSpan.class);
 
-      final Span span = contextStore.get(asyncResponse);
+      final AgentSpan span = contextStore.get(asyncResponse);
       if (span != null) {
         contextStore.put(asyncResponse, null);
         DECORATE.onError(span, throwable);
@@ -99,10 +100,10 @@ public final class JaxRsAsyncResponseInstrumentation extends Instrumenter.Defaul
     @Advice.OnMethodExit(suppress = Throwable.class)
     public static void stopSpan(@Advice.This final AsyncResponse asyncResponse) {
 
-      final ContextStore<AsyncResponse, Span> contextStore =
-          InstrumentationContext.get(AsyncResponse.class, Span.class);
+      final ContextStore<AsyncResponse, AgentSpan> contextStore =
+          InstrumentationContext.get(AsyncResponse.class, AgentSpan.class);
 
-      final Span span = contextStore.get(asyncResponse);
+      final AgentSpan span = contextStore.get(asyncResponse);
       if (span != null) {
         contextStore.put(asyncResponse, null);
         span.setTag("canceled", true);

--- a/dd-java-agent/instrumentation/jax-rs-client-1.9/src/main/java/datadog/trace/instrumentation/jaxrs/v1/InjectAdapter.java
+++ b/dd-java-agent/instrumentation/jax-rs-client-1.9/src/main/java/datadog/trace/instrumentation/jaxrs/v1/InjectAdapter.java
@@ -1,15 +1,15 @@
 package datadog.trace.instrumentation.jaxrs.v1;
 
-import com.sun.jersey.api.client.ClientRequest;
 import datadog.trace.instrumentation.api.AgentPropagation;
+import javax.ws.rs.core.MultivaluedMap;
 
-public final class InjectAdapter implements AgentPropagation.Setter<ClientRequest> {
+public final class InjectAdapter implements AgentPropagation.Setter<MultivaluedMap> {
 
   public static final InjectAdapter SETTER = new InjectAdapter();
 
   @Override
-  public void set(final ClientRequest carrier, final String key, final String value) {
+  public void set(final MultivaluedMap headers, final String key, final String value) {
     // Don't allow duplicates.
-    carrier.getHeaders().putSingle(key, value);
+    headers.putSingle(key, value);
   }
 }

--- a/dd-java-agent/instrumentation/jax-rs-client-1.9/src/main/java/datadog/trace/instrumentation/jaxrs/v1/InjectAdapter.java
+++ b/dd-java-agent/instrumentation/jax-rs-client-1.9/src/main/java/datadog/trace/instrumentation/jaxrs/v1/InjectAdapter.java
@@ -1,26 +1,15 @@
 package datadog.trace.instrumentation.jaxrs.v1;
 
-import io.opentracing.propagation.TextMap;
-import java.util.Iterator;
-import java.util.Map;
-import javax.ws.rs.core.MultivaluedMap;
+import com.sun.jersey.api.client.ClientRequest;
+import datadog.trace.instrumentation.api.AgentPropagation;
 
-public final class InjectAdapter implements TextMap {
-  private final MultivaluedMap<String, Object> map;
+public final class InjectAdapter implements AgentPropagation.Setter<ClientRequest> {
 
-  public InjectAdapter(final MultivaluedMap<String, Object> map) {
-    this.map = map;
-  }
+  public static final InjectAdapter SETTER = new InjectAdapter();
 
   @Override
-  public Iterator<Map.Entry<String, String>> iterator() {
-    throw new UnsupportedOperationException(
-        "InjectAdapter should only be used with Tracer.inject()");
-  }
-
-  @Override
-  public void put(final String key, final String value) {
+  public void set(final ClientRequest carrier, final String key, final String value) {
     // Don't allow duplicates.
-    map.putSingle(key, value);
+    carrier.getHeaders().putSingle(key, value);
   }
 }

--- a/dd-java-agent/instrumentation/jax-rs-client-1.9/src/main/java/datadog/trace/instrumentation/jaxrs/v1/JaxRsClientV1Instrumentation.java
+++ b/dd-java-agent/instrumentation/jax-rs-client-1.9/src/main/java/datadog/trace/instrumentation/jaxrs/v1/JaxRsClientV1Instrumentation.java
@@ -2,6 +2,10 @@ package datadog.trace.instrumentation.jaxrs.v1;
 
 import static datadog.trace.agent.decorator.HttpServerDecorator.DD_SPAN_ATTRIBUTE;
 import static datadog.trace.agent.tooling.ByteBuddyElementMatchers.safeHasSuperType;
+import static datadog.trace.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.instrumentation.api.AgentTracer.propagate;
+import static datadog.trace.instrumentation.api.AgentTracer.startSpan;
+import static datadog.trace.instrumentation.jaxrs.v1.InjectAdapter.SETTER;
 import static datadog.trace.instrumentation.jaxrs.v1.JaxRsClientV1Decorator.DECORATE;
 import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.named;
@@ -14,11 +18,8 @@ import com.sun.jersey.api.client.ClientRequest;
 import com.sun.jersey.api.client.ClientResponse;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.DDTags;
-import io.opentracing.Scope;
-import io.opentracing.Span;
-import io.opentracing.Tracer;
-import io.opentracing.propagation.Format;
-import io.opentracing.util.GlobalTracer;
+import datadog.trace.instrumentation.api.AgentScope;
+import datadog.trace.instrumentation.api.AgentSpan;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.method.MethodDescription;
@@ -62,37 +63,33 @@ public final class JaxRsClientV1Instrumentation extends Instrumenter.Default {
   public static class HandleAdvice {
 
     @Advice.OnMethodEnter
-    public static Scope onEnter(
+    public static AgentScope onEnter(
         @Advice.Argument(value = 0) final ClientRequest request,
         @Advice.This final ClientHandler thisObj) {
 
       // WARNING: this might be a chain...so we only have to trace the first in the chain.
       final boolean isRootClientHandler = null == request.getProperties().get(DD_SPAN_ATTRIBUTE);
       if (isRootClientHandler) {
-        final Tracer tracer = GlobalTracer.get();
-        final Span span =
-            tracer
-                .buildSpan("jax-rs.client.call")
-                .withTag(DDTags.RESOURCE_NAME, request.getMethod() + " jax-rs.client.call")
-                .start();
+        final AgentSpan span =
+            startSpan("jax-rs.client.call")
+                .setTag(DDTags.RESOURCE_NAME, request.getMethod() + " jax-rs.client.call");
         DECORATE.afterStart(span);
         DECORATE.onRequest(span, request);
         request.getProperties().put(DD_SPAN_ATTRIBUTE, span);
 
-        tracer.inject(
-            span.context(), Format.Builtin.HTTP_HEADERS, new InjectAdapter(request.getHeaders()));
-        return tracer.scopeManager().activate(span, true);
+        propagate().inject(span, request, SETTER);
+        return activateSpan(span, true);
       }
       return null;
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
     public static void onExit(
-        @Advice.Enter final Scope scope,
+        @Advice.Enter final AgentScope scope,
         @Advice.Return final ClientResponse response,
         @Advice.Thrown final Throwable throwable) {
       if (null != scope) {
-        final Span span = scope.span();
+        final AgentSpan span = scope.span();
         DECORATE.onResponse(span, response);
         DECORATE.onError(span, throwable);
         DECORATE.beforeFinish(span);

--- a/dd-java-agent/instrumentation/jax-rs-client-1.9/src/main/java/datadog/trace/instrumentation/jaxrs/v1/JaxRsClientV1Instrumentation.java
+++ b/dd-java-agent/instrumentation/jax-rs-client-1.9/src/main/java/datadog/trace/instrumentation/jaxrs/v1/JaxRsClientV1Instrumentation.java
@@ -77,7 +77,7 @@ public final class JaxRsClientV1Instrumentation extends Instrumenter.Default {
         DECORATE.onRequest(span, request);
         request.getProperties().put(DD_SPAN_ATTRIBUTE, span);
 
-        propagate().inject(span, request, SETTER);
+        propagate().inject(span, request.getHeaders(), SETTER);
         return activateSpan(span, true);
       }
       return null;

--- a/dd-java-agent/instrumentation/jax-rs-client-2.0/connection-error-handling-jersey/src/main/java/datadog/trace/instrumentation/connection_error/jersey/JerseyClientConnectionErrorInstrumentation.java
+++ b/dd-java-agent/instrumentation/jax-rs-client-2.0/connection-error-handling-jersey/src/main/java/datadog/trace/instrumentation/connection_error/jersey/JerseyClientConnectionErrorInstrumentation.java
@@ -1,6 +1,5 @@
 package datadog.trace.instrumentation.connection_error.jersey;
 
-import static io.opentracing.log.Fields.ERROR_OBJECT;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.named;
@@ -8,11 +7,8 @@ import static net.bytebuddy.matcher.ElementMatchers.returns;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.instrumentation.api.AgentSpan;
 import datadog.trace.instrumentation.jaxrs.ClientTracingFilter;
-import io.opentracing.Span;
-import io.opentracing.log.Fields;
-import io.opentracing.tag.Tags;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -66,10 +62,10 @@ public final class JerseyClientConnectionErrorInstrumentation extends Instrument
         @Advice.Thrown final Throwable throwable) {
       if (throwable != null) {
         final Object prop = context.getProperty(ClientTracingFilter.SPAN_PROPERTY_NAME);
-        if (prop instanceof Span) {
-          final Span span = (Span) prop;
-          Tags.ERROR.set(span, true);
-          span.log(Collections.singletonMap(ERROR_OBJECT, throwable));
+        if (prop instanceof AgentSpan) {
+          final AgentSpan span = (AgentSpan) prop;
+          span.setError(true);
+          span.addThrowable(throwable);
           span.finish();
         }
       }
@@ -119,10 +115,10 @@ public final class JerseyClientConnectionErrorInstrumentation extends Instrument
         return wrapped.get();
       } catch (final ExecutionException e) {
         final Object prop = context.getProperty(ClientTracingFilter.SPAN_PROPERTY_NAME);
-        if (prop instanceof Span) {
-          final Span span = (Span) prop;
-          Tags.ERROR.set(span, true);
-          span.log(Collections.singletonMap(Fields.ERROR_OBJECT, e.getCause()));
+        if (prop instanceof AgentSpan) {
+          final AgentSpan span = (AgentSpan) prop;
+          span.setError(true);
+          span.addThrowable(e.getCause());
           span.finish();
         }
         throw e;
@@ -136,10 +132,10 @@ public final class JerseyClientConnectionErrorInstrumentation extends Instrument
         return wrapped.get(timeout, unit);
       } catch (final ExecutionException e) {
         final Object prop = context.getProperty(ClientTracingFilter.SPAN_PROPERTY_NAME);
-        if (prop instanceof Span) {
-          final Span span = (Span) prop;
-          Tags.ERROR.set(span, true);
-          span.log(Collections.singletonMap(Fields.ERROR_OBJECT, e.getCause()));
+        if (prop instanceof AgentSpan) {
+          final AgentSpan span = (AgentSpan) prop;
+          span.setError(true);
+          span.addThrowable(e.getCause());
           span.finish();
         }
         throw e;

--- a/dd-java-agent/instrumentation/jax-rs-client-2.0/connection-error-handling-resteasy/src/main/java/datadog/trace/instrumentation/connection_error/resteasy/ResteasyClientConnectionErrorInstrumentation.java
+++ b/dd-java-agent/instrumentation/jax-rs-client-2.0/connection-error-handling-resteasy/src/main/java/datadog/trace/instrumentation/connection_error/resteasy/ResteasyClientConnectionErrorInstrumentation.java
@@ -1,6 +1,5 @@
 package datadog.trace.instrumentation.connection_error.resteasy;
 
-import static io.opentracing.log.Fields.ERROR_OBJECT;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.named;
@@ -8,11 +7,8 @@ import static net.bytebuddy.matcher.ElementMatchers.returns;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.instrumentation.api.AgentSpan;
 import datadog.trace.instrumentation.jaxrs.ClientTracingFilter;
-import io.opentracing.Span;
-import io.opentracing.log.Fields;
-import io.opentracing.tag.Tags;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -66,10 +62,10 @@ public final class ResteasyClientConnectionErrorInstrumentation extends Instrume
         @Advice.Thrown final Throwable throwable) {
       if (throwable != null) {
         final Object prop = context.getProperty(ClientTracingFilter.SPAN_PROPERTY_NAME);
-        if (prop instanceof Span) {
-          final Span span = (Span) prop;
-          Tags.ERROR.set(span, true);
-          span.log(Collections.singletonMap(ERROR_OBJECT, throwable));
+        if (prop instanceof AgentSpan) {
+          final AgentSpan span = (AgentSpan) prop;
+          span.setError(true);
+          span.addThrowable(throwable);
           span.finish();
         }
       }
@@ -119,10 +115,10 @@ public final class ResteasyClientConnectionErrorInstrumentation extends Instrume
         return wrapped.get();
       } catch (final ExecutionException e) {
         final Object prop = context.getProperty(ClientTracingFilter.SPAN_PROPERTY_NAME);
-        if (prop instanceof Span) {
-          final Span span = (Span) prop;
-          Tags.ERROR.set(span, true);
-          span.log(Collections.singletonMap(Fields.ERROR_OBJECT, e.getCause()));
+        if (prop instanceof AgentSpan) {
+          final AgentSpan span = (AgentSpan) prop;
+          span.setError(true);
+          span.addThrowable(e.getCause());
           span.finish();
         }
         throw e;
@@ -136,10 +132,10 @@ public final class ResteasyClientConnectionErrorInstrumentation extends Instrume
         return wrapped.get(timeout, unit);
       } catch (final ExecutionException e) {
         final Object prop = context.getProperty(ClientTracingFilter.SPAN_PROPERTY_NAME);
-        if (prop instanceof Span) {
-          final Span span = (Span) prop;
-          Tags.ERROR.set(span, true);
-          span.log(Collections.singletonMap(Fields.ERROR_OBJECT, e.getCause()));
+        if (prop instanceof AgentSpan) {
+          final AgentSpan span = (AgentSpan) prop;
+          span.setError(true);
+          span.addThrowable(e.getCause());
           span.finish();
         }
         throw e;

--- a/dd-java-agent/instrumentation/jax-rs-client-2.0/src/main/java/datadog/trace/instrumentation/jaxrs/ClientTracingFilter.java
+++ b/dd-java-agent/instrumentation/jax-rs-client-2.0/src/main/java/datadog/trace/instrumentation/jaxrs/ClientTracingFilter.java
@@ -31,7 +31,7 @@ public class ClientTracingFilter implements ClientRequestFilter, ClientResponseF
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, requestContext);
 
-      propagate().inject(span, requestContext, SETTER);
+      propagate().inject(span, requestContext.getHeaders(), SETTER);
 
       requestContext.setProperty(SPAN_PROPERTY_NAME, span);
     }

--- a/dd-java-agent/instrumentation/jax-rs-client-2.0/src/main/java/datadog/trace/instrumentation/jaxrs/ClientTracingFilter.java
+++ b/dd-java-agent/instrumentation/jax-rs-client-2.0/src/main/java/datadog/trace/instrumentation/jaxrs/ClientTracingFilter.java
@@ -1,12 +1,14 @@
 package datadog.trace.instrumentation.jaxrs;
 
+import static datadog.trace.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.instrumentation.api.AgentTracer.propagate;
+import static datadog.trace.instrumentation.api.AgentTracer.startSpan;
+import static datadog.trace.instrumentation.jaxrs.InjectAdapter.SETTER;
 import static datadog.trace.instrumentation.jaxrs.JaxRsClientDecorator.DECORATE;
 
 import datadog.trace.api.DDTags;
-import io.opentracing.Scope;
-import io.opentracing.Span;
-import io.opentracing.propagation.Format;
-import io.opentracing.util.GlobalTracer;
+import datadog.trace.instrumentation.api.AgentScope;
+import datadog.trace.instrumentation.api.AgentSpan;
 import javax.annotation.Priority;
 import javax.ws.rs.Priorities;
 import javax.ws.rs.client.ClientRequestContext;
@@ -22,20 +24,14 @@ public class ClientTracingFilter implements ClientRequestFilter, ClientResponseF
 
   @Override
   public void filter(final ClientRequestContext requestContext) {
-    final Span span =
-        GlobalTracer.get()
-            .buildSpan("jax-rs.client.call")
-            .withTag(DDTags.RESOURCE_NAME, requestContext.getMethod() + " jax-rs.client.call")
-            .start();
-    try (final Scope scope = GlobalTracer.get().scopeManager().activate(span, false)) {
+    final AgentSpan span =
+        startSpan("jax-rs.client.call")
+            .setTag(DDTags.RESOURCE_NAME, requestContext.getMethod() + " jax-rs.client.call");
+    try (final AgentScope scope = activateSpan(span, false)) {
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, requestContext);
 
-      GlobalTracer.get()
-          .inject(
-              span.context(),
-              Format.Builtin.HTTP_HEADERS,
-              new InjectAdapter(requestContext.getHeaders()));
+      propagate().inject(span, requestContext, SETTER);
 
       requestContext.setProperty(SPAN_PROPERTY_NAME, span);
     }
@@ -45,8 +41,8 @@ public class ClientTracingFilter implements ClientRequestFilter, ClientResponseF
   public void filter(
       final ClientRequestContext requestContext, final ClientResponseContext responseContext) {
     final Object spanObj = requestContext.getProperty(SPAN_PROPERTY_NAME);
-    if (spanObj instanceof Span) {
-      final Span span = (Span) spanObj;
+    if (spanObj instanceof AgentSpan) {
+      final AgentSpan span = (AgentSpan) spanObj;
       DECORATE.onResponse(span, responseContext);
       DECORATE.beforeFinish(span);
       span.finish();

--- a/dd-java-agent/instrumentation/jax-rs-client-2.0/src/main/java/datadog/trace/instrumentation/jaxrs/InjectAdapter.java
+++ b/dd-java-agent/instrumentation/jax-rs-client-2.0/src/main/java/datadog/trace/instrumentation/jaxrs/InjectAdapter.java
@@ -1,15 +1,15 @@
 package datadog.trace.instrumentation.jaxrs;
 
 import datadog.trace.instrumentation.api.AgentPropagation;
-import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.core.MultivaluedMap;
 
-public final class InjectAdapter implements AgentPropagation.Setter<ClientRequestContext> {
+public final class InjectAdapter implements AgentPropagation.Setter<MultivaluedMap> {
 
   public static final InjectAdapter SETTER = new InjectAdapter();
 
   @Override
-  public void set(final ClientRequestContext carrier, final String key, final String value) {
+  public void set(final MultivaluedMap headers, final String key, final String value) {
     // Don't allow duplicates.
-    carrier.getHeaders().putSingle(key, value);
+    headers.putSingle(key, value);
   }
 }

--- a/dd-java-agent/instrumentation/jax-rs-client-2.0/src/main/java/datadog/trace/instrumentation/jaxrs/InjectAdapter.java
+++ b/dd-java-agent/instrumentation/jax-rs-client-2.0/src/main/java/datadog/trace/instrumentation/jaxrs/InjectAdapter.java
@@ -1,26 +1,15 @@
 package datadog.trace.instrumentation.jaxrs;
 
-import io.opentracing.propagation.TextMap;
-import java.util.Iterator;
-import java.util.Map;
-import javax.ws.rs.core.MultivaluedMap;
+import datadog.trace.instrumentation.api.AgentPropagation;
+import javax.ws.rs.client.ClientRequestContext;
 
-public final class InjectAdapter implements TextMap {
-  private final MultivaluedMap<String, Object> map;
+public final class InjectAdapter implements AgentPropagation.Setter<ClientRequestContext> {
 
-  public InjectAdapter(final MultivaluedMap<String, Object> map) {
-    this.map = map;
-  }
+  public static final InjectAdapter SETTER = new InjectAdapter();
 
   @Override
-  public Iterator<Map.Entry<String, String>> iterator() {
-    throw new UnsupportedOperationException(
-        "InjectAdapter should only be used with Tracer.inject()");
-  }
-
-  @Override
-  public void put(final String key, final String value) {
+  public void set(final ClientRequestContext carrier, final String key, final String value) {
     // Don't allow duplicates.
-    map.putSingle(key, value);
+    carrier.getHeaders().putSingle(key, value);
   }
 }

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/JDBCDecorator.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/JDBCDecorator.java
@@ -3,7 +3,7 @@ package datadog.trace.instrumentation.jdbc;
 import datadog.trace.agent.decorator.DatabaseClientDecorator;
 import datadog.trace.api.DDSpanTypes;
 import datadog.trace.api.DDTags;
-import io.opentracing.Span;
+import datadog.trace.instrumentation.api.AgentSpan;
 import io.opentracing.tag.Tags;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
@@ -54,7 +54,7 @@ public class JDBCDecorator extends DatabaseClientDecorator<DBInfo> {
     }
   }
 
-  public Span onConnection(final Span span, final Connection connection) {
+  public AgentSpan onConnection(final AgentSpan span, final Connection connection) {
     DBInfo dbInfo = JDBCMaps.connectionInfo.get(connection);
     /**
      * Logic to get the DBInfo from a JDBC Connection, if the connection was not created via
@@ -81,25 +81,25 @@ public class JDBCDecorator extends DatabaseClientDecorator<DBInfo> {
     }
 
     if (dbInfo != null) {
-      Tags.DB_TYPE.set(span, dbInfo.getType());
+      span.setTag(Tags.DB_TYPE.getKey(), dbInfo.getType());
       span.setTag(DDTags.SERVICE_NAME, dbInfo.getType());
     }
     return super.onConnection(span, dbInfo);
   }
 
   @Override
-  public Span onStatement(final Span span, final String statement) {
+  public AgentSpan onStatement(final AgentSpan span, final String statement) {
     final String resourceName = statement == null ? DB_QUERY : statement;
     span.setTag(DDTags.RESOURCE_NAME, resourceName);
-    Tags.COMPONENT.set(span, "java-jdbc-statement");
+    span.setTag(Tags.COMPONENT.getKey(), "java-jdbc-statement");
     return super.onStatement(span, statement);
   }
 
-  public Span onPreparedStatement(final Span span, final PreparedStatement statement) {
+  public AgentSpan onPreparedStatement(final AgentSpan span, final PreparedStatement statement) {
     final String sql = JDBCMaps.preparedStatements.get(statement);
     final String resourceName = sql == null ? DB_QUERY : sql;
     span.setTag(DDTags.RESOURCE_NAME, resourceName);
-    Tags.COMPONENT.set(span, "java-jdbc-prepared_statement");
+    span.setTag(Tags.COMPONENT.getKey(), "java-jdbc-prepared_statement");
     return super.onStatement(span, sql);
   }
 }

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/StatementInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/StatementInstrumentation.java
@@ -1,6 +1,8 @@
 package datadog.trace.instrumentation.jdbc;
 
 import static datadog.trace.agent.tooling.ByteBuddyElementMatchers.safeHasSuperType;
+import static datadog.trace.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.jdbc.JDBCDecorator.DECORATE;
 import static datadog.trace.instrumentation.jdbc.JDBCUtils.connectionFromStatement;
 import static java.util.Collections.singletonMap;
@@ -14,10 +16,8 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.bootstrap.CallDepthThreadLocalMap;
-import io.opentracing.Scope;
-import io.opentracing.Span;
-import io.opentracing.noop.NoopScopeManager;
-import io.opentracing.util.GlobalTracer;
+import datadog.trace.instrumentation.api.AgentScope;
+import datadog.trace.instrumentation.api.AgentSpan;
 import java.sql.Connection;
 import java.sql.Statement;
 import java.util.ArrayList;
@@ -71,7 +71,7 @@ public final class StatementInstrumentation extends Instrumenter.Default {
   public static class StatementAdvice {
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static Scope startSpan(
+    public static AgentScope onEnter(
         @Advice.Argument(0) final String sql, @Advice.This final Statement statement) {
       final int callDepth = CallDepthThreadLocalMap.incrementCallDepth(Statement.class);
       if (callDepth > 0) {
@@ -80,21 +80,20 @@ public final class StatementInstrumentation extends Instrumenter.Default {
 
       final Connection connection = connectionFromStatement(statement);
       if (connection == null) {
-        return NoopScopeManager.NoopScope.INSTANCE;
+        return null;
       }
 
-      final Scope scope = GlobalTracer.get().buildSpan("database.query").startActive(true);
-      final Span span = scope.span();
+      final AgentSpan span = startSpan("database.query");
       DECORATE.afterStart(span);
       DECORATE.onConnection(span, connection);
       DECORATE.onStatement(span, sql);
       span.setTag("span.origin.type", statement.getClass().getName());
-      return scope;
+      return activateSpan(span, true);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
     public static void stopSpan(
-        @Advice.Enter final Scope scope, @Advice.Thrown final Throwable throwable) {
+        @Advice.Enter final AgentScope scope, @Advice.Thrown final Throwable throwable) {
       if (scope != null) {
         DECORATE.onError(scope.span(), throwable);
         DECORATE.beforeFinish(scope.span());

--- a/dd-java-agent/instrumentation/jetty-8/src/main/java/datadog/trace/instrumentation/jetty8/HttpServletRequestExtractAdapter.java
+++ b/dd-java-agent/instrumentation/jetty-8/src/main/java/datadog/trace/instrumentation/jetty8/HttpServletRequestExtractAdapter.java
@@ -1,96 +1,23 @@
 package datadog.trace.instrumentation.jetty8;
 
-import io.opentracing.propagation.TextMap;
-import java.util.AbstractMap;
-import java.util.ArrayList;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.Iterator;
+import datadog.trace.instrumentation.api.AgentPropagation;
+import java.util.Collections;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
 import javax.servlet.http.HttpServletRequest;
 
-/**
- * Tracer extract adapter for {@link HttpServletRequest}.
- *
- * @author Pavol Loffay
- */
-// FIXME:  This code is duplicated in several places.  Extract to a common dependency.
-public class HttpServletRequestExtractAdapter implements TextMap {
+public class HttpServletRequestExtractAdapter
+    implements AgentPropagation.Getter<HttpServletRequest> {
 
-  private final Map<String, List<String>> headers;
+  public static final HttpServletRequestExtractAdapter GETTER =
+      new HttpServletRequestExtractAdapter();
 
-  public HttpServletRequestExtractAdapter(final HttpServletRequest httpServletRequest) {
-    headers = servletHeadersToMultiMap(httpServletRequest);
+  @Override
+  public List<String> keys(final HttpServletRequest carrier) {
+    return Collections.list(carrier.getHeaderNames());
   }
 
   @Override
-  public Iterator<Map.Entry<String, String>> iterator() {
-    return new MultivaluedMapFlatIterator<>(headers.entrySet());
-  }
-
-  @Override
-  public void put(final String key, final String value) {
-    throw new UnsupportedOperationException("This class should be used only with Tracer.inject()!");
-  }
-
-  protected Map<String, List<String>> servletHeadersToMultiMap(
-      final HttpServletRequest httpServletRequest) {
-    final Map<String, List<String>> headersResult = new HashMap<>();
-
-    final Enumeration<String> headerNamesIt = httpServletRequest.getHeaderNames();
-    while (headerNamesIt.hasMoreElements()) {
-      final String headerName = headerNamesIt.nextElement();
-
-      final Enumeration<String> valuesIt = httpServletRequest.getHeaders(headerName);
-      final List<String> valuesList = new ArrayList<>(1);
-      while (valuesIt.hasMoreElements()) {
-        valuesList.add(valuesIt.nextElement());
-      }
-
-      headersResult.put(headerName, valuesList);
-    }
-
-    return headersResult;
-  }
-
-  public static final class MultivaluedMapFlatIterator<K, V> implements Iterator<Map.Entry<K, V>> {
-
-    private final Iterator<Map.Entry<K, List<V>>> mapIterator;
-    private Map.Entry<K, List<V>> mapEntry;
-    private Iterator<V> listIterator;
-
-    public MultivaluedMapFlatIterator(final Set<Map.Entry<K, List<V>>> multiValuesEntrySet) {
-      mapIterator = multiValuesEntrySet.iterator();
-    }
-
-    @Override
-    public boolean hasNext() {
-      if (listIterator != null && listIterator.hasNext()) {
-        return true;
-      }
-
-      return mapIterator.hasNext();
-    }
-
-    @Override
-    public Map.Entry<K, V> next() {
-      if (mapEntry == null || (!listIterator.hasNext() && mapIterator.hasNext())) {
-        mapEntry = mapIterator.next();
-        listIterator = mapEntry.getValue().iterator();
-      }
-
-      if (listIterator.hasNext()) {
-        return new AbstractMap.SimpleImmutableEntry<>(mapEntry.getKey(), listIterator.next());
-      } else {
-        return new AbstractMap.SimpleImmutableEntry<>(mapEntry.getKey(), null);
-      }
-    }
-
-    @Override
-    public void remove() {
-      throw new UnsupportedOperationException();
-    }
+  public String get(final HttpServletRequest carrier, final String key) {
+    return carrier.getHeader(key);
   }
 }

--- a/dd-java-agent/instrumentation/jetty-8/src/main/java/datadog/trace/instrumentation/jetty8/JettyDecorator.java
+++ b/dd-java-agent/instrumentation/jetty-8/src/main/java/datadog/trace/instrumentation/jetty8/JettyDecorator.java
@@ -1,7 +1,7 @@
 package datadog.trace.instrumentation.jetty8;
 
 import datadog.trace.agent.decorator.HttpServerDecorator;
-import io.opentracing.Span;
+import datadog.trace.instrumentation.api.AgentSpan;
 import java.net.URI;
 import java.net.URISyntaxException;
 import javax.servlet.http.HttpServletRequest;
@@ -52,7 +52,7 @@ public class JettyDecorator
   }
 
   @Override
-  public Span onRequest(final Span span, final HttpServletRequest request) {
+  public AgentSpan onRequest(final AgentSpan span, final HttpServletRequest request) {
     assert span != null;
     if (request != null) {
       span.setTag("servlet.context", request.getContextPath());

--- a/dd-java-agent/instrumentation/jetty-8/src/main/java/datadog/trace/instrumentation/jetty8/JettyHandlerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-8/src/main/java/datadog/trace/instrumentation/jetty8/JettyHandlerInstrumentation.java
@@ -42,7 +42,6 @@ public final class JettyHandlerInstrumentation extends Instrumenter.Default {
       "datadog.trace.agent.decorator.HttpServerDecorator",
       packageName + ".JettyDecorator",
       packageName + ".HttpServletRequestExtractAdapter",
-      packageName + ".HttpServletRequestExtractAdapter$MultivaluedMapFlatIterator",
       packageName + ".TagSettingAsyncListener"
     };
   }

--- a/dd-java-agent/instrumentation/jetty-8/src/main/java/datadog/trace/instrumentation/jetty8/TagSettingAsyncListener.java
+++ b/dd-java-agent/instrumentation/jetty-8/src/main/java/datadog/trace/instrumentation/jetty8/TagSettingAsyncListener.java
@@ -2,7 +2,7 @@ package datadog.trace.instrumentation.jetty8;
 
 import static datadog.trace.instrumentation.jetty8.JettyDecorator.DECORATE;
 
-import io.opentracing.Span;
+import datadog.trace.instrumentation.api.AgentSpan;
 import io.opentracing.tag.Tags;
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -12,9 +12,9 @@ import javax.servlet.http.HttpServletResponse;
 
 public class TagSettingAsyncListener implements AsyncListener {
   private final AtomicBoolean activated;
-  private final Span span;
+  private final AgentSpan span;
 
-  public TagSettingAsyncListener(final AtomicBoolean activated, final Span span) {
+  public TagSettingAsyncListener(final AtomicBoolean activated, final AgentSpan span) {
     this.activated = activated;
     this.span = span;
   }
@@ -31,7 +31,7 @@ public class TagSettingAsyncListener implements AsyncListener {
   @Override
   public void onTimeout(final AsyncEvent event) throws IOException {
     if (activated.compareAndSet(false, true)) {
-      Tags.ERROR.set(span, Boolean.TRUE);
+      span.setError(true);
       span.setTag("timeout", event.getAsyncContext().getTimeout());
       DECORATE.beforeFinish(span);
       span.finish();
@@ -41,10 +41,11 @@ public class TagSettingAsyncListener implements AsyncListener {
   @Override
   public void onError(final AsyncEvent event) throws IOException {
     if (event.getThrowable() != null && activated.compareAndSet(false, true)) {
+      DECORATE.onResponse(span, (HttpServletResponse) event.getSuppliedResponse());
       if (((HttpServletResponse) event.getSuppliedResponse()).getStatus()
           == HttpServletResponse.SC_OK) {
         // exception is thrown in filter chain, but status code is incorrect
-        Tags.HTTP_STATUS.set(span, 500);
+        span.setTag(Tags.HTTP_STATUS.getKey(), 500);
       }
       DECORATE.onError(span, event.getThrowable());
       DECORATE.beforeFinish(span);

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSDecorator.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSDecorator.java
@@ -3,8 +3,7 @@ package datadog.trace.instrumentation.jms;
 import datadog.trace.agent.decorator.ClientDecorator;
 import datadog.trace.api.DDSpanTypes;
 import datadog.trace.api.DDTags;
-import io.opentracing.Scope;
-import io.opentracing.Span;
+import datadog.trace.instrumentation.api.AgentSpan;
 import io.opentracing.tag.Tags;
 import java.lang.reflect.Method;
 import javax.jms.Destination;
@@ -59,22 +58,21 @@ public abstract class JMSDecorator extends ClientDecorator {
   @Override
   protected abstract String spanKind();
 
-  public void onConsume(final Span span, final Message message) {
+  public void onConsume(final AgentSpan span, final Message message) {
     span.setTag(DDTags.RESOURCE_NAME, "Consumed from " + toResourceName(message, null));
   }
 
-  public void onReceive(final Span span, final Method method) {
+  public void onReceive(final AgentSpan span, final Method method) {
     span.setTag(DDTags.RESOURCE_NAME, "JMS " + method.getName());
   }
 
-  public void onReceive(final Scope scope, final Message message) {
-    scope.span().setTag(DDTags.RESOURCE_NAME, "Received from " + toResourceName(message, null));
+  public void onReceive(final AgentSpan span, final Message message) {
+    span.setTag(DDTags.RESOURCE_NAME, "Received from " + toResourceName(message, null));
   }
 
-  public void onProduce(final Scope scope, final Message message, final Destination destination) {
-    scope
-        .span()
-        .setTag(DDTags.RESOURCE_NAME, "Produced for " + toResourceName(message, destination));
+  public void onProduce(
+      final AgentSpan span, final Message message, final Destination destination) {
+    span.setTag(DDTags.RESOURCE_NAME, "Produced for " + toResourceName(message, destination));
   }
 
   private static final String TIBCO_TMP_PREFIX = "$TMP$";

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageConsumerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageConsumerInstrumentation.java
@@ -5,7 +5,7 @@ import static datadog.trace.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.instrumentation.api.AgentTracer.propagate;
 import static datadog.trace.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.jms.JMSDecorator.CONSUMER_DECORATE;
-import static datadog.trace.instrumentation.jms.MessagePropertyTextMap.GETTER;
+import static datadog.trace.instrumentation.jms.MessageExtractAdapter.GETTER;
 import static net.bytebuddy.matcher.ElementMatchers.isInterface;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.named;
@@ -48,7 +48,8 @@ public final class JMSMessageConsumerInstrumentation extends Instrumenter.Defaul
       packageName + ".JMSDecorator",
       packageName + ".JMSDecorator$1",
       packageName + ".JMSDecorator$2",
-      packageName + ".MessagePropertyTextMap",
+      packageName + ".MessageExtractAdapter",
+      packageName + ".MessageInjectAdapter"
     };
   }
 

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageConsumerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageConsumerInstrumentation.java
@@ -1,7 +1,11 @@
 package datadog.trace.instrumentation.jms;
 
 import static datadog.trace.agent.tooling.ByteBuddyElementMatchers.safeHasSuperType;
+import static datadog.trace.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.instrumentation.api.AgentTracer.propagate;
+import static datadog.trace.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.jms.JMSDecorator.CONSUMER_DECORATE;
+import static datadog.trace.instrumentation.jms.MessagePropertyTextMap.GETTER;
 import static net.bytebuddy.matcher.ElementMatchers.isInterface;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.named;
@@ -10,12 +14,9 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
-import io.opentracing.Scope;
-import io.opentracing.Span;
-import io.opentracing.SpanContext;
-import io.opentracing.Tracer;
-import io.opentracing.propagation.Format;
-import io.opentracing.util.GlobalTracer;
+import datadog.trace.instrumentation.api.AgentScope;
+import datadog.trace.instrumentation.api.AgentSpan;
+import datadog.trace.instrumentation.api.AgentSpan.Context;
 import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
@@ -66,7 +67,7 @@ public final class JMSMessageConsumerInstrumentation extends Instrumenter.Defaul
   public static class ConsumerAdvice {
 
     @Advice.OnMethodEnter
-    public static long startSpan() {
+    public static long onEnter() {
       return System.currentTimeMillis();
     }
 
@@ -77,23 +78,17 @@ public final class JMSMessageConsumerInstrumentation extends Instrumenter.Defaul
         @Advice.Origin final Method method,
         @Advice.Return final Message message,
         @Advice.Thrown final Throwable throwable) {
-      Tracer.SpanBuilder spanBuilder =
-          GlobalTracer.get()
-              .buildSpan("jms.consume")
-              .withTag("span.origin.type", consumer.getClass().getName())
-              .withStartTimestamp(TimeUnit.MILLISECONDS.toMicros(startTime));
-
+      final AgentSpan span;
       if (message != null) {
-        final SpanContext extractedContext =
-            GlobalTracer.get()
-                .extract(Format.Builtin.TEXT_MAP, new MessagePropertyTextMap(message));
-        if (extractedContext != null) {
-          spanBuilder = spanBuilder.asChildOf(extractedContext);
-        }
+        final Context extractedContext = propagate().extract(message, GETTER);
+        span =
+            startSpan("jms.consume", extractedContext, TimeUnit.MILLISECONDS.toMicros(startTime));
+      } else {
+        span = startSpan("jms.consume", TimeUnit.MILLISECONDS.toMicros(startTime));
       }
+      span.setTag("span.origin.type", consumer.getClass().getName());
 
-      final Span span = spanBuilder.start();
-      try (final Scope scope = GlobalTracer.get().scopeManager().activate(span, false)) {
+      try (final AgentScope scope = activateSpan(span, false)) {
         CONSUMER_DECORATE.afterStart(span);
         if (message == null) {
           CONSUMER_DECORATE.onReceive(span, method);

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageListenerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageListenerInstrumentation.java
@@ -1,7 +1,11 @@
 package datadog.trace.instrumentation.jms;
 
 import static datadog.trace.agent.tooling.ByteBuddyElementMatchers.safeHasSuperType;
+import static datadog.trace.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.instrumentation.api.AgentTracer.propagate;
+import static datadog.trace.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.jms.JMSDecorator.CONSUMER_DECORATE;
+import static datadog.trace.instrumentation.jms.MessagePropertyTextMap.GETTER;
 import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isInterface;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
@@ -11,11 +15,9 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
-import datadog.trace.context.TraceScope;
-import io.opentracing.Scope;
-import io.opentracing.SpanContext;
-import io.opentracing.propagation.Format;
-import io.opentracing.util.GlobalTracer;
+import datadog.trace.instrumentation.api.AgentScope;
+import datadog.trace.instrumentation.api.AgentSpan;
+import datadog.trace.instrumentation.api.AgentSpan.Context;
 import java.util.Map;
 import javax.jms.Message;
 import javax.jms.MessageListener;
@@ -58,31 +60,25 @@ public final class JMSMessageListenerInstrumentation extends Instrumenter.Defaul
   public static class MessageListenerAdvice {
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static Scope startSpan(
+    public static AgentScope onEnter(
         @Advice.Argument(0) final Message message, @Advice.This final MessageListener listener) {
 
-      final SpanContext extractedContext =
-          GlobalTracer.get().extract(Format.Builtin.TEXT_MAP, new MessagePropertyTextMap(message));
+      final Context extractedContext = propagate().extract(message, GETTER);
 
-      final Scope scope =
-          GlobalTracer.get()
-              .buildSpan("jms.onMessage")
-              .asChildOf(extractedContext)
-              .withTag("span.origin.type", listener.getClass().getName())
-              .startActive(true);
-      CONSUMER_DECORATE.afterStart(scope);
-      CONSUMER_DECORATE.onReceive(scope, message);
+      final AgentSpan span =
+          startSpan("jms.onMessage", extractedContext)
+              .setTag("span.origin.type", listener.getClass().getName());
+      CONSUMER_DECORATE.afterStart(span);
+      CONSUMER_DECORATE.onReceive(span, message);
 
-      if (scope instanceof TraceScope) {
-        ((TraceScope) scope).setAsyncPropagation(true);
-      }
-
+      final AgentScope scope = activateSpan(span, true);
+      scope.setAsyncPropagation(true);
       return scope;
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
     public static void stopSpan(
-        @Advice.Enter final Scope scope, @Advice.Thrown final Throwable throwable) {
+        @Advice.Enter final AgentScope scope, @Advice.Thrown final Throwable throwable) {
       if (scope != null) {
         CONSUMER_DECORATE.onError(scope, throwable);
         CONSUMER_DECORATE.beforeFinish(scope);

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageListenerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageListenerInstrumentation.java
@@ -5,7 +5,7 @@ import static datadog.trace.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.instrumentation.api.AgentTracer.propagate;
 import static datadog.trace.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.jms.JMSDecorator.CONSUMER_DECORATE;
-import static datadog.trace.instrumentation.jms.MessagePropertyTextMap.GETTER;
+import static datadog.trace.instrumentation.jms.MessageExtractAdapter.GETTER;
 import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isInterface;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
@@ -46,7 +46,8 @@ public final class JMSMessageListenerInstrumentation extends Instrumenter.Defaul
       packageName + ".JMSDecorator",
       packageName + ".JMSDecorator$1",
       packageName + ".JMSDecorator$2",
-      packageName + ".MessagePropertyTextMap",
+      packageName + ".MessageExtractAdapter",
+      packageName + ".MessageInjectAdapter"
     };
   }
 

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageProducerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageProducerInstrumentation.java
@@ -5,7 +5,7 @@ import static datadog.trace.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.instrumentation.api.AgentTracer.propagate;
 import static datadog.trace.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.jms.JMSDecorator.PRODUCER_DECORATE;
-import static datadog.trace.instrumentation.jms.MessagePropertyTextMap.SETTER;
+import static datadog.trace.instrumentation.jms.MessageInjectAdapter.SETTER;
 import static net.bytebuddy.matcher.ElementMatchers.isInterface;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.named;
@@ -48,7 +48,8 @@ public final class JMSMessageProducerInstrumentation extends Instrumenter.Defaul
       packageName + ".JMSDecorator",
       packageName + ".JMSDecorator$1",
       packageName + ".JMSDecorator$2",
-      packageName + ".MessagePropertyTextMap",
+      packageName + ".MessageExtractAdapter",
+      packageName + ".MessageInjectAdapter"
     };
   }
 

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageProducerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageProducerInstrumentation.java
@@ -1,7 +1,11 @@
 package datadog.trace.instrumentation.jms;
 
 import static datadog.trace.agent.tooling.ByteBuddyElementMatchers.safeHasSuperType;
+import static datadog.trace.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.instrumentation.api.AgentTracer.propagate;
+import static datadog.trace.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.jms.JMSDecorator.PRODUCER_DECORATE;
+import static datadog.trace.instrumentation.jms.MessagePropertyTextMap.SETTER;
 import static net.bytebuddy.matcher.ElementMatchers.isInterface;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.named;
@@ -11,9 +15,8 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.bootstrap.CallDepthThreadLocalMap;
-import io.opentracing.Scope;
-import io.opentracing.propagation.Format;
-import io.opentracing.util.GlobalTracer;
+import datadog.trace.instrumentation.api.AgentScope;
+import datadog.trace.instrumentation.api.AgentSpan;
 import java.util.HashMap;
 import java.util.Map;
 import javax.jms.Destination;
@@ -67,7 +70,7 @@ public final class JMSMessageProducerInstrumentation extends Instrumenter.Defaul
   public static class ProducerAdvice {
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static Scope startSpan(
+    public static AgentScope onEnter(
         @Advice.Argument(0) final Message message, @Advice.This final MessageProducer producer) {
       final int callDepth = CallDepthThreadLocalMap.incrementCallDepth(MessageProducer.class);
       if (callDepth > 0) {
@@ -81,24 +84,19 @@ public final class JMSMessageProducerInstrumentation extends Instrumenter.Defaul
         defaultDestination = null;
       }
 
-      final Scope scope =
-          GlobalTracer.get()
-              .buildSpan("jms.produce")
-              .withTag("span.origin.type", producer.getClass().getName())
-              .startActive(true);
-      PRODUCER_DECORATE.afterStart(scope);
-      PRODUCER_DECORATE.onProduce(scope, message, defaultDestination);
+      final AgentSpan span =
+          startSpan("jms.produce").setTag("span.origin.type", producer.getClass().getName());
+      PRODUCER_DECORATE.afterStart(span);
+      PRODUCER_DECORATE.onProduce(span, message, defaultDestination);
 
-      GlobalTracer.get()
-          .inject(
-              scope.span().context(), Format.Builtin.TEXT_MAP, new MessagePropertyTextMap(message));
+      propagate().inject(span, message, SETTER);
 
-      return scope;
+      return activateSpan(span, true);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
     public static void stopSpan(
-        @Advice.Enter final Scope scope, @Advice.Thrown final Throwable throwable) {
+        @Advice.Enter final AgentScope scope, @Advice.Thrown final Throwable throwable) {
 
       if (scope != null) {
         PRODUCER_DECORATE.onError(scope, throwable);
@@ -112,7 +110,7 @@ public final class JMSMessageProducerInstrumentation extends Instrumenter.Defaul
   public static class ProducerWithDestinationAdvice {
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static Scope startSpan(
+    public static AgentScope onEnter(
         @Advice.Argument(0) final Destination destination,
         @Advice.Argument(1) final Message message,
         @Advice.This final MessageProducer producer) {
@@ -121,24 +119,19 @@ public final class JMSMessageProducerInstrumentation extends Instrumenter.Defaul
         return null;
       }
 
-      final Scope scope =
-          GlobalTracer.get()
-              .buildSpan("jms.produce")
-              .withTag("span.origin.type", producer.getClass().getName())
-              .startActive(true);
-      PRODUCER_DECORATE.afterStart(scope);
-      PRODUCER_DECORATE.onProduce(scope, message, destination);
+      final AgentSpan span =
+          startSpan("jms.produce").setTag("span.origin.type", producer.getClass().getName());
+      PRODUCER_DECORATE.afterStart(span);
+      PRODUCER_DECORATE.onProduce(span, message, destination);
 
-      GlobalTracer.get()
-          .inject(
-              scope.span().context(), Format.Builtin.TEXT_MAP, new MessagePropertyTextMap(message));
+      propagate().inject(span, message, SETTER);
 
-      return scope;
+      return activateSpan(span, true);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
     public static void stopSpan(
-        @Advice.Enter final Scope scope, @Advice.Thrown final Throwable throwable) {
+        @Advice.Enter final AgentScope scope, @Advice.Thrown final Throwable throwable) {
       if (scope != null) {
         PRODUCER_DECORATE.onError(scope, throwable);
         PRODUCER_DECORATE.beforeFinish(scope);

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/MessageExtractAdapter.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/MessageExtractAdapter.java
@@ -9,13 +9,9 @@ import javax.jms.Message;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public class MessagePropertyTextMap
-    implements AgentPropagation.Getter<Message>, AgentPropagation.Setter<Message> {
+public class MessageExtractAdapter implements AgentPropagation.Getter<Message> {
 
-  public static final MessagePropertyTextMap GETTER = new MessagePropertyTextMap();
-  public static final MessagePropertyTextMap SETTER = new MessagePropertyTextMap();
-
-  static final String DASH = "__dash__";
+  public static final MessageExtractAdapter GETTER = new MessageExtractAdapter();
 
   @Override
   public Iterable<String> keys(final Message carrier) {
@@ -27,7 +23,7 @@ public class MessagePropertyTextMap
           final String key = (String) enumeration.nextElement();
           final Object value = carrier.getObjectProperty(key);
           if (value instanceof String) {
-            keys.add(key.replace(DASH, "-"));
+            keys.add(key.replace(MessageInjectAdapter.DASH, "-"));
           }
         }
       }
@@ -39,7 +35,7 @@ public class MessagePropertyTextMap
 
   @Override
   public String get(final Message carrier, final String key) {
-    final String propName = key.replace("-", DASH);
+    final String propName = key.replace("-", MessageInjectAdapter.DASH);
     final Object value;
     try {
       value = carrier.getObjectProperty(propName);
@@ -50,18 +46,6 @@ public class MessagePropertyTextMap
       return (String) value;
     } else {
       return null;
-    }
-  }
-
-  @Override
-  public void set(final Message carrier, final String key, final String value) {
-    final String propName = key.replace("-", DASH);
-    try {
-      carrier.setStringProperty(propName, value);
-    } catch (final JMSException e) {
-      if (log.isDebugEnabled()) {
-        log.debug("Failure setting jms property: " + propName, e);
-      }
     }
   }
 }

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/MessageInjectAdapter.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/MessageInjectAdapter.java
@@ -1,0 +1,26 @@
+package datadog.trace.instrumentation.jms;
+
+import datadog.trace.instrumentation.api.AgentPropagation;
+import javax.jms.JMSException;
+import javax.jms.Message;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class MessageInjectAdapter implements AgentPropagation.Setter<Message> {
+
+  public static final MessageInjectAdapter SETTER = new MessageInjectAdapter();
+
+  static final String DASH = "__dash__";
+
+  @Override
+  public void set(final Message carrier, final String key, final String value) {
+    final String propName = key.replace("-", DASH);
+    try {
+      carrier.setStringProperty(propName, value);
+    } catch (final JMSException e) {
+      if (log.isDebugEnabled()) {
+        log.debug("Failure setting jms property: " + propName, e);
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/MessagePropertyTextMap.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/MessagePropertyTextMap.java
@@ -1,49 +1,63 @@
 package datadog.trace.instrumentation.jms;
 
-import io.opentracing.propagation.TextMap;
+import datadog.trace.instrumentation.api.AgentPropagation;
+import java.util.ArrayList;
 import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
+import java.util.List;
 import javax.jms.JMSException;
 import javax.jms.Message;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public class MessagePropertyTextMap implements TextMap {
+public class MessagePropertyTextMap
+    implements AgentPropagation.Getter<Message>, AgentPropagation.Setter<Message> {
+
+  public static final MessagePropertyTextMap GETTER = new MessagePropertyTextMap();
+  public static final MessagePropertyTextMap SETTER = new MessagePropertyTextMap();
+
   static final String DASH = "__dash__";
 
-  private final Message message;
-
-  public MessagePropertyTextMap(final Message message) {
-    this.message = message;
-  }
-
   @Override
-  public Iterator<Map.Entry<String, String>> iterator() {
-    final Map<String, String> map = new HashMap<>();
+  public Iterable<String> keys(final Message carrier) {
+    final List<String> keys = new ArrayList<>();
     try {
-      final Enumeration<?> enumeration = message.getPropertyNames();
+      final Enumeration<?> enumeration = carrier.getPropertyNames();
       if (enumeration != null) {
         while (enumeration.hasMoreElements()) {
           final String key = (String) enumeration.nextElement();
-          final Object value = message.getObjectProperty(key);
+          final Object value = carrier.getObjectProperty(key);
           if (value instanceof String) {
-            map.put(key.replace(DASH, "-"), (String) value);
+            keys.add(key.replace(DASH, "-"));
           }
         }
       }
     } catch (final JMSException e) {
       throw new RuntimeException(e);
     }
-    return map.entrySet().iterator();
+    return keys;
   }
 
   @Override
-  public void put(final String key, final String value) {
+  public String get(final Message carrier, final String key) {
+    final String propName = key.replace("-", DASH);
+    final Object value;
+    try {
+      value = carrier.getObjectProperty(propName);
+    } catch (final JMSException e) {
+      throw new RuntimeException(e);
+    }
+    if (value instanceof String) {
+      return (String) value;
+    } else {
+      return null;
+    }
+  }
+
+  @Override
+  public void set(final Message carrier, final String key, final String value) {
     final String propName = key.replace("-", DASH);
     try {
-      message.setStringProperty(propName, value);
+      carrier.setStringProperty(propName, value);
     } catch (final JMSException e) {
       if (log.isDebugEnabled()) {
         log.debug("Failure setting jms property: " + propName, e);

--- a/dd-java-agent/instrumentation/jsp-2.3/src/main/java/datadog/trace/instrumentation/jsp/JSPDecorator.java
+++ b/dd-java-agent/instrumentation/jsp-2.3/src/main/java/datadog/trace/instrumentation/jsp/JSPDecorator.java
@@ -2,8 +2,8 @@ package datadog.trace.instrumentation.jsp;
 
 import datadog.trace.agent.decorator.BaseDecorator;
 import datadog.trace.api.DDTags;
-import io.opentracing.Scope;
-import io.opentracing.Span;
+import datadog.trace.instrumentation.api.AgentScope;
+import datadog.trace.instrumentation.api.AgentSpan;
 import java.net.URI;
 import java.net.URISyntaxException;
 import javax.servlet.RequestDispatcher;
@@ -30,9 +30,9 @@ public class JSPDecorator extends BaseDecorator {
     return "jsp-http-servlet";
   }
 
-  public void onCompile(final Scope scope, final JspCompilationContext jspCompilationContext) {
+  public void onCompile(final AgentScope scope, final JspCompilationContext jspCompilationContext) {
     if (jspCompilationContext != null) {
-      final Span span = scope.span();
+      final AgentSpan span = scope.span();
       span.setTag(DDTags.RESOURCE_NAME, jspCompilationContext.getJspFile());
 
       if (jspCompilationContext.getServletContext() != null) {
@@ -46,8 +46,7 @@ public class JSPDecorator extends BaseDecorator {
     }
   }
 
-  public void onRender(final Scope scope, final HttpServletRequest req) {
-    final Span span = scope.span();
+  public void onRender(final AgentSpan span, final HttpServletRequest req) {
     // get the JSP file name being rendered in an include action
     final Object includeServletPath = req.getAttribute(RequestDispatcher.INCLUDE_SERVLET_PATH);
     String resourceName = req.getServletPath();

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaDecorator.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaDecorator.java
@@ -3,8 +3,7 @@ package datadog.trace.instrumentation.kafka_clients;
 import datadog.trace.agent.decorator.ClientDecorator;
 import datadog.trace.api.DDSpanTypes;
 import datadog.trace.api.DDTags;
-import io.opentracing.Scope;
-import io.opentracing.Span;
+import datadog.trace.instrumentation.api.AgentSpan;
 import io.opentracing.tag.Tags;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -54,8 +53,7 @@ public abstract class KafkaDecorator extends ClientDecorator {
   @Override
   protected abstract String spanKind();
 
-  public void onConsume(final Scope scope, final ConsumerRecord record) {
-    final Span span = scope.span();
+  public void onConsume(final AgentSpan span, final ConsumerRecord record) {
     if (record != null) {
       final String topic = record.topic() == null ? "kafka" : record.topic();
       span.setTag(DDTags.RESOURCE_NAME, "Consume Topic " + topic);
@@ -64,9 +62,8 @@ public abstract class KafkaDecorator extends ClientDecorator {
     }
   }
 
-  public void onProduce(final Scope scope, final ProducerRecord record) {
+  public void onProduce(final AgentSpan span, final ProducerRecord record) {
     if (record != null) {
-      final Span span = scope.span();
 
       final String topic = record.topic() == null ? "kafka" : record.topic();
       if (record.partition() != null) {

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerInstrumentation.java
@@ -80,7 +80,7 @@ public final class KafkaProducerInstrumentation extends Instrumenter.Default {
       // https://github.com/apache/kafka/blob/05fcfde8f69b0349216553f711fdfc3f0259c601/clients/src/main/java/org/apache/kafka/common/record/MemoryRecordsBuilder.java#L411-L412
       if (apiVersions.maxUsableProduceMagic() >= RecordBatch.MAGIC_VALUE_V2) {
         try {
-          propagate().inject(span, record, SETTER);
+          propagate().inject(span, record.headers(), SETTER);
         } catch (final IllegalStateException e) {
           // headers must be read-only from reused record. try again with new one.
           record =
@@ -92,7 +92,7 @@ public final class KafkaProducerInstrumentation extends Instrumenter.Default {
                   record.value(),
                   record.headers());
 
-          propagate().inject(span, record, SETTER);
+          propagate().inject(span, record.headers(), SETTER);
         }
       }
 

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerInstrumentation.java
@@ -1,6 +1,10 @@
 package datadog.trace.instrumentation.kafka_clients;
 
+import static datadog.trace.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.instrumentation.api.AgentTracer.propagate;
+import static datadog.trace.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.kafka_clients.KafkaDecorator.PRODUCER_DECORATE;
+import static datadog.trace.instrumentation.kafka_clients.TextMapInjectAdapter.SETTER;
 import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
@@ -9,10 +13,8 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
-import io.opentracing.Scope;
-import io.opentracing.Span;
-import io.opentracing.propagation.Format;
-import io.opentracing.util.GlobalTracer;
+import datadog.trace.instrumentation.api.AgentScope;
+import datadog.trace.instrumentation.api.AgentSpan;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.method.MethodDescription;
@@ -63,26 +65,22 @@ public final class KafkaProducerInstrumentation extends Instrumenter.Default {
   public static class ProducerAdvice {
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static Scope startSpan(
+    public static AgentScope onEnter(
         @Advice.FieldValue("apiVersions") final ApiVersions apiVersions,
         @Advice.Argument(value = 0, readOnly = false) ProducerRecord record,
         @Advice.Argument(value = 1, readOnly = false) Callback callback) {
-      final Scope scope = GlobalTracer.get().buildSpan("kafka.produce").startActive(false);
-      PRODUCER_DECORATE.afterStart(scope);
-      PRODUCER_DECORATE.onProduce(scope, record);
+      final AgentSpan span = startSpan("kafka.produce");
+      PRODUCER_DECORATE.afterStart(span);
+      PRODUCER_DECORATE.onProduce(span, record);
 
-      callback = new ProducerCallback(callback, scope.span());
+      callback = new ProducerCallback(callback, span);
 
       // Do not inject headers for batch versions below 2
       // This is how similar check is being done in Kafka client itself:
       // https://github.com/apache/kafka/blob/05fcfde8f69b0349216553f711fdfc3f0259c601/clients/src/main/java/org/apache/kafka/common/record/MemoryRecordsBuilder.java#L411-L412
       if (apiVersions.maxUsableProduceMagic() >= RecordBatch.MAGIC_VALUE_V2) {
         try {
-          GlobalTracer.get()
-              .inject(
-                  scope.span().context(),
-                  Format.Builtin.TEXT_MAP,
-                  new TextMapInjectAdapter(record.headers()));
+          propagate().inject(span, record, SETTER);
         } catch (final IllegalStateException e) {
           // headers must be read-only from reused record. try again with new one.
           record =
@@ -94,20 +92,16 @@ public final class KafkaProducerInstrumentation extends Instrumenter.Default {
                   record.value(),
                   record.headers());
 
-          GlobalTracer.get()
-              .inject(
-                  scope.span().context(),
-                  Format.Builtin.TEXT_MAP,
-                  new TextMapInjectAdapter(record.headers()));
+          propagate().inject(span, record, SETTER);
         }
       }
 
-      return scope;
+      return activateSpan(span, false);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
     public static void stopSpan(
-        @Advice.Enter final Scope scope, @Advice.Thrown final Throwable throwable) {
+        @Advice.Enter final AgentScope scope, @Advice.Thrown final Throwable throwable) {
       PRODUCER_DECORATE.onError(scope, throwable);
       PRODUCER_DECORATE.beforeFinish(scope);
       scope.close();
@@ -116,16 +110,16 @@ public final class KafkaProducerInstrumentation extends Instrumenter.Default {
 
   public static class ProducerCallback implements Callback {
     private final Callback callback;
-    private final Span span;
+    private final AgentSpan span;
 
-    public ProducerCallback(final Callback callback, final Span span) {
+    public ProducerCallback(final Callback callback, final AgentSpan span) {
       this.callback = callback;
       this.span = span;
     }
 
     @Override
     public void onCompletion(final RecordMetadata metadata, final Exception exception) {
-      try (final Scope scope = GlobalTracer.get().scopeManager().activate(span, false)) {
+      try (final AgentScope scope = activateSpan(span, false)) {
         PRODUCER_DECORATE.onError(span, exception);
         try {
           if (callback != null) {

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TextMapExtractAdapter.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TextMapExtractAdapter.java
@@ -1,30 +1,31 @@
 package datadog.trace.instrumentation.kafka_clients;
 
-import io.opentracing.propagation.TextMap;
+import datadog.trace.instrumentation.api.AgentPropagation;
 import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.header.Header;
-import org.apache.kafka.common.header.Headers;
 
-public class TextMapExtractAdapter implements TextMap {
+public class TextMapExtractAdapter implements AgentPropagation.Getter<ConsumerRecord> {
 
-  private final Map<String, String> map = new HashMap<>();
+  public static final TextMapExtractAdapter GETTER = new TextMapExtractAdapter();
 
-  public TextMapExtractAdapter(final Headers headers) {
-    for (final Header header : headers) {
-      map.put(header.key(), new String(header.value(), StandardCharsets.UTF_8));
+  @Override
+  public Iterable<String> keys(final ConsumerRecord carrier) {
+    final List<String> keys = new ArrayList<>();
+    for (final Header header : carrier.headers()) {
+      keys.add(header.key());
     }
+    return keys;
   }
 
   @Override
-  public Iterator<Map.Entry<String, String>> iterator() {
-    return map.entrySet().iterator();
-  }
-
-  @Override
-  public void put(final String key, final String value) {
-    throw new UnsupportedOperationException("Use inject adapter instead");
+  public String get(final ConsumerRecord carrier, final String key) {
+    final Header header = carrier.headers().lastHeader(key);
+    if (header == null) {
+      return null;
+    }
+    return new String(header.value(), StandardCharsets.UTF_8);
   }
 }

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TextMapExtractAdapter.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TextMapExtractAdapter.java
@@ -4,25 +4,25 @@ import datadog.trace.instrumentation.api.AgentPropagation;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
-import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.Headers;
 
-public class TextMapExtractAdapter implements AgentPropagation.Getter<ConsumerRecord> {
+public class TextMapExtractAdapter implements AgentPropagation.Getter<Headers> {
 
   public static final TextMapExtractAdapter GETTER = new TextMapExtractAdapter();
 
   @Override
-  public Iterable<String> keys(final ConsumerRecord carrier) {
+  public Iterable<String> keys(final Headers headers) {
     final List<String> keys = new ArrayList<>();
-    for (final Header header : carrier.headers()) {
+    for (final Header header : headers) {
       keys.add(header.key());
     }
     return keys;
   }
 
   @Override
-  public String get(final ConsumerRecord carrier, final String key) {
-    final Header header = carrier.headers().lastHeader(key);
+  public String get(final Headers headers, final String key) {
+    final Header header = headers.lastHeader(key);
     if (header == null) {
       return null;
     }

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TextMapInjectAdapter.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TextMapInjectAdapter.java
@@ -2,14 +2,14 @@ package datadog.trace.instrumentation.kafka_clients;
 
 import datadog.trace.instrumentation.api.AgentPropagation;
 import java.nio.charset.StandardCharsets;
-import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.header.Headers;
 
-public class TextMapInjectAdapter implements AgentPropagation.Setter<ProducerRecord> {
+public class TextMapInjectAdapter implements AgentPropagation.Setter<Headers> {
 
   public static final TextMapInjectAdapter SETTER = new TextMapInjectAdapter();
 
   @Override
-  public void set(final ProducerRecord carrier, final String key, final String value) {
-    carrier.headers().remove(key).add(key, value.getBytes(StandardCharsets.UTF_8));
+  public void set(final Headers headers, final String key, final String value) {
+    headers.remove(key).add(key, value.getBytes(StandardCharsets.UTF_8));
   }
 }

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TextMapInjectAdapter.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TextMapInjectAdapter.java
@@ -1,26 +1,15 @@
 package datadog.trace.instrumentation.kafka_clients;
 
-import io.opentracing.propagation.TextMap;
+import datadog.trace.instrumentation.api.AgentPropagation;
 import java.nio.charset.StandardCharsets;
-import java.util.Iterator;
-import java.util.Map;
-import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.clients.producer.ProducerRecord;
 
-public class TextMapInjectAdapter implements TextMap {
+public class TextMapInjectAdapter implements AgentPropagation.Setter<ProducerRecord> {
 
-  private final Headers headers;
-
-  public TextMapInjectAdapter(final Headers headers) {
-    this.headers = headers;
-  }
+  public static final TextMapInjectAdapter SETTER = new TextMapInjectAdapter();
 
   @Override
-  public Iterator<Map.Entry<String, String>> iterator() {
-    throw new UnsupportedOperationException("Use extract adapter instead");
-  }
-
-  @Override
-  public void put(final String key, final String value) {
-    headers.remove(key).add(key, value.getBytes(StandardCharsets.UTF_8));
+  public void set(final ProducerRecord carrier, final String key, final String value) {
+    carrier.headers().remove(key).add(key, value.getBytes(StandardCharsets.UTF_8));
   }
 }

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TracingIterator.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TracingIterator.java
@@ -54,7 +54,7 @@ public class TracingIterator implements Iterator<ConsumerRecord> {
 
     try {
       if (next != null) {
-        final Context spanContext = propagate().extract(next, GETTER);
+        final Context spanContext = propagate().extract(next.headers(), GETTER);
         final AgentSpan span = startSpan(operationName, spanContext);
         decorator.afterStart(span);
         decorator.onConsume(span, next);

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TracingIterator.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TracingIterator.java
@@ -1,9 +1,13 @@
 package datadog.trace.instrumentation.kafka_clients;
 
-import io.opentracing.Scope;
-import io.opentracing.SpanContext;
-import io.opentracing.propagation.Format;
-import io.opentracing.util.GlobalTracer;
+import static datadog.trace.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.instrumentation.api.AgentTracer.propagate;
+import static datadog.trace.instrumentation.api.AgentTracer.startSpan;
+import static datadog.trace.instrumentation.kafka_clients.TextMapExtractAdapter.GETTER;
+
+import datadog.trace.instrumentation.api.AgentScope;
+import datadog.trace.instrumentation.api.AgentSpan;
+import datadog.trace.instrumentation.api.AgentSpan.Context;
 import java.util.Iterator;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -18,7 +22,7 @@ public class TracingIterator implements Iterator<ConsumerRecord> {
    * Note: this may potentially create problems if this iterator is used from different threads. But
    * at the moment we cannot do much about this.
    */
-  private Scope currentScope;
+  private AgentScope currentScope;
 
   public TracingIterator(
       final Iterator<ConsumerRecord> delegateIterator,
@@ -50,13 +54,11 @@ public class TracingIterator implements Iterator<ConsumerRecord> {
 
     try {
       if (next != null) {
-        final SpanContext spanContext =
-            GlobalTracer.get()
-                .extract(Format.Builtin.TEXT_MAP, new TextMapExtractAdapter(next.headers()));
-        currentScope =
-            GlobalTracer.get().buildSpan(operationName).asChildOf(spanContext).startActive(true);
-        decorator.afterStart(currentScope);
-        decorator.onConsume(currentScope, next);
+        final Context spanContext = propagate().extract(next, GETTER);
+        final AgentSpan span = startSpan(operationName, spanContext);
+        decorator.afterStart(span);
+        decorator.onConsume(span, next);
+        currentScope = activateSpan(span, true);
       }
     } catch (final Exception e) {
       log.debug("Error during decoration", e);

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/KafkaStreamsDecorator.java
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/KafkaStreamsDecorator.java
@@ -3,8 +3,7 @@ package datadog.trace.instrumentation.kafka_streams;
 import datadog.trace.agent.decorator.ClientDecorator;
 import datadog.trace.api.DDSpanTypes;
 import datadog.trace.api.DDTags;
-import io.opentracing.Scope;
-import io.opentracing.Span;
+import datadog.trace.instrumentation.api.AgentSpan;
 import io.opentracing.tag.Tags;
 import org.apache.kafka.streams.processor.internals.StampedRecord;
 
@@ -36,8 +35,7 @@ public class KafkaStreamsDecorator extends ClientDecorator {
     return DDSpanTypes.MESSAGE_CONSUMER;
   }
 
-  public void onConsume(final Scope scope, final StampedRecord record) {
-    final Span span = scope.span();
+  public void onConsume(final AgentSpan span, final StampedRecord record) {
     if (record != null) {
       final String topic = record.topic() == null ? "kafka" : record.topic();
       span.setTag(DDTags.RESOURCE_NAME, "Consume Topic " + topic);

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/KafkaStreamsProcessorInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/KafkaStreamsProcessorInstrumentation.java
@@ -1,6 +1,12 @@
 package datadog.trace.instrumentation.kafka_streams;
 
+import static datadog.trace.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.instrumentation.api.AgentTracer.activeScope;
+import static datadog.trace.instrumentation.api.AgentTracer.activeSpan;
+import static datadog.trace.instrumentation.api.AgentTracer.propagate;
+import static datadog.trace.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.kafka_streams.KafkaStreamsDecorator.CONSUMER_DECORATE;
+import static datadog.trace.instrumentation.kafka_streams.TextMapExtractAdapter.GETTER;
 import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.isPackagePrivate;
@@ -11,10 +17,9 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
-import io.opentracing.Scope;
-import io.opentracing.SpanContext;
-import io.opentracing.propagation.Format;
-import io.opentracing.util.GlobalTracer;
+import datadog.trace.context.TraceScope;
+import datadog.trace.instrumentation.api.AgentSpan;
+import datadog.trace.instrumentation.api.AgentSpan.Context;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.method.MethodDescription;
@@ -65,23 +70,18 @@ public class KafkaStreamsProcessorInstrumentation {
     public static class StartSpanAdvice {
 
       @Advice.OnMethodExit(suppress = Throwable.class)
-      public static void startSpan(@Advice.Return final StampedRecord record) {
+      public static void onExit(@Advice.Return final StampedRecord record) {
         if (record == null) {
           return;
         }
 
-        final SpanContext extractedContext =
-            GlobalTracer.get()
-                .extract(
-                    Format.Builtin.TEXT_MAP, new TextMapExtractAdapter(record.value.headers()));
+        final Context extractedContext = propagate().extract(record.value, GETTER);
 
-        final Scope scope =
-            GlobalTracer.get()
-                .buildSpan("kafka.consume")
-                .asChildOf(extractedContext)
-                .startActive(true);
-        CONSUMER_DECORATE.afterStart(scope);
-        CONSUMER_DECORATE.onConsume(scope, record);
+        final AgentSpan span = startSpan("kafka.consume", extractedContext);
+        CONSUMER_DECORATE.afterStart(span);
+        CONSUMER_DECORATE.onConsume(span, record);
+
+        activateSpan(span, true);
       }
     }
   }
@@ -119,10 +119,13 @@ public class KafkaStreamsProcessorInstrumentation {
 
       @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
       public static void stopSpan(@Advice.Thrown final Throwable throwable) {
-        final Scope scope = GlobalTracer.get().scopeManager().active();
+        final AgentSpan span = activeSpan();
+        if (span != null) {
+          CONSUMER_DECORATE.onError(span, throwable);
+          CONSUMER_DECORATE.beforeFinish(span);
+        }
+        final TraceScope scope = activeScope();
         if (scope != null) {
-          CONSUMER_DECORATE.onError(scope, throwable);
-          CONSUMER_DECORATE.beforeFinish(scope);
           scope.close();
         }
       }

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/KafkaStreamsProcessorInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/KafkaStreamsProcessorInstrumentation.java
@@ -75,7 +75,7 @@ public class KafkaStreamsProcessorInstrumentation {
           return;
         }
 
-        final Context extractedContext = propagate().extract(record.value, GETTER);
+        final Context extractedContext = propagate().extract(record.value.headers(), GETTER);
 
         final AgentSpan span = startSpan("kafka.consume", extractedContext);
         CONSUMER_DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/TextMapExtractAdapter.java
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/TextMapExtractAdapter.java
@@ -1,30 +1,31 @@
 package datadog.trace.instrumentation.kafka_streams;
 
-import io.opentracing.propagation.TextMap;
+import datadog.trace.instrumentation.api.AgentPropagation;
 import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.header.Header;
-import org.apache.kafka.common.header.Headers;
 
-public class TextMapExtractAdapter implements TextMap {
+public class TextMapExtractAdapter implements AgentPropagation.Getter<ConsumerRecord> {
 
-  private final Map<String, String> map = new HashMap<>();
+  public static final TextMapExtractAdapter GETTER = new TextMapExtractAdapter();
 
-  public TextMapExtractAdapter(final Headers headers) {
-    for (final Header header : headers) {
-      map.put(header.key(), new String(header.value(), StandardCharsets.UTF_8));
+  @Override
+  public Iterable<String> keys(final ConsumerRecord carrier) {
+    final List<String> keys = new ArrayList<>();
+    for (final Header header : carrier.headers()) {
+      keys.add(header.key());
     }
+    return keys;
   }
 
   @Override
-  public Iterator<Map.Entry<String, String>> iterator() {
-    return map.entrySet().iterator();
-  }
-
-  @Override
-  public void put(final String key, final String value) {
-    throw new UnsupportedOperationException("Use inject adapter instead");
+  public String get(final ConsumerRecord carrier, final String key) {
+    final Header header = carrier.headers().lastHeader(key);
+    if (header == null) {
+      return null;
+    }
+    return new String(header.value(), StandardCharsets.UTF_8);
   }
 }

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/TextMapExtractAdapter.java
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/TextMapExtractAdapter.java
@@ -4,25 +4,25 @@ import datadog.trace.instrumentation.api.AgentPropagation;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
-import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.Headers;
 
-public class TextMapExtractAdapter implements AgentPropagation.Getter<ConsumerRecord> {
+public class TextMapExtractAdapter implements AgentPropagation.Getter<Headers> {
 
   public static final TextMapExtractAdapter GETTER = new TextMapExtractAdapter();
 
   @Override
-  public Iterable<String> keys(final ConsumerRecord carrier) {
+  public Iterable<String> keys(final Headers headers) {
     final List<String> keys = new ArrayList<>();
-    for (final Header header : carrier.headers()) {
+    for (final Header header : headers) {
       keys.add(header.key());
     }
     return keys;
   }
 
   @Override
-  public String get(final ConsumerRecord carrier, final String key) {
-    final Header header = carrier.headers().lastHeader(key);
+  public String get(final Headers headers, final String key) {
+    final Header header = headers.lastHeader(key);
     if (header == null) {
       return null;
     }

--- a/dd-java-agent/instrumentation/lettuce-5/src/main/java8/datadog/trace/instrumentation/lettuce/ConnectionFutureAdvice.java
+++ b/dd-java-agent/instrumentation/lettuce-5/src/main/java8/datadog/trace/instrumentation/lettuce/ConnectionFutureAdvice.java
@@ -1,31 +1,31 @@
 package datadog.trace.instrumentation.lettuce;
 
+import static datadog.trace.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.lettuce.LettuceClientDecorator.DECORATE;
 
+import datadog.trace.instrumentation.api.AgentScope;
+import datadog.trace.instrumentation.api.AgentSpan;
 import io.lettuce.core.ConnectionFuture;
 import io.lettuce.core.RedisURI;
-import io.opentracing.Scope;
-import io.opentracing.Span;
-import io.opentracing.util.GlobalTracer;
 import net.bytebuddy.asm.Advice;
 
 public class ConnectionFutureAdvice {
 
   @Advice.OnMethodEnter(suppress = Throwable.class)
-  public static Scope startSpan(@Advice.Argument(1) final RedisURI redisURI) {
-    final Scope scope = GlobalTracer.get().buildSpan("redis.query").startActive(false);
-    final Span span = scope.span();
+  public static AgentScope onEnter(@Advice.Argument(1) final RedisURI redisURI) {
+    final AgentSpan span = startSpan("redis.query");
     DECORATE.afterStart(span);
     DECORATE.onConnection(span, redisURI);
-    return scope;
+    return activateSpan(span, false);
   }
 
   @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
   public static void stopSpan(
-      @Advice.Enter final Scope scope,
+      @Advice.Enter final AgentScope scope,
       @Advice.Thrown final Throwable throwable,
       @Advice.Return final ConnectionFuture<?> connectionFuture) {
-    final Span span = scope.span();
+    final AgentSpan span = scope.span();
     if (throwable != null) {
       DECORATE.onError(span, throwable);
       DECORATE.beforeFinish(span);

--- a/dd-java-agent/instrumentation/lettuce-5/src/main/java8/datadog/trace/instrumentation/lettuce/LettuceAsyncBiFunction.java
+++ b/dd-java-agent/instrumentation/lettuce-5/src/main/java8/datadog/trace/instrumentation/lettuce/LettuceAsyncBiFunction.java
@@ -2,7 +2,7 @@ package datadog.trace.instrumentation.lettuce;
 
 import static datadog.trace.instrumentation.lettuce.LettuceClientDecorator.DECORATE;
 
-import io.opentracing.Span;
+import datadog.trace.instrumentation.api.AgentSpan;
 import java.util.concurrent.CancellationException;
 import java.util.function.BiFunction;
 
@@ -18,9 +18,9 @@ import java.util.function.BiFunction;
 public class LettuceAsyncBiFunction<T extends Object, U extends Throwable, R extends Object>
     implements BiFunction<T, Throwable, R> {
 
-  private final Span span;
+  private final AgentSpan span;
 
-  public LettuceAsyncBiFunction(final Span span) {
+  public LettuceAsyncBiFunction(final AgentSpan span) {
     this.span = span;
   }
 

--- a/dd-java-agent/instrumentation/lettuce-5/src/main/java8/datadog/trace/instrumentation/lettuce/LettuceAsyncCommandsAdvice.java
+++ b/dd-java-agent/instrumentation/lettuce-5/src/main/java8/datadog/trace/instrumentation/lettuce/LettuceAsyncCommandsAdvice.java
@@ -1,37 +1,36 @@
 package datadog.trace.instrumentation.lettuce;
 
+import static datadog.trace.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.lettuce.LettuceClientDecorator.DECORATE;
 import static datadog.trace.instrumentation.lettuce.LettuceInstrumentationUtil.doFinishSpanEarly;
 
+import datadog.trace.instrumentation.api.AgentScope;
+import datadog.trace.instrumentation.api.AgentSpan;
 import io.lettuce.core.protocol.AsyncCommand;
 import io.lettuce.core.protocol.RedisCommand;
-import io.opentracing.Scope;
-import io.opentracing.Span;
-import io.opentracing.util.GlobalTracer;
 import net.bytebuddy.asm.Advice;
 
 public class LettuceAsyncCommandsAdvice {
 
   @Advice.OnMethodEnter(suppress = Throwable.class)
-  public static Scope startSpan(@Advice.Argument(0) final RedisCommand command) {
+  public static AgentScope onEnter(@Advice.Argument(0) final RedisCommand command) {
 
-    final Scope scope =
-        GlobalTracer.get().buildSpan("redis.query").startActive(doFinishSpanEarly(command));
-
-    final Span span = scope.span();
+    final AgentSpan span = startSpan("redis.query");
     DECORATE.afterStart(span);
     DECORATE.onCommand(span, command);
-    return scope;
+
+    return activateSpan(span, doFinishSpanEarly(command));
   }
 
   @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
   public static void stopSpan(
       @Advice.Argument(0) final RedisCommand command,
-      @Advice.Enter final Scope scope,
+      @Advice.Enter final AgentScope scope,
       @Advice.Thrown final Throwable throwable,
       @Advice.Return final AsyncCommand<?, ?, ?> asyncCommand) {
 
-    final Span span = scope.span();
+    final AgentSpan span = scope.span();
     if (throwable != null) {
       DECORATE.onError(span, throwable);
       DECORATE.beforeFinish(span);

--- a/dd-java-agent/instrumentation/lettuce-5/src/main/java8/datadog/trace/instrumentation/lettuce/rx/LettuceFluxTerminationRunnable.java
+++ b/dd-java-agent/instrumentation/lettuce-5/src/main/java8/datadog/trace/instrumentation/lettuce/rx/LettuceFluxTerminationRunnable.java
@@ -1,10 +1,10 @@
 package datadog.trace.instrumentation.lettuce.rx;
 
+import static datadog.trace.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.lettuce.LettuceClientDecorator.DECORATE;
 
+import datadog.trace.instrumentation.api.AgentSpan;
 import io.lettuce.core.protocol.RedisCommand;
-import io.opentracing.Span;
-import io.opentracing.util.GlobalTracer;
 import java.util.function.Consumer;
 import org.reactivestreams.Subscription;
 import org.slf4j.LoggerFactory;
@@ -14,7 +14,7 @@ import reactor.core.publisher.SignalType;
 
 public class LettuceFluxTerminationRunnable implements Consumer<Signal>, Runnable {
 
-  private Span span = null;
+  private AgentSpan span = null;
   private int numResults = 0;
   private FluxOnSubscribeConsumer onSubscribeConsumer = null;
 
@@ -83,7 +83,7 @@ public class LettuceFluxTerminationRunnable implements Consumer<Signal>, Runnabl
 
     @Override
     public void accept(final Subscription subscription) {
-      final Span span = GlobalTracer.get().buildSpan("redis.query").start();
+      final AgentSpan span = startSpan("redis.query");
       owner.span = span;
       DECORATE.afterStart(span);
       DECORATE.onCommand(span, command);

--- a/dd-java-agent/instrumentation/mongo/driver-3.1/src/main/java/datadog/trace/instrumentation/mongo/MongoClientDecorator.java
+++ b/dd-java-agent/instrumentation/mongo/driver-3.1/src/main/java/datadog/trace/instrumentation/mongo/MongoClientDecorator.java
@@ -8,7 +8,7 @@ import com.mongodb.event.CommandStartedEvent;
 import datadog.trace.agent.decorator.DatabaseClientDecorator;
 import datadog.trace.api.DDSpanTypes;
 import datadog.trace.api.DDTags;
-import io.opentracing.Span;
+import datadog.trace.instrumentation.api.AgentSpan;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -59,9 +59,9 @@ public class MongoClientDecorator extends DatabaseClientDecorator<CommandStarted
       if (connectionId != null) {
         final ServerId serverId = connectionId.getServerId();
         if (serverId != null) {
-          ClusterId clusterId = serverId.getClusterId();
+          final ClusterId clusterId = serverId.getClusterId();
           if (clusterId != null) {
-            String description = clusterId.getDescription();
+            final String description = clusterId.getDescription();
             if (description != null) {
               return description;
             }
@@ -73,7 +73,7 @@ public class MongoClientDecorator extends DatabaseClientDecorator<CommandStarted
     return event.getDatabaseName();
   }
 
-  public Span onStatement(final Span span, final BsonDocument statement) {
+  public AgentSpan onStatement(final AgentSpan span, final BsonDocument statement) {
 
     // scrub the Mongo command so that parameters are removed from the string
     final BsonDocument scrubbed = scrub(statement);

--- a/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/AttributeKeys.java
+++ b/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/AttributeKeys.java
@@ -2,10 +2,10 @@ package datadog.trace.instrumentation.netty40;
 
 import datadog.trace.bootstrap.WeakMap;
 import datadog.trace.context.TraceScope;
+import datadog.trace.instrumentation.api.AgentSpan;
 import datadog.trace.instrumentation.netty40.client.HttpClientTracingHandler;
 import datadog.trace.instrumentation.netty40.server.HttpServerTracingHandler;
 import io.netty.util.AttributeKey;
-import io.opentracing.Span;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -26,13 +26,13 @@ public class AttributeKeys {
       PARENT_CONNECT_CONTINUATION_ATTRIBUTE_KEY =
           attributeKey("datadog.trace.instrumentation.netty40.parent.connect.continuation");
 
-  public static final AttributeKey<Span> SERVER_ATTRIBUTE_KEY =
+  public static final AttributeKey<AgentSpan> SERVER_ATTRIBUTE_KEY =
       attributeKey(HttpServerTracingHandler.class.getName() + ".span");
 
-  public static final AttributeKey<Span> CLIENT_ATTRIBUTE_KEY =
+  public static final AttributeKey<AgentSpan> CLIENT_ATTRIBUTE_KEY =
       attributeKey(HttpClientTracingHandler.class.getName() + ".span");
 
-  public static final AttributeKey<Span> CLIENT_PARENT_ATTRIBUTE_KEY =
+  public static final AttributeKey<AgentSpan> CLIENT_PARENT_ATTRIBUTE_KEY =
       attributeKey(HttpClientTracingHandler.class.getName() + ".parent");
 
   /**

--- a/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/ChannelFutureListenerInstrumentation.java
+++ b/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/ChannelFutureListenerInstrumentation.java
@@ -1,6 +1,8 @@
 package datadog.trace.instrumentation.netty40;
 
 import static datadog.trace.agent.tooling.ByteBuddyElementMatchers.safeHasSuperType;
+import static datadog.trace.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.instrumentation.api.AgentTracer.startSpan;
 import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isInterface;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
@@ -11,12 +13,11 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.context.TraceScope;
+import datadog.trace.instrumentation.api.AgentScope;
+import datadog.trace.instrumentation.api.AgentSpan;
 import datadog.trace.instrumentation.netty40.server.NettyHttpServerDecorator;
 import io.netty.channel.ChannelFuture;
-import io.opentracing.Scope;
-import io.opentracing.Span;
 import io.opentracing.tag.Tags;
-import io.opentracing.util.GlobalTracer;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.method.MethodDescription;
@@ -94,12 +95,9 @@ public class ChannelFutureListenerInstrumentation extends Instrumenter.Default {
       }
       final TraceScope parentScope = continuation.activate();
 
-      final Span errorSpan =
-          GlobalTracer.get()
-              .buildSpan("netty.connect")
-              .withTag(Tags.COMPONENT.getKey(), "netty")
-              .start();
-      try (final Scope scope = GlobalTracer.get().scopeManager().activate(errorSpan, false)) {
+      final AgentSpan errorSpan =
+          startSpan("netty.connect").setTag(Tags.COMPONENT.getKey(), "netty");
+      try (final AgentScope scope = activateSpan(errorSpan, false)) {
         NettyHttpServerDecorator.DECORATE.onError(errorSpan, cause);
         NettyHttpServerDecorator.DECORATE.beforeFinish(errorSpan);
         errorSpan.finish();
@@ -111,7 +109,7 @@ public class ChannelFutureListenerInstrumentation extends Instrumenter.Default {
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
     public static void deactivateScope(@Advice.Enter final TraceScope scope) {
       if (scope != null) {
-        ((Scope) scope).close();
+        scope.close();
       }
     }
   }

--- a/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/NettyChannelPipelineInstrumentation.java
+++ b/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/NettyChannelPipelineInstrumentation.java
@@ -1,6 +1,7 @@
 package datadog.trace.instrumentation.netty40;
 
 import static datadog.trace.agent.tooling.ByteBuddyElementMatchers.safeHasSuperType;
+import static datadog.trace.instrumentation.api.AgentTracer.activeScope;
 import static net.bytebuddy.matcher.ElementMatchers.isInterface;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;
@@ -28,8 +29,6 @@ import io.netty.handler.codec.http.HttpResponseDecoder;
 import io.netty.handler.codec.http.HttpResponseEncoder;
 import io.netty.handler.codec.http.HttpServerCodec;
 import io.netty.util.Attribute;
-import io.opentracing.Scope;
-import io.opentracing.util.GlobalTracer;
 import java.util.HashMap;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
@@ -149,9 +148,9 @@ public class NettyChannelPipelineInstrumentation extends Instrumenter.Default {
   public static class ChannelPipelineConnectAdvice {
     @Advice.OnMethodEnter
     public static void addParentSpan(@Advice.This final ChannelPipeline pipeline) {
-      final Scope scope = GlobalTracer.get().scopeManager().active();
-      if (scope instanceof TraceScope) {
-        final TraceScope.Continuation continuation = ((TraceScope) scope).capture();
+      final TraceScope scope = activeScope();
+      if (scope != null) {
+        final TraceScope.Continuation continuation = scope.capture();
         if (null != continuation) {
           final Attribute<TraceScope.Continuation> attribute =
               pipeline.channel().attr(AttributeKeys.PARENT_CONNECT_CONTINUATION_ATTRIBUTE_KEY);

--- a/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/client/HttpClientRequestTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/client/HttpClientRequestTracingHandler.java
@@ -47,7 +47,7 @@ public class HttpClientRequestTracingHandler extends ChannelOutboundHandlerAdapt
 
       // AWS calls are often signed, so we can't add headers without breaking the signature.
       if (!request.headers().contains("amz-sdk-invocation-id")) {
-        propagate().inject(span, request, SETTER);
+        propagate().inject(span, request.headers(), SETTER);
       }
 
       ctx.channel().attr(AttributeKeys.CLIENT_ATTRIBUTE_KEY).set(span);

--- a/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/client/HttpClientRequestTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/client/HttpClientRequestTracingHandler.java
@@ -1,18 +1,20 @@
 package datadog.trace.instrumentation.netty40.client;
 
+import static datadog.trace.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.instrumentation.api.AgentTracer.activeSpan;
+import static datadog.trace.instrumentation.api.AgentTracer.propagate;
+import static datadog.trace.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.netty40.client.NettyHttpClientDecorator.DECORATE;
+import static datadog.trace.instrumentation.netty40.client.NettyResponseInjectAdapter.SETTER;
 
 import datadog.trace.context.TraceScope;
+import datadog.trace.instrumentation.api.AgentScope;
+import datadog.trace.instrumentation.api.AgentSpan;
 import datadog.trace.instrumentation.netty40.AttributeKeys;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOutboundHandlerAdapter;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http.HttpRequest;
-import io.opentracing.Scope;
-import io.opentracing.Span;
-import io.opentracing.Tracer;
-import io.opentracing.propagation.Format;
-import io.opentracing.util.GlobalTracer;
 import java.net.InetSocketAddress;
 import lombok.extern.slf4j.Slf4j;
 
@@ -35,19 +37,17 @@ public class HttpClientRequestTracingHandler extends ChannelOutboundHandlerAdapt
 
     final HttpRequest request = (HttpRequest) msg;
 
-    final Tracer tracer = GlobalTracer.get();
-    ctx.channel().attr(AttributeKeys.CLIENT_PARENT_ATTRIBUTE_KEY).set(tracer.activeSpan());
+    ctx.channel().attr(AttributeKeys.CLIENT_PARENT_ATTRIBUTE_KEY).set(activeSpan());
 
-    final Span span = tracer.buildSpan("netty.client.request").start();
-    try (final Scope scope = tracer.scopeManager().activate(span, false)) {
+    final AgentSpan span = startSpan("netty.client.request");
+    try (final AgentScope scope = activateSpan(span, false)) {
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, request);
       DECORATE.onPeerConnection(span, (InetSocketAddress) ctx.channel().remoteAddress());
 
       // AWS calls are often signed, so we can't add headers without breaking the signature.
       if (!request.headers().contains("amz-sdk-invocation-id")) {
-        tracer.inject(
-            span.context(), Format.Builtin.HTTP_HEADERS, new NettyResponseInjectAdapter(request));
+        propagate().inject(span, request, SETTER);
       }
 
       ctx.channel().attr(AttributeKeys.CLIENT_ATTRIBUTE_KEY).set(span);

--- a/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/client/HttpClientResponseTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/client/HttpClientResponseTracingHandler.java
@@ -1,32 +1,31 @@
 package datadog.trace.instrumentation.netty40.client;
 
+import static datadog.trace.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.instrumentation.api.AgentTracer.noopSpan;
 import static datadog.trace.instrumentation.netty40.client.NettyHttpClientDecorator.DECORATE;
 
-import datadog.trace.context.TraceScope;
+import datadog.trace.instrumentation.api.AgentScope;
+import datadog.trace.instrumentation.api.AgentSpan;
 import datadog.trace.instrumentation.netty40.AttributeKeys;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.util.Attribute;
-import io.opentracing.Scope;
-import io.opentracing.Span;
-import io.opentracing.noop.NoopSpan;
-import io.opentracing.util.GlobalTracer;
 
 public class HttpClientResponseTracingHandler extends ChannelInboundHandlerAdapter {
 
   @Override
   public void channelRead(final ChannelHandlerContext ctx, final Object msg) {
-    final Attribute<Span> parentAttr =
+    final Attribute<AgentSpan> parentAttr =
         ctx.channel().attr(AttributeKeys.CLIENT_PARENT_ATTRIBUTE_KEY);
-    parentAttr.setIfAbsent(NoopSpan.INSTANCE);
-    final Span parent = parentAttr.get();
-    final Span span = ctx.channel().attr(AttributeKeys.CLIENT_ATTRIBUTE_KEY).get();
+    parentAttr.setIfAbsent(noopSpan());
+    final AgentSpan parent = parentAttr.get();
+    final AgentSpan span = ctx.channel().attr(AttributeKeys.CLIENT_ATTRIBUTE_KEY).get();
 
     final boolean finishSpan = msg instanceof HttpResponse;
 
     if (span != null && finishSpan) {
-      try (final Scope scope = GlobalTracer.get().scopeManager().activate(span, false)) {
+      try (final AgentScope scope = activateSpan(span, false)) {
         DECORATE.onResponse(span, (HttpResponse) msg);
         DECORATE.beforeFinish(span);
         span.finish();
@@ -34,10 +33,8 @@ public class HttpClientResponseTracingHandler extends ChannelInboundHandlerAdapt
     }
 
     // We want the callback in the scope of the parent, not the client span
-    try (final Scope scope = GlobalTracer.get().scopeManager().activate(parent, false)) {
-      if (scope instanceof TraceScope) {
-        ((TraceScope) scope).setAsyncPropagation(true);
-      }
+    try (final AgentScope scope = activateSpan(parent, false)) {
+      scope.setAsyncPropagation(true);
       ctx.fireChannelRead(msg);
     }
   }

--- a/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/client/NettyResponseInjectAdapter.java
+++ b/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/client/NettyResponseInjectAdapter.java
@@ -1,25 +1,14 @@
 package datadog.trace.instrumentation.netty40.client;
 
-import io.netty.handler.codec.http.HttpHeaders;
+import datadog.trace.instrumentation.api.AgentPropagation;
 import io.netty.handler.codec.http.HttpRequest;
-import io.opentracing.propagation.TextMap;
-import java.util.Iterator;
-import java.util.Map;
 
-public class NettyResponseInjectAdapter implements TextMap {
-  private final HttpHeaders headers;
+public class NettyResponseInjectAdapter implements AgentPropagation.Setter<HttpRequest> {
 
-  NettyResponseInjectAdapter(final HttpRequest request) {
-    this.headers = request.headers();
-  }
+  public static final NettyResponseInjectAdapter SETTER = new NettyResponseInjectAdapter();
 
   @Override
-  public Iterator<Map.Entry<String, String>> iterator() {
-    throw new UnsupportedOperationException("This class should be used only with Tracer.inject()!");
-  }
-
-  @Override
-  public void put(final String key, final String value) {
-    headers.set(key, value);
+  public void set(final HttpRequest carrier, final String key, final String value) {
+    carrier.headers().set(key, value);
   }
 }

--- a/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/client/NettyResponseInjectAdapter.java
+++ b/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/client/NettyResponseInjectAdapter.java
@@ -1,14 +1,14 @@
 package datadog.trace.instrumentation.netty40.client;
 
 import datadog.trace.instrumentation.api.AgentPropagation;
-import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpHeaders;
 
-public class NettyResponseInjectAdapter implements AgentPropagation.Setter<HttpRequest> {
+public class NettyResponseInjectAdapter implements AgentPropagation.Setter<HttpHeaders> {
 
   public static final NettyResponseInjectAdapter SETTER = new NettyResponseInjectAdapter();
 
   @Override
-  public void set(final HttpRequest carrier, final String key, final String value) {
-    carrier.headers().set(key, value);
+  public void set(final HttpHeaders headers, final String key, final String value) {
+    headers.set(key, value);
   }
 }

--- a/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/server/HttpServerRequestTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/server/HttpServerRequestTracingHandler.java
@@ -34,7 +34,7 @@ public class HttpServerRequestTracingHandler extends ChannelInboundHandlerAdapte
 
     final HttpRequest request = (HttpRequest) msg;
 
-    final Context context = propagate().extract(request, GETTER);
+    final Context context = propagate().extract(request.headers(), GETTER);
 
     final AgentSpan span = startSpan("netty.request", context);
     try (final AgentScope scope = activateSpan(span, false)) {

--- a/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/server/HttpServerRequestTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/server/HttpServerRequestTracingHandler.java
@@ -1,34 +1,31 @@
 package datadog.trace.instrumentation.netty40.server;
 
+import static datadog.trace.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.instrumentation.api.AgentTracer.propagate;
+import static datadog.trace.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.netty40.server.NettyHttpServerDecorator.DECORATE;
+import static datadog.trace.instrumentation.netty40.server.NettyRequestExtractAdapter.GETTER;
 
-import datadog.trace.context.TraceScope;
+import datadog.trace.instrumentation.api.AgentScope;
+import datadog.trace.instrumentation.api.AgentSpan;
+import datadog.trace.instrumentation.api.AgentSpan.Context;
 import datadog.trace.instrumentation.netty40.AttributeKeys;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.codec.http.HttpRequest;
-import io.opentracing.Scope;
-import io.opentracing.Span;
-import io.opentracing.SpanContext;
-import io.opentracing.Tracer;
-import io.opentracing.propagation.Format;
-import io.opentracing.util.GlobalTracer;
 
 public class HttpServerRequestTracingHandler extends ChannelInboundHandlerAdapter {
 
   @Override
   public void channelRead(final ChannelHandlerContext ctx, final Object msg) {
-    final Tracer tracer = GlobalTracer.get();
 
     if (!(msg instanceof HttpRequest)) {
-      final Span span = ctx.channel().attr(AttributeKeys.SERVER_ATTRIBUTE_KEY).get();
+      final AgentSpan span = ctx.channel().attr(AttributeKeys.SERVER_ATTRIBUTE_KEY).get();
       if (span == null) {
         ctx.fireChannelRead(msg); // superclass does not throw
       } else {
-        try (final Scope scope = tracer.scopeManager().activate(span, false)) {
-          if (scope instanceof TraceScope) {
-            ((TraceScope) scope).setAsyncPropagation(true);
-          }
+        try (final AgentScope scope = activateSpan(span, false)) {
+          scope.setAsyncPropagation(true);
           ctx.fireChannelRead(msg); // superclass does not throw
         }
       }
@@ -37,19 +34,15 @@ public class HttpServerRequestTracingHandler extends ChannelInboundHandlerAdapte
 
     final HttpRequest request = (HttpRequest) msg;
 
-    final SpanContext extractedContext =
-        tracer.extract(Format.Builtin.HTTP_HEADERS, new NettyRequestExtractAdapter(request));
+    final Context context = propagate().extract(request, GETTER);
 
-    final Span span =
-        tracer.buildSpan("netty.request").asChildOf(extractedContext).ignoreActiveSpan().start();
-    try (final Scope scope = tracer.scopeManager().activate(span, false)) {
+    final AgentSpan span = startSpan("netty.request", context);
+    try (final AgentScope scope = activateSpan(span, false)) {
       DECORATE.afterStart(span);
       DECORATE.onConnection(span, ctx.channel());
       DECORATE.onRequest(span, request);
 
-      if (scope instanceof TraceScope) {
-        ((TraceScope) scope).setAsyncPropagation(true);
-      }
+      scope.setAsyncPropagation(true);
 
       ctx.channel().attr(AttributeKeys.SERVER_ATTRIBUTE_KEY).set(span);
 

--- a/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/server/HttpServerResponseTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/server/HttpServerResponseTracingHandler.java
@@ -2,19 +2,19 @@ package datadog.trace.instrumentation.netty40.server;
 
 import static datadog.trace.instrumentation.netty40.server.NettyHttpServerDecorator.DECORATE;
 
+import datadog.trace.instrumentation.api.AgentSpan;
 import datadog.trace.instrumentation.netty40.AttributeKeys;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOutboundHandlerAdapter;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http.HttpResponse;
-import io.opentracing.Span;
 import io.opentracing.tag.Tags;
 
 public class HttpServerResponseTracingHandler extends ChannelOutboundHandlerAdapter {
 
   @Override
   public void write(final ChannelHandlerContext ctx, final Object msg, final ChannelPromise prm) {
-    final Span span = ctx.channel().attr(AttributeKeys.SERVER_ATTRIBUTE_KEY).get();
+    final AgentSpan span = ctx.channel().attr(AttributeKeys.SERVER_ATTRIBUTE_KEY).get();
     if (span == null || !(msg instanceof HttpResponse)) {
       ctx.write(msg, prm);
       return;
@@ -26,7 +26,7 @@ public class HttpServerResponseTracingHandler extends ChannelOutboundHandlerAdap
       ctx.write(msg, prm);
     } catch (final Throwable throwable) {
       DECORATE.onError(span, throwable);
-      Tags.HTTP_STATUS.set(span, 500);
+      span.setTag(Tags.HTTP_STATUS.getKey(), 500);
       span.finish(); // Finish the span manually since finishSpanOnClose was false
       throw throwable;
     }

--- a/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/server/NettyRequestExtractAdapter.java
+++ b/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/server/NettyRequestExtractAdapter.java
@@ -1,25 +1,19 @@
 package datadog.trace.instrumentation.netty40.server;
 
-import io.netty.handler.codec.http.HttpHeaders;
+import datadog.trace.instrumentation.api.AgentPropagation;
 import io.netty.handler.codec.http.HttpRequest;
-import io.opentracing.propagation.TextMap;
-import java.util.Iterator;
-import java.util.Map;
 
-public class NettyRequestExtractAdapter implements TextMap {
-  private final HttpHeaders headers;
+public class NettyRequestExtractAdapter implements AgentPropagation.Getter<HttpRequest> {
 
-  NettyRequestExtractAdapter(final HttpRequest request) {
-    this.headers = request.headers();
+  public static final NettyRequestExtractAdapter GETTER = new NettyRequestExtractAdapter();
+
+  @Override
+  public Iterable<String> keys(final HttpRequest carrier) {
+    return carrier.headers().names();
   }
 
   @Override
-  public Iterator<Map.Entry<String, String>> iterator() {
-    return headers.iterator();
-  }
-
-  @Override
-  public void put(final String key, final String value) {
-    throw new UnsupportedOperationException("This class should be used only with Tracer.inject()!");
+  public String get(final HttpRequest carrier, final String key) {
+    return carrier.headers().get(key);
   }
 }

--- a/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/server/NettyRequestExtractAdapter.java
+++ b/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/server/NettyRequestExtractAdapter.java
@@ -1,19 +1,19 @@
 package datadog.trace.instrumentation.netty40.server;
 
 import datadog.trace.instrumentation.api.AgentPropagation;
-import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpHeaders;
 
-public class NettyRequestExtractAdapter implements AgentPropagation.Getter<HttpRequest> {
+public class NettyRequestExtractAdapter implements AgentPropagation.Getter<HttpHeaders> {
 
   public static final NettyRequestExtractAdapter GETTER = new NettyRequestExtractAdapter();
 
   @Override
-  public Iterable<String> keys(final HttpRequest carrier) {
-    return carrier.headers().names();
+  public Iterable<String> keys(final HttpHeaders headers) {
+    return headers.names();
   }
 
   @Override
-  public String get(final HttpRequest carrier, final String key) {
-    return carrier.headers().get(key);
+  public String get(final HttpHeaders headers, final String key) {
+    return headers.get(key);
   }
 }

--- a/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/AttributeKeys.java
+++ b/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/AttributeKeys.java
@@ -2,10 +2,10 @@ package datadog.trace.instrumentation.netty41;
 
 import datadog.trace.bootstrap.WeakMap;
 import datadog.trace.context.TraceScope;
+import datadog.trace.instrumentation.api.AgentSpan;
 import datadog.trace.instrumentation.netty41.client.HttpClientTracingHandler;
 import datadog.trace.instrumentation.netty41.server.HttpServerTracingHandler;
 import io.netty.util.AttributeKey;
-import io.opentracing.Span;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -30,13 +30,13 @@ public class AttributeKeys {
    * This constant is copied over to datadog.trace.instrumentation.ratpack.server.TracingHandler, so
    * if this changes, that must also change.
    */
-  public static final AttributeKey<Span> SERVER_ATTRIBUTE_KEY =
+  public static final AttributeKey<AgentSpan> SERVER_ATTRIBUTE_KEY =
       attributeKey(HttpServerTracingHandler.class.getName() + ".span");
 
-  public static final AttributeKey<Span> CLIENT_ATTRIBUTE_KEY =
+  public static final AttributeKey<AgentSpan> CLIENT_ATTRIBUTE_KEY =
       attributeKey(HttpClientTracingHandler.class.getName() + ".span");
 
-  public static final AttributeKey<Span> CLIENT_PARENT_ATTRIBUTE_KEY =
+  public static final AttributeKey<AgentSpan> CLIENT_PARENT_ATTRIBUTE_KEY =
       attributeKey(HttpClientTracingHandler.class.getName() + ".parent");
 
   /**

--- a/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/NettyChannelPipelineInstrumentation.java
+++ b/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/NettyChannelPipelineInstrumentation.java
@@ -1,6 +1,7 @@
 package datadog.trace.instrumentation.netty41;
 
 import static datadog.trace.agent.tooling.ByteBuddyElementMatchers.safeHasSuperType;
+import static datadog.trace.instrumentation.api.AgentTracer.activeScope;
 import static net.bytebuddy.matcher.ElementMatchers.isInterface;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;
@@ -28,8 +29,6 @@ import io.netty.handler.codec.http.HttpResponseDecoder;
 import io.netty.handler.codec.http.HttpResponseEncoder;
 import io.netty.handler.codec.http.HttpServerCodec;
 import io.netty.util.Attribute;
-import io.opentracing.Scope;
-import io.opentracing.util.GlobalTracer;
 import java.util.HashMap;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
@@ -158,9 +157,9 @@ public class NettyChannelPipelineInstrumentation extends Instrumenter.Default {
   public static class ChannelPipelineConnectAdvice {
     @Advice.OnMethodEnter
     public static void addParentSpan(@Advice.This final ChannelPipeline pipeline) {
-      final Scope scope = GlobalTracer.get().scopeManager().active();
-      if (scope instanceof TraceScope) {
-        final TraceScope.Continuation continuation = ((TraceScope) scope).capture();
+      final TraceScope scope = activeScope();
+      if (scope != null) {
+        final TraceScope.Continuation continuation = scope.capture();
         if (null != continuation) {
           final Attribute<TraceScope.Continuation> attribute =
               pipeline.channel().attr(AttributeKeys.PARENT_CONNECT_CONTINUATION_ATTRIBUTE_KEY);

--- a/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/client/HttpClientRequestTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/client/HttpClientRequestTracingHandler.java
@@ -1,18 +1,20 @@
 package datadog.trace.instrumentation.netty41.client;
 
+import static datadog.trace.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.instrumentation.api.AgentTracer.activeSpan;
+import static datadog.trace.instrumentation.api.AgentTracer.propagate;
+import static datadog.trace.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.netty41.client.NettyHttpClientDecorator.DECORATE;
+import static datadog.trace.instrumentation.netty41.client.NettyResponseInjectAdapter.SETTER;
 
 import datadog.trace.context.TraceScope;
+import datadog.trace.instrumentation.api.AgentScope;
+import datadog.trace.instrumentation.api.AgentSpan;
 import datadog.trace.instrumentation.netty41.AttributeKeys;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOutboundHandlerAdapter;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http.HttpRequest;
-import io.opentracing.Scope;
-import io.opentracing.Span;
-import io.opentracing.Tracer;
-import io.opentracing.propagation.Format;
-import io.opentracing.util.GlobalTracer;
 import java.net.InetSocketAddress;
 import lombok.extern.slf4j.Slf4j;
 
@@ -35,19 +37,17 @@ public class HttpClientRequestTracingHandler extends ChannelOutboundHandlerAdapt
 
     final HttpRequest request = (HttpRequest) msg;
 
-    final Tracer tracer = GlobalTracer.get();
-    ctx.channel().attr(AttributeKeys.CLIENT_PARENT_ATTRIBUTE_KEY).set(tracer.activeSpan());
+    ctx.channel().attr(AttributeKeys.CLIENT_PARENT_ATTRIBUTE_KEY).set(activeSpan());
 
-    final Span span = tracer.buildSpan("netty.client.request").start();
-    try (final Scope scope = tracer.scopeManager().activate(span, false)) {
+    final AgentSpan span = startSpan("netty.client.request");
+    try (final AgentScope scope = activateSpan(span, false)) {
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, request);
       DECORATE.onPeerConnection(span, (InetSocketAddress) ctx.channel().remoteAddress());
 
       // AWS calls are often signed, so we can't add headers without breaking the signature.
       if (!request.headers().contains("amz-sdk-invocation-id")) {
-        tracer.inject(
-            span.context(), Format.Builtin.HTTP_HEADERS, new NettyResponseInjectAdapter(request));
+        propagate().inject(span, request, SETTER);
       }
 
       ctx.channel().attr(AttributeKeys.CLIENT_ATTRIBUTE_KEY).set(span);

--- a/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/client/HttpClientRequestTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/client/HttpClientRequestTracingHandler.java
@@ -47,7 +47,7 @@ public class HttpClientRequestTracingHandler extends ChannelOutboundHandlerAdapt
 
       // AWS calls are often signed, so we can't add headers without breaking the signature.
       if (!request.headers().contains("amz-sdk-invocation-id")) {
-        propagate().inject(span, request, SETTER);
+        propagate().inject(span, request.headers(), SETTER);
       }
 
       ctx.channel().attr(AttributeKeys.CLIENT_ATTRIBUTE_KEY).set(span);

--- a/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/client/HttpClientResponseTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/client/HttpClientResponseTracingHandler.java
@@ -1,32 +1,31 @@
 package datadog.trace.instrumentation.netty41.client;
 
+import static datadog.trace.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.instrumentation.api.AgentTracer.noopSpan;
 import static datadog.trace.instrumentation.netty41.client.NettyHttpClientDecorator.DECORATE;
 
-import datadog.trace.context.TraceScope;
+import datadog.trace.instrumentation.api.AgentScope;
+import datadog.trace.instrumentation.api.AgentSpan;
 import datadog.trace.instrumentation.netty41.AttributeKeys;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.util.Attribute;
-import io.opentracing.Scope;
-import io.opentracing.Span;
-import io.opentracing.noop.NoopSpan;
-import io.opentracing.util.GlobalTracer;
 
 public class HttpClientResponseTracingHandler extends ChannelInboundHandlerAdapter {
 
   @Override
   public void channelRead(final ChannelHandlerContext ctx, final Object msg) {
-    final Attribute<Span> parentAttr =
+    final Attribute<AgentSpan> parentAttr =
         ctx.channel().attr(AttributeKeys.CLIENT_PARENT_ATTRIBUTE_KEY);
-    parentAttr.setIfAbsent(NoopSpan.INSTANCE);
-    final Span parent = parentAttr.get();
-    final Span span = ctx.channel().attr(AttributeKeys.CLIENT_ATTRIBUTE_KEY).get();
+    parentAttr.setIfAbsent(noopSpan());
+    final AgentSpan parent = parentAttr.get();
+    final AgentSpan span = ctx.channel().attr(AttributeKeys.CLIENT_ATTRIBUTE_KEY).get();
 
     final boolean finishSpan = msg instanceof HttpResponse;
 
     if (span != null && finishSpan) {
-      try (final Scope scope = GlobalTracer.get().scopeManager().activate(span, false)) {
+      try (final AgentScope scope = activateSpan(span, false)) {
         DECORATE.onResponse(span, (HttpResponse) msg);
         DECORATE.beforeFinish(span);
         span.finish();
@@ -34,10 +33,8 @@ public class HttpClientResponseTracingHandler extends ChannelInboundHandlerAdapt
     }
 
     // We want the callback in the scope of the parent, not the client span
-    try (final Scope scope = GlobalTracer.get().scopeManager().activate(parent, false)) {
-      if (scope instanceof TraceScope) {
-        ((TraceScope) scope).setAsyncPropagation(true);
-      }
+    try (final AgentScope scope = activateSpan(parent, false)) {
+      scope.setAsyncPropagation(true);
       ctx.fireChannelRead(msg);
     }
   }

--- a/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/client/NettyResponseInjectAdapter.java
+++ b/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/client/NettyResponseInjectAdapter.java
@@ -1,14 +1,14 @@
 package datadog.trace.instrumentation.netty41.client;
 
 import datadog.trace.instrumentation.api.AgentPropagation;
-import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpHeaders;
 
-public class NettyResponseInjectAdapter implements AgentPropagation.Setter<HttpRequest> {
+public class NettyResponseInjectAdapter implements AgentPropagation.Setter<HttpHeaders> {
 
   public static final NettyResponseInjectAdapter SETTER = new NettyResponseInjectAdapter();
 
   @Override
-  public void set(final HttpRequest carrier, final String key, final String value) {
-    carrier.headers().set(key, value);
+  public void set(final HttpHeaders headers, final String key, final String value) {
+    headers.set(key, value);
   }
 }

--- a/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/client/NettyResponseInjectAdapter.java
+++ b/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/client/NettyResponseInjectAdapter.java
@@ -1,25 +1,14 @@
 package datadog.trace.instrumentation.netty41.client;
 
-import io.netty.handler.codec.http.HttpHeaders;
+import datadog.trace.instrumentation.api.AgentPropagation;
 import io.netty.handler.codec.http.HttpRequest;
-import io.opentracing.propagation.TextMap;
-import java.util.Iterator;
-import java.util.Map;
 
-public class NettyResponseInjectAdapter implements TextMap {
-  private final HttpHeaders headers;
+public class NettyResponseInjectAdapter implements AgentPropagation.Setter<HttpRequest> {
 
-  NettyResponseInjectAdapter(final HttpRequest request) {
-    this.headers = request.headers();
-  }
+  public static final NettyResponseInjectAdapter SETTER = new NettyResponseInjectAdapter();
 
   @Override
-  public Iterator<Map.Entry<String, String>> iterator() {
-    throw new UnsupportedOperationException("This class should be used only with Tracer.inject()!");
-  }
-
-  @Override
-  public void put(final String key, final String value) {
-    headers.set(key, value);
+  public void set(final HttpRequest carrier, final String key, final String value) {
+    carrier.headers().set(key, value);
   }
 }

--- a/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/server/HttpServerRequestTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/server/HttpServerRequestTracingHandler.java
@@ -1,34 +1,31 @@
 package datadog.trace.instrumentation.netty41.server;
 
+import static datadog.trace.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.instrumentation.api.AgentTracer.propagate;
+import static datadog.trace.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.netty41.server.NettyHttpServerDecorator.DECORATE;
+import static datadog.trace.instrumentation.netty41.server.NettyRequestExtractAdapter.GETTER;
 
-import datadog.trace.context.TraceScope;
+import datadog.trace.instrumentation.api.AgentScope;
+import datadog.trace.instrumentation.api.AgentSpan;
+import datadog.trace.instrumentation.api.AgentSpan.Context;
 import datadog.trace.instrumentation.netty41.AttributeKeys;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.codec.http.HttpRequest;
-import io.opentracing.Scope;
-import io.opentracing.Span;
-import io.opentracing.SpanContext;
-import io.opentracing.Tracer;
-import io.opentracing.propagation.Format;
-import io.opentracing.util.GlobalTracer;
 
 public class HttpServerRequestTracingHandler extends ChannelInboundHandlerAdapter {
 
   @Override
   public void channelRead(final ChannelHandlerContext ctx, final Object msg) {
-    final Tracer tracer = GlobalTracer.get();
 
     if (!(msg instanceof HttpRequest)) {
-      final Span span = ctx.channel().attr(AttributeKeys.SERVER_ATTRIBUTE_KEY).get();
+      final AgentSpan span = ctx.channel().attr(AttributeKeys.SERVER_ATTRIBUTE_KEY).get();
       if (span == null) {
         ctx.fireChannelRead(msg); // superclass does not throw
       } else {
-        try (final Scope scope = tracer.scopeManager().activate(span, false)) {
-          if (scope instanceof TraceScope) {
-            ((TraceScope) scope).setAsyncPropagation(true);
-          }
+        try (final AgentScope scope = activateSpan(span, false)) {
+          scope.setAsyncPropagation(true);
           ctx.fireChannelRead(msg); // superclass does not throw
         }
       }
@@ -37,19 +34,15 @@ public class HttpServerRequestTracingHandler extends ChannelInboundHandlerAdapte
 
     final HttpRequest request = (HttpRequest) msg;
 
-    final SpanContext extractedContext =
-        tracer.extract(Format.Builtin.HTTP_HEADERS, new NettyRequestExtractAdapter(request));
+    final Context extractedContext = propagate().extract(request, GETTER);
 
-    final Span span =
-        tracer.buildSpan("netty.request").asChildOf(extractedContext).ignoreActiveSpan().start();
-    try (final Scope scope = tracer.scopeManager().activate(span, false)) {
+    final AgentSpan span = startSpan("netty.request", extractedContext);
+    try (final AgentScope scope = activateSpan(span, false)) {
       DECORATE.afterStart(span);
       DECORATE.onConnection(span, ctx.channel());
       DECORATE.onRequest(span, request);
 
-      if (scope instanceof TraceScope) {
-        ((TraceScope) scope).setAsyncPropagation(true);
-      }
+      scope.setAsyncPropagation(true);
 
       ctx.channel().attr(AttributeKeys.SERVER_ATTRIBUTE_KEY).set(span);
 

--- a/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/server/HttpServerRequestTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/server/HttpServerRequestTracingHandler.java
@@ -34,7 +34,7 @@ public class HttpServerRequestTracingHandler extends ChannelInboundHandlerAdapte
 
     final HttpRequest request = (HttpRequest) msg;
 
-    final Context extractedContext = propagate().extract(request, GETTER);
+    final Context extractedContext = propagate().extract(request.headers(), GETTER);
 
     final AgentSpan span = startSpan("netty.request", extractedContext);
     try (final AgentScope scope = activateSpan(span, false)) {

--- a/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/server/HttpServerResponseTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/server/HttpServerResponseTracingHandler.java
@@ -2,19 +2,19 @@ package datadog.trace.instrumentation.netty41.server;
 
 import static datadog.trace.instrumentation.netty41.server.NettyHttpServerDecorator.DECORATE;
 
+import datadog.trace.instrumentation.api.AgentSpan;
 import datadog.trace.instrumentation.netty41.AttributeKeys;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOutboundHandlerAdapter;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http.HttpResponse;
-import io.opentracing.Span;
 import io.opentracing.tag.Tags;
 
 public class HttpServerResponseTracingHandler extends ChannelOutboundHandlerAdapter {
 
   @Override
   public void write(final ChannelHandlerContext ctx, final Object msg, final ChannelPromise prm) {
-    final Span span = ctx.channel().attr(AttributeKeys.SERVER_ATTRIBUTE_KEY).get();
+    final AgentSpan span = ctx.channel().attr(AttributeKeys.SERVER_ATTRIBUTE_KEY).get();
     if (span == null || !(msg instanceof HttpResponse)) {
       ctx.write(msg, prm);
       return;
@@ -26,7 +26,7 @@ public class HttpServerResponseTracingHandler extends ChannelOutboundHandlerAdap
       ctx.write(msg, prm);
     } catch (final Throwable throwable) {
       DECORATE.onError(span, throwable);
-      Tags.HTTP_STATUS.set(span, 500);
+      span.setTag(Tags.HTTP_STATUS.getKey(), 500);
       span.finish(); // Finish the span manually since finishSpanOnClose was false
       throw throwable;
     }

--- a/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/server/NettyRequestExtractAdapter.java
+++ b/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/server/NettyRequestExtractAdapter.java
@@ -1,19 +1,19 @@
 package datadog.trace.instrumentation.netty41.server;
 
 import datadog.trace.instrumentation.api.AgentPropagation;
-import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpHeaders;
 
-public class NettyRequestExtractAdapter implements AgentPropagation.Getter<HttpRequest> {
+public class NettyRequestExtractAdapter implements AgentPropagation.Getter<HttpHeaders> {
 
   public static final NettyRequestExtractAdapter GETTER = new NettyRequestExtractAdapter();
 
   @Override
-  public Iterable<String> keys(final HttpRequest carrier) {
-    return carrier.headers().names();
+  public Iterable<String> keys(final HttpHeaders headers) {
+    return headers.names();
   }
 
   @Override
-  public String get(final HttpRequest carrier, final String key) {
-    return carrier.headers().get(key);
+  public String get(final HttpHeaders headers, final String key) {
+    return headers.get(key);
   }
 }

--- a/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/server/NettyRequestExtractAdapter.java
+++ b/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/server/NettyRequestExtractAdapter.java
@@ -1,25 +1,19 @@
 package datadog.trace.instrumentation.netty41.server;
 
-import io.netty.handler.codec.http.HttpHeaders;
+import datadog.trace.instrumentation.api.AgentPropagation;
 import io.netty.handler.codec.http.HttpRequest;
-import io.opentracing.propagation.TextMap;
-import java.util.Iterator;
-import java.util.Map;
 
-public class NettyRequestExtractAdapter implements TextMap {
-  private final HttpHeaders headers;
+public class NettyRequestExtractAdapter implements AgentPropagation.Getter<HttpRequest> {
 
-  NettyRequestExtractAdapter(final HttpRequest request) {
-    this.headers = request.headers();
+  public static final NettyRequestExtractAdapter GETTER = new NettyRequestExtractAdapter();
+
+  @Override
+  public Iterable<String> keys(final HttpRequest carrier) {
+    return carrier.headers().names();
   }
 
   @Override
-  public Iterator<Map.Entry<String, String>> iterator() {
-    return headers.iteratorAsString();
-  }
-
-  @Override
-  public void put(final String key, final String value) {
-    throw new UnsupportedOperationException("This class should be used only with Tracer.inject()!");
+  public String get(final HttpRequest carrier, final String key) {
+    return carrier.headers().get(key);
   }
 }

--- a/dd-java-agent/instrumentation/okhttp-3/src/main/java/datadog/trace/instrumentation/okhttp3/RequestBuilderInjectAdapter.java
+++ b/dd-java-agent/instrumentation/okhttp-3/src/main/java/datadog/trace/instrumentation/okhttp3/RequestBuilderInjectAdapter.java
@@ -1,8 +1,6 @@
 package datadog.trace.instrumentation.okhttp3;
 
-import io.opentracing.propagation.TextMap;
-import java.util.Iterator;
-import java.util.Map;
+import datadog.trace.instrumentation.api.AgentPropagation;
 import okhttp3.Request;
 
 /**
@@ -10,21 +8,12 @@ import okhttp3.Request;
  *
  * @author Pavol Loffay
  */
-public class RequestBuilderInjectAdapter implements TextMap {
+public class RequestBuilderInjectAdapter implements AgentPropagation.Setter<Request.Builder> {
 
-  private final Request.Builder requestBuilder;
-
-  public RequestBuilderInjectAdapter(final Request.Builder request) {
-    this.requestBuilder = request;
-  }
+  public static final RequestBuilderInjectAdapter SETTER = new RequestBuilderInjectAdapter();
 
   @Override
-  public Iterator<Map.Entry<String, String>> iterator() {
-    throw new UnsupportedOperationException("Should be used only with tracer#inject()");
-  }
-
-  @Override
-  public void put(final String key, final String value) {
-    requestBuilder.addHeader(key, value);
+  public void set(final Request.Builder carrier, final String key, final String value) {
+    carrier.addHeader(key, value);
   }
 }

--- a/dd-java-agent/instrumentation/okhttp-3/src/main/java/datadog/trace/instrumentation/okhttp3/TagWrapper.java
+++ b/dd-java-agent/instrumentation/okhttp-3/src/main/java/datadog/trace/instrumentation/okhttp3/TagWrapper.java
@@ -1,6 +1,6 @@
 package datadog.trace.instrumentation.okhttp3;
 
-import io.opentracing.Span;
+import datadog.trace.instrumentation.api.AgentSpan;
 
 /**
  * Tag wrapper to store parent span context and user defined tags.
@@ -8,7 +8,7 @@ import io.opentracing.Span;
  * @author Pavol Loffay
  */
 public class TagWrapper {
-  private Span span;
+  private AgentSpan span;
 
   private Object tag;
 
@@ -21,9 +21,9 @@ public class TagWrapper {
    * @param wrapper previous wrapper
    * @param span span
    */
-  TagWrapper(final TagWrapper wrapper, final Span span) {
+  TagWrapper(final TagWrapper wrapper, final AgentSpan span) {
     this.span = span;
-    this.tag = wrapper.tag;
+    tag = wrapper.tag;
   }
 
   public void setTag(final Object tag) {
@@ -34,7 +34,7 @@ public class TagWrapper {
     return tag;
   }
 
-  Span getSpan() {
+  AgentSpan getSpan() {
     return span;
   }
 }

--- a/dd-java-agent/instrumentation/play-2.4/src/main/java8/datadog/trace/instrumentation/play24/PlayAdvice.java
+++ b/dd-java-agent/instrumentation/play-2.4/src/main/java8/datadog/trace/instrumentation/play24/PlayAdvice.java
@@ -1,14 +1,16 @@
 package datadog.trace.instrumentation.play24;
 
+import static datadog.trace.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.instrumentation.api.AgentTracer.activeSpan;
+import static datadog.trace.instrumentation.api.AgentTracer.propagate;
+import static datadog.trace.instrumentation.api.AgentTracer.startSpan;
+import static datadog.trace.instrumentation.play24.PlayHeaders.GETTER;
 import static datadog.trace.instrumentation.play24.PlayHttpServerDecorator.DECORATE;
 
-import datadog.trace.context.TraceScope;
-import io.opentracing.Scope;
-import io.opentracing.Span;
-import io.opentracing.SpanContext;
-import io.opentracing.propagation.Format;
+import datadog.trace.instrumentation.api.AgentScope;
+import datadog.trace.instrumentation.api.AgentSpan;
+import datadog.trace.instrumentation.api.AgentSpan.Context;
 import io.opentracing.tag.Tags;
-import io.opentracing.util.GlobalTracer;
 import net.bytebuddy.asm.Advice;
 import play.api.mvc.Action;
 import play.api.mvc.Request;
@@ -17,43 +19,32 @@ import scala.concurrent.Future;
 
 public class PlayAdvice {
   @Advice.OnMethodEnter(suppress = Throwable.class)
-  public static Scope startSpan(@Advice.Argument(0) final Request req) {
-    final Scope scope;
-    if (GlobalTracer.get().activeSpan() == null) {
-      final SpanContext extractedContext;
-      if (GlobalTracer.get().scopeManager().active() == null) {
-        extractedContext =
-            GlobalTracer.get().extract(Format.Builtin.HTTP_HEADERS, new PlayHeaders(req));
-      } else {
-        extractedContext = null;
-      }
-      scope =
-          GlobalTracer.get()
-              .buildSpan("play.request")
-              .asChildOf(extractedContext)
-              .startActive(false);
+  public static AgentScope onEnter(@Advice.Argument(0) final Request req) {
+    final AgentSpan span;
+    if (activeSpan() == null) {
+      final Context extractedContext = propagate().extract(req, GETTER);
+      span = startSpan("play.request", extractedContext);
     } else {
       // An upstream framework (e.g. akka-http, netty) has already started the span.
       // Do not extract the context.
-      scope = GlobalTracer.get().buildSpan("play.request").startActive(false);
+      span = startSpan("play.request");
     }
-    DECORATE.afterStart(scope);
-    DECORATE.onConnection(scope.span(), req);
+    DECORATE.afterStart(span);
+    DECORATE.onConnection(span, req);
 
-    if (GlobalTracer.get().scopeManager().active() instanceof TraceScope) {
-      ((TraceScope) GlobalTracer.get().scopeManager().active()).setAsyncPropagation(true);
-    }
+    final AgentScope scope = activateSpan(span, false);
+    scope.setAsyncPropagation(true);
     return scope;
   }
 
   @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
   public static void stopTraceOnResponse(
-      @Advice.Enter final Scope playControllerScope,
+      @Advice.Enter final AgentScope playControllerScope,
       @Advice.This final Object thisAction,
       @Advice.Thrown final Throwable throwable,
       @Advice.Argument(0) final Request req,
       @Advice.Return(readOnly = false) final Future<Result> responseFuture) {
-    final Span playControllerSpan = playControllerScope.span();
+    final AgentSpan playControllerSpan = playControllerScope.span();
 
     // Call onRequest on return after tags are populated.
     DECORATE.onRequest(playControllerSpan, req);
@@ -64,13 +55,13 @@ public class PlayAdvice {
           ((Action) thisAction).executionContext());
     } else {
       DECORATE.onError(playControllerSpan, throwable);
-      Tags.HTTP_STATUS.set(playControllerSpan, 500);
+      playControllerSpan.setTag(Tags.HTTP_STATUS.getKey(), 500);
       DECORATE.beforeFinish(playControllerSpan);
       playControllerSpan.finish();
     }
     playControllerScope.close();
 
-    final Span rootSpan = GlobalTracer.get().activeSpan();
+    final AgentSpan rootSpan = activeSpan();
     // set the resource name on the upstream akka/netty span
     DECORATE.onRequest(rootSpan, req);
   }

--- a/dd-java-agent/instrumentation/play-2.4/src/main/java8/datadog/trace/instrumentation/play24/PlayAdvice.java
+++ b/dd-java-agent/instrumentation/play-2.4/src/main/java8/datadog/trace/instrumentation/play24/PlayAdvice.java
@@ -22,7 +22,7 @@ public class PlayAdvice {
   public static AgentScope onEnter(@Advice.Argument(0) final Request req) {
     final AgentSpan span;
     if (activeSpan() == null) {
-      final Context extractedContext = propagate().extract(req, GETTER);
+      final Context extractedContext = propagate().extract(req.headers(), GETTER);
       span = startSpan("play.request", extractedContext);
     } else {
       // An upstream framework (e.g. akka-http, netty) has already started the span.

--- a/dd-java-agent/instrumentation/play-2.4/src/main/java8/datadog/trace/instrumentation/play24/PlayHeaders.java
+++ b/dd-java-agent/instrumentation/play-2.4/src/main/java8/datadog/trace/instrumentation/play24/PlayHeaders.java
@@ -1,22 +1,22 @@
 package datadog.trace.instrumentation.play24;
 
 import datadog.trace.instrumentation.api.AgentPropagation;
-import play.api.mvc.Request;
+import play.api.mvc.Headers;
 import scala.Option;
 import scala.collection.JavaConversions;
 
-public class PlayHeaders implements AgentPropagation.Getter<Request> {
+public class PlayHeaders implements AgentPropagation.Getter<Headers> {
 
   public static final PlayHeaders GETTER = new PlayHeaders();
 
   @Override
-  public Iterable<String> keys(final Request carrier) {
-    return JavaConversions.asJavaIterable(carrier.headers().keys());
+  public Iterable<String> keys(final Headers headers) {
+    return JavaConversions.asJavaIterable(headers.keys());
   }
 
   @Override
-  public String get(final Request carrier, final String key) {
-    final Option<String> option = carrier.headers().get(key);
+  public String get(final Headers headers, final String key) {
+    final Option<String> option = headers.get(key);
     if (option.isDefined()) {
       return option.get();
     } else {

--- a/dd-java-agent/instrumentation/play-2.4/src/main/java8/datadog/trace/instrumentation/play24/PlayHeaders.java
+++ b/dd-java-agent/instrumentation/play-2.4/src/main/java8/datadog/trace/instrumentation/play24/PlayHeaders.java
@@ -1,33 +1,26 @@
 package datadog.trace.instrumentation.play24;
 
-import io.opentracing.propagation.TextMap;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
+import datadog.trace.instrumentation.api.AgentPropagation;
 import play.api.mvc.Request;
-import scala.Tuple2;
+import scala.Option;
+import scala.collection.JavaConversions;
 
-public class PlayHeaders implements TextMap {
-  private final Request request;
+public class PlayHeaders implements AgentPropagation.Getter<Request> {
 
-  public PlayHeaders(final Request request) {
-    this.request = request;
+  public static final PlayHeaders GETTER = new PlayHeaders();
+
+  @Override
+  public Iterable<String> keys(final Request carrier) {
+    return JavaConversions.asJavaIterable(carrier.headers().keys());
   }
 
   @Override
-  public Iterator<Map.Entry<String, String>> iterator() {
-    final scala.collection.Map scalaMap = request.headers().toSimpleMap();
-    final Map<String, String> javaMap = new HashMap<>(scalaMap.size());
-    final scala.collection.Iterator<Tuple2<String, String>> scalaIterator = scalaMap.iterator();
-    while (scalaIterator.hasNext()) {
-      final Tuple2<String, String> tuple = scalaIterator.next();
-      javaMap.put(tuple._1(), tuple._2());
+  public String get(final Request carrier, final String key) {
+    final Option<String> option = carrier.headers().get(key);
+    if (option.isDefined()) {
+      return option.get();
+    } else {
+      return null;
     }
-    return javaMap.entrySet().iterator();
-  }
-
-  @Override
-  public void put(final String s, final String s1) {
-    throw new IllegalStateException("play headers can only be extracted");
   }
 }

--- a/dd-java-agent/instrumentation/play-2.4/src/main/java8/datadog/trace/instrumentation/play24/PlayHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/play-2.4/src/main/java8/datadog/trace/instrumentation/play24/PlayHttpServerDecorator.java
@@ -2,7 +2,7 @@ package datadog.trace.instrumentation.play24;
 
 import datadog.trace.agent.decorator.HttpServerDecorator;
 import datadog.trace.api.DDTags;
-import io.opentracing.Span;
+import datadog.trace.instrumentation.api.AgentSpan;
 import io.opentracing.tag.Tags;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.UndeclaredThrowableException;
@@ -58,7 +58,7 @@ public class PlayHttpServerDecorator extends HttpServerDecorator<Request, Reques
   }
 
   @Override
-  public Span onRequest(final Span span, final Request request) {
+  public AgentSpan onRequest(final AgentSpan span, final Request request) {
     super.onRequest(span, request);
     if (request != null) {
       // more about routes here:
@@ -73,8 +73,8 @@ public class PlayHttpServerDecorator extends HttpServerDecorator<Request, Reques
   }
 
   @Override
-  public Span onError(final Span span, Throwable throwable) {
-    Tags.HTTP_STATUS.set(span, 500);
+  public AgentSpan onError(final AgentSpan span, Throwable throwable) {
+    span.setTag(Tags.HTTP_STATUS.getKey(), 500);
     if (throwable != null
         // This can be moved to instanceof check when using Java 8.
         && throwable.getClass().getName().equals("java.util.concurrent.CompletionException")

--- a/dd-java-agent/instrumentation/play-2.6/src/main/java8/datadog/trace/instrumentation/play26/PlayAdvice.java
+++ b/dd-java-agent/instrumentation/play-2.6/src/main/java8/datadog/trace/instrumentation/play26/PlayAdvice.java
@@ -1,14 +1,16 @@
 package datadog.trace.instrumentation.play26;
 
+import static datadog.trace.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.instrumentation.api.AgentTracer.activeSpan;
+import static datadog.trace.instrumentation.api.AgentTracer.propagate;
+import static datadog.trace.instrumentation.api.AgentTracer.startSpan;
+import static datadog.trace.instrumentation.play26.PlayHeaders.GETTER;
 import static datadog.trace.instrumentation.play26.PlayHttpServerDecorator.DECORATE;
 
-import datadog.trace.context.TraceScope;
-import io.opentracing.Scope;
-import io.opentracing.Span;
-import io.opentracing.SpanContext;
-import io.opentracing.propagation.Format;
+import datadog.trace.instrumentation.api.AgentScope;
+import datadog.trace.instrumentation.api.AgentSpan;
+import datadog.trace.instrumentation.api.AgentSpan.Context;
 import io.opentracing.tag.Tags;
-import io.opentracing.util.GlobalTracer;
 import net.bytebuddy.asm.Advice;
 import play.api.mvc.Action;
 import play.api.mvc.Request;
@@ -17,43 +19,32 @@ import scala.concurrent.Future;
 
 public class PlayAdvice {
   @Advice.OnMethodEnter(suppress = Throwable.class)
-  public static Scope startSpan(@Advice.Argument(0) final Request req) {
-    final Scope scope;
-    if (GlobalTracer.get().activeSpan() == null) {
-      final SpanContext extractedContext;
-      if (GlobalTracer.get().scopeManager().active() == null) {
-        extractedContext =
-            GlobalTracer.get().extract(Format.Builtin.HTTP_HEADERS, new PlayHeaders(req));
-      } else {
-        extractedContext = null;
-      }
-      scope =
-          GlobalTracer.get()
-              .buildSpan("play.request")
-              .asChildOf(extractedContext)
-              .startActive(false);
+  public static AgentScope onEnter(@Advice.Argument(0) final Request req) {
+    final AgentSpan span;
+    if (activeSpan() == null) {
+      final Context extractedContext = propagate().extract(req, GETTER);
+      span = startSpan("play.request", extractedContext);
     } else {
       // An upstream framework (e.g. akka-http, netty) has already started the span.
       // Do not extract the context.
-      scope = GlobalTracer.get().buildSpan("play.request").startActive(false);
+      span = startSpan("play.request");
     }
-    DECORATE.afterStart(scope);
-    DECORATE.onConnection(scope.span(), req);
+    DECORATE.afterStart(span);
+    DECORATE.onConnection(span, req);
 
-    if (GlobalTracer.get().scopeManager().active() instanceof TraceScope) {
-      ((TraceScope) GlobalTracer.get().scopeManager().active()).setAsyncPropagation(true);
-    }
+    final AgentScope scope = activateSpan(span, false);
+    scope.setAsyncPropagation(true);
     return scope;
   }
 
   @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
   public static void stopTraceOnResponse(
-      @Advice.Enter final Scope playControllerScope,
+      @Advice.Enter final AgentScope playControllerScope,
       @Advice.This final Object thisAction,
       @Advice.Thrown final Throwable throwable,
       @Advice.Argument(0) final Request req,
       @Advice.Return(readOnly = false) final Future<Result> responseFuture) {
-    final Span playControllerSpan = playControllerScope.span();
+    final AgentSpan playControllerSpan = playControllerScope.span();
 
     // Call onRequest on return after tags are populated.
     DECORATE.onRequest(playControllerSpan, req);
@@ -64,13 +55,13 @@ public class PlayAdvice {
           ((Action) thisAction).executionContext());
     } else {
       DECORATE.onError(playControllerSpan, throwable);
-      Tags.HTTP_STATUS.set(playControllerSpan, 500);
+      playControllerSpan.setTag(Tags.HTTP_STATUS.getKey(), 500);
       DECORATE.beforeFinish(playControllerSpan);
       playControllerSpan.finish();
     }
     playControllerScope.close();
 
-    final Span rootSpan = GlobalTracer.get().activeSpan();
+    final AgentSpan rootSpan = activeSpan();
     // set the resource name on the upstream akka/netty span
     DECORATE.onRequest(rootSpan, req);
   }

--- a/dd-java-agent/instrumentation/play-2.6/src/main/java8/datadog/trace/instrumentation/play26/PlayAdvice.java
+++ b/dd-java-agent/instrumentation/play-2.6/src/main/java8/datadog/trace/instrumentation/play26/PlayAdvice.java
@@ -22,7 +22,7 @@ public class PlayAdvice {
   public static AgentScope onEnter(@Advice.Argument(0) final Request req) {
     final AgentSpan span;
     if (activeSpan() == null) {
-      final Context extractedContext = propagate().extract(req, GETTER);
+      final Context extractedContext = propagate().extract(req.headers(), GETTER);
       span = startSpan("play.request", extractedContext);
     } else {
       // An upstream framework (e.g. akka-http, netty) has already started the span.

--- a/dd-java-agent/instrumentation/play-2.6/src/main/java8/datadog/trace/instrumentation/play26/PlayHeaders.java
+++ b/dd-java-agent/instrumentation/play-2.6/src/main/java8/datadog/trace/instrumentation/play26/PlayHeaders.java
@@ -3,17 +3,17 @@ package datadog.trace.instrumentation.play26;
 import datadog.trace.instrumentation.api.AgentPropagation;
 import java.util.ArrayList;
 import java.util.List;
-import play.api.mvc.Request;
+import play.api.mvc.Headers;
 import scala.Option;
 
-public class PlayHeaders implements AgentPropagation.Getter<Request> {
+public class PlayHeaders implements AgentPropagation.Getter<Headers> {
 
   public static final PlayHeaders GETTER = new PlayHeaders();
 
   @Override
-  public Iterable<String> keys(final Request carrier) {
+  public Iterable<String> keys(final Headers headers) {
     final List<String> javaList = new ArrayList<>();
-    final scala.collection.Iterator<String> scalaIterator = carrier.headers().keys().iterator();
+    final scala.collection.Iterator<String> scalaIterator = headers.keys().iterator();
     while (scalaIterator.hasNext()) {
       javaList.add(scalaIterator.next());
     }
@@ -21,8 +21,8 @@ public class PlayHeaders implements AgentPropagation.Getter<Request> {
   }
 
   @Override
-  public String get(final Request carrier, final String key) {
-    final Option<String> option = carrier.headers().get(key);
+  public String get(final Headers headers, final String key) {
+    final Option<String> option = headers.get(key);
     if (option.isDefined()) {
       return option.get();
     } else {

--- a/dd-java-agent/instrumentation/play-2.6/src/main/java8/datadog/trace/instrumentation/play26/PlayHeaders.java
+++ b/dd-java-agent/instrumentation/play-2.6/src/main/java8/datadog/trace/instrumentation/play26/PlayHeaders.java
@@ -1,33 +1,32 @@
 package datadog.trace.instrumentation.play26;
 
-import io.opentracing.propagation.TextMap;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
+import datadog.trace.instrumentation.api.AgentPropagation;
+import java.util.ArrayList;
+import java.util.List;
 import play.api.mvc.Request;
-import scala.Tuple2;
+import scala.Option;
 
-public class PlayHeaders implements TextMap {
-  private final Request request;
+public class PlayHeaders implements AgentPropagation.Getter<Request> {
 
-  public PlayHeaders(final Request request) {
-    this.request = request;
-  }
+  public static final PlayHeaders GETTER = new PlayHeaders();
 
   @Override
-  public Iterator<Map.Entry<String, String>> iterator() {
-    final scala.collection.Map scalaMap = request.headers().toSimpleMap();
-    final Map<String, String> javaMap = new HashMap<>(scalaMap.size());
-    final scala.collection.Iterator<Tuple2<String, String>> scalaIterator = scalaMap.iterator();
+  public Iterable<String> keys(final Request carrier) {
+    final List<String> javaList = new ArrayList<>();
+    final scala.collection.Iterator<String> scalaIterator = carrier.headers().keys().iterator();
     while (scalaIterator.hasNext()) {
-      final Tuple2<String, String> tuple = scalaIterator.next();
-      javaMap.put(tuple._1(), tuple._2());
+      javaList.add(scalaIterator.next());
     }
-    return javaMap.entrySet().iterator();
+    return javaList;
   }
 
   @Override
-  public void put(final String s, final String s1) {
-    throw new IllegalStateException("play headers can only be extracted");
+  public String get(final Request carrier, final String key) {
+    final Option<String> option = carrier.headers().get(key);
+    if (option.isDefined()) {
+      return option.get();
+    } else {
+      return null;
+    }
   }
 }

--- a/dd-java-agent/instrumentation/play-2.6/src/main/java8/datadog/trace/instrumentation/play26/PlayHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/play-2.6/src/main/java8/datadog/trace/instrumentation/play26/PlayHttpServerDecorator.java
@@ -2,7 +2,7 @@ package datadog.trace.instrumentation.play26;
 
 import datadog.trace.agent.decorator.HttpServerDecorator;
 import datadog.trace.api.DDTags;
-import io.opentracing.Span;
+import datadog.trace.instrumentation.api.AgentSpan;
 import io.opentracing.tag.Tags;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.UndeclaredThrowableException;
@@ -60,7 +60,7 @@ public class PlayHttpServerDecorator extends HttpServerDecorator<Request, Reques
   }
 
   @Override
-  public Span onRequest(final Span span, final Request request) {
+  public AgentSpan onRequest(final AgentSpan span, final Request request) {
     super.onRequest(span, request);
     if (request != null) {
       // more about routes here:
@@ -76,8 +76,8 @@ public class PlayHttpServerDecorator extends HttpServerDecorator<Request, Reques
   }
 
   @Override
-  public Span onError(final Span span, Throwable throwable) {
-    Tags.HTTP_STATUS.set(span, 500);
+  public AgentSpan onError(final AgentSpan span, Throwable throwable) {
+    span.setTag(Tags.HTTP_STATUS.getKey(), 500);
     if (throwable != null
         // This can be moved to instanceof check when using Java 8.
         && throwable.getClass().getName().equals("java.util.concurrent.CompletionException")

--- a/dd-java-agent/instrumentation/play-2.6/src/main/java8/datadog/trace/instrumentation/play26/RequestCompleteCallback.java
+++ b/dd-java-agent/instrumentation/play-2.6/src/main/java8/datadog/trace/instrumentation/play26/RequestCompleteCallback.java
@@ -1,19 +1,19 @@
 package datadog.trace.instrumentation.play26;
 
+import static datadog.trace.instrumentation.api.AgentTracer.activeScope;
 import static datadog.trace.instrumentation.play26.PlayHttpServerDecorator.DECORATE;
 
 import datadog.trace.context.TraceScope;
-import io.opentracing.Span;
-import io.opentracing.util.GlobalTracer;
+import datadog.trace.instrumentation.api.AgentSpan;
 import lombok.extern.slf4j.Slf4j;
 import play.api.mvc.Result;
 import scala.util.Try;
 
 @Slf4j
 public class RequestCompleteCallback extends scala.runtime.AbstractFunction1<Try<Result>, Object> {
-  private final Span span;
+  private final AgentSpan span;
 
-  public RequestCompleteCallback(final Span span) {
+  public RequestCompleteCallback(final AgentSpan span) {
     this.span = span;
   }
 
@@ -26,8 +26,9 @@ public class RequestCompleteCallback extends scala.runtime.AbstractFunction1<Try
         DECORATE.onResponse(span, result.get());
       }
       DECORATE.beforeFinish(span);
-      if (GlobalTracer.get().scopeManager().active() instanceof TraceScope) {
-        ((TraceScope) GlobalTracer.get().scopeManager().active()).setAsyncPropagation(false);
+      final TraceScope scope = activeScope();
+      if (scope != null) {
+        scope.setAsyncPropagation(false);
       }
     } catch (final Throwable t) {
       log.debug("error in play instrumentation", t);

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/TextMapExtractAdapter.java
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/TextMapExtractAdapter.java
@@ -1,30 +1,20 @@
 package datadog.trace.instrumentation.rabbitmq.amqp;
 
-import io.opentracing.propagation.TextMap;
-import java.util.HashMap;
-import java.util.Iterator;
+import datadog.trace.instrumentation.api.AgentPropagation;
 import java.util.Map;
 
-// TextMap works with <String,String>, but the type we're given is <String,Object>
-public class TextMapExtractAdapter implements TextMap {
+public class TextMapExtractAdapter implements AgentPropagation.Getter<Map<String, Object>> {
 
-  private final Map<String, String> map = new HashMap<>();
+  public static final TextMapExtractAdapter GETTER = new TextMapExtractAdapter();
 
-  public TextMapExtractAdapter(final Map<String, Object> headers) {
-    for (final Map.Entry<String, Object> entry : headers.entrySet()) {
-      if (entry != null && entry.getValue() != null) {
-        map.put(entry.getKey(), entry.getValue().toString());
-      }
-    }
+  @Override
+  public Iterable<String> keys(final Map<String, Object> carrier) {
+    return carrier.keySet();
   }
 
   @Override
-  public Iterator<Map.Entry<String, String>> iterator() {
-    return map.entrySet().iterator();
-  }
-
-  @Override
-  public void put(final String key, final String value) {
-    throw new UnsupportedOperationException("Use inject adapter instead");
+  public String get(final Map<String, Object> carrier, final String key) {
+    final Object obj = carrier.get(key);
+    return obj == null ? null : obj.toString();
   }
 }

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/TextMapInjectAdapter.java
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/TextMapInjectAdapter.java
@@ -1,25 +1,14 @@
 package datadog.trace.instrumentation.rabbitmq.amqp;
 
-import io.opentracing.propagation.TextMap;
-import java.util.Iterator;
+import datadog.trace.instrumentation.api.AgentPropagation;
 import java.util.Map;
 
-// TextMap works with <String,String>, but the type we're given is <String,Object>
-public class TextMapInjectAdapter implements TextMap {
-  private final Map<String, ? super String> map;
+public class TextMapInjectAdapter implements AgentPropagation.Setter<Map<String, Object>> {
 
-  public TextMapInjectAdapter(final Map<String, ? super String> map) {
-    this.map = map;
-  }
+  public static final TextMapInjectAdapter SETTER = new TextMapInjectAdapter();
 
   @Override
-  public Iterator<Map.Entry<String, String>> iterator() {
-    throw new UnsupportedOperationException(
-        "TextMapInjectAdapter should only be used with Tracer.inject()");
-  }
-
-  @Override
-  public void put(final String key, final String value) {
-    map.put(key, value);
+  public void set(final Map<String, Object> carrier, final String key, final String value) {
+    carrier.put(key, value);
   }
 }

--- a/dd-java-agent/instrumentation/ratpack-1.4/src/main/java/datadog/trace/instrumentation/ratpack/ContinuationInstrumentation.java
+++ b/dd-java-agent/instrumentation/ratpack-1.4/src/main/java/datadog/trace/instrumentation/ratpack/ContinuationInstrumentation.java
@@ -1,13 +1,13 @@
 package datadog.trace.instrumentation.ratpack;
 
 import static datadog.trace.agent.tooling.ByteBuddyElementMatchers.safeHasSuperType;
+import static datadog.trace.instrumentation.api.AgentTracer.activeSpan;
 import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
-import io.opentracing.util.GlobalTracer;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.method.MethodDescription;
@@ -46,7 +46,7 @@ public final class ContinuationInstrumentation extends Instrumenter.Default {
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static void wrap(@Advice.Argument(value = 0, readOnly = false) Block block) {
-      block = BlockWrapper.wrapIfNeeded(block, GlobalTracer.get().activeSpan());
+      block = BlockWrapper.wrapIfNeeded(block, activeSpan());
     }
 
     public void muzzleCheck(final PathBinding binding) {

--- a/dd-java-agent/instrumentation/ratpack-1.4/src/main/java/datadog/trace/instrumentation/ratpack/DefaultExecutionInstrumentation.java
+++ b/dd-java-agent/instrumentation/ratpack-1.4/src/main/java/datadog/trace/instrumentation/ratpack/DefaultExecutionInstrumentation.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.ratpack;
 
+import static datadog.trace.instrumentation.api.AgentTracer.activeSpan;
 import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;
 import static net.bytebuddy.matcher.ElementMatchers.named;
@@ -7,8 +8,7 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
-import io.opentracing.Span;
-import io.opentracing.util.GlobalTracer;
+import datadog.trace.instrumentation.api.AgentSpan;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.method.MethodDescription;
@@ -56,7 +56,7 @@ public final class DefaultExecutionInstrumentation extends Instrumenter.Default 
        * Here we pass along the span instead of a continuation because we aren't sure the callback
        * will actually be called.
        */
-      final Span span = GlobalTracer.get().activeSpan();
+      final AgentSpan span = activeSpan();
       onError = ActionWrapper.wrapIfNeeded(onError, span);
       segment = ActionWrapper.wrapIfNeeded(segment, span);
     }

--- a/dd-java-agent/instrumentation/ratpack-1.4/src/main/java8/datadog/trace/instrumentation/ratpack/BlockWrapper.java
+++ b/dd-java-agent/instrumentation/ratpack-1.4/src/main/java8/datadog/trace/instrumentation/ratpack/BlockWrapper.java
@@ -1,18 +1,18 @@
 package datadog.trace.instrumentation.ratpack;
 
-import datadog.trace.context.TraceScope;
-import io.opentracing.Scope;
-import io.opentracing.Span;
-import io.opentracing.util.GlobalTracer;
+import static datadog.trace.instrumentation.api.AgentTracer.activateSpan;
+
+import datadog.trace.instrumentation.api.AgentScope;
+import datadog.trace.instrumentation.api.AgentSpan;
 import lombok.extern.slf4j.Slf4j;
 import ratpack.func.Block;
 
 @Slf4j
 public class BlockWrapper implements Block {
   private final Block delegate;
-  private final Span span;
+  private final AgentSpan span;
 
-  private BlockWrapper(final Block delegate, final Span span) {
+  private BlockWrapper(final Block delegate, final AgentSpan span) {
     assert span != null;
     this.delegate = delegate;
     this.span = span;
@@ -20,15 +20,13 @@ public class BlockWrapper implements Block {
 
   @Override
   public void execute() throws Exception {
-    try (final Scope scope = GlobalTracer.get().scopeManager().activate(span, false)) {
-      if (scope instanceof TraceScope) {
-        ((TraceScope) scope).setAsyncPropagation(true);
-      }
+    try (final AgentScope scope = activateSpan(span, false)) {
+      scope.setAsyncPropagation(true);
       delegate.execute();
     }
   }
 
-  public static Block wrapIfNeeded(final Block delegate, final Span span) {
+  public static Block wrapIfNeeded(final Block delegate, final AgentSpan span) {
     if (delegate instanceof BlockWrapper || span == null) {
       return delegate;
     }

--- a/dd-java-agent/instrumentation/ratpack-1.4/src/main/java8/datadog/trace/instrumentation/ratpack/ErrorHandlerAdvice.java
+++ b/dd-java-agent/instrumentation/ratpack-1.4/src/main/java8/datadog/trace/instrumentation/ratpack/ErrorHandlerAdvice.java
@@ -1,17 +1,18 @@
 package datadog.trace.instrumentation.ratpack;
 
-import static datadog.trace.instrumentation.ratpack.RatpackServerDecorator.DECORATE;
-
-import io.opentracing.Span;
 import java.util.Optional;
+
+import datadog.trace.instrumentation.api.AgentSpan;
 import net.bytebuddy.asm.Advice;
 import ratpack.handling.Context;
+
+import static datadog.trace.instrumentation.ratpack.RatpackServerDecorator.DECORATE;
 
 public class ErrorHandlerAdvice {
   @Advice.OnMethodEnter(suppress = Throwable.class)
   public static void captureThrowable(
       @Advice.Argument(0) final Context ctx, @Advice.Argument(1) final Throwable throwable) {
-    final Optional<Span> span = ctx.maybeGet(Span.class);
+    final Optional<AgentSpan> span = ctx.maybeGet(AgentSpan.class);
     if (span.isPresent()) {
       DECORATE.onError(span.get(), throwable);
     }

--- a/dd-java-agent/instrumentation/ratpack-1.4/src/main/java8/datadog/trace/instrumentation/ratpack/RatpackServerDecorator.java
+++ b/dd-java-agent/instrumentation/ratpack-1.4/src/main/java8/datadog/trace/instrumentation/ratpack/RatpackServerDecorator.java
@@ -3,7 +3,7 @@ package datadog.trace.instrumentation.ratpack;
 import com.google.common.net.HostAndPort;
 import datadog.trace.agent.decorator.HttpServerDecorator;
 import datadog.trace.api.DDTags;
-import io.opentracing.Span;
+import datadog.trace.instrumentation.api.AgentSpan;
 import java.net.URI;
 import lombok.extern.slf4j.Slf4j;
 import ratpack.handling.Context;
@@ -70,7 +70,7 @@ public class RatpackServerDecorator extends HttpServerDecorator<Request, Request
     }
   }
 
-  public Span onContext(final Span span, final Context ctx) {
+  public AgentSpan onContext(final AgentSpan span, final Context ctx) {
 
     String description = ctx.getPathBinding().getDescription();
     if (description == null || description.isEmpty()) {
@@ -86,7 +86,7 @@ public class RatpackServerDecorator extends HttpServerDecorator<Request, Request
   }
 
   @Override
-  public Span onError(final Span span, final Throwable throwable) {
+  public AgentSpan onError(final AgentSpan span, final Throwable throwable) {
     // Attempt to unwrap ratpack.handling.internal.HandlerException without direct reference.
     if (throwable instanceof Error && throwable.getCause() != null) {
       return super.onError(span, throwable.getCause());

--- a/dd-java-agent/instrumentation/ratpack-1.4/src/main/java8/datadog/trace/instrumentation/ratpack/TracingHandler.java
+++ b/dd-java-agent/instrumentation/ratpack-1.4/src/main/java8/datadog/trace/instrumentation/ratpack/TracingHandler.java
@@ -1,14 +1,13 @@
 package datadog.trace.instrumentation.ratpack;
 
+import static datadog.trace.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.ratpack.RatpackServerDecorator.DECORATE;
 
-import datadog.trace.context.TraceScope;
+import datadog.trace.instrumentation.api.AgentScope;
+import datadog.trace.instrumentation.api.AgentSpan;
 import io.netty.util.Attribute;
 import io.netty.util.AttributeKey;
-import io.opentracing.Scope;
-import io.opentracing.Span;
-import io.opentracing.Tracer;
-import io.opentracing.util.GlobalTracer;
 import ratpack.handling.Context;
 import ratpack.handling.Handler;
 import ratpack.http.Request;
@@ -20,35 +19,32 @@ public final class TracingHandler implements Handler {
    * This constant is copied over from datadog.trace.instrumentation.netty41.AttributeKeys. The key
    * string must be kept consistent.
    */
-  public static final AttributeKey<Span> SERVER_ATTRIBUTE_KEY =
+  public static final AttributeKey<AgentSpan> SERVER_ATTRIBUTE_KEY =
       AttributeKey.valueOf(
           "datadog.trace.instrumentation.netty41.server.HttpServerTracingHandler.span");
 
   @Override
   public void handle(final Context ctx) {
-    final Tracer tracer = GlobalTracer.get();
     final Request request = ctx.getRequest();
 
-    final Attribute<Span> spanAttribute =
+    final Attribute<AgentSpan> spanAttribute =
         ctx.getDirectChannelAccess().getChannel().attr(SERVER_ATTRIBUTE_KEY);
-    final Span nettySpan = spanAttribute.get();
+    final AgentSpan nettySpan = spanAttribute.get();
 
     // Relying on executor instrumentation to assume the netty span is in context as the parent.
-    final Span ratpackSpan = tracer.buildSpan("ratpack.handler").start();
+    final AgentSpan ratpackSpan = startSpan("ratpack.handler");
     DECORATE.afterStart(ratpackSpan);
     DECORATE.onConnection(ratpackSpan, request);
     DECORATE.onRequest(ratpackSpan, request);
     ctx.getExecution().add(ratpackSpan);
 
-    try (final Scope scope = tracer.scopeManager().activate(ratpackSpan, false)) {
-      if (scope instanceof TraceScope) {
-        ((TraceScope) scope).setAsyncPropagation(true);
-      }
+    try (final AgentScope scope = activateSpan(ratpackSpan, false)) {
+      scope.setAsyncPropagation(true);
 
       ctx.getResponse()
           .beforeSend(
               response -> {
-                try (final Scope ignored = tracer.scopeManager().activate(ratpackSpan, false)) {
+                try (final AgentScope ignored = activateSpan(ratpackSpan, false)) {
                   if (nettySpan != null) {
                     // Rename the netty span resource name with the ratpack route.
                     DECORATE.onContext(nettySpan, ctx);

--- a/dd-java-agent/instrumentation/rxjava-1/src/main/java/datadog/trace/instrumentation/rxjava/SpanFinishingSubscription.java
+++ b/dd-java-agent/instrumentation/rxjava-1/src/main/java/datadog/trace/instrumentation/rxjava/SpanFinishingSubscription.java
@@ -1,23 +1,23 @@
 package datadog.trace.instrumentation.rxjava;
 
 import datadog.trace.agent.decorator.BaseDecorator;
-import io.opentracing.Span;
+import datadog.trace.instrumentation.api.AgentSpan;
 import java.util.concurrent.atomic.AtomicReference;
 import rx.Subscription;
 
 public class SpanFinishingSubscription implements Subscription {
   private final BaseDecorator decorator;
-  private final AtomicReference<Span> spanRef;
+  private final AtomicReference<AgentSpan> spanRef;
 
   public SpanFinishingSubscription(
-      final BaseDecorator decorator, final AtomicReference<Span> spanRef) {
+      final BaseDecorator decorator, final AtomicReference<AgentSpan> spanRef) {
     this.decorator = decorator;
     this.spanRef = spanRef;
   }
 
   @Override
   public void unsubscribe() {
-    final Span span = spanRef.getAndSet(null);
+    final AgentSpan span = spanRef.getAndSet(null);
     if (span != null) {
       decorator.beforeFinish(span);
       span.finish();

--- a/dd-java-agent/instrumentation/servlet-2/src/main/java/datadog/trace/instrumentation/servlet2/AbstractServlet2Instrumentation.java
+++ b/dd-java-agent/instrumentation/servlet-2/src/main/java/datadog/trace/instrumentation/servlet2/AbstractServlet2Instrumentation.java
@@ -26,7 +26,6 @@ public abstract class AbstractServlet2Instrumentation extends Instrumenter.Defau
       "datadog.trace.agent.decorator.HttpServerDecorator",
       packageName + ".Servlet2Decorator",
       packageName + ".HttpServletRequestExtractAdapter",
-      packageName + ".HttpServletRequestExtractAdapter$MultivaluedMapFlatIterator",
       packageName + ".StatusSavingHttpServletResponseWrapper",
     };
   }

--- a/dd-java-agent/instrumentation/servlet-2/src/main/java/datadog/trace/instrumentation/servlet2/HttpServletRequestExtractAdapter.java
+++ b/dd-java-agent/instrumentation/servlet-2/src/main/java/datadog/trace/instrumentation/servlet2/HttpServletRequestExtractAdapter.java
@@ -1,14 +1,7 @@
 package datadog.trace.instrumentation.servlet2;
 
-import io.opentracing.propagation.TextMap;
-import java.util.AbstractMap;
-import java.util.ArrayList;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import datadog.trace.instrumentation.api.AgentPropagation;
+import java.util.Collections;
 import javax.servlet.http.HttpServletRequest;
 
 /**
@@ -17,80 +10,19 @@ import javax.servlet.http.HttpServletRequest;
  * @author Pavol Loffay
  */
 // FIXME:  This code is duplicated in several places.  Extract to a common dependency.
-public class HttpServletRequestExtractAdapter implements TextMap {
+public class HttpServletRequestExtractAdapter
+    implements AgentPropagation.Getter<HttpServletRequest> {
 
-  private final Map<String, List<String>> headers;
+  public static final HttpServletRequestExtractAdapter GETTER =
+      new HttpServletRequestExtractAdapter();
 
-  public HttpServletRequestExtractAdapter(final HttpServletRequest httpServletRequest) {
-    headers = servletHeadersToMultiMap(httpServletRequest);
+  @Override
+  public Iterable<String> keys(final HttpServletRequest carrier) {
+    return Collections.list(carrier.getHeaderNames());
   }
 
   @Override
-  public Iterator<Map.Entry<String, String>> iterator() {
-    return new MultivaluedMapFlatIterator<>(headers.entrySet());
-  }
-
-  @Override
-  public void put(final String key, final String value) {
-    throw new UnsupportedOperationException("This class should be used only with Tracer.inject()!");
-  }
-
-  protected Map<String, List<String>> servletHeadersToMultiMap(
-      final HttpServletRequest httpServletRequest) {
-    final Map<String, List<String>> headersResult = new HashMap<>();
-
-    final Enumeration<?> headerNamesIt = httpServletRequest.getHeaderNames();
-    while (headerNamesIt.hasMoreElements()) {
-      final String headerName = headerNamesIt.nextElement().toString();
-
-      final Enumeration<?> valuesIt = httpServletRequest.getHeaders(headerName);
-      final List<String> valuesList = new ArrayList<>(1);
-      while (valuesIt.hasMoreElements()) {
-        valuesList.add(valuesIt.nextElement().toString());
-      }
-
-      headersResult.put(headerName, valuesList);
-    }
-
-    return headersResult;
-  }
-
-  public static final class MultivaluedMapFlatIterator<K, V> implements Iterator<Map.Entry<K, V>> {
-
-    private final Iterator<Map.Entry<K, List<V>>> mapIterator;
-    private Map.Entry<K, List<V>> mapEntry;
-    private Iterator<V> listIterator;
-
-    public MultivaluedMapFlatIterator(final Set<Map.Entry<K, List<V>>> multiValuesEntrySet) {
-      mapIterator = multiValuesEntrySet.iterator();
-    }
-
-    @Override
-    public boolean hasNext() {
-      if (listIterator != null && listIterator.hasNext()) {
-        return true;
-      }
-
-      return mapIterator.hasNext();
-    }
-
-    @Override
-    public Map.Entry<K, V> next() {
-      if (mapEntry == null || (!listIterator.hasNext() && mapIterator.hasNext())) {
-        mapEntry = mapIterator.next();
-        listIterator = mapEntry.getValue().iterator();
-      }
-
-      if (listIterator.hasNext()) {
-        return new AbstractMap.SimpleImmutableEntry<>(mapEntry.getKey(), listIterator.next());
-      } else {
-        return new AbstractMap.SimpleImmutableEntry<>(mapEntry.getKey(), null);
-      }
-    }
-
-    @Override
-    public void remove() {
-      throw new UnsupportedOperationException();
-    }
+  public String get(final HttpServletRequest carrier, final String key) {
+    return carrier.getHeader(key);
   }
 }

--- a/dd-java-agent/instrumentation/servlet-2/src/main/java/datadog/trace/instrumentation/servlet2/Servlet2Decorator.java
+++ b/dd-java-agent/instrumentation/servlet-2/src/main/java/datadog/trace/instrumentation/servlet2/Servlet2Decorator.java
@@ -1,7 +1,7 @@
 package datadog.trace.instrumentation.servlet2;
 
 import datadog.trace.agent.decorator.HttpServerDecorator;
-import io.opentracing.Span;
+import datadog.trace.instrumentation.api.AgentSpan;
 import java.net.URI;
 import java.net.URISyntaxException;
 import javax.servlet.ServletResponse;
@@ -58,7 +58,7 @@ public class Servlet2Decorator
   }
 
   @Override
-  public Span onRequest(final Span span, final HttpServletRequest request) {
+  public AgentSpan onRequest(final AgentSpan span, final HttpServletRequest request) {
     assert span != null;
     if (request != null) {
       span.setTag("servlet.context", request.getContextPath());

--- a/dd-java-agent/instrumentation/servlet-3/src/main/java/datadog/trace/instrumentation/servlet3/FilterChain3Instrumentation.java
+++ b/dd-java-agent/instrumentation/servlet-3/src/main/java/datadog/trace/instrumentation/servlet3/FilterChain3Instrumentation.java
@@ -28,7 +28,6 @@ public final class FilterChain3Instrumentation extends Instrumenter.Default {
       "datadog.trace.agent.decorator.ServerDecorator",
       "datadog.trace.agent.decorator.HttpServerDecorator",
       packageName + ".HttpServletRequestExtractAdapter",
-      packageName + ".HttpServletRequestExtractAdapter$MultivaluedMapFlatIterator",
       packageName + ".Servlet3Decorator",
       packageName + ".TagSettingAsyncListener"
     };

--- a/dd-java-agent/instrumentation/servlet-3/src/main/java/datadog/trace/instrumentation/servlet3/HttpServlet3Instrumentation.java
+++ b/dd-java-agent/instrumentation/servlet-3/src/main/java/datadog/trace/instrumentation/servlet3/HttpServlet3Instrumentation.java
@@ -28,7 +28,6 @@ public final class HttpServlet3Instrumentation extends Instrumenter.Default {
       "datadog.trace.agent.decorator.ServerDecorator",
       "datadog.trace.agent.decorator.HttpServerDecorator",
       packageName + ".HttpServletRequestExtractAdapter",
-      packageName + ".HttpServletRequestExtractAdapter$MultivaluedMapFlatIterator",
       packageName + ".Servlet3Decorator",
       packageName + ".TagSettingAsyncListener",
     };

--- a/dd-java-agent/instrumentation/servlet-3/src/main/java/datadog/trace/instrumentation/servlet3/HttpServletRequestExtractAdapter.java
+++ b/dd-java-agent/instrumentation/servlet-3/src/main/java/datadog/trace/instrumentation/servlet3/HttpServletRequestExtractAdapter.java
@@ -1,111 +1,34 @@
 package datadog.trace.instrumentation.servlet3;
 
-import io.opentracing.propagation.TextMap;
-import java.util.AbstractMap;
+import datadog.trace.instrumentation.api.AgentPropagation;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
 import javax.servlet.http.HttpServletRequest;
 
-/**
- * Tracer extract adapter for {@link HttpServletRequest}.
- *
- * @author Pavol Loffay
- */
-// FIXME:  This code is duplicated in several places.  Extract to a common dependency.
-public class HttpServletRequestExtractAdapter implements TextMap {
+public class HttpServletRequestExtractAdapter
+    implements AgentPropagation.Getter<HttpServletRequest> {
 
-  private final Map<String, List<String>> headers;
+  public static final HttpServletRequestExtractAdapter GETTER =
+      new HttpServletRequestExtractAdapter();
 
-  public HttpServletRequestExtractAdapter(final HttpServletRequest httpServletRequest) {
-    headers = servletHeadersToMultiMap(httpServletRequest);
+  @Override
+  public List<String> keys(final HttpServletRequest carrier) {
+    final ArrayList<String> keys = Collections.list(carrier.getHeaderNames());
+    keys.addAll(Collections.list(carrier.getAttributeNames()));
+    return keys;
   }
 
   @Override
-  public Iterator<Map.Entry<String, String>> iterator() {
-    return new MultivaluedMapFlatIterator<>(headers.entrySet());
-  }
-
-  @Override
-  public void put(final String key, final String value) {
-    throw new UnsupportedOperationException("This class should be used only with Tracer.inject()!");
-  }
-
-  protected Map<String, List<String>> servletHeadersToMultiMap(
-      final HttpServletRequest httpServletRequest) {
-    final Map<String, List<String>> headersResult = new HashMap<>();
-
-    final Enumeration<String> headerNamesIt = httpServletRequest.getHeaderNames();
-    while (headerNamesIt.hasMoreElements()) {
-      final String headerName = headerNamesIt.nextElement();
-
-      final Enumeration<String> valuesIt = httpServletRequest.getHeaders(headerName);
-      final List<String> valuesList = new ArrayList<>(1);
-      while (valuesIt.hasMoreElements()) {
-        valuesList.add(valuesIt.nextElement());
-      }
-
-      headersResult.put(headerName, valuesList);
-    }
-
+  public String get(final HttpServletRequest carrier, final String key) {
     /*
      * Read from the attributes and override the headers.
-     * This is used by HttpServletRequestInjectAdapter when a request is async-dispatched.
+     * This is used by HttpServletRequestSetter when a request is async-dispatched.
      */
-    final Enumeration<String> attributeNamesIt = httpServletRequest.getAttributeNames();
-    while (attributeNamesIt.hasMoreElements()) {
-      final String attributeName = attributeNamesIt.nextElement();
-
-      final Object valuesIt = httpServletRequest.getAttribute(attributeName);
-      if (valuesIt instanceof String) {
-        headersResult.put(attributeName, Collections.singletonList((String) valuesIt));
-      }
+    final Object attribute = carrier.getAttribute(key);
+    if (attribute instanceof String) {
+      return (String) attribute;
     }
-
-    return headersResult;
-  }
-
-  public static final class MultivaluedMapFlatIterator<K, V> implements Iterator<Map.Entry<K, V>> {
-
-    private final Iterator<Map.Entry<K, List<V>>> mapIterator;
-    private Map.Entry<K, List<V>> mapEntry;
-    private Iterator<V> listIterator;
-
-    public MultivaluedMapFlatIterator(final Set<Map.Entry<K, List<V>>> multiValuesEntrySet) {
-      mapIterator = multiValuesEntrySet.iterator();
-    }
-
-    @Override
-    public boolean hasNext() {
-      if (listIterator != null && listIterator.hasNext()) {
-        return true;
-      }
-
-      return mapIterator.hasNext();
-    }
-
-    @Override
-    public Map.Entry<K, V> next() {
-      if (mapEntry == null || (!listIterator.hasNext() && mapIterator.hasNext())) {
-        mapEntry = mapIterator.next();
-        listIterator = mapEntry.getValue().iterator();
-      }
-
-      if (listIterator.hasNext()) {
-        return new AbstractMap.SimpleImmutableEntry<>(mapEntry.getKey(), listIterator.next());
-      } else {
-        return new AbstractMap.SimpleImmutableEntry<>(mapEntry.getKey(), null);
-      }
-    }
-
-    @Override
-    public void remove() {
-      throw new UnsupportedOperationException();
-    }
+    return carrier.getHeader(key);
   }
 }

--- a/dd-java-agent/instrumentation/servlet-3/src/main/java/datadog/trace/instrumentation/servlet3/HttpServletRequestInjectAdapter.java
+++ b/dd-java-agent/instrumentation/servlet-3/src/main/java/datadog/trace/instrumentation/servlet3/HttpServletRequestInjectAdapter.java
@@ -1,27 +1,17 @@
 package datadog.trace.instrumentation.servlet3;
 
-import io.opentracing.propagation.TextMap;
-import java.util.Iterator;
-import java.util.Map;
+import datadog.trace.instrumentation.api.AgentPropagation;
 import javax.servlet.http.HttpServletRequest;
 
 /** Inject into request attributes since the request headers can't be modified. */
-public class HttpServletRequestInjectAdapter implements TextMap {
+public class HttpServletRequestInjectAdapter
+    implements AgentPropagation.Setter<HttpServletRequest> {
 
-  private final HttpServletRequest httpServletRequest;
-
-  public HttpServletRequestInjectAdapter(final HttpServletRequest httpServletRequest) {
-    this.httpServletRequest = httpServletRequest;
-  }
+  public static final HttpServletRequestInjectAdapter SETTER =
+      new HttpServletRequestInjectAdapter();
 
   @Override
-  public Iterator<Map.Entry<String, String>> iterator() {
-    throw new UnsupportedOperationException(
-        "This class should be used only with Tracer.extract()!");
-  }
-
-  @Override
-  public void put(final String key, final String value) {
-    httpServletRequest.setAttribute(key, value);
+  public void set(final HttpServletRequest carrier, final String key, final String value) {
+    carrier.setAttribute(key, value);
   }
 }

--- a/dd-java-agent/instrumentation/servlet-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Advice.java
+++ b/dd-java-agent/instrumentation/servlet-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Advice.java
@@ -1,16 +1,16 @@
 package datadog.trace.instrumentation.servlet3;
 
 import static datadog.trace.agent.decorator.HttpServerDecorator.DD_SPAN_ATTRIBUTE;
+import static datadog.trace.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.instrumentation.api.AgentTracer.propagate;
+import static datadog.trace.instrumentation.api.AgentTracer.startSpan;
+import static datadog.trace.instrumentation.servlet3.HttpServletRequestExtractAdapter.GETTER;
 import static datadog.trace.instrumentation.servlet3.Servlet3Decorator.DECORATE;
 
 import datadog.trace.api.DDTags;
-import datadog.trace.context.TraceScope;
-import io.opentracing.Scope;
-import io.opentracing.Span;
-import io.opentracing.SpanContext;
-import io.opentracing.propagation.Format;
+import datadog.trace.instrumentation.api.AgentScope;
+import datadog.trace.instrumentation.api.AgentSpan;
 import io.opentracing.tag.Tags;
-import io.opentracing.util.GlobalTracer;
 import java.security.Principal;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.servlet.ServletRequest;
@@ -22,7 +22,7 @@ import net.bytebuddy.asm.Advice;
 public class Servlet3Advice {
 
   @Advice.OnMethodEnter(suppress = Throwable.class)
-  public static Scope startSpan(
+  public static AgentScope onEnter(
       @Advice.This final Object servlet, @Advice.Argument(0) final ServletRequest req) {
     final Object spanAttr = req.getAttribute(DD_SPAN_ATTRIBUTE);
     if (!(req instanceof HttpServletRequest) || spanAttr != null) {
@@ -31,30 +31,19 @@ public class Servlet3Advice {
     }
 
     final HttpServletRequest httpServletRequest = (HttpServletRequest) req;
-    final SpanContext extractedContext =
-        GlobalTracer.get()
-            .extract(
-                Format.Builtin.HTTP_HEADERS,
-                new HttpServletRequestExtractAdapter(httpServletRequest));
+    final AgentSpan.Context extractedContext = propagate().extract(httpServletRequest, GETTER);
 
-    final Scope scope =
-        GlobalTracer.get()
-            .buildSpan("servlet.request")
-            .ignoreActiveSpan()
-            .asChildOf(extractedContext)
-            .withTag("span.origin.type", servlet.getClass().getName())
-            .startActive(false);
-
-    final Span span = scope.span();
+    final AgentSpan span =
+        startSpan("servlet.request", extractedContext)
+            .setTag("span.origin.type", servlet.getClass().getName());
     DECORATE.afterStart(span);
     DECORATE.onConnection(span, httpServletRequest);
     DECORATE.onRequest(span, httpServletRequest);
 
-    if (scope instanceof TraceScope) {
-      ((TraceScope) scope).setAsyncPropagation(true);
-    }
-
     req.setAttribute(DD_SPAN_ATTRIBUTE, span);
+
+    final AgentScope scope = activateSpan(span, false);
+    scope.setAsyncPropagation(true);
     return scope;
   }
 
@@ -62,14 +51,14 @@ public class Servlet3Advice {
   public static void stopSpan(
       @Advice.Argument(0) final ServletRequest request,
       @Advice.Argument(1) final ServletResponse response,
-      @Advice.Enter final Scope scope,
+      @Advice.Enter final AgentScope scope,
       @Advice.Thrown final Throwable throwable) {
     // Set user.principal regardless of who created this span.
     final Object spanAttr = request.getAttribute(DD_SPAN_ATTRIBUTE);
-    if (spanAttr instanceof Span && request instanceof HttpServletRequest) {
+    if (spanAttr instanceof AgentSpan && request instanceof HttpServletRequest) {
       final Principal principal = ((HttpServletRequest) request).getUserPrincipal();
       if (principal != null) {
-        ((Span) spanAttr).setTag(DDTags.USER_NAME, principal.getName());
+        ((AgentSpan) spanAttr).setTag(DDTags.USER_NAME, principal.getName());
       }
     }
 
@@ -77,13 +66,13 @@ public class Servlet3Advice {
       if (request instanceof HttpServletRequest && response instanceof HttpServletResponse) {
         final HttpServletRequest req = (HttpServletRequest) request;
         final HttpServletResponse resp = (HttpServletResponse) response;
-        final Span span = scope.span();
+        final AgentSpan span = scope.span();
 
         if (throwable != null) {
           DECORATE.onResponse(span, resp);
           if (resp.getStatus() == HttpServletResponse.SC_OK) {
             // exception is thrown in filter chain, but status code is incorrect
-            Tags.HTTP_STATUS.set(span, 500);
+            span.setTag(Tags.HTTP_STATUS.getKey(), 500);
           }
           DECORATE.onError(span, throwable);
           DECORATE.beforeFinish(span);

--- a/dd-java-agent/instrumentation/servlet-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Decorator.java
+++ b/dd-java-agent/instrumentation/servlet-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Decorator.java
@@ -1,7 +1,7 @@
 package datadog.trace.instrumentation.servlet3;
 
 import datadog.trace.agent.decorator.HttpServerDecorator;
-import io.opentracing.Span;
+import datadog.trace.instrumentation.api.AgentSpan;
 import java.net.URI;
 import java.net.URISyntaxException;
 import javax.servlet.ServletException;
@@ -53,7 +53,7 @@ public class Servlet3Decorator
   }
 
   @Override
-  public Span onRequest(final Span span, final HttpServletRequest request) {
+  public AgentSpan onRequest(final AgentSpan span, final HttpServletRequest request) {
     assert span != null;
     if (request != null) {
       span.setTag("servlet.context", request.getContextPath());
@@ -62,7 +62,7 @@ public class Servlet3Decorator
   }
 
   @Override
-  public Span onError(final Span span, final Throwable throwable) {
+  public AgentSpan onError(final AgentSpan span, final Throwable throwable) {
     if (throwable instanceof ServletException && throwable.getCause() != null) {
       super.onError(span, throwable.getCause());
     } else {

--- a/dd-java-agent/instrumentation/sparkjava-2.3/src/main/java/datadog/trace/instrumentation/sparkjava/RoutesInstrumentation.java
+++ b/dd-java-agent/instrumentation/sparkjava-2.3/src/main/java/datadog/trace/instrumentation/sparkjava/RoutesInstrumentation.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.sparkjava;
 
+import static datadog.trace.instrumentation.api.AgentTracer.activeSpan;
 import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.named;
@@ -9,8 +10,7 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.DDTags;
-import io.opentracing.Scope;
-import io.opentracing.util.GlobalTracer;
+import datadog.trace.instrumentation.api.AgentSpan;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.method.MethodDescription;
@@ -52,10 +52,10 @@ public class RoutesInstrumentation extends Instrumenter.Default {
     public static void routeMatchEnricher(
         @Advice.Argument(0) final HttpMethod method, @Advice.Return final RouteMatch routeMatch) {
 
-      final Scope scope = GlobalTracer.get().scopeManager().active();
-      if (scope != null && routeMatch != null) {
+      final AgentSpan span = activeSpan();
+      if (span != null && routeMatch != null) {
         final String resourceName = method.name().toUpperCase() + " " + routeMatch.getMatchUri();
-        scope.span().setTag(DDTags.RESOURCE_NAME, resourceName);
+        span.setTag(DDTags.RESOURCE_NAME, resourceName);
       }
     }
   }

--- a/dd-java-agent/instrumentation/spring-data-1.9/src/main/java/datadog/trace/instrumentation/springdata/SpringDataDecorator.java
+++ b/dd-java-agent/instrumentation/spring-data-1.9/src/main/java/datadog/trace/instrumentation/springdata/SpringDataDecorator.java
@@ -4,7 +4,7 @@ package datadog.trace.instrumentation.springdata;
 
 import datadog.trace.agent.decorator.ClientDecorator;
 import datadog.trace.api.DDTags;
-import io.opentracing.Span;
+import datadog.trace.instrumentation.api.AgentSpan;
 import java.lang.reflect.Method;
 
 public final class SpringDataDecorator extends ClientDecorator {
@@ -32,7 +32,7 @@ public final class SpringDataDecorator extends ClientDecorator {
     return "spring-data";
   }
 
-  public Span onOperation(final Span span, final Method method) {
+  public AgentSpan onOperation(final AgentSpan span, final Method method) {
     assert span != null;
     assert method != null;
 

--- a/dd-java-agent/instrumentation/spring-web/src/main/java/datadog/trace/instrumentation/springweb/SpringWebHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/spring-web/src/main/java/datadog/trace/instrumentation/springweb/SpringWebHttpServerDecorator.java
@@ -3,8 +3,7 @@ package datadog.trace.instrumentation.springweb;
 import datadog.trace.agent.decorator.HttpServerDecorator;
 import datadog.trace.api.DDSpanTypes;
 import datadog.trace.api.DDTags;
-import io.opentracing.Scope;
-import io.opentracing.Span;
+import datadog.trace.instrumentation.api.AgentSpan;
 import java.net.URI;
 import java.net.URISyntaxException;
 import javax.servlet.http.HttpServletRequest;
@@ -71,7 +70,7 @@ public class SpringWebHttpServerDecorator
   }
 
   @Override
-  public Span onRequest(final Span span, final HttpServletRequest request) {
+  public AgentSpan onRequest(final AgentSpan span, final HttpServletRequest request) {
     super.onRequest(span, request);
     if (request != null) {
       final String method = request.getMethod();
@@ -86,14 +85,13 @@ public class SpringWebHttpServerDecorator
     return span;
   }
 
-  public Scope onRender(final Scope scope, final ModelAndView mv) {
-    final Span span = scope.span();
+  public AgentSpan onRender(final AgentSpan span, final ModelAndView mv) {
     if (mv.getViewName() != null) {
       span.setTag("view.name", mv.getViewName());
     }
     if (mv.getView() != null) {
       span.setTag("view.type", mv.getView().getClass().getName());
     }
-    return scope;
+    return span;
   }
 }

--- a/dd-java-agent/instrumentation/spring-webflux/src/main/java8/datadog/trace/instrumentation/springwebflux/client/DefaultWebClientAdvice.java
+++ b/dd-java-agent/instrumentation/spring-webflux/src/main/java8/datadog/trace/instrumentation/springwebflux/client/DefaultWebClientAdvice.java
@@ -1,6 +1,5 @@
 package datadog.trace.instrumentation.springwebflux.client;
 
-import io.opentracing.util.GlobalTracer;
 import net.bytebuddy.asm.Advice;
 import org.springframework.web.reactive.function.client.ClientRequest;
 import org.springframework.web.reactive.function.client.ClientResponse;
@@ -23,7 +22,7 @@ public class DefaultWebClientAdvice {
       // is already decorated (we detect this if the "x-datadog-trace-id" is added), the result is not decorated again
       // to avoid StackOverflowErrors.
       && !clientRequest.headers().keySet().contains("x-datadog-trace-id")) {
-      mono = new TracingClientResponseMono(clientRequest, exchangeFunction, GlobalTracer.get());
+      mono = new TracingClientResponseMono(clientRequest, exchangeFunction);
     }
   }
 }

--- a/dd-java-agent/instrumentation/spring-webflux/src/main/java8/datadog/trace/instrumentation/springwebflux/client/HttpHeadersInjectAdapter.java
+++ b/dd-java-agent/instrumentation/spring-webflux/src/main/java8/datadog/trace/instrumentation/springwebflux/client/HttpHeadersInjectAdapter.java
@@ -1,25 +1,14 @@
 package datadog.trace.instrumentation.springwebflux.client;
 
-import io.opentracing.propagation.TextMap;
-import java.util.Iterator;
-import java.util.Map;
+import datadog.trace.instrumentation.api.AgentPropagation;
 import org.springframework.http.HttpHeaders;
 
-public class HttpHeadersInjectAdapter implements TextMap {
+public class HttpHeadersInjectAdapter implements AgentPropagation.Setter<HttpHeaders> {
 
-  private final HttpHeaders headers;
-
-  public HttpHeadersInjectAdapter(final HttpHeaders headers) {
-    this.headers = headers;
-  }
+  public static final HttpHeadersInjectAdapter SETTER = new HttpHeadersInjectAdapter();
 
   @Override
-  public Iterator<Map.Entry<String, String>> iterator() {
-    throw new UnsupportedOperationException("This class should be used only with Tracer.inject()!");
-  }
-
-  @Override
-  public void put(final String key, final String value) {
-    headers.set(key, value);
+  public void set(final HttpHeaders carrier, final String key, final String value) {
+    carrier.set(key, value);
   }
 }

--- a/dd-java-agent/instrumentation/spring-webflux/src/main/java8/datadog/trace/instrumentation/springwebflux/client/SpringWebfluxHttpClientDecorator.java
+++ b/dd-java-agent/instrumentation/spring-webflux/src/main/java8/datadog/trace/instrumentation/springwebflux/client/SpringWebfluxHttpClientDecorator.java
@@ -1,7 +1,7 @@
 package datadog.trace.instrumentation.springwebflux.client;
 
 import datadog.trace.agent.decorator.HttpClientDecorator;
-import io.opentracing.Span;
+import datadog.trace.instrumentation.api.AgentSpan;
 import java.net.URI;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.reactive.function.client.ClientRequest;
@@ -10,10 +10,11 @@ import org.springframework.web.reactive.function.client.ClientResponse;
 @Slf4j
 public class SpringWebfluxHttpClientDecorator
     extends HttpClientDecorator<ClientRequest, ClientResponse> {
+
   public static final SpringWebfluxHttpClientDecorator DECORATE =
       new SpringWebfluxHttpClientDecorator();
 
-  public void onCancel(final Span span) {
+  public void onCancel(final AgentSpan span) {
     span.setTag("event", "cancelled");
     span.setTag("message", "The subscription was cancelled");
   }

--- a/dd-java-agent/instrumentation/spring-webflux/src/main/java8/datadog/trace/instrumentation/springwebflux/client/TracingClientResponseSubscriber.java
+++ b/dd-java-agent/instrumentation/spring-webflux/src/main/java8/datadog/trace/instrumentation/springwebflux/client/TracingClientResponseSubscriber.java
@@ -1,13 +1,11 @@
 package datadog.trace.instrumentation.springwebflux.client;
 
+import static datadog.trace.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.instrumentation.api.AgentTracer.noopSpan;
 import static datadog.trace.instrumentation.springwebflux.client.SpringWebfluxHttpClientDecorator.DECORATE;
 
-import datadog.trace.context.TraceScope;
-import io.opentracing.Scope;
-import io.opentracing.Span;
-import io.opentracing.Tracer;
-import io.opentracing.noop.NoopSpan;
-import io.opentracing.util.GlobalTracer;
+import datadog.trace.instrumentation.api.AgentScope;
+import datadog.trace.instrumentation.api.AgentSpan;
 import java.util.concurrent.atomic.AtomicReference;
 import org.reactivestreams.Subscription;
 import org.springframework.web.reactive.function.client.ClientRequest;
@@ -17,39 +15,36 @@ import reactor.util.context.Context;
 
 public class TracingClientResponseSubscriber implements CoreSubscriber<ClientResponse> {
 
-  private final Tracer tracer = GlobalTracer.get();
   private final CoreSubscriber<? super ClientResponse> subscriber;
   private final ClientRequest clientRequest;
   private final Context context;
-  private final AtomicReference<Span> spanRef;
-  private final Span parentSpan;
+  private final AtomicReference<AgentSpan> spanRef;
+  private final AgentSpan parentSpan;
 
   public TracingClientResponseSubscriber(
-    final CoreSubscriber<? super ClientResponse> subscriber,
-    final ClientRequest clientRequest,
-    final Context context,
-    final Span span,
-    final Span parentSpan) {
+      final CoreSubscriber<? super ClientResponse> subscriber,
+      final ClientRequest clientRequest,
+      final Context context,
+      final AgentSpan span,
+      final AgentSpan parentSpan) {
     this.subscriber = subscriber;
     this.clientRequest = clientRequest;
     this.context = context;
     spanRef = new AtomicReference<>(span);
-    this.parentSpan = parentSpan == null ? NoopSpan.INSTANCE : parentSpan;
+    this.parentSpan = parentSpan == null ? noopSpan() : parentSpan;
   }
 
   @Override
   public void onSubscribe(final Subscription subscription) {
-    final Span span = spanRef.get();
+    final AgentSpan span = spanRef.get();
     if (span == null) {
       subscriber.onSubscribe(subscription);
       return;
     }
 
-    try (final Scope scope = tracer.scopeManager().activate(span, false)) {
+    try (final AgentScope scope = activateSpan(span, false)) {
 
-      if (scope instanceof TraceScope) {
-        ((TraceScope) scope).setAsyncPropagation(true);
-      }
+      scope.setAsyncPropagation(true);
 
       DECORATE.onRequest(span, clientRequest);
 
@@ -57,7 +52,7 @@ public class TracingClientResponseSubscriber implements CoreSubscriber<ClientRes
         new Subscription() {
           @Override
           public void request(final long n) {
-            try (final Scope scope = tracer.scopeManager().activate(span, false)) {
+            try (final AgentScope scope = activateSpan(span, false)) {
               subscription.request(n);
             }
           }
@@ -75,18 +70,16 @@ public class TracingClientResponseSubscriber implements CoreSubscriber<ClientRes
 
   @Override
   public void onNext(final ClientResponse clientResponse) {
-    final Span span = spanRef.getAndSet(null);
+    final AgentSpan span = spanRef.getAndSet(null);
     if (span != null) {
       DECORATE.onResponse(span, clientResponse);
       DECORATE.beforeFinish(span);
       span.finish();
     }
 
-    try (final Scope scope = tracer.scopeManager().activate(parentSpan, false)) {
+    try (final AgentScope scope = activateSpan(parentSpan, false)) {
 
-      if (scope instanceof TraceScope) {
-        ((TraceScope) scope).setAsyncPropagation(true);
-      }
+      scope.setAsyncPropagation(true);
 
       subscriber.onNext(clientResponse);
     }
@@ -94,18 +87,16 @@ public class TracingClientResponseSubscriber implements CoreSubscriber<ClientRes
 
   @Override
   public void onError(final Throwable throwable) {
-    final Span span = spanRef.getAndSet(null);
+    final AgentSpan span = spanRef.getAndSet(null);
     if (span != null) {
       DECORATE.onError(span, throwable);
       DECORATE.beforeFinish(span);
       span.finish();
     }
 
-    try (final Scope scope = tracer.scopeManager().activate(parentSpan, false)) {
+    try (final AgentScope scope = activateSpan(parentSpan, false)) {
 
-      if (scope instanceof TraceScope) {
-        ((TraceScope) scope).setAsyncPropagation(true);
-      }
+      scope.setAsyncPropagation(true);
 
       subscriber.onError(throwable);
     }
@@ -113,17 +104,15 @@ public class TracingClientResponseSubscriber implements CoreSubscriber<ClientRes
 
   @Override
   public void onComplete() {
-    final Span span = spanRef.getAndSet(null);
+    final AgentSpan span = spanRef.getAndSet(null);
     if (span != null) {
       DECORATE.beforeFinish(span);
       span.finish();
     }
 
-    try (final Scope scope = tracer.scopeManager().activate(parentSpan, false)) {
+    try (final AgentScope scope = activateSpan(parentSpan, false)) {
 
-      if (scope instanceof TraceScope) {
-        ((TraceScope) scope).setAsyncPropagation(true);
-      }
+      scope.setAsyncPropagation(true);
 
       subscriber.onComplete();
     }

--- a/dd-java-agent/instrumentation/spring-webflux/src/main/java8/datadog/trace/instrumentation/springwebflux/server/AdviceUtils.java
+++ b/dd-java-agent/instrumentation/spring-webflux/src/main/java8/datadog/trace/instrumentation/springwebflux/server/AdviceUtils.java
@@ -2,8 +2,8 @@ package datadog.trace.instrumentation.springwebflux.server;
 
 import static datadog.trace.instrumentation.springwebflux.server.SpringWebfluxHttpServerDecorator.DECORATE;
 
+import datadog.trace.instrumentation.api.AgentSpan;
 import datadog.trace.instrumentation.reactor.core.ReactorCoreAdviceUtils;
-import io.opentracing.Span;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.reactive.function.client.ClientRequest;
 import org.springframework.web.reactive.function.server.ServerRequest;
@@ -32,18 +32,18 @@ public class AdviceUtils {
   public static void finishSpanIfPresent(
       final ServerWebExchange exchange, final Throwable throwable) {
     ReactorCoreAdviceUtils.finishSpanIfPresent(
-        (Span) exchange.getAttributes().remove(SPAN_ATTRIBUTE), throwable);
+        (AgentSpan) exchange.getAttributes().remove(SPAN_ATTRIBUTE), throwable);
   }
 
   public static void finishSpanIfPresent(
       final ServerRequest serverRequest, final Throwable throwable) {
     ReactorCoreAdviceUtils.finishSpanIfPresent(
-        (Span) serverRequest.attributes().remove(SPAN_ATTRIBUTE), throwable);
+        (AgentSpan) serverRequest.attributes().remove(SPAN_ATTRIBUTE), throwable);
   }
 
   public static void finishSpanIfPresent(
       final ClientRequest clientRequest, final Throwable throwable) {
     ReactorCoreAdviceUtils.finishSpanIfPresent(
-        (Span) clientRequest.attributes().remove(SPAN_ATTRIBUTE), throwable);
+        (AgentSpan) clientRequest.attributes().remove(SPAN_ATTRIBUTE), throwable);
   }
 }

--- a/dd-java-agent/instrumentation/spring-webflux/src/main/java8/datadog/trace/instrumentation/springwebflux/server/RouteOnSuccessOrError.java
+++ b/dd-java-agent/instrumentation/spring-webflux/src/main/java8/datadog/trace/instrumentation/springwebflux/server/RouteOnSuccessOrError.java
@@ -1,7 +1,7 @@
 package datadog.trace.instrumentation.springwebflux.server;
 
 import datadog.trace.api.DDTags;
-import io.opentracing.Span;
+import datadog.trace.instrumentation.api.AgentSpan;
 import java.util.function.BiConsumer;
 import java.util.regex.Pattern;
 import org.springframework.web.reactive.function.server.HandlerFunction;
@@ -27,12 +27,13 @@ public class RouteOnSuccessOrError implements BiConsumer<HandlerFunction<?>, Thr
     if (handler != null) {
       final String predicateString = parsePredicateString();
       if (predicateString != null) {
-        final Span span = (Span) serverRequest.attributes().get(AdviceUtils.SPAN_ATTRIBUTE);
+        final AgentSpan span =
+            (AgentSpan) serverRequest.attributes().get(AdviceUtils.SPAN_ATTRIBUTE);
         if (span != null) {
           span.setTag("request.predicate", predicateString);
         }
-        final Span parentSpan =
-            (Span) serverRequest.attributes().get(AdviceUtils.PARENT_SPAN_ATTRIBUTE);
+        final AgentSpan parentSpan =
+            (AgentSpan) serverRequest.attributes().get(AdviceUtils.PARENT_SPAN_ATTRIBUTE);
         if (parentSpan != null) {
           parentSpan.setTag(DDTags.RESOURCE_NAME, parseResourceName(predicateString));
         }

--- a/dd-java-agent/instrumentation/spring-webflux/src/test/groovy/dd/trace/instrumentation/springwebflux/client/SpringWebfluxHttpClientTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webflux/src/test/groovy/dd/trace/instrumentation/springwebflux/client/SpringWebfluxHttpClientTest.groovy
@@ -7,11 +7,12 @@ import datadog.trace.api.DDTags
 import datadog.trace.instrumentation.netty41.client.NettyHttpClientDecorator
 import datadog.trace.instrumentation.springwebflux.client.SpringWebfluxHttpClientDecorator
 import io.opentracing.tag.Tags
-import io.opentracing.util.GlobalTracer
 import org.springframework.http.HttpMethod
 import org.springframework.web.reactive.function.client.ClientResponse
 import org.springframework.web.reactive.function.client.WebClient
 import spock.lang.Shared
+
+import static datadog.trace.instrumentation.api.AgentTracer.activeSpan
 
 class SpringWebfluxHttpClientTest extends HttpClientTest<SpringWebfluxHttpClientDecorator> {
 
@@ -20,7 +21,7 @@ class SpringWebfluxHttpClientTest extends HttpClientTest<SpringWebfluxHttpClient
 
   @Override
   int doRequest(String method, URI uri, Map<String, String> headers, Closure callback) {
-    def hasParent = GlobalTracer.get().activeSpan() != null
+    def hasParent = activeSpan() != null
     ClientResponse response = client.method(HttpMethod.resolve(method))
       .headers { h -> headers.forEach({ key, value -> h.add(key, value) }) }
       .uri(uri)

--- a/dd-java-agent/instrumentation/spymemcached-2.12/src/main/java/datadog/trace/instrumentation/spymemcached/BulkGetCompletionListener.java
+++ b/dd-java-agent/instrumentation/spymemcached-2.12/src/main/java/datadog/trace/instrumentation/spymemcached/BulkGetCompletionListener.java
@@ -1,12 +1,13 @@
 package datadog.trace.instrumentation.spymemcached;
 
-import io.opentracing.Span;
+import datadog.trace.instrumentation.api.AgentSpan;
 import java.util.concurrent.ExecutionException;
 import net.spy.memcached.MemcachedConnection;
 import net.spy.memcached.internal.BulkGetFuture;
 
 public class BulkGetCompletionListener extends CompletionListener<BulkGetFuture<?>>
     implements net.spy.memcached.internal.BulkGetCompletionListener {
+
   public BulkGetCompletionListener(final MemcachedConnection connection, final String methodName) {
     super(connection, methodName);
   }
@@ -17,7 +18,7 @@ public class BulkGetCompletionListener extends CompletionListener<BulkGetFuture<
   }
 
   @Override
-  protected void processResult(final Span span, final BulkGetFuture<?> future)
+  protected void processResult(final AgentSpan span, final BulkGetFuture<?> future)
       throws ExecutionException, InterruptedException {
     /*
     Note: for now we do not have an affective way of representing results of bulk operations,

--- a/dd-java-agent/instrumentation/spymemcached-2.12/src/main/java/datadog/trace/instrumentation/spymemcached/GetCompletionListener.java
+++ b/dd-java-agent/instrumentation/spymemcached-2.12/src/main/java/datadog/trace/instrumentation/spymemcached/GetCompletionListener.java
@@ -1,6 +1,6 @@
 package datadog.trace.instrumentation.spymemcached;
 
-import io.opentracing.Span;
+import datadog.trace.instrumentation.api.AgentSpan;
 import java.util.concurrent.ExecutionException;
 import net.spy.memcached.MemcachedConnection;
 import net.spy.memcached.internal.GetFuture;
@@ -17,7 +17,7 @@ public class GetCompletionListener extends CompletionListener<GetFuture<?>>
   }
 
   @Override
-  protected void processResult(final Span span, final GetFuture<?> future)
+  protected void processResult(final AgentSpan span, final GetFuture<?> future)
       throws ExecutionException, InterruptedException {
     final Object result = future.get();
     setResultTag(span, result != null);

--- a/dd-java-agent/instrumentation/spymemcached-2.12/src/main/java/datadog/trace/instrumentation/spymemcached/MemcacheClientDecorator.java
+++ b/dd-java-agent/instrumentation/spymemcached-2.12/src/main/java/datadog/trace/instrumentation/spymemcached/MemcacheClientDecorator.java
@@ -3,7 +3,7 @@ package datadog.trace.instrumentation.spymemcached;
 import datadog.trace.agent.decorator.DatabaseClientDecorator;
 import datadog.trace.api.DDSpanTypes;
 import datadog.trace.api.DDTags;
-import io.opentracing.Span;
+import datadog.trace.instrumentation.api.AgentSpan;
 import net.spy.memcached.MemcachedConnection;
 
 public class MemcacheClientDecorator extends DatabaseClientDecorator<MemcachedConnection> {
@@ -44,7 +44,7 @@ public class MemcacheClientDecorator extends DatabaseClientDecorator<MemcachedCo
     return null;
   }
 
-  public Span onOperation(final Span span, final String methodName) {
+  public AgentSpan onOperation(final AgentSpan span, final String methodName) {
 
     final char[] chars =
         methodName

--- a/dd-java-agent/instrumentation/spymemcached-2.12/src/main/java/datadog/trace/instrumentation/spymemcached/OperationCompletionListener.java
+++ b/dd-java-agent/instrumentation/spymemcached-2.12/src/main/java/datadog/trace/instrumentation/spymemcached/OperationCompletionListener.java
@@ -1,6 +1,6 @@
 package datadog.trace.instrumentation.spymemcached;
 
-import io.opentracing.Span;
+import datadog.trace.instrumentation.api.AgentSpan;
 import java.util.concurrent.ExecutionException;
 import net.spy.memcached.MemcachedConnection;
 import net.spy.memcached.internal.OperationFuture;
@@ -19,7 +19,7 @@ public class OperationCompletionListener
   }
 
   @Override
-  protected void processResult(final Span span, final OperationFuture<? extends Object> future)
+  protected void processResult(final AgentSpan span, final OperationFuture<? extends Object> future)
       throws ExecutionException, InterruptedException {
     future.get();
   }

--- a/dd-java-agent/instrumentation/spymemcached-2.12/src/main/java/datadog/trace/instrumentation/spymemcached/SyncCompletionListener.java
+++ b/dd-java-agent/instrumentation/spymemcached-2.12/src/main/java/datadog/trace/instrumentation/spymemcached/SyncCompletionListener.java
@@ -1,6 +1,6 @@
 package datadog.trace.instrumentation.spymemcached;
 
-import io.opentracing.Span;
+import datadog.trace.instrumentation.api.AgentSpan;
 import java.util.concurrent.ExecutionException;
 import lombok.extern.slf4j.Slf4j;
 import net.spy.memcached.MemcachedConnection;
@@ -12,7 +12,7 @@ public class SyncCompletionListener extends CompletionListener<Void> {
   }
 
   @Override
-  protected void processResult(final Span span, final Void future)
+  protected void processResult(final AgentSpan span, final Void future)
       throws ExecutionException, InterruptedException {
     log.error("processResult was called on SyncCompletionListener. This should never happen. ");
   }

--- a/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceAdvice.java
+++ b/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceAdvice.java
@@ -1,13 +1,13 @@
 package datadog.trace.instrumentation.trace_annotation;
 
+import static datadog.trace.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.trace_annotation.TraceDecorator.DECORATE;
 
 import datadog.trace.api.DDTags;
 import datadog.trace.api.Trace;
-import datadog.trace.context.TraceScope;
-import io.opentracing.Scope;
-import io.opentracing.Tracer;
-import io.opentracing.util.GlobalTracer;
+import datadog.trace.instrumentation.api.AgentScope;
+import datadog.trace.instrumentation.api.AgentSpan;
 import java.lang.reflect.Method;
 import net.bytebuddy.asm.Advice;
 
@@ -15,33 +15,30 @@ public class TraceAdvice {
   private static final String DEFAULT_OPERATION_NAME = "trace.annotation";
 
   @Advice.OnMethodEnter(suppress = Throwable.class)
-  public static Scope startSpan(@Advice.Origin final Method method) {
+  public static AgentScope onEnter(@Advice.Origin final Method method) {
     final Trace traceAnnotation = method.getAnnotation(Trace.class);
     String operationName = traceAnnotation == null ? null : traceAnnotation.operationName();
     if (operationName == null || operationName.isEmpty()) {
       operationName = DEFAULT_OPERATION_NAME;
     }
 
-    Tracer.SpanBuilder spanBuilder = GlobalTracer.get().buildSpan(operationName);
+    final AgentSpan span = startSpan(operationName);
 
     String resourceName = traceAnnotation == null ? null : traceAnnotation.resourceName();
     if (resourceName == null || resourceName.isEmpty()) {
       resourceName = DECORATE.spanNameForMethod(method);
     }
-    spanBuilder = spanBuilder.withTag(DDTags.RESOURCE_NAME, resourceName);
+    span.setTag(DDTags.RESOURCE_NAME, resourceName);
+    DECORATE.afterStart(span);
 
-    final Scope scope = DECORATE.afterStart(spanBuilder.startActive(true));
-
-    if (scope instanceof TraceScope) {
-      ((TraceScope) scope).setAsyncPropagation(true);
-    }
-
+    final AgentScope scope = activateSpan(span, true);
+    scope.setAsyncPropagation(true);
     return scope;
   }
 
   @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
   public static void stopSpan(
-      @Advice.Enter final Scope scope, @Advice.Thrown final Throwable throwable) {
+      @Advice.Enter final AgentScope scope, @Advice.Thrown final Throwable throwable) {
     DECORATE.onError(scope, throwable);
     DECORATE.beforeFinish(scope);
     scope.close();

--- a/dd-java-agent/instrumentation/twilio/src/main/java/datadog/trace/instrumentation/twilio/TwilioClientDecorator.java
+++ b/dd-java-agent/instrumentation/twilio/src/main/java/datadog/trace/instrumentation/twilio/TwilioClientDecorator.java
@@ -6,7 +6,7 @@ import com.twilio.rest.api.v2010.account.Message;
 import datadog.trace.agent.decorator.ClientDecorator;
 import datadog.trace.api.DDSpanTypes;
 import datadog.trace.api.DDTags;
-import io.opentracing.Span;
+import datadog.trace.instrumentation.api.AgentSpan;
 import java.lang.reflect.Method;
 import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
@@ -40,8 +40,8 @@ public class TwilioClientDecorator extends ClientDecorator {
   }
 
   /** Decorate trace based on service execution metadata. */
-  public Span onServiceExecution(
-      final Span span, final Object serviceExecutor, final String methodName) {
+  public AgentSpan onServiceExecution(
+      final AgentSpan span, final Object serviceExecutor, final String methodName) {
 
     // Drop common package prefix (com.twilio.rest)
     final String simpleClassName =
@@ -53,7 +53,7 @@ public class TwilioClientDecorator extends ClientDecorator {
   }
 
   /** Annotate the span with the results of the operation. */
-  public Span onResult(final Span span, Object result) {
+  public AgentSpan onResult(final AgentSpan span, Object result) {
 
     // Unwrap ListenableFuture (if present)
     if (result instanceof ListenableFuture) {
@@ -105,7 +105,7 @@ public class TwilioClientDecorator extends ClientDecorator {
    * required.
    */
   private void setTagIfPresent(
-      final Span span, final Object result, final String tag, final String getter) {
+      final AgentSpan span, final Object result, final String tag, final String getter) {
     try {
       final Method method = result.getClass().getMethod(getter);
       final Object value = method.invoke(result);


### PR DESCRIPTION
Hi friends!

I'm looking forward to working with you all under the OpenTelemetry Auto-Instrumentation group! [plug: first meeting is tomorrow [Thu 9am Pacific](https://calendar.google.com/calendar/embed?src=google.com_b79e3e90j7bbsa2n2p5an5lf60%40group.calendar.google.com)]

I discussed with Tyler last week, and he pointed me toward his initial work (#936) toward decoupling the integrations from OpenTracing, and he expressed interest in having this done in the DataDog repository itself.

This PR attempts to minimally complete that work. If you have suggestions on how to reduce it further for ease of review, let me know!

I can make future PR(s) to remove/move OpenTracing constants and completely remove the io.opentracing as a dependency of instrumentation, and any other suggestions you have that can be layered on top of the initial minimal work.

(also, @tylerbenson, heads up, in trying to keep the PR minimal, I removed an unrelated changes you made in the POC, I put it [here](https://github.com/trask/opentelemetry-auto-instr-java/commit/229fd777a2a7a591e334912e07252625bbf2dee7) so it doesn't get lost)

Thanks all!