### PR TITLE
Another couchbase test race condition

### DIFF
--- a/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/springdata/CouchbaseSpringTemplateTest.groovy
+++ b/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/springdata/CouchbaseSpringTemplateTest.groovy
@@ -42,8 +42,11 @@ class CouchbaseSpringTemplateTest extends AbstractCouchbaseTest {
     Bucket bucketCouchbase = couchbaseCluster.openBucket(bucketCouchbase.name(), bucketCouchbase.password())
     Bucket bucketMemcache = memcacheCluster.openBucket(bucketMemcache.name(), bucketMemcache.password())
 
-    templates = [new CouchbaseTemplate(couchbaseManager.info(), bucketCouchbase),
-                 new CouchbaseTemplate(memcacheManager.info(), bucketMemcache)]
+    runUnderTrace("getting info") {
+      templates = [new CouchbaseTemplate(couchbaseManager.info(), bucketCouchbase),
+                   new CouchbaseTemplate(memcacheManager.info(), bucketMemcache)]
+      blockUntilChildSpansFinished(2)
+    }
   }
 
   def cleanupSpec() {


### PR DESCRIPTION
The `setupSpec()` method of the test class called `couchbaseManager.info()`.  This creates a span.  Usually, these spans are created before the `clear()` call that happens before every test.  Rarely though, `clear()` is called before all of the spans from the setup have returned.  This creates a race condition for only the first test.

This pull request rectifies the race condition by waiting for the `setupSpec()` spans