### PR TITLE
Change default for Spring and Ratpack analytics to be off

### DIFF
--- a/dd-java-agent/instrumentation/ratpack-1.4/src/main/java8/datadog/trace/instrumentation/ratpack/RatpackServerDecorator.java
+++ b/dd-java-agent/instrumentation/ratpack-1.4/src/main/java8/datadog/trace/instrumentation/ratpack/RatpackServerDecorator.java
@@ -27,6 +27,11 @@ public class RatpackServerDecorator extends HttpServerDecorator<Request, Request
   }
 
   @Override
+  protected boolean traceAnalyticsDefault() {
+    return false;
+  }
+
+  @Override
   protected String method(final Request request) {
     return request.getMethod().getName();
   }

--- a/dd-java-agent/instrumentation/spring-web/src/main/java/datadog/trace/instrumentation/springweb/SpringWebHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/spring-web/src/main/java/datadog/trace/instrumentation/springweb/SpringWebHttpServerDecorator.java
@@ -36,6 +36,11 @@ public class SpringWebHttpServerDecorator
   }
 
   @Override
+  protected boolean traceAnalyticsDefault() {
+    return false;
+  }
+
+  @Override
   protected String method(final HttpServletRequest httpServletRequest) {
     return httpServletRequest.getMethod();
   }


### PR DESCRIPTION
Setting `dd.trace.analytics.enabled=true` enables analytics events in general and toggles "web server integrations" specifically to generate events.  For most web integrations, this works as expected.  For Spring, however, each request created 2-4 events (servlet, handler, controller, render) depending on on the type of request.

This pull request disables these extra events by default for Spring and Ratpack.  They will still produce a single event per request for `servlet` and `netty` respectively.  All other web server integrations already only produce one event per request.

To reenable, a user can set `dd.spring-web.analytics.enabled=true` and/or `dd.ratpack.analytics.enabled=true` as they would for any other integration.

Automated testing is very difficult in this situation.  It would require overriding the config before the `BaseDecorator` class is instantiated and `HttpServerTest` would not be useable.  We are also in the process of changing how config overrides for tests work in #1007.  For those reasons, I did not include any additional tests.