### PR TITLE
Update vertx tests to play nice with latest version

### DIFF
--- a/dd-java-agent/instrumentation/vertx/src/test/groovy/client/VertxRxCircuitBreakerWebClientTest.groovy
+++ b/dd-java-agent/instrumentation/vertx/src/test/groovy/client/VertxRxCircuitBreakerWebClientTest.groovy
@@ -5,9 +5,7 @@ import datadog.trace.instrumentation.netty41.client.NettyHttpClientDecorator
 import io.vertx.circuitbreaker.CircuitBreakerOptions
 import io.vertx.core.VertxOptions
 import io.vertx.core.http.HttpMethod
-import io.vertx.ext.web.client.HttpResponse
 import io.vertx.reactivex.circuitbreaker.CircuitBreaker
-import io.vertx.reactivex.core.Future
 import io.vertx.reactivex.core.Vertx
 import io.vertx.reactivex.ext.web.client.WebClient
 import spock.lang.Shared
@@ -35,7 +33,7 @@ class VertxRxCircuitBreakerWebClientTest extends HttpClientTest<NettyHttpClientD
 
     def future = new CompletableFuture<Integer>()
 
-    Future<HttpResponse> result = breaker.executeCommand({ command ->
+    breaker.executeCommand({ command ->
       request.rxSend().doOnSuccess {
         command.complete(it)
       }.doOnError {

--- a/dd-java-agent/instrumentation/vertx/src/test/groovy/server/VertxRxCircuitBreakerHttpServerTest.groovy
+++ b/dd-java-agent/instrumentation/vertx/src/test/groovy/server/VertxRxCircuitBreakerHttpServerTest.groovy
@@ -33,7 +33,7 @@ class VertxRxCircuitBreakerHttpServerTest extends VertxHttpServerTest {
         )
 
       router.route(SUCCESS.path).handler { ctx ->
-        def result = breaker.executeCommand({ future ->
+        breaker.executeCommand({ future ->
           future.complete(SUCCESS)
         }, { it ->
           if (it.failed()) {
@@ -46,7 +46,7 @@ class VertxRxCircuitBreakerHttpServerTest extends VertxHttpServerTest {
         })
       }
       router.route(REDIRECT.path).handler { ctx ->
-        def result = breaker.executeCommand({ future ->
+        breaker.executeCommand({ future ->
           future.complete(REDIRECT)
         }, {
           if (it.failed()) {
@@ -59,7 +59,7 @@ class VertxRxCircuitBreakerHttpServerTest extends VertxHttpServerTest {
         })
       }
       router.route(ERROR.path).handler { ctx ->
-        def result = breaker.executeCommand({ future ->
+        breaker.executeCommand({ future ->
           future.complete(ERROR)
         }, {
           if (it.failed()) {
@@ -72,7 +72,7 @@ class VertxRxCircuitBreakerHttpServerTest extends VertxHttpServerTest {
         })
       }
       router.route(EXCEPTION.path).handler { ctx ->
-        def result = breaker.executeCommand({ future ->
+        breaker.executeCommand({ future ->
           future.fail(new Exception(EXCEPTION.body))
         }, {
           try {

--- a/dd-java-agent/instrumentation/vertx/src/test/groovy/server/VertxRxCircuitBreakerHttpServerTest.groovy
+++ b/dd-java-agent/instrumentation/vertx/src/test/groovy/server/VertxRxCircuitBreakerHttpServerTest.groovy
@@ -33,10 +33,9 @@ class VertxRxCircuitBreakerHttpServerTest extends VertxHttpServerTest {
         )
 
       router.route(SUCCESS.path).handler { ctx ->
-        def result = breaker.execute { future ->
+        def result = breaker.executeCommand({ future ->
           future.complete(SUCCESS)
-        }
-        result.setHandler {
+        }, { it ->
           if (it.failed()) {
             throw it.cause()
           }
@@ -44,13 +43,12 @@ class VertxRxCircuitBreakerHttpServerTest extends VertxHttpServerTest {
           controller(endpoint) {
             ctx.response().setStatusCode(endpoint.status).end(endpoint.body)
           }
-        }
+        })
       }
       router.route(REDIRECT.path).handler { ctx ->
-        def result = breaker.execute { future ->
+        def result = breaker.executeCommand({ future ->
           future.complete(REDIRECT)
-        }
-        result.setHandler {
+        }, {
           if (it.failed()) {
             throw it.cause()
           }
@@ -58,13 +56,12 @@ class VertxRxCircuitBreakerHttpServerTest extends VertxHttpServerTest {
           controller(endpoint) {
             ctx.response().setStatusCode(endpoint.status).putHeader("location", endpoint.body).end()
           }
-        }
+        })
       }
       router.route(ERROR.path).handler { ctx ->
-        def result = breaker.execute { future ->
+        def result = breaker.executeCommand({ future ->
           future.complete(ERROR)
-        }
-        result.setHandler {
+        }, {
           if (it.failed()) {
             throw it.cause()
           }
@@ -72,13 +69,12 @@ class VertxRxCircuitBreakerHttpServerTest extends VertxHttpServerTest {
           controller(endpoint) {
             ctx.response().setStatusCode(endpoint.status).end(endpoint.body)
           }
-        }
+        })
       }
       router.route(EXCEPTION.path).handler { ctx ->
-        def result = breaker.execute { future ->
+        def result = breaker.executeCommand({ future ->
           future.fail(new Exception(EXCEPTION.body))
-        }
-        result.setHandler {
+        }, {
           try {
             def cause = it.cause()
             controller(EXCEPTION) {
@@ -87,7 +83,7 @@ class VertxRxCircuitBreakerHttpServerTest extends VertxHttpServerTest {
           } catch (Exception ex) {
             ctx.response().setStatusCode(EXCEPTION.status).end(ex.message)
           }
-        }
+        })
       }
 
       super.@vertx.createHttpServer()


### PR DESCRIPTION
Vert.x made some [deprecations and breaking changes](https://github.com/vert-x3/wiki/wiki/3.8.2-Deprecations-and-breaking-changes) in the latest 3.x release that affected some methods we used for tests.  The rxJava Vert.x code is autogenerated so the deprecations move to method removal quicker

This pull request changes the tests to be backwards and forwards compatible in 3.x