### PR TITLE
Fix OSGi bootstrap delegation property

### DIFF
--- a/dd-java-agent/instrumentation/osgi-classloading/src/main/java/datadog/trace/instrumentation/osgi/OSGIClassloadingInstrumentation.java
+++ b/dd-java-agent/instrumentation/osgi-classloading/src/main/java/datadog/trace/instrumentation/osgi/OSGIClassloadingInstrumentation.java
@@ -92,12 +92,12 @@ public final class OSGIClassloadingInstrumentation extends Instrumenter.Default 
     }
 
     public static String getNewValue(final String existingValue) {
-      if (null != existingValue
-          && !"".equals(existingValue)
-          && !existingValue.contains(PROPERTY_VALUE)) {
+      if (existingValue == null || "".equals(existingValue)) {
+        return PROPERTY_VALUE;
+      } else if (!existingValue.contains(PROPERTY_VALUE)) {
         return existingValue + "," + PROPERTY_VALUE;
       } else {
-        return PROPERTY_VALUE;
+        return existingValue;
       }
     }
   }

--- a/dd-java-agent/instrumentation/osgi-classloading/src/test/groovy/OSGIClassloadingTest.groovy
+++ b/dd-java-agent/instrumentation/osgi-classloading/src/test/groovy/OSGIClassloadingTest.groovy
@@ -1,4 +1,5 @@
 import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.instrumentation.osgi.OSGIClassloadingInstrumentation
 import org.eclipse.osgi.launch.EquinoxFactory
 import org.junit.Rule
 import org.junit.contrib.java.lang.system.RestoreSystemProperties
@@ -9,12 +10,14 @@ class OSGIClassloadingTest extends AgentTestRunner {
   @Rule
   public final RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties()
 
+  static final String BOOT_DELEGATION_ADDITION = "datadog.slf4j.*,datadog.slf4j,datadog.trace.agent.TracingAgent.*,datadog.trace.agent.TracingAgent,datadog.trace.api.*,datadog.trace.api,datadog.trace.bootstrap.*,datadog.trace.bootstrap,datadog.trace.context.*,datadog.trace.context,io.opentracing.*,io.opentracing"
+
   def "delegation property set on module load"() {
     when:
     org.osgi.framework.Bundle.getName()
 
     then:
-    System.getProperty("org.osgi.framework.bootdelegation") == "datadog.slf4j.*,datadog.slf4j,datadog.trace.agent.TracingAgent.*,datadog.trace.agent.TracingAgent,datadog.trace.api.*,datadog.trace.api,datadog.trace.bootstrap.*,datadog.trace.bootstrap,datadog.trace.context.*,datadog.trace.context,io.opentracing.*,io.opentracing"
+    System.getProperty("org.osgi.framework.bootdelegation") == BOOT_DELEGATION_ADDITION
   }
 
   def "test OSGi framework factory"() {
@@ -31,5 +34,22 @@ class OSGIClassloadingTest extends AgentTestRunner {
     factory                                           | _
     new EquinoxFactory()                              | _
     new org.apache.felix.framework.FrameworkFactory() | _
+  }
+
+  def "test property transformations"() {
+    when:
+    def newValue = OSGIClassloadingInstrumentation.Helper.getNewValue(existingValue)
+
+    then:
+    newValue == expectedNewValue
+
+    where:
+    existingValue                                  | expectedNewValue
+    null                                           | BOOT_DELEGATION_ADDITION
+    ""                                             | BOOT_DELEGATION_ADDITION
+    BOOT_DELEGATION_ADDITION                       | BOOT_DELEGATION_ADDITION
+    "foo.*"                                        | "foo.*," + BOOT_DELEGATION_ADDITION
+    "foo.*," + BOOT_DELEGATION_ADDITION + ",bar.*" | "foo.*," + BOOT_DELEGATION_ADDITION + ",bar.*"
+
   }
 }


### PR DESCRIPTION
The OSGi instrumentation incorrectly overrode the bootstrap delegation property when run more than once.  This removed any custom values previously set and caused startup issues.

This pull request fixes that bug and adds some tests.