### PR TITLE
Enable Async Propagation for @Trace Annotatation instrumentation

### DIFF
--- a/dd-java-agent/instrumentation/netty-4.1/netty-4.1.gradle
+++ b/dd-java-agent/instrumentation/netty-4.1/netty-4.1.gradle
@@ -38,6 +38,7 @@ dependencies {
   compileOnly group: 'io.netty', name: 'netty-codec-http', version: '4.1.0.Final'
 
   testCompile project(':dd-java-agent:instrumentation:java-concurrent')
+  testCompile project(':dd-java-agent:instrumentation:trace-annotation')
   testCompile group: 'io.netty', name: 'netty-codec-http', version: '4.1.0.Final'
   testCompile group: 'org.asynchttpclient', name: 'async-http-client', version: '2.1.0'
 

--- a/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceAdvice.java
+++ b/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceAdvice.java
@@ -4,6 +4,7 @@ import static datadog.trace.instrumentation.trace_annotation.TraceDecorator.DECO
 
 import datadog.trace.api.DDTags;
 import datadog.trace.api.Trace;
+import datadog.trace.context.TraceScope;
 import io.opentracing.Scope;
 import io.opentracing.Tracer;
 import io.opentracing.util.GlobalTracer;
@@ -29,7 +30,13 @@ public class TraceAdvice {
     }
     spanBuilder = spanBuilder.withTag(DDTags.RESOURCE_NAME, resourceName);
 
-    return DECORATE.afterStart(spanBuilder.startActive(true));
+    final Scope scope = DECORATE.afterStart(spanBuilder.startActive(true));
+
+    if (scope instanceof TraceScope) {
+      ((TraceScope) scope).setAsyncPropagation(true);
+    }
+
+    return scope;
   }
 
   @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)


### PR DESCRIPTION
This pull request enables async propagation for the `@Trace` annotation instrumentation.

Without async propagation, annotating a method that calls an async instrumentation results in broken traces.  The accompanying addition to the netty4.1 tests illustrates this point.