### PR TITLE
Test config cleanup

### DIFF
--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/decorator/BaseDecoratorTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/decorator/BaseDecoratorTest.groovy
@@ -1,6 +1,5 @@
 package datadog.trace.agent.decorator
 
-import datadog.trace.agent.test.utils.ConfigUtils
 import datadog.trace.api.DDTags
 import datadog.trace.util.test.DDSpecification
 import io.opentracing.Scope
@@ -8,10 +7,10 @@ import io.opentracing.Span
 import io.opentracing.tag.Tags
 import spock.lang.Shared
 
+import static datadog.trace.agent.test.utils.ConfigUtils.withNewConfig
 import static io.opentracing.log.Fields.ERROR_OBJECT
 
 class BaseDecoratorTest extends DDSpecification {
-
   @Shared
   def decorator = newDecorator()
 
@@ -164,21 +163,17 @@ class BaseDecoratorTest extends DDSpecification {
 
   def "test analytics rate enabled:#enabled, integration:#integName, sampleRate:#sampleRate"() {
     setup:
-    ConfigUtils.updateConfig {
-      System.properties.setProperty("dd.${integName}.analytics.enabled", "true")
-      System.properties.setProperty("dd.${integName}.analytics.sample-rate", "$sampleRate")
-    }
+    System.properties.setProperty("dd.${integName}.analytics.enabled", "true")
+    System.properties.setProperty("dd.${integName}.analytics.sample-rate", "$sampleRate")
 
     when:
-    BaseDecorator dec = newDecorator(enabled)
+    BaseDecorator dec = withNewConfig {
+      newDecorator(enabled)
+    }
 
     then:
     dec.traceAnalyticsEnabled == expectedEnabled
     dec.traceAnalyticsSampleRate == (Float) expectedRate
-
-    cleanup:
-    System.clearProperty("dd.${integName}.analytics.enabled")
-    System.clearProperty("dd.${integName}.analytics.sample-rate")
 
     where:
     enabled | integName | sampleRate | expectedEnabled | expectedRate

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test/groovy/AWSClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test/groovy/AWSClientTest.groovy
@@ -43,14 +43,9 @@ class AWSClientTest extends AgentTestRunner {
     new ProfileCredentialsProvider(),
     new InstanceProfileCredentialsProvider())
 
-  def setupSpec() {
+  def setup() {
     System.setProperty(SDKGlobalConfiguration.ACCESS_KEY_SYSTEM_PROPERTY, "my-access-key")
     System.setProperty(SDKGlobalConfiguration.SECRET_KEY_SYSTEM_PROPERTY, "my-secret-key")
-  }
-
-  def cleanupSpec() {
-    System.clearProperty(SDKGlobalConfiguration.ACCESS_KEY_SYSTEM_PROPERTY)
-    System.clearProperty(SDKGlobalConfiguration.SECRET_KEY_SYSTEM_PROPERTY)
   }
 
   @Shared

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test_before_1_11_106/groovy/AWSClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test_before_1_11_106/groovy/AWSClientTest.groovy
@@ -37,14 +37,9 @@ class AWSClientTest extends AgentTestRunner {
     new ProfileCredentialsProvider(),
     new InstanceProfileCredentialsProvider())
 
-  def setupSpec() {
+  def setup() {
     System.setProperty(SDKGlobalConfiguration.ACCESS_KEY_SYSTEM_PROPERTY, "my-access-key")
     System.setProperty(SDKGlobalConfiguration.SECRET_KEY_SYSTEM_PROPERTY, "my-secret-key")
-  }
-
-  def cleanupSpec() {
-    System.clearProperty(SDKGlobalConfiguration.ACCESS_KEY_SYSTEM_PROPERTY)
-    System.clearProperty(SDKGlobalConfiguration.SECRET_KEY_SYSTEM_PROPERTY)
   }
 
   @Shared

--- a/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/ExecutorInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/ExecutorInstrumentationTest.groovy
@@ -1,7 +1,6 @@
 import datadog.opentracing.DDSpan
 import datadog.opentracing.scopemanager.ContinuableScope
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.utils.ConfigUtils
 import datadog.trace.api.Trace
 import datadog.trace.bootstrap.instrumentation.java.concurrent.CallableWrapper
 import datadog.trace.bootstrap.instrumentation.java.concurrent.RunnableWrapper
@@ -30,9 +29,7 @@ import static org.junit.Assume.assumeTrue
 class ExecutorInstrumentationTest extends AgentTestRunner {
 
   static {
-    ConfigUtils.updateConfig {
-      System.setProperty("dd.trace.executors", "ExecutorInstrumentationTest\$CustomThreadPoolExecutor")
-    }
+    PRE_AGENT_SYS_PROPS = ["dd.trace.executors": "ExecutorInstrumentationTest\$CustomThreadPoolExecutor"]
   }
 
   @Shared

--- a/dd-java-agent/instrumentation/osgi-classloading/src/test/groovy/OSGIClassloadingTest.groovy
+++ b/dd-java-agent/instrumentation/osgi-classloading/src/test/groovy/OSGIClassloadingTest.groovy
@@ -1,15 +1,9 @@
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.instrumentation.osgi.OSGIClassloadingInstrumentation
 import org.eclipse.osgi.launch.EquinoxFactory
-import org.junit.Rule
-import org.junit.contrib.java.lang.system.RestoreSystemProperties
 import org.osgi.framework.launch.Framework
 
 class OSGIClassloadingTest extends AgentTestRunner {
-
-  @Rule
-  public final RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties()
-
   static final String BOOT_DELEGATION_ADDITION = "datadog.slf4j.*,datadog.slf4j,datadog.trace.agent.TracingAgent.*,datadog.trace.agent.TracingAgent,datadog.trace.api.*,datadog.trace.api,datadog.trace.bootstrap.*,datadog.trace.bootstrap,datadog.trace.context.*,datadog.trace.context,io.opentracing.*,io.opentracing"
 
   def "delegation property set on module load"() {

--- a/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/TraceAnnotationsTest.groovy
+++ b/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/TraceAnnotationsTest.groovy
@@ -1,6 +1,5 @@
 import datadog.opentracing.decorators.ErrorFlag
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.utils.ConfigUtils
 import datadog.trace.api.Trace
 import dd.test.trace.annotation.SayTracedHello
 import io.opentracing.tag.Tags
@@ -8,19 +7,12 @@ import io.opentracing.tag.Tags
 import java.util.concurrent.Callable
 
 class TraceAnnotationsTest extends AgentTestRunner {
-
-  static {
-    ConfigUtils.updateConfig {
-      System.clearProperty("dd.trace.annotations")
-    }
-  }
-
   def "test simple case annotations"() {
-    setup:
+    when:
     // Test single span in new trace
     SayTracedHello.sayHello()
 
-    expect:
+    then:
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
@@ -39,11 +31,11 @@ class TraceAnnotationsTest extends AgentTestRunner {
   }
 
   def "test simple case with only operation name set"() {
-    setup:
+    when:
     // Test single span in new trace
     SayTracedHello.sayHA()
 
-    expect:
+    then:
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
@@ -63,11 +55,11 @@ class TraceAnnotationsTest extends AgentTestRunner {
   }
 
   def "test simple case with only resource name set"() {
-    setup:
+    when:
     // Test single span in new trace
     SayTracedHello.sayHelloOnlyResourceSet()
 
-    expect:
+    then:
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
@@ -86,11 +78,11 @@ class TraceAnnotationsTest extends AgentTestRunner {
   }
 
   def "test simple case with both resource and operation name set"() {
-    setup:
+    when:
     // Test single span in new trace
     SayTracedHello.sayHAWithResource()
 
-    expect:
+    then:
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
@@ -243,17 +235,14 @@ class TraceAnnotationsTest extends AgentTestRunner {
 
   def "test exception exit"() {
     setup:
-
     TEST_TRACER.addDecorator(new ErrorFlag())
 
-    Throwable error = null
-    try {
-      SayTracedHello.sayERROR()
-    } catch (final Throwable ex) {
-      error = ex
-    }
+    when:
+    SayTracedHello.sayERROR()
 
-    expect:
+    then:
+    def ex = thrown(RuntimeException)
+
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
@@ -262,7 +251,7 @@ class TraceAnnotationsTest extends AgentTestRunner {
           errored true
           tags {
             "$Tags.COMPONENT.key" "trace"
-            errorTags(error.class)
+            errorTags(ex.class)
             defaultTags()
           }
         }
@@ -275,14 +264,12 @@ class TraceAnnotationsTest extends AgentTestRunner {
 
     TEST_TRACER.addDecorator(new ErrorFlag())
 
-    Throwable error = null
-    try {
-      SayTracedHello.sayERRORWithResource()
-    } catch (final Throwable ex) {
-      error = ex
-    }
+    when:
+    SayTracedHello.sayERRORWithResource()
 
-    expect:
+    then:
+    def ex = thrown(RuntimeException)
+
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
@@ -291,7 +278,7 @@ class TraceAnnotationsTest extends AgentTestRunner {
           errored true
           tags {
             "$Tags.COMPONENT.key" "trace"
-            errorTags(error.class)
+            errorTags(ex.class)
             defaultTags()
           }
         }
@@ -300,11 +287,11 @@ class TraceAnnotationsTest extends AgentTestRunner {
   }
 
   def "test annonymous class annotations"() {
-    setup:
+    when:
     // Test anonymous classes with package.
     SayTracedHello.fromCallable()
 
-    expect:
+    then:
     assertTraces(1) {
       trace(0, 1) {
         span(0) {

--- a/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/TraceConfigTest.groovy
+++ b/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/TraceConfigTest.groovy
@@ -5,17 +5,8 @@ import datadog.trace.instrumentation.trace_annotation.TraceConfigInstrumentation
 import java.util.concurrent.Callable
 
 class TraceConfigTest extends AgentTestRunner {
-
   static {
-    ConfigUtils.updateConfig {
-      System.setProperty("dd.trace.methods", "package.ClassName[method1,method2];${ConfigTracedCallable.name}[call]")
-    }
-  }
-
-  def specCleanup() {
-    ConfigUtils.updateConfig {
-      System.clearProperty("dd.trace.methods")
-    }
+    PRE_AGENT_SYS_PROPS = ["dd.trace.methods": "package.ClassName[method1,method2];${ConfigTracedCallable.name}[call]"]
   }
 
   class ConfigTracedCallable implements Callable<String> {
@@ -26,11 +17,8 @@ class TraceConfigTest extends AgentTestRunner {
   }
 
   def "test configuration based trace"() {
-    expect:
-    new ConfigTracedCallable().call() == "Hello!"
-
     when:
-    TEST_WRITER.waitForTraces(1)
+    new ConfigTracedCallable().call() == "Hello!"
 
     then:
     assertTraces(1) {
@@ -45,19 +33,19 @@ class TraceConfigTest extends AgentTestRunner {
 
   def "test configuration #value"() {
     setup:
-    ConfigUtils.updateConfig {
-      if (value) {
-        System.properties.setProperty("dd.trace.methods", value)
-      } else {
-        System.clearProperty("dd.trace.methods")
-      }
+    if (value) {
+      System.properties.setProperty("dd.trace.methods", value)
+    } else {
+      System.clearProperty("dd.trace.methods")
     }
 
-    expect:
-    new TraceConfigInstrumentation().classMethodsToTrace == expected
+    when:
+    Map result = ConfigUtils.withNewConfig {
+      new TraceConfigInstrumentation().classMethodsToTrace
+    }
 
-    cleanup:
-    System.clearProperty("dd.trace.methods")
+    then:
+    result == expected
 
     where:
     value                                                           | expected

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/log/injection/LogContextInjectionTestBase.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/log/injection/LogContextInjectionTestBase.groovy
@@ -1,7 +1,6 @@
 package datadog.trace.agent.test.log.injection
 
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.utils.ConfigUtils
 import datadog.trace.api.CorrelationIdentifier
 import io.opentracing.Scope
 import io.opentracing.util.GlobalTracer
@@ -13,7 +12,6 @@ import java.util.concurrent.atomic.AtomicReference
  * satisfy in order to support log injection.
  */
 abstract class LogContextInjectionTestBase extends AgentTestRunner {
-
   /**
    * Set in the framework-specific context the given value at the given key
    */
@@ -25,9 +23,7 @@ abstract class LogContextInjectionTestBase extends AgentTestRunner {
   abstract get(String key)
 
   static {
-    ConfigUtils.updateConfig {
-      System.setProperty("dd.logs.injection", "true")
-    }
+    PRE_AGENT_SYS_PROPS = ["dd.logs.injection": "true"]
   }
 
   def "Log context shows trace and span ids for active scope"() {
@@ -67,9 +63,6 @@ abstract class LogContextInjectionTestBase extends AgentTestRunner {
 
   def "Log context is scoped by thread"() {
     setup:
-    ConfigUtils.updateConfig {
-      System.setProperty("dd.logs.injection", "true")
-    }
     AtomicReference<String> thread1TraceId = new AtomicReference<>()
     AtomicReference<String> thread2TraceId = new AtomicReference<>()
 

--- a/dd-java-agent/testing/src/test/groovy/AgentTestRunnerTest.groovy
+++ b/dd-java-agent/testing/src/test/groovy/AgentTestRunnerTest.groovy
@@ -2,7 +2,6 @@ import com.google.common.reflect.ClassPath
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.SpockRunner
 import datadog.trace.agent.test.utils.ClasspathUtils
-import datadog.trace.agent.test.utils.ConfigUtils
 import datadog.trace.agent.test.utils.GlobalTracerUtils
 import datadog.trace.agent.tooling.Constants
 import io.opentracing.Span
@@ -24,9 +23,7 @@ class AgentTestRunnerTest extends AgentTestRunner {
   private Class sharedSpanClass
 
   static {
-    ConfigUtils.updateConfig {
-      System.setProperty("dd." + TRACE_CLASSES_EXCLUDE, "config.exclude.packagename.*, config.exclude.SomeClass,config.exclude.SomeClass\$NestedClass")
-    }
+    PRE_AGENT_SYS_PROPS = [("dd." + TRACE_CLASSES_EXCLUDE): "config.exclude.packagename.*, config.exclude.SomeClass,config.exclude.SomeClass\$NestedClass"]
 
     // when test class initializes, opentracing should be set up, but not the agent.
     OT_LOADER = io.opentracing.Tracer.getClassLoader()

--- a/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -3,7 +3,6 @@ package datadog.trace.api
 import datadog.trace.util.test.DDSpecification
 import org.junit.Rule
 import org.junit.contrib.java.lang.system.EnvironmentVariables
-import org.junit.contrib.java.lang.system.RestoreSystemProperties
 
 import static datadog.trace.api.Config.AGENT_HOST
 import static datadog.trace.api.Config.AGENT_PORT_LEGACY
@@ -42,8 +41,6 @@ import static datadog.trace.api.Config.TRACE_RESOLVER_ENABLED
 import static datadog.trace.api.Config.WRITER_TYPE
 
 class ConfigTest extends DDSpecification {
-  @Rule
-  public final RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties()
   @Rule
   public final EnvironmentVariables environmentVariables = new EnvironmentVariables()
 
@@ -742,9 +739,6 @@ class ConfigTest extends DDSpecification {
 
     then:
     config.serviceName == "set-in-properties"
-
-    cleanup:
-    System.clearProperty(PREFIX + CONFIGURATION_FILE)
   }
 
   def "verify fallback to properties file has lower priority than system property"() {
@@ -757,10 +751,6 @@ class ConfigTest extends DDSpecification {
 
     then:
     config.serviceName == "set-in-system"
-
-    cleanup:
-    System.clearProperty(PREFIX + CONFIGURATION_FILE)
-    System.clearProperty(PREFIX + SERVICE_NAME)
   }
 
   def "verify fallback to properties file has lower priority than env var"() {
@@ -775,8 +765,6 @@ class ConfigTest extends DDSpecification {
     config.serviceName == "set-in-env"
 
     cleanup:
-    System.clearProperty(PREFIX + CONFIGURATION_FILE)
-    System.clearProperty(PREFIX + SERVICE_NAME)
     environmentVariables.clear("DD_SERVICE_NAME")
   }
 
@@ -789,8 +777,5 @@ class ConfigTest extends DDSpecification {
 
     then:
     config.serviceName == 'unnamed-java-app'
-
-    cleanup:
-    System.clearProperty(PREFIX + CONFIGURATION_FILE)
   }
 }

--- a/dd-trace-ot/src/test/groovy/datadog/trace/DDTracerTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/trace/DDTracerTest.groovy
@@ -11,7 +11,6 @@ import datadog.trace.common.writer.LoggingWriter
 import datadog.trace.util.test.DDSpecification
 import org.junit.Rule
 import org.junit.contrib.java.lang.system.EnvironmentVariables
-import org.junit.contrib.java.lang.system.RestoreSystemProperties
 
 import static datadog.trace.api.Config.DEFAULT_SERVICE_NAME
 import static datadog.trace.api.Config.HEADER_TAGS
@@ -22,9 +21,6 @@ import static datadog.trace.api.Config.SPAN_TAGS
 import static datadog.trace.api.Config.WRITER_TYPE
 
 class DDTracerTest extends DDSpecification {
-
-  @Rule
-  public final RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties()
   @Rule
   public final EnvironmentVariables environmentVariables = new EnvironmentVariables()
 

--- a/utils/test-utils/src/main/groovy/datadog/trace/util/test/DDSpecification.groovy
+++ b/utils/test-utils/src/main/groovy/datadog/trace/util/test/DDSpecification.groovy
@@ -27,6 +27,8 @@ abstract class DDSpecification extends Specification {
     makeConfigInstanceModifiable()
   }
 
+  private static Properties ORIGINAL_SYS_PROPS
+
   // Keep track of config instance already made modifiable
   private static isConfigInstanceModifiable = false
 
@@ -74,5 +76,18 @@ abstract class DDSpecification extends Specification {
 
     // No longer needed (Unless class gets retransformed somehow).
     instrumentation.removeTransformer(transformer)
+  }
+
+  void setupSpec() {
+    ORIGINAL_SYS_PROPS = new Properties()
+    ORIGINAL_SYS_PROPS.putAll(System.getProperties())
+  }
+
+  void cleanupSpec() {
+    System.setProperties(new Properties(ORIGINAL_SYS_PROPS))
+  }
+
+  void setup() {
+    System.setProperties(new Properties(ORIGINAL_SYS_PROPS))
   }
 }


### PR DESCRIPTION
_This is a resubmission of #1007 built on the latest test code changes_

This pull request increases the stability of tests dealing with config and system properties:

### Simplified `ConfigUtils` interface
The public interface was reduced to two actions:
   * `withNewConfig`: runs the block with a completely new `Config` based on the current system properties
   * `withConfigOverride`: runs the block with a new `Config` based on the old config plus passed in overrides

In both cases, the old config is restored after the block is executed.  This eliminates problems arising from not calling `resetConfig` at the proper time or tests trying to override config in a static scope (nondeterministic)

### Consistent System Properties
System properties are now restored in the `DDSpecification` class. This ensures a consistent state and eliminates inadvertent execution order dependencies.  It also removes the need to manually call `clearProperty()`.

### Pre-agent Property Hook
Any class wanting to set system properties before the test agent is created can set `PRE_AGENT_SYS_PROPS` in a static scope.  The agent is then installed in a `withNewConfig` block.  Additionally, for each test class, the system properties are properly reset at the beginning of each test execution.