### PR TITLE
Upgrade Jackson to 2.10.0

### DIFF
--- a/dd-java-agent/agent-jmxfetch/agent-jmxfetch.gradle
+++ b/dd-java-agent/agent-jmxfetch/agent-jmxfetch.gradle
@@ -4,7 +4,7 @@ plugins {
 apply from: "${rootDir}/gradle/java.gradle"
 
 dependencies {
-  compile('com.datadoghq:jmxfetch:0.32.0') {
+  compile('com.datadoghq:jmxfetch:0.32.1') {
     exclude group: 'org.slf4j', module: 'slf4j-log4j12'
     exclude group: 'log4j', module: 'log4j'
   }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -9,7 +9,7 @@ ext {
     guava      : "20.0", // Last version to support Java 7
 
     // When upgrading for security fixes, ensure corresponding change is reflected in jmxfetch.
-    jackson    : "2.9.9.3", // https://nvd.nist.gov/vuln/detail/CVE-2019-14379
+    jackson    : "2.10.0", // https://nvd.nist.gov/vuln/detail/CVE-2019-16942 et al
 
     spock      : "1.3-groovy-$spockGroovyVer",
     groovy     : groovyVer,


### PR DESCRIPTION
This is primarily motivated by new CVE’s.

Upgrade jmxfetch to 0.32.1 which has the same change.