### PR TITLE
Ensure baggage can always be added to

### DIFF
--- a/dd-trace-ot/src/main/java/datadog/opentracing/DDSpanContext.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/DDSpanContext.java
@@ -103,7 +103,7 @@ public class DDSpanContext implements io.opentracing.SpanContext {
     if (baggageItems == null) {
       this.baggageItems = new ConcurrentHashMap<>(0);
     } else {
-      this.baggageItems = baggageItems;
+      this.baggageItems = new ConcurrentHashMap<>(baggageItems);
     }
 
     if (tags != null) {


### PR DESCRIPTION
Otherwise it could be assigned to a Collections.emptyMap()
Fixes https://github.com/DataDog/dd-trace-java/issues/1036