### PR TITLE
Decrease cache size and make soft values

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/DDCachingPoolStrategy.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/DDCachingPoolStrategy.java
@@ -73,7 +73,8 @@ public class DDCachingPoolStrategy implements PoolStrategy {
       cache =
           CacheBuilder.newBuilder()
               .initialCapacity(100) // Per classloader, so we want a small default.
-              .maximumSize(10000)
+              .maximumSize(5000)
+              .softValues()
               .expireAfterAccess(expireDuration, unit)
               .build();
 

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/EvictingCacheProviderTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/EvictingCacheProviderTest.groovy
@@ -86,12 +86,12 @@ class EvictingCacheProviderTest extends DDSpecification {
     setup:
     def provider = new DDCachingPoolStrategy.EvictingCacheProvider(CLEANER, 2, TimeUnit.MINUTES)
     def typeDef = new TypePool.Resolution.Simple(TypeDescription.VOID)
-    for (int i = 0; i < 20000; i++) {
+    for (int i = 0; i < 10000; i++) {
       provider.register("ClassName$i", typeDef)
     }
 
     expect:
-    provider.size() == 10000
+    provider.size() == 5000
 
     when:
     provider.clear()


### PR DESCRIPTION
Attempt to reduce memory overhead requirements.  Based on feedback, it seems 10k was overly agressive.  In memory constrained environments, use soft values to ensure the cache isn’t pushing usage over the limit.