### PR TITLE
Add instrumentation for all of Apache HttpClient methods

### DIFF
--- a/dd-java-agent/instrumentation/apache-httpclient-4/src/main/java/datadog/trace/instrumentation/apachehttpclient/HostAndRequestAsHttpUriRequest.java
+++ b/dd-java-agent/instrumentation/apache-httpclient-4/src/main/java/datadog/trace/instrumentation/apachehttpclient/HostAndRequestAsHttpUriRequest.java
@@ -1,0 +1,54 @@
+package datadog.trace.instrumentation.apachehttpclient;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import lombok.Getter;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpRequest;
+import org.apache.http.ProtocolVersion;
+import org.apache.http.RequestLine;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.message.AbstractHttpMessage;
+
+/** Wraps HttpHost and HttpRequest into a HttpUriRequest for decorators and injectors */
+@Getter
+public class HostAndRequestAsHttpUriRequest extends AbstractHttpMessage implements HttpUriRequest {
+
+  private final String method;
+  private final RequestLine requestLine;
+  private final ProtocolVersion protocolVersion;
+  private final java.net.URI URI;
+
+  private final HttpRequest actualRequest;
+
+  public HostAndRequestAsHttpUriRequest(final HttpHost httpHost, final HttpRequest httpRequest) {
+
+    method = httpRequest.getRequestLine().getMethod();
+    requestLine = httpRequest.getRequestLine();
+    protocolVersion = requestLine.getProtocolVersion();
+
+    URI calculatedURI;
+    try {
+      calculatedURI = new URI(httpHost.toURI() + httpRequest.getRequestLine().getUri());
+    } catch (final URISyntaxException e) {
+      calculatedURI = null;
+    }
+    URI = calculatedURI;
+    actualRequest = httpRequest;
+  }
+
+  @Override
+  public void abort() throws UnsupportedOperationException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean isAborted() {
+    return false;
+  }
+
+  @Override
+  public void addHeader(final String name, final String value) {
+    actualRequest.addHeader(name, value);
+  }
+}

--- a/dd-java-agent/instrumentation/apache-httpclient-4/src/test/groovy/ApacheHttpClientTest.groovy
+++ b/dd-java-agent/instrumentation/apache-httpclient-4/src/test/groovy/ApacheHttpClientTest.groovy
@@ -35,12 +35,30 @@ abstract class ApacheHttpClientTest<T extends HttpRequest> extends HttpClientTes
   abstract T createRequest(String method, URI uri)
 
   abstract HttpResponse executeRequest(T request, URI uri)
+
+  static String fullPathFromURI(URI uri) {
+    StringBuilder builder = new StringBuilder()
+    if (uri.getPath() != null) {
+      builder.append(uri.getPath())
+    }
+
+    if (uri.getQuery() != null) {
+      builder.append('?')
+      builder.append(uri.getQuery())
+    }
+
+    if (uri.getFragment() != null) {
+      builder.append('#')
+      builder.append(uri.getFragment())
+    }
+    return builder.toString()
+  }
 }
 
 class ApacheClientHostRequest extends ApacheHttpClientTest<BasicHttpRequest> {
   @Override
   BasicHttpRequest createRequest(String method, URI uri) {
-    return new BasicHttpRequest(method, uri.getPath())
+    return new BasicHttpRequest(method, fullPathFromURI(uri))
   }
 
   @Override
@@ -52,7 +70,7 @@ class ApacheClientHostRequest extends ApacheHttpClientTest<BasicHttpRequest> {
 class ApacheClientHostRequestContext extends ApacheHttpClientTest<BasicHttpRequest> {
   @Override
   BasicHttpRequest createRequest(String method, URI uri) {
-    return new BasicHttpRequest(method, uri.getPath())
+    return new BasicHttpRequest(method, fullPathFromURI(uri))
   }
 
   @Override
@@ -64,7 +82,7 @@ class ApacheClientHostRequestContext extends ApacheHttpClientTest<BasicHttpReque
 class ApacheClientHostRequestResponseHandler extends ApacheHttpClientTest<BasicHttpRequest> {
   @Override
   BasicHttpRequest createRequest(String method, URI uri) {
-    return new BasicHttpRequest(method, uri.getPath())
+    return new BasicHttpRequest(method, fullPathFromURI(uri))
   }
 
   @Override
@@ -76,7 +94,7 @@ class ApacheClientHostRequestResponseHandler extends ApacheHttpClientTest<BasicH
 class ApacheClientHostRequestResponseHandlerContext extends ApacheHttpClientTest<BasicHttpRequest> {
   @Override
   BasicHttpRequest createRequest(String method, URI uri) {
-    return new BasicHttpRequest(method, uri.getPath())
+    return new BasicHttpRequest(method, fullPathFromURI(uri))
   }
 
   @Override

--- a/dd-java-agent/instrumentation/apache-httpclient-4/src/test/groovy/ApacheHttpClientTest.groovy
+++ b/dd-java-agent/instrumentation/apache-httpclient-4/src/test/groovy/ApacheHttpClientTest.groovy
@@ -1,30 +1,134 @@
 import datadog.trace.agent.test.base.HttpClientTest
 import datadog.trace.instrumentation.apachehttpclient.ApacheHttpClientDecorator
+import org.apache.http.HttpHost
+import org.apache.http.HttpRequest
+import org.apache.http.HttpResponse
 import org.apache.http.impl.client.DefaultHttpClient
 import org.apache.http.message.BasicHeader
+import org.apache.http.message.BasicHttpRequest
+import org.apache.http.protocol.BasicHttpContext
 import spock.lang.Shared
 
-class ApacheHttpClientTest extends HttpClientTest<ApacheHttpClientDecorator> {
-
+abstract class ApacheHttpClientTest<T extends HttpRequest> extends HttpClientTest<ApacheHttpClientDecorator> {
   @Shared
   def client = new DefaultHttpClient()
 
   @Override
+  ApacheHttpClientDecorator decorator() {
+    return ApacheHttpClientDecorator.DECORATE
+  }
+
+  @Override
   int doRequest(String method, URI uri, Map<String, String> headers, Closure callback) {
-    def request = new HttpUriRequest(method, uri)
+    def request = createRequest(method, uri)
     headers.entrySet().each {
       request.addHeader(new BasicHeader(it.key, it.value))
     }
 
-    def response = client.execute(request)
+    def response = executeRequest(request, uri)
     callback?.call()
     response.entity?.content?.close() // Make sure the connection is closed.
 
     return response.statusLine.statusCode
   }
 
+  abstract T createRequest(String method, URI uri)
+
+  abstract HttpResponse executeRequest(T request, URI uri)
+}
+
+class ApacheClientHostRequest extends ApacheHttpClientTest<BasicHttpRequest> {
   @Override
-  ApacheHttpClientDecorator decorator() {
-    return ApacheHttpClientDecorator.DECORATE
+  BasicHttpRequest createRequest(String method, URI uri) {
+    return new BasicHttpRequest(method, uri.getPath())
+  }
+
+  @Override
+  HttpResponse executeRequest(BasicHttpRequest request, URI uri) {
+    return client.execute(new HttpHost(uri.getHost(), uri.getPort()), request)
+  }
+}
+
+class ApacheClientHostRequestContext extends ApacheHttpClientTest<BasicHttpRequest> {
+  @Override
+  BasicHttpRequest createRequest(String method, URI uri) {
+    return new BasicHttpRequest(method, uri.getPath())
+  }
+
+  @Override
+  HttpResponse executeRequest(BasicHttpRequest request, URI uri) {
+    return client.execute(new HttpHost(uri.getHost(), uri.getPort()), request, new BasicHttpContext())
+  }
+}
+
+class ApacheClientHostRequestResponseHandler extends ApacheHttpClientTest<BasicHttpRequest> {
+  @Override
+  BasicHttpRequest createRequest(String method, URI uri) {
+    return new BasicHttpRequest(method, uri.getPath())
+  }
+
+  @Override
+  HttpResponse executeRequest(BasicHttpRequest request, URI uri) {
+    return client.execute(new HttpHost(uri.getHost(), uri.getPort()), request, { response -> response })
+  }
+}
+
+class ApacheClientHostRequestResponseHandlerContext extends ApacheHttpClientTest<BasicHttpRequest> {
+  @Override
+  BasicHttpRequest createRequest(String method, URI uri) {
+    return new BasicHttpRequest(method, uri.getPath())
+  }
+
+  @Override
+  HttpResponse executeRequest(BasicHttpRequest request, URI uri) {
+    return client.execute(new HttpHost(uri.getHost(), uri.getPort()), request, { response -> response }, new BasicHttpContext())
+  }
+}
+
+class ApacheClientUriRequest extends ApacheHttpClientTest<HttpUriRequest> {
+  @Override
+  HttpUriRequest createRequest(String method, URI uri) {
+    return new HttpUriRequest(method, uri)
+  }
+
+  @Override
+  HttpResponse executeRequest(HttpUriRequest request, URI uri) {
+    return client.execute(request)
+  }
+}
+
+class ApacheClientUriRequestContext extends ApacheHttpClientTest<HttpUriRequest> {
+  @Override
+  HttpUriRequest createRequest(String method, URI uri) {
+    return new HttpUriRequest(method, uri)
+  }
+
+  @Override
+  HttpResponse executeRequest(HttpUriRequest request, URI uri) {
+    return client.execute(request, new BasicHttpContext())
+  }
+}
+
+class ApacheClientUriRequestResponseHandler extends ApacheHttpClientTest<HttpUriRequest> {
+  @Override
+  HttpUriRequest createRequest(String method, URI uri) {
+    return new HttpUriRequest(method, uri)
+  }
+
+  @Override
+  HttpResponse executeRequest(HttpUriRequest request, URI uri) {
+    return client.execute(request, { response -> response })
+  }
+}
+
+class ApacheClientUriRequestResponseHandlerContext extends ApacheHttpClientTest<HttpUriRequest> {
+  @Override
+  HttpUriRequest createRequest(String method, URI uri) {
+    return new HttpUriRequest(method, uri)
+  }
+
+  @Override
+  HttpResponse executeRequest(HttpUriRequest request, URI uri) {
+    return client.execute(request, { response -> response })
   }
 }


### PR DESCRIPTION
Previously, we only instrumented some of the `execute(...)` methods in Apache HttpClient.  This caused missing instrumentation for both direct Apache HttpClient users and users of frameworks that used Apache HttpClient (eg Zuul)