### PR TITLE
Avoid submitting a job if executor is shutdown

### DIFF
--- a/dd-trace-ot/src/main/java/datadog/trace/common/writer/DDAgentWriter.java
+++ b/dd-trace-ot/src/main/java/datadog/trace/common/writer/DDAgentWriter.java
@@ -171,7 +171,7 @@ public class DDAgentWriter implements Writer {
   }
 
   private void scheduleFlush() {
-    if (flushFrequencySeconds > 0) {
+    if (flushFrequencySeconds > 0 && !scheduledWriterExecutor.isShutdown()) {
       final ScheduledFuture<?> previous =
           flushSchedule.getAndSet(
               scheduledWriterExecutor.schedule(flushTask, flushFrequencySeconds, SECONDS));


### PR DESCRIPTION
There’s still a possibility of a race condition and we could catch and handle the exception, but this should reduce the shutdown noise a bit.