### PR TITLE
Reduce tracer log line length - make name nicer

### DIFF
--- a/dd-java-agent/src/main/java/datadog/trace/agent/TracingAgent.java
+++ b/dd-java-agent/src/main/java/datadog/trace/agent/TracingAgent.java
@@ -28,7 +28,7 @@ public class TracingAgent {
   private static final String SIMPLE_LOGGER_DATE_TIME_FORMAT_PROPERTY =
       "datadog.slf4j.simpleLogger.dateTimeFormat";
   private static final String SIMPLE_LOGGER_DATE_TIME_FORMAT_DEFAULT =
-      "'[dd.tracing.agent - 'yyyy-MM-dd HH:mm:ss:SSS Z']'";
+      "'[dd.trace 'yyyy-MM-dd HH:mm:ss:SSS Z']'";
   private static final String SIMPLE_LOGGER_DEFAULT_LOG_LEVEL_PROPERTY =
       "datadog.slf4j.simpleLogger.defaultLogLevel";
 


### PR DESCRIPTION
While “tracing.agent” matches the class name, this applies to the whole tracer where most things are labeled just “trace” (ie, config).