### PR TITLE
Treat empty proc file as `Not Running In Container`

### DIFF
--- a/dd-trace-ot/src/main/java/datadog/opentracing/ContainerInfo.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/ContainerInfo.java
@@ -66,7 +66,8 @@ public class ContainerInfo {
   }
 
   public static boolean isRunningInContainer() {
-    return Files.isReadable(CGROUP_DEFAULT_PROCFILE);
+    return Files.isReadable(CGROUP_DEFAULT_PROCFILE)
+        && CGROUP_DEFAULT_PROCFILE.toFile().length() > 0;
   }
 
   public static ContainerInfo fromDefaultProcFile() throws IOException, ParseException {


### PR DESCRIPTION
Previously, an empty proc file cause a parse error to be thrown.  This pull request changes the behavior and treats an empty proc file the same as a missing proc file.