### PR TITLE
Health Metrics

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/Config.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/Config.java
@@ -87,6 +87,10 @@ public class Config {
   public static final String JMX_FETCH_STATSD_HOST = "jmxfetch.statsd.host";
   public static final String JMX_FETCH_STATSD_PORT = "jmxfetch.statsd.port";
 
+  public static final String HEALTH_METRICS_ENABLED = "trace.health.metrics.enabled";
+  public static final String HEALTH_METRICS_STATSD_HOST = "trace.health.metrics.statsd.host";
+  public static final String HEALTH_METRICS_STATSD_PORT = "trace.health.metrics.statsd.port";
+
   public static final String LOGS_INJECTION_ENABLED = "logs.injection";
 
   public static final String SERVICE_TAG = "service";
@@ -126,6 +130,9 @@ public class Config {
   private static final boolean DEFAULT_JMX_FETCH_ENABLED = true;
 
   public static final int DEFAULT_JMX_FETCH_STATSD_PORT = 8125;
+
+  public static final boolean DEFAULT_METRICS_ENABLED = false;
+  // No default constants for metrics statsd support -- falls back to jmx fetch values
 
   public static final boolean DEFAULT_LOGS_INJECTION_ENABLED = false;
 
@@ -189,6 +196,11 @@ public class Config {
   @Getter private final Integer jmxFetchRefreshBeansPeriod;
   @Getter private final String jmxFetchStatsdHost;
   @Getter private final Integer jmxFetchStatsdPort;
+
+  // These values are default-ed to those of jmx fetch values as needed
+  @Getter private final boolean healthMetricsEnabled;
+  @Getter private final String healthMetricsStatsdHost;
+  @Getter private final Integer healthMetricsStatsdPort;
 
   @Getter private final boolean logsInjectionEnabled;
 
@@ -299,6 +311,12 @@ public class Config {
     jmxFetchStatsdHost = getSettingFromEnvironment(JMX_FETCH_STATSD_HOST, null);
     jmxFetchStatsdPort =
         getIntegerSettingFromEnvironment(JMX_FETCH_STATSD_PORT, DEFAULT_JMX_FETCH_STATSD_PORT);
+
+    // Writer.Builder createMonitor will use the values of the JMX fetch & agent to fill-in defaults
+    healthMetricsEnabled =
+        getBooleanSettingFromEnvironment(HEALTH_METRICS_ENABLED, DEFAULT_METRICS_ENABLED);
+    healthMetricsStatsdHost = getSettingFromEnvironment(HEALTH_METRICS_STATSD_HOST, null);
+    healthMetricsStatsdPort = getIntegerSettingFromEnvironment(HEALTH_METRICS_STATSD_PORT, null);
 
     logsInjectionEnabled =
         getBooleanSettingFromEnvironment(LOGS_INJECTION_ENABLED, DEFAULT_LOGS_INJECTION_ENABLED);
@@ -416,6 +434,14 @@ public class Config {
     jmxFetchStatsdHost = properties.getProperty(JMX_FETCH_STATSD_HOST, parent.jmxFetchStatsdHost);
     jmxFetchStatsdPort =
         getPropertyIntegerValue(properties, JMX_FETCH_STATSD_PORT, parent.jmxFetchStatsdPort);
+
+    healthMetricsEnabled =
+        getPropertyBooleanValue(properties, HEALTH_METRICS_ENABLED, DEFAULT_METRICS_ENABLED);
+    healthMetricsStatsdHost =
+        properties.getProperty(HEALTH_METRICS_STATSD_HOST, parent.healthMetricsStatsdHost);
+    healthMetricsStatsdPort =
+        getPropertyIntegerValue(
+            properties, HEALTH_METRICS_STATSD_PORT, parent.healthMetricsStatsdPort);
 
     logsInjectionEnabled =
         getBooleanSettingFromEnvironment(LOGS_INJECTION_ENABLED, DEFAULT_LOGS_INJECTION_ENABLED);

--- a/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -40,6 +40,9 @@ import static datadog.trace.api.Config.TRACE_ENABLED
 import static datadog.trace.api.Config.TRACE_REPORT_HOSTNAME
 import static datadog.trace.api.Config.TRACE_RESOLVER_ENABLED
 import static datadog.trace.api.Config.WRITER_TYPE
+import static datadog.trace.api.Config.HEALTH_METRICS_ENABLED
+import static datadog.trace.api.Config.HEALTH_METRICS_STATSD_HOST
+import static datadog.trace.api.Config.HEALTH_METRICS_STATSD_PORT
 
 class ConfigTest extends DDSpecification {
   @Rule
@@ -93,6 +96,9 @@ class ConfigTest extends DDSpecification {
     config.jmxFetchRefreshBeansPeriod == null
     config.jmxFetchStatsdHost == null
     config.jmxFetchStatsdPort == DEFAULT_JMX_FETCH_STATSD_PORT
+    config.healthMetricsEnabled == false
+    config.healthMetricsStatsdHost == null
+    config.healthMetricsStatsdPort == null
     config.toString().contains("unnamed-java-app")
 
     where:
@@ -136,6 +142,9 @@ class ConfigTest extends DDSpecification {
     prop.setProperty(JMX_FETCH_REFRESH_BEANS_PERIOD, "200")
     prop.setProperty(JMX_FETCH_STATSD_HOST, "statsd host")
     prop.setProperty(JMX_FETCH_STATSD_PORT, "321")
+    prop.setProperty(HEALTH_METRICS_ENABLED, "true")
+    prop.setProperty(HEALTH_METRICS_STATSD_HOST, "metrics statsd host")
+    prop.setProperty(HEALTH_METRICS_STATSD_PORT, "654")
 
     when:
     Config config = Config.get(prop)
@@ -169,6 +178,9 @@ class ConfigTest extends DDSpecification {
     config.jmxFetchRefreshBeansPeriod == 200
     config.jmxFetchStatsdHost == "statsd host"
     config.jmxFetchStatsdPort == 321
+    config.healthMetricsEnabled == true
+    config.healthMetricsStatsdHost == "metrics statsd host"
+    config.healthMetricsStatsdPort == 654
   }
 
   def "specify overrides via system properties"() {
@@ -203,6 +215,9 @@ class ConfigTest extends DDSpecification {
     System.setProperty(PREFIX + JMX_FETCH_REFRESH_BEANS_PERIOD, "200")
     System.setProperty(PREFIX + JMX_FETCH_STATSD_HOST, "statsd host")
     System.setProperty(PREFIX + JMX_FETCH_STATSD_PORT, "321")
+    System.setProperty(PREFIX + HEALTH_METRICS_ENABLED, "true")
+    System.setProperty(PREFIX + HEALTH_METRICS_STATSD_HOST, "metrics statsd host")
+    System.setProperty(PREFIX + HEALTH_METRICS_STATSD_PORT, "654")
 
     when:
     Config config = new Config()
@@ -236,6 +251,9 @@ class ConfigTest extends DDSpecification {
     config.jmxFetchRefreshBeansPeriod == 200
     config.jmxFetchStatsdHost == "statsd host"
     config.jmxFetchStatsdPort == 321
+    config.healthMetricsEnabled == true
+    config.healthMetricsStatsdHost == "metrics statsd host"
+    config.healthMetricsStatsdPort == 654
   }
 
   def "specify overrides via env vars"() {

--- a/dd-trace-ot/dd-trace-ot.gradle
+++ b/dd-trace-ot/dd-trace-ot.gradle
@@ -33,6 +33,8 @@ dependencies {
   compile deps.opentracing
   compile group: 'io.opentracing.contrib', name: 'opentracing-tracerresolver', version: '0.1.0'
 
+  compile group: 'com.datadoghq', name: 'java-dogstatsd-client', version: '2.1.1'
+
   compile deps.jackson
   compile deps.slf4j
   compile group: 'com.squareup.okhttp3', name: 'okhttp', version: '3.11.0' // Last version to support Java7

--- a/dd-trace-ot/src/main/java/datadog/trace/common/writer/DDAgentWriter.java
+++ b/dd-trace-ot/src/main/java/datadog/trace/common/writer/DDAgentWriter.java
@@ -466,19 +466,21 @@ public class DDAgentWriter implements Writer {
     public static final String LANG_INTERPRETER_VENDOR_TAG = "lang_interpreter_vendor";
     public static final String TRACER_VERSION_TAG = "tracer_version";
 
-    private final String host;
-    private final int port;
+    private final String hostInfo;
     private final StatsDClient statsd;
 
     // DQH - Made a conscious choice to not take a Config object here.
     // Letting the creating of the Monitor take the Config,
     // so it can decide which Monitor variant to create.
-
     public StatsDMonitor(final String host, final int port) {
-      this.host = host;
-      this.port = port;
-
+      hostInfo = host + ":" + port;
       statsd = new NonBlockingStatsDClient(PREFIX, host, port, getDefaultTags());
+    }
+
+    // Currently, intended for testing
+    private StatsDMonitor(final StatsDClient statsd) {
+      hostInfo = null;
+      this.statsd = statsd;
     }
 
     protected static final String[] getDefaultTags() {
@@ -574,7 +576,11 @@ public class DDAgentWriter implements Writer {
     }
 
     public String toString() {
-      return "StatsD { host=" + host + ":" + port + " }";
+      if (hostInfo == null) {
+        return "StatsD";
+      } else {
+        return "StatsD { host=" + hostInfo + " }";
+      }
     }
   }
 }

--- a/dd-trace-ot/src/main/java/datadog/trace/common/writer/DDAgentWriter.java
+++ b/dd-trace-ot/src/main/java/datadog/trace/common/writer/DDAgentWriter.java
@@ -237,9 +237,10 @@ public class DDAgentWriter implements Writer {
               @Override
               public void run() {
                 try {
-                  final boolean sent =
+                  final DDApi.Response response =
                       api.sendSerializedTraces(representativeCount, sizeInBytes, toSend);
-                  if (sent) {
+
+                  if (response.success()) {
                     log.debug("Successfully sent {} traces to the API", toSend.size());
                   } else {
                     log.debug(

--- a/dd-trace-ot/src/main/java/datadog/trace/common/writer/DDAgentWriter.java
+++ b/dd-trace-ot/src/main/java/datadog/trace/common/writer/DDAgentWriter.java
@@ -13,7 +13,10 @@ import com.lmax.disruptor.EventTranslatorOneArg;
 import com.lmax.disruptor.SleepingWaitStrategy;
 import com.lmax.disruptor.dsl.Disruptor;
 import com.lmax.disruptor.dsl.ProducerType;
+import com.timgroup.statsd.NonBlockingStatsDClient;
+import com.timgroup.statsd.StatsDClient;
 import datadog.opentracing.DDSpan;
+import datadog.opentracing.DDTraceOTInfo;
 import datadog.trace.common.util.DaemonThreadFactory;
 import java.util.ArrayList;
 import java.util.List;
@@ -83,7 +86,8 @@ public class DDAgentWriter implements Writer {
     this(api, monitor, DISRUPTOR_BUFFER_SIZE, FLUSH_PAYLOAD_DELAY);
   }
 
-  public DDAgentWriter(final DDApi api) {
+  /** Old signature (pre-Monitor) used in tests */
+  private DDAgentWriter(final DDApi api) {
     this(api, new NoopMonitor());
   }
 
@@ -120,6 +124,19 @@ public class DDAgentWriter implements Writer {
 
     apiPhaser = new Phaser(); // Ensure API calls are completed when flushing
     apiPhaser.register(); // Register on behalf of the scheduled executor thread.
+  }
+
+  // Exposing some statistics for consumption by monitors
+  public final long getDisruptorCapacity() {
+    return disruptor.getRingBuffer().getBufferSize();
+  }
+
+  public final long getDisruptorUtilizedCapacity() {
+    return getDisruptorCapacity() - getDisruptorRemainingCapacity();
+  }
+
+  public final long getDisruptorRemainingCapacity() {
+    return disruptor.getRingBuffer().remainingCapacity();
   }
 
   @Override
@@ -209,7 +226,18 @@ public class DDAgentWriter implements Writer {
 
   @Override
   public String toString() {
-    return "DDAgentWriter { api=" + api + " }";
+    // DQH - I don't particularly like the instanceof check,
+    // but I decided it was preferable to adding an isNoop method onto
+    // Monitor or checking the result of Monitor#toString() to determine
+    // if something is *probably* the NoopMonitor.
+
+    String str = "DDAgentWriter { api=" + api;
+    if (!(monitor instanceof NoopMonitor)) {
+      str += ", monitor=" + monitor;
+    }
+    str += " }";
+
+    return str;
   }
 
   private void scheduleFlush() {
@@ -426,6 +454,127 @@ public class DDAgentWriter implements Writer {
     @Override
     public String toString() {
       return "NoOp";
+    }
+  }
+
+  public static final class StatsDMonitor implements Monitor {
+    public static final String PREFIX = "datadog.tracer";
+
+    public static final String LANG_TAG = "lang";
+    public static final String LANG_VERSION_TAG = "lang_version";
+    public static final String LANG_INTERPRETER_TAG = "lang_interpreter";
+    public static final String LANG_INTERPRETER_VENDOR_TAG = "lang_interpreter_vendor";
+    public static final String TRACER_VERSION_TAG = "tracer_version";
+
+    private final String host;
+    private final int port;
+    private final StatsDClient statsd;
+
+    // DQH - Made a conscious choice to not take a Config object here.
+    // Letting the creating of the Monitor take the Config,
+    // so it can decide which Monitor variant to create.
+
+    public StatsDMonitor(final String host, final int port) {
+      this.host = host;
+      this.port = port;
+
+      statsd = new NonBlockingStatsDClient(PREFIX, host, port, getDefaultTags());
+    }
+
+    protected static final String[] getDefaultTags() {
+      return new String[] {
+        tag(LANG_TAG, "java"),
+        tag(LANG_VERSION_TAG, DDTraceOTInfo.JAVA_VERSION),
+        tag(LANG_INTERPRETER_TAG, DDTraceOTInfo.JAVA_VM_NAME),
+        tag(LANG_INTERPRETER_VENDOR_TAG, DDTraceOTInfo.JAVA_VM_VENDOR),
+        tag(TRACER_VERSION_TAG, DDTraceOTInfo.VERSION)
+      };
+    }
+
+    private static final String tag(final String tagPrefix, final String tagValue) {
+      return tagPrefix + ":" + tagValue;
+    }
+
+    @Override
+    public void onStart(final DDAgentWriter agentWriter) {
+      statsd.recordGaugeValue("queue.max_length", agentWriter.getDisruptorCapacity());
+    }
+
+    @Override
+    public void onShutdown(final DDAgentWriter agentWriter, final boolean flushSuccess) {}
+
+    @Override
+    public void onPublish(final DDAgentWriter agentWriter, final List<DDSpan> trace) {
+      statsd.incrementCounter("queue.accepted");
+      statsd.count("queue.accepted_lengths", trace.size());
+    }
+
+    @Override
+    public void onFailedPublish(final DDAgentWriter agentWriter, final List<DDSpan> trace) {
+      statsd.incrementCounter("queue.dropped");
+    }
+
+    @Override
+    public void onScheduleFlush(final DDAgentWriter agentWriter, final boolean previousIncomplete) {
+      // not recorded
+    }
+
+    @Override
+    public void onSerialize(
+        final DDAgentWriter agentWriter, final List<DDSpan> trace, final byte[] serializedTrace) {
+      // DQH - Because of Java tracer's 2 phase acceptance and serialization scheme, this doesn't
+      // map precisely
+      statsd.count("queue.accepted_size", serializedTrace.length);
+    }
+
+    @Override
+    public void onFailedSerialize(
+        final DDAgentWriter agentWriter, final List<DDSpan> trace, final Throwable optionalCause) {
+      // TODO - DQH - make a new stat for serialization failure -- or maybe count this towards
+      // api.errors???
+    }
+
+    @Override
+    public void onSend(
+        final DDAgentWriter agentWriter,
+        final int representativeCount,
+        final int sizeInBytes,
+        final DDApi.Response response) {
+      onSendAttempt(agentWriter, representativeCount, sizeInBytes, response);
+    }
+
+    @Override
+    public void onFailedSend(
+        final DDAgentWriter agentWriter,
+        final int representativeCount,
+        final int sizeInBytes,
+        final DDApi.Response response) {
+      onSendAttempt(agentWriter, representativeCount, sizeInBytes, response);
+    }
+
+    private void onSendAttempt(
+        final DDAgentWriter agentWriter,
+        final int representativeCount,
+        final int sizeInBytes,
+        final DDApi.Response response) {
+      statsd.incrementCounter("api.requests");
+      statsd.recordGaugeValue("queue.length", representativeCount);
+      // TODO: missing queue.spans (# of spans being sent)
+      statsd.recordGaugeValue("queue.size", sizeInBytes);
+
+      if (response.exception() != null) {
+        // covers communication errors -- both not receiving a response or
+        // receiving malformed response (even when otherwise successful)
+        statsd.incrementCounter("api.errors");
+      }
+
+      if (response.status() != null) {
+        statsd.incrementCounter("api.responses", "status: " + response.status());
+      }
+    }
+
+    public String toString() {
+      return "StatsD { host=" + host + ":" + port + " }";
     }
   }
 }

--- a/dd-trace-ot/src/main/java/datadog/trace/common/writer/DDAgentWriter.java
+++ b/dd-trace-ot/src/main/java/datadog/trace/common/writer/DDAgentWriter.java
@@ -71,12 +71,20 @@ public class DDAgentWriter implements Writer {
   private final Phaser apiPhaser;
   private volatile boolean running = false;
 
+  private final Monitor monitor;
+
   public DDAgentWriter() {
-    this(new DDApi(DEFAULT_AGENT_HOST, DEFAULT_TRACE_AGENT_PORT, DEFAULT_AGENT_UNIX_DOMAIN_SOCKET));
+    this(
+        new DDApi(DEFAULT_AGENT_HOST, DEFAULT_TRACE_AGENT_PORT, DEFAULT_AGENT_UNIX_DOMAIN_SOCKET),
+        new NoopMonitor());
+  }
+
+  public DDAgentWriter(final DDApi api, final Monitor monitor) {
+    this(api, monitor, DISRUPTOR_BUFFER_SIZE, FLUSH_PAYLOAD_DELAY);
   }
 
   public DDAgentWriter(final DDApi api) {
-    this(api, DISRUPTOR_BUFFER_SIZE, FLUSH_PAYLOAD_DELAY);
+    this(api, new NoopMonitor());
   }
 
   /**
@@ -87,8 +95,17 @@ public class DDAgentWriter implements Writer {
    * @param flushFrequencySeconds value < 1 disables scheduled flushes
    */
   private DDAgentWriter(final DDApi api, final int disruptorSize, final int flushFrequencySeconds) {
+    this(api, new NoopMonitor(), disruptorSize, flushFrequencySeconds);
+  }
+
+  private DDAgentWriter(
+      final DDApi api,
+      final Monitor monitor,
+      final int disruptorSize,
+      final int flushFrequencySeconds) {
     this.api = api;
-    this.flushFrequencySeconds = flushFrequencySeconds;
+    this.monitor = monitor;
+
     disruptor =
         new Disruptor<>(
             new DisruptorEventFactory<List<DDSpan>>(),
@@ -97,7 +114,10 @@ public class DDAgentWriter implements Writer {
             ProducerType.MULTI,
             new SleepingWaitStrategy(0, TimeUnit.MILLISECONDS.toNanos(5)));
     disruptor.handleEventsWith(new TraceConsumer());
+
+    this.flushFrequencySeconds = flushFrequencySeconds;
     scheduledWriterExecutor = Executors.newScheduledThreadPool(1, SCHEDULED_FLUSH_THREAD_FACTORY);
+
     apiPhaser = new Phaser(); // Ensure API calls are completed when flushing
     apiPhaser.register(); // Register on behalf of the scheduled executor thread.
   }
@@ -107,13 +127,20 @@ public class DDAgentWriter implements Writer {
     // We can't add events after shutdown otherwise it will never complete shutting down.
     if (running) {
       final boolean published = disruptor.getRingBuffer().tryPublishEvent(TRANSLATOR, trace);
-      if (!published) {
+
+      if (published) {
+        monitor.onPublish(DDAgentWriter.this, trace);
+      } else {
         // We're discarding the trace, but we still want to count it.
         traceCount.incrementAndGet();
         log.debug("Trace written to overfilled buffer. Counted but dropping trace: {}", trace);
+
+        monitor.onFailedPublish(this, trace);
       }
     } else {
       log.debug("Trace written after shutdown. Ignoring trace: {}", trace);
+
+      monitor.onFailedPublish(this, trace);
     }
   }
 
@@ -131,11 +158,16 @@ public class DDAgentWriter implements Writer {
     disruptor.start();
     running = true;
     scheduleFlush();
+
+    monitor.onStart(this);
   }
 
   @Override
   public void close() {
     running = false;
+
+    boolean flushSuccess = true;
+
     // We have to shutdown scheduled executor first to make sure no flush events issued after
     // disruptor has been shutdown.
     // Otherwise those events will never be processed and flush call will wait forever.
@@ -144,13 +176,17 @@ public class DDAgentWriter implements Writer {
       scheduledWriterExecutor.awaitTermination(flushFrequencySeconds, SECONDS);
     } catch (final InterruptedException e) {
       log.warn("Waiting for flush executor shutdown interrupted.", e);
+
+      flushSuccess = false;
     }
-    flush();
+    flushSuccess |= flush();
     disruptor.shutdown();
+
+    monitor.onShutdown(this, flushSuccess);
   }
 
   /** This method will block until the flush is complete. */
-  public void flush() {
+  public boolean flush() {
     if (running) {
       log.info("Flushing any remaining traces.");
       // Register with the phaser so we can block until the flush completion.
@@ -159,9 +195,15 @@ public class DDAgentWriter implements Writer {
       try {
         // Allow thread to be interrupted.
         apiPhaser.awaitAdvanceInterruptibly(apiPhaser.arriveAndDeregister());
+
+        return true;
       } catch (final InterruptedException e) {
         log.warn("Waiting for flush interrupted.", e);
+
+        return false;
       }
+    } else {
+      return false;
     }
   }
 
@@ -175,9 +217,13 @@ public class DDAgentWriter implements Writer {
       final ScheduledFuture<?> previous =
           flushSchedule.getAndSet(
               scheduledWriterExecutor.schedule(flushTask, flushFrequencySeconds, SECONDS));
-      if (previous != null) {
+
+      final boolean previousIncomplete = (previous != null);
+      if (previousIncomplete) {
         previous.cancel(true);
       }
+
+      monitor.onScheduleFlush(this, previousIncomplete);
     }
   }
 
@@ -205,10 +251,16 @@ public class DDAgentWriter implements Writer {
           final byte[] serializedTrace = api.serializeTrace(trace);
           payloadSize += serializedTrace.length;
           serializedTraces.add(serializedTrace);
+
+          monitor.onSerialize(DDAgentWriter.this, trace, serializedTrace);
         } catch (final JsonProcessingException e) {
           log.warn("Error serializing trace", e);
+
+          monitor.onFailedSerialize(DDAgentWriter.this, trace, e);
         } catch (final Throwable e) {
           log.debug("Error while serializing trace", e);
+
+          monitor.onFailedSerialize(DDAgentWriter.this, trace, e);
         }
       }
       if (event.shouldFlush || payloadSize >= FLUSH_PAYLOAD_BYTES) {
@@ -242,15 +294,30 @@ public class DDAgentWriter implements Writer {
 
                   if (response.success()) {
                     log.debug("Successfully sent {} traces to the API", toSend.size());
+
+                    monitor.onSend(DDAgentWriter.this, representativeCount, sizeInBytes, response);
                   } else {
                     log.debug(
                         "Failed to send {} traces (representing {}) of size {} bytes to the API",
                         toSend.size(),
                         representativeCount,
                         sizeInBytes);
+
+                    monitor.onFailedSend(
+                        DDAgentWriter.this, representativeCount, sizeInBytes, response);
                   }
                 } catch (final Throwable e) {
                   log.debug("Failed to send traces to the API: {}", e.getMessage());
+
+                  // DQH - 10/2019 - DDApi should wrap most exceptions itself, so this really
+                  // shouldn't occur.
+                  // However, just to be safe to start, create a failed Response to handle any
+                  // spurious Throwable-s.
+                  monitor.onFailedSend(
+                      DDAgentWriter.this,
+                      representativeCount,
+                      sizeInBytes,
+                      DDApi.Response.failed(e));
                 } finally {
                   apiPhaser.arrive(); // Flush completed.
                 }
@@ -272,6 +339,93 @@ public class DDAgentWriter implements Writer {
     @Override
     public Event<T> newInstance() {
       return new Event<>();
+    }
+  }
+
+  /**
+   * Callback interface for monitoring the health of the DDAgentWriter. Provides hooks for major
+   * lifecycle events...
+   *
+   * <ul>
+   *   <li>start
+   *   <li>shutdown
+   *   <li>publishing to disruptor
+   *   <li>serializing
+   *   <li>sending to agent
+   * </ul>
+   */
+  public interface Monitor {
+    void onStart(final DDAgentWriter agentWriter);
+
+    void onShutdown(final DDAgentWriter agentWriter, final boolean flushSuccess);
+
+    void onPublish(final DDAgentWriter agentWriter, final List<DDSpan> trace);
+
+    void onFailedPublish(final DDAgentWriter agentWriter, final List<DDSpan> trace);
+
+    void onScheduleFlush(final DDAgentWriter agentWriter, final boolean previousIncomplete);
+
+    void onSerialize(
+        final DDAgentWriter agentWriter, final List<DDSpan> trace, final byte[] serializedTrace);
+
+    void onFailedSerialize(
+        final DDAgentWriter agentWriter, final List<DDSpan> trace, final Throwable optionalCause);
+
+    void onSend(
+        final DDAgentWriter agentWriter,
+        final int representativeCount,
+        final int sizeInBytes,
+        final DDApi.Response response);
+
+    void onFailedSend(
+        final DDAgentWriter agentWriter,
+        final int representativeCount,
+        final int sizeInBytes,
+        final DDApi.Response response);
+  }
+
+  public static final class NoopMonitor implements Monitor {
+    @Override
+    public void onStart(final DDAgentWriter agentWriter) {}
+
+    @Override
+    public void onShutdown(final DDAgentWriter agentWriter, final boolean flushSuccess) {}
+
+    @Override
+    public void onPublish(final DDAgentWriter agentWriter, final List<DDSpan> trace) {}
+
+    @Override
+    public void onFailedPublish(final DDAgentWriter agentWriter, final List<DDSpan> trace) {}
+
+    @Override
+    public void onScheduleFlush(
+        final DDAgentWriter agentWriter, final boolean previousIncomplete) {}
+
+    @Override
+    public void onSerialize(
+        final DDAgentWriter agentWriter, final List<DDSpan> trace, final byte[] serializedTrace) {}
+
+    @Override
+    public void onFailedSerialize(
+        final DDAgentWriter agentWriter, final List<DDSpan> trace, final Throwable optionalCause) {}
+
+    @Override
+    public void onSend(
+        final DDAgentWriter agentWriter,
+        final int representativeCount,
+        final int sizeInBytes,
+        final DDApi.Response response) {}
+
+    @Override
+    public void onFailedSend(
+        final DDAgentWriter agentWriter,
+        final int representativeCount,
+        final int sizeInBytes,
+        final DDApi.Response response) {}
+
+    @Override
+    public String toString() {
+      return "NoOp";
     }
   }
 }

--- a/dd-trace-ot/src/test/groovy/datadog/trace/api/writer/DDAgentWriterTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/trace/api/writer/DDAgentWriterTest.groovy
@@ -11,8 +11,10 @@ import datadog.trace.util.test.DDSpecification
 import spock.lang.Timeout
 
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
 
 import static datadog.opentracing.SpanFactory.newSpanOf
+import static datadog.trace.agent.test.server.http.TestHttpServer.httpServer
 import static datadog.trace.common.writer.DDAgentWriter.DISRUPTOR_BUFFER_SIZE
 
 @Timeout(20)
@@ -192,5 +194,295 @@ class DDAgentWriterTest extends DDSpecification {
     then:
     0 * _
     writer.traceCount.get() == 0
+  }
+
+  def createMinimalTrace() {
+    def minimalContext = new DDSpanContext(
+      "1",
+      "1",
+      "0",
+      "",
+      "",
+      "",
+      PrioritySampling.UNSET,
+      "",
+      Collections.emptyMap(),
+      false,
+      "",
+      Collections.emptyMap(),
+      Mock(PendingTrace),
+      Mock(DDTracer))
+    def minimalSpan = new DDSpan(0, minimalContext)
+    def minimalTrace = [minimalSpan]
+
+    return minimalTrace
+  }
+
+  def "monitor happy path"() {
+    setup:
+    def minimalTrace = createMinimalTrace()
+
+    // DQH -- need to set-up a dummy agent for the final send callback to work
+    def agent = httpServer {
+      handlers {
+        put("v0.4/traces") {
+          response.status(200).send()
+        }
+      }
+    }
+    def api = new DDApi("localhost", agent.address.port, null)
+    def monitor = Mock(DDAgentWriter.Monitor)
+    def writer = new DDAgentWriter(api, monitor)
+
+    when:
+    writer.start()
+
+    then:
+    1 * monitor.onStart(writer)
+
+    when:
+    writer.write(minimalTrace)
+    writer.flush()
+
+    then:
+    1 * monitor.onPublish(writer, minimalTrace)
+    1 * monitor.onSerialize(writer, minimalTrace, _)
+    1 * monitor.onScheduleFlush(writer, _)
+    1 * monitor.onSend(writer, 1, _, { response -> response.success() && response.status() == 200 })
+
+    when:
+    writer.close()
+
+    then:
+    1 * monitor.onShutdown(writer, true)
+
+    cleanup:
+    agent.close()
+  }
+
+  def "monitor agent returns error"() {
+    setup:
+    def minimalTrace = createMinimalTrace()
+
+    // DQH -- need to set-up a dummy agent for the final send callback to work
+    def first = true
+    def agent = httpServer {
+      handlers {
+        put("v0.4/traces") {
+          // DQH - DDApi sniffs for end point existence, so respond with 200 the first time
+          if (first) {
+            response.status(200).send()
+            first = false
+          } else {
+            response.status(500).send()
+          }
+        }
+      }
+    }
+    def api = new DDApi("localhost", agent.address.port, null)
+    def monitor = Mock(DDAgentWriter.Monitor)
+    def writer = new DDAgentWriter(api, monitor)
+
+    when:
+    writer.start()
+
+    then:
+    1 * monitor.onStart(writer)
+
+    when:
+    writer.write(minimalTrace)
+    writer.flush()
+
+    then:
+    1 * monitor.onPublish(writer, minimalTrace)
+    1 * monitor.onSerialize(writer, minimalTrace, _)
+    1 * monitor.onScheduleFlush(writer, _)
+    1 * monitor.onFailedSend(writer, 1, _, { response -> !response.success() && response.status() == 500 })
+
+    when:
+    writer.close()
+
+    then:
+    1 * monitor.onShutdown(writer, true)
+
+    cleanup:
+    agent.close()
+  }
+
+  def "unreachable agent test"() {
+    setup:
+    def minimalTrace = createMinimalTrace()
+
+    def api = new DDApi("localhost", 8192, null) {
+      DDApi.Response sendSerializedTraces(
+        int representativeCount,
+        Integer sizeInBytes,
+        List<byte[]> traces)
+      {
+        // simulating a communication failure to a server
+        return DDApi.Response.failed(new IOException("comm error"))
+      }
+    }
+    def monitor = Mock(DDAgentWriter.Monitor)
+    def writer = new DDAgentWriter(api, monitor)
+
+    when:
+    writer.start()
+
+    then:
+    1 * monitor.onStart(writer)
+
+    when:
+    writer.write(minimalTrace)
+    writer.flush()
+
+    then:
+    1 * monitor.onPublish(writer, minimalTrace)
+    1 * monitor.onSerialize(writer, minimalTrace, _)
+    1 * monitor.onScheduleFlush(writer, _)
+    1 * monitor.onFailedSend(writer, 1, _, { response -> !response.success() && response.status() == null })
+
+    when:
+    writer.close()
+
+    then:
+    1 * monitor.onShutdown(writer, true)
+  }
+
+  def "slow response test"() {
+    def numPublished = 0
+    def numFailedPublish = 0
+
+    setup:
+    def minimalTrace = createMinimalTrace()
+
+    // Need to set-up a dummy agent for the final send callback to work
+    def first = true
+    def agent = httpServer {
+      handlers {
+        put("v0.4/traces") {
+          // DDApi sniffs for end point existence, so respond quickly the first time
+          // then slowly thereafter
+
+          if (!first) {
+            // Long enough to stall the pipeline, but not long enough to fail
+            Thread.sleep(2_500)
+          }
+          response.status(200).send()
+          first = false
+        }
+      }
+    }
+    def api = new DDApi("localhost", agent.address.port, null)
+
+    // This test focuses just on failed publish, so not verifying every callback
+    def monitor = Stub(DDAgentWriter.Monitor)
+    monitor.onPublish(_, _) >> {
+      numPublished += 1
+    }
+    monitor.onFailedPublish(_, _) >> {
+      numFailedPublish += 1
+    }
+
+    def bufferSize = 32
+    def writer = new DDAgentWriter(api, monitor, bufferSize, DDAgentWriter.FLUSH_PAYLOAD_DELAY)
+    writer.start()
+
+    when:
+    // write & flush a single trace -- the slow agent response will cause
+    // additional writes to back-up the sending queue
+    writer.write(minimalTrace)
+    writer.flush()
+
+    then:
+    numPublished == 1
+    numFailedPublish == 0
+
+    when:
+    // send many traces to flood the sender queue...
+    (1..20).each {
+      writer.write(minimalTrace)
+    }
+
+    then:
+    // might spill back into the Disruptor slightly, but sender queue is currently unbounded
+    numPublished == 1 + 20
+    numFailedPublish == 0
+
+    when:
+    // now, fill-up the disruptor buffer as well
+    (1..bufferSize * 2).each {
+      writer.write(minimalTrace)
+    }
+
+    then:
+    // Disruptor still doesn't reject because the sender queue is unbounded
+    (numPublished + numFailedPublish) == (1 + 20 + bufferSize * 2)
+    numFailedPublish >= 0
+
+    cleanup:
+    writer.close()
+    agent.close()
+  }
+
+  def "multi threaded"() {
+    def numPublished = new AtomicInteger(0)
+    def numFailedPublish = new AtomicInteger(0)
+    def numRepSent = new AtomicInteger(0)
+
+    setup:
+    def minimalTrace = createMinimalTrace()
+
+    // Need to set-up a dummy agent for the final send callback to work
+    def agent = httpServer {
+      handlers {
+        put("v0.4/traces") {
+          response.status(200).send()
+        }
+      }
+    }
+    def api = new DDApi("localhost", agent.address.port, null)
+
+    // This test focuses just on failed publish, so not verifying every callback
+    def monitor = Stub(DDAgentWriter.Monitor)
+    monitor.onPublish(_, _) >> {
+      numPublished.incrementAndGet()
+    }
+    monitor.onFailedPublish(_, _) >> {
+      numFailedPublish.incrementAndGet()
+    }
+    monitor.onSend(_, _, _, _) >> { writer, repCount, sizeInBytes, response ->
+      numRepSent.addAndGet(repCount)
+    }
+
+    def writer = new DDAgentWriter(api, monitor)
+    writer.start()
+
+    when:
+    def producer = {
+      (1..100).each {
+        writer.write(minimalTrace)
+      }
+    } as Runnable
+
+    def t1 = new Thread(producer)
+    t1.start()
+
+    def t2 = new Thread(producer)
+    t2.start()
+
+    t1.join()
+    t2.join()
+
+    writer.flush()
+
+    then:
+    def totalTraces = 100 + 100
+    numPublished.get() == totalTraces
+    numRepSent.get() == totalTraces
+
+    cleanup:
+    writer.close()
+    agent.close()
   }
 }

--- a/dd-trace-ot/src/test/groovy/datadog/trace/api/writer/DDApiTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/trace/api/writer/DDApiTest.groovy
@@ -34,13 +34,15 @@ class DDApiTest extends DDSpecification {
 
     expect:
     client.tracesUrl.toString() == "http://localhost:${agent.address.port}/v0.4/traces"
-    client.sendTraces([])
+    def response = client.sendTraces([])
+    response.success()
+    response.status() == 200
 
     cleanup:
     agent.close()
   }
 
-  def "non-200 response results in false returned"() {
+  def "non-200 response"() {
     setup:
     def agent = httpServer {
       handlers {
@@ -53,7 +55,10 @@ class DDApiTest extends DDSpecification {
 
     expect:
     client.tracesUrl.toString() == "http://localhost:${agent.address.port}/v0.3/traces"
-    !client.sendTraces([])
+
+    def response = client.sendTraces([])
+    !response.success()
+    response.status() == 404
 
     cleanup:
     agent.close()
@@ -72,7 +77,7 @@ class DDApiTest extends DDSpecification {
 
     expect:
     client.tracesUrl.toString() == "http://localhost:${agent.address.port}/v0.4/traces"
-    client.sendTraces(traces)
+    client.sendTraces(traces).success()
     agent.lastRequest.contentType == "application/msgpack"
     agent.lastRequest.headers.get("Datadog-Meta-Lang") == "java"
     agent.lastRequest.headers.get("Datadog-Meta-Lang-Version") == System.getProperty("java.version", "unknown")
@@ -161,7 +166,7 @@ class DDApiTest extends DDSpecification {
 
     expect:
     client.tracesUrl.toString() == "http://localhost:${v3Agent.address.port}/v0.3/traces"
-    client.sendTraces([])
+    client.sendTraces([]).success()
 
     cleanup:
     v3Agent.close()
@@ -214,7 +219,7 @@ class DDApiTest extends DDSpecification {
     def client = new DDApi("localhost", agent.address.port, null)
 
     when:
-    def success = client.sendTraces(traces)
+    def success = client.sendTraces(traces).success()
     then:
     success
     receivedContentLength.get() == expectedLength


### PR DESCRIPTION
A cleaned-up version of the original health monitoring branch/pull request - #1049 
The approach and final result are the same, but with a hopefully less noisy and easy to follow history.

This change introduces 2 significant API additions...
- DDApi.Response
- DDAgentWriter.Monitor

DDApi.Response replaces the prior boolean return values for the DDApi send methods.
Response.success() provides the same boolean result as previously returned.
But Response also carries...
- http response status
- exception - for both failed communication & malformed agent responses
- JSON payload

That additional information is used by the new DDAgentWriter.Monitor-s for metrics gathering.

By default, DDAgentWriter uses a NoopMonitor that maintains the same behavior as before -- including designing the Monitor so the NoopMonitor will impose no additional overhead.

By changing the property: dd.trace.health.metrics.enabled to true, StatsD monitoring is enabled.

This is implemented via the other Monitor implementation StatsDMonitor which sends metrics via dogstatsd.

