### PR TITLE
Refactor JAX-RS Annotation and Spring Controller/Handler Instrumentation

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/instrumentation/api/AgentSpan.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/instrumentation/api/AgentSpan.java
@@ -17,6 +17,8 @@ public interface AgentSpan {
 
   AgentSpan addThrowable(Throwable throwable);
 
+  AgentSpan getLocalRootSpan();
+
   Context context();
 
   void finish();

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/instrumentation/api/AgentTracer.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/instrumentation/api/AgentTracer.java
@@ -178,6 +178,11 @@ public class AgentTracer {
     }
 
     @Override
+    public AgentSpan getLocalRootSpan() {
+      return this;
+    }
+
+    @Override
     public Context context() {
       return NoopContext.INSTANCE;
     }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/OpenTracing32.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/OpenTracing32.java
@@ -182,6 +182,18 @@ public final class OpenTracing32 implements TracerAPI {
     }
 
     @Override
+    public AgentSpan getLocalRootSpan() {
+      if (span instanceof MutableSpan) {
+        final MutableSpan root = ((MutableSpan) span).getLocalRootSpan();
+        if (root == span) {
+          return this;
+        }
+        return new OT32Span(root.getOperationName(), (Span) root);
+      }
+      return this;
+    }
+
+    @Override
     public OT32Context context() {
       final SpanContext context = span.context();
       return new OT32Context(context);

--- a/dd-java-agent/instrumentation/jax-rs-annotations-2/src/main/java/datadog/trace/instrumentation/jaxrs2/JaxRsAnnotationsDecorator.java
+++ b/dd-java-agent/instrumentation/jax-rs-annotations-2/src/main/java/datadog/trace/instrumentation/jaxrs2/JaxRsAnnotationsDecorator.java
@@ -51,10 +51,11 @@ public class JaxRsAnnotationsDecorator extends BaseDecorator {
     }
   }
 
-  private void updateParent(final AgentSpan span, final String resourceName) {
+  private void updateParent(AgentSpan span, final String resourceName) {
     if (span == null) {
       return;
     }
+    span = span.getLocalRootSpan();
     span.setTag(Tags.COMPONENT.getKey(), "jax-rs");
 
     if (!resourceName.isEmpty()) {

--- a/dd-java-agent/instrumentation/jax-rs-annotations-2/src/main/java/datadog/trace/instrumentation/jaxrs2/JaxRsAnnotationsInstrumentation.java
+++ b/dd-java-agent/instrumentation/jax-rs-annotations-2/src/main/java/datadog/trace/instrumentation/jaxrs2/JaxRsAnnotationsInstrumentation.java
@@ -4,6 +4,7 @@ import static datadog.trace.agent.tooling.ByteBuddyElementMatchers.safeHasSuperT
 import static datadog.trace.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.instrumentation.api.AgentTracer.activeSpan;
 import static datadog.trace.instrumentation.api.AgentTracer.startSpan;
+import static datadog.trace.instrumentation.jaxrs2.JaxRsAnnotationsDecorator.DECORATE;
 import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.declaresMethod;
 import static net.bytebuddy.matcher.ElementMatchers.isAnnotatedWith;
@@ -15,7 +16,6 @@ import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.instrumentation.api.AgentScope;
 import datadog.trace.instrumentation.api.AgentSpan;
 import java.lang.reflect.Method;
-import java.util.Collections;
 import java.util.Map;
 import javax.ws.rs.container.AsyncResponse;
 import net.bytebuddy.asm.Advice;
@@ -34,8 +34,7 @@ public final class JaxRsAnnotationsInstrumentation extends Instrumenter.Default 
 
   @Override
   public Map<String, String> contextStore() {
-    return Collections.singletonMap(
-        "javax.ws.rs.container.AsyncResponse", AgentSpan.class.getName());
+    return singletonMap("javax.ws.rs.container.AsyncResponse", AgentSpan.class.getName());
   }
 
   @Override
@@ -89,8 +88,8 @@ public final class JaxRsAnnotationsInstrumentation extends Instrumenter.Default 
         @Advice.AllArguments final Object[] args) {
       final AgentSpan span = scope.span();
       if (throwable != null) {
-        JaxRsAnnotationsDecorator.DECORATE.onError(span, throwable);
-        JaxRsAnnotationsDecorator.DECORATE.beforeFinish(span);
+        DECORATE.onError(span, throwable);
+        DECORATE.beforeFinish(span);
         span.finish();
         scope.close();
         return;
@@ -106,7 +105,7 @@ public final class JaxRsAnnotationsInstrumentation extends Instrumenter.Default 
       if (asyncResponse != null && asyncResponse.isSuspended()) {
         InstrumentationContext.get(AsyncResponse.class, AgentSpan.class).put(asyncResponse, span);
       } else {
-        JaxRsAnnotationsDecorator.DECORATE.beforeFinish(span);
+        DECORATE.beforeFinish(span);
         span.finish();
       }
       scope.close();

--- a/dd-java-agent/instrumentation/jax-rs-annotations-2/src/test/groovy/DropwizardTest.groovy
+++ b/dd-java-agent/instrumentation/jax-rs-annotations-2/src/test/groovy/DropwizardTest.groovy
@@ -22,7 +22,7 @@ import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.REDIRE
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
 class DropwizardTest extends HttpServerTest<DropwizardTestSupport, Servlet3Decorator> {
-  
+
   @Override
   DropwizardTestSupport startServer(int port) {
     def testSupport = new DropwizardTestSupport(testApp(),

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/SpringBootBasedTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/SpringBootBasedTest.groovy
@@ -94,7 +94,8 @@ class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext,
   void handlerSpan(TraceAssert trace, int index, Object parent, ServerEndpoint endpoint = SUCCESS) {
     trace.span(index) {
       serviceName expectedServiceName()
-      operationName "TestController.${endpoint.name().toLowerCase()}"
+      operationName "spring.handler"
+      resourceName "TestController.${endpoint.name().toLowerCase()}"
       spanType DDSpanTypes.HTTP_SERVER
       errored endpoint == EXCEPTION
       childOf(parent as DDSpan)


### PR DESCRIPTION
For spring:
* Move more logic to the decorator.
* Use a fixed operation name, but set the resource name.
* Rename the root span instead of the parent span (If there are other spans in between this could make a difference.)  Not sure what impact this would have if multiple controllers are called (ie, forward/include).

For Jax-rs:
* Rename the root span instead of the parent span (same concern as above with spring)