### PR TITLE
Add span when calling DataSource.getConnection with a trace.

### DIFF
--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/DataSourceDecorator.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/DataSourceDecorator.java
@@ -1,0 +1,22 @@
+package datadog.trace.instrumentation.jdbc;
+
+import datadog.trace.agent.decorator.BaseDecorator;
+
+public class DataSourceDecorator extends BaseDecorator {
+  public static final DataSourceDecorator DECORATE = new DataSourceDecorator();
+
+  @Override
+  protected String[] instrumentationNames() {
+    return new String[] {"jdbc", "jdbc-datasource"};
+  }
+
+  @Override
+  protected String component() {
+    return "java-jdbc-connection";
+  }
+
+  @Override
+  protected String spanType() {
+    return null;
+  }
+}

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/DataSourceInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/DataSourceInstrumentation.java
@@ -1,0 +1,81 @@
+package datadog.trace.instrumentation.jdbc;
+
+import static datadog.trace.agent.tooling.ByteBuddyElementMatchers.safeHasSuperType;
+import static datadog.trace.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.instrumentation.api.AgentTracer.activeSpan;
+import static datadog.trace.instrumentation.api.AgentTracer.startSpan;
+import static datadog.trace.instrumentation.jdbc.DataSourceDecorator.DECORATE;
+import static java.util.Collections.singletonMap;
+import static net.bytebuddy.matcher.ElementMatchers.isInterface;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.not;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.api.DDTags;
+import datadog.trace.instrumentation.api.AgentScope;
+import datadog.trace.instrumentation.api.AgentSpan;
+import java.util.Map;
+import javax.sql.DataSource;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+@AutoService(Instrumenter.class)
+public final class DataSourceInstrumentation extends Instrumenter.Default {
+  public DataSourceInstrumentation() {
+    super("jdbc", "jdbc-datasource");
+  }
+
+  @Override
+  public boolean defaultEnabled() {
+    return false;
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {
+      "datadog.trace.agent.decorator.BaseDecorator", packageName + ".DataSourceDecorator",
+    };
+  }
+
+  @Override
+  public ElementMatcher<TypeDescription> typeMatcher() {
+    return not(isInterface()).and(safeHasSuperType(named("javax.sql.DataSource")));
+  }
+
+  @Override
+  public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
+    return singletonMap(named("getConnection"), GetConnectionAdvice.class.getName());
+  }
+
+  public static class GetConnectionAdvice {
+
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static AgentScope start(@Advice.This final DataSource ds) {
+      if (activeSpan() == null) {
+        // Don't want to generate a new top-level span
+        return null;
+      }
+
+      final AgentSpan span = startSpan("database.connection");
+      DECORATE.afterStart(span);
+
+      span.setTag(DDTags.RESOURCE_NAME, ds.getClass().getSimpleName() + ".getConnection");
+
+      return activateSpan(span, true).setAsyncPropagation(true);
+    }
+
+    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
+    public static void stopSpan(
+        @Advice.Enter final AgentScope scope, @Advice.Thrown final Throwable throwable) {
+      if (scope == null) {
+        return;
+      }
+      DECORATE.onError(scope, throwable);
+      DECORATE.beforeFinish(scope);
+      scope.close();
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/DriverInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/DriverInstrumentation.java
@@ -64,6 +64,10 @@ public final class DriverInstrumentation extends Instrumenter.Default {
         @Advice.Argument(0) final String url,
         @Advice.Argument(1) final Properties props,
         @Advice.Return final Connection connection) {
+      if (connection == null) {
+        // Exception was probably thrown.
+        return;
+      }
       final DBInfo dbInfo = JDBCConnectionUrlParser.parse(url, props);
       JDBCMaps.connectionInfo.put(connection, dbInfo);
     }


### PR DESCRIPTION
Disabled by default, and only creates a span if existing trace detected.

To enable:
* System Property: `-Ddd.integration.jdbc.enabled=true`
* Environment Variable: `DD_INTEGRATION_JDBC_ENABLED=true`
(Or more specifically `jdbc-datasource`.)