### PR TITLE
OT 0.33 compatibility

### DIFF
--- a/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
@@ -326,8 +326,7 @@ public class DDTracer implements io.opentracing.Tracer, Closeable, datadog.trace
 
   @Override
   public Span activeSpan() {
-    final Scope active = scopeManager.active();
-    return active == null ? null : active.span();
+    return scopeManager.activeSpan();
   }
 
   @Override
@@ -630,9 +629,9 @@ public class DDTracer implements io.opentracing.Tracer, Closeable, datadog.trace
       SpanContext parentContext = parent;
       if (parentContext == null && !ignoreScope) {
         // use the Scope as parent unless overridden or ignored.
-        final Scope scope = scopeManager.active();
-        if (scope != null) {
-          parentContext = scope.span().context();
+        final Span activeSpan = scopeManager.activeSpan();
+        if (activeSpan != null) {
+          parentContext = activeSpan.context();
         }
       }
 


### PR DESCRIPTION
If a project uses `dd-trace-ot` and has OT v0.33 on its path, certain method calls result in `java.lang.NoSuchMethodError`. v0.33 removed some api methods that were only deprecated in v0.32.

This pull request modifies DDTracer to use the forward compatible methods.

In the future, we can add some tests similar to `OT31ApiTest` that tests forwards compatibility.

_Side note: `Scopemanager.activate(span, finishOnClose)` was also removed but it is only called from another method that was removed. There is no way to call it using the v0.33 api and removing it would break the v0.32 api_