### PR TITLE
Add "testCircularRedirects" option to HttpClientTest

### DIFF
--- a/dd-java-agent/instrumentation/google-http-client/src/test/groovy/AbstractGoogleHttpClientTest.groovy
+++ b/dd-java-agent/instrumentation/google-http-client/src/test/groovy/AbstractGoogleHttpClientTest.groovy
@@ -38,7 +38,7 @@ abstract class AbstractGoogleHttpClientTest extends HttpClientTest<GoogleHttpCli
   }
 
   @Override
-  boolean testRedirects() {
+  boolean testCircularRedirects() {
     // Circular redirects don't throw an exception with Google Http Client
     return false
   }

--- a/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionResponseCodeOnlyTest.groovy
+++ b/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionResponseCodeOnlyTest.groovy
@@ -23,7 +23,7 @@ class HttpUrlConnectionResponseCodeOnlyTest extends HttpClientTest<HttpUrlConnec
   }
 
   @Override
-  boolean testRedirects() {
+  boolean testCircularRedirects() {
     false
   }
 }

--- a/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionTest.groovy
+++ b/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionTest.groovy
@@ -43,7 +43,7 @@ class HttpUrlConnectionTest extends HttpClientTest<HttpUrlConnectionDecorator> {
   }
 
   @Override
-  boolean testRedirects() {
+  boolean testCircularRedirects() {
     false
   }
 

--- a/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionUseCachesFalseTest.groovy
+++ b/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionUseCachesFalseTest.groovy
@@ -31,7 +31,7 @@ class HttpUrlConnectionUseCachesFalseTest extends HttpClientTest<HttpUrlConnecti
   }
 
   @Override
-  boolean testRedirects() {
+  boolean testCircularRedirects() {
     false
   }
 }

--- a/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/SpringRestTemplateTest.groovy
+++ b/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/SpringRestTemplateTest.groovy
@@ -28,7 +28,7 @@ class SpringRestTemplateTest extends HttpClientTest<HttpUrlConnectionDecorator> 
   }
 
   @Override
-  boolean testRedirects() {
+  boolean testCircularRedirects() {
     false
   }
 

--- a/dd-java-agent/instrumentation/jax-rs-client-1.1/src/test/groovy/JaxRsClientV1Test.groovy
+++ b/dd-java-agent/instrumentation/jax-rs-client-1.1/src/test/groovy/JaxRsClientV1Test.groovy
@@ -38,7 +38,7 @@ class JaxRsClientV1Test extends HttpClientTest<JaxRsClientV1Decorator> {
     return "jax-rs.client.call"
   }
 
-  boolean testRedirects() {
+  boolean testCircularRedirects() {
     false
   }
 }

--- a/dd-java-agent/instrumentation/jax-rs-client-2.0/src/test/groovy/JaxRsClientAsyncTest.groovy
+++ b/dd-java-agent/instrumentation/jax-rs-client-2.0/src/test/groovy/JaxRsClientAsyncTest.groovy
@@ -48,10 +48,6 @@ abstract class JaxRsClientAsyncTest extends HttpClientTest<JaxRsClientDecorator>
     return "jax-rs.client.call"
   }
 
-  boolean testRedirects() {
-    false
-  }
-
   abstract ClientBuilder builder()
 }
 
@@ -61,6 +57,10 @@ class JerseyClientAsyncTest extends JaxRsClientAsyncTest {
   ClientBuilder builder() {
     return new JerseyClientBuilder()
   }
+
+  boolean testCircularRedirects() {
+    false
+  }
 }
 
 class ResteasyClientAsyncTest extends JaxRsClientAsyncTest {
@@ -69,6 +69,10 @@ class ResteasyClientAsyncTest extends JaxRsClientAsyncTest {
   ClientBuilder builder() {
     return new ResteasyClientBuilder()
   }
+
+  boolean testRedirects() {
+    false
+  }
 }
 
 class CxfClientAsyncTest extends JaxRsClientAsyncTest {
@@ -76,6 +80,10 @@ class CxfClientAsyncTest extends JaxRsClientAsyncTest {
   @Override
   ClientBuilder builder() {
     return new ClientBuilderImpl()
+  }
+
+  boolean testRedirects() {
+    false
   }
 
   boolean testConnectionFailure() {

--- a/dd-java-agent/instrumentation/jax-rs-client-2.0/src/test/groovy/JaxRsClientTest.groovy
+++ b/dd-java-agent/instrumentation/jax-rs-client-2.0/src/test/groovy/JaxRsClientTest.groovy
@@ -38,10 +38,6 @@ abstract class JaxRsClientTest extends HttpClientTest<JaxRsClientDecorator> {
     return "jax-rs.client.call"
   }
 
-  boolean testRedirects() {
-    false
-  }
-
   abstract ClientBuilder builder()
 }
 
@@ -51,6 +47,10 @@ class JerseyClientTest extends JaxRsClientTest {
   ClientBuilder builder() {
     return new JerseyClientBuilder()
   }
+
+  boolean testCircularRedirects() {
+    false
+  }
 }
 
 class ResteasyClientTest extends JaxRsClientTest {
@@ -59,6 +59,11 @@ class ResteasyClientTest extends JaxRsClientTest {
   ClientBuilder builder() {
     return new ResteasyClientBuilder()
   }
+
+  boolean testRedirects() {
+    false
+  }
+
 }
 
 class CxfClientTest extends JaxRsClientTest {
@@ -66,6 +71,10 @@ class CxfClientTest extends JaxRsClientTest {
   @Override
   ClientBuilder builder() {
     return new ClientBuilderImpl()
+  }
+
+  boolean testRedirects() {
+    false
   }
 
   boolean testConnectionFailure() {

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
@@ -211,6 +211,9 @@ abstract class HttpClientTest<DECORATOR extends HttpClientDecorator> extends Age
   }
 
   def "basic #method request with 1 redirect"() {
+    // TODO quite a few clients create an extra span for the redirect
+    // This test should handle both types or we should unify how the clients work
+
     given:
     assumeTrue(testRedirects())
     def uri = server.address.resolve("/redirect")
@@ -258,6 +261,7 @@ abstract class HttpClientTest<DECORATOR extends HttpClientDecorator> extends Age
   def "basic #method request with circular redirects"() {
     given:
     assumeTrue(testRedirects())
+    assumeTrue(testCircularRedirects())
     def uri = server.address.resolve("/circular-redirect")
 
     when:
@@ -351,6 +355,10 @@ abstract class HttpClientTest<DECORATOR extends HttpClientDecorator> extends Age
   }
 
   boolean testRedirects() {
+    true
+  }
+
+  boolean testCircularRedirects() {
     true
   }
 


### PR DESCRIPTION
Many of the clients pass the basic redirect tests but "fail" the circular redirect test.

This pull request add the explicit option to skip the circular redirect test.

Originally, this was part of a larger pull request and I decided to cherry pick it out.