### PR TITLE
Rename config key for beta/experimental instrumentation.

### DIFF
--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/DataSourceDecorator.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/DataSourceDecorator.java
@@ -7,7 +7,7 @@ public class DataSourceDecorator extends BaseDecorator {
 
   @Override
   protected String[] instrumentationNames() {
-    return new String[] {"jdbc", "jdbc-datasource"};
+    return new String[] {"jdbc-beta", "jdbc-datasource"};
   }
 
   @Override

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/DataSourceInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/DataSourceInstrumentation.java
@@ -25,7 +25,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 @AutoService(Instrumenter.class)
 public final class DataSourceInstrumentation extends Instrumenter.Default {
   public DataSourceInstrumentation() {
-    super("jdbc", "jdbc-datasource");
+    super("jdbc-beta", "jdbc-datasource");
   }
 
   @Override

--- a/dd-java-agent/instrumentation/jdbc/src/test/groovy/JDBCInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/jdbc/src/test/groovy/JDBCInstrumentationTest.groovy
@@ -26,7 +26,7 @@ import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 
 class JDBCInstrumentationTest extends AgentTestRunner {
   static {
-    System.setProperty("dd.integration.jdbc.enabled", "true")
+    System.setProperty("dd.integration.jdbc-beta.enabled", "true")
   }
 
   @Shared

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/dispatcher/RequestDispatcherDecorator.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/dispatcher/RequestDispatcherDecorator.java
@@ -7,7 +7,7 @@ public class RequestDispatcherDecorator extends BaseDecorator {
 
   @Override
   protected String[] instrumentationNames() {
-    return new String[] {"servlet", "servlet-dispatcher"};
+    return new String[] {"servlet-beta", "servlet-dispatcher"};
   }
 
   @Override

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/dispatcher/RequestDispatcherInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/dispatcher/RequestDispatcherInstrumentation.java
@@ -31,7 +31,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 @AutoService(Instrumenter.class)
 public final class RequestDispatcherInstrumentation extends Instrumenter.Default {
   public RequestDispatcherInstrumentation() {
-    super("servlet", "servlet-dispatcher");
+    super("servlet-beta", "servlet-dispatcher");
   }
 
   @Override

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/dispatcher/ServletContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/dispatcher/ServletContextInstrumentation.java
@@ -22,7 +22,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 @AutoService(Instrumenter.class)
 public final class ServletContextInstrumentation extends Instrumenter.Default {
   public ServletContextInstrumentation() {
-    super("servlet", "servlet-dispatcher");
+    super("servlet-beta", "servlet-dispatcher");
   }
 
   @Override

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/filter/FilterDecorator.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/filter/FilterDecorator.java
@@ -7,7 +7,7 @@ public class FilterDecorator extends BaseDecorator {
 
   @Override
   protected String[] instrumentationNames() {
-    return new String[] {"servlet", "servlet-filter"};
+    return new String[] {"servlet-beta", "servlet-filter"};
   }
 
   @Override

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/filter/FilterInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/filter/FilterInstrumentation.java
@@ -27,7 +27,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 @AutoService(Instrumenter.class)
 public final class FilterInstrumentation extends Instrumenter.Default {
   public FilterInstrumentation() {
-    super("servlet", "servlet-filter");
+    super("servlet-beta", "servlet-filter");
   }
 
   @Override

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/http/HttpServletDecorator.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/http/HttpServletDecorator.java
@@ -7,7 +7,7 @@ public class HttpServletDecorator extends BaseDecorator {
 
   @Override
   protected String[] instrumentationNames() {
-    return new String[] {"servlet", "servlet-service"};
+    return new String[] {"servlet-beta", "servlet-service"};
   }
 
   @Override

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/http/HttpServletInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/http/HttpServletInstrumentation.java
@@ -32,7 +32,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 @AutoService(Instrumenter.class)
 public final class HttpServletInstrumentation extends Instrumenter.Default {
   public HttpServletInstrumentation() {
-    super("servlet", "servlet-service");
+    super("servlet-beta", "servlet-service");
   }
 
   @Override

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/http/HttpServletResponseDecorator.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/http/HttpServletResponseDecorator.java
@@ -7,7 +7,7 @@ public class HttpServletResponseDecorator extends BaseDecorator {
 
   @Override
   protected String[] instrumentationNames() {
-    return new String[] {"servlet", "servlet-response"};
+    return new String[] {"servlet-beta", "servlet-response"};
   }
 
   @Override

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/http/HttpServletResponseInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/http/HttpServletResponseInstrumentation.java
@@ -29,7 +29,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 @AutoService(Instrumenter.class)
 public final class HttpServletResponseInstrumentation extends Instrumenter.Default {
   public HttpServletResponseInstrumentation() {
-    super("servlet", "servlet-response");
+    super("servlet-beta", "servlet-response");
   }
 
   @Override

--- a/dd-java-agent/instrumentation/servlet/src/test/groovy/FilterTest.groovy
+++ b/dd-java-agent/instrumentation/servlet/src/test/groovy/FilterTest.groovy
@@ -11,7 +11,7 @@ import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 
 class FilterTest extends AgentTestRunner {
   static {
-    System.setProperty("dd.integration.servlet.enabled", "true")
+    System.setProperty("dd.integration.servlet-beta.enabled", "true")
   }
 
   def "test doFilter no-parent"() {

--- a/dd-java-agent/instrumentation/servlet/src/test/groovy/HttpServletResponseTest.groovy
+++ b/dd-java-agent/instrumentation/servlet/src/test/groovy/HttpServletResponseTest.groovy
@@ -11,7 +11,7 @@ import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 
 class HttpServletResponseTest extends AgentTestRunner {
   static {
-    System.setProperty("dd.integration.servlet.enabled", "true")
+    System.setProperty("dd.integration.servlet-beta.enabled", "true")
   }
 
   @Subject

--- a/dd-java-agent/instrumentation/servlet/src/test/groovy/HttpServletTest.groovy
+++ b/dd-java-agent/instrumentation/servlet/src/test/groovy/HttpServletTest.groovy
@@ -8,7 +8,7 @@ import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 
 class HttpServletTest extends AgentTestRunner {
   static {
-    System.setProperty("dd.integration.servlet.enabled", "true")
+    System.setProperty("dd.integration.servlet-beta.enabled", "true")
   }
 
   def req = Mock(HttpServletRequest) {

--- a/dd-java-agent/instrumentation/servlet/src/test/groovy/RequestDispatcherTest.groovy
+++ b/dd-java-agent/instrumentation/servlet/src/test/groovy/RequestDispatcherTest.groovy
@@ -8,7 +8,7 @@ import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 
 class RequestDispatcherTest extends AgentTestRunner {
   static {
-    System.setProperty("dd.integration.servlet.enabled", "true")
+    System.setProperty("dd.integration.servlet-beta.enabled", "true")
   }
 
   def dispatcher = new RequestDispatcherUtils(Mock(HttpServletRequest), Mock(HttpServletResponse))


### PR DESCRIPTION
Postfix the existing config names with `-beta` for `servlet` and `jdbc`.

To avoid any risk that the config was explicitly enabled for an unrelated reason resulting in unexpected behavior when upgrading to the latest version.