### PR TITLE
Excluded classes generated by Eclipse Sisu

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
@@ -130,6 +130,7 @@ public class AgentInstaller {
             .or(nameContains("CGLIB$$"))
             .or(nameContains("javassist"))
             .or(nameContains(".asm."))
+            .or(nameContains("$__sisu"))
             .or(nameMatches("com\\.mchange\\.v2\\.c3p0\\..*Proxy"))
             .or(isAnnotatedWith(named("javax.decorator.Decorator")))
             .or(matchesConfiguredExcludes());


### PR DESCRIPTION
This change excludes classes generated by Eclipse Sisu (part of Equinox DS).

These classes are created by https://github.com/eclipse/sisu.inject/blob/master/org.eclipse.sisu.inject/src/org/eclipse/sisu/space/CloningClassSpace.java

To the best of my understanding, the generated classes extends a class for which SISU wishes to defer loading.  Interestingly, the generated class simply implements a no-arg constructor and nothing more regardless of the class being extended / deferred.