### PR TITLE
Move play-ws-1 and play-ws-2 into separate packages

### DIFF
--- a/dd-java-agent/instrumentation/play-ws-1/src/main/java/datadog/trace/instrumentation/playws1/AsyncHandlerWrapper.java
+++ b/dd-java-agent/instrumentation/play-ws-1/src/main/java/datadog/trace/instrumentation/playws1/AsyncHandlerWrapper.java
@@ -1,7 +1,7 @@
-package datadog.trace.instrumentation.playws;
+package datadog.trace.instrumentation.playws1;
 
 import static datadog.trace.instrumentation.api.AgentTracer.propagate;
-import static datadog.trace.instrumentation.playws.PlayWSClientDecorator.DECORATE;
+import static datadog.trace.instrumentation.playws1.PlayWSClientDecorator.DECORATE;
 
 import datadog.trace.context.TraceScope;
 import datadog.trace.instrumentation.api.AgentSpan;

--- a/dd-java-agent/instrumentation/play-ws-1/src/main/java/datadog/trace/instrumentation/playws1/HeadersInjectAdapter.java
+++ b/dd-java-agent/instrumentation/play-ws-1/src/main/java/datadog/trace/instrumentation/playws1/HeadersInjectAdapter.java
@@ -1,4 +1,4 @@
-package datadog.trace.instrumentation.playws;
+package datadog.trace.instrumentation.playws1;
 
 import datadog.trace.instrumentation.api.AgentPropagation;
 import play.shaded.ahc.org.asynchttpclient.Request;

--- a/dd-java-agent/instrumentation/play-ws-1/src/main/java/datadog/trace/instrumentation/playws1/PlayWSClientDecorator.java
+++ b/dd-java-agent/instrumentation/play-ws-1/src/main/java/datadog/trace/instrumentation/playws1/PlayWSClientDecorator.java
@@ -1,4 +1,4 @@
-package datadog.trace.instrumentation.playws;
+package datadog.trace.instrumentation.playws1;
 
 import datadog.trace.agent.decorator.HttpClientDecorator;
 import java.net.URI;

--- a/dd-java-agent/instrumentation/play-ws-1/src/main/java/datadog/trace/instrumentation/playws1/PlayWSClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/play-ws-1/src/main/java/datadog/trace/instrumentation/playws1/PlayWSClientInstrumentation.java
@@ -1,10 +1,10 @@
-package datadog.trace.instrumentation.playws;
+package datadog.trace.instrumentation.playws1;
 
 import static datadog.trace.agent.tooling.ByteBuddyElementMatchers.safeHasSuperType;
 import static datadog.trace.instrumentation.api.AgentTracer.propagate;
 import static datadog.trace.instrumentation.api.AgentTracer.startSpan;
-import static datadog.trace.instrumentation.playws.HeadersInjectAdapter.SETTER;
-import static datadog.trace.instrumentation.playws.PlayWSClientDecorator.DECORATE;
+import static datadog.trace.instrumentation.playws1.HeadersInjectAdapter.SETTER;
+import static datadog.trace.instrumentation.playws1.PlayWSClientDecorator.DECORATE;
 import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.named;

--- a/dd-java-agent/instrumentation/play-ws-1/src/test/groovy/PlayWSClientTest.groovy
+++ b/dd-java-agent/instrumentation/play-ws-1/src/test/groovy/PlayWSClientTest.groovy
@@ -2,7 +2,7 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.stream.ActorMaterializerSettings
 import datadog.trace.agent.test.base.HttpClientTest
-import datadog.trace.instrumentation.playws.PlayWSClientDecorator
+import datadog.trace.instrumentation.playws1.PlayWSClientDecorator
 import play.libs.ws.StandaloneWSClient
 import play.libs.ws.StandaloneWSRequest
 import play.libs.ws.StandaloneWSResponse

--- a/dd-java-agent/instrumentation/play-ws-2/src/main/java/datadog/trace/instrumentation/playws2/AsyncHandlerWrapper.java
+++ b/dd-java-agent/instrumentation/play-ws-2/src/main/java/datadog/trace/instrumentation/playws2/AsyncHandlerWrapper.java
@@ -1,7 +1,7 @@
-package datadog.trace.instrumentation.playws;
+package datadog.trace.instrumentation.playws2;
 
 import static datadog.trace.instrumentation.api.AgentTracer.propagate;
-import static datadog.trace.instrumentation.playws.PlayWSClientDecorator.DECORATE;
+import static datadog.trace.instrumentation.playws2.PlayWSClientDecorator.DECORATE;
 
 import datadog.trace.context.TraceScope;
 import datadog.trace.instrumentation.api.AgentSpan;

--- a/dd-java-agent/instrumentation/play-ws-2/src/main/java/datadog/trace/instrumentation/playws2/HeadersInjectAdapter.java
+++ b/dd-java-agent/instrumentation/play-ws-2/src/main/java/datadog/trace/instrumentation/playws2/HeadersInjectAdapter.java
@@ -1,4 +1,4 @@
-package datadog.trace.instrumentation.playws;
+package datadog.trace.instrumentation.playws2;
 
 import datadog.trace.instrumentation.api.AgentPropagation;
 import play.shaded.ahc.org.asynchttpclient.Request;

--- a/dd-java-agent/instrumentation/play-ws-2/src/main/java/datadog/trace/instrumentation/playws2/PlayWSClientDecorator.java
+++ b/dd-java-agent/instrumentation/play-ws-2/src/main/java/datadog/trace/instrumentation/playws2/PlayWSClientDecorator.java
@@ -1,4 +1,4 @@
-package datadog.trace.instrumentation.playws;
+package datadog.trace.instrumentation.playws2;
 
 import datadog.trace.agent.decorator.HttpClientDecorator;
 import java.net.URI;

--- a/dd-java-agent/instrumentation/play-ws-2/src/main/java/datadog/trace/instrumentation/playws2/PlayWSClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/play-ws-2/src/main/java/datadog/trace/instrumentation/playws2/PlayWSClientInstrumentation.java
@@ -1,10 +1,10 @@
-package datadog.trace.instrumentation.playws;
+package datadog.trace.instrumentation.playws2;
 
 import static datadog.trace.agent.tooling.ByteBuddyElementMatchers.safeHasSuperType;
 import static datadog.trace.instrumentation.api.AgentTracer.propagate;
 import static datadog.trace.instrumentation.api.AgentTracer.startSpan;
-import static datadog.trace.instrumentation.playws.HeadersInjectAdapter.SETTER;
-import static datadog.trace.instrumentation.playws.PlayWSClientDecorator.DECORATE;
+import static datadog.trace.instrumentation.playws2.HeadersInjectAdapter.SETTER;
+import static datadog.trace.instrumentation.playws2.PlayWSClientDecorator.DECORATE;
 import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.named;

--- a/dd-java-agent/instrumentation/play-ws-2/src/test/groovy/PlayWSClientTest.groovy
+++ b/dd-java-agent/instrumentation/play-ws-2/src/test/groovy/PlayWSClientTest.groovy
@@ -2,7 +2,7 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.stream.ActorMaterializerSettings
 import datadog.trace.agent.test.base.HttpClientTest
-import datadog.trace.instrumentation.playws.PlayWSClientDecorator
+import datadog.trace.instrumentation.playws2.PlayWSClientDecorator
 import play.libs.ws.StandaloneWSClient
 import play.libs.ws.StandaloneWSRequest
 import play.libs.ws.StandaloneWSResponse


### PR DESCRIPTION
The fixes the play-ws instrumentation.  Previously, both the play-ws-1 and play-ws-2 instrumentations were in the `datadog.trace.instrumentation.playws` Java package.  When the dd-java-agent jar was created, only one set of classes was included.