### PR TITLE
Replacing Advice.class references

### DIFF
--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/AkkaHttpClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/AkkaHttpClientInstrumentation.java
@@ -58,12 +58,12 @@ public final class AkkaHttpClientInstrumentation extends Instrumenter.Default {
     // This is mainly for compatibility with 10.0
     transformers.put(
         named("singleRequest").and(takesArgument(0, named("akka.http.scaladsl.model.HttpRequest"))),
-        SingleRequestAdvice.class.getName());
+        AkkaHttpClientInstrumentation.class.getName() + "$SingleRequestAdvice");
     // This is for 10.1+
     transformers.put(
         named("singleRequestImpl")
             .and(takesArgument(0, named("akka.http.scaladsl.model.HttpRequest"))),
-        SingleRequestAdvice.class.getName());
+        AkkaHttpClientInstrumentation.class.getName() + "$SingleRequestAdvice");
     return transformers;
   }
 

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/AkkaHttpServerInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/AkkaHttpServerInstrumentation.java
@@ -69,10 +69,10 @@ public final class AkkaHttpServerInstrumentation extends Instrumenter.Default {
     final Map<ElementMatcher<? super MethodDescription>, String> transformers = new HashMap<>();
     transformers.put(
         named("bindAndHandleSync").and(takesArgument(0, named("scala.Function1"))),
-        AkkaHttpSyncAdvice.class.getName());
+        AkkaHttpServerInstrumentation.class.getName() + "$AkkaHttpSyncAdvice");
     transformers.put(
         named("bindAndHandleAsync").and(takesArgument(0, named("scala.Function1"))),
-        AkkaHttpAsyncAdvice.class.getName());
+        AkkaHttpServerInstrumentation.class.getName() + "$AkkaHttpAsyncAdvice");
     return transformers;
   }
 

--- a/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientInstrumentation.java
@@ -66,7 +66,7 @@ public class ApacheHttpAsyncClientInstrumentation extends Instrumenter.Default {
             .and(takesArgument(1, named("org.apache.http.nio.protocol.HttpAsyncResponseConsumer")))
             .and(takesArgument(2, named("org.apache.http.protocol.HttpContext")))
             .and(takesArgument(3, named("org.apache.http.concurrent.FutureCallback"))),
-        ClientAdvice.class.getName());
+        ApacheHttpAsyncClientInstrumentation.class.getName() + "$ClientAdvice");
   }
 
   public static class ClientAdvice {

--- a/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/ApacheHttpClientRedirectInstrumentation.java
+++ b/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/ApacheHttpClientRedirectInstrumentation.java
@@ -40,7 +40,7 @@ public class ApacheHttpClientRedirectInstrumentation extends Instrumenter.Defaul
         isMethod()
             .and(named("getRedirect"))
             .and(takesArgument(0, named("org.apache.http.HttpRequest"))),
-        ClientRedirectAdvice.class.getName());
+        ApacheHttpClientRedirectInstrumentation.class.getName() + "$ClientRedirectAdvice");
   }
 
   public static class ClientRedirectAdvice {

--- a/dd-java-agent/instrumentation/apache-httpclient-4/src/main/java/datadog/trace/instrumentation/apachehttpclient/ApacheHttpClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/apache-httpclient-4/src/main/java/datadog/trace/instrumentation/apachehttpclient/ApacheHttpClientInstrumentation.java
@@ -75,7 +75,7 @@ public class ApacheHttpClientInstrumentation extends Instrumenter.Default {
             .and(not(isAbstract()))
             .and(takesArguments(1))
             .and(takesArgument(0, named("org.apache.http.client.methods.HttpUriRequest"))),
-        UriRequestAdvice.class.getName());
+        ApacheHttpClientInstrumentation.class.getName() + "$UriRequestAdvice");
 
     transformers.put(
         isMethod()
@@ -84,7 +84,7 @@ public class ApacheHttpClientInstrumentation extends Instrumenter.Default {
             .and(takesArguments(2))
             .and(takesArgument(0, named("org.apache.http.client.methods.HttpUriRequest")))
             .and(takesArgument(1, named("org.apache.http.protocol.HttpContext"))),
-        UriRequestAdvice.class.getName());
+        ApacheHttpClientInstrumentation.class.getName() + "$UriRequestAdvice");
 
     transformers.put(
         isMethod()
@@ -93,7 +93,7 @@ public class ApacheHttpClientInstrumentation extends Instrumenter.Default {
             .and(takesArguments(2))
             .and(takesArgument(0, named("org.apache.http.client.methods.HttpUriRequest")))
             .and(takesArgument(1, named("org.apache.http.client.ResponseHandler"))),
-        UriRequestWithHandlerAdvice.class.getName());
+        ApacheHttpClientInstrumentation.class.getName() + "$UriRequestWithHandlerAdvice");
 
     transformers.put(
         isMethod()
@@ -103,7 +103,7 @@ public class ApacheHttpClientInstrumentation extends Instrumenter.Default {
             .and(takesArgument(0, named("org.apache.http.client.methods.HttpUriRequest")))
             .and(takesArgument(1, named("org.apache.http.client.ResponseHandler")))
             .and(takesArgument(2, named("org.apache.http.protocol.HttpContext"))),
-        UriRequestWithHandlerAdvice.class.getName());
+        ApacheHttpClientInstrumentation.class.getName() + "$UriRequestWithHandlerAdvice");
 
     transformers.put(
         isMethod()
@@ -112,7 +112,7 @@ public class ApacheHttpClientInstrumentation extends Instrumenter.Default {
             .and(takesArguments(2))
             .and(takesArgument(0, named("org.apache.http.HttpHost")))
             .and(takesArgument(1, named("org.apache.http.HttpRequest"))),
-        RequestAdvice.class.getName());
+        ApacheHttpClientInstrumentation.class.getName() + "$RequestAdvice");
 
     transformers.put(
         isMethod()
@@ -122,7 +122,7 @@ public class ApacheHttpClientInstrumentation extends Instrumenter.Default {
             .and(takesArgument(0, named("org.apache.http.HttpHost")))
             .and(takesArgument(1, named("org.apache.http.HttpRequest")))
             .and(takesArgument(2, named("org.apache.http.protocol.HttpContext"))),
-        RequestAdvice.class.getName());
+        ApacheHttpClientInstrumentation.class.getName() + "$RequestAdvice");
 
     transformers.put(
         isMethod()
@@ -132,7 +132,7 @@ public class ApacheHttpClientInstrumentation extends Instrumenter.Default {
             .and(takesArgument(0, named("org.apache.http.HttpHost")))
             .and(takesArgument(1, named("org.apache.http.HttpRequest")))
             .and(takesArgument(2, named("org.apache.http.client.ResponseHandler"))),
-        RequestWithHandlerAdvice.class.getName());
+        ApacheHttpClientInstrumentation.class.getName() + "$RequestWithHandlerAdvice");
 
     transformers.put(
         isMethod()
@@ -143,7 +143,7 @@ public class ApacheHttpClientInstrumentation extends Instrumenter.Default {
             .and(takesArgument(1, named("org.apache.http.HttpRequest")))
             .and(takesArgument(2, named("org.apache.http.client.ResponseHandler")))
             .and(takesArgument(3, named("org.apache.http.protocol.HttpContext"))),
-        RequestWithHandlerAdvice.class.getName());
+        ApacheHttpClientInstrumentation.class.getName() + "$RequestWithHandlerAdvice");
 
     return transformers;
   }

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/AWSClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/AWSClientInstrumentation.java
@@ -45,7 +45,8 @@ public final class AWSClientInstrumentation extends Instrumenter.Default {
 
   @Override
   public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
-    return singletonMap(isConstructor(), AWSClientAdvice.class.getName());
+    return singletonMap(
+        isConstructor(), AWSClientInstrumentation.class.getName() + "$AWSClientAdvice");
   }
 
   public static class AWSClientAdvice {

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/AWSHttpClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/AWSHttpClientInstrumentation.java
@@ -51,7 +51,7 @@ public class AWSHttpClientInstrumentation extends Instrumenter.Default {
   public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
     return singletonMap(
         isMethod().and(not(isAbstract())).and(named("doExecute")),
-        HttpClientAdvice.class.getName());
+        AWSHttpClientInstrumentation.class.getName() + "$HttpClientAdvice");
   }
 
   public static class HttpClientAdvice {
@@ -87,7 +87,7 @@ public class AWSHttpClientInstrumentation extends Instrumenter.Default {
     public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
       return singletonMap(
           isMethod().and(not(isAbstract())).and(named("doExecute")),
-          RequestExecutorAdvice.class.getName());
+          RequestExecutorInstrumentation.class.getName() + "$RequestExecutorAdvice");
     }
 
     public static class RequestExecutorAdvice {

--- a/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java/datadog/trace/instrumentation/aws/v2/AwsClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java/datadog/trace/instrumentation/aws/v2/AwsClientInstrumentation.java
@@ -30,7 +30,8 @@ public final class AwsClientInstrumentation extends AbstractAwsClientInstrumenta
   @Override
   public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
     return singletonMap(
-        isMethod().and(isPublic()).and(named("build")), AwsBuilderAdvice.class.getName());
+        isMethod().and(isPublic()).and(named("build")),
+        AwsClientInstrumentation.class.getName() + "$AwsBuilderAdvice");
   }
 
   public static class AwsBuilderAdvice {

--- a/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java/datadog/trace/instrumentation/aws/v2/AwsHttpClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java/datadog/trace/instrumentation/aws/v2/AwsHttpClientInstrumentation.java
@@ -39,7 +39,8 @@ public final class AwsHttpClientInstrumentation extends AbstractAwsClientInstrum
   @Override
   public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
     return Collections.singletonMap(
-        isMethod().and(isPublic()).and(named("execute")), AwsHttpClientAdvice.class.getName());
+        isMethod().and(isPublic()).and(named("execute")),
+        AwsHttpClientInstrumentation.class.getName() + "$AwsHttpClientAdvice");
   }
 
   public static class AwsHttpClientAdvice {

--- a/dd-java-agent/instrumentation/couchbase-2.0/src/main/java/datadog/trace/instrumentation/couchbase/client/CouchbaseBucketInstrumentation.java
+++ b/dd-java-agent/instrumentation/couchbase-2.0/src/main/java/datadog/trace/instrumentation/couchbase/client/CouchbaseBucketInstrumentation.java
@@ -54,7 +54,7 @@ public class CouchbaseBucketInstrumentation extends Instrumenter.Default {
   public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
     return singletonMap(
         isMethod().and(isPublic()).and(returns(named("rx.Observable"))),
-        CouchbaseClientAdvice.class.getName());
+        CouchbaseBucketInstrumentation.class.getName() + "$CouchbaseClientAdvice");
   }
 
   public static class CouchbaseClientAdvice {

--- a/dd-java-agent/instrumentation/couchbase-2.0/src/main/java/datadog/trace/instrumentation/couchbase/client/CouchbaseClusterInstrumentation.java
+++ b/dd-java-agent/instrumentation/couchbase-2.0/src/main/java/datadog/trace/instrumentation/couchbase/client/CouchbaseClusterInstrumentation.java
@@ -54,7 +54,7 @@ public class CouchbaseClusterInstrumentation extends Instrumenter.Default {
   public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
     return singletonMap(
         isMethod().and(isPublic()).and(returns(named("rx.Observable"))).and(not(named("core"))),
-        CouchbaseClientAdvice.class.getName());
+        CouchbaseClusterInstrumentation.class.getName() + "$CouchbaseClientAdvice");
   }
 
   public static class CouchbaseClientAdvice {

--- a/dd-java-agent/instrumentation/couchbase-2.6/src/main/java/datadog/trace/instrumentation/couchbase/client/CouchbaseCoreInstrumentation.java
+++ b/dd-java-agent/instrumentation/couchbase-2.6/src/main/java/datadog/trace/instrumentation/couchbase/client/CouchbaseCoreInstrumentation.java
@@ -47,7 +47,7 @@ public class CouchbaseCoreInstrumentation extends Instrumenter.Default {
             .and(isPublic())
             .and(takesArgument(0, named("com.couchbase.client.core.message.CouchbaseRequest")))
             .and(named("send")),
-        CouchbaseCoreAdvice.class.getName());
+        CouchbaseCoreInstrumentation.class.getName() + "$CouchbaseCoreAdvice");
   }
 
   public static class CouchbaseCoreAdvice {

--- a/dd-java-agent/instrumentation/couchbase-2.6/src/main/java/datadog/trace/instrumentation/couchbase/client/CouchbaseNetworkInstrumentation.java
+++ b/dd-java-agent/instrumentation/couchbase-2.6/src/main/java/datadog/trace/instrumentation/couchbase/client/CouchbaseNetworkInstrumentation.java
@@ -51,7 +51,7 @@ public class CouchbaseNetworkInstrumentation extends Instrumenter.Default {
                 takesArgument(
                     0, named("com.couchbase.client.deps.io.netty.channel.ChannelHandlerContext")))
             .and(takesArgument(2, named("java.util.List"))),
-        CouchbaseNetworkAdvice.class.getName());
+        CouchbaseNetworkInstrumentation.class.getName() + "$CouchbaseNetworkAdvice");
   }
 
   public static class CouchbaseNetworkAdvice {

--- a/dd-java-agent/instrumentation/datastax-cassandra-3/src/main/java/datadog/trace/instrumentation/datastax/cassandra/CassandraClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/datastax-cassandra-3/src/main/java/datadog/trace/instrumentation/datastax/cassandra/CassandraClientInstrumentation.java
@@ -44,7 +44,7 @@ public class CassandraClientInstrumentation extends Instrumenter.Default {
   public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
     return singletonMap(
         isMethod().and(isPrivate()).and(named("newSession")).and(takesArguments(0)),
-        CassandraClientAdvice.class.getName());
+        CassandraClientInstrumentation.class.getName() + "$CassandraClientAdvice");
   }
 
   public static class CassandraClientAdvice {

--- a/dd-java-agent/instrumentation/dropwizard/dropwizard-views/src/main/java/datadog/trace/instrumentation/dropwizard/view/DropwizardViewInstrumentation.java
+++ b/dd-java-agent/instrumentation/dropwizard/dropwizard-views/src/main/java/datadog/trace/instrumentation/dropwizard/view/DropwizardViewInstrumentation.java
@@ -44,7 +44,7 @@ public final class DropwizardViewInstrumentation extends Instrumenter.Default {
             .and(named("render"))
             .and(takesArgument(0, named("io.dropwizard.views.View")))
             .and(isPublic()),
-        RenderAdvice.class.getName());
+        DropwizardViewInstrumentation.class.getName() + "$RenderAdvice");
   }
 
   public static class RenderAdvice {

--- a/dd-java-agent/instrumentation/elasticsearch/rest-5/src/main/java/datadog/trace/instrumentation/elasticsearch5/Elasticsearch5RestClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/elasticsearch/rest-5/src/main/java/datadog/trace/instrumentation/elasticsearch5/Elasticsearch5RestClientInstrumentation.java
@@ -54,7 +54,7 @@ public class Elasticsearch5RestClientInstrumentation extends Instrumenter.Defaul
             .and(takesArgument(0, named("java.lang.String"))) // method
             .and(takesArgument(1, named("java.lang.String"))) // endpoint
             .and(takesArgument(5, named("org.elasticsearch.client.ResponseListener"))),
-        ElasticsearchRestClientAdvice.class.getName());
+        Elasticsearch5RestClientInstrumentation.class.getName() + "$ElasticsearchRestClientAdvice");
   }
 
   public static class ElasticsearchRestClientAdvice {

--- a/dd-java-agent/instrumentation/elasticsearch/rest-6.4/src/main/java/datadog/trace/instrumentation/elasticsearch6_4/Elasticsearch6RestClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/elasticsearch/rest-6.4/src/main/java/datadog/trace/instrumentation/elasticsearch6_4/Elasticsearch6RestClientInstrumentation.java
@@ -54,7 +54,7 @@ public class Elasticsearch6RestClientInstrumentation extends Instrumenter.Defaul
             .and(takesArguments(2))
             .and(takesArgument(0, named("org.elasticsearch.client.Request")))
             .and(takesArgument(1, named("org.elasticsearch.client.ResponseListener"))),
-        ElasticsearchRestClientAdvice.class.getName());
+        Elasticsearch6RestClientInstrumentation.class.getName() + "$ElasticsearchRestClientAdvice");
   }
 
   public static class ElasticsearchRestClientAdvice {

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/main/java/datadog/trace/instrumentation/elasticsearch2/Elasticsearch2TransportClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/main/java/datadog/trace/instrumentation/elasticsearch2/Elasticsearch2TransportClientInstrumentation.java
@@ -62,7 +62,8 @@ public class Elasticsearch2TransportClientInstrumentation extends Instrumenter.D
             .and(takesArgument(0, named("org.elasticsearch.action.Action")))
             .and(takesArgument(1, named("org.elasticsearch.action.ActionRequest")))
             .and(takesArgument(2, named("org.elasticsearch.action.ActionListener"))),
-        ElasticsearchTransportClientAdvice.class.getName());
+        Elasticsearch2TransportClientInstrumentation.class.getName()
+            + "$ElasticsearchTransportClientAdvice");
   }
 
   public static class ElasticsearchTransportClientAdvice {

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/main/java/datadog/trace/instrumentation/elasticsearch5_3/Elasticsearch53TransportClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/main/java/datadog/trace/instrumentation/elasticsearch5_3/Elasticsearch53TransportClientInstrumentation.java
@@ -63,7 +63,8 @@ public class Elasticsearch53TransportClientInstrumentation extends Instrumenter.
             .and(takesArgument(0, named("org.elasticsearch.action.Action")))
             .and(takesArgument(1, named("org.elasticsearch.action.ActionRequest")))
             .and(takesArgument(2, named("org.elasticsearch.action.ActionListener"))),
-        ElasticsearchTransportClientAdvice.class.getName());
+        Elasticsearch53TransportClientInstrumentation.class.getName()
+            + "$ElasticsearchTransportClientAdvice");
   }
 
   public static class ElasticsearchTransportClientAdvice {

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5/src/main/java/datadog/trace/instrumentation/elasticsearch5/Elasticsearch5TransportClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5/src/main/java/datadog/trace/instrumentation/elasticsearch5/Elasticsearch5TransportClientInstrumentation.java
@@ -62,7 +62,8 @@ public class Elasticsearch5TransportClientInstrumentation extends Instrumenter.D
             .and(takesArgument(0, named("org.elasticsearch.action.Action")))
             .and(takesArgument(1, named("org.elasticsearch.action.ActionRequest")))
             .and(takesArgument(2, named("org.elasticsearch.action.ActionListener"))),
-        ElasticsearchTransportClientAdvice.class.getName());
+        Elasticsearch5TransportClientInstrumentation.class.getName()
+            + "$ElasticsearchTransportClientAdvice");
   }
 
   public static class ElasticsearchTransportClientAdvice {

--- a/dd-java-agent/instrumentation/elasticsearch/transport-6/src/main/java/datadog/trace/instrumentation/elasticsearch6/Elasticsearch6TransportClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-6/src/main/java/datadog/trace/instrumentation/elasticsearch6/Elasticsearch6TransportClientInstrumentation.java
@@ -66,7 +66,8 @@ public class Elasticsearch6TransportClientInstrumentation extends Instrumenter.D
             .and(takesArgument(0, named("org.elasticsearch.action.Action")))
             .and(takesArgument(1, named("org.elasticsearch.action.ActionRequest")))
             .and(takesArgument(2, named("org.elasticsearch.action.ActionListener"))),
-        Elasticsearch6TransportClientAdvice.class.getName());
+        Elasticsearch6TransportClientInstrumentation.class.getName()
+            + "$Elasticsearch6TransportClientAdvice");
   }
 
   public static class Elasticsearch6TransportClientAdvice {

--- a/dd-java-agent/instrumentation/glassfish/src/main/java/datadog/trace/instrumentation/glassfish/GlassFishInstrumentation.java
+++ b/dd-java-agent/instrumentation/glassfish/src/main/java/datadog/trace/instrumentation/glassfish/GlassFishInstrumentation.java
@@ -47,7 +47,7 @@ public final class GlassFishInstrumentation extends Instrumenter.Default {
   public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
     return singletonMap(
         isMethod().and(named("addToBlackList")).and(takesArguments(1)),
-        AvoidGlassFishBlacklistAdvice.class.getName());
+        GlassFishInstrumentation.class.getName() + "$AvoidGlassFishBlacklistAdvice");
   }
 
   public static class AvoidGlassFishBlacklistAdvice {

--- a/dd-java-agent/instrumentation/google-http-client/src/main/java/datadog/trace/instrumentation/googlehttpclient/GoogleHttpClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/google-http-client/src/main/java/datadog/trace/instrumentation/googlehttpclient/GoogleHttpClientInstrumentation.java
@@ -64,7 +64,7 @@ public class GoogleHttpClientInstrumentation extends Instrumenter.Default {
     final Map<ElementMatcher<? super MethodDescription>, String> transformers = new HashMap<>();
     transformers.put(
         isMethod().and(isPublic()).and(named("execute")).and(takesArguments(0)),
-        GoogleHttpClientAdvice.class.getName());
+        GoogleHttpClientInstrumentation.class.getName() + "$GoogleHttpClientAdvice");
 
     transformers.put(
         isMethod()
@@ -72,7 +72,7 @@ public class GoogleHttpClientInstrumentation extends Instrumenter.Default {
             .and(named("executeAsync"))
             .and(takesArguments(1))
             .and(takesArgument(0, (named("java.util.concurrent.Executor")))),
-        GoogleHttpClientAsyncAdvice.class.getName());
+        GoogleHttpClientInstrumentation.class.getName() + "$GoogleHttpClientAsyncAdvice");
 
     return transformers;
   }

--- a/dd-java-agent/instrumentation/grizzly-2/src/main/java/datadog/trace/instrumentation/grizzly/GrizzlyHttpHandlerInstrumentation.java
+++ b/dd-java-agent/instrumentation/grizzly-2/src/main/java/datadog/trace/instrumentation/grizzly/GrizzlyHttpHandlerInstrumentation.java
@@ -60,7 +60,7 @@ public class GrizzlyHttpHandlerInstrumentation extends Instrumenter.Default {
             .and(named("doHandle"))
             .and(takesArgument(0, named("org.glassfish.grizzly.http.server.Request")))
             .and(takesArgument(1, named("org.glassfish.grizzly.http.server.Response"))),
-        HandleAdvice.class.getName());
+        GrizzlyHttpHandlerInstrumentation.class.getName() + "$HandleAdvice");
   }
 
   public static class HandleAdvice {

--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/client/GrpcClientBuilderInstrumentation.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/client/GrpcClientBuilderInstrumentation.java
@@ -41,7 +41,9 @@ public class GrpcClientBuilderInstrumentation extends Instrumenter.Default {
 
   @Override
   public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
-    return singletonMap(isMethod().and(named("build")), AddInterceptorAdvice.class.getName());
+    return singletonMap(
+        isMethod().and(named("build")),
+        GrpcClientBuilderInstrumentation.class.getName() + "$AddInterceptorAdvice");
   }
 
   public static class AddInterceptorAdvice {

--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/GrpcServerBuilderInstrumentation.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/GrpcServerBuilderInstrumentation.java
@@ -41,7 +41,9 @@ public class GrpcServerBuilderInstrumentation extends Instrumenter.Default {
 
   @Override
   public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
-    return singletonMap(isMethod().and(named("build")), AddInterceptorAdvice.class.getName());
+    return singletonMap(
+        isMethod().and(named("build")),
+        GrpcServerBuilderInstrumentation.class.getName() + "$AddInterceptorAdvice");
   }
 
   public static class AddInterceptorAdvice {

--- a/dd-java-agent/instrumentation/hibernate/core-3.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v3_3/CriteriaInstrumentation.java
+++ b/dd-java-agent/instrumentation/hibernate/core-3.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v3_3/CriteriaInstrumentation.java
@@ -38,7 +38,7 @@ public class CriteriaInstrumentation extends AbstractHibernateInstrumentation {
   public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
     return singletonMap(
         isMethod().and(named("list").or(named("uniqueResult")).or(named("scroll"))),
-        CriteriaMethodAdvice.class.getName());
+        CriteriaInstrumentation.class.getName() + "$CriteriaMethodAdvice");
   }
 
   public static class CriteriaMethodAdvice extends V3Advice {

--- a/dd-java-agent/instrumentation/hibernate/core-3.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v3_3/QueryInstrumentation.java
+++ b/dd-java-agent/instrumentation/hibernate/core-3.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v3_3/QueryInstrumentation.java
@@ -45,7 +45,7 @@ public class QueryInstrumentation extends AbstractHibernateInstrumentation {
                     .or(named("executeUpdate"))
                     .or(named("uniqueResult"))
                     .or(named("scroll"))),
-        QueryMethodAdvice.class.getName());
+        QueryInstrumentation.class.getName() + "$QueryMethodAdvice");
   }
 
   public static class QueryMethodAdvice extends V3Advice {

--- a/dd-java-agent/instrumentation/hibernate/core-3.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v3_3/SessionFactoryInstrumentation.java
+++ b/dd-java-agent/instrumentation/hibernate/core-3.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v3_3/SessionFactoryInstrumentation.java
@@ -54,7 +54,7 @@ public class SessionFactoryInstrumentation extends AbstractHibernateInstrumentat
                     named("org.hibernate.Session")
                         .or(named("org.hibernate.StatelessSession"))
                         .or(safeHasSuperType(named("org.hibernate.Session"))))),
-        SessionFactoryAdvice.class.getName());
+        SessionFactoryInstrumentation.class.getName() + "$SessionFactoryAdvice");
   }
 
   public static class SessionFactoryAdvice extends V3Advice {

--- a/dd-java-agent/instrumentation/hibernate/core-3.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v3_3/SessionInstrumentation.java
+++ b/dd-java-agent/instrumentation/hibernate/core-3.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v3_3/SessionInstrumentation.java
@@ -58,7 +58,8 @@ public class SessionInstrumentation extends AbstractHibernateInstrumentation {
   public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
     final Map<ElementMatcher<? super MethodDescription>, String> transformers = new HashMap<>();
     transformers.put(
-        isMethod().and(named("close")).and(takesArguments(0)), SessionCloseAdvice.class.getName());
+        isMethod().and(named("close")).and(takesArguments(0)),
+        SessionInstrumentation.class.getName() + "$SessionCloseAdvice");
 
     // Session synchronous methods we want to instrument.
     transformers.put(
@@ -79,14 +80,15 @@ public class SessionInstrumentation extends AbstractHibernateInstrumentation {
                     // Lazy-load methods.
                     .or(named("immediateLoad"))
                     .or(named("internalLoad"))),
-        SessionMethodAdvice.class.getName());
+        SessionInstrumentation.class.getName() + "$SessionMethodAdvice");
+
     // Handle the non-generic 'get' separately.
     transformers.put(
         isMethod()
             .and(named("get"))
             .and(returns(named("java.lang.Object")))
             .and(takesArgument(0, named("java.lang.String"))),
-        SessionMethodAdvice.class.getName());
+        SessionInstrumentation.class.getName() + "$SessionMethodAdvice");
 
     // These methods return some object that we want to instrument, and so the Advice will pin the
     // current Span to the returned object using a ContextStore.
@@ -94,15 +96,15 @@ public class SessionInstrumentation extends AbstractHibernateInstrumentation {
         isMethod()
             .and(named("beginTransaction").or(named("getTransaction")))
             .and(returns(named("org.hibernate.Transaction"))),
-        GetTransactionAdvice.class.getName());
+        SessionInstrumentation.class.getName() + "$GetTransactionAdvice");
 
     transformers.put(
         isMethod().and(returns(safeHasSuperType(named("org.hibernate.Query")))),
-        GetQueryAdvice.class.getName());
+        SessionInstrumentation.class.getName() + "$GetQueryAdvice");
 
     transformers.put(
         isMethod().and(returns(safeHasSuperType(named("org.hibernate.Criteria")))),
-        GetCriteriaAdvice.class.getName());
+        SessionInstrumentation.class.getName() + "$GetCriteriaAdvice");
 
     return transformers;
   }

--- a/dd-java-agent/instrumentation/hibernate/core-3.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v3_3/TransactionInstrumentation.java
+++ b/dd-java-agent/instrumentation/hibernate/core-3.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v3_3/TransactionInstrumentation.java
@@ -38,7 +38,7 @@ public class TransactionInstrumentation extends AbstractHibernateInstrumentation
   public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
     return singletonMap(
         isMethod().and(named("commit")).and(takesArguments(0)),
-        TransactionCommitAdvice.class.getName());
+        TransactionInstrumentation.class.getName() + "$TransactionCommitAdvice");
   }
 
   public static class TransactionCommitAdvice extends V3Advice {

--- a/dd-java-agent/instrumentation/hibernate/core-4.0/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_0/CriteriaInstrumentation.java
+++ b/dd-java-agent/instrumentation/hibernate/core-4.0/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_0/CriteriaInstrumentation.java
@@ -38,7 +38,7 @@ public class CriteriaInstrumentation extends AbstractHibernateInstrumentation {
   public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
     return singletonMap(
         isMethod().and(named("list").or(named("uniqueResult")).or(named("scroll"))),
-        CriteriaMethodAdvice.class.getName());
+        CriteriaInstrumentation.class.getName() + "$CriteriaMethodAdvice");
   }
 
   public static class CriteriaMethodAdvice extends V4Advice {

--- a/dd-java-agent/instrumentation/hibernate/core-4.0/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_0/QueryInstrumentation.java
+++ b/dd-java-agent/instrumentation/hibernate/core-4.0/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_0/QueryInstrumentation.java
@@ -45,7 +45,7 @@ public class QueryInstrumentation extends AbstractHibernateInstrumentation {
                     .or(named("executeUpdate"))
                     .or(named("uniqueResult"))
                     .or(named("scroll"))),
-        QueryMethodAdvice.class.getName());
+        QueryInstrumentation.class.getName() + "$QueryMethodAdvice");
   }
 
   public static class QueryMethodAdvice extends V4Advice {

--- a/dd-java-agent/instrumentation/hibernate/core-4.0/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_0/SessionFactoryInstrumentation.java
+++ b/dd-java-agent/instrumentation/hibernate/core-4.0/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_0/SessionFactoryInstrumentation.java
@@ -46,7 +46,7 @@ public class SessionFactoryInstrumentation extends AbstractHibernateInstrumentat
             .and(
                 returns(
                     named("org.hibernate.Session").or(named("org.hibernate.StatelessSession")))),
-        SessionFactoryAdvice.class.getName());
+        SessionFactoryInstrumentation.class.getName() + "$SessionFactoryAdvice");
   }
 
   public static class SessionFactoryAdvice extends V4Advice {

--- a/dd-java-agent/instrumentation/hibernate/core-4.0/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_0/SessionInstrumentation.java
+++ b/dd-java-agent/instrumentation/hibernate/core-4.0/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_0/SessionInstrumentation.java
@@ -53,7 +53,8 @@ public class SessionInstrumentation extends AbstractHibernateInstrumentation {
   public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
     final Map<ElementMatcher<? super MethodDescription>, String> transformers = new HashMap<>();
     transformers.put(
-        isMethod().and(named("close")).and(takesArguments(0)), SessionCloseAdvice.class.getName());
+        isMethod().and(named("close")).and(takesArguments(0)),
+        SessionInstrumentation.class.getName() + "$SessionCloseAdvice");
 
     // Session synchronous methods we want to instrument.
     transformers.put(
@@ -74,14 +75,14 @@ public class SessionInstrumentation extends AbstractHibernateInstrumentation {
                     // Lazy-load methods.
                     .or(named("immediateLoad"))
                     .or(named("internalLoad"))),
-        SessionMethodAdvice.class.getName());
+        SessionInstrumentation.class.getName() + "$SessionMethodAdvice");
     // Handle the non-generic 'get' separately.
     transformers.put(
         isMethod()
             .and(named("get"))
             .and(returns(named("java.lang.Object")))
             .and(takesArgument(0, named("java.lang.String"))),
-        SessionMethodAdvice.class.getName());
+        SessionInstrumentation.class.getName() + "$SessionMethodAdvice");
 
     // These methods return some object that we want to instrument, and so the Advice will pin the
     // current Span to the returned object using a ContextStore.
@@ -89,15 +90,15 @@ public class SessionInstrumentation extends AbstractHibernateInstrumentation {
         isMethod()
             .and(named("beginTransaction").or(named("getTransaction")))
             .and(returns(named("org.hibernate.Transaction"))),
-        GetTransactionAdvice.class.getName());
+        SessionInstrumentation.class.getName() + "$GetTransactionAdvice");
 
     transformers.put(
         isMethod().and(returns(safeHasSuperType(named("org.hibernate.Query")))),
-        GetQueryAdvice.class.getName());
+        SessionInstrumentation.class.getName() + "$GetQueryAdvice");
 
     transformers.put(
         isMethod().and(returns(safeHasSuperType(named("org.hibernate.Criteria")))),
-        GetCriteriaAdvice.class.getName());
+        SessionInstrumentation.class.getName() + "$GetCriteriaAdvice");
 
     return transformers;
   }

--- a/dd-java-agent/instrumentation/hibernate/core-4.0/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_0/TransactionInstrumentation.java
+++ b/dd-java-agent/instrumentation/hibernate/core-4.0/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_0/TransactionInstrumentation.java
@@ -38,7 +38,7 @@ public class TransactionInstrumentation extends AbstractHibernateInstrumentation
   public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
     return singletonMap(
         isMethod().and(named("commit")).and(takesArguments(0)),
-        TransactionCommitAdvice.class.getName());
+        TransactionInstrumentation.class.getName() + "$TransactionCommitAdvice");
   }
 
   public static class TransactionCommitAdvice extends V4Advice {

--- a/dd-java-agent/instrumentation/hibernate/core-4.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_3/ProcedureCallInstrumentation.java
+++ b/dd-java-agent/instrumentation/hibernate/core-4.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_3/ProcedureCallInstrumentation.java
@@ -53,7 +53,8 @@ public class ProcedureCallInstrumentation extends Instrumenter.Default {
   @Override
   public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
     return singletonMap(
-        isMethod().and(named("getOutputs")), ProcedureCallMethodAdvice.class.getName());
+        isMethod().and(named("getOutputs")),
+        ProcedureCallInstrumentation.class.getName() + "$ProcedureCallMethodAdvice");
   }
 
   public static class ProcedureCallMethodAdvice {

--- a/dd-java-agent/instrumentation/hibernate/core-4.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_3/SessionInstrumentation.java
+++ b/dd-java-agent/instrumentation/hibernate/core-4.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_3/SessionInstrumentation.java
@@ -62,7 +62,7 @@ public class SessionInstrumentation extends Instrumenter.Default {
 
     transformers.put(
         isMethod().and(returns(safeHasSuperType(named("org.hibernate.procedure.ProcedureCall")))),
-        GetProcedureCallAdvice.class.getName());
+        SessionInstrumentation.class.getName() + "$GetProcedureCallAdvice");
 
     return transformers;
   }

--- a/dd-java-agent/instrumentation/http-url-connection/src/main/java/datadog/trace/instrumentation/http_url_connection/HttpUrlConnectionInstrumentation.java
+++ b/dd-java-agent/instrumentation/http-url-connection/src/main/java/datadog/trace/instrumentation/http_url_connection/HttpUrlConnectionInstrumentation.java
@@ -64,7 +64,7 @@ public class HttpUrlConnectionInstrumentation extends Instrumenter.Default {
         isMethod()
             .and(isPublic())
             .and(named("connect").or(named("getOutputStream")).or(named("getInputStream"))),
-        HttpUrlConnectionAdvice.class.getName());
+        HttpUrlConnectionInstrumentation.class.getName() + "$HttpUrlConnectionAdvice");
   }
 
   public static class HttpUrlConnectionAdvice {

--- a/dd-java-agent/instrumentation/http-url-connection/src/main/java/datadog/trace/instrumentation/http_url_connection/UrlInstrumentation.java
+++ b/dd-java-agent/instrumentation/http-url-connection/src/main/java/datadog/trace/instrumentation/http_url_connection/UrlInstrumentation.java
@@ -3,10 +3,7 @@ package datadog.trace.instrumentation.http_url_connection;
 import static datadog.trace.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.instrumentation.api.AgentTracer.startSpan;
 import static java.util.Collections.singletonMap;
-import static net.bytebuddy.matcher.ElementMatchers.is;
-import static net.bytebuddy.matcher.ElementMatchers.isMethod;
-import static net.bytebuddy.matcher.ElementMatchers.isPublic;
-import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.*;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
@@ -43,7 +40,7 @@ public class UrlInstrumentation extends Instrumenter.Default {
   public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
     return singletonMap(
         isMethod().and(isPublic()).and(named("openConnection")),
-        ConnectionErrorAdvice.class.getName());
+        UrlInstrumentation.class.getName() + "$ConnectionErrorAdvice");
   }
 
   public static class ConnectionErrorAdvice {

--- a/dd-java-agent/instrumentation/hystrix-1.4/src/main/java/datadog/trace/instrumentation/hystrix/HystrixInstrumentation.java
+++ b/dd-java-agent/instrumentation/hystrix-1.4/src/main/java/datadog/trace/instrumentation/hystrix/HystrixInstrumentation.java
@@ -52,10 +52,10 @@ public class HystrixInstrumentation extends Instrumenter.Default {
     final Map<ElementMatcher.Junction<MethodDescription>, String> transformers = new HashMap<>();
     transformers.put(
         named("getExecutionObservable").and(returns(named("rx.Observable"))),
-        ExecuteAdvice.class.getName());
+        HystrixInstrumentation.class.getName() + "$ExecuteAdvice");
     transformers.put(
         named("getFallbackObservable").and(returns(named("rx.Observable"))),
-        FallbackAdvice.class.getName());
+        HystrixInstrumentation.class.getName() + "$FallbackAdvice");
     return transformers;
   }
 

--- a/dd-java-agent/instrumentation/hystrix-1.4/src/main/java/datadog/trace/instrumentation/hystrix/HystrixThreadPoolInstrumentation.java
+++ b/dd-java-agent/instrumentation/hystrix-1.4/src/main/java/datadog/trace/instrumentation/hystrix/HystrixThreadPoolInstrumentation.java
@@ -32,7 +32,7 @@ public class HystrixThreadPoolInstrumentation extends Instrumenter.Default {
   public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
     return singletonMap(
         isMethod().and(named("schedule")).and(takesArguments(1)),
-        EnableAsyncAdvice.class.getName());
+        HystrixThreadPoolInstrumentation.class.getName() + "$EnableAsyncAdvice");
   }
 
   public static class EnableAsyncAdvice {

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/AkkaExecutorInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/AkkaExecutorInstrumentation.java
@@ -41,15 +41,15 @@ public final class AkkaExecutorInstrumentation extends AbstractExecutorInstrumen
     transformers.put(
         named("execute")
             .and(takesArgument(0, named(AkkaForkJoinTaskInstrumentation.TASK_CLASS_NAME))),
-        SetAkkaForkJoinStateAdvice.class.getName());
+        AkkaExecutorInstrumentation.class.getName() + "$SetAkkaForkJoinStateAdvice");
     transformers.put(
         named("submit")
             .and(takesArgument(0, named(AkkaForkJoinTaskInstrumentation.TASK_CLASS_NAME))),
-        SetAkkaForkJoinStateAdvice.class.getName());
+        AkkaExecutorInstrumentation.class.getName() + "$SetAkkaForkJoinStateAdvice");
     transformers.put(
         nameMatches("invoke")
             .and(takesArgument(0, named(AkkaForkJoinTaskInstrumentation.TASK_CLASS_NAME))),
-        SetAkkaForkJoinStateAdvice.class.getName());
+        AkkaExecutorInstrumentation.class.getName() + "$SetAkkaForkJoinStateAdvice");
     return transformers;
   }
 

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/AkkaForkJoinTaskInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/AkkaForkJoinTaskInstrumentation.java
@@ -67,7 +67,7 @@ public final class AkkaForkJoinTaskInstrumentation extends Instrumenter.Default 
   public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
     return singletonMap(
         named("exec").and(takesArguments(0)).and(not(isAbstract())),
-        ForkJoinTaskAdvice.class.getName());
+        AkkaForkJoinTaskInstrumentation.class.getName() + "$ForkJoinTaskAdvice");
   }
 
   public static class ForkJoinTaskAdvice {

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/AsyncPropagatingDisableInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/AsyncPropagatingDisableInstrumentation.java
@@ -78,7 +78,9 @@ public final class AsyncPropagatingDisableInstrumentation implements Instrumente
 
     @Override
     public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
-      return singletonMap(methodMatcher, DisableAsyncAdvice.class.getName());
+      return singletonMap(
+          methodMatcher,
+          AsyncPropagatingDisableInstrumentation.class.getName() + "$DisableAsyncAdvice");
     }
   }
 

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/FutureInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/FutureInstrumentation.java
@@ -103,7 +103,8 @@ public final class FutureInstrumentation extends Instrumenter.Default {
   @Override
   public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
     return singletonMap(
-        named("cancel").and(returns(boolean.class)), CanceledFutureAdvice.class.getName());
+        named("cancel").and(returns(boolean.class)),
+        FutureInstrumentation.class.getName() + "$CanceledFutureAdvice");
   }
 
   public static class CanceledFutureAdvice {

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/JavaExecutorInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/JavaExecutorInstrumentation.java
@@ -44,31 +44,32 @@ public final class JavaExecutorInstrumentation extends AbstractExecutorInstrumen
     final Map<ElementMatcher<? super MethodDescription>, String> transformers = new HashMap<>();
     transformers.put(
         named("execute").and(takesArgument(0, Runnable.class)),
-        SetExecuteRunnableStateAdvice.class.getName());
+        JavaExecutorInstrumentation.class.getName() + "$SetExecuteRunnableStateAdvice");
     transformers.put(
         named("execute").and(takesArgument(0, ForkJoinTask.class)),
-        SetJavaForkJoinStateAdvice.class.getName());
+        JavaExecutorInstrumentation.class.getName() + "$SetJavaForkJoinStateAdvice");
     transformers.put(
         named("submit").and(takesArgument(0, Runnable.class)),
-        SetSubmitRunnableStateAdvice.class.getName());
+        JavaExecutorInstrumentation.class.getName() + "$SetSubmitRunnableStateAdvice");
     transformers.put(
         named("submit").and(takesArgument(0, Callable.class)),
-        SetCallableStateAdvice.class.getName());
+        JavaExecutorInstrumentation.class.getName() + "$SetCallableStateAdvice");
     transformers.put(
         named("submit").and(takesArgument(0, ForkJoinTask.class)),
-        SetJavaForkJoinStateAdvice.class.getName());
+        JavaExecutorInstrumentation.class.getName() + "$SetJavaForkJoinStateAdvice");
     transformers.put(
         nameMatches("invoke(Any|All)$").and(takesArgument(0, Collection.class)),
-        SetCallableStateForCallableCollectionAdvice.class.getName());
+        JavaExecutorInstrumentation.class.getName()
+            + "$SetCallableStateForCallableCollectionAdvice");
     transformers.put(
         nameMatches("invoke").and(takesArgument(0, ForkJoinTask.class)),
-        SetJavaForkJoinStateAdvice.class.getName());
+        JavaExecutorInstrumentation.class.getName() + "$SetJavaForkJoinStateAdvice");
     transformers.put(
         named("schedule").and(takesArgument(0, Runnable.class)),
-        SetSubmitRunnableStateAdvice.class.getName());
+        JavaExecutorInstrumentation.class.getName() + "$SetSubmitRunnableStateAdvice");
     transformers.put(
         named("schedule").and(takesArgument(0, Callable.class)),
-        SetCallableStateAdvice.class.getName());
+        JavaExecutorInstrumentation.class.getName() + "$SetCallableStateAdvice");
     return transformers;
   }
 

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/JavaForkJoinTaskInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/JavaForkJoinTaskInstrumentation.java
@@ -65,7 +65,7 @@ public final class JavaForkJoinTaskInstrumentation extends Instrumenter.Default 
     final Map<ElementMatcher<? super MethodDescription>, String> transformers = new HashMap<>();
     transformers.put(
         named("exec").and(takesArguments(0)).and(not(isAbstract())),
-        ForkJoinTaskAdvice.class.getName());
+        JavaForkJoinTaskInstrumentation.class.getName() + "$ForkJoinTaskAdvice");
     return transformers;
   }
 

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/NonStandardExecutorInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/NonStandardExecutorInstrumentation.java
@@ -32,10 +32,11 @@ public final class NonStandardExecutorInstrumentation extends AbstractExecutorIn
         named("dispatch")
             .and(takesArgument(0, Runnable.class))
             .and(takesArgument(1, named("kotlinx.coroutines.scheduling.TaskContext"))),
-        JavaExecutorInstrumentation.SetExecuteRunnableStateAdvice.class.getName());
+        JavaExecutorInstrumentation.class.getName() + "$SetExecuteRunnableStateAdvice");
+
     transformers.put( // org.eclipse.jetty.util.thread.QueuedThreadPool
         named("dispatch").and(takesArguments(1)).and(takesArgument(0, Runnable.class)),
-        JavaExecutorInstrumentation.SetExecuteRunnableStateAdvice.class.getName());
+        JavaExecutorInstrumentation.class.getName() + "$SetExecuteRunnableStateAdvice");
     return transformers;
   }
 }

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/RunnableCallableInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/RunnableCallableInstrumentation.java
@@ -57,9 +57,11 @@ public final class RunnableCallableInstrumentation extends Instrumenter.Default 
   public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
     final Map<ElementMatcher<? super MethodDescription>, String> transformers = new HashMap<>();
     transformers.put(
-        named("run").and(takesArguments(0)).and(isPublic()), RunnableAdvice.class.getName());
+        named("run").and(takesArguments(0)).and(isPublic()),
+        RunnableCallableInstrumentation.class.getName() + "$RunnableAdvice");
     transformers.put(
-        named("call").and(takesArguments(0)).and(isPublic()), CallableAdvice.class.getName());
+        named("call").and(takesArguments(0)).and(isPublic()),
+        RunnableCallableInstrumentation.class.getName() + "$CallableAdvice");
     return transformers;
   }
 

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/ScalaExecutorInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/ScalaExecutorInstrumentation.java
@@ -41,15 +41,15 @@ public final class ScalaExecutorInstrumentation extends AbstractExecutorInstrume
     transformers.put(
         named("execute")
             .and(takesArgument(0, named(ScalaForkJoinTaskInstrumentation.TASK_CLASS_NAME))),
-        SetScalaForkJoinStateAdvice.class.getName());
+        ScalaExecutorInstrumentation.class.getName() + "$SetScalaForkJoinStateAdvice");
     transformers.put(
         named("submit")
             .and(takesArgument(0, named(ScalaForkJoinTaskInstrumentation.TASK_CLASS_NAME))),
-        SetScalaForkJoinStateAdvice.class.getName());
+        ScalaExecutorInstrumentation.class.getName() + "$SetScalaForkJoinStateAdvice");
     transformers.put(
         nameMatches("invoke")
             .and(takesArgument(0, named(ScalaForkJoinTaskInstrumentation.TASK_CLASS_NAME))),
-        SetScalaForkJoinStateAdvice.class.getName());
+        ScalaExecutorInstrumentation.class.getName() + "$SetScalaForkJoinStateAdvice");
     return transformers;
   }
 

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/ScalaForkJoinTaskInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/ScalaForkJoinTaskInstrumentation.java
@@ -67,7 +67,7 @@ public final class ScalaForkJoinTaskInstrumentation extends Instrumenter.Default
     final Map<ElementMatcher<? super MethodDescription>, String> transformers = new HashMap<>();
     transformers.put(
         named("exec").and(takesArguments(0)).and(not(isAbstract())),
-        ForkJoinTaskAdvice.class.getName());
+        ScalaForkJoinTaskInstrumentation.class.getName() + "$ForkJoinTaskAdvice");
     return transformers;
   }
 

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/ThreadPoolExecutorInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/ThreadPoolExecutorInstrumentation.java
@@ -50,7 +50,7 @@ public class ThreadPoolExecutorInstrumentation extends Instrumenter.Default {
         isConstructor()
             .and(takesArgument(4, named("java.util.concurrent.BlockingQueue")))
             .and(takesArguments(7)),
-        ThreadPoolExecutorAdvice.class.getName());
+        ThreadPoolExecutorInstrumentation.class.getName() + "$ThreadPoolExecutorAdvice");
   }
 
   public static class ThreadPoolExecutorAdvice {

--- a/dd-java-agent/instrumentation/jax-rs-annotations-1/src/main/java/datadog/trace/instrumentation/jaxrs1/JaxRsAnnotationsInstrumentation.java
+++ b/dd-java-agent/instrumentation/jax-rs-annotations-1/src/main/java/datadog/trace/instrumentation/jaxrs1/JaxRsAnnotationsInstrumentation.java
@@ -63,7 +63,7 @@ public final class JaxRsAnnotationsInstrumentation extends Instrumenter.Default 
                 .or(named("javax.ws.rs.OPTIONS"))
                 .or(named("javax.ws.rs.POST"))
                 .or(named("javax.ws.rs.PUT"))),
-        JaxRsAnnotationsAdvice.class.getName());
+        JaxRsAnnotationsInstrumentation.class.getName() + "$JaxRsAnnotationsAdvice");
   }
 
   public static class JaxRsAnnotationsAdvice {

--- a/dd-java-agent/instrumentation/jax-rs-annotations-2/src/main/java/datadog/trace/instrumentation/jaxrs2/JaxRsAnnotationsInstrumentation.java
+++ b/dd-java-agent/instrumentation/jax-rs-annotations-2/src/main/java/datadog/trace/instrumentation/jaxrs2/JaxRsAnnotationsInstrumentation.java
@@ -62,7 +62,7 @@ public final class JaxRsAnnotationsInstrumentation extends Instrumenter.Default 
                 .or(named("javax.ws.rs.OPTIONS"))
                 .or(named("javax.ws.rs.POST"))
                 .or(named("javax.ws.rs.PUT"))),
-        JaxRsAnnotationsAdvice.class.getName());
+        JaxRsAnnotationsInstrumentation.class.getName() + "$JaxRsAnnotationsAdvice");
   }
 
   public static class JaxRsAnnotationsAdvice {

--- a/dd-java-agent/instrumentation/jax-rs-annotations-2/src/main/java/datadog/trace/instrumentation/jaxrs2/JaxRsAsyncResponseInstrumentation.java
+++ b/dd-java-agent/instrumentation/jax-rs-annotations-2/src/main/java/datadog/trace/instrumentation/jaxrs2/JaxRsAsyncResponseInstrumentation.java
@@ -50,11 +50,13 @@ public final class JaxRsAsyncResponseInstrumentation extends Instrumenter.Defaul
     final Map<ElementMatcher<? super MethodDescription>, String> transformers = new HashMap<>();
     transformers.put(
         named("resume").and(takesArgument(0, Object.class)).and(isPublic()),
-        AsyncResponseAdvice.class.getName());
+        JaxRsAsyncResponseInstrumentation.class.getName() + "$AsyncResponseAdvice");
     transformers.put(
         named("resume").and(takesArgument(0, Throwable.class)).and(isPublic()),
-        AsyncResponseThrowableAdvice.class.getName());
-    transformers.put(named("cancel"), AsyncResponseCancelAdvice.class.getName());
+        JaxRsAsyncResponseInstrumentation.class.getName() + "$AsyncResponseThrowableAdvice");
+    transformers.put(
+        named("cancel"),
+        JaxRsAsyncResponseInstrumentation.class.getName() + "$AsyncResponseCancelAdvice");
     return transformers;
   }
 

--- a/dd-java-agent/instrumentation/jax-rs-client-1.1/src/main/java/datadog/trace/instrumentation/jaxrs/v1/JaxRsClientV1Instrumentation.java
+++ b/dd-java-agent/instrumentation/jax-rs-client-1.1/src/main/java/datadog/trace/instrumentation/jaxrs/v1/JaxRsClientV1Instrumentation.java
@@ -57,7 +57,7 @@ public final class JaxRsClientV1Instrumentation extends Instrumenter.Default {
                 takesArgument(
                     0, safeHasSuperType(named("com.sun.jersey.api.client.ClientRequest"))))
             .and(returns(safeHasSuperType(named("com.sun.jersey.api.client.ClientResponse")))),
-        HandleAdvice.class.getName());
+        JaxRsClientV1Instrumentation.class.getName() + "$HandleAdvice");
   }
 
   public static class HandleAdvice {

--- a/dd-java-agent/instrumentation/jax-rs-client-2.0/connection-error-handling-jersey/src/main/java/datadog/trace/instrumentation/connection_error/jersey/JerseyClientConnectionErrorInstrumentation.java
+++ b/dd-java-agent/instrumentation/jax-rs-client-2.0/connection-error-handling-jersey/src/main/java/datadog/trace/instrumentation/connection_error/jersey/JerseyClientConnectionErrorInstrumentation.java
@@ -47,10 +47,15 @@ public final class JerseyClientConnectionErrorInstrumentation extends Instrument
   @Override
   public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
     final Map<ElementMatcher<? super MethodDescription>, String> transformers = new HashMap<>();
-    transformers.put(isMethod().and(isPublic()).and(named("invoke")), InvokeAdvice.class.getName());
+
+    transformers.put(
+        isMethod().and(isPublic()).and(named("invoke")),
+        JerseyClientConnectionErrorInstrumentation.class.getName() + "$InvokeAdvice");
+
     transformers.put(
         isMethod().and(isPublic()).and(named("submit")).and(returns(Future.class)),
-        SubmitAdvice.class.getName());
+        JerseyClientConnectionErrorInstrumentation.class.getName() + "$SubmitAdvice");
+
     return transformers;
   }
 

--- a/dd-java-agent/instrumentation/jax-rs-client-2.0/connection-error-handling-resteasy/src/main/java/datadog/trace/instrumentation/connection_error/resteasy/ResteasyClientConnectionErrorInstrumentation.java
+++ b/dd-java-agent/instrumentation/jax-rs-client-2.0/connection-error-handling-resteasy/src/main/java/datadog/trace/instrumentation/connection_error/resteasy/ResteasyClientConnectionErrorInstrumentation.java
@@ -47,10 +47,15 @@ public final class ResteasyClientConnectionErrorInstrumentation extends Instrume
   @Override
   public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
     final Map<ElementMatcher<? super MethodDescription>, String> transformers = new HashMap<>();
-    transformers.put(isMethod().and(isPublic()).and(named("invoke")), InvokeAdvice.class.getName());
+
+    transformers.put(
+        isMethod().and(isPublic()).and(named("invoke")),
+        ResteasyClientConnectionErrorInstrumentation.class.getName() + "$InvokeAdvice");
+
     transformers.put(
         isMethod().and(isPublic()).and(named("submit")).and(returns(Future.class)),
-        SubmitAdvice.class.getName());
+        ResteasyClientConnectionErrorInstrumentation.class.getName() + "$SubmitAdvice");
+
     return transformers;
   }
 

--- a/dd-java-agent/instrumentation/jax-rs-client-2.0/src/main/java/datadog/trace/instrumentation/jaxrs/JaxRsClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/jax-rs-client-2.0/src/main/java/datadog/trace/instrumentation/jaxrs/JaxRsClientInstrumentation.java
@@ -43,7 +43,7 @@ public final class JaxRsClientInstrumentation extends Instrumenter.Default {
   public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
     return singletonMap(
         named("build").and(returns(safeHasSuperType(named("javax.ws.rs.client.Client")))),
-        ClientBuilderAdvice.class.getName());
+        JaxRsClientInstrumentation.class.getName() + "$ClientBuilderAdvice");
   }
 
   public static class ClientBuilderAdvice {

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/ConnectionInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/ConnectionInstrumentation.java
@@ -44,7 +44,7 @@ public final class ConnectionInstrumentation extends Instrumenter.Default {
             .and(takesArgument(0, String.class))
             // Also include CallableStatement, which is a sub type of PreparedStatement
             .and(returns(safeHasSuperType(named("java.sql.PreparedStatement")))),
-        ConnectionPrepareAdvice.class.getName());
+        ConnectionInstrumentation.class.getName() + "$ConnectionPrepareAdvice");
   }
 
   public static class ConnectionPrepareAdvice {

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/DriverInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/DriverInstrumentation.java
@@ -55,7 +55,7 @@ public final class DriverInstrumentation extends Instrumenter.Default {
             .and(takesArgument(0, String.class))
             .and(takesArgument(1, Properties.class))
             .and(returns(named("java.sql.Connection"))),
-        DriverAdvice.class.getName());
+        DriverInstrumentation.class.getName() + "$DriverAdvice");
   }
 
   public static class DriverAdvice {

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/PreparedStatementInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/PreparedStatementInstrumentation.java
@@ -65,7 +65,7 @@ public final class PreparedStatementInstrumentation extends Instrumenter.Default
   public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
     return singletonMap(
         nameStartsWith("execute").and(takesArguments(0)).and(isPublic()),
-        PreparedStatementAdvice.class.getName());
+        PreparedStatementInstrumentation.class.getName() + "$PreparedStatementAdvice");
   }
 
   public static class PreparedStatementAdvice {

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/StatementInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/StatementInstrumentation.java
@@ -65,7 +65,7 @@ public final class StatementInstrumentation extends Instrumenter.Default {
   public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
     return singletonMap(
         nameStartsWith("execute").and(takesArgument(0, String.class)).and(isPublic()),
-        StatementAdvice.class.getName());
+        StatementInstrumentation.class.getName() + "$StatementAdvice");
   }
 
   public static class StatementAdvice {

--- a/dd-java-agent/instrumentation/jedis-1.4/src/main/java/datadog/trace/instrumentation/jedis/JedisInstrumentation.java
+++ b/dd-java-agent/instrumentation/jedis-1.4/src/main/java/datadog/trace/instrumentation/jedis/JedisInstrumentation.java
@@ -52,7 +52,7 @@ public final class JedisInstrumentation extends Instrumenter.Default {
             .and(isPublic())
             .and(named("sendCommand"))
             .and(takesArgument(1, named("redis.clients.jedis.Protocol$Command"))),
-        JedisAdvice.class.getName());
+        JedisInstrumentation.class.getName() + "$JedisAdvice");
     // FIXME: This instrumentation only incorporates sending the command, not processing the result.
   }
 

--- a/dd-java-agent/instrumentation/jetty-8/src/main/java/datadog/trace/instrumentation/jetty8/JettyHandlerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-8/src/main/java/datadog/trace/instrumentation/jetty8/JettyHandlerInstrumentation.java
@@ -55,6 +55,6 @@ public final class JettyHandlerInstrumentation extends Instrumenter.Default {
             .and(takesArgument(2, named("javax.servlet.http.HttpServletRequest")))
             .and(takesArgument(3, named("javax.servlet.http.HttpServletResponse")))
             .and(isPublic()),
-        JettyHandlerAdvice.class.getName());
+        packageName + ".JettyHandlerAdvice");
   }
 }

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageConsumerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageConsumerInstrumentation.java
@@ -58,10 +58,10 @@ public final class JMSMessageConsumerInstrumentation extends Instrumenter.Defaul
     final Map<ElementMatcher<? super MethodDescription>, String> transformers = new HashMap<>();
     transformers.put(
         named("receive").and(takesArguments(0).or(takesArguments(1))).and(isPublic()),
-        ConsumerAdvice.class.getName());
+        JMSMessageConsumerInstrumentation.class.getName() + "$ConsumerAdvice");
     transformers.put(
         named("receiveNoWait").and(takesArguments(0)).and(isPublic()),
-        ConsumerAdvice.class.getName());
+        JMSMessageConsumerInstrumentation.class.getName() + "$ConsumerAdvice");
     return transformers;
   }
 

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageListenerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageListenerInstrumentation.java
@@ -55,7 +55,7 @@ public final class JMSMessageListenerInstrumentation extends Instrumenter.Defaul
   public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
     return singletonMap(
         named("onMessage").and(takesArgument(0, named("javax.jms.Message"))).and(isPublic()),
-        MessageListenerAdvice.class.getName());
+        JMSMessageListenerInstrumentation.class.getName() + "$MessageListenerAdvice");
   }
 
   public static class MessageListenerAdvice {

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageProducerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageProducerInstrumentation.java
@@ -58,13 +58,13 @@ public final class JMSMessageProducerInstrumentation extends Instrumenter.Defaul
     final Map<ElementMatcher<? super MethodDescription>, String> transformers = new HashMap<>();
     transformers.put(
         named("send").and(takesArgument(0, named("javax.jms.Message"))).and(isPublic()),
-        ProducerAdvice.class.getName());
+        JMSMessageProducerInstrumentation.class.getName() + "$ProducerAdvice");
     transformers.put(
         named("send")
             .and(takesArgument(0, named("javax.jms.Destination")))
             .and(takesArgument(1, named("javax.jms.Message")))
             .and(isPublic()),
-        ProducerWithDestinationAdvice.class.getName());
+        JMSMessageProducerInstrumentation.class.getName() + "$ProducerWithDestinationAdvice");
     return transformers;
   }
 

--- a/dd-java-agent/instrumentation/jsp-2.3/src/main/java/datadog/trace/instrumentation/jsp/JSPInstrumentation.java
+++ b/dd-java-agent/instrumentation/jsp-2.3/src/main/java/datadog/trace/instrumentation/jsp/JSPInstrumentation.java
@@ -48,7 +48,7 @@ public final class JSPInstrumentation extends Instrumenter.Default {
             .and(takesArgument(0, named("javax.servlet.http.HttpServletRequest")))
             .and(takesArgument(1, named("javax.servlet.http.HttpServletResponse")))
             .and(isPublic()),
-        HttpJspPageAdvice.class.getName());
+        JSPInstrumentation.class.getName() + "$HttpJspPageAdvice");
   }
 
   public static class HttpJspPageAdvice {

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaConsumerInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaConsumerInstrumentation.java
@@ -56,21 +56,21 @@ public final class KafkaConsumerInstrumentation extends Instrumenter.Default {
             .and(named("records"))
             .and(takesArgument(0, String.class))
             .and(returns(Iterable.class)),
-        IterableAdvice.class.getName());
+        KafkaConsumerInstrumentation.class.getName() + "$IterableAdvice");
     transformers.put(
         isMethod()
             .and(isPublic())
             .and(named("records"))
             .and(takesArgument(0, named("org.apache.kafka.common.TopicPartition")))
             .and(returns(List.class)),
-        ListAdvice.class.getName());
+        KafkaConsumerInstrumentation.class.getName() + "$ListAdvice");
     transformers.put(
         isMethod()
             .and(isPublic())
             .and(named("iterator"))
             .and(takesArguments(0))
             .and(returns(Iterator.class)),
-        IteratorAdvice.class.getName());
+        KafkaConsumerInstrumentation.class.getName() + "$IteratorAdvice");
     return transformers;
   }
 

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerInstrumentation.java
@@ -59,7 +59,7 @@ public final class KafkaProducerInstrumentation extends Instrumenter.Default {
             .and(named("send"))
             .and(takesArgument(0, named("org.apache.kafka.clients.producer.ProducerRecord")))
             .and(takesArgument(1, named("org.apache.kafka.clients.producer.Callback"))),
-        ProducerAdvice.class.getName());
+        KafkaProducerInstrumentation.class.getName() + "$ProducerAdvice");
   }
 
   public static class ProducerAdvice {

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/KafkaStreamsProcessorInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/KafkaStreamsProcessorInstrumentation.java
@@ -64,7 +64,7 @@ public class KafkaStreamsProcessorInstrumentation {
               .and(isPackagePrivate())
               .and(named("nextRecord"))
               .and(returns(named("org.apache.kafka.streams.processor.internals.StampedRecord"))),
-          StartSpanAdvice.class.getName());
+          StartInstrumentation.class.getName() + "$StartSpanAdvice");
     }
 
     public static class StartSpanAdvice {
@@ -112,7 +112,7 @@ public class KafkaStreamsProcessorInstrumentation {
     public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
       return singletonMap(
           isMethod().and(isPublic()).and(named("process")).and(takesArguments(0)),
-          StopSpanAdvice.class.getName());
+          StopInstrumentation.class.getName() + "$StopSpanAdvice");
     }
 
     public static class StopSpanAdvice {

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/KafkaStreamsSourceNodeRecordDeserializerInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/KafkaStreamsSourceNodeRecordDeserializerInstrumentation.java
@@ -38,7 +38,8 @@ public class KafkaStreamsSourceNodeRecordDeserializerInstrumentation extends Ins
             .and(named("deserialize"))
             .and(takesArgument(0, named("org.apache.kafka.clients.consumer.ConsumerRecord")))
             .and(returns(named("org.apache.kafka.clients.consumer.ConsumerRecord"))),
-        SaveHeadersAdvice.class.getName());
+        KafkaStreamsSourceNodeRecordDeserializerInstrumentation.class.getName()
+            + "$SaveHeadersAdvice");
   }
 
   public static class SaveHeadersAdvice {

--- a/dd-java-agent/instrumentation/log4j1/src/main/java/datadog/trace/instrumentation/log4j1/Log4j1MDCInstrumentation.java
+++ b/dd-java-agent/instrumentation/log4j1/src/main/java/datadog/trace/instrumentation/log4j1/Log4j1MDCInstrumentation.java
@@ -36,7 +36,8 @@ public class Log4j1MDCInstrumentation extends Instrumenter.Default {
 
   @Override
   public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
-    return singletonMap(isConstructor(), MDCContextAdvice.class.getName());
+    return singletonMap(
+        isConstructor(), Log4j1MDCInstrumentation.class.getName() + "$MDCContextAdvice");
   }
 
   @Override

--- a/dd-java-agent/instrumentation/log4j2/src/main/java/datadog/trace/instrumentation/log4j2/ThreadContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/log4j2/src/main/java/datadog/trace/instrumentation/log4j2/ThreadContextInstrumentation.java
@@ -36,7 +36,8 @@ public class ThreadContextInstrumentation extends Instrumenter.Default {
 
   @Override
   public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
-    return singletonMap(isTypeInitializer(), ThreadContextAdvice.class.getName());
+    return singletonMap(
+        isTypeInitializer(), ThreadContextInstrumentation.class.getName() + "$ThreadContextAdvice");
   }
 
   @Override

--- a/dd-java-agent/instrumentation/mongo/driver-3.1/src/main/java/datadog/trace/instrumentation/mongo/MongoClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/mongo/driver-3.1/src/main/java/datadog/trace/instrumentation/mongo/MongoClientInstrumentation.java
@@ -56,7 +56,7 @@ public final class MongoClientInstrumentation extends Instrumenter.Default {
   public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
     return singletonMap(
         isMethod().and(isPublic()).and(named("build")).and(takesArguments(0)),
-        MongoClientAdvice.class.getName());
+        MongoClientInstrumentation.class.getName() + "$MongoClientAdvice");
   }
 
   public static class MongoClientAdvice {

--- a/dd-java-agent/instrumentation/mongo/driver-async-3.3/src/main/java/datadog/trace/instrumentation/mongo/MongoAsyncClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/mongo/driver-async-3.3/src/main/java/datadog/trace/instrumentation/mongo/MongoAsyncClientInstrumentation.java
@@ -56,7 +56,7 @@ public final class MongoAsyncClientInstrumentation extends Instrumenter.Default 
   public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
     return singletonMap(
         isMethod().and(isPublic()).and(named("build")).and(takesArguments(0)),
-        MongoAsyncClientAdvice.class.getName());
+        MongoAsyncClientInstrumentation.class.getName() + "$MongoAsyncClientAdvice");
   }
 
   public static class MongoAsyncClientAdvice {

--- a/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/ChannelFutureListenerInstrumentation.java
+++ b/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/ChannelFutureListenerInstrumentation.java
@@ -70,7 +70,7 @@ public class ChannelFutureListenerInstrumentation extends Instrumenter.Default {
         isMethod()
             .and(named("operationComplete"))
             .and(takesArgument(0, named("io.netty.channel.ChannelFuture"))),
-        OperationCompleteAdvice.class.getName());
+        ChannelFutureListenerInstrumentation.class.getName() + "$OperationCompleteAdvice");
   }
 
   public static class OperationCompleteAdvice {

--- a/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/NettyChannelPipelineInstrumentation.java
+++ b/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/NettyChannelPipelineInstrumentation.java
@@ -83,10 +83,10 @@ public class NettyChannelPipelineInstrumentation extends Instrumenter.Default {
         isMethod()
             .and(nameStartsWith("add"))
             .and(takesArgument(2, named("io.netty.channel.ChannelHandler"))),
-        ChannelPipelineAddAdvice.class.getName());
+        NettyChannelPipelineInstrumentation.class.getName() + "$ChannelPipelineAddAdvice");
     transformers.put(
         isMethod().and(named("connect")).and(returns(named("io.netty.channel.ChannelFuture"))),
-        ChannelPipelineConnectAdvice.class.getName());
+        NettyChannelPipelineInstrumentation.class.getName() + "$ChannelPipelineConnectAdvice");
     return transformers;
   }
 

--- a/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/ChannelFutureListenerInstrumentation.java
+++ b/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/ChannelFutureListenerInstrumentation.java
@@ -70,7 +70,7 @@ public class ChannelFutureListenerInstrumentation extends Instrumenter.Default {
         isMethod()
             .and(named("operationComplete"))
             .and(takesArgument(0, named("io.netty.channel.ChannelFuture"))),
-        OperationCompleteAdvice.class.getName());
+        ChannelFutureListenerInstrumentation.class.getName() + "$OperationCompleteAdvice");
   }
 
   public static class OperationCompleteAdvice {

--- a/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/NettyChannelPipelineInstrumentation.java
+++ b/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/NettyChannelPipelineInstrumentation.java
@@ -83,10 +83,10 @@ public class NettyChannelPipelineInstrumentation extends Instrumenter.Default {
         isMethod()
             .and(nameStartsWith("add"))
             .and(takesArgument(2, named("io.netty.channel.ChannelHandler"))),
-        ChannelPipelineAddAdvice.class.getName());
+        NettyChannelPipelineInstrumentation.class.getName() + "$ChannelPipelineAddAdvice");
     transformers.put(
         isMethod().and(named("connect")).and(returns(named("io.netty.channel.ChannelFuture"))),
-        ChannelPipelineConnectAdvice.class.getName());
+        NettyChannelPipelineInstrumentation.class.getName() + "$ChannelPipelineConnectAdvice");
     return transformers;
   }
 

--- a/dd-java-agent/instrumentation/okhttp-3/src/main/java/datadog/trace/instrumentation/okhttp3/OkHttp3Instrumentation.java
+++ b/dd-java-agent/instrumentation/okhttp-3/src/main/java/datadog/trace/instrumentation/okhttp3/OkHttp3Instrumentation.java
@@ -48,7 +48,7 @@ public class OkHttp3Instrumentation extends Instrumenter.Default {
   public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
     return singletonMap(
         isConstructor().and(takesArgument(0, named("okhttp3.OkHttpClient$Builder"))),
-        OkHttp3Advice.class.getName());
+        OkHttp3Instrumentation.class.getName() + "$OkHttp3Advice");
   }
 
   public static class OkHttp3Advice {

--- a/dd-java-agent/instrumentation/osgi-classloading/src/main/java/datadog/trace/instrumentation/osgi/OSGIClassloadingInstrumentation.java
+++ b/dd-java-agent/instrumentation/osgi-classloading/src/main/java/datadog/trace/instrumentation/osgi/OSGIClassloadingInstrumentation.java
@@ -55,7 +55,7 @@ public final class OSGIClassloadingInstrumentation extends Instrumenter.Default 
   public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
     return singletonMap(
         isMethod().and(isPublic()).and(named("newFramework")).and(takesArgument(0, Map.class)),
-        FrameworkFactoryAdvice.class.getName());
+        OSGIClassloadingInstrumentation.class.getName() + "$FrameworkFactoryAdvice");
   }
 
   /**

--- a/dd-java-agent/instrumentation/play-ws-1/src/main/java/datadog/trace/instrumentation/playws1/PlayWSClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/play-ws-1/src/main/java/datadog/trace/instrumentation/playws1/PlayWSClientInstrumentation.java
@@ -45,7 +45,7 @@ public class PlayWSClientInstrumentation extends Instrumenter.Default {
             .and(takesArguments(2))
             .and(takesArgument(0, named("play.shaded.ahc.org.asynchttpclient.Request")))
             .and(takesArgument(1, named("play.shaded.ahc.org.asynchttpclient.AsyncHandler"))),
-        ClientAdvice.class.getName());
+        PlayWSClientInstrumentation.class.getName() + "$ClientAdvice");
   }
 
   @Override

--- a/dd-java-agent/instrumentation/play-ws-2/src/main/java/datadog/trace/instrumentation/playws2/PlayWSClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/play-ws-2/src/main/java/datadog/trace/instrumentation/playws2/PlayWSClientInstrumentation.java
@@ -45,7 +45,7 @@ public class PlayWSClientInstrumentation extends Instrumenter.Default {
             .and(takesArguments(2))
             .and(takesArgument(0, named("play.shaded.ahc.org.asynchttpclient.Request")))
             .and(takesArgument(1, named("play.shaded.ahc.org.asynchttpclient.AsyncHandler"))),
-        ClientAdvice.class.getName());
+        PlayWSClientInstrumentation.class.getName() + "$ClientAdvice");
   }
 
   @Override

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitChannelInstrumentation.java
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitChannelInstrumentation.java
@@ -93,19 +93,19 @@ public class RabbitChannelInstrumentation extends Instrumenter.Default {
                         .or(named("basicGet"))))
             .and(isPublic())
             .and(canThrow(IOException.class).or(canThrow(InterruptedException.class))),
-        ChannelMethodAdvice.class.getName());
+        RabbitChannelInstrumentation.class.getName() + "$ChannelMethodAdvice");
     transformers.put(
         isMethod().and(named("basicPublish")).and(takesArguments(6)),
-        ChannelPublishAdvice.class.getName());
+        RabbitChannelInstrumentation.class.getName() + "$ChannelPublishAdvice");
     transformers.put(
         isMethod().and(named("basicGet")).and(takesArgument(0, String.class)),
-        ChannelGetAdvice.class.getName());
+        RabbitChannelInstrumentation.class.getName() + "$ChannelGetAdvice");
     transformers.put(
         isMethod()
             .and(named("basicConsume"))
             .and(takesArgument(0, String.class))
             .and(takesArgument(6, named("com.rabbitmq.client.Consumer"))),
-        ChannelConsumeAdvice.class.getName());
+        RabbitChannelInstrumentation.class.getName() + "$ChannelConsumeAdvice");
     return transformers;
   }
 

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitCommandInstrumentation.java
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitCommandInstrumentation.java
@@ -47,7 +47,9 @@ public class RabbitCommandInstrumentation extends Instrumenter.Default {
 
   @Override
   public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
-    return singletonMap(isConstructor(), CommandConstructorAdvice.class.getName());
+    return singletonMap(
+        isConstructor(),
+        RabbitCommandInstrumentation.class.getName() + "$CommandConstructorAdvice");
   }
 
   public static class CommandConstructorAdvice {

--- a/dd-java-agent/instrumentation/ratpack-1.4/src/main/java/datadog/trace/instrumentation/ratpack/ContinuationInstrumentation.java
+++ b/dd-java-agent/instrumentation/ratpack-1.4/src/main/java/datadog/trace/instrumentation/ratpack/ContinuationInstrumentation.java
@@ -39,7 +39,7 @@ public final class ContinuationInstrumentation extends Instrumenter.Default {
   public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
     return singletonMap(
         named("resume").and(takesArgument(0, named("ratpack.func.Block"))),
-        ResumeAdvice.class.getName());
+        ContinuationInstrumentation.class.getName() + "$ResumeAdvice");
   }
 
   public static class ResumeAdvice {

--- a/dd-java-agent/instrumentation/ratpack-1.4/src/main/java/datadog/trace/instrumentation/ratpack/DefaultExecutionInstrumentation.java
+++ b/dd-java-agent/instrumentation/ratpack-1.4/src/main/java/datadog/trace/instrumentation/ratpack/DefaultExecutionInstrumentation.java
@@ -43,7 +43,7 @@ public final class DefaultExecutionInstrumentation extends Instrumenter.Default 
         nameStartsWith("delimit") // include delimitStream
             .and(takesArgument(0, named("ratpack.func.Action")))
             .and(takesArgument(1, named("ratpack.func.Action"))),
-        DelimitAdvice.class.getName());
+        DefaultExecutionInstrumentation.class.getName() + "$DelimitAdvice");
   }
 
   public static class DelimitAdvice {

--- a/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/Servlet2Instrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/Servlet2Instrumentation.java
@@ -62,6 +62,6 @@ public final class Servlet2Instrumentation extends Instrumenter.Default {
             .and(takesArgument(0, named("javax.servlet.ServletRequest")))
             .and(takesArgument(1, named("javax.servlet.ServletResponse")))
             .and(isPublic()),
-        Servlet2Advice.class.getName());
+        packageName + ".Servlet2Advice");
   }
 }

--- a/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/AsyncContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/AsyncContextInstrumentation.java
@@ -44,7 +44,8 @@ public final class AsyncContextInstrumentation extends Instrumenter.Default {
   @Override
   public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
     return singletonMap(
-        isMethod().and(isPublic()).and(named("dispatch")), DispatchAdvice.class.getName());
+        isMethod().and(isPublic()).and(named("dispatch")),
+        AsyncContextInstrumentation.class.getName() + "$DispatchAdvice");
   }
 
   /**

--- a/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Instrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Instrumentation.java
@@ -54,6 +54,6 @@ public final class Servlet3Instrumentation extends Instrumenter.Default {
             .and(takesArgument(0, named("javax.servlet.ServletRequest")))
             .and(takesArgument(1, named("javax.servlet.ServletResponse")))
             .and(isPublic()),
-        Servlet3Advice.class.getName());
+        packageName + ".Servlet3Advice");
   }
 }

--- a/dd-java-agent/instrumentation/slf4j-mdc/src/main/java/datadog/trace/instrumentation/slf4j/mdc/MDCInjectionInstrumentation.java
+++ b/dd-java-agent/instrumentation/slf4j-mdc/src/main/java/datadog/trace/instrumentation/slf4j/mdc/MDCInjectionInstrumentation.java
@@ -54,7 +54,8 @@ public class MDCInjectionInstrumentation extends Instrumenter.Default {
 
   @Override
   public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
-    return singletonMap(isTypeInitializer(), MDCAdvice.class.getName());
+    return singletonMap(
+        isTypeInitializer(), MDCInjectionInstrumentation.class.getName() + "$MDCAdvice");
   }
 
   @Override

--- a/dd-java-agent/instrumentation/sparkjava-2.3/src/main/java/datadog/trace/instrumentation/sparkjava/RoutesInstrumentation.java
+++ b/dd-java-agent/instrumentation/sparkjava-2.3/src/main/java/datadog/trace/instrumentation/sparkjava/RoutesInstrumentation.java
@@ -43,7 +43,7 @@ public class RoutesInstrumentation extends Instrumenter.Default {
             .and(takesArgument(0, named("spark.route.HttpMethod")))
             .and(returns(named("spark.routematch.RouteMatch")))
             .and(isPublic()),
-        RoutesAdvice.class.getName());
+        RoutesInstrumentation.class.getName() + "$RoutesAdvice");
   }
 
   public static class RoutesAdvice {

--- a/dd-java-agent/instrumentation/spring-data-1.8/src/main/java/datadog/trace/instrumentation/springdata/SpringRepositoryInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-data-1.8/src/main/java/datadog/trace/instrumentation/springdata/SpringRepositoryInstrumentation.java
@@ -56,7 +56,8 @@ public final class SpringRepositoryInstrumentation extends Instrumenter.Default 
   @Override
   public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
     return Collections.singletonMap(
-        isConstructor(), RepositoryFactorySupportAdvice.class.getName());
+        isConstructor(),
+        SpringRepositoryInstrumentation.class.getName() + "$RepositoryFactorySupportAdvice");
   }
 
   public static class RepositoryFactorySupportAdvice {

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/DispatcherServletInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/DispatcherServletInstrumentation.java
@@ -55,13 +55,13 @@ public final class DispatcherServletInstrumentation extends Instrumenter.Default
             .and(isProtected())
             .and(named("render"))
             .and(takesArgument(0, named("org.springframework.web.servlet.ModelAndView"))),
-        DispatcherAdvice.class.getName());
+        DispatcherServletInstrumentation.class.getName() + "$DispatcherAdvice");
     transformers.put(
         isMethod()
             .and(isProtected())
             .and(nameStartsWith("processHandlerException"))
             .and(takesArgument(3, Exception.class)),
-        ErrorHandlerAdvice.class.getName());
+        DispatcherServletInstrumentation.class.getName() + "$ErrorHandlerAdvice");
     return transformers;
   }
 

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/HandlerAdapterInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/HandlerAdapterInstrumentation.java
@@ -59,7 +59,7 @@ public final class HandlerAdapterInstrumentation extends Instrumenter.Default {
             .and(nameStartsWith("handle"))
             .and(takesArgument(0, named("javax.servlet.http.HttpServletRequest")))
             .and(takesArguments(3)),
-        ControllerAdvice.class.getName());
+        HandlerAdapterInstrumentation.class.getName() + "$ControllerAdvice");
   }
 
   public static class ControllerAdvice {

--- a/dd-java-agent/instrumentation/spymemcached-2.12/src/main/java/datadog/trace/instrumentation/spymemcached/MemcachedClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/spymemcached-2.12/src/main/java/datadog/trace/instrumentation/spymemcached/MemcachedClientInstrumentation.java
@@ -61,16 +61,16 @@ public final class MemcachedClientInstrumentation extends Instrumenter.Default {
             Also tracing flush is probably of a very limited value.
             */
             .and(not(named("flush"))),
-        AsyncOperationAdvice.class.getName());
+        MemcachedClientInstrumentation.class.getName() + "$AsyncOperationAdvice");
     transformers.put(
         isMethod().and(isPublic()).and(returns(named(MEMCACHED_PACKAGE + ".internal.GetFuture"))),
-        AsyncGetAdvice.class.getName());
+        MemcachedClientInstrumentation.class.getName() + "$AsyncGetAdvice");
     transformers.put(
         isMethod().and(isPublic()).and(returns(named(MEMCACHED_PACKAGE + ".internal.BulkFuture"))),
-        AsyncBulkAdvice.class.getName());
+        MemcachedClientInstrumentation.class.getName() + "$AsyncBulkAdvice");
     transformers.put(
         isMethod().and(isPublic()).and(named("incr").or(named("decr"))),
-        SyncOperationAdvice.class.getName());
+        MemcachedClientInstrumentation.class.getName() + "$SyncOperationAdvice");
     return transformers;
   }
 

--- a/dd-java-agent/instrumentation/tomcat-classloading/src/main/java/datadog/trace/instrumentation/tomcat/TomcatClassloadingInstrumentation.java
+++ b/dd-java-agent/instrumentation/tomcat-classloading/src/main/java/datadog/trace/instrumentation/tomcat/TomcatClassloadingInstrumentation.java
@@ -47,7 +47,7 @@ public final class TomcatClassloadingInstrumentation extends Instrumenter.Defaul
             .and(takesArgument(0, String.class))
             // Older versions have 1 argument method, newer versions have two arguments
             .and(takesArguments(2).or(takesArguments(1))),
-        WebappClassLoaderAdvice.class.getName());
+        TomcatClassloadingInstrumentation.class.getName() + "$WebappClassLoaderAdvice");
   }
 
   public static class WebappClassLoaderAdvice {

--- a/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceAnnotationsInstrumentation.java
+++ b/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceAnnotationsInstrumentation.java
@@ -92,6 +92,6 @@ public final class TraceAnnotationsInstrumentation extends Instrumenter.Default 
   @Override
   public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
     return Collections.singletonMap(
-        isAnnotatedWith(methodTraceMatcher), TraceAdvice.class.getName());
+        isAnnotatedWith(methodTraceMatcher), packageName + ".TraceAdvice");
   }
 }

--- a/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceConfigInstrumentation.java
+++ b/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceConfigInstrumentation.java
@@ -139,7 +139,7 @@ public class TraceConfigInstrumentation implements Instrumenter {
       }
 
       final Map<ElementMatcher<? super MethodDescription>, String> transformers = new HashMap<>();
-      transformers.put(methodMatchers, TraceAdvice.class.getName());
+      transformers.put(methodMatchers, packageName + ".TraceAdvice");
       return transformers;
     }
   }

--- a/dd-java-agent/instrumentation/twilio/src/main/java/datadog/trace/instrumentation/twilio/TwilioAsyncInstrumentation.java
+++ b/dd-java-agent/instrumentation/twilio/src/main/java/datadog/trace/instrumentation/twilio/TwilioAsyncInstrumentation.java
@@ -78,7 +78,7 @@ public class TwilioAsyncInstrumentation extends Instrumenter.Default {
                     .or(named("fetchAsync"))
                     .or(named("updateAsync")))
             .and(returns(named("com.google.common.util.concurrent.ListenableFuture"))),
-        TwilioClientAsyncAdvice.class.getName());
+        TwilioAsyncInstrumentation.class.getName() + "$TwilioClientAsyncAdvice");
   }
 
   /** Advice for instrumenting Twilio service classes. */

--- a/dd-java-agent/instrumentation/twilio/src/main/java/datadog/trace/instrumentation/twilio/TwilioSyncInstrumentation.java
+++ b/dd-java-agent/instrumentation/twilio/src/main/java/datadog/trace/instrumentation/twilio/TwilioSyncInstrumentation.java
@@ -74,7 +74,7 @@ public class TwilioSyncInstrumentation extends Instrumenter.Default {
                     .or(named("read"))
                     .or(named("fetch"))
                     .or(named("update"))),
-        TwilioClientAdvice.class.getName());
+        TwilioSyncInstrumentation.class.getName() + "$TwilioClientAdvice");
   }
 
   /** Advice for instrumenting Twilio service classes. */


### PR DESCRIPTION
Replacing Advice.class references with string construction.

This stops the JVM from loading the Advice classes which are used as templates for bytebuddy and don't ever need to be run directly.

This eliminates ~130 class loads at start-up -- and saves 0.5MiB in metaspace