### PR TITLE
Normalize tag verification

### DIFF
--- a/dd-java-agent/instrumentation/akka-http-10.0/src/lagomTest/groovy/LagomTest.groovy
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/lagomTest/groovy/LagomTest.groovy
@@ -65,12 +65,12 @@ class LagomTest extends AgentTestRunner {
           spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
-            defaultTags()
-            "$Tags.HTTP_STATUS" 101
+            "$Tags.COMPONENT" "akka-http-server"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
             "$Tags.HTTP_URL" "ws://localhost:${server.port()}/echo"
             "$Tags.HTTP_METHOD" "GET"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
-            "$Tags.COMPONENT" "akka-http-server"
+            "$Tags.HTTP_STATUS" 101
+            defaultTags()
           }
         }
         span(1) {
@@ -104,13 +104,13 @@ class LagomTest extends AgentTestRunner {
           spanType DDSpanTypes.HTTP_SERVER
           errored true
           tags {
-            defaultTags()
-            "$Tags.HTTP_STATUS" 500
+            "$Tags.COMPONENT" "akka-http-server"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
             "$Tags.HTTP_URL" "ws://localhost:${server.port()}/error"
             "$Tags.HTTP_METHOD" "GET"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
-            "$Tags.COMPONENT" "akka-http-server"
+            "$Tags.HTTP_STATUS" 500
             "$Tags.ERROR" true
+            defaultTags()
           }
         }
       }

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/lagomTest/groovy/LagomTest.groovy
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/lagomTest/groovy/LagomTest.groovy
@@ -77,6 +77,10 @@ class LagomTest extends AgentTestRunner {
           childOf span(0)
           operationName 'trace.annotation'
           resourceName 'EchoServiceImpl.tracedMethod'
+          tags {
+            "$Tags.COMPONENT" "trace"
+            defaultTags()
+          }
         }
       }
     }

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpClientInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpClientInstrumentationTest.groovy
@@ -73,11 +73,11 @@ class AkkaHttpClientInstrumentationTest extends HttpClientTest<AkkaHttpClientDec
           spanType DDSpanTypes.HTTP_CLIENT
           errored true
           tags {
-            defaultTags()
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.COMPONENT" "akka-http-client"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.ERROR" true
             errorTags(NullPointerException)
+            defaultTags()
           }
         }
       }

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpServerInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpServerInstrumentationTest.groovy
@@ -49,18 +49,18 @@ abstract class AkkaHttpServerInstrumentationTest extends HttpServerTest<Object, 
         parent()
       }
       tags {
-        defaultTags(true)
         "$Tags.COMPONENT" serverDecorator.component()
+        "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
+        "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
+        "$Tags.HTTP_METHOD" method
+        "$Tags.HTTP_STATUS" endpoint.status
         if (endpoint.errored) {
           "$Tags.ERROR" endpoint.errored
           "error.msg" { it == null || it == EXCEPTION.body }
           "error.type" { it == null || it == Exception.name }
           "error.stack" { it == null || it instanceof String }
         }
-        "$Tags.HTTP_STATUS" endpoint.status
-        "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
-        "$Tags.HTTP_METHOD" method
-        "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
+        defaultTags(true)
       }
     }
   }

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test/groovy/AWSClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test/groovy/AWSClientTest.groovy
@@ -135,10 +135,10 @@ class AWSClientTest extends AgentTestRunner {
           parent()
           tags {
             "$Tags.COMPONENT" "java-aws-sdk"
-            "$Tags.HTTP_STATUS" 200
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.HTTP_URL" "$server.address/"
             "$Tags.HTTP_METHOD" "$method"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.HTTP_STATUS" 200
             "aws.service" { it.contains(service) }
             "aws.endpoint" "$server.address"
             "aws.operation" "${operation}Request"
@@ -154,12 +154,12 @@ class AWSClientTest extends AgentTestRunner {
           childOf(span(0))
           tags {
             "$Tags.COMPONENT" "apache-httpclient"
-            "$Tags.HTTP_STATUS" 200
-            "$Tags.HTTP_URL" "$server.address/$url"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "localhost"
             "$Tags.PEER_PORT" server.address.port
+            "$Tags.HTTP_URL" "$server.address/$url"
             "$Tags.HTTP_METHOD" "$method"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.HTTP_STATUS" 200
             defaultTags()
           }
         }
@@ -209,9 +209,9 @@ class AWSClientTest extends AgentTestRunner {
           parent()
           tags {
             "$Tags.COMPONENT" "java-aws-sdk"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.HTTP_URL" "http://localhost:${UNUSABLE_PORT}/"
             "$Tags.HTTP_METHOD" "$method"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "aws.service" { it.contains(service) }
             "aws.endpoint" "http://localhost:${UNUSABLE_PORT}"
             "aws.operation" "${operation}Request"
@@ -228,11 +228,11 @@ class AWSClientTest extends AgentTestRunner {
           childOf(span(0))
           tags {
             "$Tags.COMPONENT" "apache-httpclient"
-            "$Tags.HTTP_URL" "http://localhost:${UNUSABLE_PORT}/$url"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "localhost"
             "$Tags.PEER_PORT" UNUSABLE_PORT
+            "$Tags.HTTP_URL" "http://localhost:${UNUSABLE_PORT}/$url"
             "$Tags.HTTP_METHOD" "$method"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             errorTags HttpHostConnectException, ~/Connection refused/
             defaultTags()
           }
@@ -272,9 +272,9 @@ class AWSClientTest extends AgentTestRunner {
           parent()
           tags {
             "$Tags.COMPONENT" "java-aws-sdk"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.HTTP_URL" "https://s3.amazonaws.com/"
             "$Tags.HTTP_METHOD" "HEAD"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "aws.service" "Amazon S3"
             "aws.endpoint" "https://s3.amazonaws.com"
             "aws.operation" "HeadBucketRequest"
@@ -318,9 +318,9 @@ class AWSClientTest extends AgentTestRunner {
           parent()
           tags {
             "$Tags.COMPONENT" "java-aws-sdk"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.HTTP_URL" "$server.address/"
             "$Tags.HTTP_METHOD" "GET"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "aws.service" "Amazon S3"
             "aws.endpoint" "$server.address"
             "aws.operation" "GetObjectRequest"
@@ -342,11 +342,11 @@ class AWSClientTest extends AgentTestRunner {
             childOf(span(0))
             tags {
               "$Tags.COMPONENT" "apache-httpclient"
-              "$Tags.HTTP_URL" "$server.address/someBucket/someKey"
+              "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
               "$Tags.PEER_HOSTNAME" "localhost"
               "$Tags.PEER_PORT" server.address.port
+              "$Tags.HTTP_URL" "$server.address/someBucket/someKey"
               "$Tags.HTTP_METHOD" "GET"
-              "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
               try {
                 errorTags SocketException, "Socket closed"
               } catch (AssertionError e) {

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test_before_1_11_106/groovy/AWSClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test_before_1_11_106/groovy/AWSClientTest.groovy
@@ -105,10 +105,10 @@ class AWSClientTest extends AgentTestRunner {
           parent()
           tags {
             "$Tags.COMPONENT" "java-aws-sdk"
-            "$Tags.HTTP_STATUS" 200
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.HTTP_URL" "$server.address/"
             "$Tags.HTTP_METHOD" "$method"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.HTTP_STATUS" 200
             "aws.service" { it.contains(service) }
             "aws.endpoint" "$server.address"
             "aws.operation" "${operation}Request"
@@ -124,12 +124,12 @@ class AWSClientTest extends AgentTestRunner {
           childOf(span(0))
           tags {
             "$Tags.COMPONENT" "apache-httpclient"
-            "$Tags.HTTP_STATUS" 200
-            "$Tags.HTTP_URL" "$server.address/$url"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "localhost"
             "$Tags.PEER_PORT" server.address.port
+            "$Tags.HTTP_URL" "$server.address/$url"
             "$Tags.HTTP_METHOD" "$method"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.HTTP_STATUS" 200
             defaultTags()
           }
         }
@@ -179,9 +179,9 @@ class AWSClientTest extends AgentTestRunner {
           parent()
           tags {
             "$Tags.COMPONENT" "java-aws-sdk"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.HTTP_URL" "http://localhost:${UNUSABLE_PORT}/"
             "$Tags.HTTP_METHOD" "$method"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "aws.service" { it.contains(service) }
             "aws.endpoint" "http://localhost:${UNUSABLE_PORT}"
             "aws.operation" "${operation}Request"
@@ -198,11 +198,11 @@ class AWSClientTest extends AgentTestRunner {
           childOf(span(0))
           tags {
             "$Tags.COMPONENT" "apache-httpclient"
-            "$Tags.HTTP_URL" "http://localhost:${UNUSABLE_PORT}/$url"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "localhost"
             "$Tags.PEER_PORT" UNUSABLE_PORT
+            "$Tags.HTTP_URL" "http://localhost:${UNUSABLE_PORT}/$url"
             "$Tags.HTTP_METHOD" "$method"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             errorTags HttpHostConnectException, ~/Connection refused/
             defaultTags()
           }
@@ -242,9 +242,9 @@ class AWSClientTest extends AgentTestRunner {
           parent()
           tags {
             "$Tags.COMPONENT" "java-aws-sdk"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.HTTP_URL" "https://s3.amazonaws.com/"
             "$Tags.HTTP_METHOD" "GET"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "aws.service" "Amazon S3"
             "aws.endpoint" "https://s3.amazonaws.com"
             "aws.operation" "GetObjectRequest"
@@ -288,9 +288,9 @@ class AWSClientTest extends AgentTestRunner {
           parent()
           tags {
             "$Tags.COMPONENT" "java-aws-sdk"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.HTTP_URL" "$server.address/"
             "$Tags.HTTP_METHOD" "GET"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "aws.service" "Amazon S3"
             "aws.endpoint" "http://localhost:$server.address.port"
             "aws.operation" "GetObjectRequest"
@@ -308,11 +308,11 @@ class AWSClientTest extends AgentTestRunner {
             childOf(span(0))
             tags {
               "$Tags.COMPONENT" "apache-httpclient"
-              "$Tags.HTTP_URL" "$server.address/someBucket/someKey"
+              "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
               "$Tags.PEER_HOSTNAME" "localhost"
               "$Tags.PEER_PORT" server.address.port
+              "$Tags.HTTP_URL" "$server.address/someBucket/someKey"
               "$Tags.HTTP_METHOD" "GET"
-              "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
               try {
                 errorTags SocketException, "Socket closed"
               } catch (AssertionError e) {

--- a/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/test/groovy/AwsClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/test/groovy/AwsClientTest.groovy
@@ -82,12 +82,12 @@ class AwsClientTest extends AgentTestRunner {
           parent()
           tags {
             "$Tags.COMPONENT" "java-aws-sdk"
-            "$Tags.HTTP_STATUS" 200
-            "$Tags.HTTP_URL" "${server.address}${path}"
-            "$Tags.HTTP_METHOD" "$method"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "localhost"
             "$Tags.PEER_PORT" server.address.port
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.HTTP_URL" "${server.address}${path}"
+            "$Tags.HTTP_METHOD" "$method"
+            "$Tags.HTTP_STATUS" 200
             "aws.service" "$service"
             "aws.operation" "${operation}"
             "aws.agent" "java-aws-sdk"
@@ -114,12 +114,12 @@ class AwsClientTest extends AgentTestRunner {
           childOf(span(0))
           tags {
             "$Tags.COMPONENT" "apache-httpclient"
-            "$Tags.HTTP_STATUS" 200
-            "$Tags.HTTP_URL" "${server.address}${path}"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "localhost"
             "$Tags.PEER_PORT" server.address.port
+            "$Tags.HTTP_URL" "${server.address}${path}"
             "$Tags.HTTP_METHOD" "$method"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.HTTP_STATUS" 200
             defaultTags()
           }
         }
@@ -199,12 +199,12 @@ class AwsClientTest extends AgentTestRunner {
           parent()
           tags {
             "$Tags.COMPONENT" "java-aws-sdk"
-            "$Tags.HTTP_STATUS" 200
-            "$Tags.HTTP_URL" "${server.address}${path}"
-            "$Tags.HTTP_METHOD" "$method"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "localhost"
             "$Tags.PEER_PORT" server.address.port
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.HTTP_URL" "${server.address}${path}"
+            "$Tags.HTTP_METHOD" "$method"
+            "$Tags.HTTP_STATUS" 200
             "aws.service" "$service"
             "aws.operation" "${operation}"
             "aws.agent" "java-aws-sdk"
@@ -234,13 +234,13 @@ class AwsClientTest extends AgentTestRunner {
           parent()
           tags {
             "$Tags.COMPONENT" "netty-client"
-            "$Tags.HTTP_STATUS" 200
-            "$Tags.HTTP_URL" "${server.address}${path}"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "localhost"
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
             "$Tags.PEER_PORT" server.address.port
+            "$Tags.HTTP_URL" "${server.address}${path}"
             "$Tags.HTTP_METHOD" "$method"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.HTTP_STATUS" 200
             defaultTags()
           }
         }
@@ -320,11 +320,11 @@ class AwsClientTest extends AgentTestRunner {
           parent()
           tags {
             "$Tags.COMPONENT" "java-aws-sdk"
-            "$Tags.HTTP_URL" "$server.address/somebucket/somekey"
-            "$Tags.HTTP_METHOD" "GET"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "localhost"
             "$Tags.PEER_PORT" server.address.port
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.HTTP_URL" "$server.address/somebucket/somekey"
+            "$Tags.HTTP_METHOD" "GET"
             "aws.service" "S3"
             "aws.operation" "GetObject"
             "aws.agent" "java-aws-sdk"
@@ -342,11 +342,11 @@ class AwsClientTest extends AgentTestRunner {
             childOf(span(0))
             tags {
               "$Tags.COMPONENT" "apache-httpclient"
-              "$Tags.HTTP_URL" "$server.address/somebucket/somekey"
+              "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
               "$Tags.PEER_HOSTNAME" "localhost"
               "$Tags.PEER_PORT" server.address.port
+              "$Tags.HTTP_URL" "$server.address/somebucket/somekey"
               "$Tags.HTTP_METHOD" "GET"
-              "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
               errorTags SocketTimeoutException, "Read timed out"
               defaultTags()
             }

--- a/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/util/AbstractCouchbaseTest.groovy
+++ b/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/util/AbstractCouchbaseTest.groovy
@@ -148,8 +148,8 @@ abstract class AbstractCouchbaseTest extends AgentTestRunner {
       }
       tags {
         "$Tags.COMPONENT" "couchbase-client"
-        "$Tags.DB_TYPE" "couchbase"
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+        "$Tags.DB_TYPE" "couchbase"
         if (bucketName != null) {
           "bucket" bucketName
         }

--- a/dd-java-agent/instrumentation/couchbase-2.6/src/test/groovy/CouchbaseSpanUtil.groovy
+++ b/dd-java-agent/instrumentation/couchbase-2.6/src/test/groovy/CouchbaseSpanUtil.groovy
@@ -20,15 +20,18 @@ class CouchbaseSpanUtil {
       }
       tags {
         "$Tags.COMPONENT" "couchbase-client"
-        "$Tags.DB_TYPE" "couchbase"
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-        if (bucketName != null) {
-          "bucket" bucketName
-        }
 
         // Because of caching, not all requests hit the server so these tags may be absent
         "$Tags.PEER_HOSTNAME" { it == "localhost" || it == "127.0.0.1" || it == null }
         "$Tags.PEER_PORT" { it == null || Number }
+
+        "$Tags.DB_TYPE" "couchbase"
+        if (bucketName != null) {
+          "bucket" bucketName
+        }
+
+        // Because of caching, not all requests hit the server so this tag may be absent
         "local.address" { it == null || String }
 
         // Not all couchbase operations have operation id.  Notably, 'ViewQuery's do not

--- a/dd-java-agent/instrumentation/datastax-cassandra-3/src/test/groovy/CassandraClientTest.groovy
+++ b/dd-java-agent/instrumentation/datastax-cassandra-3/src/test/groovy/CassandraClientTest.groovy
@@ -123,11 +123,11 @@ class CassandraClientTest extends AgentTestRunner {
       tags {
         "$Tags.COMPONENT" "java-cassandra"
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-        "$Tags.DB_INSTANCE" keyspace
-        "$Tags.DB_TYPE" "cassandra"
         "$Tags.PEER_HOSTNAME" "localhost"
         "$Tags.PEER_HOST_IPV4" "127.0.0.1"
         "$Tags.PEER_PORT" port
+        "$Tags.DB_TYPE" "cassandra"
+        "$Tags.DB_INSTANCE" keyspace
         defaultTags()
       }
     }

--- a/dd-java-agent/instrumentation/dropwizard/dropwizard-views/src/test/groovy/ViewRenderTest.groovy
+++ b/dd-java-agent/instrumentation/dropwizard/dropwizard-views/src/test/groovy/ViewRenderTest.groovy
@@ -1,4 +1,5 @@
 import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.instrumentation.api.Tags
 import io.dropwizard.views.View
 import io.dropwizard.views.freemarker.FreemarkerViewRenderer
 import io.dropwizard.views.mustache.MustacheViewRenderer
@@ -30,7 +31,7 @@ class ViewRenderTest extends AgentTestRunner {
           operationName "view.render"
           childOf span(0)
           tags {
-            "component" "dropwizard-view"
+            "$Tags.COMPONENT" "dropwizard-view"
             "span.origin.type" renderer.class.simpleName
             defaultTags()
           }

--- a/dd-java-agent/instrumentation/elasticsearch/rest-5/src/latestDepTest/groovy/Elasticsearch6RestClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/rest-5/src/latestDepTest/groovy/Elasticsearch6RestClientTest.groovy
@@ -87,12 +87,12 @@ class Elasticsearch6RestClientTest extends AgentTestRunner {
           parent()
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.HTTP_METHOD" "GET"
-            "$Tags.HTTP_URL" "_cluster/health"
             "$Tags.PEER_HOSTNAME" "localhost"
             "$Tags.PEER_PORT" httpPort
+            "$Tags.HTTP_URL" "_cluster/health"
+            "$Tags.HTTP_METHOD" "GET"
+            "$Tags.DB_TYPE" "elasticsearch"
             defaultTags()
           }
         }
@@ -105,8 +105,8 @@ class Elasticsearch6RestClientTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT" "apache-httpasyncclient"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.HTTP_METHOD" "GET"
             "$Tags.HTTP_URL" "_cluster/health"
+            "$Tags.HTTP_METHOD" "GET"
             "$Tags.HTTP_STATUS" 200
             defaultTags()
           }

--- a/dd-java-agent/instrumentation/elasticsearch/rest-5/src/test/groovy/Elasticsearch5RestClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/rest-5/src/test/groovy/Elasticsearch5RestClientTest.groovy
@@ -92,12 +92,12 @@ class Elasticsearch5RestClientTest extends AgentTestRunner {
           parent()
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.HTTP_METHOD" "GET"
-            "$Tags.HTTP_URL" "_cluster/health"
             "$Tags.PEER_HOSTNAME" "localhost"
             "$Tags.PEER_PORT" httpPort
+            "$Tags.HTTP_URL" "_cluster/health"
+            "$Tags.HTTP_METHOD" "GET"
+            "$Tags.DB_TYPE" "elasticsearch"
             defaultTags()
           }
         }
@@ -110,8 +110,8 @@ class Elasticsearch5RestClientTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT" "apache-httpasyncclient"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.HTTP_METHOD" "GET"
             "$Tags.HTTP_URL" "_cluster/health"
+            "$Tags.HTTP_METHOD" "GET"
             "$Tags.HTTP_STATUS" 200
             defaultTags()
           }

--- a/dd-java-agent/instrumentation/elasticsearch/rest-6.4/src/latestDepTest/groovy/Elasticsearch6RestClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/rest-6.4/src/latestDepTest/groovy/Elasticsearch6RestClientTest.groovy
@@ -91,12 +91,12 @@ class Elasticsearch6RestClientTest extends AgentTestRunner {
           parent()
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.HTTP_METHOD" "GET"
-            "$Tags.HTTP_URL" "_cluster/health"
             "$Tags.PEER_HOSTNAME" "localhost"
             "$Tags.PEER_PORT" httpPort
+            "$Tags.HTTP_URL" "_cluster/health"
+            "$Tags.HTTP_METHOD" "GET"
+            "$Tags.DB_TYPE" "elasticsearch"
             defaultTags()
           }
         }
@@ -109,8 +109,8 @@ class Elasticsearch6RestClientTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT" "apache-httpasyncclient"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.HTTP_METHOD" "GET"
             "$Tags.HTTP_URL" "_cluster/health"
+            "$Tags.HTTP_METHOD" "GET"
             "$Tags.HTTP_STATUS" 200
             defaultTags()
           }

--- a/dd-java-agent/instrumentation/elasticsearch/rest-6.4/src/test/groovy/Elasticsearch6RestClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/rest-6.4/src/test/groovy/Elasticsearch6RestClientTest.groovy
@@ -87,12 +87,12 @@ class Elasticsearch6RestClientTest extends AgentTestRunner {
           parent()
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.HTTP_METHOD" "GET"
-            "$Tags.HTTP_URL" "_cluster/health"
             "$Tags.PEER_HOSTNAME" "localhost"
             "$Tags.PEER_PORT" httpPort
+            "$Tags.HTTP_URL" "_cluster/health"
+            "$Tags.HTTP_METHOD" "GET"
+            "$Tags.DB_TYPE" "elasticsearch"
             defaultTags()
           }
         }
@@ -105,8 +105,8 @@ class Elasticsearch6RestClientTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT" "apache-httpasyncclient"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.HTTP_METHOD" "GET"
             "$Tags.HTTP_URL" "_cluster/health"
+            "$Tags.HTTP_METHOD" "GET"
             "$Tags.HTTP_STATUS" 200
             defaultTags()
           }

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/Elasticsearch2NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/Elasticsearch2NodeClientTest.groovy
@@ -79,8 +79,8 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
             defaultTags()
@@ -108,8 +108,8 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           errored true
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -180,8 +180,8 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "CreateIndexAction"
             "elasticsearch.request" "CreateIndexRequest"
             "elasticsearch.request.indices" indexName
@@ -197,8 +197,8 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
             defaultTags()
@@ -213,8 +213,8 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -233,8 +233,8 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "PutMappingAction"
             "elasticsearch.request" "PutMappingRequest"
             "elasticsearch.request.indices" indexName
@@ -250,8 +250,8 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
@@ -268,8 +268,8 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/Elasticsearch2TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/Elasticsearch2TransportClientTest.groovy
@@ -90,11 +90,11 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "localhost"
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
             "$Tags.PEER_PORT" tcpPort
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
             defaultTags()
@@ -122,8 +122,8 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
           errored true
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -194,14 +194,14 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "elasticsearch.action" "CreateIndexAction"
-            "elasticsearch.request" "CreateIndexRequest"
-            "elasticsearch.request.indices" indexName
             "$Tags.PEER_HOSTNAME" "localhost"
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
             "$Tags.PEER_PORT" tcpPort
+            "$Tags.DB_TYPE" "elasticsearch"
+            "elasticsearch.action" "CreateIndexAction"
+            "elasticsearch.request" "CreateIndexRequest"
+            "elasticsearch.request.indices" indexName
             defaultTags()
           }
         }
@@ -214,13 +214,13 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "elasticsearch.action" "ClusterHealthAction"
-            "elasticsearch.request" "ClusterHealthRequest"
             "$Tags.PEER_HOSTNAME" "localhost"
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
             "$Tags.PEER_PORT" tcpPort
+            "$Tags.DB_TYPE" "elasticsearch"
+            "elasticsearch.action" "ClusterHealthAction"
+            "elasticsearch.request" "ClusterHealthRequest"
             defaultTags()
           }
         }
@@ -233,11 +233,11 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "localhost"
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
             "$Tags.PEER_PORT" tcpPort
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -256,8 +256,8 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "PutMappingAction"
             "elasticsearch.request" "PutMappingRequest"
             "elasticsearch.request.indices" indexName
@@ -273,11 +273,11 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "localhost"
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
             "$Tags.PEER_PORT" tcpPort
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
@@ -294,11 +294,11 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "localhost"
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
             "$Tags.PEER_PORT" tcpPort
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/springdata/Elasticsearch2SpringRepositoryTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/springdata/Elasticsearch2SpringRepositoryTest.groovy
@@ -45,8 +45,8 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           errored false
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "SearchAction"
             "elasticsearch.request" "SearchRequest"
             "elasticsearch.request.indices" indexName
@@ -77,8 +77,8 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
@@ -94,8 +94,8 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "RefreshAction"
             "elasticsearch.request" "RefreshRequest"
             "elasticsearch.request.indices" indexName
@@ -122,8 +122,8 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -153,8 +153,8 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
@@ -170,8 +170,8 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "RefreshAction"
             "elasticsearch.request" "RefreshRequest"
             "elasticsearch.request.indices" indexName
@@ -190,8 +190,8 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -220,8 +220,8 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "DeleteAction"
             "elasticsearch.request" "DeleteRequest"
             "elasticsearch.request.indices" indexName
@@ -237,8 +237,8 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "RefreshAction"
             "elasticsearch.request" "RefreshRequest"
             "elasticsearch.request.indices" indexName
@@ -257,8 +257,8 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "SearchAction"
             "elasticsearch.request" "SearchRequest"
             "elasticsearch.request.indices" indexName

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
@@ -85,8 +85,8 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           errored true
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "RefreshAction"
             "elasticsearch.request" "RefreshRequest"
             "elasticsearch.request.indices" indexName
@@ -148,8 +148,8 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "CreateIndexAction"
             "elasticsearch.request" "CreateIndexRequest"
             "elasticsearch.request.indices" indexName
@@ -165,8 +165,8 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
             defaultTags()
@@ -181,8 +181,8 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "SearchAction"
             "elasticsearch.request" "SearchRequest"
             "elasticsearch.request.indices" indexName
@@ -199,8 +199,8 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "PutMappingAction"
             "elasticsearch.request" "PutMappingRequest"
             "elasticsearch.request.indices" indexName
@@ -216,8 +216,8 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
@@ -234,8 +234,8 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "RefreshAction"
             "elasticsearch.request" "RefreshRequest"
             "elasticsearch.request.indices" indexName
@@ -254,8 +254,8 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "SearchAction"
             "elasticsearch.request" "SearchRequest"
             "elasticsearch.request.indices" indexName
@@ -338,8 +338,8 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "SearchAction"
             "elasticsearch.request" "SearchRequest"
             "elasticsearch.request.indices" indexName

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/Elasticsearch2NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/Elasticsearch2NodeClientTest.groovy
@@ -79,8 +79,8 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
             defaultTags()
@@ -108,8 +108,8 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           errored true
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -180,8 +180,8 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "CreateIndexAction"
             "elasticsearch.request" "CreateIndexRequest"
             "elasticsearch.request.indices" indexName
@@ -197,8 +197,8 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
             defaultTags()
@@ -213,11 +213,11 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "local"
             "$Tags.PEER_HOST_IPV4" "0.0.0.0"
             "$Tags.PEER_PORT" 0
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -236,8 +236,8 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "PutMappingAction"
             "elasticsearch.request" "PutMappingRequest"
             "elasticsearch.request.indices" indexName
@@ -253,11 +253,11 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "local"
             "$Tags.PEER_HOST_IPV4" "0.0.0.0"
             "$Tags.PEER_PORT" 0
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
@@ -274,11 +274,11 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "local"
             "$Tags.PEER_HOST_IPV4" "0.0.0.0"
             "$Tags.PEER_PORT" 0
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/Elasticsearch2TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/Elasticsearch2TransportClientTest.groovy
@@ -90,11 +90,11 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "127.0.0.1"
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
             "$Tags.PEER_PORT" tcpPort
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
             defaultTags()
@@ -122,8 +122,8 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
           errored true
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -194,14 +194,14 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "elasticsearch.action" "CreateIndexAction"
-            "elasticsearch.request" "CreateIndexRequest"
-            "elasticsearch.request.indices" indexName
             "$Tags.PEER_HOSTNAME" "127.0.0.1"
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
             "$Tags.PEER_PORT" tcpPort
+            "$Tags.DB_TYPE" "elasticsearch"
+            "elasticsearch.action" "CreateIndexAction"
+            "elasticsearch.request" "CreateIndexRequest"
+            "elasticsearch.request.indices" indexName
             defaultTags()
           }
         }
@@ -214,13 +214,13 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "elasticsearch.action" "ClusterHealthAction"
-            "elasticsearch.request" "ClusterHealthRequest"
             "$Tags.PEER_HOSTNAME" "127.0.0.1"
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
             "$Tags.PEER_PORT" tcpPort
+            "$Tags.DB_TYPE" "elasticsearch"
+            "elasticsearch.action" "ClusterHealthAction"
+            "elasticsearch.request" "ClusterHealthRequest"
             defaultTags()
           }
         }
@@ -233,11 +233,11 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "127.0.0.1"
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
             "$Tags.PEER_PORT" tcpPort
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -256,8 +256,8 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "PutMappingAction"
             "elasticsearch.request" "PutMappingRequest"
             "elasticsearch.request.indices" indexName
@@ -273,11 +273,11 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "127.0.0.1"
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
             "$Tags.PEER_PORT" tcpPort
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
@@ -294,11 +294,11 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "127.0.0.1"
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
             "$Tags.PEER_PORT" tcpPort
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/springdata/Elasticsearch2SpringRepositoryTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/springdata/Elasticsearch2SpringRepositoryTest.groovy
@@ -45,8 +45,8 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           errored false
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "SearchAction"
             "elasticsearch.request" "SearchRequest"
             "elasticsearch.request.indices" indexName
@@ -77,11 +77,11 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "local"
             "$Tags.PEER_HOST_IPV4" "0.0.0.0"
             "$Tags.PEER_PORT" 0
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
@@ -97,8 +97,8 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "RefreshAction"
             "elasticsearch.request" "RefreshRequest"
             "elasticsearch.request.indices" indexName
@@ -125,11 +125,11 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "local"
             "$Tags.PEER_HOST_IPV4" "0.0.0.0"
             "$Tags.PEER_PORT" 0
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -159,11 +159,11 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "local"
             "$Tags.PEER_HOST_IPV4" "0.0.0.0"
             "$Tags.PEER_PORT" 0
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
@@ -179,8 +179,8 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "RefreshAction"
             "elasticsearch.request" "RefreshRequest"
             "elasticsearch.request.indices" indexName
@@ -199,11 +199,11 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "local"
             "$Tags.PEER_HOST_IPV4" "0.0.0.0"
             "$Tags.PEER_PORT" 0
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -232,11 +232,11 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "local"
             "$Tags.PEER_HOST_IPV4" "0.0.0.0"
             "$Tags.PEER_PORT" 0
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "DeleteAction"
             "elasticsearch.request" "DeleteRequest"
             "elasticsearch.request.indices" indexName
@@ -252,8 +252,8 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "RefreshAction"
             "elasticsearch.request" "RefreshRequest"
             "elasticsearch.request.indices" indexName
@@ -272,8 +272,8 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "SearchAction"
             "elasticsearch.request" "SearchRequest"
             "elasticsearch.request.indices" indexName

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
@@ -85,8 +85,8 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           errored true
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "RefreshAction"
             "elasticsearch.request" "RefreshRequest"
             "elasticsearch.request.indices" indexName
@@ -148,8 +148,8 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "CreateIndexAction"
             "elasticsearch.request" "CreateIndexRequest"
             "elasticsearch.request.indices" indexName
@@ -165,8 +165,8 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
             defaultTags()
@@ -181,8 +181,8 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "SearchAction"
             "elasticsearch.request" "SearchRequest"
             "elasticsearch.request.indices" indexName
@@ -199,8 +199,8 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "PutMappingAction"
             "elasticsearch.request" "PutMappingRequest"
             "elasticsearch.request.indices" indexName
@@ -216,11 +216,11 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "local"
             "$Tags.PEER_HOST_IPV4" "0.0.0.0"
             "$Tags.PEER_PORT" 0
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
@@ -237,8 +237,8 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "RefreshAction"
             "elasticsearch.request" "RefreshRequest"
             "elasticsearch.request.indices" indexName
@@ -257,8 +257,8 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "SearchAction"
             "elasticsearch.request" "SearchRequest"
             "elasticsearch.request.indices" indexName
@@ -338,8 +338,8 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "SearchAction"
             "elasticsearch.request" "SearchRequest"
             "elasticsearch.request.indices" indexName

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/Elasticsearch53NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/Elasticsearch53NodeClientTest.groovy
@@ -85,8 +85,8 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
             defaultTags()
@@ -114,8 +114,8 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
           errored true
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -187,8 +187,8 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "CreateIndexAction"
             "elasticsearch.request" "CreateIndexRequest"
             "elasticsearch.request.indices" indexName
@@ -204,8 +204,8 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
             defaultTags()
@@ -220,8 +220,8 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -240,8 +240,8 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "PutMappingAction"
             "elasticsearch.request" "PutMappingRequest"
             defaultTags()
@@ -256,8 +256,8 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
@@ -279,8 +279,8 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/Elasticsearch53TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/Elasticsearch53TransportClientTest.groovy
@@ -97,11 +97,11 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "localhost"
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
             "$Tags.PEER_PORT" tcpPort
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
             defaultTags()
@@ -129,8 +129,8 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
           errored true
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -201,11 +201,11 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "localhost"
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
             "$Tags.PEER_PORT" tcpPort
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "CreateIndexAction"
             "elasticsearch.request" "CreateIndexRequest"
             "elasticsearch.request.indices" indexName
@@ -221,11 +221,11 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "localhost"
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
             "$Tags.PEER_PORT" tcpPort
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -244,8 +244,8 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "PutMappingAction"
             "elasticsearch.request" "PutMappingRequest"
             defaultTags()
@@ -260,11 +260,11 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "localhost"
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
             "$Tags.PEER_PORT" tcpPort
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
@@ -286,11 +286,11 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "localhost"
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
             "$Tags.PEER_PORT" tcpPort
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/springdata/Elasticsearch53SpringRepositoryTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/springdata/Elasticsearch53SpringRepositoryTest.groovy
@@ -90,8 +90,8 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
 
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "SearchAction"
             "elasticsearch.request" "SearchRequest"
             "elasticsearch.request.indices" indexName
@@ -133,8 +133,8 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           childOf(span(0))
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "RefreshAction"
             "elasticsearch.request" "RefreshRequest"
             "elasticsearch.request.indices" indexName
@@ -152,8 +152,8 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           childOf(span(0))
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
@@ -194,8 +194,8 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           childOf(span(0))
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -235,8 +235,8 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           childOf(span(0))
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "RefreshAction"
             "elasticsearch.request" "RefreshRequest"
             "elasticsearch.request.indices" indexName
@@ -253,8 +253,8 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           childOf(span(0))
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
@@ -287,8 +287,8 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           childOf(span(0))
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -328,8 +328,8 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           childOf(span(0))
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "RefreshAction"
             "elasticsearch.request" "RefreshRequest"
             "elasticsearch.request.indices" indexName
@@ -346,8 +346,8 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           childOf(span(0))
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "DeleteAction"
             "elasticsearch.request" "DeleteRequest"
             "elasticsearch.request.indices" indexName
@@ -380,8 +380,8 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           childOf(span(0))
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "SearchAction"
             "elasticsearch.request" "SearchRequest"
             "elasticsearch.request.indices" indexName

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/springdata/Elasticsearch53SpringTemplateTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/springdata/Elasticsearch53SpringTemplateTest.groovy
@@ -105,8 +105,8 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
           errored true
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "RefreshAction"
             "elasticsearch.request" "RefreshRequest"
             "elasticsearch.request.indices" indexName
@@ -172,8 +172,8 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "CreateIndexAction"
             "elasticsearch.request" "CreateIndexRequest"
             "elasticsearch.request.indices" indexName
@@ -189,8 +189,8 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
             defaultTags()
@@ -205,8 +205,8 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "SearchAction"
             "elasticsearch.request" "SearchRequest"
             "elasticsearch.request.indices" indexName
@@ -223,8 +223,8 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "PutMappingAction"
             "elasticsearch.request" "PutMappingRequest"
             defaultTags()
@@ -239,8 +239,8 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
@@ -262,8 +262,8 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "RefreshAction"
             "elasticsearch.request" "RefreshRequest"
             "elasticsearch.request.indices" indexName
@@ -282,8 +282,8 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "SearchAction"
             "elasticsearch.request" "SearchRequest"
             "elasticsearch.request.indices" indexName
@@ -366,8 +366,8 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "SearchAction"
             "elasticsearch.request" "SearchRequest"
             "elasticsearch.request.indices" indexName

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5/src/test/groovy/Elasticsearch5NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5/src/test/groovy/Elasticsearch5NodeClientTest.groovy
@@ -85,8 +85,8 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
             defaultTags()
@@ -114,8 +114,8 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
           errored true
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -187,8 +187,8 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "CreateIndexAction"
             "elasticsearch.request" "CreateIndexRequest"
             "elasticsearch.request.indices" indexName
@@ -204,8 +204,8 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
             defaultTags()
@@ -220,8 +220,8 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -240,8 +240,8 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "PutMappingAction"
             "elasticsearch.request" "PutMappingRequest"
             defaultTags()
@@ -256,8 +256,8 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
@@ -278,8 +278,8 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5/src/test/groovy/Elasticsearch5TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5/src/test/groovy/Elasticsearch5TransportClientTest.groovy
@@ -97,11 +97,11 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" String
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
             "$Tags.PEER_PORT" tcpPort
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
             defaultTags()
@@ -129,8 +129,8 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
           errored true
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -201,14 +201,14 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "elasticsearch.action" "CreateIndexAction"
-            "elasticsearch.request" "CreateIndexRequest"
-            "elasticsearch.request.indices" indexName
             "$Tags.PEER_HOSTNAME" String
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
             "$Tags.PEER_PORT" tcpPort
+            "$Tags.DB_TYPE" "elasticsearch"
+            "elasticsearch.action" "CreateIndexAction"
+            "elasticsearch.request" "CreateIndexRequest"
+            "elasticsearch.request.indices" indexName
             defaultTags()
           }
         }
@@ -221,11 +221,11 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" String
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
             "$Tags.PEER_PORT" tcpPort
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -244,8 +244,8 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "PutMappingAction"
             "elasticsearch.request" "PutMappingRequest"
             defaultTags()
@@ -260,11 +260,11 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" String
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
             "$Tags.PEER_PORT" tcpPort
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
@@ -285,11 +285,11 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" String
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
             "$Tags.PEER_PORT" tcpPort
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName

--- a/dd-java-agent/instrumentation/elasticsearch/transport-6/src/test/groovy/Elasticsearch6NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-6/src/test/groovy/Elasticsearch6NodeClientTest.groovy
@@ -82,8 +82,8 @@ class Elasticsearch6NodeClientTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
             defaultTags()
@@ -111,8 +111,8 @@ class Elasticsearch6NodeClientTest extends AgentTestRunner {
           errored true
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -183,8 +183,8 @@ class Elasticsearch6NodeClientTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "CreateIndexAction"
             "elasticsearch.request" "CreateIndexRequest"
             "elasticsearch.request.indices" indexName
@@ -200,8 +200,8 @@ class Elasticsearch6NodeClientTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -220,8 +220,8 @@ class Elasticsearch6NodeClientTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "PutMappingAction"
             "elasticsearch.request" "PutMappingRequest"
             defaultTags()
@@ -236,8 +236,8 @@ class Elasticsearch6NodeClientTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
@@ -259,8 +259,8 @@ class Elasticsearch6NodeClientTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName

--- a/dd-java-agent/instrumentation/elasticsearch/transport-6/src/test/groovy/Elasticsearch6TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-6/src/test/groovy/Elasticsearch6TransportClientTest.groovy
@@ -94,11 +94,11 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "localhost"
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
             "$Tags.PEER_PORT" tcpPort
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
             defaultTags()
@@ -126,8 +126,8 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
           errored true
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -198,11 +198,11 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "localhost"
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
             "$Tags.PEER_PORT" tcpPort
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "CreateIndexAction"
             "elasticsearch.request" "CreateIndexRequest"
             "elasticsearch.request.indices" indexName
@@ -218,11 +218,11 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "localhost"
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
             "$Tags.PEER_PORT" tcpPort
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -241,8 +241,8 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "PutMappingAction"
             "elasticsearch.request" "PutMappingRequest"
             defaultTags()
@@ -257,11 +257,11 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "localhost"
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
             "$Tags.PEER_PORT" tcpPort
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
@@ -283,11 +283,11 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "localhost"
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
             "$Tags.PEER_PORT" tcpPort
+            "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName

--- a/dd-java-agent/instrumentation/glassfish/src/test/groovy/GlassFishServerTest.groovy
+++ b/dd-java-agent/instrumentation/glassfish/src/test/groovy/GlassFishServerTest.groovy
@@ -100,25 +100,24 @@ class GlassFishServerTest extends HttpServerTest<GlassFish, Servlet3Decorator> {
         parent()
       }
       tags {
+        "$Tags.COMPONENT" serverDecorator.component()
+        "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
+        "$Tags.PEER_HOSTNAME" { it == "localhost" || it == "127.0.0.1" }
+        "$Tags.PEER_HOST_IPV4" { it == null || it == "127.0.0.1" } // Optional
+        "$Tags.PEER_PORT" Integer
+        "$Tags.HTTP_STATUS" endpoint.status
+        "$Tags.HTTP_METHOD" method
+        "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "servlet.context" "/$context"
         "servlet.path" endpoint.path
         "span.origin.type" { it.startsWith("TestServlets\$") || it == DefaultServlet.name }
-
-        defaultTags(true)
-        "$Tags.COMPONENT" serverDecorator.component()
         if (endpoint.errored) {
           "$Tags.ERROR" endpoint.errored
           "error.msg" { it == null || it == EXCEPTION.body }
           "error.type" { it == null || it == Exception.name }
           "error.stack" { it == null || it instanceof String }
         }
-        "$Tags.HTTP_STATUS" endpoint.status
-        "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
-        "$Tags.PEER_HOSTNAME" { it == "localhost" || it == "127.0.0.1" }
-        "$Tags.PEER_PORT" Integer
-        "$Tags.PEER_HOST_IPV4" { it == null || it == "127.0.0.1" } // Optional
-        "$Tags.HTTP_METHOD" method
-        "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
+        defaultTags(true)
       }
     }
   }

--- a/dd-java-agent/instrumentation/google-http-client/src/test/groovy/AbstractGoogleHttpClientTest.groovy
+++ b/dd-java-agent/instrumentation/google-http-client/src/test/groovy/AbstractGoogleHttpClientTest.groovy
@@ -4,6 +4,7 @@ import com.google.api.client.http.HttpResponse
 import com.google.api.client.http.javanet.NetHttpTransport
 import datadog.trace.agent.test.base.HttpClientTest
 import datadog.trace.api.DDSpanTypes
+import datadog.trace.instrumentation.api.Tags
 import datadog.trace.instrumentation.googlehttpclient.GoogleHttpClientDecorator
 import spock.lang.Shared
 
@@ -59,6 +60,17 @@ abstract class AbstractGoogleHttpClientTest extends HttpClientTest<GoogleHttpCli
           resourceName "$method $uri.path"
           spanType DDSpanTypes.HTTP_CLIENT
           errored true
+          tags {
+            "$Tags.COMPONENT" "google-http-client"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" "localhost"
+            "$Tags.PEER_PORT" Integer
+            "$Tags.HTTP_URL" String
+            "$Tags.HTTP_METHOD" String
+            "$Tags.HTTP_STATUS" Integer
+            "$Tags.ERROR" true
+            defaultTags()
+          }
         }
       }
     }

--- a/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcStreamingTest.groovy
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcStreamingTest.groovy
@@ -91,9 +91,9 @@ class GrpcStreamingTest extends AgentTestRunner {
           childOf trace(1).get(0)
           errored false
           tags {
-            "status.code" "OK"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
             "$Tags.COMPONENT" "grpc-server"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
+            "status.code" "OK"
             defaultTags(true)
           }
         }
@@ -106,8 +106,8 @@ class GrpcStreamingTest extends AgentTestRunner {
             childOf span(0)
             errored false
             tags {
-              "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
               "$Tags.COMPONENT" "grpc-server"
+              "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
               "message.type" "example.Helloworld\$Response"
               defaultTags()
             }
@@ -123,9 +123,9 @@ class GrpcStreamingTest extends AgentTestRunner {
           parent()
           errored false
           tags {
-            "status.code" "OK"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.COMPONENT" "grpc-client"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "status.code" "OK"
             defaultTags()
           }
         }
@@ -138,8 +138,8 @@ class GrpcStreamingTest extends AgentTestRunner {
             childOf span(0)
             errored false
             tags {
-              "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
               "$Tags.COMPONENT" "grpc-client"
+              "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
               "message.type" "example.Helloworld\$Response"
               defaultTags()
             }

--- a/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcTest.groovy
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcTest.groovy
@@ -47,9 +47,9 @@ class GrpcTest extends AgentTestRunner {
           childOf trace(1).get(0)
           errored false
           tags {
-            "status.code" "OK"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
             "$Tags.COMPONENT" "grpc-server"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
+            "status.code" "OK"
             defaultTags(true)
           }
         }
@@ -61,8 +61,8 @@ class GrpcTest extends AgentTestRunner {
           childOf span(0)
           errored false
           tags {
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
             "$Tags.COMPONENT" "grpc-server"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
             "message.type" "example.Helloworld\$Request"
             defaultTags()
           }
@@ -77,9 +77,9 @@ class GrpcTest extends AgentTestRunner {
           parent()
           errored false
           tags {
-            "status.code" "OK"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.COMPONENT" "grpc-client"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "status.code" "OK"
             defaultTags()
           }
         }
@@ -91,8 +91,8 @@ class GrpcTest extends AgentTestRunner {
           childOf span(0)
           errored false
           tags {
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.COMPONENT" "grpc-client"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "message.type" "example.Helloworld\$Response"
             defaultTags()
           }
@@ -139,10 +139,10 @@ class GrpcTest extends AgentTestRunner {
           childOf trace(1).get(0)
           errored true
           tags {
+            "$Tags.COMPONENT" "grpc-server"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
             "status.code" "${status.code.name()}"
             "status.description" description
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
-            "$Tags.COMPONENT" "grpc-server"
             if (status.cause != null) {
               errorTags status.cause.class, status.cause.message
             } else {
@@ -159,8 +159,8 @@ class GrpcTest extends AgentTestRunner {
           childOf span(0)
           errored false
           tags {
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
             "$Tags.COMPONENT" "grpc-server"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
             "message.type" "example.Helloworld\$Request"
             defaultTags()
           }
@@ -175,10 +175,10 @@ class GrpcTest extends AgentTestRunner {
           parent()
           errored true
           tags {
+            "$Tags.COMPONENT" "grpc-client"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "status.code" "${status.code.name()}"
             "status.description" description
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.COMPONENT" "grpc-client"
             tag "error", true
             defaultTags()
           }
@@ -231,8 +231,8 @@ class GrpcTest extends AgentTestRunner {
           childOf trace(1).get(0)
           errored true
           tags {
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
             "$Tags.COMPONENT" "grpc-server"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
             errorTags error.class, error.message
             defaultTags(true)
           }
@@ -245,8 +245,8 @@ class GrpcTest extends AgentTestRunner {
           childOf span(0)
           errored false
           tags {
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
             "$Tags.COMPONENT" "grpc-server"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
             "message.type" "example.Helloworld\$Request"
             defaultTags()
           }
@@ -261,9 +261,9 @@ class GrpcTest extends AgentTestRunner {
           parent()
           errored true
           tags {
-            "status.code" "UNKNOWN"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.COMPONENT" "grpc-client"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "status.code" "UNKNOWN"
             tag "error", true
             defaultTags()
           }

--- a/dd-java-agent/instrumentation/hibernate/core-3.3/src/test/groovy/CriteriaTest.groovy
+++ b/dd-java-agent/instrumentation/hibernate/core-3.3/src/test/groovy/CriteriaTest.groovy
@@ -61,6 +61,15 @@ class CriteriaTest extends AbstractHibernateTest {
           serviceName "h2"
           spanType "sql"
           childOf span(2)
+          tags {
+            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "h2"
+            "$Tags.DB_INSTANCE" "db1"
+            "$Tags.DB_USER" "sa"
+            "span.origin.type" "org.h2.jdbc.JdbcPreparedStatement"
+            defaultTags()
+          }
         }
       }
     }

--- a/dd-java-agent/instrumentation/hibernate/core-3.3/src/test/groovy/QueryTest.groovy
+++ b/dd-java-agent/instrumentation/hibernate/core-3.3/src/test/groovy/QueryTest.groovy
@@ -66,6 +66,15 @@ class QueryTest extends AbstractHibernateTest {
           serviceName "h2"
           spanType "sql"
           childOf span(2)
+          tags {
+            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "h2"
+            "$Tags.DB_INSTANCE" "db1"
+            "$Tags.DB_USER" "sa"
+            "span.origin.type" "org.h2.jdbc.JdbcPreparedStatement"
+            defaultTags()
+          }
         }
       }
       if (!requiresTransaction) {
@@ -99,6 +108,15 @@ class QueryTest extends AbstractHibernateTest {
             serviceName "h2"
             spanType "sql"
             childOf span(1)
+            tags {
+              "$Tags.COMPONENT" "java-jdbc-prepared_statement"
+              "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+              "$Tags.DB_TYPE" "h2"
+              "$Tags.DB_INSTANCE" "db1"
+              "$Tags.DB_USER" "sa"
+              "span.origin.type" "org.h2.jdbc.JdbcPreparedStatement"
+              defaultTags()
+            }
           }
         }
       }
@@ -184,6 +202,15 @@ class QueryTest extends AbstractHibernateTest {
           serviceName "h2"
           spanType "sql"
           childOf span(2)
+          tags {
+            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "h2"
+            "$Tags.DB_INSTANCE" "db1"
+            "$Tags.DB_USER" "sa"
+            "span.origin.type" "org.h2.jdbc.JdbcPreparedStatement"
+            defaultTags()
+          }
         }
       }
     }

--- a/dd-java-agent/instrumentation/hibernate/core-3.3/src/test/groovy/SessionTest.groovy
+++ b/dd-java-agent/instrumentation/hibernate/core-3.3/src/test/groovy/SessionTest.groovy
@@ -81,6 +81,15 @@ class SessionTest extends AbstractHibernateTest {
             serviceName "h2"
             spanType "sql"
             childOf span(2)
+            tags {
+              "$Tags.COMPONENT" "java-jdbc-prepared_statement"
+              "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+              "$Tags.DB_TYPE" "h2"
+              "$Tags.DB_INSTANCE" "db1"
+              "$Tags.DB_USER" "sa"
+              "span.origin.type" "org.h2.jdbc.JdbcPreparedStatement"
+              defaultTags()
+            }
           }
         }
       }
@@ -146,6 +155,15 @@ class SessionTest extends AbstractHibernateTest {
           serviceName "h2"
           spanType "sql"
           childOf span(1)
+          tags {
+            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "h2"
+            "$Tags.DB_INSTANCE" "db1"
+            "$Tags.DB_USER" "sa"
+            "span.origin.type" "org.h2.jdbc.JdbcPreparedStatement"
+            defaultTags()
+          }
         }
         span(3) {
           serviceName "hibernate"
@@ -227,6 +245,15 @@ class SessionTest extends AbstractHibernateTest {
           serviceName "h2"
           spanType "sql"
           childOf span(1)
+          tags {
+            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "h2"
+            "$Tags.DB_INSTANCE" "db1"
+            "$Tags.DB_USER" "sa"
+            "span.origin.type" "org.h2.jdbc.JdbcPreparedStatement"
+            defaultTags()
+          }
         }
         span(3) {
           serviceName "hibernate"
@@ -244,6 +271,15 @@ class SessionTest extends AbstractHibernateTest {
           serviceName "h2"
           spanType "sql"
           childOf span(3)
+          tags {
+            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "h2"
+            "$Tags.DB_INSTANCE" "db1"
+            "$Tags.DB_USER" "sa"
+            "span.origin.type" "org.h2.jdbc.JdbcPreparedStatement"
+            defaultTags()
+          }
         }
       }
 
@@ -372,6 +408,15 @@ class SessionTest extends AbstractHibernateTest {
           serviceName "h2"
           spanType "sql"
           childOf span(1)
+          tags {
+            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "h2"
+            "$Tags.DB_INSTANCE" "db1"
+            "$Tags.DB_USER" "sa"
+            "span.origin.type" "org.h2.jdbc.JdbcPreparedStatement"
+            defaultTags()
+          }
         }
         span(3) {
           serviceName "hibernate"
@@ -473,6 +518,15 @@ class SessionTest extends AbstractHibernateTest {
           serviceName "h2"
           spanType "sql"
           childOf span(2)
+          tags {
+            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "h2"
+            "$Tags.DB_INSTANCE" "db1"
+            "$Tags.DB_USER" "sa"
+            "span.origin.type" "org.h2.jdbc.JdbcPreparedStatement"
+            defaultTags()
+          }
         }
       }
     }
@@ -515,6 +569,9 @@ class SessionTest extends AbstractHibernateTest {
         span(0) {
           serviceName "unnamed-java-app"
           operationName "overlapping Sessions"
+          tags {
+            defaultTags()
+          }
         }
         span(1) {
           serviceName "hibernate"
@@ -556,11 +613,29 @@ class SessionTest extends AbstractHibernateTest {
           serviceName "h2"
           spanType "sql"
           childOf span(3)
+          tags {
+            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "h2"
+            "$Tags.DB_INSTANCE" "db1"
+            "$Tags.DB_USER" "sa"
+            "span.origin.type" "org.h2.jdbc.JdbcPreparedStatement"
+            defaultTags()
+          }
         }
         span(5) {
           serviceName "h2"
           spanType "sql"
           childOf span(3)
+          tags {
+            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "h2"
+            "$Tags.DB_INSTANCE" "db1"
+            "$Tags.DB_USER" "sa"
+            "span.origin.type" "org.h2.jdbc.JdbcPreparedStatement"
+            defaultTags()
+          }
         }
         span(6) {
           serviceName "hibernate"

--- a/dd-java-agent/instrumentation/hibernate/core-3.3/src/test/groovy/SessionTest.groovy
+++ b/dd-java-agent/instrumentation/hibernate/core-3.3/src/test/groovy/SessionTest.groovy
@@ -314,10 +314,9 @@ class SessionTest extends AbstractHibernateTest {
           childOf span(0)
           errored(true)
           tags {
-            errorTags(MappingException, "Unknown entity: java.lang.Long")
-
             "$Tags.COMPONENT" "java-hibernate"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            errorTags(MappingException, "Unknown entity: java.lang.Long")
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/hibernate/core-4.0/src/test/groovy/CriteriaTest.groovy
+++ b/dd-java-agent/instrumentation/hibernate/core-4.0/src/test/groovy/CriteriaTest.groovy
@@ -61,6 +61,15 @@ class CriteriaTest extends AbstractHibernateTest {
           serviceName "h2"
           spanType "sql"
           childOf span(2)
+          tags {
+            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "h2"
+            "$Tags.DB_INSTANCE" "db1"
+            "$Tags.DB_USER" "sa"
+            "span.origin.type" "org.h2.jdbc.JdbcPreparedStatement"
+            defaultTags()
+          }
         }
       }
     }

--- a/dd-java-agent/instrumentation/hibernate/core-4.0/src/test/groovy/QueryTest.groovy
+++ b/dd-java-agent/instrumentation/hibernate/core-4.0/src/test/groovy/QueryTest.groovy
@@ -66,6 +66,15 @@ class QueryTest extends AbstractHibernateTest {
           serviceName "h2"
           spanType "sql"
           childOf span(2)
+          tags {
+            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "h2"
+            "$Tags.DB_INSTANCE" "db1"
+            "$Tags.DB_USER" "sa"
+            "span.origin.type" "org.h2.jdbc.JdbcPreparedStatement"
+            defaultTags()
+          }
         }
       }
       if (!requiresTransaction) {
@@ -99,6 +108,15 @@ class QueryTest extends AbstractHibernateTest {
             serviceName "h2"
             spanType "sql"
             childOf span(1)
+            tags {
+              "$Tags.COMPONENT" "java-jdbc-prepared_statement"
+              "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+              "$Tags.DB_TYPE" "h2"
+              "$Tags.DB_INSTANCE" "db1"
+              "$Tags.DB_USER" "sa"
+              "span.origin.type" "org.h2.jdbc.JdbcPreparedStatement"
+              defaultTags()
+            }
           }
         }
       }
@@ -184,6 +202,15 @@ class QueryTest extends AbstractHibernateTest {
           serviceName "h2"
           spanType "sql"
           childOf span(2)
+          tags {
+            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "h2"
+            "$Tags.DB_INSTANCE" "db1"
+            "$Tags.DB_USER" "sa"
+            "span.origin.type" "org.h2.jdbc.JdbcPreparedStatement"
+            defaultTags()
+          }
         }
       }
     }

--- a/dd-java-agent/instrumentation/hibernate/core-4.0/src/test/groovy/SessionTest.groovy
+++ b/dd-java-agent/instrumentation/hibernate/core-4.0/src/test/groovy/SessionTest.groovy
@@ -81,6 +81,15 @@ class SessionTest extends AbstractHibernateTest {
             serviceName "h2"
             spanType "sql"
             childOf span(2)
+            tags {
+              "$Tags.COMPONENT" "java-jdbc-prepared_statement"
+              "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+              "$Tags.DB_TYPE" "h2"
+              "$Tags.DB_INSTANCE" "db1"
+              "$Tags.DB_USER" "sa"
+              "span.origin.type" "org.h2.jdbc.JdbcPreparedStatement"
+              defaultTags()
+            }
           }
         }
       }
@@ -160,6 +169,15 @@ class SessionTest extends AbstractHibernateTest {
           serviceName "h2"
           spanType "sql"
           childOf span(1)
+          tags {
+            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "h2"
+            "$Tags.DB_INSTANCE" "db1"
+            "$Tags.DB_USER" "sa"
+            "span.origin.type" "org.h2.jdbc.JdbcPreparedStatement"
+            defaultTags()
+          }
         }
         span(3) {
           serviceName "hibernate"
@@ -177,6 +195,15 @@ class SessionTest extends AbstractHibernateTest {
           serviceName "h2"
           spanType "sql"
           childOf span(3)
+          tags {
+            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "h2"
+            "$Tags.DB_INSTANCE" "db1"
+            "$Tags.DB_USER" "sa"
+            "span.origin.type" "org.h2.jdbc.JdbcPreparedStatement"
+            defaultTags()
+          }
         }
       }
 
@@ -305,6 +332,15 @@ class SessionTest extends AbstractHibernateTest {
           serviceName "h2"
           spanType "sql"
           childOf span(1)
+          tags {
+            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "h2"
+            "$Tags.DB_INSTANCE" "db1"
+            "$Tags.DB_USER" "sa"
+            "span.origin.type" "org.h2.jdbc.JdbcPreparedStatement"
+            defaultTags()
+          }
         }
         span(3) {
           serviceName "hibernate"
@@ -406,6 +442,15 @@ class SessionTest extends AbstractHibernateTest {
           serviceName "h2"
           spanType "sql"
           childOf span(2)
+          tags {
+            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "h2"
+            "$Tags.DB_INSTANCE" "db1"
+            "$Tags.DB_USER" "sa"
+            "span.origin.type" "org.h2.jdbc.JdbcPreparedStatement"
+            defaultTags()
+          }
         }
       }
     }
@@ -448,6 +493,9 @@ class SessionTest extends AbstractHibernateTest {
         span(0) {
           serviceName "unnamed-java-app"
           operationName "overlapping Sessions"
+          tags {
+            defaultTags()
+          }
         }
         span(1) {
           serviceName "hibernate"
@@ -489,11 +537,29 @@ class SessionTest extends AbstractHibernateTest {
           serviceName "h2"
           spanType "sql"
           childOf span(3)
+          tags {
+            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "h2"
+            "$Tags.DB_INSTANCE" "db1"
+            "$Tags.DB_USER" "sa"
+            "span.origin.type" "org.h2.jdbc.JdbcPreparedStatement"
+            defaultTags()
+          }
         }
         span(5) {
           serviceName "h2"
           spanType "sql"
           childOf span(3)
+          tags {
+            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "h2"
+            "$Tags.DB_INSTANCE" "db1"
+            "$Tags.DB_USER" "sa"
+            "span.origin.type" "org.h2.jdbc.JdbcPreparedStatement"
+            defaultTags()
+          }
         }
         span(6) {
           serviceName "hibernate"
@@ -547,6 +613,15 @@ class SessionTest extends AbstractHibernateTest {
           serviceName "h2"
           spanType "sql"
           childOf span(9)
+          tags {
+            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "h2"
+            "$Tags.DB_INSTANCE" "db1"
+            "$Tags.DB_USER" "sa"
+            "span.origin.type" "org.h2.jdbc.JdbcPreparedStatement"
+            defaultTags()
+          }
         }
         span(11) {
           serviceName "hibernate"

--- a/dd-java-agent/instrumentation/hibernate/core-4.0/src/test/groovy/SessionTest.groovy
+++ b/dd-java-agent/instrumentation/hibernate/core-4.0/src/test/groovy/SessionTest.groovy
@@ -247,10 +247,9 @@ class SessionTest extends AbstractHibernateTest {
           childOf span(0)
           errored(true)
           tags {
-            errorTags(MappingException, "Unknown entity: java.lang.Long")
-
             "$Tags.COMPONENT" "java-hibernate"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            errorTags(MappingException, "Unknown entity: java.lang.Long")
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/hibernate/core-4.3/src/test/groovy/ProcedureCallTest.groovy
+++ b/dd-java-agent/instrumentation/hibernate/core-4.3/src/test/groovy/ProcedureCallTest.groovy
@@ -104,6 +104,15 @@ class ProcedureCallTest extends AgentTestRunner {
           serviceName "hsqldb"
           spanType "sql"
           childOf span(2)
+          tags {
+            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "hsqldb"
+            "$Tags.DB_INSTANCE" "test"
+            "$Tags.DB_USER" "sa"
+            "span.origin.type" "org.hsqldb.jdbc.JDBCCallableStatement"
+            defaultTags()
+          }
         }
       }
     }

--- a/dd-java-agent/instrumentation/hibernate/core-4.3/src/test/groovy/ProcedureCallTest.groovy
+++ b/dd-java-agent/instrumentation/hibernate/core-4.3/src/test/groovy/ProcedureCallTest.groovy
@@ -162,9 +162,9 @@ class ProcedureCallTest extends AgentTestRunner {
           childOf span(0)
           errored(true)
           tags {
-            errorTags(SQLGrammarException, "could not prepare statement")
             "$Tags.COMPONENT" "java-hibernate"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            errorTags(SQLGrammarException, "could not prepare statement")
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/hibernate/core-4.3/src/test/groovy/SpringJpaTest.groovy
+++ b/dd-java-agent/instrumentation/hibernate/core-4.3/src/test/groovy/SpringJpaTest.groovy
@@ -1,4 +1,5 @@
 import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.instrumentation.api.Tags
 import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import spock.lang.Shared
 import spring.jpa.Customer
@@ -31,6 +32,15 @@ class SpringJpaTest extends AgentTestRunner {
           serviceName "hsqldb"
           resourceName "select customer0_.id as id1_0_, customer0_.firstName as firstNam2_0_, customer0_.lastName as lastName3_0_ from Customer customer0_"
           spanType "sql"
+          tags {
+            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "hsqldb"
+            "$Tags.DB_INSTANCE" "test"
+            "$Tags.DB_USER" "sa"
+            "span.origin.type" "org.hsqldb.jdbc.JDBCPreparedStatement"
+            defaultTags()
+          }
         }
       }
     }
@@ -51,6 +61,15 @@ class SpringJpaTest extends AgentTestRunner {
             serviceName "hsqldb"
             resourceName "call next value for hibernate_sequence"
             spanType "sql"
+            tags {
+              "$Tags.COMPONENT" "java-jdbc-prepared_statement"
+              "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+              "$Tags.DB_TYPE" "hsqldb"
+              "$Tags.DB_INSTANCE" "test"
+              "$Tags.DB_USER" "sa"
+              "span.origin.type" "org.hsqldb.jdbc.JDBCPreparedStatement"
+              defaultTags()
+            }
           }
         }
       }
@@ -59,6 +78,15 @@ class SpringJpaTest extends AgentTestRunner {
           serviceName "hsqldb"
           resourceName ~/insert into Customer \(.*\) values \(.*, \?, \?\)/
           spanType "sql"
+          tags {
+            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "hsqldb"
+            "$Tags.DB_INSTANCE" "test"
+            "$Tags.DB_USER" "sa"
+            "span.origin.type" "org.hsqldb.jdbc.JDBCPreparedStatement"
+            defaultTags()
+          }
         }
       }
     }
@@ -76,6 +104,15 @@ class SpringJpaTest extends AgentTestRunner {
           serviceName "hsqldb"
           resourceName "select customer0_.id as id1_0_0_, customer0_.firstName as firstNam2_0_0_, customer0_.lastName as lastName3_0_0_ from Customer customer0_ where customer0_.id=?"
           spanType "sql"
+          tags {
+            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "hsqldb"
+            "$Tags.DB_INSTANCE" "test"
+            "$Tags.DB_USER" "sa"
+            "span.origin.type" "org.hsqldb.jdbc.JDBCPreparedStatement"
+            defaultTags()
+          }
         }
       }
       trace(1, 1) {
@@ -83,6 +120,15 @@ class SpringJpaTest extends AgentTestRunner {
           serviceName "hsqldb"
           resourceName "update Customer set firstName=?, lastName=? where id=?"
           spanType "sql"
+          tags {
+            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "hsqldb"
+            "$Tags.DB_INSTANCE" "test"
+            "$Tags.DB_USER" "sa"
+            "span.origin.type" "org.hsqldb.jdbc.JDBCPreparedStatement"
+            defaultTags()
+          }
         }
       }
     }
@@ -100,6 +146,15 @@ class SpringJpaTest extends AgentTestRunner {
           serviceName "hsqldb"
           resourceName "select customer0_.id as id1_0_, customer0_.firstName as firstNam2_0_, customer0_.lastName as lastName3_0_ from Customer customer0_ where customer0_.lastName=?"
           spanType "sql"
+          tags {
+            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "hsqldb"
+            "$Tags.DB_INSTANCE" "test"
+            "$Tags.DB_USER" "sa"
+            "span.origin.type" "org.hsqldb.jdbc.JDBCPreparedStatement"
+            defaultTags()
+          }
         }
       }
     }
@@ -115,6 +170,15 @@ class SpringJpaTest extends AgentTestRunner {
           serviceName "hsqldb"
           resourceName "select customer0_.id as id1_0_0_, customer0_.firstName as firstNam2_0_0_, customer0_.lastName as lastName3_0_0_ from Customer customer0_ where customer0_.id=?"
           spanType "sql"
+          tags {
+            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "hsqldb"
+            "$Tags.DB_INSTANCE" "test"
+            "$Tags.DB_USER" "sa"
+            "span.origin.type" "org.hsqldb.jdbc.JDBCPreparedStatement"
+            defaultTags()
+          }
         }
       }
       trace(1, 1) {
@@ -122,6 +186,15 @@ class SpringJpaTest extends AgentTestRunner {
           serviceName "hsqldb"
           resourceName "delete from Customer where id=?"
           spanType "sql"
+          tags {
+            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "hsqldb"
+            "$Tags.DB_INSTANCE" "test"
+            "$Tags.DB_USER" "sa"
+            "span.origin.type" "org.hsqldb.jdbc.JDBCPreparedStatement"
+            defaultTags()
+          }
         }
       }
     }

--- a/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionTest.groovy
+++ b/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionTest.groovy
@@ -98,11 +98,11 @@ class HttpUrlConnectionTest extends HttpClientTest<HttpUrlConnectionDecorator> {
           tags {
             "$Tags.COMPONENT" "http-url-connection"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" "localhost"
+            "$Tags.PEER_PORT" server.address.port
             "$Tags.HTTP_URL" "$url"
             "$Tags.HTTP_METHOD" "GET"
             "$Tags.HTTP_STATUS" STATUS
-            "$Tags.PEER_HOSTNAME" "localhost"
-            "$Tags.PEER_PORT" server.address.port
             defaultTags()
           }
         }
@@ -116,11 +116,11 @@ class HttpUrlConnectionTest extends HttpClientTest<HttpUrlConnectionDecorator> {
           tags {
             "$Tags.COMPONENT" "http-url-connection"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" "localhost"
+            "$Tags.PEER_PORT" server.address.port
             "$Tags.HTTP_URL" "$url"
             "$Tags.HTTP_METHOD" "GET"
             "$Tags.HTTP_STATUS" STATUS
-            "$Tags.PEER_HOSTNAME" "localhost"
-            "$Tags.PEER_PORT" server.address.port
             defaultTags()
           }
         }
@@ -183,11 +183,11 @@ class HttpUrlConnectionTest extends HttpClientTest<HttpUrlConnectionDecorator> {
           tags {
             "$Tags.COMPONENT" "http-url-connection"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" "localhost"
+            "$Tags.PEER_PORT" server.address.port
             "$Tags.HTTP_URL" "$url"
             "$Tags.HTTP_METHOD" "GET"
             "$Tags.HTTP_STATUS" STATUS
-            "$Tags.PEER_HOSTNAME" "localhost"
-            "$Tags.PEER_PORT" server.address.port
             defaultTags()
           }
         }
@@ -201,11 +201,11 @@ class HttpUrlConnectionTest extends HttpClientTest<HttpUrlConnectionDecorator> {
           tags {
             "$Tags.COMPONENT" "http-url-connection"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" "localhost"
+            "$Tags.PEER_PORT" server.address.port
             "$Tags.HTTP_URL" "$url"
             "$Tags.HTTP_METHOD" "GET"
             "$Tags.HTTP_STATUS" STATUS
-            "$Tags.PEER_HOSTNAME" "localhost"
-            "$Tags.PEER_PORT" server.address.port
             defaultTags()
           }
         }
@@ -253,11 +253,11 @@ class HttpUrlConnectionTest extends HttpClientTest<HttpUrlConnectionDecorator> {
           tags {
             "$Tags.COMPONENT" "http-url-connection"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" "localhost"
+            "$Tags.PEER_PORT" server.address.port
             "$Tags.HTTP_URL" "$url"
             "$Tags.HTTP_METHOD" "GET"
             "$Tags.HTTP_STATUS" STATUS
-            "$Tags.PEER_HOSTNAME" "localhost"
-            "$Tags.PEER_PORT" server.address.port
             defaultTags()
           }
         }
@@ -321,11 +321,11 @@ class HttpUrlConnectionTest extends HttpClientTest<HttpUrlConnectionDecorator> {
           tags {
             "$Tags.COMPONENT" "http-url-connection"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" "localhost"
+            "$Tags.PEER_PORT" server.address.port
             "$Tags.HTTP_URL" "$url"
             "$Tags.HTTP_METHOD" "POST"
             "$Tags.HTTP_STATUS" STATUS
-            "$Tags.PEER_HOSTNAME" "localhost"
-            "$Tags.PEER_PORT" server.address.port
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/UrlConnectionTest.groovy
+++ b/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/UrlConnectionTest.groovy
@@ -50,10 +50,10 @@ class UrlConnectionTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT" "http-url-connection"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.HTTP_URL" "$url/"
-            "$Tags.HTTP_METHOD" "GET"
             "$Tags.PEER_HOSTNAME" "localhost"
             "$Tags.PEER_PORT" UNUSABLE_PORT
+            "$Tags.HTTP_URL" "$url/"
+            "$Tags.HTTP_METHOD" "GET"
             errorTags ConnectException, String
             defaultTags()
           }
@@ -105,9 +105,9 @@ class UrlConnectionTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT" UrlInstrumentation.COMPONENT
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_PORT" 80
             // FIXME: These tags really make no sense for non-http connections, why do we set them?
             "$Tags.HTTP_URL" "$url"
-            "$Tags.PEER_PORT" 80
             errorTags IllegalArgumentException, String
             defaultTags()
           }

--- a/dd-java-agent/instrumentation/hystrix-1.4/src/test/groovy/HystrixObservableChainTest.groovy
+++ b/dd-java-agent/instrumentation/hystrix-1.4/src/test/groovy/HystrixObservableChainTest.groovy
@@ -90,10 +90,10 @@ class HystrixObservableChainTest extends AgentTestRunner {
           childOf span(3)
           errored false
           tags {
+            "$Tags.COMPONENT" "hystrix"
             "hystrix.command" "HystrixObservableChainTest\$2"
             "hystrix.group" "OtherGroup"
             "hystrix.circuit-open" false
-            "$Tags.COMPONENT" "hystrix"
             defaultTags()
           }
         }
@@ -117,10 +117,10 @@ class HystrixObservableChainTest extends AgentTestRunner {
           childOf span(0)
           errored false
           tags {
+            "$Tags.COMPONENT" "hystrix"
             "hystrix.command" "HystrixObservableChainTest\$1"
             "hystrix.group" "ExampleGroup"
             "hystrix.circuit-open" false
-            "$Tags.COMPONENT" "hystrix"
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/hystrix-1.4/src/test/groovy/HystrixObservableTest.groovy
+++ b/dd-java-agent/instrumentation/hystrix-1.4/src/test/groovy/HystrixObservableTest.groovy
@@ -82,10 +82,10 @@ class HystrixObservableTest extends AgentTestRunner {
           childOf span(0)
           errored false
           tags {
+            "$Tags.COMPONENT" "hystrix"
             "hystrix.command" "HystrixObservableTest\$1"
             "hystrix.group" "ExampleGroup"
             "hystrix.circuit-open" false
-            "$Tags.COMPONENT" "hystrix"
             defaultTags()
           }
         }
@@ -192,10 +192,10 @@ class HystrixObservableTest extends AgentTestRunner {
           childOf span(0)
           errored true
           tags {
+            "$Tags.COMPONENT" "hystrix"
             "hystrix.command" "HystrixObservableTest\$2"
             "hystrix.group" "ExampleGroup"
             "hystrix.circuit-open" false
-            "$Tags.COMPONENT" "hystrix"
             errorTags(IllegalArgumentException)
             defaultTags()
           }
@@ -208,10 +208,10 @@ class HystrixObservableTest extends AgentTestRunner {
           childOf span(1)
           errored false
           tags {
+            "$Tags.COMPONENT" "hystrix"
             "hystrix.command" "HystrixObservableTest\$2"
             "hystrix.group" "ExampleGroup"
             "hystrix.circuit-open" false
-            "$Tags.COMPONENT" "hystrix"
             defaultTags()
           }
         }
@@ -312,10 +312,10 @@ class HystrixObservableTest extends AgentTestRunner {
           childOf span(0)
           errored true
           tags {
+            "$Tags.COMPONENT" "hystrix"
             "hystrix.command" "HystrixObservableTest\$3"
             "hystrix.group" "FailingGroup"
             "hystrix.circuit-open" false
-            "$Tags.COMPONENT" "hystrix"
             errorTags(IllegalArgumentException)
             defaultTags()
           }
@@ -328,10 +328,10 @@ class HystrixObservableTest extends AgentTestRunner {
           childOf span(1)
           errored true
           tags {
+            "$Tags.COMPONENT" "hystrix"
             "hystrix.command" "HystrixObservableTest\$3"
             "hystrix.group" "FailingGroup"
             "hystrix.circuit-open" false
-            "$Tags.COMPONENT" "hystrix"
             errorTags(UnsupportedOperationException, "No fallback available.")
             defaultTags()
           }

--- a/dd-java-agent/instrumentation/hystrix-1.4/src/test/groovy/HystrixTest.groovy
+++ b/dd-java-agent/instrumentation/hystrix-1.4/src/test/groovy/HystrixTest.groovy
@@ -62,10 +62,10 @@ class HystrixTest extends AgentTestRunner {
           childOf span(0)
           errored false
           tags {
+            "$Tags.COMPONENT" "hystrix"
             "hystrix.command" "HystrixTest\$1"
             "hystrix.group" "ExampleGroup"
             "hystrix.circuit-open" false
-            "$Tags.COMPONENT" "hystrix"
             defaultTags()
           }
         }
@@ -140,10 +140,10 @@ class HystrixTest extends AgentTestRunner {
           childOf span(0)
           errored true
           tags {
+            "$Tags.COMPONENT" "hystrix"
             "hystrix.command" "HystrixTest\$2"
             "hystrix.group" "ExampleGroup"
             "hystrix.circuit-open" false
-            "$Tags.COMPONENT" "hystrix"
             errorTags(IllegalArgumentException)
             defaultTags()
           }
@@ -156,10 +156,10 @@ class HystrixTest extends AgentTestRunner {
           childOf span(1)
           errored false
           tags {
+            "$Tags.COMPONENT" "hystrix"
             "hystrix.command" "HystrixTest\$2"
             "hystrix.group" "ExampleGroup"
             "hystrix.circuit-open" false
-            "$Tags.COMPONENT" "hystrix"
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/java-concurrent/src/slickTest/groovy/SlickTest.groovy
+++ b/dd-java-agent/instrumentation/java-concurrent/src/slickTest/groovy/SlickTest.groovy
@@ -38,13 +38,10 @@ class SlickTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-
             "$Tags.DB_TYPE" SlickUtils.Driver()
+            "$Tags.DB_INSTANCE" SlickUtils.Db()
             "$Tags.DB_USER" SlickUtils.Username()
-
-            "db.instance" SlickUtils.Db()
             "span.origin.type" "org.h2.jdbc.JdbcPreparedStatement"
-
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/jax-rs-annotations-2/src/test/groovy/DropwizardTest.groovy
+++ b/dd-java-agent/instrumentation/jax-rs-annotations-2/src/test/groovy/DropwizardTest.groovy
@@ -2,6 +2,7 @@ import datadog.opentracing.DDSpan
 import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.agent.test.base.HttpServerTest
 import datadog.trace.api.DDSpanTypes
+import datadog.trace.instrumentation.api.Tags
 import datadog.trace.instrumentation.jaxrs2.JaxRsAnnotationsDecorator
 import datadog.trace.instrumentation.servlet3.Servlet3Decorator
 import io.dropwizard.Application
@@ -10,7 +11,6 @@ import io.dropwizard.setup.Bootstrap
 import io.dropwizard.setup.Environment
 import io.dropwizard.testing.ConfigOverride
 import io.dropwizard.testing.DropwizardTestSupport
-import io.opentracing.tag.Tags
 import org.eclipse.jetty.servlet.ServletHandler
 
 import javax.ws.rs.GET
@@ -85,11 +85,11 @@ class DropwizardTest extends HttpServerTest<DropwizardTestSupport, Servlet3Decor
       errored endpoint == EXCEPTION
       childOf(parent as DDSpan)
       tags {
-        "$Tags.COMPONENT.key" JaxRsAnnotationsDecorator.DECORATE.component()
-        defaultTags()
+        "$Tags.COMPONENT" JaxRsAnnotationsDecorator.DECORATE.component()
         if (endpoint == EXCEPTION) {
           errorTags(Exception, EXCEPTION.body)
         }
+        defaultTags()
       }
     }
   }
@@ -109,23 +109,22 @@ class DropwizardTest extends HttpServerTest<DropwizardTestSupport, Servlet3Decor
         parent()
       }
       tags {
+        "$Tags.COMPONENT" serverDecorator.component()
+        "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
+        "$Tags.PEER_HOSTNAME" { it == "localhost" || it == "127.0.0.1" }
+        "$Tags.PEER_HOST_IPV4" { it == null || it == "127.0.0.1" } // Optional
+        "$Tags.PEER_PORT" Integer
+        "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
+        "$Tags.HTTP_METHOD" method
+        "$Tags.HTTP_STATUS" endpoint.status
         "span.origin.type" ServletHandler.CachedChain.name
-
-        defaultTags(true)
-        "$Tags.COMPONENT.key" serverDecorator.component()
         if (endpoint.errored) {
-          "$Tags.ERROR.key" endpoint.errored
+          "$Tags.ERROR" endpoint.errored
           "error.msg" { it == null || it == EXCEPTION.body }
           "error.type" { it == null || it == Exception.name }
           "error.stack" { it == null || it instanceof String }
         }
-        "$Tags.HTTP_STATUS.key" endpoint.status
-        "$Tags.HTTP_URL.key" "${endpoint.resolve(address)}"
-        "$Tags.PEER_HOSTNAME.key" { it == "localhost" || it == "127.0.0.1" }
-        "$Tags.PEER_PORT.key" Integer
-        "$Tags.PEER_HOST_IPV4.key" { it == null || it == "127.0.0.1" } // Optional
-        "$Tags.HTTP_METHOD.key" method
-        "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
+        defaultTags(true)
       }
     }
   }

--- a/dd-java-agent/instrumentation/jdbc/src/test/groovy/JDBCInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/jdbc/src/test/groovy/JDBCInstrumentationTest.groovy
@@ -5,13 +5,13 @@ import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.Config
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.instrumentation.api.Tags
-import javax.sql.DataSource
 import org.apache.derby.jdbc.EmbeddedDriver
 import org.h2.Driver
 import org.hsqldb.jdbc.JDBCDriver
 import spock.lang.Shared
 import spock.lang.Unroll
 
+import javax.sql.DataSource
 import java.sql.CallableStatement
 import java.sql.Connection
 import java.sql.PreparedStatement
@@ -176,13 +176,13 @@ class JDBCInstrumentationTest extends AgentTestRunner {
           childOf span(0)
           errored false
           tags {
-            "db.type" driver
+            "$Tags.COMPONENT" "java-jdbc-statement"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" driver
+            "$Tags.DB_INSTANCE" dbName.toLowerCase()
             if (username != null) {
-              "db.user" username
+              "$Tags.DB_USER" username
             }
-            "span.kind" Tags.SPAN_KIND_CLIENT
-            "component" "java-jdbc-statement"
-            "db.instance" dbName.toLowerCase()
             "span.origin.type" String
             defaultTags()
           }
@@ -236,13 +236,13 @@ class JDBCInstrumentationTest extends AgentTestRunner {
           childOf span(0)
           errored false
           tags {
-            "db.type" driver
+            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" driver
+            "$Tags.DB_INSTANCE" dbName.toLowerCase()
             if (username != null) {
-              "db.user" username
+              "$Tags.DB_USER" username
             }
-            "span.kind" Tags.SPAN_KIND_CLIENT
-            "component" "java-jdbc-prepared_statement"
-            "db.instance" dbName.toLowerCase()
             "span.origin.type" String
             defaultTags()
           }
@@ -288,13 +288,13 @@ class JDBCInstrumentationTest extends AgentTestRunner {
           childOf span(0)
           errored false
           tags {
-            "db.type" driver
+            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" driver
+            "$Tags.DB_INSTANCE" dbName.toLowerCase()
             if (username != null) {
-              "db.user" username
+              "$Tags.DB_USER" username
             }
-            "span.kind" Tags.SPAN_KIND_CLIENT
-            "component" "java-jdbc-prepared_statement"
-            "db.instance" dbName.toLowerCase()
             "span.origin.type" String
             defaultTags()
           }
@@ -340,13 +340,13 @@ class JDBCInstrumentationTest extends AgentTestRunner {
           childOf span(0)
           errored false
           tags {
-            "db.type" driver
+            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" driver
+            "$Tags.DB_INSTANCE" dbName.toLowerCase()
             if (username != null) {
-              "db.user" username
+              "$Tags.DB_USER" username
             }
-            "span.kind" Tags.SPAN_KIND_CLIENT
-            "component" "java-jdbc-prepared_statement"
-            "db.instance" dbName.toLowerCase()
             "span.origin.type" String
             defaultTags()
           }
@@ -392,13 +392,13 @@ class JDBCInstrumentationTest extends AgentTestRunner {
           childOf span(0)
           errored false
           tags {
-            "db.type" driver
+            "$Tags.COMPONENT" "java-jdbc-statement"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" driver
+            "$Tags.DB_INSTANCE" dbName.toLowerCase()
             if (username != null) {
-              "db.user" username
+              "$Tags.DB_USER" username
             }
-            "span.kind" Tags.SPAN_KIND_CLIENT
-            "component" "java-jdbc-statement"
-            "db.instance" dbName.toLowerCase()
             "span.origin.type" String
             defaultTags()
           }
@@ -447,13 +447,13 @@ class JDBCInstrumentationTest extends AgentTestRunner {
           childOf span(0)
           errored false
           tags {
-            "db.type" driver
+            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" driver
+            "$Tags.DB_INSTANCE" dbName.toLowerCase()
             if (username != null) {
-              "db.user" username
+              "$Tags.DB_USER" username
             }
-            "span.kind" Tags.SPAN_KIND_CLIENT
-            "component" "java-jdbc-prepared_statement"
-            "db.instance" dbName.toLowerCase()
             "span.origin.type" String
             defaultTags()
           }
@@ -515,17 +515,17 @@ class JDBCInstrumentationTest extends AgentTestRunner {
           childOf span(0)
           errored false
           tags {
-            "db.type" driver
-            if (username != null) {
-              "db.user" username
-            }
             if (prepareStatement) {
-              "component" "java-jdbc-prepared_statement"
+              "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             } else {
-              "component" "java-jdbc-statement"
+              "$Tags.COMPONENT" "java-jdbc-statement"
             }
-            "span.kind" Tags.SPAN_KIND_CLIENT
-            "db.instance" dbName.toLowerCase()
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" driver
+            "$Tags.DB_INSTANCE" dbName.toLowerCase()
+            if (username != null) {
+              "$Tags.DB_USER" username
+            }
             "span.origin.type" String
             defaultTags()
           }
@@ -590,11 +590,11 @@ class JDBCInstrumentationTest extends AgentTestRunner {
           spanType DDSpanTypes.SQL
           errored false
           tags {
-            "db.type" dbType
-            "db.user" "SA"
-            "component" "java-jdbc-prepared_statement"
-            "span.kind" Tags.SPAN_KIND_CLIENT
-            "db.instance" dbName.toLowerCase()
+            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" dbType
+            "$Tags.DB_INSTANCE" dbName.toLowerCase()
+            "$Tags.DB_USER" "SA"
             "span.origin.type" String
             defaultTags()
           }
@@ -609,11 +609,11 @@ class JDBCInstrumentationTest extends AgentTestRunner {
             spanType DDSpanTypes.SQL
             errored false
             tags {
-              "db.type" dbType
-              "db.user" "SA"
-              "component" "java-jdbc-prepared_statement"
-              "span.kind" Tags.SPAN_KIND_CLIENT
-              "db.instance" dbName.toLowerCase()
+              "$Tags.COMPONENT" "java-jdbc-prepared_statement"
+              "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+              "$Tags.DB_TYPE" dbType
+              "$Tags.DB_INSTANCE" dbName.toLowerCase()
+              "$Tags.DB_USER" "SA"
               "span.origin.type" String
               defaultTags()
             }

--- a/dd-java-agent/instrumentation/jedis-1.4/src/test/groovy/JedisClientTest.groovy
+++ b/dd-java-agent/instrumentation/jedis-1.4/src/test/groovy/JedisClientTest.groovy
@@ -54,8 +54,8 @@ class JedisClientTest extends AgentTestRunner {
           spanType DDSpanTypes.REDIS
           tags {
             "$Tags.COMPONENT" "redis-command"
-            "$Tags.DB_TYPE" "redis"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "redis"
             defaultTags()
           }
         }
@@ -80,8 +80,8 @@ class JedisClientTest extends AgentTestRunner {
           spanType DDSpanTypes.REDIS
           tags {
             "$Tags.COMPONENT" "redis-command"
-            "$Tags.DB_TYPE" "redis"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "redis"
             defaultTags()
           }
         }
@@ -94,8 +94,8 @@ class JedisClientTest extends AgentTestRunner {
           spanType DDSpanTypes.REDIS
           tags {
             "$Tags.COMPONENT" "redis-command"
-            "$Tags.DB_TYPE" "redis"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "redis"
             defaultTags()
           }
         }
@@ -120,8 +120,8 @@ class JedisClientTest extends AgentTestRunner {
           spanType DDSpanTypes.REDIS
           tags {
             "$Tags.COMPONENT" "redis-command"
-            "$Tags.DB_TYPE" "redis"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "redis"
             defaultTags()
           }
         }
@@ -134,8 +134,8 @@ class JedisClientTest extends AgentTestRunner {
           spanType DDSpanTypes.REDIS
           tags {
             "$Tags.COMPONENT" "redis-command"
-            "$Tags.DB_TYPE" "redis"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "redis"
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/jetty-8/src/test/groovy/JettyHandlerTest.groovy
+++ b/dd-java-agent/instrumentation/jetty-8/src/test/groovy/JettyHandlerTest.groovy
@@ -124,22 +124,22 @@ class JettyHandlerTest extends HttpServerTest<Server, JettyDecorator> {
         parent()
       }
       tags {
-        "span.origin.type" handlerName
-        defaultTags(true)
         "$Tags.COMPONENT" serverDecorator.component()
+        "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
+        "$Tags.PEER_HOSTNAME" { it == "localhost" || it == "127.0.0.1" }
+        "$Tags.PEER_HOST_IPV4" { it == null || it == "127.0.0.1" } // Optional
+        "$Tags.PEER_PORT" Integer
+        "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
+        "$Tags.HTTP_METHOD" method
+        "$Tags.HTTP_STATUS" endpoint.status
+        "span.origin.type" handlerName
         if (endpoint.errored) {
           "$Tags.ERROR" endpoint.errored
           "error.msg" { it == null || it == EXCEPTION.body }
           "error.type" { it == null || it == Exception.name }
           "error.stack" { it == null || it instanceof String }
         }
-        "$Tags.HTTP_STATUS" endpoint.status
-        "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
-        "$Tags.PEER_HOSTNAME" { it == "localhost" || it == "127.0.0.1" }
-        "$Tags.PEER_PORT" Integer
-        "$Tags.PEER_HOST_IPV4" { it == null || it == "127.0.0.1" } // Optional
-        "$Tags.HTTP_METHOD" method
-        "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
+        defaultTags(true)
       }
     }
   }

--- a/dd-java-agent/instrumentation/jms/src/latestDepTest/groovy/JMS2Test.groovy
+++ b/dd-java-agent/instrumentation/jms/src/latestDepTest/groovy/JMS2Test.groovy
@@ -163,10 +163,10 @@ class JMS2Test extends AgentTestRunner {
           errored false
 
           tags {
-            defaultTags()
-            "${Tags.COMPONENT}" "jms"
-            "${Tags.SPAN_KIND}" "consumer"
+            "$Tags.COMPONENT" "jms"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
             "span.origin.type" HornetQMessageConsumer.name
+            defaultTags()
           }
         }
       }
@@ -201,10 +201,10 @@ class JMS2Test extends AgentTestRunner {
           errored false
 
           tags {
-            defaultTags()
-            "${Tags.COMPONENT}" "jms"
-            "${Tags.SPAN_KIND}" "consumer"
+            "$Tags.COMPONENT" "jms"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
             "span.origin.type" HornetQMessageConsumer.name
+            defaultTags()
           }
         }
       }
@@ -230,10 +230,10 @@ class JMS2Test extends AgentTestRunner {
         errored false
 
         tags {
-          defaultTags()
-          "${Tags.COMPONENT}" "jms"
-          "${Tags.SPAN_KIND}" "producer"
+          "$Tags.COMPONENT" "jms"
+          "$Tags.SPAN_KIND" Tags.SPAN_KIND_PRODUCER
           "span.origin.type" HornetQMessageProducer.name
+          defaultTags()
         }
       }
     }
@@ -255,10 +255,10 @@ class JMS2Test extends AgentTestRunner {
         errored false
 
         tags {
-          defaultTags(true)
           "${Tags.COMPONENT}" "jms"
           "${Tags.SPAN_KIND}" "consumer"
           "span.origin.type" origin.name
+          defaultTags(true)
         }
       }
     }

--- a/dd-java-agent/instrumentation/jms/src/test/groovy/JMS1Test.groovy
+++ b/dd-java-agent/instrumentation/jms/src/test/groovy/JMS1Test.groovy
@@ -126,10 +126,10 @@ class JMS1Test extends AgentTestRunner {
           errored false
 
           tags {
-            defaultTags()
-            "${Tags.COMPONENT}" "jms"
-            "${Tags.SPAN_KIND}" "consumer"
+            "$Tags.COMPONENT" "jms"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
             "span.origin.type" ActiveMQMessageConsumer.name
+            defaultTags()
           }
         }
       }
@@ -164,10 +164,10 @@ class JMS1Test extends AgentTestRunner {
           errored false
 
           tags {
-            defaultTags()
-            "${Tags.COMPONENT}" "jms"
-            "${Tags.SPAN_KIND}" "consumer"
+            "$Tags.COMPONENT" "jms"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
             "span.origin.type" ActiveMQMessageConsumer.name
+            defaultTags()
           }
         }
       }
@@ -215,10 +215,10 @@ class JMS1Test extends AgentTestRunner {
           errored false
 
           tags {
-            defaultTags()
-            "${Tags.COMPONENT}" "jms"
-            "${Tags.SPAN_KIND}" "consumer"
+            "$Tags.COMPONENT" "jms"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
             "span.origin.type" ActiveMQMessageConsumer.name
+            defaultTags()
           }
         }
       }
@@ -247,10 +247,10 @@ class JMS1Test extends AgentTestRunner {
         parent()
 
         tags {
-          defaultTags()
-          "${Tags.COMPONENT}" "jms"
-          "${Tags.SPAN_KIND}" "producer"
+          "$Tags.COMPONENT" "jms"
+          "$Tags.SPAN_KIND" Tags.SPAN_KIND_PRODUCER
           "span.origin.type" ActiveMQMessageProducer.name
+          defaultTags()
         }
       }
     }
@@ -272,10 +272,10 @@ class JMS1Test extends AgentTestRunner {
         childOf parentSpan
 
         tags {
-          defaultTags(true)
-          "${Tags.COMPONENT}" "jms"
-          "${Tags.SPAN_KIND}" "consumer"
+          "$Tags.COMPONENT" "jms"
+          "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
           "span.origin.type" origin.name
+          defaultTags(true)
         }
       }
     }

--- a/dd-java-agent/instrumentation/jsp-2.3/src/test/groovy/JSPInstrumentationBasicTests.groovy
+++ b/dd-java-agent/instrumentation/jsp-2.3/src/test/groovy/JSPInstrumentationBasicTests.groovy
@@ -3,6 +3,7 @@ import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.utils.OkHttpUtils
 import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
+import datadog.trace.instrumentation.api.Tags
 import okhttp3.MultipartBody
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -93,17 +94,17 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
-            "http.url" "http://localhost:$port/$jspWebappContext/$jspFileName"
-            "http.method" "GET"
-            "peer.hostname" "127.0.0.1"
-            "peer.ipv4" "127.0.0.1"
-            "peer.port" Integer
-            "span.kind" "server"
-            "component" "java-web-servlet"
+            "$Tags.COMPONENT" "java-web-servlet"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
+            "$Tags.PEER_HOSTNAME" "127.0.0.1"
+            "$Tags.PEER_HOST_IPV4" "127.0.0.1"
+            "$Tags.PEER_PORT" Integer
+            "$Tags.HTTP_URL" "http://localhost:$port/$jspWebappContext/$jspFileName"
+            "$Tags.HTTP_METHOD" "GET"
+            "$Tags.HTTP_STATUS" 200
             "span.origin.type" "org.apache.catalina.core.ApplicationFilterChain"
             "servlet.context" "/$jspWebappContext"
             "servlet.path" "/$jspFileName"
-            "http.status_code" 200
             defaultTags()
           }
         }
@@ -114,7 +115,7 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           resourceName "/$jspFileName"
           errored false
           tags {
-            "component" "jsp-http-servlet"
+            "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" jspClassName
             "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl
@@ -128,7 +129,7 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           resourceName "/$jspFileName"
           errored false
           tags {
-            "component" "jsp-http-servlet"
+            "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.$jspClassNamePrefix$jspClassName"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -169,17 +170,17 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
-            "http.url" "http://localhost:$port/$jspWebappContext/getQuery.jsp"
-            "http.method" "GET"
-            "peer.hostname" "127.0.0.1"
-            "peer.ipv4" "127.0.0.1"
-            "peer.port" Integer
-            "span.kind" "server"
-            "component" "java-web-servlet"
+            "$Tags.COMPONENT" "java-web-servlet"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
+            "$Tags.PEER_HOSTNAME" "127.0.0.1"
+            "$Tags.PEER_HOST_IPV4" "127.0.0.1"
+            "$Tags.PEER_PORT" Integer
+            "$Tags.HTTP_URL" "http://localhost:$port/$jspWebappContext/getQuery.jsp"
+            "$Tags.HTTP_METHOD" "GET"
+            "$Tags.HTTP_STATUS" 200
             "span.origin.type" "org.apache.catalina.core.ApplicationFilterChain"
             "servlet.context" "/$jspWebappContext"
             "servlet.path" "/getQuery.jsp"
-            "http.status_code" 200
             defaultTags()
           }
         }
@@ -190,7 +191,7 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           resourceName "/getQuery.jsp"
           errored false
           tags {
-            "component" "jsp-http-servlet"
+            "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" "getQuery_jsp"
             "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl
@@ -204,7 +205,7 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           resourceName "/getQuery.jsp"
           errored false
           tags {
-            "component" "jsp-http-servlet"
+            "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.getQuery_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -242,17 +243,17 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
-            "http.url" "http://localhost:$port/$jspWebappContext/post.jsp"
-            "http.method" "POST"
-            "peer.hostname" "127.0.0.1"
-            "peer.ipv4" "127.0.0.1"
-            "peer.port" Integer
-            "span.kind" "server"
-            "component" "java-web-servlet"
+            "$Tags.COMPONENT" "java-web-servlet"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
+            "$Tags.PEER_HOSTNAME" "127.0.0.1"
+            "$Tags.PEER_HOST_IPV4" "127.0.0.1"
+            "$Tags.PEER_PORT" Integer
+            "$Tags.HTTP_URL" "http://localhost:$port/$jspWebappContext/post.jsp"
+            "$Tags.HTTP_METHOD" "POST"
+            "$Tags.HTTP_STATUS" 200
             "span.origin.type" "org.apache.catalina.core.ApplicationFilterChain"
             "servlet.context" "/$jspWebappContext"
             "servlet.path" "/post.jsp"
-            "http.status_code" 200
             defaultTags()
           }
         }
@@ -263,7 +264,7 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           resourceName "/post.jsp"
           errored false
           tags {
-            "component" "jsp-http-servlet"
+            "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" "post_jsp"
             "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl
@@ -277,7 +278,7 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           resourceName "/post.jsp"
           errored false
           tags {
-            "component" "jsp-http-servlet"
+            "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.post_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -312,17 +313,17 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           spanType DDSpanTypes.HTTP_SERVER
           errored true
           tags {
-            "http.url" "http://localhost:$port/$jspWebappContext/$jspFileName"
-            "http.method" "GET"
-            "peer.hostname" "127.0.0.1"
-            "peer.ipv4" "127.0.0.1"
-            "peer.port" Integer
-            "span.kind" "server"
-            "component" "java-web-servlet"
+            "$Tags.COMPONENT" "java-web-servlet"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
+            "$Tags.PEER_HOSTNAME" "127.0.0.1"
+            "$Tags.PEER_HOST_IPV4" "127.0.0.1"
+            "$Tags.PEER_PORT" Integer
+            "$Tags.HTTP_URL" "http://localhost:$port/$jspWebappContext/$jspFileName"
+            "$Tags.HTTP_METHOD" "GET"
+            "$Tags.HTTP_STATUS" 500
             "span.origin.type" "org.apache.catalina.core.ApplicationFilterChain"
             "servlet.context" "/$jspWebappContext"
             "servlet.path" "/$jspFileName"
-            "http.status_code" 500
             "error" true
             "error.type" { String tagExceptionType ->
               return tagExceptionType == exceptionClass.getName() || tagExceptionType.contains(exceptionClass.getSimpleName())
@@ -341,7 +342,7 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           resourceName "/$jspFileName"
           errored true
           tags {
-            "component" "jsp-http-servlet"
+            "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" jspClassName
             "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl
@@ -363,7 +364,7 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           resourceName "/$jspFileName"
           errored false
           tags {
-            "component" "jsp-http-servlet"
+            "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.$jspClassName"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -403,17 +404,17 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
-            "http.url" "http://localhost:$port/$jspWebappContext/includes/includeHtml.jsp"
-            "http.method" "GET"
-            "peer.hostname" "127.0.0.1"
-            "peer.ipv4" "127.0.0.1"
-            "peer.port" Integer
-            "span.kind" "server"
-            "component" "java-web-servlet"
+            "$Tags.COMPONENT" "java-web-servlet"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
+            "$Tags.PEER_HOSTNAME" "127.0.0.1"
+            "$Tags.PEER_HOST_IPV4" "127.0.0.1"
+            "$Tags.PEER_PORT" Integer
+            "$Tags.HTTP_URL" "http://localhost:$port/$jspWebappContext/includes/includeHtml.jsp"
+            "$Tags.HTTP_METHOD" "GET"
+            "$Tags.HTTP_STATUS" 200
             "span.origin.type" "org.apache.catalina.core.ApplicationFilterChain"
             "servlet.context" "/$jspWebappContext"
             "servlet.path" "/includes/includeHtml.jsp"
-            "http.status_code" 200
             defaultTags()
           }
         }
@@ -424,7 +425,7 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           resourceName "/includes/includeHtml.jsp"
           errored false
           tags {
-            "component" "jsp-http-servlet"
+            "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" "includeHtml_jsp"
             "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl
@@ -438,7 +439,7 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           resourceName "/includes/includeHtml.jsp"
           errored false
           tags {
-            "component" "jsp-http-servlet"
+            "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.includes.includeHtml_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -472,17 +473,17 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
-            "http.url" "http://localhost:$port/$jspWebappContext/includes/includeMulti.jsp"
-            "http.method" "GET"
-            "peer.hostname" "127.0.0.1"
-            "peer.ipv4" "127.0.0.1"
-            "peer.port" Integer
-            "span.kind" "server"
-            "component" "java-web-servlet"
+            "$Tags.COMPONENT" "java-web-servlet"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
+            "$Tags.PEER_HOSTNAME" "127.0.0.1"
+            "$Tags.PEER_HOST_IPV4" "127.0.0.1"
+            "$Tags.PEER_PORT" Integer
+            "$Tags.HTTP_URL" "http://localhost:$port/$jspWebappContext/includes/includeMulti.jsp"
+            "$Tags.HTTP_METHOD" "GET"
+            "$Tags.HTTP_STATUS" 200
             "span.origin.type" "org.apache.catalina.core.ApplicationFilterChain"
             "servlet.context" "/$jspWebappContext"
             "servlet.path" "/includes/includeMulti.jsp"
-            "http.status_code" 200
             defaultTags()
           }
         }
@@ -493,7 +494,7 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           resourceName "/includes/includeMulti.jsp"
           errored false
           tags {
-            "component" "jsp-http-servlet"
+            "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" "includeMulti_jsp"
             "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl
@@ -507,7 +508,7 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           resourceName "/common/javaLoopH2.jsp"
           errored false
           tags {
-            "component" "jsp-http-servlet"
+            "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" "javaLoopH2_jsp"
             "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl
@@ -521,7 +522,7 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           resourceName "/common/javaLoopH2.jsp"
           errored false
           tags {
-            "component" "jsp-http-servlet"
+            "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.common.javaLoopH2_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -535,7 +536,7 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           resourceName "/common/javaLoopH2.jsp"
           errored false
           tags {
-            "component" "jsp-http-servlet"
+            "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" "javaLoopH2_jsp"
             "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl
@@ -549,7 +550,7 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           resourceName "/common/javaLoopH2.jsp"
           errored false
           tags {
-            "component" "jsp-http-servlet"
+            "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.common.javaLoopH2_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -563,7 +564,7 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           resourceName "/includes/includeMulti.jsp"
           errored false
           tags {
-            "component" "jsp-http-servlet"
+            "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.includes.includeMulti_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -597,17 +598,17 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           spanType DDSpanTypes.HTTP_SERVER
           errored true
           tags {
-            "http.url" "http://localhost:$port/$jspWebappContext/$jspFileName"
-            "http.method" "GET"
-            "peer.hostname" "127.0.0.1"
-            "peer.ipv4" "127.0.0.1"
-            "peer.port" Integer
-            "span.kind" "server"
-            "component" "java-web-servlet"
+            "$Tags.COMPONENT" "java-web-servlet"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
+            "$Tags.PEER_HOSTNAME" "127.0.0.1"
+            "$Tags.PEER_HOST_IPV4" "127.0.0.1"
+            "$Tags.PEER_PORT" Integer
+            "$Tags.HTTP_URL" "http://localhost:$port/$jspWebappContext/$jspFileName"
+            "$Tags.HTTP_METHOD" "GET"
+            "$Tags.HTTP_STATUS" 500
             "span.origin.type" "org.apache.catalina.core.ApplicationFilterChain"
             "servlet.context" "/$jspWebappContext"
             "servlet.path" "/$jspFileName"
-            "http.status_code" 500
             errorTags(JasperException, String)
             defaultTags()
           }
@@ -619,7 +620,7 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           resourceName "/$jspFileName"
           errored true
           tags {
-            "component" "jsp-http-servlet"
+            "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.$jspClassNamePrefix$jspClassName"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"

--- a/dd-java-agent/instrumentation/jsp-2.3/src/test/groovy/JSPInstrumentationForwardTests.groovy
+++ b/dd-java-agent/instrumentation/jsp-2.3/src/test/groovy/JSPInstrumentationForwardTests.groovy
@@ -3,6 +3,7 @@ import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.utils.OkHttpUtils
 import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
+import datadog.trace.instrumentation.api.Tags
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
@@ -92,17 +93,17 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
-            "http.url" "http://localhost:$port/$jspWebappContext/$forwardFromFileName"
-            "http.method" "GET"
-            "peer.hostname" "127.0.0.1"
-            "peer.ipv4" "127.0.0.1"
-            "peer.port" Integer
-            "span.kind" "server"
-            "component" "java-web-servlet"
+            "$Tags.COMPONENT" "java-web-servlet"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
+            "$Tags.PEER_HOSTNAME" "127.0.0.1"
+            "$Tags.PEER_HOST_IPV4" "127.0.0.1"
+            "$Tags.PEER_PORT" Integer
+            "$Tags.HTTP_URL" "http://localhost:$port/$jspWebappContext/$forwardFromFileName"
+            "$Tags.HTTP_METHOD" "GET"
+            "$Tags.HTTP_STATUS" 200
             "span.origin.type" "org.apache.catalina.core.ApplicationFilterChain"
             "servlet.context" "/$jspWebappContext"
             "servlet.path" "/$forwardFromFileName"
-            "http.status_code" 200
             defaultTags()
           }
         }
@@ -113,7 +114,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           resourceName "/$forwardFromFileName"
           errored false
           tags {
-            "component" "jsp-http-servlet"
+            "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" jspForwardFromClassName
             "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl
@@ -127,7 +128,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           resourceName "/$forwardDestFileName"
           errored false
           tags {
-            "component" "jsp-http-servlet"
+            "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" jspForwardDestClassName
             "servlet.context" "/$jspWebappContext"
             "jsp.forwardOrigin" "/$forwardFromFileName"
@@ -142,7 +143,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           resourceName "/$forwardDestFileName"
           errored false
           tags {
-            "component" "jsp-http-servlet"
+            "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.$jspForwardDestClassPrefix$jspForwardDestClassName"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -156,7 +157,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           resourceName "/$forwardFromFileName"
           errored false
           tags {
-            "component" "jsp-http-servlet"
+            "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.$jspForwardFromClassPrefix$jspForwardFromClassName"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -195,17 +196,17 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
-            "http.url" "http://localhost:$port/$jspWebappContext/forwards/forwardToHtml.jsp"
-            "http.method" "GET"
-            "peer.hostname" "127.0.0.1"
-            "peer.ipv4" "127.0.0.1"
-            "peer.port" Integer
-            "span.kind" "server"
-            "component" "java-web-servlet"
+            "$Tags.COMPONENT" "java-web-servlet"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
+            "$Tags.PEER_HOSTNAME" "127.0.0.1"
+            "$Tags.PEER_HOST_IPV4" "127.0.0.1"
+            "$Tags.PEER_PORT" Integer
+            "$Tags.HTTP_URL" "http://localhost:$port/$jspWebappContext/forwards/forwardToHtml.jsp"
+            "$Tags.HTTP_METHOD" "GET"
+            "$Tags.HTTP_STATUS" 200
             "span.origin.type" "org.apache.catalina.core.ApplicationFilterChain"
             "servlet.context" "/$jspWebappContext"
             "servlet.path" "/forwards/forwardToHtml.jsp"
-            "http.status_code" 200
             defaultTags()
           }
         }
@@ -216,7 +217,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           resourceName "/forwards/forwardToHtml.jsp"
           errored false
           tags {
-            "component" "jsp-http-servlet"
+            "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" "forwardToHtml_jsp"
             "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl
@@ -230,7 +231,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           resourceName "/forwards/forwardToHtml.jsp"
           errored false
           tags {
-            "component" "jsp-http-servlet"
+            "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.forwards.forwardToHtml_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -264,17 +265,17 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
-            "http.url" "http://localhost:$port/$jspWebappContext/forwards/forwardToIncludeMulti.jsp"
-            "http.method" "GET"
-            "peer.hostname" "127.0.0.1"
-            "peer.ipv4" "127.0.0.1"
-            "peer.port" Integer
-            "span.kind" "server"
-            "component" "java-web-servlet"
+            "$Tags.COMPONENT" "java-web-servlet"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
+            "$Tags.PEER_HOSTNAME" "127.0.0.1"
+            "$Tags.PEER_HOST_IPV4" "127.0.0.1"
+            "$Tags.PEER_PORT" Integer
+            "$Tags.HTTP_URL" "http://localhost:$port/$jspWebappContext/forwards/forwardToIncludeMulti.jsp"
+            "$Tags.HTTP_METHOD" "GET"
+            "$Tags.HTTP_STATUS" 200
             "span.origin.type" "org.apache.catalina.core.ApplicationFilterChain"
             "servlet.context" "/$jspWebappContext"
             "servlet.path" "/forwards/forwardToIncludeMulti.jsp"
-            "http.status_code" 200
             defaultTags()
           }
         }
@@ -285,7 +286,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           resourceName "/forwards/forwardToIncludeMulti.jsp"
           errored false
           tags {
-            "component" "jsp-http-servlet"
+            "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" "forwardToIncludeMulti_jsp"
             "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl
@@ -299,7 +300,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           resourceName "/includes/includeMulti.jsp"
           errored false
           tags {
-            "component" "jsp-http-servlet"
+            "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" "includeMulti_jsp"
             "servlet.context" "/$jspWebappContext"
             "jsp.forwardOrigin" "/forwards/forwardToIncludeMulti.jsp"
@@ -314,7 +315,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           resourceName "/common/javaLoopH2.jsp"
           errored false
           tags {
-            "component" "jsp-http-servlet"
+            "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" "javaLoopH2_jsp"
             "servlet.context" "/$jspWebappContext"
             "jsp.forwardOrigin" "/forwards/forwardToIncludeMulti.jsp"
@@ -329,7 +330,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           resourceName "/common/javaLoopH2.jsp"
           errored false
           tags {
-            "component" "jsp-http-servlet"
+            "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.common.javaLoopH2_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -343,7 +344,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           resourceName "/common/javaLoopH2.jsp"
           errored false
           tags {
-            "component" "jsp-http-servlet"
+            "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" "javaLoopH2_jsp"
             "servlet.context" "/$jspWebappContext"
             "jsp.forwardOrigin" "/forwards/forwardToIncludeMulti.jsp"
@@ -358,7 +359,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           resourceName "/common/javaLoopH2.jsp"
           errored false
           tags {
-            "component" "jsp-http-servlet"
+            "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.common.javaLoopH2_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -372,7 +373,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           resourceName "/includes/includeMulti.jsp"
           errored false
           tags {
-            "component" "jsp-http-servlet"
+            "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.includes.includeMulti_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -386,7 +387,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           resourceName "/forwards/forwardToIncludeMulti.jsp"
           errored false
           tags {
-            "component" "jsp-http-servlet"
+            "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.forwards.forwardToIncludeMulti_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -420,17 +421,17 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
-            "http.url" "http://localhost:$port/$jspWebappContext/forwards/forwardToJspForward.jsp"
-            "http.method" "GET"
-            "peer.hostname" "127.0.0.1"
-            "peer.ipv4" "127.0.0.1"
-            "peer.port" Integer
-            "span.kind" "server"
-            "component" "java-web-servlet"
+            "$Tags.COMPONENT" "java-web-servlet"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
+            "$Tags.PEER_HOSTNAME" "127.0.0.1"
+            "$Tags.PEER_HOST_IPV4" "127.0.0.1"
+            "$Tags.PEER_PORT" Integer
+            "$Tags.HTTP_URL" "http://localhost:$port/$jspWebappContext/forwards/forwardToJspForward.jsp"
+            "$Tags.HTTP_METHOD" "GET"
+            "$Tags.HTTP_STATUS" 200
             "span.origin.type" "org.apache.catalina.core.ApplicationFilterChain"
             "servlet.context" "/$jspWebappContext"
             "servlet.path" "/forwards/forwardToJspForward.jsp"
-            "http.status_code" 200
             defaultTags()
           }
         }
@@ -441,7 +442,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           resourceName "/forwards/forwardToJspForward.jsp"
           errored false
           tags {
-            "component" "jsp-http-servlet"
+            "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" "forwardToJspForward_jsp"
             "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl
@@ -455,7 +456,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           resourceName "/forwards/forwardToSimpleJava.jsp"
           errored false
           tags {
-            "component" "jsp-http-servlet"
+            "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" "forwardToSimpleJava_jsp"
             "servlet.context" "/$jspWebappContext"
             "jsp.forwardOrigin" "/forwards/forwardToJspForward.jsp"
@@ -470,7 +471,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           resourceName "/common/loop.jsp"
           errored false
           tags {
-            "component" "jsp-http-servlet"
+            "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" "loop_jsp"
             "servlet.context" "/$jspWebappContext"
             "jsp.forwardOrigin" "/forwards/forwardToJspForward.jsp"
@@ -485,7 +486,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           resourceName "/common/loop.jsp"
           errored false
           tags {
-            "component" "jsp-http-servlet"
+            "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.common.loop_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -499,7 +500,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           resourceName "/forwards/forwardToSimpleJava.jsp"
           errored false
           tags {
-            "component" "jsp-http-servlet"
+            "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.forwards.forwardToSimpleJava_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -513,7 +514,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           resourceName "/forwards/forwardToJspForward.jsp"
           errored false
           tags {
-            "component" "jsp-http-servlet"
+            "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.forwards.forwardToJspForward_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -547,17 +548,17 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           spanType DDSpanTypes.HTTP_SERVER
           errored true
           tags {
-            "http.url" "http://localhost:$port/$jspWebappContext/forwards/forwardToCompileError.jsp"
-            "http.method" "GET"
-            "peer.hostname" "127.0.0.1"
-            "peer.ipv4" "127.0.0.1"
-            "peer.port" Integer
-            "span.kind" "server"
-            "component" "java-web-servlet"
+            "$Tags.COMPONENT" "java-web-servlet"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
+            "$Tags.PEER_HOSTNAME" "127.0.0.1"
+            "$Tags.PEER_HOST_IPV4" "127.0.0.1"
+            "$Tags.PEER_PORT" Integer
+            "$Tags.HTTP_URL" "http://localhost:$port/$jspWebappContext/forwards/forwardToCompileError.jsp"
+            "$Tags.HTTP_METHOD" "GET"
+            "$Tags.HTTP_STATUS" 500
             "span.origin.type" "org.apache.catalina.core.ApplicationFilterChain"
             "servlet.context" "/$jspWebappContext"
             "servlet.path" "/forwards/forwardToCompileError.jsp"
-            "http.status_code" 500
             errorTags(JasperException, String)
             defaultTags()
           }
@@ -569,7 +570,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           resourceName "/forwards/forwardToCompileError.jsp"
           errored true
           tags {
-            "component" "jsp-http-servlet"
+            "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" "forwardToCompileError_jsp"
             "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl
@@ -584,7 +585,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           resourceName "/compileError.jsp"
           errored true
           tags {
-            "component" "jsp-http-servlet"
+            "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.compileError_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -599,7 +600,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           resourceName "/forwards/forwardToCompileError.jsp"
           errored false
           tags {
-            "component" "jsp-http-servlet"
+            "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.forwards.forwardToCompileError_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -633,17 +634,17 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
-            "http.url" "http://localhost:$port/$jspWebappContext/forwards/forwardToNonExistent.jsp"
-            "http.method" "GET"
-            "peer.hostname" "127.0.0.1"
-            "peer.ipv4" "127.0.0.1"
-            "peer.port" Integer
-            "span.kind" "server"
-            "component" "java-web-servlet"
+            "$Tags.COMPONENT" "java-web-servlet"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
+            "$Tags.PEER_HOSTNAME" "127.0.0.1"
+            "$Tags.PEER_HOST_IPV4" "127.0.0.1"
+            "$Tags.PEER_PORT" Integer
+            "$Tags.HTTP_URL" "http://localhost:$port/$jspWebappContext/forwards/forwardToNonExistent.jsp"
+            "$Tags.HTTP_METHOD" "GET"
+            "$Tags.HTTP_STATUS" 404
             "span.origin.type" "org.apache.catalina.core.ApplicationFilterChain"
             "servlet.context" "/$jspWebappContext"
             "servlet.path" "/forwards/forwardToNonExistent.jsp"
-            "http.status_code" 404
             defaultTags()
           }
         }
@@ -654,7 +655,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           resourceName "/forwards/forwardToNonExistent.jsp"
           errored false
           tags {
-            "component" "jsp-http-servlet"
+            "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" "forwardToNonExistent_jsp"
             "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl
@@ -668,7 +669,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           resourceName "/forwards/forwardToNonExistent.jsp"
           errored false
           tags {
-            "component" "jsp-http-servlet"
+            "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.forwards.forwardToNonExistent_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTest.groovy
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTest.groovy
@@ -1,4 +1,5 @@
 import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.instrumentation.api.Tags
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.clients.consumer.KafkaConsumer
@@ -88,8 +89,8 @@ class KafkaClientTest extends AgentTestRunner {
           errored false
           parent()
           tags {
-            "component" "java-kafka"
-            "span.kind" "producer"
+            "$Tags.COMPONENT" "java-kafka"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_PRODUCER
             defaultTags()
           }
         }
@@ -104,8 +105,8 @@ class KafkaClientTest extends AgentTestRunner {
           errored false
           childOf TEST_WRITER[0][0]
           tags {
-            "component" "java-kafka"
-            "span.kind" "consumer"
+            "$Tags.COMPONENT" "java-kafka"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
             "partition" { it >= 0 }
             "offset" 0
             defaultTags(true)
@@ -170,8 +171,8 @@ class KafkaClientTest extends AgentTestRunner {
           errored false
           parent()
           tags {
-            "component" "java-kafka"
-            "span.kind" "producer"
+            "$Tags.COMPONENT" "java-kafka"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_PRODUCER
             "kafka.partition" { it >= 0 }
             defaultTags(true)
           }
@@ -187,8 +188,8 @@ class KafkaClientTest extends AgentTestRunner {
           errored false
           childOf TEST_WRITER[0][0]
           tags {
-            "component" "java-kafka"
-            "span.kind" "consumer"
+            "$Tags.COMPONENT" "java-kafka"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
             "partition" { it >= 0 }
             "offset" 0
             defaultTags(true)

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/src/test/groovy/KafkaStreamsTest.groovy
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/src/test/groovy/KafkaStreamsTest.groovy
@@ -1,4 +1,5 @@
 import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.instrumentation.api.Tags
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.common.serialization.Serdes
 import org.apache.kafka.streams.KafkaStreams
@@ -133,8 +134,8 @@ class KafkaStreamsTest extends AgentTestRunner {
           errored false
           parent()
           tags {
-            "component" "java-kafka"
-            "span.kind" "producer"
+            "$Tags.COMPONENT" "java-kafka"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_PRODUCER
             defaultTags()
           }
         }
@@ -149,8 +150,8 @@ class KafkaStreamsTest extends AgentTestRunner {
           errored false
           childOf TEST_WRITER[0][0]
           tags {
-            "component" "java-kafka"
-            "span.kind" "consumer"
+            "$Tags.COMPONENT" "java-kafka"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
             "partition" { it >= 0 }
             "offset" 0
             defaultTags(true)
@@ -169,8 +170,8 @@ class KafkaStreamsTest extends AgentTestRunner {
           childOf span(1)
 
           tags {
-            "component" "java-kafka"
-            "span.kind" "producer"
+            "$Tags.COMPONENT" "java-kafka"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_PRODUCER
             defaultTags()
           }
         }
@@ -185,12 +186,12 @@ class KafkaStreamsTest extends AgentTestRunner {
           childOf TEST_WRITER[0][0]
 
           tags {
-            "component" "java-kafka"
-            "span.kind" "consumer"
+            "$Tags.COMPONENT" "java-kafka"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
             "partition" { it >= 0 }
             "offset" 0
-            defaultTags(true)
             "asdf" "testing"
+            defaultTags(true)
           }
         }
       }
@@ -204,12 +205,12 @@ class KafkaStreamsTest extends AgentTestRunner {
           errored false
           childOf TEST_WRITER[2][0]
           tags {
-            "component" "java-kafka"
-            "span.kind" "consumer"
+            "$Tags.COMPONENT" "java-kafka"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
             "partition" { it >= 0 }
             "offset" 0
-            defaultTags(true)
             "testing" 123
+            defaultTags(true)
           }
         }
       }

--- a/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/LettuceAsyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/LettuceAsyncClientTest.groovy
@@ -1,6 +1,7 @@
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
+import datadog.trace.instrumentation.api.Tags
 import io.lettuce.core.ClientOptions
 import io.lettuce.core.ConnectionFuture
 import io.lettuce.core.RedisClient
@@ -121,13 +122,13 @@ class LettuceAsyncClientTest extends AgentTestRunner {
           errored false
 
           tags {
-            defaultTags()
-            "component" "redis-client"
+            "$Tags.COMPONENT" "redis-client"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" HOST
+            "$Tags.PEER_PORT" port
+            "$Tags.DB_TYPE" "redis"
             "db.redis.dbIndex" 0
-            "db.type" "redis"
-            "peer.hostname" HOST
-            "peer.port" port
-            "span.kind" "client"
+            defaultTags()
           }
         }
       }
@@ -160,14 +161,14 @@ class LettuceAsyncClientTest extends AgentTestRunner {
           errored true
 
           tags {
-            defaultTags()
-            "component" "redis-client"
+            "$Tags.COMPONENT" "redis-client"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" HOST
+            "$Tags.PEER_PORT" incorrectPort
+            "$Tags.DB_TYPE" "redis"
             "db.redis.dbIndex" 0
-            "db.type" "redis"
             errorTags CompletionException, String
-            "peer.hostname" HOST
-            "peer.port" incorrectPort
-            "span.kind" "client"
+            defaultTags()
           }
         }
       }
@@ -191,10 +192,10 @@ class LettuceAsyncClientTest extends AgentTestRunner {
           errored false
 
           tags {
+            "$Tags.COMPONENT" "redis-client"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "redis"
             defaultTags()
-            "component" "redis-client"
-            "db.type" "redis"
-            "span.kind" "client"
           }
         }
       }
@@ -229,10 +230,10 @@ class LettuceAsyncClientTest extends AgentTestRunner {
           errored false
 
           tags {
+            "$Tags.COMPONENT" "redis-client"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "redis"
             defaultTags()
-            "component" "redis-client"
-            "db.type" "redis"
-            "span.kind" "client"
           }
         }
       }
@@ -281,10 +282,10 @@ class LettuceAsyncClientTest extends AgentTestRunner {
           errored false
 
           tags {
+            "$Tags.COMPONENT" "redis-client"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "redis"
             defaultTags()
-            "component" "redis-client"
-            "db.type" "redis"
-            "span.kind" "client"
           }
         }
       }
@@ -319,10 +320,10 @@ class LettuceAsyncClientTest extends AgentTestRunner {
           errored false
 
           tags {
+            "$Tags.COMPONENT" "redis-client"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "redis"
             defaultTags()
-            "component" "redis-client"
-            "db.type" "redis"
-            "span.kind" "client"
           }
         }
       }
@@ -376,10 +377,10 @@ class LettuceAsyncClientTest extends AgentTestRunner {
           errored false
 
           tags {
+            "$Tags.COMPONENT" "redis-client"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "redis"
             defaultTags()
-            "component" "redis-client"
-            "db.type" "redis"
-            "span.kind" "client"
           }
         }
       }
@@ -392,10 +393,10 @@ class LettuceAsyncClientTest extends AgentTestRunner {
           errored false
 
           tags {
+            "$Tags.COMPONENT" "redis-client"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "redis"
             defaultTags()
-            "component" "redis-client"
-            "db.type" "redis"
-            "span.kind" "client"
           }
         }
       }
@@ -438,11 +439,11 @@ class LettuceAsyncClientTest extends AgentTestRunner {
           errored true
 
           tags {
-            defaultTags()
-            "component" "redis-client"
-            "db.type" "redis"
+            "$Tags.COMPONENT" "redis-client"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "redis"
             errorTags(IllegalStateException, "TestException")
-            "span.kind" "client"
+            defaultTags()
           }
         }
       }
@@ -479,11 +480,11 @@ class LettuceAsyncClientTest extends AgentTestRunner {
           errored false
 
           tags {
-            defaultTags()
-            "component" "redis-client"
-            "db.type" "redis"
+            "$Tags.COMPONENT" "redis-client"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "redis"
             "db.command.cancelled" true
-            "span.kind" "client"
+            defaultTags()
           }
         }
       }
@@ -505,10 +506,10 @@ class LettuceAsyncClientTest extends AgentTestRunner {
           errored false
 
           tags {
+            "$Tags.COMPONENT" "redis-client"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "redis"
             defaultTags()
-            "component" "redis-client"
-            "db.type" "redis"
-            "span.kind" "client"
           }
         }
       }
@@ -531,10 +532,10 @@ class LettuceAsyncClientTest extends AgentTestRunner {
           errored false
 
           tags {
+            "$Tags.COMPONENT" "redis-client"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "redis"
             defaultTags()
-            "component" "redis-client"
-            "db.type" "redis"
-            "span.kind" "client"
           }
         }
       }

--- a/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/LettuceReactiveClientTest.groovy
+++ b/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/LettuceReactiveClientTest.groovy
@@ -1,6 +1,7 @@
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
+import datadog.trace.instrumentation.api.Tags
 import io.lettuce.core.ClientOptions
 import io.lettuce.core.RedisClient
 import io.lettuce.core.api.StatefulConnection
@@ -94,10 +95,10 @@ class LettuceReactiveClientTest extends AgentTestRunner {
           errored false
 
           tags {
+            "$Tags.COMPONENT" "redis-client"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "redis"
             defaultTags()
-            "component" "redis-client"
-            "db.type" "redis"
-            "span.kind" "client"
           }
         }
       }
@@ -123,10 +124,10 @@ class LettuceReactiveClientTest extends AgentTestRunner {
           errored false
 
           tags {
+            "$Tags.COMPONENT" "redis-client"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "redis"
             defaultTags()
-            "component" "redis-client"
-            "db.type" "redis"
-            "span.kind" "client"
           }
         }
       }
@@ -160,10 +161,10 @@ class LettuceReactiveClientTest extends AgentTestRunner {
           errored false
 
           tags {
+            "$Tags.COMPONENT" "redis-client"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "redis"
             defaultTags()
-            "component" "redis-client"
-            "db.type" "redis"
-            "span.kind" "client"
           }
         }
       }
@@ -195,10 +196,10 @@ class LettuceReactiveClientTest extends AgentTestRunner {
           errored false
 
           tags {
+            "$Tags.COMPONENT" "redis-client"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "redis"
             defaultTags()
-            "component" "redis-client"
-            "db.type" "redis"
-            "span.kind" "client"
           }
         }
       }
@@ -220,11 +221,11 @@ class LettuceReactiveClientTest extends AgentTestRunner {
           errored false
 
           tags {
-            defaultTags()
-            "component" "redis-client"
-            "db.type" "redis"
+            "$Tags.COMPONENT" "redis-client"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "redis"
             "db.command.results.count" 157
-            "span.kind" "client"
+            defaultTags()
           }
         }
       }
@@ -246,12 +247,12 @@ class LettuceReactiveClientTest extends AgentTestRunner {
           errored false
 
           tags {
-            defaultTags()
-            "component" "redis-client"
-            "db.type" "redis"
+            "$Tags.COMPONENT" "redis-client"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "redis"
             "db.command.cancelled" true
             "db.command.results.count" 2
-            "span.kind" "client"
+            defaultTags()
           }
         }
       }
@@ -285,10 +286,10 @@ class LettuceReactiveClientTest extends AgentTestRunner {
           errored false
 
           tags {
+            "$Tags.COMPONENT" "redis-client"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "redis"
             defaultTags()
-            "component" "redis-client"
-            "db.type" "redis"
-            "span.kind" "client"
           }
         }
       }
@@ -310,10 +311,10 @@ class LettuceReactiveClientTest extends AgentTestRunner {
           errored false
 
           tags {
+            "$Tags.COMPONENT" "redis-client"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "redis"
             defaultTags()
-            "component" "redis-client"
-            "db.type" "redis"
-            "span.kind" "client"
           }
         }
       }

--- a/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/LettuceSyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/LettuceSyncClientTest.groovy
@@ -1,6 +1,7 @@
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
+import datadog.trace.instrumentation.api.Tags
 import io.lettuce.core.ClientOptions
 import io.lettuce.core.RedisClient
 import io.lettuce.core.RedisConnectionException
@@ -101,13 +102,13 @@ class LettuceSyncClientTest extends AgentTestRunner {
           errored false
 
           tags {
-            defaultTags()
-            "component" "redis-client"
+            "$Tags.COMPONENT" "redis-client"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" HOST
+            "$Tags.PEER_PORT" port
+            "$Tags.DB_TYPE" "redis"
             "db.redis.dbIndex" 0
-            "db.type" "redis"
-            "peer.hostname" HOST
-            "peer.port" port
-            "span.kind" "client"
+            defaultTags()
           }
         }
       }
@@ -137,14 +138,14 @@ class LettuceSyncClientTest extends AgentTestRunner {
           errored true
 
           tags {
-            defaultTags()
-            "component" "redis-client"
+            "$Tags.COMPONENT" "redis-client"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" HOST
+            "$Tags.PEER_PORT" incorrectPort
+            "$Tags.DB_TYPE" "redis"
             "db.redis.dbIndex" 0
-            "db.type" "redis"
             errorTags CompletionException, String
-            "peer.hostname" HOST
-            "peer.port" incorrectPort
-            "span.kind" "client"
+            defaultTags()
           }
         }
       }
@@ -167,10 +168,10 @@ class LettuceSyncClientTest extends AgentTestRunner {
           errored false
 
           tags {
+            "$Tags.COMPONENT" "redis-client"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "redis"
             defaultTags()
-            "component" "redis-client"
-            "db.type" "redis"
-            "span.kind" "client"
           }
         }
       }
@@ -193,10 +194,10 @@ class LettuceSyncClientTest extends AgentTestRunner {
           errored false
 
           tags {
+            "$Tags.COMPONENT" "redis-client"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "redis"
             defaultTags()
-            "component" "redis-client"
-            "db.type" "redis"
-            "span.kind" "client"
           }
         }
       }
@@ -219,10 +220,10 @@ class LettuceSyncClientTest extends AgentTestRunner {
           errored false
 
           tags {
+            "$Tags.COMPONENT" "redis-client"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "redis"
             defaultTags()
-            "component" "redis-client"
-            "db.type" "redis"
-            "span.kind" "client"
           }
         }
       }
@@ -245,10 +246,10 @@ class LettuceSyncClientTest extends AgentTestRunner {
           errored false
 
           tags {
+            "$Tags.COMPONENT" "redis-client"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "redis"
             defaultTags()
-            "component" "redis-client"
-            "db.type" "redis"
-            "span.kind" "client"
           }
         }
       }
@@ -271,10 +272,10 @@ class LettuceSyncClientTest extends AgentTestRunner {
           errored false
 
           tags {
+            "$Tags.COMPONENT" "redis-client"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "redis"
             defaultTags()
-            "component" "redis-client"
-            "db.type" "redis"
-            "span.kind" "client"
           }
         }
       }
@@ -297,10 +298,10 @@ class LettuceSyncClientTest extends AgentTestRunner {
           errored false
 
           tags {
+            "$Tags.COMPONENT" "redis-client"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "redis"
             defaultTags()
-            "component" "redis-client"
-            "db.type" "redis"
-            "span.kind" "client"
           }
         }
       }
@@ -323,10 +324,10 @@ class LettuceSyncClientTest extends AgentTestRunner {
           errored false
 
           tags {
+            "$Tags.COMPONENT" "redis-client"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "redis"
             defaultTags()
-            "component" "redis-client"
-            "db.type" "redis"
-            "span.kind" "client"
           }
         }
       }
@@ -348,10 +349,10 @@ class LettuceSyncClientTest extends AgentTestRunner {
           errored false
 
           tags {
+            "$Tags.COMPONENT" "redis-client"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "redis"
             defaultTags()
-            "component" "redis-client"
-            "db.type" "redis"
-            "span.kind" "client"
           }
         }
       }
@@ -373,10 +374,10 @@ class LettuceSyncClientTest extends AgentTestRunner {
           errored false
 
           tags {
+            "$Tags.COMPONENT" "redis-client"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "redis"
             defaultTags()
-            "component" "redis-client"
-            "db.type" "redis"
-            "span.kind" "client"
           }
         }
       }

--- a/dd-java-agent/instrumentation/mongo/driver-3.1/src/test/groovy/MongoClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-3.1/src/test/groovy/MongoClientTest.groovy
@@ -250,14 +250,14 @@ class MongoClientTest extends MongoBaseTest {
       tags {
         "$Tags.COMPONENT" "java-mongo"
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-        "$Tags.DB_INSTANCE" instance
+        "$Tags.PEER_HOSTNAME" "localhost"
+        "$Tags.PEER_HOST_IPV4" "127.0.0.1"
+        "$Tags.PEER_PORT" port
         "$Tags.DB_STATEMENT" {
           it.replace(" ", "") == statement
         }
         "$Tags.DB_TYPE" "mongo"
-        "$Tags.PEER_HOSTNAME" "localhost"
-        "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-        "$Tags.PEER_PORT" port
+        "$Tags.DB_INSTANCE" instance
         defaultTags()
       }
     }

--- a/dd-java-agent/instrumentation/mongo/driver-async-3.3/src/test/groovy/MongoAsyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-async-3.3/src/test/groovy/MongoAsyncClientTest.groovy
@@ -285,12 +285,12 @@ class MongoAsyncClientTest extends MongoBaseTest {
       tags {
         "$Tags.COMPONENT" "java-mongo"
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-        "$Tags.DB_INSTANCE" instance
-        "$Tags.DB_STATEMENT" statementEval
-        "$Tags.DB_TYPE" "mongo"
         "$Tags.PEER_HOSTNAME" "localhost"
         "$Tags.PEER_HOST_IPV4" "127.0.0.1"
         "$Tags.PEER_PORT" port
+        "$Tags.DB_STATEMENT" statementEval
+        "$Tags.DB_TYPE" "mongo"
+        "$Tags.DB_INSTANCE" instance
         defaultTags()
       }
     }

--- a/dd-java-agent/instrumentation/netty-4.1/src/test/groovy/Netty41ClientTest.groovy
+++ b/dd-java-agent/instrumentation/netty-4.1/src/test/groovy/Netty41ClientTest.groovy
@@ -199,8 +199,8 @@ class Netty41ClientTest extends HttpClientTest<NettyHttpClientDecorator> {
           resourceName "AnnotatedClass.makeRequestUnderTrace"
           errored false
           tags {
-            defaultTags()
             "$Tags.COMPONENT" "trace"
+            defaultTags()
           }
         }
         clientSpan(it, 2, span(1), method)

--- a/dd-java-agent/instrumentation/play-2.4/src/test/groovy/server/PlayServerTest.groovy
+++ b/dd-java-agent/instrumentation/play-2.4/src/test/groovy/server/PlayServerTest.groovy
@@ -88,17 +88,17 @@ class PlayServerTest extends HttpServerTest<Server, NettyHttpServerDecorator> {
       childOf(parent as DDSpan)
       tags {
         "$Tags.COMPONENT" PlayHttpServerDecorator.DECORATE.component()
-        "$Tags.HTTP_STATUS" Integer
-        "$Tags.HTTP_URL" String
-        "$Tags.PEER_HOST_IPV4" { it == null || it == "127.0.0.1" } // Optional
-        "$Tags.HTTP_METHOD" String
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
-        defaultTags()
+        "$Tags.PEER_HOST_IPV4" { it == null || it == "127.0.0.1" } // Optional
+        "$Tags.HTTP_URL" String
+        "$Tags.HTTP_METHOD" String
+        "$Tags.HTTP_STATUS" Integer
         if (endpoint == ERROR) {
           "$Tags.ERROR" true
         } else if (endpoint == EXCEPTION) {
           errorTags(Exception, EXCEPTION.body)
         }
+        defaultTags()
       }
     }
   }

--- a/dd-java-agent/instrumentation/play-2.6/src/test/groovy/server/PlayServerTest.groovy
+++ b/dd-java-agent/instrumentation/play-2.6/src/test/groovy/server/PlayServerTest.groovy
@@ -90,17 +90,17 @@ class PlayServerTest extends HttpServerTest<Server, AkkaHttpServerDecorator> {
       childOf(parent as DDSpan)
       tags {
         "$Tags.COMPONENT" PlayHttpServerDecorator.DECORATE.component()
-        "$Tags.HTTP_STATUS" Integer
-        "$Tags.HTTP_URL" String
-        "$Tags.PEER_HOST_IPV4" { it == null || it == "127.0.0.1" } // Optional
-        "$Tags.HTTP_METHOD" String
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
-        defaultTags()
+        "$Tags.PEER_HOST_IPV4" { it == null || it == "127.0.0.1" } // Optional
+        "$Tags.HTTP_URL" String
+        "$Tags.HTTP_METHOD" String
+        "$Tags.HTTP_STATUS" Integer
         if (endpoint == ERROR) {
           "$Tags.ERROR" true
         } else if (endpoint == EXCEPTION) {
           errorTags(Exception, EXCEPTION.body)
         }
+        defaultTags()
       }
     }
   }
@@ -119,18 +119,18 @@ class PlayServerTest extends HttpServerTest<Server, AkkaHttpServerDecorator> {
         parent()
       }
       tags {
-        defaultTags(true)
         "$Tags.COMPONENT" serverDecorator.component()
+        "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
+        "$Tags.HTTP_STATUS" endpoint.status
+        "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
+        "$Tags.HTTP_METHOD" method
         if (endpoint.errored) {
           "$Tags.ERROR" endpoint.errored
           "error.msg" { it == null || it == EXCEPTION.body }
           "error.type" { it == null || it == Exception.name }
           "error.stack" { it == null || it instanceof String }
         }
-        "$Tags.HTTP_STATUS" endpoint.status
-        "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
-        "$Tags.HTTP_METHOD" method
-        "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
+        defaultTags(true)
       }
     }
   }

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/test/groovy/RabbitMQTest.groovy
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/test/groovy/RabbitMQTest.groovy
@@ -365,9 +365,6 @@ class RabbitMQTest extends AgentTestRunner {
       errored exception != null
 
       tags {
-        if (exception) {
-          errorTags(exception.class, errorMsg)
-        }
         "$Tags.COMPONENT" "rabbitmq-amqp"
         "$Tags.PEER_HOSTNAME" { it == null || it instanceof String }
         "$Tags.PEER_HOST_IPV4" { "127.0.0.1" }
@@ -400,6 +397,9 @@ class RabbitMQTest extends AgentTestRunner {
           default:
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "amqp.command" { it == null || it == resource }
+        }
+        if (exception) {
+          errorTags(exception.class, errorMsg)
         }
         defaultTags(distributedRootSpan)
       }

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/test/groovy/RabbitMQTest.groovy
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/test/groovy/RabbitMQTest.groovy
@@ -107,6 +107,9 @@ class RabbitMQTest extends AgentTestRunner {
       trace(1, 5) {
         span(0) {
           operationName "parent"
+          tags {
+            defaultTags()
+          }
         }
         // reverse order
         rabbitSpan(it, 1, "basic.publish $exchangeName -> $routingKey", false, span(0))

--- a/dd-java-agent/instrumentation/ratpack-1.4/src/test/groovy/RatpackOtherTest.groovy
+++ b/dd-java-agent/instrumentation/ratpack-1.4/src/test/groovy/RatpackOtherTest.groovy
@@ -72,12 +72,12 @@ class RatpackOtherTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT" "netty"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
-            "$Tags.HTTP_METHOD" "GET"
-            "$Tags.HTTP_STATUS" 200
-            "$Tags.HTTP_URL" "${app.address.resolve(path)}"
             "$Tags.PEER_HOSTNAME" "$app.address.host"
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
             "$Tags.PEER_PORT" Integer
+            "$Tags.HTTP_URL" "${app.address.resolve(path)}"
+            "$Tags.HTTP_METHOD" "GET"
+            "$Tags.HTTP_STATUS" 200
             defaultTags()
           }
         }
@@ -91,11 +91,11 @@ class RatpackOtherTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT" "ratpack"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
-            "$Tags.HTTP_METHOD" "GET"
-            "$Tags.HTTP_STATUS" 200
-            "$Tags.HTTP_URL" "${app.address.resolve(path)}"
             "$Tags.PEER_HOSTNAME" "$app.address.host"
             "$Tags.PEER_PORT" Integer
+            "$Tags.HTTP_URL" "${app.address.resolve(path)}"
+            "$Tags.HTTP_METHOD" "GET"
+            "$Tags.HTTP_STATUS" 200
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/ratpack-1.4/src/test/groovy/server/RatpackHttpServerTest.groovy
+++ b/dd-java-agent/instrumentation/ratpack-1.4/src/test/groovy/server/RatpackHttpServerTest.groovy
@@ -107,19 +107,19 @@ class RatpackHttpServerTest extends HttpServerTest<EmbeddedApp, NettyHttpServerD
       childOf(parent as DDSpan)
       tags {
         "$Tags.COMPONENT" RatpackServerDecorator.DECORATE.component()
-        "$Tags.HTTP_STATUS" Integer
-        "$Tags.HTTP_URL" String
-        "$Tags.PEER_HOSTNAME" "localhost"
-        "$Tags.PEER_PORT" Integer
-        "$Tags.PEER_HOST_IPV4" { it == null || it == "127.0.0.1" } // Optional
-        "$Tags.HTTP_METHOD" String
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
-        defaultTags()
+        "$Tags.PEER_HOSTNAME" "localhost"
+        "$Tags.PEER_HOST_IPV4" { it == null || it == "127.0.0.1" } // Optional
+        "$Tags.PEER_PORT" Integer
+        "$Tags.HTTP_URL" String
+        "$Tags.HTTP_METHOD" String
+        "$Tags.HTTP_STATUS" Integer
         if (endpoint == ERROR) {
           "$Tags.ERROR" true
         } else if (endpoint == EXCEPTION) {
           errorTags(Exception, EXCEPTION.body)
         }
+        defaultTags()
       }
     }
   }

--- a/dd-java-agent/instrumentation/servlet/request-2/src/test/groovy/JettyServlet2Test.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-2/src/test/groovy/JettyServlet2Test.groovy
@@ -93,25 +93,24 @@ class JettyServlet2Test extends HttpServerTest<Server, Servlet2Decorator> {
         parent()
       }
       tags {
+        "$Tags.COMPONENT" serverDecorator.component()
+        "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
+        "$Tags.PEER_HOSTNAME" "localhost"
+        "$Tags.PEER_HOST_IPV4" "127.0.0.1"
+        // No peer port
+        "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
+        "$Tags.HTTP_METHOD" method
+        "$Tags.HTTP_STATUS" endpoint.status
         "servlet.context" "/$CONTEXT"
         "servlet.path" endpoint.path
         "span.origin.type" TestServlet2.Sync.name
-
-        defaultTags(true)
-        "$Tags.COMPONENT" serverDecorator.component()
         if (endpoint.errored) {
           "$Tags.ERROR" endpoint.errored
           "error.msg" { it == null || it == EXCEPTION.body }
           "error.type" { it == null || it == Exception.name }
           "error.stack" { it == null || it instanceof String }
         }
-        "$Tags.HTTP_STATUS" endpoint.status
-        "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
-        "$Tags.PEER_HOSTNAME" "localhost"
-        // No peer port
-        "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-        "$Tags.HTTP_METHOD" method
-        "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
+        defaultTags(true)
       }
     }
   }

--- a/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/AbstractServlet3Test.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/AbstractServlet3Test.groovy
@@ -82,25 +82,24 @@ abstract class AbstractServlet3Test<SERVER, CONTEXT> extends HttpServerTest<SERV
         parent()
       }
       tags {
+        "$Tags.COMPONENT" serverDecorator.component()
+        "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
+        "$Tags.PEER_HOSTNAME" { it == "localhost" || it == "127.0.0.1" }
+        "$Tags.PEER_HOST_IPV4" { it == null || it == "127.0.0.1" } // Optional
+        "$Tags.PEER_PORT" Integer
+        "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
+        "$Tags.HTTP_METHOD" method
+        "$Tags.HTTP_STATUS" endpoint.status
         "servlet.context" "/$context"
         "servlet.path" { it == endpoint.path || it == "/dispatch$endpoint.path" }
         "span.origin.type" { it == servlet.name || it == ApplicationFilterChain.name }
-
-        defaultTags(true)
-        "$Tags.COMPONENT" serverDecorator.component()
         if (endpoint.errored) {
           "$Tags.ERROR" endpoint.errored
           "error.msg" { it == null || it == EXCEPTION.body }
           "error.type" { it == null || it == Exception.name }
           "error.stack" { it == null || it instanceof String }
         }
-        "$Tags.HTTP_STATUS" endpoint.status
-        "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
-        "$Tags.PEER_HOSTNAME" { it == "localhost" || it == "127.0.0.1" }
-        "$Tags.PEER_PORT" Integer
-        "$Tags.PEER_HOST_IPV4" { it == null || it == "127.0.0.1" } // Optional
-        "$Tags.HTTP_METHOD" method
-        "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
+        defaultTags(true)
       }
     }
   }

--- a/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/TomcatServlet3Test.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/TomcatServlet3Test.groovy
@@ -295,28 +295,27 @@ abstract class TomcatDispatchTest extends TomcatServlet3Test {
           errored endpoint.errored
           // we can't reliably assert parent or child relationship here since both are tested.
           tags {
+            "$Tags.COMPONENT" serverDecorator.component()
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
+            "$Tags.PEER_HOSTNAME" "localhost"
+            "$Tags.PEER_HOST_IPV4" { it == null || it == "127.0.0.1" } // Optional
+            "$Tags.PEER_PORT" Integer
+            "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
+            "$Tags.HTTP_METHOD" "GET"
+            "$Tags.HTTP_STATUS" endpoint.status
             "servlet.context" "/$context"
             "servlet.path" endpoint.status == 404 ? endpoint.path : "/dispatch$endpoint.path"
             "servlet.dispatch" endpoint.path
             "span.origin.type" {
               it == TestServlet3.DispatchImmediate.name || it == TestServlet3.DispatchAsync.name || it == ApplicationFilterChain.name
             }
-
-            defaultTags(true)
-            "$Tags.COMPONENT" serverDecorator.component()
             if (endpoint.errored) {
               "$Tags.ERROR" endpoint.errored
               "error.msg" { it == null || it == EXCEPTION.body }
               "error.type" { it == null || it == Exception.name }
               "error.stack" { it == null || it instanceof String }
             }
-            "$Tags.HTTP_STATUS" endpoint.status
-            "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
-            "$Tags.PEER_HOSTNAME" "localhost"
-            "$Tags.PEER_PORT" Integer
-            "$Tags.PEER_HOST_IPV4" { it == null || it == "127.0.0.1" } // Optional
-            "$Tags.HTTP_METHOD" "GET"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
+            defaultTags(true)
           }
         }
       }

--- a/dd-java-agent/instrumentation/sparkjava-2.3/src/test/groovy/SparkJavaBasedTest.groovy
+++ b/dd-java-agent/instrumentation/sparkjava-2.3/src/test/groovy/SparkJavaBasedTest.groovy
@@ -2,6 +2,7 @@ import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.utils.OkHttpUtils
 import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
+import datadog.trace.instrumentation.api.Tags
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import spark.Spark
@@ -50,15 +51,15 @@ class SparkJavaBasedTest extends AgentTestRunner {
           errored false
           parent()
           tags {
-            "http.url" "http://localhost:$port/param/asdf1234"
-            "http.method" "GET"
-            "span.kind" "server"
-            "component" "jetty-handler"
+            "$Tags.COMPONENT" "jetty-handler"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
+            "$Tags.PEER_HOSTNAME" "127.0.0.1"
+            "$Tags.PEER_HOST_IPV4" "127.0.0.1"
+            "$Tags.PEER_PORT" Integer
+            "$Tags.HTTP_URL" "http://localhost:$port/param/asdf1234"
+            "$Tags.HTTP_METHOD" "GET"
+            "$Tags.HTTP_STATUS" 200
             "span.origin.type" spark.embeddedserver.jetty.JettyHandler.name
-            "http.status_code" 200
-            "peer.hostname" "127.0.0.1"
-            "peer.ipv4" "127.0.0.1"
-            "peer.port" Integer
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/spring-data-1.8/src/test/groovy/SpringJpaTest.groovy
+++ b/dd-java-agent/instrumentation/spring-data-1.8/src/test/groovy/SpringJpaTest.groovy
@@ -1,6 +1,6 @@
 // This file includes software developed at SignalFx
 import datadog.trace.agent.test.AgentTestRunner
-import io.opentracing.tag.Tags
+import datadog.trace.instrumentation.api.Tags
 import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import spring.jpa.JpaCustomer
 import spring.jpa.JpaCustomerRepository
@@ -55,8 +55,8 @@ class SpringJpaTest extends AgentTestRunner {
           resourceName "JpaRepository.findAll"
           errored false
           tags {
-            "$Tags.COMPONENT.key" "spring-data"
-            "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
+            "$Tags.COMPONENT" "spring-data"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             defaultTags()
           }
         }
@@ -82,8 +82,8 @@ class SpringJpaTest extends AgentTestRunner {
           resourceName "CrudRepository.save"
           errored false
           tags {
-            "$Tags.COMPONENT.key" "spring-data"
-            "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
+            "$Tags.COMPONENT" "spring-data"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             defaultTags()
           }
         }
@@ -109,8 +109,8 @@ class SpringJpaTest extends AgentTestRunner {
           resourceName "CrudRepository.save"
           errored false
           tags {
-            "$Tags.COMPONENT.key" "spring-data"
-            "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
+            "$Tags.COMPONENT" "spring-data"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             defaultTags()
           }
         }
@@ -139,8 +139,8 @@ class SpringJpaTest extends AgentTestRunner {
           resourceName "JpaCustomerRepository.findByLastName"
           errored false
           tags {
-            "$Tags.COMPONENT.key" "spring-data"
-            "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
+            "$Tags.COMPONENT" "spring-data"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             defaultTags()
           }
         }
@@ -164,8 +164,8 @@ class SpringJpaTest extends AgentTestRunner {
           resourceName "CrudRepository.delete"
           errored false
           tags {
-            "$Tags.COMPONENT.key" "spring-data"
-            "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_CLIENT
+            "$Tags.COMPONENT" "spring-data"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/spring-data-1.8/src/test/groovy/SpringJpaTest.groovy
+++ b/dd-java-agent/instrumentation/spring-data-1.8/src/test/groovy/SpringJpaTest.groovy
@@ -28,6 +28,9 @@ class SpringJpaTest extends AgentTestRunner {
       trace(0, 1) {
         span(0) {
           operationName "toString test"
+          tags {
+            defaultTags()
+          }
         }
       }
     }
@@ -64,6 +67,15 @@ class SpringJpaTest extends AgentTestRunner {
           serviceName "hsqldb"
           spanType "sql"
           childOf(span(0))
+          tags {
+            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "hsqldb"
+            "$Tags.DB_INSTANCE" "test"
+            "$Tags.DB_USER" "sa"
+            "span.origin.type" "org.hsqldb.jdbc.JDBCPreparedStatement"
+            defaultTags()
+          }
         }
       }
     }
@@ -91,6 +103,15 @@ class SpringJpaTest extends AgentTestRunner {
           serviceName "hsqldb"
           spanType "sql"
           childOf(span(0))
+          tags {
+            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "hsqldb"
+            "$Tags.DB_INSTANCE" "test"
+            "$Tags.DB_USER" "sa"
+            "span.origin.type" "org.hsqldb.jdbc.JDBCPreparedStatement"
+            defaultTags()
+          }
         }
       }
     }
@@ -118,11 +139,29 @@ class SpringJpaTest extends AgentTestRunner {
           serviceName "hsqldb"
           spanType "sql"
           childOf(span(0))
+          tags {
+            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "hsqldb"
+            "$Tags.DB_INSTANCE" "test"
+            "$Tags.DB_USER" "sa"
+            "span.origin.type" "org.hsqldb.jdbc.JDBCPreparedStatement"
+            defaultTags()
+          }
         }
         span(2) { //update
           serviceName "hsqldb"
           spanType "sql"
           childOf(span(0))
+          tags {
+            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "hsqldb"
+            "$Tags.DB_INSTANCE" "test"
+            "$Tags.DB_USER" "sa"
+            "span.origin.type" "org.hsqldb.jdbc.JDBCPreparedStatement"
+            defaultTags()
+          }
         }
       }
     }
@@ -148,6 +187,15 @@ class SpringJpaTest extends AgentTestRunner {
           serviceName "hsqldb"
           spanType "sql"
           childOf(span(0))
+          tags {
+            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "hsqldb"
+            "$Tags.DB_INSTANCE" "test"
+            "$Tags.DB_USER" "sa"
+            "span.origin.type" "org.hsqldb.jdbc.JDBCPreparedStatement"
+            defaultTags()
+          }
         }
       }
     }
@@ -173,11 +221,29 @@ class SpringJpaTest extends AgentTestRunner {
           serviceName "hsqldb"
           spanType "sql"
           childOf(span(0))
+          tags {
+            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "hsqldb"
+            "$Tags.DB_INSTANCE" "test"
+            "$Tags.DB_USER" "sa"
+            "span.origin.type" "org.hsqldb.jdbc.JDBCPreparedStatement"
+            defaultTags()
+          }
         }
         span(2) { // delete
           serviceName "hsqldb"
           spanType "sql"
           childOf(span(0))
+          tags {
+            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "hsqldb"
+            "$Tags.DB_INSTANCE" "test"
+            "$Tags.DB_USER" "sa"
+            "span.origin.type" "org.hsqldb.jdbc.JDBCPreparedStatement"
+            defaultTags()
+          }
         }
       }
     }

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/test/groovy/SpringWebfluxTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/test/groovy/SpringWebfluxTest.groovy
@@ -87,9 +87,9 @@ class SpringWebfluxTest extends AgentTestRunner {
             "$Tags.PEER_HOSTNAME" "localhost"
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
             "$Tags.PEER_PORT" Integer
+            "$Tags.HTTP_URL" url
             "$Tags.HTTP_METHOD" "GET"
             "$Tags.HTTP_STATUS" 200
-            "$Tags.HTTP_URL" url
             defaultTags()
           }
         }
@@ -161,9 +161,9 @@ class SpringWebfluxTest extends AgentTestRunner {
             "$Tags.PEER_HOSTNAME" "localhost"
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
             "$Tags.PEER_PORT" Integer
+            "$Tags.HTTP_URL" url
             "$Tags.HTTP_METHOD" "GET"
             "$Tags.HTTP_STATUS" 200
-            "$Tags.HTTP_URL" url
             defaultTags()
           }
         }
@@ -222,9 +222,9 @@ class SpringWebfluxTest extends AgentTestRunner {
             "$Tags.PEER_HOSTNAME" "localhost"
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
             "$Tags.PEER_PORT" Integer
+            "$Tags.HTTP_URL" url
             "$Tags.HTTP_METHOD" "GET"
             "$Tags.HTTP_STATUS" 404
-            "$Tags.HTTP_URL" url
             defaultTags()
           }
         }
@@ -287,9 +287,9 @@ class SpringWebfluxTest extends AgentTestRunner {
             "$Tags.PEER_HOSTNAME" "localhost"
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
             "$Tags.PEER_PORT" Integer
+            "$Tags.HTTP_URL" url
             "$Tags.HTTP_METHOD" "POST"
             "$Tags.HTTP_STATUS" 202
-            "$Tags.HTTP_URL" url
             defaultTags()
           }
         }
@@ -330,9 +330,9 @@ class SpringWebfluxTest extends AgentTestRunner {
             "$Tags.PEER_HOSTNAME" "localhost"
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
             "$Tags.PEER_PORT" Integer
+            "$Tags.HTTP_URL" url
             "$Tags.HTTP_METHOD" "GET"
             "$Tags.HTTP_STATUS" 500
-            "$Tags.HTTP_URL" url
             "error" true
             defaultTags()
           }
@@ -404,9 +404,9 @@ class SpringWebfluxTest extends AgentTestRunner {
             "$Tags.PEER_HOSTNAME" "localhost"
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
             "$Tags.PEER_PORT" Integer
+            "$Tags.HTTP_URL" url
             "$Tags.HTTP_METHOD" "GET"
             "$Tags.HTTP_STATUS" 307
-            "$Tags.HTTP_URL" url
             defaultTags()
           }
         }
@@ -454,9 +454,9 @@ class SpringWebfluxTest extends AgentTestRunner {
             "$Tags.PEER_HOSTNAME" "localhost"
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
             "$Tags.PEER_PORT" Integer
+            "$Tags.HTTP_URL" finalUrl
             "$Tags.HTTP_METHOD" "GET"
             "$Tags.HTTP_STATUS" 200
-            "$Tags.HTTP_URL" finalUrl
             defaultTags()
           }
         }
@@ -517,9 +517,9 @@ class SpringWebfluxTest extends AgentTestRunner {
               "$Tags.PEER_HOSTNAME" "localhost"
               "$Tags.PEER_HOST_IPV4" "127.0.0.1"
               "$Tags.PEER_PORT" Integer
+              "$Tags.HTTP_URL" url
               "$Tags.HTTP_METHOD" "GET"
               "$Tags.HTTP_STATUS" 200
-              "$Tags.HTTP_URL" url
               defaultTags()
             }
           }

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/test/groovy/dd/trace/instrumentation/springwebflux/client/SpringWebfluxHttpClientTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/test/groovy/dd/trace/instrumentation/springwebflux/client/SpringWebfluxHttpClientTest.groovy
@@ -57,24 +57,24 @@ class SpringWebfluxHttpClientTest extends HttpClientTest<SpringWebfluxHttpClient
         spanType DDSpanTypes.HTTP_CLIENT
         errored exception != null
         tags {
-          defaultTags()
-          if (exception) {
-            errorTags(exception.class, exception.message)
-          }
           "$Tags.COMPONENT" NettyHttpClientDecorator.DECORATE.component()
+          "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+          "$Tags.PEER_HOSTNAME" "localhost"
+          "$Tags.PEER_PORT" uri.port
+          "$Tags.PEER_HOST_IPV4" { it == null || it == "127.0.0.1" } // Optional
+          "$Tags.HTTP_URL" "${uri.resolve(uri.path)}"
+          "$Tags.HTTP_METHOD" method
           if (status) {
             "$Tags.HTTP_STATUS" status
           }
-          "$Tags.HTTP_URL" "${uri.resolve(uri.path)}"
           if (tagQueryString) {
             "$DDTags.HTTP_QUERY" uri.query
             "$DDTags.HTTP_FRAGMENT" { it == null || it == uri.fragment } // Optional
           }
-          "$Tags.PEER_HOSTNAME" "localhost"
-          "$Tags.PEER_PORT" uri.port
-          "$Tags.PEER_HOST_IPV4" { it == null || it == "127.0.0.1" } // Optional
-          "$Tags.HTTP_METHOD" method
-          "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+          if (exception) {
+            errorTags(exception.class, exception.message)
+          }
+          defaultTags()
         }
       }
     }

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/SpringBootBasedTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/SpringBootBasedTest.groovy
@@ -77,9 +77,9 @@ class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext,
           spanType "web"
           errored false
           tags {
-            "component" "spring-webmvc"
+            "$Tags.COMPONENT" "spring-webmvc"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
             "view.type" RedirectView.name
-            "span.kind" "server"
             defaultTags()
           }
         }
@@ -102,10 +102,10 @@ class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext,
       tags {
         "$Tags.COMPONENT" SpringWebHttpServerDecorator.DECORATE.component()
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
-        defaultTags()
         if (endpoint == EXCEPTION) {
           errorTags(Exception, EXCEPTION.body)
         }
+        defaultTags()
       }
     }
   }
@@ -125,24 +125,23 @@ class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext,
         parent()
       }
       tags {
+        "$Tags.COMPONENT" serverDecorator.component()
+        "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
+        "$Tags.PEER_HOSTNAME" { it == "localhost" || it == "127.0.0.1" }
+        "$Tags.PEER_HOST_IPV4" { it == null || it == "127.0.0.1" } // Optional
+        "$Tags.PEER_PORT" Integer
+        "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
+        "$Tags.HTTP_METHOD" method
+        "$Tags.HTTP_STATUS" endpoint.status
         "span.origin.type" ApplicationFilterChain.name
         "servlet.path" endpoint.path
-
-        defaultTags(true)
-        "$Tags.COMPONENT" serverDecorator.component()
         if (endpoint.errored) {
           "$Tags.ERROR" endpoint.errored
           "error.msg" { it == null || it == EXCEPTION.body }
           "error.type" { it == null || it == Exception.name }
           "error.stack" { it == null || it instanceof String }
         }
-        "$Tags.HTTP_STATUS" endpoint.status
-        "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
-        "$Tags.PEER_HOSTNAME" { it == "localhost" || it == "127.0.0.1" }
-        "$Tags.PEER_PORT" Integer
-        "$Tags.PEER_HOST_IPV4" { it == null || it == "127.0.0.1" } // Optional
-        "$Tags.HTTP_METHOD" method
-        "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
+        defaultTags(true)
       }
     }
   }

--- a/dd-java-agent/instrumentation/spymemcached-2.12/src/test/groovy/datadog/trace/instrumentation/spymemcached/SpymemcachedTest.groovy
+++ b/dd-java-agent/instrumentation/spymemcached-2.12/src/test/groovy/datadog/trace/instrumentation/spymemcached/SpymemcachedTest.groovy
@@ -637,13 +637,20 @@ class SpymemcachedTest extends AgentTestRunner {
       errored(error != null && error != "canceled")
 
       tags {
-        defaultTags()
-        "${Tags.COMPONENT}" COMPONENT_NAME
-        "${Tags.SPAN_KIND}" Tags.SPAN_KIND_CLIENT
-        "${Tags.DB_TYPE}" CompletionListener.DB_TYPE
+        "$Tags.COMPONENT" COMPONENT_NAME
+        "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+        "$Tags.DB_TYPE" CompletionListener.DB_TYPE
 
         if (error == "canceled") {
           "${CompletionListener.DB_COMMAND_CANCELLED}" true
+        }
+
+        if (result == "hit") {
+          "${CompletionListener.MEMCACHED_RESULT}" CompletionListener.HIT
+        }
+
+        if (result == "miss") {
+          "${CompletionListener.MEMCACHED_RESULT}" CompletionListener.MISS
         }
 
         if (error == "timeout") {
@@ -658,13 +665,7 @@ class SpymemcachedTest extends AgentTestRunner {
             "Key is too long (maxlen = 250)")
         }
 
-        if (result == "hit") {
-          "${CompletionListener.MEMCACHED_RESULT}" CompletionListener.HIT
-        }
-
-        if (result == "miss") {
-          "${CompletionListener.MEMCACHED_RESULT}" CompletionListener.MISS
-        }
+        defaultTags()
       }
     }
   }

--- a/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/ConfiguredTraceAnnotationsTest.groovy
+++ b/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/ConfiguredTraceAnnotationsTest.groovy
@@ -1,5 +1,6 @@
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.utils.ConfigUtils
+import datadog.trace.instrumentation.api.Tags
 import datadog.trace.instrumentation.trace_annotation.TraceAnnotationsInstrumentation
 import dd.test.trace.annotation.SayTracedHello
 
@@ -40,6 +41,10 @@ class ConfiguredTraceAnnotationsTest extends AgentTestRunner {
         span(0) {
           resourceName "AnnotationTracedCallable.call"
           operationName "trace.annotation"
+          tags {
+            "$Tags.COMPONENT" "trace"
+            defaultTags()
+          }
         }
       }
     }

--- a/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/TraceAnnotationsTest.groovy
+++ b/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/TraceAnnotationsTest.groovy
@@ -310,6 +310,10 @@ class TraceAnnotationsTest extends AgentTestRunner {
         span(0) {
           resourceName "SayTracedHello\$1.call"
           operationName "trace.annotation"
+          tags {
+            "$Tags.COMPONENT" "trace"
+            defaultTags()
+          }
         }
       }
     }
@@ -331,11 +335,19 @@ class TraceAnnotationsTest extends AgentTestRunner {
         span(0) {
           resourceName "SayTracedHello\$1.call"
           operationName "trace.annotation"
+          tags {
+            "$Tags.COMPONENT" "trace"
+            defaultTags()
+          }
         }
         trace(1, 1) {
           span(0) {
             resourceName "TraceAnnotationsTest\$1.call"
             operationName "trace.annotation"
+            tags {
+              "$Tags.COMPONENT" "trace"
+              defaultTags()
+            }
           }
         }
       }

--- a/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/TraceConfigTest.groovy
+++ b/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/TraceConfigTest.groovy
@@ -1,5 +1,6 @@
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.utils.ConfigUtils
+import datadog.trace.instrumentation.api.Tags
 import datadog.trace.instrumentation.trace_annotation.TraceConfigInstrumentation
 
 import java.util.concurrent.Callable
@@ -38,6 +39,10 @@ class TraceConfigTest extends AgentTestRunner {
         span(0) {
           resourceName "ConfigTracedCallable.call"
           operationName "trace.annotation"
+          tags {
+            "$Tags.COMPONENT" "trace"
+            defaultTags()
+          }
         }
       }
     }

--- a/dd-java-agent/instrumentation/twilio/src/test/groovy/test/TwilioClientTest.groovy
+++ b/dd-java-agent/instrumentation/twilio/src/test/groovy/test/TwilioClientTest.groovy
@@ -139,6 +139,9 @@ class TwilioClientTest extends AgentTestRunner {
           resourceName "test"
           errored false
           parent()
+          tags {
+            defaultTags()
+          }
         }
         span(1) {
           serviceName "twilio-sdk"
@@ -193,6 +196,9 @@ class TwilioClientTest extends AgentTestRunner {
           resourceName "test"
           errored false
           parent()
+          tags {
+            defaultTags()
+          }
         }
         span(1) {
           serviceName "twilio-sdk"
@@ -269,6 +275,9 @@ class TwilioClientTest extends AgentTestRunner {
           resourceName "test"
           errored false
           parent()
+          tags {
+            defaultTags()
+          }
         }
         span(1) {
           serviceName "twilio-sdk"
@@ -292,6 +301,15 @@ class TwilioClientTest extends AgentTestRunner {
           resourceName "POST /?/Accounts/abc/Messages.json"
           spanType DDSpanTypes.HTTP_CLIENT
           errored false
+          tags {
+            "$Tags.COMPONENT" "apache-httpclient"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" String
+            "$Tags.HTTP_URL" String
+            "$Tags.HTTP_METHOD" String
+            "$Tags.HTTP_STATUS" Integer
+            defaultTags()
+          }
         }
       }
     }
@@ -368,6 +386,9 @@ class TwilioClientTest extends AgentTestRunner {
           resourceName "test"
           errored false
           parent()
+          tags {
+            defaultTags()
+          }
         }
         span(1) {
           serviceName "twilio-sdk"
@@ -391,6 +412,15 @@ class TwilioClientTest extends AgentTestRunner {
           resourceName "POST /?/Accounts/abc/Messages.json"
           spanType DDSpanTypes.HTTP_CLIENT
           errored false
+          tags {
+            "$Tags.COMPONENT" "apache-httpclient"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" String
+            "$Tags.HTTP_URL" String
+            "$Tags.HTTP_METHOD" String
+            "$Tags.HTTP_STATUS" Integer
+            defaultTags()
+          }
         }
         span(3) {
           serviceName "twilio-sdk"
@@ -398,6 +428,16 @@ class TwilioClientTest extends AgentTestRunner {
           resourceName "POST /?/Accounts/abc/Messages.json"
           spanType DDSpanTypes.HTTP_CLIENT
           errored true
+          tags {
+            "$Tags.COMPONENT" "apache-httpclient"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" String
+            "$Tags.HTTP_URL" String
+            "$Tags.HTTP_METHOD" String
+            "$Tags.HTTP_STATUS" Integer
+            "$Tags.ERROR" true
+            defaultTags()
+          }
         }
       }
     }
@@ -482,6 +522,9 @@ class TwilioClientTest extends AgentTestRunner {
           resourceName "test"
           errored false
           parent()
+          tags {
+            defaultTags()
+          }
         }
         span(1) {
           serviceName "twilio-sdk"
@@ -523,6 +566,15 @@ class TwilioClientTest extends AgentTestRunner {
           resourceName "POST /?/Accounts/abc/Messages.json"
           spanType DDSpanTypes.HTTP_CLIENT
           errored false
+          tags {
+            "$Tags.COMPONENT" "apache-httpclient"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" String
+            "$Tags.HTTP_URL" String
+            "$Tags.HTTP_METHOD" String
+            "$Tags.HTTP_STATUS" Integer
+            defaultTags()
+          }
         }
         span(4) {
           serviceName "twilio-sdk"
@@ -530,6 +582,16 @@ class TwilioClientTest extends AgentTestRunner {
           resourceName "POST /?/Accounts/abc/Messages.json"
           spanType DDSpanTypes.HTTP_CLIENT
           errored true
+          tags {
+            "$Tags.COMPONENT" "apache-httpclient"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" String
+            "$Tags.HTTP_URL" String
+            "$Tags.HTTP_METHOD" String
+            "$Tags.HTTP_STATUS" Integer
+            "$Tags.ERROR" true
+            defaultTags()
+          }
         }
       }
     }
@@ -574,6 +636,9 @@ class TwilioClientTest extends AgentTestRunner {
           resourceName "test"
           errored false
           parent()
+          tags {
+            defaultTags()
+          }
         }
         span(1) {
           serviceName "twilio-sdk"
@@ -581,6 +646,12 @@ class TwilioClientTest extends AgentTestRunner {
           resourceName "api.v2010.account.MessageCreator.create"
           spanType DDSpanTypes.HTTP_CLIENT
           errored true
+          tags {
+            "$Tags.COMPONENT" "twilio-sdk"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            errorTags(ApiException, "Testing Failure")
+            defaultTags()
+          }
         }
       }
     }
@@ -667,6 +738,9 @@ class TwilioClientTest extends AgentTestRunner {
           resourceName "test"
           errored false
           parent()
+          tags {
+            defaultTags()
+          }
         }
         span(1) {
           serviceName "twilio-sdk"
@@ -755,6 +829,9 @@ class TwilioClientTest extends AgentTestRunner {
           resourceName "test"
           errored false
           parent()
+          tags {
+            defaultTags()
+          }
         }
         span(1) {
           serviceName "twilio-sdk"
@@ -762,6 +839,12 @@ class TwilioClientTest extends AgentTestRunner {
           resourceName "api.v2010.account.MessageCreator.createAsync"
           spanType DDSpanTypes.HTTP_CLIENT
           errored true
+          tags {
+            "$Tags.COMPONENT" "twilio-sdk"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            errorTags(ApiException, "Testing Failure")
+            defaultTags()
+          }
         }
         span(2) {
           serviceName "twilio-sdk"
@@ -769,6 +852,12 @@ class TwilioClientTest extends AgentTestRunner {
           resourceName "api.v2010.account.MessageCreator.create"
           spanType DDSpanTypes.HTTP_CLIENT
           errored true
+          tags {
+            "$Tags.COMPONENT" "twilio-sdk"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            errorTags(ApiException, "Testing Failure")
+            defaultTags()
+          }
         }
       }
     }

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
@@ -324,24 +324,24 @@ abstract class HttpClientTest<DECORATOR extends HttpClientDecorator> extends Age
       spanType DDSpanTypes.HTTP_CLIENT
       errored exception != null
       tags {
-        defaultTags()
-        if (exception) {
-          errorTags(exception.class, exception.message)
-        }
         "$Tags.COMPONENT" clientDecorator.component()
+        "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+        "$Tags.PEER_HOSTNAME" "localhost"
+        "$Tags.PEER_HOST_IPV4" { it == null || it == "127.0.0.1" } // Optional
+        "$Tags.PEER_PORT" uri.port
+        "$Tags.HTTP_URL" "${uri.resolve(uri.path)}"
+        "$Tags.HTTP_METHOD" method
         if (status) {
           "$Tags.HTTP_STATUS" status
         }
-        "$Tags.HTTP_URL" "${uri.resolve(uri.path)}"
         if (tagQueryString) {
           "$DDTags.HTTP_QUERY" uri.query
           "$DDTags.HTTP_FRAGMENT" { it == null || it == uri.fragment } // Optional
         }
-        "$Tags.PEER_HOSTNAME" "localhost"
-        "$Tags.PEER_PORT" uri.port
-        "$Tags.PEER_HOST_IPV4" { it == null || it == "127.0.0.1" } // Optional
-        "$Tags.HTTP_METHOD" method
-        "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+        if (exception) {
+          errorTags(exception.class, exception.message)
+        }
+        defaultTags()
       }
     }
   }

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
@@ -412,10 +412,10 @@ abstract class HttpServerTest<SERVER, DECORATOR extends HttpServerDecorator> ext
       errored errorMessage != null
       childOf(parent as DDSpan)
       tags {
-        defaultTags()
         if (errorMessage) {
           errorTags(Exception, errorMessage)
         }
+        defaultTags()
       }
     }
   }
@@ -439,22 +439,22 @@ abstract class HttpServerTest<SERVER, DECORATOR extends HttpServerDecorator> ext
         parent()
       }
       tags {
-        defaultTags(true)
         "$Tags.COMPONENT" serverDecorator.component()
-        if (endpoint.errored) {
-          "$Tags.ERROR" endpoint.errored
-        }
-        "$Tags.HTTP_STATUS" endpoint.status
+        "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
+        "$Tags.PEER_HOSTNAME" { it == "localhost" || it == "127.0.0.1" }
+        "$Tags.PEER_PORT" Integer
+        "$Tags.PEER_HOST_IPV4" { it == null || it == "127.0.0.1" } // Optional
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
+        "$Tags.HTTP_METHOD" method
+        "$Tags.HTTP_STATUS" endpoint.status
 //        if (tagQueryString) {
 //          "$DDTags.HTTP_QUERY" uri.query
 //          "$DDTags.HTTP_FRAGMENT" { it == null || it == uri.fragment } // Optional
 //        }
-        "$Tags.PEER_HOSTNAME" { it == "localhost" || it == "127.0.0.1" }
-        "$Tags.PEER_PORT" Integer
-        "$Tags.PEER_HOST_IPV4" { it == null || it == "127.0.0.1" } // Optional
-        "$Tags.HTTP_METHOD" method
-        "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
+        if (endpoint.errored) {
+          "$Tags.ERROR" endpoint.errored
+        }
+        defaultTags(true)
       }
     }
   }

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/utils/TraceUtils.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/utils/TraceUtils.groovy
@@ -63,10 +63,10 @@ class TraceUtils {
       resourceName resource
       errored exception != null
       tags {
-        defaultTags()
         if (exception) {
           errorTags(exception.class, exception.message)
         }
+        defaultTags()
       }
     }
   }


### PR DESCRIPTION
Hey all! I thought this work was going to come in handy so I could do some automated updates to the tag verification (it still might, but I ended up not needing this for now).

Regardless, I think it's a nice clean up, and maybe worth merging upstream into this repo before we diverge and this merge causes massive conflicts.

It normalizes a couple of things:
* Uses the `Tags` and `DDTags` constants where possible
* Consistent ordering of the tags in the `tags` verification block
* Adds a `tags` verification block where there was none

Sorry it's another big change. If you think it's not worth it, I can accept that :smile:.