### PR TITLE
Eliminate class expression to Advice class

### DIFF
--- a/dd-java-agent/instrumentation/jsp-2.3/src/main/java/datadog/trace/instrumentation/jsp/JasperJSPCompilationContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/jsp-2.3/src/main/java/datadog/trace/instrumentation/jsp/JasperJSPCompilationContextInstrumentation.java
@@ -42,7 +42,8 @@ public final class JasperJSPCompilationContextInstrumentation extends Instrument
   public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
     return singletonMap(
         named("compile").and(takesArguments(0)).and(isPublic()),
-        JasperJspCompilationContext.class.getName());
+        JasperJSPCompilationContextInstrumentation.class.getName()
+            + "$JasperJspCompilationContext");
   }
 
   public static class JasperJspCompilationContext {


### PR DESCRIPTION
Changing Jasper instrumentation to not load the advice class.
This class was missed originally because it doesn't end in Advice.