### PR TITLE
Rename KnuthSampler to DeterministicSampler

### DIFF
--- a/dd-trace-ot/src/main/java/datadog/trace/common/sampling/DeterministicSampler.java
+++ b/dd-trace-ot/src/main/java/datadog/trace/common/sampling/DeterministicSampler.java
@@ -6,8 +6,12 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import lombok.extern.slf4j.Slf4j;
 
+/**
+ * This implements the deterministic sampling algorithm used by the Datadog Agent as well as the
+ * tracers for other languages
+ */
 @Slf4j
-public class KnuthSampler implements RateSampler {
+public class DeterministicSampler implements RateSampler {
   private static final BigInteger KNUTH_FACTOR = new BigInteger("1111111111111111111");
   private static final BigDecimal TRACE_ID_MAX_AS_BIG_DECIMAL =
       new BigDecimal(DDTracer.TRACE_ID_MAX);
@@ -16,7 +20,7 @@ public class KnuthSampler implements RateSampler {
   private final BigInteger cutoff;
   private final double rate;
 
-  public KnuthSampler(final double rate) {
+  public DeterministicSampler(final double rate) {
     this.rate = rate;
     cutoff = new BigDecimal(rate).multiply(TRACE_ID_MAX_AS_BIG_DECIMAL).toBigInteger();
 

--- a/dd-trace-ot/src/main/java/datadog/trace/common/sampling/RateByServiceSampler.java
+++ b/dd-trace-ot/src/main/java/datadog/trace/common/sampling/RateByServiceSampler.java
@@ -107,6 +107,6 @@ public class RateByServiceSampler implements Sampler, PrioritySampler, ResponseL
       sanitizedRate = sampleRate;
     }
 
-    return new KnuthSampler(sanitizedRate);
+    return new DeterministicSampler(sanitizedRate);
   }
 }

--- a/dd-trace-ot/src/main/java/datadog/trace/common/sampling/RuleBasedSampler.java
+++ b/dd-trace-ot/src/main/java/datadog/trace/common/sampling/RuleBasedSampler.java
@@ -45,7 +45,7 @@ public class RuleBasedSampler implements Sampler, PrioritySampler {
         try {
           final double rateForEntry = Double.parseDouble(entry.getValue());
           final SamplingRule samplingRule =
-              new ServiceSamplingRule(entry.getKey(), new KnuthSampler(rateForEntry));
+              new ServiceSamplingRule(entry.getKey(), new DeterministicSampler(rateForEntry));
           samplingRules.add(samplingRule);
         } catch (final NumberFormatException e) {
           log.error("Unable to parse rate for service: {}", entry, e);
@@ -58,7 +58,7 @@ public class RuleBasedSampler implements Sampler, PrioritySampler {
         try {
           final double rateForEntry = Double.parseDouble(entry.getValue());
           final SamplingRule samplingRule =
-              new OperationSamplingRule(entry.getKey(), new KnuthSampler(rateForEntry));
+              new OperationSamplingRule(entry.getKey(), new DeterministicSampler(rateForEntry));
           samplingRules.add(samplingRule);
         } catch (final NumberFormatException e) {
           log.error("Unable to parse rate for operation: {}", entry, e);
@@ -68,7 +68,7 @@ public class RuleBasedSampler implements Sampler, PrioritySampler {
 
     if (defaultRate != null) {
       final SamplingRule samplingRule =
-          new AlwaysMatchesSamplingRule(new KnuthSampler(defaultRate));
+          new AlwaysMatchesSamplingRule(new DeterministicSampler(defaultRate));
       samplingRules.add(samplingRule);
     }
 

--- a/dd-trace-ot/src/test/groovy/datadog/trace/api/sampling/DeterministicSamplerTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/trace/api/sampling/DeterministicSamplerTest.groovy
@@ -1,14 +1,14 @@
 package datadog.trace.api.sampling
 
 import datadog.opentracing.DDSpan
-import datadog.trace.common.sampling.KnuthSampler
+import datadog.trace.common.sampling.DeterministicSampler
 import datadog.trace.util.test.DDSpecification
 
-class KnuthSamplerTest extends DDSpecification {
+class DeterministicSamplerTest extends DDSpecification {
 
   def "test known values: #traceId"() {
     given:
-    KnuthSampler sampler = new KnuthSampler(0.5)
+    DeterministicSampler sampler = new DeterministicSampler(0.5)
     DDSpan span = Mock(DDSpan) {
       getTraceId() >> traceId
     }
@@ -125,7 +125,7 @@ class KnuthSamplerTest extends DDSpecification {
 
   def "test sampling none: #traceId"() {
     given:
-    KnuthSampler sampler = new KnuthSampler(0)
+    DeterministicSampler sampler = new DeterministicSampler(0)
     DDSpan span = Mock(DDSpan) {
       getTraceId() >> traceId
     }
@@ -244,7 +244,7 @@ class KnuthSamplerTest extends DDSpecification {
 
   def "test sampling all: #traceId"() {
     given:
-    KnuthSampler sampler = new KnuthSampler(1)
+    DeterministicSampler sampler = new DeterministicSampler(1)
     DDSpan span = Mock(DDSpan) {
       getTraceId() >> traceId
     }


### PR DESCRIPTION
`KnuthSampler` was potentially confusing without any references to the particular algorithm.  This pull request instead uses the generic name `DeterministicSampler` instead.