### PR TITLE
Ordering inconistency with DDSpanBuilder.withTag

### DIFF
--- a/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
@@ -34,6 +34,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -489,7 +490,7 @@ public class DDTracer implements io.opentracing.Tracer, Closeable, datadog.trace
     private final String operationName;
 
     // Builder attributes
-    private final Map<String, Object> tags = new HashMap<String, Object>(defaultSpanTags);
+    private final Map<String, Object> tags = new LinkedHashMap<String, Object>(defaultSpanTags);
     private long timestampMicro;
     private SpanContext parent;
     private String serviceName;


### PR DESCRIPTION
Prior to this change, DDSpanBuilder.withTag behaves different than DDSpan.setTag when decorators are triggered.

Specifically builder.withTag(a, val).withTag(b, val) can behave differently than span.setTag(a, val); span.setTag(b, val)

This change makes a small step towards determinism by changing the HashMap inside DDSpanBuilder into a LinkedHashMap.  That guarantees the tags from withTags translated to the same sequence of setTag calls.

The order of setTag calls is important when there's an interaction between decorators.
For instance, the PeerServiceDecorator and the ServiceNameDecorator.

Some test cases that were previously failing have been added to confirm consistency.

NOTE: Even with this change, there are inconsistencies when tags are removed or set to an empty value.