### PR TITLE
AllowUstoGetContainerInfoOnDocker

### DIFF
--- a/dd-trace-ot/src/main/java/datadog/opentracing/ContainerInfo.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/ContainerInfo.java
@@ -66,12 +66,15 @@ public class ContainerInfo {
   }
 
   public static boolean isRunningInContainer() {
-    return Files.isReadable(CGROUP_DEFAULT_PROCFILE)
-        && CGROUP_DEFAULT_PROCFILE.toFile().length() > 0;
+    return Files.isReadable(CGROUP_DEFAULT_PROCFILE);
   }
 
   public static ContainerInfo fromDefaultProcFile() throws IOException, ParseException {
     final String content = new String(Files.readAllBytes(CGROUP_DEFAULT_PROCFILE));
+    if (content.isEmpty()) {
+      log.error("proc file is empty");
+      throw new IOException();
+    }
     return parse(content);
   }
 

--- a/dd-trace-ot/src/main/java/datadog/opentracing/ContainerInfo.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/ContainerInfo.java
@@ -72,8 +72,8 @@ public class ContainerInfo {
   public static ContainerInfo fromDefaultProcFile() throws IOException, ParseException {
     final String content = new String(Files.readAllBytes(CGROUP_DEFAULT_PROCFILE));
     if (content.isEmpty()) {
-      log.error("proc file is empty");
-      throw new IOException();
+      log.debug("Proc file is empty");
+      return new ContainerInfo();
     }
     return parse(content);
   }


### PR DESCRIPTION
Tested on docker. Although "/proc/self/cgroup" file is not empty, "/proc/self/cgroup".toFile().length() returns 0
as does Files.size("/proc/self/cgroup") so we should check that the content is not empty after reading it.