### PR TITLE
Capture full servlet URL in decorator

### DIFF
--- a/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/Servlet2Decorator.java
+++ b/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/Servlet2Decorator.java
@@ -28,7 +28,14 @@ public class Servlet2Decorator
 
   @Override
   protected URI url(final HttpServletRequest httpServletRequest) throws URISyntaxException {
-    return new URI(httpServletRequest.getRequestURL().toString());
+    return new URI(
+        httpServletRequest.getScheme(),
+        null,
+        httpServletRequest.getServerName(),
+        httpServletRequest.getServerPort(),
+        httpServletRequest.getRequestURI(),
+        httpServletRequest.getQueryString(),
+        null);
   }
 
   @Override

--- a/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Decorator.java
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Decorator.java
@@ -29,7 +29,14 @@ public class Servlet3Decorator
 
   @Override
   protected URI url(final HttpServletRequest httpServletRequest) throws URISyntaxException {
-    return new URI(httpServletRequest.getRequestURL().toString());
+    return new URI(
+        httpServletRequest.getScheme(),
+        null,
+        httpServletRequest.getServerName(),
+        httpServletRequest.getServerPort(),
+        httpServletRequest.getRequestURI(),
+        httpServletRequest.getQueryString(),
+        null);
   }
 
   @Override


### PR DESCRIPTION
This is needed in order to tag the query string (when configured).

Full test suite will follow in future PR.