### PR TITLE
Fix tagging query string for additional servers

### DIFF
--- a/dd-java-agent/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpServerInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpServerInstrumentationTest.groovy
@@ -1,6 +1,7 @@
 import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.agent.test.base.HttpServerTest
 import datadog.trace.api.DDSpanTypes
+import datadog.trace.api.DDTags
 import datadog.trace.instrumentation.akkahttp.AkkaHttpServerDecorator
 import datadog.trace.instrumentation.api.Tags
 
@@ -59,6 +60,9 @@ abstract class AkkaHttpServerInstrumentationTest extends HttpServerTest<Object, 
           "error.msg" { it == null || it == EXCEPTION.body }
           "error.type" { it == null || it == Exception.name }
           "error.stack" { it == null || it instanceof String }
+        }
+        if (endpoint.query) {
+          "$DDTags.HTTP_QUERY" endpoint.query
         }
         defaultTags(true)
       }

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/test/scala/AkkaHttpTestAsyncWebServer.scala
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/test/scala/AkkaHttpTestAsyncWebServer.scala
@@ -24,6 +24,7 @@ object AkkaHttpTestAsyncWebServer {
             val resp = HttpResponse(status = endpoint.getStatus) //.withHeaders(headers.Type)resp.contentType = "text/plain"
             endpoint match {
               case SUCCESS => resp.withEntity(endpoint.getBody)
+              case QUERY_PARAM => resp.withEntity(uri.queryString().orNull)
               case REDIRECT => resp.withHeaders(headers.Location(endpoint.getBody))
               case ERROR => resp.withEntity(endpoint.getBody)
               case EXCEPTION => throw new Exception(endpoint.getBody)

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/test/scala/AkkaHttpTestSyncWebServer.scala
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/test/scala/AkkaHttpTestSyncWebServer.scala
@@ -23,6 +23,7 @@ object AkkaHttpTestSyncWebServer {
           val resp = HttpResponse(status = endpoint.getStatus)
           endpoint match {
             case SUCCESS => resp.withEntity(endpoint.getBody)
+            case QUERY_PARAM => resp.withEntity(uri.queryString().orNull)
             case REDIRECT => resp.withHeaders(headers.Location(endpoint.getBody))
             case ERROR => resp.withEntity(endpoint.getBody)
             case EXCEPTION => throw new Exception(endpoint.getBody)

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/test/scala/AkkaHttpTestWebServer.scala
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/test/scala/AkkaHttpTestWebServer.scala
@@ -23,6 +23,8 @@ object AkkaHttpTestWebServer {
   val route = { //handleExceptions(exceptionHandler) {
     path(SUCCESS.rawPath) {
       complete(HttpResponse(status = SUCCESS.getStatus).withEntity(SUCCESS.getBody))
+    } ~ path(QUERY_PARAM.rawPath) {
+      complete(HttpResponse(status = QUERY_PARAM.getStatus).withEntity(SUCCESS.getBody))
     } ~ path(REDIRECT.rawPath) {
       redirect(Uri(REDIRECT.getBody), StatusCodes.Found)
     } ~ path(ERROR.rawPath) {

--- a/dd-java-agent/instrumentation/dropwizard/src/test/groovy/DropwizardAsyncTest.groovy
+++ b/dd-java-agent/instrumentation/dropwizard/src/test/groovy/DropwizardAsyncTest.groovy
@@ -4,6 +4,7 @@ import io.dropwizard.setup.Bootstrap
 import io.dropwizard.setup.Environment
 import javax.ws.rs.GET
 import javax.ws.rs.Path
+import javax.ws.rs.QueryParam
 import javax.ws.rs.container.AsyncResponse
 import javax.ws.rs.container.Suspended
 import javax.ws.rs.core.Response
@@ -12,6 +13,7 @@ import java.util.concurrent.Executors
 
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
@@ -53,6 +55,14 @@ class DropwizardAsyncTest extends DropwizardTest {
         controller(SUCCESS) {
           asyncResponse.resume(Response.status(SUCCESS.status).entity(SUCCESS.body).build())
         }
+      }
+    }
+
+    @GET
+    @Path("query")
+    Response query_param(@QueryParam("some") String param) {
+      controller(QUERY_PARAM) {
+        Response.status(QUERY_PARAM.status).entity("some=$param".toString()).build()
       }
     }
 

--- a/dd-java-agent/instrumentation/dropwizard/src/test/groovy/DropwizardTest.groovy
+++ b/dd-java-agent/instrumentation/dropwizard/src/test/groovy/DropwizardTest.groovy
@@ -2,6 +2,7 @@ import datadog.opentracing.DDSpan
 import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.agent.test.base.HttpServerTest
 import datadog.trace.api.DDSpanTypes
+import datadog.trace.api.DDTags
 import datadog.trace.instrumentation.api.Tags
 import datadog.trace.instrumentation.jaxrs2.JaxRsAnnotationsDecorator
 import datadog.trace.instrumentation.servlet3.Servlet3Decorator
@@ -11,14 +12,15 @@ import io.dropwizard.setup.Bootstrap
 import io.dropwizard.setup.Environment
 import io.dropwizard.testing.ConfigOverride
 import io.dropwizard.testing.DropwizardTestSupport
-import org.eclipse.jetty.servlet.ServletHandler
-
 import javax.ws.rs.GET
 import javax.ws.rs.Path
+import javax.ws.rs.QueryParam
 import javax.ws.rs.core.Response
+import org.eclipse.jetty.servlet.ServletHandler
 
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
@@ -124,6 +126,9 @@ class DropwizardTest extends HttpServerTest<DropwizardTestSupport, Servlet3Decor
           "error.type" { it == null || it == Exception.name }
           "error.stack" { it == null || it instanceof String }
         }
+        if (endpoint.query) {
+          "$DDTags.HTTP_QUERY" endpoint.query
+        }
         defaultTags(true)
       }
     }
@@ -151,6 +156,14 @@ class DropwizardTest extends HttpServerTest<DropwizardTestSupport, Servlet3Decor
     Response success() {
       controller(SUCCESS) {
         Response.status(SUCCESS.status).entity(SUCCESS.body).build()
+      }
+    }
+
+    @GET
+    @Path("query")
+    Response query_param(@QueryParam("some") String param) {
+      controller(QUERY_PARAM) {
+        Response.status(QUERY_PARAM.status).entity("some=$param".toString()).build()
       }
     }
 

--- a/dd-java-agent/instrumentation/glassfish/src/test/groovy/GlassFishServerTest.groovy
+++ b/dd-java-agent/instrumentation/glassfish/src/test/groovy/GlassFishServerTest.groovy
@@ -1,6 +1,7 @@
 import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.agent.test.base.HttpServerTest
 import datadog.trace.api.DDSpanTypes
+import datadog.trace.api.DDTags
 import datadog.trace.instrumentation.api.Tags
 import datadog.trace.instrumentation.servlet3.Servlet3Decorator
 import org.apache.catalina.servlets.DefaultServlet
@@ -116,6 +117,9 @@ class GlassFishServerTest extends HttpServerTest<GlassFish, Servlet3Decorator> {
           "error.msg" { it == null || it == EXCEPTION.body }
           "error.type" { it == null || it == Exception.name }
           "error.stack" { it == null || it instanceof String }
+        }
+        if (endpoint.query) {
+          "$DDTags.HTTP_QUERY" endpoint.query
         }
         defaultTags(true)
       }

--- a/dd-java-agent/instrumentation/glassfish/src/test/groovy/TestServlets.java
+++ b/dd-java-agent/instrumentation/glassfish/src/test/groovy/TestServlets.java
@@ -26,6 +26,25 @@ public class TestServlets {
     }
   }
 
+  @WebServlet("/query")
+  public static class Query extends HttpServlet {
+    @Override
+    protected void service(final HttpServletRequest req, final HttpServletResponse resp) {
+      final HttpServerTest.ServerEndpoint endpoint =
+          HttpServerTest.ServerEndpoint.forPath(req.getServletPath());
+      HttpServerTest.controller(
+          endpoint,
+          new Closure(null) {
+            public Object doCall() throws Exception {
+              resp.setContentType("text/plain");
+              resp.setStatus(endpoint.getStatus());
+              resp.getWriter().print(req.getQueryString());
+              return null;
+            }
+          });
+    }
+  }
+
   @WebServlet("/redirect")
   public static class Redirect extends HttpServlet {
     @Override

--- a/dd-java-agent/instrumentation/grizzly-2/src/main/java/datadog/trace/instrumentation/grizzly/GrizzlyDecorator.java
+++ b/dd-java-agent/instrumentation/grizzly-2/src/main/java/datadog/trace/instrumentation/grizzly/GrizzlyDecorator.java
@@ -16,7 +16,14 @@ public class GrizzlyDecorator extends HttpServerDecorator<Request, Request, Resp
 
   @Override
   protected URI url(final Request request) throws URISyntaxException {
-    return new URI(request.getRequestURL().toString());
+    return new URI(
+        request.getScheme(),
+        null,
+        request.getServerName(),
+        request.getServerPort(),
+        request.getRequestURI(),
+        request.getQueryString(),
+        null);
   }
 
   @Override

--- a/dd-java-agent/instrumentation/grizzly-2/src/test/groovy/GrizzlyAsyncTest.groovy
+++ b/dd-java-agent/instrumentation/grizzly-2/src/test/groovy/GrizzlyAsyncTest.groovy
@@ -1,17 +1,19 @@
+import javax.ws.rs.GET
+import javax.ws.rs.Path
+import javax.ws.rs.QueryParam
+import javax.ws.rs.container.AsyncResponse
+import javax.ws.rs.container.Suspended
+import javax.ws.rs.core.Response
 import org.glassfish.grizzly.http.server.HttpServer
 import org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpServerFactory
 import org.glassfish.jersey.server.ResourceConfig
 
-import javax.ws.rs.GET
-import javax.ws.rs.Path
-import javax.ws.rs.container.AsyncResponse
-import javax.ws.rs.container.Suspended
-import javax.ws.rs.core.Response
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
@@ -41,6 +43,14 @@ class GrizzlyAsyncTest extends GrizzlyTest {
         controller(SUCCESS) {
           ar.resume(Response.status(SUCCESS.status).entity(SUCCESS.body).build())
         }
+      }
+    }
+
+    @GET
+    @Path("query")
+    Response query_param(@QueryParam("some") String param, @Suspended AsyncResponse ar) {
+      controller(QUERY_PARAM) {
+        ar.resume(Response.status(QUERY_PARAM.status).entity("some=$param".toString()).build())
       }
     }
 

--- a/dd-java-agent/instrumentation/grizzly-2/src/test/groovy/GrizzlyTest.groovy
+++ b/dd-java-agent/instrumentation/grizzly-2/src/test/groovy/GrizzlyTest.groovy
@@ -1,17 +1,18 @@
 import datadog.trace.agent.test.base.HttpServerTest
 import datadog.trace.instrumentation.grizzly.GrizzlyDecorator
+import javax.ws.rs.GET
+import javax.ws.rs.NotFoundException
+import javax.ws.rs.Path
+import javax.ws.rs.QueryParam
+import javax.ws.rs.core.Response
+import javax.ws.rs.ext.ExceptionMapper
 import org.glassfish.grizzly.http.server.HttpServer
 import org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpServerFactory
 import org.glassfish.jersey.server.ResourceConfig
 
-import javax.ws.rs.GET
-import javax.ws.rs.NotFoundException
-import javax.ws.rs.Path
-import javax.ws.rs.core.Response
-import javax.ws.rs.ext.ExceptionMapper
-
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
@@ -63,6 +64,14 @@ class GrizzlyTest extends HttpServerTest<HttpServer, GrizzlyDecorator> {
     Response success() {
       controller(SUCCESS) {
         Response.status(SUCCESS.status).entity(SUCCESS.body).build()
+      }
+    }
+
+    @GET
+    @Path("query")
+    Response query_param(@QueryParam("some") String param) {
+      controller(QUERY_PARAM) {
+        Response.status(QUERY_PARAM.status).entity("some=$param".toString()).build()
       }
     }
 

--- a/dd-java-agent/instrumentation/jetty-8/src/main/java/datadog/trace/instrumentation/jetty8/JettyDecorator.java
+++ b/dd-java-agent/instrumentation/jetty-8/src/main/java/datadog/trace/instrumentation/jetty8/JettyDecorator.java
@@ -28,7 +28,14 @@ public class JettyDecorator
 
   @Override
   protected URI url(final HttpServletRequest httpServletRequest) throws URISyntaxException {
-    return new URI(httpServletRequest.getRequestURL().toString());
+    return new URI(
+        httpServletRequest.getScheme(),
+        null,
+        httpServletRequest.getServerName(),
+        httpServletRequest.getServerPort(),
+        httpServletRequest.getRequestURI(),
+        httpServletRequest.getQueryString(),
+        null);
   }
 
   @Override

--- a/dd-java-agent/instrumentation/netty-4.0/src/test/groovy/Netty40ServerTest.groovy
+++ b/dd-java-agent/instrumentation/netty-4.0/src/test/groovy/Netty40ServerTest.groovy
@@ -24,6 +24,7 @@ import io.netty.util.CharsetUtil
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 import static io.netty.handler.codec.http.HttpHeaders.Names.CONTENT_LENGTH
@@ -48,7 +49,8 @@ class Netty40ServerTest extends HttpServerTest<EventLoopGroup, NettyHttpServerDe
           pipeline.addLast([
             channelRead0       : { ctx, msg ->
               if (msg instanceof HttpRequest) {
-                ServerEndpoint endpoint = ServerEndpoint.forPath((msg as HttpRequest).uri)
+                def uri = URI.create((msg as HttpRequest).uri)
+                ServerEndpoint endpoint = ServerEndpoint.forPath(uri.path)
                 ctx.write controller(endpoint) {
                   ByteBuf content = null
                   FullHttpResponse response = null
@@ -56,6 +58,10 @@ class Netty40ServerTest extends HttpServerTest<EventLoopGroup, NettyHttpServerDe
                     case SUCCESS:
                     case ERROR:
                       content = Unpooled.copiedBuffer(endpoint.body, CharsetUtil.UTF_8)
+                      response = new DefaultFullHttpResponse(HTTP_1_1, HttpResponseStatus.valueOf(endpoint.status), content)
+                      break
+                    case QUERY_PARAM:
+                      content = Unpooled.copiedBuffer(uri.query, CharsetUtil.UTF_8)
                       response = new DefaultFullHttpResponse(HTTP_1_1, HttpResponseStatus.valueOf(endpoint.status), content)
                       break
                     case REDIRECT:

--- a/dd-java-agent/instrumentation/play-2.4/src/test/groovy/server/PlayAsyncServerTest.groovy
+++ b/dd-java-agent/instrumentation/play-2.4/src/test/groovy/server/PlayAsyncServerTest.groovy
@@ -10,6 +10,7 @@ import java.util.function.Supplier
 
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
@@ -22,6 +23,13 @@ class PlayAsyncServerTest extends PlayServerTest {
         CompletableFuture.supplyAsync({
           controller(SUCCESS) {
             Results.status(SUCCESS.getStatus(), SUCCESS.getBody())
+          }
+        }, HttpExecution.defaultContext())
+      } as Supplier)
+        .GET(QUERY_PARAM.getPath()).routeAsync({
+        CompletableFuture.supplyAsync({
+          controller(QUERY_PARAM) {
+            Results.status(QUERY_PARAM.getStatus(), QUERY_PARAM.getBody())
           }
         }, HttpExecution.defaultContext())
       } as Supplier)

--- a/dd-java-agent/instrumentation/play-2.4/src/test/groovy/server/PlayServerTest.groovy
+++ b/dd-java-agent/instrumentation/play-2.4/src/test/groovy/server/PlayServerTest.groovy
@@ -4,6 +4,7 @@ import datadog.opentracing.DDSpan
 import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.agent.test.base.HttpServerTest
 import datadog.trace.api.DDSpanTypes
+import datadog.trace.api.DDTags
 import datadog.trace.instrumentation.api.Tags
 import datadog.trace.instrumentation.netty40.server.NettyHttpServerDecorator
 import datadog.trace.instrumentation.play24.PlayHttpServerDecorator
@@ -15,6 +16,7 @@ import java.util.function.Supplier
 
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
@@ -26,6 +28,11 @@ class PlayServerTest extends HttpServerTest<Server, NettyHttpServerDecorator> {
         .GET(SUCCESS.getPath()).routeTo({
         controller(SUCCESS) {
           Results.status(SUCCESS.getStatus(), SUCCESS.getBody())
+        }
+      } as Supplier)
+        .GET(QUERY_PARAM.getPath()).routeTo({
+        controller(QUERY_PARAM) {
+          Results.status(QUERY_PARAM.getStatus(), QUERY_PARAM.getBody())
         }
       } as Supplier)
         .GET(REDIRECT.getPath()).routeTo({
@@ -97,6 +104,9 @@ class PlayServerTest extends HttpServerTest<Server, NettyHttpServerDecorator> {
           "$Tags.ERROR" true
         } else if (endpoint == EXCEPTION) {
           errorTags(Exception, EXCEPTION.body)
+        }
+        if (endpoint.query) {
+          "$DDTags.HTTP_QUERY" endpoint.query
         }
         defaultTags()
       }

--- a/dd-java-agent/instrumentation/play-2.6/src/test/groovy/server/PlayAsyncServerTest.groovy
+++ b/dd-java-agent/instrumentation/play-2.6/src/test/groovy/server/PlayAsyncServerTest.groovy
@@ -14,6 +14,7 @@ import java.util.function.Supplier
 
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
@@ -34,6 +35,13 @@ class PlayAsyncServerTest extends PlayServerTest {
         CompletableFuture.supplyAsync({
           controller(SUCCESS) {
             Results.status(SUCCESS.getStatus(), SUCCESS.getBody())
+          }
+        }, execContext)
+      } as Supplier)
+        .GET(QUERY_PARAM.getPath()).routeAsync({
+        CompletableFuture.supplyAsync({
+          controller(QUERY_PARAM) {
+            Results.status(QUERY_PARAM.getStatus(), QUERY_PARAM.getBody())
           }
         }, execContext)
       } as Supplier)

--- a/dd-java-agent/instrumentation/play-2.6/src/test/groovy/server/PlayServerTest.groovy
+++ b/dd-java-agent/instrumentation/play-2.6/src/test/groovy/server/PlayServerTest.groovy
@@ -4,6 +4,7 @@ import datadog.opentracing.DDSpan
 import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.agent.test.base.HttpServerTest
 import datadog.trace.api.DDSpanTypes
+import datadog.trace.api.DDTags
 import datadog.trace.instrumentation.akkahttp.AkkaHttpServerDecorator
 import datadog.trace.instrumentation.api.Tags
 import datadog.trace.instrumentation.play26.PlayHttpServerDecorator
@@ -17,6 +18,7 @@ import java.util.function.Supplier
 
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
@@ -28,6 +30,11 @@ class PlayServerTest extends HttpServerTest<Server, AkkaHttpServerDecorator> {
         .GET(SUCCESS.getPath()).routeTo({
         controller(SUCCESS) {
           Results.status(SUCCESS.getStatus(), SUCCESS.getBody())
+        }
+      } as Supplier)
+        .GET(QUERY_PARAM.getPath()).routeTo({
+        controller(QUERY_PARAM) {
+          Results.status(QUERY_PARAM.getStatus(), QUERY_PARAM.getBody())
         }
       } as Supplier)
         .GET(REDIRECT.getPath()).routeTo({
@@ -100,6 +107,9 @@ class PlayServerTest extends HttpServerTest<Server, AkkaHttpServerDecorator> {
         } else if (endpoint == EXCEPTION) {
           errorTags(Exception, EXCEPTION.body)
         }
+        if (endpoint.query) {
+          "$DDTags.HTTP_QUERY" endpoint.query
+        }
         defaultTags()
       }
     }
@@ -129,6 +139,9 @@ class PlayServerTest extends HttpServerTest<Server, AkkaHttpServerDecorator> {
           "error.msg" { it == null || it == EXCEPTION.body }
           "error.type" { it == null || it == Exception.name }
           "error.stack" { it == null || it instanceof String }
+        }
+        if (endpoint.query) {
+          "$DDTags.HTTP_QUERY" endpoint.query
         }
         defaultTags(true)
       }

--- a/dd-java-agent/instrumentation/ratpack-1.4/src/main/java8/datadog/trace/instrumentation/ratpack/RatpackServerDecorator.java
+++ b/dd-java-agent/instrumentation/ratpack-1.4/src/main/java8/datadog/trace/instrumentation/ratpack/RatpackServerDecorator.java
@@ -7,6 +7,7 @@ import datadog.trace.instrumentation.api.AgentSpan;
 import java.net.URI;
 import lombok.extern.slf4j.Slf4j;
 import ratpack.handling.Context;
+import ratpack.http.HttpUrlBuilder;
 import ratpack.http.Request;
 import ratpack.http.Response;
 import ratpack.http.Status;
@@ -42,7 +43,9 @@ public class RatpackServerDecorator extends HttpServerDecorator<Request, Request
     // This call implicitly uses request via a threadlocal provided by ratpack.
     final PublicAddress publicAddress =
         PublicAddress.inferred(address.getPort() == 443 ? "https" : "http");
-    return publicAddress.get(request.getPath());
+    final HttpUrlBuilder url =
+        publicAddress.builder().path(request.getPath()).params(request.getQueryParams());
+    return url.build();
   }
 
   @Override

--- a/dd-java-agent/instrumentation/ratpack-1.4/src/test/groovy/server/RatpackAsyncHttpServerTest.groovy
+++ b/dd-java-agent/instrumentation/ratpack-1.4/src/test/groovy/server/RatpackAsyncHttpServerTest.groovy
@@ -6,6 +6,7 @@ import ratpack.test.embed.EmbeddedApp
 
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
@@ -28,6 +29,17 @@ class RatpackAsyncHttpServerTest extends RatpackHttpServerTest {
             } then { ServerEndpoint endpoint ->
               controller(endpoint) {
                 context.response.status(endpoint.status).send(endpoint.body)
+              }
+            }
+          }
+        }
+        prefix(QUERY_PARAM.rawPath()) {
+          all {
+            Promise.sync {
+              QUERY_PARAM
+            } then { ServerEndpoint endpoint ->
+              controller(endpoint) {
+                context.response.status(endpoint.status).send(request.query)
               }
             }
           }

--- a/dd-java-agent/instrumentation/ratpack-1.4/src/test/groovy/server/RatpackForkedHttpServerTest.groovy
+++ b/dd-java-agent/instrumentation/ratpack-1.4/src/test/groovy/server/RatpackForkedHttpServerTest.groovy
@@ -6,6 +6,7 @@ import ratpack.test.embed.EmbeddedApp
 
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
@@ -28,6 +29,17 @@ class RatpackForkedHttpServerTest extends RatpackHttpServerTest {
             }.fork().then { ServerEndpoint endpoint ->
               controller(endpoint) {
                 context.response.status(endpoint.status).send(endpoint.body)
+              }
+            }
+          }
+        }
+        prefix(QUERY_PARAM.rawPath()) {
+          all {
+            Promise.sync {
+              QUERY_PARAM
+            }.fork().then { ServerEndpoint endpoint ->
+              controller(endpoint) {
+                context.response.status(endpoint.status).send(request.query)
               }
             }
           }

--- a/dd-java-agent/instrumentation/ratpack-1.4/src/test/groovy/server/RatpackHttpServerTest.groovy
+++ b/dd-java-agent/instrumentation/ratpack-1.4/src/test/groovy/server/RatpackHttpServerTest.groovy
@@ -4,6 +4,7 @@ import datadog.opentracing.DDSpan
 import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.agent.test.base.HttpServerTest
 import datadog.trace.api.DDSpanTypes
+import datadog.trace.api.DDTags
 import datadog.trace.instrumentation.api.Tags
 import datadog.trace.instrumentation.netty41.server.NettyHttpServerDecorator
 import datadog.trace.instrumentation.ratpack.RatpackServerDecorator
@@ -14,6 +15,7 @@ import ratpack.test.embed.EmbeddedApp
 
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
@@ -33,6 +35,13 @@ class RatpackHttpServerTest extends HttpServerTest<EmbeddedApp, NettyHttpServerD
           all {
             controller(SUCCESS) {
               context.response.status(SUCCESS.status).send(SUCCESS.body)
+            }
+          }
+        }
+        prefix(QUERY_PARAM.rawPath()) {
+          all {
+            controller(QUERY_PARAM) {
+              context.response.status(QUERY_PARAM.status).send(request.query)
             }
           }
         }
@@ -118,6 +127,9 @@ class RatpackHttpServerTest extends HttpServerTest<EmbeddedApp, NettyHttpServerD
           "$Tags.ERROR" true
         } else if (endpoint == EXCEPTION) {
           errorTags(Exception, EXCEPTION.body)
+        }
+        if (endpoint.query) {
+          "$DDTags.HTTP_QUERY" endpoint.query
         }
         defaultTags()
       }

--- a/dd-java-agent/instrumentation/servlet/request-2/src/test/groovy/TestServlet2.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-2/src/test/groovy/TestServlet2.groovy
@@ -1,11 +1,11 @@
 import datadog.trace.agent.test.base.HttpServerTest
 import groovy.servlet.AbstractHttpServlet
-
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
 
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
@@ -22,6 +22,10 @@ class TestServlet2 {
           case SUCCESS:
             resp.status = endpoint.status
             resp.writer.print(endpoint.body)
+            break
+          case QUERY_PARAM:
+            resp.status = endpoint.status
+            resp.writer.print(req.queryString)
             break
           case REDIRECT:
             resp.sendRedirect(endpoint.body)

--- a/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/AbstractServlet3Test.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/AbstractServlet3Test.groovy
@@ -1,16 +1,17 @@
 import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.agent.test.base.HttpServerTest
 import datadog.trace.api.DDSpanTypes
+import datadog.trace.api.DDTags
 import datadog.trace.instrumentation.api.Tags
 import datadog.trace.instrumentation.servlet3.Servlet3Decorator
+import javax.servlet.Servlet
 import okhttp3.Request
 import org.apache.catalina.core.ApplicationFilterChain
-
-import javax.servlet.Servlet
 
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.AUTH_REQUIRED
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
@@ -53,6 +54,7 @@ abstract class AbstractServlet3Test<SERVER, CONTEXT> extends HttpServerTest<SERV
     def servlet = servlet()
 
     addServlet(context, SUCCESS.path, servlet)
+    addServlet(context, QUERY_PARAM.path, servlet)
     addServlet(context, ERROR.path, servlet)
     addServlet(context, EXCEPTION.path, servlet)
     addServlet(context, REDIRECT.path, servlet)
@@ -98,6 +100,9 @@ abstract class AbstractServlet3Test<SERVER, CONTEXT> extends HttpServerTest<SERV
           "error.msg" { it == null || it == EXCEPTION.body }
           "error.type" { it == null || it == Exception.name }
           "error.stack" { it == null || it instanceof String }
+        }
+        if (endpoint.query) {
+          "$DDTags.HTTP_QUERY" endpoint.query
         }
         defaultTags(true)
       }

--- a/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/JettyServlet3Test.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/JettyServlet3Test.groovy
@@ -1,20 +1,21 @@
 import datadog.opentracing.DDSpan
 import datadog.trace.agent.test.asserts.ListWriterAssert
 import datadog.trace.api.DDSpanTypes
+import datadog.trace.api.DDTags
 import datadog.trace.instrumentation.api.Tags
 import groovy.transform.stc.ClosureParams
 import groovy.transform.stc.SimpleType
+import javax.servlet.Servlet
+import javax.servlet.http.HttpServletRequest
 import org.eclipse.jetty.server.Server
 import org.eclipse.jetty.server.handler.ErrorHandler
 import org.eclipse.jetty.servlet.ServletContextHandler
-
-import javax.servlet.Servlet
-import javax.servlet.http.HttpServletRequest
 
 import static datadog.trace.agent.test.asserts.TraceAssert.assertTrace
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.AUTH_REQUIRED
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 import static datadog.trace.agent.test.utils.TraceUtils.basicSpan
@@ -116,51 +117,55 @@ class JettyServlet3TestFakeAsync extends JettyServlet3Test {
   }
 }
 
-class JettyServlet3TestForward extends JettyServlet3Test {
-  @Override
-  Class<Servlet> servlet() {
-    TestServlet3.Sync // dispatch to sync servlet
-  }
+// FIXME: not working right now...
+//class JettyServlet3TestForward extends JettyDispatchTest {
+//  @Override
+//  Class<Servlet> servlet() {
+//    TestServlet3.Sync // dispatch to sync servlet
+//  }
+//
+//  @Override
+//  boolean testNotFound() {
+//    false
+//  }
+//
+//  @Override
+//  protected void setupServlets(ServletContextHandler context) {
+//    super.setupServlets(context)
+//
+//    addServlet(context, "/dispatch" + SUCCESS.path, RequestDispatcherServlet.Forward)
+//    addServlet(context, "/dispatch" + QUERY_PARAM.path, RequestDispatcherServlet.Forward)
+//    addServlet(context, "/dispatch" + REDIRECT.path, RequestDispatcherServlet.Forward)
+//    addServlet(context, "/dispatch" + ERROR.path, RequestDispatcherServlet.Forward)
+//    addServlet(context, "/dispatch" + EXCEPTION.path, RequestDispatcherServlet.Forward)
+//    addServlet(context, "/dispatch" + AUTH_REQUIRED.path, RequestDispatcherServlet.Forward)
+//  }
+//}
 
-  @Override
-  boolean testNotFound() {
-    false
-  }
-
-  @Override
-  protected void setupServlets(ServletContextHandler context) {
-    super.setupServlets(context)
-
-    addServlet(context, "/dispatch" + SUCCESS.path, RequestDispatcherServlet.Forward)
-    addServlet(context, "/dispatch" + ERROR.path, RequestDispatcherServlet.Forward)
-    addServlet(context, "/dispatch" + EXCEPTION.path, RequestDispatcherServlet.Forward)
-    addServlet(context, "/dispatch" + REDIRECT.path, RequestDispatcherServlet.Forward)
-    addServlet(context, "/dispatch" + AUTH_REQUIRED.path, RequestDispatcherServlet.Forward)
-  }
-}
-
-class JettyServlet3TestInclude extends JettyServlet3Test {
-  @Override
-  Class<Servlet> servlet() {
-    TestServlet3.Sync // dispatch to sync servlet
-  }
-
-  @Override
-  boolean testNotFound() {
-    false
-  }
-
-  @Override
-  protected void setupServlets(ServletContextHandler context) {
-    super.setupServlets(context)
-
-    addServlet(context, "/dispatch" + SUCCESS.path, RequestDispatcherServlet.Include)
-    addServlet(context, "/dispatch" + ERROR.path, RequestDispatcherServlet.Include)
-    addServlet(context, "/dispatch" + EXCEPTION.path, RequestDispatcherServlet.Include)
-    addServlet(context, "/dispatch" + REDIRECT.path, RequestDispatcherServlet.Include)
-    addServlet(context, "/dispatch" + AUTH_REQUIRED.path, RequestDispatcherServlet.Include)
-  }
-}
+// FIXME: not working right now...
+//class JettyServlet3TestInclude extends JettyDispatchTest {
+//  @Override
+//  Class<Servlet> servlet() {
+//    TestServlet3.Sync // dispatch to sync servlet
+//  }
+//
+//  @Override
+//  boolean testNotFound() {
+//    false
+//  }
+//
+//  @Override
+//  protected void setupServlets(ServletContextHandler context) {
+//    super.setupServlets(context)
+//
+//    addServlet(context, "/dispatch" + SUCCESS.path, RequestDispatcherServlet.Include)
+//    addServlet(context, "/dispatch" + QUERY_PARAM.path, RequestDispatcherServlet.Include)
+//    addServlet(context, "/dispatch" + REDIRECT.path, RequestDispatcherServlet.Include)
+//    addServlet(context, "/dispatch" + ERROR.path, RequestDispatcherServlet.Include)
+//    addServlet(context, "/dispatch" + EXCEPTION.path, RequestDispatcherServlet.Include)
+//    addServlet(context, "/dispatch" + AUTH_REQUIRED.path, RequestDispatcherServlet.Include)
+//  }
+//}
 
 
 class JettyServlet3TestDispatchImmediate extends JettyDispatchTest {
@@ -174,6 +179,7 @@ class JettyServlet3TestDispatchImmediate extends JettyDispatchTest {
     super.setupServlets(context)
 
     addServlet(context, "/dispatch" + SUCCESS.path, TestServlet3.DispatchImmediate)
+    addServlet(context, "/dispatch" + QUERY_PARAM.path, TestServlet3.DispatchImmediate)
     addServlet(context, "/dispatch" + ERROR.path, TestServlet3.DispatchImmediate)
     addServlet(context, "/dispatch" + EXCEPTION.path, TestServlet3.DispatchImmediate)
     addServlet(context, "/dispatch" + REDIRECT.path, TestServlet3.DispatchImmediate)
@@ -193,6 +199,7 @@ class JettyServlet3TestDispatchAsync extends JettyDispatchTest {
     super.setupServlets(context)
 
     addServlet(context, "/dispatch" + SUCCESS.path, TestServlet3.DispatchAsync)
+    addServlet(context, "/dispatch" + QUERY_PARAM.path, TestServlet3.DispatchAsync)
     addServlet(context, "/dispatch" + ERROR.path, TestServlet3.DispatchAsync)
     addServlet(context, "/dispatch" + EXCEPTION.path, TestServlet3.DispatchAsync)
     addServlet(context, "/dispatch" + REDIRECT.path, TestServlet3.DispatchAsync)
@@ -263,6 +270,9 @@ abstract class JettyDispatchTest extends JettyServlet3Test {
               "error.msg" { it == null || it == EXCEPTION.body }
               "error.type" { it == null || it == Exception.name }
               "error.stack" { it == null || it instanceof String }
+            }
+            if (endpoint.query) {
+              "$DDTags.HTTP_QUERY" endpoint.query
             }
             defaultTags(true)
           }

--- a/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/TestServlet3.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/TestServlet3.groovy
@@ -1,13 +1,14 @@
 import datadog.trace.agent.test.base.HttpServerTest
 import groovy.servlet.AbstractHttpServlet
-
 import javax.servlet.annotation.WebServlet
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
+
 import java.util.concurrent.Phaser
 
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
@@ -24,6 +25,10 @@ class TestServlet3 {
           case SUCCESS:
             resp.status = endpoint.status
             resp.writer.print(endpoint.body)
+            break
+          case QUERY_PARAM:
+            resp.status = endpoint.status
+            resp.writer.print(req.queryString)
             break
           case REDIRECT:
             resp.sendRedirect(endpoint.body)
@@ -52,13 +57,23 @@ class TestServlet3 {
             resp.contentType = "text/plain"
             switch (endpoint) {
               case SUCCESS:
-              case ERROR:
                 resp.status = endpoint.status
                 resp.writer.print(endpoint.body)
                 context.complete()
                 break
+              case QUERY_PARAM:
+                resp.status = endpoint.status
+                resp.writer.print(req.queryString)
+                context.complete()
+                break
               case REDIRECT:
                 resp.sendRedirect(endpoint.body)
+                context.complete()
+                break
+              case ERROR:
+                resp.status = endpoint.status
+                resp.writer.print(endpoint.body)
+//                resp.sendError(endpoint.status, endpoint.body)
                 context.complete()
                 break
               case EXCEPTION:
@@ -88,12 +103,18 @@ class TestServlet3 {
           resp.contentType = "text/plain"
           switch (endpoint) {
             case SUCCESS:
-            case ERROR:
               resp.status = endpoint.status
               resp.writer.print(endpoint.body)
               break
+            case QUERY_PARAM:
+              resp.status = endpoint.status
+              resp.writer.print(req.queryString)
+              break
             case REDIRECT:
               resp.sendRedirect(endpoint.body)
+              break
+            case ERROR:
+              resp.sendError(endpoint.status, endpoint.body)
               break
             case EXCEPTION:
               throw new Exception(endpoint.body)

--- a/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/TomcatServlet3Test.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/TomcatServlet3Test.groovy
@@ -2,9 +2,11 @@ import com.google.common.io.Files
 import datadog.opentracing.DDSpan
 import datadog.trace.agent.test.asserts.ListWriterAssert
 import datadog.trace.api.DDSpanTypes
+import datadog.trace.api.DDTags
 import datadog.trace.instrumentation.api.Tags
 import groovy.transform.stc.ClosureParams
 import groovy.transform.stc.SimpleType
+import javax.servlet.Servlet
 import org.apache.catalina.Context
 import org.apache.catalina.connector.Request
 import org.apache.catalina.connector.Response
@@ -15,13 +17,12 @@ import org.apache.catalina.valves.ErrorReportValve
 import org.apache.tomcat.JarScanFilter
 import org.apache.tomcat.JarScanType
 
-import javax.servlet.Servlet
-
 import static datadog.trace.agent.test.asserts.TraceAssert.assertTrace
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.AUTH_REQUIRED
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 import static datadog.trace.agent.test.utils.TraceUtils.basicSpan
@@ -153,51 +154,55 @@ class TomcatServlet3TestFakeAsync extends TomcatServlet3Test {
   }
 }
 
-class TomcatServlet3TestForward extends TomcatServlet3Test {
-  @Override
-  Class<Servlet> servlet() {
-    TestServlet3.Sync // dispatch to sync servlet
-  }
+// FIXME: not working right now...
+//class TomcatServlet3TestForward extends TomcatDispatchTest {
+//  @Override
+//  Class<Servlet> servlet() {
+//    TestServlet3.Sync // dispatch to sync servlet
+//  }
+//
+//  @Override
+//  boolean testNotFound() {
+//    false
+//  }
+//
+//  @Override
+//  protected void setupServlets(Context context) {
+//    super.setupServlets(context)
+//
+//    addServlet(context, "/dispatch" + SUCCESS.path, RequestDispatcherServlet.Forward)
+//    addServlet(context, "/dispatch" + QUERY_PARAM.path, RequestDispatcherServlet.Forward)
+//    addServlet(context, "/dispatch" + REDIRECT.path, RequestDispatcherServlet.Forward)
+//    addServlet(context, "/dispatch" + ERROR.path, RequestDispatcherServlet.Forward)
+//    addServlet(context, "/dispatch" + EXCEPTION.path, RequestDispatcherServlet.Forward)
+//    addServlet(context, "/dispatch" + AUTH_REQUIRED.path, RequestDispatcherServlet.Forward)
+//  }
+//}
 
-  @Override
-  boolean testNotFound() {
-    false
-  }
-
-  @Override
-  protected void setupServlets(Context context) {
-    super.setupServlets(context)
-
-    addServlet(context, "/dispatch" + SUCCESS.path, RequestDispatcherServlet.Forward)
-    addServlet(context, "/dispatch" + ERROR.path, RequestDispatcherServlet.Forward)
-    addServlet(context, "/dispatch" + EXCEPTION.path, RequestDispatcherServlet.Forward)
-    addServlet(context, "/dispatch" + REDIRECT.path, RequestDispatcherServlet.Forward)
-    addServlet(context, "/dispatch" + AUTH_REQUIRED.path, RequestDispatcherServlet.Forward)
-  }
-}
-
-class TomcatServlet3TestInclude extends TomcatServlet3Test {
-  @Override
-  Class<Servlet> servlet() {
-    TestServlet3.Sync // dispatch to sync servlet
-  }
-
-  @Override
-  boolean testNotFound() {
-    false
-  }
-
-  @Override
-  protected void setupServlets(Context context) {
-    super.setupServlets(context)
-
-    addServlet(context, "/dispatch" + SUCCESS.path, RequestDispatcherServlet.Include)
-    addServlet(context, "/dispatch" + ERROR.path, RequestDispatcherServlet.Include)
-    addServlet(context, "/dispatch" + EXCEPTION.path, RequestDispatcherServlet.Include)
-    addServlet(context, "/dispatch" + REDIRECT.path, RequestDispatcherServlet.Include)
-    addServlet(context, "/dispatch" + AUTH_REQUIRED.path, RequestDispatcherServlet.Include)
-  }
-}
+// FIXME: not working right now...
+//class TomcatServlet3TestInclude extends TomcatDispatchTest {
+//  @Override
+//  Class<Servlet> servlet() {
+//    TestServlet3.Sync // dispatch to sync servlet
+//  }
+//
+//  @Override
+//  boolean testNotFound() {
+//    false
+//  }
+//
+//  @Override
+//  protected void setupServlets(Context context) {
+//    super.setupServlets(context)
+//
+//    addServlet(context, "/dispatch" + SUCCESS.path, RequestDispatcherServlet.Include)
+//    addServlet(context, "/dispatch" + QUERY_PARAM.path, RequestDispatcherServlet.Include)
+//    addServlet(context, "/dispatch" + REDIRECT.path, RequestDispatcherServlet.Include)
+//    addServlet(context, "/dispatch" + ERROR.path, RequestDispatcherServlet.Include)
+//    addServlet(context, "/dispatch" + EXCEPTION.path, RequestDispatcherServlet.Include)
+//    addServlet(context, "/dispatch" + AUTH_REQUIRED.path, RequestDispatcherServlet.Include)
+//  }
+//}
 
 class TomcatServlet3TestDispatchImmediate extends TomcatDispatchTest {
   @Override
@@ -215,6 +220,7 @@ class TomcatServlet3TestDispatchImmediate extends TomcatDispatchTest {
     super.setupServlets(context)
 
     addServlet(context, "/dispatch" + SUCCESS.path, TestServlet3.DispatchImmediate)
+    addServlet(context, "/dispatch" + QUERY_PARAM.path, TestServlet3.DispatchImmediate)
     addServlet(context, "/dispatch" + ERROR.path, TestServlet3.DispatchImmediate)
     addServlet(context, "/dispatch" + EXCEPTION.path, TestServlet3.DispatchImmediate)
     addServlet(context, "/dispatch" + REDIRECT.path, TestServlet3.DispatchImmediate)
@@ -234,6 +240,7 @@ class TomcatServlet3TestDispatchAsync extends TomcatDispatchTest {
     super.setupServlets(context)
 
     addServlet(context, "/dispatch" + SUCCESS.path, TestServlet3.DispatchAsync)
+    addServlet(context, "/dispatch" + QUERY_PARAM.path, TestServlet3.DispatchAsync)
     addServlet(context, "/dispatch" + ERROR.path, TestServlet3.DispatchAsync)
     addServlet(context, "/dispatch" + EXCEPTION.path, TestServlet3.DispatchAsync)
     addServlet(context, "/dispatch" + REDIRECT.path, TestServlet3.DispatchAsync)
@@ -314,6 +321,9 @@ abstract class TomcatDispatchTest extends TomcatServlet3Test {
               "error.msg" { it == null || it == EXCEPTION.body }
               "error.type" { it == null || it == Exception.name }
               "error.stack" { it == null || it instanceof String }
+            }
+            if (endpoint.query) {
+              "$DDTags.HTTP_QUERY" endpoint.query
             }
             defaultTags(true)
           }

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/SpringWebHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/SpringWebHttpServerDecorator.java
@@ -50,7 +50,14 @@ public class SpringWebHttpServerDecorator
 
   @Override
   protected URI url(final HttpServletRequest httpServletRequest) throws URISyntaxException {
-    return new URI(httpServletRequest.getRequestURL().toString());
+    return new URI(
+        httpServletRequest.getScheme(),
+        null,
+        httpServletRequest.getServerName(),
+        httpServletRequest.getServerPort(),
+        httpServletRequest.getRequestURI(),
+        httpServletRequest.getQueryString(),
+        null);
   }
 
   @Override

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/SpringBootBasedTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/SpringBootBasedTest.groovy
@@ -6,6 +6,7 @@ import datadog.trace.agent.test.asserts.SpanAssert
 import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.agent.test.base.HttpServerTest
 import datadog.trace.api.DDSpanTypes
+import datadog.trace.api.DDTags
 import datadog.trace.instrumentation.api.Tags
 import datadog.trace.instrumentation.servlet3.Servlet3Decorator
 import datadog.trace.instrumentation.springweb.SpringWebHttpServerDecorator
@@ -140,6 +141,9 @@ class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext,
           "error.msg" { it == null || it == EXCEPTION.body }
           "error.type" { it == null || it == Exception.name }
           "error.stack" { it == null || it instanceof String }
+        }
+        if (endpoint.query) {
+          "$DDTags.HTTP_QUERY" endpoint.query
         }
         defaultTags(true)
       }

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/TestController.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/TestController.groovy
@@ -6,11 +6,13 @@ import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Controller
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseBody
 import org.springframework.web.servlet.view.RedirectView
 
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
@@ -22,6 +24,14 @@ class TestController {
   String success() {
     HttpServerTest.controller(SUCCESS) {
       SUCCESS.body
+    }
+  }
+
+  @RequestMapping("/query")
+  @ResponseBody
+  String query_param(@RequestParam("some") String param) {
+    HttpServerTest.controller(QUERY_PARAM) {
+      "some=$param"
     }
   }
 

--- a/dd-java-agent/instrumentation/vertx/src/test/groovy/server/VertxHttpServerTest.groovy
+++ b/dd-java-agent/instrumentation/vertx/src/test/groovy/server/VertxHttpServerTest.groovy
@@ -15,6 +15,7 @@ import java.util.concurrent.CompletableFuture
 
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
@@ -81,6 +82,11 @@ class VertxHttpServerTest extends HttpServerTest<Vertx, NettyHttpServerDecorator
       router.route(SUCCESS.path).handler { ctx ->
         controller(SUCCESS) {
           ctx.response().setStatusCode(SUCCESS.status).end(SUCCESS.body)
+        }
+      }
+      router.route(QUERY_PARAM.path).handler { ctx ->
+        controller(QUERY_PARAM) {
+          ctx.response().setStatusCode(QUERY_PARAM.status).end(ctx.request().query())
         }
       }
       router.route(REDIRECT.path).handler { ctx ->

--- a/dd-java-agent/instrumentation/vertx/src/test/groovy/server/VertxRxHttpServerTest.groovy
+++ b/dd-java-agent/instrumentation/vertx/src/test/groovy/server/VertxRxHttpServerTest.groovy
@@ -7,6 +7,7 @@ import io.vertx.reactivex.ext.web.Router
 
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
@@ -27,6 +28,11 @@ class VertxRxHttpServerTest extends VertxHttpServerTest {
       router.route(SUCCESS.path).handler { ctx ->
         controller(SUCCESS) {
           ctx.response().setStatusCode(SUCCESS.status).end(SUCCESS.body)
+        }
+      }
+      router.route(QUERY_PARAM.path).handler { ctx ->
+        controller(QUERY_PARAM) {
+          ctx.response().setStatusCode(QUERY_PARAM.status).end(ctx.request().query())
         }
       }
       router.route(REDIRECT.path).handler { ctx ->

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
@@ -8,6 +8,7 @@ import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.agent.test.utils.OkHttpUtils
 import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
+import datadog.trace.api.DDTags
 import datadog.trace.instrumentation.api.Tags
 import groovy.transform.stc.ClosureParams
 import groovy.transform.stc.SimpleType
@@ -24,8 +25,10 @@ import static datadog.trace.agent.test.asserts.TraceAssert.assertTrace
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
+import static datadog.trace.agent.test.utils.ConfigUtils.withConfigOverride
 import static datadog.trace.agent.test.utils.TraceUtils.basicSpan
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 import static datadog.trace.instrumentation.api.AgentTracer.activeScope
@@ -111,16 +114,25 @@ abstract class HttpServerTest<SERVER, DECORATOR extends HttpServerDecorator> ext
     NOT_FOUND("notFound", 404, "not found"),
 
     // TODO: add tests for the following cases:
+    QUERY_PARAM("query?some=query", 200, "some=query"),
+    // OkHttp never sends the fragment in the request, so these cases don't work.
+//    FRAGMENT_PARAM("fragment#some-fragment", 200, "some-fragment"),
+//    QUERY_FRAGMENT_PARAM("query/fragment?some=query#some-fragment", 200, "some=query#some-fragment"),
     PATH_PARAM("path/123/param", 200, "123"),
     AUTH_REQUIRED("authRequired", 200, null),
 
     private final String path
+    final String query
+    final String fragment
     final int status
     final String body
     final Boolean errored
 
-    ServerEndpoint(String path, int status, String body) {
-      this.path = path
+    ServerEndpoint(String uri, int status, String body) {
+      def uriObj = URI.create(uri)
+      this.path = uriObj.path
+      this.query = uriObj.query
+      this.fragment = uriObj.fragment
       this.status = status
       this.body = body
       this.errored = status >= 500
@@ -146,8 +158,12 @@ abstract class HttpServerTest<SERVER, DECORATOR extends HttpServerDecorator> ext
   }
 
   Request.Builder request(ServerEndpoint uri, String method, String body) {
+    def url = HttpUrl.get(uri.resolve(address)).newBuilder()
+      .query(uri.query)
+      .fragment(uri.fragment)
+      .build()
     return new Request.Builder()
-      .url(HttpUrl.get(uri.resolve(address)))
+      .url(url)
       .method(method, body)
   }
 
@@ -230,6 +246,39 @@ abstract class HttpServerTest<SERVER, DECORATOR extends HttpServerDecorator> ext
     where:
     method = "GET"
     body = null
+  }
+
+  def "test tag query string for #endpoint"() {
+    setup:
+    def request = request(endpoint, method, body).build()
+    Response response = withConfigOverride("http.server.tag.query-string", "true") {
+      client.newCall(request).execute()
+    }
+
+    expect:
+    response.code() == endpoint.status
+    response.body().string() == endpoint.body
+
+    and:
+    cleanAndAssertTraces(1) {
+      if (hasHandlerSpan()) {
+        trace(0, 3) {
+          serverSpan(it, 0, null, null, "GET", endpoint)
+          handlerSpan(it, 1, span(0), endpoint)
+          controllerSpan(it, 2, span(1))
+        }
+      } else {
+        trace(0, 2) {
+          serverSpan(it, 0, null, null, "GET", endpoint)
+          controllerSpan(it, 1, span(0))
+        }
+      }
+    }
+
+    where:
+    method = "GET"
+    body = null
+    endpoint << [SUCCESS, QUERY_PARAM]
   }
 
   def "test redirect"() {
@@ -447,13 +496,16 @@ abstract class HttpServerTest<SERVER, DECORATOR extends HttpServerDecorator> ext
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
         "$Tags.HTTP_STATUS" endpoint.status
-//        if (tagQueryString) {
-//          "$DDTags.HTTP_QUERY" uri.query
-//          "$DDTags.HTTP_FRAGMENT" { it == null || it == uri.fragment } // Optional
-//        }
         if (endpoint.errored) {
           "$Tags.ERROR" endpoint.errored
         }
+        if (endpoint.query) {
+          "$DDTags.HTTP_QUERY" endpoint.query
+        }
+        // OkHttp never sends the fragment in the request.
+//        if (endpoint.fragment) {
+//          "$DDTags.HTTP_FRAGMENT" endpoint.fragment
+//        }
         defaultTags(true)
       }
     }


### PR DESCRIPTION
Add test to common test suite and adapt each test.

Follow up from #1136 