### PR TITLE
Pin kafka latestDepTest version to 2.3.x

### DIFF
--- a/dd-java-agent/instrumentation/kafka-clients-0.11/kafka-clients-0.11.gradle
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/kafka-clients-0.11.gradle
@@ -29,8 +29,10 @@ dependencies {
 
   // Include latest version of kafka itself along with latest version of client libs.
   // This seems to help with jar compatibility hell.
-  latestDepTestCompile group: 'org.apache.kafka', name: 'kafka_2.11', version: '+'
-  latestDepTestCompile group: 'org.apache.kafka', name: 'kafka-clients', version: '+'
+  latestDepTestCompile group: 'org.apache.kafka', name: 'kafka_2.11', version: '2.3.+'
+  // (Pinning to 2.3.x: 2.4.0 introduces an error when executing compileLatestDepTestGroovy)
+  //  Caused by: java.lang.NoClassDefFoundError: org.I0Itec.zkclient.ZkClient
+  latestDepTestCompile group: 'org.apache.kafka', name: 'kafka-clients', version: '2.3.+'
   latestDepTestCompile group: 'org.springframework.kafka', name: 'spring-kafka', version: '2.2.+'
   latestDepTestCompile group: 'org.springframework.kafka', name: 'spring-kafka-test', version: '2.2.+'
   latestDepTestCompile group: 'org.assertj', name: 'assertj-core', version: '3.+'

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/kafka-streams-0.11.gradle
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/kafka-streams-0.11.gradle
@@ -33,9 +33,11 @@ dependencies {
 
   // Include latest version of kafka itself along with latest version of client libs.
   // This seems to help with jar compatibility hell.
-  latestDepTestCompile group: 'org.apache.kafka', name: 'kafka_2.11', version: '+'
-  latestDepTestCompile group: 'org.apache.kafka', name: 'kafka-clients', version: '+'
-  latestDepTestCompile group: 'org.apache.kafka', name: 'kafka-streams', version: '+'
+  latestDepTestCompile group: 'org.apache.kafka', name: 'kafka_2.11', version: '2.3.+'
+  // (Pinning to 2.3.x: 2.4.0 introduces an error when executing compileLatestDepTestGroovy)
+  //  Caused by: java.lang.NoClassDefFoundError: org.I0Itec.zkclient.ZkClient
+  latestDepTestCompile group: 'org.apache.kafka', name: 'kafka-clients', version: '2.3.+'
+  latestDepTestCompile group: 'org.apache.kafka', name: 'kafka-streams', version: '2.3.+'
   latestDepTestCompile group: 'org.springframework.kafka', name: 'spring-kafka', version: '2.2.+'
   latestDepTestCompile group: 'org.springframework.kafka', name: 'spring-kafka-test', version: '2.2.+'
   latestDepTestCompile group: 'org.assertj', name: 'assertj-core', version: '3.+'


### PR DESCRIPTION
2.4.0 introduces test failures:
```
Caused by: java.lang.NoClassDefFoundError: org.I0Itec.zkclient.ZkClient
```
when executing `compileLatestDepTestGroovy`.