### PR TITLE
AWS 1.0 Tagging

### DIFF
--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/aws-java-sdk-1.11.0.gradle
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/aws-java-sdk-1.11.0.gradle
@@ -36,12 +36,14 @@ testSets {
 
 dependencies {
   compileOnly group: 'com.amazonaws', name: 'aws-java-sdk-core', version: '1.11.0'
+  compileOnly group: 'com.amazonaws', name: 'aws-java-sdk-kinesis', version: '1.11.106'
 
   // Include httpclient instrumentation for testing because it is a dependency for aws-sdk.
   testCompile project(':dd-java-agent:instrumentation:apache-httpclient-4')
   testCompile group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.11.106'
   testCompile group: 'com.amazonaws', name: 'aws-java-sdk-rds', version: '1.11.106'
   testCompile group: 'com.amazonaws', name: 'aws-java-sdk-ec2', version: '1.11.106'
+  testCompile group: 'com.amazonaws', name: 'aws-java-sdk-kinesis', version: '1.11.106'
 
   test_before_1_11_106Compile(group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.11.0') {
     force = true
@@ -52,10 +54,14 @@ dependencies {
   test_before_1_11_106Compile(group: 'com.amazonaws', name: 'aws-java-sdk-ec2', version: '1.11.0') {
     force = true
   }
+  test_before_1_11_106Compile(group: 'com.amazonaws', name: 'aws-java-sdk-kinesis', version: '1.11.0') {
+    force = true
+  }
 
   latestDepTestCompile group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '+'
   latestDepTestCompile group: 'com.amazonaws', name: 'aws-java-sdk-rds', version: '+'
   latestDepTestCompile group: 'com.amazonaws', name: 'aws-java-sdk-ec2', version: '+'
+  latestDepTestCompile group: 'com.amazonaws', name: 'aws-java-sdk-kinesis', version: '+'
 }
 
 test.dependsOn test_before_1_11_106

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/AWSKinesisClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/AWSKinesisClientInstrumentation.java
@@ -1,0 +1,103 @@
+package datadog.trace.instrumentation.aws.v0;
+
+import static java.util.Collections.singletonMap;
+import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+
+import com.amazonaws.handlers.RequestHandler2;
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Map;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+/**
+ * This instrumentation might work with versions before 1.11.0, but this was the first version that
+ * is tested. It could possibly be extended earlier.
+ */
+@AutoService(Instrumenter.class)
+public final class AWSKinesisClientInstrumentation extends Instrumenter.Default {
+
+  public AWSKinesisClientInstrumentation() {
+    super("aws-sdk");
+  }
+
+  @Override
+  public ElementMatcher<TypeDescription> typeMatcher() {
+    // TODO: What should this matching clause be
+    return named("com.amazonaws.services.kinesis.AmazonKinesisClient");
+  }
+
+  @Override
+  public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
+    return singletonMap(
+        isConstructor(), AWSKinesisClientInstrumentation.class.getName() + "$KinesisClientAdvice");
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {
+      "datadog.trace.agent.decorator.BaseDecorator",
+      "datadog.trace.agent.decorator.ClientDecorator",
+      "datadog.trace.agent.decorator.HttpClientDecorator",
+      packageName + ".AwsSdkClientDecorator",
+      packageName + ".KinesisClientDecorator",
+      packageName + ".TracingRequestHandler",
+      packageName + ".KinesisTracingRequestHandler",
+    };
+  }
+
+  public static class KinesisClientAdvice {
+    // Since we're instrumenting the constructor, we can't add onThrowable.
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    public static void addHandler(
+        @Advice.FieldValue("requestHandler2s") final List<RequestHandler2> handlers) {
+
+      // DQH - This is a bit ugly but effective.
+
+      // Our general instrumentation adds a generic TracingRequestHandler,
+      // but for Kinesis we'd like extra tags so we want to use a
+      // KinesisTracingRequestHandler instead.
+
+      // To avoid double spans, we need to remove any existing TracingRequestHandler-s
+      // and use a KinesisTracingRequestHandler instead.  In practice, the generic
+      // instrumentation guarantees that we only have a single TracingRequestHandler
+      // after the super constructor completes, so this code only handles a single
+      // TracingRequestHandler being in the list.
+
+      // As a final wrinkle, the List is a CopyOnWriteArrayList and its
+      // ListIterator doesn't support the remove operation.  So we have
+      // to store the index and manipulate the list after the loop.
+
+      boolean addedKinesisDDHandler = false;
+      int tracingRequestHandlerIndex = -1;
+      ListIterator<RequestHandler2> handlerIter = handlers.listIterator();
+      while (handlerIter.hasNext()) {
+        int index = handlerIter.nextIndex();
+        RequestHandler2 handler2 = handlerIter.next();
+
+        if (handler2 instanceof KinesisTracingRequestHandler) {
+          addedKinesisDDHandler = true;
+        } else if (handler2 instanceof TracingRequestHandler) {
+          tracingRequestHandlerIndex = index;
+        }
+      }
+
+      if (tracingRequestHandlerIndex == -1) {
+        if (!addedKinesisDDHandler) {
+          handlers.add(KinesisTracingRequestHandler.INSTANCE);
+        }
+      } else {
+        if (addedKinesisDDHandler) {
+          handlers.remove(tracingRequestHandlerIndex);
+        } else {
+          handlers.set(tracingRequestHandlerIndex, KinesisTracingRequestHandler.INSTANCE);
+        }
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/AwsSdkClientDecorator.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/AwsSdkClientDecorator.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.aws.v0;
 
+import com.amazonaws.AmazonWebServiceRequest;
 import com.amazonaws.AmazonWebServiceResponse;
 import com.amazonaws.Request;
 import com.amazonaws.Response;
@@ -36,8 +37,13 @@ public class AwsSdkClientDecorator extends HttpClientDecorator<Request, Response
         DDTags.RESOURCE_NAME,
         remapServiceName(awsServiceName) + "." + remapOperationName(awsOperation));
 
+    onOriginalRequest(span, request.getOriginalRequest());
+
     return span;
   }
+
+  public void onOriginalRequest(
+      final AgentSpan span, final AmazonWebServiceRequest originalRequest) {}
 
   @Override
   public AgentSpan onResponse(final AgentSpan span, final Response response) {

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/KinesisClientDecorator.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/KinesisClientDecorator.java
@@ -1,0 +1,74 @@
+package datadog.trace.instrumentation.aws.v0;
+
+import com.amazonaws.AmazonWebServiceRequest;
+import com.amazonaws.services.kinesis.model.AddTagsToStreamRequest;
+import com.amazonaws.services.kinesis.model.CreateStreamRequest;
+import com.amazonaws.services.kinesis.model.DecreaseStreamRetentionPeriodRequest;
+import com.amazonaws.services.kinesis.model.DeleteStreamRequest;
+import com.amazonaws.services.kinesis.model.DescribeStreamRequest;
+import com.amazonaws.services.kinesis.model.DisableEnhancedMonitoringRequest;
+import com.amazonaws.services.kinesis.model.EnableEnhancedMonitoringRequest;
+import com.amazonaws.services.kinesis.model.GetShardIteratorRequest;
+import com.amazonaws.services.kinesis.model.IncreaseStreamRetentionPeriodRequest;
+import com.amazonaws.services.kinesis.model.ListTagsForStreamRequest;
+import com.amazonaws.services.kinesis.model.MergeShardsRequest;
+import com.amazonaws.services.kinesis.model.PutRecordRequest;
+import com.amazonaws.services.kinesis.model.PutRecordsRequest;
+import com.amazonaws.services.kinesis.model.RemoveTagsFromStreamRequest;
+import com.amazonaws.services.kinesis.model.SplitShardRequest;
+import com.amazonaws.services.kinesis.model.UpdateShardCountRequest;
+import datadog.trace.instrumentation.api.AgentSpan;
+
+public final class KinesisClientDecorator extends AwsSdkClientDecorator {
+  public static final KinesisClientDecorator DECORATE = new KinesisClientDecorator();
+  public static final String AWS_STREAM_NAME_TAG = "aws.stream.name";
+
+  private KinesisClientDecorator() {}
+
+  @Override
+  public void onOriginalRequest(
+      final AgentSpan span, final AmazonWebServiceRequest originalRequest) {
+    if (originalRequest instanceof AddTagsToStreamRequest) {
+      span.setTag(AWS_STREAM_NAME_TAG, ((AddTagsToStreamRequest) originalRequest).getStreamName());
+    } else if (originalRequest instanceof CreateStreamRequest) {
+      span.setTag(AWS_STREAM_NAME_TAG, ((CreateStreamRequest) originalRequest).getStreamName());
+    } else if (originalRequest instanceof DecreaseStreamRetentionPeriodRequest) {
+      span.setTag(
+          AWS_STREAM_NAME_TAG,
+          ((DecreaseStreamRetentionPeriodRequest) originalRequest).getStreamName());
+    } else if (originalRequest instanceof DescribeStreamRequest) {
+      span.setTag(AWS_STREAM_NAME_TAG, ((DescribeStreamRequest) originalRequest).getStreamName());
+    } else if (originalRequest instanceof DeleteStreamRequest) {
+      span.setTag(AWS_STREAM_NAME_TAG, ((DeleteStreamRequest) originalRequest).getStreamName());
+    } else if (originalRequest instanceof DisableEnhancedMonitoringRequest) {
+      span.setTag(
+          AWS_STREAM_NAME_TAG,
+          ((DisableEnhancedMonitoringRequest) originalRequest).getStreamName());
+    } else if (originalRequest instanceof EnableEnhancedMonitoringRequest) {
+      span.setTag(
+          AWS_STREAM_NAME_TAG, ((EnableEnhancedMonitoringRequest) originalRequest).getStreamName());
+    } else if (originalRequest instanceof GetShardIteratorRequest) {
+      span.setTag(AWS_STREAM_NAME_TAG, ((GetShardIteratorRequest) originalRequest).getStreamName());
+    } else if (originalRequest instanceof IncreaseStreamRetentionPeriodRequest) {
+      span.setTag(
+          AWS_STREAM_NAME_TAG,
+          ((IncreaseStreamRetentionPeriodRequest) originalRequest).getStreamName());
+    } else if (originalRequest instanceof ListTagsForStreamRequest) {
+      span.setTag(
+          AWS_STREAM_NAME_TAG, ((ListTagsForStreamRequest) originalRequest).getStreamName());
+    } else if (originalRequest instanceof MergeShardsRequest) {
+      span.setTag(AWS_STREAM_NAME_TAG, ((MergeShardsRequest) originalRequest).getStreamName());
+    } else if (originalRequest instanceof PutRecordRequest) {
+      span.setTag(AWS_STREAM_NAME_TAG, ((PutRecordRequest) originalRequest).getStreamName());
+    } else if (originalRequest instanceof PutRecordsRequest) {
+      span.setTag(AWS_STREAM_NAME_TAG, ((PutRecordsRequest) originalRequest).getStreamName());
+    } else if (originalRequest instanceof RemoveTagsFromStreamRequest) {
+      span.setTag(
+          AWS_STREAM_NAME_TAG, ((RemoveTagsFromStreamRequest) originalRequest).getStreamName());
+    } else if (originalRequest instanceof SplitShardRequest) {
+      span.setTag(AWS_STREAM_NAME_TAG, ((SplitShardRequest) originalRequest).getStreamName());
+    } else if (originalRequest instanceof UpdateShardCountRequest) {
+      span.setTag(AWS_STREAM_NAME_TAG, ((UpdateShardCountRequest) originalRequest).getStreamName());
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/KinesisTracingRequestHandler.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/KinesisTracingRequestHandler.java
@@ -1,0 +1,9 @@
+package datadog.trace.instrumentation.aws.v0;
+
+public final class KinesisTracingRequestHandler extends TracingRequestHandler {
+  public static final KinesisTracingRequestHandler INSTANCE = new KinesisTracingRequestHandler();
+
+  private KinesisTracingRequestHandler() {
+    super(KinesisClientDecorator.DECORATE);
+  }
+}

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test/groovy/ClientSpecificDecorationTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test/groovy/ClientSpecificDecorationTest.groovy
@@ -1,0 +1,174 @@
+import com.amazonaws.AmazonWebServiceRequest
+import com.amazonaws.services.kinesis.AmazonKinesisClient
+import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.instrumentation.api.AgentSpan
+import datadog.trace.instrumentation.aws.v0.KinesisClientDecorator
+import groovy.transform.Canonical
+
+class ClientSpecificDecorationTest extends AgentTestRunner {
+  @Canonical
+  class ClientSpec {
+    Class<?> clientClass
+    String attributeName
+    KinesisClientDecorator decorator
+    String tagName
+  }
+
+  def "kinesis"() {
+    expect:
+    testClient(new ClientSpec(
+      clientClass: AmazonKinesisClient,
+      attributeName: "streamName",
+      decorator: KinesisClientDecorator.DECORATE,
+      tagName: "aws.stream.name"
+    ))
+  }
+
+  def testClient(clientSpec) {
+    // Scans a AWS Client class looking for methods that take a Request object
+    // with the specified parameter
+
+    // For each Request object that is discovered, constructs a Request object
+    // and runs it through AwsSdkClientDecorator.onRequest to make sure the span
+    // is tagged appropriately
+    def found = false
+    clientSpec.clientClass.methods.each { method ->
+      def requestClass = requestClassOf(method)
+      if (requestClass != null && hasAttr(clientSpec, requestClass)) {
+        testRequestClass(clientSpec, requestClass)
+
+        found = true
+      }
+    }
+    return found
+  }
+
+  def testRequestClass(clientSpec, requestClass) {
+    AmazonWebServiceRequest request = requestClass.newInstance()
+    request[clientSpec.attributeName] = "a-test-value"
+
+    def tags = new HashMap<String, Object>()
+    def span = createMockSpan(tags)
+    clientSpec.decorator.onOriginalRequest(span, request)
+
+    def tag = tags.get(clientSpec.tagName)
+    if (tag == null) {
+      def requestClassName = requestClass.name
+      def requestClassSimpleName = requestClass.simpleName
+      def tagName = clientSpec.tagName
+      def getterName = getterName(clientSpec.attributeName)
+
+      def message = "Unhandled request type: ${requestClassSimpleName} - add...\n" +
+        "import ${requestClassName};\n" +
+        "if (originalRequest instanceof ${requestClassSimpleName}) {\n" +
+        "  span.setTag(\"${tagName}\", (($requestClassSimpleName)originalRequest).${getterName}());\n" +
+        "}"
+
+      throw new IllegalStateException(message)
+    }
+    assert tags.get(clientSpec.tagName) == "a-test-value"
+  }
+
+  static requestClassOf(method) {
+    Class<?>[] paramTypes = method.parameterTypes
+    if (paramTypes.length != 1) {
+      return null
+    }
+
+    Class<?> onlyParamType = paramTypes[0]
+    if (!AmazonWebServiceRequest.isAssignableFrom(onlyParamType)) {
+      return null
+    }
+    if (AmazonWebServiceRequest.equals(onlyParamType)) {
+      return null
+    }
+
+    return onlyParamType
+  }
+
+  static hasAttr(clientSpec, klass) {
+    def methodName = getterName(clientSpec.attributeName)
+
+    try {
+      klass.getMethod(methodName)
+    } catch (NoSuchMethodException e) {
+      return false
+    }
+  }
+
+  static getterName(attrName) {
+    return "get" + Character.toUpperCase(attrName.charAt(0)) + attrName.substring(1)
+  }
+
+  def createMockSpan(tagMap) {
+    return new AgentSpan() {
+      @Override
+      AgentSpan setTag(String key, boolean value) {
+        tagMap.set(key, value)
+        return this
+      }
+
+      @Override
+      AgentSpan setTag(String key, int value) {
+        tagMap.put(key, value)
+        return this
+      }
+
+      @Override
+      AgentSpan setTag(String key, long value) {
+        tagMap.put(key, value)
+        return this
+      }
+
+      @Override
+      AgentSpan setTag(String key, double value) {
+        tagMap.put(key, value)
+        return this
+      }
+
+      @Override
+      AgentSpan setTag(String key, String value) {
+        tagMap.put(key, value)
+        return this
+      }
+
+      @Override
+      AgentSpan setError(boolean error) {
+        throw new UnsupportedOperationException()
+      }
+
+      @Override
+      AgentSpan setErrorMessage(String errorMessage) {
+        throw new UnsupportedOperationException()
+      }
+
+      @Override
+      AgentSpan addThrowable(Throwable throwable) {
+        throw new UnsupportedOperationException()
+      }
+
+      @Override
+      AgentSpan getLocalRootSpan() {
+        throw new UnsupportedOperationException()
+      }
+
+      @Override
+      AgentSpan.Context context() {
+        throw new UnsupportedOperationException()
+      }
+
+      @Override
+      void finish() {}
+
+      @Override
+      String getSpanName() {
+        return "span.name"
+      }
+
+      @Override
+      void setSpanName(String spanName) {
+        throw new UnsupportedOperationException()
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR is currently a PoC for extracting additional tags for the AWS 1.0 API.
Currently, the PR only covers Kinesis, but if we're happy with the approach I'll add other clients as well.

The basic approach that I've chosen is to replace the generic TracingRequestHandler currently added to AmazonWebServiceClient with a new kinesis specific KinesisTracingRequestHandler for AmazonKinesisClient.

The KinesisTracingRequestHandler extends TracingRequestHandler but uses a kinesis specific decorator: KinesisClientDecorator.

To accomplish this, I changed TracingRequestHandler to take a AwsSdkDecorator to its constructor.  The standard instance of TracingRequestHandler uses the plain AwsSdkDecorator.

KinesisTracingRequestHandler supplies a KinesisClientDecorator instead.

The KinesisClientDecorator overrides the new method AwsSdkDecorator.onOriginalRequest.  The default implementation does nothing, but KinesisClientDecorator extracts getStreamName from the Request object.

Unfortunately, AWS 1.0 request objects don't share a useful common ancestor.  So to make sure that I've covered all the relevant request objects, I wrote a new test that uses reflection to scan an Amazon client class and find any pertinent request classes.
