### PR TITLE
Capture error message even if no exception object provided.

### DIFF
--- a/dd-java-agent/instrumentation/google-http-client/src/test/groovy/AbstractGoogleHttpClientTest.groovy
+++ b/dd-java-agent/instrumentation/google-http-client/src/test/groovy/AbstractGoogleHttpClientTest.groovy
@@ -4,6 +4,7 @@ import com.google.api.client.http.HttpResponse
 import com.google.api.client.http.javanet.NetHttpTransport
 import datadog.trace.agent.test.base.HttpClientTest
 import datadog.trace.api.DDSpanTypes
+import datadog.trace.api.DDTags
 import datadog.trace.instrumentation.api.Tags
 import datadog.trace.instrumentation.googlehttpclient.GoogleHttpClientDecorator
 import spock.lang.Shared
@@ -69,6 +70,7 @@ abstract class AbstractGoogleHttpClientTest extends HttpClientTest<GoogleHttpCli
             "$Tags.HTTP_METHOD" String
             "$Tags.HTTP_STATUS" Integer
             "$Tags.ERROR" true
+            "$DDTags.ERROR_MSG" "Server Error"
             defaultTags()
           }
         }

--- a/dd-trace-ot/src/main/java/datadog/opentracing/DDSpan.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/DDSpan.java
@@ -1,6 +1,7 @@
 package datadog.opentracing;
 
 import static io.opentracing.log.Fields.ERROR_OBJECT;
+import static io.opentracing.log.Fields.MESSAGE;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -152,6 +153,9 @@ public class DDSpan implements Span, MutableSpan {
     if (map.get(ERROR_OBJECT) instanceof Throwable) {
       final Throwable error = (Throwable) map.get(ERROR_OBJECT);
       setErrorMeta(error);
+      return true;
+    } else if (map.get(MESSAGE) instanceof String) {
+      setTag(DDTags.ERROR_MSG, (String) map.get(MESSAGE));
       return true;
     }
     return false;


### PR DESCRIPTION
This is currently only used by the GoogleHttpClient instrumentation, but may be used by customers too.