### PR TITLE
Add option for muzzle validation on the specific JDK version

### DIFF
--- a/dd-java-agent/instrumentation/http-url-connection/http-url-connection.gradle
+++ b/dd-java-agent/instrumentation/http-url-connection/http-url-connection.gradle
@@ -1,3 +1,9 @@
+muzzle {
+  pass {
+    coreJdk()
+  }
+}
+
 apply from: "${rootDir}/gradle/java.gradle"
 
 dependencies {

--- a/dd-java-agent/instrumentation/java-concurrent/java-concurrent.gradle
+++ b/dd-java-agent/instrumentation/java-concurrent/java-concurrent.gradle
@@ -1,3 +1,10 @@
+// This won't work until the akka and scala integrations are split into separate projects.
+//muzzle {
+//  pass {
+//    coreJdk()
+//  }
+//}
+
 apply from: "${rootDir}/gradle/java.gradle"
 apply from: "${rootDir}/gradle/test-with-scala.gradle"
 apply from: "${rootDir}/gradle/test-with-kotlin.gradle"

--- a/dd-java-agent/instrumentation/jdbc/jdbc.gradle
+++ b/dd-java-agent/instrumentation/jdbc/jdbc.gradle
@@ -1,3 +1,9 @@
+muzzle {
+  pass {
+    coreJdk()
+  }
+}
+
 apply from: "${rootDir}/gradle/java.gradle"
 
 apply plugin: 'org.unbroken-dome.test-sets'


### PR DESCRIPTION
This is still useful to validate various aspects of the integrations even if it doesn't need to check against maven.

@pawelchcki this should be helpful for your PR: #1128 