### PR TITLE
Add classloader matcher to muzzle scan

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/MuzzleVersionScanPlugin.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/MuzzleVersionScanPlugin.java
@@ -53,8 +53,11 @@ public class MuzzleVersionScanPlugin {
         final ReferenceMatcher muzzle = (ReferenceMatcher) m.invoke(instrumenter);
         final List<Reference.Mismatch> mismatches =
             muzzle.getMismatchedReferenceSources(userClassLoader);
-        final boolean passed = mismatches.size() == 0;
-        if (mismatches.size() > 0) {}
+
+        final boolean classLoaderMatch =
+            ((Instrumenter.Default) instrumenter).classLoaderMatcher().matches(userClassLoader);
+        final boolean passed = mismatches.isEmpty() && classLoaderMatch;
+
         if (passed && !assertPass) {
           System.err.println(
               "MUZZLE PASSED "
@@ -64,6 +67,11 @@ public class MuzzleVersionScanPlugin {
         } else if (!passed && assertPass) {
           System.err.println(
               "FAILED MUZZLE VALIDATION: " + instrumenter.getClass().getName() + " mismatches:");
+
+          if (!classLoaderMatch) {
+            System.err.println("-- classloader mismatch");
+          }
+
           for (final Reference.Mismatch mismatch : mismatches) {
             System.err.println("-- " + mismatch);
           }

--- a/dd-java-agent/instrumentation/jax-rs-annotations-1/jax-rs-annotations-1.gradle
+++ b/dd-java-agent/instrumentation/jax-rs-annotations-1/jax-rs-annotations-1.gradle
@@ -4,7 +4,11 @@ muzzle {
     module = "jsr311-api"
     versions = "[0.5,)"
   }
-  // Muzzle doesn't detect the classLoaderMatcher, so we can't assert fail for v2 api.
+  fail {
+    group = "javax.ws.rs"
+    module = "javax.ws.rs-api"
+    versions = "[,]"
+  }
 }
 
 apply from: "${rootDir}/gradle/java.gradle"

--- a/dd-java-agent/instrumentation/jedis-1.4/jedis-1.4.gradle
+++ b/dd-java-agent/instrumentation/jedis-1.4/jedis-1.4.gradle
@@ -3,8 +3,8 @@ muzzle {
     group = "redis.clients"
     module = "jedis"
     versions = "[1.4.0,3.0.0)"
+    assertInverse = true
   }
-  // Muzzle doesn't detect the classLoaderMatcher, so we can't assert fail for 3.0+
 }
 
 apply from: "${rootDir}/gradle/java.gradle"

--- a/dd-java-agent/instrumentation/servlet/request-2/request-2.gradle
+++ b/dd-java-agent/instrumentation/servlet/request-2/request-2.gradle
@@ -5,8 +5,12 @@ muzzle {
     versions = "[2.3, 3.0)"
     assertInverse = true
   }
-  // can't add a fail block for servlet 3, because servlet 3 is backward compatible with servlet 2.3+,
-  // meaning that for every class that exists in servlet 2, it also exists in servlet 3
+  
+  fail {
+    group = "javax.servlet"
+    module = 'javax.servlet-api'
+    versions = "[3.0,)"
+  }
 }
 
 apply from: "${rootDir}/gradle/java.gradle"


### PR DESCRIPTION
- Adds the classloader matcher to the muzzle scan.
- Updates the muzzle directives of the three projects that use `classLoaderHasClasses` 