### PR TITLE
[rmi] add instrumentation names to client and server decorators, remove default client service name

### DIFF
--- a/dd-java-agent/instrumentation/rmi/src/main/java/datadog/trace/instrumentation/rmi/client/RmiClientDecorator.java
+++ b/dd-java-agent/instrumentation/rmi/src/main/java/datadog/trace/instrumentation/rmi/client/RmiClientDecorator.java
@@ -8,7 +8,7 @@ public class RmiClientDecorator extends ClientDecorator {
 
   @Override
   protected String[] instrumentationNames() {
-    return new String[] {"rmi"};
+    return new String[] {"rmi", "rmi-client"};
   }
 
   @Override

--- a/dd-java-agent/instrumentation/rmi/src/main/java/datadog/trace/instrumentation/rmi/client/RmiClientDecorator.java
+++ b/dd-java-agent/instrumentation/rmi/src/main/java/datadog/trace/instrumentation/rmi/client/RmiClientDecorator.java
@@ -23,6 +23,6 @@ public class RmiClientDecorator extends ClientDecorator {
 
   @Override
   protected String service() {
-    return "rmi";
+    return null;
   }
 }

--- a/dd-java-agent/instrumentation/rmi/src/main/java/datadog/trace/instrumentation/rmi/server/RmiServerDecorator.java
+++ b/dd-java-agent/instrumentation/rmi/src/main/java/datadog/trace/instrumentation/rmi/server/RmiServerDecorator.java
@@ -8,7 +8,7 @@ public class RmiServerDecorator extends ServerDecorator {
 
   @Override
   protected String[] instrumentationNames() {
-    return new String[] {"rmi"};
+    return new String[] {"rmi", "rmi-server"};
   }
 
   @Override


### PR DESCRIPTION
- Add missing `rmi-client` and `rmi-server` instrumentation names to respective Decorators.
- remove default client service name to avoid extra hop in service map 