### PR TITLE
Optimize HasSuperMethodMatcher logic

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/ByteBuddyElementMatchers.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/ByteBuddyElementMatchers.java
@@ -328,9 +328,8 @@ public class ByteBuddyElementMatchers {
       final Set<TypeDefinition> checkedInterfaces = new HashSet<>();
 
       while (declaringType != null) {
-        for (final MethodDescription methodDescription :
-            declaringType.getDeclaredMethods().filter(signatureMatcher)) {
-          if (matcher.matches(methodDescription)) {
+        for (final MethodDescription methodDescription : declaringType.getDeclaredMethods()) {
+          if (signatureMatcher.matches(methodDescription) && matcher.matches(methodDescription)) {
             return true;
           }
         }


### PR DESCRIPTION
Instead of filtering then iterating, just iterate through everything and apply filter inline.

This will help avoid allocation for filter iterator and improve if early match is found.

(See discussion here: https://github.com/raphw/byte-buddy/issues/772#issuecomment-571503721)