### PR TITLE
Adjust version compatibility to only 2.x

### DIFF
--- a/dd-java-agent/instrumentation/couchbase-2.0/couchbase-2.0.gradle
+++ b/dd-java-agent/instrumentation/couchbase-2.0/couchbase-2.0.gradle
@@ -29,7 +29,7 @@ muzzle {
   pass {
     group = 'com.couchbase.client'
     module = 'java-client'
-    versions = "[2.7.9,)"
+    versions = "[2.7.9,3.0.0)"
   }
   fail {
     group = 'com.couchbase.client'

--- a/dd-java-agent/instrumentation/couchbase-2.0/couchbase-2.0.gradle
+++ b/dd-java-agent/instrumentation/couchbase-2.0/couchbase-2.0.gradle
@@ -59,6 +59,6 @@ dependencies {
   testCompile group: 'com.couchbase.client', name: 'java-client', version: '2.5.0'
 
   latestDepTestCompile group: 'org.springframework.data', name: 'spring-data-couchbase', version: '3.+'
-  latestDepTestCompile group: 'com.couchbase.client', name: 'java-client', version: '2.6+'
+  latestDepTestCompile group: 'com.couchbase.client', name: 'java-client', version: '2.+'
   latestDepTestCompile group: 'com.couchbase.client', name: 'encryption', version: '+'
 }

--- a/dd-java-agent/instrumentation/couchbase-2.6/couchbase-2.6.gradle
+++ b/dd-java-agent/instrumentation/couchbase-2.6/couchbase-2.6.gradle
@@ -34,7 +34,7 @@ muzzle {
   pass {
     group = 'com.couchbase.client'
     module = 'java-client'
-    versions = "[2.7.9,)"
+    versions = "[2.7.9,3.0.0)"
   }
   fail {
     group = 'com.couchbase.client'

--- a/dd-java-agent/instrumentation/couchbase-2.6/couchbase-2.6.gradle
+++ b/dd-java-agent/instrumentation/couchbase-2.6/couchbase-2.6.gradle
@@ -58,6 +58,6 @@ dependencies {
   testCompile group: 'com.couchbase.client', name: 'encryption', version: '1.0.0'
 
   latestDepTestCompile group: 'org.springframework.data', name: 'spring-data-couchbase', version: '3.1+'
-  latestDepTestCompile group: 'com.couchbase.client', name: 'java-client', version: '2.6+'
+  latestDepTestCompile group: 'com.couchbase.client', name: 'java-client', version: '2.+'
   latestDepTestCompile group: 'com.couchbase.client', name: 'encryption', version: '+'
 }


### PR DESCRIPTION
They recently released 3.0.0 which is not compatible with our instrumentation.