### PR TITLE
Synchronized audit: WeakMap computeIfAbsent

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/WeakMap.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/WeakMap.java
@@ -18,7 +18,7 @@ public interface WeakMap<K, V> {
 
   void putIfAbsent(K key, V value);
 
-  V getOrCreate(K key, ValueSupplier<V> supplier);
+  V computeIfAbsent(K key, ValueSupplier<? super K, ? extends V> supplier);
 
   @Slf4j
   class Provider {
@@ -62,8 +62,8 @@ public interface WeakMap<K, V> {
    * Supplies the value to be stored and it is called only when a value does not exists yet in the
    * registry.
    */
-  interface ValueSupplier<V> {
-    V get();
+  interface ValueSupplier<K, V> {
+    V get(K key);
   }
 
   class MapAdapter<K, V> implements WeakMap<K, V> {
@@ -107,11 +107,12 @@ public interface WeakMap<K, V> {
     }
 
     @Override
-    public V getOrCreate(final K key, final ValueSupplier<V> supplier) {
+    public V computeIfAbsent(final K key, final ValueSupplier<? super K, ? extends V> supplier) {
+      // We can't use computeIfAbsent since it was added in 1.8.
       if (!map.containsKey(key)) {
         synchronized (this) {
           if (!map.containsKey(key)) {
-            map.put(key, supplier.get());
+            map.put(key, supplier.get(key));
           }
         }
       }

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/WeakMap.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/WeakMap.java
@@ -109,15 +109,20 @@ public interface WeakMap<K, V> {
     @Override
     public V computeIfAbsent(final K key, final ValueSupplier<? super K, ? extends V> supplier) {
       // We can't use computeIfAbsent since it was added in 1.8.
-      if (!map.containsKey(key)) {
-        synchronized (this) {
-          if (!map.containsKey(key)) {
-            map.put(key, supplier.get(key));
-          }
-        }
+      if (map.containsKey(key)) {
+        return map.get(key);
       }
 
-      return map.get(key);
+      synchronized (this) {
+        if (map.containsKey(key)) {
+          return map.get(key);
+        } else {
+          final V value = supplier.get(key);
+
+          map.put(key, value);
+          return value;
+        }
+      }
     }
 
     @Override

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/WeakMapTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/WeakMapTest.groovy
@@ -10,7 +10,7 @@ class WeakMapTest extends Specification {
 
   def "getOrCreate a value"() {
     when:
-    def count = sut.getOrCreate('key', supplier)
+    def count = sut.computeIfAbsent('key', supplier)
 
     then:
     count == 1
@@ -19,8 +19,8 @@ class WeakMapTest extends Specification {
 
   def "getOrCreate a value multiple times same class loader same key"() {
     when:
-    def count1 = sut.getOrCreate('key', supplier)
-    def count2 = sut.getOrCreate('key', supplier)
+    def count1 = sut.computeIfAbsent('key', supplier)
+    def count2 = sut.computeIfAbsent('key', supplier)
 
     then:
     count1 == 1
@@ -30,8 +30,8 @@ class WeakMapTest extends Specification {
 
   def "getOrCreate a value multiple times same class loader different keys"() {
     when:
-    def count1 = sut.getOrCreate('key1', supplier)
-    def count2 = sut.getOrCreate('key2', supplier)
+    def count1 = sut.computeIfAbsent('key1', supplier)
+    def count2 = sut.computeIfAbsent('key2', supplier)
 
     then:
     count1 == 1
@@ -39,12 +39,12 @@ class WeakMapTest extends Specification {
     supplier.counter == 2
   }
 
-  class CounterSupplier implements WeakMap.ValueSupplier<Integer> {
+  class CounterSupplier implements WeakMap.ValueSupplier<String, Integer> {
 
     def counter = 0
 
     @Override
-    Integer get() {
+    Integer get(String ignored) {
       counter = counter + 1
       return counter
     }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/ClassLoaderMatcher.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/ClassLoaderMatcher.java
@@ -30,18 +30,9 @@ public class ClassLoaderMatcher {
     return new ClassLoaderHasClassMatcher(names);
   }
 
-  public static ElementMatcher.Junction.AbstractBase<ClassLoader> classLoaderHasClassWithField(
-      final String className, final String fieldName) {
-    return new ClassLoaderHasClassWithFieldMatcher(className, fieldName);
-  }
-
-  public static ElementMatcher.Junction.AbstractBase<ClassLoader> classLoaderHasClassWithMethod(
-      final String className, final String methodName, final String... methodArgs) {
-    return new ClassLoaderHasClassWithMethodMatcher(className, methodName, methodArgs);
-  }
-
   private static class SkipClassLoaderMatcher
-      extends ElementMatcher.Junction.AbstractBase<ClassLoader> {
+      extends ElementMatcher.Junction.AbstractBase<ClassLoader>
+      implements WeakMap.ValueSupplier<ClassLoader, Boolean> {
     public static final SkipClassLoaderMatcher INSTANCE = new SkipClassLoaderMatcher();
     /* Cache of classloader-instance -> (true|false). True = skip instrumentation. False = safe to instrument. */
     private static final WeakMap<ClassLoader, Boolean> SKIP_CACHE = newWeakMap();
@@ -74,23 +65,18 @@ public class ClassLoaderMatcher {
     }
 
     private boolean shouldSkipInstance(final ClassLoader loader) {
-      Boolean cached = SKIP_CACHE.get(loader);
-      if (null != cached) {
-        return cached.booleanValue();
+      return SKIP_CACHE.computeIfAbsent(loader, this);
+    }
+
+    @Override
+    public Boolean get(final ClassLoader loader) {
+      final boolean skip = !delegatesToBootstrap(loader);
+      if (skip) {
+        log.debug(
+            "skipping classloader instance {} of type {}", loader, loader.getClass().getName());
       }
-      synchronized (this) {
-        cached = SKIP_CACHE.get(loader);
-        if (null != cached) {
-          return cached.booleanValue();
-        }
-        final boolean skip = !delegatesToBootstrap(loader);
-        if (skip) {
-          log.debug(
-              "skipping classloader instance {} of type {}", loader, loader.getClass().getName());
-        }
-        SKIP_CACHE.put(loader, skip);
-        return skip;
-      }
+
+      return skip;
     }
 
     /**
@@ -121,23 +107,9 @@ public class ClassLoaderMatcher {
     }
   }
 
-  private static class ClassLoaderNameMatcher
-      extends ElementMatcher.Junction.AbstractBase<ClassLoader> {
-
-    private final String name;
-
-    private ClassLoaderNameMatcher(final String name) {
-      this.name = name;
-    }
-
-    @Override
-    public boolean matches(final ClassLoader target) {
-      return target != null && name.equals(target.getClass().getName());
-    }
-  }
-
   public static class ClassLoaderHasClassMatcher
-      extends ElementMatcher.Junction.AbstractBase<ClassLoader> {
+      extends ElementMatcher.Junction.AbstractBase<ClassLoader>
+      implements WeakMap.ValueSupplier<ClassLoader, Boolean> {
 
     private final WeakMap<ClassLoader, Boolean> cache = newWeakMap();
 
@@ -150,123 +122,21 @@ public class ClassLoaderMatcher {
     @Override
     public boolean matches(final ClassLoader target) {
       if (target != null) {
-        Boolean result = cache.get(target);
-        if (result != null) {
-          return result;
-        }
-        synchronized (target) {
-          result = cache.get(target);
-          if (result != null) {
-            return result;
-          }
-          for (final String name : names) {
-            if (target.getResource(Utils.getResourceName(name)) == null) {
-              cache.put(target, false);
-              return false;
-            }
-          }
-          cache.put(target, true);
-          return true;
-        }
+        return cache.computeIfAbsent(target, this);
       }
+
       return false;
-    }
-  }
-
-  public static class ClassLoaderHasClassWithFieldMatcher
-      extends ElementMatcher.Junction.AbstractBase<ClassLoader> {
-
-    private final WeakMap<ClassLoader, Boolean> cache = newWeakMap();
-
-    private final String className;
-    private final String fieldName;
-
-    private ClassLoaderHasClassWithFieldMatcher(final String className, final String fieldName) {
-      this.className = className;
-      this.fieldName = fieldName;
     }
 
     @Override
-    public boolean matches(final ClassLoader target) {
-      if (target != null) {
-        Boolean result = cache.get(target);
-        if (result != null) {
-          return result;
-        }
-        synchronized (target) {
-          result = cache.get(target);
-          if (result != null) {
-            return result;
-          }
-          try {
-            final Class<?> aClass = Class.forName(className, false, target);
-            aClass.getDeclaredField(fieldName);
-            cache.put(target, true);
-            return true;
-          } catch (final ClassNotFoundException e) {
-            cache.put(target, false);
-            return false;
-          } catch (final NoSuchFieldException e) {
-            cache.put(target, false);
-            return false;
-          }
+    public Boolean get(final ClassLoader target) {
+      for (final String name : names) {
+        if (target.getResource(Utils.getResourceName(name)) == null) {
+          return false;
         }
       }
-      return false;
-    }
-  }
 
-  public static class ClassLoaderHasClassWithMethodMatcher
-      extends ElementMatcher.Junction.AbstractBase<ClassLoader> {
-
-    private final WeakMap<ClassLoader, Boolean> cache = newWeakMap();
-
-    private final String className;
-    private final String methodName;
-    private final String[] methodArgs;
-
-    private ClassLoaderHasClassWithMethodMatcher(
-        final String className, final String methodName, final String... methodArgs) {
-      this.className = className;
-      this.methodName = methodName;
-      this.methodArgs = methodArgs;
-    }
-
-    @Override
-    public boolean matches(final ClassLoader target) {
-      if (target != null) {
-        Boolean result = cache.get(target);
-        if (result != null) {
-          return result;
-        }
-        synchronized (target) {
-          result = cache.get(target);
-          if (result != null) {
-            return result;
-          }
-          try {
-            final Class<?> aClass = Class.forName(className, false, target);
-            final Class[] methodArgsClasses = new Class[methodArgs.length];
-            for (int i = 0; i < methodArgs.length; ++i) {
-              methodArgsClasses[i] = target.loadClass(methodArgs[i]);
-            }
-            if (aClass.isInterface()) {
-              aClass.getMethod(methodName, methodArgsClasses);
-            } else {
-              aClass.getDeclaredMethod(methodName, methodArgsClasses);
-            }
-            cache.put(target, true);
-            return true;
-          } catch (final ClassNotFoundException e) {
-            cache.put(target, false);
-            return false;
-          } catch (final NoSuchMethodException e) {
-            cache.put(target, false);
-            return false;
-          }
-        }
-      }
-      return false;
+      return true;
     }
   }
 }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/WeakMapSuppliers.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/WeakMapSuppliers.java
@@ -41,7 +41,7 @@ class WeakMapSuppliers {
     public <K, V> WeakMap<K, V> get() {
       final WeakConcurrentMap<K, V> map = new WeakConcurrentMap<>(false);
       cleaner.scheduleCleaning(map, MapCleaner.CLEANER, CLEAN_FREQUENCY_SECONDS, TimeUnit.SECONDS);
-      return new Adapter(map);
+      return new Adapter<>(map);
     }
 
     private static class MapCleaner implements Cleaner.Adapter<WeakConcurrentMap> {
@@ -86,11 +86,11 @@ class WeakMapSuppliers {
       }
 
       @Override
-      public V getOrCreate(final K key, final ValueSupplier<V> supplier) {
+      public V computeIfAbsent(final K key, final ValueSupplier<? super K, ? extends V> supplier) {
         if (!map.containsKey(key)) {
           synchronized (this) {
             if (!map.containsKey(key)) {
-              map.put(key, supplier.get());
+              map.put(key, supplier.get(key));
             }
           }
         }
@@ -103,7 +103,7 @@ class WeakMapSuppliers {
 
       @Override
       public <K, V> WeakMap<K, V> get() {
-        return new Adapter(new WeakConcurrentMap.WithInlinedExpunction<K, V>());
+        return new Adapter<>(new WeakConcurrentMap.WithInlinedExpunction<K, V>());
       }
     }
   }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/WeakMapSuppliers.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/WeakMapSuppliers.java
@@ -87,15 +87,20 @@ class WeakMapSuppliers {
 
       @Override
       public V computeIfAbsent(final K key, final ValueSupplier<? super K, ? extends V> supplier) {
-        if (!map.containsKey(key)) {
-          synchronized (this) {
-            if (!map.containsKey(key)) {
-              map.put(key, supplier.get(key));
-            }
-          }
+        if (map.containsKey(key)) {
+          return map.get(key);
         }
 
-        return map.get(key);
+        synchronized (this) {
+          if (map.containsKey(key)) {
+            return map.get(key);
+          } else {
+            final V value = supplier.get(key);
+
+            map.put(key, value);
+            return value;
+          }
+        }
       }
     }
 

--- a/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/AttributeKeys.java
+++ b/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/AttributeKeys.java
@@ -14,13 +14,14 @@ public class AttributeKeys {
   private static final WeakMap<ClassLoader, Map<String, AttributeKey<?>>> map =
       WeakMap.Implementation.DEFAULT.get();
 
-  private static final WeakMap.ValueSupplier<Map<String, AttributeKey<?>>> mapSupplier =
-      new WeakMap.ValueSupplier<Map<String, AttributeKey<?>>>() {
-        @Override
-        public Map<String, AttributeKey<?>> get() {
-          return new ConcurrentHashMap<>();
-        }
-      };
+  private static final WeakMap.ValueSupplier<ClassLoader, Map<String, AttributeKey<?>>>
+      mapSupplier =
+          new WeakMap.ValueSupplier<ClassLoader, Map<String, AttributeKey<?>>>() {
+            @Override
+            public Map<String, AttributeKey<?>> get(final ClassLoader ignored) {
+              return new ConcurrentHashMap<>();
+            }
+          };
 
   public static final AttributeKey<TraceScope.Continuation>
       PARENT_CONNECT_CONTINUATION_ATTRIBUTE_KEY =
@@ -42,9 +43,9 @@ public class AttributeKeys {
    * while the Attribute class is loaded by a third class loader and used internally for the
    * cassandra driver.
    */
-  private static <T> AttributeKey<T> attributeKey(String key) {
-    Map<String, AttributeKey<?>> classLoaderMap =
-        map.getOrCreate(AttributeKey.class.getClassLoader(), mapSupplier);
+  private static <T> AttributeKey<T> attributeKey(final String key) {
+    final Map<String, AttributeKey<?>> classLoaderMap =
+        map.computeIfAbsent(AttributeKey.class.getClassLoader(), mapSupplier);
     if (classLoaderMap.containsKey(key)) {
       return (AttributeKey<T>) classLoaderMap.get(key);
     }

--- a/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/AttributeKeys.java
+++ b/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/AttributeKeys.java
@@ -14,13 +14,14 @@ public class AttributeKeys {
   private static final WeakMap<ClassLoader, Map<String, AttributeKey<?>>> map =
       WeakMap.Implementation.DEFAULT.get();
 
-  private static final WeakMap.ValueSupplier<Map<String, AttributeKey<?>>> mapSupplier =
-      new WeakMap.ValueSupplier<Map<String, AttributeKey<?>>>() {
-        @Override
-        public Map<String, AttributeKey<?>> get() {
-          return new ConcurrentHashMap<>();
-        }
-      };
+  private static final WeakMap.ValueSupplier<ClassLoader, Map<String, AttributeKey<?>>>
+      mapSupplier =
+          new WeakMap.ValueSupplier<ClassLoader, Map<String, AttributeKey<?>>>() {
+            @Override
+            public Map<String, AttributeKey<?>> get(final ClassLoader ignored) {
+              return new ConcurrentHashMap<>();
+            }
+          };
 
   public static final AttributeKey<TraceScope.Continuation>
       PARENT_CONNECT_CONTINUATION_ATTRIBUTE_KEY =
@@ -46,9 +47,9 @@ public class AttributeKeys {
    * while the Attribute class is loaded by a third class loader and used internally for the
    * cassandra driver.
    */
-  private static <T> AttributeKey<T> attributeKey(String key) {
-    Map<String, AttributeKey<?>> classLoaderMap =
-        map.getOrCreate(AttributeKey.class.getClassLoader(), mapSupplier);
+  private static <T> AttributeKey<T> attributeKey(final String key) {
+    final Map<String, AttributeKey<?>> classLoaderMap =
+        map.computeIfAbsent(AttributeKey.class.getClassLoader(), mapSupplier);
     if (classLoaderMap.containsKey(key)) {
       return (AttributeKey<T>) classLoaderMap.get(key);
     }


### PR DESCRIPTION
As part of the audit of `synchronized` blocks, I noticed a repeated pattern around WeakMap caches:
```java
synchronized (cache) {
  value = cache.get(key);
  if (value == null) {
    value = .......
    cache.put(key, value);
  }
  return value;
}
```
We had `getOrCreate()` but `ValueSupplier.get()` didn't take the key as an argument.  This pull request:
- Renames `getOrCreate()` to `computeIfAbsent()` (the Java 8 name for this method)
- Changes `ValueSupplier.get()` to take a key
- Simplifies the code wherever this pattern was used

In the future, adjusting or improving WeakMap locking will benefit all callers.

Additionally, I removed the unused `ClassLoaderMatcher`s of `classLaderHasClassWithMethod` and `classLoaderHasClassWithField`