### PR TITLE
Update bytebuddy to 1.10.6

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -15,7 +15,7 @@ ext {
     groovy     : groovyVer,
     logback    : "1.2.3",
     lombok     : "1.18.10",
-    bytebuddy  : "1.10.4",
+    bytebuddy  : "1.10.6",
     scala      : "2.11.12",  // Last version to support Java 7 (2.12+ require Java 8+)
     kotlin     : "1.3.50",
     coroutines : "1.3.0"


### PR DESCRIPTION
Updates from 1.10.4 to 1.10.6 .  The most notable change is that 1.10.5 fixes the maven source code attachment for Bytebuddy that's been broken for a few releases (breaking IDE integration)