### PR TITLE
Update muzzle maven URL to use https

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -29,4 +29,7 @@ dependencies {
   compile("com.google.guava", "guava", "20.0")
   compile("org.ow2.asm", "asm", "7.0-beta")
   compile("org.ow2.asm", "asm-tree", "7.0-beta")
+
+  testCompile("org.spockframework", "spock-core", "1.3-groovy-2.5")
+  testCompile("org.codehaus.groovy", "groovy-all", "2.5.8")
 }

--- a/buildSrc/src/main/groovy/MuzzlePlugin.groovy
+++ b/buildSrc/src/main/groovy/MuzzlePlugin.groovy
@@ -35,7 +35,7 @@ class MuzzlePlugin implements Plugin<Project> {
   private static final List<RemoteRepository> MUZZLE_REPOS
   private static final AtomicReference<ClassLoader> TOOLING_LOADER = new AtomicReference<>()
   static {
-    RemoteRepository central = new RemoteRepository.Builder("central", "default", "http://central.maven.org/maven2/").build()
+    RemoteRepository central = new RemoteRepository.Builder("central", "default", "https://repo1.maven.org/maven2/").build()
     MUZZLE_REPOS = new ArrayList<RemoteRepository>(Arrays.asList(central))
   }
 

--- a/buildSrc/src/test/groovy/RangeQueryTest.groovy
+++ b/buildSrc/src/test/groovy/RangeQueryTest.groovy
@@ -1,0 +1,28 @@
+import org.eclipse.aether.RepositorySystem
+import org.eclipse.aether.RepositorySystemSession
+import org.eclipse.aether.artifact.Artifact
+import org.eclipse.aether.artifact.DefaultArtifact
+import org.eclipse.aether.resolution.VersionRangeRequest
+import org.eclipse.aether.resolution.VersionRangeResult
+import spock.lang.Specification
+
+class RangeQueryTest extends Specification {
+
+  RepositorySystem system = MuzzlePlugin.newRepositorySystem()
+  RepositorySystemSession session = MuzzlePlugin.newRepositorySystemSession(system)
+
+  def "test range request"() {
+    setup:
+//    compile group: 'org.codehaus.groovy', name: 'groovy-all', version: '2.5.0', ext: 'pom'
+    final Artifact directiveArtifact = new DefaultArtifact("org.codehaus.groovy", "groovy-all", "jar", "[2.5.0,2.5.8)")
+    final VersionRangeRequest rangeRequest = new VersionRangeRequest()
+    rangeRequest.setRepositories(MuzzlePlugin.MUZZLE_REPOS)
+    rangeRequest.setArtifact(directiveArtifact)
+    
+    // This call makes an actual network request, which may fail if network access is limited.
+    final VersionRangeResult rangeResult = system.resolveVersionRange(session, rangeRequest)
+
+    expect:
+    rangeResult.versions.size() >= 8
+  }
+}


### PR DESCRIPTION
Also add a test.

Muzzle tasks were failing because maven central is now blocking non-https requests.  This should fix that.