### PR TITLE
Add null check to hibernate decorator

### DIFF
--- a/dd-java-agent/instrumentation/hibernate/src/main/java/datadog/trace/instrumentation/hibernate/HibernateDecorator.java
+++ b/dd-java-agent/instrumentation/hibernate/src/main/java/datadog/trace/instrumentation/hibernate/HibernateDecorator.java
@@ -47,6 +47,9 @@ public class HibernateDecorator extends OrmClientDecorator {
 
   @Override
   public String entityName(final Object entity) {
+    if (entity == null) {
+      return null;
+    }
     String name = null;
     final Set<String> annotations = new HashSet<>();
     for (final Annotation annotation : entity.getClass().getDeclaredAnnotations()) {


### PR DESCRIPTION
It seems that sometimes in later versions of hibernate the entities of type list will contain null as their first element. It is unclear whether other elements in the list are not null, or if there even would be a case where the list has a length greater than 1 and contained a null.