### PR TITLE
Set dispatcher span on request instead of clear

### DIFF
--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/dispatcher/RequestDispatcherInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/dispatcher/RequestDispatcherInstrumentation.java
@@ -71,6 +71,7 @@ public final class RequestDispatcherInstrumentation extends Instrumenter.Default
     public static AgentScope start(
         @Advice.Origin("#m") final String method,
         @Advice.This final RequestDispatcher dispatcher,
+        @Advice.Local("_requestSpan") Object requestSpan,
         @Advice.Argument(0) final ServletRequest request) {
       if (activeSpan() == null) {
         // Don't want to generate a new top-level span
@@ -87,8 +88,9 @@ public final class RequestDispatcherInstrumentation extends Instrumenter.Default
       // In case we lose context, inject trace into to the request.
       propagate().inject(span, request, SETTER);
 
-      // temporarily remove from request to avoid spring resource name bubbling up:
-      request.removeAttribute(DD_SPAN_ATTRIBUTE);
+      // temporarily replace from request to avoid spring resource name bubbling up:
+      requestSpan = request.getAttribute(DD_SPAN_ATTRIBUTE);
+      request.setAttribute(DD_SPAN_ATTRIBUTE, span);
 
       return activateSpan(span, true).setAsyncPropagation(true);
     }
@@ -96,14 +98,17 @@ public final class RequestDispatcherInstrumentation extends Instrumenter.Default
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
     public static void stop(
         @Advice.Enter final AgentScope scope,
+        @Advice.Local("_requestSpan") final Object requestSpan,
         @Advice.Argument(0) final ServletRequest request,
         @Advice.Thrown final Throwable throwable) {
       if (scope == null) {
         return;
       }
 
-      // now add it back...
-      request.setAttribute(DD_SPAN_ATTRIBUTE, scope.span());
+      if (requestSpan != null) {
+        // now add it back...
+        request.setAttribute(DD_SPAN_ATTRIBUTE, requestSpan);
+      }
 
       DECORATE.onError(scope, throwable);
       DECORATE.beforeFinish(scope);

--- a/dd-java-agent/instrumentation/servlet/src/test/groovy/RequestDispatcherUtils.java
+++ b/dd-java-agent/instrumentation/servlet/src/test/groovy/RequestDispatcherUtils.java
@@ -1,9 +1,12 @@
+import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Enumeration;
 import java.util.Set;
+import java.util.concurrent.Callable;
 import javax.servlet.RequestDispatcher;
 import javax.servlet.Servlet;
 import javax.servlet.ServletContext;
@@ -164,7 +167,15 @@ public class RequestDispatcherUtils {
   class TestDispatcher implements RequestDispatcher {
     @Override
     public void forward(final ServletRequest servletRequest, final ServletResponse servletResponse)
-        throws ServletException, IOException {
+        throws ServletException {
+      runUnderTrace(
+          "forward-child",
+          new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+              return null;
+            }
+          });
       if (toThrow != null) {
         throw toThrow;
       }
@@ -172,7 +183,15 @@ public class RequestDispatcherUtils {
 
     @Override
     public void include(final ServletRequest servletRequest, final ServletResponse servletResponse)
-        throws ServletException, IOException {
+        throws ServletException {
+      runUnderTrace(
+          "include-child",
+          new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+              return null;
+            }
+          });
       if (toThrow != null) {
         throw toThrow;
       }


### PR DESCRIPTION
Clearing the span caused traces to be broken up and reported independently when calling forward/include.

#1195