### PR TITLE
Reduce use of Thread::setContextClassLoader and hard references to DatadogClassLoader

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,8 +20,8 @@ Other source files (Groovy, Scala, etc) should ideally be formatted by Intellij 
 Suggested plugins and settings:
 
 * Editor > Code Style > Java/Groovy > Imports
-  * Class count to use import with '*': `50` (some number sufficiently large that is unlikely to matter)
-  * Names count to use static import with '*': `50`
+  * Class count to use import with '*': `9999` (some number sufficiently large that is unlikely to matter)
+  * Names count to use static import with '*': `9999`
   * With java use the following import layout (groovy should still use the default) to ensure consistency with google-java-format:
     ![import layout](https://user-images.githubusercontent.com/734411/43430811-28442636-94ae-11e8-86f1-f270ddcba023.png)
 * [Google Java Format](https://plugins.jetbrains.com/plugin/8527-google-java-format)

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
@@ -163,11 +163,9 @@ public class Agent {
   private static synchronized void startDatadogAgent(
       final Instrumentation inst, final URL bootstrapURL) {
     if (AGENT_CLASSLOADER == null) {
-      final ClassLoader contextLoader = Thread.currentThread().getContextClassLoader();
       try {
         final ClassLoader agentClassLoader =
             createDatadogClassLoader("agent-tooling-and-instrumentation.isolated", bootstrapURL);
-        Thread.currentThread().setContextClassLoader(agentClassLoader);
         final Class<?> agentInstallerClass =
             agentClassLoader.loadClass("datadog.trace.agent.tooling.AgentInstaller");
         final Method agentInstallerMethod =
@@ -176,8 +174,6 @@ public class Agent {
         AGENT_CLASSLOADER = agentClassLoader;
       } catch (final Throwable ex) {
         log.error("Throwable thrown while installing the Datadog Agent", ex);
-      } finally {
-        Thread.currentThread().setContextClassLoader(contextLoader);
       }
     }
   }
@@ -186,11 +182,9 @@ public class Agent {
     if (AGENT_CLASSLOADER == null) {
       throw new IllegalStateException("Datadog agent should have been started already");
     }
-    final ClassLoader contextLoader = Thread.currentThread().getContextClassLoader();
     // TracerInstaller.installGlobalTracer can be called multiple times without any problem
     // so there is no need to have a 'datadogTracerInstalled' flag here.
     try {
-      Thread.currentThread().setContextClassLoader(AGENT_CLASSLOADER);
       // install global tracer
       final Class<?> tracerInstallerClass =
           AGENT_CLASSLOADER.loadClass("datadog.trace.agent.tooling.TracerInstaller");
@@ -200,8 +194,6 @@ public class Agent {
       logVersionInfoMethod.invoke(null);
     } catch (final Throwable ex) {
       log.error("Throwable thrown while installing the Datadog Tracer", ex);
-    } finally {
-      Thread.currentThread().setContextClassLoader(contextLoader);
     }
   }
 

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
@@ -143,7 +143,8 @@ public class AgentInstaller {
       agentBuilder = agentBuilder.with(listener);
     }
     int numInstrumenters = 0;
-    for (final Instrumenter instrumenter : ServiceLoader.load(Instrumenter.class)) {
+    for (final Instrumenter instrumenter :
+        ServiceLoader.load(Instrumenter.class, AgentInstaller.class.getClassLoader())) {
       log.debug("Loading instrumentation {}", instrumenter.getClass().getName());
 
       try {

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/AgentTestRunner.java
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/AgentTestRunner.java
@@ -139,20 +139,15 @@ public abstract class AgentTestRunner extends DDSpecification {
   }
 
   @BeforeClass
-  public static synchronized void agentSetup() throws Exception {
+  public static synchronized void agentSetup() {
     if (null != activeTransformer) {
       throw new IllegalStateException("transformer already in place: " + activeTransformer);
     }
-
-    final ClassLoader contextLoader = Thread.currentThread().getContextClassLoader();
-    try {
-      Thread.currentThread().setContextClassLoader(AgentTestRunner.class.getClassLoader());
-      assert ServiceLoader.load(Instrumenter.class).iterator().hasNext()
-          : "No instrumentation found";
-      activeTransformer = AgentInstaller.installBytebuddyAgent(INSTRUMENTATION, TEST_LISTENER);
-    } finally {
-      Thread.currentThread().setContextClassLoader(contextLoader);
-    }
+    assert ServiceLoader.load(Instrumenter.class, AgentTestRunner.class.getClassLoader())
+            .iterator()
+            .hasNext()
+        : "No instrumentation found";
+    activeTransformer = AgentInstaller.installBytebuddyAgent(INSTRUMENTATION, TEST_LISTENER);
 
     INSTRUMENTATION_ERROR_COUNT.set(0);
   }


### PR DESCRIPTION
Specify explicit AgentInstaller class loader instead of storing reference to context class loader in current thread object. We can install agent by [ServiceLoader::load(Class, ClassLoader)](https://hg.openjdk.java.net/jdk7u/jdk7u-dev/jdk/file/70e3553d9d6e/src/share/classes/java/util/ServiceLoader.java#l470) and without this call 
https://hg.openjdk.java.net/jdk7u/jdk7u-dev/jdk/file/70e3553d9d6e/src/share/classes/java/util/ServiceLoader.java#l498


- [ ] Maybe have to manually merge with #1199