### PR TITLE
Limit Hibernate latest dependency test to 5.x

### DIFF
--- a/dd-java-agent/instrumentation/hibernate/core-4.3/core-4.3.gradle
+++ b/dd-java-agent/instrumentation/hibernate/core-4.3/core-4.3.gradle
@@ -32,8 +32,8 @@ dependencies {
   testCompile group: 'org.hsqldb', name: 'hsqldb', version: '2.0.0'
   testCompile group: 'org.springframework.data', name: 'spring-data-jpa', version: '1.5.1.RELEASE'
 
-  latestDepTestCompile group: 'org.hibernate', name: 'hibernate-core', version: '5.+'
-  latestDepTestCompile group: 'org.hibernate', name: 'hibernate-entitymanager', version: '5.+'
+  latestDepTestCompile group: 'org.hibernate', name: 'hibernate-core', version: '(,6.0.0.Final)'
+  latestDepTestCompile group: 'org.hibernate', name: 'hibernate-entitymanager', version: '(,6.0.0.Final)'
   latestDepTestCompile group: 'org.hsqldb', name: 'hsqldb', version: '2.0.0'
   latestDepTestCompile group: 'org.springframework.data', name: 'spring-data-jpa', version: '+'
 }


### PR DESCRIPTION
Based on changes made in [this PR](https://github.com/open-telemetry/opentelemetry-auto-instr-java/pull/143).