### PR TITLE
Enable reuseKeys on WeakConcurrentMap

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/WeakMapSuppliers.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/WeakMapSuppliers.java
@@ -39,7 +39,7 @@ class WeakMapSuppliers {
 
     @Override
     public <K, V> WeakMap<K, V> get() {
-      final WeakConcurrentMap<K, V> map = new WeakConcurrentMap<>(false);
+      final WeakConcurrentMap<K, V> map = new WeakConcurrentMap<>(false, true);
       cleaner.scheduleCleaning(map, MapCleaner.CLEANER, CLEAN_FREQUENCY_SECONDS, TimeUnit.SECONDS);
       return new Adapter<>(map);
     }


### PR DESCRIPTION
for each call to get method in WeakConcurrentMap, a LatentKey is
created. Considering the frequency of call it's significant.
Also, the classloader of the tracer can be considered as permanent
through the lifecycle of the JVM which is a prerequisite to be able
to reuse keys (otherwise classloader leak).