### PR TITLE
Cache the result of toString in BigInteger

### DIFF
--- a/dd-trace-ot/dd-trace-ot.gradle
+++ b/dd-trace-ot/dd-trace-ot.gradle
@@ -17,7 +17,8 @@ excludedClassesCoverage += [
   'datadog.trace.common.sampling.PrioritySampling',
   // This code is copied from okHttp samples and we have integration tests to verify that it works.
   'datadog.trace.common.writer.unixdomainsockets.TunnelingUnixSocket',
-  'datadog.trace.common.writer.unixdomainsockets.UnixDomainSocketFactory'
+  'datadog.trace.common.writer.unixdomainsockets.UnixDomainSocketFactory',
+  'datadog.opentracing.StringCachingBigInteger'
 ]
 
 apply plugin: 'org.unbroken-dome.test-sets'

--- a/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
@@ -716,7 +716,7 @@ public class DDTracer implements io.opentracing.Tracer, Closeable, datadog.trace
       // case
       BigInteger value;
       do {
-        value = new BigInteger(63, ThreadLocalRandom.current());
+        value = new StringCachingBigInteger(63, ThreadLocalRandom.current());
       } while (value.signum() == 0);
 
       return value;

--- a/dd-trace-ot/src/main/java/datadog/opentracing/StringCachingBigInteger.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/StringCachingBigInteger.java
@@ -12,16 +12,8 @@ public class StringCachingBigInteger extends BigInteger {
 
   private String cachedString;
 
-  public StringCachingBigInteger(byte[] val, int off, int len) {
-    super(val, off, len);
-  }
-
   public StringCachingBigInteger(byte[] val) {
     super(val);
-  }
-
-  public StringCachingBigInteger(int signum, byte[] magnitude, int off, int len) {
-    super(signum, magnitude, off, len);
   }
 
   public StringCachingBigInteger(int signum, byte[] magnitude) {

--- a/dd-trace-ot/src/main/java/datadog/opentracing/StringCachingBigInteger.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/StringCachingBigInteger.java
@@ -1,0 +1,64 @@
+package datadog.opentracing;
+
+import java.math.BigInteger;
+import java.util.Random;
+
+/**
+ * Because we are using BigInteger for Trace and Span Id, the toString() operator may result in heavy
+ * computation and string allocation overhead. In order to limit this, we are caching the result
+ * of toString, thereby taking advantage of the immutability of BigInteger.
+ */
+public class StringCachingBigInteger extends BigInteger {
+
+  private String cachedString;
+
+  public StringCachingBigInteger(byte[] val, int off, int len) {
+    super(val, off, len);
+  }
+
+  public StringCachingBigInteger(byte[] val) {
+    super(val);
+  }
+
+  public StringCachingBigInteger(int signum, byte[] magnitude, int off, int len) {
+    super(signum, magnitude, off, len);
+  }
+
+  public StringCachingBigInteger(int signum, byte[] magnitude) {
+    super(signum, magnitude);
+  }
+
+  public StringCachingBigInteger(String val, int radix) {
+    super(val, radix);
+  }
+
+  public StringCachingBigInteger(String val) {
+    super(val);
+  }
+
+  public StringCachingBigInteger(int numBits, Random rnd) {
+    super(numBits, rnd);
+  }
+
+  public StringCachingBigInteger(int bitLength, int certainty, Random rnd) {
+    super(bitLength, certainty, rnd);
+  }
+
+  @Override
+  public String toString() {
+    if (cachedString == null) {
+      this.cachedString = super.toString();
+    }
+    return cachedString;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    return super.equals(o);
+  }
+
+  @Override
+  public int hashCode() {
+    return super.hashCode();
+  }
+}

--- a/dd-trace-ot/src/main/java/datadog/opentracing/StringCachingBigInteger.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/StringCachingBigInteger.java
@@ -4,9 +4,9 @@ import java.math.BigInteger;
 import java.util.Random;
 
 /**
- * Because we are using BigInteger for Trace and Span Id, the toString() operator may result in heavy
- * computation and string allocation overhead. In order to limit this, we are caching the result
- * of toString, thereby taking advantage of the immutability of BigInteger.
+ * Because we are using BigInteger for Trace and Span Id, the toString() operator may result in
+ * heavy computation and string allocation overhead. In order to limit this, we are caching the
+ * result of toString, thereby taking advantage of the immutability of BigInteger.
  */
 public class StringCachingBigInteger extends BigInteger {
 


### PR DESCRIPTION
I'm currently testing out the new datadog profiling feature and am seeing a high number of MutableBigIntegers being allocated. Because it was pretty much exclusively due to `toString()`, I've created a simple wrapper that caches the result, which will (hopefully) reduce our overhead of logging the same trace id multiple times.