### PR TITLE
Create AgentBuilder with logging listeners only if in debug mode

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
@@ -58,10 +58,8 @@ public class AgentInstaller {
         new AgentBuilder.Default()
             .disableClassFormatChanges()
             .with(AgentBuilder.RedefinitionStrategy.RETRANSFORMATION)
-            .with(new RedefinitionLoggingListener())
             .with(AgentBuilder.DescriptionStrategy.Default.POOL_ONLY)
             .with(AgentTooling.poolStrategy())
-            .with(new TransformLoggingListener())
             .with(new ClassLoadListener())
             .with(AgentTooling.locationStrategy())
             // FIXME: we cannot enable it yet due to BB/JVM bug, see
@@ -138,6 +136,14 @@ public class AgentInstaller {
             .or(nameMatches("com\\.mchange\\.v2\\.c3p0\\..*Proxy"))
             .or(isAnnotatedWith(named("javax.decorator.Decorator")))
             .or(matchesConfiguredExcludes());
+
+    if (log.isDebugEnabled()) {
+      agentBuilder =
+          agentBuilder
+              .with(AgentBuilder.RedefinitionStrategy.RETRANSFORMATION)
+              .with(new RedefinitionLoggingListener())
+              .with(new TransformLoggingListener());
+    }
 
     for (final AgentBuilder.Listener listener : listeners) {
       agentBuilder = agentBuilder.with(listener);


### PR DESCRIPTION
To test the effectiveness of this change, a sample spring app was run multiple times with tracer 0.43.0 and 0.44.0 (the tracer with these changes) on non-debug mode. The average start-up time is shown below:

0.43.0 -> 12.996 s
0.44.0 -> 12.196 s

Not adding the listener on non-debug mode shaves a bit of time off start-up.