### PR TITLE
SkipClassLoaderMatcher use str-switch in shouldSkipClass(ClassLoader)

### DIFF
--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/test/ClassLoaderMatcherTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/test/ClassLoaderMatcherTest.groovy
@@ -33,6 +33,11 @@ class ClassLoaderMatcherTest extends DDSpecification {
     !ClassLoaderMatcher.skipClassLoader().matches(null)
   }
 
+  def "DatadogClassLoader class name is hardcoded in ClassLoaderMatcher"() {
+    expect:
+    DatadogClassLoader.name == "datadog.trace.bootstrap.DatadogClassLoader"
+  }
+
   /*
    * A URLClassloader which only delegates java.* classes
    */


### PR DESCRIPTION
string-switch statement  seems to be 0.5 seconds faster than HashSet::contains on petclinic app