### PR TITLE
Add global check of integrations Enabled

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
@@ -143,15 +143,17 @@ public class AgentInstaller {
       agentBuilder = agentBuilder.with(listener);
     }
     int numInstrumenters = 0;
-    for (final Instrumenter instrumenter :
-        ServiceLoader.load(Instrumenter.class, AgentInstaller.class.getClassLoader())) {
-      log.debug("Loading instrumentation {}", instrumenter.getClass().getName());
+    if (Config.get().isIntegrationsEnabled()) {
+      for (final Instrumenter instrumenter :
+          ServiceLoader.load(Instrumenter.class, AgentInstaller.class.getClassLoader())) {
+        log.debug("Loading instrumentation {}", instrumenter.getClass().getName());
 
-      try {
-        agentBuilder = instrumenter.instrument(agentBuilder);
-        numInstrumenters++;
-      } catch (final Exception | LinkageError e) {
-        log.error("Unable to load instrumentation {}", instrumenter.getClass().getName(), e);
+        try {
+          agentBuilder = instrumenter.instrument(agentBuilder);
+          numInstrumenters++;
+        } catch (final Exception | LinkageError e) {
+          log.error("Unable to load instrumentation {}", instrumenter.getClass().getName(), e);
+        }
       }
     }
     log.debug("Installed {} instrumenter(s)", numInstrumenters);


### PR DESCRIPTION
If integrations are disabled, instrumenters are still loaded which
consume a non significant amount of time (up to 1s)