### PR TITLE
Merge pull request #1240 from DataDog/tyler/executor-matcher-reorder

### DIFF
--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/FutureInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/FutureInstrumentation.java
@@ -79,7 +79,6 @@ public final class FutureInstrumentation extends Instrumenter.Default {
   @Override
   public ElementMatcher<TypeDescription> typeMatcher() {
     return not(isInterface())
-        .and(safeHasInterface(named(Future.class.getName())))
         .and(
             new ElementMatcher<TypeDescription>() {
               @Override
@@ -90,7 +89,8 @@ public final class FutureInstrumentation extends Instrumenter.Default {
                 }
                 return whitelisted;
               }
-            });
+            })
+        .and(safeHasInterface(named(Future.class.getName()))); // Apply expensive matcher last.
   }
 
   @Override


### PR DESCRIPTION
Move the expensive matcher to last.

In theory this should help, but did not seem to make a significant difference in basic startup benchmarks.