### PR TITLE
Tomcat 10.0.0-M1 release seems to have some issues

### DIFF
--- a/dd-java-agent/instrumentation/jsp-2.3/jsp-2.3.gradle
+++ b/dd-java-agent/instrumentation/jsp-2.3/jsp-2.3.gradle
@@ -32,7 +32,7 @@ dependencies {
 
   latestDepTestCompile group: 'javax.servlet.jsp', name: 'javax.servlet.jsp-api', version: '+'
   latestDepTestCompile group: 'javax.servlet', name: 'javax.servlet-api', version: '+'
-  latestDepTestCompile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '+'
-  latestDepTestCompile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-jasper', version: '+'
-  latestDepTestCompile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-logging-juli', version: '+'
+  latestDepTestCompile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.+'
+  latestDepTestCompile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-jasper', version: '9.+'
+  latestDepTestCompile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-logging-juli', version: '9.+'
 }


### PR DESCRIPTION
```
Instrumentation muzzled: [jsp, jsp-compile] -- datadog.trace.instrumentation.jsp.JasperJSPCompilationContextInstrumentation on jdk.internal.loader.ClassLoaders$AppClassLoader@2c13da15
-- datadog.trace.instrumentation.jsp.JSPDecorator:39 Missing method getServletContext#()Ljavax/servlet/ServletContext;
```