### PR TITLE
Fail fast in the matcher, let the debug outputs use the cache

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Instrumenter.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Instrumenter.java
@@ -135,9 +135,9 @@ public interface Instrumenter {
         if (null != muzzle) {
           final boolean isMatch = muzzle.matches(classLoader);
           if (!isMatch) {
-            final List<Reference.Mismatch> mismatches =
-                muzzle.getMismatchedReferenceSources(classLoader);
             if (log.isDebugEnabled()) {
+              final List<Reference.Mismatch> mismatches =
+                  muzzle.getMismatchedReferenceSources(classLoader);
               log.debug(
                   "Instrumentation muzzled: {} -- {} on {}",
                   instrumentationNames,

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Instrumenter.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Instrumenter.java
@@ -133,9 +133,10 @@ public interface Instrumenter {
          */
         final ReferenceMatcher muzzle = getInstrumentationMuzzle();
         if (null != muzzle) {
-          final List<Reference.Mismatch> mismatches =
-              muzzle.getMismatchedReferenceSources(classLoader);
-          if (mismatches.size() > 0) {
+          final boolean isMatch = muzzle.matches(classLoader);
+          if (!isMatch) {
+            final List<Reference.Mismatch> mismatches =
+                muzzle.getMismatchedReferenceSources(classLoader);
             if (log.isDebugEnabled()) {
               log.debug(
                   "Instrumentation muzzled: {} -- {} on {}",
@@ -153,7 +154,7 @@ public interface Instrumenter {
                 Instrumenter.Default.this.getClass().getName(),
                 classLoader);
           }
-          return mismatches.size() == 0;
+          return isMatch;
         }
         return true;
       }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/ReferenceMatcher.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/ReferenceMatcher.java
@@ -70,7 +70,7 @@ public class ReferenceMatcher implements WeakMap.ValueSupplier<ClassLoader, Bool
   }
 
   /**
-   * Loads and caches the full list of mismatches. Used in debug contexts only
+   * Loads the full list of mismatches. Used in debug contexts only
    *
    * @param loader Classloader to validate against (or null for bootstrap)
    * @return A list of all mismatches between this ReferenceMatcher and loader's classpath.

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/ReferenceMatcher.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/ReferenceMatcher.java
@@ -80,7 +80,7 @@ public class ReferenceMatcher implements WeakMap.ValueSupplier<ClassLoader, Bool
       loader = Utils.getBootstrapProxy();
     }
 
-    final List<Mismatch> mismatches = new ArrayList<>(0);
+    final List<Mismatch> mismatches = new ArrayList<>();
 
     for (final Reference reference : references) {
       // Don't reference-check helper classes.
@@ -104,7 +104,7 @@ public class ReferenceMatcher implements WeakMap.ValueSupplier<ClassLoader, Bool
     final TypePool typePool =
         AgentTooling.poolStrategy()
             .typePool(AgentTooling.locationStrategy().classFileLocator(loader), loader);
-    final List<Mismatch> mismatches = new ArrayList<>(0);
+    final List<Mismatch> mismatches = new ArrayList<>();
     try {
       final TypePool.Resolution resolution =
           typePool.describe(Utils.getClassName(reference.getClassName()));
@@ -131,7 +131,7 @@ public class ReferenceMatcher implements WeakMap.ValueSupplier<ClassLoader, Bool
 
   public static List<Reference.Mismatch> checkMatch(
       final Reference reference, final TypeDescription typeOnClasspath) {
-    final List<Mismatch> mismatches = new ArrayList<>(0);
+    final List<Mismatch> mismatches = new ArrayList<>();
 
     for (final Reference.Flag flag : reference.getFlags()) {
       if (!flag.matches(typeOnClasspath.getModifiers())) {

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/ReferenceMatcher.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/ReferenceMatcher.java
@@ -22,7 +22,7 @@ import net.bytebuddy.pool.TypePool;
 
 /** Matches a set of references against a classloader. */
 @Slf4j
-public class ReferenceMatcher implements WeakMap.ValueSupplier<ClassLoader, Boolean> {
+public final class ReferenceMatcher implements WeakMap.ValueSupplier<ClassLoader, Boolean> {
   private final WeakMap<ClassLoader, Boolean> mismatchCache = newWeakMap();
   private final Reference[] references;
   private final Set<String> helperClassNames;
@@ -99,7 +99,7 @@ public class ReferenceMatcher implements WeakMap.ValueSupplier<ClassLoader, Bool
    * @param loader
    * @return A list of mismatched sources. A list of size 0 means the reference matches the class.
    */
-  public static List<Reference.Mismatch> checkMatch(
+  private static List<Reference.Mismatch> checkMatch(
       final Reference reference, final ClassLoader loader) {
     final TypePool typePool =
         AgentTooling.poolStrategy()

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/ReferenceMatcher.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/ReferenceMatcher.java
@@ -56,20 +56,17 @@ public class ReferenceMatcher implements WeakMap.ValueSupplier<ClassLoader, Bool
 
   @Override
   public Boolean get(final ClassLoader loader) {
-    final List<Mismatch> mismatches = new ArrayList<>();
-
     for (final Reference reference : references) {
-      if (mismatches.size() > 0) {
-        return false;
-      }
       // Don't reference-check helper classes.
       // They will be injected by the instrumentation's HelperInjector.
       if (!helperClassNames.contains(reference.getClassName())) {
-        mismatches.addAll(checkMatch(reference, loader));
+        if (!checkMatch(reference, loader).isEmpty()) {
+          return false;
+        }
       }
     }
 
-    return mismatches.size() == 0;
+    return true;
   }
 
   /**

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/ReferenceMatcher.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/ReferenceMatcher.java
@@ -42,14 +42,36 @@ public class ReferenceMatcher
   }
 
   /**
+   * Matcher used by ByteBuddy. Fails fast and only caches empty results, or complete results
+   *
    * @param loader Classloader to validate against (or null for bootstrap)
    * @return true if all references match the classpath of loader
    */
-  public boolean matches(final ClassLoader loader) {
-    return getMismatchedReferenceSources(loader).isEmpty();
+  public boolean matches(ClassLoader loader) {
+    if (loader == BOOTSTRAP_LOADER) {
+      loader = Utils.getBootstrapProxy();
+    }
+
+    final List<Mismatch> mismatches = new ArrayList<>(0);
+
+    for (final Reference reference : references) {
+      if (mismatches.size() > 0) {
+        return false;
+      }
+      // Don't reference-check helper classes.
+      // They will be injected by the instrumentation's HelperInjector.
+      if (!helperClassNames.contains(reference.getClassName())) {
+        mismatches.addAll(checkMatch(reference, loader));
+      }
+    }
+
+    mismatchCache.put(loader, mismatches);
+    return true;
   }
 
   /**
+   * Loads and caches the full list of mismatches. Used in debug contexts only
+   *
    * @param loader Classloader to validate against (or null for bootstrap)
    * @return A list of all mismatches between this ReferenceMatcher and loader's classpath.
    */
@@ -82,7 +104,8 @@ public class ReferenceMatcher
    * @param loader
    * @return A list of mismatched sources. A list of size 0 means the reference matches the class.
    */
-  public static List<Reference.Mismatch> checkMatch(Reference reference, ClassLoader loader) {
+  public static List<Reference.Mismatch> checkMatch(
+      final Reference reference, final ClassLoader loader) {
     final TypePool typePool =
         AgentTooling.poolStrategy()
             .typePool(AgentTooling.locationStrategy().classFileLocator(loader), loader);
@@ -96,7 +119,7 @@ public class ReferenceMatcher
                 reference.getSources().toArray(new Source[0]), reference.getClassName()));
       }
       return checkMatch(reference, resolution.resolve());
-    } catch (Exception e) {
+    } catch (final Exception e) {
       if (e.getMessage().startsWith("Cannot resolve type description for ")) {
         // bytebuddy throws an illegal state exception with this message if it cannot resolve types
         // TODO: handle missing type resolutions without catching bytebuddy's exceptions
@@ -112,10 +135,10 @@ public class ReferenceMatcher
   }
 
   public static List<Reference.Mismatch> checkMatch(
-      Reference reference, TypeDescription typeOnClasspath) {
+      final Reference reference, final TypeDescription typeOnClasspath) {
     final List<Mismatch> mismatches = new ArrayList<>(0);
 
-    for (Reference.Flag flag : reference.getFlags()) {
+    for (final Reference.Flag flag : reference.getFlags()) {
       if (!flag.matches(typeOnClasspath.getModifiers())) {
         final String desc = reference.getClassName();
         mismatches.add(
@@ -127,8 +150,8 @@ public class ReferenceMatcher
       }
     }
 
-    for (Reference.Field fieldRef : reference.getFields()) {
-      FieldDescription.InDefinedShape fieldDescription = findField(fieldRef, typeOnClasspath);
+    for (final Reference.Field fieldRef : reference.getFields()) {
+      final FieldDescription.InDefinedShape fieldDescription = findField(fieldRef, typeOnClasspath);
       if (fieldDescription == null) {
         mismatches.add(
             new Reference.Mismatch.MissingField(
@@ -137,7 +160,7 @@ public class ReferenceMatcher
                 fieldRef.getName(),
                 fieldRef.getType().getInternalName()));
       } else {
-        for (Reference.Flag flag : fieldRef.getFlags()) {
+        for (final Reference.Flag flag : fieldRef.getFlags()) {
           if (!flag.matches(fieldDescription.getModifiers())) {
             final String desc =
                 reference.getClassName()
@@ -155,7 +178,7 @@ public class ReferenceMatcher
       }
     }
 
-    for (Reference.Method methodRef : reference.getMethods()) {
+    for (final Reference.Method methodRef : reference.getMethods()) {
       final MethodDescription.InDefinedShape methodDescription =
           findMethod(methodRef, typeOnClasspath);
       if (methodDescription == null) {
@@ -165,7 +188,7 @@ public class ReferenceMatcher
                 methodRef.getName(),
                 methodRef.getDescriptor()));
       } else {
-        for (Reference.Flag flag : methodRef.getFlags()) {
+        for (final Reference.Flag flag : methodRef.getFlags()) {
           if (!flag.matches(methodDescription.getModifiers())) {
             final String desc =
                 reference.getClassName() + "#" + methodRef.getName() + methodRef.getDescriptor();
@@ -184,8 +207,8 @@ public class ReferenceMatcher
   }
 
   private static FieldDescription.InDefinedShape findField(
-      Reference.Field fieldRef, TypeDescription typeOnClasspath) {
-    for (FieldDescription.InDefinedShape fieldType : typeOnClasspath.getDeclaredFields()) {
+      final Reference.Field fieldRef, final TypeDescription typeOnClasspath) {
+    for (final FieldDescription.InDefinedShape fieldType : typeOnClasspath.getDeclaredFields()) {
       if (fieldType.getName().equals(fieldRef.getName())
           && fieldType
               .getType()
@@ -196,14 +219,14 @@ public class ReferenceMatcher
       }
     }
     if (typeOnClasspath.getSuperClass() != null) {
-      FieldDescription.InDefinedShape fieldOnSupertype =
+      final FieldDescription.InDefinedShape fieldOnSupertype =
           findField(fieldRef, typeOnClasspath.getSuperClass().asErasure());
       if (fieldOnSupertype != null) {
         return fieldOnSupertype;
       }
     }
-    for (TypeDescription.Generic interfaceType : typeOnClasspath.getInterfaces()) {
-      FieldDescription.InDefinedShape fieldOnSupertype =
+    for (final TypeDescription.Generic interfaceType : typeOnClasspath.getInterfaces()) {
+      final FieldDescription.InDefinedShape fieldOnSupertype =
           findField(fieldRef, interfaceType.asErasure());
       if (fieldOnSupertype != null) {
         return fieldOnSupertype;
@@ -213,8 +236,8 @@ public class ReferenceMatcher
   }
 
   private static MethodDescription.InDefinedShape findMethod(
-      Reference.Method methodRef, TypeDescription typeOnClasspath) {
-    for (MethodDescription.InDefinedShape methodDescription :
+      final Reference.Method methodRef, final TypeDescription typeOnClasspath) {
+    for (final MethodDescription.InDefinedShape methodDescription :
         typeOnClasspath.getDeclaredMethods()) {
       if (methodDescription.getInternalName().equals(methodRef.getName())
           && methodDescription.getDescriptor().equals(methodRef.getDescriptor())) {
@@ -222,14 +245,14 @@ public class ReferenceMatcher
       }
     }
     if (typeOnClasspath.getSuperClass() != null) {
-      MethodDescription.InDefinedShape methodOnSupertype =
+      final MethodDescription.InDefinedShape methodOnSupertype =
           findMethod(methodRef, typeOnClasspath.getSuperClass().asErasure());
       if (methodOnSupertype != null) {
         return methodOnSupertype;
       }
     }
-    for (TypeDescription.Generic interfaceType : typeOnClasspath.getInterfaces()) {
-      MethodDescription.InDefinedShape methodOnSupertype =
+    for (final TypeDescription.Generic interfaceType : typeOnClasspath.getInterfaces()) {
+      final MethodDescription.InDefinedShape methodOnSupertype =
           findMethod(methodRef, interfaceType.asErasure());
       if (methodOnSupertype != null) {
         return methodOnSupertype;

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/ReferenceMatcher.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/ReferenceMatcher.java
@@ -22,9 +22,8 @@ import net.bytebuddy.pool.TypePool;
 
 /** Matches a set of references against a classloader. */
 @Slf4j
-public class ReferenceMatcher
-    implements WeakMap.ValueSupplier<ClassLoader, List<Reference.Mismatch>> {
-  private final WeakMap<ClassLoader, List<Reference.Mismatch>> mismatchCache = newWeakMap();
+public class ReferenceMatcher implements WeakMap.ValueSupplier<ClassLoader, Boolean> {
+  private final WeakMap<ClassLoader, Boolean> mismatchCache = newWeakMap();
   private final Reference[] references;
   private final Set<String> helperClassNames;
 
@@ -52,6 +51,11 @@ public class ReferenceMatcher
       loader = Utils.getBootstrapProxy();
     }
 
+    return mismatchCache.computeIfAbsent(loader, this);
+  }
+
+  @Override
+  public Boolean get(final ClassLoader loader) {
     final List<Mismatch> mismatches = new ArrayList<>(0);
 
     for (final Reference reference : references) {
@@ -65,7 +69,6 @@ public class ReferenceMatcher
       }
     }
 
-    mismatchCache.put(loader, mismatches);
     return mismatches.size() == 0;
   }
 
@@ -80,11 +83,6 @@ public class ReferenceMatcher
       loader = Utils.getBootstrapProxy();
     }
 
-    return mismatchCache.computeIfAbsent(loader, this);
-  }
-
-  @Override
-  public List<Mismatch> get(final ClassLoader loader) {
     final List<Mismatch> mismatches = new ArrayList<>(0);
 
     for (final Reference reference : references) {

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/ReferenceMatcher.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/ReferenceMatcher.java
@@ -56,7 +56,7 @@ public class ReferenceMatcher implements WeakMap.ValueSupplier<ClassLoader, Bool
 
   @Override
   public Boolean get(final ClassLoader loader) {
-    final List<Mismatch> mismatches = new ArrayList<>(0);
+    final List<Mismatch> mismatches = new ArrayList<>();
 
     for (final Reference reference : references) {
       if (mismatches.size() > 0) {

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/ReferenceMatcher.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/ReferenceMatcher.java
@@ -66,7 +66,7 @@ public class ReferenceMatcher
     }
 
     mismatchCache.put(loader, mismatches);
-    return true;
+    return mismatches.size() == 0;
   }
 
   /**


### PR DESCRIPTION
Minimal CPU improvement unfortunately but does at least help some.

![startup plot](https://user-images.githubusercontent.com/139938/75202542-93a46b80-5739-11ea-89ba-2c0007682218.png)

Memory stats should be treated as grain of salt. The test app results in 5:1 cache hit:miss ratio and 2 total mismatches (scala concurrent classes). So doesn't really exercise this cache.

![memory plot](https://user-images.githubusercontent.com/139938/75193939-39011480-5725-11ea-9637-46caaa9df706.png)