### PR TITLE
Add ThreadLocal cache for super type matcher

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
@@ -7,6 +7,7 @@ import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.none;
 
+import datadog.trace.agent.tooling.bytebuddy.matcher.ThreadLocalCache;
 import datadog.trace.api.Config;
 import java.lang.instrument.Instrumentation;
 import java.util.ArrayList;
@@ -92,8 +93,11 @@ public class AgentInstaller {
       }
     }
     log.debug("Installed {} instrumenter(s)", numInstrumenters);
-
-    return agentBuilder.installOn(inst);
+    try {
+      return agentBuilder.installOn(inst);
+    } finally {
+      ThreadLocalCache.clearCache();
+    }
   }
 
   private static void addByteBuddyRawSetting() {

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/ThreadLocalCache.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/ThreadLocalCache.java
@@ -1,0 +1,27 @@
+package datadog.trace.agent.tooling.bytebuddy.matcher;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ThreadLocalCache {
+
+  private static final ThreadLocal<Map<String, Boolean>> superTypeCache =
+    new ThreadLocal<Map<String, Boolean>>() {
+      @Override
+      protected Map<String, Boolean> initialValue() {
+        return new HashMap<String, Boolean>();
+      }
+    };
+
+  public static Boolean get(String key) {
+    return superTypeCache.get().get(key);
+  }
+
+  public static void put(String key, boolean value) {
+    superTypeCache.get().put(key, value);
+  }
+
+  public static void clearCache() {
+    superTypeCache.remove();
+  }
+}


### PR DESCRIPTION
SafeHasSuperTypeMatcher is called multiple times with the same
target TypeName which re process the relatively expensive check over
and over again. This ThreadLocal cache avoid those checks at the
expense of some memory, that it released right away after installing
the agent

Here the results of launching 5 times the spring petclinic app with dd-trace-java agent and finally without the agent on the current master branch:
```
COMP11909:~/git/spring-petclinic$ ./spring-startup-test.sh 0.44.0-SNAPSHOT
PetClinicApplication in 9.261 seconds (JVM running for 11.649)
PetClinicApplication in 8.682 seconds (JVM running for 10.788)
PetClinicApplication in 9.626 seconds (JVM running for 11.82)
PetClinicApplication in 9.455 seconds (JVM running for 11.714)
PetClinicApplication in 9.842 seconds (JVM running for 12.094)
baseline
PetClinicApplication in 5.853 seconds (JVM running for 6.316)
```

now with the super type ThreadLocal cache for SafeHasSuperTypeMatcher:

```
COMP11909:~/git/spring-petclinic$ ./spring-startup-test.sh 0.44.0-SNAPSHOT
PetClinicApplication in 6.581 seconds (JVM running for 8.404)
PetClinicApplication in 5.975 seconds (JVM running for 7.693)
PetClinicApplication in 5.82 seconds (JVM running for 7.451)
PetClinicApplication in 5.84 seconds (JVM running for 7.467)
PetClinicApplication in 5.865 seconds (JVM running for 7.482)
baseline
PetClinicApplication in 5.363 seconds (JVM running for 5.805)

```