### PR TITLE
Return TypePool.Resolution that caches TypeDescription calls.

### DIFF
--- a/dd-java-agent/benchmark/benchmark.gradle
+++ b/dd-java-agent/benchmark/benchmark.gradle
@@ -10,14 +10,14 @@ dependencies {
 }
 
 jmh {
-  timeUnit = 'us' // Output time unit. Available time units are: [m, s, ms, us, ns].
+  timeUnit = 'ms' // Output time unit. Available time units are: [m, s, ms, us, ns].
   benchmarkMode = ['avgt']
   timeOnIteration = '20s'
   iterations = 1 // Number of measurement iterations to do.
   fork = 1 // How many times to forks a single benchmark. Use 0 to disable forking altogether
   jvmArgs = ["-Ddd.jmxfetch.enabled=false", "-Ddd.writer.type=LoggingWriter"]
 //  jvmArgs += ["-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints", "-XX:StartFlightRecording=delay=5s,dumponexit=true,name=jmh-benchmark,filename=${rootDir}/dd-java-agent/benchmark/build/reports/jmh/jmh-benchmark.jfr"]
-//  jvmArgs += ["-agentpath:${rootDir}/dd-java-agent/benchmark/src/jmh/resources/libasyncProfiler.so=start,collapsed,file=${rootDir}/dd-java-agent/benchmark/build/reports/jmh/profiler.txt"]
+//  jvmArgs += ["-agentpath:${rootDir}/dd-java-agent/benchmark/src/jmh/resources/libasyncProfiler.so=start,collapsed,file=${rootDir}/dd-java-agent/benchmark/build/reports/jmh/profiler.txt".toString()]
   failOnError = true // Should JMH fail immediately if any benchmark had experienced the unrecoverable error?
   warmup = '5s' // Time to spend at each warmup iteration.
 //  warmupBatchSize = 10 // Warmup batch size: number of benchmark method calls per operation.

--- a/dd-smoke-tests/springboot/src/main/java/datadog/smoketest/springboot/SpringbootApplication.java
+++ b/dd-smoke-tests/springboot/src/main/java/datadog/smoketest/springboot/SpringbootApplication.java
@@ -1,5 +1,6 @@
 package datadog.smoketest.springboot;
 
+import java.lang.management.ManagementFactory;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
@@ -8,5 +9,6 @@ public class SpringbootApplication {
 
   public static void main(final String[] args) {
     SpringApplication.run(SpringbootApplication.class, args);
+    System.out.println("Started in " + ManagementFactory.getRuntimeMXBean().getUptime() + "ms");
   }
 }


### PR DESCRIPTION
Caching focused on the expensive calls primarily used by our instrumentation.

This reduces startup by nearly a second.

I'm not sure what the impact of this on memory overhead will be.  We should consider increasing the cache size a bit to make this even more effective.