### PR TITLE
Apply matcher if debug logging enabled to avoid confusing log output.

### DIFF
--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/AbstractExecutorInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/AbstractExecutorInstrumentation.java
@@ -103,6 +103,8 @@ public abstract class AbstractExecutorInstrumentation extends Instrumenter.Defau
   @Override
   public ElementMatcher<TypeDescription> typeMatcher() {
     ElementMatcher.Junction<TypeDescription> matcher = not(isInterface());
+    final ElementMatcher.Junction<TypeDescription> hasExecutorInterfaceMatcher =
+        hasInterface(named(Executor.class.getName()));
     if (!TRACE_ALL_EXECUTORS) {
       matcher =
           matcher.and(
@@ -121,15 +123,16 @@ public abstract class AbstractExecutorInstrumentation extends Instrumenter.Defau
                     }
                   }
 
-                  if (!whitelisted) {
+                  if (!whitelisted
+                      && log.isDebugEnabled()
+                      && hasExecutorInterfaceMatcher.matches(target)) {
                     log.debug("Skipping executor instrumentation for {}", target.getName());
                   }
                   return whitelisted;
                 }
               });
     }
-    return matcher.and(
-        hasInterface(named(Executor.class.getName()))); // Apply expensive matcher last.
+    return matcher.and(hasExecutorInterfaceMatcher); // Apply expensive matcher last.
   }
 
   @Override

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/FutureInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/FutureInstrumentation.java
@@ -78,19 +78,23 @@ public final class FutureInstrumentation extends Instrumenter.Default {
 
   @Override
   public ElementMatcher<TypeDescription> typeMatcher() {
+    final ElementMatcher.Junction<TypeDescription> hasFutureInterfaceMatcher =
+        hasInterface(named(Future.class.getName()));
     return not(isInterface())
         .and(
             new ElementMatcher<TypeDescription>() {
               @Override
               public boolean matches(final TypeDescription target) {
                 final boolean whitelisted = WHITELISTED_FUTURES.contains(target.getName());
-                if (!whitelisted) {
+                if (!whitelisted
+                    && log.isDebugEnabled()
+                    && hasFutureInterfaceMatcher.matches(target)) {
                   log.debug("Skipping future instrumentation for {}", target.getName());
                 }
                 return whitelisted;
               }
             })
-        .and(hasInterface(named(Future.class.getName()))); // Apply expensive matcher last.
+        .and(hasFutureInterfaceMatcher); // Apply expensive matcher last.
   }
 
   @Override


### PR DESCRIPTION
Otherwise it was "Skipping" every unrelated class.