### PR TITLE
Use plugin to automatically set version

### DIFF
--- a/dd-trace-java.gradle
+++ b/dd-trace-java.gradle
@@ -21,10 +21,6 @@ scmVersion {
     versionSeparator = ''
   }
 
-  createReleaseCommit true
-
-  releaseCommitMessage { version, position -> "Version ${version}" }
-
   versionIncrementer 'incrementMinor'
 
   checks {

--- a/dd-trace-java.gradle
+++ b/dd-trace-java.gradle
@@ -21,6 +21,10 @@ scmVersion {
     versionSeparator = ''
   }
 
+  createReleaseCommit true
+
+  releaseCommitMessage { version, position -> "Version ${version}" }
+
   versionIncrementer 'incrementMinor'
 
   checks {

--- a/dd-trace-java.gradle
+++ b/dd-trace-java.gradle
@@ -10,13 +10,29 @@ plugins {
   // files in 'workspace' build directory in CI
   id 'com.github.sherter.google-java-format' version '0.8' apply false
   id 'com.dorongold.task-tree' version '1.5'
+  id 'pl.allegro.tech.build.axion-release' version '1.9.3'
 }
 
 def isCI = System.getenv("CI") != null
 
+scmVersion {
+  tag {
+    prefix = 'v'
+    versionSeparator = ''
+  }
+
+  versionIncrementer 'incrementMinor'
+
+  checks {
+    uncommittedChanges = false
+    aheadOfRemote = true
+    snapshotDependencies = false
+  }
+}
+
 allprojects {
   group = 'com.datadoghq'
-  version = '0.46.0-SNAPSHOT'
+  version = scmVersion.version
 
   if (isCI) {
     buildDir = "${rootDir}/workspace/${projectDir.path.replace(rootDir.path, '')}/build/"


### PR DESCRIPTION
This uses the [axion-release](https://axion-release-plugin.readthedocs.io/en/latest/) to automatically set the version for the gradle project by looking at git tags.

This removes 9 steps from the 21 step release process.

~I preserved our practice of generating a release commit but don't have strong feelings about it.~

### Relevant commands
Show current version:

```
./gradlew currentVersion
```

Do a dry-run of a release (no actions performed):

```
./gradlew release -Prelease.dryRun
```

Perform a release:

```
./gradlew release
```