### PR TITLE
Resolve injection file collisions

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
@@ -7,6 +7,7 @@ import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.none;
 
+import datadog.trace.agent.tooling.context.FieldBackedProvider;
 import datadog.trace.api.Config;
 import java.lang.instrument.Instrumentation;
 import java.util.ArrayList;
@@ -52,6 +53,8 @@ public class AgentInstaller {
     INSTRUMENTATION = inst;
 
     addByteBuddyRawSetting();
+
+    FieldBackedProvider.resetContextMatchers();
 
     AgentBuilder agentBuilder =
         new AgentBuilder.Default()

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Instrumenter.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Instrumenter.java
@@ -100,7 +100,9 @@ public interface Instrumenter {
         AgentBuilder.Identified.Extendable agentBuilder) {
       final String[] helperClassNames = helperClassNames();
       if (helperClassNames.length > 0) {
-        agentBuilder = agentBuilder.transform(new HelperInjector(helperClassNames));
+        agentBuilder =
+            agentBuilder.transform(
+                new HelperInjector(this.getClass().getSimpleName(), helperClassNames));
       }
       return agentBuilder;
     }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/context/FieldBackedProvider.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/context/FieldBackedProvider.java
@@ -324,8 +324,10 @@ public class FieldBackedProvider implements InstrumentationContextProvider {
   /** Get transformer that forces helper injection onto bootstrap classloader. */
   private AgentBuilder.Transformer bootstrapHelperInjector(
       final Collection<DynamicType.Unloaded<?>> helpers) {
+    // TODO: Better to pass through the context of the Instrumenter
     return new AgentBuilder.Transformer() {
-      final HelperInjector injector = HelperInjector.forDynamicTypes(helpers);
+      final HelperInjector injector =
+          HelperInjector.forDynamicTypes(this.getClass().getSimpleName(), helpers);
 
       @Override
       public DynamicType.Builder<?> transform(

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/MuzzleVersionScanPlugin.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/MuzzleVersionScanPlugin.java
@@ -102,7 +102,9 @@ public class MuzzleVersionScanPlugin {
           // verify helper injector works
           final String[] helperClassNames = defaultInstrumenter.helperClassNames();
           if (helperClassNames.length > 0) {
-            new HelperInjector(createHelperMap(defaultInstrumenter))
+            new HelperInjector(
+                    MuzzleVersionScanPlugin.class.getSimpleName(),
+                    createHelperMap(defaultInstrumenter))
                 .transform(null, null, userClassLoader, null);
           }
         } catch (final Exception e) {

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/test/HelperInjectionTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/test/HelperInjectionTest.groovy
@@ -24,7 +24,7 @@ class HelperInjectionTest extends DDSpecification {
   def "helpers injected to non-delegating classloader"() {
     setup:
     String helperClassName = HelperInjectionTest.getPackage().getName() + '.HelperClass'
-    HelperInjector injector = new HelperInjector(helperClassName)
+    HelperInjector injector = new HelperInjector("test", helperClassName)
     AtomicReference<URLClassLoader> emptyLoader = new AtomicReference<>(new URLClassLoader(new URL[0], (ClassLoader) null))
 
     when:
@@ -56,7 +56,7 @@ class HelperInjectionTest extends DDSpecification {
     ByteBuddyAgent.install()
     AgentInstaller.installBytebuddyAgent(ByteBuddyAgent.getInstrumentation())
     String helperClassName = HelperInjectionTest.getPackage().getName() + '.HelperClass'
-    HelperInjector injector = new HelperInjector(helperClassName)
+    HelperInjector injector = new HelperInjector("test", helperClassName)
     URLClassLoader bootstrapChild = new URLClassLoader(new URL[0], (ClassLoader) null)
 
     when:


### PR DESCRIPTION
This change aims to solve sporadic errors with failing to create temp JARs in HelperInjector

This is accomplished by creating a per-process temp directory in which to place the JARs, so that two processes do not conflict.

This approach was chosen to minimize collisions, but also because it isn't easy to recreate the contents of ClassInjector.UsingInstrumentation where the problem originates.  Ideally, we might make a version of UsingInstrumentation that has some retry logic, but many of the supporting classes are not public.