### PR TITLE
Avoid temporary Jar file collisions

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Instrumenter.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Instrumenter.java
@@ -106,7 +106,9 @@ public interface Instrumenter {
         AgentBuilder.Identified.Extendable agentBuilder) {
       final String[] helperClassNames = helperClassNames();
       if (helperClassNames.length > 0) {
-        agentBuilder = agentBuilder.transform(new HelperInjector(helperClassNames));
+        agentBuilder =
+            agentBuilder.transform(
+                new HelperInjector(this.getClass().getSimpleName(), helperClassNames));
       }
       return agentBuilder;
     }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/context/FieldBackedProvider.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/context/FieldBackedProvider.java
@@ -322,8 +322,10 @@ public class FieldBackedProvider implements InstrumentationContextProvider {
   /** Get transformer that forces helper injection onto bootstrap classloader. */
   private AgentBuilder.Transformer bootstrapHelperInjector(
       final Collection<DynamicType.Unloaded<?>> helpers) {
+    // TODO: Better to pass through the context of the Instrumenter
     return new AgentBuilder.Transformer() {
-      final HelperInjector injector = HelperInjector.forDynamicTypes(helpers);
+      final HelperInjector injector =
+          HelperInjector.forDynamicTypes(this.getClass().getSimpleName(), helpers);
 
       @Override
       public DynamicType.Builder<?> transform(

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/MuzzleVersionScanPlugin.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/MuzzleVersionScanPlugin.java
@@ -102,7 +102,9 @@ public class MuzzleVersionScanPlugin {
           // verify helper injector works
           final String[] helperClassNames = defaultInstrumenter.helperClassNames();
           if (helperClassNames.length > 0) {
-            new HelperInjector(createHelperMap(defaultInstrumenter))
+            new HelperInjector(
+                    MuzzleVersionScanPlugin.class.getSimpleName(),
+                    createHelperMap(defaultInstrumenter))
                 .transform(null, null, userClassLoader, null);
           }
         } catch (final Exception e) {

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/test/HelperInjectionTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/test/HelperInjectionTest.groovy
@@ -24,7 +24,7 @@ class HelperInjectionTest extends DDSpecification {
   def "helpers injected to non-delegating classloader"() {
     setup:
     String helperClassName = HelperInjectionTest.getPackage().getName() + '.HelperClass'
-    HelperInjector injector = new HelperInjector(helperClassName)
+    HelperInjector injector = new HelperInjector("test", helperClassName)
     AtomicReference<URLClassLoader> emptyLoader = new AtomicReference<>(new URLClassLoader(new URL[0], (ClassLoader) null))
 
     when:
@@ -56,7 +56,7 @@ class HelperInjectionTest extends DDSpecification {
     ByteBuddyAgent.install()
     AgentInstaller.installBytebuddyAgent(ByteBuddyAgent.getInstrumentation())
     String helperClassName = HelperInjectionTest.getPackage().getName() + '.HelperClass'
-    HelperInjector injector = new HelperInjector(helperClassName)
+    HelperInjector injector = new HelperInjector("test", helperClassName)
     URLClassLoader bootstrapChild = new URLClassLoader(new URL[0], (ClassLoader) null)
 
     when:


### PR DESCRIPTION
This change aims to avoid JAR file collisions by creating a per-injection temp dir inside the usual java.io.tmpdir.

The HelperInjector selects a temporary directory using Files.createTempDirectory for each injection.  This compensates for ByteBuddy's ClassInjector.UsingInstrumentation not using File.createTempFile which leads to occasional collisions.

This scheme was chosen in part to avoid modifying or recreating the logic in ClassInjector.UsingInstrumentation.  While the logic of that class is not complicated, many of the helper classes it calls are not public.