### PR TITLE
Add instrumentation name to allow configuring `@Trace`

### DIFF
--- a/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceDecorator.java
+++ b/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceDecorator.java
@@ -7,7 +7,8 @@ public class TraceDecorator extends BaseDecorator {
 
   @Override
   protected String[] instrumentationNames() {
-    return new String[0];
+    // Can't use "trace" because that's used as the general config name:
+    return new String[] {"trace-annotation", "trace-config"};
   }
 
   @Override


### PR DESCRIPTION
Specifically, this allows annotated/configured methods to be reported to App Analytics:
- System Property: `-Ddd.trace-annotation.analytics.enabled=true`
- Environment Variable: `DD_TRACE_ANNOTATION_ANALYTICS_ENABLED=true`
or
- System Property: `-Ddd.trace-config.analytics.enabled=true`
- Environment Variable: `DD_TRACE_CONFIG_ANALYTICS_ENABLED=true`