### PR TITLE
Remove non-delegating loader check

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/ClassLoaderMatcher.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/ClassLoaderMatcher.java
@@ -28,9 +28,6 @@ public final class ClassLoaderMatcher {
   private static final class SkipClassLoaderMatcher
       extends ElementMatcher.Junction.AbstractBase<ClassLoader> {
     public static final SkipClassLoaderMatcher INSTANCE = new SkipClassLoaderMatcher();
-    /* Cache of classloader-instance -> (true|false). True = skip instrumentation. False = safe to instrument. */
-    private static final Cache<ClassLoader, Boolean> skipCache =
-        CacheBuilder.newBuilder().weakKeys().concurrencyLevel(CACHE_CONCURRENCY).build();
     private static final String DATADOG_CLASSLOADER_NAME =
         "datadog.trace.bootstrap.DatadogClassLoader";
 
@@ -42,13 +39,7 @@ public final class ClassLoaderMatcher {
         // Don't skip bootstrap loader
         return false;
       }
-      Boolean v = skipCache.getIfPresent(cl);
-      if (v != null) {
-        return v;
-      }
-      v = shouldSkipClass(cl);
-      skipCache.put(cl, v);
-      return v;
+      return shouldSkipClass(cl);
     }
 
     private static boolean shouldSkipClass(final ClassLoader loader) {

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/ClassLoaderMatcher.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/ClassLoaderMatcher.java
@@ -2,8 +2,6 @@ package datadog.trace.agent.tooling;
 
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
-import datadog.trace.bootstrap.PatchLogger;
-import io.opentracing.util.GlobalTracer;
 import lombok.extern.slf4j.Slf4j;
 import net.bytebuddy.matcher.ElementMatcher;
 
@@ -48,7 +46,7 @@ public final class ClassLoaderMatcher {
       if (v != null) {
         return v;
       }
-      v = shouldSkipClass(cl) || !delegatesToBootstrap(cl);
+      v = shouldSkipClass(cl);
       skipCache.put(cl, v);
       return v;
     }
@@ -66,34 +64,6 @@ public final class ClassLoaderMatcher {
       }
       return false;
     }
-
-    /**
-     * TODO: this turns out to be useless with OSGi: {@code
-     * org.eclipse.osgi.internal.loader.BundleLoader#isRequestFromVM} returns {@code true} when
-     * class loading is issued from this check and {@code false} for 'real' class loads. We should
-     * come up with some sort of hack to avoid this problem.
-     */
-    private static boolean delegatesToBootstrap(final ClassLoader loader) {
-      boolean delegates = true;
-      if (!loadsExpectedClass(loader, GlobalTracer.class)) {
-        log.debug("loader {} failed to delegate bootstrap opentracing class", loader);
-        delegates = false;
-      }
-      if (!loadsExpectedClass(loader, PatchLogger.class)) {
-        log.debug("loader {} failed to delegate bootstrap datadog class", loader);
-        delegates = false;
-      }
-      return delegates;
-    }
-
-    private static boolean loadsExpectedClass(
-        final ClassLoader loader, final Class<?> expectedClass) {
-      try {
-        return loader.loadClass(expectedClass.getName()) == expectedClass;
-      } catch (final ClassNotFoundException e) {
-        return false;
-      }
-    }
   }
 
   private static class ClassLoaderHasNoResourceMatcher
@@ -107,7 +77,7 @@ public final class ClassLoaderMatcher {
       this.resources = resources;
     }
 
-    private boolean hasNoResources(ClassLoader cl) {
+    private boolean hasNoResources(final ClassLoader cl) {
       for (final String resource : resources) {
         if (cl.getResource(resource) == null) {
           return true;

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/test/ClassLoaderMatcherTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/test/ClassLoaderMatcherTest.groovy
@@ -6,13 +6,6 @@ import datadog.trace.util.test.DDSpecification
 
 class ClassLoaderMatcherTest extends DDSpecification {
 
-  def "skip non-delegating classloader"() {
-    setup:
-    final URLClassLoader badLoader = new NonDelegatingClassLoader()
-    expect:
-    ClassLoaderMatcher.skipClassLoader().matches(badLoader)
-  }
-
   def "skips agent classloader"() {
     setup:
     URL root = new URL("file://")
@@ -37,23 +30,4 @@ class ClassLoaderMatcherTest extends DDSpecification {
     expect:
     DatadogClassLoader.name == "datadog.trace.bootstrap.DatadogClassLoader"
   }
-
-  /*
-   * A URLClassloader which only delegates java.* classes
-   */
-
-  private static class NonDelegatingClassLoader extends URLClassLoader {
-    NonDelegatingClassLoader() {
-      super(new URL[0], (ClassLoader) null)
-    }
-
-    @Override
-    Class<?> loadClass(String className) {
-      if (className.startsWith("java.")) {
-        return super.loadClass(className)
-      }
-      throw new ClassNotFoundException(className)
-    }
-  }
-
 }


### PR DESCRIPTION
This is not needed anymore now that loadClass() is being instrumented to deal with non-delegating class loaders.

See https://github.com/open-telemetry/opentelemetry-auto-instr-java/pull/203