### PR TITLE
Scale back ignores

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/AdditionalLibraryIgnoresMatcher.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/AdditionalLibraryIgnoresMatcher.java
@@ -63,7 +63,6 @@ public class AdditionalLibraryIgnoresMatcher<T extends TypeDescription>
           || name.startsWith("org.springframework.objenesis.")
           || name.startsWith("org.springframework.orm.")
           || name.startsWith("org.springframework.remoting.")
-          || name.startsWith("org.springframework.scheduling.annotation")
           || name.startsWith("org.springframework.scripting.")
           || name.startsWith("org.springframework.stereotype.")
           || name.startsWith("org.springframework.transaction.")

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/AdditionalLibraryIgnoresMatcher.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/AdditionalLibraryIgnoresMatcher.java
@@ -28,7 +28,6 @@ public class AdditionalLibraryIgnoresMatcher<T extends TypeDescription>
     final String name = target.getActualName();
 
     if (name.startsWith("com.beust.jcommander.")
-        || name.startsWith("com.carrotsearch.hppc.")
         || name.startsWith("com.fasterxml.classmate.")
         || name.startsWith("com.fasterxml.jackson.")
         || name.startsWith("com.github.mustachejava.")
@@ -240,6 +239,13 @@ public class AdditionalLibraryIgnoresMatcher<T extends TypeDescription>
           || name.equals("org.h2.store.FileLock")
           || name.equals("org.h2.engine.DatabaseCloser")
           || name.equals("org.h2.engine.OnExitDatabaseCloser")) {
+        return false;
+      }
+      return true;
+    }
+
+    if (name.startsWith("com.carrotsearch.hppc.")) {
+      if (name.startsWith("com.carrotsearch.hppc.HashOrderMixing$")) {
         return false;
       }
       return true;

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/AdditionalLibraryIgnoresMatcher.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/AdditionalLibraryIgnoresMatcher.java
@@ -33,13 +33,13 @@ public class AdditionalLibraryIgnoresMatcher<T extends TypeDescription>
         || name.startsWith("com.fasterxml.jackson.")
         || name.startsWith("com.github.mustachejava.")
         || name.startsWith("com.jayway.jsonpath.")
-        || name.startsWith("com.lightbend.lagom")
+        || name.startsWith("com.lightbend.lagom.")
         || name.startsWith("javax.el.")
         || name.startsWith("net.sf.cglib.")
-        || name.startsWith("org.apache.lucene")
-        || name.startsWith("org.apache.tartarus")
-        || name.startsWith("org.json.simple")
-        || name.startsWith("org.yaml.snakeyaml")) {
+        || name.startsWith("org.apache.lucene.")
+        || name.startsWith("org.apache.tartarus.")
+        || name.startsWith("org.json.simple.")
+        || name.startsWith("org.yaml.snakeyaml.")) {
       return true;
     }
 

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/AdditionalLibraryIgnoresMatcher.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/AdditionalLibraryIgnoresMatcher.java
@@ -218,7 +218,7 @@ public class AdditionalLibraryIgnoresMatcher<T extends TypeDescription>
       return true;
     }
     if (name.startsWith("com.google.api.")) {
-      if (name.equals("com.google.api.client.http.HttpRequest")) {
+      if (name.startsWith("com.google.api.client.http.HttpRequest")) {
         return false;
       }
       return true;

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/AdditionalLibraryIgnoresMatcher.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/AdditionalLibraryIgnoresMatcher.java
@@ -29,7 +29,6 @@ public class AdditionalLibraryIgnoresMatcher<T extends TypeDescription>
 
     if (name.startsWith("com.beust.jcommander.")
         || name.startsWith("com.fasterxml.classmate.")
-        || name.startsWith("com.fasterxml.jackson.")
         || name.startsWith("com.github.mustachejava.")
         || name.startsWith("com.jayway.jsonpath.")
         || name.startsWith("com.lightbend.lagom.")
@@ -49,7 +48,6 @@ public class AdditionalLibraryIgnoresMatcher<T extends TypeDescription>
           || name.startsWith("org.springframework.ejb.")
           || name.startsWith("org.springframework.expression.")
           || name.startsWith("org.springframework.format.")
-          || name.startsWith("org.springframework.instrument.")
           || name.startsWith("org.springframework.jca.")
           || name.startsWith("org.springframework.jdbc.")
           || name.startsWith("org.springframework.jms.")
@@ -69,8 +67,11 @@ public class AdditionalLibraryIgnoresMatcher<T extends TypeDescription>
       }
 
       if (name.startsWith("org.springframework.data.")) {
-        if (name.equals(
-            "org.springframework.data.repository.core.support.RepositoryFactorySupport")) {
+        if (name.equals("org.springframework.data.repository.core.support.RepositoryFactorySupport")
+            || name.startsWith(
+                "org.springframework.data.convert.ClassGeneratingEntityInstantiator$")
+            || name.equals(
+                "org.springframework.data.jpa.repository.config.InspectionClassLoader")) {
           return false;
         }
         return true;
@@ -98,7 +99,9 @@ public class AdditionalLibraryIgnoresMatcher<T extends TypeDescription>
             || name.startsWith("org.springframework.boot.autoconfigure.condition.OnClassCondition$")
             || name.startsWith("org.springframework.boot.web.embedded.netty.NettyWebServer$")
             || name.startsWith(
-                "org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainer$")) {
+                "org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainer$")
+            || name.equals(
+                "org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedWebappClassLoader")) {
           return false;
         }
         return true;
@@ -116,14 +119,25 @@ public class AdditionalLibraryIgnoresMatcher<T extends TypeDescription>
 
       if (name.startsWith("org.springframework.context.")) {
         // More runnables to deal with
-        if (name.startsWith("org.springframework.context.support.AbstractApplicationContext$")) {
+        if (name.startsWith("org.springframework.context.support.AbstractApplicationContext$")
+            || name.equals("org.springframework.context.support.ContextTypeMatchClassLoader")) {
           return false;
         }
         return true;
       }
 
       if (name.startsWith("org.springframework.core.")) {
-        if (name.startsWith("org.springframework.core.task.")) {
+        if (name.startsWith("org.springframework.core.task.")
+            || name.equals("org.springframework.core.DecoratingClassLoader")
+            || name.equals("org.springframework.core.OverridingClassLoader")) {
+          return false;
+        }
+        return true;
+      }
+
+      if (name.startsWith("org.springframework.instrument.")) {
+        if (name.equals("org.springframework.instrument.classloading.SimpleThrowawayClassLoader")
+            || name.equals("org.springframework.instrument.classloading.ShadowingClassLoader")) {
           return false;
         }
         return true;
@@ -219,7 +233,8 @@ public class AdditionalLibraryIgnoresMatcher<T extends TypeDescription>
     }
     if (name.startsWith("com.google.inject.")) {
       // We instrument Runnable there
-      if (name.startsWith("com.google.inject.internal.AbstractBindingProcessor$")) {
+      if (name.startsWith("com.google.inject.internal.AbstractBindingProcessor$")
+          || name.startsWith("com.google.inject.internal.BytecodeGen$")) {
         return false;
       }
       return true;
@@ -247,6 +262,13 @@ public class AdditionalLibraryIgnoresMatcher<T extends TypeDescription>
 
     if (name.startsWith("com.carrotsearch.hppc.")) {
       if (name.startsWith("com.carrotsearch.hppc.HashOrderMixing$")) {
+        return false;
+      }
+      return true;
+    }
+
+    if (name.startsWith("com.fasterxml.jackson.")) {
+      if (name.equals("com.fasterxml.jackson.module.afterburner.util.MyClassLoader")) {
         return false;
       }
       return true;

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/AdditionalLibraryIgnoresMatcher.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/AdditionalLibraryIgnoresMatcher.java
@@ -96,7 +96,10 @@ public class AdditionalLibraryIgnoresMatcher<T extends TypeDescription>
       if (name.startsWith("org.springframework.boot.")) {
         // More runnables to deal with
         if (name.startsWith("org.springframework.boot.autoconfigure.BackgroundPreinitializer$")
-            || name.startsWith("org.springframework.boot.web.embedded.netty.NettyWebServer$")) {
+            || name.startsWith("org.springframework.boot.autoconfigure.condition.OnClassCondition$")
+            || name.startsWith("org.springframework.boot.web.embedded.netty.NettyWebServer$")
+            || name.startsWith(
+                "org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainer$")) {
           return false;
         }
         return true;
@@ -144,7 +147,8 @@ public class AdditionalLibraryIgnoresMatcher<T extends TypeDescription>
 
       if (name.startsWith("org.springframework.web.")) {
         if (name.startsWith("org.springframework.web.servlet.")
-            || name.startsWith("org.springframework.web.reactive.")) {
+            || name.startsWith("org.springframework.web.reactive.")
+            || name.startsWith("org.springframework.web.context.request.async.")) {
           return false;
         }
         return true;

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/AdditionalLibraryIgnoresMatcher.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/AdditionalLibraryIgnoresMatcher.java
@@ -181,13 +181,6 @@ public class AdditionalLibraryIgnoresMatcher<T extends TypeDescription>
       return true;
     }
 
-    if (name.startsWith("com.datastax.driver.")) {
-      if (name.startsWith("com.datastax.driver.core.Cluster$")) {
-        return false;
-      }
-      return true;
-    }
-
     if (name.startsWith("com.couchbase.client.deps.")) {
       // Couchbase library includes some packaged dependencies, unfortunately some of them are
       // instrumented by java-concurrent instrumentation

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/AdditionalLibraryIgnoresMatcher.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/AdditionalLibraryIgnoresMatcher.java
@@ -234,7 +234,8 @@ public class AdditionalLibraryIgnoresMatcher<T extends TypeDescription>
           || name.startsWith("org.h2.jdbcx.")
           // Some runnables that get instrumented
           || name.equals("org.h2.store.FileLock")
-          || name.equals("org.h2.engine.DatabaseCloser")) {
+          || name.equals("org.h2.engine.DatabaseCloser")
+          || name.equals("org.h2.engine.OnExitDatabaseCloser")) {
         return false;
       }
       return true;

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/AdditionalLibraryIgnoresMatcher.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/AdditionalLibraryIgnoresMatcher.java
@@ -236,6 +236,7 @@ public class AdditionalLibraryIgnoresMatcher<T extends TypeDescription>
           || name.startsWith("org.h2.jdbc.")
           || name.startsWith("org.h2.jdbcx.")
           // Some runnables that get instrumented
+          || name.equals("org.h2.util.Task")
           || name.equals("org.h2.store.FileLock")
           || name.equals("org.h2.engine.DatabaseCloser")
           || name.equals("org.h2.engine.OnExitDatabaseCloser")) {

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/AdditionalLibraryIgnoresMatcher.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/AdditionalLibraryIgnoresMatcher.java
@@ -39,14 +39,12 @@ public class AdditionalLibraryIgnoresMatcher<T extends TypeDescription>
         || name.startsWith("org.apache.lucene")
         || name.startsWith("org.apache.tartarus")
         || name.startsWith("org.json.simple")
-        || name.startsWith("org.objectweb.asm.")
         || name.startsWith("org.yaml.snakeyaml")) {
       return true;
     }
 
     if (name.startsWith("org.springframework.")) {
       if (name.startsWith("org.springframework.aop.")
-          || name.startsWith("org.springframework.asm.")
           || name.startsWith("org.springframework.cache.")
           || name.startsWith("org.springframework.dao.")
           || name.startsWith("org.springframework.ejb.")

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/AdditionalLibraryIgnoresMatcher.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/AdditionalLibraryIgnoresMatcher.java
@@ -29,7 +29,6 @@ public class AdditionalLibraryIgnoresMatcher<T extends TypeDescription>
 
     if (name.startsWith("com.beust.jcommander.")
         || name.startsWith("com.carrotsearch.hppc.")
-        || name.startsWith("com.couchbase.client.deps.")
         || name.startsWith("com.fasterxml.classmate.")
         || name.startsWith("com.fasterxml.jackson.")
         || name.startsWith("com.github.mustachejava.")
@@ -184,6 +183,17 @@ public class AdditionalLibraryIgnoresMatcher<T extends TypeDescription>
 
     if (name.startsWith("com.datastax.driver.")) {
       if (name.startsWith("com.datastax.driver.core.Cluster$")) {
+        return false;
+      }
+      return true;
+    }
+
+    if (name.startsWith("com.couchbase.client.deps.")) {
+      // Couchbase library includes some packaged dependencies, unfortunately some of them are
+      // instrumented by java-concurrent instrumentation
+      if (name.startsWith("com.couchbase.client.deps.io.netty.")
+          || name.startsWith("com.couchbase.client.deps.org.LatencyUtils.")
+          || name.startsWith("com.couchbase.client.deps.com.lmax.disruptor.")) {
         return false;
       }
       return true;

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/AdditionalLibraryIgnoresMatcher.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/AdditionalLibraryIgnoresMatcher.java
@@ -65,7 +65,6 @@ public class AdditionalLibraryIgnoresMatcher<T extends TypeDescription>
           || name.startsWith("org.springframework.stereotype.")
           || name.startsWith("org.springframework.transaction.")
           || name.startsWith("org.springframework.ui.")
-          || name.startsWith("org.springframework.util.")
           || name.startsWith("org.springframework.validation.")) {
         return true;
       }
@@ -131,6 +130,13 @@ public class AdditionalLibraryIgnoresMatcher<T extends TypeDescription>
       if (name.startsWith("org.springframework.http.")) {
         // There are some Mono implementation that get instrumented
         if (name.startsWith("org.springframework.http.server.reactive.")) {
+          return false;
+        }
+        return true;
+      }
+
+      if (name.startsWith("org.springframework.util.")) {
+        if (name.startsWith("org.springframework.util.concurrent.")) {
           return false;
         }
         return true;

--- a/dd-java-agent/instrumentation/akka-http-10.0/akka-http-10.0.gradle
+++ b/dd-java-agent/instrumentation/akka-http-10.0/akka-http-10.0.gradle
@@ -80,25 +80,17 @@ dependencies {
 
   testCompile group: 'com.typesafe.akka', name: 'akka-http_2.11', version: '10.0.0'
   testCompile group: 'com.squareup.okhttp3', name: 'okhttp', version: '3.6.0'
-  testCompile project(':dd-java-agent:instrumentation:java-concurrent')
   testCompile project(':dd-java-agent:instrumentation:trace-annotation')
 
   lagomTestCompile project(':dd-java-agent:instrumentation:akka-http-10.0')
-  lagomTestCompile project(':dd-java-agent:instrumentation:trace-annotation')
-  lagomTestCompile project(':dd-java-agent:instrumentation:java-concurrent')
-
   lagomTestCompile group: 'com.lightbend.lagom', name: 'lagom-javadsl-testkit_2.11', version: '1.4.0'
 
   // There are some internal API changes in 10.1 that we would like to test separately for
   version101TestCompile group: 'com.typesafe.akka', name: 'akka-http_2.11', version: '10.1.0'
   version101TestCompile group: 'com.typesafe.akka', name: 'akka-stream_2.11', version: '2.5.11'
-  version101TestCompile project(':dd-java-agent:instrumentation:java-concurrent')
-  version101TestCompile project(':dd-java-agent:instrumentation:trace-annotation')
 
   latestDepTestCompile group: 'com.typesafe.akka', name: 'akka-http_2.11', version: '+'
   latestDepTestCompile group: 'com.typesafe.akka', name: 'akka-stream_2.11', version: '+'
-  latestDepTestCompile project(':dd-java-agent:instrumentation:java-concurrent')
-  latestDepTestCompile project(':dd-java-agent:instrumentation:trace-annotation')
 }
 
 test.dependsOn lagomTest

--- a/dd-java-agent/instrumentation/apache-httpasyncclient-4/apache-httpasyncclient-4.gradle
+++ b/dd-java-agent/instrumentation/apache-httpasyncclient-4/apache-httpasyncclient-4.gradle
@@ -22,9 +22,7 @@ testSets {
 
 dependencies {
   compileOnly group: 'org.apache.httpcomponents', name: 'httpasyncclient', version: '4.0'
-
-  testCompile project(':dd-java-agent:instrumentation:java-concurrent')
-
+  
   testCompile group: 'org.apache.httpcomponents', name: 'httpasyncclient', version: '4.0'
 
   latestDepTestCompile group: 'org.apache.httpcomponents', name: 'httpasyncclient', version: '+'

--- a/dd-java-agent/instrumentation/aws-java-sdk-2.2/aws-java-sdk-2.2.gradle
+++ b/dd-java-agent/instrumentation/aws-java-sdk-2.2/aws-java-sdk-2.2.gradle
@@ -26,8 +26,6 @@ dependencies {
   testCompile project(':dd-java-agent:instrumentation:apache-httpclient-4')
   // Also include netty instrumentation because it is used by aws async client
   testCompile project(':dd-java-agent:instrumentation:netty-4.1')
-  // Needed by netty async instrumentation
-  testCompile project(':dd-java-agent:instrumentation:java-concurrent')
   testCompile group: 'software.amazon.awssdk', name: 'apache-client', version: '2.2.0'
   testCompile group: 'software.amazon.awssdk', name: 's3', version: '2.2.0'
   testCompile group: 'software.amazon.awssdk', name: 'rds', version: '2.2.0'
@@ -38,7 +36,6 @@ dependencies {
 
   latestDepTestCompile project(':dd-java-agent:instrumentation:apache-httpclient-4')
   latestDepTestCompile project(':dd-java-agent:instrumentation:netty-4.1')
-  latestDepTestCompile project(':dd-java-agent:instrumentation:java-concurrent')
 
   latestDepTestCompile group: 'software.amazon.awssdk', name: 'apache-client', version: '+'
   latestDepTestCompile group: 'software.amazon.awssdk', name: 's3', version: '+'

--- a/dd-java-agent/instrumentation/cdi-1.2/cdi-1.2.gradle
+++ b/dd-java-agent/instrumentation/cdi-1.2/cdi-1.2.gradle
@@ -9,8 +9,6 @@ testSets {
 }
 
 dependencies {
-  testCompile project(':dd-java-agent:instrumentation:java-concurrent')
-  
   testCompile group: 'org.jboss.weld', name: 'weld-core', version: '2.3.0.Final'
   testCompile group: 'org.jboss.weld.se', name: 'weld-se', version: '2.3.0.Final'
   testCompile group: 'org.jboss.weld.se', name: 'weld-se-core', version: '2.3.0.Final'

--- a/dd-java-agent/instrumentation/dropwizard/dropwizard.gradle
+++ b/dd-java-agent/instrumentation/dropwizard/dropwizard.gradle
@@ -9,7 +9,6 @@ apply from: "${rootDir}/gradle/java.gradle"
 //}
 
 dependencies {
-  testCompile project(':dd-java-agent:instrumentation:java-concurrent')
   testCompile project(':dd-java-agent:instrumentation:jax-rs-annotations-2')
   testCompile project(':dd-java-agent:instrumentation:servlet:request-3')
 

--- a/dd-java-agent/instrumentation/finatra-2.9/finatra-2.9.gradle
+++ b/dd-java-agent/instrumentation/finatra-2.9/finatra-2.9.gradle
@@ -34,18 +34,14 @@ dependencies {
   compileOnly group: 'com.twitter', name: 'finatra-http_2.11', version: '2.9.0'
 
   testCompile project(':dd-java-agent:instrumentation:netty-4.1')
-  testCompile project(':dd-java-agent:instrumentation:java-concurrent')
 
   testCompile group: 'com.twitter', name: 'finatra-http_2.11', version: '19.12.0'
   testCompile(group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.9.10') {
     force = true
   }
-
   // Required for older versions of finatra on JDKs >= 11
   testCompile group: 'com.sun.activation', name: 'javax.activation', version: '1.2.0'
 
-  latestDepTestCompile project(':dd-java-agent:instrumentation:netty-4.1')
-  latestDepTestCompile project(':dd-java-agent:instrumentation:java-concurrent')
   latestDepTestCompile group: 'com.twitter', name: 'finatra-http_2.11', version: '+'
 }
 

--- a/dd-java-agent/instrumentation/grizzly-2/grizzly-2.gradle
+++ b/dd-java-agent/instrumentation/grizzly-2/grizzly-2.gradle
@@ -22,8 +22,6 @@ testSets {
 dependencies {
   compileOnly group: 'org.glassfish.grizzly', name: 'grizzly-http-server', version: '2.0'
 
-  testCompile project(':dd-java-agent:instrumentation:java-concurrent')
-
   testCompile group: 'javax.xml.bind', name: 'jaxb-api', version: '2.2.3'
   testCompile group: 'javax.ws.rs', name: 'javax.ws.rs-api', version: '2.0'
   testCompile group: 'org.glassfish.grizzly', name: 'grizzly-http-server', version: '2.0'

--- a/dd-java-agent/instrumentation/grpc-1.5/grpc-1.5.gradle
+++ b/dd-java-agent/instrumentation/grpc-1.5/grpc-1.5.gradle
@@ -49,8 +49,6 @@ dependencies {
   testCompile group: 'io.grpc', name: 'grpc-stub', version: grpcVersion
   testCompile group: 'javax.annotation', name: 'javax.annotation-api', version: '1.3.2'
 
-  testCompile project(':dd-java-agent:instrumentation:java-concurrent')
-
   latestDepTestCompile sourceSets.test.output // include the protobuf generated classes
   latestDepTestCompile group: 'io.grpc', name: 'grpc-netty', version: '+'
   latestDepTestCompile group: 'io.grpc', name: 'grpc-protobuf', version: '+'

--- a/dd-java-agent/instrumentation/hystrix-1.4/hystrix-1.4.gradle
+++ b/dd-java-agent/instrumentation/hystrix-1.4/hystrix-1.4.gradle
@@ -22,7 +22,6 @@ dependencies {
   compileOnly group: 'com.netflix.hystrix', name: 'hystrix-core', version: '1.4.0'
   compileOnly group: 'io.reactivex', name: 'rxjava', version: '1.0.7'
 
-  testCompile project(':dd-java-agent:instrumentation:java-concurrent')
   testCompile project(':dd-java-agent:instrumentation:trace-annotation')
 
   testCompile group: 'io.reactivex', name: 'rxjava', version: '1.0.7'

--- a/dd-java-agent/instrumentation/hystrix-1.4/src/test/groovy/HystrixObservableTest.groovy
+++ b/dd-java-agent/instrumentation/hystrix-1.4/src/test/groovy/HystrixObservableTest.groovy
@@ -16,7 +16,7 @@ import static com.netflix.hystrix.HystrixCommandGroupKey.Factory.asKey
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 
 @Retry
-@Timeout(5)
+@Timeout(10)
 class HystrixObservableTest extends AgentTestRunner {
   static {
     // Disable so failure testing below doesn't inadvertently change the behavior.

--- a/dd-java-agent/instrumentation/instrumentation.gradle
+++ b/dd-java-agent/instrumentation/instrumentation.gradle
@@ -56,6 +56,8 @@ subprojects { Project subProj ->
       annotationProcessor deps.autoservice
       implementation deps.autoservice
 
+      // Always include concurrent instrumentation dependency to make sure that all instrumentations are tested with async parts instrumented
+      testCompile project(':dd-java-agent:instrumentation:java-concurrent')
       testCompile project(':dd-java-agent:testing')
       testAnnotationProcessor deps.autoservice
       testImplementation deps.autoservice

--- a/dd-java-agent/instrumentation/instrumentation.gradle
+++ b/dd-java-agent/instrumentation/instrumentation.gradle
@@ -56,8 +56,12 @@ subprojects { Project subProj ->
       annotationProcessor deps.autoservice
       implementation deps.autoservice
 
-      // Always include concurrent instrumentation dependency to make sure that all instrumentations are tested with async parts instrumented
+      // Include instrumentations instrumenting core JDK classes tp ensure interoperability with other instrumentation
       testCompile project(':dd-java-agent:instrumentation:java-concurrent')
+      // FIXME: we should enable this, but currently this fails tests for google http client
+      //testCompile project(':dd-java-agent:instrumentation:http-url-connection')
+      testCompile project(':dd-java-agent:instrumentation:classloading')
+
       testCompile project(':dd-java-agent:testing')
       testAnnotationProcessor deps.autoservice
       testImplementation deps.autoservice

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/CallableInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/CallableInstrumentation.java
@@ -1,0 +1,75 @@
+package datadog.trace.instrumentation.java.concurrent;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers.implementsInterface;
+import static net.bytebuddy.matcher.ElementMatchers.isPublic;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.bootstrap.ContextStore;
+import datadog.trace.bootstrap.InstrumentationContext;
+import datadog.trace.bootstrap.instrumentation.java.concurrent.State;
+import datadog.trace.context.TraceScope;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import lombok.extern.slf4j.Slf4j;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+/** Instrument {@link Runnable} and {@Callable} */
+@Slf4j
+@AutoService(Instrumenter.class)
+public final class CallableInstrumentation extends Instrumenter.Default {
+
+  public CallableInstrumentation() {
+    super(AbstractExecutorInstrumentation.EXEC_NAME);
+  }
+
+  @Override
+  public ElementMatcher<TypeDescription> typeMatcher() {
+    return implementsInterface(named(Callable.class.getName()));
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {
+      AdviceUtils.class.getName(),
+    };
+  }
+
+  @Override
+  public Map<String, String> contextStore() {
+    final Map<String, String> map = new HashMap<>();
+    map.put(Callable.class.getName(), State.class.getName());
+    return Collections.unmodifiableMap(map);
+  }
+
+  @Override
+  public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
+    final Map<ElementMatcher<? super MethodDescription>, String> transformers = new HashMap<>();
+    transformers.put(
+        named("call").and(takesArguments(0)).and(isPublic()),
+        CallableInstrumentation.class.getName() + "$CallableAdvice");
+    return transformers;
+  }
+
+  public static class CallableAdvice {
+
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static TraceScope enter(@Advice.This final Callable thiz) {
+      final ContextStore<Callable, State> contextStore =
+          InstrumentationContext.get(Callable.class, State.class);
+      return AdviceUtils.startTaskScope(contextStore, thiz);
+    }
+
+    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
+    public static void exit(@Advice.Enter final TraceScope scope) {
+      AdviceUtils.endTaskScope(scope);
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/jax-rs-annotations-2/jax-rs-annotations-2.gradle
+++ b/dd-java-agent/instrumentation/jax-rs-annotations-2/jax-rs-annotations-2.gradle
@@ -28,7 +28,6 @@ testSets {
 dependencies {
   compileOnly group: 'javax.ws.rs', name: 'javax.ws.rs-api', version: '2.0'
 
-  testCompile project(':dd-java-agent:instrumentation:java-concurrent')
   testCompile project(':dd-java-agent:instrumentation:servlet:request-3')
   testCompile project(':dd-java-agent:instrumentation:jax-rs-annotations-2:filter-jersey')
   testCompile project(':dd-java-agent:instrumentation:jax-rs-annotations-2:filter-resteasy-3.0')
@@ -41,14 +40,14 @@ dependencies {
   testCompile group: 'com.fasterxml.jackson.module', name: 'jackson-module-afterburner', version: '2.9.10'
 
   latestDepTestCompile group: 'io.dropwizard', name: 'dropwizard-testing', version: '1.+'
-  
+
   // Resteasy
   testCompile group: 'org.jboss.resteasy', name: 'resteasy-jaxrs', version: '3.0.0.Final'
-  
+
   resteasy31TestCompile(group: 'org.jboss.resteasy', name: 'resteasy-jaxrs', version: '3.1.0.Final') {
     force = true
   }
-  
+
   latestDepTestCompile group: 'org.jboss.resteasy', name: 'resteasy-jaxrs', version: '+'
 }
 

--- a/dd-java-agent/instrumentation/jax-rs-client-2.0/jax-rs-client-2.0.gradle
+++ b/dd-java-agent/instrumentation/jax-rs-client-2.0/jax-rs-client-2.0.gradle
@@ -27,8 +27,6 @@ dependencies {
   compileOnly group: 'javax.ws.rs', name: 'javax.ws.rs-api', version: '2.0.1'
   compileOnly group: 'javax.annotation', name: 'javax.annotation-api', version: '1.2'
 
-  testCompile project(':dd-java-agent:instrumentation:java-concurrent')
-
   testCompile project(':dd-java-agent:instrumentation:jax-rs-client-2.0:connection-error-handling-jersey')
   testCompile project(':dd-java-agent:instrumentation:jax-rs-client-2.0:connection-error-handling-resteasy')
 

--- a/dd-java-agent/instrumentation/jetty-8/jetty-8.gradle
+++ b/dd-java-agent/instrumentation/jetty-8/jetty-8.gradle
@@ -24,7 +24,6 @@ dependencies {
   testCompile(project(':dd-java-agent:testing')) {
     exclude group: 'org.eclipse.jetty', module: 'jetty-server'
   }
-  testCompile project(':dd-java-agent:instrumentation:java-concurrent')
 
   testCompile group: 'org.eclipse.jetty', name: 'jetty-server', version: '8.0.0.v20110901'
   testCompile group: 'org.eclipse.jetty', name: 'jetty-servlet', version: '8.0.0.v20110901'

--- a/dd-java-agent/instrumentation/netty-4.0/netty-4.0.gradle
+++ b/dd-java-agent/instrumentation/netty-4.0/netty-4.0.gradle
@@ -43,8 +43,6 @@ testSets {
 dependencies {
   compileOnly group: 'io.netty', name: 'netty-codec-http', version: '4.0.0.Final'
 
-  testCompile project(':dd-java-agent:instrumentation:java-concurrent')
-
   testCompile group: 'io.netty', name: 'netty-codec-http', version: '4.0.0.Final'
   testCompile group: 'org.asynchttpclient', name: 'async-http-client', version: '2.0.0'
 

--- a/dd-java-agent/instrumentation/netty-4.1/netty-4.1.gradle
+++ b/dd-java-agent/instrumentation/netty-4.1/netty-4.1.gradle
@@ -42,7 +42,6 @@ testSets {
 dependencies {
   compileOnly group: 'io.netty', name: 'netty-codec-http', version: '4.1.0.Final'
 
-  testCompile project(':dd-java-agent:instrumentation:java-concurrent')
   testCompile project(':dd-java-agent:instrumentation:trace-annotation')
   testCompile group: 'io.netty', name: 'netty-codec-http', version: '4.1.0.Final'
   testCompile group: 'org.asynchttpclient', name: 'async-http-client', version: '2.1.0'

--- a/dd-java-agent/instrumentation/play-2.4/play-2.4.gradle
+++ b/dd-java-agent/instrumentation/play-2.4/play-2.4.gradle
@@ -36,7 +36,6 @@ testSets {
 dependencies {
   main_java8Compile group: 'com.typesafe.play', name: 'play_2.11', version: '2.4.0'
 
-  testCompile project(':dd-java-agent:instrumentation:java-concurrent')
   testCompile project(':dd-java-agent:instrumentation:netty-4.0')
   testCompile project(':dd-java-agent:instrumentation:netty-4.1')
   testCompile project(':dd-java-agent:instrumentation:akka-http-10.0')

--- a/dd-java-agent/instrumentation/play-2.6/play-2.6.gradle
+++ b/dd-java-agent/instrumentation/play-2.6/play-2.6.gradle
@@ -41,7 +41,6 @@ testSets {
 dependencies {
   main_java8Compile group: 'com.typesafe.play', name: "play_$scalaVersion", version: playVersion
 
-  testCompile project(':dd-java-agent:instrumentation:java-concurrent')
   testCompile project(':dd-java-agent:instrumentation:netty-4.0')
   testCompile project(':dd-java-agent:instrumentation:netty-4.1')
   testCompile project(':dd-java-agent:instrumentation:akka-http-10.0')

--- a/dd-java-agent/instrumentation/play-ws-1/play-ws-1.gradle
+++ b/dd-java-agent/instrumentation/play-ws-1/play-ws-1.gradle
@@ -41,8 +41,6 @@ dependencies {
   compile project(':dd-java-agent:instrumentation:play-ws')
   testCompile project(path: ':dd-java-agent:instrumentation:play-ws', configuration: 'testArtifacts')
 
-  testCompile project(':dd-java-agent:instrumentation:java-concurrent')
-
   // These are to ensure cross compatibility
   testCompile project(':dd-java-agent:instrumentation:netty-4.0')
   testCompile project(':dd-java-agent:instrumentation:netty-4.1')

--- a/dd-java-agent/instrumentation/play-ws-2.1/play-ws-2.1.gradle
+++ b/dd-java-agent/instrumentation/play-ws-2.1/play-ws-2.1.gradle
@@ -64,8 +64,6 @@ dependencies {
   compile project(':dd-java-agent:instrumentation:play-ws')
   testCompile project(path: ':dd-java-agent:instrumentation:play-ws', configuration: 'testArtifacts')
 
-  testCompile project(':dd-java-agent:instrumentation:java-concurrent')
-
   // These are to ensure cross compatibility
   testCompile project(':dd-java-agent:instrumentation:netty-4.0')
   testCompile project(':dd-java-agent:instrumentation:netty-4.1')

--- a/dd-java-agent/instrumentation/play-ws-2/play-ws-2.gradle
+++ b/dd-java-agent/instrumentation/play-ws-2/play-ws-2.gradle
@@ -64,14 +64,12 @@ dependencies {
   compile project(':dd-java-agent:instrumentation:play-ws')
   testCompile project(path: ':dd-java-agent:instrumentation:play-ws', configuration: 'testArtifacts')
 
-  testCompile project(':dd-java-agent:instrumentation:java-concurrent')
-
   // These are to ensure cross compatibility
   testCompile project(':dd-java-agent:instrumentation:netty-4.0')
   testCompile project(':dd-java-agent:instrumentation:netty-4.1')
   testCompile project(':dd-java-agent:instrumentation:akka-http-10.0')
 
   testCompile group: 'com.typesafe.play', name: "play-ahc-ws-standalone_$scalaVersion", version: '2.0.0'
-  
+
   latestDepTestCompile group: 'com.typesafe.play', name: "play-ahc-ws-standalone_$scalaVersion", version: '2.0.+'
 }

--- a/dd-java-agent/instrumentation/ratpack-1.4/ratpack-1.4.gradle
+++ b/dd-java-agent/instrumentation/ratpack-1.4/ratpack-1.4.gradle
@@ -31,7 +31,6 @@ testSets {
 dependencies {
   main_java8CompileOnly group: 'io.ratpack', name: 'ratpack-core', version: '1.4.0'
 
-  testCompile project(':dd-java-agent:instrumentation:java-concurrent')
   testCompile project(':dd-java-agent:instrumentation:netty-4.1')
   testCompile group: 'io.ratpack', name: 'ratpack-groovy-test', version: '1.4.0'
   latestDepTestCompile group: 'io.ratpack', name: 'ratpack-groovy-test', version: '+'

--- a/dd-java-agent/instrumentation/reactor-core-3.1/reactor-core-3.1.gradle
+++ b/dd-java-agent/instrumentation/reactor-core-3.1/reactor-core-3.1.gradle
@@ -27,7 +27,6 @@ dependencies {
   main_java8CompileOnly group: 'io.projectreactor', name: 'reactor-core', version: '3.1.0.RELEASE'
 
   testCompile project(':dd-java-agent:instrumentation:trace-annotation')
-  testCompile project(':dd-java-agent:instrumentation:java-concurrent')
 
   testCompile group: 'io.projectreactor', name: 'reactor-core', version: '3.1.0.RELEASE'
 

--- a/dd-java-agent/instrumentation/servlet/request-3/request-3.gradle
+++ b/dd-java-agent/instrumentation/servlet/request-3/request-3.gradle
@@ -28,7 +28,6 @@ dependencies {
   testCompile(project(':dd-java-agent:testing')) {
     exclude group: 'org.eclipse.jetty', module: 'jetty-server'
   }
-  testCompile project(':dd-java-agent:instrumentation:java-concurrent')
   testCompile project(':dd-java-agent:instrumentation:jetty-8') // See if there's any conflicts.
   testCompile group: 'org.eclipse.jetty', name: 'jetty-server', version: '8.2.0.v20160908'
   testCompile group: 'org.eclipse.jetty', name: 'jetty-servlet', version: '8.2.0.v20160908'

--- a/dd-java-agent/instrumentation/spring-webflux-5/spring-webflux-5.gradle
+++ b/dd-java-agent/instrumentation/spring-webflux-5/spring-webflux-5.gradle
@@ -32,7 +32,6 @@ dependencies {
   // TODO: It is unclear why we need to use `compile` here (instead of 'compileOnly')
   compile project(':dd-java-agent:instrumentation:reactor-core-3.1')
 
-  testCompile project(':dd-java-agent:instrumentation:java-concurrent')
   testCompile project(':dd-java-agent:instrumentation:trace-annotation')
   testCompile project(':dd-java-agent:instrumentation:netty-4.1')
   testCompile project(':dd-java-agent:instrumentation:reactor-core-3.1')

--- a/dd-java-agent/instrumentation/twilio/twilio.gradle
+++ b/dd-java-agent/instrumentation/twilio/twilio.gradle
@@ -19,7 +19,6 @@ dependencies {
 
   testCompile group: 'com.twilio.sdk', name: 'twilio', version: '0.0.1'
   testCompile project(':dd-java-agent:instrumentation:apache-httpclient-4')
-  testCompile project(':dd-java-agent:instrumentation:java-concurrent')
   testCompile group: 'nl.jqno.equalsverifier', name: 'equalsverifier', version: '2.5.2' // Last version to support Java7
 
   latestDepTestCompile group: 'com.twilio.sdk', name: 'twilio', version: '+'

--- a/dd-java-agent/instrumentation/vertx/vertx.gradle
+++ b/dd-java-agent/instrumentation/vertx/vertx.gradle
@@ -20,7 +20,6 @@ dependencies {
 //  compileOnly group: 'io.vertx', name: 'vertx-web', version: '3.5.0'
 
   testCompile project(':dd-java-agent:instrumentation:netty-4.1')
-  testCompile project(':dd-java-agent:instrumentation:java-concurrent')
   testCompile project(':dd-java-agent:instrumentation:trace-annotation')
 
   // Tests seem to fail before 3.5... maybe a problem with some of the tests?


### PR DESCRIPTION
Include `java-concurrent` instrumentation in all instrumentations when running tests.

This has uncovered bugs in `java-concurrent` instrumentation and `grpc` instrumentation which should also be fixed by this PR.