### PR TITLE
Revert removal of non-delegating loader check

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/ClassLoaderMatcher.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/ClassLoaderMatcher.java
@@ -36,6 +36,9 @@ public final class ClassLoaderMatcher {
   private static final class SkipClassLoaderMatcher
       extends ElementMatcher.Junction.AbstractBase<ClassLoader> {
     public static final SkipClassLoaderMatcher INSTANCE = new SkipClassLoaderMatcher();
+    /* Cache of classloader-instance -> (true|false). True = skip instrumentation. False = safe to instrument. */
+    private static final Cache<ClassLoader, Boolean> skipCache =
+        CacheBuilder.newBuilder().weakKeys().concurrencyLevel(CACHE_CONCURRENCY).build();
     private static final String DATADOG_CLASSLOADER_NAME =
         "datadog.trace.bootstrap.DatadogClassLoader";
 
@@ -47,7 +50,13 @@ public final class ClassLoaderMatcher {
         // Don't skip bootstrap loader
         return false;
       }
-      return shouldSkipClass(cl);
+      Boolean v = skipCache.getIfPresent(cl);
+      if (v != null) {
+        return v;
+      }
+      v = shouldSkipClass(cl);
+      skipCache.put(cl, v);
+      return v;
     }
 
     private static boolean shouldSkipClass(final ClassLoader loader) {

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/ClassLoaderMatcher.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/ClassLoaderMatcher.java
@@ -56,6 +56,14 @@ public final class ClassLoaderMatcher {
       if (v != null) {
         return v;
       }
+      // when ClassloadingInstrumentation is active, checking delegatesToBootstrap() below is not
+      // required, because ClassloadingInstrumentation forces all class loaders to load all of the
+      // classes in Constants.BOOTSTRAP_PACKAGE_PREFIXES directly from the bootstrap class loader
+      //
+      // however, at this time we don't want to introduce the concept of a required instrumentation,
+      // and we don't want to introduce the concept of the tooling code depending on whether or not
+      // a particular instrumentation is active (mainly because this particular use case doesn't
+      // seem to justify introducing either of these new concepts)
       v = shouldSkipClass(cl) || !delegatesToBootstrap(cl);
       skipCache.put(cl, v);
       return v;

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/test/ClassLoaderMatcherTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/test/ClassLoaderMatcherTest.groovy
@@ -6,6 +6,13 @@ import datadog.trace.util.test.DDSpecification
 
 class ClassLoaderMatcherTest extends DDSpecification {
 
+  def "skip non-delegating classloader"() {
+    setup:
+    final URLClassLoader badLoader = new NonDelegatingClassLoader()
+    expect:
+    ClassLoaderMatcher.skipClassLoader().matches(badLoader)
+  }
+
   def "skips agent classloader"() {
     setup:
     URL root = new URL("file://")
@@ -30,4 +37,23 @@ class ClassLoaderMatcherTest extends DDSpecification {
     expect:
     DatadogClassLoader.name == "datadog.trace.bootstrap.DatadogClassLoader"
   }
+
+  /*
+   * A URLClassloader which only delegates java.* classes
+   */
+
+  private static class NonDelegatingClassLoader extends URLClassLoader {
+    NonDelegatingClassLoader() {
+      super(new URL[0], (ClassLoader) null)
+    }
+
+    @Override
+    Class<?> loadClass(String className) {
+      if (className.startsWith("java.")) {
+        return super.loadClass(className)
+      }
+      throw new ClassNotFoundException(className)
+    }
+  }
+
 }


### PR DESCRIPTION
Reverts #1288, and adds comment explaining why the non-delegating class loader check is being kept