### PR TITLE
Replace OT tags with api tags in decorators

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/ClientDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/ClientDecorator.java
@@ -2,7 +2,7 @@ package datadog.trace.bootstrap.instrumentation.decorator;
 
 import datadog.trace.api.DDTags;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import io.opentracing.tag.Tags;
+import datadog.trace.bootstrap.instrumentation.api.Tags;
 
 public abstract class ClientDecorator extends BaseDecorator {
 
@@ -18,7 +18,7 @@ public abstract class ClientDecorator extends BaseDecorator {
     if (service() != null) {
       span.setTag(DDTags.SERVICE_NAME, service());
     }
-    span.setTag(Tags.SPAN_KIND.getKey(), spanKind());
+    span.setTag(Tags.SPAN_KIND, spanKind());
     return super.afterStart(span);
   }
 }

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/DatabaseClientDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/DatabaseClientDecorator.java
@@ -3,7 +3,7 @@ package datadog.trace.bootstrap.instrumentation.decorator;
 import datadog.trace.api.Config;
 import datadog.trace.api.DDTags;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import io.opentracing.tag.Tags;
+import datadog.trace.bootstrap.instrumentation.api.Tags;
 
 public abstract class DatabaseClientDecorator<CONNECTION> extends ClientDecorator {
 
@@ -16,7 +16,7 @@ public abstract class DatabaseClientDecorator<CONNECTION> extends ClientDecorato
   @Override
   public AgentSpan afterStart(final AgentSpan span) {
     assert span != null;
-    span.setTag(Tags.DB_TYPE.getKey(), dbType());
+    span.setTag(Tags.DB_TYPE, dbType());
     return super.afterStart(span);
   }
 
@@ -30,9 +30,9 @@ public abstract class DatabaseClientDecorator<CONNECTION> extends ClientDecorato
   public AgentSpan onConnection(final AgentSpan span, final CONNECTION connection) {
     assert span != null;
     if (connection != null) {
-      span.setTag(Tags.DB_USER.getKey(), dbUser(connection));
+      span.setTag(Tags.DB_USER, dbUser(connection));
       final String instanceName = dbInstance(connection);
-      span.setTag(Tags.DB_INSTANCE.getKey(), instanceName);
+      span.setTag(Tags.DB_INSTANCE, instanceName);
 
       if (instanceName != null && Config.get().isDbClientSplitByInstance()) {
         span.setTag(DDTags.SERVICE_NAME, instanceName);
@@ -43,7 +43,7 @@ public abstract class DatabaseClientDecorator<CONNECTION> extends ClientDecorato
 
   public AgentSpan onStatement(final AgentSpan span, final String statement) {
     assert span != null;
-    span.setTag(Tags.DB_STATEMENT.getKey(), statement);
+    span.setTag(Tags.DB_STATEMENT, statement);
     return span;
   }
 }

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpClientDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpClientDecorator.java
@@ -4,7 +4,7 @@ import datadog.trace.api.Config;
 import datadog.trace.api.DDSpanTypes;
 import datadog.trace.api.DDTags;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import io.opentracing.tag.Tags;
+import datadog.trace.bootstrap.instrumentation.api.Tags;
 import java.net.URI;
 import java.net.URISyntaxException;
 import lombok.extern.slf4j.Slf4j;
@@ -35,7 +35,7 @@ public abstract class HttpClientDecorator<REQUEST, RESPONSE> extends ClientDecor
   public AgentSpan onRequest(final AgentSpan span, final REQUEST request) {
     assert span != null;
     if (request != null) {
-      span.setTag(Tags.HTTP_METHOD.getKey(), method(request));
+      span.setTag(Tags.HTTP_METHOD, method(request));
 
       // Copy of HttpServerDecorator url handling
       try {
@@ -60,7 +60,7 @@ public abstract class HttpClientDecorator<REQUEST, RESPONSE> extends ClientDecor
             urlNoParams.append(path);
           }
 
-          span.setTag(Tags.HTTP_URL.getKey(), urlNoParams.toString());
+          span.setTag(Tags.HTTP_URL, urlNoParams.toString());
 
           if (Config.get().isHttpClientTagQueryString()) {
             span.setTag(DDTags.HTTP_QUERY, url.getQuery());
@@ -71,11 +71,11 @@ public abstract class HttpClientDecorator<REQUEST, RESPONSE> extends ClientDecor
         log.debug("Error tagging url", e);
       }
 
-      span.setTag(Tags.PEER_HOSTNAME.getKey(), hostname(request));
+      span.setTag(Tags.PEER_HOSTNAME, hostname(request));
       final Integer port = port(request);
       // Negative or Zero ports might represent an unset/null value for an int type.  Skip setting.
       if (port != null && port > 0) {
-        span.setTag(Tags.PEER_PORT.getKey(), port);
+        span.setTag(Tags.PEER_PORT, port);
       }
 
       if (Config.get().isHttpClientSplitByDomain()) {
@@ -90,7 +90,7 @@ public abstract class HttpClientDecorator<REQUEST, RESPONSE> extends ClientDecor
     if (response != null) {
       final Integer status = status(response);
       if (status != null) {
-        span.setTag(Tags.HTTP_STATUS.getKey(), status);
+        span.setTag(Tags.HTTP_STATUS, status);
 
         if (Config.get().getHttpClientErrorStatuses().contains(status)) {
           span.setError(true);

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
@@ -4,7 +4,7 @@ import datadog.trace.api.Config;
 import datadog.trace.api.DDSpanTypes;
 import datadog.trace.api.DDTags;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import io.opentracing.tag.Tags;
+import datadog.trace.bootstrap.instrumentation.api.Tags;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.regex.Pattern;
@@ -42,7 +42,7 @@ public abstract class HttpServerDecorator<REQUEST, CONNECTION, RESPONSE> extends
   public AgentSpan onRequest(final AgentSpan span, final REQUEST request) {
     assert span != null;
     if (request != null) {
-      span.setTag(Tags.HTTP_METHOD.getKey(), method(request));
+      span.setTag(Tags.HTTP_METHOD, method(request));
 
       // Copy of HttpClientDecorator url handling
       try {
@@ -67,7 +67,7 @@ public abstract class HttpServerDecorator<REQUEST, CONNECTION, RESPONSE> extends
             urlNoParams.append(path);
           }
 
-          span.setTag(Tags.HTTP_URL.getKey(), urlNoParams.toString());
+          span.setTag(Tags.HTTP_URL, urlNoParams.toString());
 
           if (Config.get().isHttpServerTagQueryString()) {
             span.setTag(DDTags.HTTP_QUERY, url.getQuery());
@@ -88,15 +88,15 @@ public abstract class HttpServerDecorator<REQUEST, CONNECTION, RESPONSE> extends
       final String ip = peerHostIP(connection);
       if (ip != null) {
         if (VALID_IPV4_ADDRESS.matcher(ip).matches()) {
-          span.setTag(Tags.PEER_HOST_IPV4.getKey(), ip);
+          span.setTag(Tags.PEER_HOST_IPV4, ip);
         } else if (ip.contains(":")) {
-          span.setTag(Tags.PEER_HOST_IPV6.getKey(), ip);
+          span.setTag(Tags.PEER_HOST_IPV6, ip);
         }
       }
       final Integer port = peerPort(connection);
       // Negative or Zero ports might represent an unset/null value for an int type.  Skip setting.
       if (port != null && port > 0) {
-        span.setTag(Tags.PEER_PORT.getKey(), port);
+        span.setTag(Tags.PEER_PORT, port);
       }
     }
     return span;
@@ -107,7 +107,7 @@ public abstract class HttpServerDecorator<REQUEST, CONNECTION, RESPONSE> extends
     if (response != null) {
       final Integer status = status(response);
       if (status != null) {
-        span.setTag(Tags.HTTP_STATUS.getKey(), status);
+        span.setTag(Tags.HTTP_STATUS, status);
 
         if (Config.get().getHttpServerErrorStatuses().contains(status)) {
           span.setError(true);

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/ServerDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/ServerDecorator.java
@@ -2,14 +2,14 @@ package datadog.trace.bootstrap.instrumentation.decorator;
 
 import datadog.trace.api.Config;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import io.opentracing.tag.Tags;
+import datadog.trace.bootstrap.instrumentation.api.Tags;
 
 public abstract class ServerDecorator extends BaseDecorator {
 
   @Override
   public AgentSpan afterStart(final AgentSpan span) {
     assert span != null;
-    span.setTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_SERVER);
+    span.setTag(Tags.SPAN_KIND, Tags.SPAN_KIND_SERVER);
     span.setTag(Config.LANGUAGE_TAG_KEY, Config.LANGUAGE_TAG_VALUE);
     return super.afterStart(span);
   }

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/BaseDecoratorTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/BaseDecoratorTest.groovy
@@ -4,8 +4,8 @@ import datadog.trace.agent.test.utils.ConfigUtils
 import datadog.trace.api.DDTags
 import datadog.trace.bootstrap.instrumentation.api.AgentScope
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan
+import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.util.test.DDSpecification
-import io.opentracing.tag.Tags
 import spock.lang.Shared
 import spock.lang.Timeout
 
@@ -24,7 +24,7 @@ class BaseDecoratorTest extends DDSpecification {
 
     then:
     1 * span.setTag(DDTags.SPAN_TYPE, decorator.spanType())
-    1 * span.setTag(Tags.COMPONENT.key, "test-component")
+    1 * span.setTag(Tags.COMPONENT, "test-component")
     _ * span.setTag(_, _) // Want to allow other calls from child implementations.
     0 * _
   }
@@ -35,16 +35,16 @@ class BaseDecoratorTest extends DDSpecification {
 
     then:
     if (connection.getAddress()) {
-      2 * span.setTag(Tags.PEER_HOSTNAME.key, connection.hostName)
+      2 * span.setTag(Tags.PEER_HOSTNAME, connection.hostName)
     } else {
-      1 * span.setTag(Tags.PEER_HOSTNAME.key, connection.hostName)
+      1 * span.setTag(Tags.PEER_HOSTNAME, connection.hostName)
     }
-    1 * span.setTag(Tags.PEER_PORT.key, connection.port)
+    1 * span.setTag(Tags.PEER_PORT, connection.port)
     if (connection.address instanceof Inet4Address) {
-      1 * span.setTag(Tags.PEER_HOST_IPV4.key, connection.address.hostAddress)
+      1 * span.setTag(Tags.PEER_HOST_IPV4, connection.address.hostAddress)
     }
     if (connection.address instanceof Inet6Address) {
-      1 * span.setTag(Tags.PEER_HOST_IPV6.key, connection.address.hostAddress)
+      1 * span.setTag(Tags.PEER_HOST_IPV6, connection.address.hostAddress)
     }
     0 * _
 

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/ClientDecoratorTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/ClientDecoratorTest.groovy
@@ -2,7 +2,7 @@ package datadog.trace.bootstrap.instrumentation.decorator
 
 import datadog.trace.api.DDTags
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan
-import io.opentracing.tag.Tags
+import datadog.trace.bootstrap.instrumentation.api.Tags
 
 class ClientDecoratorTest extends BaseDecoratorTest {
 
@@ -19,8 +19,8 @@ class ClientDecoratorTest extends BaseDecoratorTest {
     if (serviceName != null) {
       1 * span.setTag(DDTags.SERVICE_NAME, serviceName)
     }
-    1 * span.setTag(Tags.COMPONENT.key, "test-component")
-    1 * span.setTag(Tags.SPAN_KIND.key, "client")
+    1 * span.setTag(Tags.COMPONENT, "test-component")
+    1 * span.setTag(Tags.SPAN_KIND, "client")
     1 * span.setTag(DDTags.SPAN_TYPE, decorator.spanType())
     1 * span.setTag(DDTags.ANALYTICS_SAMPLE_RATE, 1.0)
     _ * span.setTag(_, _) // Want to allow other calls from child implementations.

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/DatabaseClientDecoratorTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/DatabaseClientDecoratorTest.groovy
@@ -3,7 +3,7 @@ package datadog.trace.bootstrap.instrumentation.decorator
 import datadog.trace.api.Config
 import datadog.trace.api.DDTags
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan
-import io.opentracing.tag.Tags
+import datadog.trace.bootstrap.instrumentation.api.Tags
 
 import static datadog.trace.agent.test.utils.ConfigUtils.withConfigOverride
 
@@ -22,9 +22,9 @@ class DatabaseClientDecoratorTest extends ClientDecoratorTest {
     if (serviceName != null) {
       1 * span.setTag(DDTags.SERVICE_NAME, serviceName)
     }
-    1 * span.setTag(Tags.COMPONENT.key, "test-component")
-    1 * span.setTag(Tags.SPAN_KIND.key, "client")
-    1 * span.setTag(Tags.DB_TYPE.key, "test-db")
+    1 * span.setTag(Tags.COMPONENT, "test-component")
+    1 * span.setTag(Tags.SPAN_KIND, "client")
+    1 * span.setTag(Tags.DB_TYPE, "test-db")
     1 * span.setTag(DDTags.SPAN_TYPE, "test-type")
     1 * span.setTag(DDTags.ANALYTICS_SAMPLE_RATE, 1.0)
     0 * _
@@ -44,8 +44,8 @@ class DatabaseClientDecoratorTest extends ClientDecoratorTest {
 
     then:
     if (session) {
-      1 * span.setTag(Tags.DB_USER.key, session.user)
-      1 * span.setTag(Tags.DB_INSTANCE.key, session.instance)
+      1 * span.setTag(Tags.DB_USER, session.user)
+      1 * span.setTag(Tags.DB_INSTANCE, session.instance)
       if (renameService && session.instance) {
         1 * span.setTag(DDTags.SERVICE_NAME, session.instance)
       }
@@ -68,7 +68,7 @@ class DatabaseClientDecoratorTest extends ClientDecoratorTest {
     decorator.onStatement(span, statement)
 
     then:
-    1 * span.setTag(Tags.DB_STATEMENT.key, statement)
+    1 * span.setTag(Tags.DB_STATEMENT, statement)
     0 * _
 
     where:

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/HttpClientDecoratorTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/HttpClientDecoratorTest.groovy
@@ -3,7 +3,7 @@ package datadog.trace.bootstrap.instrumentation.decorator
 import datadog.trace.api.Config
 import datadog.trace.api.DDTags
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan
-import io.opentracing.tag.Tags
+import datadog.trace.bootstrap.instrumentation.api.Tags
 import spock.lang.Shared
 
 import static datadog.trace.agent.test.utils.ConfigUtils.withConfigOverride
@@ -26,10 +26,10 @@ class HttpClientDecoratorTest extends ClientDecoratorTest {
 
     then:
     if (req) {
-      1 * span.setTag(Tags.HTTP_METHOD.key, req.method)
-      1 * span.setTag(Tags.HTTP_URL.key, "$req.url")
-      1 * span.setTag(Tags.PEER_HOSTNAME.key, req.host)
-      1 * span.setTag(Tags.PEER_PORT.key, req.port)
+      1 * span.setTag(Tags.HTTP_METHOD, req.method)
+      1 * span.setTag(Tags.HTTP_URL, "$req.url")
+      1 * span.setTag(Tags.PEER_HOSTNAME, req.host)
+      1 * span.setTag(Tags.PEER_PORT, req.port)
       if (renameService) {
         1 * span.setTag(DDTags.SERVICE_NAME, req.host)
       }
@@ -55,14 +55,14 @@ class HttpClientDecoratorTest extends ClientDecoratorTest {
 
     then:
     if (expectedUrl) {
-      1 * span.setTag(Tags.HTTP_URL.key, expectedUrl)
+      1 * span.setTag(Tags.HTTP_URL, expectedUrl)
     }
     if (expectedUrl && tagQueryString) {
       1 * span.setTag(DDTags.HTTP_QUERY, expectedQuery)
       1 * span.setTag(DDTags.HTTP_FRAGMENT, expectedFragment)
     }
-    1 * span.setTag(Tags.HTTP_METHOD.key, null)
-    1 * span.setTag(Tags.PEER_HOSTNAME.key, null)
+    1 * span.setTag(Tags.HTTP_METHOD, null)
+    1 * span.setTag(Tags.PEER_HOSTNAME, null)
     0 * _
 
     where:
@@ -94,7 +94,7 @@ class HttpClientDecoratorTest extends ClientDecoratorTest {
 
     then:
     if (status) {
-      1 * span.setTag(Tags.HTTP_STATUS.key, status)
+      1 * span.setTag(Tags.HTTP_STATUS, status)
     }
     if (error) {
       1 * span.setError(true)

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecoratorTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecoratorTest.groovy
@@ -4,7 +4,7 @@ package datadog.trace.bootstrap.instrumentation.decorator
 import datadog.trace.api.Config
 import datadog.trace.api.DDTags
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan
-import io.opentracing.tag.Tags
+import datadog.trace.bootstrap.instrumentation.api.Tags
 
 import static datadog.trace.agent.test.utils.ConfigUtils.withConfigOverride
 
@@ -21,8 +21,8 @@ class HttpServerDecoratorTest extends ServerDecoratorTest {
 
     then:
     if (req) {
-      1 * span.setTag(Tags.HTTP_METHOD.key, "test-method")
-      1 * span.setTag(Tags.HTTP_URL.key, url)
+      1 * span.setTag(Tags.HTTP_METHOD, "test-method")
+      1 * span.setTag(Tags.HTTP_URL, url)
     }
     0 * _
 
@@ -47,13 +47,13 @@ class HttpServerDecoratorTest extends ServerDecoratorTest {
 
     then:
     if (expectedUrl) {
-      1 * span.setTag(Tags.HTTP_URL.key, expectedUrl)
+      1 * span.setTag(Tags.HTTP_URL, expectedUrl)
     }
     if (expectedUrl && tagQueryString) {
       1 * span.setTag(DDTags.HTTP_QUERY, expectedQuery)
       1 * span.setTag(DDTags.HTTP_FRAGMENT, expectedFragment)
     }
-    1 * span.setTag(Tags.HTTP_METHOD.key, null)
+    1 * span.setTag(Tags.HTTP_METHOD, null)
     0 * _
 
     where:
@@ -84,11 +84,11 @@ class HttpServerDecoratorTest extends ServerDecoratorTest {
 
     then:
     if (conn) {
-      1 * span.setTag(Tags.PEER_PORT.key, 555)
+      1 * span.setTag(Tags.PEER_PORT, 555)
       if (ipv4) {
-        1 * span.setTag(Tags.PEER_HOST_IPV4.key, "10.0.0.1")
+        1 * span.setTag(Tags.PEER_HOST_IPV4, "10.0.0.1")
       } else if (ipv4 != null) {
-        1 * span.setTag(Tags.PEER_HOST_IPV6.key, "3ffe:1900:4545:3:200:f8ff:fe21:67cf")
+        1 * span.setTag(Tags.PEER_HOST_IPV6, "3ffe:1900:4545:3:200:f8ff:fe21:67cf")
       }
     }
     0 * _
@@ -112,7 +112,7 @@ class HttpServerDecoratorTest extends ServerDecoratorTest {
 
     then:
     if (status) {
-      1 * span.setTag(Tags.HTTP_STATUS.key, status)
+      1 * span.setTag(Tags.HTTP_STATUS, status)
     }
     if (error) {
       1 * span.setError(true)

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/ServerDecoratorTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/ServerDecoratorTest.groovy
@@ -3,7 +3,7 @@ package datadog.trace.bootstrap.instrumentation.decorator
 import datadog.trace.api.Config
 import datadog.trace.api.DDTags
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan
-import io.opentracing.tag.Tags
+import datadog.trace.bootstrap.instrumentation.api.Tags
 
 class ServerDecoratorTest extends BaseDecoratorTest {
 
@@ -16,8 +16,8 @@ class ServerDecoratorTest extends BaseDecoratorTest {
 
     then:
     1 * span.setTag(Config.LANGUAGE_TAG_KEY, Config.LANGUAGE_TAG_VALUE)
-    1 * span.setTag(Tags.COMPONENT.key, "test-component")
-    1 * span.setTag(Tags.SPAN_KIND.key, "server")
+    1 * span.setTag(Tags.COMPONENT, "test-component")
+    1 * span.setTag(Tags.SPAN_KIND, "server")
     1 * span.setTag(DDTags.SPAN_TYPE, decorator.spanType())
     if (decorator.traceAnalyticsEnabled) {
       1 * span.setTag(DDTags.ANALYTICS_SAMPLE_RATE, 1.0)


### PR DESCRIPTION
Removes one of the last places still using OpenTracing tags instead of `datadog.trace.bootstrap.instrumentation.api.Tags`

I noticed this when I did the bootstrap move but didn't want to muddy that PR.