### PR TITLE
Fix jms tests with JDK11+

### DIFF
--- a/dd-java-agent/instrumentation/jms/jms.gradle
+++ b/dd-java-agent/instrumentation/jms/jms.gradle
@@ -27,6 +27,7 @@ dependencies {
   testCompile group: 'org.apache.activemq', name: 'activemq-pool', version: '5.14.5'
   testCompile group: 'org.apache.activemq', name: 'activemq-broker', version: '5.14.5'
 
+  testCompile group: 'javax.annotation', name: 'javax.annotation-api', version: '1.3.2' //required for Java 11+
   testCompile group: 'org.springframework', name: 'spring-jms', version: '4.3.21.RELEASE' // 4.x required for Java 7
 
   latestDepTestCompile group: 'org.hornetq', name: 'hornetq-jms-client', version: '2.4.7.Final'


### PR DESCRIPTION
JDK 11 and newer removes the JavaEE classes.  Tests don't build on 11 without adding this dependency.