### PR TITLE
Remove hostname and port from HttpClientDecorator

### DIFF
--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/AkkaHttpClientDecorator.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/AkkaHttpClientDecorator.java
@@ -30,16 +30,6 @@ public class AkkaHttpClientDecorator extends HttpClientDecorator<HttpRequest, Ht
   }
 
   @Override
-  protected String hostname(final HttpRequest httpRequest) {
-    return httpRequest.getUri().host().address();
-  }
-
-  @Override
-  protected Integer port(final HttpRequest httpRequest) {
-    return httpRequest.getUri().port();
-  }
-
-  @Override
   protected Integer status(final HttpResponse httpResponse) {
     return httpResponse.status().intValue();
   }

--- a/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientDecorator.java
+++ b/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientDecorator.java
@@ -12,6 +12,7 @@ import org.apache.http.protocol.HttpContext;
 import org.apache.http.protocol.HttpCoreContext;
 
 public class ApacheHttpAsyncClientDecorator extends HttpClientDecorator<HttpRequest, HttpContext> {
+
   public static final ApacheHttpAsyncClientDecorator DECORATE =
       new ApacheHttpAsyncClientDecorator();
 
@@ -47,34 +48,6 @@ public class ApacheHttpAsyncClientDecorator extends HttpClientDecorator<HttpRequ
     } else {
       final RequestLine requestLine = request.getRequestLine();
       return requestLine == null ? null : new URI(requestLine.getUri());
-    }
-  }
-
-  @Override
-  protected String hostname(final HttpRequest request) {
-    try {
-      final URI uri = url(request);
-      if (uri != null) {
-        return uri.getHost();
-      } else {
-        return null;
-      }
-    } catch (final URISyntaxException e) {
-      return null;
-    }
-  }
-
-  @Override
-  protected Integer port(final HttpRequest request) {
-    try {
-      final URI uri = url(request);
-      if (uri != null) {
-        return uri.getPort();
-      } else {
-        return null;
-      }
-    } catch (final URISyntaxException e) {
-      return null;
     }
   }
 

--- a/dd-java-agent/instrumentation/apache-httpclient-4/src/main/java/datadog/trace/instrumentation/apachehttpclient/ApacheHttpClientDecorator.java
+++ b/dd-java-agent/instrumentation/apache-httpclient-4/src/main/java/datadog/trace/instrumentation/apachehttpclient/ApacheHttpClientDecorator.java
@@ -29,26 +29,6 @@ public class ApacheHttpClientDecorator extends HttpClientDecorator<HttpUriReques
   }
 
   @Override
-  protected String hostname(final HttpUriRequest httpRequest) {
-    final URI uri = httpRequest.getURI();
-    if (uri != null) {
-      return uri.getHost();
-    } else {
-      return null;
-    }
-  }
-
-  @Override
-  protected Integer port(final HttpUriRequest httpRequest) {
-    final URI uri = httpRequest.getURI();
-    if (uri != null) {
-      return uri.getPort();
-    } else {
-      return null;
-    }
-  }
-
-  @Override
   protected Integer status(final HttpResponse httpResponse) {
     return httpResponse.getStatusLine().getStatusCode();
   }

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/AwsSdkClientDecorator.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/AwsSdkClientDecorator.java
@@ -106,16 +106,6 @@ public class AwsSdkClientDecorator extends HttpClientDecorator<Request, Response
   }
 
   @Override
-  protected String hostname(final Request request) {
-    return null;
-  }
-
-  @Override
-  protected Integer port(final Request request) {
-    return null;
-  }
-
-  @Override
   protected Integer status(final Response response) {
     return response.getHttpResponse().getStatusCode();
   }

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test/groovy/AWSClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test/groovy/AWSClientTest.groovy
@@ -1,6 +1,9 @@
+import com.amazonaws.AmazonClientException
 import com.amazonaws.AmazonWebServiceClient
 import com.amazonaws.ClientConfiguration
 import com.amazonaws.Request
+import com.amazonaws.SDKGlobalConfiguration
+import com.amazonaws.SdkClientException
 import com.amazonaws.auth.AWSCredentialsProviderChain
 import com.amazonaws.auth.AWSStaticCredentialsProvider
 import com.amazonaws.auth.AnonymousAWSCredentials

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test/groovy/AWSClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test/groovy/AWSClientTest.groovy
@@ -1,9 +1,6 @@
-import com.amazonaws.AmazonClientException
 import com.amazonaws.AmazonWebServiceClient
 import com.amazonaws.ClientConfiguration
 import com.amazonaws.Request
-import com.amazonaws.SDKGlobalConfiguration
-import com.amazonaws.SdkClientException
 import com.amazonaws.auth.AWSCredentialsProviderChain
 import com.amazonaws.auth.AWSStaticCredentialsProvider
 import com.amazonaws.auth.AnonymousAWSCredentials
@@ -146,6 +143,8 @@ class AWSClientTest extends AgentTestRunner {
             "$Tags.HTTP_URL" "$server.address/"
             "$Tags.HTTP_METHOD" "$method"
             "$Tags.HTTP_STATUS" 200
+            "$Tags.PEER_PORT" server.address.port
+            "$Tags.PEER_HOSTNAME" "localhost"
             "aws.service" { it.contains(service) }
             "aws.endpoint" "$server.address"
             "aws.operation" "${operation}Request"
@@ -240,6 +239,8 @@ class AWSClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.HTTP_URL" "http://localhost:${UNUSABLE_PORT}/"
             "$Tags.HTTP_METHOD" "$method"
+            "$Tags.PEER_HOSTNAME" "localhost"
+            "$Tags.PEER_PORT" 61
             "aws.service" { it.contains(service) }
             "aws.endpoint" "http://localhost:${UNUSABLE_PORT}"
             "aws.operation" "${operation}Request"
@@ -306,6 +307,7 @@ class AWSClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.HTTP_URL" "https://s3.amazonaws.com/"
             "$Tags.HTTP_METHOD" "HEAD"
+            "$Tags.PEER_HOSTNAME" "s3.amazonaws.com"
             "aws.service" "Amazon S3"
             "aws.endpoint" "https://s3.amazonaws.com"
             "aws.operation" "HeadBucketRequest"
@@ -352,6 +354,8 @@ class AWSClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.HTTP_URL" "$server.address/"
             "$Tags.HTTP_METHOD" "GET"
+            "$Tags.PEER_PORT" server.address.port
+            "$Tags.PEER_HOSTNAME" "localhost"
             "aws.service" "Amazon S3"
             "aws.endpoint" "$server.address"
             "aws.operation" "GetObjectRequest"

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test_before_1_11_106/groovy/AWSClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test_before_1_11_106/groovy/AWSClientTest.groovy
@@ -109,6 +109,8 @@ class AWSClientTest extends AgentTestRunner {
             "$Tags.HTTP_URL" "$server.address/"
             "$Tags.HTTP_METHOD" "$method"
             "$Tags.HTTP_STATUS" 200
+            "$Tags.PEER_PORT" server.address.port
+            "$Tags.PEER_HOSTNAME" "localhost"
             "aws.service" { it.contains(service) }
             "aws.endpoint" "$server.address"
             "aws.operation" "${operation}Request"
@@ -185,6 +187,8 @@ class AWSClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.HTTP_URL" "http://localhost:${UNUSABLE_PORT}/"
             "$Tags.HTTP_METHOD" "$method"
+            "$Tags.PEER_PORT" 61
+            "$Tags.PEER_HOSTNAME" "localhost"
             "aws.service" { it.contains(service) }
             "aws.endpoint" "http://localhost:${UNUSABLE_PORT}"
             "aws.operation" "${operation}Request"
@@ -251,6 +255,7 @@ class AWSClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.HTTP_URL" "https://s3.amazonaws.com/"
             "$Tags.HTTP_METHOD" "GET"
+            "$Tags.PEER_HOSTNAME" "s3.amazonaws.com"
             "aws.service" "Amazon S3"
             "aws.endpoint" "https://s3.amazonaws.com"
             "aws.operation" "GetObjectRequest"
@@ -298,6 +303,8 @@ class AWSClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.HTTP_URL" "$server.address/"
             "$Tags.HTTP_METHOD" "GET"
+            "$Tags.PEER_PORT" server.address.port
+            "$Tags.PEER_HOSTNAME" "localhost"
             "aws.service" "Amazon S3"
             "aws.endpoint" "http://localhost:$server.address.port"
             "aws.operation" "GetObjectRequest"

--- a/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java8/datadog/trace/instrumentation/aws/v2/AwsSdkClientDecorator.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java8/datadog/trace/instrumentation/aws/v2/AwsSdkClientDecorator.java
@@ -89,16 +89,6 @@ public class AwsSdkClientDecorator extends HttpClientDecorator<SdkHttpRequest, S
   }
 
   @Override
-  protected String hostname(final SdkHttpRequest request) {
-    return request.host();
-  }
-
-  @Override
-  protected Integer port(final SdkHttpRequest request) {
-    return request.port();
-  }
-
-  @Override
   protected Integer status(final SdkHttpResponse response) {
     return response.statusCode();
   }

--- a/dd-java-agent/instrumentation/commons-httpclient-2/src/main/java/datadog/trace/instrumentation/commonshttpclient/CommonsHttpClientDecorator.java
+++ b/dd-java-agent/instrumentation/commons-httpclient-2/src/main/java/datadog/trace/instrumentation/commonshttpclient/CommonsHttpClientDecorator.java
@@ -36,24 +36,6 @@ public class CommonsHttpClientDecorator extends HttpClientDecorator<HttpMethod, 
   }
 
   @Override
-  protected String hostname(final HttpMethod httpMethod) {
-    try {
-      return httpMethod.getURI().getHost();
-    } catch (final URIException e) {
-      return null;
-    }
-  }
-
-  @Override
-  protected Integer port(final HttpMethod httpMethod) {
-    try {
-      return httpMethod.getURI().getPort();
-    } catch (final URIException e) {
-      return null;
-    }
-  }
-
-  @Override
   protected Integer status(final HttpMethod httpMethod) {
     final StatusLine statusLine = httpMethod.getStatusLine();
     return statusLine == null ? null : statusLine.getStatusCode();

--- a/dd-java-agent/instrumentation/google-http-client/src/main/java/datadog/trace/instrumentation/googlehttpclient/GoogleHttpClientDecorator.java
+++ b/dd-java-agent/instrumentation/google-http-client/src/main/java/datadog/trace/instrumentation/googlehttpclient/GoogleHttpClientDecorator.java
@@ -24,16 +24,6 @@ public class GoogleHttpClientDecorator extends HttpClientDecorator<HttpRequest, 
   }
 
   @Override
-  protected String hostname(final HttpRequest httpRequest) {
-    return httpRequest.getUrl().getHost();
-  }
-
-  @Override
-  protected Integer port(final HttpRequest httpRequest) {
-    return httpRequest.getUrl().getPort();
-  }
-
-  @Override
   protected Integer status(final HttpResponse httpResponse) {
     return httpResponse.getStatusCode();
   }

--- a/dd-java-agent/instrumentation/http-url-connection/src/main/java/datadog/trace/instrumentation/http_url_connection/HttpUrlConnectionDecorator.java
+++ b/dd-java-agent/instrumentation/http-url-connection/src/main/java/datadog/trace/instrumentation/http_url_connection/HttpUrlConnectionDecorator.java
@@ -4,9 +4,9 @@ import datadog.trace.bootstrap.instrumentation.decorator.HttpClientDecorator;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URISyntaxException;
-import javax.net.ssl.HttpsURLConnection;
 
 public class HttpUrlConnectionDecorator extends HttpClientDecorator<HttpURLConnection, Integer> {
+
   public static final HttpUrlConnectionDecorator DECORATE = new HttpUrlConnectionDecorator();
 
   @Override
@@ -27,23 +27,6 @@ public class HttpUrlConnectionDecorator extends HttpClientDecorator<HttpURLConne
   @Override
   protected URI url(final HttpURLConnection connection) throws URISyntaxException {
     return connection.getURL().toURI();
-  }
-
-  @Override
-  protected String hostname(final HttpURLConnection connection) {
-    return connection.getURL().getHost();
-  }
-
-  @Override
-  protected Integer port(final HttpURLConnection connection) {
-    final int port = connection.getURL().getPort();
-    if (port > 0) {
-      return port;
-    } else if (connection instanceof HttpsURLConnection) {
-      return 443;
-    } else {
-      return 80;
-    }
   }
 
   @Override

--- a/dd-java-agent/instrumentation/jax-rs-client-1.1/src/main/java/datadog/trace/instrumentation/jaxrs/v1/JaxRsClientV1Decorator.java
+++ b/dd-java-agent/instrumentation/jax-rs-client-1.1/src/main/java/datadog/trace/instrumentation/jaxrs/v1/JaxRsClientV1Decorator.java
@@ -29,16 +29,6 @@ public class JaxRsClientV1Decorator extends HttpClientDecorator<ClientRequest, C
   }
 
   @Override
-  protected String hostname(final ClientRequest httpRequest) {
-    return httpRequest.getURI().getHost();
-  }
-
-  @Override
-  protected Integer port(final ClientRequest httpRequest) {
-    return httpRequest.getURI().getPort();
-  }
-
-  @Override
   protected Integer status(final ClientResponse clientResponse) {
     return clientResponse.getStatus();
   }

--- a/dd-java-agent/instrumentation/jax-rs-client-2.0/src/main/java/datadog/trace/instrumentation/jaxrs/JaxRsClientDecorator.java
+++ b/dd-java-agent/instrumentation/jax-rs-client-2.0/src/main/java/datadog/trace/instrumentation/jaxrs/JaxRsClientDecorator.java
@@ -30,16 +30,6 @@ public class JaxRsClientDecorator
   }
 
   @Override
-  protected String hostname(final ClientRequestContext httpRequest) {
-    return httpRequest.getUri().getHost();
-  }
-
-  @Override
-  protected Integer port(final ClientRequestContext httpRequest) {
-    return httpRequest.getUri().getPort();
-  }
-
-  @Override
   protected Integer status(final ClientResponseContext httpResponse) {
     return httpResponse.getStatus();
   }

--- a/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/client/NettyHttpClientDecorator.java
+++ b/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/client/NettyHttpClientDecorator.java
@@ -39,35 +39,6 @@ public class NettyHttpClientDecorator extends HttpClientDecorator<HttpRequest, H
   }
 
   @Override
-  protected String hostname(final HttpRequest request) {
-    try {
-      final URI uri = new URI(request.getUri());
-      if ((uri.getHost() == null || uri.getHost().equals("")) && request.headers().contains(HOST)) {
-        return request.headers().get(HOST).split(":")[0];
-      } else {
-        return uri.getHost();
-      }
-    } catch (final Exception e) {
-      return null;
-    }
-  }
-
-  @Override
-  protected Integer port(final HttpRequest request) {
-    try {
-      final URI uri = new URI(request.getUri());
-      if ((uri.getHost() == null || uri.getHost().equals("")) && request.headers().contains(HOST)) {
-        final String[] hostPort = request.headers().get(HOST).split(":");
-        return hostPort.length == 2 ? Integer.parseInt(hostPort[1]) : null;
-      } else {
-        return uri.getPort();
-      }
-    } catch (final Exception e) {
-      return null;
-    }
-  }
-
-  @Override
   protected Integer status(final HttpResponse httpResponse) {
     return httpResponse.getStatus().code();
   }

--- a/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/client/NettyHttpClientDecorator.java
+++ b/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/client/NettyHttpClientDecorator.java
@@ -39,35 +39,6 @@ public class NettyHttpClientDecorator extends HttpClientDecorator<HttpRequest, H
   }
 
   @Override
-  protected String hostname(final HttpRequest request) {
-    try {
-      final URI uri = new URI(request.uri());
-      if ((uri.getHost() == null || uri.getHost().equals("")) && request.headers().contains(HOST)) {
-        return request.headers().get(HOST).split(":")[0];
-      } else {
-        return uri.getHost();
-      }
-    } catch (final Exception e) {
-      return null;
-    }
-  }
-
-  @Override
-  protected Integer port(final HttpRequest request) {
-    try {
-      final URI uri = new URI(request.uri());
-      if ((uri.getHost() == null || uri.getHost().equals("")) && request.headers().contains(HOST)) {
-        final String[] hostPort = request.headers().get(HOST).split(":");
-        return hostPort.length == 2 ? Integer.parseInt(hostPort[1]) : null;
-      } else {
-        return uri.getPort();
-      }
-    } catch (final Exception e) {
-      return null;
-    }
-  }
-
-  @Override
   protected Integer status(final HttpResponse httpResponse) {
     return httpResponse.status().code();
   }

--- a/dd-java-agent/instrumentation/okhttp-3/src/main/java/datadog/trace/instrumentation/okhttp3/OkHttpClientDecorator.java
+++ b/dd-java-agent/instrumentation/okhttp-3/src/main/java/datadog/trace/instrumentation/okhttp3/OkHttpClientDecorator.java
@@ -34,16 +34,6 @@ public class OkHttpClientDecorator extends HttpClientDecorator<Request, Response
   }
 
   @Override
-  protected String hostname(final Request httpRequest) {
-    return httpRequest.url().host();
-  }
-
-  @Override
-  protected Integer port(final Request httpRequest) {
-    return httpRequest.url().port();
-  }
-
-  @Override
   protected Integer status(final Response httpResponse) {
     return httpResponse.code();
   }

--- a/dd-java-agent/instrumentation/play-ws/src/main/java/datadog/trace/instrumentation/playws/PlayWSClientDecorator.java
+++ b/dd-java-agent/instrumentation/play-ws/src/main/java/datadog/trace/instrumentation/playws/PlayWSClientDecorator.java
@@ -20,16 +20,6 @@ public class PlayWSClientDecorator extends HttpClientDecorator<Request, Response
   }
 
   @Override
-  protected String hostname(final Request request) {
-    return request.getUri().getHost();
-  }
-
-  @Override
-  protected Integer port(final Request request) {
-    return request.getUri().getPort();
-  }
-
-  @Override
   protected Integer status(final Response response) {
     return response.getStatusCode();
   }

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java8/datadog/trace/instrumentation/springwebflux/client/SpringWebfluxHttpClientDecorator.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java8/datadog/trace/instrumentation/springwebflux/client/SpringWebfluxHttpClientDecorator.java
@@ -40,16 +40,6 @@ public class SpringWebfluxHttpClientDecorator
   }
 
   @Override
-  protected String hostname(final ClientRequest httpRequest) {
-    return httpRequest.url().getHost();
-  }
-
-  @Override
-  protected Integer port(final ClientRequest httpRequest) {
-    return httpRequest.url().getPort();
-  }
-
-  @Override
   protected Integer status(final ClientResponse httpResponse) {
     return httpResponse.statusCode().value();
   }


### PR DESCRIPTION
Was talking to @tylerbenson and saw that out profiles were doing a lot of parsing of URIs. I've found the culprit to be in the `hostname(REQUEST request)` and `port(REQUEST request)` methods. Since this data is already computed via the initial URI parse to build the url, I see no need to delegate the extra calls for tags.