### PR TITLE
Fix release plugin auth with new version

### DIFF
--- a/dd-trace-java.gradle
+++ b/dd-trace-java.gradle
@@ -10,7 +10,7 @@ plugins {
   // files in 'workspace' build directory in CI
   id 'com.github.sherter.google-java-format' version '0.8' apply false
   id 'com.dorongold.task-tree' version '1.5'
-  id 'pl.allegro.tech.build.axion-release' version '1.9.3'
+  id 'pl.allegro.tech.build.axion-release' version '1.10.3'
 }
 
 def isCI = System.getenv("CI") != null


### PR DESCRIPTION
During the 0.46.0 release, there was an "Auth Fail" error when the plugin tried to push the new tag.  Upgrading to the latest version of the plugin fixes that.

Tested on a private repo.