### PR TITLE
Fix JMS test library for Java 7

### DIFF
--- a/dd-java-agent/instrumentation/jms/jms.gradle
+++ b/dd-java-agent/instrumentation/jms/jms.gradle
@@ -27,7 +27,8 @@ dependencies {
   testCompile group: 'org.apache.activemq', name: 'activemq-pool', version: '5.14.5'
   testCompile group: 'org.apache.activemq', name: 'activemq-broker', version: '5.14.5'
 
-  testCompile group: 'javax.annotation', name: 'javax.annotation-api', version: '1.3.2' //required for Java 11+
+  // required for Java 11+ .  Latest version that runs on Java 7
+  testCompile group: 'javax.annotation', name: 'javax.annotation-api', version: '1.2'
   testCompile group: 'org.springframework', name: 'spring-jms', version: '4.3.21.RELEASE' // 4.x required for Java 7
 
   latestDepTestCompile group: 'org.hornetq', name: 'hornetq-jms-client', version: '2.4.7.Final'


### PR DESCRIPTION
#1314 broke tests with Java 7 (while fixing compiles under 11).  This pull request switches to an older version of `javax.annotation-api` that compiles under both.