### PR TITLE
Add check to ensure value isn't empty

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/OpenTracing32.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/OpenTracing32.java
@@ -301,7 +301,9 @@ public final class OpenTracing32 implements TracerAPI {
         // extracted header value
         String s = getter.get(carrier, key);
         // in case of multiple values in the header, need to parse
-        if (s != null) s = s.split(",")[0].trim();
+        if (s != null && !s.isEmpty()) {
+          s = s.split(",")[0].trim();
+        }
         extracted.put(key, s);
       }
     }


### PR DESCRIPTION
Otherwise split on an empty string may return an empty array.