### PR TITLE
Activating a null span puts a NoopScope on top of the scope manager stack

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -248,8 +248,8 @@ public class AgentTracer {
     public void close(final boolean closeContinuationScope) {}
   }
 
-  static class NoopTraceScope implements TraceScope {
-    static final NoopTraceScope INSTANCE = new NoopTraceScope();
+  public static class NoopTraceScope implements TraceScope {
+    public static final NoopTraceScope INSTANCE = new NoopTraceScope();
 
     @Override
     public Continuation capture() {

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/OpenTracing32.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/OpenTracing32.java
@@ -10,6 +10,7 @@ import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation.Getter;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer.TracerAPI;
 import datadog.trace.context.TraceScope;
 import io.opentracing.Scope;
@@ -86,6 +87,8 @@ public final class OpenTracing32 implements TracerAPI {
     final Scope scope = tracer.scopeManager().active();
     if (scope instanceof TraceScope) {
       return (TraceScope) scope;
+    } else if (scope.span() == NoopSpan.INSTANCE) {
+      return AgentTracer.NoopTraceScope.INSTANCE;
     } else {
       return null;
     }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/OpenTracing32.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/OpenTracing32.java
@@ -56,7 +56,10 @@ public final class OpenTracing32 implements TracerAPI {
   }
 
   @Override
-  public AgentScope activateSpan(final AgentSpan span, final boolean finishSpanOnClose) {
+  public AgentScope activateSpan(AgentSpan span, final boolean finishSpanOnClose) {
+    if (span == null) {
+      span = NOOP_SPAN;
+    }
     // when span is noopSpan(), the scope returned is not a TracerScope
     final Scope scope = tracer.scopeManager().activate(((OT32Span) span).span, finishSpanOnClose);
     return new OT32Scope(span, scope);

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/OpenTracing32.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/OpenTracing32.java
@@ -87,7 +87,7 @@ public final class OpenTracing32 implements TracerAPI {
     final Scope scope = tracer.scopeManager().active();
     if (scope instanceof TraceScope) {
       return (TraceScope) scope;
-    } else if (scope.span() == NoopSpan.INSTANCE) {
+    } else if (scope != null && scope.span() == NoopSpan.INSTANCE) {
       return AgentTracer.NoopTraceScope.INSTANCE;
     } else {
       return null;

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/OpenTracing32Test.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/OpenTracing32Test.groovy
@@ -57,6 +57,7 @@ class OpenTracing32Test extends DDSpecification {
 
     then:
     ((OpenTracing32.OT32Span) tracer.activeSpan()).span == NoopSpan.INSTANCE
+    tracer.activeScope() != null
 
     when:
     noopScope.close()

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/OpenTracing32Test.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/OpenTracing32Test.groovy
@@ -1,0 +1,76 @@
+package datadog.trace.agent.tooling
+
+import datadog.opentracing.DDSpan
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer
+import datadog.trace.util.test.DDSpecification
+import io.opentracing.noop.NoopSpan
+
+class OpenTracing32Test extends DDSpecification {
+  def setupSpec() {
+    TracerInstaller.installGlobalTracer()
+  }
+
+  def "Start and activate spans on the normal path"() {
+    given:
+    def tracer = AgentTracer.get()
+
+    when:
+    def span = tracer.startSpan("test")
+
+    then:
+    span.spanName == "test"
+
+    when:
+    def scope = tracer.activateSpan(span, true)
+
+    then:
+    ((OpenTracing32.OT32Span) tracer.activeSpan()).span == ((OpenTracing32.OT32Span) span).span
+
+    when:
+    scope.close()
+
+    then:
+    ((DDSpan) ((OpenTracing32.OT32Span) span).span).getDurationNano() > 0
+
+    and:
+    tracer.activeSpan() == null
+  }
+
+  def "Start span and activate span then activate noop span"() {
+    given:
+    def tracer = AgentTracer.get()
+
+    when:
+    def span = tracer.startSpan("test")
+
+    then:
+    span.spanName == "test"
+
+    when:
+    def scope = tracer.activateSpan(span, true)
+
+    then:
+    ((OpenTracing32.OT32Span) tracer.activeSpan()).span == ((OpenTracing32.OT32Span) span).span
+
+    when:
+    def noopScope = tracer.activateSpan(null, true)
+
+    then:
+    ((OpenTracing32.OT32Span) tracer.activeSpan()).span == NoopSpan.INSTANCE
+
+    when:
+    noopScope.close()
+
+    then:
+    ((OpenTracing32.OT32Span) tracer.activeSpan()).span == ((OpenTracing32.OT32Span) span).span
+
+    when:
+    scope.close()
+
+    then:
+    ((DDSpan) ((OpenTracing32.OT32Span) span).span).getDurationNano() > 0
+
+    and:
+    tracer.activeSpan() == null
+  }
+}


### PR DESCRIPTION
Influenced by semantics in the brave tracer where activating "null" will place a noop scope onto the stack

This is required in streaming use cases where the active span upstream should not be propagated any further. IE: a stream operator is not scoped within a span