### PR TITLE
Also catch ClassNotFoundException when trying to instantiate datadog.opentracing.jfr.openjdk.ScopeEventFactory.

### DIFF
--- a/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
@@ -558,7 +558,7 @@ public class DDTracer implements io.opentracing.Tracer, Closeable, datadog.trace
     try {
       return (DDScopeEventFactory)
           Class.forName("datadog.opentracing.jfr.openjdk.ScopeEventFactory").newInstance();
-    } catch (final ClassFormatError | ReflectiveOperationException | NoClassDefFoundError e) {
+    } catch (final ClassFormatError | ReflectiveOperationException | NoClassDefFoundError | ClassNotFoundException e) {
       log.debug("Cannot create Openjdk JFR scope event factory", e);
     }
     return new DDNoopScopeEventFactory();


### PR DESCRIPTION
I am getting an uncaught exception that seems to have been forgotten in the anticipated catch block:

```
java.lang.ClassNotFoundException: datadog.opentracing.jfr.openjdk.ScopeEventFactory
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:602)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
	at java.base/java.lang.Class.forName0(Native Method)
	at java.base/java.lang.Class.forName(Class.java:340)
	at datadog.opentracing.DDTracer.createScopeEventFactory(DDTracer.java:560)
	at datadog.opentracing.DDTracer.access$000(DDTracer.java:55)
	at datadog.opentracing.DDTracer$DDTracerBuilder.config(DDTracer.java:121)
	at datadog.opentracing.DDTracer$DDTracerBuilder.withProperties(DDTracer.java:110)
	at ace.client.external.tracing.TracingClient$Companion.test(TracingClient.kt:71)
	at ace.ApplicationKt$main$4.invokeSuspend(Application.kt:210)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:56)
	at kotlinx.coroutines.EventLoopImplBase.processNextEvent(EventLoop.common.kt:271)
	at kotlinx.coroutines.BlockingCoroutine.joinBlocking(Builders.kt:79)
	at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking(Builders.kt:54)
	at kotlinx.coroutines.BuildersKt.runBlocking(Unknown Source)
	at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking$default(Builders.kt:36)
	at kotlinx.coroutines.BuildersKt.runBlocking$default(Unknown Source)
	at ace.ApplicationKt.main(Application.kt:209)
	at ace.ApplicationKt.main(Application.kt)
```