### PR TITLE
Remove sensitive information from debug log

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/Config.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/Config.java
@@ -38,7 +38,7 @@ import lombok.extern.slf4j.Slf4j;
  * system property, but uppercased with '.' -> '_'.
  */
 @Slf4j
-@ToString(includeFieldNames = true, exclude = {"profilingApiKey", "profilingProxyPassword"})
+@ToString(includeFieldNames = true)
 public class Config {
   /** Config keys below */
   private static final String PREFIX = "dd.";
@@ -201,6 +201,14 @@ public class Config {
 
   /** A tag intended for internal use only, hence not added to the public api DDTags class. */
   private static final String INTERNAL_HOST_NAME = "_dd.hostname";
+
+  /** Used for masking sensitive information when doing toString */
+  @ToString.Include(name = "profilingApiKey")
+  private String profilingApiKeyMasker() { return "****"; }
+
+  /** Used for masking sensitive information when doing toString */
+  @ToString.Include(name = "profilingProxyPassword")
+  private String profilingProxyPasswordMasker() { return "****"; }
 
   /**
    * this is a random UUID that gets generated on JVM start up and is attached to every root span

--- a/dd-trace-api/src/main/java/datadog/trace/api/Config.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/Config.java
@@ -38,7 +38,7 @@ import lombok.extern.slf4j.Slf4j;
  * system property, but uppercased with '.' -> '_'.
  */
 @Slf4j
-@ToString(includeFieldNames = true)
+@ToString(includeFieldNames = true, exclude = {"profilingApiKey", "profilingProxyPassword"})
 public class Config {
   /** Config keys below */
   private static final String PREFIX = "dd.";

--- a/dd-trace-api/src/main/java/datadog/trace/api/Config.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/Config.java
@@ -204,11 +204,15 @@ public class Config {
 
   /** Used for masking sensitive information when doing toString */
   @ToString.Include(name = "profilingApiKey")
-  private String profilingApiKeyMasker() { return "****"; }
+  private String profilingApiKeyMasker() {
+    return profilingApiKey != null ? "****" : null;
+  }
 
   /** Used for masking sensitive information when doing toString */
   @ToString.Include(name = "profilingProxyPassword")
-  private String profilingProxyPasswordMasker() { return "****"; }
+  private String profilingProxyPasswordMasker() {
+    return profilingProxyPassword != null ? "****" : null;
+  }
 
   /**
    * this is a random UUID that gets generated on JVM start up and is attached to every root span

--- a/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -406,6 +406,19 @@ class ConfigTest extends DDSpecification {
     config.profilingApiKey == "test-api-key"
   }
 
+  def "sensitive information removed for toString/debug log"() {
+    setup:
+    environmentVariables.set(DD_PROFILING_API_KEY_ENV, "test-secret-api-key")
+    environmentVariables.set(PROFILING_PROXY_PASSWORD, "test-secret-proxy-password")
+
+    when:
+    def config = new Config()
+
+    then:
+    !config.toString().contains("test-secret-api-key")
+    !config.toString().contains("test-secret-proxy-password")
+  }
+
   def "sys props override env vars"() {
     setup:
     environmentVariables.set(DD_SERVICE_NAME_ENV, "still something else")

--- a/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -415,7 +415,9 @@ class ConfigTest extends DDSpecification {
     def config = new Config()
 
     then:
+    config.toString().contains("profilingApiKey=****");
     !config.toString().contains("test-secret-api-key")
+    config.toString().contains("profilingProxyPassword=****");
     !config.toString().contains("test-secret-proxy-password")
   }
 

--- a/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -93,6 +93,7 @@ class ConfigTest extends DDSpecification {
   private static final DD_PROFILING_API_KEY_ENV = "DD_PROFILING_API_KEY"
   private static final DD_PROFILING_API_KEY_OLD_ENV = "DD_PROFILING_APIKEY"
   private static final DD_PROFILING_TAGS_ENV = "DD_PROFILING_TAGS"
+  private static final DD_PROFILING_PROXY_PASSWORD_ENV = "DD_PROFILING_PROXY_PASSWORD"
 
   def "verify defaults"() {
     when:
@@ -409,7 +410,7 @@ class ConfigTest extends DDSpecification {
   def "sensitive information removed for toString/debug log"() {
     setup:
     environmentVariables.set(DD_PROFILING_API_KEY_ENV, "test-secret-api-key")
-    environmentVariables.set(PROFILING_PROXY_PASSWORD, "test-secret-proxy-password")
+    environmentVariables.set(DD_PROFILING_PROXY_PASSWORD_ENV, "test-secret-proxy-password")
 
     when:
     def config = new Config()
@@ -419,6 +420,8 @@ class ConfigTest extends DDSpecification {
     !config.toString().contains("test-secret-api-key")
     config.toString().contains("profilingProxyPassword=****");
     !config.toString().contains("test-secret-proxy-password")
+    config.getProfilingApiKey() == "test-secret-api-key"
+    config.getProfilingProxyPassword() == "test-secret-proxy-password"
   }
 
   def "sys props override env vars"() {


### PR DESCRIPTION
Config.toString() method is dumped when logging in debug the conf.
It includes in some case the profile api key when used with env vars.
Also proxy password is also dumped.
toString method generated by Lombok now excludes both fields