### PR TITLE
Add option to configure Datadog site used to send profiling information

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-uploader/src/main/java/com/datadog/profiling/uploader/RecordingUploader.java
+++ b/dd-java-agent/agent-profiling/profiling-uploader/src/main/java/com/datadog/profiling/uploader/RecordingUploader.java
@@ -53,6 +53,7 @@ import okhttp3.Response;
 /** The class for uploading recordings to the backend. */
 @Slf4j
 public final class RecordingUploader {
+
   private static final MediaType OCTET_STREAM = MediaType.parse("application/octet-stream");
 
   static final String RECORDING_NAME_PARAM = "recording-name";
@@ -120,7 +121,7 @@ public final class RecordingUploader {
   private final Deque<Integer> requestSizeHistory;
 
   public RecordingUploader(final Config config) {
-    url = config.getProfilingUrl();
+    url = config.getFinalProfilingUrl();
     apiKey = config.getProfilingApiKey();
 
     /*
@@ -233,6 +234,7 @@ public final class RecordingUploader {
 
   @FunctionalInterface
   private interface Compression {
+
     RequestBody compress(InputStream is, int expectedSize) throws IOException;
   }
 

--- a/dd-java-agent/agent-profiling/profiling-uploader/src/test/java/com/datadog/profiling/uploader/RecordingUploaderTest.java
+++ b/dd-java-agent/agent-profiling/profiling-uploader/src/test/java/com/datadog/profiling/uploader/RecordingUploaderTest.java
@@ -120,7 +120,7 @@ public class RecordingUploaderTest {
     server.start();
     url = server.url(URL_PATH);
 
-    when(config.getProfilingUrl()).thenReturn(server.url(URL_PATH).toString());
+    when(config.getFinalProfilingUrl()).thenReturn(server.url(URL_PATH).toString());
     when(config.getProfilingApiKey()).thenReturn(APIKEY_VALUE);
     when(config.getMergedProfilingTags()).thenReturn(TAGS);
     when(config.getProfilingUploadTimeout()).thenReturn((int) REQUEST_TIMEOUT.getSeconds());
@@ -199,7 +199,7 @@ public class RecordingUploaderTest {
   public void testRequestWithProxy() throws IOException, InterruptedException {
     final String backendHost = "intake.profiling.datadoghq.com:1234";
     final String backendUrl = "http://intake.profiling.datadoghq.com:1234" + URL_PATH;
-    when(config.getProfilingUrl())
+    when(config.getFinalProfilingUrl())
         .thenReturn("http://intake.profiling.datadoghq.com:1234" + URL_PATH);
     when(config.getProfilingProxyHost()).thenReturn(server.url("").host());
     when(config.getProfilingProxyPort()).thenReturn(server.url("").port());
@@ -235,7 +235,7 @@ public class RecordingUploaderTest {
   @Test
   public void testRequestWithProxyDefaultPassword() throws IOException, InterruptedException {
     final String backendUrl = "http://intake.profiling.datadoghq.com:1234" + URL_PATH;
-    when(config.getProfilingUrl())
+    when(config.getFinalProfilingUrl())
         .thenReturn("http://intake.profiling.datadoghq.com:1234" + URL_PATH);
     when(config.getProfilingProxyHost()).thenReturn(server.url("").host());
     when(config.getProfilingProxyPort()).thenReturn(server.url("").port());

--- a/dd-trace-api/src/main/java/datadog/trace/api/Config.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/Config.java
@@ -97,7 +97,7 @@ public class Config {
   public static final String JMX_FETCH_ENABLED = "jmxfetch.enabled";
   public static final String JMX_FETCH_CONFIG_DIR = "jmxfetch.config.dir";
   public static final String JMX_FETCH_CONFIG = "jmxfetch.config";
-  public static final String JMX_FETCH_METRICS_CONFIGS = "jmxfetch.metrics-configs";
+  @Deprecated public static final String JMX_FETCH_METRICS_CONFIGS = "jmxfetch.metrics-configs";
   public static final String JMX_FETCH_CHECK_PERIOD = "jmxfetch.check-period";
   public static final String JMX_FETCH_REFRESH_BEANS_PERIOD = "jmxfetch.refresh-beans-period";
   public static final String JMX_FETCH_STATSD_HOST = "jmxfetch.statsd.host";
@@ -110,8 +110,8 @@ public class Config {
   public static final String LOGS_INJECTION_ENABLED = "logs.injection";
 
   public static final String PROFILING_ENABLED = "profiling.enabled";
+  @Deprecated // Use dd.site instead
   public static final String PROFILING_URL = "profiling.url";
-
   public static final String PROFILING_API_KEY = "profiling.api-key";
   public static final String PROFILING_API_KEY_FILE = "profiling.api-key-file";
   public static final String PROFILING_API_KEY_OLD = "profiling.apikey";
@@ -278,7 +278,7 @@ public class Config {
   @Getter private final Double traceRateLimit;
 
   @Getter private final boolean profilingEnabled;
-  private final String profilingUrl;
+  @Deprecated private final String profilingUrl;
   @Getter private final String profilingApiKey;
   private final Map<String, String> profilingTags;
   @Getter private final int profilingStartDelay;

--- a/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -40,7 +40,6 @@ import static datadog.trace.api.Config.PROFILING_PROXY_HOST
 import static datadog.trace.api.Config.PROFILING_PROXY_PASSWORD
 import static datadog.trace.api.Config.PROFILING_PROXY_PORT
 import static datadog.trace.api.Config.PROFILING_PROXY_USERNAME
-import static datadog.trace.api.Config.PROFILING_SITE
 import static datadog.trace.api.Config.PROFILING_START_DELAY
 import static datadog.trace.api.Config.PROFILING_START_FORCE_FIRST
 import static datadog.trace.api.Config.PROFILING_TAGS
@@ -56,6 +55,7 @@ import static datadog.trace.api.Config.RUNTIME_ID_TAG
 import static datadog.trace.api.Config.SERVICE_MAPPING
 import static datadog.trace.api.Config.SERVICE_NAME
 import static datadog.trace.api.Config.SERVICE_TAG
+import static datadog.trace.api.Config.SITE
 import static datadog.trace.api.Config.SPAN_TAGS
 import static datadog.trace.api.Config.SPLIT_BY_TAGS
 import static datadog.trace.api.Config.TAGS
@@ -134,7 +134,7 @@ class ConfigTest extends DDSpecification {
     config.healthMetricsStatsdPort == null
 
     config.profilingEnabled == false
-    config.profilingSite == Config.DEFAULT_PROFILING_SITE
+    config.site == Config.DEFAULT_SITE
     config.profilingUrl == null
     config.profilingApiKey == null
     config.mergedProfilingTags == [(HOST_TAG): config.getHostName(), (RUNTIME_ID_TAG): config.getRuntimeId(), (SERVICE_TAG): config.serviceName, (LANGUAGE_TAG_KEY): LANGUAGE_TAG_VALUE]
@@ -200,7 +200,7 @@ class ConfigTest extends DDSpecification {
     prop.setProperty(TRACE_RATE_LIMIT, "200")
 
     prop.setProperty(PROFILING_ENABLED, "true")
-    prop.setProperty(PROFILING_SITE, "new site")
+    prop.setProperty(SITE, "new site")
     prop.setProperty(PROFILING_URL, "new url")
     prop.setProperty(PROFILING_API_KEY, "new api key")
     prop.setProperty(PROFILING_TAGS, "f:6,host:test-host")
@@ -257,7 +257,7 @@ class ConfigTest extends DDSpecification {
     config.traceRateLimit == 200
 
     config.profilingEnabled == true
-    config.profilingSite == "new site"
+    config.site == "new site"
     config.profilingUrl == "new url"
     config.profilingApiKey == "new api key" // we can still override via internal properties object
     config.mergedProfilingTags == [b: "2", f: "6", (HOST_TAG): "test-host", (RUNTIME_ID_TAG): config.getRuntimeId(), (SERVICE_TAG): config.serviceName, (LANGUAGE_TAG_KEY): LANGUAGE_TAG_VALUE]
@@ -314,7 +314,7 @@ class ConfigTest extends DDSpecification {
     System.setProperty(PREFIX + TRACE_RATE_LIMIT, "200")
 
     System.setProperty(PREFIX + PROFILING_ENABLED, "true")
-    System.setProperty(PREFIX + PROFILING_SITE, "new site")
+    System.setProperty(PREFIX + SITE, "new site")
     System.setProperty(PREFIX + PROFILING_URL, "new url")
     System.setProperty(PREFIX + PROFILING_API_KEY, "new api key")
     System.setProperty(PREFIX + PROFILING_TAGS, "f:6,host:test-host")
@@ -371,7 +371,7 @@ class ConfigTest extends DDSpecification {
     config.traceRateLimit == 200
 
     config.profilingEnabled == true
-    config.profilingSite == "new site"
+    config.site == "new site"
     config.profilingUrl == "new url"
     config.profilingApiKey == null // system properties cannot be used to provide a key
     config.mergedProfilingTags == [b: "2", f: "6", (HOST_TAG): "test-host", (RUNTIME_ID_TAG): config.getRuntimeId(), (SERVICE_TAG): config.serviceName, (LANGUAGE_TAG_KEY): LANGUAGE_TAG_VALUE]
@@ -1115,7 +1115,7 @@ class ConfigTest extends DDSpecification {
   def "custom datadog site"() {
     setup:
     def prop = new Properties()
-    prop.setProperty(PROFILING_SITE, "some.new.site")
+    prop.setProperty(SITE, "some.new.site")
 
     when:
     Config config = Config.get(prop)
@@ -1127,7 +1127,7 @@ class ConfigTest extends DDSpecification {
   def "custom profiling url override"() {
     setup:
     def prop = new Properties()
-    prop.setProperty(PROFILING_SITE, "some.new.site")
+    prop.setProperty(SITE, "some.new.site")
     prop.setProperty(PROFILING_URL, "https://some.new.url/goes/here")
 
     when:

--- a/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -40,6 +40,7 @@ import static datadog.trace.api.Config.PROFILING_PROXY_HOST
 import static datadog.trace.api.Config.PROFILING_PROXY_PASSWORD
 import static datadog.trace.api.Config.PROFILING_PROXY_PORT
 import static datadog.trace.api.Config.PROFILING_PROXY_USERNAME
+import static datadog.trace.api.Config.PROFILING_SITE
 import static datadog.trace.api.Config.PROFILING_START_DELAY
 import static datadog.trace.api.Config.PROFILING_START_FORCE_FIRST
 import static datadog.trace.api.Config.PROFILING_TAGS
@@ -133,7 +134,8 @@ class ConfigTest extends DDSpecification {
     config.healthMetricsStatsdPort == null
 
     config.profilingEnabled == false
-    config.profilingUrl == Config.DEFAULT_PROFILING_URL
+    config.profilingSite == Config.DEFAULT_PROFILING_SITE
+    config.profilingUrl == null
     config.profilingApiKey == null
     config.mergedProfilingTags == [(HOST_TAG): config.getHostName(), (RUNTIME_ID_TAG): config.getRuntimeId(), (SERVICE_TAG): config.serviceName, (LANGUAGE_TAG_KEY): LANGUAGE_TAG_VALUE]
     config.profilingStartDelay == 10
@@ -198,6 +200,7 @@ class ConfigTest extends DDSpecification {
     prop.setProperty(TRACE_RATE_LIMIT, "200")
 
     prop.setProperty(PROFILING_ENABLED, "true")
+    prop.setProperty(PROFILING_SITE, "new site")
     prop.setProperty(PROFILING_URL, "new url")
     prop.setProperty(PROFILING_API_KEY, "new api key")
     prop.setProperty(PROFILING_TAGS, "f:6,host:test-host")
@@ -254,6 +257,7 @@ class ConfigTest extends DDSpecification {
     config.traceRateLimit == 200
 
     config.profilingEnabled == true
+    config.profilingSite == "new site"
     config.profilingUrl == "new url"
     config.profilingApiKey == "new api key" // we can still override via internal properties object
     config.mergedProfilingTags == [b: "2", f: "6", (HOST_TAG): "test-host", (RUNTIME_ID_TAG): config.getRuntimeId(), (SERVICE_TAG): config.serviceName, (LANGUAGE_TAG_KEY): LANGUAGE_TAG_VALUE]
@@ -310,6 +314,7 @@ class ConfigTest extends DDSpecification {
     System.setProperty(PREFIX + TRACE_RATE_LIMIT, "200")
 
     System.setProperty(PREFIX + PROFILING_ENABLED, "true")
+    System.setProperty(PREFIX + PROFILING_SITE, "new site")
     System.setProperty(PREFIX + PROFILING_URL, "new url")
     System.setProperty(PREFIX + PROFILING_API_KEY, "new api key")
     System.setProperty(PREFIX + PROFILING_TAGS, "f:6,host:test-host")
@@ -366,6 +371,7 @@ class ConfigTest extends DDSpecification {
     config.traceRateLimit == 200
 
     config.profilingEnabled == true
+    config.profilingSite == "new site"
     config.profilingUrl == "new url"
     config.profilingApiKey == null // system properties cannot be used to provide a key
     config.mergedProfilingTags == [b: "2", f: "6", (HOST_TAG): "test-host", (RUNTIME_ID_TAG): config.getRuntimeId(), (SERVICE_TAG): config.serviceName, (LANGUAGE_TAG_KEY): LANGUAGE_TAG_VALUE]
@@ -1104,5 +1110,30 @@ class ConfigTest extends DDSpecification {
     config.headerTags == [e: "5"]
 
     config.mergedProfilingTags == [a: "1", f: "6", (HOST_TAG): config.getHostName(), (RUNTIME_ID_TAG): config.getRuntimeId(), (SERVICE_TAG): config.serviceName, (LANGUAGE_TAG_KEY): LANGUAGE_TAG_VALUE]
+  }
+
+  def "custom datadog site"() {
+    setup:
+    def prop = new Properties()
+    prop.setProperty(PROFILING_SITE, "some.new.site")
+
+    when:
+    Config config = Config.get(prop)
+
+    then:
+    config.getFinalProfilingUrl() == "https://intake.profile.some.new.site/v1/input"
+  }
+
+  def "custom profiling url override"() {
+    setup:
+    def prop = new Properties()
+    prop.setProperty(PROFILING_SITE, "some.new.site")
+    prop.setProperty(PROFILING_URL, "https://some.new.url/goes/here")
+
+    when:
+    Config config = Config.get(prop)
+
+    then:
+    config.getFinalProfilingUrl() == "https://some.new.url/goes/here"
   }
 }


### PR DESCRIPTION
Add `DD_SITE` (and `dd.site`) configuration option to support sending profiles to different datadog sites (e.g. EU).