### PR TITLE
Fix Extractor edge case with value of a single comma.

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/OpenTracing32.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/OpenTracing32.java
@@ -299,12 +299,15 @@ public final class OpenTracing32 implements TracerAPI {
       extracted = new HashMap<>();
       for (final String key : getter.keys(carrier)) {
         // extracted header value
-        String s = getter.get(carrier, key);
+        String value = getter.get(carrier, key);
         // in case of multiple values in the header, need to parse
-        if (s != null && !s.isEmpty()) {
-          s = s.split(",")[0].trim();
+        if (value != null) {
+          final String[] split = value.split(",");
+          if (split.length > 0) {
+            value = split[0].trim();
+          }
         }
-        extracted.put(key, s);
+        extracted.put(key, value);
       }
     }
 


### PR DESCRIPTION
Turns out the issue wasn't with an empty string returning an empty array, but a string with just `,`.
```
jshell> ",".split(",")
$1 ==> String[0] {  }
```
A non-intuitive edge case in my opinion.