### PR TITLE
Fix reliability branch filter regex

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -360,7 +360,7 @@ workflows:
             branches:
               only:
                 - master
-                - .*-reliability
+                - /.*-reliability/
 
       - check:
           requires:


### PR DESCRIPTION
Regular expressions have to be enclosed with `/`s according to the [circleci docs](https://circleci.com/docs/2.0/configuration-reference/). 🙂 
