### PR TITLE
add dd.{service,env,version} to logs

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/DDSpanTypes.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/DDSpanTypes.java
@@ -5,7 +5,6 @@ public class DDSpanTypes {
   public static final String HTTP_SERVER = "web";
   @Deprecated public static final String WEB_SERVLET = HTTP_SERVER;
   public static final String RPC = "rpc";
-  public static final String CACHE = "cache";
 
   public static final String SQL = "sql";
   public static final String MONGO = "mongodb";

--- a/dd-trace-api/src/main/java/datadog/trace/api/DDTags.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/DDTags.java
@@ -6,7 +6,10 @@ public class DDTags {
   public static final String RESOURCE_NAME = "resource.name";
   public static final String THREAD_NAME = "thread.name";
   public static final String THREAD_ID = "thread.id";
-  public static final String DB_STATEMENT = "sql.query";
+
+  public static final String DD_SERVICE = "dd.service";
+  public static final String DD_ENV = "dd.env";
+  public static final String DD_VERSION = "dd.version";
 
   public static final String HTTP_QUERY = "http.query.string";
   public static final String HTTP_FRAGMENT = "http.fragment.string";


### PR DESCRIPTION
add tags dd.{service,env,version} to MDC log context
- dd.service is always added
- dd.env and dd.version only added if they are configured through corresponding environment variables or java properties 