### PR TITLE
Extend JDBC catch to include Errors

### DIFF
--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/JDBCDecorator.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/JDBCDecorator.java
@@ -73,7 +73,7 @@ public class JDBCDecorator extends DatabaseClientDecorator<DBInfo> {
           if (url != null) {
             try {
               dbInfo = JDBCConnectionUrlParser.parse(url, connection.getClientInfo());
-            } catch (final Exception ex) {
+            } catch (final Throwable ex) {
               // getClientInfo is likely not allowed.
               dbInfo = JDBCConnectionUrlParser.parse(url, null);
             }

--- a/dd-java-agent/instrumentation/jdbc/src/test/groovy/test/TestConnection.groovy
+++ b/dd-java-agent/instrumentation/jdbc/src/test/groovy/test/TestConnection.groovy
@@ -251,7 +251,7 @@ class TestConnection implements Connection {
 
   @Override
   Properties getClientInfo() throws SQLException {
-    throw new UnsupportedOperationException("Test 123")
+    throw new Throwable("Test 123")
   }
 
   @Override


### PR DESCRIPTION
This should help resolve a situation where `getClientInfo` is not implemented and throws an `AbstractMethodError`.