### PR TITLE
Add jCenter as a muzzle repository to catch things that are different from Maven Central

### DIFF
--- a/buildSrc/src/main/groovy/MuzzlePlugin.groovy
+++ b/buildSrc/src/main/groovy/MuzzlePlugin.groovy
@@ -44,7 +44,8 @@ class MuzzlePlugin implements Plugin<Project> {
     RemoteRepository typesafe = new RemoteRepository.Builder("typesafe", "default", "https://repo.typesafe.com/typesafe/releases").build()
     RemoteRepository akka = new RemoteRepository.Builder("akka", "default", "https://dl.bintray.com/akka/maven/").build()
     RemoteRepository atlassian = new RemoteRepository.Builder("atlassian", "default", "https://maven.atlassian.com/content/repositories/atlassian-public/").build()
-    MUZZLE_REPOS = Arrays.asList(central, sonatype, jcenter, spring, jboss, typesafe, akka, atlassian)
+//    MUZZLE_REPOS = Arrays.asList(central, sonatype, jcenter, spring, jboss, typesafe, akka, atlassian)
+    MUZZLE_REPOS = Arrays.asList(central, jcenter, typesafe)
   }
 
   @Override

--- a/buildSrc/src/main/groovy/MuzzlePlugin.groovy
+++ b/buildSrc/src/main/groovy/MuzzlePlugin.groovy
@@ -37,9 +37,14 @@ class MuzzlePlugin implements Plugin<Project> {
   private static final AtomicReference<ClassLoader> TOOLING_LOADER = new AtomicReference<>()
   static {
     RemoteRepository central = new RemoteRepository.Builder("central", "default", "https://repo1.maven.org/maven2/").build()
+    RemoteRepository sonatype = new RemoteRepository.Builder("sonatype", "default", "https://oss.sonatype.org/content/repositories/releases/").build()
     RemoteRepository jcenter = new RemoteRepository.Builder("jcenter", "default", "https://jcenter.bintray.com/").build()
+    RemoteRepository spring = new RemoteRepository.Builder("spring", "default", "https://repo.spring.io/libs-release/").build()
+    RemoteRepository jboss = new RemoteRepository.Builder("jboss", "default", "https://repository.jboss.org/nexus/content/repositories/releases/").build()
     RemoteRepository typesafe = new RemoteRepository.Builder("typesafe", "default", "https://repo.typesafe.com/typesafe/releases").build()
-    MUZZLE_REPOS = new ArrayList<RemoteRepository>(Arrays.asList(central, jcenter, typesafe))
+    RemoteRepository akka = new RemoteRepository.Builder("akka", "default", "https://dl.bintray.com/akka/maven/").build()
+    RemoteRepository atlassian = new RemoteRepository.Builder("atlassian", "default", "https://maven.atlassian.com/content/repositories/atlassian-public/").build()
+    MUZZLE_REPOS = Arrays.asList(central, sonatype, jcenter, spring, jboss, typesafe, akka, atlassian)
   }
 
   @Override
@@ -206,6 +211,9 @@ class MuzzlePlugin implements Plugin<Project> {
     rangeRequest.setArtifact(directiveArtifact)
     final VersionRangeResult rangeResult = system.resolveVersionRange(session, rangeRequest)
 
+//    println "Range Request: " + rangeRequest
+//    println "Range Result: " + rangeResult
+
     final List<Artifact> allVersionArtifacts = filterVersion(rangeResult.versions, muzzleDirective.skipVersions).collect { version ->
       new DefaultArtifact(muzzleDirective.group, muzzleDirective.module, "jar", version.toString())
     }
@@ -362,6 +370,8 @@ class MuzzlePlugin implements Plugin<Project> {
         version.contains(".m") ||
         version.contains("-m") ||
         version.contains("-dev") ||
+        version.contains("-ea") ||
+        version.contains("-atlassian-") ||
         version.contains("public_draft") ||
         skipVersions.contains(version) ||
         version.matches(GIT_SHA_PATTERN)

--- a/buildSrc/src/main/groovy/MuzzlePlugin.groovy
+++ b/buildSrc/src/main/groovy/MuzzlePlugin.groovy
@@ -37,8 +37,9 @@ class MuzzlePlugin implements Plugin<Project> {
   private static final AtomicReference<ClassLoader> TOOLING_LOADER = new AtomicReference<>()
   static {
     RemoteRepository central = new RemoteRepository.Builder("central", "default", "https://repo1.maven.org/maven2/").build()
+    RemoteRepository jcenter = new RemoteRepository.Builder("jcenter", "default", "https://jcenter.bintray.com/").build()
     RemoteRepository typesafe = new RemoteRepository.Builder("typesafe", "default", "https://repo.typesafe.com/typesafe/releases").build()
-    MUZZLE_REPOS = new ArrayList<RemoteRepository>(Arrays.asList(central, typesafe))
+    MUZZLE_REPOS = new ArrayList<RemoteRepository>(Arrays.asList(central, jcenter, typesafe))
   }
 
   @Override

--- a/dd-java-agent/instrumentation/apache-httpclient-4/apache-httpclient-4.gradle
+++ b/dd-java-agent/instrumentation/apache-httpclient-4/apache-httpclient-4.gradle
@@ -3,6 +3,7 @@ muzzle {
     group = "commons-httpclient"
     module = "commons-httpclient"
     versions = "[,4.0)"
+    skipVersions += '3.1-jenkins-1'
   }
   pass {
     group = "org.apache.httpcomponents"

--- a/dd-java-agent/instrumentation/commons-httpclient-2/commons-httpclient-2.gradle
+++ b/dd-java-agent/instrumentation/commons-httpclient-2/commons-httpclient-2.gradle
@@ -3,6 +3,7 @@ muzzle {
     group = "commons-httpclient"
     module = "commons-httpclient"
     versions = "[2.0,]"
+    skipVersions += "3.1-jenkins-1" // odd version in jcenter
     assertInverse = true
   }
 }

--- a/dd-java-agent/instrumentation/elasticsearch/rest-6.4/rest-6.4.gradle
+++ b/dd-java-agent/instrumentation/elasticsearch/rest-6.4/rest-6.4.gradle
@@ -45,9 +45,8 @@ dependencies {
   testCompile group: 'org.elasticsearch.plugin', name: 'transport-netty4-client', version: '6.4.0'
 
   // TODO: The tests are incompatible with 7.x.  The instrumentation may be as well.
-  // FIXME: Lock to specific version due to bad deploy rollout.
-  latestDepTestCompile group: 'org.elasticsearch.client', name: 'elasticsearch-rest-client', version: '6.8.3'
-  latestDepTestCompile group: 'org.elasticsearch.client', name: 'transport', version: '6.8.3'
-  latestDepTestCompile group: 'org.elasticsearch', name: 'elasticsearch', version: '6.8.3'
-  latestDepTestCompile group: 'org.elasticsearch.plugin', name: 'transport-netty4-client', version: '6.8.3'
+  latestDepTestCompile group: 'org.elasticsearch.client', name: 'elasticsearch-rest-client', version: '6.+'
+  latestDepTestCompile group: 'org.elasticsearch.client', name: 'transport', version: '6.+'
+  latestDepTestCompile group: 'org.elasticsearch', name: 'elasticsearch', version: '6.+'
+  latestDepTestCompile group: 'org.elasticsearch.plugin', name: 'transport-netty4-client', version: '6.+'
 }

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5.3/transport-5.3.gradle
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5.3/transport-5.3.gradle
@@ -8,8 +8,7 @@ muzzle {
     group = "org.elasticsearch.client"
     module = "transport"
     versions = "[5.3.0,6.0.0)"
-    // Work around for a bad release of 6.8.4
-//    assertInverse = true
+    assertInverse = true
   }
   pass {
     group = "org.elasticsearch"

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5/transport-5.gradle
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5/transport-5.gradle
@@ -8,8 +8,7 @@ muzzle {
     group = "org.elasticsearch.client"
     module = "transport"
     versions = "[5.0.0,5.3.0)"
-    // Work around for a bad release of 6.8.4
-//    assertInverse = true
+    assertInverse = true
   }
   pass {
     group = "org.elasticsearch"

--- a/dd-java-agent/instrumentation/elasticsearch/transport-6/transport-6.gradle
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-6/transport-6.gradle
@@ -7,13 +7,13 @@ muzzle {
   pass {
     group = "org.elasticsearch.client"
     module = "transport"
-    versions = "[6.0.0,6.8.4)"
+    versions = "[6.0.0,]"
     assertInverse = true
   }
   pass {
     group = "org.elasticsearch"
     module = "elasticsearch"
-    versions = "[6.0.0,)"
+    versions = "[6.0.0,]"
     assertInverse = true
   }
 }

--- a/dd-java-agent/instrumentation/elasticsearch/transport-6/transport-6.gradle
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-6/transport-6.gradle
@@ -8,8 +8,7 @@ muzzle {
     group = "org.elasticsearch.client"
     module = "transport"
     versions = "[6.0.0,6.8.4)"
-    // Work around for a bad release of 6.8.4
-//    assertInverse = true
+    assertInverse = true
   }
   pass {
     group = "org.elasticsearch"

--- a/dd-java-agent/instrumentation/jax-rs-client-1.1/jax-rs-client-1.1.gradle
+++ b/dd-java-agent/instrumentation/jax-rs-client-1.1/jax-rs-client-1.1.gradle
@@ -2,7 +2,9 @@ muzzle {
   pass {
     group = "com.sun.jersey"
     module = "jersey-client"
-    versions = "[,]"
+    versions = "[1.1,]"
+    skipVersions += ['1.0.3-atlassian-1-logpatch', '1.8-atlassian-6']
+    assertInverse = true
   }
 }
 

--- a/dd-java-agent/instrumentation/play-ws-2.1/play-ws-2.1.gradle
+++ b/dd-java-agent/instrumentation/play-ws-2.1/play-ws-2.1.gradle
@@ -14,45 +14,27 @@ testSets {
 }
 
 muzzle {
-  // 2.0.5 was a bad release
 
   fail {
     group = 'com.typesafe.play'
     module = 'play-ahc-ws-standalone_2.11'
-    versions = '[,2.0.4]'
-  }
-  fail {
-    group = 'com.typesafe.play'
-    module = 'play-ahc-ws-standalone_2.11'
-    versions = '[2.0.6,)'
+    versions = '[,]'
   }
 
-  fail {
-    group = 'com.typesafe.play'
-    module = 'play-ahc-ws-standalone_2.12'
-    versions = '[,2.0.4]'
-  }
-  fail {
-    group = 'com.typesafe.play'
-    module = 'play-ahc-ws-standalone_2.12'
-    versions = '[2.0.6,2.1.0)'
-  }
   pass {
     group = 'com.typesafe.play'
     module = 'play-ahc-ws-standalone_2.12'
     versions = '[2.1.0,]'
+    skipVersions += '2.0.5' // Bad release
+    assertInverse = true
   }
 
-  // No Scala 2.13 versions below 2.0.6 exist
-  fail {
-    group = 'com.typesafe.play'
-    module = 'play-ahc-ws-standalone_2.13'
-    versions = '[2.0.6,2.1.0)'
-  }
   pass {
     group = 'com.typesafe.play'
     module = 'play-ahc-ws-standalone_2.13'
     versions = '[2.1.0,]'
+    skipVersions += '2.0.5' // Bad release
+    assertInverse = true
   }
 }
 

--- a/dd-java-agent/instrumentation/play-ws-2/play-ws-2.gradle
+++ b/dd-java-agent/instrumentation/play-ws-2/play-ws-2.gradle
@@ -14,38 +14,20 @@ testSets {
 }
 
 muzzle {
-  // 2.0.5 was a bad release
 
-  fail {
-    group = 'com.typesafe.play'
-    module = 'play-ahc-ws-standalone_2.11'
-    versions = '[,2.0.0)'
-  }
   pass {
-    group = 'com.typesafe.play'
     module = 'play-ahc-ws-standalone_2.11'
-    versions = '[2.0.0,2.0.4]'
-  }
-  pass {
     group = 'com.typesafe.play'
-    module = 'play-ahc-ws-standalone_2.11'
-    versions = '[2.0.6,]'
+    versions = '[2.0.0,]'
+    assertInverse = true
   }
 
-  fail {
-    group = 'com.typesafe.play'
-    module = 'play-ahc-ws-standalone_2.12'
-    versions = '[,2.0.0)'
-  }
   pass {
     group = 'com.typesafe.play'
     module = 'play-ahc-ws-standalone_2.12'
-    versions = '[2.0.0,2.0.4]'
-  }
-  pass {
-    group = 'com.typesafe.play'
-    module = 'play-ahc-ws-standalone_2.12'
-    versions = '[2.0.6,2.1.0)'
+    versions = '[2.0.0,2.1.0)'
+    skipVersions += '2.0.5' // Bad release
+    assertInverse = true
   }
 
   // No Scala 2.13 versions below 2.0.6 exist

--- a/dd-java-agent/instrumentation/servlet/servlet.gradle
+++ b/dd-java-agent/instrumentation/servlet/servlet.gradle
@@ -9,6 +9,8 @@ muzzle {
     group = "javax.servlet"
     module = 'servlet-api'
     versions = "[,]"
+    skipVersions += '0'
+    assertInverse = true
   }
 }
 

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/spring-webmvc-3.1.gradle
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/spring-webmvc-3.1.gradle
@@ -1,36 +1,20 @@
 muzzle {
-  fail {
-    group = 'org.springframework'
-    module = 'spring-webmvc'
-    versions = "[,1.2.1)"
-    extraDependency "javax.servlet:javax.servlet-api:3.0.1"
-  }
-  // 1.2.1-1.2.4 have broken dependencies.
-  fail {
-    group = 'org.springframework'
-    module = 'spring-webmvc'
-    versions = "(1.2.4,3.1.0.RELEASE)"
-    extraDependency "javax.servlet:javax.servlet-api:3.0.1"
-  }
   pass {
     group = 'org.springframework'
     module = 'spring-webmvc'
-    versions = "[3.1.0.RELEASE,3.2.1.RELEASE)"
+    versions = "[3.1.0.RELEASE,]"
+    skipVersions += ['1.2.1', '1.2.2', '1.2.3', '1.2.4'] // broken releases... missing dependencies
+    skipVersions += '3.2.1.RELEASE' // missing a required class.  (bad release?)
     extraDependency "javax.servlet:javax.servlet-api:3.0.1"
-  }
-  // 3.2.1.RELEASE is missing a required class.  (bad release?)
-  pass {
-    group = 'org.springframework'
-    module = 'spring-webmvc'
-    versions = "(3.2.1.RELEASE,]"
-    extraDependency "javax.servlet:javax.servlet-api:3.0.1"
+    assertInverse = true
   }
 
   // FIXME: webmvc depends on web, so we need a separate integration for spring-web specifically.
   fail {
     group = 'org.springframework'
     module = 'spring-web'
-    versions = "(1.2.4,]"
+    versions = "[,]"
+    skipVersions += ['1.2.1', '1.2.2', '1.2.3', '1.2.4'] // broken releases... missing dependencies
     extraDependency "javax.servlet:javax.servlet-api:3.0.1"
   }
 }


### PR DESCRIPTION
For example in the latest release `jetty-server`'s version list was messed up:
https://repo1.maven.org/maven2/org/glassfish/jersey/core/jersey-server/maven-metadata.xml
but still available in jcenter:
https://jcenter.bintray.com/org/glassfish/jersey/core/jersey-server/maven-metadata.xml

Add `skipVersions` to muzzle to handle bad versions found in various repositories.

Roll back various hacks around the broken versions.