### PR TITLE
Update issues when Release Notes are published

### DIFF
--- a/.github/workflows/update-issues-on-release.yaml
+++ b/.github/workflows/update-issues-on-release.yaml
@@ -1,0 +1,58 @@
+name: Update issues on release
+on:
+  release:
+    types: [published]
+
+jobs:
+  update_issues:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get milestone for release
+        id: milestone
+        uses: actions/github-script@0.9.0
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const milestones = await github.issues.listMilestonesForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'all'
+            })
+
+            return milestones.data.find( milestone => milestone.title == "${{github.event.release.name}}" ).number
+      - name: Get issues for milestone
+        id: issues
+        uses: actions/github-script@0.9.0
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const list = await github.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'all',
+              milestone: ${{steps.milestone.outputs.result}}
+            })
+
+            // Pull requests are issues so filter them out
+            return list.data.filter( issue => !issue["pull_request"] )
+      - name: Comment and close issues
+        uses: actions/github-script@0.9.0
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            for (let issue of ${{ steps.issues.outputs.result }}) {
+              // This can be parallelized better by moving the await but it might trip rate limits
+              await github.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: ':robot: This issue has been addressed in the latest release.  See full details in the [Release Notes]( ${{ github.event.release.html_url }}).'
+              })
+
+              await github.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: 'closed'
+              })
+            }


### PR DESCRIPTION
When Release Notes are published, this Github Action updates all issues in the milestone with the text:

:robot: This issue has been addressed in the latest release.  See full details in the [Release Notes]( ${{ github.event.release.html_url }}).'

and closes the issue