### PR TITLE
Draft release notes on milestone close

### DIFF
--- a/.github/workflows/draft-release-notes-on-milestone-close.yaml
+++ b/.github/workflows/draft-release-notes-on-milestone-close.yaml
@@ -1,0 +1,51 @@
+name: Create draft release notes
+on:
+  milestone:
+    types: [closed]
+
+jobs:
+  draft_release_notes:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get pull requests for milestone
+        id: pullsA
+        uses: actions/github-script@0.9.0
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const options = github.pulls.list.endpoint.merge({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'closed'
+            })
+
+            const pullRequests = await github.paginate(options)
+
+            return pullRequests.filter(pullRequest => pullRequest.merged_at
+              && pullRequest.milestone
+              && pullRequest.milestone.number == ${{ github.event.milestone.number }})
+      - name: Generate release notes text
+        id: generate
+        uses: actions/github-script@0.9.0
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            var draftText = "# Improvements \n\n# Changes \n\n"
+            for (let pull of ${{ steps.pullsA.outputs.result }}) {
+              draftText += "* " + pull.title + " #" + pull.number + " \n"
+            }
+            draftText += "\n# Fixes \n"
+            return draftText
+      - name: Create release notes draft
+        uses: actions/github-script@0.9.0
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            await github.repos.createRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: 'v' + '${{ github.event.milestone.title }}',
+              name: '${{ github.event.milestone.title}}',
+              draft: true,
+              body: ${{ steps.generate.outputs.result }}
+            })


### PR DESCRIPTION
This github action creates draft release notes from a milestone when it is closed.  The release notes **still have to be manually edited** (because it doesn't know categories and pull request titles aren't always the best), but this should greatly reduce the effort and copy/paste involved.