### PR TITLE
Add limit for grizzly latestDepTest

### DIFF
--- a/dd-java-agent/instrumentation/grizzly-2/grizzly-2.gradle
+++ b/dd-java-agent/instrumentation/grizzly-2/grizzly-2.gradle
@@ -28,6 +28,6 @@ dependencies {
   testCompile group: 'org.glassfish.jersey.containers', name: 'jersey-container-grizzly2-http', version: '2.0'
 
   latestDepTestCompile group: 'org.glassfish.grizzly', name: 'grizzly-http-server', version: '+'
-  latestDepTestCompile group: 'org.glassfish.jersey.containers', name: 'jersey-container-grizzly2-http', version: '+'
-  latestDepTestCompile group: 'org.glassfish.jersey.inject', name: 'jersey-hk2', version: '+'
+  latestDepTestCompile group: 'org.glassfish.jersey.containers', name: 'jersey-container-grizzly2-http', version: '2.+'
+  latestDepTestCompile group: 'org.glassfish.jersey.inject', name: 'jersey-hk2', version: '2.+'
 }


### PR DESCRIPTION
New `3.0.0-M1` release seems to be breaking the tests.