### PR TITLE
Improve message when running with < JDK8

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
@@ -321,7 +321,8 @@ public class Agent {
       Profiling is compiled for Java8. Loading it on Java7 results in ClassFormatError
       (more specifically UnsupportedClassVersionError). Just ignore and continue when this happens.
       */
-      log.error("Cannot start profiling agent ", e);
+      log.error("Profiling requires OpenJDK 8 or above - skipping");
+      log.debug("Cannot start profiling agent ", e);
     } catch (final Throwable ex) {
       log.error("Throwable thrown while starting profiling agent", ex);
     } finally {


### PR DESCRIPTION
Instead of having `java.lang.UnsupportedClassVersionError: com/datadog/profiling/agent/ProfilingAgent : Unsupported major.minor version 52.0` 
we don't show the stack trace and just indicating we need at least Open JDK8 and we are skipping profiling:
`Profiling requires OpenJDK 8 or above - skipping`