### PR TITLE
Make scope event threshold 0 ms

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/resources/jfr/dd.jfp
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/resources/jfr/dd.jfp
@@ -240,6 +240,6 @@ jdk.ZStatisticsCounter#enabled=true
 jdk.ZStatisticsSampler#enabled=true
 jdk.ZStatisticsSampler#threshold=10 ms
 datadog.Scope#enabled=true
-datadog.Scope#threshold=10 ms
+datadog.Scope#threshold=0 ms
 datadog.ExceptionSample#enabled=true
 datadog.ExceptionCount#enabled=true


### PR DESCRIPTION
In async frameworks we often have situations when span is activated
for a very short time only to 'pass thing along'. 10 ms threshold
resulted in those activations not being recorded.