### PR TITLE
Apply copy artifact to only master and *-reliability

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -262,6 +262,18 @@ jobs:
   publish_tag:
     <<: *publish
 
+  copy_artifact_s3:
+    docker:
+      - image: circleci/python:3.6.4
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run:
+          command: |
+            sudo pip install boto3
+            python .circleci/copy_artifact_s3.py
+
 workflows:
   version: 2
   build_test_deploy:
@@ -362,6 +374,16 @@ workflows:
           filters:
             tags:
               only: /.*/
+
+      - copy_artifact_s3:
+          context: AWS_ACCESS
+          requires:
+            - build
+          filters:
+            branches:
+              only:
+                - master
+                - .*-reliability
 
       - check:
           requires:

--- a/.circleci/copy_artifact_s3.py
+++ b/.circleci/copy_artifact_s3.py
@@ -1,0 +1,23 @@
+import boto3
+import re
+import os
+import tempfile
+
+LIBS_PATH = './workspace/dd-java-agent/build/libs'
+p = re.compile(r"dd-java-agent.*jar$")
+
+S3_BUCKET_NAME = 'datadog-reliability-env'
+client = boto3.client('s3', aws_access_key_id=os.getenv('AWS_ACCESS_KEY_ID'),aws_secret_access_key=os.getenv('AWS_SECRET_ACCESS_KEY'))
+transfer = boto3.s3.transfer.S3Transfer(client)
+
+for path, sub_dirs, files in os.walk(LIBS_PATH):
+    for name in files:
+      if p.match(name):
+        # Write the artifact to S3
+        transfer.upload_file(os.path.join(path, name), S3_BUCKET_NAME, f'java/{name}')
+        # write additional information used by the build
+        with tempfile.NamedTemporaryFile(mode='w') as fp:
+          for line in [os.getenv('CIRCLE_BRANCH'), os.getenv('CIRCLE_SHA1'), name, os.getenv('CIRCLE_USERNAME')]:
+            fp.write(f'{line}\n')
+          fp.seek(0)
+          transfer.upload_file(fp.name, S3_BUCKET_NAME, 'java/index.txt')

--- a/.circleci/copy_artifact_s3.py
+++ b/.circleci/copy_artifact_s3.py
@@ -3,13 +3,13 @@ import re
 import os
 import tempfile
 
-LIBS_PATH = './workspace/dd-java-agent/build/libs'
-p = re.compile(r"dd-java-agent.*jar$")
 
 S3_BUCKET_NAME = 'datadog-reliability-env'
 client = boto3.client('s3', aws_access_key_id=os.getenv('AWS_ACCESS_KEY_ID'),aws_secret_access_key=os.getenv('AWS_SECRET_ACCESS_KEY'))
 transfer = boto3.s3.transfer.S3Transfer(client)
 
+p = re.compile(r"dd-java-agent.*jar$")
+LIBS_PATH = './workspace/dd-java-agent/build/libs'
 for path, sub_dirs, files in os.walk(LIBS_PATH):
     for name in files:
       if p.match(name):
@@ -17,7 +17,9 @@ for path, sub_dirs, files in os.walk(LIBS_PATH):
         transfer.upload_file(os.path.join(path, name), S3_BUCKET_NAME, f'java/{name}')
         # write additional information used by the build
         with tempfile.NamedTemporaryFile(mode='w') as fp:
-          for line in [os.getenv('CIRCLE_BRANCH'), os.getenv('CIRCLE_SHA1'), name, os.getenv('CIRCLE_USERNAME')]:
-            fp.write(f'{line}\n')
+          fp.write(f"{os.getenv('CIRCLE_BRANCH')}\n")
+          fp.write(f"{os.getenv('CIRCLE_SHA1')}\n")
+          fp.write(f"{name}\n")
+          fp.write(f"{os.getenv('CIRCLE_USERNAME')}\n")
           fp.seek(0)
           transfer.upload_file(fp.name, S3_BUCKET_NAME, 'java/index.txt')


### PR DESCRIPTION
Use context to securely handle secrets. It is a short term solution until moving the build to gitlab  