### PR TITLE
Add null servlet context check

### DIFF
--- a/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Decorator.java
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Decorator.java
@@ -78,6 +78,10 @@ public class Servlet3Decorator
    */
   private void onContext(
       final AgentSpan span, final HttpServletRequest request, final ServletContext context) {
+    if (context == null) {
+      // some frameworks (jetty) may return a null context.
+      return;
+    }
     final Object attribute = context.getAttribute("dd.dispatcher-filter");
     if (attribute instanceof Filter) {
       request.setAttribute(DD_SPAN_ATTRIBUTE, span);

--- a/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/AbstractServlet3Test.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/AbstractServlet3Test.groovy
@@ -92,7 +92,9 @@ abstract class AbstractServlet3Test<SERVER, CONTEXT> extends HttpServerTest<SERV
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
         "$Tags.HTTP_STATUS" endpoint.status
-        "servlet.context" "/$context"
+        if (context) {
+          "servlet.context" "/$context"
+        }
         "servlet.path" { it == endpoint.path || it == "/dispatch$endpoint.path" }
         "span.origin.type" { it == servlet.name || it == ApplicationFilterChain.name }
         if (endpoint.errored) {

--- a/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/JettyServletHandlerTest.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/JettyServletHandlerTest.groovy
@@ -1,0 +1,56 @@
+import org.eclipse.jetty.server.Server
+import org.eclipse.jetty.server.handler.ErrorHandler
+import org.eclipse.jetty.servlet.ServletHandler
+
+import javax.servlet.Servlet
+import javax.servlet.http.HttpServletRequest
+
+class JettyServletHandlerTest extends AbstractServlet3Test<Server, ServletHandler> {
+
+  @Override
+  Server startServer(int port) {
+    Server server = new Server(port)
+    ServletHandler handler = new ServletHandler()
+    server.setHandler(handler)
+    setupServlets(handler)
+    server.addBean(new ErrorHandler() {
+      protected void handleErrorPage(HttpServletRequest request, Writer writer, int code, String message) throws IOException {
+        Throwable th = (Throwable) request.getAttribute("javax.servlet.error.exception")
+        writer.write(th ? th.message : message)
+      }
+    })
+    server.start()
+    return server
+  }
+
+  @Override
+  void addServlet(ServletHandler servletHandler, String path, Class<Servlet> servlet) {
+    servletHandler.addServletWithMapping(servlet, path)
+  }
+
+  @Override
+  void stopServer(Server server) {
+    server.stop()
+    server.destroy()
+  }
+
+  @Override
+  String getContext() {
+    ""
+  }
+
+  @Override
+  Class<Servlet> servlet() {
+    TestServlet3.Sync
+  }
+
+  @Override
+  String expectedServiceName() {
+    "unnamed-java-app"
+  }
+
+  @Override
+  boolean testNotFound() {
+    false
+  }
+}


### PR DESCRIPTION
```
java.lang.NullPointerException
	at datadog.trace.instrumentation.servlet3.Servlet3Decorator.onContext(Servlet3Decorator.java:81)
	at datadog.trace.instrumentation.servlet3.Servlet3Decorator.onRequest(Servlet3Decorator.java:68)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:782)
	at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:755)
	at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:547)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:190)
	at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:485)
	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:141)
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:127)
	at org.eclipse.jetty.server.Server.handle(Server.java:500)
	at org.eclipse.jetty.server.HttpChannel.lambda$handle$1(HttpChannel.java:383)
	at org.eclipse.jetty.server.HttpChannel.dispatch(HttpChannel.java:547)
	at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:375)
	at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:270)
	at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:311)
	at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:103)
	at org.eclipse.jetty.io.ChannelEndPoint$2.run(ChannelEndPoint.java:117)
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:806)
	at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run(QueuedThreadPool.java:938)
	at java.base/java.lang.Thread.run(Thread.java:844)
```