### PR TITLE
Reduce finalize() logspam in CoreTracer

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -199,8 +199,10 @@ public class CoreTracer
   @Override
   public void finalize() {
     try {
-      Runtime.getRuntime().removeShutdownHook(shutdownCallback);
       shutdownCallback.run();
+      Runtime.getRuntime().removeShutdownHook(shutdownCallback);
+    } catch (final IllegalStateException e) {
+      // Do nothing.  Already shutting down
     } catch (final Exception e) {
       log.error("Error while finalizing DDTracer.", e);
     }


### PR DESCRIPTION
Trying to remove the shutdown hook in finalize often leads to an `IllegalStateException`.  This is expected if the jvm is already shutting down.

This pull request removes that logging