### PR TITLE
Change logging for ScopeEventFactory creation exception

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -441,7 +441,7 @@ public class CoreTracer
       return (DDScopeEventFactory)
           Class.forName("datadog.trace.core.jfr.openjdk.ScopeEventFactory").newInstance();
     } catch (final ClassFormatError | ReflectiveOperationException | NoClassDefFoundError e) {
-      log.debug("Cannot create Openjdk JFR scope event factory", e);
+      log.debug("Profiling ScopeEvents is disabled");
     }
     return new DDNoopScopeEventFactory();
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -441,7 +441,7 @@ public class CoreTracer
       return (DDScopeEventFactory)
           Class.forName("datadog.trace.core.jfr.openjdk.ScopeEventFactory").newInstance();
     } catch (final ClassFormatError | ReflectiveOperationException | NoClassDefFoundError e) {
-      log.debug("Profiling ScopeEvents is disabled");
+      log.debug("Profiling of ScopeEvents is not available");
     }
     return new DDNoopScopeEventFactory();
   }


### PR DESCRIPTION
Related to #1345 and similar to #1395 

The `datadog.trace.core.jfr.openjdk.ScopeEventFactory` class not being available happens in multiple common cases:
- Running without the agent
- Many tests that don't add the `jfr-openjdk` dependency
- JDK version < 8

Logging the exception creates the mistaken impression of an error and creates a lot of spam in the test logs.