### PR TITLE
Remove previously deprecated methods and make Continuation static

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -257,3 +257,34 @@ acceptedBreaks:
       old: "method datadog.opentracing.DDTracer.DDSpanBuilder datadog.opentracing.DDTracer.DDSpanBuilder::withLogHandler(datadog.opentracing.LogHandler)"
       justification: "LogManager set once instead of per-span"
     # End: Breaking changes
+  "0.51.0":
+    com.datadoghq:dd-trace-ot:
+    - code: "java.method.removed"
+      old: "method datadog.trace.bootstrap.instrumentation.api.AgentScope datadog.trace.bootstrap.instrumentation.api.AgentTracer.TracerAPI::activateSpan(datadog.trace.bootstrap.instrumentation.api.AgentSpan,\
+        \ boolean)"
+      justification: "Removed deprecated APIs preventing refactoring"
+    - code: "java.method.removed"
+      old: "method datadog.trace.bootstrap.instrumentation.api.AgentScope datadog.trace.bootstrap.instrumentation.api.AgentTracer::activateSpan(datadog.trace.bootstrap.instrumentation.api.AgentSpan,\
+        \ boolean)"
+      justification: "Removed deprecated APIs preventing refactoring"
+    - code: "java.method.removed"
+      old: "method datadog.trace.bootstrap.instrumentation.api.AgentScope datadog.trace.core.CoreTracer.CoreSpanBuilder::startActive(boolean)"
+      justification: "Removed deprecated APIs preventing refactoring"
+    - code: "java.method.removed"
+      old: "method datadog.trace.bootstrap.instrumentation.api.AgentScope datadog.trace.core.CoreTracer::activateSpan(datadog.trace.bootstrap.instrumentation.api.AgentSpan,\
+        \ boolean)"
+      justification: "Removed deprecated APIs preventing refactoring"
+    - code: "java.method.removed"
+      old: "method datadog.trace.bootstrap.instrumentation.api.AgentScope datadog.trace.core.scopemanager.ContextualScopeManager::activate(datadog.trace.bootstrap.instrumentation.api.AgentSpan,\
+        \ boolean)"
+      justification: "Removed deprecated APIs preventing refactoring"
+    - code: "java.method.removed"
+      old: "method datadog.trace.bootstrap.instrumentation.api.AgentScope datadog.trace.core.scopemanager.DDScopeManager::activate(datadog.trace.bootstrap.instrumentation.api.AgentSpan,\
+        \ boolean)"
+      justification: "Removed deprecated APIs preventing refactoring"
+    - code: "java.method.removed"
+      old: "method void datadog.trace.core.scopemanager.ContinuableScope.Continuation::close()"
+      justification: "Removed deprecated APIs preventing refactoring"
+    - code: "java.method.removed"
+      old: "method void datadog.trace.core.scopemanager.ContinuableScope.Continuation::close(boolean)"
+      justification: "Removed deprecated APIs preventing refactoring"

--- a/dd-java-agent/instrumentation/hibernate/src/main/java/datadog/trace/instrumentation/hibernate/SessionMethodUtils.java
+++ b/dd-java-agent/instrumentation/hibernate/src/main/java/datadog/trace/instrumentation/hibernate/SessionMethodUtils.java
@@ -17,8 +17,10 @@ public class SessionMethodUtils {
   public static final Set<String> SCOPE_ONLY_METHODS =
       new HashSet<>(Arrays.asList("immediateLoad", "internalLoad"));
 
-  // Starts a scope as a child from a Span, where the Span is attached to the given spanKey using
-  // the given contextStore.
+  /**
+   * Starts a scope as a child from a Span, where the Span is attached to the given spanKey using
+   * the given contextStore.
+   */
   public static <TARGET, ENTITY> SessionState startScopeFrom(
       final ContextStore<TARGET, SessionState> contextStore,
       final TARGET spanKey,
@@ -52,7 +54,7 @@ public class SessionMethodUtils {
     return sessionState;
   }
 
-  // Closes a Scope/Span, adding an error tag if the given Throwable is not null.
+  /** Closes a Scope/Span, adding an error tag if the given Throwable is not null. */
   public static void closeScope(
       final SessionState sessionState,
       final Throwable throwable,
@@ -81,8 +83,10 @@ public class SessionMethodUtils {
     sessionState.setMethodScope(null);
   }
 
-  // Copies a span from the given Session ContextStore into the targetContextStore. Used to
-  // propagate a Span from a Session to transient Session objects such as Transaction and Query.
+  /**
+   * Copies a span from the given Session ContextStore into the targetContextStore. Used to
+   * propagate a Span from a Session to transient Session objects such as Transaction and Query.
+   */
   public static <S, T> void attachSpanFromStore(
       final ContextStore<S, SessionState> sourceContextStore,
       final S source,

--- a/dd-trace-api/src/main/java/datadog/trace/context/TraceScope.java
+++ b/dd-trace-api/src/main/java/datadog/trace/context/TraceScope.java
@@ -27,8 +27,9 @@ public interface TraceScope extends Closeable {
   void setAsyncPropagation(boolean value);
 
   /**
-   * Used to pass async context between workers. Either activate or cancel must be called on each
-   * continuation instance to allow the trace to be reported.
+   * Used to pass async context between workers. A trace will not be reported until all spans and
+   * continuations are resolved. You must call activate (and close on the returned scope) or cancel
+   * on each continuation to avoid discarding traces.
    */
   interface Continuation {
 
@@ -44,22 +45,5 @@ public interface TraceScope extends Closeable {
 
     /** Allow trace to stop waiting on this continuation for reporting. */
     void cancel();
-
-    /**
-     * Cancel the continuation. This also closes parent scope.
-     *
-     * @deprecated use {@link #cancel()} instead. Will be removed in the next release.
-     */
-    @Deprecated
-    void close();
-
-    /**
-     * Close the continuation.
-     *
-     * @deprecated use {@link #cancel()} instead. Will be removed in the next release.
-     * @param closeContinuationScope true iff parent scope should also be closed
-     */
-    @Deprecated
-    void close(boolean closeContinuationScope);
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -283,14 +283,7 @@ public class CoreTracer
 
   @Override
   public AgentScope activateSpan(final AgentSpan span) {
-    return activateSpan(span, false);
-  }
-
-  /** @deprecated use {@link #activateSpan(AgentSpan)} instead */
-  @Deprecated
-  @Override
-  public AgentScope activateSpan(final AgentSpan span, final boolean finishSpanOnClose) {
-    return scopeManager.activate(span, finishSpanOnClose);
+    return scopeManager.activate(span);
   }
 
   @Override
@@ -481,15 +474,6 @@ public class CoreTracer
 
     private DDSpan buildSpan() {
       return DDSpan.create(timestampMicro, buildSpanContext());
-    }
-
-    /** @deprecated use {@link #start()} instead. */
-    @Deprecated
-    public AgentScope startActive(final boolean finishSpanOnClose) {
-      final AgentSpan span = buildSpan();
-      final AgentScope scope = scopeManager.activate(span, finishSpanOnClose);
-      log.debug("Starting a new active span: {}", span);
-      return scope;
     }
 
     public AgentSpan start() {

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContextualScopeManager.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContextualScopeManager.java
@@ -26,13 +26,6 @@ public class ContextualScopeManager implements DDScopeManager {
 
   @Override
   public AgentScope activate(final AgentSpan span) {
-    return activate(span, false);
-  }
-
-  /** @deprecated use {@link #activate(AgentSpan)} instead. */
-  @Deprecated
-  @Override
-  public AgentScope activate(final AgentSpan span, final boolean finishOnClose) {
     final DDScope active = tlsScope.get();
     if (active != null && active.span().equals(span)) {
       return active.incrementReferences();
@@ -44,10 +37,10 @@ public class ContextualScopeManager implements DDScopeManager {
     }
 
     if (span instanceof DDSpan) {
-      return new ContinuableScope(this, (DDSpan) span, finishOnClose, scopeEventFactory);
+      return new ContinuableScope(this, (DDSpan) span, scopeEventFactory);
     } else {
       // Noop Span
-      return new SimpleScope(this, span, finishOnClose);
+      return new SimpleScope(this, span);
     }
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScope.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScope.java
@@ -7,7 +7,6 @@ import datadog.trace.core.DDSpanContext;
 import datadog.trace.core.PendingTrace;
 import datadog.trace.core.jfr.DDScopeEvent;
 import datadog.trace.core.jfr.DDScopeEventFactory;
-import java.io.Closeable;
 import java.lang.ref.WeakReference;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -25,10 +24,6 @@ public class ContinuableScope implements DDScope {
   private final DDScopeEventFactory eventFactory;
   /** Event for this scope */
   private final DDScopeEvent event;
-  /** If true, finish the span when openCount hits 0. */
-  private final boolean finishOnClose;
-  /** Count of open scope and continuations */
-  private final AtomicInteger openCount;
   /** Scope to placed in the thread local after close. May be null. */
   private final DDScope toRestore;
   /** Continuation that created this scope. May be null. */
@@ -43,24 +38,19 @@ public class ContinuableScope implements DDScope {
   ContinuableScope(
       final ContextualScopeManager scopeManager,
       final DDSpan spanUnderScope,
-      final boolean finishOnClose,
       final DDScopeEventFactory eventFactory) {
-    this(scopeManager, new AtomicInteger(1), null, spanUnderScope, finishOnClose, eventFactory);
+    this(scopeManager, null, spanUnderScope, eventFactory);
   }
 
   private ContinuableScope(
       final ContextualScopeManager scopeManager,
-      final AtomicInteger openCount,
       final Continuation continuation,
       final DDSpan spanUnderScope,
-      final boolean finishOnClose,
       final DDScopeEventFactory eventFactory) {
     assert spanUnderScope != null : "span must not be null";
     this.scopeManager = scopeManager;
-    this.openCount = openCount;
     this.continuation = continuation;
     this.spanUnderScope = spanUnderScope;
-    this.finishOnClose = finishOnClose;
     this.eventFactory = eventFactory;
     event = eventFactory.create(spanUnderScope.context());
     event.start();
@@ -84,10 +74,6 @@ public class ContinuableScope implements DDScope {
 
     if (null != continuation) {
       spanUnderScope.context().getTrace().cancelContinuation(continuation);
-    }
-
-    if (openCount.decrementAndGet() == 0 && finishOnClose) {
-      spanUnderScope.finish();
     }
 
     for (final ScopeListener listener : scopeManager.scopeListeners) {
@@ -143,7 +129,7 @@ public class ContinuableScope implements DDScope {
   @Override
   public Continuation capture() {
     if (isAsyncPropagating()) {
-      return new Continuation();
+      return new Continuation(spanUnderScope, scopeManager, eventFactory);
     } else {
       return null;
     }
@@ -154,15 +140,29 @@ public class ContinuableScope implements DDScope {
     return super.toString() + "->" + spanUnderScope;
   }
 
-  public class Continuation implements Closeable, TraceScope.Continuation {
+  /**
+   * Static to avoid an unconstrained chain of references (using too much memory), but nested to
+   * maintain private constructor access.
+   */
+  public static class Continuation implements TraceScope.Continuation {
     public WeakReference<Continuation> ref;
 
-    private final AtomicBoolean used = new AtomicBoolean(false);
-    private final PendingTrace trace;
+    private final DDSpan spanUnderScope;
+    private final ContextualScopeManager scopeManager;
+    private final DDScopeEventFactory eventFactory;
 
-    private Continuation() {
-      openCount.incrementAndGet();
-      final DDSpanContext context = spanUnderScope.context();
+    private final PendingTrace trace;
+    private final AtomicBoolean used = new AtomicBoolean(false);
+
+    private Continuation(
+        final DDSpan spanUnderScope,
+        final ContextualScopeManager scopeManager,
+        final DDScopeEventFactory eventFactory) {
+
+      this.spanUnderScope = spanUnderScope;
+      this.scopeManager = scopeManager;
+      this.eventFactory = eventFactory;
+      final DDSpanContext context = this.spanUnderScope.context();
       trace = context.getTrace();
       trace.registerContinuation(this);
     }
@@ -171,48 +171,20 @@ public class ContinuableScope implements DDScope {
     public ContinuableScope activate() {
       if (used.compareAndSet(false, true)) {
         final ContinuableScope scope =
-            new ContinuableScope(
-                scopeManager, openCount, this, spanUnderScope, finishOnClose, eventFactory);
+            new ContinuableScope(scopeManager, this, spanUnderScope, eventFactory);
         log.debug("Activating continuation {}, scope: {}", this, scope);
         return scope;
       } else {
         log.debug(
-            "Failed to activate continuation. Reusing a continuation not allowed.  Returning a new scope. Spans will not be linked.");
-        return new ContinuableScope(
-            scopeManager, new AtomicInteger(1), null, spanUnderScope, finishOnClose, eventFactory);
+            "Failed to activate continuation. Reusing a continuation not allowed.  Returning a new scope. Spans may be reported separately.");
+        return new ContinuableScope(scopeManager, null, spanUnderScope, eventFactory);
       }
     }
 
+    @Override
     public void cancel() {
-      assert !finishOnClose : "cancel() should not be used with finishOnClose=true";
       if (used.compareAndSet(false, true)) {
         trace.cancelContinuation(this);
-      } else {
-        log.debug("Failed to close continuation {}. Already used.", this);
-      }
-    }
-
-    /** @deprecated use {@link #cancel()} instead. */
-    @Deprecated
-    @Override
-    public void close() {
-      close(true);
-    }
-
-    /** @deprecated use {@link #cancel()} instead. */
-    @Deprecated
-    @Override
-    public void close(final boolean closeContinuationScope) {
-      if (used.compareAndSet(false, true)) {
-        trace.cancelContinuation(this);
-        if (closeContinuationScope) {
-          ContinuableScope.this.close();
-        } else {
-          // Same as in 'close()' above.
-          if (openCount.decrementAndGet() == 0 && finishOnClose) {
-            spanUnderScope.finish();
-          }
-        }
       } else {
         log.debug("Failed to close continuation {}. Already used.", this);
       }

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScope.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScope.java
@@ -144,6 +144,7 @@ public class ContinuableScope implements DDScope {
    * Static to avoid an unconstrained chain of references (using too much memory), but nested to
    * maintain private constructor access.
    */
+  @Slf4j // This is important to prevent the log messages below from referencing the super class.
   public static class Continuation implements TraceScope.Continuation {
     public WeakReference<Continuation> ref;
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/DDScopeManager.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/DDScopeManager.java
@@ -10,10 +10,6 @@ import datadog.trace.context.TraceScope;
 public interface DDScopeManager {
   AgentScope activate(AgentSpan span);
 
-  /** @deprecated use {@link #activate(AgentSpan)} instead. */
-  @Deprecated
-  AgentScope activate(AgentSpan span, boolean finishOnClose);
-
   TraceScope active();
 
   AgentSpan activeSpan();

--- a/dd-trace-ot/src/main/java/datadog/opentracing/CustomScopeManagerWrapper.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/CustomScopeManagerWrapper.java
@@ -34,16 +34,9 @@ class CustomScopeManagerWrapper implements DDScopeManager {
   }
 
   @Override
-  public AgentScope activate(final AgentSpan span) {
-    return activate(span, false);
-  }
-
-  /** @deprecated use {@link #activate(AgentSpan)} instead. */
-  @Deprecated
-  @Override
-  public AgentScope activate(final AgentSpan agentSpan, final boolean finishOnClose) {
+  public AgentScope activate(final AgentSpan agentSpan) {
     final Span span = converter.toSpan(agentSpan);
-    final Scope scope = delegate.activate(span, finishOnClose);
+    final Scope scope = delegate.activate(span);
 
     return new CustomScopeManagerScope(scope);
   }

--- a/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
@@ -3,7 +3,6 @@ package datadog.opentracing;
 import datadog.trace.api.Config;
 import datadog.trace.api.interceptor.TraceInterceptor;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
-import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.common.sampling.Sampler;
 import datadog.trace.common.writer.Writer;
@@ -475,8 +474,7 @@ public class DDTracer implements Tracer, datadog.trace.api.Tracer {
     @Deprecated
     @Override
     public Scope startActive(final boolean finishSpanOnClose) {
-      final AgentScope agentScope = delegate.startActive(finishSpanOnClose);
-      return converter.toScope(agentScope);
+      return scopeManager.activate(start(), finishSpanOnClose);
     }
 
     public DDSpanBuilder withServiceName(final String serviceName) {

--- a/dd-trace-ot/src/main/java/datadog/opentracing/TypeConverter.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/TypeConverter.java
@@ -48,15 +48,15 @@ class TypeConverter {
   // FIXME [API] Need to use the runtime type not compile-time type so "Object" is used
   // That fact that some methods return AgentScope and other TraceScope even though its the same
   // underlying object needs to be cleaned up
-  public Scope toScope(final Object scope) {
+  public Scope toScope(final Object scope, final boolean finishSpanOnClose) {
     if (scope == null) {
       return null;
     } else if (scope instanceof CustomScopeManagerWrapper.CustomScopeManagerScope) {
       return ((CustomScopeManagerWrapper.CustomScopeManagerScope) scope).getDelegate();
     } else if (scope instanceof TraceScope) {
-      return new OTScopeManager.OTTraceScope((TraceScope) scope, this);
+      return new OTScopeManager.OTTraceScope((TraceScope) scope, finishSpanOnClose, this);
     } else {
-      return new OTScopeManager.OTScope((AgentScope) scope, this);
+      return new OTScopeManager.OTScope((AgentScope) scope, finishSpanOnClose, this);
     }
   }
 

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/CustomScopeManagerTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/CustomScopeManagerTest.groovy
@@ -271,14 +271,6 @@ class TestScopeManager implements ScopeManager {
         @Override
         void cancel() {
         }
-
-        @Override
-        void close() {
-        }
-
-        @Override
-        void close(boolean closeContinuationScope) {
-        }
       }
     }
 

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/OpenTracingAPITest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/OpenTracingAPITest.groovy
@@ -229,7 +229,7 @@ class OpenTracingAPITest extends DDSpecification {
     continuation != null
 
     when:
-    continuation.close()
+    continuation.cancel()
     scope.close()
 
     then:
@@ -291,22 +291,24 @@ class OpenTracingAPITest extends DDSpecification {
     def textMap = new TextMapAdapter(new HashMap<String, String>())
 
     when:
-    Scope scope = tracer.buildSpan("clientOperation")
+    Span testSpan = tracer.buildSpan("clientOperation")
       .withServiceName("someClientService")
-      .startActive(true)
+      .start()
+    Scope scope = tracer.activateSpan(testSpan)
 
-    Span testSpan = scope.span()
     tracer.inject(testSpan.context(), Format.Builtin.HTTP_HEADERS, textMap)
 
 
     SpanContext extractedContext = tracer.extract(Format.Builtin.HTTP_HEADERS, textMap)
-    Scope serverScope = tracer.buildSpan("serverOperation")
+    Span serverSpan = tracer.buildSpan("serverOperation")
       .withServiceName("someService")
       .asChildOf(extractedContext)
-      .startActive(true)
-    serverScope.close()
+      .start()
+    tracer.activateSpan(serverSpan).close()
+    serverSpan.finish()
 
     scope.close()
+    testSpan.finish()
 
     then:
     2 * traceInterceptor.onTraceComplete({ it.size() == 1 }) >> { args -> args[0] }
@@ -335,7 +337,6 @@ class OpenTracingAPITest extends DDSpecification {
           }
         }
       }
-
     }
   }
 }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -32,12 +32,6 @@ public class AgentTracer {
     return get().activateSpan(span);
   }
 
-  /** @deprecated use {@link #activateSpan(AgentSpan)} instead */
-  @Deprecated
-  public static AgentScope activateSpan(final AgentSpan span, final boolean finishSpanOnClose) {
-    return get().activateSpan(span, finishSpanOnClose);
-  }
-
   public static AgentSpan activeSpan() {
     return get().activeSpan();
   }
@@ -80,10 +74,6 @@ public class AgentTracer {
 
     AgentScope activateSpan(AgentSpan span);
 
-    /** @deprecated use {@link #activateSpan(AgentSpan)} instead */
-    @Deprecated
-    AgentScope activateSpan(AgentSpan span, boolean finishSpanOnClose);
-
     AgentSpan activeSpan();
 
     TraceScope activeScope();
@@ -120,13 +110,6 @@ public class AgentTracer {
 
     @Override
     public AgentScope activateSpan(final AgentSpan span) {
-      return activateSpan(span);
-    }
-
-    /** @deprecated use {@link #activateSpan(AgentSpan)} instead */
-    @Deprecated
-    @Override
-    public AgentScope activateSpan(final AgentSpan span, final boolean finishSpanOnClose) {
       return NoopAgentScope.INSTANCE;
     }
 
@@ -280,12 +263,6 @@ public class AgentTracer {
 
     @Override
     public void cancel() {}
-
-    @Override
-    public void close() {}
-
-    @Override
-    public void close(final boolean closeContinuationScope) {}
   }
 
   public static class NoopContext implements Context {


### PR DESCRIPTION
`finishSpanOnClose` will still work at the OpenTracing API level, except for `ScopeManger.active()` which returns a wrapped scope without the original `finishSpanOnClose` boolean.

The motivation here is to prevent unconstrained memory usage growth resulting from a chain of `ContinuableScope`/`Continuation` references like so:

```java
ContinuableScope scope = tracer.scopeManager().active();
Continuation continuation = scope.capture();
scope.close();
while(true){
  try(Scope scope = continuation.activate()) {
    continuation = scope.capture();
  }
}
```
Prior to this change the above would result in an OOM error. Now, the Continuation shouldn't hold on to the previous Scope which will allow it to be GC'd.

This PR should go out in the release following #1424.