### PR TITLE
[Breaking change for dd-trace-api] Deprecate scope finishOnClose and continuation close

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -282,6 +282,13 @@ public class CoreTracer
   }
 
   @Override
+  public AgentScope activateSpan(final AgentSpan span) {
+    return activateSpan(span, false);
+  }
+
+  /** @deprecated use {@link #activateSpan(AgentSpan)} instead */
+  @Deprecated
+  @Override
   public AgentScope activateSpan(final AgentSpan span, final boolean finishSpanOnClose) {
     return scopeManager.activate(span, finishSpanOnClose);
   }
@@ -475,6 +482,8 @@ public class CoreTracer
       return new DDSpan(timestampMicro, buildSpanContext());
     }
 
+    /** @deprecated use {@link #start()} instead. */
+    @Deprecated
     public AgentScope startActive(final boolean finishSpanOnClose) {
       final AgentSpan span = buildSpan();
       final AgentScope scope = scopeManager.activate(span, finishSpanOnClose);

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContextualScopeManager.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContextualScopeManager.java
@@ -25,6 +25,13 @@ public class ContextualScopeManager implements DDScopeManager {
   }
 
   @Override
+  public AgentScope activate(final AgentSpan span) {
+    return activate(span, false);
+  }
+
+  /** @deprecated use {@link #activate(AgentSpan)} instead. */
+  @Deprecated
+  @Override
   public AgentScope activate(final AgentSpan span, final boolean finishOnClose) {
     final DDScope active = tlsScope.get();
     if (active != null && active.span().equals(span)) {

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScope.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScope.java
@@ -183,11 +183,24 @@ public class ContinuableScope implements DDScope {
       }
     }
 
+    public void cancel() {
+      assert !finishOnClose : "cancel() should not be used with finishOnClose=true";
+      if (used.compareAndSet(false, true)) {
+        trace.cancelContinuation(this);
+      } else {
+        log.debug("Failed to close continuation {}. Already used.", this);
+      }
+    }
+
+    /** @deprecated use {@link #cancel()} instead. */
+    @Deprecated
     @Override
     public void close() {
       close(true);
     }
 
+    /** @deprecated use {@link #cancel()} instead. */
+    @Deprecated
     @Override
     public void close(final boolean closeContinuationScope) {
       if (used.compareAndSet(false, true)) {

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/DDScopeManager.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/DDScopeManager.java
@@ -8,6 +8,10 @@ import datadog.trace.context.TraceScope;
  * Allows custom scope managers. See OTScopeManager, CustomScopeManager, and ContextualScopeManager
  */
 public interface DDScopeManager {
+  AgentScope activate(AgentSpan span);
+
+  /** @deprecated use {@link #activate(AgentSpan)} instead. */
+  @Deprecated
   AgentScope activate(AgentSpan span, boolean finishOnClose);
 
   TraceScope active();

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerTest.groovy
@@ -185,6 +185,20 @@ class ScopeManagerTest extends DDSpecification {
     continuation.close()
   }
 
+  def "Continuation.cancel doesn't close parent scope"() {
+    setup:
+    def span = tracer.buildSpan("test").start()
+    def scope = (ContinuableScope) tracer.activateSpan(span)
+    scope.setAsyncPropagation(true)
+    def continuation = scope.capture()
+
+    when:
+    continuation.cancel()
+
+    then:
+    scopeManager.active() == scope
+  }
+
   def "ContinuableScope doesn't close if non-zero"() {
     setup:
     def builder = tracer.buildSpan("test")

--- a/dd-trace-ot/src/main/java/datadog/opentracing/CustomScopeManagerWrapper.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/CustomScopeManagerWrapper.java
@@ -29,10 +29,17 @@ class CustomScopeManagerWrapper implements DDScopeManager {
   private final TypeConverter converter;
 
   CustomScopeManagerWrapper(final ScopeManager scopeManager, final TypeConverter converter) {
-    this.delegate = scopeManager;
+    delegate = scopeManager;
     this.converter = converter;
   }
 
+  @Override
+  public AgentScope activate(final AgentSpan span) {
+    return activate(span, false);
+  }
+
+  /** @deprecated use {@link #activate(AgentSpan)} instead. */
+  @Deprecated
   @Override
   public AgentScope activate(final AgentSpan agentSpan, final boolean finishOnClose) {
     final Span span = converter.toSpan(agentSpan);

--- a/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
@@ -180,8 +180,8 @@ public class DDTracer implements Tracer, datadog.trace.api.Tracer {
   @Deprecated
   public DDTracer(final CoreTracer coreTracer) {
     this.coreTracer = coreTracer;
-    this.converter = new TypeConverter(new DefaultLogHandler());
-    this.scopeManager = new OTScopeManager(coreTracer, converter);
+    converter = new TypeConverter(new DefaultLogHandler());
+    scopeManager = new OTScopeManager(coreTracer, converter);
   }
 
   @Builder
@@ -202,9 +202,9 @@ public class DDTracer implements Tracer, datadog.trace.api.Tracer {
       final LogHandler logHandler) {
 
     if (logHandler != null) {
-      this.converter = new TypeConverter(logHandler);
+      converter = new TypeConverter(logHandler);
     } else {
-      this.converter = new TypeConverter(new DefaultLogHandler());
+      converter = new TypeConverter(new DefaultLogHandler());
     }
 
     // Each of these are only overriden if set
@@ -471,6 +471,8 @@ public class DDTracer implements Tracer, datadog.trace.api.Tracer {
       return converter.toSpan(agentSpan);
     }
 
+    /** @deprecated use {@link #start()} instead. */
+    @Deprecated
     @Override
     public Scope startActive(final boolean finishSpanOnClose) {
       final AgentScope agentScope = delegate.startActive(finishSpanOnClose);

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/CustomScopeManagerTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/CustomScopeManagerTest.groovy
@@ -270,6 +270,10 @@ class TestScopeManager implements ScopeManager {
         }
 
         @Override
+        void cancel() {
+        }
+
+        @Override
         void close() {
         }
 

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -28,6 +28,12 @@ public class AgentTracer {
     return get().startSpan(spanName, parent, startTimeMicros);
   }
 
+  public static AgentScope activateSpan(final AgentSpan span) {
+    return get().activateSpan(span);
+  }
+
+  /** @deprecated use {@link #activateSpan(AgentSpan)} instead */
+  @Deprecated
   public static AgentScope activateSpan(final AgentSpan span, final boolean finishSpanOnClose) {
     return get().activateSpan(span, finishSpanOnClose);
   }
@@ -72,6 +78,10 @@ public class AgentTracer {
 
     AgentSpan startSpan(String spanName, AgentSpan.Context parent, long startTimeMicros);
 
+    AgentScope activateSpan(AgentSpan span);
+
+    /** @deprecated use {@link #activateSpan(AgentSpan)} instead */
+    @Deprecated
     AgentScope activateSpan(AgentSpan span, boolean finishSpanOnClose);
 
     AgentSpan activeSpan();
@@ -108,6 +118,13 @@ public class AgentTracer {
       return NoopAgentSpan.INSTANCE;
     }
 
+    @Override
+    public AgentScope activateSpan(final AgentSpan span) {
+      return activateSpan(span);
+    }
+
+    /** @deprecated use {@link #activateSpan(AgentSpan)} instead */
+    @Deprecated
     @Override
     public AgentScope activateSpan(final AgentSpan span, final boolean finishSpanOnClose) {
       return NoopAgentScope.INSTANCE;
@@ -260,6 +277,9 @@ public class AgentTracer {
     public TraceScope activate() {
       return NoopAgentScope.INSTANCE;
     }
+
+    @Override
+    public void cancel() {}
 
     @Override
     public void close() {}


### PR DESCRIPTION
**Note: These deprecated methods will be removed in the following release.**

The `finishOnClose` functionality will remain in the OpenTracing compatibility layer, but behavior may change if utilizing on continuations.

Migrating usage can impact the way span duration is calculated. For example given the following code:

```java
@Trace
def someMethod() {
  executor.execute {
    // Assume this executes after someMethod() already returned.
    httpClient.request(url)
  }
}
```

Historically, the Java Tracer prevented the top level span from finishing until the child work finished, resulting in a trace like this:
```
[-------------- someMethod --------------------]
                       [---clientRequest-----]
```

After this change, it will produce a trace more like this, which more accurately depicts the duration of the method execution.
```
[---someMethod---]   (likely even shorter)
                       [----clientRequest---]
```

Since trace duration is based on the parent/top level span, this change can impact the trace duration calculation.