### PR TITLE
Fix Github action for drafting release notes

### DIFF
--- a/.github/workflows/draft-release-notes-on-tag.yaml
+++ b/.github/workflows/draft-release-notes-on-tag.yaml
@@ -36,24 +36,6 @@ jobs:
             } else {
               return null
             }
-      - name: Get pull requests for milestone
-        if: fromJSON(steps.milestone.outputs.result)
-        id: pulls
-        uses: actions/github-script@0.9.0
-        with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
-          script: |
-            const options = github.pulls.list.endpoint.merge({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'closed'
-            })
-
-            const pullRequests = await github.paginate(options)
-
-            return pullRequests.filter(pullRequest => pullRequest.merged_at
-              && pullRequest.milestone
-              && pullRequest.milestone.number == ${{steps.milestone.outputs.result}})
       - name: Generate release notes text
         if: fromJSON(steps.milestone.outputs.result)
         id: generate
@@ -62,9 +44,25 @@ jobs:
           github-token: ${{secrets.GITHUB_TOKEN}}
           result-encoding: string
           script: |
+            const options = github.pulls.list.endpoint.merge({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'closed',
+              base: 'master'
+            })
+
+            const pullRequests = await github.paginate(options)
+
             var draftText = "# Improvements \n\n# Changes \n\n"
-            for (let pull of ${{ steps.pulls.outputs.result }}) {
-              draftText += "* " + pull.title + " #" + pull.number + " \n"
+            for (let pull of pullRequests) {
+              if (pull.merged_at && pull.milestone && pull.milestone.number == ${{steps.milestone.outputs.result}}) {
+                // Add author if community labeled
+                if (pull.labels.some(label => label.name == "community")) {
+                  draftText += "* " + pull.title + " #" + pull.number + " (Thanks @" + pull.user.login + " for the contribution!)\n"
+                } else {
+                  draftText += "* " + pull.title + " #" + pull.number + " \n"
+                }
+              }
             }
             draftText += "\n# Fixes \n"
             return draftText

--- a/.github/workflows/update-issues-on-release.yaml
+++ b/.github/workflows/update-issues-on-release.yaml
@@ -38,25 +38,25 @@ jobs:
             const issues = await github.paginate(options)
 
             // Pull requests are issues so filter them out
-            return issues.filter( issue => !issue["pull_request"] )
+            return issues.filter( issue => !issue["pull_request"] ).map( issue => issue.number )
       - name: Comment and close issues
         uses: actions/github-script@0.9.0
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            for (let issue of ${{ steps.issues.outputs.result }}) {
+            for (let issue_number of ${{ steps.issues.outputs.result }}) {
               // This can be parallelized better by moving the await but it might trip rate limits
               await github.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: issue.number,
+                issue_number: issue_number,
                 body: ':robot: This issue has been addressed in the latest release.  See full details in the [Release Notes]( ${{ github.event.release.html_url }}).'
               })
 
               await github.issues.update({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: issue.number,
+                issue_number: issue_number,
                 state: 'closed'
               })
             }


### PR DESCRIPTION
The draft release notes action [failed](https://github.com/DataDog/dd-trace-java/actions/runs/90459453) because the argument list was too long.

This pull request fixes that problem and a similar one with "update issues on release" that we didn't trip yet.