### PR TITLE
Fix publishing to artifactory...

### DIFF
--- a/dd-trace-java.gradle
+++ b/dd-trace-java.gradle
@@ -1,7 +1,10 @@
 plugins {
   id 'io.franzbecker.gradle-lombok' version '1.14' // Last to support Java 7
 
-  id 'com.jfrog.artifactory' version '4.15.2'
+  id 'com.jfrog.artifactory' version '4.9.8'
+  // ^ Last version to not have problems with NoSuchMethodError HttpClientBuilder.setPublicSuffixMatcher...
+  // See also https://www.jfrog.com/jira/browse/GAP-317
+
   id 'com.jfrog.bintray' version '1.8.5'
   id 'org.unbroken-dome.test-sets' version '3.0.1'
   id 'com.github.ben-manes.versions' version '0.27.0'


### PR DESCRIPTION
Newer versions fail when publishing with the exception:
```
Caused by: java.lang.NoSuchMethodError: org.apache.http.impl.client.HttpClientBuilder.setPublicSuffixMatcher(Lorg/apache/http/conn/util/PublicSuffixMatcher;)Lorg/apache/http/impl/client/HttpClientBuilder;
```

https://www.jfrog.com/jira/browse/GAP-317