### PR TITLE
Reduce copy/allocation in trace serialization pipeline

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/BatchWritingDisruptor.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/BatchWritingDisruptor.java
@@ -87,6 +87,12 @@ public class BatchWritingDisruptor extends AbstractDisruptor<TraceBuffer> {
         final DisruptorEvent<TraceBuffer> event, final long sequence, final boolean endOfBatch) {
       try {
         if (event.data != null) {
+          // the intention here is that the batching is done on the serialization thread
+          // directly into trace buffers pooled by the disruptor. The BatchWritingDisruptor
+          // will eventually not do any batching, but claim a trace buffer from the disruptor,
+          // publish it synchronously to the agent, and return it to the disruptor for reuse.
+          // This is an incremental step towards moving away from the status quo, where we
+          // could support a hybrid approach rather than refactor in one go.
           sizeInBytes += event.data.sizeInBytes();
           traceCount += event.data.traceCount();
           serializedTraces.add(event.data);

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/DDAgentApi.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/DDAgentApi.java
@@ -1,6 +1,5 @@
 package datadog.trace.common.writer.ddagent;
 
-import static datadog.trace.core.serialization.MsgpackFormatWriter.MSGPACK_WRITER;
 import static org.msgpack.core.MessagePack.Code.ARRAY16;
 import static org.msgpack.core.MessagePack.Code.ARRAY32;
 import static org.msgpack.core.MessagePack.Code.FIXARRAY_PREFIX;
@@ -11,11 +10,9 @@ import com.squareup.moshi.Types;
 import datadog.common.exec.CommonTaskExecutor;
 import datadog.trace.common.writer.unixdomainsockets.UnixDomainSocketFactory;
 import datadog.trace.core.ContainerInfo;
-import datadog.trace.core.DDSpan;
 import datadog.trace.core.DDTraceCoreInfo;
 import java.io.File;
 import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -28,9 +25,6 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okio.BufferedSink;
-import org.msgpack.core.MessagePack;
-import org.msgpack.core.MessagePacker;
-import org.msgpack.core.buffer.ArrayBufferOutput;
 
 /** The API pointing to a DD agent */
 @Slf4j
@@ -48,12 +42,6 @@ public class DDAgentApi {
   private static final String TRACES_ENDPOINT_V3 = "v0.3/traces";
   private static final String TRACES_ENDPOINT_V4 = "v0.4/traces";
   private static final long MILLISECONDS_BETWEEN_ERROR_LOG = TimeUnit.MINUTES.toMillis(5);
-
-  // limiting the size this optimisation applies to decreases the likelihood
-  // that the MessagePacker will allocate a byte[] during UTF-8 encoding,
-  // and restricts the optimisation to very small strings which may scalarise
-  private static final MessagePack.PackerConfig MESSAGE_PACKER_CONFIG =
-      MessagePack.DEFAULT_PACKER_CONFIG.withSmallStringOptimizationThreshold(16);
 
   private final List<DDAgentResponseListener> responseListeners = new ArrayList<>();
 
@@ -87,88 +75,20 @@ public class DDAgentApi {
     }
   }
 
-  /**
-   * Send traces to the DD agent
-   *
-   * @param traces the traces to be sent
-   * @return a Response object -- encapsulating success of communication, sending, and result
-   *     parsing
-   */
-  Response sendTraces(final List<List<DDSpan>> traces) {
-    final List<ByteBuffer> serializedTraces = new ArrayList<>(traces.size());
-    int sizeInBytes = 0;
-    for (final List<DDSpan> trace : traces) {
-      try {
-        final ByteBuffer serializedTrace = serializeTrace(trace);
-        sizeInBytes += serializedTrace.limit();
-        serializedTraces.add(serializedTrace);
-      } catch (final IOException e) {
-        log.warn("Error serializing trace", e);
-
-        // TODO: DQH - Incorporate the failed serialization into the Response object???
-      }
-    }
-
-    return sendSerializedTraces(serializedTraces.size(), sizeInBytes, serializedTraces);
-  }
-
-  ByteBuffer serializeTrace(final List<DDSpan> trace) throws IOException {
-    // TODO: reuse byte array buffer
-    final ArrayBufferOutput output = new ArrayBufferOutput();
-    final MessagePacker packer = MESSAGE_PACKER_CONFIG.newPacker(output);
-    MSGPACK_WRITER.writeTrace(trace, packer);
-    packer.flush();
-    int limit = (int) packer.getTotalWrittenBytes();
-    return output.toMessageBuffer().sliceAsByteBuffer(0, limit);
-  }
-
   Response sendSerializedTraces(
-      final int representativeCount, final Integer sizeInBytes, final List<ByteBuffer> traces) {
+      final int representativeCount,
+      final int traceCount,
+      final int sizeInBytes,
+      final List<TraceBuffer> traces) {
     if (httpClient == null) {
       detectEndpointAndBuildClient();
     }
 
     try {
-      final RequestBody body =
-          new RequestBody() {
-            @Override
-            public MediaType contentType() {
-              return MSGPACK;
-            }
-
-            @Override
-            public long contentLength() {
-              final int traceCount = traces.size();
-              // Need to allocate additional to handle MessagePacker.packArrayHeader
-              if (traceCount < (1 << 4)) {
-                return sizeInBytes + 1; // byte
-              } else if (traceCount < (1 << 16)) {
-                return sizeInBytes + 3; // byte + short
-              } else {
-                return sizeInBytes + 5; // byte + int
-              }
-            }
-
-            @Override
-            public void writeTo(final BufferedSink sink) throws IOException {
-              if (traces.size() < 16) {
-                sink.writeByte((byte) (traces.size() | FIXARRAY_PREFIX));
-              } else if (traces.size() < 0x10000) {
-                sink.writeByte(ARRAY16);
-                sink.writeShort(traces.size());
-              } else {
-                sink.writeByte(ARRAY32);
-                sink.writeInt(traces.size());
-              }
-              for (ByteBuffer trace : traces) {
-                sink.write(trace);
-              }
-            }
-          };
       final Request request =
           prepareRequest(tracesUrl)
               .addHeader(X_DATADOG_TRACE_COUNT, String.valueOf(representativeCount))
-              .put(body)
+              .put(new MsgPackRequestBody(traceCount, sizeInBytes, traces))
               .build();
 
       try (final okhttp3.Response response = httpClient.newCall(request).execute()) {
@@ -375,6 +295,52 @@ public class DDAgentApi {
     // TODO: DQH - In Java 8, switch to Optional<Throwable>?
     public final Throwable exception() {
       return exception;
+    }
+  }
+
+  private static class MsgPackRequestBody extends RequestBody {
+    private final int traceCount;
+    private final int sizeInBytes;
+    private final List<TraceBuffer> traces;
+
+    private MsgPackRequestBody(int traceCount, int sizeInBytes, List<TraceBuffer> traces) {
+      this.traceCount = traceCount;
+      this.sizeInBytes = sizeInBytes;
+      this.traces = traces;
+    }
+
+    @Override
+    public MediaType contentType() {
+      return MSGPACK;
+    }
+
+    @Override
+    public long contentLength() {
+      // Need to allocate additional to handle MessagePacker.packArrayHeader
+      if (traceCount < (1 << 4)) {
+        return sizeInBytes + 1; // byte
+      } else if (traceCount < (1 << 16)) {
+        return sizeInBytes + 3; // byte + short
+      } else {
+        return sizeInBytes + 5; // byte + int
+      }
+    }
+
+    @Override
+    public void writeTo(final BufferedSink sink) throws IOException {
+      // inlines behaviour from MessagePacker.packArrayHeader
+      if (traceCount < (1 << 4)) {
+        sink.writeByte((byte) (traceCount | FIXARRAY_PREFIX));
+      } else if (traceCount < (1 << 16)) {
+        sink.writeByte(ARRAY16);
+        sink.writeShort(traceCount);
+      } else {
+        sink.writeByte(ARRAY32);
+        sink.writeInt(traceCount);
+      }
+      for (TraceBuffer trace : traces) {
+        trace.writeTo(sink);
+      }
     }
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/Monitor.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/Monitor.java
@@ -5,6 +5,7 @@ import com.timgroup.statsd.StatsDClient;
 import datadog.trace.common.writer.DDAgentWriter;
 import datadog.trace.core.DDSpan;
 import datadog.trace.core.DDTraceCoreInfo;
+import java.nio.ByteBuffer;
 import java.util.List;
 
 /**
@@ -33,7 +34,7 @@ public interface Monitor {
   void onScheduleFlush(final DDAgentWriter agentWriter, final boolean previousIncomplete);
 
   void onSerialize(
-      final DDAgentWriter agentWriter, final List<DDSpan> trace, final byte[] serializedTrace);
+      final DDAgentWriter agentWriter, final List<DDSpan> trace, final ByteBuffer serializedTrace);
 
   void onFailedSerialize(
       final DDAgentWriter agentWriter, final List<DDSpan> trace, final Throwable optionalCause);
@@ -119,10 +120,12 @@ public interface Monitor {
 
     @Override
     public void onSerialize(
-        final DDAgentWriter agentWriter, final List<DDSpan> trace, final byte[] serializedTrace) {
+        final DDAgentWriter agentWriter,
+        final List<DDSpan> trace,
+        final ByteBuffer serializedTrace) {
       // DQH - Because of Java tracer's 2 phase acceptance and serialization scheme, this doesn't
       // map precisely
-      statsd.count("queue.accepted_size", serializedTrace.length);
+      statsd.count("queue.accepted_size", serializedTrace.limit());
     }
 
     @Override
@@ -203,7 +206,9 @@ public interface Monitor {
 
     @Override
     public void onSerialize(
-        final DDAgentWriter agentWriter, final List<DDSpan> trace, final byte[] serializedTrace) {}
+        final DDAgentWriter agentWriter,
+        final List<DDSpan> trace,
+        final ByteBuffer serializedTrace) {}
 
     @Override
     public void onFailedSerialize(

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/Monitor.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/Monitor.java
@@ -5,7 +5,6 @@ import com.timgroup.statsd.StatsDClient;
 import datadog.trace.common.writer.DDAgentWriter;
 import datadog.trace.core.DDSpan;
 import datadog.trace.core.DDTraceCoreInfo;
-import java.nio.ByteBuffer;
 import java.util.List;
 
 /**
@@ -34,7 +33,7 @@ public interface Monitor {
   void onScheduleFlush(final DDAgentWriter agentWriter, final boolean previousIncomplete);
 
   void onSerialize(
-      final DDAgentWriter agentWriter, final List<DDSpan> trace, final ByteBuffer serializedTrace);
+      final DDAgentWriter agentWriter, final List<DDSpan> trace, final int serializedSizeInBytes);
 
   void onFailedSerialize(
       final DDAgentWriter agentWriter, final List<DDSpan> trace, final Throwable optionalCause);
@@ -122,10 +121,10 @@ public interface Monitor {
     public void onSerialize(
         final DDAgentWriter agentWriter,
         final List<DDSpan> trace,
-        final ByteBuffer serializedTrace) {
+        final int serializedSizeInBytes) {
       // DQH - Because of Java tracer's 2 phase acceptance and serialization scheme, this doesn't
       // map precisely
-      statsd.count("queue.accepted_size", serializedTrace.limit());
+      statsd.count("queue.accepted_size", serializedSizeInBytes);
     }
 
     @Override
@@ -208,7 +207,7 @@ public interface Monitor {
     public void onSerialize(
         final DDAgentWriter agentWriter,
         final List<DDSpan> trace,
-        final ByteBuffer serializedTrace) {}
+        final int serializedSizeInBytes) {}
 
     @Override
     public void onFailedSerialize(

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/MsgPackStatefulSerializer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/MsgPackStatefulSerializer.java
@@ -1,0 +1,135 @@
+package datadog.trace.common.writer.ddagent;
+
+import static datadog.trace.core.serialization.MsgpackFormatWriter.MSGPACK_WRITER;
+
+import datadog.trace.core.DDSpan;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.WritableByteChannel;
+import java.util.Arrays;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.msgpack.core.MessagePack;
+import org.msgpack.core.MessagePacker;
+import org.msgpack.core.buffer.ArrayBufferOutput;
+import org.msgpack.core.buffer.MessageBuffer;
+
+/**
+ * Serialises traces into a buffer and on demand releases the buffer. Aims to dynamically size
+ * buffers based on the recent history of trace sizes and how many traces were recently written into
+ * a single buffer.
+ *
+ * <p>Intentionally not thread-safe; each thread should have a dedicated instance in multi-threaded
+ * settings.
+ */
+@Slf4j
+public class MsgPackStatefulSerializer implements StatefulSerializer {
+
+  // assumed to be a power of 2 for arithmetic efficiency
+  private static final int TRACE_HISTORY_SIZE = 16;
+  private static final int INITIAL_BUFFER_SIZE = 1024;
+
+  // limiting the size this optimisation applies to decreases the likelihood
+  // that the MessagePacker will allocate a byte[] during UTF-8 encoding,
+  // and restricts the optimisation to very small strings which may scalarise
+  private static final MessagePack.PackerConfig MESSAGE_PACKER_CONFIG =
+      MessagePack.DEFAULT_PACKER_CONFIG.withSmallStringOptimizationThreshold(16);
+
+  // reusing this within the context of each thread is handy because it
+  // caches an Encoder
+  private final MessagePacker messagePacker =
+      MESSAGE_PACKER_CONFIG.newPacker(new ArrayBufferOutput(0));
+
+  private final int[] traceSizes = new int[TRACE_HISTORY_SIZE];
+
+  private int traceSizeSum;
+  private int position;
+  private MsgPackTraceBuffer lastBuffer;
+
+  private int lastTracesPerBuffer = 1;
+  private int tracesPerBuffer;
+
+  public MsgPackStatefulSerializer() {
+    Arrays.fill(traceSizes, INITIAL_BUFFER_SIZE);
+    this.traceSizeSum = INITIAL_BUFFER_SIZE * TRACE_HISTORY_SIZE;
+  }
+
+  @Override
+  public void serialize(List<DDSpan> trace) throws IOException {
+    if (null == lastBuffer) {
+      lastBuffer = newBuffer();
+      messagePacker.reset(lastBuffer.buffer);
+      messagePacker.clear();
+    }
+    MSGPACK_WRITER.writeTrace(trace, messagePacker);
+    int serializedSize = (int) messagePacker.getTotalWrittenBytes();
+    updateTraceSize(serializedSize);
+    lastBuffer.length += serializedSize;
+    ++lastBuffer.traceCount;
+    ++tracesPerBuffer;
+  }
+
+  @Override
+  public TraceBuffer getBuffer() throws IOException {
+    try {
+      messagePacker.flush();
+      return lastBuffer;
+    } finally {
+      lastTracesPerBuffer = tracesPerBuffer;
+      tracesPerBuffer = 0;
+      lastBuffer = null;
+    }
+  }
+
+  private MsgPackTraceBuffer newBuffer() {
+    MsgPackTraceBuffer buffer = new MsgPackTraceBuffer();
+    int traceBufferSize = traceBufferSize();
+    buffer.buffer = new ArrayBufferOutput(traceBufferSize);
+    return buffer;
+  }
+
+  private void updateTraceSize(int traceSize) {
+    traceSizeSum = (traceSizeSum - traceSizes[position] + traceSize);
+    traceSizes[position] = traceSize;
+    position = (position + 1) & (traceSizes.length - 1);
+  }
+
+  private int traceBufferSize() {
+    // round up to next KB, assumes for now that there will be one trace per buffer
+    return ((lastTracesPerBuffer * traceSizeSum / TRACE_HISTORY_SIZE) + 1023) / 1024;
+  }
+
+  public static class MsgPackTraceBuffer implements TraceBuffer {
+
+    private ArrayBufferOutput buffer;
+    private int length;
+    private int traceCount;
+
+    @Override
+    public void writeTo(WritableByteChannel channel) throws IOException {
+      int remaining = length;
+      for (MessageBuffer messageBuffer : buffer.toBufferList()) {
+        int size = messageBuffer.size();
+        ByteBuffer buffer =
+            size > remaining
+                ? messageBuffer.sliceAsByteBuffer(0, remaining)
+                : messageBuffer.sliceAsByteBuffer();
+        while (buffer.hasRemaining()) {
+          channel.write(buffer);
+        }
+        remaining -= size;
+      }
+      assert remaining == 0;
+    }
+
+    @Override
+    public int sizeInBytes() {
+      return length;
+    }
+
+    @Override
+    public int traceCount() {
+      return traceCount;
+    }
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/StatefulSerializer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/StatefulSerializer.java
@@ -1,0 +1,26 @@
+package datadog.trace.common.writer.ddagent;
+
+import datadog.trace.core.DDSpan;
+import java.io.IOException;
+import java.util.List;
+
+public interface StatefulSerializer {
+
+  /**
+   * Serialises the trace into a trace buffer.
+   *
+   * @param trace a list of spans making up a trace
+   * @throws IOException
+   */
+  void serialize(List<DDSpan> trace) throws IOException;
+
+  /**
+   * Returns a buffer containing all traces written since the last call to this method. The buffer
+   * belongs to the caller and should no longer be referenced by the serializer after being
+   * released.
+   *
+   * @return the buffer into which traces have been serialized.
+   * @throws IOException
+   */
+  TraceBuffer getBuffer() throws IOException;
+}

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/TraceBuffer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/TraceBuffer.java
@@ -3,6 +3,13 @@ package datadog.trace.common.writer.ddagent;
 import java.io.IOException;
 import java.nio.channels.WritableByteChannel;
 
+/**
+ * The purpose of this abtraction is to decouple serialization from preparation of a request, to
+ * allow incremental refactoring towards building requests into a small number of TraceBuffers
+ * pooled in what is now the BatchWritingDisruptor. It independently tracks how many traces have
+ * been written into it and how many bytes have been written, so that it can simply be translated to
+ * an HTTP POST to the agent, before being returned to the disruptor in a single read transaction.
+ */
 public interface TraceBuffer {
 
   /**

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/TraceBuffer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/TraceBuffer.java
@@ -1,0 +1,31 @@
+package datadog.trace.common.writer.ddagent;
+
+import java.io.IOException;
+import java.nio.channels.WritableByteChannel;
+
+public interface TraceBuffer {
+
+  /**
+   * The size in bytes of the data in the buffer, may be less than or equal to the total size of the
+   * buffer.
+   *
+   * @return
+   */
+  int sizeInBytes();
+
+  /**
+   * The number of traces held in the buffer
+   *
+   * @return the number of traces in the buffer.
+   */
+  int traceCount();
+
+  /**
+   * Writes the pooled buffer to the channel and consumes the buffer. Can only be called once; after
+   * calling the method an attempt will be made to put the buffer back in the pool.
+   *
+   * @param channel
+   * @throws IOException
+   */
+  void writeTo(WritableByteChannel channel) throws IOException;
+}

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/TraceProcessingDisruptor.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/TraceProcessingDisruptor.java
@@ -68,6 +68,11 @@ public class TraceProcessingDisruptor extends AbstractDisruptor<List<DDSpan>> {
           // TODO populate `_sample_rate` metric in a way that accounts for lost/dropped traces
           try {
             event.data = processor.onTraceComplete(event.data);
+            // the intention is that batching ends up being handled here,
+            // rather than on the BatchWritingDisruptor, which would
+            // be responsible for sending trace buffers to the agent
+            // synchronously, before returning the trace buffer for
+            // reuse.
             serializer.serialize(event.data);
             TraceBuffer serializedTrace = serializer.getBuffer();
             int sizeInBytes = serializedTrace.sizeInBytes();

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/TraceProcessingDisruptor.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/TraceProcessingDisruptor.java
@@ -5,6 +5,7 @@ import datadog.common.exec.DaemonThreadFactory;
 import datadog.trace.common.writer.DDAgentWriter;
 import datadog.trace.core.DDSpan;
 import datadog.trace.core.processor.TraceProcessor;
+import java.nio.ByteBuffer;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 
@@ -66,7 +67,7 @@ public class TraceProcessingDisruptor extends AbstractDisruptor<List<DDSpan>> {
           // TODO populate `_sample_rate` metric in a way that accounts for lost/dropped traces
           try {
             event.data = processor.onTraceComplete(event.data);
-            final byte[] serializedTrace = api.serializeTrace(event.data);
+            ByteBuffer serializedTrace = api.serializeTrace(event.data);
             batchWritingDisruptor.publish(serializedTrace, event.representativeCount);
             monitor.onSerialize(writer, event.data, serializedTrace);
             event.representativeCount = 0; // reset in case flush is invoked below.

--- a/dd-trace-core/src/main/java/datadog/trace/core/StringTables.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/StringTables.java
@@ -39,8 +39,7 @@ public class StringTables {
   }
 
   public static byte[] getBytesUTF8(String value) {
-    byte[] bytes = UTF8_INTERN_TABLE.get(value);
-    return null == bytes ? value.getBytes(UTF_8) : bytes;
+    return UTF8_INTERN_TABLE.get(value);
   }
 
   private static void internConstantsUTF8(Class<?> clazz) {

--- a/dd-trace-core/src/main/java/datadog/trace/core/serialization/FormatWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/serialization/FormatWriter.java
@@ -85,7 +85,7 @@ public abstract class FormatWriter<DEST> {
     writeKey(key, destination);
     writeMapHeader(value.size(), destination);
     for (final Map.Entry<String, String> entry : value.entrySet()) {
-      writeTag(entry.getKey(), entry.getValue(), destination);
+      writeString(entry.getKey(), entry.getValue(), destination);
     }
     writeMapFooter(destination);
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/serialization/MsgpackFormatWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/serialization/MsgpackFormatWriter.java
@@ -107,11 +107,13 @@ public class MsgpackFormatWriter extends FormatWriter<MessagePacker> {
 
   private static void writeStringUTF8(String value, MessagePacker destination) throws IOException {
     if (value.length() < 256) {
-      byte[] utf8 = StringTables.getBytesUTF8(value);
-      destination.packRawStringHeader(utf8.length);
-      destination.addPayload(utf8);
-    } else {
-      destination.packString(value);
+      byte[] interned = StringTables.getBytesUTF8(value);
+      if (null != interned) {
+        destination.packRawStringHeader(interned.length);
+        destination.addPayload(interned);
+        return;
+      }
     }
+    destination.packString(value);
   }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/CoreTracerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/CoreTracerTest.groovy
@@ -111,7 +111,7 @@ class CoreTracerTest extends DDSpecification {
     def tracer = CoreTracer.builder().config(new Config()).build()
     then:
     tracer.writer instanceof DDAgentWriter
-    ((DDAgentWriter) tracer.writer).api.sendTraces([])
+    ((DDAgentWriter) tracer.writer).api.sendSerializedTraces(0, 0, 0, [])
     ((DDAgentWriter) tracer.writer).api.tracesUrl.host() == value
     ((DDAgentWriter) tracer.writer).api.tracesUrl.port() == 8126
 
@@ -127,7 +127,7 @@ class CoreTracerTest extends DDSpecification {
 
     then:
     tracer.writer instanceof DDAgentWriter
-    ((DDAgentWriter) tracer.writer).api.sendTraces([])
+    ((DDAgentWriter) tracer.writer).api.sendSerializedTraces(0, 0, 0, [])
     ((DDAgentWriter) tracer.writer).api.tracesUrl.host() == "localhost"
     ((DDAgentWriter) tracer.writer).api.tracesUrl.port() == Integer.valueOf(value)
 


### PR DESCRIPTION
* Introduces `TraceBuffer` which may contain one or many traces, encapsulating the data buffer to avoid copying.
* Introduces `StatefulSerializer` which decouples the process of serializing traces from getting a buffer. This makes it possible to serialize several traces into the same buffer, though the responsibilities between the trace processor and batch processor are maintained for the time being.
* The `MsgPackStatefulSerializer` implementation has an adaptive buffer sizing algorithm based on a moving average of recently serialised traces and the number of traces last serialised into the buffer, which aims to minimise allocation.
* This allows reuse of a `MessagePacker` which prevents excessive allocation of `UTF_8$Encoder` objects. 
* Dead code in `DDAgentApi.sendTraces` was removed and corresponding tests were updated.

These changes reduce allocation of `byte[]` by over 34MB/s (2GB over 60s) and `UTF_8.Encoder$ by 17MB/s (1GB over 60s) in a spring pet-clinic based benchmark. These changes are intended as a stepping stone towards different buffer reuse strategies.