### PR TITLE
Avoid double counting traces...

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ListWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ListWriter.java
@@ -8,11 +8,13 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /** List writer used by tests mostly */
 public class ListWriter extends CopyOnWriteArrayList<List<DDSpan>> implements Writer {
   private final TraceProcessor processor = new TraceProcessor();
   private final List<CountDownLatch> latches = new ArrayList<>();
+  private final AtomicInteger traceCount = new AtomicInteger();
 
   public List<DDSpan> firstTrace() {
     return get(0);
@@ -20,6 +22,7 @@ public class ListWriter extends CopyOnWriteArrayList<List<DDSpan>> implements Wr
 
   @Override
   public void write(List<DDSpan> trace) {
+    incrementTraceCount();
     synchronized (latches) {
       trace = processor.onTraceComplete(trace);
       add(trace);
@@ -48,7 +51,9 @@ public class ListWriter extends CopyOnWriteArrayList<List<DDSpan>> implements Wr
   }
 
   @Override
-  public void incrementTraceCount() {}
+  public void incrementTraceCount() {
+    traceCount.incrementAndGet();
+  }
 
   @Override
   public void start() {

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -363,7 +363,6 @@ public class CoreTracer
         }
       }
     }
-    incrementTraceCount();
 
     if (!writtenTrace.isEmpty()) {
       final DDSpan rootSpan = writtenTrace.get(0).getLocalRootSpan();
@@ -372,6 +371,8 @@ public class CoreTracer
       final DDSpan spanToSample = rootSpan == null ? writtenTrace.get(0) : rootSpan;
       if (sampler.sample(spanToSample)) {
         writer.write(writtenTrace);
+      } else {
+        incrementTraceCount();
       }
     }
   }


### PR DESCRIPTION
This is already being accounted for in `DDAgentWriter`
```java
representativeCount = traceCount.getAndSet(0) + 1
```

I think this (and additional testing) might enable us to undo #1374.