### PR TITLE
Remove deprecated usage from internal instrumentation

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/ExecutorInstrumentationUtils.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/ExecutorInstrumentationUtils.java
@@ -61,7 +61,7 @@ public class ExecutorInstrumentationUtils {
     if (state.setContinuation(continuation)) {
       log.debug("created continuation {} from scope {}, state: {}", continuation, scope, state);
     } else {
-      continuation.close(false);
+      continuation.cancel();
     }
 
     return state;

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/State.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/State.java
@@ -38,7 +38,7 @@ public class State {
     if (continuation != null) {
       // We have opened this continuation, we shall not close parent scope when we close it,
       // otherwise owners of that scope will get confused.
-      continuation.close(false);
+      continuation.cancel();
     }
   }
 

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/AkkaHttpClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/AkkaHttpClientInstrumentation.java
@@ -89,7 +89,7 @@ public final class AkkaHttpClientInstrumentation extends Instrumenter.Default {
         // Request is immutable, so we have to assign new value once we update headers
         request = headers.getRequest();
       }
-      return activateSpan(span, false);
+      return activateSpan(span);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/AkkaHttpServerInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/AkkaHttpServerInstrumentation.java
@@ -101,7 +101,7 @@ public final class AkkaHttpServerInstrumentation extends Instrumenter.Default {
       DECORATE.onConnection(span, request);
       DECORATE.onRequest(span, request);
 
-      final AgentScope scope = activateSpan(span, false);
+      final AgentScope scope = activateSpan(span);
       scope.setAsyncPropagation(true);
       return scope;
     }

--- a/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/test/groovy/ApacheHttpAsyncClientCallbackTest.groovy
+++ b/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/test/groovy/ApacheHttpAsyncClientCallbackTest.groovy
@@ -41,8 +41,8 @@ class ApacheHttpAsyncClientCallbackTest extends HttpClientTest {
 
       @Override
       void completed(HttpResponse result) {
-        responseFuture.complete(result.statusLine.statusCode)
         callback?.call()
+        responseFuture.complete(result.statusLine.statusCode)
       }
 
       @Override

--- a/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/test/groovy/ApacheHttpAsyncClientNullCallbackTest.groovy
+++ b/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/test/groovy/ApacheHttpAsyncClientNullCallbackTest.groovy
@@ -37,8 +37,11 @@ class ApacheHttpAsyncClientNullCallbackTest extends HttpClientTest {
     // So to make sure request is done we start request, wait for future to finish
     // and then call callback if present.
     Future future = client.execute(request, null)
-    future.get()
-    blockUntilChildSpansFinished(1)
+    try {
+      future.get()
+    } finally {
+      blockUntilChildSpansFinished(1)
+    }
     if (callback != null) {
       callback()
     }

--- a/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/test/groovy/ApacheHttpAsyncClientNullCallbackTest.groovy
+++ b/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/test/groovy/ApacheHttpAsyncClientNullCallbackTest.groovy
@@ -38,11 +38,11 @@ class ApacheHttpAsyncClientNullCallbackTest extends HttpClientTest {
     // and then call callback if present.
     Future future = client.execute(request, null)
     future.get()
+    blockUntilChildSpansFinished(1)
     if (callback != null) {
-      blockUntilChildSpansFinished(1)
       callback()
     }
-    return 200
+    return future.get().statusLine.statusCode
   }
 
   @Override

--- a/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/test/groovy/ApacheHttpAsyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/test/groovy/ApacheHttpAsyncClientTest.groovy
@@ -56,11 +56,14 @@ class ApacheHttpAsyncClientTest extends HttpClientTest {
       }
     }
 
-    def response = client.execute(request, handler).get()
-    response.entity?.content?.close() // Make sure the connection is closed.
-    blockUntilChildSpansFinished(1)
-    latch.await()
-    response.statusLine.statusCode
+    try {
+      def response = client.execute(request, handler).get()
+      response.entity?.content?.close() // Make sure the connection is closed.
+      latch.await()
+      response.statusLine.statusCode
+    } finally {
+      blockUntilChildSpansFinished(1)
+    }
   }
 
   @Override

--- a/dd-java-agent/instrumentation/apache-httpclient-4/src/main/java/datadog/trace/instrumentation/apachehttpclient/ApacheHttpClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/apache-httpclient-4/src/main/java/datadog/trace/instrumentation/apachehttpclient/ApacheHttpClientInstrumentation.java
@@ -154,7 +154,7 @@ public class ApacheHttpClientInstrumentation extends Instrumenter.Default {
   public static class HelperMethods {
     public static AgentScope doMethodEnter(final HttpUriRequest request) {
       final AgentSpan span = startSpan("http.request");
-      final AgentScope scope = activateSpan(span, true);
+      final AgentScope scope = activateSpan(span);
 
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, request);
@@ -172,9 +172,8 @@ public class ApacheHttpClientInstrumentation extends Instrumenter.Default {
       if (scope == null) {
         return;
       }
+      final AgentSpan span = scope.span();
       try {
-        final AgentSpan span = scope.span();
-
         if (result instanceof HttpResponse) {
           DECORATE.onResponse(span, (HttpResponse) result);
         } // else they probably provided a ResponseHandler.
@@ -183,6 +182,7 @@ public class ApacheHttpClientInstrumentation extends Instrumenter.Default {
         DECORATE.beforeFinish(span);
       } finally {
         scope.close();
+        span.finish();
         CallDepthThreadLocalMap.reset(HttpClient.class);
       }
     }

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/AWSHttpClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/AWSHttpClientInstrumentation.java
@@ -14,6 +14,7 @@ import com.amazonaws.handlers.RequestHandler2;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.method.MethodDescription;
@@ -60,9 +61,11 @@ public class AWSHttpClientInstrumentation extends Instrumenter.Default {
         final AgentScope scope = request.getHandlerContext(SCOPE_CONTEXT_KEY);
         if (scope != null) {
           request.addHandlerContext(SCOPE_CONTEXT_KEY, null);
-          DECORATE.onError(scope.span(), throwable);
-          DECORATE.beforeFinish(scope.span());
+          final AgentSpan span = scope.span();
+          DECORATE.onError(span, throwable);
+          DECORATE.beforeFinish(span);
           scope.close();
+          span.finish();
         }
       }
     }
@@ -96,9 +99,11 @@ public class AWSHttpClientInstrumentation extends Instrumenter.Default {
           final AgentScope scope = request.getHandlerContext(SCOPE_CONTEXT_KEY);
           if (scope != null) {
             request.addHandlerContext(SCOPE_CONTEXT_KEY, null);
-            DECORATE.onError(scope.span(), throwable);
-            DECORATE.beforeFinish(scope.span());
+            final AgentSpan span = scope.span();
+            DECORATE.onError(span, throwable);
+            DECORATE.beforeFinish(span);
             scope.close();
+            span.finish();
           }
         }
       }

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/TracingRequestHandler.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/TracingRequestHandler.java
@@ -32,7 +32,7 @@ public class TracingRequestHandler extends RequestHandler2 {
     final AgentSpan span = startSpan("aws.http");
     decorate.afterStart(span);
     decorate.onRequest(span, request);
-    request.addHandlerContext(SCOPE_CONTEXT_KEY, activateSpan(span, true));
+    request.addHandlerContext(SCOPE_CONTEXT_KEY, activateSpan(span));
   }
 
   @Override
@@ -43,6 +43,7 @@ public class TracingRequestHandler extends RequestHandler2 {
       decorate.onResponse(scope.span(), response);
       decorate.beforeFinish(scope.span());
       scope.close();
+      scope.span().finish();
     }
   }
 
@@ -54,6 +55,7 @@ public class TracingRequestHandler extends RequestHandler2 {
       decorate.onError(scope.span(), e);
       decorate.beforeFinish(scope.span());
       scope.close();
+      scope.span().finish();
     }
   }
 }

--- a/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java8/datadog/trace/instrumentation/aws/v2/TracingExecutionInterceptor.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java8/datadog/trace/instrumentation/aws/v2/TracingExecutionInterceptor.java
@@ -30,7 +30,7 @@ public class TracingExecutionInterceptor implements ExecutionInterceptor {
   public void beforeExecution(
       final Context.BeforeExecution context, final ExecutionAttributes executionAttributes) {
     final AgentSpan span = startSpan("aws.http");
-    try (final AgentScope scope = activateSpan(span, false)) {
+    try (final AgentScope scope = activateSpan(span)) {
       DECORATE.afterStart(span);
       executionAttributes.putAttribute(SPAN_ATTRIBUTE, span);
     }
@@ -53,7 +53,7 @@ public class TracingExecutionInterceptor implements ExecutionInterceptor {
 
     // This scope will be closed by AwsHttpClientInstrumentation since ExecutionInterceptor API
     // doesn't provide a way to run code in the same thread after transmission has been scheduled.
-    final AgentScope scope = activateSpan(span, false);
+    final AgentScope scope = activateSpan(span);
     scope.setAsyncPropagation(true);
   }
 

--- a/dd-java-agent/instrumentation/commons-httpclient-2/src/main/java/datadog/trace/instrumentation/commonshttpclient/CommonsHttpClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/commons-httpclient-2/src/main/java/datadog/trace/instrumentation/commonshttpclient/CommonsHttpClientInstrumentation.java
@@ -71,7 +71,7 @@ public class CommonsHttpClientInstrumentation extends Instrumenter.Default {
       }
 
       final AgentSpan span = startSpan("http.request");
-      final AgentScope scope = activateSpan(span, true);
+      final AgentScope scope = activateSpan(span);
 
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, httpMethod);
@@ -89,14 +89,14 @@ public class CommonsHttpClientInstrumentation extends Instrumenter.Default {
       if (scope == null) {
         return;
       }
+      final AgentSpan span = scope.span();
       try {
-        final AgentSpan span = scope.span();
-
         DECORATE.onResponse(span, httpMethod);
         DECORATE.onError(span, throwable);
         DECORATE.beforeFinish(span);
       } finally {
         scope.close();
+        span.finish();
         CallDepthThreadLocalMap.reset(HttpClient.class);
       }
     }

--- a/dd-java-agent/instrumentation/datastax-cassandra-3/src/main/java/datadog/trace/instrumentation/datastax/cassandra/TracingSession.java
+++ b/dd-java-agent/instrumentation/datastax-cassandra-3/src/main/java/datadog/trace/instrumentation/datastax/cassandra/TracingSession.java
@@ -225,7 +225,7 @@ public class TracingSession implements Session {
     return new Runnable() {
       @Override
       public void run() {
-        try (final AgentScope scope = activateSpan(span, false)) {
+        try (final AgentScope scope = activateSpan(span)) {
           beforeSpanFinish(span, future.get());
         } catch (final InterruptedException | ExecutionException e) {
           beforeSpanFinish(span, e);
@@ -241,7 +241,7 @@ public class TracingSession implements Session {
     DECORATE.afterStart(span);
     DECORATE.onConnection(span, session);
     DECORATE.onStatement(span, query);
-    return activateSpan(span, false);
+    return activateSpan(span);
   }
 
   private static void beforeSpanFinish(final AgentSpan span, final ResultSet resultSet) {

--- a/dd-java-agent/instrumentation/dropwizard/dropwizard-views/src/main/java/datadog/trace/instrumentation/dropwizard/view/DropwizardViewInstrumentation.java
+++ b/dd-java-agent/instrumentation/dropwizard/dropwizard-views/src/main/java/datadog/trace/instrumentation/dropwizard/view/DropwizardViewInstrumentation.java
@@ -65,7 +65,7 @@ public final class DropwizardViewInstrumentation extends Instrumenter.Default {
               .setTag(DDTags.RESOURCE_NAME, "View " + view.getTemplateName())
               .setTag(Tags.COMPONENT, "dropwizard-view")
               .setTag("span.origin.type", obj.getClass().getSimpleName());
-      return activateSpan(span, true);
+      return activateSpan(span);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
@@ -80,6 +80,7 @@ public final class DropwizardViewInstrumentation extends Instrumenter.Default {
         span.addThrowable(throwable);
       }
       scope.close();
+      span.finish();
     }
   }
 }

--- a/dd-java-agent/instrumentation/elasticsearch/rest-5/src/main/java/datadog/trace/instrumentation/elasticsearch5/Elasticsearch5RestClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/elasticsearch/rest-5/src/main/java/datadog/trace/instrumentation/elasticsearch5/Elasticsearch5RestClientInstrumentation.java
@@ -66,7 +66,7 @@ public class Elasticsearch5RestClientInstrumentation extends Instrumenter.Defaul
 
       responseListener = new RestResponseListener(responseListener, span);
 
-      return activateSpan(span, false);
+      return activateSpan(span);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)

--- a/dd-java-agent/instrumentation/elasticsearch/rest-5/src/main/java/datadog/trace/instrumentation/elasticsearch5/Elasticsearch5RestClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/elasticsearch/rest-5/src/main/java/datadog/trace/instrumentation/elasticsearch5/Elasticsearch5RestClientInstrumentation.java
@@ -79,6 +79,7 @@ public class Elasticsearch5RestClientInstrumentation extends Instrumenter.Defaul
         span.finish();
       }
       scope.close();
+      // span finished by RestResponseListener
     }
   }
 }

--- a/dd-java-agent/instrumentation/elasticsearch/rest-6.4/src/main/java/datadog/trace/instrumentation/elasticsearch6_4/Elasticsearch6RestClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/elasticsearch/rest-6.4/src/main/java/datadog/trace/instrumentation/elasticsearch6_4/Elasticsearch6RestClientInstrumentation.java
@@ -78,6 +78,7 @@ public class Elasticsearch6RestClientInstrumentation extends Instrumenter.Defaul
         span.finish();
       }
       scope.close();
+      // span finished by RestResponseListener
     }
   }
 }

--- a/dd-java-agent/instrumentation/elasticsearch/rest-6.4/src/main/java/datadog/trace/instrumentation/elasticsearch6_4/Elasticsearch6RestClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/elasticsearch/rest-6.4/src/main/java/datadog/trace/instrumentation/elasticsearch6_4/Elasticsearch6RestClientInstrumentation.java
@@ -65,7 +65,7 @@ public class Elasticsearch6RestClientInstrumentation extends Instrumenter.Defaul
 
       responseListener = new RestResponseListener(responseListener, span);
 
-      return activateSpan(span, false);
+      return activateSpan(span);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/main/java/datadog/trace/instrumentation/elasticsearch2/Elasticsearch2TransportClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/main/java/datadog/trace/instrumentation/elasticsearch2/Elasticsearch2TransportClientInstrumentation.java
@@ -89,6 +89,7 @@ public class Elasticsearch2TransportClientInstrumentation extends Instrumenter.D
         span.finish();
       }
       scope.close();
+      // span finished by TransportActionListener
     }
   }
 }

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/main/java/datadog/trace/instrumentation/elasticsearch2/Elasticsearch2TransportClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/main/java/datadog/trace/instrumentation/elasticsearch2/Elasticsearch2TransportClientInstrumentation.java
@@ -76,7 +76,7 @@ public class Elasticsearch2TransportClientInstrumentation extends Instrumenter.D
 
       actionListener = new TransportActionListener<>(actionRequest, actionListener, span);
 
-      return activateSpan(span, false);
+      return activateSpan(span);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/main/java/datadog/trace/instrumentation/elasticsearch5_3/Elasticsearch53TransportClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/main/java/datadog/trace/instrumentation/elasticsearch5_3/Elasticsearch53TransportClientInstrumentation.java
@@ -90,6 +90,7 @@ public class Elasticsearch53TransportClientInstrumentation extends Instrumenter.
         span.finish();
       }
       scope.close();
+      // span finished by TransportActionListener
     }
   }
 }

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/main/java/datadog/trace/instrumentation/elasticsearch5_3/Elasticsearch53TransportClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/main/java/datadog/trace/instrumentation/elasticsearch5_3/Elasticsearch53TransportClientInstrumentation.java
@@ -77,7 +77,7 @@ public class Elasticsearch53TransportClientInstrumentation extends Instrumenter.
 
       actionListener = new TransportActionListener<>(actionRequest, actionListener, span);
 
-      return activateSpan(span, false);
+      return activateSpan(span);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5/src/main/java/datadog/trace/instrumentation/elasticsearch5/Elasticsearch5TransportClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5/src/main/java/datadog/trace/instrumentation/elasticsearch5/Elasticsearch5TransportClientInstrumentation.java
@@ -76,7 +76,7 @@ public class Elasticsearch5TransportClientInstrumentation extends Instrumenter.D
 
       actionListener = new TransportActionListener<>(actionRequest, actionListener, span);
 
-      return activateSpan(span, false);
+      return activateSpan(span);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5/src/main/java/datadog/trace/instrumentation/elasticsearch5/Elasticsearch5TransportClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5/src/main/java/datadog/trace/instrumentation/elasticsearch5/Elasticsearch5TransportClientInstrumentation.java
@@ -89,6 +89,7 @@ public class Elasticsearch5TransportClientInstrumentation extends Instrumenter.D
         span.finish();
       }
       scope.close();
+      // span finished by TransportActionListener
     }
   }
 }

--- a/dd-java-agent/instrumentation/elasticsearch/transport-6/src/main/java/datadog/trace/instrumentation/elasticsearch6/Elasticsearch6TransportClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-6/src/main/java/datadog/trace/instrumentation/elasticsearch6/Elasticsearch6TransportClientInstrumentation.java
@@ -80,7 +80,7 @@ public class Elasticsearch6TransportClientInstrumentation extends Instrumenter.D
 
       actionListener = new TransportActionListener<>(actionRequest, actionListener, span);
 
-      return activateSpan(span, false);
+      return activateSpan(span);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)

--- a/dd-java-agent/instrumentation/elasticsearch/transport-6/src/main/java/datadog/trace/instrumentation/elasticsearch6/Elasticsearch6TransportClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-6/src/main/java/datadog/trace/instrumentation/elasticsearch6/Elasticsearch6TransportClientInstrumentation.java
@@ -93,6 +93,7 @@ public class Elasticsearch6TransportClientInstrumentation extends Instrumenter.D
         span.finish();
       }
       scope.close();
+      // span finished by TransportActionListener
     }
   }
 }

--- a/dd-java-agent/instrumentation/finatra-2.9/src/main/java/datadog/trace/instrumentation/finatra/FinatraInstrumentation.java
+++ b/dd-java-agent/instrumentation/finatra-2.9/src/main/java/datadog/trace/instrumentation/finatra/FinatraInstrumentation.java
@@ -86,7 +86,7 @@ public class FinatraInstrumentation extends Instrumenter.Default {
       DECORATE.afterStart(span);
       span.setTag(DDTags.RESOURCE_NAME, DECORATE.spanNameForClass(clazz));
 
-      final AgentScope scope = activateSpan(span, false);
+      final AgentScope scope = activateSpan(span);
       scope.setAsyncPropagation(true);
       return scope;
     }

--- a/dd-java-agent/instrumentation/google-http-client/src/main/java/datadog/trace/instrumentation/googlehttpclient/GoogleHttpClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/google-http-client/src/main/java/datadog/trace/instrumentation/googlehttpclient/GoogleHttpClientInstrumentation.java
@@ -90,7 +90,7 @@ public class GoogleHttpClientInstrumentation extends Instrumenter.Default {
 
       final AgentSpan span = state.getSpan();
 
-      try (final AgentScope scope = activateSpan(span, false)) {
+      try (final AgentScope scope = activateSpan(span)) {
         DECORATE.afterStart(span);
         DECORATE.onRequest(span, request);
         propagate().inject(span, request, SETTER);
@@ -110,7 +110,7 @@ public class GoogleHttpClientInstrumentation extends Instrumenter.Default {
       if (state != null) {
         final AgentSpan span = state.getSpan();
 
-        try (final AgentScope scope = activateSpan(span, false)) {
+        try (final AgentScope scope = activateSpan(span)) {
           DECORATE.onResponse(span, response);
           DECORATE.onError(span, throwable);
 
@@ -154,7 +154,7 @@ public class GoogleHttpClientInstrumentation extends Instrumenter.Default {
         if (state != null) {
           final AgentSpan span = state.getSpan();
 
-          try (final AgentScope scope = activateSpan(span, false)) {
+          try (final AgentScope scope = activateSpan(span)) {
             DECORATE.onError(span, throwable);
 
             DECORATE.beforeFinish(span);

--- a/dd-java-agent/instrumentation/grizzly-2/src/main/java/datadog/trace/instrumentation/grizzly/GrizzlyHttpHandlerInstrumentation.java
+++ b/dd-java-agent/instrumentation/grizzly-2/src/main/java/datadog/trace/instrumentation/grizzly/GrizzlyHttpHandlerInstrumentation.java
@@ -101,6 +101,7 @@ public class GrizzlyHttpHandlerInstrumentation extends Instrumenter.Default {
         span.finish();
       }
       scope.close();
+      // span finished by SpanClosingListener
     }
   }
 

--- a/dd-java-agent/instrumentation/grizzly-2/src/main/java/datadog/trace/instrumentation/grizzly/GrizzlyHttpHandlerInstrumentation.java
+++ b/dd-java-agent/instrumentation/grizzly-2/src/main/java/datadog/trace/instrumentation/grizzly/GrizzlyHttpHandlerInstrumentation.java
@@ -76,7 +76,7 @@ public class GrizzlyHttpHandlerInstrumentation extends Instrumenter.Default {
       DECORATE.onConnection(span, request);
       DECORATE.onRequest(span, request);
 
-      final AgentScope scope = activateSpan(span, false);
+      final AgentScope scope = activateSpan(span);
       scope.setAsyncPropagation(true);
 
       request.setAttribute(DD_SPAN_ATTRIBUTE, span);

--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/TracingServerInterceptor.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/TracingServerInterceptor.java
@@ -55,6 +55,7 @@ public class TracingServerInterceptor implements ServerInterceptor {
     } finally {
       scope.setAsyncPropagation(false);
       scope.close();
+      // span finished by TracingServerCall
     }
 
     // This ensures the server implementation can see the span in scope

--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/TracingServerInterceptor.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/TracingServerInterceptor.java
@@ -36,7 +36,7 @@ public class TracingServerInterceptor implements ServerInterceptor {
             .setTag(DDTags.RESOURCE_NAME, call.getMethodDescriptor().getFullMethodName());
     DECORATE.afterStart(span);
 
-    final AgentScope scope = activateSpan(span, false);
+    final AgentScope scope = activateSpan(span);
     scope.setAsyncPropagation(true);
 
     final ServerCall.Listener<ReqT> result;
@@ -73,7 +73,7 @@ public class TracingServerInterceptor implements ServerInterceptor {
     @Override
     public void close(final Status status, final Metadata trailers) {
       DECORATE.onClose(span, status);
-      try (final AgentScope scope = activateSpan(span, false)) {
+      try (final AgentScope scope = activateSpan(span)) {
         // Using async propagate here breaks the tests which use InProcessTransport.
         // It also seems logical to not need it at all, so removing it.
         delegate().close(status, trailers);
@@ -99,7 +99,7 @@ public class TracingServerInterceptor implements ServerInterceptor {
           startSpan("grpc.message", this.span.context())
               .setTag("message.type", message.getClass().getName());
       DECORATE.afterStart(span);
-      final AgentScope scope = activateSpan(span, true);
+      final AgentScope scope = activateSpan(span);
       scope.setAsyncPropagation(true);
       try {
         delegate().onMessage(message);
@@ -112,12 +112,13 @@ public class TracingServerInterceptor implements ServerInterceptor {
         scope.setAsyncPropagation(false);
         DECORATE.beforeFinish(span);
         scope.close();
+        span.finish();
       }
     }
 
     @Override
     public void onHalfClose() {
-      try (final AgentScope scope = activateSpan(span, false)) {
+      try (final AgentScope scope = activateSpan(span)) {
         scope.setAsyncPropagation(true);
         delegate().onHalfClose();
         scope.setAsyncPropagation(false);
@@ -132,7 +133,7 @@ public class TracingServerInterceptor implements ServerInterceptor {
     @Override
     public void onCancel() {
       // Finishes span.
-      try (final AgentScope scope = activateSpan(span, false)) {
+      try (final AgentScope scope = activateSpan(span)) {
         scope.setAsyncPropagation(true);
         delegate().onCancel();
         span.setTag("canceled", true);
@@ -149,7 +150,7 @@ public class TracingServerInterceptor implements ServerInterceptor {
     @Override
     public void onComplete() {
       // Finishes span.
-      try (final AgentScope scope = activateSpan(span, false)) {
+      try (final AgentScope scope = activateSpan(span)) {
         scope.setAsyncPropagation(true);
         delegate().onComplete();
         scope.setAsyncPropagation(false);
@@ -164,7 +165,7 @@ public class TracingServerInterceptor implements ServerInterceptor {
 
     @Override
     public void onReady() {
-      try (final AgentScope scope = activateSpan(span, false)) {
+      try (final AgentScope scope = activateSpan(span)) {
         scope.setAsyncPropagation(true);
         delegate().onReady();
         scope.setAsyncPropagation(false);

--- a/dd-java-agent/instrumentation/hibernate/core-3.3/src/test/groovy/SessionTest.groovy
+++ b/dd-java-agent/instrumentation/hibernate/core-3.3/src/test/groovy/SessionTest.groovy
@@ -542,7 +542,7 @@ class SessionTest extends AbstractHibernateTest {
   def "test hibernate overlapping Sessions"() {
     setup:
 
-    AgentScope scope = activateSpan(startSpan("overlapping Sessions"), true)
+    AgentScope scope = activateSpan(startSpan("overlapping Sessions"))
 
     def session1 = sessionFactory.openSession()
     session1.beginTransaction()
@@ -561,6 +561,7 @@ class SessionTest extends AbstractHibernateTest {
     session3.close()
 
     scope.close()
+    scope.span().finish()
 
 
     expect:

--- a/dd-java-agent/instrumentation/hibernate/core-4.0/src/test/groovy/SessionTest.groovy
+++ b/dd-java-agent/instrumentation/hibernate/core-4.0/src/test/groovy/SessionTest.groovy
@@ -466,7 +466,7 @@ class SessionTest extends AbstractHibernateTest {
   def "test hibernate overlapping Sessions"() {
     setup:
 
-    AgentScope scope = activateSpan(startSpan("overlapping Sessions"), true)
+    AgentScope scope = activateSpan(startSpan("overlapping Sessions"))
 
     def session1 = sessionFactory.openSession()
     session1.beginTransaction()
@@ -485,7 +485,7 @@ class SessionTest extends AbstractHibernateTest {
     session3.close()
 
     scope.close()
-
+    scope.span().finish()
 
     expect:
     assertTraces(1) {

--- a/dd-java-agent/instrumentation/http-url-connection/src/main/java/datadog/trace/instrumentation/http_url_connection/HttpUrlConnectionInstrumentation.java
+++ b/dd-java-agent/instrumentation/http-url-connection/src/main/java/datadog/trace/instrumentation/http_url_connection/HttpUrlConnectionInstrumentation.java
@@ -137,7 +137,7 @@ public class HttpUrlConnectionInstrumentation extends Instrumenter.Default {
 
     public AgentSpan start(final HttpURLConnection connection) {
       span = startSpan(OPERATION_NAME);
-      try (final AgentScope scope = activateSpan(span, false)) {
+      try (final AgentScope scope = activateSpan(span)) {
         DECORATE.afterStart(span);
         DECORATE.onRequest(span, connection);
         return span;
@@ -157,7 +157,7 @@ public class HttpUrlConnectionInstrumentation extends Instrumenter.Default {
     }
 
     public void finishSpan(final Throwable throwable) {
-      try (final AgentScope scope = activateSpan(span, false)) {
+      try (final AgentScope scope = activateSpan(span)) {
         DECORATE.onError(span, throwable);
         DECORATE.beforeFinish(span);
         span.finish();
@@ -173,7 +173,7 @@ public class HttpUrlConnectionInstrumentation extends Instrumenter.Default {
        * (e.g. breaks getOutputStream).
        */
       if (responseCode > 0) {
-        try (final AgentScope scope = activateSpan(span, false)) {
+        try (final AgentScope scope = activateSpan(span)) {
           DECORATE.onResponse(span, responseCode);
           DECORATE.beforeFinish(span);
           span.finish();

--- a/dd-java-agent/instrumentation/http-url-connection/src/main/java/datadog/trace/instrumentation/http_url_connection/UrlInstrumentation.java
+++ b/dd-java-agent/instrumentation/http-url-connection/src/main/java/datadog/trace/instrumentation/http_url_connection/UrlInstrumentation.java
@@ -70,7 +70,7 @@ public class UrlInstrumentation extends Instrumenter.Default {
                 .setTag(DDTags.SPAN_TYPE, DDSpanTypes.HTTP_CLIENT)
                 .setTag(Tags.COMPONENT, COMPONENT);
 
-        try (final AgentScope scope = activateSpan(span, false)) {
+        try (final AgentScope scope = activateSpan(span)) {
           span.setTag(Tags.HTTP_URL, url.toString());
           span.setTag(Tags.PEER_PORT, url.getPort() == -1 ? 80 : url.getPort());
           span.setTag(Tags.PEER_HOSTNAME, url.getHost());

--- a/dd-java-agent/instrumentation/hystrix-1.4/src/test/groovy/HystrixTest.groovy
+++ b/dd-java-agent/instrumentation/hystrix-1.4/src/test/groovy/HystrixTest.groovy
@@ -34,7 +34,11 @@ class HystrixTest extends AgentTestRunner {
       }
     }
     def result = runUnderTrace("parent") {
-      operation(command)
+      try {
+        operation(command)
+      } finally {
+        blockUntilChildSpansFinished(2)
+      }
     }
     expect:
     TRANSFORMED_CLASSES_NAMES.contains("com.netflix.hystrix.strategy.concurrency.HystrixContextScheduler\$ThreadPoolWorker")
@@ -112,7 +116,11 @@ class HystrixTest extends AgentTestRunner {
       }
     }
     def result = runUnderTrace("parent") {
-      operation(command)
+      try {
+        return operation(command)
+      } finally {
+        blockUntilChildSpansFinished(2)
+      }
     }
     expect:
     TRANSFORMED_CLASSES_NAMES.contains("com.netflix.hystrix.strategy.concurrency.HystrixContextScheduler\$ThreadPoolWorker")

--- a/dd-java-agent/instrumentation/java-concurrent/akka-2.5-testing/src/test/groovy/AkkaExecutorInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/java-concurrent/akka-2.5-testing/src/test/groovy/AkkaExecutorInstrumentationTest.groovy
@@ -1,8 +1,8 @@
 import akka.dispatch.forkjoin.ForkJoinPool
 import akka.dispatch.forkjoin.ForkJoinTask
-import datadog.trace.core.DDSpan
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.Trace
+import datadog.trace.core.DDSpan
 import spock.lang.Shared
 
 import java.lang.reflect.InvocationTargetException
@@ -48,6 +48,7 @@ class AkkaExecutorInstrumentationTest extends AgentTestRunner {
         m(pool, new AkkaAsyncChild())
         // this child won't
         m(pool, new AkkaAsyncChild(false, false))
+        blockUntilChildSpansFinished(1)
       }
     }.run()
 

--- a/dd-java-agent/instrumentation/java-concurrent/akka-testing/src/test/scala/AkkaActors.scala
+++ b/dd-java-agent/instrumentation/java-concurrent/akka-testing/src/test/scala/AkkaActors.scala
@@ -1,6 +1,7 @@
 import akka.actor.{Actor, ActorLogging, ActorRef, ActorSystem, Props}
 import akka.pattern.ask
 import akka.util.Timeout
+import datadog.trace.agent.test.AgentTestRunner.blockUntilChildSpansFinished
 import datadog.trace.api.Trace
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer.{activeScope, activeSpan}
 
@@ -33,23 +34,35 @@ class AkkaActors {
 
   @Trace
   def basicTell(): Unit = {
-    activeScope().setAsyncPropagation(true)
-    howdyGreeter ! WhoToGreet("Akka")
-    howdyGreeter ! Greet
+    try {
+      activeScope().setAsyncPropagation(true)
+      howdyGreeter ! WhoToGreet("Akka")
+      howdyGreeter ! Greet
+    } finally {
+      blockUntilChildSpansFinished(1)
+    }
   }
 
   @Trace
   def basicAsk(): Unit = {
-    activeScope().setAsyncPropagation(true)
-    howdyGreeter ! WhoToGreet("Akka")
-    howdyGreeter ? Greet
+    try {
+      activeScope().setAsyncPropagation(true)
+      howdyGreeter ! WhoToGreet("Akka")
+      howdyGreeter ? Greet
+    } finally {
+      blockUntilChildSpansFinished(1)
+    }
   }
 
   @Trace
   def basicForward(): Unit = {
-    activeScope().setAsyncPropagation(true)
-    helloGreeter ! WhoToGreet("Akka")
-    helloGreeter ? Greet
+    try {
+      activeScope().setAsyncPropagation(true)
+      helloGreeter ! WhoToGreet("Akka")
+      helloGreeter ? Greet
+    } finally {
+      blockUntilChildSpansFinished(1)
+    }
   }
 }
 

--- a/dd-java-agent/instrumentation/java-concurrent/scala-testing/src/test/groovy/ScalaExecutorInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/java-concurrent/scala-testing/src/test/groovy/ScalaExecutorInstrumentationTest.groovy
@@ -1,6 +1,6 @@
-import datadog.trace.core.DDSpan
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.Trace
+import datadog.trace.core.DDSpan
 import scala.concurrent.forkjoin.ForkJoinPool
 import scala.concurrent.forkjoin.ForkJoinTask
 import spock.lang.Shared
@@ -48,6 +48,7 @@ class ScalaExecutorInstrumentationTest extends AgentTestRunner {
         m(pool, new ScalaAsyncChild())
         // this child won't
         m(pool, new ScalaAsyncChild(false, false))
+        blockUntilChildSpansFinished(1)
       }
     }.run()
 

--- a/dd-java-agent/instrumentation/java-concurrent/scala-testing/src/test/scala/ScalaConcurrentTests.scala
+++ b/dd-java-agent/instrumentation/java-concurrent/scala-testing/src/test/scala/ScalaConcurrentTests.scala
@@ -1,3 +1,4 @@
+import datadog.trace.agent.test.AgentTestRunner.blockUntilChildSpansFinished
 import datadog.trace.api.Trace
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer.{activeScope, activeSpan}
 
@@ -8,8 +9,8 @@ import scala.concurrent.{Await, Future, Promise}
 class ScalaConcurrentTests {
 
   /**
-    * @return Number of expected spans in the trace
-    */
+   * @return Number of expected spans in the trace
+   */
   @Trace
   def traceWithFutureAndCallbacks(): Integer = {
     activeScope().setAsyncPropagation(true)
@@ -28,6 +29,7 @@ class ScalaConcurrentTests {
       case t: Throwable => tracedChild("failureCallback")
     }
 
+    blockUntilChildSpansFinished(4)
     return 5
   }
 
@@ -45,12 +47,13 @@ class ScalaConcurrentTests {
       }
     }
 
+    blockUntilChildSpansFinished(1)
     return 2
   }
 
   /**
-    * @return Number of expected spans in the trace
-    */
+   * @return Number of expected spans in the trace
+   */
   @Trace
   def traceWithPromises(): Integer = {
     activeScope().setAsyncPropagation(true)
@@ -78,12 +81,13 @@ class ScalaConcurrentTests {
       case t => tracedChild("brokenPromise")
     }
 
+    blockUntilChildSpansFinished(4)
     return 5
   }
 
   /**
-    * @return Number of expected spans in the trace
-    */
+   * @return Number of expected spans in the trace
+   */
   @Trace
   def tracedWithFutureFirstCompletions(): Integer = {
     activeScope().setAsyncPropagation(true)
@@ -102,12 +106,14 @@ class ScalaConcurrentTests {
           true
         }))
     Await.result(completedVal, 30 seconds)
+
+    blockUntilChildSpansFinished(3)
     return 4
   }
 
   /**
-    * @return Number of expected spans in the trace
-    */
+   * @return Number of expected spans in the trace
+   */
   @Trace
   def tracedTimeout(): Integer = {
     activeScope().setAsyncPropagation(true)
@@ -124,6 +130,8 @@ class ScalaConcurrentTests {
     } catch {
       case e: Exception => {}
     }
+
+    blockUntilChildSpansFinished(1)
     return 2
   }
 

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/AsyncPropagatingDisableInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/AsyncPropagatingDisableInstrumentation.java
@@ -90,7 +90,7 @@ public final class AsyncPropagatingDisableInstrumentation implements Instrumente
     public static AgentScope enter() {
       final TraceScope scope = activeScope();
       if (scope != null && scope.isAsyncPropagating()) {
-        return activateSpan(noopSpan(), false);
+        return activateSpan(noopSpan());
       }
       return null;
     }

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/AsyncPropagatingDisableInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/AsyncPropagatingDisableInstrumentation.java
@@ -99,6 +99,7 @@ public final class AsyncPropagatingDisableInstrumentation implements Instrumente
     public static void exit(@Advice.Enter final AgentScope scope) {
       if (scope != null) {
         scope.close();
+        // Don't need to finish noop span.
       }
     }
   }

--- a/dd-java-agent/instrumentation/java-concurrent/src/slickTest/groovy/CompletableFutureTest.groovy
+++ b/dd-java-agent/instrumentation/java-concurrent/src/slickTest/groovy/CompletableFutureTest.groovy
@@ -1,6 +1,6 @@
-import datadog.trace.core.DDSpan
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.Trace
+import datadog.trace.core.DDSpan
 
 import java.util.concurrent.ArrayBlockingQueue
 import java.util.concurrent.CompletableFuture
@@ -42,10 +42,14 @@ class CompletableFutureTest extends AgentTestRunner {
       @Override
       @Trace(operationName = "parent")
       CompletableFuture<String> get() {
-        activeScope().setAsyncPropagation(true)
-        return CompletableFuture.supplyAsync(supplier, pool)
-          .thenCompose({ s -> CompletableFuture.supplyAsync(new AppendingSupplier(s), differentPool) })
-          .thenApply(function)
+        try {
+          activeScope().setAsyncPropagation(true)
+          return CompletableFuture.supplyAsync(supplier, pool)
+            .thenCompose({ s -> CompletableFuture.supplyAsync(new AppendingSupplier(s), differentPool) })
+            .thenApply(function)
+        } finally {
+          blockUntilChildSpansFinished(3)
+        }
       }
     }.get()
 

--- a/dd-java-agent/instrumentation/java-concurrent/src/slickTest/scala/SlickUtils.scala
+++ b/dd-java-agent/instrumentation/java-concurrent/src/slickTest/scala/SlickUtils.scala
@@ -1,3 +1,4 @@
+import datadog.trace.agent.test.AgentTestRunner.blockUntilChildSpansFinished
 import datadog.trace.api.Trace
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope
 import slick.jdbc.H2Profile.api._
@@ -21,8 +22,12 @@ class SlickUtils {
 
   @Trace
   def startQuery(query: String): Future[Vector[Int]] = {
-    activeScope().setAsyncPropagation(true)
-    database.run(sql"#$query".as[Int])
+    try {
+      activeScope().setAsyncPropagation(true)
+      database.run(sql"#$query".as[Int])
+    } finally {
+      blockUntilChildSpansFinished(1)
+    }
   }
 
   def getResults(future: Future[Vector[Int]]): Int = {

--- a/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/ExecutorInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/ExecutorInstrumentationTest.groovy
@@ -1,9 +1,9 @@
-import datadog.trace.core.DDSpan
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.utils.ConfigUtils
 import datadog.trace.api.Trace
 import datadog.trace.bootstrap.instrumentation.java.concurrent.CallableWrapper
 import datadog.trace.bootstrap.instrumentation.java.concurrent.RunnableWrapper
+import datadog.trace.core.DDSpan
 import spock.lang.Shared
 
 import java.lang.reflect.InvocationTargetException
@@ -74,6 +74,7 @@ class ExecutorInstrumentationTest extends AgentTestRunner {
         m(pool, new JavaAsyncChild())
         // this child won't
         m(pool, new JavaAsyncChild(false, false))
+        blockUntilChildSpansFinished(1)
       }
     }.run()
 

--- a/dd-java-agent/instrumentation/jax-rs-annotations-1/src/main/java/datadog/trace/instrumentation/jaxrs1/JaxRsAnnotationsInstrumentation.java
+++ b/dd-java-agent/instrumentation/jax-rs-annotations-1/src/main/java/datadog/trace/instrumentation/jaxrs1/JaxRsAnnotationsInstrumentation.java
@@ -87,7 +87,7 @@ public final class JaxRsAnnotationsInstrumentation extends Instrumenter.Default 
       DECORATE.onJaxRsSpan(span, parent, target.getClass(), method);
       DECORATE.afterStart(span);
 
-      final AgentScope scope = activateSpan(span, true);
+      final AgentScope scope = activateSpan(span);
       scope.setAsyncPropagation(true);
       return scope;
     }
@@ -99,6 +99,7 @@ public final class JaxRsAnnotationsInstrumentation extends Instrumenter.Default 
       DECORATE.onError(span, throwable);
       DECORATE.beforeFinish(span);
       scope.close();
+      scope.span().finish();
     }
   }
 }

--- a/dd-java-agent/instrumentation/jax-rs-annotations-2/src/main/java/datadog/trace/instrumentation/jaxrs2/AbstractRequestContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/jax-rs-annotations-2/src/main/java/datadog/trace/instrumentation/jaxrs2/AbstractRequestContextInstrumentation.java
@@ -74,7 +74,7 @@ public abstract class AbstractRequestContextInstrumentation extends Instrumenter
           parent = activeSpan();
           span = startSpan("jax-rs.request.abort");
 
-          final AgentScope scope = activateSpan(span, false);
+          final AgentScope scope = activateSpan(span);
           scope.setAsyncPropagation(true);
 
           DECORATE.afterStart(span);
@@ -101,8 +101,8 @@ public abstract class AbstractRequestContextInstrumentation extends Instrumenter
       }
 
       DECORATE.beforeFinish(span);
-      span.finish();
       scope.close();
+      span.finish();
     }
   }
 }

--- a/dd-java-agent/instrumentation/jax-rs-annotations-2/src/main/java/datadog/trace/instrumentation/jaxrs2/DefaultRequestContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/jax-rs-annotations-2/src/main/java/datadog/trace/instrumentation/jaxrs2/DefaultRequestContextInstrumentation.java
@@ -46,7 +46,7 @@ public class DefaultRequestContextInstrumentation extends AbstractRequestContext
           // can only be aborted inside the filter method
         }
 
-        final AgentScope scope = activateSpan(span, false);
+        final AgentScope scope = activateSpan(span);
         scope.setAsyncPropagation(true);
 
         DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/jax-rs-annotations-2/src/main/java/datadog/trace/instrumentation/jaxrs2/JaxRsAnnotationsInstrumentation.java
+++ b/dd-java-agent/instrumentation/jax-rs-annotations-2/src/main/java/datadog/trace/instrumentation/jaxrs2/JaxRsAnnotationsInstrumentation.java
@@ -148,6 +148,7 @@ public final class JaxRsAnnotationsInstrumentation extends Instrumenter.Default 
         DECORATE.beforeFinish(span);
         span.finish();
       }
+      // else span finished by AsyncResponseAdvice
       scope.close();
     }
   }

--- a/dd-java-agent/instrumentation/jax-rs-annotations-2/src/main/java/datadog/trace/instrumentation/jaxrs2/JaxRsAnnotationsInstrumentation.java
+++ b/dd-java-agent/instrumentation/jax-rs-annotations-2/src/main/java/datadog/trace/instrumentation/jaxrs2/JaxRsAnnotationsInstrumentation.java
@@ -113,7 +113,7 @@ public final class JaxRsAnnotationsInstrumentation extends Instrumenter.Default 
       DECORATE.onJaxRsSpan(span, parent, target.getClass(), method);
       DECORATE.afterStart(span);
 
-      final AgentScope scope = activateSpan(span, false);
+      final AgentScope scope = activateSpan(span);
       scope.setAsyncPropagation(true);
 
       if (contextStore != null && asyncResponse != null) {

--- a/dd-java-agent/instrumentation/jax-rs-client-1.1/src/main/java/datadog/trace/instrumentation/jaxrs/v1/JaxRsClientV1Instrumentation.java
+++ b/dd-java-agent/instrumentation/jax-rs-client-1.1/src/main/java/datadog/trace/instrumentation/jaxrs/v1/JaxRsClientV1Instrumentation.java
@@ -77,7 +77,7 @@ public final class JaxRsClientV1Instrumentation extends Instrumenter.Default {
         request.getProperties().put(DD_SPAN_ATTRIBUTE, span);
 
         propagate().inject(span, request.getHeaders(), SETTER);
-        return activateSpan(span, true);
+        return activateSpan(span);
       }
       return null;
     }
@@ -95,6 +95,7 @@ public final class JaxRsClientV1Instrumentation extends Instrumenter.Default {
       DECORATE.onError(span, throwable);
       DECORATE.beforeFinish(span);
       scope.close();
+      scope.span().finish();
     }
   }
 }

--- a/dd-java-agent/instrumentation/jax-rs-client-2.0/src/main/java/datadog/trace/instrumentation/jaxrs/ClientTracingFilter.java
+++ b/dd-java-agent/instrumentation/jax-rs-client-2.0/src/main/java/datadog/trace/instrumentation/jaxrs/ClientTracingFilter.java
@@ -24,7 +24,7 @@ public class ClientTracingFilter implements ClientRequestFilter, ClientResponseF
   @Override
   public void filter(final ClientRequestContext requestContext) {
     final AgentSpan span = startSpan("jax-rs.client.call");
-    try (final AgentScope scope = activateSpan(span, false)) {
+    try (final AgentScope scope = activateSpan(span)) {
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, requestContext);
 

--- a/dd-java-agent/instrumentation/jax-rs-client-2.0/src/test/groovy/JaxRsClientAsyncTest.groovy
+++ b/dd-java-agent/instrumentation/jax-rs-client-2.0/src/test/groovy/JaxRsClientAsyncTest.groovy
@@ -15,6 +15,7 @@ import javax.ws.rs.client.InvocationCallback
 import javax.ws.rs.client.WebTarget
 import javax.ws.rs.core.MediaType
 import javax.ws.rs.core.Response
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
 abstract class JaxRsClientAsyncTest extends HttpClientTest {
@@ -27,11 +28,13 @@ abstract class JaxRsClientAsyncTest extends HttpClientTest {
     headers.each { builder.header(it.key, it.value) }
     AsyncInvoker request = builder.async()
 
+    def latch = new CountDownLatch(1)
     def body = BODY_METHODS.contains(method) ? Entity.text("") : null
     Response response = request.method(method, (Entity) body, new InvocationCallback<Response>() {
       @Override
       void completed(Response s) {
         callback?.call()
+        latch.countDown()
       }
 
       @Override
@@ -39,6 +42,7 @@ abstract class JaxRsClientAsyncTest extends HttpClientTest {
       }
     }).get()
 
+    latch.await()
     return response.status
   }
 

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/DataSourceInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/DataSourceInstrumentation.java
@@ -62,7 +62,7 @@ public final class DataSourceInstrumentation extends Instrumenter.Default {
 
       span.setTag(DDTags.RESOURCE_NAME, ds.getClass().getSimpleName() + ".getConnection");
 
-      final AgentScope agentScope = activateSpan(span, true);
+      final AgentScope agentScope = activateSpan(span);
       agentScope.setAsyncPropagation(true);
       return agentScope;
     }
@@ -76,6 +76,7 @@ public final class DataSourceInstrumentation extends Instrumenter.Default {
       DECORATE.onError(scope, throwable);
       DECORATE.beforeFinish(scope);
       scope.close();
+      scope.span().finish();
     }
   }
 }

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/PreparedStatementInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/PreparedStatementInstrumentation.java
@@ -69,7 +69,7 @@ public final class PreparedStatementInstrumentation extends Instrumenter.Default
       DECORATE.onConnection(span, connection);
       DECORATE.onPreparedStatement(span, statement);
       span.setTag("span.origin.type", statement.getClass().getName());
-      return activateSpan(span, true);
+      return activateSpan(span);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
@@ -81,6 +81,7 @@ public final class PreparedStatementInstrumentation extends Instrumenter.Default
       DECORATE.onError(scope.span(), throwable);
       DECORATE.beforeFinish(scope.span());
       scope.close();
+      scope.span().finish();
       CallDepthThreadLocalMap.reset(PreparedStatement.class);
     }
   }

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/StatementInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/StatementInstrumentation.java
@@ -70,7 +70,7 @@ public final class StatementInstrumentation extends Instrumenter.Default {
       DECORATE.onConnection(span, connection);
       DECORATE.onStatement(span, sql);
       span.setTag("span.origin.type", statement.getClass().getName());
-      return activateSpan(span, true);
+      return activateSpan(span);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
@@ -82,6 +82,7 @@ public final class StatementInstrumentation extends Instrumenter.Default {
       DECORATE.onError(scope.span(), throwable);
       DECORATE.beforeFinish(scope.span());
       scope.close();
+      scope.span().finish();
       CallDepthThreadLocalMap.reset(Statement.class);
     }
   }

--- a/dd-java-agent/instrumentation/jedis-1.4/src/main/java/datadog/trace/instrumentation/jedis/JedisInstrumentation.java
+++ b/dd-java-agent/instrumentation/jedis-1.4/src/main/java/datadog/trace/instrumentation/jedis/JedisInstrumentation.java
@@ -68,7 +68,7 @@ public final class JedisInstrumentation extends Instrumenter.Default {
       final AgentSpan span = startSpan("redis.command");
       DECORATE.afterStart(span);
       DECORATE.onStatement(span, command.name());
-      return activateSpan(span, true);
+      return activateSpan(span);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
@@ -77,6 +77,7 @@ public final class JedisInstrumentation extends Instrumenter.Default {
       DECORATE.onError(scope.span(), throwable);
       DECORATE.beforeFinish(scope.span());
       scope.close();
+      scope.span().finish();
     }
   }
 }

--- a/dd-java-agent/instrumentation/jedis-3.0/src/main/java/datadog/trace/instrumentation/jedis30/JedisInstrumentation.java
+++ b/dd-java-agent/instrumentation/jedis-3.0/src/main/java/datadog/trace/instrumentation/jedis30/JedisInstrumentation.java
@@ -64,7 +64,7 @@ public final class JedisInstrumentation extends Instrumenter.Default {
         // us if that changes
         DECORATE.onStatement(span, new String(command.getRaw()));
       }
-      return activateSpan(span, true);
+      return activateSpan(span);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
@@ -73,6 +73,7 @@ public final class JedisInstrumentation extends Instrumenter.Default {
       DECORATE.onError(scope.span(), throwable);
       DECORATE.beforeFinish(scope.span());
       scope.close();
+      scope.span().finish();
     }
   }
 }

--- a/dd-java-agent/instrumentation/jetty-8/src/main/java/datadog/trace/instrumentation/jetty8/JettyHandlerAdvice.java
+++ b/dd-java-agent/instrumentation/jetty-8/src/main/java/datadog/trace/instrumentation/jetty8/JettyHandlerAdvice.java
@@ -84,8 +84,9 @@ public class JettyHandlerAdvice {
       if (!req.isAsyncStarted() && activated.compareAndSet(false, true)) {
         DECORATE.onResponse(span, resp);
         DECORATE.beforeFinish(span);
-        span.finish(); // Finish the span manually since finishSpanOnClose was false
+        span.finish();
       }
+      // else span finished by TagSettingAsyncListener
     }
     scope.close();
   }

--- a/dd-java-agent/instrumentation/jetty-8/src/main/java/datadog/trace/instrumentation/jetty8/JettyHandlerAdvice.java
+++ b/dd-java-agent/instrumentation/jetty-8/src/main/java/datadog/trace/instrumentation/jetty8/JettyHandlerAdvice.java
@@ -40,7 +40,7 @@ public class JettyHandlerAdvice {
     final String resourceName = req.getMethod() + " " + source.getClass().getName();
     span.setTag(DDTags.RESOURCE_NAME, resourceName);
 
-    final AgentScope scope = activateSpan(span, false);
+    final AgentScope scope = activateSpan(span);
     scope.setAsyncPropagation(true);
     req.setAttribute(DD_SPAN_ATTRIBUTE, span);
     req.setAttribute(CorrelationIdentifier.getTraceIdKey(), GlobalTracer.get().getTraceId());

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageConsumerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageConsumerInstrumentation.java
@@ -92,7 +92,7 @@ public final class JMSMessageConsumerInstrumentation extends Instrumenter.Defaul
       }
       span.setTag("span.origin.type", consumer.getClass().getName());
 
-      try (final AgentScope scope = activateSpan(span, false)) {
+      try (final AgentScope scope = activateSpan(span)) {
         CONSUMER_DECORATE.afterStart(span);
         if (message == null) {
           CONSUMER_DECORATE.onReceive(span, method);

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageListenerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageListenerInstrumentation.java
@@ -75,7 +75,7 @@ public final class JMSMessageListenerInstrumentation extends Instrumenter.Defaul
       CONSUMER_DECORATE.afterStart(span);
       CONSUMER_DECORATE.onReceive(span, message);
 
-      final AgentScope scope = activateSpan(span, true);
+      final AgentScope scope = activateSpan(span);
       scope.setAsyncPropagation(true);
       return scope;
     }
@@ -89,6 +89,7 @@ public final class JMSMessageListenerInstrumentation extends Instrumenter.Defaul
       CONSUMER_DECORATE.onError(scope, throwable);
       CONSUMER_DECORATE.beforeFinish(scope);
       scope.close();
+      scope.span().finish();
     }
   }
 }

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageProducerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageProducerInstrumentation.java
@@ -95,7 +95,7 @@ public final class JMSMessageProducerInstrumentation extends Instrumenter.Defaul
 
       propagate().inject(span, message, SETTER);
 
-      return activateSpan(span, true);
+      return activateSpan(span);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
@@ -107,6 +107,7 @@ public final class JMSMessageProducerInstrumentation extends Instrumenter.Defaul
       PRODUCER_DECORATE.onError(scope, throwable);
       PRODUCER_DECORATE.beforeFinish(scope);
       scope.close();
+      scope.span().finish();
       CallDepthThreadLocalMap.reset(MessageProducer.class);
     }
   }
@@ -130,7 +131,7 @@ public final class JMSMessageProducerInstrumentation extends Instrumenter.Defaul
 
       propagate().inject(span, message, SETTER);
 
-      return activateSpan(span, true);
+      return activateSpan(span);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
@@ -142,6 +143,7 @@ public final class JMSMessageProducerInstrumentation extends Instrumenter.Defaul
       PRODUCER_DECORATE.onError(scope, throwable);
       PRODUCER_DECORATE.beforeFinish(scope);
       scope.close();
+      scope.span().finish();
       CallDepthThreadLocalMap.reset(MessageProducer.class);
     }
   }

--- a/dd-java-agent/instrumentation/jsp-2.3/src/main/java/datadog/trace/instrumentation/jsp/JSPInstrumentation.java
+++ b/dd-java-agent/instrumentation/jsp-2.3/src/main/java/datadog/trace/instrumentation/jsp/JSPInstrumentation.java
@@ -67,7 +67,7 @@ public final class JSPInstrumentation extends Instrumenter.Default {
               .setTag("servlet.context", req.getContextPath());
       DECORATE.afterStart(span);
       DECORATE.onRender(span, req);
-      return activateSpan(span, true);
+      return activateSpan(span);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
@@ -76,6 +76,7 @@ public final class JSPInstrumentation extends Instrumenter.Default {
       DECORATE.onError(scope, throwable);
       DECORATE.beforeFinish(scope);
       scope.close();
+      scope.span().finish();
     }
   }
 }

--- a/dd-java-agent/instrumentation/jsp-2.3/src/main/java/datadog/trace/instrumentation/jsp/JasperJSPCompilationContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/jsp-2.3/src/main/java/datadog/trace/instrumentation/jsp/JasperJSPCompilationContextInstrumentation.java
@@ -52,7 +52,7 @@ public final class JasperJSPCompilationContextInstrumentation extends Instrument
     public static AgentScope onEnter() {
       final AgentSpan span = startSpan("jsp.compile");
       DECORATE.afterStart(span);
-      return activateSpan(span, true);
+      return activateSpan(span);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
@@ -66,6 +66,7 @@ public final class JasperJSPCompilationContextInstrumentation extends Instrument
       DECORATE.onError(scope, throwable);
       DECORATE.beforeFinish(scope);
       scope.close();
+      scope.span().finish();
     }
   }
 }

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerInstrumentation.java
@@ -103,6 +103,7 @@ public final class KafkaProducerInstrumentation extends Instrumenter.Default {
       PRODUCER_DECORATE.onError(scope, throwable);
       PRODUCER_DECORATE.beforeFinish(scope);
       scope.close();
+      // span finished by ProducerCallback
     }
   }
 

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerInstrumentation.java
@@ -94,7 +94,7 @@ public final class KafkaProducerInstrumentation extends Instrumenter.Default {
         }
       }
 
-      return activateSpan(span, false);
+      return activateSpan(span);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
@@ -117,7 +117,7 @@ public final class KafkaProducerInstrumentation extends Instrumenter.Default {
 
     @Override
     public void onCompletion(final RecordMetadata metadata, final Exception exception) {
-      try (final AgentScope scope = activateSpan(span, false)) {
+      try (final AgentScope scope = activateSpan(span)) {
         PRODUCER_DECORATE.onError(span, exception);
         try {
           if (callback != null) {

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TracingIterator.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TracingIterator.java
@@ -37,6 +37,7 @@ public class TracingIterator implements Iterator<ConsumerRecord> {
   public boolean hasNext() {
     if (currentScope != null) {
       currentScope.close();
+      currentScope.span().finish();
       currentScope = null;
     }
     return delegateIterator.hasNext();
@@ -47,6 +48,7 @@ public class TracingIterator implements Iterator<ConsumerRecord> {
     if (currentScope != null) {
       // in case they didn't call hasNext()...
       currentScope.close();
+      currentScope.span().finish();
       currentScope = null;
     }
 
@@ -58,7 +60,7 @@ public class TracingIterator implements Iterator<ConsumerRecord> {
         final AgentSpan span = startSpan(operationName, spanContext);
         decorator.afterStart(span);
         decorator.onConsume(span, next);
-        currentScope = activateSpan(span, true);
+        currentScope = activateSpan(span);
         currentScope.setAsyncPropagation(true);
       }
     } catch (final Exception e) {

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/KafkaStreamsProcessorInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/KafkaStreamsProcessorInstrumentation.java
@@ -78,7 +78,7 @@ public class KafkaStreamsProcessorInstrumentation {
         CONSUMER_DECORATE.afterStart(span);
         CONSUMER_DECORATE.onConsume(span, record);
 
-        activateSpan(span, true).setAsyncPropagation(true);
+        activateSpan(span).setAsyncPropagation(true);
       }
     }
   }
@@ -122,6 +122,7 @@ public class KafkaStreamsProcessorInstrumentation {
         final TraceScope scope = activeScope();
         if (scope != null) {
           scope.close();
+          span.finish();
         }
       }
     }

--- a/dd-java-agent/instrumentation/lettuce-4/src/main/java8/datadog/trace/instrumentation/lettuce/InstrumentationPoints.java
+++ b/dd-java-agent/instrumentation/lettuce-4/src/main/java8/datadog/trace/instrumentation/lettuce/InstrumentationPoints.java
@@ -62,6 +62,7 @@ public final class InstrumentationPoints {
         });
       }
       scope.close();
+    // span may be finished by handleAsync call above.
   }
 
   public static AgentScope beforeConnect(RedisURI redisURI) {

--- a/dd-java-agent/instrumentation/lettuce-5/src/main/java8/datadog/trace/instrumentation/lettuce/ConnectionFutureAdvice.java
+++ b/dd-java-agent/instrumentation/lettuce-5/src/main/java8/datadog/trace/instrumentation/lettuce/ConnectionFutureAdvice.java
@@ -17,7 +17,7 @@ public class ConnectionFutureAdvice {
     final AgentSpan span = startSpan("redis.query");
     DECORATE.afterStart(span);
     DECORATE.onConnection(span, redisUri);
-    return activateSpan(span, false);
+    return activateSpan(span);
   }
 
   @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
@@ -29,8 +29,8 @@ public class ConnectionFutureAdvice {
     if (throwable != null) {
       DECORATE.onError(span, throwable);
       DECORATE.beforeFinish(span);
-      span.finish();
       scope.close();
+      span.finish();
       return;
     }
     connectionFuture.handleAsync(new LettuceAsyncBiFunction<>(span));

--- a/dd-java-agent/instrumentation/lettuce-5/src/main/java8/datadog/trace/instrumentation/lettuce/ConnectionFutureAdvice.java
+++ b/dd-java-agent/instrumentation/lettuce-5/src/main/java8/datadog/trace/instrumentation/lettuce/ConnectionFutureAdvice.java
@@ -35,5 +35,6 @@ public class ConnectionFutureAdvice {
     }
     connectionFuture.handleAsync(new LettuceAsyncBiFunction<>(span));
     scope.close();
+    // span finished by LettuceAsyncBiFunction
   }
 }

--- a/dd-java-agent/instrumentation/lettuce-5/src/main/java8/datadog/trace/instrumentation/lettuce/LettuceAsyncCommandsAdvice.java
+++ b/dd-java-agent/instrumentation/lettuce-5/src/main/java8/datadog/trace/instrumentation/lettuce/LettuceAsyncCommandsAdvice.java
@@ -44,5 +44,6 @@ public class LettuceAsyncCommandsAdvice {
       asyncCommand.handleAsync(new LettuceAsyncBiFunction<>(span));
     }
     scope.close();
+    // span finished by LettuceAsyncBiFunction
   }
 }

--- a/dd-java-agent/instrumentation/lettuce-5/src/main/java8/datadog/trace/instrumentation/lettuce/LettuceAsyncCommandsAdvice.java
+++ b/dd-java-agent/instrumentation/lettuce-5/src/main/java8/datadog/trace/instrumentation/lettuce/LettuceAsyncCommandsAdvice.java
@@ -34,8 +34,8 @@ public class LettuceAsyncCommandsAdvice {
     if (throwable != null) {
       DECORATE.onError(span, throwable);
       DECORATE.beforeFinish(span);
-      span.finish();
       scope.close();
+      span.finish();
       return;
     }
 

--- a/dd-java-agent/instrumentation/mongo/driver-3.1/src/main/java/datadog/trace/instrumentation/mongo/TracingCommandListener.java
+++ b/dd-java-agent/instrumentation/mongo/driver-3.1/src/main/java/datadog/trace/instrumentation/mongo/TracingCommandListener.java
@@ -22,7 +22,7 @@ public class TracingCommandListener implements CommandListener {
   @Override
   public void commandStarted(final CommandStartedEvent event) {
     final AgentSpan span = startSpan("mongo.query");
-    try (final AgentScope scope = activateSpan(span, false)) {
+    try (final AgentScope scope = activateSpan(span)) {
       DECORATE.afterStart(span);
       DECORATE.onConnection(span, event);
       if (event.getConnectionDescription() != null

--- a/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/ChannelFutureListenerInstrumentation.java
+++ b/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/ChannelFutureListenerInstrumentation.java
@@ -100,7 +100,7 @@ public class ChannelFutureListenerInstrumentation extends Instrumenter.Default {
       final TraceScope parentScope = continuation.activate();
 
       final AgentSpan errorSpan = startSpan("netty.connect").setTag(Tags.COMPONENT, "netty");
-      try (final AgentScope scope = activateSpan(errorSpan, false)) {
+      try (final AgentScope scope = activateSpan(errorSpan)) {
         DECORATE.onError(errorSpan, cause);
         DECORATE.beforeFinish(errorSpan);
         errorSpan.finish();

--- a/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/NettyChannelInstrumentation.java
+++ b/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/NettyChannelInstrumentation.java
@@ -80,7 +80,7 @@ public class NettyChannelInstrumentation extends Instrumenter.Default {
                   .putIfAbsent(channel, ChannelTraceContext.Factory.INSTANCE)
                   .getConnectionContinuation()
               != null) {
-            continuation.close();
+            continuation.cancel();
           } else {
             contextStore.get(channel).setConnectionContinuation(continuation);
           }

--- a/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/client/HttpClientRequestTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/client/HttpClientRequestTracingHandler.java
@@ -53,7 +53,7 @@ public class HttpClientRequestTracingHandler extends SimpleChannelDownstreamHand
     channelTraceContext.setClientParentSpan(activeSpan());
 
     final AgentSpan span = startSpan("netty.client.request");
-    try (final AgentScope scope = activateSpan(span, false)) {
+    try (final AgentScope scope = activateSpan(span)) {
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, request);
       DECORATE.onPeerConnection(span, (InetSocketAddress) ctx.getChannel().getRemoteAddress());

--- a/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/client/HttpClientResponseTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/client/HttpClientResponseTracingHandler.java
@@ -39,7 +39,7 @@ public class HttpClientResponseTracingHandler extends SimpleChannelUpstreamHandl
     final boolean finishSpan = msg.getMessage() instanceof HttpResponse;
 
     if (span != null && finishSpan) {
-      try (final AgentScope scope = activateSpan(span, false)) {
+      try (final AgentScope scope = activateSpan(span)) {
         DECORATE.onResponse(span, (HttpResponse) msg.getMessage());
         DECORATE.beforeFinish(span);
         span.finish();
@@ -47,7 +47,7 @@ public class HttpClientResponseTracingHandler extends SimpleChannelUpstreamHandl
     }
 
     // We want the callback in the scope of the parent, not the client span
-    try (final AgentScope scope = activateSpan(parent, false)) {
+    try (final AgentScope scope = activateSpan(parent)) {
       scope.setAsyncPropagation(true);
       ctx.sendUpstream(msg);
     }

--- a/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/server/HttpServerRequestTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/server/HttpServerRequestTracingHandler.java
@@ -37,7 +37,7 @@ public class HttpServerRequestTracingHandler extends SimpleChannelUpstreamHandle
       if (span == null) {
         ctx.sendUpstream(msg); // superclass does not throw
       } else {
-        try (final AgentScope scope = activateSpan(span, false)) {
+        try (final AgentScope scope = activateSpan(span)) {
           scope.setAsyncPropagation(true);
           ctx.sendUpstream(msg); // superclass does not throw
         }
@@ -50,7 +50,7 @@ public class HttpServerRequestTracingHandler extends SimpleChannelUpstreamHandle
     final Context context = propagate().extract(request.headers(), GETTER);
 
     final AgentSpan span = startSpan("netty.request", context);
-    try (final AgentScope scope = activateSpan(span, false)) {
+    try (final AgentScope scope = activateSpan(span)) {
       DECORATE.afterStart(span);
       DECORATE.onConnection(span, ctx.getChannel());
       DECORATE.onRequest(span, request);

--- a/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/server/HttpServerResponseTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/server/HttpServerResponseTracingHandler.java
@@ -35,7 +35,7 @@ public class HttpServerResponseTracingHandler extends SimpleChannelDownstreamHan
       return;
     }
 
-    try (final AgentScope scope = activateSpan(span, false)) {
+    try (final AgentScope scope = activateSpan(span)) {
       final HttpResponse response = (HttpResponse) msg.getMessage();
 
       try {

--- a/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/ChannelFutureListenerInstrumentation.java
+++ b/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/ChannelFutureListenerInstrumentation.java
@@ -95,7 +95,7 @@ public class ChannelFutureListenerInstrumentation extends Instrumenter.Default {
       final TraceScope parentScope = continuation.activate();
 
       final AgentSpan errorSpan = startSpan("netty.connect").setTag(Tags.COMPONENT, "netty");
-      try (final AgentScope scope = activateSpan(errorSpan, false)) {
+      try (final AgentScope scope = activateSpan(errorSpan)) {
         NettyHttpServerDecorator.DECORATE.onError(errorSpan, cause);
         NettyHttpServerDecorator.DECORATE.beforeFinish(errorSpan);
         errorSpan.finish();

--- a/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/NettyChannelPipelineInstrumentation.java
+++ b/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/NettyChannelPipelineInstrumentation.java
@@ -155,7 +155,7 @@ public class NettyChannelPipelineInstrumentation extends Instrumenter.Default {
           final Attribute<TraceScope.Continuation> attribute =
               pipeline.channel().attr(AttributeKeys.PARENT_CONNECT_CONTINUATION_ATTRIBUTE_KEY);
           if (!attribute.compareAndSet(null, continuation)) {
-            continuation.close();
+            continuation.cancel();
           }
         }
       }

--- a/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/client/HttpClientRequestTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/client/HttpClientRequestTracingHandler.java
@@ -40,7 +40,7 @@ public class HttpClientRequestTracingHandler extends ChannelOutboundHandlerAdapt
     ctx.channel().attr(AttributeKeys.CLIENT_PARENT_ATTRIBUTE_KEY).set(activeSpan());
 
     final AgentSpan span = startSpan("netty.client.request");
-    try (final AgentScope scope = activateSpan(span, false)) {
+    try (final AgentScope scope = activateSpan(span)) {
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, request);
       DECORATE.onPeerConnection(span, (InetSocketAddress) ctx.channel().remoteAddress());

--- a/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/client/HttpClientResponseTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/client/HttpClientResponseTracingHandler.java
@@ -25,7 +25,7 @@ public class HttpClientResponseTracingHandler extends ChannelInboundHandlerAdapt
     final boolean finishSpan = msg instanceof HttpResponse;
 
     if (span != null && finishSpan) {
-      try (final AgentScope scope = activateSpan(span, false)) {
+      try (final AgentScope scope = activateSpan(span)) {
         DECORATE.onResponse(span, (HttpResponse) msg);
         DECORATE.beforeFinish(span);
         span.finish();
@@ -33,7 +33,7 @@ public class HttpClientResponseTracingHandler extends ChannelInboundHandlerAdapt
     }
 
     // We want the callback in the scope of the parent, not the client span
-    try (final AgentScope scope = activateSpan(parent, false)) {
+    try (final AgentScope scope = activateSpan(parent)) {
       scope.setAsyncPropagation(true);
       ctx.fireChannelRead(msg);
     }

--- a/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/server/HttpServerRequestTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/server/HttpServerRequestTracingHandler.java
@@ -24,7 +24,7 @@ public class HttpServerRequestTracingHandler extends ChannelInboundHandlerAdapte
       if (span == null) {
         ctx.fireChannelRead(msg); // superclass does not throw
       } else {
-        try (final AgentScope scope = activateSpan(span, false)) {
+        try (final AgentScope scope = activateSpan(span)) {
           scope.setAsyncPropagation(true);
           ctx.fireChannelRead(msg); // superclass does not throw
         }
@@ -37,7 +37,7 @@ public class HttpServerRequestTracingHandler extends ChannelInboundHandlerAdapte
     final Context context = propagate().extract(request.headers(), GETTER);
 
     final AgentSpan span = startSpan("netty.request", context);
-    try (final AgentScope scope = activateSpan(span, false)) {
+    try (final AgentScope scope = activateSpan(span)) {
       DECORATE.afterStart(span);
       DECORATE.onConnection(span, ctx.channel());
       DECORATE.onRequest(span, request);

--- a/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/server/HttpServerResponseTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/server/HttpServerResponseTracingHandler.java
@@ -22,7 +22,7 @@ public class HttpServerResponseTracingHandler extends ChannelOutboundHandlerAdap
       return;
     }
 
-    try (final AgentScope scope = activateSpan(span, false)) {
+    try (final AgentScope scope = activateSpan(span)) {
       final HttpResponse response = (HttpResponse) msg;
 
       try {

--- a/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/ChannelFutureListenerInstrumentation.java
+++ b/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/ChannelFutureListenerInstrumentation.java
@@ -95,7 +95,7 @@ public class ChannelFutureListenerInstrumentation extends Instrumenter.Default {
       final TraceScope parentScope = continuation.activate();
 
       final AgentSpan errorSpan = startSpan("netty.connect").setTag(Tags.COMPONENT, "netty");
-      try (final AgentScope scope = activateSpan(errorSpan, false)) {
+      try (final AgentScope scope = activateSpan(errorSpan)) {
         NettyHttpServerDecorator.DECORATE.onError(errorSpan, cause);
         NettyHttpServerDecorator.DECORATE.beforeFinish(errorSpan);
         errorSpan.finish();

--- a/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/NettyChannelPipelineInstrumentation.java
+++ b/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/NettyChannelPipelineInstrumentation.java
@@ -164,7 +164,7 @@ public class NettyChannelPipelineInstrumentation extends Instrumenter.Default {
           final Attribute<TraceScope.Continuation> attribute =
               pipeline.channel().attr(AttributeKeys.PARENT_CONNECT_CONTINUATION_ATTRIBUTE_KEY);
           if (!attribute.compareAndSet(null, continuation)) {
-            continuation.close();
+            continuation.cancel();
           }
         }
       }

--- a/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/client/HttpClientRequestTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/client/HttpClientRequestTracingHandler.java
@@ -40,7 +40,7 @@ public class HttpClientRequestTracingHandler extends ChannelOutboundHandlerAdapt
     ctx.channel().attr(AttributeKeys.CLIENT_PARENT_ATTRIBUTE_KEY).set(activeSpan());
 
     final AgentSpan span = startSpan("netty.client.request");
-    try (final AgentScope scope = activateSpan(span, false)) {
+    try (final AgentScope scope = activateSpan(span)) {
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, request);
       DECORATE.onPeerConnection(span, (InetSocketAddress) ctx.channel().remoteAddress());

--- a/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/client/HttpClientResponseTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/client/HttpClientResponseTracingHandler.java
@@ -25,7 +25,7 @@ public class HttpClientResponseTracingHandler extends ChannelInboundHandlerAdapt
     final boolean finishSpan = msg instanceof HttpResponse;
 
     if (span != null && finishSpan) {
-      try (final AgentScope scope = activateSpan(span, false)) {
+      try (final AgentScope scope = activateSpan(span)) {
         DECORATE.onResponse(span, (HttpResponse) msg);
         DECORATE.beforeFinish(span);
         span.finish();
@@ -33,7 +33,7 @@ public class HttpClientResponseTracingHandler extends ChannelInboundHandlerAdapt
     }
 
     // We want the callback in the scope of the parent, not the client span
-    try (final AgentScope scope = activateSpan(parent, false)) {
+    try (final AgentScope scope = activateSpan(parent)) {
       scope.setAsyncPropagation(true);
       ctx.fireChannelRead(msg);
     }

--- a/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/server/HttpServerRequestTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/server/HttpServerRequestTracingHandler.java
@@ -24,7 +24,7 @@ public class HttpServerRequestTracingHandler extends ChannelInboundHandlerAdapte
       if (span == null) {
         ctx.fireChannelRead(msg); // superclass does not throw
       } else {
-        try (final AgentScope scope = activateSpan(span, false)) {
+        try (final AgentScope scope = activateSpan(span)) {
           scope.setAsyncPropagation(true);
           ctx.fireChannelRead(msg); // superclass does not throw
         }
@@ -37,7 +37,7 @@ public class HttpServerRequestTracingHandler extends ChannelInboundHandlerAdapte
     final Context extractedContext = propagate().extract(request.headers(), GETTER);
 
     final AgentSpan span = startSpan("netty.request", extractedContext);
-    try (final AgentScope scope = activateSpan(span, false)) {
+    try (final AgentScope scope = activateSpan(span)) {
       DECORATE.afterStart(span);
       DECORATE.onConnection(span, ctx.channel());
       DECORATE.onRequest(span, request);

--- a/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/server/HttpServerResponseTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/server/HttpServerResponseTracingHandler.java
@@ -22,7 +22,7 @@ public class HttpServerResponseTracingHandler extends ChannelOutboundHandlerAdap
       return;
     }
 
-    try (final AgentScope scope = activateSpan(span, false)) {
+    try (final AgentScope scope = activateSpan(span)) {
       final HttpResponse response = (HttpResponse) msg;
 
       try {

--- a/dd-java-agent/instrumentation/okhttp-2/src/main/java/datadog/trace/instrumentation/okhttp2/TracingInterceptor.java
+++ b/dd-java-agent/instrumentation/okhttp-2/src/main/java/datadog/trace/instrumentation/okhttp2/TracingInterceptor.java
@@ -15,10 +15,10 @@ import java.io.IOException;
 
 public class TracingInterceptor implements Interceptor {
   @Override
-  public Response intercept(Chain chain) throws IOException {
+  public Response intercept(final Chain chain) throws IOException {
     final AgentSpan span = startSpan("okhttp.request");
 
-    try (final AgentScope scope = activateSpan(span, true)) {
+    try (final AgentScope scope = activateSpan(span)) {
       DECORATE.afterStart(span);
 
       DECORATE.onRequest(span, chain.request());
@@ -37,6 +37,8 @@ public class TracingInterceptor implements Interceptor {
       DECORATE.onResponse(span, response);
       DECORATE.beforeFinish(span);
       return response;
+    } finally {
+      span.finish();
     }
   }
 }

--- a/dd-java-agent/instrumentation/okhttp-3/src/main/java/datadog/trace/instrumentation/okhttp3/TracingInterceptor.java
+++ b/dd-java-agent/instrumentation/okhttp-3/src/main/java/datadog/trace/instrumentation/okhttp3/TracingInterceptor.java
@@ -24,7 +24,7 @@ public class TracingInterceptor implements Interceptor {
 
     final AgentSpan span = startSpan("okhttp.request");
 
-    try (final AgentScope scope = activateSpan(span, true)) {
+    try (final AgentScope scope = activateSpan(span)) {
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, chain.request());
 
@@ -42,6 +42,8 @@ public class TracingInterceptor implements Interceptor {
       DECORATE.onResponse(span, response);
       DECORATE.beforeFinish(span);
       return response;
+    } finally {
+      span.finish();
     }
   }
 }

--- a/dd-java-agent/instrumentation/play-2.3/src/main/java8/datadog/trace/instrumentation/play23/PlayAdvice.java
+++ b/dd-java-agent/instrumentation/play-2.3/src/main/java8/datadog/trace/instrumentation/play23/PlayAdvice.java
@@ -32,7 +32,7 @@ public class PlayAdvice {
     DECORATE.afterStart(span);
     DECORATE.onConnection(span, req);
 
-    final AgentScope scope = activateSpan(span, false);
+    final AgentScope scope = activateSpan(span);
     scope.setAsyncPropagation(true);
     return scope;
   }

--- a/dd-java-agent/instrumentation/play-2.3/src/main/java8/datadog/trace/instrumentation/play23/PlayAdvice.java
+++ b/dd-java-agent/instrumentation/play-2.3/src/main/java8/datadog/trace/instrumentation/play23/PlayAdvice.java
@@ -60,6 +60,7 @@ public class PlayAdvice {
       playControllerSpan.finish();
     }
     playControllerScope.close();
+    // span finished in RequestCompleteCallback
 
     final AgentSpan rootSpan = activeSpan();
     // set the resource name on the upstream akka/netty span

--- a/dd-java-agent/instrumentation/play-2.4/src/main/java8/datadog/trace/instrumentation/play24/PlayAdvice.java
+++ b/dd-java-agent/instrumentation/play-2.4/src/main/java8/datadog/trace/instrumentation/play24/PlayAdvice.java
@@ -32,7 +32,7 @@ public class PlayAdvice {
     DECORATE.afterStart(span);
     DECORATE.onConnection(span, req);
 
-    final AgentScope scope = activateSpan(span, false);
+    final AgentScope scope = activateSpan(span);
     scope.setAsyncPropagation(true);
     return scope;
   }

--- a/dd-java-agent/instrumentation/play-2.4/src/main/java8/datadog/trace/instrumentation/play24/PlayAdvice.java
+++ b/dd-java-agent/instrumentation/play-2.4/src/main/java8/datadog/trace/instrumentation/play24/PlayAdvice.java
@@ -60,6 +60,7 @@ public class PlayAdvice {
       playControllerSpan.finish();
     }
     playControllerScope.close();
+    // span finished in RequestCompleteCallback
 
     final AgentSpan rootSpan = activeSpan();
     // set the resource name on the upstream akka/netty span

--- a/dd-java-agent/instrumentation/play-2.6/src/main/java8/datadog/trace/instrumentation/play26/PlayAdvice.java
+++ b/dd-java-agent/instrumentation/play-2.6/src/main/java8/datadog/trace/instrumentation/play26/PlayAdvice.java
@@ -32,7 +32,7 @@ public class PlayAdvice {
     DECORATE.afterStart(span);
     DECORATE.onConnection(span, req);
 
-    final AgentScope scope = activateSpan(span, false);
+    final AgentScope scope = activateSpan(span);
     scope.setAsyncPropagation(true);
     return scope;
   }

--- a/dd-java-agent/instrumentation/play-2.6/src/main/java8/datadog/trace/instrumentation/play26/PlayAdvice.java
+++ b/dd-java-agent/instrumentation/play-2.6/src/main/java8/datadog/trace/instrumentation/play26/PlayAdvice.java
@@ -60,6 +60,7 @@ public class PlayAdvice {
       playControllerSpan.finish();
     }
     playControllerScope.close();
+    // span finished in RequestCompleteCallback
 
     final AgentSpan rootSpan = activeSpan();
     // set the resource name on the upstream akka/netty span

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitChannelInstrumentation.java
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitChannelInstrumentation.java
@@ -218,7 +218,7 @@ public class RabbitChannelInstrumentation extends Instrumenter.Default {
         @Advice.Return final GetResponse response,
         @Advice.Thrown final Throwable throwable) {
 
-      placeholderScope.close();
+      placeholderScope.close(); // noop span, so no need to finish.
 
       if (callDepth > 0) {
         return;

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitChannelInstrumentation.java
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitChannelInstrumentation.java
@@ -130,7 +130,7 @@ public class RabbitChannelInstrumentation extends Instrumenter.Default {
               .setTag(Tags.PEER_PORT, connection.getPort());
       DECORATE.afterStart(span);
       DECORATE.onPeerConnection(span, connection.getAddress());
-      return activateSpan(span, true);
+      return activateSpan(span);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
@@ -142,6 +142,7 @@ public class RabbitChannelInstrumentation extends Instrumenter.Default {
       DECORATE.onError(scope, throwable);
       DECORATE.beforeFinish(scope);
       scope.close();
+      scope.span().finish();
       CallDepthThreadLocalMap.reset(Channel.class);
     }
   }
@@ -203,7 +204,7 @@ public class RabbitChannelInstrumentation extends Instrumenter.Default {
 
       callDepth = CallDepthThreadLocalMap.incrementCallDepth(Channel.class);
       // Don't want RabbitCommandInstrumentation to mess up our actual parent span.
-      placeholderScope = activateSpan(noopSpan(), false);
+      placeholderScope = activateSpan(noopSpan());
       return System.currentTimeMillis();
     }
 
@@ -251,7 +252,7 @@ public class RabbitChannelInstrumentation extends Instrumenter.Default {
         span.setTag("message.size", response.getBody().length);
       }
       span.setTag(Tags.PEER_PORT, connection.getPort());
-      try (final AgentScope scope = activateSpan(span, false)) {
+      try (final AgentScope scope = activateSpan(span)) {
         CONSUMER_DECORATE.afterStart(span);
         CONSUMER_DECORATE.onGet(span, queue);
         CONSUMER_DECORATE.onPeerConnection(span, connection.getAddress());

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/TracedDelegatingConsumer.java
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/TracedDelegatingConsumer.java
@@ -75,7 +75,7 @@ public class TracedDelegatingConsumer implements Consumer {
       CONSUMER_DECORATE.afterStart(span);
       CONSUMER_DECORATE.onDeliver(span, queue, envelope);
 
-      scope = activateSpan(span, true);
+      scope = activateSpan(span);
 
     } catch (final Exception e) {
       log.debug("Instrumentation error in tracing consumer", e);
@@ -94,6 +94,7 @@ public class TracedDelegatingConsumer implements Consumer {
         if (scope != null) {
           CONSUMER_DECORATE.beforeFinish(scope);
           scope.close();
+          scope.span().finish();
         }
       }
     }

--- a/dd-java-agent/instrumentation/ratpack-1.5/src/main/java8/datadog/trace/instrumentation/ratpack/ActionWrapper.java
+++ b/dd-java-agent/instrumentation/ratpack-1.5/src/main/java8/datadog/trace/instrumentation/ratpack/ActionWrapper.java
@@ -20,7 +20,7 @@ public class ActionWrapper<T> implements Action<T> {
 
   @Override
   public void execute(final T t) throws Exception {
-    try (final AgentScope scope = activateSpan(span, false)) {
+    try (final AgentScope scope = activateSpan(span)) {
       scope.setAsyncPropagation(true);
       delegate.execute(t);
     }

--- a/dd-java-agent/instrumentation/ratpack-1.5/src/main/java8/datadog/trace/instrumentation/ratpack/BlockWrapper.java
+++ b/dd-java-agent/instrumentation/ratpack-1.5/src/main/java8/datadog/trace/instrumentation/ratpack/BlockWrapper.java
@@ -20,7 +20,7 @@ public class BlockWrapper implements Block {
 
   @Override
   public void execute() throws Exception {
-    try (final AgentScope scope = activateSpan(span, false)) {
+    try (final AgentScope scope = activateSpan(span)) {
       scope.setAsyncPropagation(true);
       delegate.execute();
     }

--- a/dd-java-agent/instrumentation/ratpack-1.5/src/main/java8/datadog/trace/instrumentation/ratpack/TracingHandler.java
+++ b/dd-java-agent/instrumentation/ratpack-1.5/src/main/java8/datadog/trace/instrumentation/ratpack/TracingHandler.java
@@ -38,13 +38,13 @@ public final class TracingHandler implements Handler {
     DECORATE.onRequest(ratpackSpan, request);
     ctx.getExecution().add(ratpackSpan);
 
-    try (final AgentScope scope = activateSpan(ratpackSpan, false)) {
+    try (final AgentScope scope = activateSpan(ratpackSpan)) {
       scope.setAsyncPropagation(true);
 
       ctx.getResponse()
           .beforeSend(
               response -> {
-                try (final AgentScope ignored = activateSpan(ratpackSpan, false)) {
+                try (final AgentScope ignored = activateSpan(ratpackSpan)) {
                   if (nettySpan != null) {
                     // Rename the netty span resource name with the ratpack route.
                     DECORATE.onContext(nettySpan, ctx);

--- a/dd-java-agent/instrumentation/reactor-core-3.1/src/main/java8/datadog/trace/instrumentation/reactor/core/TracingPublishers.java
+++ b/dd-java-agent/instrumentation/reactor-core-3.1/src/main/java8/datadog/trace/instrumentation/reactor/core/TracingPublishers.java
@@ -92,7 +92,7 @@ public class TracingPublishers {
 
     @Override
     public void subscribe(final CoreSubscriber<? super T> actual) {
-      try (final AgentScope scope = activateSpan(span, false)) {
+      try (final AgentScope scope = activateSpan(span)) {
         scope.setAsyncPropagation(true);
         delegate.subscribe(wrapSubscriber(span, actual));
       }
@@ -115,7 +115,7 @@ public class TracingPublishers {
 
     @Override
     protected void subscribe(final CoreSubscriber<? super T>[] subscribers) {
-      try (final AgentScope scope = activateSpan(span, false)) {
+      try (final AgentScope scope = activateSpan(span)) {
         scope.setAsyncPropagation(true);
         for (final CoreSubscriber<? super T> subscriber : subscribers) {
           delegate.subscribe(wrapSubscriber(span, subscriber));
@@ -136,14 +136,14 @@ public class TracingPublishers {
 
     @Override
     public void connect(final Consumer<? super Disposable> cancelSupport) {
-      try (final AgentScope scope = activateSpan(span, false)) {
+      try (final AgentScope scope = activateSpan(span)) {
         delegate.connect(cancelSupport);
       }
     }
 
     @Override
     public void subscribe(final CoreSubscriber<? super T> actual) {
-      try (final AgentScope scope = activateSpan(span, false)) {
+      try (final AgentScope scope = activateSpan(span)) {
         scope.setAsyncPropagation(true);
         delegate.subscribe(wrapSubscriber(span, actual));
       }
@@ -166,7 +166,7 @@ public class TracingPublishers {
 
     @Override
     public void subscribe(final CoreSubscriber<? super T> actual) {
-      try (final AgentScope scope = activateSpan(span, false)) {
+      try (final AgentScope scope = activateSpan(span)) {
         scope.setAsyncPropagation(true);
         delegate.subscribe(wrapSubscriber(span, actual));
       }
@@ -184,7 +184,7 @@ public class TracingPublishers {
 
     @Override
     public void subscribe(final CoreSubscriber<? super T> actual) {
-      try (final AgentScope scope = activateSpan(span, false)) {
+      try (final AgentScope scope = activateSpan(span)) {
         scope.setAsyncPropagation(true);
         delegate.subscribe(wrapSubscriber(span, actual));
       }

--- a/dd-java-agent/instrumentation/reactor-core-3.1/src/main/java8/datadog/trace/instrumentation/reactor/core/TracingSubscriber.java
+++ b/dd-java-agent/instrumentation/reactor-core-3.1/src/main/java8/datadog/trace/instrumentation/reactor/core/TracingSubscriber.java
@@ -37,7 +37,7 @@ public class TracingSubscriber<T>
         (AgentSpan)
             delegate.currentContext().getOrEmpty(AgentSpan.class).orElseGet(AgentTracer::noopSpan);
 
-    try (final AgentScope scope = activateSpan(downstreamSpan, false)) {
+    try (final AgentScope scope = activateSpan(downstreamSpan)) {
       final TraceScope downstreamScope = activeScope();
       if (downstreamScope != null) {
         downstreamScope.setAsyncPropagation(true);
@@ -62,7 +62,7 @@ public class TracingSubscriber<T>
   public void onSubscribe(final Subscription subscription) {
     this.subscription = subscription;
 
-    try (final AgentScope scope = activateSpan(downstreamSpan, false)) {
+    try (final AgentScope scope = activateSpan(downstreamSpan)) {
       scope.setAsyncPropagation(true);
       delegate.onSubscribe(this);
     }
@@ -70,7 +70,7 @@ public class TracingSubscriber<T>
 
   @Override
   public void onNext(final T t) {
-    try (final AgentScope scope = activateSpan(downstreamSpan, false)) {
+    try (final AgentScope scope = activateSpan(downstreamSpan)) {
       scope.setAsyncPropagation(true);
       delegate.onNext(t);
     }
@@ -83,7 +83,7 @@ public class TracingSubscriber<T>
       scope.setAsyncPropagation(true);
       return new UnifiedScope(scope);
     } else {
-      final AgentScope scope = activateSpan(downstreamSpan, false);
+      final AgentScope scope = activateSpan(downstreamSpan);
       scope.setAsyncPropagation(true);
       return new UnifiedScope(scope);
     }
@@ -109,7 +109,7 @@ public class TracingSubscriber<T>
 
   @Override
   public void request(final long n) {
-    try (final AgentScope scope = activateSpan(upstreamSpan, false)) {
+    try (final AgentScope scope = activateSpan(upstreamSpan)) {
       scope.setAsyncPropagation(true);
       subscription.request(n);
     }
@@ -117,11 +117,11 @@ public class TracingSubscriber<T>
 
   @Override
   public void cancel() {
-    try (final AgentScope scope = activateSpan(upstreamSpan, false)) {
+    try (final AgentScope scope = activateSpan(upstreamSpan)) {
       scope.setAsyncPropagation(true);
       final TraceScope.Continuation current = continuation.getAndSet(null);
       if (current != null) {
-        current.close();
+        current.cancel();
       }
       subscription.cancel();
     }

--- a/dd-java-agent/instrumentation/rediscala-1.8.0/src/main/java/datadog/trace/instrumentation/rediscala/RediscalaInstrumentation.java
+++ b/dd-java-agent/instrumentation/rediscala-1.8.0/src/main/java/datadog/trace/instrumentation/rediscala/RediscalaInstrumentation.java
@@ -92,6 +92,7 @@ public final class RediscalaInstrumentation extends Instrumenter.Default {
         span.finish();
       }
       scope.close();
+      // span finished in OnCompleteHandler
     }
   }
 

--- a/dd-java-agent/instrumentation/rediscala-1.8.0/src/main/java/datadog/trace/instrumentation/rediscala/RediscalaInstrumentation.java
+++ b/dd-java-agent/instrumentation/rediscala-1.8.0/src/main/java/datadog/trace/instrumentation/rediscala/RediscalaInstrumentation.java
@@ -72,7 +72,7 @@ public final class RediscalaInstrumentation extends Instrumenter.Default {
       final AgentSpan span = startSpan("redis.command");
       DECORATE.afterStart(span);
       DECORATE.onStatement(span, cmd.getClass().getName());
-      return activateSpan(span, false);
+      return activateSpan(span);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)

--- a/dd-java-agent/instrumentation/rmi/src/main/java/datadog/trace/instrumentation/rmi/client/RmiClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/rmi/src/main/java/datadog/trace/instrumentation/rmi/client/RmiClientInstrumentation.java
@@ -61,7 +61,7 @@ public final class RmiClientInstrumentation extends Instrumenter.Default {
               .setTag("span.origin.type", method.getDeclaringClass().getCanonicalName());
 
       DECORATE.afterStart(span);
-      return activateSpan(span, true);
+      return activateSpan(span);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
@@ -71,7 +71,9 @@ public final class RmiClientInstrumentation extends Instrumenter.Default {
         return;
       }
       DECORATE.onError(scope, throwable);
+      DECORATE.beforeFinish(scope);
       scope.close();
+      scope.span().finish();
     }
   }
 }

--- a/dd-java-agent/instrumentation/rmi/src/main/java/datadog/trace/instrumentation/rmi/server/RmiServerInstrumentation.java
+++ b/dd-java-agent/instrumentation/rmi/src/main/java/datadog/trace/instrumentation/rmi/server/RmiServerInstrumentation.java
@@ -64,7 +64,7 @@ public final class RmiServerInstrumentation extends Instrumenter.Default {
           .setTag("span.origin.type", thiz.getClass().getCanonicalName());
 
       DECORATE.afterStart(span);
-      return activateSpan(span, true);
+      return activateSpan(span);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
@@ -73,10 +73,10 @@ public final class RmiServerInstrumentation extends Instrumenter.Default {
       if (scope == null) {
         return;
       }
-
       DECORATE.onError(scope, throwable);
-
+      DECORATE.beforeFinish(scope);
       scope.close();
+      scope.span().finish();
     }
   }
 }

--- a/dd-java-agent/instrumentation/rxjava-1/src/main/java/datadog/trace/instrumentation/rxjava/TracedOnSubscribe.java
+++ b/dd-java-agent/instrumentation/rxjava-1/src/main/java/datadog/trace/instrumentation/rxjava/TracedOnSubscribe.java
@@ -43,7 +43,7 @@ public class TracedOnSubscribe<T> implements Observable.OnSubscribe<T> {
 
     afterStart(span);
 
-    try (final AgentScope scope = activateSpan(span, false)) {
+    try (final AgentScope scope = activateSpan(span)) {
       scope.setAsyncPropagation(true);
       delegate.call(new TracedSubscriber(span, subscriber, decorator));
     }

--- a/dd-java-agent/instrumentation/rxjava-1/src/main/java/datadog/trace/instrumentation/rxjava/TracedSubscriber.java
+++ b/dd-java-agent/instrumentation/rxjava-1/src/main/java/datadog/trace/instrumentation/rxjava/TracedSubscriber.java
@@ -28,7 +28,7 @@ public class TracedSubscriber<T> extends Subscriber<T> {
   public void onStart() {
     final AgentSpan span = spanRef.get();
     if (span != null) {
-      try (final AgentScope scope = activateSpan(span, false)) {
+      try (final AgentScope scope = activateSpan(span)) {
         scope.setAsyncPropagation(true);
         delegate.onStart();
       }
@@ -41,7 +41,7 @@ public class TracedSubscriber<T> extends Subscriber<T> {
   public void onNext(final T value) {
     final AgentSpan span = spanRef.get();
     if (span != null) {
-      try (final AgentScope scope = activateSpan(span, false)) {
+      try (final AgentScope scope = activateSpan(span)) {
         scope.setAsyncPropagation(true);
         delegate.onNext(value);
       } catch (final Throwable e) {
@@ -57,7 +57,7 @@ public class TracedSubscriber<T> extends Subscriber<T> {
     final AgentSpan span = spanRef.getAndSet(null);
     if (span != null) {
       boolean errored = false;
-      try (final AgentScope scope = activateSpan(span, false)) {
+      try (final AgentScope scope = activateSpan(span)) {
         scope.setAsyncPropagation(true);
         delegate.onCompleted();
       } catch (final Throwable e) {
@@ -81,7 +81,7 @@ public class TracedSubscriber<T> extends Subscriber<T> {
   public void onError(final Throwable e) {
     final AgentSpan span = spanRef.getAndSet(null);
     if (span != null) {
-      try (final AgentScope scope = activateSpan(span, false)) {
+      try (final AgentScope scope = activateSpan(span)) {
         scope.setAsyncPropagation(true);
         decorator.onError(span, e);
         delegate.onError(e);

--- a/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/Servlet2Advice.java
+++ b/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/Servlet2Advice.java
@@ -59,7 +59,7 @@ public class Servlet2Advice {
     DECORATE.onConnection(span, httpServletRequest);
     DECORATE.onRequest(span, httpServletRequest);
 
-    final AgentScope scope = activateSpan(span, true);
+    final AgentScope scope = activateSpan(span);
     scope.setAsyncPropagation(true);
 
     httpServletRequest.setAttribute(DD_SPAN_ATTRIBUTE, span);
@@ -111,5 +111,6 @@ public class Servlet2Advice {
 
     scope.setAsyncPropagation(false);
     scope.close();
+    span.finish();
   }
 }

--- a/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Advice.java
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Advice.java
@@ -115,6 +115,7 @@ public class Servlet3Advice {
           DECORATE.beforeFinish(span);
           span.finish(); // Finish the span manually since finishSpanOnClose was false
         }
+        // else span finished in TagSettingAsyncListener
       }
       scope.close();
     }

--- a/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Advice.java
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Advice.java
@@ -53,7 +53,7 @@ public class Servlet3Advice {
     DECORATE.onConnection(span, httpServletRequest);
     DECORATE.onRequest(span, httpServletRequest);
 
-    final AgentScope scope = activateSpan(span, false);
+    final AgentScope scope = activateSpan(span);
     scope.setAsyncPropagation(true);
 
     httpServletRequest.setAttribute(DD_SPAN_ATTRIBUTE, span);

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/dispatcher/RequestDispatcherInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/dispatcher/RequestDispatcherInstrumentation.java
@@ -113,7 +113,7 @@ public final class RequestDispatcherInstrumentation extends Instrumenter.Default
       requestSpan = request.getAttribute(DD_SPAN_ATTRIBUTE);
       request.setAttribute(DD_SPAN_ATTRIBUTE, span);
 
-      final AgentScope agentScope = activateSpan(span, true);
+      final AgentScope agentScope = activateSpan(span);
       agentScope.setAsyncPropagation(true);
       return agentScope;
     }
@@ -136,6 +136,7 @@ public final class RequestDispatcherInstrumentation extends Instrumenter.Default
       DECORATE.onError(scope, throwable);
       DECORATE.beforeFinish(scope);
       scope.close();
+      scope.span().finish();
     }
   }
 }

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/filter/FilterInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/filter/FilterInstrumentation.java
@@ -78,7 +78,7 @@ public final class FilterInstrumentation extends Instrumenter.Default {
       // Here we use "this" instead of "the method target" to distinguish abstract filter instances.
       span.setTag(DDTags.RESOURCE_NAME, filter.getClass().getSimpleName() + ".doFilter");
 
-      final AgentScope agentScope = activateSpan(span, true);
+      final AgentScope agentScope = activateSpan(span);
       agentScope.setAsyncPropagation(true);
       return agentScope;
     }
@@ -92,6 +92,7 @@ public final class FilterInstrumentation extends Instrumenter.Default {
       DECORATE.onError(scope, throwable);
       DECORATE.beforeFinish(scope);
       scope.close();
+      scope.span().finish();
     }
   }
 }

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/http/HttpServletInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/http/HttpServletInstrumentation.java
@@ -85,7 +85,7 @@ public final class HttpServletInstrumentation extends Instrumenter.Default {
       // Here we use the Method instead of "this.class.name" to distinguish calls to "super".
       span.setTag(DDTags.RESOURCE_NAME, DECORATE.spanNameForMethod(method));
 
-      final AgentScope agentScope = activateSpan(span, true);
+      final AgentScope agentScope = activateSpan(span);
       agentScope.setAsyncPropagation(true);
       return agentScope;
     }
@@ -99,6 +99,7 @@ public final class HttpServletInstrumentation extends Instrumenter.Default {
       DECORATE.onError(scope, throwable);
       DECORATE.beforeFinish(scope);
       scope.close();
+      scope.span().finish();
     }
   }
 }

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/http/HttpServletResponseInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/http/HttpServletResponseInstrumentation.java
@@ -86,7 +86,7 @@ public final class HttpServletResponseInstrumentation extends Instrumenter.Defau
       // In case we lose context, inject trace into to the request.
       propagate().inject(span, req, SETTER);
 
-      final AgentScope scope = activateSpan(span, true);
+      final AgentScope scope = activateSpan(span);
       scope.setAsyncPropagation(true);
       return scope;
     }
@@ -100,6 +100,7 @@ public final class HttpServletResponseInstrumentation extends Instrumenter.Defau
       DECORATE.onError(scope, throwable);
       DECORATE.beforeFinish(scope);
       scope.close();
+      scope.span().finish();
     }
   }
 }

--- a/dd-java-agent/instrumentation/spring-data-1.8/src/main/java/datadog/trace/instrumentation/springdata/SpringRepositoryInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-data-1.8/src/main/java/datadog/trace/instrumentation/springdata/SpringRepositoryInstrumentation.java
@@ -110,7 +110,7 @@ public final class SpringRepositoryInstrumentation extends Instrumenter.Default 
       DECORATOR.afterStart(span);
       DECORATOR.onOperation(span, invokedMethod);
 
-      final AgentScope scope = activateSpan(span, true);
+      final AgentScope scope = activateSpan(span);
       scope.setAsyncPropagation(true);
 
       Object result = null;
@@ -122,6 +122,7 @@ public final class SpringRepositoryInstrumentation extends Instrumenter.Default 
       } finally {
         DECORATOR.beforeFinish(scope);
         scope.close();
+        span.finish();
       }
       return result;
     }

--- a/dd-java-agent/instrumentation/spring-scheduling-3.1/src/main/java/datadog/trace/instrumentation/springscheduling/SpringSchedulingInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-scheduling-3.1/src/main/java/datadog/trace/instrumentation/springscheduling/SpringSchedulingInstrumentation.java
@@ -64,7 +64,7 @@ public final class SpringSchedulingInstrumentation extends Instrumenter.Default 
       final AgentSpan span = startSpan("scheduled.call");
       DECORATE.afterStart(span);
 
-      try (final AgentScope scope = activateSpan(span, false)) {
+      try (final AgentScope scope = activateSpan(span)) {
         DECORATE.onRun(span, runnable);
         scope.setAsyncPropagation(true);
 

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java8/datadog/trace/instrumentation/springwebflux/client/WebClientTracingFilter.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java8/datadog/trace/instrumentation/springwebflux/client/WebClientTracingFilter.java
@@ -34,7 +34,7 @@ public class WebClientTracingFilter implements ExchangeFilterFunction {
     span.setTag(Tags.SPAN_KIND, Tags.SPAN_KIND_CLIENT);
     DECORATE.afterStart(span);
 
-    try (final AgentScope scope = activateSpan(span, false)) {
+    try (final AgentScope scope = activateSpan(span)) {
       scope.setAsyncPropagation(true);
       final ClientRequest mutatedRequest =
           ClientRequest.from(request)

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java8/datadog/trace/instrumentation/springwebflux/server/AdviceUtils.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java8/datadog/trace/instrumentation/springwebflux/server/AdviceUtils.java
@@ -106,7 +106,7 @@ public class AdviceUtils {
 
     @Override
     public void onSubscribe(final Subscription s) {
-      try (final AgentScope scope = activateSpan(span, false)) {
+      try (final AgentScope scope = activateSpan(span)) {
         scope.setAsyncPropagation(true);
         subscriber.onSubscribe(s);
       }
@@ -114,7 +114,7 @@ public class AdviceUtils {
 
     @Override
     public void onNext(final T t) {
-      try (final AgentScope scope = activateSpan(span, false)) {
+      try (final AgentScope scope = activateSpan(span)) {
         scope.setAsyncPropagation(true);
         subscriber.onNext(t);
       }

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java8/datadog/trace/instrumentation/springwebflux/server/DispatcherHandlerAdvice.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java8/datadog/trace/instrumentation/springwebflux/server/DispatcherHandlerAdvice.java
@@ -32,7 +32,7 @@ public class DispatcherHandlerAdvice {
     DECORATE.afterStart(span);
     exchange.getAttributes().put(AdviceUtils.SPAN_ATTRIBUTE, span);
 
-    final AgentScope scope = activateSpan(span, false);
+    final AgentScope scope = activateSpan(span);
     scope.setAsyncPropagation(true);
     return scope;
   }

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java8/datadog/trace/instrumentation/springwebflux/server/DispatcherHandlerAdvice.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java8/datadog/trace/instrumentation/springwebflux/server/DispatcherHandlerAdvice.java
@@ -49,5 +49,6 @@ public class DispatcherHandlerAdvice {
       AdviceUtils.finishSpanIfPresent(exchange, throwable);
     }
     scope.close();
+    // span finished in SpanFinishingSubscriber
   }
 }

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java8/datadog/trace/instrumentation/springwebflux/server/HandlerAdapterAdvice.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java8/datadog/trace/instrumentation/springwebflux/server/HandlerAdapterAdvice.java
@@ -64,6 +64,7 @@ public class HandlerAdapterAdvice {
     }
     if (scope != null) {
       scope.close();
+      // span finished in SpanFinishingSubscriber
     }
   }
 }

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java8/datadog/trace/instrumentation/springwebflux/server/HandlerAdapterAdvice.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java8/datadog/trace/instrumentation/springwebflux/server/HandlerAdapterAdvice.java
@@ -38,7 +38,7 @@ public class HandlerAdapterAdvice {
       span.setSpanName(operationName);
       span.setTag("handler.type", handlerType);
 
-      scope = activateSpan(span, false);
+      scope = activateSpan(span);
       scope.setAsyncPropagation(true);
     }
 

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/DispatcherServletInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/DispatcherServletInstrumentation.java
@@ -122,7 +122,7 @@ public final class DispatcherServletInstrumentation extends Instrumenter.Default
       final AgentSpan span = startSpan("response.render");
       DECORATE_RENDER.afterStart(span);
       DECORATE_RENDER.onRender(span, mv);
-      return activateSpan(span, true);
+      return activateSpan(span);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
@@ -131,6 +131,7 @@ public final class DispatcherServletInstrumentation extends Instrumenter.Default
       DECORATE_RENDER.onError(scope, throwable);
       DECORATE_RENDER.beforeFinish(scope);
       scope.close();
+      scope.span().finish();
     }
   }
 

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/HandlerAdapterInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/HandlerAdapterInstrumentation.java
@@ -85,7 +85,7 @@ public final class HandlerAdapterInstrumentation extends Instrumenter.Default {
       DECORATE.afterStart(span);
       DECORATE.onHandle(span, handler);
 
-      final AgentScope scope = activateSpan(span, true);
+      final AgentScope scope = activateSpan(span);
       scope.setAsyncPropagation(true);
       return scope;
     }
@@ -99,6 +99,7 @@ public final class HandlerAdapterInstrumentation extends Instrumenter.Default {
       DECORATE.onError(scope, throwable);
       DECORATE.beforeFinish(scope);
       scope.close();
+      scope.span().finish();
     }
   }
 }

--- a/dd-java-agent/instrumentation/spymemcached-2.12/src/main/java/datadog/trace/instrumentation/spymemcached/CompletionListener.java
+++ b/dd-java-agent/instrumentation/spymemcached-2.12/src/main/java/datadog/trace/instrumentation/spymemcached/CompletionListener.java
@@ -31,7 +31,7 @@ public abstract class CompletionListener<T> {
   public CompletionListener(final MemcachedConnection connection, final String methodName) {
     this.connection = connection;
     span = startSpan(OPERATION_NAME);
-    try (final AgentScope scope = activateSpan(span, false)) {
+    try (final AgentScope scope = activateSpan(span)) {
       DECORATE.afterStart(span);
       DECORATE.onConnection(span, connection);
       DECORATE.onOperation(span, methodName);
@@ -39,7 +39,7 @@ public abstract class CompletionListener<T> {
   }
 
   protected void closeAsyncSpan(final T future) {
-    try (final AgentScope scope = activateSpan(span, false)) {
+    try (final AgentScope scope = activateSpan(span)) {
       try {
         processResult(span, future);
       } catch (final CancellationException e) {
@@ -67,7 +67,7 @@ public abstract class CompletionListener<T> {
   }
 
   protected void closeSyncSpan(final Throwable thrown) {
-    try (final AgentScope scope = activateSpan(span, false)) {
+    try (final AgentScope scope = activateSpan(span)) {
       DECORATE.onError(span, thrown);
       DECORATE.beforeFinish(span);
       span.finish();

--- a/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceAdvice.java
+++ b/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceAdvice.java
@@ -31,7 +31,7 @@ public class TraceAdvice {
     span.setTag(DDTags.RESOURCE_NAME, resourceName);
     DECORATE.afterStart(span);
 
-    final AgentScope scope = activateSpan(span, true);
+    final AgentScope scope = activateSpan(span);
     scope.setAsyncPropagation(true);
     return scope;
   }
@@ -42,5 +42,6 @@ public class TraceAdvice {
     DECORATE.onError(scope, throwable);
     DECORATE.beforeFinish(scope);
     scope.close();
+    scope.span().finish();
   }
 }

--- a/dd-java-agent/instrumentation/twilio/src/main/java/datadog/trace/instrumentation/twilio/TwilioAsyncInstrumentation.java
+++ b/dd-java-agent/instrumentation/twilio/src/main/java/datadog/trace/instrumentation/twilio/TwilioAsyncInstrumentation.java
@@ -108,7 +108,7 @@ public class TwilioAsyncInstrumentation extends Instrumenter.Default {
       DECORATE.afterStart(span);
       DECORATE.onServiceExecution(span, that, methodName);
 
-      final AgentScope scope = activateSpan(span, false);
+      final AgentScope scope = activateSpan(span);
       // Enable async propagation, so the newly spawned task will be associated back with this
       // original trace.
       scope.setAsyncPropagation(true);

--- a/dd-java-agent/instrumentation/twilio/src/main/java/datadog/trace/instrumentation/twilio/TwilioAsyncInstrumentation.java
+++ b/dd-java-agent/instrumentation/twilio/src/main/java/datadog/trace/instrumentation/twilio/TwilioAsyncInstrumentation.java
@@ -141,7 +141,8 @@ public class TwilioAsyncInstrumentation extends Instrumenter.Default {
               response, new SpanFinishingCallback(span), Twilio.getExecutorService());
         }
       } finally {
-        scope.close(); // won't finish the span.
+        scope.close();
+        // span finished in SpanFinishingCallback
         CallDepthThreadLocalMap.reset(Twilio.class); // reset call depth count
       }
     }

--- a/dd-java-agent/instrumentation/twilio/src/main/java/datadog/trace/instrumentation/twilio/TwilioSyncInstrumentation.java
+++ b/dd-java-agent/instrumentation/twilio/src/main/java/datadog/trace/instrumentation/twilio/TwilioSyncInstrumentation.java
@@ -103,7 +103,7 @@ public class TwilioSyncInstrumentation extends Instrumenter.Default {
       DECORATE.afterStart(span);
       DECORATE.onServiceExecution(span, that, methodName);
 
-      return activateSpan(span, true);
+      return activateSpan(span);
     }
 
     /** Method exit instrumentation. */
@@ -117,14 +117,14 @@ public class TwilioSyncInstrumentation extends Instrumenter.Default {
       }
 
       // If we have a scope (i.e. we were the top-level Twilio SDK invocation),
+      final AgentSpan span = scope.span();
       try {
-        final AgentSpan span = scope.span();
-
         DECORATE.onResult(span, response);
         DECORATE.onError(span, throwable);
         DECORATE.beforeFinish(span);
       } finally {
         scope.close();
+        span.finish();
         CallDepthThreadLocalMap.reset(Twilio.class); // reset call depth count
       }
     }

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
@@ -1,12 +1,12 @@
 package datadog.trace.agent.test.base
 
-import datadog.trace.core.DDSpan
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.api.Config
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import datadog.trace.bootstrap.instrumentation.api.Tags
+import datadog.trace.core.DDSpan
 import spock.lang.AutoCleanup
 import spock.lang.Requires
 import spock.lang.Shared

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTestAdvice.java
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTestAdvice.java
@@ -26,7 +26,7 @@ public abstract class HttpServerTestAdvice {
         return null;
       } else {
         final AgentSpan span = startSpan("TEST_SPAN").setTag(DDTags.RESOURCE_NAME, "ServerEntry");
-        final AgentScope scope = activateSpan(span, true);
+        final AgentScope scope = activateSpan(span);
         scope.setAsyncPropagation(true);
         return scope;
       }
@@ -36,6 +36,7 @@ public abstract class HttpServerTestAdvice {
     public static void methodExit(@Advice.Enter final AgentScope scope) {
       if (scope != null) {
         scope.close();
+        scope.span().finish();
       }
     }
   }

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/log/injection/LogContextInjectionTestBase.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/log/injection/LogContextInjectionTestBase.groovy
@@ -37,7 +37,7 @@ abstract class LogContextInjectionTestBase extends AgentTestRunner {
     when:
     put("foo", "bar")
     AgentSpan rootSpan = startSpan("root")
-    AgentScope rootScope = activateSpan(rootSpan, true)
+    AgentScope rootScope = activateSpan(rootSpan)
 
     then:
     get(CorrelationIdentifier.getTraceIdKey()) == CorrelationIdentifier.getTraceId()
@@ -46,7 +46,7 @@ abstract class LogContextInjectionTestBase extends AgentTestRunner {
 
     when:
     AgentSpan childSpan = startSpan("child")
-    AgentScope childScope = activateSpan(childSpan, true)
+    AgentScope childScope = activateSpan(childSpan)
 
     then:
     get(CorrelationIdentifier.getTraceIdKey()) == CorrelationIdentifier.getTraceId()
@@ -55,6 +55,7 @@ abstract class LogContextInjectionTestBase extends AgentTestRunner {
 
     when:
     childScope.close()
+    childSpan.finish()
 
     then:
     get(CorrelationIdentifier.getTraceIdKey()) == CorrelationIdentifier.getTraceId()
@@ -63,6 +64,7 @@ abstract class LogContextInjectionTestBase extends AgentTestRunner {
 
     when:
     rootScope.close()
+    rootSpan.finish()
 
     then:
     get(CorrelationIdentifier.getTraceIdKey()) == null
@@ -91,16 +93,17 @@ abstract class LogContextInjectionTestBase extends AgentTestRunner {
       void run() {
         // other trace in scope
         final AgentSpan thread2Span = startSpan("root2")
-        final AgentScope thread2Scope = activateSpan(thread2Span, true)
+        final AgentScope thread2Scope = activateSpan(thread2Span)
         try {
           thread2TraceId.set(get(CorrelationIdentifier.getTraceIdKey()))
         } finally {
           thread2Scope.close()
+          thread2Span.finish()
         }
       }
     }
     final AgentSpan mainSpan = startSpan("root")
-    final AgentScope mainScope = activateSpan(mainSpan, true)
+    final AgentScope mainScope = activateSpan(mainSpan)
     thread1.start()
     thread2.start()
     final String mainThreadTraceId = get(CorrelationIdentifier.getTraceIdKey())
@@ -117,5 +120,6 @@ abstract class LogContextInjectionTestBase extends AgentTestRunner {
 
     cleanup:
     mainScope?.close()
+    mainSpan?.finish()
   }
 }

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/utils/TraceUtils.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/utils/TraceUtils.groovy
@@ -1,10 +1,10 @@
 package datadog.trace.agent.test.utils
 
-import datadog.trace.core.DDSpan
 import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.bootstrap.instrumentation.api.AgentScope
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan
 import datadog.trace.bootstrap.instrumentation.decorator.BaseDecorator
+import datadog.trace.core.DDSpan
 import lombok.SneakyThrows
 
 import java.util.concurrent.Callable
@@ -33,7 +33,7 @@ class TraceUtils {
     final AgentSpan span = startSpan(rootOperationName)
     DECORATOR.afterStart(span)
 
-    AgentScope scope = activateSpan(span, true)
+    AgentScope scope = activateSpan(span)
     scope.setAsyncPropagation(true)
 
     try {
@@ -44,6 +44,7 @@ class TraceUtils {
     } finally {
       DECORATOR.beforeFinish(span)
       scope.close()
+      span.finish()
     }
   }
 

--- a/dd-java-agent/testing/src/test/groovy/TraceCorrelationTest.groovy
+++ b/dd-java-agent/testing/src/test/groovy/TraceCorrelationTest.groovy
@@ -6,7 +6,7 @@ class TraceCorrelationTest extends AgentTestRunner {
   def "access trace correlation only under trace"() {
     when:
     def span = getTestTracer().startSpan("myspan")
-    def scope = getTestTracer().activateSpan(span, true)
+    def scope = getTestTracer().activateSpan(span)
 
     then:
     CorrelationIdentifier.traceId == span.traceId.toString()
@@ -14,6 +14,7 @@ class TraceCorrelationTest extends AgentTestRunner {
 
     when:
     scope.close()
+    span.finish()
 
     then:
     CorrelationIdentifier.traceId == "0"

--- a/dd-trace-core/jfr-openjdk/src/test/groovy/datadog/trace/core/jfr/openjdk/ScopeEventTest.groovy
+++ b/dd-trace-core/jfr-openjdk/src/test/groovy/datadog/trace/core/jfr/openjdk/ScopeEventTest.groovy
@@ -58,8 +58,8 @@ class ScopeEventTest extends DDSpecification {
     def recording = JfrHelper.startRecording()
 
     when:
-    AgentScope scope = builder.startActive(false)
-    AgentSpan span = scope.span()
+    AgentSpan span = builder.start()
+    AgentScope scope = tracer.activateSpan(span)
     sleep(SLEEP_DURATION.toMillis())
     scope.close()
     def events = JfrHelper.stopRecording(recording)
@@ -91,8 +91,8 @@ class ScopeEventTest extends DDSpecification {
     def recording = JfrHelper.startRecording()
 
     when:
-    AgentScope scope = builder.startActive(false)
-    AgentSpan span = scope.span()
+    AgentSpan span = builder.start()
+    AgentScope scope = tracer.activateSpan(span)
     sleep(SLEEP_DURATION.toMillis())
     scope.close()
     def events = JfrHelper.stopRecording(recording)
@@ -124,8 +124,8 @@ class ScopeEventTest extends DDSpecification {
     def recording = JfrHelper.startRecording()
 
     when:
-    AgentScope scope = builder.startActive(false)
-    AgentSpan span = scope.span()
+    AgentSpan span = builder.start()
+    AgentScope scope = tracer.activateSpan(span)
     sleep(SLEEP_DURATION.toMillis())
     scope.close()
     def events = JfrHelper.stopRecording(recording)
@@ -150,9 +150,9 @@ class ScopeEventTest extends DDSpecification {
 
   def "Scope event is written after continuation activation"() {
     setup:
-    AgentScope parentScope = builder.startActive(false)
+    AgentSpan span = builder.start()
+    AgentScope parentScope = tracer.activateSpan(span)
     parentScope.setAsyncPropagation(true)
-    AgentSpan span = parentScope.span()
     TraceScope.Continuation continuation = ((TraceScope) parentScope).capture()
     def recording = JfrHelper.startRecording()
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/CoreSpanBuilderTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/CoreSpanBuilderTest.groovy
@@ -176,10 +176,8 @@ class CoreSpanBuilderTest extends DDSpecification {
 
   def "should link to parent span implicitly"() {
     setup:
-    final AgentScope parent = noopParent ?
-      tracer.activateSpan(AgentTracer.NoopAgentSpan.INSTANCE, false) :
-      tracer.buildSpan("parent")
-        .startActive(false)
+    final AgentScope parent = tracer.activateSpan(noopParent ?
+      AgentTracer.NoopAgentSpan.INSTANCE : tracer.buildSpan("parent").start())
 
     final BigInteger expectedParentId = noopParent ? 0G : parent.span().context().getSpanId()
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/TraceCorrelationTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/TraceCorrelationTest.groovy
@@ -12,10 +12,12 @@ class TraceCorrelationTest extends DDSpecification {
   @Shared
   CoreTracer tracer = CoreTracer.builder().writer(WRITER).build()
 
-  def scope = tracer.buildSpan("test").startActive(true)
+  def span = tracer.buildSpan("test").start()
+  def scope = tracer.activateSpan(span)
 
   def cleanup() {
     scope.close()
+    span.finish()
   }
 
   def "get trace id without trace"() {

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/CustomScopeManagerTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/CustomScopeManagerTest.groovy
@@ -16,7 +16,6 @@ class CustomScopeManagerTest extends DDSpecification {
   def scopeManager = new TestScopeManager()
   def tracer = DDTracer.builder().writer(writer).scopeManager(scopeManager).build()
 
-
   def "simple span works"() {
     when:
     Scope scope
@@ -177,7 +176,7 @@ class CustomScopeManagerTest extends DDSpecification {
     continuation != null
 
     when:
-    continuation.close()
+    continuation.cancel()
     coreTracer.activeScope().close()
 
     then:


### PR DESCRIPTION
Still need to work on Hibernate and Lettuce instrumentation, but everything else is migrated over.

This has potential impact on how traces are timed as discussed in #1424.  This impact can be seen on the blocking calls I added in various tests to ensure the spans are not reported too early and get out of order.