### PR TITLE
Adding an option to manually disable Kafka headers

### DIFF
--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerInstrumentation.java
@@ -78,9 +78,11 @@ public final class KafkaProducerInstrumentation extends Instrumenter.Default {
       // This is how similar check is being done in Kafka client itself:
       // https://github.com/apache/kafka/blob/05fcfde8f69b0349216553f711fdfc3f0259c601/clients/src/main/java/org/apache/kafka/common/record/MemoryRecordsBuilder.java#L411-L412
       // Also, do not inject headers if specified by JVM option or environment variable
-      // This can help in mixed client environments where clients < 0.11 that do not support headers attempt to read
+      // This can help in mixed client environments where clients < 0.11 that do not support headers
+      // attempt to read
       // messages that were produced by clients > 0.11 and the magic value of the broker(s) is >= 2
-      if (apiVersions.maxUsableProduceMagic() >= RecordBatch.MAGIC_VALUE_V2 && Config.get().isKafkaHeadersEnabled()) {
+      if (apiVersions.maxUsableProduceMagic() >= RecordBatch.MAGIC_VALUE_V2
+          && Config.get().isKafkaHeadersEnabled()) {
         try {
           propagate().inject(span, record.headers(), SETTER);
         } catch (final IllegalStateException e) {

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerInstrumentation.java
@@ -78,11 +78,11 @@ public final class KafkaProducerInstrumentation extends Instrumenter.Default {
       // This is how similar check is being done in Kafka client itself:
       // https://github.com/apache/kafka/blob/05fcfde8f69b0349216553f711fdfc3f0259c601/clients/src/main/java/org/apache/kafka/common/record/MemoryRecordsBuilder.java#L411-L412
       // Also, do not inject headers if specified by JVM option or environment variable
-      // This can help in mixed client environments where clients < 0.11 that do not support headers
-      // attempt to read
-      // messages that were produced by clients > 0.11 and the magic value of the broker(s) is >= 2
+      // This can help in mixed client environments where clients < 0.11 that do not support
+      // headers attempt to read messages that were produced by clients > 0.11 and the magic
+      // value of the broker(s) is >= 2
       if (apiVersions.maxUsableProduceMagic() >= RecordBatch.MAGIC_VALUE_V2
-          && Config.get().isKafkaHeadersEnabled()) {
+          && Config.get().isKafkaClientPropagationEnabled()) {
         try {
           propagate().inject(span, record.headers(), SETTER);
         } catch (final IllegalStateException e) {

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerInstrumentation.java
@@ -13,6 +13,7 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.api.Config;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import java.util.Map;
@@ -76,7 +77,10 @@ public final class KafkaProducerInstrumentation extends Instrumenter.Default {
       // Do not inject headers for batch versions below 2
       // This is how similar check is being done in Kafka client itself:
       // https://github.com/apache/kafka/blob/05fcfde8f69b0349216553f711fdfc3f0259c601/clients/src/main/java/org/apache/kafka/common/record/MemoryRecordsBuilder.java#L411-L412
-      if (apiVersions.maxUsableProduceMagic() >= RecordBatch.MAGIC_VALUE_V2) {
+      // Also, do not inject headers if specified by JVM option or environment variable
+      // This can help in mixed client environments where clients < 0.11 that do not support headers attempt to read
+      // messages that were produced by clients > 0.11 and the magic value of the broker(s) is >= 2
+      if (apiVersions.maxUsableProduceMagic() >= RecordBatch.MAGIC_VALUE_V2 && Config.get().isKafkaHeadersEnabled()) {
         try {
           propagate().inject(span, record.headers(), SETTER);
         } catch (final IllegalStateException e) {

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTest.groovy
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTest.groovy
@@ -209,7 +209,7 @@ class KafkaClientTest extends AgentTestRunner {
   }
 
   @Unroll
-  def "test kafka headers manual config"() {
+  def "test kafka client header propagation manual config"() {
     setup:
     def senderProps = KafkaTestUtils.senderProps(embeddedKafka.getBrokersAsString())
     def producerFactory = new DefaultKafkaProducerFactory<String, String>(senderProps)
@@ -253,7 +253,7 @@ class KafkaClientTest extends AgentTestRunner {
 
     when:
     String message = "Testing without headers"
-    withConfigOverride(Config.KAFKA_HEADERS_ENABLED, value) {
+    withConfigOverride(Config.KAFKA_CLIENT_PROPAGATION_ENABLED, value) {
       kafkaTemplate.send(SHARED_TOPIC, message)
     }
 
@@ -268,11 +268,12 @@ class KafkaClientTest extends AgentTestRunner {
     container?.stop()
 
     where:
-    value                                                | expected
-    "false"                                              | false
-    "true"                                               | true
-    String.valueOf(Config.DEFAULT_KAFKA_HEADERS_ENABLED) | true
+    value                                                           | expected
+    "false"                                                         | false
+    "true"                                                          | true
+    String.valueOf(Config.DEFAULT_KAFKA_CLIENT_PROPAGATION_ENABLED) | true
 
   }
 
 }
+

--- a/dd-trace-api/src/main/java/datadog/trace/api/Config.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/Config.java
@@ -148,6 +148,8 @@ public class Config {
   public static final String PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE =
       "profiling.exception.histogram.max-collection-size";
 
+  public static final String KAFKA_HEADERS_ENABLED = "kafka.headers.enabled";
+
   public static final String RUNTIME_ID_TAG = "runtime-id";
   public static final String SERVICE = "service";
   public static final String SERVICE_TAG = SERVICE;
@@ -204,6 +206,8 @@ public class Config {
   public static final int DEFAULT_PROFILING_EXCEPTION_SAMPLE_LIMIT = 10_000;
   public static final int DEFAULT_PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS = 50;
   public static final int DEFAULT_PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE = 10000;
+
+  public static final boolean DEFAULT_KAFKA_HEADERS_ENABLED = true;
 
   private static final String SPLIT_BY_SPACE_OR_COMMA_REGEX = "[,\\s]+";
 
@@ -329,6 +333,8 @@ public class Config {
   @Getter private final int profilingExceptionSampleLimit;
   @Getter private final int profilingExceptionHistogramTopItems;
   @Getter private final int profilingExceptionHistogramMaxCollectionSize;
+
+  @Getter private final boolean kafkaHeadersEnabled;
 
   // Values from an optionally provided properties file
   private static Properties propertiesFromConfigFile;
@@ -545,6 +551,9 @@ public class Config {
             PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE,
             DEFAULT_PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE);
 
+    kafkaHeadersEnabled =
+        getBooleanSettingFromEnvironment(KAFKA_HEADERS_ENABLED, DEFAULT_KAFKA_HEADERS_ENABLED);
+
     // Setting this last because we have a few places where this can come from
     apiKey = tmpApiKey;
 
@@ -733,6 +742,9 @@ public class Config {
             properties,
             PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE,
             parent.profilingExceptionHistogramMaxCollectionSize);
+
+    kafkaHeadersEnabled =
+        getPropertyBooleanValue(properties, KAFKA_HEADERS_ENABLED, parent.kafkaHeadersEnabled);
 
     log.debug("New instance: {}", this);
   }

--- a/dd-trace-api/src/main/java/datadog/trace/api/Config.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/Config.java
@@ -148,7 +148,7 @@ public class Config {
   public static final String PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE =
       "profiling.exception.histogram.max-collection-size";
 
-  public static final String KAFKA_HEADERS_ENABLED = "kafka.headers.enabled";
+  public static final String KAFKA_CLIENT_PROPAGATION_ENABLED = "kafka.client.propagation.enabled";
 
   public static final String RUNTIME_ID_TAG = "runtime-id";
   public static final String SERVICE = "service";
@@ -207,7 +207,7 @@ public class Config {
   public static final int DEFAULT_PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS = 50;
   public static final int DEFAULT_PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE = 10000;
 
-  public static final boolean DEFAULT_KAFKA_HEADERS_ENABLED = true;
+  public static final boolean DEFAULT_KAFKA_CLIENT_PROPAGATION_ENABLED = true;
 
   private static final String SPLIT_BY_SPACE_OR_COMMA_REGEX = "[,\\s]+";
 
@@ -334,7 +334,7 @@ public class Config {
   @Getter private final int profilingExceptionHistogramTopItems;
   @Getter private final int profilingExceptionHistogramMaxCollectionSize;
 
-  @Getter private final boolean kafkaHeadersEnabled;
+  @Getter private final boolean kafkaClientPropagationEnabled;
 
   // Values from an optionally provided properties file
   private static Properties propertiesFromConfigFile;
@@ -551,8 +551,9 @@ public class Config {
             PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE,
             DEFAULT_PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE);
 
-    kafkaHeadersEnabled =
-        getBooleanSettingFromEnvironment(KAFKA_HEADERS_ENABLED, DEFAULT_KAFKA_HEADERS_ENABLED);
+    kafkaClientPropagationEnabled =
+        getBooleanSettingFromEnvironment(
+            KAFKA_CLIENT_PROPAGATION_ENABLED, DEFAULT_KAFKA_CLIENT_PROPAGATION_ENABLED);
 
     // Setting this last because we have a few places where this can come from
     apiKey = tmpApiKey;
@@ -743,8 +744,9 @@ public class Config {
             PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE,
             parent.profilingExceptionHistogramMaxCollectionSize);
 
-    kafkaHeadersEnabled =
-        getPropertyBooleanValue(properties, KAFKA_HEADERS_ENABLED, parent.kafkaHeadersEnabled);
+    kafkaClientPropagationEnabled =
+        getPropertyBooleanValue(
+            properties, KAFKA_CLIENT_PROPAGATION_ENABLED, parent.kafkaClientPropagationEnabled);
 
     log.debug("New instance: {}", this);
   }


### PR DESCRIPTION
In environments with mixed kafka-client versions, there can be errors when a producer that has the kafka integration enabled creates a message to be sent to brokers that use the kafka-client > 0.11. This causes the magic version (apiVersions.maxUsableProduceMagic()) to be 2 and the DD trace library injects headers into the record.

Consumer is using a version of kafka-client < 0.11 will fail when attempting to consume this record with an [IllegalArgumentException](https://github.com/apache/kafka/blob/3e9d1c1411c5268de382f9dfcc95bdf66d0063a0/clients/src/main/java/org/apache/kafka/common/record/MemoryRecordsBuilder.java#L412) 

This change allows organizations that have a mixed kafka-client environment to keep the kafka integration enabled and manually disable the injection of headers by setting a JVM option or environment variable.

It's possibly related to the issue here. https://github.com/DataDog/dd-trace-java/issues/944