### PR TITLE
Attempt to improve muzzle time by randomly ignoring versions until 10 remain.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,11 +7,11 @@ defaults: &defaults
     - image: &default_container datadog/dd-trace-java-docker-build:latest
 
 cache_keys: &cache_keys
-  # Reset the cache approx every release
   keys:
-    - dd-trace-java-{{ checksum "dd-trace-java.gradle" }}-{{ .Branch }}-{{ .Revision }}
-    - dd-trace-java-{{ checksum "dd-trace-java.gradle" }}-{{ .Branch }}
-    - dd-trace-java-{{ checksum "dd-trace-java.gradle" }}
+    # Rev the version when the cache gets too big
+    - dd-trace-java-v1-{{ .Branch }}-{{ .Revision }}
+    - dd-trace-java-v1-{{ .Branch }}
+    # - dd-trace-java-v1-
 
 jobs:
   build:
@@ -225,16 +225,18 @@ jobs:
       - checkout
 
       - restore_cache:
-          # Reset the cache approx every release
           keys:
-            - dd-trace-java-muzzle-{{ checksum "dd-trace-java.gradle" }}
+            # Rev the version when the cache gets too big
+            - dd-trace-java-muzzle-v1-{{ .Branch }}-{{ .Revision }}
+            - dd-trace-java-muzzle-v1-{{ .Branch }}
+            # - dd-trace-java-muzzle-v1-
 
       - run:
           name: Verify Muzzle
           command: SKIP_BUILDSCAN="true" GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx4G -Xms64M' -Ddatadog.forkedMaxHeapSize=4G -Ddatadog.forkedMinHeapSize=64M" ./gradlew muzzle --parallel --stacktrace --no-daemon --max-workers=16
 
       - save_cache:
-          key: dd-trace-java-muzzle-{{ checksum "dd-trace-java.gradle" }}
+          key: dd-trace-java-muzzle-v1-{{ .Branch }}-{{ .Revision }}
           paths: ~/.gradle
 
 workflows:


### PR DESCRIPTION
This only works on the main directive, not the `assertInverse` portion.
