### PR TITLE
Remove stacktrace when JVM is not supported

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/ControllerFactory.java
+++ b/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/ControllerFactory.java
@@ -35,7 +35,7 @@ public final class ControllerFactory {
     try {
       Class.forName("com.oracle.jrockit.jfr.Producer");
       throw new UnsupportedEnvironmentException(
-          "The JFR controller is currently not supported on the Oracle JDK <= JDK 11!");
+          "Not enabling profiling; it requires Oracle Java 11+.");
     } catch (final ClassNotFoundException e) {
       // Fall through - until we support Oracle JDK 7 & 8, this is a good thing. ;)
     }
@@ -49,8 +49,7 @@ public final class ControllerFactory {
         | InstantiationException
         | IllegalAccessException
         | InvocationTargetException e) {
-      String exMsg =
-          "The JFR controller could not find a supported JFR API" + getFixProposalMessage();
+      String exMsg = "Not enabling profiling" + getFixProposalMessage();
       throw new UnsupportedEnvironmentException(exMsg, e);
     }
   }
@@ -64,11 +63,11 @@ public final class ControllerFactory {
       String javaVendor = System.getProperty("java.vendor", "");
       if (javaVersion.startsWith("1.8")) {
         if (javaVendor.startsWith("Azul Systems")) {
-          return ", use Azul zulu version 1.8.0_212+";
+          return "; it requires Zulu Java 8 (1.8.0_212+).";
         }
         // TODO Add version minimum once JFR backported into OpenJDK distros
       }
-      return ", use OpenJDK 11+ or Azul zulu version 1.8.0_212+";
+      return "; it requires OpenJDK 11+, Oracle Java 11+, or Zulu Java 8 (1.8.0_212+).";
     } catch (Exception ex) {
       return "";
     }

--- a/dd-java-agent/agent-profiling/profiling-controller/src/test/java/com/datadog/profiling/controller/ControllerFactoryTest.java
+++ b/dd-java-agent/agent-profiling/profiling-controller/src/test/java/com/datadog/profiling/controller/ControllerFactoryTest.java
@@ -27,18 +27,17 @@ public class ControllerFactoryTest {
               ControllerFactory.createController(config);
             });
     String expected =
-        "The JFR controller could not find a supported JFR API, use OpenJDK 11+ or Azul zulu version 1.8.0_212+";
+        "Not enabling profiling; it requires OpenJDK 11+, Oracle Java 11+, or Zulu Java 8 (1.8.0_212+).";
     final String javaVendor = System.getProperty("java.vendor");
     final String javaRuntimeName = System.getProperty("java.runtime.name");
     final String javaVersion = System.getProperty("java.version");
     if ("Azul Systems, Inc.".equals(javaVendor)) {
-      expected =
-          "The JFR controller could not find a supported JFR API, use Azul zulu version 1.8.0_212+";
+      expected = "Not enabling profiling; it requires Zulu Java 8 (1.8.0_212+).";
     } else if ("Java(TM) SE Runtime Environment".equals(javaRuntimeName)
         && "Oracle Corporation".equals(javaVendor)
         && javaVersion.startsWith("1.8")) {
       // condition for OracleJRE8 (with proprietary JFR inside)
-      expected = "The JFR controller is currently not supported on the Oracle JDK <= JDK 11!";
+      expected = "Not enabling profiling; it requires Oracle Java 11+.";
     }
     assertEquals(
         expected,

--- a/dd-java-agent/agent-profiling/src/main/java/com/datadog/profiling/agent/ProfilingAgent.java
+++ b/dd-java-agent/agent-profiling/src/main/java/com/datadog/profiling/agent/ProfilingAgent.java
@@ -73,7 +73,10 @@ public class ProfilingAgent {
         } catch (final IllegalStateException ex) {
           // The JVM is already shutting down.
         }
-      } catch (final UnsupportedEnvironmentException | ConfigurationException e) {
+      } catch (final UnsupportedEnvironmentException e) {
+        log.warn(e.getMessage());
+        log.debug("", e);
+      } catch (final ConfigurationException e) {
         log.warn("Failed to initialize profiling agent! " + e.getMessage());
         log.debug("Failed to initialize profiling agent!", e);
       }

--- a/dd-java-agent/agent-profiling/src/main/java/com/datadog/profiling/agent/ProfilingAgent.java
+++ b/dd-java-agent/agent-profiling/src/main/java/com/datadog/profiling/agent/ProfilingAgent.java
@@ -74,7 +74,8 @@ public class ProfilingAgent {
           // The JVM is already shutting down.
         }
       } catch (final UnsupportedEnvironmentException | ConfigurationException e) {
-        log.warn("Failed to initialize profiling agent!", e);
+        log.warn("Failed to initialize profiling agent! " + e.getMessage());
+        log.debug("Failed to initialize profiling agent!", e);
       }
     }
   }


### PR DESCRIPTION
When we was running profiling on a JVM that does not support it we
have improved the message but there is still a stacktrace remaining
adding a lot of noise
Remove that stack trace for the nominal case and put it in debug mode

previous message:
```
[dd.trace 2020-05-13 09:50:43:851 +0200] [main] WARN com.datadog.profiling.agent.ProfilingAgent - Failed to initialize profiling agent!
com.datadog.profiling.controller.UnsupportedEnvironmentException: The JFR controller could not find a supported JFR API, use OpenJDK 11+ or Azul zulu version 1.8.0_212+
	at com.datadog.profiling.controller.ControllerFactory.createController(ControllerFactory.java:54)
	at com.datadog.profiling.agent.ProfilingAgent.run(ProfilingAgent.java:45)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at datadog.trace.bootstrap.Agent.startProfilingAgent(Agent.java:334)
	at datadog.trace.bootstrap.Agent.start(Agent.java:101)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at datadog.trace.bootstrap.AgentBootstrap.agentmain(AgentBootstrap.java:56)
	at datadog.trace.bootstrap.AgentBootstrap.premain(AgentBootstrap.java:45)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at sun.instrument.InstrumentationImpl.loadClassAndStartAgent(InstrumentationImpl.java:386)
	at sun.instrument.InstrumentationImpl.loadClassAndCallPremain(InstrumentationImpl.java:401)
Caused by: java.lang.reflect.InvocationTargetException
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at com.datadog.profiling.controller.ControllerFactory.createController(ControllerFactory.java:46)
	... 19 more
Caused by: java.lang.ClassNotFoundException: jdk.jfr.Recording
	at java.net.URLClassLoader.findClass(URLClassLoader.java:382)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:419)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:352)
	at java.lang.Class.forName0(Native Method)
	at java.lang.Class.forName(Class.java:264)
	at com.datadog.profiling.controller.openjdk.OpenJdkController.<init>(OpenJdkController.java:48)
	... 24 more
```

new message:
```
[dd.trace 2020-05-13 10:55:15:787 +0200] [main] WARN com.datadog.profiling.agent.ProfilingAgent - Failed to initialize profiling agent! The JFR controller could not find a supported JFR API, use OpenJDK 11+ or Azul zulu version 1.8.0_212+
```