### PR TITLE
change IDs from StringCachingBigInteger to long

### DIFF
--- a/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/ScopeEvent.java
+++ b/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/ScopeEvent.java
@@ -18,8 +18,6 @@ import jdk.jfr.Timespan;
 @StackTrace(false)
 public final class ScopeEvent extends Event implements DDScopeEvent {
 
-  private static final int IDS_RADIX = 16;
-
   private final transient DDSpanContext spanContext;
 
   @Label("Trace Id")
@@ -64,9 +62,9 @@ public final class ScopeEvent extends Event implements DDScopeEvent {
       if (cpuTime > 0) {
         cpuTime = ThreadCpuTimeAccess.getCurrentThreadCpuTime() - cpuTime;
       }
-      traceId = spanContext.getTraceId().toString(IDS_RADIX);
-      spanId = spanContext.getSpanId().toString(IDS_RADIX);
-      parentId = spanContext.getParentId().toString(IDS_RADIX);
+      traceId = Long.toHexString(spanContext.getTraceId());
+      spanId = Long.toHexString(spanContext.getSpanId());
+      parentId = Long.toHexString(spanContext.getParentId());
       serviceName = spanContext.getServiceName();
       resourceName = spanContext.getResourceName();
       operationName = spanContext.getOperationName();

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -399,7 +399,7 @@ public class CoreTracer
   public String getTraceId() {
     final AgentSpan activeSpan = activeSpan();
     if (activeSpan instanceof DDSpan) {
-      return ((DDSpan) activeSpan).getTraceId().toString();
+      return Long.toString(((DDSpan) activeSpan).getTraceId());
     }
     return "0";
   }
@@ -408,7 +408,7 @@ public class CoreTracer
   public String getSpanId() {
     final AgentSpan activeSpan = activeSpan();
     if (activeSpan instanceof DDSpan) {
-      return ((DDSpan) activeSpan).getSpanId().toString();
+      return Long.toString(((DDSpan) activeSpan).getSpanId());
     }
     return "0";
   }
@@ -554,13 +554,13 @@ public class CoreTracer
       return this;
     }
 
-    private BigInteger generateNewId() {
+    private long generateNewId() {
       // It is **extremely** unlikely to generate the value "0" but we still need to handle that
       // case
-      BigInteger value;
+      long value;
       do {
-        value = new StringCachingBigInteger(63, ThreadLocalRandom.current());
-      } while (value.signum() == 0);
+        value = ThreadLocalRandom.current().nextLong(Long.MAX_VALUE);
+      } while (value == 0);
 
       return value;
     }
@@ -572,9 +572,9 @@ public class CoreTracer
      * @return the context
      */
     private DDSpanContext buildSpanContext() {
-      final BigInteger traceId;
-      final BigInteger spanId = generateNewId();
-      final BigInteger parentSpanId;
+      final long traceId;
+      final long spanId = generateNewId();
+      final long parentSpanId;
       final Map<String, String> baggage;
       final PendingTrace parentTrace;
       final int samplingPriority;
@@ -619,7 +619,7 @@ public class CoreTracer
         } else {
           // Start a new trace
           traceId = generateNewId();
-          parentSpanId = BigInteger.ZERO;
+          parentSpanId = 0L;
           samplingPriority = PrioritySampling.UNSET;
           baggage = null;
         }

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -8,7 +8,6 @@ import datadog.trace.core.util.Clock;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.lang.ref.WeakReference;
-import java.math.BigInteger;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -117,7 +116,7 @@ public class DDSpan implements MutableSpan, AgentSpan {
    * @return true if root, false otherwise
    */
   public final boolean isRootSpan() {
-    return BigInteger.ZERO.equals(context.getParentId());
+    return context.getParentId() == 0L;
   }
 
   @Override
@@ -136,7 +135,7 @@ public class DDSpan implements MutableSpan, AgentSpan {
     // FIXME [API] AgentSpan or AgentSpan.Context should have a "getTraceId()" type method
     if (otherSpan instanceof DDSpan) {
       // minor optimization to avoid BigInteger.toString()
-      return getTraceId().equals(((DDSpan) otherSpan).getTraceId());
+      return getTraceId() == ((DDSpan) otherSpan).getTraceId();
     }
 
     return false;
@@ -300,15 +299,15 @@ public class DDSpan implements MutableSpan, AgentSpan {
     return context.getServiceName();
   }
 
-  public BigInteger getTraceId() {
+  public long getTraceId() {
     return context.getTraceId();
   }
 
-  public BigInteger getSpanId() {
+  public long getSpanId() {
     return context.getSpanId();
   }
 
-  public BigInteger getParentId() {
+  public long getParentId() {
     return context.getParentId();
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
@@ -4,7 +4,6 @@ import datadog.trace.api.DDTags;
 import datadog.trace.api.sampling.PrioritySampling;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.core.decorators.AbstractDecorator;
-import java.math.BigInteger;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -40,9 +39,9 @@ public class DDSpanContext implements AgentSpan.Context {
   private final Map<String, String> baggageItems;
 
   // Not Shared with other span contexts
-  private final BigInteger traceId;
-  private final BigInteger spanId;
-  private final BigInteger parentId;
+  private final long traceId;
+  private final long spanId;
+  private final long parentId;
 
   /** Tags are associated to the current span, they will not propagate to the children span */
   private final Map<String, Object> tags = new ConcurrentHashMap<>();
@@ -76,9 +75,9 @@ public class DDSpanContext implements AgentSpan.Context {
   private final Map<String, String> serviceNameMappings;
 
   public DDSpanContext(
-      final BigInteger traceId,
-      final BigInteger spanId,
-      final BigInteger parentId,
+      final long traceId,
+      final long spanId,
+      final long parentId,
       final String serviceName,
       final String operationName,
       final String resourceName,
@@ -97,9 +96,6 @@ public class DDSpanContext implements AgentSpan.Context {
     this.tracer = tracer;
     this.trace = trace;
 
-    assert traceId != null;
-    assert spanId != null;
-    assert parentId != null;
     this.traceId = traceId;
     this.spanId = spanId;
     this.parentId = parentId;
@@ -133,15 +129,15 @@ public class DDSpanContext implements AgentSpan.Context {
     this.tags.put(DDTags.THREAD_ID, threadId);
   }
 
-  public BigInteger getTraceId() {
+  public long getTraceId() {
     return traceId;
   }
 
-  public BigInteger getParentId() {
+  public long getParentId() {
     return parentId;
   }
 
-  public BigInteger getSpanId() {
+  public long getSpanId() {
     return spanId;
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/B3HttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/B3HttpCodec.java
@@ -6,7 +6,6 @@ import static datadog.trace.core.propagation.HttpCodec.validateUInt64BitsID;
 import datadog.trace.api.sampling.PrioritySampling;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.core.DDSpanContext;
-import java.math.BigInteger;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -39,8 +38,8 @@ class B3HttpCodec {
     public <C> void inject(
         final DDSpanContext context, final C carrier, final AgentPropagation.Setter<C> setter) {
       try {
-        setter.set(carrier, TRACE_ID_KEY, context.getTraceId().toString(HEX_RADIX).toLowerCase());
-        setter.set(carrier, SPAN_ID_KEY, context.getSpanId().toString(HEX_RADIX).toLowerCase());
+        setter.set(carrier, TRACE_ID_KEY, Long.toHexString(context.getTraceId()));
+        setter.set(carrier, SPAN_ID_KEY, Long.toHexString(context.getSpanId()));
 
         if (context.lockSamplingPriority()) {
           setter.set(
@@ -75,8 +74,8 @@ class B3HttpCodec {
     public <C> TagContext extract(final C carrier, final AgentPropagation.Getter<C> getter) {
       try {
         Map<String, String> tags = Collections.emptyMap();
-        BigInteger traceId = BigInteger.ZERO;
-        BigInteger spanId = BigInteger.ZERO;
+        long traceId = 0L;
+        long spanId = 0L;
         int samplingPriority = PrioritySampling.UNSET;
 
         for (final String uncasedKey : getter.keys(carrier)) {
@@ -92,7 +91,7 @@ class B3HttpCodec {
             final int length = value.length();
             if (length > 32) {
               log.debug("Header {} exceeded max length of 32: {}", TRACE_ID_KEY, value);
-              traceId = BigInteger.ZERO;
+              traceId = 0L;
               continue;
             } else if (length > 16) {
               trimmedValue = value.substring(length - 16);
@@ -114,7 +113,7 @@ class B3HttpCodec {
           }
         }
 
-        if (!BigInteger.ZERO.equals(traceId)) {
+        if (traceId != 0L) {
           final ExtractedContext context =
               new ExtractedContext(
                   traceId,

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/DatadogHttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/DatadogHttpCodec.java
@@ -6,7 +6,6 @@ import static datadog.trace.core.propagation.HttpCodec.validateUInt64BitsID;
 import datadog.trace.api.sampling.PrioritySampling;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.core.DDSpanContext;
-import java.math.BigInteger;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -32,8 +31,8 @@ class DatadogHttpCodec {
     public <C> void inject(
         final DDSpanContext context, final C carrier, final AgentPropagation.Setter<C> setter) {
 
-      setter.set(carrier, TRACE_ID_KEY, context.getTraceId().toString());
-      setter.set(carrier, SPAN_ID_KEY, context.getSpanId().toString());
+      setter.set(carrier, TRACE_ID_KEY, String.valueOf(context.getTraceId()));
+      setter.set(carrier, SPAN_ID_KEY, String.valueOf(context.getSpanId()));
       if (context.lockSamplingPriority()) {
         setter.set(carrier, SAMPLING_PRIORITY_KEY, String.valueOf(context.getSamplingPriority()));
       }
@@ -64,8 +63,8 @@ class DatadogHttpCodec {
       try {
         Map<String, String> baggage = Collections.emptyMap();
         Map<String, String> tags = Collections.emptyMap();
-        BigInteger traceId = BigInteger.ZERO;
-        BigInteger spanId = BigInteger.ZERO;
+        long traceId = 0L;
+        long spanId = 0L;
         int samplingPriority = PrioritySampling.UNSET;
         String origin = null;
 
@@ -100,7 +99,7 @@ class DatadogHttpCodec {
           }
         }
 
-        if (!BigInteger.ZERO.equals(traceId)) {
+        if (traceId != 0L) {
           final ExtractedContext context =
               new ExtractedContext(traceId, spanId, samplingPriority, origin, baggage, tags);
           context.lockSamplingPriority();

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ExtractedContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ExtractedContext.java
@@ -1,6 +1,5 @@
 package datadog.trace.core.propagation;
 
-import java.math.BigInteger;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -8,15 +7,15 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * Propagated data resulting from calling tracer.extract with header data from an incoming request.
  */
 public class ExtractedContext extends TagContext {
-  private final BigInteger traceId;
-  private final BigInteger spanId;
+  private final long traceId;
+  private final long spanId;
   private final int samplingPriority;
   private final Map<String, String> baggage;
   private final AtomicBoolean samplingPriorityLocked = new AtomicBoolean(false);
 
   public ExtractedContext(
-      final BigInteger traceId,
-      final BigInteger spanId,
+      final long traceId,
+      final long spanId,
       final int samplingPriority,
       final String origin,
       final Map<String, String> baggage,
@@ -37,11 +36,11 @@ public class ExtractedContext extends TagContext {
     samplingPriorityLocked.set(true);
   }
 
-  public BigInteger getTraceId() {
+  public long getTraceId() {
     return traceId;
   }
 
-  public BigInteger getSpanId() {
+  public long getSpanId() {
     return spanId;
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/HttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/HttpCodec.java
@@ -4,7 +4,6 @@ import datadog.trace.api.Config;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.core.CoreTracer;
 import datadog.trace.core.DDSpanContext;
-import datadog.trace.core.StringCachingBigInteger;
 import java.io.UnsupportedEncodingException;
 import java.math.BigInteger;
 import java.net.URLDecoder;
@@ -114,16 +113,15 @@ public class HttpCodec {
    * @throws IllegalArgumentException if value cannot be converted to integer or doesn't conform to
    *     required boundaries
    */
-  static BigInteger validateUInt64BitsID(final String value, final int radix)
+  static long validateUInt64BitsID(final String value, final int radix)
       throws IllegalArgumentException {
-    final BigInteger parsedValue = new StringCachingBigInteger(value, radix);
+    final BigInteger parsedValue = new BigInteger(value, radix);
     if (parsedValue.compareTo(CoreTracer.TRACE_ID_MIN) < 0
         || parsedValue.compareTo(CoreTracer.TRACE_ID_MAX) > 0) {
       throw new IllegalArgumentException(
           "ID out of range, must be between 0 and 2^64-1, got: " + value);
     }
-
-    return parsedValue;
+    return parsedValue.longValue();
   }
 
   /** URL encode value */

--- a/dd-trace-core/src/main/java/datadog/trace/core/serialization/FormatWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/serialization/FormatWriter.java
@@ -104,9 +104,9 @@ public abstract class FormatWriter<DEST> {
     /* 1  */ writeString(SERVICE, span.getServiceName(), destination);
     /* 2  */ writeString(NAME, span.getOperationName(), destination);
     /* 3  */ writeString(RESOURCE, span.getResourceName(), destination);
-    /* 4  */ writeBigInteger(TRACE_ID, span.getTraceId(), destination);
-    /* 5  */ writeBigInteger(SPAN_ID, span.getSpanId(), destination);
-    /* 6  */ writeBigInteger(PARENT_ID, span.getParentId(), destination);
+    /* 4  */ writeLong(TRACE_ID, span.getTraceId(), destination);
+    /* 5  */ writeLong(SPAN_ID, span.getSpanId(), destination);
+    /* 6  */ writeLong(PARENT_ID, span.getParentId(), destination);
     /* 7  */ writeLong(START, span.getStartTime(), destination);
     /* 8  */ writeLong(DURATION, span.getDurationNano(), destination);
     /* 9  */ writeTag(TYPE, span.getType(), destination);

--- a/dd-trace-core/src/test/groovy/datadog/trace/api/writer/DDAgentWriterTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/api/writer/DDAgentWriterTest.groovy
@@ -295,9 +295,9 @@ class DDAgentWriterTest extends DDSpecification {
 
   def createMinimalTrace() {
     def minimalContext = new DDSpanContext(
-      1G,
-      1G,
-      0G,
+      1L,
+      1L,
+      0L,
       "",
       "",
       "",
@@ -310,7 +310,7 @@ class DDAgentWriterTest extends DDSpecification {
       Mock(PendingTrace),
       Mock(CoreTracer),
       [:])
-    def minimalSpan = new DDSpan(0, minimalContext)
+    def minimalSpan = DDSpan.create(0, minimalContext)
     def minimalTrace = [minimalSpan]
 
     return minimalTrace

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/CoreSpanBuilderTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/CoreSpanBuilderTest.groovy
@@ -156,7 +156,7 @@ class CoreSpanBuilderTest extends DDSpecification {
     1 * mockedContext.getSpanId() >> spanId
     _ * mockedContext.getServiceName() >> "foo"
     1 * mockedContext.getBaggageItems() >> [:]
-    1 * mockedContext.getTrace() >> PendingTrace.create(tracer, 1G)
+    1 * mockedContext.getTrace() >> PendingTrace.create(tracer, 1L)
 
     final String expectedName = "fakeName"
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanSerializationTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanSerializationTest.groovy
@@ -48,9 +48,9 @@ class DDSpanSerializationTest extends DDSpecification {
     def tracer = CoreTracer.builder().writer(writer).build()
     final DDSpanContext context =
       new DDSpanContext(
-        1G,
-        2G,
-        0G,
+        1L,
+        2L,
+        0L,
         "service",
         "operation",
         null,
@@ -60,7 +60,7 @@ class DDSpanSerializationTest extends DDSpecification {
         false,
         spanType,
         ["k1": "v1"],
-        PendingTrace.create(tracer, 1G),
+        PendingTrace.create(tracer, 1L),
         tracer,
         [:])
 
@@ -86,7 +86,7 @@ class DDSpanSerializationTest extends DDSpecification {
     def context = new DDSpanContext(
       value,
       value,
-      0G,
+      0L,
       "fakeService",
       "fakeOperation",
       "fakeResource",
@@ -96,7 +96,7 @@ class DDSpanSerializationTest extends DDSpecification {
       false,
       spanType,
       Collections.emptyMap(),
-      PendingTrace.create(tracer, 1G),
+      PendingTrace.create(tracer, 1L),
       tracer,
       [:])
     def span = DDSpan.create(0, context)
@@ -125,11 +125,10 @@ class DDSpanSerializationTest extends DDSpecification {
 
     where:
     value                                           | spanType
-    0G                                              | null
-    1G                                              | "some-type"
-    8223372036854775807G                            | null
-    BigInteger.valueOf(Long.MAX_VALUE).subtract(1G) | "some-type"
-    BigInteger.valueOf(Long.MAX_VALUE).add(1G)      | null
-    2G.pow(64).subtract(1G)                         | "some-type"
+    0L                                              | null
+    1L                                              | "some-type"
+    8223372036854775807L                            | null
+    Long.MAX_VALUE - 1L                             | "some-type"
+    -1L                                             | "some-type"
   }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanTest.groovy
@@ -22,9 +22,9 @@ class DDSpanTest extends DDSpecification {
     setup:
     final DDSpanContext context =
       new DDSpanContext(
-        1G,
-        1G,
-        0G,
+        1L,
+        1L,
+        0L,
         "fakeService",
         "fakeOperation",
         "fakeResource",
@@ -34,7 +34,7 @@ class DDSpanTest extends DDSpecification {
         false,
         "fakeType",
         null,
-        PendingTrace.create(tracer, 1G),
+        PendingTrace.create(tracer, 1L),
         tracer,
         [:])
 
@@ -204,7 +204,7 @@ class DDSpanTest extends DDSpecification {
     where:
     extractedContext                                         | _
     new TagContext("some-origin", [:])                       | _
-    new ExtractedContext(1G, 2G, 0, "some-origin", [:], [:]) | _
+    new ExtractedContext(1L, 2L, 0, "some-origin", [:], [:]) | _
   }
 
   def "isRootSpan() in and not in the context of distributed tracing"() {
@@ -223,7 +223,7 @@ class DDSpanTest extends DDSpecification {
     where:
     extractedContext                                     | isTraceRootSpan
     null                                                 | true
-    new ExtractedContext(123G, 456G, 1, "789", [:], [:]) | false
+    new ExtractedContext(123L, 456L, 1, "789", [:], [:]) | false
   }
 
   def "getApplicationRootSpan() in and not in the context of distributed tracing"() {
@@ -245,6 +245,6 @@ class DDSpanTest extends DDSpecification {
     where:
     extractedContext                                     | isTraceRootSpan
     null                                                 | true
-    new ExtractedContext(123G, 456G, 1, "789", [:], [:]) | false
+    new ExtractedContext(123L, 456L, 1, "789", [:], [:]) | false
   }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceTest.groovy
@@ -17,7 +17,7 @@ class PendingTraceTest extends DDSpecification {
   def writer = new ListWriter()
   def tracer = CoreTracer.builder().writer(writer).build()
 
-  BigInteger traceId = BigInteger.valueOf(System.identityHashCode(this))
+  long traceId = System.identityHashCode(this)
 
   @Subject
   PendingTrace trace = PendingTrace.create(tracer, traceId)

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/SpanFactory.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/SpanFactory.groovy
@@ -12,9 +12,9 @@ class SpanFactory {
     def currentThreadName = Thread.currentThread().getName()
     Thread.currentThread().setName(threadName)
     def context = new DDSpanContext(
-      1G,
-      1G,
-      0G,
+      1L,
+      1L,
+      0L,
       "fakeService",
       "fakeOperation",
       "fakeResource",
@@ -24,7 +24,7 @@ class SpanFactory {
       false,
       "fakeType",
       Collections.emptyMap(),
-      PendingTrace.create(tracer, 1G),
+      PendingTrace.create(tracer, 1L),
       tracer, [:])
     Thread.currentThread().setName(currentThreadName)
     return DDSpan.create(timestampMicro, context)
@@ -32,9 +32,9 @@ class SpanFactory {
 
   static DDSpan newSpanOf(CoreTracer tracer) {
     def context = new DDSpanContext(
-      1G,
-      1G,
-      0G,
+      1L,
+      1L,
+      0L,
       "fakeService",
       "fakeOperation",
       "fakeResource",
@@ -44,7 +44,7 @@ class SpanFactory {
       false,
       "fakeType",
       Collections.emptyMap(),
-      PendingTrace.create(tracer, 1G),
+      PendingTrace.create(tracer, 1L),
       tracer, [:])
     return DDSpan.create(1, context)
   }
@@ -52,8 +52,8 @@ class SpanFactory {
   static DDSpan newSpanOf(PendingTrace trace) {
     def context = new DDSpanContext(
       trace.traceId,
-      1G,
-      0G,
+      1L,
+      0L,
       "fakeService",
       "fakeOperation",
       "fakeResource",
@@ -72,9 +72,9 @@ class SpanFactory {
     def writer = new ListWriter()
     def tracer = CoreTracer.builder().writer(writer).build()
     def context = new DDSpanContext(
-      1G,
-      1G,
-      0G,
+      1L,
+      1L,
+      0L,
       serviceName,
       "fakeOperation",
       "fakeResource",
@@ -84,7 +84,7 @@ class SpanFactory {
       false,
       "fakeType",
       Collections.emptyMap(),
-      PendingTrace.create(tracer, 1G),
+      PendingTrace.create(tracer, 1L),
       tracer,
       [:])
     context.setTag("env", envName)

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/B3HttpExtractorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/B3HttpExtractorTest.groovy
@@ -28,8 +28,8 @@ class B3HttpExtractorTest extends DDSpecification {
     final ExtractedContext context = extractor.extract(headers, MapGetter.INSTANCE)
 
     then:
-    context.traceId == traceId
-    context.spanId == spanId
+    context.traceId == traceId.longValue()
+    context.spanId == spanId.longValue()
     context.baggage == [:]
     context.tags == ["some-tag": "my-interesting-info"]
     context.samplingPriority == expectedSamplingPriority
@@ -56,8 +56,8 @@ class B3HttpExtractorTest extends DDSpecification {
 
     then:
     if (expectedTraceId) {
-      assert context.traceId == expectedTraceId
-      assert context.spanId == expectedSpanId
+      assert context.traceId == expectedTraceId.longValue()
+      assert context.spanId == expectedSpanId.longValue()
     } else {
       assert context == null
     }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/DatadogHttpExtractorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/DatadogHttpExtractorTest.groovy
@@ -36,8 +36,8 @@ class DatadogHttpExtractorTest extends DDSpecification {
     final ExtractedContext context = extractor.extract(headers, MapGetter.INSTANCE)
 
     then:
-    context.traceId == new BigInteger(traceId)
-    context.spanId == new BigInteger(spanId)
+    context.traceId == new BigInteger(traceId).longValue()
+    context.spanId == new BigInteger(spanId).longValue()
     context.baggage == ["k1": "v1", "k2": "v2"]
     context.tags == ["some-tag": "my-interesting-info"]
     context.samplingPriority == samplingPriority
@@ -137,8 +137,8 @@ class DatadogHttpExtractorTest extends DDSpecification {
 
     then:
     if (expectedTraceId) {
-      assert context.traceId == expectedTraceId
-      assert context.spanId == expectedSpanId
+      assert context.traceId == expectedTraceId.longValue()
+      assert context.spanId == expectedSpanId.longValue()
     } else {
       assert context == null
     }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HaystackHttpExtractorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HaystackHttpExtractorTest.groovy
@@ -26,8 +26,8 @@ class HaystackHttpExtractorTest extends DDSpecification {
     final ExtractedContext context = extractor.extract(headers, MapGetter.INSTANCE)
 
     then:
-    context.traceId == new BigInteger(traceId)
-    context.spanId == new BigInteger(spanId)
+    context.traceId == new BigInteger(traceId).longValue()
+    context.spanId == new BigInteger(spanId).longValue()
     context.baggage == ["k1": "v1", "k2": "v2"]
     context.tags == ["some-tag": "my-interesting-info"]
     context.samplingPriority == samplingPriority
@@ -124,8 +124,8 @@ class HaystackHttpExtractorTest extends DDSpecification {
 
     then:
     if (expectedTraceId) {
-      assert context.traceId == expectedTraceId
-      assert context.spanId == expectedSpanId
+      assert context.traceId == expectedTraceId.longValue()
+      assert context.spanId == expectedSpanId.longValue()
     } else {
       assert context == null
     }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HttpInjectorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HttpInjectorTest.groovy
@@ -20,8 +20,8 @@ class HttpInjectorTest extends DDSpecification {
     }
     HttpCodec.Injector injector = HttpCodec.createInjector(config)
 
-    def traceId = 1G
-    def spanId = 2G
+    def traceId = 1L
+    def spanId = 2L
 
     def writer = new ListWriter()
     def tracer = CoreTracer.builder().writer(writer).build()
@@ -29,7 +29,7 @@ class HttpInjectorTest extends DDSpecification {
       new DDSpanContext(
         traceId,
         spanId,
-        0G,
+        0L,
         "fakeService",
         "fakeOperation",
         "fakeResource",
@@ -44,7 +44,7 @@ class HttpInjectorTest extends DDSpecification {
         false,
         "fakeType",
         null,
-        new PendingTrace(tracer, 1G),
+        new PendingTrace(tracer, 1L),
         tracer,
         [:])
 

--- a/dd-trace-ot/src/main/java/datadog/opentracing/OTExtractedContext.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/OTExtractedContext.java
@@ -13,12 +13,12 @@ class OTExtractedContext extends OTTagContext {
 
   @Override
   public String toTraceId() {
-    return extractedContext.getTraceId().toString();
+    return String.valueOf(extractedContext.getTraceId());
   }
 
   @Override
   public String toSpanId() {
-    return extractedContext.getSpanId().toString();
+    return String.valueOf(extractedContext.getSpanId());
   }
 
   ExtractedContext getDelegate() {

--- a/dd-trace-ot/src/main/java/datadog/opentracing/OTGenericContext.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/OTGenericContext.java
@@ -14,12 +14,12 @@ class OTGenericContext implements SpanContext {
 
   @Override
   public String toTraceId() {
-    return delegate.getTraceId().toString();
+    return String.valueOf(delegate.getTraceId());
   }
 
   @Override
   public String toSpanId() {
-    return delegate.getSpanId().toString();
+    return String.valueOf(delegate.getSpanId());
   }
 
   @Override


### PR DESCRIPTION
Firstly, I'm aware there's a lot of history and tradeoffs in this area, but want to better quantify the cost of the current ID strategy.

There is a significant spatial overhead according to JOL.

```java
    public static void main(String... args) {
        for (int i = 0; i < 100; ++i) {
            StringCachingBigInteger scbi = new StringCachingBigInteger(63, ThreadLocalRandom.current());
            System.out.println(GraphLayout.parseInstance(scbi).toFootprint());
        }

    }

    public static class StringCachingBigInteger extends BigInteger {

        private final String string;

        public StringCachingBigInteger(int numBits, Random rnd) {
            super(numBits, rnd);
            this.string = super.toString();
        }

        @Override
        public String toString() {
            return string;
        }
    }
```

```
...$StringCachingBigInteger@3439f68dd footprint:
     COUNT       AVG       SUM   DESCRIPTION
         1        40        40   [B
         1        24        24   [I
         1        40        40   ...$StringCachingBigInteger
         1        24        24   java.lang.String
         4                 128   (total)
```

So `StringCachingBigInteger` IDs are 16 = 128/8 times larger than `long`.

According to a quick and dirty microbenchmark, `MessagePacker.packLong` is almost 3x faster than `MessagePacker.packBigInteger` 

```java
@State(Scope.Benchmark)
public class BigIntegerVsLong {

    @Param("2048")
    int count;

    private long[] longs;
    private BigInteger[] bigIntegers;
    ArrayBufferOutput output;
    private MessagePacker packer;

    @Setup(Level.Trial)
    public void init() {
        longs = new long[count];
        bigIntegers = new BigInteger[count];
        for (int i = 0; i < count; ++i) {
            long value = ThreadLocalRandom.current().nextLong();
            BigInteger bigInteger = BigInteger.valueOf(value);
            longs[i] = value;
            bigIntegers[i] = bigInteger;
        }
        output = new ArrayBufferOutput(1 << 22);
        packer = MessagePack.newDefaultPacker(output);
    }


    @Benchmark
    public void longs(Blackhole bh) throws IOException {
        for (long value : longs) {
            packer.packLong(value);
        }
        bh.consume(packer.getTotalWrittenBytes());
        packer.clear();
    }


    @Benchmark
    public void bigIntegers(Blackhole bh) throws IOException {
        for (BigInteger value : bigIntegers) {
            packer.packBigInteger(value);
        }
        bh.consume(packer.getTotalWrittenBytes());
        packer.clear();
    }

    @Benchmark
    public void longsToString(Blackhole bh) {
        for (long value : longs) {
            bh.consume(String.valueOf(value));
        }
    }

    @Benchmark
    public void bigIntegersToString(Blackhole bh) {
        for (BigInteger value : bigIntegers) {
            bh.consume(value.toString());
        }
    }
}
```


```
Benchmark                             (count)   Mode  Cnt       Score       Error  Units
BigIntegerVsLong.bigIntegers             2048  thrpt    5   65621.899 ±  5119.073  ops/s
BigIntegerVsLong.bigIntegersToString     2048  thrpt    5    2128.691 ±   157.025  ops/s
BigIntegerVsLong.longs                   2048  thrpt    5  150278.508 ± 27685.600  ops/s
BigIntegerVsLong.longsToString           2048  thrpt    5   12353.724 ±   747.569  ops/s
```

Note that `String.valueOf(long)` seems to be significantly better optimised than `BigInteger.toString()` where performance problems have been observed.

This PR is here to enable a side by side comparison of `long` and `BigInteger` id strategies, to get an idea of what the overheads associated with each approach are. We must not neglect the cost of injection of trace ids into logs.