### PR TITLE
Add unique version to MLT branch

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -58,6 +58,8 @@ deploy_to_bintray:
   rules:
     - if: '$CI_COMMIT_BRANCH == "master"'
       when: on_success
+    - if: '$CI_COMMIT_BRANCH == "MLT"'
+      when: on_success
     - if: '$CI_COMMIT_TAG =~ /^v.*/'
       when: on_success
     - when: manual

--- a/dd-trace-java.gradle
+++ b/dd-trace-java.gradle
@@ -25,6 +25,7 @@ scmVersion {
   }
 
   versionIncrementer 'incrementMinor'
+  versionCreator { versionFromTag, position -> return "$versionFromTag-MLT" }
 
   checks {
     uncommittedChanges = false


### PR DESCRIPTION
Adds an "MLT" suffix to the project version.  This allows MLT snapshots to be pushed to bintray without collisions with master.

I chose not to use "version per branch" because it's annoying to have to do a full rebuild every time you switch branches.  The the change in this pull request, it only happens between MLT and non-MLT branches.