### PR TITLE
JMX StackTrace provider

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
@@ -265,6 +265,7 @@ public class Agent {
   private static synchronized void startJmx(final URL bootstrapURL) {
     startJmxFetch(bootstrapURL);
     initializeJmxThreadCpuTimeProvider();
+    initializeJmxThreadStackProvider();
   }
 
   /** Enable JMX based thread CPU time provider once it is safe to touch JMX */
@@ -280,6 +281,21 @@ public class Agent {
       enableJmxMethod.invoke(null);
     } catch (final Throwable ex) {
       log.error("Throwable thrown while initializing JMX thread CPU time provider", ex);
+    }
+  }
+
+  private static void initializeJmxThreadStackProvider() {
+    log.info("Initializing JMX ThreadStack provider");
+    if (AGENT_CLASSLOADER == null) {
+      throw new IllegalStateException("Datadog agent should have been started already");
+    }
+    try {
+      final Class<?> tracerInstallerClass =
+          AGENT_CLASSLOADER.loadClass("datadog.trace.core.util.ThreadStackAccess");
+      final Method enableJmxMethod = tracerInstallerClass.getMethod("enableJmx");
+      enableJmxMethod.invoke(null);
+    } catch (final Throwable ex) {
+      log.error("Throwable thrown while initializing JMX ThreadStack provider", ex);
     }
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/util/JmxThreadStackProvider.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/util/JmxThreadStackProvider.java
@@ -3,6 +3,8 @@ package datadog.trace.core.util;
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -12,7 +14,7 @@ public class JmxThreadStackProvider implements ThreadStackProvider {
   public static final ThreadStackProvider INSTANCE = new JmxThreadStackProvider();
 
   @Override
-  public void getStackTrace(Set<Long> threadIds, List<StackTraceElement[]> stackTraces) {
+  public List<StackTraceElement[]> getStackTrace(Set<Long> threadIds) {
     long[] ids = new long[threadIds.size()];
     int idx = 0;
     for (Long id : threadIds) {
@@ -20,8 +22,13 @@ public class JmxThreadStackProvider implements ThreadStackProvider {
       idx++;
     }
     ThreadInfo[] threadInfos = threadMXBean.getThreadInfo(ids); // maxDepth?
+    if (threadInfos.length == 0) {
+      return Collections.emptyList();
+    }
+    List<StackTraceElement[]> stackTraces = new ArrayList<>();
     for (int i = 0; i < threadInfos.length; i++) {
       stackTraces.add(threadInfos[i].getStackTrace());
     }
+    return stackTraces;
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/util/JmxThreadStackProvider.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/util/JmxThreadStackProvider.java
@@ -6,7 +6,6 @@ import java.lang.management.ThreadMXBean;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 
 public class JmxThreadStackProvider implements ThreadStackProvider {
   private final ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
@@ -14,7 +13,7 @@ public class JmxThreadStackProvider implements ThreadStackProvider {
   public static final ThreadStackProvider INSTANCE = new JmxThreadStackProvider();
 
   @Override
-  public List<StackTraceElement[]> getStackTrace(Set<Long> threadIds) {
+  public List<StackTraceElement[]> getStackTrace(List<Long> threadIds) {
     long[] ids = new long[threadIds.size()];
     int idx = 0;
     for (Long id : threadIds) {

--- a/dd-trace-core/src/main/java/datadog/trace/core/util/JmxThreadStackProvider.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/util/JmxThreadStackProvider.java
@@ -1,0 +1,27 @@
+package datadog.trace.core.util;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadInfo;
+import java.lang.management.ThreadMXBean;
+import java.util.List;
+import java.util.Set;
+
+public class JmxThreadStackProvider implements ThreadStackProvider {
+  private final ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
+
+  public static final ThreadStackProvider INSTANCE = new JmxThreadStackProvider();
+
+  @Override
+  public void getStackTrace(Set<Long> threadIds, List<StackTraceElement[]> stackTraces) {
+    long[] ids = new long[threadIds.size()];
+    int idx = 0;
+    for (Long id : threadIds) {
+      ids[idx] = id;
+      idx++;
+    }
+    ThreadInfo[] threadInfos = threadMXBean.getThreadInfo(ids); // maxDepth?
+    for (int i = 0; i < threadInfos.length; i++) {
+      stackTraces.add(threadInfos[i].getStackTrace());
+    }
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/core/util/NoneThreadStackProvider.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/util/NoneThreadStackProvider.java
@@ -1,10 +1,13 @@
 package datadog.trace.core.util;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
 public class NoneThreadStackProvider implements ThreadStackProvider {
 
   @Override
-  public void getStackTrace(Set<Long> threadIds, List<StackTraceElement[]> stackTraces) {}
+  public List<StackTraceElement[]> getStackTrace(Set<Long> threadIds) {
+    return Collections.emptyList();
+  }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/util/NoneThreadStackProvider.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/util/NoneThreadStackProvider.java
@@ -1,0 +1,12 @@
+package datadog.trace.core.util;
+
+import java.util.List;
+import java.util.Set;
+
+public class NoneThreadStackProvider implements ThreadStackProvider {
+
+  public static final ThreadStackProvider INSTANCE = new NoneThreadStackProvider();
+
+  @Override
+  public void getStackTrace(Set<Long> threadIds, List<StackTraceElement[]> stackTraces) {}
+}

--- a/dd-trace-core/src/main/java/datadog/trace/core/util/NoneThreadStackProvider.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/util/NoneThreadStackProvider.java
@@ -2,12 +2,11 @@ package datadog.trace.core.util;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 
 public class NoneThreadStackProvider implements ThreadStackProvider {
 
   @Override
-  public List<StackTraceElement[]> getStackTrace(Set<Long> threadIds) {
+  public List<StackTraceElement[]> getStackTrace(List<Long> threadIds) {
     return Collections.emptyList();
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/util/NoneThreadStackProvider.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/util/NoneThreadStackProvider.java
@@ -5,8 +5,6 @@ import java.util.Set;
 
 public class NoneThreadStackProvider implements ThreadStackProvider {
 
-  public static final ThreadStackProvider INSTANCE = new NoneThreadStackProvider();
-
   @Override
   public void getStackTrace(Set<Long> threadIds, List<StackTraceElement[]> stackTraces) {}
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/util/ThreadStackAccess.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/util/ThreadStackAccess.java
@@ -4,16 +4,15 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class ThreadStackAccess {
-  private static volatile ThreadStackProvider threadStackProvider =
-      NoneThreadStackProvider.INSTANCE;
+  private static volatile ThreadStackProvider threadStackProvider = new NoneThreadStackProvider();
 
   /**
-   * Disable JMX based ThreadStack. Will flip back to the {@linkplain
-   * NoneThreadStackProvider#INSTANCE} implementation.
+   * Disable JMX based ThreadStack. Will flip back to the {@linkplain NoneThreadStackProvider}
+   * implementation.
    */
   public static void disableJmx() {
     log.debug("Disabling JMX thread CPU time provider");
-    threadStackProvider = NoneThreadStackProvider.INSTANCE;
+    threadStackProvider = new NoneThreadStackProvider();
   }
 
   /** Enable JMX based ThreadStack */
@@ -42,8 +41,8 @@ public class ThreadStackAccess {
   /**
    * Get the current ThreadStack provider
    *
-   * @return the actual current ThreadStack provider or {@linkplain
-   *     NoneThreadStackProvider#INSTANCE} if the JMX provider is not available
+   * @return the actual current ThreadStack provider or {@linkplain NoneThreadStackProvider} if the
+   *     JMX provider is not available
    */
   public static ThreadStackProvider getCurrentThreadStackProvider() {
     return threadStackProvider;

--- a/dd-trace-core/src/main/java/datadog/trace/core/util/ThreadStackAccess.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/util/ThreadStackAccess.java
@@ -1,0 +1,51 @@
+package datadog.trace.core.util;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class ThreadStackAccess {
+  private static volatile ThreadStackProvider threadStackProvider =
+      NoneThreadStackProvider.INSTANCE;
+
+  /**
+   * Disable JMX based ThreadStack. Will flip back to the {@linkplain
+   * NoneThreadStackProvider#INSTANCE} implementation.
+   */
+  public static void disableJmx() {
+    log.debug("Disabling JMX thread CPU time provider");
+    threadStackProvider = NoneThreadStackProvider.INSTANCE;
+  }
+
+  /** Enable JMX based ThreadStack */
+  public static void enableJmx() {
+    try {
+      log.debug("Enabling JMX ThreadStack provider");
+      /*
+       * Can not use direct class reference to JmxThreadStackProvider since on some rare JVM implementations
+       * using eager class resolution that class could be resolved at the moment when ThreadStacks are requested,
+       * potentially triggering j.u.l initialization which is potentially dangerous and can be done only at certain
+       * point in time.
+       * Using reflection should alleviate this problem - no class constant to resolve during class load. The JMX
+       * ThreadStack provider will be loaded at exact moment when the reflection code is executed. Then it is up
+       * to the caller to ensure that it is safe to use JMX.
+       */
+      threadStackProvider =
+          (ThreadStackProvider)
+              Class.forName("datadog.trace.core.util.JmxThreadStackProvider")
+                  .getField("INSTANCE")
+                  .get(null);
+    } catch (final ClassNotFoundException | NoSuchFieldException | IllegalAccessException e) {
+      log.info("Unable to initialize JMX ThreadStack provider", e);
+    }
+  }
+
+  /**
+   * Get the current ThreadStack provider
+   *
+   * @return the actual current ThreadStack provider or {@linkplain
+   *     NoneThreadStackProvider#INSTANCE} if the JMX provider is not available
+   */
+  public static ThreadStackProvider getCurrentThreadStackProvider() {
+    return threadStackProvider;
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/core/util/ThreadStackProvider.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/util/ThreadStackProvider.java
@@ -1,8 +1,7 @@
 package datadog.trace.core.util;
 
 import java.util.List;
-import java.util.Set;
 
 public interface ThreadStackProvider {
-  List<StackTraceElement[]> getStackTrace(Set<Long> threadIds);
+  List<StackTraceElement[]> getStackTrace(List<Long> threadIds);
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/util/ThreadStackProvider.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/util/ThreadStackProvider.java
@@ -1,0 +1,8 @@
+package datadog.trace.core.util;
+
+import java.util.List;
+import java.util.Set;
+
+public interface ThreadStackProvider {
+  void getStackTrace(Set<Long> threadIds, List<StackTraceElement[]> stackTraces);
+}

--- a/dd-trace-core/src/main/java/datadog/trace/core/util/ThreadStackProvider.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/util/ThreadStackProvider.java
@@ -4,5 +4,5 @@ import java.util.List;
 import java.util.Set;
 
 public interface ThreadStackProvider {
-  void getStackTrace(Set<Long> threadIds, List<StackTraceElement[]> stackTraces);
+  List<StackTraceElement[]> getStackTrace(Set<Long> threadIds);
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/util/ThreadStackAccessTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/util/ThreadStackAccessTest.groovy
@@ -1,0 +1,36 @@
+package datadog.trace.core.util
+
+
+import datadog.trace.util.test.DDSpecification
+
+class ThreadStackAccessTest extends DDSpecification {
+  def "No ThreadStack provider"() {
+    setup:
+    ThreadStackAccess.disableJmx()
+
+    when:
+    def provider = ThreadStackAccess.currentThreadStackProvider
+
+    then:
+    provider instanceof NoneThreadStackProvider
+
+    cleanup:
+    ThreadStackAccess.disableJmx()
+  }
+
+  def "JMX ThreadStack provider"() {
+    setup:
+    ThreadStackAccess.enableJmx()
+
+    when:
+    def provider = ThreadStackAccess.getCurrentThreadStackProvider()
+    def stackTraces = provider.getStackTrace(new HashSet<Long>(Arrays.asList(Thread.currentThread().getId())))
+
+    then:
+    provider instanceof JmxThreadStackProvider
+    !stackTraces.isEmpty()
+
+    cleanup:
+    ThreadStackAccess.disableJmx()
+  }
+}

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/util/ThreadStackAccessTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/util/ThreadStackAccessTest.groovy
@@ -24,7 +24,7 @@ class ThreadStackAccessTest extends DDSpecification {
 
     when:
     def provider = ThreadStackAccess.getCurrentThreadStackProvider()
-    def stackTraces = provider.getStackTrace(new HashSet<Long>(Arrays.asList(Thread.currentThread().getId())))
+    def stackTraces = provider.getStackTrace(Collections.singletonList(Thread.currentThread().getId()))
 
     then:
     provider instanceof JmxThreadStackProvider


### PR DESCRIPTION
provides a safe way to access stacktraces through JMX getThreadInfo
call