### PR TITLE
Change LZ4 config to reduce allocation rate during decompression

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-uploader/src/main/java/com/datadog/profiling/uploader/util/StreamUtils.java
+++ b/dd-java-agent/agent-profiling/profiling-uploader/src/main/java/com/datadog/profiling/uploader/util/StreamUtils.java
@@ -74,11 +74,10 @@ public final class StreamUtils {
     } else {
       final FastByteArrayOutputStream baos = new FastByteArrayOutputStream(expectedSize);
       try (final OutputStream zipped =
-          new LZ4FrameOutputStream(
+        new LZ4FrameOutputStream(
               baos,
               LZ4FrameOutputStream.BLOCKSIZE.SIZE_64KB,
-              LZ4FrameOutputStream.FLG.Bits.BLOCK_CHECKSUM,
-              LZ4FrameOutputStream.FLG.Bits.CONTENT_CHECKSUM,
+              // copy of the default flag(s) used by LZ4FrameOutputStream
               LZ4FrameOutputStream.FLG.Bits.BLOCK_INDEPENDENCE)) {
         copy(is, zipped);
       }

--- a/dd-java-agent/agent-profiling/profiling-uploader/src/main/java/com/datadog/profiling/uploader/util/StreamUtils.java
+++ b/dd-java-agent/agent-profiling/profiling-uploader/src/main/java/com/datadog/profiling/uploader/util/StreamUtils.java
@@ -73,7 +73,13 @@ public final class StreamUtils {
       return readStream(is, expectedSize, consumer);
     } else {
       final FastByteArrayOutputStream baos = new FastByteArrayOutputStream(expectedSize);
-      try (final OutputStream zipped = new LZ4FrameOutputStream(baos)) {
+      try (final OutputStream zipped =
+          new LZ4FrameOutputStream(
+              baos,
+              LZ4FrameOutputStream.BLOCKSIZE.SIZE_64KB,
+              LZ4FrameOutputStream.FLG.Bits.BLOCK_CHECKSUM,
+              LZ4FrameOutputStream.FLG.Bits.CONTENT_CHECKSUM,
+              LZ4FrameOutputStream.FLG.Bits.BLOCK_INDEPENDENCE)) {
         copy(is, zipped);
       }
       return baos.consume(consumer);

--- a/dd-java-agent/agent-profiling/profiling-uploader/src/main/java/com/datadog/profiling/uploader/util/StreamUtils.java
+++ b/dd-java-agent/agent-profiling/profiling-uploader/src/main/java/com/datadog/profiling/uploader/util/StreamUtils.java
@@ -74,7 +74,7 @@ public final class StreamUtils {
     } else {
       final FastByteArrayOutputStream baos = new FastByteArrayOutputStream(expectedSize);
       try (final OutputStream zipped =
-        new LZ4FrameOutputStream(
+          new LZ4FrameOutputStream(
               baos,
               LZ4FrameOutputStream.BLOCKSIZE.SIZE_64KB,
               // copy of the default flag(s) used by LZ4FrameOutputStream


### PR DESCRIPTION
Currently, our LZ4 compression is using LZ4 Frame format with default block size which is 4MB. The decompressor will then pre-allocated 4MB byte array for each chunk of data although it almost never needed. This is driving the increased allocation pressure in our backend without any other benefits.

The block size is controlled by the creator of the compressed data so the change must be in agent.