### PR TITLE
revert to sleeping wait strategy in trace processor

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/DispatchingDisruptor.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/DispatchingDisruptor.java
@@ -31,6 +31,7 @@ public class DispatchingDisruptor implements AutoCloseable {
             disruptorSize,
             DaemonThreadFactory.TRACE_WRITER,
             ProducerType.SINGLE,
+            // block (and use no resources) until there's a batch of data to dispatch
             new BlockingWaitStrategy());
     disruptor.handleEventsWith(new TraceDispatchingHandler(api, monitor, writer));
   }


### PR DESCRIPTION
Because of #1454, the trace processor uses more CPU in high RPS environments. This reinstates throttling behaviour in the trace processor.