### PR TITLE
avoid materialising meta (baggage + tags) during serialisation

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -300,6 +300,9 @@ acceptedBreaks:
         \ boolean)"
       justification: "Removed deprecated APIs preventing refactoring"
     - code: "java.method.removed"
+      old: "method java.util.Map<java.lang.String, java.lang.String> datadog.trace.core.DDSpan::getMeta()"
+      justification: "internal api"
+    - code: "java.method.removed"
       old: "method long datadog.trace.common.writer.ddagent.AbstractDisruptor<T>::getCurrentCount()\
         \ @ datadog.trace.common.writer.ddagent.TraceProcessingDisruptor"
       justification: "refactor trace serialization pipeline"
@@ -309,6 +312,20 @@ acceptedBreaks:
     - code: "java.method.removed"
       old: "method void datadog.trace.core.scopemanager.ContinuableScope.Continuation::close(boolean)"
       justification: "Removed deprecated APIs preventing refactoring"
+    - code: "java.method.removed"
+      old: "method void datadog.trace.core.serialization.FormatWriter<DEST>::writeStringMap(java.lang.String,\
+        \ java.util.Map<java.lang.String, java.lang.String>, DEST) throws java.io.IOException"
+      justification: "internal api"
+    - code: "java.method.removed"
+      old: "method void datadog.trace.core.serialization.FormatWriter<DEST>::writeStringMap(java.lang.String,\
+        \ java.util.Map<java.lang.String, java.lang.String>, DEST) throws java.io.IOException\
+        \ @ datadog.trace.core.serialization.JsonFormatWriter"
+      justification: "internal api"
+    - code: "java.method.removed"
+      old: "method void datadog.trace.core.serialization.FormatWriter<DEST>::writeStringMap(java.lang.String,\
+        \ java.util.Map<java.lang.String, java.lang.String>, DEST) throws java.io.IOException\
+        \ @ datadog.trace.core.serialization.MsgpackFormatWriter"
+      justification: "internal api"
   "0.52.0":
     com.datadoghq:dd-trace-core:
     - code: "java.method.removed"

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -261,24 +261,6 @@ public class DDSpan implements MutableSpan, AgentSpan {
   // Getters
 
   /**
-   * Meta merges baggage and tags (stringified values) into a writable destination
-   *
-   * @return
-   */
-  public void transferMeta(MapAcceptor<String> acceptor) {
-    Map<String, String> baggageItems = context.getBaggageItems();
-    Map<String, Object> tags = context.getTags();
-    acceptor.beginMap(baggageItems.size() + tags.size());
-    for (Map.Entry<String, String> entry : baggageItems.entrySet()) {
-      acceptor.acceptValue(entry.getKey(), entry.getValue());
-    }
-    for (Map.Entry<String, Object> entry : tags.entrySet()) {
-      acceptor.acceptValue(entry.getKey(), String.valueOf(entry.getValue()));
-    }
-    acceptor.endMap();
-  }
-
-  /**
    * Span metrics.
    *
    * @return metrics for this span

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
@@ -349,8 +349,8 @@ public class DDSpanContext implements AgentSpan.Context {
     }
   }
 
-  public synchronized Map<String, Object> getTags() {
-    return Collections.unmodifiableMap(tags);
+  public Map<String, Object> getTags() {
+    return tags;
   }
 
   @Override

--- a/dd-trace-core/src/main/java/datadog/trace/core/MapAcceptor.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/MapAcceptor.java
@@ -1,9 +1,0 @@
-package datadog.trace.core;
-
-public interface MapAcceptor<T> {
-  void beginMap(int size);
-
-  void acceptValue(String key, T value);
-
-  void endMap();
-}

--- a/dd-trace-core/src/main/java/datadog/trace/core/MapAcceptor.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/MapAcceptor.java
@@ -1,0 +1,9 @@
+package datadog.trace.core;
+
+public interface MapAcceptor<T> {
+  void beginMap(int size);
+
+  void acceptValue(String key, T value);
+
+  void endMap();
+}

--- a/dd-trace-core/src/main/java/datadog/trace/core/serialization/FormatWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/serialization/FormatWriter.java
@@ -23,36 +23,44 @@ import java.util.Map;
 
 public abstract class FormatWriter<DEST> {
 
-  public abstract void writeKey(byte[] key, DEST destination) throws IOException;
+  public abstract void writeKey(final byte[] key, final DEST destination) throws IOException;
 
-  public abstract void writeListHeader(int size, DEST destination) throws IOException;
+  public abstract void writeListHeader(final int size, final DEST destination) throws IOException;
 
-  public abstract void writeListFooter(DEST destination) throws IOException;
+  public abstract void writeListFooter(final DEST destination) throws IOException;
 
-  public abstract void writeMapHeader(int size, DEST destination) throws IOException;
+  public abstract void writeMapHeader(final int size, final DEST destination) throws IOException;
 
-  public abstract void writeMapFooter(DEST destination) throws IOException;
+  public abstract void writeMapFooter(final DEST destination) throws IOException;
 
-  public void writeTag(byte[] key, String value, DEST destination) throws IOException {
+  public void writeTag(final byte[] key, final String value, final DEST destination)
+      throws IOException {
     writeString(key, value, destination);
   }
 
-  public abstract void writeString(byte[] key, String value, DEST destination) throws IOException;
-
-  public abstract void writeShort(byte[] key, short value, DEST destination) throws IOException;
-
-  public abstract void writeByte(byte[] key, byte value, DEST destination) throws IOException;
-
-  public abstract void writeInt(byte[] key, int value, DEST destination) throws IOException;
-
-  public abstract void writeLong(byte[] key, long value, DEST destination) throws IOException;
-
-  public abstract void writeFloat(byte[] key, float value, DEST destination) throws IOException;
-
-  public abstract void writeDouble(byte[] key, double value, DEST destination) throws IOException;
-
-  public abstract void writeBigInteger(byte[] key, BigInteger value, DEST destination)
+  public abstract void writeString(final byte[] key, final String value, final DEST destination)
       throws IOException;
+
+  public abstract void writeShort(final byte[] key, final short value, final DEST destination)
+      throws IOException;
+
+  public abstract void writeByte(final byte[] key, final byte value, final DEST destination)
+      throws IOException;
+
+  public abstract void writeInt(final byte[] key, final int value, final DEST destination)
+      throws IOException;
+
+  public abstract void writeLong(final byte[] key, final long value, final DEST destination)
+      throws IOException;
+
+  public abstract void writeFloat(final byte[] key, final float value, final DEST destination)
+      throws IOException;
+
+  public abstract void writeDouble(final byte[] key, final double value, final DEST destination)
+      throws IOException;
+
+  public abstract void writeBigInteger(
+      final byte[] key, final BigInteger value, final DEST destination) throws IOException;
 
   public void writeNumber(final byte[] key, final Number value, final DEST destination)
       throws IOException {
@@ -88,7 +96,10 @@ public abstract class FormatWriter<DEST> {
     Map<String, Object> tags = span.context().getTags();
     writeMapHeader(baggage.size() + tags.size(), destination);
     for (Map.Entry<String, String> entry : baggage.entrySet()) {
-      writeTag(stringToBytes(entry.getKey()), entry.getValue(), destination);
+      // tags and baggage may intersect, but tags take priority
+      if (!tags.containsKey(entry.getKey())) {
+        writeTag(stringToBytes(entry.getKey()), entry.getValue(), destination);
+      }
     }
     for (Map.Entry<String, Object> entry : tags.entrySet()) {
       if (entry.getValue() instanceof String) {
@@ -126,8 +137,9 @@ public abstract class FormatWriter<DEST> {
     writeMapFooter(destination);
   }
 
-  private byte[] stringToBytes(String string) {
-    byte[] key = StringTables.getBytesUTF8(string);
+  private byte[] stringToBytes(final String string) {
+    // won't reassign key or string in this method
+    final byte[] key = StringTables.getBytesUTF8(string);
     return null == key ? string.getBytes(StandardCharsets.UTF_8) : key;
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/serialization/JsonFormatWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/serialization/JsonFormatWriter.java
@@ -23,7 +23,7 @@ public class JsonFormatWriter extends FormatWriter<JsonWriter> {
   public static JsonFormatWriter JSON_WRITER = new JsonFormatWriter();
 
   @Override
-  public void writeKey(byte[] key, JsonWriter destination) throws IOException {
+  public void writeKey(final byte[] key, final JsonWriter destination) throws IOException {
     destination.name(new String(key));
   }
 
@@ -48,50 +48,57 @@ public class JsonFormatWriter extends FormatWriter<JsonWriter> {
   }
 
   @Override
-  public void writeString(byte[] key, String value, JsonWriter destination) throws IOException {
-    writeKey(key, destination);
-    destination.value(value);
-  }
-
-  @Override
-  public void writeShort(byte[] key, short value, JsonWriter destination) throws IOException {
-    writeKey(key, destination);
-    destination.value(value);
-  }
-
-  @Override
-  public void writeByte(byte[] key, byte value, JsonWriter destination) throws IOException {
-    writeKey(key, destination);
-    destination.value(value);
-  }
-
-  @Override
-  public void writeInt(byte[] key, int value, JsonWriter destination) throws IOException {
-    writeKey(key, destination);
-    destination.value(value);
-  }
-
-  @Override
-  public void writeLong(byte[] key, long value, JsonWriter destination) throws IOException {
-    writeKey(key, destination);
-    destination.value(value);
-  }
-
-  @Override
-  public void writeFloat(byte[] key, float value, JsonWriter destination) throws IOException {
-    writeKey(key, destination);
-    destination.value(value);
-  }
-
-  @Override
-  public void writeDouble(byte[] key, double value, JsonWriter destination) throws IOException {
-    writeKey(key, destination);
-    destination.value(value);
-  }
-
-  @Override
-  public void writeBigInteger(byte[] key, BigInteger value, JsonWriter destination)
+  public void writeString(final byte[] key, final String value, final JsonWriter destination)
       throws IOException {
+    writeKey(key, destination);
+    destination.value(value);
+  }
+
+  @Override
+  public void writeShort(final byte[] key, final short value, final JsonWriter destination)
+      throws IOException {
+    writeKey(key, destination);
+    destination.value(value);
+  }
+
+  @Override
+  public void writeByte(final byte[] key, final byte value, final JsonWriter destination)
+      throws IOException {
+    writeKey(key, destination);
+    destination.value(value);
+  }
+
+  @Override
+  public void writeInt(final byte[] key, final int value, final JsonWriter destination)
+      throws IOException {
+    writeKey(key, destination);
+    destination.value(value);
+  }
+
+  @Override
+  public void writeLong(final byte[] key, final long value, final JsonWriter destination)
+      throws IOException {
+    writeKey(key, destination);
+    destination.value(value);
+  }
+
+  @Override
+  public void writeFloat(final byte[] key, final float value, final JsonWriter destination)
+      throws IOException {
+    writeKey(key, destination);
+    destination.value(value);
+  }
+
+  @Override
+  public void writeDouble(final byte[] key, final double value, final JsonWriter destination)
+      throws IOException {
+    writeKey(key, destination);
+    destination.value(value);
+  }
+
+  @Override
+  public void writeBigInteger(
+      final byte[] key, final BigInteger value, final JsonWriter destination) throws IOException {
     writeKey(key, destination);
     destination.value(value);
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/serialization/JsonFormatWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/serialization/JsonFormatWriter.java
@@ -6,7 +6,6 @@ import com.squareup.moshi.JsonWriter;
 import com.squareup.moshi.Moshi;
 import com.squareup.moshi.Types;
 import datadog.trace.core.DDSpan;
-import datadog.trace.core.MapAcceptor;
 import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
@@ -97,39 +96,6 @@ public class JsonFormatWriter extends FormatWriter<JsonWriter> {
     destination.value(value);
   }
 
-  @Override
-  protected MapAcceptor<String> getMetaAcceptor(final JsonWriter destination) {
-    return new MapAcceptor<String>() {
-      @Override
-      public void beginMap(int size) {
-        try {
-          writeMapHeader(size, destination);
-        } catch (IOException e) {
-          throw new RuntimeException(e);
-        }
-      }
-
-      @Override
-      public void acceptValue(String key, String value) {
-        try {
-          destination.name(key);
-          destination.value(value);
-        } catch (IOException e) {
-          throw new RuntimeException(e);
-        }
-      }
-
-      @Override
-      public void endMap() {
-        try {
-          writeMapFooter(destination);
-        } catch (IOException e) {
-          throw new RuntimeException(e);
-        }
-      }
-    };
-  }
-
   static class DDSpanAdapter extends JsonAdapter<DDSpan> {
     public static final JsonAdapter.Factory FACTORY =
         new JsonAdapter.Factory() {
@@ -145,7 +111,7 @@ public class JsonFormatWriter extends FormatWriter<JsonWriter> {
         };
 
     @Override
-    public DDSpan fromJson(final JsonReader reader) throws IOException {
+    public DDSpan fromJson(final JsonReader reader) {
       throw new UnsupportedOperationException();
     }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/serialization/JsonFormatWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/serialization/JsonFormatWriter.java
@@ -6,6 +6,7 @@ import com.squareup.moshi.JsonWriter;
 import com.squareup.moshi.Moshi;
 import com.squareup.moshi.Types;
 import datadog.trace.core.DDSpan;
+import datadog.trace.core.MapAcceptor;
 import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
@@ -94,6 +95,39 @@ public class JsonFormatWriter extends FormatWriter<JsonWriter> {
       throws IOException {
     writeKey(key, destination);
     destination.value(value);
+  }
+
+  @Override
+  protected MapAcceptor<String> getMetaAcceptor(final JsonWriter destination) {
+    return new MapAcceptor<String>() {
+      @Override
+      public void beginMap(int size) {
+        try {
+          writeMapHeader(size, destination);
+        } catch (IOException e) {
+          throw new RuntimeException(e);
+        }
+      }
+
+      @Override
+      public void acceptValue(String key, String value) {
+        try {
+          destination.name(key);
+          destination.value(value);
+        } catch (IOException e) {
+          throw new RuntimeException(e);
+        }
+      }
+
+      @Override
+      public void endMap() {
+        try {
+          writeMapFooter(destination);
+        } catch (IOException e) {
+          throw new RuntimeException(e);
+        }
+      }
+    };
   }
 
   static class DDSpanAdapter extends JsonAdapter<DDSpan> {

--- a/dd-trace-core/src/main/java/datadog/trace/core/serialization/MsgpackFormatWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/serialization/MsgpackFormatWriter.java
@@ -9,7 +9,7 @@ public class MsgpackFormatWriter extends FormatWriter<MessagePacker> {
   public static MsgpackFormatWriter MSGPACK_WRITER = new MsgpackFormatWriter();
 
   @Override
-  public void writeKey(byte[] key, MessagePacker destination) throws IOException {
+  public void writeKey(final byte[] key, MessagePacker destination) throws IOException {
     destination.packRawStringHeader(key.length);
     destination.addPayload(key);
   }
@@ -31,7 +31,8 @@ public class MsgpackFormatWriter extends FormatWriter<MessagePacker> {
   public void writeMapFooter(final MessagePacker destination) {}
 
   @Override
-  public void writeString(byte[] key, String value, MessagePacker destination) throws IOException {
+  public void writeString(final byte[] key, final String value, MessagePacker destination)
+      throws IOException {
     writeKey(key, destination);
     if (value == null) {
       destination.packNil();
@@ -41,49 +42,57 @@ public class MsgpackFormatWriter extends FormatWriter<MessagePacker> {
   }
 
   @Override
-  public void writeTag(byte[] key, String value, MessagePacker destination) throws IOException {
+  public void writeTag(final byte[] key, final String value, final MessagePacker destination)
+      throws IOException {
     writeKey(key, destination);
     writeStringUTF8(value, destination);
   }
 
   @Override
-  public void writeShort(byte[] key, short value, MessagePacker destination) throws IOException {
+  public void writeShort(final byte[] key, final short value, final MessagePacker destination)
+      throws IOException {
     writeKey(key, destination);
     destination.packShort(value);
   }
 
   @Override
-  public void writeByte(byte[] key, byte value, MessagePacker destination) throws IOException {
+  public void writeByte(final byte[] key, final byte value, final MessagePacker destination)
+      throws IOException {
     writeKey(key, destination);
     destination.packByte(value);
   }
 
   @Override
-  public void writeInt(byte[] key, int value, MessagePacker destination) throws IOException {
+  public void writeInt(final byte[] key, final int value, final MessagePacker destination)
+      throws IOException {
     writeKey(key, destination);
     destination.packInt(value);
   }
 
   @Override
-  public void writeLong(byte[] key, long value, MessagePacker destination) throws IOException {
+  public void writeLong(final byte[] key, final long value, final MessagePacker destination)
+      throws IOException {
     writeKey(key, destination);
     destination.packLong(value);
   }
 
   @Override
-  public void writeFloat(byte[] key, float value, MessagePacker destination) throws IOException {
+  public void writeFloat(final byte[] key, final float value, final MessagePacker destination)
+      throws IOException {
     writeKey(key, destination);
     destination.packFloat(value);
   }
 
   @Override
-  public void writeDouble(byte[] key, double value, MessagePacker destination) throws IOException {
+  public void writeDouble(final byte[] key, final double value, final MessagePacker destination)
+      throws IOException {
     writeKey(key, destination);
     destination.packDouble(value);
   }
 
   @Override
-  public void writeBigInteger(byte[] key, BigInteger value, MessagePacker destination)
+  public void writeBigInteger(
+      final byte[] key, final BigInteger value, final MessagePacker destination)
       throws IOException {
     writeKey(key, destination);
     if (value == null) {
@@ -93,7 +102,8 @@ public class MsgpackFormatWriter extends FormatWriter<MessagePacker> {
     }
   }
 
-  private static void writeStringUTF8(String value, MessagePacker destination) throws IOException {
+  private static void writeStringUTF8(final String value, final MessagePacker destination)
+      throws IOException {
     if (null == value) {
       destination.packNil();
     } else {

--- a/dd-trace-core/src/main/java/datadog/trace/core/serialization/MsgpackFormatWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/serialization/MsgpackFormatWriter.java
@@ -1,6 +1,5 @@
 package datadog.trace.core.serialization;
 
-import datadog.trace.core.MapAcceptor;
 import datadog.trace.core.StringTables;
 import java.io.IOException;
 import java.math.BigInteger;
@@ -94,11 +93,6 @@ public class MsgpackFormatWriter extends FormatWriter<MessagePacker> {
     }
   }
 
-  @Override
-  protected MapAcceptor<String> getMetaAcceptor(MessagePacker destination) {
-    return new MsgPackMapAcceptor(destination);
-  }
-
   private static void writeStringUTF8(String value, MessagePacker destination) throws IOException {
     if (null == value) {
       destination.packNil();
@@ -111,35 +105,5 @@ public class MsgpackFormatWriter extends FormatWriter<MessagePacker> {
         destination.packString(value);
       }
     }
-  }
-
-  private static class MsgPackMapAcceptor implements MapAcceptor<String> {
-    private final MessagePacker packer;
-
-    private MsgPackMapAcceptor(MessagePacker packer) {
-      this.packer = packer;
-    }
-
-    @Override
-    public void beginMap(int size) {
-      try {
-        packer.packMapHeader(size);
-      } catch (IOException e) {
-        throw new RuntimeException(e);
-      }
-    }
-
-    @Override
-    public void acceptValue(String key, String value) {
-      try {
-        writeStringUTF8(key, packer);
-        writeStringUTF8(value, packer);
-      } catch (IOException e) {
-        throw new RuntimeException(e);
-      }
-    }
-
-    @Override
-    public void endMap() {}
   }
 }


### PR DESCRIPTION
Creating the meta map is a minor CPU bottleneck in serialisation, this change avoids allocating a new map or any map resizing.