### PR TITLE
Remove Java 9 and 10 from the build.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,16 +112,6 @@ jobs:
     environment:
       - TEST_TASK: testJavaZULU8
 
-  test_9:
-    <<: *default_test_job
-    environment:
-      - TEST_TASK: testJava9
-
-  test_10:
-    <<: *default_test_job
-    environment:
-      - TEST_TASK: testJava10
-
   test_11:
     <<: *default_test_job
     environment:
@@ -273,18 +263,6 @@ workflows:
             tags:
               only: /.*/
       - test_zulu8:
-          requires:
-            - build
-          filters:
-            tags:
-              only: /.*/
-      - test_9:
-          requires:
-            - build
-          filters:
-            tags:
-              only: /.*/
-      - test_10:
           requires:
             - build
           filters:


### PR DESCRIPTION
These don't really provide useful test feedback and are not widely used anymore.