### PR TITLE
Unblock pending builds with allow_failure=true

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -47,6 +47,7 @@ copy_to_s3:
     - if: '$CI_COMMIT_BRANCH == "master"'
       when: on_success
     - when: manual
+      allow_failure: true
   script:
     - export AWS_ACCESS_KEY_ID_REL=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-java.secret_key_id --with-decryption --query "Parameter.Value" --out text)
     - export AWS_SECRET_ACCESS_KEY_REL=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-java.secret_sec_key_id --with-decryption --query "Parameter.Value" --out text)
@@ -61,6 +62,7 @@ deploy_to_bintray:
     - if: '$CI_COMMIT_TAG =~ /^v.*/'
       when: on_success
     - when: manual
+      allow_failure: true
   script:
     - export BINTRAY_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-java.bintray_api_key --with-decryption --query "Parameter.Value" --out text)
     - ./gradlew -PbintrayUser=$BINTRAY_USER -PbintrayApiKey=$BINTRAY_API_KEY -PbuildInfo.build.number=$CI_JOB_ID artifactoryPublish --max-workers=1 --build-cache --stacktrace --no-daemon


### PR DESCRIPTION
When using workflow rules, gitlab sets the state to be "blocked".  This keeps the Github check state to as "Pending"

Setting "allow_failure=true" unblocks the build.  This is the correct behavior because those manual jobs (copy to s3, deploy to bintray) are never necessary for the build to complete when not on master.