### PR TITLE
Switch the ID to small instance wrapping the long and caching the Strings

### DIFF
--- a/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/ScopeEvent.java
+++ b/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/ScopeEvent.java
@@ -62,9 +62,9 @@ public final class ScopeEvent extends Event implements DDScopeEvent {
       if (cpuTime > 0) {
         cpuTime = ThreadCpuTimeAccess.getCurrentThreadCpuTime() - cpuTime;
       }
-      traceId = Long.toHexString(spanContext.getTraceId());
-      spanId = Long.toHexString(spanContext.getSpanId());
-      parentId = Long.toHexString(spanContext.getParentId());
+      traceId = spanContext.getTraceId().toHexString();
+      spanId = spanContext.getSpanId().toHexString();
+      parentId = spanContext.getParentId().toHexString();
       serviceName = spanContext.getServiceName();
       resourceName = spanContext.getResourceName();
       operationName = spanContext.getOperationName();

--- a/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/ScopeEvent.java
+++ b/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/ScopeEvent.java
@@ -18,8 +18,6 @@ import jdk.jfr.Timespan;
 @StackTrace(false)
 public final class ScopeEvent extends Event implements DDScopeEvent {
 
-  private static final int IDS_RADIX = 16;
-
   private final transient DDSpanContext spanContext;
 
   @Label("Trace Id")
@@ -64,9 +62,9 @@ public final class ScopeEvent extends Event implements DDScopeEvent {
       if (cpuTime > 0) {
         cpuTime = ThreadCpuTimeAccess.getCurrentThreadCpuTime() - cpuTime;
       }
-      traceId = spanContext.getTraceId().toString(IDS_RADIX);
-      spanId = spanContext.getSpanId().toString(IDS_RADIX);
-      parentId = spanContext.getParentId().toString(IDS_RADIX);
+      traceId = Long.toHexString(spanContext.getTraceId());
+      spanId = Long.toHexString(spanContext.getSpanId());
+      parentId = Long.toHexString(spanContext.getParentId());
       serviceName = spanContext.getServiceName();
       resourceName = spanContext.getResourceName();
       operationName = spanContext.getOperationName();

--- a/dd-trace-core/src/main/java/datadog/trace/common/sampling/DeterministicSampler.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/sampling/DeterministicSampler.java
@@ -32,7 +32,7 @@ public class DeterministicSampler implements RateSampler {
     } else if (rate == 0) {
       sampled = false;
     } else {
-      sampled = span.getTraceId() * KNUTH_FACTOR + Long.MIN_VALUE < cutoff + Long.MIN_VALUE;
+      sampled = span.getTraceId().toLong() * KNUTH_FACTOR + Long.MIN_VALUE < cutoff + Long.MIN_VALUE;
     }
 
     if (log.isDebugEnabled()) {

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -392,7 +392,7 @@ public class CoreTracer
   public String getTraceId() {
     final AgentSpan activeSpan = activeSpan();
     if (activeSpan instanceof DDSpan) {
-      return Long.toString(((DDSpan) activeSpan).getTraceId());
+      return ((DDSpan) activeSpan).getTraceId().toString();
     }
     return "0";
   }
@@ -401,7 +401,7 @@ public class CoreTracer
   public String getSpanId() {
     final AgentSpan activeSpan = activeSpan();
     if (activeSpan instanceof DDSpan) {
-      return Long.toString(((DDSpan) activeSpan).getSpanId());
+      return ((DDSpan) activeSpan).getSpanId().toString();
     }
     return "0";
   }
@@ -538,17 +538,6 @@ public class CoreTracer
       return this;
     }
 
-    private long generateNewId() {
-      // It is **extremely** unlikely to generate the value "0" but we still need to handle that
-      // case
-      long value;
-      do {
-        value = ThreadLocalRandom.current().nextLong(Long.MAX_VALUE);
-      } while (value == 0);
-
-      return value;
-    }
-
     /**
      * Build the SpanContext, if the actual span has a parent, the following attributes must be
      * propagated: - ServiceName - Baggage - Trace (a list of all spans related) - SpanType
@@ -556,9 +545,9 @@ public class CoreTracer
      * @return the context
      */
     private DDSpanContext buildSpanContext() {
-      final long traceId;
-      final long spanId = generateNewId();
-      final long parentSpanId;
+      final DDId traceId;
+      final DDId spanId = new DDId();
+      final DDId parentSpanId;
       final Map<String, String> baggage;
       final PendingTrace parentTrace;
       final int samplingPriority;
@@ -602,8 +591,8 @@ public class CoreTracer
           baggage = extractedContext.getBaggage();
         } else {
           // Start a new trace
-          traceId = generateNewId();
-          parentSpanId = 0L;
+          traceId = new DDId();
+          parentSpanId = DDId.ZERO;
           samplingPriority = PrioritySampling.UNSET;
           baggage = null;
         }

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -392,7 +392,7 @@ public class CoreTracer
   public String getTraceId() {
     final AgentSpan activeSpan = activeSpan();
     if (activeSpan instanceof DDSpan) {
-      return ((DDSpan) activeSpan).getTraceId().toString();
+      return Long.toString(((DDSpan) activeSpan).getTraceId());
     }
     return "0";
   }
@@ -401,7 +401,7 @@ public class CoreTracer
   public String getSpanId() {
     final AgentSpan activeSpan = activeSpan();
     if (activeSpan instanceof DDSpan) {
-      return ((DDSpan) activeSpan).getSpanId().toString();
+      return Long.toString(((DDSpan) activeSpan).getSpanId());
     }
     return "0";
   }
@@ -538,13 +538,13 @@ public class CoreTracer
       return this;
     }
 
-    private BigInteger generateNewId() {
+    private long generateNewId() {
       // It is **extremely** unlikely to generate the value "0" but we still need to handle that
       // case
-      BigInteger value;
+      long value;
       do {
-        value = new StringCachingBigInteger(63, ThreadLocalRandom.current());
-      } while (value.signum() == 0);
+        value = ThreadLocalRandom.current().nextLong(Long.MAX_VALUE);
+      } while (value == 0);
 
       return value;
     }
@@ -556,9 +556,9 @@ public class CoreTracer
      * @return the context
      */
     private DDSpanContext buildSpanContext() {
-      final BigInteger traceId;
-      final BigInteger spanId = generateNewId();
-      final BigInteger parentSpanId;
+      final long traceId;
+      final long spanId = generateNewId();
+      final long parentSpanId;
       final Map<String, String> baggage;
       final PendingTrace parentTrace;
       final int samplingPriority;
@@ -603,7 +603,7 @@ public class CoreTracer
         } else {
           // Start a new trace
           traceId = generateNewId();
-          parentSpanId = BigInteger.ZERO;
+          parentSpanId = 0L;
           samplingPriority = PrioritySampling.UNSET;
           baggage = null;
         }

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDId.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDId.java
@@ -1,0 +1,66 @@
+package datadog.trace.core;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+public class DDId {
+
+  public static DDId ZERO = DDId.from(0);
+
+  public static DDId from(long id) {
+    return new DDId(id);
+  }
+
+  private final long id;
+  private String str;
+  private String hex;
+
+  private DDId(long id) {
+    this.id = id;
+  }
+
+  public DDId() {
+    // It is **extremely** unlikely to generate the value "0" but we still need to handle that
+    // case
+    long id;
+    do {
+      id = ThreadLocalRandom.current().nextLong(Long.MAX_VALUE);
+    } while (id == 0);
+    this.id = id;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    DDId ddId = (DDId) o;
+    return this.id == ddId.id;
+  }
+
+  @Override
+  public int hashCode() {
+    return (int) this.id;
+  }
+
+  @Override
+  public String toString() {
+    if (this.str == null) {
+      String str = Long.toString(this.id);
+      this.str = str;
+      return str;
+    }
+    return this.str;
+  }
+
+  public String toHexString() {
+    if (this.hex == null) {
+      String hex = Long.toHexString(this.id);
+      this.hex = hex;
+      return hex;
+    }
+    return this.hex;
+  }
+
+  public long toLong() {
+    return this.id;
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -116,7 +116,7 @@ public class DDSpan implements MutableSpan, AgentSpan {
    * @return true if root, false otherwise
    */
   public final boolean isRootSpan() {
-    return context.getParentId() == 0L;
+    return DDId.ZERO.equals(context.getParentId());
   }
 
   @Override
@@ -134,8 +134,7 @@ public class DDSpan implements MutableSpan, AgentSpan {
   public boolean isSameTrace(final AgentSpan otherSpan) {
     // FIXME [API] AgentSpan or AgentSpan.Context should have a "getTraceId()" type method
     if (otherSpan instanceof DDSpan) {
-      // minor optimization to avoid BigInteger.toString()
-      return getTraceId() == ((DDSpan) otherSpan).getTraceId();
+      return getTraceId().equals(((DDSpan) otherSpan).getTraceId());
     }
 
     return false;
@@ -283,15 +282,15 @@ public class DDSpan implements MutableSpan, AgentSpan {
     return context.getServiceName();
   }
 
-  public long getTraceId() {
+  public DDId getTraceId() {
     return context.getTraceId();
   }
 
-  public long getSpanId() {
+  public DDId getSpanId() {
     return context.getSpanId();
   }
 
-  public long getParentId() {
+  public DDId getParentId() {
     return context.getParentId();
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -8,7 +8,6 @@ import datadog.trace.core.util.Clock;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.lang.ref.WeakReference;
-import java.math.BigInteger;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -117,7 +116,7 @@ public class DDSpan implements MutableSpan, AgentSpan {
    * @return true if root, false otherwise
    */
   public final boolean isRootSpan() {
-    return BigInteger.ZERO.equals(context.getParentId());
+    return context.getParentId() == 0L;
   }
 
   @Override
@@ -136,7 +135,7 @@ public class DDSpan implements MutableSpan, AgentSpan {
     // FIXME [API] AgentSpan or AgentSpan.Context should have a "getTraceId()" type method
     if (otherSpan instanceof DDSpan) {
       // minor optimization to avoid BigInteger.toString()
-      return getTraceId().equals(((DDSpan) otherSpan).getTraceId());
+      return getTraceId() == ((DDSpan) otherSpan).getTraceId();
     }
 
     return false;
@@ -284,15 +283,15 @@ public class DDSpan implements MutableSpan, AgentSpan {
     return context.getServiceName();
   }
 
-  public BigInteger getTraceId() {
+  public long getTraceId() {
     return context.getTraceId();
   }
 
-  public BigInteger getSpanId() {
+  public long getSpanId() {
     return context.getSpanId();
   }
 
-  public BigInteger getParentId() {
+  public long getParentId() {
     return context.getParentId();
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
@@ -39,9 +39,9 @@ public class DDSpanContext implements AgentSpan.Context {
   private final Map<String, String> baggageItems;
 
   // Not Shared with other span contexts
-  private final long traceId;
-  private final long spanId;
-  private final long parentId;
+  private final DDId traceId;
+  private final DDId spanId;
+  private final DDId parentId;
 
   /** Tags are associated to the current span, they will not propagate to the children span */
   private final Map<String, Object> tags = new ConcurrentHashMap<>();
@@ -75,9 +75,9 @@ public class DDSpanContext implements AgentSpan.Context {
   private final Map<String, String> serviceNameMappings;
 
   public DDSpanContext(
-      final long traceId,
-      final long spanId,
-      final long parentId,
+      final DDId traceId,
+      final DDId spanId,
+      final DDId parentId,
       final String serviceName,
       final String operationName,
       final String resourceName,
@@ -129,15 +129,15 @@ public class DDSpanContext implements AgentSpan.Context {
     this.tags.put(DDTags.THREAD_ID, threadId);
   }
 
-  public long getTraceId() {
+  public DDId getTraceId() {
     return traceId;
   }
 
-  public long getParentId() {
+  public DDId getParentId() {
     return parentId;
   }
 
-  public long getSpanId() {
+  public DDId getSpanId() {
     return spanId;
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
@@ -4,7 +4,6 @@ import datadog.trace.api.DDTags;
 import datadog.trace.api.sampling.PrioritySampling;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.core.decorators.AbstractDecorator;
-import java.math.BigInteger;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -40,9 +39,9 @@ public class DDSpanContext implements AgentSpan.Context {
   private final Map<String, String> baggageItems;
 
   // Not Shared with other span contexts
-  private final BigInteger traceId;
-  private final BigInteger spanId;
-  private final BigInteger parentId;
+  private final long traceId;
+  private final long spanId;
+  private final long parentId;
 
   /** Tags are associated to the current span, they will not propagate to the children span */
   private final Map<String, Object> tags = new ConcurrentHashMap<>();
@@ -76,9 +75,9 @@ public class DDSpanContext implements AgentSpan.Context {
   private final Map<String, String> serviceNameMappings;
 
   public DDSpanContext(
-      final BigInteger traceId,
-      final BigInteger spanId,
-      final BigInteger parentId,
+      final long traceId,
+      final long spanId,
+      final long parentId,
       final String serviceName,
       final String operationName,
       final String resourceName,
@@ -97,9 +96,6 @@ public class DDSpanContext implements AgentSpan.Context {
     this.tracer = tracer;
     this.trace = trace;
 
-    assert traceId != null;
-    assert spanId != null;
-    assert parentId != null;
     this.traceId = traceId;
     this.spanId = spanId;
     this.parentId = parentId;
@@ -133,15 +129,15 @@ public class DDSpanContext implements AgentSpan.Context {
     this.tags.put(DDTags.THREAD_ID, threadId);
   }
 
-  public BigInteger getTraceId() {
+  public long getTraceId() {
     return traceId;
   }
 
-  public BigInteger getParentId() {
+  public long getParentId() {
     return parentId;
   }
 
-  public BigInteger getSpanId() {
+  public long getSpanId() {
     return spanId;
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/PendingTrace.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/PendingTrace.java
@@ -9,7 +9,6 @@ import java.io.Closeable;
 import java.lang.ref.Reference;
 import java.lang.ref.ReferenceQueue;
 import java.lang.ref.WeakReference;
-import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -26,7 +25,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class PendingTrace extends ConcurrentLinkedDeque<DDSpan> implements AgentTrace {
 
-  static PendingTrace create(final CoreTracer tracer, final BigInteger traceId) {
+  static PendingTrace create(final CoreTracer tracer, final long traceId) {
     final PendingTrace pendingTrace = new PendingTrace(tracer, traceId);
     pendingTrace.addPendingTrace();
     return pendingTrace;
@@ -35,7 +34,7 @@ public class PendingTrace extends ConcurrentLinkedDeque<DDSpan> implements Agent
   private static final AtomicReference<SpanCleaner> SPAN_CLEANER = new AtomicReference<>();
 
   private final CoreTracer tracer;
-  private final BigInteger traceId;
+  private final long traceId;
 
   // TODO: consider moving these time fields into DDTracer to ensure that traces have precise
   // relative time
@@ -75,7 +74,7 @@ public class PendingTrace extends ConcurrentLinkedDeque<DDSpan> implements Agent
   /** Ensure a trace is never written multiple times */
   private final AtomicBoolean isWritten = new AtomicBoolean(false);
 
-  private PendingTrace(final CoreTracer tracer, final BigInteger traceId) {
+  private PendingTrace(final CoreTracer tracer, final long traceId) {
     this.tracer = tracer;
     this.traceId = traceId;
 
@@ -98,13 +97,13 @@ public class PendingTrace extends ConcurrentLinkedDeque<DDSpan> implements Agent
   }
 
   public void registerSpan(final DDSpan span) {
-    if (traceId == null || span.context() == null) {
+    if (traceId == 0L || span.context() == null) {
       log.error(
           "Failed to register span ({}) due to null PendingTrace traceId or null span context",
           span);
       return;
     }
-    if (!traceId.equals(span.context().getTraceId())) {
+    if (traceId != span.context().getTraceId()) {
       log.debug("{} - span registered for wrong trace ({})", span, traceId);
       return;
     }
@@ -124,12 +123,12 @@ public class PendingTrace extends ConcurrentLinkedDeque<DDSpan> implements Agent
   }
 
   private void expireSpan(final DDSpan span) {
-    if (traceId == null || span.context() == null) {
+    if (traceId == 0L || span.context() == null) {
       log.error(
           "Failed to expire span ({}) due to null PendingTrace traceId or null span context", span);
       return;
     }
-    if (!traceId.equals(span.context().getTraceId())) {
+    if (traceId != span.context().getTraceId()) {
       log.debug("{} - span expired for wrong trace ({})", span, traceId);
       return;
     }
@@ -150,12 +149,12 @@ public class PendingTrace extends ConcurrentLinkedDeque<DDSpan> implements Agent
       log.debug("{} - added to trace, but not complete.", span);
       return;
     }
-    if (traceId == null || span.context() == null) {
+    if (traceId == 0L || span.context() == null) {
       log.error(
           "Failed to add span ({}) due to null PendingTrace traceId or null span context", span);
       return;
     }
-    if (!traceId.equals(span.getTraceId())) {
+    if (traceId != span.getTraceId()) {
       log.debug("{} - added to a mismatched trace.", span);
       return;
     }

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/B3HttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/B3HttpCodec.java
@@ -5,6 +5,7 @@ import static datadog.trace.core.propagation.HttpCodec.validateUInt64BitsID;
 
 import datadog.trace.api.sampling.PrioritySampling;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
+import datadog.trace.core.DDId;
 import datadog.trace.core.DDSpanContext;
 import java.util.Collections;
 import java.util.HashMap;
@@ -38,8 +39,8 @@ class B3HttpCodec {
     public <C> void inject(
         final DDSpanContext context, final C carrier, final AgentPropagation.Setter<C> setter) {
       try {
-        setter.set(carrier, TRACE_ID_KEY, Long.toHexString(context.getTraceId()));
-        setter.set(carrier, SPAN_ID_KEY, Long.toHexString(context.getSpanId()));
+        setter.set(carrier, TRACE_ID_KEY, context.getTraceId().toHexString());
+        setter.set(carrier, SPAN_ID_KEY, context.getSpanId().toHexString());
 
         if (context.lockSamplingPriority()) {
           setter.set(
@@ -118,8 +119,8 @@ class B3HttpCodec {
         if (traceId != 0L) {
           final ExtractedContext context =
               new ExtractedContext(
-                  traceId,
-                  spanId,
+                  DDId.from(traceId),
+                  DDId.from(spanId),
                   samplingPriority,
                   null,
                   Collections.<String, String>emptyMap(),

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/DatadogHttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/DatadogHttpCodec.java
@@ -6,7 +6,6 @@ import static datadog.trace.core.propagation.HttpCodec.validateUInt64BitsID;
 import datadog.trace.api.sampling.PrioritySampling;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.core.DDSpanContext;
-import java.math.BigInteger;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -32,8 +31,8 @@ class DatadogHttpCodec {
     public <C> void inject(
         final DDSpanContext context, final C carrier, final AgentPropagation.Setter<C> setter) {
 
-      setter.set(carrier, TRACE_ID_KEY, context.getTraceId().toString());
-      setter.set(carrier, SPAN_ID_KEY, context.getSpanId().toString());
+      setter.set(carrier, TRACE_ID_KEY, String.valueOf(context.getTraceId()));
+      setter.set(carrier, SPAN_ID_KEY, String.valueOf(context.getSpanId()));
       if (context.lockSamplingPriority()) {
         setter.set(carrier, SAMPLING_PRIORITY_KEY, String.valueOf(context.getSamplingPriority()));
       }
@@ -64,8 +63,8 @@ class DatadogHttpCodec {
       try {
         Map<String, String> baggage = Collections.emptyMap();
         Map<String, String> tags = Collections.emptyMap();
-        BigInteger traceId = BigInteger.ZERO;
-        BigInteger spanId = BigInteger.ZERO;
+        long traceId = 0L;
+        long spanId = 0L;
         int samplingPriority = PrioritySampling.UNSET;
         String origin = null;
 
@@ -100,7 +99,7 @@ class DatadogHttpCodec {
           }
         }
 
-        if (!BigInteger.ZERO.equals(traceId)) {
+        if (traceId != 0L) {
           final ExtractedContext context =
               new ExtractedContext(traceId, spanId, samplingPriority, origin, baggage, tags);
           context.lockSamplingPriority();

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/DatadogHttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/DatadogHttpCodec.java
@@ -5,6 +5,7 @@ import static datadog.trace.core.propagation.HttpCodec.validateUInt64BitsID;
 
 import datadog.trace.api.sampling.PrioritySampling;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
+import datadog.trace.core.DDId;
 import datadog.trace.core.DDSpanContext;
 import java.util.Collections;
 import java.util.HashMap;
@@ -101,7 +102,7 @@ class DatadogHttpCodec {
 
         if (traceId != 0L) {
           final ExtractedContext context =
-              new ExtractedContext(traceId, spanId, samplingPriority, origin, baggage, tags);
+              new ExtractedContext(DDId.from(traceId), DDId.from(spanId), samplingPriority, origin, baggage, tags);
           context.lockSamplingPriority();
 
           log.debug("{} - Parent context extracted", context.getTraceId());

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ExtractedContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ExtractedContext.java
@@ -1,5 +1,6 @@
 package datadog.trace.core.propagation;
 
+import datadog.trace.core.DDId;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -7,15 +8,15 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * Propagated data resulting from calling tracer.extract with header data from an incoming request.
  */
 public class ExtractedContext extends TagContext {
-  private final long traceId;
-  private final long spanId;
+  private final DDId traceId;
+  private final DDId spanId;
   private final int samplingPriority;
   private final Map<String, String> baggage;
   private final AtomicBoolean samplingPriorityLocked = new AtomicBoolean(false);
 
   public ExtractedContext(
-      final long traceId,
-      final long spanId,
+      final DDId traceId,
+      final DDId spanId,
       final int samplingPriority,
       final String origin,
       final Map<String, String> baggage,
@@ -36,11 +37,11 @@ public class ExtractedContext extends TagContext {
     samplingPriorityLocked.set(true);
   }
 
-  public long getTraceId() {
+  public DDId getTraceId() {
     return traceId;
   }
 
-  public long getSpanId() {
+  public DDId getSpanId() {
     return spanId;
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ExtractedContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ExtractedContext.java
@@ -1,6 +1,5 @@
 package datadog.trace.core.propagation;
 
-import java.math.BigInteger;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -8,15 +7,15 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * Propagated data resulting from calling tracer.extract with header data from an incoming request.
  */
 public class ExtractedContext extends TagContext {
-  private final BigInteger traceId;
-  private final BigInteger spanId;
+  private final long traceId;
+  private final long spanId;
   private final int samplingPriority;
   private final Map<String, String> baggage;
   private final AtomicBoolean samplingPriorityLocked = new AtomicBoolean(false);
 
   public ExtractedContext(
-      final BigInteger traceId,
-      final BigInteger spanId,
+      final long traceId,
+      final long spanId,
       final int samplingPriority,
       final String origin,
       final Map<String, String> baggage,
@@ -37,11 +36,11 @@ public class ExtractedContext extends TagContext {
     samplingPriorityLocked.set(true);
   }
 
-  public BigInteger getTraceId() {
+  public long getTraceId() {
     return traceId;
   }
 
-  public BigInteger getSpanId() {
+  public long getSpanId() {
     return spanId;
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/HaystackHttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/HaystackHttpCodec.java
@@ -5,6 +5,7 @@ import static datadog.trace.core.propagation.HttpCodec.validateUInt64BitsID;
 
 import datadog.trace.api.sampling.PrioritySampling;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
+import datadog.trace.core.DDId;
 import datadog.trace.core.DDSpanContext;
 import java.util.Collections;
 import java.util.HashMap;
@@ -33,9 +34,9 @@ public class HaystackHttpCodec {
     @Override
     public <C> void inject(
         final DDSpanContext context, final C carrier, final AgentPropagation.Setter<C> setter) {
-      setter.set(carrier, TRACE_ID_KEY, String.valueOf(context.getTraceId()));
-      setter.set(carrier, SPAN_ID_KEY, String.valueOf(context.getSpanId()));
-      setter.set(carrier, PARENT_ID_KEY, String.valueOf(context.getParentId()));
+      setter.set(carrier, TRACE_ID_KEY, context.getTraceId().toString());
+      setter.set(carrier, SPAN_ID_KEY, context.getSpanId().toString());
+      setter.set(carrier, PARENT_ID_KEY, context.getParentId().toString());
 
       for (final Map.Entry<String, String> entry : context.baggageItems()) {
         setter.set(carrier, OT_BAGGAGE_PREFIX + entry.getKey(), HttpCodec.encode(entry.getValue()));
@@ -94,7 +95,7 @@ public class HaystackHttpCodec {
 
         if (traceId != 0L) {
           final ExtractedContext context =
-              new ExtractedContext(traceId, spanId, samplingPriority, origin, baggage, tags);
+              new ExtractedContext(DDId.from(traceId), DDId.from(spanId), samplingPriority, origin, baggage, tags);
           context.lockSamplingPriority();
 
           log.debug("{} - Parent context extracted", context.getTraceId());

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/HttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/HttpCodec.java
@@ -4,7 +4,6 @@ import datadog.trace.api.Config;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.core.CoreTracer;
 import datadog.trace.core.DDSpanContext;
-import datadog.trace.core.StringCachingBigInteger;
 import java.io.UnsupportedEncodingException;
 import java.math.BigInteger;
 import java.net.URLDecoder;
@@ -114,16 +113,15 @@ public class HttpCodec {
    * @throws IllegalArgumentException if value cannot be converted to integer or doesn't conform to
    *     required boundaries
    */
-  static BigInteger validateUInt64BitsID(final String value, final int radix)
+  static long validateUInt64BitsID(final String value, final int radix)
       throws IllegalArgumentException {
-    final BigInteger parsedValue = new StringCachingBigInteger(value, radix);
+    final BigInteger parsedValue = new BigInteger(value, radix);
     if (parsedValue.compareTo(CoreTracer.TRACE_ID_MIN) < 0
         || parsedValue.compareTo(CoreTracer.TRACE_ID_MAX) > 0) {
       throw new IllegalArgumentException(
           "ID out of range, must be between 0 and 2^64-1, got: " + value);
     }
-
-    return parsedValue;
+    return parsedValue.longValue();
   }
 
   /** URL encode value */

--- a/dd-trace-core/src/main/java/datadog/trace/core/serialization/FormatWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/serialization/FormatWriter.java
@@ -125,9 +125,9 @@ public abstract class FormatWriter<DEST> {
     /* 1  */ writeString(SERVICE, span.getServiceName(), destination);
     /* 2  */ writeString(NAME, span.getOperationName(), destination);
     /* 3  */ writeString(RESOURCE, span.getResourceName(), destination);
-    /* 4  */ writeBigInteger(TRACE_ID, span.getTraceId(), destination);
-    /* 5  */ writeBigInteger(SPAN_ID, span.getSpanId(), destination);
-    /* 6  */ writeBigInteger(PARENT_ID, span.getParentId(), destination);
+    /* 4  */ writeLong(TRACE_ID, span.getTraceId(), destination);
+    /* 5  */ writeLong(SPAN_ID, span.getSpanId(), destination);
+    /* 6  */ writeLong(PARENT_ID, span.getParentId(), destination);
     /* 7  */ writeLong(START, span.getStartTime(), destination);
     /* 8  */ writeLong(DURATION, span.getDurationNano(), destination);
     /* 9  */ writeTag(TYPE, span.getType(), destination);

--- a/dd-trace-core/src/main/java/datadog/trace/core/serialization/FormatWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/serialization/FormatWriter.java
@@ -125,9 +125,9 @@ public abstract class FormatWriter<DEST> {
     /* 1  */ writeString(SERVICE, span.getServiceName(), destination);
     /* 2  */ writeString(NAME, span.getOperationName(), destination);
     /* 3  */ writeString(RESOURCE, span.getResourceName(), destination);
-    /* 4  */ writeLong(TRACE_ID, span.getTraceId(), destination);
-    /* 5  */ writeLong(SPAN_ID, span.getSpanId(), destination);
-    /* 6  */ writeLong(PARENT_ID, span.getParentId(), destination);
+    /* 4  */ writeLong(TRACE_ID, span.getTraceId().toLong(), destination);
+    /* 5  */ writeLong(SPAN_ID, span.getSpanId().toLong(), destination);
+    /* 6  */ writeLong(PARENT_ID, span.getParentId().toLong(), destination);
     /* 7  */ writeLong(START, span.getStartTime(), destination);
     /* 8  */ writeLong(DURATION, span.getDurationNano(), destination);
     /* 9  */ writeTag(TYPE, span.getType(), destination);

--- a/dd-trace-core/src/test/groovy/datadog/trace/api/writer/DDAgentWriterTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/api/writer/DDAgentWriterTest.groovy
@@ -8,6 +8,7 @@ import datadog.trace.common.writer.ddagent.Monitor
 import datadog.trace.common.writer.ddagent.MsgPackStatefulSerializer
 import datadog.trace.common.writer.ddagent.TraceBuffer
 import datadog.trace.core.CoreTracer
+import datadog.trace.core.DDId
 import datadog.trace.core.DDSpan
 import datadog.trace.core.DDSpanContext
 import datadog.trace.core.PendingTrace
@@ -189,9 +190,9 @@ class DDAgentWriterTest extends DDSpecification {
 
     where:
     minimalContext = new DDSpanContext(
-      1G,
-      1G,
-      0G,
+      DDId.from(1),
+      DDId.from(1),
+      DDId.ZERO,
       "",
       "",
       "",
@@ -269,9 +270,9 @@ class DDAgentWriterTest extends DDSpecification {
 
   def createMinimalTrace() {
     def minimalContext = new DDSpanContext(
-      1L,
-      1L,
-      0L,
+      DDId.from(1),
+      DDId.from(1),
+      DDId.ZERO,
       "",
       "",
       "",

--- a/dd-trace-core/src/test/groovy/datadog/trace/api/writer/DDAgentWriterTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/api/writer/DDAgentWriterTest.groovy
@@ -269,9 +269,9 @@ class DDAgentWriterTest extends DDSpecification {
 
   def createMinimalTrace() {
     def minimalContext = new DDSpanContext(
-      1G,
-      1G,
-      0G,
+      1L,
+      1L,
+      0L,
       "",
       "",
       "",
@@ -284,7 +284,7 @@ class DDAgentWriterTest extends DDSpecification {
       Mock(PendingTrace),
       Mock(CoreTracer),
       [:])
-    def minimalSpan = new DDSpan(0, minimalContext)
+    def minimalSpan = DDSpan.create(0, minimalContext)
     def minimalTrace = [minimalSpan]
 
     return minimalTrace

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/CoreSpanBuilderTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/CoreSpanBuilderTest.groovy
@@ -156,7 +156,7 @@ class CoreSpanBuilderTest extends DDSpecification {
     1 * mockedContext.getSpanId() >> spanId
     _ * mockedContext.getServiceName() >> "foo"
     1 * mockedContext.getBaggageItems() >> [:]
-    1 * mockedContext.getTrace() >> PendingTrace.create(tracer, 1G)
+    1 * mockedContext.getTrace() >> PendingTrace.create(tracer, 1L)
 
     final String expectedName = "fakeName"
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/CoreSpanBuilderTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/CoreSpanBuilderTest.groovy
@@ -156,7 +156,7 @@ class CoreSpanBuilderTest extends DDSpecification {
     1 * mockedContext.getSpanId() >> spanId
     _ * mockedContext.getServiceName() >> "foo"
     1 * mockedContext.getBaggageItems() >> [:]
-    1 * mockedContext.getTrace() >> PendingTrace.create(tracer, 1L)
+    1 * mockedContext.getTrace() >> PendingTrace.create(tracer, DDId.from(1))
 
     final String expectedName = "fakeName"
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanSerializationTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanSerializationTest.groovy
@@ -28,9 +28,9 @@ class DDSpanSerializationTest extends DDSpecification {
       service  : "service",
       name     : "operation",
       resource : "operation",
-      trace_id : 1l,
-      span_id  : 2l,
-      parent_id: 0l,
+      trace_id : DDId.from(1),
+      span_id  : DDId.from(2),
+      parent_id: DDId.ZERO,
       start    : 100000,
       duration : 33000,
       type     : spanType,
@@ -48,9 +48,9 @@ class DDSpanSerializationTest extends DDSpecification {
     def tracer = CoreTracer.builder().writer(writer).build()
     final DDSpanContext context =
       new DDSpanContext(
-        1L,
-        2L,
-        0L,
+        DDId.from(1),
+        DDId.from(2),
+        DDId.ZERO,
         "service",
         "operation",
         null,
@@ -60,7 +60,7 @@ class DDSpanSerializationTest extends DDSpecification {
         false,
         spanType,
         ["k1": "v1"],
-        PendingTrace.create(tracer, 1L),
+        PendingTrace.create(tracer, DDId.from(1)),
         tracer,
         [:])
 
@@ -86,7 +86,7 @@ class DDSpanSerializationTest extends DDSpecification {
     def context = new DDSpanContext(
       value,
       value,
-      0L,
+      DDId.ZERO,
       "fakeService",
       "fakeOperation",
       "fakeResource",
@@ -96,7 +96,7 @@ class DDSpanSerializationTest extends DDSpecification {
       false,
       spanType,
       Collections.emptyMap(),
-      PendingTrace.create(tracer, 1L),
+      PendingTrace.create(tracer, DDId.from(1)),
       tracer,
       [:])
     def span = DDSpan.create(0, context)
@@ -125,10 +125,10 @@ class DDSpanSerializationTest extends DDSpecification {
 
     where:
     value                                           | spanType
-    0L                                              | null
-    1L                                              | "some-type"
-    8223372036854775807L                            | null
-    Long.MAX_VALUE - 1L                             | "some-type"
-    -1L                                             | "some-type"
+    DDId.ZERO                                       | null
+    DDId.from(1)                                    | "some-type"
+    DDId.from(8223372036854775807)                  | null
+    DDId.from(Long.MAX_VALUE - 1)                   | "some-type"
+    DDId.from(-1)                                   | "some-type"
   }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanSerializationTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanSerializationTest.groovy
@@ -48,9 +48,9 @@ class DDSpanSerializationTest extends DDSpecification {
     def tracer = CoreTracer.builder().writer(writer).build()
     final DDSpanContext context =
       new DDSpanContext(
-        1G,
-        2G,
-        0G,
+        1L,
+        2L,
+        0L,
         "service",
         "operation",
         null,
@@ -60,7 +60,7 @@ class DDSpanSerializationTest extends DDSpecification {
         false,
         spanType,
         ["k1": "v1"],
-        PendingTrace.create(tracer, 1G),
+        PendingTrace.create(tracer, 1L),
         tracer,
         [:])
 
@@ -86,7 +86,7 @@ class DDSpanSerializationTest extends DDSpecification {
     def context = new DDSpanContext(
       value,
       value,
-      0G,
+      0L,
       "fakeService",
       "fakeOperation",
       "fakeResource",
@@ -96,7 +96,7 @@ class DDSpanSerializationTest extends DDSpecification {
       false,
       spanType,
       Collections.emptyMap(),
-      PendingTrace.create(tracer, 1G),
+      PendingTrace.create(tracer, 1L),
       tracer,
       [:])
     def span = DDSpan.create(0, context)
@@ -125,11 +125,10 @@ class DDSpanSerializationTest extends DDSpecification {
 
     where:
     value                                           | spanType
-    0G                                              | null
-    1G                                              | "some-type"
-    8223372036854775807G                            | null
-    BigInteger.valueOf(Long.MAX_VALUE).subtract(1G) | "some-type"
-    BigInteger.valueOf(Long.MAX_VALUE).add(1G)      | null
-    2G.pow(64).subtract(1G)                         | "some-type"
+    0L                                              | null
+    1L                                              | "some-type"
+    8223372036854775807L                            | null
+    Long.MAX_VALUE - 1L                             | "some-type"
+    -1L                                             | "some-type"
   }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanTest.groovy
@@ -22,9 +22,9 @@ class DDSpanTest extends DDSpecification {
     setup:
     final DDSpanContext context =
       new DDSpanContext(
-        1L,
-        1L,
-        0L,
+        DDId.from(1),
+        DDId.from(1),
+        DDId.ZERO,
         "fakeService",
         "fakeOperation",
         "fakeResource",
@@ -34,7 +34,7 @@ class DDSpanTest extends DDSpecification {
         false,
         "fakeType",
         null,
-        PendingTrace.create(tracer, 1L),
+        PendingTrace.create(tracer, DDId.from(1)),
         tracer,
         [:])
 
@@ -204,7 +204,7 @@ class DDSpanTest extends DDSpecification {
     where:
     extractedContext                                         | _
     new TagContext("some-origin", [:])                       | _
-    new ExtractedContext(1L, 2L, 0, "some-origin", [:], [:]) | _
+    new ExtractedContext(DDId.from(1), DDId.from(2), 0, "some-origin", [:], [:]) | _
   }
 
   def "isRootSpan() in and not in the context of distributed tracing"() {
@@ -223,7 +223,7 @@ class DDSpanTest extends DDSpecification {
     where:
     extractedContext                                     | isTraceRootSpan
     null                                                 | true
-    new ExtractedContext(123L, 456L, 1, "789", [:], [:]) | false
+    new ExtractedContext(DDId.from(123), DDId.from(456), 1, "789", [:], [:]) | false
   }
 
   def "getApplicationRootSpan() in and not in the context of distributed tracing"() {

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanTest.groovy
@@ -22,9 +22,9 @@ class DDSpanTest extends DDSpecification {
     setup:
     final DDSpanContext context =
       new DDSpanContext(
-        1G,
-        1G,
-        0G,
+        1L,
+        1L,
+        0L,
         "fakeService",
         "fakeOperation",
         "fakeResource",
@@ -34,7 +34,7 @@ class DDSpanTest extends DDSpecification {
         false,
         "fakeType",
         null,
-        PendingTrace.create(tracer, 1G),
+        PendingTrace.create(tracer, 1L),
         tracer,
         [:])
 
@@ -204,7 +204,7 @@ class DDSpanTest extends DDSpecification {
     where:
     extractedContext                                         | _
     new TagContext("some-origin", [:])                       | _
-    new ExtractedContext(1G, 2G, 0, "some-origin", [:], [:]) | _
+    new ExtractedContext(1L, 2L, 0, "some-origin", [:], [:]) | _
   }
 
   def "isRootSpan() in and not in the context of distributed tracing"() {
@@ -223,7 +223,7 @@ class DDSpanTest extends DDSpecification {
     where:
     extractedContext                                     | isTraceRootSpan
     null                                                 | true
-    new ExtractedContext(123G, 456G, 1, "789", [:], [:]) | false
+    new ExtractedContext(123L, 456L, 1, "789", [:], [:]) | false
   }
 
   def "getApplicationRootSpan() in and not in the context of distributed tracing"() {
@@ -245,6 +245,6 @@ class DDSpanTest extends DDSpecification {
     where:
     extractedContext                                     | isTraceRootSpan
     null                                                 | true
-    new ExtractedContext(123G, 456G, 1, "789", [:], [:]) | false
+    new ExtractedContext(123L, 456L, 1, "789", [:], [:]) | false
   }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceTest.groovy
@@ -17,7 +17,7 @@ class PendingTraceTest extends DDSpecification {
   def writer = new ListWriter()
   def tracer = CoreTracer.builder().writer(writer).build()
 
-  long traceId = System.identityHashCode(this)
+  DDId traceId = DDId.from(System.identityHashCode(this))
 
   @Subject
   PendingTrace trace = PendingTrace.create(tracer, traceId)

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceTest.groovy
@@ -17,7 +17,7 @@ class PendingTraceTest extends DDSpecification {
   def writer = new ListWriter()
   def tracer = CoreTracer.builder().writer(writer).build()
 
-  BigInteger traceId = BigInteger.valueOf(System.identityHashCode(this))
+  long traceId = System.identityHashCode(this)
 
   @Subject
   PendingTrace trace = PendingTrace.create(tracer, traceId)

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/SpanFactory.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/SpanFactory.groovy
@@ -12,9 +12,9 @@ class SpanFactory {
     def currentThreadName = Thread.currentThread().getName()
     Thread.currentThread().setName(threadName)
     def context = new DDSpanContext(
-      1G,
-      1G,
-      0G,
+      1L,
+      1L,
+      0L,
       "fakeService",
       "fakeOperation",
       "fakeResource",
@@ -24,7 +24,7 @@ class SpanFactory {
       false,
       "fakeType",
       Collections.emptyMap(),
-      PendingTrace.create(tracer, 1G),
+      PendingTrace.create(tracer, 1L),
       tracer, [:])
     Thread.currentThread().setName(currentThreadName)
     return DDSpan.create(timestampMicro, context)
@@ -32,9 +32,9 @@ class SpanFactory {
 
   static DDSpan newSpanOf(CoreTracer tracer) {
     def context = new DDSpanContext(
-      1G,
-      1G,
-      0G,
+      1L,
+      1L,
+      0L,
       "fakeService",
       "fakeOperation",
       "fakeResource",
@@ -44,7 +44,7 @@ class SpanFactory {
       false,
       "fakeType",
       Collections.emptyMap(),
-      PendingTrace.create(tracer, 1G),
+      PendingTrace.create(tracer, 1L),
       tracer, [:])
     return DDSpan.create(1, context)
   }
@@ -52,8 +52,8 @@ class SpanFactory {
   static DDSpan newSpanOf(PendingTrace trace) {
     def context = new DDSpanContext(
       trace.traceId,
-      1G,
-      0G,
+      1L,
+      0L,
       "fakeService",
       "fakeOperation",
       "fakeResource",
@@ -72,9 +72,9 @@ class SpanFactory {
     def writer = new ListWriter()
     def tracer = CoreTracer.builder().writer(writer).build()
     def context = new DDSpanContext(
-      1G,
-      1G,
-      0G,
+      1L,
+      1L,
+      0L,
       serviceName,
       "fakeOperation",
       "fakeResource",
@@ -84,7 +84,7 @@ class SpanFactory {
       false,
       "fakeType",
       Collections.emptyMap(),
-      PendingTrace.create(tracer, 1G),
+      PendingTrace.create(tracer, 1L),
       tracer,
       [:])
     context.setTag("env", envName)

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/SpanFactory.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/SpanFactory.groovy
@@ -12,9 +12,9 @@ class SpanFactory {
     def currentThreadName = Thread.currentThread().getName()
     Thread.currentThread().setName(threadName)
     def context = new DDSpanContext(
-      1L,
-      1L,
-      0L,
+      DDId.from(1),
+      DDId.from(1),
+      DDId.ZERO,
       "fakeService",
       "fakeOperation",
       "fakeResource",
@@ -24,7 +24,7 @@ class SpanFactory {
       false,
       "fakeType",
       Collections.emptyMap(),
-      PendingTrace.create(tracer, 1L),
+      PendingTrace.create(tracer, DDId.from(1)),
       tracer, [:])
     Thread.currentThread().setName(currentThreadName)
     return DDSpan.create(timestampMicro, context)
@@ -32,9 +32,9 @@ class SpanFactory {
 
   static DDSpan newSpanOf(CoreTracer tracer) {
     def context = new DDSpanContext(
-      1L,
-      1L,
-      0L,
+      DDId.from(1),
+      DDId.from(1),
+      DDId.ZERO,
       "fakeService",
       "fakeOperation",
       "fakeResource",
@@ -44,7 +44,7 @@ class SpanFactory {
       false,
       "fakeType",
       Collections.emptyMap(),
-      PendingTrace.create(tracer, 1L),
+      PendingTrace.create(tracer, DDId.from(1)),
       tracer, [:])
     return DDSpan.create(1, context)
   }
@@ -52,8 +52,8 @@ class SpanFactory {
   static DDSpan newSpanOf(PendingTrace trace) {
     def context = new DDSpanContext(
       trace.traceId,
-      1L,
-      0L,
+      DDId.from(1),
+      DDId.ZERO,
       "fakeService",
       "fakeOperation",
       "fakeResource",
@@ -72,9 +72,9 @@ class SpanFactory {
     def writer = new ListWriter()
     def tracer = CoreTracer.builder().writer(writer).build()
     def context = new DDSpanContext(
-      1L,
-      1L,
-      0L,
+      DDId.from(1),
+      DDId.from(1),
+      DDId.ZERO,
       serviceName,
       "fakeOperation",
       "fakeResource",
@@ -84,7 +84,7 @@ class SpanFactory {
       false,
       "fakeType",
       Collections.emptyMap(),
-      PendingTrace.create(tracer, 1L),
+      PendingTrace.create(tracer, DDId.from(1)),
       tracer,
       [:])
     context.setTag("env", envName)

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/B3HttpExtractorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/B3HttpExtractorTest.groovy
@@ -28,8 +28,8 @@ class B3HttpExtractorTest extends DDSpecification {
     final ExtractedContext context = extractor.extract(headers, MapGetter.INSTANCE)
 
     then:
-    context.traceId == traceId
-    context.spanId == spanId
+    context.traceId == traceId.longValue()
+    context.spanId == spanId.longValue()
     context.baggage == [:]
     context.tags == ["some-tag": "my-interesting-info"]
     context.samplingPriority == expectedSamplingPriority
@@ -56,8 +56,8 @@ class B3HttpExtractorTest extends DDSpecification {
 
     then:
     if (expectedTraceId) {
-      assert context.traceId == expectedTraceId
-      assert context.spanId == expectedSpanId
+      assert context.traceId == expectedTraceId.longValue()
+      assert context.spanId == expectedSpanId.longValue()
     } else {
       assert context == null
     }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/B3HttpExtractorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/B3HttpExtractorTest.groovy
@@ -1,6 +1,7 @@
 package datadog.trace.core.propagation
 
 import datadog.trace.api.sampling.PrioritySampling
+import datadog.trace.core.DDId
 import datadog.trace.util.test.DDSpecification
 
 import static datadog.trace.core.CoreTracer.TRACE_ID_MAX
@@ -28,8 +29,8 @@ class B3HttpExtractorTest extends DDSpecification {
     final ExtractedContext context = extractor.extract(headers, MapGetter.INSTANCE)
 
     then:
-    context.traceId == traceId.longValue()
-    context.spanId == spanId.longValue()
+    context.traceId == DDId.from(traceId.longValue())
+    context.spanId == DDId.from(spanId.longValue())
     context.baggage == [:]
     context.tags == ["some-tag": "my-interesting-info"]
     context.samplingPriority == expectedSamplingPriority
@@ -56,8 +57,8 @@ class B3HttpExtractorTest extends DDSpecification {
 
     then:
     if (expectedTraceId) {
-      assert context.traceId == expectedTraceId.longValue()
-      assert context.spanId == expectedSpanId.longValue()
+      assert context.traceId == DDId.from(expectedTraceId.longValue())
+      assert context.spanId == DDId.from(expectedSpanId.longValue())
     } else {
       assert context == null
     }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/B3HttpInjectorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/B3HttpInjectorTest.groovy
@@ -3,6 +3,7 @@ package datadog.trace.core.propagation
 import datadog.trace.api.sampling.PrioritySampling
 import datadog.trace.common.writer.ListWriter
 import datadog.trace.core.CoreTracer
+import datadog.trace.core.DDId
 import datadog.trace.core.DDSpanContext
 import datadog.trace.core.PendingTrace
 import datadog.trace.util.test.DDSpecification
@@ -24,7 +25,7 @@ class B3HttpInjectorTest extends DDSpecification {
       new DDSpanContext(
         traceId,
         spanId,
-        0G,
+        DDId.ZERO,
         "fakeService",
         "fakeOperation",
         "fakeResource",

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/DatadogHttpExtractorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/DatadogHttpExtractorTest.groovy
@@ -36,8 +36,8 @@ class DatadogHttpExtractorTest extends DDSpecification {
     final ExtractedContext context = extractor.extract(headers, MapGetter.INSTANCE)
 
     then:
-    context.traceId == new BigInteger(traceId)
-    context.spanId == new BigInteger(spanId)
+    context.traceId == new BigInteger(traceId).longValue()
+    context.spanId == new BigInteger(spanId).longValue()
     context.baggage == ["k1": "v1", "k2": "v2"]
     context.tags == ["some-tag": "my-interesting-info"]
     context.samplingPriority == samplingPriority
@@ -137,8 +137,8 @@ class DatadogHttpExtractorTest extends DDSpecification {
 
     then:
     if (expectedTraceId) {
-      assert context.traceId == expectedTraceId
-      assert context.spanId == expectedSpanId
+      assert context.traceId == expectedTraceId.longValue()
+      assert context.spanId == expectedSpanId.longValue()
     } else {
       assert context == null
     }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/DatadogHttpExtractorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/DatadogHttpExtractorTest.groovy
@@ -1,6 +1,7 @@
 package datadog.trace.core.propagation
 
 import datadog.trace.api.sampling.PrioritySampling
+import datadog.trace.core.DDId
 import datadog.trace.util.test.DDSpecification
 
 import static datadog.trace.core.CoreTracer.TRACE_ID_MAX
@@ -36,8 +37,8 @@ class DatadogHttpExtractorTest extends DDSpecification {
     final ExtractedContext context = extractor.extract(headers, MapGetter.INSTANCE)
 
     then:
-    context.traceId == new BigInteger(traceId).longValue()
-    context.spanId == new BigInteger(spanId).longValue()
+    context.traceId == DDId.from(new BigInteger(traceId).longValue())
+    context.spanId == DDId.from(new BigInteger(spanId).longValue())
     context.baggage == ["k1": "v1", "k2": "v2"]
     context.tags == ["some-tag": "my-interesting-info"]
     context.samplingPriority == samplingPriority

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HaystackHttpExtractorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HaystackHttpExtractorTest.groovy
@@ -26,8 +26,8 @@ class HaystackHttpExtractorTest extends DDSpecification {
     final ExtractedContext context = extractor.extract(headers, MapGetter.INSTANCE)
 
     then:
-    context.traceId == new BigInteger(traceId)
-    context.spanId == new BigInteger(spanId)
+    context.traceId == new BigInteger(traceId).longValue()
+    context.spanId == new BigInteger(spanId).longValue()
     context.baggage == ["k1": "v1", "k2": "v2"]
     context.tags == ["some-tag": "my-interesting-info"]
     context.samplingPriority == samplingPriority
@@ -124,8 +124,8 @@ class HaystackHttpExtractorTest extends DDSpecification {
 
     then:
     if (expectedTraceId) {
-      assert context.traceId == expectedTraceId
-      assert context.spanId == expectedSpanId
+      assert context.traceId == expectedTraceId.longValue()
+      assert context.spanId == expectedSpanId.longValue()
     } else {
       assert context == null
     }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HaystackHttpExtractorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HaystackHttpExtractorTest.groovy
@@ -1,6 +1,7 @@
 package datadog.trace.core.propagation
 
 import datadog.trace.api.sampling.PrioritySampling
+import datadog.trace.core.DDId
 import datadog.trace.util.test.DDSpecification
 
 import static datadog.trace.core.CoreTracer.TRACE_ID_MAX
@@ -26,8 +27,8 @@ class HaystackHttpExtractorTest extends DDSpecification {
     final ExtractedContext context = extractor.extract(headers, MapGetter.INSTANCE)
 
     then:
-    context.traceId == new BigInteger(traceId).longValue()
-    context.spanId == new BigInteger(spanId).longValue()
+    context.traceId == DDId.from(new BigInteger(traceId).longValue())
+    context.spanId == DDId.from(new BigInteger(spanId).longValue())
     context.baggage == ["k1": "v1", "k2": "v2"]
     context.tags == ["some-tag": "my-interesting-info"]
     context.samplingPriority == samplingPriority
@@ -124,8 +125,8 @@ class HaystackHttpExtractorTest extends DDSpecification {
 
     then:
     if (expectedTraceId) {
-      assert context.traceId == expectedTraceId.longValue()
-      assert context.spanId == expectedSpanId.longValue()
+      assert context.traceId == DDId.from(expectedTraceId.longValue())
+      assert context.spanId == DDId.from(expectedSpanId.longValue())
     } else {
       assert context == null
     }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HttpInjectorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HttpInjectorTest.groovy
@@ -4,6 +4,7 @@ import datadog.trace.api.Config
 import datadog.trace.api.sampling.PrioritySampling
 import datadog.trace.common.writer.ListWriter
 import datadog.trace.core.CoreTracer
+import datadog.trace.core.DDId
 import datadog.trace.core.DDSpanContext
 import datadog.trace.core.PendingTrace
 import datadog.trace.util.test.DDSpecification
@@ -20,8 +21,8 @@ class HttpInjectorTest extends DDSpecification {
     }
     HttpCodec.Injector injector = HttpCodec.createInjector(config)
 
-    def traceId = 1L
-    def spanId = 2L
+    def traceId = DDId.from(1)
+    def spanId = DDId.from(2)
 
     def writer = new ListWriter()
     def tracer = CoreTracer.builder().writer(writer).build()
@@ -29,7 +30,7 @@ class HttpInjectorTest extends DDSpecification {
       new DDSpanContext(
         traceId,
         spanId,
-        0L,
+        DDId.ZERO,
         "fakeService",
         "fakeOperation",
         "fakeResource",
@@ -44,7 +45,7 @@ class HttpInjectorTest extends DDSpecification {
         false,
         "fakeType",
         null,
-        new PendingTrace(tracer, 1L),
+        new PendingTrace(tracer, DDId.from(1)),
         tracer,
         [:])
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HttpInjectorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HttpInjectorTest.groovy
@@ -20,8 +20,8 @@ class HttpInjectorTest extends DDSpecification {
     }
     HttpCodec.Injector injector = HttpCodec.createInjector(config)
 
-    def traceId = 1G
-    def spanId = 2G
+    def traceId = 1L
+    def spanId = 2L
 
     def writer = new ListWriter()
     def tracer = CoreTracer.builder().writer(writer).build()
@@ -29,7 +29,7 @@ class HttpInjectorTest extends DDSpecification {
       new DDSpanContext(
         traceId,
         spanId,
-        0G,
+        0L,
         "fakeService",
         "fakeOperation",
         "fakeResource",
@@ -44,7 +44,7 @@ class HttpInjectorTest extends DDSpecification {
         false,
         "fakeType",
         null,
-        new PendingTrace(tracer, 1G),
+        new PendingTrace(tracer, 1L),
         tracer,
         [:])
 

--- a/dd-trace-ot/src/main/java/datadog/opentracing/OTExtractedContext.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/OTExtractedContext.java
@@ -13,12 +13,12 @@ class OTExtractedContext extends OTTagContext {
 
   @Override
   public String toTraceId() {
-    return String.valueOf(extractedContext.getTraceId());
+    return extractedContext.getTraceId().toString();
   }
 
   @Override
   public String toSpanId() {
-    return String.valueOf(extractedContext.getSpanId());
+    return extractedContext.getSpanId().toString();
   }
 
   ExtractedContext getDelegate() {

--- a/dd-trace-ot/src/main/java/datadog/opentracing/OTExtractedContext.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/OTExtractedContext.java
@@ -13,12 +13,12 @@ class OTExtractedContext extends OTTagContext {
 
   @Override
   public String toTraceId() {
-    return extractedContext.getTraceId().toString();
+    return String.valueOf(extractedContext.getTraceId());
   }
 
   @Override
   public String toSpanId() {
-    return extractedContext.getSpanId().toString();
+    return String.valueOf(extractedContext.getSpanId());
   }
 
   ExtractedContext getDelegate() {

--- a/dd-trace-ot/src/main/java/datadog/opentracing/OTGenericContext.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/OTGenericContext.java
@@ -14,12 +14,12 @@ class OTGenericContext implements SpanContext {
 
   @Override
   public String toTraceId() {
-    return String.valueOf(delegate.getTraceId());
+    return delegate.getTraceId().toString();
   }
 
   @Override
   public String toSpanId() {
-    return String.valueOf(delegate.getSpanId());
+    return delegate.getSpanId().toString();
   }
 
   @Override

--- a/dd-trace-ot/src/main/java/datadog/opentracing/OTGenericContext.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/OTGenericContext.java
@@ -14,12 +14,12 @@ class OTGenericContext implements SpanContext {
 
   @Override
   public String toTraceId() {
-    return delegate.getTraceId().toString();
+    return String.valueOf(delegate.getTraceId());
   }
 
   @Override
   public String toSpanId() {
-    return delegate.getSpanId().toString();
+    return String.valueOf(delegate.getSpanId());
   }
 
   @Override


### PR DESCRIPTION
Hacked together this to measure it on the `petclinic` benchmark. Based on #1458. The instance size of a `DDId` is 32 bytes on HotSpot 64bit with COOPS.