### PR TITLE
Disable CI cache for muzzle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -214,20 +214,12 @@ jobs:
     steps:
       - checkout
 
-      - restore_cache:
-          keys:
-            # Rev the version when the cache gets too big
-            - dd-trace-java-muzzle-v1-{{ .Branch }}-{{ .Revision }}
-            - dd-trace-java-muzzle-v1-{{ .Branch }}
-            # - dd-trace-java-muzzle-v1-
+      # We are not running with a cache here because it gets very big and ends up taking more time
+      # restoring/saving than the actual increase in time it takes just downloading the artifacts each time.
 
       - run:
           name: Verify Muzzle
           command: SKIP_BUILDSCAN="true" GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx4G -Xms64M' -Ddatadog.forkedMaxHeapSize=4G -Ddatadog.forkedMinHeapSize=64M" ./gradlew muzzle --parallel --stacktrace --no-daemon --max-workers=16
-
-      - save_cache:
-          key: dd-trace-java-muzzle-v1-{{ .Branch }}-{{ .Revision }}
-          paths: ~/.gradle
 
 workflows:
   version: 2


### PR DESCRIPTION
It gets very big (5+ GB) and causes the job to take a long time just restoring and resaving the cache.