### PR TITLE
Register WeakMapProvider earlier in AgentInstaller

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/WeakMap.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/WeakMap.java
@@ -52,7 +52,7 @@ public interface WeakMap<K, V> {
 
       @Override
       public <K, V> WeakMap<K, V> get() {
-        log.warn("WeakMap.Supplier not registered. Returning a synchronized WeakHashMap.");
+        log.debug("WeakMap.Supplier not registered. Returning a synchronized WeakHashMap.");
         return new MapAdapter<>(Collections.synchronizedMap(new WeakHashMap<K, V>()));
       }
     }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
@@ -34,6 +34,11 @@ public class AgentInstaller {
     return INSTRUMENTATION;
   }
 
+  static {
+    // WeakMap is used by other classes below, so we need to register the provider first.
+    AgentTooling.registerWeakMapProvider();
+  }
+
   public static void installBytebuddyAgent(final Instrumentation inst) {
     if (Config.get().isTraceEnabled()) {
       installBytebuddyAgent(inst, false, new AgentBuilder.Listener[0]);

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentTooling.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentTooling.java
@@ -20,7 +20,7 @@ public class AgentTooling {
     registerWeakMapProvider();
   }
 
-  private static void registerWeakMapProvider() {
+  static void registerWeakMapProvider() {
     if (!WeakMap.Provider.isProviderRegistered()) {
       WeakMap.Provider.registerIfAbsent(new WeakMapSuppliers.WeakConcurrent());
       //    WeakMap.Provider.registerIfAbsent(new WeakMapSuppliers.WeakConcurrent.Inline());


### PR DESCRIPTION
Specifically it is used statically by `FieldBackedProvider` which was likely called before the `AgentTooling` class was initialized.