### PR TITLE
add time in queue

### DIFF
--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaDecorator.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaDecorator.java
@@ -1,5 +1,7 @@
 package datadog.trace.instrumentation.kafka_clients;
 
+import java.util.concurrent.TimeUnit;
+
 import datadog.trace.api.DDSpanTypes;
 import datadog.trace.api.DDTags;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
@@ -59,6 +61,10 @@ public abstract class KafkaDecorator extends ClientDecorator {
       span.setTag(DDTags.RESOURCE_NAME, "Consume Topic " + topic);
       span.setTag("partition", record.partition());
       span.setTag("offset", record.offset());
+
+      final long produceTime = record.timestamp();
+      final long consumeTime = TimeUnit.NANOSECONDS.toMillis(span.getLocalRootSpan().getStartTime());
+      span.setTag("record.time_in_queue_milliseconds", consumeTime - produceTime);
     }
   }
 
@@ -69,7 +75,6 @@ public abstract class KafkaDecorator extends ClientDecorator {
       if (record.partition() != null) {
         span.setTag("kafka.partition", record.partition());
       }
-
       span.setTag(DDTags.RESOURCE_NAME, "Produce Topic " + topic);
     }
   }

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaDecorator.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaDecorator.java
@@ -1,12 +1,16 @@
 package datadog.trace.instrumentation.kafka_clients;
 
-import java.util.concurrent.TimeUnit;
+import static datadog.trace.bootstrap.instrumentation.api.DDComponents.JAVA_KAFKA;
+import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.OFFSET;
+import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.PARTITION;
+import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.RECORD_QUEUE_TIME_MS;
 
 import datadog.trace.api.DDSpanTypes;
 import datadog.trace.api.DDTags;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.decorator.ClientDecorator;
+import java.util.concurrent.TimeUnit;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.producer.ProducerRecord;
 
@@ -49,7 +53,7 @@ public abstract class KafkaDecorator extends ClientDecorator {
 
   @Override
   protected String component() {
-    return "java-kafka";
+    return JAVA_KAFKA;
   }
 
   @Override
@@ -59,12 +63,11 @@ public abstract class KafkaDecorator extends ClientDecorator {
     if (record != null) {
       final String topic = record.topic() == null ? "kafka" : record.topic();
       span.setTag(DDTags.RESOURCE_NAME, "Consume Topic " + topic);
-      span.setTag("partition", record.partition());
-      span.setTag("offset", record.offset());
-
+      span.setTag(PARTITION, record.partition());
+      span.setTag(OFFSET, record.offset());
       final long produceTime = record.timestamp();
-      final long consumeTime = TimeUnit.NANOSECONDS.toMillis(span.getLocalRootSpan().getStartTime());
-      span.setTag("record.time_in_queue_milliseconds", consumeTime - produceTime);
+      final long consumeTime = TimeUnit.NANOSECONDS.toMillis(span.getStartTime());
+      span.setTag(RECORD_QUEUE_TIME_MS, Math.max(0L, consumeTime - produceTime));
     }
   }
 
@@ -73,7 +76,7 @@ public abstract class KafkaDecorator extends ClientDecorator {
 
       final String topic = record.topic() == null ? "kafka" : record.topic();
       if (record.partition() != null) {
-        span.setTag("kafka.partition", record.partition());
+        span.setTag(PARTITION, record.partition());
       }
       span.setTag(DDTags.RESOURCE_NAME, "Produce Topic " + topic);
     }

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTest.groovy
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTest.groovy
@@ -1,5 +1,6 @@
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.Config
+import datadog.trace.bootstrap.instrumentation.api.InstrumentationTags
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.clients.consumer.ConsumerRecord
@@ -111,8 +112,9 @@ class KafkaClientTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT" "java-kafka"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
-            "partition" { it >= 0 }
-            "offset" 0
+            "$InstrumentationTags.PARTITION" { it >= 0 }
+            "$InstrumentationTags.OFFSET" 0
+            "$InstrumentationTags.RECORD_QUEUE_TIME_MS" {it >= 0 }
             defaultTags(true)
           }
         }
@@ -177,7 +179,7 @@ class KafkaClientTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT" "java-kafka"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_PRODUCER
-            "kafka.partition" { it >= 0 }
+            "$InstrumentationTags.PARTITION" { it >= 0 }
             defaultTags(true)
           }
         }
@@ -194,8 +196,9 @@ class KafkaClientTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT" "java-kafka"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
-            "partition" { it >= 0 }
-            "offset" 0
+            "$InstrumentationTags.PARTITION" { it >= 0 }
+            "$InstrumentationTags.OFFSET" 0
+            "$InstrumentationTags.RECORD_QUEUE_TIME_MS" { it >= 0 }
             defaultTags(true)
           }
         }

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/src/test/groovy/KafkaStreamsTest.groovy
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/src/test/groovy/KafkaStreamsTest.groovy
@@ -1,4 +1,5 @@
 import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.bootstrap.instrumentation.api.InstrumentationTags
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.common.serialization.Serdes
@@ -152,8 +153,9 @@ class KafkaStreamsTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT" "java-kafka"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
-            "partition" { it >= 0 }
-            "offset" 0
+            "$InstrumentationTags.PARTITION" { it >= 0 }
+            "$InstrumentationTags.OFFSET" 0
+            "$InstrumentationTags.RECORD_QUEUE_TIME_MS" { it >= 0 }
             defaultTags(true)
           }
         }
@@ -188,8 +190,8 @@ class KafkaStreamsTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT" "java-kafka"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
-            "partition" { it >= 0 }
-            "offset" 0
+            "$InstrumentationTags.PARTITION" { it >= 0 }
+            "$InstrumentationTags.OFFSET" 0
             "asdf" "testing"
             defaultTags(true)
           }
@@ -207,8 +209,9 @@ class KafkaStreamsTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT" "java-kafka"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
-            "partition" { it >= 0 }
-            "offset" 0
+            "$InstrumentationTags.PARTITION" { it >= 0 }
+            "$InstrumentationTags.OFFSET" 0
+            "$InstrumentationTags.RECORD_QUEUE_TIME_MS" { it >= 0 }
             "testing" 123
             defaultTags(true)
           }

--- a/dd-trace-core/src/main/java/datadog/trace/core/StringTables.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/StringTables.java
@@ -5,6 +5,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import datadog.trace.api.DDSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.DDComponents;
 import datadog.trace.bootstrap.instrumentation.api.DDSpanNames;
+import datadog.trace.bootstrap.instrumentation.api.InstrumentationTags;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
@@ -35,6 +36,7 @@ public class StringTables {
   static {
     internConstantsUTF8(StringTables.class);
     internConstantsUTF8(Tags.class);
+    internConstantsUTF8(InstrumentationTags.class);
     internConstantsUTF8(DDSpanTypes.class);
     internConstantsUTF8(DDComponents.class);
     internConstantsUTF8(DDSpanNames.class);

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/InstrumentationTags.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/InstrumentationTags.java
@@ -1,0 +1,14 @@
+package datadog.trace.bootstrap.instrumentation.api;
+
+public class InstrumentationTags {
+
+  // this exists to make it easy to intern UTF-8 encoding
+  // of tag/metric keys used in instrumentations. It should
+  // stay reasonably small. TODO when/if this gets large
+  // start looking at generating constants based on the
+  // enabled instrumentations.
+
+  public static final String PARTITION = "partition";
+  public static final String OFFSET = "offset";
+  public static final String RECORD_QUEUE_TIME_MS = "record.queue_time_ms";
+}


### PR DESCRIPTION
Adds visibility on how long transactions spend in a kafka queue
submits the time difference between the start of the consumer span and the record's [timestamp](https://github.com/a0x8o/kafka/blob/master/clients/src/main/java/org/apache/kafka/common/record/TimestampType.java) to generate an estimation of time spent in queue