### PR TITLE
Add a context event type support for MLT sampler JFR recording

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/mlt/SamplerContext.java
+++ b/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/mlt/SamplerContext.java
@@ -1,0 +1,16 @@
+package com.datadog.profiling.mlt;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NonNull;
+
+/**
+ * A sampler trace per-thread context wrapper. For now the context is completely determined by the
+ * 'traceId' but it can be extended with more dimensions if necessary.
+ */
+@Builder
+public final class SamplerContext {
+  @Builder.Default @Getter @NonNull private Thread thread = Thread.currentThread();
+
+  @Getter @NonNull private String traceId;
+}

--- a/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/mlt/SamplerWriter.java
+++ b/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/mlt/SamplerWriter.java
@@ -17,15 +17,18 @@ import java.util.concurrent.atomic.AtomicReference;
  * stacktraces.
  */
 public final class SamplerWriter {
-  static final String EVENT_NAME = "datadog.SamplerEvent";
+  static final String CONTEXT_EVENT_NAME = "datadog.TraceContextEvent";
+  static final String SAMPLER_EVENT_NAME = "datadog.SamplerEvent";
 
   private final Type sampleEventType;
+  private final Type contextEventType;
   private final Recording recording;
   private final AtomicReference<Chunk> chunkWriter = new AtomicReference<>();
 
   public SamplerWriter() {
     this.recording = new Recording();
-    this.sampleEventType = recording.registerEventType(EVENT_NAME);
+    this.contextEventType = registerContextEventType();
+    this.sampleEventType = recording.registerEventType(SAMPLER_EVENT_NAME);
     this.chunkWriter.set(recording.newChunk());
   }
 
@@ -33,6 +36,22 @@ public final class SamplerWriter {
     byte[] data = chunkWriter.getAndSet(recording.newChunk()).finish();
 
     Files.write(target, data);
+  }
+
+  public void writeContextEvent(SamplerContext context) {
+    if (context == null) {
+      return;
+    }
+    chunkWriter
+        .get()
+        .writeEvent(
+            contextEventType.asValue(
+                builder -> {
+                  builder
+                      .putField("startTime", System.nanoTime())
+                      .putField("eventThread", getThread(context.getThread()))
+                      .putField("traceId", context.getTraceId());
+                }));
   }
 
   public void writeThreadSample(ThreadInfo threadInfo) {
@@ -50,6 +69,26 @@ public final class SamplerWriter {
                       .putField("eventThread", getThread(threadInfo))
                       .putField("stackTrace", getStackTrace(threadInfo));
                 }));
+  }
+
+  private Type registerContextEventType() {
+    return recording.registerEventType(
+        CONTEXT_EVENT_NAME,
+        builder -> {
+          builder.addField("traceId", Types.Builtin.STRING);
+        });
+  }
+
+  private TypedValue getThread(Thread thread) {
+    return recording
+        .getType(Types.JDK.THREAD)
+        .asValue(
+            builder -> {
+              builder
+                  .putField("javaName", thread.getName())
+                  .putField("osName", thread.getName())
+                  .putField("osThreadId", thread.getId());
+            });
   }
 
   private TypedValue getThread(ThreadInfo threadInfo) {


### PR DESCRIPTION
This simple patch adds the ability to write the 'context' event so we can track the current tracing context for each sampled thread.
The context is wrapped in its own type to make further evolution easier.