### PR TITLE
store numeric tags in the metrics map for serialization efficiency

### DIFF
--- a/dd-java-agent/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpServerInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpServerInstrumentationTest.groovy
@@ -55,7 +55,7 @@ abstract class AkkaHttpServerInstrumentationTest extends HttpServerTest<Object> 
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
-        "$Tags.HTTP_STATUS" "${Integer.toString(endpoint.status)}"
+        "$Tags.HTTP_STATUS" "$endpoint.status"
         if (endpoint.errored) {
           "error.msg" { it == null || it == EXCEPTION.body }
           "error.type" { it == null || it == Exception.name }

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpServerInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpServerInstrumentationTest.groovy
@@ -55,7 +55,7 @@ abstract class AkkaHttpServerInstrumentationTest extends HttpServerTest<Object> 
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
-        "$Tags.HTTP_STATUS" endpoint.status
+        "$Tags.HTTP_STATUS" "${Integer.toString(endpoint.status)}"
         if (endpoint.errored) {
           "error.msg" { it == null || it == EXCEPTION.body }
           "error.type" { it == null || it == Exception.name }

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test/groovy/AWS1ClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test/groovy/AWS1ClientTest.groovy
@@ -145,8 +145,7 @@ class AWS1ClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.HTTP_URL" "$server.address/"
             "$Tags.HTTP_METHOD" "$method"
-            "$Tags.HTTP_STATUS" 200
-            "$Tags.PEER_PORT" server.address.port
+            "$Tags.HTTP_STATUS" "200"
             "$Tags.PEER_HOSTNAME" "localhost"
             "aws.service" { it.contains(service) }
             "aws.endpoint" "$server.address"
@@ -156,6 +155,10 @@ class AWS1ClientTest extends AgentTestRunner {
               "$addedTag.key" "$addedTag.value"
             }
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" server.address.port
+            defaultMetrics()
           }
         }
         span(1) {
@@ -168,11 +171,14 @@ class AWS1ClientTest extends AgentTestRunner {
             "$Tags.COMPONENT" "apache-httpclient"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "localhost"
-            "$Tags.PEER_PORT" server.address.port
             "$Tags.HTTP_URL" "${server.address}${path}"
             "$Tags.HTTP_METHOD" "$method"
-            "$Tags.HTTP_STATUS" 200
+            "$Tags.HTTP_STATUS" "200"
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" server.address.port
+            defaultMetrics()
           }
         }
       }
@@ -243,7 +249,6 @@ class AWS1ClientTest extends AgentTestRunner {
             "$Tags.HTTP_URL" "http://localhost:${UNUSABLE_PORT}/"
             "$Tags.HTTP_METHOD" "$method"
             "$Tags.PEER_HOSTNAME" "localhost"
-            "$Tags.PEER_PORT" 61
             "aws.service" { it.contains(service) }
             "aws.endpoint" "http://localhost:${UNUSABLE_PORT}"
             "aws.operation" "${operation}Request"
@@ -253,6 +258,10 @@ class AWS1ClientTest extends AgentTestRunner {
             }
             errorTags SdkClientException, ~/Unable to execute HTTP request/
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" 61
+            defaultMetrics()
           }
         }
         span(1) {
@@ -265,11 +274,14 @@ class AWS1ClientTest extends AgentTestRunner {
             "$Tags.COMPONENT" "apache-httpclient"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "localhost"
-            "$Tags.PEER_PORT" UNUSABLE_PORT
             "$Tags.HTTP_URL" "http://localhost:${UNUSABLE_PORT}/$url"
             "$Tags.HTTP_METHOD" "$method"
             errorTags HttpHostConnectException, ~/Connection refused/
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" UNUSABLE_PORT
+            defaultMetrics()
           }
         }
       }
@@ -357,7 +369,6 @@ class AWS1ClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.HTTP_URL" "$server.address/"
             "$Tags.HTTP_METHOD" "GET"
-            "$Tags.PEER_PORT" server.address.port
             "$Tags.PEER_HOSTNAME" "localhost"
             "aws.service" "Amazon S3"
             "aws.endpoint" "$server.address"
@@ -371,6 +382,10 @@ class AWS1ClientTest extends AgentTestRunner {
             }
             defaultTags()
           }
+          metrics {
+            "$Tags.PEER_PORT" server.address.port
+            defaultMetrics()
+          }
         }
         (1..4).each {
           span(it) {
@@ -383,7 +398,6 @@ class AWS1ClientTest extends AgentTestRunner {
               "$Tags.COMPONENT" "apache-httpclient"
               "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
               "$Tags.PEER_HOSTNAME" "localhost"
-              "$Tags.PEER_PORT" server.address.port
               "$Tags.HTTP_URL" "$server.address/someBucket/someKey"
               "$Tags.HTTP_METHOD" "GET"
               try {
@@ -392,6 +406,10 @@ class AWS1ClientTest extends AgentTestRunner {
                 errorTags RequestAbortedException, "Request aborted"
               }
               defaultTags()
+            }
+            metrics {
+              "$Tags.PEER_PORT" server.address.port
+              defaultMetrics()
             }
           }
         }

--- a/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/test/groovy/Aws2ClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/test/groovy/Aws2ClientTest.groovy
@@ -84,10 +84,9 @@ class Aws2ClientTest extends AgentTestRunner {
             "$Tags.COMPONENT" "java-aws-sdk"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "localhost"
-            "$Tags.PEER_PORT" server.address.port
             "$Tags.HTTP_URL" "${server.address}${path}"
             "$Tags.HTTP_METHOD" "$method"
-            "$Tags.HTTP_STATUS" 200
+            "$Tags.HTTP_STATUS" "200"
             "aws.service" "$service"
             "aws.operation" "${operation}"
             "aws.agent" "java-aws-sdk"
@@ -105,6 +104,10 @@ class Aws2ClientTest extends AgentTestRunner {
             }
             defaultTags()
           }
+          metrics {
+            "$Tags.PEER_PORT" server.address.port
+            defaultMetrics()
+          }
         }
         span(1) {
           operationName "http.request"
@@ -116,11 +119,13 @@ class Aws2ClientTest extends AgentTestRunner {
             "$Tags.COMPONENT" "apache-httpclient"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "localhost"
-            "$Tags.PEER_PORT" server.address.port
             "$Tags.HTTP_URL" "${server.address}${path}"
             "$Tags.HTTP_METHOD" "$method"
-            "$Tags.HTTP_STATUS" 200
+            "$Tags.HTTP_STATUS" "200"
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" server.address.port
           }
         }
       }
@@ -201,10 +206,9 @@ class Aws2ClientTest extends AgentTestRunner {
             "$Tags.COMPONENT" "java-aws-sdk"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "localhost"
-            "$Tags.PEER_PORT" server.address.port
             "$Tags.HTTP_URL" "${server.address}${path}"
             "$Tags.HTTP_METHOD" "$method"
-            "$Tags.HTTP_STATUS" 200
+            "$Tags.HTTP_STATUS" "200"
             "aws.service" "$service"
             "aws.operation" "${operation}"
             "aws.agent" "java-aws-sdk"
@@ -222,6 +226,10 @@ class Aws2ClientTest extends AgentTestRunner {
             }
             defaultTags()
           }
+          metrics {
+            "$Tags.PEER_PORT" server.address.port
+            defaultMetrics()
+          }
         }
       }
       // TODO: this should be part of the same trace but netty instrumentation doesn't cooperate
@@ -237,11 +245,14 @@ class Aws2ClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "localhost"
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-            "$Tags.PEER_PORT" server.address.port
             "$Tags.HTTP_URL" "${server.address}${path}"
             "$Tags.HTTP_METHOD" "$method"
-            "$Tags.HTTP_STATUS" 200
+            "$Tags.HTTP_STATUS" "200"
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" server.address.port
+            defaultMetrics()
           }
         }
       }
@@ -322,7 +333,6 @@ class Aws2ClientTest extends AgentTestRunner {
             "$Tags.COMPONENT" "java-aws-sdk"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "localhost"
-            "$Tags.PEER_PORT" server.address.port
             "$Tags.HTTP_URL" "$server.address/somebucket/somekey"
             "$Tags.HTTP_METHOD" "GET"
             "aws.service" "S3"
@@ -331,6 +341,10 @@ class Aws2ClientTest extends AgentTestRunner {
             "aws.bucket.name" "somebucket"
             errorTags SdkClientException, "Unable to execute HTTP request: Read timed out"
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" server.address.port
+            defaultMetrics()
           }
         }
         (1..4).each {
@@ -344,11 +358,13 @@ class Aws2ClientTest extends AgentTestRunner {
               "$Tags.COMPONENT" "apache-httpclient"
               "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
               "$Tags.PEER_HOSTNAME" "localhost"
-              "$Tags.PEER_PORT" server.address.port
               "$Tags.HTTP_URL" "$server.address/somebucket/somekey"
               "$Tags.HTTP_METHOD" "GET"
               errorTags SocketTimeoutException, "Read timed out"
               defaultTags()
+            }
+            metrics {
+              "$Tags.PEER_PORT" server.address.port
             }
           }
         }

--- a/dd-java-agent/instrumentation/dropwizard/src/test/groovy/DropwizardTest.groovy
+++ b/dd-java-agent/instrumentation/dropwizard/src/test/groovy/DropwizardTest.groovy
@@ -112,7 +112,6 @@ class DropwizardTest extends HttpServerTest<DropwizardTestSupport> {
         "$Tags.COMPONENT" component
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
         "$Tags.PEER_HOST_IPV4" { it == null || it == "127.0.0.1" } // Optional
-        "$Tags.PEER_PORT" Integer
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
         "$Tags.HTTP_STATUS" "$endpoint.status"
@@ -126,6 +125,10 @@ class DropwizardTest extends HttpServerTest<DropwizardTestSupport> {
           "$DDTags.HTTP_QUERY" endpoint.query
         }
         defaultTags(true)
+      }
+      metrics {
+        "$Tags.PEER_PORT" Integer
+        defaultMetrics()
       }
     }
   }

--- a/dd-java-agent/instrumentation/dropwizard/src/test/groovy/DropwizardTest.groovy
+++ b/dd-java-agent/instrumentation/dropwizard/src/test/groovy/DropwizardTest.groovy
@@ -115,7 +115,7 @@ class DropwizardTest extends HttpServerTest<DropwizardTestSupport> {
         "$Tags.PEER_PORT" Integer
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
-        "$Tags.HTTP_STATUS" endpoint.status
+        "$Tags.HTTP_STATUS" "${Integer.toString(endpoint.status)}"
         "span.origin.type" ServletHandler.CachedChain.name
         if (endpoint.errored) {
           "error.msg" { it == null || it == EXCEPTION.body }

--- a/dd-java-agent/instrumentation/dropwizard/src/test/groovy/DropwizardTest.groovy
+++ b/dd-java-agent/instrumentation/dropwizard/src/test/groovy/DropwizardTest.groovy
@@ -115,7 +115,7 @@ class DropwizardTest extends HttpServerTest<DropwizardTestSupport> {
         "$Tags.PEER_PORT" Integer
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
-        "$Tags.HTTP_STATUS" "${Integer.toString(endpoint.status)}"
+        "$Tags.HTTP_STATUS" "$endpoint.status"
         "span.origin.type" ServletHandler.CachedChain.name
         if (endpoint.errored) {
           "error.msg" { it == null || it == EXCEPTION.body }

--- a/dd-java-agent/instrumentation/glassfish/src/test/groovy/GlassFishServerTest.groovy
+++ b/dd-java-agent/instrumentation/glassfish/src/test/groovy/GlassFishServerTest.groovy
@@ -105,7 +105,7 @@ class GlassFishServerTest extends HttpServerTest<GlassFish> {
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
         "$Tags.PEER_HOST_IPV4" { it == null || it == "127.0.0.1" } // Optional
         "$Tags.PEER_PORT" Integer
-        "$Tags.HTTP_STATUS" "${Integer.toString(endpoint.status)}"
+        "$Tags.HTTP_STATUS" "$endpoint.status"
         "$Tags.HTTP_METHOD" method
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "servlet.context" "/$context"

--- a/dd-java-agent/instrumentation/glassfish/src/test/groovy/GlassFishServerTest.groovy
+++ b/dd-java-agent/instrumentation/glassfish/src/test/groovy/GlassFishServerTest.groovy
@@ -105,7 +105,7 @@ class GlassFishServerTest extends HttpServerTest<GlassFish> {
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
         "$Tags.PEER_HOST_IPV4" { it == null || it == "127.0.0.1" } // Optional
         "$Tags.PEER_PORT" Integer
-        "$Tags.HTTP_STATUS" endpoint.status
+        "$Tags.HTTP_STATUS" "${Integer.toString(endpoint.status)}"
         "$Tags.HTTP_METHOD" method
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "servlet.context" "/$context"

--- a/dd-java-agent/instrumentation/google-http-client/src/test/groovy/AbstractGoogleHttpClientTest.groovy
+++ b/dd-java-agent/instrumentation/google-http-client/src/test/groovy/AbstractGoogleHttpClientTest.groovy
@@ -67,12 +67,15 @@ abstract class AbstractGoogleHttpClientTest extends HttpClientTest {
             "$Tags.COMPONENT" "google-http-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "localhost"
-            "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_URL" String
             "$Tags.HTTP_METHOD" String
-            "$Tags.HTTP_STATUS" Integer
+            "$Tags.HTTP_STATUS" String
             "$DDTags.ERROR_MSG" "Server Error"
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" Integer
+            defaultMetrics()
           }
         }
       }

--- a/dd-java-agent/instrumentation/jetty-8/src/test/groovy/JettyHandlerTest.groovy
+++ b/dd-java-agent/instrumentation/jetty-8/src/test/groovy/JettyHandlerTest.groovy
@@ -142,7 +142,7 @@ class JettyHandlerTest extends HttpServerTest<Server> {
         "$Tags.PEER_PORT" Integer
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
-        "$Tags.HTTP_STATUS" "${Integer.toString(endpoint.status)}"
+        "$Tags.HTTP_STATUS" "$endpoint.status"
         "span.origin.type" handlerName
         if (endpoint.errored) {
           "error.msg" { it == null || it == EXCEPTION.body }

--- a/dd-java-agent/instrumentation/jetty-8/src/test/groovy/JettyHandlerTest.groovy
+++ b/dd-java-agent/instrumentation/jetty-8/src/test/groovy/JettyHandlerTest.groovy
@@ -142,7 +142,7 @@ class JettyHandlerTest extends HttpServerTest<Server> {
         "$Tags.PEER_PORT" Integer
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
-        "$Tags.HTTP_STATUS" endpoint.status
+        "$Tags.HTTP_STATUS" "${Integer.toString(endpoint.status)}"
         "span.origin.type" handlerName
         if (endpoint.errored) {
           "error.msg" { it == null || it == EXCEPTION.body }

--- a/dd-java-agent/instrumentation/play-2.6/src/test/groovy/server/PlayServerTest.groovy
+++ b/dd-java-agent/instrumentation/play-2.6/src/test/groovy/server/PlayServerTest.groovy
@@ -129,7 +129,7 @@ class PlayServerTest extends HttpServerTest<Server> {
       tags {
         "$Tags.COMPONENT" component
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
-        "$Tags.HTTP_STATUS" endpoint.status
+        "$Tags.HTTP_STATUS" "${Integer.toString(endpoint.status)}"
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
         if (endpoint.errored) {

--- a/dd-java-agent/instrumentation/play-2.6/src/test/groovy/server/PlayServerTest.groovy
+++ b/dd-java-agent/instrumentation/play-2.6/src/test/groovy/server/PlayServerTest.groovy
@@ -129,7 +129,7 @@ class PlayServerTest extends HttpServerTest<Server> {
       tags {
         "$Tags.COMPONENT" component
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
-        "$Tags.HTTP_STATUS" "${Integer.toString(endpoint.status)}"
+        "$Tags.HTTP_STATUS" "$endpoint.status"
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
         if (endpoint.errored) {

--- a/dd-java-agent/instrumentation/servlet/request-2/src/test/groovy/JettyServlet2Test.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-2/src/test/groovy/JettyServlet2Test.groovy
@@ -104,7 +104,7 @@ class JettyServlet2Test extends HttpServerTest<Server> {
         // No peer port
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
-        "$Tags.HTTP_STATUS" endpoint.status
+        "$Tags.HTTP_STATUS" "${Integer.toString(endpoint.status)}"
         "servlet.context" "/$CONTEXT"
         "servlet.path" endpoint.path
         "span.origin.type" TestServlet2.Sync.name

--- a/dd-java-agent/instrumentation/servlet/request-2/src/test/groovy/JettyServlet2Test.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-2/src/test/groovy/JettyServlet2Test.groovy
@@ -104,7 +104,7 @@ class JettyServlet2Test extends HttpServerTest<Server> {
         // No peer port
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
-        "$Tags.HTTP_STATUS" "${Integer.toString(endpoint.status)}"
+        "$Tags.HTTP_STATUS" "$endpoint.status"
         "servlet.context" "/$CONTEXT"
         "servlet.path" endpoint.path
         "span.origin.type" TestServlet2.Sync.name

--- a/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/AbstractServlet3Test.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/AbstractServlet3Test.groovy
@@ -91,7 +91,7 @@ abstract class AbstractServlet3Test<SERVER, CONTEXT> extends HttpServerTest<SERV
         "$Tags.PEER_PORT" Integer
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
-        "$Tags.HTTP_STATUS" endpoint.status
+        "$Tags.HTTP_STATUS" "${Integer.toString(endpoint.status)}"
         if (context) {
           "servlet.context" "/$context"
         }

--- a/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/AbstractServlet3Test.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/AbstractServlet3Test.groovy
@@ -91,7 +91,7 @@ abstract class AbstractServlet3Test<SERVER, CONTEXT> extends HttpServerTest<SERV
         "$Tags.PEER_PORT" Integer
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
-        "$Tags.HTTP_STATUS" "${Integer.toString(endpoint.status)}"
+        "$Tags.HTTP_STATUS" "$endpoint.status"
         if (context) {
           "servlet.context" "/$context"
         }

--- a/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/JettyServlet3Test.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/JettyServlet3Test.groovy
@@ -256,7 +256,7 @@ abstract class JettyDispatchTest extends JettyServlet3Test {
             "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
             "$Tags.HTTP_METHOD" "GET"
-            "$Tags.HTTP_STATUS" endpoint.status
+            "$Tags.HTTP_STATUS" "${Integer.toString(endpoint.status)}"
             "servlet.context" "/$context"
             "servlet.path" endpoint.status == 404 ? endpoint.path : "/dispatch$endpoint.path"
             "servlet.dispatch" endpoint.path

--- a/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/JettyServlet3Test.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/JettyServlet3Test.groovy
@@ -256,7 +256,7 @@ abstract class JettyDispatchTest extends JettyServlet3Test {
             "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
             "$Tags.HTTP_METHOD" "GET"
-            "$Tags.HTTP_STATUS" "${Integer.toString(endpoint.status)}"
+            "$Tags.HTTP_STATUS" "$endpoint.status"
             "servlet.context" "/$context"
             "servlet.path" endpoint.status == 404 ? endpoint.path : "/dispatch$endpoint.path"
             "servlet.dispatch" endpoint.path

--- a/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/TomcatServlet3Test.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/TomcatServlet3Test.groovy
@@ -413,7 +413,7 @@ abstract class TomcatDispatchTest extends TomcatServlet3Test {
             "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
             "$Tags.HTTP_METHOD" "GET"
-            "$Tags.HTTP_STATUS" "${Integer.toString(endpoint.status)}"
+            "$Tags.HTTP_STATUS" "$endpoint.status"
             "servlet.context" "/$context"
             "servlet.path" endpoint.status == 404 ? endpoint.path : "/dispatch$endpoint.path"
             "servlet.dispatch" endpoint.path

--- a/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/TomcatServlet3Test.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/TomcatServlet3Test.groovy
@@ -413,7 +413,7 @@ abstract class TomcatDispatchTest extends TomcatServlet3Test {
             "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
             "$Tags.HTTP_METHOD" "GET"
-            "$Tags.HTTP_STATUS" endpoint.status
+            "$Tags.HTTP_STATUS" "${Integer.toString(endpoint.status)}"
             "servlet.context" "/$context"
             "servlet.path" endpoint.status == 404 ? endpoint.path : "/dispatch$endpoint.path"
             "servlet.dispatch" endpoint.path

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/boot/SpringBootBasedTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/boot/SpringBootBasedTest.groovy
@@ -152,7 +152,7 @@ class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext>
         "$Tags.PEER_PORT" Integer
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
-        "$Tags.HTTP_STATUS" endpoint.status
+        "$Tags.HTTP_STATUS" "${Integer.toString(endpoint.status)}"
         "span.origin.type" ApplicationFilterChain.name
         "servlet.path" endpoint.path
         if (endpoint.errored) {

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/boot/SpringBootBasedTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/boot/SpringBootBasedTest.groovy
@@ -152,7 +152,7 @@ class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext>
         "$Tags.PEER_PORT" Integer
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
-        "$Tags.HTTP_STATUS" "${Integer.toString(endpoint.status)}"
+        "$Tags.HTTP_STATUS" "$endpoint.status"
         "span.origin.type" ApplicationFilterChain.name
         "servlet.path" endpoint.path
         if (endpoint.errored) {

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/filter/ServletFilterTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/filter/ServletFilterTest.groovy
@@ -157,7 +157,7 @@ class ServletFilterTest extends HttpServerTest<ConfigurableApplicationContext> {
         "$Tags.PEER_PORT" Integer
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
-        "$Tags.HTTP_STATUS" endpoint.status
+        "$Tags.HTTP_STATUS" "${Integer.toString(endpoint.status)}"
         "span.origin.type" ApplicationFilterChain.name
         "servlet.path" endpoint.path
         if (endpoint.errored) {

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/filter/ServletFilterTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/filter/ServletFilterTest.groovy
@@ -157,7 +157,7 @@ class ServletFilterTest extends HttpServerTest<ConfigurableApplicationContext> {
         "$Tags.PEER_PORT" Integer
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
-        "$Tags.HTTP_STATUS" "${Integer.toString(endpoint.status)}"
+        "$Tags.HTTP_STATUS" "$endpoint.status"
         "span.origin.type" ApplicationFilterChain.name
         "servlet.path" endpoint.path
         if (endpoint.errored) {

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/MetricsAssert.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/MetricsAssert.groovy
@@ -1,0 +1,63 @@
+package datadog.trace.agent.test.asserts
+
+import datadog.trace.core.DDSpan
+import groovy.transform.stc.ClosureParams
+import groovy.transform.stc.SimpleType
+
+class MetricsAssert {
+  private final BigInteger spanParentId
+  private final Map<String, Number> metrics
+  private final Set<String> assertedMetrics = new TreeSet<>()
+
+  private MetricsAssert(DDSpan span) {
+    this.spanParentId = span.parentId
+    this.metrics = span.metrics
+  }
+
+  static void assertMetrics(DDSpan span,
+                            @ClosureParams(value = SimpleType, options = ['datadog.trace.agent.test.asserts.MetricsAssert'])
+                            @DelegatesTo(value = MetricsAssert, strategy = Closure.DELEGATE_FIRST) Closure spec) {
+    def asserter = new MetricsAssert(span)
+    def clone = (Closure) spec.clone()
+    clone.delegate = asserter
+    clone.resolveStrategy = Closure.DELEGATE_FIRST
+    clone(asserter)
+    asserter.assertTagsAllVerified()
+  }
+
+  def defaultMetrics() {
+    assertedMetrics.add("_dd.agent_psr")
+    assertedMetrics.add("_sampling_priority_v1")
+  }
+
+  def methodMissing(String name, args) {
+    if (args.length == 0) {
+      throw new IllegalArgumentException(args.toString())
+    }
+    def value = args[0]
+    if (value instanceof Number) {
+      metric(name, (Number) value)
+    } else if (value instanceof Closure) {
+      assert ((Closure) value).call(metrics[name])
+    } else if (value instanceof Class) {
+      assert ((Class) value).isInstance(metrics[name])
+    }
+  }
+
+  def metric(String name, Number value) {
+    if (value == null) {
+      return
+    }
+    assertedMetrics.add(name)
+    assert metrics[name] == value
+  }
+
+  void assertTagsAllVerified() {
+    def set = new TreeMap<>(metrics).keySet()
+    set.removeAll(assertedMetrics)
+    // The primary goal is to ensure the set is empty.
+    // tags and assertedTags are included via an "always true" comparison
+    // so they provide better context in the error message.
+    assert metrics.entrySet() != assertedMetrics && set.isEmpty()
+  }
+}

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/MetricsAssert.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/MetricsAssert.groovy
@@ -22,7 +22,7 @@ class MetricsAssert {
     clone.delegate = asserter
     clone.resolveStrategy = Closure.DELEGATE_FIRST
     clone(asserter)
-    asserter.assertTagsAllVerified()
+    asserter.assertMetricsAllVerified()
   }
 
   def defaultMetrics() {
@@ -38,8 +38,10 @@ class MetricsAssert {
     if (value instanceof Number) {
       metric(name, (Number) value)
     } else if (value instanceof Closure) {
+      assertedMetrics.add(name)
       assert ((Closure) value).call(metrics[name])
     } else if (value instanceof Class) {
+      assertedMetrics.add(name)
       assert ((Class) value).isInstance(metrics[name])
     }
   }
@@ -52,7 +54,7 @@ class MetricsAssert {
     assert metrics[name] == value
   }
 
-  void assertTagsAllVerified() {
+  void assertMetricsAllVerified() {
     def set = new TreeMap<>(metrics).keySet()
     set.removeAll(assertedMetrics)
     // The primary goal is to ensure the set is empty.

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/SpanAssert.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/SpanAssert.groovy
@@ -7,6 +7,7 @@ import groovy.transform.stc.SimpleType
 import java.util.regex.Pattern
 
 import static TagsAssert.assertTags
+import static datadog.trace.agent.test.asserts.MetricsAssert.assertMetrics
 
 class SpanAssert {
   private final DDSpan span
@@ -117,5 +118,10 @@ class SpanAssert {
   void tags(@ClosureParams(value = SimpleType, options = ['datadog.trace.agent.test.asserts.TagsAssert'])
             @DelegatesTo(value = TagsAssert, strategy = Closure.DELEGATE_FIRST) Closure spec) {
     assertTags(span, spec)
+  }
+
+  void metrics(@ClosureParams(value = SimpleType, options = ['datadog.trace.agent.test.asserts.MetricsAssert'])
+               @DelegatesTo(value = MetricsAssert, strategy = Closure.DELEGATE_FIRST) Closure spec) {
+    assertMetrics(span, spec)
   }
 }

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
@@ -419,7 +419,6 @@ abstract class HttpClientTest extends AgentTestRunner {
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
         "$Tags.PEER_HOSTNAME" uri.host
         "$Tags.PEER_HOST_IPV4" { it == null || it == "127.0.0.1" } // Optional
-        "$Tags.PEER_PORT" uri.port > 0 ? uri.port : { it == null || it == 443 } // Optional
         "$Tags.HTTP_URL" "${uri.resolve(uri.path)}"
         "$Tags.HTTP_METHOD" method
         if (status) {
@@ -433,6 +432,10 @@ abstract class HttpClientTest extends AgentTestRunner {
           errorTags(exception.class, exception.message)
         }
         defaultTags()
+      }
+      metrics {
+        "$Tags.PEER_PORT" uri.port > 0 ? uri.port : { it == null || it == 443 } // Optional
+        defaultMetrics()
       }
     }
   }

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
@@ -423,7 +423,7 @@ abstract class HttpClientTest extends AgentTestRunner {
         "$Tags.HTTP_URL" "${uri.resolve(uri.path)}"
         "$Tags.HTTP_METHOD" method
         if (status) {
-          "$Tags.HTTP_STATUS" status
+          "$Tags.HTTP_STATUS" "${status.toString()}"
         }
         if (tagQueryString) {
           "$DDTags.HTTP_QUERY" uri.query

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
@@ -585,7 +585,7 @@ abstract class HttpServerTest<SERVER> extends AgentTestRunner {
         "$Tags.PEER_HOST_IPV4" { it == null || it == "127.0.0.1" } // Optional
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
-        "$Tags.HTTP_STATUS" endpoint.status
+        "$Tags.HTTP_STATUS" "${String.valueOf(endpoint.status)}"
         if (endpoint.query) {
           "$DDTags.HTTP_QUERY" endpoint.query
         }

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
@@ -581,7 +581,6 @@ abstract class HttpServerTest<SERVER> extends AgentTestRunner {
       tags {
         "$Tags.COMPONENT" component
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
-        "$Tags.PEER_PORT" Integer
         "$Tags.PEER_HOST_IPV4" { it == null || it == "127.0.0.1" } // Optional
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
@@ -594,6 +593,10 @@ abstract class HttpServerTest<SERVER> extends AgentTestRunner {
 //          "$DDTags.HTTP_FRAGMENT" endpoint.fragment
 //        }
         defaultTags(true)
+      }
+      metrics {
+        "$Tags.PEER_PORT" Integer
+        defaultMetrics()
       }
     }
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -175,25 +175,25 @@ public class DDSpan implements MutableSpan, AgentSpan {
 
   @Override
   public AgentSpan setTag(final String tag, final int value) {
-    context.setTag(tag, value);
+    context.setMetric(tag, value);
     return this;
   }
 
   @Override
   public AgentSpan setTag(final String tag, final long value) {
-    context.setTag(tag, value);
+    context.setMetric(tag, value);
     return this;
   }
 
   @Override
   public AgentSpan setTag(final String tag, final double value) {
-    context.setTag(tag, value);
+    context.setMetric(tag, value);
     return this;
   }
 
   @Override
   public DDSpan setTag(final String tag, final Number value) {
-    context.setTag(tag, value);
+    context.setMetric(tag, value);
     return this;
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/processor/rule/HttpStatusErrorRule.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/processor/rule/HttpStatusErrorRule.java
@@ -17,11 +17,14 @@ public class HttpStatusErrorRule implements TraceProcessor.Rule {
   @Override
   public void processSpan(
       final DDSpan span, final Map<String, Object> tags, final Collection<DDSpan> trace) {
-    final Object value = tags.get(Tags.HTTP_STATUS);
+    final Number value = span.getMetrics().remove(Tags.HTTP_STATUS);
+    if (value instanceof Integer) {
+      span.setTag(Tags.HTTP_STATUS, Integer.toString(value.intValue()));
+    }
+
     if (value != null && !span.context().getErrorFlag()) {
       try {
-        final int status =
-            value instanceof Integer ? (int) value : Integer.parseInt(value.toString());
+        final int status = value.intValue();
         if (DDSpanTypes.HTTP_SERVER.equals(span.getType())) {
           if (Config.get().getHttpServerErrorStatuses().contains(status)) {
             span.setError(true);

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/TraceInterceptorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/TraceInterceptorTest.groovy
@@ -136,16 +136,18 @@ class TraceInterceptorTest extends DDSpecification {
     span.context().getErrorFlag()
 
     def tags = span.context().tags
+    def metrics = span.context().metrics
 
     tags["boolean-tag"] == true
-    tags["number-tag"] == 5.0
+    metrics["number-tag"] == 5.0
     tags["string-tag"] == "howdy"
 
     tags["thread.name"] != null
     tags["thread.id"] != null
     tags["runtime-id"] != null
     tags["language"] != null
-    tags.size() == 7
+    tags.size() == 6
+    metrics.size() >= 1
   }
 
   def "register interceptor through bridge"() {

--- a/dd-trace-ot/src/main/java/datadog/opentracing/OTSpan.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/OTSpan.java
@@ -42,7 +42,8 @@ class OTSpan implements Span, MutableSpan {
 
   @Override
   public OTSpan setTag(final String key, final Number value) {
-    delegate.setTag(key, value);
+    // make sure this is not treated as a metric if the delegate is DDSpan
+    delegate.setTag(key, (Object) value);
     return this;
   }
 


### PR DESCRIPTION
Storing numeric tags in the metrics map has the a few benefits
* avoid allocation and CPU cost associated with UTF-8 encoding
* faster messagepack serialisation routines for numbers
* messagepack _packs_ most numbers, reducing payload size

There is one important exception: `http.status_code` which the agent assumes is a string, so must be found in `meta`.
