### PR TITLE
intern more common UTF-8 string encodings

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -344,3 +344,7 @@ acceptedBreaks:
       old: "method void datadog.trace.common.writer.ddagent.Monitor::onFlush(datadog.trace.common.writer.DDAgentWriter,\
         \ boolean)"
       justification: "refactor serialization pipeline"
+    com.datadoghq:dd-trace-ot:
+    - code: "java.method.removed"
+      old: "method byte[] datadog.trace.core.StringTables::getBytesUTF8(java.lang.String)"
+      justification: "internal api"

--- a/dd-trace-core/src/main/java/datadog/trace/core/StringTables.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/StringTables.java
@@ -3,6 +3,7 @@ package datadog.trace.core;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import datadog.trace.api.DDSpanTypes;
+import datadog.trace.bootstrap.instrumentation.api.CommonTagValues;
 import datadog.trace.bootstrap.instrumentation.api.DDComponents;
 import datadog.trace.bootstrap.instrumentation.api.DDSpanNames;
 import datadog.trace.bootstrap.instrumentation.api.InstrumentationTags;
@@ -31,28 +32,33 @@ public class StringTables {
   // intentionally not thread safe; must be maintained to be effectively immutable
   // if a constant registration API is added, should be ensured that this is only used during
   // startup
-  private static final Map<String, byte[]> UTF8_INTERN_TABLE = new HashMap<>(256);
+  private static final Map<String, byte[]> UTF8_INTERN_KEYS_TABLE = new HashMap<>(256);
+  private static final Map<String, byte[]> UTF8_INTERN_TAGS_TABLE = new HashMap<>(256);
 
   static {
-    internConstantsUTF8(StringTables.class);
-    internConstantsUTF8(Tags.class);
-    internConstantsUTF8(InstrumentationTags.class);
-    internConstantsUTF8(DDSpanTypes.class);
-    internConstantsUTF8(DDComponents.class);
-    internConstantsUTF8(DDSpanNames.class);
+    internConstantsUTF8(Tags.class, UTF8_INTERN_KEYS_TABLE);
+    internConstantsUTF8(InstrumentationTags.class, UTF8_INTERN_KEYS_TABLE);
+    internConstantsUTF8(DDSpanTypes.class, UTF8_INTERN_TAGS_TABLE);
+    internConstantsUTF8(DDComponents.class, UTF8_INTERN_TAGS_TABLE);
+    internConstantsUTF8(DDSpanNames.class, UTF8_INTERN_TAGS_TABLE);
+    internConstantsUTF8(CommonTagValues.class, UTF8_INTERN_TAGS_TABLE);
   }
 
-  public static byte[] getBytesUTF8(String value) {
-    return UTF8_INTERN_TABLE.get(value);
+  public static byte[] getKeyBytesUTF8(String value) {
+    return UTF8_INTERN_KEYS_TABLE.get(value);
   }
 
-  private static void internConstantsUTF8(Class<?> clazz) {
+  public static byte[] getTagBytesUTF8(String value) {
+    return UTF8_INTERN_TAGS_TABLE.get(value);
+  }
+
+  private static void internConstantsUTF8(Class<?> clazz, Map<String, byte[]> map) {
     for (Field field : clazz.getDeclaredFields()) {
       if (Modifier.isStatic(field.getModifiers())
           && Modifier.isPublic(field.getModifiers())
           && field.getType() == String.class) {
         try {
-          intern(UTF8_INTERN_TABLE, (String) field.get(null), UTF_8);
+          intern(map, (String) field.get(null), UTF_8);
         } catch (IllegalAccessException e) {
           // won't happen
         }

--- a/dd-trace-core/src/main/java/datadog/trace/core/serialization/FormatWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/serialization/FormatWriter.java
@@ -139,7 +139,7 @@ public abstract class FormatWriter<DEST> {
 
   private byte[] stringToBytes(final String string) {
     // won't reassign key or string in this method
-    final byte[] key = StringTables.getBytesUTF8(string);
+    final byte[] key = StringTables.getKeyBytesUTF8(string);
     return null == key ? string.getBytes(StandardCharsets.UTF_8) : key;
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/serialization/MsgpackFormatWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/serialization/MsgpackFormatWriter.java
@@ -45,7 +45,7 @@ public class MsgpackFormatWriter extends FormatWriter<MessagePacker> {
   public void writeTag(final byte[] key, final String value, final MessagePacker destination)
       throws IOException {
     writeKey(key, destination);
-    writeStringUTF8(value, destination);
+    writeUTF8Tag(value, destination);
   }
 
   @Override
@@ -102,12 +102,12 @@ public class MsgpackFormatWriter extends FormatWriter<MessagePacker> {
     }
   }
 
-  private static void writeStringUTF8(final String value, final MessagePacker destination)
+  private static void writeUTF8Tag(final String value, final MessagePacker destination)
       throws IOException {
     if (null == value) {
       destination.packNil();
     } else {
-      byte[] interned = StringTables.getBytesUTF8(value);
+      byte[] interned = StringTables.getTagBytesUTF8(value);
       if (null != interned) {
         destination.packRawStringHeader(interned.length);
         destination.addPayload(interned);

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/StringTablesTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/StringTablesTest.groovy
@@ -1,0 +1,44 @@
+package datadog.trace.core
+
+import spock.lang.Specification
+
+class StringTablesTest extends Specification {
+
+  def "naive string keys table strategy interns a small number of strings"() {
+    // when this starts failing, it's time to investigate better ways to precompute UTF-8 encodings
+    expect: StringTables.UTF8_INTERN_KEYS_TABLE.size() < 256
+  }
+
+  def "naive string tags table strategy interns a small number of strings"() {
+    // when this starts failing, it's time to investigate better ways to precompute UTF-8 encodings
+    expect: StringTables.UTF8_INTERN_TAGS_TABLE.size() < 256
+  }
+
+  def "naive string keys table strategy interns has low spatial overhead"() {
+    int approxSizeBytesIgnoringHashMapOverhead = 0
+    for (Map.Entry<String, byte[]> entry : StringTables.UTF8_INTERN_KEYS_TABLE.entrySet()) {
+      // include the string even though it's constant, because the strategy
+      // is naive enough to include everything we *could* need, some of these
+      // constants might not otherwise ever be loaded
+      approxSizeBytesIgnoringHashMapOverhead += entry.getKey().length()
+      approxSizeBytesIgnoringHashMapOverhead += entry.getValue().length
+    }
+    // less than 3KB memory overhead seems reasonable for reducing GBs of allocations
+    expect: approxSizeBytesIgnoringHashMapOverhead < 1024 * 3
+  }
+
+  def "naive string tags table strategy interns has low spatial overhead"() {
+    int approxSizeBytesIgnoringHashMapOverhead = 0
+    for (Map.Entry<String, byte[]> entry : StringTables.UTF8_INTERN_TAGS_TABLE.entrySet()) {
+      // include the string even though it's constant, because the strategy
+      // is naive enough to include everything we *could* need, some of these
+      // constants might not otherwise ever be loaded
+      approxSizeBytesIgnoringHashMapOverhead += entry.getKey().length()
+      approxSizeBytesIgnoringHashMapOverhead += entry.getValue().length
+    }
+    // less than 2KB memory overhead seems reasonable for reducing some allocation
+    // quite often, but we will often not find a value in this table so it's better
+    // this stays small
+    expect: approxSizeBytesIgnoringHashMapOverhead < 2 * 1024
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/CommonTagValues.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/CommonTagValues.java
@@ -1,0 +1,9 @@
+package datadog.trace.bootstrap.instrumentation.api;
+
+public class CommonTagValues {
+
+  public static final String GET = "GET";
+  public static final String PUT = "PUT";
+  public static final String POST = "POST";
+  public static final String DELETE = "DELETE";
+}

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/InstrumentationTags.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/InstrumentationTags.java
@@ -11,4 +11,69 @@ public class InstrumentationTags {
   public static final String PARTITION = "partition";
   public static final String OFFSET = "offset";
   public static final String RECORD_QUEUE_TIME_MS = "record.queue_time_ms";
+  public static final String AWS_AGENT = "aws.agent";
+  public static final String AWS_SERVICE = "aws.service";
+  public static final String BUCKET = "bucket";
+  public static final String COUCHBASE_OPERATION_ID = "couchbase.operation_id";
+  public static final String ELASTICSEARCH_REQUEST_INDICES = "elasticsearch.request.indices";
+  public static final String ELASTICSEARCH_REQUEST_SEARCH_TYPES =
+      "elasticsearch.request.search.types";
+  public static final String ELASTICSEARCH_REQUEST_WRITE_TYPE = "elasticsearch.request.write.type";
+  public static final String ELASTICSEARCH_REQUEST_WRITE_ROUTING =
+      "elasticsearch.request.write.routing";
+  public static final String ELASTICSEARCH_REQUEST_WRITE_VERSION =
+      "elasticsearch.request.write.version";
+  public static final String ELASTICSEARCH_TYPE = "elasticsearch.type";
+  public static final String ELASTICSEARCH_ID = "elasticsearch.id";
+  public static final String ELASTICSEARCH_VERSION = "elasticsearch.version";
+  public static final String ELASTICSEARCH_SHARD_BROADCAST_TOTAL =
+      "elasticsearch.shard.broadcast.total";
+  public static final String ELASTICSEARCH_SHARD_BROADCAST_SUCCESSFUL =
+      "elasticsearch.shard.broadcast.successful";
+  public static final String ELASTICSEARCH_SHARD_BROADCAST_FAILED =
+      "elasticsearch.shard.broadcast.failed";
+  public static final String ELASTICSEARCH_SHARD_BULK_ID = "elasticsearch.shard.bulk.id";
+  public static final String ELASTICSEARCH_SHARD_BULK_INDEX = "elasticsearch.shard.bulk.index";
+  public static final String ELASTICSEARCH_NODE_FAILURES = "elasticsearch.node.failures";
+  public static final String ELASTICSEARCH_NODE_CLUSTER_NAME = "elasticsearch.node.cluster.name";
+  public static final String ELASTICSEARCH_SHARD_REPLICATION_TOTAL =
+      "elasticsearch.shard.replication.total";
+  public static final String ELASTICSEARCH_SHARD_REPLICATION_FAILED =
+      "elasticsearch.shard.replication.failed";
+  public static final String ELASTICSEARCH_RESPONSE_STATUS = "elasticsearch.response.status";
+  public static final String STATUS_CODE = "status.code";
+  public static final String STATUS_DESCRIPTION = "status.description";
+  public static final String MESSAGE_TYPE = "message.type";
+  public static final String MESSAGE_SIZE = "message.size";
+  public static final String HYSTRIX_COMMAND = "hystrix.command";
+  public static final String HYSTRIX_CIRCUIT_OPEN = "hystrix.circuit-open";
+  public static final String HYSTRIX_GROUP = "hystrix.group";
+  public static final String SPAN_ORIGIN_TYPE = "span.origin.type";
+  public static final String SERVLET_CONTEXT = "servlet.context";
+  public static final String SERVLET_PATH = "servlet.path";
+  public static final String SERVLET_DISPATCH = "servlet.dispatch";
+  public static final String TIMEOUT = "timeout";
+  public static final String JMS_PRODUCE = "jms.produce";
+  public static final String JSP_COMPILER = "jsp.compiler";
+  public static final String JSP_CLASSFQCN = "jsp.classFQCN";
+  public static final String JSP_FORWARD_ORIGIN = "jsp.forwardOrigin";
+  public static final String DB_REDIS_DBINDEX = "db.redis.dbIndex";
+  public static final String DB_COMMAND_CANCELLED = "db.command.cancelled";
+  public static final String DB_COMMAND_RESULTS_COUNT = "db.command.results.count";
+  public static final String AMQP_DELIVERY_MODE = "amqp.delivery_mode";
+  public static final String AMQP_COMMAND = "amqp.command";
+  public static final String AMQP_EXCHANGE = "amqp.exchange";
+  public static final String AMQP_ROUTING_KEY = "amqp.routing_key";
+  public static final String AMQP_QUEUE = "amqp.queue";
+  public static final String EVENT = "event";
+  public static final String MESSAGE = "message";
+  public static final String HANDLER_TYPE = "handler.type";
+  public static final String REQUEST_PREDICATE = "request.predicate";
+  public static final String VIEW_NAME = "view.name";
+  public static final String VIEW_TYPE = "view.type";
+  public static final String TWILIO_TYPE = "twilio.type";
+  public static final String TWILIO_ACCOUNT = "twilio.account";
+  public static final String TWILIO_SID = "twilio.sid";
+  public static final String TWILIO_STATUS = "twilio.status";
+  public static final String TWILIO_PARENT_SID = "twilio.parentSid";
 }


### PR DESCRIPTION
Sorry to churn on this. Adds some more keys and a few common tag values. Splits the tables into keys and tags since we know we won't be looking for a tag when we're looking for a key's encoding. Adds a test so we can track how large the tables are, both in terms of number of elements, and in terms of size. Currently the naive strategy has tiny overhead, but if this test fails we can investigate more sophisticated strategies, tailoring what gets interned to the activated instrumentations.