### PR TITLE
Don't publish dd-trace-core

### DIFF
--- a/dd-trace-core/dd-trace-core.gradle
+++ b/dd-trace-core/dd-trace-core.gradle
@@ -1,7 +1,6 @@
 description = 'dd-trace-core'
 
 apply from: "${rootDir}/gradle/java.gradle"
-apply from: "${rootDir}/gradle/publish.gradle"
 
 minimumBranchCoverage = 0.5
 minimumInstructionCoverage = 0.6


### PR DESCRIPTION
dd-trace-core was being incorrectly published.  Its classes are in `dd-trace-ot`