### PR TITLE
specify maxDepth

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/util/JmxThreadStackProvider.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/util/JmxThreadStackProvider.java
@@ -11,7 +11,8 @@ public class JmxThreadStackProvider implements ThreadStackProvider {
 
   @Override
   public StackTraceElement[][] getStackTrace(long[] threadIds) {
-    ThreadInfo[] threadInfos = threadMXBean.getThreadInfo(threadIds, 128); // maxDepth?
+    // TODO maxDepth should be configurable
+    ThreadInfo[] threadInfos = threadMXBean.getThreadInfo(threadIds, 128);
     if (threadInfos.length == 0) {
       return ThreadStackProvider.EMPTY_STACKTRACE_ARRAY;
     }
@@ -24,7 +25,8 @@ public class JmxThreadStackProvider implements ThreadStackProvider {
 
   @Override
   public ThreadInfo[] getThreadInfo(long[] threadIds) {
-    ThreadInfo[] threadInfos = threadMXBean.getThreadInfo(threadIds, 128); // maxDepth?
+    // TODO maxDepth should be configurable
+    ThreadInfo[] threadInfos = threadMXBean.getThreadInfo(threadIds, 128);
     if (threadInfos.length == 0) {
       return ThreadStackProvider.EMPTY_THERADINFO_ARRAY;
     }

--- a/dd-trace-core/src/main/java/datadog/trace/core/util/JmxThreadStackProvider.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/util/JmxThreadStackProvider.java
@@ -11,7 +11,7 @@ public class JmxThreadStackProvider implements ThreadStackProvider {
 
   @Override
   public StackTraceElement[][] getStackTrace(long[] threadIds) {
-    ThreadInfo[] threadInfos = threadMXBean.getThreadInfo(threadIds); // maxDepth?
+    ThreadInfo[] threadInfos = threadMXBean.getThreadInfo(threadIds, 128); // maxDepth?
     if (threadInfos.length == 0) {
       return ThreadStackProvider.EMPTY_STACKTRACE_ARRAY;
     }
@@ -24,7 +24,7 @@ public class JmxThreadStackProvider implements ThreadStackProvider {
 
   @Override
   public ThreadInfo[] getThreadInfo(long[] threadIds) {
-    ThreadInfo[] threadInfos = threadMXBean.getThreadInfo(threadIds); // maxDepth?
+    ThreadInfo[] threadInfos = threadMXBean.getThreadInfo(threadIds, 128); // maxDepth?
     if (threadInfos.length == 0) {
       return ThreadStackProvider.EMPTY_THERADINFO_ARRAY;
     }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/util/ThreadStackAccessTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/util/ThreadStackAccessTest.groovy
@@ -32,7 +32,9 @@ class ThreadStackAccessTest extends DDSpecification {
     then:
     provider instanceof JmxThreadStackProvider
     stackTraces.length > 0
+    stackTraces[0].length > 0
     threadInfos.length > 0
+    threadInfos[0].getStackTrace().length > 0
 
     cleanup:
     ThreadStackAccess.disableJmx()


### PR DESCRIPTION
by default, getThreadInfo does not provide stacktraces