### PR TITLE
Allow traces to be reported if continuations are GC'd before activation.

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -478,7 +478,6 @@ public class CoreTracer
 
     public AgentSpan start() {
       final AgentSpan span = buildSpan();
-      log.debug("Starting a new span: {}", span);
       return span;
     }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -25,7 +25,8 @@ import lombok.extern.slf4j.Slf4j;
 public class DDSpan implements MutableSpan, AgentSpan {
 
   static DDSpan create(final long timestampMicro, final DDSpanContext context) {
-    DDSpan span = new DDSpan(timestampMicro, context);
+    final DDSpan span = new DDSpan(timestampMicro, context);
+    log.debug("Started span: {}", span);
     context.getTrace().registerSpan(span);
     return span;
   }
@@ -82,10 +83,10 @@ public class DDSpan implements MutableSpan, AgentSpan {
   private void finishAndAddToTrace(final long durationNano) {
     // ensure a min duration of 1
     if (this.durationNano.compareAndSet(0, Math.max(1, durationNano))) {
-      log.debug("Finished: {}", this);
+      log.debug("Finished span: {}", this);
       context.getTrace().addSpan(this);
     } else {
-      log.debug("{} - already finished!", this);
+      log.debug("Already finished: {}", this);
     }
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -285,6 +285,7 @@ public class DDSpan implements MutableSpan, AgentSpan {
     return context.getServiceName();
   }
 
+  @Override
   public BigInteger getTraceId() {
     return context.getTraceId();
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/PendingTrace.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/PendingTrace.java
@@ -44,9 +44,13 @@ public class PendingTrace extends ConcurrentLinkedDeque<DDSpan> implements Agent
   /** Nano second ticks value at trace start */
   private final long startNanoTicks;
 
-  private final ReferenceQueue referenceQueue = new ReferenceQueue();
-  private final Set<WeakReference<?>> weakReferences =
-      Collections.newSetFromMap(new ConcurrentHashMap<WeakReference<?>, Boolean>());
+  private final ReferenceQueue spanReferenceQueue = new ReferenceQueue();
+  private final Set<WeakReference<DDSpan>> weakSpans =
+      Collections.newSetFromMap(new ConcurrentHashMap<WeakReference<DDSpan>, Boolean>());
+  private final ReferenceQueue continuationReferenceQueue = new ReferenceQueue();
+  private final Set<WeakReference<AgentScope.Continuation>> weakContinuations =
+      Collections.newSetFromMap(
+          new ConcurrentHashMap<WeakReference<AgentScope.Continuation>, Boolean>());
 
   private final AtomicInteger pendingReferenceCount = new AtomicInteger(0);
 
@@ -105,20 +109,20 @@ public class PendingTrace extends ConcurrentLinkedDeque<DDSpan> implements Agent
       return;
     }
     if (!traceId.equals(span.context().getTraceId())) {
-      log.debug("{} - span registered for wrong trace ({})", span, traceId);
+      log.debug("t_id={} -> registered for wrong trace {}", traceId, span);
       return;
     }
     rootSpan.compareAndSet(null, new WeakReference<>(span));
     synchronized (span) {
       if (null == span.ref) {
-        span.ref = new WeakReference<DDSpan>(span, referenceQueue);
-        weakReferences.add(span.ref);
+        span.ref = new WeakReference<DDSpan>(span, spanReferenceQueue);
+        weakSpans.add(span.ref);
         final int count = pendingReferenceCount.incrementAndGet();
         if (log.isDebugEnabled()) {
-          log.debug("traceId: {} -- registered span {}. count = {}", traceId, span, count);
+          log.debug("t_id={} -> registered span {}. count = {}", traceId, span, count);
         }
       } else {
-        log.debug("span {} already registered in trace {}", span, traceId);
+        log.debug("t_id={} -> span already registered {}", traceId, span);
       }
     }
   }
@@ -130,14 +134,14 @@ public class PendingTrace extends ConcurrentLinkedDeque<DDSpan> implements Agent
       return;
     }
     if (!traceId.equals(span.context().getTraceId())) {
-      log.debug("{} - span expired for wrong trace ({})", span, traceId);
+      log.debug("t_id={} -> span expired for wrong trace {}", traceId, span);
       return;
     }
     synchronized (span) {
       if (null == span.ref) {
-        log.debug("span {} not registered in trace {}", span, traceId);
+        log.debug("t_id={} -> not registered in trace: {}", traceId, span);
       } else {
-        weakReferences.remove(span.ref);
+        weakSpans.remove(span.ref);
         span.ref.clear();
         span.ref = null;
         expireReference();
@@ -147,7 +151,7 @@ public class PendingTrace extends ConcurrentLinkedDeque<DDSpan> implements Agent
 
   public void addSpan(final DDSpan span) {
     if (span.getDurationNano() == 0) {
-      log.debug("{} - added to trace, but not complete.", span);
+      log.debug("t_id={} -> added to trace, but not complete: {}", traceId, span);
       return;
     }
     if (traceId == null || span.context() == null) {
@@ -156,14 +160,14 @@ public class PendingTrace extends ConcurrentLinkedDeque<DDSpan> implements Agent
       return;
     }
     if (!traceId.equals(span.getTraceId())) {
-      log.debug("{} - added to a mismatched trace.", span);
+      log.debug("t_id={} -> added to a mismatched trace: {}", traceId, span);
       return;
     }
 
     if (!isWritten.get()) {
       addFirst(span);
     } else {
-      log.debug("{} - finished after trace reported.", span);
+      log.debug("t_id={} -> finished after trace reported: {}", traceId, span);
     }
     expireSpan(span);
   }
@@ -181,7 +185,7 @@ public class PendingTrace extends ConcurrentLinkedDeque<DDSpan> implements Agent
   public void registerContinuation(final AgentScope.Continuation continuation) {
     synchronized (continuation) {
       if (!continuation.isRegistered()) {
-        weakReferences.add(continuation.register(referenceQueue));
+        weakContinuations.add(continuation.register(continuationReferenceQueue));
         final int count = pendingReferenceCount.incrementAndGet();
         if (log.isDebugEnabled()) {
           log.debug(
@@ -200,10 +204,10 @@ public class PendingTrace extends ConcurrentLinkedDeque<DDSpan> implements Agent
   public void cancelContinuation(final AgentScope.Continuation continuation) {
     synchronized (continuation) {
       if (continuation.isRegistered()) {
-        continuation.cancel(weakReferences);
+        continuation.cancel(weakContinuations);
         expireReference();
       } else {
-        log.debug("continuation {} not registered in trace {}", continuation, traceId);
+        log.debug("t_id={} -> not registered in trace: {}", traceId, continuation);
       }
     }
   }
@@ -233,7 +237,14 @@ public class PendingTrace extends ConcurrentLinkedDeque<DDSpan> implements Agent
         }
       }
     }
-    log.debug("traceId: {} -- Expired reference. count = {}", traceId, count);
+    if (log.isDebugEnabled()) {
+      log.debug(
+          "t_id={} -> Expired reference. count={} spans={} continuations={}",
+          traceId,
+          count,
+          weakSpans.size(),
+          weakContinuations.size());
+    }
   }
 
   private synchronized void write() {
@@ -249,8 +260,18 @@ public class PendingTrace extends ConcurrentLinkedDeque<DDSpan> implements Agent
   public synchronized boolean clean() {
     Reference ref;
     int count = 0;
-    while ((ref = referenceQueue.poll()) != null) {
-      weakReferences.remove(ref);
+    while ((ref = continuationReferenceQueue.poll()) != null) {
+      weakContinuations.remove(ref);
+      count++;
+      expireReference();
+    }
+    if (count > 0) {
+      log.debug("t_id={} -> {} unfinished continuations garbage collected.", traceId, count);
+    }
+
+    count = 0;
+    while ((ref = spanReferenceQueue.poll()) != null) {
+      weakSpans.remove(ref);
       if (isWritten.compareAndSet(false, true)) {
         removePendingTrace();
         // preserve throughput count.
@@ -263,7 +284,7 @@ public class PendingTrace extends ConcurrentLinkedDeque<DDSpan> implements Agent
     if (count > 0) {
       // TODO attempt to flatten and report if top level spans are finished. (for accurate metrics)
       log.debug(
-          "trace {} : {} unfinished spans garbage collected. Trace will not report.",
+          "t_id={} -> {} unfinished spans garbage collected. Trace will not be reported.",
           traceId,
           count);
     }

--- a/dd-trace-core/src/main/java/datadog/trace/core/PendingTrace.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/PendingTrace.java
@@ -189,10 +189,7 @@ public class PendingTrace extends ConcurrentLinkedDeque<DDSpan> implements Agent
         final int count = pendingReferenceCount.incrementAndGet();
         if (log.isDebugEnabled()) {
           log.debug(
-              "traceId: {} -- registered continuation {}. count = {}",
-              traceId,
-              continuation,
-              count);
+              "t_id={} -> registered continuation {} -- count = {}", traceId, continuation, count);
         }
       } else {
         log.debug("continuation {} already registered in trace {}", continuation, traceId);
@@ -239,7 +236,7 @@ public class PendingTrace extends ConcurrentLinkedDeque<DDSpan> implements Agent
     }
     if (log.isDebugEnabled()) {
       log.debug(
-          "t_id={} -> Expired reference. count={} spans={} continuations={}",
+          "t_id={} -> expired reference. count={} spans={} continuations={}",
           traceId,
           count,
           weakSpans.size(),

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
@@ -227,7 +227,7 @@ public class ContinuableScopeManager extends ScopeInterceptor.DelegatingIntercep
     }
 
     @Override
-    public void cancel(final Set<WeakReference<?>> weakReferences) {
+    public void cancel(final Set<WeakReference<AgentScope.Continuation>> weakReferences) {
       weakReferences.remove(ref);
       ref.clear();
       ref = null;

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
@@ -197,7 +197,7 @@ public class ContinuableScopeManager extends ScopeInterceptor.DelegatingIntercep
     public AgentScope activate() {
       if (used.compareAndSet(false, true)) {
         final AgentScope scope = handleSpan(this, spanUnderScope);
-        log.debug("Activating continuation {}, scope: {}", this, scope);
+        log.debug("t_id={} -> activating continuation {}", spanUnderScope.getTraceId(), this);
         return scope;
       } else {
         log.debug(
@@ -231,6 +231,15 @@ public class ContinuableScopeManager extends ScopeInterceptor.DelegatingIntercep
       weakReferences.remove(ref);
       ref.clear();
       ref = null;
+    }
+
+    @Override
+    public String toString() {
+      return getClass().getSimpleName()
+          + "@"
+          + Integer.toHexString(hashCode())
+          + "->"
+          + spanUnderScope;
     }
   }
 }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentScope.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentScope.java
@@ -20,6 +20,6 @@ public interface AgentScope extends TraceScope, Closeable {
 
     WeakReference<Continuation> register(ReferenceQueue referenceQueue);
 
-    void cancel(Set<WeakReference<?>> weakReferences);
+    void cancel(Set<WeakReference<AgentScope.Continuation>> weakReferences);
   }
 }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
@@ -1,8 +1,12 @@
 package datadog.trace.bootstrap.instrumentation.api;
 
 import datadog.trace.api.interceptor.MutableSpan;
+import java.math.BigInteger;
 
 public interface AgentSpan extends MutableSpan {
+
+  BigInteger getTraceId();
+
   @Override
   AgentSpan setTag(String key, boolean value);
 

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -6,6 +6,7 @@ import datadog.trace.bootstrap.instrumentation.api.AgentSpan.Context;
 import datadog.trace.context.TraceScope;
 import java.lang.ref.ReferenceQueue;
 import java.lang.ref.WeakReference;
+import java.math.BigInteger;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
@@ -144,6 +145,11 @@ public class AgentTracer {
 
   public static class NoopAgentSpan implements AgentSpan {
     public static final NoopAgentSpan INSTANCE = new NoopAgentSpan();
+
+    @Override
+    public BigInteger getTraceId() {
+      return BigInteger.ZERO;
+    }
 
     @Override
     public AgentSpan setTag(final String key, final boolean value) {

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -363,7 +363,7 @@ public class AgentTracer {
     }
 
     @Override
-    public void cancel(final Set<WeakReference<?>> weakReferences) {}
+    public void cancel(final Set<WeakReference<AgentScope.Continuation>> weakReferences) {}
   }
 
   public static class NoopContext implements Context {


### PR DESCRIPTION
Split up tracking between spans and continuations for better logging.
Restructure the logs for better consistency.