### PR TITLE
Use Retry.Mode.SETUP_FEATURE_CLEANUP to improve Elasticsearch test flakiness

### DIFF
--- a/dd-java-agent/instrumentation/elasticsearch/rest-5/src/latestDepTest/groovy/Elasticsearch6RestClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/rest-5/src/latestDepTest/groovy/Elasticsearch6RestClientTest.groovy
@@ -17,7 +17,7 @@ import org.elasticsearch.transport.Netty4Plugin
 import spock.lang.Retry
 import spock.lang.Shared
 
-@Retry(count = 3, delay = 1000)
+@Retry(count = 3, delay = 1000, mode = Retry.Mode.SETUP_FEATURE_CLEANUP)
 class Elasticsearch6RestClientTest extends AgentTestRunner {
   @Shared
   int httpPort

--- a/dd-java-agent/instrumentation/elasticsearch/rest-5/src/test/groovy/Elasticsearch5RestClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/rest-5/src/test/groovy/Elasticsearch5RestClientTest.groovy
@@ -20,7 +20,7 @@ import spock.lang.Shared
 
 import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
 
-@Retry(count = 3, delay = 1000)
+@Retry(count = 3, delay = 1000, mode = Retry.Mode.SETUP_FEATURE_CLEANUP)
 class Elasticsearch5RestClientTest extends AgentTestRunner {
   @Shared
   int httpPort

--- a/dd-java-agent/instrumentation/elasticsearch/rest-6.4/src/latestDepTest/groovy/Elasticsearch6RestClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/rest-6.4/src/latestDepTest/groovy/Elasticsearch6RestClientTest.groovy
@@ -20,7 +20,7 @@ import org.elasticsearch.transport.Netty4Plugin
 import spock.lang.Retry
 import spock.lang.Shared
 
-@Retry(count = 3, delay = 1000)
+@Retry(count = 3, delay = 1000, mode = Retry.Mode.SETUP_FEATURE_CLEANUP)
 class Elasticsearch6RestClientTest extends AgentTestRunner {
   @Shared
   int httpPort

--- a/dd-java-agent/instrumentation/elasticsearch/rest-6.4/src/test/groovy/Elasticsearch6RestClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/rest-6.4/src/test/groovy/Elasticsearch6RestClientTest.groovy
@@ -17,7 +17,7 @@ import org.elasticsearch.transport.Netty4Plugin
 import spock.lang.Retry
 import spock.lang.Shared
 
-@Retry(count = 3, delay = 1000)
+@Retry(count = 3, delay = 1000, mode = Retry.Mode.SETUP_FEATURE_CLEANUP)
 class Elasticsearch6RestClientTest extends AgentTestRunner {
   @Shared
   int httpPort

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/Elasticsearch2NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/Elasticsearch2NodeClientTest.groovy
@@ -13,7 +13,7 @@ import spock.lang.Shared
 
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 
-@Retry(count = 3, delay = 1000)
+@Retry(count = 3, delay = 1000, mode = Retry.Mode.SETUP_FEATURE_CLEANUP)
 class Elasticsearch2NodeClientTest extends AgentTestRunner {
   public static final long TIMEOUT = 10000; // 10 seconds
 

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/Elasticsearch2TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/Elasticsearch2TransportClientTest.groovy
@@ -16,7 +16,7 @@ import spock.lang.Shared
 
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 
-@Retry(count = 3, delay = 1000)
+@Retry(count = 3, delay = 1000, mode = Retry.Mode.SETUP_FEATURE_CLEANUP)
 class Elasticsearch2TransportClientTest extends AgentTestRunner {
   public static final long TIMEOUT = 10000; // 10 seconds
 

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/springdata/Elasticsearch2SpringRepositoryTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/springdata/Elasticsearch2SpringRepositoryTest.groovy
@@ -1,16 +1,17 @@
 package springdata
 
-import com.anotherchrisberry.spock.extensions.retry.RetryOnFailure
+
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.AnnotationConfigApplicationContext
+import spock.lang.Retry
 import spock.lang.Shared
 
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 
-@RetryOnFailure(times = 3, delaySeconds = 1)
+@Retry(count = 3, delay = 1000, mode = Retry.Mode.SETUP_FEATURE_CLEANUP)
 class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
   @Shared
   ApplicationContext applicationContext = new AnnotationConfigApplicationContext(Config)
@@ -19,6 +20,7 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
   DocRepository repo = applicationContext.getBean(DocRepository)
 
   def setup() {
+    repo.refresh()
     TEST_WRITER.clear()
     runUnderTrace("delete") {
       repo.deleteAll()

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
@@ -1,6 +1,6 @@
 package springdata
 
-import com.anotherchrisberry.spock.extensions.retry.RetryOnFailure
+
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
@@ -18,11 +18,12 @@ import org.springframework.data.elasticsearch.core.ResultsExtractor
 import org.springframework.data.elasticsearch.core.query.IndexQueryBuilder
 import org.springframework.data.elasticsearch.core.query.NativeSearchQuery
 import org.springframework.data.elasticsearch.core.query.NativeSearchQueryBuilder
+import spock.lang.Retry
 import spock.lang.Shared
 
 import java.util.concurrent.atomic.AtomicLong
 
-@RetryOnFailure(times = 3, delaySeconds = 1)
+@Retry(count = 3, delay = 1000, mode = Retry.Mode.SETUP_FEATURE_CLEANUP)
 class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
   public static final long TIMEOUT = 10000; // 10 seconds
 

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/Elasticsearch2NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/Elasticsearch2NodeClientTest.groovy
@@ -13,7 +13,7 @@ import spock.lang.Shared
 
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 
-@Retry(count = 3, delay = 1000)
+@Retry(count = 3, delay = 1000, mode = Retry.Mode.SETUP_FEATURE_CLEANUP)
 class Elasticsearch2NodeClientTest extends AgentTestRunner {
   public static final long TIMEOUT = 10000; // 10 seconds
 

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/Elasticsearch2TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/Elasticsearch2TransportClientTest.groovy
@@ -17,7 +17,7 @@ import spock.lang.Shared
 
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 
-@Retry(count = 3, delay = 1000)
+@Retry(count = 3, delay = 1000, mode = Retry.Mode.SETUP_FEATURE_CLEANUP)
 class Elasticsearch2TransportClientTest extends AgentTestRunner {
   public static final long TIMEOUT = 10000; // 10 seconds
 

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/springdata/Elasticsearch2SpringRepositoryTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/springdata/Elasticsearch2SpringRepositoryTest.groovy
@@ -1,16 +1,17 @@
 package springdata
 
-import com.anotherchrisberry.spock.extensions.retry.RetryOnFailure
+
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.AnnotationConfigApplicationContext
+import spock.lang.Retry
 import spock.lang.Shared
 
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 
-@RetryOnFailure(times = 3, delaySeconds = 1)
+@Retry(count = 3, delay = 1000, mode = Retry.Mode.SETUP_FEATURE_CLEANUP)
 class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
   @Shared
   ApplicationContext applicationContext = new AnnotationConfigApplicationContext(Config)
@@ -19,6 +20,7 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
   DocRepository repo = applicationContext.getBean(DocRepository)
 
   def setup() {
+    repo.refresh()
     TEST_WRITER.clear()
     runUnderTrace("delete") {
       repo.deleteAll()

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
@@ -1,6 +1,6 @@
 package springdata
 
-import com.anotherchrisberry.spock.extensions.retry.RetryOnFailure
+
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
@@ -18,11 +18,12 @@ import org.springframework.data.elasticsearch.core.ResultsExtractor
 import org.springframework.data.elasticsearch.core.query.IndexQueryBuilder
 import org.springframework.data.elasticsearch.core.query.NativeSearchQuery
 import org.springframework.data.elasticsearch.core.query.NativeSearchQueryBuilder
+import spock.lang.Retry
 import spock.lang.Shared
 
 import java.util.concurrent.atomic.AtomicLong
 
-@RetryOnFailure(times = 3, delaySeconds = 1)
+@Retry(count = 3, delay = 1000, mode = Retry.Mode.SETUP_FEATURE_CLEANUP)
 class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
   public static final long TIMEOUT = 10000; // 10 seconds
 

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/Elasticsearch53NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/Elasticsearch53NodeClientTest.groovy
@@ -16,7 +16,7 @@ import spock.lang.Shared
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
 
-@Retry(count = 3, delay = 1000)
+@Retry(count = 3, delay = 1000, mode = Retry.Mode.SETUP_FEATURE_CLEANUP)
 class Elasticsearch53NodeClientTest extends AgentTestRunner {
   public static final long TIMEOUT = 10000; // 10 seconds
 

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/Elasticsearch53TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/Elasticsearch53TransportClientTest.groovy
@@ -20,7 +20,7 @@ import spock.lang.Shared
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
 
-@Retry(count = 3, delay = 1000)
+@Retry(count = 3, delay = 1000, mode = Retry.Mode.SETUP_FEATURE_CLEANUP)
 class Elasticsearch53TransportClientTest extends AgentTestRunner {
   public static final long TIMEOUT = 10000; // 10 seconds
 

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/springdata/Elasticsearch53SpringRepositoryTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/springdata/Elasticsearch53SpringRepositoryTest.groovy
@@ -1,11 +1,11 @@
 package springdata
 
-import com.anotherchrisberry.spock.extensions.retry.RetryOnFailure
-import datadog.trace.core.DDSpan
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
+import datadog.trace.core.DDSpan
 import org.springframework.context.annotation.AnnotationConfigApplicationContext
+import spock.lang.Retry
 import spock.lang.Shared
 
 import java.lang.reflect.InvocationHandler
@@ -14,7 +14,7 @@ import java.lang.reflect.Proxy
 
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 
-@RetryOnFailure(times = 10, delaySeconds = 1)
+@Retry(count = 3, delay = 1000, mode = Retry.Mode.SETUP_FEATURE_CLEANUP)
 class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
   // Setting up appContext & repo with @Shared doesn't allow
   // spring-data instrumentation to applied.
@@ -48,6 +48,7 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
   }
 
   def setup() {
+    repo.refresh()
     TEST_WRITER.clear()
     runUnderTrace("delete") {
       repo.deleteAll()

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/springdata/Elasticsearch53SpringTemplateTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/springdata/Elasticsearch53SpringTemplateTest.groovy
@@ -1,6 +1,6 @@
 package springdata
 
-import com.anotherchrisberry.spock.extensions.retry.RetryOnFailure
+
 import com.google.common.collect.ImmutableSet
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.utils.PortUtils
@@ -21,6 +21,7 @@ import org.springframework.data.elasticsearch.core.ResultsExtractor
 import org.springframework.data.elasticsearch.core.query.IndexQueryBuilder
 import org.springframework.data.elasticsearch.core.query.NativeSearchQuery
 import org.springframework.data.elasticsearch.core.query.NativeSearchQueryBuilder
+import spock.lang.Retry
 import spock.lang.Shared
 
 import java.util.concurrent.atomic.AtomicLong
@@ -28,7 +29,7 @@ import java.util.concurrent.atomic.AtomicLong
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
 
-@RetryOnFailure(times = 3, delaySeconds = 1)
+@Retry(count = 3, delay = 1000, mode = Retry.Mode.SETUP_FEATURE_CLEANUP)
 class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
   public static final long TIMEOUT = 10000; // 10 seconds
 

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5/src/test/groovy/Elasticsearch5NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5/src/test/groovy/Elasticsearch5NodeClientTest.groovy
@@ -16,7 +16,7 @@ import spock.lang.Shared
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
 
-@Retry(count = 3, delay = 1000)
+@Retry(count = 3, delay = 1000, mode = Retry.Mode.SETUP_FEATURE_CLEANUP)
 class Elasticsearch5NodeClientTest extends AgentTestRunner {
   public static final long TIMEOUT = 10000; // 10 seconds
 

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5/src/test/groovy/Elasticsearch5TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5/src/test/groovy/Elasticsearch5TransportClientTest.groovy
@@ -20,7 +20,7 @@ import spock.lang.Shared
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
 
-@Retry(count = 3, delay = 1000)
+@Retry(count = 3, delay = 1000, mode = Retry.Mode.SETUP_FEATURE_CLEANUP)
 class Elasticsearch5TransportClientTest extends AgentTestRunner {
   public static final long TIMEOUT = 10000; // 10 seconds
 

--- a/dd-java-agent/instrumentation/elasticsearch/transport-6/src/test/groovy/Elasticsearch6NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-6/src/test/groovy/Elasticsearch6NodeClientTest.groovy
@@ -15,7 +15,7 @@ import spock.lang.Shared
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
 
-@Retry(count = 3, delay = 1000)
+@Retry(count = 3, delay = 1000, mode = Retry.Mode.SETUP_FEATURE_CLEANUP)
 class Elasticsearch6NodeClientTest extends AgentTestRunner {
   public static final long TIMEOUT = 10000; // 10 seconds
 

--- a/dd-java-agent/instrumentation/elasticsearch/transport-6/src/test/groovy/Elasticsearch6TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-6/src/test/groovy/Elasticsearch6TransportClientTest.groovy
@@ -19,7 +19,7 @@ import spock.lang.Shared
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
 
-@Retry(count = 3, delay = 1000)
+@Retry(count = 3, delay = 1000, mode = Retry.Mode.SETUP_FEATURE_CLEANUP)
 class Elasticsearch6TransportClientTest extends AgentTestRunner {
   public static final long TIMEOUT = 10000; // 10 seconds
 

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -141,7 +141,6 @@ dependencies {
   testCompile deps.groovy
   testCompile deps.testLogging
   testCompile group: 'info.solidsoft.spock', name: 'spock-global-unroll', version: '0.5.1'
-  testCompile group: 'com.anotherchrisberry', name: 'spock-retry', version: '0.6.4'
   testCompile group: 'com.github.stefanbirkner', name: 'system-rules', version: '1.19.0'
 }
 


### PR DESCRIPTION
I think this is primarily improved by the `Retry.Mode.SETUP_FEATURE_CLEANUP` change.  Previously it would not run `AgentTestRunner.beforeTest()` which resets the list of collected traces, so any spans generated in a failed run would mess up the results from the retry.