### PR TITLE
replace Set<Integer> with BitSet for HTTP statuses

### DIFF
--- a/dd-java-agent/instrumentation/finatra-2.9/src/main/java/datadog/trace/instrumentation/finatra/FinatraInstrumentation.java
+++ b/dd-java-agent/instrumentation/finatra-2.9/src/main/java/datadog/trace/instrumentation/finatra/FinatraInstrumentation.java
@@ -124,7 +124,7 @@ public class FinatraInstrumentation extends Instrumenter.Default {
     @Override
     public void onSuccess(final Response response) {
       // Don't use DECORATE.onResponse because this is the controller span
-      if (Config.get().getHttpServerErrorStatuses().contains(DECORATE.status(response))) {
+      if (Config.get().getHttpServerErrorStatuses().get(DECORATE.status(response))) {
         scope.span().setError(true);
       }
 

--- a/dd-trace-api/src/main/java/datadog/trace/api/Config.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/Config.java
@@ -15,9 +15,9 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.BitSet;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -174,9 +174,9 @@ public class Config {
 
   private static final boolean DEFAULT_PRIORITY_SAMPLING_ENABLED = true;
   private static final boolean DEFAULT_TRACE_RESOLVER_ENABLED = true;
-  private static final Set<Integer> DEFAULT_HTTP_SERVER_ERROR_STATUSES =
+  private static final BitSet DEFAULT_HTTP_SERVER_ERROR_STATUSES =
       parseIntegerRangeSet("500-599", "default");
-  private static final Set<Integer> DEFAULT_HTTP_CLIENT_ERROR_STATUSES =
+  private static final BitSet DEFAULT_HTTP_CLIENT_ERROR_STATUSES =
       parseIntegerRangeSet("400-499", "default");
   private static final boolean DEFAULT_HTTP_SERVER_TAG_QUERY_STRING = false;
   private static final boolean DEFAULT_HTTP_CLIENT_TAG_QUERY_STRING = false;
@@ -273,8 +273,8 @@ public class Config {
   private final Map<String, String> jmxTags;
   @Getter private final List<String> excludedClasses;
   @Getter private final Map<String, String> headerTags;
-  @Getter private final Set<Integer> httpServerErrorStatuses;
-  @Getter private final Set<Integer> httpClientErrorStatuses;
+  @Getter private final BitSet httpServerErrorStatuses;
+  @Getter private final BitSet httpClientErrorStatuses;
   @Getter private final boolean httpServerTagQueryString;
   @Getter private final boolean httpClientTagQueryString;
   @Getter private final boolean httpClientSplitByDomain;
@@ -1071,8 +1071,8 @@ public class Config {
     return result;
   }
 
-  private static Set<Integer> getIntegerRangeSettingFromEnvironment(
-      final String name, final Set<Integer> defaultValue) {
+  private static BitSet getIntegerRangeSettingFromEnvironment(
+      final String name, final BitSet defaultValue) {
     final String value = getSettingFromEnvironment(name, null);
     try {
       return value == null ? defaultValue : parseIntegerRangeSet(value, name);
@@ -1178,8 +1178,8 @@ public class Config {
     return null;
   }
 
-  private static Set<Integer> getPropertyIntegerRangeValue(
-      final Properties properties, final String name, final Set<Integer> defaultValue) {
+  private static BitSet getPropertyIntegerRangeValue(
+      final Properties properties, final String name, final BitSet defaultValue) {
     final String value = properties.getProperty(name);
     try {
       return value == null ? defaultValue : parseIntegerRangeSet(value, name);
@@ -1220,7 +1220,7 @@ public class Config {
   }
 
   @NonNull
-  private static Set<Integer> parseIntegerRangeSet(@NonNull String str, final String settingName)
+  private static BitSet parseIntegerRangeSet(@NonNull String str, final String settingName)
       throws NumberFormatException {
     str = str.replaceAll("\\s", "");
     if (!str.matches("\\d{3}(?:-\\d{3})?(?:,\\d{3}(?:-\\d{3})?)*")) {
@@ -1231,24 +1231,23 @@ public class Config {
       throw new NumberFormatException();
     }
 
+    final int lastSeparator = Math.max(str.lastIndexOf(','), str.lastIndexOf('-'));
+    final int maxValue = Integer.parseInt(str.substring(lastSeparator + 1));
+    final BitSet set = new BitSet(maxValue);
     final String[] tokens = str.split(",", -1);
-    final Set<Integer> set = new HashSet<>();
-
     for (final String token : tokens) {
-      final String[] range = token.split("-", -1);
-      if (range.length == 1) {
-        set.add(Integer.parseInt(range[0]));
-      } else if (range.length == 2) {
-        final int left = Integer.parseInt(range[0]);
-        final int right = Integer.parseInt(range[1]);
+      final int separator = token.indexOf('-');
+      if (separator == -1) {
+        set.set(Integer.parseInt(token));
+      } else if (separator > 0) {
+        final int left = Integer.parseInt(token.substring(0, separator));
+        final int right = Integer.parseInt(token.substring(separator + 1));
         final int min = Math.min(left, right);
         final int max = Math.max(left, right);
-        for (int i = min; i <= max; i++) {
-          set.add(i);
-        }
+        set.set(min, max + 1);
       }
     }
-    return Collections.unmodifiableSet(set);
+    return set;
   }
 
   @NonNull

--- a/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -127,8 +127,8 @@ class ConfigTest extends DDSpecification {
     config.mergedSpanTags == [:]
     config.mergedJmxTags == [(RUNTIME_ID_TAG): config.getRuntimeId(), (SERVICE_TAG): config.serviceName]
     config.headerTags == [:]
-    config.httpServerErrorStatuses == (500..599).toSet()
-    config.httpClientErrorStatuses == (400..499).toSet()
+    config.httpServerErrorStatuses == toBitSet((500..599).toSet())
+    config.httpClientErrorStatuses == toBitSet((400..499).toSet())
     config.httpClientSplitByDomain == false
     config.dbClientSplitByInstance == false
     config.splitByTags == [].toSet()
@@ -252,8 +252,8 @@ class ConfigTest extends DDSpecification {
     config.mergedSpanTags == [b: "2", c: "3"]
     config.mergedJmxTags == [b: "2", d: "4", (RUNTIME_ID_TAG): config.getRuntimeId(), (SERVICE_TAG): config.serviceName]
     config.headerTags == [e: "5"]
-    config.httpServerErrorStatuses == (122..457).toSet()
-    config.httpClientErrorStatuses == (111..111).toSet()
+    config.httpServerErrorStatuses == toBitSet((122..457).toSet())
+    config.httpClientErrorStatuses == toBitSet((111..111).toSet())
     config.httpClientSplitByDomain == true
     config.dbClientSplitByInstance == true
     config.splitByTags == ["some.tag1", "some.tag2"].toSet()
@@ -372,8 +372,8 @@ class ConfigTest extends DDSpecification {
     config.mergedSpanTags == [b: "2", c: "3"]
     config.mergedJmxTags == [b: "2", d: "4", (RUNTIME_ID_TAG): config.getRuntimeId(), (SERVICE_TAG): config.serviceName]
     config.headerTags == [e: "5"]
-    config.httpServerErrorStatuses == (122..457).toSet()
-    config.httpClientErrorStatuses == (111..111).toSet()
+    config.httpServerErrorStatuses == toBitSet((122..457).toSet())
+    config.httpClientErrorStatuses == toBitSet((111..111).toSet())
     config.httpClientSplitByDomain == true
     config.dbClientSplitByInstance == true
     config.splitByTags == ["some.tag3", "some.tag2", "some.tag1"].toSet()
@@ -495,8 +495,8 @@ class ConfigTest extends DDSpecification {
     config.serviceMapping == [:]
     config.mergedSpanTags == [:]
     config.headerTags == [:]
-    config.httpServerErrorStatuses == (500..599).toSet()
-    config.httpClientErrorStatuses == (400..499).toSet()
+    config.httpServerErrorStatuses == toBitSet((500..599).toSet())
+    config.httpClientErrorStatuses == toBitSet((400..499).toSet())
     config.httpClientSplitByDomain == false
     config.dbClientSplitByInstance == false
     config.splitByTags == [].toSet()
@@ -592,8 +592,8 @@ class ConfigTest extends DDSpecification {
     config.mergedSpanTags == [b: "2", c: "3"]
     config.mergedJmxTags == [b: "2", d: "4", (RUNTIME_ID_TAG): config.getRuntimeId(), (SERVICE_TAG): config.serviceName]
     config.headerTags == [e: "5"]
-    config.httpServerErrorStatuses == (122..457).toSet()
-    config.httpClientErrorStatuses == (111..111).toSet()
+    config.httpServerErrorStatuses == toBitSet((122..457).toSet())
+    config.httpClientErrorStatuses == toBitSet((111..111).toSet())
     config.httpClientSplitByDomain == true
     config.dbClientSplitByInstance == true
     config.splitByTags == [].toSet()
@@ -859,10 +859,10 @@ class ConfigTest extends DDSpecification {
 
     then:
     if (expected) {
-      assert config.httpServerErrorStatuses == expected.toSet()
-      assert config.httpClientErrorStatuses == expected.toSet()
-      assert propConfig.httpServerErrorStatuses == expected.toSet()
-      assert propConfig.httpClientErrorStatuses == expected.toSet()
+      assert config.httpServerErrorStatuses == toBitSet(expected.toSet())
+      assert config.httpClientErrorStatuses == toBitSet(expected.toSet())
+      assert propConfig.httpServerErrorStatuses == toBitSet(expected.toSet())
+      assert propConfig.httpClientErrorStatuses == toBitSet(expected.toSet())
     } else {
       assert config.httpServerErrorStatuses == Config.DEFAULT_HTTP_SERVER_ERROR_STATUSES
       assert config.httpClientErrorStatuses == Config.DEFAULT_HTTP_CLIENT_ERROR_STATUSES
@@ -1574,5 +1574,13 @@ class ConfigTest extends DDSpecification {
     static ClassThrowsExceptionForValueOfMethod valueOf(String ignored) {
       throw new Throwable()
     }
+  }
+
+  static BitSet toBitSet(Set<Integer> set) {
+    BitSet bs = new BitSet()
+    for (Integer i : set) {
+      bs.set(i)
+    }
+    return bs
   }
 }

--- a/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -127,8 +127,8 @@ class ConfigTest extends DDSpecification {
     config.mergedSpanTags == [:]
     config.mergedJmxTags == [(RUNTIME_ID_TAG): config.getRuntimeId(), (SERVICE_TAG): config.serviceName]
     config.headerTags == [:]
-    config.httpServerErrorStatuses == toBitSet((500..599).toSet())
-    config.httpClientErrorStatuses == toBitSet((400..499).toSet())
+    config.httpServerErrorStatuses == toBitSet((500..599))
+    config.httpClientErrorStatuses == toBitSet((400..499))
     config.httpClientSplitByDomain == false
     config.dbClientSplitByInstance == false
     config.splitByTags == [].toSet()
@@ -252,8 +252,8 @@ class ConfigTest extends DDSpecification {
     config.mergedSpanTags == [b: "2", c: "3"]
     config.mergedJmxTags == [b: "2", d: "4", (RUNTIME_ID_TAG): config.getRuntimeId(), (SERVICE_TAG): config.serviceName]
     config.headerTags == [e: "5"]
-    config.httpServerErrorStatuses == toBitSet((122..457).toSet())
-    config.httpClientErrorStatuses == toBitSet((111..111).toSet())
+    config.httpServerErrorStatuses == toBitSet((122..457))
+    config.httpClientErrorStatuses == toBitSet((111..111))
     config.httpClientSplitByDomain == true
     config.dbClientSplitByInstance == true
     config.splitByTags == ["some.tag1", "some.tag2"].toSet()
@@ -372,8 +372,8 @@ class ConfigTest extends DDSpecification {
     config.mergedSpanTags == [b: "2", c: "3"]
     config.mergedJmxTags == [b: "2", d: "4", (RUNTIME_ID_TAG): config.getRuntimeId(), (SERVICE_TAG): config.serviceName]
     config.headerTags == [e: "5"]
-    config.httpServerErrorStatuses == toBitSet((122..457).toSet())
-    config.httpClientErrorStatuses == toBitSet((111..111).toSet())
+    config.httpServerErrorStatuses == toBitSet((122..457))
+    config.httpClientErrorStatuses == toBitSet((111..111))
     config.httpClientSplitByDomain == true
     config.dbClientSplitByInstance == true
     config.splitByTags == ["some.tag3", "some.tag2", "some.tag1"].toSet()
@@ -495,8 +495,8 @@ class ConfigTest extends DDSpecification {
     config.serviceMapping == [:]
     config.mergedSpanTags == [:]
     config.headerTags == [:]
-    config.httpServerErrorStatuses == toBitSet((500..599).toSet())
-    config.httpClientErrorStatuses == toBitSet((400..499).toSet())
+    config.httpServerErrorStatuses == toBitSet((500..599))
+    config.httpClientErrorStatuses == toBitSet((400..499))
     config.httpClientSplitByDomain == false
     config.dbClientSplitByInstance == false
     config.splitByTags == [].toSet()
@@ -592,8 +592,8 @@ class ConfigTest extends DDSpecification {
     config.mergedSpanTags == [b: "2", c: "3"]
     config.mergedJmxTags == [b: "2", d: "4", (RUNTIME_ID_TAG): config.getRuntimeId(), (SERVICE_TAG): config.serviceName]
     config.headerTags == [e: "5"]
-    config.httpServerErrorStatuses == toBitSet((122..457).toSet())
-    config.httpClientErrorStatuses == toBitSet((111..111).toSet())
+    config.httpServerErrorStatuses == toBitSet((122..457))
+    config.httpClientErrorStatuses == toBitSet((111..111))
     config.httpClientSplitByDomain == true
     config.dbClientSplitByInstance == true
     config.splitByTags == [].toSet()
@@ -859,10 +859,10 @@ class ConfigTest extends DDSpecification {
 
     then:
     if (expected) {
-      assert config.httpServerErrorStatuses == toBitSet(expected.toSet())
-      assert config.httpClientErrorStatuses == toBitSet(expected.toSet())
-      assert propConfig.httpServerErrorStatuses == toBitSet(expected.toSet())
-      assert propConfig.httpClientErrorStatuses == toBitSet(expected.toSet())
+      assert config.httpServerErrorStatuses == toBitSet(expected)
+      assert config.httpClientErrorStatuses == toBitSet(expected)
+      assert propConfig.httpServerErrorStatuses == toBitSet(expected)
+      assert propConfig.httpClientErrorStatuses == toBitSet(expected)
     } else {
       assert config.httpServerErrorStatuses == Config.DEFAULT_HTTP_SERVER_ERROR_STATUSES
       assert config.httpClientErrorStatuses == Config.DEFAULT_HTTP_CLIENT_ERROR_STATUSES
@@ -1576,7 +1576,7 @@ class ConfigTest extends DDSpecification {
     }
   }
 
-  static BitSet toBitSet(Set<Integer> set) {
+  static BitSet toBitSet(Collection<Integer> set) {
     BitSet bs = new BitSet()
     for (Integer i : set) {
       bs.set(i)

--- a/dd-trace-core/src/main/java/datadog/trace/core/processor/rule/HttpStatusErrorRule.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/processor/rule/HttpStatusErrorRule.java
@@ -23,11 +23,11 @@ public class HttpStatusErrorRule implements TraceProcessor.Rule {
         final int status =
             value instanceof Integer ? (int) value : Integer.parseInt(value.toString());
         if (DDSpanTypes.HTTP_SERVER.equals(span.getType())) {
-          if (Config.get().getHttpServerErrorStatuses().contains(status)) {
+          if (Config.get().getHttpServerErrorStatuses().get(status)) {
             span.setError(true);
           }
         } else if (DDSpanTypes.HTTP_CLIENT.equals((span.getType()))) {
-          if (Config.get().getHttpClientErrorStatuses().contains(status)) {
+          if (Config.get().getHttpClientErrorStatuses().get(status)) {
             span.setError(true);
           }
         }


### PR DESCRIPTION
Replaces the HTTP statuses with a more compact data structure, because they're `static final` and surprisingly large:

```
java.util.HashSet@65ab7765d footprint:
     COUNT       AVG       SUM   DESCRIPTION
         1      1040      1040   [Ljava.util.HashMap$Node;
       100        16      1600   java.lang.Integer
         1        16        16   java.lang.Object
         1        48        48   java.util.HashMap
       100        32      3200   java.util.HashMap$Node
         1        16        16   java.util.HashSet
       204                5920   (total)
```

We have between 2 and 4 of the above. This means we could have overhead between 12 and 24KB (if there is an override with a lot of status codes) depending on what configuration overrides are in place.

Using a `BitSet` we have:

server errors:
```
java.util.BitSet@1b28cdfad footprint:
     COUNT       AVG       SUM   DESCRIPTION
         1        96        96   [J
         1        24        24   java.util.BitSet
         2                 120   (total)
```

and client errors
```
java.util.BitSet@1b28cdfad footprint:
     COUNT       AVG       SUM   DESCRIPTION
         1        80        80   [J
         1        24        24   java.util.BitSet
         2                 104   (total)
```

The worst case size overhead with `BitSet` is ~0.5KB.

This also means we can avoid wrapping status codes if we represent them with primitive types in the future.