### PR TITLE
reduce the number of ConcurrentHashMap lookups per span in rule processing

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -210,6 +210,10 @@ public class DDSpan implements MutableSpan, AgentSpan {
     return this;
   }
 
+  public Object getAndRemoveTag(final String tag) {
+    return context.getTags().remove(tag);
+  }
+
   @Override
   public final DDSpanContext context() {
     return context;

--- a/dd-trace-core/src/main/java/datadog/trace/core/processor/rule/AnalyticsSampleRateRule.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/processor/rule/AnalyticsSampleRateRule.java
@@ -16,7 +16,7 @@ public class AnalyticsSampleRateRule implements TraceProcessor.Rule {
   @Override
   public void processSpan(
       final DDSpan span, final Map<String, Object> tags, final Collection<DDSpan> trace) {
-    final Object sampleRateValue = tags.get(DDTags.ANALYTICS_SAMPLE_RATE);
+    final Object sampleRateValue = span.getAndRemoveTag(DDTags.ANALYTICS_SAMPLE_RATE);
     if (sampleRateValue instanceof Number) {
       span.context().setMetric(DDTags.ANALYTICS_SAMPLE_RATE, (Number) sampleRateValue);
     } else if (sampleRateValue instanceof String) {
@@ -27,7 +27,5 @@ public class AnalyticsSampleRateRule implements TraceProcessor.Rule {
         // ignore
       }
     }
-
-    span.removeTag(DDTags.ANALYTICS_SAMPLE_RATE);
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/processor/rule/DBStatementRule.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/processor/rule/DBStatementRule.java
@@ -19,20 +19,16 @@ public class DBStatementRule implements TraceProcessor.Rule {
   @Override
   public void processSpan(
       final DDSpan span, final Map<String, Object> tags, final Collection<DDSpan> trace) {
-    final Object dbStatementValue = tags.get(Tags.DB_STATEMENT);
-
-    if (dbStatementValue instanceof String) {
-      // Special case: Mongo
-      // Skip the decorators
-      if (tags.containsKey(Tags.COMPONENT) && "java-mongo".equals(tags.get(Tags.COMPONENT))) {
-        return;
-      }
-      final String statement = (String) dbStatementValue;
-      if (!statement.isEmpty()) {
-        span.setResourceName(statement);
+    // Special case: Mongo
+    // Skip the decorators
+    if (!"java-mongo".equals(tags.get(Tags.COMPONENT))) {
+      final Object dbStatementValue = span.getAndRemoveTag(Tags.DB_STATEMENT);
+      if (dbStatementValue instanceof String) {
+        final String statement = (String) dbStatementValue;
+        if (!statement.isEmpty()) {
+          span.setResourceName(statement);
+        }
       }
     }
-
-    span.removeTag(Tags.DB_STATEMENT);
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/processor/rule/ErrorRule.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/processor/rule/ErrorRule.java
@@ -16,13 +16,11 @@ public class ErrorRule implements TraceProcessor.Rule {
   @Override
   public void processSpan(
       final DDSpan span, final Map<String, Object> tags, final Collection<DDSpan> trace) {
-    final Object value = tags.get(Tags.ERROR);
+    final Object value = span.getAndRemoveTag(Tags.ERROR);
     if (value instanceof Boolean) {
       span.setError((Boolean) value);
     } else if (value != null) {
       span.setError(Boolean.parseBoolean(value.toString()));
     }
-
-    span.removeTag(Tags.ERROR);
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/processor/rule/ResourceNameRule.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/processor/rule/ResourceNameRule.java
@@ -16,11 +16,9 @@ public class ResourceNameRule implements TraceProcessor.Rule {
   @Override
   public void processSpan(
       final DDSpan span, final Map<String, Object> tags, final Collection<DDSpan> trace) {
-    final Object name = tags.get(DDTags.RESOURCE_NAME);
+    final Object name = span.getAndRemoveTag(DDTags.RESOURCE_NAME);
     if (name != null) {
       span.setResourceName(name.toString());
     }
-
-    span.removeTag(DDTags.RESOURCE_NAME);
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/processor/rule/SpanTypeRule.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/processor/rule/SpanTypeRule.java
@@ -16,11 +16,9 @@ public class SpanTypeRule implements TraceProcessor.Rule {
   @Override
   public void processSpan(
       final DDSpan span, final Map<String, Object> tags, final Collection<DDSpan> trace) {
-    final Object type = tags.get(DDTags.SPAN_TYPE);
+    final Object type = span.getAndRemoveTag(DDTags.SPAN_TYPE);
     if (type != null) {
       span.setSpanType(type.toString());
     }
-
-    span.removeTag(DDTags.SPAN_TYPE);
   }
 }


### PR DESCRIPTION
Avoids looking up tags twice in several places in one of the hotspots seen in profiling. Previously in several rules the tag value would be looked up in an unmodifiable view over the tags map in `DDSpanContext` and then removed through `DDSpan.removeTag`, which would enter but immediately leave an uncontended synchronised block. Now, when we need to remove the tag, we get and remove it in one lookup via `ConcurrentHashMap.remove` (and might not need the unmodifiable view either).