### PR TITLE
Remove duplicate "build from config" in DDTracer

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -357,3 +357,7 @@ acceptedBreaks:
       old: "method void datadog.trace.core.serialization.FormatWriter<DEST>::writeBigInteger(byte[],\
         \ java.math.BigInteger, DEST) throws java.io.IOException"
       justification: "internal api"
+    - code: "java.method.visibilityReduced"
+      old: "method void datadog.opentracing.DDTracer.DDTracerBuilder::<init>()"
+      new: "method void datadog.opentracing.DDTracer.DDTracerBuilder::<init>()"
+      justification: "Builder constructor was never meant to be public"

--- a/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
@@ -46,11 +46,6 @@ public class DDTracer implements Tracer, datadog.trace.api.Tracer {
   private ScopeManager scopeManager;
 
   public static class DDTracerBuilder {
-    public DDTracerBuilder() {
-      // Apply the default values from config.
-      config(Config.get());
-    }
-
     public DDTracerBuilder withProperties(final Properties properties) {
       return config(Config.get(properties));
     }


### PR DESCRIPTION
A slightly complex interaction was occurring:

- `DDTracerBuilder` initializes from `Config.get()`
- `CoreTracerBuilder` initializes from `Config.get()`
- The `@Builder`-constructor for `DDTracer` sees `config` is not `null` so it passes it to `CoreTracerBuilder`
- `CoreTracerBuilder` initializes from config again

The end result is that classes built in `CoreTracerBuilder.config()` (eg `DeterministicSampler`, `ContinuableScopeManager`, etc) are created multiple times.

There is no need for the `DDTracerBuilder` to initialize from config because `CoreTracerBuilder` already does.