### PR TITLE
Fix elasticsearch test flakiness

### DIFF
--- a/dd-java-agent/instrumentation/elasticsearch/rest-5/src/latestDepTest/groovy/Elasticsearch6RestClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/rest-5/src/latestDepTest/groovy/Elasticsearch6RestClientTest.groovy
@@ -1,5 +1,4 @@
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import groovy.json.JsonSlurper
@@ -11,6 +10,8 @@ import org.elasticsearch.client.RestClient
 import org.elasticsearch.client.RestClientBuilder
 import org.elasticsearch.common.io.FileSystemUtils
 import org.elasticsearch.common.settings.Settings
+import org.elasticsearch.common.transport.TransportAddress
+import org.elasticsearch.http.HttpServerTransport
 import org.elasticsearch.node.InternalSettingsPreparer
 import org.elasticsearch.node.Node
 import org.elasticsearch.transport.Netty4Plugin
@@ -20,20 +21,18 @@ import spock.lang.Shared
 @Retry(count = 3, delay = 1000, mode = Retry.Mode.SETUP_FEATURE_CLEANUP)
 class Elasticsearch6RestClientTest extends AgentTestRunner {
   @Shared
-  int httpPort
-  @Shared
-  int tcpPort
+  TransportAddress httpTransportAddress
   @Shared
   Node testNode
   @Shared
   File esWorkingDir
+  @Shared
+  String clusterName = UUID.randomUUID().toString()
 
   @Shared
   RestClient client
 
   def setupSpec() {
-    httpPort = PortUtils.randomOpenPort()
-    tcpPort = PortUtils.randomOpenPort()
 
     esWorkingDir = File.createTempDir("test-es-working-dir-", "")
     esWorkingDir.deleteOnExit()
@@ -41,14 +40,13 @@ class Elasticsearch6RestClientTest extends AgentTestRunner {
 
     def settings = Settings.builder()
       .put("path.home", esWorkingDir.path)
-      .put("http.port", httpPort)
-      .put("transport.tcp.port", tcpPort)
-      .put("cluster.name", "test-cluster")
+      .put("cluster.name", clusterName)
       .build()
     testNode = new Node(InternalSettingsPreparer.prepareEnvironment(settings, null), [Netty4Plugin])
     testNode.start()
+    httpTransportAddress = testNode.injector().getInstance(HttpServerTransport).boundAddress().publishAddress()
 
-    client = RestClient.builder(new HttpHost("localhost", httpPort))
+    client = RestClient.builder(new HttpHost(httpTransportAddress.address, httpTransportAddress.port))
       .setMaxRetryTimeoutMillis(Integer.MAX_VALUE)
       .setRequestConfigCallback(new RestClientBuilder.RequestConfigCallback() {
         @Override
@@ -88,8 +86,8 @@ class Elasticsearch6RestClientTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.PEER_HOSTNAME" "localhost"
-            "$Tags.PEER_PORT" httpPort
+            "$Tags.PEER_HOSTNAME" httpTransportAddress.address
+            "$Tags.PEER_PORT" httpTransportAddress.port
             "$Tags.HTTP_URL" "_cluster/health"
             "$Tags.HTTP_METHOD" "GET"
             "$Tags.DB_TYPE" "elasticsearch"

--- a/dd-java-agent/instrumentation/elasticsearch/rest-6.4/src/latestDepTest/groovy/Elasticsearch6RestClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/rest-6.4/src/latestDepTest/groovy/Elasticsearch6RestClientTest.groovy
@@ -1,5 +1,4 @@
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import groovy.json.JsonSlurper
@@ -12,7 +11,9 @@ import org.elasticsearch.client.RestClient
 import org.elasticsearch.client.RestClientBuilder
 import org.elasticsearch.common.io.FileSystemUtils
 import org.elasticsearch.common.settings.Settings
+import org.elasticsearch.common.transport.TransportAddress
 import org.elasticsearch.env.Environment
+import org.elasticsearch.http.HttpServerTransport
 import org.elasticsearch.node.InternalSettingsPreparer
 import org.elasticsearch.node.Node
 import org.elasticsearch.plugins.Plugin
@@ -22,10 +23,9 @@ import spock.lang.Shared
 
 @Retry(count = 3, delay = 1000, mode = Retry.Mode.SETUP_FEATURE_CLEANUP)
 class Elasticsearch6RestClientTest extends AgentTestRunner {
+
   @Shared
-  int httpPort
-  @Shared
-  int tcpPort
+  TransportAddress httpTransportAddress
   @Shared
   Node testNode
   @Shared
@@ -33,10 +33,10 @@ class Elasticsearch6RestClientTest extends AgentTestRunner {
 
   @Shared
   RestClient client
+  @Shared
+  String clusterName = UUID.randomUUID().toString()
 
   def setupSpec() {
-    httpPort = PortUtils.randomOpenPort()
-    tcpPort = PortUtils.randomOpenPort()
 
     esWorkingDir = File.createTempDir("test-es-working-dir-", "")
     esWorkingDir.deleteOnExit()
@@ -44,14 +44,13 @@ class Elasticsearch6RestClientTest extends AgentTestRunner {
 
     def settings = Settings.builder()
       .put("path.home", esWorkingDir.path)
-      .put("http.port", httpPort)
-      .put("transport.tcp.port", tcpPort)
-      .put("cluster.name", "test-cluster")
+      .put("cluster.name", clusterName)
       .build()
     testNode = new TestNode(InternalSettingsPreparer.prepareEnvironment(settings, null), [Netty4Plugin])
     testNode.start()
+    httpTransportAddress = testNode.injector().getInstance(HttpServerTransport).boundAddress().publishAddress()
 
-    client = RestClient.builder(new HttpHost("localhost", httpPort))
+    client = RestClient.builder(new HttpHost(httpTransportAddress.address, httpTransportAddress.port))
       .setMaxRetryTimeoutMillis(Integer.MAX_VALUE)
       .setRequestConfigCallback(new RestClientBuilder.RequestConfigCallback() {
         @Override
@@ -92,8 +91,8 @@ class Elasticsearch6RestClientTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.PEER_HOSTNAME" "localhost"
-            "$Tags.PEER_PORT" httpPort
+            "$Tags.PEER_HOSTNAME" httpTransportAddress.address
+            "$Tags.PEER_PORT" httpTransportAddress.port
             "$Tags.HTTP_URL" "_cluster/health"
             "$Tags.HTTP_METHOD" "GET"
             "$Tags.DB_TYPE" "elasticsearch"

--- a/dd-java-agent/instrumentation/elasticsearch/rest-6.4/src/test/groovy/Elasticsearch6RestClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/rest-6.4/src/test/groovy/Elasticsearch6RestClientTest.groovy
@@ -1,5 +1,4 @@
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import groovy.json.JsonSlurper
@@ -11,6 +10,8 @@ import org.elasticsearch.client.RestClient
 import org.elasticsearch.client.RestClientBuilder
 import org.elasticsearch.common.io.FileSystemUtils
 import org.elasticsearch.common.settings.Settings
+import org.elasticsearch.common.transport.TransportAddress
+import org.elasticsearch.http.HttpServerTransport
 import org.elasticsearch.node.InternalSettingsPreparer
 import org.elasticsearch.node.Node
 import org.elasticsearch.transport.Netty4Plugin
@@ -20,20 +21,18 @@ import spock.lang.Shared
 @Retry(count = 3, delay = 1000, mode = Retry.Mode.SETUP_FEATURE_CLEANUP)
 class Elasticsearch6RestClientTest extends AgentTestRunner {
   @Shared
-  int httpPort
-  @Shared
-  int tcpPort
+  TransportAddress httpTransportAddress
   @Shared
   Node testNode
   @Shared
   File esWorkingDir
+  @Shared
+  String clusterName = UUID.randomUUID().toString()
 
   @Shared
   RestClient client
 
   def setupSpec() {
-    httpPort = PortUtils.randomOpenPort()
-    tcpPort = PortUtils.randomOpenPort()
 
     esWorkingDir = File.createTempDir("test-es-working-dir-", "")
     esWorkingDir.deleteOnExit()
@@ -41,14 +40,13 @@ class Elasticsearch6RestClientTest extends AgentTestRunner {
 
     def settings = Settings.builder()
       .put("path.home", esWorkingDir.path)
-      .put("http.port", httpPort)
-      .put("transport.tcp.port", tcpPort)
-      .put("cluster.name", "test-cluster")
+      .put("cluster.name", clusterName)
       .build()
     testNode = new Node(InternalSettingsPreparer.prepareEnvironment(settings, null), [Netty4Plugin])
     testNode.start()
+    httpTransportAddress = testNode.injector().getInstance(HttpServerTransport).boundAddress().publishAddress()
 
-    client = RestClient.builder(new HttpHost("localhost", httpPort))
+    client = RestClient.builder(new HttpHost(httpTransportAddress.address, httpTransportAddress.port))
       .setMaxRetryTimeoutMillis(Integer.MAX_VALUE)
       .setRequestConfigCallback(new RestClientBuilder.RequestConfigCallback() {
         @Override
@@ -88,8 +86,8 @@ class Elasticsearch6RestClientTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.PEER_HOSTNAME" "localhost"
-            "$Tags.PEER_PORT" httpPort
+            "$Tags.PEER_HOSTNAME" httpTransportAddress.address
+            "$Tags.PEER_PORT" httpTransportAddress.port
             "$Tags.HTTP_URL" "_cluster/health"
             "$Tags.HTTP_METHOD" "GET"
             "$Tags.DB_TYPE" "elasticsearch"

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/Elasticsearch2NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/Elasticsearch2NodeClientTest.groovy
@@ -1,13 +1,14 @@
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest
 import org.elasticsearch.common.io.FileSystemUtils
 import org.elasticsearch.common.settings.Settings
+import org.elasticsearch.common.transport.TransportAddress
 import org.elasticsearch.index.IndexNotFoundException
 import org.elasticsearch.node.Node
 import org.elasticsearch.node.NodeBuilder
+import org.elasticsearch.transport.TransportService
 import spock.lang.Retry
 import spock.lang.Shared
 
@@ -18,19 +19,17 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
   public static final long TIMEOUT = 10000; // 10 seconds
 
   @Shared
-  int httpPort
-  @Shared
-  int tcpPort
+  TransportAddress tcpPublishAddress
   @Shared
   Node testNode
   @Shared
   File esWorkingDir
+  @Shared
+  String clusterName = UUID.randomUUID().toString()
 
   def client = testNode.client()
 
   def setupSpec() {
-    httpPort = PortUtils.randomOpenPort()
-    tcpPort = PortUtils.randomOpenPort()
 
     esWorkingDir = File.createTempDir("test-es-working-dir-", "")
     esWorkingDir.deleteOnExit()
@@ -40,11 +39,10 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
       .put("path.home", esWorkingDir.path)
     // Since we use listeners to close spans this should make our span closing deterministic which is good for tests
       .put("threadpool.listener.size", 1)
-      .put("http.port", httpPort)
-      .put("transport.tcp.port", tcpPort)
       .build()
-    testNode = NodeBuilder.newInstance().local(true).clusterName("test-cluster").settings(settings).build()
+    testNode = NodeBuilder.newInstance().local(true).clusterName(clusterName).settings(settings).build()
     testNode.start()
+    tcpPublishAddress = testNode.injector().getInstance(TransportService).boundAddress().publishAddress()
     runUnderTrace("setup") {
       // this may potentially create multiple requests and therefore multiple spans, so we wrap this call
       // into a top level trace to get exactly one trace in the result.

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
@@ -2,7 +2,6 @@ package springdata
 
 
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import org.elasticsearch.action.search.SearchResponse
@@ -28,20 +27,16 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
   public static final long TIMEOUT = 10000; // 10 seconds
 
   @Shared
-  int httpPort
-  @Shared
-  int tcpPort
-  @Shared
   Node testNode
   @Shared
   File esWorkingDir
+  @Shared
+  String clusterName = UUID.randomUUID().toString()
 
   @Shared
   ElasticsearchTemplate template
 
   def setupSpec() {
-    httpPort = PortUtils.randomOpenPort()
-    tcpPort = PortUtils.randomOpenPort()
 
     esWorkingDir = File.createTempDir("test-es-working-dir-", "")
     esWorkingDir.deleteOnExit()
@@ -51,10 +46,8 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
       .put("path.home", esWorkingDir.path)
     // Since we use listeners to close spans this should make our span closing deterministic which is good for tests
       .put("threadpool.listener.size", 1)
-      .put("http.port", httpPort)
-      .put("transport.tcp.port", tcpPort)
       .build()
-    testNode = NodeBuilder.newInstance().local(true).clusterName("test-cluster").settings(settings).build()
+    testNode = NodeBuilder.newInstance().local(true).clusterName(clusterName).settings(settings).build()
     testNode.start()
 
     template = new ElasticsearchTemplate(testNode.client())

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/Elasticsearch2NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/Elasticsearch2NodeClientTest.groovy
@@ -1,5 +1,4 @@
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest
@@ -18,19 +17,15 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
   public static final long TIMEOUT = 10000; // 10 seconds
 
   @Shared
-  int httpPort
-  @Shared
-  int tcpPort
-  @Shared
   Node testNode
   @Shared
   File esWorkingDir
+  @Shared
+  String clusterName = UUID.randomUUID().toString()
 
   def client = testNode.client()
 
   def setupSpec() {
-    httpPort = PortUtils.randomOpenPort()
-    tcpPort = PortUtils.randomOpenPort()
 
     esWorkingDir = File.createTempDir("test-es-working-dir-", "")
     esWorkingDir.deleteOnExit()
@@ -40,10 +35,8 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
       .put("path.home", esWorkingDir.path)
     // Since we use listeners to close spans this should make our span closing deterministic which is good for tests
       .put("threadpool.listener.size", 1)
-      .put("http.port", httpPort)
-      .put("transport.tcp.port", tcpPort)
       .build()
-    testNode = NodeBuilder.newInstance().local(true).clusterName("test-cluster").settings(settings).build()
+    testNode = NodeBuilder.newInstance().local(true).clusterName(clusterName).settings(settings).build()
     testNode.start()
     runUnderTrace("setup") {
       // this may potentially create multiple requests and therefore multiple spans, so we wrap this call

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/Elasticsearch2TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/Elasticsearch2TransportClientTest.groovy
@@ -1,5 +1,4 @@
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest
@@ -7,11 +6,12 @@ import org.elasticsearch.action.admin.cluster.stats.ClusterStatsRequest
 import org.elasticsearch.client.transport.TransportClient
 import org.elasticsearch.common.io.FileSystemUtils
 import org.elasticsearch.common.settings.Settings
-import org.elasticsearch.common.transport.InetSocketTransportAddress
+import org.elasticsearch.common.transport.TransportAddress
 import org.elasticsearch.index.IndexNotFoundException
 import org.elasticsearch.node.Node
 import org.elasticsearch.node.NodeBuilder
 import org.elasticsearch.transport.RemoteTransportException
+import org.elasticsearch.transport.TransportService
 import spock.lang.Retry
 import spock.lang.Shared
 
@@ -22,20 +22,18 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
   public static final long TIMEOUT = 10000; // 10 seconds
 
   @Shared
-  int httpPort
-  @Shared
-  int tcpPort
+  TransportAddress tcpPublishAddress
   @Shared
   Node testNode
   @Shared
   File esWorkingDir
+  @Shared
+  String clusterName = UUID.randomUUID().toString()
 
   @Shared
   TransportClient client
 
   def setupSpec() {
-    httpPort = PortUtils.randomOpenPort()
-    tcpPort = PortUtils.randomOpenPort()
 
     esWorkingDir = File.createTempDir("test-es-working-dir-", "")
     esWorkingDir.deleteOnExit()
@@ -43,20 +41,20 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
 
     def settings = Settings.builder()
       .put("path.home", esWorkingDir.path)
-      .put("http.port", httpPort)
-      .put("transport.tcp.port", tcpPort)
       .build()
-    testNode = NodeBuilder.newInstance().clusterName("test-cluster").settings(settings).build()
+    testNode = NodeBuilder.newInstance().clusterName(clusterName).settings(settings).build()
     testNode.start()
+
+    tcpPublishAddress = testNode.injector().getInstance(TransportService).boundAddress().publishAddress()
 
     client = TransportClient.builder().settings(
       Settings.builder()
       // Since we use listeners to close spans this should make our span closing deterministic which is good for tests
         .put("threadpool.listener.size", 1)
-        .put("cluster.name", "test-cluster")
+        .put("cluster.name", clusterName)
         .build()
     ).build()
-    client.addTransportAddress(new InetSocketTransportAddress(InetAddress.getByName("localhost"), tcpPort))
+    client.addTransportAddress(tcpPublishAddress)
     runUnderTrace("setup") {
       // this may potentially create multiple requests and therefore multiple spans, so we wrap this call
       // into a top level trace to get exactly one trace in the result.
@@ -92,9 +90,9 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.PEER_HOSTNAME" "127.0.0.1"
-            "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-            "$Tags.PEER_PORT" tcpPort
+            "$Tags.PEER_HOSTNAME" tcpPublishAddress.host
+            "$Tags.PEER_HOST_IPV4" tcpPublishAddress.address
+            "$Tags.PEER_PORT" tcpPublishAddress.port
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
@@ -126,13 +124,13 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.PEER_HOSTNAME" "127.0.0.1"
-            "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-            "$Tags.PEER_PORT" tcpPort
+            "$Tags.PEER_HOSTNAME" tcpPublishAddress.host
+            "$Tags.PEER_HOST_IPV4" tcpPublishAddress.address
+            "$Tags.PEER_PORT" tcpPublishAddress.port
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "ClusterStatsAction"
             "elasticsearch.request" "ClusterStatsRequest"
-            "elasticsearch.node.cluster.name" "test-cluster"
+            "elasticsearch.node.cluster.name" clusterName
             defaultTags()
           }
         }
@@ -231,9 +229,9 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.PEER_HOSTNAME" "127.0.0.1"
-            "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-            "$Tags.PEER_PORT" tcpPort
+            "$Tags.PEER_HOSTNAME" tcpPublishAddress.host
+            "$Tags.PEER_HOST_IPV4" tcpPublishAddress.address
+            "$Tags.PEER_PORT" tcpPublishAddress.port
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "CreateIndexAction"
             "elasticsearch.request" "CreateIndexRequest"
@@ -251,9 +249,9 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.PEER_HOSTNAME" "127.0.0.1"
-            "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-            "$Tags.PEER_PORT" tcpPort
+            "$Tags.PEER_HOSTNAME" tcpPublishAddress.host
+            "$Tags.PEER_HOST_IPV4" tcpPublishAddress.address
+            "$Tags.PEER_PORT" tcpPublishAddress.port
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
@@ -270,9 +268,9 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.PEER_HOSTNAME" "127.0.0.1"
-            "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-            "$Tags.PEER_PORT" tcpPort
+            "$Tags.PEER_HOSTNAME" tcpPublishAddress.host
+            "$Tags.PEER_HOST_IPV4" tcpPublishAddress.address
+            "$Tags.PEER_PORT" tcpPublishAddress.port
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
@@ -310,9 +308,9 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.PEER_HOSTNAME" "127.0.0.1"
-            "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-            "$Tags.PEER_PORT" tcpPort
+            "$Tags.PEER_HOSTNAME" tcpPublishAddress.host
+            "$Tags.PEER_HOST_IPV4" tcpPublishAddress.address
+            "$Tags.PEER_PORT" tcpPublishAddress.port
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
@@ -331,9 +329,9 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.PEER_HOSTNAME" "127.0.0.1"
-            "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-            "$Tags.PEER_PORT" tcpPort
+            "$Tags.PEER_HOSTNAME" tcpPublishAddress.host
+            "$Tags.PEER_HOST_IPV4" tcpPublishAddress.address
+            "$Tags.PEER_PORT" tcpPublishAddress.port
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
@@ -1,8 +1,6 @@
 package springdata
 
-
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import org.elasticsearch.action.search.SearchResponse
@@ -28,20 +26,16 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
   public static final long TIMEOUT = 10000; // 10 seconds
 
   @Shared
-  int httpPort
-  @Shared
-  int tcpPort
-  @Shared
   Node testNode
   @Shared
   File esWorkingDir
+  @Shared
+  String clusterName = UUID.randomUUID().toString()
 
   @Shared
   ElasticsearchTemplate template
 
   def setupSpec() {
-    httpPort = PortUtils.randomOpenPort()
-    tcpPort = PortUtils.randomOpenPort()
 
     esWorkingDir = File.createTempDir("test-es-working-dir-", "")
     esWorkingDir.deleteOnExit()
@@ -51,10 +45,8 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
       .put("path.home", esWorkingDir.path)
     // Since we use listeners to close spans this should make our span closing deterministic which is good for tests
       .put("threadpool.listener.size", 1)
-      .put("http.port", httpPort)
-      .put("transport.tcp.port", tcpPort)
       .build()
-    testNode = NodeBuilder.newInstance().local(true).clusterName("test-cluster").settings(settings).build()
+    testNode = NodeBuilder.newInstance().local(true).clusterName(clusterName).settings(settings).build()
     testNode.start()
 
     template = new ElasticsearchTemplate(testNode.client())

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/Elasticsearch53NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/Elasticsearch53NodeClientTest.groovy
@@ -1,5 +1,4 @@
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest
@@ -21,19 +20,15 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
   public static final long TIMEOUT = 10000; // 10 seconds
 
   @Shared
-  int httpPort
-  @Shared
-  int tcpPort
-  @Shared
   Node testNode
   @Shared
   File esWorkingDir
+  @Shared
+  String clusterName = UUID.randomUUID().toString()
 
   def client = testNode.client()
 
   def setupSpec() {
-    httpPort = PortUtils.randomOpenPort()
-    tcpPort = PortUtils.randomOpenPort()
 
     esWorkingDir = File.createTempDir("test-es-working-dir-", "")
     esWorkingDir.deleteOnExit()
@@ -43,11 +38,9 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
       .put("path.home", esWorkingDir.path)
     // Since we use listeners to close spans this should make our span closing deterministic which is good for tests
       .put("thread_pool.listener.size", 1)
-      .put("http.port", httpPort)
-      .put("transport.tcp.port", tcpPort)
       .put("transport.type", "netty3")
       .put("http.type", "netty3")
-      .put(CLUSTER_NAME_SETTING.getKey(), "test-cluster")
+      .put(CLUSTER_NAME_SETTING.getKey(), clusterName)
       .build()
     testNode = new Node(new Environment(InternalSettingsPreparer.prepareSettings(settings)), [Netty3Plugin])
     testNode.start()

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/Elasticsearch53TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/Elasticsearch53TransportClientTest.groovy
@@ -1,18 +1,18 @@
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest
 import org.elasticsearch.client.transport.TransportClient
 import org.elasticsearch.common.io.FileSystemUtils
 import org.elasticsearch.common.settings.Settings
-import org.elasticsearch.common.transport.InetSocketTransportAddress
+import org.elasticsearch.common.transport.TransportAddress
 import org.elasticsearch.env.Environment
 import org.elasticsearch.index.IndexNotFoundException
 import org.elasticsearch.node.InternalSettingsPreparer
 import org.elasticsearch.node.Node
 import org.elasticsearch.transport.Netty3Plugin
 import org.elasticsearch.transport.RemoteTransportException
+import org.elasticsearch.transport.TransportService
 import org.elasticsearch.transport.client.PreBuiltTransportClient
 import spock.lang.Retry
 import spock.lang.Shared
@@ -25,9 +25,8 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
   public static final long TIMEOUT = 10000; // 10 seconds
 
   @Shared
-  int httpPort
-  @Shared
-  int tcpPort
+  TransportAddress tcpPublishAddress
+
   @Shared
   Node testNode
   @Shared
@@ -35,10 +34,10 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
 
   @Shared
   TransportClient client
+  @Shared
+  String clusterName = UUID.randomUUID().toString()
 
   def setupSpec() {
-    httpPort = PortUtils.randomOpenPort()
-    tcpPort = PortUtils.randomOpenPort()
 
     esWorkingDir = File.createTempDir("test-es-working-dir-", "")
     esWorkingDir.deleteOnExit()
@@ -46,23 +45,22 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
 
     def settings = Settings.builder()
       .put("path.home", esWorkingDir.path)
-      .put("http.port", httpPort)
-      .put("transport.tcp.port", tcpPort)
       .put("transport.type", "netty3")
       .put("http.type", "netty3")
-      .put(CLUSTER_NAME_SETTING.getKey(), "test-cluster")
+      .put(CLUSTER_NAME_SETTING.getKey(), clusterName)
       .build()
     testNode = new Node(new Environment(InternalSettingsPreparer.prepareSettings(settings)), [Netty3Plugin])
     testNode.start()
+    tcpPublishAddress = testNode.injector().getInstance(TransportService).boundAddress().publishAddress()
 
     client = new PreBuiltTransportClient(
       Settings.builder()
       // Since we use listeners to close spans this should make our span closing deterministic which is good for tests
         .put("thread_pool.listener.size", 1)
-        .put(CLUSTER_NAME_SETTING.getKey(), "test-cluster")
+        .put(CLUSTER_NAME_SETTING.getKey(), clusterName)
         .build()
     )
-    client.addTransportAddress(new InetSocketTransportAddress(InetAddress.getByName("localhost"), tcpPort))
+    client.addTransportAddress(tcpPublishAddress)
     runUnderTrace("setup") {
       // this may potentially create multiple requests and therefore multiple spans, so we wrap this call
       // into a top level trace to get exactly one trace in the result.
@@ -98,9 +96,9 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.PEER_HOSTNAME" "localhost"
-            "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-            "$Tags.PEER_PORT" tcpPort
+            "$Tags.PEER_HOSTNAME" tcpPublishAddress.host
+            "$Tags.PEER_HOST_IPV4" tcpPublishAddress.address
+            "$Tags.PEER_PORT" tcpPublishAddress.port
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
@@ -202,9 +200,9 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.PEER_HOSTNAME" "localhost"
-            "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-            "$Tags.PEER_PORT" tcpPort
+            "$Tags.PEER_HOSTNAME" tcpPublishAddress.host
+            "$Tags.PEER_HOST_IPV4" tcpPublishAddress.address
+            "$Tags.PEER_PORT" tcpPublishAddress.port
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "CreateIndexAction"
             "elasticsearch.request" "CreateIndexRequest"
@@ -222,9 +220,9 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.PEER_HOSTNAME" "localhost"
-            "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-            "$Tags.PEER_PORT" tcpPort
+            "$Tags.PEER_HOSTNAME" tcpPublishAddress.host
+            "$Tags.PEER_HOST_IPV4" tcpPublishAddress.address
+            "$Tags.PEER_PORT" tcpPublishAddress.port
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
@@ -261,9 +259,9 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.PEER_HOSTNAME" "localhost"
-            "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-            "$Tags.PEER_PORT" tcpPort
+            "$Tags.PEER_HOSTNAME" tcpPublishAddress.host
+            "$Tags.PEER_HOST_IPV4" tcpPublishAddress.address
+            "$Tags.PEER_PORT" tcpPublishAddress.port
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
@@ -287,9 +285,9 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.PEER_HOSTNAME" "localhost"
-            "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-            "$Tags.PEER_PORT" tcpPort
+            "$Tags.PEER_HOSTNAME" tcpPublishAddress.host
+            "$Tags.PEER_HOST_IPV4" tcpPublishAddress.address
+            "$Tags.PEER_PORT" tcpPublishAddress.port
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/springdata/Elasticsearch53SpringTemplateTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/springdata/Elasticsearch53SpringTemplateTest.groovy
@@ -1,9 +1,7 @@
 package springdata
 
-
 import com.google.common.collect.ImmutableSet
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import org.elasticsearch.action.search.SearchResponse
@@ -39,20 +37,16 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
   public static final Set<String> IGNORED_ACTIONS = ImmutableSet.of("NodesStatsAction", "IndicesStatsAction")
 
   @Shared
-  int httpPort
-  @Shared
-  int tcpPort
-  @Shared
   Node testNode
   @Shared
   File esWorkingDir
+  @Shared
+  String clusterName = UUID.randomUUID().toString()
 
   @Shared
   ElasticsearchTemplate template
 
   def setupSpec() {
-    httpPort = PortUtils.randomOpenPort()
-    tcpPort = PortUtils.randomOpenPort()
 
     esWorkingDir = File.createTempDir("test-es-working-dir-", "")
     esWorkingDir.deleteOnExit()
@@ -62,11 +56,9 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
       .put("path.home", esWorkingDir.path)
     // Since we use listeners to close spans this should make our span closing deterministic which is good for tests
       .put("thread_pool.listener.size", 1)
-      .put("http.port", httpPort)
-      .put("transport.tcp.port", tcpPort)
       .put("transport.type", "netty3")
       .put("http.type", "netty3")
-      .put(CLUSTER_NAME_SETTING.getKey(), "test-cluster")
+      .put(CLUSTER_NAME_SETTING.getKey(), clusterName)
       .build()
     testNode = new Node(new Environment(InternalSettingsPreparer.prepareSettings(settings)), [Netty3Plugin])
     testNode.start()

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5/src/test/groovy/Elasticsearch5NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5/src/test/groovy/Elasticsearch5NodeClientTest.groovy
@@ -1,5 +1,4 @@
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest
@@ -21,19 +20,15 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
   public static final long TIMEOUT = 10000; // 10 seconds
 
   @Shared
-  int httpPort
-  @Shared
-  int tcpPort
-  @Shared
   Node testNode
   @Shared
   File esWorkingDir
+  @Shared
+  String clusterName = UUID.randomUUID().toString()
 
   def client = testNode.client()
 
   def setupSpec() {
-    httpPort = PortUtils.randomOpenPort()
-    tcpPort = PortUtils.randomOpenPort()
 
     esWorkingDir = File.createTempDir("test-es-working-dir-", "")
     esWorkingDir.deleteOnExit()
@@ -43,11 +38,9 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
       .put("path.home", esWorkingDir.path)
     // Since we use listeners to close spans this should make our span closing deterministic which is good for tests
       .put("thread_pool.listener.size", 1)
-      .put("http.port", httpPort)
-      .put("transport.tcp.port", tcpPort)
       .put("transport.type", "netty3")
       .put("http.type", "netty3")
-      .put(CLUSTER_NAME_SETTING.getKey(), "test-cluster")
+      .put(CLUSTER_NAME_SETTING.getKey(), clusterName)
       .build()
     testNode = new Node(new Environment(InternalSettingsPreparer.prepareSettings(settings)), [Netty3Plugin])
     testNode.start()

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5/src/test/groovy/Elasticsearch5TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5/src/test/groovy/Elasticsearch5TransportClientTest.groovy
@@ -1,18 +1,18 @@
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest
 import org.elasticsearch.client.transport.TransportClient
 import org.elasticsearch.common.io.FileSystemUtils
 import org.elasticsearch.common.settings.Settings
-import org.elasticsearch.common.transport.InetSocketTransportAddress
+import org.elasticsearch.common.transport.TransportAddress
 import org.elasticsearch.env.Environment
 import org.elasticsearch.index.IndexNotFoundException
 import org.elasticsearch.node.Node
 import org.elasticsearch.node.internal.InternalSettingsPreparer
 import org.elasticsearch.transport.Netty3Plugin
 import org.elasticsearch.transport.RemoteTransportException
+import org.elasticsearch.transport.TransportService
 import org.elasticsearch.transport.client.PreBuiltTransportClient
 import spock.lang.Retry
 import spock.lang.Shared
@@ -25,20 +25,18 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
   public static final long TIMEOUT = 10000; // 10 seconds
 
   @Shared
-  int httpPort
-  @Shared
-  int tcpPort
+  TransportAddress tcpPublishAddress
   @Shared
   Node testNode
   @Shared
   File esWorkingDir
+  @Shared
+  String clusterName = UUID.randomUUID().toString()
 
   @Shared
   TransportClient client
 
   def setupSpec() {
-    httpPort = PortUtils.randomOpenPort()
-    tcpPort = PortUtils.randomOpenPort()
 
     esWorkingDir = File.createTempDir("test-es-working-dir-", "")
     esWorkingDir.deleteOnExit()
@@ -46,23 +44,22 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
 
     def settings = Settings.builder()
       .put("path.home", esWorkingDir.path)
-      .put("http.port", httpPort)
-      .put("transport.tcp.port", tcpPort)
       .put("transport.type", "netty3")
       .put("http.type", "netty3")
-      .put(CLUSTER_NAME_SETTING.getKey(), "test-cluster")
+      .put(CLUSTER_NAME_SETTING.getKey(), clusterName)
       .build()
     testNode = new Node(new Environment(InternalSettingsPreparer.prepareSettings(settings)), [Netty3Plugin])
     testNode.start()
+    tcpPublishAddress = testNode.injector().getInstance(TransportService).boundAddress().publishAddress()
 
     client = new PreBuiltTransportClient(
       Settings.builder()
       // Since we use listeners to close spans this should make our span closing deterministic which is good for tests
         .put("thread_pool.listener.size", 1)
-        .put(CLUSTER_NAME_SETTING.getKey(), "test-cluster")
+        .put(CLUSTER_NAME_SETTING.getKey(), clusterName)
         .build()
     )
-    client.addTransportAddress(new InetSocketTransportAddress(InetAddress.getByName("localhost"), tcpPort))
+    client.addTransportAddress(tcpPublishAddress)
     runUnderTrace("setup") {
       // this may potentially create multiple requests and therefore multiple spans, so we wrap this call
       // into a top level trace to get exactly one trace in the result.
@@ -99,8 +96,8 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" String
-            "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-            "$Tags.PEER_PORT" tcpPort
+            "$Tags.PEER_HOST_IPV4" tcpPublishAddress.address
+            "$Tags.PEER_PORT" tcpPublishAddress.port
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
@@ -203,8 +200,8 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" String
-            "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-            "$Tags.PEER_PORT" tcpPort
+            "$Tags.PEER_HOST_IPV4" tcpPublishAddress.address
+            "$Tags.PEER_PORT" tcpPublishAddress.port
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "CreateIndexAction"
             "elasticsearch.request" "CreateIndexRequest"
@@ -223,8 +220,8 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" String
-            "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-            "$Tags.PEER_PORT" tcpPort
+            "$Tags.PEER_HOST_IPV4" tcpPublishAddress.address
+            "$Tags.PEER_PORT" tcpPublishAddress.port
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
@@ -262,8 +259,8 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" String
-            "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-            "$Tags.PEER_PORT" tcpPort
+            "$Tags.PEER_HOST_IPV4" tcpPublishAddress.address
+            "$Tags.PEER_PORT" tcpPublishAddress.port
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
@@ -287,8 +284,8 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" String
-            "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-            "$Tags.PEER_PORT" tcpPort
+            "$Tags.PEER_HOST_IPV4" tcpPublishAddress.address
+            "$Tags.PEER_PORT" tcpPublishAddress.port
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"

--- a/dd-java-agent/instrumentation/elasticsearch/transport-6/src/test/groovy/Elasticsearch6NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-6/src/test/groovy/Elasticsearch6NodeClientTest.groovy
@@ -1,5 +1,4 @@
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest
@@ -20,19 +19,15 @@ class Elasticsearch6NodeClientTest extends AgentTestRunner {
   public static final long TIMEOUT = 10000; // 10 seconds
 
   @Shared
-  int httpPort
-  @Shared
-  int tcpPort
-  @Shared
   Node testNode
   @Shared
   File esWorkingDir
+  @Shared
+  String clusterName = UUID.randomUUID().toString()
 
   def client = testNode.client()
 
   def setupSpec() {
-    httpPort = PortUtils.randomOpenPort()
-    tcpPort = PortUtils.randomOpenPort()
 
     esWorkingDir = File.createTempDir("test-es-working-dir-", "")
     esWorkingDir.deleteOnExit()
@@ -42,9 +37,7 @@ class Elasticsearch6NodeClientTest extends AgentTestRunner {
       .put("path.home", esWorkingDir.path)
     // Since we use listeners to close spans this should make our span closing deterministic which is good for tests
       .put("thread_pool.listener.size", 1)
-      .put("http.port", httpPort)
-      .put("transport.tcp.port", tcpPort)
-      .put(CLUSTER_NAME_SETTING.getKey(), "test-cluster")
+      .put(CLUSTER_NAME_SETTING.getKey(), clusterName)
       .build()
     testNode = new Node(InternalSettingsPreparer.prepareEnvironment(settings, null), [Netty4Plugin])
     testNode.start()

--- a/dd-java-agent/instrumentation/elasticsearch/transport-6/src/test/groovy/Elasticsearch6TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-6/src/test/groovy/Elasticsearch6TransportClientTest.groovy
@@ -1,5 +1,4 @@
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest
@@ -12,6 +11,7 @@ import org.elasticsearch.node.InternalSettingsPreparer
 import org.elasticsearch.node.Node
 import org.elasticsearch.transport.Netty4Plugin
 import org.elasticsearch.transport.RemoteTransportException
+import org.elasticsearch.transport.TransportService
 import org.elasticsearch.transport.client.PreBuiltTransportClient
 import spock.lang.Retry
 import spock.lang.Shared
@@ -22,44 +22,40 @@ import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
 @Retry(count = 3, delay = 1000, mode = Retry.Mode.SETUP_FEATURE_CLEANUP)
 class Elasticsearch6TransportClientTest extends AgentTestRunner {
   public static final long TIMEOUT = 10000; // 10 seconds
-
+  
   @Shared
-  int httpPort
-  @Shared
-  int tcpPort
+  TransportAddress tcpPublishAddress
   @Shared
   Node testNode
   @Shared
   File esWorkingDir
+  @Shared
+  String clusterName = UUID.randomUUID().toString()
 
   @Shared
   TransportClient client
 
   def setupSpec() {
-    httpPort = PortUtils.randomOpenPort()
-    tcpPort = PortUtils.randomOpenPort()
-
     esWorkingDir = File.createTempDir("test-es-working-dir-", "")
     esWorkingDir.deleteOnExit()
     println "ES work dir: $esWorkingDir"
 
     def settings = Settings.builder()
       .put("path.home", esWorkingDir.path)
-      .put("http.port", httpPort)
-      .put("transport.tcp.port", tcpPort)
-      .put(CLUSTER_NAME_SETTING.getKey(), "test-cluster")
+      .put(CLUSTER_NAME_SETTING.getKey(), clusterName)
       .build()
     testNode = new Node(InternalSettingsPreparer.prepareEnvironment(settings, null), [Netty4Plugin])
     testNode.start()
-
+    tcpPublishAddress = testNode.injector().getInstance(TransportService).boundAddress().publishAddress()
+    
     client = new PreBuiltTransportClient(
       Settings.builder()
       // Since we use listeners to close spans this should make our span closing deterministic which is good for tests
         .put("thread_pool.listener.size", 1)
-        .put(CLUSTER_NAME_SETTING.getKey(), "test-cluster")
+        .put(CLUSTER_NAME_SETTING.getKey(), clusterName)
         .build()
     )
-    client.addTransportAddress(new TransportAddress(InetAddress.getByName("localhost"), tcpPort))
+    client.addTransportAddress(tcpPublishAddress)
     runUnderTrace("setup") {
       // this may potentially create multiple requests and therefore multiple spans, so we wrap this call
       // into a top level trace to get exactly one trace in the result.
@@ -96,8 +92,8 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "localhost"
-            "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-            "$Tags.PEER_PORT" tcpPort
+            "$Tags.PEER_HOST_IPV4" tcpPublishAddress.address
+            "$Tags.PEER_PORT" tcpPublishAddress.port
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
@@ -200,8 +196,8 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "localhost"
-            "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-            "$Tags.PEER_PORT" tcpPort
+            "$Tags.PEER_HOST_IPV4" tcpPublishAddress.address
+            "$Tags.PEER_PORT" tcpPublishAddress.port
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "CreateIndexAction"
             "elasticsearch.request" "CreateIndexRequest"
@@ -220,8 +216,8 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "localhost"
-            "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-            "$Tags.PEER_PORT" tcpPort
+            "$Tags.PEER_HOST_IPV4" tcpPublishAddress.address
+            "$Tags.PEER_PORT" tcpPublishAddress.port
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
@@ -259,8 +255,8 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "localhost"
-            "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-            "$Tags.PEER_PORT" tcpPort
+            "$Tags.PEER_HOST_IPV4" tcpPublishAddress.address
+            "$Tags.PEER_PORT" tcpPublishAddress.port
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
@@ -285,8 +281,8 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "localhost"
-            "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-            "$Tags.PEER_PORT" tcpPort
+            "$Tags.PEER_HOST_IPV4" tcpPublishAddress.address
+            "$Tags.PEER_PORT" tcpPublishAddress.port
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"


### PR DESCRIPTION
See what happens if we let elastic find a port to bind to and get the port back from the client.

From their [docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-network.html#common-network-settings) can take a port number or a range, if a range is given, will find the first free port in the range, defaults are 100 port ranges.

Also prevent tests from communicating by assigning unique cluster names.