### PR TITLE
Always send id as long

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -410,6 +410,10 @@ acceptedBreaks:
       old: "method void datadog.trace.core.serialization.FormatWriter<DEST>::writeBigInteger(byte[],\
         \ java.math.BigInteger, DEST) throws java.io.IOException"
       justification: "internal api"
+    - code: "java.method.removed"
+      old: "method void datadog.trace.core.serialization.MsgpackFormatWriter::writeBigInteger(byte[],\
+        \ java.math.BigInteger, org.msgpack.core.MessagePacker) throws java.io.IOException"
+      justification: "internal api"
     - code: "java.method.visibilityReduced"
       old: "method void datadog.opentracing.DDTracer.DDTracerBuilder::<init>()"
       new: "method void datadog.opentracing.DDTracer.DDTracerBuilder::<init>()"

--- a/dd-trace-api/src/main/java/datadog/trace/api/DDId.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/DDId.java
@@ -1,6 +1,5 @@
 package datadog.trace.api;
 
-import java.math.BigInteger;
 import java.util.concurrent.ThreadLocalRandom;
 
 /**
@@ -24,13 +23,11 @@ public class DDId {
    * @return DDId
    */
   public static DDId generate() {
-    // It is **extremely** unlikely to generate the value "0" but we still need to handle that
-    // case
+    // It is **extremely** unlikely to generate the value "0" but we still need to handle that case
     long id;
     do {
-      // TODO the ids are positive here by design to avoid materialization of a BigInteger,
-      //      and that can be changed to nextLong(Long.MIN_VALUE, Long.MAX_VALUE), when
-      //      msgpack supports packUnsignedLong
+      // The ids are positive here for historical reasons, and supposed compatibility with
+      // different older Datadog agent versions.
       id = ThreadLocalRandom.current().nextLong(Long.MAX_VALUE);
     } while (id == 0);
     return DDId.from(id);
@@ -195,16 +192,6 @@ public class DDId {
     return Long.toString(quot) + rem;
   }
 
-  // TODO Can be removed when msgpack support packUnsignedLong
-  private static BigInteger toUnsignedBigInteger(long l) {
-    if (l >= 0L) return BigInteger.valueOf(l);
-
-    long high = l >>> 32;
-    long low = l & 0xffffffffL;
-
-    return BigInteger.valueOf(high).shiftLeft(32).add(BigInteger.valueOf(low));
-  }
-
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
@@ -250,18 +237,6 @@ public class DDId {
       this.hex = h = Long.toHexString(this.id);
     }
     return h;
-  }
-
-  /**
-   * Returns a {@code BigInteger} representation of the 64 bit id. The {@code BigInteger} will not
-   * be cached.
-   *
-   * <p>TODO Can be removed if msgpack supports packUnsignedLong
-   *
-   * @return BigInteger representation of the 64 bit id.
-   */
-  public BigInteger toBigInteger() {
-    return toUnsignedBigInteger(this.id);
   }
 
   /**

--- a/dd-trace-api/src/test/groovy/datadog/trace/api/DDIdTest.groovy
+++ b/dd-trace-api/src/test/groovy/datadog/trace/api/DDIdTest.groovy
@@ -12,7 +12,6 @@ class DDIdTest extends DDSpecification {
     ddid.toLong() == longId
     ddid.toString() == expectedString
     ddid.toHexString() == expectedHex
-    ddid.toBigInteger() == new BigInteger(expectedString, 10)
 
     where:
     longId         | expectedId                | expectedString         | expectedHex

--- a/dd-trace-core/src/main/java/datadog/trace/core/serialization/JsonFormatWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/serialization/JsonFormatWriter.java
@@ -104,7 +104,10 @@ public class JsonFormatWriter extends FormatWriter<JsonWriter> {
     if (l >= 0) {
       writeLong(key, l, destination);
     } else {
-      writeBigInteger(key, id.toBigInteger(), destination);
+      long high = l >>> 32;
+      long low = l & 0xffffffffL;
+      writeBigInteger(
+          key, BigInteger.valueOf(high).shiftLeft(32).add(BigInteger.valueOf(low)), destination);
     }
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/serialization/MsgpackFormatWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/serialization/MsgpackFormatWriter.java
@@ -3,7 +3,6 @@ package datadog.trace.core.serialization;
 import datadog.trace.api.DDId;
 import datadog.trace.core.StringTables;
 import java.io.IOException;
-import java.math.BigInteger;
 import org.msgpack.core.MessagePacker;
 
 public class MsgpackFormatWriter extends FormatWriter<MessagePacker> {
@@ -93,24 +92,9 @@ public class MsgpackFormatWriter extends FormatWriter<MessagePacker> {
 
   @Override
   public void writeId(byte[] key, DDId id, MessagePacker destination) throws IOException {
-    // This can be removed when msgpack supports packUnsignedLong
-    long l = id.toLong();
-    if (l >= 0) {
-      writeLong(key, l, destination);
-    } else {
-      writeBigInteger(key, id.toBigInteger(), destination);
-    }
-  }
-
-  private void writeBigInteger(
-      final byte[] key, final BigInteger value, final MessagePacker destination)
-      throws IOException {
-    writeKey(key, destination);
-    if (value == null) {
-      destination.packNil();
-    } else {
-      destination.packBigInteger(value);
-    }
+    // Since the Datadog agent will decode the long as an unsigned 64 bit integer even
+    // if it's sent as a signed 64 bit integer, we can just use writeLong here
+    writeLong(key, id.toLong(), destination);
   }
 
   private static void writeUTF8Tag(final String value, final MessagePacker destination)

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/serialization/JsonFormatWriterTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/serialization/JsonFormatWriterTest.groovy
@@ -1,0 +1,33 @@
+package datadog.trace.core.serialization
+
+import com.squareup.moshi.JsonWriter
+import datadog.trace.api.DDId
+import okio.Buffer
+import spock.lang.Specification
+
+import java.nio.charset.StandardCharsets
+
+class JsonFormatWriterTest extends Specification {
+
+  def "serialize ids"() {
+    setup:
+    def writer = JsonFormatWriter.JSON_WRITER
+    def buffer = new Buffer()
+    def dest = JsonWriter.of(buffer)
+
+
+    when:
+    dest.beginObject()
+    writer.writeId("key".getBytes(StandardCharsets.UTF_8), id, dest)
+    dest.endObject()
+
+    then:
+    buffer.snapshot().utf8() == expected
+
+    where:
+    id        | expected
+    DDId.ZERO | """{"key":0}"""
+    DDId.ONE  | """{"key":1}"""
+    DDId.MAX  | """{"key":18446744073709551615}"""
+  }
+}


### PR DESCRIPTION
As @richardstartin commented, the Datadog Agent  will probably decode our integers the right way even if we send a signed 64 bit when it expects an unsigned 64 bit, and lo and behold https://github.com/DataDog/datadog-agent/blob/f12fc7af659455c252ab4c251a666ee95f0b930a/pkg/trace/pb/decoder.go#L125 that is exactly what it does.