### PR TITLE
Add logic to prevent randomOpenPort from reusing ports

### DIFF
--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/AgentTestRunner.java
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/AgentTestRunner.java
@@ -281,6 +281,7 @@ public abstract class AgentTestRunner extends DDSpecification {
         for (final AgentTestRunner testRunner : activeTests) {
           if (testRunner.onInstrumentationError(typeName, classLoader, module, loaded, throwable)) {
             INSTRUMENTATION_ERROR_COUNT.incrementAndGet();
+            throwable.printStackTrace();
             break;
           }
         }

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/utils/PortUtils.java
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/utils/PortUtils.java
@@ -10,13 +10,14 @@ import lombok.SneakyThrows;
 
 public class PortUtils {
   private static final long TIMEOUT = TimeUnit.SECONDS.toNanos(1);
+  // Access guarded by randomOpenPort method synchronization.
   private static final BitSet USED_PORTS = new BitSet();
 
   public static int UNUSABLE_PORT = 61;
 
   /** Open up a random, reusable port. */
   @SneakyThrows
-  public static int randomOpenPort() {
+  public static synchronized int randomOpenPort() {
     final long startTime = System.nanoTime();
     int port = 0;
     while (port <= 0 || USED_PORTS.get(port)) {


### PR DESCRIPTION
There's a chance that the OS may attempt to reuse ports very aggressively causing the timeout to occur.  If that happens, we may want to change when we close the socket.