### PR TITLE
Update play-2.6 instrumentation to support Play version 2.8.x

### DIFF
--- a/dd-java-agent/instrumentation/play-2.6/play-2.6.gradle
+++ b/dd-java-agent/instrumentation/play-2.6/play-2.6.gradle
@@ -17,13 +17,13 @@ muzzle {
   pass {
     group = 'com.typesafe.play'
     module = 'play_2.12'
-    versions = '[2.6.0,2.8.0)'
+    versions = '[2.6.0)'
     assertInverse = true
   }
   pass {
     group = 'com.typesafe.play'
     module = 'play_2.13'
-    versions = '[2.6.0,2.8.0)'
+    versions = '[2.6.0)'
     assertInverse = true
   }
 }

--- a/dd-java-agent/instrumentation/play-2.6/play-2.6.gradle
+++ b/dd-java-agent/instrumentation/play-2.6/play-2.6.gradle
@@ -17,13 +17,13 @@ muzzle {
   pass {
     group = 'com.typesafe.play'
     module = 'play_2.12'
-    versions = '[2.6.0,)'
+    versions = "[$playVersion,)"
     assertInverse = true
   }
   pass {
     group = 'com.typesafe.play'
     module = 'play_2.13'
-    versions = '[2.6.0,)'
+    versions = "[$playVersion,)"
     assertInverse = true
   }
 }

--- a/dd-java-agent/instrumentation/play-2.6/play-2.6.gradle
+++ b/dd-java-agent/instrumentation/play-2.6/play-2.6.gradle
@@ -17,13 +17,13 @@ muzzle {
   pass {
     group = 'com.typesafe.play'
     module = 'play_2.12'
-    versions = '[2.6.0)'
+    versions = '[2.6.0,)'
     assertInverse = true
   }
   pass {
     group = 'com.typesafe.play'
     module = 'play_2.13'
-    versions = '[2.6.0)'
+    versions = '[2.6.0,)'
     assertInverse = true
   }
 }

--- a/dd-java-agent/instrumentation/play-2.6/src/main/java8/datadog/trace/instrumentation/play26/PlayHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/play-2.6/src/main/java8/datadog/trace/instrumentation/play26/PlayHttpServerDecorator.java
@@ -61,7 +61,7 @@ public class PlayHttpServerDecorator extends HttpServerDecorator<Request, Reques
       // more about routes here:
       // https://github.com/playframework/playframework/blob/master/documentation/manual/releases/release26/migration26/Migration26.md
       final Option<HandlerDef> defOption =
-          request.attrs().get(Router.Attrs.HANDLER_DEF.underlying());
+          request.attrs().get(Router.Attrs.HANDLER_DEF.asScala());
       if (!defOption.isEmpty()) {
         final String path = defOption.get().path();
         span.setTag(DDTags.RESOURCE_NAME, request.method() + " " + path);


### PR DESCRIPTION
Possible fix for the problem shown in https://github.com/DataDog/dd-trace-java/pull/1138.

`play.api.libs.TypedKey.underlying` was deprecated in 2.7 and removed in 2.8 (https://github.com/playframework/playframework/commit/be442e255a1153ed6babe29bfb5ad00accbacb2e#diff-0cdc3904ffe7ccdcc86d04337cf912d9), `play.api.libs.TypedKey.asScala` was added in Play 26 instead.


