### PR TITLE
Ignore proxool proxy classes

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/GlobalIgnoresMatcher.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/GlobalIgnoresMatcher.java
@@ -151,6 +151,7 @@ public class GlobalIgnoresMatcher<T extends TypeDescription>
         || name.contains("javassist")
         || name.contains(".asm.")
         || name.contains("$__sisu")
+        || name.contains("$$EnhancerByProxool$$")
         || name.startsWith("org.springframework.core.$Proxy")) {
       return true;
     }


### PR DESCRIPTION
When we wrap these proxy classes we cause the bytecode within these proxies to break.

```
Caused by:java.lang.VerifyError: (class: 
org/postgresql/PGStatement$$EnhancerByProxool$$afb2abd7, method: 
executeWithFlags signature: (Ljava/lang/String;I)Z) Register 3 
contains wrong type	at 
java.base/java.lang.Class.getDeclaredMethods0(Native Method)	at 
java.base/java.lang.Class.privateGetDeclaredMethods(Class.java:3166)	at 
java.base/java.lang.Class.getDeclaredMethod(Class.java:2473)	at
```