### PR TITLE
change error bound so test should almost never fail

### DIFF
--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/CacheProviderTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/CacheProviderTest.groovy
@@ -186,7 +186,7 @@ class CacheProviderTest extends DDSpecification {
 
     then:
     // cache will start to proactively free slots & size calc is approximate
-    poolStrat.approximateSize() > 0.8 * capacity
+    poolStrat.approximateSize() >= 0.75 * capacity
 
     when:
     10.times {


### PR DESCRIPTION
Saw this one fail on master, and reproduced it consistently after about 500 runs using IDEA's repeat until failure feature. Changing 0.8 to 0.75 ran so many test cases (hundreds of thousands) that IDEA crashed :)