### PR TITLE
Tests in dd-trace-core should extend DDSpecification

### DIFF
--- a/dd-trace-core/src/test/groovy/datadog/trace/core/StringTablesTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/StringTablesTest.groovy
@@ -1,17 +1,19 @@
 package datadog.trace.core
 
-import spock.lang.Specification
+import datadog.trace.util.test.DDSpecification
 
-class StringTablesTest extends Specification {
+class StringTablesTest extends DDSpecification {
 
   def "naive string keys table strategy interns a small number of strings"() {
     // when this starts failing, it's time to investigate better ways to precompute UTF-8 encodings
-    expect: StringTables.UTF8_INTERN_KEYS_TABLE.size() < 256
+    expect:
+    StringTables.UTF8_INTERN_KEYS_TABLE.size() < 256
   }
 
   def "naive string tags table strategy interns a small number of strings"() {
     // when this starts failing, it's time to investigate better ways to precompute UTF-8 encodings
-    expect: StringTables.UTF8_INTERN_TAGS_TABLE.size() < 256
+    expect:
+    StringTables.UTF8_INTERN_TAGS_TABLE.size() < 256
   }
 
   def "naive string keys table strategy interns has low spatial overhead"() {
@@ -24,7 +26,8 @@ class StringTablesTest extends Specification {
       approxSizeBytesIgnoringHashMapOverhead += entry.getValue().length
     }
     // less than 4KB memory overhead seems reasonable for reducing GBs of allocations
-    expect: approxSizeBytesIgnoringHashMapOverhead < 1024 * 4
+    expect:
+    approxSizeBytesIgnoringHashMapOverhead < 1024 * 4
   }
 
   def "naive string tags table strategy interns has low spatial overhead"() {
@@ -39,6 +42,7 @@ class StringTablesTest extends Specification {
     // less than 2KB memory overhead seems reasonable for reducing some allocation
     // quite often, but we will often not find a value in this table so it's better
     // this stays small
-    expect: approxSizeBytesIgnoringHashMapOverhead < 2 * 1024
+    expect:
+    approxSizeBytesIgnoringHashMapOverhead < 2 * 1024
   }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/serialization/MsgPackFormatWriterTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/serialization/MsgPackFormatWriterTest.groovy
@@ -1,13 +1,12 @@
 package datadog.trace.core.serialization
 
-
+import datadog.trace.util.test.DDSpecification
 import org.msgpack.core.MessagePack
 import org.msgpack.core.buffer.ArrayBufferOutput
-import spock.lang.Specification
 
 import java.nio.charset.StandardCharsets
 
-class MsgPackFormatWriterTest extends Specification {
+class MsgPackFormatWriterTest extends DDSpecification {
 
   def "serialize strings"() {
     setup:


### PR DESCRIPTION
It has a work around to ensure Config is modifiable before it is loaded and if Config is loaded before hand, it can cause other tests to fail.
For example:
```
Caused by: java.lang.NoClassDefFoundError: Could not initialize class datadog.trace.util.test.DDSpecification
```