### PR TITLE
Fix OT31 tests

### DIFF
--- a/dd-java-agent/instrumentation/opentracing/api-0.31/src/test/groovy/OpenTracing31Test.groovy
+++ b/dd-java-agent/instrumentation/opentracing/api-0.31/src/test/groovy/OpenTracing31Test.groovy
@@ -1,6 +1,7 @@
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.DDTags
 import datadog.trace.api.interceptor.MutableSpan
+import datadog.trace.api.sampling.PrioritySampling
 import datadog.trace.context.TraceScope
 import datadog.trace.core.DDSpan
 import io.opentracing.log.Fields
@@ -212,13 +213,14 @@ class OpenTracing31Test extends AgentTestRunner {
     def adapter = new TextMapAdapter(textMap)
 
     when:
+    context.delegate.samplingPriority = contextPriority
     tracer.inject(context, Format.Builtin.TEXT_MAP, adapter)
 
     then:
     textMap == [
       "x-datadog-trace-id"         : "$context.delegate.traceId",
       "x-datadog-parent-id"        : "$context.delegate.spanId",
-      "x-datadog-sampling-priority": "$context.delegate.samplingPriority",
+      "x-datadog-sampling-priority": propagatedPriority.toString(),
     ]
 
     when:
@@ -227,7 +229,15 @@ class OpenTracing31Test extends AgentTestRunner {
     then:
     extract.delegate.traceId == context.delegate.traceId
     extract.delegate.spanId == context.delegate.spanId
-    extract.delegate.samplingPriority == context.delegate.samplingPriority
+    extract.delegate.samplingPriority == propagatedPriority
+
+    where:
+    contextPriority               | propagatedPriority
+    PrioritySampling.SAMPLER_DROP | PrioritySampling.SAMPLER_DROP
+    PrioritySampling.SAMPLER_KEEP | PrioritySampling.SAMPLER_KEEP
+    PrioritySampling.UNSET        | PrioritySampling.SAMPLER_KEEP
+    PrioritySampling.USER_KEEP    | PrioritySampling.USER_KEEP
+    PrioritySampling.USER_DROP    | PrioritySampling.USER_DROP
   }
 
   static class TextMapAdapter implements TextMap {


### PR DESCRIPTION
The main bug is the handling of `PrioritySampling.UNSET` and how that interacts with `"$context.delegate.samplingPriority"`.  In the unset case, the sampling priority is set on propagation.

Depending on when `"$context.delegate.samplingPriority"` is evaluated it could be one of a couple different values.  This fix has explicit inputs -> outputs