### PR TITLE
Reduce amount of data in scope events

### DIFF
--- a/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/ScopeEvent.java
+++ b/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/ScopeEvent.java
@@ -28,18 +28,6 @@ public final class ScopeEvent extends Event implements DDScopeEvent {
   @Label("Span Id")
   private String spanId;
 
-  @Label("Parent Id")
-  private String parentId;
-
-  @Label("Service Name")
-  private String serviceName;
-
-  @Label("Resource Name")
-  private String resourceName;
-
-  @Label("Operation Name")
-  private String operationName;
-
   @Label("Thread CPU Time")
   @Timespan
   // does not need to be volatile since the event is created and committed from the same thread
@@ -66,10 +54,6 @@ public final class ScopeEvent extends Event implements DDScopeEvent {
       }
       traceId = spanContext.getTraceId().toHexString();
       spanId = spanContext.getSpanId().toHexString();
-      parentId = spanContext.getParentId().toHexString();
-      serviceName = spanContext.getServiceName();
-      resourceName = spanContext.getResourceName();
-      operationName = spanContext.getOperationName();
       commit();
     }
   }

--- a/dd-trace-core/jfr-openjdk/src/test/groovy/datadog/trace/core/jfr/openjdk/ScopeEventTest.groovy
+++ b/dd-trace-core/jfr-openjdk/src/test/groovy/datadog/trace/core/jfr/openjdk/ScopeEventTest.groovy
@@ -72,10 +72,6 @@ class ScopeEventTest extends DDSpecification {
     event.duration >= SLEEP_DURATION
     event.getString("traceId") == span.context().traceId.toHexString()
     event.getString("spanId") == span.context().spanId.toHexString()
-    event.getString("parentId") == span.context().parentId.toHexString()
-    event.getString("serviceName") == "test service"
-    event.getString("resourceName") == "test resource"
-    event.getString("operationName") == "test operation"
     event.getLong("cpuTime") != Long.MIN_VALUE
 
     cleanup:
@@ -105,10 +101,6 @@ class ScopeEventTest extends DDSpecification {
     event.duration >= SLEEP_DURATION
     event.getString("traceId") == span.context().traceId.toHexString()
     event.getString("spanId") == span.context().spanId.toHexString()
-    event.getString("parentId") == span.context().parentId.toHexString()
-    event.getString("serviceName") == "test service"
-    event.getString("resourceName") == "test resource"
-    event.getString("operationName") == "test operation"
     event.getLong("cpuTime") == Long.MIN_VALUE
 
     cleanup:
@@ -138,10 +130,6 @@ class ScopeEventTest extends DDSpecification {
     event.duration >= SLEEP_DURATION
     event.getString("traceId") == span.context().traceId.toHexString()
     event.getString("spanId") == span.context().spanId.toHexString()
-    event.getString("parentId") == span.context().parentId.toHexString()
-    event.getString("serviceName") == "test service"
-    event.getString("resourceName") == "test resource"
-    event.getString("operationName") == "test operation"
     event.getLong("cpuTime") == Long.MIN_VALUE
 
     cleanup:
@@ -170,9 +158,5 @@ class ScopeEventTest extends DDSpecification {
     event.duration >= SLEEP_DURATION
     event.getString("traceId") == span.context().traceId.toHexString()
     event.getString("spanId") == span.context().spanId.toHexString()
-    event.getString("parentId") == span.context().parentId.toHexString()
-    event.getString("serviceName") == "test service"
-    event.getString("resourceName") == "test resource"
-    event.getString("operationName") == "test operation"
   }
 }


### PR DESCRIPTION
Reducing the amount of contextual data saved in the scope events to allow us to capture more scope activations.