### PR TITLE
ApacheHttpClientRedirectInstrumentation copy headers from original request to redirect if original redirect headers were empty

### DIFF
--- a/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/ApacheHttpClientRedirectInstrumentation.java
+++ b/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/ApacheHttpClientRedirectInstrumentation.java
@@ -58,12 +58,23 @@ public class ApacheHttpClientRedirectInstrumentation extends Instrumenter.Defaul
       if (redirect == null) {
         return;
       }
-
-      for (final Header header : original.getAllHeaders()) {
-        final String name = header.getName().toLowerCase();
-        if (name.startsWith("x-datadog-") || name.startsWith("x-b3-")) {
-          if (!redirect.containsHeader(header.getName())) {
-            redirect.setHeader(header.getName(), header.getValue());
+      // Apache HttpClient 4.0.1+ copies headers from original to redirect only
+      // if redirect headers are empty. Because we add headers
+      // "x-datadog-" and "x-b3-" to redirect: it means redirect headers never
+      // will be empty. So in case if not-instrumented redirect had no headers,
+      // we just copy all not set headers from original to redirect (doing same
+      // thing as apache httpclient does).
+      if (!redirect.headerIterator().hasNext()) {
+        // redirect didn't have other headers besides tracing, so we need to do copy
+        // (same work as Apache HttpClient 4.0.1+ does w/o instrumentation)
+        redirect.setHeaders(original.getAllHeaders());
+      } else {
+        for (final Header header : original.getAllHeaders()) {
+          final String name = header.getName().toLowerCase();
+          if (name.startsWith("x-datadog-") || name.startsWith("x-b3-")) {
+            if (!redirect.containsHeader(header.getName())) {
+              redirect.setHeader(header.getName(), header.getValue());
+            }
           }
         }
       }

--- a/dd-java-agent/instrumentation/google-http-client/src/test/groovy/AbstractGoogleHttpClientTest.groovy
+++ b/dd-java-agent/instrumentation/google-http-client/src/test/groovy/AbstractGoogleHttpClientTest.groovy
@@ -25,7 +25,13 @@ abstract class AbstractGoogleHttpClientTest extends HttpClientTest {
     HttpRequest request = requestFactory.buildRequest(method, genericUrl, null)
     request.connectTimeout = CONNECT_TIMEOUT_MS
     request.readTimeout = READ_TIMEOUT_MS
-    request.getHeaders().putAll(headers)
+
+    // GenericData::putAll method converts all known http headers to List<String>
+    // and lowercase all other headers
+    def ci = request.getHeaders().getClassInfo()
+    request.getHeaders().putAll(headers.collectEntries { name, value
+           -> [(name) : (ci.getFieldInfo(name) != null ? [value] : value.toLowerCase())]})
+
     request.setThrowExceptionOnExecuteError(throwExceptionOnError)
 
     HttpResponse response = executeRequest(request)

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
@@ -26,6 +26,8 @@ abstract class HttpClientTest extends AgentTestRunner {
   protected static final BODY_METHODS = ["POST", "PUT"]
   protected static final CONNECT_TIMEOUT_MS = 1000
   protected static final READ_TIMEOUT_MS = 2000
+  protected static final BASIC_AUTH_KEY = "custom authorization header"
+  protected static final BASIC_AUTH_VAL = "plain text auth token"
 
   @AutoCleanup
   @Shared
@@ -52,6 +54,18 @@ abstract class HttpClientTest extends AgentTestRunner {
       prefix("circular-redirect") {
         handleDistributedRequest()
         redirect(server.address.resolve("/circular-redirect").toURL().toString())
+      }
+      prefix("secured") {
+        handleDistributedRequest()
+        if (request.headers.get(BASIC_AUTH_KEY) == BASIC_AUTH_VAL) {
+          response.status(200).send("secured string under basic auth")
+        } else {
+          response.status(401).send("Unauthorized")
+        }
+      }
+      prefix("to-secured") {
+        handleDistributedRequest()
+        redirect(server.address.resolve("/secured").toURL().toString())
       }
     }
   }
@@ -297,6 +311,28 @@ abstract class HttpClientTest extends AgentTestRunner {
       server.distributedRequestTrace(it, 1, trace(2).last())
       trace(2, size(1)) {
         clientSpan(it, 0, null, method, false, false, uri, statusOnRedirectError(), thrownException)
+      }
+    }
+
+    where:
+    method = "GET"
+  }
+
+  def "redirect #method to secured endpoint copies auth header"() {
+    given:
+    assumeTrue(testRedirects())
+    def uri = server.address.resolve("/to-secured")
+
+    when:
+    def status = doRequest(method, uri, [(BASIC_AUTH_KEY) : BASIC_AUTH_VAL])
+
+    then:
+    status == 200
+    assertTraces(3) {
+      server.distributedRequestTrace(it, 0, trace(2).last())
+      server.distributedRequestTrace(it, 1, trace(2).last())
+      trace(2, size(1)) {
+        clientSpan(it, 0, null, method, false, false, uri)
       }
     }
 


### PR DESCRIPTION
ApacheHttpClientRedirectInstrumentation:
copy headers from original request to redirect request only if original redirect headers were empty without additinal headers