### PR TITLE
Allow the mock http server get assigned a transient port.

### DIFF
--- a/dd-smoke-tests/cli/src/test/groovy/datadog/smoketest/CliApplicationSmokeTest.groovy
+++ b/dd-smoke-tests/cli/src/test/groovy/datadog/smoketest/CliApplicationSmokeTest.groovy
@@ -25,6 +25,6 @@ class CliApplicationSmokeTest extends AbstractSmokeTest {
   @Timeout(value = TIMEOUT_SECS, unit = TimeUnit.SECONDS)
   def "Cli application process ends before timeout"() {
     expect:
-    assert serverProcess.waitFor() == 0
+    assert testedProcess.waitFor() == 0
   }
 }

--- a/dd-smoke-tests/java9-modules/src/test/groovy/datadog/smoketest/Java9ModulesSmokeTest.groovy
+++ b/dd-smoke-tests/java9-modules/src/test/groovy/datadog/smoketest/Java9ModulesSmokeTest.groovy
@@ -27,6 +27,6 @@ class Java9ModulesSmokeTest extends AbstractSmokeTest {
   @Timeout(value = TIMEOUT_SECS, unit = TimeUnit.SECONDS)
   def "Module application runs correctly"() {
     expect:
-    assert serverProcess.waitFor() == 0
+    assert testedProcess.waitFor() == 0
   }
 }

--- a/dd-smoke-tests/opentracing/src/test/groovy/datadog/smoketest/OpenTracingSmokeTest.groovy
+++ b/dd-smoke-tests/opentracing/src/test/groovy/datadog/smoketest/OpenTracingSmokeTest.groovy
@@ -32,7 +32,7 @@ abstract class OpenTracingSmokeTest extends AbstractSmokeTest {
     conditions.eventually {
       assert traceRequests.poll(REQUEST_TIMEOUT, TimeUnit.SECONDS)?.getHeader("X-Datadog-Trace-Count")?.size() > 0
     }
-    assert serverProcess.waitFor() == 0
+    assert testedProcess.waitFor() == 0
   }
 }
 

--- a/dd-smoke-tests/profiling-integration-tests/src/test/groovy/datadog/smoketest/AbstractProfilingIntegrationTest.groovy
+++ b/dd-smoke-tests/profiling-integration-tests/src/test/groovy/datadog/smoketest/AbstractProfilingIntegrationTest.groovy
@@ -1,0 +1,42 @@
+package datadog.smoketest
+
+import okhttp3.mockwebserver.MockWebServer
+
+abstract class AbstractProfilingIntegrationTest extends AbstractSmokeTest {
+  // can not be @Shared since the same instance will be reused for all specs and this is not supported by MockWebServer
+  protected static MockWebServer profilingServer
+
+  @Override
+  ProcessBuilder createProcessBuilder() {
+    String profilingShadowJar = System.getProperty("datadog.smoketest.profiling.shadowJar.path")
+
+    List<String> command = new ArrayList<>()
+    command.add(javaPath())
+    command.addAll(defaultJavaProperties)
+    command.addAll((String[]) ["-jar", profilingShadowJar])
+    command.add(Integer.toString(exitDelay))
+    ProcessBuilder processBuilder = new ProcessBuilder(command)
+    processBuilder.directory(new File(buildDirectory))
+    return processBuilder
+  }
+
+  @Override
+  def startServer() {
+    profilingServer = new MockWebServer()
+    profilingServer.start()
+    profilingPort = profilingServer.getPort()
+  }
+
+  @Override
+  def stopServer() {
+    try {
+      profilingServer.shutdown()
+    } catch (final IOException e) {
+      // Looks like this happens for some unclear reason, but should not affect tests
+    }
+  }
+
+  def getExitDelay() {
+    return -1
+  }
+}

--- a/dd-smoke-tests/profiling-integration-tests/src/test/groovy/datadog/smoketest/ProfilingIntegrationBogusApiKeyTest.groovy
+++ b/dd-smoke-tests/profiling-integration-tests/src/test/groovy/datadog/smoketest/ProfilingIntegrationBogusApiKeyTest.groovy
@@ -2,53 +2,26 @@ package datadog.smoketest
 
 
 import okhttp3.mockwebserver.MockResponse
-import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.RecordedRequest
 
 import java.util.concurrent.TimeUnit
 
-class ProfilingIntegrationBogusApiKeyTest extends AbstractSmokeTest {
+class ProfilingIntegrationBogusApiKeyTest extends AbstractProfilingIntegrationTest {
 
   // This needs to give enough time for test app to start up and recording to happen
   private static final int REQUEST_WAIT_TIMEOUT = 40
 
-  // Run app enough time to get profiles if they were sent
-  private static final int RUN_APP_FOR = PROFILING_START_DELAY_SECONDS + PROFILING_RECORDING_UPLOAD_PERIOD_SECONDS * 2 + 1
-
-  private final MockWebServer server = new MockWebServer()
-
   @Override
-  ProcessBuilder createProcessBuilder() {
-    String profilingShadowJar = System.getProperty("datadog.smoketest.profiling.shadowJar.path")
-
-    List<String> command = new ArrayList<>()
-    command.add(javaPath())
-    command.addAll(defaultJavaProperties)
-    command.addAll((String[]) ["-jar", profilingShadowJar])
-    command.add(Integer.toString(RUN_APP_FOR))
-    ProcessBuilder processBuilder = new ProcessBuilder(command)
-    processBuilder.directory(new File(buildDirectory))
-    return processBuilder
-  }
-
-  def setup() {
-    server.start(profilingPort)
-  }
-
-  def cleanup() {
-    try {
-      server.shutdown()
-    } catch (final IOException e) {
-      // Looks like this happens for some unclear reason, but should not affect tests
-    }
+  def getExitDelay() {
+    return PROFILING_START_DELAY_SECONDS + PROFILING_RECORDING_UPLOAD_PERIOD_SECONDS * 2 + 1
   }
 
   def "test that profiling doesn't start with bogus api key"() {
     setup:
-    server.enqueue(new MockResponse().setResponseCode(200))
+    profilingServer.enqueue(new MockResponse().setResponseCode(200))
 
     when:
-    RecordedRequest request = server.takeRequest(REQUEST_WAIT_TIMEOUT, TimeUnit.SECONDS)
+    RecordedRequest request = profilingServer.takeRequest(REQUEST_WAIT_TIMEOUT, TimeUnit.SECONDS)
 
     then:
     // No request expected since profiling was disabled due to bogus api key

--- a/dd-smoke-tests/profiling-integration-tests/src/test/groovy/datadog/smoketest/ProfilingIntegrationContinuousProfilesTest.groovy
+++ b/dd-smoke-tests/profiling-integration-tests/src/test/groovy/datadog/smoketest/ProfilingIntegrationContinuousProfilesTest.groovy
@@ -4,7 +4,6 @@ import com.datadog.profiling.testing.ProfilingTestUtils
 import com.google.common.collect.Multimap
 import net.jpountz.lz4.LZ4FrameInputStream
 import okhttp3.mockwebserver.MockResponse
-import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.RecordedRequest
 import org.openjdk.jmc.common.item.Aggregators
 import org.openjdk.jmc.common.item.Attribute
@@ -16,44 +15,15 @@ import org.openjdk.jmc.flightrecorder.JfrLoaderToolkit
 import java.time.Instant
 import java.util.concurrent.TimeUnit
 
-class ProfilingIntegrationContinuousProfilesTest extends AbstractSmokeTest {
-
-  // This needs to give enough time for test app to start up and recording to happen
+class ProfilingIntegrationContinuousProfilesTest extends AbstractProfilingIntegrationTest {
   private static final int REQUEST_WAIT_TIMEOUT = 40
-
-  private final MockWebServer server = new MockWebServer()
-
-  @Override
-  ProcessBuilder createProcessBuilder() {
-    String profilingShadowJar = System.getProperty("datadog.smoketest.profiling.shadowJar.path")
-
-    List<String> command = new ArrayList<>()
-    command.add(javaPath())
-    command.addAll(defaultJavaProperties)
-    command.addAll((String[]) ["-jar", profilingShadowJar])
-    ProcessBuilder processBuilder = new ProcessBuilder(command)
-    processBuilder.directory(new File(buildDirectory))
-    return processBuilder
-  }
-
-  def setup() {
-    server.start(profilingPort)
-  }
-
-  def cleanup() {
-    try {
-      server.shutdown()
-    } catch (final IOException e) {
-      // Looks like this happens for some unclear reason, but should not affect tests
-    }
-  }
 
   def "test continuous recording"() {
     setup:
-    server.enqueue(new MockResponse().setResponseCode(200))
+    profilingServer.enqueue(new MockResponse().setResponseCode(200))
 
     when:
-    RecordedRequest firstRequest = server.takeRequest(REQUEST_WAIT_TIMEOUT, TimeUnit.SECONDS)
+    RecordedRequest firstRequest = profilingServer.takeRequest(REQUEST_WAIT_TIMEOUT, TimeUnit.SECONDS)
     Multimap<String, Object> firstRequestParameters =
       ProfilingTestUtils.parseProfilingRequestParameters(firstRequest)
 
@@ -82,7 +52,7 @@ class ProfilingIntegrationContinuousProfilesTest extends AbstractSmokeTest {
     firstRequestParameters.get("chunk-data").get(0) != null
 
     when:
-    RecordedRequest secondRequest = server.takeRequest(REQUEST_WAIT_TIMEOUT, TimeUnit.SECONDS)
+    RecordedRequest secondRequest = profilingServer.takeRequest(REQUEST_WAIT_TIMEOUT, TimeUnit.SECONDS)
     Multimap<String, Object> secondRequestParameters =
       ProfilingTestUtils.parseProfilingRequestParameters(secondRequest)
 

--- a/dd-smoke-tests/profiling-integration-tests/src/test/groovy/datadog/smoketest/ProfilingIntegrationShutdownTest.groovy
+++ b/dd-smoke-tests/profiling-integration-tests/src/test/groovy/datadog/smoketest/ProfilingIntegrationShutdownTest.groovy
@@ -2,12 +2,11 @@ package datadog.smoketest
 
 
 import okhttp3.mockwebserver.MockResponse
-import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.RecordedRequest
 
 import java.util.concurrent.TimeUnit
 
-class ProfilingIntegrationShutdownTest extends AbstractSmokeTest {
+class ProfilingIntegrationShutdownTest extends AbstractProfilingIntegrationTest {
 
   // This needs to give enough time for test app to start up and recording to happen
   private static final int REQUEST_WAIT_TIMEOUT = 40
@@ -15,40 +14,17 @@ class ProfilingIntegrationShutdownTest extends AbstractSmokeTest {
   // Run app enough time to get profiles
   private static final int RUN_APP_FOR = PROFILING_START_DELAY_SECONDS + PROFILING_RECORDING_UPLOAD_PERIOD_SECONDS * 2 + 1
 
-  private final MockWebServer server = new MockWebServer()
-
   @Override
-  ProcessBuilder createProcessBuilder() {
-    String profilingShadowJar = System.getProperty("datadog.smoketest.profiling.shadowJar.path")
-
-    List<String> command = new ArrayList<>()
-    command.add(javaPath())
-    command.addAll(defaultJavaProperties)
-    command.addAll((String[]) ["-jar", profilingShadowJar])
-    command.add(Integer.toString(RUN_APP_FOR))
-    ProcessBuilder processBuilder = new ProcessBuilder(command)
-    processBuilder.directory(new File(buildDirectory))
-    return processBuilder
-  }
-
-  def setup() {
-    server.start(profilingPort)
-  }
-
-  def cleanup() {
-    try {
-      server.shutdown()
-    } catch (final IOException e) {
-      // Looks like this happens for some unclear reason, but should not affect tests
-    }
+  def getExitDelay() {
+    return RUN_APP_FOR
   }
 
   def "test that profiling agent doesn't prevent app from exiting"() {
     setup:
-    server.enqueue(new MockResponse().setResponseCode(200))
+    profilingServer.enqueue(new MockResponse().setResponseCode(200))
 
     when:
-    RecordedRequest request = server.takeRequest(REQUEST_WAIT_TIMEOUT, TimeUnit.SECONDS)
+    RecordedRequest request = profilingServer.takeRequest(REQUEST_WAIT_TIMEOUT, TimeUnit.SECONDS)
 
     then:
     request.bodySize > 0
@@ -56,7 +32,7 @@ class ProfilingIntegrationShutdownTest extends AbstractSmokeTest {
     then:
     // Wait for the app exit with some extra time.
     // The expectation is that agent doesn't prevent app from exiting.
-    serverProcess.waitFor(RUN_APP_FOR + 10, TimeUnit.SECONDS) == true
+    testedProcess.waitFor(RUN_APP_FOR + 10, TimeUnit.SECONDS) == true
   }
 
 }

--- a/dd-smoke-tests/src/main/groovy/datadog/smoketest/AbstractServerSmokeTest.groovy
+++ b/dd-smoke-tests/src/main/groovy/datadog/smoketest/AbstractServerSmokeTest.groovy
@@ -17,7 +17,7 @@ abstract class AbstractServerSmokeTest extends AbstractSmokeTest {
   protected OkHttpClient client = OkHttpUtils.client()
 
   def setupSpec() {
-    PortUtils.waitForPortToOpen(httpPort, 240, TimeUnit.SECONDS, serverProcess)
+    PortUtils.waitForPortToOpen(httpPort, 240, TimeUnit.SECONDS, testedProcess)
   }
 
 }

--- a/dd-smoke-tests/src/main/groovy/datadog/smoketest/AbstractSmokeTest.groovy
+++ b/dd-smoke-tests/src/main/groovy/datadog/smoketest/AbstractSmokeTest.groovy
@@ -23,14 +23,13 @@ abstract class AbstractSmokeTest extends Specification {
   @Shared
   protected String shadowJarPath = System.getProperty("datadog.smoketest.agent.shadowJar.path")
   @Shared
-  protected int profilingPort
-  @Shared
-  protected String profilingUrl
+  protected static int profilingPort = -1
+
   @Shared
   protected String[] defaultJavaProperties
 
   @Shared
-  protected Process serverProcess
+  protected Process testedProcess
 
   @Shared
   protected BlockingQueue<TestHttpServer.HandlerApi.RequestApi> traceRequests = new LinkedBlockingQueue<>()
@@ -53,16 +52,12 @@ abstract class AbstractSmokeTest extends Specification {
     traceRequests.clear()
   }
 
-
   def setupSpec() {
     if (buildDirectory == null || shadowJarPath == null) {
       throw new AssertionError("Expected system properties not found. Smoke tests have to be run from Gradle. Please make sure that is the case.")
     }
 
-    profilingPort = PortUtils.randomOpenPort()
-    profilingUrl = "http://localhost:${profilingPort}/"
-
-    server.start()
+    startServer()
 
     defaultJavaProperties = [
       "-javaagent:${shadowJarPath}",
@@ -71,7 +66,7 @@ abstract class AbstractSmokeTest extends Specification {
       "-Ddd.profiling.enabled=true",
       "-Ddd.profiling.start-delay=${PROFILING_START_DELAY_SECONDS}",
       "-Ddd.profiling.upload.period=${PROFILING_RECORDING_UPLOAD_PERIOD_SECONDS}",
-      "-Ddd.profiling.url=http://localhost:${profilingPort}",
+      "-Ddd.profiling.url=${getProfilingUrl()}",
       "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=debug",
       "-Dorg.slf4j.simpleLogger.defaultLogLevel=debug"
     ]
@@ -85,7 +80,7 @@ abstract class AbstractSmokeTest extends Specification {
     File log = new File("${buildDirectory}/reports/testProcess.${this.getClass().getName()}.log")
     processBuilder.redirectOutput(ProcessBuilder.Redirect.to(log))
 
-    serverProcess = processBuilder.start()
+    testedProcess = processBuilder.start()
   }
 
   String javaPath() {
@@ -94,7 +89,23 @@ abstract class AbstractSmokeTest extends Specification {
   }
 
   def cleanupSpec() {
-    serverProcess?.waitForOrKill(1)
+    testedProcess?.waitForOrKill(1)
+    stopServer()
+  }
+
+   def getProfilingUrl() {
+    if (profilingPort == -1) {
+      profilingPort = PortUtils.randomOpenPort()
+    }
+    return "http://localhost:${profilingPort}/"
+  }
+
+  def startServer() {
+    server.start()
+  }
+
+  def stopServer() {
+    // do nothing; 'server' is autocleanup
   }
 
   abstract ProcessBuilder createProcessBuilder()


### PR DESCRIPTION
This change should eradicate the spurious test failures due to port conflicts - at least for the profiling smoke tests by letting the profiling mock http server to use OS allocated transient ports.