### PR TITLE
Add thread sampling data to span tag

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/processor/TraceProcessor.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/processor/TraceProcessor.java
@@ -8,6 +8,7 @@ import datadog.trace.core.processor.rule.DBStatementRule;
 import datadog.trace.core.processor.rule.ErrorRule;
 import datadog.trace.core.processor.rule.HttpStatusErrorRule;
 import datadog.trace.core.processor.rule.MarkSpanForMetricCalculationRule;
+import datadog.trace.core.processor.rule.MethodLevelTracingDataRule;
 import datadog.trace.core.processor.rule.ResourceNameRule;
 import datadog.trace.core.processor.rule.SpanTypeRule;
 import datadog.trace.core.processor.rule.Status404Rule;
@@ -32,6 +33,7 @@ public class TraceProcessor {
         new Status404Rule(),
         new AnalyticsSampleRateRule(),
         new MarkSpanForMetricCalculationRule(),
+        new MethodLevelTracingDataRule(),
       };
 
   private final List<Rule> rules;

--- a/dd-trace-core/src/main/java/datadog/trace/core/processor/rule/MethodLevelTracingDataRule.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/processor/rule/MethodLevelTracingDataRule.java
@@ -1,0 +1,51 @@
+package datadog.trace.core.processor.rule;
+
+import com.google.common.io.BaseEncoding;
+import datadog.trace.bootstrap.instrumentation.api.InstrumentationTags;
+import datadog.trace.core.DDSpan;
+import datadog.trace.core.processor.TraceProcessor;
+import java.util.Collection;
+import java.util.Map;
+
+public class MethodLevelTracingDataRule implements TraceProcessor.Rule {
+  private static final String TAG_PREFIX = InstrumentationTags.DD_MLT + ".";
+
+  // https://github.com/DataDog/datadog-agent/blob/master/pkg/trace/agent/truncator.go
+  private static final int TAG_LENGTH_LIMIT = 5000;
+
+  // 4n / 3 bytes in -> base64 encoding where "n" is the byte array length
+  // Flipping the equation, you get max bytes for a base64 length.
+  private static final int BYTES_LIMIT_PER_TAG = TAG_LENGTH_LIMIT * 3 / 4;
+
+  // Guava encoder because the built in Base64 wasn't added in JDK8
+  private static final BaseEncoding ENCODER = BaseEncoding.base64();
+
+  @Override
+  public String[] aliases() {
+    return new String[0];
+  }
+
+  @Override
+  public void processSpan(
+      final DDSpan span, final Map<String, Object> tags, final Collection<DDSpan> trace) {
+    final Object mltDataObject = span.getAndRemoveTag(InstrumentationTags.DD_MLT);
+
+    if (mltDataObject instanceof byte[]) {
+      final byte[] mltData = (byte[]) mltDataObject;
+      int tagIndex = 0;
+      int dataOffset = 0;
+
+      while (dataOffset < mltData.length) {
+        final int dataLength = Math.min(mltData.length - dataOffset, BYTES_LIMIT_PER_TAG);
+
+        final String tag = TAG_PREFIX + tagIndex;
+        final String value = ENCODER.encode(mltData, dataOffset, dataLength);
+
+        span.setTag(tag, value);
+
+        tagIndex++;
+        dataOffset += dataLength;
+      }
+    }
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/core/processor/rule/MethodLevelTracingDataRule.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/processor/rule/MethodLevelTracingDataRule.java
@@ -17,7 +17,7 @@ public class MethodLevelTracingDataRule implements TraceProcessor.Rule {
   // Flipping the equation, you get max bytes for a base64 length.
   private static final int BYTES_LIMIT_PER_TAG = TAG_LENGTH_LIMIT * 3 / 4;
 
-  // Guava encoder because the built in Base64 wasn't added in JDK8
+  // Guava encoder because the built-in Base64 encoder wasn't added until JDK8
   private static final BaseEncoding ENCODER = BaseEncoding.base64();
 
   @Override

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/TraceProfilingScopeInterceptor.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/TraceProfilingScopeInterceptor.java
@@ -1,9 +1,9 @@
 package datadog.trace.core.scopemanager;
 
-import com.google.common.io.BaseEncoding;
 import com.google.common.util.concurrent.RateLimiter;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import datadog.trace.bootstrap.instrumentation.api.InstrumentationTags;
 import datadog.trace.core.CoreTracer;
 import datadog.trace.core.interceptor.TraceStatsCollector;
 import datadog.trace.mlt.MethodLevelTracer;
@@ -133,16 +133,6 @@ public abstract class TraceProfilingScopeInterceptor
   }
 
   private static class TraceProfilingScope extends DelegatingScope {
-    private static final String SAMPLING_DATA_TAG_PREFIX = "_dd.mlt.";
-
-    // 4n / 3 bytes in -> base64 encoding where "n" is the byte array length
-    // Flipping the equation, you get max bytes for a base64 length.
-    private static final int TAG_LENGTH_LIMIT = 5000;
-    private static final int BYTES_LIMIT_PER_TAG = TAG_LENGTH_LIMIT * 3 / 4;
-
-    // Guava encoder because the built in Base64 was added in JDK8
-    private static final BaseEncoding ENCODER = BaseEncoding.base64();
-
     private final Session session;
 
     private TraceProfilingScope(final AgentSpan span, final Scope delegate) {
@@ -158,24 +148,7 @@ public abstract class TraceProfilingScopeInterceptor
       final byte[] samplingData = session.close();
 
       if (samplingData != null) {
-        encodeSamplingData(samplingData);
-      }
-    }
-
-    private void encodeSamplingData(final byte[] samplingData) {
-      int tagIndex = 0;
-      int dataOffset = 0;
-
-      while (dataOffset < samplingData.length) {
-        final int dataLength = Math.min(samplingData.length - dataOffset, BYTES_LIMIT_PER_TAG);
-
-        final String tag = SAMPLING_DATA_TAG_PREFIX + tagIndex;
-        final String value = ENCODER.encode(samplingData, dataOffset, dataLength);
-
-        span().setTag(tag, value);
-
-        tagIndex++;
-        dataOffset += dataLength;
+        span().setTag(InstrumentationTags.DD_MLT, samplingData);
       }
     }
   }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/processor/MethodLevelTracingDataRuleTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/processor/MethodLevelTracingDataRuleTest.groovy
@@ -1,0 +1,43 @@
+package datadog.trace.core.processor
+
+import datadog.trace.bootstrap.instrumentation.api.InstrumentationTags
+import datadog.trace.core.SpanFactory
+import datadog.trace.core.interceptor.TraceStatsCollector
+import datadog.trace.util.test.DDSpecification
+
+class MethodLevelTracingDataRuleTest extends DDSpecification {
+  def statsCollector = Mock(TraceStatsCollector)
+
+  def processor = new TraceProcessor(statsCollector)
+
+  def span = SpanFactory.newSpanOf(0)
+  def trace = [span]
+
+  def "mlt tag is always removed"() {
+    when:
+    span.setTag(InstrumentationTags.DD_MLT, value)
+    processor.onTraceComplete(trace)
+
+    then:
+    span.getTags().get(InstrumentationTags.DD_MLT) == null
+
+    where:
+    value << [null, new byte[0], "ignored"]
+  }
+
+  def "mlt data is split into at 5000 characters"() {
+    given:
+    byte[] data = new byte[10000]
+    new Random().nextBytes(data)
+
+    when:
+    span.setTag(InstrumentationTags.DD_MLT, data)
+    processor.onTraceComplete(trace)
+
+    then:
+    span.getTags().get(InstrumentationTags.DD_MLT + ".0").size() == 5000
+    span.getTags().get(InstrumentationTags.DD_MLT + ".1").size() == 5000
+    span.getTags().get(InstrumentationTags.DD_MLT + ".2").size() == 3336
+    span.getTags().get(InstrumentationTags.DD_MLT + ".3") == null
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/InstrumentationTags.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/InstrumentationTags.java
@@ -77,4 +77,5 @@ public class InstrumentationTags {
   public static final String TWILIO_STATUS = "twilio.status";
   public static final String TWILIO_PARENT_SID = "twilio.parentSid";
   public static final String DD_MEASURED = "_dd.measured";
+  public static final String DD_MLT = "_dd.mlt";
 }


### PR DESCRIPTION
Add sampling data from the MLT api to the span:

- Base64 encodes the bytes
- Chunks the resulting string into 5000 character parts
- Puts chunks into `_dd.mlt.{index}` tags

I went with the simplest approach (instead of having an encoding interface) because it's just a single method.