### PR TITLE
Fix ProfilingIntegrationMLTTest

### DIFF
--- a/dd-smoke-tests/profiling-integration-tests/src/test/groovy/datadog/smoketest/ProfilingIntegrationMLTTest.groovy
+++ b/dd-smoke-tests/profiling-integration-tests/src/test/groovy/datadog/smoketest/ProfilingIntegrationMLTTest.groovy
@@ -55,8 +55,7 @@ class ProfilingIntegrationMLTTest extends AbstractSmokeTest {
 
     then:
     firstRequest.getRequestUrl().toString() == profilingUrl
-
-    firstRequestParameters.get("recording-name").get(0) == 'dd-profiling'
+    
     firstRequestParameters.get("format").get(0) == "jfr"
     firstRequestParameters.get("type").get(0) == "jfr-continuous"
     firstRequestParameters.get("runtime").get(0) == "jvm"


### PR DESCRIPTION
`recording-name` was removed as a parameter in #1535 