### PR TITLE
Split muzzle across multiple executors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -211,6 +211,7 @@ jobs:
 
   muzzle:
     <<: *defaults
+    parallelism: 4
     steps:
       - checkout
 
@@ -218,8 +219,14 @@ jobs:
       # restoring/saving than the actual increase in time it takes just downloading the artifacts each time.
 
       - run:
+          name: Gather muzzle tasks
+          command: ./gradlew writeMuzzleTasksToFile --parallel --stacktrace --no-daemon
+      - run:
           name: Verify Muzzle
-          command: SKIP_BUILDSCAN="true" GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx4G -Xms64M' -Ddatadog.forkedMaxHeapSize=4G -Ddatadog.forkedMinHeapSize=64M" ./gradlew muzzle --parallel --stacktrace --no-daemon --max-workers=16
+          command: >-
+            SKIP_BUILDSCAN="true"
+            GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx4G -Xms64M' -Ddatadog.forkedMaxHeapSize=4G -Ddatadog.forkedMinHeapSize=64M"
+            ./gradlew `circleci tests split workspace/build/muzzleTasks | xargs` --parallel --stacktrace --no-daemon --max-workers=16
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -211,7 +211,7 @@ jobs:
 
   muzzle:
     <<: *defaults
-    parallelism: 4
+    parallelism: 8
     steps:
       - checkout
 
@@ -220,7 +220,7 @@ jobs:
 
       - run:
           name: Gather muzzle tasks
-          command: ./gradlew writeMuzzleTasksToFile --parallel --stacktrace --no-daemon
+          command: SKIP_BUILDSCAN="true" ./gradlew writeMuzzleTasksToFile --stacktrace --no-daemon
       - run:
           name: Verify Muzzle
           command: >-

--- a/buildSrc/src/main/groovy/MuzzlePlugin.groovy
+++ b/buildSrc/src/main/groovy/MuzzlePlugin.groovy
@@ -33,7 +33,7 @@ class MuzzlePlugin implements Plugin<Project> {
   /**
    * Select a random set of versions to test
    */
-  private static final int RANGE_COUNT_LIMIT = 10
+  private static final int RANGE_COUNT_LIMIT = 25
   /**
    * Remote repositories used to query version ranges and fetch dependencies
    */

--- a/dd-trace-java.gradle
+++ b/dd-trace-java.gradle
@@ -69,3 +69,12 @@ allprojects {
     jvmArgs "-XX:ErrorFile=/tmp/hs_err_pid%p.log"
   }
 }
+
+task writeMuzzleTasksToFile {
+  doLast {
+    def muzzleFile = file("${buildDir}/muzzleTasks")
+    muzzleFile.text = subprojects.findAll { subproject -> subproject.plugins.hasPlugin('muzzle') }
+      .collect { it.path + ":muzzle" }
+      .join('\n')
+  }
+}

--- a/dd-trace-java.gradle
+++ b/dd-trace-java.gradle
@@ -73,6 +73,8 @@ allprojects {
 task writeMuzzleTasksToFile {
   doLast {
     def muzzleFile = file("${buildDir}/muzzleTasks")
+    assert muzzleFile.parentFile.mkdirs() || muzzleFile.parentFile.directory
+
     muzzleFile.text = subprojects.findAll { subproject -> subproject.plugins.hasPlugin('muzzle') }
       .collect { it.path + ":muzzle" }
       .join('\n')


### PR DESCRIPTION
This pull request splits the muzzle task using CircleCI's split function.  The goal being to avoid some of the 25+ min muzzle builds that happen sometime.

**Long muzzle build:**
https://app.circleci.com/pipelines/github/DataDog/dd-trace-java/1360/workflows/881959e9-a14a-4555-a676-1937e7da9b83/jobs/66544

**New build in action:**
https://app.circleci.com/pipelines/github/DataDog/dd-trace-java/1409/workflows/7b8f71e9-5f7a-43e1-9917-730775575a4a/jobs/66999/parallel-runs/6?filterBy=ALL

It's not a perfect split because it's split by project and not by `muzzle-AssertPass-*` and `muzzle-AssertFail-*` tasks.  Some executors take longer depending on their projects.  The reason for this is that splitting by subtask would mean repeating the `compileJava` and `bytebuddy` steps for the same project.  I also didn't look into using the "split according to time" feature because that's overkill.

The parameters can probably be tweaked but I found that 8 executors kept the muzzle task to about the same duration as the test tasks so I didn't put any more effort in.  There's a fixed ~2min startup time for each executor so adding more has diminishing returns.

I found that increasing the tested artifacts limit from 10 -> 25 had no effect on the build time and got more libs to 100% coverage.