### PR TITLE
Switch DDScopeEvent ids to long and remove hex String caching

### DIFF
--- a/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/ScopeEvent.java
+++ b/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/ScopeEvent.java
@@ -23,10 +23,10 @@ public final class ScopeEvent extends Event implements DDScopeEvent {
   private final transient DDSpanContext spanContext;
 
   @Label("Trace Id")
-  private String traceId;
+  private long traceId;
 
   @Label("Span Id")
-  private String spanId;
+  private long spanId;
 
   @Label("Thread CPU Time")
   @Timespan
@@ -52,8 +52,8 @@ public final class ScopeEvent extends Event implements DDScopeEvent {
       if (cpuTime > 0) {
         cpuTime = ThreadCpuTimeAccess.getCurrentThreadCpuTime() - cpuTime;
       }
-      traceId = spanContext.getTraceId().toHexString();
-      spanId = spanContext.getSpanId().toHexString();
+      traceId = spanContext.getTraceId().toLong();
+      spanId = spanContext.getSpanId().toLong();
       commit();
     }
   }

--- a/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/ScopeEvent.java
+++ b/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/ScopeEvent.java
@@ -28,18 +28,6 @@ public final class ScopeEvent extends Event implements DDScopeEvent {
   @Label("Span Id")
   private String spanId;
 
-  @Label("Parent Id")
-  private String parentId;
-
-  @Label("Service Name")
-  private String serviceName;
-
-  @Label("Resource Name")
-  private String resourceName;
-
-  @Label("Operation Name")
-  private String operationName;
-
   @Label("Thread CPU Time")
   @Timespan
   // does not need to be volatile since the event is created and committed from the same thread
@@ -66,10 +54,6 @@ public final class ScopeEvent extends Event implements DDScopeEvent {
       }
       traceId = spanContext.getTraceId().toHexString();
       spanId = spanContext.getSpanId().toHexString();
-      parentId = spanContext.getParentId().toHexString();
-      serviceName = spanContext.getServiceName();
-      resourceName = spanContext.getResourceName();
-      operationName = spanContext.getOperationName();
       commit();
     }
   }

--- a/dd-trace-core/jfr-openjdk/src/test/groovy/datadog/trace/core/jfr/openjdk/ScopeEventTest.groovy
+++ b/dd-trace-core/jfr-openjdk/src/test/groovy/datadog/trace/core/jfr/openjdk/ScopeEventTest.groovy
@@ -70,8 +70,8 @@ class ScopeEventTest extends DDSpecification {
     def event = events[0]
     event.eventType.name == "datadog.Scope"
     event.duration >= SLEEP_DURATION
-    event.getString("traceId") == span.context().traceId.toHexString()
-    event.getString("spanId") == span.context().spanId.toHexString()
+    event.getLong("traceId") == span.context().traceId.toLong()
+    event.getLong("spanId") == span.context().spanId.toLong()
     event.getLong("cpuTime") != Long.MIN_VALUE
 
     cleanup:
@@ -99,8 +99,8 @@ class ScopeEventTest extends DDSpecification {
     def event = events[0]
     event.eventType.name == "datadog.Scope"
     event.duration >= SLEEP_DURATION
-    event.getString("traceId") == span.context().traceId.toHexString()
-    event.getString("spanId") == span.context().spanId.toHexString()
+    event.getLong("traceId") == span.context().traceId.toLong()
+    event.getLong("spanId") == span.context().spanId.toLong()
     event.getLong("cpuTime") == Long.MIN_VALUE
 
     cleanup:
@@ -128,8 +128,8 @@ class ScopeEventTest extends DDSpecification {
     def event = events[0]
     event.eventType.name == "datadog.Scope"
     event.duration >= SLEEP_DURATION
-    event.getString("traceId") == span.context().traceId.toHexString()
-    event.getString("spanId") == span.context().spanId.toHexString()
+    event.getLong("traceId") == span.context().traceId.toLong()
+    event.getLong("spanId") == span.context().spanId.toLong()
     event.getLong("cpuTime") == Long.MIN_VALUE
 
     cleanup:
@@ -156,7 +156,7 @@ class ScopeEventTest extends DDSpecification {
     def event = events[0]
     event.eventType.name == "datadog.Scope"
     event.duration >= SLEEP_DURATION
-    event.getString("traceId") == span.context().traceId.toHexString()
-    event.getString("spanId") == span.context().spanId.toHexString()
+    event.getLong("traceId") == span.context().traceId.toLong()
+    event.getLong("spanId") == span.context().spanId.toLong()
   }
 }

--- a/dd-trace-core/jfr-openjdk/src/test/groovy/datadog/trace/core/jfr/openjdk/ScopeEventTest.groovy
+++ b/dd-trace-core/jfr-openjdk/src/test/groovy/datadog/trace/core/jfr/openjdk/ScopeEventTest.groovy
@@ -72,10 +72,6 @@ class ScopeEventTest extends DDSpecification {
     event.duration >= SLEEP_DURATION
     event.getString("traceId") == span.context().traceId.toHexString()
     event.getString("spanId") == span.context().spanId.toHexString()
-    event.getString("parentId") == span.context().parentId.toHexString()
-    event.getString("serviceName") == "test service"
-    event.getString("resourceName") == "test resource"
-    event.getString("operationName") == "test operation"
     event.getLong("cpuTime") != Long.MIN_VALUE
 
     cleanup:
@@ -105,10 +101,6 @@ class ScopeEventTest extends DDSpecification {
     event.duration >= SLEEP_DURATION
     event.getString("traceId") == span.context().traceId.toHexString()
     event.getString("spanId") == span.context().spanId.toHexString()
-    event.getString("parentId") == span.context().parentId.toHexString()
-    event.getString("serviceName") == "test service"
-    event.getString("resourceName") == "test resource"
-    event.getString("operationName") == "test operation"
     event.getLong("cpuTime") == Long.MIN_VALUE
 
     cleanup:
@@ -138,10 +130,6 @@ class ScopeEventTest extends DDSpecification {
     event.duration >= SLEEP_DURATION
     event.getString("traceId") == span.context().traceId.toHexString()
     event.getString("spanId") == span.context().spanId.toHexString()
-    event.getString("parentId") == span.context().parentId.toHexString()
-    event.getString("serviceName") == "test service"
-    event.getString("resourceName") == "test resource"
-    event.getString("operationName") == "test operation"
     event.getLong("cpuTime") == Long.MIN_VALUE
 
     cleanup:
@@ -170,9 +158,5 @@ class ScopeEventTest extends DDSpecification {
     event.duration >= SLEEP_DURATION
     event.getString("traceId") == span.context().traceId.toHexString()
     event.getString("spanId") == span.context().spanId.toHexString()
-    event.getString("parentId") == span.context().parentId.toHexString()
-    event.getString("serviceName") == "test service"
-    event.getString("resourceName") == "test resource"
-    event.getString("operationName") == "test operation"
   }
 }


### PR DESCRIPTION
Switch the `DDScopeEvent` ids to long and remove hex String caching in `DDId`.

Based on top of #1538