### PR TITLE
Fix sampling

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/mlt/JMXSessionFactory.java
+++ b/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/mlt/JMXSessionFactory.java
@@ -20,11 +20,9 @@ public class JMXSessionFactory implements SessionFactory {
   public Session createSession(String id, Thread thread) {
     ScopeManager scopeManager = threadScopeMapper.forThread(thread);
     ScopeStackCollector scopeStackCollector = scopeManager.startScope(id);
-
     long threadId = thread.getId();
-    JMXSession session = createNewSession(id, threadId, scopeStackCollector);
-    jmxSessions.put(threadId, session);
-    return session;
+    return jmxSessions.compute(
+        threadId, (key, jmxSession) -> createNewSession(id, threadId, scopeStackCollector));
   }
 
   @Override


### PR DESCRIPTION
made threadIds in JMXsampler a set, so you cannot add dumplicates now
skip stacks dispatching when no scope found