### PR TITLE
Fix future cancelation

### DIFF
--- a/utils/thread-utils/src/main/java/datadog/common/exec/CommonTaskExecutor.java
+++ b/utils/thread-utils/src/main/java/datadog/common/exec/CommonTaskExecutor.java
@@ -65,8 +65,7 @@ public final class CommonTaskExecutor extends AbstractExecutorService {
       try {
         final PeriodicTask<T> periodicTask = new PeriodicTask<>(task, target);
         final ScheduledFuture<?> future =
-            executorService.scheduleAtFixedRate(
-                new PeriodicTask<>(task, target), initialDelay, period, unit);
+            executorService.scheduleAtFixedRate(periodicTask, initialDelay, period, unit);
         periodicTask.setFuture(future);
         return future;
       } catch (final RejectedExecutionException e) {

--- a/utils/thread-utils/src/test/groovy/datadog/common/exec/PeriodicSchedulingTest.groovy
+++ b/utils/thread-utils/src/test/groovy/datadog/common/exec/PeriodicSchedulingTest.groovy
@@ -72,10 +72,11 @@ class PeriodicSchedulingTest extends DDSpecification {
     !CommonTaskExecutor.INSTANCE.isShutdown()
 
     when:
-    CommonTaskExecutor.INSTANCE.scheduleAtFixedRate(task, null, 10, 10, MILLISECONDS, "test")
+    def future = CommonTaskExecutor.INSTANCE.scheduleAtFixedRate(task, null, 10, 10, MILLISECONDS, "test")
     Thread.sleep(11)
 
     then:
+    future.isCancelled()
     callCount.get() == 0
   }
 }


### PR DESCRIPTION
We should cancel futures when target is GCed. This was the intention that was overlooked in original implementation.