### PR TITLE
Don't fetch merge commit if not in pull request

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,9 +22,12 @@ commands:
           command: |
             CIRCLE_PR_NUMBER="${CIRCLE_PR_NUMBER:-${CIRCLE_PULL_REQUEST##*/}}"
 
-            FETCH_REFS="${FETCH_REFS} +refs/pull/${CIRCLE_PR_NUMBER}/merge:pr/${CIRCLE_PR_NUMBER}/merge"
-            git fetch -u origin ${FETCH_REFS}
-            git checkout "pr/${CIRCLE_PR_NUMBER}/merge"
+            if [[ -n "${CIRCLE_PR_NUMBER}" ]]
+            then
+              FETCH_REFS="${FETCH_REFS} +refs/pull/${CIRCLE_PR_NUMBER}/merge:pr/${CIRCLE_PR_NUMBER}/merge"
+              git fetch -u origin ${FETCH_REFS}
+              git checkout "pr/${CIRCLE_PR_NUMBER}/merge"
+            fi
       - attach_workspace:
           at: .
 


### PR DESCRIPTION
#1554 didn't check if the build wasn't in a pull request.  This broke the master build (and would break any other non-pull request builds)