### PR TITLE
disable agent if we may append wrong jar to boot classpath

### DIFF
--- a/dd-java-agent/src/main/java/datadog/trace/bootstrap/AgentBootstrap.java
+++ b/dd-java-agent/src/main/java/datadog/trace/bootstrap/AgentBootstrap.java
@@ -5,6 +5,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.lang.instrument.Instrumentation;
+import java.lang.invoke.MethodHandles;
 import java.lang.management.ManagementFactory;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -40,6 +41,7 @@ import java.util.regex.Pattern;
  * </ul>
  */
 public class AgentBootstrap {
+  private static final Class<?> thisClass = MethodHandles.lookup().lookupClass();
 
   public static void premain(final String agentArgs, final Instrumentation inst) {
     agentmain(agentArgs, inst);
@@ -56,24 +58,26 @@ public class AgentBootstrap {
       startMethod.invoke(null, inst, bootstrapURL);
     } catch (final Throwable ex) {
       // Don't rethrow.  We don't have a log manager here, so just print.
+      System.err.println("ERROR " + thisClass.getName());
       ex.printStackTrace();
     }
   }
 
   private static synchronized URL installBootstrapJar(final Instrumentation inst)
       throws IOException, URISyntaxException {
-    URL bootstrapURL = null;
+    URL ddJavaAgentJarURL = null;
 
     // First try Code Source
-    final CodeSource codeSource = AgentBootstrap.class.getProtectionDomain().getCodeSource();
+    final CodeSource codeSource = thisClass.getProtectionDomain().getCodeSource();
 
     if (codeSource != null) {
-      bootstrapURL = codeSource.getLocation();
-      final File bootstrapFile = new File(bootstrapURL.toURI());
+      ddJavaAgentJarURL = codeSource.getLocation();
+      final File bootstrapFile = new File(ddJavaAgentJarURL.toURI());
 
       if (!bootstrapFile.isDirectory()) {
+        checkJarManifestMainClassIsThis(ddJavaAgentJarURL);
         inst.appendToBootstrapClassLoaderSearch(new JarFile(bootstrapFile));
-        return bootstrapURL;
+        return ddJavaAgentJarURL;
       }
     }
 
@@ -114,20 +118,21 @@ public class AgentBootstrap {
     if (!(javaagentFile.exists() || javaagentFile.isFile())) {
       throw new RuntimeException("Unable to find javaagent file: " + javaagentFile);
     }
-    bootstrapURL = javaagentFile.toURI().toURL();
+    ddJavaAgentJarURL = javaagentFile.toURI().toURL();
+    checkJarManifestMainClassIsThis(ddJavaAgentJarURL);
     inst.appendToBootstrapClassLoaderSearch(new JarFile(javaagentFile));
 
-    return bootstrapURL;
+    return ddJavaAgentJarURL;
   }
 
   private static List<String> getVMArgumentsThroughReflection() {
     try {
       // Try Oracle-based
       final Class managementFactoryHelperClass =
-          AgentBootstrap.class.getClassLoader().loadClass("sun.management.ManagementFactoryHelper");
+          thisClass.getClassLoader().loadClass("sun.management.ManagementFactoryHelper");
 
       final Class vmManagementClass =
-          AgentBootstrap.class.getClassLoader().loadClass("sun.management.VMManagement");
+          thisClass.getClassLoader().loadClass("sun.management.VMManagement");
 
       Object vmManagement;
 
@@ -146,7 +151,7 @@ public class AgentBootstrap {
 
     } catch (final ReflectiveOperationException e) {
       try { // Try IBM-based.
-        final Class VMClass = AgentBootstrap.class.getClassLoader().loadClass("com.ibm.oti.vm.VM");
+        final Class VMClass = thisClass.getClassLoader().loadClass("com.ibm.oti.vm.VM");
         final String[] argArray = (String[]) VMClass.getMethod("getVMArgs").invoke(null);
         return Arrays.asList(argArray);
       } catch (final ReflectiveOperationException e1) {
@@ -157,6 +162,27 @@ public class AgentBootstrap {
         return ManagementFactory.getRuntimeMXBean().getInputArguments();
       }
     }
+  }
+
+  private static boolean checkJarManifestMainClassIsThis(final URL jarUrl) throws IOException {
+    final URL manifestUrl = new URL("jar:" + jarUrl + "!/META-INF/MANIFEST.MF");
+    final String mainClassLine = "Main-Class: " + thisClass.getCanonicalName();
+    try (final BufferedReader reader =
+        new BufferedReader(
+            new InputStreamReader(manifestUrl.openStream(), StandardCharsets.UTF_8))) {
+      String line;
+      while ((line = reader.readLine()) != null) {
+        if (line.equals(mainClassLine)) {
+          return true;
+        }
+      }
+    }
+    throw new RuntimeException(
+        "dd-java-agent is not installed, because class '"
+            + thisClass.getCanonicalName()
+            + "' is located in '"
+            + jarUrl
+            + "'. Make sure you don't have this .class-file anywhere, besides dd-java-agent.jar");
   }
 
   /**
@@ -183,8 +209,7 @@ public class AgentBootstrap {
     try (final BufferedReader reader =
         new BufferedReader(
             new InputStreamReader(
-                AgentBootstrap.class.getResourceAsStream("/dd-java-agent.version"),
-                StandardCharsets.UTF_8))) {
+                thisClass.getResourceAsStream("/dd-java-agent.version"), StandardCharsets.UTF_8))) {
 
       for (int c = reader.read(); c != -1; c = reader.read()) {
         sb.append((char) c);

--- a/dd-java-agent/src/test/groovy/datadog/trace/agent/AgentLoadedIntoBootstrapTest.groovy
+++ b/dd-java-agent/src/test/groovy/datadog/trace/agent/AgentLoadedIntoBootstrapTest.groovy
@@ -1,7 +1,9 @@
 package datadog.trace.agent
 
 import datadog.trace.agent.test.IntegrationTestUtils
+import datadog.trace.bootstrap.AgentBootstrap
 import jvmbootstraptest.AgentLoadedChecker
+import jvmbootstraptest.MyClassLoaderIsNotBootstrap
 import spock.lang.Specification
 import spock.lang.Timeout
 
@@ -15,5 +17,24 @@ class AgentLoadedIntoBootstrapTest extends Specification {
       , "" as String[]
       , [:]
       , true) == 0
+  }
+
+  def "AgentBootstrap is loaded not from dd-java-agent.jar"() {
+    setup:
+    def mainClassName = MyClassLoaderIsNotBootstrap.getName()
+    def pathToJar = IntegrationTestUtils.createJarWithClasses(mainClassName,
+      MyClassLoaderIsNotBootstrap,
+      AgentBootstrap).getPath()
+
+    expect:
+    IntegrationTestUtils.runOnSeparateJvm(mainClassName
+      , "" as String[]
+      , "" as String[]
+      , [:]
+      , pathToJar as String
+      , true) == 0
+
+    cleanup:
+    new File(pathToJar).delete()
   }
 }

--- a/dd-java-agent/src/test/java/datadog/trace/agent/test/IntegrationTestUtils.java
+++ b/dd-java-agent/src/test/java/datadog/trace/agent/test/IntegrationTestUtils.java
@@ -159,6 +159,18 @@ public class IntegrationTestUtils {
     throw new RuntimeException("Agent jar not found");
   }
 
+  public static int runOnSeparateJvm(
+      final String mainClassName,
+      final String[] jvmArgs,
+      final String[] mainMethodArgs,
+      final Map<String, String> envVars,
+      final boolean printOutputStreams)
+      throws Exception {
+    final String classPath = System.getProperty("java.class.path");
+    return runOnSeparateJvm(
+        mainClassName, jvmArgs, mainMethodArgs, envVars, classPath, printOutputStreams);
+  }
+
   /**
    * On a separate JVM, run the main method for a given class.
    *
@@ -172,11 +184,11 @@ public class IntegrationTestUtils {
       final String[] jvmArgs,
       final String[] mainMethodArgs,
       final Map<String, String> envVars,
+      final String classpath,
       final boolean printOutputStreams)
       throws Exception {
 
     final String separator = System.getProperty("file.separator");
-    final String classpath = System.getProperty("java.class.path");
     final String path = System.getProperty("java.home") + separator + "bin" + separator + "java";
 
     final List<String> vmArgsList = new ArrayList<>(Arrays.asList(jvmArgs));

--- a/dd-java-agent/src/test/java/jvmbootstraptest/MyClassLoaderIsNotBootstrap.java
+++ b/dd-java-agent/src/test/java/jvmbootstraptest/MyClassLoaderIsNotBootstrap.java
@@ -1,0 +1,9 @@
+package jvmbootstraptest;
+
+public class MyClassLoaderIsNotBootstrap {
+  public static void main(final String[] args) {
+    if (MyClassLoaderIsNotBootstrap.class.getClassLoader() == null) {
+      throw new RuntimeException("Application level class was loaded by bootstrap classloader");
+    }
+  }
+}


### PR DESCRIPTION
If someone by mistake adds content of dd-java-agent.jar to application level "uber.jar" out agent installer will add this "uber.jar" to bootstrap classpath. And if some application level classes are loaded by bootstrap classpath we see random NPEs is user code where we never expect `MyAppClass.getClassLoader()` returns `null` .