### PR TITLE
#1563 do not attempt to instrument websocket upgrade handlers

### DIFF
--- a/dd-java-agent/instrumentation/play-ws-1/src/main/java/datadog/trace/instrumentation/playws1/PlayWSClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/play-ws-1/src/main/java/datadog/trace/instrumentation/playws1/PlayWSClientInstrumentation.java
@@ -14,6 +14,7 @@ import net.bytebuddy.asm.Advice;
 import play.shaded.ahc.org.asynchttpclient.AsyncHandler;
 import play.shaded.ahc.org.asynchttpclient.Request;
 import play.shaded.ahc.org.asynchttpclient.handler.StreamedAsyncHandler;
+import play.shaded.ahc.org.asynchttpclient.ws.WebSocketUpgradeHandler;
 
 @AutoService(Instrumenter.class)
 public class PlayWSClientInstrumentation extends BasePlayWSClientInstrumentation {
@@ -32,7 +33,8 @@ public class PlayWSClientInstrumentation extends BasePlayWSClientInstrumentation
 
       if (asyncHandler instanceof StreamedAsyncHandler) {
         asyncHandler = new StreamedAsyncHandlerWrapper((StreamedAsyncHandler) asyncHandler, span);
-      } else {
+      } else if (!(asyncHandler instanceof WebSocketUpgradeHandler)) {
+        // websocket upgrade handlers aren't supported
         asyncHandler = new AsyncHandlerWrapper(asyncHandler, span);
       }
 

--- a/dd-java-agent/instrumentation/play-ws-2.1/src/main/java/datadog/trace/instrumentation/playws21/PlayWSClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/play-ws-2.1/src/main/java/datadog/trace/instrumentation/playws21/PlayWSClientInstrumentation.java
@@ -14,6 +14,7 @@ import net.bytebuddy.asm.Advice;
 import play.shaded.ahc.org.asynchttpclient.AsyncHandler;
 import play.shaded.ahc.org.asynchttpclient.Request;
 import play.shaded.ahc.org.asynchttpclient.handler.StreamedAsyncHandler;
+import play.shaded.ahc.org.asynchttpclient.ws.WebSocketUpgradeHandler;
 
 @AutoService(Instrumenter.class)
 public class PlayWSClientInstrumentation extends BasePlayWSClientInstrumentation {
@@ -32,7 +33,8 @@ public class PlayWSClientInstrumentation extends BasePlayWSClientInstrumentation
 
       if (asyncHandler instanceof StreamedAsyncHandler) {
         asyncHandler = new StreamedAsyncHandlerWrapper((StreamedAsyncHandler) asyncHandler, span);
-      } else {
+      } else if (!(asyncHandler instanceof WebSocketUpgradeHandler)) {
+        // websocket upgrade handlers aren't supported
         asyncHandler = new AsyncHandlerWrapper(asyncHandler, span);
       }
 

--- a/dd-java-agent/instrumentation/play-ws-2/src/main/java/datadog/trace/instrumentation/playws2/PlayWSClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/play-ws-2/src/main/java/datadog/trace/instrumentation/playws2/PlayWSClientInstrumentation.java
@@ -14,6 +14,7 @@ import net.bytebuddy.asm.Advice;
 import play.shaded.ahc.org.asynchttpclient.AsyncHandler;
 import play.shaded.ahc.org.asynchttpclient.Request;
 import play.shaded.ahc.org.asynchttpclient.handler.StreamedAsyncHandler;
+import play.shaded.ahc.org.asynchttpclient.ws.WebSocketUpgradeHandler;
 
 @AutoService(Instrumenter.class)
 public class PlayWSClientInstrumentation extends BasePlayWSClientInstrumentation {
@@ -32,7 +33,8 @@ public class PlayWSClientInstrumentation extends BasePlayWSClientInstrumentation
 
       if (asyncHandler instanceof StreamedAsyncHandler) {
         asyncHandler = new StreamedAsyncHandlerWrapper((StreamedAsyncHandler) asyncHandler, span);
-      } else {
+      } else if (!(asyncHandler instanceof WebSocketUpgradeHandler)) {
+        // websocket upgrade handlers aren't supported
         asyncHandler = new AsyncHandlerWrapper(asyncHandler, span);
       }
 


### PR DESCRIPTION
Fix for https://github.com/DataDog/dd-trace-java/issues/1563

Stops the play-ws integration from trying to instrument the `WebsocketUpgradeHandler` 