### PR TITLE
Change the LRU cache in MsgpackFormatWriter and also write out Long/Integer directly

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/MsgPackStatefulSerializer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/MsgPackStatefulSerializer.java
@@ -35,11 +35,11 @@ public class MsgPackStatefulSerializer implements StatefulSerializer {
   private static final int TRACE_HISTORY_SIZE = 16;
   private static final int INITIAL_TRACE_SIZE_ESTIMATE = 8 * 1024; // 8KB
 
-  // limiting the size this optimisation applies to decreases the likelihood
-  // that the MessagePacker will allocate a byte[] during UTF-8 encoding,
-  // and restricts the optimisation to very small strings which may scalarise
+  // disabling this optimization to make sure that the MessagePacker will not allocate
+  // a byte[] during UTF-8 encoding, since the cachedWriteString method in
+  // MsgPackFormatWriter is doing that for small strings
   private static final MessagePack.PackerConfig MESSAGE_PACKER_CONFIG =
-      MessagePack.DEFAULT_PACKER_CONFIG.withSmallStringOptimizationThreshold(16);
+      MessagePack.DEFAULT_PACKER_CONFIG.withSmallStringOptimizationThreshold(0);
 
   // reusing this within the context of each thread is handy because it
   // caches an Encoder

--- a/dd-trace-core/src/main/java/datadog/trace/core/serialization/FormatWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/serialization/FormatWriter.java
@@ -62,6 +62,9 @@ public abstract class FormatWriter<DEST> {
   public abstract void writeId(final byte[] key, DDId id, final DEST destination)
       throws IOException;
 
+  public abstract void writeNumberAsString(
+      final byte[] key, final Number value, final DEST destination) throws IOException;
+
   public void writeNumber(final byte[] key, final Number value, final DEST destination)
       throws IOException {
     if (value instanceof Double) {
@@ -102,10 +105,14 @@ public abstract class FormatWriter<DEST> {
       }
     }
     for (Map.Entry<String, Object> entry : tags.entrySet()) {
-      if (entry.getValue() instanceof String) {
-        writeTag(stringToBytes(entry.getKey()), (String) entry.getValue(), destination);
+      byte[] key = stringToBytes(entry.getKey());
+      Object value = entry.getValue();
+      if (value instanceof String) {
+        writeTag(key, (String) value, destination);
+      } else if (value instanceof Number) {
+        writeNumberAsString(key, (Number) value, destination);
       } else {
-        writeString(stringToBytes(entry.getKey()), String.valueOf(entry.getValue()), destination);
+        writeString(key, String.valueOf(entry.getValue()), destination);
       }
     }
     writeMapFooter(destination);

--- a/dd-trace-core/src/main/java/datadog/trace/core/serialization/JsonFormatWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/serialization/JsonFormatWriter.java
@@ -111,6 +111,12 @@ public class JsonFormatWriter extends FormatWriter<JsonWriter> {
     }
   }
 
+  @Override
+  public void writeNumberAsString(byte[] key, Number value, JsonWriter destination)
+      throws IOException {
+    writeString(key, String.valueOf(value), destination);
+  }
+
   private void writeBigInteger(
       final byte[] key, final BigInteger value, final JsonWriter destination) throws IOException {
     writeKey(key, destination);

--- a/dd-trace-core/src/main/java/datadog/trace/core/serialization/MsgpackFormatWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/serialization/MsgpackFormatWriter.java
@@ -95,6 +95,17 @@ public class MsgpackFormatWriter extends FormatWriter<MessagePacker> {
     writeLong(key, id.toLong(), destination);
   }
 
+  @Override
+  public void writeNumberAsString(byte[] key, Number value, MessagePacker destination)
+      throws IOException {
+    writeKey(key, destination);
+    if (value instanceof Long || value instanceof Integer) {
+      writeLongAsString(value.longValue(), destination);
+    } else {
+      cachedWriteString(String.valueOf(value), destination);
+    }
+  }
+
   private void writeUTF8Tag(final String value, final MessagePacker destination)
       throws IOException {
     if (null == value) {
@@ -132,5 +143,83 @@ public class MsgpackFormatWriter extends FormatWriter<MessagePacker> {
         destination.packString(value);
       }
     }
+  }
+
+  private static final byte[] DIGIT_TENS = {
+    '0', '0', '0', '0', '0', '0', '0', '0', '0', '0',
+    '1', '1', '1', '1', '1', '1', '1', '1', '1', '1',
+    '2', '2', '2', '2', '2', '2', '2', '2', '2', '2',
+    '3', '3', '3', '3', '3', '3', '3', '3', '3', '3',
+    '4', '4', '4', '4', '4', '4', '4', '4', '4', '4',
+    '5', '5', '5', '5', '5', '5', '5', '5', '5', '5',
+    '6', '6', '6', '6', '6', '6', '6', '6', '6', '6',
+    '7', '7', '7', '7', '7', '7', '7', '7', '7', '7',
+    '8', '8', '8', '8', '8', '8', '8', '8', '8', '8',
+    '9', '9', '9', '9', '9', '9', '9', '9', '9', '9',
+  };
+
+  private static final byte[] DIGIT_ONES = {
+    '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+    '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+    '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+    '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+    '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+    '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+    '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+    '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+    '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+    '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+  };
+
+  private final byte[] numberByteArray = new byte[20]; // this is max long digits and sign
+
+  private void writeLongAsString(final long value, final MessagePacker destination)
+      throws IOException {
+    int pos = 20; // start from the end
+    long l = value;
+    boolean negative = (l < 0);
+    if (!negative) {
+      l = -l; // do the conversion on negative values to not overflow Long.MIN_VALUE
+    }
+
+    int r;
+    // convert 2 digits per iteration with longs until quotient fits into an int
+    long lq;
+    while (l <= Integer.MIN_VALUE) {
+      lq = l / 100;
+      r = (int) ((lq * 100) - l);
+      l = lq;
+      numberByteArray[--pos] = DIGIT_ONES[r];
+      numberByteArray[--pos] = DIGIT_TENS[r];
+    }
+
+    // convert 2 digits per iteration with ints
+    int iq;
+    int i = (int) l;
+    while (i <= -100) {
+      iq = i / 100;
+      r = (iq * 100) - i;
+      i = iq;
+      numberByteArray[--pos] = DIGIT_ONES[r];
+      numberByteArray[--pos] = DIGIT_TENS[r];
+    }
+
+    // now there are at most two digits left
+    iq = i / 10;
+    r = (iq * 10) - i;
+    numberByteArray[--pos] = (byte) ('0' + r);
+
+    // if there is something left it is the remaining digit
+    if (iq < 0) {
+      numberByteArray[--pos] = (byte) ('0' - iq);
+    }
+
+    if (negative) {
+      numberByteArray[--pos] = (byte) '-';
+    }
+
+    int len = 20 - pos;
+    destination.packRawStringHeader(len);
+    destination.addPayload(numberByteArray, pos, len);
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/util/LRUCache.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/util/LRUCache.java
@@ -1,0 +1,30 @@
+package datadog.trace.core.util;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public final class LRUCache<K, V> extends LinkedHashMap<K, V> {
+  // Copied here since they for some reason are `package` and not `protected` in HashMap
+  private static final int DEFAULT_INITIAL_CAPACITY = 1 << 4;
+  private static final float DEFAULT_LOAD_FACTOR = 0.75f;
+
+  private final int maxEntries;
+
+  public LRUCache(int maxEntries) {
+    this(DEFAULT_INITIAL_CAPACITY, maxEntries);
+  }
+
+  public LRUCache(int initialCapacity, int maxEntries) {
+    this(initialCapacity, DEFAULT_LOAD_FACTOR, maxEntries);
+  }
+
+  public LRUCache(int initialCapacity, float loadFactor, int maxEntries) {
+    super(initialCapacity, loadFactor, true); // keep track of access order
+    this.maxEntries = maxEntries;
+  }
+
+  @Override
+  protected boolean removeEldestEntry(Map.Entry<K, V> eldest) {
+    return size() > maxEntries;
+  }
+}

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/util/LRUCacheTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/util/LRUCacheTest.groovy
@@ -1,0 +1,23 @@
+package datadog.trace.core.util
+
+import datadog.trace.util.test.DDSpecification
+
+class LRUCacheTest extends DDSpecification {
+  def "Should eject least recently used element"() {
+    when:
+    def lruCache = new LRUCache<Integer, String>(5)
+    for (int i = 1; i <= 5; i++) {
+      lruCache.put(i, String.valueOf(i))
+    }
+    // now look at 2 values
+    lruCache.get(1)
+    lruCache.get(3)
+    // now insert 2 new values
+    lruCache.put(6, "6")
+    lruCache.put(7, "7")
+
+    then:
+    lruCache.size() == 5
+    lruCache.values().containsAll(Arrays.asList("1", "3", "5", "6", "7"))
+  }
+}


### PR DESCRIPTION
Two optimizations to the msgpack serialization:

* Changes to a very simple LRU cache, since serialization is single threaded, instead of  the more heavyweight guava one, and also limits the entry length to 32 characters.
* Adds direct writing of Long/Integer as a String without materializing a String
