### PR TITLE
Fix Regression in 0.54.0 in OpenTracing `addReference` usage

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/ReferenceCreator.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/ReferenceCreator.java
@@ -365,6 +365,16 @@ public class ReferenceCreator extends ClassVisitor {
     }
 
     @Override
+    public void visitTypeInsn(final int opcode, final String type) {
+      addReference(
+          new Reference.Builder(type)
+              .withSource(refSourceClassName, currentLineNumber)
+              .withFlag(computeMinimumClassAccess(refSourceType, Type.getObjectType(type)))
+              .build());
+      super.visitTypeInsn(opcode, type);
+    }
+
+    @Override
     public void visitLdcInsn(final Object value) {
       if (value instanceof Type) {
         final Type type = underlyingType((Type) value);

--- a/dd-java-agent/instrumentation/opentracing/api-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/OTTracer.java
+++ b/dd-java-agent/instrumentation/opentracing/api-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/OTTracer.java
@@ -2,8 +2,6 @@ package datadog.trace.instrumentation.opentracing31;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
-import datadog.trace.core.DDSpanContext;
-import datadog.trace.core.propagation.ExtractedContext;
 import datadog.trace.instrumentation.opentracing.DefaultLogHandler;
 import io.opentracing.References;
 import io.opentracing.Scope;
@@ -98,12 +96,6 @@ public class OTTracer implements Tracer {
       }
 
       final AgentSpan.Context context = converter.toContext(referencedContext);
-      if (!(context instanceof ExtractedContext) && !(context instanceof DDSpanContext)) {
-        log.debug(
-            "Expected to have a DDSpanContext or ExtractedContext but got "
-                + context.getClass().getName());
-        return this;
-      }
 
       if (References.CHILD_OF.equals(referenceType)
           || References.FOLLOWS_FROM.equals(referenceType)) {

--- a/dd-java-agent/instrumentation/opentracing/api-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/OTTracer.java
+++ b/dd-java-agent/instrumentation/opentracing/api-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/OTTracer.java
@@ -2,8 +2,6 @@ package datadog.trace.instrumentation.opentracing32;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
-import datadog.trace.core.DDSpanContext;
-import datadog.trace.core.propagation.ExtractedContext;
 import datadog.trace.instrumentation.opentracing.DefaultLogHandler;
 import io.opentracing.References;
 import io.opentracing.Scope;
@@ -111,12 +109,6 @@ public class OTTracer implements Tracer {
       }
 
       final AgentSpan.Context context = converter.toContext(referencedContext);
-      if (!(context instanceof ExtractedContext) && !(context instanceof DDSpanContext)) {
-        log.debug(
-            "Expected to have a DDSpanContext or ExtractedContext but got "
-                + context.getClass().getName());
-        return this;
-      }
 
       if (References.CHILD_OF.equals(referenceType)
           || References.FOLLOWS_FROM.equals(referenceType)) {

--- a/dd-java-agent/instrumentation/opentracing/api-0.32/src/test/groovy/OpenTracing32Test.groovy
+++ b/dd-java-agent/instrumentation/opentracing/api-0.32/src/test/groovy/OpenTracing32Test.groovy
@@ -1,9 +1,12 @@
 import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.api.DDId
 import datadog.trace.api.DDTags
 import datadog.trace.api.interceptor.MutableSpan
 import datadog.trace.api.sampling.PrioritySampling
 import datadog.trace.context.TraceScope
 import datadog.trace.core.DDSpan
+import datadog.trace.core.propagation.ExtractedContext
+import io.opentracing.References
 import io.opentracing.log.Fields
 import io.opentracing.noop.NoopSpan
 import io.opentracing.propagation.Format
@@ -25,7 +28,10 @@ class OpenTracing32Test extends AgentTestRunner {
         .withTag("number", 1)
         .withTag("boolean", true)
     }
-    def result = builder."$method"()
+    if (addReference) {
+      builder.addReference(addReference, tracer.tracer.converter.toSpanContext(new ExtractedContext(DDId.ONE, DDId.from(2), 0, null, [:], [:])))
+    }
+    def result = builder.start()
     if (tagSpan) {
       result.setTag(DDTags.RESOURCE_NAME, "other resource")
         .setTag("string", "b")
@@ -57,7 +63,11 @@ class OpenTracing32Test extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          parent()
+          if ([References.CHILD_OF, References.FOLLOWS_FROM].contains(addReference)) {
+            parentDDId(DDId.from(2))
+          } else {
+            parent()
+          }
           serviceName "unnamed-java-app"
           operationName "some name"
           if (tagSpan) {
@@ -81,7 +91,7 @@ class OpenTracing32Test extends AgentTestRunner {
             if (exception) {
               errorTags(exception.class)
             }
-            defaultTags()
+            defaultTags(addReference != null)
           }
           metrics {
             defaultMetrics()
@@ -91,11 +101,11 @@ class OpenTracing32Test extends AgentTestRunner {
     }
 
     where:
-    method        | tagBuilder | tagSpan | exception
-    "start"       | true       | false   | null
-    "startManual" | true       | true    | new Exception()
-    "startManual" | false      | false   | new Exception()
-    "start"       | false      | true    | null
+    method        | addReference            | tagBuilder | tagSpan | exception
+    "start"       | null                    | true       | false   | null
+    "startManual" | References.CHILD_OF     | true       | true    | new Exception()
+    "startManual" | "bogus"                 | false      | false   | new Exception()
+    "start"       | References.FOLLOWS_FROM | false      | true    | null
   }
 
   def "test startActive"() {
@@ -229,7 +239,6 @@ class OpenTracing32Test extends AgentTestRunner {
     then:
     extract.delegate.traceId == context.delegate.traceId
     extract.delegate.spanId == context.delegate.spanId
-    extract.delegate.samplingPriority == context.delegate.samplingPriority
     extract.delegate.samplingPriority == propagatedPriority
 
     where:

--- a/dd-java-agent/testing/src/test/groovy/muzzle/ReferenceCreatorTest.groovy
+++ b/dd-java-agent/testing/src/test/groovy/muzzle/ReferenceCreatorTest.groovy
@@ -4,6 +4,7 @@ import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.tooling.muzzle.Reference
 import datadog.trace.agent.tooling.muzzle.ReferenceCreator
 
+import static muzzle.TestClasses.InstanceofAdvice
 import static muzzle.TestClasses.LdcAdvice
 import static muzzle.TestClasses.MethodBodyAdvice
 
@@ -62,6 +63,14 @@ class ReferenceCreatorTest extends AgentTestRunner {
   def "ldc creates references"() {
     setup:
     Map<String, Reference> references = ReferenceCreator.createReferencesFrom(LdcAdvice.getName(), this.getClass().getClassLoader())
+
+    expect:
+    references.get('muzzle.TestClasses$MethodBodyAdvice$A') != null
+  }
+
+  def "instanceof creates references"() {
+    setup:
+    Map<String, Reference> references = ReferenceCreator.createReferencesFrom(InstanceofAdvice.getName(), this.getClass().getClassLoader())
 
     expect:
     references.get('muzzle.TestClasses$MethodBodyAdvice$A') != null

--- a/dd-java-agent/testing/src/test/java/muzzle/TestClasses.java
+++ b/dd-java-agent/testing/src/test/java/muzzle/TestClasses.java
@@ -7,8 +7,8 @@ public class TestClasses {
   public static class MethodBodyAdvice {
     @Advice.OnMethodEnter
     public static void methodBodyAdvice() {
-      A a = new A();
-      SomeInterface inter = new SomeImplementation();
+      final A a = new A();
+      final SomeInterface inter = new SomeImplementation();
       inter.someMethod();
       a.b.aMethod("foo");
       a.b.aMethodWithPrimitives(false);
@@ -20,18 +20,18 @@ public class TestClasses {
     public static class A {
       public B b = new B();
       protected Object protectedField = null;
-      private Object privateField = null;
+      private final Object privateField = null;
       public static B staticB = new B();
     }
 
     public static class B {
-      public String aMethod(String s) {
+      public String aMethod(final String s) {
         return s;
       }
 
-      public void aMethodWithPrimitives(boolean b) {}
+      public void aMethodWithPrimitives(final boolean b) {}
 
-      public Object[] aMethodWithArrays(String[] s) {
+      public Object[] aMethodWithArrays(final String[] s) {
         return s;
       }
 
@@ -44,7 +44,7 @@ public class TestClasses {
 
     public static class B2 extends B {
       public void stuff() {
-        B b = new B();
+        final B b = new B();
         b.protectedMethod();
       }
     }
@@ -72,6 +72,12 @@ public class TestClasses {
   public static class LdcAdvice {
     public static void ldcMethod() {
       MethodBodyAdvice.A.class.getName();
+    }
+  }
+
+  public static class InstanceofAdvice {
+    public static boolean instanceofMethod(final Object a) {
+      return a instanceof MethodBodyAdvice.A;
     }
   }
 }


### PR DESCRIPTION
The muzzle compile time check failed to detect invalid references in the advice helper classes because they were simply `instanceof` checks.
I've updated muzzle to detect this problem and removed the references since they are not really necessary.
This might increase the instrumentation class's resident size due to more reference types being detected.

Reported in: #1566