### PR TITLE
Prevent re-entering throwable instrumentation handler

### DIFF
--- a/dd-java-agent/instrumentation/exception-profiling/src/main/java/datadog/exceptions/instrumentation/ThrowableInstrumentation.java
+++ b/dd-java-agent/instrumentation/exception-profiling/src/main/java/datadog/exceptions/instrumentation/ThrowableInstrumentation.java
@@ -46,7 +46,8 @@ public final class ThrowableInstrumentation extends Instrumenter.Default {
           "com.datadog.profiling.exceptions.ExceptionHistogram$Pair",
           "com.datadog.profiling.exceptions.ExceptionProfiling",
           "com.datadog.profiling.exceptions.ExceptionSampleEvent",
-          "com.datadog.profiling.exceptions.ExceptionSampler"
+          "com.datadog.profiling.exceptions.ExceptionSampler",
+          "datadog.exceptions.instrumentation.ThrowableInstanceAdviceHelper"
         }
         : new String[0];
   }

--- a/dd-java-agent/instrumentation/exception-profiling/src/main/java11/datadog/exceptions/instrumentation/ThrowableInstanceAdvice.java
+++ b/dd-java-agent/instrumentation/exception-profiling/src/main/java11/datadog/exceptions/instrumentation/ThrowableInstanceAdvice.java
@@ -7,21 +7,27 @@ import net.bytebuddy.asm.Advice;
 public class ThrowableInstanceAdvice {
   @Advice.OnMethodExit(suppress = Throwable.class)
   public static void onExit(@Advice.This final Throwable t) {
-    /*
-     * We may get into a situation when this is called before ExceptionProfiling had a chance
-     * to fully initialize. So despite the fact that this returns static singleton this may
-     * return null sometimes.
-     */
-    if (ExceptionProfiling.getInstance() == null) {
-      return;
-    }
-    /*
-     * JFR will assign the stacktrace depending on the place where the event is committed.
-     * Therefore we need to commit the event here, right in the 'Exception' constructor
-     */
-    final ExceptionSampleEvent event = ExceptionProfiling.getInstance().process(t);
-    if (event != null && event.shouldCommit()) {
-      event.commit();
+    if (ThrowableInstanceAdviceHelper.enterHandler()) {
+      try {
+        /*
+         * We may get into a situation when this is called before ExceptionProfiling had a chance
+         * to fully initialize. So despite the fact that this returns static singleton this may
+         * return null sometimes.
+         */
+        if (ExceptionProfiling.getInstance() == null) {
+          return;
+        }
+        /*
+         * JFR will assign the stacktrace depending on the place where the event is committed.
+         * Therefore we need to commit the event here, right in the 'Exception' constructor
+         */
+        final ExceptionSampleEvent event = ExceptionProfiling.getInstance().process(t);
+        if (event != null && event.shouldCommit()) {
+          event.commit();
+        }
+      } finally {
+        ThrowableInstanceAdviceHelper.exitHandler();
+      }
     }
   }
 }

--- a/dd-java-agent/instrumentation/exception-profiling/src/main/java11/datadog/exceptions/instrumentation/ThrowableInstanceAdvice.java
+++ b/dd-java-agent/instrumentation/exception-profiling/src/main/java11/datadog/exceptions/instrumentation/ThrowableInstanceAdvice.java
@@ -7,6 +7,14 @@ import net.bytebuddy.asm.Advice;
 public class ThrowableInstanceAdvice {
   @Advice.OnMethodExit(suppress = Throwable.class)
   public static void onExit(@Advice.This final Throwable t) {
+    /*
+     * This instrumentation handler is sensitive to any throwables thrown from its body -
+     * it will go into infinite loop of trying to handle the new throwable instance and generating
+     * another instance while doing so.
+     *
+     * The solution is to keep a TLS flag and just skip the handler if it was invoked as a result of handling
+     * a previous throwable instance (on the same thread).
+     */
     if (ThrowableInstanceAdviceHelper.enterHandler()) {
       try {
         /*

--- a/dd-java-agent/instrumentation/exception-profiling/src/main/java11/datadog/exceptions/instrumentation/ThrowableInstanceAdviceHelper.java
+++ b/dd-java-agent/instrumentation/exception-profiling/src/main/java11/datadog/exceptions/instrumentation/ThrowableInstanceAdviceHelper.java
@@ -1,8 +1,15 @@
 package datadog.exceptions.instrumentation;
 
+/**
+ * A simple utility class to provide re-entrancy guard support
+ */
 public final class ThrowableInstanceAdviceHelper {
   private static final ThreadLocal<Boolean> enteredFlag = ThreadLocal.withInitial(() -> false);
 
+  /**
+   * Try to enter 'handler' code
+   * @return {@literal true} if the handler hasn't been entered yet on this thread, {@literal false} otherwise
+   */
   public static boolean enterHandler() {
     if (enteredFlag.get()) {
       return false;
@@ -11,6 +18,10 @@ public final class ThrowableInstanceAdviceHelper {
     return true;
   }
 
+  /**
+   * Exit the 'handler' code.
+   * Should be always called in finally block of the handler.
+   */
   public static void exitHandler() {
     enteredFlag.remove();
   }

--- a/dd-java-agent/instrumentation/exception-profiling/src/main/java11/datadog/exceptions/instrumentation/ThrowableInstanceAdviceHelper.java
+++ b/dd-java-agent/instrumentation/exception-profiling/src/main/java11/datadog/exceptions/instrumentation/ThrowableInstanceAdviceHelper.java
@@ -1,0 +1,17 @@
+package datadog.exceptions.instrumentation;
+
+public final class ThrowableInstanceAdviceHelper {
+  private static final ThreadLocal<Boolean> enteredFlag = ThreadLocal.withInitial(() -> false);
+
+  public static boolean enterHandler() {
+    if (enteredFlag.get()) {
+      return false;
+    }
+    enteredFlag.set(true);
+    return true;
+  }
+
+  public static void exitHandler() {
+    enteredFlag.remove();
+  }
+}

--- a/dd-java-agent/instrumentation/exception-profiling/src/test/java/datadog/exceptions/instrumentation/ThrowableInstanceAdviceHelperTest.java
+++ b/dd-java-agent/instrumentation/exception-profiling/src/test/java/datadog/exceptions/instrumentation/ThrowableInstanceAdviceHelperTest.java
@@ -1,0 +1,46 @@
+package datadog.exceptions.instrumentation;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ThrowableInstanceAdviceHelperTest {
+  @BeforeEach
+  void setup() {
+    ThrowableInstanceAdviceHelper.exitHandler(); // reset the tracker
+  }
+
+  @Test
+  void singleReenter() {
+    assertTrue(ThrowableInstanceAdviceHelper.enterHandler());
+    assertFalse(ThrowableInstanceAdviceHelper.enterHandler());
+  }
+
+  @Test
+  void reenterAfterExit() {
+    assertTrue(ThrowableInstanceAdviceHelper.enterHandler());
+    ThrowableInstanceAdviceHelper.exitHandler();
+    assertTrue(ThrowableInstanceAdviceHelper.enterHandler());
+  }
+
+  @Test
+  void reenterAfterExitMulti() {
+    assertTrue(ThrowableInstanceAdviceHelper.enterHandler());
+    for (int i = 0; i < 111; i++) {
+      assertFalse(ThrowableInstanceAdviceHelper.enterHandler());
+    }
+    ThrowableInstanceAdviceHelper.exitHandler();
+    assertTrue(ThrowableInstanceAdviceHelper.enterHandler());
+  }
+
+  @Test
+  void multiExit() {
+    assertTrue(ThrowableInstanceAdviceHelper.enterHandler());
+    for (int i = 0; i < 111; i++) {
+      ThrowableInstanceAdviceHelper.exitHandler();
+    }
+    assertTrue(ThrowableInstanceAdviceHelper.enterHandler());
+  }
+}

--- a/dd-smoke-tests/profiling-integration-tests/profiling-integration-tests.gradle
+++ b/dd-smoke-tests/profiling-integration-tests/profiling-integration-tests.gradle
@@ -34,3 +34,9 @@ tasks.withType(Test).configureEach {
 
   jvmArgs "-Ddatadog.smoketest.profiling.shadowJar.path=${tasks.shadowJar.archivePath}"
 }
+
+shadowJar {
+  dependencies {
+    include(dependency('org.slf4j::'))
+  }
+}

--- a/dd-smoke-tests/profiling-integration-tests/profiling-integration-tests.gradle
+++ b/dd-smoke-tests/profiling-integration-tests/profiling-integration-tests.gradle
@@ -22,7 +22,6 @@ jar {
 
 dependencies {
   compile project(':dd-trace-api')
-  compile group: 'org.lz4', name: 'lz4-java', version: '1.7.1'
 
   testCompile project(':dd-smoke-tests')
   testCompile project(':dd-java-agent:agent-profiling:profiling-testing')
@@ -33,10 +32,4 @@ tasks.withType(Test).configureEach {
   dependsOn shadowJar
 
   jvmArgs "-Ddatadog.smoketest.profiling.shadowJar.path=${tasks.shadowJar.archivePath}"
-}
-
-shadowJar {
-  dependencies {
-    include(dependency('org.slf4j::'))
-  }
 }

--- a/dd-smoke-tests/profiling-integration-tests/src/test/groovy/datadog/smoketest/AbstractProfilingIntegrationTest.groovy
+++ b/dd-smoke-tests/profiling-integration-tests/src/test/groovy/datadog/smoketest/AbstractProfilingIntegrationTest.groovy
@@ -1,10 +1,14 @@
 package datadog.smoketest
 
 import okhttp3.mockwebserver.MockWebServer
+import spock.lang.Shared
 
 abstract class AbstractProfilingIntegrationTest extends AbstractSmokeTest {
   // can not be @Shared since the same instance will be reused for all specs and this is not supported by MockWebServer
   protected static MockWebServer profilingServer
+
+  @Shared
+  def logHasErrors
 
   @Override
   ProcessBuilder createProcessBuilder() {
@@ -38,5 +42,19 @@ abstract class AbstractProfilingIntegrationTest extends AbstractSmokeTest {
 
   def getExitDelay() {
     return -1
+  }
+
+  def checkLog(Closure checker) {
+    new File("${buildDirectory}/reports/testProcess.${this.getClass().getName()}.log").eachLine {
+      if (it.contains("ERROR") || it.contains("WARN") || it.contains("ASSERTION FAILED")) {
+        println it
+        logHasErrors = true
+      }
+      checker(it)
+    }
+  }
+
+  def checkLog() {
+    checkLog {}
   }
 }

--- a/dd-smoke-tests/profiling-integration-tests/src/test/groovy/datadog/smoketest/AbstractProfilingIntegrationTest.groovy
+++ b/dd-smoke-tests/profiling-integration-tests/src/test/groovy/datadog/smoketest/AbstractProfilingIntegrationTest.groovy
@@ -7,9 +7,6 @@ abstract class AbstractProfilingIntegrationTest extends AbstractSmokeTest {
   // can not be @Shared since the same instance will be reused for all specs and this is not supported by MockWebServer
   protected static MockWebServer profilingServer
 
-  @Shared
-  def logHasErrors
-
   @Override
   ProcessBuilder createProcessBuilder() {
     String profilingShadowJar = System.getProperty("datadog.smoketest.profiling.shadowJar.path")
@@ -42,19 +39,5 @@ abstract class AbstractProfilingIntegrationTest extends AbstractSmokeTest {
 
   def getExitDelay() {
     return -1
-  }
-
-  def checkLog(Closure checker) {
-    new File("${buildDirectory}/reports/testProcess.${this.getClass().getName()}.log").eachLine {
-      if (it.contains("ERROR") || it.contains("WARN") || it.contains("ASSERTION FAILED")) {
-        println it
-        logHasErrors = true
-      }
-      checker(it)
-    }
-  }
-
-  def checkLog() {
-    checkLog {}
   }
 }

--- a/dd-smoke-tests/profiling-integration-tests/src/test/groovy/datadog/smoketest/ProfilingIntegrationBogusApiKeyTest.groovy
+++ b/dd-smoke-tests/profiling-integration-tests/src/test/groovy/datadog/smoketest/ProfilingIntegrationBogusApiKeyTest.groovy
@@ -22,8 +22,10 @@ class ProfilingIntegrationBogusApiKeyTest extends AbstractProfilingIntegrationTe
 
     when:
     RecordedRequest request = profilingServer.takeRequest(REQUEST_WAIT_TIMEOUT, TimeUnit.SECONDS)
+    checkLog()
 
     then:
+    !logHasErrors
     // No request expected since profiling was disabled due to bogus api key
     request == null
   }

--- a/dd-smoke-tests/profiling-integration-tests/src/test/groovy/datadog/smoketest/ProfilingIntegrationContinuousProfilesTest.groovy
+++ b/dd-smoke-tests/profiling-integration-tests/src/test/groovy/datadog/smoketest/ProfilingIntegrationContinuousProfilesTest.groovy
@@ -56,7 +56,10 @@ class ProfilingIntegrationContinuousProfilesTest extends AbstractProfilingIntegr
     Multimap<String, Object> secondRequestParameters =
       ProfilingTestUtils.parseProfilingRequestParameters(secondRequest)
 
+    checkLog()
+
     then:
+    !logHasErrors
     secondRequest.getRequestUrl().toString() == profilingUrl
     secondRequest.getHeader("DD-API-KEY") == apiKey()
 

--- a/dd-smoke-tests/profiling-integration-tests/src/test/groovy/datadog/smoketest/ProfilingIntegrationShutdownTest.groovy
+++ b/dd-smoke-tests/profiling-integration-tests/src/test/groovy/datadog/smoketest/ProfilingIntegrationShutdownTest.groovy
@@ -26,7 +26,10 @@ class ProfilingIntegrationShutdownTest extends AbstractProfilingIntegrationTest 
     when:
     RecordedRequest request = profilingServer.takeRequest(REQUEST_WAIT_TIMEOUT, TimeUnit.SECONDS)
 
+    checkLog()
+
     then:
+    !logHasErrors
     request.bodySize > 0
 
     then:


### PR DESCRIPTION
The throwable instance instrumentation handler is using code which in turn will end up using lazily linked lambdas - and as a part of the linkage process a `LinkageError` is thrown. Which will enter the throwable instrumentation handler code and so on and so forth.

This patch is adding a TLS flag which is supposed to prevent re-entrant execution of the instrumentation handler.
In addition to the main fix the smoke tests were updated to detect this kind of failure (and also other failures manifesting as ERROR or WARN messages in the test application log file) such that it can be detected earlier in the future.