### PR TITLE
Extract Config into Deprecated and Non-Deprecated parts

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/ServerDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/ServerDecorator.java
@@ -1,6 +1,6 @@
 package datadog.trace.bootstrap.instrumentation.decorator;
 
-import datadog.trace.api.Config;
+import datadog.trace.api.DDTags;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 
@@ -10,7 +10,7 @@ public abstract class ServerDecorator extends BaseDecorator {
   public AgentSpan afterStart(final AgentSpan span) {
     assert span != null;
     span.setTag(Tags.SPAN_KIND, Tags.SPAN_KIND_SERVER);
-    span.setTag(Config.LANGUAGE_TAG_KEY, Config.LANGUAGE_TAG_VALUE);
+    span.setTag(DDTags.LANGUAGE_TAG_KEY, DDTags.LANGUAGE_TAG_VALUE);
     return super.afterStart(span);
   }
 }

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/DatabaseClientDecoratorTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/DatabaseClientDecoratorTest.groovy
@@ -1,11 +1,11 @@
 package datadog.trace.bootstrap.instrumentation.decorator
 
-import datadog.trace.api.Config
 import datadog.trace.api.DDTags
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan
 import datadog.trace.bootstrap.instrumentation.api.Tags
 
 import static datadog.trace.agent.test.utils.ConfigUtils.withConfigOverride
+import static datadog.trace.api.config.TraceInstrumentationConfig.DB_CLIENT_HOST_SPLIT_BY_INSTANCE
 
 class DatabaseClientDecoratorTest extends ClientDecoratorTest {
 
@@ -38,7 +38,7 @@ class DatabaseClientDecoratorTest extends ClientDecoratorTest {
     def decorator = newDecorator()
 
     when:
-    withConfigOverride(Config.DB_CLIENT_HOST_SPLIT_BY_INSTANCE, "$renameService") {
+    withConfigOverride(DB_CLIENT_HOST_SPLIT_BY_INSTANCE, "$renameService") {
       decorator.onConnection(span, session)
     }
 

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecoratorTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecoratorTest.groovy
@@ -1,12 +1,12 @@
 package datadog.trace.bootstrap.instrumentation.decorator
 
 
-import datadog.trace.api.Config
 import datadog.trace.api.DDTags
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan
 import datadog.trace.bootstrap.instrumentation.api.Tags
 
 import static datadog.trace.agent.test.utils.ConfigUtils.withConfigOverride
+import static datadog.trace.api.config.TraceInstrumentationConfig.HTTP_SERVER_TAG_QUERY_STRING
 
 class HttpServerDecoratorTest extends ServerDecoratorTest {
 
@@ -41,7 +41,7 @@ class HttpServerDecoratorTest extends ServerDecoratorTest {
     def decorator = newDecorator()
 
     when:
-    withConfigOverride(Config.HTTP_SERVER_TAG_QUERY_STRING, "$tagQueryString") {
+    withConfigOverride(HTTP_SERVER_TAG_QUERY_STRING, "$tagQueryString") {
       decorator.onRequest(span, req)
     }
 

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/ServerDecoratorTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/ServerDecoratorTest.groovy
@@ -1,9 +1,14 @@
 package datadog.trace.bootstrap.instrumentation.decorator
 
-import datadog.trace.api.Config
-import datadog.trace.api.DDTags
+
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan
-import datadog.trace.bootstrap.instrumentation.api.Tags
+
+import static datadog.trace.api.DDTags.ANALYTICS_SAMPLE_RATE
+import static datadog.trace.api.DDTags.LANGUAGE_TAG_KEY
+import static datadog.trace.api.DDTags.LANGUAGE_TAG_VALUE
+import static datadog.trace.api.DDTags.SPAN_TYPE
+import static datadog.trace.bootstrap.instrumentation.api.Tags.COMPONENT
+import static datadog.trace.bootstrap.instrumentation.api.Tags.SPAN_KIND
 
 class ServerDecoratorTest extends BaseDecoratorTest {
 
@@ -15,12 +20,12 @@ class ServerDecoratorTest extends BaseDecoratorTest {
     decorator.afterStart(span)
 
     then:
-    1 * span.setTag(Config.LANGUAGE_TAG_KEY, Config.LANGUAGE_TAG_VALUE)
-    1 * span.setTag(Tags.COMPONENT, "test-component")
-    1 * span.setTag(Tags.SPAN_KIND, "server")
-    1 * span.setTag(DDTags.SPAN_TYPE, decorator.spanType())
+    1 * span.setTag(LANGUAGE_TAG_KEY, LANGUAGE_TAG_VALUE)
+    1 * span.setTag(COMPONENT, "test-component")
+    1 * span.setTag(SPAN_KIND, "server")
+    1 * span.setTag(SPAN_TYPE, decorator.spanType())
     if (decorator.traceAnalyticsEnabled) {
-      1 * span.setTag(DDTags.ANALYTICS_SAMPLE_RATE, 1.0)
+      1 * span.setTag(ANALYTICS_SAMPLE_RATE, 1.0)
     }
     0 * _
   }

--- a/dd-java-agent/agent-jmxfetch/agent-jmxfetch.gradle
+++ b/dd-java-agent/agent-jmxfetch/agent-jmxfetch.gradle
@@ -11,6 +11,7 @@ dependencies {
   }
   compile deps.slf4j
   compile project(':dd-trace-api')
+  compile project(':internal-api')
 }
 
 shadowJar {
@@ -18,6 +19,7 @@ shadowJar {
   dependencies {
     exclude(project(':dd-java-agent:agent-bootstrap'))
     exclude(project(':dd-trace-api'))
+    exclude(project(':internal-api'))
     exclude(dependency('org.slf4j::'))
   }
 }

--- a/dd-java-agent/agent-jmxfetch/src/main/java/datadog/trace/agent/jmxfetch/JMXFetch.java
+++ b/dd-java-agent/agent-jmxfetch/src/main/java/datadog/trace/agent/jmxfetch/JMXFetch.java
@@ -4,7 +4,7 @@ import static org.datadog.jmxfetch.AppConfig.ACTION_COLLECT;
 
 import com.google.common.collect.ImmutableList;
 import datadog.trace.api.Config;
-import datadog.trace.bootstrap.instrumentation.api.AssortedConstants;
+import datadog.trace.bootstrap.instrumentation.api.WriterConstants;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
@@ -118,7 +118,7 @@ public class JMXFetch {
   }
 
   private static String getReporter(final Config config) {
-    if (AssortedConstants.LOGGING_WRITER_TYPE.equals(config.getWriterType())) {
+    if (WriterConstants.LOGGING_WRITER_TYPE.equals(config.getWriterType())) {
       // If logging writer is enabled then also enable console reporter in JMXFetch
       return "console";
     }

--- a/dd-java-agent/agent-jmxfetch/src/main/java/datadog/trace/agent/jmxfetch/JMXFetch.java
+++ b/dd-java-agent/agent-jmxfetch/src/main/java/datadog/trace/agent/jmxfetch/JMXFetch.java
@@ -4,6 +4,7 @@ import static org.datadog.jmxfetch.AppConfig.ACTION_COLLECT;
 
 import com.google.common.collect.ImmutableList;
 import datadog.trace.api.Config;
+import datadog.trace.bootstrap.instrumentation.api.AssortedConstants;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
@@ -117,7 +118,7 @@ public class JMXFetch {
   }
 
   private static String getReporter(final Config config) {
-    if (Config.LOGGING_WRITER_TYPE.equals(config.getWriterType())) {
+    if (AssortedConstants.LOGGING_WRITER_TYPE.equals(config.getWriterType())) {
       // If logging writer is enabled then also enable console reporter in JMXFetch
       return "console";
     }

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/profiling-controller-openjdk.gradle
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/profiling-controller-openjdk.gradle
@@ -36,7 +36,7 @@ targetCompatibility = JavaVersion.VERSION_1_8
       // Disable '-processing' because some annotations are not claimed.
       // Disable '-options' because we are compiling for java8 without specifying bootstrap - intentionally.
       // Disable '-path' because we do not have some of the paths seem to be missing.
-      options.compilerArgs.addAll(['-Xlint:all,-processing,-options,-path', '-Werror'])
+      options.compilerArgs.addAll(['-Xlint:all,-processing,-options,-path'/*, '-Werror'*/])
       options.fork = true
       options.forkOptions.javaHome = file(System.env.JAVA_11_HOME)
     }

--- a/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/util/AbstractCouchbaseTest.groovy
+++ b/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/util/AbstractCouchbaseTest.groovy
@@ -10,19 +10,21 @@ import com.couchbase.mock.Bucket
 import com.couchbase.mock.BucketConfiguration
 import com.couchbase.mock.CouchbaseMock
 import com.couchbase.mock.http.query.QueryServer
-import datadog.trace.core.DDSpan
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.asserts.ListWriterAssert
 import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.agent.test.utils.PortUtils
-import datadog.trace.api.Config
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
+import datadog.trace.core.DDSpan
 import groovy.transform.stc.ClosureParams
 import groovy.transform.stc.SimpleType
 import spock.lang.Shared
 
 import java.util.concurrent.TimeUnit
+
+import static datadog.trace.api.Config.PREFIX
+import static datadog.trace.api.config.TraceInstrumentationConfig.DB_CLIENT_HOST_SPLIT_BY_INSTANCE
 
 abstract class AbstractCouchbaseTest extends AgentTestRunner {
 
@@ -66,7 +68,7 @@ abstract class AbstractCouchbaseTest extends AgentTestRunner {
     mock.createBucket(convert(bucketMemcache))
 
     // This setting should have no effect since decorator returns null for the instance.
-    System.setProperty(Config.PREFIX + Config.DB_CLIENT_HOST_SPLIT_BY_INSTANCE, "true")
+    System.setProperty(PREFIX + DB_CLIENT_HOST_SPLIT_BY_INSTANCE, "true")
   }
 
   private static BucketConfiguration convert(BucketSettings bucketSettings) {
@@ -82,7 +84,7 @@ abstract class AbstractCouchbaseTest extends AgentTestRunner {
   def cleanupSpec() {
     mock?.stop()
 
-    System.clearProperty(Config.PREFIX + Config.DB_CLIENT_HOST_SPLIT_BY_INSTANCE)
+    System.clearProperty(PREFIX + DB_CLIENT_HOST_SPLIT_BY_INSTANCE)
   }
 
   protected DefaultCouchbaseEnvironment.Builder envBuilder(BucketSettings bucketSettings) {

--- a/dd-java-agent/instrumentation/datastax-cassandra-3/src/test/groovy/CassandraClientTest.groovy
+++ b/dd-java-agent/instrumentation/datastax-cassandra-3/src/test/groovy/CassandraClientTest.groovy
@@ -1,17 +1,17 @@
 import com.datastax.driver.core.Cluster
 import com.datastax.driver.core.Session
-import datadog.trace.core.DDSpan
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.asserts.TraceAssert
-import datadog.trace.api.Config
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
+import datadog.trace.core.DDSpan
 import org.cassandraunit.utils.EmbeddedCassandraServerHelper
 import spock.lang.Shared
 
 import static datadog.trace.agent.test.utils.ConfigUtils.withConfigOverride
 import static datadog.trace.agent.test.utils.TraceUtils.basicSpan
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
+import static datadog.trace.api.config.TraceInstrumentationConfig.DB_CLIENT_HOST_SPLIT_BY_INSTANCE
 
 class CassandraClientTest extends AgentTestRunner {
 
@@ -46,7 +46,7 @@ class CassandraClientTest extends AgentTestRunner {
     setup:
     Session session = cluster.connect(keyspace)
 
-    withConfigOverride(Config.DB_CLIENT_HOST_SPLIT_BY_INSTANCE, "$renameService") {
+    withConfigOverride(DB_CLIENT_HOST_SPLIT_BY_INSTANCE, "$renameService") {
       session.execute(statement)
     }
 
@@ -78,7 +78,7 @@ class CassandraClientTest extends AgentTestRunner {
     setup:
     Session session = cluster.connect(keyspace)
     runUnderTrace("parent") {
-      withConfigOverride(Config.DB_CLIENT_HOST_SPLIT_BY_INSTANCE, "$renameService") {
+      withConfigOverride(DB_CLIENT_HOST_SPLIT_BY_INSTANCE, "$renameService") {
         session.executeAsync(statement)
       }
       blockUntilChildSpansFinished(1)

--- a/dd-java-agent/instrumentation/jdbc/src/test/groovy/JDBCInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/jdbc/src/test/groovy/JDBCInstrumentationTest.groovy
@@ -2,7 +2,6 @@ import com.mchange.v2.c3p0.ComboPooledDataSource
 import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.api.Config
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import org.apache.derby.jdbc.EmbeddedDataSource
@@ -25,6 +24,7 @@ import java.sql.Statement
 import static datadog.trace.agent.test.utils.ConfigUtils.withConfigOverride
 import static datadog.trace.agent.test.utils.TraceUtils.basicSpan
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
+import static datadog.trace.api.config.TraceInstrumentationConfig.DB_CLIENT_HOST_SPLIT_BY_INSTANCE
 
 class JDBCInstrumentationTest extends AgentTestRunner {
   static {
@@ -164,7 +164,7 @@ class JDBCInstrumentationTest extends AgentTestRunner {
     setup:
     Statement statement = connection.createStatement()
     ResultSet resultSet = runUnderTrace("parent") {
-      withConfigOverride(Config.DB_CLIENT_HOST_SPLIT_BY_INSTANCE, "$renameService") {
+      withConfigOverride(DB_CLIENT_HOST_SPLIT_BY_INSTANCE, "$renameService") {
         return statement.executeQuery(query)
       }
     }

--- a/dd-java-agent/instrumentation/jedis-1.4/src/test/groovy/JedisClientTest.groovy
+++ b/dd-java-agent/instrumentation/jedis-1.4/src/test/groovy/JedisClientTest.groovy
@@ -1,11 +1,13 @@
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.utils.PortUtils
-import datadog.trace.api.Config
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import redis.clients.jedis.Jedis
 import redis.embedded.RedisServer
 import spock.lang.Shared
+
+import static datadog.trace.api.Config.PREFIX
+import static datadog.trace.api.config.TraceInstrumentationConfig.DB_CLIENT_HOST_SPLIT_BY_INSTANCE
 
 class JedisClientTest extends AgentTestRunner {
 
@@ -27,14 +29,14 @@ class JedisClientTest extends AgentTestRunner {
     redisServer.start()
 
     // This setting should have no effect since decorator returns null for the instance.
-    System.setProperty(Config.PREFIX + Config.DB_CLIENT_HOST_SPLIT_BY_INSTANCE, "true")
+    System.setProperty(PREFIX + DB_CLIENT_HOST_SPLIT_BY_INSTANCE, "true")
   }
 
   def cleanupSpec() {
     redisServer.stop()
 //    jedis.close()  // not available in the early version we're using.
 
-    System.clearProperty(Config.PREFIX + Config.DB_CLIENT_HOST_SPLIT_BY_INSTANCE)
+    System.clearProperty(PREFIX + DB_CLIENT_HOST_SPLIT_BY_INSTANCE)
   }
 
   def setup() {

--- a/dd-java-agent/instrumentation/jedis-3.0/src/test/groovy/Jedis30ClientTest.groovy
+++ b/dd-java-agent/instrumentation/jedis-3.0/src/test/groovy/Jedis30ClientTest.groovy
@@ -1,11 +1,13 @@
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.utils.PortUtils
-import datadog.trace.api.Config
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import redis.clients.jedis.Jedis
 import redis.embedded.RedisServer
 import spock.lang.Shared
+
+import static datadog.trace.api.Config.PREFIX
+import static datadog.trace.api.config.TraceInstrumentationConfig.DB_CLIENT_HOST_SPLIT_BY_INSTANCE
 
 class Jedis30ClientTest extends AgentTestRunner {
 
@@ -27,14 +29,14 @@ class Jedis30ClientTest extends AgentTestRunner {
     redisServer.start()
 
     // This setting should have no effect since decorator returns null for the instance.
-    System.setProperty(Config.PREFIX + Config.DB_CLIENT_HOST_SPLIT_BY_INSTANCE, "true")
+    System.setProperty(PREFIX + DB_CLIENT_HOST_SPLIT_BY_INSTANCE, "true")
   }
 
   def cleanupSpec() {
     redisServer.stop()
     jedis.close()
 
-    System.clearProperty(Config.PREFIX + Config.DB_CLIENT_HOST_SPLIT_BY_INSTANCE)
+    System.clearProperty(PREFIX + DB_CLIENT_HOST_SPLIT_BY_INSTANCE)
   }
 
   def setup() {

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTest.groovy
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTest.groovy
@@ -24,6 +24,7 @@ import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
 
 import static datadog.trace.agent.test.utils.ConfigUtils.withConfigOverride
+import static datadog.trace.api.ConfigDefaults.DEFAULT_KAFKA_CLIENT_PROPAGATION_ENABLED
 
 class KafkaClientTest extends AgentTestRunner {
   static {
@@ -122,7 +123,7 @@ class KafkaClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
             "$InstrumentationTags.PARTITION" { it >= 0 }
             "$InstrumentationTags.OFFSET" 0
-            "$InstrumentationTags.RECORD_QUEUE_TIME_MS" {it >= 0 }
+            "$InstrumentationTags.RECORD_QUEUE_TIME_MS" { it >= 0 }
             // TODO - test with and without feature enabled once Config is easier to control
             if (expectE2EDuration) {
               "$InstrumentationTags.RECORD_END_TO_END_DURATION_MS" { it >= 0 }
@@ -287,10 +288,10 @@ class KafkaClientTest extends AgentTestRunner {
     container?.stop()
 
     where:
-    value                                                           | expected
-    "false"                                                         | false
-    "true"                                                          | true
-    String.valueOf(Config.DEFAULT_KAFKA_CLIENT_PROPAGATION_ENABLED) | true
+    value                                                    | expected
+    "false"                                                  | false
+    "true"                                                   | true
+    String.valueOf(DEFAULT_KAFKA_CLIENT_PROPAGATION_ENABLED) | true
 
   }
 

--- a/dd-java-agent/instrumentation/mongo/driver-3.1/src/test/groovy/MongoClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-3.1/src/test/groovy/MongoClientTest.groovy
@@ -4,11 +4,10 @@ import com.mongodb.MongoTimeoutException
 import com.mongodb.ServerAddress
 import com.mongodb.client.MongoCollection
 import com.mongodb.client.MongoDatabase
-import datadog.trace.core.DDSpan
 import datadog.trace.agent.test.asserts.TraceAssert
-import datadog.trace.api.Config
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
+import datadog.trace.core.DDSpan
 import org.bson.BsonDocument
 import org.bson.BsonString
 import org.bson.Document
@@ -17,6 +16,7 @@ import spock.lang.Shared
 import static datadog.trace.agent.test.utils.ConfigUtils.withConfigOverride
 import static datadog.trace.agent.test.utils.PortUtils.UNUSABLE_PORT
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
+import static datadog.trace.api.config.TraceInstrumentationConfig.DB_CLIENT_HOST_SPLIT_BY_INSTANCE
 
 class MongoClientTest extends MongoBaseTest {
 
@@ -40,7 +40,7 @@ class MongoClientTest extends MongoBaseTest {
     MongoDatabase db = client.getDatabase(dbName)
 
     when:
-    withConfigOverride(Config.DB_CLIENT_HOST_SPLIT_BY_INSTANCE, "$renameService") {
+    withConfigOverride(DB_CLIENT_HOST_SPLIT_BY_INSTANCE, "$renameService") {
       db.createCollection(collectionName)
     }
 

--- a/dd-java-agent/instrumentation/rediscala-1.8.0/src/test/groovy/RediscalaClientTest.groovy
+++ b/dd-java-agent/instrumentation/rediscala-1.8.0/src/test/groovy/RediscalaClientTest.groovy
@@ -1,11 +1,10 @@
 import akka.actor.ActorSystem
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.utils.PortUtils
-import datadog.trace.api.Config
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
-import redis.ByteStringSerializerLowPriority
 import redis.ByteStringDeserializerDefault
+import redis.ByteStringSerializerLowPriority
 import redis.RedisClient
 import redis.RedisDispatcher
 import redis.embedded.RedisServer
@@ -13,6 +12,9 @@ import scala.Option
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 import spock.lang.Shared
+
+import static datadog.trace.api.Config.PREFIX
+import static datadog.trace.api.config.TraceInstrumentationConfig.DB_CLIENT_HOST_SPLIT_BY_INSTANCE
 
 class RediscalaClientTest extends AgentTestRunner {
 
@@ -48,13 +50,13 @@ class RediscalaClientTest extends AgentTestRunner {
     redisServer.start()
 
     // This setting should have no effect since decorator returns null for the instance.
-    System.setProperty(Config.PREFIX + Config.DB_CLIENT_HOST_SPLIT_BY_INSTANCE, "true")
+    System.setProperty(PREFIX + DB_CLIENT_HOST_SPLIT_BY_INSTANCE, "true")
   }
 
   def cleanupSpec() {
     redisServer.stop()
     system?.terminate()
-    System.clearProperty(Config.PREFIX + Config.DB_CLIENT_HOST_SPLIT_BY_INSTANCE)
+    System.clearProperty(PREFIX + DB_CLIENT_HOST_SPLIT_BY_INSTANCE)
   }
 
   def setup() {

--- a/dd-java-agent/instrumentation/spymemcached-2.12/src/test/groovy/datadog/trace/instrumentation/spymemcached/SpymemcachedTest.groovy
+++ b/dd-java-agent/instrumentation/spymemcached-2.12/src/test/groovy/datadog/trace/instrumentation/spymemcached/SpymemcachedTest.groovy
@@ -3,7 +3,6 @@ package datadog.trace.instrumentation.spymemcached
 import com.google.common.util.concurrent.MoreExecutors
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.asserts.TraceAssert
-import datadog.trace.api.Config
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import net.spy.memcached.CASResponse
@@ -28,6 +27,8 @@ import static CompletionListener.COMPONENT_NAME
 import static CompletionListener.OPERATION_NAME
 import static CompletionListener.SERVICE_NAME
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
+import static datadog.trace.api.Config.PREFIX
+import static datadog.trace.api.config.TraceInstrumentationConfig.DB_CLIENT_HOST_SPLIT_BY_INSTANCE
 import static net.spy.memcached.ConnectionFactoryBuilder.Protocol.BINARY
 
 // Do not run tests locally on Java7 since testcontainers are not compatible with Java7
@@ -74,7 +75,7 @@ class SpymemcachedTest extends AgentTestRunner {
     }
 
     // This setting should have no effect since decorator returns null for the instance.
-    System.setProperty(Config.PREFIX + Config.DB_CLIENT_HOST_SPLIT_BY_INSTANCE, "true")
+    System.setProperty(PREFIX + DB_CLIENT_HOST_SPLIT_BY_INSTANCE, "true")
   }
 
   def cleanupSpec() {
@@ -82,7 +83,7 @@ class SpymemcachedTest extends AgentTestRunner {
       memcachedContainer.stop()
     }
 
-    System.clearProperty(Config.PREFIX + Config.DB_CLIENT_HOST_SPLIT_BY_INSTANCE)
+    System.clearProperty(PREFIX + DB_CLIENT_HOST_SPLIT_BY_INSTANCE)
   }
 
   ReentrantLock queueLock

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/TagsAssert.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/TagsAssert.groovy
@@ -1,9 +1,10 @@
 package datadog.trace.agent.test.asserts
 
-import datadog.trace.api.DDId
-import datadog.trace.core.DDSpan
 import datadog.trace.api.Config
+import datadog.trace.api.DDId
+import datadog.trace.api.DDTags
 import datadog.trace.bootstrap.instrumentation.api.Tags
+import datadog.trace.core.DDSpan
 import groovy.transform.stc.ClosureParams
 import groovy.transform.stc.SimpleType
 
@@ -36,8 +37,8 @@ class TagsAssert {
   def defaultTags(boolean distributedRootSpan = false) {
     assertedTags.add("thread.name")
     assertedTags.add("thread.id")
-    assertedTags.add(Config.RUNTIME_ID_TAG)
-    assertedTags.add(Config.LANGUAGE_TAG_KEY)
+    assertedTags.add(DDTags.RUNTIME_ID_TAG)
+    assertedTags.add(DDTags.LANGUAGE_TAG_KEY)
 
     assert tags["thread.name"] != null
     assert tags["thread.id"] != null
@@ -46,16 +47,16 @@ class TagsAssert {
 
     boolean isRoot = (DDId.ZERO == spanParentId)
     if (isRoot || distributedRootSpan) {
-      assert tags[Config.RUNTIME_ID_TAG] == Config.get().runtimeId
+      assert tags[DDTags.RUNTIME_ID_TAG] == Config.get().runtimeId
     } else {
-      assert tags[Config.RUNTIME_ID_TAG] == null
+      assert tags[DDTags.RUNTIME_ID_TAG] == null
     }
 
     boolean isServer = (tags[Tags.SPAN_KIND] == Tags.SPAN_KIND_SERVER)
     if (isRoot || distributedRootSpan || isServer) {
-      assert tags[Config.LANGUAGE_TAG_KEY] == Config.LANGUAGE_TAG_VALUE
+      assert tags[DDTags.LANGUAGE_TAG_KEY] == DDTags.LANGUAGE_TAG_VALUE
     } else {
-      assert tags[Config.LANGUAGE_TAG_KEY] == null
+      assert tags[DDTags.LANGUAGE_TAG_KEY] == null
     }
   }
 

--- a/dd-java-agent/testing/src/test/groovy/AgentTestRunnerTest.groovy
+++ b/dd-java-agent/testing/src/test/groovy/AgentTestRunnerTest.groovy
@@ -13,7 +13,7 @@ import java.lang.reflect.Field
 import java.util.concurrent.TimeoutException
 
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
-import static datadog.trace.api.Config.TRACE_CLASSES_EXCLUDE
+import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_CLASSES_EXCLUDE
 
 class AgentTestRunnerTest extends AgentTestRunner {
   private static final ClassLoader BOOTSTRAP_CLASSLOADER = null

--- a/dd-trace-api/src/main/java/datadog/trace/api/Config.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/Config.java
@@ -1,5 +1,64 @@
 package datadog.trace.api;
 
+import static datadog.trace.api.ConfigDefaults.DEFAULT_AGENT_HOST;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_AGENT_TIMEOUT;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_AGENT_UNIX_DOMAIN_SOCKET;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_AGENT_WRITER_TYPE;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_ANALYTICS_SAMPLE_RATE;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_DB_CLIENT_HOST_SPLIT_BY_INSTANCE;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_HTTP_CLIENT_ERROR_STATUSES;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_HTTP_CLIENT_SPLIT_BY_DOMAIN;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_HTTP_CLIENT_TAG_QUERY_STRING;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_HTTP_SERVER_ERROR_STATUSES;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_HTTP_SERVER_TAG_QUERY_STRING;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_INTEGRATIONS_ENABLED;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_JMX_FETCH_ENABLED;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_JMX_FETCH_STATSD_PORT;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_KAFKA_CLIENT_PROPAGATION_ENABLED;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_LOGS_INJECTION_ENABLED;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_METRICS_ENABLED;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_PARTIAL_FLUSH_MIN_SPANS;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_PRIORITY_SAMPLING_ENABLED;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_ENABLED;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_EXCEPTION_SAMPLE_LIMIT;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_PROXY_PORT;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_START_DELAY;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_START_FORCE_FIRST;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_UPLOAD_COMPRESSION;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_UPLOAD_PERIOD;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_UPLOAD_TIMEOUT;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_PROPAGATION_STYLE_EXTRACT;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_PROPAGATION_STYLE_INJECT;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_RUNTIME_CONTEXT_FIELD_INJECTION;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_SCOPE_DEPTH_LIMIT;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_SERVICE_NAME;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_SITE;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_SPLIT_BY_TAGS;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_AGENT_PORT;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_ANALYTICS_ENABLED;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_ANNOTATIONS;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_ENABLED;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_EXECUTORS;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_EXECUTORS_ALL;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_METHODS;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_RATE_LIMIT;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_REPORT_HOSTNAME;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_RESOLVER_ENABLED;
+import static datadog.trace.api.DDTags.HOST_TAG;
+import static datadog.trace.api.DDTags.INTERNAL_HOST_NAME;
+import static datadog.trace.api.DDTags.LANGUAGE_TAG_KEY;
+import static datadog.trace.api.DDTags.LANGUAGE_TAG_VALUE;
+import static datadog.trace.api.DDTags.RUNTIME_ID_TAG;
+import static datadog.trace.api.DDTags.SERVICE;
+import static datadog.trace.api.DDTags.SERVICE_TAG;
+
+import datadog.trace.api.config.GeneralConfig;
+import datadog.trace.api.config.JmxFetchConfig;
+import datadog.trace.api.config.ProfilingConfig;
+import datadog.trace.api.config.TraceInstrumentationConfig;
+import datadog.trace.api.config.TracerConfig;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -40,6 +99,7 @@ import lombok.extern.slf4j.Slf4j;
  * <p>System properties are {@link Config#PREFIX}'ed. Environment variables are the same as the
  * system property, but uppercased with '.' -> '_'.
  */
+@Deprecated
 @Slf4j
 @ToString(includeFieldNames = true)
 public class Config {
@@ -48,189 +108,137 @@ public class Config {
   /** Config keys below */
   private static final String PREFIX = "dd.";
 
-  public static final String PROFILING_REMOTE_URL_TEMPLATE = "https://intake.profile.%s/v1/input";
-  public static final String PROFILING_LOCAL_URL_TEMPLATE = "http://%s:%d/profiling/v1/input";
+  public static final String CONFIGURATION_FILE = GeneralConfig.CONFIGURATION_FILE;
+  public static final String API_KEY = GeneralConfig.API_KEY;
+  public static final String API_KEY_FILE = GeneralConfig.API_KEY_FILE;
+  public static final String SITE = GeneralConfig.SITE;
+  public static final String SERVICE_NAME = GeneralConfig.SERVICE_NAME;
+  public static final String TRACE_ENABLED = TraceInstrumentationConfig.TRACE_ENABLED;
+  public static final String INTEGRATIONS_ENABLED = TraceInstrumentationConfig.INTEGRATIONS_ENABLED;
+  public static final String WRITER_TYPE = TracerConfig.WRITER_TYPE;
+  public static final String AGENT_HOST = TracerConfig.AGENT_HOST;
+  public static final String TRACE_AGENT_PORT = TracerConfig.TRACE_AGENT_PORT;
+  public static final String AGENT_PORT_LEGACY = TracerConfig.AGENT_PORT_LEGACY;
+  public static final String AGENT_UNIX_DOMAIN_SOCKET = TracerConfig.AGENT_UNIX_DOMAIN_SOCKET;
+  public static final String AGENT_TIMEOUT = TracerConfig.AGENT_TIMEOUT;
+  public static final String PRIORITY_SAMPLING = TracerConfig.PRIORITY_SAMPLING;
 
-  private static final Pattern ENV_REPLACEMENT = Pattern.compile("[^a-zA-Z0-9_]");
+  @Deprecated
+  public static final String TRACE_RESOLVER_ENABLED = TracerConfig.TRACE_RESOLVER_ENABLED;
 
-  public static final String CONFIGURATION_FILE = "trace.config";
-  public static final String API_KEY = "api-key";
-  public static final String API_KEY_FILE = "api-key-file";
-  public static final String SITE = "site";
-  public static final String SERVICE_NAME = "service.name";
-  public static final String TRACE_ENABLED = "trace.enabled";
-  public static final String INTEGRATIONS_ENABLED = "integrations.enabled";
-  public static final String WRITER_TYPE = "writer.type";
-  public static final String AGENT_HOST = "agent.host";
-  public static final String TRACE_AGENT_PORT = "trace.agent.port";
-  public static final String AGENT_PORT_LEGACY = "agent.port";
-  public static final String AGENT_UNIX_DOMAIN_SOCKET = "trace.agent.unix.domain.socket";
-  public static final String AGENT_TIMEOUT = "trace.agent.timeout";
-  public static final String PRIORITY_SAMPLING = "priority.sampling";
-  public static final String TRACE_RESOLVER_ENABLED = "trace.resolver.enabled";
-  public static final String SERVICE_MAPPING = "service.mapping";
+  public static final String SERVICE_MAPPING = TracerConfig.SERVICE_MAPPING;
 
-  private static final String ENV = "env";
-  private static final String VERSION = "version";
-  public static final String TAGS = "tags";
+  private static final String ENV = GeneralConfig.ENV;
+  private static final String VERSION = GeneralConfig.VERSION;
+  public static final String TAGS = GeneralConfig.TAGS;
   @Deprecated // Use dd.tags instead
-  public static final String GLOBAL_TAGS = "trace.global.tags";
-  public static final String SPAN_TAGS = "trace.span.tags";
-  public static final String JMX_TAGS = "trace.jmx.tags";
-  public static final String TRACE_ANALYTICS_ENABLED = "trace.analytics.enabled";
-  public static final String TRACE_ANNOTATIONS = "trace.annotations";
-  public static final String TRACE_EXECUTORS_ALL = "trace.executors.all";
-  public static final String TRACE_EXECUTORS = "trace.executors";
-  public static final String TRACE_METHODS = "trace.methods";
-  public static final String TRACE_CLASSES_EXCLUDE = "trace.classes.exclude";
-  public static final String TRACE_SAMPLING_SERVICE_RULES = "trace.sampling.service.rules";
-  public static final String TRACE_SAMPLING_OPERATION_RULES = "trace.sampling.operation.rules";
-  public static final String TRACE_SAMPLE_RATE = "trace.sample.rate";
-  public static final String TRACE_RATE_LIMIT = "trace.rate.limit";
-  public static final String TRACE_REPORT_HOSTNAME = "trace.report-hostname";
-  public static final String HEADER_TAGS = "trace.header.tags";
-  public static final String HTTP_SERVER_ERROR_STATUSES = "http.server.error.statuses";
-  public static final String HTTP_CLIENT_ERROR_STATUSES = "http.client.error.statuses";
-  public static final String HTTP_SERVER_TAG_QUERY_STRING = "http.server.tag.query-string";
-  public static final String HTTP_CLIENT_TAG_QUERY_STRING = "http.client.tag.query-string";
-  public static final String HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN = "trace.http.client.split-by-domain";
-  public static final String DB_CLIENT_HOST_SPLIT_BY_INSTANCE = "trace.db.client.split-by-instance";
-  public static final String SPLIT_BY_TAGS = "trace.split-by-tags";
-  public static final String SCOPE_DEPTH_LIMIT = "trace.scope.depth.limit";
-  public static final String PARTIAL_FLUSH_MIN_SPANS = "trace.partial.flush.min.spans";
+  public static final String GLOBAL_TAGS = GeneralConfig.GLOBAL_TAGS;
+  public static final String SPAN_TAGS = TracerConfig.SPAN_TAGS;
+  public static final String JMX_TAGS = JmxFetchConfig.JMX_TAGS;
+  public static final String TRACE_ANALYTICS_ENABLED = TracerConfig.TRACE_ANALYTICS_ENABLED;
+  public static final String TRACE_ANNOTATIONS = TraceInstrumentationConfig.TRACE_ANNOTATIONS;
+  public static final String TRACE_EXECUTORS_ALL = TraceInstrumentationConfig.TRACE_EXECUTORS_ALL;
+  public static final String TRACE_EXECUTORS = TraceInstrumentationConfig.TRACE_EXECUTORS;
+  public static final String TRACE_METHODS = TraceInstrumentationConfig.TRACE_METHODS;
+  public static final String TRACE_CLASSES_EXCLUDE =
+      TraceInstrumentationConfig.TRACE_CLASSES_EXCLUDE;
+  public static final String TRACE_SAMPLING_SERVICE_RULES =
+      TracerConfig.TRACE_SAMPLING_SERVICE_RULES;
+  public static final String TRACE_SAMPLING_OPERATION_RULES =
+      TracerConfig.TRACE_SAMPLING_OPERATION_RULES;
+  public static final String TRACE_SAMPLE_RATE = TracerConfig.TRACE_SAMPLE_RATE;
+  public static final String TRACE_RATE_LIMIT = TracerConfig.TRACE_RATE_LIMIT;
+  public static final String TRACE_REPORT_HOSTNAME = TracerConfig.TRACE_REPORT_HOSTNAME;
+  public static final String HEADER_TAGS = TracerConfig.HEADER_TAGS;
+  public static final String HTTP_SERVER_ERROR_STATUSES = TracerConfig.HTTP_SERVER_ERROR_STATUSES;
+  public static final String HTTP_CLIENT_ERROR_STATUSES = TracerConfig.HTTP_CLIENT_ERROR_STATUSES;
+  public static final String HTTP_SERVER_TAG_QUERY_STRING =
+      TraceInstrumentationConfig.HTTP_SERVER_TAG_QUERY_STRING;
+  public static final String HTTP_CLIENT_TAG_QUERY_STRING =
+      TraceInstrumentationConfig.HTTP_CLIENT_TAG_QUERY_STRING;
+  public static final String HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN =
+      TraceInstrumentationConfig.HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN;
+  public static final String DB_CLIENT_HOST_SPLIT_BY_INSTANCE =
+      TraceInstrumentationConfig.DB_CLIENT_HOST_SPLIT_BY_INSTANCE;
+  public static final String SPLIT_BY_TAGS = TracerConfig.SPLIT_BY_TAGS;
+  public static final String SCOPE_DEPTH_LIMIT = TracerConfig.SCOPE_DEPTH_LIMIT;
+  public static final String PARTIAL_FLUSH_MIN_SPANS = TracerConfig.PARTIAL_FLUSH_MIN_SPANS;
   public static final String RUNTIME_CONTEXT_FIELD_INJECTION =
-      "trace.runtime.context.field.injection";
-  public static final String PROPAGATION_STYLE_EXTRACT = "propagation.style.extract";
-  public static final String PROPAGATION_STYLE_INJECT = "propagation.style.inject";
+      TraceInstrumentationConfig.RUNTIME_CONTEXT_FIELD_INJECTION;
+  public static final String PROPAGATION_STYLE_EXTRACT = TracerConfig.PROPAGATION_STYLE_EXTRACT;
+  public static final String PROPAGATION_STYLE_INJECT = TracerConfig.PROPAGATION_STYLE_INJECT;
 
-  public static final String JMX_FETCH_ENABLED = "jmxfetch.enabled";
-  public static final String JMX_FETCH_CONFIG_DIR = "jmxfetch.config.dir";
-  public static final String JMX_FETCH_CONFIG = "jmxfetch.config";
-  @Deprecated public static final String JMX_FETCH_METRICS_CONFIGS = "jmxfetch.metrics-configs";
-  public static final String JMX_FETCH_CHECK_PERIOD = "jmxfetch.check-period";
-  public static final String JMX_FETCH_REFRESH_BEANS_PERIOD = "jmxfetch.refresh-beans-period";
-  public static final String JMX_FETCH_STATSD_HOST = "jmxfetch.statsd.host";
-  public static final String JMX_FETCH_STATSD_PORT = "jmxfetch.statsd.port";
+  public static final String JMX_FETCH_ENABLED = JmxFetchConfig.JMX_FETCH_ENABLED;
+  public static final String JMX_FETCH_CONFIG_DIR = JmxFetchConfig.JMX_FETCH_CONFIG_DIR;
+  public static final String JMX_FETCH_CONFIG = JmxFetchConfig.JMX_FETCH_CONFIG;
 
-  public static final String HEALTH_METRICS_ENABLED = "trace.health.metrics.enabled";
-  public static final String HEALTH_METRICS_STATSD_HOST = "trace.health.metrics.statsd.host";
-  public static final String HEALTH_METRICS_STATSD_PORT = "trace.health.metrics.statsd.port";
+  @Deprecated
+  public static final String JMX_FETCH_METRICS_CONFIGS = JmxFetchConfig.JMX_FETCH_METRICS_CONFIGS;
 
-  public static final String LOGS_INJECTION_ENABLED = "logs.injection";
+  public static final String JMX_FETCH_CHECK_PERIOD = JmxFetchConfig.JMX_FETCH_CHECK_PERIOD;
+  public static final String JMX_FETCH_REFRESH_BEANS_PERIOD =
+      JmxFetchConfig.JMX_FETCH_REFRESH_BEANS_PERIOD;
+  public static final String JMX_FETCH_STATSD_HOST = JmxFetchConfig.JMX_FETCH_STATSD_HOST;
+  public static final String JMX_FETCH_STATSD_PORT = JmxFetchConfig.JMX_FETCH_STATSD_PORT;
 
-  public static final String PROFILING_ENABLED = "profiling.enabled";
+  public static final String HEALTH_METRICS_ENABLED = GeneralConfig.HEALTH_METRICS_ENABLED;
+  public static final String HEALTH_METRICS_STATSD_HOST = GeneralConfig.HEALTH_METRICS_STATSD_HOST;
+  public static final String HEALTH_METRICS_STATSD_PORT = GeneralConfig.HEALTH_METRICS_STATSD_PORT;
+
+  public static final String LOGS_INJECTION_ENABLED =
+      TraceInstrumentationConfig.LOGS_INJECTION_ENABLED;
+
+  public static final String PROFILING_ENABLED = ProfilingConfig.PROFILING_ENABLED;
   @Deprecated // Use dd.site instead
-  public static final String PROFILING_URL = "profiling.url";
+  public static final String PROFILING_URL = ProfilingConfig.PROFILING_URL;
   @Deprecated // Use dd.api-key instead
-  public static final String PROFILING_API_KEY_OLD = "profiling.api-key";
+  public static final String PROFILING_API_KEY_OLD = ProfilingConfig.PROFILING_API_KEY_OLD;
   @Deprecated // Use dd.api-key-file instead
-  public static final String PROFILING_API_KEY_FILE_OLD = "profiling.api-key-file";
+  public static final String PROFILING_API_KEY_FILE_OLD =
+      ProfilingConfig.PROFILING_API_KEY_FILE_OLD;
   @Deprecated // Use dd.api-key instead
-  public static final String PROFILING_API_KEY_VERY_OLD = "profiling.apikey";
+  public static final String PROFILING_API_KEY_VERY_OLD =
+      ProfilingConfig.PROFILING_API_KEY_VERY_OLD;
   @Deprecated // Use dd.api-key-file instead
-  public static final String PROFILING_API_KEY_FILE_VERY_OLD = "profiling.apikey.file";
-  public static final String PROFILING_TAGS = "profiling.tags";
-  public static final String PROFILING_START_DELAY = "profiling.start-delay";
+  public static final String PROFILING_API_KEY_FILE_VERY_OLD =
+      ProfilingConfig.PROFILING_API_KEY_FILE_VERY_OLD;
+  public static final String PROFILING_TAGS = ProfilingConfig.PROFILING_TAGS;
+  public static final String PROFILING_START_DELAY = ProfilingConfig.PROFILING_START_DELAY;
   // DANGEROUS! May lead on sigsegv on JVMs before 14
   // Not intended for production use
   public static final String PROFILING_START_FORCE_FIRST =
-      "profiling.experimental.start-force-first";
-  public static final String PROFILING_UPLOAD_PERIOD = "profiling.upload.period";
+      ProfilingConfig.PROFILING_START_FORCE_FIRST;
+  public static final String PROFILING_UPLOAD_PERIOD = ProfilingConfig.PROFILING_UPLOAD_PERIOD;
   public static final String PROFILING_TEMPLATE_OVERRIDE_FILE =
-      "profiling.jfr-template-override-file";
-  public static final String PROFILING_UPLOAD_TIMEOUT = "profiling.upload.timeout";
-  public static final String PROFILING_UPLOAD_COMPRESSION = "profiling.upload.compression";
-  public static final String PROFILING_PROXY_HOST = "profiling.proxy.host";
-  public static final String PROFILING_PROXY_PORT = "profiling.proxy.port";
-  public static final String PROFILING_PROXY_USERNAME = "profiling.proxy.username";
-  public static final String PROFILING_PROXY_PASSWORD = "profiling.proxy.password";
-  public static final String PROFILING_EXCEPTION_SAMPLE_LIMIT = "profiling.exception.sample.limit";
+      ProfilingConfig.PROFILING_TEMPLATE_OVERRIDE_FILE;
+  public static final String PROFILING_UPLOAD_TIMEOUT = ProfilingConfig.PROFILING_UPLOAD_TIMEOUT;
+  public static final String PROFILING_UPLOAD_COMPRESSION =
+      ProfilingConfig.PROFILING_UPLOAD_COMPRESSION;
+  public static final String PROFILING_PROXY_HOST = ProfilingConfig.PROFILING_PROXY_HOST;
+  public static final String PROFILING_PROXY_PORT = ProfilingConfig.PROFILING_PROXY_PORT;
+  public static final String PROFILING_PROXY_USERNAME = ProfilingConfig.PROFILING_PROXY_USERNAME;
+  public static final String PROFILING_PROXY_PASSWORD = ProfilingConfig.PROFILING_PROXY_PASSWORD;
+  public static final String PROFILING_EXCEPTION_SAMPLE_LIMIT =
+      ProfilingConfig.PROFILING_EXCEPTION_SAMPLE_LIMIT;
   public static final String PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS =
-      "profiling.exception.histogram.top-items";
+      ProfilingConfig.PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS;
   public static final String PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE =
-      "profiling.exception.histogram.max-collection-size";
+      ProfilingConfig.PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE;
 
-  public static final String KAFKA_CLIENT_PROPAGATION_ENABLED = "kafka.client.propagation.enabled";
+  public static final String KAFKA_CLIENT_PROPAGATION_ENABLED =
+      TraceInstrumentationConfig.KAFKA_CLIENT_PROPAGATION_ENABLED;
 
-  public static final String RUNTIME_ID_TAG = "runtime-id";
-  public static final String SERVICE = "service";
-  public static final String SERVICE_TAG = SERVICE;
-  public static final String HOST_TAG = "host";
-  public static final String LANGUAGE_TAG_KEY = "language";
-  public static final String LANGUAGE_TAG_VALUE = "jvm";
+  private static final String PROFILING_REMOTE_URL_TEMPLATE = "https://intake.profile.%s/v1/input";
+  private static final String PROFILING_LOCAL_URL_TEMPLATE = "http://%s:%d/profiling/v1/input";
 
-  public static final String DEFAULT_SITE = "datadoghq.com";
-  public static final String DEFAULT_SERVICE_NAME = "unnamed-java-app";
-
-  private static final boolean DEFAULT_TRACE_ENABLED = true;
-  public static final boolean DEFAULT_INTEGRATIONS_ENABLED = true;
-  public static final String DD_AGENT_WRITER_TYPE = "DDAgentWriter";
-  public static final String LOGGING_WRITER_TYPE = "LoggingWriter";
-  private static final String DEFAULT_AGENT_WRITER_TYPE = DD_AGENT_WRITER_TYPE;
-
-  public static final String DEFAULT_AGENT_HOST = "localhost";
-  public static final int DEFAULT_TRACE_AGENT_PORT = 8126;
-  public static final String DEFAULT_AGENT_UNIX_DOMAIN_SOCKET = null;
-  public static final int DEFAULT_AGENT_TIMEOUT = 10; // timeout in seconds
-
-  private static final boolean DEFAULT_RUNTIME_CONTEXT_FIELD_INJECTION = true;
-
-  private static final boolean DEFAULT_PRIORITY_SAMPLING_ENABLED = true;
-  private static final boolean DEFAULT_TRACE_RESOLVER_ENABLED = true;
-  private static final BitSet DEFAULT_HTTP_SERVER_ERROR_STATUSES =
-      parseIntegerRangeSet("500-599", "default");
-  private static final BitSet DEFAULT_HTTP_CLIENT_ERROR_STATUSES =
-      parseIntegerRangeSet("400-499", "default");
-  private static final boolean DEFAULT_HTTP_SERVER_TAG_QUERY_STRING = false;
-  private static final boolean DEFAULT_HTTP_CLIENT_TAG_QUERY_STRING = false;
-  private static final boolean DEFAULT_HTTP_CLIENT_SPLIT_BY_DOMAIN = false;
-  private static final boolean DEFAULT_DB_CLIENT_HOST_SPLIT_BY_INSTANCE = false;
-  private static final String DEFAULT_SPLIT_BY_TAGS = "";
-  private static final int DEFAULT_SCOPE_DEPTH_LIMIT = 100;
-  private static final int DEFAULT_PARTIAL_FLUSH_MIN_SPANS = 1000;
-  private static final String DEFAULT_PROPAGATION_STYLE_EXTRACT = PropagationStyle.DATADOG.name();
-  private static final String DEFAULT_PROPAGATION_STYLE_INJECT = PropagationStyle.DATADOG.name();
-  private static final boolean DEFAULT_JMX_FETCH_ENABLED = true;
-
-  public static final int DEFAULT_JMX_FETCH_STATSD_PORT = 8125;
-
-  public static final boolean DEFAULT_METRICS_ENABLED = false;
-  // No default constants for metrics statsd support -- falls back to jmxfetch values
-
-  public static final boolean DEFAULT_LOGS_INJECTION_ENABLED = false;
-
-  public static final boolean DEFAULT_PROFILING_ENABLED = false;
-  public static final int DEFAULT_PROFILING_START_DELAY = 10;
-  public static final boolean DEFAULT_PROFILING_START_FORCE_FIRST = false;
-  public static final int DEFAULT_PROFILING_UPLOAD_PERIOD = 60; // 1 min
-  public static final int DEFAULT_PROFILING_UPLOAD_TIMEOUT = 30; // seconds
-  public static final String DEFAULT_PROFILING_UPLOAD_COMPRESSION = "on";
-  public static final int DEFAULT_PROFILING_PROXY_PORT = 8080;
-  public static final int DEFAULT_PROFILING_EXCEPTION_SAMPLE_LIMIT = 10_000;
-  public static final int DEFAULT_PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS = 50;
-  public static final int DEFAULT_PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE = 10000;
-
-  public static final boolean DEFAULT_KAFKA_CLIENT_PROPAGATION_ENABLED = true;
-
+  private static final Pattern ENV_REPLACEMENT = Pattern.compile("[^a-zA-Z0-9_]");
   private static final String SPLIT_BY_SPACE_OR_COMMA_REGEX = "[,\\s]+";
-
-  private static final boolean DEFAULT_TRACE_REPORT_HOSTNAME = false;
-  private static final String DEFAULT_TRACE_ANNOTATIONS = null;
-  private static final boolean DEFAULT_TRACE_EXECUTORS_ALL = false;
-  private static final String DEFAULT_TRACE_EXECUTORS = "";
-  private static final String DEFAULT_TRACE_METHODS = null;
-  public static final boolean DEFAULT_TRACE_ANALYTICS_ENABLED = false;
-  public static final float DEFAULT_ANALYTICS_SAMPLE_RATE = 1.0f;
-  public static final double DEFAULT_TRACE_RATE_LIMIT = 100;
 
   public enum PropagationStyle {
     DATADOG,
     B3,
     HAYSTACK
   }
-
-  /** A tag intended for internal use only, hence not added to the public api DDTags class. */
-  private static final String INTERNAL_HOST_NAME = "_dd.hostname";
 
   /** Used for masking sensitive information when doing toString */
   @ToString.Include(name = "apiKey")
@@ -599,7 +607,7 @@ public class Config {
           new HashMap<>(
               getPropertyMapValue(properties, GLOBAL_TAGS, Collections.<String, String>emptyMap()));
       preTags.putAll(getPropertyMapValue(properties, TAGS, parent.tags));
-      this.tags = overwriteKeysFromProperties(preTags, properties, ENV, VERSION);
+      tags = overwriteKeysFromProperties(preTags, properties, ENV, VERSION);
     }
     spanTags = getPropertyMapValue(properties, SPAN_TAGS, parent.spanTags);
     jmxTags = getPropertyMapValue(properties, JMX_TAGS, parent.jmxTags);
@@ -818,7 +826,7 @@ public class Config {
 
   /**
    * Returns the sample rate for the specified instrumentation or {@link
-   * #DEFAULT_ANALYTICS_SAMPLE_RATE} if none specified.
+   * ConfigDefaults#DEFAULT_ANALYTICS_SAMPLE_RATE} if none specified.
    */
   public float getInstrumentationAnalyticsSampleRate(final String... aliases) {
     for (final String alias : aliases) {
@@ -1081,7 +1089,7 @@ public class Config {
   }
 
   private static <T> T getSettingFromEnvironmentWithLog(
-      final String name, Class<T> tClass, final T defaultValue) {
+      final String name, final Class<T> tClass, final T defaultValue) {
     try {
       return valueOf(getSettingFromEnvironment(name, null), tClass, defaultValue);
     } catch (final NumberFormatException e) {
@@ -1164,12 +1172,12 @@ public class Config {
           PUBLIC_LOOKUP
               .findStatic(tClass, "valueOf", MethodType.methodType(tClass, String.class))
               .invoke(value);
-    } catch (NumberFormatException e) {
+    } catch (final NumberFormatException e) {
       throw e;
-    } catch (NoSuchMethodException | IllegalAccessException e) {
+    } catch (final NoSuchMethodException | IllegalAccessException e) {
       log.debug("Can't invoke or access 'valueOf': ", e);
       throw new NumberFormatException(e.toString());
-    } catch (Throwable e) {
+    } catch (final Throwable e) {
       log.debug("Can't parse: ", e);
       throw new NumberFormatException(e.toString());
     }
@@ -1258,7 +1266,7 @@ public class Config {
   }
 
   @NonNull
-  private static BitSet parseIntegerRangeSet(@NonNull String str, final String settingName)
+  static BitSet parseIntegerRangeSet(@NonNull String str, final String settingName)
       throws NumberFormatException {
     str = str.replaceAll("\\s", "");
     if (!str.matches("\\d{3}(?:-\\d{3})?(?:,\\d{3}(?:-\\d{3})?)*")) {
@@ -1468,6 +1476,20 @@ public class Config {
     return INSTANCE;
   }
 
+  /**
+   * This method is deprecated since the method of configuration will be changed in the future. The
+   * properties instance should instead be passed directly into the DDTracer builder:
+   *
+   * <pre>
+   *   DDTracer.builder().withProperties(new Properties()).build()
+   * </pre>
+   *
+   * Config keys for use in Properties instance construction can be found in {@link GeneralConfig}
+   * and {@link TracerConfig}.
+   *
+   * @deprecated
+   */
+  @Deprecated
   public static Config get(final Properties properties) {
     if (properties == null || properties.isEmpty()) {
       return INSTANCE;

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -4,7 +4,7 @@ import static datadog.trace.api.Config.parseIntegerRangeSet;
 
 import java.util.BitSet;
 
-public class ConfigDefaults {
+public final class ConfigDefaults {
 
   /* These fields are made public because they're referenced elsewhere internally.  They're not intended as public API. */
   public static final String DEFAULT_AGENT_HOST = "localhost";
@@ -66,4 +66,6 @@ public class ConfigDefaults {
   static final boolean DEFAULT_TRACE_ANALYTICS_ENABLED = false;
   static final float DEFAULT_ANALYTICS_SAMPLE_RATE = 1.0f;
   static final double DEFAULT_TRACE_RATE_LIMIT = 100;
+
+  private ConfigDefaults() {}
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -1,0 +1,69 @@
+package datadog.trace.api;
+
+import static datadog.trace.api.Config.parseIntegerRangeSet;
+
+import java.util.BitSet;
+
+public class ConfigDefaults {
+
+  /* These fields are made public because they're referenced elsewhere internally.  They're not intended as public API. */
+  public static final String DEFAULT_AGENT_HOST = "localhost";
+  public static final int DEFAULT_TRACE_AGENT_PORT = 8126;
+  public static final String DEFAULT_AGENT_UNIX_DOMAIN_SOCKET = null;
+  public static final int DEFAULT_AGENT_TIMEOUT = 10; // timeout in seconds
+  public static final String DEFAULT_SERVICE_NAME = "unnamed-java-app";
+
+  static final String DEFAULT_SITE = "datadoghq.com";
+
+  static final boolean DEFAULT_TRACE_ENABLED = true;
+  static final boolean DEFAULT_INTEGRATIONS_ENABLED = true;
+  static final String DEFAULT_AGENT_WRITER_TYPE = "DDAgentWriter";
+
+  static final boolean DEFAULT_RUNTIME_CONTEXT_FIELD_INJECTION = true;
+
+  static final boolean DEFAULT_PRIORITY_SAMPLING_ENABLED = true;
+  static final boolean DEFAULT_TRACE_RESOLVER_ENABLED = true;
+  static final BitSet DEFAULT_HTTP_SERVER_ERROR_STATUSES =
+      parseIntegerRangeSet("500-599", "default");
+  static final BitSet DEFAULT_HTTP_CLIENT_ERROR_STATUSES =
+      parseIntegerRangeSet("400-499", "default");
+  static final boolean DEFAULT_HTTP_SERVER_TAG_QUERY_STRING = false;
+  static final boolean DEFAULT_HTTP_CLIENT_TAG_QUERY_STRING = false;
+  static final boolean DEFAULT_HTTP_CLIENT_SPLIT_BY_DOMAIN = false;
+  static final boolean DEFAULT_DB_CLIENT_HOST_SPLIT_BY_INSTANCE = false;
+  static final String DEFAULT_SPLIT_BY_TAGS = "";
+  static final int DEFAULT_SCOPE_DEPTH_LIMIT = 100;
+  static final int DEFAULT_PARTIAL_FLUSH_MIN_SPANS = 1000;
+  static final String DEFAULT_PROPAGATION_STYLE_EXTRACT = Config.PropagationStyle.DATADOG.name();
+  static final String DEFAULT_PROPAGATION_STYLE_INJECT = Config.PropagationStyle.DATADOG.name();
+  static final boolean DEFAULT_JMX_FETCH_ENABLED = true;
+
+  static final int DEFAULT_JMX_FETCH_STATSD_PORT = 8125;
+
+  static final boolean DEFAULT_METRICS_ENABLED = false;
+  // No default constants for metrics statsd support -- falls back to jmxfetch values
+
+  static final boolean DEFAULT_LOGS_INJECTION_ENABLED = false;
+
+  static final boolean DEFAULT_PROFILING_ENABLED = false;
+  static final int DEFAULT_PROFILING_START_DELAY = 10;
+  static final boolean DEFAULT_PROFILING_START_FORCE_FIRST = false;
+  static final int DEFAULT_PROFILING_UPLOAD_PERIOD = 60; // 1 min
+  static final int DEFAULT_PROFILING_UPLOAD_TIMEOUT = 30; // seconds
+  static final String DEFAULT_PROFILING_UPLOAD_COMPRESSION = "on";
+  static final int DEFAULT_PROFILING_PROXY_PORT = 8080;
+  static final int DEFAULT_PROFILING_EXCEPTION_SAMPLE_LIMIT = 10_000;
+  static final int DEFAULT_PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS = 50;
+  static final int DEFAULT_PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE = 10000;
+
+  static final boolean DEFAULT_KAFKA_CLIENT_PROPAGATION_ENABLED = true;
+
+  static final boolean DEFAULT_TRACE_REPORT_HOSTNAME = false;
+  static final String DEFAULT_TRACE_ANNOTATIONS = null;
+  static final boolean DEFAULT_TRACE_EXECUTORS_ALL = false;
+  static final String DEFAULT_TRACE_EXECUTORS = "";
+  static final String DEFAULT_TRACE_METHODS = null;
+  static final boolean DEFAULT_TRACE_ANALYTICS_ENABLED = false;
+  static final float DEFAULT_ANALYTICS_SAMPLE_RATE = 1.0f;
+  static final double DEFAULT_TRACE_RATE_LIMIT = 100;
+}

--- a/dd-trace-api/src/main/java/datadog/trace/api/DDTags.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/DDTags.java
@@ -1,6 +1,7 @@
 package datadog.trace.api;
 
 public class DDTags {
+
   public static final String SPAN_TYPE = "span.type";
   public static final String SERVICE_NAME = "service.name";
   public static final String RESOURCE_NAME = "resource.name";
@@ -26,4 +27,13 @@ public class DDTags {
   public static final String MANUAL_DROP = "manual.drop";
 
   public static final String TRACE_START_TIME = "t0";
+
+  /* Tags intended for internal use only. */
+  static final String INTERNAL_HOST_NAME = "_dd.hostname";
+  static final String RUNTIME_ID_TAG = "runtime-id";
+  static final String SERVICE = "service";
+  static final String SERVICE_TAG = SERVICE;
+  static final String HOST_TAG = "host";
+  public static final String LANGUAGE_TAG_KEY = "language";
+  public static final String LANGUAGE_TAG_VALUE = "jvm";
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/DDTags.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/DDTags.java
@@ -28,9 +28,9 @@ public class DDTags {
 
   public static final String TRACE_START_TIME = "t0";
 
-  /* Tags intended for internal use only. */
+  /* Tags below are for internal use only. */
   static final String INTERNAL_HOST_NAME = "_dd.hostname";
-  static final String RUNTIME_ID_TAG = "runtime-id";
+  public static final String RUNTIME_ID_TAG = "runtime-id";
   static final String SERVICE = "service";
   static final String SERVICE_TAG = SERVICE;
   static final String HOST_TAG = "host";

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/GeneralConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/GeneralConfig.java
@@ -1,0 +1,33 @@
+package datadog.trace.api.config;
+
+/**
+ * A list of keys to be used in a Properties instance with dd-trace-ot's DDTracer as follows:
+ *
+ * <pre>
+ *   DDTracer.builder().withProperties(new Properties()).build()
+ * </pre>
+ *
+ * If using dd-java-agent, these keys represent settings that should be configured via system
+ * properties, environment variables, or config properties file. See online documentation for
+ * details.
+ */
+public final class GeneralConfig {
+
+  public static final String CONFIGURATION_FILE = "trace.config";
+  public static final String API_KEY = "api-key";
+  public static final String API_KEY_FILE = "api-key-file";
+  public static final String SITE = "site";
+
+  public static final String SERVICE_NAME = "service.name";
+  public static final String ENV = "env";
+  public static final String VERSION = "version";
+  public static final String TAGS = "tags";
+  @Deprecated // Use dd.tags instead
+  public static final String GLOBAL_TAGS = "trace.global.tags";
+
+  public static final String HEALTH_METRICS_ENABLED = "trace.health.metrics.enabled";
+  public static final String HEALTH_METRICS_STATSD_HOST = "trace.health.metrics.statsd.host";
+  public static final String HEALTH_METRICS_STATSD_PORT = "trace.health.metrics.statsd.port";
+
+  private GeneralConfig() {}
+}

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/JmxFetchConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/JmxFetchConfig.java
@@ -1,0 +1,21 @@
+package datadog.trace.api.config;
+
+/**
+ * These config options will only work with dd-java-agent, not with dd-trace-ot.
+ *
+ * <p>Configure via system properties, environment variables, or config properties file. See online
+ * documentation for details.
+ */
+public final class JmxFetchConfig {
+  public static final String JMX_TAGS = "trace.jmx.tags";
+  public static final String JMX_FETCH_ENABLED = "jmxfetch.enabled";
+  public static final String JMX_FETCH_CONFIG_DIR = "jmxfetch.config.dir";
+  public static final String JMX_FETCH_CONFIG = "jmxfetch.config";
+  @Deprecated public static final String JMX_FETCH_METRICS_CONFIGS = "jmxfetch.metrics-configs";
+  public static final String JMX_FETCH_CHECK_PERIOD = "jmxfetch.check-period";
+  public static final String JMX_FETCH_REFRESH_BEANS_PERIOD = "jmxfetch.refresh-beans-period";
+  public static final String JMX_FETCH_STATSD_HOST = "jmxfetch.statsd.host";
+  public static final String JMX_FETCH_STATSD_PORT = "jmxfetch.statsd.port";
+
+  private JmxFetchConfig() {}
+}

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
@@ -1,0 +1,43 @@
+package datadog.trace.api.config;
+
+/**
+ * These config options will only work with dd-java-agent, not with dd-trace-ot.
+ *
+ * <p>Configure via system properties, environment variables, or config properties file. See online
+ * documentation for details.
+ */
+public final class ProfilingConfig {
+  public static final String PROFILING_ENABLED = "profiling.enabled";
+  @Deprecated // Use dd.site instead
+  public static final String PROFILING_URL = "profiling.url";
+  @Deprecated // Use dd.api-key instead
+  public static final String PROFILING_API_KEY_OLD = "profiling.api-key";
+  @Deprecated // Use dd.api-key-file instead
+  public static final String PROFILING_API_KEY_FILE_OLD = "profiling.api-key-file";
+  @Deprecated // Use dd.api-key instead
+  public static final String PROFILING_API_KEY_VERY_OLD = "profiling.apikey";
+  @Deprecated // Use dd.api-key-file instead
+  public static final String PROFILING_API_KEY_FILE_VERY_OLD = "profiling.apikey.file";
+  public static final String PROFILING_TAGS = "profiling.tags";
+  public static final String PROFILING_START_DELAY = "profiling.start-delay";
+  // DANGEROUS! May lead on sigsegv on JVMs before 14
+  // Not intended for production use
+  public static final String PROFILING_START_FORCE_FIRST =
+      "profiling.experimental.start-force-first";
+  public static final String PROFILING_UPLOAD_PERIOD = "profiling.upload.period";
+  public static final String PROFILING_TEMPLATE_OVERRIDE_FILE =
+      "profiling.jfr-template-override-file";
+  public static final String PROFILING_UPLOAD_TIMEOUT = "profiling.upload.timeout";
+  public static final String PROFILING_UPLOAD_COMPRESSION = "profiling.upload.compression";
+  public static final String PROFILING_PROXY_HOST = "profiling.proxy.host";
+  public static final String PROFILING_PROXY_PORT = "profiling.proxy.port";
+  public static final String PROFILING_PROXY_USERNAME = "profiling.proxy.username";
+  public static final String PROFILING_PROXY_PASSWORD = "profiling.proxy.password";
+  public static final String PROFILING_EXCEPTION_SAMPLE_LIMIT = "profiling.exception.sample.limit";
+  public static final String PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS =
+      "profiling.exception.histogram.top-items";
+  public static final String PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE =
+      "profiling.exception.histogram.max-collection-size";
+
+  private ProfilingConfig() {}
+}

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
@@ -1,0 +1,34 @@
+package datadog.trace.api.config;
+
+/**
+ * These config options will only work with dd-java-agent, not with dd-trace-ot.
+ *
+ * <p>Configure via system properties, environment variables, or config properties file. See online
+ * documentation for details.
+ *
+ * @see {@link TracerConfig} for more tracer config options
+ */
+public final class TraceInstrumentationConfig {
+  public static final String TRACE_ENABLED = "trace.enabled";
+  public static final String INTEGRATIONS_ENABLED = "integrations.enabled";
+
+  public static final String TRACE_ANNOTATIONS = "trace.annotations";
+  public static final String TRACE_EXECUTORS_ALL = "trace.executors.all";
+  public static final String TRACE_EXECUTORS = "trace.executors";
+  public static final String TRACE_METHODS = "trace.methods";
+  public static final String TRACE_CLASSES_EXCLUDE = "trace.classes.exclude";
+
+  public static final String HTTP_SERVER_TAG_QUERY_STRING = "http.server.tag.query-string";
+  public static final String HTTP_CLIENT_TAG_QUERY_STRING = "http.client.tag.query-string";
+  public static final String HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN = "trace.http.client.split-by-domain";
+  public static final String DB_CLIENT_HOST_SPLIT_BY_INSTANCE = "trace.db.client.split-by-instance";
+
+  public static final String RUNTIME_CONTEXT_FIELD_INJECTION =
+      "trace.runtime.context.field.injection";
+
+  public static final String LOGS_INJECTION_ENABLED = "logs.injection";
+
+  public static final String KAFKA_CLIENT_PROPAGATION_ENABLED = "kafka.client.propagation.enabled";
+
+  private TraceInstrumentationConfig() {}
+}

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
@@ -1,0 +1,44 @@
+package datadog.trace.api.config;
+
+/**
+ * A list of keys to be used in a Properties instance with dd-trace-ot's DDTracer as follows:
+ *
+ * <pre>
+ *   DDTracer.builder().withProperties(new Properties()).build()
+ * </pre>
+ *
+ * If using dd-java-agent, these keys represent settings that should be configured via system
+ * properties, environment variables, or config properties file. See online documentation for
+ * details.
+ */
+public final class TracerConfig {
+  public static final String WRITER_TYPE = "writer.type";
+  public static final String AGENT_HOST = "agent.host";
+  public static final String TRACE_AGENT_PORT = "trace.agent.port";
+  public static final String AGENT_PORT_LEGACY = "agent.port";
+  public static final String AGENT_UNIX_DOMAIN_SOCKET = "trace.agent.unix.domain.socket";
+  public static final String AGENT_TIMEOUT = "trace.agent.timeout";
+  public static final String PRIORITY_SAMPLING = "priority.sampling";
+  public static final String TRACE_RESOLVER_ENABLED = "trace.resolver.enabled";
+  public static final String SERVICE_MAPPING = "service.mapping";
+
+  public static final String SPAN_TAGS = "trace.span.tags";
+  public static final String TRACE_ANALYTICS_ENABLED = "trace.analytics.enabled";
+  public static final String TRACE_SAMPLING_SERVICE_RULES = "trace.sampling.service.rules";
+  public static final String TRACE_SAMPLING_OPERATION_RULES = "trace.sampling.operation.rules";
+  public static final String TRACE_SAMPLE_RATE = "trace.sample.rate";
+  public static final String TRACE_RATE_LIMIT = "trace.rate.limit";
+  public static final String TRACE_REPORT_HOSTNAME = "trace.report-hostname";
+  public static final String HEADER_TAGS = "trace.header.tags";
+  public static final String HTTP_SERVER_ERROR_STATUSES = "http.server.error.statuses";
+  public static final String HTTP_CLIENT_ERROR_STATUSES = "http.client.error.statuses";
+
+  public static final String SPLIT_BY_TAGS = "trace.split-by-tags";
+
+  public static final String SCOPE_DEPTH_LIMIT = "trace.scope.depth.limit";
+  public static final String PARTIAL_FLUSH_MIN_SPANS = "trace.partial.flush.min.spans";
+  public static final String PROPAGATION_STYLE_EXTRACT = "propagation.style.extract";
+  public static final String PROPAGATION_STYLE_INJECT = "propagation.style.inject";
+
+  private TracerConfig() {}
+}

--- a/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -11,7 +11,6 @@ import static datadog.trace.api.Config.AGENT_UNIX_DOMAIN_SOCKET
 import static datadog.trace.api.Config.API_KEY
 import static datadog.trace.api.Config.API_KEY_FILE
 import static datadog.trace.api.Config.CONFIGURATION_FILE
-import static datadog.trace.api.Config.DB_CLIENT_HOST_SPLIT_BY_INSTANCE
 import static datadog.trace.api.Config.GLOBAL_TAGS
 import static datadog.trace.api.Config.HEADER_TAGS
 import static datadog.trace.api.Config.HEALTH_METRICS_ENABLED
@@ -81,6 +80,7 @@ import static datadog.trace.api.DDTags.LANGUAGE_TAG_VALUE
 import static datadog.trace.api.DDTags.RUNTIME_ID_TAG
 import static datadog.trace.api.DDTags.SERVICE
 import static datadog.trace.api.DDTags.SERVICE_TAG
+import static datadog.trace.api.config.TraceInstrumentationConfig.DB_CLIENT_HOST_SPLIT_BY_INSTANCE
 
 class ConfigTest extends DDSpecification {
   @Rule

--- a/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -12,17 +12,11 @@ import static datadog.trace.api.Config.API_KEY
 import static datadog.trace.api.Config.API_KEY_FILE
 import static datadog.trace.api.Config.CONFIGURATION_FILE
 import static datadog.trace.api.Config.DB_CLIENT_HOST_SPLIT_BY_INSTANCE
-import static datadog.trace.api.Config.DEFAULT_JMX_FETCH_STATSD_PORT
-import static datadog.trace.api.Config.DEFAULT_PROFILING_EXCEPTION_SAMPLE_LIMIT
-import static datadog.trace.api.Config.DEFAULT_PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE
-import static datadog.trace.api.Config.DEFAULT_PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS
-import static datadog.trace.api.Config.DEFAULT_SERVICE_NAME
 import static datadog.trace.api.Config.GLOBAL_TAGS
 import static datadog.trace.api.Config.HEADER_TAGS
 import static datadog.trace.api.Config.HEALTH_METRICS_ENABLED
 import static datadog.trace.api.Config.HEALTH_METRICS_STATSD_HOST
 import static datadog.trace.api.Config.HEALTH_METRICS_STATSD_PORT
-import static datadog.trace.api.Config.HOST_TAG
 import static datadog.trace.api.Config.HTTP_CLIENT_ERROR_STATUSES
 import static datadog.trace.api.Config.HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN
 import static datadog.trace.api.Config.HTTP_SERVER_ERROR_STATUSES
@@ -33,8 +27,6 @@ import static datadog.trace.api.Config.JMX_FETCH_REFRESH_BEANS_PERIOD
 import static datadog.trace.api.Config.JMX_FETCH_STATSD_HOST
 import static datadog.trace.api.Config.JMX_FETCH_STATSD_PORT
 import static datadog.trace.api.Config.JMX_TAGS
-import static datadog.trace.api.Config.LANGUAGE_TAG_KEY
-import static datadog.trace.api.Config.LANGUAGE_TAG_VALUE
 import static datadog.trace.api.Config.PARTIAL_FLUSH_MIN_SPANS
 import static datadog.trace.api.Config.PREFIX
 import static datadog.trace.api.Config.PRIORITY_SAMPLING
@@ -59,11 +51,8 @@ import static datadog.trace.api.Config.PROFILING_URL
 import static datadog.trace.api.Config.PROPAGATION_STYLE_EXTRACT
 import static datadog.trace.api.Config.PROPAGATION_STYLE_INJECT
 import static datadog.trace.api.Config.RUNTIME_CONTEXT_FIELD_INJECTION
-import static datadog.trace.api.Config.RUNTIME_ID_TAG
-import static datadog.trace.api.Config.SERVICE
 import static datadog.trace.api.Config.SERVICE_MAPPING
 import static datadog.trace.api.Config.SERVICE_NAME
-import static datadog.trace.api.Config.SERVICE_TAG
 import static datadog.trace.api.Config.SITE
 import static datadog.trace.api.Config.SPAN_TAGS
 import static datadog.trace.api.Config.SPLIT_BY_TAGS
@@ -77,6 +66,21 @@ import static datadog.trace.api.Config.TRACE_SAMPLE_RATE
 import static datadog.trace.api.Config.TRACE_SAMPLING_OPERATION_RULES
 import static datadog.trace.api.Config.TRACE_SAMPLING_SERVICE_RULES
 import static datadog.trace.api.Config.WRITER_TYPE
+import static datadog.trace.api.ConfigDefaults.DEFAULT_HTTP_CLIENT_ERROR_STATUSES
+import static datadog.trace.api.ConfigDefaults.DEFAULT_HTTP_SERVER_ERROR_STATUSES
+import static datadog.trace.api.ConfigDefaults.DEFAULT_JMX_FETCH_STATSD_PORT
+import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE
+import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS
+import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_EXCEPTION_SAMPLE_LIMIT
+import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_PROXY_PORT
+import static datadog.trace.api.ConfigDefaults.DEFAULT_SERVICE_NAME
+import static datadog.trace.api.ConfigDefaults.DEFAULT_SITE
+import static datadog.trace.api.DDTags.HOST_TAG
+import static datadog.trace.api.DDTags.LANGUAGE_TAG_KEY
+import static datadog.trace.api.DDTags.LANGUAGE_TAG_VALUE
+import static datadog.trace.api.DDTags.RUNTIME_ID_TAG
+import static datadog.trace.api.DDTags.SERVICE
+import static datadog.trace.api.DDTags.SERVICE_TAG
 
 class ConfigTest extends DDSpecification {
   @Rule
@@ -114,7 +118,7 @@ class ConfigTest extends DDSpecification {
 
     then:
     config.apiKey == null
-    config.site == Config.DEFAULT_SITE
+    config.site == DEFAULT_SITE
     config.serviceName == "unnamed-java-app"
     config.traceEnabled == true
     config.writerType == "DDAgentWriter"
@@ -157,7 +161,7 @@ class ConfigTest extends DDSpecification {
     config.profilingTemplateOverrideFile == null
     config.profilingUploadTimeout == 30
     config.profilingProxyHost == null
-    config.profilingProxyPort == Config.DEFAULT_PROFILING_PROXY_PORT
+    config.profilingProxyPort == DEFAULT_PROFILING_PROXY_PORT
     config.profilingProxyUsername == null
     config.profilingProxyPassword == null
     config.profilingExceptionSampleLimit == DEFAULT_PROFILING_EXCEPTION_SAMPLE_LIMIT
@@ -864,10 +868,10 @@ class ConfigTest extends DDSpecification {
       assert propConfig.httpServerErrorStatuses == toBitSet(expected)
       assert propConfig.httpClientErrorStatuses == toBitSet(expected)
     } else {
-      assert config.httpServerErrorStatuses == Config.DEFAULT_HTTP_SERVER_ERROR_STATUSES
-      assert config.httpClientErrorStatuses == Config.DEFAULT_HTTP_CLIENT_ERROR_STATUSES
-      assert propConfig.httpServerErrorStatuses == Config.DEFAULT_HTTP_SERVER_ERROR_STATUSES
-      assert propConfig.httpClientErrorStatuses == Config.DEFAULT_HTTP_CLIENT_ERROR_STATUSES
+      assert config.httpServerErrorStatuses == DEFAULT_HTTP_SERVER_ERROR_STATUSES
+      assert config.httpClientErrorStatuses == DEFAULT_HTTP_CLIENT_ERROR_STATUSES
+      assert propConfig.httpServerErrorStatuses == DEFAULT_HTTP_SERVER_ERROR_STATUSES
+      assert propConfig.httpClientErrorStatuses == DEFAULT_HTTP_CLIENT_ERROR_STATUSES
     }
 
     where:
@@ -1156,13 +1160,13 @@ class ConfigTest extends DDSpecification {
     Config config = Config.get(prop)
 
     then:
-    config.mergedSpanTags == [a: "1", b: "2", c: "3",  (Config.ENV) : "eu-east", (Config.VERSION) : "43"]
-    config.mergedJmxTags == [a: "1", b: "2", d: "4",  (Config.ENV) : "eu-east", (Config.VERSION) : "43",
+    config.mergedSpanTags == [a: "1", b: "2", c: "3", (Config.ENV): "eu-east", (Config.VERSION): "43"]
+    config.mergedJmxTags == [a               : "1", b: "2", d: "4", (Config.ENV): "eu-east", (Config.VERSION): "43",
                              (RUNTIME_ID_TAG): config.getRuntimeId(), (SERVICE_TAG): config.serviceName]
     config.headerTags == [e: "5"]
 
-    config.mergedProfilingTags == [a: "1", b: "2", f: "6",  (Config.ENV) : "eu-east", (Config.VERSION) : "43",
-                                   (HOST_TAG): config.getHostName(), (RUNTIME_ID_TAG): config.getRuntimeId(),
+    config.mergedProfilingTags == [a            : "1", b: "2", f: "6", (Config.ENV): "eu-east", (Config.VERSION): "43",
+                                   (HOST_TAG)   : config.getHostName(), (RUNTIME_ID_TAG): config.getRuntimeId(),
                                    (SERVICE_TAG): config.serviceName, (LANGUAGE_TAG_KEY): LANGUAGE_TAG_VALUE]
   }
 
@@ -1306,7 +1310,7 @@ class ConfigTest extends DDSpecification {
     Config config = new Config()
 
     then:
-    config.mergedSpanTags == ["version": "1.2.3", "env": "production-us", "other_tag":"test"]
+    config.mergedSpanTags == ["version": "1.2.3", "env": "production-us", "other_tag": "test"]
   }
 
   def "merge env from dd.trace.global.tags and DD_VERSION"() {
@@ -1318,7 +1322,7 @@ class ConfigTest extends DDSpecification {
     Config config = new Config()
 
     then:
-    config.mergedSpanTags == ["version": "1.2.3", "env": "us-barista-test", "other_tag":"test"]
+    config.mergedSpanTags == ["version": "1.2.3", "env": "us-barista-test", "other_tag": "test"]
   }
 
   def "merge version from dd.trace.global.tags and DD_ENV"() {
@@ -1330,7 +1334,7 @@ class ConfigTest extends DDSpecification {
     Config config = new Config()
 
     then:
-    config.mergedSpanTags == ["version": "3.2.1", "env": "us-barista-test", "other_tag":"test"]
+    config.mergedSpanTags == ["version": "3.2.1", "env": "us-barista-test", "other_tag": "test"]
   }
 
   def "merge version from dd.trace.global.tags and DD_SERVICE and DD_ENV"() {
@@ -1344,9 +1348,9 @@ class ConfigTest extends DDSpecification {
 
     then:
     config.serviceName == "dd-service-env-var"
-    config.mergedSpanTags == [version: "3.2.1", "service.version" : "my-svc-vers", "env": "us-barista-test", other_tag:"test"]
+    config.mergedSpanTags == [version: "3.2.1", "service.version": "my-svc-vers", "env": "us-barista-test", other_tag: "test"]
     config.mergedJmxTags == [(RUNTIME_ID_TAG): config.getRuntimeId(), (SERVICE_TAG): 'dd-service-env-var',
-                             version: "3.2.1","service.version" : "my-svc-vers", "env": "us-barista-test", other_tag:"test"]
+                             version         : "3.2.1", "service.version": "my-svc-vers", "env": "us-barista-test", other_tag: "test"]
   }
 
   def "merge env from dd.trace.global.tags and DD_SERVICE and DD_VERSION"() {
@@ -1360,9 +1364,9 @@ class ConfigTest extends DDSpecification {
 
     then:
     config.serviceName == "dd-service-env-var"
-    config.mergedSpanTags == [version: "3.2.1", "service.version" : "my-svc-vers", "env": "us-barista-test", other_tag:"test"]
+    config.mergedSpanTags == [version: "3.2.1", "service.version": "my-svc-vers", "env": "us-barista-test", other_tag: "test"]
     config.mergedJmxTags == [(RUNTIME_ID_TAG): config.getRuntimeId(), (SERVICE_TAG): 'dd-service-env-var',
-                             version: "3.2.1","service.version" : "my-svc-vers", "env": "us-barista-test", other_tag:"test"]
+                             version         : "3.2.1", "service.version": "my-svc-vers", "env": "us-barista-test", other_tag: "test"]
   }
 
   def "set of dd.trace.global.tags.env exclusively by java properties and without DD_ENV"() {
@@ -1392,7 +1396,7 @@ class ConfigTest extends DDSpecification {
     System.getenv(DD_ENV_ENV) == null
     System.getenv(DD_VERSION_ENV) == null
     //actual guard:
-    config.mergedSpanTags == [(Config.VERSION) : "42"]
+    config.mergedSpanTags == [(Config.VERSION): "42"]
   }
 
   def "set of version exclusively by DD_VERSION and without DD_ENV "() {
@@ -1423,14 +1427,14 @@ class ConfigTest extends DDSpecification {
 
     then:
     config.serviceName == DEFAULT_SERVICE_NAME
-    config.mergedSpanTags == [service:'service-tag-in-dd-trace-global-tags-java-property','service.version' : 'my-svc-vers']
-    config.mergedJmxTags == [(RUNTIME_ID_TAG): config.getRuntimeId(), (SERVICE_TAG): config.serviceName,
-                             'service.version' : 'my-svc-vers']
+    config.mergedSpanTags == [service: 'service-tag-in-dd-trace-global-tags-java-property', 'service.version': 'my-svc-vers']
+    config.mergedJmxTags == [(RUNTIME_ID_TAG) : config.getRuntimeId(), (SERVICE_TAG): config.serviceName,
+                             'service.version': 'my-svc-vers']
   }
 
   def "DD_SERVICE precedence over 'dd.service.name' java property is set; 'dd.service' overwrites DD_SERVICE"() {
     setup:
-    environmentVariables.set(DD_SERVICE_NAME_ENV,"dd-service-name-env-var")
+    environmentVariables.set(DD_SERVICE_NAME_ENV, "dd-service-name-env-var")
     System.setProperty(PREFIX + SERVICE_NAME, "dd-service-name-java-prop")
     environmentVariables.set("DD_SERVICE", "dd-service-env-var")
     System.setProperty(PREFIX + SERVICE, "dd-service-java-prop")
@@ -1441,14 +1445,14 @@ class ConfigTest extends DDSpecification {
 
     then:
     config.serviceName == "dd-service-java-prop"
-    config.mergedSpanTags == [service:'service-tag-in-dd-trace-global-tags-java-property','service.version' : 'my-svc-vers']
-    config.mergedJmxTags == [(RUNTIME_ID_TAG): config.getRuntimeId(), (SERVICE_TAG): config.serviceName,
-                             'service.version' : 'my-svc-vers']
+    config.mergedSpanTags == [service: 'service-tag-in-dd-trace-global-tags-java-property', 'service.version': 'my-svc-vers']
+    config.mergedJmxTags == [(RUNTIME_ID_TAG) : config.getRuntimeId(), (SERVICE_TAG): config.serviceName,
+                             'service.version': 'my-svc-vers']
   }
 
   def "DD_SERVICE precedence over 'DD_SERVICE_NAME' environment var is set"() {
     setup:
-    environmentVariables.set(DD_SERVICE_NAME_ENV,"dd-service-name-env-var")
+    environmentVariables.set(DD_SERVICE_NAME_ENV, "dd-service-name-env-var")
     environmentVariables.set("DD_SERVICE", "dd-service-env-var")
     System.setProperty(PREFIX + GLOBAL_TAGS, "service:service-tag-in-dd-trace-global-tags-java-property,service.version:my-svc-vers")
 
@@ -1457,9 +1461,9 @@ class ConfigTest extends DDSpecification {
 
     then:
     config.serviceName == "dd-service-env-var"
-    config.mergedSpanTags == [service:'service-tag-in-dd-trace-global-tags-java-property','service.version' : 'my-svc-vers']
-    config.mergedJmxTags == [(RUNTIME_ID_TAG): config.getRuntimeId(), (SERVICE_TAG): config.serviceName,
-                             'service.version' : 'my-svc-vers']
+    config.mergedSpanTags == [service: 'service-tag-in-dd-trace-global-tags-java-property', 'service.version': 'my-svc-vers']
+    config.mergedJmxTags == [(RUNTIME_ID_TAG) : config.getRuntimeId(), (SERVICE_TAG): config.serviceName,
+                             'service.version': 'my-svc-vers']
   }
 
   def "dd.service overwrites DD_SERVICE"() {
@@ -1473,9 +1477,9 @@ class ConfigTest extends DDSpecification {
 
     then:
     config.serviceName == "dd-service-java-prop"
-    config.mergedSpanTags == [service:'service-tag-in-dd-trace-global-tags-java-property','service.version' : 'my-svc-vers']
-    config.mergedJmxTags == [(RUNTIME_ID_TAG): config.getRuntimeId(), (SERVICE_TAG): config.serviceName,
-                             'service.version' : 'my-svc-vers']
+    config.mergedSpanTags == [service: 'service-tag-in-dd-trace-global-tags-java-property', 'service.version': 'my-svc-vers']
+    config.mergedJmxTags == [(RUNTIME_ID_TAG) : config.getRuntimeId(), (SERVICE_TAG): config.serviceName,
+                             'service.version': 'my-svc-vers']
   }
 
   def "set servicenaem by DD_SERVICE"() {
@@ -1489,9 +1493,9 @@ class ConfigTest extends DDSpecification {
 
     then:
     config.serviceName == "dd-service-env-var"
-    config.mergedSpanTags == [service:'service-tag-in-dd-trace-global-tags-java-property','service.version' : 'my-svc-vers']
-    config.mergedJmxTags == [(RUNTIME_ID_TAG): config.getRuntimeId(), (SERVICE_TAG): config.serviceName,
-                             'service.version' : 'my-svc-vers']
+    config.mergedSpanTags == [service: 'service-tag-in-dd-trace-global-tags-java-property', 'service.version': 'my-svc-vers']
+    config.mergedJmxTags == [(RUNTIME_ID_TAG) : config.getRuntimeId(), (SERVICE_TAG): config.serviceName,
+                             'service.version': 'my-svc-vers']
   }
 
   // Static methods test:
@@ -1514,26 +1518,26 @@ class ConfigTest extends DDSpecification {
     Config.valueOf(value, tClass, defaultValue) == expected
 
     where:
-    value      | tClass  | defaultValue | expected
-    "42.42"    | Boolean | true         | false
-    "42.42"    | Boolean | null         | false
-    "true"     | Boolean | null         | true
-    "trUe"     | Boolean | null         | true
-    "trUe"     | Boolean | false        | true
-    "tru"      | Boolean | true         | false
-    "truee"    | Boolean | true         | false
-    "true "    | Boolean | true         | false
-    " true"    | Boolean | true         | false
-    " true "   | Boolean | true         | false
-    "   true  "| Boolean | true         | false
-    null       | Float   | 43.3         | 43.3
-    "42.42"    | Float   | 21.21        | 42.42f
-    null       | Double  | 43.3         | 43.3
-    "42.42"    | Double  | 21.21        | 42.42
-    null       | Integer | 13           | 13
-    "44"       | Integer | 21           | 44
-    "45"       | Long    | 21           | 45
-    "46"       | Short   | 21           | 46
+    value       | tClass  | defaultValue | expected
+    "42.42"     | Boolean | true         | false
+    "42.42"     | Boolean | null         | false
+    "true"      | Boolean | null         | true
+    "trUe"      | Boolean | null         | true
+    "trUe"      | Boolean | false        | true
+    "tru"       | Boolean | true         | false
+    "truee"     | Boolean | true         | false
+    "true "     | Boolean | true         | false
+    " true"     | Boolean | true         | false
+    " true "    | Boolean | true         | false
+    "   true  " | Boolean | true         | false
+    null        | Float   | 43.3         | 43.3
+    "42.42"     | Float   | 21.21        | 42.42f
+    null        | Double  | 43.3         | 43.3
+    "42.42"     | Double  | 21.21        | 42.42
+    null        | Integer | 13           | 13
+    "44"        | Integer | 21           | 44
+    "45"        | Long    | 21           | 45
+    "46"        | Short   | 21           | 46
   }
 
   def "valueOf negative test when tClass is null"() {
@@ -1545,11 +1549,11 @@ class ConfigTest extends DDSpecification {
     exception.message == "tClass is marked non-null but is null"
 
     where:
-    value      | tClass  | defaultValue
-    null       | null    | "42"
-    ""         | null    | "43"
-    "      "   | null    | "44"
-    "1"        | null    | "45"
+    value    | tClass | defaultValue
+    null     | null   | "42"
+    ""       | null   | "43"
+    "      " | null   | "44"
+    "1"      | null   | "45"
   }
 
   def "valueOf negative test"() {
@@ -1558,29 +1562,29 @@ class ConfigTest extends DDSpecification {
 
     then:
     def exception = thrown(NumberFormatException)
-    println("cause: " : exception.message)
+    println("cause: ": exception.message)
 
     where:
-    value      | tClass
-    "42.42"    | Number
-    "42.42"    | Byte
-    "42.42"    | Character
-    "42.42"    | Short
-    "42.42"    | Integer
-    "42.42"    | Long
-    "42.42"    | Object
-    "42.42"    | Object[]
-    "42.42"    | boolean[]
-    "42.42"    | boolean
-    "42.42"    | byte
-    "42.42"    | byte
-    "42.42"    | char
-    "42.42"    | short
-    "42.42"    | int
-    "42.42"    | long
-    "42.42"    | double
-    "42.42"    | float
-    "42.42"    | ClassThrowsExceptionForValueOfMethod // will wrapped in NumberFormatException anyway
+    value   | tClass
+    "42.42" | Number
+    "42.42" | Byte
+    "42.42" | Character
+    "42.42" | Short
+    "42.42" | Integer
+    "42.42" | Long
+    "42.42" | Object
+    "42.42" | Object[]
+    "42.42" | boolean[]
+    "42.42" | boolean
+    "42.42" | byte
+    "42.42" | byte
+    "42.42" | char
+    "42.42" | short
+    "42.42" | int
+    "42.42" | long
+    "42.42" | double
+    "42.42" | float
+    "42.42" | ClassThrowsExceptionForValueOfMethod // will wrapped in NumberFormatException anyway
   }
 
   static class ClassThrowsExceptionForValueOfMethod {

--- a/dd-trace-core/jfr-openjdk/src/test/groovy/datadog/trace/core/jfr/openjdk/ScopeEventTest.groovy
+++ b/dd-trace-core/jfr-openjdk/src/test/groovy/datadog/trace/core/jfr/openjdk/ScopeEventTest.groovy
@@ -2,13 +2,13 @@ package datadog.trace.core.jfr.openjdk
 
 import datadog.trace.agent.test.utils.ConfigUtils
 import datadog.trace.api.Config
+import datadog.trace.api.DDId
 import datadog.trace.api.sampling.PrioritySampling
 import datadog.trace.bootstrap.instrumentation.api.AgentScope
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan
 import datadog.trace.common.writer.ListWriter
 import datadog.trace.context.TraceScope
 import datadog.trace.core.CoreTracer
-import datadog.trace.api.DDId
 import datadog.trace.core.DDSpanContext
 import datadog.trace.core.PendingTrace
 import datadog.trace.core.util.ThreadCpuTimeAccess
@@ -17,7 +17,7 @@ import spock.lang.Requires
 
 import java.time.Duration
 
-import static datadog.trace.api.Config.DEFAULT_SERVICE_NAME
+import static datadog.trace.api.ConfigDefaults.DEFAULT_SERVICE_NAME
 
 @Requires({ jvm.java11Compatible })
 class ScopeEventTest extends DDSpecification {

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/DDAgentWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/DDAgentWriter.java
@@ -1,9 +1,9 @@
 package datadog.trace.common.writer;
 
-import static datadog.trace.api.Config.DEFAULT_AGENT_HOST;
-import static datadog.trace.api.Config.DEFAULT_AGENT_TIMEOUT;
-import static datadog.trace.api.Config.DEFAULT_AGENT_UNIX_DOMAIN_SOCKET;
-import static datadog.trace.api.Config.DEFAULT_TRACE_AGENT_PORT;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_AGENT_HOST;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_AGENT_TIMEOUT;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_AGENT_UNIX_DOMAIN_SOCKET;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_AGENT_PORT;
 
 import com.lmax.disruptor.EventFactory;
 import datadog.trace.common.writer.ddagent.DDAgentApi;
@@ -73,7 +73,7 @@ public class DDAgentWriter implements Writer {
 
   @Deprecated
   public DDAgentWriter(final DDAgentApi api, final Monitor monitor) {
-    StatefulSerializer serializer = new MsgPackStatefulSerializer();
+    final StatefulSerializer serializer = new MsgPackStatefulSerializer();
     this.api = api;
     this.monitor = monitor;
     dispatchingDisruptor =
@@ -110,9 +110,9 @@ public class DDAgentWriter implements Writer {
     }
     final StatefulSerializer s = null == serializer ? new MsgPackStatefulSerializer() : serializer;
     this.monitor = monitor;
-    this.dispatchingDisruptor =
+    dispatchingDisruptor =
         new DispatchingDisruptor(OUTSTANDING_REQUESTS, toEventFactory(s), api, monitor, this);
-    this.traceProcessingDisruptor =
+    traceProcessingDisruptor =
         new TraceProcessingDisruptor(
             traceBufferSize,
             dispatchingDisruptor,
@@ -197,7 +197,7 @@ public class DDAgentWriter implements Writer {
 
   @Override
   public void close() {
-    boolean flushed = flush();
+    final boolean flushed = flush();
     closed = true;
     try {
       traceProcessingDisruptor.close();
@@ -230,7 +230,7 @@ public class DDAgentWriter implements Writer {
   private static final class SerializerBackedEventFactory implements EventFactory<TraceBuffer> {
     private final StatefulSerializer serializer;
 
-    private SerializerBackedEventFactory(StatefulSerializer serializer) {
+    private SerializerBackedEventFactory(final StatefulSerializer serializer) {
       this.serializer = serializer;
     }
 

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/Writer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/Writer.java
@@ -1,7 +1,7 @@
 package datadog.trace.common.writer;
 
 import datadog.trace.api.Config;
-import datadog.trace.bootstrap.instrumentation.api.AssortedConstants;
+import datadog.trace.bootstrap.instrumentation.api.WriterConstants;
 import datadog.trace.common.writer.ddagent.DDAgentApi;
 import datadog.trace.common.writer.ddagent.Monitor;
 import datadog.trace.core.DDSpan;
@@ -42,9 +42,9 @@ public interface Writer extends Closeable {
 
       if (config != null) {
         final String configuredType = config.getWriterType();
-        if (AssortedConstants.DD_AGENT_WRITER_TYPE.equals(configuredType)) {
+        if (WriterConstants.DD_AGENT_WRITER_TYPE.equals(configuredType)) {
           writer = createAgentWriter(config);
-        } else if (AssortedConstants.LOGGING_WRITER_TYPE.equals(configuredType)) {
+        } else if (WriterConstants.LOGGING_WRITER_TYPE.equals(configuredType)) {
           writer = new LoggingWriter();
         } else {
           log.warn(

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/Writer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/Writer.java
@@ -1,6 +1,7 @@
 package datadog.trace.common.writer;
 
 import datadog.trace.api.Config;
+import datadog.trace.bootstrap.instrumentation.api.AssortedConstants;
 import datadog.trace.common.writer.ddagent.DDAgentApi;
 import datadog.trace.common.writer.ddagent.Monitor;
 import datadog.trace.core.DDSpan;
@@ -41,9 +42,9 @@ public interface Writer extends Closeable {
 
       if (config != null) {
         final String configuredType = config.getWriterType();
-        if (Config.DD_AGENT_WRITER_TYPE.equals(configuredType)) {
+        if (AssortedConstants.DD_AGENT_WRITER_TYPE.equals(configuredType)) {
           writer = createAgentWriter(config);
-        } else if (Config.LOGGING_WRITER_TYPE.equals(configuredType)) {
+        } else if (AssortedConstants.LOGGING_WRITER_TYPE.equals(configuredType)) {
           writer = new LoggingWriter();
         } else {
           log.warn(

--- a/dd-trace-core/src/main/java/datadog/trace/core/taginterceptor/ServletContextTagInterceptor.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/taginterceptor/ServletContextTagInterceptor.java
@@ -1,6 +1,6 @@
 package datadog.trace.core.taginterceptor;
 
-import datadog.trace.api.Config;
+import datadog.trace.api.ConfigDefaults;
 import datadog.trace.bootstrap.instrumentation.api.InstrumentationTags;
 import datadog.trace.core.DDSpanContext;
 
@@ -14,7 +14,7 @@ class ServletContextTagInterceptor extends AbstractTagInterceptor {
   public boolean shouldSetTag(final DDSpanContext context, final String tag, final Object value) {
     String contextName = String.valueOf(value).trim();
     if (contextName.equals("/")
-        || (!context.getServiceName().equals(Config.DEFAULT_SERVICE_NAME)
+        || (!context.getServiceName().equals(ConfigDefaults.DEFAULT_SERVICE_NAME)
             && !context.getServiceName().isEmpty())) {
       return true;
     }

--- a/dd-trace-core/src/test/groovy/datadog/trace/api/sampling/RuleBasedSamplingTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/api/sampling/RuleBasedSamplingTest.groovy
@@ -1,17 +1,17 @@
 package datadog.trace.api.sampling
 
-import datadog.trace.core.DDSpan
-import datadog.trace.core.SpanFactory
 import datadog.trace.common.sampling.PrioritySampler
 import datadog.trace.common.sampling.RateByServiceSampler
 import datadog.trace.common.sampling.RuleBasedSampler
 import datadog.trace.common.sampling.Sampler
+import datadog.trace.core.DDSpan
+import datadog.trace.core.SpanFactory
 import datadog.trace.util.test.DDSpecification
 
-import static datadog.trace.api.Config.TRACE_RATE_LIMIT
-import static datadog.trace.api.Config.TRACE_SAMPLE_RATE
-import static datadog.trace.api.Config.TRACE_SAMPLING_OPERATION_RULES
-import static datadog.trace.api.Config.TRACE_SAMPLING_SERVICE_RULES
+import static datadog.trace.api.config.TracerConfig.TRACE_RATE_LIMIT
+import static datadog.trace.api.config.TracerConfig.TRACE_SAMPLE_RATE
+import static datadog.trace.api.config.TracerConfig.TRACE_SAMPLING_OPERATION_RULES
+import static datadog.trace.api.config.TracerConfig.TRACE_SAMPLING_SERVICE_RULES
 import static datadog.trace.api.sampling.PrioritySampling.SAMPLER_DROP
 import static datadog.trace.api.sampling.PrioritySampling.SAMPLER_KEEP
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/CoreSpanBuilderTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/CoreSpanBuilderTest.groovy
@@ -2,7 +2,6 @@ package datadog.trace.core
 
 import datadog.trace.api.Config
 import datadog.trace.api.DDId
-import datadog.trace.api.DDTags
 import datadog.trace.bootstrap.instrumentation.api.AgentScope
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer
 import datadog.trace.common.writer.ListWriter
@@ -10,6 +9,11 @@ import datadog.trace.core.propagation.ExtractedContext
 import datadog.trace.core.propagation.TagContext
 import datadog.trace.util.test.DDSpecification
 
+import static datadog.trace.api.DDTags.LANGUAGE_TAG_KEY
+import static datadog.trace.api.DDTags.LANGUAGE_TAG_VALUE
+import static datadog.trace.api.DDTags.RUNTIME_ID_TAG
+import static datadog.trace.api.DDTags.THREAD_ID
+import static datadog.trace.api.DDTags.THREAD_NAME
 import static datadog.trace.core.DDSpanContext.ORIGIN_KEY
 import static java.util.concurrent.TimeUnit.MILLISECONDS
 
@@ -56,10 +60,10 @@ class CoreSpanBuilderTest extends DDSpecification {
 
     then:
     span.getTags() == [
-      (DDTags.THREAD_NAME)     : Thread.currentThread().getName(),
-      (DDTags.THREAD_ID)       : Thread.currentThread().getId(),
-      (Config.RUNTIME_ID_TAG)  : config.getRuntimeId(),
-      (Config.LANGUAGE_TAG_KEY): Config.LANGUAGE_TAG_VALUE,
+      (THREAD_NAME)     : Thread.currentThread().getName(),
+      (THREAD_ID)       : Thread.currentThread().getId(),
+      (RUNTIME_ID_TAG)  : config.getRuntimeId(),
+      (LANGUAGE_TAG_KEY): LANGUAGE_TAG_VALUE,
     ]
 
     when:
@@ -86,8 +90,8 @@ class CoreSpanBuilderTest extends DDSpecification {
     context.getServiceName() == expectedService
     context.getSpanType() == expectedType
 
-    context.tags[DDTags.THREAD_NAME] == Thread.currentThread().getName()
-    context.tags[DDTags.THREAD_ID] == Thread.currentThread().getId()
+    context.tags[THREAD_NAME] == Thread.currentThread().getName()
+    context.tags[THREAD_ID] == Thread.currentThread().getId()
   }
 
   def "setting #name should remove"() {
@@ -298,12 +302,12 @@ class CoreSpanBuilderTest extends DDSpecification {
     span.samplingPriority == extractedContext.samplingPriority
     span.context().origin == extractedContext.origin
     span.context().baggageItems == extractedContext.baggage
-    span.context().@tags == extractedContext.tags + [(Config.RUNTIME_ID_TAG)  : config.getRuntimeId(),
-                                                     (Config.LANGUAGE_TAG_KEY): Config.LANGUAGE_TAG_VALUE,
-                                                     (DDTags.THREAD_NAME)     : thread.name, (DDTags.THREAD_ID): thread.id]
+    span.context().@tags == extractedContext.tags + [(RUNTIME_ID_TAG)  : config.getRuntimeId(),
+                                                     (LANGUAGE_TAG_KEY): LANGUAGE_TAG_VALUE,
+                                                     (THREAD_NAME)     : thread.name, (THREAD_ID): thread.id]
 
     where:
-    extractedContext                                                                                                | _
+    extractedContext                                                                                                                    | _
     new ExtractedContext(DDId.ONE, DDId.from(2), 0, null, [:], [:])                                                                     | _
     new ExtractedContext(DDId.from(3), DDId.from(4), 1, "some-origin", ["asdf": "qwer"], [(ORIGIN_KEY): "some-origin", "zxcv": "1234"]) | _
   }
@@ -319,9 +323,9 @@ class CoreSpanBuilderTest extends DDSpecification {
     span.samplingPriority == null
     span.context().origin == tagContext.origin
     span.context().baggageItems == [:]
-    span.context().@tags == tagContext.tags + [(Config.RUNTIME_ID_TAG)  : config.getRuntimeId(),
-                                               (Config.LANGUAGE_TAG_KEY): Config.LANGUAGE_TAG_VALUE,
-                                               (DDTags.THREAD_NAME)     : thread.name, (DDTags.THREAD_ID): thread.id]
+    span.context().@tags == tagContext.tags + [(RUNTIME_ID_TAG)  : config.getRuntimeId(),
+                                               (LANGUAGE_TAG_KEY): LANGUAGE_TAG_VALUE,
+                                               (THREAD_NAME)     : thread.name, (THREAD_ID): thread.id]
 
     where:
     tagContext                                                                   | _
@@ -338,10 +342,10 @@ class CoreSpanBuilderTest extends DDSpecification {
 
     expect:
     span.tags == tags + [
-      (DDTags.THREAD_NAME)     : Thread.currentThread().getName(),
-      (DDTags.THREAD_ID)       : Thread.currentThread().getId(),
-      (Config.RUNTIME_ID_TAG)  : config.getRuntimeId(),
-      (Config.LANGUAGE_TAG_KEY): Config.LANGUAGE_TAG_VALUE,
+      (THREAD_NAME)     : Thread.currentThread().getName(),
+      (THREAD_ID)       : Thread.currentThread().getId(),
+      (RUNTIME_ID_TAG)  : config.getRuntimeId(),
+      (LANGUAGE_TAG_KEY): LANGUAGE_TAG_VALUE,
     ]
 
     cleanup:

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/CoreTracerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/CoreTracerTest.groovy
@@ -19,13 +19,13 @@ import org.junit.contrib.java.lang.system.EnvironmentVariables
 import org.junit.contrib.java.lang.system.RestoreSystemProperties
 import spock.lang.Timeout
 
-import static datadog.trace.api.Config.HEADER_TAGS
-import static datadog.trace.api.Config.HEALTH_METRICS_ENABLED
 import static datadog.trace.api.Config.PREFIX
-import static datadog.trace.api.Config.PRIORITY_SAMPLING
-import static datadog.trace.api.Config.SERVICE_MAPPING
-import static datadog.trace.api.Config.SPAN_TAGS
-import static datadog.trace.api.Config.WRITER_TYPE
+import static datadog.trace.api.config.GeneralConfig.HEALTH_METRICS_ENABLED
+import static datadog.trace.api.config.TracerConfig.HEADER_TAGS
+import static datadog.trace.api.config.TracerConfig.PRIORITY_SAMPLING
+import static datadog.trace.api.config.TracerConfig.SERVICE_MAPPING
+import static datadog.trace.api.config.TracerConfig.SPAN_TAGS
+import static datadog.trace.api.config.TracerConfig.WRITER_TYPE
 
 @Timeout(10)
 class CoreTracerTest extends DDSpecification {

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanTest.groovy
@@ -11,7 +11,7 @@ import datadog.trace.util.test.DDSpecification
 
 import java.util.concurrent.TimeUnit
 
-import static datadog.trace.api.Config.DEFAULT_SERVICE_NAME
+import static datadog.trace.api.ConfigDefaults.DEFAULT_SERVICE_NAME
 
 class DDSpanTest extends DDSpecification {
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceTest.groovy
@@ -11,7 +11,7 @@ import spock.lang.Timeout
 import java.lang.ref.WeakReference
 import java.util.concurrent.TimeUnit
 
-import static datadog.trace.api.Config.PARTIAL_FLUSH_MIN_SPANS
+import static datadog.trace.api.config.TracerConfig.PARTIAL_FLUSH_MIN_SPANS
 
 class PendingTraceTest extends DDSpecification {
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/taginterceptor/TagInterceptorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/taginterceptor/TagInterceptorTest.groovy
@@ -1,7 +1,6 @@
 package datadog.trace.core.taginterceptor
 
 import datadog.trace.agent.test.utils.ConfigUtils
-import datadog.trace.api.Config
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import datadog.trace.api.sampling.PrioritySampling
@@ -13,19 +12,20 @@ import datadog.trace.core.DDSpanContext
 import datadog.trace.core.SpanFactory
 import datadog.trace.util.test.DDSpecification
 
-import static datadog.trace.api.Config.DEFAULT_SERVICE_NAME
+import static datadog.trace.api.ConfigDefaults.DEFAULT_SERVICE_NAME
 import static datadog.trace.api.DDTags.ANALYTICS_SAMPLE_RATE
+import static datadog.trace.api.config.TracerConfig.SPLIT_BY_TAGS
 
 class TagInterceptorTest extends DDSpecification {
   static {
     ConfigUtils.updateConfig {
-      System.setProperty("dd.$Config.SPLIT_BY_TAGS", "sn.tag1,sn.tag2")
+      System.setProperty("dd.$SPLIT_BY_TAGS", "sn.tag1,sn.tag2")
     }
   }
 
   def cleanupSpec() {
     ConfigUtils.updateConfig {
-      System.clearProperty("dd.$Config.SPLIT_BY_TAGS")
+      System.clearProperty("dd.$SPLIT_BY_TAGS")
     }
   }
   def tracer = CoreTracer.builder().writer(new LoggingWriter()).build()

--- a/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
@@ -1,6 +1,7 @@
 package datadog.opentracing;
 
 import datadog.trace.api.Config;
+import datadog.trace.api.DDTags;
 import datadog.trace.api.interceptor.TraceInterceptor;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
@@ -180,7 +181,7 @@ public class DDTracer implements Tracer, datadog.trace.api.Tracer {
   @Builder
   // These field names must be stable to ensure the builder api is stable.
   private DDTracer(
-      final Config config,
+      @Deprecated final Config config,
       final String serviceName,
       final Writer writer,
       final Sampler sampler,
@@ -200,8 +201,8 @@ public class DDTracer implements Tracer, datadog.trace.api.Tracer {
       converter = new TypeConverter(new DefaultLogHandler());
     }
 
-    // Each of these are only overriden if set
-    // Otherwise, the values retrieved from config will be overriden with null
+    // Each of these are only overridden if set
+    // Otherwise, the values retrieved from config will be overridden with null
     CoreTracer.CoreTracerBuilder builder = CoreTracer.builder();
 
     if (config != null) {
@@ -266,7 +267,7 @@ public class DDTracer implements Tracer, datadog.trace.api.Tracer {
   private static Map<String, String> customRuntimeTags(
       final String runtimeId, final Map<String, String> applicationRootSpanTags) {
     final Map<String, String> runtimeTags = new HashMap<>(applicationRootSpanTags);
-    runtimeTags.put(Config.RUNTIME_ID_TAG, runtimeId);
+    runtimeTags.put(DDTags.RUNTIME_ID_TAG, runtimeId);
     return Collections.unmodifiableMap(runtimeTags);
   }
 

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/DDTracerAPITest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/DDTracerAPITest.groovy
@@ -1,12 +1,14 @@
 package datadog.opentracing
 
 
-import datadog.trace.api.Config
 import datadog.trace.common.sampling.RateByServiceSampler
 import datadog.trace.common.writer.ListWriter
 import datadog.trace.util.test.DDSpecification
 
-import static datadog.trace.api.Config.DEFAULT_SERVICE_NAME
+import static datadog.trace.api.ConfigDefaults.DEFAULT_SERVICE_NAME
+import static datadog.trace.api.DDTags.LANGUAGE_TAG_KEY
+import static datadog.trace.api.DDTags.LANGUAGE_TAG_VALUE
+import static datadog.trace.api.DDTags.RUNTIME_ID_TAG
 
 class DDTracerAPITest extends DDSpecification {
   def "verify sampler/writer constructor"() {
@@ -22,7 +24,7 @@ class DDTracerAPITest extends DDSpecification {
     tracer.serviceName == DEFAULT_SERVICE_NAME
     tracer.sampler == sampler
     tracer.writer == writer
-    tracer.localRootSpanTags[Config.RUNTIME_ID_TAG].size() > 0 // not null or empty
-    tracer.localRootSpanTags[Config.LANGUAGE_TAG_KEY] == Config.LANGUAGE_TAG_VALUE
+    tracer.localRootSpanTags[RUNTIME_ID_TAG].size() > 0 // not null or empty
+    tracer.localRootSpanTags[LANGUAGE_TAG_KEY] == LANGUAGE_TAG_VALUE
   }
 }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AssortedConstants.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AssortedConstants.java
@@ -1,0 +1,6 @@
+package datadog.trace.bootstrap.instrumentation.api;
+
+public class AssortedConstants {
+  public static final String DD_AGENT_WRITER_TYPE = "DDAgentWriter";
+  public static final String LOGGING_WRITER_TYPE = "LoggingWriter";
+}

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/WriterConstants.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/WriterConstants.java
@@ -1,6 +1,8 @@
 package datadog.trace.bootstrap.instrumentation.api;
 
-public class WriterConstants {
+public final class WriterConstants {
   public static final String DD_AGENT_WRITER_TYPE = "DDAgentWriter";
   public static final String LOGGING_WRITER_TYPE = "LoggingWriter";
+
+  private WriterConstants() {}
 }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/WriterConstants.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/WriterConstants.java
@@ -1,6 +1,6 @@
 package datadog.trace.bootstrap.instrumentation.api;
 
-public class AssortedConstants {
+public class WriterConstants {
   public static final String DD_AGENT_WRITER_TYPE = "DDAgentWriter";
   public static final String LOGGING_WRITER_TYPE = "LoggingWriter";
 }


### PR DESCRIPTION
This way the classes with config keys can stay long term while we move the config class out.