### PR TITLE
Iterate type interfaces without materialising a list during super type matching

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/HasSuperMethodMatcher.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/HasSuperMethodMatcher.java
@@ -27,7 +27,7 @@ class HasSuperMethodMatcher<T extends MethodDescription>
     }
     final Junction<MethodDescription> signatureMatcher = hasSignature(target.asSignatureToken());
     TypeDefinition declaringType = target.getDeclaringType();
-    final Set<TypeDefinition> checkedInterfaces = new HashSet<>();
+    final Set<TypeDefinition> checkedInterfaces = new HashSet<>(8);
 
     while (declaringType != null) {
       for (final MethodDescription methodDescription : declaringType.getDeclaredMethods()) {
@@ -48,8 +48,7 @@ class HasSuperMethodMatcher<T extends MethodDescription>
       final Junction<MethodDescription> signatureMatcher,
       final Set<TypeDefinition> checkedInterfaces) {
     for (final TypeDefinition type : interfaces) {
-      if (!checkedInterfaces.contains(type)) {
-        checkedInterfaces.add(type);
+      if (checkedInterfaces.add(type)) {
         for (final MethodDescription methodDescription : type.getDeclaredMethods()) {
           if (signatureMatcher.matches(methodDescription) && matcher.matches(methodDescription)) {
             return true;

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/bytebuddy/matcher/HasInterfaceMatcherTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/bytebuddy/matcher/HasInterfaceMatcherTest.groovy
@@ -8,6 +8,7 @@ import datadog.trace.agent.tooling.bytebuddy.matcher.testclasses.F
 import datadog.trace.agent.tooling.bytebuddy.matcher.testclasses.G
 import datadog.trace.util.test.DDSpecification
 import net.bytebuddy.description.type.TypeDescription
+import net.bytebuddy.description.type.TypeList
 import net.bytebuddy.jar.asm.Opcodes
 import spock.lang.Shared
 
@@ -46,6 +47,8 @@ class HasInterfaceMatcherTest extends DDSpecification {
     def type = Mock(TypeDescription)
     def typeGeneric = Mock(TypeDescription.Generic)
     def matcher = implementsInterface(named(Object.name))
+    def interfaces = Mock(TypeList.Generic)
+    def it = new ThrowOnFirstElement()
 
     when:
     def result = matcher.matches(type)
@@ -58,7 +61,8 @@ class HasInterfaceMatcherTest extends DDSpecification {
     1 * type.asGenericType() >> typeGeneric
     1 * typeGeneric.asErasure() >> { throw new Exception("asErasure exception") }
     1 * typeGeneric.getTypeName() >> "typeGeneric-name"
-    1 * type.getInterfaces() >> { throw new Exception("getInterfaces exception") }
+    1 * type.getInterfaces() >> interfaces
+    1 * interfaces.iterator() >> it
     1 * type.getSuperClass() >> { throw new Exception("getSuperClass exception") }
     2 * type.getTypeName() >> "type-name"
     0 * _

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/bytebuddy/matcher/ImplementsInterfaceMatcherTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/bytebuddy/matcher/ImplementsInterfaceMatcherTest.groovy
@@ -8,6 +8,7 @@ import datadog.trace.agent.tooling.bytebuddy.matcher.testclasses.F
 import datadog.trace.agent.tooling.bytebuddy.matcher.testclasses.G
 import datadog.trace.util.test.DDSpecification
 import net.bytebuddy.description.type.TypeDescription
+import net.bytebuddy.description.type.TypeList
 import net.bytebuddy.jar.asm.Opcodes
 import spock.lang.Shared
 
@@ -40,7 +41,7 @@ class ImplementsInterfaceMatcherTest extends DDSpecification {
     argument = typePool.describe(type.name).resolve()
   }
 
-  def "test traversal exceptions"() {
+  def "test exception getting interfaces"() {
     setup:
     def type = Mock(TypeDescription)
     def typeGeneric = Mock(TypeDescription.Generic)
@@ -57,9 +58,35 @@ class ImplementsInterfaceMatcherTest extends DDSpecification {
     1 * type.asGenericType() >> typeGeneric
     1 * typeGeneric.asErasure() >> { throw new Exception("asErasure exception") }
     1 * typeGeneric.getTypeName() >> "typeGeneric-name"
-    1 * type.getInterfaces() >> { throw new Exception("getInterfaces exception") }
+    1 * type.getInterfaces() >>  { throw new Exception("getInterfaces exception") }
     1 * type.getSuperClass() >> { throw new Exception("getSuperClass exception") }
     2 * type.getTypeName() >> "type-name"
+    0 * _
+  }
+
+  def "test traversal exceptions"() {
+    setup:
+    def type = Mock(TypeDescription)
+    def typeGeneric = Mock(TypeDescription.Generic)
+    def matcher = implementsInterface(named(Object.name))
+    def interfaces = Mock(TypeList.Generic)
+    def it = new ThrowOnFirstElement()
+
+    when:
+    def result = matcher.matches(type)
+
+    then:
+    !result // default to false
+    noExceptionThrown()
+    1 * type.getModifiers() >> Opcodes.ACC_ABSTRACT
+    1 * type.isInterface() >> true
+    1 * type.asGenericType() >> typeGeneric
+    1 * typeGeneric.asErasure() >> { throw new Exception("asErasure exception") }
+    1 * typeGeneric.getTypeName() >> "typeGeneric-name"
+    1 * type.getInterfaces() >> interfaces
+    1 * interfaces.iterator() >> it
+    2 * type.getTypeName() >> "type-name"
+    1 * type.getSuperClass() >> { throw new Exception("getSuperClass exception") }
     0 * _
   }
 }

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/bytebuddy/matcher/SafeHasSuperTypeMatcherTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/bytebuddy/matcher/SafeHasSuperTypeMatcherTest.groovy
@@ -8,6 +8,7 @@ import datadog.trace.agent.tooling.bytebuddy.matcher.testclasses.F
 import datadog.trace.agent.tooling.bytebuddy.matcher.testclasses.G
 import datadog.trace.util.test.DDSpecification
 import net.bytebuddy.description.type.TypeDescription
+import net.bytebuddy.description.type.TypeList
 import net.bytebuddy.jar.asm.Opcodes
 import spock.lang.Shared
 
@@ -40,7 +41,7 @@ class SafeHasSuperTypeMatcherTest extends DDSpecification {
     argument = typePool.describe(type.name).resolve()
   }
 
-  def "test traversal exceptions"() {
+  def "test exception getting interfaces"() {
     setup:
     def type = Mock(TypeDescription)
     def typeGeneric = Mock(TypeDescription.Generic)
@@ -56,9 +57,31 @@ class SafeHasSuperTypeMatcherTest extends DDSpecification {
     1 * type.asGenericType() >> typeGeneric
     1 * typeGeneric.asErasure() >> { throw new Exception("asErasure exception") }
     1 * typeGeneric.getTypeName() >> "typeGeneric-name"
-    1 * type.getInterfaces() >> { throw new Exception("getInterfaces exception") }
+    1 * type.getInterfaces() >>  { throw new Exception("getInterfaces exception") }
     1 * type.getSuperClass() >> { throw new Exception("getSuperClass exception") }
     2 * type.getTypeName() >> "type-name"
     0 * _
+  }
+
+  def "test traversal exceptions"() {
+    setup:
+    def type = Mock(TypeDescription)
+    def typeGeneric = Mock(TypeDescription.Generic)
+    def matcher = safeHasSuperType(named(Object.name))
+    def interfaces = Mock(TypeList.Generic)
+    def it = new ThrowOnFirstElement()
+
+    when:
+    def result = matcher.matches(type)
+
+    then:
+    !result // default to false
+    noExceptionThrown()
+    1 * type.getModifiers() >> Opcodes.ACC_ABSTRACT
+    1 * type.getInterfaces() >> interfaces
+    1 * interfaces.iterator() >> it
+    1 * type.asGenericType() >> typeGeneric
+    1 * typeGeneric.asErasure() >> { throw new Exception("asErasure exception") }
+    1 * typeGeneric.getTypeName() >> "typeGeneric-name"
   }
 }

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/bytebuddy/matcher/ThrowOnFirstElement.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/bytebuddy/matcher/ThrowOnFirstElement.groovy
@@ -1,0 +1,16 @@
+package datadog.trace.agent.tooling.bytebuddy.matcher
+
+class ThrowOnFirstElement implements Iterator<Object> {
+
+  int i = 0
+
+  @Override
+  boolean hasNext() {
+    return i++ < 1
+  }
+
+  @Override
+  Object next() {
+    throw new Exception("iteration exception")
+  }
+}


### PR DESCRIPTION
reduces allocation during type matching at startup.

Evaluation:

run spring pet-clinic with `-XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -mx1G -XX:+HeapDumpOnOutOfMemoryError` to capture every allocated object in the first GB allocated. Results in reduction in `ArrayList` allocations by 1% of total (4th most commonly allocated object during startup)

```
before:
java.util.ArrayList           636,997 (4.1%)     20,383,904 B (1.6%)
after:
java.util.ArrayList           484,917   (3%)     15,517,344 B (1.2%)
``` 

Some tests weren't actually testing handling of an exception thrown during iteration, but simulated this by throwing on the `getInterfaces()` call - I fixed those.