### PR TITLE
Inject dd.{service|version|env} in logs

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/AdditionalLibraryIgnoresMatcher.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/AdditionalLibraryIgnoresMatcher.java
@@ -195,6 +195,10 @@ public class AdditionalLibraryIgnoresMatcher<T extends TypeDescription>
       if (name.equals("ch.qos.logback.core.AsyncAppenderBase$Worker")) {
         return false;
       }
+      // for inserting service, env, version in MDC of every thread
+      if (name.equals("ch.qos.logback.classic.util.LogbackMDCAdapter")) {
+        return false;
+      }
 
       return true;
     }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/log/LogContextScopeListener.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/log/LogContextScopeListener.java
@@ -60,16 +60,20 @@ public class LogContextScopeListener implements ScopeListener {
     putMethod.invoke(null, Tags.DD_SERVICE, Config.get().getServiceName());
     {
       final Map<String, String> mergedSpanTags = Config.get().getMergedSpanTags();
-      if (mergedSpanTags != null && mergedSpanTags.containsKey("version")) {
-        putMethod.invoke(null, Tags.DD_VERSION, mergedSpanTags.get("version"));
-      } else {
-        putMethod.invoke(null, Tags.DD_VERSION, "");
+      String version = "";
+      String env = "";
+      if (mergedSpanTags != null) {
+        version = mergedSpanTags.get("version");
+        if (version == null) {
+          version = "";
+        }
+        env = mergedSpanTags.get("env");
+        if (env == null) {
+          env = "";
+        }
       }
-      if (mergedSpanTags != null && mergedSpanTags.containsKey("env")) {
-        putMethod.invoke(null, Tags.DD_ENV, mergedSpanTags.get("env"));
-      } else {
-        putMethod.invoke(null, Tags.DD_ENV, "");
-      }
+      putMethod.invoke(null, Tags.DD_VERSION, version);
+      putMethod.invoke(null, Tags.DD_ENV, env);
     }
   }
 }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/log/LogContextScopeListener.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/log/LogContextScopeListener.java
@@ -8,6 +8,8 @@ import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.context.ScopeListener;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 
@@ -55,25 +57,33 @@ public class LogContextScopeListener implements ScopeListener {
     }
   }
 
+  static final Map<String, String> LOG_CONTEXT_DD_TAGS;
+
+  static {
+    Map<String, String> logContextDDTags = new HashMap<>();
+    logContextDDTags.put(Tags.DD_SERVICE, Config.get().getServiceName());
+    final Map<String, String> mergedSpanTags = Config.get().getMergedSpanTags();
+    String version = "";
+    String env = "";
+    if (mergedSpanTags != null) {
+      version = mergedSpanTags.get("version");
+      if (version == null) {
+        version = "";
+      }
+      env = mergedSpanTags.get("env");
+      if (env == null) {
+        env = "";
+      }
+    }
+    logContextDDTags.put(Tags.DD_VERSION, version);
+    logContextDDTags.put(Tags.DD_ENV, env);
+    LOG_CONTEXT_DD_TAGS = Collections.unmodifiableMap(logContextDDTags);
+  }
+
   public static void addDDTagsToMDC(final Method putMethod)
       throws InvocationTargetException, IllegalAccessException {
-    putMethod.invoke(null, Tags.DD_SERVICE, Config.get().getServiceName());
-    {
-      final Map<String, String> mergedSpanTags = Config.get().getMergedSpanTags();
-      String version = "";
-      String env = "";
-      if (mergedSpanTags != null) {
-        version = mergedSpanTags.get("version");
-        if (version == null) {
-          version = "";
-        }
-        env = mergedSpanTags.get("env");
-        if (env == null) {
-          env = "";
-        }
-      }
-      putMethod.invoke(null, Tags.DD_VERSION, version);
-      putMethod.invoke(null, Tags.DD_ENV, env);
+    for (final Map.Entry<String, String> e : LOG_CONTEXT_DD_TAGS.entrySet()) {
+      putMethod.invoke(null, e.getKey(), e.getValue());
     }
   }
 }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/log/ThreadLocalWithDDTagsInitValue.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/log/ThreadLocalWithDDTagsInitValue.java
@@ -1,0 +1,10 @@
+package datadog.trace.agent.tooling.log;
+
+import java.util.Map;
+
+public class ThreadLocalWithDDTagsInitValue extends ThreadLocal<Map<String, String>> {
+  @Override
+  protected Map<String, String> initialValue() {
+    return LogContextScopeListener.LOG_CONTEXT_DD_TAGS;
+  }
+}

--- a/dd-java-agent/instrumentation/log4j1/src/main/java/datadog/trace/instrumentation/log4j1/Log4j1MDCInstrumentation.java
+++ b/dd-java-agent/instrumentation/log4j1/src/main/java/datadog/trace/instrumentation/log4j1/Log4j1MDCInstrumentation.java
@@ -53,8 +53,10 @@ public class Log4j1MDCInstrumentation extends Instrumenter.Default {
         final Method putMethod = mdcClass.getMethod("put", String.class, Object.class);
         final Method removeMethod = mdcClass.getMethod("remove", String.class);
         GlobalTracer.get().addScopeListener(new LogContextScopeListener(putMethod, removeMethod));
+        // log4j1 uses subclass of InheritableThreadLocal and we don't need to modify private thread
+        // local field:
         LogContextScopeListener.addDDTagsToMDC(putMethod);
-      } catch (final NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+      } catch (final NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
         org.slf4j.LoggerFactory.getLogger(mdcClass)
             .debug("Failed to add log4j ThreadContext span listener", e);
       }

--- a/dd-java-agent/instrumentation/slf4j-mdc/src/main/java/datadog/trace/instrumentation/slf4j/mdc/MDCInjectionInstrumentation.java
+++ b/dd-java-agent/instrumentation/slf4j-mdc/src/main/java/datadog/trace/instrumentation/slf4j/mdc/MDCInjectionInstrumentation.java
@@ -7,9 +7,10 @@ import static net.bytebuddy.matcher.ElementMatchers.named;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.log.LogContextScopeListener;
+import datadog.trace.agent.tooling.log.ThreadLocalWithDDTagsInitValue;
 import datadog.trace.api.Config;
 import datadog.trace.api.GlobalTracer;
-import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.security.ProtectionDomain;
 import java.util.Map;
@@ -19,6 +20,7 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.BooleanMatcher;
 import net.bytebuddy.matcher.ElementMatcher;
 import net.bytebuddy.utility.JavaModule;
+import org.slf4j.spi.MDCAdapter;
 
 @AutoService(Instrumenter.class)
 public class MDCInjectionInstrumentation extends Instrumenter.Default {
@@ -71,7 +73,9 @@ public class MDCInjectionInstrumentation extends Instrumenter.Default {
 
   @Override
   public String[] helperClassNames() {
-    return new String[] {LogContextScopeListener.class.getName()};
+    return new String[] {
+      LogContextScopeListener.class.getName(), ThreadLocalWithDDTagsInitValue.class.getName(),
+    };
   }
 
   public static class MDCAdvice {
@@ -81,8 +85,16 @@ public class MDCInjectionInstrumentation extends Instrumenter.Default {
         final Method putMethod = mdcClass.getMethod("put", String.class, String.class);
         final Method removeMethod = mdcClass.getMethod("remove", String.class);
         GlobalTracer.get().addScopeListener(new LogContextScopeListener(putMethod, removeMethod));
-        LogContextScopeListener.addDDTagsToMDC(putMethod);
-      } catch (final NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+
+        final Field mdcAdapterField = mdcClass.getDeclaredField("mdcAdapter");
+        mdcAdapterField.setAccessible(true);
+        final MDCAdapter mdcAdapterInstance = (MDCAdapter) mdcAdapterField.get(null);
+        final Field copyOnThreadLocalField =
+            mdcAdapterInstance.getClass().getDeclaredField("copyOnThreadLocal");
+        copyOnThreadLocalField.setAccessible(true);
+        copyOnThreadLocalField.set(mdcAdapterInstance, new ThreadLocalWithDDTagsInitValue());
+
+      } catch (final NoSuchMethodException | IllegalAccessException | NoSuchFieldException e) {
         org.slf4j.LoggerFactory.getLogger(mdcClass).debug("Failed to add MDC span listener", e);
       }
     }

--- a/dd-java-agent/src/main/java/datadog/trace/bootstrap/AgentBootstrap.java
+++ b/dd-java-agent/src/main/java/datadog/trace/bootstrap/AgentBootstrap.java
@@ -40,7 +40,7 @@ import java.util.regex.Pattern;
  *   <li>Do dot touch any logging facilities here so we can configure them later
  * </ul>
  */
-public class AgentBootstrap {
+public final class AgentBootstrap {
   private static final Class<?> thisClass = MethodHandles.lookup().lookupClass();
 
   public static void premain(final String agentArgs, final Instrumentation inst) {

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/Tags.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/Tags.java
@@ -25,4 +25,8 @@ public class Tags {
   public static final String DB_USER = "db.user";
   public static final String DB_STATEMENT = "db.statement";
   public static final String MESSAGE_BUS_DESTINATION = "message_bus.destination";
+
+  public static final String DD_SERVICE = "dd.service";
+  public static final String DD_VERSION = "dd.version";
+  public static final String DD_ENV = "dd.env";
 }


### PR DESCRIPTION
Injecting 3 new tags :
- dd.service
- dd.version
- dd.env

in MDC of *every* thread for 3 supported logger interfaces . 

Logger instrumentation is disabled by default. It can be enabled by `-Ddd.logs.injection=true` .
