### PR TITLE
avoid creating new strings prior to jar lookup

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/InternalJarURLHandler.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/InternalJarURLHandler.java
@@ -33,7 +33,10 @@ public class InternalJarURLHandler extends URLStreamHandler {
           final JarEntry entry = entries.nextElement();
 
           if (!entry.isDirectory() && entry.getName().startsWith(filePrefix)) {
-            filenameToEntry.put(entry.getName().substring(internalJarFileName.length()), entry);
+            String name = entry.getName();
+            // remove data suffix
+            int end = name.endsWith("data") ? name.length() - 4 : name.length();
+            filenameToEntry.put(name.substring(internalJarFileName.length(), end), entry);
           }
         }
       }
@@ -48,15 +51,16 @@ public class InternalJarURLHandler extends URLStreamHandler {
 
   @Override
   protected URLConnection openConnection(final URL url) throws IOException {
-    final String filename = url.getFile().replaceAll("\\.class$", ".classdata");
+    final String filename = url.getFile();
     if ("/".equals(filename)) {
       // "/" is used as the default url of the jar
       // This is called by the SecureClassLoader trying to obtain permissions
 
       // nullInputStream() is not available until Java 11
       return new InternalJarURLConnection(url, new ByteArrayInputStream(new byte[0]));
-    } else if (filenameToEntry.containsKey(filename)) {
-      final JarEntry entry = filenameToEntry.get(filename);
+    }
+    final JarEntry entry = filenameToEntry.get(filename);
+    if (null != entry) {
       return new InternalJarURLConnection(url, bootstrapJarFile.getInputStream(entry));
     } else {
       throw new NoSuchFileException(url.getFile(), null, url.getFile() + " not in internal jar");

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/InternalJarURLHandler.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/InternalJarURLHandler.java
@@ -35,7 +35,7 @@ public class InternalJarURLHandler extends URLStreamHandler {
           if (!entry.isDirectory() && entry.getName().startsWith(filePrefix)) {
             String name = entry.getName();
             // remove data suffix
-            int end = name.endsWith("data") ? name.length() - 4 : name.length();
+            int end = name.endsWith(".classdata") ? name.length() - 4 : name.length();
             filenameToEntry.put(name.substring(internalJarFileName.length(), end), entry);
           }
         }


### PR DESCRIPTION
Uses the name we will lookup by as the key in the HashMap during building, which has two effects:

1. Don't need to allocate - this explains some of the unreferenced strings I found in a heap dump taken with EpsilonGC
2. Might not need to compute the hash code during the lookup

I don't _think_ this changes behaviour, but I'm not entirely sure.

