### PR TITLE
Easy MLT binary format writer perf fixes

### DIFF
--- a/dd-java-agent/agent-mlt/src/main/java/com/datadog/mlt/sampler/ScopeStackCollector.java
+++ b/dd-java-agent/agent-mlt/src/main/java/com/datadog/mlt/sampler/ScopeStackCollector.java
@@ -8,8 +8,10 @@ import com.datadog.mlt.io.MLTWriter;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntIterator;
 import it.unimi.dsi.fastutil.ints.IntList;
+import java.nio.ByteBuffer;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import lombok.Getter;
@@ -105,6 +107,11 @@ final class ScopeStackCollector implements IMLTChunk {
   @Override
   public byte[] serialize() {
     return chunkWriter.writeChunk(this);
+  }
+
+  @Override
+  public void serialize(Consumer<ByteBuffer> consumer) {
+    chunkWriter.writeChunk(this, consumer);
   }
 
   void addCompressedStackptr(int stackptr) {

--- a/utils/mlt-support/mlt-support.gradle
+++ b/utils/mlt-support/mlt-support.gradle
@@ -32,7 +32,9 @@ excludedClassesCoverage += [
   // MLTReader and MLTWriter are exercised in mlt-agent project tests
   'com.datadog.mlt.io.MLTWriter',
   'com.datadog.mlt.io.MLTReader',
-  'com.datadog.mlt.io.MLTConstants'
+  'com.datadog.mlt.io.MLTConstants',
+  'com.datadog.mlt.io.LEB128ByteArrayWriter',
+  'com.datadog.mlt.io.LEB128WriterFactory'
 ]
 
 sourceCompatibility = JavaVersion.VERSION_1_8

--- a/utils/mlt-support/src/main/java/com/datadog/mlt/io/AbstractLEB128Writer.java
+++ b/utils/mlt-support/src/main/java/com/datadog/mlt/io/AbstractLEB128Writer.java
@@ -128,10 +128,30 @@ abstract class AbstractLEB128Writer implements LEB128Writer {
   }
 
   @Override
+  public final LEB128Writer writeUTF(byte[] data) {
+    writeUTF(position(), data);
+    return this;
+  }
+
+  @Override
   public final long writeUTF(long offset, String data) {
-    byte[] bytes = data.getBytes(StandardCharsets.UTF_8);
-    long pos = writeInt(offset, bytes.length);
-    return writeBytes(pos, bytes);
+    return writeUTF(offset, data == null ? null : data.getBytes(StandardCharsets.UTF_8));
+  }
+
+  @Override
+  public final long writeUTF(long offset, byte[] data) {
+    int len = data == null ? 0 : data.length;
+    long pos = writeInt(offset, len);
+    if (len > 0) {
+      pos = writeBytes(pos, data);
+    }
+    return pos;
+  }
+
+  @Override
+  public final LEB128Writer writeCompactUTF(byte[] data) {
+    writeCompactUTF(position(), data);
+    return this;
   }
 
   @Override
@@ -141,18 +161,22 @@ abstract class AbstractLEB128Writer implements LEB128Writer {
   }
 
   @Override
-  public final long writeCompactUTF(long offset, String data) {
+  public final long writeCompactUTF(long offset, byte[] data) {
     if (data == null) {
       return writeByte(offset, (byte) 0); // special NULL encoding
     }
-    if (data.isEmpty()) {
+    if (data.length == 0) {
       return writeByte(offset, (byte) 1); // special empty string encoding
     }
     long pos = writeByte(offset, (byte) 3); // UTF-8 string
-    byte[] out = data.getBytes(StandardCharsets.UTF_8);
-    pos = writeInt(pos, out.length);
-    pos = writeBytes(pos, out);
+    pos = writeInt(pos, data.length);
+    pos = writeBytes(pos, data);
     return pos;
+  }
+
+  @Override
+  public final long writeCompactUTF(long offset, String data) {
+    return writeCompactUTF(offset, data.getBytes(StandardCharsets.UTF_8));
   }
 
   @Override

--- a/utils/mlt-support/src/main/java/com/datadog/mlt/io/AbstractLEB128Writer.java
+++ b/utils/mlt-support/src/main/java/com/datadog/mlt/io/AbstractLEB128Writer.java
@@ -1,0 +1,223 @@
+package com.datadog.mlt.io;
+
+import java.nio.charset.StandardCharsets;
+
+abstract class AbstractLEB128Writer implements LEB128Writer {
+  @Override
+  public final LEB128Writer writeChar(char data) {
+    writeChar(position(), data);
+    return this;
+  }
+
+  @Override
+  public final long writeChar(long offset, char data) {
+    return writeLong(offset, data & 0x000000000000ffffL);
+  }
+
+  @Override
+  public final LEB128Writer writeShort(short data) {
+    writeShort(position(), data);
+    return this;
+  }
+
+  @Override
+  public final long writeShort(long offset, short data) {
+    return writeLong(offset, data & 0x000000000000ffffL);
+  }
+
+  @Override
+  public final LEB128Writer writeInt(int data) {
+    writeInt(position(), data);
+    return this;
+  }
+
+  @Override
+  public final long writeInt(long offset, int data) {
+    return writeLong(offset, data & 0x00000000ffffffffL);
+  }
+
+  @Override
+  public final LEB128Writer writeLong(long data) {
+    writeLong(position(), data);
+    return this;
+  }
+
+  @Override
+  public final long writeLong(long offset, long data) {
+    if ((data & LEB128Writer.COMPRESSED_INT_MASK) == 0) {
+      return writeByte(offset, (byte) (data & 0xff));
+    }
+    offset = writeByte(offset, (byte) (data | LEB128Writer.EXT_BIT));
+    data >>= 7;
+    if ((data & LEB128Writer.COMPRESSED_INT_MASK) == 0) {
+      return writeByte(offset, (byte) data);
+    }
+    offset = writeByte(offset, (byte) (data | LEB128Writer.EXT_BIT));
+    data >>= 7;
+    if ((data & LEB128Writer.COMPRESSED_INT_MASK) == 0) {
+      return writeByte(offset, (byte) data);
+    }
+    offset = writeByte(offset, (byte) (data | LEB128Writer.EXT_BIT));
+    data >>= 7;
+    if ((data & LEB128Writer.COMPRESSED_INT_MASK) == 0) {
+      return writeByte(offset, (byte) data);
+    }
+    offset = writeByte(offset, (byte) (data | LEB128Writer.EXT_BIT));
+    data >>= 7;
+    if ((data & LEB128Writer.COMPRESSED_INT_MASK) == 0) {
+      return writeByte(offset, (byte) data);
+    }
+    offset = writeByte(offset, (byte) (data | LEB128Writer.EXT_BIT));
+    data >>= 7;
+    if ((data & LEB128Writer.COMPRESSED_INT_MASK) == 0) {
+      return writeByte(offset, (byte) data);
+    }
+    offset = writeByte(offset, (byte) (data | LEB128Writer.EXT_BIT));
+    data >>= 7;
+    if ((data & LEB128Writer.COMPRESSED_INT_MASK) == 0) {
+      return writeByte(offset, (byte) data);
+    }
+    offset = writeByte(offset, (byte) (data | LEB128Writer.EXT_BIT));
+    data >>= 7;
+    if ((data & LEB128Writer.COMPRESSED_INT_MASK) == 0) {
+      return writeByte(offset, (byte) data);
+    }
+    offset = writeByte(offset, (byte) (data | LEB128Writer.EXT_BIT));
+    return writeByte(offset, (byte) (data >> 7));
+  }
+
+  @Override
+  public final LEB128Writer writeFloat(float data) {
+    writeFloat(position(), data);
+    return this;
+  }
+
+  @Override
+  public final LEB128Writer writeDouble(double data) {
+    writeDouble(position(), data);
+    return this;
+  }
+
+  @Override
+  public final LEB128Writer writeBoolean(boolean data) {
+    writeBoolean(position(), data);
+    return this;
+  }
+
+  @Override
+  public final long writeBoolean(long offset, boolean data) {
+    return writeByte(offset, data ? (byte) 1 : (byte) 0);
+  }
+
+  @Override
+  public final LEB128Writer writeByte(byte data) {
+    writeByte(position(), data);
+    return this;
+  }
+
+  @Override
+  public final LEB128Writer writeBytes(byte... data) {
+    writeBytes(position(), data);
+    return this;
+  }
+
+  @Override
+  public final LEB128Writer writeUTF(String data) {
+    writeUTF(position(), data);
+    return this;
+  }
+
+  @Override
+  public final long writeUTF(long offset, String data) {
+    byte[] bytes = data.getBytes(StandardCharsets.UTF_8);
+    long pos = writeInt(offset, bytes.length);
+    return writeBytes(pos, bytes);
+  }
+
+  @Override
+  public final LEB128Writer writeCompactUTF(String data) {
+    writeCompactUTF(position(), data);
+    return this;
+  }
+
+  @Override
+  public final long writeCompactUTF(long offset, String data) {
+    if (data == null) {
+      return writeByte(offset, (byte) 0); // special NULL encoding
+    }
+    if (data.isEmpty()) {
+      return writeByte(offset, (byte) 1); // special empty string encoding
+    }
+    long pos = writeByte(offset, (byte) 3); // UTF-8 string
+    byte[] out = data.getBytes(StandardCharsets.UTF_8);
+    pos = writeInt(pos, out.length);
+    pos = writeBytes(pos, out);
+    return pos;
+  }
+
+  @Override
+  public final LEB128Writer writeShortRaw(short data) {
+    writeShortRaw(position(), data);
+    return this;
+  }
+
+  @Override
+  public final LEB128Writer writeIntRaw(int data) {
+    writeIntRaw(position(), data);
+    return this;
+  }
+
+  @Override
+  public final LEB128Writer writeLongRaw(long data) {
+    writeLongRaw(position(), data);
+    return this;
+  }
+
+  @Override
+  public final int length() {
+    return adjustLength(position());
+  }
+
+  static int adjustLength(int length) {
+    int extraLen = 0;
+    do {
+      extraLen = getPackedIntLen(length + extraLen);
+    } while (getPackedIntLen(length + extraLen) != extraLen);
+    return length + extraLen;
+  }
+
+  static int getPackedIntLen(long data) {
+    if ((data & COMPRESSED_INT_MASK) == 0) {
+      return 1;
+    }
+    data >>= 7;
+    if ((data & COMPRESSED_INT_MASK) == 0) {
+      return 2;
+    }
+    data >>= 7;
+    if ((data & COMPRESSED_INT_MASK) == 0) {
+      return 3;
+    }
+    data >>= 7;
+    if ((data & COMPRESSED_INT_MASK) == 0) {
+      return 4;
+    }
+    data >>= 7;
+    if ((data & COMPRESSED_INT_MASK) == 0) {
+      return 5;
+    }
+    data >>= 7;
+    if ((data & COMPRESSED_INT_MASK) == 0) {
+      return 6;
+    }
+    data >>= 7;
+    if ((data & COMPRESSED_INT_MASK) == 0) {
+      return 7;
+    }
+    data >>= 7;
+    if ((data & COMPRESSED_INT_MASK) == 0) {
+      return 8;
+    }
+    return 9;
+  }
+}

--- a/utils/mlt-support/src/main/java/com/datadog/mlt/io/FrameSequence.java
+++ b/utils/mlt-support/src/main/java/com/datadog/mlt/io/FrameSequence.java
@@ -17,6 +17,7 @@ public final class FrameSequence {
 
   private final int[] frameCpIndexes;
   private final int subsequenceCpIndex;
+  private int length;
 
   @Generated // do not force unit tests for lombok generated null checks
   FrameSequence(
@@ -34,6 +35,7 @@ public final class FrameSequence {
     this.stackPool = stackPool;
     this.frameCpIndexes = Arrays.copyOf(frameCpIndexes, frameCpIndexes.length);
     this.subsequenceCpIndex = subsequenceCpIndex;
+    // this.length may not be computed here because the constant pools may not yet be filled up
   }
 
   @Generated // do not force unit tests for lombok generated null checks
@@ -46,6 +48,7 @@ public final class FrameSequence {
     this.stackPool = stackPool;
     this.frameCpIndexes = new int[] {framePool.getOrInsert(head)};
     this.subsequenceCpIndex = stackPool.getOrInsert(subsequence);
+    this.length = 1 + (subsequence != null ? subsequence.length : 0);
   }
 
   /**
@@ -58,14 +61,16 @@ public final class FrameSequence {
   }
 
   public int length() {
-    if (isEmpty()) {
-      return 0;
+    if (length == -1) {
+      /*
+       * the length could not be computed in the constructor - calculate it here and cache the
+       * result
+       */
+      length =
+          frameCpIndexes.length
+              + (subsequenceCpIndex != -1 ? stackPool.get(subsequenceCpIndex).length() : 0);
     }
-    if (isLeaf()) {
-      return frameCpIndexes.length;
-    }
-
-    return frameCpIndexes.length + stackPool.get(subsequenceCpIndex).length();
+    return length;
   }
 
   int getCpIndex() {

--- a/utils/mlt-support/src/main/java/com/datadog/mlt/io/FrameSequence.java
+++ b/utils/mlt-support/src/main/java/com/datadog/mlt/io/FrameSequence.java
@@ -17,7 +17,7 @@ public final class FrameSequence {
 
   private final int[] frameCpIndexes;
   private final int subsequenceCpIndex;
-  private int length;
+  private int length = -1;
 
   @Generated // do not force unit tests for lombok generated null checks
   FrameSequence(

--- a/utils/mlt-support/src/main/java/com/datadog/mlt/io/IMLTChunk.java
+++ b/utils/mlt-support/src/main/java/com/datadog/mlt/io/IMLTChunk.java
@@ -1,5 +1,7 @@
 package com.datadog.mlt.io;
 
+import java.nio.ByteBuffer;
+import java.util.function.Consumer;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -41,6 +43,13 @@ public interface IMLTChunk {
    * @return the contents of the chunk in the MLT binary format
    */
   byte[] serialize();
+
+  /**
+   * Write out the contents of the chunk in the MLT binary format
+   *
+   * @param consumer a {@linkplain ByteBuffer} based callback to export the contents
+   */
+  void serialize(Consumer<ByteBuffer> consumer);
 
   /**
    * A helper method to expand the compressed version of the {@linkplain FrameSequence} CP index

--- a/utils/mlt-support/src/main/java/com/datadog/mlt/io/LEB128ByteArrayWriter.java
+++ b/utils/mlt-support/src/main/java/com/datadog/mlt/io/LEB128ByteArrayWriter.java
@@ -40,6 +40,9 @@ final class LEB128ByteArrayWriter extends AbstractLEB128Writer {
 
   @Override
   public long writeBytes(long offset, byte... data) {
+    if (data == null) {
+      return offset;
+    }
     int newOffset = (int) (offset + data.length);
     if (newOffset >= array.length) {
       array = Arrays.copyOf(array, newOffset * 2);

--- a/utils/mlt-support/src/main/java/com/datadog/mlt/io/LEB128ByteArrayWriter.java
+++ b/utils/mlt-support/src/main/java/com/datadog/mlt/io/LEB128ByteArrayWriter.java
@@ -1,6 +1,8 @@
 package com.datadog.mlt.io;
 
+import java.nio.ByteBuffer;
 import java.util.Arrays;
+import java.util.function.Consumer;
 
 /** Byte-array writer with default support for LEB128 encoded integer types */
 final class LEB128ByteArrayWriter extends AbstractLEB128Writer {
@@ -82,8 +84,8 @@ final class LEB128ByteArrayWriter extends AbstractLEB128Writer {
   }
 
   @Override
-  public byte[] toByteArray() {
-    return Arrays.copyOf(array, pointer);
+  public void export(Consumer<ByteBuffer> consumer) {
+    consumer.accept(ByteBuffer.wrap(array, 0, pointer));
   }
 
   @Override

--- a/utils/mlt-support/src/main/java/com/datadog/mlt/io/LEB128ByteArrayWriter.java
+++ b/utils/mlt-support/src/main/java/com/datadog/mlt/io/LEB128ByteArrayWriter.java
@@ -1,167 +1,34 @@
 package com.datadog.mlt.io;
 
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 /** Byte-array writer with default support for LEB128 encoded integer types */
-final class LEB128ByteArrayWriter {
-  private static final int EXT_BIT = 0x80;
-  private static final long COMPRESSED_INT_MASK = -EXT_BIT;
+final class LEB128ByteArrayWriter extends AbstractLEB128Writer {
   private byte[] array;
   private int pointer = 0;
 
-  LEB128ByteArrayWriter(int size) {
-    array = new byte[size];
+  LEB128ByteArrayWriter(int intialCapacity) {
+    array = new byte[intialCapacity];
   }
 
-  void reset() {
+  @Override
+  public void reset() {
     Arrays.fill(array, (byte) 0);
     pointer = 0;
   }
 
-  LEB128ByteArrayWriter writeChar(char data) {
-    writeChar(pointer, data);
-    return this;
-  }
-
-  long writeChar(long offset, char data) {
-    return writeLong(offset, data & 0x000000000000ffffL);
-  }
-
-  LEB128ByteArrayWriter writeShort(short data) {
-    writeShort(pointer, data);
-    return this;
-  }
-
-  long writeShort(long offset, short data) {
-    return writeLong(offset, data & 0x000000000000ffffL);
-  }
-
-  LEB128ByteArrayWriter writeInt(int data) {
-    writeInt(pointer, data);
-    return this;
-  }
-
-  long writeInt(long offset, int data) {
-    return writeLong(offset, data & 0x00000000ffffffffL);
-  }
-
-  static int getPackedIntLen(long data) {
-    if ((data & COMPRESSED_INT_MASK) == 0) {
-      return 1;
-    }
-    data >>= 7;
-    if ((data & COMPRESSED_INT_MASK) == 0) {
-      return 2;
-    }
-    data >>= 7;
-    if ((data & COMPRESSED_INT_MASK) == 0) {
-      return 3;
-    }
-    data >>= 7;
-    if ((data & COMPRESSED_INT_MASK) == 0) {
-      return 4;
-    }
-    data >>= 7;
-    if ((data & COMPRESSED_INT_MASK) == 0) {
-      return 5;
-    }
-    data >>= 7;
-    if ((data & COMPRESSED_INT_MASK) == 0) {
-      return 6;
-    }
-    data >>= 7;
-    if ((data & COMPRESSED_INT_MASK) == 0) {
-      return 7;
-    }
-    data >>= 7;
-    if ((data & COMPRESSED_INT_MASK) == 0) {
-      return 8;
-    }
-    return 9;
-  }
-
-  LEB128ByteArrayWriter writeLong(long data) {
-    writeLong(pointer, data);
-    return this;
-  }
-
-  long writeLong(long offset, long data) {
-    if ((data & COMPRESSED_INT_MASK) == 0) {
-      return writeByte(offset, (byte) (data & 0xff));
-    }
-    offset = writeByte(offset, (byte) (data | EXT_BIT));
-    data >>= 7;
-    if ((data & COMPRESSED_INT_MASK) == 0) {
-      return writeByte(offset, (byte) data);
-    }
-    offset = writeByte(offset, (byte) (data | EXT_BIT));
-    data >>= 7;
-    if ((data & COMPRESSED_INT_MASK) == 0) {
-      return writeByte(offset, (byte) data);
-    }
-    offset = writeByte(offset, (byte) (data | EXT_BIT));
-    data >>= 7;
-    if ((data & COMPRESSED_INT_MASK) == 0) {
-      return writeByte(offset, (byte) data);
-    }
-    offset = writeByte(offset, (byte) (data | EXT_BIT));
-    data >>= 7;
-    if ((data & COMPRESSED_INT_MASK) == 0) {
-      return writeByte(offset, (byte) data);
-    }
-    offset = writeByte(offset, (byte) (data | EXT_BIT));
-    data >>= 7;
-    if ((data & COMPRESSED_INT_MASK) == 0) {
-      return writeByte(offset, (byte) data);
-    }
-    offset = writeByte(offset, (byte) (data | EXT_BIT));
-    data >>= 7;
-    if ((data & COMPRESSED_INT_MASK) == 0) {
-      return writeByte(offset, (byte) data);
-    }
-    offset = writeByte(offset, (byte) (data | EXT_BIT));
-    data >>= 7;
-    if ((data & COMPRESSED_INT_MASK) == 0) {
-      return writeByte(offset, (byte) data);
-    }
-    offset = writeByte(offset, (byte) (data | EXT_BIT));
-    return writeByte(offset, (byte) (data >> 7));
-  }
-
-  LEB128ByteArrayWriter writeFloat(float data) {
-    writeFloat(pointer, data);
-    return this;
-  }
-
-  long writeFloat(long offset, float data) {
+  @Override
+  public long writeFloat(long offset, float data) {
     return writeIntRaw(offset, Float.floatToIntBits(data));
   }
 
-  LEB128ByteArrayWriter writeDouble(double data) {
-    writeDouble(pointer, data);
-    return this;
-  }
-
-  long writeDouble(long offset, double data) {
+  @Override
+  public long writeDouble(long offset, double data) {
     return writeLongRaw(offset, Double.doubleToLongBits(data));
   }
 
-  LEB128ByteArrayWriter writeBoolean(boolean data) {
-    writeBoolean(pointer, data);
-    return this;
-  }
-
-  long writeBoolean(long offset, boolean data) {
-    return writeByte(offset, data ? (byte) 1 : (byte) 0);
-  }
-
-  LEB128ByteArrayWriter writeByte(byte data) {
-    writeByte(pointer, data);
-    return this;
-  }
-
-  long writeByte(long offset, byte data) {
+  @Override
+  public long writeByte(long offset, byte data) {
     int newOffset = (int) (offset + 1);
     if (newOffset >= array.length) {
       array = Arrays.copyOf(array, newOffset * 2);
@@ -171,12 +38,8 @@ final class LEB128ByteArrayWriter {
     return newOffset;
   }
 
-  LEB128ByteArrayWriter writeBytes(byte... data) {
-    writeBytes(pointer, data);
-    return this;
-  }
-
-  long writeBytes(long offset, byte... data) {
+  @Override
+  public long writeBytes(long offset, byte... data) {
     int newOffset = (int) (offset + data.length);
     if (newOffset >= array.length) {
       array = Arrays.copyOf(array, newOffset * 2);
@@ -186,51 +49,13 @@ final class LEB128ByteArrayWriter {
     return newOffset;
   }
 
-  LEB128ByteArrayWriter writeUTF(String data) {
-    writeUTF(pointer, data);
-    return this;
-  }
-
-  long writeUTF(long offset, String data) {
-    byte[] bytes = data.getBytes(StandardCharsets.UTF_8);
-    long pos = writeInt(offset, bytes.length);
-    return writeBytes(pos, bytes);
-  }
-
-  LEB128ByteArrayWriter writeCompactUTF(String data) {
-    writeCompactUTF(pointer, data);
-    return this;
-  }
-
-  long writeCompactUTF(long offset, String data) {
-    if (data == null) {
-      return writeByte(offset, (byte) 0); // special NULL encoding
-    }
-    if (data.isEmpty()) {
-      return writeByte(offset, (byte) 1); // special empty string encoding
-    }
-    long pos = writeByte(offset, (byte) 3); // UTF-8 string
-    byte[] out = data.getBytes(StandardCharsets.UTF_8);
-    pos = writeInt(pos, out.length);
-    pos = writeBytes(pos, out);
-    return pos;
-  }
-
-  LEB128ByteArrayWriter writeShortRaw(short data) {
-    writeShortRaw(pointer, data);
-    return this;
-  }
-
-  long writeShortRaw(long offset, short data) {
+  @Override
+  public long writeShortRaw(long offset, short data) {
     return writeBytes(offset, (byte) ((data >> 8) & 0xff), (byte) (data & 0xff));
   }
 
-  LEB128ByteArrayWriter writeIntRaw(int data) {
-    writeIntRaw(pointer, data);
-    return this;
-  }
-
-  long writeIntRaw(long offset, int data) {
+  @Override
+  public long writeIntRaw(long offset, int data) {
     return writeBytes(
         offset,
         (byte) ((data >> 24) & 0xff),
@@ -239,12 +64,8 @@ final class LEB128ByteArrayWriter {
         (byte) (data & 0xff));
   }
 
-  LEB128ByteArrayWriter writeLongRaw(long data) {
-    writeLongRaw(pointer, data);
-    return this;
-  }
-
-  long writeLongRaw(long offset, long data) {
+  @Override
+  public long writeLongRaw(long offset, long data) {
     return writeBytes(
         offset,
         (byte) ((data >> 56) & 0xff),
@@ -257,28 +78,18 @@ final class LEB128ByteArrayWriter {
         (byte) (data & 0xff));
   }
 
-  byte[] toByteArray() {
+  @Override
+  public byte[] toByteArray() {
     return Arrays.copyOf(array, pointer);
   }
 
-  /** @return current writer position */
-  int position() {
+  @Override
+  public int position() {
     return pointer;
   }
 
-  /**
-   * @return number of bytes written adjusted by the number of bytes necessary to encode the length
-   *     itself
-   */
-  int length() {
-    return adjustLength(pointer);
-  }
-
-  static int adjustLength(int length) {
-    int extraLen = 0;
-    do {
-      extraLen = getPackedIntLen(length + extraLen);
-    } while (getPackedIntLen(length + extraLen) != extraLen);
-    return length + extraLen;
+  @Override
+  public int capacity() {
+    return array.length;
   }
 }

--- a/utils/mlt-support/src/main/java/com/datadog/mlt/io/LEB128ByteBufferWriter.java
+++ b/utils/mlt-support/src/main/java/com/datadog/mlt/io/LEB128ByteBufferWriter.java
@@ -1,0 +1,135 @@
+package com.datadog.mlt.io;
+
+import java.nio.ByteBuffer;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+final class LEB128ByteBufferWriter extends AbstractLEB128Writer {
+  private ByteBuffer buffer;
+
+  LEB128ByteBufferWriter(int initialCapacity) {
+    this.buffer = ByteBuffer.allocateDirect(initialCapacity);
+  }
+
+  @Override
+  public void reset() {
+    buffer.clear();
+  }
+
+  @Override
+  public long writeFloat(long offset, float data) {
+    ensureCapacity((int) offset, 4);
+    int originalPosition = buffer.position();
+    buffer.position((int) offset);
+    buffer.putFloat(data);
+    if (originalPosition > buffer.position()) {
+      buffer.position(originalPosition);
+    }
+    return buffer.position();
+  }
+
+  @Override
+  public long writeDouble(long offset, double data) {
+    ensureCapacity((int) offset, 8);
+    int originalPosition = buffer.position();
+    buffer.position((int) offset);
+    buffer.putDouble(data);
+    if (originalPosition > buffer.position()) {
+      buffer.position(originalPosition);
+    }
+    return buffer.position();
+  }
+
+  @Override
+  public long writeByte(long offset, byte data) {
+    ensureCapacity((int) offset, 1);
+    int originalPosition = buffer.position();
+    buffer.position((int) offset);
+    buffer.put(data);
+    if (originalPosition > buffer.position()) {
+      buffer.position(originalPosition);
+    }
+    return buffer.position();
+  }
+
+  @Override
+  public long writeBytes(long offset, byte... data) {
+    ensureCapacity((int) offset, data.length);
+    int originalPosition = buffer.position();
+    buffer.position((int) offset);
+    buffer.put(data, 0, data.length);
+    if (originalPosition > buffer.position()) {
+      buffer.position(originalPosition);
+    }
+    return buffer.position();
+  }
+
+  @Override
+  public long writeShortRaw(long offset, short data) {
+    ensureCapacity((int) offset, 2);
+    int originalPosition = buffer.position();
+    buffer.position((int) offset);
+    buffer.putShort(data);
+    if (originalPosition > buffer.position()) {
+      buffer.position(originalPosition);
+    }
+    return buffer.position();
+  }
+
+  @Override
+  public long writeIntRaw(long offset, int data) {
+    ensureCapacity((int) offset, 4);
+    int originalPosition = buffer.position();
+    buffer.position((int) offset);
+    buffer.putInt(data);
+    if (originalPosition > buffer.position()) {
+      buffer.position(originalPosition);
+    }
+    return buffer.position();
+  }
+
+  @Override
+  public long writeLongRaw(long offset, long data) {
+    ensureCapacity((int) offset, 8);
+    int originalPosition = buffer.position();
+    buffer.position((int) offset);
+    buffer.putLong(data);
+    if (originalPosition > buffer.position()) {
+      buffer.position(originalPosition);
+    }
+    return buffer.position();
+  }
+
+  @Override
+  public byte[] toByteArray() {
+    buffer.flip();
+    byte[] data = new byte[buffer.remaining()];
+    buffer.get(data, 0, data.length);
+    return data;
+  }
+
+  @Override
+  public int position() {
+    return buffer.position();
+  }
+
+  @Override
+  public int capacity() {
+    return buffer.capacity();
+  }
+
+  private void ensureCapacity(int offset, int dataLength) {
+    if (offset + dataLength > buffer.capacity()) {
+      int newCapacity = buffer.capacity() * 2;
+      log.warn(
+          "{} capacity ({} bytes) exceeded. Reallocating internal buffer with new capacity {} bytes",
+          this.getClass().getName(),
+          buffer.capacity(),
+          newCapacity);
+      ByteBuffer newBuffer = ByteBuffer.allocateDirect(newCapacity);
+      buffer.flip();
+      newBuffer.put(buffer);
+      buffer = newBuffer;
+    }
+  }
+}

--- a/utils/mlt-support/src/main/java/com/datadog/mlt/io/LEB128ByteBufferWriter.java
+++ b/utils/mlt-support/src/main/java/com/datadog/mlt/io/LEB128ByteBufferWriter.java
@@ -8,7 +8,7 @@ final class LEB128ByteBufferWriter extends AbstractLEB128Writer {
   private ByteBuffer buffer;
 
   LEB128ByteBufferWriter(int initialCapacity) {
-    this.buffer = ByteBuffer.allocateDirect(initialCapacity);
+    this.buffer = allocateBuffer(initialCapacity);
   }
 
   @Override
@@ -126,10 +126,14 @@ final class LEB128ByteBufferWriter extends AbstractLEB128Writer {
           this.getClass().getName(),
           buffer.capacity(),
           newCapacity);
-      ByteBuffer newBuffer = ByteBuffer.allocateDirect(newCapacity);
+      ByteBuffer newBuffer = allocateBuffer(newCapacity);
       buffer.flip();
       newBuffer.put(buffer);
       buffer = newBuffer;
     }
+  }
+
+  private static ByteBuffer allocateBuffer(int capacity) {
+    return ByteBuffer.allocateDirect(capacity);
   }
 }

--- a/utils/mlt-support/src/main/java/com/datadog/mlt/io/LEB128ByteBufferWriter.java
+++ b/utils/mlt-support/src/main/java/com/datadog/mlt/io/LEB128ByteBufferWriter.java
@@ -1,6 +1,7 @@
 package com.datadog.mlt.io;
 
 import java.nio.ByteBuffer;
+import java.util.function.Consumer;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -101,11 +102,8 @@ final class LEB128ByteBufferWriter extends AbstractLEB128Writer {
   }
 
   @Override
-  public byte[] toByteArray() {
-    buffer.flip();
-    byte[] data = new byte[buffer.remaining()];
-    buffer.get(data, 0, data.length);
-    return data;
+  public void export(Consumer<ByteBuffer> consumer) {
+    consumer.accept(buffer);
   }
 
   @Override

--- a/utils/mlt-support/src/main/java/com/datadog/mlt/io/LEB128Writer.java
+++ b/utils/mlt-support/src/main/java/com/datadog/mlt/io/LEB128Writer.java
@@ -318,15 +318,18 @@ public interface LEB128Writer {
     final byte[][] dataRef = new byte[1][];
     export(
         buffer -> {
-          int len = buffer.position();
-          dataRef[0] = new byte[len];
           if (buffer.hasArray()) {
-            System.arraycopy(buffer.array(), buffer.arrayOffset(), dataRef[0], 0, len);
+            int len = buffer.remaining();
+            dataRef[0] = new byte[len];
+            System.arraycopy(buffer.array(), buffer.arrayOffset() + buffer.position(), dataRef[0], 0, len);
             buffer.position(buffer.limit());
           } else {
+            int limit = buffer.limit();
             buffer.flip();
+            int len = buffer.remaining();
+            dataRef[0] = new byte[len];
             buffer.get(dataRef[0]);
-            buffer.limit(buffer.capacity());
+            buffer.limit(limit);
           }
         });
     return dataRef[0];

--- a/utils/mlt-support/src/main/java/com/datadog/mlt/io/LEB128Writer.java
+++ b/utils/mlt-support/src/main/java/com/datadog/mlt/io/LEB128Writer.java
@@ -1,0 +1,285 @@
+package com.datadog.mlt.io;
+
+public interface LEB128Writer {
+  int EXT_BIT = 0x80;
+  long COMPRESSED_INT_MASK = -EXT_BIT;
+
+  /**
+   * Get a default {@linkplain LEB128Writer} instance with the given initial capacity
+   *
+   * @param initialCapacity the initial capacity of the writer's internal buffer
+   * @return a new instance of {@linkplain LEB128Writer}
+   */
+  static LEB128Writer getInstance(int initialCapacity) {
+    return LEB128WriterFactory.getWriter(initialCapacity);
+  }
+
+  /** Reset the writer. Discard any collected data and set position to 0. */
+  void reset();
+
+  /**
+   * Write {@linkplain Character} data in LEB128 encoding
+   *
+   * @param data the data
+   * @return the writer instance for chaining
+   */
+  LEB128Writer writeChar(char data);
+
+  /**
+   * Write {@linkplain Character} data in LEB128 encoding at the given offset
+   *
+   * @param offset the offset from which to start writing the data
+   * @param data the data
+   * @return the writer position after the data has been written
+   */
+  long writeChar(long offset, char data);
+
+  /**
+   * Write {@linkplain Short} data in LEB128 encoding
+   *
+   * @param data the data
+   * @return the writer instance for chaining
+   */
+  LEB128Writer writeShort(short data);
+
+  /**
+   * Write {@linkplain Short} data in LEB128 encoding at the given offset
+   *
+   * @param offset the offset from which to start writing the data
+   * @param data the data
+   * @return the writer position after the data has been written
+   */
+  long writeShort(long offset, short data);
+
+  /**
+   * Write {@linkplain Integer} data in LEB128 encoding
+   *
+   * @param data the data
+   * @return the writer instance for chaining
+   */
+  LEB128Writer writeInt(int data);
+
+  /**
+   * Write {@linkplain Integer} data in LEB128 encoding at the given offset
+   *
+   * @param offset the offset from which to start writing the data
+   * @param data the data
+   * @return the writer position after the data has been written
+   */
+  long writeInt(long offset, int data);
+
+  /**
+   * Write {@linkplain Long} data in LEB128 encoding
+   *
+   * @param data the data
+   * @return the writer instance for chaining
+   */
+  LEB128Writer writeLong(long data);
+
+  /**
+   * Write {@linkplain Long} data in LEB128 encoding at the given offset
+   *
+   * @param offset the offset from which to start writing the data
+   * @param data the data
+   * @return the writer position after the data has been written
+   */
+  long writeLong(long offset, long data);
+
+  /**
+   * Write {@linkplain Float} data in default Java encoding
+   *
+   * @param data the data
+   * @return the writer instance for chaining
+   */
+  LEB128Writer writeFloat(float data);
+
+  /**
+   * Write {@linkplain Float} data in default Java encoding at the given offset
+   *
+   * @param offset the offset from which to start writing the data
+   * @param data the data
+   * @return the writer position after the data has been written
+   */
+  long writeFloat(long offset, float data);
+
+  /**
+   * Write {@linkplain Double} data in default Java encoding
+   *
+   * @param data the data
+   * @return the writer instance for chaining
+   */
+  LEB128Writer writeDouble(double data);
+
+  /**
+   * Write {@linkplain Double} data in default Java encoding at the given offset
+   *
+   * @param offset the offset from which to start writing the data
+   * @param data the data
+   * @return the writer position after the data has been written
+   */
+  long writeDouble(long offset, double data);
+
+  /**
+   * Write {@linkplain Boolean} data in default Java encoding
+   *
+   * @param data the data
+   * @return the writer instance for chaining
+   */
+  LEB128Writer writeBoolean(boolean data);
+
+  /**
+   * Write {@linkplain Boolean} data in default Java encoding at the given offset
+   *
+   * @param offset the offset from which to start writing the data
+   * @param data the data
+   * @return the writer position after the data has been written
+   */
+  long writeBoolean(long offset, boolean data);
+
+  /**
+   * Write {@linkplain Byte} data
+   *
+   * @param data the data
+   * @return the writer instance for chaining
+   */
+  LEB128Writer writeByte(byte data);
+
+  /**
+   * Write {@linkplain Byte} data at the given offset
+   *
+   * @param offset the offset from which to start writing the data
+   * @param data the data
+   * @return the writer position after the data has been written
+   */
+  long writeByte(long offset, byte data);
+
+  /**
+   * Write an array of {@linkplain Byte} elements
+   *
+   * @param data the data
+   * @return the writer instance for chaining
+   */
+  LEB128Writer writeBytes(byte... data);
+
+  /**
+   * Write an array of {@linkplain Byte} elements at the given offset
+   *
+   * @param offset the offset from which to start writing the data
+   * @param data the data
+   * @return the writer position after the data has been written
+   */
+  long writeBytes(long offset, byte... data);
+
+  /**
+   * Write {@linkplain String} in special encoding. The string will translate to (byte)0 for
+   * {@literal null} value, (byte)1 for empty string and (byte)3 for the sequence of bytes
+   * representing UTF8 encoded string. The sequence starts with LEB128 encoded int for the length of
+   * the sequence followed by the sequence bytes.
+   *
+   * @param data the data
+   * @return the writer instance for chaining
+   */
+  LEB128Writer writeUTF(String data);
+
+  /**
+   * Write {@linkplain String} in special encoding at the given offset. The string will translate to
+   * (byte)0 for {@literal null} value, (byte)1 for empty string and (byte)3 for the sequence of
+   * bytes representing UTF8 encoded string. The sequence starts with LEB128 encoded int for the
+   * length of the sequence followed by the sequence bytes.
+   *
+   * @param offset the offset from which to start writing the data
+   * @param data the data
+   * @return the writer position after the data has been written
+   */
+  long writeUTF(long offset, String data);
+
+  /**
+   * Write {@linkplain String} as a sequence of bytes representing UTF8 encoded string. The sequence
+   * starts with LEB128 encoded int for the length of the sequence followed by the sequence bytes.
+   *
+   * @param data the data
+   * @return the writer instance for chaining
+   */
+  LEB128Writer writeCompactUTF(String data);
+
+  /**
+   * Write {@linkplain String} as a sequence of bytes representing UTF8 encoded string at the given
+   * offset. The sequence starts with LEB128 encoded int for the length of the sequence followed by
+   * the sequence bytes.
+   *
+   * @param offset the offset from which to start writing the data
+   * @param data the data
+   * @return the writer position after the data has been written
+   */
+  long writeCompactUTF(long offset, String data);
+
+  /**
+   * Write {@linkplain Short} data in default Java encoding
+   *
+   * @param data the data
+   * @return the writer instance for chaining
+   */
+  LEB128Writer writeShortRaw(short data);
+
+  /**
+   * Write {@linkplain Short} data in default Java encoding at the given offset
+   *
+   * @param offset the offset from which to start writing the data
+   * @param data the data
+   * @return the writer position after the data has been written
+   */
+  long writeShortRaw(long offset, short data);
+
+  /**
+   * Write {@linkplain Integer} data in default Java encoding
+   *
+   * @param data the data
+   * @return the writer instance for chaining
+   */
+  LEB128Writer writeIntRaw(int data);
+
+  /**
+   * Write {@linkplain Integer} data in default Java encoding at the given offset
+   *
+   * @param offset the offset from which to start writing the data
+   * @param data the data
+   * @return the writer position after the data has been written
+   */
+  long writeIntRaw(long offset, int data);
+
+  /**
+   * Write {@linkplain Long} data in default Java encoding
+   *
+   * @param data the data
+   * @return the writer instance for chaining
+   */
+  LEB128Writer writeLongRaw(long data);
+
+  /**
+   * Write {@linkplain Long} data in default Java encoding at the given offset
+   *
+   * @param offset the offset from which to start writing the data
+   * @param data the data
+   * @return the writer position after the data has been written
+   */
+  long writeLongRaw(long offset, long data);
+
+  /**
+   * Transfer the written data to a byte array
+   *
+   * @return byte array containing the written data
+   */
+  byte[] toByteArray();
+
+  /** @return current writer position */
+  int position();
+
+  /**
+   * @return number of bytes written adjusted by the number of bytes necessary to encode the length
+   *     itself
+   */
+  int length();
+
+  /** @return the maximum number of bytes the writer can process */
+  int capacity();
+}

--- a/utils/mlt-support/src/main/java/com/datadog/mlt/io/LEB128Writer.java
+++ b/utils/mlt-support/src/main/java/com/datadog/mlt/io/LEB128Writer.java
@@ -171,10 +171,8 @@ public interface LEB128Writer {
   long writeBytes(long offset, byte... data);
 
   /**
-   * Write {@linkplain String} in special encoding. The string will translate to (byte)0 for
-   * {@literal null} value, (byte)1 for empty string and (byte)3 for the sequence of bytes
-   * representing UTF8 encoded string. The sequence starts with LEB128 encoded int for the length of
-   * the sequence followed by the sequence bytes.
+   * Write {@linkplain String} as a sequence of bytes representing UTF8 encoded string. The sequence
+   * starts with LEB128 encoded int for the length of the sequence followed by the sequence bytes.
    *
    * @param data the data
    * @return the writer instance for chaining
@@ -182,10 +180,19 @@ public interface LEB128Writer {
   LEB128Writer writeUTF(String data);
 
   /**
-   * Write {@linkplain String} in special encoding at the given offset. The string will translate to
-   * (byte)0 for {@literal null} value, (byte)1 for empty string and (byte)3 for the sequence of
-   * bytes representing UTF8 encoded string. The sequence starts with LEB128 encoded int for the
-   * length of the sequence followed by the sequence bytes.
+   * Write {@linkplain String} byte array data as a sequence of bytes representing UTF8 encoded
+   * string. The sequence starts with LEB128 encoded int for the length of the sequence followed by
+   * the sequence bytes.
+   *
+   * @param utf8Data the byte array representation of an UTF8 string
+   * @return the writer instance for chaining
+   */
+  LEB128Writer writeUTF(byte[] utf8Data);
+
+  /**
+   * Write {@linkplain String} as a sequence of bytes representing UTF8 encoded string at the given
+   * offset. The sequence starts with LEB128 encoded int for the length of the sequence followed by
+   * the sequence bytes.
    *
    * @param offset the offset from which to start writing the data
    * @param data the data
@@ -194,8 +201,42 @@ public interface LEB128Writer {
   long writeUTF(long offset, String data);
 
   /**
-   * Write {@linkplain String} as a sequence of bytes representing UTF8 encoded string. The sequence
-   * starts with LEB128 encoded int for the length of the sequence followed by the sequence bytes.
+   * Write {@linkplain String} byte array data at the given offset. The sequence starts with LEB128
+   * encoded int for the length of the sequence followed by the sequence bytes.
+   *
+   * @param offset the offset from which to start writing the data
+   * @param utf8Data the byte array representation of an UTF8 string
+   * @return the writer position after the data has been written
+   */
+  long writeUTF(long offset, byte[] utf8Data);
+
+  /**
+   * Write {@linkplain String} byte array data in special encoding. The string will translate to
+   * (byte)0 for {@literal null} value, (byte)1 for empty string and (byte)3 for the sequence of
+   * bytes representing UTF8 encoded string. The sequence starts with LEB128 encoded int for the
+   * length of the sequence followed by the sequence bytes.
+   *
+   * @param utf8Data the byte array representation of an UTF8 string
+   * @return the writer instance for chaining
+   */
+  LEB128Writer writeCompactUTF(byte[] utf8Data);
+
+  /**
+   * Write {@linkplain String} as a sequence of bytes representing UTF8 encoded string at the given
+   * offset. The sequence starts with LEB128 encoded int for the length of the sequence followed by
+   * the sequence bytes.
+   *
+   * @param offset the offset from which to start writing the data
+   * @param utf8Data the byte array representation of an UTF8 string
+   * @return the writer position after the data has been written
+   */
+  long writeCompactUTF(long offset, byte[] utf8Data);
+
+  /**
+   * Write {@linkplain String} in special encoding. The string will translate to (byte)0 for
+   * {@literal null} value, (byte)1 for empty string and (byte)3 for the sequence of bytes
+   * representing UTF8 encoded string. The sequence starts with LEB128 encoded int for the length of
+   * the sequence followed by the sequence bytes.
    *
    * @param data the data
    * @return the writer instance for chaining
@@ -203,9 +244,10 @@ public interface LEB128Writer {
   LEB128Writer writeCompactUTF(String data);
 
   /**
-   * Write {@linkplain String} as a sequence of bytes representing UTF8 encoded string at the given
-   * offset. The sequence starts with LEB128 encoded int for the length of the sequence followed by
-   * the sequence bytes.
+   * Write {@linkplain String} byte array data in special encoding at the given offset. The string
+   * will translate to (byte)0 for {@literal null} value, (byte)1 for empty string and (byte)3 for
+   * the sequence of bytes representing UTF8 encoded string. The sequence starts with LEB128 encoded
+   * int for the length of the sequence followed by the sequence bytes.
    *
    * @param offset the offset from which to start writing the data
    * @param data the data

--- a/utils/mlt-support/src/main/java/com/datadog/mlt/io/LEB128Writer.java
+++ b/utils/mlt-support/src/main/java/com/datadog/mlt/io/LEB128Writer.java
@@ -321,7 +321,8 @@ public interface LEB128Writer {
           if (buffer.hasArray()) {
             int len = buffer.remaining();
             dataRef[0] = new byte[len];
-            System.arraycopy(buffer.array(), buffer.arrayOffset() + buffer.position(), dataRef[0], 0, len);
+            System.arraycopy(
+                buffer.array(), buffer.arrayOffset() + buffer.position(), dataRef[0], 0, len);
             buffer.position(buffer.limit());
           } else {
             int limit = buffer.limit();

--- a/utils/mlt-support/src/main/java/com/datadog/mlt/io/LEB128WriterFactory.java
+++ b/utils/mlt-support/src/main/java/com/datadog/mlt/io/LEB128WriterFactory.java
@@ -1,0 +1,38 @@
+package com.datadog.mlt.io;
+
+import java.util.function.Function;
+
+/*
+ * TODO The whole class would probably be removed once we pick the implementation we want to use
+ */
+final class LEB128WriterFactory {
+  private static final Function<Integer, LEB128Writer> factoryFunction;
+
+  static {
+    /*
+     * TODO this will be most likely removed in favor of one of those two implementation
+     *  Does not seem worthy of creating a full-fledged config for this.
+     */
+    String writerType = System.getProperty("mlt.writer", "buffer");
+    switch (writerType) {
+      case "array":
+        {
+          factoryFunction = LEB128ByteArrayWriter::new;
+          break;
+        }
+      case "buffer":
+        {
+          factoryFunction = LEB128ByteBufferWriter::new;
+          break;
+        }
+      default:
+        {
+          throw new IllegalArgumentException("Unknown writer type: " + writerType);
+        }
+    }
+  }
+
+  static LEB128Writer getWriter(int initialCapacity) {
+    return factoryFunction.apply(initialCapacity);
+  }
+}

--- a/utils/mlt-support/src/main/java/com/datadog/mlt/io/MLTChunk.java
+++ b/utils/mlt-support/src/main/java/com/datadog/mlt/io/MLTChunk.java
@@ -1,6 +1,8 @@
 package com.datadog.mlt.io;
 
+import java.nio.ByteBuffer;
 import java.util.List;
+import java.util.function.Consumer;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import lombok.Data;
@@ -44,5 +46,10 @@ public final class MLTChunk implements IMLTChunk {
   @Override
   public byte[] serialize() {
     return writer.writeChunk(this);
+  }
+
+  @Override
+  public void serialize(Consumer<ByteBuffer> consumer) {
+    writer.writeChunk(this, consumer);
   }
 }

--- a/utils/mlt-support/src/main/java/com/datadog/mlt/io/MLTWriter.java
+++ b/utils/mlt-support/src/main/java/com/datadog/mlt/io/MLTWriter.java
@@ -4,11 +4,15 @@ import it.unimi.dsi.fastutil.ints.IntArraySet;
 import it.unimi.dsi.fastutil.ints.IntSet;
 import java.nio.charset.StandardCharsets;
 import java.util.function.IntConsumer;
-import java.util.stream.Stream;
-import lombok.Generated;
 
 /** The MLT binary format writer */
 public final class MLTWriter {
+  private static final int CHUNK_WRITER_CAPACITY = 512 * 1024; // initial 512kB for chunk writer
+  private static final int FRAME_STACK_WRITER_CAPACITY =
+      256 * 1024; // initial 256kB for frame stack writer
+  private final LEB128Writer chunkWriter = LEB128Writer.getInstance(CHUNK_WRITER_CAPACITY);
+  private final LEB128Writer frameStackDataWriter =
+      LEB128Writer.getInstance(FRAME_STACK_WRITER_CAPACITY);
   /**
    * Write a single chunk to its binary format
    *
@@ -16,26 +20,13 @@ public final class MLTWriter {
    * @return chunk in its MLT binary format
    */
   public byte[] writeChunk(IMLTChunk chunk) {
-    LEB128ByteArrayWriter writer =
-        new LEB128ByteArrayWriter(16384); // conservatively pre-allocate 16k byte array
-    writeChunk(chunk, writer);
-    return writer.toByteArray();
+    writeChunk(chunk, chunkWriter);
+    byte[] data = chunkWriter.toByteArray();
+    chunkWriter.reset();
+    return data;
   }
 
-  /**
-   * Write multiple chunks into one blob
-   *
-   * @param chunks the chunk sequence
-   * @return the MLT binary format representation of the given chunks sequence
-   */
-  @Generated // trivial delegating implementation; exclude from jacoco
-  public byte[] writeChunks(Stream<IMLTChunk> chunks) {
-    LEB128ByteArrayWriter writer = new LEB128ByteArrayWriter(65536); // 64k buffer
-    chunks.forEach(chunk -> writeChunk(chunk, writer));
-    return writer.toByteArray();
-  }
-
-  private void writeChunk(IMLTChunk chunk, LEB128ByteArrayWriter writer) {
+  private void writeChunk(IMLTChunk chunk, LEB128Writer writer) {
     writer
         .writeBytes(MLTConstants.MAGIC) // MAGIC
         .writeByte(chunk.getVersion()) // version
@@ -52,9 +43,9 @@ public final class MLTWriter {
     /*
      * Write out the stack trace sequence and collect the constant pool usage.
      * In order collect the data and count it in one pass the intermediary result is written to a separate
-     * byte array.
+     * writer.
      */
-    LEB128ByteArrayWriter stackEventWriter = new LEB128ByteArrayWriter(8192);
+    LEB128Writer stackEventWriter = frameStackDataWriter;
     int[] eventCount = new int[1];
     chunk
         .frameSequenceCpIndexes()
@@ -83,8 +74,7 @@ public final class MLTWriter {
     writer.writeIntRaw(MLTConstants.CHUNK_SIZE_OFFSET, writer.position()); // write the chunk size
   }
 
-  private void writeStackPool(
-      IMLTChunk chunk, LEB128ByteArrayWriter writer, IntSet stackConstants) {
+  private void writeStackPool(IMLTChunk chunk, LEB128Writer writer, IntSet stackConstants) {
     // write stack pool array
     writer.writeInt(stackConstants.size());
     stackConstants
@@ -117,8 +107,7 @@ public final class MLTWriter {
                 });
   }
 
-  private void writeFramePool(
-      IMLTChunk chunk, LEB128ByteArrayWriter writer, IntSet frameConstants) {
+  private void writeFramePool(IMLTChunk chunk, LEB128Writer writer, IntSet frameConstants) {
     // write frame pool array
     writer.writeInt(frameConstants.size());
     frameConstants
@@ -135,8 +124,7 @@ public final class MLTWriter {
                 });
   }
 
-  private void writeStringPool(
-      IMLTChunk chunk, LEB128ByteArrayWriter writer, IntSet stringConstants) {
+  private void writeStringPool(IMLTChunk chunk, LEB128Writer writer, IntSet stringConstants) {
     // write constant pool array
     writer.writeInt(stringConstants.size() + 1);
     byte[] threadNameUtf = chunk.getThreadName().getBytes(StandardCharsets.UTF_8);

--- a/utils/mlt-support/src/test/java/com/datadog/mlt/io/AbstractLEB128WriterTest.java
+++ b/utils/mlt-support/src/test/java/com/datadog/mlt/io/AbstractLEB128WriterTest.java
@@ -4,17 +4,17 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.Test;
 
-class LEB128ByteArrayWriterTest {
+class AbstractLEB128WriterTest {
   /** Make sure the packed integer length is correctly calculated */
   @Test
   void testGetPackedIntLen() {
-    assertEquals(1, LEB128ByteArrayWriter.getPackedIntLen(0));
+    assertEquals(1, AbstractLEB128Writer.getPackedIntLen(0));
 
     long val = 1L;
 
     for (int i = 1; i < 10; i++) {
-      assertEquals(Math.max(i - 1, 1), LEB128ByteArrayWriter.getPackedIntLen(val - 1));
-      assertEquals(i, LEB128ByteArrayWriter.getPackedIntLen(val));
+      assertEquals(Math.max(i - 1, 1), AbstractLEB128Writer.getPackedIntLen(val - 1));
+      assertEquals(i, AbstractLEB128Writer.getPackedIntLen(val));
       val = val << 7;
     }
   }
@@ -24,7 +24,7 @@ class LEB128ByteArrayWriterTest {
     // numeric overflow over Integer.MAX_VALUE will cause negative number and we want stop right at
     // that moment
     for (int i = 1; i > 0; i = i * 2) {
-      int estimatedLength = i + LEB128ByteArrayWriter.getPackedIntLen(i);
+      int estimatedLength = i + AbstractLEB128Writer.getPackedIntLen(i);
       assertTrue(estimatedLength <= LEB128ByteArrayWriter.adjustLength(i));
     }
   }

--- a/utils/mlt-support/src/test/java/com/datadog/mlt/io/LEB128ByteArrayReaderTest.java
+++ b/utils/mlt-support/src/test/java/com/datadog/mlt/io/LEB128ByteArrayReaderTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 class LEB128ByteArrayReaderTest {
   @Test
   void sanity() {
-    LEB128ByteArrayWriter writer = new LEB128ByteArrayWriter(2048);
+    LEB128Writer writer = LEB128Writer.getInstance(2048);
     byte b = Byte.MAX_VALUE - 1;
     char c = Character.MAX_VALUE - 1;
     short s = Short.MAX_VALUE - 1;

--- a/utils/mlt-support/src/test/java/com/datadog/mlt/io/LEB128ByteArrayReaderTest.java
+++ b/utils/mlt-support/src/test/java/com/datadog/mlt/io/LEB128ByteArrayReaderTest.java
@@ -33,7 +33,7 @@ class LEB128ByteArrayReaderTest {
     assertTrue(writer.length() > 0);
     assertTrue(writer.length() >= writer.position());
 
-    LEB128ByteArrayReader reader = new LEB128ByteArrayReader(writer.toByteArray());
+    LEB128ByteArrayReader reader = new LEB128ByteArrayReader(writer.export());
     assertEquals(b, reader.readByte());
     assertEquals(c, reader.readChar());
     assertEquals(s, reader.readShort());


### PR DESCRIPTION
This PR contains 2 commits:
- FrameSequence.length computation fix (non-contentious simple fix)
- A ByteBuffer backed implementation of the LEB128Writer