### PR TITLE
Allow OkHttp client to start when TLS is not configured

### DIFF
--- a/dd-smoke-tests/cli/src/main/resources/remove.tls.properties
+++ b/dd-smoke-tests/cli/src/main/resources/remove.tls.properties
@@ -1,0 +1,2 @@
+ssl.KeyManagerFactory.algorithm=
+ssl.TrustManagerFactory.algorithm=

--- a/dd-smoke-tests/cli/src/test/groovy/datadog/smoketest/CliApplicationSmokeTest.groovy
+++ b/dd-smoke-tests/cli/src/test/groovy/datadog/smoketest/CliApplicationSmokeTest.groovy
@@ -1,12 +1,16 @@
 package datadog.smoketest
 
 import spock.lang.Timeout
+import spock.util.concurrent.PollingConditions
 
 import java.util.concurrent.TimeUnit
 
-class CliApplicationSmokeTest extends AbstractSmokeTest {
+abstract class CliApplicationSmokeTest extends AbstractSmokeTest {
   // Estimate for the amount of time instrumentation, plus request, plus some extra
   private static final int TIMEOUT_SECS = 30
+
+  // Timeout for individual requests
+  public static final int REQUEST_TIMEOUT = 5
 
   @Override
   ProcessBuilder createProcessBuilder() {
@@ -15,16 +19,40 @@ class CliApplicationSmokeTest extends AbstractSmokeTest {
     List<String> command = new ArrayList<>()
     command.add(javaPath())
     command.addAll(defaultJavaProperties)
+    command.addAll(additionalArguments())
     command.addAll((String[]) ["-jar", cliShadowJar])
+
     ProcessBuilder processBuilder = new ProcessBuilder(command)
     processBuilder.directory(new File(buildDirectory))
+
+    return processBuilder
+  }
+
+  List<String> additionalArguments() {
+    return Collections.emptyList()
   }
 
   // TODO: once java7 support is dropped use waitFor() with timeout call added in java8
   // instead of timeout on test
   @Timeout(value = TIMEOUT_SECS, unit = TimeUnit.SECONDS)
-  def "Cli application process ends before timeout"() {
-    expect:
+  def "Receive traces in agent and CLI exits"() {
+    when:
+    def conditions = new PollingConditions(timeout: TIMEOUT_SECS, initialDelay: 1, factor: 1)
+
+    then:
+    conditions.eventually {
+      assert traceRequests.poll(REQUEST_TIMEOUT, TimeUnit.SECONDS)?.getHeader("X-Datadog-Trace-Count")?.size() > 0
+    }
     assert testedProcess.waitFor() == 0
+  }
+}
+
+class BasicCLITest extends CliApplicationSmokeTest {
+
+}
+
+class NoKeystoreTest extends CliApplicationSmokeTest {
+  List<String> additionalArguments() {
+    return ["-Djava.security.properties=${buildDirectory}/resources/main/remove.tls.properties".toString()]
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/DDAgentApi.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/DDAgentApi.java
@@ -12,10 +12,12 @@ import datadog.trace.core.DDTraceCoreInfo;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
+import okhttp3.ConnectionSpec;
 import okhttp3.Dispatcher;
 import okhttp3.HttpUrl;
 import okhttp3.MediaType;
@@ -185,6 +187,9 @@ public class DDAgentApi {
         .connectTimeout(HTTP_TIMEOUT, TimeUnit.SECONDS)
         .writeTimeout(HTTP_TIMEOUT, TimeUnit.SECONDS)
         .readTimeout(HTTP_TIMEOUT, TimeUnit.SECONDS)
+
+        // We only use http to talk to the agent
+        .connectionSpecs(Collections.singletonList(ConnectionSpec.CLEARTEXT))
 
         // We don't do async so this shouldn't matter, but just to be safe...
         .dispatcher(new Dispatcher(CommonTaskExecutor.INSTANCE))


### PR DESCRIPTION
When TLS was not configured in the JVM, the OkHttp client failed to start with `java.lang.AssertionError: No System TLS` despite the fact that we don't use TLS to communicate with the agent.

This change fixes that issue by limiting the OkHttp client to `http` only.

Tests are added for this case.  I also added a check to the base CLI test to make sure traces are actually sent (similar to the OT smoketests)