### PR TITLE
BaseDecorator shouldn't rely on $ in class names

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/BaseDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/BaseDecorator.java
@@ -168,10 +168,8 @@ public abstract class BaseDecorator {
    * @return
    */
   public String spanNameForClass(final Class<?> clazz) {
-    if (!clazz.isAnonymousClass()) {
-      return clazz.getSimpleName();
-    }
-    return CLASS_NAMES.get(clazz).getName();
+    String simpleName = clazz.getSimpleName();
+    return simpleName.isEmpty() ? CLASS_NAMES.get(clazz).getName() : simpleName;
   }
 
   private static class ClassName {
@@ -197,12 +195,12 @@ public abstract class BaseDecorator {
   }
 
   private static String getClassName(Class<?> clazz) {
-    String name = clazz.getName();
-    int start = name.lastIndexOf('.');
-    if (!clazz.isAnonymousClass()) {
-      int qualifier = name.indexOf('$', start);
-      return name.substring(Math.max(start, qualifier) + 1);
+    String simpleName = clazz.getSimpleName();
+    if (simpleName.isEmpty()) {
+      String name = clazz.getName();
+      int start = name.lastIndexOf('.');
+      return name.substring(start + 1);
     }
-    return name.substring(start + 1);
+    return simpleName;
   }
 }


### PR DESCRIPTION
I introduced some bad behaviour in #1562 - relying on $ in anonymous classnames is not safe, this PR reverts this. I also found that `Class.getAnonymousClass` is a relatively expensive call (500-1000ns, native, allocates for anonymous classes) where all we really care about is whether we have a name we can use or not.