### PR TITLE
Increase agent communication timeouts and add more logging

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/Config.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/Config.java
@@ -65,6 +65,7 @@ public class Config {
   public static final String TRACE_AGENT_PORT = "trace.agent.port";
   public static final String AGENT_PORT_LEGACY = "agent.port";
   public static final String AGENT_UNIX_DOMAIN_SOCKET = "trace.agent.unix.domain.socket";
+  public static final String AGENT_TIMEOUT = "trace.agent.timeout";
   public static final String PRIORITY_SAMPLING = "priority.sampling";
   public static final String TRACE_RESOLVER_ENABLED = "trace.resolver.enabled";
   public static final String SERVICE_MAPPING = "service.mapping";
@@ -170,6 +171,7 @@ public class Config {
   public static final String DEFAULT_AGENT_HOST = "localhost";
   public static final int DEFAULT_TRACE_AGENT_PORT = 8126;
   public static final String DEFAULT_AGENT_UNIX_DOMAIN_SOCKET = null;
+  public static final int DEFAULT_AGENT_TIMEOUT = 10; // timeout in seconds
 
   private static final boolean DEFAULT_RUNTIME_CONTEXT_FIELD_INJECTION = true;
 
@@ -266,6 +268,7 @@ public class Config {
   @Getter private final String agentHost;
   @Getter private final int agentPort;
   @Getter private final String agentUnixDomainSocket;
+  @Getter private final int agentTimeout;
   @Getter private final boolean prioritySamplingEnabled;
   @Getter private final boolean traceResolverEnabled;
   @Getter private final Map<String, String> serviceMapping;
@@ -376,6 +379,7 @@ public class Config {
             getIntegerSettingFromEnvironment(AGENT_PORT_LEGACY, DEFAULT_TRACE_AGENT_PORT));
     agentUnixDomainSocket =
         getSettingFromEnvironment(AGENT_UNIX_DOMAIN_SOCKET, DEFAULT_AGENT_UNIX_DOMAIN_SOCKET);
+    agentTimeout = getIntegerSettingFromEnvironment(AGENT_TIMEOUT, DEFAULT_AGENT_TIMEOUT);
     prioritySamplingEnabled =
         getBooleanSettingFromEnvironment(PRIORITY_SAMPLING, DEFAULT_PRIORITY_SAMPLING_ENABLED);
     traceResolverEnabled =
@@ -583,6 +587,7 @@ public class Config {
             getPropertyIntegerValue(properties, AGENT_PORT_LEGACY, parent.agentPort));
     agentUnixDomainSocket =
         properties.getProperty(AGENT_UNIX_DOMAIN_SOCKET, parent.agentUnixDomainSocket);
+    agentTimeout = getPropertyIntegerValue(properties, AGENT_TIMEOUT, parent.agentTimeout);
     prioritySamplingEnabled =
         getPropertyBooleanValue(properties, PRIORITY_SAMPLING, parent.prioritySamplingEnabled);
     traceResolverEnabled =

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/DDAgentWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/DDAgentWriter.java
@@ -1,6 +1,7 @@
 package datadog.trace.common.writer;
 
 import static datadog.trace.api.Config.DEFAULT_AGENT_HOST;
+import static datadog.trace.api.Config.DEFAULT_AGENT_TIMEOUT;
 import static datadog.trace.api.Config.DEFAULT_AGENT_UNIX_DOMAIN_SOCKET;
 import static datadog.trace.api.Config.DEFAULT_TRACE_AGENT_PORT;
 
@@ -53,6 +54,7 @@ public class DDAgentWriter implements Writer {
     String agentHost = DEFAULT_AGENT_HOST;
     int traceAgentPort = DEFAULT_TRACE_AGENT_PORT;
     String unixDomainSocket = DEFAULT_AGENT_UNIX_DOMAIN_SOCKET;
+    long timeoutMillis = TimeUnit.SECONDS.toMillis(DEFAULT_AGENT_TIMEOUT);
     int traceBufferSize = DISRUPTOR_BUFFER_SIZE;
     Monitor monitor = new Monitor.Noop();
     int flushFrequencySeconds = 1;
@@ -62,7 +64,10 @@ public class DDAgentWriter implements Writer {
   public DDAgentWriter() {
     this(
         new DDAgentApi(
-            DEFAULT_AGENT_HOST, DEFAULT_TRACE_AGENT_PORT, DEFAULT_AGENT_UNIX_DOMAIN_SOCKET),
+            DEFAULT_AGENT_HOST,
+            DEFAULT_TRACE_AGENT_PORT,
+            DEFAULT_AGENT_UNIX_DOMAIN_SOCKET,
+            TimeUnit.SECONDS.toMillis(DEFAULT_AGENT_TIMEOUT)),
         new Monitor.Noop());
   }
 
@@ -93,6 +98,7 @@ public class DDAgentWriter implements Writer {
       final String agentHost,
       final int traceAgentPort,
       final String unixDomainSocket,
+      final long timeoutMillis,
       final int traceBufferSize,
       final Monitor monitor,
       final int flushFrequencySeconds,
@@ -100,7 +106,7 @@ public class DDAgentWriter implements Writer {
     if (agentApi != null) {
       api = agentApi;
     } else {
-      api = new DDAgentApi(agentHost, traceAgentPort, unixDomainSocket);
+      api = new DDAgentApi(agentHost, traceAgentPort, unixDomainSocket, timeoutMillis);
     }
     final StatefulSerializer s = null == serializer ? new MsgPackStatefulSerializer() : serializer;
     this.monitor = monitor;

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/Writer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/Writer.java
@@ -7,6 +7,7 @@ import datadog.trace.core.DDSpan;
 import java.io.Closeable;
 import java.util.List;
 import java.util.Properties;
+import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
 
 /** A writer is responsible to send collected spans to some place */
@@ -72,7 +73,10 @@ public interface Writer extends Closeable {
 
     private static DDAgentApi createApi(final Config config) {
       return new DDAgentApi(
-          config.getAgentHost(), config.getAgentPort(), config.getAgentUnixDomainSocket());
+          config.getAgentHost(),
+          config.getAgentPort(),
+          config.getAgentUnixDomainSocket(),
+          TimeUnit.SECONDS.toMillis(config.getAgentTimeout()));
     }
 
     private static Monitor createMonitor(final Config config) {

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/DDAgentApi.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/DDAgentApi.java
@@ -40,11 +40,17 @@ public class DDAgentApi {
 
   private static final String TRACES_ENDPOINT_V3 = "v0.3/traces";
   private static final String TRACES_ENDPOINT_V4 = "v0.4/traces";
-  private static final long MILLISECONDS_BETWEEN_ERROR_LOG = TimeUnit.MINUTES.toMillis(5);
+  private static final long NANOSECONDS_BETWEEN_ERROR_LOG = TimeUnit.MINUTES.toNanos(5);
+  private static final String WILL_NOT_LOG_FOR_MESSAGE = "(Will not log errors for 5 minutes)";
 
   private final List<DDAgentResponseListener> responseListeners = new ArrayList<>();
 
-  private volatile long nextAllowedLogTime = 0;
+  private long previousErrorLogNanos = System.nanoTime() - NANOSECONDS_BETWEEN_ERROR_LOG;
+  private boolean logNextSuccess = false;
+  private long totalTraces = 0;
+  private long receivedTraces = 0;
+  private long sentTraces = 0;
+  private long failedTraces = 0;
 
   private static final JsonAdapter<Map<String, Map<String, Number>>> RESPONSE_ADAPTER =
       new Moshi.Builder()
@@ -91,36 +97,17 @@ public class DDAgentApi {
               .addHeader(X_DATADOG_TRACE_COUNT, Integer.toString(traces.representativeCount()))
               .put(new MsgPackRequestBody(traces))
               .build();
+      this.totalTraces += traces.representativeCount();
+      this.receivedTraces += traces.traceCount();
       try (final okhttp3.Response response = httpClient.newCall(request).execute()) {
         if (response.code() != 200) {
-          if (log.isDebugEnabled()) {
-            log.debug(
-                "Error while sending {} of {} traces to the DD agent. Status: {}, Response: {}, Body: {}",
-                traces.traceCount(),
-                traces.representativeCount(),
-                response.code(),
-                response.message(),
-                response.body().string());
-          } else if (nextAllowedLogTime < System.currentTimeMillis()) {
-            nextAllowedLogTime = System.currentTimeMillis() + MILLISECONDS_BETWEEN_ERROR_LOG;
-            log.warn(
-                "Error while sending {} of {} traces to the DD agent. Status: {} {} (going silent for {} minutes)",
-                traces.traceCount(),
-                traces.representativeCount(),
-                response.code(),
-                response.message(),
-                TimeUnit.MILLISECONDS.toMinutes(MILLISECONDS_BETWEEN_ERROR_LOG));
-          }
+          countAndLogFailedSend(traces, response, null);
           return Response.failed(response.code());
         }
-        if (log.isDebugEnabled()) {
-          log.debug(
-              "Successfully sent {} of {} traces to the DD agent.",
-              traces.traceCount(),
-              traces.representativeCount());
-        }
-        final String responseString = response.body().string().trim();
+        countAndLogSuccessfulSend(traces);
+        String responseString = null;
         try {
+          responseString = response.body().string().trim();
           if (!"".equals(responseString) && !"OK".equalsIgnoreCase(responseString)) {
             final Map<String, Map<String, Number>> parsedResponse =
                 RESPONSE_ADAPTER.fromJson(responseString);
@@ -131,36 +118,110 @@ public class DDAgentApi {
           }
           return Response.success(response.code());
         } catch (final IOException e) {
-          log.debug("Failed to parse DD agent response: " + responseString, e);
+          log.debug("Failed to parse DD agent response: {}", responseString, e);
           return Response.success(response.code(), e);
         }
       }
     } catch (final IOException e) {
-      if (log.isDebugEnabled()) {
-        log.debug(
-            "Error while sending "
-                + traces.traceCount()
-                + " of "
-                + traces.representativeCount()
-                + " (size="
-                + (traces.sizeInBytes() / 1024)
-                + "KB)"
-                + " traces to the DD agent.",
-            e);
-      } else if (nextAllowedLogTime < System.currentTimeMillis()) {
-        nextAllowedLogTime = System.currentTimeMillis() + MILLISECONDS_BETWEEN_ERROR_LOG;
-        log.warn(
-            "Error while sending {} of {} (size={}KB, bufferId={}) traces to the DD agent. {}: {} (going silent for {} minutes)",
-            traces.traceCount(),
-            traces.representativeCount(),
-            (traces.sizeInBytes() / 1024),
-            ((MsgPackStatefulSerializer.MsgPackTraceBuffer) traces).id,
-            e.getClass().getName(),
-            e.getMessage(),
-            TimeUnit.MILLISECONDS.toMinutes(MILLISECONDS_BETWEEN_ERROR_LOG));
-      }
+      countAndLogFailedSend(traces, null, e);
       return Response.failed(e);
     }
+  }
+
+  private void countAndLogSuccessfulSend(final TraceBuffer traces) {
+    // count the successful traces
+    this.sentTraces += traces.traceCount();
+
+    if (log.isDebugEnabled()) {
+      log.debug(createSendLogMessage(traces, "Success"));
+    } else if (this.logNextSuccess) {
+      this.logNextSuccess = false;
+      if (log.isInfoEnabled()) {
+        log.info(createSendLogMessage(traces, "Success"));
+      }
+    }
+  }
+
+  private void countAndLogFailedSend(
+      final TraceBuffer traces, final okhttp3.Response response, final IOException outer) {
+    // count the failed traces
+    this.failedTraces += traces.traceCount();
+
+    // these are used to catch and log if there is a failure in debug logging the response body
+    IOException exception = outer;
+    boolean hasLogged = false;
+
+    if (log.isDebugEnabled()) {
+      String sendErrorString = createSendLogMessage(traces, "Error");
+      if (response != null) {
+        try {
+          log.debug(
+              "{} Status: {}, Response: {}, Body: {}",
+              sendErrorString,
+              response.code(),
+              response.message(),
+              response.body().string().trim());
+          hasLogged = true;
+        } catch (IOException inner) {
+          exception = inner;
+        }
+      } else if (exception != null) {
+        log.debug(sendErrorString, exception);
+        hasLogged = true;
+      } else {
+        log.debug(sendErrorString);
+        hasLogged = true;
+      }
+    }
+    if (!hasLogged && log.isWarnEnabled()) {
+      long now = System.nanoTime();
+      if (now - this.previousErrorLogNanos >= NANOSECONDS_BETWEEN_ERROR_LOG) {
+        this.previousErrorLogNanos = now;
+        this.logNextSuccess = true;
+        String sendErrorString = createSendLogMessage(traces, "Error");
+        if (response != null) {
+          log.warn(
+              "{} Status: {} {} {}",
+              sendErrorString,
+              response.code(),
+              response.message(),
+              WILL_NOT_LOG_FOR_MESSAGE);
+        } else if (exception != null) {
+          log.warn(
+              "{} {}: {} {}",
+              sendErrorString,
+              exception.getClass().getName(),
+              exception.getMessage(),
+              WILL_NOT_LOG_FOR_MESSAGE);
+        } else {
+          log.warn("{} {}", sendErrorString, WILL_NOT_LOG_FOR_MESSAGE);
+        }
+      }
+    }
+  }
+
+  private String createSendLogMessage(final TraceBuffer traces, String prefix) {
+    int size = traces.sizeInBytes();
+    String sizeString =
+        size > 1024 ? String.valueOf(size / 1024) + "KB" : String.valueOf(size) + "B";
+    return prefix
+        + " while sending "
+        + traces.traceCount()
+        + " of "
+        + traces.representativeCount()
+        + " (size="
+        + sizeString
+        + ")"
+        + " traces to the DD agent."
+        + " Total: "
+        + this.totalTraces
+        + ", Received: "
+        + this.receivedTraces
+        + ", Sent: "
+        + this.sentTraces
+        + ", Failed: "
+        + this.failedTraces
+        + ".";
   }
 
   private static final byte[] EMPTY_LIST = new byte[] {FIXARRAY_PREFIX};

--- a/dd-trace-core/src/test/groovy/datadog/trace/api/writer/DDAgentApiTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/api/writer/DDAgentApiTest.groovy
@@ -49,7 +49,7 @@ class DDAgentApiTest extends DDSpecification {
         }
       }
     }
-    def client = new DDAgentApi("localhost", agent.address.port, null)
+    def client = new DDAgentApi("localhost", agent.address.port, null, 1000)
     def request = prepareTraces([])
     expect:
     def response = client.sendSerializedTraces(request)
@@ -74,7 +74,7 @@ class DDAgentApiTest extends DDSpecification {
         }
       }
     }
-    def client = new DDAgentApi("localhost", agent.address.port, null)
+    def client = new DDAgentApi("localhost", agent.address.port, null, 1000)
     def request = prepareTraces([])
     expect:
     def response = client.sendSerializedTraces(request)
@@ -95,7 +95,7 @@ class DDAgentApiTest extends DDSpecification {
         }
       }
     }
-    def client = new DDAgentApi("localhost", agent.address.port, null)
+    def client = new DDAgentApi("localhost", agent.address.port, null, 1000)
     def request = prepareTraces(traces)
 
     expect:
@@ -171,7 +171,7 @@ class DDAgentApiTest extends DDSpecification {
         }
       }
     }
-    def client = new DDAgentApi("localhost", agent.address.port, null)
+    def client = new DDAgentApi("localhost", agent.address.port, null, 1000)
     client.addResponseListener(responseListener)
     def request = prepareTraces([[], [], []])
 
@@ -198,7 +198,7 @@ class DDAgentApiTest extends DDSpecification {
         }
       }
     }
-    def client = new DDAgentApi("localhost", v3Agent.address.port, null)
+    def client = new DDAgentApi("localhost", v3Agent.address.port, null, 1000)
     def request = prepareTraces([])
     expect:
     client.sendSerializedTraces(request).success()
@@ -225,7 +225,7 @@ class DDAgentApiTest extends DDSpecification {
       }
     }
     def port = badPort ? 999 : agent.address.port
-    def client = new DDAgentApi("localhost", port, null)
+    def client = new DDAgentApi("localhost", port, null, 1000)
     def request = prepareTraces([])
     def result = client.sendSerializedTraces(request)
 
@@ -257,7 +257,7 @@ class DDAgentApiTest extends DDSpecification {
         }
       }
     }
-    def client = new DDAgentApi("localhost", agent.address.port, null)
+    def client = new DDAgentApi("localhost", agent.address.port, null, 1000)
     def request = prepareTraces(traces)
     when:
     def success = client.sendSerializedTraces(request).success()

--- a/dd-trace-core/src/traceAgentTest/groovy/DDApiIntegrationTest.groovy
+++ b/dd-trace-core/src/traceAgentTest/groovy/DDApiIntegrationTest.groovy
@@ -112,10 +112,10 @@ class DDApiIntegrationTest extends DDSpecification {
   }
 
   def setup() {
-    api = new DDAgentApi(agentContainerHost, agentContainerPort, null)
+    api = new DDAgentApi(agentContainerHost, agentContainerPort, null, 5000)
     api.addResponseListener(responseListener)
 
-    unixDomainSocketApi = new DDAgentApi(SOMEHOST, SOMEPORT, socketPath.toString())
+    unixDomainSocketApi = new DDAgentApi(SOMEHOST, SOMEPORT, socketPath.toString(), 5000)
     unixDomainSocketApi.addResponseListener(responseListener)
   }
 

--- a/utils/thread-utils/src/main/java/datadog/common/exec/DaemonThreadFactory.java
+++ b/utils/thread-utils/src/main/java/datadog/common/exec/DaemonThreadFactory.java
@@ -11,6 +11,7 @@ public final class DaemonThreadFactory implements ThreadFactory {
       new DaemonThreadFactory("dd-task-scheduler");
 
   private final String threadName;
+  private final Runnable initializer;
 
   /**
    * Constructs a new {@code DaemonThreadFactory} with a null ContextClassLoader.
@@ -18,12 +19,47 @@ public final class DaemonThreadFactory implements ThreadFactory {
    * @param threadName used to prefix all thread names.
    */
   public DaemonThreadFactory(final String threadName) {
+    this(threadName, null);
+  }
+
+  /**
+   * Constructs a new {@code DaemonThreadFactory} with a null ContextClassLoader.
+   *
+   * @param threadName used to prefix all thread names.
+   * @param initializer initializer runnable that will be executed for all created threads.
+   * @note The initializer runnable can be executed by multiple threads if more than one thread is
+   *     created by the factory, and should take that into account to avoid race conditions.
+   */
+  private DaemonThreadFactory(final String threadName, Runnable initializer) {
     this.threadName = threadName;
+    this.initializer = initializer;
+  }
+
+  /**
+   * Constructs a new {@code DaemonThreadFactory} with a null ContextClassLoader.
+   *
+   * @param initializer initializer runnable that will be executed for all created threads.
+   * @note The initializer runnable can be executed by multiple threads if more than one thread is
+   *     created by the factory, and should take that into account to avoid race conditions.
+   */
+  public ThreadFactory withInitializer(Runnable initializer) {
+    return new DaemonThreadFactory(this.threadName, initializer);
   }
 
   @Override
   public Thread newThread(final Runnable r) {
-    final Thread thread = new Thread(r, threadName);
+    Runnable runnable = r;
+    if (this.initializer != null) {
+      runnable =
+          new Runnable() {
+            @Override
+            public void run() {
+              initializer.run();
+              r.run();
+            }
+          };
+    }
+    final Thread thread = new Thread(runnable, threadName);
     thread.setDaemon(true);
     thread.setContextClassLoader(null);
     return thread;


### PR DESCRIPTION
This PR has two parts:

1. It increase the timeouts for communicating to the agent from `1` second to `10` seconds, since the communication happens on a separate thread and won't block application. It also tries to connect to the agent as soon as the `writer` is started, again on the separate thread, to get the http client creation out of the way of normal sending.
2. It makes logging the results of agent communication more uniform, adds more information, and also logs the first success after a failure on `info` level. The first success after failure logging is subject to the same quiet period as failure logging.

Have tested and verified logging locally, since I can't figure out how to test that in unit tests in a nice way.

The timeout configuration option should be added to the docs. Where is that done?