### PR TITLE
shorten jar names (prefixes of runtime classnames)

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
@@ -216,7 +216,7 @@ public class Agent {
           grandParent = getPlatformClassLoader();
         }
 
-        PARENT_CLASSLOADER = createDatadogClassLoader("shared.isolated", bootstrapURL, grandParent);
+        PARENT_CLASSLOADER = createDatadogClassLoader("shared", bootstrapURL, grandParent);
       } catch (final Throwable ex) {
         log.error("Throwable thrown creating parent classloader", ex);
       }
@@ -228,8 +228,7 @@ public class Agent {
     if (AGENT_CLASSLOADER == null) {
       try {
         final ClassLoader agentClassLoader =
-            createDatadogClassLoader(
-                "agent-tooling-and-instrumentation.isolated", bootstrapURL, PARENT_CLASSLOADER);
+            createDatadogClassLoader("inst", bootstrapURL, PARENT_CLASSLOADER);
 
         final Class<?> agentInstallerClass =
             agentClassLoader.loadClass("datadog.trace.agent.tooling.AgentInstaller");
@@ -288,7 +287,7 @@ public class Agent {
       final ClassLoader contextLoader = Thread.currentThread().getContextClassLoader();
       try {
         final ClassLoader jmxFetchClassLoader =
-            createDatadogClassLoader("agent-jmxfetch.isolated", bootstrapURL, PARENT_CLASSLOADER);
+            createDatadogClassLoader("metrics", bootstrapURL, PARENT_CLASSLOADER);
         Thread.currentThread().setContextClassLoader(jmxFetchClassLoader);
         final Class<?> jmxFetchAgentClass =
             jmxFetchClassLoader.loadClass("datadog.trace.agent.jmxfetch.JMXFetch");
@@ -309,7 +308,7 @@ public class Agent {
     try {
       if (PROFILING_CLASSLOADER == null) {
         PROFILING_CLASSLOADER =
-            createDatadogClassLoader("agent-profiling.isolated", bootstrapURL, PARENT_CLASSLOADER);
+            createDatadogClassLoader("profiling", bootstrapURL, PARENT_CLASSLOADER);
       }
       Thread.currentThread().setContextClassLoader(PROFILING_CLASSLOADER);
       final Class<?> profilingAgentClass =

--- a/dd-java-agent/dd-java-agent.gradle
+++ b/dd-java-agent/dd-java-agent.gradle
@@ -64,7 +64,7 @@ def includeShadowJar(shadowJarTask, jarname) {
     }
 
     from(zipTree(shadowJarTask.archiveFile)) {
-      into jarname + '.isolated'
+      into jarname
       rename '(^.*)\\.class$', '$1.classdata'
       // Rename LICENSE file since it clashes with license dir on non-case sensitive FSs (i.e. Mac)
       rename '^LICENSE$', 'LICENSE.renamed'
@@ -76,13 +76,13 @@ def includeShadowJar(shadowJarTask, jarname) {
 }
 
 project(':dd-java-agent:instrumentation').afterEvaluate {
-  includeShadowJar(it.tasks.shadowJar, 'agent-tooling-and-instrumentation')
+  includeShadowJar(it.tasks.shadowJar, 'inst')
 }
 project(':dd-java-agent:agent-jmxfetch').afterEvaluate {
-  includeShadowJar(it.tasks.shadowJar, 'agent-jmxfetch')
+  includeShadowJar(it.tasks.shadowJar, 'metrics')
 }
 project(':dd-java-agent:agent-profiling').afterEvaluate {
-  includeShadowJar(it.tasks.shadowJar, 'agent-profiling')
+  includeShadowJar(it.tasks.shadowJar, 'profiling')
 }
 
 task sharedShadowJar(type: ShadowJar) {


### PR DESCRIPTION
Looking at heapdumps, the names we choose here take up way more space than we might think because they are prefixed to every class in our private classloaders. I wanted to name them `a.ddcls`, `b.ddcls`, `c.ddcls`, `d.ddcls` but @tylerbenson talked me out of it.