### PR TITLE
Fix Spring handler mapping affecting character encoding

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/AdditionalLibraryIgnoresMatcher.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/AdditionalLibraryIgnoresMatcher.java
@@ -100,7 +100,11 @@ public class AdditionalLibraryIgnoresMatcher<T extends TypeDescription>
             || name.startsWith(
                 "org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainer$")
             || name.equals(
-                "org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedWebappClassLoader")) {
+                "org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedWebappClassLoader")
+            || name.equals(
+                "org.springframework.boot.context.embedded.EmbeddedWebApplicationContext")
+            || name.equals(
+                "org.springframework.boot.context.embedded.AnnotationConfigEmbeddedWebApplicationContext")) {
           return false;
         }
         return true;
@@ -167,7 +171,11 @@ public class AdditionalLibraryIgnoresMatcher<T extends TypeDescription>
       if (name.startsWith("org.springframework.web.")) {
         if (name.startsWith("org.springframework.web.servlet.")
             || name.startsWith("org.springframework.web.reactive.")
-            || name.startsWith("org.springframework.web.context.request.async.")) {
+            || name.startsWith("org.springframework.web.context.request.async.")
+            || name.equals(
+                "org.springframework.web.context.support.AbstractRefreshableWebApplicationContext")
+            || name.equals("org.springframework.web.context.support.GenericWebApplicationContext")
+            || name.equals("org.springframework.web.context.support.XmlWebApplicationContext")) {
           return false;
         }
         return true;

--- a/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Decorator.java
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Decorator.java
@@ -2,11 +2,8 @@ package datadog.trace.instrumentation.servlet3;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
-import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import javax.servlet.Filter;
-import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -65,32 +62,12 @@ public class Servlet3Decorator
     if (request != null) {
       span.setTag("servlet.path", request.getServletPath());
       span.setTag("servlet.context", request.getContextPath());
-      onContext(span, request, request.getServletContext());
-    }
-    return super.onRequest(span, request);
-  }
 
-  /**
-   * This method executes the filter created by
-   * datadog.trace.instrumentation.springweb.DispatcherServletInstrumentation$HandlerMappingAdvice.
-   * This was easier and less "hacky" than other ways to add the filter to the front of the filter
-   * chain.
-   */
-  private void onContext(
-      final AgentSpan span, final HttpServletRequest request, final ServletContext context) {
-    if (context == null) {
-      // some frameworks (jetty) may return a null context.
-      return;
-    }
-    final Object attribute = context.getAttribute("dd.dispatcher-filter");
-    if (attribute instanceof Filter) {
-      request.setAttribute(DD_SPAN_ATTRIBUTE, span);
-      try {
-        ((Filter) attribute).doFilter(request, null, null);
-      } catch (final IOException | ServletException e) {
-        log.debug("Exception unexpectedly thrown by filter", e);
+      if (request.getServletContext() != null) {
+        request.setAttribute(DD_SPAN_ATTRIBUTE, span);
       }
     }
+    return super.onRequest(span, request);
   }
 
   @Override

--- a/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/AbstractServlet3Test.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/AbstractServlet3Test.groovy
@@ -5,6 +5,7 @@ import datadog.trace.api.DDTags
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.instrumentation.servlet3.Servlet3Decorator
 import okhttp3.Request
+import okhttp3.RequestBody
 import org.apache.catalina.core.ApplicationFilterChain
 
 import javax.servlet.Servlet
@@ -65,7 +66,7 @@ abstract class AbstractServlet3Test<SERVER, CONTEXT> extends HttpServerTest<SERV
   protected ServerEndpoint lastRequest
 
   @Override
-  Request.Builder request(ServerEndpoint uri, String method, String body) {
+  Request.Builder request(ServerEndpoint uri, String method, RequestBody body) {
     lastRequest = uri
     super.request(uri, method, body)
   }

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/spring-webmvc-3.1.gradle
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/spring-webmvc-3.1.gradle
@@ -42,4 +42,10 @@ dependencies {
 
   testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: '1.5.17.RELEASE'
   testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: '1.5.17.RELEASE'
+  testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-security', version: '1.5.17.RELEASE'
+  testCompile group: 'org.springframework.security.oauth', name: 'spring-security-oauth2', version: '2.0.16.RELEASE'
+
+  // For spring security
+  testCompile "jakarta.xml.bind:jakarta.xml.bind-api:2.3.2"
+  testCompile "org.glassfish.jaxb:jaxb-runtime:2.3.2"
 }

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/DispatcherServletInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/DispatcherServletInstrumentation.java
@@ -84,10 +84,12 @@ public final class DispatcherServletInstrumentation extends Instrumenter.Default
     public static void afterRefresh(
         @Advice.Argument(0) final ApplicationContext springCtx,
         @Advice.FieldValue("handlerMappings") final List<HandlerMapping> handlerMappings) {
-      final HandlerMappingResourceNameFilter filter =
-          springCtx.getBean(HandlerMappingResourceNameFilter.class);
-      if (handlerMappings != null && filter != null) {
-        filter.setHandlerMappings(handlerMappings);
+      if (springCtx.containsBean("ddDispatcherFilter")) {
+        final HandlerMappingResourceNameFilter filter =
+            springCtx.getBean(HandlerMappingResourceNameFilter.class);
+        if (handlerMappings != null && filter != null) {
+          filter.setHandlerMappings(handlerMappings);
+        }
       }
     }
   }

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/DispatcherServletInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/DispatcherServletInstrumentation.java
@@ -5,7 +5,6 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.springweb.SpringWebHttpServerDecorator.DECORATE;
 import static datadog.trace.instrumentation.springweb.SpringWebHttpServerDecorator.DECORATE_RENDER;
-import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.isProtected;
 import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;
@@ -15,20 +14,16 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
-import datadog.trace.bootstrap.ContextStore;
-import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import javax.servlet.ServletContext;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 import org.springframework.context.ApplicationContext;
-import org.springframework.web.servlet.DispatcherServlet;
 import org.springframework.web.servlet.HandlerMapping;
 import org.springframework.web.servlet.ModelAndView;
 
@@ -42,13 +37,6 @@ public final class DispatcherServletInstrumentation extends Instrumenter.Default
   @Override
   public ElementMatcher<TypeDescription> typeMatcher() {
     return named("org.springframework.web.servlet.DispatcherServlet");
-  }
-
-  @Override
-  public Map<String, String> contextStore() {
-    return singletonMap(
-        "org.springframework.web.servlet.DispatcherServlet",
-        packageName + ".HandlerMappingResourceNameFilter");
   }
 
   @Override
@@ -94,23 +82,12 @@ public final class DispatcherServletInstrumentation extends Instrumenter.Default
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
     public static void afterRefresh(
-        @Advice.This final DispatcherServlet dispatcher,
         @Advice.Argument(0) final ApplicationContext springCtx,
-        @Advice.FieldValue("handlerMappings") final List<HandlerMapping> handlerMappings,
-        @Advice.Thrown final Throwable throwable) {
-      final ServletContext servletContext = springCtx.getBean(ServletContext.class);
-      if (handlerMappings != null && servletContext != null) {
-        final ContextStore<DispatcherServlet, HandlerMappingResourceNameFilter> contextStore =
-            InstrumentationContext.get(
-                DispatcherServlet.class, HandlerMappingResourceNameFilter.class);
-        HandlerMappingResourceNameFilter filter = contextStore.get(dispatcher);
-        if (filter == null) {
-          filter = new HandlerMappingResourceNameFilter();
-          contextStore.put(dispatcher, filter);
-        }
+        @Advice.FieldValue("handlerMappings") final List<HandlerMapping> handlerMappings) {
+      final HandlerMappingResourceNameFilter filter =
+          springCtx.getBean(HandlerMappingResourceNameFilter.class);
+      if (handlerMappings != null && filter != null) {
         filter.setHandlerMappings(handlerMappings);
-        servletContext.setAttribute(
-            "dd.dispatcher-filter", filter); // used by Servlet3Decorator.onContext
       }
     }
   }

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/DispatcherServletInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/DispatcherServletInstrumentation.java
@@ -86,7 +86,7 @@ public final class DispatcherServletInstrumentation extends Instrumenter.Default
         @Advice.FieldValue("handlerMappings") final List<HandlerMapping> handlerMappings) {
       if (springCtx.containsBean("ddDispatcherFilter")) {
         final HandlerMappingResourceNameFilter filter =
-            springCtx.getBean(HandlerMappingResourceNameFilter.class);
+            (HandlerMappingResourceNameFilter) springCtx.getBean("ddDispatcherFilter");
         if (handlerMappings != null && filter != null) {
           filter.setHandlerMappings(handlerMappings);
         }

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/HandlerMappingResourceNameFilter.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/HandlerMappingResourceNameFilter.java
@@ -10,6 +10,7 @@ import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.support.GenericBeanDefinition;
 import org.springframework.core.Ordered;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.servlet.HandlerExecutionChain;
@@ -65,5 +66,13 @@ public class HandlerMappingResourceNameFilter extends OncePerRequestFilter imple
   public int getOrder() {
     // Run after all HIGHEST_PRECEDENCE items
     return Ordered.HIGHEST_PRECEDENCE + 1;
+  }
+
+  public static class BeanDefinition extends GenericBeanDefinition {
+    public BeanDefinition() {
+      setScope(SCOPE_SINGLETON);
+      setBeanClass(HandlerMappingResourceNameFilter.class);
+      setBeanClassName(HandlerMappingResourceNameFilter.class.getName());
+    }
   }
 }

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/HandlerMappingResourceNameFilter.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/HandlerMappingResourceNameFilter.java
@@ -4,45 +4,43 @@ import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecora
 import static datadog.trace.instrumentation.springweb.SpringWebHttpServerDecorator.DECORATE;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import java.io.IOException;
 import java.util.List;
-import javax.servlet.Filter;
 import javax.servlet.FilterChain;
-import javax.servlet.FilterConfig;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
+import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.core.Ordered;
+import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.servlet.HandlerExecutionChain;
 import org.springframework.web.servlet.HandlerMapping;
 
-public class HandlerMappingResourceNameFilter implements Filter {
+public class HandlerMappingResourceNameFilter extends OncePerRequestFilter implements Ordered {
   private volatile List<HandlerMapping> handlerMappings;
 
   @Override
-  public void init(final FilterConfig filterConfig) {}
+  protected void doFilterInternal(
+      final HttpServletRequest request,
+      final HttpServletResponse response,
+      final FilterChain filterChain)
+      throws ServletException, IOException {
 
-  @Override
-  public void doFilter(
-      final ServletRequest servletRequest,
-      final ServletResponse servletResponse,
-      final FilterChain filterChain) {
-    if (servletRequest instanceof HttpServletRequest && handlerMappings != null) {
-      final HttpServletRequest request = (HttpServletRequest) servletRequest;
+    final Object parentSpan = request.getAttribute(DD_SPAN_ATTRIBUTE);
+
+    if (handlerMappings != null && parentSpan instanceof AgentSpan) {
       try {
         if (findMapping(request)) {
           // Name the parent span based on the matching pattern
-          final Object parentSpan = request.getAttribute(DD_SPAN_ATTRIBUTE);
-          if (parentSpan instanceof AgentSpan) {
-            // Let the parent span resource name be set with the attribute set in findMapping.
-            DECORATE.onRequest((AgentSpan) parentSpan, request);
-          }
+          // Let the parent span resource name be set with the attribute set in findMapping.
+          DECORATE.onRequest((AgentSpan) parentSpan, request);
         }
-      } catch (final Exception e) {
+      } catch (final Exception ignored) {
+        // mapping.getHandler() threw exception.  Ignore
       }
+
+      filterChain.doFilter(request, response);
     }
   }
-
-  @Override
-  public void destroy() {}
 
   /**
    * When a HandlerMapping matches a request, it sets HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE
@@ -61,5 +59,11 @@ public class HandlerMappingResourceNameFilter implements Filter {
 
   public void setHandlerMappings(final List<HandlerMapping> handlerMappings) {
     this.handlerMappings = handlerMappings;
+  }
+
+  @Override
+  public int getOrder() {
+    // Run after all HIGHEST_PRECEDENCE items
+    return Ordered.HIGHEST_PRECEDENCE + 1;
   }
 }

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/WebApplicationContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/WebApplicationContextInstrumentation.java
@@ -16,6 +16,7 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 
 @AutoService(Instrumenter.class)
 public class WebApplicationContextInstrumentation extends Instrumenter.Default {
@@ -43,6 +44,7 @@ public class WebApplicationContextInstrumentation extends Instrumenter.Default {
       packageName + ".SpringWebHttpServerDecorator",
       packageName + ".SpringWebHttpServerDecorator$1",
       packageName + ".HandlerMappingResourceNameFilter",
+      packageName + ".HandlerMappingResourceNameFilter$BeanDefinition",
     };
   }
 
@@ -64,8 +66,12 @@ public class WebApplicationContextInstrumentation extends Instrumenter.Default {
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static void onEnter(
         @Advice.Argument(0) final ConfigurableListableBeanFactory beanFactory) {
-      if (!beanFactory.containsBean("ddDispatcherFilter")) {
-        beanFactory.registerSingleton("ddDispatcherFilter", new HandlerMappingResourceNameFilter());
+      if (beanFactory instanceof BeanDefinitionRegistry
+          && !beanFactory.containsBean("ddDispatcherFilter")) {
+
+        ((BeanDefinitionRegistry) beanFactory)
+            .registerBeanDefinition(
+                "ddDispatcherFilter", new HandlerMappingResourceNameFilter.BeanDefinition());
       }
     }
   }

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/WebApplicationContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/WebApplicationContextInstrumentation.java
@@ -40,6 +40,8 @@ public class WebApplicationContextInstrumentation extends Instrumenter.Default {
   @Override
   public String[] helperClassNames() {
     return new String[] {
+      packageName + ".SpringWebHttpServerDecorator",
+      packageName + ".SpringWebHttpServerDecorator$1",
       packageName + ".HandlerMappingResourceNameFilter",
     };
   }

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/WebApplicationContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/WebApplicationContextInstrumentation.java
@@ -1,0 +1,70 @@
+package datadog.trace.instrumentation.springweb;
+
+import static datadog.trace.agent.tooling.ClassLoaderMatcher.hasClassesNamed;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers.extendsClass;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers.implementsInterface;
+import static java.util.Collections.singletonMap;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import java.util.Map;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+
+@AutoService(Instrumenter.class)
+public class WebApplicationContextInstrumentation extends Instrumenter.Default {
+  public WebApplicationContextInstrumentation() {
+    super("spring-web");
+  }
+
+  @Override
+  public ElementMatcher<ClassLoader> classLoaderMatcher() {
+    // Optimization for expensive typeMatcher.
+    return hasClassesNamed(
+        "org.springframework.context.support.AbstractApplicationContext",
+        "org.springframework.web.context.WebApplicationContext");
+  }
+
+  @Override
+  public ElementMatcher<TypeDescription> typeMatcher() {
+    return extendsClass(named("org.springframework.context.support.AbstractApplicationContext"))
+        .and(implementsInterface(named("org.springframework.web.context.WebApplicationContext")));
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {
+      packageName + ".HandlerMappingResourceNameFilter",
+    };
+  }
+
+  @Override
+  public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
+
+    return singletonMap(
+        isMethod()
+            .and(named("postProcessBeanFactory"))
+            .and(
+                takesArgument(
+                    0,
+                    named(
+                        "org.springframework.beans.factory.config.ConfigurableListableBeanFactory"))),
+        WebApplicationContextInstrumentation.class.getName() + "$FilterInjectingAdvice");
+  }
+
+  public static class FilterInjectingAdvice {
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static void onEnter(
+        @Advice.Argument(0) final ConfigurableListableBeanFactory beanFactory) {
+      if (!beanFactory.containsBean("ddDispatcherFilter")) {
+        beanFactory.registerSingleton("ddDispatcherFilter", new HandlerMappingResourceNameFilter());
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/boot/AppConfig.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/boot/AppConfig.groovy
@@ -6,29 +6,10 @@ import org.springframework.boot.context.embedded.EmbeddedServletContainerFactory
 import org.springframework.boot.context.embedded.tomcat.TomcatConnectorCustomizer
 import org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainerFactory
 import org.springframework.context.annotation.Bean
-import org.springframework.http.MediaType
-import org.springframework.web.HttpMediaTypeNotAcceptableException
-import org.springframework.web.accept.ContentNegotiationStrategy
-import org.springframework.web.context.request.NativeWebRequest
-import org.springframework.web.servlet.config.annotation.ContentNegotiationConfigurer
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter
 
 @SpringBootApplication
 class AppConfig extends WebMvcConfigurerAdapter {
-
-  @Override
-  void configureContentNegotiation(ContentNegotiationConfigurer configurer) {
-    configurer.favorPathExtension(false)
-      .favorParameter(true)
-      .ignoreAcceptHeader(true)
-      .useJaf(false)
-      .defaultContentTypeStrategy(new ContentNegotiationStrategy() {
-        @Override
-        List<MediaType> resolveMediaTypes(NativeWebRequest webRequest) throws HttpMediaTypeNotAcceptableException {
-          return [MediaType.TEXT_PLAIN]
-        }
-      })
-  }
 
   @Bean
   EmbeddedServletContainerFactory servletContainerFactory() {

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/boot/AuthServerConfig.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/boot/AuthServerConfig.groovy
@@ -1,0 +1,10 @@
+package test.boot
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.oauth2.config.annotation.web.configuration.AuthorizationServerConfigurerAdapter
+import org.springframework.security.oauth2.config.annotation.web.configuration.EnableAuthorizationServer
+
+@Configuration
+@EnableAuthorizationServer
+class AuthServerConfig extends AuthorizationServerConfigurerAdapter {
+}

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/boot/SavingAuthenticationProvider.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/boot/SavingAuthenticationProvider.groovy
@@ -1,0 +1,70 @@
+package test.boot
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.authentication.dao.AbstractUserDetailsAuthenticationProvider
+import org.springframework.security.core.AuthenticationException
+import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.core.userdetails.UserDetails
+
+class SavingAuthenticationProvider extends AbstractUserDetailsAuthenticationProvider {
+  List<TestUserDetails> latestAuthentications = new ArrayList<>()
+
+  @Override
+  protected void additionalAuthenticationChecks(UserDetails userDetails, UsernamePasswordAuthenticationToken authentication) throws AuthenticationException {
+    // none
+  }
+
+  @Override
+  protected UserDetails retrieveUser(String username, UsernamePasswordAuthenticationToken authentication) throws AuthenticationException {
+    def details = new TestUserDetails(username, authentication.credentials.toString())
+
+    latestAuthentications.add(details)
+
+    return details
+  }
+}
+
+class TestUserDetails implements UserDetails {
+  private final String username
+  private final String password
+
+  TestUserDetails(String username, String password) {
+    this.username = username
+    this.password = password
+  }
+
+  @Override
+  Collection<? extends GrantedAuthority> getAuthorities() {
+    return Collections.emptySet()
+  }
+
+  @Override
+  String getPassword() {
+    return password
+  }
+
+  @Override
+  String getUsername() {
+    return username
+  }
+
+  @Override
+  boolean isAccountNonExpired() {
+    return true
+  }
+
+  @Override
+  boolean isAccountNonLocked() {
+    return true
+  }
+
+  @Override
+  boolean isCredentialsNonExpired() {
+    return true
+  }
+
+  @Override
+  boolean isEnabled() {
+    return true
+  }
+}

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/boot/SecurityConfig.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/boot/SecurityConfig.groovy
@@ -1,0 +1,28 @@
+package test.boot
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter
+
+@Configuration
+@EnableWebSecurity
+class SecurityConfig extends WebSecurityConfigurerAdapter {
+
+  @Override
+  protected void configure(HttpSecurity http) throws Exception {
+
+    http
+      .authorizeRequests()
+      .antMatchers("/secure/**").authenticated()
+      .and().formLogin()
+      .and().authenticationProvider(applicationContext.getBean(SavingAuthenticationProvider))
+      .csrf().disable()
+  }
+
+  @Bean
+  SavingAuthenticationProvider savingAuthenticationProvider() {
+    return new SavingAuthenticationProvider()
+  }
+}

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/boot/SpringBootBasedTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/boot/SpringBootBasedTest.groovy
@@ -1,6 +1,5 @@
 package test.boot
 
-import datadog.trace.core.DDSpan
 import datadog.trace.agent.test.asserts.ListWriterAssert
 import datadog.trace.agent.test.asserts.SpanAssert
 import datadog.trace.agent.test.asserts.TraceAssert
@@ -8,16 +7,20 @@ import datadog.trace.agent.test.base.HttpServerTest
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import datadog.trace.bootstrap.instrumentation.api.Tags
+import datadog.trace.core.DDSpan
 import datadog.trace.instrumentation.servlet3.Servlet3Decorator
 import datadog.trace.instrumentation.springweb.SpringWebHttpServerDecorator
 import groovy.transform.stc.ClosureParams
 import groovy.transform.stc.SimpleType
+import okhttp3.FormBody
+import okhttp3.RequestBody
 import org.apache.catalina.core.ApplicationFilterChain
 import org.springframework.boot.SpringApplication
 import org.springframework.context.ConfigurableApplicationContext
 import org.springframework.web.servlet.view.RedirectView
 
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.LOGIN
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 import static java.util.Collections.singletonMap
 
@@ -25,7 +28,7 @@ class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext>
 
   @Override
   ConfigurableApplicationContext startServer(int port) {
-    def app = new SpringApplication(AppConfig)
+    def app = new SpringApplication(AppConfig, SecurityConfig, AuthServerConfig)
     app.setDefaultProperties(singletonMap("server.port", port))
     def context = app.run()
     return context
@@ -61,6 +64,36 @@ class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext>
     // FIXME: the instrumentation adds an extra controller span which is not consistent.
     // Fix tests or remove extra span.
     false
+  }
+
+
+  def "test character encoding of #testPassword"() {
+    setup:
+    def authProvider = server.getBean(SavingAuthenticationProvider)
+
+    RequestBody formBody = new FormBody.Builder()
+      .add("username", "test")
+      .add("password", testPassword).build()
+
+    def request = request(LOGIN, "POST", formBody).build()
+
+    when:
+    authProvider.latestAuthentications.clear()
+    def response = client.newCall(request).execute()
+
+    then:
+    response.code() == 302 // redirect after success
+    authProvider.latestAuthentications.get(0).password == testPassword
+
+    and:
+    cleanAndAssertTraces(1) {
+      trace(0, 1) {
+        serverSpan(it, 0, null, null, "POST", LOGIN)
+      }
+    }
+
+    where:
+    testPassword << ["password", "dfsdföääöüüä", "🤓"]
   }
 
   void cleanAndAssertTraces(

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/filter/ServletFilterTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/filter/ServletFilterTest.groovy
@@ -16,6 +16,7 @@ import org.apache.catalina.core.ApplicationFilterChain
 import org.springframework.boot.SpringApplication
 import org.springframework.context.ConfigurableApplicationContext
 import org.springframework.web.servlet.view.RedirectView
+import test.boot.SecurityConfig
 
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
@@ -25,7 +26,7 @@ class ServletFilterTest extends HttpServerTest<ConfigurableApplicationContext> {
 
   @Override
   ConfigurableApplicationContext startServer(int port) {
-    def app = new SpringApplication(FilteredAppConfig)
+    def app = new SpringApplication(FilteredAppConfig, SecurityConfig)
     app.setDefaultProperties(singletonMap("server.port", port))
     def context = app.run()
     return context

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
@@ -1,7 +1,6 @@
 package datadog.trace.agent.test.base
 
 import ch.qos.logback.classic.Level
-import datadog.trace.core.DDSpan
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.asserts.ListWriterAssert
 import datadog.trace.agent.test.asserts.TraceAssert
@@ -10,11 +9,13 @@ import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import datadog.trace.bootstrap.instrumentation.api.Tags
+import datadog.trace.core.DDSpan
 import groovy.transform.stc.ClosureParams
 import groovy.transform.stc.SimpleType
 import okhttp3.HttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import okhttp3.RequestBody
 import okhttp3.Response
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -137,6 +138,7 @@ abstract class HttpServerTest<SERVER> extends AgentTestRunner {
 //    QUERY_FRAGMENT_PARAM("query/fragment?some=query#some-fragment", 200, "some=query#some-fragment"),
     PATH_PARAM("path/123/param", 200, "123"),
     AUTH_REQUIRED("authRequired", 200, null),
+    LOGIN("login", 302, null),
 
     private final String path
     final String query
@@ -180,7 +182,7 @@ abstract class HttpServerTest<SERVER> extends AgentTestRunner {
     }
   }
 
-  Request.Builder request(ServerEndpoint uri, String method, String body) {
+  Request.Builder request(ServerEndpoint uri, String method, RequestBody body) {
     def url = HttpUrl.get(uri.resolve(address)).newBuilder()
       .query(uri.query)
       .fragment(uri.fragment)


### PR DESCRIPTION
### Problem
`HandlerMappingResourceNameFilter` was injected before the entire `FilterChain`.  This was so that if a filter handled a request instead of a controller, the correctly tagged spans were still generated.

One unintended side effect was that in certain configurations, HMRNF set the character encoding to the servlet container default.   `SetCharacterEncodingFilter` is responsible for setting the character encoding but HMRNF ran before all filters.  HMRNF's use of `mapping.getHandler()` forced the lazy evaluation.

This is highlighted in the `test character encoding of #testPassword` test

### Solution

Instead of running specially, `HandlerMappingResourceNameFilter` is injected into the WebApplicationContext and loaded as any other filter.  It has a a precedence of `HIGHEST_PRECEDENCE + 1` so it will run directly after all items with highest precedence.  The dispatcher servlet injection is still used to set the handler mappings on the filter. 
