### PR TITLE
Fix discrepancy between exception histo and sample events

### DIFF
--- a/dd-java-agent/instrumentation/exception-profiling/src/main/java11/com/datadog/profiling/exceptions/ExceptionHistogram.java
+++ b/dd-java-agent/instrumentation/exception-profiling/src/main/java11/com/datadog/profiling/exceptions/ExceptionHistogram.java
@@ -56,7 +56,7 @@ public class ExceptionHistogram {
     if (exception == null) {
       return false;
     }
-    return record(exception.getClass().getCanonicalName());
+    return record(exception.getClass().getName());
   }
 
   private boolean record(String typeName) {


### PR DESCRIPTION
Be consistent and use Class.getName() for both exception sample and histogram events