### PR TITLE
Cache Strings in DBTypeTagInterceptor

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/taginterceptor/DBTypeTagInterceptor.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/taginterceptor/DBTypeTagInterceptor.java
@@ -3,6 +3,7 @@ package datadog.trace.core.taginterceptor;
 import datadog.trace.api.DDSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.core.DDSpanContext;
+import datadog.trace.core.util.FixedSizeCache;
 
 /**
  * This span decorator leverages DB tags. It allows the dev to define a custom service name and
@@ -15,29 +16,46 @@ class DBTypeTagInterceptor extends AbstractTagInterceptor {
     super(Tags.DB_TYPE);
   }
 
+  private static final String OPERATION_SUFFIX = ".query";
+
+  // The total number of entries in the cache will normally be less than 4, since
+  // most applications only have one or two DBs, and "jdbc" itself is also used as
+  // one DB_TYPE, but set the cache size to 16 to help avoid collisions.
+  private final FixedSizeCache<String, String> cache = new FixedSizeCache<>(16);
+  private final FixedSizeCache.Creator<String, String> appendOperationSuffix =
+      new FixedSizeCache.Creator<String, String>() {
+        @Override
+        public String create(String key) {
+          return key + OPERATION_SUFFIX;
+        }
+      };
+
   @Override
   public boolean shouldSetTag(final DDSpanContext context, final String tag, final Object value) {
-    context.setServiceName(String.valueOf(value));
+    final String serviceName = String.valueOf(value);
 
     // Assign service name
-    if ("couchbase".equals(value) || "elasticsearch".equals(value)) {
+    context.setServiceName(serviceName);
+
+    if ("couchbase".equals(serviceName) || "elasticsearch".equals(serviceName)) {
       // these instrumentation have different behavior.
       return true;
     }
     // Assign span type to DB
     // Special case: Mongo, set to mongodb
-    if ("mongo".equals(value)) {
+    if ("mongo".equals(serviceName)) {
       // Todo: not sure it's used cos already in the agent mongo helper
       context.setSpanType(DDSpanTypes.MONGO);
-    } else if ("cassandra".equals(value)) {
+    } else if ("cassandra".equals(serviceName)) {
       context.setSpanType(DDSpanTypes.CASSANDRA);
-    } else if ("memcached".equals(value)) {
+    } else if ("memcached".equals(serviceName)) {
       context.setSpanType(DDSpanTypes.MEMCACHED);
     } else {
       context.setSpanType(DDSpanTypes.SQL);
     }
     // Works for: mongo, cassandra, jdbc
-    context.setOperationName(String.valueOf(value) + ".query");
+    String operationName = cache.computeIfAbsent(serviceName, appendOperationSuffix);
+    context.setOperationName(operationName);
 
     return true;
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/util/FixedSizeCache.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/util/FixedSizeCache.java
@@ -1,0 +1,115 @@
+package datadog.trace.core.util;
+
+/**
+ * This is a fixed size cache that only has one operation <code>computeIfAbsent</code>, that is used
+ * to retrieve, or store and compute the cached value.
+ *
+ * <p>If there is a hash collision, the cache uses double hashing two more times to try to find a
+ * match or an unused slot.
+ *
+ * <p>The cache is thread safe, and assumes that the <code>Creator</code> passed into <code>
+ * computeIfAbsent</code> is idempotent or otherwise you might not get back the value you expect
+ * from a cache lookup.
+ *
+ * @param <K> key type
+ * @param <V> value type
+ */
+public class FixedSizeCache<K, V> {
+
+  public interface Creator<K, V> {
+    V create(K key);
+  }
+
+  static final int MAXIMUM_CAPACITY = 1 << 30;
+
+  private static final class Node<K, V> {
+    private final K key;
+    private final V value;
+
+    private Node(K key, V value) {
+      this.key = key;
+      this.value = value;
+    }
+  }
+
+  private final int mask;
+  // This is a cache, so there is no need for volatile, atomics or synchronized.
+  // All race conditions here are benign since you always read or write a full
+  // Node that can not be modified, and eventually other threads will see it or
+  // write the same information at that position, or other information in the
+  // case of a collision.
+  private final Node<K, V>[] elements;
+
+  /**
+   * Creates a <code>FixedSizeCache</code> that can hold up to <code>capacity</code> elements, if
+   * the key hash function has perfect spread.
+   *
+   * @param capacity the maximum number of elements that the cache can hold
+   */
+  public FixedSizeCache(int capacity) {
+    if (capacity <= 0) {
+      throw new IllegalArgumentException("Cache capacity must be > 0");
+    }
+    if (capacity > MAXIMUM_CAPACITY) {
+      capacity = MAXIMUM_CAPACITY;
+    }
+    // compute a power of two size for the given capacity
+    int n = -1 >>> Integer.numberOfLeadingZeros(capacity - 1);
+    n = (n < 0) ? 1 : (n >= MAXIMUM_CAPACITY) ? MAXIMUM_CAPACITY : n + 1;
+    @SuppressWarnings({"rawtype", "unchecked"})
+    Node<K, V>[] lmnts = (Node<K, V>[]) new Node[n];
+    this.elements = lmnts;
+    this.mask = n - 1;
+  }
+
+  /**
+   * Look up or create and store a value in the cache.
+   *
+   * @param key the key to look up
+   * @param creator how to create a cached value base on the key if the lookup fails
+   * @return the cached or created and stored value
+   */
+  public V computeIfAbsent(K key, Creator<K, ? extends V> creator) {
+    if (key == null) {
+      return null;
+    }
+
+    int h = key.hashCode();
+    int firstPos = h & mask;
+    V value = null;
+    // try to find a slot or a match 3 times
+    for (int i = 1; i <= 3; i++) {
+      int pos = h & mask;
+      Node<K, V> current = elements[pos];
+      if (current == null) {
+        // we found an empty slot, so store the value there
+        value = createAndStoreValue(key, creator, pos);
+        break;
+      } else if (key.equals(current.key)) {
+        // we found a cached key, so use that value
+        value = current.value;
+        break;
+      } else if (i == 3) {
+        // all 3 slots have been taken, so overwrite the first one
+        value = createAndStoreValue(key, creator, firstPos);
+        break;
+      }
+      // slot was occupied by someone else, so try another slot
+      h = rehash(h);
+    }
+    return value;
+  }
+
+  private V createAndStoreValue(K key, Creator<K, ? extends V> creator, int pos) {
+    V value = creator.create(key);
+    Node<K, V> node = new Node<>(key, value);
+    elements[pos] = node;
+    return value;
+  }
+
+  private int rehash(int v) {
+    int h = v * 0x9e3775cd;
+    h = Integer.reverseBytes(h);
+    return h * 0x9e3775cd;
+  }
+}

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/util/FixedSizeCacheTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/util/FixedSizeCacheTest.groovy
@@ -1,0 +1,114 @@
+package datadog.trace.core.util
+
+import datadog.trace.util.test.DDSpecification
+import spock.util.concurrent.AsyncConditions
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.ThreadLocalRandom
+import java.util.concurrent.atomic.AtomicInteger
+
+class FixedSizeCacheTest extends DDSpecification {
+  def "should store and retrieve values"() {
+    setup:
+    def fsCache = new FixedSizeCache<TKey, String>(15)
+    def creationCount = new AtomicInteger(0)
+    def tvc = new TVC(creationCount)
+    def tk1 = new TKey(1, 1, "one")
+    def tk6 = new TKey(6, 6, "six")
+    def tk10 = new TKey(10, 10, "ten")
+    // insert some values that happen to be the chain of hashes 1 -> 6 -> 10
+    fsCache.computeIfAbsent(tk1, tvc)
+    fsCache.computeIfAbsent(tk6, tvc)
+    fsCache.computeIfAbsent(tk10, tvc)
+
+    expect:
+    fsCache.computeIfAbsent(tk, tvc) == value
+    creationCount.get() == count
+
+    where:
+    tk                        | value          | count
+    new TKey(1, 1, "foo")     | "one_value"    | 3     // used the cached tk1
+    new TKey(1, 6, "foo")     | "six_value"    | 3     // used the cached tk6
+    new TKey(1, 10, "foo")    | "ten_value"    | 3     // used the cached tk10
+    new TKey(6, 6, "foo")     | "six_value"    | 3     // used the cached tk6
+    new TKey(1, 11, "eleven") | "eleven_value" | 4     // create new value in an occupied slot
+    new TKey(4, 4, "four" )   | "four_value"   | 4     // create new value in empty slot
+    null                      | null           | 3     // do nothing
+  }
+
+  def "should handle concurrent usage"() {
+    setup:
+    def numThreads = 5
+    def numInsertions = 100000
+    def conds = new AsyncConditions(numThreads)
+    def started = new CountDownLatch(numThreads)
+    def runTest = new CountDownLatch(1)
+    def fsCache = new FixedSizeCache<TKey, String>(64)
+
+    when:
+    for (int t = 0; t < numThreads; t++) {
+      Thread.start {
+        def tlr = ThreadLocalRandom.current()
+        started.countDown()
+        runTest.await()
+        conds.evaluate {
+          for (int i = 0; i < numInsertions; i++) {
+            def r = tlr.nextInt()
+            def s = String.valueOf(r)
+            def tkey = new TKey(r, r, s)
+            assert fsCache.computeIfAbsent(tkey, { k -> k.string + "_value" }) == s + "_value"
+          }
+        }
+      }
+    }
+    started.await()
+    runTest.countDown()
+
+    then:
+    conds.await(30.0) // the test is really fast locally, but I don't know how fast CI is
+  }
+
+  private class TVC implements FixedSizeCache.Creator<TKey, String> {
+    private final AtomicInteger count
+
+    TVC(AtomicInteger count) {
+      this.count = count
+    }
+
+    @Override
+    String create(TKey key) {
+      count.incrementAndGet()
+      return key.string + "_value"
+    }
+  }
+
+  private class TKey {
+    private final int hash
+    private final int eq
+    private final String string
+
+    TKey(int hash, int eq, String string) {
+      this.hash = hash
+      this.eq = eq
+      this.string = string
+    }
+
+    boolean equals(o) {
+      if (getClass() != o.class) {
+        return false
+      }
+
+      TKey tKey = (TKey) o
+
+      return eq == tKey.eq
+    }
+
+    int hashCode() {
+      return hash
+    }
+
+    String toString() {
+      return string
+    }
+  }
+}


### PR DESCRIPTION
It may not look like much, but it gets called often enough to account for ~4.5% of all `char[]` memory during `pet-clinic` steady state.