### PR TITLE
do not eagerly load classfiles at startup

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/DatadogClassLoaderTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/DatadogClassLoaderTest.groovy
@@ -73,6 +73,23 @@ class DatadogClassLoaderTest extends Specification {
     c.getClassLoader() == parent
   }
 
+
+  def "test delegate class load to bootstrap"() {
+    given:
+    assumeFalse(System.getProperty("java.version").contains("1.7"))
+    DatadogClassLoader.BootstrapClassLoaderProxy bootstrapProxy =
+      new DatadogClassLoader.BootstrapClassLoaderProxy()
+    DatadogClassLoader parent = new DatadogClassLoader(testJarLocation, "parent", bootstrapProxy, null)
+    DatadogClassLoader.DelegateClassLoader child = new DatadogClassLoader.DelegateClassLoader(testJarLocation,
+      "child", bootstrapProxy, null, parent)
+
+    when:
+    Class<?> v = child.loadClass("java.lang.Void")
+
+    then:
+    v.getClassLoader() == null
+  }
+
   def "test class load managed by child"() {
     given:
     assumeFalse(System.getProperty("java.version").contains("1.7"))


### PR DESCRIPTION
This cuts another second off time to install the agent in spring pet clinic with JDK11

```
./start.sh install  2.73s user 0.14s system 206% cpu 1.386 total
./start.sh install  2.78s user 0.15s system 208% cpu 1.405 total
./start.sh install  2.91s user 0.15s system 210% cpu 1.452 total
./start.sh install  2.82s user 0.15s system 209% cpu 1.416 total
./start.sh install  2.81s user 0.16s system 208% cpu 1.424 total
./start.sh install  2.86s user 0.15s system 209% cpu 1.433 total
./start.sh install  2.87s user 0.15s system 209% cpu 1.439 total
./start.sh install  2.90s user 0.15s system 210% cpu 1.446 total
./start.sh install  2.88s user 0.15s system 209% cpu 1.445 total
./start.sh install  3.01s user 0.16s system 210% cpu 1.502 total
```

On master (JDK11):

```
./start.sh install  4.26s user 0.20s system 285% cpu 1.565 total
./start.sh install  4.29s user 0.21s system 293% cpu 1.529 total
./start.sh install  4.14s user 0.20s system 283% cpu 1.530 total
./start.sh install  4.29s user 0.21s system 284% cpu 1.583 total
./start.sh install  4.27s user 0.21s system 286% cpu 1.563 total
./start.sh install  4.20s user 0.20s system 283% cpu 1.551 total
./start.sh install  4.26s user 0.21s system 287% cpu 1.552 total
./start.sh install  4.20s user 0.20s system 292% cpu 1.508 total
./start.sh install  4.35s user 0.20s system 290% cpu 1.568 total
./start.sh install  4.29s user 0.21s system 286% cpu 1.569 total
```

branch (JDK8)

```
./start.sh install  3.22s user 0.12s system 97% cpu 3.440 total
./start.sh install  3.15s user 0.10s system 100% cpu 3.254 total
./start.sh install  3.15s user 0.10s system 100% cpu 3.245 total
./start.sh install  3.18s user 0.10s system 99% cpu 3.279 total
./start.sh install  3.28s user 0.10s system 99% cpu 3.379 total
./start.sh install  3.21s user 0.10s system 99% cpu 3.311 total
./start.sh install  3.40s user 0.11s system 99% cpu 3.514 total
./start.sh install  3.29s user 0.11s system 99% cpu 3.409 total
./start.sh install  3.29s user 0.12s system 99% cpu 3.416 total
./start.sh install  3.39s user 0.13s system 99% cpu 3.518 total
```