### PR TITLE
Use request path for Jetty resource name

### DIFF
--- a/dd-java-agent/instrumentation/jetty-8/src/main/java/datadog/trace/instrumentation/jetty8/JettyHandlerAdvice.java
+++ b/dd-java-agent/instrumentation/jetty-8/src/main/java/datadog/trace/instrumentation/jetty8/JettyHandlerAdvice.java
@@ -39,8 +39,6 @@ public class JettyHandlerAdvice {
     DECORATE.afterStart(span);
     DECORATE.onConnection(span, req);
     DECORATE.onRequest(span, req);
-    final String resourceName = req.getMethod() + " " + source.getClass().getName();
-    span.setTag(DDTags.RESOURCE_NAME, resourceName);
 
     final AgentScope scope = activateSpan(span);
     scope.setAsyncPropagation(true);

--- a/dd-java-agent/instrumentation/jetty-8/src/test/groovy/JettyHandlerTest.groovy
+++ b/dd-java-agent/instrumentation/jetty-8/src/test/groovy/JettyHandlerTest.groovy
@@ -67,12 +67,6 @@ class JettyHandlerTest extends HttpServerTest<Server> {
   }
 
   @Override
-  boolean testNotFound() {
-    // resource name is set to "GET JettyHandlerTest$TestHandler"
-    false
-  }
-
-  @Override
   boolean testExceptionBody() {
     false
   }
@@ -126,7 +120,7 @@ class JettyHandlerTest extends HttpServerTest<Server> {
     trace.span(index) {
       serviceName expectedServiceName()
       operationName expectedOperationName()
-      resourceName endpoint.status == 404 ? "404" : "$method $handlerName"
+      resourceName endpoint.resource(method, address, testPathParam())
       spanType DDSpanTypes.HTTP_SERVER
       errored endpoint.errored
       if (parentID != null) {

--- a/dd-java-agent/instrumentation/servlet/request-2/src/test/groovy/JettyServlet2Test.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-2/src/test/groovy/JettyServlet2Test.groovy
@@ -88,7 +88,7 @@ class JettyServlet2Test extends HttpServerTest<Server> {
     trace.span(index) {
       serviceName expectedServiceName()
       operationName expectedOperationName()
-      resourceName endpoint.status == 404 ? "404" : "$method ${endpoint.resolve(address).path}"
+      resourceName endpoint.resource(method, address, testPathParam())
       spanType DDSpanTypes.HTTP_SERVER
       errored endpoint.errored
       if (parentID != null) {


### PR DESCRIPTION
This improves resource naming for Jetty by not setting a resource name and relying on `URLAsResourceNameRule`.  In the common case, the resource name becomes the request path instead of a usually static 

> GET org.eclipse.jetty.server.handler.HandlerList

When JAX-RS is being used, JAX-RS will set an even better resource name from the jax-rs annotations.