### PR TITLE
Remove noisy logging in InternalJarURLHandler

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/InternalJarURLHandler.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/InternalJarURLHandler.java
@@ -107,7 +107,6 @@ public class InternalJarURLHandler extends URLStreamHandler {
         // matter
         this.cache = new WeakReference<>(pair);
       } else {
-        log.debug("{} not found in {}", filename, name);
         throw notFound;
       }
     } else {


### PR DESCRIPTION
A line is logged every time the classloader didn't have a class.  It's very noisy in the debug logs