### PR TITLE
remove anonymous class from spring webmvc-3.1

### DIFF
--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/DispatcherServletInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/DispatcherServletInstrumentation.java
@@ -43,7 +43,6 @@ public final class DispatcherServletInstrumentation extends Instrumenter.Default
   public String[] helperClassNames() {
     return new String[] {
       packageName + ".SpringWebHttpServerDecorator",
-      packageName + ".SpringWebHttpServerDecorator$1",
       packageName + ".HandlerMappingResourceNameFilter",
     };
   }

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/HandlerAdapterInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/HandlerAdapterInstrumentation.java
@@ -47,10 +47,7 @@ public final class HandlerAdapterInstrumentation extends Instrumenter.Default {
 
   @Override
   public String[] helperClassNames() {
-    return new String[] {
-      packageName + ".SpringWebHttpServerDecorator",
-      packageName + ".SpringWebHttpServerDecorator$1",
-    };
+    return new String[] {packageName + ".SpringWebHttpServerDecorator"};
   }
 
   @Override

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/SpringWebHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/SpringWebHttpServerDecorator.java
@@ -19,14 +19,17 @@ import org.springframework.web.servlet.mvc.Controller;
 @Slf4j
 public class SpringWebHttpServerDecorator
     extends HttpServerDecorator<HttpServletRequest, HttpServletRequest, HttpServletResponse> {
-  public static final SpringWebHttpServerDecorator DECORATE = new SpringWebHttpServerDecorator();
+
+  private final String component;
+
+  public static final SpringWebHttpServerDecorator DECORATE =
+      new SpringWebHttpServerDecorator("spring-web-controller");
   public static final SpringWebHttpServerDecorator DECORATE_RENDER =
-      new SpringWebHttpServerDecorator() {
-        @Override
-        protected String component() {
-          return "spring-webmvc";
-        }
-      };
+      new SpringWebHttpServerDecorator("spring-webmvc");
+
+  public SpringWebHttpServerDecorator(String component) {
+    this.component = component;
+  }
 
   @Override
   protected String[] instrumentationNames() {
@@ -35,7 +38,7 @@ public class SpringWebHttpServerDecorator
 
   @Override
   protected String component() {
-    return "spring-web-controller";
+    return component;
   }
 
   @Override
@@ -127,7 +130,7 @@ public class SpringWebHttpServerDecorator
       span.setTag(DDTags.RESOURCE_NAME, viewName);
     }
     if (mv.getView() != null) {
-      span.setTag("view.type", mv.getView().getClass().getName());
+      span.setTag("view.type", spanNameForClass(mv.getView().getClass()));
     }
     return span;
   }

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/WebApplicationContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/WebApplicationContextInstrumentation.java
@@ -42,7 +42,6 @@ public class WebApplicationContextInstrumentation extends Instrumenter.Default {
   public String[] helperClassNames() {
     return new String[] {
       packageName + ".SpringWebHttpServerDecorator",
-      packageName + ".SpringWebHttpServerDecorator$1",
       packageName + ".HandlerMappingResourceNameFilter",
       packageName + ".HandlerMappingResourceNameFilter$BeanDefinition",
     };

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/boot/SpringBootBasedTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/boot/SpringBootBasedTest.groovy
@@ -118,7 +118,7 @@ class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext>
           tags {
             "$Tags.COMPONENT" "spring-webmvc"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
-            "view.type" RedirectView.name
+            "view.type" RedirectView.simpleName
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/filter/ServletFilterTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/filter/ServletFilterTest.groovy
@@ -91,7 +91,7 @@ class ServletFilterTest extends HttpServerTest<ConfigurableApplicationContext> {
           tags {
             "$Tags.COMPONENT" "spring-webmvc"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
-            "view.type" RedirectView.name
+            "view.type" RedirectView.simpleName
             defaultTags()
           }
         }


### PR DESCRIPTION
I noticed an anonymous class being used where a data parameter would do whilst investigating something else. This reduces a class load, is another class which doesn't need to be muzzled or otherwise matches, another entry which doesn't need to be cached anywhere, and so on. Also uses the class's simple name instead of full name for the "view.type" property.