### PR TITLE
Exclude JDK class references at build time, reduce allocation in ReferenceMatcher

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/Reference.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/Reference.java
@@ -5,6 +5,7 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -596,7 +597,7 @@ public class Reference {
 
   public static class Builder {
     private final Set<Source> sources = new HashSet<>();
-    private final Set<Flag> flags = new HashSet<>();
+    private final Set<Flag> flags = EnumSet.noneOf(Flag.class);
     private final String className;
     private String superName = null;
     private final Set<String> interfaces = new HashSet<>();

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/ReferenceCreator.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/ReferenceCreator.java
@@ -183,10 +183,13 @@ public class ReferenceCreator extends ClassVisitor {
   }
 
   private void addReference(final Reference ref) {
-    if (references.containsKey(ref.getClassName())) {
-      references.put(ref.getClassName(), references.get(ref.getClassName()).merge(ref));
-    } else {
-      references.put(ref.getClassName(), ref);
+    if (!ref.getClassName().startsWith("java.")) {
+      Reference reference = references.get(ref.getClassName());
+      if (null == reference) {
+        references.put(ref.getClassName(), ref);
+      } else {
+        references.put(ref.getClassName(), reference.merge(ref));
+      }
     }
   }
 

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/ReferenceMatcher.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/ReferenceMatcher.java
@@ -63,11 +63,9 @@ public final class ReferenceMatcher {
 
   private boolean doesMatch(final ClassLoader loader) {
     for (final Reference reference : references) {
-      // Don't reference check JDK classes
       // Don't reference-check helper classes.
       // They will be injected by the instrumentation's HelperInjector.
-      if (!reference.getClassName().startsWith("java.")
-          && !helperClassNames.contains(reference.getClassName())) {
+      if (!helperClassNames.contains(reference.getClassName())) {
         if (!checkMatch(reference, loader).isEmpty()) {
           return false;
         }
@@ -93,8 +91,7 @@ public final class ReferenceMatcher {
     for (final Reference reference : references) {
       // Don't reference-check helper classes.
       // They will be injected by the instrumentation's HelperInjector.
-      if (!reference.getClassName().startsWith("java.")
-          && !helperClassNames.contains(reference.getClassName())) {
+      if (!helperClassNames.contains(reference.getClassName())) {
         mismatches = lazyAddAll(mismatches, checkMatch(reference, loader));
       }
     }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/ReferenceMatcher.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/ReferenceMatcher.java
@@ -63,9 +63,11 @@ public final class ReferenceMatcher {
 
   private boolean doesMatch(final ClassLoader loader) {
     for (final Reference reference : references) {
+      // Don't reference check JDK classes
       // Don't reference-check helper classes.
       // They will be injected by the instrumentation's HelperInjector.
-      if (!helperClassNames.contains(reference.getClassName())) {
+      if (!reference.getClassName().startsWith("java.")
+          && !helperClassNames.contains(reference.getClassName())) {
         if (!checkMatch(reference, loader).isEmpty()) {
           return false;
         }
@@ -86,13 +88,14 @@ public final class ReferenceMatcher {
       loader = Utils.getBootstrapProxy();
     }
 
-    final List<Mismatch> mismatches = new ArrayList<>();
+    List<Mismatch> mismatches = Collections.emptyList();
 
     for (final Reference reference : references) {
       // Don't reference-check helper classes.
       // They will be injected by the instrumentation's HelperInjector.
-      if (!helperClassNames.contains(reference.getClassName())) {
-        mismatches.addAll(checkMatch(reference, loader));
+      if (!reference.getClassName().startsWith("java.")
+          && !helperClassNames.contains(reference.getClassName())) {
+        mismatches = lazyAddAll(mismatches, checkMatch(reference, loader));
       }
     }
 
@@ -110,10 +113,8 @@ public final class ReferenceMatcher {
     final TypePool typePool =
         AgentTooling.poolStrategy()
             .typePool(AgentTooling.locationStrategy().classFileLocator(loader), loader);
-    final List<Mismatch> mismatches = new ArrayList<>();
     try {
-      final TypePool.Resolution resolution =
-          typePool.describe(Utils.getClassName(reference.getClassName()));
+      final TypePool.Resolution resolution = typePool.describe(reference.getClassName());
       if (!resolution.isResolved()) {
         return Collections.<Mismatch>singletonList(
             new Mismatch.MissingClass(
@@ -125,41 +126,45 @@ public final class ReferenceMatcher {
         // bytebuddy throws an illegal state exception with this message if it cannot resolve types
         // TODO: handle missing type resolutions without catching bytebuddy's exceptions
         final String className = e.getMessage().replace("Cannot resolve type description for ", "");
-        mismatches.add(
+        return Collections.<Mismatch>singletonList(
             new Mismatch.MissingClass(reference.getSources().toArray(new Source[0]), className));
       } else {
         // Shouldn't happen. Fail the reference check and add a mismatch for debug logging.
-        mismatches.add(new Mismatch.ReferenceCheckError(e, reference, loader));
+        return Collections.<Mismatch>singletonList(
+            new Mismatch.ReferenceCheckError(e, reference, loader));
       }
     }
-    return mismatches;
   }
 
   public static List<Reference.Mismatch> checkMatch(
       final Reference reference, final TypeDescription typeOnClasspath) {
-    final List<Mismatch> mismatches = new ArrayList<>();
+    List<Mismatch> mismatches = Collections.emptyList();
 
     for (final Reference.Flag flag : reference.getFlags()) {
       if (!flag.matches(typeOnClasspath.getModifiers())) {
         final String desc = reference.getClassName();
-        mismatches.add(
-            new Mismatch.MissingFlag(
-                reference.getSources().toArray(new Source[0]),
-                desc,
-                flag,
-                typeOnClasspath.getModifiers()));
+        mismatches =
+            lazyAdd(
+                mismatches,
+                new Mismatch.MissingFlag(
+                    reference.getSources().toArray(new Source[0]),
+                    desc,
+                    flag,
+                    typeOnClasspath.getModifiers()));
       }
     }
 
     for (final Reference.Field fieldRef : reference.getFields()) {
       final FieldDescription.InDefinedShape fieldDescription = findField(fieldRef, typeOnClasspath);
       if (fieldDescription == null) {
-        mismatches.add(
-            new Reference.Mismatch.MissingField(
-                fieldRef.getSources().toArray(new Reference.Source[0]),
-                reference.getClassName(),
-                fieldRef.getName(),
-                fieldRef.getType().getInternalName()));
+        mismatches =
+            lazyAdd(
+                mismatches,
+                new Reference.Mismatch.MissingField(
+                    fieldRef.getSources().toArray(new Reference.Source[0]),
+                    reference.getClassName(),
+                    fieldRef.getName(),
+                    fieldRef.getType().getInternalName()));
       } else {
         for (final Reference.Flag flag : fieldRef.getFlags()) {
           if (!flag.matches(fieldDescription.getModifiers())) {
@@ -168,12 +173,14 @@ public final class ReferenceMatcher {
                     + "#"
                     + fieldRef.getName()
                     + fieldRef.getType().getInternalName();
-            mismatches.add(
-                new Mismatch.MissingFlag(
-                    fieldRef.getSources().toArray(new Source[0]),
-                    desc,
-                    flag,
-                    fieldDescription.getModifiers()));
+            mismatches =
+                lazyAdd(
+                    mismatches,
+                    new Mismatch.MissingFlag(
+                        fieldRef.getSources().toArray(new Source[0]),
+                        desc,
+                        flag,
+                        fieldDescription.getModifiers()));
           }
         }
       }
@@ -183,27 +190,30 @@ public final class ReferenceMatcher {
       final MethodDescription.InDefinedShape methodDescription =
           findMethod(methodRef, typeOnClasspath);
       if (methodDescription == null) {
-        mismatches.add(
-            new Reference.Mismatch.MissingMethod(
-                methodRef.getSources().toArray(new Reference.Source[0]),
-                methodRef.getName(),
-                methodRef.getDescriptor()));
+        mismatches =
+            lazyAdd(
+                mismatches,
+                new Reference.Mismatch.MissingMethod(
+                    methodRef.getSources().toArray(new Reference.Source[0]),
+                    methodRef.getName(),
+                    methodRef.getDescriptor()));
       } else {
         for (final Reference.Flag flag : methodRef.getFlags()) {
           if (!flag.matches(methodDescription.getModifiers())) {
             final String desc =
                 reference.getClassName() + "#" + methodRef.getName() + methodRef.getDescriptor();
-            mismatches.add(
-                new Mismatch.MissingFlag(
-                    methodRef.getSources().toArray(new Source[0]),
-                    desc,
-                    flag,
-                    methodDescription.getModifiers()));
+            mismatches =
+                lazyAdd(
+                    mismatches,
+                    new Mismatch.MissingFlag(
+                        methodRef.getSources().toArray(new Source[0]),
+                        desc,
+                        flag,
+                        methodDescription.getModifiers()));
           }
         }
       }
     }
-
     return mismatches;
   }
 
@@ -260,5 +270,20 @@ public final class ReferenceMatcher {
       }
     }
     return null;
+  }
+
+  private static List<Mismatch> lazyAdd(List<Mismatch> mismatches, Mismatch mismatch) {
+    List<Mismatch> result = mismatches.isEmpty() ? new ArrayList<Mismatch>() : mismatches;
+    result.add(mismatch);
+    return result;
+  }
+
+  private static List<Mismatch> lazyAddAll(List<Mismatch> mismatches, List<Mismatch> toAdd) {
+    if (!toAdd.isEmpty()) {
+      List<Mismatch> result = mismatches.isEmpty() ? new ArrayList<Mismatch>() : mismatches;
+      result.addAll(toAdd);
+      return result;
+    }
+    return mismatches;
   }
 }

--- a/dd-java-agent/testing/src/test/groovy/muzzle/ReferenceCreatorTest.groovy
+++ b/dd-java-agent/testing/src/test/groovy/muzzle/ReferenceCreatorTest.groovy
@@ -14,20 +14,18 @@ class ReferenceCreatorTest extends AgentTestRunner {
     Map<String, Reference> references = ReferenceCreator.createReferencesFrom(MethodBodyAdvice.getName(), this.getClass().getClassLoader())
 
     expect:
-    references.get('java.lang.Object') != null
-    references.get('java.lang.String') != null
     references.get('muzzle.TestClasses$MethodBodyAdvice$A') != null
     references.get('muzzle.TestClasses$MethodBodyAdvice$B') != null
     references.get('muzzle.TestClasses$MethodBodyAdvice$SomeInterface') != null
     references.get('muzzle.TestClasses$MethodBodyAdvice$SomeImplementation') != null
-    references.keySet().size() == 6
+    references.keySet().size() == 4
 
     // interface flags
     references.get('muzzle.TestClasses$MethodBodyAdvice$B').getFlags().contains(Reference.Flag.NON_INTERFACE)
     references.get('muzzle.TestClasses$MethodBodyAdvice$SomeInterface').getFlags().contains(Reference.Flag.INTERFACE)
 
     // class access flags
-    references.get('java.lang.Object').getFlags().contains(Reference.Flag.PUBLIC)
+    references.get('muzzle.TestClasses$MethodBodyAdvice$A').getFlags().contains(Reference.Flag.PACKAGE_OR_HIGHER)
     references.get('muzzle.TestClasses$MethodBodyAdvice$B').getFlags().contains(Reference.Flag.PACKAGE_OR_HIGHER)
 
     // method refs


### PR DESCRIPTION
* Prevents from repeatedly checking very common JDK classes
* Mismatches are exceptional so only allocate an `ArrayList` when they happen