### PR TITLE
Fix okio dependency in shared classloader

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -75,6 +75,10 @@ ext {
     // Shared between agent tooling, instrumentation, JMXFetch, and profiling
     shared        : [
       dependencies.create(group: 'com.squareup.okhttp3', name: 'okhttp', version: versions.okhttp),
+      // Force specific version of okio required by com.squareup.moshi:moshi
+      // When all of the dependencies are declared in dd-trace-core, moshi overrides the okhttp's
+      // transitive dependency.  Since okhttp is declared here and moshi is not, this lead to an incompatible version
+      dependencies.create(group: 'com.squareup.okio', name: 'okio', version: '1.16.0'),
       dependencies.create(group: 'com.datadoghq', name: 'java-dogstatsd-client', version: versions.dogstatsd),
       dependencies.create(group: 'com.github.jnr', name: 'jnr-unixsocket', version: versions.jnr_unixsocket),
       dependencies.create(group: 'com.google.guava', name: 'guava', version: versions.guava)


### PR DESCRIPTION
This fixes the version of okio in the shared classloader.  Previously, the version of okio used by dd-trace-core for debug logging was pulled up to 1.16.0 by the com.squareup.moshi:moshi dependency.

Output of `./gradlew :dd-trace-core:dependencies --configuration runtimeClasspath`:

```
+--- com.squareup.okhttp3:okhttp:3.12.12
|    \--- com.squareup.okio:okio:1.15.0 -> 1.16.0
+--- com.squareup.moshi:moshi:1.9.2
|    \--- com.squareup.okio:okio:1.16.0
...
```

Since only okhttp was moved to the shared classloader and not moshi, the transitive dependency was no longer overridden

Output of `./gradlew :dd-java-agent:dependencies --configuration sharedShadowInclude` before this pull request:

```
+--- com.squareup.okhttp3:okhttp:3.12.12
|    \--- com.squareup.okio:okio:1.15.0
...
```

By explicitly setting the okio version in the shared classloader, the version is correct again.

Output of `./gradlew :dd-java-agent:dependencies --configuration sharedShadowInclude` after this pull request:
```
+--- com.squareup.okhttp3:okhttp:3.12.12
|    \--- com.squareup.okio:okio:1.15.0 -> 1.16.0
+--- com.squareup.okio:okio:1.16.0
...
```