### PR TITLE
Remove confusing DDAgentApi toString

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/DDAgentWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/DDAgentWriter.java
@@ -214,11 +214,10 @@ public class DDAgentWriter implements Writer {
     // Monitor or checking the result of Monitor#toString() to determine
     // if something is *probably* the NoopMonitor.
 
-    String str = "DDAgentWriter { api=" + api;
+    String str = "DDAgentWriter";
     if (!(monitor instanceof Monitor.Noop)) {
-      str += ", monitor=" + monitor;
+      str += " { monitor=" + monitor + " }";
     }
-    str += " }";
 
     return str;
   }

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/DDAgentApi.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/DDAgentApi.java
@@ -306,11 +306,6 @@ public class DDAgentApi {
     }
   }
 
-  @Override
-  public String toString() {
-    return "DDApi { tracesUrl=" + tracesUrl + " }";
-  }
-
   /**
    * Encapsulates an attempted response from the Datadog agent.
    *


### PR DESCRIPTION
Because of the lazy determination of `tracesUrl`, the `toString()` of DDAgentApi showed as:

> DDApi { tracesUrl=null }

This has lead to user confusion on multiple occasions.

I did not change the `toString()` to use a more complicated algorithm (eg "unset") because we already have logging for when the URL is downgraded to v3 from v4.  We also have logging for agent host and agent port.