### PR TITLE
Handle kafka tombstones 

### DIFF
--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaConsumerInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaConsumerInstrumentation.java
@@ -39,8 +39,7 @@ public final class KafkaConsumerInstrumentation extends Instrumenter.Default {
       packageName + ".TextMapExtractAdapter",
       packageName + ".TracingIterable",
       packageName + ".TracingIterator",
-      packageName + ".TracingList",
-      "datadog.trace.core.util.Clock"
+      packageName + ".TracingList"
     };
   }
 

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaDecorator.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaDecorator.java
@@ -77,7 +77,10 @@ public class KafkaDecorator extends ClientDecorator {
   }
 
   public void finishConsumerSpan(final AgentSpan span) {
-    if (endToEndDurationsEnabled) {
+    if (endToEndDurationsEnabled
+      // no context propagation on tombstones, so this is always the
+      // trace start if we get one
+      && !Boolean.TRUE.equals(span.getTag(InstrumentationTags.TOMBSTONE))) {
       long now = System.currentTimeMillis();
       String traceStartTime = span.getBaggageItem(DDTags.TRACE_START_TIME);
       if (null != traceStartTime) {

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerInstrumentation.java
@@ -16,6 +16,7 @@ import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.Config;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.InstrumentationTags;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.method.MethodDescription;
@@ -44,8 +45,7 @@ public final class KafkaProducerInstrumentation extends Instrumenter.Default {
     return new String[] {
       packageName + ".KafkaDecorator",
       packageName + ".TextMapInjectAdapter",
-      KafkaProducerInstrumentation.class.getName() + "$ProducerCallback",
-      "datadog.trace.core.util.Clock",
+      KafkaProducerInstrumentation.class.getName() + "$ProducerCallback"
     };
   }
 
@@ -73,6 +73,11 @@ public final class KafkaProducerInstrumentation extends Instrumenter.Default {
 
       callback = new ProducerCallback(callback, span);
 
+      boolean isTombstone = record.value() == null && !record.headers().iterator().hasNext();
+      if (isTombstone) {
+        span.setTag(InstrumentationTags.TOMBSTONE, true);
+      }
+
       // Do not inject headers for batch versions below 2
       // This is how similar check is being done in Kafka client itself:
       // https://github.com/apache/kafka/blob/05fcfde8f69b0349216553f711fdfc3f0259c601/clients/src/main/java/org/apache/kafka/common/record/MemoryRecordsBuilder.java#L411-L412
@@ -81,7 +86,9 @@ public final class KafkaProducerInstrumentation extends Instrumenter.Default {
       // headers attempt to read messages that were produced by clients > 0.11 and the magic
       // value of the broker(s) is >= 2
       if (apiVersions.maxUsableProduceMagic() >= RecordBatch.MAGIC_VALUE_V2
-          && Config.get().isKafkaClientPropagationEnabled()) {
+          && Config.get().isKafkaClientPropagationEnabled()
+          // Must not interfere with tombstones
+          && !isTombstone) {
         try {
           propagate().inject(span, record.headers(), SETTER);
         } catch (final IllegalStateException e) {

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/SpanAssert.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/SpanAssert.groovy
@@ -110,6 +110,11 @@ class SpanAssert {
     traceDDId(parent.traceId)
   }
 
+  def notChildOf(DDSpan parent) {
+    assert parent.spanId != span.parentId
+    assert parent.traceId != span.traceId
+  }
+
   def errored(boolean errored) {
     assert span.isError() == errored
     checked.errored = true

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -215,6 +215,7 @@ public class DDSpan implements MutableSpan, AgentSpan {
     return context.getTags().remove(tag);
   }
 
+  @Override
   public Object getTag(final String tag) {
     return context.getTags().get(tag);
   }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
@@ -22,6 +22,8 @@ public interface AgentSpan extends MutableSpan {
 
   AgentSpan setTag(String key, Object value);
 
+  Object getTag(String key);
+
   @Override
   AgentSpan setError(boolean error);
 

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -267,6 +267,11 @@ public class AgentTracer {
     }
 
     @Override
+    public Object getTag(String key) {
+      return null;
+    }
+
+    @Override
     public long getStartTime() {
       return 0;
     }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/InstrumentationTags.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/InstrumentationTags.java
@@ -12,6 +12,7 @@ public class InstrumentationTags {
   public static final String OFFSET = "offset";
   public static final String RECORD_QUEUE_TIME_MS = "record.queue_time_ms";
   public static final String RECORD_END_TO_END_DURATION_MS = "record.e2e_duration_ms";
+  public static final String TOMBSTONE = "tombstone";
   public static final String AWS_AGENT = "aws.agent";
   public static final String AWS_SERVICE = "aws.service";
   public static final String BUCKET = "bucket";


### PR DESCRIPTION
Changes the handling of Kafka tombstones (where there are no headers and the body is null).

1. We don't propagate through tombstones, since they are logically terminal operations. We tag the producer span as being a tombstone.
2. If we detect a tombstone during consumption, we still create a span to indicate that a tombstone has been consumed, but tag as a tombstone and won't compute an e2e duration since no baggage can have been propagated in this case.

There is a [proposal](https://cwiki.apache.org/confluence/display/KAFKA/KIP-87+-+Add+Compaction+Tombstone+Flag) for a tombstone flag which we may be able to use in the future.