### PR TITLE
Don't instrument org.apache.logging.log4j.ThreadContext's ThreadLocal field in case Log4j-to-SLF4J Adapter detected

### DIFF
--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaDecorator.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaDecorator.java
@@ -78,9 +78,9 @@ public class KafkaDecorator extends ClientDecorator {
 
   public void finishConsumerSpan(final AgentSpan span) {
     if (endToEndDurationsEnabled
-      // no context propagation on tombstones, so this is always the
-      // trace start if we get one
-      && !Boolean.TRUE.equals(span.getTag(InstrumentationTags.TOMBSTONE))) {
+        // no context propagation on tombstones, so this is always the
+        // trace start if we get one
+        && !Boolean.TRUE.equals(span.getTag(InstrumentationTags.TOMBSTONE))) {
       long now = System.currentTimeMillis();
       String traceStartTime = span.getBaggageItem(DDTags.TRACE_START_TIME);
       if (null != traceStartTime) {

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TracingIterator.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TracingIterator.java
@@ -8,9 +8,8 @@ import static datadog.trace.instrumentation.kafka_clients.TextMapExtractAdapter.
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan.Context;
-import java.util.Iterator;
-
 import datadog.trace.bootstrap.instrumentation.api.InstrumentationTags;
+import java.util.Iterator;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 

--- a/dd-java-agent/instrumentation/slf4j-mdc/src/main/java/datadog/trace/instrumentation/slf4j/mdc/MDCInjectionInstrumentation.java
+++ b/dd-java-agent/instrumentation/slf4j-mdc/src/main/java/datadog/trace/instrumentation/slf4j/mdc/MDCInjectionInstrumentation.java
@@ -20,7 +20,6 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.BooleanMatcher;
 import net.bytebuddy.matcher.ElementMatcher;
 import net.bytebuddy.utility.JavaModule;
-import org.slf4j.spi.MDCAdapter;
 
 @AutoService(Instrumenter.class)
 public class MDCInjectionInstrumentation extends Instrumenter.Default {
@@ -88,7 +87,7 @@ public class MDCInjectionInstrumentation extends Instrumenter.Default {
 
         final Field mdcAdapterField = mdcClass.getDeclaredField("mdcAdapter");
         mdcAdapterField.setAccessible(true);
-        final MDCAdapter mdcAdapterInstance = (MDCAdapter) mdcAdapterField.get(null);
+        final Object mdcAdapterInstance = mdcAdapterField.get(null);
         final Field copyOnThreadLocalField =
             mdcAdapterInstance.getClass().getDeclaredField("copyOnThreadLocal");
         copyOnThreadLocalField.setAccessible(true);

--- a/dd-java-agent/src/main/java/datadog/trace/bootstrap/AgentBootstrap.java
+++ b/dd-java-agent/src/main/java/datadog/trace/bootstrap/AgentBootstrap.java
@@ -5,7 +5,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.lang.instrument.Instrumentation;
-import java.lang.invoke.MethodHandles;
 import java.lang.management.ManagementFactory;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -41,7 +40,7 @@ import java.util.regex.Pattern;
  * </ul>
  */
 public final class AgentBootstrap {
-  private static final Class<?> thisClass = MethodHandles.lookup().lookupClass();
+  private static final Class<?> thisClass = AgentBootstrap.class;
 
   public static void premain(final String agentArgs, final Instrumentation inst) {
     agentmain(agentArgs, inst);
@@ -128,10 +127,10 @@ public final class AgentBootstrap {
   private static List<String> getVMArgumentsThroughReflection() {
     try {
       // Try Oracle-based
-      final Class managementFactoryHelperClass =
+      final Class<?> managementFactoryHelperClass =
           thisClass.getClassLoader().loadClass("sun.management.ManagementFactoryHelper");
 
-      final Class vmManagementClass =
+      final Class<?> vmManagementClass =
           thisClass.getClassLoader().loadClass("sun.management.VMManagement");
 
       Object vmManagement;
@@ -151,7 +150,7 @@ public final class AgentBootstrap {
 
     } catch (final ReflectiveOperationException e) {
       try { // Try IBM-based.
-        final Class VMClass = thisClass.getClassLoader().loadClass("com.ibm.oti.vm.VM");
+        final Class<?> VMClass = thisClass.getClassLoader().loadClass("com.ibm.oti.vm.VM");
         final String[] argArray = (String[]) VMClass.getMethod("getVMArgs").invoke(null);
         return Arrays.asList(argArray);
       } catch (final ReflectiveOperationException e1) {


### PR DESCRIPTION
1. Don't instrument org.apache.logging.log4j.ThreadContext's ThreadLocal field in case Log4j-to-SLF4J Adapter detected
1. delete casting to MDCAdapter because we shadowing it to datadog.slf4j.spi.MDCAdapter
1. `./gradlew spotlessApply`  also added some changes to this PR :)