### PR TITLE
Cache the UTF8 bytes for prepared statements

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -463,3 +463,15 @@ acceptedBreaks:
       old: "class datadog.trace.core.util.FixedSizeCache<K extends java.lang.Object,\
         \ V extends java.lang.Object>"
       justification: "INTERNAL API"
+    - code: "java.method.removed"
+      old: "method void datadog.trace.core.serialization.FormatWriter<DEST>::writeNumberAsString(byte[],\
+        \ java.lang.Number, DEST) throws java.io.IOException"
+      justification: "internal api"
+    - code: "java.method.removed"
+      old: "method void datadog.trace.core.serialization.JsonFormatWriter::writeNumberAsString(byte[],\
+        \ java.lang.Number, com.squareup.moshi.JsonWriter) throws java.io.IOException"
+      justification: "internal api"
+    - code: "java.method.removed"
+      old: "method void datadog.trace.core.serialization.MsgpackFormatWriter::writeNumberAsString(byte[],\
+        \ java.lang.Number, org.msgpack.core.MessagePacker) throws java.io.IOException"
+      justification: "internal api"

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/DatabaseClientDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/DatabaseClientDecorator.java
@@ -44,7 +44,7 @@ public abstract class DatabaseClientDecorator<CONNECTION> extends ClientDecorato
     return span;
   }
 
-  public AgentSpan onStatement(final AgentSpan span, final String statement) {
+  public AgentSpan onStatement(final AgentSpan span, final CharSequence statement) {
     assert span != null;
     span.setTag(Tags.DB_STATEMENT, statement);
     return span;

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/ConnectionInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/ConnectionInstrumentation.java
@@ -11,6 +11,7 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import java.sql.PreparedStatement;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
@@ -56,7 +57,14 @@ public final class ConnectionInstrumentation extends Instrumenter.Default {
     @Advice.OnMethodExit(suppress = Throwable.class)
     public static void addDBInfo(
         @Advice.Argument(0) final String sql, @Advice.Return final PreparedStatement statement) {
-      JDBCMaps.preparedStatements.put(statement, sql);
+      // Sometimes the prepared statement is not reused, but the underlying String is reused, so
+      // check if we have seen this String before
+      UTF8BytesString utf8Sql = JDBCMaps.preparedStatementsSql.get(sql);
+      if (utf8Sql == null) {
+        utf8Sql = UTF8BytesString.create(sql);
+        JDBCMaps.preparedStatementsSql.put(sql, utf8Sql);
+      }
+      JDBCMaps.preparedStatements.putIfAbsent(statement, utf8Sql);
     }
   }
 }

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/JDBCDecorator.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/JDBCDecorator.java
@@ -4,6 +4,7 @@ import datadog.trace.api.DDSpanTypes;
 import datadog.trace.api.DDTags;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
+import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.DatabaseClientDecorator;
 import datadog.trace.bootstrap.instrumentation.jdbc.DBInfo;
 import datadog.trace.bootstrap.instrumentation.jdbc.JDBCConnectionUrlParser;
@@ -15,7 +16,11 @@ import java.sql.SQLException;
 public class JDBCDecorator extends DatabaseClientDecorator<DBInfo> {
   public static final JDBCDecorator DECORATE = new JDBCDecorator();
 
-  private static final String DB_QUERY = "DB Query";
+  private static final UTF8BytesString DB_QUERY = UTF8BytesString.create("DB Query");
+  private static final UTF8BytesString JDBC_STATEMENT =
+      UTF8BytesString.create("java-jdbc-statement");
+  private static final UTF8BytesString JDBC_PREPARED_STATEMENT =
+      UTF8BytesString.create("java-jdbc-prepared_statement");
 
   @Override
   protected String[] instrumentationNames() {
@@ -94,18 +99,18 @@ public class JDBCDecorator extends DatabaseClientDecorator<DBInfo> {
   }
 
   @Override
-  public AgentSpan onStatement(final AgentSpan span, final String statement) {
-    final String resourceName = statement == null ? DB_QUERY : statement;
+  public AgentSpan onStatement(final AgentSpan span, final CharSequence statement) {
+    final CharSequence resourceName = statement == null ? DB_QUERY : statement;
     span.setTag(DDTags.RESOURCE_NAME, resourceName);
-    span.setTag(Tags.COMPONENT, "java-jdbc-statement");
+    span.setTag(Tags.COMPONENT, JDBC_STATEMENT);
     return super.onStatement(span, statement);
   }
 
   public AgentSpan onPreparedStatement(final AgentSpan span, final PreparedStatement statement) {
-    final String sql = JDBCMaps.preparedStatements.get(statement);
-    final String resourceName = sql == null ? DB_QUERY : sql;
+    final UTF8BytesString sql = JDBCMaps.preparedStatements.get(statement);
+    final UTF8BytesString resourceName = sql == null ? DB_QUERY : sql;
     span.setTag(DDTags.RESOURCE_NAME, resourceName);
-    span.setTag(Tags.COMPONENT, "java-jdbc-prepared_statement");
+    span.setTag(Tags.COMPONENT, JDBC_PREPARED_STATEMENT);
     return super.onStatement(span, sql);
   }
 }

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/JDBCMaps.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/JDBCMaps.java
@@ -3,6 +3,7 @@ package datadog.trace.instrumentation.jdbc;
 import static datadog.trace.bootstrap.WeakMap.Provider.newWeakMap;
 
 import datadog.trace.bootstrap.WeakMap;
+import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.jdbc.DBInfo;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -14,5 +15,6 @@ import java.sql.PreparedStatement;
  */
 public class JDBCMaps {
   public static final WeakMap<Connection, DBInfo> connectionInfo = newWeakMap();
-  public static final WeakMap<PreparedStatement, String> preparedStatements = newWeakMap();
+  public static final WeakMap<String, UTF8BytesString> preparedStatementsSql = newWeakMap();
+  public static final WeakMap<PreparedStatement, UTF8BytesString> preparedStatements = newWeakMap();
 }

--- a/dd-java-agent/instrumentation/opentelemetry/src/main/java/datadog/trace/instrumentation/opentelemetry/OtelSpan.java
+++ b/dd-java-agent/instrumentation/opentelemetry/src/main/java/datadog/trace/instrumentation/opentelemetry/OtelSpan.java
@@ -152,12 +152,12 @@ public class OtelSpan implements Span, MutableSpan {
   }
 
   @Override
-  public String getResourceName() {
+  public CharSequence getResourceName() {
     return delegate.getResourceName();
   }
 
   @Override
-  public MutableSpan setResourceName(final String resourceName) {
+  public MutableSpan setResourceName(final CharSequence resourceName) {
     return delegate.setResourceName(resourceName);
   }
 

--- a/dd-java-agent/instrumentation/opentracing/api-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/OTSpan.java
+++ b/dd-java-agent/instrumentation/opentracing/api-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/OTSpan.java
@@ -132,12 +132,12 @@ class OTSpan implements Span, MutableSpan {
   }
 
   @Override
-  public String getResourceName() {
+  public CharSequence getResourceName() {
     return delegate.getResourceName();
   }
 
   @Override
-  public MutableSpan setResourceName(final String resourceName) {
+  public MutableSpan setResourceName(final CharSequence resourceName) {
     return delegate.setResourceName(resourceName);
   }
 

--- a/dd-java-agent/instrumentation/opentracing/api-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/OTSpan.java
+++ b/dd-java-agent/instrumentation/opentracing/api-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/OTSpan.java
@@ -139,12 +139,12 @@ class OTSpan implements Span, MutableSpan {
   }
 
   @Override
-  public String getResourceName() {
+  public CharSequence getResourceName() {
     return delegate.getResourceName();
   }
 
   @Override
-  public MutableSpan setResourceName(final String resourceName) {
+  public MutableSpan setResourceName(final CharSequence resourceName) {
     return delegate.setResourceName(resourceName);
   }
 

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/SpanAssert.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/SpanAssert.groovy
@@ -57,22 +57,22 @@ class SpanAssert {
   }
 
   def resourceName(Pattern pattern) {
-    assert span.resourceName.matches(pattern)
+    assert span.resourceName.toString().matches(pattern)
     checked.resourceName = true
   }
 
   def resourceName(String name) {
-    assert span.resourceName == name
+    assert span.resourceName.toString() == name
     checked.resourceName = true
   }
 
   def resourceName(Closure<Boolean> eval) {
-    assert eval(span.resourceName)
+    assert eval(span.resourceName.toString())
     checked.resourceName = true
   }
 
   def resourceNameContains(String... resourceNameParts) {
-    assertSpanNameContains(span.resourceName, resourceNameParts)
+    assertSpanNameContains(span.resourceName.toString(), resourceNameParts)
     checked.resourceName = true
   }
 

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/TagsAssert.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/TagsAssert.groovy
@@ -4,6 +4,7 @@ import datadog.trace.api.Config
 import datadog.trace.api.DDId
 import datadog.trace.api.DDTags
 import datadog.trace.bootstrap.instrumentation.api.Tags
+import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString
 import datadog.trace.core.DDSpan
 import groovy.transform.stc.ClosureParams
 import groovy.transform.stc.SimpleType
@@ -78,19 +79,21 @@ class TagsAssert {
       return
     }
     assertedTags.add(name)
+    def t = tag(name)
     if (value instanceof Pattern) {
-      assert tags[name] =~ value
+      assert t =~ value
     } else if (value instanceof Class) {
-      assert ((Class) value).isInstance(tags[name])
+      assert ((Class) value).isInstance(t)
     } else if (value instanceof Closure) {
-      assert ((Closure) value).call(tags[name])
+      assert ((Closure) value).call(t)
     } else {
-      assert tags[name] == value
+      assert t == value
     }
   }
 
   def tag(String name) {
-    return tags[name]
+    def t = tags[name]
+    return (t instanceof UTF8BytesString) ? t.toString() : t
   }
 
   def methodMissing(String name, args) {

--- a/dd-trace-api/src/main/java/datadog/trace/api/interceptor/MutableSpan.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/interceptor/MutableSpan.java
@@ -18,9 +18,9 @@ public interface MutableSpan {
 
   MutableSpan setServiceName(final String serviceName);
 
-  String getResourceName();
+  CharSequence getResourceName();
 
-  MutableSpan setResourceName(final String resourceName);
+  MutableSpan setResourceName(final CharSequence resourceName);
 
   Integer getSamplingPriority();
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -249,7 +249,7 @@ public class DDSpan implements MutableSpan, AgentSpan {
   }
 
   @Override
-  public final DDSpan setResourceName(final String resourceName) {
+  public final DDSpan setResourceName(final CharSequence resourceName) {
     context.setResourceName(resourceName);
     return this;
   }
@@ -311,7 +311,7 @@ public class DDSpan implements MutableSpan, AgentSpan {
   }
 
   @Override
-  public String getResourceName() {
+  public CharSequence getResourceName() {
     return context.getResourceName();
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
@@ -50,7 +50,7 @@ public class DDSpanContext implements AgentSpan.Context {
   /** The service name is required, otherwise the span are dropped by the agent */
   private volatile String serviceName;
   /** The resource associated to the service (server_web, database, etc.) */
-  private volatile String resourceName;
+  private volatile CharSequence resourceName;
   /** Each span have an operation name describing the current span */
   private volatile String operationName;
   /** The type of the span. If null, the Datadog Agent will report as a custom */
@@ -81,7 +81,7 @@ public class DDSpanContext implements AgentSpan.Context {
       final DDId parentId,
       final String serviceName,
       final String operationName,
-      final String resourceName,
+      final CharSequence resourceName,
       final int samplingPriority,
       final String origin,
       final Map<String, String> baggageItems,
@@ -156,19 +156,19 @@ public class DDSpanContext implements AgentSpan.Context {
     this.serviceName = mappedServiceName == null ? serviceName : mappedServiceName;
   }
 
-  public String getResourceName() {
+  public CharSequence getResourceName() {
     return isResourceNameSet() ? resourceName : operationName;
   }
 
   public boolean isResourceNameSet() {
-    return !(resourceName == null || resourceName.isEmpty());
+    return resourceName != null && resourceName.length() != 0;
   }
 
   public boolean hasResourceName() {
     return isResourceNameSet() || tags.containsKey(DDTags.RESOURCE_NAME);
   }
 
-  public void setResourceName(final String resourceName) {
+  public void setResourceName(final CharSequence resourceName) {
     this.resourceName = resourceName;
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/processor/rule/DBStatementRule.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/processor/rule/DBStatementRule.java
@@ -20,9 +20,9 @@ public class DBStatementRule implements TraceProcessor.Rule {
     // Skip the decorators
     if (!"java-mongo".equals(span.getTag(Tags.COMPONENT))) {
       final Object dbStatementValue = span.getAndRemoveTag(Tags.DB_STATEMENT);
-      if (dbStatementValue instanceof String) {
-        final String statement = (String) dbStatementValue;
-        if (!statement.isEmpty()) {
+      if (dbStatementValue instanceof CharSequence) {
+        final CharSequence statement = (CharSequence) dbStatementValue;
+        if (statement.length() != 0) {
           span.setResourceName(statement);
         }
       }

--- a/dd-trace-core/src/main/java/datadog/trace/core/processor/rule/ResourceNameRule.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/processor/rule/ResourceNameRule.java
@@ -14,7 +14,9 @@ public class ResourceNameRule implements TraceProcessor.Rule {
   @Override
   public void processSpan(final DDSpan span) {
     final Object name = span.getAndRemoveTag(DDTags.RESOURCE_NAME);
-    if (name != null) {
+    if (name instanceof CharSequence) {
+      span.setResourceName((CharSequence) name);
+    } else if (name != null) {
       span.setResourceName(name.toString());
     }
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/serialization/FormatWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/serialization/FormatWriter.java
@@ -62,8 +62,8 @@ public abstract class FormatWriter<DEST> {
   public abstract void writeId(final byte[] key, DDId id, final DEST destination)
       throws IOException;
 
-  public abstract void writeNumberAsString(
-      final byte[] key, final Number value, final DEST destination) throws IOException;
+  public abstract void writeObjectAsString(
+      final byte[] key, final Object value, final DEST destination) throws IOException;
 
   public void writeNumber(final byte[] key, final Number value, final DEST destination)
       throws IOException {
@@ -105,15 +105,7 @@ public abstract class FormatWriter<DEST> {
       }
     }
     for (Map.Entry<String, Object> entry : tags.entrySet()) {
-      byte[] key = stringToBytes(entry.getKey());
-      Object value = entry.getValue();
-      if (value instanceof String) {
-        writeTag(key, (String) value, destination);
-      } else if (value instanceof Number) {
-        writeNumberAsString(key, (Number) value, destination);
-      } else {
-        writeString(key, String.valueOf(entry.getValue()), destination);
-      }
+      writeObjectAsString(stringToBytes(entry.getKey()), entry.getValue(), destination);
     }
     writeMapFooter(destination);
   }
@@ -131,7 +123,7 @@ public abstract class FormatWriter<DEST> {
     writeMapHeader(12, destination); // must match count below.
     /* 1  */ writeTag(SERVICE, span.getServiceName(), destination);
     /* 2  */ writeString(NAME, span.getOperationName(), destination);
-    /* 3  */ writeString(RESOURCE, span.getResourceName(), destination);
+    /* 3  */ writeObjectAsString(RESOURCE, span.getResourceName(), destination);
     /* 4  */ writeId(TRACE_ID, span.getTraceId(), destination);
     /* 5  */ writeId(SPAN_ID, span.getSpanId(), destination);
     /* 6  */ writeId(PARENT_ID, span.getParentId(), destination);

--- a/dd-trace-core/src/main/java/datadog/trace/core/serialization/JsonFormatWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/serialization/JsonFormatWriter.java
@@ -112,7 +112,7 @@ public class JsonFormatWriter extends FormatWriter<JsonWriter> {
   }
 
   @Override
-  public void writeNumberAsString(byte[] key, Number value, JsonWriter destination)
+  public void writeObjectAsString(byte[] key, Object value, JsonWriter destination)
       throws IOException {
     writeString(key, String.valueOf(value), destination);
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/serialization/MsgpackFormatWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/serialization/MsgpackFormatWriter.java
@@ -1,6 +1,7 @@
 package datadog.trace.core.serialization;
 
 import datadog.trace.api.DDId;
+import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.core.StringTables;
 import datadog.trace.core.util.LRUCache;
 import java.io.IOException;
@@ -103,6 +104,10 @@ public class MsgpackFormatWriter extends FormatWriter<MessagePacker> {
       writeLongAsString(((Number) value).longValue(), destination);
     } else if (value instanceof String) {
       cachedWriteString((String) value, destination);
+    } else if (value instanceof UTF8BytesString) {
+      byte[] bytes = ((UTF8BytesString) value).getUtf8Bytes();
+      destination.packRawStringHeader(bytes.length);
+      destination.addPayload(bytes);
     } else {
       cachedWriteString(String.valueOf(value), destination);
     }

--- a/dd-trace-core/src/main/java/datadog/trace/core/serialization/MsgpackFormatWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/serialization/MsgpackFormatWriter.java
@@ -96,11 +96,13 @@ public class MsgpackFormatWriter extends FormatWriter<MessagePacker> {
   }
 
   @Override
-  public void writeNumberAsString(byte[] key, Number value, MessagePacker destination)
+  public void writeObjectAsString(byte[] key, Object value, MessagePacker destination)
       throws IOException {
     writeKey(key, destination);
     if (value instanceof Long || value instanceof Integer) {
-      writeLongAsString(value.longValue(), destination);
+      writeLongAsString(((Number) value).longValue(), destination);
+    } else if (value instanceof String) {
+      cachedWriteString((String) value, destination);
     } else {
       cachedWriteString(String.valueOf(value), destination);
     }

--- a/dd-trace-ot/src/main/java/datadog/opentracing/OTSpan.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/OTSpan.java
@@ -139,12 +139,12 @@ class OTSpan implements Span, MutableSpan {
   }
 
   @Override
-  public String getResourceName() {
+  public CharSequence getResourceName() {
     return delegate.getResourceName();
   }
 
   @Override
-  public MutableSpan setResourceName(final String resourceName) {
+  public MutableSpan setResourceName(final CharSequence resourceName) {
     return delegate.setResourceName(resourceName);
   }
 

--- a/internal-api/internal-api.gradle
+++ b/internal-api/internal-api.gradle
@@ -1,6 +1,24 @@
 apply from: "$rootDir/gradle/java.gradle"
 
+excludedClassesCoverage += [
+  "datadog.trace.bootstrap.instrumentation.api.Tags",
+  "datadog.trace.bootstrap.instrumentation.api.CommonTagValues",
+  "datadog.trace.bootstrap.instrumentation.api.AgentTracer.NoopAgentPropagation",
+  "datadog.trace.bootstrap.instrumentation.api.AgentTracer",
+  "datadog.trace.bootstrap.instrumentation.api.AgentTracer.NoopContext",
+  "datadog.trace.bootstrap.instrumentation.api.InstrumentationTags",
+  "datadog.trace.bootstrap.instrumentation.api.AgentTracer.NoopContinuation",
+  "datadog.trace.bootstrap.instrumentation.api.AgentTracer.NoopAgentSpan",
+  "datadog.trace.bootstrap.instrumentation.api.DDSpanNames",
+  "datadog.trace.bootstrap.instrumentation.api.DDComponents",
+  "datadog.trace.bootstrap.instrumentation.api.AgentTracer.NoopAgentScope",
+  "datadog.trace.bootstrap.instrumentation.api.AgentTracer.NoopTracerAPI",
+  "datadog.trace.bootstrap.instrumentation.api.AgentTracer.NoopAgentTrace",
+]
+
 dependencies {
   // references TraceScope and Continuation from public api
   compile project(':dd-trace-api')
+
+  testCompile project(":utils:test-utils")
 }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -302,12 +302,12 @@ public class AgentTracer {
     }
 
     @Override
-    public String getResourceName() {
+    public CharSequence getResourceName() {
       return null;
     }
 
     @Override
-    public MutableSpan setResourceName(final String resourceName) {
+    public MutableSpan setResourceName(final CharSequence resourceName) {
       return this;
     }
 

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/UTF8BytesString.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/UTF8BytesString.java
@@ -1,0 +1,91 @@
+package datadog.trace.bootstrap.instrumentation.api;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Class that wraps a {@code String} and caches the UTF8 byte representation. Implements {@code
+ * CharSequence} so that it can be mixed with normal{@code String} instances.
+ */
+public final class UTF8BytesString implements CharSequence {
+  public static UTF8BytesString create(String string) {
+    if (string == null) {
+      return null;
+    } else {
+      // To make sure that we don't get an infinite circle in weak caches that are indexed on this
+      // very String, we create a new wrapper String that we hold on to instead.
+      return new UTF8BytesString(new String(string));
+    }
+  }
+
+  public static UTF8BytesString create(CharSequence chars) {
+    if (chars == null) {
+      return null;
+    } else if (chars instanceof UTF8BytesString) {
+      return (UTF8BytesString) chars;
+    } else if (chars instanceof String) {
+      return create((String) chars);
+    } else {
+      return new UTF8BytesString(String.valueOf(chars));
+    }
+  }
+
+  private final String string;
+  private byte[] utf8Bytes = null;
+
+  private UTF8BytesString(String string) {
+    this.string = string;
+  }
+
+  /**
+   * Returns a <code>byte[]</code> representing the UTF8 encoding of the wrapped {@code String}.
+   * Please note that the same <code>byte[]</code> will be returned on each call, and the caller is
+   * bound by honor, and the fear of purgatory, to not modify the <code>byte[]</code>.
+   *
+   * @return the byte array of the UTF8 encode string
+   */
+  public byte[] getUtf8Bytes() {
+    byte[] bytes = this.utf8Bytes;
+    // This race condition is intentional and benign.
+    // The worst that can happen is that an identical value is produced and written into the field.
+    if (bytes == null) {
+      this.utf8Bytes = bytes = this.string.getBytes(StandardCharsets.UTF_8);
+    }
+    return bytes;
+  }
+
+  @Override
+  public String toString() {
+    return string;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null) return false;
+    String that = null;
+    if (o instanceof UTF8BytesString) {
+      that = ((UTF8BytesString) o).string;
+    }
+    return this.string.equals(that);
+  }
+
+  @Override
+  public int hashCode() {
+    return this.string.hashCode();
+  }
+
+  @Override
+  public int length() {
+    return this.string.length();
+  }
+
+  @Override
+  public char charAt(int index) {
+    return this.string.charAt(index);
+  }
+
+  @Override
+  public CharSequence subSequence(int start, int end) {
+    return this.string.subSequence(start, end);
+  }
+}

--- a/internal-api/src/test/groovy/datadog/trace/bootstrap/instrumentation/api/Utf8ByteStringTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/bootstrap/instrumentation/api/Utf8ByteStringTest.groovy
@@ -1,0 +1,50 @@
+package datadog.trace.bootstrap.instrumentation.api
+
+
+import datadog.trace.util.test.DDSpecification
+
+import java.nio.charset.StandardCharsets
+
+class Utf8ByteStringTest extends DDSpecification {
+  def "wrap String and produce the right bytes and String"() {
+    when:
+    final utf8String = UTF8BytesString.create((String) str)
+
+    then:
+    if (utf8String != null) {
+      utf8String.toString() == str
+      utf8String.hashCode() == str.hashCode()
+      def bytes = str.getBytes(StandardCharsets.UTF_8)
+      def utf8Bytes = utf8String.getUtf8Bytes()
+      utf8Bytes == bytes
+      // check that we get back the same byte array
+      utf8String.getUtf8Bytes().is(utf8Bytes)
+      utf8String.equals(utf8String)
+      utf8String == UTF8BytesString.create(str)
+      !utf8String.equals(null)
+      utf8String != str
+      utf8String != UTF8BytesString.create("somethingcompletelydifferent")
+    }
+
+    where:
+    str << [null, "foo", "bar", "alongerstring"]
+  }
+
+  def "behave like a proper CharSequence"() {
+    when:
+    final utf8String = UTF8BytesString.create((CharSequence) chars)
+
+    then:
+    if (utf8String != null) {
+      utf8String.toString() == chars.toString()
+      utf8String.length() == chars.length()
+      for (int i = 0; i < chars.length(); i++) {
+        utf8String.charAt(i) == chars.charAt(i)
+      }
+      utf8String.subSequence(1, chars.length()).toString() == chars.subSequence(1, chars.length()).toString()
+    }
+
+    where:
+    chars << [null, "foo", new StringBuffer("bar"), new StringBuffer("someotherlongstring"), UTF8BytesString.create("utf8string")]
+  }
+}


### PR DESCRIPTION
This PR drops time spent in encoding and serializing for the aggressive `pet-clinic` from 28% to 22% by not re-encoding the JDBC prepared statements, and the resource name. Looking at the profile this change seems to increase the overflow of the message buffer in msgpack somewhat.

It has two parts:

1. Switch the `Resource Name` from a `String` to a `CharSequence`. Yes, there are no immutability guarantees for a `CharSequence` but this is an internal API, and it's the one `interface` that can easily be implemented by something that want's to wrap a `String`, where you could just use a `String` instead.
2. Introduce a wrapper class `UTF8BytesString` that caches the `byte[]` and hands out the same one for every call to `getUtf8Bytes`, and change the JDBC decorator and prepared statement instrumentation to use that instead of a plain `String`
 