### PR TITLE
Remove overly verbose logging

### DIFF
--- a/dd-java-agent/agent-mlt/src/main/java/com/datadog/mlt/sampler/JMXSampler.java
+++ b/dd-java-agent/agent-mlt/src/main/java/com/datadog/mlt/sampler/JMXSampler.java
@@ -95,13 +95,7 @@ class JMXSampler {
       log.warn("ThreadStack provider is no op. It will not provide thread stacks.");
       providerFirstAccess = false;
     }
-    ThreadInfo[] threadInfos = provider.getThreadInfo(tmpArray);
-    if (threadInfos.length > 0 && log.isDebugEnabled()) {
-      log.debug(
-          "Collecting stacktraces for {} {}",
-          threadInfos.length,
-          threadInfos.length == 1 ? "thread" : "threads");
-    }
+    final ThreadInfo[] threadInfos = provider.getThreadInfo(tmpArray);
     // dispatch to Scopes
     for (ThreadInfo threadInfo : threadInfos) {
       ScopeManager scopeManager = threadScopeMapper.forThread(threadInfo.getThreadId());

--- a/dd-smoke-tests/profiling-integration-tests/src/test/groovy/datadog/smoketest/ProfilingIntegrationMLTTest.groovy
+++ b/dd-smoke-tests/profiling-integration-tests/src/test/groovy/datadog/smoketest/ProfilingIntegrationMLTTest.groovy
@@ -53,21 +53,16 @@ class ProfilingIntegrationMLTTest extends AbstractSmokeTest {
     Multimap<String, Object> firstRequestParameters =
       ProfilingTestUtils.parseProfilingRequestParameters(firstRequest)
 
-
-    def logHasSamplerEntries = false
     def logHasErrors = false
     new File("${buildDirectory}/reports/testProcess.${this.getClass().getName()}.log").eachLine {
       if (it.contains("ERROR") || it.contains("WARN")) {
         println it
         logHasErrors = true
-      } else if (it.contains("JMXSampler") && it.contains("Collecting stacktraces")) {
-        logHasSamplerEntries = true
       }
     }
 
     then:
     !logHasErrors
-    logHasSamplerEntries
     firstRequest.getRequestUrl().toString() == profilingUrl
 
     firstRequestParameters.get("format").get(0) == "jfr"


### PR DESCRIPTION
This logging generates 50-100+ lines of 
> Collecting stacktraces for 1 thread

**per request** in petclinic