### PR TITLE
Deadlock detection JFR events

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
@@ -284,7 +284,7 @@ public class Agent {
   /** Enable JMX based thread CPU time provider once it is safe to touch JMX */
   private static synchronized void initializeJmxThreadCpuTimeProvider() {
     log.info("Initializing JMX thread CPU time provider");
-    if (PROFILING_CLASSLOADER == null) {
+    if (AGENT_CLASSLOADER == null) {
       throw new IllegalStateException("Datadog agent should have been started already");
     }
     try {

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
@@ -264,12 +264,27 @@ public class Agent {
   private static synchronized void startJmx(final URL bootstrapURL) {
     startJmxFetch(bootstrapURL);
     initializeJmxThreadCpuTimeProvider();
+    registerDeadlockDetectionEvent(bootstrapURL);
+  }
+
+  private static synchronized void registerDeadlockDetectionEvent(URL bootstrapUrl) {
+    log.info("Initializing JMX thread deadlock detector");
+    try {
+      ClassLoader classLoader = getProfilingClassloader(bootstrapUrl);
+      final Class<?> deadlockFactoryClass =
+          classLoader.loadClass(
+              "com.datadog.profiling.controller.openjdk.events.DeadlockEventFactory");
+      final Method registerMethod = deadlockFactoryClass.getMethod("registerEvents");
+      registerMethod.invoke(null);
+    } catch (final Throwable ex) {
+      log.error("Throwable thrown while initializing JMX thread deadlock detector", ex);
+    }
   }
 
   /** Enable JMX based thread CPU time provider once it is safe to touch JMX */
   private static synchronized void initializeJmxThreadCpuTimeProvider() {
     log.info("Initializing JMX thread CPU time provider");
-    if (AGENT_CLASSLOADER == null) {
+    if (PROFILING_CLASSLOADER == null) {
       throw new IllegalStateException("Datadog agent should have been started already");
     }
     try {
@@ -306,13 +321,10 @@ public class Agent {
       final URL bootstrapURL, final boolean isStartingFirst) {
     final ClassLoader contextLoader = Thread.currentThread().getContextClassLoader();
     try {
-      if (PROFILING_CLASSLOADER == null) {
-        PROFILING_CLASSLOADER =
-            createDelegateClassLoader("profiling", bootstrapURL, PARENT_CLASSLOADER);
-      }
-      Thread.currentThread().setContextClassLoader(PROFILING_CLASSLOADER);
+      ClassLoader classLoader = getProfilingClassloader(bootstrapURL);
+      Thread.currentThread().setContextClassLoader(classLoader);
       final Class<?> profilingAgentClass =
-          PROFILING_CLASSLOADER.loadClass("com.datadog.profiling.agent.ProfilingAgent");
+          classLoader.loadClass("com.datadog.profiling.agent.ProfilingAgent");
       final Method profilingInstallerMethod = profilingAgentClass.getMethod("run", Boolean.TYPE);
       profilingInstallerMethod.invoke(null, isStartingFirst);
     } catch (final ClassFormatError e) {
@@ -327,6 +339,15 @@ public class Agent {
     } finally {
       Thread.currentThread().setContextClassLoader(contextLoader);
     }
+  }
+
+  private static synchronized ClassLoader getProfilingClassloader(URL bootstrapURL)
+      throws Exception {
+    if (PROFILING_CLASSLOADER == null) {
+      PROFILING_CLASSLOADER =
+          createDelegateClassLoader("profiling", bootstrapURL, PARENT_CLASSLOADER);
+    }
+    return PROFILING_CLASSLOADER;
   }
 
   private static void configureLogger() {

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkController.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkController.java
@@ -17,12 +17,10 @@ package com.datadog.profiling.controller.openjdk;
 
 import com.datadog.profiling.controller.ConfigurationException;
 import com.datadog.profiling.controller.Controller;
-import com.datadog.profiling.controller.openjdk.events.DeadlockEventFactory;
 import datadog.trace.api.Config;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
 import jdk.jfr.Recording;
 
 /**
@@ -31,8 +29,6 @@ import jdk.jfr.Recording;
  * messier... ;)
  */
 public final class OpenJdkController implements Controller {
-  private static final AtomicBoolean EVENTS_REGISTERED_FLAG = new AtomicBoolean();
-
   // Visible for testing
   static final String JFP = "jfr/dd.jfp";
   static final int RECORDING_MAX_SIZE = 64 * 1024 * 1024; // 64 megs
@@ -62,8 +58,6 @@ public final class OpenJdkController implements Controller {
 
   @Override
   public OpenJdkOngoingRecording createRecording(final String recordingName) {
-    registerEvents();
-
     final Recording recording = new Recording();
     recording.setName(recordingName);
     recording.setSettings(recordingSettings);
@@ -71,12 +65,5 @@ public final class OpenJdkController implements Controller {
     recording.setMaxAge(RECORDING_MAX_AGE);
     recording.start();
     return new OpenJdkOngoingRecording(recording);
-  }
-
-  private void registerEvents() {
-    // prevent re-registration as that would cause JFR to throw an exception
-    if (EVENTS_REGISTERED_FLAG.compareAndSet(false, true)) {
-      DeadlockEventFactory.registerEvents();
-    }
   }
 }

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkController.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkController.java
@@ -24,14 +24,12 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import jdk.jfr.Recording;
-import lombok.extern.slf4j.Slf4j;
 
 /**
  * This is the implementation of the controller for OpenJDK. It should work for JDK 11+ today, and
  * unmodified for JDK 8+ once JFR has been back-ported. The Oracle JDK implementation will be far
  * messier... ;)
  */
-@Slf4j
 public final class OpenJdkController implements Controller {
   private static final AtomicBoolean EVENTS_REGISTERED_FLAG = new AtomicBoolean();
 

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkController.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkController.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
-
 import jdk.jfr.Recording;
 import lombok.extern.slf4j.Slf4j;
 

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkController.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkController.java
@@ -17,11 +17,13 @@ package com.datadog.profiling.controller.openjdk;
 
 import com.datadog.profiling.controller.ConfigurationException;
 import com.datadog.profiling.controller.Controller;
-import com.datadog.profiling.controller.openjdk.events.DeadlockEvent;
+import com.datadog.profiling.controller.openjdk.events.DeadlockEventFactory;
 import datadog.trace.api.Config;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import jdk.jfr.Recording;
 import lombok.extern.slf4j.Slf4j;
 
@@ -32,6 +34,8 @@ import lombok.extern.slf4j.Slf4j;
  */
 @Slf4j
 public final class OpenJdkController implements Controller {
+  private static final AtomicBoolean EVENTS_REGISTERED_FLAG = new AtomicBoolean();
+
   // Visible for testing
   static final String JFP = "jfr/dd.jfp";
   static final int RECORDING_MAX_SIZE = 64 * 1024 * 1024; // 64 megs
@@ -54,9 +58,6 @@ public final class OpenJdkController implements Controller {
     try {
       recordingSettings =
           JfpUtils.readNamedJfpResource(JFP, config.getProfilingTemplateOverrideFile());
-
-      log.info("Register deadlock event");
-      DeadlockEvent.register();
     } catch (final IOException e) {
       throw new ConfigurationException(e);
     }
@@ -64,6 +65,8 @@ public final class OpenJdkController implements Controller {
 
   @Override
   public OpenJdkOngoingRecording createRecording(final String recordingName) {
+    registerEvents();
+
     final Recording recording = new Recording();
     recording.setName(recordingName);
     recording.setSettings(recordingSettings);
@@ -71,5 +74,12 @@ public final class OpenJdkController implements Controller {
     recording.setMaxAge(RECORDING_MAX_AGE);
     recording.start();
     return new OpenJdkOngoingRecording(recording);
+  }
+
+  private void registerEvents() {
+    // prevent re-registration as that would cause JFR to throw an exception
+    if (EVENTS_REGISTERED_FLAG.compareAndSet(false, true)) {
+      DeadlockEventFactory.registerEvents();
+    }
   }
 }

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkController.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkController.java
@@ -17,17 +17,20 @@ package com.datadog.profiling.controller.openjdk;
 
 import com.datadog.profiling.controller.ConfigurationException;
 import com.datadog.profiling.controller.Controller;
+import com.datadog.profiling.controller.openjdk.events.DeadlockEvent;
 import datadog.trace.api.Config;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Map;
 import jdk.jfr.Recording;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * This is the implementation of the controller for OpenJDK. It should work for JDK 11+ today, and
  * unmodified for JDK 8+ once JFR has been back-ported. The Oracle JDK implementation will be far
  * messier... ;)
  */
+@Slf4j
 public final class OpenJdkController implements Controller {
   // Visible for testing
   static final String JFP = "jfr/dd.jfp";
@@ -51,6 +54,9 @@ public final class OpenJdkController implements Controller {
     try {
       recordingSettings =
           JfpUtils.readNamedJfpResource(JFP, config.getProfilingTemplateOverrideFile());
+
+      log.info("Register deadlock event");
+      DeadlockEvent.register();
     } catch (final IOException e) {
       throw new ConfigurationException(e);
     }

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/events/DeadlockEvent.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/events/DeadlockEvent.java
@@ -1,11 +1,9 @@
 package com.datadog.profiling.controller.openjdk.events;
 
-import java.util.concurrent.atomic.AtomicBoolean;
 import jdk.jfr.Category;
 import jdk.jfr.Description;
 import jdk.jfr.Enabled;
 import jdk.jfr.Event;
-import jdk.jfr.FlightRecorder;
 import jdk.jfr.Label;
 import jdk.jfr.Name;
 import jdk.jfr.Period;

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/events/DeadlockEvent.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/events/DeadlockEvent.java
@@ -1,0 +1,53 @@
+package com.datadog.profiling.controller.openjdk.events;
+
+import jdk.jfr.Category;
+import jdk.jfr.Description;
+import jdk.jfr.Enabled;
+import jdk.jfr.Event;
+import jdk.jfr.FlightRecorder;
+import jdk.jfr.Label;
+import jdk.jfr.Name;
+import jdk.jfr.Period;
+
+@Name("datadog.Deadlock")
+@Label("Deadlock")
+@Description("Datadog deadlock detection event.")
+@Category("Datadog")
+@Period(value = "57 s")
+@Enabled
+public class DeadlockEvent extends Event {
+  private static final DeadlockEventFactory eventFactory = new DeadlockEventFactory();
+
+  @Label("Deadlock ID")
+  @Description("Referential index for data related to a particular deadlock")
+  private final long id;
+
+  @Label("Deadlocked Thread Count")
+  private final int threadCount;
+
+  DeadlockEvent() {
+    this.id = Long.MIN_VALUE;
+    this.threadCount = Integer.MIN_VALUE;
+  }
+
+  public DeadlockEvent(long id, int threadCount) {
+    this.id = id;
+    this.threadCount = threadCount;
+  }
+
+  public static void emit() {
+    eventFactory.collectEvents().forEach(Event::commit);
+  }
+
+  public static void register() {
+    FlightRecorder.addPeriodicEvent(DeadlockEvent.class, DeadlockEvent::emit);
+  }
+
+  long getId() {
+    return id;
+  }
+
+  int getThreadCount() {
+    return threadCount;
+  }
+}

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/events/DeadlockEvent.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/events/DeadlockEvent.java
@@ -1,5 +1,6 @@
 package com.datadog.profiling.controller.openjdk.events;
 
+import java.util.concurrent.atomic.AtomicBoolean;
 import jdk.jfr.Category;
 import jdk.jfr.Description;
 import jdk.jfr.Enabled;
@@ -8,8 +9,6 @@ import jdk.jfr.FlightRecorder;
 import jdk.jfr.Label;
 import jdk.jfr.Name;
 import jdk.jfr.Period;
-
-import java.util.concurrent.atomic.AtomicBoolean;
 
 @Name("datadog.Deadlock")
 @Label("Deadlock")

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/events/DeadlockEvent.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/events/DeadlockEvent.java
@@ -17,7 +17,6 @@ import jdk.jfr.Period;
 @Period(value = "57 s")
 @Enabled
 public class DeadlockEvent extends Event {
-  private static final AtomicBoolean REGISTERED_FLAG = new AtomicBoolean();
   private static final DeadlockEventFactory EVENT_FACTORY = new DeadlockEventFactory();
 
   @Label("Deadlock ID")
@@ -39,12 +38,6 @@ public class DeadlockEvent extends Event {
 
   public static void emit() {
     EVENT_FACTORY.collectEvents().forEach(Event::commit);
-  }
-
-  public static void register() {
-    if (REGISTERED_FLAG.compareAndSet(false, true)) {
-      FlightRecorder.addPeriodicEvent(DeadlockEvent.class, DeadlockEvent::emit);
-    }
   }
 
   long getId() {

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/events/DeadlockEventFactory.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/events/DeadlockEventFactory.java
@@ -13,7 +13,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import jdk.jfr.Event;
 import jdk.jfr.FlightRecorder;

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/events/DeadlockEventFactory.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/events/DeadlockEventFactory.java
@@ -13,16 +13,21 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import jdk.jfr.Event;
+import jdk.jfr.FlightRecorder;
 
 public class DeadlockEventFactory {
-
   private static final DeadlockEvent DEADLOCK_EVENT = new DeadlockEvent();
   private static final DeadlockedThreadEvent DEADLOCKED_THREAD_EVENT = new DeadlockedThreadEvent();
 
   private final ThreadMXBean threadMXBean;
   private final AtomicLong deadlockCounter = new AtomicLong();
+
+  public static void registerEvents() {
+    FlightRecorder.addPeriodicEvent(DeadlockEvent.class, DeadlockEvent::emit);
+  }
 
   DeadlockEventFactory(ThreadMXBean threadMXBean) {
     this.threadMXBean = threadMXBean;

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/events/DeadlockEventFactory.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/events/DeadlockEventFactory.java
@@ -1,0 +1,128 @@
+package com.datadog.profiling.controller.openjdk.events;
+
+import java.lang.management.LockInfo;
+import java.lang.management.ManagementFactory;
+import java.lang.management.MonitorInfo;
+import java.lang.management.ThreadInfo;
+import java.lang.management.ThreadMXBean;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.concurrent.atomic.AtomicLong;
+import jdk.jfr.Event;
+
+public class DeadlockEventFactory {
+
+  private static final DeadlockEvent DEADLOCK_EVENT = new DeadlockEvent();
+  private static final DeadlockedThreadEvent DEADLOCKED_THREAD_EVENT = new DeadlockedThreadEvent();
+
+  private final ThreadMXBean threadMXBean;
+  private final AtomicLong deadlockCounter = new AtomicLong();
+
+  DeadlockEventFactory(ThreadMXBean threadMXBean) {
+    this.threadMXBean = threadMXBean;
+  }
+
+  DeadlockEventFactory() {
+    this(ManagementFactory.getThreadMXBean());
+  }
+
+  final List<? extends Event> collectEvents() {
+    if (!isDeadlockEventEnabled()) {
+      return Collections.emptyList();
+    }
+
+    long[] locked = threadMXBean.findDeadlockedThreads();
+    if (locked == null) {
+      return Collections.emptyList();
+    }
+    long id = deadlockCounter.getAndIncrement();
+
+    List<Event> events = new ArrayList<>();
+    DeadlockEvent event = new DeadlockEvent(id, locked.length);
+
+    events.add(event);
+    if (isDeadlockedThreadEventEnabled()) {
+      ThreadInfo[] lockedThreads = threadMXBean.getThreadInfo(locked, true, true);
+
+      Map<LockInfo, Set<StackTraceElement>> waitingFrames =
+          new TreeMap<>(Comparator.comparingLong(LockInfo::getIdentityHashCode));
+      for (ThreadInfo ti : lockedThreads) {
+        waitingFrames
+            .computeIfAbsent(ti.getLockInfo(), k -> new HashSet<>())
+            .add(ti.getStackTrace()[0]);
+      }
+
+      for (ThreadInfo ti : lockedThreads) {
+        processLockedMonitors(ti, id, waitingFrames, events);
+        processSynchronizables(ti, id, waitingFrames, events);
+      }
+    }
+    return events;
+  }
+
+  private void processSynchronizables(
+      ThreadInfo ti,
+      long id,
+      Map<LockInfo, Set<StackTraceElement>> waitingFrames,
+      List<Event> events) {
+    for (LockInfo li : ti.getLockedSynchronizers()) {
+      Set<StackTraceElement> waitingFramesSet = waitingFrames.get(li);
+      if (waitingFramesSet != null) {
+        for (StackTraceElement waitingFrame : waitingFramesSet) {
+          events.add(
+              new DeadlockedThreadEvent(
+                  id,
+                  ti.getThreadId(),
+                  ti.getThreadName(),
+                  ti.getLockOwnerId(),
+                  ti.getLockOwnerName(),
+                  ti.getLockName(),
+                  null,
+                  frameAsString(waitingFrame)));
+        }
+      }
+    }
+  }
+
+  private void processLockedMonitors(
+      ThreadInfo ti,
+      long id,
+      Map<LockInfo, Set<StackTraceElement>> waitingFrames,
+      List<Event> events) {
+    for (MonitorInfo mi : ti.getLockedMonitors()) {
+      Set<StackTraceElement> waitingFramesSet = waitingFrames.get(mi);
+      if (waitingFramesSet != null) {
+        for (StackTraceElement waitingFrame : waitingFramesSet) {
+          events.add(
+              new DeadlockedThreadEvent(
+                  id,
+                  ti.getThreadId(),
+                  ti.getThreadName(),
+                  ti.getLockOwnerId(),
+                  ti.getLockOwnerName(),
+                  ti.getLockName(),
+                  frameAsString(mi.getLockedStackFrame()),
+                  frameAsString(waitingFrame)));
+        }
+      }
+    }
+  }
+
+  boolean isDeadlockEventEnabled() {
+    return DEADLOCK_EVENT.isEnabled() && DEADLOCK_EVENT.shouldCommit();
+  }
+
+  boolean isDeadlockedThreadEventEnabled() {
+    return DEADLOCKED_THREAD_EVENT.isEnabled() && DEADLOCKED_THREAD_EVENT.shouldCommit();
+  }
+
+  private static String frameAsString(StackTraceElement ste) {
+    return ste.getClassName() + "." + ste.getMethodName() + "#" + ste.getLineNumber();
+  }
+}

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/events/DeadlockedThreadEvent.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/events/DeadlockedThreadEvent.java
@@ -1,0 +1,94 @@
+package com.datadog.profiling.controller.openjdk.events;
+
+import jdk.jfr.Category;
+import jdk.jfr.Description;
+import jdk.jfr.Enabled;
+import jdk.jfr.Event;
+import jdk.jfr.Label;
+import jdk.jfr.Name;
+
+@Name("datadog.DeadlockedThread")
+@Label("Deadlocked Thread")
+@Description("Datadog deadlock detection event - thread details.")
+@Category("Datadog")
+@Enabled
+public class DeadlockedThreadEvent extends Event {
+  @Label("Deadlocked Thread ID")
+  private final long threadId;
+
+  @Label("Deadlocked Thread Name")
+  private final String threadName;
+
+  @Label("Lock name")
+  private final String lockName;
+
+  @Label("Lock Owner Thread Name")
+  private final String lockOwnerThreadName;
+
+  @Label("Lock Owner Thread ID")
+  private final long lockOwnerThreadId;
+
+  @Label("Locking Frame")
+  @Description(
+      "Textual representation of the frame locking the monitor. 'null' for java.util.concurrent locks.")
+  private final String lockingFrame;
+
+  @Label("Waiting Frame")
+  @Description(
+      "Textual representation of the frame awaiting to lock a monitor or java.util.concurrent lock.")
+  private final String waitingFrame;
+
+  @Label("Deadlock ID")
+  @Description("Referential index for data related to a particular deadlock")
+  private final long id;
+
+  DeadlockedThreadEvent() {
+    this.id = Long.MIN_VALUE;
+    this.threadId = Long.MIN_VALUE;
+    this.threadName = null;
+    this.lockOwnerThreadId = Long.MIN_VALUE;
+    this.lockOwnerThreadName = null;
+    this.lockName = null;
+    this.lockingFrame = null;
+    this.waitingFrame = null;
+  }
+
+  public DeadlockedThreadEvent(
+      long id,
+      long threadId,
+      String threadName,
+      long lockOwnerThreadId,
+      String lockOwnerThreadName,
+      String lockName,
+      String lockingFrame,
+      String waitingFrame) {
+    this.id = id;
+    this.threadId = threadId;
+    this.threadName = threadName;
+    this.lockOwnerThreadId = lockOwnerThreadId;
+    this.lockOwnerThreadName = lockOwnerThreadName;
+    this.lockName = lockName;
+    this.lockingFrame = lockingFrame;
+    this.waitingFrame = waitingFrame;
+  }
+
+  String getThreadName() {
+    return threadName;
+  }
+
+  String getLockOwnerThreadName() {
+    return lockOwnerThreadName;
+  }
+
+  String getLockingFrame() {
+    return lockingFrame;
+  }
+
+  String getWaitingFrame() {
+    return waitingFrame;
+  }
+
+  long getId() {
+    return id;
+  }
+}

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/test/java/com/datadog/profiling/controller/openjdk/events/DeadlockEventFactoryTest.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/test/java/com/datadog/profiling/controller/openjdk/events/DeadlockEventFactoryTest.java
@@ -93,19 +93,22 @@ class DeadlockEventFactoryTest {
                   }
                   return true;
                 })
-            .sorted((e1, e2) -> {
-              if (e1 instanceof DeadlockEvent) {
-                return e2 instanceof DeadlockEvent ? 0 : -1;
-              } else {
-                if (e2 instanceof DeadlockEvent) {
-                  return 1;
-                }
-              }
-              if (e1 instanceof DeadlockedThreadEvent && e2 instanceof DeadlockedThreadEvent) {
-                return ((DeadlockedThreadEvent) e1).getThreadName().compareTo(((DeadlockedThreadEvent) e2).getThreadName());
-              }
-              return 0;
-            })
+            .sorted(
+                (e1, e2) -> {
+                  if (e1 instanceof DeadlockEvent) {
+                    return e2 instanceof DeadlockEvent ? 0 : -1;
+                  } else {
+                    if (e2 instanceof DeadlockEvent) {
+                      return 1;
+                    }
+                  }
+                  if (e1 instanceof DeadlockedThreadEvent && e2 instanceof DeadlockedThreadEvent) {
+                    return ((DeadlockedThreadEvent) e1)
+                        .getThreadName()
+                        .compareTo(((DeadlockedThreadEvent) e2).getThreadName());
+                  }
+                  return 0;
+                })
             .collect(Collectors.toList());
 
     assertNotNull(events);

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/test/java/com/datadog/profiling/controller/openjdk/events/DeadlockEventFactoryTest.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/test/java/com/datadog/profiling/controller/openjdk/events/DeadlockEventFactoryTest.java
@@ -93,6 +93,19 @@ class DeadlockEventFactoryTest {
                   }
                   return true;
                 })
+            .sorted((e1, e2) -> {
+              if (e1 instanceof DeadlockEvent) {
+                return e2 instanceof DeadlockEvent ? 0 : -1;
+              } else {
+                if (e2 instanceof DeadlockEvent) {
+                  return 1;
+                }
+              }
+              if (e1 instanceof DeadlockedThreadEvent && e2 instanceof DeadlockedThreadEvent) {
+                return ((DeadlockedThreadEvent) e1).getThreadName().compareTo(((DeadlockedThreadEvent) e2).getThreadName());
+              }
+              return 0;
+            })
             .collect(Collectors.toList());
 
     assertNotNull(events);

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/test/java/com/datadog/profiling/controller/openjdk/events/DeadlockEventFactoryTest.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/test/java/com/datadog/profiling/controller/openjdk/events/DeadlockEventFactoryTest.java
@@ -1,0 +1,257 @@
+package com.datadog.profiling.controller.openjdk.events;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Phaser;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.stream.Collectors;
+import jdk.jfr.Event;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class DeadlockEventFactoryTest {
+  private DeadlockEventFactory eventFactory;
+  private DeadlockEventFactory disabledDetailsEventFactory;
+  private DeadlockEventFactory allDisabledEventFactory;
+
+  @BeforeEach
+  void setUp() {
+    eventFactory =
+        new DeadlockEventFactory() {
+          @Override
+          boolean isDeadlockEventEnabled() {
+            return true;
+          }
+
+          @Override
+          boolean isDeadlockedThreadEventEnabled() {
+            return true;
+          }
+        };
+
+    disabledDetailsEventFactory =
+        new DeadlockEventFactory() {
+          @Override
+          boolean isDeadlockEventEnabled() {
+            return true;
+          }
+
+          @Override
+          boolean isDeadlockedThreadEventEnabled() {
+            return false;
+          }
+        };
+
+    allDisabledEventFactory =
+        new DeadlockEventFactory() {
+          @Override
+          boolean isDeadlockEventEnabled() {
+            return false;
+          }
+
+          @Override
+          boolean isDeadlockedThreadEventEnabled() {
+            return false;
+          }
+        };
+  }
+
+  @Test
+  void collectEvents() throws Exception {
+    /*
+     * All test cases must be done within one test method since there is no way to terminate
+     * deadlocked threads and indeterminate execution of test case would be very problematic
+     * due to residual state of the previous test cases.
+     */
+    assertNoDeadlocks();
+    int deadlocked = setupMonitorDeadlock();
+    assertDeadlock(true, deadlocked);
+    deadlocked += setupSynchronizableDeadlock();
+    assertDeadlock(false, deadlocked);
+
+    assertEquals(
+        1,
+        disabledDetailsEventFactory.collectEvents().stream()
+            .filter(e -> e instanceof DeadlockEvent)
+            .count());
+    assertTrue(allDisabledEventFactory.collectEvents().isEmpty());
+  }
+
+  private void assertDeadlock(boolean isMonitor, int expected) throws InterruptedException {
+    String classifier = isMonitor ? "monitor" : "lock";
+
+    List<? extends Event> events =
+        eventFactory.collectEvents().stream()
+            .filter(
+                e -> {
+                  if (e instanceof DeadlockedThreadEvent) {
+                    return ((DeadlockedThreadEvent) e).getThreadName().contains(classifier);
+                  }
+                  return true;
+                })
+            .collect(Collectors.toList());
+
+    assertNotNull(events);
+    assertEquals(3, events.size()); // 1 deadlock event + 2 deadlocked thread events in that order
+    assertEquals(DeadlockEvent.class, events.get(0).getClass());
+    assertEquals(DeadlockedThreadEvent.class, events.get(1).getClass());
+    assertEquals(DeadlockedThreadEvent.class, events.get(2).getClass());
+
+    DeadlockEvent deadlockEvent = (DeadlockEvent) events.get(0);
+    assertNotEquals(Long.MIN_VALUE, deadlockEvent.getId());
+    assertEquals(expected, deadlockEvent.getThreadCount());
+
+    long eventId = deadlockEvent.getId();
+
+    DeadlockedThreadEvent threadEvent1 = (DeadlockedThreadEvent) events.get(1);
+    DeadlockedThreadEvent threadEvent2 = (DeadlockedThreadEvent) events.get(2);
+
+    assertEquals(classifier + "-thread-A", threadEvent1.getThreadName());
+    assertEquals(classifier + "-thread-B", threadEvent1.getLockOwnerThreadName());
+    assertEquals(eventId, threadEvent1.getId());
+    assertEquals(threadEvent1.getLockOwnerThreadName(), threadEvent2.getThreadName());
+    if (isMonitor) {
+      assertNotNull(threadEvent1.getLockingFrame());
+    } else {
+      assertNull(threadEvent1.getLockingFrame());
+    }
+    assertNotNull(threadEvent1.getWaitingFrame());
+
+    assertEquals(classifier + "-thread-B", threadEvent2.getThreadName());
+    assertEquals(classifier + "-thread-A", threadEvent2.getLockOwnerThreadName());
+    assertEquals(eventId, threadEvent2.getId());
+    assertEquals(threadEvent1.getLockOwnerThreadName(), threadEvent2.getThreadName());
+    if (isMonitor) {
+      assertNotNull(threadEvent2.getLockingFrame());
+    } else {
+      assertNull(threadEvent2.getLockingFrame());
+    }
+    assertNotNull(threadEvent2.getWaitingFrame());
+  }
+
+  private void assertNoDeadlocks() {
+    // no deadlocks
+    assertTrue(eventFactory.collectEvents().isEmpty());
+  }
+
+  private static int setupMonitorDeadlock() throws InterruptedException {
+    // it is much easier to provoke a deadlock than mock all the JMX machinery
+    Phaser phaser = new Phaser(3);
+    Object lockA = new Object();
+    Object lockB = new Object();
+
+    Thread threadA =
+        new Thread(
+            () -> {
+              synchronized (lockA) {
+                phaser.arriveAndAwaitAdvance(); // sync such as cross-order locking is provoked
+                synchronized (lockB) {
+                  phaser.arriveAndDeregister(); // virtually unreachable
+                }
+              }
+            },
+            "monitor-thread-A");
+    Thread threadB =
+        new Thread(
+            () -> {
+              synchronized (lockB) {
+                phaser.arriveAndAwaitAdvance(); // sync such as cross-order locking is provoked
+                synchronized (lockA) {
+                  phaser.arriveAndDeregister(); // virtually unreachable
+                }
+              }
+            },
+            "monitor-thread-B");
+    threadA.setDaemon(true);
+    threadB.setDaemon(true);
+
+    CountDownLatch latch = new CountDownLatch(1);
+    Thread main =
+        new Thread(
+            () -> {
+              threadA.start();
+              threadB.start();
+              phaser.arriveAndAwaitAdvance(); // enter deadlock
+              phaser.arriveAndAwaitAdvance(); // unreachable if deadlock is present
+              latch.countDown();
+            },
+            "main-monitor-thread");
+    main.setDaemon(true);
+
+    main.start();
+
+    if (latch.await(500, TimeUnit.MILLISECONDS)) {
+      fail("Unable to create deadlock");
+    }
+    return 2;
+  }
+
+  private static int setupSynchronizableDeadlock() throws InterruptedException {
+    // it is much easier to provoke a deadlock than mock all the JMX machinery
+    Phaser phaser = new Phaser(3);
+    Lock lockA = new ReentrantLock();
+    Lock lockB = new ReentrantLock();
+
+    Thread threadA =
+        new Thread(
+            () -> {
+              lockA.lock();
+              try {
+                phaser.arriveAndAwaitAdvance(); // sync such as cross-order locking is provoked
+                lockB.lock();
+                try {
+                  phaser.arriveAndDeregister(); // virtually unreachable
+                } finally {
+                  lockB.unlock();
+                }
+              } finally {
+                lockA.unlock();
+              }
+            },
+            "lock-thread-A");
+    Thread threadB =
+        new Thread(
+            () -> {
+              lockB.lock();
+              try {
+                phaser.arriveAndAwaitAdvance(); // sync such as cross-order locking is provoked
+                lockA.lock();
+                try {
+                  phaser.arriveAndDeregister(); // virtually unreachable
+                } finally {
+                  lockA.unlock();
+                }
+              } finally {
+                lockB.unlock();
+              }
+            },
+            "lock-thread-B");
+    threadA.setDaemon(true);
+    threadB.setDaemon(true);
+
+    CountDownLatch latch = new CountDownLatch(1);
+    Thread main =
+        new Thread(
+            () -> {
+              threadA.start();
+              threadB.start();
+              phaser.arriveAndAwaitAdvance(); // enter deadlock
+              phaser.arriveAndAwaitAdvance(); // unreachable if deadlock is present
+              latch.countDown();
+            },
+            "main-lock-thread");
+    main.setDaemon(true);
+
+    main.start();
+
+    if (latch.await(500, TimeUnit.MILLISECONDS)) {
+      fail("Unable to create deadlock");
+    }
+
+    return 2;
+  }
+}

--- a/dd-smoke-tests/profiling-integration-tests/src/test/groovy/datadog/smoketest/AbstractProfilingIntegrationTest.groovy
+++ b/dd-smoke-tests/profiling-integration-tests/src/test/groovy/datadog/smoketest/AbstractProfilingIntegrationTest.groovy
@@ -1,5 +1,6 @@
 package datadog.smoketest
 
+import datadog.trace.api.config.ProfilingConfig
 import okhttp3.mockwebserver.MockWebServer
 import spock.lang.Shared
 
@@ -11,9 +12,12 @@ abstract class AbstractProfilingIntegrationTest extends AbstractSmokeTest {
   ProcessBuilder createProcessBuilder() {
     String profilingShadowJar = System.getProperty("datadog.smoketest.profiling.shadowJar.path")
 
+    String templateOverride = AbstractProfilingIntegrationTest.getClassLoader().getResource("overrides.jfp").getFile()
+
     List<String> command = new ArrayList<>()
     command.add(javaPath())
     command.addAll(defaultJavaProperties)
+    command.addAll((String[]) ["-Ddd.${ProfilingConfig.PROFILING_TEMPLATE_OVERRIDE_FILE}=${templateOverride}"])
     command.addAll((String[]) ["-jar", profilingShadowJar])
     command.add(Integer.toString(exitDelay))
     ProcessBuilder processBuilder = new ProcessBuilder(command)

--- a/dd-smoke-tests/profiling-integration-tests/src/test/groovy/datadog/smoketest/ProfilingIntegrationContinuousProfilesTest.groovy
+++ b/dd-smoke-tests/profiling-integration-tests/src/test/groovy/datadog/smoketest/ProfilingIntegrationContinuousProfilesTest.groovy
@@ -91,7 +91,5 @@ class ProfilingIntegrationContinuousProfilesTest extends AbstractProfilingIntegr
     // check deadlock events
     events.apply(ItemFilters.type("datadog.Deadlock")).hasItems()
     events.apply(ItemFilters.type("datadog.DeadlockedThread")).hasItems()
-
-    Thread.sleep(120000)
   }
 }

--- a/dd-smoke-tests/profiling-integration-tests/src/test/groovy/datadog/smoketest/ProfilingIntegrationContinuousProfilesTest.groovy
+++ b/dd-smoke-tests/profiling-integration-tests/src/test/groovy/datadog/smoketest/ProfilingIntegrationContinuousProfilesTest.groovy
@@ -80,11 +80,18 @@ class ProfilingIntegrationContinuousProfilesTest extends AbstractProfilingIntegr
     // filter out scope events without CPU time data
     def filteredScopeEvents = scopeEvents.apply(ItemFilters.more(cpuTimeAttr, UnitLookup.NANOSECOND.quantity(Long.MIN_VALUE)))
     // make sure there is at least one scope event with CPU time data
-    filteredScopeEvents.size() > 0
+    filteredScopeEvents.hasItems()
 
     filteredScopeEvents.getAggregate(Aggregators.min("datadog.Scope", cpuTimeAttr)).longValue() >= 10_000L
 
-    IItemCollection exceptionSampleEvents = events.apply(ItemFilters.type("datadog.ExceptionSample"))
-    exceptionSampleEvents.size() > 0
+    // check exception events
+    events.apply(ItemFilters.type("datadog.ExceptionSample")).hasItems()
+    events.apply(ItemFilters.type("datadog.ExceptionCount")).hasItems()
+
+    // check deadlock events
+    events.apply(ItemFilters.type("datadog.Deadlock")).hasItems()
+    events.apply(ItemFilters.type("datadog.DeadlockedThread")).hasItems()
+
+    Thread.sleep(120000)
   }
 }

--- a/dd-smoke-tests/profiling-integration-tests/src/test/resources/overrides.jfp
+++ b/dd-smoke-tests/profiling-integration-tests/src/test/resources/overrides.jfp
@@ -1,0 +1,1 @@
+datadog.Deadlock#period=1 s


### PR DESCRIPTION
Periodically check for deadlocked threads using JMX `ThreadMXBean` and emit a series of events describing the locking cycle. 

Unfortunately, JFR user (Java) definable events do not support any non-scalar attributes and as such the list of affected threads had to be decomposed into a list of separate events. 

Additionally, it also makes it impossible to capture the full stack trace of threads in dead-lock so the information must be extracted and only the locker-waiter frames are reported if available (j.u.concurrent locks do not provide info about which frame locked them).

In addition to unit tests the profiling smoke test was extended to have a guaranteed deadlock and the test recording is then asserted for the presence of the deadlock related events.