### PR TITLE
switch microseconds to nanoseconds

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/BaseDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/BaseDecorator.java
@@ -1,6 +1,6 @@
 package datadog.trace.bootstrap.instrumentation.decorator;
 
-import static java.util.concurrent.TimeUnit.MICROSECONDS;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 import datadog.trace.api.Config;
 import datadog.trace.api.DDTags;
@@ -69,7 +69,7 @@ public abstract class BaseDecorator {
     if (endToEndDurationsEnabled) {
       if (null == span.getBaggageItem(DDTags.TRACE_START_TIME)) {
         span.setBaggageItem(
-            DDTags.TRACE_START_TIME, Long.toString(MICROSECONDS.toMillis(span.getStartTime())));
+            DDTags.TRACE_START_TIME, Long.toString(NANOSECONDS.toMillis(span.getStartTime())));
       }
     }
     return span;


### PR DESCRIPTION
span.getTime() function looks to be inherited from MutableSpan which produces a [Nanosecond value](https://github.com/DataDog/dd-trace-java/blob/master/dd-trace-api/src/main/java/datadog/trace/api/interceptor/MutableSpan.java#L7-L8)
Changing the converter for setting the start time so it is properly converted otherwise all e2e value calculations end up being 0