### PR TITLE
Automatic service naming

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/env/CapturedEnvironment.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/env/CapturedEnvironment.java
@@ -55,7 +55,7 @@ public class CapturedEnvironment {
 
     final String candidate = split[0];
     if (candidate.endsWith(".jar")) {
-      return new File(candidate).getName();
+      return new File(candidate).getName().replace(".jar", "");
     }
 
     return candidate;

--- a/dd-trace-api/src/main/java/datadog/trace/api/env/CapturedEnvironment.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/env/CapturedEnvironment.java
@@ -1,0 +1,74 @@
+package datadog.trace.api.env;
+
+import datadog.trace.api.config.GeneralConfig;
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * The {@code CapturedEnvironment} instance keeps those {@code Config} values which are platform
+ * dependant.
+ */
+@Slf4j
+public class CapturedEnvironment {
+
+  private static final CapturedEnvironment INSTANCE = new CapturedEnvironment();
+
+  @Getter private final Map<String, String> properties;
+
+  CapturedEnvironment() {
+    properties = new HashMap<>();
+    properties.put(GeneralConfig.SERVICE_NAME, autodetectServiceName());
+  }
+
+  // Testing purposes
+  static void useFixedEnv(final Map<String, String> props) {
+    INSTANCE.properties.clear();
+
+    for (final Map.Entry<String, String> entry : props.entrySet()) {
+      INSTANCE.properties.put(entry.getKey(), entry.getValue());
+    }
+  }
+
+  /**
+   * Returns autodetected service name based on the java process command line. Typically, the
+   * autodetection will return either the JAR filename or the java main class.
+   */
+  private String autodetectServiceName() {
+    if (System.getenv("JAVA_MAIN_CLASS") != null) {
+      return System.getenv("JAVA_MAIN_CLASS");
+    }
+
+    // Oracle JDKs
+    if (System.getProperty("sun.java.command") != null) {
+      return extractJarOrClass(System.getProperty("sun.java.command"));
+    }
+
+    // TODO Others JDKs
+    return null;
+  }
+
+  private String extractJarOrClass(final String command) {
+    if (command == null || command.equals("")) {
+      return null;
+    }
+
+    final String[] split = command.split(" ");
+    if (split.length < 1 || split[0] == null || split[0].equals("")) {
+      return null;
+    }
+
+    final String candidate = split[0];
+    if (candidate.endsWith(".jar")) {
+      return new File(candidate).getName();
+    }
+
+    return candidate;
+  }
+
+  public static CapturedEnvironment get() {
+    return INSTANCE;
+  }
+}

--- a/dd-trace-api/src/main/java/datadog/trace/api/env/CapturedEnvironment.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/env/CapturedEnvironment.java
@@ -37,16 +37,13 @@ public class CapturedEnvironment {
    * autodetection will return either the JAR filename or the java main class.
    */
   private String autodetectServiceName() {
-    if (System.getenv("JAVA_MAIN_CLASS") != null) {
-      return System.getenv("JAVA_MAIN_CLASS");
-    }
-
-    // Oracle JDKs
+    // Besides "sun.java.command" property is not an standard, all main JDKs has set this property.
+    // Tested on:
+    // - OracleJDK, OpenJDK, AdoptOpenJDK, IBM JDK, Azul Zulu JDK, Amazon Coretto JDK
     if (System.getProperty("sun.java.command") != null) {
       return extractJarOrClass(System.getProperty("sun.java.command"));
     }
 
-    // TODO Others JDKs
     return null;
   }
 
@@ -55,8 +52,8 @@ public class CapturedEnvironment {
       return null;
     }
 
-    final String[] split = command.split(" ");
-    if (split.length < 1 || split[0] == null || split[0].equals("")) {
+    final String[] split = command.trim().split(" ");
+    if (split.length < 1 || split[0].equals("")) {
       return null;
     }
 

--- a/dd-trace-api/src/main/java/datadog/trace/api/env/CapturedEnvironment.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/env/CapturedEnvironment.java
@@ -40,11 +40,7 @@ public class CapturedEnvironment {
     // Besides "sun.java.command" property is not an standard, all main JDKs has set this property.
     // Tested on:
     // - OracleJDK, OpenJDK, AdoptOpenJDK, IBM JDK, Azul Zulu JDK, Amazon Coretto JDK
-    if (System.getProperty("sun.java.command") != null) {
-      return extractJarOrClass(System.getProperty("sun.java.command"));
-    }
-
-    return null;
+    return extractJarOrClass(System.getProperty("sun.java.command"));
   }
 
   private String extractJarOrClass(final String command) {
@@ -53,7 +49,7 @@ public class CapturedEnvironment {
     }
 
     final String[] split = command.trim().split(" ");
-    if (split.length < 1 || split[0].equals("")) {
+    if (split.length == 0 || split[0].equals("")) {
       return null;
     }
 

--- a/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -651,15 +651,61 @@ class ConfigTest extends DDSpecification {
 
   def "captured env props override default props"() {
     setup:
-    Properties properties = new Properties()
-    properties.setProperty(SERVICE_NAME, "automatic service name")
-    fixedCapturedEnvironment.load(properties)
+    def capturedEnv = new HashMap<String, String>()
+    capturedEnv.put(SERVICE_NAME, "automatic service name")
+    fixedCapturedEnvironment.load(capturedEnv)
 
     when:
     def config = new Config()
 
     then:
     config.serviceName == "automatic service name"
+  }
+
+  def "specify props override captured env props"() {
+    setup:
+    def prop = new Properties()
+    prop.setProperty(SERVICE_NAME, "what actually wants")
+
+    def capturedEnv = new HashMap<String, String>()
+    capturedEnv.put(SERVICE_NAME, "something else")
+    fixedCapturedEnvironment.load(capturedEnv)
+
+    when:
+    def config = Config.get(prop)
+
+    then:
+    config.serviceName == "what actually wants"
+  }
+
+  def "sys props override captured env props"() {
+    setup:
+    System.setProperty(PREFIX + SERVICE_NAME, "what actually wants")
+
+    def capturedEnv = new HashMap<String, String>()
+    capturedEnv.put(SERVICE_NAME, "something else")
+    fixedCapturedEnvironment.load(capturedEnv)
+
+    when:
+    def config = new Config()
+
+    then:
+    config.serviceName == "what actually wants"
+  }
+
+  def "env vars override captured env props"() {
+    setup:
+    environmentVariables.set(DD_SERVICE_NAME_ENV, "what actually wants")
+
+    def capturedEnv = new HashMap<String, String>()
+    capturedEnv.put(SERVICE_NAME, "something else")
+    fixedCapturedEnvironment.load(capturedEnv)
+
+    when:
+    def config = new Config()
+
+    then:
+    config.serviceName == "what actually wants"
   }
 
   def "verify integration config"() {

--- a/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -1498,6 +1498,30 @@ class ConfigTest extends DDSpecification {
                              'service.version': 'my-svc-vers']
   }
 
+  def "set servicename by autodetection with class"() {
+    setup:
+    System.setProperty("DDSpecification", "")
+    System.setProperty("sun.java.command", "org.example.App arg1 arg2 arg3")
+
+    when:
+    def config = new Config()
+
+    then:
+    config.serviceName == "org.example.App"
+  }
+
+  def "set servicename by autodetection with jar"() {
+    setup:
+    System.setProperty("DDSpecification", "")
+    System.setProperty("sun.java.command", "foo/bar/example.jar arg1 arg2 arg3")
+
+    when:
+    def config = new Config()
+
+    then:
+    config.serviceName == "example.jar"
+  }
+
   // Static methods test:
   def "getProperty*Value unit test"() {
     setup:

--- a/dd-trace-api/src/test/groovy/datadog/trace/api/env/CapturedEnvironmentTest.groovy
+++ b/dd-trace-api/src/test/groovy/datadog/trace/api/env/CapturedEnvironmentTest.groovy
@@ -67,7 +67,7 @@ class CapturedEnvironmentTest extends DDSpecification {
 
     then:
     def props = capturedEnv.properties
-    props.get(GeneralConfig.SERVICE_NAME) == "example.jar"
+    props.get(GeneralConfig.SERVICE_NAME) == "example"
   }
 
   def "set service.name with real 'sun.java.command' property"() {

--- a/dd-trace-api/src/test/groovy/datadog/trace/api/env/CapturedEnvironmentTest.groovy
+++ b/dd-trace-api/src/test/groovy/datadog/trace/api/env/CapturedEnvironmentTest.groovy
@@ -1,0 +1,66 @@
+package datadog.trace.api.env
+
+import datadog.trace.api.config.GeneralConfig
+import datadog.trace.util.test.DDSpecification
+import org.junit.Rule
+import org.junit.contrib.java.lang.system.EnvironmentVariables
+import org.junit.contrib.java.lang.system.RestoreSystemProperties
+
+class CapturedEnvironmentTest extends DDSpecification {
+
+  @Rule
+  public final RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties()
+
+  @Rule
+  public final EnvironmentVariables environmentVariables = new EnvironmentVariables()
+
+  def "non autodetected servicename"() {
+    setup:
+    System.setProperty("sun.java.command", "")
+    environmentVariables.set("JAVA_MAIN_CLASS", null)
+
+    when:
+    def capturedEnv = new CapturedEnvironment()
+
+    then:
+    def props = capturedEnv.properties
+    props.get(GeneralConfig.SERVICE_NAME) == null
+  }
+
+  def "set servicename by env var JAVA_MAIN_CLASS"() {
+    setup:
+    environmentVariables.set("JAVA_MAIN_CLASS", "org.example.App")
+
+    when:
+    def capturedEnv = new CapturedEnvironment()
+
+    then:
+    def props = capturedEnv.properties
+    props.get(GeneralConfig.SERVICE_NAME) == "org.example.App"
+  }
+
+  def "set servicename by sysprop 'sun.java.command' with class"() {
+    setup:
+    System.setProperty("sun.java.command", "org.example.App arg1 arg2 arg3")
+
+    when:
+    def capturedEnv = new CapturedEnvironment()
+
+    then:
+    def props = capturedEnv.properties
+    props.get(GeneralConfig.SERVICE_NAME) == "org.example.App"
+  }
+
+  def "set servicename by sysprop 'sun.java.command' with jar"() {
+    setup:
+    System.setProperty("sun.java.command", "foo/bar/example.jar arg1 arg2 arg3")
+
+    when:
+    def capturedEnv = new CapturedEnvironment()
+
+    then:
+    def props = capturedEnv.properties
+    props.get(GeneralConfig.SERVICE_NAME) == "example.jar"
+  }
+
+}

--- a/dd-trace-api/src/test/groovy/datadog/trace/api/env/FixedCapturedEnvironment.java
+++ b/dd-trace-api/src/test/groovy/datadog/trace/api/env/FixedCapturedEnvironment.java
@@ -1,0 +1,26 @@
+package datadog.trace.api.env;
+
+import java.util.Collections;
+import java.util.Map;
+import org.junit.rules.ExternalResource;
+
+/**
+ * The {@code FixedCapturedEnvironment} rule cleans the {@code CapturedEnvironment} instance when
+ * the test starts. Additionally, this rule can be used to set fixed properties into that {@code
+ * CapturedEnvironment} instance. This is useful to be deterministic in those tests that are testing
+ * logic which interacts with {@code CapturedEnvironment} instance, because that object returns
+ * properties which are platform dependant (JDK, OS, etc...)
+ */
+public class FixedCapturedEnvironment extends ExternalResource {
+
+  @Override
+  protected void before() throws Throwable {
+    // Clean CapturedEnvironment instance when test starts.
+    CapturedEnvironment.useFixedEnv(Collections.<String, String>emptyMap());
+  }
+
+  /** Load properties instance into the {@code CapturedEnvironment} instance. */
+  public void load(final Map<String, String> properties) {
+    CapturedEnvironment.useFixedEnv(properties);
+  }
+}

--- a/utils/test-utils/src/main/groovy/datadog/trace/util/test/DDSpecification.groovy
+++ b/utils/test-utils/src/main/groovy/datadog/trace/util/test/DDSpecification.groovy
@@ -17,6 +17,7 @@ abstract class DDSpecification extends Specification {
 
   static {
     makeConfigInstanceModifiable()
+    System.setProperty("DDSpecification", "true")
   }
 
   // Keep track of config instance already made modifiable

--- a/utils/test-utils/src/main/groovy/datadog/trace/util/test/DDSpecification.groovy
+++ b/utils/test-utils/src/main/groovy/datadog/trace/util/test/DDSpecification.groovy
@@ -14,10 +14,11 @@ import static net.bytebuddy.matcher.ElementMatchers.none
 
 abstract class DDSpecification extends Specification {
   private static final String CONFIG = "datadog.trace.api.Config"
+  private static final String CAPTURED_ENV = "datadog.trace.api.env.CapturedEnvironment"
 
   static {
     makeConfigInstanceModifiable()
-    System.setProperty("DDSpecification", "true")
+    cleanCapturedEnvironment()
   }
 
   // Keep track of config instance already made modifiable
@@ -51,5 +52,20 @@ abstract class DDSpecification extends Specification {
       }
       .installOn(instrumentation)
     isConfigInstanceModifiable = true
+  }
+
+  //Clean captured environment to avoid affecting Config settings with platform dependant properties.
+  static void cleanCapturedEnvironment() {
+    try {
+      def capturedEnvClass = this.getClassLoader().loadClass(CAPTURED_ENV)
+      def capturedEnvField = capturedEnvClass.getDeclaredField("INSTANCE")
+      capturedEnvField.setAccessible(true)
+
+      def propsField = capturedEnvClass.getDeclaredField("properties")
+      propsField.setAccessible(true)
+      propsField.set(capturedEnvField.get(null), new HashMap<String, String>())
+    } catch (final ClassNotFoundException ignored) {
+      //If CapturedEnvironment class is not found, no actions needed.
+    }
   }
 }


### PR DESCRIPTION
As first approach, it will be consider either the JAR name or the main class name as substitute of the current `unnamed-java-service`, in case that this info could be calculated.

This PR has two parts:
1) Modification of the `Config`: Added a new step in the `getSettingFromEnvironment` to check if the requested property was set in the `CapturedEnvironment` properties.
2) Creation of the `CapturedEnvironment`: This class should keep all environment properties which are platform dependant. In this particular case, the Java System Property `sun.java.command` will be used to obtain the JAR/Main Class information.
Besides this property is not a standard, all main JDKs has set this property.
Tested on: `OracleJDK`, `OpenJDK`, `AdoptOpenJDK`, `IBM JDK`, `Azul Zulu JDK`, `Amazon Coretto JDK`

**Example**:
If the property `sun.java.command` returns `user/app/user-app.jar arg1 arg2 arg3` should set `user-app` as `service.name`.

Finally, it is needed to clean `CapturedEnvironment` properties at `DDSpecification` startup to avoid polluting `Config` settings with platform dependant properties which may affect instrumentation tests that assert `service.name == "unnamed-java-service"`. 