### PR TITLE
Handle null header values

### DIFF
--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TextMapExtractAdapter.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TextMapExtractAdapter.java
@@ -26,6 +26,9 @@ public class TextMapExtractAdapter implements AgentPropagation.Getter<Headers> {
     if (header == null) {
       return null;
     }
+    if (header.value() == null) {
+      return null;
+    }
     return new String(header.value(), StandardCharsets.UTF_8);
   }
 }

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/TextMapExtractAdapter.java
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/TextMapExtractAdapter.java
@@ -26,6 +26,9 @@ public class TextMapExtractAdapter implements AgentPropagation.Getter<Headers> {
     if (header == null) {
       return null;
     }
+    if (header.value() == null) {
+      return null;
+    }
     return new String(header.value(), StandardCharsets.UTF_8);
   }
 }


### PR DESCRIPTION
Based on the issue here: https://github.com/DataDog/dd-trace-java/issues/1631

Tested on our side, worked fine then: no more error, tracing is working on the service (we can see metrics in Datadog like trace.kafka.consume.duration)