### PR TITLE
ignore micronaut tracing classes

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/GlobalIgnoresMatcher.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/GlobalIgnoresMatcher.java
@@ -103,6 +103,9 @@ public class GlobalIgnoresMatcher<T extends TypeDescription>
       case 'h' - 'a':
         break;
       case 'i' - 'a':
+        if (name.startsWith("io.micronaut.tracing.")) {
+          return true;
+        }
         break;
       case 'j' - 'a':
         if (name.startsWith("jdk.")) {


### PR DESCRIPTION
Prevents the tracer from failing to instrument when micronaut tracing is present.