### PR TITLE
Move the StatsDClient into CoreTracer

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -460,9 +460,25 @@ acceptedBreaks:
   "0.56.0":
     com.datadoghq:dd-trace-ot:
     - code: "java.class.removed"
+      old: "class datadog.trace.common.writer.Writer.Builder"
+      justification: "DDWriter's builder should be used directly "
+    - code: "java.class.removed"
+      old: "class datadog.trace.common.writer.ddagent.Monitor.Noop"
+      justification: "internal API. NoOp enforced through statsd client"
+    - code: "java.class.removed"
+      old: "class datadog.trace.common.writer.ddagent.Monitor.StatsD"
+      justification: "internal API. NoOp enforced through statsd client"
+    - code: "java.class.removed"
       old: "class datadog.trace.core.util.FixedSizeCache<K extends java.lang.Object,\
         \ V extends java.lang.Object>"
       justification: "INTERNAL API"
+    - code: "java.method.removed"
+      old: "method void datadog.trace.common.writer.DDAgentWriter::<init>()"
+      justification: "Deprecated.  Builder should be used instead"
+    - code: "java.method.removed"
+      old: "method void datadog.trace.common.writer.DDAgentWriter::<init>(datadog.trace.common.writer.ddagent.DDAgentApi,\
+        \ datadog.trace.common.writer.ddagent.Monitor)"
+      justification: "Internal.  Only used for tests"
     - code: "java.method.removed"
       old: "method void datadog.trace.core.serialization.FormatWriter<DEST>::writeNumberAsString(byte[],\
         \ java.lang.Number, DEST) throws java.io.IOException"

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/Writer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/Writer.java
@@ -1,15 +1,8 @@
 package datadog.trace.common.writer;
 
-import datadog.trace.api.Config;
-import datadog.trace.bootstrap.instrumentation.api.WriterConstants;
-import datadog.trace.common.writer.ddagent.DDAgentApi;
-import datadog.trace.common.writer.ddagent.Monitor;
 import datadog.trace.core.DDSpan;
 import java.io.Closeable;
 import java.util.List;
-import java.util.Properties;
-import java.util.concurrent.TimeUnit;
-import lombok.extern.slf4j.Slf4j;
 
 /** A writer is responsible to send collected spans to some place */
 public interface Writer extends Closeable {
@@ -33,74 +26,4 @@ public interface Writer extends Closeable {
 
   /** Count that a trace was captured for stats, but without reporting it. */
   void incrementTraceCount();
-
-  @Slf4j
-  final class Builder {
-
-    public static Writer forConfig(final Config config) {
-      final Writer writer;
-
-      if (config != null) {
-        final String configuredType = config.getWriterType();
-        if (WriterConstants.DD_AGENT_WRITER_TYPE.equals(configuredType)) {
-          writer = createAgentWriter(config);
-        } else if (WriterConstants.LOGGING_WRITER_TYPE.equals(configuredType)) {
-          writer = new LoggingWriter();
-        } else {
-          log.warn(
-              "Writer type not configured correctly: Type {} not recognized. Defaulting to DDAgentWriter.",
-              configuredType);
-          writer = createAgentWriter(config);
-        }
-      } else {
-        log.warn(
-            "Writer type not configured correctly: No config provided! Defaulting to DDAgentWriter.");
-        writer = DDAgentWriter.builder().build();
-      }
-
-      return writer;
-    }
-
-    public static Writer forConfig(final Properties config) {
-      return forConfig(Config.get(config));
-    }
-
-    private static Writer createAgentWriter(final Config config) {
-      return DDAgentWriter.builder()
-          .agentApi(createApi(config))
-          .monitor(createMonitor(config))
-          .build();
-    }
-
-    private static DDAgentApi createApi(final Config config) {
-      return new DDAgentApi(
-          config.getAgentHost(),
-          config.getAgentPort(),
-          config.getAgentUnixDomainSocket(),
-          TimeUnit.SECONDS.toMillis(config.getAgentTimeout()));
-    }
-
-    private static Monitor createMonitor(final Config config) {
-      if (!config.isHealthMetricsEnabled()) {
-        return new Monitor.Noop();
-      } else {
-        String host = config.getHealthMetricsStatsdHost();
-        if (host == null) {
-          host = config.getJmxFetchStatsdHost();
-        }
-        if (host == null) {
-          host = config.getAgentHost();
-        }
-
-        Integer port = config.getHealthMetricsStatsdPort();
-        if (port == null) {
-          port = config.getJmxFetchStatsdPort();
-        }
-
-        return new Monitor.StatsD(host, port);
-      }
-    }
-
-    private Builder() {}
-  }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/Monitor.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/Monitor.java
@@ -1,15 +1,13 @@
 package datadog.trace.common.writer.ddagent;
 
-import com.timgroup.statsd.NonBlockingStatsDClient;
 import com.timgroup.statsd.StatsDClient;
 import datadog.trace.common.writer.DDAgentWriter;
 import datadog.trace.core.DDSpan;
-import datadog.trace.core.DDTraceCoreInfo;
 import java.util.List;
 
 /**
- * Callback interface for monitoring the health of the DDAgentWriter. Provides hooks for major
- * lifecycle events...
+ * Callback for monitoring the health of the DDAgentWriter. Provides hooks for major lifecycle
+ * events...
  *
  * <ul>
  *   <li>start
@@ -19,227 +17,85 @@ import java.util.List;
  *   <li>sending to agent
  * </ul>
  */
-public interface Monitor {
-  void onStart(final DDAgentWriter agentWriter);
+public class Monitor {
+  private final StatsDClient statsd;
 
-  void onShutdown(final DDAgentWriter agentWriter, final boolean flushSuccess);
-
-  void onPublish(final DDAgentWriter agentWriter, final List<DDSpan> trace);
-
-  void onFailedPublish(final DDAgentWriter agentWriter, final List<DDSpan> trace);
-
-  void onFlush(final DDAgentWriter agentWriter, final boolean early);
-
-  void onScheduleFlush(final DDAgentWriter agentWriter, final boolean previousIncomplete);
-
-  void onBackedUpTraceBuffer();
-
-  void onSerialize(
-      final DDAgentWriter agentWriter, final List<DDSpan> trace, final int serializedSizeInBytes);
-
-  void onFailedSerialize(
-      final DDAgentWriter agentWriter, final List<DDSpan> trace, final Throwable optionalCause);
-
-  void onSend(
-      final DDAgentWriter agentWriter,
-      final int representativeCount,
-      final int sizeInBytes,
-      final DDAgentApi.Response response);
-
-  void onFailedSend(
-      final DDAgentWriter agentWriter,
-      final int representativeCount,
-      final int sizeInBytes,
-      final DDAgentApi.Response response);
-
-  final class StatsD implements Monitor {
-    public static final String PREFIX = "datadog.tracer";
-
-    public static final String LANG_TAG = "lang";
-    public static final String LANG_VERSION_TAG = "lang_version";
-    public static final String LANG_INTERPRETER_TAG = "lang_interpreter";
-    public static final String LANG_INTERPRETER_VENDOR_TAG = "lang_interpreter_vendor";
-    public static final String TRACER_VERSION_TAG = "tracer_version";
-
-    private final String hostInfo;
-    private final StatsDClient statsd;
-
-    // DQH - Made a conscious choice to not take a Config object here.
-    // Letting the creating of the Monitor take the Config,
-    // so it can decide which Monitor variant to create.
-    public StatsD(final String host, final int port) {
-      hostInfo = host + ":" + port;
-      statsd = new NonBlockingStatsDClient(PREFIX, host, port, getDefaultTags());
-    }
-
-    // Currently, intended for testing
-    private StatsD(final StatsDClient statsd) {
-      hostInfo = null;
-      this.statsd = statsd;
-    }
-
-    protected static final String[] getDefaultTags() {
-      return new String[] {
-        tag(LANG_TAG, "java"),
-        tag(LANG_VERSION_TAG, DDTraceCoreInfo.JAVA_VERSION),
-        tag(LANG_INTERPRETER_TAG, DDTraceCoreInfo.JAVA_VM_NAME),
-        tag(LANG_INTERPRETER_VENDOR_TAG, DDTraceCoreInfo.JAVA_VM_VENDOR),
-        tag(TRACER_VERSION_TAG, DDTraceCoreInfo.VERSION)
-      };
-    }
-
-    private static String tag(final String tagPrefix, final String tagValue) {
-      return tagPrefix + ":" + tagValue;
-    }
-
-    @Override
-    public void onStart(final DDAgentWriter agentWriter) {
-      statsd.recordGaugeValue("queue.max_length", agentWriter.getDisruptorCapacity());
-    }
-
-    @Override
-    public void onShutdown(final DDAgentWriter agentWriter, final boolean flushSuccess) {}
-
-    @Override
-    public void onPublish(final DDAgentWriter agentWriter, final List<DDSpan> trace) {
-      statsd.incrementCounter("queue.accepted");
-      statsd.count("queue.accepted_lengths", trace.size());
-    }
-
-    @Override
-    public void onFailedPublish(final DDAgentWriter agentWriter, final List<DDSpan> trace) {
-      statsd.incrementCounter("queue.dropped");
-    }
-
-    @Override
-    public void onScheduleFlush(final DDAgentWriter agentWriter, final boolean previousIncomplete) {
-      // not recorded
-    }
-
-    @Override
-    public void onBackedUpTraceBuffer() {
-      statsd.incrementCounter("trace.buffer.backlog");
-    }
-
-    @Override
-    public void onFlush(final DDAgentWriter agentWriter, final boolean early) {}
-
-    @Override
-    public void onSerialize(
-        final DDAgentWriter agentWriter,
-        final List<DDSpan> trace,
-        final int serializedSizeInBytes) {
-      // DQH - Because of Java tracer's 2 phase acceptance and serialization scheme, this doesn't
-      // map precisely
-      statsd.count("queue.accepted_size", serializedSizeInBytes);
-    }
-
-    @Override
-    public void onFailedSerialize(
-        final DDAgentWriter agentWriter, final List<DDSpan> trace, final Throwable optionalCause) {
-      // TODO - DQH - make a new stat for serialization failure -- or maybe count this towards
-      // api.errors???
-    }
-
-    @Override
-    public void onSend(
-        final DDAgentWriter agentWriter,
-        final int representativeCount,
-        final int sizeInBytes,
-        final DDAgentApi.Response response) {
-      onSendAttempt(agentWriter, representativeCount, sizeInBytes, response);
-    }
-
-    @Override
-    public void onFailedSend(
-        final DDAgentWriter agentWriter,
-        final int representativeCount,
-        final int sizeInBytes,
-        final DDAgentApi.Response response) {
-      onSendAttempt(agentWriter, representativeCount, sizeInBytes, response);
-    }
-
-    private void onSendAttempt(
-        final DDAgentWriter agentWriter,
-        final int representativeCount,
-        final int sizeInBytes,
-        final DDAgentApi.Response response) {
-      statsd.incrementCounter("api.requests");
-      statsd.recordGaugeValue("queue.length", representativeCount);
-      // TODO: missing queue.spans (# of spans being sent)
-      statsd.recordGaugeValue("queue.size", sizeInBytes);
-
-      if (response.exception() != null) {
-        // covers communication errors -- both not receiving a response or
-        // receiving malformed response (even when otherwise successful)
-        statsd.incrementCounter("api.errors");
-      }
-
-      if (response.status() != null) {
-        statsd.incrementCounter("api.responses", "status: " + response.status());
-      }
-    }
-
-    @Override
-    public String toString() {
-      if (hostInfo == null) {
-        return "StatsD";
-      } else {
-        return "StatsD { host=" + hostInfo + " }";
-      }
-    }
+  public Monitor(final StatsDClient statsd) {
+    this.statsd = statsd;
   }
 
-  final class Noop implements Monitor {
-    @Override
-    public void onStart(final DDAgentWriter agentWriter) {}
+  public void onStart(final DDAgentWriter agentWriter) {
+    statsd.recordGaugeValue("queue.max_length", agentWriter.getDisruptorCapacity());
+  }
 
-    @Override
-    public void onShutdown(final DDAgentWriter agentWriter, final boolean flushSuccess) {}
+  public void onShutdown(final DDAgentWriter agentWriter, final boolean flushSuccess) {}
 
-    @Override
-    public void onPublish(final DDAgentWriter agentWriter, final List<DDSpan> trace) {}
+  public void onPublish(final DDAgentWriter agentWriter, final List<DDSpan> trace) {
+    statsd.incrementCounter("queue.accepted");
+    statsd.count("queue.accepted_lengths", trace.size());
+  }
 
-    @Override
-    public void onFailedPublish(final DDAgentWriter agentWriter, final List<DDSpan> trace) {}
+  public void onFailedPublish(final DDAgentWriter agentWriter, final List<DDSpan> trace) {
+    statsd.incrementCounter("queue.dropped");
+  }
 
-    @Override
-    public void onFlush(final DDAgentWriter agentWriter, final boolean early) {}
+  public void onScheduleFlush(final DDAgentWriter agentWriter, final boolean previousIncomplete) {
+    // not recorded
+  }
 
-    @Override
-    public void onScheduleFlush(
-        final DDAgentWriter agentWriter, final boolean previousIncomplete) {}
+  public void onBackedUpTraceBuffer() {
+    statsd.incrementCounter("trace.buffer.backlog");
+  }
 
-    @Override
-    public void onBackedUpTraceBuffer() {}
+  public void onFlush(final DDAgentWriter agentWriter, final boolean early) {}
 
-    @Override
-    public void onSerialize(
-        final DDAgentWriter agentWriter,
-        final List<DDSpan> trace,
-        final int serializedSizeInBytes) {}
+  public void onSerialize(
+      final DDAgentWriter agentWriter, final List<DDSpan> trace, final int serializedSizeInBytes) {
+    // DQH - Because of Java tracer's 2 phase acceptance and serialization scheme, this doesn't
+    // map precisely
+    statsd.count("queue.accepted_size", serializedSizeInBytes);
+  }
 
-    @Override
-    public void onFailedSerialize(
-        final DDAgentWriter agentWriter, final List<DDSpan> trace, final Throwable optionalCause) {}
+  public void onFailedSerialize(
+      final DDAgentWriter agentWriter, final List<DDSpan> trace, final Throwable optionalCause) {
+    // TODO - DQH - make a new stat for serialization failure -- or maybe count this towards
+    // api.errors???
+  }
 
-    @Override
-    public void onSend(
-        final DDAgentWriter agentWriter,
-        final int representativeCount,
-        final int sizeInBytes,
-        final DDAgentApi.Response response) {}
+  public void onSend(
+      final DDAgentWriter agentWriter,
+      final int representativeCount,
+      final int sizeInBytes,
+      final DDAgentApi.Response response) {
+    onSendAttempt(agentWriter, representativeCount, sizeInBytes, response);
+  }
 
-    @Override
-    public void onFailedSend(
-        final DDAgentWriter agentWriter,
-        final int representativeCount,
-        final int sizeInBytes,
-        final DDAgentApi.Response response) {}
+  public void onFailedSend(
+      final DDAgentWriter agentWriter,
+      final int representativeCount,
+      final int sizeInBytes,
+      final DDAgentApi.Response response) {
+    onSendAttempt(agentWriter, representativeCount, sizeInBytes, response);
+  }
 
-    @Override
-    public String toString() {
-      return "NoOp";
+  private void onSendAttempt(
+      final DDAgentWriter agentWriter,
+      final int representativeCount,
+      final int sizeInBytes,
+      final DDAgentApi.Response response) {
+    statsd.incrementCounter("api.requests");
+    statsd.recordGaugeValue("queue.length", representativeCount);
+    // TODO: missing queue.spans (# of spans being sent)
+    statsd.recordGaugeValue("queue.size", sizeInBytes);
+
+    if (response.exception() != null) {
+      // covers communication errors -- both not receiving a response or
+      // receiving malformed response (even when otherwise successful)
+      statsd.incrementCounter("api.errors");
+    }
+
+    if (response.status() != null) {
+      statsd.incrementCounter("api.responses", "status: " + response.status());
     }
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -1,7 +1,7 @@
 package datadog.trace.core;
 
 import com.timgroup.statsd.NoOpStatsDClient;
-import com.timgroup.statsd.NonBlockingStatsDClientBuilder;
+import com.timgroup.statsd.NonBlockingStatsDClient;
 import com.timgroup.statsd.StatsDClient;
 import datadog.trace.api.Config;
 import datadog.trace.api.DDId;
@@ -522,11 +522,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
             statsdTag(TRACER_VERSION_STATSD_TAG, DDTraceCoreInfo.VERSION)
           };
 
-      return new NonBlockingStatsDClientBuilder()
-          .hostname(host)
-          .port(port)
-          .constantTags(constantTags)
-          .build();
+      return new NonBlockingStatsDClient("datadog.tracer", host, port, constantTags);
     }
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -195,10 +195,6 @@ public class CoreTracer implements AgentTracer.TracerAPI {
       // The JVM is already shutting down.
     }
 
-    if (this.writer instanceof DDAgentWriter && sampler instanceof DDAgentResponseListener) {
-      ((DDAgentWriter) this.writer).addResponseListener((DDAgentResponseListener) this.sampler);
-    }
-
     log.info("New instance: {}", this);
 
     final List<AbstractTagInterceptor> tagInterceptors =

--- a/dd-trace-core/src/test/groovy/datadog/trace/api/writer/DDAgentWriterTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/api/writer/DDAgentWriterTest.groovy
@@ -1,6 +1,7 @@
 package datadog.trace.api.writer
 
 import com.timgroup.statsd.StatsDClient
+import datadog.trace.api.DDId
 import datadog.trace.api.sampling.PrioritySampling
 import datadog.trace.common.writer.DDAgentWriter
 import datadog.trace.common.writer.ddagent.DDAgentApi
@@ -9,7 +10,6 @@ import datadog.trace.common.writer.ddagent.Monitor
 import datadog.trace.common.writer.ddagent.MsgPackStatefulSerializer
 import datadog.trace.common.writer.ddagent.TraceBuffer
 import datadog.trace.core.CoreTracer
-import datadog.trace.api.DDId
 import datadog.trace.core.DDSpan
 import datadog.trace.core.DDSpanContext
 import datadog.trace.core.PendingTrace
@@ -146,7 +146,7 @@ class DDAgentWriterTest extends DDSpecification {
     _ * serializer.isAtCapacity() >> { trace -> callRealMethod() }
     _ * serializer.dropBuffer() >> { trace -> callRealMethod() }
     _ * serializer.reset(_) >> { trace -> callRealMethod() }
-    1 * api.sendSerializedTraces( { it.traceCount() == 5 }) >> DDAgentApi.Response.success(200)
+    1 * api.sendSerializedTraces({ it.traceCount() == 5 }) >> DDAgentApi.Response.success(200)
     _ * monitor.onPublish(_, _)
     _ * monitor.onSerialize(_, _, _)
     1 * monitor.onSend(_, _, _, _) >> {
@@ -612,7 +612,7 @@ class DDAgentWriterTest extends DDSpecification {
       numResponses += 1
     }
 
-    def monitor = new Monitor.StatsD(statsd)
+    def monitor = new Monitor(statsd)
     def writer = DDAgentWriter.builder().traceAgentPort(agent.address.port).monitor(monitor).build()
     writer.start()
 
@@ -657,7 +657,7 @@ class DDAgentWriterTest extends DDSpecification {
       numErrors += 1
     }
 
-    def monitor = new Monitor.StatsD(statsd)
+    def monitor = new Monitor(statsd)
     def writer = DDAgentWriter.builder().agentApi(api).monitor(monitor).build()
     writer.start()
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/CoreTracerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/CoreTracerTest.groovy
@@ -1,5 +1,7 @@
 package datadog.trace.core
 
+import com.timgroup.statsd.NoOpStatsDClient
+import com.timgroup.statsd.NonBlockingStatsDClient
 import datadog.trace.api.Config
 import datadog.trace.api.sampling.PrioritySampling
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation
@@ -9,7 +11,6 @@ import datadog.trace.common.sampling.RateByServiceSampler
 import datadog.trace.common.sampling.Sampler
 import datadog.trace.common.writer.DDAgentWriter
 import datadog.trace.common.writer.LoggingWriter
-import datadog.trace.common.writer.ddagent.Monitor
 import datadog.trace.common.writer.ddagent.TraceBuffer
 import datadog.trace.core.propagation.DatadogHttpCodec
 import datadog.trace.core.propagation.HttpCodec
@@ -43,7 +44,7 @@ class CoreTracerTest extends DDSpecification {
     tracer.serviceName == "unnamed-java-app"
     tracer.sampler instanceof RateByServiceSampler
     tracer.writer instanceof DDAgentWriter
-    tracer.writer.monitor instanceof Monitor.Noop
+    tracer.statsDClient instanceof NoOpStatsDClient
 
     !tracer.spanTagInterceptors.isEmpty()
 
@@ -59,8 +60,7 @@ class CoreTracerTest extends DDSpecification {
     def tracer = CoreTracer.builder().config(new Config()).build()
 
     then:
-    tracer.writer.monitor instanceof Monitor.StatsD
-    tracer.writer.monitor.hostInfo == "localhost:8125"
+    tracer.statsDClient instanceof NonBlockingStatsDClient
   }
 
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -16,7 +16,7 @@ ext {
     scala         : "2.11.12",  // Last version to support Java 7 (2.12+ require Java 8+)
     kotlin        : "1.3.72",
     coroutines    : "1.3.0",
-    dogstatsd     : "2.10.1",
+    dogstatsd     : "2.9.0",
     jnr_unixsocket: "0.28",
     commons       : "3.2",
     mockito       : '3.3.3',

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -16,7 +16,7 @@ ext {
     scala         : "2.11.12",  // Last version to support Java 7 (2.12+ require Java 8+)
     kotlin        : "1.3.72",
     coroutines    : "1.3.0",
-    dogstatsd     : "2.9.0",
+    dogstatsd     : "2.10.1",
     jnr_unixsocket: "0.28",
     commons       : "3.2",
     mockito       : '3.3.3',


### PR DESCRIPTION
Previously, the StatsD client was solely used by `DDAgentWriter` through the `Monitor` interface.  This pull request moves the client into `CoreTracer` so that other components will be able to report health metrics.

Additionally, the creation of DDAgentWriter was moved into `CoreTracer` for the following reasons:
- There was a confusing cycle of where the StatsD client was created and passed into the various builders
- CoreTracer still needs to do extra configuration to add the sampler as a ResponseListener on the writer (for RateByService sampling)
- `Writer.Builder` didn't have a real use case.  Users wanting customization could either pass in their own `Writer`, customize the default Writer with the `Config` class, or customize with `DDAgentWriter.Builder`.  `Writer.Builder` returned a `Writer` that had no customization options.

The specialization of `Monitor.StatsD` and `Monitor.NoOp` is no longer necessary and is instead handled using the `NoOpStatsDClient`