### PR TITLE
Small tweaks to tags map in DDSpanContext

### DIFF
--- a/dd-trace-core/jfr-openjdk/src/test/groovy/datadog/trace/core/jfr/openjdk/ScopeEventTest.groovy
+++ b/dd-trace-core/jfr-openjdk/src/test/groovy/datadog/trace/core/jfr/openjdk/ScopeEventTest.groovy
@@ -40,7 +40,7 @@ class ScopeEventTest extends DDSpecification {
       [:],
       false,
       "fakeType",
-      null,
+      0,
       new PendingTrace(tracer, DDId.from(123)),
       tracer,
       [:])

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/TraceMapper.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/TraceMapper.java
@@ -18,6 +18,7 @@ import static datadog.trace.core.serialization.msgpack.EncodingCachingStrategies
 
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.core.DDSpan;
+import datadog.trace.core.DDSpanContext;
 import datadog.trace.core.serialization.msgpack.Mapper;
 import datadog.trace.core.serialization.msgpack.Writable;
 import java.util.List;
@@ -25,7 +26,7 @@ import java.util.Map;
 
 public final class TraceMapper implements Mapper<List<DDSpan>> {
   @Override
-  public void map(List<DDSpan> trace, Writable writable) {
+  public void map(List<DDSpan> trace, final Writable writable) {
     writable.startArray(trace.size());
     for (DDSpan span : trace) {
       writable.startMap(12);
@@ -64,42 +65,48 @@ public final class TraceMapper implements Mapper<List<DDSpan>> {
       writable.writeMap(span.getMetrics(), CONSTANT_KEYS);
       /* 12 */
       writable.writeUTF8(META);
-      Map<String, String> baggage = span.context().getBaggageItems();
-      Map<String, Object> tags = span.context().getTags();
-      // since tags can "override" baggage, we need to count the non overlapping ones
-      int size = tags.size();
-      boolean overlap = false;
-      if (baggage.size() > 0) {
-        for (String key : baggage.keySet()) {
-          if (!tags.containsKey(key)) {
-            size++;
-          } else {
-            overlap = true;
-          }
-        }
-      }
-      writable.startMap(size);
-      for (Map.Entry<String, String> entry : baggage.entrySet()) {
-        // tags and baggage may intersect, but tags take priority
-        if (!overlap || !tags.containsKey(entry.getKey())) {
-          writable.writeString(entry.getKey(), CONSTANT_KEYS);
-          writable.writeObject(entry.getValue(), NO_CACHING);
-        }
-      }
-      for (Map.Entry<String, Object> entry : tags.entrySet()) {
-        writable.writeString(entry.getKey(), CONSTANT_KEYS);
-        if (entry.getValue() instanceof Long || entry.getValue() instanceof Integer) {
-          // TODO it would be nice not to need to do this, either because
-          //  the agent would accept variably typed tag values, or numeric
-          //  tags get moved to the metrics
-          writeLongAsString(((Number) entry.getValue()).longValue(), writable);
-        } else if (entry.getValue() instanceof UTF8BytesString) {
-          // TODO assess whether this is still worth it
-          writable.writeObject(entry.getValue(), NO_CACHING);
-        } else {
-          writable.writeString(String.valueOf(entry.getValue()), NO_CACHING);
-        }
-      }
+      span.context()
+          .processTagsAndBaggage(
+              new DDSpanContext.TagsAndBaggageConsumer() {
+                @Override
+                public void accept(Map<String, Object> tags, Map<String, String> baggage) {
+                  // since tags can "override" baggage, we need to count the non overlapping ones
+                  int size = tags.size();
+                  boolean overlap = false;
+                  if (baggage.size() > 0) {
+                    for (String key : baggage.keySet()) {
+                      if (!tags.containsKey(key)) {
+                        size++;
+                      } else {
+                        overlap = true;
+                      }
+                    }
+                  }
+                  writable.startMap(size);
+                  for (Map.Entry<String, String> entry : baggage.entrySet()) {
+                    // tags and baggage may intersect, but tags take priority
+                    if (!overlap || !tags.containsKey(entry.getKey())) {
+                      writable.writeString(entry.getKey(), CONSTANT_KEYS);
+                      writable.writeObject(entry.getValue(), NO_CACHING);
+                    }
+                  }
+                  for (Map.Entry<String, Object> entry : tags.entrySet()) {
+                    writable.writeString(entry.getKey(), CONSTANT_KEYS);
+                    if (entry.getValue() instanceof Long || entry.getValue() instanceof Integer) {
+                      // TODO it would be nice not to need to do this, either because
+                      //  the agent would accept variably typed tag values, or numeric
+                      //  tags get moved to the metrics
+                      TraceMapper.this.writeLongAsString(
+                          ((Number) entry.getValue()).longValue(), writable);
+                    } else if (entry.getValue() instanceof UTF8BytesString) {
+                      // TODO assess whether this is still worth it
+                      writable.writeObject(entry.getValue(), NO_CACHING);
+                    } else {
+                      writable.writeString(String.valueOf(entry.getValue()), NO_CACHING);
+                    }
+                  }
+                }
+              });
     }
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -42,6 +42,7 @@ import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -49,7 +50,6 @@ import java.util.Properties;
 import java.util.ServiceConfigurationError;
 import java.util.ServiceLoader;
 import java.util.SortedSet;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.TimeUnit;
 import lombok.Builder;
@@ -100,9 +100,11 @@ public class CoreTracer implements AgentTracer.TracerAPI {
    */
   private final Thread shutdownCallback;
 
-  /** Span tag interceptors */
-  private final Map<String, List<AbstractTagInterceptor>> spanTagInterceptors =
-      new ConcurrentHashMap<>();
+  /**
+   * Span tag interceptors. This Map is only ever added to during initialization, so it doesn't need
+   * to be concurrent.
+   */
+  private final Map<String, List<AbstractTagInterceptor>> spanTagInterceptors = new HashMap<>();
 
   private final SortedSet<TraceInterceptor> interceptors =
       new ConcurrentSkipListSet<>(

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -9,7 +9,6 @@ import datadog.trace.core.util.Clock;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.lang.ref.WeakReference;
-import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
@@ -352,7 +351,8 @@ public class DDSpan implements MutableSpan, AgentSpan {
 
   @Override
   public Map<String, Object> getTags() {
-    return Collections.unmodifiableMap(context.getTags());
+    // This is an imutable copy of the tags
+    return context.getTags();
   }
 
   public String getType() {

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -212,12 +212,12 @@ public class DDSpan implements MutableSpan, AgentSpan {
   }
 
   public Object getAndRemoveTag(final String tag) {
-    return context.getTags().remove(tag);
+    return context.getAndRemoveTag(tag);
   }
 
   @Override
   public Object getTag(final String tag) {
-    return context.getTags().get(tag);
+    return context.getTag(tag);
   }
 
   @Override

--- a/dd-trace-core/src/main/java/datadog/trace/core/ExclusiveSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/ExclusiveSpan.java
@@ -1,0 +1,73 @@
+package datadog.trace.core;
+
+/** Internal API for a span where the holder has exclusive access to the resources exposed. */
+public final class ExclusiveSpan {
+  private final DDSpanContext context;
+
+  /**
+   * Should only be created from inside the {@link DDSpanContext}, and accessed via the {@link
+   * DDSpanContext#processExclusiveSpan(Consumer)} method.
+   *
+   * @param context the context that this exclusive span wraps
+   */
+  ExclusiveSpan(DDSpanContext context) {
+    this.context = context;
+  }
+
+  public Object getTag(final String tag) {
+    return context.unsafeGetTag(tag);
+  }
+
+  public void setTag(final String tag, final Object value) {
+    context.unsafeSetTag(tag, value);
+  }
+
+  public Object getAndRemoveTag(final String tag) {
+    return context.unsafeGetAndRemoveTag(tag);
+  }
+
+  public void setMetric(final String key, final Number value) {
+    context.setMetric(key, value);
+  }
+
+  public boolean isResourceNameSet() {
+    return context.isResourceNameSet();
+  }
+
+  public void setResourceName(final CharSequence resourceName) {
+    context.setResourceName(resourceName);
+  }
+
+  public String getServiceName() {
+    return context.getServiceName();
+  }
+
+  public void setServiceName(final String serviceName) {
+    context.setServiceName(serviceName);
+  }
+
+  public boolean isError() {
+    return context.getErrorFlag();
+  }
+
+  public void setError(final boolean error) {
+    context.setErrorFlag(error);
+  }
+
+  public String getType() {
+    return context.getSpanType();
+  }
+
+  public void setType(final String type) {
+    context.setSpanType(type);
+  }
+
+  /** @return if sampling priority was set by this method invocation */
+  public boolean setSamplingPriority(final int newPriority) {
+    return context.setSamplingPriority(newPriority);
+  }
+
+  public abstract static class Consumer {
+    public abstract void accept(ExclusiveSpan span);
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/core/processor/rule/AnalyticsSampleRateRule.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/processor/rule/AnalyticsSampleRateRule.java
@@ -1,7 +1,7 @@
 package datadog.trace.core.processor.rule;
 
 import datadog.trace.api.DDTags;
-import datadog.trace.core.DDSpan;
+import datadog.trace.core.ExclusiveSpan;
 import datadog.trace.core.processor.TraceProcessor;
 
 /** Converts analytics sample rate tag to metric */
@@ -12,14 +12,13 @@ public class AnalyticsSampleRateRule implements TraceProcessor.Rule {
   }
 
   @Override
-  public void processSpan(final DDSpan span) {
+  public void processSpan(final ExclusiveSpan span) {
     final Object sampleRateValue = span.getAndRemoveTag(DDTags.ANALYTICS_SAMPLE_RATE);
     if (sampleRateValue instanceof Number) {
-      span.context().setMetric(DDTags.ANALYTICS_SAMPLE_RATE, (Number) sampleRateValue);
+      span.setMetric(DDTags.ANALYTICS_SAMPLE_RATE, (Number) sampleRateValue);
     } else if (sampleRateValue instanceof String) {
       try {
-        span.context()
-            .setMetric(DDTags.ANALYTICS_SAMPLE_RATE, Double.parseDouble((String) sampleRateValue));
+        span.setMetric(DDTags.ANALYTICS_SAMPLE_RATE, Double.parseDouble((String) sampleRateValue));
       } catch (final NumberFormatException ex) {
         // ignore
       }

--- a/dd-trace-core/src/main/java/datadog/trace/core/processor/rule/DBStatementRule.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/processor/rule/DBStatementRule.java
@@ -1,7 +1,7 @@
 package datadog.trace.core.processor.rule;
 
 import datadog.trace.bootstrap.instrumentation.api.Tags;
-import datadog.trace.core.DDSpan;
+import datadog.trace.core.ExclusiveSpan;
 import datadog.trace.core.processor.TraceProcessor;
 
 /**
@@ -15,7 +15,7 @@ public class DBStatementRule implements TraceProcessor.Rule {
   }
 
   @Override
-  public void processSpan(final DDSpan span) {
+  public void processSpan(final ExclusiveSpan span) {
     // Special case: Mongo
     // Skip the decorators
     if (!"java-mongo".equals(span.getTag(Tags.COMPONENT))) {

--- a/dd-trace-core/src/main/java/datadog/trace/core/processor/rule/ErrorRule.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/processor/rule/ErrorRule.java
@@ -1,7 +1,7 @@
 package datadog.trace.core.processor.rule;
 
 import datadog.trace.bootstrap.instrumentation.api.Tags;
-import datadog.trace.core.DDSpan;
+import datadog.trace.core.ExclusiveSpan;
 import datadog.trace.core.processor.TraceProcessor;
 
 /** Converts error tag to field */
@@ -12,7 +12,7 @@ public class ErrorRule implements TraceProcessor.Rule {
   }
 
   @Override
-  public void processSpan(final DDSpan span) {
+  public void processSpan(final ExclusiveSpan span) {
     final Object value = span.getAndRemoveTag(Tags.ERROR);
     if (value instanceof Boolean) {
       span.setError((Boolean) value);

--- a/dd-trace-core/src/main/java/datadog/trace/core/processor/rule/HttpStatusErrorRule.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/processor/rule/HttpStatusErrorRule.java
@@ -3,7 +3,7 @@ package datadog.trace.core.processor.rule;
 import datadog.trace.api.Config;
 import datadog.trace.api.DDSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
-import datadog.trace.core.DDSpan;
+import datadog.trace.core.ExclusiveSpan;
 import datadog.trace.core.processor.TraceProcessor;
 
 public class HttpStatusErrorRule implements TraceProcessor.Rule {
@@ -13,9 +13,9 @@ public class HttpStatusErrorRule implements TraceProcessor.Rule {
   }
 
   @Override
-  public void processSpan(final DDSpan span) {
+  public void processSpan(final ExclusiveSpan span) {
     final Object value = span.getTag(Tags.HTTP_STATUS);
-    if (value != null && !span.context().getErrorFlag()) {
+    if (value != null && !span.isError()) {
       try {
         final int status =
             value instanceof Integer ? (int) value : Integer.parseInt(value.toString());

--- a/dd-trace-core/src/main/java/datadog/trace/core/processor/rule/MarkSpanForMetricCalculationRule.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/processor/rule/MarkSpanForMetricCalculationRule.java
@@ -1,7 +1,7 @@
 package datadog.trace.core.processor.rule;
 
 import datadog.trace.bootstrap.instrumentation.api.InstrumentationTags;
-import datadog.trace.core.DDSpan;
+import datadog.trace.core.ExclusiveSpan;
 import datadog.trace.core.processor.TraceProcessor;
 
 public class MarkSpanForMetricCalculationRule implements TraceProcessor.Rule {
@@ -11,10 +11,10 @@ public class MarkSpanForMetricCalculationRule implements TraceProcessor.Rule {
   }
 
   @Override
-  public void processSpan(final DDSpan span) {
+  public void processSpan(final ExclusiveSpan span) {
     final Object val = span.getAndRemoveTag(InstrumentationTags.DD_MEASURED);
     if (val instanceof Boolean && (Boolean) val) {
-      span.context().setMetric(InstrumentationTags.DD_MEASURED, 1);
+      span.setMetric(InstrumentationTags.DD_MEASURED, 1);
     }
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/processor/rule/ResourceNameRule.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/processor/rule/ResourceNameRule.java
@@ -1,7 +1,7 @@
 package datadog.trace.core.processor.rule;
 
 import datadog.trace.api.DDTags;
-import datadog.trace.core.DDSpan;
+import datadog.trace.core.ExclusiveSpan;
 import datadog.trace.core.processor.TraceProcessor;
 
 /** Converts resource name tag to field */
@@ -12,7 +12,7 @@ public class ResourceNameRule implements TraceProcessor.Rule {
   }
 
   @Override
-  public void processSpan(final DDSpan span) {
+  public void processSpan(final ExclusiveSpan span) {
     final Object name = span.getAndRemoveTag(DDTags.RESOURCE_NAME);
     if (name instanceof CharSequence) {
       span.setResourceName((CharSequence) name);

--- a/dd-trace-core/src/main/java/datadog/trace/core/processor/rule/SpanTypeRule.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/processor/rule/SpanTypeRule.java
@@ -1,7 +1,7 @@
 package datadog.trace.core.processor.rule;
 
 import datadog.trace.api.DDTags;
-import datadog.trace.core.DDSpan;
+import datadog.trace.core.ExclusiveSpan;
 import datadog.trace.core.processor.TraceProcessor;
 
 /** Converts span type tag to field */
@@ -12,10 +12,10 @@ public class SpanTypeRule implements TraceProcessor.Rule {
   }
 
   @Override
-  public void processSpan(final DDSpan span) {
+  public void processSpan(final ExclusiveSpan span) {
     final Object type = span.getAndRemoveTag(DDTags.SPAN_TYPE);
     if (type != null) {
-      span.setSpanType(type.toString());
+      span.setType(type.toString());
     }
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/processor/rule/URLAsResourceNameRule.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/processor/rule/URLAsResourceNameRule.java
@@ -1,8 +1,7 @@
 package datadog.trace.core.processor.rule;
 
 import datadog.trace.bootstrap.instrumentation.api.Tags;
-import datadog.trace.core.DDSpan;
-import datadog.trace.core.DDSpanContext;
+import datadog.trace.core.ExclusiveSpan;
 import datadog.trace.core.processor.TraceProcessor;
 
 public class URLAsResourceNameRule implements TraceProcessor.Rule {
@@ -23,9 +22,8 @@ public class URLAsResourceNameRule implements TraceProcessor.Rule {
   }
 
   @Override
-  public void processSpan(final DDSpan span) {
-    final DDSpanContext context = span.context();
-    if (context.isResourceNameSet()) {
+  public void processSpan(final ExclusiveSpan span) {
+    if (span.isResourceNameSet()) {
       return;
     }
     final Object httpStatus = span.getTag(Tags.HTTP_STATUS);
@@ -37,8 +35,7 @@ public class URLAsResourceNameRule implements TraceProcessor.Rule {
     if (null == url) {
       return;
     }
-    context.setResourceName(
-        extractResourceNameFromURL(span.getTag(Tags.HTTP_METHOD), url.toString()));
+    span.setResourceName(extractResourceNameFromURL(span.getTag(Tags.HTTP_METHOD), url.toString()));
   }
 
   private String extractResourceNameFromURL(final Object method, final String url) {

--- a/dd-trace-core/src/main/java/datadog/trace/core/taginterceptor/AbstractTagInterceptor.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/taginterceptor/AbstractTagInterceptor.java
@@ -1,6 +1,6 @@
 package datadog.trace.core.taginterceptor;
 
-import datadog.trace.core.DDSpanContext;
+import datadog.trace.core.ExclusiveSpan;
 
 /**
  * Span decorators are called when new tags are written and proceed to various remappings and
@@ -15,7 +15,7 @@ public abstract class AbstractTagInterceptor {
   }
 
   public abstract boolean shouldSetTag(
-      final DDSpanContext context, final String tag, final Object value);
+      final ExclusiveSpan span, final String tag, final Object value);
 
   public String getMatchingTag() {
     return matchingTag;

--- a/dd-trace-core/src/main/java/datadog/trace/core/taginterceptor/ForceManualDropTagInterceptor.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/taginterceptor/ForceManualDropTagInterceptor.java
@@ -2,7 +2,7 @@ package datadog.trace.core.taginterceptor;
 
 import datadog.trace.api.DDTags;
 import datadog.trace.api.sampling.PrioritySampling;
-import datadog.trace.core.DDSpanContext;
+import datadog.trace.core.ExclusiveSpan;
 
 /**
  * Tag decorator to replace tag 'manual.drop: true' with the appropriate priority sampling value.
@@ -14,11 +14,11 @@ class ForceManualDropTagInterceptor extends AbstractTagInterceptor {
   }
 
   @Override
-  public boolean shouldSetTag(final DDSpanContext context, final String tag, final Object value) {
+  public boolean shouldSetTag(final ExclusiveSpan span, final String tag, final Object value) {
     if (value instanceof Boolean && (boolean) value) {
-      context.setSamplingPriority(PrioritySampling.USER_DROP);
+      span.setSamplingPriority(PrioritySampling.USER_DROP);
     } else if (value instanceof String && Boolean.parseBoolean((String) value)) {
-      context.setSamplingPriority(PrioritySampling.USER_DROP);
+      span.setSamplingPriority(PrioritySampling.USER_DROP);
     }
     return false;
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/taginterceptor/ForceManualKeepTagInterceptor.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/taginterceptor/ForceManualKeepTagInterceptor.java
@@ -2,7 +2,7 @@ package datadog.trace.core.taginterceptor;
 
 import datadog.trace.api.DDTags;
 import datadog.trace.api.sampling.PrioritySampling;
-import datadog.trace.core.DDSpanContext;
+import datadog.trace.core.ExclusiveSpan;
 
 /**
  * Tag decorator to replace tag 'manual.keep: true' with the appropriate priority sampling value.
@@ -14,11 +14,11 @@ class ForceManualKeepTagInterceptor extends AbstractTagInterceptor {
   }
 
   @Override
-  public boolean shouldSetTag(final DDSpanContext context, final String tag, final Object value) {
+  public boolean shouldSetTag(final ExclusiveSpan span, final String tag, final Object value) {
     if (value instanceof Boolean && (boolean) value) {
-      context.setSamplingPriority(PrioritySampling.USER_KEEP);
+      span.setSamplingPriority(PrioritySampling.USER_KEEP);
     } else if (value instanceof String && Boolean.parseBoolean((String) value)) {
-      context.setSamplingPriority(PrioritySampling.USER_KEEP);
+      span.setSamplingPriority(PrioritySampling.USER_KEEP);
     }
     return false;
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/taginterceptor/PeerServiceTagInterceptor.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/taginterceptor/PeerServiceTagInterceptor.java
@@ -1,7 +1,7 @@
 package datadog.trace.core.taginterceptor;
 
 import datadog.trace.bootstrap.instrumentation.api.Tags;
-import datadog.trace.core.DDSpanContext;
+import datadog.trace.core.ExclusiveSpan;
 
 class PeerServiceTagInterceptor extends AbstractTagInterceptor {
   public PeerServiceTagInterceptor() {
@@ -9,8 +9,8 @@ class PeerServiceTagInterceptor extends AbstractTagInterceptor {
   }
 
   @Override
-  public boolean shouldSetTag(final DDSpanContext context, final String tag, final Object value) {
-    context.setServiceName(String.valueOf(value));
+  public boolean shouldSetTag(final ExclusiveSpan span, final String tag, final Object value) {
+    span.setServiceName(String.valueOf(value));
     return false;
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/taginterceptor/ServiceNameTagInterceptor.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/taginterceptor/ServiceNameTagInterceptor.java
@@ -1,7 +1,7 @@
 package datadog.trace.core.taginterceptor;
 
 import datadog.trace.api.DDTags;
-import datadog.trace.core.DDSpanContext;
+import datadog.trace.core.ExclusiveSpan;
 
 class ServiceNameTagInterceptor extends AbstractTagInterceptor {
 
@@ -17,8 +17,8 @@ class ServiceNameTagInterceptor extends AbstractTagInterceptor {
   }
 
   @Override
-  public boolean shouldSetTag(final DDSpanContext context, final String tag, final Object value) {
-    context.setServiceName(String.valueOf(value));
+  public boolean shouldSetTag(final ExclusiveSpan span, final String tag, final Object value) {
+    span.setServiceName(String.valueOf(value));
     return setTag;
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/taginterceptor/ServletContextTagInterceptor.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/taginterceptor/ServletContextTagInterceptor.java
@@ -4,7 +4,7 @@ import datadog.trace.api.ConfigDefaults;
 import datadog.trace.api.config.GeneralConfig;
 import datadog.trace.api.env.CapturedEnvironment;
 import datadog.trace.bootstrap.instrumentation.api.InstrumentationTags;
-import datadog.trace.core.DDSpanContext;
+import datadog.trace.core.ExclusiveSpan;
 
 class ServletContextTagInterceptor extends AbstractTagInterceptor {
 
@@ -13,14 +13,13 @@ class ServletContextTagInterceptor extends AbstractTagInterceptor {
   }
 
   @Override
-  public boolean shouldSetTag(final DDSpanContext context, final String tag, final Object value) {
+  public boolean shouldSetTag(final ExclusiveSpan span, final String tag, final Object value) {
     String contextName = String.valueOf(value).trim();
     if (contextName.equals("/")
-        || (!context.getServiceName().equals(ConfigDefaults.DEFAULT_SERVICE_NAME)
-            && !context
-                .getServiceName()
+        || (!span.getServiceName().equals(ConfigDefaults.DEFAULT_SERVICE_NAME)
+            && !span.getServiceName()
                 .equals(CapturedEnvironment.get().getProperties().get(GeneralConfig.SERVICE_NAME))
-            && !context.getServiceName().isEmpty())) {
+            && !span.getServiceName().isEmpty())) {
       return true;
     }
     if (contextName.startsWith("/")) {
@@ -29,7 +28,7 @@ class ServletContextTagInterceptor extends AbstractTagInterceptor {
       }
     }
     if (!contextName.isEmpty()) {
-      context.setServiceName(contextName);
+      span.setServiceName(contextName);
     }
     return true;
   }

--- a/dd-trace-core/src/test/groovy/datadog/trace/api/writer/DDAgentWriterTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/api/writer/DDAgentWriterTest.groovy
@@ -181,7 +181,7 @@ class DDAgentWriterTest extends DDSpecification {
       [:],
       false,
       "",
-      [:],
+      0,
       Mock(PendingTrace),
       Mock(CoreTracer),
       [:])
@@ -227,7 +227,7 @@ class DDAgentWriterTest extends DDSpecification {
       [:],
       false,
       "",
-      [:],
+      0,
       Mock(PendingTrace),
       Mock(CoreTracer),
       [:])

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/CoreSpanBuilderTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/CoreSpanBuilderTest.groovy
@@ -90,8 +90,8 @@ class CoreSpanBuilderTest extends DDSpecification {
     context.getServiceName() == expectedService
     context.getSpanType() == expectedType
 
-    context.tags[THREAD_NAME] == Thread.currentThread().getName()
-    context.tags[THREAD_ID] == Thread.currentThread().getId()
+    context.getTag(THREAD_NAME) == Thread.currentThread().getName()
+    context.getTag(THREAD_ID) == Thread.currentThread().getId()
   }
 
   def "setting #name should remove"() {
@@ -302,9 +302,9 @@ class CoreSpanBuilderTest extends DDSpecification {
     span.samplingPriority == extractedContext.samplingPriority
     span.context().origin == extractedContext.origin
     span.context().baggageItems == extractedContext.baggage
-    span.context().@tags == extractedContext.tags + [(RUNTIME_ID_TAG)  : config.getRuntimeId(),
-                                                     (LANGUAGE_TAG_KEY): LANGUAGE_TAG_VALUE,
-                                                     (THREAD_NAME)     : thread.name, (THREAD_ID): thread.id]
+    span.context().tags == extractedContext.tags + [(RUNTIME_ID_TAG)  : config.getRuntimeId(),
+                                                            (LANGUAGE_TAG_KEY): LANGUAGE_TAG_VALUE,
+                                                            (THREAD_NAME)     : thread.name, (THREAD_ID): thread.id]
 
     where:
     extractedContext                                                                                                                    | _
@@ -323,9 +323,9 @@ class CoreSpanBuilderTest extends DDSpecification {
     span.samplingPriority == null
     span.context().origin == tagContext.origin
     span.context().baggageItems == [:]
-    span.context().@tags == tagContext.tags + [(RUNTIME_ID_TAG)  : config.getRuntimeId(),
-                                               (LANGUAGE_TAG_KEY): LANGUAGE_TAG_VALUE,
-                                               (THREAD_NAME)     : thread.name, (THREAD_ID): thread.id]
+    span.context().tags == tagContext.tags + [(RUNTIME_ID_TAG)  : config.getRuntimeId(),
+                                                      (LANGUAGE_TAG_KEY): LANGUAGE_TAG_VALUE,
+                                                      (THREAD_NAME)     : thread.name, (THREAD_ID): thread.id]
 
     where:
     tagContext                                                                   | _

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanSerializationTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanSerializationTest.groovy
@@ -96,10 +96,11 @@ class DDSpanSerializationTest extends DDSpecification {
       baggage,
       false,
       null,
-      tags,
+      tags.size(),
       PendingTrace.create(tracer, DDId.ONE),
       tracer,
       [:])
+    context.setAllTags(tags)
     def span = DDSpan.create(0, context)
     def buffer = ByteBuffer.allocate(1024)
     CaptureBuffer capture = new CaptureBuffer()

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanSerializationTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanSerializationTest.groovy
@@ -32,7 +32,7 @@ class DDSpanSerializationTest extends DDSpecification {
       Collections.emptyMap(),
       false,
       spanType,
-      Collections.emptyMap(),
+      0,
       PendingTrace.create(tracer, DDId.ONE),
       tracer,
       [:])

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanTest.groovy
@@ -32,7 +32,7 @@ class DDSpanTest extends DDSpecification {
         Collections.<String, String> emptyMap(),
         false,
         "fakeType",
-        null,
+        0,
         PendingTrace.create(tracer, DDId.ONE),
         tracer,
         [:])

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/SpanFactory.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/SpanFactory.groovy
@@ -23,7 +23,7 @@ class SpanFactory {
       Collections.emptyMap(),
       false,
       "fakeType",
-      Collections.emptyMap(),
+      0,
       PendingTrace.create(tracer, DDId.ONE),
       tracer, [:])
     Thread.currentThread().setName(currentThreadName)
@@ -43,7 +43,7 @@ class SpanFactory {
       Collections.emptyMap(),
       false,
       "fakeType",
-      Collections.emptyMap(),
+      0,
       PendingTrace.create(tracer, DDId.ONE),
       tracer, [:])
     return DDSpan.create(1, context)
@@ -62,7 +62,7 @@ class SpanFactory {
       Collections.emptyMap(),
       false,
       "fakeType",
-      Collections.emptyMap(),
+      0,
       trace,
       trace.tracer, [:])
     return DDSpan.create(1, context)
@@ -83,7 +83,7 @@ class SpanFactory {
       Collections.emptyMap(),
       false,
       "fakeType",
-      Collections.emptyMap(),
+      0,
       PendingTrace.create(tracer, DDId.ONE),
       tracer,
       [:])

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/processor/URLAsResourceNameRuleTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/processor/URLAsResourceNameRuleTest.groovy
@@ -1,6 +1,7 @@
 package datadog.trace.core.processor
 
 import datadog.trace.bootstrap.instrumentation.api.Tags
+import datadog.trace.core.ExclusiveSpan
 import datadog.trace.core.SpanFactory
 import datadog.trace.core.processor.rule.URLAsResourceNameRule
 import datadog.trace.util.test.DDSpecification
@@ -116,7 +117,12 @@ class URLAsResourceNameRuleTest extends DDSpecification {
     }
 
     when:
-    decorator.processSpan(span)
+    span.context().processExclusiveSpan(new ExclusiveSpan.Consumer() {
+      @Override
+      void accept(ExclusiveSpan exclusiveSpan) {
+        decorator.processSpan(exclusiveSpan)
+      }
+    })
 
     then:
     span.resourceName == resourceName

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/B3HttpInjectorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/B3HttpInjectorTest.groovy
@@ -39,7 +39,7 @@ class B3HttpInjectorTest extends DDSpecification {
         },
         false,
         "fakeType",
-        null,
+        0,
         new PendingTrace(tracer, DDId.ONE),
         tracer,
         [:])

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/DatadogHttpInjectorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/DatadogHttpInjectorTest.groovy
@@ -41,7 +41,7 @@ class DatadogHttpInjectorTest extends DDSpecification {
         },
         false,
         "fakeType",
-        null,
+        0,
         new PendingTrace(tracer, DDId.ONE),
         tracer,
         [:])

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HaystackHttpInjectorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HaystackHttpInjectorTest.groovy
@@ -39,7 +39,7 @@ class HaystackHttpInjectorTest extends DDSpecification {
         },
         false,
         "fakeType",
-        null,
+        0,
         new PendingTrace(tracer, DDId.ONE),
         tracer,
         [:])

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HttpInjectorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HttpInjectorTest.groovy
@@ -44,7 +44,7 @@ class HttpInjectorTest extends DDSpecification {
         },
         false,
         "fakeType",
-        null,
+        0,
         new PendingTrace(tracer, DDId.ONE),
         tracer,
         [:])

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/taginterceptor/TagInterceptorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/taginterceptor/TagInterceptorTest.groovy
@@ -8,7 +8,7 @@ import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.common.sampling.AllSampler
 import datadog.trace.common.writer.LoggingWriter
 import datadog.trace.core.CoreTracer
-import datadog.trace.core.DDSpanContext
+import datadog.trace.core.ExclusiveSpan
 import datadog.trace.core.SpanFactory
 import datadog.trace.util.test.DDSpecification
 
@@ -34,8 +34,8 @@ class TagInterceptorTest extends DDSpecification {
   def "adding span personalisation using Decorators"() {
     setup:
     def decorator = new AbstractTagInterceptor("foo") {
-      boolean shouldSetTag(DDSpanContext context, String tag, Object value) {
-        context.setTag("newFoo", value)
+      boolean shouldSetTag(ExclusiveSpan span, String tag, Object value) {
+        span.setTag("newFoo", value)
         return false
       }
     }

--- a/dd-trace-core/src/traceAgentTest/groovy/DDApiIntegrationTest.groovy
+++ b/dd-trace-core/src/traceAgentTest/groovy/DDApiIntegrationTest.groovy
@@ -39,7 +39,7 @@ class DDApiIntegrationTest extends DDSpecification {
     [:],
     false,
     "fakeType",
-    [:],
+    0,
     new PendingTrace(TRACER, DDId.ONE),
     TRACER,
     [:])


### PR DESCRIPTION
This PR consists of three parts that are separate, but build on each other.

1. Don't insert all tags into the `CoreSpanBuilder` tags hash map just to copy them out and insert them into the `DDSpanContext` tags map.
2. Since the tags map in `DDSpanContext` in most cases is probably not accessed concurrently, change it to a normal `HashMap` that is guarded by `synchronized` access.
3. Make sure that processing of tag interceptors and rules don't take the lock multiple times.

These three combined shaves off `25-45%` of the time being spent in creating a span and adding tags to it.


```
|                                                                          |      |     |   Master |         |       PR |         |       |
|Benchmark                                                                 | Mode | Cnt |    Score |   Error |    Score |   Error | Units |
|--------------------------------------------------------------------------|------|-----|----------|---------|----------|---------|-------|
|StartSpanBenchmark.addTagAfterChildSpan                                   |   ss |  30 |    8.041 | ± 0.784 |    4.658 | ± 0.511 | ms/op |
|StartSpanBenchmark.addTagAfterChildSpan:·gc.alloc.rate.norm               |   ss |  30 | 1115.891 | ± 0.093 |  691.863 | ± 0.086 |  B/op |
|StartSpanBenchmark.addTagWitInterceptorAfterChildSpan                     |   ss |  30 |    6.878 | ± 0.668 |    4.569 | ± 0.248 | ms/op |
|StartSpanBenchmark.addTagWitInterceptorAfterChildSpan:·gc.alloc.rate.norm |   ss |  30 | 1003.890 | ± 0.094 |  659.862 | ± 0.095 |  B/op |
|StartSpanBenchmark.childSpan                                              |   ss |  30 |    6.780 | ± 0.660 |    4.421 | ± 0.245 | ms/op |
|StartSpanBenchmark.childSpan:·gc.alloc.rate.norm                          |   ss |  30 | 1003.891 | ± 0.094 |  659.862 | ± 0.096 |  B/op |
|StartSpanBenchmark.onTraceComplete                                        |   ss |  30 |    1.359 | ± 0.163 |    1.233 | ± 0.177 | ms/op |
|StartSpanBenchmark.onTraceComplete:·gc.alloc.rate.norm                    |   ss |  30 |    0.252 | ± 0.004 |    0.220 | ± 0.005 |  B/op |
|StartSpanBenchmark.onTraceCompleteWithTagMatchingRule                     |   ss |  30 |    8.701 | ± 0.694 |    5.996 | ± 0.666 | ms/op |
|StartSpanBenchmark.onTraceCompleteWithTagMatchingRule:·gc.alloc.rate.norm |   ss |  30 | 1616.242 | ± 0.004 | 1360.217 | ± 0.005 |  B/op |
|StartSpanBenchmark.rootSpan                                               |   ss |  30 |    6.828 | ± 0.512 |    5.201 | ± 0.522 | ms/op |
|StartSpanBenchmark.rootSpan:·gc.alloc.rate.norm                           |   ss |  30 | 1560.242 | ± 0.006 | 1304.216 | ± 0.004 |  B/op |
```

This is the Bencmark:
```
package datadog.trace.core;

import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
import datadog.trace.core.processor.TraceProcessor;
import java.util.Collections;
import java.util.List;
import org.openjdk.jmh.annotations.*;
import org.openjdk.jmh.infra.Blackhole;

@State(Scope.Benchmark)
@OperationsPerInvocation(value = 10000)
@BenchmarkMode(value = Mode.SingleShotTime)
@Warmup(iterations = 100)
@Measurement(iterations = 30)
public class StartSpanBenchmark {

  private final int count = 10000;
  private CoreTracer tracer;
  private AgentSpan parentSpan;
  private TraceProcessor processor = new TraceProcessor();
  private List<DDSpan> trace;

  @Setup(Level.Trial)
  public void init() {
    // TODO maybe add something more to this one
    tracer = new CoreTracer.CoreTracerBuilder().build();
    trace = Collections.singletonList((DDSpan) tracer.startSpan("processingTrace"));
  }

  @Setup(Level.Iteration)
  public void gc() {
    parentSpan = tracer.startSpan("parentSpan");
    System.gc();
  }

  @Benchmark()
  public void rootSpan(Blackhole bh) {
    for (int i = 0; i < count; i++) {
      bh.consume(tracer.startSpan("rootSpan"));
    }
  }

  @Benchmark()
  public void childSpan(Blackhole bh) {
    for (int i = 0; i < count; i++) {
      bh.consume(tracer.startSpan("childSpan", parentSpan.context()));
    }
  }

  @Benchmark()
  public void addTagAfterChildSpan(Blackhole bh) {
    for (int i = 0; i < count; i++) {
      bh.consume(tracer.startSpan("childSpan", parentSpan.context()).setTag("foo", "bar"));
    }
  }

  @Benchmark()
  public void addTagWitInterceptorAfterChildSpan(Blackhole bh) {
    for (int i = 0; i < count; i++) {
      bh.consume(tracer.startSpan("childSpan", parentSpan.context()).setTag("service.name", "bar"));
    }
  }

  @Benchmark()
  public void onTraceComplete(Blackhole bh) {
    for (int i = 0; i < count; i++) {
      bh.consume(processor.onTraceComplete(trace));
    }
  }

  @Benchmark()
  public void onTraceCompleteWithTagMatchinRule(Blackhole bh) {
    for (int i = 0; i < count; i++) {
      bh.consume(
          processor.onTraceComplete(
              Collections.singletonList(
                  (DDSpan) tracer.startSpan("processingTrace").setTag("resource.name", "bar"))));
    }
  }
}
```
