### PR TITLE
attempt to base64 decode invalid DDIds 

### DIFF
--- a/dd-trace-api/dd-trace-api.gradle
+++ b/dd-trace-api/dd-trace-api.gradle
@@ -9,14 +9,14 @@ excludedClassesCoverage += [
   'datadog.trace.api.DDTraceApiInfo',
   'datadog.trace.api.GlobalTracer*',
   'datadog.trace.api.CorrelationIdentifier',
-  'datadog.trace.api.DDTags'
+  'datadog.trace.api.DDTags',
+  'datadog.trace.api.DDId.Base64Decoder'
 ]
 
 description = 'dd-trace-api'
 dependencies {
   compile deps.slf4j
-  // TODO kill this off in JDK8
-  compile deps.guava
 
+  testCompile deps.guava
   testCompile project(':utils:test-utils')
 }

--- a/dd-trace-api/dd-trace-api.gradle
+++ b/dd-trace-api/dd-trace-api.gradle
@@ -15,6 +15,8 @@ excludedClassesCoverage += [
 description = 'dd-trace-api'
 dependencies {
   compile deps.slf4j
+  // TODO kill this off in JDK8
+  compile deps.guava
 
   testCompile project(':utils:test-utils')
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/DDId.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/DDId.java
@@ -1,7 +1,7 @@
 package datadog.trace.api;
 
-import com.google.common.io.BaseEncoding;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.concurrent.ThreadLocalRandom;
 import lombok.extern.slf4j.Slf4j;
 
@@ -18,7 +18,7 @@ public class DDId {
   public static final DDId ZERO = new DDId(0, "0");
   public static final DDId MAX = new DDId(-1, "18446744073709551615"); // All bits set
 
-  private static final BaseEncoding BASE64 = BaseEncoding.base64();
+  private static final Base64Decoder BASE64 = new Base64Decoder();
 
   // Convenience constant used from tests
   private static final DDId ONE = DDId.from(1);
@@ -66,13 +66,17 @@ public class DDId {
       // we have reports of Kakfa mirror maker base64 encoding record headers
       // attempting to base64 decode the ids here rather than in the Kafka instrumentation
       // helps users understand they have a problem without making other users pay for it
-      if (null != s && BASE64.canDecode(s)) {
-        String decoded = new String(BASE64.decode(s), StandardCharsets.ISO_8859_1);
-        log.debug(
-            "id {} was base 64 encoded to {}, it was decoded but this indicates there is a problem elsewhere in your system",
-            decoded,
-            s);
-        return DDId.create(parseUnsignedLong(decoded), decoded);
+      if (null != s) {
+        try {
+          String decoded = new String(BASE64.decode(s), StandardCharsets.ISO_8859_1);
+          log.debug(
+              "id {} was base 64 encoded to {}, it was decoded but this indicates there is a problem elsewhere in your system",
+              decoded,
+              s);
+          return DDId.create(parseUnsignedLong(decoded), decoded);
+        } catch (Exception ignored) {
+
+        }
       }
       throw e;
     }
@@ -94,13 +98,16 @@ public class DDId {
       // we have reports of Kakfa mirror maker base64 encoding record headers
       // attempting to base64 decode the ids here rather than in the Kafka instrumentation
       // helps users understand they have a problem without making other users pay for it
-      if (null != s && BASE64.canDecode(s)) {
-        String decoded = new String(BASE64.decode(s), StandardCharsets.ISO_8859_1);
-        log.debug(
-            "id {} was base 64 encoded to {}, it was decoded but this indicates there is a problem elsewhere in your system",
-            decoded,
-            s);
-        return DDId.create(parseUnsignedLongHex(decoded), null);
+      if (null != s) {
+        try {
+          String decoded = new String(BASE64.decode(s), StandardCharsets.ISO_8859_1);
+          log.debug(
+              "id {} was base 64 encoded to {}, it was decoded but this indicates there is a problem elsewhere in your system",
+              decoded,
+              s);
+          return DDId.create(parseUnsignedLongHex(decoded), null);
+        } catch (Exception ignored) {
+        }
       }
       throw e;
     }
@@ -206,6 +213,133 @@ public class DDId {
       return result;
     } else {
       throw new NumberFormatException("Empty input string");
+    }
+  }
+
+  // TODO - can be removed when JDK7 is dropped (adapted from JDK8 source)
+  private static class Base64Decoder {
+
+    private static final int[] BASE_64 = new int[256];
+
+    static {
+      Arrays.fill(BASE_64, -1);
+      int i = 0;
+      for (char c = 'A'; c <= 'Z'; ++c) {
+        BASE_64[c] = i++;
+      }
+      for (char c = 'a'; c <= 'z'; ++c) {
+        BASE_64[c] = i++;
+      }
+      for (char c = '0'; c <= '9'; ++c) {
+        BASE_64[c] = i++;
+      }
+      BASE_64['+'] = i++;
+      BASE_64['/'] = i;
+      BASE_64['='] = -2;
+    }
+
+    public byte[] decode(byte[] src) {
+      byte[] dst = new byte[outLength(src, 0, src.length)];
+      int ret = decode0(src, 0, src.length, dst);
+      if (ret != dst.length) {
+        dst = Arrays.copyOf(dst, ret);
+      }
+      return dst;
+    }
+
+    public byte[] decode(String src) {
+      return decode(src.getBytes(StandardCharsets.ISO_8859_1));
+    }
+
+    private int outLength(byte[] src, int sp, int sl) {
+      int paddings = 0;
+      int len = sl - sp;
+      if (len == 0) return 0;
+      if (len < 2) {
+        if (BASE_64[0] == -1) return 0;
+        throw new IllegalArgumentException(
+            "Input byte[] should at least have 2 bytes for base64 bytes");
+      }
+      // scan all bytes to fill out all non-alphabet. a performance
+      // trade-off of pre-scan or Arrays.copyOf
+      int n = 0;
+      while (sp < sl) {
+        int b = src[sp++] & 0xff;
+        if (b == '=') {
+          len -= (sl - sp + 1);
+          break;
+        }
+        if ((b = BASE_64[b]) == -1) n++;
+      }
+      len -= n;
+      if ((len & 0x3) != 0) paddings = 4 - (len & 0x3);
+      return 3 * ((len + 3) / 4) - paddings;
+    }
+
+    private int decode0(byte[] src, int sp, int sl, byte[] dst) {
+      int dp = 0;
+      int bits = 0;
+      int shiftto = 18; // pos of first byte of 4-byte atom
+
+      while (sp < sl) {
+        if (shiftto == 18 && sp + 4 < sl) { // fast path
+          int sl0 = sp + ((sl - sp) & ~0b11);
+          while (sp < sl0) {
+            int b1 = BASE_64[src[sp++] & 0xff];
+            int b2 = BASE_64[src[sp++] & 0xff];
+            int b3 = BASE_64[src[sp++] & 0xff];
+            int b4 = BASE_64[src[sp++] & 0xff];
+            if ((b1 | b2 | b3 | b4) < 0) { // non base64 byte
+              sp -= 4;
+              break;
+            }
+            int bits0 = b1 << 18 | b2 << 12 | b3 << 6 | b4;
+            dst[dp++] = (byte) (bits0 >> 16);
+            dst[dp++] = (byte) (bits0 >> 8);
+            dst[dp++] = (byte) (bits0);
+          }
+          if (sp >= sl) break;
+        }
+        int b = src[sp++] & 0xff;
+        if ((b = BASE_64[b]) < 0) {
+          if (b == -2) { // padding byte '='
+            // =     shiftto==18 unnecessary padding
+            // x=    shiftto==12 a dangling single x
+            // x     to be handled together with non-padding case
+            // xx=   shiftto==6&&sp==sl missing last =
+            // xx=y  shiftto==6 last is not =
+            if (shiftto == 6 && (sp == sl || src[sp++] != '=') || shiftto == 18) {
+              throw new IllegalArgumentException("Input byte array has wrong 4-byte ending unit");
+            }
+            break;
+          }
+        }
+        bits |= (b << shiftto);
+        shiftto -= 6;
+        if (shiftto < 0) {
+          dst[dp++] = (byte) (bits >> 16);
+          dst[dp++] = (byte) (bits >> 8);
+          dst[dp++] = (byte) (bits);
+          shiftto = 18;
+          bits = 0;
+        }
+      }
+      // reached end of byte array or hit padding '=' characters.
+      if (shiftto == 6) {
+        dst[dp++] = (byte) (bits >> 16);
+      } else if (shiftto == 0) {
+        dst[dp++] = (byte) (bits >> 16);
+        dst[dp++] = (byte) (bits >> 8);
+      } else if (shiftto == 12) {
+        // dangling single "x", incorrectly encoded.
+        throw new IllegalArgumentException("Last unit does not have enough valid bits");
+      }
+      // ignore all non-base64 character
+      while (sp < sl) {
+        if (BASE_64[src[sp++] & 0xff] < 0) continue;
+        throw new IllegalArgumentException("Input byte array has incorrect ending byte at " + sp);
+      }
+      return dp;
     }
   }
 


### PR DESCRIPTION
This one comes from a support issue where Kafka Mirrormaker was reportedly base64 encoding Kafka headers, and the user was complaining that we wouldn't parse the trace IDs. I've investigated and there is no way to detect that this has happened, except trying to base64 decode the headers. Doing this "just in case" in the Kafka instrumentation would give other users a significant performance regression so we don't want to do this unless absolutely necessary. This isn't really the tracer's fault and the user needs to prevent infrastructure from mangling header data, but attempting to base64 decode in a catch block in `DDId.from` helps the user diagnose and fix their problem, avoids breaking trace lineage if they can't fix it right away, whilst preventing other users from paying for it.