### PR TITLE
Allow disabling of encoding MLT

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/Config.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/Config.java
@@ -149,6 +149,7 @@ public class Config {
   public static final String TRACE_SAMPLE_RATE = TracerConfig.TRACE_SAMPLE_RATE;
   public static final String TRACE_RATE_LIMIT = TracerConfig.TRACE_RATE_LIMIT;
   public static final String METHOD_TRACE_SAMPLE_RATE = TracerConfig.METHOD_TRACE_SAMPLE_RATE;
+  public static final String METHOD_TRACE_ENCODE_DATA = TracerConfig.METHOD_TRACE_ENCODE_DATA;
   public static final String TRACE_REPORT_HOSTNAME = TracerConfig.TRACE_REPORT_HOSTNAME;
   public static final String HEADER_TAGS = TracerConfig.HEADER_TAGS;
   public static final String HTTP_SERVER_ERROR_STATUSES = TracerConfig.HTTP_SERVER_ERROR_STATUSES;
@@ -331,6 +332,7 @@ public class Config {
   @Getter private final Double traceRateLimit;
 
   @Getter private final Double methodTraceSampleRate;
+  @Getter private final boolean methodTraceEncodeData;
 
   @Getter private final boolean profilingEnabled;
   @Deprecated private final String profilingUrl;
@@ -498,6 +500,7 @@ public class Config {
     traceRateLimit = getDoubleSettingFromEnvironment(TRACE_RATE_LIMIT, DEFAULT_TRACE_RATE_LIMIT);
 
     methodTraceSampleRate = getDoubleSettingFromEnvironment(METHOD_TRACE_SAMPLE_RATE, null);
+    methodTraceEncodeData = getBooleanSettingFromEnvironment(METHOD_TRACE_ENCODE_DATA, true);
 
     profilingEnabled =
         getBooleanSettingFromEnvironment(PROFILING_ENABLED, DEFAULT_PROFILING_ENABLED);
@@ -723,6 +726,8 @@ public class Config {
 
     methodTraceSampleRate =
         getPropertyDoubleValue(properties, METHOD_TRACE_SAMPLE_RATE, parent.methodTraceSampleRate);
+    methodTraceEncodeData =
+        getPropertyBooleanValue(properties, METHOD_TRACE_ENCODE_DATA, parent.methodTraceEncodeData);
 
     profilingEnabled =
         getPropertyBooleanValue(properties, PROFILING_ENABLED, parent.profilingEnabled);

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
@@ -29,6 +29,9 @@ public final class TracerConfig {
   public static final String TRACE_SAMPLE_RATE = "trace.sample.rate";
   public static final String TRACE_RATE_LIMIT = "trace.rate.limit";
   public static final String METHOD_TRACE_SAMPLE_RATE = "method.trace.sample.rate";
+  /** Temporary config... TODO: remove. */
+  public static final String METHOD_TRACE_ENCODE_DATA = "method.trace.encode.data";
+
   public static final String TRACE_REPORT_HOSTNAME = "trace.report-hostname";
   public static final String HEADER_TAGS = "trace.header.tags";
   public static final String HTTP_SERVER_ERROR_STATUSES = "http.server.error.statuses";

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -34,6 +34,8 @@ public class DDSpan implements MutableSpan, AgentSpan {
   /** The context attached to the span */
   private final DDSpanContext context;
 
+  private byte[] binaryData;
+
   /**
    * Creation time of the span in microseconds provided by external clock. Must be greater than
    * zero.
@@ -389,6 +391,14 @@ public class DDSpan implements MutableSpan, AgentSpan {
 
   public int getError() {
     return context.getErrorFlag() ? 1 : 0;
+  }
+
+  public byte[] getBinaryData() {
+    return binaryData;
+  }
+
+  public void setBinaryData(final byte[] binaryData) {
+    this.binaryData = binaryData;
   }
 
   @Override

--- a/dd-trace-core/src/main/java/datadog/trace/core/StringTables.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/StringTables.java
@@ -32,6 +32,7 @@ public class StringTables {
   public static final byte[] ERROR = "error".getBytes(UTF_8);
   public static final byte[] METRICS = "metrics".getBytes(UTF_8);
   public static final byte[] META = "meta".getBytes(UTF_8);
+  public static final byte[] BLOB = "blob".getBytes(UTF_8);
 
   // intentionally not thread safe; must be maintained to be effectively immutable
   // if a constant registration API is added, should be ensured that this is only used during

--- a/dd-trace-core/src/main/java/datadog/trace/core/processor/rule/MethodLevelTracingDataRule.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/processor/rule/MethodLevelTracingDataRule.java
@@ -1,6 +1,7 @@
 package datadog.trace.core.processor.rule;
 
 import com.google.common.io.BaseEncoding;
+import datadog.trace.api.Config;
 import datadog.trace.bootstrap.instrumentation.api.InstrumentationTags;
 import datadog.trace.core.DDSpan;
 import datadog.trace.core.processor.TraceProcessor;
@@ -18,6 +19,8 @@ public class MethodLevelTracingDataRule implements TraceProcessor.Rule {
   // Guava encoder because the built-in Base64 encoder wasn't added until JDK8
   private static final BaseEncoding ENCODER = BaseEncoding.base64();
 
+  private static final boolean ENCODE_DATA = Config.get().isMethodTraceEncodeData();
+
   @Override
   public String[] aliases() {
     return new String[0];
@@ -29,19 +32,23 @@ public class MethodLevelTracingDataRule implements TraceProcessor.Rule {
 
     if (mltDataObject instanceof byte[]) {
       final byte[] mltData = (byte[]) mltDataObject;
-      int tagIndex = 0;
-      int dataOffset = 0;
+      if (ENCODE_DATA) {
+        int tagIndex = 0;
+        int dataOffset = 0;
 
-      while (dataOffset < mltData.length) {
-        final int dataLength = Math.min(mltData.length - dataOffset, BYTES_LIMIT_PER_TAG);
+        while (dataOffset < mltData.length) {
+          final int dataLength = Math.min(mltData.length - dataOffset, BYTES_LIMIT_PER_TAG);
 
-        final String tag = TAG_PREFIX + tagIndex;
-        final String value = ENCODER.encode(mltData, dataOffset, dataLength);
+          final String tag = TAG_PREFIX + tagIndex;
+          final String value = ENCODER.encode(mltData, dataOffset, dataLength);
 
-        span.setTag(tag, value);
+          span.setTag(tag, value);
 
-        tagIndex++;
-        dataOffset += dataLength;
+          tagIndex++;
+          dataOffset += dataLength;
+        }
+      } else {
+        span.setBinaryData(mltData);
       }
     }
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/serialization/JsonFormatWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/serialization/JsonFormatWriter.java
@@ -117,6 +117,12 @@ public class JsonFormatWriter extends FormatWriter<JsonWriter> {
     writeString(key, String.valueOf(value), destination);
   }
 
+  @Override
+  public void writeBlob(final byte[] key, final byte[] value, final JsonWriter destination)
+      throws IOException {
+    // TODO: not implemented.
+  }
+
   private void writeBigInteger(
       final byte[] key, final BigInteger value, final JsonWriter destination) throws IOException {
     writeKey(key, destination);

--- a/dd-trace-core/src/main/java/datadog/trace/core/serialization/MsgpackFormatWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/serialization/MsgpackFormatWriter.java
@@ -113,6 +113,14 @@ public class MsgpackFormatWriter extends FormatWriter<MessagePacker> {
     }
   }
 
+  @Override
+  public void writeBlob(final byte[] key, final byte[] value, final MessagePacker destination)
+      throws IOException {
+    writeKey(key, destination);
+    destination.packBinaryHeader(value.length);
+    destination.writePayload(value);
+  }
+
   private void writeUTF8Tag(final String value, final MessagePacker destination)
       throws IOException {
     if (null == value) {


### PR DESCRIPTION
When disabled, the profile data will be added as a `blob` field on the msgpack span.

This should only impact the serialization thread, not necessarily improve the application thread request latency.

Use the following setting to disable:
```
-Ddd.method.trace.encode.data=false
```