### PR TITLE
Strict mode and health metrics for scope close failures

### DIFF
--- a/dd-java-agent/instrumentation/opentelemetry/src/main/java/datadog/trace/instrumentation/opentelemetry/OtelTracer.java
+++ b/dd-java-agent/instrumentation/opentelemetry/src/main/java/datadog/trace/instrumentation/opentelemetry/OtelTracer.java
@@ -3,6 +3,7 @@ package datadog.trace.instrumentation.opentelemetry;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import datadog.trace.bootstrap.instrumentation.api.ScopeSource;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import io.opentelemetry.common.AttributeValue;
 import io.opentelemetry.context.Scope;
@@ -33,7 +34,7 @@ public class OtelTracer implements Tracer {
   @Override
   public Scope withSpan(final Span span) {
     final AgentSpan agentSpan = converter.toAgentSpan(span);
-    final AgentScope agentScope = tracer.activateSpan(agentSpan);
+    final AgentScope agentScope = tracer.activateSpan(agentSpan, ScopeSource.MANUAL);
     return converter.toScope(agentScope);
   }
 

--- a/dd-java-agent/instrumentation/opentracing/api-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/OTScopeManager.java
+++ b/dd-java-agent/instrumentation/opentracing/api-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/OTScopeManager.java
@@ -3,6 +3,7 @@ package datadog.trace.instrumentation.opentracing31;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import datadog.trace.bootstrap.instrumentation.api.ScopeSource;
 import datadog.trace.context.TraceScope;
 import io.opentracing.Scope;
 import io.opentracing.ScopeManager;
@@ -20,7 +21,7 @@ public class OTScopeManager implements ScopeManager {
   @Override
   public Scope activate(final Span span, final boolean finishSpanOnClose) {
     final AgentSpan agentSpan = converter.toAgentSpan(span);
-    final AgentScope agentScope = tracer.activateSpan(agentSpan);
+    final AgentScope agentScope = tracer.activateSpan(agentSpan, ScopeSource.MANUAL);
 
     return converter.toScope(agentScope, finishSpanOnClose);
   }

--- a/dd-java-agent/instrumentation/opentracing/api-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/OTTracer.java
+++ b/dd-java-agent/instrumentation/opentracing/api-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/OTTracer.java
@@ -2,6 +2,7 @@ package datadog.trace.instrumentation.opentracing31;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import datadog.trace.bootstrap.instrumentation.api.ScopeSource;
 import datadog.trace.instrumentation.opentracing.DefaultLogHandler;
 import io.opentracing.References;
 import io.opentracing.Scope;
@@ -150,7 +151,8 @@ public class OTTracer implements Tracer {
 
     @Override
     public Scope startActive(final boolean finishSpanOnClose) {
-      return converter.toScope(tracer.activateSpan(delegate.start()), finishSpanOnClose);
+      return converter.toScope(
+          tracer.activateSpan(delegate.start(), ScopeSource.MANUAL), finishSpanOnClose);
     }
   }
 }

--- a/dd-java-agent/instrumentation/opentracing/api-0.31/src/test/groovy/OpenTracing31Test.groovy
+++ b/dd-java-agent/instrumentation/opentracing/api-0.31/src/test/groovy/OpenTracing31Test.groovy
@@ -7,6 +7,8 @@ import datadog.trace.context.TraceScope
 import datadog.trace.core.DDSpan
 import datadog.trace.core.propagation.ExtractedContext
 import io.opentracing.References
+import io.opentracing.Scope
+import io.opentracing.Span
 import io.opentracing.log.Fields
 import io.opentracing.noop.NoopSpan
 import io.opentracing.propagation.Format
@@ -214,6 +216,38 @@ class OpenTracing31Test extends AgentTestRunner {
 
     cleanup:
     scope.close()
+  }
+
+  def "closing scope when not on top"() {
+    when:
+    Span firstSpan = tracer.buildSpan("someOperation").start()
+    Scope firstScope = tracer.scopeManager().activate(firstSpan, false)
+
+    Span secondSpan = tracer.buildSpan("someOperation").start()
+    Scope secondScope = tracer.scopeManager().activate(secondSpan, false)
+
+    firstSpan.finish()
+    firstScope.close()
+
+    then:
+    tracer.scopeManager().active().delegate == secondScope.delegate
+    1 * STATS_D_CLIENT.incrementCounter("scope.close.error")
+    1 * STATS_D_CLIENT.incrementCounter("scope.user.close.error")
+    0 * _
+
+    when:
+    secondSpan.finish()
+    secondScope.close()
+
+    then:
+    tracer.scopeManager().active().delegate == firstScope.delegate
+    0 * _
+
+    when:
+    firstScope.close()
+
+    then:
+    0 * _
   }
 
   def "test inject extract"() {

--- a/dd-java-agent/instrumentation/opentracing/api-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/OTScopeManager.java
+++ b/dd-java-agent/instrumentation/opentracing/api-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/OTScopeManager.java
@@ -3,6 +3,7 @@ package datadog.trace.instrumentation.opentracing32;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import datadog.trace.bootstrap.instrumentation.api.ScopeSource;
 import datadog.trace.context.TraceScope;
 import io.opentracing.Scope;
 import io.opentracing.ScopeManager;
@@ -25,7 +26,7 @@ public class OTScopeManager implements ScopeManager {
   @Override
   public Scope activate(final Span span, final boolean finishSpanOnClose) {
     final AgentSpan agentSpan = converter.toAgentSpan(span);
-    final AgentScope agentScope = tracer.activateSpan(agentSpan);
+    final AgentScope agentScope = tracer.activateSpan(agentSpan, ScopeSource.MANUAL);
 
     return converter.toScope(agentScope, finishSpanOnClose);
   }

--- a/dd-java-agent/instrumentation/opentracing/api-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/OTTracer.java
+++ b/dd-java-agent/instrumentation/opentracing/api-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/OTTracer.java
@@ -2,6 +2,7 @@ package datadog.trace.instrumentation.opentracing32;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import datadog.trace.bootstrap.instrumentation.api.ScopeSource;
 import datadog.trace.instrumentation.opentracing.DefaultLogHandler;
 import io.opentracing.References;
 import io.opentracing.Scope;
@@ -39,7 +40,8 @@ public class OTTracer implements Tracer {
 
   @Override
   public Scope activateSpan(final Span span) {
-    return converter.toScope(tracer.activateSpan(converter.toAgentSpan(span)), false);
+    return converter.toScope(
+        tracer.activateSpan(converter.toAgentSpan(span), ScopeSource.MANUAL), false);
   }
 
   @Override
@@ -169,7 +171,8 @@ public class OTTracer implements Tracer {
 
     @Override
     public Scope startActive(final boolean finishSpanOnClose) {
-      return converter.toScope(tracer.activateSpan(delegate.start()), finishSpanOnClose);
+      return converter.toScope(
+          tracer.activateSpan(delegate.start(), ScopeSource.MANUAL), finishSpanOnClose);
     }
   }
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/Config.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/Config.java
@@ -162,6 +162,7 @@ public class Config {
       TraceInstrumentationConfig.DB_CLIENT_HOST_SPLIT_BY_INSTANCE;
   public static final String SPLIT_BY_TAGS = TracerConfig.SPLIT_BY_TAGS;
   public static final String SCOPE_DEPTH_LIMIT = TracerConfig.SCOPE_DEPTH_LIMIT;
+  public static final String SCOPE_STRICT_MODE = TracerConfig.SCOPE_STRICT_MODE;
   public static final String PARTIAL_FLUSH_MIN_SPANS = TracerConfig.PARTIAL_FLUSH_MIN_SPANS;
   public static final String RUNTIME_CONTEXT_FIELD_INJECTION =
       TraceInstrumentationConfig.RUNTIME_CONTEXT_FIELD_INJECTION;
@@ -293,6 +294,7 @@ public class Config {
   @Getter private final boolean dbClientSplitByInstance;
   @Getter private final Set<String> splitByTags;
   @Getter private final Integer scopeDepthLimit;
+  @Getter private final boolean scopeStrictMode;
   @Getter private final Integer partialFlushMinSpans;
   @Getter private final boolean runtimeContextFieldInjection;
   @Getter private final Set<PropagationStyle> propagationStylesToExtract;
@@ -438,6 +440,8 @@ public class Config {
 
     scopeDepthLimit =
         getIntegerSettingFromEnvironment(SCOPE_DEPTH_LIMIT, DEFAULT_SCOPE_DEPTH_LIMIT);
+
+    scopeStrictMode = getBooleanSettingFromEnvironment(SCOPE_STRICT_MODE, false);
 
     partialFlushMinSpans =
         getIntegerSettingFromEnvironment(PARTIAL_FLUSH_MIN_SPANS, DEFAULT_PARTIAL_FLUSH_MIN_SPANS);
@@ -647,6 +651,9 @@ public class Config {
 
     scopeDepthLimit =
         getPropertyIntegerValue(properties, SCOPE_DEPTH_LIMIT, parent.scopeDepthLimit);
+
+    scopeStrictMode =
+        getPropertyBooleanValue(properties, SCOPE_STRICT_MODE, parent.scopeStrictMode);
 
     partialFlushMinSpans =
         getPropertyIntegerValue(properties, PARTIAL_FLUSH_MIN_SPANS, parent.partialFlushMinSpans);

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
@@ -36,6 +36,7 @@ public final class TracerConfig {
   public static final String SPLIT_BY_TAGS = "trace.split-by-tags";
 
   public static final String SCOPE_DEPTH_LIMIT = "trace.scope.depth.limit";
+  public static final String SCOPE_STRICT_MODE = "trace.scope.strict.mode";
   public static final String PARTIAL_FLUSH_MIN_SPANS = "trace.partial.flush.min.spans";
   public static final String PROPAGATION_STYLE_EXTRACT = "propagation.style.extract";
   public static final String PROPAGATION_STYLE_INJECT = "propagation.style.inject";

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -13,6 +13,7 @@ import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentScopeManager;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import datadog.trace.bootstrap.instrumentation.api.ScopeSource;
 import datadog.trace.bootstrap.instrumentation.api.WriterConstants;
 import datadog.trace.common.sampling.PrioritySampler;
 import datadog.trace.common.sampling.Sampler;
@@ -297,9 +298,13 @@ public class CoreTracer implements AgentTracer.TracerAPI {
         .start();
   }
 
-  @Override
   public AgentScope activateSpan(final AgentSpan span) {
-    return scopeManager.activate(span);
+    return scopeManager.activate(span, ScopeSource.INSTRUMENTATION);
+  }
+
+  @Override
+  public AgentScope activateSpan(final AgentSpan span, final ScopeSource source) {
+    return scopeManager.activate(span, source);
   }
 
   @Override

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerDepthTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerDepthTest.groovy
@@ -4,6 +4,7 @@ import datadog.trace.api.config.TracerConfig
 import datadog.trace.bootstrap.instrumentation.api.AgentScope
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer.NoopAgentScope
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer.NoopAgentSpan
+import datadog.trace.bootstrap.instrumentation.api.ScopeSource
 import datadog.trace.common.writer.ListWriter
 import datadog.trace.core.CoreTracer
 import datadog.trace.util.test.DDSpecification
@@ -35,7 +36,7 @@ class ScopeManagerDepthTest extends DDSpecification {
     scope instanceof NoopAgentScope
 
     when: "activate a noop scope over the limit"
-    scope = scopeManager.activate(NoopAgentSpan.INSTANCE)
+    scope = scopeManager.activate(NoopAgentSpan.INSTANCE, ScopeSource.MANUAL)
 
     then: "still have a noop instance"
     scope instanceof NoopAgentScope
@@ -78,7 +79,7 @@ class ScopeManagerDepthTest extends DDSpecification {
     (scopeManager.active() as ContinuableScopeManager.ContinuableScope).depth() == defaultLimit + 1
 
     when: "activate a noop span"
-    scope = scopeManager.activate(NoopAgentSpan.INSTANCE)
+    scope = scopeManager.activate(NoopAgentSpan.INSTANCE, ScopeSource.MANUAL)
 
     then: "a real instance is still returned"
     !(scope instanceof NoopAgentScope)

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerTest.groovy
@@ -1,15 +1,15 @@
 package datadog.trace.core.scopemanager
 
+import com.timgroup.statsd.StatsDClient
 import datadog.trace.bootstrap.instrumentation.api.AgentScope
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer.NoopAgentSpan
+import datadog.trace.bootstrap.instrumentation.api.ScopeSource
 import datadog.trace.common.writer.ListWriter
 import datadog.trace.context.ScopeListener
 import datadog.trace.core.CoreTracer
 import datadog.trace.core.DDSpan
 import datadog.trace.util.test.DDSpecification
-import spock.lang.Shared
-import spock.lang.Subject
 import spock.lang.Timeout
 
 import java.lang.ref.WeakReference
@@ -22,18 +22,13 @@ import static java.util.concurrent.TimeUnit.SECONDS
 
 class ScopeManagerTest extends DDSpecification {
 
-  @Shared
   CountDownLatch latch
-  @Shared
   ListWriter writer
-  @Shared
   CoreTracer tracer
-
-  @Shared
-  @Subject
   ContinuableScopeManager scopeManager
+  StatsDClient statsDClient
 
-  def setupSpec() {
+  def setup() {
     latch = new CountDownLatch(1)
     final currentLatch = latch
     writer = new ListWriter() {
@@ -41,19 +36,18 @@ class ScopeManagerTest extends DDSpecification {
         currentLatch.countDown()
       }
     }
-    tracer = CoreTracer.builder().writer(writer).build()
+    statsDClient = Mock()
+    tracer = CoreTracer.builder().writer(writer).statsDClient(statsDClient).build()
     scopeManager = tracer.scopeManager
   }
 
   def cleanup() {
-    scopeManager.tlsScope.remove()
-    scopeManager.scopeListeners.clear()
-    writer.clear()
+    ContinuableScopeManager.tlsScope.remove()
   }
 
   def "non-ddspan activation results in a continuable scope"() {
     when:
-    def scope = scopeManager.activate(NoopAgentSpan.INSTANCE)
+    def scope = scopeManager.activate(NoopAgentSpan.INSTANCE, ScopeSource.INSTRUMENTATION)
 
     then:
     scopeManager.active() == scope
@@ -336,32 +330,23 @@ class ScopeManagerTest extends DDSpecification {
     scopeManager.tlsScope.get() == newScope
   }
 
-  def "add scope listener"() {
+  def "test activating same scope multiple times"() {
     setup:
-    AtomicInteger activatedCount = new AtomicInteger(0)
-    AtomicInteger closedCount = new AtomicInteger(0)
+    def eventCountingLister = new EventCountingListener()
+    AtomicInteger activatedCount = eventCountingLister.activatedCount
+    AtomicInteger closedCount = eventCountingLister.closedCount
 
-    scopeManager.addScopeListener(new ScopeListener() {
-      @Override
-      void afterScopeActivated() {
-        activatedCount.incrementAndGet()
-      }
-
-      @Override
-      void afterScopeClosed() {
-        closedCount.incrementAndGet()
-      }
-    })
+    scopeManager.addScopeListener(eventCountingLister)
 
     when:
-    AgentScope scope1 = scopeManager.activate(NoopAgentSpan.INSTANCE)
+    AgentScope scope1 = scopeManager.activate(NoopAgentSpan.INSTANCE, ScopeSource.INSTRUMENTATION)
 
     then:
     activatedCount.get() == 1
     closedCount.get() == 0
 
     when:
-    AgentScope scope2 = scopeManager.activate(NoopAgentSpan.INSTANCE)
+    AgentScope scope2 = scopeManager.activate(NoopAgentSpan.INSTANCE, ScopeSource.INSTRUMENTATION)
 
     then: 'Activating the same span multiple times does not create a new scope'
     activatedCount.get() == 1
@@ -380,6 +365,15 @@ class ScopeManagerTest extends DDSpecification {
     then:
     activatedCount.get() == 1
     closedCount.get() == 1
+  }
+
+  def "opening and closing multiple scopes"() {
+    setup:
+    def eventCountingLister = new EventCountingListener()
+    AtomicInteger activatedCount = eventCountingLister.activatedCount
+    AtomicInteger closedCount = eventCountingLister.closedCount
+
+    scopeManager.addScopeListener(eventCountingLister)
 
     when:
     AgentSpan span = tracer.buildSpan("foo").start()
@@ -387,8 +381,8 @@ class ScopeManagerTest extends DDSpecification {
 
     then:
     continuableScope instanceof ScopeInterceptor.Scope
-    activatedCount.get() == 2
-    closedCount.get() == 1
+    activatedCount.get() == 1
+    closedCount.get() == 0
 
     when:
     AgentSpan childSpan = tracer.buildSpan("foo").start()
@@ -396,27 +390,83 @@ class ScopeManagerTest extends DDSpecification {
 
     then:
     childDDScope instanceof ScopeInterceptor.Scope
-    activatedCount.get() == 3
-    closedCount.get() == 1
+    activatedCount.get() == 2
+    closedCount.get() == 0
 
     when:
     childDDScope.close()
     childSpan.finish()
 
     then:
-    activatedCount.get() == 3
-    closedCount.get() == 2
+    activatedCount.get() == 2
+    closedCount.get() == 1
 
     when:
     continuableScope.close()
     span.finish()
 
     then:
-    activatedCount.get() == 3 // the last scope closed was the last one on the stack so nothing more got activated
-    closedCount.get() == 3
+    activatedCount.get() == 2
+    closedCount.get() == 2
+  }
+
+  def "scope not closed when not on top"() {
+    setup:
+    def eventCountingLister = new EventCountingListener()
+    AtomicInteger activatedCount = eventCountingLister.activatedCount
+    AtomicInteger closedCount = eventCountingLister.closedCount
+
+    scopeManager.addScopeListener(eventCountingLister)
+
+    when:
+    AgentSpan firstSpan = tracer.buildSpan("foo").start()
+    AgentScope firstScope = tracer.activateSpan(firstSpan)
+
+    AgentSpan secondSpan = tracer.buildSpan("foo").start()
+    AgentScope secondScope = tracer.activateSpan(secondSpan)
+
+    firstSpan.finish()
+    firstScope.close()
+
+    then:
+    activatedCount.get() == 2
+    closedCount.get() == 0
+    1 * statsDClient.incrementCounter("scope.close.error")
+    0 * _
+
+    when:
+    secondSpan.finish()
+    secondScope.close()
+
+    then:
+    activatedCount.get() == 2
+    closedCount.get() == 1
+    0 * _
+
+    when:
+    firstScope.close()
+
+    then:
+    activatedCount.get() == 2
+    closedCount.get() == 2
+    0 * _
   }
 
   boolean spanFinished(AgentSpan span) {
     return ((DDSpan) span)?.isFinished()
+  }
+}
+
+class EventCountingListener implements ScopeListener {
+  AtomicInteger activatedCount = new AtomicInteger(0)
+  AtomicInteger closedCount = new AtomicInteger(0)
+
+  void afterScopeActivated() {
+    activatedCount.incrementAndGet()
+  }
+
+  @Override
+  void afterScopeClosed() {
+    closedCount.incrementAndGet()
   }
 }

--- a/dd-trace-ot/src/main/java/datadog/opentracing/CustomScopeManagerWrapper.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/CustomScopeManagerWrapper.java
@@ -3,6 +3,7 @@ package datadog.opentracing;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentScopeManager;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.ScopeSource;
 import datadog.trace.context.TraceScope;
 import io.opentracing.Scope;
 import io.opentracing.ScopeManager;
@@ -34,7 +35,7 @@ class CustomScopeManagerWrapper implements AgentScopeManager {
   }
 
   @Override
-  public AgentScope activate(final AgentSpan agentSpan) {
+  public AgentScope activate(final AgentSpan agentSpan, final ScopeSource source) {
     final Span span = converter.toSpan(agentSpan);
     final Scope scope = delegate.activate(span);
 

--- a/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
@@ -1,5 +1,6 @@
 package datadog.opentracing;
 
+import com.timgroup.statsd.StatsDClient;
 import datadog.trace.api.Config;
 import datadog.trace.api.DDTags;
 import datadog.trace.api.interceptor.TraceInterceptor;
@@ -193,7 +194,8 @@ public class DDTracer implements Tracer, datadog.trace.api.Tracer {
       final Map<String, String> serviceNameMappings,
       final Map<String, String> taggedHeaders,
       final int partialFlushMinSpans,
-      final LogHandler logHandler) {
+      final LogHandler logHandler,
+      final StatsDClient statsDClient) {
 
     if (logHandler != null) {
       converter = new TypeConverter(logHandler);
@@ -252,6 +254,10 @@ public class DDTracer implements Tracer, datadog.trace.api.Tracer {
 
     if (partialFlushMinSpans != 0) {
       builder = builder.partialFlushMinSpans(partialFlushMinSpans);
+    }
+
+    if (statsDClient != null) {
+      builder = builder.statsDClient(statsDClient);
     }
 
     tracer = builder.build();

--- a/dd-trace-ot/src/main/java/datadog/opentracing/OTScopeManager.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/OTScopeManager.java
@@ -3,6 +3,7 @@ package datadog.opentracing;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import datadog.trace.bootstrap.instrumentation.api.ScopeSource;
 import datadog.trace.context.TraceScope;
 import io.opentracing.Scope;
 import io.opentracing.ScopeManager;
@@ -27,7 +28,7 @@ class OTScopeManager implements ScopeManager {
   @Override
   public Scope activate(final Span span, final boolean finishSpanOnClose) {
     final AgentSpan agentSpan = converter.toAgentSpan(span);
-    final AgentScope agentScope = tracer.activateSpan(agentSpan);
+    final AgentScope agentScope = tracer.activateSpan(agentSpan, ScopeSource.MANUAL);
 
     return converter.toScope(agentScope, finishSpanOnClose);
   }

--- a/internal-api/internal-api.gradle
+++ b/internal-api/internal-api.gradle
@@ -14,6 +14,7 @@ excludedClassesCoverage += [
   "datadog.trace.bootstrap.instrumentation.api.AgentTracer.NoopAgentScope",
   "datadog.trace.bootstrap.instrumentation.api.AgentTracer.NoopTracerAPI",
   "datadog.trace.bootstrap.instrumentation.api.AgentTracer.NoopAgentTrace",
+  "datadog.trace.bootstrap.instrumentation.api.ScopeSource",
 ]
 
 dependencies {

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentScopeManager.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentScopeManager.java
@@ -6,7 +6,8 @@ import datadog.trace.context.TraceScope;
  * Allows custom scope managers. See OTScopeManager, CustomScopeManager, and ContextualScopeManager
  */
 public interface AgentScopeManager {
-  AgentScope activate(AgentSpan span);
+
+  AgentScope activate(AgentSpan span, ScopeSource source);
 
   TraceScope active();
 

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -38,7 +38,7 @@ public class AgentTracer {
   }
 
   public static AgentScope activateSpan(final AgentSpan span) {
-    return get().activateSpan(span);
+    return get().activateSpan(span, ScopeSource.INSTRUMENTATION);
   }
 
   public static AgentSpan activeSpan() {
@@ -89,7 +89,7 @@ public class AgentTracer {
 
     AgentSpan startSpan(String spanName, AgentSpan.Context parent, long startTimeMicros);
 
-    AgentScope activateSpan(AgentSpan span);
+    AgentScope activateSpan(AgentSpan span, ScopeSource source);
 
     AgentSpan activeSpan();
 
@@ -156,7 +156,7 @@ public class AgentTracer {
     }
 
     @Override
-    public AgentScope activateSpan(final AgentSpan span) {
+    public AgentScope activateSpan(final AgentSpan span, final ScopeSource source) {
       return NoopAgentScope.INSTANCE;
     }
 
@@ -267,7 +267,7 @@ public class AgentTracer {
     }
 
     @Override
-    public Object getTag(String key) {
+    public Object getTag(final String key) {
       return null;
     }
 

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/ScopeSource.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/ScopeSource.java
@@ -1,0 +1,6 @@
+package datadog.trace.bootstrap.instrumentation.api;
+
+public enum ScopeSource {
+  INSTRUMENTATION,
+  MANUAL
+}


### PR DESCRIPTION
This pull requests addresses silent failures when trying to close scopes by:

1.  Incrementing a statsd counter when a scope is not closed because it is not on top
2. Adding the `dd.trace.scope.strict.mode` flag where this error throws a `RuntimeException` instead of being silent

To accomplish this, `ContinuableScope` now tracks whether the scope was created manually or through automatic instrumentation.  This change is completely internal.  No instrumentation or external APIs changed.