### PR TITLE
add config based base64 decoding to kafka instrumentation

### DIFF
--- a/dd-java-agent/instrumentation/kafka-clients-0.11/kafka-clients-0.11.gradle
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/kafka-clients-0.11.gradle
@@ -26,6 +26,7 @@ dependencies {
   testCompile group: 'javax.xml.bind', name: 'jaxb-api', version: '2.2.3'
   testCompile group: 'org.assertj', name: 'assertj-core', version: '2.9.+'
   testCompile group: 'org.mockito', name: 'mockito-core', version: '2.19.0'
+  testCompile deps.guava
 
   // Include latest version of kafka itself along with latest version of client libs.
   // This seems to help with jar compatibility hell.
@@ -36,4 +37,5 @@ dependencies {
   latestDepTestCompile group: 'org.springframework.kafka', name: 'spring-kafka', version: '2.2.+'
   latestDepTestCompile group: 'org.springframework.kafka', name: 'spring-kafka-test', version: '2.2.+'
   latestDepTestCompile group: 'org.assertj', name: 'assertj-core', version: '3.+'
+  latestDepTestCompile deps.guava
 }

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/Base64Decoder.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/Base64Decoder.java
@@ -1,0 +1,131 @@
+package datadog.trace.instrumentation.kafka_clients;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+// TODO - can be removed when JDK7 is dropped (adapted from JDK8 source)
+public class Base64Decoder {
+
+  private static final int[] BASE_64 = new int[256];
+
+  static {
+    Arrays.fill(BASE_64, -1);
+    int i = 0;
+    for (char c = 'A'; c <= 'Z'; ++c) {
+      BASE_64[c] = i++;
+    }
+    for (char c = 'a'; c <= 'z'; ++c) {
+      BASE_64[c] = i++;
+    }
+    for (char c = '0'; c <= '9'; ++c) {
+      BASE_64[c] = i++;
+    }
+    BASE_64['+'] = i++;
+    BASE_64['/'] = i;
+    BASE_64['='] = -2;
+  }
+
+  public byte[] decode(byte[] src) {
+    byte[] dst = new byte[outLength(src, 0, src.length)];
+    int ret = decode0(src, 0, src.length, dst);
+    if (ret != dst.length) {
+      dst = Arrays.copyOf(dst, ret);
+    }
+    return dst;
+  }
+
+  public byte[] decode(String src) {
+    return decode(src.getBytes(StandardCharsets.ISO_8859_1));
+  }
+
+  private int outLength(byte[] src, int sp, int sl) {
+    int paddings = 0;
+    int len = sl - sp;
+    if (len == 0) return 0;
+    if (len < 2) {
+      if (BASE_64[0] == -1) return 0;
+      throw new IllegalArgumentException(
+          "Input byte[] should at least have 2 bytes for base64 bytes");
+    }
+    // scan all bytes to fill out all non-alphabet. a performance
+    // trade-off of pre-scan or Arrays.copyOf
+    int n = 0;
+    while (sp < sl) {
+      int b = src[sp++] & 0xff;
+      if (b == '=') {
+        len -= (sl - sp + 1);
+        break;
+      }
+      if ((b = BASE_64[b]) == -1) n++;
+    }
+    len -= n;
+    if ((len & 0x3) != 0) paddings = 4 - (len & 0x3);
+    return 3 * ((len + 3) / 4) - paddings;
+  }
+
+  private int decode0(byte[] src, int sp, int sl, byte[] dst) {
+    int dp = 0;
+    int bits = 0;
+    int shiftto = 18; // pos of first byte of 4-byte atom
+
+    while (sp < sl) {
+      if (shiftto == 18 && sp + 4 < sl) { // fast path
+        int sl0 = sp + ((sl - sp) & ~0b11);
+        while (sp < sl0) {
+          int b1 = BASE_64[src[sp++] & 0xff];
+          int b2 = BASE_64[src[sp++] & 0xff];
+          int b3 = BASE_64[src[sp++] & 0xff];
+          int b4 = BASE_64[src[sp++] & 0xff];
+          if ((b1 | b2 | b3 | b4) < 0) { // non base64 byte
+            sp -= 4;
+            break;
+          }
+          int bits0 = b1 << 18 | b2 << 12 | b3 << 6 | b4;
+          dst[dp++] = (byte) (bits0 >> 16);
+          dst[dp++] = (byte) (bits0 >> 8);
+          dst[dp++] = (byte) (bits0);
+        }
+        if (sp >= sl) break;
+      }
+      int b = src[sp++] & 0xff;
+      if ((b = BASE_64[b]) < 0) {
+        if (b == -2) { // padding byte '='
+          // =     shiftto==18 unnecessary padding
+          // x=    shiftto==12 a dangling single x
+          // x     to be handled together with non-padding case
+          // xx=   shiftto==6&&sp==sl missing last =
+          // xx=y  shiftto==6 last is not =
+          if (shiftto == 6 && (sp == sl || src[sp++] != '=') || shiftto == 18) {
+            throw new IllegalArgumentException("Input byte array has wrong 4-byte ending unit");
+          }
+          break;
+        }
+      }
+      bits |= (b << shiftto);
+      shiftto -= 6;
+      if (shiftto < 0) {
+        dst[dp++] = (byte) (bits >> 16);
+        dst[dp++] = (byte) (bits >> 8);
+        dst[dp++] = (byte) (bits);
+        shiftto = 18;
+        bits = 0;
+      }
+    }
+    // reached end of byte array or hit padding '=' characters.
+    if (shiftto == 6) {
+      dst[dp++] = (byte) (bits >> 16);
+    } else if (shiftto == 0) {
+      dst[dp++] = (byte) (bits >> 16);
+      dst[dp++] = (byte) (bits >> 8);
+    } else if (shiftto == 12) {
+      // dangling single "x", incorrectly encoded.
+      throw new IllegalArgumentException("Last unit does not have enough valid bits");
+    }
+    // ignore all non-base64 character
+    while (sp < sl) {
+      if (BASE_64[src[sp++] & 0xff] < 0) continue;
+      throw new IllegalArgumentException("Input byte array has incorrect ending byte at " + sp);
+    }
+    return dp;
+  }
+}

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaConsumerInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaConsumerInstrumentation.java
@@ -39,7 +39,8 @@ public final class KafkaConsumerInstrumentation extends Instrumenter.Default {
       packageName + ".TextMapExtractAdapter",
       packageName + ".TracingIterable",
       packageName + ".TracingIterator",
-      packageName + ".TracingList"
+      packageName + ".TracingList",
+      packageName + ".Base64Decoder"
     };
   }
 

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TextMapExtractAdapter.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TextMapExtractAdapter.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.kafka_clients;
 
+import datadog.trace.api.Config;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -9,7 +10,16 @@ import org.apache.kafka.common.header.Headers;
 
 public class TextMapExtractAdapter implements AgentPropagation.Getter<Headers> {
 
-  public static final TextMapExtractAdapter GETTER = new TextMapExtractAdapter();
+  public static final TextMapExtractAdapter GETTER =
+      new TextMapExtractAdapter(Config.get().isKafkaClientBase64DecodingEnabled());
+
+  private final boolean base64DecodeHeaders;
+  private final Base64Decoder base64;
+
+  public TextMapExtractAdapter(boolean base64DecodeHeaders) {
+    this.base64DecodeHeaders = base64DecodeHeaders;
+    this.base64 = base64DecodeHeaders ? new Base64Decoder() : null;
+  }
 
   @Override
   public Iterable<String> keys(final Headers headers) {
@@ -28,6 +38,9 @@ public class TextMapExtractAdapter implements AgentPropagation.Getter<Headers> {
     }
     if (header.value() == null) {
       return null;
+    }
+    if (base64DecodeHeaders) {
+      return new String(base64.decode(header.value()), StandardCharsets.UTF_8);
     }
     return new String(header.value(), StandardCharsets.UTF_8);
   }

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/TextMapExtractAdapterTest.groovy
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/TextMapExtractAdapterTest.groovy
@@ -1,0 +1,27 @@
+import com.google.common.io.BaseEncoding
+import datadog.trace.instrumentation.kafka_clients.TextMapExtractAdapter
+import datadog.trace.util.test.DDSpecification
+import org.apache.kafka.common.header.Headers
+import org.apache.kafka.common.header.internals.RecordHeader
+import org.apache.kafka.common.header.internals.RecordHeaders
+
+import java.nio.charset.StandardCharsets
+
+class TextMapExtractAdapterTest extends DDSpecification {
+
+  def "check can decode base64 mangled headers" () {
+    given:
+    def base64 = BaseEncoding.base64().encode("foo".getBytes(StandardCharsets.UTF_8))
+    def expectedValue = base64Decode ? "foo" : base64
+    Headers headers = new RecordHeaders(new RecordHeader("key", base64.getBytes(StandardCharsets.UTF_8)))
+    TextMapExtractAdapter adapter = new TextMapExtractAdapter(base64Decode)
+    when:
+    def extracted = adapter.get(headers, "key")
+
+    then:
+    extracted == expectedValue
+
+    where:
+    base64Decode << [true, false]
+  }
+}

--- a/dd-trace-api/dd-trace-api.gradle
+++ b/dd-trace-api/dd-trace-api.gradle
@@ -9,8 +9,7 @@ excludedClassesCoverage += [
   'datadog.trace.api.DDTraceApiInfo',
   'datadog.trace.api.GlobalTracer*',
   'datadog.trace.api.CorrelationIdentifier',
-  'datadog.trace.api.DDTags',
-  'datadog.trace.api.DDId.Base64Decoder'
+  'datadog.trace.api.DDTags'
 ]
 
 description = 'dd-trace-api'

--- a/dd-trace-api/src/main/java/datadog/trace/api/Config.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/Config.java
@@ -229,6 +229,9 @@ public class Config {
   public static final String KAFKA_CLIENT_PROPAGATION_ENABLED =
       TraceInstrumentationConfig.KAFKA_CLIENT_PROPAGATION_ENABLED;
 
+  public static final String KAFKA_CLIENT_BASE64_DECODING_ENABLED =
+      TraceInstrumentationConfig.KAFKA_CLIENT_BASE64_DECODING_ENABLED;
+
   private static final String PROFILING_REMOTE_URL_TEMPLATE = "https://intake.profile.%s/v1/input";
   private static final String PROFILING_LOCAL_URL_TEMPLATE = "http://%s:%d/profiling/v1/input";
 
@@ -349,6 +352,7 @@ public class Config {
   @Getter private final int profilingExceptionHistogramMaxCollectionSize;
 
   @Getter private final boolean kafkaClientPropagationEnabled;
+  @Getter private final boolean kafkaClientBase64DecodingEnabled;
 
   // Values from an optionally provided properties file
   private static Properties propertiesFromConfigFile;
@@ -572,6 +576,9 @@ public class Config {
         getBooleanSettingFromEnvironment(
             KAFKA_CLIENT_PROPAGATION_ENABLED, DEFAULT_KAFKA_CLIENT_PROPAGATION_ENABLED);
 
+    kafkaClientBase64DecodingEnabled =
+        getBooleanSettingFromEnvironment(KAFKA_CLIENT_BASE64_DECODING_ENABLED, false);
+
     // Setting this last because we have a few places where this can come from
     apiKey = tmpApiKey;
 
@@ -768,6 +775,12 @@ public class Config {
     kafkaClientPropagationEnabled =
         getPropertyBooleanValue(
             properties, KAFKA_CLIENT_PROPAGATION_ENABLED, parent.kafkaClientPropagationEnabled);
+
+    kafkaClientBase64DecodingEnabled =
+        getPropertyBooleanValue(
+            properties,
+            KAFKA_CLIENT_BASE64_DECODING_ENABLED,
+            parent.kafkaClientBase64DecodingEnabled);
 
     log.debug("New instance: {}", this);
   }

--- a/dd-trace-api/src/main/java/datadog/trace/api/DDId.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/DDId.java
@@ -1,7 +1,5 @@
 package datadog.trace.api;
 
-import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 import java.util.concurrent.ThreadLocalRandom;
 import lombok.extern.slf4j.Slf4j;
 
@@ -17,8 +15,6 @@ public class DDId {
 
   public static final DDId ZERO = new DDId(0, "0");
   public static final DDId MAX = new DDId(-1, "18446744073709551615"); // All bits set
-
-  private static final Base64Decoder BASE64 = new Base64Decoder();
 
   // Convenience constant used from tests
   private static final DDId ONE = DDId.from(1);
@@ -60,26 +56,7 @@ public class DDId {
    * @throws NumberFormatException
    */
   public static DDId from(String s) throws NumberFormatException {
-    try {
-      return DDId.create(parseUnsignedLong(s), s);
-    } catch (NumberFormatException e) {
-      // we have reports of Kakfa mirror maker base64 encoding record headers
-      // attempting to base64 decode the ids here rather than in the Kafka instrumentation
-      // helps users understand they have a problem without making other users pay for it
-      if (null != s) {
-        try {
-          String decoded = new String(BASE64.decode(s), StandardCharsets.ISO_8859_1);
-          log.debug(
-              "id {} was base 64 encoded to {}, it was decoded but this indicates there is a problem elsewhere in your system",
-              decoded,
-              s);
-          return DDId.create(parseUnsignedLong(decoded), decoded);
-        } catch (Exception ignored) {
-
-        }
-      }
-      throw e;
-    }
+    return DDId.create(parseUnsignedLong(s), s);
   }
 
   /**
@@ -91,26 +68,7 @@ public class DDId {
    * @throws NumberFormatException
    */
   public static DDId fromHex(String s) throws NumberFormatException {
-    try {
-      long id = parseUnsignedLongHex(s);
-      return DDId.create(id, null);
-    } catch (NumberFormatException e) {
-      // we have reports of Kakfa mirror maker base64 encoding record headers
-      // attempting to base64 decode the ids here rather than in the Kafka instrumentation
-      // helps users understand they have a problem without making other users pay for it
-      if (null != s) {
-        try {
-          String decoded = new String(BASE64.decode(s), StandardCharsets.ISO_8859_1);
-          log.debug(
-              "id {} was base 64 encoded to {}, it was decoded but this indicates there is a problem elsewhere in your system",
-              decoded,
-              s);
-          return DDId.create(parseUnsignedLongHex(decoded), null);
-        } catch (Exception ignored) {
-        }
-      }
-      throw e;
-    }
+    return DDId.create(parseUnsignedLongHex(s), null);
   }
 
   private final long id;
@@ -213,133 +171,6 @@ public class DDId {
       return result;
     } else {
       throw new NumberFormatException("Empty input string");
-    }
-  }
-
-  // TODO - can be removed when JDK7 is dropped (adapted from JDK8 source)
-  private static class Base64Decoder {
-
-    private static final int[] BASE_64 = new int[256];
-
-    static {
-      Arrays.fill(BASE_64, -1);
-      int i = 0;
-      for (char c = 'A'; c <= 'Z'; ++c) {
-        BASE_64[c] = i++;
-      }
-      for (char c = 'a'; c <= 'z'; ++c) {
-        BASE_64[c] = i++;
-      }
-      for (char c = '0'; c <= '9'; ++c) {
-        BASE_64[c] = i++;
-      }
-      BASE_64['+'] = i++;
-      BASE_64['/'] = i;
-      BASE_64['='] = -2;
-    }
-
-    public byte[] decode(byte[] src) {
-      byte[] dst = new byte[outLength(src, 0, src.length)];
-      int ret = decode0(src, 0, src.length, dst);
-      if (ret != dst.length) {
-        dst = Arrays.copyOf(dst, ret);
-      }
-      return dst;
-    }
-
-    public byte[] decode(String src) {
-      return decode(src.getBytes(StandardCharsets.ISO_8859_1));
-    }
-
-    private int outLength(byte[] src, int sp, int sl) {
-      int paddings = 0;
-      int len = sl - sp;
-      if (len == 0) return 0;
-      if (len < 2) {
-        if (BASE_64[0] == -1) return 0;
-        throw new IllegalArgumentException(
-            "Input byte[] should at least have 2 bytes for base64 bytes");
-      }
-      // scan all bytes to fill out all non-alphabet. a performance
-      // trade-off of pre-scan or Arrays.copyOf
-      int n = 0;
-      while (sp < sl) {
-        int b = src[sp++] & 0xff;
-        if (b == '=') {
-          len -= (sl - sp + 1);
-          break;
-        }
-        if ((b = BASE_64[b]) == -1) n++;
-      }
-      len -= n;
-      if ((len & 0x3) != 0) paddings = 4 - (len & 0x3);
-      return 3 * ((len + 3) / 4) - paddings;
-    }
-
-    private int decode0(byte[] src, int sp, int sl, byte[] dst) {
-      int dp = 0;
-      int bits = 0;
-      int shiftto = 18; // pos of first byte of 4-byte atom
-
-      while (sp < sl) {
-        if (shiftto == 18 && sp + 4 < sl) { // fast path
-          int sl0 = sp + ((sl - sp) & ~0b11);
-          while (sp < sl0) {
-            int b1 = BASE_64[src[sp++] & 0xff];
-            int b2 = BASE_64[src[sp++] & 0xff];
-            int b3 = BASE_64[src[sp++] & 0xff];
-            int b4 = BASE_64[src[sp++] & 0xff];
-            if ((b1 | b2 | b3 | b4) < 0) { // non base64 byte
-              sp -= 4;
-              break;
-            }
-            int bits0 = b1 << 18 | b2 << 12 | b3 << 6 | b4;
-            dst[dp++] = (byte) (bits0 >> 16);
-            dst[dp++] = (byte) (bits0 >> 8);
-            dst[dp++] = (byte) (bits0);
-          }
-          if (sp >= sl) break;
-        }
-        int b = src[sp++] & 0xff;
-        if ((b = BASE_64[b]) < 0) {
-          if (b == -2) { // padding byte '='
-            // =     shiftto==18 unnecessary padding
-            // x=    shiftto==12 a dangling single x
-            // x     to be handled together with non-padding case
-            // xx=   shiftto==6&&sp==sl missing last =
-            // xx=y  shiftto==6 last is not =
-            if (shiftto == 6 && (sp == sl || src[sp++] != '=') || shiftto == 18) {
-              throw new IllegalArgumentException("Input byte array has wrong 4-byte ending unit");
-            }
-            break;
-          }
-        }
-        bits |= (b << shiftto);
-        shiftto -= 6;
-        if (shiftto < 0) {
-          dst[dp++] = (byte) (bits >> 16);
-          dst[dp++] = (byte) (bits >> 8);
-          dst[dp++] = (byte) (bits);
-          shiftto = 18;
-          bits = 0;
-        }
-      }
-      // reached end of byte array or hit padding '=' characters.
-      if (shiftto == 6) {
-        dst[dp++] = (byte) (bits >> 16);
-      } else if (shiftto == 0) {
-        dst[dp++] = (byte) (bits >> 16);
-        dst[dp++] = (byte) (bits >> 8);
-      } else if (shiftto == 12) {
-        // dangling single "x", incorrectly encoded.
-        throw new IllegalArgumentException("Last unit does not have enough valid bits");
-      }
-      // ignore all non-base64 character
-      while (sp < sl) {
-        if (BASE_64[src[sp++] & 0xff] < 0) continue;
-        throw new IllegalArgumentException("Input byte array has incorrect ending byte at " + sp);
-      }
-      return dp;
     }
   }
 

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
@@ -29,6 +29,8 @@ public final class TraceInstrumentationConfig {
   public static final String LOGS_INJECTION_ENABLED = "logs.injection";
 
   public static final String KAFKA_CLIENT_PROPAGATION_ENABLED = "kafka.client.propagation.enabled";
+  public static final String KAFKA_CLIENT_BASE64_DECODING_ENABLED =
+      "kafka.client.base64.decoding.enabled";
 
   private TraceInstrumentationConfig() {}
 }

--- a/dd-trace-api/src/test/groovy/datadog/trace/api/DDIdTest.groovy
+++ b/dd-trace-api/src/test/groovy/datadog/trace/api/DDIdTest.groovy
@@ -1,9 +1,7 @@
 package datadog.trace.api
 
-import com.google.common.io.BaseEncoding
-import datadog.trace.util.test.DDSpecification
 
-import java.nio.charset.StandardCharsets
+import datadog.trace.util.test.DDSpecification
 
 class DDIdTest extends DDSpecification {
   def "convert ids from/to long and check strings and BigInteger"() {
@@ -83,44 +81,6 @@ class DDIdTest extends DDSpecification {
 
     where:
     hexId << [null, "", "-1", "1" + "0" * 16, "f" * 14 + "zf", "f" * 15 + "z" ]
-  }
-
-  def "lenient to base64 encoded valid ids decimal"() {
-    when:
-    final ddid = DDId.from(BaseEncoding.base64().encode(stringId.getBytes(StandardCharsets.ISO_8859_1)))
-
-    then:
-    ddid == expectedId
-    ddid.toString() == stringId
-
-    where:
-    stringId                                        | expectedId
-    "0"                                             | DDId.ZERO
-    "1"                                             | DDId.ONE
-    "18446744073709551615"                          | DDId.MAX
-    "${Long.MAX_VALUE}"                             | DDId.from(Long.MAX_VALUE)
-    "${BigInteger.valueOf(Long.MAX_VALUE).plus(1)}" | DDId.from(Long.MIN_VALUE)
-  }
-
-  def "lenient to base64 encoded valid ids hex"() {
-    when:
-    final ddid = DDId.fromHex(BaseEncoding.base64().encode(hexId.getBytes(StandardCharsets.ISO_8859_1)))
-
-    then:
-    ddid == expectedId
-    if (hexId.length() > 1) {
-      hexId = hexId.replaceAll("^0+", "") // drop leading zeros
-    }
-    ddid.toHexString() == hexId
-
-    where:
-    hexId                    | expectedId
-    "0"                      | DDId.ZERO
-    "1"                      | DDId.ONE
-    "f" * 16                 | DDId.MAX
-    "7" + "f" * 15           | DDId.from(Long.MAX_VALUE)
-    "8" + "0" * 15           | DDId.from(Long.MIN_VALUE)
-    "0" * 4 + "8" + "0" * 15 | DDId.from(Long.MIN_VALUE)
   }
 
   def "pump up the coverage"() {

--- a/dd-trace-core/dd-trace-core.gradle
+++ b/dd-trace-core/dd-trace-core.gradle
@@ -13,7 +13,6 @@ excludedClassesCoverage += [
   // This code is copied from okHttp samples and we have integration tests to verify that it works.
   'datadog.trace.common.writer.unixdomainsockets.TunnelingUnixSocket',
   'datadog.trace.common.writer.unixdomainsockets.UnixDomainSocketFactory',
-  'datadog.trace.core.StringCachingBigInteger',
   'datadog.trace.core.scopemanager.ScopeInterceptor.DelegatingScope',
 ]
 


### PR DESCRIPTION
reverts the fallback to base 64 in `DDId` and moves a configuration enabled (default false) base 64 decoding setting to the kafka client instrumentation