### PR TITLE
Make JMX thread deadlock detector init fail graciously

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
@@ -277,7 +277,14 @@ public class Agent {
       final Method registerMethod = deadlockFactoryClass.getMethod("registerEvents");
       registerMethod.invoke(null);
     } catch (final Throwable ex) {
-      log.error("Throwable thrown while initializing JMX thread deadlock detector", ex);
+      String msg = "Unable to initialize JMX thread deadlock detector";
+      if (log.isDebugEnabled()) {
+        // in debug level we want to see also the throwable and stacktrace
+        log.info(msg, ex);
+      } else {
+        // in non-debug level do not scare the user with the throwable and stacktrace
+        log.info(msg);
+      }
     }
   }
 


### PR DESCRIPTION
Do not log the failure to initialize the JMX thread deadlock detector at the 'error' level with full stacktrace as it may confuse the customers into thinking a real error occurred. Rather, provide a simple state describing message at 'info' level.