### PR TITLE
Add classloader matcher to validate scala/akka presence

### DIFF
--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/AkkaExecutorInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/AkkaExecutorInstrumentation.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.java.concurrent;
 
+import static datadog.trace.agent.tooling.ClassLoaderMatcher.hasClassesNamed;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
 import static net.bytebuddy.matcher.ElementMatchers.nameMatches;
 import static net.bytebuddy.matcher.ElementMatchers.named;
@@ -28,6 +29,12 @@ public final class AkkaExecutorInstrumentation extends AbstractExecutorInstrumen
 
   public AkkaExecutorInstrumentation() {
     super(EXEC_NAME + ".akka_fork_join");
+  }
+
+  @Override
+  public ElementMatcher<ClassLoader> classLoaderMatcher() {
+    // Optimization for expensive typeMatcher.
+    return hasClassesNamed(AkkaForkJoinTaskInstrumentation.TASK_CLASS_NAME);
   }
 
   @Override

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/ScalaExecutorInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/ScalaExecutorInstrumentation.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.java.concurrent;
 
+import static datadog.trace.agent.tooling.ClassLoaderMatcher.hasClassesNamed;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
 import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.nameMatches;
@@ -28,6 +29,12 @@ public final class ScalaExecutorInstrumentation extends AbstractExecutorInstrume
 
   public ScalaExecutorInstrumentation() {
     super(EXEC_NAME + ".scala_fork_join");
+  }
+
+  @Override
+  public ElementMatcher<ClassLoader> classLoaderMatcher() {
+    // Optimization for expensive typeMatcher.
+    return hasClassesNamed(ScalaForkJoinTaskInstrumentation.TASK_CLASS_NAME);
   }
 
   @Override


### PR DESCRIPTION
Similar to what was done elsewhere.  This was missed because it is a child of the abstract class where the actual type matcher is at.