### PR TITLE
Config class should be loaded on the bootstrap for instrumentation tests.

### DIFF
--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/TextMapExtractAdapterTest.groovy
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/TextMapExtractAdapterTest.groovy
@@ -1,15 +1,15 @@
 import com.google.common.io.BaseEncoding
+import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.instrumentation.kafka_clients.TextMapExtractAdapter
-import datadog.trace.util.test.DDSpecification
 import org.apache.kafka.common.header.Headers
 import org.apache.kafka.common.header.internals.RecordHeader
 import org.apache.kafka.common.header.internals.RecordHeaders
 
 import java.nio.charset.StandardCharsets
 
-class TextMapExtractAdapterTest extends DDSpecification {
+class TextMapExtractAdapterTest extends AgentTestRunner {
 
-  def "check can decode base64 mangled headers" () {
+  def "check can decode base64 mangled headers"() {
     given:
     def base64 = BaseEncoding.base64().encode("foo".getBytes(StandardCharsets.UTF_8))
     def expectedValue = base64Decode ? "foo" : base64

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/AgentTestRunner.java
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/AgentTestRunner.java
@@ -9,6 +9,7 @@ import datadog.trace.agent.tooling.AgentInstaller;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.TracerInstaller;
 import datadog.trace.agent.tooling.bytebuddy.matcher.AdditionalLibraryIgnoresMatcher;
+import datadog.trace.api.Config;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer.TracerAPI;
 import datadog.trace.common.writer.ListWriter;
@@ -95,6 +96,9 @@ public abstract class AgentTestRunner extends DDSpecification {
   private static volatile ClassFileTransformer activeTransformer = null;
 
   static {
+    // If this fails, it's likely the result of another test loading Config before it can be
+    // injected into the bootstrap classpath.
+    assert Config.class.getClassLoader() == null : "Config must load on the bootstrap classpath.";
     INSTRUMENTATION = ByteBuddyAgent.getInstrumentation();
 
     ((Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME)).setLevel(Level.WARN);


### PR DESCRIPTION
`KafkaClientTest` was failing in some cases because `TextMapExtractAdapterTest` didn't extend `AgentTestRunner` and caused `Config` to be loaded on the system classpath before it could be injected into the bootstrap classpath by `KafkaClientTest`.

This adds an assertion in `AgentTestRunner` to help better identify the problem, and makes `TextMapExtractAdapterTest` extend `AgentTestRunner` instead to ensure the classpath is setup correctly regardless of which test executes first.