### PR TITLE
Tweak ContinuableScopeManager for better inlining

### DIFF
--- a/dd-trace-core/dd-trace-core.gradle
+++ b/dd-trace-core/dd-trace-core.gradle
@@ -1,3 +1,7 @@
+plugins {
+  id "me.champeau.gradle.jmh" version "0.5.0"
+}
+
 description = 'dd-trace-core'
 
 apply from: "$rootDir/gradle/java.gradle"
@@ -49,4 +53,9 @@ dependencies {
   testCompile group: 'org.msgpack', name: 'jackson-dataformat-msgpack', version: '0.8.20'
 
   traceAgentTestCompile deps.testcontainers
+}
+
+jmh {
+  jmhVersion = "1.23"
+  duplicateClassesStrategy = 'warn'
 }

--- a/dd-trace-core/src/jmh/java/datadog/trace/core/scopemanager/ContinuableScopeManagerBenchmark.java
+++ b/dd-trace-core/src/jmh/java/datadog/trace/core/scopemanager/ContinuableScopeManagerBenchmark.java
@@ -1,0 +1,334 @@
+package datadog.trace.core.scopemanager;
+
+import com.timgroup.statsd.NoOpStatsDClient;
+import datadog.trace.api.DDId;
+import datadog.trace.api.interceptor.MutableSpan;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import datadog.trace.bootstrap.instrumentation.api.ScopeSource;
+import datadog.trace.core.jfr.DDNoopScopeEventFactory;
+import java.util.Collections;
+import java.util.Map;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+
+public class ContinuableScopeManagerBenchmark {
+
+  public enum ConvolutedWork {
+    LIGHT {
+      @Override
+      long work(AgentSpan span) {
+        long id = span.getTraceId().toLong();
+        id = id ^ Long.reverseBytes(id);
+        id = Long.rotateLeft(id, 8);
+        id = id ^ Long.reverseBytes(id);
+        id = Long.rotateLeft(id, 8);
+        id = id ^ Long.reverseBytes(id);
+        id = Long.rotateLeft(id, 8);
+        id = id ^ Long.reverseBytes(id);
+        id = Long.rotateLeft(id, 8);
+        id = id ^ Long.reverseBytes(id);
+        id = Long.rotateLeft(id, 8);
+        id = id ^ Long.reverseBytes(id);
+        id = Long.rotateLeft(id, 8);
+        id = id ^ Long.reverseBytes(id);
+        id = Long.rotateLeft(id, 8);
+        id = id ^ Long.reverseBytes(id);
+        id = Long.rotateLeft(id, 8);
+        id = id ^ Long.reverseBytes(id);
+        return id;
+      }
+    },
+    MODERATE {
+      @Override
+      long work(AgentSpan span) {
+        long id = span.getTraceId().toLong();
+        id = id ^ Long.reverseBytes(id);
+        id = Long.rotateLeft(id, 8);
+        id = id ^ Long.reverseBytes(id);
+        id = Long.rotateLeft(id, 8);
+        id = id ^ Long.reverseBytes(id);
+        id = Long.rotateLeft(id, 8);
+        id = id ^ Long.reverseBytes(id);
+        id = Long.rotateLeft(id, 8);
+        id = id ^ Long.reverseBytes(id);
+        id = Long.rotateLeft(id, 8);
+        id = id ^ Long.reverseBytes(id);
+        id = Long.rotateLeft(id, 8);
+        id = id ^ Long.reverseBytes(id);
+        id = Long.rotateLeft(id, 8);
+        id = id ^ Long.reverseBytes(id);
+        id = Long.rotateLeft(id, 8);
+        id = id ^ Long.reverseBytes(id);
+
+        id = id ^ Long.reverseBytes(id);
+        id = Long.rotateRight(id, 4);
+        id = id ^ Long.reverseBytes(id);
+        id = Long.rotateRight(id, 4);
+        id = id ^ Long.reverseBytes(id);
+        id = Long.rotateRight(id, 4);
+        id = id ^ Long.reverseBytes(id);
+        id = Long.rotateRight(id, 4);
+        id = id ^ Long.reverseBytes(id);
+        id = Long.rotateRight(id, 4);
+        id = id ^ Long.reverseBytes(id);
+        id = Long.rotateRight(id, 4);
+        id = id ^ Long.reverseBytes(id);
+        id = Long.rotateRight(id, 4);
+        id = id ^ Long.reverseBytes(id);
+        id = Long.rotateRight(id, 4);
+        id = id ^ Long.reverseBytes(id);
+        return id;
+      }
+    };
+
+    abstract long work(AgentSpan span);
+  }
+
+  public static class CheapSpan implements AgentSpan {
+
+    private final DDId traceId = DDId.generate();
+    private final long now = System.currentTimeMillis();
+
+    @Override
+    public DDId getTraceId() {
+      return traceId;
+    }
+
+    @Override
+    public AgentSpan setTag(String key, boolean value) {
+      return this;
+    }
+
+    @Override
+    public MutableSpan setTag(String tag, Number value) {
+      return this;
+    }
+
+    @Override
+    public Boolean isError() {
+      return false;
+    }
+
+    @Override
+    public AgentSpan setTag(String key, int value) {
+      return this;
+    }
+
+    @Override
+    public AgentSpan setTag(String key, long value) {
+      return this;
+    }
+
+    @Override
+    public AgentSpan setTag(String key, double value) {
+      return this;
+    }
+
+    @Override
+    public long getStartTime() {
+      return now;
+    }
+
+    @Override
+    public long getDurationNano() {
+      return 100;
+    }
+
+    @Override
+    public String getOperationName() {
+      return "operation name";
+    }
+
+    @Override
+    public MutableSpan setOperationName(String serviceName) {
+      return this;
+    }
+
+    @Override
+    public String getServiceName() {
+      return "service name";
+    }
+
+    @Override
+    public MutableSpan setServiceName(String serviceName) {
+      return this;
+    }
+
+    @Override
+    public CharSequence getResourceName() {
+      return "resource name";
+    }
+
+    @Override
+    public MutableSpan setResourceName(CharSequence resourceName) {
+      return this;
+    }
+
+    @Override
+    public Integer getSamplingPriority() {
+      return 1;
+    }
+
+    @Override
+    public MutableSpan setSamplingPriority(int newPriority) {
+      return this;
+    }
+
+    @Override
+    public String getSpanType() {
+      return "span type";
+    }
+
+    @Override
+    public MutableSpan setSpanType(String type) {
+      return this;
+    }
+
+    @Override
+    public Map<String, Object> getTags() {
+      return Collections.emptyMap();
+    }
+
+    @Override
+    public AgentSpan setTag(String key, String value) {
+      return this;
+    }
+
+    @Override
+    public AgentSpan setTag(String key, Object value) {
+      return this;
+    }
+
+    @Override
+    public Object getTag(String key) {
+      return null;
+    }
+
+    @Override
+    public AgentSpan setError(boolean error) {
+      return this;
+    }
+
+    @Override
+    public MutableSpan getRootSpan() {
+      return this;
+    }
+
+    @Override
+    public AgentSpan setErrorMessage(String errorMessage) {
+      return this;
+    }
+
+    @Override
+    public AgentSpan addThrowable(Throwable throwable) {
+      return this;
+    }
+
+    @Override
+    public AgentSpan getLocalRootSpan() {
+      return this;
+    }
+
+    @Override
+    public boolean isSameTrace(AgentSpan otherSpan) {
+      return otherSpan == this;
+    }
+
+    @Override
+    public Context context() {
+      return AgentTracer.NoopContext.INSTANCE;
+    }
+
+    @Override
+    public String getBaggageItem(String key) {
+      return null;
+    }
+
+    @Override
+    public AgentSpan setBaggageItem(String key, String value) {
+      return this;
+    }
+
+    @Override
+    public void finish() {}
+
+    @Override
+    public void finish(long finishMicros) {}
+
+    @Override
+    public String getSpanName() {
+      return "span name";
+    }
+
+    @Override
+    public void setSpanName(String spanName) {}
+
+    @Override
+    public boolean hasResourceName() {
+      return false;
+    }
+  }
+
+  @State(Scope.Benchmark)
+  public static class SpanState {
+
+    @Param({"0", "100"})
+    int maxDepth;
+
+    @Param({"1", "3", "5"})
+    int depth;
+
+    @Param({"true", "false"})
+    boolean strict;
+
+    @Param ConvolutedWork work;
+
+    private ContinuableScopeManager scopeManager;
+
+    AgentSpan[] spans;
+
+    AgentScope[] scopes;
+
+    @Setup(Level.Trial)
+    public void init() {
+      scopes = new AgentScope[depth];
+      spans = new AgentSpan[depth];
+      for (int i = 0; i < spans.length; ++i) {
+        spans[i] = new CheapSpan();
+      }
+      scopeManager =
+          new ContinuableScopeManager(
+              100, new DDNoopScopeEventFactory(), new NoOpStatsDClient(), strict);
+    }
+  }
+
+  @Benchmark
+  public void activate(SpanState state, Blackhole bh) {
+    AgentScope[] scopes = state.scopes;
+    AgentSpan[] spans = state.spans;
+    for (int i = 0; i < spans.length; ++i) {
+      AgentScope scope = state.scopeManager.activate(spans[i], ScopeSource.INSTRUMENTATION);
+      scopes[i] = scope;
+      bh.consume(state.work.work(spans[i]));
+    }
+    for (int i = 0; i < spans.length; ++i) {
+      scopes[i].close();
+      scopes[i] = null;
+    }
+  }
+
+  @Benchmark
+  public void baseline(SpanState state, Blackhole bh) {
+    AgentSpan[] spans = state.spans;
+    for (int i = 0; i < spans.length; ++i) {
+      bh.consume(state.work.work(spans[i]));
+    }
+  }
+}

--- a/dd-trace-core/src/jmh/resources/logback-test.xml
+++ b/dd-trace-core/src/jmh/resources/logback-test.xml
@@ -1,0 +1,17 @@
+<configuration>
+
+  <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <layout class="ch.qos.logback.classic.PatternLayout">
+      <Pattern>
+        %d{yyyy-MM-dd HH:mm:ss} %-5level %logger{36} - %msg%n
+      </Pattern>
+    </layout>
+  </appender>
+
+  <root level="error">
+    <appender-ref ref="STDOUT"/>
+  </root>
+
+</configuration>


### PR DESCRIPTION
After #1658 there was a strange increase in CPU utilisation in the reliability environment, which seems to have been caused by crossing an inlining threshold. This PR makes several tweaks which generally move exceptional code (e.g. logging or handling unexpected cases) out of hot methods, and reduces the number of accesses to the `ThreadLocal`. Here's the inlining in spring-petclinic

Before #1658 `58cf75de66a7f60a0966411e4812c1228af87a7d `

```
                              @ 4   datadog.trace.agent.core.scopemanager.ContinuableScopeManager::active (10 bytes)
                              @ 29   datadog.trace.agent.core.scopemanager.ContinuableScopeManager::activeSpan (25 bytes)
                              @ 21   datadog.trace.agent.core.scopemanager.ContinuableScopeManager::access$000 (4 bytes)
                              @ 5   datadog.trace.agent.core.scopemanager.ContinuableScopeManager::activate (75 bytes)   callee is too large
                              @ 26   datadog.trace.agent.core.scopemanager.ContinuableScopeManager$ContinuableScope::incrementReferences (10 bytes)
                              @ 39   datadog.trace.agent.core.scopemanager.ContinuableScopeManager$ContinuableScope::depth (5 bytes)
                              @ 71   datadog.trace.agent.core.scopemanager.ContinuableScopeManager::handleSpan (7 bytes)
                                @ 3   datadog.trace.agent.core.scopemanager.ContinuableScopeManager::handleSpan (33 bytes)   callee is too large
                              @ 3   datadog.trace.agent.core.scopemanager.ContinuableScopeManager::handleSpan (33 bytes)
                                @ 16   datadog.trace.agent.core.scopemanager.ContinuableScopeManager$ContinuableScope::<init> (100 bytes)   callee is too large
                              @ 16   datadog.trace.agent.core.scopemanager.ContinuableScopeManager$ContinuableScope::<init> (100 bytes)   callee is too large
                              @ 91   datadog.trace.agent.core.scopemanager.ContinuableScopeManager$ContinuableScope::depth (5 bytes)
                              @ 29   datadog.trace.agent.core.scopemanager.ContinuableScopeManager::activeSpan (25 bytes)   inline (hot)
                               \-> TypeProfile (19703/19703 counts) = datadog/trace/agent/core/scopemanager/ContinuableScopeManager
                              @ 5   datadog.trace.agent.core.scopemanager.ContinuableScopeManager::activate (75 bytes)   inline (hot)
                               \-> TypeProfile (26941/26941 counts) = datadog/trace/agent/core/scopemanager/ContinuableScopeManager
                                @ 39   datadog.trace.agent.core.scopemanager.ContinuableScopeManager$ContinuableScope::depth (5 bytes)   accessor
                                @ 71   datadog.trace.agent.core.scopemanager.ContinuableScopeManager::handleSpan (7 bytes)   inline (hot)
                                  @ 3   datadog.trace.agent.core.scopemanager.ContinuableScopeManager::handleSpan (33 bytes)   inline (hot)
                                    @ 16   datadog.trace.agent.core.scopemanager.ContinuableScopeManager$ContinuableScope::<init> (100 bytes)   inline (hot)
                                      @ 91   datadog.trace.agent.core.scopemanager.ContinuableScopeManager$ContinuableScope::depth (5 bytes)   accessor
                              @ 39   datadog.trace.agent.core.scopemanager.ContinuableScopeManager$ContinuableScope::depth (5 bytes)   accessor
                              @ 71   datadog.trace.agent.core.scopemanager.ContinuableScopeManager::handleSpan (7 bytes)   inline (hot)
                                @ 3   datadog.trace.agent.core.scopemanager.ContinuableScopeManager::handleSpan (33 bytes)   inline (hot)
                                  @ 16   datadog.trace.agent.core.scopemanager.ContinuableScopeManager$ContinuableScope::<init> (100 bytes)   inline (hot)
                                    @ 91   datadog.trace.agent.core.scopemanager.ContinuableScopeManager$ContinuableScope::depth (5 bytes)   accessor
                              @ 16   datadog.trace.agent.core.scopemanager.ContinuableScopeManager$ContinuableScope::<init> (100 bytes)   inline (hot)
                                @ 91   datadog.trace.agent.core.scopemanager.ContinuableScopeManager$ContinuableScope::depth (5 bytes)   accessor
                                 \-> TypeProfile (7099/7099 counts) = datadog/trace/agent/core/scopemanager/ContinuableScopeManager$ContinuableScope
                                @ 166   datadog.trace.agent.core.scopemanager.ContinuableScopeManager$ContinuableScope::close (85 bytes)   inline (hot)
                              @ 4   datadog.trace.agent.core.scopemanager.ContinuableScopeManager::active (10 bytes)
                              @ 4   datadog.trace.agent.core.scopemanager.ContinuableScopeManager::activeSpan (25 bytes)
```

master `fdc5b576f3413cf4e66f6d2acf0dd71308612b3e `

```
                              @ 4   datadog.trace.agent.core.scopemanager.ContinuableScopeManager::active (10 bytes)
                              @ 29   datadog.trace.agent.core.scopemanager.ContinuableScopeManager::activeSpan (25 bytes)
                              @ 6   datadog.trace.agent.core.scopemanager.ContinuableScopeManager::activate (87 bytes)   callee is too large
                              @ 26   datadog.trace.agent.core.scopemanager.ContinuableScopeManager$ContinuableScope::incrementReferences (10 bytes)
                              @ 39   datadog.trace.agent.core.scopemanager.ContinuableScopeManager$ContinuableScope::depth (5 bytes)
                              @ 83   datadog.trace.agent.core.scopemanager.ContinuableScopeManager::handleSpan (38 bytes)   callee is too large
                              @ 17   datadog.trace.agent.core.scopemanager.ContinuableScopeManager$ContinuableScope::<init> (106 bytes)   callee is too large
                              @ 91   datadog.trace.agent.core.scopemanager.ContinuableScopeManager$ContinuableScope::depth (5 bytes)
                              @ 21   datadog.trace.agent.core.scopemanager.ContinuableScopeManager::access$000 (4 bytes)
                              @ 42   datadog.trace.agent.core.scopemanager.ContinuableScopeManager::access$100 (5 bytes)
                              @ 70   datadog.trace.agent.core.scopemanager.ContinuableScopeManager::access$100 (5 bytes)
                              @ 88   datadog.trace.agent.core.scopemanager.ContinuableScopeManager::access$200 (5 bytes)
                              @ 29   datadog.trace.agent.core.scopemanager.ContinuableScopeManager::activeSpan (25 bytes)   inline (hot)
                               \-> TypeProfile (13319/13319 counts) = datadog/trace/agent/core/scopemanager/ContinuableScopeManager
                              @ 6   datadog.trace.agent.core.scopemanager.ContinuableScopeManager::activate (87 bytes)   inline (hot)
                               \-> TypeProfile (23562/23562 counts) = datadog/trace/agent/core/scopemanager/ContinuableScopeManager
                                @ 39   datadog.trace.agent.core.scopemanager.ContinuableScopeManager$ContinuableScope::depth (5 bytes)   accessor
                                @ 83   datadog.trace.agent.core.scopemanager.ContinuableScopeManager::handleSpan (38 bytes)   inline (hot)
                                  @ 17   datadog.trace.agent.core.scopemanager.ContinuableScopeManager$ContinuableScope::<init> (106 bytes)   inline (hot)
                                    @ 91   datadog.trace.agent.core.scopemanager.ContinuableScopeManager$ContinuableScope::depth (5 bytes)   accessor
                                                 \-> TypeProfile (28082/28082 counts) = datadog/trace/agent/core/scopemanager/ContinuableScopeManager$ContinuableScope
                                                @ 166   datadog.trace.agent.core.scopemanager.ContinuableScopeManager$ContinuableScope::close (151 bytes)   inline (hot)
                               \-> TypeProfile (66383/66383 counts) = datadog/trace/agent/core/scopemanager/ContinuableScopeManager$ContinuableScope
                              @ 166   datadog.trace.agent.core.scopemanager.ContinuableScopeManager$ContinuableScope::close (151 bytes)   inline (hot)
                              @ 4   datadog.trace.agent.core.scopemanager.ContinuableScopeManager::activeSpan (25 bytes)
```

Here, `2ea761e86fd5e4eb0d072be0e725af08737b0bca `, everything gets inlined except for the exceptional methods.

```
                              @ 4   datadog.trace.agent.core.scopemanager.ContinuableScopeManager::active (10 bytes)
                              @ 29   datadog.trace.agent.core.scopemanager.ContinuableScopeManager::activeSpan (25 bytes)
                              @ 6   datadog.trace.agent.core.scopemanager.ContinuableScopeManager::activate (38 bytes)   callee is too large
                              @ 26   datadog.trace.agent.core.scopemanager.ContinuableScopeManager$ContinuableScope::incrementReferences (10 bytes)
                              @ 34   datadog.trace.agent.core.scopemanager.ContinuableScopeManager::activate (38 bytes)   callee is too large
                              @ 9   datadog.trace.agent.core.scopemanager.ContinuableScopeManager$ContinuableScope::access$000 (5 bytes)
                              @ 25   datadog.trace.agent.core.scopemanager.ContinuableScopeManager::depthLimitExceeded (18 bytes)
                              @ 34   datadog.trace.agent.core.scopemanager.ContinuableScopeManager::handleSpan (73 bytes)   callee is too large
                              @ 23   datadog.trace.agent.core.scopemanager.ContinuableScopeManager::handleSpan (73 bytes)   callee is too large
                              @ 52   datadog.trace.agent.core.scopemanager.ContinuableScopeManager$ContinuableScope::<init> (60 bytes)   callee is too large
                              @ 47   datadog.trace.agent.core.scopemanager.ContinuableScopeManager::childDepth (16 bytes)
                                @ 10   datadog.trace.agent.core.scopemanager.ContinuableScopeManager$ContinuableScope::access$000 (5 bytes)
                              @ 10   datadog.trace.agent.core.scopemanager.ContinuableScopeManager$ContinuableScope::access$000 (5 bytes)
                              @ 22   datadog.trace.agent.core.scopemanager.ContinuableScopeManager$ContinuableScope::closeExceptionally (84 bytes)   callee is too large
                              @ 29   datadog.trace.agent.core.scopemanager.ContinuableScopeManager::activeSpan (25 bytes)   inline (hot)
                               \-> TypeProfile (21384/21384 counts) = datadog/trace/agent/core/scopemanager/ContinuableScopeManager
                              @ 6   datadog.trace.agent.core.scopemanager.ContinuableScopeManager::activate (38 bytes)   inline (hot)
                               \-> TypeProfile (34812/34812 counts) = datadog/trace/agent/core/scopemanager/ContinuableScopeManager
                                @ 34   datadog.trace.agent.core.scopemanager.ContinuableScopeManager::activate (38 bytes)   inline (hot)
                                  @ 9   datadog.trace.agent.core.scopemanager.ContinuableScopeManager$ContinuableScope::access$000 (5 bytes)   accessor
                                  @ 34   datadog.trace.agent.core.scopemanager.ContinuableScopeManager::handleSpan (73 bytes)   inline (hot)
                                    @ 52   datadog.trace.agent.core.scopemanager.ContinuableScopeManager$ContinuableScope::<init> (60 bytes)   inline (hot)
                                      @ 47   datadog.trace.agent.core.scopemanager.ContinuableScopeManager::childDepth (16 bytes)   inline (hot)
                                        @ 10   datadog.trace.agent.core.scopemanager.ContinuableScopeManager$ContinuableScope::access$000 (5 bytes)   accessor
                              @ 34   datadog.trace.agent.core.scopemanager.ContinuableScopeManager::activate (38 bytes)   inline (hot)
                                @ 9   datadog.trace.agent.core.scopemanager.ContinuableScopeManager$ContinuableScope::access$000 (5 bytes)   accessor
                                @ 34   datadog.trace.agent.core.scopemanager.ContinuableScopeManager::handleSpan (73 bytes)   inline (hot)
                                  @ 52   datadog.trace.agent.core.scopemanager.ContinuableScopeManager$ContinuableScope::<init> (60 bytes)   inline (hot)
                                    @ 47   datadog.trace.agent.core.scopemanager.ContinuableScopeManager::childDepth (16 bytes)   inline (hot)
                                      @ 10   datadog.trace.agent.core.scopemanager.ContinuableScopeManager$ContinuableScope::access$000 (5 bytes)   accessor
                              @ 9   datadog.trace.agent.core.scopemanager.ContinuableScopeManager$ContinuableScope::access$000 (5 bytes)   accessor
                              @ 34   datadog.trace.agent.core.scopemanager.ContinuableScopeManager::handleSpan (73 bytes)   inline (hot)
                                @ 52   datadog.trace.agent.core.scopemanager.ContinuableScopeManager$ContinuableScope::<init> (60 bytes)   inline (hot)
                                  @ 47   datadog.trace.agent.core.scopemanager.ContinuableScopeManager::childDepth (16 bytes)   inline (hot)
                                    @ 10   datadog.trace.agent.core.scopemanager.ContinuableScopeManager$ContinuableScope::access$000 (5 bytes)   accessor
```

It's difficult to provoke the behaviour here (and it will vary from application to application too) in a microbenchmark, because it depends more on the context of the caller than it does on the local shape of the code. Nevertheless, I added a microbenchmark and small gains can be seen from the reduction in TLS lookups, but there isn't enough code to stress inlining heuristics.

master `fdc5b576f3413cf4e66f6d2acf0dd71308612b3e`

```
Benchmark                                  (depth)  (maxDepth)  (strict)    (work)  Mode  Cnt    Score   Error  Units
ContinuableScopeManagerBenchmark.activate        1           0      true     LIGHT  avgt    5   59.654 ± 1.406  ns/op
ContinuableScopeManagerBenchmark.activate        1           0      true  MODERATE  avgt    5   63.831 ± 1.280  ns/op
ContinuableScopeManagerBenchmark.activate        1           0     false     LIGHT  avgt    5   58.787 ± 0.713  ns/op
ContinuableScopeManagerBenchmark.activate        1           0     false  MODERATE  avgt    5   64.287 ± 0.538  ns/op
ContinuableScopeManagerBenchmark.activate        1         100      true     LIGHT  avgt    5   59.812 ± 0.646  ns/op
ContinuableScopeManagerBenchmark.activate        1         100      true  MODERATE  avgt    5   63.968 ± 0.715  ns/op
ContinuableScopeManagerBenchmark.activate        1         100     false     LIGHT  avgt    5   59.739 ± 0.654  ns/op
ContinuableScopeManagerBenchmark.activate        1         100     false  MODERATE  avgt    5   64.642 ± 0.841  ns/op
ContinuableScopeManagerBenchmark.activate        3           0      true     LIGHT  avgt    5  100.233 ± 1.734  ns/op
ContinuableScopeManagerBenchmark.activate        3           0      true  MODERATE  avgt    5  122.567 ± 1.019  ns/op
ContinuableScopeManagerBenchmark.activate        3           0     false     LIGHT  avgt    5   98.074 ± 0.498  ns/op
ContinuableScopeManagerBenchmark.activate        3           0     false  MODERATE  avgt    5  119.912 ± 0.695  ns/op
ContinuableScopeManagerBenchmark.activate        3         100      true     LIGHT  avgt    5   97.573 ± 1.271  ns/op
ContinuableScopeManagerBenchmark.activate        3         100      true  MODERATE  avgt    5  119.201 ± 0.426  ns/op
ContinuableScopeManagerBenchmark.activate        3         100     false     LIGHT  avgt    5   96.639 ± 1.217  ns/op
ContinuableScopeManagerBenchmark.activate        3         100     false  MODERATE  avgt    5  123.188 ± 1.117  ns/op
ContinuableScopeManagerBenchmark.activate        5           0      true     LIGHT  avgt    5  138.134 ± 2.360  ns/op
ContinuableScopeManagerBenchmark.activate        5           0      true  MODERATE  avgt    5  171.540 ± 2.626  ns/op
ContinuableScopeManagerBenchmark.activate        5           0     false     LIGHT  avgt    5  137.424 ± 1.894  ns/op
ContinuableScopeManagerBenchmark.activate        5           0     false  MODERATE  avgt    5  170.942 ± 2.001  ns/op
ContinuableScopeManagerBenchmark.activate        5         100      true     LIGHT  avgt    5  137.123 ± 1.267  ns/op
ContinuableScopeManagerBenchmark.activate        5         100      true  MODERATE  avgt    5  172.344 ± 2.831  ns/op
ContinuableScopeManagerBenchmark.activate        5         100     false     LIGHT  avgt    5  137.976 ± 0.719  ns/op
ContinuableScopeManagerBenchmark.activate        5         100     false  MODERATE  avgt    5  173.601 ± 1.886  ns/op
```

branch `2ea761e86fd5e4eb0d072be0e725af08737b0bca `

```
Benchmark                                  (depth)  (maxDepth)  (strict)    (work)  Mode  Cnt    Score    Error  Units
ContinuableScopeManagerBenchmark.activate        1           0      true     LIGHT  avgt    5   56.458 ±  0.565  ns/op
ContinuableScopeManagerBenchmark.activate        1           0      true  MODERATE  avgt    5   61.324 ±  1.402  ns/op
ContinuableScopeManagerBenchmark.activate        1           0     false     LIGHT  avgt    5   56.157 ±  0.550  ns/op
ContinuableScopeManagerBenchmark.activate        1           0     false  MODERATE  avgt    5   61.243 ±  0.909  ns/op
ContinuableScopeManagerBenchmark.activate        1         100      true     LIGHT  avgt    5   56.169 ±  0.692  ns/op
ContinuableScopeManagerBenchmark.activate        1         100      true  MODERATE  avgt    5   60.926 ±  1.009  ns/op
ContinuableScopeManagerBenchmark.activate        1         100     false     LIGHT  avgt    5   55.888 ±  0.688  ns/op
ContinuableScopeManagerBenchmark.activate        1         100     false  MODERATE  avgt    5   60.926 ±  1.132  ns/op
ContinuableScopeManagerBenchmark.activate        3           0      true     LIGHT  avgt    5   93.311 ±  1.070  ns/op
ContinuableScopeManagerBenchmark.activate        3           0      true  MODERATE  avgt    5  117.095 ±  0.920  ns/op
ContinuableScopeManagerBenchmark.activate        3           0     false     LIGHT  avgt    5   93.416 ±  0.769  ns/op
ContinuableScopeManagerBenchmark.activate        3           0     false  MODERATE  avgt    5  115.838 ±  1.031  ns/op
ContinuableScopeManagerBenchmark.activate        3         100      true     LIGHT  avgt    5   96.108 ±  1.448  ns/op
ContinuableScopeManagerBenchmark.activate        3         100      true  MODERATE  avgt    5  114.675 ±  0.981  ns/op
ContinuableScopeManagerBenchmark.activate        3         100     false     LIGHT  avgt    5   95.840 ±  0.551  ns/op
ContinuableScopeManagerBenchmark.activate        3         100     false  MODERATE  avgt    5  120.067 ±  1.704  ns/op
ContinuableScopeManagerBenchmark.activate        5           0      true     LIGHT  avgt    5  129.881 ±  0.980  ns/op
ContinuableScopeManagerBenchmark.activate        5           0      true  MODERATE  avgt    5  172.945 ± 22.347  ns/op
ContinuableScopeManagerBenchmark.activate        5           0     false     LIGHT  avgt    5  131.886 ±  3.025  ns/op
ContinuableScopeManagerBenchmark.activate        5           0     false  MODERATE  avgt    5  168.731 ±  1.860  ns/op
ContinuableScopeManagerBenchmark.activate        5         100      true     LIGHT  avgt    5  131.646 ±  1.457  ns/op
ContinuableScopeManagerBenchmark.activate        5         100      true  MODERATE  avgt    5  168.686 ±  3.143  ns/op
ContinuableScopeManagerBenchmark.activate        5         100     false     LIGHT  avgt    5  131.964 ±  1.052  ns/op
ContinuableScopeManagerBenchmark.activate        5         100     false  MODERATE  avgt    5  168.375 ±  0.615  ns/op
```


