### PR TITLE
Add Service Name Detection (#1649) back in

### DIFF
--- a/dd-java-agent/instrumentation/akka-http-10.0/src/lagomTest/groovy/LagomTest.groovy
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/lagomTest/groovy/LagomTest.groovy
@@ -59,7 +59,6 @@ class LagomTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 2) {
         span(0) {
-          hasServiceName()
           operationName "akka-http.request"
           resourceName "GET /echo"
           spanType DDSpanTypes.HTTP_SERVER
@@ -102,7 +101,6 @@ class LagomTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          hasServiceName()
           operationName "akka-http.request"
           resourceName "GET /error"
           spanType DDSpanTypes.HTTP_SERVER

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/lagomTest/groovy/LagomTest.groovy
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/lagomTest/groovy/LagomTest.groovy
@@ -59,7 +59,7 @@ class LagomTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 2) {
         span(0) {
-          serviceName "unnamed-java-app"
+          hasServiceName()
           operationName "akka-http.request"
           resourceName "GET /echo"
           spanType DDSpanTypes.HTTP_SERVER
@@ -102,7 +102,7 @@ class LagomTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          serviceName "unnamed-java-app"
+          hasServiceName()
           operationName "akka-http.request"
           resourceName "GET /error"
           spanType DDSpanTypes.HTTP_SERVER

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpClientInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpClientInstrumentationTest.groovy
@@ -75,7 +75,7 @@ class AkkaHttpClientInstrumentationTest extends HttpClientTest {
       trace(0, 1) {
         span(0) {
           parent()
-          serviceName "unnamed-java-app"
+          hasServiceName()
           operationName "akka-http.client.request"
           resourceName "akka-http.client.request"
           spanType DDSpanTypes.HTTP_CLIENT

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpClientInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpClientInstrumentationTest.groovy
@@ -75,7 +75,6 @@ class AkkaHttpClientInstrumentationTest extends HttpClientTest {
       trace(0, 1) {
         span(0) {
           parent()
-          hasServiceName()
           operationName "akka-http.client.request"
           resourceName "akka-http.client.request"
           spanType DDSpanTypes.HTTP_CLIENT

--- a/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcStreamingTest.groovy
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcStreamingTest.groovy
@@ -113,7 +113,6 @@ class GrpcStreamingTest extends AgentTestRunner {
     assertTraces(2) {
       trace(0, clientMessageCount + 1) {
         span(0) {
-          hasServiceName()
           operationName "grpc.server"
           resourceName "example.Greeter/Conversation"
           spanType DDSpanTypes.RPC
@@ -128,7 +127,6 @@ class GrpcStreamingTest extends AgentTestRunner {
         }
         clientRange.each {
           span(it) {
-            hasServiceName()
             operationName "grpc.message"
             resourceName "grpc.message"
             spanType DDSpanTypes.RPC
@@ -145,7 +143,6 @@ class GrpcStreamingTest extends AgentTestRunner {
       }
       trace(1, (clientMessageCount * serverMessageCount) + 1) {
         span(0) {
-          hasServiceName()
           operationName "grpc.client"
           resourceName "example.Greeter/Conversation"
           spanType DDSpanTypes.RPC
@@ -160,7 +157,6 @@ class GrpcStreamingTest extends AgentTestRunner {
         }
         (1..(clientMessageCount * serverMessageCount)).each {
           span(it) {
-            hasServiceName()
             operationName "grpc.message"
             resourceName "grpc.message"
             spanType DDSpanTypes.RPC

--- a/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcStreamingTest.groovy
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcStreamingTest.groovy
@@ -113,7 +113,7 @@ class GrpcStreamingTest extends AgentTestRunner {
     assertTraces(2) {
       trace(0, clientMessageCount + 1) {
         span(0) {
-          serviceName "unnamed-java-app"
+          hasServiceName()
           operationName "grpc.server"
           resourceName "example.Greeter/Conversation"
           spanType DDSpanTypes.RPC
@@ -128,7 +128,7 @@ class GrpcStreamingTest extends AgentTestRunner {
         }
         clientRange.each {
           span(it) {
-            serviceName "unnamed-java-app"
+            hasServiceName()
             operationName "grpc.message"
             resourceName "grpc.message"
             spanType DDSpanTypes.RPC
@@ -145,7 +145,7 @@ class GrpcStreamingTest extends AgentTestRunner {
       }
       trace(1, (clientMessageCount * serverMessageCount) + 1) {
         span(0) {
-          serviceName "unnamed-java-app"
+          hasServiceName()
           operationName "grpc.client"
           resourceName "example.Greeter/Conversation"
           spanType DDSpanTypes.RPC
@@ -160,7 +160,7 @@ class GrpcStreamingTest extends AgentTestRunner {
         }
         (1..(clientMessageCount * serverMessageCount)).each {
           span(it) {
-            serviceName "unnamed-java-app"
+            hasServiceName()
             operationName "grpc.message"
             resourceName "grpc.message"
             spanType DDSpanTypes.RPC

--- a/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcTest.groovy
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcTest.groovy
@@ -57,7 +57,6 @@ class GrpcTest extends AgentTestRunner {
     assertTraces(2) {
       trace(0, 2) {
         span(0) {
-          hasServiceName()
           operationName "grpc.server"
           resourceName "example.Greeter/SayHello"
           spanType DDSpanTypes.RPC
@@ -71,7 +70,6 @@ class GrpcTest extends AgentTestRunner {
           }
         }
         span(1) {
-          hasServiceName()
           operationName "grpc.message"
           resourceName "grpc.message"
           spanType DDSpanTypes.RPC
@@ -88,7 +86,6 @@ class GrpcTest extends AgentTestRunner {
       trace(1, 3) {
         basicSpan(it, 0, "parent")
         span(1) {
-          hasServiceName()
           operationName "grpc.client"
           resourceName "example.Greeter/SayHello"
           spanType DDSpanTypes.RPC
@@ -102,7 +99,6 @@ class GrpcTest extends AgentTestRunner {
           }
         }
         span(2) {
-          hasServiceName()
           operationName "grpc.message"
           resourceName "grpc.message"
           spanType DDSpanTypes.RPC
@@ -150,7 +146,6 @@ class GrpcTest extends AgentTestRunner {
     assertTraces(2) {
       trace(0, 2) {
         span(0) {
-          hasServiceName()
           operationName "grpc.server"
           resourceName "example.Greeter/SayHello"
           spanType DDSpanTypes.RPC
@@ -168,7 +163,6 @@ class GrpcTest extends AgentTestRunner {
           }
         }
         span(1) {
-          hasServiceName()
           operationName "grpc.message"
           resourceName "grpc.message"
           spanType DDSpanTypes.RPC
@@ -184,7 +178,6 @@ class GrpcTest extends AgentTestRunner {
       }
       trace(1, 1) {
         span(0) {
-          hasServiceName()
           operationName "grpc.client"
           resourceName "example.Greeter/SayHello"
           spanType DDSpanTypes.RPC
@@ -239,7 +232,6 @@ class GrpcTest extends AgentTestRunner {
     assertTraces(2) {
       trace(0, 2) {
         span(0) {
-          hasServiceName()
           operationName "grpc.server"
           resourceName "example.Greeter/SayHello"
           spanType DDSpanTypes.RPC
@@ -253,7 +245,6 @@ class GrpcTest extends AgentTestRunner {
           }
         }
         span(1) {
-          hasServiceName()
           operationName "grpc.message"
           resourceName "grpc.message"
           spanType DDSpanTypes.RPC
@@ -269,7 +260,6 @@ class GrpcTest extends AgentTestRunner {
       }
       trace(1, 1) {
         span(0) {
-          hasServiceName()
           operationName "grpc.client"
           resourceName "example.Greeter/SayHello"
           spanType DDSpanTypes.RPC

--- a/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcTest.groovy
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcTest.groovy
@@ -57,7 +57,7 @@ class GrpcTest extends AgentTestRunner {
     assertTraces(2) {
       trace(0, 2) {
         span(0) {
-          serviceName "unnamed-java-app"
+          hasServiceName()
           operationName "grpc.server"
           resourceName "example.Greeter/SayHello"
           spanType DDSpanTypes.RPC
@@ -71,7 +71,7 @@ class GrpcTest extends AgentTestRunner {
           }
         }
         span(1) {
-          serviceName "unnamed-java-app"
+          hasServiceName()
           operationName "grpc.message"
           resourceName "grpc.message"
           spanType DDSpanTypes.RPC
@@ -88,7 +88,7 @@ class GrpcTest extends AgentTestRunner {
       trace(1, 3) {
         basicSpan(it, 0, "parent")
         span(1) {
-          serviceName "unnamed-java-app"
+          hasServiceName()
           operationName "grpc.client"
           resourceName "example.Greeter/SayHello"
           spanType DDSpanTypes.RPC
@@ -102,7 +102,7 @@ class GrpcTest extends AgentTestRunner {
           }
         }
         span(2) {
-          serviceName "unnamed-java-app"
+          hasServiceName()
           operationName "grpc.message"
           resourceName "grpc.message"
           spanType DDSpanTypes.RPC
@@ -150,7 +150,7 @@ class GrpcTest extends AgentTestRunner {
     assertTraces(2) {
       trace(0, 2) {
         span(0) {
-          serviceName "unnamed-java-app"
+          hasServiceName()
           operationName "grpc.server"
           resourceName "example.Greeter/SayHello"
           spanType DDSpanTypes.RPC
@@ -168,7 +168,7 @@ class GrpcTest extends AgentTestRunner {
           }
         }
         span(1) {
-          serviceName "unnamed-java-app"
+          hasServiceName()
           operationName "grpc.message"
           resourceName "grpc.message"
           spanType DDSpanTypes.RPC
@@ -184,7 +184,7 @@ class GrpcTest extends AgentTestRunner {
       }
       trace(1, 1) {
         span(0) {
-          serviceName "unnamed-java-app"
+          hasServiceName()
           operationName "grpc.client"
           resourceName "example.Greeter/SayHello"
           spanType DDSpanTypes.RPC
@@ -239,7 +239,7 @@ class GrpcTest extends AgentTestRunner {
     assertTraces(2) {
       trace(0, 2) {
         span(0) {
-          serviceName "unnamed-java-app"
+          hasServiceName()
           operationName "grpc.server"
           resourceName "example.Greeter/SayHello"
           spanType DDSpanTypes.RPC
@@ -253,7 +253,7 @@ class GrpcTest extends AgentTestRunner {
           }
         }
         span(1) {
-          serviceName "unnamed-java-app"
+          hasServiceName()
           operationName "grpc.message"
           resourceName "grpc.message"
           spanType DDSpanTypes.RPC
@@ -269,7 +269,7 @@ class GrpcTest extends AgentTestRunner {
       }
       trace(1, 1) {
         span(0) {
-          serviceName "unnamed-java-app"
+          hasServiceName()
           operationName "grpc.client"
           resourceName "example.Greeter/SayHello"
           spanType DDSpanTypes.RPC

--- a/dd-java-agent/instrumentation/hibernate/core-3.3/src/test/groovy/SessionTest.groovy
+++ b/dd-java-agent/instrumentation/hibernate/core-3.3/src/test/groovy/SessionTest.groovy
@@ -568,7 +568,6 @@ class SessionTest extends AbstractHibernateTest {
     assertTraces(1) {
       trace(0, 11) {
         span(0) {
-          hasServiceName()
           operationName "overlapping Sessions"
           tags {
             defaultTags()

--- a/dd-java-agent/instrumentation/hibernate/core-3.3/src/test/groovy/SessionTest.groovy
+++ b/dd-java-agent/instrumentation/hibernate/core-3.3/src/test/groovy/SessionTest.groovy
@@ -568,7 +568,7 @@ class SessionTest extends AbstractHibernateTest {
     assertTraces(1) {
       trace(0, 11) {
         span(0) {
-          serviceName "unnamed-java-app"
+          hasServiceName()
           operationName "overlapping Sessions"
           tags {
             defaultTags()

--- a/dd-java-agent/instrumentation/hibernate/core-4.0/src/test/groovy/SessionTest.groovy
+++ b/dd-java-agent/instrumentation/hibernate/core-4.0/src/test/groovy/SessionTest.groovy
@@ -491,7 +491,7 @@ class SessionTest extends AbstractHibernateTest {
     assertTraces(1) {
       trace(0, 12) {
         span(0) {
-          serviceName "unnamed-java-app"
+          hasServiceName()
           operationName "overlapping Sessions"
           tags {
             defaultTags()

--- a/dd-java-agent/instrumentation/hibernate/core-4.0/src/test/groovy/SessionTest.groovy
+++ b/dd-java-agent/instrumentation/hibernate/core-4.0/src/test/groovy/SessionTest.groovy
@@ -491,7 +491,6 @@ class SessionTest extends AbstractHibernateTest {
     assertTraces(1) {
       trace(0, 12) {
         span(0) {
-          hasServiceName()
           operationName "overlapping Sessions"
           tags {
             defaultTags()

--- a/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionTest.groovy
+++ b/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionTest.groovy
@@ -93,7 +93,10 @@ class HttpUrlConnectionTest extends HttpClientTest {
           }
         }
         span(1) {
-          serviceName renameService ? "localhost" : "unnamed-java-app"
+          hasServiceName()
+          if (renameService) {
+            serviceName "localhost"
+          }
           operationName OPERATION_NAME
           resourceName "GET $url.path"
           spanType DDSpanTypes.HTTP_CLIENT
@@ -111,7 +114,10 @@ class HttpUrlConnectionTest extends HttpClientTest {
           }
         }
         span(2) {
-          serviceName renameService ? "localhost" : "unnamed-java-app"
+          hasServiceName()
+          if (renameService) {
+            serviceName "localhost"
+          }
           operationName OPERATION_NAME
           resourceName "GET $url.path"
           spanType DDSpanTypes.HTTP_CLIENT
@@ -178,7 +184,10 @@ class HttpUrlConnectionTest extends HttpClientTest {
           }
         }
         span(1) {
-          serviceName renameService ? "localhost" : "unnamed-java-app"
+          hasServiceName()
+          if (renameService) {
+            serviceName "localhost"
+          }
           operationName OPERATION_NAME
           resourceName "GET $url.path"
           spanType DDSpanTypes.HTTP_CLIENT
@@ -196,7 +205,10 @@ class HttpUrlConnectionTest extends HttpClientTest {
           }
         }
         span(2) {
-          serviceName renameService ? "localhost" : "unnamed-java-app"
+          hasServiceName()
+          if (renameService) {
+            serviceName "localhost"
+          }
           operationName OPERATION_NAME
           resourceName "GET $url.path"
           spanType DDSpanTypes.HTTP_CLIENT
@@ -248,7 +260,10 @@ class HttpUrlConnectionTest extends HttpClientTest {
           }
         }
         span(1) {
-          serviceName renameService ? "localhost" : "unnamed-java-app"
+          hasServiceName()
+          if (renameService) {
+            serviceName "localhost"
+          }
           operationName OPERATION_NAME
           resourceName "GET $url.path"
           spanType DDSpanTypes.HTTP_CLIENT
@@ -316,7 +331,10 @@ class HttpUrlConnectionTest extends HttpClientTest {
           }
         }
         span(1) {
-          serviceName renameService ? "localhost" : "unnamed-java-app"
+          hasServiceName()
+          if (renameService) {
+            serviceName "localhost"
+          }
           operationName OPERATION_NAME
           resourceName "POST $url.path"
           spanType DDSpanTypes.HTTP_CLIENT

--- a/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionTest.groovy
+++ b/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionTest.groovy
@@ -93,7 +93,6 @@ class HttpUrlConnectionTest extends HttpClientTest {
           }
         }
         span(1) {
-          hasServiceName()
           if (renameService) {
             serviceName "localhost"
           }
@@ -114,7 +113,6 @@ class HttpUrlConnectionTest extends HttpClientTest {
           }
         }
         span(2) {
-          hasServiceName()
           if (renameService) {
             serviceName "localhost"
           }
@@ -184,7 +182,6 @@ class HttpUrlConnectionTest extends HttpClientTest {
           }
         }
         span(1) {
-          hasServiceName()
           if (renameService) {
             serviceName "localhost"
           }
@@ -205,7 +202,6 @@ class HttpUrlConnectionTest extends HttpClientTest {
           }
         }
         span(2) {
-          hasServiceName()
           if (renameService) {
             serviceName "localhost"
           }
@@ -260,7 +256,6 @@ class HttpUrlConnectionTest extends HttpClientTest {
           }
         }
         span(1) {
-          hasServiceName()
           if (renameService) {
             serviceName "localhost"
           }
@@ -331,7 +326,6 @@ class HttpUrlConnectionTest extends HttpClientTest {
           }
         }
         span(1) {
-          hasServiceName()
           if (renameService) {
             serviceName "localhost"
           }

--- a/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/UrlConnectionTest.groovy
+++ b/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/UrlConnectionTest.groovy
@@ -41,7 +41,10 @@ class UrlConnectionTest extends AgentTestRunner {
           }
         }
         span(1) {
-          serviceName renameService ? "localhost" : "unnamed-java-app"
+          hasServiceName()
+          if (renameService) {
+            serviceName "localhost"
+          }
           operationName OPERATION_NAME
           resourceName "GET /"
           spanType DDSpanTypes.HTTP_CLIENT
@@ -96,7 +99,7 @@ class UrlConnectionTest extends AgentTestRunner {
           }
         }
         span(1) {
-          serviceName "unnamed-java-app"
+          hasServiceName()
           operationName "file.request"
           resourceName "file:$url.path"
           spanType DDSpanTypes.HTTP_CLIENT

--- a/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/UrlConnectionTest.groovy
+++ b/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/UrlConnectionTest.groovy
@@ -41,7 +41,6 @@ class UrlConnectionTest extends AgentTestRunner {
           }
         }
         span(1) {
-          hasServiceName()
           if (renameService) {
             serviceName "localhost"
           }
@@ -99,7 +98,6 @@ class UrlConnectionTest extends AgentTestRunner {
           }
         }
         span(1) {
-          hasServiceName()
           operationName "file.request"
           resourceName "file:$url.path"
           spanType DDSpanTypes.HTTP_CLIENT

--- a/dd-java-agent/instrumentation/hystrix-1.4/src/test/groovy/HystrixObservableChainTest.groovy
+++ b/dd-java-agent/instrumentation/hystrix-1.4/src/test/groovy/HystrixObservableChainTest.groovy
@@ -72,7 +72,6 @@ class HystrixObservableChainTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 5) {
         span(0) {
-          hasServiceName()
           operationName "parent"
           resourceName "parent"
           spanType null
@@ -83,7 +82,6 @@ class HystrixObservableChainTest extends AgentTestRunner {
           }
         }
         span(1) {
-          hasServiceName()
           operationName "hystrix.cmd"
           resourceName "OtherGroup.HystrixObservableChainTest\$2.execute"
           spanType null
@@ -98,7 +96,6 @@ class HystrixObservableChainTest extends AgentTestRunner {
           }
         }
         span(2) {
-          hasServiceName()
           operationName "trace.annotation"
           resourceName "HystrixObservableChainTest\$2.tracedMethod"
           spanType null
@@ -110,7 +107,6 @@ class HystrixObservableChainTest extends AgentTestRunner {
           }
         }
         span(3) {
-          hasServiceName()
           operationName "hystrix.cmd"
           resourceName "ExampleGroup.HystrixObservableChainTest\$1.execute"
           spanType null
@@ -125,7 +121,6 @@ class HystrixObservableChainTest extends AgentTestRunner {
           }
         }
         span(4) {
-          hasServiceName()
           operationName "trace.annotation"
           resourceName "HystrixObservableChainTest\$1.tracedMethod"
           spanType null

--- a/dd-java-agent/instrumentation/hystrix-1.4/src/test/groovy/HystrixObservableChainTest.groovy
+++ b/dd-java-agent/instrumentation/hystrix-1.4/src/test/groovy/HystrixObservableChainTest.groovy
@@ -72,7 +72,7 @@ class HystrixObservableChainTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 5) {
         span(0) {
-          serviceName "unnamed-java-app"
+          hasServiceName()
           operationName "parent"
           resourceName "parent"
           spanType null
@@ -83,7 +83,7 @@ class HystrixObservableChainTest extends AgentTestRunner {
           }
         }
         span(1) {
-          serviceName "unnamed-java-app"
+          hasServiceName()
           operationName "hystrix.cmd"
           resourceName "OtherGroup.HystrixObservableChainTest\$2.execute"
           spanType null
@@ -98,7 +98,7 @@ class HystrixObservableChainTest extends AgentTestRunner {
           }
         }
         span(2) {
-          serviceName "unnamed-java-app"
+          hasServiceName()
           operationName "trace.annotation"
           resourceName "HystrixObservableChainTest\$2.tracedMethod"
           spanType null
@@ -110,7 +110,7 @@ class HystrixObservableChainTest extends AgentTestRunner {
           }
         }
         span(3) {
-          serviceName "unnamed-java-app"
+          hasServiceName()
           operationName "hystrix.cmd"
           resourceName "ExampleGroup.HystrixObservableChainTest\$1.execute"
           spanType null
@@ -125,7 +125,7 @@ class HystrixObservableChainTest extends AgentTestRunner {
           }
         }
         span(4) {
-          serviceName "unnamed-java-app"
+          hasServiceName()
           operationName "trace.annotation"
           resourceName "HystrixObservableChainTest\$1.tracedMethod"
           spanType null

--- a/dd-java-agent/instrumentation/hystrix-1.4/src/test/groovy/HystrixObservableTest.groovy
+++ b/dd-java-agent/instrumentation/hystrix-1.4/src/test/groovy/HystrixObservableTest.groovy
@@ -64,7 +64,7 @@ class HystrixObservableTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 3) {
         span(0) {
-          serviceName "unnamed-java-app"
+          hasServiceName()
           operationName "parent"
           resourceName "parent"
           spanType null
@@ -75,7 +75,7 @@ class HystrixObservableTest extends AgentTestRunner {
           }
         }
         span(1) {
-          serviceName "unnamed-java-app"
+          hasServiceName()
           operationName "hystrix.cmd"
           resourceName "ExampleGroup.HystrixObservableTest\$1.execute"
           spanType null
@@ -90,7 +90,7 @@ class HystrixObservableTest extends AgentTestRunner {
           }
         }
         span(2) {
-          serviceName "unnamed-java-app"
+          hasServiceName()
           operationName "trace.annotation"
           resourceName "HystrixObservableTest\$1.tracedMethod"
           spanType null
@@ -174,7 +174,7 @@ class HystrixObservableTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 3) {
         span(0) {
-          serviceName "unnamed-java-app"
+          hasServiceName()
           operationName "parent"
           resourceName "parent"
           spanType null
@@ -185,7 +185,7 @@ class HystrixObservableTest extends AgentTestRunner {
           }
         }
         span(1) {
-          serviceName "unnamed-java-app"
+          hasServiceName()
           operationName "hystrix.cmd"
           resourceName "ExampleGroup.HystrixObservableTest\$2.execute"
           spanType null
@@ -201,7 +201,7 @@ class HystrixObservableTest extends AgentTestRunner {
           }
         }
         span(2) {
-          serviceName "unnamed-java-app"
+          hasServiceName()
           operationName "hystrix.cmd"
           resourceName "ExampleGroup.HystrixObservableTest\$2.fallback"
           spanType null
@@ -293,7 +293,7 @@ class HystrixObservableTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 3) {
         span(0) {
-          serviceName "unnamed-java-app"
+          hasServiceName()
           operationName "parent"
           resourceName "parent"
           spanType null
@@ -305,7 +305,7 @@ class HystrixObservableTest extends AgentTestRunner {
           }
         }
         span(1) {
-          serviceName "unnamed-java-app"
+          hasServiceName()
           operationName "hystrix.cmd"
           resourceName "FailingGroup.HystrixObservableTest\$3.execute"
           spanType null
@@ -321,7 +321,7 @@ class HystrixObservableTest extends AgentTestRunner {
           }
         }
         span(2) {
-          serviceName "unnamed-java-app"
+          hasServiceName()
           operationName "hystrix.cmd"
           resourceName "FailingGroup.HystrixObservableTest\$3.fallback"
           spanType null

--- a/dd-java-agent/instrumentation/hystrix-1.4/src/test/groovy/HystrixObservableTest.groovy
+++ b/dd-java-agent/instrumentation/hystrix-1.4/src/test/groovy/HystrixObservableTest.groovy
@@ -64,7 +64,6 @@ class HystrixObservableTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 3) {
         span(0) {
-          hasServiceName()
           operationName "parent"
           resourceName "parent"
           spanType null
@@ -75,7 +74,6 @@ class HystrixObservableTest extends AgentTestRunner {
           }
         }
         span(1) {
-          hasServiceName()
           operationName "hystrix.cmd"
           resourceName "ExampleGroup.HystrixObservableTest\$1.execute"
           spanType null
@@ -90,7 +88,6 @@ class HystrixObservableTest extends AgentTestRunner {
           }
         }
         span(2) {
-          hasServiceName()
           operationName "trace.annotation"
           resourceName "HystrixObservableTest\$1.tracedMethod"
           spanType null
@@ -174,7 +171,6 @@ class HystrixObservableTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 3) {
         span(0) {
-          hasServiceName()
           operationName "parent"
           resourceName "parent"
           spanType null
@@ -185,7 +181,6 @@ class HystrixObservableTest extends AgentTestRunner {
           }
         }
         span(1) {
-          hasServiceName()
           operationName "hystrix.cmd"
           resourceName "ExampleGroup.HystrixObservableTest\$2.execute"
           spanType null
@@ -201,7 +196,6 @@ class HystrixObservableTest extends AgentTestRunner {
           }
         }
         span(2) {
-          hasServiceName()
           operationName "hystrix.cmd"
           resourceName "ExampleGroup.HystrixObservableTest\$2.fallback"
           spanType null
@@ -293,7 +287,6 @@ class HystrixObservableTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 3) {
         span(0) {
-          hasServiceName()
           operationName "parent"
           resourceName "parent"
           spanType null
@@ -305,7 +298,6 @@ class HystrixObservableTest extends AgentTestRunner {
           }
         }
         span(1) {
-          hasServiceName()
           operationName "hystrix.cmd"
           resourceName "FailingGroup.HystrixObservableTest\$3.execute"
           spanType null
@@ -321,7 +313,6 @@ class HystrixObservableTest extends AgentTestRunner {
           }
         }
         span(2) {
-          hasServiceName()
           operationName "hystrix.cmd"
           resourceName "FailingGroup.HystrixObservableTest\$3.fallback"
           spanType null

--- a/dd-java-agent/instrumentation/hystrix-1.4/src/test/groovy/HystrixTest.groovy
+++ b/dd-java-agent/instrumentation/hystrix-1.4/src/test/groovy/HystrixTest.groovy
@@ -48,7 +48,7 @@ class HystrixTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 3) {
         span(0) {
-          serviceName "unnamed-java-app"
+          hasServiceName()
           operationName "parent"
           resourceName "parent"
           spanType null
@@ -59,7 +59,7 @@ class HystrixTest extends AgentTestRunner {
           }
         }
         span(1) {
-          serviceName "unnamed-java-app"
+          hasServiceName()
           operationName "hystrix.cmd"
           resourceName "ExampleGroup.HystrixTest\$1.execute"
           spanType null
@@ -74,7 +74,7 @@ class HystrixTest extends AgentTestRunner {
           }
         }
         span(2) {
-          serviceName "unnamed-java-app"
+          hasServiceName()
           operationName "trace.annotation"
           resourceName "HystrixTest\$1.tracedMethod"
           spanType null
@@ -130,7 +130,7 @@ class HystrixTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 3) {
         span(0) {
-          serviceName "unnamed-java-app"
+          hasServiceName()
           operationName "parent"
           resourceName "parent"
           spanType null
@@ -141,7 +141,7 @@ class HystrixTest extends AgentTestRunner {
           }
         }
         span(1) {
-          serviceName "unnamed-java-app"
+          hasServiceName()
           operationName "hystrix.cmd"
           resourceName "ExampleGroup.HystrixTest\$2.execute"
           spanType null
@@ -157,7 +157,7 @@ class HystrixTest extends AgentTestRunner {
           }
         }
         span(2) {
-          serviceName "unnamed-java-app"
+          hasServiceName()
           operationName "hystrix.cmd"
           resourceName "ExampleGroup.HystrixTest\$2.fallback"
           spanType null

--- a/dd-java-agent/instrumentation/hystrix-1.4/src/test/groovy/HystrixTest.groovy
+++ b/dd-java-agent/instrumentation/hystrix-1.4/src/test/groovy/HystrixTest.groovy
@@ -48,7 +48,6 @@ class HystrixTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 3) {
         span(0) {
-          hasServiceName()
           operationName "parent"
           resourceName "parent"
           spanType null
@@ -59,7 +58,6 @@ class HystrixTest extends AgentTestRunner {
           }
         }
         span(1) {
-          hasServiceName()
           operationName "hystrix.cmd"
           resourceName "ExampleGroup.HystrixTest\$1.execute"
           spanType null
@@ -74,7 +72,6 @@ class HystrixTest extends AgentTestRunner {
           }
         }
         span(2) {
-          hasServiceName()
           operationName "trace.annotation"
           resourceName "HystrixTest\$1.tracedMethod"
           spanType null
@@ -130,7 +127,6 @@ class HystrixTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 3) {
         span(0) {
-          hasServiceName()
           operationName "parent"
           resourceName "parent"
           spanType null
@@ -141,7 +137,6 @@ class HystrixTest extends AgentTestRunner {
           }
         }
         span(1) {
-          hasServiceName()
           operationName "hystrix.cmd"
           resourceName "ExampleGroup.HystrixTest\$2.execute"
           spanType null
@@ -157,7 +152,6 @@ class HystrixTest extends AgentTestRunner {
           }
         }
         span(2) {
-          hasServiceName()
           operationName "hystrix.cmd"
           resourceName "ExampleGroup.HystrixTest\$2.fallback"
           spanType null

--- a/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/Lettuce5ReactiveClientTest.groovy
+++ b/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/Lettuce5ReactiveClientTest.groovy
@@ -339,7 +339,7 @@ class Lettuce5ReactiveClientTest extends AgentTestRunner {
     sortAndAssertTraces(1) {
       trace(0, 3) {
         span(0) {
-          serviceName "unnamed-java-app"
+          hasServiceName()
           operationName "test-parent"
           resourceName "test-parent"
           errored false
@@ -394,7 +394,7 @@ class Lettuce5ReactiveClientTest extends AgentTestRunner {
     sortAndAssertTraces(1) {
       trace(0, 3) {
         span(0) {
-          serviceName "unnamed-java-app"
+          hasServiceName()
           operationName "test-parent"
           resourceName "test-parent"
           errored false
@@ -450,7 +450,7 @@ class Lettuce5ReactiveClientTest extends AgentTestRunner {
     sortAndAssertTraces(1) {
       trace(0, 3) {
         span(0) {
-          serviceName "unnamed-java-app"
+          hasServiceName()
           operationName "test-parent"
           resourceName "test-parent"
           errored false

--- a/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/Lettuce5ReactiveClientTest.groovy
+++ b/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/Lettuce5ReactiveClientTest.groovy
@@ -339,7 +339,6 @@ class Lettuce5ReactiveClientTest extends AgentTestRunner {
     sortAndAssertTraces(1) {
       trace(0, 3) {
         span(0) {
-          hasServiceName()
           operationName "test-parent"
           resourceName "test-parent"
           errored false
@@ -394,7 +393,6 @@ class Lettuce5ReactiveClientTest extends AgentTestRunner {
     sortAndAssertTraces(1) {
       trace(0, 3) {
         span(0) {
-          hasServiceName()
           operationName "test-parent"
           resourceName "test-parent"
           errored false
@@ -450,7 +448,6 @@ class Lettuce5ReactiveClientTest extends AgentTestRunner {
     sortAndAssertTraces(1) {
       trace(0, 3) {
         span(0) {
-          hasServiceName()
           operationName "test-parent"
           resourceName "test-parent"
           errored false

--- a/dd-java-agent/instrumentation/netty-4.1/src/test/groovy/Netty41ClientTest.groovy
+++ b/dd-java-agent/instrumentation/netty-4.1/src/test/groovy/Netty41ClientTest.groovy
@@ -1,7 +1,7 @@
-import datadog.trace.core.DDSpan
 import datadog.trace.agent.test.base.HttpClientTest
 import datadog.trace.api.Trace
 import datadog.trace.bootstrap.instrumentation.api.Tags
+import datadog.trace.core.DDSpan
 import datadog.trace.instrumentation.netty41.client.HttpClientTracingHandler
 import datadog.trace.instrumentation.netty41.client.NettyHttpClientDecorator
 import io.netty.channel.AbstractChannel
@@ -203,7 +203,7 @@ class Netty41ClientTest extends HttpClientTest {
         basicSpan(it, 0, "parent")
         span(1) {
           childOf((DDSpan) span(0))
-          serviceName "unnamed-java-app"
+          hasServiceName()
           operationName "trace.annotation"
           resourceName "AnnotatedClass.makeRequestUnderTrace"
           errored false

--- a/dd-java-agent/instrumentation/netty-4.1/src/test/groovy/Netty41ClientTest.groovy
+++ b/dd-java-agent/instrumentation/netty-4.1/src/test/groovy/Netty41ClientTest.groovy
@@ -203,7 +203,6 @@ class Netty41ClientTest extends HttpClientTest {
         basicSpan(it, 0, "parent")
         span(1) {
           childOf((DDSpan) span(0))
-          hasServiceName()
           operationName "trace.annotation"
           resourceName "AnnotatedClass.makeRequestUnderTrace"
           errored false

--- a/dd-java-agent/instrumentation/opentelemetry/src/test/groovy/OpenTelemetryTest.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/src/test/groovy/OpenTelemetryTest.groovy
@@ -53,7 +53,6 @@ class OpenTelemetryTest extends AgentTestRunner {
       trace(0, 1) {
         span(0) {
           parent()
-          hasServiceName()
           operationName "test-inst"
           if (tagSpan) {
             resourceName "other resource"
@@ -115,7 +114,6 @@ class OpenTelemetryTest extends AgentTestRunner {
       trace(0, 1) {
         span(0) {
           parent()
-          hasServiceName()
           operationName "test-inst"
           resourceName "some name"
           errored true
@@ -163,7 +161,6 @@ class OpenTelemetryTest extends AgentTestRunner {
           } else {
             parent()
           }
-          hasServiceName()
           operationName "test-inst"
           resourceName "some name"
           errored false

--- a/dd-java-agent/instrumentation/opentelemetry/src/test/groovy/OpenTelemetryTest.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/src/test/groovy/OpenTelemetryTest.groovy
@@ -53,7 +53,7 @@ class OpenTelemetryTest extends AgentTestRunner {
       trace(0, 1) {
         span(0) {
           parent()
-          serviceName "unnamed-java-app"
+          hasServiceName()
           operationName "test-inst"
           if (tagSpan) {
             resourceName "other resource"
@@ -115,7 +115,7 @@ class OpenTelemetryTest extends AgentTestRunner {
       trace(0, 1) {
         span(0) {
           parent()
-          serviceName "unnamed-java-app"
+          hasServiceName()
           operationName "test-inst"
           resourceName "some name"
           errored true
@@ -163,7 +163,7 @@ class OpenTelemetryTest extends AgentTestRunner {
           } else {
             parent()
           }
-          serviceName "unnamed-java-app"
+          hasServiceName()
           operationName "test-inst"
           resourceName "some name"
           errored false

--- a/dd-java-agent/instrumentation/opentracing/api-0.31/src/test/groovy/OpenTracing31Test.groovy
+++ b/dd-java-agent/instrumentation/opentracing/api-0.31/src/test/groovy/OpenTracing31Test.groovy
@@ -70,7 +70,6 @@ class OpenTracing31Test extends AgentTestRunner {
           } else {
             parent()
           }
-          hasServiceName()
           operationName "some name"
           if (tagSpan) {
             resourceName "other resource"

--- a/dd-java-agent/instrumentation/opentracing/api-0.31/src/test/groovy/OpenTracing31Test.groovy
+++ b/dd-java-agent/instrumentation/opentracing/api-0.31/src/test/groovy/OpenTracing31Test.groovy
@@ -70,7 +70,7 @@ class OpenTracing31Test extends AgentTestRunner {
           } else {
             parent()
           }
-          serviceName "unnamed-java-app"
+          hasServiceName()
           operationName "some name"
           if (tagSpan) {
             resourceName "other resource"

--- a/dd-java-agent/instrumentation/opentracing/api-0.32/src/test/groovy/OpenTracing32Test.groovy
+++ b/dd-java-agent/instrumentation/opentracing/api-0.32/src/test/groovy/OpenTracing32Test.groovy
@@ -70,7 +70,7 @@ class OpenTracing32Test extends AgentTestRunner {
           } else {
             parent()
           }
-          serviceName "unnamed-java-app"
+          hasServiceName()
           operationName "some name"
           if (tagSpan) {
             resourceName "other resource"

--- a/dd-java-agent/instrumentation/opentracing/api-0.32/src/test/groovy/OpenTracing32Test.groovy
+++ b/dd-java-agent/instrumentation/opentracing/api-0.32/src/test/groovy/OpenTracing32Test.groovy
@@ -70,7 +70,6 @@ class OpenTracing32Test extends AgentTestRunner {
           } else {
             parent()
           }
-          hasServiceName()
           operationName "some name"
           if (tagSpan) {
             resourceName "other resource"

--- a/dd-java-agent/instrumentation/ratpack-1.5/src/test/groovy/RatpackOtherTest.groovy
+++ b/dd-java-agent/instrumentation/ratpack-1.5/src/test/groovy/RatpackOtherTest.groovy
@@ -64,7 +64,6 @@ class RatpackOtherTest extends AgentTestRunner {
       trace(0, 2) {
         span(0) {
           resourceName "GET /$route"
-          hasServiceName()
           operationName "netty.request"
           spanType DDSpanTypes.HTTP_SERVER
           parent()
@@ -82,7 +81,6 @@ class RatpackOtherTest extends AgentTestRunner {
         }
         span(1) {
           resourceName "GET /$route"
-          hasServiceName()
           operationName "ratpack.handler"
           spanType DDSpanTypes.HTTP_SERVER
           childOf(span(0))

--- a/dd-java-agent/instrumentation/ratpack-1.5/src/test/groovy/RatpackOtherTest.groovy
+++ b/dd-java-agent/instrumentation/ratpack-1.5/src/test/groovy/RatpackOtherTest.groovy
@@ -64,7 +64,7 @@ class RatpackOtherTest extends AgentTestRunner {
       trace(0, 2) {
         span(0) {
           resourceName "GET /$route"
-          serviceName "unnamed-java-app"
+          hasServiceName()
           operationName "netty.request"
           spanType DDSpanTypes.HTTP_SERVER
           parent()
@@ -82,7 +82,7 @@ class RatpackOtherTest extends AgentTestRunner {
         }
         span(1) {
           resourceName "GET /$route"
-          serviceName "unnamed-java-app"
+          hasServiceName()
           operationName "ratpack.handler"
           spanType DDSpanTypes.HTTP_SERVER
           childOf(span(0))

--- a/dd-java-agent/instrumentation/scala-concurrent/src/slickTest/groovy/SlickTest.groovy
+++ b/dd-java-agent/instrumentation/scala-concurrent/src/slickTest/groovy/SlickTest.groovy
@@ -18,7 +18,7 @@ class SlickTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 2) {
         span(0) {
-          serviceName "unnamed-java-app"
+          hasServiceName()
           operationName "trace.annotation"
           resourceName "SlickUtils.startQuery"
           parent()

--- a/dd-java-agent/instrumentation/scala-concurrent/src/slickTest/groovy/SlickTest.groovy
+++ b/dd-java-agent/instrumentation/scala-concurrent/src/slickTest/groovy/SlickTest.groovy
@@ -18,7 +18,6 @@ class SlickTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 2) {
         span(0) {
-          hasServiceName()
           operationName "trace.annotation"
           resourceName "SlickUtils.startQuery"
           parent()

--- a/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/JettyServletHandlerTest.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/JettyServletHandlerTest.groovy
@@ -1,3 +1,5 @@
+import datadog.trace.api.config.GeneralConfig
+import datadog.trace.api.env.CapturedEnvironment
 import org.eclipse.jetty.server.Server
 import org.eclipse.jetty.server.handler.ErrorHandler
 import org.eclipse.jetty.servlet.ServletHandler
@@ -46,7 +48,7 @@ class JettyServletHandlerTest extends AbstractServlet3Test<Server, ServletHandle
 
   @Override
   String expectedServiceName() {
-    "unnamed-java-app"
+    CapturedEnvironment.get().getProperties().get(GeneralConfig.SERVICE_NAME)
   }
 
   @Override

--- a/dd-java-agent/instrumentation/sparkjava-2.3/src/test/groovy/SparkJavaBasedTest.groovy
+++ b/dd-java-agent/instrumentation/sparkjava-2.3/src/test/groovy/SparkJavaBasedTest.groovy
@@ -44,7 +44,6 @@ class SparkJavaBasedTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          hasServiceName()
           operationName "jetty.request"
           resourceName "GET /param/:param"
           spanType DDSpanTypes.HTTP_SERVER

--- a/dd-java-agent/instrumentation/sparkjava-2.3/src/test/groovy/SparkJavaBasedTest.groovy
+++ b/dd-java-agent/instrumentation/sparkjava-2.3/src/test/groovy/SparkJavaBasedTest.groovy
@@ -44,7 +44,7 @@ class SparkJavaBasedTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          serviceName "unnamed-java-app"
+          hasServiceName()
           operationName "jetty.request"
           resourceName "GET /param/:param"
           spanType DDSpanTypes.HTTP_SERVER

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/test/groovy/SpringWebfluxTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/test/groovy/SpringWebfluxTest.groovy
@@ -169,7 +169,7 @@ class SpringWebfluxTest extends AgentTestRunner {
           }
         }
         span(2) {
-          serviceName "unnamed-java-app"
+          hasServiceName()
           if (annotatedMethod == null) {
             // Functional API
             resourceName "SpringWebFluxTestApplication.tracedMethod"

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/test/groovy/SpringWebfluxTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/test/groovy/SpringWebfluxTest.groovy
@@ -169,7 +169,6 @@ class SpringWebfluxTest extends AgentTestRunner {
           }
         }
         span(2) {
-          hasServiceName()
           if (annotatedMethod == null) {
             // Functional API
             resourceName "SpringWebFluxTestApplication.tracedMethod"

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/test/groovy/dd/trace/instrumentation/springwebflux/client/SpringWebfluxHttpClientTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/test/groovy/dd/trace/instrumentation/springwebflux/client/SpringWebfluxHttpClientTest.groovy
@@ -48,7 +48,10 @@ class SpringWebfluxHttpClientTest extends HttpClientTest {
     if (!exception) {
       trace.span(index + 1) {
         childOf(trace.span(index))
-        serviceName renameService ? "localhost" : "unnamed-java-app"
+        hasServiceName()
+        if (renameService) {
+          serviceName("localhost")
+        }
         operationName "netty.client.request"
         resourceName "$method $uri.path"
         spanType DDSpanTypes.HTTP_CLIENT

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/test/groovy/dd/trace/instrumentation/springwebflux/client/SpringWebfluxHttpClientTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/test/groovy/dd/trace/instrumentation/springwebflux/client/SpringWebfluxHttpClientTest.groovy
@@ -48,7 +48,6 @@ class SpringWebfluxHttpClientTest extends HttpClientTest {
     if (!exception) {
       trace.span(index + 1) {
         childOf(trace.span(index))
-        hasServiceName()
         if (renameService) {
           serviceName("localhost")
         }

--- a/dd-java-agent/instrumentation/twilio/src/test/groovy/test/TwilioClientTest.groovy
+++ b/dd-java-agent/instrumentation/twilio/src/test/groovy/test/TwilioClientTest.groovy
@@ -132,7 +132,6 @@ class TwilioClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 2) {
         span(0) {
-          hasServiceName()
           operationName "test"
           resourceName "test"
           errored false
@@ -184,7 +183,6 @@ class TwilioClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 2) {
         span(0) {
-          hasServiceName()
           operationName "test"
           resourceName "test"
           errored false
@@ -258,7 +256,6 @@ class TwilioClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 3) {
         span(0) {
-          hasServiceName()
           operationName "test"
           resourceName "test"
           errored false
@@ -363,7 +360,6 @@ class TwilioClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 4) {
         span(0) {
-          hasServiceName()
           operationName "test"
           resourceName "test"
           errored false
@@ -491,7 +487,6 @@ class TwilioClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 5) {
         span(0) {
-          hasServiceName()
           operationName "test"
           resourceName "test"
           errored false
@@ -598,7 +593,6 @@ class TwilioClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 2) {
         span(0) {
-          hasServiceName()
           operationName "test"
           resourceName "test"
           errored true
@@ -696,7 +690,6 @@ class TwilioClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 3) {
         span(0) {
-          hasServiceName()
           operationName "test"
           resourceName "test"
           errored false
@@ -780,7 +773,6 @@ class TwilioClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 3) {
         span(0) {
-          hasServiceName()
           operationName "test"
           resourceName "test"
           errored true

--- a/dd-java-agent/instrumentation/twilio/src/test/groovy/test/TwilioClientTest.groovy
+++ b/dd-java-agent/instrumentation/twilio/src/test/groovy/test/TwilioClientTest.groovy
@@ -132,7 +132,7 @@ class TwilioClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 2) {
         span(0) {
-          serviceName "unnamed-java-app"
+          hasServiceName()
           operationName "test"
           resourceName "test"
           errored false
@@ -184,7 +184,7 @@ class TwilioClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 2) {
         span(0) {
-          serviceName "unnamed-java-app"
+          hasServiceName()
           operationName "test"
           resourceName "test"
           errored false
@@ -258,7 +258,7 @@ class TwilioClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 3) {
         span(0) {
-          serviceName "unnamed-java-app"
+          hasServiceName()
           operationName "test"
           resourceName "test"
           errored false
@@ -363,7 +363,7 @@ class TwilioClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 4) {
         span(0) {
-          serviceName "unnamed-java-app"
+          hasServiceName()
           operationName "test"
           resourceName "test"
           errored false
@@ -491,7 +491,7 @@ class TwilioClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 5) {
         span(0) {
-          serviceName "unnamed-java-app"
+          hasServiceName()
           operationName "test"
           resourceName "test"
           errored false
@@ -598,7 +598,7 @@ class TwilioClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 2) {
         span(0) {
-          serviceName "unnamed-java-app"
+          hasServiceName()
           operationName "test"
           resourceName "test"
           errored true
@@ -696,7 +696,7 @@ class TwilioClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 3) {
         span(0) {
-          serviceName "unnamed-java-app"
+          hasServiceName()
           operationName "test"
           resourceName "test"
           errored false
@@ -780,7 +780,7 @@ class TwilioClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 3) {
         span(0) {
-          serviceName "unnamed-java-app"
+          hasServiceName()
           operationName "test"
           resourceName "test"
           errored true

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/SpanAssert.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/SpanAssert.groovy
@@ -131,6 +131,7 @@ class SpanAssert {
     if (!checked.errored) {
       errored(false)
     }
+    hasServiceName()
   }
 
   void tags(@ClosureParams(value = SimpleType, options = ['datadog.trace.agent.test.asserts.TagsAssert'])

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/SpanAssert.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/SpanAssert.groovy
@@ -41,6 +41,10 @@ class SpanAssert {
     }
   }
 
+  def hasServiceName() {
+    assert span.serviceName != null && !span.serviceName.isEmpty()
+  }
+
   def serviceName(String name) {
     assert span.serviceName == name
     checked.serviceName = true

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
@@ -445,7 +445,6 @@ abstract class HttpClientTest extends AgentTestRunner {
       } else {
         childOf((DDSpan) parentSpan)
       }
-      hasServiceName()
       if (renameService) {
         serviceName uri.host
       }

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
@@ -324,7 +324,7 @@ abstract class HttpClientTest extends AgentTestRunner {
     def uri = server.address.resolve("/to-secured")
 
     when:
-    def status = doRequest(method, uri, [(BASIC_AUTH_KEY) : BASIC_AUTH_VAL])
+    def status = doRequest(method, uri, [(BASIC_AUTH_KEY): BASIC_AUTH_VAL])
 
     then:
     status == 200
@@ -445,7 +445,10 @@ abstract class HttpClientTest extends AgentTestRunner {
       } else {
         childOf((DDSpan) parentSpan)
       }
-      serviceName renameService ? uri.host : "unnamed-java-app"
+      hasServiceName()
+      if (renameService) {
+        serviceName uri.host
+      }
       operationName expectedOperationName()
       resourceName "$method $uri.path"
       spanType DDSpanTypes.HTTP_CLIENT

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
@@ -8,6 +8,8 @@ import datadog.trace.agent.test.utils.OkHttpUtils
 import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
+import datadog.trace.api.config.GeneralConfig
+import datadog.trace.api.env.CapturedEnvironment
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.core.DDSpan
 import groovy.transform.stc.ClosureParams
@@ -85,7 +87,7 @@ abstract class HttpServerTest<SERVER> extends AgentTestRunner {
   abstract String component()
 
   String expectedServiceName() {
-    "unnamed-java-app"
+    CapturedEnvironment.get().getProperties().get(GeneralConfig.SERVICE_NAME)
   }
 
   abstract String expectedOperationName()

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/log/injection/LogContextInjectionTestBase.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/log/injection/LogContextInjectionTestBase.groovy
@@ -10,7 +10,6 @@ import datadog.trace.bootstrap.instrumentation.api.Tags
 import java.util.concurrent.atomic.AtomicReference
 
 import static datadog.trace.api.Config.PREFIX
-import static datadog.trace.api.ConfigDefaults.DEFAULT_SERVICE_NAME
 import static datadog.trace.api.config.GeneralConfig.TAGS
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan
@@ -57,7 +56,7 @@ abstract class LogContextInjectionTestBase extends AgentTestRunner {
     get(CorrelationIdentifier.getTraceIdKey()) == CorrelationIdentifier.getTraceId()
     get(CorrelationIdentifier.getSpanIdKey()) == CorrelationIdentifier.getSpanId()
     get("foo") == "bar"
-    get(Tags.DD_SERVICE) == DEFAULT_SERVICE_NAME
+    get(Tags.DD_SERVICE) != ""
     get(Tags.DD_VERSION) == TEST_VERSION
     get(Tags.DD_ENV) == TEST_ENV
 
@@ -69,7 +68,7 @@ abstract class LogContextInjectionTestBase extends AgentTestRunner {
     get(CorrelationIdentifier.getTraceIdKey()) == CorrelationIdentifier.getTraceId()
     get(CorrelationIdentifier.getSpanIdKey()) == CorrelationIdentifier.getSpanId()
     get("foo") == "bar"
-    get(Tags.DD_SERVICE) == DEFAULT_SERVICE_NAME
+    get(Tags.DD_SERVICE) != ""
     get(Tags.DD_VERSION) == TEST_VERSION
     get(Tags.DD_ENV) == TEST_ENV
 
@@ -81,7 +80,7 @@ abstract class LogContextInjectionTestBase extends AgentTestRunner {
     get(CorrelationIdentifier.getTraceIdKey()) == CorrelationIdentifier.getTraceId()
     get(CorrelationIdentifier.getSpanIdKey()) == CorrelationIdentifier.getSpanId()
     get("foo") == "bar"
-    get(Tags.DD_SERVICE) == DEFAULT_SERVICE_NAME
+    get(Tags.DD_SERVICE) != ""
     get(Tags.DD_VERSION) == TEST_VERSION
     get(Tags.DD_ENV) == TEST_ENV
 
@@ -93,7 +92,7 @@ abstract class LogContextInjectionTestBase extends AgentTestRunner {
     get(CorrelationIdentifier.getTraceIdKey()) == null
     get(CorrelationIdentifier.getSpanIdKey()) == null
     get("foo") == "bar"
-    get(Tags.DD_SERVICE) == DEFAULT_SERVICE_NAME
+    get(Tags.DD_SERVICE) != ""
     get(Tags.DD_VERSION) == TEST_VERSION
     get(Tags.DD_ENV) == TEST_ENV
   }
@@ -155,7 +154,7 @@ abstract class LogContextInjectionTestBase extends AgentTestRunner {
     thread1TraceId.get() == null
     thread2TraceId.get() != null
     thread2TraceId.get() != mainThreadTraceId
-    get(Tags.DD_SERVICE) == DEFAULT_SERVICE_NAME
+    get(Tags.DD_SERVICE) != ""
     get(Tags.DD_VERSION) == TEST_VERSION
     get(Tags.DD_ENV) == TEST_ENV
     t1VersionBeg == TEST_VERSION
@@ -193,7 +192,7 @@ abstract class LogContextInjectionTestBase extends AgentTestRunner {
         t1threadNameBeg = get("threadName")
         remove("threadName")
 
-        t1threadNameEnd =  get("threadName")
+        t1threadNameEnd = get("threadName")
         t1VersionEnd = get(Tags.DD_VERSION)
         t1EnvEnd = get(Tags.DD_ENV)
 
@@ -212,7 +211,7 @@ abstract class LogContextInjectionTestBase extends AgentTestRunner {
 
     expect:
     mainThreadVersion == get(Tags.DD_VERSION)
-    get(Tags.DD_SERVICE) == DEFAULT_SERVICE_NAME
+    get(Tags.DD_SERVICE) != ""
     get(Tags.DD_VERSION) == TEST_VERSION
     get(Tags.DD_ENV) == TEST_ENV
     t1VersionBeg == TEST_VERSION

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/utils/TraceUtils.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/utils/TraceUtils.groovy
@@ -59,7 +59,7 @@ class TraceUtils {
       } else {
         childOf((DDSpan) parentSpan)
       }
-      serviceName "unnamed-java-app"
+      hasServiceName()
       operationName operation
       resourceName resource
       errored exception != null

--- a/dd-trace-api/src/main/java/datadog/trace/api/Config.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/Config.java
@@ -1598,7 +1598,7 @@ public class Config {
 
     return properties;
   }
-
+  
   /**
    * Returns the detected hostname. First tries locally, then using DNS
    */

--- a/dd-trace-api/src/main/java/datadog/trace/api/Config.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/Config.java
@@ -60,11 +60,6 @@ import datadog.trace.api.config.ProfilingConfig;
 import datadog.trace.api.config.TraceInstrumentationConfig;
 import datadog.trace.api.config.TracerConfig;
 import datadog.trace.api.env.CapturedEnvironment;
-import lombok.Getter;
-import lombok.NonNull;
-import lombok.ToString;
-import lombok.extern.slf4j.Slf4j;
-
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -91,6 +86,10 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.UUID;
 import java.util.regex.Pattern;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Config reads values with the following priority: 1) system properties, 2) environment variables,
@@ -108,9 +107,7 @@ import java.util.regex.Pattern;
 public class Config {
   private static final MethodHandles.Lookup PUBLIC_LOOKUP = MethodHandles.publicLookup();
 
-  /**
-   * Config keys below
-   */
+  /** Config keys below */
   private static final String PREFIX = "dd.";
 
   public static final String CONFIGURATION_FILE = GeneralConfig.CONFIGURATION_FILE;
@@ -146,11 +143,11 @@ public class Config {
   public static final String TRACE_EXECUTORS = TraceInstrumentationConfig.TRACE_EXECUTORS;
   public static final String TRACE_METHODS = TraceInstrumentationConfig.TRACE_METHODS;
   public static final String TRACE_CLASSES_EXCLUDE =
-    TraceInstrumentationConfig.TRACE_CLASSES_EXCLUDE;
+      TraceInstrumentationConfig.TRACE_CLASSES_EXCLUDE;
   public static final String TRACE_SAMPLING_SERVICE_RULES =
-    TracerConfig.TRACE_SAMPLING_SERVICE_RULES;
+      TracerConfig.TRACE_SAMPLING_SERVICE_RULES;
   public static final String TRACE_SAMPLING_OPERATION_RULES =
-    TracerConfig.TRACE_SAMPLING_OPERATION_RULES;
+      TracerConfig.TRACE_SAMPLING_OPERATION_RULES;
   public static final String TRACE_SAMPLE_RATE = TracerConfig.TRACE_SAMPLE_RATE;
   public static final String TRACE_RATE_LIMIT = TracerConfig.TRACE_RATE_LIMIT;
   public static final String TRACE_REPORT_HOSTNAME = TracerConfig.TRACE_REPORT_HOSTNAME;
@@ -158,19 +155,19 @@ public class Config {
   public static final String HTTP_SERVER_ERROR_STATUSES = TracerConfig.HTTP_SERVER_ERROR_STATUSES;
   public static final String HTTP_CLIENT_ERROR_STATUSES = TracerConfig.HTTP_CLIENT_ERROR_STATUSES;
   public static final String HTTP_SERVER_TAG_QUERY_STRING =
-    TraceInstrumentationConfig.HTTP_SERVER_TAG_QUERY_STRING;
+      TraceInstrumentationConfig.HTTP_SERVER_TAG_QUERY_STRING;
   public static final String HTTP_CLIENT_TAG_QUERY_STRING =
-    TraceInstrumentationConfig.HTTP_CLIENT_TAG_QUERY_STRING;
+      TraceInstrumentationConfig.HTTP_CLIENT_TAG_QUERY_STRING;
   public static final String HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN =
-    TraceInstrumentationConfig.HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN;
+      TraceInstrumentationConfig.HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN;
   public static final String DB_CLIENT_HOST_SPLIT_BY_INSTANCE =
-    TraceInstrumentationConfig.DB_CLIENT_HOST_SPLIT_BY_INSTANCE;
+      TraceInstrumentationConfig.DB_CLIENT_HOST_SPLIT_BY_INSTANCE;
   public static final String SPLIT_BY_TAGS = TracerConfig.SPLIT_BY_TAGS;
   public static final String SCOPE_DEPTH_LIMIT = TracerConfig.SCOPE_DEPTH_LIMIT;
   public static final String SCOPE_STRICT_MODE = TracerConfig.SCOPE_STRICT_MODE;
   public static final String PARTIAL_FLUSH_MIN_SPANS = TracerConfig.PARTIAL_FLUSH_MIN_SPANS;
   public static final String RUNTIME_CONTEXT_FIELD_INJECTION =
-    TraceInstrumentationConfig.RUNTIME_CONTEXT_FIELD_INJECTION;
+      TraceInstrumentationConfig.RUNTIME_CONTEXT_FIELD_INJECTION;
   public static final String PROPAGATION_STYLE_EXTRACT = TracerConfig.PROPAGATION_STYLE_EXTRACT;
   public static final String PROPAGATION_STYLE_INJECT = TracerConfig.PROPAGATION_STYLE_INJECT;
 
@@ -183,7 +180,7 @@ public class Config {
 
   public static final String JMX_FETCH_CHECK_PERIOD = JmxFetchConfig.JMX_FETCH_CHECK_PERIOD;
   public static final String JMX_FETCH_REFRESH_BEANS_PERIOD =
-    JmxFetchConfig.JMX_FETCH_REFRESH_BEANS_PERIOD;
+      JmxFetchConfig.JMX_FETCH_REFRESH_BEANS_PERIOD;
   public static final String JMX_FETCH_STATSD_HOST = JmxFetchConfig.JMX_FETCH_STATSD_HOST;
   public static final String JMX_FETCH_STATSD_PORT = JmxFetchConfig.JMX_FETCH_STATSD_PORT;
 
@@ -192,7 +189,7 @@ public class Config {
   public static final String HEALTH_METRICS_STATSD_PORT = GeneralConfig.HEALTH_METRICS_STATSD_PORT;
 
   public static final String LOGS_INJECTION_ENABLED =
-    TraceInstrumentationConfig.LOGS_INJECTION_ENABLED;
+      TraceInstrumentationConfig.LOGS_INJECTION_ENABLED;
 
   public static final String PROFILING_ENABLED = ProfilingConfig.PROFILING_ENABLED;
   @Deprecated // Use dd.site instead
@@ -201,41 +198,41 @@ public class Config {
   public static final String PROFILING_API_KEY_OLD = ProfilingConfig.PROFILING_API_KEY_OLD;
   @Deprecated // Use dd.api-key-file instead
   public static final String PROFILING_API_KEY_FILE_OLD =
-    ProfilingConfig.PROFILING_API_KEY_FILE_OLD;
+      ProfilingConfig.PROFILING_API_KEY_FILE_OLD;
   @Deprecated // Use dd.api-key instead
   public static final String PROFILING_API_KEY_VERY_OLD =
-    ProfilingConfig.PROFILING_API_KEY_VERY_OLD;
+      ProfilingConfig.PROFILING_API_KEY_VERY_OLD;
   @Deprecated // Use dd.api-key-file instead
   public static final String PROFILING_API_KEY_FILE_VERY_OLD =
-    ProfilingConfig.PROFILING_API_KEY_FILE_VERY_OLD;
+      ProfilingConfig.PROFILING_API_KEY_FILE_VERY_OLD;
   public static final String PROFILING_TAGS = ProfilingConfig.PROFILING_TAGS;
   public static final String PROFILING_START_DELAY = ProfilingConfig.PROFILING_START_DELAY;
   // DANGEROUS! May lead on sigsegv on JVMs before 14
   // Not intended for production use
   public static final String PROFILING_START_FORCE_FIRST =
-    ProfilingConfig.PROFILING_START_FORCE_FIRST;
+      ProfilingConfig.PROFILING_START_FORCE_FIRST;
   public static final String PROFILING_UPLOAD_PERIOD = ProfilingConfig.PROFILING_UPLOAD_PERIOD;
   public static final String PROFILING_TEMPLATE_OVERRIDE_FILE =
-    ProfilingConfig.PROFILING_TEMPLATE_OVERRIDE_FILE;
+      ProfilingConfig.PROFILING_TEMPLATE_OVERRIDE_FILE;
   public static final String PROFILING_UPLOAD_TIMEOUT = ProfilingConfig.PROFILING_UPLOAD_TIMEOUT;
   public static final String PROFILING_UPLOAD_COMPRESSION =
-    ProfilingConfig.PROFILING_UPLOAD_COMPRESSION;
+      ProfilingConfig.PROFILING_UPLOAD_COMPRESSION;
   public static final String PROFILING_PROXY_HOST = ProfilingConfig.PROFILING_PROXY_HOST;
   public static final String PROFILING_PROXY_PORT = ProfilingConfig.PROFILING_PROXY_PORT;
   public static final String PROFILING_PROXY_USERNAME = ProfilingConfig.PROFILING_PROXY_USERNAME;
   public static final String PROFILING_PROXY_PASSWORD = ProfilingConfig.PROFILING_PROXY_PASSWORD;
   public static final String PROFILING_EXCEPTION_SAMPLE_LIMIT =
-    ProfilingConfig.PROFILING_EXCEPTION_SAMPLE_LIMIT;
+      ProfilingConfig.PROFILING_EXCEPTION_SAMPLE_LIMIT;
   public static final String PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS =
-    ProfilingConfig.PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS;
+      ProfilingConfig.PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS;
   public static final String PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE =
-    ProfilingConfig.PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE;
+      ProfilingConfig.PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE;
 
   public static final String KAFKA_CLIENT_PROPAGATION_ENABLED =
-    TraceInstrumentationConfig.KAFKA_CLIENT_PROPAGATION_ENABLED;
+      TraceInstrumentationConfig.KAFKA_CLIENT_PROPAGATION_ENABLED;
 
   public static final String KAFKA_CLIENT_BASE64_DECODING_ENABLED =
-    TraceInstrumentationConfig.KAFKA_CLIENT_BASE64_DECODING_ENABLED;
+      TraceInstrumentationConfig.KAFKA_CLIENT_BASE64_DECODING_ENABLED;
 
   private static final String PROFILING_REMOTE_URL_TEMPLATE = "https://intake.profile.%s/v1/input";
   private static final String PROFILING_LOCAL_URL_TEMPLATE = "http://%s:%d/profiling/v1/input";
@@ -243,17 +240,13 @@ public class Config {
   private static final Pattern ENV_REPLACEMENT = Pattern.compile("[^a-zA-Z0-9_]");
   private static final String SPLIT_BY_SPACE_OR_COMMA_REGEX = "[,\\s]+";
 
-  /**
-   * Used for masking sensitive information when doing toString
-   */
+  /** Used for masking sensitive information when doing toString */
   @ToString.Include(name = "apiKey")
   private String profilingApiKeyMasker() {
     return apiKey != null ? "****" : null;
   }
 
-  /**
-   * Used for masking sensitive information when doing toString
-   */
+  /** Used for masking sensitive information when doing toString */
   @ToString.Include(name = "profilingProxyPassword")
   private String profilingProxyPasswordMasker() {
     return profilingProxyPassword != null ? "****" : null;
@@ -263,174 +256,102 @@ public class Config {
    * this is a random UUID that gets generated on JVM start up and is attached to every root span
    * and every JMX metric that is sent out.
    */
-  @Getter
-  private final String runtimeId;
+  @Getter private final String runtimeId;
 
   /**
    * Note: this has effect only on profiling site. Traces are sent to Datadog agent and are not
    * affected by this setting.
    */
-  @Getter
-  private final String apiKey;
+  @Getter private final String apiKey;
   /**
    * Note: this has effect only on profiling site. Traces are sent to Datadog agent and are not
    * affected by this setting.
    */
-  @Getter
-  private final String site;
+  @Getter private final String site;
 
-  @Getter
-  private final String serviceName;
-  @Getter
-  private final boolean traceEnabled;
-  @Getter
-  private final boolean integrationsEnabled;
-  @Getter
-  private final String writerType;
-  @Getter
-  private final String agentHost;
-  @Getter
-  private final int agentPort;
-  @Getter
-  private final String agentUnixDomainSocket;
-  @Getter
-  private final int agentTimeout;
-  @Getter
-  private final boolean prioritySamplingEnabled;
-  @Getter
-  private final boolean traceResolverEnabled;
-  @Getter
-  private final Map<String, String> serviceMapping;
-  @NonNull
-  private final Map<String, String> tags;
+  @Getter private final String serviceName;
+  @Getter private final boolean traceEnabled;
+  @Getter private final boolean integrationsEnabled;
+  @Getter private final String writerType;
+  @Getter private final String agentHost;
+  @Getter private final int agentPort;
+  @Getter private final String agentUnixDomainSocket;
+  @Getter private final int agentTimeout;
+  @Getter private final boolean prioritySamplingEnabled;
+  @Getter private final boolean traceResolverEnabled;
+  @Getter private final Map<String, String> serviceMapping;
+  @NonNull private final Map<String, String> tags;
   private final Map<String, String> spanTags;
   private final Map<String, String> jmxTags;
-  @Getter
-  private final List<String> excludedClasses;
-  @Getter
-  private final Map<String, String> headerTags;
-  @Getter
-  private final BitSet httpServerErrorStatuses;
-  @Getter
-  private final BitSet httpClientErrorStatuses;
-  @Getter
-  private final boolean httpServerTagQueryString;
-  @Getter
-  private final boolean httpClientTagQueryString;
-  @Getter
-  private final boolean httpClientSplitByDomain;
-  @Getter
-  private final boolean dbClientSplitByInstance;
-  @Getter
-  private final Set<String> splitByTags;
-  @Getter
-  private final Integer scopeDepthLimit;
-  @Getter
-  private final boolean scopeStrictMode;
-  @Getter
-  private final Integer partialFlushMinSpans;
-  @Getter
-  private final boolean runtimeContextFieldInjection;
-  @Getter
-  private final Set<PropagationStyle> propagationStylesToExtract;
-  @Getter
-  private final Set<PropagationStyle> propagationStylesToInject;
+  @Getter private final List<String> excludedClasses;
+  @Getter private final Map<String, String> headerTags;
+  @Getter private final BitSet httpServerErrorStatuses;
+  @Getter private final BitSet httpClientErrorStatuses;
+  @Getter private final boolean httpServerTagQueryString;
+  @Getter private final boolean httpClientTagQueryString;
+  @Getter private final boolean httpClientSplitByDomain;
+  @Getter private final boolean dbClientSplitByInstance;
+  @Getter private final Set<String> splitByTags;
+  @Getter private final Integer scopeDepthLimit;
+  @Getter private final boolean scopeStrictMode;
+  @Getter private final Integer partialFlushMinSpans;
+  @Getter private final boolean runtimeContextFieldInjection;
+  @Getter private final Set<PropagationStyle> propagationStylesToExtract;
+  @Getter private final Set<PropagationStyle> propagationStylesToInject;
 
-  @Getter
-  private final boolean jmxFetchEnabled;
-  @Getter
-  private final String jmxFetchConfigDir;
-  @Getter
-  private final List<String> jmxFetchConfigs;
-  @Deprecated
-  @Getter
-  private final List<String> jmxFetchMetricsConfigs;
-  @Getter
-  private final Integer jmxFetchCheckPeriod;
-  @Getter
-  private final Integer jmxFetchRefreshBeansPeriod;
-  @Getter
-  private final String jmxFetchStatsdHost;
-  @Getter
-  private final Integer jmxFetchStatsdPort;
+  @Getter private final boolean jmxFetchEnabled;
+  @Getter private final String jmxFetchConfigDir;
+  @Getter private final List<String> jmxFetchConfigs;
+  @Deprecated @Getter private final List<String> jmxFetchMetricsConfigs;
+  @Getter private final Integer jmxFetchCheckPeriod;
+  @Getter private final Integer jmxFetchRefreshBeansPeriod;
+  @Getter private final String jmxFetchStatsdHost;
+  @Getter private final Integer jmxFetchStatsdPort;
 
   // These values are default-ed to those of jmx fetch values as needed
-  @Getter
-  private final boolean healthMetricsEnabled;
-  @Getter
-  private final String healthMetricsStatsdHost;
-  @Getter
-  private final Integer healthMetricsStatsdPort;
+  @Getter private final boolean healthMetricsEnabled;
+  @Getter private final String healthMetricsStatsdHost;
+  @Getter private final Integer healthMetricsStatsdPort;
 
-  @Getter
-  private final boolean logsInjectionEnabled;
-  @Getter
-  private final boolean reportHostName;
+  @Getter private final boolean logsInjectionEnabled;
+  @Getter private final boolean reportHostName;
 
-  @Getter
-  private final String traceAnnotations;
+  @Getter private final String traceAnnotations;
 
-  @Getter
-  private final String traceMethods;
+  @Getter private final String traceMethods;
 
-  @Getter
-  private final boolean traceExecutorsAll;
-  @Getter
-  private final List<String> traceExecutors;
+  @Getter private final boolean traceExecutorsAll;
+  @Getter private final List<String> traceExecutors;
 
-  @Getter
-  private final boolean traceAnalyticsEnabled;
+  @Getter private final boolean traceAnalyticsEnabled;
 
-  @Getter
-  private final Map<String, String> traceSamplingServiceRules;
-  @Getter
-  private final Map<String, String> traceSamplingOperationRules;
-  @Getter
-  private final Double traceSampleRate;
-  @Getter
-  private final Double traceRateLimit;
+  @Getter private final Map<String, String> traceSamplingServiceRules;
+  @Getter private final Map<String, String> traceSamplingOperationRules;
+  @Getter private final Double traceSampleRate;
+  @Getter private final Double traceRateLimit;
 
-  @Getter
-  private final boolean profilingEnabled;
-  @Deprecated
-  private final String profilingUrl;
+  @Getter private final boolean profilingEnabled;
+  @Deprecated private final String profilingUrl;
   private final Map<String, String> profilingTags;
-  @Getter
-  private final int profilingStartDelay;
-  @Getter
-  private final boolean profilingStartForceFirst;
-  @Getter
-  private final int profilingUploadPeriod;
-  @Getter
-  private final String profilingTemplateOverrideFile;
-  @Getter
-  private final int profilingUploadTimeout;
-  @Getter
-  private final String profilingUploadCompression;
-  @Getter
-  private final String profilingProxyHost;
-  @Getter
-  private final int profilingProxyPort;
-  @Getter
-  private final String profilingProxyUsername;
-  @Getter
-  private final String profilingProxyPassword;
-  @Getter
-  private final int profilingExceptionSampleLimit;
-  @Getter
-  private final int profilingExceptionHistogramTopItems;
-  @Getter
-  private final int profilingExceptionHistogramMaxCollectionSize;
+  @Getter private final int profilingStartDelay;
+  @Getter private final boolean profilingStartForceFirst;
+  @Getter private final int profilingUploadPeriod;
+  @Getter private final String profilingTemplateOverrideFile;
+  @Getter private final int profilingUploadTimeout;
+  @Getter private final String profilingUploadCompression;
+  @Getter private final String profilingProxyHost;
+  @Getter private final int profilingProxyPort;
+  @Getter private final String profilingProxyUsername;
+  @Getter private final String profilingProxyPassword;
+  @Getter private final int profilingExceptionSampleLimit;
+  @Getter private final int profilingExceptionHistogramTopItems;
+  @Getter private final int profilingExceptionHistogramMaxCollectionSize;
 
-  @Getter
-  private final boolean kafkaClientPropagationEnabled;
-  @Getter
-  private final boolean kafkaClientBase64DecodingEnabled;
+  @Getter private final boolean kafkaClientPropagationEnabled;
+  @Getter private final boolean kafkaClientBase64DecodingEnabled;
 
-  @Getter
-  private final boolean debugEnabled;
-  @Getter
-  private final String configFile;
+  @Getter private final boolean debugEnabled;
+  @Getter private final String configFile;
 
   // Values from an optionally provided properties file
   private static Properties propertiesFromConfigFile;
@@ -457,37 +378,37 @@ public class Config {
     if (apiKeyFile != null) {
       try {
         tmpApiKey =
-          new String(Files.readAllBytes(Paths.get(apiKeyFile)), StandardCharsets.UTF_8).trim();
+            new String(Files.readAllBytes(Paths.get(apiKeyFile)), StandardCharsets.UTF_8).trim();
       } catch (final IOException e) {
         log.error("Cannot read API key from file {}, skipping", apiKeyFile, e);
       }
     }
     site = getSettingFromEnvironment(SITE, DEFAULT_SITE);
     serviceName =
-      getSettingFromEnvironment(
-        SERVICE, getSettingFromEnvironment(SERVICE_NAME, DEFAULT_SERVICE_NAME));
+        getSettingFromEnvironment(
+            SERVICE, getSettingFromEnvironment(SERVICE_NAME, DEFAULT_SERVICE_NAME));
 
     traceEnabled = getBooleanSettingFromEnvironment(TRACE_ENABLED, DEFAULT_TRACE_ENABLED);
     integrationsEnabled =
-      getBooleanSettingFromEnvironment(INTEGRATIONS_ENABLED, DEFAULT_INTEGRATIONS_ENABLED);
+        getBooleanSettingFromEnvironment(INTEGRATIONS_ENABLED, DEFAULT_INTEGRATIONS_ENABLED);
     writerType = getSettingFromEnvironment(WRITER_TYPE, DEFAULT_AGENT_WRITER_TYPE);
     agentHost = getSettingFromEnvironment(AGENT_HOST, DEFAULT_AGENT_HOST);
     agentPort =
-      getIntegerSettingFromEnvironment(
-        TRACE_AGENT_PORT,
-        getIntegerSettingFromEnvironment(AGENT_PORT_LEGACY, DEFAULT_TRACE_AGENT_PORT));
+        getIntegerSettingFromEnvironment(
+            TRACE_AGENT_PORT,
+            getIntegerSettingFromEnvironment(AGENT_PORT_LEGACY, DEFAULT_TRACE_AGENT_PORT));
     agentUnixDomainSocket =
-      getSettingFromEnvironment(AGENT_UNIX_DOMAIN_SOCKET, DEFAULT_AGENT_UNIX_DOMAIN_SOCKET);
+        getSettingFromEnvironment(AGENT_UNIX_DOMAIN_SOCKET, DEFAULT_AGENT_UNIX_DOMAIN_SOCKET);
     agentTimeout = getIntegerSettingFromEnvironment(AGENT_TIMEOUT, DEFAULT_AGENT_TIMEOUT);
     prioritySamplingEnabled =
-      getBooleanSettingFromEnvironment(PRIORITY_SAMPLING, DEFAULT_PRIORITY_SAMPLING_ENABLED);
+        getBooleanSettingFromEnvironment(PRIORITY_SAMPLING, DEFAULT_PRIORITY_SAMPLING_ENABLED);
     traceResolverEnabled =
-      getBooleanSettingFromEnvironment(TRACE_RESOLVER_ENABLED, DEFAULT_TRACE_RESOLVER_ENABLED);
+        getBooleanSettingFromEnvironment(TRACE_RESOLVER_ENABLED, DEFAULT_TRACE_RESOLVER_ENABLED);
     serviceMapping = getMapSettingFromEnvironment(SERVICE_MAPPING, null);
 
     {
       final Map<String, String> tags =
-        new HashMap<>(getMapSettingFromEnvironment(GLOBAL_TAGS, null));
+          new HashMap<>(getMapSettingFromEnvironment(GLOBAL_TAGS, null));
       tags.putAll(getMapSettingFromEnvironment(TAGS, null));
       this.tags = getMapWithPropertiesDefinedByEnvironment(tags, ENV, VERSION);
     }
@@ -499,108 +420,108 @@ public class Config {
     headerTags = getMapSettingFromEnvironment(HEADER_TAGS, null);
 
     httpServerErrorStatuses =
-      getIntegerRangeSettingFromEnvironment(
-        HTTP_SERVER_ERROR_STATUSES, DEFAULT_HTTP_SERVER_ERROR_STATUSES);
+        getIntegerRangeSettingFromEnvironment(
+            HTTP_SERVER_ERROR_STATUSES, DEFAULT_HTTP_SERVER_ERROR_STATUSES);
 
     httpClientErrorStatuses =
-      getIntegerRangeSettingFromEnvironment(
-        HTTP_CLIENT_ERROR_STATUSES, DEFAULT_HTTP_CLIENT_ERROR_STATUSES);
+        getIntegerRangeSettingFromEnvironment(
+            HTTP_CLIENT_ERROR_STATUSES, DEFAULT_HTTP_CLIENT_ERROR_STATUSES);
 
     httpServerTagQueryString =
-      getBooleanSettingFromEnvironment(
-        HTTP_SERVER_TAG_QUERY_STRING, DEFAULT_HTTP_SERVER_TAG_QUERY_STRING);
+        getBooleanSettingFromEnvironment(
+            HTTP_SERVER_TAG_QUERY_STRING, DEFAULT_HTTP_SERVER_TAG_QUERY_STRING);
 
     httpClientTagQueryString =
-      getBooleanSettingFromEnvironment(
-        HTTP_CLIENT_TAG_QUERY_STRING, DEFAULT_HTTP_CLIENT_TAG_QUERY_STRING);
+        getBooleanSettingFromEnvironment(
+            HTTP_CLIENT_TAG_QUERY_STRING, DEFAULT_HTTP_CLIENT_TAG_QUERY_STRING);
 
     httpClientSplitByDomain =
-      getBooleanSettingFromEnvironment(
-        HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN, DEFAULT_HTTP_CLIENT_SPLIT_BY_DOMAIN);
+        getBooleanSettingFromEnvironment(
+            HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN, DEFAULT_HTTP_CLIENT_SPLIT_BY_DOMAIN);
 
     dbClientSplitByInstance =
-      getBooleanSettingFromEnvironment(
-        DB_CLIENT_HOST_SPLIT_BY_INSTANCE, DEFAULT_DB_CLIENT_HOST_SPLIT_BY_INSTANCE);
+        getBooleanSettingFromEnvironment(
+            DB_CLIENT_HOST_SPLIT_BY_INSTANCE, DEFAULT_DB_CLIENT_HOST_SPLIT_BY_INSTANCE);
 
     splitByTags =
-      Collections.unmodifiableSet(
-        new LinkedHashSet<>(
-          getListSettingFromEnvironment(SPLIT_BY_TAGS, DEFAULT_SPLIT_BY_TAGS)));
+        Collections.unmodifiableSet(
+            new LinkedHashSet<>(
+                getListSettingFromEnvironment(SPLIT_BY_TAGS, DEFAULT_SPLIT_BY_TAGS)));
 
     scopeDepthLimit =
-      getIntegerSettingFromEnvironment(SCOPE_DEPTH_LIMIT, DEFAULT_SCOPE_DEPTH_LIMIT);
+        getIntegerSettingFromEnvironment(SCOPE_DEPTH_LIMIT, DEFAULT_SCOPE_DEPTH_LIMIT);
 
     scopeStrictMode = getBooleanSettingFromEnvironment(SCOPE_STRICT_MODE, false);
 
     partialFlushMinSpans =
-      getIntegerSettingFromEnvironment(PARTIAL_FLUSH_MIN_SPANS, DEFAULT_PARTIAL_FLUSH_MIN_SPANS);
+        getIntegerSettingFromEnvironment(PARTIAL_FLUSH_MIN_SPANS, DEFAULT_PARTIAL_FLUSH_MIN_SPANS);
 
     runtimeContextFieldInjection =
-      getBooleanSettingFromEnvironment(
-        RUNTIME_CONTEXT_FIELD_INJECTION, DEFAULT_RUNTIME_CONTEXT_FIELD_INJECTION);
+        getBooleanSettingFromEnvironment(
+            RUNTIME_CONTEXT_FIELD_INJECTION, DEFAULT_RUNTIME_CONTEXT_FIELD_INJECTION);
 
     propagationStylesToExtract =
-      getPropagationStyleSetSettingFromEnvironmentOrDefault(
-        PROPAGATION_STYLE_EXTRACT, DEFAULT_PROPAGATION_STYLE_EXTRACT);
+        getPropagationStyleSetSettingFromEnvironmentOrDefault(
+            PROPAGATION_STYLE_EXTRACT, DEFAULT_PROPAGATION_STYLE_EXTRACT);
     propagationStylesToInject =
-      getPropagationStyleSetSettingFromEnvironmentOrDefault(
-        PROPAGATION_STYLE_INJECT, DEFAULT_PROPAGATION_STYLE_INJECT);
+        getPropagationStyleSetSettingFromEnvironmentOrDefault(
+            PROPAGATION_STYLE_INJECT, DEFAULT_PROPAGATION_STYLE_INJECT);
 
     jmxFetchEnabled =
-      getBooleanSettingFromEnvironment(JMX_FETCH_ENABLED, DEFAULT_JMX_FETCH_ENABLED);
+        getBooleanSettingFromEnvironment(JMX_FETCH_ENABLED, DEFAULT_JMX_FETCH_ENABLED);
     jmxFetchConfigDir = getSettingFromEnvironment(JMX_FETCH_CONFIG_DIR, null);
     jmxFetchConfigs = getListSettingFromEnvironment(JMX_FETCH_CONFIG, null);
     jmxFetchMetricsConfigs = getListSettingFromEnvironment(JMX_FETCH_METRICS_CONFIGS, null);
     jmxFetchCheckPeriod = getIntegerSettingFromEnvironment(JMX_FETCH_CHECK_PERIOD, null);
     jmxFetchRefreshBeansPeriod =
-      getIntegerSettingFromEnvironment(JMX_FETCH_REFRESH_BEANS_PERIOD, null);
+        getIntegerSettingFromEnvironment(JMX_FETCH_REFRESH_BEANS_PERIOD, null);
     jmxFetchStatsdHost = getSettingFromEnvironment(JMX_FETCH_STATSD_HOST, null);
     jmxFetchStatsdPort =
-      getIntegerSettingFromEnvironment(JMX_FETCH_STATSD_PORT, DEFAULT_JMX_FETCH_STATSD_PORT);
+        getIntegerSettingFromEnvironment(JMX_FETCH_STATSD_PORT, DEFAULT_JMX_FETCH_STATSD_PORT);
 
     // Writer.Builder createMonitor will use the values of the JMX fetch & agent to fill-in defaults
     healthMetricsEnabled =
-      getBooleanSettingFromEnvironment(HEALTH_METRICS_ENABLED, DEFAULT_METRICS_ENABLED);
+        getBooleanSettingFromEnvironment(HEALTH_METRICS_ENABLED, DEFAULT_METRICS_ENABLED);
     healthMetricsStatsdHost = getSettingFromEnvironment(HEALTH_METRICS_STATSD_HOST, null);
     healthMetricsStatsdPort = getIntegerSettingFromEnvironment(HEALTH_METRICS_STATSD_PORT, null);
 
     logsInjectionEnabled =
-      getBooleanSettingFromEnvironment(LOGS_INJECTION_ENABLED, DEFAULT_LOGS_INJECTION_ENABLED);
+        getBooleanSettingFromEnvironment(LOGS_INJECTION_ENABLED, DEFAULT_LOGS_INJECTION_ENABLED);
     reportHostName =
-      getBooleanSettingFromEnvironment(TRACE_REPORT_HOSTNAME, DEFAULT_TRACE_REPORT_HOSTNAME);
+        getBooleanSettingFromEnvironment(TRACE_REPORT_HOSTNAME, DEFAULT_TRACE_REPORT_HOSTNAME);
 
     traceAnnotations = getSettingFromEnvironment(TRACE_ANNOTATIONS, DEFAULT_TRACE_ANNOTATIONS);
 
     traceMethods = getSettingFromEnvironment(TRACE_METHODS, DEFAULT_TRACE_METHODS);
 
     traceExecutorsAll =
-      getBooleanSettingFromEnvironment(TRACE_EXECUTORS_ALL, DEFAULT_TRACE_EXECUTORS_ALL);
+        getBooleanSettingFromEnvironment(TRACE_EXECUTORS_ALL, DEFAULT_TRACE_EXECUTORS_ALL);
 
     traceExecutors = getListSettingFromEnvironment(TRACE_EXECUTORS, DEFAULT_TRACE_EXECUTORS);
 
     traceAnalyticsEnabled =
-      getBooleanSettingFromEnvironment(TRACE_ANALYTICS_ENABLED, DEFAULT_TRACE_ANALYTICS_ENABLED);
+        getBooleanSettingFromEnvironment(TRACE_ANALYTICS_ENABLED, DEFAULT_TRACE_ANALYTICS_ENABLED);
 
     traceSamplingServiceRules = getMapSettingFromEnvironment(TRACE_SAMPLING_SERVICE_RULES, null);
     traceSamplingOperationRules =
-      getMapSettingFromEnvironment(TRACE_SAMPLING_OPERATION_RULES, null);
+        getMapSettingFromEnvironment(TRACE_SAMPLING_OPERATION_RULES, null);
     traceSampleRate = getDoubleSettingFromEnvironment(TRACE_SAMPLE_RATE, null);
     traceRateLimit = getDoubleSettingFromEnvironment(TRACE_RATE_LIMIT, DEFAULT_TRACE_RATE_LIMIT);
 
     profilingEnabled =
-      getBooleanSettingFromEnvironment(PROFILING_ENABLED, DEFAULT_PROFILING_ENABLED);
+        getBooleanSettingFromEnvironment(PROFILING_ENABLED, DEFAULT_PROFILING_ENABLED);
     profilingUrl = getSettingFromEnvironment(PROFILING_URL, null);
 
     if (tmpApiKey == null) {
       final String oldProfilingApiKeyFile =
-        getSettingFromEnvironment(PROFILING_API_KEY_FILE_OLD, null);
+          getSettingFromEnvironment(PROFILING_API_KEY_FILE_OLD, null);
       tmpApiKey = System.getenv(propertyNameToEnvironmentVariableName(PROFILING_API_KEY_OLD));
       if (oldProfilingApiKeyFile != null) {
         try {
           tmpApiKey =
-            new String(
-              Files.readAllBytes(Paths.get(oldProfilingApiKeyFile)), StandardCharsets.UTF_8)
-              .trim();
+              new String(
+                      Files.readAllBytes(Paths.get(oldProfilingApiKeyFile)), StandardCharsets.UTF_8)
+                  .trim();
         } catch (final IOException e) {
           log.error("Cannot read API key from file {}, skipping", oldProfilingApiKeyFile, e);
         }
@@ -608,15 +529,15 @@ public class Config {
     }
     if (tmpApiKey == null) {
       final String veryOldProfilingApiKeyFile =
-        getSettingFromEnvironment(PROFILING_API_KEY_FILE_VERY_OLD, null);
+          getSettingFromEnvironment(PROFILING_API_KEY_FILE_VERY_OLD, null);
       tmpApiKey = System.getenv(propertyNameToEnvironmentVariableName(PROFILING_API_KEY_VERY_OLD));
       if (veryOldProfilingApiKeyFile != null) {
         try {
           tmpApiKey =
-            new String(
-              Files.readAllBytes(Paths.get(veryOldProfilingApiKeyFile)),
-              StandardCharsets.UTF_8)
-              .trim();
+              new String(
+                      Files.readAllBytes(Paths.get(veryOldProfilingApiKeyFile)),
+                      StandardCharsets.UTF_8)
+                  .trim();
         } catch (final IOException e) {
           log.error("Cannot read API key from file {}, skipping", veryOldProfilingApiKeyFile, e);
         }
@@ -625,44 +546,44 @@ public class Config {
 
     profilingTags = getMapSettingFromEnvironment(PROFILING_TAGS, null);
     profilingStartDelay =
-      getIntegerSettingFromEnvironment(PROFILING_START_DELAY, DEFAULT_PROFILING_START_DELAY);
+        getIntegerSettingFromEnvironment(PROFILING_START_DELAY, DEFAULT_PROFILING_START_DELAY);
     profilingStartForceFirst =
-      getBooleanSettingFromEnvironment(
-        PROFILING_START_FORCE_FIRST, DEFAULT_PROFILING_START_FORCE_FIRST);
+        getBooleanSettingFromEnvironment(
+            PROFILING_START_FORCE_FIRST, DEFAULT_PROFILING_START_FORCE_FIRST);
     profilingUploadPeriod =
-      getIntegerSettingFromEnvironment(PROFILING_UPLOAD_PERIOD, DEFAULT_PROFILING_UPLOAD_PERIOD);
+        getIntegerSettingFromEnvironment(PROFILING_UPLOAD_PERIOD, DEFAULT_PROFILING_UPLOAD_PERIOD);
     profilingTemplateOverrideFile =
-      getSettingFromEnvironment(PROFILING_TEMPLATE_OVERRIDE_FILE, null);
+        getSettingFromEnvironment(PROFILING_TEMPLATE_OVERRIDE_FILE, null);
     profilingUploadTimeout =
-      getIntegerSettingFromEnvironment(
-        PROFILING_UPLOAD_TIMEOUT, DEFAULT_PROFILING_UPLOAD_TIMEOUT);
+        getIntegerSettingFromEnvironment(
+            PROFILING_UPLOAD_TIMEOUT, DEFAULT_PROFILING_UPLOAD_TIMEOUT);
     profilingUploadCompression =
-      getSettingFromEnvironment(
-        PROFILING_UPLOAD_COMPRESSION, DEFAULT_PROFILING_UPLOAD_COMPRESSION);
+        getSettingFromEnvironment(
+            PROFILING_UPLOAD_COMPRESSION, DEFAULT_PROFILING_UPLOAD_COMPRESSION);
     profilingProxyHost = getSettingFromEnvironment(PROFILING_PROXY_HOST, null);
     profilingProxyPort =
-      getIntegerSettingFromEnvironment(PROFILING_PROXY_PORT, DEFAULT_PROFILING_PROXY_PORT);
+        getIntegerSettingFromEnvironment(PROFILING_PROXY_PORT, DEFAULT_PROFILING_PROXY_PORT);
     profilingProxyUsername = getSettingFromEnvironment(PROFILING_PROXY_USERNAME, null);
     profilingProxyPassword = getSettingFromEnvironment(PROFILING_PROXY_PASSWORD, null);
 
     profilingExceptionSampleLimit =
-      getIntegerSettingFromEnvironment(
-        PROFILING_EXCEPTION_SAMPLE_LIMIT, DEFAULT_PROFILING_EXCEPTION_SAMPLE_LIMIT);
+        getIntegerSettingFromEnvironment(
+            PROFILING_EXCEPTION_SAMPLE_LIMIT, DEFAULT_PROFILING_EXCEPTION_SAMPLE_LIMIT);
     profilingExceptionHistogramTopItems =
-      getIntegerSettingFromEnvironment(
-        PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS,
-        DEFAULT_PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS);
+        getIntegerSettingFromEnvironment(
+            PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS,
+            DEFAULT_PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS);
     profilingExceptionHistogramMaxCollectionSize =
-      getIntegerSettingFromEnvironment(
-        PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE,
-        DEFAULT_PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE);
+        getIntegerSettingFromEnvironment(
+            PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE,
+            DEFAULT_PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE);
 
     kafkaClientPropagationEnabled =
-      getBooleanSettingFromEnvironment(
-        KAFKA_CLIENT_PROPAGATION_ENABLED, DEFAULT_KAFKA_CLIENT_PROPAGATION_ENABLED);
+        getBooleanSettingFromEnvironment(
+            KAFKA_CLIENT_PROPAGATION_ENABLED, DEFAULT_KAFKA_CLIENT_PROPAGATION_ENABLED);
 
     kafkaClientBase64DecodingEnabled =
-      getBooleanSettingFromEnvironment(KAFKA_CLIENT_BASE64_DECODING_ENABLED, false);
+        getBooleanSettingFromEnvironment(KAFKA_CLIENT_BASE64_DECODING_ENABLED, false);
 
     debugEnabled = isDebugMode();
 
@@ -681,204 +602,202 @@ public class Config {
     apiKey = properties.getProperty(API_KEY, parent.apiKey);
     site = properties.getProperty(SITE, parent.site);
     serviceName =
-      properties.getProperty(SERVICE, properties.getProperty(SERVICE_NAME, parent.serviceName));
+        properties.getProperty(SERVICE, properties.getProperty(SERVICE_NAME, parent.serviceName));
 
     traceEnabled = getPropertyBooleanValue(properties, TRACE_ENABLED, parent.traceEnabled);
     integrationsEnabled =
-      getPropertyBooleanValue(properties, INTEGRATIONS_ENABLED, parent.integrationsEnabled);
+        getPropertyBooleanValue(properties, INTEGRATIONS_ENABLED, parent.integrationsEnabled);
     writerType = properties.getProperty(WRITER_TYPE, parent.writerType);
     agentHost = properties.getProperty(AGENT_HOST, parent.agentHost);
     agentPort =
-      getPropertyIntegerValue(
-        properties,
-        TRACE_AGENT_PORT,
-        getPropertyIntegerValue(properties, AGENT_PORT_LEGACY, parent.agentPort));
+        getPropertyIntegerValue(
+            properties,
+            TRACE_AGENT_PORT,
+            getPropertyIntegerValue(properties, AGENT_PORT_LEGACY, parent.agentPort));
     agentUnixDomainSocket =
-      properties.getProperty(AGENT_UNIX_DOMAIN_SOCKET, parent.agentUnixDomainSocket);
+        properties.getProperty(AGENT_UNIX_DOMAIN_SOCKET, parent.agentUnixDomainSocket);
     agentTimeout = getPropertyIntegerValue(properties, AGENT_TIMEOUT, parent.agentTimeout);
     prioritySamplingEnabled =
-      getPropertyBooleanValue(properties, PRIORITY_SAMPLING, parent.prioritySamplingEnabled);
+        getPropertyBooleanValue(properties, PRIORITY_SAMPLING, parent.prioritySamplingEnabled);
     traceResolverEnabled =
-      getPropertyBooleanValue(properties, TRACE_RESOLVER_ENABLED, parent.traceResolverEnabled);
+        getPropertyBooleanValue(properties, TRACE_RESOLVER_ENABLED, parent.traceResolverEnabled);
     serviceMapping = getPropertyMapValue(properties, SERVICE_MAPPING, parent.serviceMapping);
 
     {
       final Map<String, String> preTags =
-        new HashMap<>(
-          getPropertyMapValue(properties, GLOBAL_TAGS, Collections.<String, String>emptyMap()));
+          new HashMap<>(
+              getPropertyMapValue(properties, GLOBAL_TAGS, Collections.<String, String>emptyMap()));
       preTags.putAll(getPropertyMapValue(properties, TAGS, parent.tags));
       tags = overwriteKeysFromProperties(preTags, properties, ENV, VERSION);
     }
     spanTags = getPropertyMapValue(properties, SPAN_TAGS, parent.spanTags);
     jmxTags = getPropertyMapValue(properties, JMX_TAGS, parent.jmxTags);
     excludedClasses =
-      getPropertyListValue(properties, TRACE_CLASSES_EXCLUDE, parent.excludedClasses);
+        getPropertyListValue(properties, TRACE_CLASSES_EXCLUDE, parent.excludedClasses);
     headerTags = getPropertyMapValue(properties, HEADER_TAGS, parent.headerTags);
 
     httpServerErrorStatuses =
-      getPropertyIntegerRangeValue(
-        properties, HTTP_SERVER_ERROR_STATUSES, parent.httpServerErrorStatuses);
+        getPropertyIntegerRangeValue(
+            properties, HTTP_SERVER_ERROR_STATUSES, parent.httpServerErrorStatuses);
 
     httpClientErrorStatuses =
-      getPropertyIntegerRangeValue(
-        properties, HTTP_CLIENT_ERROR_STATUSES, parent.httpClientErrorStatuses);
+        getPropertyIntegerRangeValue(
+            properties, HTTP_CLIENT_ERROR_STATUSES, parent.httpClientErrorStatuses);
 
     httpServerTagQueryString =
-      getPropertyBooleanValue(
-        properties, HTTP_SERVER_TAG_QUERY_STRING, parent.httpServerTagQueryString);
+        getPropertyBooleanValue(
+            properties, HTTP_SERVER_TAG_QUERY_STRING, parent.httpServerTagQueryString);
 
     httpClientTagQueryString =
-      getPropertyBooleanValue(
-        properties, HTTP_CLIENT_TAG_QUERY_STRING, parent.httpClientTagQueryString);
+        getPropertyBooleanValue(
+            properties, HTTP_CLIENT_TAG_QUERY_STRING, parent.httpClientTagQueryString);
 
     httpClientSplitByDomain =
-      getPropertyBooleanValue(
-        properties, HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN, parent.httpClientSplitByDomain);
+        getPropertyBooleanValue(
+            properties, HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN, parent.httpClientSplitByDomain);
 
     dbClientSplitByInstance =
-      getPropertyBooleanValue(
-        properties, DB_CLIENT_HOST_SPLIT_BY_INSTANCE, parent.dbClientSplitByInstance);
+        getPropertyBooleanValue(
+            properties, DB_CLIENT_HOST_SPLIT_BY_INSTANCE, parent.dbClientSplitByInstance);
 
     splitByTags =
-      Collections.unmodifiableSet(
-        new LinkedHashSet<>(
-          getPropertyListValue(
-            properties, SPLIT_BY_TAGS, new ArrayList<>(parent.splitByTags))));
+        Collections.unmodifiableSet(
+            new LinkedHashSet<>(
+                getPropertyListValue(
+                    properties, SPLIT_BY_TAGS, new ArrayList<>(parent.splitByTags))));
 
     scopeDepthLimit =
-      getPropertyIntegerValue(properties, SCOPE_DEPTH_LIMIT, parent.scopeDepthLimit);
+        getPropertyIntegerValue(properties, SCOPE_DEPTH_LIMIT, parent.scopeDepthLimit);
 
     scopeStrictMode =
-      getPropertyBooleanValue(properties, SCOPE_STRICT_MODE, parent.scopeStrictMode);
+        getPropertyBooleanValue(properties, SCOPE_STRICT_MODE, parent.scopeStrictMode);
 
     partialFlushMinSpans =
-      getPropertyIntegerValue(properties, PARTIAL_FLUSH_MIN_SPANS, parent.partialFlushMinSpans);
+        getPropertyIntegerValue(properties, PARTIAL_FLUSH_MIN_SPANS, parent.partialFlushMinSpans);
 
     runtimeContextFieldInjection =
-      getPropertyBooleanValue(
-        properties, RUNTIME_CONTEXT_FIELD_INJECTION, parent.runtimeContextFieldInjection);
+        getPropertyBooleanValue(
+            properties, RUNTIME_CONTEXT_FIELD_INJECTION, parent.runtimeContextFieldInjection);
 
     final Set<PropagationStyle> parsedPropagationStylesToExtract =
-      getPropagationStyleSetFromPropertyValue(properties, PROPAGATION_STYLE_EXTRACT);
+        getPropagationStyleSetFromPropertyValue(properties, PROPAGATION_STYLE_EXTRACT);
     propagationStylesToExtract =
-      parsedPropagationStylesToExtract == null
-        ? parent.propagationStylesToExtract
-        : parsedPropagationStylesToExtract;
+        parsedPropagationStylesToExtract == null
+            ? parent.propagationStylesToExtract
+            : parsedPropagationStylesToExtract;
     final Set<PropagationStyle> parsedPropagationStylesToInject =
-      getPropagationStyleSetFromPropertyValue(properties, PROPAGATION_STYLE_INJECT);
+        getPropagationStyleSetFromPropertyValue(properties, PROPAGATION_STYLE_INJECT);
     propagationStylesToInject =
-      parsedPropagationStylesToInject == null
-        ? parent.propagationStylesToInject
-        : parsedPropagationStylesToInject;
+        parsedPropagationStylesToInject == null
+            ? parent.propagationStylesToInject
+            : parsedPropagationStylesToInject;
 
     jmxFetchEnabled =
-      getPropertyBooleanValue(properties, JMX_FETCH_ENABLED, parent.jmxFetchEnabled);
+        getPropertyBooleanValue(properties, JMX_FETCH_ENABLED, parent.jmxFetchEnabled);
     jmxFetchConfigDir = properties.getProperty(JMX_FETCH_CONFIG_DIR, parent.jmxFetchConfigDir);
     jmxFetchConfigs = getPropertyListValue(properties, JMX_FETCH_CONFIG, parent.jmxFetchConfigs);
     jmxFetchMetricsConfigs =
-      getPropertyListValue(properties, JMX_FETCH_METRICS_CONFIGS, parent.jmxFetchMetricsConfigs);
+        getPropertyListValue(properties, JMX_FETCH_METRICS_CONFIGS, parent.jmxFetchMetricsConfigs);
     jmxFetchCheckPeriod =
-      getPropertyIntegerValue(properties, JMX_FETCH_CHECK_PERIOD, parent.jmxFetchCheckPeriod);
+        getPropertyIntegerValue(properties, JMX_FETCH_CHECK_PERIOD, parent.jmxFetchCheckPeriod);
     jmxFetchRefreshBeansPeriod =
-      getPropertyIntegerValue(
-        properties, JMX_FETCH_REFRESH_BEANS_PERIOD, parent.jmxFetchRefreshBeansPeriod);
+        getPropertyIntegerValue(
+            properties, JMX_FETCH_REFRESH_BEANS_PERIOD, parent.jmxFetchRefreshBeansPeriod);
     jmxFetchStatsdHost = properties.getProperty(JMX_FETCH_STATSD_HOST, parent.jmxFetchStatsdHost);
     jmxFetchStatsdPort =
-      getPropertyIntegerValue(properties, JMX_FETCH_STATSD_PORT, parent.jmxFetchStatsdPort);
+        getPropertyIntegerValue(properties, JMX_FETCH_STATSD_PORT, parent.jmxFetchStatsdPort);
 
     healthMetricsEnabled =
-      getPropertyBooleanValue(properties, HEALTH_METRICS_ENABLED, DEFAULT_METRICS_ENABLED);
+        getPropertyBooleanValue(properties, HEALTH_METRICS_ENABLED, DEFAULT_METRICS_ENABLED);
     healthMetricsStatsdHost =
-      properties.getProperty(HEALTH_METRICS_STATSD_HOST, parent.healthMetricsStatsdHost);
+        properties.getProperty(HEALTH_METRICS_STATSD_HOST, parent.healthMetricsStatsdHost);
     healthMetricsStatsdPort =
-      getPropertyIntegerValue(
-        properties, HEALTH_METRICS_STATSD_PORT, parent.healthMetricsStatsdPort);
+        getPropertyIntegerValue(
+            properties, HEALTH_METRICS_STATSD_PORT, parent.healthMetricsStatsdPort);
 
     logsInjectionEnabled =
-      getBooleanSettingFromEnvironment(LOGS_INJECTION_ENABLED, DEFAULT_LOGS_INJECTION_ENABLED);
+        getBooleanSettingFromEnvironment(LOGS_INJECTION_ENABLED, DEFAULT_LOGS_INJECTION_ENABLED);
     reportHostName =
-      getPropertyBooleanValue(properties, TRACE_REPORT_HOSTNAME, parent.reportHostName);
+        getPropertyBooleanValue(properties, TRACE_REPORT_HOSTNAME, parent.reportHostName);
 
     traceAnnotations = properties.getProperty(TRACE_ANNOTATIONS, parent.traceAnnotations);
 
     traceMethods = properties.getProperty(TRACE_METHODS, parent.traceMethods);
 
     traceExecutorsAll =
-      getPropertyBooleanValue(properties, TRACE_EXECUTORS_ALL, parent.traceExecutorsAll);
+        getPropertyBooleanValue(properties, TRACE_EXECUTORS_ALL, parent.traceExecutorsAll);
     traceExecutors = getPropertyListValue(properties, TRACE_EXECUTORS, parent.traceExecutors);
 
     traceAnalyticsEnabled =
-      getPropertyBooleanValue(properties, TRACE_ANALYTICS_ENABLED, parent.traceAnalyticsEnabled);
+        getPropertyBooleanValue(properties, TRACE_ANALYTICS_ENABLED, parent.traceAnalyticsEnabled);
 
     traceSamplingServiceRules =
-      getPropertyMapValue(
-        properties, TRACE_SAMPLING_SERVICE_RULES, parent.traceSamplingServiceRules);
+        getPropertyMapValue(
+            properties, TRACE_SAMPLING_SERVICE_RULES, parent.traceSamplingServiceRules);
     traceSamplingOperationRules =
-      getPropertyMapValue(
-        properties, TRACE_SAMPLING_OPERATION_RULES, parent.traceSamplingOperationRules);
+        getPropertyMapValue(
+            properties, TRACE_SAMPLING_OPERATION_RULES, parent.traceSamplingOperationRules);
     traceSampleRate = getPropertyDoubleValue(properties, TRACE_SAMPLE_RATE, parent.traceSampleRate);
     traceRateLimit = getPropertyDoubleValue(properties, TRACE_RATE_LIMIT, parent.traceRateLimit);
 
     profilingEnabled =
-      getPropertyBooleanValue(properties, PROFILING_ENABLED, parent.profilingEnabled);
+        getPropertyBooleanValue(properties, PROFILING_ENABLED, parent.profilingEnabled);
     profilingUrl = properties.getProperty(PROFILING_URL, parent.profilingUrl);
     profilingTags = getPropertyMapValue(properties, PROFILING_TAGS, parent.profilingTags);
     profilingStartDelay =
-      getPropertyIntegerValue(properties, PROFILING_START_DELAY, parent.profilingStartDelay);
+        getPropertyIntegerValue(properties, PROFILING_START_DELAY, parent.profilingStartDelay);
     profilingStartForceFirst =
-      getPropertyBooleanValue(
-        properties, PROFILING_START_FORCE_FIRST, parent.profilingStartForceFirst);
+        getPropertyBooleanValue(
+            properties, PROFILING_START_FORCE_FIRST, parent.profilingStartForceFirst);
     profilingUploadPeriod =
-      getPropertyIntegerValue(properties, PROFILING_UPLOAD_PERIOD, parent.profilingUploadPeriod);
+        getPropertyIntegerValue(properties, PROFILING_UPLOAD_PERIOD, parent.profilingUploadPeriod);
     profilingTemplateOverrideFile =
-      properties.getProperty(
-        PROFILING_TEMPLATE_OVERRIDE_FILE, parent.profilingTemplateOverrideFile);
+        properties.getProperty(
+            PROFILING_TEMPLATE_OVERRIDE_FILE, parent.profilingTemplateOverrideFile);
     profilingUploadTimeout =
-      getPropertyIntegerValue(
-        properties, PROFILING_UPLOAD_TIMEOUT, parent.profilingUploadTimeout);
+        getPropertyIntegerValue(
+            properties, PROFILING_UPLOAD_TIMEOUT, parent.profilingUploadTimeout);
     profilingUploadCompression =
-      properties.getProperty(PROFILING_UPLOAD_COMPRESSION, parent.profilingUploadCompression);
+        properties.getProperty(PROFILING_UPLOAD_COMPRESSION, parent.profilingUploadCompression);
     profilingProxyHost = properties.getProperty(PROFILING_PROXY_HOST, parent.profilingProxyHost);
     profilingProxyPort =
-      getPropertyIntegerValue(properties, PROFILING_PROXY_PORT, parent.profilingProxyPort);
+        getPropertyIntegerValue(properties, PROFILING_PROXY_PORT, parent.profilingProxyPort);
     profilingProxyUsername =
-      properties.getProperty(PROFILING_PROXY_USERNAME, parent.profilingProxyUsername);
+        properties.getProperty(PROFILING_PROXY_USERNAME, parent.profilingProxyUsername);
     profilingProxyPassword =
-      properties.getProperty(PROFILING_PROXY_PASSWORD, parent.profilingProxyPassword);
+        properties.getProperty(PROFILING_PROXY_PASSWORD, parent.profilingProxyPassword);
 
     profilingExceptionSampleLimit =
-      getPropertyIntegerValue(
-        properties, PROFILING_EXCEPTION_SAMPLE_LIMIT, parent.profilingExceptionSampleLimit);
+        getPropertyIntegerValue(
+            properties, PROFILING_EXCEPTION_SAMPLE_LIMIT, parent.profilingExceptionSampleLimit);
 
     profilingExceptionHistogramTopItems =
-      getPropertyIntegerValue(
-        properties,
-        PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS,
-        parent.profilingExceptionHistogramTopItems);
+        getPropertyIntegerValue(
+            properties,
+            PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS,
+            parent.profilingExceptionHistogramTopItems);
     profilingExceptionHistogramMaxCollectionSize =
-      getPropertyIntegerValue(
-        properties,
-        PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE,
-        parent.profilingExceptionHistogramMaxCollectionSize);
+        getPropertyIntegerValue(
+            properties,
+            PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE,
+            parent.profilingExceptionHistogramMaxCollectionSize);
 
     kafkaClientPropagationEnabled =
-      getPropertyBooleanValue(
-        properties, KAFKA_CLIENT_PROPAGATION_ENABLED, parent.kafkaClientPropagationEnabled);
+        getPropertyBooleanValue(
+            properties, KAFKA_CLIENT_PROPAGATION_ENABLED, parent.kafkaClientPropagationEnabled);
 
     debugEnabled = parent.debugEnabled || isDebugMode();
 
     kafkaClientBase64DecodingEnabled =
-      getPropertyBooleanValue(
-        properties,
-        KAFKA_CLIENT_BASE64_DECODING_ENABLED,
-        parent.kafkaClientBase64DecodingEnabled);
+        getPropertyBooleanValue(
+            properties,
+            KAFKA_CLIENT_BASE64_DECODING_ENABLED,
+            parent.kafkaClientBase64DecodingEnabled);
 
     log.debug("New instance: {}", this);
   }
 
-  /**
-   * @return A map of tags to be applied only to the local application root span.
-   */
+  /** @return A map of tags to be applied only to the local application root span. */
   public Map<String, String> getLocalRootSpanTags() {
     final Map<String, String> runtimeTags = getRuntimeTags();
     final Map<String, String> result = new HashMap<>(runtimeTags);
@@ -905,8 +824,8 @@ public class Config {
   public Map<String, String> getMergedJmxTags() {
     final Map<String, String> runtimeTags = getRuntimeTags();
     final Map<String, String> result =
-      newHashMap(
-        getGlobalTags().size() + jmxTags.size() + runtimeTags.size() + 1 /* for serviceName */);
+        newHashMap(
+            getGlobalTags().size() + jmxTags.size() + runtimeTags.size() + 1 /* for serviceName */);
     result.putAll(getGlobalTags());
     result.putAll(jmxTags);
     result.putAll(runtimeTags);
@@ -921,11 +840,11 @@ public class Config {
     final Map<String, String> runtimeTags = getRuntimeTags();
     final String host = getHostName();
     final Map<String, String> result =
-      newHashMap(
-        getGlobalTags().size()
-          + profilingTags.size()
-          + runtimeTags.size()
-          + 3 /* for serviceName and host and language */);
+        newHashMap(
+            getGlobalTags().size()
+                + profilingTags.size()
+                + runtimeTags.size()
+                + 3 /* for serviceName and host and language */);
     result.put(HOST_TAG, host); // Host goes first to allow to override it
     result.putAll(getGlobalTags());
     result.putAll(profilingTags);
@@ -988,7 +907,7 @@ public class Config {
   }
 
   public boolean isIntegrationEnabled(
-    final SortedSet<String> integrationNames, final boolean defaultEnabled) {
+      final SortedSet<String> integrationNames, final boolean defaultEnabled) {
     return integrationEnabled(integrationNames, defaultEnabled);
   }
 
@@ -997,17 +916,17 @@ public class Config {
    * @param defaultEnabled
    * @return
    * @deprecated This method should only be used internally. Use the instance getter instead {@link
-   * #isIntegrationEnabled(SortedSet, boolean)}.
+   *     #isIntegrationEnabled(SortedSet, boolean)}.
    */
   @Deprecated
   private static boolean integrationEnabled(
-    final SortedSet<String> integrationNames, final boolean defaultEnabled) {
+      final SortedSet<String> integrationNames, final boolean defaultEnabled) {
     // If default is enabled, we want to enable individually,
     // if default is disabled, we want to disable individually.
     boolean anyEnabled = defaultEnabled;
     for (final String name : integrationNames) {
       final boolean configEnabled =
-        getBooleanSettingFromEnvironment("integration." + name + ".enabled", defaultEnabled);
+          getBooleanSettingFromEnvironment("integration." + name + ".enabled", defaultEnabled);
       if (defaultEnabled) {
         anyEnabled &= configEnabled;
       } else {
@@ -1018,13 +937,13 @@ public class Config {
   }
 
   public boolean isJmxFetchIntegrationEnabled(
-    final SortedSet<String> integrationNames, final boolean defaultEnabled) {
+      final SortedSet<String> integrationNames, final boolean defaultEnabled) {
     return jmxFetchIntegrationEnabled(integrationNames, defaultEnabled);
   }
 
   public boolean isRuleEnabled(final String name) {
     return getBooleanSettingFromEnvironment("trace." + name + ".enabled", true)
-      && getBooleanSettingFromEnvironment("trace." + name.toLowerCase() + ".enabled", true);
+        && getBooleanSettingFromEnvironment("trace." + name.toLowerCase() + ".enabled", true);
   }
 
   /**
@@ -1032,16 +951,16 @@ public class Config {
    * @param defaultEnabled
    * @return
    * @deprecated This method should only be used internally. Use the instance getter instead {@link
-   * #isJmxFetchIntegrationEnabled(SortedSet, boolean)}.
+   *     #isJmxFetchIntegrationEnabled(SortedSet, boolean)}.
    */
   public static boolean jmxFetchIntegrationEnabled(
-    final SortedSet<String> integrationNames, final boolean defaultEnabled) {
+      final SortedSet<String> integrationNames, final boolean defaultEnabled) {
     // If default is enabled, we want to enable individually,
     // if default is disabled, we want to disable individually.
     boolean anyEnabled = defaultEnabled;
     for (final String name : integrationNames) {
       final boolean configEnabled =
-        getBooleanSettingFromEnvironment("jmxfetch." + name + ".enabled", defaultEnabled);
+          getBooleanSettingFromEnvironment("jmxfetch." + name + ".enabled", defaultEnabled);
       if (defaultEnabled) {
         anyEnabled &= configEnabled;
       } else {
@@ -1052,17 +971,17 @@ public class Config {
   }
 
   public boolean isEndToEndDurationEnabled(
-    final boolean defaultEnabled, final String... integrationNames) {
+      final boolean defaultEnabled, final String... integrationNames) {
     return isEnabled(integrationNames, ".e2e.duration.enabled", defaultEnabled);
   }
 
   public boolean isTraceAnalyticsIntegrationEnabled(
-    final SortedSet<String> integrationNames, final boolean defaultEnabled) {
+      final SortedSet<String> integrationNames, final boolean defaultEnabled) {
     return traceAnalyticsIntegrationEnabled(integrationNames, defaultEnabled);
   }
 
   public boolean isTraceAnalyticsIntegrationEnabled(
-    final boolean defaultEnabled, final String... integrationNames) {
+      final boolean defaultEnabled, final String... integrationNames) {
     return isEnabled(integrationNames, ".analytics.enabled", defaultEnabled);
   }
 
@@ -1075,7 +994,7 @@ public class Config {
     }
 
     final String tracerDebugLevelEnv =
-      System.getenv(tracerDebugLevelSysprop.replace('.', '_').toUpperCase());
+        System.getenv(tracerDebugLevelSysprop.replace('.', '_').toUpperCase());
 
     if (tracerDebugLevelEnv != null) {
       return Boolean.parseBoolean(tracerDebugLevelEnv);
@@ -1088,16 +1007,16 @@ public class Config {
    * @param defaultEnabled
    * @return
    * @deprecated This method should only be used internally. Use the instance getter instead {@link
-   * #isTraceAnalyticsIntegrationEnabled(SortedSet, boolean)}.
+   *     #isTraceAnalyticsIntegrationEnabled(SortedSet, boolean)}.
    */
   public static boolean traceAnalyticsIntegrationEnabled(
-    final SortedSet<String> integrationNames, final boolean defaultEnabled) {
+      final SortedSet<String> integrationNames, final boolean defaultEnabled) {
     // If default is enabled, we want to enable individually,
     // if default is disabled, we want to disable individually.
     boolean anyEnabled = defaultEnabled;
     for (final String name : integrationNames) {
       final boolean configEnabled =
-        getBooleanSettingFromEnvironment(name + ".analytics.enabled", defaultEnabled);
+          getBooleanSettingFromEnvironment(name + ".analytics.enabled", defaultEnabled);
       if (defaultEnabled) {
         anyEnabled &= configEnabled;
       } else {
@@ -1108,13 +1027,13 @@ public class Config {
   }
 
   private static boolean isEnabled(
-    final String[] integrationNames, final String settingSuffix, final boolean defaultEnabled) {
+      final String[] integrationNames, final String settingSuffix, final boolean defaultEnabled) {
     // If default is enabled, we want to enable individually,
     // if default is disabled, we want to disable individually.
     boolean anyEnabled = defaultEnabled;
     for (final String name : integrationNames) {
       final boolean configEnabled =
-        getBooleanSettingFromEnvironment(name + settingSuffix, defaultEnabled);
+          getBooleanSettingFromEnvironment(name + settingSuffix, defaultEnabled);
       if (defaultEnabled) {
         anyEnabled &= configEnabled;
       } else {
@@ -1167,14 +1086,12 @@ public class Config {
     return defaultValue;
   }
 
-  /**
-   * @deprecated This method should only be used internally. Use the explicit getter instead.
-   */
+  /** @deprecated This method should only be used internally. Use the explicit getter instead. */
   @NonNull
   private static Map<String, String> getMapSettingFromEnvironment(
-    final String name, final String defaultValue) {
+      final String name, final String defaultValue) {
     return parseMap(
-      getSettingFromEnvironment(name, defaultValue), propertyNameToSystemPropertyName(name));
+        getSettingFromEnvironment(name, defaultValue), propertyNameToSystemPropertyName(name));
   }
 
   /**
@@ -1185,7 +1102,7 @@ public class Config {
    */
   @NonNull
   private static List<String> getListSettingFromEnvironment(
-    final String name, final String defaultValue) {
+      final String name, final String defaultValue) {
     return parseList(getSettingFromEnvironment(name, defaultValue));
   }
 
@@ -1195,7 +1112,7 @@ public class Config {
    * @deprecated This method should only be used internally. Use the explicit getter instead.
    */
   public static Boolean getBooleanSettingFromEnvironment(
-    final String name, final Boolean defaultValue) {
+      final String name, final Boolean defaultValue) {
     return getSettingFromEnvironmentWithLog(name, Boolean.class, defaultValue);
   }
 
@@ -1215,7 +1132,7 @@ public class Config {
    */
   @Deprecated
   private static Double getDoubleSettingFromEnvironment(
-    final String name, final Double defaultValue) {
+      final String name, final Double defaultValue) {
     return getSettingFromEnvironmentWithLog(name, Double.class, defaultValue);
   }
 
@@ -1223,12 +1140,12 @@ public class Config {
    * Calls {@link #getSettingFromEnvironment(String, String)} and converts the result to a Integer.
    */
   private static Integer getIntegerSettingFromEnvironment(
-    final String name, final Integer defaultValue) {
+      final String name, final Integer defaultValue) {
     return getSettingFromEnvironmentWithLog(name, Integer.class, defaultValue);
   }
 
   private static <T> T getSettingFromEnvironmentWithLog(
-    final String name, final Class<T> tClass, final T defaultValue) {
+      final String name, final Class<T> tClass, final T defaultValue) {
     try {
       return valueOf(getSettingFromEnvironment(name, null), tClass, defaultValue);
     } catch (final NumberFormatException e) {
@@ -1242,22 +1159,22 @@ public class Config {
    * strings splitting by space or comma.
    */
   private static Set<PropagationStyle> getPropagationStyleSetSettingFromEnvironmentOrDefault(
-    final String name, final String defaultValue) {
+      final String name, final String defaultValue) {
     final String value = getSettingFromEnvironment(name, defaultValue);
     Set<PropagationStyle> result =
-      convertStringSetToPropagationStyleSet(parseStringIntoSetOfNonEmptyStrings(value));
+        convertStringSetToPropagationStyleSet(parseStringIntoSetOfNonEmptyStrings(value));
 
     if (result.isEmpty()) {
       // Treat empty parsing result as no value and use default instead
       result =
-        convertStringSetToPropagationStyleSet(parseStringIntoSetOfNonEmptyStrings(defaultValue));
+          convertStringSetToPropagationStyleSet(parseStringIntoSetOfNonEmptyStrings(defaultValue));
     }
 
     return result;
   }
 
   private static BitSet getIntegerRangeSettingFromEnvironment(
-    final String name, final BitSet defaultValue) {
+      final String name, final BitSet defaultValue) {
     final String value = getSettingFromEnvironment(name, null);
     try {
       return value == null ? defaultValue : parseIntegerRangeSet(value, name);
@@ -1277,8 +1194,8 @@ public class Config {
   @NonNull
   private static String propertyNameToEnvironmentVariableName(final String setting) {
     return ENV_REPLACEMENT
-      .matcher(propertyNameToSystemPropertyName(setting).toUpperCase())
-      .replaceAll("_");
+        .matcher(propertyNameToSystemPropertyName(setting).toUpperCase())
+        .replaceAll("_");
   }
 
   /**
@@ -1294,23 +1211,23 @@ public class Config {
   }
 
   /**
-   * @param value        to parse by tClass::valueOf
-   * @param tClass       should contain static parsing method "T valueOf(String)"
+   * @param value to parse by tClass::valueOf
+   * @param tClass should contain static parsing method "T valueOf(String)"
    * @param defaultValue
    * @param <T>
    * @return value == null || value.trim().isEmpty() ? defaultValue : tClass.valueOf(value)
    * @throws NumberFormatException
    */
   private static <T> T valueOf(
-    final String value, @NonNull final Class<T> tClass, final T defaultValue) {
+      final String value, @NonNull final Class<T> tClass, final T defaultValue) {
     if (value == null || value.trim().isEmpty()) {
       return defaultValue;
     }
     try {
       return (T)
-        PUBLIC_LOOKUP
-          .findStatic(tClass, "valueOf", MethodType.methodType(tClass, String.class))
-          .invoke(value);
+          PUBLIC_LOOKUP
+              .findStatic(tClass, "valueOf", MethodType.methodType(tClass, String.class))
+              .invoke(value);
     } catch (final NumberFormatException e) {
       throw e;
     } catch (final NoSuchMethodException | IllegalAccessException e) {
@@ -1323,38 +1240,38 @@ public class Config {
   }
 
   private static Map<String, String> getPropertyMapValue(
-    final Properties properties, final String name, final Map<String, String> defaultValue) {
+      final Properties properties, final String name, final Map<String, String> defaultValue) {
     final String value = properties.getProperty(name);
     return value == null || value.trim().isEmpty() ? defaultValue : parseMap(value, name);
   }
 
   private static List<String> getPropertyListValue(
-    final Properties properties, final String name, final List<String> defaultValue) {
+      final Properties properties, final String name, final List<String> defaultValue) {
     final String value = properties.getProperty(name);
     return value == null || value.trim().isEmpty() ? defaultValue : parseList(value);
   }
 
   private static Boolean getPropertyBooleanValue(
-    final Properties properties, final String name, final Boolean defaultValue) {
+      final Properties properties, final String name, final Boolean defaultValue) {
     return valueOf(properties.getProperty(name), Boolean.class, defaultValue);
   }
 
   private static Integer getPropertyIntegerValue(
-    final Properties properties, final String name, final Integer defaultValue) {
+      final Properties properties, final String name, final Integer defaultValue) {
     return valueOf(properties.getProperty(name), Integer.class, defaultValue);
   }
 
   private static Double getPropertyDoubleValue(
-    final Properties properties, final String name, final Double defaultValue) {
+      final Properties properties, final String name, final Double defaultValue) {
     return valueOf(properties.getProperty(name), Double.class, defaultValue);
   }
 
   private static Set<PropagationStyle> getPropagationStyleSetFromPropertyValue(
-    final Properties properties, final String name) {
+      final Properties properties, final String name) {
     final String value = properties.getProperty(name);
     if (value != null) {
       final Set<PropagationStyle> result =
-        convertStringSetToPropagationStyleSet(parseStringIntoSetOfNonEmptyStrings(value));
+          convertStringSetToPropagationStyleSet(parseStringIntoSetOfNonEmptyStrings(value));
       if (!result.isEmpty()) {
         return result;
       }
@@ -1364,7 +1281,7 @@ public class Config {
   }
 
   private static BitSet getPropertyIntegerRangeValue(
-    final Properties properties, final String name, final BitSet defaultValue) {
+      final Properties properties, final String name, final BitSet defaultValue) {
     final String value = properties.getProperty(name);
     try {
       return value == null ? defaultValue : parseIntegerRangeSet(value, name);
@@ -1382,7 +1299,7 @@ public class Config {
     }
     if (!str.matches("(([^,:]+:[^,:]*,)*([^,:]+:[^,:]*),?)?")) {
       log.warn(
-        "Invalid config for {}: '{}'. Must match 'key1:value1,key2:value2'.", settingName, str);
+          "Invalid config for {}: '{}'. Must match 'key1:value1,key2:value2'.", settingName, str);
       return Collections.emptyMap();
     }
 
@@ -1406,13 +1323,13 @@ public class Config {
 
   @NonNull
   static BitSet parseIntegerRangeSet(@NonNull String str, final String settingName)
-    throws NumberFormatException {
+      throws NumberFormatException {
     str = str.replaceAll("\\s", "");
     if (!str.matches("\\d{3}(?:-\\d{3})?(?:,\\d{3}(?:-\\d{3})?)*")) {
       log.warn(
-        "Invalid config for {}: '{}'. Must be formatted like '400-403,405,410-499'.",
-        settingName,
-        str);
+          "Invalid config for {}: '{}'. Must be formatted like '400-403,405,410-499'.",
+          settingName,
+          str);
       throw new NumberFormatException();
     }
 
@@ -1447,7 +1364,7 @@ public class Config {
    */
   @NonNull
   private static Map<String, String> getMapWithPropertiesDefinedByEnvironment(
-    @NonNull final Map<String, String> map, @NonNull final String... propNames) {
+      @NonNull final Map<String, String> map, @NonNull final String... propNames) {
     final Map<String, String> res = new HashMap<>(map);
     for (final String propName : propNames) {
       final String val = getSettingFromEnvironment(propName, null);
@@ -1469,9 +1386,9 @@ public class Config {
    */
   @NonNull
   private static Map<String, String> overwriteKeysFromProperties(
-    @NonNull final Map<String, String> map,
-    @NonNull final Properties properties,
-    @NonNull final String... keys) {
+      @NonNull final Map<String, String> map,
+      @NonNull final Properties properties,
+      @NonNull final String... keys) {
     final Map<String, String> res = new HashMap<>(map);
     for (final String propName : keys) {
       final String val = properties.getProperty(propName, null);
@@ -1512,7 +1429,7 @@ public class Config {
 
   @NonNull
   private static Set<PropagationStyle> convertStringSetToPropagationStyleSet(
-    final Set<String> input) {
+      final Set<String> input) {
     // Using LinkedHashSet to preserve original string order
     final Set<PropagationStyle> result = new LinkedHashSet<>();
     for (final String value : input) {
@@ -1529,17 +1446,17 @@ public class Config {
    * Loads the optional configuration properties file into the global {@link Properties} object.
    *
    * @return The {@link Properties} object. the returned instance might be empty of file does not
-   * exist or if it is in a wrong format.
+   *     exist or if it is in a wrong format.
    */
   private static Properties loadConfigurationFile() {
     final Properties properties = new Properties();
 
     // Reading from system property first and from env after
     String configurationFilePath =
-      System.getProperty(propertyNameToSystemPropertyName(CONFIGURATION_FILE));
+        System.getProperty(propertyNameToSystemPropertyName(CONFIGURATION_FILE));
     if (null == configurationFilePath) {
       configurationFilePath =
-        System.getenv(propertyNameToEnvironmentVariableName(CONFIGURATION_FILE));
+          System.getenv(propertyNameToEnvironmentVariableName(CONFIGURATION_FILE));
     }
     if (null == configurationFilePath) {
       return properties;
@@ -1547,7 +1464,7 @@ public class Config {
 
     // Normalizing tilde (~) paths for unix systems
     configurationFilePath =
-      configurationFilePath.replaceFirst("^~", System.getProperty("user.home"));
+        configurationFilePath.replaceFirst("^~", System.getProperty("user.home"));
 
     // Configuration properties file is optional
     final File configurationFile = new File(configurationFilePath);
@@ -1562,23 +1479,22 @@ public class Config {
       log.error("Configuration file '{}' not found.", configurationFilePath);
     } catch (final IOException ioe) {
       log.error(
-        "Configuration file '{}' cannot be accessed or correctly parsed.", configurationFilePath);
+          "Configuration file '{}' cannot be accessed or correctly parsed.", configurationFilePath);
     }
 
     return properties;
   }
 
-
   private static String findConfigurationFile() {
     String configurationFilePath =
-      System.getProperty(propertyNameToSystemPropertyName(CONFIGURATION_FILE));
+        System.getProperty(propertyNameToSystemPropertyName(CONFIGURATION_FILE));
     if (null == configurationFilePath) {
       configurationFilePath =
-        System.getenv(propertyNameToEnvironmentVariableName(CONFIGURATION_FILE));
+          System.getenv(propertyNameToEnvironmentVariableName(CONFIGURATION_FILE));
     }
     if (null != configurationFilePath) {
       configurationFilePath =
-        configurationFilePath.replaceFirst("^~", System.getProperty("user.home"));
+          configurationFilePath.replaceFirst("^~", System.getProperty("user.home"));
       final File configurationFile = new File(configurationFilePath);
       if (!configurationFile.exists()) {
         return configurationFilePath;
@@ -1598,10 +1514,8 @@ public class Config {
 
     return properties;
   }
-  
-  /**
-   * Returns the detected hostname. First tries locally, then using DNS
-   */
+
+  /** Returns the detected hostname. First tries locally, then using DNS */
   private static String getHostName() {
     String possibleHostname;
 
@@ -1619,8 +1533,8 @@ public class Config {
 
     // Try hostname command
     try (final BufferedReader reader =
-           new BufferedReader(
-             new InputStreamReader(Runtime.getRuntime().exec("hostname").getInputStream()))) {
+        new BufferedReader(
+            new InputStreamReader(Runtime.getRuntime().exec("hostname").getInputStream()))) {
       possibleHostname = reader.readLine();
     } catch (final Exception ignore) {
       // Ignore.  Hostname command is not always available

--- a/dd-trace-api/src/main/java/datadog/trace/api/Config.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/Config.java
@@ -59,6 +59,12 @@ import datadog.trace.api.config.JmxFetchConfig;
 import datadog.trace.api.config.ProfilingConfig;
 import datadog.trace.api.config.TraceInstrumentationConfig;
 import datadog.trace.api.config.TracerConfig;
+import datadog.trace.api.env.CapturedEnvironment;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -85,14 +91,11 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.UUID;
 import java.util.regex.Pattern;
-import lombok.Getter;
-import lombok.NonNull;
-import lombok.ToString;
-import lombok.extern.slf4j.Slf4j;
 
 /**
  * Config reads values with the following priority: 1) system properties, 2) environment variables,
- * 3) optional configuration file. It also includes default values to ensure a valid config.
+ * 3) optional configuration file, 4) platform dependant properties. It also includes default values
+ * to ensure a valid config.
  *
  * <p>
  *
@@ -105,7 +108,9 @@ import lombok.extern.slf4j.Slf4j;
 public class Config {
   private static final MethodHandles.Lookup PUBLIC_LOOKUP = MethodHandles.publicLookup();
 
-  /** Config keys below */
+  /**
+   * Config keys below
+   */
   private static final String PREFIX = "dd.";
 
   public static final String CONFIGURATION_FILE = GeneralConfig.CONFIGURATION_FILE;
@@ -141,11 +146,11 @@ public class Config {
   public static final String TRACE_EXECUTORS = TraceInstrumentationConfig.TRACE_EXECUTORS;
   public static final String TRACE_METHODS = TraceInstrumentationConfig.TRACE_METHODS;
   public static final String TRACE_CLASSES_EXCLUDE =
-      TraceInstrumentationConfig.TRACE_CLASSES_EXCLUDE;
+    TraceInstrumentationConfig.TRACE_CLASSES_EXCLUDE;
   public static final String TRACE_SAMPLING_SERVICE_RULES =
-      TracerConfig.TRACE_SAMPLING_SERVICE_RULES;
+    TracerConfig.TRACE_SAMPLING_SERVICE_RULES;
   public static final String TRACE_SAMPLING_OPERATION_RULES =
-      TracerConfig.TRACE_SAMPLING_OPERATION_RULES;
+    TracerConfig.TRACE_SAMPLING_OPERATION_RULES;
   public static final String TRACE_SAMPLE_RATE = TracerConfig.TRACE_SAMPLE_RATE;
   public static final String TRACE_RATE_LIMIT = TracerConfig.TRACE_RATE_LIMIT;
   public static final String TRACE_REPORT_HOSTNAME = TracerConfig.TRACE_REPORT_HOSTNAME;
@@ -153,19 +158,19 @@ public class Config {
   public static final String HTTP_SERVER_ERROR_STATUSES = TracerConfig.HTTP_SERVER_ERROR_STATUSES;
   public static final String HTTP_CLIENT_ERROR_STATUSES = TracerConfig.HTTP_CLIENT_ERROR_STATUSES;
   public static final String HTTP_SERVER_TAG_QUERY_STRING =
-      TraceInstrumentationConfig.HTTP_SERVER_TAG_QUERY_STRING;
+    TraceInstrumentationConfig.HTTP_SERVER_TAG_QUERY_STRING;
   public static final String HTTP_CLIENT_TAG_QUERY_STRING =
-      TraceInstrumentationConfig.HTTP_CLIENT_TAG_QUERY_STRING;
+    TraceInstrumentationConfig.HTTP_CLIENT_TAG_QUERY_STRING;
   public static final String HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN =
-      TraceInstrumentationConfig.HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN;
+    TraceInstrumentationConfig.HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN;
   public static final String DB_CLIENT_HOST_SPLIT_BY_INSTANCE =
-      TraceInstrumentationConfig.DB_CLIENT_HOST_SPLIT_BY_INSTANCE;
+    TraceInstrumentationConfig.DB_CLIENT_HOST_SPLIT_BY_INSTANCE;
   public static final String SPLIT_BY_TAGS = TracerConfig.SPLIT_BY_TAGS;
   public static final String SCOPE_DEPTH_LIMIT = TracerConfig.SCOPE_DEPTH_LIMIT;
   public static final String SCOPE_STRICT_MODE = TracerConfig.SCOPE_STRICT_MODE;
   public static final String PARTIAL_FLUSH_MIN_SPANS = TracerConfig.PARTIAL_FLUSH_MIN_SPANS;
   public static final String RUNTIME_CONTEXT_FIELD_INJECTION =
-      TraceInstrumentationConfig.RUNTIME_CONTEXT_FIELD_INJECTION;
+    TraceInstrumentationConfig.RUNTIME_CONTEXT_FIELD_INJECTION;
   public static final String PROPAGATION_STYLE_EXTRACT = TracerConfig.PROPAGATION_STYLE_EXTRACT;
   public static final String PROPAGATION_STYLE_INJECT = TracerConfig.PROPAGATION_STYLE_INJECT;
 
@@ -178,7 +183,7 @@ public class Config {
 
   public static final String JMX_FETCH_CHECK_PERIOD = JmxFetchConfig.JMX_FETCH_CHECK_PERIOD;
   public static final String JMX_FETCH_REFRESH_BEANS_PERIOD =
-      JmxFetchConfig.JMX_FETCH_REFRESH_BEANS_PERIOD;
+    JmxFetchConfig.JMX_FETCH_REFRESH_BEANS_PERIOD;
   public static final String JMX_FETCH_STATSD_HOST = JmxFetchConfig.JMX_FETCH_STATSD_HOST;
   public static final String JMX_FETCH_STATSD_PORT = JmxFetchConfig.JMX_FETCH_STATSD_PORT;
 
@@ -187,7 +192,7 @@ public class Config {
   public static final String HEALTH_METRICS_STATSD_PORT = GeneralConfig.HEALTH_METRICS_STATSD_PORT;
 
   public static final String LOGS_INJECTION_ENABLED =
-      TraceInstrumentationConfig.LOGS_INJECTION_ENABLED;
+    TraceInstrumentationConfig.LOGS_INJECTION_ENABLED;
 
   public static final String PROFILING_ENABLED = ProfilingConfig.PROFILING_ENABLED;
   @Deprecated // Use dd.site instead
@@ -196,41 +201,41 @@ public class Config {
   public static final String PROFILING_API_KEY_OLD = ProfilingConfig.PROFILING_API_KEY_OLD;
   @Deprecated // Use dd.api-key-file instead
   public static final String PROFILING_API_KEY_FILE_OLD =
-      ProfilingConfig.PROFILING_API_KEY_FILE_OLD;
+    ProfilingConfig.PROFILING_API_KEY_FILE_OLD;
   @Deprecated // Use dd.api-key instead
   public static final String PROFILING_API_KEY_VERY_OLD =
-      ProfilingConfig.PROFILING_API_KEY_VERY_OLD;
+    ProfilingConfig.PROFILING_API_KEY_VERY_OLD;
   @Deprecated // Use dd.api-key-file instead
   public static final String PROFILING_API_KEY_FILE_VERY_OLD =
-      ProfilingConfig.PROFILING_API_KEY_FILE_VERY_OLD;
+    ProfilingConfig.PROFILING_API_KEY_FILE_VERY_OLD;
   public static final String PROFILING_TAGS = ProfilingConfig.PROFILING_TAGS;
   public static final String PROFILING_START_DELAY = ProfilingConfig.PROFILING_START_DELAY;
   // DANGEROUS! May lead on sigsegv on JVMs before 14
   // Not intended for production use
   public static final String PROFILING_START_FORCE_FIRST =
-      ProfilingConfig.PROFILING_START_FORCE_FIRST;
+    ProfilingConfig.PROFILING_START_FORCE_FIRST;
   public static final String PROFILING_UPLOAD_PERIOD = ProfilingConfig.PROFILING_UPLOAD_PERIOD;
   public static final String PROFILING_TEMPLATE_OVERRIDE_FILE =
-      ProfilingConfig.PROFILING_TEMPLATE_OVERRIDE_FILE;
+    ProfilingConfig.PROFILING_TEMPLATE_OVERRIDE_FILE;
   public static final String PROFILING_UPLOAD_TIMEOUT = ProfilingConfig.PROFILING_UPLOAD_TIMEOUT;
   public static final String PROFILING_UPLOAD_COMPRESSION =
-      ProfilingConfig.PROFILING_UPLOAD_COMPRESSION;
+    ProfilingConfig.PROFILING_UPLOAD_COMPRESSION;
   public static final String PROFILING_PROXY_HOST = ProfilingConfig.PROFILING_PROXY_HOST;
   public static final String PROFILING_PROXY_PORT = ProfilingConfig.PROFILING_PROXY_PORT;
   public static final String PROFILING_PROXY_USERNAME = ProfilingConfig.PROFILING_PROXY_USERNAME;
   public static final String PROFILING_PROXY_PASSWORD = ProfilingConfig.PROFILING_PROXY_PASSWORD;
   public static final String PROFILING_EXCEPTION_SAMPLE_LIMIT =
-      ProfilingConfig.PROFILING_EXCEPTION_SAMPLE_LIMIT;
+    ProfilingConfig.PROFILING_EXCEPTION_SAMPLE_LIMIT;
   public static final String PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS =
-      ProfilingConfig.PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS;
+    ProfilingConfig.PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS;
   public static final String PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE =
-      ProfilingConfig.PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE;
+    ProfilingConfig.PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE;
 
   public static final String KAFKA_CLIENT_PROPAGATION_ENABLED =
-      TraceInstrumentationConfig.KAFKA_CLIENT_PROPAGATION_ENABLED;
+    TraceInstrumentationConfig.KAFKA_CLIENT_PROPAGATION_ENABLED;
 
   public static final String KAFKA_CLIENT_BASE64_DECODING_ENABLED =
-      TraceInstrumentationConfig.KAFKA_CLIENT_BASE64_DECODING_ENABLED;
+    TraceInstrumentationConfig.KAFKA_CLIENT_BASE64_DECODING_ENABLED;
 
   private static final String PROFILING_REMOTE_URL_TEMPLATE = "https://intake.profile.%s/v1/input";
   private static final String PROFILING_LOCAL_URL_TEMPLATE = "http://%s:%d/profiling/v1/input";
@@ -238,13 +243,17 @@ public class Config {
   private static final Pattern ENV_REPLACEMENT = Pattern.compile("[^a-zA-Z0-9_]");
   private static final String SPLIT_BY_SPACE_OR_COMMA_REGEX = "[,\\s]+";
 
-  /** Used for masking sensitive information when doing toString */
+  /**
+   * Used for masking sensitive information when doing toString
+   */
   @ToString.Include(name = "apiKey")
   private String profilingApiKeyMasker() {
     return apiKey != null ? "****" : null;
   }
 
-  /** Used for masking sensitive information when doing toString */
+  /**
+   * Used for masking sensitive information when doing toString
+   */
   @ToString.Include(name = "profilingProxyPassword")
   private String profilingProxyPasswordMasker() {
     return profilingProxyPassword != null ? "****" : null;
@@ -254,105 +263,180 @@ public class Config {
    * this is a random UUID that gets generated on JVM start up and is attached to every root span
    * and every JMX metric that is sent out.
    */
-  @Getter private final String runtimeId;
+  @Getter
+  private final String runtimeId;
 
   /**
    * Note: this has effect only on profiling site. Traces are sent to Datadog agent and are not
    * affected by this setting.
    */
-  @Getter private final String apiKey;
+  @Getter
+  private final String apiKey;
   /**
    * Note: this has effect only on profiling site. Traces are sent to Datadog agent and are not
    * affected by this setting.
    */
-  @Getter private final String site;
+  @Getter
+  private final String site;
 
-  @Getter private final String serviceName;
-  @Getter private final boolean traceEnabled;
-  @Getter private final boolean integrationsEnabled;
-  @Getter private final String writerType;
-  @Getter private final String agentHost;
-  @Getter private final int agentPort;
-  @Getter private final String agentUnixDomainSocket;
-  @Getter private final int agentTimeout;
-  @Getter private final boolean prioritySamplingEnabled;
-  @Getter private final boolean traceResolverEnabled;
-  @Getter private final Map<String, String> serviceMapping;
-  @NonNull private final Map<String, String> tags;
+  @Getter
+  private final String serviceName;
+  @Getter
+  private final boolean traceEnabled;
+  @Getter
+  private final boolean integrationsEnabled;
+  @Getter
+  private final String writerType;
+  @Getter
+  private final String agentHost;
+  @Getter
+  private final int agentPort;
+  @Getter
+  private final String agentUnixDomainSocket;
+  @Getter
+  private final int agentTimeout;
+  @Getter
+  private final boolean prioritySamplingEnabled;
+  @Getter
+  private final boolean traceResolverEnabled;
+  @Getter
+  private final Map<String, String> serviceMapping;
+  @NonNull
+  private final Map<String, String> tags;
   private final Map<String, String> spanTags;
   private final Map<String, String> jmxTags;
-  @Getter private final List<String> excludedClasses;
-  @Getter private final Map<String, String> headerTags;
-  @Getter private final BitSet httpServerErrorStatuses;
-  @Getter private final BitSet httpClientErrorStatuses;
-  @Getter private final boolean httpServerTagQueryString;
-  @Getter private final boolean httpClientTagQueryString;
-  @Getter private final boolean httpClientSplitByDomain;
-  @Getter private final boolean dbClientSplitByInstance;
-  @Getter private final Set<String> splitByTags;
-  @Getter private final Integer scopeDepthLimit;
-  @Getter private final boolean scopeStrictMode;
-  @Getter private final Integer partialFlushMinSpans;
-  @Getter private final boolean runtimeContextFieldInjection;
-  @Getter private final Set<PropagationStyle> propagationStylesToExtract;
-  @Getter private final Set<PropagationStyle> propagationStylesToInject;
+  @Getter
+  private final List<String> excludedClasses;
+  @Getter
+  private final Map<String, String> headerTags;
+  @Getter
+  private final BitSet httpServerErrorStatuses;
+  @Getter
+  private final BitSet httpClientErrorStatuses;
+  @Getter
+  private final boolean httpServerTagQueryString;
+  @Getter
+  private final boolean httpClientTagQueryString;
+  @Getter
+  private final boolean httpClientSplitByDomain;
+  @Getter
+  private final boolean dbClientSplitByInstance;
+  @Getter
+  private final Set<String> splitByTags;
+  @Getter
+  private final Integer scopeDepthLimit;
+  @Getter
+  private final boolean scopeStrictMode;
+  @Getter
+  private final Integer partialFlushMinSpans;
+  @Getter
+  private final boolean runtimeContextFieldInjection;
+  @Getter
+  private final Set<PropagationStyle> propagationStylesToExtract;
+  @Getter
+  private final Set<PropagationStyle> propagationStylesToInject;
 
-  @Getter private final boolean jmxFetchEnabled;
-  @Getter private final String jmxFetchConfigDir;
-  @Getter private final List<String> jmxFetchConfigs;
-  @Deprecated @Getter private final List<String> jmxFetchMetricsConfigs;
-  @Getter private final Integer jmxFetchCheckPeriod;
-  @Getter private final Integer jmxFetchRefreshBeansPeriod;
-  @Getter private final String jmxFetchStatsdHost;
-  @Getter private final Integer jmxFetchStatsdPort;
+  @Getter
+  private final boolean jmxFetchEnabled;
+  @Getter
+  private final String jmxFetchConfigDir;
+  @Getter
+  private final List<String> jmxFetchConfigs;
+  @Deprecated
+  @Getter
+  private final List<String> jmxFetchMetricsConfigs;
+  @Getter
+  private final Integer jmxFetchCheckPeriod;
+  @Getter
+  private final Integer jmxFetchRefreshBeansPeriod;
+  @Getter
+  private final String jmxFetchStatsdHost;
+  @Getter
+  private final Integer jmxFetchStatsdPort;
 
   // These values are default-ed to those of jmx fetch values as needed
-  @Getter private final boolean healthMetricsEnabled;
-  @Getter private final String healthMetricsStatsdHost;
-  @Getter private final Integer healthMetricsStatsdPort;
+  @Getter
+  private final boolean healthMetricsEnabled;
+  @Getter
+  private final String healthMetricsStatsdHost;
+  @Getter
+  private final Integer healthMetricsStatsdPort;
 
-  @Getter private final boolean logsInjectionEnabled;
-  @Getter private final boolean reportHostName;
+  @Getter
+  private final boolean logsInjectionEnabled;
+  @Getter
+  private final boolean reportHostName;
 
-  @Getter private final String traceAnnotations;
+  @Getter
+  private final String traceAnnotations;
 
-  @Getter private final String traceMethods;
+  @Getter
+  private final String traceMethods;
 
-  @Getter private final boolean traceExecutorsAll;
-  @Getter private final List<String> traceExecutors;
+  @Getter
+  private final boolean traceExecutorsAll;
+  @Getter
+  private final List<String> traceExecutors;
 
-  @Getter private final boolean traceAnalyticsEnabled;
+  @Getter
+  private final boolean traceAnalyticsEnabled;
 
-  @Getter private final Map<String, String> traceSamplingServiceRules;
-  @Getter private final Map<String, String> traceSamplingOperationRules;
-  @Getter private final Double traceSampleRate;
-  @Getter private final Double traceRateLimit;
+  @Getter
+  private final Map<String, String> traceSamplingServiceRules;
+  @Getter
+  private final Map<String, String> traceSamplingOperationRules;
+  @Getter
+  private final Double traceSampleRate;
+  @Getter
+  private final Double traceRateLimit;
 
-  @Getter private final boolean profilingEnabled;
-  @Deprecated private final String profilingUrl;
+  @Getter
+  private final boolean profilingEnabled;
+  @Deprecated
+  private final String profilingUrl;
   private final Map<String, String> profilingTags;
-  @Getter private final int profilingStartDelay;
-  @Getter private final boolean profilingStartForceFirst;
-  @Getter private final int profilingUploadPeriod;
-  @Getter private final String profilingTemplateOverrideFile;
-  @Getter private final int profilingUploadTimeout;
-  @Getter private final String profilingUploadCompression;
-  @Getter private final String profilingProxyHost;
-  @Getter private final int profilingProxyPort;
-  @Getter private final String profilingProxyUsername;
-  @Getter private final String profilingProxyPassword;
-  @Getter private final int profilingExceptionSampleLimit;
-  @Getter private final int profilingExceptionHistogramTopItems;
-  @Getter private final int profilingExceptionHistogramMaxCollectionSize;
+  @Getter
+  private final int profilingStartDelay;
+  @Getter
+  private final boolean profilingStartForceFirst;
+  @Getter
+  private final int profilingUploadPeriod;
+  @Getter
+  private final String profilingTemplateOverrideFile;
+  @Getter
+  private final int profilingUploadTimeout;
+  @Getter
+  private final String profilingUploadCompression;
+  @Getter
+  private final String profilingProxyHost;
+  @Getter
+  private final int profilingProxyPort;
+  @Getter
+  private final String profilingProxyUsername;
+  @Getter
+  private final String profilingProxyPassword;
+  @Getter
+  private final int profilingExceptionSampleLimit;
+  @Getter
+  private final int profilingExceptionHistogramTopItems;
+  @Getter
+  private final int profilingExceptionHistogramMaxCollectionSize;
 
-  @Getter private final boolean kafkaClientPropagationEnabled;
-  @Getter private final boolean kafkaClientBase64DecodingEnabled;
+  @Getter
+  private final boolean kafkaClientPropagationEnabled;
+  @Getter
+  private final boolean kafkaClientBase64DecodingEnabled;
 
-  @Getter private final boolean debugEnabled;
-  @Getter private final String configFile;
+  @Getter
+  private final boolean debugEnabled;
+  @Getter
+  private final String configFile;
 
   // Values from an optionally provided properties file
   private static Properties propertiesFromConfigFile;
+
+  // Values extracted from the environment. These properties are platform dependant.
+  private static Properties propertiesFromCapturedEnv;
 
   // Read order: System Properties -> Env Variables, [-> properties file], [-> default value]
   private Config() {
@@ -361,8 +445,8 @@ public class Config {
 
   private Config(final String runtimeId) {
     propertiesFromConfigFile = loadConfigurationFile();
+    propertiesFromCapturedEnv = loadCapturedEnvironment();
     configFile = findConfigurationFile();
-
     this.runtimeId = runtimeId;
 
     // Note: We do not want APiKey to be loaded from property for security reasons
@@ -373,37 +457,37 @@ public class Config {
     if (apiKeyFile != null) {
       try {
         tmpApiKey =
-            new String(Files.readAllBytes(Paths.get(apiKeyFile)), StandardCharsets.UTF_8).trim();
+          new String(Files.readAllBytes(Paths.get(apiKeyFile)), StandardCharsets.UTF_8).trim();
       } catch (final IOException e) {
         log.error("Cannot read API key from file {}, skipping", apiKeyFile, e);
       }
     }
     site = getSettingFromEnvironment(SITE, DEFAULT_SITE);
     serviceName =
-        getSettingFromEnvironment(
-            SERVICE, getSettingFromEnvironment(SERVICE_NAME, DEFAULT_SERVICE_NAME));
+      getSettingFromEnvironment(
+        SERVICE, getSettingFromEnvironment(SERVICE_NAME, DEFAULT_SERVICE_NAME));
 
     traceEnabled = getBooleanSettingFromEnvironment(TRACE_ENABLED, DEFAULT_TRACE_ENABLED);
     integrationsEnabled =
-        getBooleanSettingFromEnvironment(INTEGRATIONS_ENABLED, DEFAULT_INTEGRATIONS_ENABLED);
+      getBooleanSettingFromEnvironment(INTEGRATIONS_ENABLED, DEFAULT_INTEGRATIONS_ENABLED);
     writerType = getSettingFromEnvironment(WRITER_TYPE, DEFAULT_AGENT_WRITER_TYPE);
     agentHost = getSettingFromEnvironment(AGENT_HOST, DEFAULT_AGENT_HOST);
     agentPort =
-        getIntegerSettingFromEnvironment(
-            TRACE_AGENT_PORT,
-            getIntegerSettingFromEnvironment(AGENT_PORT_LEGACY, DEFAULT_TRACE_AGENT_PORT));
+      getIntegerSettingFromEnvironment(
+        TRACE_AGENT_PORT,
+        getIntegerSettingFromEnvironment(AGENT_PORT_LEGACY, DEFAULT_TRACE_AGENT_PORT));
     agentUnixDomainSocket =
-        getSettingFromEnvironment(AGENT_UNIX_DOMAIN_SOCKET, DEFAULT_AGENT_UNIX_DOMAIN_SOCKET);
+      getSettingFromEnvironment(AGENT_UNIX_DOMAIN_SOCKET, DEFAULT_AGENT_UNIX_DOMAIN_SOCKET);
     agentTimeout = getIntegerSettingFromEnvironment(AGENT_TIMEOUT, DEFAULT_AGENT_TIMEOUT);
     prioritySamplingEnabled =
-        getBooleanSettingFromEnvironment(PRIORITY_SAMPLING, DEFAULT_PRIORITY_SAMPLING_ENABLED);
+      getBooleanSettingFromEnvironment(PRIORITY_SAMPLING, DEFAULT_PRIORITY_SAMPLING_ENABLED);
     traceResolverEnabled =
-        getBooleanSettingFromEnvironment(TRACE_RESOLVER_ENABLED, DEFAULT_TRACE_RESOLVER_ENABLED);
+      getBooleanSettingFromEnvironment(TRACE_RESOLVER_ENABLED, DEFAULT_TRACE_RESOLVER_ENABLED);
     serviceMapping = getMapSettingFromEnvironment(SERVICE_MAPPING, null);
 
     {
       final Map<String, String> tags =
-          new HashMap<>(getMapSettingFromEnvironment(GLOBAL_TAGS, null));
+        new HashMap<>(getMapSettingFromEnvironment(GLOBAL_TAGS, null));
       tags.putAll(getMapSettingFromEnvironment(TAGS, null));
       this.tags = getMapWithPropertiesDefinedByEnvironment(tags, ENV, VERSION);
     }
@@ -415,108 +499,108 @@ public class Config {
     headerTags = getMapSettingFromEnvironment(HEADER_TAGS, null);
 
     httpServerErrorStatuses =
-        getIntegerRangeSettingFromEnvironment(
-            HTTP_SERVER_ERROR_STATUSES, DEFAULT_HTTP_SERVER_ERROR_STATUSES);
+      getIntegerRangeSettingFromEnvironment(
+        HTTP_SERVER_ERROR_STATUSES, DEFAULT_HTTP_SERVER_ERROR_STATUSES);
 
     httpClientErrorStatuses =
-        getIntegerRangeSettingFromEnvironment(
-            HTTP_CLIENT_ERROR_STATUSES, DEFAULT_HTTP_CLIENT_ERROR_STATUSES);
+      getIntegerRangeSettingFromEnvironment(
+        HTTP_CLIENT_ERROR_STATUSES, DEFAULT_HTTP_CLIENT_ERROR_STATUSES);
 
     httpServerTagQueryString =
-        getBooleanSettingFromEnvironment(
-            HTTP_SERVER_TAG_QUERY_STRING, DEFAULT_HTTP_SERVER_TAG_QUERY_STRING);
+      getBooleanSettingFromEnvironment(
+        HTTP_SERVER_TAG_QUERY_STRING, DEFAULT_HTTP_SERVER_TAG_QUERY_STRING);
 
     httpClientTagQueryString =
-        getBooleanSettingFromEnvironment(
-            HTTP_CLIENT_TAG_QUERY_STRING, DEFAULT_HTTP_CLIENT_TAG_QUERY_STRING);
+      getBooleanSettingFromEnvironment(
+        HTTP_CLIENT_TAG_QUERY_STRING, DEFAULT_HTTP_CLIENT_TAG_QUERY_STRING);
 
     httpClientSplitByDomain =
-        getBooleanSettingFromEnvironment(
-            HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN, DEFAULT_HTTP_CLIENT_SPLIT_BY_DOMAIN);
+      getBooleanSettingFromEnvironment(
+        HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN, DEFAULT_HTTP_CLIENT_SPLIT_BY_DOMAIN);
 
     dbClientSplitByInstance =
-        getBooleanSettingFromEnvironment(
-            DB_CLIENT_HOST_SPLIT_BY_INSTANCE, DEFAULT_DB_CLIENT_HOST_SPLIT_BY_INSTANCE);
+      getBooleanSettingFromEnvironment(
+        DB_CLIENT_HOST_SPLIT_BY_INSTANCE, DEFAULT_DB_CLIENT_HOST_SPLIT_BY_INSTANCE);
 
     splitByTags =
-        Collections.unmodifiableSet(
-            new LinkedHashSet<>(
-                getListSettingFromEnvironment(SPLIT_BY_TAGS, DEFAULT_SPLIT_BY_TAGS)));
+      Collections.unmodifiableSet(
+        new LinkedHashSet<>(
+          getListSettingFromEnvironment(SPLIT_BY_TAGS, DEFAULT_SPLIT_BY_TAGS)));
 
     scopeDepthLimit =
-        getIntegerSettingFromEnvironment(SCOPE_DEPTH_LIMIT, DEFAULT_SCOPE_DEPTH_LIMIT);
+      getIntegerSettingFromEnvironment(SCOPE_DEPTH_LIMIT, DEFAULT_SCOPE_DEPTH_LIMIT);
 
     scopeStrictMode = getBooleanSettingFromEnvironment(SCOPE_STRICT_MODE, false);
 
     partialFlushMinSpans =
-        getIntegerSettingFromEnvironment(PARTIAL_FLUSH_MIN_SPANS, DEFAULT_PARTIAL_FLUSH_MIN_SPANS);
+      getIntegerSettingFromEnvironment(PARTIAL_FLUSH_MIN_SPANS, DEFAULT_PARTIAL_FLUSH_MIN_SPANS);
 
     runtimeContextFieldInjection =
-        getBooleanSettingFromEnvironment(
-            RUNTIME_CONTEXT_FIELD_INJECTION, DEFAULT_RUNTIME_CONTEXT_FIELD_INJECTION);
+      getBooleanSettingFromEnvironment(
+        RUNTIME_CONTEXT_FIELD_INJECTION, DEFAULT_RUNTIME_CONTEXT_FIELD_INJECTION);
 
     propagationStylesToExtract =
-        getPropagationStyleSetSettingFromEnvironmentOrDefault(
-            PROPAGATION_STYLE_EXTRACT, DEFAULT_PROPAGATION_STYLE_EXTRACT);
+      getPropagationStyleSetSettingFromEnvironmentOrDefault(
+        PROPAGATION_STYLE_EXTRACT, DEFAULT_PROPAGATION_STYLE_EXTRACT);
     propagationStylesToInject =
-        getPropagationStyleSetSettingFromEnvironmentOrDefault(
-            PROPAGATION_STYLE_INJECT, DEFAULT_PROPAGATION_STYLE_INJECT);
+      getPropagationStyleSetSettingFromEnvironmentOrDefault(
+        PROPAGATION_STYLE_INJECT, DEFAULT_PROPAGATION_STYLE_INJECT);
 
     jmxFetchEnabled =
-        getBooleanSettingFromEnvironment(JMX_FETCH_ENABLED, DEFAULT_JMX_FETCH_ENABLED);
+      getBooleanSettingFromEnvironment(JMX_FETCH_ENABLED, DEFAULT_JMX_FETCH_ENABLED);
     jmxFetchConfigDir = getSettingFromEnvironment(JMX_FETCH_CONFIG_DIR, null);
     jmxFetchConfigs = getListSettingFromEnvironment(JMX_FETCH_CONFIG, null);
     jmxFetchMetricsConfigs = getListSettingFromEnvironment(JMX_FETCH_METRICS_CONFIGS, null);
     jmxFetchCheckPeriod = getIntegerSettingFromEnvironment(JMX_FETCH_CHECK_PERIOD, null);
     jmxFetchRefreshBeansPeriod =
-        getIntegerSettingFromEnvironment(JMX_FETCH_REFRESH_BEANS_PERIOD, null);
+      getIntegerSettingFromEnvironment(JMX_FETCH_REFRESH_BEANS_PERIOD, null);
     jmxFetchStatsdHost = getSettingFromEnvironment(JMX_FETCH_STATSD_HOST, null);
     jmxFetchStatsdPort =
-        getIntegerSettingFromEnvironment(JMX_FETCH_STATSD_PORT, DEFAULT_JMX_FETCH_STATSD_PORT);
+      getIntegerSettingFromEnvironment(JMX_FETCH_STATSD_PORT, DEFAULT_JMX_FETCH_STATSD_PORT);
 
     // Writer.Builder createMonitor will use the values of the JMX fetch & agent to fill-in defaults
     healthMetricsEnabled =
-        getBooleanSettingFromEnvironment(HEALTH_METRICS_ENABLED, DEFAULT_METRICS_ENABLED);
+      getBooleanSettingFromEnvironment(HEALTH_METRICS_ENABLED, DEFAULT_METRICS_ENABLED);
     healthMetricsStatsdHost = getSettingFromEnvironment(HEALTH_METRICS_STATSD_HOST, null);
     healthMetricsStatsdPort = getIntegerSettingFromEnvironment(HEALTH_METRICS_STATSD_PORT, null);
 
     logsInjectionEnabled =
-        getBooleanSettingFromEnvironment(LOGS_INJECTION_ENABLED, DEFAULT_LOGS_INJECTION_ENABLED);
+      getBooleanSettingFromEnvironment(LOGS_INJECTION_ENABLED, DEFAULT_LOGS_INJECTION_ENABLED);
     reportHostName =
-        getBooleanSettingFromEnvironment(TRACE_REPORT_HOSTNAME, DEFAULT_TRACE_REPORT_HOSTNAME);
+      getBooleanSettingFromEnvironment(TRACE_REPORT_HOSTNAME, DEFAULT_TRACE_REPORT_HOSTNAME);
 
     traceAnnotations = getSettingFromEnvironment(TRACE_ANNOTATIONS, DEFAULT_TRACE_ANNOTATIONS);
 
     traceMethods = getSettingFromEnvironment(TRACE_METHODS, DEFAULT_TRACE_METHODS);
 
     traceExecutorsAll =
-        getBooleanSettingFromEnvironment(TRACE_EXECUTORS_ALL, DEFAULT_TRACE_EXECUTORS_ALL);
+      getBooleanSettingFromEnvironment(TRACE_EXECUTORS_ALL, DEFAULT_TRACE_EXECUTORS_ALL);
 
     traceExecutors = getListSettingFromEnvironment(TRACE_EXECUTORS, DEFAULT_TRACE_EXECUTORS);
 
     traceAnalyticsEnabled =
-        getBooleanSettingFromEnvironment(TRACE_ANALYTICS_ENABLED, DEFAULT_TRACE_ANALYTICS_ENABLED);
+      getBooleanSettingFromEnvironment(TRACE_ANALYTICS_ENABLED, DEFAULT_TRACE_ANALYTICS_ENABLED);
 
     traceSamplingServiceRules = getMapSettingFromEnvironment(TRACE_SAMPLING_SERVICE_RULES, null);
     traceSamplingOperationRules =
-        getMapSettingFromEnvironment(TRACE_SAMPLING_OPERATION_RULES, null);
+      getMapSettingFromEnvironment(TRACE_SAMPLING_OPERATION_RULES, null);
     traceSampleRate = getDoubleSettingFromEnvironment(TRACE_SAMPLE_RATE, null);
     traceRateLimit = getDoubleSettingFromEnvironment(TRACE_RATE_LIMIT, DEFAULT_TRACE_RATE_LIMIT);
 
     profilingEnabled =
-        getBooleanSettingFromEnvironment(PROFILING_ENABLED, DEFAULT_PROFILING_ENABLED);
+      getBooleanSettingFromEnvironment(PROFILING_ENABLED, DEFAULT_PROFILING_ENABLED);
     profilingUrl = getSettingFromEnvironment(PROFILING_URL, null);
 
     if (tmpApiKey == null) {
       final String oldProfilingApiKeyFile =
-          getSettingFromEnvironment(PROFILING_API_KEY_FILE_OLD, null);
+        getSettingFromEnvironment(PROFILING_API_KEY_FILE_OLD, null);
       tmpApiKey = System.getenv(propertyNameToEnvironmentVariableName(PROFILING_API_KEY_OLD));
       if (oldProfilingApiKeyFile != null) {
         try {
           tmpApiKey =
-              new String(
-                      Files.readAllBytes(Paths.get(oldProfilingApiKeyFile)), StandardCharsets.UTF_8)
-                  .trim();
+            new String(
+              Files.readAllBytes(Paths.get(oldProfilingApiKeyFile)), StandardCharsets.UTF_8)
+              .trim();
         } catch (final IOException e) {
           log.error("Cannot read API key from file {}, skipping", oldProfilingApiKeyFile, e);
         }
@@ -524,15 +608,15 @@ public class Config {
     }
     if (tmpApiKey == null) {
       final String veryOldProfilingApiKeyFile =
-          getSettingFromEnvironment(PROFILING_API_KEY_FILE_VERY_OLD, null);
+        getSettingFromEnvironment(PROFILING_API_KEY_FILE_VERY_OLD, null);
       tmpApiKey = System.getenv(propertyNameToEnvironmentVariableName(PROFILING_API_KEY_VERY_OLD));
       if (veryOldProfilingApiKeyFile != null) {
         try {
           tmpApiKey =
-              new String(
-                      Files.readAllBytes(Paths.get(veryOldProfilingApiKeyFile)),
-                      StandardCharsets.UTF_8)
-                  .trim();
+            new String(
+              Files.readAllBytes(Paths.get(veryOldProfilingApiKeyFile)),
+              StandardCharsets.UTF_8)
+              .trim();
         } catch (final IOException e) {
           log.error("Cannot read API key from file {}, skipping", veryOldProfilingApiKeyFile, e);
         }
@@ -541,44 +625,44 @@ public class Config {
 
     profilingTags = getMapSettingFromEnvironment(PROFILING_TAGS, null);
     profilingStartDelay =
-        getIntegerSettingFromEnvironment(PROFILING_START_DELAY, DEFAULT_PROFILING_START_DELAY);
+      getIntegerSettingFromEnvironment(PROFILING_START_DELAY, DEFAULT_PROFILING_START_DELAY);
     profilingStartForceFirst =
-        getBooleanSettingFromEnvironment(
-            PROFILING_START_FORCE_FIRST, DEFAULT_PROFILING_START_FORCE_FIRST);
+      getBooleanSettingFromEnvironment(
+        PROFILING_START_FORCE_FIRST, DEFAULT_PROFILING_START_FORCE_FIRST);
     profilingUploadPeriod =
-        getIntegerSettingFromEnvironment(PROFILING_UPLOAD_PERIOD, DEFAULT_PROFILING_UPLOAD_PERIOD);
+      getIntegerSettingFromEnvironment(PROFILING_UPLOAD_PERIOD, DEFAULT_PROFILING_UPLOAD_PERIOD);
     profilingTemplateOverrideFile =
-        getSettingFromEnvironment(PROFILING_TEMPLATE_OVERRIDE_FILE, null);
+      getSettingFromEnvironment(PROFILING_TEMPLATE_OVERRIDE_FILE, null);
     profilingUploadTimeout =
-        getIntegerSettingFromEnvironment(
-            PROFILING_UPLOAD_TIMEOUT, DEFAULT_PROFILING_UPLOAD_TIMEOUT);
+      getIntegerSettingFromEnvironment(
+        PROFILING_UPLOAD_TIMEOUT, DEFAULT_PROFILING_UPLOAD_TIMEOUT);
     profilingUploadCompression =
-        getSettingFromEnvironment(
-            PROFILING_UPLOAD_COMPRESSION, DEFAULT_PROFILING_UPLOAD_COMPRESSION);
+      getSettingFromEnvironment(
+        PROFILING_UPLOAD_COMPRESSION, DEFAULT_PROFILING_UPLOAD_COMPRESSION);
     profilingProxyHost = getSettingFromEnvironment(PROFILING_PROXY_HOST, null);
     profilingProxyPort =
-        getIntegerSettingFromEnvironment(PROFILING_PROXY_PORT, DEFAULT_PROFILING_PROXY_PORT);
+      getIntegerSettingFromEnvironment(PROFILING_PROXY_PORT, DEFAULT_PROFILING_PROXY_PORT);
     profilingProxyUsername = getSettingFromEnvironment(PROFILING_PROXY_USERNAME, null);
     profilingProxyPassword = getSettingFromEnvironment(PROFILING_PROXY_PASSWORD, null);
 
     profilingExceptionSampleLimit =
-        getIntegerSettingFromEnvironment(
-            PROFILING_EXCEPTION_SAMPLE_LIMIT, DEFAULT_PROFILING_EXCEPTION_SAMPLE_LIMIT);
+      getIntegerSettingFromEnvironment(
+        PROFILING_EXCEPTION_SAMPLE_LIMIT, DEFAULT_PROFILING_EXCEPTION_SAMPLE_LIMIT);
     profilingExceptionHistogramTopItems =
-        getIntegerSettingFromEnvironment(
-            PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS,
-            DEFAULT_PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS);
+      getIntegerSettingFromEnvironment(
+        PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS,
+        DEFAULT_PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS);
     profilingExceptionHistogramMaxCollectionSize =
-        getIntegerSettingFromEnvironment(
-            PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE,
-            DEFAULT_PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE);
+      getIntegerSettingFromEnvironment(
+        PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE,
+        DEFAULT_PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE);
 
     kafkaClientPropagationEnabled =
-        getBooleanSettingFromEnvironment(
-            KAFKA_CLIENT_PROPAGATION_ENABLED, DEFAULT_KAFKA_CLIENT_PROPAGATION_ENABLED);
+      getBooleanSettingFromEnvironment(
+        KAFKA_CLIENT_PROPAGATION_ENABLED, DEFAULT_KAFKA_CLIENT_PROPAGATION_ENABLED);
 
     kafkaClientBase64DecodingEnabled =
-        getBooleanSettingFromEnvironment(KAFKA_CLIENT_BASE64_DECODING_ENABLED, false);
+      getBooleanSettingFromEnvironment(KAFKA_CLIENT_BASE64_DECODING_ENABLED, false);
 
     debugEnabled = isDebugMode();
 
@@ -597,202 +681,204 @@ public class Config {
     apiKey = properties.getProperty(API_KEY, parent.apiKey);
     site = properties.getProperty(SITE, parent.site);
     serviceName =
-        properties.getProperty(SERVICE, properties.getProperty(SERVICE_NAME, parent.serviceName));
+      properties.getProperty(SERVICE, properties.getProperty(SERVICE_NAME, parent.serviceName));
 
     traceEnabled = getPropertyBooleanValue(properties, TRACE_ENABLED, parent.traceEnabled);
     integrationsEnabled =
-        getPropertyBooleanValue(properties, INTEGRATIONS_ENABLED, parent.integrationsEnabled);
+      getPropertyBooleanValue(properties, INTEGRATIONS_ENABLED, parent.integrationsEnabled);
     writerType = properties.getProperty(WRITER_TYPE, parent.writerType);
     agentHost = properties.getProperty(AGENT_HOST, parent.agentHost);
     agentPort =
-        getPropertyIntegerValue(
-            properties,
-            TRACE_AGENT_PORT,
-            getPropertyIntegerValue(properties, AGENT_PORT_LEGACY, parent.agentPort));
+      getPropertyIntegerValue(
+        properties,
+        TRACE_AGENT_PORT,
+        getPropertyIntegerValue(properties, AGENT_PORT_LEGACY, parent.agentPort));
     agentUnixDomainSocket =
-        properties.getProperty(AGENT_UNIX_DOMAIN_SOCKET, parent.agentUnixDomainSocket);
+      properties.getProperty(AGENT_UNIX_DOMAIN_SOCKET, parent.agentUnixDomainSocket);
     agentTimeout = getPropertyIntegerValue(properties, AGENT_TIMEOUT, parent.agentTimeout);
     prioritySamplingEnabled =
-        getPropertyBooleanValue(properties, PRIORITY_SAMPLING, parent.prioritySamplingEnabled);
+      getPropertyBooleanValue(properties, PRIORITY_SAMPLING, parent.prioritySamplingEnabled);
     traceResolverEnabled =
-        getPropertyBooleanValue(properties, TRACE_RESOLVER_ENABLED, parent.traceResolverEnabled);
+      getPropertyBooleanValue(properties, TRACE_RESOLVER_ENABLED, parent.traceResolverEnabled);
     serviceMapping = getPropertyMapValue(properties, SERVICE_MAPPING, parent.serviceMapping);
 
     {
       final Map<String, String> preTags =
-          new HashMap<>(
-              getPropertyMapValue(properties, GLOBAL_TAGS, Collections.<String, String>emptyMap()));
+        new HashMap<>(
+          getPropertyMapValue(properties, GLOBAL_TAGS, Collections.<String, String>emptyMap()));
       preTags.putAll(getPropertyMapValue(properties, TAGS, parent.tags));
       tags = overwriteKeysFromProperties(preTags, properties, ENV, VERSION);
     }
     spanTags = getPropertyMapValue(properties, SPAN_TAGS, parent.spanTags);
     jmxTags = getPropertyMapValue(properties, JMX_TAGS, parent.jmxTags);
     excludedClasses =
-        getPropertyListValue(properties, TRACE_CLASSES_EXCLUDE, parent.excludedClasses);
+      getPropertyListValue(properties, TRACE_CLASSES_EXCLUDE, parent.excludedClasses);
     headerTags = getPropertyMapValue(properties, HEADER_TAGS, parent.headerTags);
 
     httpServerErrorStatuses =
-        getPropertyIntegerRangeValue(
-            properties, HTTP_SERVER_ERROR_STATUSES, parent.httpServerErrorStatuses);
+      getPropertyIntegerRangeValue(
+        properties, HTTP_SERVER_ERROR_STATUSES, parent.httpServerErrorStatuses);
 
     httpClientErrorStatuses =
-        getPropertyIntegerRangeValue(
-            properties, HTTP_CLIENT_ERROR_STATUSES, parent.httpClientErrorStatuses);
+      getPropertyIntegerRangeValue(
+        properties, HTTP_CLIENT_ERROR_STATUSES, parent.httpClientErrorStatuses);
 
     httpServerTagQueryString =
-        getPropertyBooleanValue(
-            properties, HTTP_SERVER_TAG_QUERY_STRING, parent.httpServerTagQueryString);
+      getPropertyBooleanValue(
+        properties, HTTP_SERVER_TAG_QUERY_STRING, parent.httpServerTagQueryString);
 
     httpClientTagQueryString =
-        getPropertyBooleanValue(
-            properties, HTTP_CLIENT_TAG_QUERY_STRING, parent.httpClientTagQueryString);
+      getPropertyBooleanValue(
+        properties, HTTP_CLIENT_TAG_QUERY_STRING, parent.httpClientTagQueryString);
 
     httpClientSplitByDomain =
-        getPropertyBooleanValue(
-            properties, HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN, parent.httpClientSplitByDomain);
+      getPropertyBooleanValue(
+        properties, HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN, parent.httpClientSplitByDomain);
 
     dbClientSplitByInstance =
-        getPropertyBooleanValue(
-            properties, DB_CLIENT_HOST_SPLIT_BY_INSTANCE, parent.dbClientSplitByInstance);
+      getPropertyBooleanValue(
+        properties, DB_CLIENT_HOST_SPLIT_BY_INSTANCE, parent.dbClientSplitByInstance);
 
     splitByTags =
-        Collections.unmodifiableSet(
-            new LinkedHashSet<>(
-                getPropertyListValue(
-                    properties, SPLIT_BY_TAGS, new ArrayList<>(parent.splitByTags))));
+      Collections.unmodifiableSet(
+        new LinkedHashSet<>(
+          getPropertyListValue(
+            properties, SPLIT_BY_TAGS, new ArrayList<>(parent.splitByTags))));
 
     scopeDepthLimit =
-        getPropertyIntegerValue(properties, SCOPE_DEPTH_LIMIT, parent.scopeDepthLimit);
+      getPropertyIntegerValue(properties, SCOPE_DEPTH_LIMIT, parent.scopeDepthLimit);
 
     scopeStrictMode =
-        getPropertyBooleanValue(properties, SCOPE_STRICT_MODE, parent.scopeStrictMode);
+      getPropertyBooleanValue(properties, SCOPE_STRICT_MODE, parent.scopeStrictMode);
 
     partialFlushMinSpans =
-        getPropertyIntegerValue(properties, PARTIAL_FLUSH_MIN_SPANS, parent.partialFlushMinSpans);
+      getPropertyIntegerValue(properties, PARTIAL_FLUSH_MIN_SPANS, parent.partialFlushMinSpans);
 
     runtimeContextFieldInjection =
-        getPropertyBooleanValue(
-            properties, RUNTIME_CONTEXT_FIELD_INJECTION, parent.runtimeContextFieldInjection);
+      getPropertyBooleanValue(
+        properties, RUNTIME_CONTEXT_FIELD_INJECTION, parent.runtimeContextFieldInjection);
 
     final Set<PropagationStyle> parsedPropagationStylesToExtract =
-        getPropagationStyleSetFromPropertyValue(properties, PROPAGATION_STYLE_EXTRACT);
+      getPropagationStyleSetFromPropertyValue(properties, PROPAGATION_STYLE_EXTRACT);
     propagationStylesToExtract =
-        parsedPropagationStylesToExtract == null
-            ? parent.propagationStylesToExtract
-            : parsedPropagationStylesToExtract;
+      parsedPropagationStylesToExtract == null
+        ? parent.propagationStylesToExtract
+        : parsedPropagationStylesToExtract;
     final Set<PropagationStyle> parsedPropagationStylesToInject =
-        getPropagationStyleSetFromPropertyValue(properties, PROPAGATION_STYLE_INJECT);
+      getPropagationStyleSetFromPropertyValue(properties, PROPAGATION_STYLE_INJECT);
     propagationStylesToInject =
-        parsedPropagationStylesToInject == null
-            ? parent.propagationStylesToInject
-            : parsedPropagationStylesToInject;
+      parsedPropagationStylesToInject == null
+        ? parent.propagationStylesToInject
+        : parsedPropagationStylesToInject;
 
     jmxFetchEnabled =
-        getPropertyBooleanValue(properties, JMX_FETCH_ENABLED, parent.jmxFetchEnabled);
+      getPropertyBooleanValue(properties, JMX_FETCH_ENABLED, parent.jmxFetchEnabled);
     jmxFetchConfigDir = properties.getProperty(JMX_FETCH_CONFIG_DIR, parent.jmxFetchConfigDir);
     jmxFetchConfigs = getPropertyListValue(properties, JMX_FETCH_CONFIG, parent.jmxFetchConfigs);
     jmxFetchMetricsConfigs =
-        getPropertyListValue(properties, JMX_FETCH_METRICS_CONFIGS, parent.jmxFetchMetricsConfigs);
+      getPropertyListValue(properties, JMX_FETCH_METRICS_CONFIGS, parent.jmxFetchMetricsConfigs);
     jmxFetchCheckPeriod =
-        getPropertyIntegerValue(properties, JMX_FETCH_CHECK_PERIOD, parent.jmxFetchCheckPeriod);
+      getPropertyIntegerValue(properties, JMX_FETCH_CHECK_PERIOD, parent.jmxFetchCheckPeriod);
     jmxFetchRefreshBeansPeriod =
-        getPropertyIntegerValue(
-            properties, JMX_FETCH_REFRESH_BEANS_PERIOD, parent.jmxFetchRefreshBeansPeriod);
+      getPropertyIntegerValue(
+        properties, JMX_FETCH_REFRESH_BEANS_PERIOD, parent.jmxFetchRefreshBeansPeriod);
     jmxFetchStatsdHost = properties.getProperty(JMX_FETCH_STATSD_HOST, parent.jmxFetchStatsdHost);
     jmxFetchStatsdPort =
-        getPropertyIntegerValue(properties, JMX_FETCH_STATSD_PORT, parent.jmxFetchStatsdPort);
+      getPropertyIntegerValue(properties, JMX_FETCH_STATSD_PORT, parent.jmxFetchStatsdPort);
 
     healthMetricsEnabled =
-        getPropertyBooleanValue(properties, HEALTH_METRICS_ENABLED, DEFAULT_METRICS_ENABLED);
+      getPropertyBooleanValue(properties, HEALTH_METRICS_ENABLED, DEFAULT_METRICS_ENABLED);
     healthMetricsStatsdHost =
-        properties.getProperty(HEALTH_METRICS_STATSD_HOST, parent.healthMetricsStatsdHost);
+      properties.getProperty(HEALTH_METRICS_STATSD_HOST, parent.healthMetricsStatsdHost);
     healthMetricsStatsdPort =
-        getPropertyIntegerValue(
-            properties, HEALTH_METRICS_STATSD_PORT, parent.healthMetricsStatsdPort);
+      getPropertyIntegerValue(
+        properties, HEALTH_METRICS_STATSD_PORT, parent.healthMetricsStatsdPort);
 
     logsInjectionEnabled =
-        getBooleanSettingFromEnvironment(LOGS_INJECTION_ENABLED, DEFAULT_LOGS_INJECTION_ENABLED);
+      getBooleanSettingFromEnvironment(LOGS_INJECTION_ENABLED, DEFAULT_LOGS_INJECTION_ENABLED);
     reportHostName =
-        getPropertyBooleanValue(properties, TRACE_REPORT_HOSTNAME, parent.reportHostName);
+      getPropertyBooleanValue(properties, TRACE_REPORT_HOSTNAME, parent.reportHostName);
 
     traceAnnotations = properties.getProperty(TRACE_ANNOTATIONS, parent.traceAnnotations);
 
     traceMethods = properties.getProperty(TRACE_METHODS, parent.traceMethods);
 
     traceExecutorsAll =
-        getPropertyBooleanValue(properties, TRACE_EXECUTORS_ALL, parent.traceExecutorsAll);
+      getPropertyBooleanValue(properties, TRACE_EXECUTORS_ALL, parent.traceExecutorsAll);
     traceExecutors = getPropertyListValue(properties, TRACE_EXECUTORS, parent.traceExecutors);
 
     traceAnalyticsEnabled =
-        getPropertyBooleanValue(properties, TRACE_ANALYTICS_ENABLED, parent.traceAnalyticsEnabled);
+      getPropertyBooleanValue(properties, TRACE_ANALYTICS_ENABLED, parent.traceAnalyticsEnabled);
 
     traceSamplingServiceRules =
-        getPropertyMapValue(
-            properties, TRACE_SAMPLING_SERVICE_RULES, parent.traceSamplingServiceRules);
+      getPropertyMapValue(
+        properties, TRACE_SAMPLING_SERVICE_RULES, parent.traceSamplingServiceRules);
     traceSamplingOperationRules =
-        getPropertyMapValue(
-            properties, TRACE_SAMPLING_OPERATION_RULES, parent.traceSamplingOperationRules);
+      getPropertyMapValue(
+        properties, TRACE_SAMPLING_OPERATION_RULES, parent.traceSamplingOperationRules);
     traceSampleRate = getPropertyDoubleValue(properties, TRACE_SAMPLE_RATE, parent.traceSampleRate);
     traceRateLimit = getPropertyDoubleValue(properties, TRACE_RATE_LIMIT, parent.traceRateLimit);
 
     profilingEnabled =
-        getPropertyBooleanValue(properties, PROFILING_ENABLED, parent.profilingEnabled);
+      getPropertyBooleanValue(properties, PROFILING_ENABLED, parent.profilingEnabled);
     profilingUrl = properties.getProperty(PROFILING_URL, parent.profilingUrl);
     profilingTags = getPropertyMapValue(properties, PROFILING_TAGS, parent.profilingTags);
     profilingStartDelay =
-        getPropertyIntegerValue(properties, PROFILING_START_DELAY, parent.profilingStartDelay);
+      getPropertyIntegerValue(properties, PROFILING_START_DELAY, parent.profilingStartDelay);
     profilingStartForceFirst =
-        getPropertyBooleanValue(
-            properties, PROFILING_START_FORCE_FIRST, parent.profilingStartForceFirst);
+      getPropertyBooleanValue(
+        properties, PROFILING_START_FORCE_FIRST, parent.profilingStartForceFirst);
     profilingUploadPeriod =
-        getPropertyIntegerValue(properties, PROFILING_UPLOAD_PERIOD, parent.profilingUploadPeriod);
+      getPropertyIntegerValue(properties, PROFILING_UPLOAD_PERIOD, parent.profilingUploadPeriod);
     profilingTemplateOverrideFile =
-        properties.getProperty(
-            PROFILING_TEMPLATE_OVERRIDE_FILE, parent.profilingTemplateOverrideFile);
+      properties.getProperty(
+        PROFILING_TEMPLATE_OVERRIDE_FILE, parent.profilingTemplateOverrideFile);
     profilingUploadTimeout =
-        getPropertyIntegerValue(
-            properties, PROFILING_UPLOAD_TIMEOUT, parent.profilingUploadTimeout);
+      getPropertyIntegerValue(
+        properties, PROFILING_UPLOAD_TIMEOUT, parent.profilingUploadTimeout);
     profilingUploadCompression =
-        properties.getProperty(PROFILING_UPLOAD_COMPRESSION, parent.profilingUploadCompression);
+      properties.getProperty(PROFILING_UPLOAD_COMPRESSION, parent.profilingUploadCompression);
     profilingProxyHost = properties.getProperty(PROFILING_PROXY_HOST, parent.profilingProxyHost);
     profilingProxyPort =
-        getPropertyIntegerValue(properties, PROFILING_PROXY_PORT, parent.profilingProxyPort);
+      getPropertyIntegerValue(properties, PROFILING_PROXY_PORT, parent.profilingProxyPort);
     profilingProxyUsername =
-        properties.getProperty(PROFILING_PROXY_USERNAME, parent.profilingProxyUsername);
+      properties.getProperty(PROFILING_PROXY_USERNAME, parent.profilingProxyUsername);
     profilingProxyPassword =
-        properties.getProperty(PROFILING_PROXY_PASSWORD, parent.profilingProxyPassword);
+      properties.getProperty(PROFILING_PROXY_PASSWORD, parent.profilingProxyPassword);
 
     profilingExceptionSampleLimit =
-        getPropertyIntegerValue(
-            properties, PROFILING_EXCEPTION_SAMPLE_LIMIT, parent.profilingExceptionSampleLimit);
+      getPropertyIntegerValue(
+        properties, PROFILING_EXCEPTION_SAMPLE_LIMIT, parent.profilingExceptionSampleLimit);
 
     profilingExceptionHistogramTopItems =
-        getPropertyIntegerValue(
-            properties,
-            PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS,
-            parent.profilingExceptionHistogramTopItems);
+      getPropertyIntegerValue(
+        properties,
+        PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS,
+        parent.profilingExceptionHistogramTopItems);
     profilingExceptionHistogramMaxCollectionSize =
-        getPropertyIntegerValue(
-            properties,
-            PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE,
-            parent.profilingExceptionHistogramMaxCollectionSize);
+      getPropertyIntegerValue(
+        properties,
+        PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE,
+        parent.profilingExceptionHistogramMaxCollectionSize);
 
     kafkaClientPropagationEnabled =
-        getPropertyBooleanValue(
-            properties, KAFKA_CLIENT_PROPAGATION_ENABLED, parent.kafkaClientPropagationEnabled);
+      getPropertyBooleanValue(
+        properties, KAFKA_CLIENT_PROPAGATION_ENABLED, parent.kafkaClientPropagationEnabled);
 
     debugEnabled = parent.debugEnabled || isDebugMode();
 
     kafkaClientBase64DecodingEnabled =
-        getPropertyBooleanValue(
-            properties,
-            KAFKA_CLIENT_BASE64_DECODING_ENABLED,
-            parent.kafkaClientBase64DecodingEnabled);
+      getPropertyBooleanValue(
+        properties,
+        KAFKA_CLIENT_BASE64_DECODING_ENABLED,
+        parent.kafkaClientBase64DecodingEnabled);
 
     log.debug("New instance: {}", this);
   }
 
-  /** @return A map of tags to be applied only to the local application root span. */
+  /**
+   * @return A map of tags to be applied only to the local application root span.
+   */
   public Map<String, String> getLocalRootSpanTags() {
     final Map<String, String> runtimeTags = getRuntimeTags();
     final Map<String, String> result = new HashMap<>(runtimeTags);
@@ -819,8 +905,8 @@ public class Config {
   public Map<String, String> getMergedJmxTags() {
     final Map<String, String> runtimeTags = getRuntimeTags();
     final Map<String, String> result =
-        newHashMap(
-            getGlobalTags().size() + jmxTags.size() + runtimeTags.size() + 1 /* for serviceName */);
+      newHashMap(
+        getGlobalTags().size() + jmxTags.size() + runtimeTags.size() + 1 /* for serviceName */);
     result.putAll(getGlobalTags());
     result.putAll(jmxTags);
     result.putAll(runtimeTags);
@@ -835,11 +921,11 @@ public class Config {
     final Map<String, String> runtimeTags = getRuntimeTags();
     final String host = getHostName();
     final Map<String, String> result =
-        newHashMap(
-            getGlobalTags().size()
-                + profilingTags.size()
-                + runtimeTags.size()
-                + 3 /* for serviceName and host and language */);
+      newHashMap(
+        getGlobalTags().size()
+          + profilingTags.size()
+          + runtimeTags.size()
+          + 3 /* for serviceName and host and language */);
     result.put(HOST_TAG, host); // Host goes first to allow to override it
     result.putAll(getGlobalTags());
     result.putAll(profilingTags);
@@ -902,7 +988,7 @@ public class Config {
   }
 
   public boolean isIntegrationEnabled(
-      final SortedSet<String> integrationNames, final boolean defaultEnabled) {
+    final SortedSet<String> integrationNames, final boolean defaultEnabled) {
     return integrationEnabled(integrationNames, defaultEnabled);
   }
 
@@ -911,17 +997,17 @@ public class Config {
    * @param defaultEnabled
    * @return
    * @deprecated This method should only be used internally. Use the instance getter instead {@link
-   *     #isIntegrationEnabled(SortedSet, boolean)}.
+   * #isIntegrationEnabled(SortedSet, boolean)}.
    */
   @Deprecated
   private static boolean integrationEnabled(
-      final SortedSet<String> integrationNames, final boolean defaultEnabled) {
+    final SortedSet<String> integrationNames, final boolean defaultEnabled) {
     // If default is enabled, we want to enable individually,
     // if default is disabled, we want to disable individually.
     boolean anyEnabled = defaultEnabled;
     for (final String name : integrationNames) {
       final boolean configEnabled =
-          getBooleanSettingFromEnvironment("integration." + name + ".enabled", defaultEnabled);
+        getBooleanSettingFromEnvironment("integration." + name + ".enabled", defaultEnabled);
       if (defaultEnabled) {
         anyEnabled &= configEnabled;
       } else {
@@ -932,13 +1018,13 @@ public class Config {
   }
 
   public boolean isJmxFetchIntegrationEnabled(
-      final SortedSet<String> integrationNames, final boolean defaultEnabled) {
+    final SortedSet<String> integrationNames, final boolean defaultEnabled) {
     return jmxFetchIntegrationEnabled(integrationNames, defaultEnabled);
   }
 
   public boolean isRuleEnabled(final String name) {
     return getBooleanSettingFromEnvironment("trace." + name + ".enabled", true)
-        && getBooleanSettingFromEnvironment("trace." + name.toLowerCase() + ".enabled", true);
+      && getBooleanSettingFromEnvironment("trace." + name.toLowerCase() + ".enabled", true);
   }
 
   /**
@@ -946,16 +1032,16 @@ public class Config {
    * @param defaultEnabled
    * @return
    * @deprecated This method should only be used internally. Use the instance getter instead {@link
-   *     #isJmxFetchIntegrationEnabled(SortedSet, boolean)}.
+   * #isJmxFetchIntegrationEnabled(SortedSet, boolean)}.
    */
   public static boolean jmxFetchIntegrationEnabled(
-      final SortedSet<String> integrationNames, final boolean defaultEnabled) {
+    final SortedSet<String> integrationNames, final boolean defaultEnabled) {
     // If default is enabled, we want to enable individually,
     // if default is disabled, we want to disable individually.
     boolean anyEnabled = defaultEnabled;
     for (final String name : integrationNames) {
       final boolean configEnabled =
-          getBooleanSettingFromEnvironment("jmxfetch." + name + ".enabled", defaultEnabled);
+        getBooleanSettingFromEnvironment("jmxfetch." + name + ".enabled", defaultEnabled);
       if (defaultEnabled) {
         anyEnabled &= configEnabled;
       } else {
@@ -966,17 +1052,17 @@ public class Config {
   }
 
   public boolean isEndToEndDurationEnabled(
-      final boolean defaultEnabled, final String... integrationNames) {
+    final boolean defaultEnabled, final String... integrationNames) {
     return isEnabled(integrationNames, ".e2e.duration.enabled", defaultEnabled);
   }
 
   public boolean isTraceAnalyticsIntegrationEnabled(
-      final SortedSet<String> integrationNames, final boolean defaultEnabled) {
+    final SortedSet<String> integrationNames, final boolean defaultEnabled) {
     return traceAnalyticsIntegrationEnabled(integrationNames, defaultEnabled);
   }
 
   public boolean isTraceAnalyticsIntegrationEnabled(
-      final boolean defaultEnabled, final String... integrationNames) {
+    final boolean defaultEnabled, final String... integrationNames) {
     return isEnabled(integrationNames, ".analytics.enabled", defaultEnabled);
   }
 
@@ -989,7 +1075,7 @@ public class Config {
     }
 
     final String tracerDebugLevelEnv =
-        System.getenv(tracerDebugLevelSysprop.replace('.', '_').toUpperCase());
+      System.getenv(tracerDebugLevelSysprop.replace('.', '_').toUpperCase());
 
     if (tracerDebugLevelEnv != null) {
       return Boolean.parseBoolean(tracerDebugLevelEnv);
@@ -1002,16 +1088,16 @@ public class Config {
    * @param defaultEnabled
    * @return
    * @deprecated This method should only be used internally. Use the instance getter instead {@link
-   *     #isTraceAnalyticsIntegrationEnabled(SortedSet, boolean)}.
+   * #isTraceAnalyticsIntegrationEnabled(SortedSet, boolean)}.
    */
   public static boolean traceAnalyticsIntegrationEnabled(
-      final SortedSet<String> integrationNames, final boolean defaultEnabled) {
+    final SortedSet<String> integrationNames, final boolean defaultEnabled) {
     // If default is enabled, we want to enable individually,
     // if default is disabled, we want to disable individually.
     boolean anyEnabled = defaultEnabled;
     for (final String name : integrationNames) {
       final boolean configEnabled =
-          getBooleanSettingFromEnvironment(name + ".analytics.enabled", defaultEnabled);
+        getBooleanSettingFromEnvironment(name + ".analytics.enabled", defaultEnabled);
       if (defaultEnabled) {
         anyEnabled &= configEnabled;
       } else {
@@ -1022,13 +1108,13 @@ public class Config {
   }
 
   private static boolean isEnabled(
-      final String[] integrationNames, final String settingSuffix, final boolean defaultEnabled) {
+    final String[] integrationNames, final String settingSuffix, final boolean defaultEnabled) {
     // If default is enabled, we want to enable individually,
     // if default is disabled, we want to disable individually.
     boolean anyEnabled = defaultEnabled;
     for (final String name : integrationNames) {
       final boolean configEnabled =
-          getBooleanSettingFromEnvironment(name + settingSuffix, defaultEnabled);
+        getBooleanSettingFromEnvironment(name + settingSuffix, defaultEnabled);
       if (defaultEnabled) {
         anyEnabled &= configEnabled;
       } else {
@@ -1042,7 +1128,8 @@ public class Config {
    * Helper method that takes the name, adds a "dd." prefix then checks for System Properties of
    * that name. If none found, the name is converted to an Environment Variable and used to check
    * the env. If none of the above returns a value, then an optional properties file if checked. If
-   * setting is not configured in either location, <code>defaultValue</code> is returned.
+   * none found, then platform dependant properties are checked. If setting is not configured in
+   * either location, <code>defaultValue</code> is returned.
    *
    * @param name
    * @param defaultValue
@@ -1071,15 +1158,23 @@ public class Config {
       return value;
     }
 
+    // If value is not defined yet, we look at properties dependant of the platform.
+    value = propertiesFromCapturedEnv.getProperty(name);
+    if (null != value) {
+      return value;
+    }
+
     return defaultValue;
   }
 
-  /** @deprecated This method should only be used internally. Use the explicit getter instead. */
+  /**
+   * @deprecated This method should only be used internally. Use the explicit getter instead.
+   */
   @NonNull
   private static Map<String, String> getMapSettingFromEnvironment(
-      final String name, final String defaultValue) {
+    final String name, final String defaultValue) {
     return parseMap(
-        getSettingFromEnvironment(name, defaultValue), propertyNameToSystemPropertyName(name));
+      getSettingFromEnvironment(name, defaultValue), propertyNameToSystemPropertyName(name));
   }
 
   /**
@@ -1090,7 +1185,7 @@ public class Config {
    */
   @NonNull
   private static List<String> getListSettingFromEnvironment(
-      final String name, final String defaultValue) {
+    final String name, final String defaultValue) {
     return parseList(getSettingFromEnvironment(name, defaultValue));
   }
 
@@ -1100,7 +1195,7 @@ public class Config {
    * @deprecated This method should only be used internally. Use the explicit getter instead.
    */
   public static Boolean getBooleanSettingFromEnvironment(
-      final String name, final Boolean defaultValue) {
+    final String name, final Boolean defaultValue) {
     return getSettingFromEnvironmentWithLog(name, Boolean.class, defaultValue);
   }
 
@@ -1120,7 +1215,7 @@ public class Config {
    */
   @Deprecated
   private static Double getDoubleSettingFromEnvironment(
-      final String name, final Double defaultValue) {
+    final String name, final Double defaultValue) {
     return getSettingFromEnvironmentWithLog(name, Double.class, defaultValue);
   }
 
@@ -1128,12 +1223,12 @@ public class Config {
    * Calls {@link #getSettingFromEnvironment(String, String)} and converts the result to a Integer.
    */
   private static Integer getIntegerSettingFromEnvironment(
-      final String name, final Integer defaultValue) {
+    final String name, final Integer defaultValue) {
     return getSettingFromEnvironmentWithLog(name, Integer.class, defaultValue);
   }
 
   private static <T> T getSettingFromEnvironmentWithLog(
-      final String name, final Class<T> tClass, final T defaultValue) {
+    final String name, final Class<T> tClass, final T defaultValue) {
     try {
       return valueOf(getSettingFromEnvironment(name, null), tClass, defaultValue);
     } catch (final NumberFormatException e) {
@@ -1147,22 +1242,22 @@ public class Config {
    * strings splitting by space or comma.
    */
   private static Set<PropagationStyle> getPropagationStyleSetSettingFromEnvironmentOrDefault(
-      final String name, final String defaultValue) {
+    final String name, final String defaultValue) {
     final String value = getSettingFromEnvironment(name, defaultValue);
     Set<PropagationStyle> result =
-        convertStringSetToPropagationStyleSet(parseStringIntoSetOfNonEmptyStrings(value));
+      convertStringSetToPropagationStyleSet(parseStringIntoSetOfNonEmptyStrings(value));
 
     if (result.isEmpty()) {
       // Treat empty parsing result as no value and use default instead
       result =
-          convertStringSetToPropagationStyleSet(parseStringIntoSetOfNonEmptyStrings(defaultValue));
+        convertStringSetToPropagationStyleSet(parseStringIntoSetOfNonEmptyStrings(defaultValue));
     }
 
     return result;
   }
 
   private static BitSet getIntegerRangeSettingFromEnvironment(
-      final String name, final BitSet defaultValue) {
+    final String name, final BitSet defaultValue) {
     final String value = getSettingFromEnvironment(name, null);
     try {
       return value == null ? defaultValue : parseIntegerRangeSet(value, name);
@@ -1182,8 +1277,8 @@ public class Config {
   @NonNull
   private static String propertyNameToEnvironmentVariableName(final String setting) {
     return ENV_REPLACEMENT
-        .matcher(propertyNameToSystemPropertyName(setting).toUpperCase())
-        .replaceAll("_");
+      .matcher(propertyNameToSystemPropertyName(setting).toUpperCase())
+      .replaceAll("_");
   }
 
   /**
@@ -1199,23 +1294,23 @@ public class Config {
   }
 
   /**
-   * @param value to parse by tClass::valueOf
-   * @param tClass should contain static parsing method "T valueOf(String)"
+   * @param value        to parse by tClass::valueOf
+   * @param tClass       should contain static parsing method "T valueOf(String)"
    * @param defaultValue
    * @param <T>
    * @return value == null || value.trim().isEmpty() ? defaultValue : tClass.valueOf(value)
    * @throws NumberFormatException
    */
   private static <T> T valueOf(
-      final String value, @NonNull final Class<T> tClass, final T defaultValue) {
+    final String value, @NonNull final Class<T> tClass, final T defaultValue) {
     if (value == null || value.trim().isEmpty()) {
       return defaultValue;
     }
     try {
       return (T)
-          PUBLIC_LOOKUP
-              .findStatic(tClass, "valueOf", MethodType.methodType(tClass, String.class))
-              .invoke(value);
+        PUBLIC_LOOKUP
+          .findStatic(tClass, "valueOf", MethodType.methodType(tClass, String.class))
+          .invoke(value);
     } catch (final NumberFormatException e) {
       throw e;
     } catch (final NoSuchMethodException | IllegalAccessException e) {
@@ -1228,38 +1323,38 @@ public class Config {
   }
 
   private static Map<String, String> getPropertyMapValue(
-      final Properties properties, final String name, final Map<String, String> defaultValue) {
+    final Properties properties, final String name, final Map<String, String> defaultValue) {
     final String value = properties.getProperty(name);
     return value == null || value.trim().isEmpty() ? defaultValue : parseMap(value, name);
   }
 
   private static List<String> getPropertyListValue(
-      final Properties properties, final String name, final List<String> defaultValue) {
+    final Properties properties, final String name, final List<String> defaultValue) {
     final String value = properties.getProperty(name);
     return value == null || value.trim().isEmpty() ? defaultValue : parseList(value);
   }
 
   private static Boolean getPropertyBooleanValue(
-      final Properties properties, final String name, final Boolean defaultValue) {
+    final Properties properties, final String name, final Boolean defaultValue) {
     return valueOf(properties.getProperty(name), Boolean.class, defaultValue);
   }
 
   private static Integer getPropertyIntegerValue(
-      final Properties properties, final String name, final Integer defaultValue) {
+    final Properties properties, final String name, final Integer defaultValue) {
     return valueOf(properties.getProperty(name), Integer.class, defaultValue);
   }
 
   private static Double getPropertyDoubleValue(
-      final Properties properties, final String name, final Double defaultValue) {
+    final Properties properties, final String name, final Double defaultValue) {
     return valueOf(properties.getProperty(name), Double.class, defaultValue);
   }
 
   private static Set<PropagationStyle> getPropagationStyleSetFromPropertyValue(
-      final Properties properties, final String name) {
+    final Properties properties, final String name) {
     final String value = properties.getProperty(name);
     if (value != null) {
       final Set<PropagationStyle> result =
-          convertStringSetToPropagationStyleSet(parseStringIntoSetOfNonEmptyStrings(value));
+        convertStringSetToPropagationStyleSet(parseStringIntoSetOfNonEmptyStrings(value));
       if (!result.isEmpty()) {
         return result;
       }
@@ -1269,7 +1364,7 @@ public class Config {
   }
 
   private static BitSet getPropertyIntegerRangeValue(
-      final Properties properties, final String name, final BitSet defaultValue) {
+    final Properties properties, final String name, final BitSet defaultValue) {
     final String value = properties.getProperty(name);
     try {
       return value == null ? defaultValue : parseIntegerRangeSet(value, name);
@@ -1287,7 +1382,7 @@ public class Config {
     }
     if (!str.matches("(([^,:]+:[^,:]*,)*([^,:]+:[^,:]*),?)?")) {
       log.warn(
-          "Invalid config for {}: '{}'. Must match 'key1:value1,key2:value2'.", settingName, str);
+        "Invalid config for {}: '{}'. Must match 'key1:value1,key2:value2'.", settingName, str);
       return Collections.emptyMap();
     }
 
@@ -1311,13 +1406,13 @@ public class Config {
 
   @NonNull
   static BitSet parseIntegerRangeSet(@NonNull String str, final String settingName)
-      throws NumberFormatException {
+    throws NumberFormatException {
     str = str.replaceAll("\\s", "");
     if (!str.matches("\\d{3}(?:-\\d{3})?(?:,\\d{3}(?:-\\d{3})?)*")) {
       log.warn(
-          "Invalid config for {}: '{}'. Must be formatted like '400-403,405,410-499'.",
-          settingName,
-          str);
+        "Invalid config for {}: '{}'. Must be formatted like '400-403,405,410-499'.",
+        settingName,
+        str);
       throw new NumberFormatException();
     }
 
@@ -1352,7 +1447,7 @@ public class Config {
    */
   @NonNull
   private static Map<String, String> getMapWithPropertiesDefinedByEnvironment(
-      @NonNull final Map<String, String> map, @NonNull final String... propNames) {
+    @NonNull final Map<String, String> map, @NonNull final String... propNames) {
     final Map<String, String> res = new HashMap<>(map);
     for (final String propName : propNames) {
       final String val = getSettingFromEnvironment(propName, null);
@@ -1374,9 +1469,9 @@ public class Config {
    */
   @NonNull
   private static Map<String, String> overwriteKeysFromProperties(
-      @NonNull final Map<String, String> map,
-      @NonNull final Properties properties,
-      @NonNull final String... keys) {
+    @NonNull final Map<String, String> map,
+    @NonNull final Properties properties,
+    @NonNull final String... keys) {
     final Map<String, String> res = new HashMap<>(map);
     for (final String propName : keys) {
       final String val = properties.getProperty(propName, null);
@@ -1417,7 +1512,7 @@ public class Config {
 
   @NonNull
   private static Set<PropagationStyle> convertStringSetToPropagationStyleSet(
-      final Set<String> input) {
+    final Set<String> input) {
     // Using LinkedHashSet to preserve original string order
     final Set<PropagationStyle> result = new LinkedHashSet<>();
     for (final String value : input) {
@@ -1434,17 +1529,17 @@ public class Config {
    * Loads the optional configuration properties file into the global {@link Properties} object.
    *
    * @return The {@link Properties} object. the returned instance might be empty of file does not
-   *     exist or if it is in a wrong format.
+   * exist or if it is in a wrong format.
    */
   private static Properties loadConfigurationFile() {
     final Properties properties = new Properties();
 
     // Reading from system property first and from env after
     String configurationFilePath =
-        System.getProperty(propertyNameToSystemPropertyName(CONFIGURATION_FILE));
+      System.getProperty(propertyNameToSystemPropertyName(CONFIGURATION_FILE));
     if (null == configurationFilePath) {
       configurationFilePath =
-          System.getenv(propertyNameToEnvironmentVariableName(CONFIGURATION_FILE));
+        System.getenv(propertyNameToEnvironmentVariableName(CONFIGURATION_FILE));
     }
     if (null == configurationFilePath) {
       return properties;
@@ -1452,7 +1547,7 @@ public class Config {
 
     // Normalizing tilde (~) paths for unix systems
     configurationFilePath =
-        configurationFilePath.replaceFirst("^~", System.getProperty("user.home"));
+      configurationFilePath.replaceFirst("^~", System.getProperty("user.home"));
 
     // Configuration properties file is optional
     final File configurationFile = new File(configurationFilePath);
@@ -1467,22 +1562,23 @@ public class Config {
       log.error("Configuration file '{}' not found.", configurationFilePath);
     } catch (final IOException ioe) {
       log.error(
-          "Configuration file '{}' cannot be accessed or correctly parsed.", configurationFilePath);
+        "Configuration file '{}' cannot be accessed or correctly parsed.", configurationFilePath);
     }
 
     return properties;
   }
 
+
   private static String findConfigurationFile() {
     String configurationFilePath =
-        System.getProperty(propertyNameToSystemPropertyName(CONFIGURATION_FILE));
+      System.getProperty(propertyNameToSystemPropertyName(CONFIGURATION_FILE));
     if (null == configurationFilePath) {
       configurationFilePath =
-          System.getenv(propertyNameToEnvironmentVariableName(CONFIGURATION_FILE));
+        System.getenv(propertyNameToEnvironmentVariableName(CONFIGURATION_FILE));
     }
     if (null != configurationFilePath) {
       configurationFilePath =
-          configurationFilePath.replaceFirst("^~", System.getProperty("user.home"));
+        configurationFilePath.replaceFirst("^~", System.getProperty("user.home"));
       final File configurationFile = new File(configurationFilePath);
       if (!configurationFile.exists()) {
         return configurationFilePath;
@@ -1491,7 +1587,21 @@ public class Config {
     return "no config file present";
   }
 
-  /** Returns the detected hostname. First tries locally, then using DNS */
+  private static Properties loadCapturedEnvironment() {
+    final CapturedEnvironment capturedEnvironment = CapturedEnvironment.get();
+    final Properties properties = new Properties();
+    for (final Map.Entry<String, String> entry : capturedEnvironment.getProperties().entrySet()) {
+      if (entry.getKey() != null && entry.getValue() != null) {
+        properties.put(entry.getKey(), entry.getValue());
+      }
+    }
+
+    return properties;
+  }
+
+  /**
+   * Returns the detected hostname. First tries locally, then using DNS
+   */
   private static String getHostName() {
     String possibleHostname;
 
@@ -1509,8 +1619,8 @@ public class Config {
 
     // Try hostname command
     try (final BufferedReader reader =
-        new BufferedReader(
-            new InputStreamReader(Runtime.getRuntime().exec("hostname").getInputStream()))) {
+           new BufferedReader(
+             new InputStreamReader(Runtime.getRuntime().exec("hostname").getInputStream()))) {
       possibleHostname = reader.readLine();
     } catch (final Exception ignore) {
       // Ignore.  Hostname command is not always available
@@ -1546,8 +1656,8 @@ public class Config {
    *   DDTracer.builder().withProperties(new Properties()).build()
    * </pre>
    *
-   * Config keys for use in Properties instance construction can be found in {@link GeneralConfig}
-   * and {@link TracerConfig}.
+   * <p>Config keys for use in Properties instance construction can be found in {@link
+   * GeneralConfig} and {@link TracerConfig}.
    *
    * @deprecated
    */

--- a/dd-trace-api/src/main/java/datadog/trace/api/env/CapturedEnvironment.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/env/CapturedEnvironment.java
@@ -9,7 +9,8 @@ import lombok.extern.slf4j.Slf4j;
 
 /**
  * The {@code CapturedEnvironment} instance keeps those {@code Config} values which are platform
- * dependant.
+ * dependant. Notice that this class must be consider internal. You should not depend on it
+ * directly.
  */
 @Slf4j
 public class CapturedEnvironment {

--- a/dd-trace-api/src/main/java/datadog/trace/api/env/CapturedEnvironment.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/env/CapturedEnvironment.java
@@ -1,0 +1,67 @@
+package datadog.trace.api.env;
+
+import datadog.trace.api.config.GeneralConfig;
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * The {@code CapturedEnvironment} instance keeps those {@code Config} values which are platform
+ * dependant.
+ */
+@Slf4j
+public class CapturedEnvironment {
+
+  private static final CapturedEnvironment INSTANCE = new CapturedEnvironment();
+
+  @Getter private final Map<String, String> properties;
+
+  CapturedEnvironment() {
+    properties = new HashMap<>();
+    properties.put(GeneralConfig.SERVICE_NAME, autodetectServiceName());
+  }
+
+  // Testing purposes
+  static void useFixedEnv(final Map<String, String> props) {
+    INSTANCE.properties.clear();
+
+    for (final Map.Entry<String, String> entry : props.entrySet()) {
+      INSTANCE.properties.put(entry.getKey(), entry.getValue());
+    }
+  }
+
+  /**
+   * Returns autodetected service name based on the java process command line. Typically, the
+   * autodetection will return either the JAR filename or the java main class.
+   */
+  private String autodetectServiceName() {
+    // Besides "sun.java.command" property is not an standard, all main JDKs has set this property.
+    // Tested on:
+    // - OracleJDK, OpenJDK, AdoptOpenJDK, IBM JDK, Azul Zulu JDK, Amazon Coretto JDK
+    return extractJarOrClass(System.getProperty("sun.java.command"));
+  }
+
+  private String extractJarOrClass(final String command) {
+    if (command == null || command.equals("")) {
+      return null;
+    }
+
+    final String[] split = command.trim().split(" ");
+    if (split.length == 0 || split[0].equals("")) {
+      return null;
+    }
+
+    final String candidate = split[0];
+    if (candidate.endsWith(".jar")) {
+      return new File(candidate).getName().replace(".jar", "");
+    }
+
+    return candidate;
+  }
+
+  public static CapturedEnvironment get() {
+    return INSTANCE;
+  }
+}

--- a/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -1,5 +1,7 @@
 package datadog.trace.api
 
+
+import datadog.trace.api.env.FixedCapturedEnvironment
 import datadog.trace.util.test.DDSpecification
 import org.junit.Rule
 import org.junit.contrib.java.lang.system.EnvironmentVariables
@@ -87,6 +89,8 @@ class ConfigTest extends DDSpecification {
   public final RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties()
   @Rule
   public final EnvironmentVariables environmentVariables = new EnvironmentVariables()
+  @Rule
+  public final FixedCapturedEnvironment fixedCapturedEnvironment = new FixedCapturedEnvironment()
 
   private static final DD_API_KEY_ENV = "DD_API_KEY"
   private static final DD_SERVICE_NAME_ENV = "DD_SERVICE_NAME"
@@ -643,6 +647,65 @@ class ConfigTest extends DDSpecification {
     then:
     config.serviceName == "unnamed-java-app"
     config.writerType == "DDAgentWriter"
+  }
+
+  def "captured env props override default props"() {
+    setup:
+    def capturedEnv = new HashMap<String, String>()
+    capturedEnv.put(SERVICE_NAME, "automatic service name")
+    fixedCapturedEnvironment.load(capturedEnv)
+
+    when:
+    def config = new Config()
+
+    then:
+    config.serviceName == "automatic service name"
+  }
+
+  def "specify props override captured env props"() {
+    setup:
+    def prop = new Properties()
+    prop.setProperty(SERVICE_NAME, "what actually wants")
+
+    def capturedEnv = new HashMap<String, String>()
+    capturedEnv.put(SERVICE_NAME, "something else")
+    fixedCapturedEnvironment.load(capturedEnv)
+
+    when:
+    def config = Config.get(prop)
+
+    then:
+    config.serviceName == "what actually wants"
+  }
+
+  def "sys props override captured env props"() {
+    setup:
+    System.setProperty(PREFIX + SERVICE_NAME, "what actually wants")
+
+    def capturedEnv = new HashMap<String, String>()
+    capturedEnv.put(SERVICE_NAME, "something else")
+    fixedCapturedEnvironment.load(capturedEnv)
+
+    when:
+    def config = new Config()
+
+    then:
+    config.serviceName == "what actually wants"
+  }
+
+  def "env vars override captured env props"() {
+    setup:
+    environmentVariables.set(DD_SERVICE_NAME_ENV, "what actually wants")
+
+    def capturedEnv = new HashMap<String, String>()
+    capturedEnv.put(SERVICE_NAME, "something else")
+    fixedCapturedEnvironment.load(capturedEnv)
+
+    when:
+    def config = new Config()
+
+    then:
+    config.serviceName == "what actually wants"
   }
 
   def "verify integration config"() {

--- a/dd-trace-api/src/test/groovy/datadog/trace/api/env/CapturedEnvironmentTest.groovy
+++ b/dd-trace-api/src/test/groovy/datadog/trace/api/env/CapturedEnvironmentTest.groovy
@@ -1,0 +1,82 @@
+package datadog.trace.api.env
+
+import datadog.trace.api.config.GeneralConfig
+import datadog.trace.util.test.DDSpecification
+import org.junit.Rule
+import org.junit.contrib.java.lang.system.RestoreSystemProperties
+
+class CapturedEnvironmentTest extends DDSpecification {
+
+  @Rule
+  public final RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties()
+
+  def "non autodetected service.name with null command"() {
+    setup:
+    System.clearProperty("sun.java.command")
+
+    when:
+    def capturedEnv = new CapturedEnvironment()
+
+    then:
+    def props = capturedEnv.properties
+    props.get(GeneralConfig.SERVICE_NAME) == null
+  }
+
+  def "non autodetected service.name with empty command"() {
+    setup:
+    System.setProperty("sun.java.command", "")
+
+    when:
+    def capturedEnv = new CapturedEnvironment()
+
+    then:
+    def props = capturedEnv.properties
+    props.get(GeneralConfig.SERVICE_NAME) == null
+  }
+
+  def "non autodetected service.name with all blanks command"() {
+    setup:
+    System.setProperty("sun.java.command", " ")
+
+    when:
+    def capturedEnv = new CapturedEnvironment()
+
+    then:
+    def props = capturedEnv.properties
+    props.get(GeneralConfig.SERVICE_NAME) == null
+  }
+
+  def "set service.name by sysprop 'sun.java.command' with class"() {
+    setup:
+    System.setProperty("sun.java.command", "org.example.App -Dfoo=bar arg2 arg3")
+
+    when:
+    def capturedEnv = new CapturedEnvironment()
+
+    then:
+    def props = capturedEnv.properties
+    props.get(GeneralConfig.SERVICE_NAME) == "org.example.App"
+  }
+
+  def "set service.name by sysprop 'sun.java.command' with jar"() {
+    setup:
+    System.setProperty("sun.java.command", "foo/bar/example.jar -Dfoo=bar arg2 arg3")
+
+    when:
+    def capturedEnv = new CapturedEnvironment()
+
+    then:
+    def props = capturedEnv.properties
+    props.get(GeneralConfig.SERVICE_NAME) == "example"
+  }
+
+  def "set service.name with real 'sun.java.command' property"() {
+    when:
+    def capturedEnv = new CapturedEnvironment()
+
+    then:
+    def props = capturedEnv.properties
+    props.get(GeneralConfig.SERVICE_NAME) != null
+  }
+
+}

--- a/dd-trace-api/src/test/groovy/datadog/trace/api/env/FixedCapturedEnvironment.java
+++ b/dd-trace-api/src/test/groovy/datadog/trace/api/env/FixedCapturedEnvironment.java
@@ -1,0 +1,26 @@
+package datadog.trace.api.env;
+
+import java.util.Collections;
+import java.util.Map;
+import org.junit.rules.ExternalResource;
+
+/**
+ * The {@code FixedCapturedEnvironment} rule cleans the {@code CapturedEnvironment} instance when
+ * the test starts. Additionally, this rule can be used to set fixed properties into that {@code
+ * CapturedEnvironment} instance. This is useful to be deterministic in those tests that are testing
+ * logic which interacts with {@code CapturedEnvironment} instance, because that object returns
+ * properties which are platform dependant (JDK, OS, etc...)
+ */
+public class FixedCapturedEnvironment extends ExternalResource {
+
+  @Override
+  protected void before() throws Throwable {
+    // Clean CapturedEnvironment instance when test starts.
+    CapturedEnvironment.useFixedEnv(Collections.<String, String>emptyMap());
+  }
+
+  /** Load properties instance into the {@code CapturedEnvironment} instance. */
+  public void load(final Map<String, String> properties) {
+    CapturedEnvironment.useFixedEnv(properties);
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/core/taginterceptor/ServletContextTagInterceptor.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/taginterceptor/ServletContextTagInterceptor.java
@@ -1,6 +1,8 @@
 package datadog.trace.core.taginterceptor;
 
 import datadog.trace.api.ConfigDefaults;
+import datadog.trace.api.config.GeneralConfig;
+import datadog.trace.api.env.CapturedEnvironment;
 import datadog.trace.bootstrap.instrumentation.api.InstrumentationTags;
 import datadog.trace.core.DDSpanContext;
 
@@ -15,6 +17,9 @@ class ServletContextTagInterceptor extends AbstractTagInterceptor {
     String contextName = String.valueOf(value).trim();
     if (contextName.equals("/")
         || (!context.getServiceName().equals(ConfigDefaults.DEFAULT_SERVICE_NAME)
+            && !context
+                .getServiceName()
+                .equals(CapturedEnvironment.get().getProperties().get(GeneralConfig.SERVICE_NAME))
             && !context.getServiceName().isEmpty())) {
       return true;
     }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/CoreTracerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/CoreTracerTest.groovy
@@ -11,7 +11,6 @@ import datadog.trace.common.sampling.RateByServiceSampler
 import datadog.trace.common.sampling.Sampler
 import datadog.trace.common.writer.DDAgentWriter
 import datadog.trace.common.writer.LoggingWriter
-
 import datadog.trace.core.propagation.DatadogHttpCodec
 import datadog.trace.core.propagation.HttpCodec
 import datadog.trace.util.test.DDSpecification
@@ -43,7 +42,7 @@ class CoreTracerTest extends DDSpecification {
     def tracer = CoreTracer.builder().build()
 
     then:
-    tracer.serviceName == "unnamed-java-app"
+    tracer.serviceName != ""
     tracer.sampler instanceof RateByServiceSampler
     tracer.writer instanceof DDAgentWriter
     tracer.statsDClient instanceof NoOpStatsDClient

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanTest.groovy
@@ -11,8 +11,6 @@ import datadog.trace.util.test.DDSpecification
 
 import java.util.concurrent.TimeUnit
 
-import static datadog.trace.api.ConfigDefaults.DEFAULT_SERVICE_NAME
-
 class DDSpanTest extends DDSpecification {
 
   def writer = new ListWriter()
@@ -87,7 +85,7 @@ class DDSpanTest extends DDSpecification {
     span = tracer.buildSpan(opName).start()
     then:
     span.getResourceName() == opName
-    span.getServiceName() == DEFAULT_SERVICE_NAME
+    span.getServiceName() != ""
 
     when:
     final String resourceName = "fake"

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/TraceInterceptorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/TraceInterceptorTest.groovy
@@ -130,7 +130,7 @@ class TraceInterceptorTest extends DDSpecification {
     def span = trace[0]
 
     span.context().operationName == "modifiedON-test"
-    span.serviceName == "modifiedSN-unnamed-java-app"
+    span.serviceName.startsWith("modifiedSN-")
     span.resourceName == "modifiedRN-modifiedON-test"
     span.type == "modifiedST-null"
     span.context().getErrorFlag()

--- a/utils/test-utils/src/main/groovy/datadog/trace/util/test/DDSpecification.groovy
+++ b/utils/test-utils/src/main/groovy/datadog/trace/util/test/DDSpecification.groovy
@@ -14,9 +14,11 @@ import static net.bytebuddy.matcher.ElementMatchers.none
 
 abstract class DDSpecification extends Specification {
   private static final String CONFIG = "datadog.trace.api.Config"
+  private static final String CAPTURED_ENV = "datadog.trace.api.env.CapturedEnvironment"
 
   static {
     makeConfigInstanceModifiable()
+    cleanCapturedEnvironment()
   }
 
   // Keep track of config instance already made modifiable
@@ -44,5 +46,20 @@ abstract class DDSpecification extends Specification {
       }
       .installOn(instrumentation)
     isConfigInstanceModifiable = true
+  }
+
+  //Clean captured environment to avoid affecting Config settings with platform dependant properties.
+  static void cleanCapturedEnvironment() {
+    try {
+      def capturedEnvClass = this.getClassLoader().loadClass(CAPTURED_ENV)
+      def capturedEnvField = capturedEnvClass.getDeclaredField("INSTANCE")
+      capturedEnvField.setAccessible(true)
+
+      def propsField = capturedEnvClass.getDeclaredField("properties")
+      propsField.setAccessible(true)
+      propsField.set(capturedEnvField.get(null), new HashMap<String, String>())
+    } catch (final ClassNotFoundException ignored) {
+      //If CapturedEnvironment class is not found, no actions needed.
+    }
   }
 }

--- a/utils/test-utils/src/main/groovy/datadog/trace/util/test/DDSpecification.groovy
+++ b/utils/test-utils/src/main/groovy/datadog/trace/util/test/DDSpecification.groovy
@@ -18,7 +18,7 @@ abstract class DDSpecification extends Specification {
 
   static {
     makeConfigInstanceModifiable()
-    cleanCapturedEnvironment()
+    //cleanCapturedEnvironment()
   }
 
   // Keep track of config instance already made modifiable

--- a/utils/test-utils/src/main/groovy/datadog/trace/util/test/DDSpecification.groovy
+++ b/utils/test-utils/src/main/groovy/datadog/trace/util/test/DDSpecification.groovy
@@ -14,11 +14,9 @@ import static net.bytebuddy.matcher.ElementMatchers.none
 
 abstract class DDSpecification extends Specification {
   private static final String CONFIG = "datadog.trace.api.Config"
-  private static final String CAPTURED_ENV = "datadog.trace.api.env.CapturedEnvironment"
 
   static {
     makeConfigInstanceModifiable()
-    //cleanCapturedEnvironment()
   }
 
   // Keep track of config instance already made modifiable
@@ -46,20 +44,5 @@ abstract class DDSpecification extends Specification {
       }
       .installOn(instrumentation)
     isConfigInstanceModifiable = true
-  }
-
-  //Clean captured environment to avoid affecting Config settings with platform dependant properties.
-  static void cleanCapturedEnvironment() {
-    try {
-      def capturedEnvClass = this.getClassLoader().loadClass(CAPTURED_ENV)
-      def capturedEnvField = capturedEnvClass.getDeclaredField("INSTANCE")
-      capturedEnvField.setAccessible(true)
-
-      def propsField = capturedEnvClass.getDeclaredField("properties")
-      propsField.setAccessible(true)
-      propsField.set(capturedEnvField.get(null), new HashMap<String, String>())
-    } catch (final ClassNotFoundException ignored) {
-      //If CapturedEnvironment class is not found, no actions needed.
-    }
   }
 }


### PR DESCRIPTION
Reverts DataDog/dd-trace-java#1663

Was originally reverted because we suspected it as the problem for the build instability.  We've identified the source of the problem, so this can be added back in.