### PR TITLE
Fix multi-threaded classloading of DataDog agent classes

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/DatadogClassLoader.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/DatadogClassLoader.java
@@ -68,8 +68,10 @@ public class DatadogClassLoader extends URLClassLoader {
 
   Class<?> loadFromPackage(String packageName, String name) throws ClassNotFoundException {
     if (internalJarURLHandler.getPackages().contains(packageName)) {
-      Class<?> loaded = findLoadedClass(name);
-      return null == loaded ? findClass(name) : loaded;
+      synchronized (this) {
+        Class<?> loaded = findLoadedClass(name);
+        return null == loaded ? findClass(name) : loaded;
+      }
     }
     return super.loadClass(name);
   }
@@ -157,8 +159,10 @@ public class DatadogClassLoader extends URLClassLoader {
     protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
       String packageName = shared.getPackageName(name);
       if (internalJarURLHandler.getPackages().contains(packageName)) {
-        Class<?> loaded = findLoadedClass(name);
-        return null == loaded ? findClass(name) : loaded;
+        synchronized (this) {
+          Class<?> loaded = findLoadedClass(name);
+          return null == loaded ? findClass(name) : loaded;
+        }
       }
       return shared.loadFromPackage(packageName, name);
     }


### PR DESCRIPTION
Since the introduction of the `DelegateClassloader` in `DatadogClassLoader` and the associated refactoring this entailed, the Datadog classloader has been susceptible to a race condition when multiple threads are initialised and attempt to load DataDog agent classes as the same time. This is due to the `loadFromPackage` in `DatadogClassLoader` and `loadClass` in `DelegateClassLoader` both un-synchronized calls to `findLoadedClass` and then `findClass` if this first call returns `null`. As repeated call to `findClass` cause the JVM to throw a `LinkageError` due to the attempt to define a class with the same fully-qualified name more than once, this race condition results in the affected threads failing to initialise.

To overcome this, the two impacted methods have both had `synchronization` blocks added around the checks for whether the class has been loaded and the subsequent attempt to load it. To ensure any performance impact of this change is limited, the additional synchronization is performed inside the checks as to whether a package from the DataDog agent JAR is being loaded, so that only DataDog agent classes will incur the additional synchronization overhead.

Since there is no easy way of forcing two threads to race to the point where they've both completed the class existence check and are about to try and load the class, the test cases take a brute-force approach of making the classloader believe the class has never been loaded and then making multiple threads all attempt to load the same class. This gives a high probability that two or more threads will trigger the failure condition rather than a fail-safe check.