### PR TITLE
Add DD tags to log instrumentations

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/HelperInjector.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/HelperInjector.java
@@ -204,6 +204,9 @@ public class HelperInjector implements Transformer {
     final boolean deleted = file.delete();
     if (!deleted) {
       file.deleteOnExit();
+      log.debug("file '{}' added to shutdown delete hook", file);
+    } else {
+      log.debug("file '{}' deleted", file);
     }
   }
 }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/AdditionalLibraryIgnoresMatcher.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/AdditionalLibraryIgnoresMatcher.java
@@ -203,6 +203,10 @@ public class AdditionalLibraryIgnoresMatcher<T extends TypeDescription>
       if (name.equals("ch.qos.logback.core.AsyncAppenderBase$Worker")) {
         return false;
       }
+      // for inserting service, env, version in MDC of every thread
+      if (name.equals("ch.qos.logback.classic.util.LogbackMDCAdapter")) {
+        return false;
+      }
 
       return true;
     }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/log/LogContextScopeListener.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/log/LogContextScopeListener.java
@@ -2,9 +2,15 @@ package datadog.trace.agent.tooling.log;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 
+import datadog.trace.api.Config;
 import datadog.trace.api.CorrelationIdentifier;
+import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.context.ScopeListener;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -48,6 +54,36 @@ public class LogContextScopeListener implements ScopeListener {
       removeMethod.invoke(null, CorrelationIdentifier.getSpanIdKey());
     } catch (final Exception e) {
       log.debug("Exception removing log context context", e);
+    }
+  }
+
+  static final Map<String, String> LOG_CONTEXT_DD_TAGS;
+
+  static {
+    Map<String, String> logContextDDTags = new HashMap<>();
+    logContextDDTags.put(Tags.DD_SERVICE, Config.get().getServiceName());
+    final Map<String, String> mergedSpanTags = Config.get().getMergedSpanTags();
+    String version = "";
+    String env = "";
+    if (mergedSpanTags != null) {
+      version = mergedSpanTags.get("version");
+      if (version == null) {
+        version = "";
+      }
+      env = mergedSpanTags.get("env");
+      if (env == null) {
+        env = "";
+      }
+    }
+    logContextDDTags.put(Tags.DD_VERSION, version);
+    logContextDDTags.put(Tags.DD_ENV, env);
+    LOG_CONTEXT_DD_TAGS = Collections.unmodifiableMap(logContextDDTags);
+  }
+
+  public static void addDDTagsToMDC(final Method putMethod)
+      throws InvocationTargetException, IllegalAccessException {
+    for (final Map.Entry<String, String> e : LOG_CONTEXT_DD_TAGS.entrySet()) {
+      putMethod.invoke(null, e.getKey(), e.getValue());
     }
   }
 }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/log/ThreadLocalWithDDTagsInitValue.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/log/ThreadLocalWithDDTagsInitValue.java
@@ -1,0 +1,97 @@
+package datadog.trace.agent.tooling.log;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * @param <T> something like String to String map. DD tags will be injected in T only if T is
+ *     instance of Map, or has T#put(String, Object) method, or putValue(String, Object) method.
+ */
+@Slf4j
+public class ThreadLocalWithDDTagsInitValue<T> extends ThreadLocal<T> {
+  private static final String[] PUT_METHODS_POSSIBLE_NAMES_IN_ORDER =
+      new String[] {"put", "putValue"};
+
+  private static Method findMethodWithName(final Method[] methods, final String methodName) {
+    for (final Method method : methods) {
+      if (method.getName().equals(methodName)) {
+        return method;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * try to find method with name in {@param methods} in order of names listed in {@param
+   * methodNames}
+   */
+  private static Method findMethodWithNamesByOrder(
+      final Method[] methods, final String[] methodNames) {
+    for (final String methodName : methodNames) {
+      final Method method = findMethodWithName(methods, methodName);
+      if (method != null) {
+        return method;
+      }
+    }
+    return null;
+  }
+
+  private static <T> T putToMap(final T stringToObjMap, final Map<String, ?> whatToPut)
+      throws InvocationTargetException, IllegalAccessException {
+    if (stringToObjMap instanceof Map) {
+      ((Map) stringToObjMap).putAll(whatToPut);
+    } else {
+      final Class<?> cl = stringToObjMap.getClass();
+      final Method[] methods = cl.getDeclaredMethods();
+      final Method method =
+          findMethodWithNamesByOrder(methods, PUT_METHODS_POSSIBLE_NAMES_IN_ORDER);
+      if (method != null) {
+        final Class<?>[] parameterTypes = method.getParameterTypes();
+        if (parameterTypes.length != 2 || !String.class.equals(parameterTypes[0])) {
+          log.warn(
+              "Can't find a way how to add DD tags to '{}'; was trying to use {}, "
+                  + "but didn't like it's signature",
+              stringToObjMap,
+              method);
+          return null;
+        }
+        method.setAccessible(true);
+        for (final Map.Entry<String, ?> entry : whatToPut.entrySet()) {
+          method.invoke(stringToObjMap, entry.getKey(), entry.getValue());
+        }
+      } else {
+        log.warn("Can't find a method how to add DD tags to '{}'", stringToObjMap);
+        return null;
+      }
+    }
+    return stringToObjMap;
+  }
+
+  public static <T> ThreadLocal<T> create(T origThreadLocalValue)
+      throws InvocationTargetException, IllegalAccessException {
+    if (origThreadLocalValue instanceof Map) {
+      ((Map) origThreadLocalValue).putAll(LogContextScopeListener.LOG_CONTEXT_DD_TAGS);
+    } else {
+      putToMap(origThreadLocalValue, LogContextScopeListener.LOG_CONTEXT_DD_TAGS);
+    }
+    return new ThreadLocalWithDDTagsInitValue<>(origThreadLocalValue);
+  }
+
+  private final T initValue;
+
+  private ThreadLocalWithDDTagsInitValue() {
+    log.warn("This constructor should never be called");
+    initValue = null;
+  }
+
+  private ThreadLocalWithDDTagsInitValue(final T initValue) {
+    this.initValue = initValue;
+  }
+
+  @Override
+  protected T initialValue() {
+    return initValue;
+  }
+}

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/test/ClassLoaderMatcherTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/test/ClassLoaderMatcherTest.groovy
@@ -1,6 +1,8 @@
 package datadog.trace.agent.test
 
 import datadog.trace.agent.tooling.ClassLoaderMatcher
+import datadog.trace.agent.tooling.log.LogContextScopeListener
+import datadog.trace.agent.tooling.log.ThreadLocalWithDDTagsInitValue
 import datadog.trace.bootstrap.DatadogClassLoader
 import datadog.trace.util.test.DDSpecification
 
@@ -36,6 +38,12 @@ class ClassLoaderMatcherTest extends DDSpecification {
   def "DatadogClassLoader class name is hardcoded in ClassLoaderMatcher"() {
     expect:
     DatadogClassLoader.name == "datadog.trace.bootstrap.DatadogClassLoader"
+  }
+
+  def "helper class names are hardcoded in Log Instrumentations"() {
+    expect:
+    LogContextScopeListener.name == "datadog.trace.agent.tooling.log.LogContextScopeListener"
+    ThreadLocalWithDDTagsInitValue.name == "datadog.trace.agent.tooling.log.ThreadLocalWithDDTagsInitValue"
   }
 
   /*

--- a/dd-java-agent/instrumentation/log4j1/src/main/java/datadog/trace/instrumentation/log4j1/Log4j1MDCInstrumentation.java
+++ b/dd-java-agent/instrumentation/log4j1/src/main/java/datadog/trace/instrumentation/log4j1/Log4j1MDCInstrumentation.java
@@ -1,7 +1,7 @@
 package datadog.trace.instrumentation.log4j1;
 
 import static java.util.Collections.singletonMap;
-import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
+import static net.bytebuddy.matcher.ElementMatchers.isTypeInitializer;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 
 import com.google.auto.service.AutoService;
@@ -9,6 +9,7 @@ import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.log.LogContextScopeListener;
 import datadog.trace.api.Config;
 import datadog.trace.api.GlobalTracer;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
@@ -37,7 +38,7 @@ public class Log4j1MDCInstrumentation extends Instrumenter.Default {
   @Override
   public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
     return singletonMap(
-        isConstructor(), Log4j1MDCInstrumentation.class.getName() + "$MDCContextAdvice");
+        isTypeInitializer(), Log4j1MDCInstrumentation.class.getName() + "$MDCContextAdvice");
   }
 
   @Override
@@ -47,18 +48,16 @@ public class Log4j1MDCInstrumentation extends Instrumenter.Default {
 
   public static class MDCContextAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
-    public static void mdcClassInitialized(@Advice.This Object instance) {
-      if (instance == null) {
-        return;
-      }
-
+    public static void mdcClassInitialized(@Advice.Origin final Class<?> mdcClass) {
       try {
-        Class<?> mdcClass = instance.getClass();
         final Method putMethod = mdcClass.getMethod("put", String.class, Object.class);
         final Method removeMethod = mdcClass.getMethod("remove", String.class);
         GlobalTracer.get().addScopeListener(new LogContextScopeListener(putMethod, removeMethod));
-      } catch (final NoSuchMethodException e) {
-        org.slf4j.LoggerFactory.getLogger(instance.getClass())
+        // log4j1 uses subclass of InheritableThreadLocal and we don't need to modify private thread
+        // local field:
+        LogContextScopeListener.addDDTagsToMDC(putMethod);
+      } catch (final NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
+        org.slf4j.LoggerFactory.getLogger(mdcClass)
             .debug("Failed to add log4j ThreadContext span listener", e);
       }
     }

--- a/dd-java-agent/instrumentation/log4j1/src/test/groovy/Log4j1MDCTest.groovy
+++ b/dd-java-agent/instrumentation/log4j1/src/test/groovy/Log4j1MDCTest.groovy
@@ -19,4 +19,15 @@ class Log4j1MDCTest extends LogContextInjectionTestBase {
   def get(String key) {
     return MDC.get(key)
   }
+
+  @Override
+  def remove(String key) {
+    MDC.context
+    return MDC.remove(key)
+  }
+
+  @Override
+  def clear() {
+    return MDC.clear()
+  }
 }

--- a/dd-java-agent/instrumentation/log4j2/src/main/java/datadog/trace/instrumentation/log4j2/ThreadContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/log4j2/src/main/java/datadog/trace/instrumentation/log4j2/ThreadContextInstrumentation.java
@@ -7,9 +7,13 @@ import static net.bytebuddy.matcher.ElementMatchers.named;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.log.LogContextScopeListener;
+import datadog.trace.agent.tooling.log.ThreadLocalWithDDTagsInitValue;
 import datadog.trace.api.Config;
 import datadog.trace.api.GlobalTracer;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.HashMap;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.method.MethodDescription;
@@ -18,7 +22,8 @@ import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(Instrumenter.class)
 public class ThreadContextInstrumentation extends Instrumenter.Default {
-  public static final String MDC_INSTRUMENTATION_NAME = "log4j";
+  private static final String TYPE_NAME = "org.apache.logging.log4j.ThreadContext";
+  private static final String MDC_INSTRUMENTATION_NAME = "log4j";
 
   public ThreadContextInstrumentation() {
     super(MDC_INSTRUMENTATION_NAME);
@@ -31,7 +36,7 @@ public class ThreadContextInstrumentation extends Instrumenter.Default {
 
   @Override
   public ElementMatcher<? super TypeDescription> typeMatcher() {
-    return named("org.apache.logging.log4j.ThreadContext");
+    return named(TYPE_NAME);
   }
 
   @Override
@@ -42,19 +47,83 @@ public class ThreadContextInstrumentation extends Instrumenter.Default {
 
   @Override
   public String[] helperClassNames() {
-    return new String[] {"datadog.trace.agent.tooling.log.LogContextScopeListener"};
+    return new String[] {
+      "datadog.trace.agent.tooling.log.LogContextScopeListener",
+      "datadog.trace.agent.tooling.log.ThreadLocalWithDDTagsInitValue",
+    };
   }
 
   public static class ThreadContextAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
-    public static void mdcClassInitialized(@Advice.Origin final Class threadClass) {
+    public static void mdcClassInitialized(@Advice.Origin final Class<?> threadContextClass) {
       try {
-        final Method putMethod = threadClass.getMethod("put", String.class, String.class);
-        final Method removeMethod = threadClass.getMethod("remove", String.class);
+        final Method putMethod = threadContextClass.getMethod("put", String.class, String.class);
+        final Method removeMethod = threadContextClass.getMethod("remove", String.class);
         GlobalTracer.get().addScopeListener(new LogContextScopeListener(putMethod, removeMethod));
-      } catch (final NoSuchMethodException e) {
-        org.slf4j.LoggerFactory.getLogger(threadClass)
+
+        final Field contextMapField = threadContextClass.getDeclaredField("contextMap");
+        contextMapField.setAccessible(true);
+        final Object contextMap = contextMapField.get(null);
+        if (contextMap
+            .getClass()
+            .getCanonicalName()
+            .equals("org.apache.logging.slf4j.MDCContextMap")) {
+          org.slf4j.LoggerFactory.getLogger(threadContextClass)
+              .debug(
+                  "Log4j to SLF4J Adapter detected. "
+                      + TYPE_NAME
+                      + "'s ThreadLocal"
+                      + " field will not be instrumented because it delegates to slf4-MDC");
+          return;
+        }
+        final Field localMapField = contextMap.getClass().getDeclaredField("localMap");
+        if (!ThreadLocal.class.isAssignableFrom(localMapField.getType())) {
+          org.slf4j.LoggerFactory.getLogger(threadContextClass)
+              .debug("Can't find thread local field: {}", localMapField);
+          return;
+        }
+
+        localMapField.setAccessible(true);
+        final Object threadLocalInitValue = ((ThreadLocal) localMapField.get(contextMap)).get();
+        final String fullTypeWithGeneric = localMapField.getGenericType().toString();
+        if ("java.lang.ThreadLocal<java.util.Map<java.lang.String, java.lang.String>>"
+            .equals(fullTypeWithGeneric)) {
+          final Map<String, String> threadLocalInitValueAsMap =
+              threadLocalInitValue != null
+                  ? (Map<String, String>) threadLocalInitValue
+                  : new HashMap<String, String>();
+          org.slf4j.LoggerFactory.getLogger(threadContextClass)
+              .debug("Setting {} for ThreadLocalWithDDTagsInitValue ", threadLocalInitValueAsMap);
+          localMapField.set(
+              contextMap, ThreadLocalWithDDTagsInitValue.create(threadLocalInitValueAsMap));
+        } else if ("java.lang.ThreadLocal<org.apache.logging.log4j.util.StringMap>"
+            .equals(fullTypeWithGeneric)) {
+          final Object threadLocalInitValueAsStringMap =
+              threadLocalInitValue != null
+                  ? threadLocalInitValue
+                  : Class.forName("org.apache.logging.log4j.util.SortedArrayStringMap")
+                      .newInstance();
+          org.slf4j.LoggerFactory.getLogger(threadContextClass)
+              .debug(
+                  "Setting {} for ThreadLocalWithDDTagsInitValue ",
+                  threadLocalInitValueAsStringMap);
+          localMapField.set(
+              contextMap, ThreadLocalWithDDTagsInitValue.create(threadLocalInitValueAsStringMap));
+        } else {
+          org.slf4j.LoggerFactory.getLogger(threadContextClass)
+              .warn(
+                  "can't find thread local for {}; skipping adding extra tags",
+                  fullTypeWithGeneric);
+        }
+      } catch (final NoSuchMethodException
+          | NoSuchFieldException
+          | IllegalAccessException
+          | InvocationTargetException e) {
+        org.slf4j.LoggerFactory.getLogger(threadContextClass)
             .debug("Failed to add log4j ThreadContext span listener", e);
+      } catch (final Throwable t) {
+        org.slf4j.LoggerFactory.getLogger(threadContextClass)
+            .debug("Unexpected exception while adding log4j ThreadContext span listener", t);
       }
     }
   }

--- a/dd-java-agent/instrumentation/log4j2/src/test/groovy/Log4jThreadContextTest.groovy
+++ b/dd-java-agent/instrumentation/log4j2/src/test/groovy/Log4jThreadContextTest.groovy
@@ -12,4 +12,14 @@ class Log4jThreadContextTest extends LogContextInjectionTestBase {
   def get(String key) {
     return ThreadContext.get(key)
   }
+
+  @Override
+  def remove(String key) {
+    return ThreadContext.remove(key)
+  }
+
+  @Override
+  def clear() {
+    return ThreadContext.clearAll()
+  }
 }

--- a/dd-java-agent/instrumentation/log4j2/src/test/groovy/Log4jThreadContextWithEnableThreadLocalsTest.groovy
+++ b/dd-java-agent/instrumentation/log4j2/src/test/groovy/Log4jThreadContextWithEnableThreadLocalsTest.groovy
@@ -1,0 +1,11 @@
+import datadog.trace.agent.test.utils.UnsafeUtils
+
+class Log4jThreadContextWithEnableThreadLocalsTest extends Log4jThreadContextTest {
+  static {
+    //TODO: set ("log4j2.is.webapp" = "true") from "log4j2.component.properties" file instead of:
+    UnsafeUtils.setStaticField(
+      Class.forName("org.apache.logging.log4j.util.Constants")  .getField("ENABLE_THREADLOCALS"),
+      true
+    )
+  }
+}

--- a/dd-java-agent/instrumentation/slf4j-mdc/src/test/groovy/Slf4jMDCTest.groovy
+++ b/dd-java-agent/instrumentation/slf4j-mdc/src/test/groovy/Slf4jMDCTest.groovy
@@ -12,4 +12,14 @@ class Slf4jMDCTest extends LogContextInjectionTestBase {
   def get(String key) {
     return MDC.get(key)
   }
+
+  @Override
+  def remove(String key) {
+    return MDC.remove(key)
+  }
+
+  @Override
+  def clear() {
+    return MDC.clear()
+  }
 }

--- a/dd-java-agent/src/main/java/datadog/trace/bootstrap/AgentBootstrap.java
+++ b/dd-java-agent/src/main/java/datadog/trace/bootstrap/AgentBootstrap.java
@@ -5,7 +5,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.lang.instrument.Instrumentation;
-import java.lang.invoke.MethodHandles;
 import java.lang.management.ManagementFactory;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -40,8 +39,8 @@ import java.util.regex.Pattern;
  *   <li>Do dot touch any logging facilities here so we can configure them later
  * </ul>
  */
-public class AgentBootstrap {
-  private static final Class<?> thisClass = MethodHandles.lookup().lookupClass();
+public final class AgentBootstrap {
+  private static final Class<?> thisClass = AgentBootstrap.class;
 
   public static void premain(final String agentArgs, final Instrumentation inst) {
     agentmain(agentArgs, inst);

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/log/injection/LogContextInjectionTestBase.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/log/injection/LogContextInjectionTestBase.groovy
@@ -5,9 +5,13 @@ import datadog.trace.agent.test.utils.ConfigUtils
 import datadog.trace.api.CorrelationIdentifier
 import datadog.trace.bootstrap.instrumentation.api.AgentScope
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan
+import datadog.trace.bootstrap.instrumentation.api.Tags
 
 import java.util.concurrent.atomic.AtomicReference
 
+import static datadog.trace.api.Config.PREFIX
+import static datadog.trace.api.ConfigDefaults.DEFAULT_SERVICE_NAME
+import static datadog.trace.api.config.GeneralConfig.TAGS
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan
 
@@ -16,6 +20,8 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan
  * satisfy in order to support log injection.
  */
 abstract class LogContextInjectionTestBase extends AgentTestRunner {
+  private static final TEST_ENV = "test"
+  private static final TEST_VERSION = "0.1"
 
   /**
    * Set in the framework-specific context the given value at the given key
@@ -27,9 +33,17 @@ abstract class LogContextInjectionTestBase extends AgentTestRunner {
    */
   abstract get(String key)
 
+  /**
+   * Remove from the framework-specific context the value at the given key
+   */
+  abstract remove(String key)
+
+  abstract clear()
+
   static {
     ConfigUtils.updateConfig {
       System.setProperty("dd.logs.injection", "true")
+      System.setProperty(PREFIX + TAGS, "env:${TEST_ENV},version:${TEST_VERSION}")
     }
   }
 
@@ -43,6 +57,9 @@ abstract class LogContextInjectionTestBase extends AgentTestRunner {
     get(CorrelationIdentifier.getTraceIdKey()) == CorrelationIdentifier.getTraceId()
     get(CorrelationIdentifier.getSpanIdKey()) == CorrelationIdentifier.getSpanId()
     get("foo") == "bar"
+    get(Tags.DD_SERVICE) == DEFAULT_SERVICE_NAME
+    get(Tags.DD_VERSION) == TEST_VERSION
+    get(Tags.DD_ENV) == TEST_ENV
 
     when:
     AgentSpan childSpan = startSpan("child")
@@ -52,6 +69,9 @@ abstract class LogContextInjectionTestBase extends AgentTestRunner {
     get(CorrelationIdentifier.getTraceIdKey()) == CorrelationIdentifier.getTraceId()
     get(CorrelationIdentifier.getSpanIdKey()) == CorrelationIdentifier.getSpanId()
     get("foo") == "bar"
+    get(Tags.DD_SERVICE) == DEFAULT_SERVICE_NAME
+    get(Tags.DD_VERSION) == TEST_VERSION
+    get(Tags.DD_ENV) == TEST_ENV
 
     when:
     childScope.close()
@@ -61,6 +81,9 @@ abstract class LogContextInjectionTestBase extends AgentTestRunner {
     get(CorrelationIdentifier.getTraceIdKey()) == CorrelationIdentifier.getTraceId()
     get(CorrelationIdentifier.getSpanIdKey()) == CorrelationIdentifier.getSpanId()
     get("foo") == "bar"
+    get(Tags.DD_SERVICE) == DEFAULT_SERVICE_NAME
+    get(Tags.DD_VERSION) == TEST_VERSION
+    get(Tags.DD_ENV) == TEST_ENV
 
     when:
     rootScope.close()
@@ -70,27 +93,40 @@ abstract class LogContextInjectionTestBase extends AgentTestRunner {
     get(CorrelationIdentifier.getTraceIdKey()) == null
     get(CorrelationIdentifier.getSpanIdKey()) == null
     get("foo") == "bar"
+    get(Tags.DD_SERVICE) == DEFAULT_SERVICE_NAME
+    get(Tags.DD_VERSION) == TEST_VERSION
+    get(Tags.DD_ENV) == TEST_ENV
   }
 
   def "Log context is scoped by thread"() {
-    setup:
-    ConfigUtils.updateConfig {
-      System.setProperty("dd.logs.injection", "true")
-    }
     AtomicReference<String> thread1TraceId = new AtomicReference<>()
     AtomicReference<String> thread2TraceId = new AtomicReference<>()
+    def t1VersionBeg
+    def t1VersionEnd
+    def t2VersionBeg
+    def t2VersionEnd
+    def t1EnvBeg
+    def t1EnvEnd
+    def t2EnvBeg
+    def t2EnvEnd
 
     final Thread thread1 = new Thread() {
       @Override
       void run() {
+        t1VersionBeg = get(Tags.DD_VERSION)
+        t1EnvBeg = get(Tags.DD_ENV)
         // no trace in scope
         thread1TraceId.set(get(CorrelationIdentifier.getTraceIdKey()))
+        t1VersionEnd = get(Tags.DD_VERSION)
+        t1EnvEnd = get(Tags.DD_ENV)
       }
     }
 
     final Thread thread2 = new Thread() {
       @Override
       void run() {
+        t2VersionBeg = get(Tags.DD_VERSION)
+        t2EnvBeg = get(Tags.DD_ENV)
         // other trace in scope
         final AgentSpan thread2Span = startSpan("root2")
         final AgentScope thread2Scope = activateSpan(thread2Span)
@@ -100,6 +136,8 @@ abstract class LogContextInjectionTestBase extends AgentTestRunner {
           thread2Scope.close()
           thread2Span.finish()
         }
+        t2VersionEnd = get(Tags.DD_VERSION)
+        t2EnvEnd = get(Tags.DD_ENV)
       }
     }
     final AgentSpan mainSpan = startSpan("root")
@@ -117,9 +155,90 @@ abstract class LogContextInjectionTestBase extends AgentTestRunner {
     thread1TraceId.get() == null
     thread2TraceId.get() != null
     thread2TraceId.get() != mainThreadTraceId
+    get(Tags.DD_SERVICE) == DEFAULT_SERVICE_NAME
+    get(Tags.DD_VERSION) == TEST_VERSION
+    get(Tags.DD_ENV) == TEST_ENV
+    t1VersionBeg == TEST_VERSION
+    t1VersionEnd == TEST_VERSION
+    t2VersionBeg == TEST_VERSION
+    t2VersionEnd == TEST_VERSION
+    t1EnvBeg == TEST_ENV
+    t1EnvEnd == TEST_ENV
+    t2EnvBeg == TEST_ENV
+    t2EnvEnd == TEST_ENV
 
     cleanup:
     mainScope?.close()
     mainSpan?.finish()
+  }
+
+  def "always log service, version, env"() {
+    def mainThreadVersion = get(Tags.DD_VERSION)
+    def t1threadNameBeg
+    def t1threadNameEnd
+    def t1VersionBeg
+    def t1VersionEnd
+    def t1EnvBeg
+    def t1EnvEnd
+
+    final Thread thread1 = new Thread() {
+      @Override
+      void run() {
+        t1VersionBeg = get(Tags.DD_VERSION)
+        t1EnvBeg = get(Tags.DD_ENV)
+        put("threadName", currentThread().getName())
+
+        println("something: " + this)
+
+        t1threadNameBeg = get("threadName")
+        remove("threadName")
+
+        t1threadNameEnd =  get("threadName")
+        t1VersionEnd = get(Tags.DD_VERSION)
+        t1EnvEnd = get(Tags.DD_ENV)
+
+        remove(Tags.DD_VERSION)
+        remove(Tags.DD_ENV)
+      }
+    }
+    thread1.setName("thread1")
+    thread1.start()
+    put("threadName", Thread.currentThread().getName())
+    def mainThreadNameBeg = get("threadName")
+    remove("threadName")
+    def mainThreadNameEnd = get("threadName")
+
+    thread1.join()
+
+    expect:
+    mainThreadVersion == get(Tags.DD_VERSION)
+    get(Tags.DD_SERVICE) == DEFAULT_SERVICE_NAME
+    get(Tags.DD_VERSION) == TEST_VERSION
+    get(Tags.DD_ENV) == TEST_ENV
+    t1VersionBeg == TEST_VERSION
+    t1VersionEnd == TEST_VERSION
+    t1EnvBeg == TEST_ENV
+    t1EnvEnd == TEST_ENV
+    t1threadNameBeg == "thread1"
+    mainThreadNameBeg != t1threadNameBeg
+    t1threadNameEnd == null
+    mainThreadNameEnd == null
+  }
+
+  def "modify thread context after clear of context map at the beginning of new thread"() {
+    def t1A
+    final Thread thread1 = new Thread() {
+      @Override
+      void run() {
+        clear()
+        put("a", "a thread1")
+        t1A = get("a")
+      }
+    }
+    thread1.start()
+    thread1.join()
+
+    expect:
+    t1A == "a thread1"
   }
 }

--- a/dd-java-agent/testing/src/main/java/datadog/trace/agent/test/utils/UnsafeUtils.java
+++ b/dd-java-agent/testing/src/main/java/datadog/trace/agent/test/utils/UnsafeUtils.java
@@ -1,0 +1,48 @@
+package datadog.trace.agent.test.utils;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+
+public class UnsafeUtils {
+  private UnsafeUtils() {}
+
+  public static final int JAVA_VERSION = getJavaVersion();
+
+  private static int getJavaVersion() {
+    final String javaVersion = System.getProperty("java.version", "0.");
+    final int beg = javaVersion.startsWith("1.") ? 2 : 0;
+    final int end = javaVersion.indexOf('.', beg);
+    return Integer.parseInt(javaVersion.substring(beg, end));
+  }
+
+  private static void setStaticFieldViaUnsafe(final Field field, final Object newValue)
+      throws Exception {
+    final Field unsafeField = sun.misc.Unsafe.class.getDeclaredField("theUnsafe");
+    unsafeField.setAccessible(true);
+    final sun.misc.Unsafe unsafe = (sun.misc.Unsafe) unsafeField.get(null);
+
+    final Object staticFieldBase = unsafe.staticFieldBase(field);
+    final long staticFieldOffset = unsafe.staticFieldOffset(field);
+    unsafe.putObject(staticFieldBase, staticFieldOffset, newValue);
+  }
+
+  private static void setStaticFieldViaReflection(final Field field, final Object newValue)
+      throws Exception {
+    field.setAccessible(true);
+    final Field modifiersField = Field.class.getDeclaredField("modifiers");
+    modifiersField.setAccessible(true);
+    final int origModifiers = field.getModifiers();
+    modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
+    field.set(null, newValue);
+    modifiersField.setInt(field, origModifiers);
+  }
+
+  public static void setStaticField(final Field field, final Object newValue) throws Exception {
+    if (JAVA_VERSION < 12) {
+      setStaticFieldViaReflection(field, newValue);
+    } else {
+      // since 12 we can't use reflection: http://hg.openjdk.java.net/jdk/jdk/rev/f55a4bc91ef4
+      setStaticFieldViaUnsafe(field, newValue);
+    }
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/Tags.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/Tags.java
@@ -25,4 +25,8 @@ public class Tags {
   public static final String DB_USER = "db.user";
   public static final String DB_STATEMENT = "db.statement";
   public static final String MESSAGE_BUS_DESTINATION = "message_bus.destination";
+
+  public static final String DD_SERVICE = "dd.service";
+  public static final String DD_VERSION = "dd.version";
+  public static final String DD_ENV = "dd.env";
 }


### PR DESCRIPTION
1. revert of this revert : https://github.com/DataDog/dd-trace-java/pull/1662revert of this revert : https://github.com/DataDog/dd-trace-java/pull/1662
1. fix for https://github.com/DataDog/dd-trace-java/issues/1654 and test for it: 

The issue https://github.com/DataDog/dd-trace-java/issues/1654 was introduced after instrumentation of log4j2. Original instrumentation assumed that interface ThreadContextMap always contains threadlocal field with instance of Map in generic parameter.
```
ThreadLocal<Map<?, ?>> localMap
```

In fact, log4j2 has 2 other implementations ( [CopyOnWriteSortedArrayThreadContextMap](https://github.com/apache/logging-log4j2/blob/master/log4j-api/src/main/java/org/apache/logging/log4j/spi/CopyOnWriteSortedArrayThreadContextMap.java) , [GarbageFreeSortedArrayThreadContextMap](https://github.com/apache/logging-log4j2/blob/master/log4j-api/src/main/java/org/apache/logging/log4j/spi/GarbageFreeSortedArrayThreadContextMap.java)  ) which contains  StringMap in generic parameter:
```
ThreadLocal<org.apache.logging.log4j.util.StringMap> localMap
```
And this org.apache.logging.log4j.util.StringMap is not instance of java.util.Map. And It was causing ClassCastException in https://github.com/DataDog/dd-trace-java/issues/1654 .


As a solution in this changeset class [ThreadLocalWithDDTagsInitValue<T> extends ThreadLocal<T>](https://github.com/DataDog/dd-trace-java/pull/1688/files#diff-c0f391488f8a9b254794c9f452e9756fR13) has also generic parameter, which will contain "Map-like" type of instrumented implementation. "Map-like" property means method  [ThreadLocalWithDDTagsInitValue#putToMap](https://github.com/DataDog/dd-trace-java/pull/1688/files#diff-c0f391488f8a9b254794c9f452e9756fR41) looks for the way how to "put" datadog key/values in the instance of this type by following  [duck typing](https://en.wikipedia.org/wiki/Duck_typing) scenario:
1. if this type is instance of Map, then use Map#put(String,String) method. If Not
1. if this type has `put(String, ?)` method then use it. If not
1. if this type has `putValue(String, ?)` method then use it. If not
1. skip insertion of DD tags with WARN log message



Regression test [Log4jThreadContextWithEnableThreadLocalsTest](  https://github.com/DataDog/dd-trace-java/pull/1688/files#diff-024eafb70a73f1931f9ec01bcd0e9992R7 ) for this issue, modifies static final field to ensure log4j2 uses org.apache.logging.log4j.util.StringMap.


