### PR TITLE
break circular dependency between Config and ConfigDefaults

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/Config.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/Config.java
@@ -238,12 +238,6 @@ public class Config {
   private static final Pattern ENV_REPLACEMENT = Pattern.compile("[^a-zA-Z0-9_]");
   private static final String SPLIT_BY_SPACE_OR_COMMA_REGEX = "[,\\s]+";
 
-  public enum PropagationStyle {
-    DATADOG,
-    B3,
-    HAYSTACK
-  }
-
   /** Used for masking sensitive information when doing toString */
   @ToString.Include(name = "apiKey")
   private String profilingApiKeyMasker() {

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -1,10 +1,18 @@
 package datadog.trace.api;
 
-import static datadog.trace.api.Config.parseIntegerRangeSet;
-
 import java.util.BitSet;
 
 public final class ConfigDefaults {
+
+  static final BitSet DEFAULT_HTTP_SERVER_ERROR_STATUSES;
+  static final BitSet DEFAULT_HTTP_CLIENT_ERROR_STATUSES;
+
+  static {
+    DEFAULT_HTTP_SERVER_ERROR_STATUSES = new BitSet();
+    DEFAULT_HTTP_SERVER_ERROR_STATUSES.set(500, 600);
+    DEFAULT_HTTP_CLIENT_ERROR_STATUSES = new BitSet();
+    DEFAULT_HTTP_CLIENT_ERROR_STATUSES.set(400, 500);
+  }
 
   /* These fields are made public because they're referenced elsewhere internally.  They're not intended as public API. */
   public static final String DEFAULT_AGENT_HOST = "localhost";
@@ -23,10 +31,6 @@ public final class ConfigDefaults {
 
   static final boolean DEFAULT_PRIORITY_SAMPLING_ENABLED = true;
   static final boolean DEFAULT_TRACE_RESOLVER_ENABLED = true;
-  static final BitSet DEFAULT_HTTP_SERVER_ERROR_STATUSES =
-      parseIntegerRangeSet("500-599", "default");
-  static final BitSet DEFAULT_HTTP_CLIENT_ERROR_STATUSES =
-      parseIntegerRangeSet("400-499", "default");
   static final boolean DEFAULT_HTTP_SERVER_TAG_QUERY_STRING = false;
   static final boolean DEFAULT_HTTP_CLIENT_TAG_QUERY_STRING = false;
   static final boolean DEFAULT_HTTP_CLIENT_SPLIT_BY_DOMAIN = false;

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -38,8 +38,8 @@ public final class ConfigDefaults {
   static final String DEFAULT_SPLIT_BY_TAGS = "";
   static final int DEFAULT_SCOPE_DEPTH_LIMIT = 100;
   static final int DEFAULT_PARTIAL_FLUSH_MIN_SPANS = 1000;
-  static final String DEFAULT_PROPAGATION_STYLE_EXTRACT = Config.PropagationStyle.DATADOG.name();
-  static final String DEFAULT_PROPAGATION_STYLE_INJECT = Config.PropagationStyle.DATADOG.name();
+  static final String DEFAULT_PROPAGATION_STYLE_EXTRACT = PropagationStyle.DATADOG.name();
+  static final String DEFAULT_PROPAGATION_STYLE_INJECT = PropagationStyle.DATADOG.name();
   static final boolean DEFAULT_JMX_FETCH_ENABLED = true;
 
   static final int DEFAULT_JMX_FETCH_STATSD_PORT = 8125;

--- a/dd-trace-api/src/main/java/datadog/trace/api/PropagationStyle.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/PropagationStyle.java
@@ -1,0 +1,7 @@
+package datadog.trace.api;
+
+public enum PropagationStyle {
+  DATADOG,
+  B3,
+  HAYSTACK
+}

--- a/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -139,8 +139,8 @@ class ConfigTest extends DDSpecification {
     config.partialFlushMinSpans == 1000
     config.reportHostName == false
     config.runtimeContextFieldInjection == true
-    config.propagationStylesToExtract.toList() == [Config.PropagationStyle.DATADOG]
-    config.propagationStylesToInject.toList() == [Config.PropagationStyle.DATADOG]
+    config.propagationStylesToExtract.toList() == [PropagationStyle.DATADOG]
+    config.propagationStylesToInject.toList() == [PropagationStyle.DATADOG]
     config.jmxFetchEnabled == true
     config.jmxFetchMetricsConfigs == []
     config.jmxFetchCheckPeriod == null
@@ -264,8 +264,8 @@ class ConfigTest extends DDSpecification {
     config.partialFlushMinSpans == 15
     config.reportHostName == true
     config.runtimeContextFieldInjection == false
-    config.propagationStylesToExtract.toList() == [Config.PropagationStyle.DATADOG, Config.PropagationStyle.B3]
-    config.propagationStylesToInject.toList() == [Config.PropagationStyle.B3, Config.PropagationStyle.DATADOG]
+    config.propagationStylesToExtract.toList() == [PropagationStyle.DATADOG, PropagationStyle.B3]
+    config.propagationStylesToInject.toList() == [PropagationStyle.B3, PropagationStyle.DATADOG]
     config.jmxFetchEnabled == false
     config.jmxFetchMetricsConfigs == ["/foo.yaml", "/bar.yaml"]
     config.jmxFetchCheckPeriod == 100
@@ -384,8 +384,8 @@ class ConfigTest extends DDSpecification {
     config.partialFlushMinSpans == 25
     config.reportHostName == true
     config.runtimeContextFieldInjection == false
-    config.propagationStylesToExtract.toList() == [Config.PropagationStyle.DATADOG, Config.PropagationStyle.B3]
-    config.propagationStylesToInject.toList() == [Config.PropagationStyle.B3, Config.PropagationStyle.DATADOG]
+    config.propagationStylesToExtract.toList() == [PropagationStyle.DATADOG, PropagationStyle.B3]
+    config.propagationStylesToInject.toList() == [PropagationStyle.B3, PropagationStyle.DATADOG]
     config.jmxFetchEnabled == false
     config.jmxFetchMetricsConfigs == ["/foo.yaml", "/bar.yaml"]
     config.jmxFetchCheckPeriod == 100
@@ -438,8 +438,8 @@ class ConfigTest extends DDSpecification {
     config.serviceName == "still something else"
     config.traceEnabled == false
     config.writerType == "LoggingWriter"
-    config.propagationStylesToExtract.toList() == [Config.PropagationStyle.B3, Config.PropagationStyle.DATADOG]
-    config.propagationStylesToInject.toList() == [Config.PropagationStyle.DATADOG, Config.PropagationStyle.B3]
+    config.propagationStylesToExtract.toList() == [PropagationStyle.B3, PropagationStyle.DATADOG]
+    config.propagationStylesToInject.toList() == [PropagationStyle.DATADOG, PropagationStyle.B3]
     config.jmxFetchMetricsConfigs == ["some/file"]
     config.reportHostName == true
   }
@@ -504,8 +504,8 @@ class ConfigTest extends DDSpecification {
     config.httpClientSplitByDomain == false
     config.dbClientSplitByInstance == false
     config.splitByTags == [].toSet()
-    config.propagationStylesToExtract.toList() == [Config.PropagationStyle.DATADOG]
-    config.propagationStylesToInject.toList() == [Config.PropagationStyle.DATADOG]
+    config.propagationStylesToExtract.toList() == [PropagationStyle.DATADOG]
+    config.propagationStylesToInject.toList() == [PropagationStyle.DATADOG]
   }
 
   def "sys props and env vars overrides for trace_agent_port and agent_port_legacy as expected"() {
@@ -602,8 +602,8 @@ class ConfigTest extends DDSpecification {
     config.dbClientSplitByInstance == true
     config.splitByTags == [].toSet()
     config.partialFlushMinSpans == 15
-    config.propagationStylesToExtract.toList() == [Config.PropagationStyle.B3, Config.PropagationStyle.DATADOG]
-    config.propagationStylesToInject.toList() == [Config.PropagationStyle.DATADOG, Config.PropagationStyle.B3]
+    config.propagationStylesToExtract.toList() == [PropagationStyle.B3, PropagationStyle.DATADOG]
+    config.propagationStylesToInject.toList() == [PropagationStyle.DATADOG, PropagationStyle.B3]
     config.jmxFetchMetricsConfigs == ["/foo.yaml", "/bar.yaml"]
     config.jmxFetchCheckPeriod == 100
     config.jmxFetchRefreshBeansPeriod == 200

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/HttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/HttpCodec.java
@@ -1,6 +1,7 @@
 package datadog.trace.core.propagation;
 
 import datadog.trace.api.Config;
+import datadog.trace.api.PropagationStyle;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.core.DDSpanContext;
 import java.io.UnsupportedEncodingException;
@@ -24,16 +25,16 @@ public class HttpCodec {
 
   public static Injector createInjector(final Config config) {
     final List<Injector> injectors = new ArrayList<>();
-    for (final Config.PropagationStyle style : config.getPropagationStylesToInject()) {
-      if (style == Config.PropagationStyle.DATADOG) {
+    for (final PropagationStyle style : config.getPropagationStylesToInject()) {
+      if (style == PropagationStyle.DATADOG) {
         injectors.add(new DatadogHttpCodec.Injector());
         continue;
       }
-      if (style == Config.PropagationStyle.B3) {
+      if (style == PropagationStyle.B3) {
         injectors.add(new B3HttpCodec.Injector());
         continue;
       }
-      if (style == Config.PropagationStyle.HAYSTACK) {
+      if (style == PropagationStyle.HAYSTACK) {
         injectors.add(new HaystackHttpCodec.Injector());
         continue;
       }
@@ -45,16 +46,16 @@ public class HttpCodec {
   public static Extractor createExtractor(
       final Config config, final Map<String, String> taggedHeaders) {
     final List<Extractor> extractors = new ArrayList<>();
-    for (final Config.PropagationStyle style : config.getPropagationStylesToExtract()) {
-      if (style == Config.PropagationStyle.DATADOG) {
+    for (final PropagationStyle style : config.getPropagationStylesToExtract()) {
+      if (style == PropagationStyle.DATADOG) {
         extractors.add(new DatadogHttpCodec.Extractor(taggedHeaders));
         continue;
       }
-      if (style == Config.PropagationStyle.B3) {
+      if (style == PropagationStyle.B3) {
         extractors.add(new B3HttpCodec.Extractor(taggedHeaders));
         continue;
       }
-      if (style == Config.PropagationStyle.HAYSTACK) {
+      if (style == PropagationStyle.HAYSTACK) {
         extractors.add(new HaystackHttpCodec.Extractor(taggedHeaders));
         continue;
       }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HttpExtractorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HttpExtractorTest.groovy
@@ -5,8 +5,8 @@ import datadog.trace.api.DDId
 import datadog.trace.util.test.DDSpecification
 import spock.lang.Shared
 
-import static datadog.trace.api.Config.PropagationStyle.B3
-import static datadog.trace.api.Config.PropagationStyle.DATADOG
+import static datadog.trace.api.PropagationStyle.B3
+import static datadog.trace.api.PropagationStyle.DATADOG
 import static datadog.trace.core.CoreTracer.TRACE_ID_MAX
 
 class HttpExtractorTest extends DDSpecification {

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HttpInjectorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HttpInjectorTest.groovy
@@ -9,8 +9,8 @@ import datadog.trace.core.DDSpanContext
 import datadog.trace.core.PendingTrace
 import datadog.trace.util.test.DDSpecification
 
-import static datadog.trace.api.Config.PropagationStyle.B3
-import static datadog.trace.api.Config.PropagationStyle.DATADOG
+import static datadog.trace.api.PropagationStyle.B3
+import static datadog.trace.api.PropagationStyle.DATADOG
 
 class HttpInjectorTest extends DDSpecification {
 


### PR DESCRIPTION
This led to weird test failures occasionally (where the method on `Config` wouldn't even get invoked, so it wasn't a case of the method throwing during `clinit`). 

```
java.lang.ExceptionInInitializerError
	at datadog.trace.api.ConfigDefaults.<clinit>(ConfigDefaults.java:7)
	at datadog.trace.common.writer.DDAgentWriter$DDAgentWriterBuilder.<init>(DDAgentWriter.java:50)
	at datadog.trace.common.writer.DDAgentWriter.builder(DDAgentWriter.java:57)
	at datadog.trace.api.writer.DDAgentWriterTest.check that are no interactions after close(DDAgentWriterTest.groovy:196)
Caused by: java.lang.NullPointerException
	at datadog.trace.api.Config.parseStringIntoSetOfNonEmptyStrings(Config.java:1414)
	at datadog.trace.api.Config.getPropagationStyleSetSettingFromEnvironmentOrDefault(Config.java:1156)
	at datadog.trace.api.Config.<init>(Config.java:462)
	at datadog.trace.api.Config.<clinit>(Config.java:1539)
	... 4 more
```