### PR TITLE
Haystack Support with UUID

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/B3HttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/B3HttpCodec.java
@@ -6,7 +6,6 @@ import datadog.trace.api.DDId;
 import datadog.trace.api.sampling.PrioritySampling;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.core.DDSpanContext;
-import java.math.BigInteger;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/B3HttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/B3HttpCodec.java
@@ -1,7 +1,6 @@
 package datadog.trace.core.propagation;
 
 import static datadog.trace.core.propagation.HttpCodec.firstHeaderValue;
-import static datadog.trace.core.propagation.HttpCodec.validateUInt64BitsID;
 
 import datadog.trace.api.DDId;
 import datadog.trace.api.sampling.PrioritySampling;
@@ -40,9 +39,9 @@ class B3HttpCodec {
     public <C> void inject(
         final DDSpanContext context, final C carrier, final AgentPropagation.Setter<C> setter) {
       try {
-        String injectedTraceId = context.getTraceId().toString(HEX_RADIX).toLowerCase();
+        String injectedTraceId = context.getTraceId().toHexString().toLowerCase();
         setter.set(carrier, TRACE_ID_KEY, injectedTraceId);
-        setter.set(carrier, SPAN_ID_KEY, context.getSpanId().toString(HEX_RADIX).toLowerCase());
+        setter.set(carrier, SPAN_ID_KEY, context.getSpanId().toHexString().toLowerCase());
 
         if (context.lockSamplingPriority()) {
           setter.set(

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/HaystackHttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/HaystackHttpCodec.java
@@ -56,10 +56,12 @@ public class HaystackHttpCodec {
         //  to the converted value in BigInteger, use that instead.
         //  this will preserve the complete UUID/GUID without losing the most significant bit part
         String originalHaystackTraceId = getBaggageItemIgnoreCase(context.getBaggageItems(), HAYSTACK_TRACE_ID_BAGGAGE_KEY);
+        String injectedTraceId = originalHaystackTraceId;
         if (originalHaystackTraceId != null && convertUUIDToBigInt(originalHaystackTraceId).equals(context.getTraceId())) {
           setter.set(carrier, TRACE_ID_KEY, originalHaystackTraceId);
         } else {
-          setter.set(carrier, TRACE_ID_KEY, convertBigIntToUUID(context.getTraceId()));
+          injectedTraceId = convertBigIntToUUID(context.getTraceId());
+          setter.set(carrier, TRACE_ID_KEY, injectedTraceId);
         }
         setter.set(carrier, DD_TRACE_ID_BAGGAGE_KEY, HttpCodec.encode(context.getTraceId().toString()));
         setter.set(carrier, SPAN_ID_KEY, convertBigIntToUUID(context.getSpanId()));
@@ -70,7 +72,7 @@ public class HaystackHttpCodec {
         for (final Map.Entry<String, String> entry : context.baggageItems()) {
           setter.set(carrier, OT_BAGGAGE_PREFIX + entry.getKey(), HttpCodec.encode(entry.getValue()));
         }
-        log.debug("{} - Haystack parent context injected", context.getTraceId());
+        log.debug("{} - Haystack parent context injected - {}", context.getTraceId(), injectedTraceId);
       } catch (final NumberFormatException e) {
         log.debug(
           "Cannot parse context id(s): {} {}", context.getTraceId(), context.getSpanId(), e);

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/HaystackHttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/HaystackHttpCodec.java
@@ -56,13 +56,14 @@ public class HaystackHttpCodec {
         //  to the converted value in BigInteger, use that instead.
         //  this will preserve the complete UUID/GUID without losing the most significant bit part
         String originalHaystackTraceId = getBaggageItemIgnoreCase(context.getBaggageItems(), HAYSTACK_TRACE_ID_BAGGAGE_KEY);
-        String injectedTraceId = originalHaystackTraceId;
+        String injectedTraceId;
         if (originalHaystackTraceId != null && convertUUIDToBigInt(originalHaystackTraceId).equals(context.getTraceId())) {
-          setter.set(carrier, TRACE_ID_KEY, originalHaystackTraceId);
+          injectedTraceId = originalHaystackTraceId;
         } else {
           injectedTraceId = convertBigIntToUUID(context.getTraceId());
-          setter.set(carrier, TRACE_ID_KEY, injectedTraceId);
         }
+        setter.set(carrier, TRACE_ID_KEY, injectedTraceId);
+        context.setTag(HAYSTACK_TRACE_ID_BAGGAGE_KEY, injectedTraceId);
         setter.set(carrier, DD_TRACE_ID_BAGGAGE_KEY, HttpCodec.encode(context.getTraceId().toString()));
         setter.set(carrier, SPAN_ID_KEY, convertBigIntToUUID(context.getSpanId()));
         setter.set(carrier, DD_SPAN_ID_BAGGAGE_KEY, HttpCodec.encode(context.getSpanId().toString()));

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/HaystackHttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/HaystackHttpCodec.java
@@ -9,6 +9,7 @@ import datadog.trace.core.DDSpanContext;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -24,6 +25,17 @@ public class HaystackHttpCodec {
   private static final String SPAN_ID_KEY = "Span-ID";
   private static final String PARENT_ID_KEY = "Parent_ID";
 
+  private static final String DD_TRACE_ID_BAGGAGE_KEY = OT_BAGGAGE_PREFIX + "x-datadog-trace-id";
+  private static final String DD_SPAN_ID_BAGGAGE_KEY = OT_BAGGAGE_PREFIX + "x-datadog-span-id";
+  private static final String DD_PARENT_ID_BAGGAGE_KEY = OT_BAGGAGE_PREFIX + "x-datadog-parent-id";
+
+  private static final String HAYSTACK_TRACE_ID_BAGGAGE_KEY = "Haystack-Trace-ID";
+  private static final String HAYSTACK_SPAN_ID_BAGGAGE_KEY = "Haystack-Span-ID";
+  private static final String HAYSTACK_PARENT_ID_BAGGAGE_KEY = "Haystack-Parent-ID";
+
+  //public static final long DATADOG = new BigInteger("Datadog!".getBytes()).longValue();
+  public static final String DATADOG = "44617461-646f-6721";
+
   private HaystackHttpCodec() {
     // This class should not be created. This also makes code coverage checks happy.
   }
@@ -33,14 +45,35 @@ public class HaystackHttpCodec {
     @Override
     public <C> void inject(
         final DDSpanContext context, final C carrier, final AgentPropagation.Setter<C> setter) {
-      setter.set(carrier, TRACE_ID_KEY, context.getTraceId().toString());
-      setter.set(carrier, SPAN_ID_KEY, context.getSpanId().toString());
-      setter.set(carrier, PARENT_ID_KEY, context.getParentId().toString());
+      try {
+        // Given that Haystack uses a 128-bit UUID/GUID for all ID representations, need to convert from 64-bit BigInteger
+        //  also record the original DataDog IDs into Baggage payload
+        setter.put(TRACE_ID_KEY, convertBigIntToUUID(context.getTraceId()));
+        setter.put(DD_TRACE_ID_BAGGAGE_KEY, HttpCodec.encode(context.getTraceId().toString()));
+        setter.put(SPAN_ID_KEY, convertBigIntToUUID(context.getSpanId()));
+        setter.put(DD_SPAN_ID_BAGGAGE_KEY, HttpCodec.encode(context.getSpanId().toString()));
+        setter.put(PARENT_ID_KEY, convertBigIntToUUID(context.getParentId()));
+        setter.put(DD_PARENT_ID_BAGGAGE_KEY, HttpCodec.encode(context.getParentId().toString()));
 
-      for (final Map.Entry<String, String> entry : context.baggageItems()) {
-        setter.set(carrier, OT_BAGGAGE_PREFIX + entry.getKey(), HttpCodec.encode(entry.getValue()));
+        for (final Map.Entry<String, String> entry : context.baggageItems()) {
+          setter.put(OT_BAGGAGE_PREFIX + entry.getKey(), HttpCodec.encode(entry.getValue()));
+        }
+        log.debug("{} - Haystack parent context injected", context.getTraceId());
+      } catch (final NumberFormatException e) {
+        log.debug(
+          "Cannot parse context id(s): {} {}", context.getTraceId(), context.getSpanId(), e);
       }
-      log.debug("{} - Haystack parent context injected", context.getTraceId());
+    }
+
+    private String convertBigIntToUUID(BigInteger id) {
+      // This is not a true/real UUID, as we don't care about the version and variant markers
+      //  the creation is just taking the least significant bits and doing static most significant ones.
+      //  this is done for the purpose of being able to maintain cardinality and idempotency of the conversion
+      String idHex = String.format("%016x", id);
+      return DATADOG + "-" + idHex.substring(0, 4) + "-" + idHex.substring(4);
+
+//      UUID uuid = new UUID(DATADOG, id.longValue());
+//      return uuid.toString();
     }
   }
 
@@ -73,10 +106,15 @@ public class HaystackHttpCodec {
             continue;
           }
 
+          // We are preserving the original UUID values as baggage to be able to loop them through the 2 systems
           if (TRACE_ID_KEY.equalsIgnoreCase(key)) {
-            traceId = DDId.from(value);
+            traceId = convertUUIDToBigInt(value);
+            baggage.put(HAYSTACK_TRACE_ID_BAGGAGE_KEY, HttpCodec.decode(value));
           } else if (SPAN_ID_KEY.equalsIgnoreCase(key)) {
-            spanId = DDId.from(value);
+            spanId = convertUUIDToBigInt(value);
+            baggage.put(HAYSTACK_SPAN_ID_BAGGAGE_KEY, HttpCodec.decode(value));
+          } else if (PARENT_ID_KEY.equalsIgnoreCase(key)) {
+            baggage.put(HAYSTACK_PARENT_ID_BAGGAGE_KEY, HttpCodec.decode(value));
           } else if (key.startsWith(OT_BAGGAGE_PREFIX.toLowerCase())) {
             if (baggage.isEmpty()) {
               baggage = new HashMap<>();
@@ -108,6 +146,31 @@ public class HaystackHttpCodec {
       }
 
       return null;
+    }
+
+    private DDId convertUUIDToBigInt(String value) {
+      try {
+        if (value.contains("-")) {
+          String[] strings = value.split("-");
+          // We are only interested in the least significant bit component, dropping the most
+          // significant one.
+          if (strings.length == 5) {
+            String idHex = strings[3] + strings[4];
+            return DDId.from(idHex);
+          }
+          throw new NumberFormatException("Invalid UUID format: " + value);
+        } else {
+          // This could be a regular hex id without separators
+          int length = value.length();
+          if (length == 32) {
+            return DDId.from(value.substring(16));
+          } else {
+            return DDId.from(value);
+          }
+        }
+      } catch (final Exception e) {
+        throw new IllegalArgumentException("Exception when converting UUID to BigInteger: " + value, e);
+      }
     }
   }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HaystackHttpExtractorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HaystackHttpExtractorTest.groovy
@@ -16,8 +16,8 @@ class HaystackHttpExtractorTest extends DDSpecification {
   def "extract http headers"() {
     setup:
     def headers = [
-      (TRACE_ID_KEY.toUpperCase())            : traceId,
-      (SPAN_ID_KEY.toUpperCase())             : spanId,
+      (TRACE_ID_KEY.toUpperCase())            : traceUuid,
+      (SPAN_ID_KEY.toUpperCase())             : spanUuid,
       (OT_BAGGAGE_PREFIX.toUpperCase() + "k1"): "v1",
       (OT_BAGGAGE_PREFIX.toUpperCase() + "k2"): "v2",
       SOME_HEADER                             : "my-interesting-info",
@@ -27,19 +27,19 @@ class HaystackHttpExtractorTest extends DDSpecification {
     final ExtractedContext context = extractor.extract(headers, MapGetter.INSTANCE)
 
     then:
-    context.traceId == DDId.from(traceId)
-    context.spanId == DDId.from(spanId)
-    context.baggage == ["k1": "v1", "k2": "v2"]
+    context.traceId == new BigInteger(traceId)
+    context.spanId == new BigInteger(spanId)
+    context.baggage == ["k1": "v1", "k2": "v2", "Haystack-Trace-ID": traceUuid, "Haystack-Span-ID": spanUuid]
     context.tags == ["some-tag": "my-interesting-info"]
     context.samplingPriority == samplingPriority
     context.origin == origin
 
     where:
-    traceId               | spanId                | samplingPriority              | origin
-    "1"                   | "2"                   | PrioritySampling.SAMPLER_KEEP | null
-    "2"                   | "3"                   | PrioritySampling.SAMPLER_KEEP | null
-    "$TRACE_ID_MAX"       | "${TRACE_ID_MAX - 1}" | PrioritySampling.SAMPLER_KEEP | null
-    "${TRACE_ID_MAX - 1}" | "$TRACE_ID_MAX"       | PrioritySampling.SAMPLER_KEEP | null
+    traceId               | spanId                | samplingPriority              | origin | traceUuid                              | spanUuid
+    "1"                   | "2"                   | PrioritySampling.SAMPLER_KEEP | null   | "44617461-646f-6721-0000-000000000001" | "44617461-646f-6721-0000-000000000002"
+    "2"                   | "3"                   | PrioritySampling.SAMPLER_KEEP | null   | "44617461-646f-6721-0000-000000000002" | "44617461-646f-6721-0000-000000000003"
+    "${TRACE_ID_MAX}"     | "${TRACE_ID_MAX - 6}" | PrioritySampling.SAMPLER_KEEP | null   | "44617461-646f-6721-ffff-ffffffffffff" | "44617461-646f-6721-ffff-fffffffffff9"
+    "${TRACE_ID_MAX - 1}" | "${TRACE_ID_MAX - 7}" | PrioritySampling.SAMPLER_KEEP | null   | "44617461-646f-6721-ffff-fffffffffffe" | "44617461-646f-6721-ffff-fffffffffff8"
   }
 
   def "extract header tags with no propagation"() {
@@ -113,7 +113,7 @@ class HaystackHttpExtractorTest extends DDSpecification {
     context == null
   }
 
-  def "more ID range validation"() {
+  def "extract 128 bit id truncates id to 64 bit"() {
     setup:
     def headers = [
       (TRACE_ID_KEY.toUpperCase()): traceId,
@@ -132,14 +132,20 @@ class HaystackHttpExtractorTest extends DDSpecification {
     }
 
     where:
-    traceId               | spanId                | expectedTraceId             | expectedSpanId
-    "-1"                  | "1"                   | null                        | null
-    "1"                   | "-1"                  | null                        | null
-    "0"                   | "1"                   | null                        | null
-    "1"                   | "0"                   | DDId.ONE                    | DDId.ZERO
-    "$TRACE_ID_MAX"       | "1"                   | DDId.from("$TRACE_ID_MAX")  | DDId.ONE
-    "${TRACE_ID_MAX + 1}" | "1"                   | null                        | null
-    "1"                   | "$TRACE_ID_MAX"       | DDId.ONE                    | DDId.from("$TRACE_ID_MAX")
-    "1"                   | "${TRACE_ID_MAX + 1}" | null                        | null
+    traceId                                | spanId                                | expectedTraceId      | expectedSpanId
+    "-1"                                   | "1"                                   | null                 | 0G
+    "1"                                    | "-1"                                  | null                 | 0G
+    "0"                                    | "1"                                   | null                 | 0G
+    "00001"                                | "00001"                               | 1G                   | 1G
+    "463ac35c9f6413ad"                     | "463ac35c9f6413ad"                    | 5060571933882717101G | 5060571933882717101G
+    "463ac35c9f6413ad48485a3953bb6124"     | "1"                                   | 5208512171318403364G | 1G
+    "44617461-646f-6721-463a-c35c9f6413ad" |"44617461-646f-6721-463a-c35c9f6413ad" | 5060571933882717101G | 5060571933882717101G
+    "f" * 16                               | "1"                                   | TRACE_ID_MAX         | 1G
+    "a" * 16 + "f" * 16                    | "1"                                   | TRACE_ID_MAX         | 1G
+    "1" + "f" * 32                         | "1"                                   | null                 | 1G
+    "0" + "f" * 32                         | "1"                                   | null                 | 1G
+    "1"                                    | "f" * 16                              | 1G                   | TRACE_ID_MAX
+    "1"                                    | "1" + "f" * 16                        | null                 | 0G
+    "1"                                    | "000" + "f" * 16                      | 1G                   | TRACE_ID_MAX
   }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HaystackHttpExtractorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HaystackHttpExtractorTest.groovy
@@ -27,8 +27,8 @@ class HaystackHttpExtractorTest extends DDSpecification {
     final ExtractedContext context = extractor.extract(headers, MapGetter.INSTANCE)
 
     then:
-    context.traceId == new BigInteger(traceId)
-    context.spanId == new BigInteger(spanId)
+    context.traceId == DDId.from(traceId)
+    context.spanId == DDId.from(spanId)
     context.baggage == ["k1": "v1", "k2": "v2", "Haystack-Trace-ID": traceUuid, "Haystack-Span-ID": spanUuid]
     context.tags == ["some-tag": "my-interesting-info"]
     context.samplingPriority == samplingPriority
@@ -132,20 +132,20 @@ class HaystackHttpExtractorTest extends DDSpecification {
     }
 
     where:
-    traceId                                | spanId                                | expectedTraceId      | expectedSpanId
-    "-1"                                   | "1"                                   | null                 | 0G
-    "1"                                    | "-1"                                  | null                 | 0G
-    "0"                                    | "1"                                   | null                 | 0G
-    "00001"                                | "00001"                               | 1G                   | 1G
-    "463ac35c9f6413ad"                     | "463ac35c9f6413ad"                    | 5060571933882717101G | 5060571933882717101G
-    "463ac35c9f6413ad48485a3953bb6124"     | "1"                                   | 5208512171318403364G | 1G
-    "44617461-646f-6721-463a-c35c9f6413ad" |"44617461-646f-6721-463a-c35c9f6413ad" | 5060571933882717101G | 5060571933882717101G
-    "f" * 16                               | "1"                                   | TRACE_ID_MAX         | 1G
-    "a" * 16 + "f" * 16                    | "1"                                   | TRACE_ID_MAX         | 1G
-    "1" + "f" * 32                         | "1"                                   | null                 | 1G
-    "0" + "f" * 32                         | "1"                                   | null                 | 1G
-    "1"                                    | "f" * 16                              | 1G                   | TRACE_ID_MAX
-    "1"                                    | "1" + "f" * 16                        | null                 | 0G
-    "1"                                    | "000" + "f" * 16                      | 1G                   | TRACE_ID_MAX
+    traceId                                | spanId                                | expectedTraceId                | expectedSpanId
+    "-1"                                   | "1"                                   | null                           | DDId.ZERO
+    "1"                                    | "-1"                                  | null                           | DDId.ZERO
+    "0"                                    | "1"                                   | null                           | DDId.ZERO
+    "00001"                                | "00001"                               | DDId.ONE                       | DDId.ONE
+    "463ac35c9f6413ad"                     | "463ac35c9f6413ad"                    | DDId.from(5060571933882717101) | DDId.from(5060571933882717101)
+    "463ac35c9f6413ad48485a3953bb6124"     | "1"                                   | DDId.from(5208512171318403364) | DDId.ONE
+    "44617461-646f-6721-463a-c35c9f6413ad" |"44617461-646f-6721-463a-c35c9f6413ad" | DDId.from(5060571933882717101) | DDId.from(5060571933882717101)
+    "f" * 16                               | "1"                                   | DDId.MAX                       | DDId.ONE
+    "a" * 16 + "f" * 16                    | "1"                                   | DDId.MAX                       | DDId.ONE
+    "1" + "f" * 32                         | "1"                                   | null                           | DDId.ONE
+    "0" + "f" * 32                         | "1"                                   | null                           | DDId.ONE
+    "1"                                    | "f" * 16                              | DDId.ONE                       | DDId.MAX
+    "1"                                    | "1" + "f" * 16                        | null                           | DDId.ZERO
+    "1"                                    | "000" + "f" * 16                      | DDId.ONE                       | DDId.MAX
   }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HaystackHttpInjectorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HaystackHttpInjectorTest.groovy
@@ -55,6 +55,7 @@ class HaystackHttpInjectorTest extends DDSpecification {
 
     then:
     1 * carrier.put(TRACE_ID_KEY, traceUuid)
+    mockedContext.getTags().get(HAYSTACK_TRACE_ID_BAGGAGE_KEY) == traceUuid
     1 * carrier.put(DD_TRACE_ID_BAGGAGE_KEY, traceId.toString())
     1 * carrier.put(SPAN_ID_KEY, spanUuid)
     1 * carrier.put(DD_SPAN_ID_BAGGAGE_KEY, spanId.toString())

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HaystackHttpInjectorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HaystackHttpInjectorTest.groovy
@@ -27,9 +27,9 @@ class HaystackHttpInjectorTest extends DDSpecification {
     def tracer = CoreTracer.builder().writer(writer).build()
     final DDSpanContext mockedContext =
       new DDSpanContext(
-        traceId,
-        spanId,
-        0G,
+        DDId.from(traceId),
+        DDId.from(spanId),
+        DDId.ZERO,
         "fakeService",
         "fakeOperation",
         "fakeResource",
@@ -63,11 +63,11 @@ class HaystackHttpInjectorTest extends DDSpecification {
     1 * carrier.put(OT_BAGGAGE_PREFIX + "k2", "v2")
 
     where:
-    traceId          | spanId           | samplingPriority              | origin | traceUuid                              | spanUuid
-    1G               | 2G               | PrioritySampling.SAMPLER_KEEP | null   | "44617461-646f-6721-0000-000000000001" | "44617461-646f-6721-0000-000000000002"
-    1G               | 2G               | PrioritySampling.SAMPLER_KEEP | null   | "44617461-646f-6721-0000-000000000001" | "44617461-646f-6721-0000-000000000002"
-    TRACE_ID_MAX     | TRACE_ID_MAX - 1 | PrioritySampling.SAMPLER_KEEP | null   | "44617461-646f-6721-ffff-ffffffffffff" | "44617461-646f-6721-ffff-fffffffffffe"
-    TRACE_ID_MAX - 1 | TRACE_ID_MAX     | PrioritySampling.SAMPLER_KEEP | null   | "44617461-646f-6721-ffff-fffffffffffe" | "44617461-646f-6721-ffff-ffffffffffff"
+    traceId               | spanId                | samplingPriority              | origin | traceUuid                              | spanUuid
+    "1"                   | "2"                   | PrioritySampling.SAMPLER_KEEP | null   | "44617461-646f-6721-0000-000000000001" | "44617461-646f-6721-0000-000000000002"
+    "1"                   | "2"                   | PrioritySampling.SAMPLER_KEEP | null   | "44617461-646f-6721-0000-000000000001" | "44617461-646f-6721-0000-000000000002"
+    "$TRACE_ID_MAX"       | "${TRACE_ID_MAX - 1}" | PrioritySampling.SAMPLER_KEEP | null   | "44617461-646f-6721-ffff-ffffffffffff" | "44617461-646f-6721-ffff-fffffffffffe"
+    "${TRACE_ID_MAX - 1}" | "$TRACE_ID_MAX"       | PrioritySampling.SAMPLER_KEEP | null   | "44617461-646f-6721-ffff-fffffffffffe" | "44617461-646f-6721-ffff-ffffffffffff"
   }
 
   def "inject http headers with haystack traceId in baggage"() {
@@ -77,9 +77,9 @@ class HaystackHttpInjectorTest extends DDSpecification {
     def haystackUuid = traceUuid
     final DDSpanContext mockedContext =
       new DDSpanContext(
-        traceId,
-        spanId,
-        0G,
+        DDId.from(traceId),
+        DDId.from(spanId),
+        DDId.ZERO,
         "fakeService",
         "fakeOperation",
         "fakeResource",
@@ -95,7 +95,7 @@ class HaystackHttpInjectorTest extends DDSpecification {
         false,
         "fakeType",
         null,
-        new PendingTrace(tracer, 1G),
+        new PendingTrace(tracer, DDId.ONE),
         tracer,
         [:])
 
@@ -113,10 +113,10 @@ class HaystackHttpInjectorTest extends DDSpecification {
     1 * carrier.put(OT_BAGGAGE_PREFIX + "k2", "v2")
 
     where:
-    traceId          | spanId           | samplingPriority              | origin | traceUuid                              | spanUuid
-    1G               | 2G               | PrioritySampling.SAMPLER_KEEP | null   | "54617461-646f-6721-0000-000000000001" | "44617461-646f-6721-0000-000000000002"
-    1G               | 2G               | PrioritySampling.SAMPLER_KEEP | null   | "54617461-646f-6721-0000-000000000001" | "44617461-646f-6721-0000-000000000002"
-    TRACE_ID_MAX     | TRACE_ID_MAX - 1 | PrioritySampling.SAMPLER_KEEP | null   | "54617461-646f-6721-ffff-ffffffffffff" | "44617461-646f-6721-ffff-fffffffffffe"
-    TRACE_ID_MAX - 1 | TRACE_ID_MAX     | PrioritySampling.SAMPLER_KEEP | null   | "54617461-646f-6721-ffff-fffffffffffe" | "44617461-646f-6721-ffff-ffffffffffff"
+    traceId               | spanId                | samplingPriority              | origin | traceUuid                              | spanUuid
+    "1"                   | "2"                   | PrioritySampling.SAMPLER_KEEP | null   | "54617461-646f-6721-0000-000000000001" | "44617461-646f-6721-0000-000000000002"
+    "1"                   | "2"                   | PrioritySampling.SAMPLER_KEEP | null   | "54617461-646f-6721-0000-000000000001" | "44617461-646f-6721-0000-000000000002"
+    "$TRACE_ID_MAX"       | "${TRACE_ID_MAX - 1}" | PrioritySampling.SAMPLER_KEEP | null   | "54617461-646f-6721-ffff-ffffffffffff" | "44617461-646f-6721-ffff-fffffffffffe"
+    "${TRACE_ID_MAX - 1}" | "$TRACE_ID_MAX"       | PrioritySampling.SAMPLER_KEEP | null   | "54617461-646f-6721-ffff-fffffffffffe" | "44617461-646f-6721-ffff-ffffffffffff"
   }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HaystackHttpInjectorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HaystackHttpInjectorTest.groovy
@@ -61,6 +61,7 @@ class HaystackHttpInjectorTest extends DDSpecification {
     1 * carrier.put(DD_SPAN_ID_BAGGAGE_KEY, spanId.toString())
     1 * carrier.put(OT_BAGGAGE_PREFIX + "k1", "v1")
     1 * carrier.put(OT_BAGGAGE_PREFIX + "k2", "v2")
+    1 * carrier.put(DD_PARENT_ID_BAGGAGE_KEY, "0")
 
     where:
     traceId               | spanId                | samplingPriority              | origin | traceUuid                              | spanUuid


### PR DESCRIPTION
* Enhancement to the Haystack Codec to add support for common use of UUID as an identifier format
* Add tag for original Haystack Trace ID to be preserved for continuous stitching between multiple systems (HS -> DD -> HS)