### PR TITLE
Simplify Config runtime id handling

### DIFF
--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTest.groovy
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTest.groovy
@@ -139,7 +139,6 @@ class KafkaClientTest extends AgentTestRunner {
   }
 
 
-
   def "test pass through tombstone"() {
     setup:
     def senderProps = KafkaTestUtils.senderProps(embeddedKafka.getBrokersAsString())

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/TagsAssert.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/TagsAssert.groovy
@@ -48,6 +48,8 @@ class TagsAssert {
 
     boolean isRoot = (DDId.ZERO == spanParentId)
     if (isRoot || distributedRootSpan) {
+      // If runtime id is actually different here, it might indicate that
+      // the Config class was loaded on multiple different class loaders.
       assert tags[DDTags.RUNTIME_ID_TAG] == Config.get().runtimeId
     } else {
       assert tags[DDTags.RUNTIME_ID_TAG] == null

--- a/dd-trace-api/src/main/java/datadog/trace/api/Config.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/Config.java
@@ -355,12 +355,15 @@ public class Config {
   private static Properties propertiesFromConfigFile;
 
   // Read order: System Properties -> Env Variables, [-> properties file], [-> default value]
-  // Visible for testing
-  Config() {
+  private Config() {
+    this(INSTANCE != null ? INSTANCE.runtimeId : UUID.randomUUID().toString());
+  }
+
+  private Config(final String runtimeId) {
     propertiesFromConfigFile = loadConfigurationFile();
     configFile = findConfigurationFile();
 
-    runtimeId = UUID.randomUUID().toString();
+    this.runtimeId = runtimeId;
 
     // Note: We do not want APiKey to be loaded from property for security reasons
     // Note: we do not use defined default here

--- a/utils/test-utils/src/main/groovy/datadog/trace/util/test/DDSpecification.groovy
+++ b/utils/test-utils/src/main/groovy/datadog/trace/util/test/DDSpecification.groovy
@@ -42,12 +42,6 @@ abstract class DDSpecification extends Specification {
           .field(named("INSTANCE"))
           .transform(Transformer.ForField.withModifiers(PUBLIC, STATIC, VOLATILE))
       }
-    // Making runtimeId modifiable so that it can be preserved when resetting config in tests
-      .transform { builder, typeDescription, classLoader, module ->
-        builder
-          .field(named("runtimeId"))
-          .transform(Transformer.ForField.withModifiers(PUBLIC, VOLATILE))
-      }
       .installOn(instrumentation)
     isConfigInstanceModifiable = true
   }


### PR DESCRIPTION
Avoid the need to modify at test runtime and add comment to help in future circumstance.