### PR TITLE
Fix Spring filter instrumentation edge case

### DIFF
--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/HandlerMappingResourceNameFilter.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/HandlerMappingResourceNameFilter.java
@@ -38,9 +38,9 @@ public class HandlerMappingResourceNameFilter extends OncePerRequestFilter imple
       } catch (final Exception ignored) {
         // mapping.getHandler() threw exception.  Ignore
       }
-
-      filterChain.doFilter(request, response);
     }
+
+    filterChain.doFilter(request, response);
   }
 
   /**

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/WebApplicationContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/WebApplicationContextInstrumentation.java
@@ -18,6 +18,10 @@ import net.bytebuddy.matcher.ElementMatcher;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 
+/**
+ * This instrumentation adds the HandlerMappingResourceNameFilter definition to the spring context
+ * When the context is created, the filter will be added to the beginning of the filter chain
+ */
 @AutoService(Instrumenter.class)
 public class WebApplicationContextInstrumentation extends Instrumenter.Default {
   public WebApplicationContextInstrumentation() {

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/filter/TestController.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/filter/TestController.groovy
@@ -18,6 +18,10 @@ import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
+/**
+ * None of the methods in this controller should be called because they are intercepted
+ * by the filter
+ */
 @Controller
 class TestController {
 
@@ -25,7 +29,7 @@ class TestController {
   @ResponseBody
   String success() {
     HttpServerTest.controller(SUCCESS) {
-      SUCCESS.body
+      throw new Exception("This should not be called")
     }
   }
 
@@ -33,7 +37,7 @@ class TestController {
   @ResponseBody
   String query_param(@RequestParam("some") String param) {
     HttpServerTest.controller(QUERY_PARAM) {
-      "some=$param"
+      throw new Exception("This should not be called")
     }
   }
 
@@ -41,7 +45,7 @@ class TestController {
   @ResponseBody
   String path_param(@PathVariable Integer id) {
     HttpServerTest.controller(PATH_PARAM) {
-      "$id"
+      throw new Exception("This should not be called")
     }
   }
 
@@ -49,21 +53,21 @@ class TestController {
   @ResponseBody
   RedirectView redirect() {
     HttpServerTest.controller(REDIRECT) {
-      new RedirectView(REDIRECT.body)
+      throw new Exception("This should not be called")
     }
   }
 
   @RequestMapping("/error-status")
   ResponseEntity error() {
     HttpServerTest.controller(ERROR) {
-      new ResponseEntity(ERROR.body, HttpStatus.valueOf(ERROR.status))
+      throw new Exception("This should not be called")
     }
   }
 
   @RequestMapping("/exception")
   ResponseEntity exception() {
     HttpServerTest.controller(EXCEPTION) {
-      throw new Exception(EXCEPTION.body)
+      throw new Exception("This should not be called")
     }
   }
 


### PR DESCRIPTION
This is a backport of https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/705

Before this change, if the request attribute isn't set, then the rest of the filter chain would not be called.  This could only happen if our instrumentation was broken somehow but we should still guard against that.

I was unable to create a test for this condition.  Removing the attribute manually, the servlet instrumentation would readd a new span.  I think the only way might be to run with the Spring instrumentation but without the Servlet instrumentation.

Additionally I added a little javadoc and clarified the role of `TestController` in filter tests.