### PR TITLE
MLT - Avoid sending only base stacktrace

### DIFF
--- a/dd-java-agent/agent-mlt/agent-mlt.gradle
+++ b/dd-java-agent/agent-mlt/agent-mlt.gradle
@@ -30,6 +30,9 @@ excludedClassesCoverage += [
   'com.datadog.mlt.sampler.NoneThreadStackProvider',
   'com.datadog.mlt.sampler.ThreadStackProvider'
 ]
+excludedClassesBranchCoverage += [
+  'com.datadog.mlt.sampler.ScopeStackCollector',
+]
 
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8

--- a/dd-java-agent/agent-mlt/src/main/java/com/datadog/mlt/sampler/ScopeStackCollector.java
+++ b/dd-java-agent/agent-mlt/src/main/java/com/datadog/mlt/sampler/ScopeStackCollector.java
@@ -4,45 +4,25 @@ import com.datadog.mlt.io.ConstantPool;
 import com.datadog.mlt.io.FrameElement;
 import com.datadog.mlt.io.FrameSequence;
 import com.datadog.mlt.io.IMLTChunk;
-import com.datadog.mlt.io.MLTWriter;
-import it.unimi.dsi.fastutil.ints.IntArrayList;
-import it.unimi.dsi.fastutil.ints.IntIterator;
-import it.unimi.dsi.fastutil.ints.IntList;
-import java.nio.ByteBuffer;
+import com.datadog.mlt.io.MLTChunkCollector;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.stream.IntStream;
-import java.util.stream.Stream;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-final class ScopeStackCollector implements IMLTChunk {
-  /*
-   * TODO seems like subtree compression is worse than plain full-tree deduplication
-   *  when the subtree compression is finally removed this flag should go as well + subtree support in FrameSequence
-   */
-  private static final boolean USE_SUBTREE_COMPRESSION =
-      Boolean.getBoolean("mlt.subtree_compression");
+final class ScopeStackCollector extends MLTChunkCollector {
 
   private static final byte VERSION = (byte) 0;
 
-  @Getter private final ConstantPool<FrameElement> framePool;
-  @Getter private final ConstantPool<FrameSequence> stackPool;
-  @Getter private final ConstantPool<String> stringPool;
   private final ScopeManager threadStacktraceCollector;
 
   @Getter private final long startTime;
   private final long startTimeNs;
 
   @Getter private final String scopeId;
-
-  private final IntList stacks = new IntArrayList();
-
-  private final MLTWriter chunkWriter = new MLTWriter();
 
   ScopeStackCollector(
       @NonNull String scopeId,
@@ -52,53 +32,11 @@ final class ScopeStackCollector implements IMLTChunk {
       ConstantPool<String> stringPool,
       ConstantPool<FrameElement> framePool,
       ConstantPool<FrameSequence> stackPool) {
+    super(new Throwable().getStackTrace(), stringPool, framePool, stackPool);
     this.scopeId = scopeId;
-    this.framePool = framePool;
-    this.stackPool = stackPool;
-    this.stringPool = stringPool;
     this.threadStacktraceCollector = threadStacktraceCollector;
-    this.startTime = startTimeEpoch;
+    startTime = startTimeEpoch;
     this.startTimeNs = startTimeNs;
-
-    // Capture the base stacktrace:
-    collect(new Throwable().getStackTrace());
-  }
-
-  public void collect(StackTraceElement[] stackTrace) {
-    if (stackTrace.length == 0) {
-      return;
-    }
-    FrameSequence tree = null;
-    if (USE_SUBTREE_COMPRESSION) {
-      for (int i = stackTrace.length - 1; i >= 0; i--) {
-        StackTraceElement element = stackTrace[i];
-        tree =
-            newTree(
-                new FrameElement(
-                    element.getClassName(),
-                    element.getMethodName(),
-                    element.getLineNumber(),
-                    stringPool,
-                    framePool),
-                tree);
-      }
-    } else {
-      int[] framePtrs = new int[stackTrace.length];
-      for (int i = 0; i < stackTrace.length; i++) {
-        StackTraceElement element = stackTrace[i];
-        framePtrs[i] =
-            framePool.getOrInsert(
-                new FrameElement(
-                    element.getClassName(),
-                    element.getMethodName(),
-                    element.getLineNumber(),
-                    stringPool,
-                    framePool));
-      }
-      tree = new FrameSequence(framePtrs, framePool, stackPool);
-    }
-
-    addCompressedStackptr(tree.getCpIndex());
   }
 
   @Override
@@ -121,82 +59,8 @@ final class ScopeStackCollector implements IMLTChunk {
     return threadStacktraceCollector.getThreadName();
   }
 
-  @Override
-  public boolean hasStacks() {
-    return !stacks.isEmpty();
-  }
-
-  @Override
-  public FrameSequence baseFrameSequence() {
-    return stackPool.get(stacks.getInt(0));
-  }
-
-  @Override
-  public Stream<FrameSequence> frameSequences() {
-    // stack pointer stream is internally compressed - needs to be decompressed first
-    // Skip over the base stacktrace.
-    return IMLTChunk.decompressStackPtrs(frameSequenceCpIndexes().skip(1)).mapToObj(stackPool::get);
-  }
-
-  @Override
-  public IntStream frameSequenceCpIndexes() {
-    int limit = stacks.size();
-    IntIterator iterator = stacks.iterator();
-    return IntStream.generate(iterator::nextInt).limit(limit);
-  }
-
-  @Override
-  public byte[] serialize() {
-    return chunkWriter.writeChunk(this);
-  }
-
-  @Override
-  public void serialize(Consumer<ByteBuffer> consumer) {
-    chunkWriter.writeChunk(this, consumer);
-  }
-
-  void addCompressedStackptr(int stackptr) {
-    if (!stacks.isEmpty()) {
-      int topItem = stacks.removeInt(stacks.size() - 1);
-      if (!stacks.isEmpty()) {
-        // checking for compression flag - `(topItem & 0x80000000) == 0x80000000`, simplified as
-        // `topItem < 0`
-        if (topItem < 0) { // topItem is the repetition counter
-          int counter = (topItem & 0x7fffffff);
-          if (stacks.getInt(stacks.size() - 1) == stackptr && counter < Integer.MAX_VALUE - 2) {
-            /*
-             * If inserting a consequent occurrence of the same stack trace and the repetition counter is not
-             * overflowing just update the repetition counter.
-             */
-            stacks.add((counter + 1) | 0x80000000);
-            return;
-          }
-          /*
-           * Not inserting a consequent occurrence of the same stack trace or the repetition counter is overflowing
-           */
-          stacks.add(topItem); // re-insert the topItem
-          stacks.add(stackptr);
-          return;
-        }
-      }
-      // otherwise the topItem is a plain stack pointer
-      if (stackptr == topItem) {
-        stacks.add(topItem); // re-insert the topItem
-        // inserting a consequent occurrence of the same stack trace
-        stacks.add(1 | 0x80000000); // insert repetition counter
-        return;
-      }
-      stacks.add(topItem);
-    }
-    stacks.add(stackptr);
-  }
-
   public <T> T end(Function<IMLTChunk, T> onEnd) {
     return onEnd.apply(threadStacktraceCollector.endScope(this));
-  }
-
-  private FrameSequence newTree(FrameElement frame, FrameSequence subtree) {
-    return new FrameSequence(frame, subtree, framePool, stackPool);
   }
 
   @Override

--- a/dd-java-agent/agent-mlt/src/test/java/com/datadog/mlt/sampler/ScopeManagerTest.java
+++ b/dd-java-agent/agent-mlt/src/test/java/com/datadog/mlt/sampler/ScopeManagerTest.java
@@ -74,10 +74,13 @@ class ScopeManagerTest {
           FrameElement[] origFrames =
               collectedChunk
                   .frameSequences()
-                  .flatMap(FrameSequence::frames)
+                  .flatMap(FrameSequence::framesFromLeaves)
                   .toArray(FrameElement[]::new);
           FrameElement[] restoredFrames =
-              chunk.frameSequences().flatMap(FrameSequence::frames).toArray(FrameElement[]::new);
+              chunk
+                  .frameSequences()
+                  .flatMap(FrameSequence::framesFromLeaves)
+                  .toArray(FrameElement[]::new);
           assertArrayEquals(origFrames, restoredFrames);
           return null;
         });

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/TraceProfilingScopeInterceptor.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/TraceProfilingScopeInterceptor.java
@@ -112,7 +112,8 @@ public abstract class TraceProfilingScopeInterceptor
         return true;
       }
 
-      if (span.getSamplingPriority() == PrioritySampling.USER_KEEP) {
+      Integer samplingPriority = span.getSamplingPriority();
+      if (samplingPriority != null && samplingPriority == PrioritySampling.USER_KEEP) {
         // The trace was manually identified as important, so more likely interesting.
         return true;
       }

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/TraceProfilingScopeInterceptor.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/TraceProfilingScopeInterceptor.java
@@ -2,6 +2,7 @@ package datadog.trace.core.scopemanager;
 
 import com.google.common.util.concurrent.RateLimiter;
 import com.timgroup.statsd.StatsDClient;
+import datadog.trace.api.sampling.PrioritySampling;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.bootstrap.instrumentation.api.InstrumentationTags;
@@ -143,6 +144,10 @@ public abstract class TraceProfilingScopeInterceptor
       if (samplingData != null) {
         statsDClient.incrementCounter("mlt.count");
         statsDClient.count("mlt.bytes", samplingData.length);
+        if (span().getSamplingPriority() == null) {
+          // if priority not set, let's increase priority to improve chance this is kept.
+          span().setSamplingPriority(PrioritySampling.SAMPLER_KEEP);
+        }
         span().setTag(InstrumentationTags.DD_MLT, samplingData);
       }
     }

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/TraceProfilingScopeInterceptor.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/TraceProfilingScopeInterceptor.java
@@ -16,7 +16,7 @@ import java.util.concurrent.TimeUnit;
 public abstract class TraceProfilingScopeInterceptor
     extends ScopeInterceptor.DelegatingInterceptor {
   private static final long MAX_NANOSECONDS_BETWEEN_ACTIVATIONS = TimeUnit.SECONDS.toNanos(1);
-  private static final double ACTIVATIONS_PER_SECOND = 5;
+  private static final double ACTIVATIONS_PER_SECOND = 50;
   private static final ThreadLocal<Boolean> IS_THREAD_PROFILING =
       new ThreadLocal<Boolean>() {
         @Override
@@ -112,6 +112,11 @@ public abstract class TraceProfilingScopeInterceptor
         return true;
       }
 
+      if (span.getSamplingPriority() == PrioritySampling.USER_KEEP) {
+        // The trace was manually identified as important, so more likely interesting.
+        return true;
+      }
+
       if (lastProfileTimestamp + MAX_NANOSECONDS_BETWEEN_ACTIVATIONS < System.nanoTime()) {
         // It's been a while since we last profiled, so lets take one now.
         // Due to the multi-threaded nature here, we will likely have multiple threads enter here
@@ -144,11 +149,12 @@ public abstract class TraceProfilingScopeInterceptor
       if (samplingData != null) {
         statsDClient.incrementCounter("mlt.count");
         statsDClient.count("mlt.bytes", samplingData.length);
-        if (span().getSamplingPriority() == null) {
+        AgentSpan span = span();
+        span.setTag(InstrumentationTags.DD_MLT, samplingData);
+        if (span.getSamplingPriority() == null) {
           // if priority not set, let's increase priority to improve chance this is kept.
-          span().setSamplingPriority(PrioritySampling.SAMPLER_KEEP);
+          span.setSamplingPriority(PrioritySampling.SAMPLER_KEEP);
         }
-        span().setTag(InstrumentationTags.DD_MLT, samplingData);
       }
     }
   }

--- a/utils/mlt-support/mlt-support.gradle
+++ b/utils/mlt-support/mlt-support.gradle
@@ -34,7 +34,8 @@ excludedClassesCoverage += [
   'com.datadog.mlt.io.MLTReader',
   'com.datadog.mlt.io.MLTConstants',
   'com.datadog.mlt.io.LEB128ByteArrayWriter',
-  'com.datadog.mlt.io.LEB128WriterFactory'
+  'com.datadog.mlt.io.LEB128WriterFactory',
+  'com.datadog.mlt.io.MLTChunkCollector',
 ]
 
 sourceCompatibility = JavaVersion.VERSION_1_8

--- a/utils/mlt-support/src/main/java/com/datadog/mlt/io/MLTChunk.java
+++ b/utils/mlt-support/src/main/java/com/datadog/mlt/io/MLTChunk.java
@@ -33,7 +33,8 @@ public final class MLTChunk implements IMLTChunk {
   @Generated // disable jacoco check; the method is trivial
   @Override
   public boolean hasStacks() {
-    return !stacks.isEmpty();
+    // Base stack doesn't count.
+    return stacks.size() > 1;
   }
 
   @Override

--- a/utils/mlt-support/src/main/java/com/datadog/mlt/io/MLTChunkCollector.java
+++ b/utils/mlt-support/src/main/java/com/datadog/mlt/io/MLTChunkCollector.java
@@ -1,0 +1,149 @@
+package com.datadog.mlt.io;
+
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntIterator;
+import it.unimi.dsi.fastutil.ints.IntList;
+import java.nio.ByteBuffer;
+import java.util.function.Consumer;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import lombok.Getter;
+
+public abstract class MLTChunkCollector implements IMLTChunk {
+  /*
+   * TODO seems like subtree compression is worse than plain full-tree deduplication
+   *  when the subtree compression is finally removed this flag should go as well + subtree support in FrameSequence
+   */
+  private static final boolean USE_SUBTREE_COMPRESSION =
+      Boolean.getBoolean("mlt.subtree_compression");
+
+  @Getter protected final ConstantPool<FrameElement> framePool;
+  @Getter protected final ConstantPool<FrameSequence> stackPool;
+  @Getter protected final ConstantPool<String> stringPool;
+
+  private final IntList stacks = new IntArrayList();
+
+  private final MLTWriter chunkWriter = new MLTWriter();
+
+  public MLTChunkCollector(
+      StackTraceElement[] baseStack,
+      ConstantPool<String> stringPool,
+      ConstantPool<FrameElement> framePool,
+      ConstantPool<FrameSequence> stackPool) {
+    this.framePool = framePool;
+    this.stackPool = stackPool;
+    this.stringPool = stringPool;
+    collect(baseStack);
+  }
+
+  public void collect(StackTraceElement[] stackTrace) {
+    if (stackTrace.length == 0) {
+      return;
+    }
+    FrameSequence tree = null;
+    if (USE_SUBTREE_COMPRESSION) {
+      for (int i = stackTrace.length - 1; i >= 0; i--) {
+        StackTraceElement element = stackTrace[i];
+        tree =
+            newTree(
+                new FrameElement(
+                    element.getClassName(),
+                    element.getMethodName(),
+                    element.getLineNumber(),
+                    stringPool,
+                    framePool),
+                tree);
+      }
+    } else {
+      int[] framePtrs = new int[stackTrace.length];
+      for (int i = 0; i < stackTrace.length; i++) {
+        StackTraceElement element = stackTrace[i];
+        framePtrs[i] =
+            framePool.getOrInsert(
+                new FrameElement(
+                    element.getClassName(),
+                    element.getMethodName(),
+                    element.getLineNumber(),
+                    stringPool,
+                    framePool));
+      }
+      tree = new FrameSequence(framePtrs, framePool, stackPool);
+    }
+
+    addCompressedStackptr(tree.getCpIndex());
+  }
+
+  @Override
+  public boolean hasStacks() {
+    return !stacks.isEmpty();
+  }
+
+  @Override
+  public FrameSequence baseFrameSequence() {
+    return stackPool.get(stacks.getInt(0));
+  }
+
+  @Override
+  public Stream<FrameSequence> frameSequences() {
+    // stack pointer stream is internally compressed - needs to be decompressed first
+    // Skip over the base stacktrace.
+    return IMLTChunk.decompressStackPtrs(frameSequenceCpIndexes().skip(1)).mapToObj(stackPool::get);
+  }
+
+  @Override
+  public IntStream frameSequenceCpIndexes() {
+    int limit = stacks.size();
+    IntIterator iterator = stacks.iterator();
+    return IntStream.generate(iterator::nextInt).limit(limit);
+  }
+
+  @Override
+  public byte[] serialize() {
+    return chunkWriter.writeChunk(this);
+  }
+
+  @Override
+  public void serialize(Consumer<ByteBuffer> consumer) {
+    chunkWriter.writeChunk(this, consumer);
+  }
+
+  void addCompressedStackptr(int stackptr) {
+    if (!stacks.isEmpty()) {
+      int topItem = stacks.removeInt(stacks.size() - 1);
+      if (!stacks.isEmpty()) {
+        // checking for compression flag - `(topItem & 0x80000000) == 0x80000000`, simplified as
+        // `topItem < 0`
+        if (topItem < 0) { // topItem is the repetition counter
+          int counter = (topItem & 0x7fffffff);
+          if (stacks.getInt(stacks.size() - 1) == stackptr && counter < Integer.MAX_VALUE - 2) {
+            /*
+             * If inserting a consequent occurrence of the same stack trace and the repetition counter is not
+             * overflowing just update the repetition counter.
+             */
+            stacks.add((counter + 1) | 0x80000000);
+            return;
+          }
+          /*
+           * Not inserting a consequent occurrence of the same stack trace or the repetition counter is overflowing
+           */
+          stacks.add(topItem); // re-insert the topItem
+          stacks.add(stackptr);
+          return;
+        }
+      }
+      // otherwise the topItem is a plain stack pointer
+      if (stackptr == topItem) {
+        stacks.add(topItem); // re-insert the topItem
+        // inserting a consequent occurrence of the same stack trace
+        stacks.add(1 | 0x80000000); // insert repetition counter
+        return;
+      }
+      stacks.add(topItem);
+    }
+    stacks.add(stackptr);
+  }
+
+  private FrameSequence newTree(FrameElement frame, FrameSequence subtree) {
+    return new FrameSequence(frame, subtree, framePool, stackPool);
+  }
+}

--- a/utils/mlt-support/src/main/java/com/datadog/mlt/io/MLTChunkCollector.java
+++ b/utils/mlt-support/src/main/java/com/datadog/mlt/io/MLTChunkCollector.java
@@ -75,7 +75,8 @@ public abstract class MLTChunkCollector implements IMLTChunk {
 
   @Override
   public boolean hasStacks() {
-    return !stacks.isEmpty();
+    // Base stack doesn't count.
+    return stacks.size() > 1;
   }
 
   @Override

--- a/utils/mlt-support/src/main/java/com/datadog/mlt/io/MLTWriter.java
+++ b/utils/mlt-support/src/main/java/com/datadog/mlt/io/MLTWriter.java
@@ -89,7 +89,10 @@ public final class MLTWriter {
                   if (stack.getSubsequenceCpIndex() == -1) {
                     writer.writeByte((byte) 2);
                     writer.writeInt(stack.length());
-                    stack.frames().map(FrameElement::getCpIndex).forEachOrdered(writer::writeInt);
+                    stack
+                        .framesFromLeaves()
+                        .map(FrameElement::getCpIndex)
+                        .forEachOrdered(writer::writeInt);
                   } else {
                     int cutoff = 5;
                     int depth = stack.length();

--- a/utils/mlt-support/src/test/java/com/datadog/mlt/io/FrameSequenceTest.java
+++ b/utils/mlt-support/src/test/java/com/datadog/mlt/io/FrameSequenceTest.java
@@ -1,6 +1,10 @@
 package com.datadog.mlt.io;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -21,7 +25,7 @@ class FrameSequenceTest {
   void testEmptyInstance() {
     FrameSequence instance = new FrameSequence(0, new int[0], -1, framePool, stackPool);
     assertEquals(0, instance.length());
-    assertEquals(0, instance.frames().count());
+    assertEquals(0, instance.framesFromLeaves().count());
     assertEquals(-1, instance.getHeadCpIndex());
     assertEquals(-1, instance.getSubsequenceCpIndex());
   }
@@ -35,25 +39,30 @@ class FrameSequenceTest {
     assertNotEquals(-1, instance.getCpIndex());
     assertNotEquals(-1, instance.getHeadCpIndex());
     assertEquals(-1, instance.getSubsequenceCpIndex());
-
-    assertEquals(1, instance.frames().count());
-    assertArrayEquals(new FrameElement[] {frame}, instance.frames().toArray(FrameElement[]::new));
+    assertEquals(1, instance.framesFromLeaves().count());
+    assertArrayEquals(
+        new FrameElement[] {frame}, instance.framesFromLeaves().toArray(FrameElement[]::new));
   }
 
   @Test
   void testWithSubtreeInstanceFromElements() {
-    FrameElement frame = new FrameElement("owner", "method", 1, stringPool, framePool);
-    FrameSequence subtree = new FrameSequence(frame, null, framePool, stackPool);
-    FrameSequence instance = new FrameSequence(frame, subtree, framePool, stackPool);
+    FrameElement frame1 = new FrameElement("owner1", "method1", 1, stringPool, framePool);
+    FrameElement frame2 = new FrameElement("owner2", "method2", 2, stringPool, framePool);
+    FrameSequence subtree = new FrameSequence(frame1, null, framePool, stackPool);
+    FrameSequence instance = new FrameSequence(frame2, subtree, framePool, stackPool);
     assertNotNull(instance);
     assertEquals(2, instance.length());
     assertNotEquals(-1, instance.getCpIndex());
     assertNotEquals(-1, instance.getHeadCpIndex());
     assertNotEquals(-1, instance.getSubsequenceCpIndex());
 
-    assertEquals(2, instance.frames().count());
+    assertEquals(2, instance.framesFromLeaves().count());
     assertArrayEquals(
-        new FrameElement[] {frame, frame}, instance.frames().toArray(FrameElement[]::new));
+        new FrameElement[] {frame2, frame1},
+        instance.framesFromLeaves().toArray(FrameElement[]::new));
+    assertArrayEquals(
+        new FrameElement[] {frame1, frame2},
+        instance.framesFromRoot().toArray(FrameElement[]::new));
   }
 
   @Test
@@ -76,8 +85,9 @@ class FrameSequenceTest {
     assertEquals(framePtr, instance.getHeadCpIndex());
     assertEquals(-1, instance.getSubsequenceCpIndex());
 
-    assertEquals(1, instance.frames().count());
-    assertArrayEquals(new FrameElement[] {frame}, instance.frames().toArray(FrameElement[]::new));
+    assertEquals(1, instance.framesFromLeaves().count());
+    assertArrayEquals(
+        new FrameElement[] {frame}, instance.framesFromLeaves().toArray(FrameElement[]::new));
   }
 
   @Test
@@ -98,8 +108,9 @@ class FrameSequenceTest {
     assertEquals(framePtr, instance.getHeadCpIndex());
     assertEquals(stackSubtreePtr, instance.getSubsequenceCpIndex());
 
-    assertEquals(2, instance.frames().count());
+    assertEquals(2, instance.framesFromLeaves().count());
     assertArrayEquals(
-        new FrameElement[] {frame, frame}, instance.frames().toArray(FrameElement[]::new));
+        new FrameElement[] {frame, frame},
+        instance.framesFromLeaves().toArray(FrameElement[]::new));
   }
 }


### PR DESCRIPTION
Also increase span priority for MLT traces and use existing span priority as a signal for the heuristic.

Includes some changes for the decoder to allow iteration in both directions.