### PR TITLE
Fix finatra tests for latest dependencies

### DIFF
--- a/dd-java-agent/instrumentation/finatra-2.9/finatra-2.9.gradle
+++ b/dd-java-agent/instrumentation/finatra-2.9/finatra-2.9.gradle
@@ -9,10 +9,12 @@ apply from: "$rootDir/gradle/test-with-scala.gradle"
 apply plugin: 'org.unbroken-dome.test-sets'
 
 testSets {
-
-  latestDepTest {
+  // Up to 20.7 where the server structure changes
+  latestPre207Test {
     dirName = 'test'
   }
+
+  latestDepTest
 }
 
 muzzle {
@@ -40,11 +42,20 @@ dependencies {
   // Required for older versions of finatra on JDKs >= 11
   testCompile group: 'com.sun.activation', name: 'javax.activation', version: '1.2.0'
 
+  latestPre207TestCompile group: 'com.twitter', name: 'finatra-http_2.11', version: '[,20.7.0)'
+
   latestDepTestCompile group: 'com.twitter', name: 'finatra-http_2.11', version: '+'
-  latestDepTestCompile(group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.11.0')
+  latestDepTestCompile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.11.0'
 }
 
 compileLatestDepTestGroovy {
   classpath = classpath.plus(files(compileLatestDepTestScala.destinationDir))
   dependsOn compileLatestDepTestScala
 }
+
+compileLatestPre207TestGroovy {
+  classpath = classpath.plus(files(compileLatestPre207TestScala.destinationDir))
+  dependsOn compileLatestPre207TestScala
+}
+
+latestDepTest.finalizedBy latestPre207Test

--- a/dd-java-agent/instrumentation/finatra-2.9/src/latestDepTest/groovy/FinatraServer270Test.groovy
+++ b/dd-java-agent/instrumentation/finatra-2.9/src/latestDepTest/groovy/FinatraServer270Test.groovy
@@ -1,0 +1,112 @@
+import com.twitter.app.lifecycle.Event
+import com.twitter.app.lifecycle.Observer
+import com.twitter.finatra.http.HttpServer
+import com.twitter.util.Await
+import com.twitter.util.Closable
+import com.twitter.util.Duration
+import com.twitter.util.Promise
+import datadog.trace.agent.test.asserts.TraceAssert
+import datadog.trace.agent.test.base.HttpServerTest
+import datadog.trace.api.DDSpanTypes
+import datadog.trace.bootstrap.instrumentation.api.Tags
+import datadog.trace.core.DDSpan
+import datadog.trace.instrumentation.finatra.FinatraDecorator
+
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
+
+class FinatraServer270Test extends HttpServerTest<HttpServer> {
+  private static final Duration TIMEOUT = Duration.fromSeconds(5)
+  private static final Duration STARTUP_TIMEOUT = Duration.fromSeconds(20)
+
+  static closeAndWait(Closable closable) {
+    if (closable != null) {
+      Await.ready(closable.close(), TIMEOUT)
+    }
+  }
+
+  @Override
+  HttpServer startServer(int port) {
+    HttpServer testServer = new FinatraServer()
+
+    // Starting the server is blocking so start it in a separate thread
+    Thread startupThread = new Thread({
+      testServer.main("-admin.port=:0", "-http.port=:" + port)
+    })
+    startupThread.setDaemon(true)
+    startupThread.start()
+
+    Promise<Boolean> startupPromise = new Promise<>()
+
+    testServer.withObserver(new Observer() {
+      @Override
+      void onSuccess(Event event) {
+        if (event == testServer.startupCompletionEvent()) {
+          startupPromise.setValue(true)
+        }
+      }
+
+      void onEntry(Event event) {
+
+      }
+
+      @Override
+      void onFailure(Event stage, Throwable throwable) {
+        if (stage != Event.Close$.MODULE$) {
+          startupPromise.setException(throwable)
+        }
+      }
+    })
+
+    Await.result(startupPromise, STARTUP_TIMEOUT)
+
+    return testServer
+  }
+
+  @Override
+  boolean hasHandlerSpan() {
+    return true
+  }
+
+  @Override
+  boolean testNotFound() {
+    // Resource name is set to "GET /notFound"
+    false
+  }
+
+  @Override
+  void stopServer(HttpServer httpServer) {
+    Await.ready(httpServer.close(), TIMEOUT)
+  }
+
+  @Override
+  String component() {
+    return FinatraDecorator.DECORATE.component()
+  }
+
+  @Override
+  String expectedOperationName() {
+    return "finatra.request"
+  }
+
+  void handlerSpan(TraceAssert trace, int index, Object parent, ServerEndpoint endpoint = SUCCESS) {
+    def errorEndpoint = endpoint == EXCEPTION || endpoint == ERROR
+    trace.span(index) {
+      serviceName expectedServiceName()
+      operationName "finatra.controller"
+      resourceName "FinatraController"
+      spanType DDSpanTypes.HTTP_SERVER
+      errored errorEndpoint
+      childOf(parent as DDSpan)
+      tags {
+        "$Tags.COMPONENT" FinatraDecorator.DECORATE.component()
+        "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
+
+        // Finatra doesn't propagate the stack trace or exception to the instrumentation
+        // so the normal errorTags() method can't be used
+        defaultTags()
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/finatra-2.9/src/latestDepTest/groovy/NettyServerTestInstrumentation.java
+++ b/dd-java-agent/instrumentation/finatra-2.9/src/latestDepTest/groovy/NettyServerTestInstrumentation.java
@@ -1,0 +1,20 @@
+import static net.bytebuddy.matcher.ElementMatchers.named;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.test.base.HttpServerTestAdvice;
+import datadog.trace.agent.tooling.Instrumenter;
+import net.bytebuddy.agent.builder.AgentBuilder;
+
+@AutoService(Instrumenter.class)
+public class NettyServerTestInstrumentation implements Instrumenter {
+
+  @Override
+  public AgentBuilder instrument(final AgentBuilder agentBuilder) {
+    return agentBuilder
+        .type(named("io.netty.handler.codec.ByteToMessageDecoder"))
+        .transform(
+            new AgentBuilder.Transformer.ForAdvice()
+                .advice(
+                    named("channelRead"), HttpServerTestAdvice.ServerEntryAdvice.class.getName()));
+  }
+}

--- a/dd-java-agent/instrumentation/finatra-2.9/src/latestDepTest/scala/FinatraController.scala
+++ b/dd-java-agent/instrumentation/finatra-2.9/src/latestDepTest/scala/FinatraController.scala
@@ -1,0 +1,48 @@
+import com.twitter.finagle.http.{Request, Response}
+import com.twitter.finatra.http.Controller
+import com.twitter.util.Future
+import datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint._
+import datadog.trace.agent.test.base.HttpServerTest.controller
+import groovy.lang.Closure
+
+class FinatraController extends Controller {
+  any(SUCCESS.getPath) { request: Request =>
+    controller(SUCCESS, new Closure[Response](null) {
+      override def call(): Response = {
+        response.ok(SUCCESS.getBody)
+      }
+    })
+  }
+
+  any(ERROR.getPath) { request: Request =>
+    controller(ERROR, new Closure[Response](null) {
+      override def call(): Response = {
+        response.internalServerError(ERROR.getBody)
+      }
+    })
+  }
+
+  any(QUERY_PARAM.getPath) { request: Request =>
+    controller(QUERY_PARAM, new Closure[Response](null) {
+      override def call(): Response = {
+        response.ok(QUERY_PARAM.getBody)
+      }
+    })
+  }
+
+  any(EXCEPTION.getPath) { request: Request =>
+    controller(EXCEPTION, new Closure[Future[Response]](null) {
+      override def call(): Future[Response] = {
+        throw new Exception(EXCEPTION.getBody)
+      }
+    })
+  }
+
+  any(REDIRECT.getPath) { request: Request =>
+    controller(REDIRECT, new Closure[Response](null) {
+      override def call(): Response = {
+        response.found.location(REDIRECT.getBody)
+      }
+    })
+  }
+}

--- a/dd-java-agent/instrumentation/finatra-2.9/src/latestDepTest/scala/FinatraServer.scala
+++ b/dd-java-agent/instrumentation/finatra-2.9/src/latestDepTest/scala/FinatraServer.scala
@@ -1,0 +1,13 @@
+import com.twitter.finagle.http.Request
+import com.twitter.finatra.http.HttpServer
+import com.twitter.finatra.http.filters.ExceptionMappingFilter
+import com.twitter.finatra.http.routing.HttpRouter
+
+class FinatraServer extends HttpServer {
+  override protected def configureHttp(router: HttpRouter): Unit = {
+    router
+      .filter[ExceptionMappingFilter[Request]]
+      .add[FinatraController]
+      .exceptionMapper[ResponseSettingExceptionMapper]
+  }
+}

--- a/dd-java-agent/instrumentation/finatra-2.9/src/latestDepTest/scala/ResponseSettingExceptionMapper.scala
+++ b/dd-java-agent/instrumentation/finatra-2.9/src/latestDepTest/scala/ResponseSettingExceptionMapper.scala
@@ -1,0 +1,13 @@
+import com.twitter.finagle.http.{Request, Response}
+import com.twitter.finatra.http.exceptions.ExceptionMapper
+import com.twitter.finatra.http.response.ResponseBuilder
+import javax.inject.{Inject, Singleton}
+
+@Singleton
+class ResponseSettingExceptionMapper @Inject()(response: ResponseBuilder)
+    extends ExceptionMapper[Exception] {
+
+  override def toResponse(request: Request, exception: Exception): Response = {
+    response.internalServerError(exception.getMessage)
+  }
+}


### PR DESCRIPTION
At `20.7.0` Finatra removed the `started` property from HttpServer.  This caused `latestDepTest` to fail.

This pull request addresses the change by checking for the startup event.  After this pull request, there are 3 distinct test sets: 
- 19.12
- everything up until 20.7
- the latest.

At first, I attempted to reuse the test code more however I could not get the testSets plugin, scala, and Finatra to behave.  I'm sure it could be done with a little more effort.  For now, I just copy/pasted the test code.  The only difference between the tests is `startServer()`