### PR TITLE
use spring-webflux-5.1+ ClientResponse.rawStatusCode when available

### DIFF
--- a/dd-java-agent/instrumentation/spring-webflux-5/spring-webflux-5.gradle
+++ b/dd-java-agent/instrumentation/spring-webflux-5/spring-webflux-5.gradle
@@ -6,6 +6,16 @@ ext {
 
 muzzle {
   pass {
+    name = "webflux_5.0.0+_with_netty_0.8.0"
+    group = "org.springframework"
+    module = "spring-webflux"
+    versions = "[5.0.0.RELEASE,)"
+    assertInverse = true
+    extraDependency "io.projectreactor.netty:reactor-netty:0.8.0.RELEASE"
+  }
+
+  pass {
+    name = "webflux_5.0.0_with_ipc_0.7.0"
     group = "org.springframework"
     module = "spring-webflux"
     versions = "[5.0.0.RELEASE,)"
@@ -14,6 +24,15 @@ muzzle {
   }
 
   pass {
+    name = "netty_0.8.0+_with_spring-webflux:5.1.0"
+    group = "io.projectreactor.netty"
+    module = "reactor-netty"
+    versions = "[0.8.0.RELEASE,)"
+    extraDependency "org.springframework:spring-webflux:5.1.0.RELEASE"
+  }
+
+  pass {
+    name = "ipc_0.7.0+_with_spring-webflux:5.0.0"
     group = "io.projectreactor.ipc"
     module = "reactor-netty"
     versions = "[0.7.0.RELEASE,)"


### PR DESCRIPTION
Allows support for non-standard HTTP status codes which webflux allows access to from 5.1.0+ via method handles. Still works with older webflux versions but the absence of `ClientResponse.rawStatusCode` will raise an error and default to the strict mode of webflux 5.0.0, which is all we can really do.

I muzzle all combinations of `spring-webflux/reactor-netty` except for webflux 5.0.0/reactor-netty 0.8.0 which can't exist.

I ruled out cloning the instrumentation for webflux 5.1.0+ because it would lead to too much duplication, and I found no good way to detect which webflux version was present. I also ruled out dropping support for webflux 5.0.0.