### PR TITLE
MLT - Delay processing of stacktrace on construct

### DIFF
--- a/utils/mlt-support/src/main/java/com/datadog/mlt/io/MLTChunkCollector.java
+++ b/utils/mlt-support/src/main/java/com/datadog/mlt/io/MLTChunkCollector.java
@@ -21,7 +21,7 @@ public abstract class MLTChunkCollector implements IMLTChunk {
    * Base stacktrace to add the first time collect is called. This is done to avoid the cost of
    * converting in the main thread (especially if no additional stacktraces are collected).
    */
-  private StackTraceElement[] baseStack;
+  private volatile StackTraceElement[] baseStack;
 
   @Getter protected final ConstantPool<FrameElement> framePool;
   @Getter protected final ConstantPool<FrameSequence> stackPool;


### PR DESCRIPTION
This was expensive, so we want to do it the first time collect is called, which will be on a background thread.