### PR TITLE
Move Spring Scheduling RunnableWrapper to separate class

### DIFF
--- a/dd-java-agent/instrumentation/spring-scheduling-3.1/src/main/java/datadog/trace/instrumentation/springscheduling/SpringSchedulingInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-scheduling-3.1/src/main/java/datadog/trace/instrumentation/springscheduling/SpringSchedulingInstrumentation.java
@@ -28,7 +28,7 @@ public final class SpringSchedulingInstrumentation extends Instrumenter.Default 
   @Override
   public String[] helperClassNames() {
     return new String[] {
-      packageName + ".SpringSchedulingDecorator", packageName + "SpringSchedulingRunnableWrapper",
+      packageName + ".SpringSchedulingDecorator", packageName + ".SpringSchedulingRunnableWrapper",
     };
   }
 

--- a/dd-java-agent/instrumentation/spring-scheduling-3.1/src/main/java/datadog/trace/instrumentation/springscheduling/SpringSchedulingInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-scheduling-3.1/src/main/java/datadog/trace/instrumentation/springscheduling/SpringSchedulingInstrumentation.java
@@ -1,8 +1,5 @@
 package datadog.trace.instrumentation.springscheduling;
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
-import static datadog.trace.instrumentation.springscheduling.SpringSchedulingDecorator.DECORATE;
 import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
 import static net.bytebuddy.matcher.ElementMatchers.named;
@@ -10,8 +7,6 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
-import datadog.trace.bootstrap.instrumentation.api.AgentScope;
-import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.method.MethodDescription;
@@ -33,7 +28,7 @@ public final class SpringSchedulingInstrumentation extends Instrumenter.Default 
   @Override
   public String[] helperClassNames() {
     return new String[] {
-      packageName + ".SpringSchedulingDecorator", getClass().getName() + "$RunnableWrapper",
+      packageName + ".SpringSchedulingDecorator", packageName + "SpringSchedulingRunnableWrapper",
     };
   }
 
@@ -48,45 +43,7 @@ public final class SpringSchedulingInstrumentation extends Instrumenter.Default 
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static void onConstruction(
         @Advice.Argument(value = 0, readOnly = false) Runnable runnable) {
-      runnable = RunnableWrapper.wrapIfNeeded(runnable);
-    }
-  }
-
-  public static class RunnableWrapper implements Runnable {
-    private final Runnable runnable;
-
-    private RunnableWrapper(final Runnable runnable) {
-      this.runnable = runnable;
-    }
-
-    @Override
-    public void run() {
-      final AgentSpan span = startSpan("scheduled.call");
-      DECORATE.afterStart(span);
-
-      try (final AgentScope scope = activateSpan(span)) {
-        DECORATE.onRun(span, runnable);
-        scope.setAsyncPropagation(true);
-
-        try {
-          runnable.run();
-        } catch (final Throwable throwable) {
-          DECORATE.onError(span, throwable);
-          throw throwable;
-        }
-      } finally {
-        DECORATE.beforeFinish(span);
-        span.finish();
-      }
-    }
-
-    public static Runnable wrapIfNeeded(final Runnable task) {
-      // We wrap only lambdas' anonymous classes and if given object has not already been wrapped.
-      // Anonymous classes have '/' in class name which is not allowed in 'normal' classes.
-      if (task instanceof RunnableWrapper) {
-        return task;
-      }
-      return new RunnableWrapper(task);
+      runnable = SpringSchedulingRunnableWrapper.wrapIfNeeded(runnable);
     }
   }
 }

--- a/dd-java-agent/instrumentation/spring-scheduling-3.1/src/main/java/datadog/trace/instrumentation/springscheduling/SpringSchedulingRunnableWrapper.java
+++ b/dd-java-agent/instrumentation/spring-scheduling-3.1/src/main/java/datadog/trace/instrumentation/springscheduling/SpringSchedulingRunnableWrapper.java
@@ -1,0 +1,46 @@
+package datadog.trace.instrumentation.springscheduling;
+
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+import static datadog.trace.instrumentation.springscheduling.SpringSchedulingDecorator.DECORATE;
+
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+
+public class SpringSchedulingRunnableWrapper implements Runnable {
+  private final Runnable runnable;
+
+  private SpringSchedulingRunnableWrapper(final Runnable runnable) {
+    this.runnable = runnable;
+  }
+
+  @Override
+  public void run() {
+    final AgentSpan span = startSpan("scheduled.call");
+    DECORATE.afterStart(span);
+
+    try (final AgentScope scope = activateSpan(span)) {
+      DECORATE.onRun(span, runnable);
+      scope.setAsyncPropagation(true);
+
+      try {
+        runnable.run();
+      } catch (final Throwable throwable) {
+        DECORATE.onError(span, throwable);
+        throw throwable;
+      }
+    } finally {
+      DECORATE.beforeFinish(span);
+      span.finish();
+    }
+  }
+
+  public static Runnable wrapIfNeeded(final Runnable task) {
+    // We wrap only lambdas' anonymous classes and if given object has not already been wrapped.
+    // Anonymous classes have '/' in class name which is not allowed in 'normal' classes.
+    if (task instanceof SpringSchedulingRunnableWrapper) {
+      return task;
+    }
+    return new SpringSchedulingRunnableWrapper(task);
+  }
+}


### PR DESCRIPTION
This works around an edge case where Spring Sleuth tries to load the RunnableWrapper's enclosing class:
https://github.com/spring-projects/spring-framework/blob/v5.2.2.RELEASE/spring-core/src/main/java/org/springframework/core/annotation/AnnotationsScanner.java#L233

Since the enclosing class is on a separate class loader, this fails and results in an exception.