### PR TITLE
UnsafeUtils::setStaticFieldViaUnsafe should use putBooleanVolatile

### DIFF
--- a/dd-java-agent/instrumentation/log4j2/src/test/groovy/Log4jThreadContextWithEnableThreadLocalsTest.groovy
+++ b/dd-java-agent/instrumentation/log4j2/src/test/groovy/Log4jThreadContextWithEnableThreadLocalsTest.groovy
@@ -1,10 +1,12 @@
 import datadog.trace.agent.test.utils.UnsafeUtils
 
+
 class Log4jThreadContextWithEnableThreadLocalsTest extends Log4jThreadContextTest {
   static {
     //TODO: set ("log4j2.is.webapp" = "true") from "log4j2.component.properties" file instead of:
-    UnsafeUtils.setStaticField(
-      Class.forName("org.apache.logging.log4j.util.Constants")  .getField("ENABLE_THREADLOCALS"),
+    UnsafeUtils.setStaticBooleanField(
+      Class.forName("org.apache.logging.log4j.util.Constants")
+        .getField("ENABLE_THREADLOCALS"),
       true
     )
   }

--- a/dd-java-agent/testing/src/main/java/datadog/trace/agent/test/utils/UnsafeUtils.java
+++ b/dd-java-agent/testing/src/main/java/datadog/trace/agent/test/utils/UnsafeUtils.java
@@ -15,7 +15,7 @@ public class UnsafeUtils {
     return Integer.parseInt(javaVersion.substring(beg, end));
   }
 
-  private static void setStaticFieldViaUnsafe(final Field field, final Object newValue)
+  private static void setStaticBooleanFieldViaUnsafe(final Field field, final boolean newValue)
       throws Exception {
     final Field unsafeField = sun.misc.Unsafe.class.getDeclaredField("theUnsafe");
     unsafeField.setAccessible(true);
@@ -25,7 +25,7 @@ public class UnsafeUtils {
 
     final Object staticFieldBase = unsafe.staticFieldBase(field);
     final long staticFieldOffset = unsafe.staticFieldOffset(field);
-    unsafe.putObjectVolatile(staticFieldBase, staticFieldOffset, newValue);
+    unsafe.putBooleanVolatile(staticFieldBase, staticFieldOffset, newValue);
   }
 
   private static void setStaticFieldViaReflection(final Field field, final Object newValue)
@@ -39,12 +39,13 @@ public class UnsafeUtils {
     modifiersField.setInt(field, origModifiers);
   }
 
-  public static void setStaticField(final Field field, final Object newValue) throws Exception {
+  public static void setStaticBooleanField(final Field field, final boolean newValue)
+      throws Exception {
     if (JAVA_VERSION < 12) {
       setStaticFieldViaReflection(field, newValue);
     } else {
       // since 12 we can't use reflection: http://hg.openjdk.java.net/jdk/jdk/rev/f55a4bc91ef4
-      setStaticFieldViaUnsafe(field, newValue);
+      setStaticBooleanFieldViaUnsafe(field, newValue);
     }
   }
 }

--- a/dd-java-agent/testing/src/main/java/datadog/trace/agent/test/utils/UnsafeUtils.java
+++ b/dd-java-agent/testing/src/main/java/datadog/trace/agent/test/utils/UnsafeUtils.java
@@ -21,9 +21,11 @@ public class UnsafeUtils {
     unsafeField.setAccessible(true);
     final sun.misc.Unsafe unsafe = (sun.misc.Unsafe) unsafeField.get(null);
 
+    unsafe.ensureClassInitialized(field.getDeclaringClass());
+
     final Object staticFieldBase = unsafe.staticFieldBase(field);
     final long staticFieldOffset = unsafe.staticFieldOffset(field);
-    unsafe.putObject(staticFieldBase, staticFieldOffset, newValue);
+    unsafe.putObjectVolatile(staticFieldBase, staticFieldOffset, newValue);
   }
 
   private static void setStaticFieldViaReflection(final Field field, final Object newValue)


### PR DESCRIPTION
log4j2:testJava14Generated crashes in VM G1 code after setting static final field by Unsafe. This change tries to fix this test problem