### PR TITLE
Don't double count baggage overridden by tag

### DIFF
--- a/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanSerializationTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanSerializationTest.groovy
@@ -148,6 +148,72 @@ class DDSpanSerializationTest extends DDSpecification {
     DDId.from("${2G.pow(64).subtract(1G)}")                         | "some-type"
   }
 
+  def "serialize trace with baggage and tags correctly"() {
+    setup:
+    def writer = new ListWriter()
+    def tracer = CoreTracer.builder().writer(writer).build()
+    def context = new DDSpanContext(
+      DDId.ONE,
+      DDId.ONE,
+      DDId.ZERO,
+      "fakeService",
+      "fakeOperation",
+      "fakeResource",
+      PrioritySampling.UNSET,
+      null,
+      baggage,
+      false,
+      null,
+      tags,
+      PendingTrace.create(tracer, DDId.ONE),
+      tracer,
+      [:])
+    def span = DDSpan.create(0, context)
+    def buffer = ByteBuffer.allocate(1024)
+    CaptureBuffer capture = new CaptureBuffer()
+    def packer = new Packer(capture, buffer)
+    packer.format(Collections.singletonList(span), new TraceMapper())
+    packer.flush()
+    def unpacker = MessagePack.newDefaultUnpacker(new ArrayBufferInput(capture.bytes))
+    int traceCount = unpacker.unpackArrayHeader()
+    int spanCount = unpacker.unpackArrayHeader()
+    int size = unpacker.unpackMapHeader()
+
+    expect:
+    traceCount == 1
+    spanCount == 1
+    size == 12
+    for (int i = 0; i < size; i++) {
+      String key = unpacker.unpackString()
+
+      switch (key) {
+        case "meta":
+          int packedSize = unpacker.unpackMapHeader()
+          int expectedSize = expected.size()
+          // filter out "thread.name" and "thread.id"
+          assert packedSize - 2 == expectedSize
+          Map<String, String> unpackedMeta = [:]
+          for (int j = 0; j < packedSize; j++) {
+            def k = unpacker.unpackString()
+            def v = unpacker.unpackString()
+            if (k != "thread.name" && k != "thread.id") {
+              unpackedMeta.put(k, v)
+            }
+          }
+          assert unpackedMeta == expected
+          break
+        default:
+          unpacker.unpackValue()
+      }
+    }
+
+    where:
+    baggage       | tags           | expected
+    [:]           | [:]            | [:]
+    [foo: "bbar"] | [:]            | [foo: "bbar"]
+    [foo: "bbar"] | [bar: "tfoo"]  | [foo: "bbar", bar: "tfoo"]
+    [foo: "bbar"] | [foo: "tbar"]  | [foo: "tbar"]
+  }
 
   private class CaptureBuffer implements ByteBufferConsumer {
 


### PR DESCRIPTION
While working on optimizing the tags map, I ran into this little gem, that can make us write a bad `msgpack` message with a map with higher count than actual entries. Been there since we stopped merging the baggage and tags into a common map before writing.