### PR TITLE
MLT - Attempt at using `fillInStackTrace` to reduce overhead

### DIFF
--- a/dd-java-agent/agent-mlt/src/main/java/com/datadog/mlt/sampler/ScopeStackCollector.java
+++ b/dd-java-agent/agent-mlt/src/main/java/com/datadog/mlt/sampler/ScopeStackCollector.java
@@ -32,7 +32,7 @@ final class ScopeStackCollector extends MLTChunkCollector {
       ConstantPool<String> stringPool,
       ConstantPool<FrameElement> framePool,
       ConstantPool<FrameSequence> stackPool) {
-    super(new Throwable().getStackTrace(), stringPool, framePool, stackPool);
+    super(new Throwable(), stringPool, framePool, stackPool);
     this.scopeId = scopeId;
     this.threadStacktraceCollector = threadStacktraceCollector;
     startTime = startTimeEpoch;

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/TraceProfilingScopeInterceptor.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/TraceProfilingScopeInterceptor.java
@@ -17,7 +17,7 @@ import java.util.concurrent.TimeUnit;
 public abstract class TraceProfilingScopeInterceptor
     extends ScopeInterceptor.DelegatingInterceptor {
   private static final long MAX_NANOSECONDS_BETWEEN_ACTIVATIONS = TimeUnit.SECONDS.toNanos(1);
-  private static final double ACTIVATIONS_PER_SECOND = 50;
+  private static final double ACTIVATIONS_PER_SECOND = 5;
   private static final ThreadLocal<Boolean> IS_THREAD_PROFILING =
       new ThreadLocal<Boolean>() {
         @Override

--- a/utils/mlt-support/src/main/java/com/datadog/mlt/io/MLTChunkCollector.java
+++ b/utils/mlt-support/src/main/java/com/datadog/mlt/io/MLTChunkCollector.java
@@ -21,7 +21,7 @@ public abstract class MLTChunkCollector implements IMLTChunk {
    * Base stacktrace to add the first time collect is called. This is done to avoid the cost of
    * converting in the main thread (especially if no additional stacktraces are collected).
    */
-  private volatile StackTraceElement[] baseStack;
+  private volatile Throwable baseStack;
 
   @Getter protected final ConstantPool<FrameElement> framePool;
   @Getter protected final ConstantPool<FrameSequence> stackPool;
@@ -32,7 +32,7 @@ public abstract class MLTChunkCollector implements IMLTChunk {
   private final MLTWriter chunkWriter = new MLTWriter();
 
   public MLTChunkCollector(
-      StackTraceElement[] baseStack,
+      Throwable baseStack,
       ConstantPool<String> stringPool,
       ConstantPool<FrameElement> framePool,
       ConstantPool<FrameSequence> stackPool) {
@@ -52,7 +52,7 @@ public abstract class MLTChunkCollector implements IMLTChunk {
       return;
     }
     if (baseStack != null) {
-      StackTraceElement[] base = baseStack;
+      StackTraceElement[] base = baseStack.getStackTrace();
       baseStack = null;
       collect(base); // recursive call to add base as first element.
     }


### PR DESCRIPTION
Turns out `getStackTrace` is quite expensive and not feasible to use on the critical path.  Hopefully `fillInStackTrace` isn't so expensive.