### PR TITLE
Remove specific configuration properties for JUnit integration.

### DIFF
--- a/dd-java-agent/instrumentation/junit-4.10/junit-4.10.gradle
+++ b/dd-java-agent/instrumentation/junit-4.10/junit-4.10.gradle
@@ -4,7 +4,7 @@ muzzle {
   pass {
     group = 'junit'
     module = 'junit'
-    versions = '[4.10,]'
+    versions = '[4.10,5)'
     assertInverse = true
   }
 }

--- a/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4Instrumentation.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4Instrumentation.java
@@ -7,7 +7,6 @@ import static net.bytebuddy.matcher.ElementMatchers.named;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
-import datadog.trace.api.Config;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
@@ -58,7 +57,7 @@ public class JUnit4Instrumentation extends Instrumenter.Default {
 
   @Override
   protected boolean defaultEnabled() {
-    return Config.get().isTraceTestsEnabled();
+    return false;
   }
 
   public static class TestStartedAdvice {

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/TestFrameworkTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/TestFrameworkTest.groovy
@@ -14,7 +14,7 @@ abstract class TestFrameworkTest extends AgentTestRunner {
 
   static {
     ConfigUtils.updateConfig {
-      System.setProperty("dd.trace.tests.enabled", "true")
+      System.setProperty("dd.integration.junit.enabled", "true")
     }
   }
 

--- a/dd-trace-api/src/main/java/datadog/trace/api/Config.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/Config.java
@@ -46,7 +46,6 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_METHODS;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_RATE_LIMIT;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_REPORT_HOSTNAME;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_RESOLVER_ENABLED;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_TESTS_ENABLED;
 import static datadog.trace.api.DDTags.HOST_TAG;
 import static datadog.trace.api.DDTags.INTERNAL_HOST_NAME;
 import static datadog.trace.api.DDTags.LANGUAGE_TAG_KEY;
@@ -54,7 +53,6 @@ import static datadog.trace.api.DDTags.LANGUAGE_TAG_VALUE;
 import static datadog.trace.api.DDTags.RUNTIME_ID_TAG;
 import static datadog.trace.api.DDTags.SERVICE;
 import static datadog.trace.api.DDTags.SERVICE_TAG;
-import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_TESTS_ENABLED;
 
 import datadog.trace.api.config.GeneralConfig;
 import datadog.trace.api.config.JmxFetchConfig;
@@ -333,8 +331,6 @@ public class Config {
   @Getter private final Double traceSampleRate;
   @Getter private final Double traceRateLimit;
 
-  @Getter private final boolean traceTestsEnabled;
-
   @Getter private final boolean profilingEnabled;
   @Deprecated private final String profilingUrl;
   private final Map<String, String> profilingTags;
@@ -537,9 +533,6 @@ public class Config {
         getMapSettingFromEnvironment(TRACE_SAMPLING_OPERATION_RULES, null);
     traceSampleRate = getDoubleSettingFromEnvironment(TRACE_SAMPLE_RATE, null);
     traceRateLimit = getDoubleSettingFromEnvironment(TRACE_RATE_LIMIT, DEFAULT_TRACE_RATE_LIMIT);
-
-    traceTestsEnabled =
-        getBooleanSettingFromEnvironment(TRACE_TESTS_ENABLED, DEFAULT_TRACE_TESTS_ENABLED);
 
     profilingEnabled =
         getBooleanSettingFromEnvironment(PROFILING_ENABLED, DEFAULT_PROFILING_ENABLED);
@@ -778,8 +771,6 @@ public class Config {
             properties, TRACE_SAMPLING_OPERATION_RULES, parent.traceSamplingOperationRules);
     traceSampleRate = getPropertyDoubleValue(properties, TRACE_SAMPLE_RATE, parent.traceSampleRate);
     traceRateLimit = getPropertyDoubleValue(properties, TRACE_RATE_LIMIT, parent.traceRateLimit);
-    traceTestsEnabled =
-        getPropertyBooleanValue(properties, TRACE_TESTS_ENABLED, parent.traceTestsEnabled);
 
     profilingEnabled =
         getPropertyBooleanValue(properties, PROFILING_ENABLED, parent.profilingEnabled);

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -68,7 +68,6 @@ public final class ConfigDefaults {
   static final String DEFAULT_TRACE_EXECUTORS = "";
   static final String DEFAULT_TRACE_METHODS = null;
   static final boolean DEFAULT_TRACE_ANALYTICS_ENABLED = false;
-  static final boolean DEFAULT_TRACE_TESTS_ENABLED = false;
   static final float DEFAULT_ANALYTICS_SAMPLE_RATE = 1.0f;
   static final double DEFAULT_TRACE_RATE_LIMIT = 100;
 


### PR DESCRIPTION
Removed specific configuration properties for `JUnit` integration.

The property `dd.integrations.junit.enabled=true` will be used instead of that.