### PR TITLE
cache kafka resource names

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/api/FixedSizeCache.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/api/FixedSizeCache.java
@@ -33,6 +33,19 @@ public final class FixedSizeCache<K, V> {
     }
   }
 
+  public static final class Prefix implements Creator<String, String> {
+    private final String prefix;
+
+    public Prefix(String prefix) {
+      this.prefix = prefix;
+    }
+
+    @Override
+    public String create(String key) {
+      return prefix + key;
+    }
+  }
+
   public static final class LowerCase implements Creator<String, String> {
 
     @Override

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/KafkaStreamsDecorator.java
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/KafkaStreamsDecorator.java
@@ -3,6 +3,7 @@ package datadog.trace.instrumentation.kafka_streams;
 import datadog.trace.api.DDSpanTypes;
 import datadog.trace.api.DDTags;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.FixedSizeCache;
 import datadog.trace.bootstrap.instrumentation.api.InstrumentationTags;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.decorator.ClientDecorator;
@@ -10,6 +11,10 @@ import org.apache.kafka.streams.processor.internals.StampedRecord;
 
 public class KafkaStreamsDecorator extends ClientDecorator {
   public static final KafkaStreamsDecorator CONSUMER_DECORATE = new KafkaStreamsDecorator();
+
+  private static final FixedSizeCache<String, String> RESOURCE_NAME_CACHE =
+      new FixedSizeCache<>(32);
+  private static final FixedSizeCache.Prefix PREFIX = new FixedSizeCache.Prefix("Consume Topic ");
 
   @Override
   protected String[] instrumentationNames() {
@@ -39,7 +44,7 @@ public class KafkaStreamsDecorator extends ClientDecorator {
   public void onConsume(final AgentSpan span, final StampedRecord record) {
     if (record != null) {
       final String topic = record.topic() == null ? "kafka" : record.topic();
-      span.setTag(DDTags.RESOURCE_NAME, "Consume Topic " + topic);
+      span.setTag(DDTags.RESOURCE_NAME, RESOURCE_NAME_CACHE.computeIfAbsent(topic, PREFIX));
       span.setTag("partition", record.partition());
       span.setTag("offset", record.offset());
       span.setTag(InstrumentationTags.DD_MEASURED, true);


### PR DESCRIPTION
This caches the kafka resource names which avoids recomputing string hash codes during serialisation, once we start deduplicating strings this will become important.