### PR TITLE
Consistent error messaging for profiling startup

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
@@ -276,15 +276,10 @@ public class Agent {
               "com.datadog.profiling.controller.openjdk.events.DeadlockEventFactory");
       final Method registerMethod = deadlockFactoryClass.getMethod("registerEvents");
       registerMethod.invoke(null);
+    } catch (final NoClassDefFoundError | ClassNotFoundException e) {
+      log.info("JMX deadlock detection not supported");
     } catch (final Throwable ex) {
-      String msg = "Unable to initialize JMX thread deadlock detector";
-      if (log.isDebugEnabled()) {
-        // in debug level we want to see also the throwable and stacktrace
-        log.info(msg, ex);
-      } else {
-        // in non-debug level do not scare the user with the throwable and stacktrace
-        log.info(msg);
-      }
+      log.error("Unable to initialize JMX thread deadlock detector", ex);
     }
   }
 
@@ -339,8 +334,7 @@ public class Agent {
       Profiling is compiled for Java8. Loading it on Java7 results in ClassFormatError
       (more specifically UnsupportedClassVersionError). Just ignore and continue when this happens.
       */
-      log.error("Profiling requires OpenJDK 8 or above - skipping");
-      log.debug("Cannot start profiling agent ", e);
+      log.info("Profiling requires OpenJDK 8 or above - skipping");
     } catch (final Throwable ex) {
       log.error("Throwable thrown while starting profiling agent", ex);
     } finally {

--- a/dd-trace-core/src/main/java/datadog/trace/core/util/ThreadCpuTimeAccess.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/util/ThreadCpuTimeAccess.java
@@ -23,7 +23,7 @@ public final class ThreadCpuTimeAccess {
   /** Enable JMX based thread CPU time */
   public static void enableJmx() {
     if (!Config.get().isProfilingEnabled()) {
-      log.debug("Will not enable thread CPU time access. Profiling is disabled.");
+      log.info("Will not enable thread CPU time access. Profiling is disabled.");
       return;
     }
     try {


### PR DESCRIPTION
* Put all "not initializing" messages at `info` level.  The log has messages like "Initializing ..." at info, but then the "Not started because..." messages are hidden unless at `debug`

* Don't print known exceptions at `debug`.  This continues to lead to confusion when users are running a jdk with JFR events