### PR TITLE
don't cache classloaders which can be skipped by name

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/ClassLoaderMatcher.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/ClassLoaderMatcher.java
@@ -49,6 +49,9 @@ public final class ClassLoaderMatcher {
         // Don't skip bootstrap loader
         return false;
       }
+      if (shouldSkipClass(cl)) {
+        return true;
+      }
       Boolean v = skipCache.getIfPresent(cl);
       if (v != null) {
         return v;
@@ -61,7 +64,7 @@ public final class ClassLoaderMatcher {
       // and we don't want to introduce the concept of the tooling code depending on whether or not
       // a particular instrumentation is active (mainly because this particular use case doesn't
       // seem to justify introducing either of these new concepts)
-      v = shouldSkipClass(cl) || !delegatesToBootstrap(cl);
+      v = !delegatesToBootstrap(cl);
       skipCache.put(cl, v);
       return v;
     }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/ClassLoaderMatcher.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/ClassLoaderMatcher.java
@@ -49,7 +49,7 @@ public final class ClassLoaderMatcher {
         // Don't skip bootstrap loader
         return false;
       }
-      if (shouldSkipClass(cl)) {
+      if (canSkipClassLoaderByName(cl)) {
         return true;
       }
       Boolean v = skipCache.getIfPresent(cl);
@@ -69,7 +69,7 @@ public final class ClassLoaderMatcher {
       return v;
     }
 
-    private static boolean shouldSkipClass(final ClassLoader loader) {
+    private static boolean canSkipClassLoaderByName(final ClassLoader loader) {
       switch (loader.getClass().getName()) {
         case "org.codehaus.groovy.runtime.callsite.CallSiteClassLoader":
         case "sun.reflect.DelegatingClassLoader":


### PR DESCRIPTION
These classloaders are so cheap to skip that the check doesn't require caching.