### PR TITLE
PrintingWriter fails on second trace

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/PrintingWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/PrintingWriter.java
@@ -1,7 +1,6 @@
 package datadog.trace.common.writer;
 
 import com.squareup.moshi.JsonAdapter;
-import com.squareup.moshi.JsonWriter;
 import com.squareup.moshi.Moshi;
 import com.squareup.moshi.Types;
 import datadog.trace.core.DDSpan;
@@ -11,15 +10,16 @@ import java.io.OutputStream;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import okio.BufferedSink;
 import okio.Okio;
 
 public class PrintingWriter implements Writer {
   private final TraceProcessor processor = new TraceProcessor();
-  private final JsonWriter jsonWriter;
+  private final BufferedSink sink;
   private final JsonAdapter<Map<String, List<DDSpan>>> jsonAdapter;
 
   public PrintingWriter(final OutputStream outputStream, final boolean hexIds) {
-    jsonWriter = JsonWriter.of(Okio.buffer(Okio.sink(outputStream)));
+    sink = Okio.buffer(Okio.sink(outputStream));
 
     this.jsonAdapter =
         new Moshi.Builder()
@@ -34,8 +34,10 @@ public class PrintingWriter implements Writer {
   public void write(final List<DDSpan> trace) {
     final List<DDSpan> processedTrace = processor.onTraceComplete(trace);
     try {
-      jsonAdapter.toJson(jsonWriter, Collections.singletonMap("traces", processedTrace));
-      jsonWriter.flush();
+      synchronized (sink) {
+        jsonAdapter.toJson(sink, Collections.singletonMap("traces", processedTrace));
+        sink.flush();
+      }
     } catch (final IOException e) {
       // do nothing
     }

--- a/dd-trace-core/src/test/groovy/datadog/trace/api/writer/PrintingWriterTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/api/writer/PrintingWriterTest.groovy
@@ -14,6 +14,7 @@ class PrintingWriterTest extends DDSpecification {
 
   def tracer = Mock(CoreTracer)
   def sampleTrace = [SpanFactory.newSpanOf(tracer), SpanFactory.newSpanOf(tracer)]
+  def secondTrace = [SpanFactory.newSpanOf(tracer)]
 
   def adapter = new Moshi.Builder().build().adapter(Types.newParameterizedType(Map, String, Types.newParameterizedType(List, Map)))
 
@@ -28,6 +29,27 @@ class PrintingWriterTest extends DDSpecification {
 
     then:
     result["traces"].size() == sampleTrace.size()
+    result["traces"].each {
+      assert it["service"] == "fakeService"
+      assert it["name"] == "fakeOperation"
+      assert it["resource"] == "fakeResource"
+      assert it["type"] == "fakeType"
+      assert it["trace_id"] instanceof Number
+      assert it["span_id"] instanceof Number
+      assert it["parent_id"] instanceof Number
+      assert it["start"] instanceof Number
+      assert it["duration"] instanceof Number
+      assert it["error"] == 0
+      assert it["metrics"] instanceof Map
+      assert it["meta"] instanceof Map
+    }
+
+    when:
+    writer.write(secondTrace)
+    result = adapter.fromJson(buffer.readString(StandardCharsets.UTF_8))
+
+    then:
+    result["traces"].size() == secondTrace.size()
     result["traces"].each {
       assert it["service"] == "fakeService"
       assert it["name"] == "fakeOperation"


### PR DESCRIPTION
Annoyingly, I missed that `com.squareup.moshi.JsonWriter` can't be reused.  The PrintingWriter fails on the second call to `write()` 🤦 .