### PR TITLE
Out-of-Order Scope Close Handling

### DIFF
--- a/dd-java-agent/instrumentation/opentelemetry/src/test/groovy/OpenTelemetryTest.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/src/test/groovy/OpenTelemetryTest.groovy
@@ -223,14 +223,9 @@ class OpenTelemetryTest extends AgentTestRunner {
     secondScope.close()
 
     then:
-    tracer.currentSpan.delegate == firstScope.delegate.span()
+    tracer.currentSpan == null
     0 * _
 
-    when:
-    firstScope.close()
-
-    then:
-    0 * _
   }
 
   def "test continuation"() {

--- a/dd-java-agent/instrumentation/opentracing/api-0.31/src/test/groovy/OpenTracing31Test.groovy
+++ b/dd-java-agent/instrumentation/opentracing/api-0.31/src/test/groovy/OpenTracing31Test.groovy
@@ -239,14 +239,7 @@ class OpenTracing31Test extends AgentTestRunner {
     secondScope.close()
 
     then:
-    tracer.scopeManager().active().delegate == firstScope.delegate
-    0 * _
-
-    when:
-    firstScope.close()
-
-    then:
-    0 * _
+    assert tracer.scopeManager().active() == null
   }
 
   def "test inject extract"() {

--- a/dd-java-agent/instrumentation/opentracing/api-0.32/src/test/groovy/OpenTracing32Test.groovy
+++ b/dd-java-agent/instrumentation/opentracing/api-0.32/src/test/groovy/OpenTracing32Test.groovy
@@ -239,14 +239,7 @@ class OpenTracing32Test extends AgentTestRunner {
     secondScope.close()
 
     then:
-    tracer.scopeManager().active().delegate == firstScope.delegate
-    0 * _
-
-    when:
-    firstScope.close()
-
-    then:
-    0 * _
+    assert tracer.scopeManager().active() == null
   }
 
   def "test inject extract"() {

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
@@ -1,7 +1,12 @@
 package datadog.trace.core.scopemanager;
 
 import com.timgroup.statsd.StatsDClient;
-import datadog.trace.bootstrap.instrumentation.api.*;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentScopeManager;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.AgentTrace;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import datadog.trace.bootstrap.instrumentation.api.ScopeSource;
 import datadog.trace.context.ScopeListener;
 import datadog.trace.context.TraceScope;
 import datadog.trace.core.jfr.DDScopeEventFactory;

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
@@ -29,7 +29,6 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class ContinuableScopeManager extends ScopeInterceptor.DelegatingInterceptor
     implements AgentScopeManager {
-  // static final ThreadLocal<ContinuableScope> tlsScope = new ThreadLocal<>();
   final ThreadLocal<ScopeStack> tlsScopeStack =
       new ThreadLocal<ScopeStack>() {
         @Override

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
@@ -214,16 +214,12 @@ public class ContinuableScopeManager extends ScopeInterceptor.DelegatingIntercep
       referenceCount.incrementAndGet();
     }
 
-    /**
-     * Decrements ref count -- returns true if the scope is still alive
-     */
+    /** Decrements ref count -- returns true if the scope is still alive */
     final boolean decrementReferences() {
       return (referenceCount.decrementAndGet() > 0);
     }
 
-    /**
-     * Returns true if the scope is still alive (non-zero ref count)
-     */
+    /** Returns true if the scope is still alive (non-zero ref count) */
     final boolean alive() {
       return (referenceCount.get() > 0);
     }
@@ -265,8 +261,8 @@ public class ContinuableScopeManager extends ScopeInterceptor.DelegatingIntercep
     int topPos = -1;
 
     /**
-     * top - accesses the top of the ScopeStack making sure the Scope on-top is still active
-     * If the top scope isn't active, then the stack is popped back to the top-most active Scope
+     * top - accesses the top of the ScopeStack making sure the Scope on-top is still active If the
+     * top scope isn't active, then the stack is popped back to the top-most active Scope
      */
     final ContinuableScope top() {
       int priorTopPos = this.topPos;
@@ -308,8 +304,8 @@ public class ContinuableScopeManager extends ScopeInterceptor.DelegatingIntercep
     }
 
     /**
-     * Similar to top but without the fix-up behavior that skips over any closed Scopes
-     * Mostly useful in logging to avoid side effects, but could be used in other places with caution.
+     * Similar to top but without the fix-up behavior that skips over any closed Scopes Mostly
+     * useful in logging to avoid side effects, but could be used in other places with caution.
      */
     final ContinuableScope noFixupTop() {
       if (topPos == -1) return null;
@@ -317,12 +313,10 @@ public class ContinuableScopeManager extends ScopeInterceptor.DelegatingIntercep
     }
 
     /**
-     * Pushes a new scope unto the stack
-     * Currently, the new scope is pushed onto the stack without any stack fix-up.
-     * This works under two assumptions...
-     * 1 - Normally, the stack doesn't need fix-up because the stack is proactively clean by Scope.close
-     * 2 - If the stack does need fix-up, it has probably already been done by calling active to get the
-     * parent scope
+     * Pushes a new scope unto the stack Currently, the new scope is pushed onto the stack without
+     * any stack fix-up. This works under two assumptions... 1 - Normally, the stack doesn't need
+     * fix-up because the stack is proactively clean by Scope.close 2 - If the stack does need
+     * fix-up, it has probably already been done by calling active to get the parent scope
      */
     final void push(final ContinuableScope scope) {
       // no proactive stack cleaning in push
@@ -348,18 +342,15 @@ public class ContinuableScopeManager extends ScopeInterceptor.DelegatingIntercep
     }
 
     /**
-     * Blind pop of the top stack entry
-     * This is done without fix-up, checking the stack top, or even a depth check
-     * Responsibility lies with the caller to do the diligence of calling depth or checkTop
-     * ahead of calling blindPop.
+     * Blind pop of the top stack entry This is done without fix-up, checking the stack top, or even
+     * a depth check Responsibility lies with the caller to do the diligence of calling depth or
+     * checkTop ahead of calling blindPop.
      */
     final void blindPop() {
       stack[topPos--] = null;
     }
 
-    /**
-     * Returns the current stack depth
-     */
+    /** Returns the current stack depth */
     final int depth() {
       return topPos + 1;
     }

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
@@ -12,6 +12,7 @@ import datadog.trace.context.TraceScope;
 import datadog.trace.core.jfr.DDScopeEventFactory;
 import java.lang.ref.ReferenceQueue;
 import java.lang.ref.WeakReference;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.Stack;
@@ -215,21 +216,27 @@ public class ContinuableScopeManager extends ScopeInterceptor.DelegatingIntercep
   }
 
   private static final class ScopeStack {
-    final Stack<ContinuableScope> stack = new Stack<>();
+    final List<ContinuableScope> stack = new ArrayList<>(32);
 
     final ContinuableScope top() {
-      if ( stack.isEmpty() ) return null;
+      int size = stack.size();
+      if ( size == 0 ) return null;
 
-      return stack.peek();
+      return stack.get(size - 1);
     }
 
     final void push(ContinuableScope scope) {
-      stack.push(scope);
+      stack.add(scope);
     }
 
     boolean tryPop(ContinuableScope expectedScope) {
-      boolean isTop = expectedScope.equals(top());
-      if ( isTop ) stack.pop();
+      int size = stack.size();
+      if ( size == 0 ) return false;
+
+      int topIndex = size - 1;
+      ContinuableScope topScope = stack.get(topIndex);
+      boolean isTop = topScope.equals(expectedScope);
+      if ( isTop ) stack.remove(topIndex);
       return isTop;
     }
   }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerDepthTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerDepthTest.groovy
@@ -19,14 +19,14 @@ class ScopeManagerDepthTest extends DDSpecification {
 
     when: "fill up the scope stack"
     AgentScope scope = null
-    for (int i = 0; i <= depth; i++) {
+    for (int i = 0; i < depth; i++) {
       def span = tracer.buildSpan("test").start()
       scope = tracer.activateSpan(span)
       assert scope instanceof ContinuableScopeManager.ContinuableScope
     }
 
     then: "last scope is still valid"
-    (scope as ContinuableScopeManager.ContinuableScope).depth() == depth
+    scopeManager.scopeStack().depth() == depth
 
     when: "activate span over limit"
     def span = tracer.buildSpan("test").start()
@@ -42,10 +42,10 @@ class ScopeManagerDepthTest extends DDSpecification {
     scope instanceof NoopAgentScope
 
     and: "scope stack not effected."
-    (scopeManager.active() as ContinuableScopeManager.ContinuableScope).depth() == depth
+    scopeManager.scopeStack().depth() == depth
 
     cleanup:
-    scopeManager.tlsScope.remove()
+    scopeManager.scopeStack().clear()
 
     where:
     depth = 100  // Using ConfigDefaults here causes classloading issues
@@ -61,14 +61,14 @@ class ScopeManagerDepthTest extends DDSpecification {
 
     when: "fill up the scope stack"
     AgentScope scope = null
-    for (int i = 0; i <= defaultLimit; i++) {
+    for (int i = 0; i < defaultLimit; i++) {
       def span = tracer.buildSpan("test").start()
       scope = tracer.activateSpan(span)
       assert scope instanceof ContinuableScopeManager.ContinuableScope
     }
 
     then: "last scope is still valid"
-    (scope as ContinuableScopeManager.ContinuableScope).depth() == defaultLimit
+    scopeManager.scopeStack().depth() == defaultLimit
 
     when: "activate a scope"
     def span = tracer.buildSpan("test").start()
@@ -76,7 +76,7 @@ class ScopeManagerDepthTest extends DDSpecification {
 
     then: "a real scope is returned"
     !(scope instanceof NoopAgentScope)
-    (scopeManager.active() as ContinuableScopeManager.ContinuableScope).depth() == defaultLimit + 1
+    scopeManager.scopeStack().depth() == defaultLimit + 1
 
     when: "activate a noop span"
     scope = scopeManager.activate(NoopAgentSpan.INSTANCE, ScopeSource.MANUAL)
@@ -85,10 +85,10 @@ class ScopeManagerDepthTest extends DDSpecification {
     !(scope instanceof NoopAgentScope)
 
     and: "scope stack not effected."
-    (scopeManager.active() as ContinuableScopeManager.ContinuableScope).depth() == defaultLimit + 2
+    scopeManager.scopeStack().depth() == defaultLimit + 2
 
     cleanup:
-    scopeManager.tlsScope.remove()
+    scopeManager.scopeStack().clear()
 
     where:
     defaultLimit = 100 // Using ConfigDefaults here causes classloading issues

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerTest.groovy
@@ -42,7 +42,7 @@ class ScopeManagerTest extends DDSpecification {
   }
 
   def cleanup() {
-    ContinuableScopeManager.tlsScope.remove()
+    scopeManager.tlsScopeStack.get().clear()
   }
 
   def "non-ddspan activation results in a continuable scope"() {
@@ -313,21 +313,21 @@ class ScopeManagerTest extends DDSpecification {
     scope.setAsyncPropagation(true)
 
     expect:
-    scopeManager.tlsScope.get() == scope
+    scopeManager.active() == scope
 
     when:
     def cont = scope.capture()
     scope.close()
 
     then:
-    scopeManager.tlsScope.get() == null
+    scopeManager.active() == null
 
     when:
     def newScope = cont.activate()
 
     then:
     newScope != scope
-    scopeManager.tlsScope.get() == newScope
+    scopeManager.active() == newScope
   }
 
   def "test activating same scope multiple times"() {


### PR DESCRIPTION
The functional part of this change is simply improving out-of-order close behavior.

Previously, given a stack C, B, A...
If B was closed out-of-order, then C would be left on-top.
Once C was closed, B would be restored to the top of stack.
But B would need to be closed again, which would in turn restore C.

This behavior could then lead to unbounded stack growth.

The new code behaves better -- given a stack C, B, A...
If B is closed out-of-order, then C would be left on-top
Once C is closed, the stack will skip over B, since it is already closed -- returning to A.
Then A can be closed properly (without any additional closes of B or C).

Ultimately, this doesn't entirely eliminate the possibility of having the stack grow indefinitely, 
but I believe it does reduce it significantly.


In hindsight, this could have been achieved via the toRestore field already on 
ContinuableScope, but I've elected to implemented a conventional stack instead.

The stack clean-up works by cleaning up the stack on querying active / activeScope.
At access time, the ContinuableScopeManager checks if the ContinuableScope is still active.
If it isn't, then the stack top is moved back a scope at a time until an active 
scope is found. 

To avoid doing the clean-up often, the stack is proactively unwound on a normal close in 
ContinuableScope.close.


Changed inner-classes to be static to make class boundaries more apparent
Dropped the toRestore & depth fields from ContinuableScope
Restoration is now managed via ContinuableScope[]
depth is no longer tracked on the ContinuableScope, but instead tracked by the 
topPos member of ScopeStack

In this change, I've taken care to maintain the existing reference counting &
notification semantics -- despite my general feeling that they are not 
completely intuitive or correct.

I've also taken care to do minimum of moving code around -- including in tests 
to make the change easier to review for correctness.

As such, most things have a 1-to-1 replacement...
- ContinuableScope.depth -> ContinuableScopeManager.ScopeStack.depth
- ContinuableScope.toRestore linked list -> ScopeManager.stack
- ContinuableScopeManager.tlsScope.remove -> ContinuableScopeManager.ScopeStack.clear


