### PR TITLE
disable hystrix tags by default, enabled by system property

### DIFF
--- a/dd-java-agent/instrumentation/hystrix-1.4/src/test/groovy/HystrixObservableChainTest.groovy
+++ b/dd-java-agent/instrumentation/hystrix-1.4/src/test/groovy/HystrixObservableChainTest.groovy
@@ -2,6 +2,7 @@ import com.netflix.hystrix.HystrixObservableCommand
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.Trace
 import datadog.trace.bootstrap.instrumentation.api.Tags
+import datadog.trace.instrumentation.hystrix.HystrixDecorator
 import rx.Observable
 import rx.schedulers.Schedulers
 import spock.lang.Retry
@@ -16,6 +17,9 @@ class HystrixObservableChainTest extends AgentTestRunner {
   static {
     // Disable so failure testing below doesn't inadvertently change the behavior.
     System.setProperty("hystrix.command.default.circuitBreaker.enabled", "false")
+    // hack to guarantee that that extra tags is enabled since it can't be guaranteed that
+    // the Config singleton will not be initialised before this block runs.
+    HystrixDecorator.DECORATE = new HystrixDecorator(true)
 
     // Uncomment for debugging:
     // System.setProperty("hystrix.command.default.execution.timeout.enabled", "false")

--- a/dd-java-agent/instrumentation/hystrix-1.4/src/test/groovy/HystrixObservableTest.groovy
+++ b/dd-java-agent/instrumentation/hystrix-1.4/src/test/groovy/HystrixObservableTest.groovy
@@ -4,6 +4,7 @@ import com.netflix.hystrix.exception.HystrixRuntimeException
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.Trace
 import datadog.trace.bootstrap.instrumentation.api.Tags
+import datadog.trace.instrumentation.hystrix.HystrixDecorator
 import rx.Observable
 import rx.schedulers.Schedulers
 import spock.lang.Retry
@@ -21,6 +22,9 @@ class HystrixObservableTest extends AgentTestRunner {
   static {
     // Disable so failure testing below doesn't inadvertently change the behavior.
     System.setProperty("hystrix.command.default.circuitBreaker.enabled", "false")
+    // hack to guarantee that that extra tags is enabled since it can't be guaranteed that
+    // the Config singleton will not be initialised before this block runs.
+    HystrixDecorator.DECORATE = new HystrixDecorator(true)
 
     // Uncomment for debugging:
     // System.setProperty("hystrix.command.default.execution.timeout.enabled", "false")

--- a/dd-java-agent/instrumentation/hystrix-1.4/src/test/groovy/HystrixTest.groovy
+++ b/dd-java-agent/instrumentation/hystrix-1.4/src/test/groovy/HystrixTest.groovy
@@ -2,6 +2,7 @@ import com.netflix.hystrix.HystrixCommand
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.Trace
 import datadog.trace.bootstrap.instrumentation.api.Tags
+import datadog.trace.instrumentation.hystrix.HystrixDecorator
 import spock.lang.Timeout
 
 import java.util.concurrent.BlockingQueue
@@ -15,6 +16,9 @@ class HystrixTest extends AgentTestRunner {
   static {
     // Disable so failure testing below doesn't inadvertently change the behavior.
     System.setProperty("hystrix.command.default.circuitBreaker.enabled", "false")
+    // hack to guarantee that that extra tags is enabled since it can't be guaranteed that
+    // the Config singleton will not be initialised before this block runs.
+    HystrixDecorator.DECORATE = new HystrixDecorator(true)
 
     // Uncomment for debugging:
     // System.setProperty("hystrix.command.default.execution.timeout.enabled", "false")

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
@@ -33,5 +33,7 @@ public final class TraceInstrumentationConfig {
   public static final String KAFKA_CLIENT_BASE64_DECODING_ENABLED =
       "kafka.client.base64.decoding.enabled";
 
+  public static final String HYSTRIX_TAGS_ENABLED = "hystrix.tags.enabled";
+
   private TraceInstrumentationConfig() {}
 }

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -351,6 +351,8 @@ public class Config {
   @Getter private final boolean kafkaClientPropagationEnabled;
   @Getter private final boolean kafkaClientBase64DecodingEnabled;
 
+  @Getter private final boolean hystrixTagsEnabled;
+
   @Getter private final boolean debugEnabled;
   @Getter private final String configFile;
 
@@ -611,6 +613,9 @@ public class Config {
     kafkaClientBase64DecodingEnabled =
         getBooleanSettingFromEnvironment(KAFKA_CLIENT_BASE64_DECODING_ENABLED, false);
 
+    hystrixTagsEnabled =
+        getBooleanSettingFromEnvironment(TraceInstrumentationConfig.HYSTRIX_TAGS_ENABLED, false);
+
     debugEnabled = isDebugMode();
 
     // Setting this last because we have a few places where this can come from
@@ -817,6 +822,10 @@ public class Config {
     kafkaClientPropagationEnabled =
         getPropertyBooleanValue(
             properties, KAFKA_CLIENT_PROPAGATION_ENABLED, parent.kafkaClientPropagationEnabled);
+
+    hystrixTagsEnabled =
+        getBooleanSettingFromEnvironment(
+            TraceInstrumentationConfig.HYSTRIX_TAGS_ENABLED, parent.hystrixTagsEnabled);
 
     debugEnabled = parent.debugEnabled || isDebugMode();
 


### PR DESCRIPTION
This disables most hystrix tags by default, which can be enabled by setting `DD_HYSTRIX_TAGS_ENABLED` to true if users are interested in these tags. The reason for doing this is that we have found that users are willing to disable the hystrix integration entirely to reduce trace size, but this integration tends to glue traces together. The tags in the hystrix integration tend to be very long (e.g. fully qualified class names), and are mostly duplicated in the resource name. These can still be enabled and haven't just been removed because there are users who find the tags beneficial.