### PR TITLE
allow context propagation for kafka tombstones

### DIFF
--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaDecorator.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaDecorator.java
@@ -89,10 +89,7 @@ public class KafkaDecorator extends ClientDecorator {
   }
 
   public void finishConsumerSpan(final AgentSpan span) {
-    if (endToEndDurationsEnabled
-        // no context propagation on tombstones, so this is always the
-        // trace start if we get one
-        && !Boolean.TRUE.equals(span.getTag(InstrumentationTags.TOMBSTONE))) {
+    if (endToEndDurationsEnabled) {
       long now = System.currentTimeMillis();
       String traceStartTime = span.getBaggageItem(DDTags.TRACE_START_TIME);
       if (null != traceStartTime) {

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerInstrumentation.java
@@ -75,8 +75,7 @@ public final class KafkaProducerInstrumentation extends Instrumenter.Default {
 
       callback = new ProducerCallback(callback, parent, span);
 
-      boolean isTombstone = record.value() == null && !record.headers().iterator().hasNext();
-      if (isTombstone) {
+      if (record.value() == null) {
         span.setTag(InstrumentationTags.TOMBSTONE, true);
       }
 
@@ -88,9 +87,7 @@ public final class KafkaProducerInstrumentation extends Instrumenter.Default {
       // headers attempt to read messages that were produced by clients > 0.11 and the magic
       // value of the broker(s) is >= 2
       if (apiVersions.maxUsableProduceMagic() >= RecordBatch.MAGIC_VALUE_V2
-          && Config.get().isKafkaClientPropagationEnabled()
-          // Must not interfere with tombstones
-          && !isTombstone) {
+          && Config.get().isKafkaClientPropagationEnabled()) {
         try {
           propagate().inject(span, record.headers(), SETTER);
         } catch (final IllegalStateException e) {

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TracingIterator.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TracingIterator.java
@@ -55,9 +55,7 @@ public class TracingIterator implements Iterator<ConsumerRecord> {
       if (next != null) {
         final Context spanContext = propagate().extract(next.headers(), GETTER);
         final AgentSpan span = startSpan(operationName, spanContext);
-        // tombstone checking logic here because it can only be inferred
-        // from the record itself
-        if (next.value() == null && !next.headers().iterator().hasNext()) {
+        if (next.value() == null) {
           span.setTag(InstrumentationTags.TOMBSTONE, true);
         }
         decorator.afterStart(span);


### PR DESCRIPTION
I implemented this based on advice on a community issue that headers could prevent log compaction, without attempting to reproduce. I have since spoken to someone involved in the implementation of Kafka who reassured me that headers have no impact on log compaction whatsoever, so reverting the change, but keeping the tag in place because it seems useful.