### PR TITLE
Add Invocation Caller API to internal-api

### DIFF
--- a/dd-java-agent/src/test/groovy/datadog/trace/agent/integration/classloading/ShadowPackageRenamingTest.groovy
+++ b/dd-java-agent/src/test/groovy/datadog/trace/agent/integration/classloading/ShadowPackageRenamingTest.groovy
@@ -64,16 +64,21 @@ class ShadowPackageRenamingTest extends Specification {
     for (ClassPath.ClassInfo info : bootstrapClasspath.getAllClasses()) {
       bootstrapClasses.add(info.getName())
       // make sure all bootstrap classes can be loaded from system
-      ClassLoader.getSystemClassLoader().loadClass(info.getName())
-      boolean goodPrefix = false
-      for (int i = 0; i < bootstrapPrefixes.length; ++i) {
-        if (info.getName().startsWith(bootstrapPrefixes[i])) {
-          goodPrefix = true
-          break
+      try {
+        ClassLoader.getSystemClassLoader().loadClass(info.getName())
+        boolean goodPrefix = false
+        for (int i = 0; i < bootstrapPrefixes.length; ++i) {
+          if (info.getName().startsWith(bootstrapPrefixes[i])) {
+            goodPrefix = true
+            break
+          }
         }
-      }
-      if (!goodPrefix) {
-        badBootstrapPrefixes.add(info.getName())
+        if (!goodPrefix) {
+          badBootstrapPrefixes.add(info.getName())
+        }
+      } catch (UnsupportedClassVersionError ex) {
+        // there might be impl-specific classes which require newer Java
+        // ignore unsupported class version
       }
     }
 

--- a/dd-java-agent/testing/src/test/groovy/AgentTestRunnerTest.groovy
+++ b/dd-java-agent/testing/src/test/groovy/AgentTestRunnerTest.groovy
@@ -45,9 +45,14 @@ class AgentTestRunnerTest extends AgentTestRunner {
     for (ClassPath.ClassInfo info : ClasspathUtils.getTestClasspath().getAllClasses()) {
       for (int i = 0; i < Constants.BOOTSTRAP_PACKAGE_PREFIXES.length; ++i) {
         if (info.getName().startsWith(Constants.BOOTSTRAP_PACKAGE_PREFIXES[i])) {
-          Class<?> bootstrapClass = Class.forName(info.getName())
-          if (bootstrapClass.getClassLoader() != BOOTSTRAP_CLASSLOADER) {
-            bootstrapClassesIncorrectlyLoaded.add(bootstrapClass)
+          try {
+            Class<?> bootstrapClass = Class.forName(info.getName())
+            if (bootstrapClass.getClassLoader() != BOOTSTRAP_CLASSLOADER) {
+              bootstrapClassesIncorrectlyLoaded.add(bootstrapClass)
+            }
+          } catch (UnsupportedClassVersionError ex) {
+            // there might be impl-specific classes which require newer Java
+            // ignore unsupported class version
           }
           break
         }

--- a/internal-api/internal-api.gradle
+++ b/internal-api/internal-api.gradle
@@ -64,19 +64,6 @@ testClasses {
   dependsOn java9ImplClasses
 }
 
-//tasks.withType(Test).configureEach {
-//  if (!name.endsWith("Generated")) {
-//    return
-//  }
-//
-//  if (!name.contains("8")) {
-//    dependsOn java9ImplClasses
-//  }
-//  filter {
-//    include "InvocationTest"
-//  }
-//}
-
 jar {
   // need to include the custom Java 9+ impl classes
   from(sourceSets.java9Impl.output) {

--- a/internal-api/internal-api.gradle
+++ b/internal-api/internal-api.gradle
@@ -17,6 +17,7 @@ excludedClassesCoverage += [
   "datadog.trace.bootstrap.instrumentation.api.ScopeSource",
   "datadog.trace.mlt.MethodLevelTracer",
   "datadog.trace.mlt.MethodLevelTracer.NoSession",
+  "datadog.trace.mlt.Invocation.Caller",
 ]
 
 sourceSets {

--- a/internal-api/internal-api.gradle
+++ b/internal-api/internal-api.gradle
@@ -1,3 +1,7 @@
+ext {
+  enableJunitPlatform = true
+}
+
 apply from: "$rootDir/gradle/java.gradle"
 
 excludedClassesCoverage += [
@@ -19,9 +23,64 @@ excludedClassesCoverage += [
   "datadog.trace.mlt.MethodLevelTracer.NoSession",
 ]
 
+sourceSets {
+  main {
+    java {
+      srcDirs = ["src/main/java"]
+    }
+  }
+  /*
+   * can't be main_java9 as the global java.gradle adds some magic souce
+   * to all main_* source roots and that will mess up the dependency order
+   */
+  java9Impl {
+    java {
+      srcDirs = ["src/main/java9Impl"]
+    }
+  }
+}
+
 dependencies {
   // references TraceScope and Continuation from public api
   compile project(':dd-trace-api')
 
+  java9ImplCompile sourceSets.main.output
+  java9ImplCompile deps.slf4j
+  java9ImplCompileOnly "org.projectlombok:lombok:${project.lombok.version}" transitive false
+  java9ImplAnnotationProcessor "org.projectlombok:lombok:${project.lombok.version}" transitive false
+
   testCompile project(":utils:test-utils")
+  testRuntime sourceSets.java9Impl.output
+}
+
+compileJava9ImplJava {
+  sourceCompatibility = 9
+  targetCompatibility = 9
+  options.fork = true
+  options.forkOptions.javaHome = file(System.env.JAVA_11_HOME)
+}
+
+testClasses {
+  dependsOn java9ImplClasses
+}
+
+//tasks.withType(Test).configureEach {
+//  if (!name.endsWith("Generated")) {
+//    return
+//  }
+//
+//  if (!name.contains("8")) {
+//    dependsOn java9ImplClasses
+//  }
+//  filter {
+//    include "InvocationTest"
+//  }
+//}
+
+jar {
+  // need to include the custom Java 9+ impl classes
+  from(sourceSets.java9Impl.output) {
+    include '**/*.class'
+  }
+  dependsOn java9ImplClasses
 }

--- a/internal-api/internal-api.gradle
+++ b/internal-api/internal-api.gradle
@@ -1,7 +1,3 @@
-ext {
-  enableJunitPlatform = true
-}
-
 apply from: "$rootDir/gradle/java.gradle"
 
 excludedClassesCoverage += [

--- a/internal-api/internal-api.gradle
+++ b/internal-api/internal-api.gradle
@@ -18,6 +18,7 @@ excludedClassesCoverage += [
   "datadog.trace.mlt.MethodLevelTracer",
   "datadog.trace.mlt.MethodLevelTracer.NoSession",
   "datadog.trace.mlt.Invocation.Caller",
+  "datadog.trace.mlt.Invocation",
 ]
 
 sourceSets {

--- a/internal-api/src/main/java/datadog/trace/mlt/Invocation.java
+++ b/internal-api/src/main/java/datadog/trace/mlt/Invocation.java
@@ -61,7 +61,7 @@ public final class Invocation {
     try {
       Runtime.class.getMethod("version");
       Constructor<?> constructor =
-          Class.forName(Invocation.class.getPackage().getName() + ".InvocationImpl9")
+          Class.forName(Invocation.class.getPackage().getName() + ".InvocationImplStackWalker")
               .getDeclaredConstructor();
       constructor.setAccessible(true);
       rtImpl = (Invocation.Impl) constructor.newInstance();
@@ -82,8 +82,7 @@ public final class Invocation {
    *
    * @param offset the offset to adjust the caller stackframe by
    * @return the {@linkplain Caller} located {@literal offset} stackframes above the called method;
-   *     if the offset is bigger than the current stack depth the callstack root will be returned
-   *     instead
+   *     {@literal null} if the offset is bigger than the current stack depth
    */
   public static Caller getCaller(int offset) {
     return impl.getCaller(offset);
@@ -96,6 +95,7 @@ public final class Invocation {
    * @return the caller chain in the form of a list starting at the immediate caller and ending at
    *     the callstack root
    */
+  @NonNull
   public static List<Caller> getCallers() {
     return impl.getCallers();
   }

--- a/internal-api/src/main/java/datadog/trace/mlt/Invocation.java
+++ b/internal-api/src/main/java/datadog/trace/mlt/Invocation.java
@@ -1,0 +1,102 @@
+package datadog.trace.mlt;
+
+import java.lang.reflect.Constructor;
+import java.util.List;
+import java.util.Objects;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public final class Invocation {
+  static final int INVOCATION_OFFSET = 3;
+
+  /**
+   * A simple data class representing an invocation caller. Provides the caller class and method
+   * name.
+   */
+  public static final class Caller {
+    public final String className;
+    public final String methodName;
+
+    Caller(String className, String methodName) {
+      this.className = className;
+      this.methodName = methodName;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      Caller caller = (Caller) o;
+      return className.equals(caller.className) && Objects.equals(methodName, caller.methodName);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(className, methodName);
+    }
+  }
+
+  /**
+   * Invocation caller detection can use StackWalker API which available in Java 9+ only. Therefore
+   * abstracting the common interface which can be implemented by the default (pre Java 9)
+   * implementation and the post Java 9 one as well.
+   */
+  public interface Impl {
+    @NonNull
+    Caller getCaller(int offset);
+
+    @NonNull
+    List<Caller> getCallers();
+  }
+
+  private static final Invocation.Impl impl;
+
+  static {
+    Invocation.Impl rtImpl = new InvocationImplDefault();
+    try {
+      Runtime.class.getMethod("version");
+      Constructor<?> constructor =
+          Class.forName(Invocation.class.getPackage().getName() + ".InvocationImpl9")
+              .getDeclaredConstructor();
+      constructor.setAccessible(true);
+      rtImpl = (Invocation.Impl) constructor.newInstance();
+    } catch (NoSuchMethodException ignored) {
+      // running on pre-9 Java; silently ignore and use the default impl
+    } catch (Throwable t) {
+      log.info(
+          "Unable to instantiate StackWalker API based invocation caller impl. Using the default one.",
+          t);
+    }
+
+    impl = rtImpl;
+  }
+
+  /**
+   * Get the method {@linkplain Caller} adjusted by offset. An offset of 0 will return the immediate
+   * caller.
+   *
+   * @param offset the offset to adjust the caller stackframe by
+   * @return the {@linkplain Caller} located {@literal offset} stackframes above the called method;
+   *     if the offset is bigger than the current stack depth the callstack root will be returned
+   *     instead
+   */
+  public static Caller getCaller(int offset) {
+    return impl.getCaller(offset);
+  }
+
+  /**
+   * Get the caller chain in the form of a list starting at the immediate caller and ending at the
+   * callstack root.
+   *
+   * @return the caller chain in the form of a list starting at the immediate caller and ending at
+   *     the callstack root
+   */
+  public static List<Caller> getCallers() {
+    return impl.getCallers();
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/mlt/InvocationImplDefault.java
+++ b/internal-api/src/main/java/datadog/trace/mlt/InvocationImplDefault.java
@@ -2,7 +2,7 @@ package datadog.trace.mlt;
 
 import static datadog.trace.mlt.Invocation.INVOCATION_OFFSET;
 
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
@@ -46,11 +46,11 @@ final class InvocationImplDefault implements Invocation.Impl {
   public List<Invocation.Caller> getCallers() {
     Class<?>[] list = ACCESSOR.getClassContext();
     int callerLength = Math.max(list.length - INVOCATION_OFFSET, 0);
-    Invocation.Caller[] callers = new Invocation.Caller[callerLength];
+    List<Invocation.Caller> callers = new ArrayList<>(callerLength);
 
-    for (int i = 0; i < callers.length; i++) {
-      callers[i] = new Invocation.Caller(list[i + INVOCATION_OFFSET].getName(), null);
+    for (int i = INVOCATION_OFFSET; i < list.length; i++) {
+      callers.add(new Invocation.Caller(list[i].getName(), null));
     }
-    return Arrays.asList(callers);
+    return callers;
   }
 }

--- a/internal-api/src/main/java/datadog/trace/mlt/InvocationImplDefault.java
+++ b/internal-api/src/main/java/datadog/trace/mlt/InvocationImplDefault.java
@@ -1,0 +1,56 @@
+package datadog.trace.mlt;
+
+import static datadog.trace.mlt.Invocation.INVOCATION_OFFSET;
+
+import java.util.Arrays;
+import java.util.List;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Default implementation of the invocation caller detection. Works for all Java versions from 7
+ * till the latest current one. The downside is a slight performance hit and the inability to report
+ * the caller method name.
+ */
+@Slf4j
+final class InvocationImplDefault implements Invocation.Impl {
+  private static final class WhoCalledSM extends SecurityManager {
+    @Override
+    public Class<?>[] getClassContext() {
+      return super.getClassContext();
+    }
+  }
+
+  private static final WhoCalledSM ACCESSOR = new WhoCalledSM();
+
+  @Override
+  @NonNull
+  public Invocation.Caller getCaller(int offset) {
+    if (offset < 0) {
+      throw new IllegalArgumentException();
+    }
+
+    offset += INVOCATION_OFFSET;
+
+    Class<?>[] list = ACCESSOR.getClassContext();
+
+    if (list.length <= offset) {
+      return null;
+    }
+
+    return new Invocation.Caller(list[offset].getName(), null);
+  }
+
+  @Override
+  @NonNull
+  public List<Invocation.Caller> getCallers() {
+    Class<?>[] list = ACCESSOR.getClassContext();
+    int callerLength = Math.max(list.length - INVOCATION_OFFSET, 0);
+    Invocation.Caller[] callers = new Invocation.Caller[callerLength];
+
+    for (int i = 0; i < callers.length; i++) {
+      callers[i] = new Invocation.Caller(list[i + INVOCATION_OFFSET].getName(), null);
+    }
+    return Arrays.asList(callers);
+  }
+}

--- a/internal-api/src/main/java9Impl/datadog/trace/mlt/InvocationImplStackWalker.java
+++ b/internal-api/src/main/java9Impl/datadog/trace/mlt/InvocationImplStackWalker.java
@@ -9,6 +9,23 @@ import lombok.extern.slf4j.Slf4j;
 /** Invocation caller implementation based on the StackWalker API. Works only for Java 9+. */
 @Slf4j
 final class InvocationImplStackWalker implements Invocation.Impl {
+  private static class FrameRef {
+    final StackWalker.StackFrame frame;
+    final int depth;
+
+    FrameRef(StackWalker.StackFrame frame) {
+      this(frame, 1);
+    }
+
+    FrameRef(StackWalker.StackFrame frame, int depth) {
+      this.frame = frame;
+      this.depth = depth;
+    }
+
+    StackWalker.StackFrame getFrame() {
+      return frame;
+    }
+  }
   @Override
   public Invocation.Caller getCaller(int offset) {
     if (offset < 0) {
@@ -19,7 +36,10 @@ final class InvocationImplStackWalker implements Invocation.Impl {
             frames ->
                 frames
                     .limit(INVOCATION_OFFSET + offset)
-                    .reduce((a, b) -> b)
+                    .map(FrameRef::new)
+                    .reduce((a, b) -> new FrameRef(b.frame, a.depth + b.depth))
+                    .filter(f -> f.depth == INVOCATION_OFFSET + offset)
+                    .map(FrameRef::getFrame)
                     .map(f -> new Invocation.Caller(f.getClassName(), f.getMethodName())))
         .orElse(null);
   }

--- a/internal-api/src/main/java9Impl/datadog/trace/mlt/InvocationImplStackWalker.java
+++ b/internal-api/src/main/java9Impl/datadog/trace/mlt/InvocationImplStackWalker.java
@@ -26,6 +26,7 @@ final class InvocationImplStackWalker implements Invocation.Impl {
       return frame;
     }
   }
+
   @Override
   public Invocation.Caller getCaller(int offset) {
     if (offset < 0) {

--- a/internal-api/src/main/java9Impl/datadog/trace/mlt/InvocationImplStackWalker.java
+++ b/internal-api/src/main/java9Impl/datadog/trace/mlt/InvocationImplStackWalker.java
@@ -1,0 +1,34 @@
+package datadog.trace.mlt;
+
+import static datadog.trace.mlt.Invocation.INVOCATION_OFFSET;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+
+/** Invocation caller implementation based on the StackWalker API. Works only for Java 9+. */
+@Slf4j
+final class InvocationImplStackWalker implements Invocation.Impl {
+  @Override
+  public Invocation.Caller getCaller(int offset) {
+    if (offset < 0) {
+      throw new IllegalArgumentException();
+    }
+    return StackWalker.getInstance()
+        .walk(
+            frames ->
+                frames
+                    .limit(INVOCATION_OFFSET + offset)
+                    .reduce((a, b) -> b)
+                    .map(f -> new Invocation.Caller(f.getClassName(), f.getMethodName())))
+        .orElse(null);
+  }
+
+  @Override
+  public List<Invocation.Caller> getCallers() {
+    final List<Invocation.Caller> callers = new ArrayList<>();
+    StackWalker.getInstance()
+        .forEach(f -> callers.add(new Invocation.Caller(f.getClassName(), f.getMethodName())));
+    return callers.subList(INVOCATION_OFFSET, callers.size());
+  }
+}

--- a/internal-api/src/test/groovy/datadog/trace/mlt/InvocationTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/mlt/InvocationTest.groovy
@@ -1,0 +1,34 @@
+package datadog.trace.mlt
+
+import datadog.trace.util.test.DDSpecification
+
+class InvocationTest extends DDSpecification {
+  def "get immediate caller"() {
+    when:
+    def caller = Invocation.getCaller(0)
+
+    then:
+    println caller.className
+    caller.className != null
+  }
+
+  def "get all callers"() {
+    when:
+    def callers = Invocation.getCallers()
+
+    then:
+    !callers.isEmpty()
+
+    def hasMethod = 0
+    def noMethod = 0
+    callers.each {
+      it.className != null
+      if (it.methodName != null) {
+        hasMethod++
+      } else {
+        noMethod++
+      }
+    }
+    hasMethod == 0 || noMethod == 0
+  }
+}

--- a/internal-api/src/test/groovy/datadog/trace/mlt/InvocationTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/mlt/InvocationTest.groovy
@@ -8,8 +8,16 @@ class InvocationTest extends DDSpecification {
     def caller = Invocation.getCaller(0)
 
     then:
-    println caller.className
-    caller.className != null
+    caller.className == 'datadog.trace.mlt.Invocation$getCaller'
+  }
+
+  def "get beyond stack depth"() {
+    when:
+    def callers = Invocation.getCallers()
+    def caller = Invocation.getCaller(callers.size() + 1)
+
+    then:
+    caller == null
   }
 
   def "get all callers"() {


### PR DESCRIPTION
Adding a unified API to get the invocation caller which will dispatch to the appropriate runtime implementation.
For Java 7 and 8 we need to use a security manager based hack while for Java 9+ we can use StackWalker API to achieve the same effect (and provide even more information).