### PR TITLE
Fix grizzly host/port identification

### DIFF
--- a/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/main/java/datadog/trace/instrumentation/grizzlyhttp232/GrizzlyDecorator.java
+++ b/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/main/java/datadog/trace/instrumentation/grizzlyhttp232/GrizzlyDecorator.java
@@ -30,21 +30,21 @@ public class GrizzlyDecorator
   protected URI url(final HttpRequestPacket httpRequest) throws URISyntaxException {
     return new URI(
         (httpRequest.isSecure() ? "https://" : "http://")
-            + httpRequest.getRemoteHost()
+            + httpRequest.serverName()
             + ":"
-            + httpRequest.getLocalPort()
+            + httpRequest.getServerPort()
             + httpRequest.getRequestURI()
             + (httpRequest.getQueryString() != null ? "?" + httpRequest.getQueryString() : ""));
   }
 
   @Override
   protected String peerHostIP(final HttpRequestPacket httpRequest) {
-    return httpRequest.getLocalHost();
+    return httpRequest.getRemoteAddress();
   }
 
   @Override
   protected Integer peerPort(final HttpRequestPacket httpRequest) {
-    return httpRequest.getLocalPort();
+    return httpRequest.getRemotePort();
   }
 
   @Override


### PR DESCRIPTION
This applies the same fix as https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/887

Thanks @trask!