### PR TITLE
Add synchronization while adding dd tags to thread context(MDC) map

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/log/ThreadLocalWithDDTagsInitValue.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/log/ThreadLocalWithDDTagsInitValue.java
@@ -71,9 +71,10 @@ public class ThreadLocalWithDDTagsInitValue<T> extends ThreadLocal<T> {
 
   public static <T> ThreadLocal<T> create(T origThreadLocalValue)
       throws InvocationTargetException, IllegalAccessException {
-    if (origThreadLocalValue instanceof Map) {
-      ((Map) origThreadLocalValue).putAll(LogContextScopeListener.LOG_CONTEXT_DD_TAGS);
-    } else {
+    // eg logback implementation uses synchronization on old instance of the map:
+    // https://github.com/qos-ch/logback/blob/a6356170acfa6ce6e2383477bf80e6cae8a82d80/logback-classic/src/main/java/ch/qos/logback/classic/util/LogbackMDCAdapter.java#L77
+    // here we try to follow this contract:
+    synchronized (origThreadLocalValue) {
       putToMap(origThreadLocalValue, LogContextScopeListener.LOG_CONTEXT_DD_TAGS);
     }
     return new ThreadLocalWithDDTagsInitValue<>(origThreadLocalValue);

--- a/dd-java-agent/instrumentation/log4j1/src/test/groovy/Log4j1MDCTest.groovy
+++ b/dd-java-agent/instrumentation/log4j1/src/test/groovy/Log4j1MDCTest.groovy
@@ -30,4 +30,9 @@ class Log4j1MDCTest extends LogContextInjectionTestBase {
   def clear() {
     return MDC.clear()
   }
+
+  @Override
+  def getMap() {
+    return MDC.getContext()
+  }
 }

--- a/dd-java-agent/instrumentation/log4j2/src/main/java/datadog/trace/instrumentation/log4j2/ThreadContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/log4j2/src/main/java/datadog/trace/instrumentation/log4j2/ThreadContextInstrumentation.java
@@ -13,6 +13,7 @@ import datadog.trace.api.GlobalTracer;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
@@ -91,7 +92,7 @@ public class ThreadContextInstrumentation extends Instrumenter.Default {
           final Map<String, String> threadLocalInitValueAsMap =
               threadLocalInitValue != null
                   ? (Map<String, String>) threadLocalInitValue
-                  : new HashMap<String, String>();
+                  : Collections.synchronizedMap(new HashMap<String, String>());
           org.slf4j.LoggerFactory.getLogger(threadContextClass)
               .debug("Setting {} for ThreadLocalWithDDTagsInitValue ", threadLocalInitValueAsMap);
           localMapField.set(

--- a/dd-java-agent/instrumentation/log4j2/src/test/groovy/Log4jThreadContextTest.groovy
+++ b/dd-java-agent/instrumentation/log4j2/src/test/groovy/Log4jThreadContextTest.groovy
@@ -22,4 +22,9 @@ class Log4jThreadContextTest extends LogContextInjectionTestBase {
   def clear() {
     return ThreadContext.clearAll()
   }
+
+  @Override
+  def getMap() {
+    return ThreadContext.getImmutableContext()
+  }
 }

--- a/dd-java-agent/instrumentation/slf4j-mdc/src/main/java/datadog/trace/instrumentation/slf4j/mdc/MDCInjectionInstrumentation.java
+++ b/dd-java-agent/instrumentation/slf4j-mdc/src/main/java/datadog/trace/instrumentation/slf4j/mdc/MDCInjectionInstrumentation.java
@@ -14,6 +14,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.security.ProtectionDomain;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
@@ -31,7 +32,7 @@ public class MDCInjectionInstrumentation extends Instrumenter.Default {
   // mdcClassName = org.slf4j.MDC
   private static final String mdcClassName = "org.TMP.MDC".replaceFirst("TMP", "slf4j");
 
-  private boolean initialized = false;
+  private volatile boolean initialized = false;
 
   public MDCInjectionInstrumentation() {
     super(MDC_INSTRUMENTATION_NAME);
@@ -102,7 +103,9 @@ public class MDCInjectionInstrumentation extends Instrumenter.Default {
         Object copyOnThreadLocalFieldValue =
             ((ThreadLocal) copyOnThreadLocalField.get(mdcAdapterInstance)).get();
         copyOnThreadLocalFieldValue =
-            copyOnThreadLocalFieldValue != null ? copyOnThreadLocalFieldValue : new HashMap<>();
+            copyOnThreadLocalFieldValue != null
+                ? copyOnThreadLocalFieldValue
+                : Collections.synchronizedMap(new HashMap<>());
         copyOnThreadLocalField.set(
             mdcAdapterInstance, ThreadLocalWithDDTagsInitValue.create(copyOnThreadLocalFieldValue));
 

--- a/dd-java-agent/instrumentation/slf4j-mdc/src/test/groovy/Slf4jMDCTest.groovy
+++ b/dd-java-agent/instrumentation/slf4j-mdc/src/test/groovy/Slf4jMDCTest.groovy
@@ -22,4 +22,9 @@ class Slf4jMDCTest extends LogContextInjectionTestBase {
   def clear() {
     return MDC.clear()
   }
+
+  @Override
+  def getMap() {
+    return MDC.getCopyOfContextMap()
+  }
 }

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/log/injection/LogContextInjectionTestBase.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/log/injection/LogContextInjectionTestBase.groovy
@@ -39,6 +39,8 @@ abstract class LogContextInjectionTestBase extends AgentTestRunner {
 
   abstract clear()
 
+  abstract getMap()
+
   static {
     ConfigUtils.updateConfig {
       System.setProperty("dd.logs.injection", "true")
@@ -240,4 +242,12 @@ abstract class LogContextInjectionTestBase extends AgentTestRunner {
     expect:
     t1A == "a thread1"
   }
+
+  def "test getCopyOfContextMap"() {
+    final context = getMap()
+
+    expect:
+    context == getMap()
+  }
+
 }


### PR DESCRIPTION
original threadlocal map value should be synchronized while copied to another map
Like it done here: https://github.com/qos-ch/logback/blob/a6356170acfa6ce6e2383477bf80e6cae8a82d80/logback-classic/src/main/java/ch/qos/logback/classic/util/LogbackMDCAdapter.java#L77 

issue: https://github.com/DataDog/dd-trace-java/issues/1753