### PR TITLE
avoid unnecessary allocation in handoff between PendingTrace and CoreTracer 

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -381,14 +381,12 @@ public class CoreTracer implements AgentTracer.TracerAPI {
    *
    * @param trace a list of the spans related to the same trace
    */
-  void write(final Collection<DDSpan> trace) {
+  void write(final List<DDSpan> trace) {
     if (trace.isEmpty()) {
       return;
     }
-    final ArrayList<DDSpan> writtenTrace;
-    if (interceptors.isEmpty()) {
-      writtenTrace = new ArrayList<>(trace);
-    } else {
+    List<DDSpan> writtenTrace = trace;
+    if (!interceptors.isEmpty()) {
       Collection<? extends MutableSpan> interceptedTrace = new ArrayList<>(trace);
       for (final TraceInterceptor interceptor : interceptors) {
         interceptedTrace = interceptor.onTraceComplete(interceptedTrace);


### PR DESCRIPTION
This prevents copying the trace twice when partial spans occur