### PR TITLE
MLT Support should not be published.

### DIFF
--- a/utils/mlt-support/mlt-support.gradle
+++ b/utils/mlt-support/mlt-support.gradle
@@ -8,7 +8,6 @@ ext {
 }
 
 apply from: "$rootDir/gradle/java.gradle"
-apply from: "$rootDir/gradle/publish.gradle"
 
 description = "dd mlt binary format support"
 


### PR DESCRIPTION
I had to manually remove it from bintray before syncing with sonatype for 0.60.0 release.