### PR TITLE
Replace SLF4J SimpleLogger with own compatible implementation

### DIFF
--- a/dd-java-agent/agent-bootstrap/agent-bootstrap.gradle
+++ b/dd-java-agent/agent-bootstrap/agent-bootstrap.gradle
@@ -10,11 +10,11 @@ minimumBranchCoverage = 0.0
 minimumInstructionCoverage = 0.0
 
 dependencies {
+  compile project(':dd-java-agent:agent-logging')
   compile project(':dd-trace-api')
   compile project(':internal-api')
   compile project(':utils:thread-utils')
   compile deps.slf4j
-  compile group: 'org.slf4j', name: 'slf4j-simple', version: versions.slf4j
   // ^ Generally a bad idea for libraries, but we're shadowing.
 
   testCompile project(':dd-java-agent:testing')

--- a/dd-java-agent/agent-jmxfetch/agent-jmxfetch.gradle
+++ b/dd-java-agent/agent-jmxfetch/agent-jmxfetch.gradle
@@ -17,6 +17,7 @@ shadowJar {
   dependencies deps.sharedInverse
   dependencies {
     exclude(project(':dd-java-agent:agent-bootstrap'))
+    exclude(project(':dd-java-agent:agent-logging'))
     exclude(project(':dd-trace-api'))
     exclude(project(':internal-api'))
     exclude(dependency('org.slf4j::'))

--- a/dd-java-agent/agent-logging/agent-logging.gradle
+++ b/dd-java-agent/agent-logging/agent-logging.gradle
@@ -6,6 +6,7 @@ excludedClassesCoverage += [
   'datadog.trace.logging.simplelogger.SLCompatSettings.Defaults',
   // Can't test fallback path
   'datadog.trace.logging.simplelogger.SLCompatSettings.ResourceStreamPrivilegedAction',
+  'datadog.trace.logging.simplelogger.SLCompatSettings.DTFormatter',
   // Only wires up the logging
   'datadog.slf4j.impl.StaticLoggerBinder',
   'datadog.slf4j.impl.StaticMarkerBinder',

--- a/dd-java-agent/agent-logging/agent-logging.gradle
+++ b/dd-java-agent/agent-logging/agent-logging.gradle
@@ -1,0 +1,20 @@
+apply from: "$rootDir/gradle/java.gradle"
+
+excludedClassesCoverage += [
+  // Contains no code
+  'datadog.trace.logging.simplelogger.SLCompatSettings.Keys',
+  'datadog.trace.logging.simplelogger.SLCompatSettings.Defaults',
+  // Can't test fallback path
+  'datadog.trace.logging.simplelogger.SLCompatSettings.ResourceStreamPrivilegedAction',
+  // Only wires up the logging
+  'datadog.slf4j.impl.StaticLoggerBinder',
+  'datadog.slf4j.impl.StaticMarkerBinder',
+  'datadog.slf4j.impl.StaticMDCBinder',
+  'datadog.trace.logging.DDLoggerFactory',
+  'datadog.trace.logging.simplelogger.SLCompatFactory',
+]
+
+dependencies {
+  compile group: 'org.slf4j', name: 'slf4j-api', version: versions.slf4j
+  // This is fine since this project is shadowed into the agent-jar by dd-java-agent:agent-bootstrap
+}

--- a/dd-java-agent/agent-logging/src/main/java/datadog/slf4j/impl/StaticLoggerBinder.java
+++ b/dd-java-agent/agent-logging/src/main/java/datadog/slf4j/impl/StaticLoggerBinder.java
@@ -1,0 +1,34 @@
+/**
+ * Please note that the package name here needs to match where org.slf4j.impl will be in the
+ * shadowed jar.
+ */
+package datadog.slf4j.impl;
+
+import datadog.trace.logging.DDLoggerFactory;
+import org.slf4j.ILoggerFactory;
+import org.slf4j.spi.LoggerFactoryBinder;
+
+public class StaticLoggerBinder implements LoggerFactoryBinder {
+
+  private static final StaticLoggerBinder SINGLETON = new StaticLoggerBinder();
+
+  public static final StaticLoggerBinder getSingleton() {
+    return SINGLETON;
+  }
+
+  private static final String loggerFactoryClassStr = DDLoggerFactory.class.getName();
+
+  private final ILoggerFactory loggerFactory;
+
+  private StaticLoggerBinder() {
+    loggerFactory = new DDLoggerFactory();
+  }
+
+  public ILoggerFactory getLoggerFactory() {
+    return loggerFactory;
+  }
+
+  public String getLoggerFactoryClassStr() {
+    return loggerFactoryClassStr;
+  }
+}

--- a/dd-java-agent/agent-logging/src/main/java/datadog/slf4j/impl/StaticMDCBinder.java
+++ b/dd-java-agent/agent-logging/src/main/java/datadog/slf4j/impl/StaticMDCBinder.java
@@ -1,0 +1,23 @@
+/**
+ * Please note that the package name here needs to match where org.slf4j.impl will be in the
+ * shadowed jar.
+ */
+package datadog.slf4j.impl;
+
+import org.slf4j.helpers.NOPMDCAdapter;
+import org.slf4j.spi.MDCAdapter;
+
+public class StaticMDCBinder {
+
+  public static final StaticMDCBinder SINGLETON = new StaticMDCBinder();
+
+  private StaticMDCBinder() {}
+
+  public MDCAdapter getMDCA() {
+    return new NOPMDCAdapter();
+  }
+
+  public String getMDCAdapterClassStr() {
+    return NOPMDCAdapter.class.getName();
+  }
+}

--- a/dd-java-agent/agent-logging/src/main/java/datadog/slf4j/impl/StaticMarkerBinder.java
+++ b/dd-java-agent/agent-logging/src/main/java/datadog/slf4j/impl/StaticMarkerBinder.java
@@ -1,0 +1,30 @@
+/**
+ * Please note that the package name here needs to match where org.slf4j.impl will be in the
+ * shadowed jar.
+ */
+package datadog.slf4j.impl;
+
+import org.slf4j.IMarkerFactory;
+import org.slf4j.helpers.BasicMarkerFactory;
+import org.slf4j.spi.MarkerFactoryBinder;
+
+public class StaticMarkerBinder implements MarkerFactoryBinder {
+
+  public static final StaticMarkerBinder SINGLETON = new StaticMarkerBinder();
+
+  final IMarkerFactory markerFactory = new BasicMarkerFactory();
+
+  private StaticMarkerBinder() {}
+
+  public static StaticMarkerBinder getSingleton() {
+    return SINGLETON;
+  }
+
+  public IMarkerFactory getMarkerFactory() {
+    return markerFactory;
+  }
+
+  public String getMarkerFactoryClassStr() {
+    return BasicMarkerFactory.class.getName();
+  }
+}

--- a/dd-java-agent/agent-logging/src/main/java/datadog/trace/logging/DDLogger.java
+++ b/dd-java-agent/agent-logging/src/main/java/datadog/trace/logging/DDLogger.java
@@ -1,0 +1,362 @@
+package datadog.trace.logging;
+
+import org.slf4j.Logger;
+import org.slf4j.Marker;
+import org.slf4j.helpers.FormattingTuple;
+import org.slf4j.helpers.MessageFormatter;
+
+/** Implementation of org.slf4j.Logger. Delegates actual rendering to {@link LoggerHelper}. */
+public class DDLogger implements Logger {
+
+  private final String name;
+  private final LoggerHelper helper;
+
+  public DDLogger(LoggerHelperFactory helperFactory, String name) {
+    this.name = name;
+    this.helper = helperFactory.loggerHelperForName(name);
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public boolean isTraceEnabled() {
+    return helper.enabled(LogLevel.TRACE, null);
+  }
+
+  @Override
+  public void trace(String msg) {
+    log(LogLevel.TRACE, null, msg, null);
+  }
+
+  @Override
+  public void trace(String format, Object arg) {
+    formatLog(LogLevel.TRACE, null, format, arg);
+  }
+
+  @Override
+  public void trace(String format, Object arg1, Object arg2) {
+    formatLog(LogLevel.TRACE, null, format, arg1, arg2);
+  }
+
+  @Override
+  public void trace(String format, Object... arguments) {
+    formatLog(LogLevel.TRACE, null, format, arguments);
+  }
+
+  @Override
+  public void trace(String msg, Throwable t) {
+    log(LogLevel.TRACE, null, msg, t);
+  }
+
+  @Override
+  public boolean isTraceEnabled(Marker marker) {
+    return helper.enabled(LogLevel.TRACE, marker);
+  }
+
+  @Override
+  public void trace(Marker marker, String msg) {
+    log(LogLevel.TRACE, marker, msg, null);
+  }
+
+  @Override
+  public void trace(Marker marker, String format, Object arg) {
+    formatLog(LogLevel.TRACE, marker, format, arg);
+  }
+
+  @Override
+  public void trace(Marker marker, String format, Object arg1, Object arg2) {
+    formatLog(LogLevel.TRACE, marker, format, arg1, arg2);
+  }
+
+  @Override
+  public void trace(Marker marker, String format, Object... arguments) {
+    formatLog(LogLevel.TRACE, marker, format, arguments);
+  }
+
+  @Override
+  public void trace(Marker marker, String msg, Throwable t) {
+    log(LogLevel.TRACE, marker, msg, t);
+  }
+
+  @Override
+  public boolean isDebugEnabled() {
+    return helper.enabled(LogLevel.DEBUG, null);
+  }
+
+  @Override
+  public void debug(String msg) {
+    log(LogLevel.DEBUG, null, msg, null);
+  }
+
+  @Override
+  public void debug(String format, Object arg) {
+    formatLog(LogLevel.DEBUG, null, format, arg);
+  }
+
+  @Override
+  public void debug(String format, Object arg1, Object arg2) {
+    formatLog(LogLevel.DEBUG, null, format, arg1, arg2);
+  }
+
+  @Override
+  public void debug(String format, Object... arguments) {
+    formatLog(LogLevel.DEBUG, null, format, arguments);
+  }
+
+  @Override
+  public void debug(String msg, Throwable t) {
+    log(LogLevel.DEBUG, null, msg, t);
+  }
+
+  @Override
+  public boolean isDebugEnabled(Marker marker) {
+    return helper.enabled(LogLevel.DEBUG, marker);
+  }
+
+  @Override
+  public void debug(Marker marker, String msg) {
+    log(LogLevel.DEBUG, marker, msg, null);
+  }
+
+  @Override
+  public void debug(Marker marker, String format, Object arg) {
+    formatLog(LogLevel.DEBUG, marker, format, arg);
+  }
+
+  @Override
+  public void debug(Marker marker, String format, Object arg1, Object arg2) {
+    formatLog(LogLevel.DEBUG, marker, format, arg1, arg2);
+  }
+
+  @Override
+  public void debug(Marker marker, String format, Object... arguments) {
+    formatLog(LogLevel.DEBUG, marker, format, arguments);
+  }
+
+  @Override
+  public void debug(Marker marker, String msg, Throwable t) {
+    log(LogLevel.DEBUG, marker, msg, t);
+  }
+
+  @Override
+  public boolean isInfoEnabled() {
+    return helper.enabled(LogLevel.INFO, null);
+  }
+
+  @Override
+  public void info(String msg) {
+    log(LogLevel.INFO, null, msg, null);
+  }
+
+  @Override
+  public void info(String format, Object arg) {
+    formatLog(LogLevel.INFO, null, format, arg);
+  }
+
+  @Override
+  public void info(String format, Object arg1, Object arg2) {
+    formatLog(LogLevel.INFO, null, format, arg1, arg2);
+  }
+
+  @Override
+  public void info(String format, Object... arguments) {
+    formatLog(LogLevel.INFO, null, format, arguments);
+  }
+
+  @Override
+  public void info(String msg, Throwable t) {
+    log(LogLevel.INFO, null, msg, t);
+  }
+
+  @Override
+  public boolean isInfoEnabled(Marker marker) {
+    return helper.enabled(LogLevel.INFO, marker);
+  }
+
+  @Override
+  public void info(Marker marker, String msg) {
+    log(LogLevel.INFO, marker, msg, null);
+  }
+
+  @Override
+  public void info(Marker marker, String format, Object arg) {
+    formatLog(LogLevel.INFO, marker, format, arg);
+  }
+
+  @Override
+  public void info(Marker marker, String format, Object arg1, Object arg2) {
+    formatLog(LogLevel.INFO, marker, format, arg1, arg2);
+  }
+
+  @Override
+  public void info(Marker marker, String format, Object... arguments) {
+    formatLog(LogLevel.INFO, marker, format, arguments);
+  }
+
+  @Override
+  public void info(Marker marker, String msg, Throwable t) {
+    log(LogLevel.INFO, marker, msg, t);
+  }
+
+  @Override
+  public boolean isWarnEnabled() {
+    return helper.enabled(LogLevel.WARN, null);
+  }
+
+  @Override
+  public void warn(String msg) {
+    log(LogLevel.WARN, null, msg, null);
+  }
+
+  @Override
+  public void warn(String format, Object arg) {
+    formatLog(LogLevel.WARN, null, format, arg);
+  }
+
+  @Override
+  public void warn(String format, Object arg1, Object arg2) {
+    formatLog(LogLevel.WARN, null, format, arg1, arg2);
+  }
+
+  @Override
+  public void warn(String format, Object... arguments) {
+    formatLog(LogLevel.WARN, null, format, arguments);
+  }
+
+  @Override
+  public void warn(String msg, Throwable t) {
+    log(LogLevel.WARN, null, msg, t);
+  }
+
+  @Override
+  public boolean isWarnEnabled(Marker marker) {
+    return helper.enabled(LogLevel.WARN, marker);
+  }
+
+  @Override
+  public void warn(Marker marker, String msg) {
+    log(LogLevel.WARN, marker, msg, null);
+  }
+
+  @Override
+  public void warn(Marker marker, String format, Object arg) {
+    formatLog(LogLevel.WARN, marker, format, arg);
+  }
+
+  @Override
+  public void warn(Marker marker, String format, Object arg1, Object arg2) {
+    formatLog(LogLevel.WARN, marker, format, arg1, arg2);
+  }
+
+  @Override
+  public void warn(Marker marker, String format, Object... arguments) {
+    formatLog(LogLevel.WARN, marker, format, arguments);
+  }
+
+  @Override
+  public void warn(Marker marker, String msg, Throwable t) {
+    log(LogLevel.WARN, marker, msg, t);
+  }
+
+  @Override
+  public boolean isErrorEnabled() {
+    return helper.enabled(LogLevel.ERROR, null);
+  }
+
+  @Override
+  public void error(String msg) {
+    log(LogLevel.ERROR, null, msg, null);
+  }
+
+  @Override
+  public void error(String format, Object arg) {
+    formatLog(LogLevel.ERROR, null, format, arg);
+  }
+
+  @Override
+  public void error(String format, Object arg1, Object arg2) {
+    formatLog(LogLevel.ERROR, null, format, arg1, arg2);
+  }
+
+  @Override
+  public void error(String format, Object... arguments) {
+    formatLog(LogLevel.ERROR, null, format, arguments);
+  }
+
+  @Override
+  public void error(String msg, Throwable t) {
+    log(LogLevel.ERROR, null, msg, t);
+  }
+
+  @Override
+  public boolean isErrorEnabled(Marker marker) {
+    return helper.enabled(LogLevel.ERROR, marker);
+  }
+
+  @Override
+  public void error(Marker marker, String msg) {
+    log(LogLevel.ERROR, marker, msg, null);
+  }
+
+  @Override
+  public void error(Marker marker, String format, Object arg) {
+    formatLog(LogLevel.ERROR, marker, format, arg);
+  }
+
+  @Override
+  public void error(Marker marker, String format, Object arg1, Object arg2) {
+    formatLog(LogLevel.ERROR, marker, format, arg1, arg2);
+  }
+
+  @Override
+  public void error(Marker marker, String format, Object... arguments) {
+    formatLog(LogLevel.ERROR, marker, format, arguments);
+  }
+
+  @Override
+  public void error(Marker marker, String msg, Throwable t) {
+    log(LogLevel.ERROR, marker, msg, t);
+  }
+
+  public void formatLog(LogLevel level, Marker marker, String format, Object arg) {
+    if (!helper.enabled(level, marker)) {
+      return;
+    }
+
+    FormattingTuple tuple = MessageFormatter.format(format, arg);
+    alwaysLog(level, marker, tuple.getMessage(), tuple.getThrowable());
+  }
+
+  public void formatLog(LogLevel level, Marker marker, String format, Object arg1, Object arg2) {
+    if (!helper.enabled(level, marker)) {
+      return;
+    }
+
+    FormattingTuple tuple = MessageFormatter.format(format, arg1, arg2);
+    alwaysLog(level, marker, tuple.getMessage(), tuple.getThrowable());
+  }
+
+  public void formatLog(LogLevel level, Marker marker, String format, Object... arguments) {
+    if (!helper.enabled(level, marker)) {
+      return;
+    }
+
+    FormattingTuple tuple = MessageFormatter.arrayFormat(format, arguments);
+    alwaysLog(level, marker, tuple.getMessage(), tuple.getThrowable());
+  }
+
+  private void log(LogLevel level, Marker marker, String msg, Throwable t) {
+    if (!helper.enabled(level, marker)) {
+      return;
+    }
+    alwaysLog(level, marker, msg, t);
+  }
+
+  private void alwaysLog(LogLevel level, Marker marker, String msg, Throwable t) {
+    // TODO Ignoring Marker for now since SLCompatHelper ignores it as well
+    helper.log(level, msg, t);
+  }
+}

--- a/dd-java-agent/agent-logging/src/main/java/datadog/trace/logging/DDLoggerFactory.java
+++ b/dd-java-agent/agent-logging/src/main/java/datadog/trace/logging/DDLoggerFactory.java
@@ -1,0 +1,21 @@
+package datadog.trace.logging;
+
+import datadog.trace.logging.simplelogger.SLCompatFactory;
+import org.slf4j.ILoggerFactory;
+import org.slf4j.Logger;
+
+public class DDLoggerFactory implements ILoggerFactory {
+
+  public DDLoggerFactory() {}
+
+  private static LoggerHelperFactory helperFactory = null;
+
+  @Override
+  public Logger getLogger(String name) {
+    LoggerHelperFactory c = helperFactory;
+    if (c == null) {
+      c = helperFactory = new SLCompatFactory();
+    }
+    return new DDLogger(c, name);
+  }
+}

--- a/dd-java-agent/agent-logging/src/main/java/datadog/trace/logging/LogLevel.java
+++ b/dd-java-agent/agent-logging/src/main/java/datadog/trace/logging/LogLevel.java
@@ -1,0 +1,39 @@
+package datadog.trace.logging;
+
+/** Log level enum. */
+public enum LogLevel {
+  TRACE,
+  DEBUG,
+  INFO,
+  WARN,
+  ERROR,
+  OFF;
+
+  /**
+   * Case insensitive conversion from {@link String} to {@link LogLevel}.
+   *
+   * <p>Fallback is {@link #INFO}.
+   *
+   * @param level the {@link LogLevel} as a {@link String}
+   * @return the corresponding {@link LogLevel} enum
+   */
+  public static LogLevel fromString(String level) {
+    String upper = level.toUpperCase();
+    try {
+      return Enum.valueOf(LogLevel.class, upper);
+    } catch (Throwable t) {
+      // INFO is the fallback
+      return LogLevel.INFO;
+    }
+  }
+
+  /**
+   * Check if a {@link LogLevel} is enabled for this {@link LogLevel}.
+   *
+   * @param level the {@link LogLevel} to check
+   * @return true if the {@code level} is enabled, false otherwise
+   */
+  public boolean isEnabled(LogLevel level) {
+    return this.compareTo(level) >= 0;
+  }
+}

--- a/dd-java-agent/agent-logging/src/main/java/datadog/trace/logging/LoggerHelper.java
+++ b/dd-java-agent/agent-logging/src/main/java/datadog/trace/logging/LoggerHelper.java
@@ -1,0 +1,27 @@
+package datadog.trace.logging;
+
+import org.slf4j.Marker;
+
+public abstract class LoggerHelper {
+  /**
+   * Check if the provided {@link LogLevel} and {@link Marker} combination is enabled.
+   *
+   * @param level the {@link LogLevel} to check
+   * @param marker the {@link Marker} to check
+   * @return true if logging is enabled for the {@code level} and {@code marker} combination, false
+   *     otherwise
+   */
+  public abstract boolean enabled(LogLevel level, Marker marker);
+
+  /**
+   * Log a message at a certain level.
+   *
+   * <p>The {@link LoggerHelper} can assume that the caller have checked if the {@code level} is
+   * {@code enabled}.
+   *
+   * @param level the {@link LogLevel} to log at
+   * @param message the message to log
+   * @param t the {@link Throwable} to log
+   */
+  public abstract void log(LogLevel level, String message, Throwable t);
+}

--- a/dd-java-agent/agent-logging/src/main/java/datadog/trace/logging/LoggerHelperFactory.java
+++ b/dd-java-agent/agent-logging/src/main/java/datadog/trace/logging/LoggerHelperFactory.java
@@ -1,0 +1,12 @@
+package datadog.trace.logging;
+
+/** A factory for creating {@link LoggerHelper} instances. */
+public abstract class LoggerHelperFactory {
+  /**
+   * Create a {@link LoggerHelper} for the given {@code name}.
+   *
+   * @param name the name of the {@code logger}
+   * @return the {@link LoggerHelper} for the given name
+   */
+  public abstract LoggerHelper loggerHelperForName(String name);
+}

--- a/dd-java-agent/agent-logging/src/main/java/datadog/trace/logging/simplelogger/SLCompatFactory.java
+++ b/dd-java-agent/agent-logging/src/main/java/datadog/trace/logging/simplelogger/SLCompatFactory.java
@@ -1,0 +1,60 @@
+package datadog.trace.logging.simplelogger;
+
+import datadog.trace.logging.LoggerHelper;
+import datadog.trace.logging.LoggerHelperFactory;
+import java.util.Properties;
+
+/**
+ * A {@link LoggerHelperFactory} for {@link SLCompatHelper} that logs in a way compatible with the
+ * {@code SimpleLogger} from SLF4J.
+ *
+ * <p>Tries to initialize lazily to mimic the behavior of {@code SimpleLogger} as much as possible.
+ */
+public final class SLCompatFactory extends LoggerHelperFactory {
+
+  static final long START_TIME = System.currentTimeMillis();
+
+  private static Properties getProperties() {
+    try {
+      return System.getProperties();
+    } catch (SecurityException e) {
+      return new Properties();
+    }
+  }
+
+  private final Properties properties;
+  private volatile SLCompatSettings lazySettings;
+
+  public SLCompatFactory() {
+    this(getProperties());
+  }
+
+  public SLCompatFactory(Properties properties) {
+    this(properties, null);
+  }
+
+  public SLCompatFactory(Properties properties, SLCompatSettings settings) {
+    this.properties = properties;
+    this.lazySettings = settings;
+  }
+
+  private SLCompatSettings getSettings() {
+    // This race condition is intentional and benign.
+    SLCompatSettings settings = lazySettings;
+    while (settings == null) {
+      try {
+        settings = lazySettings = new SLCompatSettings(properties);
+      } catch (IllegalStateException e) {
+        // This can only happen if there is a race within the constructor and multiple
+        // threads try to create conflicting log files
+      }
+    }
+    return settings;
+  }
+
+  @Override
+  public LoggerHelper loggerHelperForName(String name) {
+    SLCompatSettings settings = getSettings();
+    return new SLCompatHelper(name, settings);
+  }
+}

--- a/dd-java-agent/agent-logging/src/main/java/datadog/trace/logging/simplelogger/SLCompatHelper.java
+++ b/dd-java-agent/agent-logging/src/main/java/datadog/trace/logging/simplelogger/SLCompatHelper.java
@@ -1,0 +1,107 @@
+package datadog.trace.logging.simplelogger;
+
+import datadog.trace.logging.LogLevel;
+import datadog.trace.logging.LoggerHelper;
+import java.util.Date;
+import org.slf4j.Marker;
+
+/**
+ * A {@link LoggerHelper} that logs in a way compatible with the {@code SimpleLogger} from SLF4J.
+ */
+class SLCompatHelper extends LoggerHelper {
+  private final String logName;
+  private final LogLevel logLevel;
+  private final SLCompatSettings settings;
+
+  SLCompatHelper(String name, SLCompatSettings settings) {
+    this(settings.logNameForName(name), settings.logLevelForName(name), settings);
+  }
+
+  SLCompatHelper(String logName, LogLevel logLevel, SLCompatSettings settings) {
+    this.logName = logName;
+    this.logLevel = logLevel;
+    this.settings = settings;
+  }
+
+  private void appendFormattedDate(StringBuilder builder, long timeMillis, long startTimeMillis) {
+    if (settings.dateTimeFormatter != null) {
+      Date date = new Date(timeMillis);
+      String dateString;
+      synchronized (settings.dateTimeFormatter) {
+        dateString = settings.dateTimeFormatter.format(date);
+      }
+      builder.append(dateString);
+    } else {
+      builder.append(timeMillis - startTimeMillis);
+    }
+  }
+
+  @Override
+  public boolean enabled(LogLevel level, Marker marker) {
+    // SimpleLogger ignores markers
+    return level.isEnabled(this.logLevel);
+  }
+
+  @Override
+  public void log(LogLevel level, String message, Throwable t) {
+    long timeMillis = Integer.MIN_VALUE;
+    if (settings.showDateTime) {
+      timeMillis = System.currentTimeMillis();
+    }
+    log(level, SLCompatFactory.START_TIME, timeMillis, message, t);
+  }
+
+  void log(LogLevel level, long startTimeMillis, long timeMillis, String message, Throwable t) {
+    String threadName = null;
+    if (settings.showThreadName) {
+      threadName = Thread.currentThread().getName();
+    }
+    log(level, startTimeMillis, timeMillis, threadName, message, t);
+  }
+
+  void log(
+      LogLevel level,
+      long startTimeMillis,
+      long timeMillis,
+      String threadName,
+      String message,
+      Throwable t) {
+    StringBuilder buf = new StringBuilder(32);
+
+    if (timeMillis >= 0 && settings.showDateTime) {
+      appendFormattedDate(buf, timeMillis, startTimeMillis);
+      buf.append(' ');
+    }
+
+    if (settings.showThreadName && threadName != null) {
+      buf.append('[');
+      buf.append(threadName);
+      buf.append("] ");
+    }
+
+    if (settings.levelInBrackets) {
+      buf.append('[');
+    }
+
+    if (settings.warnLevelString != null && level == LogLevel.WARN) {
+      buf.append(settings.warnLevelString);
+    } else {
+      buf.append(level.name());
+    }
+    if (settings.levelInBrackets) {
+      buf.append(']');
+    }
+    buf.append(' ');
+
+    if (logName.length() > 0) {
+      buf.append(logName).append(" - ");
+    }
+
+    buf.append(message);
+
+    settings.printStream.println(buf.toString());
+    if (t != null) {
+      t.printStackTrace(settings.printStream);
+    }
+  }
+}

--- a/dd-java-agent/agent-logging/src/main/java/datadog/trace/logging/simplelogger/SLCompatHelper.java
+++ b/dd-java-agent/agent-logging/src/main/java/datadog/trace/logging/simplelogger/SLCompatHelper.java
@@ -2,7 +2,6 @@ package datadog.trace.logging.simplelogger;
 
 import datadog.trace.logging.LogLevel;
 import datadog.trace.logging.LoggerHelper;
-import java.util.Date;
 import org.slf4j.Marker;
 
 /**
@@ -21,19 +20,6 @@ class SLCompatHelper extends LoggerHelper {
     this.logName = logName;
     this.logLevel = logLevel;
     this.settings = settings;
-  }
-
-  private void appendFormattedDate(StringBuilder builder, long timeMillis, long startTimeMillis) {
-    if (settings.dateTimeFormatter != null) {
-      Date date = new Date(timeMillis);
-      String dateString;
-      synchronized (settings.dateTimeFormatter) {
-        dateString = settings.dateTimeFormatter.format(date);
-      }
-      builder.append(dateString);
-    } else {
-      builder.append(timeMillis - startTimeMillis);
-    }
   }
 
   @Override
@@ -69,7 +55,7 @@ class SLCompatHelper extends LoggerHelper {
     StringBuilder buf = new StringBuilder(32);
 
     if (timeMillis >= 0 && settings.showDateTime) {
-      appendFormattedDate(buf, timeMillis, startTimeMillis);
+      settings.dateTimeFormatter.appendFormattedDate(buf, timeMillis, startTimeMillis);
       buf.append(' ');
     }
 

--- a/dd-java-agent/agent-logging/src/main/java/datadog/trace/logging/simplelogger/SLCompatSettings.java
+++ b/dd-java-agent/agent-logging/src/main/java/datadog/trace/logging/simplelogger/SLCompatSettings.java
@@ -1,0 +1,243 @@
+package datadog.trace.logging.simplelogger;
+
+import datadog.trace.logging.LogLevel;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Properties;
+
+/** Settings that provide the same configurable options as {@code SimpleLogger} from SLF4J. */
+public class SLCompatSettings {
+
+  public static final class Keys {
+    // This is the package name that the shaded SimpleLogger had before. Use that for compatibility.
+    private static final String PREFIX = "datadog.slf4j.simpleLogger.";
+
+    public static final String LOG_KEY_PREFIX = PREFIX + "log.";
+    // This setting does not change anything in the behavior as of slf4j 1.7.30 so we ignore it
+    // public static final String CACHE_OUTPUT_STREAM = PREFIX + "cacheOutputStream";
+    public static final String WARN_LEVEL_STRING = PREFIX + "warnLevelString";
+    public static final String LEVEL_IN_BRACKETS = PREFIX + "levelInBrackets";
+    public static final String LOG_FILE = PREFIX + "logFile";
+    public static final String SHOW_SHORT_LOG_NAME = PREFIX + "showShortLogName";
+    public static final String SHOW_LOG_NAME = PREFIX + "showLogName";
+    public static final String SHOW_THREAD_NAME = PREFIX + "showThreadName";
+    public static final String DATE_TIME_FORMAT = PREFIX + "dateTimeFormat";
+    public static final String SHOW_DATE_TIME = PREFIX + "showDateTime";
+    public static final String DEFAULT_LOG_LEVEL = PREFIX + "defaultLogLevel";
+
+    // This is not available in SimpleLogger, but added here to simplify testing.
+    static final String CONFIGURATION_FILE = PREFIX + "configurationFile";
+  }
+
+  public static final class Defaults {
+    // This setting does not change anything in the behavior as of slf4j 1.7.30 so we ignore it
+    // static final boolean CACHE_OUTPUT_STREAM = false;
+    public static final boolean LEVEL_IN_BRACKETS = false;
+    public static final String LOG_FILE = "System.err";
+    public static final boolean SHOW_SHORT_LOG_NAME = false;
+    public static final boolean SHOW_LOG_NAME = true;
+    public static final boolean SHOW_THREAD_NAME = true;
+    public static final String DATE_TIME_FORMAT = null;
+    public static final boolean SHOW_DATE_TIME = false;
+    public static final String DEFAULT_LOG_LEVEL = "INFO";
+
+    public static final String CONFIGURATION_FILE = "simplelogger.properties";
+  }
+
+  static PrintStream getPrintStream(String logFile) {
+    switch (logFile.toLowerCase()) {
+      case "system.err":
+        return System.err;
+      case "system.out":
+        return System.out;
+      default:
+        try {
+          FileOutputStream outputStream = new FileOutputStream(logFile);
+          PrintStream printStream = new PrintStream(outputStream);
+          return printStream;
+        } catch (FileNotFoundException | SecurityException e) {
+          // TODO maybe have support for delayed logging of early failures?
+          return System.err;
+        }
+    }
+  }
+
+  private static final class ResourceStreamPrivilegedAction
+      implements PrivilegedAction<InputStream> {
+    private final String fileName;
+
+    public ResourceStreamPrivilegedAction(String fileName) {
+      this.fileName = fileName;
+    }
+
+    @Override
+    public InputStream run() {
+      ClassLoader threadCL = Thread.currentThread().getContextClassLoader();
+      if (threadCL != null) {
+        return threadCL.getResourceAsStream(fileName);
+      } else {
+        return ClassLoader.getSystemResourceAsStream(fileName);
+      }
+    }
+  }
+
+  static Properties loadProperties(final String fileName) {
+    Properties fileProperties = null;
+    // Load properties in the same way that SimpleLogger does
+    InputStream inputStream =
+        AccessController.doPrivileged(new ResourceStreamPrivilegedAction(fileName));
+
+    if (inputStream != null) {
+      try {
+        Properties properties = new Properties();
+        properties.load(inputStream);
+        fileProperties = properties;
+        inputStream.close();
+      } catch (java.io.IOException e) {
+        // ignored
+      }
+    }
+
+    return fileProperties;
+  }
+
+  private static String getString(
+      Properties properties, Properties fallbackProperties, String name) {
+    String property = properties == null ? null : properties.getProperty(name);
+    if (property == null) {
+      property = fallbackProperties == null ? null : fallbackProperties.getProperty(name);
+    }
+    return property;
+  }
+
+  static String getString(
+      Properties properties, Properties fallbackProperties, String name, String defaultValue) {
+    String property = getString(properties, fallbackProperties, name);
+    return property == null ? defaultValue : property;
+  }
+
+  static boolean getBoolean(
+      Properties properties, Properties fallbackProperties, String name, boolean defaultValue) {
+    String property = getString(properties, fallbackProperties, name);
+    return property == null ? defaultValue : Boolean.parseBoolean(property);
+  }
+
+  private static DateFormat getDateTimeFormatter(String dateTimeFormat) {
+    if (dateTimeFormat == null) {
+      return null;
+    }
+    DateFormat dateTimeFormatter = null;
+    try {
+      dateTimeFormatter = new SimpleDateFormat(dateTimeFormat);
+    } catch (IllegalArgumentException e) {
+      // TODO maybe have support for delayed logging of early failures?
+    }
+    return dateTimeFormatter;
+  }
+
+  private final Properties properties;
+  private final Properties fileProperties;
+
+  // Package reachable for SLCompatHelper and tests
+  final String warnLevelString;
+  final boolean levelInBrackets;
+  final PrintStream printStream;
+  final boolean showShortLogName;
+  final boolean showLogName;
+  final boolean showThreadName;
+  final DateFormat dateTimeFormatter;
+  final boolean showDateTime;
+  final LogLevel defaultLogLevel;
+
+  public SLCompatSettings(Properties properties) {
+    this(
+        properties,
+        loadProperties(
+            properties.getProperty(Keys.CONFIGURATION_FILE, Defaults.CONFIGURATION_FILE)));
+  }
+
+  public SLCompatSettings(Properties properties, Properties fileProperties) {
+    this(
+        properties,
+        fileProperties,
+        getPrintStream(getString(properties, fileProperties, Keys.LOG_FILE, Defaults.LOG_FILE)));
+  }
+
+  public SLCompatSettings(
+      Properties properties, Properties fileProperties, PrintStream printStream) {
+    this(
+        properties,
+        fileProperties,
+        getString(properties, fileProperties, Keys.WARN_LEVEL_STRING),
+        getBoolean(properties, fileProperties, Keys.LEVEL_IN_BRACKETS, Defaults.LEVEL_IN_BRACKETS),
+        printStream,
+        getBoolean(
+            properties, fileProperties, Keys.SHOW_SHORT_LOG_NAME, Defaults.SHOW_SHORT_LOG_NAME),
+        getBoolean(properties, fileProperties, Keys.SHOW_LOG_NAME, Defaults.SHOW_LOG_NAME),
+        getBoolean(properties, fileProperties, Keys.SHOW_THREAD_NAME, Defaults.SHOW_THREAD_NAME),
+        getDateTimeFormatter(
+            getString(
+                properties, fileProperties, Keys.DATE_TIME_FORMAT, Defaults.DATE_TIME_FORMAT)),
+        getBoolean(properties, fileProperties, Keys.SHOW_DATE_TIME, Defaults.SHOW_DATE_TIME),
+        LogLevel.fromString(
+            getString(
+                properties, fileProperties, Keys.DEFAULT_LOG_LEVEL, Defaults.DEFAULT_LOG_LEVEL)));
+  }
+
+  public SLCompatSettings(
+      Properties properties,
+      Properties fileProperties,
+      String warnLevelString,
+      boolean levelInBrackets,
+      PrintStream printStream,
+      boolean showShortLogName,
+      boolean showLogName,
+      boolean showThreadName,
+      DateFormat dateTimeFormatter,
+      boolean showDateTime,
+      LogLevel defaultLogLevel) {
+    this.properties = properties;
+    this.fileProperties = fileProperties;
+    this.warnLevelString = warnLevelString;
+    this.levelInBrackets = levelInBrackets;
+    this.printStream = printStream;
+    this.showShortLogName = showShortLogName;
+    this.showLogName = showLogName;
+    this.showThreadName = showThreadName;
+    this.dateTimeFormatter = dateTimeFormatter;
+    this.showDateTime = showDateTime;
+    this.defaultLogLevel = defaultLogLevel;
+  }
+
+  String getString(String name) {
+    return getString(properties, fileProperties, name);
+  }
+
+  public LogLevel logLevelForName(String name) {
+    String level = null;
+    String remainder = name;
+    int end = name.length();
+    while (level == null && end > -1) {
+      remainder = remainder.substring(0, end);
+      level = getString(Keys.LOG_KEY_PREFIX + remainder);
+      end = remainder.lastIndexOf('.');
+    }
+    return level != null ? LogLevel.fromString(level) : defaultLogLevel;
+  }
+
+  public String logNameForName(String name) {
+    if (showShortLogName) {
+      return name.substring(name.lastIndexOf(".") + 1);
+    } else if (showLogName) {
+      return name;
+    } else {
+      return "";
+    }
+  }
+}

--- a/dd-java-agent/agent-logging/src/test/groovy/datadog/trace/logging/DDLoggerTest.groovy
+++ b/dd-java-agent/agent-logging/src/test/groovy/datadog/trace/logging/DDLoggerTest.groovy
@@ -1,0 +1,198 @@
+package datadog.trace.logging
+
+import datadog.slf4j.impl.StaticMarkerBinder
+import datadog.trace.logging.simplelogger.SLCompatFactory
+import datadog.trace.logging.simplelogger.SLCompatSettings
+import spock.lang.Specification
+
+class DDLoggerTest extends Specification {
+
+  private class NoStackException extends Exception {
+    NoStackException(String message) {
+      super(message, null, false, false)
+    }
+  }
+
+  def marker = StaticMarkerBinder.getSingleton().markerFactory.getMarker("marker")
+
+  def "test enabled"() {
+    when:
+    Properties props = new Properties()
+    props.setProperty(SLCompatSettings.Keys.DEFAULT_LOG_LEVEL, level)
+    def factory = new SLCompatFactory(props)
+    def logger = new DDLogger(factory, "foo.bar")
+
+    then:
+    logger.isTraceEnabled() == trace
+    logger.isTraceEnabled(marker) == trace
+
+    logger.isDebugEnabled() == debug
+    logger.isDebugEnabled(marker) == debug
+
+    logger.isInfoEnabled() == info
+    logger.isInfoEnabled(marker) == info
+
+    logger.isWarnEnabled() == warn
+    logger.isWarnEnabled(marker) == warn
+
+    logger.isErrorEnabled() == error
+    logger.isErrorEnabled(marker) == error
+
+    where:
+    level   | trace | debug | info  | warn  | error | off
+    "trace" | true  | true  | true  | true  | true  | true
+    "debug" | false | true  | true  | true  | true  | true
+    "info"  | false | false | true  | true  | true  | true
+    "warn"  | false | false | false | true  | true  | true
+    "error" | false | false | false | false | true  | true
+    "off"   | false | false | false | false | false | true
+  }
+
+  String validateLogLine(OutputStream outputStream, String previous, boolean enabled, String level, String msg, String emsg) {
+    def total = outputStream.toString()
+    def current = total.substring(previous.length())
+    def expected = ""
+    if (enabled) {
+      expected = "$level foo.bar - $msg\n"
+      expected = emsg == null ? expected : "$expected${NoStackException.getName()}: $emsg\n"
+    }
+    assert current == expected
+    return total
+  }
+
+  def "test logging"() {
+    when:
+    Properties props = new Properties()
+    props.setProperty(SLCompatSettings.Keys.DEFAULT_LOG_LEVEL, level)
+    props.setProperty(SLCompatSettings.Keys.SHOW_THREAD_NAME, "false")
+    def os = new ByteArrayOutputStream()
+    def printStream = new PrintStream(os, true)
+    def settings = new SLCompatSettings(props, null, printStream)
+    def factory = new SLCompatFactory(props, settings)
+    def logger = new DDLogger(factory, "foo.bar")
+
+    then:
+    {
+      def logged = ""
+      // TRACE
+      logger.trace("m1")
+      logged = validateLogLine(os, logged, trace, "TRACE", "m1", null)
+      logger.trace("m1 {}", "a")
+      logged = validateLogLine(os, logged, trace, "TRACE", "m1 a", null)
+      logger.trace("m1 {} {}", "b1", "b2")
+      logged = validateLogLine(os, logged, trace, "TRACE", "m1 b1 b2", null)
+      logger.trace("m1 {} {} {} {}", "c1", "c2", "c3", "c4")
+      logged = validateLogLine(os, logged, trace, "TRACE", "m1 c1 c2 c3 c4", null)
+      logger.trace("m1", new NoStackException("d"))
+      logged = validateLogLine(os, logged, trace, "TRACE", "m1", "d")
+      logger.trace(marker, "m2")
+      logged = validateLogLine(os, logged, trace, "TRACE", "m2", null)
+      logger.trace(marker, "m2 {}", "e")
+      logged = validateLogLine(os, logged, trace, "TRACE", "m2 e", null)
+      logger.trace(marker, "m2 {} {}", "f2", "f1")
+      logged = validateLogLine(os, logged, trace, "TRACE", "m2 f2 f1", null)
+      logger.trace(marker, "m2 {} {} {} {}", "g4", "g3", "g2", "g1")
+      logged = validateLogLine(os, logged, trace, "TRACE", "m2 g4 g3 g2 g1", null)
+      logger.trace("m2", new NoStackException("h"))
+      logged = validateLogLine(os, logged, trace, "TRACE", "m2", "h")
+
+      // DEBUG
+      logger.debug("m1")
+      logged = validateLogLine(os, logged, debug, "DEBUG", "m1", null)
+      logger.debug("m1 {}", "a")
+      logged = validateLogLine(os, logged, debug, "DEBUG", "m1 a", null)
+      logger.debug("m1 {} {}", "b1", "b2")
+      logged = validateLogLine(os, logged, debug, "DEBUG", "m1 b1 b2", null)
+      logger.debug("m1 {} {} {} {}", "c1", "c2", "c3", "c4")
+      logged = validateLogLine(os, logged, debug, "DEBUG", "m1 c1 c2 c3 c4", null)
+      logger.debug("m1", new NoStackException("d"))
+      logged = validateLogLine(os, logged, debug, "DEBUG", "m1", "d")
+      logger.debug(marker, "m2")
+      logged = validateLogLine(os, logged, debug, "DEBUG", "m2", null)
+      logger.debug(marker, "m2 {}", "e")
+      logged = validateLogLine(os, logged, debug, "DEBUG", "m2 e", null)
+      logger.debug(marker, "m2 {} {}", "f2", "f1")
+      logged = validateLogLine(os, logged, debug, "DEBUG", "m2 f2 f1", null)
+      logger.debug(marker, "m2 {} {} {} {}", "g4", "g3", "g2", "g1")
+      logged = validateLogLine(os, logged, debug, "DEBUG", "m2 g4 g3 g2 g1", null)
+      logger.debug("m2", new NoStackException("h"))
+      logged = validateLogLine(os, logged, debug, "DEBUG", "m2", "h")
+
+      // INFO
+      logger.info("m1")
+      logged = validateLogLine(os, logged, info, "INFO", "m1", null)
+      logger.info("m1 {}", "a")
+      logged = validateLogLine(os, logged, info, "INFO", "m1 a", null)
+      logger.info("m1 {} {}", "b1", "b2")
+      logged = validateLogLine(os, logged, info, "INFO", "m1 b1 b2", null)
+      logger.info("m1 {} {} {} {}", "c1", "c2", "c3", "c4")
+      logged = validateLogLine(os, logged, info, "INFO", "m1 c1 c2 c3 c4", null)
+      logger.info("m1", new NoStackException("d"))
+      logged = validateLogLine(os, logged, info, "INFO", "m1", "d")
+      logger.info(marker, "m2")
+      logged = validateLogLine(os, logged, info, "INFO", "m2", null)
+      logger.info(marker, "m2 {}", "e")
+      logged = validateLogLine(os, logged, info, "INFO", "m2 e", null)
+      logger.info(marker, "m2 {} {}", "f2", "f1")
+      logged = validateLogLine(os, logged, info, "INFO", "m2 f2 f1", null)
+      logger.info(marker, "m2 {} {} {} {}", "g4", "g3", "g2", "g1")
+      logged = validateLogLine(os, logged, info, "INFO", "m2 g4 g3 g2 g1", null)
+      logger.info("m2", new NoStackException("h"))
+      logged = validateLogLine(os, logged, info, "INFO", "m2", "h")
+
+      // WARN
+      logger.warn("m1")
+      logged = validateLogLine(os, logged, warn, "WARN", "m1", null)
+      logger.warn("m1 {}", "a")
+      logged = validateLogLine(os, logged, warn, "WARN", "m1 a", null)
+      logger.warn("m1 {} {}", "b1", "b2")
+      logged = validateLogLine(os, logged, warn, "WARN", "m1 b1 b2", null)
+      logger.warn("m1 {} {} {} {}", "c1", "c2", "c3", "c4")
+      logged = validateLogLine(os, logged, warn, "WARN", "m1 c1 c2 c3 c4", null)
+      logger.warn("m1", new NoStackException("d"))
+      logged = validateLogLine(os, logged, warn, "WARN", "m1", "d")
+      logger.warn(marker, "m2")
+      logged = validateLogLine(os, logged, warn, "WARN", "m2", null)
+      logger.warn(marker, "m2 {}", "e")
+      logged = validateLogLine(os, logged, warn, "WARN", "m2 e", null)
+      logger.warn(marker, "m2 {} {}", "f2", "f1")
+      logged = validateLogLine(os, logged, warn, "WARN", "m2 f2 f1", null)
+      logger.warn(marker, "m2 {} {} {} {}", "g4", "g3", "g2", "g1")
+      logged = validateLogLine(os, logged, warn, "WARN", "m2 g4 g3 g2 g1", null)
+      logger.warn("m2", new NoStackException("h"))
+      logged = validateLogLine(os, logged, warn, "WARN", "m2", "h")
+
+      // ERROR
+      logger.error("m1")
+      logged = validateLogLine(os, logged, error, "ERROR", "m1", null)
+      logger.error("m1 {}", "a")
+      logged = validateLogLine(os, logged, error, "ERROR", "m1 a", null)
+      logger.error("m1 {} {}", "b1", "b2")
+      logged = validateLogLine(os, logged, error, "ERROR", "m1 b1 b2", null)
+      logger.error("m1 {} {} {} {}", "c1", "c2", "c3", "c4")
+      logged = validateLogLine(os, logged, error, "ERROR", "m1 c1 c2 c3 c4", null)
+      logger.error("m1", new NoStackException("d"))
+      logged = validateLogLine(os, logged, error, "ERROR", "m1", "d")
+      logger.error(marker, "m2")
+      logged = validateLogLine(os, logged, error, "ERROR", "m2", null)
+      logger.error(marker, "m2 {}", "e")
+      logged = validateLogLine(os, logged, error, "ERROR", "m2 e", null)
+      logger.error(marker, "m2 {} {}", "f2", "f1")
+      logged = validateLogLine(os, logged, error, "ERROR", "m2 f2 f1", null)
+      logger.error(marker, "m2 {} {} {} {}", "g4", "g3", "g2", "g1")
+      logged = validateLogLine(os, logged, error, "ERROR", "m2 g4 g3 g2 g1", null)
+      logger.error("m2", new NoStackException("h"))
+      logged = validateLogLine(os, logged, error, "ERROR", "m2", "h")
+    }
+
+    where:
+    level   | trace | debug | info  | warn  | error | off
+    "trace" | true  | true  | true  | true  | true  | true
+    "debug" | false | true  | true  | true  | true  | true
+    "info"  | false | false | true  | true  | true  | true
+    "warn"  | false | false | false | true  | true  | true
+    "error" | false | false | false | false | true  | true
+    "off"   | false | false | false | false | false | true
+  }
+
+}

--- a/dd-java-agent/agent-logging/src/test/groovy/datadog/trace/logging/LogLevelTest.groovy
+++ b/dd-java-agent/agent-logging/src/test/groovy/datadog/trace/logging/LogLevelTest.groovy
@@ -1,0 +1,45 @@
+package datadog.trace.bootstrap
+
+import datadog.trace.logging.LogLevel
+import spock.lang.Specification
+
+class LogLevelTest extends Specification {
+
+  def "test fromString"() {
+    when:
+    LogLevel fromString = LogLevel.fromString(str)
+
+    then:
+    fromString == level
+
+    where:
+    str     | level
+    "trace" | LogLevel.TRACE
+    "debug" | LogLevel.DEBUG
+    "info"  | LogLevel.INFO
+    "warn"  | LogLevel.WARN
+    "error" | LogLevel.ERROR
+    "off"   | LogLevel.OFF
+    "foo"   | LogLevel.INFO
+  }
+
+  def "test isEnabled"() {
+    expect:
+    LogLevel.TRACE.isEnabled(level) == trace
+    LogLevel.DEBUG.isEnabled(level) == debug
+    LogLevel.INFO.isEnabled(level) == info
+    LogLevel.WARN.isEnabled(level) == warn
+    LogLevel.ERROR.isEnabled(level) == error
+    LogLevel.OFF.isEnabled(level) == off
+
+    where:
+    level          | trace | debug | info  | warn  | error | off
+    LogLevel.TRACE | true  | true  | true  | true  | true  | true
+    LogLevel.DEBUG | false | true  | true  | true  | true  | true
+    LogLevel.INFO  | false | false | true  | true  | true  | true
+    LogLevel.WARN  | false | false | false | true  | true  | true
+    LogLevel.ERROR | false | false | false | false | true  | true
+    LogLevel.OFF   | false | false | false | false | false | true
+  }
+
+}

--- a/dd-java-agent/agent-logging/src/test/groovy/datadog/trace/logging/simplelogger/SLCompatHelperTest.groovy
+++ b/dd-java-agent/agent-logging/src/test/groovy/datadog/trace/logging/simplelogger/SLCompatHelperTest.groovy
@@ -117,10 +117,7 @@ class SLCompatHelperTest extends Specification {
     def outputStream = new ByteArrayOutputStream()
     def printStream = new PrintStream(outputStream, true)
     def props = new Properties()
-    def dateTimeFormatter = dateTFS == null ? null : new SimpleDateFormat(dateTFS)
-    if (dateTimeFormatter != null) {
-      dateTimeFormatter.setTimeZone(TimeZone.getTimeZone("UTC"))
-    }
+    def dateTimeFormatter = SLCompatSettings.DTFormatter.create(dateTFS)
     def settings = new SLCompatSettings(props, props, warnS, showB, printStream, showS, showL, showT, dateTimeFormatter, showDT, LogLevel.INFO)
     def helper = new SLCompatHelper("foo.bar", settings)
     helper.log(level, 0, 4711, "thread", "log", null)
@@ -140,6 +137,6 @@ class SLCompatHelperTest extends Specification {
     LogLevel.INFO | null     | false | false | false | true  | null                    | false  | "[thread] INFO log\n"
     LogLevel.INFO | null     | false | false | false | true  | null                    | true   | "4711 [thread] INFO log\n"
     LogLevel.INFO | null     | false | false | false | true  | "yyyy-MM-dd HH:mm:ss z" | false  | "[thread] INFO log\n"
-    LogLevel.INFO | null     | false | false | false | true  | "yyyy-MM-dd HH:mm:ss z" | true   | "1970-01-01 00:00:04 UTC [thread] INFO log\n"
+    LogLevel.INFO | null     | false | false | false | true  | "yyyy-MM-dd HH:mm:ss z" | true   | "${new SimpleDateFormat("yyyy-MM-dd HH:mm:ss z").format(new Date(4711))} [thread] INFO log\n"
   }
 }

--- a/dd-java-agent/agent-logging/src/test/groovy/datadog/trace/logging/simplelogger/SLCompatHelperTest.groovy
+++ b/dd-java-agent/agent-logging/src/test/groovy/datadog/trace/logging/simplelogger/SLCompatHelperTest.groovy
@@ -1,0 +1,145 @@
+package datadog.trace.logging.simplelogger
+
+import datadog.trace.logging.LogLevel
+import spock.lang.Shared
+import spock.lang.Specification
+
+import java.text.SimpleDateFormat
+
+class SLCompatHelperTest extends Specification {
+
+  private class NoStackException extends Exception {
+    NoStackException(String message) {
+      super(message, null, false, false)
+    }
+  }
+
+  def "test levelEnabled"() {
+    when:
+    Properties props = new Properties()
+    props.setProperty(SLCompatSettings.Keys.DEFAULT_LOG_LEVEL, level)
+    def helper = new SLCompatHelper("foo", new SLCompatSettings(props))
+
+    then:
+    helper.enabled(LogLevel.TRACE, null) == trace
+    helper.enabled(LogLevel.DEBUG, null) == debug
+    helper.enabled(LogLevel.INFO, null) == info
+    helper.enabled(LogLevel.WARN, null) == warn
+    helper.enabled(LogLevel.ERROR, null) == error
+    helper.enabled(LogLevel.OFF, null) == off
+
+    where:
+    level   | trace | debug | info  | warn  | error | off
+    "trace" | true  | true  | true  | true  | true  | true
+    "debug" | false | true  | true  | true  | true  | true
+    "info"  | false | false | true  | true  | true  | true
+    "warn"  | false | false | false | true  | true  | true
+    "error" | false | false | false | false | true  | true
+    "off"   | false | false | false | false | false | true
+  }
+
+  def "test levelEnabled logLevelForName"() {
+    when:
+    Properties props = new Properties()
+    ["foo.bar": "debug", "foo.bar.baz": "warn"].each {
+      props.setProperty(SLCompatSettings.Keys.LOG_KEY_PREFIX + it.key, it.value)
+    }
+    def helper = new SLCompatHelper(name, new SLCompatSettings(props))
+
+    then:
+    helper.enabled(LogLevel.TRACE, null) == trace
+    helper.enabled(LogLevel.DEBUG, null) == debug
+    helper.enabled(LogLevel.INFO, null) == info
+    helper.enabled(LogLevel.WARN, null) == warn
+    helper.enabled(LogLevel.ERROR, null) == error
+    helper.enabled(LogLevel.OFF, null) == off
+
+    where:
+    name          | trace | debug | info  | warn | error | off
+    "foo"         | false | false | true  | true | true  | true
+    "foo.bar"     | false | true  | true  | true | true  | true
+    "foo.bar.baz" | false | false | false | true | true  | true
+  }
+
+  @Shared
+  def thread = Thread.currentThread().getName()
+
+  def "test default logging format"() {
+    when:
+    def outputStream = new ByteArrayOutputStream()
+    def printStream = new PrintStream(outputStream, true)
+    def settings = new SLCompatSettings(new Properties(), new Properties(), printStream)
+    def helper = new SLCompatHelper(name, settings)
+    helper.log(level, msg, null)
+
+    then:
+    outputStream.toString() == expected
+
+    where:
+    name  | level          | msg     | expected
+    "foo" | LogLevel.TRACE | "who"   | "[$thread] TRACE foo - who\n"
+    "bar" | LogLevel.DEBUG | "when"  | "[$thread] DEBUG bar - when\n"
+    "baz" | LogLevel.INFO  | "why"   | "[$thread] INFO baz - why\n"
+    "biz" | LogLevel.WARN  | "what"  | "[$thread] WARN biz - what\n"
+    "buz" | LogLevel.ERROR | "srsly" | "[$thread] ERROR buz - srsly\n"
+  }
+
+  def "test default logging format with exception"() {
+    setup:
+    def outputStream = new ByteArrayOutputStream()
+    def printStream = new PrintStream(outputStream, true)
+    def settings = new SLCompatSettings(new Properties(), new Properties(), printStream)
+    def helper = new SLCompatHelper("foo", settings)
+    def exception = new NoStackException("wrong")
+    helper.log(LogLevel.ERROR, "log", exception)
+
+    expect:
+    outputStream.toString() == "[$thread] ERROR foo - log\n${NoStackException.getName()}: wrong\n"
+  }
+
+  def "test logging without thread name and with time"() {
+    setup:
+    def outputStream = new ByteArrayOutputStream()
+    def printStream = new PrintStream(outputStream, true)
+    def props = new Properties()
+    props.setProperty(SLCompatSettings.Keys.SHOW_THREAD_NAME, "false")
+    props.setProperty(SLCompatSettings.Keys.SHOW_DATE_TIME, "true")
+    def settings = new SLCompatSettings(props, new Properties(), printStream)
+    def helper = new SLCompatHelper("foo", settings)
+    helper.log(LogLevel.ERROR, "log", null)
+
+    expect:
+    outputStream.toString() ==~ /^\d+ ERROR foo - log\n$/
+  }
+
+  def "test log output with configuration"() {
+    when:
+    def outputStream = new ByteArrayOutputStream()
+    def printStream = new PrintStream(outputStream, true)
+    def props = new Properties()
+    def dateTimeFormatter = dateTFS == null ? null : new SimpleDateFormat(dateTFS)
+    if (dateTimeFormatter != null) {
+      dateTimeFormatter.setTimeZone(TimeZone.getTimeZone("UTC"))
+    }
+    def settings = new SLCompatSettings(props, props, warnS, showB, printStream, showS, showL, showT, dateTimeFormatter, showDT, LogLevel.INFO)
+    def helper = new SLCompatHelper("foo.bar", settings)
+    helper.log(level, 0, 4711, "thread", "log", null)
+
+    then:
+    outputStream.toString() == expected
+
+    where:
+    level         | warnS    | showB | showS | showL | showT | dateTFS                 | showDT | expected
+    LogLevel.WARN | null     | false | false | false | false | null                    | false  | "WARN log\n"
+    LogLevel.WARN | "DANGER" | false | false | false | false | null                    | false  | "DANGER log\n"
+    LogLevel.INFO | "DANGER" | false | false | false | false | null                    | false  | "INFO log\n"
+    LogLevel.WARN | null     | true  | false | false | false | null                    | false  | "[WARN] log\n"
+    LogLevel.INFO | null     | false | true  | false | false | null                    | false  | "INFO bar - log\n"
+    LogLevel.INFO | null     | true  | true  | true  | false | null                    | false  | "[INFO] bar - log\n"
+    LogLevel.INFO | null     | true  | false | true  | false | null                    | false  | "[INFO] foo.bar - log\n"
+    LogLevel.INFO | null     | false | false | false | true  | null                    | false  | "[thread] INFO log\n"
+    LogLevel.INFO | null     | false | false | false | true  | null                    | true   | "4711 [thread] INFO log\n"
+    LogLevel.INFO | null     | false | false | false | true  | "yyyy-MM-dd HH:mm:ss z" | false  | "[thread] INFO log\n"
+    LogLevel.INFO | null     | false | false | false | true  | "yyyy-MM-dd HH:mm:ss z" | true   | "1970-01-01 00:00:04 UTC [thread] INFO log\n"
+  }
+}

--- a/dd-java-agent/agent-logging/src/test/resources/slcompatsettingstest.properties
+++ b/dd-java-agent/agent-logging/src/test/resources/slcompatsettingstest.properties
@@ -1,0 +1,9 @@
+datadog.slf4j.simpleLogger.warnLevelString = WRN
+datadog.slf4j.simpleLogger.levelInBrackets = true
+datadog.slf4j.simpleLogger.logFile = System.out
+datadog.slf4j.simpleLogger.showShortLogName = true
+datadog.slf4j.simpleLogger.showLogName = false
+datadog.slf4j.simpleLogger.showThreadName = false
+datadog.slf4j.simpleLogger.dateTimeFormat = '['yyyy-MM-dd HH:mm:ss:SSS Z']'
+datadog.slf4j.simpleLogger.showDateTime = true
+datadog.slf4j.simpleLogger.defaultLogLevel = DEBUG

--- a/dd-java-agent/agent-logging/src/test/resources/slcompatsettingstest.properties
+++ b/dd-java-agent/agent-logging/src/test/resources/slcompatsettingstest.properties
@@ -4,6 +4,6 @@ datadog.slf4j.simpleLogger.logFile = System.out
 datadog.slf4j.simpleLogger.showShortLogName = true
 datadog.slf4j.simpleLogger.showLogName = false
 datadog.slf4j.simpleLogger.showThreadName = false
-datadog.slf4j.simpleLogger.dateTimeFormat = '['yyyy-MM-dd HH:mm:ss:SSS Z']'
+datadog.slf4j.simpleLogger.dateTimeFormat = '['yy-dd-MM HH:mm:ss:SSS Z']'
 datadog.slf4j.simpleLogger.showDateTime = true
 datadog.slf4j.simpleLogger.defaultLogLevel = DEBUG

--- a/dd-java-agent/agent-profiling/agent-profiling.gradle
+++ b/dd-java-agent/agent-profiling/agent-profiling.gradle
@@ -34,6 +34,7 @@ shadowJar {
   dependencies deps.sharedInverse
   dependencies {
     exclude(project(':dd-java-agent:agent-bootstrap'))
+    exclude(project(':dd-java-agent:agent-logging'))
     exclude(project(':dd-trace-api'))
     exclude(project(':internal-api'))
     exclude(dependency('org.slf4j::'))

--- a/dd-java-agent/agent-tooling/agent-tooling.gradle
+++ b/dd-java-agent/agent-tooling/agent-tooling.gradle
@@ -10,8 +10,7 @@ configurations {
 
 dependencies {
   compile(project(':dd-java-agent:agent-bootstrap')) {
-    // This only needs to exist in the bootstrap, not the instrumentation jar.
-    exclude group: 'org.slf4j', module: 'slf4j-simple'
+    exclude group: 'com.datadoghq', module: 'agent-logging'
   }
   compile group: 'com.blogspot.mydailyjava', name: 'weak-lock-free', version: '0.15'
   compile deps.bytebuddy

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Constants.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Constants.java
@@ -20,6 +20,7 @@ public final class Constants {
     "datadog.trace.bootstrap",
     "datadog.trace.context",
     "datadog.trace.instrumentation.api",
+    "datadog.trace.logging",
   };
 
   // This is used in IntegrationTestUtils.java

--- a/dd-java-agent/dd-java-agent.gradle
+++ b/dd-java-agent/dd-java-agent.gradle
@@ -112,7 +112,9 @@ modifyPom {
 }
 
 dependencies {
-  testCompile project(':dd-java-agent:agent-bootstrap')
+  testCompile(project(':dd-java-agent:agent-bootstrap')) {
+    exclude group: 'com.datadoghq', module: 'agent-logging'
+  }
   testCompile project(':dd-trace-api')
   testCompile project(':dd-trace-core')
   testCompile project(':utils:test-utils')

--- a/dd-java-agent/instrumentation/instrumentation.gradle
+++ b/dd-java-agent/instrumentation/instrumentation.gradle
@@ -87,6 +87,7 @@ shadowJar {
   dependencies deps.sharedInverse
   dependencies {
     exclude(project(':dd-java-agent:agent-bootstrap'))
+    exclude(project(':dd-java-agent:agent-logging'))
     exclude(project(':dd-trace-api'))
     exclude(project(':internal-api'))
     exclude(dependency('org.slf4j::'))

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/SpockRunner.java
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/SpockRunner.java
@@ -38,6 +38,7 @@ public class SpockRunner extends Sputnik {
     "datadog.trace.bootstrap",
     "datadog.trace.context",
     "datadog.trace.instrumentation.api",
+    "datadog.trace.logging",
   };
 
   private static final String[] TEST_BOOTSTRAP_PREFIXES;

--- a/dd-smoke-tests/opentracing/opentracing.gradle
+++ b/dd-smoke-tests/opentracing/opentracing.gradle
@@ -6,7 +6,7 @@ apply from: "$rootDir/gradle/java.gradle"
 dependencies {
   compile project(':dd-trace-api')
   compile project(':dd-trace-ot')
-  compile group: 'org.slf4j', name: 'slf4j-simple', version: versions.slf4j
+  compile deps.slf4j
 
   testCompile project(':dd-smoke-tests')
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -30,6 +30,7 @@ include ':dd-java-agent'
 include ':dd-java-agent:agent-bootstrap'
 include ':dd-java-agent:agent-tooling'
 include ':dd-java-agent:agent-jmxfetch'
+include ':dd-java-agent:agent-logging'
 include ':dd-java-agent:load-generator'
 
 include ':dd-java-agent:agent-profiling'


### PR DESCRIPTION
This is the first step towards better logging.

It adds our own Logger implementation, using the shaded SLf4J API. This first logger is a drop in replacement for the SimpleLogger in both configuration and behavior so there should be no noticeable difference for the end user.

Going forward we can start to support markers, and runtime switchable log levels.