### PR TITLE
replace guava Joiner with Strings.join

### DIFF
--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/main/java/datadog/trace/instrumentation/elasticsearch2/Elasticsearch2TransportClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/main/java/datadog/trace/instrumentation/elasticsearch2/Elasticsearch2TransportClientInstrumentation.java
@@ -39,11 +39,6 @@ public class Elasticsearch2TransportClientInstrumentation extends Instrumenter.D
   @Override
   public String[] helperClassNames() {
     return new String[] {
-      "com.google.common.base.Preconditions",
-      "com.google.common.base.Joiner",
-      "com.google.common.base.Joiner$1",
-      "com.google.common.base.Joiner$2",
-      "com.google.common.base.Joiner$MapJoiner",
       "datadog.trace.instrumentation.elasticsearch.ElasticsearchTransportClientDecorator",
       packageName + ".TransportActionListener",
     };

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/main/java/datadog/trace/instrumentation/elasticsearch2/TransportActionListener.java
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/main/java/datadog/trace/instrumentation/elasticsearch2/TransportActionListener.java
@@ -2,7 +2,7 @@ package datadog.trace.instrumentation.elasticsearch2;
 
 import static datadog.trace.instrumentation.elasticsearch.ElasticsearchTransportClientDecorator.DECORATE;
 
-import com.google.common.base.Joiner;
+import datadog.trace.api.utils.Strings;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import org.elasticsearch.action.ActionListener;
@@ -32,12 +32,12 @@ public class TransportActionListener<T extends ActionResponse> implements Action
     if (request instanceof IndicesRequest) {
       final IndicesRequest req = (IndicesRequest) request;
       if (req.indices() != null) {
-        span.setTag("elasticsearch.request.indices", Joiner.on(",").join(req.indices()));
+        span.setTag("elasticsearch.request.indices", Strings.join(",", req.indices()));
       }
     }
     if (request instanceof SearchRequest) {
       final SearchRequest req = (SearchRequest) request;
-      span.setTag("elasticsearch.request.search.types", Joiner.on(",").join(req.types()));
+      span.setTag("elasticsearch.request.search.types", Strings.join(",", req.types()));
     }
     if (request instanceof DocumentRequest) {
       final DocumentRequest req = (DocumentRequest) request;

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/main/java/datadog/trace/instrumentation/elasticsearch5_3/Elasticsearch53TransportClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/main/java/datadog/trace/instrumentation/elasticsearch5_3/Elasticsearch53TransportClientInstrumentation.java
@@ -40,11 +40,6 @@ public class Elasticsearch53TransportClientInstrumentation extends Instrumenter.
   @Override
   public String[] helperClassNames() {
     return new String[] {
-      "com.google.common.base.Preconditions",
-      "com.google.common.base.Joiner",
-      "com.google.common.base.Joiner$1",
-      "com.google.common.base.Joiner$2",
-      "com.google.common.base.Joiner$MapJoiner",
       "datadog.trace.instrumentation.elasticsearch.ElasticsearchTransportClientDecorator",
       packageName + ".TransportActionListener",
     };

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/main/java/datadog/trace/instrumentation/elasticsearch5_3/TransportActionListener.java
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/main/java/datadog/trace/instrumentation/elasticsearch5_3/TransportActionListener.java
@@ -2,7 +2,7 @@ package datadog.trace.instrumentation.elasticsearch5_3;
 
 import static datadog.trace.instrumentation.elasticsearch.ElasticsearchTransportClientDecorator.DECORATE;
 
-import com.google.common.base.Joiner;
+import datadog.trace.api.utils.Strings;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import org.elasticsearch.action.ActionListener;
@@ -34,12 +34,12 @@ public class TransportActionListener<T extends ActionResponse> implements Action
     if (request instanceof IndicesRequest) {
       final IndicesRequest req = (IndicesRequest) request;
       if (req.indices() != null) {
-        span.setTag("elasticsearch.request.indices", Joiner.on(",").join(req.indices()));
+        span.setTag("elasticsearch.request.indices", Strings.join(",", req.indices()));
       }
     }
     if (request instanceof SearchRequest) {
       final SearchRequest req = (SearchRequest) request;
-      span.setTag("elasticsearch.request.search.types", Joiner.on(",").join(req.types()));
+      span.setTag("elasticsearch.request.search.types", Strings.join(",", req.types()));
     }
     if (request instanceof DocWriteRequest) {
       final DocWriteRequest req = (DocWriteRequest) request;

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5/src/main/java/datadog/trace/instrumentation/elasticsearch5/Elasticsearch5TransportClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5/src/main/java/datadog/trace/instrumentation/elasticsearch5/Elasticsearch5TransportClientInstrumentation.java
@@ -39,11 +39,6 @@ public class Elasticsearch5TransportClientInstrumentation extends Instrumenter.D
   @Override
   public String[] helperClassNames() {
     return new String[] {
-      "com.google.common.base.Preconditions",
-      "com.google.common.base.Joiner",
-      "com.google.common.base.Joiner$1",
-      "com.google.common.base.Joiner$2",
-      "com.google.common.base.Joiner$MapJoiner",
       "datadog.trace.instrumentation.elasticsearch.ElasticsearchTransportClientDecorator",
       packageName + ".TransportActionListener",
     };

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5/src/main/java/datadog/trace/instrumentation/elasticsearch5/TransportActionListener.java
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5/src/main/java/datadog/trace/instrumentation/elasticsearch5/TransportActionListener.java
@@ -2,7 +2,7 @@ package datadog.trace.instrumentation.elasticsearch5;
 
 import static datadog.trace.instrumentation.elasticsearch.ElasticsearchTransportClientDecorator.DECORATE;
 
-import com.google.common.base.Joiner;
+import datadog.trace.api.utils.Strings;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import org.elasticsearch.action.ActionListener;
@@ -34,12 +34,12 @@ public class TransportActionListener<T extends ActionResponse> implements Action
     if (request instanceof IndicesRequest) {
       final IndicesRequest req = (IndicesRequest) request;
       if (req.indices() != null) {
-        span.setTag("elasticsearch.request.indices", Joiner.on(",").join(req.indices()));
+        span.setTag("elasticsearch.request.indices", Strings.join(",", req.indices()));
       }
     }
     if (request instanceof SearchRequest) {
       final SearchRequest req = (SearchRequest) request;
-      span.setTag("elasticsearch.request.search.types", Joiner.on(",").join(req.types()));
+      span.setTag("elasticsearch.request.search.types", Strings.join(",", req.types()));
     }
     if (request instanceof DocumentRequest) {
       final DocumentRequest req = (DocumentRequest) request;

--- a/dd-java-agent/instrumentation/elasticsearch/transport-6/src/main/java/datadog/trace/instrumentation/elasticsearch6/Elasticsearch6TransportClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-6/src/main/java/datadog/trace/instrumentation/elasticsearch6/Elasticsearch6TransportClientInstrumentation.java
@@ -43,11 +43,6 @@ public class Elasticsearch6TransportClientInstrumentation extends Instrumenter.D
   @Override
   public String[] helperClassNames() {
     return new String[] {
-      "com.google.common.base.Preconditions",
-      "com.google.common.base.Joiner",
-      "com.google.common.base.Joiner$1",
-      "com.google.common.base.Joiner$2",
-      "com.google.common.base.Joiner$MapJoiner",
       "datadog.trace.instrumentation.elasticsearch.ElasticsearchTransportClientDecorator",
       packageName + ".TransportActionListener",
     };

--- a/dd-java-agent/instrumentation/elasticsearch/transport-6/src/main/java/datadog/trace/instrumentation/elasticsearch6/TransportActionListener.java
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-6/src/main/java/datadog/trace/instrumentation/elasticsearch6/TransportActionListener.java
@@ -2,7 +2,7 @@ package datadog.trace.instrumentation.elasticsearch6;
 
 import static datadog.trace.instrumentation.elasticsearch.ElasticsearchTransportClientDecorator.DECORATE;
 
-import com.google.common.base.Joiner;
+import datadog.trace.api.utils.Strings;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import org.elasticsearch.action.ActionListener;
@@ -38,12 +38,12 @@ public class TransportActionListener<T extends ActionResponse> implements Action
     if (request instanceof IndicesRequest) {
       final IndicesRequest req = (IndicesRequest) request;
       if (req.indices() != null) {
-        span.setTag("elasticsearch.request.indices", Joiner.on(",").join(req.indices()));
+        span.setTag("elasticsearch.request.indices", Strings.join(",", req.indices()));
       }
     }
     if (request instanceof SearchRequest) {
       final SearchRequest req = (SearchRequest) request;
-      span.setTag("elasticsearch.request.search.types", Joiner.on(",").join(req.types()));
+      span.setTag("elasticsearch.request.search.types", Strings.join(",", req.types()));
     }
     if (request instanceof DocWriteRequest) {
       final DocWriteRequest req = (DocWriteRequest) request;

--- a/internal-api/src/main/java/datadog/trace/api/utils/Strings.java
+++ b/internal-api/src/main/java/datadog/trace/api/utils/Strings.java
@@ -1,0 +1,28 @@
+package datadog.trace.api.utils;
+
+public final class Strings {
+
+  public static String join(CharSequence joiner, Iterable<? extends CharSequence> strings) {
+    StringBuilder sb = new StringBuilder();
+    for (CharSequence string : strings) {
+      sb.append(string).append(joiner);
+    }
+    // truncate to remove the last joiner
+    if (sb.length() > 0) {
+      sb.setLength(sb.length() - joiner.length());
+    }
+    return sb.toString();
+  }
+
+  public static String join(CharSequence joiner, CharSequence... strings) {
+    if (strings.length > 0) {
+      StringBuilder sb = new StringBuilder();
+      sb.append(strings[0]);
+      for (int i = 1; i < strings.length; ++i) {
+        sb.append(joiner).append(strings[i]);
+      }
+      return sb.toString();
+    }
+    return "";
+  }
+}

--- a/internal-api/src/test/groovy/datadog/trace/api/utils/StringsTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/utils/StringsTest.groovy
@@ -1,0 +1,33 @@
+package datadog.trace.api.utils
+
+import datadog.trace.util.test.DDSpecification
+
+class StringsTest extends DDSpecification {
+
+  def "test join strings"() {
+    when:
+    String s = Strings.join(joiner, strings)
+    then:
+    s == expected
+    where:
+    joiner     |     strings      | expected
+    ","        |  ["a", "b", "c"] | "a,b,c"
+    ","        |  ["a", "b"]      | "a,b"
+    ","        |  ["a"]           | "a"
+    ","        |  []              | ""
+  }
+
+  def "test join strings varargs"() {
+    when:
+    // apparently groovy doesn't like this but it runs as if it's java
+    String s = Strings.join(joiner, strings.toArray(new CharSequence[0]))
+    then:
+    s == expected
+    where:
+    joiner     |     strings      | expected
+    ","        |  ["a", "b", "c"] | "a,b,c"
+    ","        |  ["a", "b"]      | "a,b"
+    ","        |  ["a"]           | "a"
+    ","        |  []              | ""
+  }
+}


### PR DESCRIPTION
This aims to remove one of our dependencies on guava, so we can get closer to removing it since it's nearly 20% of our artefact size. I followed the contract of JDK8+ `String.join` so we can replace the new method with that once JDK7 is dropped.