### PR TITLE
CI-App: JUnit4 - Use a RunListener to send traces

### DIFF
--- a/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4Instrumentation.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4Instrumentation.java
@@ -1,28 +1,22 @@
 package datadog.trace.instrumentation.junit4;
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
-import static datadog.trace.instrumentation.junit4.JUnit4Decorator.DECORATE;
+import static datadog.trace.agent.tooling.ClassLoaderMatcher.hasClassesNamed;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers.extendsClass;
 import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
-import datadog.trace.bootstrap.instrumentation.api.AgentScope;
-import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
-import datadog.trace.context.TraceScope;
-import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
-import org.junit.Test;
 import org.junit.rules.RuleChain;
-import org.junit.runner.Description;
-import org.junit.runner.notification.Failure;
+import org.junit.runner.notification.RunListener;
+import org.junit.runner.notification.RunNotifier;
 
 @AutoService(Instrumenter.class)
 public class JUnit4Instrumentation extends Instrumenter.Default {
@@ -33,26 +27,28 @@ public class JUnit4Instrumentation extends Instrumenter.Default {
 
   @Override
   public ElementMatcher<? super TypeDescription> typeMatcher() {
-    return named("org.junit.runner.notification.RunNotifier");
+    return extendsClass(named("org.junit.runner.Runner"));
+  }
+
+  @Override
+  public ElementMatcher<ClassLoader> classLoaderMatcher() {
+    return hasClassesNamed("org.junit.runner.Runner");
   }
 
   @Override
   public String[] helperClassNames() {
-    return new String[] {packageName + ".JUnit4Decorator"};
+    return new String[] {
+      packageName + ".JUnit4Decorator",
+      packageName + ".TracingListener",
+      packageName + ".JUnit4Utils"
+    };
   }
 
   @Override
   public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
-    final Map<ElementMatcher<? super MethodDescription>, String> transformers = new HashMap<>();
-    transformers.put(
-        named("fireTestStarted"), JUnit4Instrumentation.class.getName() + "$TestStartedAdvice");
-    transformers.put(
-        named("fireTestFinished"), JUnit4Instrumentation.class.getName() + "$TestFinishedAdvice");
-    transformers.put(
-        named("fireTestFailure"), JUnit4Instrumentation.class.getName() + "$TestFailureAdvice");
-    transformers.put(
-        named("fireTestIgnored"), JUnit4Instrumentation.class.getName() + "$TestIgnoredAdvice");
-    return transformers;
+    return Collections.singletonMap(
+        named("run").and(takesArgument(0, named("org.junit.runner.notification.RunNotifier"))),
+        JUnit4Instrumentation.class.getName() + "$JUnit4Advice");
   }
 
   @Override
@@ -60,84 +56,25 @@ public class JUnit4Instrumentation extends Instrumenter.Default {
     return false;
   }
 
-  public static class TestStartedAdvice {
-    @Advice.OnMethodExit(suppress = Throwable.class)
-    public static void startTest(@Advice.Argument(0) final Description description) {
-      if (DECORATE.skipTrace(description)) {
+  public static class JUnit4Advice {
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static void addTracingListener(@Advice.Argument(0) final RunNotifier runNotifier) {
+      // No public accessor to get already installed listeners.
+      // The installed RunListeners list are obtained using reflection.
+      final List<RunListener> runListeners = JUnit4Utils.runListenersFromRunNotifier(runNotifier);
+      if (runListeners == null) {
         return;
       }
 
-      final AgentSpan span = startSpan("junit.test");
-      final AgentScope scope = activateSpan(span);
-      scope.setAsyncPropagation(true);
-
-      DECORATE.afterStart(span);
-      DECORATE.onTestStart(span, description);
-    }
-  }
-
-  public static class TestFinishedAdvice {
-    @Advice.OnMethodExit(suppress = Throwable.class)
-    public static void finishTest(@Advice.Argument(0) final Description description) {
-      if (DECORATE.skipTrace(description)) {
-        return;
+      // This prevents installing the TracingListener multiple times.
+      for (final RunListener listener : runListeners) {
+        if (listener instanceof TracingListener) {
+          return;
+        }
       }
 
-      final AgentSpan span = AgentTracer.activeSpan();
-      if (span == null) {
-        return;
-      }
-
-      final TraceScope scope = AgentTracer.activeScope();
-      if (scope != null) {
-        scope.close();
-      }
-
-      DECORATE.onTestFinish(span);
-      DECORATE.beforeFinish(span);
-      span.finish();
-    }
-  }
-
-  public static class TestFailureAdvice {
-    @Advice.OnMethodExit(suppress = Throwable.class)
-    public static void failureTest(@Advice.Argument(0) final Failure failure) {
-      if (DECORATE.skipTrace(failure.getDescription())) {
-        return;
-      }
-
-      final AgentSpan span = AgentTracer.activeSpan();
-      if (span == null) {
-        return;
-      }
-
-      DECORATE.onTestFailure(span, failure);
-    }
-  }
-
-  public static class TestIgnoredAdvice {
-    @Advice.OnMethodExit
-    public static void ignoreTest(@Advice.Argument(0) final Description description) {
-      if (DECORATE.skipTrace(description)) {
-        return;
-      }
-
-      final List<String> testNames = new ArrayList<>();
-      if (description.getMethodName() != null && !"".equals(description.getMethodName())) {
-        testNames.add(description.getMethodName());
-      } else {
-        // If @Ignore annotation is kept at class level, the instrumentation
-        // reports every method annotated with @Test as skipped test.
-        testNames.addAll(DECORATE.testNames(description.getTestClass(), Test.class));
-      }
-
-      for (final String testName : testNames) {
-        final AgentSpan span = startSpan("junit.test");
-        DECORATE.afterStart(span);
-        DECORATE.onTestIgnored(span, description, testName);
-        DECORATE.beforeFinish(span);
-        span.finish(span.getStartTime());
-      }
+      final TracingListener tracingListener = new TracingListener();
+      runNotifier.addListener(tracingListener);
     }
 
     // JUnit 4.10 and above

--- a/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4Utils.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4Utils.java
@@ -1,0 +1,31 @@
+package datadog.trace.instrumentation.junit4;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.runner.notification.RunListener;
+import org.junit.runner.notification.RunNotifier;
+
+@Slf4j
+public abstract class JUnit4Utils {
+
+  public static List<RunListener> runListenersFromRunNotifier(final RunNotifier runNotifier) {
+    try {
+
+      Field listeners;
+      try {
+        // Since JUnit 4.12, the field is called "listeners"
+        listeners = runNotifier.getClass().getDeclaredField("listeners");
+      } catch (final NoSuchFieldException e) {
+        // Before JUnit 4.12, the field is called "fListeners"
+        listeners = runNotifier.getClass().getDeclaredField("fListeners");
+      }
+
+      listeners.setAccessible(true);
+      return (List<RunListener>) listeners.get(runNotifier);
+    } catch (final Throwable e) {
+      log.debug("Could not get runListeners for JUnit4Advice", e);
+      return null;
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/TracingListener.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/TracingListener.java
@@ -1,0 +1,92 @@
+package datadog.trace.instrumentation.junit4;
+
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+import static datadog.trace.instrumentation.junit4.JUnit4Decorator.DECORATE;
+
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import datadog.trace.context.TraceScope;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.Description;
+import org.junit.runner.notification.Failure;
+import org.junit.runner.notification.RunListener;
+
+public class TracingListener extends RunListener {
+
+  @Override
+  public void testStarted(final Description description) throws Exception {
+    if (DECORATE.skipTrace(description)) {
+      return;
+    }
+
+    final AgentSpan span = startSpan("junit.test");
+    final AgentScope scope = activateSpan(span);
+    scope.setAsyncPropagation(true);
+
+    DECORATE.afterStart(span);
+    DECORATE.onTestStart(span, description);
+  }
+
+  @Override
+  public void testFinished(final Description description) throws Exception {
+    if (DECORATE.skipTrace(description)) {
+      return;
+    }
+
+    final AgentSpan span = AgentTracer.activeSpan();
+    if (span == null) {
+      return;
+    }
+
+    final TraceScope scope = AgentTracer.activeScope();
+    if (scope != null) {
+      scope.close();
+    }
+
+    DECORATE.onTestFinish(span);
+    DECORATE.beforeFinish(span);
+    span.finish();
+  }
+
+  @Override
+  public void testFailure(final Failure failure) throws Exception {
+    if (DECORATE.skipTrace(failure.getDescription())) {
+      return;
+    }
+
+    final AgentSpan span = AgentTracer.activeSpan();
+    if (span == null) {
+      return;
+    }
+
+    DECORATE.onTestFailure(span, failure);
+  }
+
+  @Override
+  public void testIgnored(final Description description) throws Exception {
+    if (DECORATE.skipTrace(description)) {
+      return;
+    }
+
+    final List<String> testNames = new ArrayList<>();
+    if (description.getMethodName() != null && !"".equals(description.getMethodName())) {
+      testNames.add(description.getMethodName());
+    } else {
+      // If @Ignore annotation is kept at class level, the instrumentation
+      // reports every method annotated with @Test as skipped test.
+      testNames.addAll(DECORATE.testNames(description.getTestClass(), Test.class));
+    }
+
+    for (final String testName : testNames) {
+      final AgentSpan span = startSpan("junit.test");
+      DECORATE.afterStart(span);
+      DECORATE.onTestIgnored(span, description, testName);
+      DECORATE.beforeFinish(span);
+      span.finish(span.getStartTime());
+    }
+  }
+}


### PR DESCRIPTION
In this PR, the JUnit4 tracing logic has been encapsulated in the `datadog.trace.instrumentation.junit4.TracingListener`, which is a JUnit4 [RunListener](https://junit.org/junit4/javadoc/4.12/org/junit/runner/notification/RunListener.html).

This `datadog.trace.instrumentation.junit4.TracingListener` is added as another listener when the `Runner.run(RunNotifier notifier)` method is invoked. This approach follows the standard way of listening to the test events based on its public API.