### PR TITLE
Use blocking queue implementation for prioritisation

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/DDAgentWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/DDAgentWriter.java
@@ -90,8 +90,7 @@ public class DDAgentWriter implements Writer {
             dispatcher,
             null == prioritization ? FAST_LANE : prioritization,
             flushFrequencySeconds,
-            TimeUnit.SECONDS,
-            flushFrequencySeconds > 0);
+            TimeUnit.SECONDS);
   }
 
   private DDAgentWriter(

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/Prioritization.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/Prioritization.java
@@ -5,36 +5,32 @@ import static datadog.trace.common.sampling.PrioritySampling.USER_DROP;
 
 import datadog.trace.core.DDSpan;
 import java.util.List;
+import java.util.Queue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import org.jctools.queues.MessagePassingQueue;
 
 public enum Prioritization {
   FAST_LANE {
     @Override
-    public PrioritizationStrategy create(
-        MessagePassingQueue<Object> primary, MessagePassingQueue<Object> secondary) {
+    public PrioritizationStrategy create(Queue<Object> primary, Queue<Object> secondary) {
       return new FastLaneStrategy(primary, secondary);
     }
   },
   DEAD_LETTERS {
     @Override
-    public PrioritizationStrategy create(
-        MessagePassingQueue<Object> primary, MessagePassingQueue<Object> secondary) {
+    public PrioritizationStrategy create(Queue<Object> primary, Queue<Object> secondary) {
       return new DeadLettersStrategy(primary, secondary);
     }
   };
 
-  public abstract PrioritizationStrategy create(
-      MessagePassingQueue<Object> primary, MessagePassingQueue<Object> secondary);
+  public abstract PrioritizationStrategy create(Queue<Object> primary, Queue<Object> secondary);
 
   private static final class FastLaneStrategy implements PrioritizationStrategy {
 
-    private final MessagePassingQueue<Object> primary;
-    private final MessagePassingQueue<Object> secondary;
+    private final Queue<Object> primary;
+    private final Queue<Object> secondary;
 
-    private FastLaneStrategy(
-        MessagePassingQueue<Object> primary, MessagePassingQueue<Object> secondary) {
+    private FastLaneStrategy(Queue<Object> primary, Queue<Object> secondary) {
       this.primary = primary;
       this.secondary = secondary;
     }
@@ -64,7 +60,7 @@ public enum Prioritization {
       }
     }
 
-    private void offer(MessagePassingQueue<Object> queue, FlushEvent event) {
+    private void offer(Queue<Object> queue, FlushEvent event) {
       boolean offered;
       do {
         offered = queue.offer(event);
@@ -74,11 +70,10 @@ public enum Prioritization {
 
   private static final class DeadLettersStrategy implements PrioritizationStrategy {
 
-    private final MessagePassingQueue<Object> primary;
-    private final MessagePassingQueue<Object> secondary;
+    private final Queue<Object> primary;
+    private final Queue<Object> secondary;
 
-    private DeadLettersStrategy(
-        MessagePassingQueue<Object> primary, MessagePassingQueue<Object> secondary) {
+    private DeadLettersStrategy(Queue<Object> primary, Queue<Object> secondary) {
       this.primary = primary;
       this.secondary = secondary;
     }
@@ -112,7 +107,7 @@ public enum Prioritization {
       }
     }
 
-    private void offer(MessagePassingQueue<Object> queue, FlushEvent event) {
+    private void offer(Queue<Object> queue, FlushEvent event) {
       boolean offered;
       do {
         offered = queue.offer(event);

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterCombinedTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterCombinedTest.groovy
@@ -191,11 +191,6 @@ class DDAgentWriterCombinedTest extends DDSpecification {
         // Busywait because we don't want to fill up the ring buffer
       }
     }
-    // current queue does not have strict FIFO guarantees
-    // so the flush can race ahead of traces, this hack should
-    // prevent the test being flaky (we're only flushing to wait
-    // until after the buffer overflow triggered flush anyway).
-    Thread.sleep(1000)
     writer.flush()
 
     then:

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/PrioritizationTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/PrioritizationTest.groovy
@@ -4,7 +4,6 @@ import datadog.trace.common.writer.ddagent.FlushEvent
 import datadog.trace.common.writer.ddagent.Prioritization
 import datadog.trace.common.writer.ddagent.PrioritizationStrategy
 import datadog.trace.util.test.DDSpecification
-import org.jctools.queues.MessagePassingQueue
 
 import java.util.concurrent.TimeUnit
 
@@ -17,8 +16,8 @@ class PrioritizationTest extends DDSpecification {
 
   def "fast lane strategy sends kept and unset priority traces to the primary queue, dropped traces to the secondary queue" () {
     setup:
-    MessagePassingQueue<Object> primary = Mock(MessagePassingQueue)
-    MessagePassingQueue<Object> secondary = Mock(MessagePassingQueue)
+    Queue<Object> primary = Mock(Queue)
+    Queue<Object> secondary = Mock(Queue)
     PrioritizationStrategy fastLane =  Prioritization.FAST_LANE.create(primary, secondary)
 
     when:
@@ -39,8 +38,8 @@ class PrioritizationTest extends DDSpecification {
 
   def "fast lane strategy flushes primary queue" () {
     setup:
-    MessagePassingQueue<Object> primary = Mock(MessagePassingQueue)
-    MessagePassingQueue<Object> secondary = Mock(MessagePassingQueue)
+    Queue<Object> primary = Mock(Queue)
+    Queue<Object> secondary = Mock(Queue)
     PrioritizationStrategy fastLane =  Prioritization.FAST_LANE.create(primary, secondary)
     when:
     fastLane.flush(100, TimeUnit.MILLISECONDS)
@@ -51,8 +50,8 @@ class PrioritizationTest extends DDSpecification {
 
   def "dead letters strategy drops unkept traces if the primary queue is full" () {
     setup:
-    MessagePassingQueue<Object> primary = Mock(MessagePassingQueue)
-    MessagePassingQueue<Object> secondary = Mock(MessagePassingQueue)
+    Queue<Object> primary = Mock(Queue)
+    Queue<Object> secondary = Mock(Queue)
     PrioritizationStrategy fastLane =  Prioritization.DEAD_LETTERS.create(primary, secondary)
 
     when:
@@ -78,8 +77,8 @@ class PrioritizationTest extends DDSpecification {
 
   def "dead letters strategy flushes both queues" () {
     setup:
-    MessagePassingQueue<Object> primary = Mock(MessagePassingQueue)
-    MessagePassingQueue<Object> secondary = Mock(MessagePassingQueue)
+    Queue<Object> primary = Mock(Queue)
+    Queue<Object> secondary = Mock(Queue)
     PrioritizationStrategy deadLetters =  Prioritization.DEAD_LETTERS.create(primary, secondary)
     when:
     deadLetters.flush(100, TimeUnit.MILLISECONDS)


### PR DESCRIPTION
It's pretty clear that low core environments don't take kindly to busy spinning, and I think we're better off blocking for this use case. 