### PR TITLE
Classes with prefix 'datadog.trace.instrumentation' will be resolved by boot classloader in class loader instrumentation

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Constants.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Constants.java
@@ -19,7 +19,8 @@ public final class Constants {
     "datadog.trace.api",
     "datadog.trace.bootstrap",
     "datadog.trace.context",
-    "datadog.trace.instrumentation.api",
+    "datadog.trace.agent.tooling",
+    "datadog.trace.instrumentation",
     "datadog.trace.logging",
   };
 

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/HelperInjector.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/HelperInjector.java
@@ -127,13 +127,14 @@ public class HelperInjector implements Transformer {
             helperModules.add(new WeakReference<>(javaModule.unwrap()));
           }
         } catch (final Exception e) {
+          e.printStackTrace();
           if (log.isErrorEnabled()) {
             log.error(
-                "Error preparing helpers while processing {} for {}. Failed to inject helper classes into instance {}",
+                "Error preparing helpers while processing '{}' for '{}'. "
+                    + "Failed to inject helper classes into instance '{}'.",
                 typeDescription,
                 requestingName,
-                classLoader,
-                e);
+                classLoader);
           }
           throw new RuntimeException(e);
         }

--- a/dd-java-agent/instrumentation/classloading/src/main/java/datadog/trace/instrumentation/classloading/ClassloadingInstrumentation.java
+++ b/dd-java-agent/instrumentation/classloading/src/main/java/datadog/trace/instrumentation/classloading/ClassloadingInstrumentation.java
@@ -22,15 +22,15 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-/*
- * Some class loaders do not delegate to their parent, so classes in those class loaders
- * will not be able to see classes in the bootstrap class loader.
+/**
+ * Some class loaders do not delegate to their parent, so classes in those class loaders will not be
+ * able to see classes in the bootstrap class loader.
  *
- * In particular, instrumentation on classes in those class loaders will not be able to see
- * the shaded OpenTelemetry API classes in the bootstrap class loader.
+ * <p>In particular, instrumentation on classes in those class loaders will not be able to see the
+ * shaded OpenTelemetry API classes in the bootstrap class loader.
  *
- * This instrumentation forces all class loaders to delegate to the bootstrap class loader
- * for the classes that we have put in the bootstrap class loader.
+ * <p>This instrumentation forces all class loaders to delegate to the bootstrap class loader for
+ * the classes that we have put in the bootstrap class loader.
  */
 @AutoService(Instrumenter.class)
 public final class ClassloadingInstrumentation extends Instrumenter.Default {

--- a/dd-java-agent/instrumentation/classloading/src/test/groovy/ClassloadingTest.groovy
+++ b/dd-java-agent/instrumentation/classloading/src/test/groovy/ClassloadingTest.groovy
@@ -10,6 +10,7 @@ class ClassloadingTest extends AgentTestRunner {
     try {
       clazz = Class.forName("datadog.trace.api.GlobalTracer", false, classLoader)
     } catch (ClassNotFoundException e) {
+      e.printStackTrace()
     }
 
     then:

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/SpockRunner.java
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/SpockRunner.java
@@ -37,7 +37,8 @@ public class SpockRunner extends Sputnik {
     "datadog.trace.api",
     "datadog.trace.bootstrap",
     "datadog.trace.context",
-    "datadog.trace.instrumentation.api",
+    "datadog.trace.instrumentation",
+    "datadog.trace.agent.tooling",
     "datadog.trace.logging",
   };
 


### PR DESCRIPTION
We failing to instrument certains classes in jira plugins implemented as OSGi modules. 

`BundleWiringImpl$BundleClassLoader` contains class `org.apache.http.client.HttpClient` (distributed in artifact `org.apache.httpcomponents:httpclient`) and we start injection of helper classes for `com.amazonaws.http.apache.client.impl.SdkHttpClient` (implements `org.apache.http.client.HttpClient`) to instrument it. Then:
1. ApacheHttpClientInstrumentation starts loading it helper classes and tries to load HostAndRequestAsHttpUriRequest
1. HostAndRequestAsHttpUriRequest requests to load org.apache.http.message.AbstractHttpMessage
1. class `org.apache.http.message.AbstractHttpMessage` (distributed in artifact "org.apache.httpcomponents:httpcore" ) wasn't injected to bootstrap classpath and ClassNotFoundException happens

Log, when we start jira with dd agent:

```
__ Starting the JIRA Plugin System _________________
    
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.apache.felix.framework.ext.ClassPathExtenderFactory$DefaultClassLoaderExtender (file:/Users/lev.priima/Downloads/atlassian-jira-software-8.8.1-standalone/atlassian-jira/WEB-INF/lib/org.apache.felix.framework-5.6.12.jar) to method java.net.URLClassLoader.addURL(java.net.URL)
WARNING: Please consider reporting this to the maintainers of org.apache.felix.framework.ext.ClassPathExtenderFactory$DefaultClassLoaderExtender
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
2020-08-20 21:46:05,134-0700 ThreadPoolAsyncTaskExecutor::Thread 10 INFO      [c.a.ratelimiting.internal.RateLimitingConfiguration] Rate Limited Request Handler ENABLED
java.lang.IllegalStateException: Error invoking (accessor)::defineClass
	at net.bytebuddy.dynamic.loading.ClassInjector$UsingReflection$Dispatcher$UsingUnsafeInjection.defineClass(ClassInjector.java:922)
	at net.bytebuddy.dynamic.loading.ClassInjector$UsingReflection.injectRaw(ClassInjector.java:234)
	at datadog.trace.agent.tooling.HelperInjector.injectClassLoader(HelperInjector.java:172)
	at datadog.trace.agent.tooling.HelperInjector.transform(HelperInjector.java:119)
	at net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer.doTransform(AgentBuilder.java:10364)
	at net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer.transform(AgentBuilder.java:10302)
	at net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer.access$1600(AgentBuilder.java:10068)
	at net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer$Java9CapableVmDispatcher.run(AgentBuilder.java:10761)
	at net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer$Java9CapableVmDispatcher.run(AgentBuilder.java:10699)
	at java.base/java.security.AccessController.doPrivileged(Native Method)
	at net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer.transform(AgentBuilder.java:10258)
	at net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer$ByteBuddy$ModuleSupport.transform(Unknown Source)
	at java.instrument/sun.instrument.TransformerManager.transform(TransformerManager.java:188)
	at java.instrument/sun.instrument.InstrumentationImpl.transform(InstrumentationImpl.java:563)
	at java.base/java.lang.ClassLoader.defineClass1(Native Method)
	at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1017)
	at org.apache.felix.framework.BundleWiringImpl$BundleClassLoader.defineClass(BundleWiringImpl.java:2410)
	at org.apache.felix.framework.BundleWiringImpl$BundleClassLoader.findClass(BundleWiringImpl.java:2194)
	at org.apache.felix.framework.BundleWiringImpl.findClassOrResourceByDelegation(BundleWiringImpl.java:1607)
	at org.apache.felix.framework.BundleWiringImpl.access$200(BundleWiringImpl.java:80)
	at org.apache.felix.framework.BundleWiringImpl$BundleClassLoader.loadClass(BundleWiringImpl.java:2053)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
	at com.amazonaws.http.apache.client.impl.ApacheHttpClientFactory.create(ApacheHttpClientFactory.java:77)
	at com.amazonaws.http.apache.client.impl.ApacheHttpClientFactory.create(ApacheHttpClientFactory.java:38)
	at com.amazonaws.http.AmazonHttpClient.<init>(AmazonHttpClient.java:315)
	at com.amazonaws.http.AmazonHttpClient.<init>(AmazonHttpClient.java:299)
	at com.amazonaws.AmazonWebServiceClient.<init>(AmazonWebServiceClient.java:169)
	at com.amazonaws.services.s3.AmazonS3Client.<init>(AmazonS3Client.java:579)
	at com.amazonaws.services.s3.AmazonS3Client.<init>(AmazonS3Client.java:559)
	at com.amazonaws.services.s3.AmazonS3Client.<init>(AmazonS3Client.java:537)
	at com.amazonaws.services.s3.AmazonS3Client.<init>(AmazonS3Client.java:504)
	at com.atlassian.analytics.client.s3.AnalyticsS3Client.<init>(AnalyticsS3Client.java:67)
	at com.atlassian.analytics.client.s3.AnalyticsS3Client.<init>(AnalyticsS3Client.java:63)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:490)
	at org.springframework.beans.BeanUtils.instantiateClass(BeanUtils.java:170)
	at org.springframework.beans.factory.support.SimpleInstantiationStrategy.instantiate(SimpleInstantiationStrategy.java:117)
	at org.springframework.beans.factory.support.ConstructorResolver.autowireConstructor(ConstructorResolver.java:276)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.autowireConstructor(AbstractAutowireCapableBeanFactory.java:1266)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBeanInstance(AbstractAutowireCapableBeanFactory.java:1123)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:535)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:495)
	at org.springframework.beans.factory.support.AbstractBeanFactory.lambda$doGetBean$0(AbstractBeanFactory.java:317)
	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:222)
	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:315)
	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:199)
	at org.springframework.beans.factory.config.DependencyDescriptor.resolveCandidate(DependencyDescriptor.java:251)
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.doResolveDependency(DefaultListableBeanFactory.java:1135)
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.resolveDependency(DefaultListableBeanFactory.java:1062)
	at org.springframework.beans.factory.support.ConstructorResolver.resolveAutowiredArgument(ConstructorResolver.java:819)
	at org.springframework.beans.factory.support.ConstructorResolver.createArgumentArray(ConstructorResolver.java:725)
	at org.springframework.beans.factory.support.ConstructorResolver.autowireConstructor(ConstructorResolver.java:198)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.autowireConstructor(AbstractAutowireCapableBeanFactory.java:1266)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBeanInstance(AbstractAutowireCapableBeanFactory.java:1123)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:535)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:495)
	at org.springframework.beans.factory.support.AbstractBeanFactory.lambda$doGetBean$0(AbstractBeanFactory.java:317)
	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:222)
	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:315)
	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:199)
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.preInstantiateSingletons(DefaultListableBeanFactory.java:759)
	at org.springframework.context.support.AbstractApplicationContext.finishBeanFactoryInitialization(AbstractApplicationContext.java:867)
	at org.eclipse.gemini.blueprint.context.support.AbstractDelegatedExecutionApplicationContext.access$1600(AbstractDelegatedExecutionApplicationContext.java:57)
	at org.eclipse.gemini.blueprint.context.support.AbstractDelegatedExecutionApplicationContext$4.run(AbstractDelegatedExecutionApplicationContext.java:322)
	at org.eclipse.gemini.blueprint.util.internal.PrivilegedUtils.executeWithCustomTCCL(PrivilegedUtils.java:85)
	at org.eclipse.gemini.blueprint.context.support.AbstractDelegatedExecutionApplicationContext.completeRefresh(AbstractDelegatedExecutionApplicationContext.java:287)
	at org.eclipse.gemini.blueprint.extender.internal.dependencies.startup.DependencyWaiterApplicationContextExecutor$CompleteRefreshTask.run(DependencyWaiterApplicationContextExecutor.java:137)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
Caused by: java.lang.NoClassDefFoundError: org/apache/http/message/AbstractHttpMessage
	at java.base/java.lang.ClassLoader.defineClass1(Native Method)
	at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1017)
	at java.base/java.lang.ClassLoader$ByteBuddyAccessor$8BTDy4lA.defineClass(Unknown Source)
	at java.base/jdk.internal.reflect.GeneratedMethodAccessor79.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at net.bytebuddy.dynamic.loading.ClassInjector$UsingReflection$Dispatcher$UsingUnsafeInjection.defineClass(ClassInjector.java:918)
	... 71 more
Caused by: java.lang.ClassNotFoundException: org.apache.http.message.AbstractHttpMessage not found by com.atlassian.analytics.client [20]
	at org.apache.felix.framework.BundleWiringImpl.findClassOrResourceByDelegation(BundleWiringImpl.java:1639)
	at org.apache.felix.framework.BundleWiringImpl.access$200(BundleWiringImpl.java:80)
	at org.apache.felix.framework.BundleWiringImpl$BundleClassLoader.loadClass(BundleWiringImpl.java:2053)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
	... 78 more
[dd.trace 2020-08-20 21:46:05:165 -0700] [ThreadPoolAsyncTaskExecutor::Thread 9] ERROR datadog.trace.agent.tooling.HelperInjector - Error preparing helpers while processing 'class com.amazonaws.http.apache.client.impl.SdkHttpClient' for 'ApacheHttpClientInstrumentation'. Failed to inject helper classes into instance 'com.atlassian.analytics.client [20]'.
Security framework of XStream not initialized, XStream is probably vulnerable.
java.lang.IllegalStateException: Error invoking (accessor)::defineClass
	at net.bytebuddy.dynamic.loading.ClassInjector$UsingReflection$Dispatcher$UsingUnsafeInjection.defineClass(ClassInjector.java:922)
	at net.bytebuddy.dynamic.loading.ClassInjector$UsingReflection.injectRaw(ClassInjector.java:234)
	at datadog.trace.agent.tooling.HelperInjector.injectClassLoader(HelperInjector.java:172)
	at datadog.trace.agent.tooling.HelperInjector.transform(HelperInjector.java:119)
	at net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer.doTransform(AgentBuilder.java:10364)
	at net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer.transform(AgentBuilder.java:10302)
	at net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer.access$1600(AgentBuilder.java:10068)
	at net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer$Java9CapableVmDispatcher.run(AgentBuilder.java:10761)
	at net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer$Java9CapableVmDispatcher.run(AgentBuilder.java:10699)
	at java.base/java.security.AccessController.doPrivileged(Native Method)
	at net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer.transform(AgentBuilder.java:10258)
	at net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer$ByteBuddy$ModuleSupport.transform(Unknown Source)
	at java.instrument/sun.instrument.TransformerManager.transform(TransformerManager.java:188)
	at java.instrument/sun.instrument.InstrumentationImpl.transform(InstrumentationImpl.java:563)
	at java.base/java.lang.ClassLoader.defineClass1(Native Method)
	at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1017)
	at org.apache.felix.framework.BundleWiringImpl$BundleClassLoader.defineClass(BundleWiringImpl.java:2410)
	at org.apache.felix.framework.BundleWiringImpl$BundleClassLoader.findClass(BundleWiringImpl.java:2194)
	at org.apache.felix.framework.BundleWiringImpl.findClassOrResourceByDelegation(BundleWiringImpl.java:1607)
	at org.apache.felix.framework.BundleWiringImpl.access$200(BundleWiringImpl.java:80)
	at org.apache.felix.framework.BundleWiringImpl$BundleClassLoader.loadClass(BundleWiringImpl.java:2053)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
	at org.apache.felix.framework.Felix.loadBundleClass(Felix.java:1927)
	at org.apache.felix.framework.BundleImpl.loadClass(BundleImpl.java:978)
	at com.atlassian.plugin.osgi.util.BundleClassLoaderAccessor.loadClass(BundleClassLoaderAccessor.java:43)
	at com.atlassian.plugin.osgi.factory.OsgiPluginInstalledHelper.loadClass(OsgiPluginInstalledHelper.java:52)
	at com.atlassian.plugin.osgi.factory.OsgiPlugin.loadClass(OsgiPlugin.java:209)
	at com.atlassian.plugin.module.ClassPrefixModuleFactory.getModuleClass(ClassPrefixModuleFactory.java:44)
	at com.atlassian.plugin.module.PrefixDelegatingModuleFactory.guessModuleClass(PrefixDelegatingModuleFactory.java:145)
	at com.atlassian.plugin.descriptors.AbstractModuleDescriptor.loadClass(AbstractModuleDescriptor.java:190)
	at com.atlassian.plugin.descriptors.AbstractModuleDescriptor.enabled(AbstractModuleDescriptor.java:406)
	at com.atlassian.plugin.servlet.descriptors.ServletModuleDescriptor.enabled(ServletModuleDescriptor.java:30)
	at com.atlassian.plugin.manager.DefaultPluginManager.lambda$notifyModuleEnabled$44(DefaultPluginManager.java:1884)
	at com.atlassian.plugin.manager.PluginTransactionContext.wrap(PluginTransactionContext.java:63)
	at com.atlassian.plugin.manager.DefaultPluginManager.notifyModuleEnabled(DefaultPluginManager.java:1880)
	at com.atlassian.plugin.manager.DefaultPluginManager.lambda$enableConfiguredPluginModule$30(DefaultPluginManager.java:1635)
	at com.atlassian.plugin.manager.PluginTransactionContext.wrap(PluginTransactionContext.java:72)
	at com.atlassian.plugin.manager.DefaultPluginManager.enableConfiguredPluginModule(DefaultPluginManager.java:1619)
	at com.atlassian.plugin.manager.DefaultPluginManager.lambda$enableConfiguredPluginModules$29(DefaultPluginManager.java:1610)
	at com.atlassian.plugin.manager.PluginTransactionContext.wrap(PluginTransactionContext.java:72)
	at com.atlassian.plugin.manager.DefaultPluginManager.enableConfiguredPluginModules(DefaultPluginManager.java:1607)
	at com.atlassian.plugin.manager.DefaultPluginManager.lambda$enableDependentPlugins$22(DefaultPluginManager.java:1261)
	at com.atlassian.plugin.manager.PluginTransactionContext.wrap(PluginTransactionContext.java:63)
	at com.atlassian.plugin.manager.DefaultPluginManager.enableDependentPlugins(DefaultPluginManager.java:1230)
	at com.atlassian.plugin.manager.DefaultPluginManager.lambda$addPlugins$20(DefaultPluginManager.java:1215)
	at com.atlassian.plugin.manager.PluginTransactionContext.wrap(PluginTransactionContext.java:63)
	at com.atlassian.plugin.manager.DefaultPluginManager.addPlugins(DefaultPluginManager.java:1115)
	at com.atlassian.jira.plugin.JiraPluginManager.addPlugins(JiraPluginManager.java:157)
	at com.atlassian.plugin.manager.DefaultPluginManager.lambda$earlyStartup$3(DefaultPluginManager.java:588)
	at com.atlassian.plugin.manager.PluginTransactionContext.wrap(PluginTransactionContext.java:63)
	at com.atlassian.plugin.manager.DefaultPluginManager.earlyStartup(DefaultPluginManager.java:523)
	at com.atlassian.jira.plugin.JiraPluginManager.earlyStartup(JiraPluginManager.java:119)
	at com.atlassian.jira.component.pico.ComponentManager$PluginSystem.earlyStartup(ComponentManager.java:669)
	at com.atlassian.jira.component.pico.ComponentManager.earlyStartPluginSystem(ComponentManager.java:238)
	at com.atlassian.jira.upgrade.PluginSystemLauncher.start(PluginSystemLauncher.java:45)
	at com.atlassian.jira.startup.DefaultJiraLauncher.lambda$postDbLaunch$2(DefaultJiraLauncher.java:145)
	at com.atlassian.jira.config.database.DatabaseConfigurationManagerImpl.doNowOrEnqueue(DatabaseConfigurationManagerImpl.java:301)
	at com.atlassian.jira.config.database.DatabaseConfigurationManagerImpl.doNowOrWhenDatabaseActivated(DatabaseConfigurationManagerImpl.java:196)
	at com.atlassian.jira.startup.DefaultJiraLauncher.postDbLaunch(DefaultJiraLauncher.java:137)
	at com.atlassian.jira.startup.DefaultJiraLauncher.lambda$start$0(DefaultJiraLauncher.java:104)
	at com.atlassian.jira.util.devspeed.JiraDevSpeedTimer.run(JiraDevSpeedTimer.java:31)
	at com.atlassian.jira.startup.DefaultJiraLauncher.start(DefaultJiraLauncher.java:102)
	at com.atlassian.jira.startup.LauncherContextListener.initSlowStuff(LauncherContextListener.java:154)
	at java.base/java.lang.Thread.run(Thread.java:834)
Caused by: java.lang.NoClassDefFoundError: javax/servlet/AsyncListener
	at java.base/java.lang.ClassLoader.defineClass1(Native Method)
	at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1017)
	at java.base/java.lang.ClassLoader$ByteBuddyAccessor$8BTDy4lA.defineClass(Unknown Source)
	at java.base/jdk.internal.reflect.GeneratedMethodAccessor79.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at net.bytebuddy.dynamic.loading.ClassInjector$UsingReflection$Dispatcher$UsingUnsafeInjection.defineClass(ClassInjector.java:918)
	... 63 more
Caused by: java.lang.ClassNotFoundException: javax.servlet.AsyncListener not found by com.atlassian.plugins.atlassian-whitelist-ui-plugin [152]
	at org.apache.felix.framework.BundleWiringImpl.findClassOrResourceByDelegation(BundleWiringImpl.java:1639)
	at org.apache.felix.framework.BundleWiringImpl.access$200(BundleWiringImpl.java:80)
	at org.apache.felix.framework.BundleWiringImpl$BundleClassLoader.loadClass(BundleWiringImpl.java:2053)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
	... 70 more
[dd.trace 2020-08-20 21:46:18:323 -0700] [JIRA-Bootstrap] ERROR datadog.trace.agent.tooling.HelperInjector - Error preparing helpers while processing 'class com.atlassian.plugins.whitelist.ui.WhitelistServlet' for 'Servlet3Instrumentation'. Failed to inject helper classes into instance 'com.atlassian.plugins.atlassian-whitelist-ui-plugin [152]'.
java.lang.IllegalStateException: Error invoking (accessor)::defineClass
	at net.bytebuddy.dynamic.loading.ClassInjector$UsingReflection$Dispatcher$UsingUnsafeInjection.defineClass(ClassInjector.java:922)
	at net.bytebuddy.dynamic.loading.ClassInjector$UsingReflection.injectRaw(ClassInjector.java:234)
	at datadog.trace.agent.tooling.HelperInjector.injectClassLoader(HelperInjector.java:172)
	at datadog.trace.agent.tooling.HelperInjector.transform(HelperInjector.java:119)
	at net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer.doTransform(AgentBuilder.java:10364)
	at net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer.transform(AgentBuilder.java:10302)
	at net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer.access$1600(AgentBuilder.java:10068)
	at net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer$Java9CapableVmDispatcher.run(AgentBuilder.java:10761)
	at net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer$Java9CapableVmDispatcher.run(AgentBuilder.java:10699)
	at java.base/java.security.AccessController.doPrivileged(Native Method)
	at net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer.transform(AgentBuilder.java:10258)
	at net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer$ByteBuddy$ModuleSupport.transform(Unknown Source)
	at java.instrument/sun.instrument.TransformerManager.transform(TransformerManager.java:188)
	at java.instrument/sun.instrument.InstrumentationImpl.transform(InstrumentationImpl.java:563)
	at java.base/java.lang.ClassLoader.defineClass1(Native Method)
	at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1017)
	at org.apache.felix.framework.BundleWiringImpl$BundleClassLoader.defineClass(BundleWiringImpl.java:2410)
	at org.apache.felix.framework.BundleWiringImpl$BundleClassLoader.findClass(BundleWiringImpl.java:2194)
	at org.apache.felix.framework.BundleWiringImpl.findClassOrResourceByDelegation(BundleWiringImpl.java:1607)
	at org.apache.felix.framework.BundleWiringImpl.access$200(BundleWiringImpl.java:80)
	at org.apache.felix.framework.BundleWiringImpl$BundleClassLoader.loadClass(BundleWiringImpl.java:2053)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
	at org.apache.felix.framework.Felix.loadBundleClass(Felix.java:1927)
	at org.apache.felix.framework.BundleImpl.loadClass(BundleImpl.java:978)
	at com.atlassian.plugin.osgi.util.BundleClassLoaderAccessor.loadClass(BundleClassLoaderAccessor.java:43)
	at com.atlassian.plugin.osgi.factory.OsgiPluginInstalledHelper.loadClass(OsgiPluginInstalledHelper.java:52)
	at com.atlassian.plugin.osgi.factory.OsgiPlugin.loadClass(OsgiPlugin.java:209)
	at com.atlassian.plugin.module.ClassPrefixModuleFactory.getModuleClass(ClassPrefixModuleFactory.java:44)
	at com.atlassian.plugin.module.PrefixDelegatingModuleFactory.guessModuleClass(PrefixDelegatingModuleFactory.java:145)
	at com.atlassian.plugin.descriptors.AbstractModuleDescriptor.loadClass(AbstractModuleDescriptor.java:190)
	at com.atlassian.plugin.descriptors.AbstractModuleDescriptor.enabled(AbstractModuleDescriptor.java:406)
	at com.atlassian.plugin.servlet.descriptors.ServletModuleDescriptor.enabled(ServletModuleDescriptor.java:30)
	at com.atlassian.plugin.manager.DefaultPluginManager.lambda$notifyModuleEnabled$44(DefaultPluginManager.java:1884)
	at com.atlassian.plugin.manager.PluginTransactionContext.wrap(PluginTransactionContext.java:63)
	at com.atlassian.plugin.manager.DefaultPluginManager.notifyModuleEnabled(DefaultPluginManager.java:1880)
	at com.atlassian.plugin.manager.DefaultPluginManager.lambda$enableConfiguredPluginModule$30(DefaultPluginManager.java:1635)
	at com.atlassian.plugin.manager.PluginTransactionContext.wrap(PluginTransactionContext.java:72)
	at com.atlassian.plugin.manager.DefaultPluginManager.enableConfiguredPluginModule(DefaultPluginManager.java:1619)
	at com.atlassian.plugin.manager.DefaultPluginManager.lambda$enableConfiguredPluginModules$29(DefaultPluginManager.java:1610)
	at com.atlassian.plugin.manager.PluginTransactionContext.wrap(PluginTransactionContext.java:72)
	at com.atlassian.plugin.manager.DefaultPluginManager.enableConfiguredPluginModules(DefaultPluginManager.java:1607)
	at com.atlassian.plugin.manager.DefaultPluginManager.lambda$enableDependentPlugins$22(DefaultPluginManager.java:1261)
	at com.atlassian.plugin.manager.PluginTransactionContext.wrap(PluginTransactionContext.java:63)
	at com.atlassian.plugin.manager.DefaultPluginManager.enableDependentPlugins(DefaultPluginManager.java:1230)
	at com.atlassian.plugin.manager.DefaultPluginManager.lambda$addPlugins$20(DefaultPluginManager.java:1215)
	at com.atlassian.plugin.manager.PluginTransactionContext.wrap(PluginTransactionContext.java:63)
	at com.atlassian.plugin.manager.DefaultPluginManager.addPlugins(DefaultPluginManager.java:1115)
	at com.atlassian.jira.plugin.JiraPluginManager.addPlugins(JiraPluginManager.java:157)
	at com.atlassian.plugin.manager.DefaultPluginManager.lambda$earlyStartup$3(DefaultPluginManager.java:588)
	at com.atlassian.plugin.manager.PluginTransactionContext.wrap(PluginTransactionContext.java:63)
	at com.atlassian.plugin.manager.DefaultPluginManager.earlyStartup(DefaultPluginManager.java:523)
	at com.atlassian.jira.plugin.JiraPluginManager.earlyStartup(JiraPluginManager.java:119)
	at com.atlassian.jira.component.pico.ComponentManager$PluginSystem.earlyStartup(ComponentManager.java:669)
	at com.atlassian.jira.component.pico.ComponentManager.earlyStartPluginSystem(ComponentManager.java:238)
	at com.atlassian.jira.upgrade.PluginSystemLauncher.start(PluginSystemLauncher.java:45)
	at com.atlassian.jira.startup.DefaultJiraLauncher.lambda$postDbLaunch$2(DefaultJiraLauncher.java:145)
	at com.atlassian.jira.config.database.DatabaseConfigurationManagerImpl.doNowOrEnqueue(DatabaseConfigurationManagerImpl.java:301)
	at com.atlassian.jira.config.database.DatabaseConfigurationManagerImpl.doNowOrWhenDatabaseActivated(DatabaseConfigurationManagerImpl.java:196)
	at com.atlassian.jira.startup.DefaultJiraLauncher.postDbLaunch(DefaultJiraLauncher.java:137)
	at com.atlassian.jira.startup.DefaultJiraLauncher.lambda$start$0(DefaultJiraLauncher.java:104)
	at com.atlassian.jira.util.devspeed.JiraDevSpeedTimer.run(JiraDevSpeedTimer.java:31)
	at com.atlassian.jira.startup.DefaultJiraLauncher.start(DefaultJiraLauncher.java:102)
	at com.atlassian.jira.startup.LauncherContextListener.initSlowStuff(LauncherContextListener.java:154)
	at java.base/java.lang.Thread.run(Thread.java:834)
Caused by: java.lang.NoClassDefFoundError: javax/servlet/AsyncListener
	at java.base/java.lang.ClassLoader.defineClass1(Native Method)
	at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1017)
	at java.base/java.lang.ClassLoader$ByteBuddyAccessor$8BTDy4lA.defineClass(Unknown Source)
	at java.base/jdk.internal.reflect.GeneratedMethodAccessor79.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at net.bytebuddy.dynamic.loading.ClassInjector$UsingReflection$Dispatcher$UsingUnsafeInjection.defineClass(ClassInjector.java:918)
	... 63 more
Caused by: java.lang.ClassNotFoundException: javax.servlet.AsyncListener not found by com.atlassian.plugins.static-assets-url [166]
	at org.apache.felix.framework.BundleWiringImpl.findClassOrResourceByDelegation(BundleWiringImpl.java:1639)
	at org.apache.felix.framework.BundleWiringImpl.access$200(BundleWiringImpl.java:80)
	at org.apache.felix.framework.BundleWiringImpl$BundleClassLoader.loadClass(BundleWiringImpl.java:2053)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
	... 70 more
[dd.trace 2020-08-20 21:46:18:474 -0700] [JIRA-Bootstrap] ERROR datadog.trace.agent.tooling.HelperInjector - Error preparing helpers while processing 'class com.atlassian.plugins.impl.servlet.AdminServlet' for 'Servlet3Instrumentation'. Failed to inject helper classes into instance 'com.atlassian.plugins.static-assets-url [166]'.
```