### PR TITLE
Apply changes to enable `./gradlew build` to succeed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,7 +142,7 @@ jobs:
           name: Build Project
           command: >-
             GRADLE_OPTS="-Ddatadog.forkedMaxHeapSize=4G -Ddatadog.forkedMinHeapSize=64M"
-            ./gradlew check -PskipTests
+            ./gradlew build -PskipTests
             << pipeline.parameters.gradle_flags >>
             --max-workers=8
 

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jdbc/DBInfo.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jdbc/DBInfo.java
@@ -15,4 +15,7 @@ public class DBInfo {
   private final String db;
   private final String host;
   private final Integer port;
+
+  // Needed for javadoc
+  public static class Builder {}
 }

--- a/gradle/jacoco.gradle
+++ b/gradle/jacoco.gradle
@@ -57,6 +57,9 @@ afterEvaluate {
         }
       }
     }
+
+    // Disable verification if skipTests property was specified
+    onlyIf { !project.rootProject.hasProperty("skipTests") }
   }
 
   jacocoTestCoverageVerification.dependsOn jacocoTestReport

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -170,7 +170,7 @@ tasks.withType(Javadoc).configureEach {
 }
 
 javadoc {
-  source = sourceSets.main.allJava
+  source = sourceSets.main.java.srcDirs
   classpath = configurations.compileClasspath
 
   options {
@@ -178,6 +178,7 @@ javadoc {
     setAuthor true
 
     links "https://docs.oracle.com/javase/8/docs/api/"
+    source = 8
   }
 }
 

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -101,7 +101,7 @@ import lombok.extern.slf4j.Slf4j;
  * <p>
  *
  * <p>System properties are {@link Config#PREFIX}'ed. Environment variables are the same as the
- * system property, but uppercased with '.' -> '_'.
+ * system property, but uppercased and '.' is replaced with '_'.
  */
 @Deprecated
 @Slf4j


### PR DESCRIPTION
Mostly doing the same thing that @iNikem did in https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/355