### PR TITLE
Better instrumentation support for dynamic Spring HandlerMapping

### DIFF
--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/HandlerMappingResourceNameFilter.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/HandlerMappingResourceNameFilter.java
@@ -64,9 +64,10 @@ public class HandlerMappingResourceNameFilter extends OncePerRequestFilter imple
 
   public void setHandlerMappings(final List<HandlerMapping> handlerMappings) {
     for (HandlerMapping handlerMapping : handlerMappings) {
-      if (handlerMapping instanceof RequestMappingInfoHandlerMapping
-          && !this.handlerMappings.contains(handlerMapping)) {
-        this.handlerMappings.add(handlerMapping);
+      if (handlerMapping instanceof RequestMappingInfoHandlerMapping) {
+        if (!this.handlerMappings.contains(handlerMapping)) {
+          this.handlerMappings.add(handlerMapping);
+        }
       } else {
         log.debug(
             "discarding handler mapping {} which won't set BEST_MATCHING_PATTERN_ATTRIBUTE",

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/dynamic/ClearRequestContext.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/dynamic/ClearRequestContext.groovy
@@ -1,0 +1,17 @@
+package test.dynamic
+
+import org.springframework.web.context.request.RequestContextHolder
+import org.springframework.web.filter.OncePerRequestFilter
+
+import javax.servlet.FilterChain
+import javax.servlet.ServletException
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
+class ClearRequestContext extends OncePerRequestFilter {
+  @Override
+  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+    RequestContextHolder.resetRequestAttributes()
+    filterChain.doFilter(request, response)
+  }
+}

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/dynamic/DynamicHandlerMapping.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/dynamic/DynamicHandlerMapping.groovy
@@ -1,6 +1,8 @@
 package test.dynamic
 
+import org.junit.Assert
 import org.springframework.context.ApplicationContext
+import org.springframework.web.context.request.RequestContextHolder
 import org.springframework.web.method.HandlerMethod
 import org.springframework.web.servlet.handler.AbstractHandlerMapping
 
@@ -11,6 +13,13 @@ class DynamicHandlerMapping extends AbstractHandlerMapping {
 
   @Override
   protected Object getHandlerInternal(HttpServletRequest request) throws Exception {
+    // this is here to cause problems if they haven't been set when this gets called
+    // this mimics bean construction which depends on this value having been set in a request
+    try {
+      RequestContextHolder.currentRequestAttributes()
+    } catch (Exception e) {
+      Assert.fail(e.getMessage())
+    }
     ApplicationContext applicationContext = this.getApplicationContext()
     DynamicRoutingConfig routingConfig = applicationContext
       .getBean(DynamicRoutingConfig)

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/dynamic/DynamicHandlerMapping.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/dynamic/DynamicHandlerMapping.groovy
@@ -1,0 +1,40 @@
+package test.dynamic
+
+import org.springframework.context.ApplicationContext
+import org.springframework.web.method.HandlerMethod
+import org.springframework.web.servlet.handler.AbstractHandlerMapping
+
+import javax.servlet.http.HttpServletRequest
+import java.lang.reflect.Method
+
+class DynamicHandlerMapping extends AbstractHandlerMapping {
+
+  @Override
+  protected Object getHandlerInternal(HttpServletRequest request) throws Exception {
+    ApplicationContext applicationContext = this.getApplicationContext()
+    DynamicRoutingConfig routingConfig = applicationContext
+      .getBean(DynamicRoutingConfig)
+    Class<?> controllerClass = Class.forName(routingConfig.getController())
+    Object controller = applicationContext.getBean(controllerClass)
+    String methodName = request.getServletPath().replace('-', '_')
+    methodName = methodName.substring(1)
+    int nextSlash = methodName.indexOf('/')
+    if (nextSlash != -1) {
+      methodName = methodName.substring(0, nextSlash)
+    }
+    if (methodName == "error_status") {
+      // easier than refactoring the entire test hierarchy to
+      // reflect this particular use case
+      methodName = "error"
+    }
+    Method method = null
+    Method[] methods = controllerClass.getDeclaredMethods()
+    for (Method m : methods) {
+      if (m.getName() == methodName) {
+        method = m
+        break
+      }
+    }
+    return new HandlerMethod(controller, method)
+  }
+}

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/dynamic/DynamicRoutingAppConfig.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/dynamic/DynamicRoutingAppConfig.groovy
@@ -5,7 +5,9 @@ import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.context.embedded.EmbeddedServletContainerFactory
 import org.springframework.boot.context.embedded.tomcat.TomcatConnectorCustomizer
 import org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainerFactory
+import org.springframework.boot.web.servlet.FilterRegistrationBean
 import org.springframework.context.annotation.Bean
+import org.springframework.core.Ordered
 import org.springframework.http.HttpInputMessage
 import org.springframework.http.HttpOutputMessage
 import org.springframework.http.MediaType
@@ -17,6 +19,7 @@ import org.springframework.util.StreamUtils
 import org.springframework.web.HttpMediaTypeNotAcceptableException
 import org.springframework.web.accept.ContentNegotiationStrategy
 import org.springframework.web.context.request.NativeWebRequest
+import org.springframework.web.filter.RequestContextFilter
 import org.springframework.web.servlet.config.annotation.ContentNegotiationConfigurer
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter
 
@@ -37,6 +40,27 @@ class DynamicRoutingAppConfig extends WebMvcConfigurerAdapter {
           return [MediaType.TEXT_PLAIN]
         }
       })
+  }
+
+
+  @Bean
+  FilterRegistrationBean requestContextFilterRegistrationBean() {
+    // make sure this hasn't happened when HandlerMappingResourceNameFilter executes
+    FilterRegistrationBean registrationBean = new FilterRegistrationBean()
+    RequestContextFilter requestContextFilter = new RequestContextFilter()
+    registrationBean.setFilter(requestContextFilter)
+    registrationBean.setOrder(Ordered.LOWEST_PRECEDENCE)
+    return registrationBean
+  }
+
+  @Bean
+  FilterRegistrationBean clearRequestContextFilterRegistrationBean() {
+    // make sure context is cleared when HandlerMappingResourceNameFilter executes
+    FilterRegistrationBean registrationBean = new FilterRegistrationBean()
+    ClearRequestContext requestContextFilter = new ClearRequestContext()
+    registrationBean.setFilter(requestContextFilter)
+    registrationBean.setOrder(Ordered.HIGHEST_PRECEDENCE)
+    return registrationBean
   }
 
   @Bean

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/dynamic/DynamicRoutingAppConfig.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/dynamic/DynamicRoutingAppConfig.groovy
@@ -1,0 +1,87 @@
+package test.dynamic
+
+import org.apache.catalina.connector.Connector
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.context.embedded.EmbeddedServletContainerFactory
+import org.springframework.boot.context.embedded.tomcat.TomcatConnectorCustomizer
+import org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainerFactory
+import org.springframework.context.annotation.Bean
+import org.springframework.http.HttpInputMessage
+import org.springframework.http.HttpOutputMessage
+import org.springframework.http.MediaType
+import org.springframework.http.converter.AbstractHttpMessageConverter
+import org.springframework.http.converter.HttpMessageConverter
+import org.springframework.http.converter.HttpMessageNotReadableException
+import org.springframework.http.converter.HttpMessageNotWritableException
+import org.springframework.util.StreamUtils
+import org.springframework.web.HttpMediaTypeNotAcceptableException
+import org.springframework.web.accept.ContentNegotiationStrategy
+import org.springframework.web.context.request.NativeWebRequest
+import org.springframework.web.servlet.config.annotation.ContentNegotiationConfigurer
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter
+
+import java.nio.charset.StandardCharsets
+
+@SpringBootApplication
+class DynamicRoutingAppConfig extends WebMvcConfigurerAdapter {
+
+  @Override
+  void configureContentNegotiation(ContentNegotiationConfigurer configurer) {
+    configurer.favorPathExtension(false)
+      .favorParameter(true)
+      .ignoreAcceptHeader(true)
+      .useJaf(false)
+      .defaultContentTypeStrategy(new ContentNegotiationStrategy() {
+        @Override
+        List<MediaType> resolveMediaTypes(NativeWebRequest webRequest) throws HttpMediaTypeNotAcceptableException {
+          return [MediaType.TEXT_PLAIN]
+        }
+      })
+  }
+
+  @Bean
+  TestController testController() {
+    return new TestController()
+  }
+
+  @Bean
+  DynamicRoutingConfig routingConfig() {
+    return new DynamicRoutingConfig()
+  }
+
+  @Bean
+  EmbeddedServletContainerFactory servletContainerFactory() {
+    def factory = new TomcatEmbeddedServletContainerFactory()
+
+    factory.addConnectorCustomizers(
+      new TomcatConnectorCustomizer() {
+        @Override
+        void customize(final Connector connector) {
+          connector.setEnableLookups(true)
+        }
+      })
+
+    return factory
+  }
+
+  @Bean
+  HttpMessageConverter<Map<String, Object>> createPlainMapMessageConverter() {
+    return new AbstractHttpMessageConverter<Map<String, Object>>(MediaType.TEXT_PLAIN) {
+
+      @Override
+      protected boolean supports(Class<?> clazz) {
+        return Map.isAssignableFrom(clazz)
+      }
+
+      @Override
+      protected Map<String, Object> readInternal(Class<? extends Map<String, Object>> clazz, HttpInputMessage inputMessage) throws IOException, HttpMessageNotReadableException {
+        return null
+      }
+
+      @Override
+      protected void writeInternal(Map<String, Object> stringObjectMap, HttpOutputMessage outputMessage) throws IOException, HttpMessageNotWritableException {
+        StreamUtils.copy(stringObjectMap.get("message"), StandardCharsets.UTF_8, outputMessage.getBody())
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/dynamic/DynamicRoutingConfig.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/dynamic/DynamicRoutingConfig.groovy
@@ -1,0 +1,8 @@
+package test.dynamic
+
+class DynamicRoutingConfig {
+
+  String getController() {
+    return "test.dynamic.TestController"
+  }
+}

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/dynamic/DynamicRoutingTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/dynamic/DynamicRoutingTest.groovy
@@ -1,0 +1,102 @@
+package test.dynamic
+
+import datadog.trace.agent.test.asserts.TraceAssert
+import datadog.trace.api.DDSpanTypes
+import datadog.trace.api.DDTags
+import datadog.trace.bootstrap.instrumentation.api.Tags
+import datadog.trace.core.DDSpan
+import datadog.trace.instrumentation.springweb.SpringWebHttpServerDecorator
+import org.apache.catalina.core.ApplicationFilterChain
+import org.springframework.boot.SpringApplication
+import org.springframework.context.ConfigurableApplicationContext
+import test.boot.SecurityConfig
+import test.filter.ServletFilterTest
+
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
+import static java.util.Collections.singletonMap
+
+class DynamicRoutingTest extends ServletFilterTest {
+
+  @Override
+  ConfigurableApplicationContext startServer(int port) {
+    def app = new SpringApplication(DynamicRoutingAppConfig, SecurityConfig)
+    app.setDefaultProperties(singletonMap("server.port", port))
+    def context = app.run()
+    return context
+  }
+
+  @Override
+  String testPathParam() {
+    // this handler mapping scheme does not support path params!
+    null
+  }
+
+  @Override
+  boolean hasHandlerSpan() {
+    true
+  }
+
+  @Override
+  void handlerSpan(TraceAssert trace, int index, Object parent, ServerEndpoint endpoint = SUCCESS) {
+    trace.span(index) {
+      serviceName expectedServiceName()
+      operationName "spring.handler"
+      resourceName "TestController.${formatEndpoint(endpoint)}"
+      spanType DDSpanTypes.HTTP_SERVER
+      errored endpoint == EXCEPTION
+      childOf(parent as DDSpan)
+      tags {
+        "$Tags.COMPONENT" SpringWebHttpServerDecorator.DECORATE.component()
+        "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
+        if (endpoint == EXCEPTION) {
+          errorTags(Exception, EXCEPTION.body)
+        }
+        defaultTags()
+      }
+    }
+  }
+
+  @Override
+  void serverSpan(TraceAssert trace, int index, BigInteger traceID = null, BigInteger parentID = null, String method = "GET", ServerEndpoint endpoint = SUCCESS) {
+    trace.span(index) {
+      serviceName expectedServiceName()
+      operationName expectedOperationName()
+      resourceName endpoint.resource(method, address, testPathParam())
+      spanType DDSpanTypes.HTTP_SERVER
+      errored endpoint.errored
+      if (parentID != null) {
+        traceId traceID
+        parentId parentID
+      } else {
+        parent()
+      }
+      tags {
+        "$Tags.COMPONENT" component
+        "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
+        "$Tags.PEER_HOST_IPV4" { it == null || it == "127.0.0.1" } // Optional
+        "$Tags.PEER_PORT" Integer
+        "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
+        "$Tags.HTTP_METHOD" method
+        "$Tags.HTTP_STATUS" endpoint.status
+        "span.origin.type" ApplicationFilterChain.name
+        "servlet.path" endpoint.path
+        if (endpoint.errored) {
+          "error.msg" { it == null || it == EXCEPTION.body }
+          "error.type" { it == null || it == Exception.name }
+          "error.stack" { it == null || it instanceof String }
+        }
+        if (endpoint.query) {
+          "$DDTags.HTTP_QUERY" endpoint.query
+        }
+        defaultTags(true)
+      }
+    }
+  }
+
+  def formatEndpoint(ServerEndpoint endpoint) {
+    String x = endpoint.name().toLowerCase()
+    int firstUnderscore = x.indexOf('_')
+    return firstUnderscore == -1 ? x : x.substring(0, firstUnderscore)
+  }
+}

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/dynamic/HandlerMappingConfiguration.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/dynamic/HandlerMappingConfiguration.groovy
@@ -1,0 +1,16 @@
+package test.dynamic
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.servlet.HandlerMapping
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurationSupport
+
+@Configuration
+class HandlerMappingConfiguration extends WebMvcConfigurationSupport {
+
+  @Bean
+  @Override
+  HandlerMapping viewControllerHandlerMapping() {
+    return new DynamicHandlerMapping()
+  }
+}

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/dynamic/TestController.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/dynamic/TestController.groovy
@@ -1,0 +1,62 @@
+package test.dynamic
+
+import datadog.trace.agent.test.base.HttpServerTest
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.ResponseBody
+import org.springframework.web.servlet.view.RedirectView
+
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.PATH_PARAM
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.REDIRECT
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
+
+class TestController {
+
+  @ResponseBody
+  String success() {
+    HttpServerTest.controller(SUCCESS) {
+      SUCCESS.body
+    }
+  }
+
+
+  @ResponseBody
+  String query(@RequestParam("some") String param) {
+    HttpServerTest.controller(QUERY_PARAM) {
+      "some=$param"
+    }
+  }
+
+
+  @ResponseBody
+  String path(@PathVariable Integer id) {
+    HttpServerTest.controller(PATH_PARAM) {
+      "$id"
+    }
+  }
+
+
+  @ResponseBody
+  RedirectView redirect() {
+    HttpServerTest.controller(REDIRECT) {
+      new RedirectView(REDIRECT.body)
+    }
+  }
+
+  ResponseEntity error() {
+    HttpServerTest.controller(ERROR) {
+      new ResponseEntity(ERROR.body, HttpStatus.valueOf(ERROR.status))
+    }
+  }
+
+  ResponseEntity exception() {
+    HttpServerTest.controller(EXCEPTION) {
+      throw new Exception(EXCEPTION.body)
+    }
+  }
+}


### PR DESCRIPTION
Currently, we invoke all of the `HandlerMapping`s from `HandlerMappingResourceNameFilter` hoping to get the property `BEST_MATCHING_PATTERN_ATTRIBUTE` set on the request as a side effect. This has other side effects like invoking a `HandlerMapping` too soon, such as before thread local `RequestAttributes` have been set in highly customised implementations - hitting the error condition below: in `RequestContextHolder`:

```
	/**
	 * Return the RequestAttributes currently bound to the thread.
	 * <p>Exposes the previously bound RequestAttributes instance, if any.
	 * Falls back to the current JSF FacesContext, if any.
	 * @return the RequestAttributes currently bound to the thread
	 * @throws IllegalStateException if no RequestAttributes object
	 * is bound to the current thread
	 * @see #setRequestAttributes
	 * @see ServletRequestAttributes
	 * @see FacesRequestAttributes
	 * @see javax.faces.context.FacesContext#getCurrentInstance()
	 */
	public static RequestAttributes currentRequestAttributes() throws IllegalStateException {
		RequestAttributes attributes = getRequestAttributes();
		if (attributes == null) {
			if (jsfPresent) {
				attributes = FacesRequestAttributesFactory.getFacesRequestAttributes();
			}
			if (attributes == null) {
				throw new IllegalStateException("No thread-bound request found: " +
						"Are you referring to request attributes outside of an actual web request, " +
						"or processing a request outside of the originally receiving thread? " +
						"If you are actually operating within a web request and still receive this message, " +
						"your code is probably running outside of DispatcherServlet/DispatcherPortlet: " +
						"In this case, use RequestContextListener or RequestContextFilter to expose the current request.");
			}
		}
		return attributes;
	}
```

This PR changes one thing: since only `RequestMappingInfoHandlerMapping` actually sets `BEST_MATCHING_PATTERN_ATTRIBUTE` on the request, only try to invoke it and its subclasses. 

The rest is a test case for the kind of dynamic handler mapping being done by a customer.