### PR TITLE
CI-App: Set CI and git tags in test spans

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/TestDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/TestDecorator.java
@@ -2,6 +2,7 @@ package datadog.trace.bootstrap.instrumentation.decorator;
 
 import datadog.trace.api.DDSpanTypes;
 import datadog.trace.api.DDTags;
+import datadog.trace.api.sampling.PrioritySampling;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import java.lang.annotation.Annotation;
@@ -12,9 +13,9 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public abstract class TestDecorator extends BaseDecorator {
-  public static final String TEST_PASS = "PASS";
-  public static final String TEST_FAIL = "FAIL";
-  public static final String TEST_SKIP = "SKIP";
+  public static final String TEST_PASS = "pass";
+  public static final String TEST_FAIL = "fail";
+  public static final String TEST_SKIP = "skip";
 
   protected abstract String testFramework();
 
@@ -33,6 +34,7 @@ public abstract class TestDecorator extends BaseDecorator {
     span.setTag(Tags.SPAN_KIND, spanKind());
     span.setTag(DDTags.SPAN_TYPE, spanType());
     span.setTag(DDTags.TEST_FRAMEWORK, testFramework());
+    span.setSamplingPriority(PrioritySampling.SAMPLER_KEEP);
     return super.afterStart(span);
   }
 

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/TestDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/TestDecorator.java
@@ -9,13 +9,58 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public abstract class TestDecorator extends BaseDecorator {
+
   public static final String TEST_PASS = "pass";
   public static final String TEST_FAIL = "fail";
   public static final String TEST_SKIP = "skip";
+
+  public static final String JENKINS = "JENKINS_URL";
+  static final String JENKINS_PROVIDER_NAME = "jenkins";
+  static final String JENKINS_PIPELINE_ID = "BUILD_TAG";
+  static final String JENKINS_PIPELINE_NUMBER = "BUILD_NUMBER";
+  static final String JENKINS_PIPELINE_URL = "BUILD_URL";
+  static final String JENKINS_JOB_URL = "JOB_URL";
+  static final String JENKINS_WORKSPACE_PATH = "WORKSPACE";
+  static final String JENKINS_GIT_REPOSITORY_URL = "GIT_URL";
+  static final String JENKINS_GIT_COMMIT = "GIT_COMMIT";
+  static final String JENKINS_GIT_BRANCH = "GIT_BRANCH";
+
+  public static final String GITLAB = "GITLAB_CI";
+  static final String GITLAB_PROVIDER_NAME = "gitlab";
+  static final String GITLAB_PIPELINE_ID = "CI_PIPELINE_ID";
+  static final String GITLAB_PIPELINE_NUMBER = "CI_PIPELINE_IID";
+  static final String GITLAB_PIPELINE_URL = "CI_PIPELINE_URL";
+  static final String GITLAB_JOB_URL = "CI_JOB_URL";
+  static final String GITLAB_WORKSPACE_PATH = "CI_PROJECT_DIR";
+  static final String GITLAB_GIT_REPOSITORY_URL = "CI_REPOSITORY_URL";
+  static final String GITLAB_GIT_COMMIT = "CI_COMMIT_SHA";
+  static final String GITLAB_GIT_BRANCH = "CI_COMMIT_BRANCH";
+  static final String GITLAB_GIT_TAG = "CI_COMMIT_TAG";
+
+  @Getter private boolean isCI;
+  @Getter private String ciProviderName;
+  @Getter private String ciPipelineId;
+  @Getter private String ciPipelineNumber;
+  @Getter private String ciPipelineUrl;
+  @Getter private String ciJobUrl;
+  @Getter private String ciWorkspacePath;
+  @Getter private String gitRepositoryUrl;
+  @Getter private String gitCommit;
+  @Getter private String gitBranch;
+  @Getter private String gitTag;
+
+  public TestDecorator() {
+    if (System.getenv(JENKINS) != null) {
+      setJenkinsData();
+    } else if (System.getenv(GITLAB) != null) {
+      setGitLabData();
+    }
+  }
 
   protected abstract String testFramework();
 
@@ -35,7 +80,74 @@ public abstract class TestDecorator extends BaseDecorator {
     span.setTag(DDTags.SPAN_TYPE, spanType());
     span.setTag(DDTags.TEST_FRAMEWORK, testFramework());
     span.setSamplingPriority(PrioritySampling.SAMPLER_KEEP);
+
+    span.setTag(DDTags.CI_PROVIDER_NAME, ciProviderName);
+    span.setTag(DDTags.CI_PIPELINE_ID, ciPipelineId);
+    span.setTag(DDTags.CI_PIPELINE_NUMBER, ciPipelineNumber);
+    span.setTag(DDTags.CI_PIPELINE_URL, ciPipelineUrl);
+    span.setTag(DDTags.CI_JOB_URL, ciJobUrl);
+    span.setTag(DDTags.CI_WORKSPACE_PATH, ciWorkspacePath);
+
+    span.setTag(DDTags.GIT_REPOSITORY_URL, gitRepositoryUrl);
+    span.setTag(DDTags.GIT_COMMIT_SHA, gitCommit);
+    span.setTag(DDTags.GIT_BRANCH, normalizeRef(gitBranch));
+    span.setTag(DDTags.GIT_TAG, normalizeRef(gitTag));
+
     return super.afterStart(span);
+  }
+
+  private void setJenkinsData() {
+    isCI = true;
+    ciProviderName = JENKINS_PROVIDER_NAME;
+    ciPipelineId = System.getenv(JENKINS_PIPELINE_ID);
+    ciPipelineNumber = System.getenv(JENKINS_PIPELINE_NUMBER);
+    ciPipelineUrl = System.getenv(JENKINS_PIPELINE_URL);
+    ciJobUrl = System.getenv(JENKINS_JOB_URL);
+    ciWorkspacePath = System.getenv(JENKINS_WORKSPACE_PATH);
+    gitRepositoryUrl = System.getenv(JENKINS_GIT_REPOSITORY_URL);
+    gitCommit = System.getenv(JENKINS_GIT_COMMIT);
+
+    final String gitBranchOrTag = System.getenv(JENKINS_GIT_BRANCH);
+    if (gitBranchOrTag != null) {
+      if (gitBranchOrTag.contains("tags")) {
+        gitTag = gitBranchOrTag;
+      } else {
+        gitBranch = gitBranchOrTag;
+      }
+    }
+  }
+
+  private void setGitLabData() {
+    isCI = true;
+    ciProviderName = GITLAB_PROVIDER_NAME;
+    ciPipelineId = System.getenv(GITLAB_PIPELINE_ID);
+    ciPipelineNumber = System.getenv(GITLAB_PIPELINE_NUMBER);
+    ciPipelineUrl = System.getenv(GITLAB_PIPELINE_URL);
+    ciJobUrl = System.getenv(GITLAB_JOB_URL);
+    ciWorkspacePath = System.getenv(GITLAB_WORKSPACE_PATH);
+    gitRepositoryUrl = System.getenv(GITLAB_GIT_REPOSITORY_URL);
+    gitCommit = System.getenv(GITLAB_GIT_COMMIT);
+    gitBranch = System.getenv(GITLAB_GIT_BRANCH);
+    gitTag = System.getenv(GITLAB_GIT_TAG);
+  }
+
+  private String normalizeRef(final String rawRef) {
+    if (rawRef == null || rawRef.isEmpty()) {
+      return rawRef;
+    }
+
+    String ref = rawRef;
+    if (ref.startsWith("origin")) {
+      ref = ref.replace("origin/", "");
+    } else if (ref.startsWith("refs/heads")) {
+      ref = ref.replace("refs/heads/", "");
+    }
+
+    if (ref.startsWith("tags")) {
+      return ref.replace("tags/", "");
+    }
+
+    return ref;
   }
 
   public List<String> testNames(

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/TestDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/TestDecorator.java
@@ -2,7 +2,6 @@ package datadog.trace.bootstrap.instrumentation.decorator;
 
 import datadog.trace.api.DDSpanTypes;
 import datadog.trace.api.DDTags;
-import datadog.trace.api.sampling.PrioritySampling;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import java.lang.annotation.Annotation;
@@ -82,9 +81,6 @@ public abstract class TestDecorator extends BaseDecorator {
     span.setTag(Tags.SPAN_KIND, spanKind());
     span.setTag(DDTags.SPAN_TYPE, spanType());
     span.setTag(DDTags.TEST_FRAMEWORK, testFramework());
-
-    // All test spans need to be sent to the backend.
-    span.setSamplingPriority(PrioritySampling.SAMPLER_KEEP);
 
     span.setTag(DDTags.CI_PROVIDER_NAME, ciProviderName);
     span.setTag(DDTags.CI_PIPELINE_ID, ciPipelineId);

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/TestDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/TestDecorator.java
@@ -55,6 +55,9 @@ public abstract class TestDecorator extends BaseDecorator {
   @Getter private String gitTag;
 
   public TestDecorator() {
+    // CI and Git information is obtained
+    // from different environment variables
+    // depending on which CI server is running the build.
     if (System.getenv(JENKINS) != null) {
       setJenkinsData();
     } else if (System.getenv(GITLAB) != null) {
@@ -79,6 +82,8 @@ public abstract class TestDecorator extends BaseDecorator {
     span.setTag(Tags.SPAN_KIND, spanKind());
     span.setTag(DDTags.SPAN_TYPE, spanType());
     span.setTag(DDTags.TEST_FRAMEWORK, testFramework());
+
+    // All test spans need to be sent to the backend.
     span.setSamplingPriority(PrioritySampling.SAMPLER_KEEP);
 
     span.setTag(DDTags.CI_PROVIDER_NAME, ciProviderName);

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/BaseDecoratorTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/BaseDecoratorTest.groovy
@@ -28,6 +28,7 @@ class BaseDecoratorTest extends DDSpecification {
     _ * span.setTag(_, _) // Want to allow other calls from child implementations.
     _ * span.setServiceName(_)
     _ * span.setOperationName(_)
+    _ * span.setSamplingPriority(_)
     0 * _
   }
 

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/BaseDecoratorTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/BaseDecoratorTest.groovy
@@ -28,7 +28,6 @@ class BaseDecoratorTest extends DDSpecification {
     _ * span.setTag(_, _) // Want to allow other calls from child implementations.
     _ * span.setServiceName(_)
     _ * span.setOperationName(_)
-    _ * span.setSamplingPriority(_)
     0 * _
   }
 

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/TestDecoratorTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/TestDecoratorTest.groovy
@@ -1,10 +1,38 @@
 package datadog.trace.bootstrap.instrumentation.decorator
 
 import datadog.trace.api.DDTags
+import datadog.trace.api.sampling.PrioritySampling
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan
 import datadog.trace.bootstrap.instrumentation.api.Tags
+import org.junit.Rule
+import org.junit.contrib.java.lang.system.EnvironmentVariables
+
+import static datadog.trace.bootstrap.instrumentation.decorator.TestDecorator.GITLAB
+import static datadog.trace.bootstrap.instrumentation.decorator.TestDecorator.GITLAB_GIT_BRANCH
+import static datadog.trace.bootstrap.instrumentation.decorator.TestDecorator.GITLAB_GIT_COMMIT
+import static datadog.trace.bootstrap.instrumentation.decorator.TestDecorator.GITLAB_GIT_REPOSITORY_URL
+import static datadog.trace.bootstrap.instrumentation.decorator.TestDecorator.GITLAB_GIT_TAG
+import static datadog.trace.bootstrap.instrumentation.decorator.TestDecorator.GITLAB_JOB_URL
+import static datadog.trace.bootstrap.instrumentation.decorator.TestDecorator.GITLAB_PIPELINE_ID
+import static datadog.trace.bootstrap.instrumentation.decorator.TestDecorator.GITLAB_PIPELINE_NUMBER
+import static datadog.trace.bootstrap.instrumentation.decorator.TestDecorator.GITLAB_PIPELINE_URL
+import static datadog.trace.bootstrap.instrumentation.decorator.TestDecorator.GITLAB_PROVIDER_NAME
+import static datadog.trace.bootstrap.instrumentation.decorator.TestDecorator.GITLAB_WORKSPACE_PATH
+import static datadog.trace.bootstrap.instrumentation.decorator.TestDecorator.JENKINS
+import static datadog.trace.bootstrap.instrumentation.decorator.TestDecorator.JENKINS_GIT_BRANCH
+import static datadog.trace.bootstrap.instrumentation.decorator.TestDecorator.JENKINS_GIT_COMMIT
+import static datadog.trace.bootstrap.instrumentation.decorator.TestDecorator.JENKINS_GIT_REPOSITORY_URL
+import static datadog.trace.bootstrap.instrumentation.decorator.TestDecorator.JENKINS_JOB_URL
+import static datadog.trace.bootstrap.instrumentation.decorator.TestDecorator.JENKINS_PIPELINE_ID
+import static datadog.trace.bootstrap.instrumentation.decorator.TestDecorator.JENKINS_PIPELINE_NUMBER
+import static datadog.trace.bootstrap.instrumentation.decorator.TestDecorator.JENKINS_PIPELINE_URL
+import static datadog.trace.bootstrap.instrumentation.decorator.TestDecorator.JENKINS_PROVIDER_NAME
+import static datadog.trace.bootstrap.instrumentation.decorator.TestDecorator.JENKINS_WORKSPACE_PATH
 
 class TestDecoratorTest extends BaseDecoratorTest {
+
+  @Rule
+  public final EnvironmentVariables environmentVariables = new EnvironmentVariables()
 
   def span = Mock(AgentSpan)
 
@@ -20,6 +48,7 @@ class TestDecoratorTest extends BaseDecoratorTest {
     1 * span.setTag(Tags.SPAN_KIND, decorator.spanKind())
     1 * span.setTag(DDTags.SPAN_TYPE, decorator.spanType())
     1 * span.setTag(DDTags.TEST_FRAMEWORK, decorator.testFramework())
+    1 * span.setSamplingPriority(PrioritySampling.SAMPLER_KEEP)
     _ * span.setTag(_, _) // Want to allow other calls from child implementations.
     _ * span.setServiceName(_)
     _ * span.setOperationName(_)
@@ -27,6 +56,100 @@ class TestDecoratorTest extends BaseDecoratorTest {
 
     where:
     serviceName << ["test-service", "other-service", null]
+  }
+  
+  def "test afterStart in Jenkins"() {
+    setup:
+    environmentVariables.set(JENKINS, "jenkins")
+    environmentVariables.set(JENKINS_PIPELINE_ID, "jenkins-pipeline-id")
+    environmentVariables.set(JENKINS_PIPELINE_NUMBER, "jenkins-pipeline-number")
+    environmentVariables.set(JENKINS_PIPELINE_URL, "jenkins-pipeline-url")
+    environmentVariables.set(JENKINS_JOB_URL, "jenkins-job-url")
+    environmentVariables.set(JENKINS_WORKSPACE_PATH, "jenkins-workspace-path")
+    environmentVariables.set(JENKINS_GIT_REPOSITORY_URL, "jenkins-git-repo-url")
+    environmentVariables.set(JENKINS_GIT_COMMIT, "jenkins-git-commit")
+    environmentVariables.set(JENKINS_GIT_BRANCH, jenkinsBranch)
+    def decorator = newDecorator()
+
+    when:
+    decorator.afterStart(span)
+
+    then:
+    1 * span.setTag(Tags.COMPONENT, "test-component")
+    1 * span.setTag(Tags.SPAN_KIND, decorator.spanKind())
+    1 * span.setTag(DDTags.SPAN_TYPE, decorator.spanType())
+    1 * span.setTag(DDTags.TEST_FRAMEWORK, decorator.testFramework())
+    1 * span.setTag(DDTags.CI_PROVIDER_NAME, JENKINS_PROVIDER_NAME)
+    1 * span.setTag(DDTags.CI_PIPELINE_ID, "jenkins-pipeline-id")
+    1 * span.setTag(DDTags.CI_PIPELINE_NUMBER, "jenkins-pipeline-number")
+    1 * span.setTag(DDTags.CI_PIPELINE_URL, "jenkins-pipeline-url")
+    1 * span.setTag(DDTags.CI_JOB_URL, "jenkins-job-url")
+    1 * span.setTag(DDTags.CI_WORKSPACE_PATH, "jenkins-workspace-path")
+    1 * span.setTag(DDTags.GIT_REPOSITORY_URL, "jenkins-git-repo-url")
+    1 * span.setTag(DDTags.GIT_COMMIT_SHA, "jenkins-git-commit")
+    1 * span.setTag(DDTags.GIT_BRANCH, spanTagBranch)
+    1 * span.setTag(DDTags.GIT_TAG, spanTagTag)
+    1 * span.setSamplingPriority(PrioritySampling.SAMPLER_KEEP)
+    _ * span.setTag(_, _) // Want to allow other calls from child implementations.
+    _ * span.setServiceName(_)
+    _ * span.setOperationName(_)
+    0 * _
+
+    where:
+    jenkinsBranch            | spanTagBranch | spanTagTag
+    "origin/master"          | "master"      | null
+    "refs/heads/master"      | "master"      | null
+    "refs/heads/feature/one" | "feature/one" | null
+    "origin/tags/0.1.0"      | null          | "0.1.0"
+    "refs/heads/tags/0.1.0"  | null          | "0.1.0"
+  }
+
+  def "test afterStart in GitLab"() {
+    setup:
+    environmentVariables.set(GITLAB, "gitlab")
+    environmentVariables.set(GITLAB_PIPELINE_ID, "gitlab-pipeline-id")
+    environmentVariables.set(GITLAB_PIPELINE_NUMBER, "gitlab-pipeline-number")
+    environmentVariables.set(GITLAB_PIPELINE_URL, "gitlab-pipeline-url")
+    environmentVariables.set(GITLAB_JOB_URL, "gitlab-job-url")
+    environmentVariables.set(GITLAB_WORKSPACE_PATH, "gitlab-workspace-path")
+    environmentVariables.set(GITLAB_GIT_REPOSITORY_URL, "gitlab-git-repo-url")
+    environmentVariables.set(GITLAB_GIT_COMMIT, "gitlab-git-commit")
+    environmentVariables.set(GITLAB_GIT_BRANCH, gitlabBranch)
+    environmentVariables.set(GITLAB_GIT_TAG, gitlabTag)
+    def decorator = newDecorator()
+
+    when:
+    decorator.afterStart(span)
+
+    then:
+    1 * span.setTag(Tags.COMPONENT, "test-component")
+    1 * span.setTag(Tags.SPAN_KIND, decorator.spanKind())
+    1 * span.setTag(DDTags.SPAN_TYPE, decorator.spanType())
+    1 * span.setTag(DDTags.TEST_FRAMEWORK, decorator.testFramework())
+    1 * span.setTag(DDTags.CI_PROVIDER_NAME, GITLAB_PROVIDER_NAME)
+    1 * span.setTag(DDTags.CI_PIPELINE_ID, "gitlab-pipeline-id")
+    1 * span.setTag(DDTags.CI_PIPELINE_NUMBER, "gitlab-pipeline-number")
+    1 * span.setTag(DDTags.CI_PIPELINE_URL, "gitlab-pipeline-url")
+    1 * span.setTag(DDTags.CI_JOB_URL, "gitlab-job-url")
+    1 * span.setTag(DDTags.CI_WORKSPACE_PATH, "gitlab-workspace-path")
+    1 * span.setTag(DDTags.GIT_REPOSITORY_URL, "gitlab-git-repo-url")
+    1 * span.setTag(DDTags.GIT_COMMIT_SHA, "gitlab-git-commit")
+    1 * span.setTag(DDTags.GIT_BRANCH, spanTagBranch)
+    1 * span.setTag(DDTags.GIT_TAG, spanTagTag)
+    1 * span.setSamplingPriority(PrioritySampling.SAMPLER_KEEP)
+    _ * span.setTag(_, _) // Want to allow other calls from child implementations.
+    _ * span.setServiceName(_)
+    _ * span.setOperationName(_)
+    0 * _
+
+    where:
+    gitlabBranch             | gitlabTag               | spanTagBranch | spanTagTag
+    "origin/master"          | null                    | "master"      | null
+    "refs/heads/master"      | null                    | "master"      | null
+    "refs/heads/feature/one" | null                    | "feature/one" | null
+    null                     | "origin/tags/0.1.0"     | null          | "0.1.0"
+    null                     | "refs/heads/tags/0.1.0" | null          | "0.1.0"
+    null                     | "0.1.0"                 | null          | "0.1.0"
   }
 
   def "test beforeFinish"() {
@@ -36,7 +159,6 @@ class TestDecoratorTest extends BaseDecoratorTest {
     then:
     0 * _
   }
-
 
   @Override
   def newDecorator() {

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/TestDecoratorTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/TestDecoratorTest.groovy
@@ -1,7 +1,6 @@
 package datadog.trace.bootstrap.instrumentation.decorator
 
 import datadog.trace.api.DDTags
-import datadog.trace.api.sampling.PrioritySampling
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import org.junit.Rule
@@ -48,7 +47,6 @@ class TestDecoratorTest extends BaseDecoratorTest {
     1 * span.setTag(Tags.SPAN_KIND, decorator.spanKind())
     1 * span.setTag(DDTags.SPAN_TYPE, decorator.spanType())
     1 * span.setTag(DDTags.TEST_FRAMEWORK, decorator.testFramework())
-    1 * span.setSamplingPriority(PrioritySampling.SAMPLER_KEEP)
     _ * span.setTag(_, _) // Want to allow other calls from child implementations.
     _ * span.setServiceName(_)
     _ * span.setOperationName(_)
@@ -57,7 +55,7 @@ class TestDecoratorTest extends BaseDecoratorTest {
     where:
     serviceName << ["test-service", "other-service", null]
   }
-  
+
   def "test afterStart in Jenkins"() {
     setup:
     environmentVariables.set(JENKINS, "jenkins")
@@ -89,7 +87,6 @@ class TestDecoratorTest extends BaseDecoratorTest {
     1 * span.setTag(DDTags.GIT_COMMIT_SHA, "jenkins-git-commit")
     1 * span.setTag(DDTags.GIT_BRANCH, spanTagBranch)
     1 * span.setTag(DDTags.GIT_TAG, spanTagTag)
-    1 * span.setSamplingPriority(PrioritySampling.SAMPLER_KEEP)
     _ * span.setTag(_, _) // Want to allow other calls from child implementations.
     _ * span.setServiceName(_)
     _ * span.setOperationName(_)
@@ -136,7 +133,6 @@ class TestDecoratorTest extends BaseDecoratorTest {
     1 * span.setTag(DDTags.GIT_COMMIT_SHA, "gitlab-git-commit")
     1 * span.setTag(DDTags.GIT_BRANCH, spanTagBranch)
     1 * span.setTag(DDTags.GIT_TAG, spanTagTag)
-    1 * span.setSamplingPriority(PrioritySampling.SAMPLER_KEEP)
     _ * span.setTag(_, _) // Want to allow other calls from child implementations.
     _ * span.setServiceName(_)
     _ * span.setOperationName(_)

--- a/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4Decorator.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4Decorator.java
@@ -62,8 +62,12 @@ public class JUnit4Decorator extends TestDecorator {
   }
 
   public void onTestIgnored(
-      final AgentSpan span, final Description description, final String testName) {
+      final AgentSpan span,
+      final Description description,
+      final String testName,
+      final String reason) {
     onTestStart(span, description, testName);
     span.setTag(DDTags.TEST_STATUS, TEST_SKIP);
+    span.setTag(DDTags.TEST_SKIP_REASON, reason);
   }
 }

--- a/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/TracingListener.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/TracingListener.java
@@ -10,6 +10,7 @@ import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.context.TraceScope;
 import java.util.ArrayList;
 import java.util.List;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.Description;
 import org.junit.runner.notification.Failure;
@@ -81,10 +82,13 @@ public class TracingListener extends RunListener {
       testNames.addAll(DECORATE.testNames(description.getTestClass(), Test.class));
     }
 
+    final Ignore ignore = description.getAnnotation(Ignore.class);
+    final String reason = ignore != null ? ignore.value() : null;
+
     for (final String testName : testNames) {
       final AgentSpan span = startSpan("junit.test");
       DECORATE.afterStart(span);
-      DECORATE.onTestIgnored(span, description, testName);
+      DECORATE.onTestIgnored(span, description, testName, reason);
       DECORATE.beforeFinish(span);
       span.finish(span.getStartTime());
     }

--- a/dd-java-agent/instrumentation/junit-4.10/src/test/groovy/JUnit4Test.groovy
+++ b/dd-java-agent/instrumentation/junit-4.10/src/test/groovy/JUnit4Test.groovy
@@ -1,4 +1,5 @@
 import datadog.trace.agent.test.base.TestFrameworkTest
+import datadog.trace.api.DDTags
 import datadog.trace.api.DisableTestTrace
 import datadog.trace.bootstrap.instrumentation.decorator.TestDecorator
 import datadog.trace.instrumentation.junit4.JUnit4Decorator
@@ -86,9 +87,12 @@ class JUnit4Test extends TestFrameworkTest {
     expect:
     assertTraces(1) {
       trace(0, 1) {
-        testSpan(it, 0, "org.example.TestSkipped", "test_skipped", TestDecorator.TEST_SKIP)
+        testSpan(it, 0, "org.example.TestSkipped", "test_skipped", TestDecorator.TEST_SKIP, testTags)
       }
     }
+
+    where:
+    testTags = ["$DDTags.TEST_SKIP_REASON": "Ignore reason in test"]
   }
 
   def "test class skipped generated spans"() {
@@ -98,9 +102,12 @@ class JUnit4Test extends TestFrameworkTest {
     expect:
     assertTraces(1) {
       trace(0, 1) {
-        testSpan(it, 0, "org.example.TestSkippedClass", "test_class_skipped", TestDecorator.TEST_SKIP)
+        testSpan(it, 0, "org.example.TestSkippedClass", "test_class_skipped", TestDecorator.TEST_SKIP, testTags)
       }
     }
+
+    where:
+    testTags = ["$DDTags.TEST_SKIP_REASON": "Ignore reason in class"]
   }
 
   @Override

--- a/dd-java-agent/instrumentation/junit-4.10/src/test/groovy/JUnit4Test.groovy
+++ b/dd-java-agent/instrumentation/junit-4.10/src/test/groovy/JUnit4Test.groovy
@@ -117,4 +117,59 @@ class JUnit4Test extends TestFrameworkTest {
   String component() {
     return JUnit4Decorator.DECORATE.component()
   }
+
+  @Override
+  boolean isCI() {
+    return JUnit4Decorator.DECORATE.isCI()
+  }
+
+  @Override
+  String ciProviderName() {
+    return JUnit4Decorator.DECORATE.getCiProviderName()
+  }
+
+  @Override
+  String ciPipelineId() {
+    return JUnit4Decorator.DECORATE.getCiPipelineId()
+  }
+
+  @Override
+  String ciPipelineNumber() {
+    return JUnit4Decorator.DECORATE.getCiPipelineNumber()
+  }
+
+  @Override
+  String ciPipelineUrl() {
+    return JUnit4Decorator.DECORATE.getCiPipelineUrl()
+  }
+
+  @Override
+  String ciJobUrl() {
+    return JUnit4Decorator.DECORATE.getCiJobUrl()
+  }
+
+  @Override
+  String ciWorkspacePath() {
+    return JUnit4Decorator.DECORATE.getCiWorkspacePath()
+  }
+
+  @Override
+  String gitRepositoryUrl() {
+    return JUnit4Decorator.DECORATE.getGitRepositoryUrl()
+  }
+
+  @Override
+  String gitCommit() {
+    return JUnit4Decorator.DECORATE.getGitCommit()
+  }
+
+  @Override
+  String gitBranch() {
+    return JUnit4Decorator.DECORATE.getGitBranch()
+  }
+
+  @Override
+  String gitTag() {
+    return JUnit4Decorator.DECORATE.getGitTag()
+  }
 }

--- a/dd-java-agent/instrumentation/junit-5.3/src/test/groovy/JUnit5Test.groovy
+++ b/dd-java-agent/instrumentation/junit-5.3/src/test/groovy/JUnit5Test.groovy
@@ -219,4 +219,59 @@ class JUnit5Test extends TestFrameworkTest {
   String component() {
     return JUnit5Decorator.DECORATE.component()
   }
+
+  @Override
+  boolean isCI() {
+    return JUnit5Decorator.DECORATE.isCI()
+  }
+
+  @Override
+  String ciProviderName() {
+    return JUnit5Decorator.DECORATE.getCiProviderName()
+  }
+
+  @Override
+  String ciPipelineId() {
+    return JUnit5Decorator.DECORATE.getCiPipelineId()
+  }
+
+  @Override
+  String ciPipelineNumber() {
+    return JUnit5Decorator.DECORATE.getCiPipelineNumber()
+  }
+
+  @Override
+  String ciPipelineUrl() {
+    return JUnit5Decorator.DECORATE.getCiPipelineUrl()
+  }
+
+  @Override
+  String ciJobUrl() {
+    return JUnit5Decorator.DECORATE.getCiJobUrl()
+  }
+
+  @Override
+  String ciWorkspacePath() {
+    return JUnit5Decorator.DECORATE.getCiWorkspacePath()
+  }
+
+  @Override
+  String gitRepositoryUrl() {
+    return JUnit5Decorator.DECORATE.getGitRepositoryUrl()
+  }
+
+  @Override
+  String gitCommit() {
+    return JUnit5Decorator.DECORATE.getGitCommit()
+  }
+
+  @Override
+  String gitBranch() {
+    return JUnit5Decorator.DECORATE.getGitBranch()
+  }
+
+  @Override
+  String gitTag() {
+    return JUnit5Decorator.DECORATE.getGitTag()
+  }
 }

--- a/dd-java-agent/instrumentation/testng-6.4/src/main/java/datadog/trace/instrumentation/testng/TestNGDecorator.java
+++ b/dd-java-agent/instrumentation/testng-6.4/src/main/java/datadog/trace/instrumentation/testng/TestNGDecorator.java
@@ -51,5 +51,9 @@ public class TestNGDecorator extends TestDecorator {
 
   public void onTestIgnored(final AgentSpan span, final ITestResult result) {
     span.setTag(DDTags.TEST_STATUS, TEST_SKIP);
+    // Typically the way of skipping a TestNG test is throwing a SkipException
+    if (result.getThrowable() != null) {
+      span.setTag(DDTags.TEST_SKIP_REASON, result.getThrowable().getMessage());
+    }
   }
 }

--- a/dd-java-agent/instrumentation/testng-6.4/src/test/groovy/TestNGTest.groovy
+++ b/dd-java-agent/instrumentation/testng-6.4/src/test/groovy/TestNGTest.groovy
@@ -146,4 +146,59 @@ class TestNGTest extends TestFrameworkTest {
   String component() {
     return TestNGDecorator.DECORATE.component()
   }
+
+  @Override
+  boolean isCI() {
+    return TestNGDecorator.DECORATE.isCI()
+  }
+
+  @Override
+  String ciProviderName() {
+    return TestNGDecorator.DECORATE.getCiProviderName()
+  }
+
+  @Override
+  String ciPipelineId() {
+    return TestNGDecorator.DECORATE.getCiPipelineId()
+  }
+
+  @Override
+  String ciPipelineNumber() {
+    return TestNGDecorator.DECORATE.getCiPipelineNumber()
+  }
+
+  @Override
+  String ciPipelineUrl() {
+    return TestNGDecorator.DECORATE.getCiPipelineUrl()
+  }
+
+  @Override
+  String ciJobUrl() {
+    return TestNGDecorator.DECORATE.getCiJobUrl()
+  }
+
+  @Override
+  String ciWorkspacePath() {
+    return TestNGDecorator.DECORATE.getCiWorkspacePath()
+  }
+
+  @Override
+  String gitRepositoryUrl() {
+    return TestNGDecorator.DECORATE.getGitRepositoryUrl()
+  }
+
+  @Override
+  String gitCommit() {
+    return TestNGDecorator.DECORATE.getGitCommit()
+  }
+
+  @Override
+  String gitBranch() {
+    return TestNGDecorator.DECORATE.getGitBranch()
+  }
+
+  @Override
+  String gitTag() {
+    return TestNGDecorator.DECORATE.getGitTag()
+  }
 }

--- a/dd-java-agent/instrumentation/testng-6.4/src/test/groovy/TestNGTest.groovy
+++ b/dd-java-agent/instrumentation/testng-6.4/src/test/groovy/TestNGTest.groovy
@@ -1,4 +1,5 @@
 import datadog.trace.agent.test.base.TestFrameworkTest
+import datadog.trace.api.DDTags
 import datadog.trace.bootstrap.instrumentation.decorator.TestDecorator
 import datadog.trace.instrumentation.testng.TestNGDecorator
 import org.example.TestError
@@ -127,9 +128,12 @@ class TestNGTest extends TestFrameworkTest {
     expect:
     assertTraces(1) {
       trace(0, 1) {
-        testSpan(it, 0, "org.example.TestSkipped", "test_skipped", TestDecorator.TEST_SKIP)
+        testSpan(it, 0, "org.example.TestSkipped", "test_skipped", TestDecorator.TEST_SKIP, testTags)
       }
     }
+
+    where:
+    testTags = ["$DDTags.TEST_SKIP_REASON": "Ignore reason in test"]
   }
 
   @Override

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/TestFrameworkTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/TestFrameworkTest.groovy
@@ -43,6 +43,19 @@ abstract class TestFrameworkTest extends AgentTestRunner {
           errorTags(exception.class, exception.message)
         }
 
+        if (isCI) {
+          "$DDTags.CI_PROVIDER_NAME" ciProviderName
+          "$DDTags.CI_PIPELINE_ID" ciPipelineId
+          "$DDTags.CI_PIPELINE_NUMBER" ciPipelineNumber
+          "$DDTags.CI_PIPELINE_URL" ciPipelineUrl
+          "$DDTags.CI_JOB_URL" ciJobUrl
+          "$DDTags.CI_WORKSPACE_PATH" ciWorkspacePath
+          "$DDTags.GIT_REPOSITORY_URL" gitRepositoryUrl
+          "$DDTags.GIT_COMMIT_SHA" gitCommit
+          "$DDTags.GIT_BRANCH" gitBranch
+          "$DDTags.GIT_TAG" gitTag
+        }
+        
         defaultTags()
       }
     }
@@ -51,9 +64,55 @@ abstract class TestFrameworkTest extends AgentTestRunner {
   @Shared
   String component = component()
 
+  @Shared
+  boolean isCI = isCI()
+  @Shared
+  String ciProviderName = ciProviderName()
+  @Shared
+  String ciPipelineId = ciPipelineId()
+  @Shared
+  String ciPipelineNumber = ciPipelineNumber()
+  @Shared
+  String ciPipelineUrl = ciPipelineUrl()
+  @Shared
+  String ciJobUrl = ciJobUrl()
+  @Shared
+  String ciWorkspacePath = ciWorkspacePath()
+  @Shared
+  String gitRepositoryUrl = gitRepositoryUrl()
+  @Shared
+  String gitCommit = gitCommit()
+  @Shared
+  String gitBranch = gitBranch()
+  @Shared
+  String gitTag = gitTag()
+
   abstract String expectedOperationName()
 
   abstract String expectedTestFramework()
 
   abstract String component()
+
+  abstract boolean isCI()
+
+  abstract String ciProviderName()
+
+  abstract String ciPipelineId()
+
+  abstract String ciPipelineNumber()
+
+  abstract String ciPipelineUrl()
+
+  abstract String ciJobUrl()
+
+  abstract String ciWorkspacePath()
+
+  abstract String gitRepositoryUrl()
+
+  abstract String gitCommit()
+
+  abstract String gitBranch()
+
+  abstract String gitTag()
+
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/DDTags.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/DDTags.java
@@ -24,6 +24,18 @@ public class DDTags {
   public static final String TEST_FRAMEWORK = "test.framework";
   public static final String TEST_SKIP_REASON = "test.skip_reason";
 
+  public static final String CI_PROVIDER_NAME = "ci.provider.name";
+  public static final String CI_PIPELINE_ID = "ci.pipeline.id";
+  public static final String CI_PIPELINE_NUMBER = "ci.pipeline.number";
+  public static final String CI_PIPELINE_URL = "ci.pipeline.url";
+  public static final String CI_JOB_URL = "ci.job.url";
+  public static final String CI_WORKSPACE_PATH = "ci.workspace_path";
+
+  public static final String GIT_REPOSITORY_URL = "git.repository_url";
+  public static final String GIT_COMMIT_SHA = "git.commit_sha";
+  public static final String GIT_BRANCH = "git.branch";
+  public static final String GIT_TAG = "git.tag";
+
   public static final String ANALYTICS_SAMPLE_RATE = "_dd1.sr.eausr";
   @Deprecated public static final String EVENT_SAMPLE_RATE = ANALYTICS_SAMPLE_RATE;
 


### PR DESCRIPTION
**Description**
- Set `CI` and `Git` tags in test spans related to `Jenkins`.
- Set `CI` and `Git` tags in test spans related to `GitLab Pipelines`.

The `datadog.trace.bootstrap.instrumentation.decorator.TestDecorator` class is modified to obtain the CI and Git information available in the environment variables for the following CI providers:
* `Jenkins`
* `GitLab Pipelines`