### PR TITLE
avoid parsing URIs unnecessarily

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/api/DefaultURIDataAdapter.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/api/DefaultURIDataAdapter.java
@@ -1,0 +1,42 @@
+package datadog.trace.bootstrap.instrumentation.api;
+
+import java.net.URI;
+
+public class DefaultURIDataAdapter implements URIDataAdapter {
+
+  private final URI uri;
+
+  public DefaultURIDataAdapter(URI uri) {
+    this.uri = uri;
+  }
+
+  @Override
+  public String scheme() {
+    return uri.getScheme();
+  }
+
+  @Override
+  public String host() {
+    return uri.getHost();
+  }
+
+  @Override
+  public int port() {
+    return uri.getPort();
+  }
+
+  @Override
+  public String path() {
+    return uri.getPath();
+  }
+
+  @Override
+  public String fragment() {
+    return uri.getFragment();
+  }
+
+  @Override
+  public String query() {
+    return uri.getQuery();
+  }
+}

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/api/URIDataAdapter.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/api/URIDataAdapter.java
@@ -1,0 +1,16 @@
+package datadog.trace.bootstrap.instrumentation.api;
+
+public interface URIDataAdapter {
+
+  String scheme();
+
+  String host();
+
+  int port();
+
+  String path();
+
+  String fragment();
+
+  String query();
+}

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecoratorTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecoratorTest.groovy
@@ -3,7 +3,9 @@ package datadog.trace.bootstrap.instrumentation.decorator
 
 import datadog.trace.api.DDTags
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan
+import datadog.trace.bootstrap.instrumentation.api.DefaultURIDataAdapter
 import datadog.trace.bootstrap.instrumentation.api.Tags
+import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter
 
 import static datadog.trace.agent.test.utils.ConfigUtils.withConfigOverride
 import static datadog.trace.api.config.TraceInstrumentationConfig.HTTP_SERVER_TAG_QUERY_STRING
@@ -164,8 +166,8 @@ class HttpServerDecoratorTest extends ServerDecoratorTest {
       }
 
       @Override
-      protected URI url(Map m) {
-        return m.url
+      protected URIDataAdapter url(Map m) {
+        return new DefaultURIDataAdapter(m.url)
       }
 
       @Override

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/AkkaHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/AkkaHttpServerDecorator.java
@@ -2,9 +2,8 @@ package datadog.trace.instrumentation.akkahttp;
 
 import akka.http.scaladsl.model.HttpRequest;
 import akka.http.scaladsl.model.HttpResponse;
+import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
-import java.net.URI;
-import java.net.URISyntaxException;
 
 public class AkkaHttpServerDecorator
     extends HttpServerDecorator<HttpRequest, HttpRequest, HttpResponse> {
@@ -26,8 +25,8 @@ public class AkkaHttpServerDecorator
   }
 
   @Override
-  protected URI url(final HttpRequest httpRequest) throws URISyntaxException {
-    return new URI(httpRequest.uri().toString());
+  protected URIDataAdapter url(final HttpRequest httpRequest) {
+    return new UriAdapter(httpRequest.uri());
   }
 
   @Override

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/AkkaHttpServerInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/AkkaHttpServerInstrumentation.java
@@ -54,6 +54,7 @@ public final class AkkaHttpServerInstrumentation extends Instrumenter.Default {
       AkkaHttpServerInstrumentation.class.getName() + "$DatadogAsyncWrapper$2",
       packageName + ".AkkaHttpServerHeaders",
       packageName + ".AkkaHttpServerDecorator",
+      packageName + ".UriAdapter",
     };
   }
 

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/UriAdapter.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/UriAdapter.java
@@ -1,0 +1,51 @@
+package datadog.trace.instrumentation.akkahttp;
+
+import akka.http.scaladsl.model.Uri;
+import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
+import scala.Option;
+
+final class UriAdapter implements URIDataAdapter {
+
+  private final Uri uri;
+
+  UriAdapter(Uri uri) {
+    this.uri = uri;
+  }
+
+  @Override
+  public String scheme() {
+    return uri.scheme();
+  }
+
+  @Override
+  public String host() {
+    return uri.authority().host().address();
+  }
+
+  @Override
+  public int port() {
+    return uri.authority().port();
+  }
+
+  @Override
+  public String path() {
+    return uri.path().toString();
+  }
+
+  @Override
+  public String fragment() {
+    return getOrElseNull(uri.fragment());
+  }
+
+  @Override
+  public String query() {
+    return getOrElseNull(uri.rawQueryString());
+  }
+
+  private static String getOrElseNull(Option<String> optional) {
+    if (optional.nonEmpty()) {
+      return optional.get();
+    }
+    return null;
+  }
+}

--- a/dd-java-agent/instrumentation/finatra-2.9/src/main/java/datadog/trace/instrumentation/finatra/FinatraDecorator.java
+++ b/dd-java-agent/instrumentation/finatra-2.9/src/main/java/datadog/trace/instrumentation/finatra/FinatraDecorator.java
@@ -2,9 +2,10 @@ package datadog.trace.instrumentation.finatra;
 
 import com.twitter.finagle.http.Request;
 import com.twitter.finagle.http.Response;
+import datadog.trace.bootstrap.instrumentation.api.DefaultURIDataAdapter;
+import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
 import java.net.URI;
-import java.net.URISyntaxException;
 
 public class FinatraDecorator extends HttpServerDecorator<Request, Request, Response> {
   public static final FinatraDecorator DECORATE = new FinatraDecorator();
@@ -20,8 +21,8 @@ public class FinatraDecorator extends HttpServerDecorator<Request, Request, Resp
   }
 
   @Override
-  protected URI url(final Request request) throws URISyntaxException {
-    return URI.create(request.uri());
+  protected URIDataAdapter url(final Request request) {
+    return new DefaultURIDataAdapter(URI.create(request.uri()));
   }
 
   @Override

--- a/dd-java-agent/instrumentation/grizzly-2/src/main/java/datadog/trace/instrumentation/grizzly/GrizzlyDecorator.java
+++ b/dd-java-agent/instrumentation/grizzly-2/src/main/java/datadog/trace/instrumentation/grizzly/GrizzlyDecorator.java
@@ -1,8 +1,7 @@
 package datadog.trace.instrumentation.grizzly;
 
+import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
-import java.net.URI;
-import java.net.URISyntaxException;
 import org.glassfish.grizzly.http.server.Request;
 import org.glassfish.grizzly.http.server.Response;
 
@@ -15,15 +14,8 @@ public class GrizzlyDecorator extends HttpServerDecorator<Request, Request, Resp
   }
 
   @Override
-  protected URI url(final Request request) throws URISyntaxException {
-    return new URI(
-        request.getScheme(),
-        null,
-        request.getServerName(),
-        request.getServerPort(),
-        request.getRequestURI(),
-        request.getQueryString(),
-        null);
+  protected URIDataAdapter url(final Request request) {
+    return new RequestURIDataAdapter(request);
   }
 
   @Override

--- a/dd-java-agent/instrumentation/grizzly-2/src/main/java/datadog/trace/instrumentation/grizzly/GrizzlyHttpHandlerInstrumentation.java
+++ b/dd-java-agent/instrumentation/grizzly-2/src/main/java/datadog/trace/instrumentation/grizzly/GrizzlyHttpHandlerInstrumentation.java
@@ -50,6 +50,7 @@ public class GrizzlyHttpHandlerInstrumentation extends Instrumenter.Default {
     return new String[] {
       packageName + ".GrizzlyDecorator",
       packageName + ".GrizzlyRequestExtractAdapter",
+      packageName + ".RequestURIDataAdapter",
       getClass().getName() + "$SpanClosingListener"
     };
   }

--- a/dd-java-agent/instrumentation/grizzly-2/src/main/java/datadog/trace/instrumentation/grizzly/RequestURIDataAdapter.java
+++ b/dd-java-agent/instrumentation/grizzly-2/src/main/java/datadog/trace/instrumentation/grizzly/RequestURIDataAdapter.java
@@ -1,0 +1,43 @@
+package datadog.trace.instrumentation.grizzly;
+
+import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
+import org.glassfish.grizzly.http.server.Request;
+
+final class RequestURIDataAdapter implements URIDataAdapter {
+
+  private final Request request;
+
+  RequestURIDataAdapter(Request request) {
+    this.request = request;
+  }
+
+  @Override
+  public String scheme() {
+    return request.getScheme();
+  }
+
+  @Override
+  public String host() {
+    return request.getServerName();
+  }
+
+  @Override
+  public int port() {
+    return request.getServerPort();
+  }
+
+  @Override
+  public String path() {
+    return request.getRequestURI();
+  }
+
+  @Override
+  public String fragment() {
+    return "";
+  }
+
+  @Override
+  public String query() {
+    return request.getQueryString();
+  }
+}

--- a/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/main/java/datadog/trace/instrumentation/grizzlyhttp232/DefaultFilterChainInstrumentation.java
+++ b/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/main/java/datadog/trace/instrumentation/grizzlyhttp232/DefaultFilterChainInstrumentation.java
@@ -27,7 +27,11 @@ public class DefaultFilterChainInstrumentation extends Instrumenter.Default {
 
   @Override
   public String[] helperClassNames() {
-    return new String[] {packageName + ".GrizzlyDecorator", packageName + ".ExtractAdapter"};
+    return new String[] {
+      packageName + ".GrizzlyDecorator",
+      packageName + ".HTTPRequestPacketURIDataAdapter",
+      packageName + ".ExtractAdapter"
+    };
   }
 
   @Override

--- a/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/main/java/datadog/trace/instrumentation/grizzlyhttp232/GrizzlyDecorator.java
+++ b/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/main/java/datadog/trace/instrumentation/grizzlyhttp232/GrizzlyDecorator.java
@@ -8,9 +8,8 @@ import static datadog.trace.bootstrap.instrumentation.api.DDSpanNames.GRIZZLY_RE
 
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
-import java.net.URI;
-import java.net.URISyntaxException;
 import org.glassfish.grizzly.filterchain.FilterChainContext;
 import org.glassfish.grizzly.http.HttpHeader;
 import org.glassfish.grizzly.http.HttpRequestPacket;
@@ -27,14 +26,8 @@ public class GrizzlyDecorator
   }
 
   @Override
-  protected URI url(final HttpRequestPacket httpRequest) throws URISyntaxException {
-    return new URI(
-        (httpRequest.isSecure() ? "https://" : "http://")
-            + httpRequest.serverName()
-            + ":"
-            + httpRequest.getServerPort()
-            + httpRequest.getRequestURI()
-            + (httpRequest.getQueryString() != null ? "?" + httpRequest.getQueryString() : ""));
+  protected URIDataAdapter url(final HttpRequestPacket httpRequest) {
+    return new HTTPRequestPacketURIDataAdapter(httpRequest);
   }
 
   @Override

--- a/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/main/java/datadog/trace/instrumentation/grizzlyhttp232/HTTPRequestPacketURIDataAdapter.java
+++ b/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/main/java/datadog/trace/instrumentation/grizzlyhttp232/HTTPRequestPacketURIDataAdapter.java
@@ -1,0 +1,44 @@
+package datadog.trace.instrumentation.grizzlyhttp232;
+
+import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
+import java.nio.charset.StandardCharsets;
+import org.glassfish.grizzly.http.HttpRequestPacket;
+
+final class HTTPRequestPacketURIDataAdapter implements URIDataAdapter {
+
+  private final HttpRequestPacket packet;
+
+  HTTPRequestPacketURIDataAdapter(HttpRequestPacket packet) {
+    this.packet = packet;
+  }
+
+  @Override
+  public String scheme() {
+    return packet.isSecure() ? "https" : "http";
+  }
+
+  @Override
+  public String host() {
+    return packet.serverName().toString(StandardCharsets.UTF_8);
+  }
+
+  @Override
+  public int port() {
+    return packet.getServerPort();
+  }
+
+  @Override
+  public String path() {
+    return packet.getRequestURI();
+  }
+
+  @Override
+  public String fragment() {
+    return "";
+  }
+
+  @Override
+  public String query() {
+    return packet.getQueryString() != null ? packet.getQueryString() : "";
+  }
+}

--- a/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/main/java/datadog/trace/instrumentation/grizzlyhttp232/HttpCodecFilterInstrumentation.java
+++ b/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/main/java/datadog/trace/instrumentation/grizzlyhttp232/HttpCodecFilterInstrumentation.java
@@ -31,7 +31,11 @@ public final class HttpCodecFilterInstrumentation extends Instrumenter.Default {
 
   @Override
   public String[] helperClassNames() {
-    return new String[] {packageName + ".GrizzlyDecorator", packageName + ".ExtractAdapter"};
+    return new String[] {
+      packageName + ".GrizzlyDecorator",
+      packageName + ".HTTPRequestPacketURIDataAdapter",
+      packageName + ".ExtractAdapter"
+    };
   }
 
   @Override

--- a/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/main/java/datadog/trace/instrumentation/grizzlyhttp232/HttpServerFilterInstrumentation.java
+++ b/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/main/java/datadog/trace/instrumentation/grizzlyhttp232/HttpServerFilterInstrumentation.java
@@ -31,7 +31,11 @@ public class HttpServerFilterInstrumentation extends Instrumenter.Default {
 
   @Override
   public String[] helperClassNames() {
-    return new String[] {packageName + ".GrizzlyDecorator", packageName + ".ExtractAdapter"};
+    return new String[] {
+      packageName + ".GrizzlyDecorator",
+      packageName + ".HTTPRequestPacketURIDataAdapter",
+      packageName + ".ExtractAdapter"
+    };
   }
 
   @Override

--- a/dd-java-agent/instrumentation/jetty-8/src/main/java/datadog/trace/instrumentation/jetty8/JettyDecorator.java
+++ b/dd-java-agent/instrumentation/jetty-8/src/main/java/datadog/trace/instrumentation/jetty8/JettyDecorator.java
@@ -1,9 +1,8 @@
 package datadog.trace.instrumentation.jetty8;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
-import java.net.URI;
-import java.net.URISyntaxException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -27,15 +26,8 @@ public class JettyDecorator
   }
 
   @Override
-  protected URI url(final HttpServletRequest httpServletRequest) throws URISyntaxException {
-    return new URI(
-        httpServletRequest.getScheme(),
-        null,
-        httpServletRequest.getServerName(),
-        httpServletRequest.getServerPort(),
-        httpServletRequest.getRequestURI(),
-        httpServletRequest.getQueryString(),
-        null);
+  protected URIDataAdapter url(final HttpServletRequest httpServletRequest) {
+    return new RequestURIDataAdapter(httpServletRequest);
   }
 
   @Override

--- a/dd-java-agent/instrumentation/jetty-8/src/main/java/datadog/trace/instrumentation/jetty8/JettyHandlerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-8/src/main/java/datadog/trace/instrumentation/jetty8/JettyHandlerInstrumentation.java
@@ -44,6 +44,7 @@ public final class JettyHandlerInstrumentation extends Instrumenter.Default {
     return new String[] {
       packageName + ".JettyDecorator",
       packageName + ".HttpServletRequestExtractAdapter",
+      packageName + ".RequestURIDataAdapter",
       packageName + ".TagSettingAsyncListener"
     };
   }

--- a/dd-java-agent/instrumentation/jetty-8/src/main/java/datadog/trace/instrumentation/jetty8/RequestURIDataAdapter.java
+++ b/dd-java-agent/instrumentation/jetty-8/src/main/java/datadog/trace/instrumentation/jetty8/RequestURIDataAdapter.java
@@ -1,0 +1,43 @@
+package datadog.trace.instrumentation.jetty8;
+
+import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
+import javax.servlet.http.HttpServletRequest;
+
+final class RequestURIDataAdapter implements URIDataAdapter {
+
+  private final HttpServletRequest request;
+
+  RequestURIDataAdapter(HttpServletRequest request) {
+    this.request = request;
+  }
+
+  @Override
+  public String scheme() {
+    return request.getScheme();
+  }
+
+  @Override
+  public String host() {
+    return request.getServerName();
+  }
+
+  @Override
+  public int port() {
+    return request.getServerPort();
+  }
+
+  @Override
+  public String path() {
+    return request.getRequestURI();
+  }
+
+  @Override
+  public String fragment() {
+    return "";
+  }
+
+  @Override
+  public String query() {
+    return request.getQueryString();
+  }
+}

--- a/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/server/NettyHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/server/NettyHttpServerDecorator.java
@@ -2,11 +2,12 @@ package datadog.trace.instrumentation.netty38.server;
 
 import static org.jboss.netty.handler.codec.http.HttpHeaders.Names.HOST;
 
+import datadog.trace.bootstrap.instrumentation.api.DefaultURIDataAdapter;
+import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.net.URI;
-import java.net.URISyntaxException;
 import lombok.extern.slf4j.Slf4j;
 import org.jboss.netty.channel.Channel;
 import org.jboss.netty.handler.codec.http.HttpRequest;
@@ -33,12 +34,13 @@ public class NettyHttpServerDecorator
   }
 
   @Override
-  protected URI url(final HttpRequest request) throws URISyntaxException {
-    final URI uri = new URI(request.getUri());
+  protected URIDataAdapter url(final HttpRequest request) {
+    final URI uri = URI.create(request.getUri());
     if ((uri.getHost() == null || uri.getHost().equals("")) && request.headers().contains(HOST)) {
-      return new URI("http://" + request.headers().get(HOST) + request.getUri());
+      return new DefaultURIDataAdapter(
+          URI.create("http://" + request.headers().get(HOST) + request.getUri()));
     } else {
-      return uri;
+      return new DefaultURIDataAdapter(uri);
     }
   }
 

--- a/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/server/NettyHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/server/NettyHttpServerDecorator.java
@@ -2,6 +2,8 @@ package datadog.trace.instrumentation.netty40.server;
 
 import static io.netty.handler.codec.http.HttpHeaders.Names.HOST;
 
+import datadog.trace.bootstrap.instrumentation.api.DefaultURIDataAdapter;
+import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
 import io.netty.channel.Channel;
 import io.netty.handler.codec.http.HttpRequest;
@@ -9,7 +11,6 @@ import io.netty.handler.codec.http.HttpResponse;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.net.URI;
-import java.net.URISyntaxException;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -33,12 +34,13 @@ public class NettyHttpServerDecorator
   }
 
   @Override
-  protected URI url(final HttpRequest request) throws URISyntaxException {
-    final URI uri = new URI(request.getUri());
+  protected URIDataAdapter url(final HttpRequest request) {
+    final URI uri = URI.create(request.getUri());
     if ((uri.getHost() == null || uri.getHost().equals("")) && request.headers().contains(HOST)) {
-      return new URI("http://" + request.headers().get(HOST) + request.getUri());
+      return new DefaultURIDataAdapter(
+          URI.create("http://" + request.headers().get(HOST) + request.getUri()));
     } else {
-      return uri;
+      return new DefaultURIDataAdapter(uri);
     }
   }
 

--- a/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/server/NettyHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/server/NettyHttpServerDecorator.java
@@ -2,6 +2,8 @@ package datadog.trace.instrumentation.netty41.server;
 
 import static io.netty.handler.codec.http.HttpHeaderNames.HOST;
 
+import datadog.trace.bootstrap.instrumentation.api.DefaultURIDataAdapter;
+import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
 import io.netty.channel.Channel;
 import io.netty.handler.codec.http.HttpRequest;
@@ -9,7 +11,6 @@ import io.netty.handler.codec.http.HttpResponse;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.net.URI;
-import java.net.URISyntaxException;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -33,12 +34,13 @@ public class NettyHttpServerDecorator
   }
 
   @Override
-  protected URI url(final HttpRequest request) throws URISyntaxException {
-    final URI uri = new URI(request.uri());
+  protected URIDataAdapter url(final HttpRequest request) {
+    final URI uri = URI.create(request.uri());
     if ((uri.getHost() == null || uri.getHost().equals("")) && request.headers().contains(HOST)) {
-      return new URI("http://" + request.headers().get(HOST) + request.uri());
+      return new DefaultURIDataAdapter(
+          URI.create("http://" + request.headers().get(HOST) + request.getUri()));
     } else {
-      return uri;
+      return new DefaultURIDataAdapter(uri);
     }
   }
 

--- a/dd-java-agent/instrumentation/play-2.3/src/main/java/datadog/trace/instrumentation/play23/PlayInstrumentation.java
+++ b/dd-java-agent/instrumentation/play-2.3/src/main/java/datadog/trace/instrumentation/play23/PlayInstrumentation.java
@@ -38,6 +38,7 @@ public final class PlayInstrumentation extends Instrumenter.Default {
       packageName + ".PlayHttpServerDecorator",
       packageName + ".RequestCompleteCallback",
       packageName + ".PlayHeaders",
+      packageName + ".RequestURIDataAdapter"
     };
   }
 

--- a/dd-java-agent/instrumentation/play-2.3/src/main/java8/datadog/trace/instrumentation/play23/PlayHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/play-2.3/src/main/java8/datadog/trace/instrumentation/play23/PlayHttpServerDecorator.java
@@ -3,11 +3,10 @@ package datadog.trace.instrumentation.play23;
 import datadog.trace.api.DDTags;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
+import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.UndeclaredThrowableException;
-import java.net.URI;
-import java.net.URISyntaxException;
 import lombok.extern.slf4j.Slf4j;
 import play.api.mvc.Request;
 import play.api.mvc.Result;
@@ -33,8 +32,8 @@ public class PlayHttpServerDecorator extends HttpServerDecorator<Request, Reques
   }
 
   @Override
-  protected URI url(final Request request) throws URISyntaxException {
-    return new URI((request.secure() ? "https://" : "http://") + request.host() + request.uri());
+  protected URIDataAdapter url(final Request request) {
+    return new RequestURIDataAdapter(request);
   }
 
   @Override

--- a/dd-java-agent/instrumentation/play-2.3/src/main/java8/datadog/trace/instrumentation/play23/RequestURIDataAdapter.java
+++ b/dd-java-agent/instrumentation/play-2.3/src/main/java8/datadog/trace/instrumentation/play23/RequestURIDataAdapter.java
@@ -1,0 +1,49 @@
+package datadog.trace.instrumentation.play23;
+
+import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
+import play.api.mvc.Request;
+
+final class RequestURIDataAdapter implements URIDataAdapter {
+
+  private final Request request;
+  private final String host;
+  private final int port;
+
+  RequestURIDataAdapter(Request request) {
+    this.request = request;
+    int split = request.host().lastIndexOf(':');
+    this.host = split == -1 ? request.host() : request.host().substring(0, split);
+    this.port = split == -1 ? 0 : Integer.parseInt(request.host().substring(split + 1));
+  }
+
+  @Override
+  public String scheme() {
+    return request.secure() ? "https" : "http";
+  }
+
+  @Override
+  public String host() {
+    return host;
+  }
+
+  @Override
+  public int port() {
+    return port;
+  }
+
+  @Override
+  public String path() {
+    int split = request.uri().lastIndexOf('?');
+    return split == -1 ? request.uri() : request.uri().substring(0, split);
+  }
+
+  @Override
+  public String fragment() {
+    return "";
+  }
+
+  @Override
+  public String query() {
+    return request.rawQueryString();
+  }
+}

--- a/dd-java-agent/instrumentation/play-2.4/src/main/java/datadog/trace/instrumentation/play24/PlayInstrumentation.java
+++ b/dd-java-agent/instrumentation/play-2.4/src/main/java/datadog/trace/instrumentation/play24/PlayInstrumentation.java
@@ -38,6 +38,7 @@ public final class PlayInstrumentation extends Instrumenter.Default {
       packageName + ".PlayHttpServerDecorator",
       packageName + ".RequestCompleteCallback",
       packageName + ".PlayHeaders",
+      packageName + ".RequestURIDataAdapter"
     };
   }
 

--- a/dd-java-agent/instrumentation/play-2.4/src/main/java8/datadog/trace/instrumentation/play24/PlayHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/play-2.4/src/main/java8/datadog/trace/instrumentation/play24/PlayHttpServerDecorator.java
@@ -3,11 +3,10 @@ package datadog.trace.instrumentation.play24;
 import datadog.trace.api.DDTags;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
+import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.UndeclaredThrowableException;
-import java.net.URI;
-import java.net.URISyntaxException;
 import lombok.extern.slf4j.Slf4j;
 import play.api.mvc.Request;
 import play.api.mvc.Result;
@@ -33,8 +32,8 @@ public class PlayHttpServerDecorator extends HttpServerDecorator<Request, Reques
   }
 
   @Override
-  protected URI url(final Request request) throws URISyntaxException {
-    return new URI((request.secure() ? "https://" : "http://") + request.host() + request.uri());
+  protected URIDataAdapter url(final Request request) {
+    return new RequestURIDataAdapter(request);
   }
 
   @Override

--- a/dd-java-agent/instrumentation/play-2.4/src/main/java8/datadog/trace/instrumentation/play24/RequestURIDataAdapter.java
+++ b/dd-java-agent/instrumentation/play-2.4/src/main/java8/datadog/trace/instrumentation/play24/RequestURIDataAdapter.java
@@ -1,0 +1,49 @@
+package datadog.trace.instrumentation.play24;
+
+import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
+import play.api.mvc.Request;
+
+final class RequestURIDataAdapter implements URIDataAdapter {
+
+  private final Request request;
+  private final String host;
+  private final int port;
+
+  RequestURIDataAdapter(Request request) {
+    this.request = request;
+    int split = request.host().lastIndexOf(':');
+    this.host = split == -1 ? request.host() : request.host().substring(0, split);
+    this.port = split == -1 ? 0 : Integer.parseInt(request.host().substring(split + 1));
+  }
+
+  @Override
+  public String scheme() {
+    return request.secure() ? "https" : "http";
+  }
+
+  @Override
+  public String host() {
+    return host;
+  }
+
+  @Override
+  public int port() {
+    return port;
+  }
+
+  @Override
+  public String path() {
+    int split = request.uri().lastIndexOf('?');
+    return split == -1 ? request.uri() : request.uri().substring(0, split);
+  }
+
+  @Override
+  public String fragment() {
+    return "";
+  }
+
+  @Override
+  public String query() {
+    return request.rawQueryString();
+  }
+}

--- a/dd-java-agent/instrumentation/play-2.6/src/main/java/datadog/trace/instrumentation/play26/PlayInstrumentation.java
+++ b/dd-java-agent/instrumentation/play-2.6/src/main/java/datadog/trace/instrumentation/play26/PlayInstrumentation.java
@@ -38,6 +38,7 @@ public final class PlayInstrumentation extends Instrumenter.Default {
       packageName + ".PlayHttpServerDecorator",
       packageName + ".RequestCompleteCallback",
       packageName + ".PlayHeaders",
+      packageName + ".RequestURIDataAdapter"
     };
   }
 

--- a/dd-java-agent/instrumentation/play-2.6/src/main/java8/datadog/trace/instrumentation/play26/PlayHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/play-2.6/src/main/java8/datadog/trace/instrumentation/play26/PlayHttpServerDecorator.java
@@ -3,12 +3,11 @@ package datadog.trace.instrumentation.play26;
 import datadog.trace.api.DDTags;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
+import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.UndeclaredThrowableException;
-import java.net.URI;
-import java.net.URISyntaxException;
 import lombok.extern.slf4j.Slf4j;
 import play.api.mvc.Request;
 import play.api.mvc.Result;
@@ -56,8 +55,8 @@ public class PlayHttpServerDecorator extends HttpServerDecorator<Request, Reques
   }
 
   @Override
-  protected URI url(final Request request) throws URISyntaxException {
-    return new URI((request.secure() ? "https://" : "http://") + request.host() + request.uri());
+  protected URIDataAdapter url(final Request request) {
+    return new RequestURIDataAdapter(request);
   }
 
   @Override

--- a/dd-java-agent/instrumentation/play-2.6/src/main/java8/datadog/trace/instrumentation/play26/RequestURIDataAdapter.java
+++ b/dd-java-agent/instrumentation/play-2.6/src/main/java8/datadog/trace/instrumentation/play26/RequestURIDataAdapter.java
@@ -1,0 +1,49 @@
+package datadog.trace.instrumentation.play26;
+
+import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
+import play.api.mvc.Request;
+
+final class RequestURIDataAdapter implements URIDataAdapter {
+
+  private final Request request;
+  private final String host;
+  private final int port;
+
+  RequestURIDataAdapter(Request request) {
+    this.request = request;
+    int split = request.host().lastIndexOf(':');
+    this.host = split == -1 ? request.host() : request.host().substring(0, split);
+    this.port = split == -1 ? 0 : Integer.parseInt(request.host().substring(split + 1));
+  }
+
+  @Override
+  public String scheme() {
+    return request.secure() ? "https" : "http";
+  }
+
+  @Override
+  public String host() {
+    return host;
+  }
+
+  @Override
+  public int port() {
+    return port;
+  }
+
+  @Override
+  public String path() {
+    int split = request.uri().lastIndexOf('?');
+    return split == -1 ? request.uri() : request.uri().substring(0, split);
+  }
+
+  @Override
+  public String fragment() {
+    return "";
+  }
+
+  @Override
+  public String query() {
+    return request.rawQueryString();
+  }
+}

--- a/dd-java-agent/instrumentation/ratpack-1.5/src/main/java/datadog/trace/instrumentation/ratpack/ServerErrorHandlerInstrumentation.java
+++ b/dd-java-agent/instrumentation/ratpack-1.5/src/main/java/datadog/trace/instrumentation/ratpack/ServerErrorHandlerInstrumentation.java
@@ -36,7 +36,7 @@ public class ServerErrorHandlerInstrumentation extends Instrumenter.Default {
   @Override
   public String[] helperClassNames() {
     return new String[] {
-      packageName + ".RatpackServerDecorator",
+      packageName + ".RatpackServerDecorator", packageName + ".RequestURIAdapterAdapter",
     };
   }
 

--- a/dd-java-agent/instrumentation/ratpack-1.5/src/main/java/datadog/trace/instrumentation/ratpack/ServerRegistryInstrumentation.java
+++ b/dd-java-agent/instrumentation/ratpack-1.5/src/main/java/datadog/trace/instrumentation/ratpack/ServerRegistryInstrumentation.java
@@ -27,7 +27,9 @@ public class ServerRegistryInstrumentation extends Instrumenter.Default {
   @Override
   public String[] helperClassNames() {
     return new String[] {
-      packageName + ".RatpackServerDecorator", packageName + ".TracingHandler",
+      packageName + ".RatpackServerDecorator",
+      packageName + ".RequestURIAdapterAdapter",
+      packageName + ".TracingHandler",
     };
   }
 

--- a/dd-java-agent/instrumentation/ratpack-1.5/src/main/java8/datadog/trace/instrumentation/ratpack/RatpackServerDecorator.java
+++ b/dd-java-agent/instrumentation/ratpack-1.5/src/main/java8/datadog/trace/instrumentation/ratpack/RatpackServerDecorator.java
@@ -1,17 +1,14 @@
 package datadog.trace.instrumentation.ratpack;
 
-import com.google.common.net.HostAndPort;
 import datadog.trace.api.DDTags;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
-import java.net.URI;
 import lombok.extern.slf4j.Slf4j;
 import ratpack.handling.Context;
-import ratpack.http.HttpUrlBuilder;
 import ratpack.http.Request;
 import ratpack.http.Response;
 import ratpack.http.Status;
-import ratpack.server.PublicAddress;
 
 @Slf4j
 public class RatpackServerDecorator extends HttpServerDecorator<Request, Request, Response> {
@@ -38,14 +35,8 @@ public class RatpackServerDecorator extends HttpServerDecorator<Request, Request
   }
 
   @Override
-  protected URI url(final Request request) {
-    final HostAndPort address = request.getLocalAddress();
-    // This call implicitly uses request via a threadlocal provided by ratpack.
-    final PublicAddress publicAddress =
-        PublicAddress.inferred(address.getPort() == 443 ? "https" : "http");
-    final HttpUrlBuilder url =
-        publicAddress.builder().path(request.getPath()).params(request.getQueryParams());
-    return url.build();
+  protected URIDataAdapter url(final Request request) {
+    return new RequestURIAdapterAdapter(request);
   }
 
   @Override

--- a/dd-java-agent/instrumentation/ratpack-1.5/src/main/java8/datadog/trace/instrumentation/ratpack/RequestURIAdapterAdapter.java
+++ b/dd-java-agent/instrumentation/ratpack-1.5/src/main/java8/datadog/trace/instrumentation/ratpack/RequestURIAdapterAdapter.java
@@ -1,0 +1,60 @@
+package datadog.trace.instrumentation.ratpack;
+
+import com.google.common.net.HostAndPort;
+import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.concurrent.ConcurrentHashMap;
+import ratpack.http.Request;
+
+final class RequestURIAdapterAdapter implements URIDataAdapter {
+
+  private final ConcurrentHashMap<String, String> DOMAIN_NAME_MAPPING = new ConcurrentHashMap<>();
+
+  private final Request request;
+  private final HostAndPort hostAndPort;
+
+  RequestURIAdapterAdapter(Request request) {
+    this.request = request;
+    this.hostAndPort = request.getLocalAddress();
+  }
+
+  @Override
+  public String scheme() {
+    return hostAndPort.getPort() == 443 ? "https" : "http";
+  }
+
+  @Override
+  public String host() {
+    // this is a local address, so not too worried about this blowing up
+    return DOMAIN_NAME_MAPPING.computeIfAbsent(
+        hostAndPort.getHost(),
+        ip -> {
+          try {
+            return InetAddress.getByName(ip).getCanonicalHostName();
+          } catch (UnknownHostException e) {
+            return ip;
+          }
+        });
+  }
+
+  @Override
+  public int port() {
+    return hostAndPort.getPort();
+  }
+
+  @Override
+  public String path() {
+    return request.getPath();
+  }
+
+  @Override
+  public String fragment() {
+    return "";
+  }
+
+  @Override
+  public String query() {
+    return request.getQuery();
+  }
+}

--- a/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/Servlet2Decorator.java
+++ b/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/Servlet2Decorator.java
@@ -1,9 +1,8 @@
 package datadog.trace.instrumentation.servlet2;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
-import java.net.URI;
-import java.net.URISyntaxException;
 import javax.servlet.http.HttpServletRequest;
 
 public class Servlet2Decorator
@@ -26,15 +25,8 @@ public class Servlet2Decorator
   }
 
   @Override
-  protected URI url(final HttpServletRequest httpServletRequest) throws URISyntaxException {
-    return new URI(
-        httpServletRequest.getScheme(),
-        null,
-        httpServletRequest.getServerName(),
-        httpServletRequest.getServerPort(),
-        httpServletRequest.getRequestURI(),
-        httpServletRequest.getQueryString(),
-        null);
+  protected URIDataAdapter url(final HttpServletRequest httpServletRequest) {
+    return new ServletRequestURIAdapter(httpServletRequest);
   }
 
   @Override

--- a/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/Servlet2Instrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/Servlet2Instrumentation.java
@@ -41,7 +41,9 @@ public final class Servlet2Instrumentation extends Instrumenter.Default {
   @Override
   public String[] helperClassNames() {
     return new String[] {
-      packageName + ".Servlet2Decorator", packageName + ".HttpServletRequestExtractAdapter",
+      packageName + ".Servlet2Decorator",
+      packageName + ".ServletRequestURIAdapter",
+      packageName + ".HttpServletRequestExtractAdapter",
     };
   }
 

--- a/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/ServletRequestURIAdapter.java
+++ b/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/ServletRequestURIAdapter.java
@@ -1,0 +1,42 @@
+package datadog.trace.instrumentation.servlet2;
+
+import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
+import javax.servlet.http.HttpServletRequest;
+
+public class ServletRequestURIAdapter implements URIDataAdapter {
+  private final HttpServletRequest request;
+
+  public ServletRequestURIAdapter(HttpServletRequest request) {
+    this.request = request;
+  }
+
+  @Override
+  public String scheme() {
+    return request.getScheme();
+  }
+
+  @Override
+  public String host() {
+    return request.getServerName();
+  }
+
+  @Override
+  public int port() {
+    return request.getServerPort();
+  }
+
+  @Override
+  public String path() {
+    return request.getRequestURI();
+  }
+
+  @Override
+  public String fragment() {
+    return "";
+  }
+
+  @Override
+  public String query() {
+    return request.getQueryString();
+  }
+}

--- a/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Decorator.java
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Decorator.java
@@ -1,9 +1,8 @@
 package datadog.trace.instrumentation.servlet3;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
-import java.net.URI;
-import java.net.URISyntaxException;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -30,15 +29,8 @@ public class Servlet3Decorator
   }
 
   @Override
-  protected URI url(final HttpServletRequest httpServletRequest) throws URISyntaxException {
-    return new URI(
-        httpServletRequest.getScheme(),
-        null,
-        httpServletRequest.getServerName(),
-        httpServletRequest.getServerPort(),
-        httpServletRequest.getRequestURI(),
-        httpServletRequest.getQueryString(),
-        null);
+  protected URIDataAdapter url(final HttpServletRequest httpServletRequest) {
+    return new ServletRequestURIAdapter(httpServletRequest);
   }
 
   @Override

--- a/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Instrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Instrumentation.java
@@ -37,6 +37,7 @@ public final class Servlet3Instrumentation extends Instrumenter.Default {
   public String[] helperClassNames() {
     return new String[] {
       packageName + ".Servlet3Decorator",
+      packageName + ".ServletRequestURIAdapter",
       packageName + ".HttpServletRequestExtractAdapter",
       packageName + ".TagSettingAsyncListener"
     };

--- a/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/ServletRequestURIAdapter.java
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/ServletRequestURIAdapter.java
@@ -1,0 +1,42 @@
+package datadog.trace.instrumentation.servlet3;
+
+import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
+import javax.servlet.http.HttpServletRequest;
+
+public class ServletRequestURIAdapter implements URIDataAdapter {
+  private final HttpServletRequest request;
+
+  public ServletRequestURIAdapter(HttpServletRequest request) {
+    this.request = request;
+  }
+
+  @Override
+  public String scheme() {
+    return request.getScheme();
+  }
+
+  @Override
+  public String host() {
+    return request.getServerName();
+  }
+
+  @Override
+  public int port() {
+    return request.getServerPort();
+  }
+
+  @Override
+  public String path() {
+    return request.getRequestURI();
+  }
+
+  @Override
+  public String fragment() {
+    return "";
+  }
+
+  @Override
+  public String query() {
+    return request.getQueryString();
+  }
+}

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/DispatcherServletInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/DispatcherServletInstrumentation.java
@@ -43,6 +43,7 @@ public final class DispatcherServletInstrumentation extends Instrumenter.Default
   public String[] helperClassNames() {
     return new String[] {
       packageName + ".SpringWebHttpServerDecorator",
+      packageName + ".ServletRequestURIAdapter",
       packageName + ".SpringWebHttpServerDecorator$1",
       packageName + ".HandlerMappingResourceNameFilter",
     };

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/HandlerAdapterInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/HandlerAdapterInstrumentation.java
@@ -48,7 +48,9 @@ public final class HandlerAdapterInstrumentation extends Instrumenter.Default {
   @Override
   public String[] helperClassNames() {
     return new String[] {
-      packageName + ".SpringWebHttpServerDecorator", packageName + ".SpringWebHttpServerDecorator$1"
+      packageName + ".SpringWebHttpServerDecorator",
+      packageName + ".ServletRequestURIAdapter",
+      packageName + ".SpringWebHttpServerDecorator$1"
     };
   }
 

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/ServletRequestURIAdapter.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/ServletRequestURIAdapter.java
@@ -1,0 +1,42 @@
+package datadog.trace.instrumentation.springweb;
+
+import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
+import javax.servlet.http.HttpServletRequest;
+
+public final class ServletRequestURIAdapter implements URIDataAdapter {
+  private final HttpServletRequest request;
+
+  public ServletRequestURIAdapter(HttpServletRequest request) {
+    this.request = request;
+  }
+
+  @Override
+  public String scheme() {
+    return request.getScheme();
+  }
+
+  @Override
+  public String host() {
+    return request.getServerName();
+  }
+
+  @Override
+  public int port() {
+    return request.getServerPort();
+  }
+
+  @Override
+  public String path() {
+    return request.getRequestURI();
+  }
+
+  @Override
+  public String fragment() {
+    return "";
+  }
+
+  @Override
+  public String query() {
+    return request.getQueryString();
+  }
+}

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/SpringWebHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/SpringWebHttpServerDecorator.java
@@ -5,11 +5,10 @@ import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.FixedSizeCache;
 import datadog.trace.bootstrap.instrumentation.api.Function;
 import datadog.trace.bootstrap.instrumentation.api.Pair;
+import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
 import java.lang.reflect.Method;
-import java.net.URI;
-import java.net.URISyntaxException;
 import javax.servlet.Servlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -66,15 +65,8 @@ public class SpringWebHttpServerDecorator
   }
 
   @Override
-  protected URI url(final HttpServletRequest httpServletRequest) throws URISyntaxException {
-    return new URI(
-        httpServletRequest.getScheme(),
-        null,
-        httpServletRequest.getServerName(),
-        httpServletRequest.getServerPort(),
-        httpServletRequest.getRequestURI(),
-        httpServletRequest.getQueryString(),
-        null);
+  protected URIDataAdapter url(final HttpServletRequest httpServletRequest) {
+    return new ServletRequestURIAdapter(httpServletRequest);
   }
 
   @Override

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/WebApplicationContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/WebApplicationContextInstrumentation.java
@@ -47,6 +47,7 @@ public class WebApplicationContextInstrumentation extends Instrumenter.Default {
     return new String[] {
       packageName + ".SpringWebHttpServerDecorator",
       packageName + ".SpringWebHttpServerDecorator$1",
+      packageName + ".ServletRequestURIAdapter",
       packageName + ".HandlerMappingResourceNameFilter",
       packageName + ".HandlerMappingResourceNameFilter$BeanDefinition",
     };


### PR DESCRIPTION
Parsing URIs shows up in profiles on the application threads.

This will make things worse for Netty, but I'm not convinced `Channel` -> `CONNECTION`, `HttpRequest` -> `REQUEST` really makes sense. URI parsing could be avoided entirely with a reference to a `Channel`.