### PR TITLE
Don't add webflux filter multiple times

### DIFF
--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java8/datadog/trace/instrumentation/springwebflux/client/WebClientTracingFilter.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java8/datadog/trace/instrumentation/springwebflux/client/WebClientTracingFilter.java
@@ -22,6 +22,15 @@ public class WebClientTracingFilter implements ExchangeFilterFunction {
   private static final WebClientTracingFilter INSTANCE = new WebClientTracingFilter();
 
   public static void addFilter(final List<ExchangeFilterFunction> exchangeFilterFunctions) {
+    // Since the builder where we instrument the build function can be reused, we need
+    // to only add the filter once
+    int index = exchangeFilterFunctions.indexOf(INSTANCE);
+    if (index == 0) {
+      return;
+    }
+    if (index > 0) {
+      exchangeFilterFunctions.remove(index);
+    }
     exchangeFilterFunctions.add(0, INSTANCE);
   }
 

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/test/groovy/dd/trace/instrumentation/springwebflux/client/SpringWebfluxHttpClientBasicTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/test/groovy/dd/trace/instrumentation/springwebflux/client/SpringWebfluxHttpClientBasicTest.groovy
@@ -1,0 +1,17 @@
+package dd.trace.instrumentation.springwebflux.client
+
+import org.springframework.web.reactive.function.client.WebClient
+import spock.lang.Timeout
+
+@Timeout(5)
+class SpringWebfluxHttpClientBasicTest extends SpringWebfluxHttpClientBase {
+
+  @Override
+  WebClient createClient(String component) {
+    return WebClient.builder().build()
+  }
+
+  @Override
+  void check() {
+  }
+}

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/test/groovy/dd/trace/instrumentation/springwebflux/client/SpringWebfluxHttpClientBuilderReuseTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/test/groovy/dd/trace/instrumentation/springwebflux/client/SpringWebfluxHttpClientBuilderReuseTest.groovy
@@ -1,0 +1,19 @@
+package dd.trace.instrumentation.springwebflux.client
+
+import org.springframework.web.reactive.function.client.WebClient
+import spock.lang.Timeout
+
+@Timeout(5)
+class SpringWebfluxHttpClientBuilderReuseTest extends SpringWebfluxHttpClientBase {
+
+  @Override
+  WebClient createClient(String component) {
+    def builder = WebClient.builder()
+    builder.build()
+    return builder.build()
+  }
+
+  @Override
+  void check() {
+  }
+}

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/test/groovy/dd/trace/instrumentation/springwebflux/client/SpringWebfluxHttpClientFilterBuilderReuseTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/test/groovy/dd/trace/instrumentation/springwebflux/client/SpringWebfluxHttpClientFilterBuilderReuseTest.groovy
@@ -1,0 +1,32 @@
+package dd.trace.instrumentation.springwebflux.client
+
+import org.springframework.web.reactive.function.client.WebClient
+import spock.lang.Timeout
+
+@Timeout(5)
+class SpringWebfluxHttpClientFilterBuilderReuseTest extends SpringWebfluxHttpClientBase {
+
+  CollectingFilter filter = null
+  String component = ""
+
+  @Override
+  WebClient createClient(String component) {
+    this.filter  = new CollectingFilter()
+    this.component = component
+    def builder = WebClient.builder()
+    // add filters before and after, and check that we move our filter first
+    builder.filter(filter)
+    builder.build()
+    builder.filters( {
+      it.add(0, filter)
+    })
+
+    return builder.build()
+  }
+
+  @Override
+  void check() {
+    assert filter.count == 2
+    assert filter.collected == "$component:$component:"
+  }
+}

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/test/groovy/dd/trace/instrumentation/springwebflux/client/SpringWebfluxHttpClientFilterTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/test/groovy/dd/trace/instrumentation/springwebflux/client/SpringWebfluxHttpClientFilterTest.groovy
@@ -1,0 +1,24 @@
+package dd.trace.instrumentation.springwebflux.client
+
+import org.springframework.web.reactive.function.client.WebClient
+import spock.lang.Timeout
+
+@Timeout(5)
+class SpringWebfluxHttpClientFilterTest extends SpringWebfluxHttpClientBase {
+
+  CollectingFilter filter = null
+  String component = ""
+
+  @Override
+  WebClient createClient(String component) {
+    filter  = new CollectingFilter()
+    this.component = component
+    return WebClient.builder().filter(filter).build()
+  }
+
+  @Override
+  void check() {
+    assert filter.count == 1
+    assert filter.collected == "$component:"
+  }
+}


### PR DESCRIPTION
The `WebClient.Builder` can be reused and we would add our filter multiple times, creating multiple spans.