### PR TITLE
Add `cinnamon.*` classes to global ignore.

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/GlobalIgnoresMatcher.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/GlobalIgnoresMatcher.java
@@ -84,6 +84,9 @@ public class GlobalIgnoresMatcher<T extends TypeDescription>
         if (name.startsWith("clojure.")) {
           return true;
         }
+        if (name.startsWith("cinnamon.")) {
+          return true;
+        }
         break;
       case 'd' - 'a':
         if (name.startsWith("datadog.")) {


### PR DESCRIPTION
They inject classes that we can't resolve that results in noisy logging.