### PR TITLE
Allow enabling/disabling exception profiling by config.

### DIFF
--- a/dd-java-agent/instrumentation/exception-profiling/src/main/java/datadog/exceptions/instrumentation/ThrowableInstrumentation.java
+++ b/dd-java-agent/instrumentation/exception-profiling/src/main/java/datadog/exceptions/instrumentation/ThrowableInstrumentation.java
@@ -70,6 +70,7 @@ public final class ThrowableInstrumentation extends Instrumenter.Default {
 
   @Override
   protected boolean defaultEnabled() {
-    return Config.get().isProfilingExceptionEnabled();
+    Config cfg = Config.get();
+    return cfg.isProfilingEnabled() && cfg.isProfilingExceptionEnabled();
   }
 }

--- a/dd-java-agent/instrumentation/exception-profiling/src/main/java/datadog/exceptions/instrumentation/ThrowableInstrumentation.java
+++ b/dd-java-agent/instrumentation/exception-profiling/src/main/java/datadog/exceptions/instrumentation/ThrowableInstrumentation.java
@@ -54,7 +54,6 @@ public final class ThrowableInstrumentation extends Instrumenter.Default {
 
   @Override
   public ElementMatcher<? super TypeDescription> typeMatcher() {
-    System.out.println("*** typeMatcher: " + hasJfr);
     if (hasJfr) {
       return is(Throwable.class);
     }

--- a/dd-java-agent/instrumentation/exception-profiling/src/main/java/datadog/exceptions/instrumentation/ThrowableInstrumentation.java
+++ b/dd-java-agent/instrumentation/exception-profiling/src/main/java/datadog/exceptions/instrumentation/ThrowableInstrumentation.java
@@ -54,6 +54,7 @@ public final class ThrowableInstrumentation extends Instrumenter.Default {
 
   @Override
   public ElementMatcher<? super TypeDescription> typeMatcher() {
+    System.out.println("*** typeMatcher: " + hasJfr);
     if (hasJfr) {
       return is(Throwable.class);
     }
@@ -70,6 +71,6 @@ public final class ThrowableInstrumentation extends Instrumenter.Default {
 
   @Override
   protected boolean defaultEnabled() {
-    return Config.get().isProfilingEnabled();
+    return Config.get().isProfilingExceptionEnabled();
   }
 }

--- a/dd-smoke-tests/profiling-integration-tests/src/test/groovy/datadog/smoketest/AbstractProfilingIntegrationTest.groovy
+++ b/dd-smoke-tests/profiling-integration-tests/src/test/groovy/datadog/smoketest/AbstractProfilingIntegrationTest.groovy
@@ -8,6 +8,10 @@ abstract class AbstractProfilingIntegrationTest extends AbstractSmokeTest {
   // can not be @Shared since the same instance will be reused for all specs and this is not supported by MockWebServer
   protected static MockWebServer profilingServer
 
+  protected String[] getExtraJavaProperties() {
+    return []
+  }
+
   @Override
   ProcessBuilder createProcessBuilder() {
     String profilingShadowJar = System.getProperty("datadog.smoketest.profiling.shadowJar.path")
@@ -17,6 +21,13 @@ abstract class AbstractProfilingIntegrationTest extends AbstractSmokeTest {
     List<String> command = new ArrayList<>()
     command.add(javaPath())
     command.addAll(defaultJavaProperties)
+    /*
+     * Spock is *always* executing parent class 'setupSpec' method first -
+     * making it impossible to do any customization to the profiled application command line.
+     * Thus we need have this hack to at least allow concrete test classes to have their
+     * specific Java properties set.
+     */
+    command.addAll(getExtraJavaProperties())
     command.addAll((String[]) ["-Ddd.${ProfilingConfig.PROFILING_TEMPLATE_OVERRIDE_FILE}=${templateOverride}"])
     command.addAll((String[]) ["-jar", profilingShadowJar])
     command.add(Integer.toString(exitDelay))

--- a/dd-smoke-tests/profiling-integration-tests/src/test/groovy/datadog/smoketest/ProfilingExceptionsDisabledTest.groovy
+++ b/dd-smoke-tests/profiling-integration-tests/src/test/groovy/datadog/smoketest/ProfilingExceptionsDisabledTest.groovy
@@ -5,17 +5,14 @@ import com.google.common.collect.Multimap
 import net.jpountz.lz4.LZ4FrameInputStream
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.RecordedRequest
-import org.openjdk.jmc.common.item.Aggregators
-import org.openjdk.jmc.common.item.Attribute
 import org.openjdk.jmc.common.item.IItemCollection
 import org.openjdk.jmc.common.item.ItemFilters
-import org.openjdk.jmc.common.unit.UnitLookup
 import org.openjdk.jmc.flightrecorder.JfrLoaderToolkit
 
 import java.time.Instant
 import java.util.concurrent.TimeUnit
 
-class ProfilingIntegrationContinuousProfilesTest extends AbstractProfilingIntegrationTest {
+class ProfilingExceptionsDisabledTest extends AbstractProfilingIntegrationTest {
   private static final int REQUEST_WAIT_TIMEOUT = 40
 
   @Override
@@ -23,7 +20,7 @@ class ProfilingIntegrationContinuousProfilesTest extends AbstractProfilingIntegr
     return ["-Ddd.profiling.exception.enabled=false"]
   }
 
-  def "test continuous recording"() {
+  def "test exception profiling disabled"() {
     setup:
     profilingServer.enqueue(new MockResponse().setResponseCode(200))
 
@@ -76,21 +73,8 @@ class ProfilingIntegrationContinuousProfilesTest extends AbstractProfilingIntegr
     firstRequestParameters.get("chunk-data").get(0) != null
 
     IItemCollection events = JfrLoaderToolkit.loadEvents(new LZ4FrameInputStream(new ByteArrayInputStream(secondRequestParameters.get("chunk-data").get(0))))
-    IItemCollection scopeEvents = events.apply(ItemFilters.type("datadog.Scope"))
 
-    scopeEvents.hasItems()
-
-    def cpuTimeAttr = Attribute.attr("cpuTime", "cpuTime", UnitLookup.TIMESPAN)
-
-    // filter out scope events without CPU time data
-    def filteredScopeEvents = scopeEvents.apply(ItemFilters.more(cpuTimeAttr, UnitLookup.NANOSECOND.quantity(Long.MIN_VALUE)))
-    // make sure there is at least one scope event with CPU time data
-    filteredScopeEvents.hasItems()
-
-    filteredScopeEvents.getAggregate(Aggregators.min("datadog.Scope", cpuTimeAttr)).longValue() >= 10_000L
-
-    // check deadlock events
-    events.apply(ItemFilters.type("datadog.Deadlock")).hasItems()
-    events.apply(ItemFilters.type("datadog.DeadlockedThread")).hasItems()
+    IItemCollection exceptionSampleEvents = events.apply(ItemFilters.type("datadog.ExceptionSample"))
+    !exceptionSampleEvents.hasItems()
   }
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
@@ -33,6 +33,7 @@ public final class ProfilingConfig {
   public static final String PROFILING_PROXY_PORT = "profiling.proxy.port";
   public static final String PROFILING_PROXY_USERNAME = "profiling.proxy.username";
   public static final String PROFILING_PROXY_PASSWORD = "profiling.proxy.password";
+  public static final String PROFILING_EXCEPTION_ENABLED = "profiling.exception.enabled";
   public static final String PROFILING_EXCEPTION_SAMPLE_LIMIT = "profiling.exception.sample.limit";
   public static final String PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS =
       "profiling.exception.histogram.top-items";

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -340,6 +340,7 @@ public class Config {
   @Getter private final int profilingProxyPort;
   @Getter private final String profilingProxyUsername;
   @Getter private final String profilingProxyPassword;
+  @Getter private final boolean profilingExceptionEnabled;
   @Getter private final int profilingExceptionSampleLimit;
   @Getter private final int profilingExceptionHistogramTopItems;
   @Getter private final int profilingExceptionHistogramMaxCollectionSize;
@@ -576,6 +577,9 @@ public class Config {
         configProvider.getInteger(PROFILING_PROXY_PORT, DEFAULT_PROFILING_PROXY_PORT);
     profilingProxyUsername = configProvider.getString(PROFILING_PROXY_USERNAME);
     profilingProxyPassword = configProvider.getString(PROFILING_PROXY_PASSWORD);
+
+    profilingExceptionEnabled =
+        configProvider.getBoolean(ProfilingConfig.PROFILING_EXCEPTION_ENABLED, true);
 
     profilingExceptionSampleLimit =
         configProvider.getInteger(

--- a/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -1,5 +1,6 @@
 package datadog.trace.api
 
+import datadog.trace.api.config.ProfilingConfig
 import datadog.trace.api.env.FixedCapturedEnvironment
 import datadog.trace.bootstrap.config.provider.ConfigConverter
 import datadog.trace.bootstrap.config.provider.ConfigProvider
@@ -169,6 +170,7 @@ class ConfigTest extends DDSpecification {
     config.profilingProxyPort == DEFAULT_PROFILING_PROXY_PORT
     config.profilingProxyUsername == null
     config.profilingProxyPassword == null
+    config.profilingExceptionEnabled == true
     config.profilingExceptionSampleLimit == DEFAULT_PROFILING_EXCEPTION_SAMPLE_LIMIT
     config.profilingExceptionHistogramTopItems == DEFAULT_PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS
     config.profilingExceptionHistogramMaxCollectionSize == DEFAULT_PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE
@@ -239,6 +241,7 @@ class ConfigTest extends DDSpecification {
     prop.setProperty(PROFILING_PROXY_PORT, "1118")
     prop.setProperty(PROFILING_PROXY_USERNAME, "proxy-username")
     prop.setProperty(PROFILING_PROXY_PASSWORD, "proxy-password")
+    prop.setProperty(ProfilingConfig.PROFILING_EXCEPTION_ENABLED, "true")
     prop.setProperty(PROFILING_EXCEPTION_SAMPLE_LIMIT, "811")
     prop.setProperty(PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS, "1121")
     prop.setProperty(PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE, "1122")
@@ -359,6 +362,7 @@ class ConfigTest extends DDSpecification {
     System.setProperty(PREFIX + PROFILING_PROXY_PORT, "1118")
     System.setProperty(PREFIX + PROFILING_PROXY_USERNAME, "proxy-username")
     System.setProperty(PREFIX + PROFILING_PROXY_PASSWORD, "proxy-password")
+    System.setProperty(PREFIX + ProfilingConfig.PROFILING_EXCEPTION_ENABLED, "true")
     System.setProperty(PREFIX + PROFILING_EXCEPTION_SAMPLE_LIMIT, "811")
     System.setProperty(PREFIX + PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS, "1121")
     System.setProperty(PREFIX + PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE, "1122")


### PR DESCRIPTION
Currently the exception profiling instrumentation is always injected - even if eg. ExceptionSample event is disabled and the data will not be collected.
This change is adding a config property to enable/disable the exception profiling. The instrumentation will be injected only if the exception profiling is enabled.