### PR TITLE
Restore logging configuration if a previous test wipes it out

### DIFF
--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/AgentTestRunner.java
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/AgentTestRunner.java
@@ -202,8 +202,8 @@ public abstract class AgentTestRunner extends DDSpecification {
       } catch (final Exception e) {
         e.printStackTrace();
       }
-      configureLoggingLevels();
     }
+    configureLoggingLevels();
   }
 
   @After


### PR DESCRIPTION
This fixes a test issue where the embedded Tomcat tests wipe out the logging configuration when Tomcat is shut down, causing any following tests run in the same JVM to not have any logging output.

We now detect this by checking if the root logger has any appenders attached before running the test. If it doesn't then we restore the default logging configuration and set the expected log levels.

Before:
![before](https://user-images.githubusercontent.com/145851/92226634-f0c56a80-ee9c-11ea-820a-ed2079cb36cf.png)

After:
![after](https://user-images.githubusercontent.com/145851/92226654-f91da580-ee9c-11ea-94db-87713087d6b5.png)
