### PR TITLE
remove guava from profiling

### DIFF
--- a/dd-java-agent/agent-jmxfetch/agent-jmxfetch.gradle
+++ b/dd-java-agent/agent-jmxfetch/agent-jmxfetch.gradle
@@ -4,7 +4,7 @@ plugins {
 apply from: "$rootDir/gradle/java.gradle"
 
 dependencies {
-  compile('com.datadoghq:jmxfetch:0.38.0') {
+  compile('com.datadoghq:jmxfetch:0.39.0') {
     exclude group: 'org.apache.logging.log4j', module: 'log4j-slf4j-impl'
     exclude group: 'org.apache.logging.log4j', module: 'log4j-core'
     exclude group: 'org.slf4j', module: 'slf4j-api'

--- a/dd-java-agent/agent-profiling/profiling-uploader/profiling-uploader.gradle
+++ b/dd-java-agent/agent-profiling/profiling-uploader/profiling-uploader.gradle
@@ -23,7 +23,6 @@ dependencies {
 
   compile "org.openjdk.jmc:common:$jmcVersion"
 
-  compile deps.guava
   compile deps.okhttp
   compile group: 'com.github.jnr', name: 'jnr-posix', version: '3.0.52'
   compile group: 'org.lz4', name: 'lz4-java', version: '1.7.1'

--- a/dd-java-agent/agent-profiling/profiling-uploader/src/main/java/com/datadog/profiling/uploader/ProfileUploader.java
+++ b/dd-java-agent/agent-profiling/profiling-uploader/src/main/java/com/datadog/profiling/uploader/ProfileUploader.java
@@ -20,7 +20,6 @@ import com.datadog.profiling.controller.RecordingType;
 import com.datadog.profiling.uploader.util.PidHelper;
 import com.datadog.profiling.uploader.util.StreamUtils;
 import com.datadog.profiling.util.ProfilingThreadFactory;
-import com.google.common.annotations.VisibleForTesting;
 import datadog.common.container.ContainerInfo;
 import datadog.trace.api.Config;
 import java.io.IOException;
@@ -138,7 +137,10 @@ public final class ProfileUploader {
     this(config, ContainerInfo.get().getContainerId());
   }
 
-  @VisibleForTesting
+  /**
+   * Note that this method is only visible for testing and should not be used from outside this
+   * class.
+   */
   ProfileUploader(final Config config, final String containerId) {
     url = config.getFinalProfilingUrl();
     apiKey = config.getApiKey();
@@ -259,7 +261,10 @@ public final class ProfileUploader {
     client.connectionPool().evictAll();
   }
 
-  @VisibleForTesting
+  /**
+   * Note that this method is only visible for testing and should not be used from outside this
+   * class.
+   */
   OkHttpClient getClient() {
     return client;
   }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -82,8 +82,7 @@ ext {
       // transitive dependency.  Since okhttp is declared here and moshi is not, this lead to an incompatible version
       dependencies.create(group: 'com.squareup.okio', name: 'okio', version: versions.okio),
       dependencies.create(group: 'com.datadoghq', name: 'java-dogstatsd-client', version: versions.dogstatsd),
-      dependencies.create(group: 'com.github.jnr', name: 'jnr-unixsocket', version: versions.jnr_unixsocket),
-      dependencies.create(group: 'com.google.guava', name: 'guava', version: versions.guava)
+      dependencies.create(group: 'com.github.jnr', name: 'jnr-unixsocket', version: versions.jnr_unixsocket)
     ],
 
     // Inverse of "shared".  These exclude directives are part of shadowJar's DSL
@@ -94,14 +93,6 @@ ext {
       exclude(dependency('com.datadoghq:java-dogstatsd-client'))
       exclude(dependency('com.github.jnr::'))
       exclude(dependency('org.ow2.asm::'))
-
-      // Guava and its transitives
-      exclude(dependency('com.google.guava::'))
-      exclude(dependency('com.google.code.findbugs::'))
-      exclude(dependency('com.google.errorprone::'))
-      exclude(dependency('com.google.j2objc::'))
-      exclude(dependency('org.codehaus.mojo::'))
-      exclude(dependency('org.checkerframework::'))
 
       // okhttp and its transitives
       exclude(dependency('com.squareup.okhttp3:okhttp'))


### PR DESCRIPTION
Needs #1827 to be merged first.

Manually verified that guava classes are now under `inst` in the jar

```
jar -tf dd-java-agent/build/libs/dd-java-agent-0.61.0-SNAPSHOT.jar| grep 'com.google.common'
inst/com/google/common/
inst/com/google/common/escape/
inst/com/google/common/escape/Escapers$1.classdata
inst/com/google/common/escape/CharEscaperBuilder$CharArrayDecorator.classdata
...
```

@DataDog/profiling look at the second commit if reviewing this before rebasing after #1827 is merged.