### PR TITLE
make it possible to disable v0.5 endpoint

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -533,7 +533,8 @@ public class CoreTracer implements AgentTracer.TracerAPI {
             config.getAgentHost(),
             config.getAgentPort(),
             unixDomainSocket,
-            TimeUnit.SECONDS.toMillis(config.getAgentTimeout()));
+            TimeUnit.SECONDS.toMillis(config.getAgentTimeout()),
+            Config.get().isTraceAgentV05Enabled());
 
     final DDAgentWriter ddAgentWriter =
         DDAgentWriter.builder().agentApi(ddAgentApi).monitor(new Monitor(statsDClient)).build();


### PR DESCRIPTION
The configuration parameter to disable v0.5 traces introduced in #1762 was intended for integration testing purposes and the PR was incomplete when @tylerbenson both renamed the PR and _rewrote my PR description_ before merging it. This PR allows actually disabling the v0.5 endpoint by config (but this should be discouraged because v0.5 payloads are ~4x smaller).