### PR TITLE
port failing reactor subscription context propagation test from opentelemetry

### DIFF
--- a/dd-java-agent/instrumentation/reactor-core-3.1/src/main/java8/datadog/trace/instrumentation/reactor/core/TracingPublishers.java
+++ b/dd-java-agent/instrumentation/reactor-core-3.1/src/main/java8/datadog/trace/instrumentation/reactor/core/TracingPublishers.java
@@ -7,9 +7,8 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import java.util.function.Consumer;
+import lombok.extern.slf4j.Slf4j;
 import org.reactivestreams.Publisher;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import reactor.core.CoreSubscriber;
 import reactor.core.Disposable;
 import reactor.core.Fuseable;
@@ -19,8 +18,8 @@ import reactor.core.publisher.GroupedFlux;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.ParallelFlux;
 
+@Slf4j
 public class TracingPublishers {
-  private static final Logger log = LoggerFactory.getLogger(TracingPublishers.class);
 
   /**
    * Instead of using {@link reactor.core.publisher.Operators#lift} (available in reactor 3.1) or

--- a/dd-java-agent/instrumentation/reactor-core-3.1/src/main/java8/datadog/trace/instrumentation/reactor/core/TracingSubscriber.java
+++ b/dd-java-agent/instrumentation/reactor-core-3.1/src/main/java8/datadog/trace/instrumentation/reactor/core/TracingSubscriber.java
@@ -28,7 +28,7 @@ public class TracingSubscriber<T>
   private final CoreSubscriber<T> delegate;
   private final Context context;
   private final AgentSpan downstreamSpan;
-  private Subscription subscription;
+  private volatile Subscription subscription;
 
   public TracingSubscriber(final AgentSpan upstreamSpan, final CoreSubscriber<T> delegate) {
     this.delegate = delegate;

--- a/dd-java-agent/instrumentation/reactor-core-3.1/src/test/groovy/SubscriptionTest.groovy
+++ b/dd-java-agent/instrumentation/reactor-core-3.1/src/test/groovy/SubscriptionTest.groovy
@@ -1,0 +1,42 @@
+import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.api.Trace
+
+import java.util.concurrent.CountDownLatch
+import reactor.core.publisher.Mono
+
+import static datadog.trace.agent.test.utils.TraceUtils.basicSpan
+import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
+
+class SubscriptionTest extends AgentTestRunner {
+
+  def "subscription test"() {
+    when:
+    CountDownLatch latch = new CountDownLatch(1)
+    runUnderTrace("parent") {
+      Mono<Connection> connection = Mono.create {
+        it.success(new Connection())
+      }
+      connection.subscribe {
+        it.query()
+        latch.countDown()
+      }
+    }
+    latch.await()
+
+    then:
+    assertTraces(1) {
+      trace(0, 2) {
+        basicSpan(it, 0, "parent")
+        basicSpan(it, 1, "Connection.query", span(0))
+      }
+    }
+
+  }
+
+  static class Connection {
+    @Trace
+    static int query() {
+      return new Random().nextInt()
+    }
+  }
+}


### PR DESCRIPTION
Ports @iNikem's test over here so we know it breaks here too.