### PR TITLE
Fix status tag on health metrics

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/monitor/Monitor.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/monitor/Monitor.java
@@ -107,7 +107,7 @@ public class Monitor {
     }
 
     if (response.status() != null) {
-      statsd.incrementCounter("api.responses", "status: " + response.status());
+      statsd.incrementCounter("api.responses", "status:" + response.status());
     }
   }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/monitor/MonitorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/monitor/MonitorTest.groovy
@@ -119,7 +119,7 @@ class MonitorTest extends DDSpecification {
       1 * statsD.incrementCounter('api.errors')
     }
     if (response.status()) {
-      1 * statsD.incrementCounter('api.responses', ["status: ${response.status()}"])
+      1 * statsD.incrementCounter('api.responses', ["status:${response.status()}"])
     }
     0 * _
 
@@ -147,7 +147,7 @@ class MonitorTest extends DDSpecification {
       1 * statsD.incrementCounter('api.errors')
     }
     if (response.status()) {
-      1 * statsD.incrementCounter('api.responses', ["status: ${response.status()}"])
+      1 * statsD.incrementCounter('api.responses', ["status:${response.status()}"])
     }
     0 * _
 


### PR DESCRIPTION
The extra space lead to metrics being tagged with `status:_200` instead of `status:200` (spaces are converted into underscores)