### PR TITLE
Add test utility to run test closure concurrently

### DIFF
--- a/dd-java-agent/testing/src/main/java/datadog/trace/agent/test/utils/ThreadUtils.java
+++ b/dd-java-agent/testing/src/main/java/datadog/trace/agent/test/utils/ThreadUtils.java
@@ -1,0 +1,97 @@
+package datadog.trace.agent.test.utils;
+
+import groovy.lang.Closure;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class ThreadUtils {
+
+  /**
+   * Utility to easily run a Closure in parallel, i.e. in spock like this:
+   *
+   * <pre>{@code
+   * def "some test"() {
+   *   expect:
+   *   runConcurrently(10, 100, {
+   *     def something = ...
+   *     def other = ...
+   *     assert something == other
+   *   })
+   * }
+   * }</pre>
+   *
+   * Writing a spock extension was investigated, but it is not possible to run an Invocation
+   * multiple times concurrently since a lot of the spock internal state and mock scoping is not
+   * thread safe.
+   *
+   * @param concurrency the number of concurrent invocations
+   * @param totalInvocations the total number of invocations
+   * @param closure the closure to run
+   * @return true if everything went well
+   * @throws Throwable if anything went wrong
+   */
+  public static boolean runConcurrently(
+      final int concurrency, final int totalInvocations, final Closure<Void> closure)
+      throws Throwable {
+    // There is no reason in creating more threads than invocations
+    int poolSize = Math.min(concurrency, totalInvocations);
+
+    // If we are not running anything concurrently, then just call the closure directly
+    if (poolSize == 1) {
+      for (int c = 0; c < totalInvocations; c++) {
+        closure.call();
+      }
+      return true;
+    }
+
+    ExecutorService executor = Executors.newFixedThreadPool(poolSize);
+    final AtomicReference<Throwable> throwable = new AtomicReference<>();
+    int each = totalInvocations / poolSize;
+    int remainder = totalInvocations % poolSize;
+    final CountDownLatch startBarrier = new CountDownLatch(poolSize + 1);
+    final CountDownLatch endBarrier = new CountDownLatch(poolSize + 1);
+    for (int i = 0; i < poolSize; i++) {
+      final int invocations = each + (remainder <= 0 ? 0 : 1);
+      executor.execute(
+          new Runnable() {
+            @Override
+            public void run() {
+              try {
+                startBarrier.countDown();
+                startBarrier.await();
+                for (int c = 0; c < invocations && throwable.get() == null; c++) {
+                  try {
+                    closure.call();
+                  } catch (Throwable t) {
+                    throwable.compareAndSet(null, t);
+                  }
+                }
+              } catch (Throwable t) {
+                throwable.compareAndSet(null, t);
+              } finally {
+                try {
+                  endBarrier.countDown();
+                } catch (Throwable t) {
+                  throwable.compareAndSet(null, t);
+                }
+              }
+            }
+          });
+      remainder--;
+    }
+    startBarrier.countDown();
+    startBarrier.await();
+    endBarrier.countDown();
+    endBarrier.await();
+    executor.shutdownNow();
+    executor.awaitTermination(30, TimeUnit.SECONDS);
+    Throwable t = throwable.get();
+    if (t != null) {
+      throw t;
+    }
+    return true;
+  }
+}

--- a/dd-java-agent/testing/src/test/groovy/utils/ThreadUtilsTest.groovy
+++ b/dd-java-agent/testing/src/test/groovy/utils/ThreadUtilsTest.groovy
@@ -1,0 +1,88 @@
+package utils
+
+import datadog.trace.agent.test.utils.ThreadUtils
+import org.spockframework.runtime.ConditionNotSatisfiedError
+import spock.lang.FailsWith
+import spock.lang.Shared
+import spock.lang.Specification
+
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
+
+class ThreadUtilsTest extends Specification {
+
+  @Shared
+  def counter = new AtomicInteger()
+
+  @Shared
+  def byThread = new ConcurrentHashMap<String, Integer>()
+
+  def cleanup() {
+    counter.set(0)
+  }
+
+  def "run a closure concurrently"() {
+    expect:
+    ThreadUtils.runConcurrently(10, 200, {
+      def total = counter.incrementAndGet()
+      def name = Thread.currentThread().getName()
+      def mine = byThread.get(name, 0) + 1
+      byThread.put(name, mine)
+      assert total >= mine
+    })
+    assert counter.get() == 200
+    assert byThread.size() == 10
+    byThread.each {
+      assert it.value == 20
+    }
+  }
+
+  @FailsWith(value = ConditionNotSatisfiedError)
+  def "assert should fail test"() {
+    expect:
+    ThreadUtils.runConcurrently(10, 200, {
+      def total = counter.incrementAndGet()
+      assert total <= 17
+    })
+    // we should never get here
+    assert "we should" == "never get here"
+  }
+
+  @FailsWith(value = ConditionNotSatisfiedError)
+  def "assert as last operation should fail test"() {
+    expect:
+    ThreadUtils.runConcurrently(10, 200, {
+      def total = counter.incrementAndGet()
+      if (total == 200) {
+        Thread.sleep(500)
+      }
+      assert total < 200
+    })
+    // we should never get here
+    assert "we should" == "never get here"
+  }
+
+  def "concurrency 1 should run on this thread"() {
+    when:
+    def thread = Thread.currentThread()
+
+    then:
+    ThreadUtils.runConcurrently(1, 200, {
+      counter.incrementAndGet()
+      assert Thread.currentThread() == thread
+    })
+    assert counter.get() == 200
+  }
+
+  def "totalIterations 1 should run on this thread"() {
+    when:
+    def thread = Thread.currentThread()
+
+    then:
+    ThreadUtils.runConcurrently(10, 1, {
+      counter.incrementAndGet()
+      assert Thread.currentThread() == thread
+    })
+    assert counter.get() == 1
+  }
+}


### PR DESCRIPTION
Broke out this little helper utility from my `play` test. Tried to build a `spock` extension at first but it seems undoable, since state is entangled everywhere and nothing is thread safe.