### PR TITLE
Add the EnsureTrace prioritization strategy.

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -26,6 +26,7 @@ public final class ConfigDefaults {
   static final boolean DEFAULT_TRACE_ENABLED = true;
   static final boolean DEFAULT_INTEGRATIONS_ENABLED = true;
   static final String DEFAULT_AGENT_WRITER_TYPE = "DDAgentWriter";
+  static final String DEFAULT_PRIORITIZATION_TYPE = "FastLane";
 
   static final boolean DEFAULT_RUNTIME_CONTEXT_FIELD_INJECTION = true;
 

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
@@ -7,13 +7,14 @@ package datadog.trace.api.config;
  *   DDTracer.builder().withProperties(new Properties()).build()
  * </pre>
  *
- * If using dd-java-agent, these keys represent settings that should be configured via system
+ * <p>If using dd-java-agent, these keys represent settings that should be configured via system
  * properties, environment variables, or config properties file. See online documentation for
  * details.
  */
 public final class TracerConfig {
   public static final String ID_GENERATION_STRATEGY = "id.generation.strategy";
   public static final String WRITER_TYPE = "writer.type";
+  public static final String PRIORITIZATION_TYPE = "prioritization.type";
   public static final String AGENT_HOST = "agent.host";
   public static final String TRACE_AGENT_PORT = "trace.agent.port";
   public static final String AGENT_PORT_LEGACY = "agent.port";

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/PrioritizationTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/PrioritizationTest.groovy
@@ -41,13 +41,13 @@ class PrioritizationTest extends DDSpecification {
     []    | false       | USER_KEEP    | 1             | 0
   }
 
-  def "ensure trace strategy strategy flushes primary queue"() {
+  def "ensure trace strategy flushes primary queue"() {
     setup:
     Queue<Object> primary = Mock(Queue)
     Queue<Object> secondary = Mock(Queue)
-    PrioritizationStrategy fastLane = Prioritization.FAST_LANE.create(primary, secondary)
+    PrioritizationStrategy ensureTrace = Prioritization.ENSURE_TRACE.create(primary, secondary)
     when:
-    fastLane.flush(100, TimeUnit.MILLISECONDS)
+    ensureTrace.flush(100, TimeUnit.MILLISECONDS)
     then:
     1 * primary.offer({ it instanceof FlushEvent }) >> true
     0 * secondary.offer(_)

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/PrioritizationTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/PrioritizationTest.groovy
@@ -14,11 +14,50 @@ import static datadog.trace.api.sampling.PrioritySampling.USER_KEEP
 
 class PrioritizationTest extends DDSpecification {
 
-  def "fast lane strategy sends kept and unset priority traces to the primary queue, dropped traces to the secondary queue" () {
+  def "ensure trace strategy tries to send kept and unset priority traces to the primary queue until offer(..) is true, dropped traces to the secondary queue"() {
     setup:
     Queue<Object> primary = Mock(Queue)
     Queue<Object> secondary = Mock(Queue)
-    PrioritizationStrategy fastLane =  Prioritization.FAST_LANE.create(primary, secondary)
+    PrioritizationStrategy blocking = Prioritization.ENSURE_TRACE.create(primary, secondary)
+
+    when:
+    blocking.publish(priority, trace)
+
+    then:
+    primaryOffers * primary.offer(trace) >> !primaryFull >> true
+    secondaryOffers * secondary.offer(trace) >> true
+
+    where:
+    trace | primaryFull | priority     | primaryOffers | secondaryOffers
+    []    | true        | UNSET        | 2             | 0
+    []    | true        | SAMPLER_DROP | 0             | 1
+    []    | true        | SAMPLER_KEEP | 2             | 0
+    []    | true        | SAMPLER_DROP | 0             | 1
+    []    | true        | USER_KEEP    | 2             | 0
+    []    | false       | UNSET        | 1             | 0
+    []    | false       | SAMPLER_DROP | 0             | 1
+    []    | false       | SAMPLER_KEEP | 1             | 0
+    []    | false       | SAMPLER_DROP | 0             | 1
+    []    | false       | USER_KEEP    | 1             | 0
+  }
+
+  def "ensure trace strategy strategy flushes primary queue"() {
+    setup:
+    Queue<Object> primary = Mock(Queue)
+    Queue<Object> secondary = Mock(Queue)
+    PrioritizationStrategy fastLane = Prioritization.FAST_LANE.create(primary, secondary)
+    when:
+    fastLane.flush(100, TimeUnit.MILLISECONDS)
+    then:
+    1 * primary.offer({ it instanceof FlushEvent }) >> true
+    0 * secondary.offer(_)
+  }
+
+  def "fast lane strategy sends kept and unset priority traces to the primary queue, dropped traces to the secondary queue"() {
+    setup:
+    Queue<Object> primary = Mock(Queue)
+    Queue<Object> secondary = Mock(Queue)
+    PrioritizationStrategy fastLane = Prioritization.FAST_LANE.create(primary, secondary)
 
     when:
     fastLane.publish(priority, trace)
@@ -28,19 +67,19 @@ class PrioritizationTest extends DDSpecification {
     secondaryOffers * secondary.offer(trace)
 
     where:
-    trace    |     priority      |   primaryOffers   | secondaryOffers
-    []       |     UNSET         |       1           |      0
-    []       |     SAMPLER_DROP  |       0           |      1
-    []       |     SAMPLER_KEEP  |       1           |      0
-    []       |     SAMPLER_DROP  |       0           |      1
-    []       |     USER_KEEP     |       1           |      0
+    trace | priority     | primaryOffers | secondaryOffers
+    []    | UNSET        | 1             | 0
+    []    | SAMPLER_DROP | 0             | 1
+    []    | SAMPLER_KEEP | 1             | 0
+    []    | SAMPLER_DROP | 0             | 1
+    []    | USER_KEEP    | 1             | 0
   }
 
-  def "fast lane strategy flushes primary queue" () {
+  def "fast lane strategy flushes primary queue"() {
     setup:
     Queue<Object> primary = Mock(Queue)
     Queue<Object> secondary = Mock(Queue)
-    PrioritizationStrategy fastLane =  Prioritization.FAST_LANE.create(primary, secondary)
+    PrioritizationStrategy fastLane = Prioritization.FAST_LANE.create(primary, secondary)
     when:
     fastLane.flush(100, TimeUnit.MILLISECONDS)
     then:
@@ -48,11 +87,11 @@ class PrioritizationTest extends DDSpecification {
     0 * secondary.offer(_)
   }
 
-  def "dead letters strategy drops unkept traces if the primary queue is full" () {
+  def "dead letters strategy drops unkept traces if the primary queue is full"() {
     setup:
     Queue<Object> primary = Mock(Queue)
     Queue<Object> secondary = Mock(Queue)
-    PrioritizationStrategy fastLane =  Prioritization.DEAD_LETTERS.create(primary, secondary)
+    PrioritizationStrategy fastLane = Prioritization.DEAD_LETTERS.create(primary, secondary)
 
     when:
     fastLane.publish(priority, trace)
@@ -62,24 +101,24 @@ class PrioritizationTest extends DDSpecification {
     secondaryOffers * secondary.offer(trace)
 
     where:
-    trace    |     primaryFull   |   priority      |   primaryOffers   | secondaryOffers
-    []       |      true         |   UNSET         |       1           |      1
-    []       |      true         |   SAMPLER_DROP  |       1           |      0
-    []       |      true         |   SAMPLER_KEEP  |       1           |      1
-    []       |      true         |   SAMPLER_DROP  |       1           |      0
-    []       |      true         |   USER_KEEP     |       1           |      1
-    []       |      false        |   UNSET         |       1           |      0
-    []       |      false        |   SAMPLER_DROP  |       1           |      0
-    []       |      false        |   SAMPLER_KEEP  |       1           |      0
-    []       |      false        |   SAMPLER_DROP  |       1           |      0
-    []       |      false        |   USER_KEEP     |       1           |      0
+    trace | primaryFull | priority     | primaryOffers | secondaryOffers
+    []    | true        | UNSET        | 1             | 1
+    []    | true        | SAMPLER_DROP | 1             | 0
+    []    | true        | SAMPLER_KEEP | 1             | 1
+    []    | true        | SAMPLER_DROP | 1             | 0
+    []    | true        | USER_KEEP    | 1             | 1
+    []    | false       | UNSET        | 1             | 0
+    []    | false       | SAMPLER_DROP | 1             | 0
+    []    | false       | SAMPLER_KEEP | 1             | 0
+    []    | false       | SAMPLER_DROP | 1             | 0
+    []    | false       | USER_KEEP    | 1             | 0
   }
 
-  def "dead letters strategy flushes both queues" () {
+  def "dead letters strategy flushes both queues"() {
     setup:
     Queue<Object> primary = Mock(Queue)
     Queue<Object> secondary = Mock(Queue)
-    PrioritizationStrategy deadLetters =  Prioritization.DEAD_LETTERS.create(primary, secondary)
+    PrioritizationStrategy deadLetters = Prioritization.DEAD_LETTERS.create(primary, secondary)
     when:
     deadLetters.flush(100, TimeUnit.MILLISECONDS)
     then:

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -64,11 +64,6 @@ import datadog.trace.api.config.ProfilingConfig;
 import datadog.trace.api.config.TraceInstrumentationConfig;
 import datadog.trace.api.config.TracerConfig;
 import datadog.trace.bootstrap.config.provider.ConfigProvider;
-import lombok.Getter;
-import lombok.NonNull;
-import lombok.ToString;
-import lombok.extern.slf4j.Slf4j;
-
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
@@ -90,6 +85,10 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.UUID;
 import java.util.regex.Pattern;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Config reads values with the following priority: 1) system properties, 2) environment variables,
@@ -106,9 +105,7 @@ import java.util.regex.Pattern;
 @ToString(includeFieldNames = true)
 public class Config {
 
-  /**
-   * Config keys below
-   */
+  /** Config keys below */
   public static final String CONFIGURATION_FILE = GeneralConfig.CONFIGURATION_FILE;
 
   public static final String API_KEY = GeneralConfig.API_KEY;
@@ -145,11 +142,11 @@ public class Config {
   public static final String TRACE_EXECUTORS = TraceInstrumentationConfig.TRACE_EXECUTORS;
   public static final String TRACE_METHODS = TraceInstrumentationConfig.TRACE_METHODS;
   public static final String TRACE_CLASSES_EXCLUDE =
-    TraceInstrumentationConfig.TRACE_CLASSES_EXCLUDE;
+      TraceInstrumentationConfig.TRACE_CLASSES_EXCLUDE;
   public static final String TRACE_SAMPLING_SERVICE_RULES =
-    TracerConfig.TRACE_SAMPLING_SERVICE_RULES;
+      TracerConfig.TRACE_SAMPLING_SERVICE_RULES;
   public static final String TRACE_SAMPLING_OPERATION_RULES =
-    TracerConfig.TRACE_SAMPLING_OPERATION_RULES;
+      TracerConfig.TRACE_SAMPLING_OPERATION_RULES;
   public static final String TRACE_SAMPLE_RATE = TracerConfig.TRACE_SAMPLE_RATE;
   public static final String TRACE_RATE_LIMIT = TracerConfig.TRACE_RATE_LIMIT;
   public static final String TRACE_REPORT_HOSTNAME = TracerConfig.TRACE_REPORT_HOSTNAME;
@@ -157,19 +154,19 @@ public class Config {
   public static final String HTTP_SERVER_ERROR_STATUSES = TracerConfig.HTTP_SERVER_ERROR_STATUSES;
   public static final String HTTP_CLIENT_ERROR_STATUSES = TracerConfig.HTTP_CLIENT_ERROR_STATUSES;
   public static final String HTTP_SERVER_TAG_QUERY_STRING =
-    TraceInstrumentationConfig.HTTP_SERVER_TAG_QUERY_STRING;
+      TraceInstrumentationConfig.HTTP_SERVER_TAG_QUERY_STRING;
   public static final String HTTP_CLIENT_TAG_QUERY_STRING =
-    TraceInstrumentationConfig.HTTP_CLIENT_TAG_QUERY_STRING;
+      TraceInstrumentationConfig.HTTP_CLIENT_TAG_QUERY_STRING;
   public static final String HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN =
-    TraceInstrumentationConfig.HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN;
+      TraceInstrumentationConfig.HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN;
   public static final String DB_CLIENT_HOST_SPLIT_BY_INSTANCE =
-    TraceInstrumentationConfig.DB_CLIENT_HOST_SPLIT_BY_INSTANCE;
+      TraceInstrumentationConfig.DB_CLIENT_HOST_SPLIT_BY_INSTANCE;
   public static final String SPLIT_BY_TAGS = TracerConfig.SPLIT_BY_TAGS;
   public static final String SCOPE_DEPTH_LIMIT = TracerConfig.SCOPE_DEPTH_LIMIT;
   public static final String SCOPE_STRICT_MODE = TracerConfig.SCOPE_STRICT_MODE;
   public static final String PARTIAL_FLUSH_MIN_SPANS = TracerConfig.PARTIAL_FLUSH_MIN_SPANS;
   public static final String RUNTIME_CONTEXT_FIELD_INJECTION =
-    TraceInstrumentationConfig.RUNTIME_CONTEXT_FIELD_INJECTION;
+      TraceInstrumentationConfig.RUNTIME_CONTEXT_FIELD_INJECTION;
   public static final String PROPAGATION_STYLE_EXTRACT = TracerConfig.PROPAGATION_STYLE_EXTRACT;
   public static final String PROPAGATION_STYLE_INJECT = TracerConfig.PROPAGATION_STYLE_INJECT;
 
@@ -182,7 +179,7 @@ public class Config {
 
   public static final String JMX_FETCH_CHECK_PERIOD = JmxFetchConfig.JMX_FETCH_CHECK_PERIOD;
   public static final String JMX_FETCH_REFRESH_BEANS_PERIOD =
-    JmxFetchConfig.JMX_FETCH_REFRESH_BEANS_PERIOD;
+      JmxFetchConfig.JMX_FETCH_REFRESH_BEANS_PERIOD;
   public static final String JMX_FETCH_STATSD_HOST = JmxFetchConfig.JMX_FETCH_STATSD_HOST;
   public static final String JMX_FETCH_STATSD_PORT = JmxFetchConfig.JMX_FETCH_STATSD_PORT;
 
@@ -191,7 +188,7 @@ public class Config {
   public static final String HEALTH_METRICS_STATSD_PORT = GeneralConfig.HEALTH_METRICS_STATSD_PORT;
 
   public static final String LOGS_INJECTION_ENABLED =
-    TraceInstrumentationConfig.LOGS_INJECTION_ENABLED;
+      TraceInstrumentationConfig.LOGS_INJECTION_ENABLED;
 
   public static final String PROFILING_ENABLED = ProfilingConfig.PROFILING_ENABLED;
   @Deprecated // Use dd.site instead
@@ -200,41 +197,41 @@ public class Config {
   public static final String PROFILING_API_KEY_OLD = ProfilingConfig.PROFILING_API_KEY_OLD;
   @Deprecated // Use dd.api-key-file instead
   public static final String PROFILING_API_KEY_FILE_OLD =
-    ProfilingConfig.PROFILING_API_KEY_FILE_OLD;
+      ProfilingConfig.PROFILING_API_KEY_FILE_OLD;
   @Deprecated // Use dd.api-key instead
   public static final String PROFILING_API_KEY_VERY_OLD =
-    ProfilingConfig.PROFILING_API_KEY_VERY_OLD;
+      ProfilingConfig.PROFILING_API_KEY_VERY_OLD;
   @Deprecated // Use dd.api-key-file instead
   public static final String PROFILING_API_KEY_FILE_VERY_OLD =
-    ProfilingConfig.PROFILING_API_KEY_FILE_VERY_OLD;
+      ProfilingConfig.PROFILING_API_KEY_FILE_VERY_OLD;
   public static final String PROFILING_TAGS = ProfilingConfig.PROFILING_TAGS;
   public static final String PROFILING_START_DELAY = ProfilingConfig.PROFILING_START_DELAY;
   // DANGEROUS! May lead on sigsegv on JVMs before 14
   // Not intended for production use
   public static final String PROFILING_START_FORCE_FIRST =
-    ProfilingConfig.PROFILING_START_FORCE_FIRST;
+      ProfilingConfig.PROFILING_START_FORCE_FIRST;
   public static final String PROFILING_UPLOAD_PERIOD = ProfilingConfig.PROFILING_UPLOAD_PERIOD;
   public static final String PROFILING_TEMPLATE_OVERRIDE_FILE =
-    ProfilingConfig.PROFILING_TEMPLATE_OVERRIDE_FILE;
+      ProfilingConfig.PROFILING_TEMPLATE_OVERRIDE_FILE;
   public static final String PROFILING_UPLOAD_TIMEOUT = ProfilingConfig.PROFILING_UPLOAD_TIMEOUT;
   public static final String PROFILING_UPLOAD_COMPRESSION =
-    ProfilingConfig.PROFILING_UPLOAD_COMPRESSION;
+      ProfilingConfig.PROFILING_UPLOAD_COMPRESSION;
   public static final String PROFILING_PROXY_HOST = ProfilingConfig.PROFILING_PROXY_HOST;
   public static final String PROFILING_PROXY_PORT = ProfilingConfig.PROFILING_PROXY_PORT;
   public static final String PROFILING_PROXY_USERNAME = ProfilingConfig.PROFILING_PROXY_USERNAME;
   public static final String PROFILING_PROXY_PASSWORD = ProfilingConfig.PROFILING_PROXY_PASSWORD;
   public static final String PROFILING_EXCEPTION_SAMPLE_LIMIT =
-    ProfilingConfig.PROFILING_EXCEPTION_SAMPLE_LIMIT;
+      ProfilingConfig.PROFILING_EXCEPTION_SAMPLE_LIMIT;
   public static final String PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS =
-    ProfilingConfig.PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS;
+      ProfilingConfig.PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS;
   public static final String PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE =
-    ProfilingConfig.PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE;
+      ProfilingConfig.PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE;
 
   public static final String KAFKA_CLIENT_PROPAGATION_ENABLED =
-    TraceInstrumentationConfig.KAFKA_CLIENT_PROPAGATION_ENABLED;
+      TraceInstrumentationConfig.KAFKA_CLIENT_PROPAGATION_ENABLED;
 
   public static final String KAFKA_CLIENT_BASE64_DECODING_ENABLED =
-    TraceInstrumentationConfig.KAFKA_CLIENT_BASE64_DECODING_ENABLED;
+      TraceInstrumentationConfig.KAFKA_CLIENT_BASE64_DECODING_ENABLED;
 
   private static final String PROFILING_REMOTE_URL_TEMPLATE = "https://intake.profile.%s/v1/input";
   private static final String PROFILING_LOCAL_URL_TEMPLATE = "http://%s:%d/profiling/v1/input";
@@ -242,17 +239,13 @@ public class Config {
   private static final Pattern ENV_REPLACEMENT = Pattern.compile("[^a-zA-Z0-9_]");
   private static final String SPLIT_BY_SPACE_OR_COMMA_REGEX = "[,\\s]+";
 
-  /**
-   * Used for masking sensitive information when doing toString
-   */
+  /** Used for masking sensitive information when doing toString */
   @ToString.Include(name = "apiKey")
   private String profilingApiKeyMasker() {
     return apiKey != null ? "****" : null;
   }
 
-  /**
-   * Used for masking sensitive information when doing toString
-   */
+  /** Used for masking sensitive information when doing toString */
   @ToString.Include(name = "profilingProxyPassword")
   private String profilingProxyPasswordMasker() {
     return profilingProxyPassword != null ? "****" : null;
@@ -262,199 +255,120 @@ public class Config {
    * this is a random UUID that gets generated on JVM start up and is attached to every root span
    * and every JMX metric that is sent out.
    */
-  @Getter
-  private final String runtimeId;
+  @Getter private final String runtimeId;
 
   /**
    * Note: this has effect only on profiling site. Traces are sent to Datadog agent and are not
    * affected by this setting.
    */
-  @Getter
-  private final String apiKey;
+  @Getter private final String apiKey;
   /**
    * Note: this has effect only on profiling site. Traces are sent to Datadog agent and are not
    * affected by this setting.
    */
-  @Getter
-  private final String site;
+  @Getter private final String site;
 
-  @Getter
-  private final String serviceName;
-  @Getter
-  private final boolean traceEnabled;
-  @Getter
-  private final boolean integrationsEnabled;
-  @Getter
-  private final String writerType;
-  @Getter
-  private final String prioritizationType;
-  @Getter
-  private final boolean agentConfiguredUsingDefault;
-  @Getter
-  private final String agentHost;
-  @Getter
-  private final int agentPort;
-  @Getter
-  private final String agentUnixDomainSocket;
-  @Getter
-  private final int agentTimeout;
-  @Getter
-  private final boolean prioritySamplingEnabled;
-  @Getter
-  private final boolean traceResolverEnabled;
-  @Getter
-  private final Map<String, String> serviceMapping;
-  @NonNull
-  private final Map<String, String> tags;
+  @Getter private final String serviceName;
+  @Getter private final boolean traceEnabled;
+  @Getter private final boolean integrationsEnabled;
+  @Getter private final String writerType;
+  @Getter private final String prioritizationType;
+  @Getter private final boolean agentConfiguredUsingDefault;
+  @Getter private final String agentHost;
+  @Getter private final int agentPort;
+  @Getter private final String agentUnixDomainSocket;
+  @Getter private final int agentTimeout;
+  @Getter private final boolean prioritySamplingEnabled;
+  @Getter private final boolean traceResolverEnabled;
+  @Getter private final Map<String, String> serviceMapping;
+  @NonNull private final Map<String, String> tags;
   private final Map<String, String> spanTags;
   private final Map<String, String> jmxTags;
-  @Getter
-  private final List<String> excludedClasses;
-  @Getter
-  private final Map<String, String> headerTags;
-  @Getter
-  private final BitSet httpServerErrorStatuses;
-  @Getter
-  private final BitSet httpClientErrorStatuses;
-  @Getter
-  private final boolean httpServerTagQueryString;
-  @Getter
-  private final boolean httpClientTagQueryString;
-  @Getter
-  private final boolean httpClientSplitByDomain;
-  @Getter
-  private final boolean dbClientSplitByInstance;
-  @Getter
-  private final Set<String> splitByTags;
-  @Getter
-  private final int scopeDepthLimit;
-  @Getter
-  private final boolean scopeStrictMode;
-  @Getter
-  private final int partialFlushMinSpans;
-  @Getter
-  private final boolean runtimeContextFieldInjection;
-  @Getter
-  private final Set<PropagationStyle> propagationStylesToExtract;
-  @Getter
-  private final Set<PropagationStyle> propagationStylesToInject;
+  @Getter private final List<String> excludedClasses;
+  @Getter private final Map<String, String> headerTags;
+  @Getter private final BitSet httpServerErrorStatuses;
+  @Getter private final BitSet httpClientErrorStatuses;
+  @Getter private final boolean httpServerTagQueryString;
+  @Getter private final boolean httpClientTagQueryString;
+  @Getter private final boolean httpClientSplitByDomain;
+  @Getter private final boolean dbClientSplitByInstance;
+  @Getter private final Set<String> splitByTags;
+  @Getter private final int scopeDepthLimit;
+  @Getter private final boolean scopeStrictMode;
+  @Getter private final int partialFlushMinSpans;
+  @Getter private final boolean runtimeContextFieldInjection;
+  @Getter private final Set<PropagationStyle> propagationStylesToExtract;
+  @Getter private final Set<PropagationStyle> propagationStylesToInject;
 
-  @Getter
-  private final boolean jmxFetchEnabled;
-  @Getter
-  private final String jmxFetchConfigDir;
-  @Getter
-  private final List<String> jmxFetchConfigs;
-  @Deprecated
-  @Getter
-  private final List<String> jmxFetchMetricsConfigs;
-  @Getter
-  private final Integer jmxFetchCheckPeriod;
-  @Getter
-  private final Integer jmxFetchRefreshBeansPeriod;
-  @Getter
-  private final String jmxFetchStatsdHost;
-  @Getter
-  private final Integer jmxFetchStatsdPort;
+  @Getter private final boolean jmxFetchEnabled;
+  @Getter private final String jmxFetchConfigDir;
+  @Getter private final List<String> jmxFetchConfigs;
+  @Deprecated @Getter private final List<String> jmxFetchMetricsConfigs;
+  @Getter private final Integer jmxFetchCheckPeriod;
+  @Getter private final Integer jmxFetchRefreshBeansPeriod;
+  @Getter private final String jmxFetchStatsdHost;
+  @Getter private final Integer jmxFetchStatsdPort;
 
   // These values are default-ed to those of jmx fetch values as needed
-  @Getter
-  private final boolean healthMetricsEnabled;
-  @Getter
-  private final String healthMetricsStatsdHost;
-  @Getter
-  private final Integer healthMetricsStatsdPort;
+  @Getter private final boolean healthMetricsEnabled;
+  @Getter private final String healthMetricsStatsdHost;
+  @Getter private final Integer healthMetricsStatsdPort;
 
-  @Getter
-  private final boolean logsInjectionEnabled;
-  @Getter
-  private final boolean logsMDCTagsInjectionEnabled;
-  @Getter
-  private final boolean reportHostName;
+  @Getter private final boolean logsInjectionEnabled;
+  @Getter private final boolean logsMDCTagsInjectionEnabled;
+  @Getter private final boolean reportHostName;
 
-  @Getter
-  private final String traceAnnotations;
+  @Getter private final String traceAnnotations;
 
-  @Getter
-  private final String traceMethods;
+  @Getter private final String traceMethods;
 
-  @Getter
-  private final boolean traceExecutorsAll;
-  @Getter
-  private final List<String> traceExecutors;
+  @Getter private final boolean traceExecutorsAll;
+  @Getter private final List<String> traceExecutors;
 
-  @Getter
-  private final boolean traceAnalyticsEnabled;
+  @Getter private final boolean traceAnalyticsEnabled;
 
-  @Getter
-  private final Map<String, String> traceSamplingServiceRules;
-  @Getter
-  private final Map<String, String> traceSamplingOperationRules;
-  @Getter
-  private final Double traceSampleRate;
-  @Getter
-  private final Double traceRateLimit;
+  @Getter private final Map<String, String> traceSamplingServiceRules;
+  @Getter private final Map<String, String> traceSamplingOperationRules;
+  @Getter private final Double traceSampleRate;
+  @Getter private final Double traceRateLimit;
 
-  @Getter
-  private final boolean profilingEnabled;
-  @Deprecated
-  private final String profilingUrl;
+  @Getter private final boolean profilingEnabled;
+  @Deprecated private final String profilingUrl;
   private final Map<String, String> profilingTags;
-  @Getter
-  private final int profilingStartDelay;
-  @Getter
-  private final boolean profilingStartForceFirst;
-  @Getter
-  private final int profilingUploadPeriod;
-  @Getter
-  private final String profilingTemplateOverrideFile;
-  @Getter
-  private final int profilingUploadTimeout;
-  @Getter
-  private final String profilingUploadCompression;
-  @Getter
-  private final String profilingProxyHost;
-  @Getter
-  private final int profilingProxyPort;
-  @Getter
-  private final String profilingProxyUsername;
-  @Getter
-  private final String profilingProxyPassword;
-  @Getter
-  private final int profilingExceptionSampleLimit;
-  @Getter
-  private final int profilingExceptionHistogramTopItems;
-  @Getter
-  private final int profilingExceptionHistogramMaxCollectionSize;
+  @Getter private final int profilingStartDelay;
+  @Getter private final boolean profilingStartForceFirst;
+  @Getter private final int profilingUploadPeriod;
+  @Getter private final String profilingTemplateOverrideFile;
+  @Getter private final int profilingUploadTimeout;
+  @Getter private final String profilingUploadCompression;
+  @Getter private final String profilingProxyHost;
+  @Getter private final int profilingProxyPort;
+  @Getter private final String profilingProxyUsername;
+  @Getter private final String profilingProxyPassword;
+  @Getter private final int profilingExceptionSampleLimit;
+  @Getter private final int profilingExceptionHistogramTopItems;
+  @Getter private final int profilingExceptionHistogramMaxCollectionSize;
 
-  @Getter
-  private final boolean kafkaClientPropagationEnabled;
-  @Getter
-  private final boolean kafkaClientBase64DecodingEnabled;
+  @Getter private final boolean kafkaClientPropagationEnabled;
+  @Getter private final boolean kafkaClientBase64DecodingEnabled;
 
-  @Getter
-  private final boolean hystrixTagsEnabled;
-  @Getter
-  private final boolean servletPrincipalEnabled;
+  @Getter private final boolean hystrixTagsEnabled;
+  @Getter private final boolean servletPrincipalEnabled;
 
-  @Getter
-  private final boolean traceAgentV05Enabled;
+  @Getter private final boolean traceAgentV05Enabled;
 
-  @Getter
-  private final boolean debugEnabled;
-  @Getter
-  private final String configFile;
+  @Getter private final boolean debugEnabled;
+  @Getter private final String configFile;
 
-  @Getter
-  private final IdGenerationStrategy idGenerationStrategy;
+  @Getter private final IdGenerationStrategy idGenerationStrategy;
 
   private final ConfigProvider configProvider;
 
   // Read order: System Properties -> Env Variables, [-> properties file], [-> default value]
   private Config() {
     this(
-      INSTANCE != null ? INSTANCE.runtimeId : UUID.randomUUID().toString(),
-      ConfigProvider.createDefault());
+        INSTANCE != null ? INSTANCE.runtimeId : UUID.randomUUID().toString(),
+        ConfigProvider.createDefault());
   }
 
   private Config(final String runtimeId, final ConfigProvider configProvider) {
@@ -470,7 +384,7 @@ public class Config {
     if (apiKeyFile != null) {
       try {
         tmpApiKey =
-          new String(Files.readAllBytes(Paths.get(apiKeyFile)), StandardCharsets.UTF_8).trim();
+            new String(Files.readAllBytes(Paths.get(apiKeyFile)), StandardCharsets.UTF_8).trim();
       } catch (final IOException e) {
         log.error("Cannot read API key from file {}, skipping", apiKeyFile, e);
       }
@@ -480,16 +394,16 @@ public class Config {
 
     traceEnabled = configProvider.getBoolean(TRACE_ENABLED, DEFAULT_TRACE_ENABLED);
     integrationsEnabled =
-      configProvider.getBoolean(INTEGRATIONS_ENABLED, DEFAULT_INTEGRATIONS_ENABLED);
+        configProvider.getBoolean(INTEGRATIONS_ENABLED, DEFAULT_INTEGRATIONS_ENABLED);
     writerType = configProvider.getString(WRITER_TYPE, DEFAULT_AGENT_WRITER_TYPE);
     prioritizationType = configProvider.getString(PRIORITIZATION_TYPE, DEFAULT_PRIORITIZATION_TYPE);
 
     idGenerationStrategy =
-      configProvider.getEnum(ID_GENERATION_STRATEGY, IdGenerationStrategy.class, RANDOM);
+        configProvider.getEnum(ID_GENERATION_STRATEGY, IdGenerationStrategy.class, RANDOM);
     if (idGenerationStrategy != RANDOM) {
       log.warn(
-        "*** you are using an unsupported id generation strategy {} - this can impact correctness of traces",
-        idGenerationStrategy);
+          "*** you are using an unsupported id generation strategy {} - this can impact correctness of traces",
+          idGenerationStrategy);
     }
 
     // The extra code is to detect when defaults are used for agent configuration
@@ -514,18 +428,18 @@ public class Config {
     }
 
     agentPort =
-      configProvider.getInteger(TRACE_AGENT_PORT, DEFAULT_TRACE_AGENT_PORT, AGENT_PORT_LEGACY);
+        configProvider.getInteger(TRACE_AGENT_PORT, DEFAULT_TRACE_AGENT_PORT, AGENT_PORT_LEGACY);
 
     agentConfiguredUsingDefault =
-      agentHostConfiguredUsingDefault
-        && socketConfiguredUsingDefault
-        && agentPort == DEFAULT_TRACE_AGENT_PORT;
+        agentHostConfiguredUsingDefault
+            && socketConfiguredUsingDefault
+            && agentPort == DEFAULT_TRACE_AGENT_PORT;
 
     agentTimeout = configProvider.getInteger(AGENT_TIMEOUT, DEFAULT_AGENT_TIMEOUT);
     prioritySamplingEnabled =
-      configProvider.getBoolean(PRIORITY_SAMPLING, DEFAULT_PRIORITY_SAMPLING_ENABLED);
+        configProvider.getBoolean(PRIORITY_SAMPLING, DEFAULT_PRIORITY_SAMPLING_ENABLED);
     traceResolverEnabled =
-      configProvider.getBoolean(TRACE_RESOLVER_ENABLED, DEFAULT_TRACE_RESOLVER_ENABLED);
+        configProvider.getBoolean(TRACE_RESOLVER_ENABLED, DEFAULT_TRACE_RESOLVER_ENABLED);
     serviceMapping = configProvider.getMergedMap(SERVICE_MAPPING);
 
     {
@@ -541,49 +455,49 @@ public class Config {
     headerTags = configProvider.getMergedMap(HEADER_TAGS);
 
     httpServerErrorStatuses =
-      configProvider.getIntegerRange(
-        HTTP_SERVER_ERROR_STATUSES, DEFAULT_HTTP_SERVER_ERROR_STATUSES);
+        configProvider.getIntegerRange(
+            HTTP_SERVER_ERROR_STATUSES, DEFAULT_HTTP_SERVER_ERROR_STATUSES);
 
     httpClientErrorStatuses =
-      configProvider.getIntegerRange(
-        HTTP_CLIENT_ERROR_STATUSES, DEFAULT_HTTP_CLIENT_ERROR_STATUSES);
+        configProvider.getIntegerRange(
+            HTTP_CLIENT_ERROR_STATUSES, DEFAULT_HTTP_CLIENT_ERROR_STATUSES);
 
     httpServerTagQueryString =
-      configProvider.getBoolean(
-        HTTP_SERVER_TAG_QUERY_STRING, DEFAULT_HTTP_SERVER_TAG_QUERY_STRING);
+        configProvider.getBoolean(
+            HTTP_SERVER_TAG_QUERY_STRING, DEFAULT_HTTP_SERVER_TAG_QUERY_STRING);
 
     httpClientTagQueryString =
-      configProvider.getBoolean(
-        HTTP_CLIENT_TAG_QUERY_STRING, DEFAULT_HTTP_CLIENT_TAG_QUERY_STRING);
+        configProvider.getBoolean(
+            HTTP_CLIENT_TAG_QUERY_STRING, DEFAULT_HTTP_CLIENT_TAG_QUERY_STRING);
 
     httpClientSplitByDomain =
-      configProvider.getBoolean(
-        HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN, DEFAULT_HTTP_CLIENT_SPLIT_BY_DOMAIN);
+        configProvider.getBoolean(
+            HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN, DEFAULT_HTTP_CLIENT_SPLIT_BY_DOMAIN);
 
     dbClientSplitByInstance =
-      configProvider.getBoolean(
-        DB_CLIENT_HOST_SPLIT_BY_INSTANCE, DEFAULT_DB_CLIENT_HOST_SPLIT_BY_INSTANCE);
+        configProvider.getBoolean(
+            DB_CLIENT_HOST_SPLIT_BY_INSTANCE, DEFAULT_DB_CLIENT_HOST_SPLIT_BY_INSTANCE);
 
     splitByTags =
-      Collections.unmodifiableSet(new LinkedHashSet<>(configProvider.getList(SPLIT_BY_TAGS)));
+        Collections.unmodifiableSet(new LinkedHashSet<>(configProvider.getList(SPLIT_BY_TAGS)));
 
     scopeDepthLimit = configProvider.getInteger(SCOPE_DEPTH_LIMIT, DEFAULT_SCOPE_DEPTH_LIMIT);
 
     scopeStrictMode = configProvider.getBoolean(SCOPE_STRICT_MODE, false);
 
     partialFlushMinSpans =
-      configProvider.getInteger(PARTIAL_FLUSH_MIN_SPANS, DEFAULT_PARTIAL_FLUSH_MIN_SPANS);
+        configProvider.getInteger(PARTIAL_FLUSH_MIN_SPANS, DEFAULT_PARTIAL_FLUSH_MIN_SPANS);
 
     runtimeContextFieldInjection =
-      configProvider.getBoolean(
-        RUNTIME_CONTEXT_FIELD_INJECTION, DEFAULT_RUNTIME_CONTEXT_FIELD_INJECTION);
+        configProvider.getBoolean(
+            RUNTIME_CONTEXT_FIELD_INJECTION, DEFAULT_RUNTIME_CONTEXT_FIELD_INJECTION);
 
     propagationStylesToExtract =
-      getPropagationStyleSetSettingFromEnvironmentOrDefault(
-        PROPAGATION_STYLE_EXTRACT, DEFAULT_PROPAGATION_STYLE_EXTRACT);
+        getPropagationStyleSetSettingFromEnvironmentOrDefault(
+            PROPAGATION_STYLE_EXTRACT, DEFAULT_PROPAGATION_STYLE_EXTRACT);
     propagationStylesToInject =
-      getPropagationStyleSetSettingFromEnvironmentOrDefault(
-        PROPAGATION_STYLE_INJECT, DEFAULT_PROPAGATION_STYLE_INJECT);
+        getPropagationStyleSetSettingFromEnvironmentOrDefault(
+            PROPAGATION_STYLE_INJECT, DEFAULT_PROPAGATION_STYLE_INJECT);
 
     jmxFetchEnabled = configProvider.getBoolean(JMX_FETCH_ENABLED, DEFAULT_JMX_FETCH_ENABLED);
     jmxFetchConfigDir = configProvider.getString(JMX_FETCH_CONFIG_DIR);
@@ -593,22 +507,22 @@ public class Config {
     jmxFetchRefreshBeansPeriod = configProvider.getInteger(JMX_FETCH_REFRESH_BEANS_PERIOD);
     jmxFetchStatsdHost = configProvider.getString(JMX_FETCH_STATSD_HOST);
     jmxFetchStatsdPort =
-      configProvider.getInteger(JMX_FETCH_STATSD_PORT, DEFAULT_JMX_FETCH_STATSD_PORT);
+        configProvider.getInteger(JMX_FETCH_STATSD_PORT, DEFAULT_JMX_FETCH_STATSD_PORT);
 
     // Writer.Builder createMonitor will use the values of the JMX fetch & agent to fill-in defaults
     healthMetricsEnabled =
-      configProvider.getBoolean(HEALTH_METRICS_ENABLED, DEFAULT_METRICS_ENABLED);
+        configProvider.getBoolean(HEALTH_METRICS_ENABLED, DEFAULT_METRICS_ENABLED);
     healthMetricsStatsdHost = configProvider.getString(HEALTH_METRICS_STATSD_HOST);
     healthMetricsStatsdPort = configProvider.getInteger(HEALTH_METRICS_STATSD_PORT);
 
     logsInjectionEnabled =
-      configProvider.getBoolean(LOGS_INJECTION_ENABLED, DEFAULT_LOGS_INJECTION_ENABLED);
+        configProvider.getBoolean(LOGS_INJECTION_ENABLED, DEFAULT_LOGS_INJECTION_ENABLED);
     logsMDCTagsInjectionEnabled = configProvider.getBoolean(LOGS_MDC_TAGS_INJECTION_ENABLED, false);
     reportHostName =
-      configProvider.getBoolean(TRACE_REPORT_HOSTNAME, DEFAULT_TRACE_REPORT_HOSTNAME);
+        configProvider.getBoolean(TRACE_REPORT_HOSTNAME, DEFAULT_TRACE_REPORT_HOSTNAME);
 
     traceAgentV05Enabled =
-      configProvider.getBoolean(ENABLE_TRACE_AGENT_V05, DEFAULT_TRACE_AGENT_V05_ENABLED);
+        configProvider.getBoolean(ENABLE_TRACE_AGENT_V05, DEFAULT_TRACE_AGENT_V05_ENABLED);
 
     traceAnnotations = configProvider.getString(TRACE_ANNOTATIONS, DEFAULT_TRACE_ANNOTATIONS);
 
@@ -619,7 +533,7 @@ public class Config {
     traceExecutors = configProvider.getList(TRACE_EXECUTORS);
 
     traceAnalyticsEnabled =
-      configProvider.getBoolean(TRACE_ANALYTICS_ENABLED, DEFAULT_TRACE_ANALYTICS_ENABLED);
+        configProvider.getBoolean(TRACE_ANALYTICS_ENABLED, DEFAULT_TRACE_ANALYTICS_ENABLED);
 
     traceSamplingServiceRules = configProvider.getMergedMap(TRACE_SAMPLING_SERVICE_RULES);
     traceSamplingOperationRules = configProvider.getMergedMap(TRACE_SAMPLING_OPERATION_RULES);
@@ -635,9 +549,9 @@ public class Config {
       if (oldProfilingApiKeyFile != null) {
         try {
           tmpApiKey =
-            new String(
-              Files.readAllBytes(Paths.get(oldProfilingApiKeyFile)), StandardCharsets.UTF_8)
-              .trim();
+              new String(
+                      Files.readAllBytes(Paths.get(oldProfilingApiKeyFile)), StandardCharsets.UTF_8)
+                  .trim();
         } catch (final IOException e) {
           log.error("Cannot read API key from file {}, skipping", oldProfilingApiKeyFile, e);
         }
@@ -645,15 +559,15 @@ public class Config {
     }
     if (tmpApiKey == null) {
       final String veryOldProfilingApiKeyFile =
-        configProvider.getString(PROFILING_API_KEY_FILE_VERY_OLD);
+          configProvider.getString(PROFILING_API_KEY_FILE_VERY_OLD);
       tmpApiKey = System.getenv(propertyNameToEnvironmentVariableName(PROFILING_API_KEY_VERY_OLD));
       if (veryOldProfilingApiKeyFile != null) {
         try {
           tmpApiKey =
-            new String(
-              Files.readAllBytes(Paths.get(veryOldProfilingApiKeyFile)),
-              StandardCharsets.UTF_8)
-              .trim();
+              new String(
+                      Files.readAllBytes(Paths.get(veryOldProfilingApiKeyFile)),
+                      StandardCharsets.UTF_8)
+                  .trim();
         } catch (final IOException e) {
           log.error("Cannot read API key from file {}, skipping", veryOldProfilingApiKeyFile, e);
         }
@@ -662,46 +576,46 @@ public class Config {
 
     profilingTags = configProvider.getMergedMap(PROFILING_TAGS);
     profilingStartDelay =
-      configProvider.getInteger(PROFILING_START_DELAY, DEFAULT_PROFILING_START_DELAY);
+        configProvider.getInteger(PROFILING_START_DELAY, DEFAULT_PROFILING_START_DELAY);
     profilingStartForceFirst =
-      configProvider.getBoolean(PROFILING_START_FORCE_FIRST, DEFAULT_PROFILING_START_FORCE_FIRST);
+        configProvider.getBoolean(PROFILING_START_FORCE_FIRST, DEFAULT_PROFILING_START_FORCE_FIRST);
     profilingUploadPeriod =
-      configProvider.getInteger(PROFILING_UPLOAD_PERIOD, DEFAULT_PROFILING_UPLOAD_PERIOD);
+        configProvider.getInteger(PROFILING_UPLOAD_PERIOD, DEFAULT_PROFILING_UPLOAD_PERIOD);
     profilingTemplateOverrideFile = configProvider.getString(PROFILING_TEMPLATE_OVERRIDE_FILE);
     profilingUploadTimeout =
-      configProvider.getInteger(PROFILING_UPLOAD_TIMEOUT, DEFAULT_PROFILING_UPLOAD_TIMEOUT);
+        configProvider.getInteger(PROFILING_UPLOAD_TIMEOUT, DEFAULT_PROFILING_UPLOAD_TIMEOUT);
     profilingUploadCompression =
-      configProvider.getString(
-        PROFILING_UPLOAD_COMPRESSION, DEFAULT_PROFILING_UPLOAD_COMPRESSION);
+        configProvider.getString(
+            PROFILING_UPLOAD_COMPRESSION, DEFAULT_PROFILING_UPLOAD_COMPRESSION);
     profilingProxyHost = configProvider.getString(PROFILING_PROXY_HOST);
     profilingProxyPort =
-      configProvider.getInteger(PROFILING_PROXY_PORT, DEFAULT_PROFILING_PROXY_PORT);
+        configProvider.getInteger(PROFILING_PROXY_PORT, DEFAULT_PROFILING_PROXY_PORT);
     profilingProxyUsername = configProvider.getString(PROFILING_PROXY_USERNAME);
     profilingProxyPassword = configProvider.getString(PROFILING_PROXY_PASSWORD);
 
     profilingExceptionSampleLimit =
-      configProvider.getInteger(
-        PROFILING_EXCEPTION_SAMPLE_LIMIT, DEFAULT_PROFILING_EXCEPTION_SAMPLE_LIMIT);
+        configProvider.getInteger(
+            PROFILING_EXCEPTION_SAMPLE_LIMIT, DEFAULT_PROFILING_EXCEPTION_SAMPLE_LIMIT);
     profilingExceptionHistogramTopItems =
-      configProvider.getInteger(
-        PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS,
-        DEFAULT_PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS);
+        configProvider.getInteger(
+            PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS,
+            DEFAULT_PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS);
     profilingExceptionHistogramMaxCollectionSize =
-      configProvider.getInteger(
-        PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE,
-        DEFAULT_PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE);
+        configProvider.getInteger(
+            PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE,
+            DEFAULT_PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE);
 
     kafkaClientPropagationEnabled =
-      configProvider.getBoolean(
-        KAFKA_CLIENT_PROPAGATION_ENABLED, DEFAULT_KAFKA_CLIENT_PROPAGATION_ENABLED);
+        configProvider.getBoolean(
+            KAFKA_CLIENT_PROPAGATION_ENABLED, DEFAULT_KAFKA_CLIENT_PROPAGATION_ENABLED);
 
     kafkaClientBase64DecodingEnabled =
-      configProvider.getBoolean(KAFKA_CLIENT_BASE64_DECODING_ENABLED, false);
+        configProvider.getBoolean(KAFKA_CLIENT_BASE64_DECODING_ENABLED, false);
 
     hystrixTagsEnabled = configProvider.getBoolean(HYSTRIX_TAGS_ENABLED, false);
 
     servletPrincipalEnabled =
-      configProvider.getBoolean(TraceInstrumentationConfig.SERVLET_PRINCIPAL_ENABLED, false);
+        configProvider.getBoolean(TraceInstrumentationConfig.SERVLET_PRINCIPAL_ENABLED, false);
 
     debugEnabled = isDebugMode();
 
@@ -711,9 +625,7 @@ public class Config {
     log.debug("New instance: {}", this);
   }
 
-  /**
-   * @return A map of tags to be applied only to the local application root span.
-   */
+  /** @return A map of tags to be applied only to the local application root span. */
   public Map<String, String> getLocalRootSpanTags() {
     final Map<String, String> runtimeTags = getRuntimeTags();
     final Map<String, String> result = new HashMap<>(runtimeTags);
@@ -740,8 +652,8 @@ public class Config {
   public Map<String, String> getMergedJmxTags() {
     final Map<String, String> runtimeTags = getRuntimeTags();
     final Map<String, String> result =
-      newHashMap(
-        getGlobalTags().size() + jmxTags.size() + runtimeTags.size() + 1 /* for serviceName */);
+        newHashMap(
+            getGlobalTags().size() + jmxTags.size() + runtimeTags.size() + 1 /* for serviceName */);
     result.putAll(getGlobalTags());
     result.putAll(jmxTags);
     result.putAll(runtimeTags);
@@ -756,11 +668,11 @@ public class Config {
     final Map<String, String> runtimeTags = getRuntimeTags();
     final String host = getHostName();
     final Map<String, String> result =
-      newHashMap(
-        getGlobalTags().size()
-          + profilingTags.size()
-          + runtimeTags.size()
-          + 3 /* for serviceName and host and language */);
+        newHashMap(
+            getGlobalTags().size()
+                + profilingTags.size()
+                + runtimeTags.size()
+                + 3 /* for serviceName and host and language */);
     result.put(HOST_TAG, host); // Host goes first to allow to override it
     result.putAll(getGlobalTags());
     result.putAll(profilingTags);
@@ -823,18 +735,18 @@ public class Config {
   }
 
   public boolean isIntegrationEnabled(
-    final SortedSet<String> integrationNames, final boolean defaultEnabled) {
+      final SortedSet<String> integrationNames, final boolean defaultEnabled) {
     return isEnabled(integrationNames, "integration.", ".enabled", defaultEnabled);
   }
 
   public boolean isJmxFetchIntegrationEnabled(
-    final SortedSet<String> integrationNames, final boolean defaultEnabled) {
+      final SortedSet<String> integrationNames, final boolean defaultEnabled) {
     return isEnabled(integrationNames, "jmxfetch.", ".enabled", defaultEnabled);
   }
 
   public boolean isRuleEnabled(final String name) {
     return configProvider.getBoolean("trace." + name + ".enabled", true)
-      && configProvider.getBoolean("trace." + name.toLowerCase() + ".enabled", true);
+        && configProvider.getBoolean("trace." + name.toLowerCase() + ".enabled", true);
   }
 
   /**
@@ -842,25 +754,25 @@ public class Config {
    * @param defaultEnabled
    * @return
    * @deprecated This method should only be used internally. Use the instance getter instead {@link
-   * #isJmxFetchIntegrationEnabled(SortedSet, boolean)}.
+   *     #isJmxFetchIntegrationEnabled(SortedSet, boolean)}.
    */
   public static boolean jmxFetchIntegrationEnabled(
-    final SortedSet<String> integrationNames, final boolean defaultEnabled) {
+      final SortedSet<String> integrationNames, final boolean defaultEnabled) {
     return Config.get().isJmxFetchIntegrationEnabled(integrationNames, defaultEnabled);
   }
 
   public boolean isEndToEndDurationEnabled(
-    final boolean defaultEnabled, final String... integrationNames) {
+      final boolean defaultEnabled, final String... integrationNames) {
     return isEnabled(Arrays.asList(integrationNames), "", ".e2e.duration.enabled", defaultEnabled);
   }
 
   public boolean isTraceAnalyticsIntegrationEnabled(
-    final SortedSet<String> integrationNames, final boolean defaultEnabled) {
+      final SortedSet<String> integrationNames, final boolean defaultEnabled) {
     return isEnabled(integrationNames, "", ".analytics.enabled", defaultEnabled);
   }
 
   public boolean isTraceAnalyticsIntegrationEnabled(
-    final boolean defaultEnabled, final String... integrationNames) {
+      final boolean defaultEnabled, final String... integrationNames) {
     return isEnabled(Arrays.asList(integrationNames), "", ".analytics.enabled", defaultEnabled);
   }
 
@@ -873,7 +785,7 @@ public class Config {
     }
 
     final String tracerDebugLevelEnv =
-      System.getenv(tracerDebugLevelSysprop.replace('.', '_').toUpperCase());
+        System.getenv(tracerDebugLevelSysprop.replace('.', '_').toUpperCase());
 
     if (tracerDebugLevelEnv != null) {
       return Boolean.parseBoolean(tracerDebugLevelEnv);
@@ -886,24 +798,24 @@ public class Config {
    * @param defaultEnabled
    * @return
    * @deprecated This method should only be used internally. Use the instance getter instead {@link
-   * #isTraceAnalyticsIntegrationEnabled(SortedSet, boolean)}.
+   *     #isTraceAnalyticsIntegrationEnabled(SortedSet, boolean)}.
    */
   public static boolean traceAnalyticsIntegrationEnabled(
-    final SortedSet<String> integrationNames, final boolean defaultEnabled) {
+      final SortedSet<String> integrationNames, final boolean defaultEnabled) {
     return Config.get().isTraceAnalyticsIntegrationEnabled(integrationNames, defaultEnabled);
   }
 
   private boolean isEnabled(
-    final Iterable<String> integrationNames,
-    final String settingPrefix,
-    final String settingSuffix,
-    final boolean defaultEnabled) {
+      final Iterable<String> integrationNames,
+      final String settingPrefix,
+      final String settingSuffix,
+      final boolean defaultEnabled) {
     // If default is enabled, we want to enable individually,
     // if default is disabled, we want to disable individually.
     boolean anyEnabled = defaultEnabled;
     for (final String name : integrationNames) {
       final boolean configEnabled =
-        configProvider.getBoolean(settingPrefix + name + settingSuffix, defaultEnabled);
+          configProvider.getBoolean(settingPrefix + name + settingSuffix, defaultEnabled);
       if (defaultEnabled) {
         anyEnabled &= configEnabled;
       } else {
@@ -918,15 +830,15 @@ public class Config {
    * splitting by space or comma.
    */
   private Set<PropagationStyle> getPropagationStyleSetSettingFromEnvironmentOrDefault(
-    final String name, final String defaultValue) {
+      final String name, final String defaultValue) {
     final String value = configProvider.getString(name, defaultValue);
     Set<PropagationStyle> result =
-      convertStringSetToPropagationStyleSet(parseStringIntoSetOfNonEmptyStrings(value));
+        convertStringSetToPropagationStyleSet(parseStringIntoSetOfNonEmptyStrings(value));
 
     if (result.isEmpty()) {
       // Treat empty parsing result as no value and use default instead
       result =
-        convertStringSetToPropagationStyleSet(parseStringIntoSetOfNonEmptyStrings(defaultValue));
+          convertStringSetToPropagationStyleSet(parseStringIntoSetOfNonEmptyStrings(defaultValue));
     }
 
     return result;
@@ -942,8 +854,8 @@ public class Config {
   @NonNull
   private static String propertyNameToEnvironmentVariableName(final String setting) {
     return ENV_REPLACEMENT
-      .matcher(propertyNameToSystemPropertyName(setting).toUpperCase())
-      .replaceAll("_");
+        .matcher(propertyNameToSystemPropertyName(setting).toUpperCase())
+        .replaceAll("_");
   }
 
   private static final String PREFIX = "dd.";
@@ -972,7 +884,7 @@ public class Config {
    */
   @NonNull
   private Map<String, String> getMapWithPropertiesDefinedByEnvironment(
-    @NonNull final Map<String, String> map, @NonNull final String... propNames) {
+      @NonNull final Map<String, String> map, @NonNull final String... propNames) {
     final Map<String, String> res = new HashMap<>(map);
     for (final String propName : propNames) {
       final String val = configProvider.getString(propName);
@@ -999,7 +911,7 @@ public class Config {
 
   @NonNull
   private static Set<PropagationStyle> convertStringSetToPropagationStyleSet(
-    final Set<String> input) {
+      final Set<String> input) {
     // Using LinkedHashSet to preserve original string order
     final Set<PropagationStyle> result = new LinkedHashSet<>();
     for (final String value : input) {
@@ -1014,14 +926,14 @@ public class Config {
 
   private static String findConfigurationFile() {
     String configurationFilePath =
-      System.getProperty(propertyNameToSystemPropertyName(CONFIGURATION_FILE));
+        System.getProperty(propertyNameToSystemPropertyName(CONFIGURATION_FILE));
     if (null == configurationFilePath) {
       configurationFilePath =
-        System.getenv(propertyNameToEnvironmentVariableName(CONFIGURATION_FILE));
+          System.getenv(propertyNameToEnvironmentVariableName(CONFIGURATION_FILE));
     }
     if (null != configurationFilePath) {
       configurationFilePath =
-        configurationFilePath.replaceFirst("^~", System.getProperty("user.home"));
+          configurationFilePath.replaceFirst("^~", System.getProperty("user.home"));
       final File configurationFile = new File(configurationFilePath);
       if (!configurationFile.exists()) {
         return configurationFilePath;
@@ -1030,9 +942,7 @@ public class Config {
     return "no config file present";
   }
 
-  /**
-   * Returns the detected hostname. First tries locally, then using DNS
-   */
+  /** Returns the detected hostname. First tries locally, then using DNS */
   private static String getHostName() {
     String possibleHostname;
 
@@ -1050,8 +960,8 @@ public class Config {
 
     // Try hostname command
     try (final BufferedReader reader =
-           new BufferedReader(
-             new InputStreamReader(Runtime.getRuntime().exec("hostname").getInputStream()))) {
+        new BufferedReader(
+            new InputStreamReader(Runtime.getRuntime().exec("hostname").getInputStream()))) {
       possibleHostname = reader.readLine();
     } catch (final Exception ignore) {
       // Ignore.  Hostname command is not always available

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -18,6 +18,7 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_KAFKA_CLIENT_PROPAGATION_
 import static datadog.trace.api.ConfigDefaults.DEFAULT_LOGS_INJECTION_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_METRICS_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PARTIAL_FLUSH_MIN_SPANS;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_PRIORITIZATION_TYPE;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PRIORITY_SAMPLING_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE;
@@ -63,6 +64,11 @@ import datadog.trace.api.config.ProfilingConfig;
 import datadog.trace.api.config.TraceInstrumentationConfig;
 import datadog.trace.api.config.TracerConfig;
 import datadog.trace.bootstrap.config.provider.ConfigProvider;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
@@ -84,10 +90,6 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.UUID;
 import java.util.regex.Pattern;
-import lombok.Getter;
-import lombok.NonNull;
-import lombok.ToString;
-import lombok.extern.slf4j.Slf4j;
 
 /**
  * Config reads values with the following priority: 1) system properties, 2) environment variables,
@@ -104,7 +106,9 @@ import lombok.extern.slf4j.Slf4j;
 @ToString(includeFieldNames = true)
 public class Config {
 
-  /** Config keys below */
+  /**
+   * Config keys below
+   */
   public static final String CONFIGURATION_FILE = GeneralConfig.CONFIGURATION_FILE;
 
   public static final String API_KEY = GeneralConfig.API_KEY;
@@ -115,6 +119,7 @@ public class Config {
   public static final String INTEGRATIONS_ENABLED = TraceInstrumentationConfig.INTEGRATIONS_ENABLED;
   public static final String ID_GENERATION_STRATEGY = TracerConfig.ID_GENERATION_STRATEGY;
   public static final String WRITER_TYPE = TracerConfig.WRITER_TYPE;
+  public static final String PRIORITIZATION_TYPE = TracerConfig.PRIORITIZATION_TYPE;
   public static final String AGENT_HOST = TracerConfig.AGENT_HOST;
   public static final String TRACE_AGENT_PORT = TracerConfig.TRACE_AGENT_PORT;
   public static final String AGENT_PORT_LEGACY = TracerConfig.AGENT_PORT_LEGACY;
@@ -140,11 +145,11 @@ public class Config {
   public static final String TRACE_EXECUTORS = TraceInstrumentationConfig.TRACE_EXECUTORS;
   public static final String TRACE_METHODS = TraceInstrumentationConfig.TRACE_METHODS;
   public static final String TRACE_CLASSES_EXCLUDE =
-      TraceInstrumentationConfig.TRACE_CLASSES_EXCLUDE;
+    TraceInstrumentationConfig.TRACE_CLASSES_EXCLUDE;
   public static final String TRACE_SAMPLING_SERVICE_RULES =
-      TracerConfig.TRACE_SAMPLING_SERVICE_RULES;
+    TracerConfig.TRACE_SAMPLING_SERVICE_RULES;
   public static final String TRACE_SAMPLING_OPERATION_RULES =
-      TracerConfig.TRACE_SAMPLING_OPERATION_RULES;
+    TracerConfig.TRACE_SAMPLING_OPERATION_RULES;
   public static final String TRACE_SAMPLE_RATE = TracerConfig.TRACE_SAMPLE_RATE;
   public static final String TRACE_RATE_LIMIT = TracerConfig.TRACE_RATE_LIMIT;
   public static final String TRACE_REPORT_HOSTNAME = TracerConfig.TRACE_REPORT_HOSTNAME;
@@ -152,19 +157,19 @@ public class Config {
   public static final String HTTP_SERVER_ERROR_STATUSES = TracerConfig.HTTP_SERVER_ERROR_STATUSES;
   public static final String HTTP_CLIENT_ERROR_STATUSES = TracerConfig.HTTP_CLIENT_ERROR_STATUSES;
   public static final String HTTP_SERVER_TAG_QUERY_STRING =
-      TraceInstrumentationConfig.HTTP_SERVER_TAG_QUERY_STRING;
+    TraceInstrumentationConfig.HTTP_SERVER_TAG_QUERY_STRING;
   public static final String HTTP_CLIENT_TAG_QUERY_STRING =
-      TraceInstrumentationConfig.HTTP_CLIENT_TAG_QUERY_STRING;
+    TraceInstrumentationConfig.HTTP_CLIENT_TAG_QUERY_STRING;
   public static final String HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN =
-      TraceInstrumentationConfig.HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN;
+    TraceInstrumentationConfig.HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN;
   public static final String DB_CLIENT_HOST_SPLIT_BY_INSTANCE =
-      TraceInstrumentationConfig.DB_CLIENT_HOST_SPLIT_BY_INSTANCE;
+    TraceInstrumentationConfig.DB_CLIENT_HOST_SPLIT_BY_INSTANCE;
   public static final String SPLIT_BY_TAGS = TracerConfig.SPLIT_BY_TAGS;
   public static final String SCOPE_DEPTH_LIMIT = TracerConfig.SCOPE_DEPTH_LIMIT;
   public static final String SCOPE_STRICT_MODE = TracerConfig.SCOPE_STRICT_MODE;
   public static final String PARTIAL_FLUSH_MIN_SPANS = TracerConfig.PARTIAL_FLUSH_MIN_SPANS;
   public static final String RUNTIME_CONTEXT_FIELD_INJECTION =
-      TraceInstrumentationConfig.RUNTIME_CONTEXT_FIELD_INJECTION;
+    TraceInstrumentationConfig.RUNTIME_CONTEXT_FIELD_INJECTION;
   public static final String PROPAGATION_STYLE_EXTRACT = TracerConfig.PROPAGATION_STYLE_EXTRACT;
   public static final String PROPAGATION_STYLE_INJECT = TracerConfig.PROPAGATION_STYLE_INJECT;
 
@@ -177,7 +182,7 @@ public class Config {
 
   public static final String JMX_FETCH_CHECK_PERIOD = JmxFetchConfig.JMX_FETCH_CHECK_PERIOD;
   public static final String JMX_FETCH_REFRESH_BEANS_PERIOD =
-      JmxFetchConfig.JMX_FETCH_REFRESH_BEANS_PERIOD;
+    JmxFetchConfig.JMX_FETCH_REFRESH_BEANS_PERIOD;
   public static final String JMX_FETCH_STATSD_HOST = JmxFetchConfig.JMX_FETCH_STATSD_HOST;
   public static final String JMX_FETCH_STATSD_PORT = JmxFetchConfig.JMX_FETCH_STATSD_PORT;
 
@@ -186,7 +191,7 @@ public class Config {
   public static final String HEALTH_METRICS_STATSD_PORT = GeneralConfig.HEALTH_METRICS_STATSD_PORT;
 
   public static final String LOGS_INJECTION_ENABLED =
-      TraceInstrumentationConfig.LOGS_INJECTION_ENABLED;
+    TraceInstrumentationConfig.LOGS_INJECTION_ENABLED;
 
   public static final String PROFILING_ENABLED = ProfilingConfig.PROFILING_ENABLED;
   @Deprecated // Use dd.site instead
@@ -195,41 +200,41 @@ public class Config {
   public static final String PROFILING_API_KEY_OLD = ProfilingConfig.PROFILING_API_KEY_OLD;
   @Deprecated // Use dd.api-key-file instead
   public static final String PROFILING_API_KEY_FILE_OLD =
-      ProfilingConfig.PROFILING_API_KEY_FILE_OLD;
+    ProfilingConfig.PROFILING_API_KEY_FILE_OLD;
   @Deprecated // Use dd.api-key instead
   public static final String PROFILING_API_KEY_VERY_OLD =
-      ProfilingConfig.PROFILING_API_KEY_VERY_OLD;
+    ProfilingConfig.PROFILING_API_KEY_VERY_OLD;
   @Deprecated // Use dd.api-key-file instead
   public static final String PROFILING_API_KEY_FILE_VERY_OLD =
-      ProfilingConfig.PROFILING_API_KEY_FILE_VERY_OLD;
+    ProfilingConfig.PROFILING_API_KEY_FILE_VERY_OLD;
   public static final String PROFILING_TAGS = ProfilingConfig.PROFILING_TAGS;
   public static final String PROFILING_START_DELAY = ProfilingConfig.PROFILING_START_DELAY;
   // DANGEROUS! May lead on sigsegv on JVMs before 14
   // Not intended for production use
   public static final String PROFILING_START_FORCE_FIRST =
-      ProfilingConfig.PROFILING_START_FORCE_FIRST;
+    ProfilingConfig.PROFILING_START_FORCE_FIRST;
   public static final String PROFILING_UPLOAD_PERIOD = ProfilingConfig.PROFILING_UPLOAD_PERIOD;
   public static final String PROFILING_TEMPLATE_OVERRIDE_FILE =
-      ProfilingConfig.PROFILING_TEMPLATE_OVERRIDE_FILE;
+    ProfilingConfig.PROFILING_TEMPLATE_OVERRIDE_FILE;
   public static final String PROFILING_UPLOAD_TIMEOUT = ProfilingConfig.PROFILING_UPLOAD_TIMEOUT;
   public static final String PROFILING_UPLOAD_COMPRESSION =
-      ProfilingConfig.PROFILING_UPLOAD_COMPRESSION;
+    ProfilingConfig.PROFILING_UPLOAD_COMPRESSION;
   public static final String PROFILING_PROXY_HOST = ProfilingConfig.PROFILING_PROXY_HOST;
   public static final String PROFILING_PROXY_PORT = ProfilingConfig.PROFILING_PROXY_PORT;
   public static final String PROFILING_PROXY_USERNAME = ProfilingConfig.PROFILING_PROXY_USERNAME;
   public static final String PROFILING_PROXY_PASSWORD = ProfilingConfig.PROFILING_PROXY_PASSWORD;
   public static final String PROFILING_EXCEPTION_SAMPLE_LIMIT =
-      ProfilingConfig.PROFILING_EXCEPTION_SAMPLE_LIMIT;
+    ProfilingConfig.PROFILING_EXCEPTION_SAMPLE_LIMIT;
   public static final String PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS =
-      ProfilingConfig.PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS;
+    ProfilingConfig.PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS;
   public static final String PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE =
-      ProfilingConfig.PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE;
+    ProfilingConfig.PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE;
 
   public static final String KAFKA_CLIENT_PROPAGATION_ENABLED =
-      TraceInstrumentationConfig.KAFKA_CLIENT_PROPAGATION_ENABLED;
+    TraceInstrumentationConfig.KAFKA_CLIENT_PROPAGATION_ENABLED;
 
   public static final String KAFKA_CLIENT_BASE64_DECODING_ENABLED =
-      TraceInstrumentationConfig.KAFKA_CLIENT_BASE64_DECODING_ENABLED;
+    TraceInstrumentationConfig.KAFKA_CLIENT_BASE64_DECODING_ENABLED;
 
   private static final String PROFILING_REMOTE_URL_TEMPLATE = "https://intake.profile.%s/v1/input";
   private static final String PROFILING_LOCAL_URL_TEMPLATE = "http://%s:%d/profiling/v1/input";
@@ -237,13 +242,17 @@ public class Config {
   private static final Pattern ENV_REPLACEMENT = Pattern.compile("[^a-zA-Z0-9_]");
   private static final String SPLIT_BY_SPACE_OR_COMMA_REGEX = "[,\\s]+";
 
-  /** Used for masking sensitive information when doing toString */
+  /**
+   * Used for masking sensitive information when doing toString
+   */
   @ToString.Include(name = "apiKey")
   private String profilingApiKeyMasker() {
     return apiKey != null ? "****" : null;
   }
 
-  /** Used for masking sensitive information when doing toString */
+  /**
+   * Used for masking sensitive information when doing toString
+   */
   @ToString.Include(name = "profilingProxyPassword")
   private String profilingProxyPasswordMasker() {
     return profilingProxyPassword != null ? "****" : null;
@@ -253,122 +262,202 @@ public class Config {
    * this is a random UUID that gets generated on JVM start up and is attached to every root span
    * and every JMX metric that is sent out.
    */
-  @Getter private final String runtimeId;
+  @Getter
+  private final String runtimeId;
 
   /**
    * Note: this has effect only on profiling site. Traces are sent to Datadog agent and are not
    * affected by this setting.
    */
-  @Getter private final String apiKey;
+  @Getter
+  private final String apiKey;
   /**
    * Note: this has effect only on profiling site. Traces are sent to Datadog agent and are not
    * affected by this setting.
    */
-  @Getter private final String site;
+  @Getter
+  private final String site;
 
-  @Getter private final String serviceName;
-  @Getter private final boolean traceEnabled;
-  @Getter private final boolean integrationsEnabled;
-  @Getter private final String writerType;
-  @Getter private final boolean agentConfiguredUsingDefault;
-  @Getter private final String agentHost;
-  @Getter private final int agentPort;
-  @Getter private final String agentUnixDomainSocket;
-  @Getter private final int agentTimeout;
-  @Getter private final boolean prioritySamplingEnabled;
-  @Getter private final boolean traceResolverEnabled;
-  @Getter private final Map<String, String> serviceMapping;
-  @NonNull private final Map<String, String> tags;
+  @Getter
+  private final String serviceName;
+  @Getter
+  private final boolean traceEnabled;
+  @Getter
+  private final boolean integrationsEnabled;
+  @Getter
+  private final String writerType;
+  @Getter
+  private final String prioritizationType;
+  @Getter
+  private final boolean agentConfiguredUsingDefault;
+  @Getter
+  private final String agentHost;
+  @Getter
+  private final int agentPort;
+  @Getter
+  private final String agentUnixDomainSocket;
+  @Getter
+  private final int agentTimeout;
+  @Getter
+  private final boolean prioritySamplingEnabled;
+  @Getter
+  private final boolean traceResolverEnabled;
+  @Getter
+  private final Map<String, String> serviceMapping;
+  @NonNull
+  private final Map<String, String> tags;
   private final Map<String, String> spanTags;
   private final Map<String, String> jmxTags;
-  @Getter private final List<String> excludedClasses;
-  @Getter private final Map<String, String> headerTags;
-  @Getter private final BitSet httpServerErrorStatuses;
-  @Getter private final BitSet httpClientErrorStatuses;
-  @Getter private final boolean httpServerTagQueryString;
-  @Getter private final boolean httpClientTagQueryString;
-  @Getter private final boolean httpClientSplitByDomain;
-  @Getter private final boolean dbClientSplitByInstance;
-  @Getter private final Set<String> splitByTags;
-  @Getter private final int scopeDepthLimit;
-  @Getter private final boolean scopeStrictMode;
-  @Getter private final int partialFlushMinSpans;
-  @Getter private final boolean runtimeContextFieldInjection;
-  @Getter private final Set<PropagationStyle> propagationStylesToExtract;
-  @Getter private final Set<PropagationStyle> propagationStylesToInject;
+  @Getter
+  private final List<String> excludedClasses;
+  @Getter
+  private final Map<String, String> headerTags;
+  @Getter
+  private final BitSet httpServerErrorStatuses;
+  @Getter
+  private final BitSet httpClientErrorStatuses;
+  @Getter
+  private final boolean httpServerTagQueryString;
+  @Getter
+  private final boolean httpClientTagQueryString;
+  @Getter
+  private final boolean httpClientSplitByDomain;
+  @Getter
+  private final boolean dbClientSplitByInstance;
+  @Getter
+  private final Set<String> splitByTags;
+  @Getter
+  private final int scopeDepthLimit;
+  @Getter
+  private final boolean scopeStrictMode;
+  @Getter
+  private final int partialFlushMinSpans;
+  @Getter
+  private final boolean runtimeContextFieldInjection;
+  @Getter
+  private final Set<PropagationStyle> propagationStylesToExtract;
+  @Getter
+  private final Set<PropagationStyle> propagationStylesToInject;
 
-  @Getter private final boolean jmxFetchEnabled;
-  @Getter private final String jmxFetchConfigDir;
-  @Getter private final List<String> jmxFetchConfigs;
-  @Deprecated @Getter private final List<String> jmxFetchMetricsConfigs;
-  @Getter private final Integer jmxFetchCheckPeriod;
-  @Getter private final Integer jmxFetchRefreshBeansPeriod;
-  @Getter private final String jmxFetchStatsdHost;
-  @Getter private final Integer jmxFetchStatsdPort;
+  @Getter
+  private final boolean jmxFetchEnabled;
+  @Getter
+  private final String jmxFetchConfigDir;
+  @Getter
+  private final List<String> jmxFetchConfigs;
+  @Deprecated
+  @Getter
+  private final List<String> jmxFetchMetricsConfigs;
+  @Getter
+  private final Integer jmxFetchCheckPeriod;
+  @Getter
+  private final Integer jmxFetchRefreshBeansPeriod;
+  @Getter
+  private final String jmxFetchStatsdHost;
+  @Getter
+  private final Integer jmxFetchStatsdPort;
 
   // These values are default-ed to those of jmx fetch values as needed
-  @Getter private final boolean healthMetricsEnabled;
-  @Getter private final String healthMetricsStatsdHost;
-  @Getter private final Integer healthMetricsStatsdPort;
+  @Getter
+  private final boolean healthMetricsEnabled;
+  @Getter
+  private final String healthMetricsStatsdHost;
+  @Getter
+  private final Integer healthMetricsStatsdPort;
 
-  @Getter private final boolean logsInjectionEnabled;
-  @Getter private final boolean logsMDCTagsInjectionEnabled;
-  @Getter private final boolean reportHostName;
+  @Getter
+  private final boolean logsInjectionEnabled;
+  @Getter
+  private final boolean logsMDCTagsInjectionEnabled;
+  @Getter
+  private final boolean reportHostName;
 
-  @Getter private final String traceAnnotations;
+  @Getter
+  private final String traceAnnotations;
 
-  @Getter private final String traceMethods;
+  @Getter
+  private final String traceMethods;
 
-  @Getter private final boolean traceExecutorsAll;
-  @Getter private final List<String> traceExecutors;
+  @Getter
+  private final boolean traceExecutorsAll;
+  @Getter
+  private final List<String> traceExecutors;
 
-  @Getter private final boolean traceAnalyticsEnabled;
+  @Getter
+  private final boolean traceAnalyticsEnabled;
 
-  @Getter private final Map<String, String> traceSamplingServiceRules;
-  @Getter private final Map<String, String> traceSamplingOperationRules;
-  @Getter private final Double traceSampleRate;
-  @Getter private final Double traceRateLimit;
+  @Getter
+  private final Map<String, String> traceSamplingServiceRules;
+  @Getter
+  private final Map<String, String> traceSamplingOperationRules;
+  @Getter
+  private final Double traceSampleRate;
+  @Getter
+  private final Double traceRateLimit;
 
-  @Getter private final boolean profilingEnabled;
-  @Deprecated private final String profilingUrl;
+  @Getter
+  private final boolean profilingEnabled;
+  @Deprecated
+  private final String profilingUrl;
   private final Map<String, String> profilingTags;
-  @Getter private final int profilingStartDelay;
-  @Getter private final boolean profilingStartForceFirst;
-  @Getter private final int profilingUploadPeriod;
-  @Getter private final String profilingTemplateOverrideFile;
-  @Getter private final int profilingUploadTimeout;
-  @Getter private final String profilingUploadCompression;
-  @Getter private final String profilingProxyHost;
-  @Getter private final int profilingProxyPort;
-  @Getter private final String profilingProxyUsername;
-  @Getter private final String profilingProxyPassword;
-  @Getter private final int profilingExceptionSampleLimit;
-  @Getter private final int profilingExceptionHistogramTopItems;
-  @Getter private final int profilingExceptionHistogramMaxCollectionSize;
+  @Getter
+  private final int profilingStartDelay;
+  @Getter
+  private final boolean profilingStartForceFirst;
+  @Getter
+  private final int profilingUploadPeriod;
+  @Getter
+  private final String profilingTemplateOverrideFile;
+  @Getter
+  private final int profilingUploadTimeout;
+  @Getter
+  private final String profilingUploadCompression;
+  @Getter
+  private final String profilingProxyHost;
+  @Getter
+  private final int profilingProxyPort;
+  @Getter
+  private final String profilingProxyUsername;
+  @Getter
+  private final String profilingProxyPassword;
+  @Getter
+  private final int profilingExceptionSampleLimit;
+  @Getter
+  private final int profilingExceptionHistogramTopItems;
+  @Getter
+  private final int profilingExceptionHistogramMaxCollectionSize;
 
-  @Getter private final boolean kafkaClientPropagationEnabled;
-  @Getter private final boolean kafkaClientBase64DecodingEnabled;
+  @Getter
+  private final boolean kafkaClientPropagationEnabled;
+  @Getter
+  private final boolean kafkaClientBase64DecodingEnabled;
 
-  @Getter private final boolean hystrixTagsEnabled;
-  @Getter private final boolean servletPrincipalEnabled;
+  @Getter
+  private final boolean hystrixTagsEnabled;
+  @Getter
+  private final boolean servletPrincipalEnabled;
 
-  @Getter private final boolean traceAgentV05Enabled;
+  @Getter
+  private final boolean traceAgentV05Enabled;
 
-  @Getter private final boolean debugEnabled;
-  @Getter private final String configFile;
+  @Getter
+  private final boolean debugEnabled;
+  @Getter
+  private final String configFile;
 
-  @Getter private final IdGenerationStrategy idGenerationStrategy;
+  @Getter
+  private final IdGenerationStrategy idGenerationStrategy;
 
   private final ConfigProvider configProvider;
 
   // Read order: System Properties -> Env Variables, [-> properties file], [-> default value]
   private Config() {
     this(
-        INSTANCE != null ? INSTANCE.runtimeId : UUID.randomUUID().toString(),
-        ConfigProvider.createDefault());
+      INSTANCE != null ? INSTANCE.runtimeId : UUID.randomUUID().toString(),
+      ConfigProvider.createDefault());
   }
 
-  private Config(final String runtimeId, ConfigProvider configProvider) {
+  private Config(final String runtimeId, final ConfigProvider configProvider) {
     this.configProvider = configProvider;
     configFile = findConfigurationFile();
     this.runtimeId = runtimeId;
@@ -381,7 +470,7 @@ public class Config {
     if (apiKeyFile != null) {
       try {
         tmpApiKey =
-            new String(Files.readAllBytes(Paths.get(apiKeyFile)), StandardCharsets.UTF_8).trim();
+          new String(Files.readAllBytes(Paths.get(apiKeyFile)), StandardCharsets.UTF_8).trim();
       } catch (final IOException e) {
         log.error("Cannot read API key from file {}, skipping", apiKeyFile, e);
       }
@@ -391,15 +480,18 @@ public class Config {
 
     traceEnabled = configProvider.getBoolean(TRACE_ENABLED, DEFAULT_TRACE_ENABLED);
     integrationsEnabled =
-        configProvider.getBoolean(INTEGRATIONS_ENABLED, DEFAULT_INTEGRATIONS_ENABLED);
+      configProvider.getBoolean(INTEGRATIONS_ENABLED, DEFAULT_INTEGRATIONS_ENABLED);
     writerType = configProvider.getString(WRITER_TYPE, DEFAULT_AGENT_WRITER_TYPE);
+    prioritizationType = configProvider.getString(PRIORITIZATION_TYPE, DEFAULT_PRIORITIZATION_TYPE);
+
     idGenerationStrategy =
-        configProvider.getEnum(ID_GENERATION_STRATEGY, IdGenerationStrategy.class, RANDOM);
+      configProvider.getEnum(ID_GENERATION_STRATEGY, IdGenerationStrategy.class, RANDOM);
     if (idGenerationStrategy != RANDOM) {
       log.warn(
-          "*** you are using an unsupported id generation strategy {} - this can impact correctness of traces",
-          idGenerationStrategy);
+        "*** you are using an unsupported id generation strategy {} - this can impact correctness of traces",
+        idGenerationStrategy);
     }
+
     // The extra code is to detect when defaults are used for agent configuration
     final boolean agentHostConfiguredUsingDefault;
     final String agentHostFromEnvironment = configProvider.getString(AGENT_HOST);
@@ -422,18 +514,18 @@ public class Config {
     }
 
     agentPort =
-        configProvider.getInteger(TRACE_AGENT_PORT, DEFAULT_TRACE_AGENT_PORT, AGENT_PORT_LEGACY);
+      configProvider.getInteger(TRACE_AGENT_PORT, DEFAULT_TRACE_AGENT_PORT, AGENT_PORT_LEGACY);
 
     agentConfiguredUsingDefault =
-        agentHostConfiguredUsingDefault
-            && socketConfiguredUsingDefault
-            && agentPort == DEFAULT_TRACE_AGENT_PORT;
+      agentHostConfiguredUsingDefault
+        && socketConfiguredUsingDefault
+        && agentPort == DEFAULT_TRACE_AGENT_PORT;
 
     agentTimeout = configProvider.getInteger(AGENT_TIMEOUT, DEFAULT_AGENT_TIMEOUT);
     prioritySamplingEnabled =
-        configProvider.getBoolean(PRIORITY_SAMPLING, DEFAULT_PRIORITY_SAMPLING_ENABLED);
+      configProvider.getBoolean(PRIORITY_SAMPLING, DEFAULT_PRIORITY_SAMPLING_ENABLED);
     traceResolverEnabled =
-        configProvider.getBoolean(TRACE_RESOLVER_ENABLED, DEFAULT_TRACE_RESOLVER_ENABLED);
+      configProvider.getBoolean(TRACE_RESOLVER_ENABLED, DEFAULT_TRACE_RESOLVER_ENABLED);
     serviceMapping = configProvider.getMergedMap(SERVICE_MAPPING);
 
     {
@@ -449,49 +541,49 @@ public class Config {
     headerTags = configProvider.getMergedMap(HEADER_TAGS);
 
     httpServerErrorStatuses =
-        configProvider.getIntegerRange(
-            HTTP_SERVER_ERROR_STATUSES, DEFAULT_HTTP_SERVER_ERROR_STATUSES);
+      configProvider.getIntegerRange(
+        HTTP_SERVER_ERROR_STATUSES, DEFAULT_HTTP_SERVER_ERROR_STATUSES);
 
     httpClientErrorStatuses =
-        configProvider.getIntegerRange(
-            HTTP_CLIENT_ERROR_STATUSES, DEFAULT_HTTP_CLIENT_ERROR_STATUSES);
+      configProvider.getIntegerRange(
+        HTTP_CLIENT_ERROR_STATUSES, DEFAULT_HTTP_CLIENT_ERROR_STATUSES);
 
     httpServerTagQueryString =
-        configProvider.getBoolean(
-            HTTP_SERVER_TAG_QUERY_STRING, DEFAULT_HTTP_SERVER_TAG_QUERY_STRING);
+      configProvider.getBoolean(
+        HTTP_SERVER_TAG_QUERY_STRING, DEFAULT_HTTP_SERVER_TAG_QUERY_STRING);
 
     httpClientTagQueryString =
-        configProvider.getBoolean(
-            HTTP_CLIENT_TAG_QUERY_STRING, DEFAULT_HTTP_CLIENT_TAG_QUERY_STRING);
+      configProvider.getBoolean(
+        HTTP_CLIENT_TAG_QUERY_STRING, DEFAULT_HTTP_CLIENT_TAG_QUERY_STRING);
 
     httpClientSplitByDomain =
-        configProvider.getBoolean(
-            HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN, DEFAULT_HTTP_CLIENT_SPLIT_BY_DOMAIN);
+      configProvider.getBoolean(
+        HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN, DEFAULT_HTTP_CLIENT_SPLIT_BY_DOMAIN);
 
     dbClientSplitByInstance =
-        configProvider.getBoolean(
-            DB_CLIENT_HOST_SPLIT_BY_INSTANCE, DEFAULT_DB_CLIENT_HOST_SPLIT_BY_INSTANCE);
+      configProvider.getBoolean(
+        DB_CLIENT_HOST_SPLIT_BY_INSTANCE, DEFAULT_DB_CLIENT_HOST_SPLIT_BY_INSTANCE);
 
     splitByTags =
-        Collections.unmodifiableSet(new LinkedHashSet<>(configProvider.getList(SPLIT_BY_TAGS)));
+      Collections.unmodifiableSet(new LinkedHashSet<>(configProvider.getList(SPLIT_BY_TAGS)));
 
     scopeDepthLimit = configProvider.getInteger(SCOPE_DEPTH_LIMIT, DEFAULT_SCOPE_DEPTH_LIMIT);
 
     scopeStrictMode = configProvider.getBoolean(SCOPE_STRICT_MODE, false);
 
     partialFlushMinSpans =
-        configProvider.getInteger(PARTIAL_FLUSH_MIN_SPANS, DEFAULT_PARTIAL_FLUSH_MIN_SPANS);
+      configProvider.getInteger(PARTIAL_FLUSH_MIN_SPANS, DEFAULT_PARTIAL_FLUSH_MIN_SPANS);
 
     runtimeContextFieldInjection =
-        configProvider.getBoolean(
-            RUNTIME_CONTEXT_FIELD_INJECTION, DEFAULT_RUNTIME_CONTEXT_FIELD_INJECTION);
+      configProvider.getBoolean(
+        RUNTIME_CONTEXT_FIELD_INJECTION, DEFAULT_RUNTIME_CONTEXT_FIELD_INJECTION);
 
     propagationStylesToExtract =
-        getPropagationStyleSetSettingFromEnvironmentOrDefault(
-            PROPAGATION_STYLE_EXTRACT, DEFAULT_PROPAGATION_STYLE_EXTRACT);
+      getPropagationStyleSetSettingFromEnvironmentOrDefault(
+        PROPAGATION_STYLE_EXTRACT, DEFAULT_PROPAGATION_STYLE_EXTRACT);
     propagationStylesToInject =
-        getPropagationStyleSetSettingFromEnvironmentOrDefault(
-            PROPAGATION_STYLE_INJECT, DEFAULT_PROPAGATION_STYLE_INJECT);
+      getPropagationStyleSetSettingFromEnvironmentOrDefault(
+        PROPAGATION_STYLE_INJECT, DEFAULT_PROPAGATION_STYLE_INJECT);
 
     jmxFetchEnabled = configProvider.getBoolean(JMX_FETCH_ENABLED, DEFAULT_JMX_FETCH_ENABLED);
     jmxFetchConfigDir = configProvider.getString(JMX_FETCH_CONFIG_DIR);
@@ -501,22 +593,22 @@ public class Config {
     jmxFetchRefreshBeansPeriod = configProvider.getInteger(JMX_FETCH_REFRESH_BEANS_PERIOD);
     jmxFetchStatsdHost = configProvider.getString(JMX_FETCH_STATSD_HOST);
     jmxFetchStatsdPort =
-        configProvider.getInteger(JMX_FETCH_STATSD_PORT, DEFAULT_JMX_FETCH_STATSD_PORT);
+      configProvider.getInteger(JMX_FETCH_STATSD_PORT, DEFAULT_JMX_FETCH_STATSD_PORT);
 
     // Writer.Builder createMonitor will use the values of the JMX fetch & agent to fill-in defaults
     healthMetricsEnabled =
-        configProvider.getBoolean(HEALTH_METRICS_ENABLED, DEFAULT_METRICS_ENABLED);
+      configProvider.getBoolean(HEALTH_METRICS_ENABLED, DEFAULT_METRICS_ENABLED);
     healthMetricsStatsdHost = configProvider.getString(HEALTH_METRICS_STATSD_HOST);
     healthMetricsStatsdPort = configProvider.getInteger(HEALTH_METRICS_STATSD_PORT);
 
     logsInjectionEnabled =
-        configProvider.getBoolean(LOGS_INJECTION_ENABLED, DEFAULT_LOGS_INJECTION_ENABLED);
+      configProvider.getBoolean(LOGS_INJECTION_ENABLED, DEFAULT_LOGS_INJECTION_ENABLED);
     logsMDCTagsInjectionEnabled = configProvider.getBoolean(LOGS_MDC_TAGS_INJECTION_ENABLED, false);
     reportHostName =
-        configProvider.getBoolean(TRACE_REPORT_HOSTNAME, DEFAULT_TRACE_REPORT_HOSTNAME);
+      configProvider.getBoolean(TRACE_REPORT_HOSTNAME, DEFAULT_TRACE_REPORT_HOSTNAME);
 
     traceAgentV05Enabled =
-        configProvider.getBoolean(ENABLE_TRACE_AGENT_V05, DEFAULT_TRACE_AGENT_V05_ENABLED);
+      configProvider.getBoolean(ENABLE_TRACE_AGENT_V05, DEFAULT_TRACE_AGENT_V05_ENABLED);
 
     traceAnnotations = configProvider.getString(TRACE_ANNOTATIONS, DEFAULT_TRACE_ANNOTATIONS);
 
@@ -527,7 +619,7 @@ public class Config {
     traceExecutors = configProvider.getList(TRACE_EXECUTORS);
 
     traceAnalyticsEnabled =
-        configProvider.getBoolean(TRACE_ANALYTICS_ENABLED, DEFAULT_TRACE_ANALYTICS_ENABLED);
+      configProvider.getBoolean(TRACE_ANALYTICS_ENABLED, DEFAULT_TRACE_ANALYTICS_ENABLED);
 
     traceSamplingServiceRules = configProvider.getMergedMap(TRACE_SAMPLING_SERVICE_RULES);
     traceSamplingOperationRules = configProvider.getMergedMap(TRACE_SAMPLING_OPERATION_RULES);
@@ -543,9 +635,9 @@ public class Config {
       if (oldProfilingApiKeyFile != null) {
         try {
           tmpApiKey =
-              new String(
-                      Files.readAllBytes(Paths.get(oldProfilingApiKeyFile)), StandardCharsets.UTF_8)
-                  .trim();
+            new String(
+              Files.readAllBytes(Paths.get(oldProfilingApiKeyFile)), StandardCharsets.UTF_8)
+              .trim();
         } catch (final IOException e) {
           log.error("Cannot read API key from file {}, skipping", oldProfilingApiKeyFile, e);
         }
@@ -553,15 +645,15 @@ public class Config {
     }
     if (tmpApiKey == null) {
       final String veryOldProfilingApiKeyFile =
-          configProvider.getString(PROFILING_API_KEY_FILE_VERY_OLD);
+        configProvider.getString(PROFILING_API_KEY_FILE_VERY_OLD);
       tmpApiKey = System.getenv(propertyNameToEnvironmentVariableName(PROFILING_API_KEY_VERY_OLD));
       if (veryOldProfilingApiKeyFile != null) {
         try {
           tmpApiKey =
-              new String(
-                      Files.readAllBytes(Paths.get(veryOldProfilingApiKeyFile)),
-                      StandardCharsets.UTF_8)
-                  .trim();
+            new String(
+              Files.readAllBytes(Paths.get(veryOldProfilingApiKeyFile)),
+              StandardCharsets.UTF_8)
+              .trim();
         } catch (final IOException e) {
           log.error("Cannot read API key from file {}, skipping", veryOldProfilingApiKeyFile, e);
         }
@@ -570,46 +662,46 @@ public class Config {
 
     profilingTags = configProvider.getMergedMap(PROFILING_TAGS);
     profilingStartDelay =
-        configProvider.getInteger(PROFILING_START_DELAY, DEFAULT_PROFILING_START_DELAY);
+      configProvider.getInteger(PROFILING_START_DELAY, DEFAULT_PROFILING_START_DELAY);
     profilingStartForceFirst =
-        configProvider.getBoolean(PROFILING_START_FORCE_FIRST, DEFAULT_PROFILING_START_FORCE_FIRST);
+      configProvider.getBoolean(PROFILING_START_FORCE_FIRST, DEFAULT_PROFILING_START_FORCE_FIRST);
     profilingUploadPeriod =
-        configProvider.getInteger(PROFILING_UPLOAD_PERIOD, DEFAULT_PROFILING_UPLOAD_PERIOD);
+      configProvider.getInteger(PROFILING_UPLOAD_PERIOD, DEFAULT_PROFILING_UPLOAD_PERIOD);
     profilingTemplateOverrideFile = configProvider.getString(PROFILING_TEMPLATE_OVERRIDE_FILE);
     profilingUploadTimeout =
-        configProvider.getInteger(PROFILING_UPLOAD_TIMEOUT, DEFAULT_PROFILING_UPLOAD_TIMEOUT);
+      configProvider.getInteger(PROFILING_UPLOAD_TIMEOUT, DEFAULT_PROFILING_UPLOAD_TIMEOUT);
     profilingUploadCompression =
-        configProvider.getString(
-            PROFILING_UPLOAD_COMPRESSION, DEFAULT_PROFILING_UPLOAD_COMPRESSION);
+      configProvider.getString(
+        PROFILING_UPLOAD_COMPRESSION, DEFAULT_PROFILING_UPLOAD_COMPRESSION);
     profilingProxyHost = configProvider.getString(PROFILING_PROXY_HOST);
     profilingProxyPort =
-        configProvider.getInteger(PROFILING_PROXY_PORT, DEFAULT_PROFILING_PROXY_PORT);
+      configProvider.getInteger(PROFILING_PROXY_PORT, DEFAULT_PROFILING_PROXY_PORT);
     profilingProxyUsername = configProvider.getString(PROFILING_PROXY_USERNAME);
     profilingProxyPassword = configProvider.getString(PROFILING_PROXY_PASSWORD);
 
     profilingExceptionSampleLimit =
-        configProvider.getInteger(
-            PROFILING_EXCEPTION_SAMPLE_LIMIT, DEFAULT_PROFILING_EXCEPTION_SAMPLE_LIMIT);
+      configProvider.getInteger(
+        PROFILING_EXCEPTION_SAMPLE_LIMIT, DEFAULT_PROFILING_EXCEPTION_SAMPLE_LIMIT);
     profilingExceptionHistogramTopItems =
-        configProvider.getInteger(
-            PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS,
-            DEFAULT_PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS);
+      configProvider.getInteger(
+        PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS,
+        DEFAULT_PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS);
     profilingExceptionHistogramMaxCollectionSize =
-        configProvider.getInteger(
-            PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE,
-            DEFAULT_PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE);
+      configProvider.getInteger(
+        PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE,
+        DEFAULT_PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE);
 
     kafkaClientPropagationEnabled =
-        configProvider.getBoolean(
-            KAFKA_CLIENT_PROPAGATION_ENABLED, DEFAULT_KAFKA_CLIENT_PROPAGATION_ENABLED);
+      configProvider.getBoolean(
+        KAFKA_CLIENT_PROPAGATION_ENABLED, DEFAULT_KAFKA_CLIENT_PROPAGATION_ENABLED);
 
     kafkaClientBase64DecodingEnabled =
-        configProvider.getBoolean(KAFKA_CLIENT_BASE64_DECODING_ENABLED, false);
+      configProvider.getBoolean(KAFKA_CLIENT_BASE64_DECODING_ENABLED, false);
 
     hystrixTagsEnabled = configProvider.getBoolean(HYSTRIX_TAGS_ENABLED, false);
 
     servletPrincipalEnabled =
-        configProvider.getBoolean(TraceInstrumentationConfig.SERVLET_PRINCIPAL_ENABLED, false);
+      configProvider.getBoolean(TraceInstrumentationConfig.SERVLET_PRINCIPAL_ENABLED, false);
 
     debugEnabled = isDebugMode();
 
@@ -619,7 +711,9 @@ public class Config {
     log.debug("New instance: {}", this);
   }
 
-  /** @return A map of tags to be applied only to the local application root span. */
+  /**
+   * @return A map of tags to be applied only to the local application root span.
+   */
   public Map<String, String> getLocalRootSpanTags() {
     final Map<String, String> runtimeTags = getRuntimeTags();
     final Map<String, String> result = new HashMap<>(runtimeTags);
@@ -646,8 +740,8 @@ public class Config {
   public Map<String, String> getMergedJmxTags() {
     final Map<String, String> runtimeTags = getRuntimeTags();
     final Map<String, String> result =
-        newHashMap(
-            getGlobalTags().size() + jmxTags.size() + runtimeTags.size() + 1 /* for serviceName */);
+      newHashMap(
+        getGlobalTags().size() + jmxTags.size() + runtimeTags.size() + 1 /* for serviceName */);
     result.putAll(getGlobalTags());
     result.putAll(jmxTags);
     result.putAll(runtimeTags);
@@ -662,11 +756,11 @@ public class Config {
     final Map<String, String> runtimeTags = getRuntimeTags();
     final String host = getHostName();
     final Map<String, String> result =
-        newHashMap(
-            getGlobalTags().size()
-                + profilingTags.size()
-                + runtimeTags.size()
-                + 3 /* for serviceName and host and language */);
+      newHashMap(
+        getGlobalTags().size()
+          + profilingTags.size()
+          + runtimeTags.size()
+          + 3 /* for serviceName and host and language */);
     result.put(HOST_TAG, host); // Host goes first to allow to override it
     result.putAll(getGlobalTags());
     result.putAll(profilingTags);
@@ -729,18 +823,18 @@ public class Config {
   }
 
   public boolean isIntegrationEnabled(
-      final SortedSet<String> integrationNames, final boolean defaultEnabled) {
+    final SortedSet<String> integrationNames, final boolean defaultEnabled) {
     return isEnabled(integrationNames, "integration.", ".enabled", defaultEnabled);
   }
 
   public boolean isJmxFetchIntegrationEnabled(
-      final SortedSet<String> integrationNames, final boolean defaultEnabled) {
+    final SortedSet<String> integrationNames, final boolean defaultEnabled) {
     return isEnabled(integrationNames, "jmxfetch.", ".enabled", defaultEnabled);
   }
 
   public boolean isRuleEnabled(final String name) {
     return configProvider.getBoolean("trace." + name + ".enabled", true)
-        && configProvider.getBoolean("trace." + name.toLowerCase() + ".enabled", true);
+      && configProvider.getBoolean("trace." + name.toLowerCase() + ".enabled", true);
   }
 
   /**
@@ -748,25 +842,25 @@ public class Config {
    * @param defaultEnabled
    * @return
    * @deprecated This method should only be used internally. Use the instance getter instead {@link
-   *     #isJmxFetchIntegrationEnabled(SortedSet, boolean)}.
+   * #isJmxFetchIntegrationEnabled(SortedSet, boolean)}.
    */
   public static boolean jmxFetchIntegrationEnabled(
-      final SortedSet<String> integrationNames, final boolean defaultEnabled) {
+    final SortedSet<String> integrationNames, final boolean defaultEnabled) {
     return Config.get().isJmxFetchIntegrationEnabled(integrationNames, defaultEnabled);
   }
 
   public boolean isEndToEndDurationEnabled(
-      final boolean defaultEnabled, final String... integrationNames) {
+    final boolean defaultEnabled, final String... integrationNames) {
     return isEnabled(Arrays.asList(integrationNames), "", ".e2e.duration.enabled", defaultEnabled);
   }
 
   public boolean isTraceAnalyticsIntegrationEnabled(
-      final SortedSet<String> integrationNames, final boolean defaultEnabled) {
+    final SortedSet<String> integrationNames, final boolean defaultEnabled) {
     return isEnabled(integrationNames, "", ".analytics.enabled", defaultEnabled);
   }
 
   public boolean isTraceAnalyticsIntegrationEnabled(
-      final boolean defaultEnabled, final String... integrationNames) {
+    final boolean defaultEnabled, final String... integrationNames) {
     return isEnabled(Arrays.asList(integrationNames), "", ".analytics.enabled", defaultEnabled);
   }
 
@@ -779,7 +873,7 @@ public class Config {
     }
 
     final String tracerDebugLevelEnv =
-        System.getenv(tracerDebugLevelSysprop.replace('.', '_').toUpperCase());
+      System.getenv(tracerDebugLevelSysprop.replace('.', '_').toUpperCase());
 
     if (tracerDebugLevelEnv != null) {
       return Boolean.parseBoolean(tracerDebugLevelEnv);
@@ -792,24 +886,24 @@ public class Config {
    * @param defaultEnabled
    * @return
    * @deprecated This method should only be used internally. Use the instance getter instead {@link
-   *     #isTraceAnalyticsIntegrationEnabled(SortedSet, boolean)}.
+   * #isTraceAnalyticsIntegrationEnabled(SortedSet, boolean)}.
    */
   public static boolean traceAnalyticsIntegrationEnabled(
-      final SortedSet<String> integrationNames, final boolean defaultEnabled) {
+    final SortedSet<String> integrationNames, final boolean defaultEnabled) {
     return Config.get().isTraceAnalyticsIntegrationEnabled(integrationNames, defaultEnabled);
   }
 
   private boolean isEnabled(
-      final Iterable<String> integrationNames,
-      final String settingPrefix,
-      final String settingSuffix,
-      final boolean defaultEnabled) {
+    final Iterable<String> integrationNames,
+    final String settingPrefix,
+    final String settingSuffix,
+    final boolean defaultEnabled) {
     // If default is enabled, we want to enable individually,
     // if default is disabled, we want to disable individually.
     boolean anyEnabled = defaultEnabled;
     for (final String name : integrationNames) {
       final boolean configEnabled =
-          configProvider.getBoolean(settingPrefix + name + settingSuffix, defaultEnabled);
+        configProvider.getBoolean(settingPrefix + name + settingSuffix, defaultEnabled);
       if (defaultEnabled) {
         anyEnabled &= configEnabled;
       } else {
@@ -824,15 +918,15 @@ public class Config {
    * splitting by space or comma.
    */
   private Set<PropagationStyle> getPropagationStyleSetSettingFromEnvironmentOrDefault(
-      final String name, final String defaultValue) {
+    final String name, final String defaultValue) {
     final String value = configProvider.getString(name, defaultValue);
     Set<PropagationStyle> result =
-        convertStringSetToPropagationStyleSet(parseStringIntoSetOfNonEmptyStrings(value));
+      convertStringSetToPropagationStyleSet(parseStringIntoSetOfNonEmptyStrings(value));
 
     if (result.isEmpty()) {
       // Treat empty parsing result as no value and use default instead
       result =
-          convertStringSetToPropagationStyleSet(parseStringIntoSetOfNonEmptyStrings(defaultValue));
+        convertStringSetToPropagationStyleSet(parseStringIntoSetOfNonEmptyStrings(defaultValue));
     }
 
     return result;
@@ -848,11 +942,12 @@ public class Config {
   @NonNull
   private static String propertyNameToEnvironmentVariableName(final String setting) {
     return ENV_REPLACEMENT
-        .matcher(propertyNameToSystemPropertyName(setting).toUpperCase())
-        .replaceAll("_");
+      .matcher(propertyNameToSystemPropertyName(setting).toUpperCase())
+      .replaceAll("_");
   }
 
   private static final String PREFIX = "dd.";
+
   /**
    * Converts the property name, e.g. 'service.name' into a public system property name, e.g.
    * `dd.service.name`.
@@ -877,7 +972,7 @@ public class Config {
    */
   @NonNull
   private Map<String, String> getMapWithPropertiesDefinedByEnvironment(
-      @NonNull final Map<String, String> map, @NonNull final String... propNames) {
+    @NonNull final Map<String, String> map, @NonNull final String... propNames) {
     final Map<String, String> res = new HashMap<>(map);
     for (final String propName : propNames) {
       final String val = configProvider.getString(propName);
@@ -904,7 +999,7 @@ public class Config {
 
   @NonNull
   private static Set<PropagationStyle> convertStringSetToPropagationStyleSet(
-      final Set<String> input) {
+    final Set<String> input) {
     // Using LinkedHashSet to preserve original string order
     final Set<PropagationStyle> result = new LinkedHashSet<>();
     for (final String value : input) {
@@ -919,14 +1014,14 @@ public class Config {
 
   private static String findConfigurationFile() {
     String configurationFilePath =
-        System.getProperty(propertyNameToSystemPropertyName(CONFIGURATION_FILE));
+      System.getProperty(propertyNameToSystemPropertyName(CONFIGURATION_FILE));
     if (null == configurationFilePath) {
       configurationFilePath =
-          System.getenv(propertyNameToEnvironmentVariableName(CONFIGURATION_FILE));
+        System.getenv(propertyNameToEnvironmentVariableName(CONFIGURATION_FILE));
     }
     if (null != configurationFilePath) {
       configurationFilePath =
-          configurationFilePath.replaceFirst("^~", System.getProperty("user.home"));
+        configurationFilePath.replaceFirst("^~", System.getProperty("user.home"));
       final File configurationFile = new File(configurationFilePath);
       if (!configurationFile.exists()) {
         return configurationFilePath;
@@ -935,7 +1030,9 @@ public class Config {
     return "no config file present";
   }
 
-  /** Returns the detected hostname. First tries locally, then using DNS */
+  /**
+   * Returns the detected hostname. First tries locally, then using DNS
+   */
   private static String getHostName() {
     String possibleHostname;
 
@@ -953,8 +1050,8 @@ public class Config {
 
     // Try hostname command
     try (final BufferedReader reader =
-        new BufferedReader(
-            new InputStreamReader(Runtime.getRuntime().exec("hostname").getInputStream()))) {
+           new BufferedReader(
+             new InputStreamReader(Runtime.getRuntime().exec("hostname").getInputStream()))) {
       possibleHostname = reader.readLine();
     } catch (final Exception ignore) {
       // Ignore.  Hostname command is not always available

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/PrioritizationConstants.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/PrioritizationConstants.java
@@ -1,0 +1,8 @@
+package datadog.trace.bootstrap.instrumentation.api;
+
+public final class PrioritizationConstants {
+  public static final String ENSURE_TRACE_TYPE = "EnsureTrace";
+  public static final String FAST_LANE_TYPE = "FastLane";
+
+  private PrioritizationConstants() {}
+}

--- a/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -31,6 +31,7 @@ import static datadog.trace.api.Config.JMX_FETCH_STATSD_HOST
 import static datadog.trace.api.Config.JMX_FETCH_STATSD_PORT
 import static datadog.trace.api.Config.JMX_TAGS
 import static datadog.trace.api.Config.PARTIAL_FLUSH_MIN_SPANS
+import static datadog.trace.api.Config.PRIORITIZATION_TYPE
 import static datadog.trace.api.Config.PRIORITY_SAMPLING
 import static datadog.trace.api.Config.PROFILING_API_KEY_FILE_OLD
 import static datadog.trace.api.Config.PROFILING_API_KEY_FILE_VERY_OLD
@@ -100,6 +101,7 @@ class ConfigTest extends DDSpecification {
   private static final DD_SERVICE_NAME_ENV = "DD_SERVICE_NAME"
   private static final DD_TRACE_ENABLED_ENV = "DD_TRACE_ENABLED"
   private static final DD_WRITER_TYPE_ENV = "DD_WRITER_TYPE"
+  private static final DD_PRIORITIZATION_TYPE_ENV = "DD_PRIORITIZATION_TYPE"
   private static final DD_SERVICE_MAPPING_ENV = "DD_SERVICE_MAPPING"
   private static final DD_TAGS_ENV = "DD_TAGS"
   private static final DD_ENV_ENV = "DD_ENV"
@@ -131,6 +133,7 @@ class ConfigTest extends DDSpecification {
     config.traceEnabled == true
     config.idGenerationStrategy == IdGenerationStrategy.RANDOM
     config.writerType == "DDAgentWriter"
+    config.prioritizationType == "FastLane"
     config.agentHost == "localhost"
     config.agentPort == 8126
     config.agentUnixDomainSocket == null
@@ -196,6 +199,7 @@ class ConfigTest extends DDSpecification {
     prop.setProperty(TRACE_ENABLED, "false")
     prop.setProperty(ID_GENERATION_STRATEGY, "SEQUENTIAL")
     prop.setProperty(WRITER_TYPE, "LoggingWriter")
+    prop.setProperty(PRIORITIZATION_TYPE, "EnsureTrace")
     prop.setProperty(AGENT_HOST, "somehost")
     prop.setProperty(TRACE_AGENT_PORT, "123")
     prop.setProperty(AGENT_UNIX_DOMAIN_SOCKET, "somepath")
@@ -258,6 +262,7 @@ class ConfigTest extends DDSpecification {
     config.idGenerationStrategy == SEQUENTIAL
     config.traceEnabled == false
     config.writerType == "LoggingWriter"
+    config.prioritizationType == "EnsureTrace"
     config.agentHost == "somehost"
     config.agentPort == 123
     config.agentUnixDomainSocket == "somepath"
@@ -317,6 +322,7 @@ class ConfigTest extends DDSpecification {
     System.setProperty(PREFIX + SERVICE_NAME, "something else")
     System.setProperty(PREFIX + TRACE_ENABLED, "false")
     System.setProperty(PREFIX + WRITER_TYPE, "LoggingWriter")
+    System.setProperty(PREFIX + PRIORITIZATION_TYPE, "EnsureTrace")
     System.setProperty(PREFIX + AGENT_HOST, "somehost")
     System.setProperty(PREFIX + TRACE_AGENT_PORT, "123")
     System.setProperty(PREFIX + AGENT_UNIX_DOMAIN_SOCKET, "somepath")
@@ -378,6 +384,7 @@ class ConfigTest extends DDSpecification {
     config.serviceName == "something else"
     config.traceEnabled == false
     config.writerType == "LoggingWriter"
+    config.prioritizationType == "EnsureTrace"
     config.agentHost == "somehost"
     config.agentPort == 123
     config.agentUnixDomainSocket == "somepath"
@@ -436,6 +443,7 @@ class ConfigTest extends DDSpecification {
     environmentVariables.set(DD_SERVICE_NAME_ENV, "still something else")
     environmentVariables.set(DD_TRACE_ENABLED_ENV, "false")
     environmentVariables.set(DD_WRITER_TYPE_ENV, "LoggingWriter")
+    environmentVariables.set(DD_PRIORITIZATION_TYPE_ENV, "EnsureTrace")
     environmentVariables.set(DD_PROPAGATION_STYLE_EXTRACT, "B3 Datadog")
     environmentVariables.set(DD_PROPAGATION_STYLE_INJECT, "Datadog B3")
     environmentVariables.set(DD_JMXFETCH_METRICS_CONFIGS_ENV, "some/file")
@@ -449,6 +457,7 @@ class ConfigTest extends DDSpecification {
     config.serviceName == "still something else"
     config.traceEnabled == false
     config.writerType == "LoggingWriter"
+    config.prioritizationType == "EnsureTrace"
     config.propagationStylesToExtract.toList() == [PropagationStyle.B3, PropagationStyle.DATADOG]
     config.propagationStylesToInject.toList() == [PropagationStyle.DATADOG, PropagationStyle.B3]
     config.jmxFetchMetricsConfigs == ["some/file"]
@@ -459,10 +468,12 @@ class ConfigTest extends DDSpecification {
     setup:
     environmentVariables.set(DD_SERVICE_NAME_ENV, "still something else")
     environmentVariables.set(DD_WRITER_TYPE_ENV, "LoggingWriter")
+    environmentVariables.set(DD_PRIORITIZATION_TYPE_ENV, "EnsureTrace")
     environmentVariables.set(DD_TRACE_AGENT_PORT_ENV, "777")
 
     System.setProperty(PREFIX + SERVICE_NAME, "what we actually want")
     System.setProperty(PREFIX + WRITER_TYPE, "DDAgentWriter")
+    System.setProperty(PREFIX + PRIORITIZATION_TYPE, "FastLane")
     System.setProperty(PREFIX + AGENT_HOST, "somewhere")
     System.setProperty(PREFIX + TRACE_AGENT_PORT, "123")
 
@@ -472,6 +483,7 @@ class ConfigTest extends DDSpecification {
     then:
     config.serviceName == "what we actually want"
     config.writerType == "DDAgentWriter"
+    config.prioritizationType == "FastLane"
     config.agentHost == "somewhere"
     config.agentPort == 123
   }
@@ -481,6 +493,7 @@ class ConfigTest extends DDSpecification {
     System.setProperty(PREFIX + SERVICE_NAME, " ")
     System.setProperty(PREFIX + TRACE_ENABLED, " ")
     System.setProperty(PREFIX + WRITER_TYPE, " ")
+    System.setProperty(PREFIX + PRIORITIZATION_TYPE, " ")
     System.setProperty(PREFIX + AGENT_HOST, " ")
     System.setProperty(PREFIX + TRACE_AGENT_PORT, " ")
     System.setProperty(PREFIX + AGENT_PORT_LEGACY, "invalid")
@@ -503,6 +516,7 @@ class ConfigTest extends DDSpecification {
     config.serviceName == " "
     config.traceEnabled == true
     config.writerType == " "
+    config.prioritizationType == " "
     config.agentHost == " "
     config.agentPort == 8126
     config.prioritySamplingEnabled == false
@@ -568,6 +582,7 @@ class ConfigTest extends DDSpecification {
     properties.setProperty(SERVICE_NAME, "something else")
     properties.setProperty(TRACE_ENABLED, "false")
     properties.setProperty(WRITER_TYPE, "LoggingWriter")
+    properties.setProperty(PRIORITIZATION_TYPE, "EnsureTrace")
     properties.setProperty(AGENT_HOST, "somehost")
     properties.setProperty(TRACE_AGENT_PORT, "123")
     properties.setProperty(AGENT_UNIX_DOMAIN_SOCKET, "somepath")
@@ -598,6 +613,7 @@ class ConfigTest extends DDSpecification {
     config.serviceName == "something else"
     config.traceEnabled == false
     config.writerType == "LoggingWriter"
+    config.prioritizationType == "EnsureTrace"
     config.agentHost == "somehost"
     config.agentPort == 123
     config.agentUnixDomainSocket == "somepath"
@@ -629,6 +645,7 @@ class ConfigTest extends DDSpecification {
     then:
     config.serviceName == "unnamed-java-app"
     config.writerType == "DDAgentWriter"
+    config.prioritizationType == "FastLane"
   }
 
   def "override empty properties"() {
@@ -641,6 +658,7 @@ class ConfigTest extends DDSpecification {
     then:
     config.serviceName == "unnamed-java-app"
     config.writerType == "DDAgentWriter"
+    config.prioritizationType == "FastLane"
   }
 
   def "override non empty properties"() {
@@ -654,6 +672,7 @@ class ConfigTest extends DDSpecification {
     then:
     config.serviceName == "unnamed-java-app"
     config.writerType == "DDAgentWriter"
+    config.prioritizationType == "FastLane"
   }
 
   def "captured env props override default props"() {


### PR DESCRIPTION
Added a new `PrioritizationStrategy` tries to offer the trace to the primary queue until the `queue.offer(...)` method returns true. This type can be configured via `Config`.

This new type is needed to avoid losing spans in CI/Tests traces. It should not be used in applications in production mode.