### PR TITLE
Ci-App: Set prioritySampling to SAMPLER_KEEP in Tests traces

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/TestDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/TestDecorator.java
@@ -87,6 +87,7 @@ public abstract class TestDecorator extends BaseDecorator {
     span.setTag(DDTags.SPAN_TYPE, spanType());
     span.setTag(Tags.TEST_FRAMEWORK, testFramework());
     span.setTag(Tags.TEST_TYPE, testType());
+    span.setTag(DDTags.MANUAL_SAMPLER_KEEP, true);
 
     span.setTag(Tags.CI_PROVIDER_NAME, ciProviderName);
     span.setTag(Tags.CI_PIPELINE_ID, ciPipelineId);

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/TestDecoratorTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/TestDecoratorTest.groovy
@@ -48,6 +48,7 @@ class TestDecoratorTest extends BaseDecoratorTest {
     1 * span.setTag(DDTags.SPAN_TYPE, decorator.spanType())
     1 * span.setTag(Tags.TEST_FRAMEWORK, decorator.testFramework())
     1 * span.setTag(Tags.TEST_TYPE, decorator.testType())
+    1 * span.setTag(DDTags.MANUAL_SAMPLER_KEEP, true)
     _ * span.setTag(_, _) // Want to allow other calls from child implementations.
     _ * span.setServiceName(_)
     _ * span.setOperationName(_)

--- a/dd-trace-api/src/main/java/datadog/trace/api/DDTags.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/DDTags.java
@@ -26,6 +26,11 @@ public class DDTags {
   /** Manually force tracer to be drop the trace */
   public static final String MANUAL_DROP = "manual.drop";
 
+  /** Manually force sampler to be keep the trace */
+  public static final String MANUAL_SAMPLER_KEEP = "manual.sampler_keep";
+  /** Manually force sampler to be drop the trace */
+  public static final String MANUAL_SAMPLER_DROP = "manual.sampler_drop";
+
   public static final String TRACE_START_TIME = "t0";
 
   /* Tags below are for internal use only. */

--- a/dd-trace-core/src/main/java/datadog/trace/core/taginterceptor/ForceManualSamplerDropTagInterceptor.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/taginterceptor/ForceManualSamplerDropTagInterceptor.java
@@ -1,0 +1,26 @@
+package datadog.trace.core.taginterceptor;
+
+import datadog.trace.api.DDTags;
+import datadog.trace.api.sampling.PrioritySampling;
+import datadog.trace.core.ExclusiveSpan;
+
+/**
+ * Tag decorator to replace tag 'manual.sampler_drop: true' with the appropriate priority sampling
+ * value.
+ */
+class ForceManualSamplerDropTagInterceptor extends AbstractTagInterceptor {
+
+  public ForceManualSamplerDropTagInterceptor() {
+    super(DDTags.MANUAL_SAMPLER_DROP);
+  }
+
+  @Override
+  public boolean shouldSetTag(final ExclusiveSpan span, final String tag, final Object value) {
+    if (value instanceof Boolean && (boolean) value) {
+      span.setSamplingPriority(PrioritySampling.SAMPLER_DROP);
+    } else if (value instanceof String && Boolean.parseBoolean((String) value)) {
+      span.setSamplingPriority(PrioritySampling.SAMPLER_DROP);
+    }
+    return false;
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/core/taginterceptor/ForceManualSamplerKeepTagInterceptor.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/taginterceptor/ForceManualSamplerKeepTagInterceptor.java
@@ -1,0 +1,26 @@
+package datadog.trace.core.taginterceptor;
+
+import datadog.trace.api.DDTags;
+import datadog.trace.api.sampling.PrioritySampling;
+import datadog.trace.core.ExclusiveSpan;
+
+/**
+ * Tag decorator to replace tag 'manual.sampler_keep: true' with the appropriate priority sampling
+ * value.
+ */
+class ForceManualSamplerKeepTagInterceptor extends AbstractTagInterceptor {
+
+  public ForceManualSamplerKeepTagInterceptor() {
+    super(DDTags.MANUAL_SAMPLER_KEEP);
+  }
+
+  @Override
+  public boolean shouldSetTag(final ExclusiveSpan span, final String tag, final Object value) {
+    if (value instanceof Boolean && (boolean) value) {
+      span.setSamplingPriority(PrioritySampling.SAMPLER_KEEP);
+    } else if (value instanceof String && Boolean.parseBoolean((String) value)) {
+      span.setSamplingPriority(PrioritySampling.SAMPLER_KEEP);
+    }
+    return false;
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/core/taginterceptor/TagInterceptorsFactory.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/taginterceptor/TagInterceptorsFactory.java
@@ -16,6 +16,8 @@ public class TagInterceptorsFactory {
         Arrays.asList(
             new ForceManualDropTagInterceptor(),
             new ForceManualKeepTagInterceptor(),
+            new ForceManualSamplerKeepTagInterceptor(),
+            new ForceManualSamplerDropTagInterceptor(),
             new PeerServiceTagInterceptor(),
             new ServiceNameTagInterceptor(),
             new ServiceNameTagInterceptor("service", false),

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/taginterceptor/TagInterceptorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/taginterceptor/TagInterceptorTest.groovy
@@ -282,18 +282,30 @@ class TagInterceptorTest extends DDSpecification {
     span.samplingPriority == expected
 
     where:
-    tag                | value   | expected
-    DDTags.MANUAL_KEEP | true    | PrioritySampling.USER_KEEP
-    DDTags.MANUAL_KEEP | false   | null
-    DDTags.MANUAL_KEEP | "true"  | PrioritySampling.USER_KEEP
-    DDTags.MANUAL_KEEP | "false" | null
-    DDTags.MANUAL_KEEP | "asdf"  | null
+    tag                        | value   | expected
+    DDTags.MANUAL_KEEP         | true    | PrioritySampling.USER_KEEP
+    DDTags.MANUAL_KEEP         | false   | null
+    DDTags.MANUAL_KEEP         | "true"  | PrioritySampling.USER_KEEP
+    DDTags.MANUAL_KEEP         | "false" | null
+    DDTags.MANUAL_KEEP         | "asdf"  | null
 
-    DDTags.MANUAL_DROP | true    | PrioritySampling.USER_DROP
-    DDTags.MANUAL_DROP | false   | null
-    DDTags.MANUAL_DROP | "true"  | PrioritySampling.USER_DROP
-    DDTags.MANUAL_DROP | "false" | null
-    DDTags.MANUAL_DROP | "asdf"  | null
+    DDTags.MANUAL_DROP         | true    | PrioritySampling.USER_DROP
+    DDTags.MANUAL_DROP         | false   | null
+    DDTags.MANUAL_DROP         | "true"  | PrioritySampling.USER_DROP
+    DDTags.MANUAL_DROP         | "false" | null
+    DDTags.MANUAL_DROP         | "asdf"  | null
+
+    DDTags.MANUAL_SAMPLER_KEEP | true    | PrioritySampling.SAMPLER_KEEP
+    DDTags.MANUAL_SAMPLER_KEEP | false   | null
+    DDTags.MANUAL_SAMPLER_KEEP | "true"  | PrioritySampling.SAMPLER_KEEP
+    DDTags.MANUAL_SAMPLER_KEEP | "false" | null
+    DDTags.MANUAL_SAMPLER_KEEP | "asdf"  | null
+
+    DDTags.MANUAL_SAMPLER_DROP | true    | PrioritySampling.SAMPLER_DROP
+    DDTags.MANUAL_SAMPLER_DROP | false   | null
+    DDTags.MANUAL_SAMPLER_DROP | "true"  | PrioritySampling.SAMPLER_DROP
+    DDTags.MANUAL_SAMPLER_DROP | "false" | null
+    DDTags.MANUAL_SAMPLER_DROP | "asdf"  | null
   }
 
   def "DBStatementAsResource should not interact on Mongo queries"() {


### PR DESCRIPTION
This PR sets the sampling priority to `SAMPLER_KEEP` to the test traces via `TagInterceptor`.
This new tag `DDTags.MANUAL_SAMPLER_KEEP` will be used in the CI traces too.