### PR TITLE
Add option to not treat async request timeouts as errors

### DIFF
--- a/dd-java-agent/instrumentation/jetty-8/src/main/java/datadog/trace/instrumentation/jetty8/TagSettingAsyncListener.java
+++ b/dd-java-agent/instrumentation/jetty-8/src/main/java/datadog/trace/instrumentation/jetty8/TagSettingAsyncListener.java
@@ -32,7 +32,7 @@ public class TagSettingAsyncListener implements AsyncListener {
   @Override
   public void onTimeout(final AsyncEvent event) throws IOException {
     if (activated.compareAndSet(false, true)) {
-      if (Config.get().isServletAsyncTimeoutIsError()) {
+      if (Config.get().isServletAsyncTimeoutError()) {
         span.setError(true);
       }
       span.setTag("timeout", event.getAsyncContext().getTimeout());

--- a/dd-java-agent/instrumentation/jetty-8/src/main/java/datadog/trace/instrumentation/jetty8/TagSettingAsyncListener.java
+++ b/dd-java-agent/instrumentation/jetty-8/src/main/java/datadog/trace/instrumentation/jetty8/TagSettingAsyncListener.java
@@ -32,7 +32,7 @@ public class TagSettingAsyncListener implements AsyncListener {
   @Override
   public void onTimeout(final AsyncEvent event) throws IOException {
     if (activated.compareAndSet(false, true)) {
-      if (Config.get().isServletAsyncTimeoutAsError()) {
+      if (Config.get().isServletAsyncTimeoutIsError()) {
         span.setError(true);
       }
       span.setTag("timeout", event.getAsyncContext().getTimeout());

--- a/dd-java-agent/instrumentation/jetty-8/src/main/java/datadog/trace/instrumentation/jetty8/TagSettingAsyncListener.java
+++ b/dd-java-agent/instrumentation/jetty-8/src/main/java/datadog/trace/instrumentation/jetty8/TagSettingAsyncListener.java
@@ -56,6 +56,9 @@ public class TagSettingAsyncListener implements AsyncListener {
     }
   }
 
+  /** Transfer the listener over to the new context. */
   @Override
-  public void onStartAsync(final AsyncEvent event) throws IOException {}
+  public void onStartAsync(final AsyncEvent event) throws IOException {
+    event.getAsyncContext().addListener(this);
+  }
 }

--- a/dd-java-agent/instrumentation/jetty-8/src/main/java/datadog/trace/instrumentation/jetty8/TagSettingAsyncListener.java
+++ b/dd-java-agent/instrumentation/jetty-8/src/main/java/datadog/trace/instrumentation/jetty8/TagSettingAsyncListener.java
@@ -32,7 +32,7 @@ public class TagSettingAsyncListener implements AsyncListener {
   @Override
   public void onTimeout(final AsyncEvent event) throws IOException {
     if (activated.compareAndSet(false, true)) {
-      if (Config.get().isServletTimeoutAsError()) {
+      if (Config.get().isServletAsyncTimeoutAsError()) {
         span.setError(true);
       }
       span.setTag("timeout", event.getAsyncContext().getTimeout());

--- a/dd-java-agent/instrumentation/jetty-8/src/main/java/datadog/trace/instrumentation/jetty8/TagSettingAsyncListener.java
+++ b/dd-java-agent/instrumentation/jetty-8/src/main/java/datadog/trace/instrumentation/jetty8/TagSettingAsyncListener.java
@@ -2,6 +2,7 @@ package datadog.trace.instrumentation.jetty8;
 
 import static datadog.trace.instrumentation.jetty8.JettyDecorator.DECORATE;
 
+import datadog.trace.api.Config;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import java.io.IOException;
@@ -31,7 +32,9 @@ public class TagSettingAsyncListener implements AsyncListener {
   @Override
   public void onTimeout(final AsyncEvent event) throws IOException {
     if (activated.compareAndSet(false, true)) {
-      span.setError(true);
+      if (Config.get().isServletTimeoutAsError()) {
+        span.setError(true);
+      }
       span.setTag("timeout", event.getAsyncContext().getTimeout());
       DECORATE.beforeFinish(span);
       span.finish();

--- a/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/TagSettingAsyncListener.java
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/TagSettingAsyncListener.java
@@ -2,6 +2,7 @@ package datadog.trace.instrumentation.servlet3;
 
 import static datadog.trace.instrumentation.servlet3.Servlet3Decorator.DECORATE;
 
+import datadog.trace.api.Config;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import java.io.IOException;
@@ -31,7 +32,9 @@ public class TagSettingAsyncListener implements AsyncListener {
   @Override
   public void onTimeout(final AsyncEvent event) throws IOException {
     if (activated.compareAndSet(false, true)) {
-      span.setError(true);
+      if (Config.get().isServletTimeoutAsError()) {
+        span.setError(true);
+      }
       span.setTag("timeout", event.getAsyncContext().getTimeout());
       DECORATE.beforeFinish(span);
       span.finish();

--- a/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/TagSettingAsyncListener.java
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/TagSettingAsyncListener.java
@@ -32,7 +32,7 @@ public class TagSettingAsyncListener implements AsyncListener {
   @Override
   public void onTimeout(final AsyncEvent event) throws IOException {
     if (activated.compareAndSet(false, true)) {
-      if (Config.get().isServletAsyncTimeoutIsError()) {
+      if (Config.get().isServletAsyncTimeoutError()) {
         span.setError(true);
       }
       span.setTag("timeout", event.getAsyncContext().getTimeout());

--- a/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/TagSettingAsyncListener.java
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/TagSettingAsyncListener.java
@@ -32,7 +32,7 @@ public class TagSettingAsyncListener implements AsyncListener {
   @Override
   public void onTimeout(final AsyncEvent event) throws IOException {
     if (activated.compareAndSet(false, true)) {
-      if (Config.get().isServletAsyncTimeoutAsError()) {
+      if (Config.get().isServletAsyncTimeoutIsError()) {
         span.setError(true);
       }
       span.setTag("timeout", event.getAsyncContext().getTimeout());

--- a/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/TagSettingAsyncListener.java
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/TagSettingAsyncListener.java
@@ -32,7 +32,7 @@ public class TagSettingAsyncListener implements AsyncListener {
   @Override
   public void onTimeout(final AsyncEvent event) throws IOException {
     if (activated.compareAndSet(false, true)) {
-      if (Config.get().isServletTimeoutAsError()) {
+      if (Config.get().isServletAsyncTimeoutAsError()) {
         span.setError(true);
       }
       span.setTag("timeout", event.getAsyncContext().getTimeout());

--- a/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/AbstractServlet3Test.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/AbstractServlet3Test.groovy
@@ -16,6 +16,8 @@ import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPT
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.TIMEOUT
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.TIMEOUT_ERROR
 
 abstract class AbstractServlet3Test<SERVER, CONTEXT> extends HttpServerTest<SERVER> {
   @Override
@@ -61,6 +63,8 @@ abstract class AbstractServlet3Test<SERVER, CONTEXT> extends HttpServerTest<SERV
     addServlet(context, EXCEPTION.path, servlet)
     addServlet(context, REDIRECT.path, servlet)
     addServlet(context, AUTH_REQUIRED.path, servlet)
+    addServlet(context, TIMEOUT.path, servlet)
+    addServlet(context, TIMEOUT_ERROR.path, servlet)
   }
 
   protected ServerEndpoint lastRequest
@@ -92,7 +96,11 @@ abstract class AbstractServlet3Test<SERVER, CONTEXT> extends HttpServerTest<SERV
         "$Tags.PEER_PORT" Integer
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
-        "$Tags.HTTP_STATUS" endpoint.status
+        if (endpoint.status > 0) {
+          "$Tags.HTTP_STATUS" endpoint.status
+        } else {
+          "timeout" 1_000
+        }
         if (context) {
           "servlet.context" "/$context"
         }

--- a/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/TestServlet3.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/TestServlet3.groovy
@@ -93,7 +93,7 @@ class TestServlet3 {
               case TIMEOUT:
               case TIMEOUT_ERROR:
                 sleep context.getTimeout() + 2_000
-                break;
+                break
             }
           }
         } finally {

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
@@ -40,7 +40,7 @@ import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.TIMEOU
 import static datadog.trace.agent.test.utils.ConfigUtils.withConfigOverride
 import static datadog.trace.agent.test.utils.TraceUtils.basicSpan
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
-import static datadog.trace.api.config.TraceInstrumentationConfig.SERVLET_TIMEOUT_AS_ERROR
+import static datadog.trace.api.config.TraceInstrumentationConfig.SERVLET_ASYNC_TIMEOUT_AS_ERROR
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
 import static org.junit.Assume.assumeTrue
@@ -523,7 +523,7 @@ abstract class HttpServerTest<SERVER> extends AgentTestRunner {
     setup:
     assumeTrue(testTimeout())
     def request = request(TIMEOUT, method, body).build()
-    def response = withConfigOverride(SERVLET_TIMEOUT_AS_ERROR, "false", {
+    def response = withConfigOverride(SERVLET_ASYNC_TIMEOUT_AS_ERROR, "false", {
       client.newCall(request).execute()
     })
 

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
@@ -40,7 +40,7 @@ import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.TIMEOU
 import static datadog.trace.agent.test.utils.ConfigUtils.withConfigOverride
 import static datadog.trace.agent.test.utils.TraceUtils.basicSpan
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
-import static datadog.trace.api.config.TraceInstrumentationConfig.SERVLET_ASYNC_TIMEOUT_IS_ERROR
+import static datadog.trace.api.config.TraceInstrumentationConfig.SERVLET_ASYNC_TIMEOUT_ERROR
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
 import static org.junit.Assume.assumeTrue
@@ -523,7 +523,7 @@ abstract class HttpServerTest<SERVER> extends AgentTestRunner {
     setup:
     assumeTrue(testTimeout())
     def request = request(TIMEOUT, method, body).build()
-    def response = withConfigOverride(SERVLET_ASYNC_TIMEOUT_IS_ERROR, "false", {
+    def response = withConfigOverride(SERVLET_ASYNC_TIMEOUT_ERROR, "false", {
       client.newCall(request).execute()
     })
 

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
@@ -40,7 +40,7 @@ import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.TIMEOU
 import static datadog.trace.agent.test.utils.ConfigUtils.withConfigOverride
 import static datadog.trace.agent.test.utils.TraceUtils.basicSpan
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
-import static datadog.trace.api.config.TraceInstrumentationConfig.SERVLET_ASYNC_TIMEOUT_AS_ERROR
+import static datadog.trace.api.config.TraceInstrumentationConfig.SERVLET_ASYNC_TIMEOUT_IS_ERROR
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
 import static org.junit.Assume.assumeTrue
@@ -523,7 +523,7 @@ abstract class HttpServerTest<SERVER> extends AgentTestRunner {
     setup:
     assumeTrue(testTimeout())
     def request = request(TIMEOUT, method, body).build()
-    def response = withConfigOverride(SERVLET_ASYNC_TIMEOUT_AS_ERROR, "false", {
+    def response = withConfigOverride(SERVLET_ASYNC_TIMEOUT_IS_ERROR, "false", {
       client.newCall(request).execute()
     })
 

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
@@ -36,8 +36,7 @@ public final class TraceInstrumentationConfig {
 
   public static final String HYSTRIX_TAGS_ENABLED = "hystrix.tags.enabled";
   public static final String SERVLET_PRINCIPAL_ENABLED = "trace.servlet.principal.enabled";
-  public static final String SERVLET_ASYNC_TIMEOUT_IS_ERROR =
-      "trace.servlet.async-timeout.is-error";
+  public static final String SERVLET_ASYNC_TIMEOUT_ERROR = "trace.servlet.async-timeout.error";
 
   private TraceInstrumentationConfig() {}
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
@@ -36,6 +36,7 @@ public final class TraceInstrumentationConfig {
 
   public static final String HYSTRIX_TAGS_ENABLED = "hystrix.tags.enabled";
   public static final String SERVLET_PRINCIPAL_ENABLED = "trace.servlet.principal.enabled";
+  public static final String SERVLET_TIMEOUT_AS_ERROR = "trace.servlet.timeout.asError";
 
   private TraceInstrumentationConfig() {}
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
@@ -36,7 +36,7 @@ public final class TraceInstrumentationConfig {
 
   public static final String HYSTRIX_TAGS_ENABLED = "hystrix.tags.enabled";
   public static final String SERVLET_PRINCIPAL_ENABLED = "trace.servlet.principal.enabled";
-  public static final String SERVLET_TIMEOUT_AS_ERROR = "trace.servlet.timeout.asError";
+  public static final String SERVLET_ASYNC_TIMEOUT_AS_ERROR = "trace.servlet.asyncTimeout.asError";
 
   private TraceInstrumentationConfig() {}
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
@@ -36,7 +36,8 @@ public final class TraceInstrumentationConfig {
 
   public static final String HYSTRIX_TAGS_ENABLED = "hystrix.tags.enabled";
   public static final String SERVLET_PRINCIPAL_ENABLED = "trace.servlet.principal.enabled";
-  public static final String SERVLET_ASYNC_TIMEOUT_AS_ERROR = "trace.servlet.asyncTimeout.asError";
+  public static final String SERVLET_ASYNC_TIMEOUT_IS_ERROR =
+      "trace.servlet.async-timeout.is-error";
 
   private TraceInstrumentationConfig() {}
 }

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -351,6 +351,7 @@ public class Config {
 
   @Getter private final boolean hystrixTagsEnabled;
   @Getter private final boolean servletPrincipalEnabled;
+  @Getter private final boolean servletTimeoutAsError;
 
   @Getter private final boolean traceAgentV05Enabled;
 
@@ -368,7 +369,7 @@ public class Config {
         ConfigProvider.createDefault());
   }
 
-  private Config(final String runtimeId, ConfigProvider configProvider) {
+  private Config(final String runtimeId, final ConfigProvider configProvider) {
     this.configProvider = configProvider;
     configFile = findConfigurationFile();
     this.runtimeId = runtimeId;
@@ -610,6 +611,9 @@ public class Config {
 
     servletPrincipalEnabled =
         configProvider.getBoolean(TraceInstrumentationConfig.SERVLET_PRINCIPAL_ENABLED, false);
+
+    servletTimeoutAsError =
+        configProvider.getBoolean(TraceInstrumentationConfig.SERVLET_TIMEOUT_AS_ERROR, true);
 
     debugEnabled = isDebugMode();
 
@@ -853,6 +857,7 @@ public class Config {
   }
 
   private static final String PREFIX = "dd.";
+
   /**
    * Converts the property name, e.g. 'service.name' into a public system property name, e.g.
    * `dd.service.name`.

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -351,7 +351,7 @@ public class Config {
 
   @Getter private final boolean hystrixTagsEnabled;
   @Getter private final boolean servletPrincipalEnabled;
-  @Getter private final boolean servletAsyncTimeoutAsError;
+  @Getter private final boolean servletAsyncTimeoutIsError;
 
   @Getter private final boolean traceAgentV05Enabled;
 
@@ -612,8 +612,8 @@ public class Config {
     servletPrincipalEnabled =
         configProvider.getBoolean(TraceInstrumentationConfig.SERVLET_PRINCIPAL_ENABLED, false);
 
-    servletAsyncTimeoutAsError =
-        configProvider.getBoolean(TraceInstrumentationConfig.SERVLET_ASYNC_TIMEOUT_AS_ERROR, true);
+    servletAsyncTimeoutIsError =
+        configProvider.getBoolean(TraceInstrumentationConfig.SERVLET_ASYNC_TIMEOUT_IS_ERROR, true);
 
     debugEnabled = isDebugMode();
 

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -351,7 +351,7 @@ public class Config {
 
   @Getter private final boolean hystrixTagsEnabled;
   @Getter private final boolean servletPrincipalEnabled;
-  @Getter private final boolean servletTimeoutAsError;
+  @Getter private final boolean servletAsyncTimeoutAsError;
 
   @Getter private final boolean traceAgentV05Enabled;
 
@@ -612,8 +612,8 @@ public class Config {
     servletPrincipalEnabled =
         configProvider.getBoolean(TraceInstrumentationConfig.SERVLET_PRINCIPAL_ENABLED, false);
 
-    servletTimeoutAsError =
-        configProvider.getBoolean(TraceInstrumentationConfig.SERVLET_TIMEOUT_AS_ERROR, true);
+    servletAsyncTimeoutAsError =
+        configProvider.getBoolean(TraceInstrumentationConfig.SERVLET_ASYNC_TIMEOUT_AS_ERROR, true);
 
     debugEnabled = isDebugMode();
 

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -351,7 +351,7 @@ public class Config {
 
   @Getter private final boolean hystrixTagsEnabled;
   @Getter private final boolean servletPrincipalEnabled;
-  @Getter private final boolean servletAsyncTimeoutIsError;
+  @Getter private final boolean servletAsyncTimeoutError;
 
   @Getter private final boolean traceAgentV05Enabled;
 
@@ -612,8 +612,8 @@ public class Config {
     servletPrincipalEnabled =
         configProvider.getBoolean(TraceInstrumentationConfig.SERVLET_PRINCIPAL_ENABLED, false);
 
-    servletAsyncTimeoutIsError =
-        configProvider.getBoolean(TraceInstrumentationConfig.SERVLET_ASYNC_TIMEOUT_IS_ERROR, true);
+    servletAsyncTimeoutError =
+        configProvider.getBoolean(TraceInstrumentationConfig.SERVLET_ASYNC_TIMEOUT_ERROR, true);
 
     debugEnabled = isDebugMode();
 


### PR DESCRIPTION
For scenarios where clients disconnect without explicitly closing connections it is useful to not treat timeouts as errors when recording spans.

The default behaviour remains the same (async request timeouts are treated as errors) but you can now set:
```
dd.trace.servlet.async-timeout.error=false
```
to not treat them as errors. These spans will still have the "timeout" tag set regardless of this setting.