### PR TITLE
Enable OpenTracing to inherit the async propagation from enclosing scope

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
@@ -40,6 +40,8 @@ public final class TracerConfig {
 
   public static final String SCOPE_DEPTH_LIMIT = "trace.scope.depth.limit";
   public static final String SCOPE_STRICT_MODE = "trace.scope.strict.mode";
+  public static final String SCOPE_INHERIT_ASYNC_PROPAGATION =
+      "trace.scope.inherit.async.propagation";
   public static final String PARTIAL_FLUSH_MIN_SPANS = "trace.partial.flush.min.spans";
   public static final String PROPAGATION_STYLE_EXTRACT = "propagation.style.extract";
   public static final String PROPAGATION_STYLE_INJECT = "propagation.style.inject";

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -224,7 +224,8 @@ public class CoreTracer implements AgentTracer.TracerAPI {
               config.getScopeDepthLimit(),
               createScopeEventFactory(),
               this.statsDClient,
-              config.isScopeStrictMode());
+              config.isScopeStrictMode(),
+              config.isScopeInheritAsyncPropagation());
     } else {
       this.scopeManager = scopeManager;
     }
@@ -347,12 +348,17 @@ public class CoreTracer implements AgentTracer.TracerAPI {
   }
 
   public AgentScope activateSpan(final AgentSpan span) {
-    return scopeManager.activate(span, ScopeSource.INSTRUMENTATION);
+    return scopeManager.activate(span, ScopeSource.INSTRUMENTATION, false);
   }
 
   @Override
   public AgentScope activateSpan(final AgentSpan span, final ScopeSource source) {
     return scopeManager.activate(span, source);
+  }
+
+  @Override
+  public AgentScope activateSpan(AgentSpan span, ScopeSource source, boolean isAsyncPropagating) {
+    return scopeManager.activate(span, source, isAsyncPropagating);
   }
 
   @Override

--- a/dd-trace-ot/src/main/java/datadog/opentracing/CustomScopeManagerWrapper.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/CustomScopeManagerWrapper.java
@@ -43,6 +43,17 @@ class CustomScopeManagerWrapper implements AgentScopeManager {
   }
 
   @Override
+  public AgentScope activate(
+      final AgentSpan agentSpan, final ScopeSource source, boolean isAsyncPropagating) {
+    final Span span = converter.toSpan(agentSpan);
+    final Scope scope = delegate.activate(span);
+    final AgentScope agentScope = new CustomScopeManagerScope(scope);
+    agentScope.setAsyncPropagation(isAsyncPropagating);
+
+    return agentScope;
+  }
+
+  @Override
   public TraceScope active() {
     return new CustomScopeManagerScope(delegate.active());
   }

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/CustomScopeManagerTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/CustomScopeManagerTest.groovy
@@ -78,7 +78,7 @@ class CustomScopeManagerTest extends DDSpecification {
     Span testSpan = tracer.buildSpan("someOperation")
       .withTag(DDTags.SERVICE_NAME, "someService")
       .start()
-    tracer.activateSpan(testSpan)
+    coreTracer.activateSpan(((OTSpan) testSpan).getDelegate())
 
     then:
     coreTracer.activeSpan() != null

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -166,6 +166,8 @@ public class Config {
   public static final String SPLIT_BY_TAGS = TracerConfig.SPLIT_BY_TAGS;
   public static final String SCOPE_DEPTH_LIMIT = TracerConfig.SCOPE_DEPTH_LIMIT;
   public static final String SCOPE_STRICT_MODE = TracerConfig.SCOPE_STRICT_MODE;
+  public static final String SCOPE_INHERIT_ASYNC_PROPAGATION =
+      TracerConfig.SCOPE_INHERIT_ASYNC_PROPAGATION;
   public static final String PARTIAL_FLUSH_MIN_SPANS = TracerConfig.PARTIAL_FLUSH_MIN_SPANS;
   public static final String RUNTIME_CONTEXT_FIELD_INJECTION =
       TraceInstrumentationConfig.RUNTIME_CONTEXT_FIELD_INJECTION;
@@ -299,6 +301,7 @@ public class Config {
   @Getter private final Set<String> splitByTags;
   @Getter private final int scopeDepthLimit;
   @Getter private final boolean scopeStrictMode;
+  @Getter private final boolean scopeInheritAsyncPropagation;
   @Getter private final int partialFlushMinSpans;
   @Getter private final boolean runtimeContextFieldInjection;
   @Getter private final Set<PropagationStyle> propagationStylesToExtract;
@@ -493,6 +496,8 @@ public class Config {
     scopeDepthLimit = configProvider.getInteger(SCOPE_DEPTH_LIMIT, DEFAULT_SCOPE_DEPTH_LIMIT);
 
     scopeStrictMode = configProvider.getBoolean(SCOPE_STRICT_MODE, false);
+
+    scopeInheritAsyncPropagation = configProvider.getBoolean(SCOPE_INHERIT_ASYNC_PROPAGATION, true);
 
     partialFlushMinSpans =
         configProvider.getInteger(PARTIAL_FLUSH_MIN_SPANS, DEFAULT_PARTIAL_FLUSH_MIN_SPANS);

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentScopeManager.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentScopeManager.java
@@ -9,6 +9,8 @@ public interface AgentScopeManager {
 
   AgentScope activate(AgentSpan span, ScopeSource source);
 
+  AgentScope activate(AgentSpan span, ScopeSource source, boolean isAsyncPropagating);
+
   TraceScope active();
 
   AgentSpan activeSpan();

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -38,7 +38,11 @@ public class AgentTracer {
   }
 
   public static AgentScope activateSpan(final AgentSpan span) {
-    return get().activateSpan(span, ScopeSource.INSTRUMENTATION);
+    return get().activateSpan(span, ScopeSource.INSTRUMENTATION, false);
+  }
+
+  public static AgentScope activateSpan(final AgentSpan span, boolean isAsyncPropagating) {
+    return get().activateSpan(span, ScopeSource.INSTRUMENTATION, isAsyncPropagating);
   }
 
   public static AgentSpan activeSpan() {
@@ -90,6 +94,8 @@ public class AgentTracer {
     AgentSpan startSpan(CharSequence spanName, AgentSpan.Context parent, long startTimeMicros);
 
     AgentScope activateSpan(AgentSpan span, ScopeSource source);
+
+    AgentScope activateSpan(AgentSpan span, ScopeSource source, boolean isAsyncPropagating);
 
     AgentSpan activeSpan();
 
@@ -157,6 +163,12 @@ public class AgentTracer {
 
     @Override
     public AgentScope activateSpan(final AgentSpan span, final ScopeSource source) {
+      return NoopAgentScope.INSTANCE;
+    }
+
+    @Override
+    public AgentScope activateSpan(
+        final AgentSpan span, final ScopeSource source, boolean isAsyncPropagating) {
       return NoopAgentScope.INSTANCE;
     }
 


### PR DESCRIPTION
This is a real issue where a customer is using OT in an async application and it breaks up the customers spans.
