### PR TITLE
Ci-App: Avoid adding the TracingListener multiple times since JUnit4 4.12

### DIFF
--- a/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4Instrumentation.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4Instrumentation.java
@@ -68,7 +68,7 @@ public class JUnit4Instrumentation extends Instrumenter.Default {
 
       // This prevents installing the TracingListener multiple times.
       for (final RunListener listener : runListeners) {
-        if (listener instanceof TracingListener) {
+        if (JUnit4Utils.isTracingListener(listener)) {
           return;
         }
       }

--- a/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4Utils.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4Utils.java
@@ -40,6 +40,7 @@ public abstract class JUnit4Utils {
     // Since JUnit 4.12, the RunListener are wrapped by a SynchronizedRunListener object.
     if (SYNCHRONIZED_LISTENER.equals(listener.getClass().getName())) {
       try {
+        // There is no public accessor to the inner listener.
         final Field innerListener = listener.getClass().getDeclaredField("listener");
         innerListener.setAccessible(true);
 

--- a/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4Utils.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4Utils.java
@@ -9,6 +9,9 @@ import org.junit.runner.notification.RunNotifier;
 @Slf4j
 public abstract class JUnit4Utils {
 
+  private static final String SYNCHRONIZED_LISTENER =
+      "org.junit.runner.notification.SynchronizedRunListener";
+
   public static List<RunListener> runListenersFromRunNotifier(final RunNotifier runNotifier) {
     try {
 
@@ -27,5 +30,26 @@ public abstract class JUnit4Utils {
       log.debug("Could not get runListeners for JUnit4Advice", e);
       return null;
     }
+  }
+
+  public static boolean isTracingListener(final RunListener listener) {
+    if (listener instanceof TracingListener) {
+      return true;
+    }
+
+    // Since JUnit 4.12, the RunListener are wrapped by a SynchronizedRunListener object.
+    if (SYNCHRONIZED_LISTENER.equals(listener.getClass().getName())) {
+      try {
+        final Field innerListener = listener.getClass().getDeclaredField("listener");
+        innerListener.setAccessible(true);
+
+        return innerListener.get(listener) instanceof TracingListener;
+      } catch (final Throwable e) {
+        log.debug("Could not get inner listener from SynchronizedRunListener for JUnit4Advice", e);
+        return false;
+      }
+    }
+
+    return false;
   }
 }


### PR DESCRIPTION
Avoid adding the TracingListener multiple times since JUnit4 4.12