### PR TITLE
disable performance metrics by default

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -628,6 +628,9 @@ acceptedBreaks:
     - code: "java.field.removed"
       old: "field datadog.trace.common.writer.DDAgentWriter.monitor"
       justification: "internal api"
+    - code: "java.field.removed"
+      old: "field datadog.trace.core.CoreTracer.TRACE_ID_MIN"
+      justification: "revapi"
     - code: "java.method.removed"
       old: "method datadog.trace.common.writer.DDAgentWriter.DDAgentWriterBuilder\
         \ datadog.trace.common.writer.DDAgentWriter.DDAgentWriterBuilder::monitor(datadog.trace.core.monitor.Monitor)"

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/GeneralConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/GeneralConfig.java
@@ -28,6 +28,7 @@ public final class GeneralConfig {
   public static final String HEALTH_METRICS_ENABLED = "trace.health.metrics.enabled";
   public static final String HEALTH_METRICS_STATSD_HOST = "trace.health.metrics.statsd.host";
   public static final String HEALTH_METRICS_STATSD_PORT = "trace.health.metrics.statsd.port";
+  public static final String PERF_METRICS_ENABLED = "trace.perf.metrics.enabled";
 
   private GeneralConfig() {}
 }

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/DDAgentApi.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/DDAgentApi.java
@@ -11,7 +11,6 @@ import datadog.trace.common.writer.ddagent.unixdomainsockets.UnixDomainSocketFac
 import datadog.trace.core.DDTraceCoreInfo;
 import datadog.trace.core.monitor.Monitoring;
 import datadog.trace.core.monitor.Recording;
-import datadog.trace.core.monitor.Timer;
 import java.io.File;
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -60,8 +59,8 @@ public class DDAgentApi {
   private long sentTraces = 0;
   private long failedTraces = 0;
 
-  private final Timer discoveryTimer;
-  private final Timer sendPayloadTimer;
+  private final Recording discoveryTimer;
+  private final Recording sendPayloadTimer;
 
   private static final JsonAdapter<Map<String, Map<String, Number>>> RESPONSE_ADAPTER =
       new Moshi.Builder()

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/PayloadDispatcher.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/PayloadDispatcher.java
@@ -3,7 +3,7 @@ package datadog.trace.common.writer.ddagent;
 import datadog.trace.core.DDSpanData;
 import datadog.trace.core.monitor.HealthMetrics;
 import datadog.trace.core.monitor.Monitoring;
-import datadog.trace.core.monitor.Timer;
+import datadog.trace.core.monitor.Recording;
 import datadog.trace.core.serialization.msgpack.ByteBufferConsumer;
 import datadog.trace.core.serialization.msgpack.Packer;
 import java.nio.ByteBuffer;
@@ -19,7 +19,7 @@ public class PayloadDispatcher implements ByteBufferConsumer {
   private final HealthMetrics healthMetrics;
   private final Monitoring monitoring;
 
-  private Timer batchTimer;
+  private Recording batchTimer;
   private TraceMapper traceMapper;
   private Packer packer;
 

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/TraceProcessingWorker.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/TraceProcessingWorker.java
@@ -6,7 +6,7 @@ import datadog.common.exec.DaemonThreadFactory;
 import datadog.trace.core.DDSpan;
 import datadog.trace.core.monitor.HealthMetrics;
 import datadog.trace.core.monitor.Monitoring;
-import datadog.trace.core.monitor.Timer;
+import datadog.trace.core.monitor.Recording;
 import datadog.trace.core.processor.TraceProcessor;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -129,7 +129,7 @@ public class TraceProcessingWorker implements AutoCloseable {
     private final boolean doTimeFlush;
     private final PayloadDispatcher payloadDispatcher;
     private long lastTicks;
-    private final Timer dutyCycleTimer;
+    private final Recording dutyCycleTimer;
 
     public TraceSerializingHandler(
         final MpscBlockingConsumerArrayQueue<Object> primaryQueue,

--- a/dd-trace-core/src/main/java/datadog/trace/core/monitor/NoOpRecording.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/monitor/NoOpRecording.java
@@ -1,0 +1,20 @@
+package datadog.trace.core.monitor;
+
+public class NoOpRecording extends Recording {
+
+  public static final Recording NO_OP = new NoOpRecording();
+
+  @Override
+  public Recording start() {
+    return this;
+  }
+
+  @Override
+  public void reset() {}
+
+  @Override
+  public void stop() {}
+
+  @Override
+  public void flush() {}
+}

--- a/dd-trace-core/src/main/java/datadog/trace/core/monitor/Recording.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/monitor/Recording.java
@@ -6,7 +6,11 @@ public abstract class Recording implements AutoCloseable {
     stop();
   }
 
+  public abstract Recording start();
+
   public abstract void reset();
 
   public abstract void stop();
+
+  public abstract void flush();
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/monitor/ThreadLocalRecording.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/monitor/ThreadLocalRecording.java
@@ -1,0 +1,30 @@
+package datadog.trace.core.monitor;
+
+public class ThreadLocalRecording extends Recording {
+
+  private final ThreadLocal<Recording> tls;
+
+  public ThreadLocalRecording(ThreadLocal<Recording> tls) {
+    this.tls = tls;
+  }
+
+  @Override
+  public Recording start() {
+    return tls.get().start();
+  }
+
+  @Override
+  public void reset() {
+    tls.get().reset();
+  }
+
+  @Override
+  public void stop() {
+    tls.get().stop();
+  }
+
+  @Override
+  public void flush() {
+    tls.get().flush();
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/core/monitor/Timer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/monitor/Timer.java
@@ -47,17 +47,20 @@ public class Timer extends Recording {
     this(name, null, statsd, flushAfterNanos);
   }
 
+  @Override
   public Recording start() {
     start = System.nanoTime();
     return this;
   }
 
+  @Override
   public void reset() {
     long now = System.nanoTime();
     record(now);
     start = now;
   }
 
+  @Override
   public void stop() {
     record(System.nanoTime());
   }
@@ -71,11 +74,12 @@ public class Timer extends Recording {
     }
   }
 
+  @Override
   public void flush() {
-    statsd.time(name, (long) histogram.getMean(), meanTags);
-    statsd.time(name, histogram.getValueAtPercentile(50), p50Tags);
-    statsd.time(name, histogram.getValueAtPercentile(99), p99Tags);
-    statsd.time(name, histogram.getMaxValue(), maxTags);
+    statsd.gauge(name, (long) histogram.getMean(), meanTags);
+    statsd.gauge(name, histogram.getValueAtPercentile(50), p50Tags);
+    statsd.gauge(name, histogram.getValueAtPercentile(99), p99Tags);
+    statsd.gauge(name, histogram.getMaxValue(), maxTags);
   }
 
   private static String[] mergeTags(String[] left, String[] right) {

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/monitor/TimingTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/monitor/TimingTest.groovy
@@ -2,6 +2,7 @@ package datadog.trace.core.monitor
 
 import com.timgroup.statsd.StatsDClient
 import datadog.trace.util.test.DDSpecification
+import org.junit.Assert
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS
 
@@ -9,18 +10,36 @@ class TimingTest extends DDSpecification {
 
   def "timer times stuff" () {
     setup:
+    System.out.println(System.getProperty("java.class.path"))
     StatsDClient statsd = Mock(StatsDClient)
     Monitoring monitoring = new Monitoring(statsd, 100, MILLISECONDS)
-    Timer timer = monitoring.newTimer("my_timer")
+    def timer = monitoring.newTimer("my_timer")
     when:
     Recording recording = timer.start()
     Thread.sleep(200)
     recording.close()
     then:
-    1 * statsd.time("my_timer", { it > MILLISECONDS.toNanos(200) }, "stat:avg")
-    1 * statsd.time("my_timer", { it > MILLISECONDS.toNanos(200) }, "stat:p50")
-    1 * statsd.time("my_timer", { it > MILLISECONDS.toNanos(200) }, "stat:p99")
-    1 * statsd.time("my_timer", { it > MILLISECONDS.toNanos(200) }, "stat:max")
+    1 * statsd.gauge("my_timer", { it > MILLISECONDS.toNanos(200) }, "stat:avg")
+    1 * statsd.gauge("my_timer", { it > MILLISECONDS.toNanos(200) }, "stat:p50")
+    1 * statsd.gauge("my_timer", { it > MILLISECONDS.toNanos(200) }, "stat:p99")
+    1 * statsd.gauge("my_timer", { it > MILLISECONDS.toNanos(200) }, "stat:max")
+    0 * _
+  }
+
+  def "threadlocal timer times stuff" () {
+    setup:
+    StatsDClient statsd = Mock(StatsDClient)
+    Monitoring monitoring = new Monitoring(statsd, 100, MILLISECONDS)
+    def timer = monitoring.newThreadLocalTimer("my_timer")
+    when:
+    Recording recording = timer.start()
+    Thread.sleep(200)
+    recording.close()
+    then:
+    1 * statsd.gauge("my_timer", { it > MILLISECONDS.toNanos(200) }, {it[0] == "stat:avg" && it[1].startsWith("thread:")})
+    1 * statsd.gauge("my_timer", { it > MILLISECONDS.toNanos(200) }, {it[0] == "stat:p50" && it[1].startsWith("thread:")})
+    1 * statsd.gauge("my_timer", { it > MILLISECONDS.toNanos(200) }, {it[0] == "stat:p99" && it[1].startsWith("thread:")})
+    1 * statsd.gauge("my_timer", { it > MILLISECONDS.toNanos(200) }, {it[0] == "stat:max" && it[1].startsWith("thread:")})
     0 * _
   }
 
@@ -28,12 +47,41 @@ class TimingTest extends DDSpecification {
     setup:
     StatsDClient statsd = Mock(StatsDClient)
     Monitoring monitoring = new Monitoring(statsd, 100, MILLISECONDS)
-    Timer timer = monitoring.newTimer("my_timer")
+    def timer = timerCreator(monitoring)
     when:
     timer.start()
     long min = System.nanoTime()
     timer.reset()
     then:
-    timer.start >= min
+    if (timer instanceof ThreadLocalRecording) {
+      timer.tls.get().start >= min
+    } else {
+      timer.start >= min
+    }
+
+    where:
+    timerCreator << [{it.newTimer("my_timer")}, { it.newThreadLocalTimer("my_timer") }]
+  }
+
+  def "disabled monitoring produces no ops" () {
+    expect:
+    Monitoring.DISABLED.newTimer("foo") instanceof NoOpRecording
+    Monitoring.DISABLED.newTimer("foo", "tag") instanceof NoOpRecording
+    Monitoring.DISABLED.newThreadLocalTimer("foo") instanceof NoOpRecording
+  }
+
+  def "no ops are safe to use" () {
+    expect:
+    try {
+      recording.start().stop()
+      recording.reset()
+    } catch (Throwable t) {
+      Assert.fail(t.getMessage())
+    }
+
+    where:
+    recording << [Monitoring.DISABLED.newTimer("foo"),
+                  Monitoring.DISABLED.newTimer("foo", "tag"),
+                  Monitoring.DISABLED.newThreadLocalTimer("foo")]
   }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerTest.groovy
@@ -444,7 +444,6 @@ class ScopeManagerTest extends DDSpecification {
     then:
     activatedCount.get() == 2
     closedCount.get() == 1
-    4 * statsDClient.time("trace.write", { it > 0 }, _)
     0 * _
 
     when:

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/OpenTracingAPITest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/OpenTracingAPITest.groovy
@@ -318,7 +318,6 @@ class OpenTracingAPITest extends DDSpecification {
     then:
     1 * scopeListener.afterScopeClosed()
     1 * traceInterceptor.onTraceComplete({ it.size() == 2 }) >> { args -> args[0] }
-    4 * statsDClient.time("trace.write", { it > 0 }, _)
     0 * _
 
     when:
@@ -362,7 +361,6 @@ class OpenTracingAPITest extends DDSpecification {
     then:
     1 * scopeListener.afterScopeClosed()
     1 * traceInterceptor.onTraceComplete({ it.size() == 2 }) >> { args -> args[0] }
-    4 * statsDClient.time("trace.write", { it > 0 }, _)
     0 * _
 
     when:

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -188,6 +188,7 @@ public class Config {
   public static final String HEALTH_METRICS_ENABLED = GeneralConfig.HEALTH_METRICS_ENABLED;
   public static final String HEALTH_METRICS_STATSD_HOST = GeneralConfig.HEALTH_METRICS_STATSD_HOST;
   public static final String HEALTH_METRICS_STATSD_PORT = GeneralConfig.HEALTH_METRICS_STATSD_PORT;
+  public static final String PERF_METRICS_ENABLED = GeneralConfig.PERF_METRICS_ENABLED;
 
   public static final String LOGS_INJECTION_ENABLED =
       TraceInstrumentationConfig.LOGS_INJECTION_ENABLED;
@@ -316,6 +317,7 @@ public class Config {
   @Getter private final boolean healthMetricsEnabled;
   @Getter private final String healthMetricsStatsdHost;
   @Getter private final Integer healthMetricsStatsdPort;
+  @Getter private final boolean perfMetricsEnabled;
 
   @Getter private final boolean logsInjectionEnabled;
   @Getter private final boolean logsMDCTagsInjectionEnabled;
@@ -521,6 +523,7 @@ public class Config {
         configProvider.getBoolean(HEALTH_METRICS_ENABLED, DEFAULT_METRICS_ENABLED);
     healthMetricsStatsdHost = configProvider.getString(HEALTH_METRICS_STATSD_HOST);
     healthMetricsStatsdPort = configProvider.getInteger(HEALTH_METRICS_STATSD_PORT);
+    perfMetricsEnabled = configProvider.getBoolean(PERF_METRICS_ENABLED, false);
 
     logsInjectionEnabled =
         configProvider.getBoolean(LOGS_INJECTION_ENABLED, DEFAULT_LOGS_INJECTION_ENABLED);


### PR DESCRIPTION
Disables more intrusive performance metrics (and distinguishes between health metrics and performance metrics), allowing them to be enabled with a flag `-Ddd.trace.perf.metrics.enabled=true`.

The distinction between health and performance is broadly based on intrusiveness and overhead. E.g. timing calls to the agent a few times a second on a single thread is a "health metric". Timing potentially thousands of accesses to a lock from an unbounded number of threads is a "performance metric".

Also uses a StatsD gauge instead of a timer for reporting summary stats from histograms, which avoids aggregations being done in the metrics pipeline.