### PR TITLE
[PROF-1574] Update agent error message for 8u262

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/ControllerFactory.java
+++ b/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/ControllerFactory.java
@@ -69,7 +69,12 @@ public final class ControllerFactory {
         if (javaVendor.startsWith("Azul Systems")) {
           return "; it requires Zulu Java 8 (1.8.0_212+).";
         }
-        // TODO Add version minimum once JFR backported into OpenJDK distros
+        String javaRuntimeName = System.getProperty("java.runtime.name", "");
+        if (javaVendor.startsWith("Oracle") && javaRuntimeName.startsWith("OpenJDK")) {
+          // this is a upstream build from openjdk docker repository for example
+          return "; it requires 1.8.0_272+ OpenJDK builds (upstream)";
+        }
+        return "; it requires 1.8.0_262+ OpenJDK builds from the following vendors: AdoptOpenJDK, Amazon Corretto, Azul Zulu, BellSoft Liberica";
       }
       return "; it requires OpenJDK 11+, Oracle Java 11+, or Zulu Java 8 (1.8.0_212+).";
     } catch (final Exception ex) {

--- a/dd-java-agent/agent-profiling/profiling-controller/src/test/java/com/datadog/profiling/controller/ControllerFactoryTest.java
+++ b/dd-java-agent/agent-profiling/profiling-controller/src/test/java/com/datadog/profiling/controller/ControllerFactoryTest.java
@@ -38,6 +38,8 @@ public class ControllerFactoryTest {
         && javaVersion.startsWith("1.8")) {
       // condition for OracleJRE8 (with proprietary JFR inside)
       expected = "Not enabling profiling; it requires Oracle Java 11+.";
+    } else if ("OpenJDK Runtime Environment".equals(javaRuntimeName)) {
+      expected = "Not enabling profiling; it requires 1.8.0_262+ OpenJDK builds from the following vendors: AdoptOpenJDK, Amazon Corretto, Azul Zulu, BellSoft Liberica";
     }
     assertEquals(
         expected,

--- a/dd-java-agent/agent-profiling/profiling-controller/src/test/java/com/datadog/profiling/controller/ControllerFactoryTest.java
+++ b/dd-java-agent/agent-profiling/profiling-controller/src/test/java/com/datadog/profiling/controller/ControllerFactoryTest.java
@@ -39,7 +39,8 @@ public class ControllerFactoryTest {
       // condition for OracleJRE8 (with proprietary JFR inside)
       expected = "Not enabling profiling; it requires Oracle Java 11+.";
     } else if ("OpenJDK Runtime Environment".equals(javaRuntimeName)) {
-      expected = "Not enabling profiling; it requires 1.8.0_262+ OpenJDK builds from the following vendors: AdoptOpenJDK, Amazon Corretto, Azul Zulu, BellSoft Liberica";
+      expected =
+          "Not enabling profiling; it requires 1.8.0_262+ OpenJDK builds from the following vendors: AdoptOpenJDK, Amazon Corretto, Azul Zulu, BellSoft Liberica";
     }
     assertEquals(
         expected,


### PR DESCRIPTION
Here are the new error messages:
on OpenJDK < 8u262:
```
[dd.trace 2020-09-11 17:04:37:832 +0000] [main] WARN com.datadog.profiling.agent.ProfilingAgent - Not enabling profiling; it requires 1.8.0_262+ OpenJDK builds from the following vendors: AdoptOpenJDK, Amazon Corretto, Azul Zulu, BellSoft Liberica
openjdk version "1.8.0_252"
```
on [OpenJDK Official docker images](https://hub.docker.com/_/openjdk?)  <= openjdk:8u262 (upstream):
```
[dd.trace 2020-09-11 17:06:08:486 +0000] [main] WARN com.datadog.profiling.agent.ProfilingAgent - Not enabling profiling; it requires 1.8.0_272+ OpenJDK builds (upstream)
openjdk version "1.8.0_262"
```
