### PR TITLE
Move HttpUrlConnection helpers to bootstrap

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/httpurlconnection/HeadersInjectAdapter.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/httpurlconnection/HeadersInjectAdapter.java
@@ -1,4 +1,4 @@
-package datadog.trace.instrumentation.http_url_connection;
+package datadog.trace.bootstrap.instrumentation.httpurlconnection;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import java.net.HttpURLConnection;

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/httpurlconnection/HttpUrlConnectionDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/httpurlconnection/HttpUrlConnectionDecorator.java
@@ -1,4 +1,4 @@
-package datadog.trace.instrumentation.http_url_connection;
+package datadog.trace.bootstrap.instrumentation.httpurlconnection;
 
 import datadog.trace.bootstrap.instrumentation.decorator.HttpClientDecorator;
 import java.net.HttpURLConnection;

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/httpurlconnection/HttpUrlState.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/httpurlconnection/HttpUrlState.java
@@ -1,0 +1,74 @@
+package datadog.trace.bootstrap.instrumentation.httpurlconnection;
+
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+import static datadog.trace.bootstrap.instrumentation.httpurlconnection.HttpUrlConnectionDecorator.DECORATE;
+
+import datadog.trace.bootstrap.ContextStore;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import java.net.HttpURLConnection;
+
+public class HttpUrlState {
+
+  public static final String OPERATION_NAME = "http.request";
+
+  public static final ContextStore.Factory<HttpUrlState> FACTORY =
+      new ContextStore.Factory<HttpUrlState>() {
+        @Override
+        public HttpUrlState create() {
+          return new HttpUrlState();
+        }
+      };
+
+  private volatile AgentSpan span = null;
+  private volatile boolean finished = false;
+
+  public AgentSpan start(final HttpURLConnection connection) {
+    span = startSpan(OPERATION_NAME);
+    try (final AgentScope scope = activateSpan(span)) {
+      DECORATE.afterStart(span);
+      DECORATE.onRequest(span, connection);
+      return span;
+    }
+  }
+
+  public boolean hasSpan() {
+    return span != null;
+  }
+
+  public boolean isFinished() {
+    return finished;
+  }
+
+  public void finish() {
+    finished = true;
+  }
+
+  public void finishSpan(final Throwable throwable) {
+    try (final AgentScope scope = activateSpan(span)) {
+      DECORATE.onError(span, throwable);
+      DECORATE.beforeFinish(span);
+      span.finish();
+      span = null;
+      finished = true;
+    }
+  }
+
+  public void finishSpan(final int responseCode) {
+    /*
+     * responseCode field is sometimes not populated.
+     * We can't call getResponseCode() due to some unwanted side-effects
+     * (e.g. breaks getOutputStream).
+     */
+    if (responseCode > 0) {
+      try (final AgentScope scope = activateSpan(span)) {
+        DECORATE.onResponse(span, responseCode);
+        DECORATE.beforeFinish(span);
+        span.finish();
+        span = null;
+        finished = true;
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionResponseCodeOnlyTest.groovy
+++ b/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionResponseCodeOnlyTest.groovy
@@ -1,5 +1,5 @@
 import datadog.trace.agent.test.base.HttpClientTest
-import datadog.trace.instrumentation.http_url_connection.HttpUrlConnectionDecorator
+import datadog.trace.bootstrap.instrumentation.httpurlconnection.HttpUrlConnectionDecorator
 import spock.lang.Timeout
 
 @Timeout(5)

--- a/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionTest.groovy
+++ b/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionTest.groovy
@@ -2,7 +2,7 @@ import datadog.trace.agent.test.base.HttpClientTest
 import datadog.trace.api.Config
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
-import datadog.trace.instrumentation.http_url_connection.HttpUrlConnectionDecorator
+import datadog.trace.bootstrap.instrumentation.httpurlconnection.HttpUrlConnectionDecorator
 import spock.lang.Ignore
 import spock.lang.Requires
 import spock.lang.Timeout
@@ -11,7 +11,7 @@ import sun.net.www.protocol.https.HttpsURLConnectionImpl
 import static datadog.trace.agent.test.utils.ConfigUtils.withConfigOverride
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope
-import static datadog.trace.instrumentation.http_url_connection.HttpUrlConnectionInstrumentation.HttpUrlState.OPERATION_NAME
+import static datadog.trace.bootstrap.instrumentation.httpurlconnection.HttpUrlState.OPERATION_NAME
 
 @Timeout(5)
 class HttpUrlConnectionTest extends HttpClientTest {

--- a/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionUseCachesFalseTest.groovy
+++ b/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionUseCachesFalseTest.groovy
@@ -1,5 +1,5 @@
 import datadog.trace.agent.test.base.HttpClientTest
-import datadog.trace.instrumentation.http_url_connection.HttpUrlConnectionDecorator
+import datadog.trace.bootstrap.instrumentation.httpurlconnection.HttpUrlConnectionDecorator
 import spock.lang.Timeout
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope

--- a/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/SpringRestTemplateTest.groovy
+++ b/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/SpringRestTemplateTest.groovy
@@ -1,5 +1,5 @@
 import datadog.trace.agent.test.base.HttpClientTest
-import datadog.trace.instrumentation.http_url_connection.HttpUrlConnectionDecorator
+import datadog.trace.bootstrap.instrumentation.httpurlconnection.HttpUrlConnectionDecorator
 import org.springframework.http.HttpEntity
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod

--- a/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/UrlConnectionTest.groovy
+++ b/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/UrlConnectionTest.groovy
@@ -9,7 +9,7 @@ import static datadog.trace.agent.test.utils.ConfigUtils.withConfigOverride
 import static datadog.trace.agent.test.utils.PortUtils.UNUSABLE_PORT
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope
-import static datadog.trace.instrumentation.http_url_connection.HttpUrlConnectionInstrumentation.HttpUrlState.OPERATION_NAME
+import static datadog.trace.bootstrap.instrumentation.httpurlconnection.HttpUrlState.OPERATION_NAME
 
 class UrlConnectionTest extends AgentTestRunner {
 


### PR DESCRIPTION
Similar to #1311, these helper classes are always injected into the bootstrap.  Moves us closer to supporting Read only filesystems (#429) while also reducing what needs to be done at startup