### PR TITLE
Change health metrics names to be more consistent with other tracers

### DIFF
--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterCombinedTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterCombinedTest.groovy
@@ -614,13 +614,13 @@ class DDAgentWriterCombinedTest extends DDSpecification {
     }
 
     def statsd = Stub(StatsDClient)
-    statsd.incrementCounter("queue.accepted", _) >> { stat ->
+    statsd.incrementCounter("queue.enqueued.traces", _) >> { stat ->
       numTracesAccepted += 1
     }
-    statsd.incrementCounter("api.requests") >> { stat ->
+    statsd.incrementCounter("api.requests.total") >> { stat ->
       numRequests += 1
     }
-    statsd.incrementCounter("api.responses", _) >> { stat, tags ->
+    statsd.incrementCounter("api.responses.total", _) >> { stat, tags ->
       numResponses += 1
     }
 
@@ -657,13 +657,13 @@ class DDAgentWriterCombinedTest extends DDSpecification {
     api.sendSerializedTraces(_) >> DDAgentApi.Response.failed(new IOException("comm error"))
 
     def statsd = Stub(StatsDClient)
-    statsd.incrementCounter("api.requests") >> { stat ->
+    statsd.incrementCounter("api.requests.total") >> { stat ->
       numRequests += 1
     }
-    statsd.incrementCounter("api.responses", _) >> { stat, tags ->
+    statsd.incrementCounter("api.responses.total", _) >> { stat, tags ->
       numResponses += 1
     }
-    statsd.incrementCounter("api.errors", _) >> { stat ->
+    statsd.incrementCounter("api.errors.total", _) >> { stat ->
       numErrors += 1
     }
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/monitor/HealthMetricsTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/monitor/HealthMetricsTest.groovy
@@ -47,16 +47,16 @@ class HealthMetricsTest extends DDSpecification {
 
     then:
     // verify the tags syntax
-    1 * statsD.incrementCounter('queue.accepted',  "priority:" + priorityName )
-    1 * statsD.count('queue.accepted_lengths', trace.size())
+    1 * statsD.incrementCounter('queue.enqueued.traces', "priority:" + priorityName)
+    1 * statsD.count('queue.enqueued.spans', trace.size())
     0 * _
 
     where:
-    trace          |  samplingPriority                |    priorityName
-    []             |   PrioritySampling.USER_DROP     |      "user_drop"
-    [null, null]   |   PrioritySampling.USER_DROP     |      "user_drop"
-    []             |   PrioritySampling.SAMPLER_KEEP  |   "sampler_keep"
-    [null, null]   |   PrioritySampling.SAMPLER_KEEP  |   "sampler_keep"
+    trace        | samplingPriority              | priorityName
+    []           | PrioritySampling.USER_DROP    | "user_drop"
+    [null, null] | PrioritySampling.USER_DROP    | "user_drop"
+    []           | PrioritySampling.SAMPLER_KEEP | "sampler_keep"
+    [null, null] | PrioritySampling.SAMPLER_KEEP | "sampler_keep"
   }
 
   def "test onFailedPublish"() {
@@ -64,7 +64,7 @@ class HealthMetricsTest extends DDSpecification {
     healthMetrics.onFailedPublish(samplingPriority)
 
     then:
-    1 * statsD.incrementCounter('queue.dropped', { it.startsWith("priority:") })
+    1 * statsD.incrementCounter('queue.dropped.traces', { it.startsWith("priority:") })
     0 * _
 
     where:
@@ -92,7 +92,7 @@ class HealthMetricsTest extends DDSpecification {
     healthMetrics.onSerialize(bytes)
 
     then:
-    1 * statsD.count('queue.accepted_size', bytes)
+    1 * statsD.count('queue.enqueued.bytes', bytes)
     0 * _
 
     where:
@@ -112,14 +112,14 @@ class HealthMetricsTest extends DDSpecification {
     healthMetrics.onSend(representativeCount, sendSize, response)
 
     then:
-    1 * statsD.incrementCounter('api.requests')
-    1 * statsD.recordGaugeValue('queue.length', representativeCount)
-    1 * statsD.recordGaugeValue('queue.size', sendSize)
+    1 * statsD.incrementCounter('api.requests.total')
+    1 * statsD.count('flush.traces.total', representativeCount)
+    1 * statsD.count('flush.bytes.total', sendSize)
     if (response.exception()) {
-      1 * statsD.incrementCounter('api.errors')
+      1 * statsD.incrementCounter('api.errors.total')
     }
     if (response.status()) {
-      1 * statsD.incrementCounter('api.responses', ["status:${response.status()}"])
+      1 * statsD.incrementCounter('api.responses.total', ["status:${response.status()}"])
     }
     0 * _
 
@@ -140,14 +140,14 @@ class HealthMetricsTest extends DDSpecification {
     healthMetrics.onFailedSend(representativeCount, sendSize, response)
 
     then:
-    1 * statsD.incrementCounter('api.requests')
-    1 * statsD.recordGaugeValue('queue.length', representativeCount)
-    1 * statsD.recordGaugeValue('queue.size', sendSize)
+    1 * statsD.incrementCounter('api.requests.total')
+    1 * statsD.count('flush.traces.total', representativeCount)
+    1 * statsD.count('flush.bytes.total', sendSize)
     if (response.exception()) {
-      1 * statsD.incrementCounter('api.errors')
+      1 * statsD.incrementCounter('api.errors.total')
     }
     if (response.status()) {
-      1 * statsD.incrementCounter('api.responses', ["status:${response.status()}"])
+      1 * statsD.incrementCounter('api.responses.total', ["status:${response.status()}"])
     }
     0 * _
 


### PR DESCRIPTION
Updates health metrics names to be more in line with other tracers.  See https://github.com/DataDog/dd-trace-py/blob/0dc08305ebc12cfbc64270c1a5aa3cab040f4b8a/ddtrace/internal/writer.py#L193