### PR TITLE
Handle custom bean classloader in Spring

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/AdditionalLibraryIgnoresMatcher.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/AdditionalLibraryIgnoresMatcher.java
@@ -86,7 +86,12 @@ public class AdditionalLibraryIgnoresMatcher<T extends TypeDescription>
       if (name.startsWith("org.springframework.beans.")) {
         if (name.equals("org.springframework.beans.factory.support.DisposableBeanAdapter")
             || name.startsWith(
-                "org.springframework.beans.factory.groovy.GroovyBeanDefinitionReader$")) {
+                "org.springframework.beans.factory.groovy.GroovyBeanDefinitionReader$")
+            || name.equals("org.springframework.beans.factory.support.AbstractBeanFactory")
+            || name.equals(
+                "org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory")
+            || name.equals(
+                "org.springframework.beans.factory.support.DefaultListableBeanFactory")) {
           return false;
         }
         return true;

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/BeanFactoryInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/BeanFactoryInstrumentation.java
@@ -1,0 +1,81 @@
+package datadog.trace.instrumentation.springweb;
+
+import static datadog.trace.agent.tooling.ClassLoaderMatcher.hasClassesNamed;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers.extendsClass;
+import static java.util.Collections.singletonMap;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import java.util.Map;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import org.springframework.beans.factory.support.RootBeanDefinition;
+
+/**
+ * Bean Factories can be set with a "beanClassloader" that is different from the injected
+ * classloader. This leads to a ClassNotFoundException at runtime.
+ *
+ * <p>This instrumentation ensures class lookups for the HandlerMappingResourceNameFilter don't fail
+ * by manually setting the class on the bean definition
+ *
+ * <p>This can't be done at BeanDefinition construction time because Spring heavy use of clone()
+ * which sometimes only copies the classname
+ */
+@AutoService(Instrumenter.class)
+public class BeanFactoryInstrumentation extends Instrumenter.Default {
+  public BeanFactoryInstrumentation() {
+    super("spring-web");
+  }
+
+  @Override
+  public ElementMatcher<ClassLoader> classLoaderMatcher() {
+    // Optimization for expensive typeMatcher.
+    return hasClassesNamed("org.springframework.beans.factory.support.AbstractBeanFactory");
+  }
+
+  @Override
+  public ElementMatcher<TypeDescription> typeMatcher() {
+    return extendsClass(named("org.springframework.beans.factory.support.AbstractBeanFactory"));
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {
+      packageName + ".SpringWebHttpServerDecorator",
+      packageName + ".SpringWebHttpServerDecorator$1",
+      packageName + ".ServletRequestURIAdapter",
+      packageName + ".HandlerMappingResourceNameFilter",
+      packageName + ".HandlerMappingResourceNameFilter$BeanDefinition",
+    };
+  }
+
+  @Override
+  public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
+
+    return singletonMap(
+        isMethod()
+            .and(named("resolveBeanClass"))
+            .and(
+                takesArgument(
+                    0, named("org.springframework.beans.factory.support.RootBeanDefinition"))),
+        BeanFactoryInstrumentation.class.getName() + "$BeanResolvingAdvice");
+  }
+
+  public static class BeanResolvingAdvice {
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static void onEnter(@Advice.Argument(0) final RootBeanDefinition beanDefinition) {
+      if (!beanDefinition.hasBeanClass()
+          && HandlerMappingResourceNameFilter.class
+              .getName()
+              .equals(beanDefinition.getBeanClassName())) {
+
+        beanDefinition.setBeanClass(HandlerMappingResourceNameFilter.class);
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/boot/CustomBeanClassloaderTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/boot/CustomBeanClassloaderTest.groovy
@@ -1,0 +1,16 @@
+package test.boot
+
+import org.springframework.boot.SpringApplication
+import org.springframework.context.ConfigurableApplicationContext
+
+import static java.util.Collections.singletonMap
+
+class CustomBeanClassloaderTest extends SpringBootBasedTest {
+  @Override
+  ConfigurableApplicationContext startServer(int port) {
+    def app = new SpringApplication(AppConfig, SecurityConfig, AuthServerConfig, CustomClassloaderConfig)
+    app.setDefaultProperties(singletonMap("server.port", port))
+    def context = app.run()
+    return context
+  }
+}

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/boot/CustomClassloaderConfig.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/boot/CustomClassloaderConfig.groovy
@@ -1,0 +1,41 @@
+package test.boot
+
+import org.springframework.beans.BeansException
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+/**
+ * Sets the bean classloader to one that explicitly filters datadog classes
+ * The goal is to test a classloader that we didn't inject.  With our test
+ * setup, its easier to filter than create a new one
+ */
+@Configuration
+class CustomClassloaderConfig {
+  
+  @Bean
+  BeanFactoryPostProcessor postProcessor() {
+    return new BeanFactoryPostProcessor() {
+      @Override
+      void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) throws BeansException {
+        beanFactory.setBeanClassLoader(new DatadogFilteringClassloader(this.getClass().getClassLoader()))
+      }
+    }
+  }
+}
+
+class DatadogFilteringClassloader extends URLClassLoader {
+  DatadogFilteringClassloader(ClassLoader parent) {
+    super(new URL[0], parent)
+  }
+
+  protected Class<?> loadClass(String className, boolean resolve)
+    throws ClassNotFoundException {
+    if (className.startsWith("datadog")) {
+      throw new ClassNotFoundException()
+    }
+
+    return super.loadClass(className, resolve);
+  }
+}

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/boot/CustomClassloaderConfig.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/boot/CustomClassloaderConfig.groovy
@@ -13,7 +13,7 @@ import org.springframework.context.annotation.Configuration
  */
 @Configuration
 class CustomClassloaderConfig {
-  
+
   @Bean
   BeanFactoryPostProcessor postProcessor() {
     return new BeanFactoryPostProcessor() {
@@ -36,6 +36,6 @@ class DatadogFilteringClassloader extends URLClassLoader {
       throw new ClassNotFoundException()
     }
 
-    return super.loadClass(className, resolve);
+    return super.loadClass(className, resolve)
   }
 }


### PR DESCRIPTION
Bean Factories can be set with a "beanClassloader" that is different from the injected classloader. This leads to a ClassNotFoundException at runtime.

This instrumentation ensures class lookups for the `HandlerMappingResourceNameFilter` don't fail by manually setting the class on the bean definition.  This can't be done at `BeanDefinition` construction time because Spring heavy use of `clone()` which sometimes only copies the classname.