### PR TITLE
Add instrumentation for ScheduledExecutorService, dormant integration testing for spanner session creation dependent on PendingTrace changes

### DIFF
--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/JavaExecutorInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/JavaExecutorInstrumentation.java
@@ -81,6 +81,9 @@ public final class JavaExecutorInstrumentation extends AbstractExecutorInstrumen
     public static State enterJobSubmit(
         @Advice.This final Executor executor,
         @Advice.Argument(value = 0, readOnly = false) Runnable task) {
+      // there are cased like ScheduledExecutorService.submit (which we instrument)
+      // which calls ScheduledExecutorService.schedule (which we also instrument)
+      // where all of this could be dodged the second time
       final TraceScope scope = activeScope();
       if (null != scope) {
         final Runnable newTask = RunnableWrapper.wrapIfNeeded(task);

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/ScheduledExecutorServiceInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/ScheduledExecutorServiceInstrumentation.java
@@ -28,7 +28,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 public class ScheduledExecutorServiceInstrumentation extends Instrumenter.Default {
 
   public ScheduledExecutorServiceInstrumentation() {
-    super("java.util.concurrent.ScheduledThreadPoolExecutor");
+    super("java-concurrent", "scheduled-executor");
   }
 
   @Override

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/ScheduledExecutorServiceInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/ScheduledExecutorServiceInstrumentation.java
@@ -67,10 +67,13 @@ public class ScheduledExecutorServiceInstrumentation extends Instrumenter.Defaul
         @Advice.This final Executor executor,
         @Advice.Argument(value = 0, readOnly = false) Runnable task) {
       final TraceScope scope = activeScope();
-      task = new RunnableWrapper(task);
-      final ContextStore<Runnable, State> contextStore =
-          InstrumentationContext.get(Runnable.class, State.class);
-      return ExecutorInstrumentationUtils.setupState(contextStore, task, scope);
+      if (null != scope) {
+        task = new RunnableWrapper(task);
+        final ContextStore<Runnable, State> contextStore =
+            InstrumentationContext.get(Runnable.class, State.class);
+        return ExecutorInstrumentationUtils.setupState(contextStore, task, scope);
+      }
+      return null;
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
@@ -95,10 +98,13 @@ public class ScheduledExecutorServiceInstrumentation extends Instrumenter.Defaul
         @Advice.This final Executor executor,
         @Advice.Argument(value = 0, readOnly = false) Callable task) {
       final TraceScope scope = activeScope();
-      task = new CallableWrapper(task);
-      final ContextStore<Callable, State> contextStore =
-          InstrumentationContext.get(Callable.class, State.class);
-      return ExecutorInstrumentationUtils.setupState(contextStore, task, scope);
+      if (null != scope) {
+        task = new CallableWrapper(task);
+        final ContextStore<Callable, State> contextStore =
+            InstrumentationContext.get(Callable.class, State.class);
+        return ExecutorInstrumentationUtils.setupState(contextStore, task, scope);
+      }
+      return null;
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/ScheduledExecutorServiceInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/ScheduledExecutorServiceInstrumentation.java
@@ -68,7 +68,7 @@ public class ScheduledExecutorServiceInstrumentation extends Instrumenter.Defaul
         @Advice.Argument(value = 0, readOnly = false) Runnable task) {
       final TraceScope scope = activeScope();
       if (null != scope) {
-        task = new RunnableWrapper(task);
+        task = RunnableWrapper.wrapIfNeeded(task);
         final ContextStore<Runnable, State> contextStore =
             InstrumentationContext.get(Runnable.class, State.class);
         return ExecutorInstrumentationUtils.setupState(contextStore, task, scope);
@@ -99,7 +99,7 @@ public class ScheduledExecutorServiceInstrumentation extends Instrumenter.Defaul
         @Advice.Argument(value = 0, readOnly = false) Callable task) {
       final TraceScope scope = activeScope();
       if (null != scope) {
-        task = new CallableWrapper(task);
+        task = CallableWrapper.wrapIfNeeded(task);
         final ContextStore<Callable, State> contextStore =
             InstrumentationContext.get(Callable.class, State.class);
         return ExecutorInstrumentationUtils.setupState(contextStore, task, scope);

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/ScheduledExecutorServiceInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/ScheduledExecutorServiceInstrumentation.java
@@ -1,0 +1,2 @@
+package datadog.trace.instrumentation.java.concurrent;public class ScheduledExecutorServiceInstrumentation {
+}

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/ScheduledExecutorServiceInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/ScheduledExecutorServiceInstrumentation.java
@@ -1,2 +1,118 @@
-package datadog.trace.instrumentation.java.concurrent;public class ScheduledExecutorServiceInstrumentation {
+package datadog.trace.instrumentation.java.concurrent;
+
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.bootstrap.ContextStore;
+import datadog.trace.bootstrap.InstrumentationContext;
+import datadog.trace.bootstrap.instrumentation.java.concurrent.CallableWrapper;
+import datadog.trace.bootstrap.instrumentation.java.concurrent.ExecutorInstrumentationUtils;
+import datadog.trace.bootstrap.instrumentation.java.concurrent.RunnableWrapper;
+import datadog.trace.bootstrap.instrumentation.java.concurrent.State;
+import datadog.trace.context.TraceScope;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Future;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+@AutoService(Instrumenter.class)
+public class ScheduledExecutorServiceInstrumentation extends Instrumenter.Default {
+
+  public ScheduledExecutorServiceInstrumentation() {
+    super("java.util.concurrent.ScheduledThreadPoolExecutor");
+  }
+
+  @Override
+  public ElementMatcher<? super TypeDescription> typeMatcher() {
+    // targeting the concrete type because it's an implementation detail
+    // that this executor's submit calls schedule, and our instrumentation
+    // is not idempotent
+    return named("java.util.concurrent.ScheduledThreadPoolExecutor");
+  }
+
+  @Override
+  public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
+    final Map<ElementMatcher<? super MethodDescription>, String> transformers = new HashMap<>();
+    transformers.put(
+        named("schedule").and(takesArgument(0, Runnable.class)),
+        ScheduledExecutorServiceInstrumentation.class.getName() + "$ScheduleRunnableAdvice");
+    transformers.put(
+        named("schedule").and(takesArgument(0, Callable.class)),
+        ScheduledExecutorServiceInstrumentation.class.getName() + "$ScheduleCallableAdvice");
+    return transformers;
+  }
+
+  @Override
+  public Map<String, String> contextStore() {
+    final Map<String, String> map = new HashMap<>(4);
+    map.put(Runnable.class.getName(), State.class.getName());
+    map.put(Callable.class.getName(), State.class.getName());
+    map.put(Future.class.getName(), State.class.getName());
+    return Collections.unmodifiableMap(map);
+  }
+
+  public static class ScheduleRunnableAdvice {
+
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static State enterSchedule(
+        @Advice.This final Executor executor,
+        @Advice.Argument(value = 0, readOnly = false) Runnable task) {
+      final TraceScope scope = activeScope();
+      task = new RunnableWrapper(task);
+      final ContextStore<Runnable, State> contextStore =
+          InstrumentationContext.get(Runnable.class, State.class);
+      return ExecutorInstrumentationUtils.setupState(contextStore, task, scope);
+    }
+
+    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
+    public static void exitSchedule(
+        @Advice.This final Executor executor,
+        @Advice.Enter final State state,
+        @Advice.Thrown final Throwable throwable,
+        @Advice.Return final Future future) {
+      if (state != null && future != null) {
+        final ContextStore<Future, State> contextStore =
+            InstrumentationContext.get(Future.class, State.class);
+        contextStore.put(future, state);
+      }
+      ExecutorInstrumentationUtils.cleanUpOnMethodExit(executor, state, throwable);
+    }
+  }
+
+  public static class ScheduleCallableAdvice {
+
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static State enterSchedule(
+        @Advice.This final Executor executor,
+        @Advice.Argument(value = 0, readOnly = false) Callable task) {
+      final TraceScope scope = activeScope();
+      task = new CallableWrapper(task);
+      final ContextStore<Callable, State> contextStore =
+          InstrumentationContext.get(Callable.class, State.class);
+      return ExecutorInstrumentationUtils.setupState(contextStore, task, scope);
+    }
+
+    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
+    public static void exitSchedule(
+        @Advice.This final Executor executor,
+        @Advice.Enter final State state,
+        @Advice.Thrown final Throwable throwable,
+        @Advice.Return final Future future) {
+      if (state != null && future != null) {
+        final ContextStore<Future, State> contextStore =
+            InstrumentationContext.get(Future.class, State.class);
+        contextStore.put(future, state);
+      }
+      ExecutorInstrumentationUtils.cleanUpOnMethodExit(executor, state, throwable);
+    }
+  }
 }

--- a/dd-smoke-tests/springboot-grpc/springboot-grpc.gradle
+++ b/dd-smoke-tests/springboot-grpc/springboot-grpc.gradle
@@ -47,6 +47,7 @@ dependencies {
   main_java8Compile 'io.grpc:grpc-protobuf:1.31.1'
   main_java8Compile 'io.grpc:grpc-stub:1.31.1'
   main_java8Compile 'org.apache.tomcat:annotations-api:6.0.53'
+  main_java8Compile 'com.google.cloud:google-cloud-spanner:1.61.0'
 
   testCompile project(':dd-smoke-tests')
 }

--- a/dd-smoke-tests/springboot-grpc/src/main_java8/java/datadog/smoketest/springboot/SpringbootGrpcApplication.java
+++ b/dd-smoke-tests/springboot-grpc/src/main_java8/java/datadog/smoketest/springboot/SpringbootGrpcApplication.java
@@ -3,6 +3,7 @@ package datadog.smoketest.springboot;
 import datadog.smoketest.springboot.grpc.AsynchronousGreeter;
 import datadog.smoketest.springboot.grpc.LocalInterface;
 import datadog.smoketest.springboot.grpc.SynchronousGreeter;
+import datadog.smoketest.springboot.spanner.SpannerTask;
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import org.springframework.boot.SpringApplication;
@@ -16,6 +17,11 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @EnableAsync
 @EnableScheduling
 public class SpringbootGrpcApplication {
+
+  @Bean
+  SpannerTask spannerTask() {
+    return new SpannerTask();
+  }
 
   @Bean
   AsyncTask asyncTask(AsynchronousGreeter greeter) {

--- a/dd-smoke-tests/springboot-grpc/src/main_java8/java/datadog/smoketest/springboot/controller/WebController.java
+++ b/dd-smoke-tests/springboot-grpc/src/main_java8/java/datadog/smoketest/springboot/controller/WebController.java
@@ -3,6 +3,7 @@ package datadog.smoketest.springboot.controller;
 import datadog.smoketest.springboot.AsyncTask;
 import datadog.smoketest.springboot.grpc.AsynchronousGreeter;
 import datadog.smoketest.springboot.grpc.SynchronousGreeter;
+import datadog.smoketest.springboot.spanner.SpannerTask;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
@@ -22,12 +23,17 @@ public class WebController {
   private final AsynchronousGreeter asyncGreeter;
   private final SynchronousGreeter greeter;
   private final AsyncTask asyncTask;
+  private final SpannerTask spannerTask;
 
   public WebController(
-      AsynchronousGreeter asyncGreeter, SynchronousGreeter greeter, AsyncTask asyncTask) {
+      AsynchronousGreeter asyncGreeter,
+      SynchronousGreeter greeter,
+      AsyncTask asyncTask,
+      SpannerTask spannerTask) {
     this.asyncGreeter = asyncGreeter;
     this.greeter = greeter;
     this.asyncTask = asyncTask;
+    this.spannerTask = spannerTask;
   }
 
   @RequestMapping("/greeting")
@@ -38,6 +44,12 @@ public class WebController {
   @RequestMapping("/async_greeting")
   public String asyncGreeting() {
     return asyncGreeter.greet();
+  }
+
+  @RequestMapping("/spanner")
+  public String spanner() {
+    spannerTask.spannerResultSet().thenAccept(results -> {}).join();
+    return "bye";
   }
 
   @RequestMapping("/async_cf_greeting")

--- a/dd-smoke-tests/springboot-grpc/src/main_java8/java/datadog/smoketest/springboot/controller/WebController.java
+++ b/dd-smoke-tests/springboot-grpc/src/main_java8/java/datadog/smoketest/springboot/controller/WebController.java
@@ -52,6 +52,12 @@ public class WebController {
     return "bye";
   }
 
+  @RequestMapping("/spanner_no_async")
+  public String spannerNoAsync() {
+    spannerTask.getSpannerResultSet().thenAccept(results -> {}).join();
+    return "bye";
+  }
+
   @RequestMapping("/async_cf_greeting")
   public String asyncCompleteableFutureGreeting() {
     CompletableFuture<String>[] cfs = new CompletableFuture[20];

--- a/dd-smoke-tests/springboot-grpc/src/main_java8/java/datadog/smoketest/springboot/spanner/SpannerTask.java
+++ b/dd-smoke-tests/springboot-grpc/src/main_java8/java/datadog/smoketest/springboot/spanner/SpannerTask.java
@@ -13,6 +13,10 @@ public class SpannerTask {
 
   @Async
   public CompletableFuture<ResultSet> spannerResultSet() {
+    return getSpannerResultSet();
+  }
+
+  public CompletableFuture<ResultSet> getSpannerResultSet() {
     SpannerOptions options = SpannerOptions.newBuilder().setProjectId("foo").build();
     Spanner spanner = options.getService();
     DatabaseId db = DatabaseId.of(options.getProjectId(), "", "");

--- a/dd-smoke-tests/springboot-grpc/src/main_java8/java/datadog/smoketest/springboot/spanner/SpannerTask.java
+++ b/dd-smoke-tests/springboot-grpc/src/main_java8/java/datadog/smoketest/springboot/spanner/SpannerTask.java
@@ -1,0 +1,28 @@
+package datadog.smoketest.springboot.spanner;
+
+import com.google.cloud.spanner.DatabaseClient;
+import com.google.cloud.spanner.DatabaseId;
+import com.google.cloud.spanner.ResultSet;
+import com.google.cloud.spanner.Spanner;
+import com.google.cloud.spanner.SpannerOptions;
+import com.google.cloud.spanner.Statement;
+import java.util.concurrent.CompletableFuture;
+import org.springframework.scheduling.annotation.Async;
+
+public class SpannerTask {
+
+  @Async
+  public CompletableFuture<ResultSet> spannerResultSet() {
+    SpannerOptions options = SpannerOptions.newBuilder().setProjectId("foo").build();
+    Spanner spanner = options.getService();
+    DatabaseId db = DatabaseId.of(options.getProjectId(), "", "");
+    DatabaseClient dbClient = spanner.getDatabaseClient(db);
+
+    Statement sql =
+        Statement.newBuilder(
+                "SELECT table_name FROM information_schema.tables WHERE table_catalog = '' and table_schema = ''")
+            .build();
+
+    return CompletableFuture.completedFuture(dbClient.singleUse().executeQuery(sql));
+  }
+}

--- a/dd-smoke-tests/springboot-grpc/src/test/groovy/datadog/smoketest/SpringBootGrpcAsyncAnnotationTest.groovy
+++ b/dd-smoke-tests/springboot-grpc/src/test/groovy/datadog/smoketest/SpringBootGrpcAsyncAnnotationTest.groovy
@@ -1,10 +1,16 @@
 package datadog.smoketest
 
+import java.util.concurrent.atomic.AtomicInteger
+
 class SpringBootGrpcAsyncAnnotationTest extends SpringBootWithGRPCTest {
+
+  private static final Set<String> EXPECTED_TRACES =
+    ["[grpc.server[grpc.message]]",
+     "[servlet.request[spring.handler[AsyncTask.greet[grpc.client[grpc.message]]]]]"].toSet()
+
   @Override
-  Set<String> expectedTraces() {
-    return ["[grpc.server[grpc.message]]",
-            "[servlet.request[spring.handler[AsyncTask.greet[grpc.client[grpc.message]]]]]"].toSet()
+  boolean isAcceptable(Map<String, AtomicInteger> traceCounts) {
+    assertTraceCounts(EXPECTED_TRACES, traceCounts)
   }
 
   @Override

--- a/dd-smoke-tests/springboot-grpc/src/test/groovy/datadog/smoketest/SpringBootGrpcAsyncConcurrentTest.groovy
+++ b/dd-smoke-tests/springboot-grpc/src/test/groovy/datadog/smoketest/SpringBootGrpcAsyncConcurrentTest.groovy
@@ -1,10 +1,16 @@
 package datadog.smoketest
 
+import java.util.concurrent.atomic.AtomicInteger
+
 class SpringBootGrpcAsyncConcurrentTest extends SpringBootWithGRPCTest {
+  private static final Set<String> EXPECTED_TRACES =
+    ["[grpc.server[grpc.message]]",
+     "[servlet.request[spring.handler[grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]]]]"]
+      .toSet()
+
   @Override
-  Set<String> expectedTraces() {
-    return ["[grpc.server[grpc.message]]",
-            "[servlet.request[spring.handler[grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]]]]"].toSet()
+  boolean isAcceptable(Map<String, AtomicInteger> traceCounts) {
+    assertTraceCounts(EXPECTED_TRACES, traceCounts)
   }
 
   @Override

--- a/dd-smoke-tests/springboot-grpc/src/test/groovy/datadog/smoketest/SpringBootGrpcAsyncTest.groovy
+++ b/dd-smoke-tests/springboot-grpc/src/test/groovy/datadog/smoketest/SpringBootGrpcAsyncTest.groovy
@@ -1,10 +1,15 @@
 package datadog.smoketest
 
+import java.util.concurrent.atomic.AtomicInteger
+
 class SpringBootGrpcAsyncTest extends SpringBootWithGRPCTest {
+  private static final Set<String> EXPECTED_TRACES =
+    ["[grpc.server[grpc.message]]",
+     "[servlet.request[spring.handler[grpc.client[grpc.message]]]]"].toSet()
+
   @Override
-  Set<String> expectedTraces() {
-    return ["[grpc.server[grpc.message]]",
-            "[servlet.request[spring.handler[grpc.client[grpc.message]]]]"].toSet()
+  boolean isAcceptable(Map<String, AtomicInteger> traceCounts) {
+    assertTraceCounts(EXPECTED_TRACES, traceCounts)
   }
 
   @Override

--- a/dd-smoke-tests/springboot-grpc/src/test/groovy/datadog/smoketest/SpringBootGrpcCompletableFutureTest.groovy
+++ b/dd-smoke-tests/springboot-grpc/src/test/groovy/datadog/smoketest/SpringBootGrpcCompletableFutureTest.groovy
@@ -1,10 +1,15 @@
 package datadog.smoketest
 
+import java.util.concurrent.atomic.AtomicInteger
+
 class SpringBootGrpcCompletableFutureTest extends SpringBootWithGRPCTest {
+  private static final Set<String> EXPECTED_TRACES =
+    ["[grpc.server[grpc.message]]",
+     "[servlet.request[spring.handler[grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]]]]"].toSet()
+
   @Override
-  Set<String> expectedTraces() {
-    return ["[grpc.server[grpc.message]]",
-            "[servlet.request[spring.handler[grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]][grpc.client[grpc.message]]]]"].toSet()
+  boolean isAcceptable(Map<String, AtomicInteger> traceCounts) {
+    assertTraceCounts(EXPECTED_TRACES, traceCounts)
   }
 
   @Override

--- a/dd-smoke-tests/springboot-grpc/src/test/groovy/datadog/smoketest/SpringBootGrpcSpannerNoAsyncTest.groovy
+++ b/dd-smoke-tests/springboot-grpc/src/test/groovy/datadog/smoketest/SpringBootGrpcSpannerNoAsyncTest.groovy
@@ -1,7 +1,10 @@
 package datadog.smoketest
 
+import spock.lang.Ignore
+
 import java.util.concurrent.atomic.AtomicInteger
 
+@Ignore("can unignore when strict continuation reference counting is dropped")
 class SpringBootGrpcSpannerNoAsyncTest extends SpringBootWithGRPCTest {
 
   @Override

--- a/dd-smoke-tests/springboot-grpc/src/test/groovy/datadog/smoketest/SpringBootGrpcSpannerNoAsyncTest.groovy
+++ b/dd-smoke-tests/springboot-grpc/src/test/groovy/datadog/smoketest/SpringBootGrpcSpannerNoAsyncTest.groovy
@@ -1,0 +1,23 @@
+package datadog.smoketest
+
+import java.util.concurrent.atomic.AtomicInteger
+
+class SpringBootGrpcSpannerNoAsyncTest extends SpringBootWithGRPCTest {
+
+  @Override
+  boolean isAcceptable(Map<String, AtomicInteger> traceCounts) {
+    // currently spring @Async instrumentation doesn't hold the trace back
+    // if spans are created after the @Async span finishes - compensate for this
+    for (Map.Entry<String, AtomicInteger> entry : traceCounts.entrySet()) {
+      if (entry.getKey().startsWith("[servlet.request[spring.handler[grpc.client]") && entry.getValue().get() > 0) {
+        return true
+      }
+    }
+    return false
+  }
+
+  @Override
+  String route() {
+    return "spanner_no_async"
+  }
+}

--- a/dd-smoke-tests/springboot-grpc/src/test/groovy/datadog/smoketest/SpringBootGrpcSpannerTest.groovy
+++ b/dd-smoke-tests/springboot-grpc/src/test/groovy/datadog/smoketest/SpringBootGrpcSpannerTest.groovy
@@ -1,0 +1,15 @@
+package datadog.smoketest
+
+class SpringBootGrpcSpannerTest extends SpringBootWithGRPCTest {
+  @Override
+  Set<String> expectedTraces() {
+    return [
+      "[servlet.request[spring.handler[SpannerTask.spannerResultSet[grpc.client][grpc.client][grpc.client][grpc.client][http.request][http.request]]]]",
+      "[servlet.request[spring.handler[SpannerTask.spannerResultSet[grpc.client][grpc.client][grpc.client][grpc.client]]]]"].toSet()
+  }
+
+  @Override
+  String route() {
+    return "spanner"
+  }
+}

--- a/dd-smoke-tests/springboot-grpc/src/test/groovy/datadog/smoketest/SpringBootGrpcSpannerTest.groovy
+++ b/dd-smoke-tests/springboot-grpc/src/test/groovy/datadog/smoketest/SpringBootGrpcSpannerTest.groovy
@@ -1,11 +1,19 @@
 package datadog.smoketest
 
+import java.util.concurrent.atomic.AtomicInteger
+
 class SpringBootGrpcSpannerTest extends SpringBootWithGRPCTest {
+
   @Override
-  Set<String> expectedTraces() {
-    return [
-      "[servlet.request[spring.handler[SpannerTask.spannerResultSet[grpc.client][grpc.client][grpc.client][grpc.client][http.request][http.request]]]]",
-      "[servlet.request[spring.handler[SpannerTask.spannerResultSet[grpc.client][grpc.client][grpc.client][grpc.client]]]]"].toSet()
+  boolean isAcceptable(Map<String, AtomicInteger> traceCounts) {
+    // currently spring @Async instrumentation doesn't hold the trace back
+    // if spans are created after the @Async span finishes - compensate for this
+    for (Map.Entry<String, AtomicInteger> entry : traceCounts.entrySet()) {
+      if (entry.getKey().startsWith("[servlet.request[spring.handler[SpannerTask.spannerResultSet[grpc.client]") && entry.getValue().get() > 0) {
+        return true
+      }
+    }
+    return false
   }
 
   @Override

--- a/dd-smoke-tests/springboot-grpc/src/test/groovy/datadog/smoketest/SpringBootGrpcSpannerTest.groovy
+++ b/dd-smoke-tests/springboot-grpc/src/test/groovy/datadog/smoketest/SpringBootGrpcSpannerTest.groovy
@@ -1,7 +1,10 @@
 package datadog.smoketest
 
+import spock.lang.Ignore
+
 import java.util.concurrent.atomic.AtomicInteger
 
+@Ignore("can unignore when strict continuation reference counting is dropped")
 class SpringBootGrpcSpannerTest extends SpringBootWithGRPCTest {
 
   @Override

--- a/dd-smoke-tests/springboot-grpc/src/test/groovy/datadog/smoketest/SpringBootGrpcSyncTest.groovy
+++ b/dd-smoke-tests/springboot-grpc/src/test/groovy/datadog/smoketest/SpringBootGrpcSyncTest.groovy
@@ -1,10 +1,15 @@
 package datadog.smoketest
 
+import java.util.concurrent.atomic.AtomicInteger
+
 class SpringBootGrpcSyncTest extends SpringBootWithGRPCTest {
-  @Override
-  Set<String> expectedTraces() {
-    return ["[grpc.server[grpc.message]]",
+  private static final Set<String> EXPECTED_TRACES =
+    ["[grpc.server[grpc.message]]",
             "[servlet.request[spring.handler[grpc.client[grpc.message]]]]"].toSet()
+
+  @Override
+  boolean isAcceptable(Map<String, AtomicInteger> traceCounts) {
+    assertTraceCounts(EXPECTED_TRACES, traceCounts)
   }
 
   @Override


### PR DESCRIPTION
`ScheduledExecutorService` is currently double instrumented because we instrument both `schedule` and `submit`, and `submit` calls `schedule`. `ScheduledExecutorService` is used in Spanner.
We are forced to create continuations which we can't close without instrumenting spanner itself, so the integration tests are dependent on pending changes to `PendingTrace` to relax reference counting semantics, in order to be able to trace creation of a session without actually connecting to spanner (or tolerating failure at all, for that matter).