### PR TITLE
Enable embedded mode for JMXFetch

### DIFF
--- a/dd-java-agent/agent-jmxfetch/src/main/java/datadog/trace/agent/jmxfetch/JMXFetch.java
+++ b/dd-java-agent/agent-jmxfetch/src/main/java/datadog/trace/agent/jmxfetch/JMXFetch.java
@@ -73,6 +73,7 @@ public class JMXFetch {
             .action(Collections.singletonList(ACTION_COLLECT))
             // App should be run as daemon otherwise CLI apps would not exit once main method exits.
             .daemon(true)
+            .embedded(true)
             .confdDirectory(jmxFetchConfigDir)
             .yamlFileList(jmxFetchConfigs)
             .targetDirectInstances(true)


### PR DESCRIPTION
this skips creation of some additional background threads which we don't need because we already run JMXFetch on its own background thread:

https://github.com/DataDog/jmxfetch/blob/0.39.0/src/main/java/org/datadog/jmxfetch/AppConfig.java#L233
https://github.com/DataDog/jmxfetch/blob/0.39.0/src/main/java/org/datadog/jmxfetch/App.java#L97