### PR TITLE
ScopeListener and ScopeManager fixes

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/log/LogContextScopeListener.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/log/LogContextScopeListener.java
@@ -1,7 +1,5 @@
 package datadog.trace.agent.tooling.log;
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
-
 import datadog.trace.api.Config;
 import datadog.trace.api.CorrelationIdentifier;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
@@ -45,10 +43,6 @@ public class LogContextScopeListener implements ScopeListener {
 
   @Override
   public void afterScopeClosed() {
-    if (activeSpan() != null) {
-      afterScopeActivated();
-      return;
-    }
     try {
       removeMethod.invoke(null, CorrelationIdentifier.getTraceIdKey());
       removeMethod.invoke(null, CorrelationIdentifier.getSpanIdKey());

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
@@ -150,18 +150,7 @@ public class ContinuableScopeManager implements AgentScopeManager {
     public void close() {
       final ScopeStack scopeStack = scopeManager.scopeStack();
 
-      // DQH - Aug 2020 - Preserving our broken reference counting semantics for the
-      // first round of out-of-order handling.
-      // When reference counts are being used, we don't check the stack top --
-      // so potentially we undercount errors
-      // Also we don't report closed until the reference count == 0 which seems
-      // incorrect given the OpenTracing semantics
-      // Both these issues should be corrected at a later date
-
       final boolean alive = decrementReferences();
-      if (alive) {
-        return;
-      }
 
       final boolean onTop = scopeStack.checkTop(this);
       if (!onTop) {
@@ -179,6 +168,10 @@ public class ContinuableScopeManager implements AgentScopeManager {
             throw new RuntimeException("Tried to close scope when not on top");
           }
         }
+      }
+
+      if (alive) {
+        return;
       }
 
       if (null != continuation) {

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
@@ -270,15 +270,11 @@ public class ContinuableScopeManager implements AgentScopeManager {
 
     ContinuableScope[] stack = new ContinuableScope[MIN_STACK_LENGTH];
     // The position of the top-most scope guaranteed to be active
-    // -1 if empty
-    int topPos = -1;
+    // 0 if empty
+    int topPos = 0;
 
     /** top - accesses the top of the ScopeStack */
     final ContinuableScope top() {
-      if (topPos == -1) {
-        return null;
-      }
-
       return stack[topPos];
     }
 
@@ -289,7 +285,7 @@ public class ContinuableScopeManager implements AgentScopeManager {
       topPos = Math.min(topPos, stack.length);
 
       boolean changedTop = false;
-      while (topPos >= 0) {
+      while (topPos > 0) {
         final ContinuableScope curScope = stack[topPos];
         if (curScope.alive()) {
           if (changedTop) {
@@ -301,7 +297,7 @@ public class ContinuableScopeManager implements AgentScopeManager {
         // no longer alive -- trigger listener & null out
         curScope.onProperClose();
         stack[topPos] = null;
-        topPos -= 1;
+        --topPos;
         changedTop = true;
       }
 
@@ -322,17 +318,17 @@ public class ContinuableScopeManager implements AgentScopeManager {
 
     /** Fast check to see if the expectedScope is on top the stack */
     final boolean checkTop(final ContinuableScope expectedScope) {
-      return topPos != -1 && expectedScope.equals(stack[topPos]);
+      return expectedScope.equals(stack[topPos]);
     }
 
     /** Returns the current stack depth */
     final int depth() {
-      return topPos + 1;
+      return topPos;
     }
 
     // DQH - regrettably needed for pre-existing tests
     final void clear() {
-      topPos = -1;
+      topPos = 0;
       Arrays.fill(stack, null);
     }
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
@@ -166,7 +166,6 @@ public class ContinuableScopeManager implements AgentScopeManager {
       final boolean onTop = scopeStack.checkTop(this);
       if (!onTop) {
         if (log.isDebugEnabled()) {
-          // Using noFixupTop because I don't want to have code with side effects in logging code
           log.debug(
               "Tried to close {} scope when not on top.  Current top: {}", this, scopeStack.top());
         }
@@ -262,7 +261,7 @@ public class ContinuableScopeManager implements AgentScopeManager {
   }
 
   /**
-   * The invariant is that the top a non-empty stack is always active Anytime a scope is closed,
+   * The invariant is that the top of a non-empty stack is always active. Anytime a scope is closed,
    * cleanup() is called to ensure the invariant
    */
   static final class ScopeStack {
@@ -385,7 +384,7 @@ public class ContinuableScopeManager implements AgentScopeManager {
     }
 
     // Called by ContinuableScopeManager when a continued scope is closed
-    // Can't use camcel() because of the "used" check
+    // Can't use cancel() because of the "used" check
     private void cancelFromContinuedScopeClose() {
       trace.cancelContinuation(this);
     }

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
@@ -72,7 +72,7 @@ public class ContinuableScopeManager implements AgentScopeManager {
 
   @Override
   public AgentScope activate(final AgentSpan span, final ScopeSource source) {
-    ScopeStack scopeStack = scopeStack();
+    final ScopeStack scopeStack = scopeStack();
 
     final ContinuableScope active = scopeStack.top();
     if (active != null && active.span.equals(span)) {
@@ -94,7 +94,7 @@ public class ContinuableScopeManager implements AgentScopeManager {
       final Continuation continuation, final AgentSpan span, final ScopeSource source) {
     final ContinuableScope scope = new ContinuableScope(this, continuation, span, source);
     scopeStack().push(scope);
-    scope.afterActivated();
+
     return scope;
   }
 
@@ -148,7 +148,7 @@ public class ContinuableScopeManager implements AgentScopeManager {
 
     @Override
     public void close() {
-      ScopeStack scopeStack = scopeManager.scopeStack();
+      final ScopeStack scopeStack = scopeManager.scopeStack();
 
       // DQH - Aug 2020 - Preserving our broken reference counting semantics for the
       // first round of out-of-order handling.
@@ -158,14 +158,17 @@ public class ContinuableScopeManager implements AgentScopeManager {
       // incorrect given the OpenTracing semantics
       // Both these issues should be corrected at a later date
 
-      boolean alive = decrementReferences();
-      if (alive) return;
+      final boolean alive = decrementReferences();
+      if (alive) {
+        return;
+      }
 
-      boolean onTop = scopeStack.checkTop(this);
+      final boolean onTop = scopeStack.checkTop(this);
       if (!onTop) {
         if (log.isDebugEnabled()) {
           // Using noFixupTop because I don't want to have code with side effects in logging code
-          log.debug("Tried to close {} scope when not on top. Ignoring!", scopeStack.noFixupTop());
+          log.debug(
+              "Tried to close {} scope when not on top.  Current top: {}", this, scopeStack.top());
         }
 
         scopeManager.statsDClient.incrementCounter("scope.close.error");
@@ -177,19 +180,13 @@ public class ContinuableScopeManager implements AgentScopeManager {
             throw new RuntimeException("Tried to close scope when not on top");
           }
         }
-
-        return;
       }
 
       if (null != continuation) {
-        span.context().getTrace().cancelContinuation(continuation);
+        continuation.cancelFromContinuedScopeClose();
       }
-      scopeStack.blindPop();
 
-      // DQH - As covered above, I feel our close notification semantics are incorrect with
-      // especially where reference counting is concerned.  Unfortunately, sorting out the
-      // semantics will also require sorting out the tests which have codified the ill-behavior.
-      onProperClose();
+      scopeStack.cleanup();
     }
 
     /*
@@ -264,109 +261,78 @@ public class ContinuableScopeManager implements AgentScopeManager {
     }
   }
 
+  /**
+   * The invariant is that the top a non-empty stack is always active Anytime a scope is closed,
+   * cleanup() is called to ensure the invariant
+   */
   static final class ScopeStack {
-    ContinuableScope[] stack = new ContinuableScope[16];
-    int topPos = 0;
+    private static final int MIN_STACK_LENGTH = 16;
 
-    /**
-     * top - accesses the top of the ScopeStack making sure the Scope on-top is still active If the
-     * top scope isn't active, then the stack is popped back to the top-most active Scope
-     */
+    ContinuableScope[] stack = new ContinuableScope[MIN_STACK_LENGTH];
+    // The position of the top-most scope guaranteed to be active
+    // -1 if empty
+    int topPos = -1;
+
+    /** top - accesses the top of the ScopeStack */
     final ContinuableScope top() {
-      int priorTopPos = this.topPos;
-      if (priorTopPos == 0) {
+      if (topPos == -1) {
         return null;
       }
 
+      return stack[topPos];
+    }
+
+    void cleanup() {
       // localizing & clamping stackPos to enable ArrayBoundsCheck elimination
       // only bothering to do this here because of the loop below
-      ContinuableScope[] stack = this.stack;
-      priorTopPos = Math.min(priorTopPos, stack.length);
+      final ContinuableScope[] stack = this.stack;
+      topPos = Math.min(topPos, stack.length);
 
-      // Peel first iteration
-      ContinuableScope topScope = stack[priorTopPos];
-      if (topScope.alive()) {
-        return topScope;
-      }
-
-      // null out top position, it is no longer alive
-      stack[topPos] = null;
-
-      for (int curPos = topPos - 1; curPos > 0; --curPos) {
-        ContinuableScope curScope = stack[curPos];
+      boolean changedTop = false;
+      while (topPos >= 0) {
+        final ContinuableScope curScope = stack[topPos];
         if (curScope.alive()) {
-          // save the position for next time
-          topPos = curPos;
-
-          if (topPos < stack.length / 4) {
-            this.stack = Arrays.copyOf(stack, stack.length / 2);
+          if (changedTop) {
+            curScope.afterActivated();
           }
-
-          return curScope;
+          break;
         }
 
         // no longer alive -- trigger listener & null out
         curScope.onProperClose();
-        stack[curPos] = null;
+        stack[topPos] = null;
+        topPos -= 1;
+        changedTop = true;
       }
 
-      // empty stack -- save topPos for next time
-      topPos = 0;
-      return null;
+      if (topPos < stack.length / 4 && stack.length > MIN_STACK_LENGTH * 4) {
+        this.stack = Arrays.copyOf(stack, stack.length / 2);
+      }
     }
 
-    /**
-     * Similar to top but without the fix-up behavior that skips over any closed Scopes Mostly
-     * useful in logging to avoid side effects, but could be used in other places with caution.
-     */
-    final ContinuableScope noFixupTop() {
-      return stack[topPos];
-    }
-
-    /**
-     * Pushes a new scope unto the stack Currently, the new scope is pushed onto the stack without
-     * any stack fix-up. This works under two assumptions... 1 - Normally, the stack doesn't need
-     * fix-up because the stack is proactively clean by Scope.close 2 - If the stack does need
-     * fix-up, it has probably already been done by calling active to get the parent scope
-     */
+    /** Pushes a new scope unto the stack */
     final void push(final ContinuableScope scope) {
-      // no proactive stack cleaning in push
-      // In most cases, the span construction will have asked for the activeScope
-      // and done any necessary stack clean-up
-
       ++topPos;
       if (topPos == stack.length) {
-        // Could scan the stack for dead activations and compact before expansion.
-        // Probably not worth it
         stack = Arrays.copyOf(stack, stack.length * 2);
       }
       stack[topPos] = scope;
+      scope.afterActivated();
     }
 
-    /**
-     * Fast check to see if the expectedScope is on top the stack -- this is done with any fix-up
-     */
-    final boolean checkTop(ContinuableScope expectedScope) {
-      return expectedScope.equals(stack[topPos]);
-    }
-
-    /**
-     * Blind pop of the top stack entry This is done without fix-up, checking the stack top, or even
-     * a depth check Responsibility lies with the caller to do the diligence of calling depth or
-     * checkTop ahead of calling blindPop.
-     */
-    final void blindPop() {
-      stack[topPos--] = null;
+    /** Fast check to see if the expectedScope is on top the stack */
+    final boolean checkTop(final ContinuableScope expectedScope) {
+      return topPos != -1 && expectedScope.equals(stack[topPos]);
     }
 
     /** Returns the current stack depth */
     final int depth() {
-      return topPos;
+      return topPos + 1;
     }
 
     // DQH - regrettably needed for pre-existing tests
     final void clear() {
-      topPos = 0;
+      topPos = -1;
       Arrays.fill(stack, null);
     }
   }
@@ -420,6 +386,12 @@ public class ContinuableScopeManager implements AgentScopeManager {
       } else {
         log.debug("Failed to close continuation {}. Already used.", this);
       }
+    }
+
+    // Called by ContinuableScopeManager when a continued scope is closed
+    // Can't use camcel() because of the "used" check
+    private void cancelFromContinuedScopeClose() {
+      trace.cancelContinuation(this);
     }
 
     @Override

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerTest.groovy
@@ -14,9 +14,10 @@ import spock.lang.Timeout
 
 import java.lang.ref.WeakReference
 import java.util.concurrent.CountDownLatch
-import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
 
+import static datadog.trace.core.scopemanager.EventCountingListener.EVENT.ACTIVATE
+import static datadog.trace.core.scopemanager.EventCountingListener.EVENT.CLOSE
 import static datadog.trace.util.gc.GCUtils.awaitGC
 import static java.util.concurrent.TimeUnit.SECONDS
 
@@ -27,6 +28,7 @@ class ScopeManagerTest extends DDSpecification {
   CoreTracer tracer
   ContinuableScopeManager scopeManager
   StatsDClient statsDClient
+  EventCountingListener eventCountingListener
 
   def setup() {
     latch = new CountDownLatch(1)
@@ -39,6 +41,8 @@ class ScopeManagerTest extends DDSpecification {
     statsDClient = Mock()
     tracer = CoreTracer.builder().writer(writer).statsDClient(statsDClient).build()
     scopeManager = tracer.scopeManager
+    eventCountingListener = new EventCountingListener()
+    scopeManager.addScopeListener(eventCountingListener)
   }
 
   def cleanup() {
@@ -330,59 +334,40 @@ class ScopeManagerTest extends DDSpecification {
     scopeManager.active() == newScope
   }
 
-  def "test activating same scope multiple times"() {
-    setup:
-    def eventCountingLister = new EventCountingListener()
-    AtomicInteger activatedCount = eventCountingLister.activatedCount
-    AtomicInteger closedCount = eventCountingLister.closedCount
-
-    scopeManager.addScopeListener(eventCountingLister)
-
+  def "test activating same span multiple times"() {
     when:
     AgentScope scope1 = scopeManager.activate(NoopAgentSpan.INSTANCE, ScopeSource.INSTRUMENTATION)
 
     then:
-    activatedCount.get() == 1
-    closedCount.get() == 0
+    eventCountingListener.events == [ACTIVATE]
 
     when:
     AgentScope scope2 = scopeManager.activate(NoopAgentSpan.INSTANCE, ScopeSource.INSTRUMENTATION)
 
     then: 'Activating the same span multiple times does not create a new scope'
-    activatedCount.get() == 1
-    closedCount.get() == 0
+    eventCountingListener.events == [ACTIVATE]
 
     when:
     scope2.close()
 
     then: 'Closing a scope once that has been activated multiple times does not close'
-    activatedCount.get() == 1
-    closedCount.get() == 0
+    eventCountingListener.events == [ACTIVATE]
 
     when:
     scope1.close()
 
     then:
-    activatedCount.get() == 1
-    closedCount.get() == 1
+    eventCountingListener.events == [ACTIVATE, CLOSE]
   }
 
   def "opening and closing multiple scopes"() {
-    setup:
-    def eventCountingLister = new EventCountingListener()
-    AtomicInteger activatedCount = eventCountingLister.activatedCount
-    AtomicInteger closedCount = eventCountingLister.closedCount
-
-    scopeManager.addScopeListener(eventCountingLister)
-
     when:
     AgentSpan span = tracer.buildSpan("foo").start()
     AgentScope continuableScope = tracer.activateSpan(span)
 
     then:
     continuableScope instanceof ContinuableScopeManager.ContinuableScope
-    activatedCount.get() == 1
-    closedCount.get() == 0
+    eventCountingListener.events == [ACTIVATE]
 
     when:
     AgentSpan childSpan = tracer.buildSpan("foo").start()
@@ -390,37 +375,24 @@ class ScopeManagerTest extends DDSpecification {
 
     then:
     childDDScope instanceof ContinuableScopeManager.ContinuableScope
-    activatedCount.get() == 2
-    closedCount.get() == 0
+    eventCountingListener.events == [ACTIVATE, ACTIVATE]
 
     when:
     childDDScope.close()
     childSpan.finish()
 
     then:
-    activatedCount.get() == 2
-    closedCount.get() == 1
+    eventCountingListener.events == [ACTIVATE, ACTIVATE, CLOSE, ACTIVATE]
 
     when:
     continuableScope.close()
     span.finish()
 
     then:
-    activatedCount.get() == 2
-    closedCount.get() == 2
+    eventCountingListener.events == [ACTIVATE, ACTIVATE, CLOSE, ACTIVATE, CLOSE]
   }
 
-  def "scope not closed when not on top"() {
-    // DQH: This test has been left unchanged from before the change to
-    // make sure all listener behavior is approximately the same.
-
-    setup:
-    def eventCountingLister = new EventCountingListener()
-    AtomicInteger activatedCount = eventCountingLister.activatedCount
-    AtomicInteger closedCount = eventCountingLister.closedCount
-
-    scopeManager.addScopeListener(eventCountingLister)
-
+  def "closing scope out of order - simple"() {
     when:
     AgentSpan firstSpan = tracer.buildSpan("foo").start()
     AgentScope firstScope = tracer.activateSpan(firstSpan)
@@ -432,8 +404,7 @@ class ScopeManagerTest extends DDSpecification {
     firstScope.close()
 
     then:
-    activatedCount.get() == 2
-    closedCount.get() == 0
+    eventCountingListener.events == [ACTIVATE, ACTIVATE]
     1 * statsDClient.incrementCounter("scope.close.error")
     0 * _
 
@@ -442,63 +413,123 @@ class ScopeManagerTest extends DDSpecification {
     secondScope.close()
 
     then:
-    activatedCount.get() == 2
-    closedCount.get() == 1
+    eventCountingListener.events == [ACTIVATE, ACTIVATE, CLOSE, CLOSE]
     0 * _
 
     when:
     firstScope.close()
 
     then:
-    activatedCount.get() == 2
-    closedCount.get() == 2
-    0 * _
+    eventCountingListener.events == [ACTIVATE, ACTIVATE, CLOSE, CLOSE]
+    1 * statsDClient.incrementCounter("scope.close.error")
   }
 
-  def "scope closed out of order 2"() {
+  def "closing scope out of order - complex"() {
+    // Events are checked twice in each case to ensure a call to
+    // tracer.activeScope() or tracer.activeSpan() doesn't change the count
+
     when:
     AgentSpan firstSpan = tracer.buildSpan("foo").start()
     AgentScope firstScope = tracer.activateSpan(firstSpan)
 
     then:
+    eventCountingListener.events == [ACTIVATE]
+
     tracer.activeSpan() == firstSpan
     tracer.activeScope() == firstScope
+    eventCountingListener.events == [ACTIVATE]
+    0 * _
 
     when:
     AgentSpan secondSpan = tracer.buildSpan("bar").start()
     AgentScope secondScope = tracer.activateSpan(secondSpan)
 
     then:
+    eventCountingListener.events == [ACTIVATE, ACTIVATE]
     tracer.activeSpan() == secondSpan
     tracer.activeScope() == secondScope
+    eventCountingListener.events == [ACTIVATE, ACTIVATE]
+    0 * _
 
     when:
     AgentSpan thirdSpan = tracer.buildSpan("quux").start()
     AgentScope thirdScope = tracer.activateSpan(thirdSpan)
 
     then:
+    eventCountingListener.events == [ACTIVATE, ACTIVATE, ACTIVATE]
     tracer.activeSpan() == thirdSpan
     tracer.activeScope() == thirdScope
+    eventCountingListener.events == [ACTIVATE, ACTIVATE, ACTIVATE]
+    0 * _
 
     when:
     secondScope.close()
 
     then:
+    eventCountingListener.events == [ACTIVATE, ACTIVATE, ACTIVATE]
     tracer.activeSpan() == thirdSpan
     tracer.activeScope() == thirdScope
+    eventCountingListener.events == [ACTIVATE, ACTIVATE, ACTIVATE]
+    1 * statsDClient.incrementCounter("scope.close.error")
+    0 * _
 
     when:
     thirdScope.close()
 
     then:
+    eventCountingListener.events == [ACTIVATE, ACTIVATE, ACTIVATE, CLOSE, CLOSE, ACTIVATE]
     tracer.activeSpan() == firstSpan
     tracer.activeScope() == firstScope
+
+    eventCountingListener.events == [ACTIVATE, ACTIVATE, ACTIVATE, CLOSE, CLOSE, ACTIVATE]
+    0 * _
 
     when:
     firstScope.close()
 
     then:
+    eventCountingListener.events == [ACTIVATE, ACTIVATE, ACTIVATE, CLOSE, CLOSE, ACTIVATE, CLOSE]
     tracer.activeScope() == null
+    eventCountingListener.events == [ACTIVATE, ACTIVATE, ACTIVATE, CLOSE, CLOSE, ACTIVATE, CLOSE]
+    0 * _
+  }
+
+  @Timeout(value = 60, unit = SECONDS)
+  def "Closing a continued scope out of order cancels the continuation"() {
+    when:
+    def span = tracer.buildSpan("test").start()
+    def scope = (ContinuableScopeManager.ContinuableScope) tracer.activateSpan(span)
+    scope.setAsyncPropagation(true)
+    def continuation = scope.capture()
+    scope.close()
+    span.finish()
+
+    then:
+    scopeManager.active() == null
+    spanFinished(span)
+    writer == []
+
+    when:
+    def continuedScope = continuation.activate()
+    AgentSpan secondSpan = tracer.buildSpan("test2").start()
+    AgentScope secondScope = (ContinuableScopeManager.ContinuableScope) tracer.activateSpan(secondSpan)
+
+    then:
+    scopeManager.active() == secondScope
+
+    when:
+    continuedScope.close()
+
+    then:
+    scopeManager.active() == secondScope
+    writer == []
+
+    when:
+    secondScope.close()
+    secondSpan.finish()
+
+    then:
+    writer == [[secondSpan, span]]
   }
 
   boolean spanFinished(AgentSpan span) {
@@ -507,15 +538,22 @@ class ScopeManagerTest extends DDSpecification {
 }
 
 class EventCountingListener implements ScopeListener {
-  AtomicInteger activatedCount = new AtomicInteger(0)
-  AtomicInteger closedCount = new AtomicInteger(0)
+  enum EVENT {
+    ACTIVATE, CLOSE
+  }
+
+  public final List<EVENT> events = new ArrayList<>()
 
   void afterScopeActivated() {
-    activatedCount.incrementAndGet()
+    synchronized (events) {
+      events.add(ACTIVATE)
+    }
   }
 
   @Override
   void afterScopeClosed() {
-    closedCount.incrementAndGet()
+    synchronized (events) {
+      events.add(CLOSE)
+    }
   }
 }

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/OpenTracingAPITest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/OpenTracingAPITest.groovy
@@ -316,7 +316,7 @@ class OpenTracingAPITest extends DDSpecification {
     secondScope.close()
 
     then:
-    1 * scopeListener.afterScopeClosed()
+    2 * scopeListener.afterScopeClosed()
     1 * traceInterceptor.onTraceComplete({ it.size() == 2 }) >> { args -> args[0] }
     0 * _
 
@@ -324,7 +324,8 @@ class OpenTracingAPITest extends DDSpecification {
     firstScope.close()
 
     then:
-    1 * scopeListener.afterScopeClosed()
+    1 * statsDClient.incrementCounter("scope.close.error")
+    1 * statsDClient.incrementCounter("scope.user.close.error")
     0 * _
   }
 
@@ -359,7 +360,7 @@ class OpenTracingAPITest extends DDSpecification {
     secondScope.close()
 
     then:
-    1 * scopeListener.afterScopeClosed()
+    2 * scopeListener.afterScopeClosed()
     1 * traceInterceptor.onTraceComplete({ it.size() == 2 }) >> { args -> args[0] }
     0 * _
 
@@ -367,7 +368,9 @@ class OpenTracingAPITest extends DDSpecification {
     firstScope.close()
 
     then:
-    1 * scopeListener.afterScopeClosed()
+    thrown(RuntimeException)
+    1 * statsDClient.incrementCounter("scope.close.error")
+    1 * statsDClient.incrementCounter("scope.user.close.error")
     0 * _
 
     cleanup:

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/OpenTracingAPITest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/OpenTracingAPITest.groovy
@@ -345,12 +345,16 @@ class OpenTracingAPITest extends DDSpecification {
     Span secondSpan = strictTracer.buildSpan("someOperation").start()
     Scope secondScope = strictTracer.activateSpan(secondSpan)
 
+    then:
+    2 * scopeListener.afterScopeActivated()
+    0 * _
+
+    when:
     firstSpan.finish()
     firstScope.close()
 
     then:
     thrown(RuntimeException)
-    2 * scopeListener.afterScopeActivated()
     1 * statsDClient.incrementCounter("scope.close.error")
     1 * statsDClient.incrementCounter("scope.user.close.error")
     0 * _


### PR DESCRIPTION
## Problem:
This fixes various problems with ScopeListener and ScopeManager

* `ScopeListener.afterScopeActivated()` was only called for new scopes and not previous scopes being activated (starting with 0.52.0)
* Scope depth was incorrectly tracked with out-of-order scope closing
* Traces with scopes meeting the following conditions were never reported:
    - a) resulting from Continuation activations
    - b) closed out of order
* `ScopeListener.afterScopeClosed()` wasn't called for Scopes closed out of order until the `ScopeStack` was modified again
* Some closed scopes were never GC'd until a call to `activeScope()` or similar (you could have an entire stack of closed scopes with the right `.close()` ordering)
* The internal array in scope stack was almost always resized to 0.  Leading to a lot of churn and array copying.
* Scopes with multiple activations didn't trigger `strict mode` when closed out of order

## Implementation:
The main change is that the stack is cleaned up when a scope is closed rather than on calls to `top()`.  This simplifies things greatly.

## Reviewing:
Please check the tests first.  Part of the issue before is we had tests that were wrong and we only tracked counts instead of ordering