### PR TITLE
Fix CONTRIBUTING link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ To use and configure Datadog Java APM, see [https://docs.datadoghq.com/tracing/l
 
 ## Contributing
 
-See [CONTRIBUTING](CONTRIBUTING.MD)
+See [CONTRIBUTING](CONTRIBUTING.md)


### PR DESCRIPTION
CONTRIBUTING file link in README should have lowercase md extension (it previously redirected to a 404 page)