### PR TITLE
More ContinuableScopeManager fixes

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
@@ -13,7 +13,7 @@ import datadog.trace.core.jfr.DDScopeEvent;
 import datadog.trace.core.jfr.DDScopeEventFactory;
 import java.lang.ref.ReferenceQueue;
 import java.lang.ref.WeakReference;
-import java.util.Arrays;
+import java.util.ArrayDeque;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -258,27 +258,17 @@ public class ContinuableScopeManager implements AgentScopeManager {
    * cleanup() is called to ensure the invariant
    */
   static final class ScopeStack {
-    private static final int MIN_STACK_LENGTH = 16;
-
-    ContinuableScope[] stack = new ContinuableScope[MIN_STACK_LENGTH];
-    // The position of the top-most scope guaranteed to be active
-    // 0 if empty
-    int topPos = 0;
+    private final ArrayDeque<ContinuableScope> stack = new ArrayDeque<>();
 
     /** top - accesses the top of the ScopeStack */
     final ContinuableScope top() {
-      return stack[topPos];
+      return stack.peek();
     }
 
     void cleanup() {
-      // localizing & clamping stackPos to enable ArrayBoundsCheck elimination
-      // only bothering to do this here because of the loop below
-      final ContinuableScope[] stack = this.stack;
-      topPos = Math.min(topPos, stack.length);
-
+      ContinuableScope curScope = stack.peek();
       boolean changedTop = false;
-      while (topPos > 0) {
-        final ContinuableScope curScope = stack[topPos];
+      while (curScope != null) {
         if (curScope.alive()) {
           if (changedTop) {
             curScope.afterActivated();
@@ -288,40 +278,31 @@ public class ContinuableScopeManager implements AgentScopeManager {
 
         // no longer alive -- trigger listener & null out
         curScope.onProperClose();
-        stack[topPos] = null;
-        --topPos;
+        stack.poll();
         changedTop = true;
-      }
-
-      if (topPos < stack.length / 4 && stack.length > MIN_STACK_LENGTH * 4) {
-        this.stack = Arrays.copyOf(stack, stack.length / 2);
+        curScope = stack.peek();
       }
     }
 
     /** Pushes a new scope unto the stack */
     final void push(final ContinuableScope scope) {
-      ++topPos;
-      if (topPos == stack.length) {
-        stack = Arrays.copyOf(stack, stack.length * 2);
-      }
-      stack[topPos] = scope;
+      stack.push(scope);
       scope.afterActivated();
     }
 
     /** Fast check to see if the expectedScope is on top the stack */
     final boolean checkTop(final ContinuableScope expectedScope) {
-      return expectedScope.equals(stack[topPos]);
+      return expectedScope.equals(stack.peek());
     }
 
     /** Returns the current stack depth */
     final int depth() {
-      return topPos;
+      return stack.size();
     }
 
     // DQH - regrettably needed for pre-existing tests
     final void clear() {
-      topPos = 0;
-      Arrays.fill(stack, null);
+      stack.clear();
     }
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
@@ -150,8 +150,6 @@ public class ContinuableScopeManager implements AgentScopeManager {
     public void close() {
       final ScopeStack scopeStack = scopeManager.scopeStack();
 
-      final boolean alive = decrementReferences();
-
       final boolean onTop = scopeStack.checkTop(this);
       if (!onTop) {
         if (log.isDebugEnabled()) {
@@ -170,15 +168,16 @@ public class ContinuableScopeManager implements AgentScopeManager {
         }
       }
 
+      final boolean alive = decrementReferences();
       if (alive) {
         return;
       }
 
+      scopeStack.cleanup();
+
       if (null != continuation) {
         continuation.cancelFromContinuedScopeClose();
       }
-
-      scopeStack.cleanup();
     }
 
     /*

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/OpenTracingAPITest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/OpenTracingAPITest.groovy
@@ -364,17 +364,16 @@ class OpenTracingAPITest extends DDSpecification {
     secondScope.close()
 
     then:
-    2 * scopeListener.afterScopeClosed()
+    1 * scopeListener.afterScopeClosed()
     1 * traceInterceptor.onTraceComplete({ it.size() == 2 }) >> { args -> args[0] }
+    1 * scopeListener.afterScopeActivated()
     0 * _
 
     when:
     firstScope.close()
 
     then:
-    thrown(RuntimeException)
-    1 * statsDClient.incrementCounter("scope.close.error")
-    1 * statsDClient.incrementCounter("scope.user.close.error")
+    1 * scopeListener.afterScopeClosed()
     0 * _
 
     cleanup:


### PR DESCRIPTION
Followup to #1889 :
* Replaced `Array` with `ArrayDeque` to simplify code
* continuation.cancel() could throw (via a TraceInterceptor) leaving the stack in a bad state
* Closing a multi-activated scope out of order with strict mode enabled could leave the stack in a bad state 