### PR TITLE
small efficiencies in inter-thread context propagation

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/CallableWrapper.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/CallableWrapper.java
@@ -22,11 +22,13 @@ public final class CallableWrapper implements Callable {
   }
 
   public static Callable<?> wrapIfNeeded(final Callable<?> task) {
-    // We wrap only lambdas' anonymous classes and if given object has not already been wrapped.
-    // Anonymous classes have '/' in class name which is not allowed in 'normal' classes.
-    if (task.getClass().getName().contains("/") && (!(task instanceof CallableWrapper))) {
-      log.debug("Wrapping callable task {}", task);
-      return new CallableWrapper(task);
+    if (!(task instanceof CallableWrapper)) {
+      // We wrap only lambdas' anonymous classes and if given object has not already been wrapped.
+      // Anonymous classes have '/' in class name which is not allowed in 'normal' classes.
+      final String className = task.getClass().getName();
+      if (className.indexOf('/', className.lastIndexOf('.')) > 0) {
+        return new CallableWrapper(task);
+      }
     }
     return task;
   }

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/ExecutorInstrumentationUtils.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/ExecutorInstrumentationUtils.java
@@ -52,13 +52,11 @@ public class ExecutorInstrumentationUtils {
 
     final State state = contextStore.putIfAbsent(task, State.FACTORY);
 
-    final TraceScope.Continuation continuation = scope.capture();
-    if (state.setContinuation(continuation)) {
-      if (log.isDebugEnabled()) {
-        log.debug("created continuation {} from scope {}, state: {}", continuation, scope, state);
-      }
-    } else {
-      continuation.cancel();
+    if (!state.captureAndSetContinuation(scope)) {
+      log.debug(
+          "continuation was already set for {} in scope {}, no continuation captured.",
+          task,
+          scope);
     }
 
     return state;

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/RunnableWrapper.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/RunnableWrapper.java
@@ -9,6 +9,7 @@ import lombok.extern.slf4j.Slf4j;
  */
 @Slf4j
 public final class RunnableWrapper implements Runnable {
+
   private final Runnable runnable;
 
   public RunnableWrapper(final Runnable runnable) {
@@ -21,11 +22,13 @@ public final class RunnableWrapper implements Runnable {
   }
 
   public static Runnable wrapIfNeeded(final Runnable task) {
-    // We wrap only lambdas' anonymous classes and if given object has not already been wrapped.
-    // Anonymous classes have '/' in class name which is not allowed in 'normal' classes.
-    if (task.getClass().getName().contains("/") && (!(task instanceof RunnableWrapper))) {
-      log.debug("Wrapping runnable task {}", task);
-      return new RunnableWrapper(task);
+    if (!(task instanceof RunnableWrapper)) {
+      // We wrap only lambdas' anonymous classes and if given object has not already been wrapped.
+      // Anonymous classes have '/' in class name which is not allowed in 'normal' classes.
+      final String className = task.getClass().getName();
+      if (className.indexOf('/', className.lastIndexOf('.')) > 0) {
+        return new RunnableWrapper(task);
+      }
     }
     return task;
   }

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/JavaExecutorInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/JavaExecutorInstrumentation.java
@@ -82,14 +82,16 @@ public final class JavaExecutorInstrumentation extends AbstractExecutorInstrumen
         @Advice.This final Executor executor,
         @Advice.Argument(value = 0, readOnly = false) Runnable task) {
       final TraceScope scope = activeScope();
-      final Runnable newTask = RunnableWrapper.wrapIfNeeded(task);
-      // It is important to check potentially wrapped task if we can instrument task in this
-      // executor. Some executors do not support wrapped tasks.
-      if (ExecutorInstrumentationUtils.shouldAttachStateToTask(newTask, executor)) {
-        task = newTask;
-        final ContextStore<Runnable, State> contextStore =
-            InstrumentationContext.get(Runnable.class, State.class);
-        return ExecutorInstrumentationUtils.setupState(contextStore, newTask, scope);
+      if (null != scope) {
+        final Runnable newTask = RunnableWrapper.wrapIfNeeded(task);
+        // It is important to check potentially wrapped task if we can instrument task in this
+        // executor. Some executors do not support wrapped tasks.
+        if (ExecutorInstrumentationUtils.shouldAttachStateToTask(newTask, executor)) {
+          task = newTask;
+          final ContextStore<Runnable, State> contextStore =
+              InstrumentationContext.get(Runnable.class, State.class);
+          return ExecutorInstrumentationUtils.setupState(contextStore, newTask, scope);
+        }
       }
       return null;
     }
@@ -134,14 +136,16 @@ public final class JavaExecutorInstrumentation extends AbstractExecutorInstrumen
         @Advice.This final Executor executor,
         @Advice.Argument(value = 0, readOnly = false) Runnable task) {
       final TraceScope scope = activeScope();
-      final Runnable newTask = RunnableWrapper.wrapIfNeeded(task);
-      // It is important to check potentially wrapped task if we can instrument task in this
-      // executor. Some executors do not support wrapped tasks.
-      if (ExecutorInstrumentationUtils.shouldAttachStateToTask(newTask, executor)) {
-        task = newTask;
-        final ContextStore<Runnable, State> contextStore =
-            InstrumentationContext.get(Runnable.class, State.class);
-        return ExecutorInstrumentationUtils.setupState(contextStore, newTask, scope);
+      if (null != scope) {
+        final Runnable newTask = RunnableWrapper.wrapIfNeeded(task);
+        // It is important to check potentially wrapped task if we can instrument task in this
+        // executor. Some executors do not support wrapped tasks.
+        if (ExecutorInstrumentationUtils.shouldAttachStateToTask(newTask, executor)) {
+          task = newTask;
+          final ContextStore<Runnable, State> contextStore =
+              InstrumentationContext.get(Runnable.class, State.class);
+          return ExecutorInstrumentationUtils.setupState(contextStore, newTask, scope);
+        }
       }
       return null;
     }


### PR DESCRIPTION
This makes some small improvements to executor instrumentations

* Avoids creating continuations twice (need to win the CAS to create the continuation)
* Efficiency improvements when checking whether we need to wrap runnables and callables
* Avoid attempting to propagate context unless there is an active scope

The first two are cherry picked from #1883, which I don't think we can make work without more ambitious rework.