### PR TITLE
 Sort traces within ListWriter by start time before asserting

### DIFF
--- a/buildSrc/src/test/groovy/RangeQueryTest.groovy
+++ b/buildSrc/src/test/groovy/RangeQueryTest.groovy
@@ -18,7 +18,7 @@ class RangeQueryTest extends Specification {
     final VersionRangeRequest rangeRequest = new VersionRangeRequest()
     rangeRequest.setRepositories(MuzzlePlugin.MUZZLE_REPOS)
     rangeRequest.setArtifact(directiveArtifact)
-    
+
     // This call makes an actual network request, which may fail if network access is limited.
     final VersionRangeResult rangeResult = system.resolveVersionRange(session, rangeRequest)
 

--- a/dd-java-agent/agent-logging/src/test/groovy/datadog/trace/logging/simplelogger/SLCompatSettingsTest.groovy
+++ b/dd-java-agent/agent-logging/src/test/groovy/datadog/trace/logging/simplelogger/SLCompatSettingsTest.groovy
@@ -47,13 +47,13 @@ class SLCompatSettingsTest extends Specification {
     SLCompatSettings.getBoolean(props, fallbackProps, name, dBool) == expected
 
     where:
-    pStr   | fStr    | dBool | expected
-    null   | null    | true  | true
-    "true" | null    | false | true
-    "true" | "foo"   | false | true
-    null   | "true"  | false | true
-    "foo"  | "true"  | true  | false // any String not matching "true" is false
-    null   | "foo"   | true  | false // any String not matching "true" is false
+    pStr   | fStr   | dBool | expected
+    null   | null   | true  | true
+    "true" | null   | false | true
+    "true" | "foo"  | false | true
+    null   | "true" | false | true
+    "foo"  | "true" | true  | false // any String not matching "true" is false
+    null   | "foo"  | true  | false // any String not matching "true" is false
   }
 
   def "test defaults"() {
@@ -140,33 +140,33 @@ class SLCompatSettingsTest extends Specification {
     def settings = new SLCompatSettings(props)
 
     then:
-    names.collect {settings.logNameForName(it) } == expected
+    names.collect { settings.logNameForName(it) } == expected
 
     where:
-    showShort | show | expected
-    false | false | ["", "", ""]
-    false | true  | ["foo", "foo.bar", "foo.bar.baz"]
-    true  | true  | ["foo", "bar", "baz"]
-    true  | false | ["foo", "bar", "baz"]
+    showShort | show  | expected
+    false     | false | ["", "", ""]
+    false     | true  | ["foo", "foo.bar", "foo.bar.baz"]
+    true      | true  | ["foo", "bar", "baz"]
+    true      | false | ["foo", "bar", "baz"]
   }
 
   def "test logLevelForName"() {
     when:
     def names = ["foo", "foo.bar", "foo.bar.baz"]
     Properties props = new Properties()
-    logProperties.each {props.setProperty(SLCompatSettings.Keys.LOG_KEY_PREFIX + it.key, it.value) }
+    logProperties.each { props.setProperty(SLCompatSettings.Keys.LOG_KEY_PREFIX + it.key, it.value) }
     def settings = new SLCompatSettings(props)
 
     then:
-    names.collect {settings.logLevelForName(it) } == expected
+    names.collect { settings.logLevelForName(it) } == expected
 
     where:
-    logProperties | expected
-    [:] | [LogLevel.INFO, LogLevel.INFO, LogLevel.INFO]
-    ["foo":"debug"] | [LogLevel.DEBUG, LogLevel.DEBUG, LogLevel.DEBUG]
-    ["foo.bar":"debug"] | [LogLevel.INFO, LogLevel.DEBUG, LogLevel.DEBUG]
-    ["foo.bar":"debug", "foo.bar.baz":"warn"] | [LogLevel.INFO, LogLevel.DEBUG, LogLevel.WARN]
-    ["bar":"trace", "foo.bar.baz":"warn"] | [LogLevel.INFO, LogLevel.INFO, LogLevel.WARN]
+    logProperties                               | expected
+    [:]                                         | [LogLevel.INFO, LogLevel.INFO, LogLevel.INFO]
+    ["foo": "debug"]                            | [LogLevel.DEBUG, LogLevel.DEBUG, LogLevel.DEBUG]
+    ["foo.bar": "debug"]                        | [LogLevel.INFO, LogLevel.DEBUG, LogLevel.DEBUG]
+    ["foo.bar": "debug", "foo.bar.baz": "warn"] | [LogLevel.INFO, LogLevel.DEBUG, LogLevel.WARN]
+    ["bar": "trace", "foo.bar.baz": "warn"]     | [LogLevel.INFO, LogLevel.INFO, LogLevel.WARN]
   }
 
   def "test DTFormatter"() {

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/WeakCacheTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/WeakCacheTest.groovy
@@ -4,7 +4,7 @@ import spock.lang.Specification
 
 import java.util.concurrent.Callable
 
-class WeakCacheTest  extends Specification  {
+class WeakCacheTest extends Specification {
   def supplier = new CounterSupplier()
 
   def weakCache = AgentTooling.newWeakCache()
@@ -46,9 +46,9 @@ class WeakCacheTest  extends Specification  {
 
   def "max size check"() {
     when:
-    def sizeBefore =  weakCacheFor1elem.cache.size()
+    def sizeBefore = weakCacheFor1elem.cache.size()
     def valBefore = weakCacheFor1elem.getIfPresent("key1")
-    def sizeAfter =  weakCacheFor1elem.cache.size()
+    def sizeAfter = weakCacheFor1elem.cache.size()
     def valAfterGet = weakCacheFor1elem.getIfPresentOrCompute("key1", supplier)
     def sizeAfterCompute = weakCacheFor1elem.cache.size()
     weakCacheFor1elem.put("key1", 42)
@@ -70,6 +70,7 @@ class WeakCacheTest  extends Specification  {
 
   class CounterSupplier implements Callable<Integer> {
     def counter = 0
+
     @Override
     Integer call() {
       counter = counter + 1

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/bytebuddy/matcher/ImplementsInterfaceMatcherTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/bytebuddy/matcher/ImplementsInterfaceMatcherTest.groovy
@@ -58,7 +58,7 @@ class ImplementsInterfaceMatcherTest extends DDSpecification {
     1 * type.asGenericType() >> typeGeneric
     1 * typeGeneric.asErasure() >> { throw new Exception("asErasure exception") }
     1 * typeGeneric.getTypeName() >> "typeGeneric-name"
-    1 * type.getInterfaces() >>  { throw new Exception("getInterfaces exception") }
+    1 * type.getInterfaces() >> { throw new Exception("getInterfaces exception") }
     1 * type.getSuperClass() >> { throw new Exception("getSuperClass exception") }
     2 * type.getTypeName() >> "type-name"
     0 * _

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/bytebuddy/matcher/NameMatchersTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/bytebuddy/matcher/NameMatchersTest.groovy
@@ -18,10 +18,10 @@ class NameMatchersTest extends DDSpecification {
     result == expected
 
     where:
-    name         | expected
-    "foo"        | true
-    "bar"        | true
-    "missing"    | false
+    name      | expected
+    "foo"     | true
+    "bar"     | true
+    "missing" | false
   }
 
 
@@ -38,9 +38,9 @@ class NameMatchersTest extends DDSpecification {
     result == expected
 
     where:
-    name         | expected
-    "foo"        | false
-    "bar"        | false
-    "missing"    | true
+    name      | expected
+    "foo"     | false
+    "bar"     | false
+    "missing" | true
   }
 }

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/bytebuddy/matcher/SafeHasSuperTypeMatcherTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/bytebuddy/matcher/SafeHasSuperTypeMatcherTest.groovy
@@ -57,7 +57,7 @@ class SafeHasSuperTypeMatcherTest extends DDSpecification {
     1 * type.asGenericType() >> typeGeneric
     1 * typeGeneric.asErasure() >> { throw new Exception("asErasure exception") }
     1 * typeGeneric.getTypeName() >> "typeGeneric-name"
-    1 * type.getInterfaces() >>  { throw new Exception("getInterfaces exception") }
+    1 * type.getInterfaces() >> { throw new Exception("getInterfaces exception") }
     1 * type.getSuperClass() >> { throw new Exception("getSuperClass exception") }
     2 * type.getTypeName() >> "type-name"
     0 * _

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/lagomTest/groovy/LagomTest.groovy
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/lagomTest/groovy/LagomTest.groovy
@@ -57,8 +57,8 @@ class LagomTest extends AgentTestRunner {
 
     expect:
     assertTraces(1) {
-      trace(0, 2) {
-        span(0) {
+      trace(2) {
+        span {
           operationName "akka-http.request"
           resourceName "GET /echo"
           spanType DDSpanTypes.HTTP_SERVER
@@ -72,7 +72,7 @@ class LagomTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           childOf span(0)
           operationName 'trace.annotation'
           resourceName 'EchoServiceImpl.tracedMethod'
@@ -99,8 +99,8 @@ class LagomTest extends AgentTestRunner {
 
     expect:
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           operationName "akka-http.request"
           resourceName "GET /error"
           spanType DDSpanTypes.HTTP_SERVER

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpClientInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpClientInstrumentationTest.groovy
@@ -72,8 +72,8 @@ class AkkaHttpClientInstrumentationTest extends HttpClientTest {
     then:
     def exception = thrown NullPointerException
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           parent()
           operationName "akka-http.client.request"
           resourceName "akka-http.client.request"

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpServerInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpServerInstrumentationTest.groovy
@@ -37,8 +37,8 @@ abstract class AkkaHttpServerInstrumentationTest extends HttpServerTest<Object> 
 //    AkkaHttpTestWebServer.stop()
 //  }
 
-  void serverSpan(TraceAssert trace, int index, BigInteger traceID = null, BigInteger parentID = null, String method = "GET", ServerEndpoint endpoint = SUCCESS) {
-    trace.span(index) {
+  void serverSpan(TraceAssert trace, BigInteger traceID = null, BigInteger parentID = null, String method = "GET", ServerEndpoint endpoint = SUCCESS) {
+    trace.span {
       serviceName expectedServiceName()
       operationName expectedOperationName()
       resourceName endpoint.status == 404 ? "404" : "$method ${endpoint.resolve(address).path}"

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test/groovy/AWS1ClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test/groovy/AWS1ClientTest.groovy
@@ -132,8 +132,8 @@ class AWS1ClientTest extends AgentTestRunner {
     client.requestHandler2s.get(0).getClass().getSimpleName() == "TracingRequestHandler"
 
     assertTraces(1) {
-      trace(0, 2) {
-        span(0) {
+      trace(2) {
+        span {
           serviceName "java-aws-sdk"
           operationName "aws.http"
           resourceName "$service.$operation"
@@ -158,7 +158,7 @@ class AWS1ClientTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           operationName "http.request"
           resourceName "$method $path"
           spanType DDSpanTypes.HTTP_CLIENT
@@ -229,8 +229,8 @@ class AWS1ClientTest extends AgentTestRunner {
     thrown SdkClientException
 
     assertTraces(1) {
-      trace(0, 2) {
-        span(0) {
+      trace(2) {
+        span {
           serviceName "java-aws-sdk"
           operationName "aws.http"
           resourceName "$service.$operation"
@@ -255,7 +255,7 @@ class AWS1ClientTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           operationName "http.request"
           resourceName "$method /$url"
           spanType DDSpanTypes.HTTP_CLIENT
@@ -297,8 +297,8 @@ class AWS1ClientTest extends AgentTestRunner {
     thrown RuntimeException
 
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "java-aws-sdk"
           operationName "aws.http"
           resourceName "S3.HeadBucket"
@@ -344,8 +344,8 @@ class AWS1ClientTest extends AgentTestRunner {
     thrown AmazonClientException
 
     assertTraces(1) {
-      trace(0, 5) {
-        span(0) {
+      trace(5) {
+        span {
           serviceName "java-aws-sdk"
           operationName "aws.http"
           resourceName "S3.GetObject"
@@ -373,7 +373,7 @@ class AWS1ClientTest extends AgentTestRunner {
           }
         }
         (1..4).each {
-          span(it) {
+          span {
             operationName "http.request"
             resourceName "GET /someBucket/someKey"
             spanType DDSpanTypes.HTTP_CLIENT

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test_before_1_11_106/groovy/AWS0ClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test_before_1_11_106/groovy/AWS0ClientTest.groovy
@@ -95,8 +95,8 @@ class AWS0ClientTest extends AgentTestRunner {
     client.requestHandler2s.get(0).getClass().getSimpleName() == "TracingRequestHandler"
 
     assertTraces(1) {
-      trace(0, 2) {
-        span(0) {
+      trace(2) {
+        span {
           serviceName "java-aws-sdk"
           operationName "aws.http"
           resourceName "$service.$operation"
@@ -121,7 +121,7 @@ class AWS0ClientTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           operationName "http.request"
           resourceName "$method $path"
           spanType DDSpanTypes.HTTP_CLIENT
@@ -174,8 +174,8 @@ class AWS0ClientTest extends AgentTestRunner {
     thrown AmazonClientException
 
     assertTraces(1) {
-      trace(0, 2) {
-        span(0) {
+      trace(2) {
+        span {
           serviceName "java-aws-sdk"
           operationName "aws.http"
           resourceName "$service.$operation"
@@ -200,7 +200,7 @@ class AWS0ClientTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           operationName "http.request"
           resourceName "$method /$url"
           spanType DDSpanTypes.HTTP_CLIENT
@@ -242,8 +242,8 @@ class AWS0ClientTest extends AgentTestRunner {
     thrown RuntimeException
 
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "java-aws-sdk"
           operationName "aws.http"
           resourceName "S3.GetObject"
@@ -290,8 +290,8 @@ class AWS0ClientTest extends AgentTestRunner {
     thrown AmazonClientException
 
     assertTraces(1) {
-      trace(0, 5) {
-        span(0) {
+      trace(5) {
+        span {
           serviceName "java-aws-sdk"
           operationName "aws.http"
           resourceName "S3.GetObject"
@@ -315,7 +315,7 @@ class AWS0ClientTest extends AgentTestRunner {
           }
         }
         (1..4).each {
-          span(it) {
+          span {
             operationName "http.request"
             resourceName "GET /someBucket/someKey"
             spanType DDSpanTypes.HTTP_CLIENT

--- a/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/test/groovy/Aws2ClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/test/groovy/Aws2ClientTest.groovy
@@ -72,8 +72,8 @@ class Aws2ClientTest extends AgentTestRunner {
     response.class.simpleName.startsWith(operation) || response instanceof ResponseInputStream
 
     assertTraces(1) {
-      trace(0, 2) {
-        span(0) {
+      trace(2) {
+        span {
           serviceName "java-aws-sdk"
           operationName "aws.http"
           resourceName "$service.$operation"
@@ -106,7 +106,7 @@ class Aws2ClientTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           operationName "http.request"
           resourceName "$method $path"
           spanType DDSpanTypes.HTTP_CLIENT
@@ -181,16 +181,9 @@ class Aws2ClientTest extends AgentTestRunner {
     expect:
     response != null
 
-    // Order is not guaranteed in these traces, so reorder them if needed to put aws trace first
-    if (TEST_WRITER[0][0].serviceName != "java-aws-sdk") {
-      def tmp = TEST_WRITER[0]
-      TEST_WRITER[0] = TEST_WRITER[1]
-      TEST_WRITER[1] = tmp
-    }
-
     assertTraces(2) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "java-aws-sdk"
           operationName "aws.http"
           resourceName "$service.$operation"
@@ -225,8 +218,8 @@ class Aws2ClientTest extends AgentTestRunner {
         }
       }
       // TODO: this should be part of the same trace but netty instrumentation doesn't cooperate
-      trace(1, 1) {
-        span(0) {
+      trace(1) {
+        span {
           operationName "netty.client.request"
           resourceName "$method $path"
           spanType DDSpanTypes.HTTP_CLIENT
@@ -310,8 +303,8 @@ class Aws2ClientTest extends AgentTestRunner {
     thrown SdkClientException
 
     assertTraces(1) {
-      trace(0, 5) {
-        span(0) {
+      trace(5) {
+        span {
           serviceName "java-aws-sdk"
           operationName "aws.http"
           resourceName "S3.GetObject"
@@ -334,7 +327,7 @@ class Aws2ClientTest extends AgentTestRunner {
           }
         }
         (1..4).each {
-          span(it) {
+          span {
             operationName "http.request"
             resourceName "GET /somebucket/somekey"
             spanType DDSpanTypes.HTTP_CLIENT

--- a/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/CouchbaseAsyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/CouchbaseAsyncClientTest.groovy
@@ -30,10 +30,10 @@ class CouchbaseAsyncClientTest extends AbstractCouchbaseTest {
 
     then:
     assert hasBucket.get()
-    sortAndAssertTraces(1) {
-      trace(0, 2) {
-        assertCouchbaseCall(it, 0, "Cluster.openBucket", null)
-        assertCouchbaseCall(it, 1, "ClusterManager.hasBucket", null, span(0))
+    assertTraces(1) {
+      trace(2) {
+        assertCouchbaseCall(it, "ClusterManager.hasBucket", null, span(1))
+        assertCouchbaseCall(it, "Cluster.openBucket", null)
       }
     }
 
@@ -68,12 +68,11 @@ class CouchbaseAsyncClientTest extends AbstractCouchbaseTest {
     then:
     inserted.get().content().getString("hello") == "world"
 
-    sortAndAssertTraces(1) {
-      trace(0, 3) {
-        basicSpan(it, 0, "someTrace")
-
-        assertCouchbaseCall(it, 2, "Cluster.openBucket", null, span(0))
-        assertCouchbaseCall(it, 1, "Bucket.upsert", bucketSettings.name(), span(2))
+    assertTraces(1) {
+      trace(3) {
+        basicSpan(it, "someTrace")
+        assertCouchbaseCall(it, "Bucket.upsert", bucketSettings.name(), span(2))
+        assertCouchbaseCall(it, "Cluster.openBucket", null, span(0))
       }
     }
 
@@ -115,13 +114,13 @@ class CouchbaseAsyncClientTest extends AbstractCouchbaseTest {
     found.get() == inserted.get()
     found.get().content().getString("hello") == "world"
 
-    sortAndAssertTraces(1) {
-      trace(0, 4) {
-        basicSpan(it, 0, "someTrace")
+    assertTraces(1) {
+      trace(4) {
+        basicSpan(it, "someTrace")
 
-        assertCouchbaseCall(it, 3, "Cluster.openBucket", null, span(0))
-        assertCouchbaseCall(it, 2, "Bucket.upsert", bucketSettings.name(), span(3))
-        assertCouchbaseCall(it, 1, "Bucket.get", bucketSettings.name(), span(2))
+        assertCouchbaseCall(it, "Bucket.get", bucketSettings.name(), span(2))
+        assertCouchbaseCall(it, "Bucket.upsert", bucketSettings.name(), span(3))
+        assertCouchbaseCall(it, "Cluster.openBucket", null, span(0))
       }
     }
 
@@ -162,12 +161,12 @@ class CouchbaseAsyncClientTest extends AbstractCouchbaseTest {
     then:
     queryResult.get().get("row") == "value"
 
-    sortAndAssertTraces(1) {
-      trace(0, 3) {
-        basicSpan(it, 0, "someTrace")
+    assertTraces(1) {
+      trace(3) {
+        basicSpan(it, "someTrace")
 
-        assertCouchbaseCall(it, 2, "Cluster.openBucket", null, span(0))
-        assertCouchbaseCall(it, 1, "Bucket.query", bucketCouchbase.name(), span(2))
+        assertCouchbaseCall(it, "Bucket.query", bucketCouchbase.name(), span(2))
+        assertCouchbaseCall(it, "Cluster.openBucket", null, span(0))
       }
     }
 

--- a/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/CouchbaseAsyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/CouchbaseAsyncClientTest.groovy
@@ -9,8 +9,6 @@ import spock.lang.Unroll
 import spock.util.concurrent.BlockingVariable
 import util.AbstractCouchbaseTest
 
-import java.util.concurrent.TimeUnit
-
 import static datadog.trace.agent.test.utils.TraceUtils.basicSpan
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 
@@ -38,8 +36,7 @@ class CouchbaseAsyncClientTest extends AbstractCouchbaseTest {
     }
 
     cleanup:
-    cluster?.disconnect()?.timeout(TIMEOUT, TimeUnit.SECONDS)?.toBlocking()?.single()
-    environment.shutdown()
+    cleanupCluster(cluster, environment)
 
     where:
     bucketSettings << [bucketCouchbase, bucketMemcache]
@@ -77,8 +74,7 @@ class CouchbaseAsyncClientTest extends AbstractCouchbaseTest {
     }
 
     cleanup:
-    cluster?.disconnect()?.timeout(TIMEOUT, TimeUnit.SECONDS)?.toBlocking()?.single()
-    environment.shutdown()
+    cleanupCluster(cluster, environment)
 
     where:
     bucketSettings << [bucketCouchbase, bucketMemcache]
@@ -125,8 +121,7 @@ class CouchbaseAsyncClientTest extends AbstractCouchbaseTest {
     }
 
     cleanup:
-    cluster?.disconnect()?.timeout(TIMEOUT, TimeUnit.SECONDS)?.toBlocking()?.single()
-    environment.shutdown()
+    cleanupCluster(cluster, environment)
 
     where:
     bucketSettings << [bucketCouchbase, bucketMemcache]
@@ -171,7 +166,6 @@ class CouchbaseAsyncClientTest extends AbstractCouchbaseTest {
     }
 
     cleanup:
-    cluster?.disconnect()?.timeout(TIMEOUT, TimeUnit.SECONDS)?.toBlocking()?.single()
-    environment.shutdown()
+    cleanupCluster(cluster, environment)
   }
 }

--- a/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/CouchbaseClientTest.groovy
+++ b/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/CouchbaseClientTest.groovy
@@ -28,8 +28,7 @@ class CouchbaseClientTest extends AbstractCouchbaseTest {
     }
 
     cleanup:
-    cluster?.disconnect()
-    environment.shutdown()
+    cleanupCluster(cluster, environment)
 
     where:
     bucketSettings << [bucketCouchbase, bucketMemcache]
@@ -74,8 +73,7 @@ class CouchbaseClientTest extends AbstractCouchbaseTest {
     }
 
     cleanup:
-    cluster?.disconnect()
-    environment.shutdown()
+    cleanupCluster(cluster, environment)
 
     where:
     bucketSettings << [bucketCouchbase, bucketMemcache]
@@ -113,7 +111,6 @@ class CouchbaseClientTest extends AbstractCouchbaseTest {
     }
 
     cleanup:
-    cluster?.disconnect()
-    environment.shutdown()
+    cleanupCluster(cluster, environment)
   }
 }

--- a/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/CouchbaseClientTest.groovy
+++ b/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/CouchbaseClientTest.groovy
@@ -21,9 +21,9 @@ class CouchbaseClientTest extends AbstractCouchbaseTest {
 
     then:
     assert hasBucket
-    sortAndAssertTraces(1) {
-      trace(0, 1) {
-        assertCouchbaseCall(it, 0, "ClusterManager.hasBucket")
+    assertTraces(1) {
+      trace(1) {
+        assertCouchbaseCall(it, "ClusterManager.hasBucket")
       }
     }
 
@@ -62,14 +62,14 @@ class CouchbaseClientTest extends AbstractCouchbaseTest {
     found == inserted
     found.content().getString("hello") == "world"
 
-    sortAndAssertTraces(2) {
-      trace(0, 1) {
-        assertCouchbaseCall(it, 0, "Cluster.openBucket")
+    assertTraces(2) {
+      trace(1) {
+        assertCouchbaseCall(it, "Cluster.openBucket")
       }
-      trace(1, 3) {
-        basicSpan(it, 0, "someTrace")
-        assertCouchbaseCall(it, 2, "Bucket.upsert", bucketSettings.name(), span(0))
-        assertCouchbaseCall(it, 1, "Bucket.get", bucketSettings.name(), span(0))
+      trace(3) {
+        basicSpan(it, "someTrace")
+        assertCouchbaseCall(it, "Bucket.get", bucketSettings.name(), span(0))
+        assertCouchbaseCall(it, "Bucket.upsert", bucketSettings.name(), span(0))
       }
     }
 
@@ -103,12 +103,12 @@ class CouchbaseClientTest extends AbstractCouchbaseTest {
     result.first().value().get("row") == "value"
 
     and:
-    sortAndAssertTraces(2) {
-      trace(0, 1) {
-        assertCouchbaseCall(it, 0, "Cluster.openBucket")
+    assertTraces(2) {
+      trace(1) {
+        assertCouchbaseCall(it, "Cluster.openBucket")
       }
-      trace(1, 1) {
-        assertCouchbaseCall(it, 0, "Bucket.query", bucketCouchbase.name())
+      trace(1) {
+        assertCouchbaseCall(it, "Bucket.query", bucketCouchbase.name())
       }
     }
 

--- a/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/CouchbaseClientTest.groovy
+++ b/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/CouchbaseClientTest.groovy
@@ -53,8 +53,6 @@ class CouchbaseClientTest extends AbstractCouchbaseTest {
     runUnderTrace("someTrace") {
       inserted = bkt.upsert(JsonDocument.create("helloworld", content))
       found = bkt.get("helloworld")
-
-      blockUntilChildSpansFinished(2)
     }
 
     then:
@@ -62,13 +60,14 @@ class CouchbaseClientTest extends AbstractCouchbaseTest {
     found.content().getString("hello") == "world"
 
     assertTraces(2) {
+      sortSpansByStart()
       trace(1) {
         assertCouchbaseCall(it, "Cluster.openBucket")
       }
       trace(3) {
         basicSpan(it, "someTrace")
-        assertCouchbaseCall(it, "Bucket.get", bucketSettings.name(), span(0))
         assertCouchbaseCall(it, "Bucket.upsert", bucketSettings.name(), span(0))
+        assertCouchbaseCall(it, "Bucket.get", bucketSettings.name(), span(0))
       }
     }
 

--- a/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/springdata/CouchbaseSpringRepositoryTest.groovy
+++ b/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/springdata/CouchbaseSpringRepositoryTest.groovy
@@ -116,17 +116,16 @@ class CouchbaseSpringRepositoryTest extends AbstractCouchbaseTest {
     runUnderTrace("someTrace") {
       repo.save(doc)
       result = FIND(repo, "1")
-
-      blockUntilChildSpansFinished(2)
     }
 
     then: // RETRIEVE
     result == doc
     assertTraces(1) {
+      sortSpansByStart()
       trace(3) {
         basicSpan(it, "someTrace")
-        assertCouchbaseCall(it, "Bucket.get", bucketCouchbase.name(), span(0))
         assertCouchbaseCall(it, "Bucket.upsert", bucketCouchbase.name(), span(0))
+        assertCouchbaseCall(it, "Bucket.get", bucketCouchbase.name(), span(0))
       }
     }
   }
@@ -140,13 +139,12 @@ class CouchbaseSpringRepositoryTest extends AbstractCouchbaseTest {
       repo.save(doc)
       doc.data = "other data"
       repo.save(doc)
-
-      blockUntilChildSpansFinished(2)
     }
 
 
     then:
     assertTraces(1) {
+      sortSpansByStart()
       trace(3) {
         basicSpan(it, "someTrace")
         assertCouchbaseCall(it, "Bucket.upsert", bucketCouchbase.name(), span(0))
@@ -165,18 +163,17 @@ class CouchbaseSpringRepositoryTest extends AbstractCouchbaseTest {
       repo.save(doc)
       repo.delete("1")
       result = repo.findAll().iterator().hasNext()
-
-      blockUntilChildSpansFinished(3)
     }
 
     then:
     assert !result
     assertTraces(1) {
+      sortSpansByStart()
       trace(4) {
         basicSpan(it, "someTrace")
-        assertCouchbaseCall(it, "Bucket.query", bucketCouchbase.name(), span(0))
-        assertCouchbaseCall(it, "Bucket.remove", bucketCouchbase.name(), span(0))
         assertCouchbaseCall(it, "Bucket.upsert", bucketCouchbase.name(), span(0))
+        assertCouchbaseCall(it, "Bucket.remove", bucketCouchbase.name(), span(0))
+        assertCouchbaseCall(it, "Bucket.query", bucketCouchbase.name(), span(0))
       }
     }
   }

--- a/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/springdata/CouchbaseSpringRepositoryTest.groovy
+++ b/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/springdata/CouchbaseSpringRepositoryTest.groovy
@@ -76,8 +76,8 @@ class CouchbaseSpringRepositoryTest extends AbstractCouchbaseTest {
 
     and:
     assertTraces(1) {
-      trace(0, 1) {
-        assertCouchbaseCall(it, 0, "Bucket.query", bucketCouchbase.name())
+      trace(1) {
+        assertCouchbaseCall(it, "Bucket.query", bucketCouchbase.name())
       }
     }
   }
@@ -92,8 +92,8 @@ class CouchbaseSpringRepositoryTest extends AbstractCouchbaseTest {
     then:
     result == doc
     assertTraces(1) {
-      trace(0, 1) {
-        assertCouchbaseCall(it, 0, "Bucket.upsert", bucketCouchbase.name())
+      trace(1) {
+        assertCouchbaseCall(it, "Bucket.upsert", bucketCouchbase.name())
       }
     }
 
@@ -118,11 +118,11 @@ class CouchbaseSpringRepositoryTest extends AbstractCouchbaseTest {
 
     then: // RETRIEVE
     result == doc
-    sortAndAssertTraces(1) {
-      trace(0, 3) {
-        basicSpan(it, 0, "someTrace")
-        assertCouchbaseCall(it, 2, "Bucket.upsert", bucketCouchbase.name(), span(0))
-        assertCouchbaseCall(it, 1, "Bucket.get", bucketCouchbase.name(), span(0))
+    assertTraces(1) {
+      trace(3) {
+        basicSpan(it, "someTrace")
+        assertCouchbaseCall(it, "Bucket.get", bucketCouchbase.name(), span(0))
+        assertCouchbaseCall(it, "Bucket.upsert", bucketCouchbase.name(), span(0))
       }
     }
 
@@ -147,11 +147,11 @@ class CouchbaseSpringRepositoryTest extends AbstractCouchbaseTest {
 
 
     then:
-    sortAndAssertTraces(1) {
-      trace(0, 3) {
-        basicSpan(it, 0, "someTrace")
-        assertCouchbaseCall(it, 1, "Bucket.upsert", bucketCouchbase.name(), span(0))
-        assertCouchbaseCall(it, 2, "Bucket.upsert", bucketCouchbase.name(), span(0))
+    assertTraces(1) {
+      trace(3) {
+        basicSpan(it, "someTrace")
+        assertCouchbaseCall(it, "Bucket.upsert", bucketCouchbase.name(), span(0))
+        assertCouchbaseCall(it, "Bucket.upsert", bucketCouchbase.name(), span(0))
       }
     }
 
@@ -177,12 +177,12 @@ class CouchbaseSpringRepositoryTest extends AbstractCouchbaseTest {
 
     then:
     assert !result
-    sortAndAssertTraces(1) {
-      trace(0, 4) {
-        basicSpan(it, 0, "someTrace")
-        assertCouchbaseCall(it, 3, "Bucket.upsert", bucketCouchbase.name(), span(0))
-        assertCouchbaseCall(it, 2, "Bucket.remove", bucketCouchbase.name(), span(0))
-        assertCouchbaseCall(it, 1, "Bucket.query", bucketCouchbase.name(), span(0))
+    assertTraces(1) {
+      trace(4) {
+        basicSpan(it, "someTrace")
+        assertCouchbaseCall(it, "Bucket.query", bucketCouchbase.name(), span(0))
+        assertCouchbaseCall(it, "Bucket.remove", bucketCouchbase.name(), span(0))
+        assertCouchbaseCall(it, "Bucket.upsert", bucketCouchbase.name(), span(0))
       }
     }
   }

--- a/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/springdata/CouchbaseSpringTemplateTest.groovy
+++ b/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/springdata/CouchbaseSpringTemplateTest.groovy
@@ -75,11 +75,11 @@ class CouchbaseSpringTemplateTest extends AbstractCouchbaseTest {
     then:
     result != null
 
-    sortAndAssertTraces(1) {
-      trace(0, 3) {
-        basicSpan(it, 0, "someTrace")
-        assertCouchbaseCall(it, 2, "Bucket.upsert", name, span(0))
-        assertCouchbaseCall(it, 1, "Bucket.get", name, span(0))
+    assertTraces(1) {
+      trace(3) {
+        basicSpan(it, "someTrace")
+        assertCouchbaseCall(it, "Bucket.get", name, span(0))
+        assertCouchbaseCall(it, "Bucket.upsert", name, span(0))
       }
     }
 
@@ -102,11 +102,11 @@ class CouchbaseSpringTemplateTest extends AbstractCouchbaseTest {
 
 
     then:
-    sortAndAssertTraces(1) {
-      trace(0, 3) {
-        basicSpan(it, 0, "someTrace")
-        assertCouchbaseCall(it, 2, "Bucket.upsert", name, span(0))
-        assertCouchbaseCall(it, 1, "Bucket.remove", name, span(0))
+    assertTraces(1) {
+      trace(3) {
+        basicSpan(it, "someTrace")
+        assertCouchbaseCall(it, "Bucket.remove", name, span(0))
+        assertCouchbaseCall(it, "Bucket.upsert", name, span(0))
       }
     }
 
@@ -117,8 +117,8 @@ class CouchbaseSpringTemplateTest extends AbstractCouchbaseTest {
     then:
     result == null
     assertTraces(1) {
-      trace(0, 1) {
-        assertCouchbaseCall(it, 0, "Bucket.get", name)
+      trace(1) {
+        assertCouchbaseCall(it, "Bucket.get", name)
       }
     }
 

--- a/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/util/AbstractCouchbaseTest.groovy
+++ b/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/util/AbstractCouchbaseTest.groovy
@@ -11,14 +11,11 @@ import com.couchbase.mock.BucketConfiguration
 import com.couchbase.mock.CouchbaseMock
 import com.couchbase.mock.http.query.QueryServer
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.asserts.ListWriterAssert
 import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.core.DDSpan
-import groovy.transform.stc.ClosureParams
-import groovy.transform.stc.SimpleType
 import spock.lang.Shared
 
 import java.util.concurrent.TimeUnit
@@ -109,35 +106,8 @@ abstract class AbstractCouchbaseTest extends AgentTestRunner {
       .socketConnectTimeout(timeout.intValue())
   }
 
-  void sortAndAssertTraces(
-    final int size,
-    @ClosureParams(value = SimpleType, options = "datadog.trace.agent.test.asserts.ListWriterAssert")
-    @DelegatesTo(value = ListWriterAssert, strategy = Closure.DELEGATE_FIRST)
-    final Closure spec) {
-
-    TEST_WRITER.waitForTraces(size)
-
-    TEST_WRITER.each {
-      it.sort({
-        a, b ->
-          boolean aIsCouchbaseOperation = a.operationName.toString() == "couchbase.call"
-          boolean bIsCouchbaseOperation = b.operationName.toString() == "couchbase.call"
-
-          if (aIsCouchbaseOperation && !bIsCouchbaseOperation) {
-            return 1
-          } else if (!aIsCouchbaseOperation && bIsCouchbaseOperation) {
-            return -1
-          }
-
-          return a.resourceName.compareTo(b.resourceName)
-      })
-    }
-
-    assertTraces(size, spec)
-  }
-
-  void assertCouchbaseCall(TraceAssert trace, int index, String name, String bucketName = null, Object parentSpan = null) {
-    trace.span(index) {
+  void assertCouchbaseCall(TraceAssert trace, String name, String bucketName = null, Object parentSpan = null) {
+    trace.span {
       serviceName "couchbase"
       resourceName name
       operationName "couchbase.call"

--- a/dd-java-agent/instrumentation/couchbase-2.6/src/test/groovy/CouchbaseAsyncClient26Test.groovy
+++ b/dd-java-agent/instrumentation/couchbase-2.6/src/test/groovy/CouchbaseAsyncClient26Test.groovy
@@ -5,7 +5,7 @@ import spock.lang.Retry
 class CouchbaseAsyncClient26Test extends CouchbaseAsyncClientTest {
 
   @Override
-  void assertCouchbaseCall(TraceAssert trace, int index, String name, String bucketName = null, Object parentSpan = null) {
-    CouchbaseSpanUtil.assertCouchbaseCall(trace, index, name, bucketName, parentSpan)
+  void assertCouchbaseCall(TraceAssert trace, String name, String bucketName = null, Object parentSpan = null) {
+    CouchbaseSpanUtil.assertCouchbaseCall(trace, name, bucketName, parentSpan)
   }
 }

--- a/dd-java-agent/instrumentation/couchbase-2.6/src/test/groovy/CouchbaseClient26Test.groovy
+++ b/dd-java-agent/instrumentation/couchbase-2.6/src/test/groovy/CouchbaseClient26Test.groovy
@@ -4,7 +4,7 @@ import spock.lang.Retry
 @Retry
 class CouchbaseClient26Test extends CouchbaseClientTest {
   @Override
-  void assertCouchbaseCall(TraceAssert trace, int index, String name, String bucketName = null, Object parentSpan = null) {
-    CouchbaseSpanUtil.assertCouchbaseCall(trace, index, name, bucketName, parentSpan)
+  void assertCouchbaseCall(TraceAssert trace, String name, String bucketName = null, Object parentSpan = null) {
+    CouchbaseSpanUtil.assertCouchbaseCall(trace, name, bucketName, parentSpan)
   }
 }

--- a/dd-java-agent/instrumentation/couchbase-2.6/src/test/groovy/CouchbaseSpanUtil.groovy
+++ b/dd-java-agent/instrumentation/couchbase-2.6/src/test/groovy/CouchbaseSpanUtil.groovy
@@ -1,13 +1,13 @@
-import datadog.trace.core.DDSpan
 import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
+import datadog.trace.core.DDSpan
 
 class CouchbaseSpanUtil {
   // Reusable span assertion method.  Cannot directly override AbstractCouchbaseTest.assertCouchbaseSpan because
   // Of the class hierarchy of these tests
-  static void assertCouchbaseCall(TraceAssert trace, int index, String name, String bucketName = null, Object parentSpan = null) {
-    trace.span(index) {
+  static void assertCouchbaseCall(TraceAssert trace, String name, String bucketName = null, Object parentSpan = null) {
+    trace.span {
       serviceName "couchbase"
       resourceName name
       operationName "couchbase.call"

--- a/dd-java-agent/instrumentation/couchbase-2.6/src/test/groovy/springdata/CouchbaseSpringRepository26Test.groovy
+++ b/dd-java-agent/instrumentation/couchbase-2.6/src/test/groovy/springdata/CouchbaseSpringRepository26Test.groovy
@@ -5,7 +5,7 @@ import datadog.trace.agent.test.asserts.TraceAssert
 
 class CouchbaseSpringRepository26Test extends CouchbaseSpringRepositoryTest {
   @Override
-  void assertCouchbaseCall(TraceAssert trace, int index, String name, String bucketName = null, Object parentSpan = null) {
-    CouchbaseSpanUtil.assertCouchbaseCall(trace, index, name, bucketName, parentSpan)
+  void assertCouchbaseCall(TraceAssert trace, String name, String bucketName = null, Object parentSpan = null) {
+    CouchbaseSpanUtil.assertCouchbaseCall(trace, name, bucketName, parentSpan)
   }
 }

--- a/dd-java-agent/instrumentation/couchbase-2.6/src/test/groovy/springdata/CouchbaseSpringTemplate26Test.groovy
+++ b/dd-java-agent/instrumentation/couchbase-2.6/src/test/groovy/springdata/CouchbaseSpringTemplate26Test.groovy
@@ -4,7 +4,7 @@ import datadog.trace.agent.test.asserts.TraceAssert
 
 class CouchbaseSpringTemplate26Test extends CouchbaseSpringTemplateTest {
   @Override
-  void assertCouchbaseCall(TraceAssert trace, int index, String name, String bucketName = null, Object parentSpan = null) {
-    CouchbaseSpanUtil.assertCouchbaseCall(trace, index, name, bucketName, parentSpan)
+  void assertCouchbaseCall(TraceAssert trace, String name, String bucketName = null, Object parentSpan = null) {
+    CouchbaseSpanUtil.assertCouchbaseCall(trace, name, bucketName, parentSpan)
   }
 }

--- a/dd-java-agent/instrumentation/datastax-cassandra-3/src/test/groovy/CassandraClientTest.groovy
+++ b/dd-java-agent/instrumentation/datastax-cassandra-3/src/test/groovy/CassandraClientTest.groovy
@@ -59,12 +59,12 @@ class CassandraClientTest extends AgentTestRunner {
     expect:
     assertTraces(keyspace ? 2 : 1) {
       if (keyspace) {
-        trace(0, 1) {
-          cassandraSpan(it, 0, "USE $keyspace", null, false)
+        trace(1) {
+          cassandraSpan(it, "USE $keyspace", null, false)
         }
       }
-      trace(keyspace ? 1 : 0, 1) {
-        cassandraSpan(it, 0, statement, keyspace, renameService)
+      trace(1) {
+        cassandraSpan(it, statement, keyspace, renameService)
       }
     }
 
@@ -100,14 +100,14 @@ class CassandraClientTest extends AgentTestRunner {
     callbackExecuted.get()
     assertTraces(keyspace ? 2 : 1) {
       if (keyspace) {
-        trace(0, 1) {
-          cassandraSpan(it, 0, "USE $keyspace", null, false)
+        trace(1) {
+          cassandraSpan(it, "USE $keyspace", null, false)
         }
       }
-      trace(keyspace ? 1 : 0, 2) {
-        basicSpan(it, 0, "parent")
-//        basicSpan(it, 1, "callbackListener", span(0))
-        cassandraSpan(it, 1, statement, keyspace, renameService, span(0))
+      trace(2) {
+        basicSpan(it, "parent")
+//        basicSpan(it, "callbackListener", span(0))
+        cassandraSpan(it, statement, keyspace, renameService, span(0))
       }
     }
 
@@ -123,8 +123,8 @@ class CassandraClientTest extends AgentTestRunner {
     "SELECT * FROM users where name = 'alice' ALLOW FILTERING"                                         | "async_test" | true
   }
 
-  def cassandraSpan(TraceAssert trace, int index, String statement, String keyspace, boolean renameService, Object parentSpan = null, Throwable exception = null) {
-    trace.span(index) {
+  def cassandraSpan(TraceAssert trace, String statement, String keyspace, boolean renameService, Object parentSpan = null, Throwable exception = null) {
+    trace.span {
       serviceName renameService && keyspace ? keyspace : "cassandra"
       operationName "cassandra.query"
       resourceName statement

--- a/dd-java-agent/instrumentation/dropwizard/dropwizard-views/src/test/groovy/ViewRenderTest.groovy
+++ b/dd-java-agent/instrumentation/dropwizard/dropwizard-views/src/test/groovy/ViewRenderTest.groovy
@@ -24,9 +24,9 @@ class ViewRenderTest extends AgentTestRunner {
     then:
     outputStream.toString().contains("This is an example of a view")
     assertTraces(TEST_WRITER, 1) {
-      trace(0, 2) {
-        basicSpan(it, 0, "parent")
-        span(1) {
+      trace(2) {
+        basicSpan(it, "parent")
+        span {
           resourceName "View $template"
           operationName "view.render"
           childOf span(0)

--- a/dd-java-agent/instrumentation/dropwizard/src/test/groovy/DropwizardTest.groovy
+++ b/dd-java-agent/instrumentation/dropwizard/src/test/groovy/DropwizardTest.groovy
@@ -1,9 +1,9 @@
-import datadog.trace.core.DDSpan
 import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.agent.test.base.HttpServerTest
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import datadog.trace.bootstrap.instrumentation.api.Tags
+import datadog.trace.core.DDSpan
 import datadog.trace.instrumentation.jaxrs2.JaxRsAnnotationsDecorator
 import io.dropwizard.Application
 import io.dropwizard.Configuration
@@ -76,8 +76,8 @@ class DropwizardTest extends HttpServerTest<DropwizardTestSupport> {
   }
 
   @Override
-  void handlerSpan(TraceAssert trace, int index, Object parent, ServerEndpoint endpoint = SUCCESS) {
-    trace.span(index) {
+  void handlerSpan(TraceAssert trace, Object parent, ServerEndpoint endpoint = SUCCESS) {
+    trace.span {
       serviceName expectedServiceName()
       operationName "jax-rs.request"
       resourceName "${testResource().simpleName}.${endpoint.name().toLowerCase()}"
@@ -95,8 +95,8 @@ class DropwizardTest extends HttpServerTest<DropwizardTestSupport> {
   }
 
   @Override
-  void serverSpan(TraceAssert trace, int index, BigInteger traceID = null, BigInteger parentID = null, String method = "GET", ServerEndpoint endpoint = SUCCESS) {
-    trace.span(index) {
+  void serverSpan(TraceAssert trace, BigInteger traceID = null, BigInteger parentID = null, String method = "GET", ServerEndpoint endpoint = SUCCESS) {
+    trace.span {
       serviceName expectedServiceName()
       operationName expectedOperationName()
       resourceName endpoint.status == 404 ? "404" : "$method ${endpoint.resolve(address).path}"

--- a/dd-java-agent/instrumentation/elasticsearch/rest-5/src/latestDepTest/groovy/Elasticsearch6RestClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/rest-5/src/latestDepTest/groovy/Elasticsearch6RestClientTest.groovy
@@ -76,8 +76,8 @@ class Elasticsearch6RestClientTest extends AgentTestRunner {
     result.status == "green"
 
     assertTraces(1) {
-      trace(0, 2) {
-        span(0) {
+      trace(2) {
+        span {
           serviceName "elasticsearch"
           resourceName "GET _cluster/health"
           operationName "elasticsearch.rest.query"
@@ -94,7 +94,7 @@ class Elasticsearch6RestClientTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "GET _cluster/health"
           operationName "http.request"

--- a/dd-java-agent/instrumentation/elasticsearch/rest-5/src/test/groovy/Elasticsearch5RestClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/rest-5/src/test/groovy/Elasticsearch5RestClientTest.groovy
@@ -81,8 +81,8 @@ class Elasticsearch5RestClientTest extends AgentTestRunner {
     result.status == "green"
 
     assertTraces(1) {
-      trace(0, 2) {
-        span(0) {
+      trace(2) {
+        span {
           serviceName "elasticsearch"
           resourceName "GET _cluster/health"
           operationName "elasticsearch.rest.query"
@@ -99,7 +99,7 @@ class Elasticsearch5RestClientTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "GET _cluster/health"
           operationName "http.request"

--- a/dd-java-agent/instrumentation/elasticsearch/rest-6.4/src/latestDepTest/groovy/Elasticsearch6RestClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/rest-6.4/src/latestDepTest/groovy/Elasticsearch6RestClientTest.groovy
@@ -81,8 +81,8 @@ class Elasticsearch6RestClientTest extends AgentTestRunner {
     result.status == "green"
 
     assertTraces(1) {
-      trace(0, 2) {
-        span(0) {
+      trace(2) {
+        span {
           serviceName "elasticsearch"
           resourceName "GET _cluster/health"
           operationName "elasticsearch.rest.query"
@@ -99,7 +99,7 @@ class Elasticsearch6RestClientTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "GET _cluster/health"
           operationName "http.request"

--- a/dd-java-agent/instrumentation/elasticsearch/rest-6.4/src/test/groovy/Elasticsearch6RestClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/rest-6.4/src/test/groovy/Elasticsearch6RestClientTest.groovy
@@ -76,8 +76,8 @@ class Elasticsearch6RestClientTest extends AgentTestRunner {
     result.status == "green"
 
     assertTraces(1) {
-      trace(0, 2) {
-        span(0) {
+      trace(2) {
+        span {
           serviceName "elasticsearch"
           resourceName "GET _cluster/health"
           operationName "elasticsearch.rest.query"
@@ -94,7 +94,7 @@ class Elasticsearch6RestClientTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "GET _cluster/health"
           operationName "http.request"

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/Elasticsearch2NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/Elasticsearch2NodeClientTest.groovy
@@ -69,8 +69,8 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
     status.name() == "GREEN"
 
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "ClusterHealthAction"
           operationName "elasticsearch.query"
@@ -97,8 +97,8 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
 
     and:
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "GetAction"
           operationName "elasticsearch.query"
@@ -162,16 +162,9 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
     result.index == indexName
 
     and:
-    // IndexAction and PutMappingAction run in separate threads and order in which
-    // these spans are closed is not defined. So we force the order if it is wrong.
-    if (TEST_WRITER[3][0].resourceName.toString() == "IndexAction") {
-      def tmp = TEST_WRITER[3]
-      TEST_WRITER[3] = TEST_WRITER[4]
-      TEST_WRITER[4] = tmp
-    }
     assertTraces(6) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "CreateIndexAction"
           operationName "elasticsearch.query"
@@ -187,8 +180,8 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           }
         }
       }
-      trace(1, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "ClusterHealthAction"
           operationName "elasticsearch.query"
@@ -203,8 +196,8 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           }
         }
       }
-      trace(2, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "GetAction"
           operationName "elasticsearch.query"
@@ -223,25 +216,8 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           }
         }
       }
-      trace(3, 1) {
-        span(0) {
-          serviceName "elasticsearch"
-          resourceName "PutMappingAction"
-          operationName "elasticsearch.query"
-          spanType DDSpanTypes.ELASTICSEARCH
-          tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "elasticsearch"
-            "elasticsearch.action" "PutMappingAction"
-            "elasticsearch.request" "PutMappingRequest"
-            "elasticsearch.request.indices" indexName
-            defaultTags()
-          }
-        }
-      }
-      trace(4, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "IndexAction"
           operationName "elasticsearch.query"
@@ -258,8 +234,25 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           }
         }
       }
-      trace(5, 1) {
-        span(0) {
+      trace(1) {
+        span {
+          serviceName "elasticsearch"
+          resourceName "PutMappingAction"
+          operationName "elasticsearch.query"
+          spanType DDSpanTypes.ELASTICSEARCH
+          tags {
+            "$Tags.COMPONENT" "elasticsearch-java"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
+            "elasticsearch.action" "PutMappingAction"
+            "elasticsearch.request" "PutMappingRequest"
+            "elasticsearch.request.indices" indexName
+            defaultTags()
+          }
+        }
+      }
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "GetAction"
           operationName "elasticsearch.query"

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/Elasticsearch2TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/Elasticsearch2TransportClientTest.groovy
@@ -79,8 +79,8 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
     status.name() == "GREEN"
 
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "ClusterHealthAction"
           operationName "elasticsearch.query"
@@ -110,8 +110,8 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
 
     and:
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "GetAction"
           operationName "elasticsearch.query"
@@ -175,16 +175,9 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
     result.index == indexName
 
     and:
-    // IndexAction and PutMappingAction run in separate threads and order in which
-    // these spans are closed is not defined. So we force the order if it is wrong.
-    if (TEST_WRITER[3][0].resourceName.toString() == "IndexAction") {
-      def tmp = TEST_WRITER[3]
-      TEST_WRITER[3] = TEST_WRITER[4]
-      TEST_WRITER[4] = tmp
-    }
     assertTraces(6) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "CreateIndexAction"
           operationName "elasticsearch.query"
@@ -203,8 +196,8 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
           }
         }
       }
-      trace(1, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "ClusterHealthAction"
           operationName "elasticsearch.query"
@@ -222,8 +215,8 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
           }
         }
       }
-      trace(2, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "GetAction"
           operationName "elasticsearch.query"
@@ -245,25 +238,8 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
           }
         }
       }
-      trace(3, 1) {
-        span(0) {
-          serviceName "elasticsearch"
-          resourceName "PutMappingAction"
-          operationName "elasticsearch.query"
-          spanType DDSpanTypes.ELASTICSEARCH
-          tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "elasticsearch"
-            "elasticsearch.action" "PutMappingAction"
-            "elasticsearch.request" "PutMappingRequest"
-            "elasticsearch.request.indices" indexName
-            defaultTags()
-          }
-        }
-      }
-      trace(4, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "IndexAction"
           operationName "elasticsearch.query"
@@ -283,8 +259,25 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
           }
         }
       }
-      trace(5, 1) {
-        span(0) {
+      trace(1) {
+        span {
+          serviceName "elasticsearch"
+          resourceName "PutMappingAction"
+          operationName "elasticsearch.query"
+          spanType DDSpanTypes.ELASTICSEARCH
+          tags {
+            "$Tags.COMPONENT" "elasticsearch-java"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
+            "elasticsearch.action" "PutMappingAction"
+            "elasticsearch.request" "PutMappingRequest"
+            "elasticsearch.request.indices" indexName
+            defaultTags()
+          }
+        }
+      }
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "GetAction"
           operationName "elasticsearch.query"

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/springdata/Elasticsearch2SpringRepositoryTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/springdata/Elasticsearch2SpringRepositoryTest.groovy
@@ -38,8 +38,8 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
 
     and:
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "SearchAction"
           operationName "elasticsearch.query"
@@ -72,8 +72,8 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
 
     and:
     assertTraces(2) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           resourceName "IndexAction"
           operationName "elasticsearch.query"
           spanType DDSpanTypes.ELASTICSEARCH
@@ -89,8 +89,8 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           }
         }
       }
-      trace(1, 1) {
-        span(0) {
+      trace(1) {
+        span {
           resourceName "RefreshAction"
           operationName "elasticsearch.query"
           spanType DDSpanTypes.ELASTICSEARCH
@@ -116,8 +116,8 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
 
     and:
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "GetAction"
           operationName "elasticsearch.query"
@@ -148,8 +148,8 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
 
     and:
     assertTraces(3) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           resourceName "IndexAction"
           operationName "elasticsearch.query"
           spanType DDSpanTypes.ELASTICSEARCH
@@ -165,8 +165,8 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           }
         }
       }
-      trace(1, 1) {
-        span(0) {
+      trace(1) {
+        span {
           resourceName "RefreshAction"
           operationName "elasticsearch.query"
           spanType DDSpanTypes.ELASTICSEARCH
@@ -184,8 +184,8 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           }
         }
       }
-      trace(2, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "GetAction"
           operationName "elasticsearch.query"
@@ -215,8 +215,8 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
 
     and:
     assertTraces(3) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           resourceName "DeleteAction"
           operationName "elasticsearch.query"
           spanType DDSpanTypes.ELASTICSEARCH
@@ -232,8 +232,8 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           }
         }
       }
-      trace(1, 1) {
-        span(0) {
+      trace(1) {
+        span {
           resourceName "RefreshAction"
           operationName "elasticsearch.query"
           spanType DDSpanTypes.ELASTICSEARCH
@@ -251,8 +251,8 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           }
         }
       }
-      trace(2, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "SearchAction"
           operationName "elasticsearch.query"

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
@@ -70,8 +70,8 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
 
     and:
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "RefreshAction"
           operationName "elasticsearch.query"
@@ -126,16 +126,9 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
     template.queryForList(query, Doc) == [new Doc()]
 
     and:
-    // IndexAction and PutMappingAction run in separate threads and order in which
-    // these spans are closed is not defined. So we force the order if it is wrong.
-    if (TEST_WRITER[3][0].resourceName.toString() == "IndexAction") {
-      def tmp = TEST_WRITER[3]
-      TEST_WRITER[3] = TEST_WRITER[4]
-      TEST_WRITER[4] = tmp
-    }
     assertTraces(7) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "CreateIndexAction"
           operationName "elasticsearch.query"
@@ -151,8 +144,8 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           }
         }
       }
-      trace(1, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "ClusterHealthAction"
           operationName "elasticsearch.query"
@@ -167,8 +160,8 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           }
         }
       }
-      trace(2, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "SearchAction"
           operationName "elasticsearch.query"
@@ -185,25 +178,8 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           }
         }
       }
-      trace(3, 1) {
-        span(0) {
-          serviceName "elasticsearch"
-          resourceName "PutMappingAction"
-          operationName "elasticsearch.query"
-          spanType DDSpanTypes.ELASTICSEARCH
-          tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "elasticsearch"
-            "elasticsearch.action" "PutMappingAction"
-            "elasticsearch.request" "PutMappingRequest"
-            "elasticsearch.request.indices" indexName
-            defaultTags()
-          }
-        }
-      }
-      trace(4, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "IndexAction"
           operationName "elasticsearch.query"
@@ -220,8 +196,25 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           }
         }
       }
-      trace(5, 1) {
-        span(0) {
+      trace(1) {
+        span {
+          serviceName "elasticsearch"
+          resourceName "PutMappingAction"
+          operationName "elasticsearch.query"
+          spanType DDSpanTypes.ELASTICSEARCH
+          tags {
+            "$Tags.COMPONENT" "elasticsearch-java"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
+            "elasticsearch.action" "PutMappingAction"
+            "elasticsearch.request" "PutMappingRequest"
+            "elasticsearch.request.indices" indexName
+            defaultTags()
+          }
+        }
+      }
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "RefreshAction"
           operationName "elasticsearch.query"
@@ -240,8 +233,8 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           }
         }
       }
-      trace(6, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "SearchAction"
           operationName "elasticsearch.query"
@@ -324,8 +317,8 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
     bucketTags == [:]
 
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "SearchAction"
           operationName "elasticsearch.query"

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/Elasticsearch2NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/Elasticsearch2NodeClientTest.groovy
@@ -64,8 +64,8 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
     status.name() == "GREEN"
 
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "ClusterHealthAction"
           operationName "elasticsearch.query"
@@ -92,8 +92,8 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
 
     and:
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "GetAction"
           operationName "elasticsearch.query"
@@ -157,16 +157,9 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
     result.index == indexName
 
     and:
-    // IndexAction and PutMappingAction run in separate threads and order in which
-    // these spans are closed is not defined. So we force the order if it is wrong.
-    if (TEST_WRITER[3][0].resourceName.toString() == "IndexAction") {
-      def tmp = TEST_WRITER[3]
-      TEST_WRITER[3] = TEST_WRITER[4]
-      TEST_WRITER[4] = tmp
-    }
     assertTraces(6) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "CreateIndexAction"
           operationName "elasticsearch.query"
@@ -182,8 +175,8 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           }
         }
       }
-      trace(1, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "ClusterHealthAction"
           operationName "elasticsearch.query"
@@ -198,8 +191,8 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           }
         }
       }
-      trace(2, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "GetAction"
           operationName "elasticsearch.query"
@@ -221,25 +214,8 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           }
         }
       }
-      trace(3, 1) {
-        span(0) {
-          serviceName "elasticsearch"
-          resourceName "PutMappingAction"
-          operationName "elasticsearch.query"
-          spanType DDSpanTypes.ELASTICSEARCH
-          tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "elasticsearch"
-            "elasticsearch.action" "PutMappingAction"
-            "elasticsearch.request" "PutMappingRequest"
-            "elasticsearch.request.indices" indexName
-            defaultTags()
-          }
-        }
-      }
-      trace(4, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "IndexAction"
           operationName "elasticsearch.query"
@@ -259,8 +235,25 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           }
         }
       }
-      trace(5, 1) {
-        span(0) {
+      trace(1) {
+        span {
+          serviceName "elasticsearch"
+          resourceName "PutMappingAction"
+          operationName "elasticsearch.query"
+          spanType DDSpanTypes.ELASTICSEARCH
+          tags {
+            "$Tags.COMPONENT" "elasticsearch-java"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
+            "elasticsearch.action" "PutMappingAction"
+            "elasticsearch.request" "PutMappingRequest"
+            "elasticsearch.request.indices" indexName
+            defaultTags()
+          }
+        }
+      }
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "GetAction"
           operationName "elasticsearch.query"

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/Elasticsearch2TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/Elasticsearch2TransportClientTest.groovy
@@ -81,8 +81,8 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
     status.name() == "GREEN"
 
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "ClusterHealthAction"
           operationName "elasticsearch.query"
@@ -115,8 +115,8 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
     failures == null
 
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "ClusterStatsAction"
           operationName "elasticsearch.query"
@@ -147,8 +147,8 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
 
     and:
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "GetAction"
           operationName "elasticsearch.query"
@@ -212,16 +212,9 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
     result.index == indexName
 
     and:
-    // IndexAction and PutMappingAction run in separate threads and order in which
-    // these spans are closed is not defined. So we force the order if it is wrong.
-    if (TEST_WRITER[3][0].resourceName.toString() == "IndexAction") {
-      def tmp = TEST_WRITER[3]
-      TEST_WRITER[3] = TEST_WRITER[4]
-      TEST_WRITER[4] = tmp
-    }
     assertTraces(6) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "CreateIndexAction"
           operationName "elasticsearch.query"
@@ -240,8 +233,8 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
           }
         }
       }
-      trace(1, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "ClusterHealthAction"
           operationName "elasticsearch.query"
@@ -259,8 +252,8 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
           }
         }
       }
-      trace(2, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "GetAction"
           operationName "elasticsearch.query"
@@ -282,25 +275,8 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
           }
         }
       }
-      trace(3, 1) {
-        span(0) {
-          serviceName "elasticsearch"
-          resourceName "PutMappingAction"
-          operationName "elasticsearch.query"
-          spanType DDSpanTypes.ELASTICSEARCH
-          tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "elasticsearch"
-            "elasticsearch.action" "PutMappingAction"
-            "elasticsearch.request" "PutMappingRequest"
-            "elasticsearch.request.indices" indexName
-            defaultTags()
-          }
-        }
-      }
-      trace(4, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "IndexAction"
           operationName "elasticsearch.query"
@@ -320,8 +296,25 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
           }
         }
       }
-      trace(5, 1) {
-        span(0) {
+      trace(1) {
+        span {
+          serviceName "elasticsearch"
+          resourceName "PutMappingAction"
+          operationName "elasticsearch.query"
+          spanType DDSpanTypes.ELASTICSEARCH
+          tags {
+            "$Tags.COMPONENT" "elasticsearch-java"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
+            "elasticsearch.action" "PutMappingAction"
+            "elasticsearch.request" "PutMappingRequest"
+            "elasticsearch.request.indices" indexName
+            defaultTags()
+          }
+        }
+      }
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "GetAction"
           operationName "elasticsearch.query"

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/springdata/Elasticsearch2SpringRepositoryTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/springdata/Elasticsearch2SpringRepositoryTest.groovy
@@ -38,8 +38,8 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
 
     and:
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "SearchAction"
           operationName "elasticsearch.query"
@@ -72,8 +72,8 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
 
     and:
     assertTraces(2) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           resourceName "IndexAction"
           operationName "elasticsearch.query"
           spanType DDSpanTypes.ELASTICSEARCH
@@ -92,8 +92,8 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           }
         }
       }
-      trace(1, 1) {
-        span(0) {
+      trace(1) {
+        span {
           resourceName "RefreshAction"
           operationName "elasticsearch.query"
           spanType DDSpanTypes.ELASTICSEARCH
@@ -119,8 +119,8 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
 
     and:
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "GetAction"
           operationName "elasticsearch.query"
@@ -154,8 +154,8 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
 
     and:
     assertTraces(3) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           resourceName "IndexAction"
           operationName "elasticsearch.query"
           spanType DDSpanTypes.ELASTICSEARCH
@@ -174,8 +174,8 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           }
         }
       }
-      trace(1, 1) {
-        span(0) {
+      trace(1) {
+        span {
           resourceName "RefreshAction"
           operationName "elasticsearch.query"
           spanType DDSpanTypes.ELASTICSEARCH
@@ -193,8 +193,8 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           }
         }
       }
-      trace(2, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "GetAction"
           operationName "elasticsearch.query"
@@ -227,8 +227,8 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
 
     and:
     assertTraces(3) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           resourceName "DeleteAction"
           operationName "elasticsearch.query"
           spanType DDSpanTypes.ELASTICSEARCH
@@ -247,8 +247,8 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           }
         }
       }
-      trace(1, 1) {
-        span(0) {
+      trace(1) {
+        span {
           resourceName "RefreshAction"
           operationName "elasticsearch.query"
           spanType DDSpanTypes.ELASTICSEARCH
@@ -266,8 +266,8 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           }
         }
       }
-      trace(2, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "SearchAction"
           operationName "elasticsearch.query"

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
@@ -69,8 +69,8 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
 
     and:
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "RefreshAction"
           operationName "elasticsearch.query"
@@ -125,16 +125,9 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
     template.queryForList(query, Doc) == [new Doc()]
 
     and:
-    // IndexAction and PutMappingAction run in separate threads and order in which
-    // these spans are closed is not defined. So we force the order if it is wrong.
-    if (TEST_WRITER[3][0].resourceName.toString() == "IndexAction") {
-      def tmp = TEST_WRITER[3]
-      TEST_WRITER[3] = TEST_WRITER[4]
-      TEST_WRITER[4] = tmp
-    }
     assertTraces(7) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "CreateIndexAction"
           operationName "elasticsearch.query"
@@ -150,8 +143,8 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           }
         }
       }
-      trace(1, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "ClusterHealthAction"
           operationName "elasticsearch.query"
@@ -166,8 +159,8 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           }
         }
       }
-      trace(2, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "SearchAction"
           operationName "elasticsearch.query"
@@ -184,25 +177,8 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           }
         }
       }
-      trace(3, 1) {
-        span(0) {
-          serviceName "elasticsearch"
-          resourceName "PutMappingAction"
-          operationName "elasticsearch.query"
-          spanType DDSpanTypes.ELASTICSEARCH
-          tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "elasticsearch"
-            "elasticsearch.action" "PutMappingAction"
-            "elasticsearch.request" "PutMappingRequest"
-            "elasticsearch.request.indices" indexName
-            defaultTags()
-          }
-        }
-      }
-      trace(4, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "IndexAction"
           operationName "elasticsearch.query"
@@ -222,8 +198,25 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           }
         }
       }
-      trace(5, 1) {
-        span(0) {
+      trace(1) {
+        span {
+          serviceName "elasticsearch"
+          resourceName "PutMappingAction"
+          operationName "elasticsearch.query"
+          spanType DDSpanTypes.ELASTICSEARCH
+          tags {
+            "$Tags.COMPONENT" "elasticsearch-java"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
+            "elasticsearch.action" "PutMappingAction"
+            "elasticsearch.request" "PutMappingRequest"
+            "elasticsearch.request.indices" indexName
+            defaultTags()
+          }
+        }
+      }
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "RefreshAction"
           operationName "elasticsearch.query"
@@ -242,8 +235,8 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           }
         }
       }
-      trace(6, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "SearchAction"
           operationName "elasticsearch.query"
@@ -323,8 +316,8 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
     bucketTags == [:]
 
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "SearchAction"
           operationName "elasticsearch.query"

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/Elasticsearch53NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/Elasticsearch53NodeClientTest.groovy
@@ -70,8 +70,8 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
     status.name() == "GREEN"
 
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "ClusterHealthAction"
           operationName "elasticsearch.query"
@@ -98,8 +98,8 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
 
     and:
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "GetAction"
           operationName "elasticsearch.query"
@@ -164,16 +164,9 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
     result.index == indexName
 
     and:
-    // IndexAction and PutMappingAction run in separate threads and order in which
-    // these spans are closed is not defined. So we force the order if it is wrong.
-    if (TEST_WRITER[3][0].resourceName.toString() == "IndexAction") {
-      def tmp = TEST_WRITER[3]
-      TEST_WRITER[3] = TEST_WRITER[4]
-      TEST_WRITER[4] = tmp
-    }
     assertTraces(6) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "CreateIndexAction"
           operationName "elasticsearch.query"
@@ -189,8 +182,8 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
           }
         }
       }
-      trace(1, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "ClusterHealthAction"
           operationName "elasticsearch.query"
@@ -205,8 +198,8 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
           }
         }
       }
-      trace(2, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "GetAction"
           operationName "elasticsearch.query"
@@ -225,24 +218,8 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
           }
         }
       }
-      trace(3, 1) {
-        span(0) {
-          serviceName "elasticsearch"
-          resourceName "PutMappingAction"
-          operationName "elasticsearch.query"
-          spanType DDSpanTypes.ELASTICSEARCH
-          tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "elasticsearch"
-            "elasticsearch.action" "PutMappingAction"
-            "elasticsearch.request" "PutMappingRequest"
-            defaultTags()
-          }
-        }
-      }
-      trace(4, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "IndexAction"
           operationName "elasticsearch.query"
@@ -264,8 +241,24 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
           }
         }
       }
-      trace(5, 1) {
-        span(0) {
+      trace(1) {
+        span {
+          serviceName "elasticsearch"
+          resourceName "PutMappingAction"
+          operationName "elasticsearch.query"
+          spanType DDSpanTypes.ELASTICSEARCH
+          tags {
+            "$Tags.COMPONENT" "elasticsearch-java"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
+            "elasticsearch.action" "PutMappingAction"
+            "elasticsearch.request" "PutMappingRequest"
+            defaultTags()
+          }
+        }
+      }
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "GetAction"
           operationName "elasticsearch.query"

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/Elasticsearch53TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/Elasticsearch53TransportClientTest.groovy
@@ -87,8 +87,8 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
     status.name() == "GREEN"
 
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "ClusterHealthAction"
           operationName "elasticsearch.query"
@@ -118,8 +118,8 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
 
     and:
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "GetAction"
           operationName "elasticsearch.query"
@@ -183,16 +183,9 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
     result.index == indexName
 
     and:
-    // IndexAction and PutMappingAction run in separate threads and order in which
-    // these spans are closed is not defined. So we force the order if it is wrong.
-    if (TEST_WRITER[2][0].resourceName.toString() == "IndexAction") {
-      def tmp = TEST_WRITER[2]
-      TEST_WRITER[2] = TEST_WRITER[3]
-      TEST_WRITER[3] = tmp
-    }
     assertTraces(5) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "CreateIndexAction"
           operationName "elasticsearch.query"
@@ -211,8 +204,8 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
           }
         }
       }
-      trace(1, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "GetAction"
           operationName "elasticsearch.query"
@@ -234,24 +227,8 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
           }
         }
       }
-      trace(2, 1) {
-        span(0) {
-          serviceName "elasticsearch"
-          resourceName "PutMappingAction"
-          operationName "elasticsearch.query"
-          spanType DDSpanTypes.ELASTICSEARCH
-          tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "elasticsearch"
-            "elasticsearch.action" "PutMappingAction"
-            "elasticsearch.request" "PutMappingRequest"
-            defaultTags()
-          }
-        }
-      }
-      trace(3, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "IndexAction"
           operationName "elasticsearch.query"
@@ -276,8 +253,24 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
           }
         }
       }
-      trace(4, 1) {
-        span(0) {
+      trace(1) {
+        span {
+          serviceName "elasticsearch"
+          resourceName "PutMappingAction"
+          operationName "elasticsearch.query"
+          spanType DDSpanTypes.ELASTICSEARCH
+          tags {
+            "$Tags.COMPONENT" "elasticsearch-java"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
+            "elasticsearch.action" "PutMappingAction"
+            "elasticsearch.request" "PutMappingRequest"
+            defaultTags()
+          }
+        }
+      }
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "GetAction"
           operationName "elasticsearch.query"

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/springdata/Config.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/springdata/Config.groovy
@@ -44,6 +44,7 @@ class Config {
       .put("thread_pool.listener.size", 1)
       .put("transport.type", "netty3")
       .put("http.type", "netty3")
+      .put("cluster.info.update.interval", "1d") // set update interval super long
       .build()
 
     println "ES work dir: $tmpDir"

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/springdata/Elasticsearch53SpringRepositoryTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/springdata/Elasticsearch53SpringRepositoryTest.groovy
@@ -117,6 +117,7 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
 
     and:
     assertTraces(2) {
+      sortSpansByStart()
       trace(3) {
         span {
           resourceName "ElasticsearchRepository.index"
@@ -127,26 +128,6 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
             defaultTags()
           }
         }
-
-        span {
-          resourceName "RefreshAction"
-          operationName "elasticsearch.query"
-          spanType DDSpanTypes.ELASTICSEARCH
-          childOf(span(0))
-          tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "elasticsearch"
-            "elasticsearch.action" "RefreshAction"
-            "elasticsearch.request" "RefreshRequest"
-            "elasticsearch.request.indices" indexName
-            "elasticsearch.shard.broadcast.failed" 0
-            "elasticsearch.shard.broadcast.successful" 5
-            "elasticsearch.shard.broadcast.total" 10
-            defaultTags()
-          }
-        }
-
         span {
           resourceName "IndexAction"
           operationName "elasticsearch.query"
@@ -165,6 +146,24 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
             "elasticsearch.shard.replication.failed" 0
             "elasticsearch.shard.replication.successful" 1
             "elasticsearch.shard.replication.total" 2
+            defaultTags()
+          }
+        }
+        span {
+          resourceName "RefreshAction"
+          operationName "elasticsearch.query"
+          spanType DDSpanTypes.ELASTICSEARCH
+          childOf(span(0))
+          tags {
+            "$Tags.COMPONENT" "elasticsearch-java"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
+            "elasticsearch.action" "RefreshAction"
+            "elasticsearch.request" "RefreshRequest"
+            "elasticsearch.request.indices" indexName
+            "elasticsearch.shard.broadcast.failed" 0
+            "elasticsearch.shard.broadcast.successful" 5
+            "elasticsearch.shard.broadcast.total" 10
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/springdata/Elasticsearch53SpringRepositoryTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/springdata/Elasticsearch53SpringRepositoryTest.groovy
@@ -67,8 +67,8 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
     and:
     waitForTracesAndSortSpans(1)
     assertTraces(1) {
-      trace(0, 2) {
-        span(0) {
+      trace(2) {
+        span {
           operationName "repository.operation"
           resourceName "CrudRepository.findAll"
           tags {
@@ -78,7 +78,7 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           }
         }
 
-        span(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "SearchAction"
           operationName "elasticsearch.query"
@@ -112,32 +112,9 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
     repo.index(doc) == doc
 
     and:
-    waitForTracesAndSortSpans(2)
-    // need to normalize trace ordering since they are finished by different threads
-    if (TEST_WRITER[1][0].resourceName.toString() == "PutMappingAction") {
-      def tmp = TEST_WRITER[1]
-      TEST_WRITER[1] = TEST_WRITER[0]
-      TEST_WRITER[0] = tmp
-    }
     assertTraces(2) {
-      trace(0, 1) {
-        span(0) {
-          serviceName "elasticsearch"
-          resourceName "PutMappingAction"
-          operationName "elasticsearch.query"
-          spanType DDSpanTypes.ELASTICSEARCH
-          tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "elasticsearch.action" "PutMappingAction"
-            "elasticsearch.request" "PutMappingRequest"
-            defaultTags()
-          }
-        }
-      }
-      trace(1, 3) {
-        span(0) {
+      trace(3) {
+        span {
           resourceName "ElasticsearchRepository.index"
           operationName "repository.operation"
           tags {
@@ -147,7 +124,7 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           }
         }
 
-        span(1) {
+        span {
           resourceName "RefreshAction"
           operationName "elasticsearch.query"
           spanType DDSpanTypes.ELASTICSEARCH
@@ -166,7 +143,7 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           }
         }
 
-        span(2) {
+        span {
           resourceName "IndexAction"
           operationName "elasticsearch.query"
           spanType DDSpanTypes.ELASTICSEARCH
@@ -188,6 +165,22 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           }
         }
       }
+      trace(1) {
+        span {
+          serviceName "elasticsearch"
+          resourceName "PutMappingAction"
+          operationName "elasticsearch.query"
+          spanType DDSpanTypes.ELASTICSEARCH
+          tags {
+            "$Tags.COMPONENT" "elasticsearch-java"
+            "$Tags.DB_TYPE" "elasticsearch"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "elasticsearch.action" "PutMappingAction"
+            "elasticsearch.request" "PutMappingRequest"
+            defaultTags()
+          }
+        }
+      }
     }
     TEST_WRITER.clear()
 
@@ -197,8 +190,8 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
     and:
     waitForTracesAndSortSpans(1)
     assertTraces(1) {
-      trace(0, 2) {
-        span(0) {
+      trace(2) {
+        span {
           resourceName "CrudRepository.findById"
           operationName "repository.operation"
           tags {
@@ -208,7 +201,7 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           }
         }
 
-        span(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "GetAction"
           operationName "elasticsearch.query"
@@ -241,8 +234,8 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
     and:
     waitForTracesAndSortSpans(2)
     assertTraces(2) {
-      trace(0, 3) {
-        span(0) {
+      trace(3) {
+        span {
           resourceName "ElasticsearchRepository.index"
           operationName "repository.operation"
           tags {
@@ -251,7 +244,7 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           resourceName "RefreshAction"
           operationName "elasticsearch.query"
           spanType DDSpanTypes.ELASTICSEARCH
@@ -269,7 +262,7 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(2) {
+        span {
           resourceName "IndexAction"
           operationName "elasticsearch.query"
           spanType DDSpanTypes.ELASTICSEARCH
@@ -291,8 +284,8 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           }
         }
       }
-      trace(1, 2) {
-        span(0) {
+      trace(2) {
+        span {
           resourceName "CrudRepository.findById"
           operationName "repository.operation"
           tags {
@@ -302,7 +295,7 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           }
         }
 
-        span(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "GetAction"
           operationName "elasticsearch.query"
@@ -334,8 +327,8 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
     and:
     waitForTracesAndSortSpans(2)
     assertTraces(2) {
-      trace(0, 3) {
-        span(0) {
+      trace(3) {
+        span {
           resourceName "CrudRepository.deleteById"
           operationName "repository.operation"
           tags {
@@ -345,7 +338,7 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           }
         }
 
-        span(1) {
+        span {
           resourceName "RefreshAction"
           operationName "elasticsearch.query"
           spanType DDSpanTypes.ELASTICSEARCH
@@ -363,7 +356,7 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(2) {
+        span {
           resourceName "DeleteAction"
           operationName "elasticsearch.query"
           spanType DDSpanTypes.ELASTICSEARCH
@@ -385,8 +378,8 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
         }
       }
 
-      trace(1, 2) {
-        span(0) {
+      trace(2) {
+        span {
           resourceName "CrudRepository.findAll"
           operationName "repository.operation"
           tags {
@@ -396,7 +389,7 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           }
         }
 
-        span(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "SearchAction"
           operationName "elasticsearch.query"

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/springdata/Elasticsearch53SpringTemplateTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/springdata/Elasticsearch53SpringTemplateTest.groovy
@@ -89,8 +89,8 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
 
     and:
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "RefreshAction"
           operationName "elasticsearch.query"
@@ -148,17 +148,10 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
     // FIXME: it looks like proper approach is to provide TEST_WRITER with an API to filter traces as they are written
     TEST_WRITER.waitForTraces(7)
     filterIgnoredActions()
-    // IndexAction and PutMappingAction run in separate threads and order in which
-    // these spans are closed is not defined. So we force the order if it is wrong.
-    if (TEST_WRITER[3][0].resourceName.toString() == "IndexAction") {
-      def tmp = TEST_WRITER[3]
-      TEST_WRITER[3] = TEST_WRITER[4]
-      TEST_WRITER[4] = tmp
-    }
 
     assertTraces(7) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "CreateIndexAction"
           operationName "elasticsearch.query"
@@ -174,8 +167,8 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
           }
         }
       }
-      trace(1, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "ClusterHealthAction"
           operationName "elasticsearch.query"
@@ -190,8 +183,8 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
           }
         }
       }
-      trace(2, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "SearchAction"
           operationName "elasticsearch.query"
@@ -208,24 +201,8 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
           }
         }
       }
-      trace(3, 1) {
-        span(0) {
-          serviceName "elasticsearch"
-          resourceName "PutMappingAction"
-          operationName "elasticsearch.query"
-          spanType DDSpanTypes.ELASTICSEARCH
-          tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "elasticsearch"
-            "elasticsearch.action" "PutMappingAction"
-            "elasticsearch.request" "PutMappingRequest"
-            defaultTags()
-          }
-        }
-      }
-      trace(4, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "IndexAction"
           operationName "elasticsearch.query"
@@ -247,8 +224,24 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
           }
         }
       }
-      trace(5, 1) {
-        span(0) {
+      trace(1) {
+        span {
+          serviceName "elasticsearch"
+          resourceName "PutMappingAction"
+          operationName "elasticsearch.query"
+          spanType DDSpanTypes.ELASTICSEARCH
+          tags {
+            "$Tags.COMPONENT" "elasticsearch-java"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
+            "elasticsearch.action" "PutMappingAction"
+            "elasticsearch.request" "PutMappingRequest"
+            defaultTags()
+          }
+        }
+      }
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "RefreshAction"
           operationName "elasticsearch.query"
@@ -267,8 +260,8 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
           }
         }
       }
-      trace(6, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "SearchAction"
           operationName "elasticsearch.query"
@@ -351,8 +344,8 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
     bucketTags == [:]
 
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "SearchAction"
           operationName "elasticsearch.query"

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5/src/test/groovy/Elasticsearch5NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5/src/test/groovy/Elasticsearch5NodeClientTest.groovy
@@ -70,8 +70,8 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
     status.name() == "GREEN"
 
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "ClusterHealthAction"
           operationName "elasticsearch.query"
@@ -98,8 +98,8 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
 
     and:
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "GetAction"
           operationName "elasticsearch.query"
@@ -164,16 +164,9 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
     result.index == indexName
 
     and:
-    // IndexAction and PutMappingAction run in separate threads and order in which
-    // these spans are closed is not defined. So we force the order if it is wrong.
-    if (TEST_WRITER[3][0].resourceName.toString() == "IndexAction") {
-      def tmp = TEST_WRITER[3]
-      TEST_WRITER[3] = TEST_WRITER[4]
-      TEST_WRITER[4] = tmp
-    }
     assertTraces(6) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "CreateIndexAction"
           operationName "elasticsearch.query"
@@ -189,8 +182,8 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
           }
         }
       }
-      trace(1, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "ClusterHealthAction"
           operationName "elasticsearch.query"
@@ -205,8 +198,8 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
           }
         }
       }
-      trace(2, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "GetAction"
           operationName "elasticsearch.query"
@@ -225,24 +218,8 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
           }
         }
       }
-      trace(3, 1) {
-        span(0) {
-          serviceName "elasticsearch"
-          resourceName "PutMappingAction"
-          operationName "elasticsearch.query"
-          spanType DDSpanTypes.ELASTICSEARCH
-          tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "elasticsearch"
-            "elasticsearch.action" "PutMappingAction"
-            "elasticsearch.request" "PutMappingRequest"
-            defaultTags()
-          }
-        }
-      }
-      trace(4, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "IndexAction"
           operationName "elasticsearch.query"
@@ -263,8 +240,24 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
           }
         }
       }
-      trace(5, 1) {
-        span(0) {
+      trace(1) {
+        span {
+          serviceName "elasticsearch"
+          resourceName "PutMappingAction"
+          operationName "elasticsearch.query"
+          spanType DDSpanTypes.ELASTICSEARCH
+          tags {
+            "$Tags.COMPONENT" "elasticsearch-java"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
+            "elasticsearch.action" "PutMappingAction"
+            "elasticsearch.request" "PutMappingRequest"
+            defaultTags()
+          }
+        }
+      }
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "GetAction"
           operationName "elasticsearch.query"

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5/src/test/groovy/Elasticsearch5TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5/src/test/groovy/Elasticsearch5TransportClientTest.groovy
@@ -86,8 +86,8 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
     status.name() == "GREEN"
 
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "ClusterHealthAction"
           operationName "elasticsearch.query"
@@ -117,8 +117,8 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
 
     and:
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "GetAction"
           operationName "elasticsearch.query"
@@ -182,16 +182,9 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
     result.index == indexName
 
     and:
-    // IndexAction and PutMappingAction run in separate threads and order in which
-    // these spans are closed is not defined. So we force the order if it is wrong.
-    if (TEST_WRITER[2][0].resourceName.toString() == "IndexAction") {
-      def tmp = TEST_WRITER[2]
-      TEST_WRITER[2] = TEST_WRITER[3]
-      TEST_WRITER[3] = tmp
-    }
     assertTraces(5) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "CreateIndexAction"
           operationName "elasticsearch.query"
@@ -210,8 +203,8 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
           }
         }
       }
-      trace(1, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "GetAction"
           operationName "elasticsearch.query"
@@ -233,24 +226,8 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
           }
         }
       }
-      trace(2, 1) {
-        span(0) {
-          serviceName "elasticsearch"
-          resourceName "PutMappingAction"
-          operationName "elasticsearch.query"
-          spanType DDSpanTypes.ELASTICSEARCH
-          tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "elasticsearch"
-            "elasticsearch.action" "PutMappingAction"
-            "elasticsearch.request" "PutMappingRequest"
-            defaultTags()
-          }
-        }
-      }
-      trace(3, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "IndexAction"
           operationName "elasticsearch.query"
@@ -274,8 +251,24 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
           }
         }
       }
-      trace(4, 1) {
-        span(0) {
+      trace(1) {
+        span {
+          serviceName "elasticsearch"
+          resourceName "PutMappingAction"
+          operationName "elasticsearch.query"
+          spanType DDSpanTypes.ELASTICSEARCH
+          tags {
+            "$Tags.COMPONENT" "elasticsearch-java"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
+            "elasticsearch.action" "PutMappingAction"
+            "elasticsearch.request" "PutMappingRequest"
+            defaultTags()
+          }
+        }
+      }
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "GetAction"
           operationName "elasticsearch.query"

--- a/dd-java-agent/instrumentation/elasticsearch/transport-6/src/test/groovy/Elasticsearch6NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-6/src/test/groovy/Elasticsearch6NodeClientTest.groovy
@@ -67,8 +67,8 @@ class Elasticsearch6NodeClientTest extends AgentTestRunner {
     status.name() == "GREEN"
 
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "ClusterHealthAction"
           operationName "elasticsearch.query"
@@ -95,8 +95,8 @@ class Elasticsearch6NodeClientTest extends AgentTestRunner {
 
     and:
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "GetAction"
           operationName "elasticsearch.query"
@@ -160,16 +160,9 @@ class Elasticsearch6NodeClientTest extends AgentTestRunner {
     result.index == indexName
 
     and:
-    // IndexAction and PutMappingAction run in separate threads and order in which
-    // these spans are closed is not defined. So we force the order if it is wrong.
-    if (TEST_WRITER[2][0].resourceName.toString() == "IndexAction") {
-      def tmp = TEST_WRITER[2]
-      TEST_WRITER[2] = TEST_WRITER[3]
-      TEST_WRITER[3] = tmp
-    }
     assertTraces(5) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "CreateIndexAction"
           operationName "elasticsearch.query"
@@ -185,8 +178,8 @@ class Elasticsearch6NodeClientTest extends AgentTestRunner {
           }
         }
       }
-      trace(1, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "GetAction"
           operationName "elasticsearch.query"
@@ -205,24 +198,8 @@ class Elasticsearch6NodeClientTest extends AgentTestRunner {
           }
         }
       }
-      trace(2, 1) {
-        span(0) {
-          serviceName "elasticsearch"
-          resourceName "PutMappingAction"
-          operationName "elasticsearch.query"
-          spanType DDSpanTypes.ELASTICSEARCH
-          tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "elasticsearch"
-            "elasticsearch.action" "PutMappingAction"
-            "elasticsearch.request" "PutMappingRequest"
-            defaultTags()
-          }
-        }
-      }
-      trace(3, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "IndexAction"
           operationName "elasticsearch.query"
@@ -244,8 +221,24 @@ class Elasticsearch6NodeClientTest extends AgentTestRunner {
           }
         }
       }
-      trace(4, 1) {
-        span(0) {
+      trace(1) {
+        span {
+          serviceName "elasticsearch"
+          resourceName "PutMappingAction"
+          operationName "elasticsearch.query"
+          spanType DDSpanTypes.ELASTICSEARCH
+          tags {
+            "$Tags.COMPONENT" "elasticsearch-java"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
+            "elasticsearch.action" "PutMappingAction"
+            "elasticsearch.request" "PutMappingRequest"
+            defaultTags()
+          }
+        }
+      }
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "GetAction"
           operationName "elasticsearch.query"

--- a/dd-java-agent/instrumentation/elasticsearch/transport-6/src/test/groovy/Elasticsearch6TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-6/src/test/groovy/Elasticsearch6TransportClientTest.groovy
@@ -22,7 +22,7 @@ import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
 @Retry(count = 3, delay = 1000, mode = Retry.Mode.SETUP_FEATURE_CLEANUP)
 class Elasticsearch6TransportClientTest extends AgentTestRunner {
   public static final long TIMEOUT = 10000; // 10 seconds
-  
+
   @Shared
   TransportAddress tcpPublishAddress
   @Shared
@@ -47,7 +47,7 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
     testNode = new Node(InternalSettingsPreparer.prepareEnvironment(settings, null), [Netty4Plugin])
     testNode.start()
     tcpPublishAddress = testNode.injector().getInstance(TransportService).boundAddress().publishAddress()
-    
+
     client = new PreBuiltTransportClient(
       Settings.builder()
       // Since we use listeners to close spans this should make our span closing deterministic which is good for tests
@@ -82,8 +82,8 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
     status.name() == "GREEN"
 
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "ClusterHealthAction"
           operationName "elasticsearch.query"
@@ -113,8 +113,8 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
 
     and:
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "GetAction"
           operationName "elasticsearch.query"
@@ -178,16 +178,9 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
     result.index == indexName
 
     and:
-    // IndexAction and PutMappingAction run in separate threads and order in which
-    // these spans are closed is not defined. So we force the order if it is wrong.
-    if (TEST_WRITER[2][0].resourceName.toString() == "IndexAction") {
-      def tmp = TEST_WRITER[2]
-      TEST_WRITER[2] = TEST_WRITER[3]
-      TEST_WRITER[3] = tmp
-    }
     assertTraces(5) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "CreateIndexAction"
           operationName "elasticsearch.query"
@@ -206,8 +199,8 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
           }
         }
       }
-      trace(1, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "GetAction"
           operationName "elasticsearch.query"
@@ -229,24 +222,8 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
           }
         }
       }
-      trace(2, 1) {
-        span(0) {
-          serviceName "elasticsearch"
-          resourceName "PutMappingAction"
-          operationName "elasticsearch.query"
-          spanType DDSpanTypes.ELASTICSEARCH
-          tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "elasticsearch"
-            "elasticsearch.action" "PutMappingAction"
-            "elasticsearch.request" "PutMappingRequest"
-            defaultTags()
-          }
-        }
-      }
-      trace(3, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "IndexAction"
           operationName "elasticsearch.query"
@@ -271,8 +248,24 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
           }
         }
       }
-      trace(4, 1) {
-        span(0) {
+      trace(1) {
+        span {
+          serviceName "elasticsearch"
+          resourceName "PutMappingAction"
+          operationName "elasticsearch.query"
+          spanType DDSpanTypes.ELASTICSEARCH
+          tags {
+            "$Tags.COMPONENT" "elasticsearch-java"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
+            "elasticsearch.action" "PutMappingAction"
+            "elasticsearch.request" "PutMappingRequest"
+            defaultTags()
+          }
+        }
+      }
+      trace(1) {
+        span {
           serviceName "elasticsearch"
           resourceName "GetAction"
           operationName "elasticsearch.query"

--- a/dd-java-agent/instrumentation/finatra-2.9/src/latestDepTest/groovy/FinatraServer270Test.groovy
+++ b/dd-java-agent/instrumentation/finatra-2.9/src/latestDepTest/groovy/FinatraServer270Test.groovy
@@ -90,9 +90,9 @@ class FinatraServer270Test extends HttpServerTest<HttpServer> {
     return "finatra.request"
   }
 
-  void handlerSpan(TraceAssert trace, int index, Object parent, ServerEndpoint endpoint = SUCCESS) {
+  void handlerSpan(TraceAssert trace, Object parent, ServerEndpoint endpoint = SUCCESS) {
     def errorEndpoint = endpoint == EXCEPTION || endpoint == ERROR
-    trace.span(index) {
+    trace.span {
       serviceName expectedServiceName()
       operationName "finatra.controller"
       resourceName "FinatraController"

--- a/dd-java-agent/instrumentation/finatra-2.9/src/test/groovy/FinatraServerTest.groovy
+++ b/dd-java-agent/instrumentation/finatra-2.9/src/test/groovy/FinatraServerTest.groovy
@@ -2,11 +2,11 @@ import com.twitter.finatra.http.HttpServer
 import com.twitter.util.Await
 import com.twitter.util.Closable
 import com.twitter.util.Duration
-import datadog.trace.core.DDSpan
 import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.agent.test.base.HttpServerTest
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
+import datadog.trace.core.DDSpan
 import datadog.trace.instrumentation.finatra.FinatraDecorator
 
 import java.util.concurrent.TimeoutException
@@ -72,9 +72,9 @@ class FinatraServerTest extends HttpServerTest<HttpServer> {
     return "finatra.request"
   }
 
-  void handlerSpan(TraceAssert trace, int index, Object parent, ServerEndpoint endpoint = SUCCESS) {
+  void handlerSpan(TraceAssert trace, Object parent, ServerEndpoint endpoint = SUCCESS) {
     def errorEndpoint = endpoint == EXCEPTION || endpoint == ERROR
-    trace.span(index) {
+    trace.span {
       serviceName expectedServiceName()
       operationName "finatra.controller"
       resourceName "FinatraController"

--- a/dd-java-agent/instrumentation/glassfish/src/test/groovy/GlassFishServerTest.groovy
+++ b/dd-java-agent/instrumentation/glassfish/src/test/groovy/GlassFishServerTest.groovy
@@ -87,8 +87,8 @@ class GlassFishServerTest extends HttpServerTest<GlassFish> {
   }
 
   @Override
-  void serverSpan(TraceAssert trace, int index, BigInteger traceID = null, BigInteger parentID = null, String method = "GET", ServerEndpoint endpoint = SUCCESS) {
-    trace.span(index) {
+  void serverSpan(TraceAssert trace, BigInteger traceID = null, BigInteger parentID = null, String method = "GET", ServerEndpoint endpoint = SUCCESS) {
+    trace.span {
       serviceName expectedServiceName()
       operationName expectedOperationName()
       resourceName endpoint.status == 404 ? "404" : "$method ${endpoint.resolve(address).path}"

--- a/dd-java-agent/instrumentation/google-http-client/src/test/groovy/AbstractGoogleHttpClientTest.groovy
+++ b/dd-java-agent/instrumentation/google-http-client/src/test/groovy/AbstractGoogleHttpClientTest.groovy
@@ -30,7 +30,8 @@ abstract class AbstractGoogleHttpClientTest extends HttpClientTest {
     // and lowercase all other headers
     def ci = request.getHeaders().getClassInfo()
     request.getHeaders().putAll(headers.collectEntries { name, value
-           -> [(name) : (ci.getFieldInfo(name) != null ? [value] : value.toLowerCase())]})
+      -> [(name): (ci.getFieldInfo(name) != null ? [value] : value.toLowerCase())]
+    })
 
     request.setThrowExceptionOnExecuteError(throwExceptionOnError)
 
@@ -63,9 +64,8 @@ abstract class AbstractGoogleHttpClientTest extends HttpClientTest {
     then:
     status == 500
     assertTraces(2) {
-      server.distributedRequestTrace(it, 0, trace(1).last())
-      trace(1, size(1)) {
-        span(0) {
+      trace(size(1)) {
+        span {
           resourceName "$method $uri.path"
           spanType DDSpanTypes.HTTP_CLIENT
           errored true
@@ -82,6 +82,7 @@ abstract class AbstractGoogleHttpClientTest extends HttpClientTest {
           }
         }
       }
+      server.distributedRequestTrace(it, trace(0).last())
     }
 
     where:

--- a/dd-java-agent/instrumentation/grizzly-client-1.9/src/test/groovy/GrizzlyAsyncHttpClientTest.groovy
+++ b/dd-java-agent/instrumentation/grizzly-client-1.9/src/test/groovy/GrizzlyAsyncHttpClientTest.groovy
@@ -1,5 +1,3 @@
-
-
 import com.ning.http.client.AsyncCompletionHandler
 import com.ning.http.client.AsyncHttpClient
 import com.ning.http.client.Request

--- a/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/test/groovy/GrizzlyFilterchainServerTest.groovy
+++ b/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/test/groovy/GrizzlyFilterchainServerTest.groovy
@@ -96,11 +96,11 @@ class GrizzlyFilterchainServerTest extends HttpServerTest<HttpServer> {
 
   FilterChain setUpFilterChain() {
     return FilterChainBuilder.stateless()
-              .add(createTransportFilter())
-              .add(createIdleTimeoutFilter())
-              .add(new HttpServerFilter())
-              .add(new LastFilter())
-              .build()
+      .add(createTransportFilter())
+      .add(createIdleTimeoutFilter())
+      .add(new HttpServerFilter())
+      .add(new LastFilter())
+      .build()
   }
 
   TransportFilter createTransportFilter() {
@@ -122,8 +122,8 @@ class GrizzlyFilterchainServerTest extends HttpServerTest<HttpServer> {
           HttpRequestPacket request = (HttpRequestPacket) httpContent.getHttpHeader()
           ResponseParameters responseParameters = buildResponse(request)
           HttpResponsePacket.Builder builder = HttpResponsePacket.builder(request)
-                            .status(responseParameters.getStatus())
-                            .header("Content-Length", valueOf(responseParameters.getResponseBody().length))
+            .status(responseParameters.getStatus())
+            .header("Content-Length", valueOf(responseParameters.getResponseBody().length))
           responseParameters.fillHeaders(builder)
           HttpResponsePacket responsePacket = builder.build()
           controller(responseParameters.getEndpoint()) {

--- a/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcStreamingTest.groovy
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcStreamingTest.groovy
@@ -111,38 +111,8 @@ class GrpcStreamingTest extends AgentTestRunner {
     clientReceived == serverRange.collect { clientRange.collect { "call $it" } }.flatten().sort()
 
     assertTraces(2) {
-      trace(0, clientMessageCount + 1) {
-        span(0) {
-          operationName "grpc.server"
-          resourceName "example.Greeter/Conversation"
-          spanType DDSpanTypes.RPC
-          childOf trace(1).get(0)
-          errored false
-          tags {
-            "$Tags.COMPONENT" "grpc-server"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
-            "status.code" "OK"
-            defaultTags(true)
-          }
-        }
-        clientRange.each {
-          span(it) {
-            operationName "grpc.message"
-            resourceName "grpc.message"
-            spanType DDSpanTypes.RPC
-            childOf span(0)
-            errored false
-            tags {
-              "$Tags.COMPONENT" "grpc-server"
-              "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
-              "message.type" "example.Helloworld\$Response"
-              defaultTags()
-            }
-          }
-        }
-      }
-      trace(1, (clientMessageCount * serverMessageCount) + 1) {
-        span(0) {
+      trace((clientMessageCount * serverMessageCount) + 1) {
+        span {
           operationName "grpc.client"
           resourceName "example.Greeter/Conversation"
           spanType DDSpanTypes.RPC
@@ -156,7 +126,7 @@ class GrpcStreamingTest extends AgentTestRunner {
           }
         }
         (1..(clientMessageCount * serverMessageCount)).each {
-          span(it) {
+          span {
             operationName "grpc.message"
             resourceName "grpc.message"
             spanType DDSpanTypes.RPC
@@ -165,6 +135,36 @@ class GrpcStreamingTest extends AgentTestRunner {
             tags {
               "$Tags.COMPONENT" "grpc-client"
               "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+              "message.type" "example.Helloworld\$Response"
+              defaultTags()
+            }
+          }
+        }
+      }
+      trace(clientMessageCount + 1) {
+        span {
+          operationName "grpc.server"
+          resourceName "example.Greeter/Conversation"
+          spanType DDSpanTypes.RPC
+          childOf trace(0).get(0)
+          errored false
+          tags {
+            "$Tags.COMPONENT" "grpc-server"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
+            "status.code" "OK"
+            defaultTags(true)
+          }
+        }
+        clientRange.each {
+          span {
+            operationName "grpc.message"
+            resourceName "grpc.message"
+            spanType DDSpanTypes.RPC
+            childOf span(0)
+            errored false
+            tags {
+              "$Tags.COMPONENT" "grpc-server"
+              "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
               "message.type" "example.Helloworld\$Response"
               defaultTags()
             }

--- a/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcTest.groovy
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcTest.groovy
@@ -57,37 +57,9 @@ class GrpcTest extends AgentTestRunner {
     then:
     response.message == "Hello $name"
     assertTraces(2) {
-      trace(0, 2) {
-        span(0) {
-          operationName "grpc.server"
-          resourceName "example.Greeter/SayHello"
-          spanType DDSpanTypes.RPC
-          childOf trace(1).get(1)
-          errored false
-          tags {
-            "$Tags.COMPONENT" "grpc-server"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
-            "status.code" "OK"
-            defaultTags(true)
-          }
-        }
-        span(1) {
-          operationName "grpc.message"
-          resourceName "grpc.message"
-          spanType DDSpanTypes.RPC
-          childOf span(0)
-          errored false
-          tags {
-            "$Tags.COMPONENT" "grpc-server"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
-            "message.type" "example.Helloworld\$Request"
-            defaultTags()
-          }
-        }
-      }
-      trace(1, 3) {
-        basicSpan(it, 0, "parent")
-        span(1) {
+      trace(3) {
+        basicSpan(it, "parent")
+        span {
           operationName "grpc.client"
           resourceName "example.Greeter/SayHello"
           spanType DDSpanTypes.RPC
@@ -100,7 +72,7 @@ class GrpcTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(2) {
+        span {
           operationName "grpc.message"
           resourceName "grpc.message"
           spanType DDSpanTypes.RPC
@@ -110,6 +82,34 @@ class GrpcTest extends AgentTestRunner {
             "$Tags.COMPONENT" "grpc-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "message.type" "example.Helloworld\$Response"
+            defaultTags()
+          }
+        }
+      }
+      trace(2) {
+        span {
+          operationName "grpc.server"
+          resourceName "example.Greeter/SayHello"
+          spanType DDSpanTypes.RPC
+          childOf trace(0).get(1)
+          errored false
+          tags {
+            "$Tags.COMPONENT" "grpc-server"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
+            "status.code" "OK"
+            defaultTags(true)
+          }
+        }
+        span {
+          operationName "grpc.message"
+          resourceName "grpc.message"
+          spanType DDSpanTypes.RPC
+          childOf span(0)
+          errored false
+          tags {
+            "$Tags.COMPONENT" "grpc-server"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
+            "message.type" "example.Helloworld\$Request"
             defaultTags()
           }
         }
@@ -146,12 +146,28 @@ class GrpcTest extends AgentTestRunner {
     thrown StatusRuntimeException
 
     assertTraces(2) {
-      trace(0, 2) {
-        span(0) {
+      trace(1) {
+        span {
+          operationName "grpc.client"
+          resourceName "example.Greeter/SayHello"
+          spanType DDSpanTypes.RPC
+          parent()
+          errored true
+          tags {
+            "$Tags.COMPONENT" "grpc-client"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "status.code" "${status.code.name()}"
+            "status.description" description
+            defaultTags()
+          }
+        }
+      }
+      trace(2) {
+        span {
           operationName "grpc.server"
           resourceName "example.Greeter/SayHello"
           spanType DDSpanTypes.RPC
-          childOf trace(1).get(0)
+          childOf trace(0).get(0)
           errored true
           tags {
             "$Tags.COMPONENT" "grpc-server"
@@ -164,7 +180,7 @@ class GrpcTest extends AgentTestRunner {
             defaultTags(true)
           }
         }
-        span(1) {
+        span {
           operationName "grpc.message"
           resourceName "grpc.message"
           spanType DDSpanTypes.RPC
@@ -174,22 +190,6 @@ class GrpcTest extends AgentTestRunner {
             "$Tags.COMPONENT" "grpc-server"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
             "message.type" "example.Helloworld\$Request"
-            defaultTags()
-          }
-        }
-      }
-      trace(1, 1) {
-        span(0) {
-          operationName "grpc.client"
-          resourceName "example.Greeter/SayHello"
-          spanType DDSpanTypes.RPC
-          parent()
-          errored true
-          tags {
-            "$Tags.COMPONENT" "grpc-client"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "status.code" "${status.code.name()}"
-            "status.description" description
             defaultTags()
           }
         }
@@ -232,36 +232,8 @@ class GrpcTest extends AgentTestRunner {
     thrown StatusRuntimeException
 
     assertTraces(2) {
-      trace(0, 2) {
-        span(0) {
-          operationName "grpc.server"
-          resourceName "example.Greeter/SayHello"
-          spanType DDSpanTypes.RPC
-          childOf trace(1).get(0)
-          errored true
-          tags {
-            "$Tags.COMPONENT" "grpc-server"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
-            errorTags error.class, error.message
-            defaultTags(true)
-          }
-        }
-        span(1) {
-          operationName "grpc.message"
-          resourceName "grpc.message"
-          spanType DDSpanTypes.RPC
-          childOf span(0)
-          errored false
-          tags {
-            "$Tags.COMPONENT" "grpc-server"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
-            "message.type" "example.Helloworld\$Request"
-            defaultTags()
-          }
-        }
-      }
-      trace(1, 1) {
-        span(0) {
+      trace(1) {
+        span {
           operationName "grpc.client"
           resourceName "example.Greeter/SayHello"
           spanType DDSpanTypes.RPC
@@ -271,6 +243,34 @@ class GrpcTest extends AgentTestRunner {
             "$Tags.COMPONENT" "grpc-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "status.code" "UNKNOWN"
+            defaultTags()
+          }
+        }
+      }
+      trace(2) {
+        span {
+          operationName "grpc.server"
+          resourceName "example.Greeter/SayHello"
+          spanType DDSpanTypes.RPC
+          childOf trace(0).get(0)
+          errored true
+          tags {
+            "$Tags.COMPONENT" "grpc-server"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
+            errorTags error.class, error.message
+            defaultTags(true)
+          }
+        }
+        span {
+          operationName "grpc.message"
+          resourceName "grpc.message"
+          spanType DDSpanTypes.RPC
+          childOf span(0)
+          errored false
+          tags {
+            "$Tags.COMPONENT" "grpc-server"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
+            "message.type" "example.Helloworld\$Request"
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/hibernate/core-3.3/src/test/groovy/CriteriaTest.groovy
+++ b/dd-java-agent/instrumentation/hibernate/core-3.3/src/test/groovy/CriteriaTest.groovy
@@ -20,8 +20,8 @@ class CriteriaTest extends AbstractHibernateTest {
 
     expect:
     assertTraces(1) {
-      trace(0, 4) {
-        span(0) {
+      trace(4) {
+        span {
           serviceName "hibernate"
           resourceName "hibernate.session"
           operationName "hibernate.session"
@@ -33,7 +33,7 @@ class CriteriaTest extends AbstractHibernateTest {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           serviceName "hibernate"
           resourceName "hibernate.transaction.commit"
           operationName "hibernate.transaction.commit"
@@ -45,7 +45,7 @@ class CriteriaTest extends AbstractHibernateTest {
             defaultTags()
           }
         }
-        span(2) {
+        span {
           serviceName "hibernate"
           resourceName "hibernate.criteria.$methodName"
           operationName "hibernate.criteria.$methodName"
@@ -57,7 +57,7 @@ class CriteriaTest extends AbstractHibernateTest {
             defaultTags()
           }
         }
-        span(3) {
+        span {
           serviceName "h2"
           spanType "sql"
           childOf span(2)

--- a/dd-java-agent/instrumentation/hibernate/core-3.3/src/test/groovy/QueryTest.groovy
+++ b/dd-java-agent/instrumentation/hibernate/core-3.3/src/test/groovy/QueryTest.groovy
@@ -25,8 +25,8 @@ class QueryTest extends AbstractHibernateTest {
     expect:
     assertTraces(requiresTransaction ? 1 : 2) {
       // With Transaction
-      trace(0, 4) {
-        span(0) {
+      trace(4) {
+        span {
           serviceName "hibernate"
           resourceName "hibernate.session"
           operationName "hibernate.session"
@@ -38,7 +38,7 @@ class QueryTest extends AbstractHibernateTest {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           serviceName "hibernate"
           resourceName "hibernate.transaction.commit"
           operationName "hibernate.transaction.commit"
@@ -50,7 +50,7 @@ class QueryTest extends AbstractHibernateTest {
             defaultTags()
           }
         }
-        span(2) {
+        span {
           serviceName "hibernate"
           resourceName "$resource"
           operationName "hibernate.$queryMethodName"
@@ -62,7 +62,7 @@ class QueryTest extends AbstractHibernateTest {
             defaultTags()
           }
         }
-        span(3) {
+        span {
           serviceName "h2"
           spanType "sql"
           childOf span(2)
@@ -79,8 +79,8 @@ class QueryTest extends AbstractHibernateTest {
       }
       if (!requiresTransaction) {
         // Without Transaction
-        trace(1, 3) {
-          span(0) {
+        trace(3) {
+          span {
             serviceName "hibernate"
             resourceName "hibernate.session"
             operationName "hibernate.session"
@@ -92,7 +92,7 @@ class QueryTest extends AbstractHibernateTest {
               defaultTags()
             }
           }
-          span(1) {
+          span {
             serviceName "hibernate"
             resourceName "$resource"
             operationName "hibernate.$queryMethodName"
@@ -104,7 +104,7 @@ class QueryTest extends AbstractHibernateTest {
               defaultTags()
             }
           }
-          span(2) {
+          span {
             serviceName "h2"
             spanType "sql"
             childOf span(1)
@@ -161,8 +161,8 @@ class QueryTest extends AbstractHibernateTest {
 
     expect:
     assertTraces(1) {
-      trace(0, 4) {
-        span(0) {
+      trace(4) {
+        span {
           serviceName "hibernate"
           resourceName "hibernate.session"
           operationName "hibernate.session"
@@ -174,7 +174,7 @@ class QueryTest extends AbstractHibernateTest {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           serviceName "hibernate"
           resourceName "hibernate.transaction.commit"
           operationName "hibernate.transaction.commit"
@@ -186,7 +186,7 @@ class QueryTest extends AbstractHibernateTest {
             defaultTags()
           }
         }
-        span(2) {
+        span {
           serviceName "hibernate"
           resourceName "from Value"
           operationName "hibernate.iterate"
@@ -198,7 +198,7 @@ class QueryTest extends AbstractHibernateTest {
             defaultTags()
           }
         }
-        span(3) {
+        span {
           serviceName "h2"
           spanType "sql"
           childOf span(2)

--- a/dd-java-agent/instrumentation/hibernate/core-3.3/src/test/groovy/SessionTest.groovy
+++ b/dd-java-agent/instrumentation/hibernate/core-3.3/src/test/groovy/SessionTest.groovy
@@ -40,8 +40,8 @@ class SessionTest extends AbstractHibernateTest {
     expect:
     assertTraces(sessionImplementations.size()) {
       for (int i = 0; i < sessionImplementations.size(); i++) {
-        trace(i, 4) {
-          span(0) {
+        trace(4) {
+          span {
             serviceName "hibernate"
             resourceName "hibernate.session"
             operationName "hibernate.session"
@@ -53,7 +53,7 @@ class SessionTest extends AbstractHibernateTest {
               defaultTags()
             }
           }
-          span(1) {
+          span {
             serviceName "hibernate"
             resourceName "hibernate.transaction.commit"
             operationName "hibernate.transaction.commit"
@@ -65,7 +65,7 @@ class SessionTest extends AbstractHibernateTest {
               defaultTags()
             }
           }
-          span(2) {
+          span {
             serviceName "hibernate"
             resourceName resource
             operationName "hibernate.$methodName"
@@ -77,7 +77,7 @@ class SessionTest extends AbstractHibernateTest {
               defaultTags()
             }
           }
-          span(3) {
+          span {
             serviceName "h2"
             spanType "sql"
             childOf span(2)
@@ -126,8 +126,8 @@ class SessionTest extends AbstractHibernateTest {
 
     expect:
     assertTraces(1) {
-      trace(0, 4) {
-        span(0) {
+      trace(4) {
+        span {
           serviceName "hibernate"
           resourceName "hibernate.session"
           operationName "hibernate.session"
@@ -139,7 +139,7 @@ class SessionTest extends AbstractHibernateTest {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           serviceName "hibernate"
           resourceName "hibernate.transaction.commit"
           operationName "hibernate.transaction.commit"
@@ -151,7 +151,7 @@ class SessionTest extends AbstractHibernateTest {
             defaultTags()
           }
         }
-        span(2) {
+        span {
           serviceName "h2"
           spanType "sql"
           childOf span(1)
@@ -165,7 +165,7 @@ class SessionTest extends AbstractHibernateTest {
             defaultTags()
           }
         }
-        span(3) {
+        span {
           serviceName "hibernate"
           resourceName resource
           operationName "hibernate.$methodName"
@@ -216,8 +216,8 @@ class SessionTest extends AbstractHibernateTest {
 
     expect:
     assertTraces(1) {
-      trace(0, 5) {
-        span(0) {
+      trace(5) {
+        span {
           serviceName "hibernate"
           resourceName "hibernate.session"
           operationName "hibernate.session"
@@ -229,7 +229,7 @@ class SessionTest extends AbstractHibernateTest {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           serviceName "hibernate"
           resourceName "hibernate.transaction.commit"
           operationName "hibernate.transaction.commit"
@@ -241,7 +241,7 @@ class SessionTest extends AbstractHibernateTest {
             defaultTags()
           }
         }
-        span(2) {
+        span {
           serviceName "h2"
           spanType "sql"
           childOf span(1)
@@ -255,7 +255,7 @@ class SessionTest extends AbstractHibernateTest {
             defaultTags()
           }
         }
-        span(3) {
+        span {
           serviceName "hibernate"
           resourceName resource
           operationName "hibernate.$methodName"
@@ -267,7 +267,7 @@ class SessionTest extends AbstractHibernateTest {
             defaultTags()
           }
         }
-        span(4) {
+        span {
           serviceName "h2"
           spanType "sql"
           childOf span(3)
@@ -317,8 +317,8 @@ class SessionTest extends AbstractHibernateTest {
 
     expect:
     assertTraces(1) {
-      trace(0, 3) {
-        span(0) {
+      trace(3) {
+        span {
           serviceName "hibernate"
           resourceName "hibernate.session"
           operationName "hibernate.session"
@@ -330,7 +330,7 @@ class SessionTest extends AbstractHibernateTest {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           serviceName "hibernate"
           resourceName "hibernate.transaction.commit"
           operationName "hibernate.transaction.commit"
@@ -342,7 +342,7 @@ class SessionTest extends AbstractHibernateTest {
             defaultTags()
           }
         }
-        span(2) {
+        span {
           serviceName "hibernate"
           resourceName "hibernate.replicate"
           operationName "hibernate.replicate"
@@ -379,8 +379,8 @@ class SessionTest extends AbstractHibernateTest {
 
     expect:
     assertTraces(1) {
-      trace(0, 4) {
-        span(0) {
+      trace(4) {
+        span {
           serviceName "hibernate"
           resourceName "hibernate.session"
           operationName "hibernate.session"
@@ -392,7 +392,7 @@ class SessionTest extends AbstractHibernateTest {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           serviceName "hibernate"
           resourceName "hibernate.transaction.commit"
           operationName "hibernate.transaction.commit"
@@ -404,7 +404,7 @@ class SessionTest extends AbstractHibernateTest {
             defaultTags()
           }
         }
-        span(2) {
+        span {
           serviceName "h2"
           spanType "sql"
           childOf span(1)
@@ -418,7 +418,7 @@ class SessionTest extends AbstractHibernateTest {
             defaultTags()
           }
         }
-        span(3) {
+        span {
           serviceName "hibernate"
           resourceName resource
           operationName "hibernate.$methodName"
@@ -477,8 +477,8 @@ class SessionTest extends AbstractHibernateTest {
 
     expect:
     assertTraces(1) {
-      trace(0, 4) {
-        span(0) {
+      trace(4) {
+        span {
           serviceName "hibernate"
           resourceName "hibernate.session"
           operationName "hibernate.session"
@@ -490,7 +490,7 @@ class SessionTest extends AbstractHibernateTest {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           serviceName "hibernate"
           resourceName "hibernate.transaction.commit"
           operationName "hibernate.transaction.commit"
@@ -502,7 +502,7 @@ class SessionTest extends AbstractHibernateTest {
             defaultTags()
           }
         }
-        span(2) {
+        span {
           serviceName "hibernate"
           resourceName "$resource"
           operationName "hibernate.query.list"
@@ -514,7 +514,7 @@ class SessionTest extends AbstractHibernateTest {
             defaultTags()
           }
         }
-        span(3) {
+        span {
           serviceName "h2"
           spanType "sql"
           childOf span(2)
@@ -566,14 +566,14 @@ class SessionTest extends AbstractHibernateTest {
 
     expect:
     assertTraces(1) {
-      trace(0, 11) {
-        span(0) {
+      trace(11) {
+        span {
           operationName "overlapping Sessions"
           tags {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           serviceName "hibernate"
           resourceName "hibernate.session"
           operationName "hibernate.session"
@@ -585,7 +585,7 @@ class SessionTest extends AbstractHibernateTest {
             defaultTags()
           }
         }
-        span(2) {
+        span {
           serviceName "hibernate"
           resourceName "hibernate.session"
           operationName "hibernate.session"
@@ -597,7 +597,7 @@ class SessionTest extends AbstractHibernateTest {
             defaultTags()
           }
         }
-        span(3) {
+        span {
           serviceName "hibernate"
           resourceName "hibernate.transaction.commit"
           operationName "hibernate.transaction.commit"
@@ -609,7 +609,7 @@ class SessionTest extends AbstractHibernateTest {
             defaultTags()
           }
         }
-        span(4) {
+        span {
           serviceName "h2"
           spanType "sql"
           childOf span(3)
@@ -623,7 +623,7 @@ class SessionTest extends AbstractHibernateTest {
             defaultTags()
           }
         }
-        span(5) {
+        span {
           serviceName "h2"
           spanType "sql"
           childOf span(3)
@@ -637,7 +637,7 @@ class SessionTest extends AbstractHibernateTest {
             defaultTags()
           }
         }
-        span(6) {
+        span {
           serviceName "hibernate"
           resourceName "hibernate.session"
           operationName "hibernate.session"
@@ -649,7 +649,7 @@ class SessionTest extends AbstractHibernateTest {
             defaultTags()
           }
         }
-        span(7) {
+        span {
           serviceName "hibernate"
           resourceName "Value"
           operationName "hibernate.delete"
@@ -661,7 +661,7 @@ class SessionTest extends AbstractHibernateTest {
             defaultTags()
           }
         }
-        span(8) {
+        span {
           serviceName "hibernate"
           resourceName "Value"
           operationName "hibernate.save"
@@ -673,7 +673,7 @@ class SessionTest extends AbstractHibernateTest {
             defaultTags()
           }
         }
-        span(9) {
+        span {
           serviceName "hibernate"
           resourceName "Value"
           operationName "hibernate.insert"
@@ -685,7 +685,7 @@ class SessionTest extends AbstractHibernateTest {
             defaultTags()
           }
         }
-        span(10) {
+        span {
           serviceName "hibernate"
           resourceName "Value"
           operationName "hibernate.save"

--- a/dd-java-agent/instrumentation/hibernate/core-4.0/src/test/groovy/CriteriaTest.groovy
+++ b/dd-java-agent/instrumentation/hibernate/core-4.0/src/test/groovy/CriteriaTest.groovy
@@ -20,8 +20,8 @@ class CriteriaTest extends AbstractHibernateTest {
 
     expect:
     assertTraces(1) {
-      trace(0, 4) {
-        span(0) {
+      trace(4) {
+        span {
           serviceName "hibernate"
           resourceName "hibernate.session"
           operationName "hibernate.session"
@@ -33,7 +33,7 @@ class CriteriaTest extends AbstractHibernateTest {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           serviceName "hibernate"
           resourceName "hibernate.transaction.commit"
           operationName "hibernate.transaction.commit"
@@ -45,7 +45,7 @@ class CriteriaTest extends AbstractHibernateTest {
             defaultTags()
           }
         }
-        span(2) {
+        span {
           serviceName "hibernate"
           resourceName "hibernate.criteria.$methodName"
           operationName "hibernate.criteria.$methodName"
@@ -57,7 +57,7 @@ class CriteriaTest extends AbstractHibernateTest {
             defaultTags()
           }
         }
-        span(3) {
+        span {
           serviceName "h2"
           spanType "sql"
           childOf span(2)

--- a/dd-java-agent/instrumentation/hibernate/core-4.0/src/test/groovy/QueryTest.groovy
+++ b/dd-java-agent/instrumentation/hibernate/core-4.0/src/test/groovy/QueryTest.groovy
@@ -25,8 +25,8 @@ class QueryTest extends AbstractHibernateTest {
     expect:
     assertTraces(requiresTransaction ? 1 : 2) {
       // With Transaction
-      trace(0, 4) {
-        span(0) {
+      trace(4) {
+        span {
           serviceName "hibernate"
           resourceName "hibernate.session"
           operationName "hibernate.session"
@@ -38,7 +38,7 @@ class QueryTest extends AbstractHibernateTest {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           serviceName "hibernate"
           resourceName "hibernate.transaction.commit"
           operationName "hibernate.transaction.commit"
@@ -50,7 +50,7 @@ class QueryTest extends AbstractHibernateTest {
             defaultTags()
           }
         }
-        span(2) {
+        span {
           serviceName "hibernate"
           resourceName "$resource"
           operationName "hibernate.$queryMethodName"
@@ -62,7 +62,7 @@ class QueryTest extends AbstractHibernateTest {
             defaultTags()
           }
         }
-        span(3) {
+        span {
           serviceName "h2"
           spanType "sql"
           childOf span(2)
@@ -79,8 +79,8 @@ class QueryTest extends AbstractHibernateTest {
       }
       if (!requiresTransaction) {
         // Without Transaction
-        trace(1, 3) {
-          span(0) {
+        trace(3) {
+          span {
             serviceName "hibernate"
             resourceName "hibernate.session"
             operationName "hibernate.session"
@@ -92,7 +92,7 @@ class QueryTest extends AbstractHibernateTest {
               defaultTags()
             }
           }
-          span(1) {
+          span {
             serviceName "hibernate"
             resourceName "$resource"
             operationName "hibernate.$queryMethodName"
@@ -104,7 +104,7 @@ class QueryTest extends AbstractHibernateTest {
               defaultTags()
             }
           }
-          span(2) {
+          span {
             serviceName "h2"
             spanType "sql"
             childOf span(1)
@@ -161,8 +161,8 @@ class QueryTest extends AbstractHibernateTest {
 
     expect:
     assertTraces(1) {
-      trace(0, 4) {
-        span(0) {
+      trace(4) {
+        span {
           serviceName "hibernate"
           resourceName "hibernate.session"
           operationName "hibernate.session"
@@ -174,7 +174,7 @@ class QueryTest extends AbstractHibernateTest {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           serviceName "hibernate"
           resourceName "hibernate.transaction.commit"
           operationName "hibernate.transaction.commit"
@@ -186,7 +186,7 @@ class QueryTest extends AbstractHibernateTest {
             defaultTags()
           }
         }
-        span(2) {
+        span {
           serviceName "hibernate"
           resourceName "from Value"
           operationName "hibernate.iterate"
@@ -198,7 +198,7 @@ class QueryTest extends AbstractHibernateTest {
             defaultTags()
           }
         }
-        span(3) {
+        span {
           serviceName "h2"
           spanType "sql"
           childOf span(2)

--- a/dd-java-agent/instrumentation/hibernate/core-4.0/src/test/groovy/SessionTest.groovy
+++ b/dd-java-agent/instrumentation/hibernate/core-4.0/src/test/groovy/SessionTest.groovy
@@ -40,8 +40,8 @@ class SessionTest extends AbstractHibernateTest {
     expect:
     assertTraces(sessionImplementations.size()) {
       for (int i = 0; i < sessionImplementations.size(); i++) {
-        trace(i, 4) {
-          span(0) {
+        trace(4) {
+          span {
             serviceName "hibernate"
             resourceName "hibernate.session"
             operationName "hibernate.session"
@@ -53,7 +53,7 @@ class SessionTest extends AbstractHibernateTest {
               defaultTags()
             }
           }
-          span(1) {
+          span {
             serviceName "hibernate"
             resourceName "hibernate.transaction.commit"
             operationName "hibernate.transaction.commit"
@@ -65,7 +65,7 @@ class SessionTest extends AbstractHibernateTest {
               defaultTags()
             }
           }
-          span(2) {
+          span {
             serviceName "hibernate"
             resourceName resource
             operationName "hibernate.$methodName"
@@ -77,7 +77,7 @@ class SessionTest extends AbstractHibernateTest {
               defaultTags()
             }
           }
-          span(3) {
+          span {
             serviceName "h2"
             spanType "sql"
             childOf span(2)
@@ -140,8 +140,8 @@ class SessionTest extends AbstractHibernateTest {
 
     expect:
     assertTraces(1) {
-      trace(0, 5) {
-        span(0) {
+      trace(5) {
+        span {
           serviceName "hibernate"
           resourceName "hibernate.session"
           operationName "hibernate.session"
@@ -153,7 +153,7 @@ class SessionTest extends AbstractHibernateTest {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           serviceName "hibernate"
           resourceName "hibernate.transaction.commit"
           operationName "hibernate.transaction.commit"
@@ -165,7 +165,7 @@ class SessionTest extends AbstractHibernateTest {
             defaultTags()
           }
         }
-        span(2) {
+        span {
           serviceName "h2"
           spanType "sql"
           childOf span(1)
@@ -179,7 +179,7 @@ class SessionTest extends AbstractHibernateTest {
             defaultTags()
           }
         }
-        span(3) {
+        span {
           serviceName "hibernate"
           resourceName resource
           operationName "hibernate.$methodName"
@@ -191,7 +191,7 @@ class SessionTest extends AbstractHibernateTest {
             defaultTags()
           }
         }
-        span(4) {
+        span {
           serviceName "h2"
           spanType "sql"
           childOf span(3)
@@ -241,8 +241,8 @@ class SessionTest extends AbstractHibernateTest {
 
     expect:
     assertTraces(1) {
-      trace(0, 3) {
-        span(0) {
+      trace(3) {
+        span {
           serviceName "hibernate"
           resourceName "hibernate.session"
           operationName "hibernate.session"
@@ -254,7 +254,7 @@ class SessionTest extends AbstractHibernateTest {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           serviceName "hibernate"
           resourceName "hibernate.transaction.commit"
           operationName "hibernate.transaction.commit"
@@ -266,7 +266,7 @@ class SessionTest extends AbstractHibernateTest {
             defaultTags()
           }
         }
-        span(2) {
+        span {
           serviceName "hibernate"
           resourceName "hibernate.replicate"
           operationName "hibernate.replicate"
@@ -303,8 +303,8 @@ class SessionTest extends AbstractHibernateTest {
 
     expect:
     assertTraces(1) {
-      trace(0, 4) {
-        span(0) {
+      trace(4) {
+        span {
           serviceName "hibernate"
           resourceName "hibernate.session"
           operationName "hibernate.session"
@@ -316,7 +316,7 @@ class SessionTest extends AbstractHibernateTest {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           serviceName "hibernate"
           resourceName "hibernate.transaction.commit"
           operationName "hibernate.transaction.commit"
@@ -328,7 +328,7 @@ class SessionTest extends AbstractHibernateTest {
             defaultTags()
           }
         }
-        span(2) {
+        span {
           serviceName "h2"
           spanType "sql"
           childOf span(1)
@@ -342,7 +342,7 @@ class SessionTest extends AbstractHibernateTest {
             defaultTags()
           }
         }
-        span(3) {
+        span {
           serviceName "hibernate"
           resourceName resource
           operationName "hibernate.$methodName"
@@ -401,8 +401,8 @@ class SessionTest extends AbstractHibernateTest {
 
     expect:
     assertTraces(1) {
-      trace(0, 4) {
-        span(0) {
+      trace(4) {
+        span {
           serviceName "hibernate"
           resourceName "hibernate.session"
           operationName "hibernate.session"
@@ -414,7 +414,7 @@ class SessionTest extends AbstractHibernateTest {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           serviceName "hibernate"
           resourceName "hibernate.transaction.commit"
           operationName "hibernate.transaction.commit"
@@ -426,7 +426,7 @@ class SessionTest extends AbstractHibernateTest {
             defaultTags()
           }
         }
-        span(2) {
+        span {
           serviceName "hibernate"
           resourceName "$resource"
           operationName "hibernate.query.list"
@@ -438,7 +438,7 @@ class SessionTest extends AbstractHibernateTest {
             defaultTags()
           }
         }
-        span(3) {
+        span {
           serviceName "h2"
           spanType "sql"
           childOf span(2)
@@ -489,14 +489,14 @@ class SessionTest extends AbstractHibernateTest {
 
     expect:
     assertTraces(1) {
-      trace(0, 12) {
-        span(0) {
+      trace(12) {
+        span {
           operationName "overlapping Sessions"
           tags {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           serviceName "hibernate"
           resourceName "hibernate.session"
           operationName "hibernate.session"
@@ -508,7 +508,7 @@ class SessionTest extends AbstractHibernateTest {
             defaultTags()
           }
         }
-        span(2) {
+        span {
           serviceName "hibernate"
           resourceName "hibernate.session"
           operationName "hibernate.session"
@@ -520,7 +520,7 @@ class SessionTest extends AbstractHibernateTest {
             defaultTags()
           }
         }
-        span(3) {
+        span {
           serviceName "hibernate"
           resourceName "hibernate.transaction.commit"
           operationName "hibernate.transaction.commit"
@@ -532,7 +532,7 @@ class SessionTest extends AbstractHibernateTest {
             defaultTags()
           }
         }
-        span(4) {
+        span {
           serviceName "h2"
           spanType "sql"
           childOf span(3)
@@ -546,7 +546,7 @@ class SessionTest extends AbstractHibernateTest {
             defaultTags()
           }
         }
-        span(5) {
+        span {
           serviceName "h2"
           spanType "sql"
           childOf span(3)
@@ -560,7 +560,7 @@ class SessionTest extends AbstractHibernateTest {
             defaultTags()
           }
         }
-        span(6) {
+        span {
           serviceName "hibernate"
           resourceName "hibernate.session"
           operationName "hibernate.session"
@@ -572,7 +572,7 @@ class SessionTest extends AbstractHibernateTest {
             defaultTags()
           }
         }
-        span(7) {
+        span {
           serviceName "hibernate"
           resourceName "Value"
           operationName "hibernate.delete"
@@ -584,7 +584,7 @@ class SessionTest extends AbstractHibernateTest {
             defaultTags()
           }
         }
-        span(8) {
+        span {
           serviceName "hibernate"
           resourceName "Value"
           operationName "hibernate.save"
@@ -596,7 +596,7 @@ class SessionTest extends AbstractHibernateTest {
             defaultTags()
           }
         }
-        span(9) {
+        span {
           serviceName "hibernate"
           resourceName "Value"
           operationName "hibernate.insert"
@@ -608,7 +608,7 @@ class SessionTest extends AbstractHibernateTest {
             defaultTags()
           }
         }
-        span(10) {
+        span {
           serviceName "h2"
           spanType "sql"
           childOf span(9)
@@ -622,7 +622,7 @@ class SessionTest extends AbstractHibernateTest {
             defaultTags()
           }
         }
-        span(11) {
+        span {
           serviceName "hibernate"
           resourceName "Value"
           operationName "hibernate.save"

--- a/dd-java-agent/instrumentation/hibernate/core-4.3/src/test/groovy/ProcedureCallTest.groovy
+++ b/dd-java-agent/instrumentation/hibernate/core-4.3/src/test/groovy/ProcedureCallTest.groovy
@@ -63,8 +63,8 @@ class ProcedureCallTest extends AgentTestRunner {
 
     expect:
     assertTraces(1) {
-      trace(0, 4) {
-        span(0) {
+      trace(4) {
+        span {
           serviceName "hibernate"
           resourceName "hibernate.session"
           operationName "hibernate.session"
@@ -76,7 +76,7 @@ class ProcedureCallTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           serviceName "hibernate"
           resourceName "hibernate.transaction.commit"
           operationName "hibernate.transaction.commit"
@@ -88,7 +88,7 @@ class ProcedureCallTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(2) {
+        span {
           serviceName "hibernate"
           resourceName "TEST_PROC"
           operationName "hibernate.procedure.getOutputs"
@@ -100,7 +100,7 @@ class ProcedureCallTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(3) {
+        span {
           serviceName "hsqldb"
           spanType "sql"
           childOf span(2)
@@ -138,8 +138,8 @@ class ProcedureCallTest extends AgentTestRunner {
 
     expect:
     assertTraces(1) {
-      trace(0, 3) {
-        span(0) {
+      trace(3) {
+        span {
           serviceName "hibernate"
           resourceName "hibernate.session"
           operationName "hibernate.session"
@@ -151,7 +151,7 @@ class ProcedureCallTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           serviceName "hibernate"
           resourceName "hibernate.transaction.commit"
           operationName "hibernate.transaction.commit"
@@ -163,7 +163,7 @@ class ProcedureCallTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(2) {
+        span {
           serviceName "hibernate"
           resourceName "TEST_PROC"
           operationName "hibernate.procedure.getOutputs"

--- a/dd-java-agent/instrumentation/hibernate/core-4.3/src/test/groovy/SpringJpaTest.groovy
+++ b/dd-java-agent/instrumentation/hibernate/core-4.3/src/test/groovy/SpringJpaTest.groovy
@@ -27,8 +27,8 @@ class SpringJpaTest extends AgentTestRunner {
     !repo.findAll().iterator().hasNext()
 
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "hsqldb"
           resourceName "select customer0_.id as id1_0_, customer0_.firstName as firstNam2_0_, customer0_.lastName as lastName3_0_ from Customer customer0_"
           spanType "sql"
@@ -56,8 +56,8 @@ class SpringJpaTest extends AgentTestRunner {
     def extraTrace = TEST_WRITER.size() == 2
     assertTraces(extraTrace ? 2 : 1) {
       if (extraTrace) {
-        trace(0, 1) {
-          span(0) {
+        trace(1) {
+          span {
             serviceName "hsqldb"
             resourceName "call next value for hibernate_sequence"
             spanType "sql"
@@ -73,8 +73,8 @@ class SpringJpaTest extends AgentTestRunner {
           }
         }
       }
-      trace(extraTrace ? 1 : 0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "hsqldb"
           resourceName ~/insert into Customer \(.*\) values \(.*, \?, \?\)/
           spanType "sql"
@@ -99,8 +99,8 @@ class SpringJpaTest extends AgentTestRunner {
     then:
     customer.id == savedId
     assertTraces(2) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "hsqldb"
           resourceName "select customer0_.id as id1_0_0_, customer0_.firstName as firstNam2_0_0_, customer0_.lastName as lastName3_0_0_ from Customer customer0_ where customer0_.id=?"
           spanType "sql"
@@ -115,8 +115,8 @@ class SpringJpaTest extends AgentTestRunner {
           }
         }
       }
-      trace(1, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "hsqldb"
           resourceName "update Customer set firstName=?, lastName=? where id=?"
           spanType "sql"
@@ -141,8 +141,8 @@ class SpringJpaTest extends AgentTestRunner {
     customer.id == savedId
     customer.firstName == "Bill"
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "hsqldb"
           resourceName "select customer0_.id as id1_0_, customer0_.firstName as firstNam2_0_, customer0_.lastName as lastName3_0_ from Customer customer0_ where customer0_.lastName=?"
           spanType "sql"
@@ -165,8 +165,8 @@ class SpringJpaTest extends AgentTestRunner {
 
     then:
     assertTraces(2) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "hsqldb"
           resourceName "select customer0_.id as id1_0_0_, customer0_.firstName as firstNam2_0_0_, customer0_.lastName as lastName3_0_0_ from Customer customer0_ where customer0_.id=?"
           spanType "sql"
@@ -181,8 +181,8 @@ class SpringJpaTest extends AgentTestRunner {
           }
         }
       }
-      trace(1, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "hsqldb"
           resourceName "delete from Customer where id=?"
           spanType "sql"

--- a/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionTest.groovy
+++ b/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionTest.groovy
@@ -81,10 +81,10 @@ class HttpUrlConnectionTest extends HttpClientTest {
 
     expect:
     assertTraces(3) {
-      server.distributedRequestTrace(it, 0, TEST_WRITER[2][2])
-      server.distributedRequestTrace(it, 1, TEST_WRITER[2][1])
-      trace(2, 3) {
-        span(0) {
+      server.distributedRequestTrace(it, TEST_WRITER[2][2])
+      server.distributedRequestTrace(it, TEST_WRITER[2][1])
+      trace(3) {
+        span {
           operationName "someTrace"
           parent()
           errored false
@@ -92,7 +92,7 @@ class HttpUrlConnectionTest extends HttpClientTest {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           if (renameService) {
             serviceName "localhost"
           }
@@ -112,7 +112,7 @@ class HttpUrlConnectionTest extends HttpClientTest {
             defaultTags()
           }
         }
-        span(2) {
+        span {
           if (renameService) {
             serviceName "localhost"
           }
@@ -172,8 +172,8 @@ class HttpUrlConnectionTest extends HttpClientTest {
 
     expect:
     assertTraces(1) {
-      trace(0, 3) {
-        span(0) {
+      trace(3) {
+        span {
           operationName "someTrace"
           parent()
           errored false
@@ -181,7 +181,7 @@ class HttpUrlConnectionTest extends HttpClientTest {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           if (renameService) {
             serviceName "localhost"
           }
@@ -201,7 +201,7 @@ class HttpUrlConnectionTest extends HttpClientTest {
             defaultTags()
           }
         }
-        span(2) {
+        span {
           if (renameService) {
             serviceName "localhost"
           }
@@ -246,8 +246,8 @@ class HttpUrlConnectionTest extends HttpClientTest {
 
     expect:
     assertTraces(1) {
-      trace(0, 2) {
-        span(0) {
+      trace(2) {
+        span {
           operationName "someTrace"
           parent()
           errored false
@@ -255,7 +255,7 @@ class HttpUrlConnectionTest extends HttpClientTest {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           if (renameService) {
             serviceName "localhost"
           }
@@ -315,9 +315,9 @@ class HttpUrlConnectionTest extends HttpClientTest {
 
     expect:
     assertTraces(2) {
-      server.distributedRequestTrace(it, 0, TEST_WRITER[1][1])
-      trace(1, 2) {
-        span(0) {
+      server.distributedRequestTrace(it, TEST_WRITER[1][1])
+      trace(2) {
+        span {
           operationName "someTrace"
           parent()
           errored false
@@ -325,7 +325,7 @@ class HttpUrlConnectionTest extends HttpClientTest {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           if (renameService) {
             serviceName "localhost"
           }

--- a/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionTest.groovy
+++ b/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionTest.groovy
@@ -81,8 +81,8 @@ class HttpUrlConnectionTest extends HttpClientTest {
 
     expect:
     assertTraces(3) {
-      server.distributedRequestTrace(it, TEST_WRITER[2][2])
-      server.distributedRequestTrace(it, TEST_WRITER[2][1])
+      server.distributedRequestTrace(it, trace(2)[2])
+      server.distributedRequestTrace(it, trace(2)[1])
       trace(3) {
         span {
           operationName "someTrace"
@@ -315,7 +315,7 @@ class HttpUrlConnectionTest extends HttpClientTest {
 
     expect:
     assertTraces(2) {
-      server.distributedRequestTrace(it, TEST_WRITER[1][1])
+      server.distributedRequestTrace(it, trace(1)[1])
       trace(2) {
         span {
           operationName "someTrace"

--- a/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/UrlConnectionTest.groovy
+++ b/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/UrlConnectionTest.groovy
@@ -30,8 +30,8 @@ class UrlConnectionTest extends AgentTestRunner {
 
     expect:
     assertTraces(1) {
-      trace(0, 2) {
-        span(0) {
+      trace(2) {
+        span {
           operationName "someTrace"
           parent()
           errored true
@@ -40,7 +40,7 @@ class UrlConnectionTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           if (renameService) {
             serviceName "localhost"
           }
@@ -87,8 +87,8 @@ class UrlConnectionTest extends AgentTestRunner {
 
     expect:
     assertTraces(1) {
-      trace(0, 2) {
-        span(0) {
+      trace(2) {
+        span {
           operationName "someTrace"
           parent()
           errored true
@@ -97,7 +97,7 @@ class UrlConnectionTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           operationName "file.request"
           resourceName "file:$url.path"
           spanType DDSpanTypes.HTTP_CLIENT
@@ -135,8 +135,8 @@ class UrlConnectionTest extends AgentTestRunner {
 
     expect:
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           operationName "someTrace"
           parent()
           errored true

--- a/dd-java-agent/instrumentation/hystrix-1.4/src/test/groovy/HystrixObservableChainTest.groovy
+++ b/dd-java-agent/instrumentation/hystrix-1.4/src/test/groovy/HystrixObservableChainTest.groovy
@@ -74,8 +74,8 @@ class HystrixObservableChainTest extends AgentTestRunner {
     result == "HELLO!"
 
     assertTraces(1) {
-      trace(0, 5) {
-        span(0) {
+      trace(5) {
+        span {
           operationName "parent"
           resourceName "parent"
           spanType null
@@ -85,7 +85,7 @@ class HystrixObservableChainTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           operationName "hystrix.cmd"
           resourceName "OtherGroup.HystrixObservableChainTest\$2.execute"
           spanType null
@@ -99,7 +99,7 @@ class HystrixObservableChainTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(2) {
+        span {
           operationName "trace.annotation"
           resourceName "HystrixObservableChainTest\$2.tracedMethod"
           spanType null
@@ -110,7 +110,7 @@ class HystrixObservableChainTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(3) {
+        span {
           operationName "hystrix.cmd"
           resourceName "ExampleGroup.HystrixObservableChainTest\$1.execute"
           spanType null
@@ -124,7 +124,7 @@ class HystrixObservableChainTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(4) {
+        span {
           operationName "trace.annotation"
           resourceName "HystrixObservableChainTest\$1.tracedMethod"
           spanType null

--- a/dd-java-agent/instrumentation/hystrix-1.4/src/test/groovy/HystrixObservableTest.groovy
+++ b/dd-java-agent/instrumentation/hystrix-1.4/src/test/groovy/HystrixObservableTest.groovy
@@ -66,8 +66,8 @@ class HystrixObservableTest extends AgentTestRunner {
     result == "Hello!"
 
     assertTraces(1) {
-      trace(0, 3) {
-        span(0) {
+      trace(3) {
+        span {
           operationName "parent"
           resourceName "parent"
           spanType null
@@ -77,7 +77,7 @@ class HystrixObservableTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           operationName "hystrix.cmd"
           resourceName "ExampleGroup.HystrixObservableTest\$1.execute"
           spanType null
@@ -91,7 +91,7 @@ class HystrixObservableTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(2) {
+        span {
           operationName "trace.annotation"
           resourceName "HystrixObservableTest\$1.tracedMethod"
           spanType null
@@ -173,8 +173,8 @@ class HystrixObservableTest extends AgentTestRunner {
     result == "Fallback!"
 
     assertTraces(1) {
-      trace(0, 3) {
-        span(0) {
+      trace(3) {
+        span {
           operationName "parent"
           resourceName "parent"
           spanType null
@@ -184,7 +184,7 @@ class HystrixObservableTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           operationName "hystrix.cmd"
           resourceName "ExampleGroup.HystrixObservableTest\$2.execute"
           spanType null
@@ -199,7 +199,7 @@ class HystrixObservableTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(2) {
+        span {
           operationName "hystrix.cmd"
           resourceName "ExampleGroup.HystrixObservableTest\$2.fallback"
           spanType null
@@ -289,8 +289,8 @@ class HystrixObservableTest extends AgentTestRunner {
     err.cause instanceof IllegalArgumentException
 
     assertTraces(1) {
-      trace(0, 3) {
-        span(0) {
+      trace(3) {
+        span {
           operationName "parent"
           resourceName "parent"
           spanType null
@@ -301,7 +301,7 @@ class HystrixObservableTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           operationName "hystrix.cmd"
           resourceName "FailingGroup.HystrixObservableTest\$3.execute"
           spanType null
@@ -316,7 +316,7 @@ class HystrixObservableTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(2) {
+        span {
           operationName "hystrix.cmd"
           resourceName "FailingGroup.HystrixObservableTest\$3.fallback"
           spanType null

--- a/dd-java-agent/instrumentation/hystrix-1.4/src/test/groovy/HystrixTest.groovy
+++ b/dd-java-agent/instrumentation/hystrix-1.4/src/test/groovy/HystrixTest.groovy
@@ -50,8 +50,8 @@ class HystrixTest extends AgentTestRunner {
     result == "Hello!"
 
     assertTraces(1) {
-      trace(0, 3) {
-        span(0) {
+      trace(3) {
+        span {
           operationName "parent"
           resourceName "parent"
           spanType null
@@ -61,7 +61,7 @@ class HystrixTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           operationName "hystrix.cmd"
           resourceName "ExampleGroup.HystrixTest\$1.execute"
           spanType null
@@ -75,7 +75,7 @@ class HystrixTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(2) {
+        span {
           operationName "trace.annotation"
           resourceName "HystrixTest\$1.tracedMethod"
           spanType null
@@ -129,8 +129,8 @@ class HystrixTest extends AgentTestRunner {
     result == "Fallback!"
 
     assertTraces(1) {
-      trace(0, 3) {
-        span(0) {
+      trace(3) {
+        span {
           operationName "parent"
           resourceName "parent"
           spanType null
@@ -140,7 +140,7 @@ class HystrixTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           operationName "hystrix.cmd"
           resourceName "ExampleGroup.HystrixTest\$2.execute"
           spanType null
@@ -155,7 +155,7 @@ class HystrixTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(2) {
+        span {
           operationName "hystrix.cmd"
           resourceName "ExampleGroup.HystrixTest\$2.fallback"
           spanType null

--- a/dd-java-agent/instrumentation/java-concurrent/java-completablefuture/src/test/groovy/CompletableFutureTest.groovy
+++ b/dd-java-agent/instrumentation/java-concurrent/java-completablefuture/src/test/groovy/CompletableFutureTest.groovy
@@ -95,9 +95,9 @@ class CompletableFutureTest extends AgentTestRunner {
 
     and:
     assertTraces(1) {
-      trace(0, 2) {
-        basicSpan(it, 0, "parent")
-        basicSpan(it, 1, "child", span(0))
+      trace(2) {
+        basicSpan(it, "parent")
+        basicSpan(it, "child", span(0))
       }
     }
   }
@@ -119,9 +119,9 @@ class CompletableFutureTest extends AgentTestRunner {
 
     and:
     assertTraces(1) {
-      trace(0, 2) {
-        basicSpan(it, 0, "parent")
-        basicSpan(it, 1, "child", span(0))
+      trace(2) {
+        basicSpan(it, "parent")
+        basicSpan(it, "child", span(0))
       }
     }
   }
@@ -145,9 +145,9 @@ class CompletableFutureTest extends AgentTestRunner {
 
     and:
     assertTraces(1) {
-      trace(0, 2) {
-        basicSpan(it, 0, "parent")
-        basicSpan(it, 1, "child", span(0))
+      trace(2) {
+        basicSpan(it, "parent")
+        basicSpan(it, "child", span(0))
       }
     }
   }
@@ -173,9 +173,9 @@ class CompletableFutureTest extends AgentTestRunner {
 
     and:
     assertTraces(1) {
-      trace(0, 2) {
-        basicSpan(it, 0, "parent")
-        basicSpan(it, 1, "child", span(0))
+      trace(2) {
+        basicSpan(it, "parent")
+        basicSpan(it, "child", span(0))
       }
     }
   }
@@ -201,9 +201,9 @@ class CompletableFutureTest extends AgentTestRunner {
 
     and:
     assertTraces(1) {
-      trace(0, 2) {
-        basicSpan(it, 0, "parent")
-        basicSpan(it, 1, "child", span(0))
+      trace(2) {
+        basicSpan(it, "parent")
+        basicSpan(it, "child", span(0))
       }
     }
   }
@@ -231,9 +231,9 @@ class CompletableFutureTest extends AgentTestRunner {
 
     and:
     assertTraces(1) {
-      trace(0, 2) {
-        basicSpan(it, 0, "parent")
-        basicSpan(it, 1, "child", span(0))
+      trace(2) {
+        basicSpan(it, "parent")
+        basicSpan(it, "child", span(0))
       }
     }
   }

--- a/dd-java-agent/instrumentation/jax-rs-annotations-1/src/test/groovy/JaxRsAnnotations1InstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/jax-rs-annotations-1/src/test/groovy/JaxRsAnnotations1InstrumentationTest.groovy
@@ -25,8 +25,8 @@ class JaxRsAnnotations1InstrumentationTest extends AgentTestRunner {
 
     expect:
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           operationName "jax-rs.request"
           resourceName "POST /a"
           spanType "web"
@@ -47,8 +47,8 @@ class JaxRsAnnotations1InstrumentationTest extends AgentTestRunner {
 
     expect:
     assertTraces(1) {
-      trace(0, 2) {
-        span(0) {
+      trace(2) {
+        span {
           operationName "test"
           resourceName name
           parent()
@@ -57,7 +57,7 @@ class JaxRsAnnotations1InstrumentationTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           operationName "jax-rs.request"
           resourceName "${className}.call"
           spanType "web"
@@ -135,8 +135,8 @@ class JaxRsAnnotations1InstrumentationTest extends AgentTestRunner {
 
     expect:
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           operationName "test"
           resourceName "test"
           tags {

--- a/dd-java-agent/instrumentation/jax-rs-annotations-1/src/test/groovy/JerseyTest.groovy
+++ b/dd-java-agent/instrumentation/jax-rs-annotations-1/src/test/groovy/JerseyTest.groovy
@@ -28,8 +28,8 @@ class JerseyTest extends AgentTestRunner {
     response == expectedResponse
 
     assertTraces(1) {
-      trace(0, 2) {
-        span(0) {
+      trace(2) {
+        span {
           operationName "test.span"
           resourceName expectedResourceName
           tags {
@@ -38,7 +38,7 @@ class JerseyTest extends AgentTestRunner {
           }
         }
 
-        span(1) {
+        span {
           childOf span(0)
           operationName "jax-rs.request"
           resourceName controllerName
@@ -70,8 +70,8 @@ class JerseyTest extends AgentTestRunner {
     response == expectedResponse
 
     assertTraces(1) {
-      trace(0, 3) {
-        span(0) {
+      trace(3) {
+        span {
           operationName "test.span"
           resourceName parentResourceName
           tags {
@@ -79,7 +79,7 @@ class JerseyTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           childOf span(0)
           operationName "jax-rs.request"
           resourceName controller1Name
@@ -89,7 +89,7 @@ class JerseyTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(2) {
+        span {
           childOf span(1)
           operationName "jax-rs.request"
           resourceName controller2Name

--- a/dd-java-agent/instrumentation/jax-rs-annotations-2/src/test/groovy/JaxRsAnnotations2InstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/jax-rs-annotations-2/src/test/groovy/JaxRsAnnotations2InstrumentationTest.groovy
@@ -25,8 +25,8 @@ class JaxRsAnnotations2InstrumentationTest extends AgentTestRunner {
 
     expect:
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           operationName "jax-rs.request"
           resourceName "POST /a"
           spanType "web"
@@ -47,8 +47,8 @@ class JaxRsAnnotations2InstrumentationTest extends AgentTestRunner {
 
     expect:
     assertTraces(1) {
-      trace(0, 2) {
-        span(0) {
+      trace(2) {
+        span {
           operationName "test"
           resourceName name
           parent()
@@ -57,7 +57,7 @@ class JaxRsAnnotations2InstrumentationTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           operationName "jax-rs.request"
           resourceName "${className}.call"
           spanType "web"
@@ -135,8 +135,8 @@ class JaxRsAnnotations2InstrumentationTest extends AgentTestRunner {
 
     expect:
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           operationName "test"
           resourceName "test"
           tags {

--- a/dd-java-agent/instrumentation/jax-rs-annotations-2/src/test/groovy/JaxRsFilterTest.groovy
+++ b/dd-java-agent/instrumentation/jax-rs-annotations-2/src/test/groovy/JaxRsFilterTest.groovy
@@ -56,8 +56,8 @@ abstract class JaxRsFilterTest extends AgentTestRunner {
     }
 
     assertTraces(1) {
-      trace(0, 2) {
-        span(0) {
+      trace(2) {
+        span {
           operationName "test.span"
           resourceName parentResourceName
           tags {
@@ -65,7 +65,7 @@ abstract class JaxRsFilterTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           childOf span(0)
           operationName abort ? "jax-rs.request.abort" : "jax-rs.request"
           resourceName controllerName
@@ -115,8 +115,8 @@ abstract class JaxRsFilterTest extends AgentTestRunner {
     responseText == expectedResponse
 
     assertTraces(1) {
-      trace(0, 3) {
-        span(0) {
+      trace(3) {
+        span {
           operationName "test.span"
           resourceName parentResourceName
           tags {
@@ -124,7 +124,7 @@ abstract class JaxRsFilterTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           childOf span(0)
           operationName "jax-rs.request"
           resourceName controller1Name
@@ -134,7 +134,7 @@ abstract class JaxRsFilterTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(2) {
+        span {
           childOf span(1)
           operationName "jax-rs.request"
           resourceName controller2Name

--- a/dd-java-agent/instrumentation/jdbc/scalikejdbc/src/test/groovy/ScalikeJDBCInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/jdbc/scalikejdbc/src/test/groovy/ScalikeJDBCInstrumentationTest.groovy
@@ -181,7 +181,7 @@ class ScalikeJDBCInstrumentationTest extends AgentTestRunner {
 
     where:
     driver  | username | query
-    "h2"    | null    | "SELECT 3"
-    "derby" | "APP"   | "SELECT 3 FROM SYSIBM.SYSDUMMY1"
+    "h2"    | null     | "SELECT 3"
+    "derby" | "APP"    | "SELECT 3 FROM SYSIBM.SYSDUMMY1"
   }
 }

--- a/dd-java-agent/instrumentation/jdbc/scalikejdbc/src/test/groovy/ScalikeJDBCInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/jdbc/scalikejdbc/src/test/groovy/ScalikeJDBCInstrumentationTest.groovy
@@ -143,9 +143,9 @@ class ScalikeJDBCInstrumentationTest extends AgentTestRunner {
 
     expect:
     assertTraces(1) {
-      trace(0, 3) {
-        basicSpan(it, 0, "parent")
-        span(1) {
+      trace(3) {
+        basicSpan(it, "parent")
+        span {
           operationName "${driver}.query"
           serviceName driver
           resourceName query
@@ -164,7 +164,7 @@ class ScalikeJDBCInstrumentationTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(2) {
+        span {
           operationName "database.connection"
           serviceName span(2).serviceName
           resourceName "PoolingDataSource.getConnection"

--- a/dd-java-agent/instrumentation/jdbc/src/test/groovy/JDBCInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/jdbc/src/test/groovy/JDBCInstrumentationTest.groovy
@@ -173,9 +173,9 @@ class JDBCInstrumentationTest extends AgentTestRunner {
     resultSet.next()
     resultSet.getInt(1) == 3
     assertTraces(1) {
-      trace(0, 2) {
-        basicSpan(it, 0, "parent")
-        span(1) {
+      trace(2) {
+        basicSpan(it, "parent")
+        span {
           serviceName renameService ? dbName.toLowerCase() : driver
           operationName "${driver}.query"
           resourceName query
@@ -233,9 +233,9 @@ class JDBCInstrumentationTest extends AgentTestRunner {
     resultSet.next()
     resultSet.getInt(1) == 3
     assertTraces(1) {
-      trace(0, 2) {
-        basicSpan(it, 0, "parent")
-        span(1) {
+      trace(2) {
+        basicSpan(it, "parent")
+        span {
           operationName "${driver}.query"
           serviceName driver
           resourceName query
@@ -285,9 +285,9 @@ class JDBCInstrumentationTest extends AgentTestRunner {
     resultSet.next()
     resultSet.getInt(1) == 3
     assertTraces(1) {
-      trace(0, 2) {
-        basicSpan(it, 0, "parent")
-        span(1) {
+      trace(2) {
+        basicSpan(it, "parent")
+        span {
           operationName "${driver}.query"
           serviceName driver
           resourceName query
@@ -337,9 +337,9 @@ class JDBCInstrumentationTest extends AgentTestRunner {
     resultSet.next()
     resultSet.getInt(1) == 3
     assertTraces(1) {
-      trace(0, 2) {
-        basicSpan(it, 0, "parent")
-        span(1) {
+      trace(2) {
+        basicSpan(it, "parent")
+        span {
           operationName "${driver}.query"
           serviceName driver
           resourceName query
@@ -389,9 +389,9 @@ class JDBCInstrumentationTest extends AgentTestRunner {
     }
     statement.updateCount == 0
     assertTraces(1) {
-      trace(0, 2) {
-        basicSpan(it, 0, "parent")
-        span(1) {
+      trace(2) {
+        basicSpan(it, "parent")
+        span {
           operationName "${driver}.query"
           serviceName driver
           resourceName query
@@ -444,9 +444,9 @@ class JDBCInstrumentationTest extends AgentTestRunner {
       return statement.executeUpdate() == 0
     }
     assertTraces(1) {
-      trace(0, 2) {
-        basicSpan(it, 0, "parent")
-        span(1) {
+      trace(2) {
+        basicSpan(it, "parent")
+        span {
           operationName "${driver}.query"
           serviceName driver
           resourceName query
@@ -511,9 +511,9 @@ class JDBCInstrumentationTest extends AgentTestRunner {
     rs.next()
     rs.getInt(1) == 3
     assertTraces(1) {
-      trace(0, 2) {
-        basicSpan(it, 0, "parent")
-        span(1) {
+      trace(2) {
+        basicSpan(it, "parent")
+        span {
           operationName "${driver}.query"
           serviceName driver
           resourceName query
@@ -574,10 +574,10 @@ class JDBCInstrumentationTest extends AgentTestRunner {
 
     then:
     assertTraces(1) {
-      trace(0, recursive ? 3 : 2) {
-        basicSpan(it, 0, "parent")
+      trace(recursive ? 3 : 2) {
+        basicSpan(it, "parent")
 
-        span(1) {
+        span {
           operationName "database.connection"
           resourceName "${datasource.class.simpleName}.getConnection"
           childOf span(0)
@@ -587,7 +587,7 @@ class JDBCInstrumentationTest extends AgentTestRunner {
           }
         }
         if (recursive) {
-          span(2) {
+          span {
             operationName "database.connection"
             resourceName "${datasource.class.simpleName}.getConnection"
             childOf span(1)
@@ -628,9 +628,9 @@ class JDBCInstrumentationTest extends AgentTestRunner {
 
     then:
     assertTraces(1) {
-      trace(0, 2) {
-        basicSpan(it, 0, "parent")
-        span(1) {
+      trace(2) {
+        basicSpan(it, "parent")
+        span {
           operationName "${database}.query"
           serviceName database
           resourceName query
@@ -694,8 +694,8 @@ class JDBCInstrumentationTest extends AgentTestRunner {
       res[i] == 3
     }
     assertTraces(5) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           operationName "${dbType}.query"
           serviceName dbType
           resourceName query
@@ -713,8 +713,8 @@ class JDBCInstrumentationTest extends AgentTestRunner {
         }
       }
       for (int i = 1; i < numQueries; ++i) {
-        trace(i, 1) {
-          span(0) {
+        trace(1) {
+          span {
             operationName "${dbType}.query"
             serviceName dbType
             resourceName query

--- a/dd-java-agent/instrumentation/jedis-1.4/src/test/groovy/JedisClientTest.groovy
+++ b/dd-java-agent/instrumentation/jedis-1.4/src/test/groovy/JedisClientTest.groovy
@@ -50,8 +50,8 @@ class JedisClientTest extends AgentTestRunner {
 
     then:
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "redis"
           operationName "redis.query"
           resourceName "SET"
@@ -76,8 +76,8 @@ class JedisClientTest extends AgentTestRunner {
     value == "bar"
 
     assertTraces(2) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "redis"
           operationName "redis.query"
           resourceName "SET"
@@ -90,8 +90,8 @@ class JedisClientTest extends AgentTestRunner {
           }
         }
       }
-      trace(1, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "redis"
           operationName "redis.query"
           resourceName "GET"
@@ -116,8 +116,8 @@ class JedisClientTest extends AgentTestRunner {
     value == "foo"
 
     assertTraces(2) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "redis"
           operationName "redis.query"
           resourceName "SET"
@@ -130,8 +130,8 @@ class JedisClientTest extends AgentTestRunner {
           }
         }
       }
-      trace(1, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "redis"
           operationName "redis.query"
           resourceName "RANDOMKEY"

--- a/dd-java-agent/instrumentation/jedis-3.0/src/test/groovy/Jedis30ClientTest.groovy
+++ b/dd-java-agent/instrumentation/jedis-3.0/src/test/groovy/Jedis30ClientTest.groovy
@@ -50,8 +50,8 @@ class Jedis30ClientTest extends AgentTestRunner {
 
     then:
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "redis"
           operationName "redis.query"
           resourceName "SET"
@@ -76,8 +76,8 @@ class Jedis30ClientTest extends AgentTestRunner {
     value == "bar"
 
     assertTraces(2) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "redis"
           operationName "redis.query"
           resourceName "SET"
@@ -90,8 +90,8 @@ class Jedis30ClientTest extends AgentTestRunner {
           }
         }
       }
-      trace(1, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "redis"
           operationName "redis.query"
           resourceName "GET"
@@ -116,8 +116,8 @@ class Jedis30ClientTest extends AgentTestRunner {
     value == "foo"
 
     assertTraces(2) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "redis"
           operationName "redis.query"
           resourceName "SET"
@@ -130,8 +130,8 @@ class Jedis30ClientTest extends AgentTestRunner {
           }
         }
       }
-      trace(1, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "redis"
           operationName "redis.query"
           resourceName "RANDOMKEY"

--- a/dd-java-agent/instrumentation/jetty-8/src/test/groovy/JettyContinuationHandlerTest.groovy
+++ b/dd-java-agent/instrumentation/jetty-8/src/test/groovy/JettyContinuationHandlerTest.groovy
@@ -51,7 +51,7 @@ abstract class JettyContinuationHandlerTest extends JettyHandlerTest {
 //    }
 //    toRemove.each {
 //      assertTrace(it, 1) {
-//        basicSpan(it, 0, "TEST_SPAN", "ServerEntry")
+//        basicSpan(it, "TEST_SPAN", "ServerEntry")
 //      }
 //    }
 //    assert toRemove.size() == size * 2

--- a/dd-java-agent/instrumentation/jetty-8/src/test/groovy/JettyHandlerTest.groovy
+++ b/dd-java-agent/instrumentation/jetty-8/src/test/groovy/JettyHandlerTest.groovy
@@ -115,9 +115,9 @@ class JettyHandlerTest extends HttpServerTest<Server> {
   }
 
   @Override
-  void serverSpan(TraceAssert trace, int index, BigInteger traceID = null, BigInteger parentID = null, String method = "GET", ServerEndpoint endpoint = SUCCESS) {
+  void serverSpan(TraceAssert trace, BigInteger traceID = null, BigInteger parentID = null, String method = "GET", ServerEndpoint endpoint = SUCCESS) {
     def handlerName = handler().class.name
-    trace.span(index) {
+    trace.span {
       serviceName expectedServiceName()
       operationName expectedOperationName()
       resourceName endpoint.resource(method, address, testPathParam())

--- a/dd-java-agent/instrumentation/jms/src/latestDepTest/groovy/JMS2Test.groovy
+++ b/dd-java-agent/instrumentation/jms/src/latestDepTest/groovy/JMS2Test.groovy
@@ -1,9 +1,9 @@
 import com.google.common.io.Files
-import datadog.trace.core.DDSpan
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.asserts.ListWriterAssert
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
+import datadog.trace.core.DDSpan
 import org.hornetq.api.core.TransportConfiguration
 import org.hornetq.api.core.client.HornetQClient
 import org.hornetq.api.jms.HornetQJMSClient
@@ -90,8 +90,8 @@ class JMS2Test extends AgentTestRunner {
     expect:
     receivedMessage.text == messageText
     assertTraces(2) {
-      producerTrace(it, 0, jmsResourceName)
-      consumerTrace(it, 1, jmsResourceName, false, HornetQMessageConsumer)
+      producerTrace(it, jmsResourceName)
+      consumerTrace(it, jmsResourceName, false, HornetQMessageConsumer)
     }
 
     cleanup:
@@ -125,8 +125,8 @@ class JMS2Test extends AgentTestRunner {
 
     expect:
     assertTraces(2) {
-      producerTrace(it, 0, jmsResourceName)
-      consumerTrace(it, 1, jmsResourceName, true, consumer.messageListener.class)
+      producerTrace(it, jmsResourceName)
+      consumerTrace(it, jmsResourceName, true, consumer.messageListener.class)
     }
     // This check needs to go after all traces have been accounted for
     messageRef.get().text == messageText
@@ -153,8 +153,8 @@ class JMS2Test extends AgentTestRunner {
     expect:
     receivedMessage == null
     assertTraces(1) {
-      trace(0, 1) { // Consumer trace
-        span(0) {
+      trace(1) { // Consumer trace
+        span {
           parent()
           serviceName "jms"
           operationName "jms.consume"
@@ -191,8 +191,8 @@ class JMS2Test extends AgentTestRunner {
     expect:
     receivedMessage == null
     assertTraces(1) {
-      trace(0, 1) { // Consumer trace
-        span(0) {
+      trace(1) { // Consumer trace
+        span {
           parent()
           serviceName "jms"
           operationName "jms.consume"
@@ -219,9 +219,9 @@ class JMS2Test extends AgentTestRunner {
     session.createTopic("someTopic") | "Topic someTopic"
   }
 
-  static producerTrace(ListWriterAssert writer, int index, String jmsResourceName) {
-    writer.trace(index, 1) {
-      span(0) {
+  static producerTrace(ListWriterAssert writer, String jmsResourceName) {
+    writer.trace(1) {
+      span {
         parent()
         serviceName "jms"
         operationName "jms.produce"
@@ -239,9 +239,9 @@ class JMS2Test extends AgentTestRunner {
     }
   }
 
-  static consumerTrace(ListWriterAssert writer, int index, String jmsResourceName, boolean messageListener, Class origin, DDSpan parentSpan = TEST_WRITER[0][0]) {
-    writer.trace(index, 1) {
-      span(0) {
+  static consumerTrace(ListWriterAssert writer, String jmsResourceName, boolean messageListener, Class origin, DDSpan parentSpan = TEST_WRITER[0][0]) {
+    writer.trace(1) {
+      span {
         childOf parentSpan
         serviceName "jms"
         if (messageListener) {

--- a/dd-java-agent/instrumentation/jms/src/latestDepTest/groovy/JMS2Test.groovy
+++ b/dd-java-agent/instrumentation/jms/src/latestDepTest/groovy/JMS2Test.groovy
@@ -91,7 +91,7 @@ class JMS2Test extends AgentTestRunner {
     receivedMessage.text == messageText
     assertTraces(2) {
       producerTrace(it, jmsResourceName)
-      consumerTrace(it, jmsResourceName, false, HornetQMessageConsumer)
+      consumerTrace(it, jmsResourceName, false, HornetQMessageConsumer, trace(0)[0])
     }
 
     cleanup:
@@ -126,7 +126,7 @@ class JMS2Test extends AgentTestRunner {
     expect:
     assertTraces(2) {
       producerTrace(it, jmsResourceName)
-      consumerTrace(it, jmsResourceName, true, consumer.messageListener.class)
+      consumerTrace(it, jmsResourceName, true, consumer.messageListener.class, trace(0)[0])
     }
     // This check needs to go after all traces have been accounted for
     messageRef.get().text == messageText
@@ -239,7 +239,7 @@ class JMS2Test extends AgentTestRunner {
     }
   }
 
-  static consumerTrace(ListWriterAssert writer, String jmsResourceName, boolean messageListener, Class origin, DDSpan parentSpan = TEST_WRITER[0][0]) {
+  static consumerTrace(ListWriterAssert writer, String jmsResourceName, boolean messageListener, Class origin, DDSpan parentSpan) {
     writer.trace(1) {
       span {
         childOf parentSpan

--- a/dd-java-agent/instrumentation/jms/src/latestDepTest/groovy/JMS2Test.groovy
+++ b/dd-java-agent/instrumentation/jms/src/latestDepTest/groovy/JMS2Test.groovy
@@ -186,7 +186,7 @@ class JMS2Test extends AgentTestRunner {
     def consumer = session.createConsumer(destination)
 
     // Receive with timeout
-    TextMessage receivedMessage = consumer.receive(100)
+    TextMessage receivedMessage = consumer.receive(1)
 
     expect:
     receivedMessage == null

--- a/dd-java-agent/instrumentation/jms/src/latestDepTest/groovy/SpringListenerJMS2Test.groovy
+++ b/dd-java-agent/instrumentation/jms/src/latestDepTest/groovy/SpringListenerJMS2Test.groovy
@@ -36,19 +36,11 @@ class SpringListenerJMS2Test extends AgentTestRunner {
     def template = new JmsTemplate(factory)
     template.convertAndSend("SpringListenerJMS2", "a message")
 
-    TEST_WRITER.waitForTraces(3)
-    // Manually reorder if reported in the wrong order.
-    if (TEST_WRITER[1][0].operationName.toString() == "jms.produce") {
-      def producerTrace = TEST_WRITER[1]
-      TEST_WRITER[1] = TEST_WRITER[0]
-      TEST_WRITER[0] = producerTrace
-    }
-
     expect:
     assertTraces(3) {
-      producerTrace(it, 0, "Queue SpringListenerJMS2")
-      consumerTrace(it, 1, "Queue SpringListenerJMS2", false, HornetQMessageConsumer)
-      consumerTrace(it, 2, "Queue SpringListenerJMS2", true, MessagingMessageListenerAdapter)
+      producerTrace(it, "Queue SpringListenerJMS2")
+      consumerTrace(it, "Queue SpringListenerJMS2", false, HornetQMessageConsumer)
+      consumerTrace(it, "Queue SpringListenerJMS2", true, MessagingMessageListenerAdapter)
     }
   }
 }

--- a/dd-java-agent/instrumentation/jms/src/latestDepTest/groovy/SpringListenerJMS2Test.groovy
+++ b/dd-java-agent/instrumentation/jms/src/latestDepTest/groovy/SpringListenerJMS2Test.groovy
@@ -39,8 +39,8 @@ class SpringListenerJMS2Test extends AgentTestRunner {
     expect:
     assertTraces(3) {
       producerTrace(it, "Queue SpringListenerJMS2")
-      consumerTrace(it, "Queue SpringListenerJMS2", false, HornetQMessageConsumer)
-      consumerTrace(it, "Queue SpringListenerJMS2", true, MessagingMessageListenerAdapter)
+      consumerTrace(it, "Queue SpringListenerJMS2", false, HornetQMessageConsumer, trace(0)[0])
+      consumerTrace(it, "Queue SpringListenerJMS2", true, MessagingMessageListenerAdapter, trace(0)[0])
     }
   }
 }

--- a/dd-java-agent/instrumentation/jms/src/latestDepTest/groovy/SpringTemplateJMS2Test.groovy
+++ b/dd-java-agent/instrumentation/jms/src/latestDepTest/groovy/SpringTemplateJMS2Test.groovy
@@ -84,7 +84,7 @@ class SpringTemplateJMS2Test extends AgentTestRunner {
     receivedMessage.text == messageText
     assertTraces(2) {
       producerTrace(it, jmsResourceName)
-      consumerTrace(it, jmsResourceName, false, HornetQMessageConsumer)
+      consumerTrace(it, jmsResourceName, false, HornetQMessageConsumer, trace(0)[0])
     }
 
     where:
@@ -108,21 +108,13 @@ class SpringTemplateJMS2Test extends AgentTestRunner {
       session -> template.getMessageConverter().toMessage(messageText, session)
     }
 
-    TEST_WRITER.waitForTraces(4)
-    // Manually reorder if reported in the wrong order.
-    if (TEST_WRITER[3][0].operationName.toString() == "jms.produce") {
-      def producerTrace = TEST_WRITER[3]
-      TEST_WRITER[3] = TEST_WRITER[2]
-      TEST_WRITER[2] = producerTrace
-    }
-
     expect:
     receivedMessage.text == "responded!"
     assertTraces(4) {
       producerTrace(it, jmsResourceName)
-      consumerTrace(it, jmsResourceName, false, HornetQMessageConsumer)
+      consumerTrace(it, jmsResourceName, false, HornetQMessageConsumer, trace(0)[0])
       producerTrace(it, "Temporary Queue") // receive doesn't propagate the trace, so this is a root
-      consumerTrace(it, "Temporary Queue", false, HornetQMessageConsumer, TEST_WRITER[2][0])
+      consumerTrace(it, "Temporary Queue", false, HornetQMessageConsumer, trace(2)[0])
     }
 
     where:

--- a/dd-java-agent/instrumentation/jms/src/latestDepTest/groovy/SpringTemplateJMS2Test.groovy
+++ b/dd-java-agent/instrumentation/jms/src/latestDepTest/groovy/SpringTemplateJMS2Test.groovy
@@ -83,8 +83,8 @@ class SpringTemplateJMS2Test extends AgentTestRunner {
     expect:
     receivedMessage.text == messageText
     assertTraces(2) {
-      producerTrace(it, 0, jmsResourceName)
-      consumerTrace(it, 1, jmsResourceName, false, HornetQMessageConsumer)
+      producerTrace(it, jmsResourceName)
+      consumerTrace(it, jmsResourceName, false, HornetQMessageConsumer)
     }
 
     where:
@@ -119,10 +119,10 @@ class SpringTemplateJMS2Test extends AgentTestRunner {
     expect:
     receivedMessage.text == "responded!"
     assertTraces(4) {
-      producerTrace(it, 0, jmsResourceName)
-      consumerTrace(it, 1, jmsResourceName, false, HornetQMessageConsumer)
-      producerTrace(it, 2, "Temporary Queue") // receive doesn't propagate the trace, so this is a root
-      consumerTrace(it, 3, "Temporary Queue", false, HornetQMessageConsumer, TEST_WRITER[2][0])
+      producerTrace(it, jmsResourceName)
+      consumerTrace(it, jmsResourceName, false, HornetQMessageConsumer)
+      producerTrace(it, "Temporary Queue") // receive doesn't propagate the trace, so this is a root
+      consumerTrace(it, "Temporary Queue", false, HornetQMessageConsumer, TEST_WRITER[2][0])
     }
 
     where:

--- a/dd-java-agent/instrumentation/jms/src/test/groovy/JMS1Test.groovy
+++ b/dd-java-agent/instrumentation/jms/src/test/groovy/JMS1Test.groovy
@@ -54,7 +54,7 @@ class JMS1Test extends AgentTestRunner {
     receivedMessage.text == messageText
     assertTraces(2) {
       producerTrace(it, jmsResourceName)
-      consumerTrace(it, jmsResourceName, false, ActiveMQMessageConsumer)
+      consumerTrace(it, jmsResourceName, false, ActiveMQMessageConsumer, trace(0)[0])
     }
 
     cleanup:
@@ -89,7 +89,7 @@ class JMS1Test extends AgentTestRunner {
     expect:
     assertTraces(2) {
       producerTrace(it, jmsResourceName)
-      consumerTrace(it, jmsResourceName, true, consumer.messageListener.class)
+      consumerTrace(it, jmsResourceName, true, consumer.messageListener.class, trace(0)[0])
     }
     // This check needs to go after all traces have been accounted for
     messageRef.get().text == messageText
@@ -256,7 +256,7 @@ class JMS1Test extends AgentTestRunner {
     }
   }
 
-  static consumerTrace(ListWriterAssert writer, String jmsResourceName, boolean messageListener, Class origin, DDSpan parentSpan = TEST_WRITER[0][0]) {
+  static consumerTrace(ListWriterAssert writer, String jmsResourceName, boolean messageListener, Class origin, DDSpan parentSpan) {
     writer.trace(1) {
       span {
         serviceName "jms"

--- a/dd-java-agent/instrumentation/jms/src/test/groovy/SpringListenerJMS1Test.groovy
+++ b/dd-java-agent/instrumentation/jms/src/test/groovy/SpringListenerJMS1Test.groovy
@@ -41,8 +41,8 @@ class SpringListenerJMS1Test extends AgentTestRunner {
     expect:
     assertTraces(3) {
       producerTrace(it, "Queue SpringListenerJMS1")
-      consumerTrace(it, "Queue SpringListenerJMS1", false, ActiveMQMessageConsumer)
-      consumerTrace(it, "Queue SpringListenerJMS1", true, MessagingMessageListenerAdapter)
+      consumerTrace(it, "Queue SpringListenerJMS1", false, ActiveMQMessageConsumer, trace(0)[0])
+      consumerTrace(it, "Queue SpringListenerJMS1", true, MessagingMessageListenerAdapter, trace(0)[0])
     }
 
     cleanup:

--- a/dd-java-agent/instrumentation/jms/src/test/groovy/SpringListenerJMS1Test.groovy
+++ b/dd-java-agent/instrumentation/jms/src/test/groovy/SpringListenerJMS1Test.groovy
@@ -38,19 +38,11 @@ class SpringListenerJMS1Test extends AgentTestRunner {
     def template = new JmsTemplate(factory)
     template.convertAndSend("SpringListenerJMS1", "a message")
 
-    TEST_WRITER.waitForTraces(3)
-    // Manually reorder if reported in the wrong order.
-    if (TEST_WRITER[1][0].operationName.toString() == "jms.produce") {
-      def producerTrace = TEST_WRITER[1]
-      TEST_WRITER[1] = TEST_WRITER[0]
-      TEST_WRITER[0] = producerTrace
-    }
-
     expect:
     assertTraces(3) {
-      producerTrace(it, 0, "Queue SpringListenerJMS1")
-      consumerTrace(it, 1, "Queue SpringListenerJMS1", false, ActiveMQMessageConsumer)
-      consumerTrace(it, 2, "Queue SpringListenerJMS1", true, MessagingMessageListenerAdapter)
+      producerTrace(it, "Queue SpringListenerJMS1")
+      consumerTrace(it, "Queue SpringListenerJMS1", false, ActiveMQMessageConsumer)
+      consumerTrace(it, "Queue SpringListenerJMS1", true, MessagingMessageListenerAdapter)
     }
 
     cleanup:

--- a/dd-java-agent/instrumentation/jms/src/test/groovy/SpringTemplateJMS1Test.groovy
+++ b/dd-java-agent/instrumentation/jms/src/test/groovy/SpringTemplateJMS1Test.groovy
@@ -50,8 +50,8 @@ class SpringTemplateJMS1Test extends AgentTestRunner {
     expect:
     receivedMessage.text == messageText
     assertTraces(2) {
-      producerTrace(it, 0, jmsResourceName)
-      consumerTrace(it, 1, jmsResourceName, false, ActiveMQMessageConsumer)
+      producerTrace(it, jmsResourceName)
+      consumerTrace(it, jmsResourceName, false, ActiveMQMessageConsumer)
     }
 
     where:
@@ -76,26 +76,13 @@ class SpringTemplateJMS1Test extends AgentTestRunner {
       session -> template.getMessageConverter().toMessage(messageText, session)
     }
 
-    TEST_WRITER.waitForTraces(4)
-    // Manually reorder if reported in the wrong order.
-    if (TEST_WRITER[1][0].operationName.toString() == "jms.produce") {
-      def producerTrace = TEST_WRITER[1]
-      TEST_WRITER[1] = TEST_WRITER[0]
-      TEST_WRITER[0] = producerTrace
-    }
-    if (TEST_WRITER[3][0].operationName.toString() == "jms.produce") {
-      def producerTrace = TEST_WRITER[3]
-      TEST_WRITER[3] = TEST_WRITER[2]
-      TEST_WRITER[2] = producerTrace
-    }
-
     expect:
     receivedMessage.text == "responded!"
     assertTraces(4) {
-      producerTrace(it, 0, jmsResourceName)
-      consumerTrace(it, 1, jmsResourceName, false, ActiveMQMessageConsumer)
-      producerTrace(it, 2, "Temporary Queue") // receive doesn't propagate the trace, so this is a root
-      consumerTrace(it, 3, "Temporary Queue", false, ActiveMQMessageConsumer, TEST_WRITER[2][0])
+      producerTrace(it, jmsResourceName)
+      consumerTrace(it, jmsResourceName, false, ActiveMQMessageConsumer)
+      producerTrace(it, "Temporary Queue") // receive doesn't propagate the trace, so this is a root
+      consumerTrace(it, "Temporary Queue", false, ActiveMQMessageConsumer, TEST_WRITER[2][0])
     }
 
     where:

--- a/dd-java-agent/instrumentation/jsp-2.3/src/test/groovy/JSPInstrumentationBasicTests.groovy
+++ b/dd-java-agent/instrumentation/jsp-2.3/src/test/groovy/JSPInstrumentationBasicTests.groovy
@@ -85,8 +85,8 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
 
     then:
     assertTraces(1) {
-      trace(0, 3) {
-        span(0) {
+      trace(3) {
+        span {
           parent()
           serviceName jspWebappContext
           operationName "servlet.request"
@@ -107,7 +107,7 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           childOf span(0)
           serviceName jspWebappContext
           operationName "jsp.render"
@@ -121,7 +121,7 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(2) {
+        span {
           childOf span(0)
           serviceName jspWebappContext
           operationName "jsp.compile"
@@ -160,8 +160,8 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
 
     then:
     assertTraces(1) {
-      trace(0, 3) {
-        span(0) {
+      trace(3) {
+        span {
           parent()
           serviceName jspWebappContext
           operationName "servlet.request"
@@ -182,7 +182,7 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           childOf span(0)
           serviceName jspWebappContext
           operationName "jsp.render"
@@ -196,7 +196,7 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(2) {
+        span {
           childOf span(0)
           serviceName jspWebappContext
           operationName "jsp.compile"
@@ -232,8 +232,8 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
 
     then:
     assertTraces(1) {
-      trace(0, 3) {
-        span(0) {
+      trace(3) {
+        span {
           parent()
           serviceName jspWebappContext
           operationName "servlet.request"
@@ -254,7 +254,7 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           childOf span(0)
           serviceName jspWebappContext
           operationName "jsp.render"
@@ -268,7 +268,7 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(2) {
+        span {
           childOf span(0)
           serviceName jspWebappContext
           operationName "jsp.compile"
@@ -301,8 +301,8 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
 
     then:
     assertTraces(1) {
-      trace(0, 3) {
-        span(0) {
+      trace(3) {
+        span {
           parent()
           serviceName jspWebappContext
           operationName "servlet.request"
@@ -330,7 +330,7 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           childOf span(0)
           serviceName jspWebappContext
           operationName "jsp.render"
@@ -351,7 +351,7 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(2) {
+        span {
           childOf span(0)
           serviceName jspWebappContext
           operationName "jsp.compile"
@@ -389,8 +389,8 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
 
     then:
     assertTraces(1) {
-      trace(0, 3) {
-        span(0) {
+      trace(3) {
+        span {
           parent()
           serviceName jspWebappContext
           operationName "servlet.request"
@@ -411,7 +411,7 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           childOf span(0)
           serviceName jspWebappContext
           operationName "jsp.render"
@@ -425,7 +425,7 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(2) {
+        span {
           childOf span(0)
           serviceName jspWebappContext
           operationName "jsp.compile"
@@ -457,8 +457,8 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
 
     then:
     assertTraces(1) {
-      trace(0, 7) {
-        span(0) {
+      trace(7) {
+        span {
           parent()
           serviceName jspWebappContext
           operationName "servlet.request"
@@ -479,7 +479,7 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           childOf span(0)
           serviceName jspWebappContext
           operationName "jsp.render"
@@ -493,7 +493,7 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(2) {
+        span {
           childOf span(1)
           serviceName jspWebappContext
           operationName "jsp.render"
@@ -507,7 +507,7 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(3) {
+        span {
           childOf span(1)
           serviceName jspWebappContext
           operationName "jsp.compile"
@@ -521,7 +521,7 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(4) {
+        span {
           childOf span(1)
           serviceName jspWebappContext
           operationName "jsp.render"
@@ -535,7 +535,7 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(5) {
+        span {
           childOf span(1)
           serviceName jspWebappContext
           operationName "jsp.compile"
@@ -549,7 +549,7 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(6) {
+        span {
           childOf span(0)
           serviceName jspWebappContext
           operationName "jsp.compile"
@@ -581,8 +581,8 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
 
     then:
     assertTraces(1) {
-      trace(0, 2) {
-        span(0) {
+      trace(2) {
+        span {
           parent()
           serviceName jspWebappContext
           operationName "servlet.request"
@@ -604,7 +604,7 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           childOf span(0)
           serviceName jspWebappContext
           operationName "jsp.compile"
@@ -643,8 +643,8 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
     then:
     res.code() == HttpStatus.OK_200
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           parent()
           serviceName jspWebappContext
           operationName "servlet.request"

--- a/dd-java-agent/instrumentation/jsp-2.3/src/test/groovy/JSPInstrumentationForwardTests.groovy
+++ b/dd-java-agent/instrumentation/jsp-2.3/src/test/groovy/JSPInstrumentationForwardTests.groovy
@@ -84,8 +84,8 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
 
     then:
     assertTraces(1) {
-      trace(0, 5) {
-        span(0) {
+      trace(5) {
+        span {
           parent()
           serviceName jspWebappContext
           operationName "servlet.request"
@@ -106,7 +106,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           childOf span(0)
           serviceName jspWebappContext
           operationName "jsp.render"
@@ -120,7 +120,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(2) {
+        span {
           childOf span(1)
           serviceName jspWebappContext
           operationName "jsp.render"
@@ -135,7 +135,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(3) {
+        span {
           childOf span(1)
           serviceName jspWebappContext
           operationName "jsp.compile"
@@ -149,7 +149,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(4) {
+        span {
           childOf span(0)
           serviceName jspWebappContext
           operationName "jsp.compile"
@@ -186,8 +186,8 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
 
     then:
     assertTraces(1) {
-      trace(0, 3) {
-        span(0) {
+      trace(3) {
+        span {
           parent()
           serviceName jspWebappContext
           operationName "servlet.request"
@@ -208,7 +208,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           childOf span(0)
           serviceName jspWebappContext
           operationName "jsp.render"
@@ -222,7 +222,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(2) {
+        span {
           childOf span(0)
           serviceName jspWebappContext
           operationName "jsp.compile"
@@ -254,8 +254,8 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
 
     then:
     assertTraces(1) {
-      trace(0, 9) {
-        span(0) {
+      trace(9) {
+        span {
           parent()
           serviceName jspWebappContext
           operationName "servlet.request"
@@ -276,7 +276,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           childOf span(0)
           serviceName jspWebappContext
           operationName "jsp.render"
@@ -290,7 +290,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(2) {
+        span {
           childOf span(1)
           serviceName jspWebappContext
           operationName "jsp.render"
@@ -305,7 +305,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(3) {
+        span {
           childOf span(2)
           serviceName jspWebappContext
           operationName "jsp.render"
@@ -320,7 +320,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(4) {
+        span {
           childOf span(2)
           serviceName jspWebappContext
           operationName "jsp.compile"
@@ -334,7 +334,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(5) {
+        span {
           childOf span(2)
           serviceName jspWebappContext
           operationName "jsp.render"
@@ -349,7 +349,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(6) {
+        span {
           childOf span(2)
           serviceName jspWebappContext
           operationName "jsp.compile"
@@ -363,7 +363,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(7) {
+        span {
           childOf span(1)
           serviceName jspWebappContext
           operationName "jsp.compile"
@@ -377,7 +377,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(8) {
+        span {
           childOf span(0)
           serviceName jspWebappContext
           operationName "jsp.compile"
@@ -409,8 +409,8 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
 
     then:
     assertTraces(1) {
-      trace(0, 7) {
-        span(0) {
+      trace(7) {
+        span {
           parent()
           serviceName jspWebappContext
           operationName "servlet.request"
@@ -431,7 +431,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           childOf span(0)
           serviceName jspWebappContext
           operationName "jsp.render"
@@ -445,7 +445,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(2) {
+        span {
           childOf span(1)
           serviceName jspWebappContext
           operationName "jsp.render"
@@ -460,7 +460,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(3) {
+        span {
           childOf span(2)
           serviceName jspWebappContext
           operationName "jsp.render"
@@ -475,7 +475,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(4) {
+        span {
           childOf span(2)
           serviceName jspWebappContext
           operationName "jsp.compile"
@@ -489,7 +489,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(5) {
+        span {
           childOf span(1)
           serviceName jspWebappContext
           operationName "jsp.compile"
@@ -503,7 +503,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(6) {
+        span {
           childOf span(0)
           serviceName jspWebappContext
           operationName "jsp.compile"
@@ -535,8 +535,8 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
 
     then:
     assertTraces(1) {
-      trace(0, 4) {
-        span(0) {
+      trace(4) {
+        span {
           parent()
           serviceName jspWebappContext
           operationName "servlet.request"
@@ -558,7 +558,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           childOf span(0)
           serviceName jspWebappContext
           operationName "jsp.render"
@@ -573,7 +573,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(2) {
+        span {
           childOf span(1)
           serviceName jspWebappContext
           operationName "jsp.compile"
@@ -588,7 +588,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(3) {
+        span {
           childOf span(0)
           serviceName jspWebappContext
           operationName "jsp.compile"
@@ -620,8 +620,8 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
 
     then:
     assertTraces(1) {
-      trace(0, 3) {
-        span(0) {
+      trace(3) {
+        span {
           parent()
           serviceName jspWebappContext
           operationName "servlet.request"
@@ -642,7 +642,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           childOf span(0)
           serviceName jspWebappContext
           operationName "jsp.render"
@@ -656,7 +656,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(2) {
+        span {
           childOf span(0)
           serviceName jspWebappContext
           operationName "jsp.compile"

--- a/dd-java-agent/instrumentation/junit-4.10/src/test/groovy/JUnit4Test.groovy
+++ b/dd-java-agent/instrumentation/junit-4.10/src/test/groovy/JUnit4Test.groovy
@@ -24,7 +24,7 @@ class JUnit4Test extends TestFrameworkTest {
 
     expect:
     assertTraces(1) {
-      trace(0, 1) {
+      trace(1) {
         testSpan(it, 0, "org.example.TestSucceed", "test_succeed", TestDecorator.TEST_PASS)
       }
     }
@@ -36,7 +36,7 @@ class JUnit4Test extends TestFrameworkTest {
 
     expect:
     assertTraces(1) {
-      trace(0, 1) {
+      trace(1) {
         testSpan(it, 0, "org.example.TestInheritance", "test_succeed", TestDecorator.TEST_PASS)
       }
     }
@@ -52,7 +52,7 @@ class JUnit4Test extends TestFrameworkTest {
 
     expect:
     assertTraces(1) {
-      trace(0, 1) {
+      trace(1) {
         testSpan(it, 0, "org.example.TestFailed", "test_failed", TestDecorator.TEST_FAIL, null, exception)
       }
     }
@@ -71,7 +71,7 @@ class JUnit4Test extends TestFrameworkTest {
 
     expect:
     assertTraces(1) {
-      trace(0, 1) {
+      trace(1) {
         testSpan(it, 0, "org.example.TestError", "test_error", TestDecorator.TEST_FAIL, null, exception)
       }
     }
@@ -86,7 +86,7 @@ class JUnit4Test extends TestFrameworkTest {
 
     expect:
     assertTraces(1) {
-      trace(0, 1) {
+      trace(1) {
         testSpan(it, 0, "org.example.TestSkipped", "test_skipped", TestDecorator.TEST_SKIP, testTags)
       }
     }
@@ -101,7 +101,7 @@ class JUnit4Test extends TestFrameworkTest {
 
     expect:
     assertTraces(1) {
-      trace(0, 1) {
+      trace(1) {
         testSpan(it, 0, "org.example.TestSkippedClass", "test_class_skipped", TestDecorator.TEST_SKIP, testTags)
       }
     }

--- a/dd-java-agent/instrumentation/junit-5.3/src/test/groovy/JUnit5Test.groovy
+++ b/dd-java-agent/instrumentation/junit-5.3/src/test/groovy/JUnit5Test.groovy
@@ -29,7 +29,7 @@ class JUnit5Test extends TestFrameworkTest {
 
     expect:
     assertTraces(1) {
-      trace(0, 1) {
+      trace(1) {
         testSpan(it, 0, "org.example.TestSucceed", "test_succeed", TestDecorator.TEST_PASS)
       }
     }
@@ -44,7 +44,7 @@ class JUnit5Test extends TestFrameworkTest {
 
     expect:
     assertTraces(1) {
-      trace(0, 1) {
+      trace(1) {
         testSpan(it, 0, "org.example.TestInheritance", "test_succeed", TestDecorator.TEST_PASS)
       }
     }
@@ -59,10 +59,10 @@ class JUnit5Test extends TestFrameworkTest {
 
     expect:
     assertTraces(2) {
-      trace(0, 1) {
+      trace(1) {
         testSpan(it, 0, "org.example.TestParameterized", "test_parameterized", TestDecorator.TEST_PASS)
       }
-      trace(1, 1) {
+      trace(1) {
         testSpan(it, 0, "org.example.TestParameterized", "test_parameterized", TestDecorator.TEST_PASS)
       }
     }
@@ -77,10 +77,10 @@ class JUnit5Test extends TestFrameworkTest {
 
     expect:
     assertTraces(2) {
-      trace(0, 1) {
+      trace(1) {
         testSpan(it, 0, "org.example.TestRepeated", "test_repeated", TestDecorator.TEST_PASS)
       }
-      trace(1, 1) {
+      trace(1) {
         testSpan(it, 0, "org.example.TestRepeated", "test_repeated", TestDecorator.TEST_PASS)
       }
     }
@@ -95,10 +95,10 @@ class JUnit5Test extends TestFrameworkTest {
 
     expect:
     assertTraces(2) {
-      trace(0, 1) {
+      trace(1) {
         testSpan(it, 0, "org.example.TestTemplate", "test_template", TestDecorator.TEST_PASS)
       }
-      trace(1, 1) {
+      trace(1) {
         testSpan(it, 0, "org.example.TestTemplate", "test_template", TestDecorator.TEST_PASS)
       }
     }
@@ -113,10 +113,10 @@ class JUnit5Test extends TestFrameworkTest {
 
     expect:
     assertTraces(2) {
-      trace(0, 1) {
+      trace(1) {
         testSpan(it, 0, "org.example.TestFactory", "test_factory", TestDecorator.TEST_PASS)
       }
-      trace(1, 1) {
+      trace(1) {
         testSpan(it, 0, "org.example.TestFactory", "test_factory", TestDecorator.TEST_PASS)
       }
     }
@@ -137,7 +137,7 @@ class JUnit5Test extends TestFrameworkTest {
 
     expect:
     assertTraces(1) {
-      trace(0, 1) {
+      trace(1) {
         testSpan(it, 0, "org.example.TestFailed", "test_failed", TestDecorator.TEST_FAIL, null, exception)
       }
     }
@@ -160,7 +160,7 @@ class JUnit5Test extends TestFrameworkTest {
 
     expect:
     assertTraces(1) {
-      trace(0, 1) {
+      trace(1) {
         testSpan(it, 0, "org.example.TestError", "test_error", TestDecorator.TEST_FAIL, null, exception)
       }
     }
@@ -178,7 +178,7 @@ class JUnit5Test extends TestFrameworkTest {
 
     expect:
     assertTraces(1) {
-      trace(0, 1) {
+      trace(1) {
         testSpan(it, 0, "org.example.TestSkipped", "test_skipped", TestDecorator.TEST_SKIP, testTags)
       }
     }
@@ -196,7 +196,7 @@ class JUnit5Test extends TestFrameworkTest {
 
     expect:
     assertTraces(1) {
-      trace(0, 1) {
+      trace(1) {
         testSpan(it, 0, "org.example.TestSkippedClass", "test_class_skipped", TestDecorator.TEST_SKIP, testTags)
       }
     }

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTest.groovy
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTest.groovy
@@ -126,7 +126,7 @@ class KafkaClientTest extends AgentTestRunner {
           resourceName "Consume Topic $SHARED_TOPIC"
           spanType "queue"
           errored false
-          childOf TEST_WRITER[0][2]
+          childOf trace(0)[2]
           tags {
             "$Tags.COMPONENT" "java-kafka"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
@@ -233,7 +233,7 @@ class KafkaClientTest extends AgentTestRunner {
           resourceName "Consume Topic $SHARED_TOPIC"
           spanType "queue"
           errored false
-          childOf TEST_WRITER[0][2]
+          childOf trace(0)[2]
           tags {
             "$Tags.COMPONENT" "java-kafka"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
@@ -333,7 +333,7 @@ class KafkaClientTest extends AgentTestRunner {
           resourceName "Consume Topic $SHARED_TOPIC"
           spanType "queue"
           errored false
-          childOf TEST_WRITER[0][0]
+          childOf trace(0)[0]
           tags {
             "$Tags.COMPONENT" "java-kafka"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
@@ -417,7 +417,7 @@ class KafkaClientTest extends AgentTestRunner {
           resourceName "Consume Topic $SHARED_TOPIC"
           spanType "queue"
           errored false
-          childOf TEST_WRITER[0][0]
+          childOf trace(0)[0]
           tags {
             "$Tags.COMPONENT" "java-kafka"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTest.groovy
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTest.groovy
@@ -101,10 +101,10 @@ class KafkaClientTest extends AgentTestRunner {
     received.key() == null
 
     assertTraces(2) {
-      trace(0, 3) {
-        basicSpan(it, 0, "parent")
-        basicSpan(it, 1, "producer callback", span(0))
-        span(2) {
+      trace(3) {
+        basicSpan(it, "parent")
+        basicSpan(it, "producer callback", span(0))
+        span {
           serviceName "kafka"
           operationName "kafka.produce"
           resourceName "Produce Topic $SHARED_TOPIC"
@@ -118,9 +118,9 @@ class KafkaClientTest extends AgentTestRunner {
           }
         }
       }
-      trace(1, 1) {
+      trace(1) {
         // CONSUMER span 0
-        span(0) {
+        span {
           serviceName "kafka"
           operationName "kafka.consume"
           resourceName "Consume Topic $SHARED_TOPIC"
@@ -208,10 +208,10 @@ class KafkaClientTest extends AgentTestRunner {
     received.key() == null
 
     assertTraces(2) {
-      trace(0, 3) {
-        basicSpan(it, 0, "parent")
-        basicSpan(it, 1, "producer callback", span(0))
-        span(2) {
+      trace(3) {
+        basicSpan(it, "parent")
+        basicSpan(it, "producer callback", span(0))
+        span {
           serviceName "kafka"
           operationName "kafka.produce"
           resourceName "Produce Topic $SHARED_TOPIC"
@@ -225,9 +225,9 @@ class KafkaClientTest extends AgentTestRunner {
           }
         }
       }
-      trace(1, 1) {
+      trace(1) {
         // CONSUMER span 0
-        span(0) {
+        span {
           serviceName "kafka"
           operationName "kafka.consume"
           resourceName "Consume Topic $SHARED_TOPIC"
@@ -308,9 +308,9 @@ class KafkaClientTest extends AgentTestRunner {
     received.key() == null
 
     assertTraces(2) {
-      trace(0, 1) {
+      trace(1) {
         // PRODUCER span 0
-        span(0) {
+        span {
           serviceName "kafka"
           operationName "kafka.produce"
           resourceName "Produce Topic $SHARED_TOPIC"
@@ -325,9 +325,9 @@ class KafkaClientTest extends AgentTestRunner {
           }
         }
       }
-      trace (1, 1) {
+      trace(1) {
         // CONSUMER span 0
-        span(0) {
+        span {
           serviceName "kafka"
           operationName "kafka.consume"
           resourceName "Consume Topic $SHARED_TOPIC"
@@ -392,9 +392,9 @@ class KafkaClientTest extends AgentTestRunner {
     first.key() == null
 
     assertTraces(2) {
-      trace(0, 1) {
+      trace(1) {
         // PRODUCER span 0
-        span(0) {
+        span {
           serviceName "kafka"
           operationName "kafka.produce"
           resourceName "Produce Topic $SHARED_TOPIC"
@@ -409,9 +409,9 @@ class KafkaClientTest extends AgentTestRunner {
           }
         }
       }
-      trace(1, 1) {
+      trace(1) {
         // CONSUMER span 0
-        span(0) {
+        span {
           serviceName "kafka"
           operationName "kafka.consume"
           resourceName "Consume Topic $SHARED_TOPIC"

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/src/test/groovy/KafkaStreamsTest.groovy
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/src/test/groovy/KafkaStreamsTest.groovy
@@ -117,13 +117,6 @@ class KafkaStreamsTest extends AgentTestRunner {
     received.value() == greeting.toLowerCase()
     received.key() == null
 
-    if (TEST_WRITER[1][0].operationName.toString() == "kafka.produce") {
-      // Make sure that order of first two traces is predetermined.
-      // Unfortunately it looks like we cannot really control it in a better way through the code
-      def tmp = TEST_WRITER[1][0]
-      TEST_WRITER[1][0] = TEST_WRITER[0][0]
-      TEST_WRITER[0][0] = tmp
-    }
     assertTraces(4) {
       trace(1) {
         // PRODUCER span 0
@@ -149,7 +142,7 @@ class KafkaStreamsTest extends AgentTestRunner {
           resourceName "Consume Topic $STREAM_PENDING"
           spanType "queue"
           errored false
-          childOf TEST_WRITER[0][0]
+          childOf trace(0)[0]
           tags {
             "$Tags.COMPONENT" "java-kafka"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
@@ -185,7 +178,7 @@ class KafkaStreamsTest extends AgentTestRunner {
           resourceName "Consume Topic $STREAM_PENDING"
           spanType "queue"
           errored false
-          childOf TEST_WRITER[0][0]
+          childOf trace(0)[0]
 
           tags {
             "$Tags.COMPONENT" "java-kafka"
@@ -205,7 +198,7 @@ class KafkaStreamsTest extends AgentTestRunner {
           resourceName "Consume Topic $STREAM_PROCESSED"
           spanType "queue"
           errored false
-          childOf TEST_WRITER[2][0]
+          childOf trace(2)[0]
           tags {
             "$Tags.COMPONENT" "java-kafka"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/src/test/groovy/KafkaStreamsTest.groovy
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/src/test/groovy/KafkaStreamsTest.groovy
@@ -125,9 +125,9 @@ class KafkaStreamsTest extends AgentTestRunner {
       TEST_WRITER[0][0] = tmp
     }
     assertTraces(4) {
-      trace(0, 1) {
+      trace(1) {
         // PRODUCER span 0
-        span(0) {
+        span {
           serviceName "kafka"
           operationName "kafka.produce"
           resourceName "Produce Topic $STREAM_PENDING"
@@ -141,9 +141,9 @@ class KafkaStreamsTest extends AgentTestRunner {
           }
         }
       }
-      trace(1, 1) {
+      trace(1) {
         // CONSUMER span 0
-        span(0) {
+        span {
           serviceName "kafka"
           operationName "kafka.consume"
           resourceName "Consume Topic $STREAM_PENDING"
@@ -160,10 +160,10 @@ class KafkaStreamsTest extends AgentTestRunner {
           }
         }
       }
-      trace(2, 2) {
+      trace(2) {
 
         // STREAMING span 0
-        span(0) {
+        span {
           serviceName "kafka"
           operationName "kafka.produce"
           resourceName "Produce Topic $STREAM_PROCESSED"
@@ -179,7 +179,7 @@ class KafkaStreamsTest extends AgentTestRunner {
         }
 
         // STREAMING span 1
-        span(1) {
+        span {
           serviceName "kafka"
           operationName "kafka.consume"
           resourceName "Consume Topic $STREAM_PENDING"
@@ -197,9 +197,9 @@ class KafkaStreamsTest extends AgentTestRunner {
           }
         }
       }
-      trace(3, 1) {
+      trace(1) {
         // CONSUMER span 0
-        span(0) {
+        span {
           serviceName "kafka"
           operationName "kafka.consume"
           resourceName "Consume Topic $STREAM_PROCESSED"

--- a/dd-java-agent/instrumentation/lettuce-4/src/test/groovy/Lettuce4AsyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/lettuce-4/src/test/groovy/Lettuce4AsyncClientTest.groovy
@@ -110,8 +110,8 @@ class Lettuce4AsyncClientTest extends AgentTestRunner {
     then:
     connection != null
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "redis"
           operationName "redis.query"
           spanType DDSpanTypes.REDIS
@@ -148,8 +148,8 @@ class Lettuce4AsyncClientTest extends AgentTestRunner {
     connection == null
     thrown RedisConnectionException
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "redis"
           operationName "redis.query"
           spanType DDSpanTypes.REDIS
@@ -179,8 +179,8 @@ class Lettuce4AsyncClientTest extends AgentTestRunner {
     expect:
     res == "OK"
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "redis"
           operationName "redis.query"
           spanType DDSpanTypes.REDIS
@@ -217,8 +217,8 @@ class Lettuce4AsyncClientTest extends AgentTestRunner {
     then:
     conds.await()
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "redis"
           operationName "redis.query"
           spanType DDSpanTypes.REDIS
@@ -269,8 +269,8 @@ class Lettuce4AsyncClientTest extends AgentTestRunner {
     then:
     conds.await()
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "redis"
           operationName "redis.query"
           spanType DDSpanTypes.REDIS
@@ -307,8 +307,8 @@ class Lettuce4AsyncClientTest extends AgentTestRunner {
     then:
     conds.await()
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "redis"
           operationName "redis.query"
           spanType DDSpanTypes.REDIS
@@ -364,8 +364,8 @@ class Lettuce4AsyncClientTest extends AgentTestRunner {
     then:
     conds.await()
     assertTraces(2) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "redis"
           operationName "redis.query"
           spanType DDSpanTypes.REDIS
@@ -380,8 +380,8 @@ class Lettuce4AsyncClientTest extends AgentTestRunner {
           }
         }
       }
-      trace(1, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "redis"
           operationName "redis.query"
           spanType DDSpanTypes.REDIS
@@ -426,8 +426,8 @@ class Lettuce4AsyncClientTest extends AgentTestRunner {
     completedExceptionally == true
     thrown Exception
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "redis"
           operationName "redis.query"
           spanType DDSpanTypes.REDIS
@@ -467,8 +467,8 @@ class Lettuce4AsyncClientTest extends AgentTestRunner {
     conds.await()
     cancelSuccess == true
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "redis"
           operationName "redis.query"
           spanType DDSpanTypes.REDIS
@@ -493,8 +493,8 @@ class Lettuce4AsyncClientTest extends AgentTestRunner {
 
     expect:
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "redis"
           operationName "redis.query"
           spanType DDSpanTypes.REDIS
@@ -519,8 +519,8 @@ class Lettuce4AsyncClientTest extends AgentTestRunner {
 
     expect:
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "redis"
           operationName "redis.query"
           spanType DDSpanTypes.REDIS

--- a/dd-java-agent/instrumentation/lettuce-4/src/test/groovy/Lettuce4SyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/lettuce-4/src/test/groovy/Lettuce4SyncClientTest.groovy
@@ -91,8 +91,8 @@ class Lettuce4SyncClientTest extends AgentTestRunner {
 
     then:
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "redis"
           operationName "redis.query"
           spanType DDSpanTypes.REDIS
@@ -127,8 +127,8 @@ class Lettuce4SyncClientTest extends AgentTestRunner {
     then:
     thrown RedisConnectionException
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "redis"
           operationName "redis.query"
           spanType DDSpanTypes.REDIS
@@ -157,8 +157,8 @@ class Lettuce4SyncClientTest extends AgentTestRunner {
     expect:
     res == "OK"
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "redis"
           operationName "redis.query"
           spanType DDSpanTypes.REDIS
@@ -183,8 +183,8 @@ class Lettuce4SyncClientTest extends AgentTestRunner {
     expect:
     res == "TESTVAL"
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "redis"
           operationName "redis.query"
           spanType DDSpanTypes.REDIS
@@ -209,8 +209,8 @@ class Lettuce4SyncClientTest extends AgentTestRunner {
     expect:
     res == null
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "redis"
           operationName "redis.query"
           spanType DDSpanTypes.REDIS
@@ -235,8 +235,8 @@ class Lettuce4SyncClientTest extends AgentTestRunner {
     expect:
     keyRetrieved != null
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "redis"
           operationName "redis.query"
           spanType DDSpanTypes.REDIS
@@ -261,8 +261,8 @@ class Lettuce4SyncClientTest extends AgentTestRunner {
     expect:
     res == 1
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "redis"
           operationName "redis.query"
           spanType DDSpanTypes.REDIS
@@ -287,8 +287,8 @@ class Lettuce4SyncClientTest extends AgentTestRunner {
     expect:
     res == "OK"
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "redis"
           operationName "redis.query"
           spanType DDSpanTypes.REDIS
@@ -313,8 +313,8 @@ class Lettuce4SyncClientTest extends AgentTestRunner {
     expect:
     res == testHashMap
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "redis"
           operationName "redis.query"
           spanType DDSpanTypes.REDIS
@@ -338,8 +338,8 @@ class Lettuce4SyncClientTest extends AgentTestRunner {
 
     expect:
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "redis"
           operationName "redis.query"
           spanType DDSpanTypes.REDIS
@@ -363,8 +363,8 @@ class Lettuce4SyncClientTest extends AgentTestRunner {
 
     expect:
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "redis"
           operationName "redis.query"
           spanType DDSpanTypes.REDIS

--- a/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/Lettuce5AsyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/Lettuce5AsyncClientTest.groovy
@@ -113,8 +113,8 @@ class Lettuce5AsyncClientTest extends AgentTestRunner {
     then:
     connection != null
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "redis"
           operationName "redis.query"
           spanType DDSpanTypes.REDIS
@@ -152,8 +152,8 @@ class Lettuce5AsyncClientTest extends AgentTestRunner {
     connection == null
     thrown ExecutionException
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "redis"
           operationName "redis.query"
           spanType DDSpanTypes.REDIS
@@ -183,8 +183,8 @@ class Lettuce5AsyncClientTest extends AgentTestRunner {
     expect:
     res == "OK"
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "redis"
           operationName "redis.query"
           spanType DDSpanTypes.REDIS
@@ -221,8 +221,8 @@ class Lettuce5AsyncClientTest extends AgentTestRunner {
     then:
     conds.await()
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "redis"
           operationName "redis.query"
           spanType DDSpanTypes.REDIS
@@ -273,8 +273,8 @@ class Lettuce5AsyncClientTest extends AgentTestRunner {
     then:
     conds.await()
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "redis"
           operationName "redis.query"
           spanType DDSpanTypes.REDIS
@@ -311,8 +311,8 @@ class Lettuce5AsyncClientTest extends AgentTestRunner {
     then:
     conds.await()
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "redis"
           operationName "redis.query"
           spanType DDSpanTypes.REDIS
@@ -368,8 +368,8 @@ class Lettuce5AsyncClientTest extends AgentTestRunner {
     then:
     conds.await()
     assertTraces(2) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "redis"
           operationName "redis.query"
           spanType DDSpanTypes.REDIS
@@ -384,8 +384,8 @@ class Lettuce5AsyncClientTest extends AgentTestRunner {
           }
         }
       }
-      trace(1, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "redis"
           operationName "redis.query"
           spanType DDSpanTypes.REDIS
@@ -430,8 +430,8 @@ class Lettuce5AsyncClientTest extends AgentTestRunner {
     completedExceptionally == true
     thrown Exception
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "redis"
           operationName "redis.query"
           spanType DDSpanTypes.REDIS
@@ -471,8 +471,8 @@ class Lettuce5AsyncClientTest extends AgentTestRunner {
     conds.await()
     cancelSuccess == true
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "redis"
           operationName "redis.query"
           spanType DDSpanTypes.REDIS
@@ -497,8 +497,8 @@ class Lettuce5AsyncClientTest extends AgentTestRunner {
 
     expect:
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "redis"
           operationName "redis.query"
           spanType DDSpanTypes.REDIS
@@ -523,8 +523,8 @@ class Lettuce5AsyncClientTest extends AgentTestRunner {
 
     expect:
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "redis"
           operationName "redis.query"
           spanType DDSpanTypes.REDIS

--- a/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/Lettuce5ReactiveClientTest.groovy
+++ b/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/Lettuce5ReactiveClientTest.groovy
@@ -1,10 +1,7 @@
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.asserts.ListWriterAssert
 import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
-import groovy.transform.stc.ClosureParams
-import groovy.transform.stc.SimpleType
 import io.lettuce.core.ClientOptions
 import io.lettuce.core.RedisClient
 import io.lettuce.core.api.StatefulConnection
@@ -92,8 +89,8 @@ class Lettuce5ReactiveClientTest extends AgentTestRunner {
     then:
     conds.await()
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "redis"
           operationName "redis.query"
           spanType DDSpanTypes.REDIS
@@ -121,8 +118,8 @@ class Lettuce5ReactiveClientTest extends AgentTestRunner {
     then:
     conds.await()
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "redis"
           operationName "redis.query"
           spanType DDSpanTypes.REDIS
@@ -158,8 +155,8 @@ class Lettuce5ReactiveClientTest extends AgentTestRunner {
     then:
     conds.await()
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "redis"
           operationName "redis.query"
           spanType DDSpanTypes.REDIS
@@ -193,8 +190,8 @@ class Lettuce5ReactiveClientTest extends AgentTestRunner {
     then:
     conds.await()
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "redis"
           operationName "redis.query"
           spanType DDSpanTypes.REDIS
@@ -218,8 +215,8 @@ class Lettuce5ReactiveClientTest extends AgentTestRunner {
 
     expect:
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "redis"
           operationName "redis.query"
           spanType DDSpanTypes.REDIS
@@ -244,8 +241,8 @@ class Lettuce5ReactiveClientTest extends AgentTestRunner {
 
     expect:
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "redis"
           operationName "redis.query"
           spanType DDSpanTypes.REDIS
@@ -283,8 +280,8 @@ class Lettuce5ReactiveClientTest extends AgentTestRunner {
 
     expect:
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "redis"
           operationName "redis.query"
           spanType DDSpanTypes.REDIS
@@ -308,8 +305,8 @@ class Lettuce5ReactiveClientTest extends AgentTestRunner {
 
     expect:
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "redis"
           operationName "redis.query"
           spanType DDSpanTypes.REDIS
@@ -336,9 +333,10 @@ class Lettuce5ReactiveClientTest extends AgentTestRunner {
     }
 
     then:
-    sortAndAssertTraces(1) {
-      trace(0, 3) {
-        span(0) {
+    assertTraces(1) {
+      sortSpansByStart()
+      trace(3) {
+        span {
           operationName "test-parent"
           resourceName "test-parent"
           errored false
@@ -347,7 +345,7 @@ class Lettuce5ReactiveClientTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           childOf(span(0))
           serviceName "redis"
           operationName "redis.query"
@@ -362,7 +360,7 @@ class Lettuce5ReactiveClientTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(2) {
+        span {
           childOf(span(0))
           serviceName "redis"
           operationName "redis.query"
@@ -390,9 +388,10 @@ class Lettuce5ReactiveClientTest extends AgentTestRunner {
     }
 
     then:
-    sortAndAssertTraces(1) {
-      trace(0, 3) {
-        span(0) {
+    assertTraces(1) {
+      sortSpansByStart()
+      trace(3) {
+        span {
           operationName "test-parent"
           resourceName "test-parent"
           errored false
@@ -401,7 +400,7 @@ class Lettuce5ReactiveClientTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           childOf(span(0))
           serviceName "redis"
           operationName "redis.query"
@@ -416,7 +415,7 @@ class Lettuce5ReactiveClientTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(2) {
+        span {
           childOf(span(0))
           serviceName "redis"
           operationName "redis.query"
@@ -445,9 +444,10 @@ class Lettuce5ReactiveClientTest extends AgentTestRunner {
     }
 
     then:
-    sortAndAssertTraces(1) {
-      trace(0, 3) {
-        span(0) {
+    assertTraces(1) {
+      sortSpansByStart()
+      trace(3) {
+        span {
           operationName "test-parent"
           resourceName "test-parent"
           errored false
@@ -456,7 +456,7 @@ class Lettuce5ReactiveClientTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           childOf(span(0))
           serviceName "redis"
           operationName "redis.query"
@@ -471,7 +471,7 @@ class Lettuce5ReactiveClientTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(2) {
+        span {
           childOf(span(0))
           serviceName "redis"
           operationName "redis.query"
@@ -488,23 +488,5 @@ class Lettuce5ReactiveClientTest extends AgentTestRunner {
         }
       }
     }
-  }
-
-  void sortAndAssertTraces(
-    final int size,
-    @ClosureParams(value = SimpleType, options = "datadog.trace.agent.test.asserts.ListWriterAssert")
-    @DelegatesTo(value = ListWriterAssert, strategy = Closure.DELEGATE_FIRST)
-    final Closure spec) {
-
-    TEST_WRITER.waitForTraces(size)
-
-    TEST_WRITER.each {
-      it.sort({
-        a, b ->
-          return a.startTime <=> b.startTime
-      })
-    }
-
-    assertTraces(size, spec)
   }
 }

--- a/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/Lettuce5SyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/Lettuce5SyncClientTest.groovy
@@ -93,8 +93,8 @@ class Lettuce5SyncClientTest extends AgentTestRunner {
 
     then:
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "redis"
           operationName "redis.query"
           spanType DDSpanTypes.REDIS
@@ -129,8 +129,8 @@ class Lettuce5SyncClientTest extends AgentTestRunner {
     then:
     thrown RedisConnectionException
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "redis"
           operationName "redis.query"
           spanType DDSpanTypes.REDIS
@@ -159,8 +159,8 @@ class Lettuce5SyncClientTest extends AgentTestRunner {
     expect:
     res == "OK"
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "redis"
           operationName "redis.query"
           spanType DDSpanTypes.REDIS
@@ -185,8 +185,8 @@ class Lettuce5SyncClientTest extends AgentTestRunner {
     expect:
     res == "TESTVAL"
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "redis"
           operationName "redis.query"
           spanType DDSpanTypes.REDIS
@@ -211,8 +211,8 @@ class Lettuce5SyncClientTest extends AgentTestRunner {
     expect:
     res == null
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "redis"
           operationName "redis.query"
           spanType DDSpanTypes.REDIS
@@ -237,8 +237,8 @@ class Lettuce5SyncClientTest extends AgentTestRunner {
     expect:
     keyRetrieved != null
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "redis"
           operationName "redis.query"
           spanType DDSpanTypes.REDIS
@@ -263,8 +263,8 @@ class Lettuce5SyncClientTest extends AgentTestRunner {
     expect:
     res == 1
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "redis"
           operationName "redis.query"
           spanType DDSpanTypes.REDIS
@@ -289,8 +289,8 @@ class Lettuce5SyncClientTest extends AgentTestRunner {
     expect:
     res == "OK"
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "redis"
           operationName "redis.query"
           spanType DDSpanTypes.REDIS
@@ -315,8 +315,8 @@ class Lettuce5SyncClientTest extends AgentTestRunner {
     expect:
     res == testHashMap
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "redis"
           operationName "redis.query"
           spanType DDSpanTypes.REDIS
@@ -340,8 +340,8 @@ class Lettuce5SyncClientTest extends AgentTestRunner {
 
     expect:
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "redis"
           operationName "redis.query"
           spanType DDSpanTypes.REDIS
@@ -365,8 +365,8 @@ class Lettuce5SyncClientTest extends AgentTestRunner {
 
     expect:
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "redis"
           operationName "redis.query"
           spanType DDSpanTypes.REDIS

--- a/dd-java-agent/instrumentation/mongo/driver-3.1/src/test/groovy/MongoClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-3.1/src/test/groovy/MongoClientTest.groovy
@@ -46,7 +46,7 @@ class MongoClientTest extends MongoBaseTest {
 
     then:
     assertTraces(1) {
-      trace(0, 1) {
+      trace(1) {
         mongoSpan(it, 0, "{\"create\":\"$collectionName\",\"capped\":\"?\"}", renameService)
       }
     }
@@ -66,7 +66,7 @@ class MongoClientTest extends MongoBaseTest {
 
     then:
     assertTraces(1) {
-      trace(0, 1) {
+      trace(1) {
         mongoSpan(it, 0, "{\"create\":\"$collectionName\",\"capped\":\"?\"}", false, dbName)
       }
     }
@@ -86,7 +86,7 @@ class MongoClientTest extends MongoBaseTest {
     then:
     count == 0
     assertTraces(1) {
-      trace(0, 1) {
+      trace(1) {
         mongoSpan(it, 0, "{\"count\":\"$collectionName\",\"query\":{}}")
       }
     }
@@ -112,10 +112,10 @@ class MongoClientTest extends MongoBaseTest {
     then:
     collection.count() == 1
     assertTraces(2) {
-      trace(0, 1) {
+      trace(1) {
         mongoSpan(it, 0, "{\"insert\":\"$collectionName\",\"ordered\":\"?\",\"documents\":[{\"_id\":\"?\",\"password\":\"?\"}]}")
       }
-      trace(1, 1) {
+      trace(1) {
         mongoSpan(it, 0, "{\"count\":\"$collectionName\",\"query\":{}}")
       }
     }
@@ -146,10 +146,10 @@ class MongoClientTest extends MongoBaseTest {
     result.modifiedCount == 1
     collection.count() == 1
     assertTraces(2) {
-      trace(0, 1) {
+      trace(1) {
         mongoSpan(it, 0, "{\"update\":\"?\",\"ordered\":\"?\",\"updates\":[{\"q\":{\"password\":\"?\"},\"u\":{\"\$set\":{\"password\":\"?\"}}}]}")
       }
-      trace(1, 1) {
+      trace(1) {
         mongoSpan(it, 0, "{\"count\":\"$collectionName\",\"query\":{}}")
       }
     }
@@ -178,10 +178,10 @@ class MongoClientTest extends MongoBaseTest {
     result.deletedCount == 1
     collection.count() == 0
     assertTraces(2) {
-      trace(0, 1) {
+      trace(1) {
         mongoSpan(it, 0, "{\"delete\":\"?\",\"ordered\":\"?\",\"deletes\":[{\"q\":{\"password\":\"?\"},\"limit\":\"?\"}]}")
       }
-      trace(1, 1) {
+      trace(1) {
         mongoSpan(it, 0, "{\"count\":\"$collectionName\",\"query\":{}}")
       }
     }
@@ -234,7 +234,7 @@ class MongoClientTest extends MongoBaseTest {
   }
 
   def mongoSpan(TraceAssert trace, int index, String statement, boolean renameService = false, String instance = "some-description", Object parentSpan = null, Throwable exception = null) {
-    trace.span(index) {
+    trace.span {
       serviceName renameService ? instance : "mongo"
       operationName "mongo.query"
       resourceName {

--- a/dd-java-agent/instrumentation/mongo/driver-async-3.3/src/test/groovy/MongoAsyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-async-3.3/src/test/groovy/MongoAsyncClientTest.groovy
@@ -8,10 +8,10 @@ import com.mongodb.async.client.MongoDatabase
 import com.mongodb.client.result.DeleteResult
 import com.mongodb.client.result.UpdateResult
 import com.mongodb.connection.ClusterSettings
-import datadog.trace.core.DDSpan
 import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
+import datadog.trace.core.DDSpan
 import org.bson.BsonDocument
 import org.bson.BsonString
 import org.bson.Document
@@ -54,7 +54,7 @@ class MongoAsyncClientTest extends MongoBaseTest {
 
     then:
     assertTraces(1) {
-      trace(0, 1) {
+      trace(1) {
         mongoSpan(it, 0) {
           assert it.replaceAll(" ", "") == "{\"create\":\"$collectionName\",\"capped\":\"?\"}" ||
             it == "{\"create\": \"$collectionName\", \"capped\": \"?\", \"\$db\": \"?\", \"\$readPreference\": {\"mode\": \"?\"}}"
@@ -77,7 +77,7 @@ class MongoAsyncClientTest extends MongoBaseTest {
 
     then:
     assertTraces(1) {
-      trace(0, 1) {
+      trace(1) {
         mongoSpan(it, 0, {
           assert it.replaceAll(" ", "") == "{\"create\":\"$collectionName\",\"capped\":\"?\"}" ||
             it == "{\"create\": \"$collectionName\", \"capped\": \"?\", \"\$db\": \"?\", \"\$readPreference\": {\"mode\": \"?\"}}"
@@ -102,7 +102,7 @@ class MongoAsyncClientTest extends MongoBaseTest {
     then:
     count.get() == 0
     assertTraces(1) {
-      trace(0, 1) {
+      trace(1) {
         mongoSpan(it, 0) {
           assert it.replaceAll(" ", "") == "{\"count\":\"$collectionName\",\"query\":{}}" ||
             it == "{\"count\": \"$collectionName\", \"query\": {}, \"\$db\": \"?\", \"\$readPreference\": {\"mode\": \"?\"}}"
@@ -137,14 +137,14 @@ class MongoAsyncClientTest extends MongoBaseTest {
     then:
     count.get() == 1
     assertTraces(2) {
-      trace(0, 1) {
+      trace(1) {
         mongoSpan(it, 0) {
           assert it.replaceAll(" ", "") == "{\"insert\":\"$collectionName\",\"ordered\":\"?\",\"documents\":[{\"_id\":\"?\",\"password\":\"?\"}]}" ||
             it == "{\"insert\": \"$collectionName\", \"ordered\": \"?\", \"\$db\": \"?\", \"documents\": [{\"_id\": \"?\", \"password\": \"?\"}]}"
           true
         }
       }
-      trace(1, 1) {
+      trace(1) {
         mongoSpan(it, 0) {
           assert it.replaceAll(" ", "") == "{\"count\":\"$collectionName\",\"query\":{}}" ||
             it == "{\"count\": \"$collectionName\", \"query\": {}, \"\$db\": \"?\", \"\$readPreference\": {\"mode\": \"?\"}}"
@@ -188,14 +188,14 @@ class MongoAsyncClientTest extends MongoBaseTest {
     result.get().modifiedCount == 1
     count.get() == 1
     assertTraces(2) {
-      trace(0, 1) {
+      trace(1) {
         mongoSpan(it, 0) {
           assert it.replaceAll(" ", "") == "{\"update\":\"?\",\"ordered\":\"?\",\"updates\":[{\"q\":{\"password\":\"?\"},\"u\":{\"\$set\":{\"password\":\"?\"}}}]}" ||
             it == "{\"update\": \"?\", \"ordered\": \"?\", \"\$db\": \"?\", \"updates\": [{\"q\": {\"password\": \"?\"}, \"u\": {\"\$set\": {\"password\": \"?\"}}}]}"
           true
         }
       }
-      trace(1, 1) {
+      trace(1) {
         mongoSpan(it, 0) {
           assert it.replaceAll(" ", "") == "{\"count\":\"$collectionName\",\"query\":{}}" ||
             it == "{\"count\": \"$collectionName\", \"query\": {}, \"\$db\": \"?\", \"\$readPreference\": {\"mode\": \"?\"}}"
@@ -237,14 +237,14 @@ class MongoAsyncClientTest extends MongoBaseTest {
     result.get().deletedCount == 1
     count.get() == 0
     assertTraces(2) {
-      trace(0, 1) {
+      trace(1) {
         mongoSpan(it, 0) {
           assert it.replaceAll(" ", "") == "{\"delete\":\"?\",\"ordered\":\"?\",\"deletes\":[{\"q\":{\"password\":\"?\"},\"limit\":\"?\"}]}" ||
             it == "{\"delete\": \"?\", \"ordered\": \"?\", \"\$db\": \"?\", \"deletes\": [{\"q\": {\"password\": \"?\"}, \"limit\": \"?\"}]}"
           true
         }
       }
-      trace(1, 1) {
+      trace(1) {
         mongoSpan(it, 0) {
           assert it.replaceAll(" ", "") == "{\"count\":\"$collectionName\",\"query\":{}}" ||
             it == "{\"count\": \"$collectionName\", \"query\": {}, \"\$db\": \"?\", \"\$readPreference\": {\"mode\": \"?\"}}"
@@ -272,7 +272,7 @@ class MongoAsyncClientTest extends MongoBaseTest {
   }
 
   def mongoSpan(TraceAssert trace, int index, Closure<Boolean> statementEval, String instance = "some-description", Object parentSpan = null, Throwable exception = null) {
-    trace.span(index) {
+    trace.span {
       serviceName "mongo"
       operationName "mongo.query"
       resourceName statementEval

--- a/dd-java-agent/instrumentation/netty-3.8/src/latestDepTest/groovy/Netty38ClientTest.groovy
+++ b/dd-java-agent/instrumentation/netty-3.8/src/latestDepTest/groovy/Netty38ClientTest.groovy
@@ -82,10 +82,10 @@ class Netty38ClientTest extends HttpClientTest {
 
     and:
     assertTraces(1) {
-      trace(0, 2) {
-        basicSpan(it, 0, "parent", null, thrownException)
+      trace(2) {
+        basicSpan(it, "parent", null, thrownException)
 
-        span(1) {
+        span {
           operationName "netty.connect"
           resourceName "netty.connect"
           childOf span(0)

--- a/dd-java-agent/instrumentation/netty-3.8/src/test/groovy/Netty38ClientTest.groovy
+++ b/dd-java-agent/instrumentation/netty-3.8/src/test/groovy/Netty38ClientTest.groovy
@@ -82,10 +82,10 @@ class Netty38ClientTest extends HttpClientTest {
 
     and:
     assertTraces(1) {
-      trace(0, 2) {
-        basicSpan(it, 0, "parent", null, thrownException)
+      trace(2) {
+        basicSpan(it, "parent", null, thrownException)
 
-        span(1) {
+        span {
           operationName "netty.connect"
           resourceName "netty.connect"
           childOf span(0)

--- a/dd-java-agent/instrumentation/netty-4.0/src/test/groovy/Netty40ClientTest.groovy
+++ b/dd-java-agent/instrumentation/netty-4.0/src/test/groovy/Netty40ClientTest.groovy
@@ -82,10 +82,10 @@ class Netty40ClientTest extends HttpClientTest {
 
     and:
     assertTraces(1) {
-      trace(0, 2) {
-        basicSpan(it, 0, "parent", null, thrownException)
+      trace(2) {
+        basicSpan(it, "parent", null, thrownException)
 
-        span(1) {
+        span {
           operationName "netty.connect"
           resourceName "netty.connect"
           childOf span(0)

--- a/dd-java-agent/instrumentation/netty-4.1/src/test/groovy/Netty41ClientTest.groovy
+++ b/dd-java-agent/instrumentation/netty-4.1/src/test/groovy/Netty41ClientTest.groovy
@@ -93,10 +93,10 @@ class Netty41ClientTest extends HttpClientTest {
 
     and:
     assertTraces(1) {
-      trace(0, 2) {
-        basicSpan(it, 0, "parent", null, thrownException)
+      trace(2) {
+        basicSpan(it, "parent", null, thrownException)
 
-        span(1) {
+        span {
           operationName "netty.connect"
           resourceName "netty.connect"
           childOf span(0)
@@ -198,10 +198,9 @@ class Netty41ClientTest extends HttpClientTest {
     then:
     status == 200
     assertTraces(2) {
-      server.distributedRequestTrace(it, 0, trace(1).last())
-      trace(1, size(3)) {
-        basicSpan(it, 0, "parent")
-        span(1) {
+      trace(size(3)) {
+        basicSpan(it, "parent")
+        span {
           childOf((DDSpan) span(0))
           operationName "trace.annotation"
           resourceName "AnnotatedClass.makeRequestUnderTrace"
@@ -211,8 +210,9 @@ class Netty41ClientTest extends HttpClientTest {
             defaultTags()
           }
         }
-        clientSpan(it, 2, span(1), method)
+        clientSpan(it, span(1), method)
       }
+      server.distributedRequestTrace(it, trace(0).last())
     }
 
     where:

--- a/dd-java-agent/instrumentation/okhttp-2/src/test/groovy/HeadersUtil.groovy
+++ b/dd-java-agent/instrumentation/okhttp-2/src/test/groovy/HeadersUtil.groovy
@@ -3,7 +3,7 @@ class HeadersUtil {
     String[] headersArr = new String[headers.size() * 2]
     headers.eachWithIndex { k, v, i ->
       headersArr[i] = k
-      headersArr[i+1] = v
+      headersArr[i + 1] = v
     }
 
     headersArr

--- a/dd-java-agent/instrumentation/okhttp-3/src/test/groovy/OkHttp3Test.groovy
+++ b/dd-java-agent/instrumentation/okhttp-3/src/test/groovy/OkHttp3Test.groovy
@@ -54,7 +54,7 @@ class OkHttp3Test extends HttpClientTest {
     then:
     status == 200
     assertTraces(1) {
-      server.distributedRequestTrace(it, 0)
+      server.distributedRequestTrace(it)
     }
 
     where:

--- a/dd-java-agent/instrumentation/opentelemetry/src/test/groovy/OpenTelemetryTest.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/src/test/groovy/OpenTelemetryTest.groovy
@@ -50,8 +50,8 @@ class OpenTelemetryTest extends AgentTestRunner {
 
     then:
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           parent()
           operationName "test-inst"
           if (tagSpan) {
@@ -111,8 +111,8 @@ class OpenTelemetryTest extends AgentTestRunner {
 
     then:
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           parent()
           operationName "test-inst"
           resourceName "some name"
@@ -153,8 +153,8 @@ class OpenTelemetryTest extends AgentTestRunner {
 
     then:
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           if (expectedId) {
             traceDDId(DDId.ONE)
             parentDDId(DDId.from(expectedId))

--- a/dd-java-agent/instrumentation/opentracing/api-0.31/src/test/groovy/OpenTracing31Test.groovy
+++ b/dd-java-agent/instrumentation/opentracing/api-0.31/src/test/groovy/OpenTracing31Test.groovy
@@ -63,8 +63,8 @@ class OpenTracing31Test extends AgentTestRunner {
 
     then:
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           if ([References.CHILD_OF, References.FOLLOWS_FROM].contains(addReference)) {
             parentDDId(DDId.from(2))
           } else {

--- a/dd-java-agent/instrumentation/opentracing/api-0.32/src/test/groovy/OpenTracing32Test.groovy
+++ b/dd-java-agent/instrumentation/opentracing/api-0.32/src/test/groovy/OpenTracing32Test.groovy
@@ -63,8 +63,8 @@ class OpenTracing32Test extends AgentTestRunner {
 
     then:
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           if ([References.CHILD_OF, References.FOLLOWS_FROM].contains(addReference)) {
             parentDDId(DDId.from(2))
           } else {

--- a/dd-java-agent/instrumentation/play-2.3/src/test/groovy/server/PlayServerTest.groovy
+++ b/dd-java-agent/instrumentation/play-2.3/src/test/groovy/server/PlayServerTest.groovy
@@ -1,11 +1,11 @@
 package server
 
-import datadog.trace.core.DDSpan
 import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.agent.test.base.HttpServerTest
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import datadog.trace.bootstrap.instrumentation.api.Tags
+import datadog.trace.core.DDSpan
 import datadog.trace.instrumentation.netty38.server.NettyHttpServerDecorator
 import datadog.trace.instrumentation.play23.PlayHttpServerDecorator
 import play.api.test.TestServer
@@ -50,8 +50,8 @@ class PlayServerTest extends HttpServerTest<TestServer> {
   }
 
   @Override
-  void handlerSpan(TraceAssert trace, int index, Object parent, ServerEndpoint endpoint = SUCCESS) {
-    trace.span(index) {
+  void handlerSpan(TraceAssert trace, Object parent, ServerEndpoint endpoint = SUCCESS) {
+    trace.span {
       serviceName expectedServiceName()
       operationName "play.request"
       spanType DDSpanTypes.HTTP_SERVER

--- a/dd-java-agent/instrumentation/play-2.4/src/test/groovy/server/PlayServerTest.groovy
+++ b/dd-java-agent/instrumentation/play-2.4/src/test/groovy/server/PlayServerTest.groovy
@@ -1,11 +1,11 @@
 package server
 
-import datadog.trace.core.DDSpan
 import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.agent.test.base.HttpServerTest
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import datadog.trace.bootstrap.instrumentation.api.Tags
+import datadog.trace.core.DDSpan
 import datadog.trace.instrumentation.netty40.server.NettyHttpServerDecorator
 import datadog.trace.instrumentation.play24.PlayHttpServerDecorator
 import play.mvc.Results
@@ -86,8 +86,8 @@ class PlayServerTest extends HttpServerTest<Server> {
   }
 
   @Override
-  void handlerSpan(TraceAssert trace, int index, Object parent, ServerEndpoint endpoint = SUCCESS) {
-    trace.span(index) {
+  void handlerSpan(TraceAssert trace, Object parent, ServerEndpoint endpoint = SUCCESS) {
+    trace.span {
       serviceName expectedServiceName()
       operationName "play.request"
       spanType DDSpanTypes.HTTP_SERVER

--- a/dd-java-agent/instrumentation/play-2.6/src/test/groovy/server/PlayServerTest.groovy
+++ b/dd-java-agent/instrumentation/play-2.6/src/test/groovy/server/PlayServerTest.groovy
@@ -1,11 +1,11 @@
 package server
 
-import datadog.trace.core.DDSpan
 import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.agent.test.base.HttpServerTest
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import datadog.trace.bootstrap.instrumentation.api.Tags
+import datadog.trace.core.DDSpan
 import datadog.trace.instrumentation.akkahttp.AkkaHttpServerDecorator
 import datadog.trace.instrumentation.play26.PlayHttpServerDecorator
 import play.BuiltInComponents
@@ -88,8 +88,8 @@ class PlayServerTest extends HttpServerTest<Server> {
   }
 
   @Override
-  void handlerSpan(TraceAssert trace, int index, Object parent, ServerEndpoint endpoint = SUCCESS) {
-    trace.span(index) {
+  void handlerSpan(TraceAssert trace, Object parent, ServerEndpoint endpoint = SUCCESS) {
+    trace.span {
       serviceName expectedServiceName()
       operationName "play.request"
       spanType DDSpanTypes.HTTP_SERVER
@@ -113,8 +113,8 @@ class PlayServerTest extends HttpServerTest<Server> {
     }
   }
 
-  void serverSpan(TraceAssert trace, int index, BigInteger traceID = null, BigInteger parentID = null, String method = "GET", ServerEndpoint endpoint = SUCCESS) {
-    trace.span(index) {
+  void serverSpan(TraceAssert trace, BigInteger traceID = null, BigInteger parentID = null, String method = "GET", ServerEndpoint endpoint = SUCCESS) {
+    trace.span {
       serviceName expectedServiceName()
       operationName expectedOperationName()
       resourceName endpoint.status == 404 ? "404" : "$method ${endpoint.resolve(address).path}"

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/test/groovy/RabbitMQTest.groovy
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/test/groovy/RabbitMQTest.groovy
@@ -27,6 +27,7 @@ import java.time.Duration
 import java.util.concurrent.Phaser
 
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
+
 // Do not run tests locally on Java7 since testcontainers are not compatible with Java7
 // It is fine to run on CI because CI provides rabbitmq externally, not through testcontainers
 @Requires({ "true" == System.getenv("CI") || jvm.java8Compatible })
@@ -155,8 +156,8 @@ class RabbitMQTest extends AgentTestRunner {
     setup:
     channel.exchangeDeclare(exchangeName, "direct", false)
     String queueName = (messageCount % 2 == 0) ?
-    channel.queueDeclare().getQueue() :
-    channel.queueDeclare("some-queue", false, true, true, null).getQueue()
+      channel.queueDeclare().getQueue() :
+      channel.queueDeclare("some-queue", false, true, true, null).getQueue()
     channel.queueBind(queueName, exchangeName, "")
 
     def phaser = new Phaser()
@@ -219,15 +220,15 @@ class RabbitMQTest extends AgentTestRunner {
     deliveries == (1..messageCount).collect { "msg $it" }
 
     where:
-    exchangeName     | messageCount | setTimestamp
-    "some-exchange"  | 1            | false
-    "some-exchange"  | 2            | false
-    "some-exchange"  | 3            | false
-    "some-exchange"  | 4            | false
-    "some-exchange"  | 1            | true
-    "some-exchange"  | 2            | true
-    "some-exchange"  | 3            | true
-    "some-exchange"  | 4            | true
+    exchangeName    | messageCount | setTimestamp
+    "some-exchange" | 1            | false
+    "some-exchange" | 2            | false
+    "some-exchange" | 3            | false
+    "some-exchange" | 4            | false
+    "some-exchange" | 1            | true
+    "some-exchange" | 2            | true
+    "some-exchange" | 3            | true
+    "some-exchange" | 4            | true
   }
 
   def "test rabbit consume error"() {

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/test/groovy/RabbitMQTest.groovy
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/test/groovy/RabbitMQTest.groovy
@@ -146,7 +146,7 @@ class RabbitMQTest extends AgentTestRunner {
         rabbitSpan(it, "basic.publish <default> -> <generated>")
       }
       trace(1) {
-        rabbitSpan(it, "basic.get <generated>", true, trace(0)[0])
+        rabbitSpan(it, "basic.get <generated>", true, trace(1)[0])
       }
     }
   }

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/test/groovy/RabbitMQTest.groovy
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/test/groovy/RabbitMQTest.groovy
@@ -113,14 +113,13 @@ class RabbitMQTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        // reverse order
         rabbitSpan(it, "basic.publish $exchangeName -> $routingKey", false, span(0))
         rabbitSpan(it, "queue.bind", false, span(0))
         rabbitSpan(it, "queue.declare", false, span(0))
         rabbitSpan(it, "exchange.declare", false, span(0))
       }
       trace(1) {
-        rabbitSpan(it, "basic.get <generated>", true, TEST_WRITER[1][1])
+        rabbitSpan(it, "basic.get <generated>", true, trace(0)[1])
       }
     }
 
@@ -147,7 +146,7 @@ class RabbitMQTest extends AgentTestRunner {
         rabbitSpan(it, "basic.publish <default> -> <generated>")
       }
       trace(1) {
-        rabbitSpan(it, "basic.get <generated>", true, TEST_WRITER[1][0])
+        rabbitSpan(it, "basic.get <generated>", true, trace(0)[0])
       }
     }
   }
@@ -338,7 +337,7 @@ class RabbitMQTest extends AgentTestRunner {
         rabbitSpan(it, "basic.publish <default> -> some-routing-queue")
       }
       trace(1) {
-        rabbitSpan(it, "basic.get $queue.name", true, TEST_WRITER[1][0])
+        rabbitSpan(it, "basic.get $queue.name", true, trace(1)[0])
       }
     }
   }

--- a/dd-java-agent/instrumentation/ratpack-1.5/src/test/groovy/RatpackOtherTest.groovy
+++ b/dd-java-agent/instrumentation/ratpack-1.5/src/test/groovy/RatpackOtherTest.groovy
@@ -61,8 +61,8 @@ class RatpackOtherTest extends AgentTestRunner {
     resp.body.string() == route
 
     assertTraces(1) {
-      trace(0, 2) {
-        span(0) {
+      trace(2) {
+        span {
           resourceName "GET /$route"
           operationName "netty.request"
           spanType DDSpanTypes.HTTP_SERVER
@@ -79,7 +79,7 @@ class RatpackOtherTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           resourceName "GET /$route"
           operationName "ratpack.handler"
           spanType DDSpanTypes.HTTP_SERVER

--- a/dd-java-agent/instrumentation/ratpack-1.5/src/test/groovy/server/RatpackHttpServerTest.groovy
+++ b/dd-java-agent/instrumentation/ratpack-1.5/src/test/groovy/server/RatpackHttpServerTest.groovy
@@ -1,11 +1,11 @@
 package server
 
-import datadog.trace.core.DDSpan
 import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.agent.test.base.HttpServerTest
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import datadog.trace.bootstrap.instrumentation.api.Tags
+import datadog.trace.core.DDSpan
 import datadog.trace.instrumentation.netty41.server.NettyHttpServerDecorator
 import datadog.trace.instrumentation.ratpack.RatpackServerDecorator
 import ratpack.error.ServerErrorHandler
@@ -114,8 +114,8 @@ class RatpackHttpServerTest extends HttpServerTest<EmbeddedApp> {
   }
 
   @Override
-  void handlerSpan(TraceAssert trace, int index, Object parent, ServerEndpoint endpoint = SUCCESS) {
-    trace.span(index) {
+  void handlerSpan(TraceAssert trace, Object parent, ServerEndpoint endpoint = SUCCESS) {
+    trace.span {
       serviceName expectedServiceName()
       operationName "ratpack.handler"
       spanType DDSpanTypes.HTTP_SERVER

--- a/dd-java-agent/instrumentation/reactor-core-3.1/src/test/groovy/ReactorCoreTest.groovy
+++ b/dd-java-agent/instrumentation/reactor-core-3.1/src/test/groovy/ReactorCoreTest.groovy
@@ -1,11 +1,8 @@
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.asserts.ListWriterAssert
 import datadog.trace.api.Trace
 import datadog.trace.bootstrap.instrumentation.api.AgentScope
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan
 import datadog.trace.bootstrap.instrumentation.api.Tags
-import groovy.transform.stc.ClosureParams
-import groovy.transform.stc.SimpleType
 import org.reactivestreams.Publisher
 import org.reactivestreams.Subscriber
 import org.reactivestreams.Subscription
@@ -48,9 +45,10 @@ class ReactorCoreTest extends AgentTestRunner {
     then:
     result == expected
     and:
-    sortAndAssertTraces(1) {
-      trace(0, workSpans + 2) {
-        span(0) {
+    assertTraces(1) {
+      sortSpansByStart()
+      trace(workSpans + 2) {
+        span {
           resourceName "trace-parent"
           operationName "trace-parent"
           parent()
@@ -60,10 +58,10 @@ class ReactorCoreTest extends AgentTestRunner {
           }
         }
 
-        basicSpan(it, 1, "publisher-parent", "publisher-parent", span(0))
+        basicSpan(it, "publisher-parent", "publisher-parent", span(0))
 
         for (int i = 0; i < workSpans; i++) {
-          span(i + 2) {
+          span {
             resourceName "addOne"
             operationName "addOne"
             childOf(span(1))
@@ -104,9 +102,10 @@ class ReactorCoreTest extends AgentTestRunner {
     def exception = thrown RuntimeException
     exception.message == EXCEPTION_MESSAGE
     and:
-    sortAndAssertTraces(1) {
-      trace(0, 2) {
-        span(0) {
+    assertTraces(1) {
+      sortSpansByStart()
+      trace(2) {
+        span {
           resourceName "trace-parent"
           operationName "trace-parent"
           parent()
@@ -122,7 +121,7 @@ class ReactorCoreTest extends AgentTestRunner {
         // impact the spans on reactor integrations such as netty and lettuce, as reactor is
         // more of a context propagation mechanism than something we would be tracking for
         // errors this is ok.
-        basicSpan(it, 1, "publisher-parent", "publisher-parent", span(0))
+        basicSpan(it, "publisher-parent", "publisher-parent", span(0))
       }
     }
 
@@ -140,9 +139,10 @@ class ReactorCoreTest extends AgentTestRunner {
     def exception = thrown RuntimeException
     exception.message == EXCEPTION_MESSAGE
     and:
-    sortAndAssertTraces(1) {
-      trace(0, workSpans + 2) {
-        span(0) {
+    assertTraces(1) {
+      sortSpansByStart()
+      trace(workSpans + 2) {
+        span {
           resourceName "trace-parent"
           operationName "trace-parent"
           parent()
@@ -158,10 +158,10 @@ class ReactorCoreTest extends AgentTestRunner {
         // impact the spans on reactor integrations such as netty and lettuce, as reactor is
         // more of a context propagation mechanism than something we would be tracking for
         // errors this is ok.
-        basicSpan(it, 1, "publisher-parent", "publisher-parent", span(0))
+        basicSpan(it, "publisher-parent", "publisher-parent", span(0))
 
         for (int i = 0; i < workSpans; i++) {
-          span(i + 2) {
+          span {
             resourceName "addOne"
             operationName "addOne"
             childOf(span(1))
@@ -186,8 +186,8 @@ class ReactorCoreTest extends AgentTestRunner {
 
     then:
     assertTraces(1) {
-      trace(0, 2) {
-        span(0) {
+      trace(2) {
+        span {
           resourceName "trace-parent"
           operationName "trace-parent"
           parent()
@@ -197,7 +197,7 @@ class ReactorCoreTest extends AgentTestRunner {
           }
         }
 
-        basicSpan(it, 1, "publisher-parent", "publisher-parent", span(0))
+        basicSpan(it, "publisher-parent", "publisher-parent", span(0))
       }
     }
 
@@ -213,8 +213,8 @@ class ReactorCoreTest extends AgentTestRunner {
 
     then:
     assertTraces(1) {
-      trace(0, workSpans + 2) {
-        span(0) {
+      trace(workSpans + 2) {
+        span {
           resourceName "trace-parent"
           operationName "trace-parent"
           parent()
@@ -224,10 +224,10 @@ class ReactorCoreTest extends AgentTestRunner {
           }
         }
 
-        basicSpan(it, 1, "publisher-parent", "publisher-parent", span(0))
+        basicSpan(it, "publisher-parent", "publisher-parent", span(0))
 
         for (int i = 0; i < workSpans; i++) {
-          span(i + 2) {
+          span {
             resourceName "addOne"
             operationName "addOne"
             childOf(span(1))
@@ -269,9 +269,10 @@ class ReactorCoreTest extends AgentTestRunner {
     }
 
     then:
-    sortAndAssertTraces(1) {
-      trace(0, (workItems * 2) + 3) {
-        span(0) {
+    assertTraces(1) {
+      sortSpansByStart()
+      trace((workItems * 2) + 3) {
+        span {
           resourceName "trace-parent"
           operationName "trace-parent"
           parent()
@@ -281,11 +282,11 @@ class ReactorCoreTest extends AgentTestRunner {
           }
         }
 
-        basicSpan(it, 1, "publisher-parent", "publisher-parent", span(0))
-        basicSpan(it, 2, "intermediate", "intermediate", span(1))
+        basicSpan(it, "publisher-parent", "publisher-parent", span(0))
+        basicSpan(it, "intermediate", "intermediate", span(1))
 
         for (int i = 0; i < workItems * 2; i++) {
-          span(i + 3) {
+          span {
             resourceName "addOne"
             operationName "addOne"
             childOf(span(i % 2 == 0 ? 1 : 2))
@@ -326,9 +327,10 @@ class ReactorCoreTest extends AgentTestRunner {
     }
 
     then:
-    sortAndAssertTraces(1 + workItems) {
-      trace(0, 2 + workItems) {
-        span(0) {
+    assertTraces(1 + workItems) {
+      sortSpansByStart()
+      trace(2 + workItems) {
+        span {
           resourceName "trace-parent"
           operationName "trace-parent"
           parent()
@@ -338,10 +340,10 @@ class ReactorCoreTest extends AgentTestRunner {
           }
         }
 
-        basicSpan(it, 1, "publisher-parent", "publisher-parent", span(0))
+        basicSpan(it, "publisher-parent", "publisher-parent", span(0))
 
         for (int i = 0; i < workItems; i++) {
-          span(2 + i) {
+          span {
             resourceName "addOne"
             operationName "addOne"
             childOf(span(1))
@@ -353,8 +355,8 @@ class ReactorCoreTest extends AgentTestRunner {
         }
       }
       for (int i = 0; i < workItems; i++) {
-        trace(i + 1, 1) {
-          span(0) {
+        trace(1) {
+          span {
             resourceName "addOne"
             operationName "addOne"
             parent()
@@ -425,26 +427,5 @@ class ReactorCoreTest extends AgentTestRunner {
   @Trace(operationName = "addOne", resourceName = "addOne")
   def static addOneFunc(int i) {
     return i + 1
-  }
-
-  void sortAndAssertTraces(
-    final int size,
-    @ClosureParams(value = SimpleType, options = "datadog.trace.agent.test.asserts.ListWriterAssert")
-    @DelegatesTo(value = ListWriterAssert, strategy = Closure.DELEGATE_FIRST)
-    final Closure spec) {
-
-    TEST_WRITER.waitForTraces(size)
-
-    TEST_WRITER.each {
-      it.sort({ a, b ->
-        return a.startTimeNano <=> b.startTimeNano
-      })
-    }
-
-    TEST_WRITER.sort({ a, b ->
-      return a[0].startTimeNano <=> b[0].startTimeNano
-    })
-
-    assertTraces(size, spec)
   }
 }

--- a/dd-java-agent/instrumentation/rediscala-1.8.0/src/test/groovy/RediscalaClientTest.groovy
+++ b/dd-java-agent/instrumentation/rediscala-1.8.0/src/test/groovy/RediscalaClientTest.groovy
@@ -77,8 +77,8 @@ class RediscalaClientTest extends AgentTestRunner {
     then:
     Await.result(value, Duration.apply("3 second")) == true
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "redis"
           operationName "redis.query"
           resourceName "Set"
@@ -109,8 +109,8 @@ class RediscalaClientTest extends AgentTestRunner {
     Await.result(write, Duration.apply("3 second")) == true
     Await.result(value, Duration.apply("3 second")) == Option.apply("baz")
     assertTraces(2) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "redis"
           operationName "redis.query"
           resourceName "Set"
@@ -123,8 +123,8 @@ class RediscalaClientTest extends AgentTestRunner {
           }
         }
       }
-      trace(1, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "redis"
           operationName "redis.query"
           resourceName "Get"

--- a/dd-java-agent/instrumentation/rmi/src/test/groovy/RmiTest.groovy
+++ b/dd-java-agent/instrumentation/rmi/src/test/groovy/RmiTest.groovy
@@ -35,10 +35,10 @@ class RmiTest extends AgentTestRunner {
 
     then:
     response.contains("Hello you")
-    assertTraces(TEST_WRITER, 2) {
-      trace(1, 2) {
-        basicSpan(it, 0, "parent")
-        span(1) {
+    assertTraces(2) {
+      trace(2) {
+        basicSpan(it, "parent")
+        span {
           resourceName "Greeter.hello"
           operationName "rmi.invoke"
           childOf span(0)
@@ -52,8 +52,8 @@ class RmiTest extends AgentTestRunner {
           }
         }
       }
-      trace(0, 2) {
-        span(0) {
+      trace(2) {
+        span {
           resourceName "Server.hello"
           operationName "rmi.request"
           spanType DDSpanTypes.RPC
@@ -65,7 +65,7 @@ class RmiTest extends AgentTestRunner {
             defaultTags(true)
           }
         }
-        span(1) {
+        span {
           resourceName "Server.someMethod"
           operationName "rmi.request"
           spanType DDSpanTypes.RPC
@@ -115,10 +115,10 @@ class RmiTest extends AgentTestRunner {
 
     then:
     def thrownException = thrown(RuntimeException)
-    assertTraces(TEST_WRITER, 2) {
-      trace(1, 2) {
-        basicSpan(it, 0, "parent", null, thrownException)
-        span(1) {
+    assertTraces(2) {
+      trace(2) {
+        basicSpan(it, "parent", null, thrownException)
+        span {
           resourceName "Greeter.exceptional"
           operationName "rmi.invoke"
           childOf span(0)
@@ -134,8 +134,8 @@ class RmiTest extends AgentTestRunner {
           }
         }
       }
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           resourceName "Server.exceptional"
           operationName "rmi.request"
           errored true
@@ -169,11 +169,10 @@ class RmiTest extends AgentTestRunner {
 
     then:
     response.contains("Hello you")
-    assertTraces(TEST_WRITER, 2) {
-      def parentSpan = TEST_WRITER[1][1]
-      trace(1, 2) {
-        basicSpan(it, 0, "parent")
-        span(1) {
+    assertTraces(2) {
+      trace(2) {
+        basicSpan(it, "parent")
+        span {
           resourceName "Greeter.hello"
           operationName "rmi.invoke"
           spanType DDSpanTypes.RPC
@@ -186,10 +185,9 @@ class RmiTest extends AgentTestRunner {
           }
         }
       }
-
-      trace(0, 1) {
-        span(0) {
-          childOf parentSpan
+      trace(1) {
+        span {
+          childOf TEST_WRITER[1][1]
           resourceName "ServerLegacy.hello"
           operationName "rmi.request"
           spanType DDSpanTypes.RPC

--- a/dd-java-agent/instrumentation/rmi/src/test/groovy/RmiTest.groovy
+++ b/dd-java-agent/instrumentation/rmi/src/test/groovy/RmiTest.groovy
@@ -187,7 +187,7 @@ class RmiTest extends AgentTestRunner {
       }
       trace(1) {
         span {
-          childOf trace(1)[1]
+          childOf trace(0)[1]
           resourceName "ServerLegacy.hello"
           operationName "rmi.request"
           spanType DDSpanTypes.RPC

--- a/dd-java-agent/instrumentation/rmi/src/test/groovy/RmiTest.groovy
+++ b/dd-java-agent/instrumentation/rmi/src/test/groovy/RmiTest.groovy
@@ -187,7 +187,7 @@ class RmiTest extends AgentTestRunner {
       }
       trace(1) {
         span {
-          childOf TEST_WRITER[1][1]
+          childOf trace(1)[1]
           resourceName "ServerLegacy.hello"
           operationName "rmi.request"
           spanType DDSpanTypes.RPC

--- a/dd-java-agent/instrumentation/scala-concurrent/src/slickTest/groovy/SlickTest.groovy
+++ b/dd-java-agent/instrumentation/scala-concurrent/src/slickTest/groovy/SlickTest.groovy
@@ -16,8 +16,8 @@ class SlickTest extends AgentTestRunner {
     result == SlickUtils.TestValue()
 
     assertTraces(1) {
-      trace(0, 2) {
-        span(0) {
+      trace(2) {
+        span {
           operationName "trace.annotation"
           resourceName "SlickUtils.startQuery"
           parent()
@@ -27,7 +27,7 @@ class SlickTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           operationName "${SlickUtils.Driver()}.query"
           serviceName SlickUtils.Driver()
           resourceName SlickUtils.TestQuery()
@@ -62,13 +62,13 @@ class SlickTest extends AgentTestRunner {
 
     // Expect two traces because two queries have been run
     assertTraces(2) {
-      trace(0, 2, {
-        span(0) {}
-        span(1) { spanType DDSpanTypes.SQL }
+      trace(2, {
+        span {}
+        span { spanType DDSpanTypes.SQL }
       })
-      trace(1, 2, {
-        span(0) {}
-        span(1) { spanType DDSpanTypes.SQL }
+      trace(2, {
+        span {}
+        span { spanType DDSpanTypes.SQL }
       })
     }
   }

--- a/dd-java-agent/instrumentation/servlet/request-2/src/test/groovy/JettyServlet2Test.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-2/src/test/groovy/JettyServlet2Test.groovy
@@ -84,8 +84,8 @@ class JettyServlet2Test extends HttpServerTest<Server> {
   }
 
   // parent span must be cast otherwise it breaks debugging classloading (junit loads it early)
-  void serverSpan(TraceAssert trace, int index, BigInteger traceID = null, BigInteger parentID = null, String method = "GET", ServerEndpoint endpoint = SUCCESS) {
-    trace.span(index) {
+  void serverSpan(TraceAssert trace, BigInteger traceID = null, BigInteger parentID = null, String method = "GET", ServerEndpoint endpoint = SUCCESS) {
+    trace.span {
       serviceName expectedServiceName()
       operationName expectedOperationName()
       resourceName endpoint.resource(method, address, testPathParam())

--- a/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/AbstractServlet3Test.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/AbstractServlet3Test.groovy
@@ -76,8 +76,8 @@ abstract class AbstractServlet3Test<SERVER, CONTEXT> extends HttpServerTest<SERV
   }
 
   @Override
-  void serverSpan(TraceAssert trace, int index, BigInteger traceID = null, BigInteger parentID = null, String method = "GET", ServerEndpoint endpoint = SUCCESS) {
-    trace.span(index) {
+  void serverSpan(TraceAssert trace, BigInteger traceID = null, BigInteger parentID = null, String method = "GET", ServerEndpoint endpoint = SUCCESS) {
+    trace.span {
       serviceName expectedServiceName()
       operationName expectedOperationName()
       resourceName endpoint.status == 404 ? "404" : "$method ${endpoint.resolve(address).path}"

--- a/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/JettyServlet3Test.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/JettyServlet3Test.groovy
@@ -243,7 +243,7 @@ abstract class JettyDispatchTest extends JettyServlet3Test {
     assert toRemove.size() == size
     toRemove.each {
       assertTrace(it, 1) {
-        basicSpan(it, 0, "TEST_SPAN", "ServerEntry")
+        basicSpan(it, "TEST_SPAN", "ServerEntry")
       }
     }
     TEST_WRITER.removeAll(toRemove)
@@ -256,7 +256,7 @@ abstract class JettyDispatchTest extends JettyServlet3Test {
     dispatchTraces.each { List<DDSpan> dispatchTrace ->
       assertTrace(dispatchTrace, 1) {
         def endpoint = lastRequest
-        span(0) {
+        span {
           serviceName expectedServiceName()
           operationName expectedOperationName()
           resourceName endpoint.status == 404 ? "404" : "GET ${endpoint.resolve(address).path}"

--- a/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/TomcatServlet3Test.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/TomcatServlet3Test.groovy
@@ -119,9 +119,9 @@ abstract class TomcatServlet3Test extends AbstractServlet3Test<Tomcat, Context> 
     and:
     cleanAndAssertTraces(count) {
       (1..count).eachWithIndex { val, i ->
-        trace(i, 2) {
-          serverSpan(it, 0)
-          controllerSpan(it, 1, span(0))
+        trace(2) {
+          serverSpan(it)
+          controllerSpan(it, span(0))
         }
 
         def (String traceId, String spanId) = accessLogValue.loggedIds[i]
@@ -147,9 +147,9 @@ abstract class TomcatServlet3Test extends AbstractServlet3Test<Tomcat, Context> 
 
     and:
     cleanAndAssertTraces(1) {
-      trace(0, 2) {
-        serverSpan(it, 0, null, null, method, ERROR)
-        controllerSpan(it, 1, span(0))
+      trace(2) {
+        serverSpan(it, null, null, method, ERROR)
+        controllerSpan(it, span(0))
       }
 
       def (String traceId, String spanId) = accessLogValue.loggedIds[0]
@@ -394,7 +394,7 @@ abstract class TomcatDispatchTest extends TomcatServlet3Test {
     assert toRemove.size() == size
     toRemove.each {
       assertTrace(it, 1) {
-        basicSpan(it, 0, "TEST_SPAN", "ServerEntry")
+        basicSpan(it, "TEST_SPAN", "ServerEntry")
       }
     }
     TEST_WRITER.removeAll(toRemove)
@@ -413,7 +413,7 @@ abstract class TomcatDispatchTest extends TomcatServlet3Test {
     dispatchTraces.each { List<DDSpan> dispatchTrace ->
       assertTrace(dispatchTrace, 1) {
         def endpoint = lastRequest
-        span(0) {
+        span {
           serviceName expectedServiceName()
           operationName expectedOperationName()
           resourceName endpoint.status == 404 ? "404" : "GET ${endpoint.resolve(address).path}"

--- a/dd-java-agent/instrumentation/servlet/src/test/groovy/FilterTest.groovy
+++ b/dd-java-agent/instrumentation/servlet/src/test/groovy/FilterTest.groovy
@@ -34,9 +34,9 @@ class FilterTest extends AgentTestRunner {
 
     then:
     assertTraces(1) {
-      trace(0, 2) {
-        basicSpan(it, 0, "parent")
-        span(1) {
+      trace(2) {
+        basicSpan(it, "parent")
+        span {
           operationName "servlet.filter"
           resourceName "${filter.class.simpleName}.doFilter"
           childOf span(0)
@@ -72,9 +72,9 @@ class FilterTest extends AgentTestRunner {
     th == ex
 
     assertTraces(1) {
-      trace(0, 2) {
-        basicSpan(it, 0, "parent", null, ex)
-        span(1) {
+      trace(2) {
+        basicSpan(it, "parent", null, ex)
+        span {
           operationName "servlet.filter"
           resourceName "${filter.class.simpleName}.doFilter"
           childOf span(0)

--- a/dd-java-agent/instrumentation/servlet/src/test/groovy/HttpServletResponseTest.groovy
+++ b/dd-java-agent/instrumentation/servlet/src/test/groovy/HttpServletResponseTest.groovy
@@ -52,9 +52,9 @@ class HttpServletResponseTest extends AgentTestRunner {
 
     then:
     assertTraces(1) {
-      trace(0, 4) {
-        basicSpan(it, 0, "parent")
-        span(1) {
+      trace(4) {
+        basicSpan(it, "parent")
+        span {
           operationName "servlet.response"
           resourceName "HttpServletResponse.sendRedirect"
           childOf span(0)
@@ -63,7 +63,7 @@ class HttpServletResponseTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(2) {
+        span {
           operationName "servlet.response"
           resourceName "HttpServletResponse.sendError"
           childOf span(0)
@@ -72,7 +72,7 @@ class HttpServletResponseTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(3) {
+        span {
           operationName "servlet.response"
           resourceName "HttpServletResponse.sendError"
           childOf span(0)
@@ -110,9 +110,9 @@ class HttpServletResponseTest extends AgentTestRunner {
     th == ex
 
     assertTraces(1) {
-      trace(0, 2) {
-        basicSpan(it, 0, "parent", null, ex)
-        span(1) {
+      trace(2) {
+        basicSpan(it, "parent", null, ex)
+        span {
           operationName "servlet.response"
           resourceName "HttpServletResponse.sendRedirect"
           childOf span(0)

--- a/dd-java-agent/instrumentation/servlet/src/test/groovy/HttpServletTest.groovy
+++ b/dd-java-agent/instrumentation/servlet/src/test/groovy/HttpServletTest.groovy
@@ -37,9 +37,9 @@ class HttpServletTest extends AgentTestRunner {
 
     then:
     assertTraces(1) {
-      trace(0, 3) {
-        basicSpan(it, 0, "parent")
-        span(1) {
+      trace(3) {
+        basicSpan(it, "parent")
+        span {
           operationName "servlet.service"
           resourceName "HttpServlet.service"
           childOf span(0)
@@ -48,7 +48,7 @@ class HttpServletTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(2) {
+        span {
           operationName "servlet.doGet"
           resourceName "${expectedResourceName}.doGet"
           childOf span(1)
@@ -90,9 +90,9 @@ class HttpServletTest extends AgentTestRunner {
     th == ex
 
     assertTraces(1) {
-      trace(0, 3) {
-        basicSpan(it, 0, "parent", null, ex)
-        span(1) {
+      trace(3) {
+        basicSpan(it, "parent", null, ex)
+        span {
           operationName "servlet.service"
           resourceName "HttpServlet.service"
           childOf span(0)
@@ -103,7 +103,7 @@ class HttpServletTest extends AgentTestRunner {
             errorTags(ex.class, ex.message)
           }
         }
-        span(2) {
+        span {
           operationName "servlet.doGet"
           resourceName "${servlet.class.name}.doGet"
           childOf span(1)

--- a/dd-java-agent/instrumentation/servlet/src/test/groovy/RequestDispatcherTest.groovy
+++ b/dd-java-agent/instrumentation/servlet/src/test/groovy/RequestDispatcherTest.groovy
@@ -1,4 +1,3 @@
-
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.core.DDSpan
 
@@ -28,11 +27,11 @@ class RequestDispatcherTest extends AgentTestRunner {
     then:
     2 * request.getAttribute(DD_SPAN_ATTRIBUTE)
     assertTraces(2) {
-      trace(0, 1) {
-        basicSpan(it, 0, "forward-child")
+      trace(1) {
+        basicSpan(it, "forward-child")
       }
-      trace(1, 1) {
-        basicSpan(it, 0, "include-child")
+      trace(1) {
+        basicSpan(it, "include-child")
       }
     }
   }
@@ -46,9 +45,9 @@ class RequestDispatcherTest extends AgentTestRunner {
     then:
     1 * request.getAttribute(DD_SPAN_ATTRIBUTE)
     assertTraces(1) {
-      trace(0, 3) {
-        basicSpan(it, 0, "parent")
-        span(1) {
+      trace(3) {
+        basicSpan(it, "parent")
+        span {
           operationName "servlet.$operation"
           resourceName target
           childOf span(0)
@@ -57,7 +56,7 @@ class RequestDispatcherTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        basicSpan(it, 2, "$operation-child", span(1))
+        basicSpan(it, "$operation-child", span(1))
       }
     }
 
@@ -98,9 +97,9 @@ class RequestDispatcherTest extends AgentTestRunner {
 
     1 * request.getAttribute(DD_SPAN_ATTRIBUTE)
     assertTraces(1) {
-      trace(0, 3) {
-        basicSpan(it, 0, "parent", null, ex)
-        span(1) {
+      trace(3) {
+        basicSpan(it, "parent", null, ex)
+        span {
           operationName "servlet.$operation"
           resourceName target
           childOf span(0)
@@ -111,7 +110,7 @@ class RequestDispatcherTest extends AgentTestRunner {
             errorTags(ex.class, ex.message)
           }
         }
-        basicSpan(it, 2, "$operation-child", span(1))
+        basicSpan(it, "$operation-child", span(1))
       }
     }
 

--- a/dd-java-agent/instrumentation/sparkjava-2.3/src/test/groovy/SparkJavaBasedTest.groovy
+++ b/dd-java-agent/instrumentation/sparkjava-2.3/src/test/groovy/SparkJavaBasedTest.groovy
@@ -42,8 +42,8 @@ class SparkJavaBasedTest extends AgentTestRunner {
     response.body().string() == "Hello asdf1234"
 
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           operationName "jetty.request"
           resourceName "GET /param/:param"
           spanType DDSpanTypes.HTTP_SERVER

--- a/dd-java-agent/instrumentation/spring-data-1.8/src/test/groovy/SpringJpaTest.groovy
+++ b/dd-java-agent/instrumentation/spring-data-1.8/src/test/groovy/SpringJpaTest.groovy
@@ -25,8 +25,8 @@ class SpringJpaTest extends AgentTestRunner {
     then:
     // Asserting that a span is NOT created for toString
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           operationName "toString test"
           tags {
             defaultTags()
@@ -52,8 +52,8 @@ class SpringJpaTest extends AgentTestRunner {
     !repo.findAll().iterator().hasNext() // select
 
     assertTraces(1) {
-      trace(0, 2) {
-        span(0) {
+      trace(2) {
+        span {
           operationName "repository.operation"
           resourceName "JpaRepository.findAll"
           errored false
@@ -63,7 +63,7 @@ class SpringJpaTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(1) { // select
+        span { // select
           serviceName "hsqldb"
           spanType "sql"
           childOf(span(0))
@@ -88,8 +88,8 @@ class SpringJpaTest extends AgentTestRunner {
     then:
     customer.id != null
     assertTraces(1) {
-      trace(0, 2) {
-        span(0) {
+      trace(2) {
+        span {
           operationName "repository.operation"
           resourceName "CrudRepository.save"
           errored false
@@ -99,7 +99,7 @@ class SpringJpaTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(1) { // insert
+        span { // insert
           serviceName "hsqldb"
           spanType "sql"
           childOf(span(0))
@@ -124,8 +124,8 @@ class SpringJpaTest extends AgentTestRunner {
     then:
     customer.id == savedId
     assertTraces(1) {
-      trace(0, 3) {
-        span(0) {
+      trace(3) {
+        span {
           operationName "repository.operation"
           resourceName "CrudRepository.save"
           errored false
@@ -135,7 +135,7 @@ class SpringJpaTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(1) { //select
+        span { //select
           serviceName "hsqldb"
           spanType "sql"
           childOf(span(0))
@@ -149,7 +149,7 @@ class SpringJpaTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(2) { //update
+        span { //update
           serviceName "hsqldb"
           spanType "sql"
           childOf(span(0))
@@ -172,8 +172,8 @@ class SpringJpaTest extends AgentTestRunner {
 
     then:
     assertTraces(1) {
-      trace(0, 2) {
-        span(0) {
+      trace(2) {
+        span {
           operationName "repository.operation"
           resourceName "JpaCustomerRepository.findByLastName"
           errored false
@@ -183,7 +183,7 @@ class SpringJpaTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(1) { // select
+        span { // select
           serviceName "hsqldb"
           spanType "sql"
           childOf(span(0))
@@ -206,8 +206,8 @@ class SpringJpaTest extends AgentTestRunner {
 
     then:
     assertTraces(1) {
-      trace(0, 3) {
-        span(0) {
+      trace(3) {
+        span {
           operationName "repository.operation"
           resourceName "CrudRepository.delete"
           errored false
@@ -217,7 +217,7 @@ class SpringJpaTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(1) { // select
+        span { // select
           serviceName "hsqldb"
           spanType "sql"
           childOf(span(0))
@@ -231,7 +231,7 @@ class SpringJpaTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(2) { // delete
+        span { // delete
           serviceName "hsqldb"
           spanType "sql"
           childOf(span(0))

--- a/dd-java-agent/instrumentation/spring-jms-3.1/src/test/groovy/SpringSAListenerTest.groovy
+++ b/dd-java-agent/instrumentation/spring-jms-3.1/src/test/groovy/SpringSAListenerTest.groovy
@@ -46,8 +46,8 @@ class SpringSAListenerTest extends AgentTestRunner {
     // The framework continues to poll the queue and will generate additional "jms.consume/JMS receive" traces when the receive times out, so we want to ignore these additional traces.
     assertTraces(3, true) {
       producerTrace(it, "Queue SpringSAListenerJMS")
-      consumerTrace(it, "Queue SpringSAListenerJMS", false, ActiveMQMessageConsumer)
-      consumerTrace(it, "Queue SpringSAListenerJMS", true, SATestListener)
+      consumerTrace(it, "Queue SpringSAListenerJMS", false, ActiveMQMessageConsumer, trace(0)[0])
+      consumerTrace(it, "Queue SpringSAListenerJMS", true, SATestListener, trace(0)[0])
     }
 
     cleanup:
@@ -74,7 +74,7 @@ class SpringSAListenerTest extends AgentTestRunner {
     }
   }
 
-  static consumerTrace(ListWriterAssert writer, String jmsResourceName, boolean messageListener, Class origin, DDSpan parentSpan = TEST_WRITER[0][0]) {
+  static consumerTrace(ListWriterAssert writer, String jmsResourceName, boolean messageListener, Class origin, DDSpan parentSpan) {
     writer.trace(1) {
       span {
         serviceName "jms"

--- a/dd-java-agent/instrumentation/spring-jms-3.1/src/test/groovy/SpringSAListenerTest.groovy
+++ b/dd-java-agent/instrumentation/spring-jms-3.1/src/test/groovy/SpringSAListenerTest.groovy
@@ -43,7 +43,8 @@ class SpringSAListenerTest extends AgentTestRunner {
     template.convertAndSend("SpringSAListenerJMS", "a message")
 
     expect:
-    assertTraces(3) {
+    // The framework continues to poll the queue and will generate additional "jms.consume/JMS receive" traces when the receive times out, so we want to ignore these additional traces.
+    assertTraces(3, true) {
       producerTrace(it, "Queue SpringSAListenerJMS")
       consumerTrace(it, "Queue SpringSAListenerJMS", false, ActiveMQMessageConsumer)
       consumerTrace(it, "Queue SpringSAListenerJMS", true, SATestListener)

--- a/dd-java-agent/instrumentation/spring-scheduling-3.1/src/test/groovy/SpringAsyncTest.groovy
+++ b/dd-java-agent/instrumentation/spring-scheduling-3.1/src/test/groovy/SpringAsyncTest.groovy
@@ -5,7 +5,7 @@ import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 
 class SpringAsyncTest extends AgentTestRunner {
 
-  def "context propagated through @async annotation" () {
+  def "context propagated through @async annotation"() {
     setup:
     def context = new AnnotationConfigApplicationContext(AsyncTaskConfig)
     AsyncTask asyncTask = context.getBean(AsyncTask)
@@ -15,16 +15,16 @@ class SpringAsyncTest extends AgentTestRunner {
     }
     then:
     assertTraces(1) {
-      trace(0, 3) {
-        span(0) {
+      trace(3) {
+        span {
           resourceName "root"
         }
-        span(1) {
+        span {
           resourceName "AsyncTask.async"
           threadNameStartsWith "SimpleAsyncTaskExecutor"
           childOf span(0)
         }
-        span(2) {
+        span {
           resourceName "AsyncTask.getInt"
           threadNameStartsWith "SimpleAsyncTaskExecutor"
           childOf span(1)

--- a/dd-java-agent/instrumentation/spring-scheduling-3.1/src/test/groovy/SpringSchedulingTest.groovy
+++ b/dd-java-agent/instrumentation/spring-scheduling-3.1/src/test/groovy/SpringSchedulingTest.groovy
@@ -16,8 +16,8 @@ class SpringSchedulingTest extends AgentTestRunner {
     expect:
     assert task != null
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           resourceName "TriggerTask.run"
           operationName "scheduled.call"
           parent()
@@ -29,9 +29,10 @@ class SpringSchedulingTest extends AgentTestRunner {
         }
       }
     }
-    cleanup: context.close()
+    cleanup:
+    context.close()
   }
-  
+
   def "schedule interval test"() {
     setup:
     def context = new AnnotationConfigApplicationContext(IntervalTaskConfig)
@@ -42,8 +43,8 @@ class SpringSchedulingTest extends AgentTestRunner {
     expect:
     assert task != null
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           resourceName "IntervalTask.run"
           operationName "scheduled.call"
           parent()
@@ -55,7 +56,8 @@ class SpringSchedulingTest extends AgentTestRunner {
         }
       }
     }
-    cleanup: context.close()
+    cleanup:
+    context.close()
   }
 
   def "schedule lambda test"() {
@@ -67,8 +69,8 @@ class SpringSchedulingTest extends AgentTestRunner {
 
     expect:
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           resourceNameContains("LambdaTaskConfigurer\$\$Lambda\$")
           operationName "scheduled.call"
           parent()

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/test/groovy/SpringWebfluxTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/test/groovy/SpringWebfluxTest.groovy
@@ -1,5 +1,4 @@
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.asserts.ListWriterAssert
 import datadog.trace.agent.test.utils.OkHttpUtils
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
@@ -7,8 +6,6 @@ import dd.trace.instrumentation.springwebflux.server.EchoHandlerFunction
 import dd.trace.instrumentation.springwebflux.server.FooModel
 import dd.trace.instrumentation.springwebflux.server.SpringWebFluxTestApplication
 import dd.trace.instrumentation.springwebflux.server.TestController
-import groovy.transform.stc.ClosureParams
-import groovy.transform.stc.SimpleType
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody
@@ -49,9 +46,10 @@ class SpringWebfluxTest extends AgentTestRunner {
     then:
     response.code == 200
     response.body().string() == expectedResponseBody
-    sortAndAssertTraces(1) {
-      trace(0, 2) {
-        span(0) {
+    assertTraces(1) {
+      sortSpansByStart()
+      trace(2) {
+        span {
           resourceName "GET $urlPathWithVariables"
           operationName "netty.request"
           spanType DDSpanTypes.HTTP_SERVER
@@ -67,7 +65,7 @@ class SpringWebfluxTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           if (annotatedMethod == null) {
             // Functional API
             resourceNameContains(SPRING_APP_CLASS_ANON_NESTED_CLASS_PREFIX, ".handle")
@@ -121,10 +119,10 @@ class SpringWebfluxTest extends AgentTestRunner {
     then:
     response.code == 200
     response.body().string() == expectedResponseBody
-    sortAndAssertTraces(1) {
-      println TEST_WRITER
-      trace(0, 3) {
-        span(0) {
+    assertTraces(1) {
+      sortSpansByStart()
+      trace(3) {
+        span {
           resourceName "GET $urlPathWithVariables"
           operationName "netty.request"
           spanType DDSpanTypes.HTTP_SERVER
@@ -140,7 +138,7 @@ class SpringWebfluxTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           if (annotatedMethod == null) {
             // Functional API
             resourceNameContains(SPRING_APP_CLASS_ANON_NESTED_CLASS_PREFIX, ".handle")
@@ -168,7 +166,7 @@ class SpringWebfluxTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(2) {
+        span {
           if (annotatedMethod == null) {
             // Functional API
             resourceName "SpringWebFluxTestApplication.tracedMethod"
@@ -209,9 +207,10 @@ class SpringWebfluxTest extends AgentTestRunner {
 
     then:
     response.code == 404
-    sortAndAssertTraces(1) {
-      trace(0, 2) {
-        span(0) {
+    assertTraces(1) {
+      sortSpansByStart()
+      trace(2) {
+        span {
           resourceName "GET /**"
           operationName "netty.request"
           spanType DDSpanTypes.HTTP_SERVER
@@ -227,7 +226,7 @@ class SpringWebfluxTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           resourceName "ResourceWebHandler.handle"
           operationName "ResourceWebHandler.handle"
           spanType DDSpanTypes.HTTP_SERVER
@@ -258,9 +257,10 @@ class SpringWebfluxTest extends AgentTestRunner {
     then:
     response.code() == 202
     response.body().string() == echoString
-    sortAndAssertTraces(1) {
-      trace(0, 3) {
-        span(0) {
+    assertTraces(1) {
+      sortSpansByStart()
+      trace(3) {
+        span {
           resourceName "POST /echo"
           operationName "netty.request"
           spanType DDSpanTypes.HTTP_SERVER
@@ -276,7 +276,7 @@ class SpringWebfluxTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           resourceName EchoHandlerFunction.getSimpleName() + ".handle"
           operationName EchoHandlerFunction.getSimpleName() + ".handle"
           spanType DDSpanTypes.HTTP_SERVER
@@ -291,7 +291,7 @@ class SpringWebfluxTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(2) {
+        span {
           resourceName "echo"
           operationName "echo"
           childOf(span(1))
@@ -314,9 +314,10 @@ class SpringWebfluxTest extends AgentTestRunner {
 
     then:
     response.code() == 500
-    sortAndAssertTraces(1) {
-      trace(0, 2) {
-        span(0) {
+    assertTraces(1) {
+      sortSpansByStart()
+      trace(2) {
+        span {
           resourceName "GET $urlPathWithVariables"
           operationName "netty.request"
           spanType DDSpanTypes.HTTP_SERVER
@@ -333,7 +334,7 @@ class SpringWebfluxTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           if (annotatedMethod == null) {
             // Functional API
             resourceNameContains(SPRING_APP_CLASS_ANON_NESTED_CLASS_PREFIX, ".handle")
@@ -386,10 +387,11 @@ class SpringWebfluxTest extends AgentTestRunner {
 
     then:
     response.code == 200
-    sortAndAssertTraces(2) {
+    assertTraces(2) {
+      sortSpansByStart()
       // TODO: why order of spans is different in these traces?
-      trace(0, 2) {
-        span(0) {
+      trace(2) {
+        span {
           resourceName "GET /double-greet-redirect"
           operationName "netty.request"
           spanType DDSpanTypes.HTTP_SERVER
@@ -405,7 +407,7 @@ class SpringWebfluxTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           resourceName "RedirectComponent.lambda"
           operationName "RedirectComponent.lambda"
           spanType DDSpanTypes.HTTP_SERVER
@@ -422,8 +424,8 @@ class SpringWebfluxTest extends AgentTestRunner {
           }
         }
       }
-      trace(1, 2) {
-        span(0) {
+      trace(2) {
+        span {
           resourceName "GET /double-greet"
           operationName "netty.request"
           spanType DDSpanTypes.HTTP_SERVER
@@ -439,7 +441,7 @@ class SpringWebfluxTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           resourceNameContains(SpringWebFluxTestApplication.getSimpleName() + "\$", ".handle")
           operationNameContains(SpringWebFluxTestApplication.getSimpleName() + "\$", ".handle")
           spanType DDSpanTypes.HTTP_SERVER
@@ -469,10 +471,11 @@ class SpringWebfluxTest extends AgentTestRunner {
     then:
     responses.every { it.code == 200 }
     responses.every { it.body().string() == expectedResponseBody }
-    sortAndAssertTraces(responses.size()) {
+    assertTraces(responses.size()) {
+      sortSpansByStart()
       responses.eachWithIndex { def response, int i ->
-        trace(i, 2) {
-          span(0) {
+        trace(2) {
+          span {
             resourceName "GET $urlPathWithVariables"
             operationName "netty.request"
             spanType DDSpanTypes.HTTP_SERVER
@@ -488,7 +491,7 @@ class SpringWebfluxTest extends AgentTestRunner {
               defaultTags()
             }
           }
-          span(1) {
+          span {
             if (annotatedMethod == null) {
               // Functional API
               resourceNameContains(SPRING_APP_CLASS_ANON_NESTED_CLASS_PREFIX, ".handle")
@@ -524,23 +527,5 @@ class SpringWebfluxTest extends AgentTestRunner {
     testName                          | urlPath          | urlPathWithVariables | annotatedMethod | expectedResponseBody
     "functional API delayed response" | "/greet-delayed" | "/greet-delayed"     | null            | SpringWebFluxTestApplication.GreetingHandler.DEFAULT_RESPONSE
     "annotation API delayed response" | "/foo-delayed"   | "/foo-delayed"       | "getFooDelayed" | new FooModel(3L, "delayed").toString()
-  }
-
-  void sortAndAssertTraces(
-    final int size,
-    @ClosureParams(value = SimpleType, options = "datadog.trace.agent.test.asserts.ListWriterAssert")
-    @DelegatesTo(value = ListWriterAssert, strategy = Closure.DELEGATE_FIRST)
-    final Closure spec) {
-
-    TEST_WRITER.waitForTraces(size)
-
-    TEST_WRITER.each {
-      it.sort({
-        a, b ->
-          return a.startTime <=> b.startTime
-      })
-    }
-
-    assertTraces(size, spec)
   }
 }

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/test/groovy/dd/trace/instrumentation/springwebflux/client/SpringWebfluxHttpClientBase.groovy
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/test/groovy/dd/trace/instrumentation/springwebflux/client/SpringWebfluxHttpClientBase.groovy
@@ -20,6 +20,7 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
 abstract class SpringWebfluxHttpClientBase extends HttpClientTest {
 
   abstract WebClient createClient(String component)
+
   abstract void check()
 
   @Override
@@ -52,11 +53,12 @@ abstract class SpringWebfluxHttpClientBase extends HttpClientTest {
 
   @Override
   // parent spanRef must be cast otherwise it breaks debugging classloading (junit loads it early)
-  void clientSpan(TraceAssert trace, int index, Object parentSpan, String method = "GET", boolean renameService = false, boolean tagQueryString = false, URI uri = server.address.resolve("/success"), Integer status = 200, Throwable exception = null) {
-    super.clientSpan(trace, index, parentSpan, method, renameService, tagQueryString, uri, status, exception)
+  void clientSpan(TraceAssert trace, Object parentSpan, String method = "GET", boolean renameService = false, boolean tagQueryString = false, URI uri = server.address.resolve("/success"), Integer status = 200, Throwable exception = null) {
+    def leafParentId = trace.spanAssertCount.get()
+    super.clientSpan(trace, parentSpan, method, renameService, tagQueryString, uri, status, exception)
     if (!exception) {
-      trace.span(index + 1) {
-        childOf(trace.span(index))
+      trace.span {
+        childOf(trace.span(leafParentId))
         if (renameService) {
           serviceName("localhost")
         }

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/test/groovy/dd/trace/instrumentation/springwebflux/client/SpringWebfluxHttpClientFilterBuilderReuseTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/test/groovy/dd/trace/instrumentation/springwebflux/client/SpringWebfluxHttpClientFilterBuilderReuseTest.groovy
@@ -11,13 +11,13 @@ class SpringWebfluxHttpClientFilterBuilderReuseTest extends SpringWebfluxHttpCli
 
   @Override
   WebClient createClient(String component) {
-    this.filter  = new CollectingFilter()
+    this.filter = new CollectingFilter()
     this.component = component
     def builder = WebClient.builder()
     // add filters before and after, and check that we move our filter first
     builder.filter(filter)
     builder.build()
-    builder.filters( {
+    builder.filters({
       it.add(0, filter)
     })
 

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/test/groovy/dd/trace/instrumentation/springwebflux/client/SpringWebfluxHttpClientFilterTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/test/groovy/dd/trace/instrumentation/springwebflux/client/SpringWebfluxHttpClientFilterTest.groovy
@@ -11,7 +11,7 @@ class SpringWebfluxHttpClientFilterTest extends SpringWebfluxHttpClientBase {
 
   @Override
   WebClient createClient(String component) {
-    filter  = new CollectingFilter()
+    filter = new CollectingFilter()
     this.component = component
     return WebClient.builder().filter(filter).build()
   }

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/boot/SpringBootBasedTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/boot/SpringBootBasedTest.groovy
@@ -87,8 +87,8 @@ class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext>
 
     and:
     cleanAndAssertTraces(1) {
-      trace(0, 1) {
-        serverSpan(it, 0, null, null, "POST", LOGIN)
+      trace(1) {
+        serverSpan(it, null, null, "POST", LOGIN)
       }
     }
 
@@ -145,8 +145,8 @@ class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext>
   }
 
   @Override
-  void handlerSpan(TraceAssert trace, int index, Object parent, ServerEndpoint endpoint = SUCCESS) {
-    trace.span(index) {
+  void handlerSpan(TraceAssert trace, Object parent, ServerEndpoint endpoint = SUCCESS) {
+    trace.span {
       serviceName expectedServiceName()
       operationName "spring.handler"
       resourceName "TestController.${endpoint.name().toLowerCase()}"
@@ -165,8 +165,8 @@ class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext>
   }
 
   @Override
-  void serverSpan(TraceAssert trace, int index, BigInteger traceID = null, BigInteger parentID = null, String method = "GET", ServerEndpoint endpoint = SUCCESS) {
-    trace.span(index) {
+  void serverSpan(TraceAssert trace, BigInteger traceID = null, BigInteger parentID = null, String method = "GET", ServerEndpoint endpoint = SUCCESS) {
+    trace.span {
       serviceName expectedServiceName()
       operationName expectedOperationName()
       resourceName endpoint.resource(method, address, testPathParam())

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/dynamic/DynamicRoutingTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/dynamic/DynamicRoutingTest.groovy
@@ -38,8 +38,8 @@ class DynamicRoutingTest extends ServletFilterTest {
   }
 
   @Override
-  void handlerSpan(TraceAssert trace, int index, Object parent, ServerEndpoint endpoint = SUCCESS) {
-    trace.span(index) {
+  void handlerSpan(TraceAssert trace, Object parent, ServerEndpoint endpoint = SUCCESS) {
+    trace.span {
       serviceName expectedServiceName()
       operationName "spring.handler"
       resourceName "TestController.${formatEndpoint(endpoint)}"
@@ -58,8 +58,8 @@ class DynamicRoutingTest extends ServletFilterTest {
   }
 
   @Override
-  void serverSpan(TraceAssert trace, int index, BigInteger traceID = null, BigInteger parentID = null, String method = "GET", ServerEndpoint endpoint = SUCCESS) {
-    trace.span(index) {
+  void serverSpan(TraceAssert trace, BigInteger traceID = null, BigInteger parentID = null, String method = "GET", ServerEndpoint endpoint = SUCCESS) {
+    trace.span {
       serviceName expectedServiceName()
       operationName expectedOperationName()
       resourceName endpoint.resource(method, address, testPathParam())

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/filter/ServletFilterTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/filter/ServletFilterTest.groovy
@@ -118,8 +118,8 @@ class ServletFilterTest extends HttpServerTest<ConfigurableApplicationContext> {
   }
 
   @Override
-  void handlerSpan(TraceAssert trace, int index, Object parent, ServerEndpoint endpoint = SUCCESS) {
-    trace.span(index) {
+  void handlerSpan(TraceAssert trace, Object parent, ServerEndpoint endpoint = SUCCESS) {
+    trace.span {
       serviceName expectedServiceName()
       operationName "spring.handler"
       resourceName "TestController.${endpoint.name().toLowerCase()}"
@@ -138,8 +138,8 @@ class ServletFilterTest extends HttpServerTest<ConfigurableApplicationContext> {
   }
 
   @Override
-  void serverSpan(TraceAssert trace, int index, BigInteger traceID = null, BigInteger parentID = null, String method = "GET", ServerEndpoint endpoint = SUCCESS) {
-    trace.span(index) {
+  void serverSpan(TraceAssert trace, BigInteger traceID = null, BigInteger parentID = null, String method = "GET", ServerEndpoint endpoint = SUCCESS) {
+    trace.span {
       serviceName expectedServiceName()
       operationName expectedOperationName()
       resourceName endpoint.resource(method, address, testPathParam())

--- a/dd-java-agent/instrumentation/spymemcached-2.12/src/test/groovy/datadog/trace/instrumentation/spymemcached/SpymemcachedTest.groovy
+++ b/dd-java-agent/instrumentation/spymemcached-2.12/src/test/groovy/datadog/trace/instrumentation/spymemcached/SpymemcachedTest.groovy
@@ -153,7 +153,7 @@ class SpymemcachedTest extends AgentTestRunner {
 
     then:
     assertTraces(1) {
-      trace(0, 2) {
+      trace(2) {
         getParentSpan(it, 0)
         getSpan(it, 1, "get", null, "hit")
       }
@@ -168,7 +168,7 @@ class SpymemcachedTest extends AgentTestRunner {
 
     then:
     assertTraces(1) {
-      trace(0, 2) {
+      trace(2) {
         getParentSpan(it, 0)
         getSpan(it, 1, "get", null, "miss")
       }
@@ -185,7 +185,7 @@ class SpymemcachedTest extends AgentTestRunner {
 
     then:
     assertTraces(1) {
-      trace(0, 2) {
+      trace(2) {
         getParentSpan(it, 0)
         getSpan(it, 1, "get", "canceled")
       }
@@ -209,7 +209,7 @@ class SpymemcachedTest extends AgentTestRunner {
 
     then:
     assertTraces(1) {
-      trace(0, 1) {
+      trace(1) {
         getSpan(it, 0, "get", "timeout")
       }
     }
@@ -224,7 +224,7 @@ class SpymemcachedTest extends AgentTestRunner {
 
     then:
     assertTraces(1) {
-      trace(0, 2) {
+      trace(2) {
         getParentSpan(it, 0)
         getSpan(it, 1, "getBulk", null, null)
       }
@@ -239,7 +239,7 @@ class SpymemcachedTest extends AgentTestRunner {
 
     then:
     assertTraces(1) {
-      trace(0, 2) {
+      trace(2) {
         getParentSpan(it, 0)
         getSpan(it, 1, "set")
       }
@@ -256,7 +256,7 @@ class SpymemcachedTest extends AgentTestRunner {
 
     then:
     assertTraces(1) {
-      trace(0, 2) {
+      trace(2) {
         getParentSpan(it, 0)
         getSpan(it, 1, "set", "canceled")
       }
@@ -272,7 +272,7 @@ class SpymemcachedTest extends AgentTestRunner {
 
     then:
     assertTraces(1) {
-      trace(0, 3) {
+      trace(3) {
         getParentSpan(it, 0)
         getSpan(it, 1, "get", null, "hit")
         getSpan(it, 2, "add")
@@ -289,7 +289,7 @@ class SpymemcachedTest extends AgentTestRunner {
 
     then:
     assertTraces(1) {
-      trace(0, 3) {
+      trace(3) {
         getParentSpan(it, 0)
         getSpan(it, 1, "add")
         getSpan(it, 2, "add")
@@ -306,7 +306,7 @@ class SpymemcachedTest extends AgentTestRunner {
 
     then:
     assertTraces(1) {
-      trace(0, 3) {
+      trace(3) {
         getParentSpan(it, 0)
         getSpan(it, 1, "get", null, "miss")
         getSpan(it, 2, "delete")
@@ -322,7 +322,7 @@ class SpymemcachedTest extends AgentTestRunner {
 
     then:
     assertTraces(1) {
-      trace(0, 2) {
+      trace(2) {
         getParentSpan(it, 0)
         getSpan(it, 1, "delete")
       }
@@ -338,7 +338,7 @@ class SpymemcachedTest extends AgentTestRunner {
 
     then:
     assertTraces(1) {
-      trace(0, 3) {
+      trace(3) {
         getParentSpan(it, 0)
         getSpan(it, 1, "get", null, "hit")
         getSpan(it, 2, "replace")
@@ -354,7 +354,7 @@ class SpymemcachedTest extends AgentTestRunner {
 
     then:
     assertTraces(1) {
-      trace(0, 2) {
+      trace(2) {
         getParentSpan(it, 0)
         getSpan(it, 1, "replace")
       }
@@ -371,7 +371,7 @@ class SpymemcachedTest extends AgentTestRunner {
 
     then:
     assertTraces(1) {
-      trace(0, 4) {
+      trace(4) {
         getParentSpan(it, 0)
         getSpan(it, 1, "get", null, "hit")
         getSpan(it, 2, "append")
@@ -390,7 +390,7 @@ class SpymemcachedTest extends AgentTestRunner {
 
     then:
     assertTraces(1) {
-      trace(0, 4) {
+      trace(4) {
         getParentSpan(it, 0)
         getSpan(it, 1, "get", null, "hit")
         getSpan(it, 2, "prepend")
@@ -408,7 +408,7 @@ class SpymemcachedTest extends AgentTestRunner {
 
     then:
     assertTraces(1) {
-      trace(0, 3) {
+      trace(3) {
         getParentSpan(it, 0)
         getSpan(it, 1, "cas")
         getSpan(it, 2, "gets")
@@ -424,7 +424,7 @@ class SpymemcachedTest extends AgentTestRunner {
 
     then:
     assertTraces(1) {
-      trace(0, 2) {
+      trace(2) {
         getParentSpan(it, 0)
         getSpan(it, 1, "cas")
       }
@@ -439,7 +439,7 @@ class SpymemcachedTest extends AgentTestRunner {
 
     then:
     assertTraces(1) {
-      trace(0, 2) {
+      trace(2) {
         getParentSpan(it, 0)
         getSpan(it, 1, "touch")
       }
@@ -454,7 +454,7 @@ class SpymemcachedTest extends AgentTestRunner {
 
     then:
     assertTraces(1) {
-      trace(0, 2) {
+      trace(2) {
         getParentSpan(it, 0)
         getSpan(it, 1, "touch")
       }
@@ -469,7 +469,7 @@ class SpymemcachedTest extends AgentTestRunner {
 
     then:
     assertTraces(1) {
-      trace(0, 2) {
+      trace(2) {
         getParentSpan(it, 0)
         getSpan(it, 1, "getAndTouch")
       }
@@ -484,7 +484,7 @@ class SpymemcachedTest extends AgentTestRunner {
 
     then:
     assertTraces(1) {
-      trace(0, 2) {
+      trace(2) {
         getParentSpan(it, 0)
         getSpan(it, 1, "getAndTouch")
       }
@@ -504,7 +504,7 @@ class SpymemcachedTest extends AgentTestRunner {
 
     then:
     assertTraces(1) {
-      trace(0, 3) {
+      trace(3) {
         getParentSpan(it, 0)
         getSpan(it, 1, "get", null, "hit")
         getSpan(it, 2, "decr")
@@ -520,7 +520,7 @@ class SpymemcachedTest extends AgentTestRunner {
 
     then:
     assertTraces(1) {
-      trace(0, 2) {
+      trace(2) {
         getParentSpan(it, 0)
         getSpan(it, 1, "decr")
       }
@@ -534,7 +534,7 @@ class SpymemcachedTest extends AgentTestRunner {
     then:
     thrown IllegalArgumentException
     assertTraces(1) {
-      trace(0, 1) {
+      trace(1) {
         getSpan(it, 0, "decr", "long key")
       }
     }
@@ -553,7 +553,7 @@ class SpymemcachedTest extends AgentTestRunner {
 
     then:
     assertTraces(1) {
-      trace(0, 3) {
+      trace(3) {
         getParentSpan(it, 0)
         getSpan(it, 1, "get", null, "hit")
         getSpan(it, 2, "incr")
@@ -569,7 +569,7 @@ class SpymemcachedTest extends AgentTestRunner {
 
     then:
     assertTraces(1) {
-      trace(0, 2) {
+      trace(2) {
         getParentSpan(it, 0)
         getSpan(it, 1, "incr")
       }
@@ -583,7 +583,7 @@ class SpymemcachedTest extends AgentTestRunner {
     then:
     thrown IllegalArgumentException
     assertTraces(1) {
-      trace(0, 1) {
+      trace(1) {
         getSpan(it, 0, "incr", "long key")
       }
     }
@@ -615,7 +615,7 @@ class SpymemcachedTest extends AgentTestRunner {
   }
 
   def getParentSpan(TraceAssert trace, int index) {
-    return trace.span(index) {
+    return trace.span {
       operationName parentOperation
       parent()
       errored false
@@ -626,7 +626,7 @@ class SpymemcachedTest extends AgentTestRunner {
   }
 
   def getSpan(TraceAssert trace, int index, String operation, String error = null, String result = null) {
-    return trace.span(index) {
+    return trace.span {
       if (index > 0) {
         childOf(trace.span(0))
       }

--- a/dd-java-agent/instrumentation/testng-6.4/src/test/groovy/TestNGTest.groovy
+++ b/dd-java-agent/instrumentation/testng-6.4/src/test/groovy/TestNGTest.groovy
@@ -23,7 +23,7 @@ class TestNGTest extends TestFrameworkTest {
 
     expect:
     assertTraces(1) {
-      trace(0, 1) {
+      trace(1) {
         testSpan(it, 0, "org.example.TestSucceed", "test_succeed", TestDecorator.TEST_PASS)
       }
     }
@@ -38,7 +38,7 @@ class TestNGTest extends TestFrameworkTest {
 
     expect:
     assertTraces(1) {
-      trace(0, 1) {
+      trace(1) {
         testSpan(it, 0, "org.example.TestInheritance", "test_succeed", TestDecorator.TEST_PASS)
       }
     }
@@ -57,7 +57,7 @@ class TestNGTest extends TestFrameworkTest {
 
     expect:
     assertTraces(1) {
-      trace(0, 1) {
+      trace(1) {
         testSpan(it, 0, "org.example.TestFailed", "test_failed", TestDecorator.TEST_FAIL, null, exception)
       }
     }
@@ -79,19 +79,19 @@ class TestNGTest extends TestFrameworkTest {
 
     expect:
     assertTraces(5) {
-      trace(0, 1) {
+      trace(1) {
         testSpan(it, 0, "org.example.TestFailedWithSuccessPercentage", "test_failed_with_success_percentage", TestDecorator.TEST_FAIL, null, exception)
       }
-      trace(1, 1) {
+      trace(1) {
         testSpan(it, 0, "org.example.TestFailedWithSuccessPercentage", "test_failed_with_success_percentage", TestDecorator.TEST_FAIL, null, exception)
       }
-      trace(2, 1) {
+      trace(1) {
         testSpan(it, 0, "org.example.TestFailedWithSuccessPercentage", "test_failed_with_success_percentage", TestDecorator.TEST_PASS)
       }
-      trace(3, 1) {
+      trace(1) {
         testSpan(it, 0, "org.example.TestFailedWithSuccessPercentage", "test_failed_with_success_percentage", TestDecorator.TEST_PASS)
       }
-      trace(4, 1) {
+      trace(1) {
         testSpan(it, 0, "org.example.TestFailedWithSuccessPercentage", "test_failed_with_success_percentage", TestDecorator.TEST_PASS)
       }
     }
@@ -109,7 +109,7 @@ class TestNGTest extends TestFrameworkTest {
 
     expect:
     assertTraces(1) {
-      trace(0, 1) {
+      trace(1) {
         testSpan(it, 0, "org.example.TestError", "test_error", TestDecorator.TEST_FAIL, null, exception)
       }
     }
@@ -127,7 +127,7 @@ class TestNGTest extends TestFrameworkTest {
 
     expect:
     assertTraces(1) {
-      trace(0, 1) {
+      trace(1) {
         testSpan(it, 0, "org.example.TestSkipped", "test_skipped", TestDecorator.TEST_SKIP, testTags)
       }
     }

--- a/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/ConfiguredTraceAnnotationsTest.groovy
+++ b/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/ConfiguredTraceAnnotationsTest.groovy
@@ -37,8 +37,8 @@ class ConfiguredTraceAnnotationsTest extends AgentTestRunner {
 
     then:
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           resourceName "AnnotationTracedCallable.call"
           operationName "trace.annotation"
           tags {

--- a/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/TraceAnnotationsTest.groovy
+++ b/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/TraceAnnotationsTest.groovy
@@ -21,8 +21,8 @@ class TraceAnnotationsTest extends AgentTestRunner {
 
     expect:
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "test"
           resourceName "SayTracedHello.sayHello"
           operationName "trace.annotation"
@@ -44,8 +44,8 @@ class TraceAnnotationsTest extends AgentTestRunner {
 
     expect:
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "test"
           resourceName "SayTracedHello.sayHA"
           operationName "SAY_HA"
@@ -68,8 +68,8 @@ class TraceAnnotationsTest extends AgentTestRunner {
 
     expect:
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "test"
           resourceName "WORLD"
           operationName "trace.annotation"
@@ -91,8 +91,8 @@ class TraceAnnotationsTest extends AgentTestRunner {
 
     expect:
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "test"
           resourceName "EARTH"
           operationName "SAY_HA"
@@ -115,8 +115,8 @@ class TraceAnnotationsTest extends AgentTestRunner {
 
     then:
     assertTraces(1) {
-      trace(0, 3) {
-        span(0) {
+      trace(3) {
+        span {
           resourceName "SayTracedHello.sayHELLOsayHA"
           operationName "NEW_TRACE"
           parent()
@@ -126,7 +126,7 @@ class TraceAnnotationsTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           resourceName "SayTracedHello.sayHA"
           operationName "SAY_HA"
           spanType "DB"
@@ -137,7 +137,7 @@ class TraceAnnotationsTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(2) {
+        span {
           serviceName "test"
           resourceName "SayTracedHello.sayHello"
           operationName "trace.annotation"
@@ -159,8 +159,8 @@ class TraceAnnotationsTest extends AgentTestRunner {
 
     then:
     assertTraces(1) {
-      trace(0, 3) {
-        span(0) {
+      trace(3) {
+        span {
           resourceName "WORLD"
           operationName "NEW_TRACE"
           parent()
@@ -170,7 +170,7 @@ class TraceAnnotationsTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           resourceName "SayTracedHello.sayHA"
           operationName "SAY_HA"
           spanType "DB"
@@ -181,7 +181,7 @@ class TraceAnnotationsTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(2) {
+        span {
           serviceName "test"
           resourceName "SayTracedHello.sayHello"
           operationName "trace.annotation"
@@ -203,8 +203,8 @@ class TraceAnnotationsTest extends AgentTestRunner {
 
     then:
     assertTraces(1) {
-      trace(0, 3) {
-        span(0) {
+      trace(3) {
+        span {
           resourceName "WORLD"
           operationName "NEW_TRACE"
           parent()
@@ -214,7 +214,7 @@ class TraceAnnotationsTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           resourceName "EARTH"
           operationName "SAY_HA"
           spanType "DB"
@@ -225,7 +225,7 @@ class TraceAnnotationsTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(2) {
+        span {
           serviceName "test"
           resourceName "SayTracedHello.sayHello"
           operationName "trace.annotation"
@@ -251,8 +251,8 @@ class TraceAnnotationsTest extends AgentTestRunner {
 
     expect:
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           resourceName "SayTracedHello.sayERROR"
           operationName "ERROR"
           errored true
@@ -277,8 +277,8 @@ class TraceAnnotationsTest extends AgentTestRunner {
 
     expect:
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           resourceName "WORLD"
           operationName "ERROR"
           errored true
@@ -299,8 +299,8 @@ class TraceAnnotationsTest extends AgentTestRunner {
 
     expect:
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           resourceName "SayTracedHello\$1.call"
           operationName "trace.annotation"
           tags {
@@ -324,8 +324,8 @@ class TraceAnnotationsTest extends AgentTestRunner {
 
     then:
     assertTraces(2) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           resourceName "SayTracedHello\$1.call"
           operationName "trace.annotation"
           tags {
@@ -333,8 +333,8 @@ class TraceAnnotationsTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        trace(1, 1) {
-          span(0) {
+        trace(1) {
+          span {
             resourceName "TraceAnnotationsTest\$1.call"
             operationName "trace.annotation"
             tags {

--- a/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/TraceConfigTest.groovy
+++ b/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/TraceConfigTest.groovy
@@ -35,8 +35,8 @@ class TraceConfigTest extends AgentTestRunner {
 
     then:
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           resourceName "ConfigTracedCallable.call"
           operationName "trace.annotation"
           tags {

--- a/dd-java-agent/instrumentation/twilio/src/test/groovy/test/TwilioClientTest.groovy
+++ b/dd-java-agent/instrumentation/twilio/src/test/groovy/test/TwilioClientTest.groovy
@@ -130,8 +130,8 @@ class TwilioClientTest extends AgentTestRunner {
     message.body == "Hello, World!"
 
     assertTraces(1) {
-      trace(0, 2) {
-        span(0) {
+      trace(2) {
+        span {
           operationName "test"
           resourceName "test"
           errored false
@@ -140,7 +140,7 @@ class TwilioClientTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           serviceName "twilio-sdk"
           operationName "twilio.sdk"
           resourceName "api.v2010.account.MessageCreator.create"
@@ -181,8 +181,8 @@ class TwilioClientTest extends AgentTestRunner {
     call.status == Call.Status.COMPLETED
 
     assertTraces(1) {
-      trace(0, 2) {
-        span(0) {
+      trace(2) {
+        span {
           operationName "test"
           resourceName "test"
           errored false
@@ -191,7 +191,7 @@ class TwilioClientTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           serviceName "twilio-sdk"
           operationName "twilio.sdk"
           resourceName "api.v2010.account.CallCreator.create"
@@ -254,8 +254,8 @@ class TwilioClientTest extends AgentTestRunner {
     message.body == "Hello, World!"
 
     assertTraces(1) {
-      trace(0, 3) {
-        span(0) {
+      trace(3) {
+        span {
           operationName "test"
           resourceName "test"
           errored false
@@ -264,7 +264,7 @@ class TwilioClientTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           serviceName "twilio-sdk"
           operationName "twilio.sdk"
           resourceName "api.v2010.account.MessageCreator.create"
@@ -280,7 +280,7 @@ class TwilioClientTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(2) {
+        span {
           serviceName "twilio-sdk"
           operationName "http.request"
           resourceName "POST /?/Accounts/abc/Messages.json"
@@ -358,8 +358,8 @@ class TwilioClientTest extends AgentTestRunner {
     message.body == "Hello, World!"
 
     assertTraces(1) {
-      trace(0, 4) {
-        span(0) {
+      trace(4) {
+        span {
           operationName "test"
           resourceName "test"
           errored false
@@ -368,7 +368,7 @@ class TwilioClientTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           serviceName "twilio-sdk"
           operationName "twilio.sdk"
           resourceName "api.v2010.account.MessageCreator.create"
@@ -384,7 +384,7 @@ class TwilioClientTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(2) {
+        span {
           serviceName "twilio-sdk"
           operationName "http.request"
           resourceName "POST /?/Accounts/abc/Messages.json"
@@ -400,7 +400,7 @@ class TwilioClientTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(3) {
+        span {
           serviceName "twilio-sdk"
           operationName "http.request"
           resourceName "POST /?/Accounts/abc/Messages.json"
@@ -485,8 +485,8 @@ class TwilioClientTest extends AgentTestRunner {
     message.body == "Hello, World!"
 
     assertTraces(1) {
-      trace(0, 5) {
-        span(0) {
+      trace(5) {
+        span {
           operationName "test"
           resourceName "test"
           errored false
@@ -495,7 +495,7 @@ class TwilioClientTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           serviceName "twilio-sdk"
           operationName "twilio.sdk"
           resourceName "api.v2010.account.MessageCreator.createAsync"
@@ -511,7 +511,7 @@ class TwilioClientTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(2) {
+        span {
           serviceName "twilio-sdk"
           operationName "twilio.sdk"
           resourceName "api.v2010.account.MessageCreator.create"
@@ -529,7 +529,7 @@ class TwilioClientTest extends AgentTestRunner {
         }
         // Spans are reported in reverse order of completion,
         // so the error span is last even though it happened first.
-        span(3) {
+        span {
           serviceName "twilio-sdk"
           operationName "http.request"
           resourceName "POST /?/Accounts/abc/Messages.json"
@@ -545,7 +545,7 @@ class TwilioClientTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(4) {
+        span {
           serviceName "twilio-sdk"
           operationName "http.request"
           resourceName "POST /?/Accounts/abc/Messages.json"
@@ -591,8 +591,8 @@ class TwilioClientTest extends AgentTestRunner {
 
     expect:
     assertTraces(1) {
-      trace(0, 2) {
-        span(0) {
+      trace(2) {
+        span {
           operationName "test"
           resourceName "test"
           errored true
@@ -602,7 +602,7 @@ class TwilioClientTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           serviceName "twilio-sdk"
           operationName "twilio.sdk"
           resourceName "api.v2010.account.MessageCreator.create"
@@ -636,8 +636,8 @@ class TwilioClientTest extends AgentTestRunner {
     message.body == "Hello, World!"
 
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "twilio-sdk"
           operationName "twilio.sdk"
           resourceName "api.v2010.account.MessageCreator.create"
@@ -688,8 +688,8 @@ class TwilioClientTest extends AgentTestRunner {
     message.body == "Hello, World!"
 
     assertTraces(1) {
-      trace(0, 3) {
-        span(0) {
+      trace(3) {
+        span {
           operationName "test"
           resourceName "test"
           errored false
@@ -698,7 +698,7 @@ class TwilioClientTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           serviceName "twilio-sdk"
           operationName "twilio.sdk"
           resourceName "api.v2010.account.MessageCreator.createAsync"
@@ -714,7 +714,7 @@ class TwilioClientTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(2) {
+        span {
           serviceName "twilio-sdk"
           operationName "twilio.sdk"
           resourceName "api.v2010.account.MessageCreator.create"
@@ -771,8 +771,8 @@ class TwilioClientTest extends AgentTestRunner {
     expect:
 
     assertTraces(1) {
-      trace(0, 3) {
-        span(0) {
+      trace(3) {
+        span {
           operationName "test"
           resourceName "test"
           errored true
@@ -782,7 +782,7 @@ class TwilioClientTest extends AgentTestRunner {
             errorTags(ApiException, "Testing Failure")
           }
         }
-        span(1) {
+        span {
           serviceName "twilio-sdk"
           operationName "twilio.sdk"
           resourceName "api.v2010.account.MessageCreator.createAsync"
@@ -795,7 +795,7 @@ class TwilioClientTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span(2) {
+        span {
           serviceName "twilio-sdk"
           operationName "twilio.sdk"
           resourceName "api.v2010.account.MessageCreator.create"

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/AgentTestRunner.java
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/AgentTestRunner.java
@@ -251,7 +251,18 @@ public abstract class AgentTestRunner extends DDSpecification {
               options = "datadog.trace.agent.test.asserts.ListWriterAssert")
           @DelegatesTo(value = ListWriterAssert.class, strategy = Closure.DELEGATE_FIRST)
           final Closure spec) {
-    ListWriterAssert.assertTraces(TEST_WRITER, size, spec);
+    assertTraces(size, false, spec);
+  }
+
+  public static void assertTraces(
+      final int size,
+      final boolean ignoreAdditionalTraces,
+      @ClosureParams(
+              value = SimpleType.class,
+              options = "datadog.trace.agent.test.asserts.ListWriterAssert")
+          @DelegatesTo(value = ListWriterAssert.class, strategy = Closure.DELEGATE_FIRST)
+          final Closure spec) {
+    ListWriterAssert.assertTraces(TEST_WRITER, size, ignoreAdditionalTraces, spec);
   }
 
   @SneakyThrows

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/ListWriterAssert.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/ListWriterAssert.groovy
@@ -32,7 +32,7 @@ class ListWriterAssert {
       def array = writer.toArray()
       assert array.length == expectedSize
       def traces = (Arrays.asList(array) as List<List<DDSpan>>)
-      traces.sort(TraceSorter.SORTER)
+      Collections.sort(traces, TraceSorter.SORTER)
       def asserter = new ListWriterAssert(traces)
       def clone = (Closure) spec.clone()
       clone.delegate = asserter

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/ListWriterAssert.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/ListWriterAssert.groovy
@@ -60,6 +60,14 @@ class ListWriterAssert {
     }
   }
 
+  void sortSpansByStart() {
+    traces.each {
+      it.sort { a, b ->
+        return a.startTimeNano <=> b.startTimeNano
+      }
+    }
+  }
+
   List<DDSpan> trace(int index) {
     return traces.get(index)
   }

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/ListWriterAssert.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/ListWriterAssert.groovy
@@ -31,7 +31,7 @@ class ListWriterAssert {
       writer.waitForTraces(expectedSize)
       def array = writer.toArray()
       assert array.length == expectedSize
-      def traces = Arrays.asList(array) as List<List<DDSpan>>;
+      def traces = (Arrays.asList(array) as List<List<DDSpan>>)
       traces.sort(TraceSorter.SORTER)
       def asserter = new ListWriterAssert(traces)
       def clone = (Closure) spec.clone()
@@ -92,7 +92,7 @@ class ListWriterAssert {
   }
 
   private static class TraceSorter implements Comparator<List<DDSpan>> {
-    static TraceSorter SORTER = new TraceSorter();
+    static final TraceSorter SORTER = new TraceSorter()
 
     @Override
     int compare(List<DDSpan> o1, List<DDSpan> o2) {

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/TraceAssert.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/TraceAssert.groovy
@@ -4,12 +4,15 @@ import datadog.trace.core.DDSpan
 import groovy.transform.stc.ClosureParams
 import groovy.transform.stc.SimpleType
 
+import java.util.concurrent.atomic.AtomicInteger
+
 import static SpanAssert.assertSpan
 
 class TraceAssert {
   private final List<DDSpan> trace
   private final int size
   private final Set<Integer> assertedIndexes = new HashSet<>()
+  private final AtomicInteger spanAssertCount = new AtomicInteger(0)
 
   private TraceAssert(trace) {
     this.trace = trace
@@ -32,7 +35,9 @@ class TraceAssert {
     trace.get(index)
   }
 
-  void span(int index, @ClosureParams(value = SimpleType, options = ['datadog.trace.agent.test.asserts.SpanAssert']) @DelegatesTo(value = SpanAssert, strategy = Closure.DELEGATE_FIRST) Closure spec) {
+  void span(@ClosureParams(value = SimpleType, options = ['datadog.trace.agent.test.asserts.SpanAssert']) @DelegatesTo(value = SpanAssert, strategy = Closure.DELEGATE_FIRST) Closure spec) {
+    def index = spanAssertCount.getAndIncrement()
+
     if (index >= size) {
       throw new ArrayIndexOutOfBoundsException(index)
     }

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/AbstractPromiseTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/AbstractPromiseTest.groovy
@@ -39,10 +39,10 @@ abstract class AbstractPromiseTest<P, M> extends AgentTestRunner {
     then:
     get(promise) == value
     assertTraces(1) {
-      trace(0, 3) {
-        basicSpan(it, 0, "parent")
-        basicSpan(it, 1, "other", it.span(0))
-        basicSpan(it, 2, "callback", it.span(0))
+      trace(3) {
+        basicSpan(it, "parent")
+        basicSpan(it, "other", it.span(0))
+        basicSpan(it, "callback", it.span(0))
       }
     }
 
@@ -71,12 +71,12 @@ abstract class AbstractPromiseTest<P, M> extends AgentTestRunner {
     then:
     get(promise) == value
     assertTraces(2) {
-      trace(0, 2) {
-        basicSpan(it, 0, "callback", it.span(1))
-        basicSpan(it, 1, "parent")
+      trace(2) {
+        basicSpan(it, "callback", it.span(1))
+        basicSpan(it, "parent")
       }
-      trace(1, 1) {
-        basicSpan(it, 0, "other")
+      trace(1) {
+        basicSpan(it, "other")
       }
     }
 
@@ -104,9 +104,9 @@ abstract class AbstractPromiseTest<P, M> extends AgentTestRunner {
     then:
     get(promise) == value
     assertTraces(1) {
-      trace(0, 2) {
-        basicSpan(it, 0, "parent")
-        basicSpan(it, 1, "callback", it.span(0))
+      trace(2) {
+        basicSpan(it, "parent")
+        basicSpan(it, "callback", it.span(0))
       }
     }
 
@@ -133,10 +133,10 @@ abstract class AbstractPromiseTest<P, M> extends AgentTestRunner {
     then:
     get(promise) == value
     assertTraces(1) {
-      trace(0, 2) {
+      trace(2) {
         // TODO: is this really the behavior we want?
-        basicSpan(it, 0, "other")
-        basicSpan(it, 1, "callback", it.span(0))
+        basicSpan(it, "other")
+        basicSpan(it, "callback", it.span(0))
       }
     }
 

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
@@ -95,10 +95,10 @@ abstract class HttpClientTest extends AgentTestRunner {
     then:
     status == 200
     assertTraces(2) {
-      server.distributedRequestTrace(it, 0, trace(1).last())
-      trace(1, size(1)) {
-        clientSpan(it, 0, null, method, false, tagQueryString, url)
+      trace(size(1)) {
+        clientSpan(it, null, method, false, tagQueryString, url)
       }
+      server.distributedRequestTrace(it, trace(0).last())
     }
 
     where:
@@ -123,11 +123,11 @@ abstract class HttpClientTest extends AgentTestRunner {
     then:
     status == 200
     assertTraces(2) {
-      server.distributedRequestTrace(it, 0, trace(1).last())
-      trace(1, size(2)) {
-        basicSpan(it, 0, "parent")
-        clientSpan(it, 1, span(0), method)
+      trace(size(2)) {
+        basicSpan(it, "parent")
+        clientSpan(it, span(0), method)
       }
+      server.distributedRequestTrace(it, trace(0).last())
     }
 
     where:
@@ -145,10 +145,10 @@ abstract class HttpClientTest extends AgentTestRunner {
     then:
     status == 200
     assertTraces(2) {
-      server.distributedRequestTrace(it, 0, trace(1).last())
-      trace(1, size(1)) {
-        clientSpan(it, 0, null, method, true)
+      trace(size(1)) {
+        clientSpan(it, null, method, true)
       }
+      server.distributedRequestTrace(it, trace(0).last())
     }
 
     where:
@@ -167,9 +167,9 @@ abstract class HttpClientTest extends AgentTestRunner {
     status == 200
     // only one trace (client).
     assertTraces(1) {
-      trace(0, size(2)) {
-        basicSpan(it, 0, "parent")
-        clientSpan(it, 1, span(0), method, renameService)
+      trace(size(2)) {
+        basicSpan(it, "parent")
+        clientSpan(it, span(0), method, renameService)
       }
     }
 
@@ -195,10 +195,10 @@ abstract class HttpClientTest extends AgentTestRunner {
     status == 200
     // only one trace (client).
     assertTraces(1) {
-      trace(0, size(3)) {
-        basicSpan(it, 0, "parent")
-        basicSpan(it, 1, "child", span(0))
-        clientSpan(it, 2, span(0), method)
+      trace(size(3)) {
+        basicSpan(it, "parent")
+        basicSpan(it, "child", span(0))
+        clientSpan(it, span(0), method)
       }
     }
 
@@ -233,11 +233,11 @@ abstract class HttpClientTest extends AgentTestRunner {
     status == 200
     // only one trace (client).
     assertTraces(2) {
-      trace(0, size(1)) {
-        clientSpan(it, 0, null, method)
+      trace(size(1)) {
+        clientSpan(it, null, method)
       }
-      trace(1, 1) {
-        basicSpan(it, 0, "callback")
+      trace(1) {
+        basicSpan(it, "callback")
       }
     }
 
@@ -259,11 +259,11 @@ abstract class HttpClientTest extends AgentTestRunner {
     then:
     status == 200
     assertTraces(3) {
-      server.distributedRequestTrace(it, 0, trace(2).last())
-      server.distributedRequestTrace(it, 1, trace(2).last())
-      trace(2, size(1)) {
-        clientSpan(it, 0, null, method, false, false, uri)
+      trace(size(1)) {
+        clientSpan(it, null, method, false, false, uri)
       }
+      server.distributedRequestTrace(it, trace(0).last())
+      server.distributedRequestTrace(it, trace(0).last())
     }
 
     where:
@@ -281,12 +281,12 @@ abstract class HttpClientTest extends AgentTestRunner {
     then:
     status == 200
     assertTraces(4) {
-      server.distributedRequestTrace(it, 0, trace(3).last())
-      server.distributedRequestTrace(it, 1, trace(3).last())
-      server.distributedRequestTrace(it, 2, trace(3).last())
-      trace(3, size(1)) {
-        clientSpan(it, 0, null, method, false, false, uri)
+      trace(size(1)) {
+        clientSpan(it, null, method, false, false, uri)
       }
+      server.distributedRequestTrace(it, trace(0).last())
+      server.distributedRequestTrace(it, trace(0).last())
+      server.distributedRequestTrace(it, trace(0).last())
     }
 
     where:
@@ -307,11 +307,11 @@ abstract class HttpClientTest extends AgentTestRunner {
 
     and:
     assertTraces(3) {
-      server.distributedRequestTrace(it, 0, trace(2).last())
-      server.distributedRequestTrace(it, 1, trace(2).last())
-      trace(2, size(1)) {
-        clientSpan(it, 0, null, method, false, false, uri, statusOnRedirectError(), thrownException)
+      trace(size(1)) {
+        clientSpan(it, null, method, false, false, uri, statusOnRedirectError(), thrownException)
       }
+      server.distributedRequestTrace(it, trace(0).last())
+      server.distributedRequestTrace(it, trace(0).last())
     }
 
     where:
@@ -329,11 +329,11 @@ abstract class HttpClientTest extends AgentTestRunner {
     then:
     status == 200
     assertTraces(3) {
-      server.distributedRequestTrace(it, 0, trace(2).last())
-      server.distributedRequestTrace(it, 1, trace(2).last())
-      trace(2, size(1)) {
-        clientSpan(it, 0, null, method, false, false, uri)
+      trace(size(1)) {
+        clientSpan(it, null, method, false, false, uri)
       }
+      server.distributedRequestTrace(it, trace(0).last())
+      server.distributedRequestTrace(it, trace(0).last())
     }
 
     where:
@@ -356,9 +356,9 @@ abstract class HttpClientTest extends AgentTestRunner {
 
     and:
     assertTraces(1) {
-      trace(0, 2) {
-        basicSpan(it, 0, "parent", null, thrownException)
-        clientSpan(it, 1, span(0), method, false, false, uri, null, thrownException)
+      trace(2) {
+        basicSpan(it, "parent", null, thrownException)
+        clientSpan(it, span(0), method, false, false, uri, null, thrownException)
       }
     }
 
@@ -381,9 +381,9 @@ abstract class HttpClientTest extends AgentTestRunner {
     def ex = thrown(Exception)
     def thrownException = ex instanceof ExecutionException ? ex.cause : ex
     assertTraces(1) {
-      trace(0, size(2)) {
-        basicSpan(it, 0, "parent", null, thrownException)
-        clientSpan(it, 1, span(0), method, false, false, uri, null, thrownException)
+      trace(size(2)) {
+        basicSpan(it, "parent", null, thrownException)
+        clientSpan(it, span(0), method, false, false, uri, null, thrownException)
       }
     }
 
@@ -405,9 +405,9 @@ abstract class HttpClientTest extends AgentTestRunner {
     def ex = thrown(Exception)
     def thrownException = ex instanceof ExecutionException ? ex.cause : ex
     assertTraces(1) {
-      trace(0, size(2)) {
-        basicSpan(it, 0, "parent", null, thrownException)
-        clientSpan(it, 1, span(0), method, false, false, uri, null, thrownException)
+      trace(size(2)) {
+        basicSpan(it, "parent", null, thrownException)
+        clientSpan(it, span(0), method, false, false, uri, null, thrownException)
       }
     }
 
@@ -428,8 +428,8 @@ abstract class HttpClientTest extends AgentTestRunner {
     then:
     status == 200
     assertTraces(1) {
-      trace(0, size(1)) {
-        clientSpan(it, 0, null, method, false, false, uri)
+      trace(size(1)) {
+        clientSpan(it, null, method, false, false, uri)
       }
     }
 
@@ -438,8 +438,8 @@ abstract class HttpClientTest extends AgentTestRunner {
   }
 
   // parent span must be cast otherwise it breaks debugging classloading (junit loads it early)
-  void clientSpan(TraceAssert trace, int index, Object parentSpan, String method = "GET", boolean renameService = false, boolean tagQueryString = false, URI uri = server.address.resolve("/success"), Integer status = 200, Throwable exception = null) {
-    trace.span(index) {
+  void clientSpan(TraceAssert trace, Object parentSpan, String method = "GET", boolean renameService = false, boolean tagQueryString = false, URI uri = server.address.resolve("/success"), Integer status = 200, Throwable exception = null) {
+    trace.span {
       if (parentSpan == null) {
         parent()
       } else {

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
@@ -241,15 +241,15 @@ abstract class HttpServerTest<SERVER> extends AgentTestRunner {
     cleanAndAssertTraces(count) {
       (1..count).eachWithIndex { val, i ->
         if (hasHandlerSpan()) {
-          trace(i, 3) {
-            serverSpan(it, 0)
-            handlerSpan(it, 1, span(0))
-            controllerSpan(it, 2, span(1))
+          trace(3) {
+            serverSpan(it)
+            handlerSpan(it, span(0))
+            controllerSpan(it, span(1))
           }
         } else {
-          trace(i, 2) {
-            serverSpan(it, 0)
-            controllerSpan(it, 1, span(0))
+          trace(2) {
+            serverSpan(it)
+            controllerSpan(it, span(0))
           }
         }
       }
@@ -278,15 +278,15 @@ abstract class HttpServerTest<SERVER> extends AgentTestRunner {
     and:
     cleanAndAssertTraces(1) {
       if (hasHandlerSpan()) {
-        trace(0, 3) {
-          serverSpan(it, 0, traceId, parentId)
-          handlerSpan(it, 1, span(0))
-          controllerSpan(it, 2, span(1))
+        trace(3) {
+          serverSpan(it, traceId, parentId)
+          handlerSpan(it, span(0))
+          controllerSpan(it, span(1))
         }
       } else {
-        trace(0, 2) {
-          serverSpan(it, 0, traceId, parentId)
-          controllerSpan(it, 1, span(0))
+        trace(2) {
+          serverSpan(it, traceId, parentId)
+          controllerSpan(it, span(0))
         }
       }
     }
@@ -310,15 +310,15 @@ abstract class HttpServerTest<SERVER> extends AgentTestRunner {
     and:
     cleanAndAssertTraces(1) {
       if (hasHandlerSpan()) {
-        trace(0, 3) {
-          serverSpan(it, 0, null, null, "GET", endpoint)
-          handlerSpan(it, 1, span(0), endpoint)
-          controllerSpan(it, 2, span(1))
+        trace(3) {
+          serverSpan(it, null, null, "GET", endpoint)
+          handlerSpan(it, span(0), endpoint)
+          controllerSpan(it, span(1))
         }
       } else {
-        trace(0, 2) {
-          serverSpan(it, 0, null, null, "GET", endpoint)
-          controllerSpan(it, 1, span(0))
+        trace(2) {
+          serverSpan(it, null, null, "GET", endpoint)
+          controllerSpan(it, span(0))
         }
       }
     }
@@ -342,15 +342,15 @@ abstract class HttpServerTest<SERVER> extends AgentTestRunner {
     and:
     cleanAndAssertTraces(1) {
       if (hasHandlerSpan()) {
-        trace(0, 3) {
-          serverSpan(it, 0, null, null, method, PATH_PARAM)
-          handlerSpan(it, 1, span(0), PATH_PARAM)
-          controllerSpan(it, 2, span(1))
+        trace(3) {
+          serverSpan(it, null, null, method, PATH_PARAM)
+          handlerSpan(it, span(0), PATH_PARAM)
+          controllerSpan(it, span(1))
         }
       } else {
-        trace(0, 2) {
-          serverSpan(it, 0, null, null, method, PATH_PARAM)
-          controllerSpan(it, 1, span(0))
+        trace(2) {
+          serverSpan(it, null, null, method, PATH_PARAM)
+          controllerSpan(it, span(0))
         }
       }
     }
@@ -378,15 +378,15 @@ abstract class HttpServerTest<SERVER> extends AgentTestRunner {
     and:
     cleanAndAssertTraces(1) {
       if (hasHandlerSpan()) {
-        trace(0, 3) {
-          serverSpan(it, 0, traceId, parentId)
-          handlerSpan(it, 1, span(0))
-          controllerSpan(it, 2, span(1))
+        trace(3) {
+          serverSpan(it, traceId, parentId)
+          handlerSpan(it, span(0))
+          controllerSpan(it, span(1))
         }
       } else {
-        trace(0, 2) {
-          serverSpan(it, 0, traceId, parentId)
-          controllerSpan(it, 1, span(0))
+        trace(2) {
+          serverSpan(it, traceId, parentId)
+          controllerSpan(it, span(0))
         }
       }
     }
@@ -410,15 +410,15 @@ abstract class HttpServerTest<SERVER> extends AgentTestRunner {
     and:
     cleanAndAssertTraces(1) {
       if (hasHandlerSpan()) {
-        trace(0, 3) {
-          serverSpan(it, 0, null, null, method, REDIRECT)
-          handlerSpan(it, 1, span(0), REDIRECT)
-          controllerSpan(it, 2, span(1))
+        trace(3) {
+          serverSpan(it, null, null, method, REDIRECT)
+          handlerSpan(it, span(0), REDIRECT)
+          controllerSpan(it, span(1))
         }
       } else {
-        trace(0, 2) {
-          serverSpan(it, 0, null, null, method, REDIRECT)
-          controllerSpan(it, 1, span(0))
+        trace(2) {
+          serverSpan(it, null, null, method, REDIRECT)
+          controllerSpan(it, span(0))
         }
       }
     }
@@ -440,15 +440,15 @@ abstract class HttpServerTest<SERVER> extends AgentTestRunner {
     and:
     cleanAndAssertTraces(1) {
       if (hasHandlerSpan()) {
-        trace(0, 3) {
-          serverSpan(it, 0, null, null, method, ERROR)
-          handlerSpan(it, 1, span(0), ERROR)
-          controllerSpan(it, 2, span(1))
+        trace(3) {
+          serverSpan(it, null, null, method, ERROR)
+          handlerSpan(it, span(0), ERROR)
+          controllerSpan(it, span(1))
         }
       } else {
-        trace(0, 2) {
-          serverSpan(it, 0, null, null, method, ERROR)
-          controllerSpan(it, 1, span(0))
+        trace(2) {
+          serverSpan(it, null, null, method, ERROR)
+          controllerSpan(it, span(0))
         }
       }
     }
@@ -473,15 +473,15 @@ abstract class HttpServerTest<SERVER> extends AgentTestRunner {
     and:
     cleanAndAssertTraces(1) {
       if (hasHandlerSpan()) {
-        trace(0, 3) {
-          serverSpan(it, 0, null, null, method, EXCEPTION)
-          handlerSpan(it, 1, span(0), EXCEPTION)
-          controllerSpan(it, 2, span(1), EXCEPTION.body)
+        trace(3) {
+          serverSpan(it, null, null, method, EXCEPTION)
+          handlerSpan(it, span(0), EXCEPTION)
+          controllerSpan(it, span(1), EXCEPTION.body)
         }
       } else {
-        trace(0, 2) {
-          serverSpan(it, 0, null, null, method, EXCEPTION)
-          controllerSpan(it, 1, span(0), EXCEPTION.body)
+        trace(2) {
+          serverSpan(it, null, null, method, EXCEPTION)
+          controllerSpan(it, span(0), EXCEPTION.body)
         }
       }
     }
@@ -503,13 +503,13 @@ abstract class HttpServerTest<SERVER> extends AgentTestRunner {
     and:
     cleanAndAssertTraces(1) {
       if (hasHandlerSpan()) {
-        trace(0, 2) {
-          serverSpan(it, 0, null, null, method, NOT_FOUND)
-          handlerSpan(it, 1, span(0), NOT_FOUND)
+        trace(2) {
+          serverSpan(it, null, null, method, NOT_FOUND)
+          handlerSpan(it, span(0), NOT_FOUND)
         }
       } else {
-        trace(0, 1) {
-          serverSpan(it, 0, null, null, method, NOT_FOUND)
+        trace(1) {
+          serverSpan(it, null, null, method, NOT_FOUND)
         }
       }
     }
@@ -534,15 +534,15 @@ abstract class HttpServerTest<SERVER> extends AgentTestRunner {
     and:
     cleanAndAssertTraces(1) {
       if (hasHandlerSpan()) {
-        trace(0, 3) {
-          serverSpan(it, 0, null, null, method, TIMEOUT)
-          handlerSpan(it, 1, span(0), TIMEOUT)
-          controllerSpan(it, 2, span(1))
+        trace(3) {
+          serverSpan(it, null, null, method, TIMEOUT)
+          handlerSpan(it, span(0), TIMEOUT)
+          controllerSpan(it, span(1))
         }
       } else {
-        trace(0, 2) {
-          serverSpan(it, 0, null, null, method, TIMEOUT)
-          controllerSpan(it, 1, span(0))
+        trace(2) {
+          serverSpan(it, null, null, method, TIMEOUT)
+          controllerSpan(it, span(0))
         }
       }
     }
@@ -565,15 +565,15 @@ abstract class HttpServerTest<SERVER> extends AgentTestRunner {
     and:
     cleanAndAssertTraces(1) {
       if (hasHandlerSpan()) {
-        trace(0, 3) {
-          serverSpan(it, 0, null, null, method, TIMEOUT_ERROR)
-          handlerSpan(it, 1, span(0), TIMEOUT_ERROR)
-          controllerSpan(it, 2, span(1))
+        trace(3) {
+          serverSpan(it, null, null, method, TIMEOUT_ERROR)
+          handlerSpan(it, span(0), TIMEOUT_ERROR)
+          controllerSpan(it, span(1))
         }
       } else {
-        trace(0, 2) {
-          serverSpan(it, 0, null, null, method, TIMEOUT_ERROR)
-          controllerSpan(it, 1, span(0))
+        trace(2) {
+          serverSpan(it, null, null, method, TIMEOUT_ERROR)
+          controllerSpan(it, span(0))
         }
       }
     }
@@ -599,7 +599,7 @@ abstract class HttpServerTest<SERVER> extends AgentTestRunner {
     }
     toRemove.each {
       assertTrace(it, 1) {
-        basicSpan(it, 0, "TEST_SPAN", "ServerEntry")
+        basicSpan(it, "TEST_SPAN", "ServerEntry")
       }
     }
     assert toRemove.size() == size
@@ -633,8 +633,8 @@ abstract class HttpServerTest<SERVER> extends AgentTestRunner {
     assertTraces(size, spec)
   }
 
-  void controllerSpan(TraceAssert trace, int index, Object parent, String errorMessage = null) {
-    trace.span(index) {
+  void controllerSpan(TraceAssert trace, Object parent, String errorMessage = null) {
+    trace.span {
       serviceName expectedServiceName()
       operationName "controller"
       resourceName "controller"
@@ -652,13 +652,13 @@ abstract class HttpServerTest<SERVER> extends AgentTestRunner {
     }
   }
 
-  void handlerSpan(TraceAssert trace, int index, Object parent, ServerEndpoint endpoint = SUCCESS) {
+  void handlerSpan(TraceAssert trace, Object parent, ServerEndpoint endpoint = SUCCESS) {
     throw new UnsupportedOperationException("handlerSpan not implemented in " + getClass().name)
   }
 
   // parent span must be cast otherwise it breaks debugging classloading (junit loads it early)
-  void serverSpan(TraceAssert trace, int index, BigInteger traceID = null, BigInteger parentID = null, String method = "GET", ServerEndpoint endpoint = SUCCESS) {
-    trace.span(index) {
+  void serverSpan(TraceAssert trace, BigInteger traceID = null, BigInteger parentID = null, String method = "GET", ServerEndpoint endpoint = SUCCESS) {
+    trace.span {
       serviceName expectedServiceName()
       operationName expectedOperationName()
       resourceName endpoint.resource(method, address, testPathParam())

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/TestFrameworkTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/TestFrameworkTest.groovy
@@ -22,7 +22,7 @@ abstract class TestFrameworkTest extends AgentTestRunner {
   void testSpan(TraceAssert trace, int index, final String testSuite, final String testName, final String testStatus, final Map<String, String> testTags = null, final Throwable exception = null) {
     def testFramework = expectedTestFramework()
 
-    trace.span(index) {
+    trace.span {
       parent()
       operationName expectedOperationName()
       resourceName "$testSuite.$testName"

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/server/http/TestHttpServer.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/server/http/TestHttpServer.groovy
@@ -1,9 +1,9 @@
 package datadog.trace.agent.test.server.http
 
-import datadog.trace.core.DDSpan
 import datadog.trace.agent.test.asserts.ListWriterAssert
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan
 import datadog.trace.bootstrap.instrumentation.api.Tags
+import datadog.trace.core.DDSpan
 import org.eclipse.jetty.http.HttpMethods
 import org.eclipse.jetty.server.Handler
 import org.eclipse.jetty.server.Request
@@ -93,9 +93,9 @@ class TestHttpServer implements AutoCloseable {
     clone(handlers)
   }
 
-  static distributedRequestTrace(ListWriterAssert traces, int index, DDSpan parentSpan = null) {
-    traces.trace(index, 1) {
-      span(0) {
+  static distributedRequestTrace(ListWriterAssert traces, DDSpan parentSpan = null) {
+    traces.trace(1) {
+      span {
         operationName "test-http-server"
         errored false
         if (parentSpan == null) {

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/utils/TraceUtils.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/utils/TraceUtils.groovy
@@ -48,12 +48,12 @@ class TraceUtils {
     }
   }
 
-  static basicSpan(TraceAssert trace, int index, String spanName, Object parentSpan = null, Throwable exception = null) {
-    basicSpan(trace, index, spanName, spanName, parentSpan, exception)
+  static basicSpan(TraceAssert trace, String spanName, Object parentSpan = null, Throwable exception = null) {
+    basicSpan(trace, spanName, spanName, parentSpan, exception)
   }
 
-  static basicSpan(TraceAssert trace, int index, String operation, String resource, Object parentSpan = null, Throwable exception = null) {
-    trace.span(index) {
+  static basicSpan(TraceAssert trace, String operation, String resource, Object parentSpan = null, Throwable exception = null) {
+    trace.span {
       if (parentSpan == null) {
         parent()
       } else {

--- a/dd-java-agent/testing/src/test/groovy/AgentTestRunnerTest.groovy
+++ b/dd-java-agent/testing/src/test/groovy/AgentTestRunnerTest.groovy
@@ -91,8 +91,8 @@ class AgentTestRunnerTest extends AgentTestRunner {
     then:
     !TRANSFORMED_CLASSES_NAMES.contains(subject.class.name)
     assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           operationName "parent"
         }
       }
@@ -115,12 +115,12 @@ class AgentTestRunnerTest extends AgentTestRunner {
 
     expect:
     assertTraces(1) {
-      trace(0, 2) {
-        span(0) {
+      trace(2) {
+        span {
           operationName "parent"
           parent()
         }
-        span(1) {
+        span {
           operationName "child"
           childOf(span(0))
         }

--- a/dd-java-agent/testing/src/test/groovy/server/ServerTest.groovy
+++ b/dd-java-agent/testing/src/test/groovy/server/ServerTest.groovy
@@ -310,7 +310,7 @@ class ServerTest extends AgentTestRunner {
     response.body().string().trim() == "done"
 
     assertTraces(1) {
-      server.distributedRequestTrace(it, 0)
+      server.distributedRequestTrace(it)
     }
 
     cleanup:
@@ -344,8 +344,8 @@ class ServerTest extends AgentTestRunner {
     response.body().string().trim() == "done"
 
     assertTraces(1) {
-      trace(0, 1) {
-        basicSpan(it, 0, "parent")
+      trace(1) {
+        basicSpan(it, "parent")
       }
     }
 
@@ -379,7 +379,7 @@ class ServerTest extends AgentTestRunner {
 
     // parent<->child relation can't be tested because okhttp isnt traced here
     assertTraces(1) {
-      server.distributedRequestTrace(it, 0)
+      server.distributedRequestTrace(it)
     }
 
     cleanup:

--- a/dd-java-agent/testing/testing.gradle
+++ b/dd-java-agent/testing/testing.gradle
@@ -4,6 +4,7 @@ minimumBranchCoverage = 0.5
 minimumInstructionCoverage = 0.5
 excludedClassesCoverage += [
   'datadog.trace.agent.test.asserts.*Assert',
+  'datadog.trace.agent.test.asserts.*Assert.*',
   'datadog.trace.agent.test.base.*',
   'datadog.trace.agent.test.log.*',
   'datadog.trace.agent.test.AgentTestRunner.ErrorCountingListener',

--- a/dd-trace-api/src/test/groovy/datadog/trace/api/DDIdTest.groovy
+++ b/dd-trace-api/src/test/groovy/datadog/trace/api/DDIdTest.groovy
@@ -48,7 +48,7 @@ class DDIdTest extends DDSpecification {
     thrown NumberFormatException
 
     where:
-    stringId << [ null, "", "-1", "18446744073709551616", "18446744073709551625", "184467440737095516150", "18446744073709551a1", "184467440737095511a" ]
+    stringId << [null, "", "-1", "18446744073709551616", "18446744073709551625", "184467440737095516150", "18446744073709551a1", "184467440737095511a"]
   }
 
   def "convert ids from/to hex String"() {
@@ -80,7 +80,7 @@ class DDIdTest extends DDSpecification {
     thrown NumberFormatException
 
     where:
-    hexId << [null, "", "-1", "1" + "0" * 16, "f" * 14 + "zf", "f" * 15 + "z" ]
+    hexId << [null, "", "-1", "1" + "0" * 16, "f" * 14 + "zf", "f" * 15 + "z"]
   }
 
   def "generate id with #idGenerator"() {

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterCombinedTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterCombinedTest.groovy
@@ -175,6 +175,7 @@ class DDAgentWriterCombinedTest extends DDSpecification {
     agentVersion << ["v0.3/traces", "v0.4/traces", "v0.5/traces"]
   }
 
+  @Timeout(30)
   def "test default buffer size"() {
     setup:
     def api = apiWithVersion(agentVersion)

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/PayloadDispatcherTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/PayloadDispatcherTest.groovy
@@ -45,10 +45,10 @@ class PayloadDispatcherTest extends DDSpecification {
     1 * api.sendSerializedTraces({ it.representativeCount() == droppedTraces + serializedTraces && it.traceCount() == serializedTraces }) >> DDAgentApi.Response.success(200)
 
     where:
-    droppedTraces |  serializedTraces
-    1              |   1
-    10             |   1
-    10             |   10
+    droppedTraces | serializedTraces
+    1             | 1
+    10            | 1
+    10            | 10
   }
 
   @Timeout(5)
@@ -94,13 +94,13 @@ class PayloadDispatcherTest extends DDSpecification {
     1 * api.sendSerializedTraces({ it.traceCount() == traceCount }) >> DDAgentApi.Response.success(200)
 
     where:
-    traceMapper             | traceCount
-    new TraceMapperV0_4()   |  1
-    new TraceMapperV0_4()   |  10
-    new TraceMapperV0_4()   |  100
-    new TraceMapperV0_5()   |  1
-    new TraceMapperV0_5()   |  10
-    new TraceMapperV0_5()   |  100
+    traceMapper           | traceCount
+    new TraceMapperV0_4() | 1
+    new TraceMapperV0_4() | 10
+    new TraceMapperV0_4() | 100
+    new TraceMapperV0_5() | 1
+    new TraceMapperV0_5() | 10
+    new TraceMapperV0_5() | 100
   }
 
   def "should report failed request to monitor"() {
@@ -123,24 +123,24 @@ class PayloadDispatcherTest extends DDSpecification {
     1 * api.sendSerializedTraces({ it.traceCount() == traceCount && it.representativeCount() == droppedTraces + traceCount }) >> DDAgentApi.Response.failed(400)
 
     where:
-    traceMapper             | traceCount   | droppedTraces
-    new TraceMapperV0_4()   |  1           |   0
-    new TraceMapperV0_4()   |  1           |   1
-    new TraceMapperV0_4()   |  1           |   10
-    new TraceMapperV0_4()   |  10          |   10
-    new TraceMapperV0_4()   |  10          |   100
-    new TraceMapperV0_4()   |  100         |   100
-    new TraceMapperV0_4()   |  100         |   1000
-    new TraceMapperV0_5()   |  1           |   0
-    new TraceMapperV0_5()   |  1           |   1
-    new TraceMapperV0_5()   |  1           |   10
-    new TraceMapperV0_5()   |  10          |   10
-    new TraceMapperV0_5()   |  10          |   100
-    new TraceMapperV0_5()   |  100         |   100
-    new TraceMapperV0_5()   |  100         |   1000
+    traceMapper           | traceCount | droppedTraces
+    new TraceMapperV0_4() | 1          | 0
+    new TraceMapperV0_4() | 1          | 1
+    new TraceMapperV0_4() | 1          | 10
+    new TraceMapperV0_4() | 10         | 10
+    new TraceMapperV0_4() | 10         | 100
+    new TraceMapperV0_4() | 100        | 100
+    new TraceMapperV0_4() | 100        | 1000
+    new TraceMapperV0_5() | 1          | 0
+    new TraceMapperV0_5() | 1          | 1
+    new TraceMapperV0_5() | 1          | 10
+    new TraceMapperV0_5() | 10         | 10
+    new TraceMapperV0_5() | 10         | 100
+    new TraceMapperV0_5() | 100        | 100
+    new TraceMapperV0_5() | 100        | 1000
   }
 
-  def "should drop trace when there is no agent connectivity" () {
+  def "should drop trace when there is no agent connectivity"() {
     setup:
     HealthMetrics healthMetrics = Mock(HealthMetrics)
     DDAgentApi api = Mock(DDAgentApi)

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/TraceProcessingWorkerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/TraceProcessingWorkerTest.groovy
@@ -107,7 +107,7 @@ class TraceProcessingWorkerTest extends DDSpecification {
     worker.close()
   }
 
-  def "should report failure if rules can't be applied to trace" () {
+  def "should report failure if rules can't be applied to trace"() {
     setup:
     Throwable theError = new IllegalStateException("thrown by test")
     TraceProcessor throwingTraceProcessor = Mock(TraceProcessor)
@@ -125,7 +125,7 @@ class TraceProcessingWorkerTest extends DDSpecification {
       errorReported.incrementAndGet()
     }
     TraceProcessingWorker worker = new TraceProcessingWorker(10, healthMetrics, monitoring,
-      Mock(PayloadDispatcher), throwingTraceProcessor, FAST_LANE,100, TimeUnit.SECONDS)
+      Mock(PayloadDispatcher), throwingTraceProcessor, FAST_LANE, 100, TimeUnit.SECONDS)
     // prevent heartbeats from helping the flush happen
     worker.start()
 
@@ -137,14 +137,15 @@ class TraceProcessingWorkerTest extends DDSpecification {
       1 == errorReported.get()
     }
 
-    cleanup: worker.close()
+    cleanup:
+    worker.close()
 
     where:
     priority << [SAMPLER_DROP, USER_DROP, SAMPLER_KEEP, USER_KEEP, UNSET]
   }
 
 
-  def "should report failure if serialization fails" () {
+  def "should report failure if serialization fails"() {
     setup:
     Throwable theError = new IllegalStateException("thrown by test")
     PayloadDispatcher throwingDispatcher = Mock(PayloadDispatcher)
@@ -174,7 +175,8 @@ class TraceProcessingWorkerTest extends DDSpecification {
       1 == errorReported.get()
     }
 
-    cleanup: worker.close()
+    cleanup:
+    worker.close()
 
     where:
     priority << [SAMPLER_DROP, USER_DROP, SAMPLER_KEEP, USER_KEEP, UNSET]
@@ -210,47 +212,47 @@ class TraceProcessingWorkerTest extends DDSpecification {
 
 
     where:
-    priority      |   traceCount   | strategy
-    SAMPLER_DROP  |   1            | FAST_LANE
-    USER_DROP     |   1            | FAST_LANE
-    SAMPLER_KEEP  |   1            | FAST_LANE
-    USER_KEEP     |   1            | FAST_LANE
-    UNSET         |   1            | FAST_LANE
-    SAMPLER_DROP  |   10           | FAST_LANE
-    USER_DROP     |   10           | FAST_LANE
-    SAMPLER_KEEP  |   10           | FAST_LANE
-    USER_KEEP     |   10           | FAST_LANE
-    UNSET         |   10           | FAST_LANE
-    SAMPLER_DROP  |   20           | FAST_LANE
-    USER_DROP     |   20           | FAST_LANE
-    SAMPLER_KEEP  |   20           | FAST_LANE
-    USER_KEEP     |   20           | FAST_LANE
-    UNSET         |   20           | FAST_LANE
-    SAMPLER_DROP  |   100          | FAST_LANE
-    USER_DROP     |   100          | FAST_LANE
-    SAMPLER_KEEP  |   100          | FAST_LANE
-    USER_KEEP     |   100          | FAST_LANE
-    UNSET         |   100          | FAST_LANE
-    SAMPLER_DROP  |   1            | DEAD_LETTERS
-    USER_DROP     |   1            | DEAD_LETTERS
-    SAMPLER_KEEP  |   1            | DEAD_LETTERS
-    USER_KEEP     |   1            | DEAD_LETTERS
-    UNSET         |   1            | DEAD_LETTERS
-    SAMPLER_DROP  |   10           | DEAD_LETTERS
-    USER_DROP     |   10           | DEAD_LETTERS
-    SAMPLER_KEEP  |   10           | DEAD_LETTERS
-    USER_KEEP     |   10           | DEAD_LETTERS
-    UNSET         |   10           | DEAD_LETTERS
-    SAMPLER_DROP  |   20           | DEAD_LETTERS
-    USER_DROP     |   20           | DEAD_LETTERS
-    SAMPLER_KEEP  |   20           | DEAD_LETTERS
-    USER_KEEP     |   20           | DEAD_LETTERS
-    UNSET         |   20           | DEAD_LETTERS
-    SAMPLER_DROP  |   100          | DEAD_LETTERS
-    USER_DROP     |   100          | DEAD_LETTERS
-    SAMPLER_KEEP  |   100          | DEAD_LETTERS
-    USER_KEEP     |   100          | DEAD_LETTERS
-    UNSET         |   100          | DEAD_LETTERS
+    priority     | traceCount | strategy
+    SAMPLER_DROP | 1          | FAST_LANE
+    USER_DROP    | 1          | FAST_LANE
+    SAMPLER_KEEP | 1          | FAST_LANE
+    USER_KEEP    | 1          | FAST_LANE
+    UNSET        | 1          | FAST_LANE
+    SAMPLER_DROP | 10         | FAST_LANE
+    USER_DROP    | 10         | FAST_LANE
+    SAMPLER_KEEP | 10         | FAST_LANE
+    USER_KEEP    | 10         | FAST_LANE
+    UNSET        | 10         | FAST_LANE
+    SAMPLER_DROP | 20         | FAST_LANE
+    USER_DROP    | 20         | FAST_LANE
+    SAMPLER_KEEP | 20         | FAST_LANE
+    USER_KEEP    | 20         | FAST_LANE
+    UNSET        | 20         | FAST_LANE
+    SAMPLER_DROP | 100        | FAST_LANE
+    USER_DROP    | 100        | FAST_LANE
+    SAMPLER_KEEP | 100        | FAST_LANE
+    USER_KEEP    | 100        | FAST_LANE
+    UNSET        | 100        | FAST_LANE
+    SAMPLER_DROP | 1          | DEAD_LETTERS
+    USER_DROP    | 1          | DEAD_LETTERS
+    SAMPLER_KEEP | 1          | DEAD_LETTERS
+    USER_KEEP    | 1          | DEAD_LETTERS
+    UNSET        | 1          | DEAD_LETTERS
+    SAMPLER_DROP | 10         | DEAD_LETTERS
+    USER_DROP    | 10         | DEAD_LETTERS
+    SAMPLER_KEEP | 10         | DEAD_LETTERS
+    USER_KEEP    | 10         | DEAD_LETTERS
+    UNSET        | 10         | DEAD_LETTERS
+    SAMPLER_DROP | 20         | DEAD_LETTERS
+    USER_DROP    | 20         | DEAD_LETTERS
+    SAMPLER_KEEP | 20         | DEAD_LETTERS
+    USER_KEEP    | 20         | DEAD_LETTERS
+    UNSET        | 20         | DEAD_LETTERS
+    SAMPLER_DROP | 100        | DEAD_LETTERS
+    USER_DROP    | 100        | DEAD_LETTERS
+    SAMPLER_KEEP | 100        | DEAD_LETTERS
+    USER_KEEP    | 100        | DEAD_LETTERS
+    UNSET        | 100        | DEAD_LETTERS
 
   }
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddagent/TraceGenerator.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddagent/TraceGenerator.groovy
@@ -52,9 +52,9 @@ class TraceGenerator {
         : ThreadLocalRandom.current().nextDouble())
     }
     return new PojoSpan(
-      "service-" + ThreadLocalRandom.current().nextInt(lowCardinality? 1 : 10),
-      "operation-" + ThreadLocalRandom.current().nextInt(lowCardinality? 1 : 100),
-      UTF8BytesString.create("resource-" + ThreadLocalRandom.current().nextInt(lowCardinality? 1 : 100)),
+      "service-" + ThreadLocalRandom.current().nextInt(lowCardinality ? 1 : 10),
+      "operation-" + ThreadLocalRandom.current().nextInt(lowCardinality ? 1 : 100),
+      UTF8BytesString.create("resource-" + ThreadLocalRandom.current().nextInt(lowCardinality ? 1 : 100)),
       DDId.from(traceId),
       IdGenerationStrategy.RANDOM.generate(),
       DDId.ZERO,
@@ -64,13 +64,13 @@ class TraceGenerator {
       metrics,
       baggage,
       tags,
-      "type-" + ThreadLocalRandom.current().nextInt(lowCardinality? 1 : 100))
+      "type-" + ThreadLocalRandom.current().nextInt(lowCardinality ? 1 : 100))
   }
 
   private static String randomString(int maxLength) {
     char[] chars = new char[ThreadLocalRandom.current().nextInt(maxLength)]
     for (int i = 0; i < chars.length; ++i) {
-      char next = (char)ThreadLocalRandom.current().nextInt((int) Character.MAX_VALUE)
+      char next = (char) ThreadLocalRandom.current().nextInt((int) Character.MAX_VALUE)
       if (Character.isSurrogate(next)) {
         if (i < chars.length - 1) {
           chars[i++] = '\uD801'

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddagent/TraceMapperRealAgentTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddagent/TraceMapperRealAgentTest.groovy
@@ -12,7 +12,7 @@ import java.util.concurrent.TimeUnit
 
 import static datadog.trace.common.writer.ddagent.TraceGenerator.generateRandomTraces
 
-@Requires({ "true" == System.getenv("CI")})
+@Requires({ "true" == System.getenv("CI") })
 class TraceMapperRealAgentTest extends DDSpecification {
 
   @Shared
@@ -22,7 +22,7 @@ class TraceMapperRealAgentTest extends DDSpecification {
   @Shared
   DDAgentApi v04Api = new DDAgentApi("localhost", 8126, null, 30_000, false, monitoring)
 
-  def "send random traces" () {
+  def "send random traces"() {
     setup:
     HealthMetrics healthMetrics = Mock(HealthMetrics)
     PayloadDispatcher dispatcher = new PayloadDispatcher(v05 ? v05Api : v04Api, healthMetrics, monitoring)
@@ -40,38 +40,38 @@ class TraceMapperRealAgentTest extends DDSpecification {
     0 * _
 
     where:
-    bufferSize    |   traceCount   | lowCardinality   | v05
-    10 << 10      |       0        | true             | true
-    10 << 10      |       1        | true             | true
-    30 << 10      |       1        | true             | true
-    30 << 10      |       2        | true             | true
-    10 << 10      |       0        | false            | true
-    10 << 10      |       1        | false            | true
-    30 << 10      |       1        | false            | true
-    30 << 10      |       2        | false            | true
-    100 << 10     |       0        | true             | true
-    100 << 10     |       1        | true             | true
-    100 << 10     |       10       | true             | true
-    100 << 10     |       100      | true             | true
-    100 << 10     |       0        | false            | true
-    100 << 10     |       1        | false            | true
-    100 << 10     |       10       | false            | true
-    100 << 10     |       100      | false            | true
-    10 << 10      |       0        | true             | false
-    10 << 10      |       1        | true             | false
-    30 << 10      |       1        | true             | false
-    30 << 10      |       2        | true             | false
-    10 << 10      |       0        | false            | false
-    10 << 10      |       1        | false            | false
-    30 << 10      |       1        | false            | false
-    30 << 10      |       2        | false            | false
-    100 << 10     |       0        | true             | false
-    100 << 10     |       1        | true             | false
-    100 << 10     |       10       | true             | false
-    100 << 10     |       100      | true             | false
-    100 << 10     |       0        | false            | false
-    100 << 10     |       1        | false            | false
-    100 << 10     |       10       | false            | false
-    100 << 10     |       100      | false            | false
+    bufferSize | traceCount | lowCardinality | v05
+    10 << 10   | 0          | true           | true
+    10 << 10   | 1          | true           | true
+    30 << 10   | 1          | true           | true
+    30 << 10   | 2          | true           | true
+    10 << 10   | 0          | false          | true
+    10 << 10   | 1          | false          | true
+    30 << 10   | 1          | false          | true
+    30 << 10   | 2          | false          | true
+    100 << 10  | 0          | true           | true
+    100 << 10  | 1          | true           | true
+    100 << 10  | 10         | true           | true
+    100 << 10  | 100        | true           | true
+    100 << 10  | 0          | false          | true
+    100 << 10  | 1          | false          | true
+    100 << 10  | 10         | false          | true
+    100 << 10  | 100        | false          | true
+    10 << 10   | 0          | true           | false
+    10 << 10   | 1          | true           | false
+    30 << 10   | 1          | true           | false
+    30 << 10   | 2          | true           | false
+    10 << 10   | 0          | false          | false
+    10 << 10   | 1          | false          | false
+    30 << 10   | 1          | false          | false
+    30 << 10   | 2          | false          | false
+    100 << 10  | 0          | true           | false
+    100 << 10  | 1          | true           | false
+    100 << 10  | 10         | true           | false
+    100 << 10  | 100        | true           | false
+    100 << 10  | 0          | false          | false
+    100 << 10  | 1          | false          | false
+    100 << 10  | 10         | false          | false
+    100 << 10  | 100        | false          | false
   }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddagent/TraceMapperV04PayloadTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddagent/TraceMapperV04PayloadTest.groovy
@@ -20,7 +20,7 @@ import static org.msgpack.core.MessageFormat.*
 
 class TraceMapperV04PayloadTest extends DDSpecification {
 
-  def "test traces written correctly" () {
+  def "test traces written correctly"() {
     setup:
     List<List<DDSpanData>> traces = generateRandomTraces(traceCount, lowCardinality)
     TraceMapperV0_4 traceMapper = new TraceMapperV0_4()
@@ -32,7 +32,7 @@ class TraceMapperV04PayloadTest extends DDSpecification {
       for (List<DDSpanData> trace : traces) {
         packer.format(trace, traceMapper)
       }
-    } catch(BufferOverflowException e) {
+    } catch (BufferOverflowException e) {
       tracesFitInBuffer = false
     }
     packer.flush()
@@ -43,25 +43,25 @@ class TraceMapperV04PayloadTest extends DDSpecification {
     }
 
     where:
-    bufferSize    |   traceCount   | lowCardinality
-    10 << 10      |       0        | true
-    10 << 10      |       1        | true
-    30 << 10      |       1        | true
-    30 << 10      |       2        | true
-    10 << 10      |       0        | false
-    10 << 10      |       1        | false
-    30 << 10      |       1        | false
-    30 << 10      |       2        | false
-    100 << 10     |       0        | true
-    100 << 10     |       1        | true
-    100 << 10     |       10       | true
-    100 << 10     |       100      | true
-    100 << 10     |       1000     | true
-    100 << 10     |       0        | false
-    100 << 10     |       1        | false
-    100 << 10     |       10       | false
-    100 << 10     |       100      | false
-    100 << 10     |       1000     | false
+    bufferSize | traceCount | lowCardinality
+    10 << 10   | 0          | true
+    10 << 10   | 1          | true
+    30 << 10   | 1          | true
+    30 << 10   | 2          | true
+    10 << 10   | 0          | false
+    10 << 10   | 1          | false
+    30 << 10   | 1          | false
+    30 << 10   | 2          | false
+    100 << 10  | 0          | true
+    100 << 10  | 1          | true
+    100 << 10  | 10         | true
+    100 << 10  | 100        | true
+    100 << 10  | 1000       | true
+    100 << 10  | 0          | false
+    100 << 10  | 1          | false
+    100 << 10  | 10         | false
+    100 << 10  | 100        | false
+    100 << 10  | 1000       | false
   }
 
   private static final class PayloadVerifier implements ByteBufferConsumer, WritableByteChannel {
@@ -204,7 +204,8 @@ class TraceMapperV04PayloadTest extends DDSpecification {
     }
 
     @Override
-    void close() {}
+    void close() {
+    }
   }
 
   private static void assertEqualsWithNullAsEmpty(CharSequence expected, CharSequence actual) {

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddagent/TraceMapperV05PayloadTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddagent/TraceMapperV05PayloadTest.groovy
@@ -20,7 +20,7 @@ import static org.msgpack.core.MessageFormat.*
 
 class TraceMapperV05PayloadTest extends DDSpecification {
 
-  def "test dictionary compressed traces written correctly" () {
+  def "test dictionary compressed traces written correctly"() {
     setup:
     List<List<DDSpanData>> traces = generateRandomTraces(traceCount, lowCardinality)
     TraceMapperV0_5 traceMapper = new TraceMapperV0_5(dictionarySize)
@@ -43,36 +43,36 @@ class TraceMapperV05PayloadTest extends DDSpecification {
     }
 
     where:
-    bufferSize    | dictionarySize |   traceCount   | lowCardinality
-    10 << 10      |   10 << 10     |       0        | true
-    10 << 10      |   10 << 10     |       1        | true
-    10 << 10      |   10 << 10     |       10       | true
-    10 << 10      |   10 << 10     |       100      | true
-    10 << 10      |   100 << 10    |       1        | true
-    10 << 10      |   100 << 10    |       10       | true
-    10 << 10      |   100 << 10    |       100      | true
-    10 << 10      |   10 << 10     |       0        | false
-    10 << 10      |   10 << 10     |       1        | false
-    10 << 10      |   10 << 10     |       10       | false
-    10 << 10      |   10 << 10     |       100      | false
-    10 << 10      |   100 << 10    |       1        | false
-    10 << 10      |   100 << 10    |       10       | false
-    10 << 10      |   100 << 10    |       100      | false
-    100 << 10     |   10 << 10     |       0        | true
-    100 << 10     |   10 << 10     |       1        | true
-    100 << 10     |   10 << 10     |       10       | true
-    100 << 10     |   10 << 10     |       100      | true
-    100 << 10     |   100 << 10    |       1        | true
-    100 << 10     |   100 << 10    |       10       | true
-    100 << 10     |   100 << 10    |       100      | true
-    100 << 10     |   10 << 10     |       0        | false
-    100 << 10     |   10 << 10     |       1        | false
-    100 << 10     |   10 << 10     |       10       | false
-    100 << 10     |   10 << 10     |       100      | false
-    100 << 10     |   100 << 10    |       1        | false
-    100 << 10     |   100 << 10    |       10       | false
-    100 << 10     |   100 << 10    |       100      | false
-    100 << 10     |   100 << 10    |       1000     | false
+    bufferSize | dictionarySize | traceCount | lowCardinality
+    10 << 10   | 10 << 10       | 0          | true
+    10 << 10   | 10 << 10       | 1          | true
+    10 << 10   | 10 << 10       | 10         | true
+    10 << 10   | 10 << 10       | 100        | true
+    10 << 10   | 100 << 10      | 1          | true
+    10 << 10   | 100 << 10      | 10         | true
+    10 << 10   | 100 << 10      | 100        | true
+    10 << 10   | 10 << 10       | 0          | false
+    10 << 10   | 10 << 10       | 1          | false
+    10 << 10   | 10 << 10       | 10         | false
+    10 << 10   | 10 << 10       | 100        | false
+    10 << 10   | 100 << 10      | 1          | false
+    10 << 10   | 100 << 10      | 10         | false
+    10 << 10   | 100 << 10      | 100        | false
+    100 << 10  | 10 << 10       | 0          | true
+    100 << 10  | 10 << 10       | 1          | true
+    100 << 10  | 10 << 10       | 10         | true
+    100 << 10  | 10 << 10       | 100        | true
+    100 << 10  | 100 << 10      | 1          | true
+    100 << 10  | 100 << 10      | 10         | true
+    100 << 10  | 100 << 10      | 100        | true
+    100 << 10  | 10 << 10       | 0          | false
+    100 << 10  | 10 << 10       | 1          | false
+    100 << 10  | 10 << 10       | 10         | false
+    100 << 10  | 10 << 10       | 100        | false
+    100 << 10  | 100 << 10      | 1          | false
+    100 << 10  | 100 << 10      | 10         | false
+    100 << 10  | 100 << 10      | 100        | false
+    100 << 10  | 100 << 10      | 1000       | false
   }
 
   private static final class PayloadVerifier implements ByteBufferConsumer, WritableByteChannel {
@@ -210,7 +210,8 @@ class TraceMapperV05PayloadTest extends DDSpecification {
     }
 
     @Override
-    void close() {}
+    void close() {
+    }
   }
 
   private static void assertEqualsWithNullAsEmpty(CharSequence expected, CharSequence actual) {

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/CoreSpanBuilderTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/CoreSpanBuilderTest.groovy
@@ -303,8 +303,8 @@ class CoreSpanBuilderTest extends DDSpecification {
     span.context().origin == extractedContext.origin
     span.context().baggageItems == extractedContext.baggage
     span.context().tags == extractedContext.tags + [(RUNTIME_ID_TAG)  : config.getRuntimeId(),
-                                                            (LANGUAGE_TAG_KEY): LANGUAGE_TAG_VALUE,
-                                                            (THREAD_NAME)     : thread.name, (THREAD_ID): thread.id]
+                                                    (LANGUAGE_TAG_KEY): LANGUAGE_TAG_VALUE,
+                                                    (THREAD_NAME)     : thread.name, (THREAD_ID): thread.id]
 
     where:
     extractedContext                                                                                                                    | _
@@ -324,8 +324,8 @@ class CoreSpanBuilderTest extends DDSpecification {
     span.context().origin == tagContext.origin
     span.context().baggageItems == [:]
     span.context().tags == tagContext.tags + [(RUNTIME_ID_TAG)  : config.getRuntimeId(),
-                                                      (LANGUAGE_TAG_KEY): LANGUAGE_TAG_VALUE,
-                                                      (THREAD_NAME)     : thread.name, (THREAD_ID): thread.id]
+                                              (LANGUAGE_TAG_KEY): LANGUAGE_TAG_VALUE,
+                                              (THREAD_NAME)     : thread.name, (THREAD_ID): thread.id]
 
     where:
     tagContext                                                                   | _

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanSerializationTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanSerializationTest.groovy
@@ -182,11 +182,11 @@ class DDSpanSerializationTest extends DDSpecification {
     }
 
     where:
-    baggage       | tags           | expected
-    [:]           | [:]            | [:]
-    [foo: "bbar"] | [:]            | [foo: "bbar"]
-    [foo: "bbar"] | [bar: "tfoo"]  | [foo: "bbar", bar: "tfoo"]
-    [foo: "bbar"] | [foo: "tbar"]  | [foo: "tbar"]
+    baggage       | tags          | expected
+    [:]           | [:]           | [:]
+    [foo: "bbar"] | [:]           | [foo: "bbar"]
+    [foo: "bbar"] | [bar: "tfoo"] | [foo: "bbar", bar: "tfoo"]
+    [foo: "bbar"] | [foo: "tbar"] | [foo: "tbar"]
   }
 
 
@@ -251,11 +251,11 @@ class DDSpanSerializationTest extends DDSpecification {
     assert unpackedMeta == expected
 
     where:
-    baggage       | tags           | expected
-    [:]           | [:]            | [:]
-    [foo: "bbar"] | [:]            | [foo: "bbar"]
-    [foo: "bbar"] | [bar: "tfoo"]  | [foo: "bbar", bar: "tfoo"]
-    [foo: "bbar"] | [foo: "tbar"]  | [foo: "tbar"]
+    baggage       | tags          | expected
+    [:]           | [:]           | [:]
+    [foo: "bbar"] | [:]           | [foo: "bbar"]
+    [foo: "bbar"] | [bar: "tfoo"] | [foo: "bbar", bar: "tfoo"]
+    [foo: "bbar"] | [foo: "tbar"] | [foo: "tbar"]
   }
 
   private class CaptureBuffer implements ByteBufferConsumer {

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/monitor/CounterTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/monitor/CounterTest.groovy
@@ -8,7 +8,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS
 
 class CounterTest extends DDSpecification {
 
-  def "counter counts stuff" () {
+  def "counter counts stuff"() {
     StatsDClient statsd = Mock(StatsDClient)
     Monitoring monitoring = new Monitoring(statsd, 100, MILLISECONDS)
     def counter = monitoring.newCounter("my_counter")
@@ -19,7 +19,7 @@ class CounterTest extends DDSpecification {
     0 * _
   }
 
-  def "counter tags error counts with cause" () {
+  def "counter tags error counts with cause"() {
     StatsDClient statsd = Mock(StatsDClient)
     Monitoring monitoring = new Monitoring(statsd, 100, MILLISECONDS)
     def counter = monitoring.newCounter("my_counter")
@@ -30,7 +30,7 @@ class CounterTest extends DDSpecification {
     0 * _
   }
 
-  def "disabled monitoring produces no op counters" () {
+  def "disabled monitoring produces no op counters"() {
     setup:
     Monitoring monitoring = Monitoring.DISABLED
     when:
@@ -39,7 +39,7 @@ class CounterTest extends DDSpecification {
     counter instanceof NoOpCounter
   }
 
-  def "no-op counters are safe" () {
+  def "no-op counters are safe"() {
     setup:
     Counter counter = Monitoring.DISABLED.newCounter("foo")
     expect:

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/monitor/TimingTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/monitor/TimingTest.groovy
@@ -10,7 +10,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS
 
 class TimingTest extends DDSpecification {
 
-  def "timer times stuff" () {
+  def "timer times stuff"() {
     setup:
     StatsDClient statsd = Mock(StatsDClient)
     Monitoring monitoring = new Monitoring(statsd, 100, MILLISECONDS)
@@ -27,7 +27,7 @@ class TimingTest extends DDSpecification {
     0 * _
   }
 
-  def "threadlocal timer times stuff" () {
+  def "threadlocal timer times stuff"() {
     setup:
     StatsDClient statsd = Mock(StatsDClient)
     Monitoring monitoring = new Monitoring(statsd, 100, MILLISECONDS)
@@ -37,14 +37,14 @@ class TimingTest extends DDSpecification {
     Thread.sleep(200)
     recording.close()
     then:
-    1 * statsd.gauge("my_timer", { it > MILLISECONDS.toNanos(200) }, {it[0] == "stat:avg" && it[1].startsWith("thread:")})
-    1 * statsd.gauge("my_timer", { it > MILLISECONDS.toNanos(200) }, {it[0] == "stat:p50" && it[1].startsWith("thread:")})
-    1 * statsd.gauge("my_timer", { it > MILLISECONDS.toNanos(200) }, {it[0] == "stat:p99" && it[1].startsWith("thread:")})
-    1 * statsd.gauge("my_timer", { it > MILLISECONDS.toNanos(200) }, {it[0] == "stat:max" && it[1].startsWith("thread:")})
+    1 * statsd.gauge("my_timer", { it > MILLISECONDS.toNanos(200) }, { it[0] == "stat:avg" && it[1].startsWith("thread:") })
+    1 * statsd.gauge("my_timer", { it > MILLISECONDS.toNanos(200) }, { it[0] == "stat:p50" && it[1].startsWith("thread:") })
+    1 * statsd.gauge("my_timer", { it > MILLISECONDS.toNanos(200) }, { it[0] == "stat:p99" && it[1].startsWith("thread:") })
+    1 * statsd.gauge("my_timer", { it > MILLISECONDS.toNanos(200) }, { it[0] == "stat:max" && it[1].startsWith("thread:") })
     0 * _
   }
 
-  def "reset timer" () {
+  def "reset timer"() {
     setup:
     StatsDClient statsd = Mock(StatsDClient)
     Monitoring monitoring = new Monitoring(statsd, 100, MILLISECONDS)
@@ -61,10 +61,10 @@ class TimingTest extends DDSpecification {
     }
 
     where:
-    timerCreator << [{it.newTimer("my_timer")}, { it.newThreadLocalTimer("my_timer") }]
+    timerCreator << [{ it.newTimer("my_timer") }, { it.newThreadLocalTimer("my_timer") }]
   }
 
-  def "disabled monitoring produces no ops" () {
+  def "disabled monitoring produces no ops"() {
     expect:
     Monitoring.DISABLED.newTimer("foo") instanceof NoOpRecording
     Monitoring.DISABLED.newTimer("foo", "tag") instanceof NoOpRecording
@@ -72,7 +72,7 @@ class TimingTest extends DDSpecification {
     Monitoring.DISABLED.newCPUTimer("foo") instanceof NoOpRecording
   }
 
-  def "no ops are safe to use" () {
+  def "no ops are safe to use"() {
     expect:
     try {
       recording.start().stop()
@@ -88,7 +88,7 @@ class TimingTest extends DDSpecification {
                   Monitoring.DISABLED.newCPUTimer("foo")]
   }
 
-  def "cpu timing records CPU time when enabled" () {
+  def "cpu timing records CPU time when enabled"() {
     setup:
     Assume.assumeTrue(getThreadMXBean().isCurrentThreadCpuTimeSupported())
     StatsDClient statsd = Mock(StatsDClient)
@@ -99,11 +99,11 @@ class TimingTest extends DDSpecification {
     Thread.sleep(200)
     recording.close()
     then:
-    1 * statsd.gauge("my_timer", { it > MILLISECONDS.toNanos(200) }, {it[0] == "stat:avg" && it[1].startsWith("thread:")})
-    1 * statsd.gauge("my_timer", { it > MILLISECONDS.toNanos(200) }, {it[0] == "stat:p50" && it[1].startsWith("thread:")})
-    1 * statsd.gauge("my_timer", { it > MILLISECONDS.toNanos(200) }, {it[0] == "stat:p99" && it[1].startsWith("thread:")})
-    1 * statsd.gauge("my_timer", { it > MILLISECONDS.toNanos(200) }, {it[0] == "stat:max" && it[1].startsWith("thread:")})
-    1 * statsd.gauge("my_timer.cpu", { it > 0 }, {it[0].startsWith("thread:")})
+    1 * statsd.gauge("my_timer", { it > MILLISECONDS.toNanos(200) }, { it[0] == "stat:avg" && it[1].startsWith("thread:") })
+    1 * statsd.gauge("my_timer", { it > MILLISECONDS.toNanos(200) }, { it[0] == "stat:p50" && it[1].startsWith("thread:") })
+    1 * statsd.gauge("my_timer", { it > MILLISECONDS.toNanos(200) }, { it[0] == "stat:p99" && it[1].startsWith("thread:") })
+    1 * statsd.gauge("my_timer", { it > MILLISECONDS.toNanos(200) }, { it[0] == "stat:max" && it[1].startsWith("thread:") })
+    1 * statsd.gauge("my_timer.cpu", { it > 0 }, { it[0].startsWith("thread:") })
     0 * _
   }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HaystackHttpExtractorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HaystackHttpExtractorTest.groovy
@@ -133,20 +133,20 @@ class HaystackHttpExtractorTest extends DDSpecification {
     }
 
     where:
-    traceId                                | spanId                                | expectedTraceId                | expectedSpanId
-    "-1"                                   | "1"                                   | null                           | DDId.ZERO
-    "1"                                    | "-1"                                  | null                           | DDId.ZERO
-    "0"                                    | "1"                                   | null                           | DDId.ZERO
-    "00001"                                | "00001"                               | DDId.ONE                       | DDId.ONE
-    "463ac35c9f6413ad"                     | "463ac35c9f6413ad"                    | DDId.from(5060571933882717101) | DDId.from(5060571933882717101)
-    "463ac35c9f6413ad48485a3953bb6124"     | "1"                                   | DDId.from(5208512171318403364) | DDId.ONE
-    "44617461-646f-6721-463a-c35c9f6413ad" |"44617461-646f-6721-463a-c35c9f6413ad" | DDId.from(5060571933882717101) | DDId.from(5060571933882717101)
-    "f" * 16                               | "1"                                   | DDId.MAX                       | DDId.ONE
-    "a" * 16 + "f" * 16                    | "1"                                   | DDId.MAX                       | DDId.ONE
-    "1" + "f" * 32                         | "1"                                   | null                           | DDId.ONE
-    "0" + "f" * 32                         | "1"                                   | null                           | DDId.ONE
-    "1"                                    | "f" * 16                              | DDId.ONE                       | DDId.MAX
-    "1"                                    | "1" + "f" * 16                        | null                           | DDId.ZERO
-    "1"                                    | "000" + "f" * 16                      | DDId.ONE                       | DDId.MAX
+    traceId                                | spanId                                 | expectedTraceId                | expectedSpanId
+    "-1"                                   | "1"                                    | null                           | DDId.ZERO
+    "1"                                    | "-1"                                   | null                           | DDId.ZERO
+    "0"                                    | "1"                                    | null                           | DDId.ZERO
+    "00001"                                | "00001"                                | DDId.ONE                       | DDId.ONE
+    "463ac35c9f6413ad"                     | "463ac35c9f6413ad"                     | DDId.from(5060571933882717101) | DDId.from(5060571933882717101)
+    "463ac35c9f6413ad48485a3953bb6124"     | "1"                                    | DDId.from(5208512171318403364) | DDId.ONE
+    "44617461-646f-6721-463a-c35c9f6413ad" | "44617461-646f-6721-463a-c35c9f6413ad" | DDId.from(5060571933882717101) | DDId.from(5060571933882717101)
+    "f" * 16                               | "1"                                    | DDId.MAX                       | DDId.ONE
+    "a" * 16 + "f" * 16                    | "1"                                    | DDId.MAX                       | DDId.ONE
+    "1" + "f" * 32                         | "1"                                    | null                           | DDId.ONE
+    "0" + "f" * 32                         | "1"                                    | null                           | DDId.ONE
+    "1"                                    | "f" * 16                               | DDId.ONE                       | DDId.MAX
+    "1"                                    | "1" + "f" * 16                         | null                           | DDId.ZERO
+    "1"                                    | "000" + "f" * 16                       | DDId.ONE                       | DDId.MAX
   }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/util/SystemAccessTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/util/SystemAccessTest.groovy
@@ -94,8 +94,8 @@ class SystemAccessTest extends DDSpecification {
     def pid = SystemAccess.getCurrentPid()
 
     then:
-      pid > 0
-      pid == Integer.parseInt(ManagementFactory.getRuntimeMXBean().getName().split("@")[0])
+    pid > 0
+    pid == Integer.parseInt(ManagementFactory.getRuntimeMXBean().getName().split("@")[0])
 
     cleanup:
     SystemAccess.disableJmx()

--- a/dd-trace-ot/src/ot31CompatabilityTest/groovy/OT31ApiTest.groovy
+++ b/dd-trace-ot/src/ot31CompatabilityTest/groovy/OT31ApiTest.groovy
@@ -36,8 +36,8 @@ class OT31ApiTest extends DDSpecification {
 
     then:
     assertTraces(WRITER, 1) {
-      trace(0, 1) {
-        basicSpan(it, 0, "some name")
+      trace(1) {
+        basicSpan(it, "some name")
       }
     }
   }

--- a/dd-trace-ot/src/ot33CompatabilityTest/groovy/OT33ApiTest.groovy
+++ b/dd-trace-ot/src/ot33CompatabilityTest/groovy/OT33ApiTest.groovy
@@ -1,6 +1,6 @@
 import datadog.opentracing.DDTracer
-import datadog.trace.core.DDSpan
 import datadog.trace.common.writer.ListWriter
+import datadog.trace.core.DDSpan
 import datadog.trace.util.test.DDSpecification
 import io.opentracing.Tracer
 import spock.lang.Subject
@@ -30,8 +30,8 @@ class OT33ApiTest extends DDSpecification {
 
     then:
     assertTraces(WRITER, 1) {
-      trace(0, 1) {
-        basicSpan(it, 0, "some name")
+      trace(1) {
+        basicSpan(it, "some name")
       }
     }
   }

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/CustomScopeManagerTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/CustomScopeManagerTest.groovy
@@ -29,8 +29,8 @@ class CustomScopeManagerTest extends DDSpecification {
 
     then:
     assertTraces(writer, 1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "someService"
           operationName "someOperation"
           resourceName "someOperation"
@@ -56,8 +56,8 @@ class CustomScopeManagerTest extends DDSpecification {
     then:
     tracer.scopeManager() instanceof TestScopeManager
     assertTraces(writer, 1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "someService"
           operationName "someOperation"
           resourceName "someOperation"
@@ -100,8 +100,8 @@ class CustomScopeManagerTest extends DDSpecification {
     then:
     tracer.scopeManager() instanceof TestScopeManager
     assertTraces(writer, 1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "someService"
           operationName "someOperation"
           resourceName "someOperation"
@@ -140,8 +140,8 @@ class CustomScopeManagerTest extends DDSpecification {
     then:
     tracer.scopeManager() instanceof TestScopeManager
     assertTraces(writer, 1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "someService"
           operationName "someOperation"
           resourceName "someOperation"
@@ -182,8 +182,8 @@ class CustomScopeManagerTest extends DDSpecification {
     then:
     tracer.scopeManager() instanceof TestScopeManager
     assertTraces(writer, 1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "someService"
           operationName "someOperation"
           resourceName "someOperation"

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/OpenTracingAPITest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/OpenTracingAPITest.groovy
@@ -59,8 +59,8 @@ class OpenTracingAPITest extends DDSpecification {
     1 * traceInterceptor.onTraceComplete({ it.size() == 1 }) >> { args -> args[0] }
 
     assertTraces(writer, 1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "someService"
           operationName "someOperation"
           resourceName "someOperation"
@@ -94,8 +94,8 @@ class OpenTracingAPITest extends DDSpecification {
     testSpan instanceof MutableSpan
 
     assertTraces(writer, 1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "someService"
           operationName "someOperation"
           resourceName "someOperation"
@@ -134,8 +134,8 @@ class OpenTracingAPITest extends DDSpecification {
     1 * scopeListener.afterScopeClosed()
 
     assertTraces(writer, 1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "someService"
           operationName("someOtherOperation")
           resourceName "someOtherOperation"
@@ -196,8 +196,8 @@ class OpenTracingAPITest extends DDSpecification {
     1 * traceInterceptor.onTraceComplete({ it.size() == 2 }) >> { args -> args[0] }
 
     assertTraces(writer, 1) {
-      trace(0, 2) {
-        span(0) {
+      trace(2) {
+        span {
           serviceName "someService"
           operationName "someOperation"
           resourceName "someOperation"
@@ -205,7 +205,7 @@ class OpenTracingAPITest extends DDSpecification {
             defaultTags()
           }
         }
-        span(1) {
+        span {
           serviceName "someService"
           operationName "someOperation2"
           resourceName "someOperation2"
@@ -244,8 +244,8 @@ class OpenTracingAPITest extends DDSpecification {
     1 * traceInterceptor.onTraceComplete({ it.size() == 1 }) >> { args -> args[0] }
 
     assertTraces(writer, 1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "someService"
           operationName "someOperation"
           resourceName "someOperation"
@@ -281,8 +281,8 @@ class OpenTracingAPITest extends DDSpecification {
     1 * scopeListener.afterScopeClosed()
 
     assertTraces(writer, 1) {
-      trace(0, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "someService"
           operationName "someOperation"
           resourceName "someOperation"
@@ -410,24 +410,24 @@ class OpenTracingAPITest extends DDSpecification {
     extractedContext.toSpanId() == testSpan.context().toSpanId()
 
     assertTraces(writer, 2) {
-      trace(0, 1) {
-        span(0) {
-          serviceName "someService"
-          operationName "serverOperation"
-          resourceName "serverOperation"
-          childOf(trace(1).get(0))
-          tags {
-            defaultTags(true)
-          }
-        }
-      }
-      trace(1, 1) {
-        span(0) {
+      trace(1) {
+        span {
           serviceName "someClientService"
           operationName "clientOperation"
           resourceName "clientOperation"
           tags {
             defaultTags()
+          }
+        }
+      }
+      trace(1) {
+        span {
+          serviceName "someService"
+          operationName "serverOperation"
+          resourceName "serverOperation"
+          childOf(trace(0).get(0))
+          tags {
+            defaultTags(true)
           }
         }
       }

--- a/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -1758,7 +1758,7 @@ class ConfigTest extends DDSpecification {
     "42.42" | ClassThrowsExceptionForValueOfMethod // will wrapped in NumberFormatException anyway
   }
 
-  def "revert to RANDOM with invalid id generation strategy" () {
+  def "revert to RANDOM with invalid id generation strategy"() {
     setup:
     def prop = new Properties()
     prop.setProperty(ID_GENERATION_STRATEGY, "LOL")

--- a/internal-api/src/test/groovy/datadog/trace/api/FunctionsTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/FunctionsTest.groovy
@@ -4,29 +4,29 @@ import datadog.trace.util.test.DDSpecification
 
 class FunctionsTest extends DDSpecification {
 
-  def "test common string functions" () {
+  def "test common string functions"() {
     when:
     CharSequence output = fn.apply(input)
     then:
     output == expected
     where:
-    fn                                 |        input | expected
-    Functions.LowerCase.INSTANCE       |        "xYz" |    "xyz"
-    new Functions.ToString<String>()   |        "xYz" |    "xYz"
+    fn                               | input | expected
+    Functions.LowerCase.INSTANCE     | "xYz" | "xyz"
+    new Functions.ToString<String>() | "xYz" | "xYz"
   }
 
 
-  def "test join strings" () {
+  def "test join strings"() {
     when:
     CharSequence output = fn.apply(left, right)
     then:
     String.valueOf(output) == expected
     where:
-    fn                                              |        left  | right | expected
-    Functions.PrefixJoin.of("~", Functions.zero())  |          "x" |  "y"  |    "x~y"
-    Functions.PrefixJoin.of("~")                    |          "x" |  "y"  |    "x~y"
-    Functions.SuffixJoin.of("~", Functions.zero())  |          "x" |  "y"  |    "x~y"
-    Functions.SuffixJoin.of("~")                    |          "x" |  "y"  |    "x~y"
+    fn                                             | left | right | expected
+    Functions.PrefixJoin.of("~", Functions.zero()) | "x"  | "y"   | "x~y"
+    Functions.PrefixJoin.of("~")                   | "x"  | "y"   | "x~y"
+    Functions.SuffixJoin.of("~", Functions.zero()) | "x"  | "y"   | "x~y"
+    Functions.SuffixJoin.of("~")                   | "x"  | "y"   | "x~y"
 
   }
 }

--- a/internal-api/src/test/groovy/datadog/trace/api/cache/FixedSizeCacheTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/cache/FixedSizeCacheTest.groovy
@@ -62,7 +62,7 @@ class FixedSizeCacheTest extends DDSpecification {
     new TKey(6, 6, "foo")     | "six_value"    | 3
     new TKey(1, 11, "eleven") | "eleven_value" | 4
     new TKey(4, 4, "four")    | "four_value"   | 4
-    null                      | null           | 3     
+    null                      | null           | 3
   }
 
   def "should handle concurrent usage"() {
@@ -97,7 +97,7 @@ class FixedSizeCacheTest extends DDSpecification {
     conds.await(30.0) // the test is really fast locally, but I don't know how fast CI is
 
     where:
-    cacheImpl << [{capacity -> DDCaches.newFixedSizeCache(capacity) }, {capacity -> DDCaches.newUnboundedCache(capacity)}]
+    cacheImpl << [{ capacity -> DDCaches.newFixedSizeCache(capacity) }, { capacity -> DDCaches.newUnboundedCache(capacity) }]
   }
 
   private class TVC implements Function<TKey, String> {

--- a/internal-api/src/test/groovy/datadog/trace/api/cache/QualifiedClassNameCacheTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/cache/QualifiedClassNameCacheTest.groovy
@@ -7,7 +7,7 @@ import datadog.trace.util.test.DDSpecification
 
 class QualifiedClassNameCacheTest extends DDSpecification {
 
-  def "test cached string operations" () {
+  def "test cached string operations"() {
     when:
     QualifiedClassNameCache cache = new QualifiedClassNameCache(new Function<Class<?>, String>() {
       @Override
@@ -20,13 +20,13 @@ class QualifiedClassNameCacheTest extends DDSpecification {
     then:
     qualified == expected
     where:
-    type    |    prefix    |  func                                                 |   expected
-    String  |    "foo."    |  Functions.Suffix.ZERO                                | "foo.String"
-    String  |    ".foo"    |  Functions.Prefix.ZERO                                | "String.foo"
-    String  |    "foo"     |  Functions.SuffixJoin.of(".")                         | "foo.String"
-    String  |    "foo"     |  Functions.PrefixJoin.of(".")                         | "String.foo"
-    String  |    "foo"     |  Functions.SuffixJoin.of(".", new Replace("oo", ""))  | "f.String"
-    String  |    "foo"     |  Functions.PrefixJoin.of(".", new Replace("oo", ""))  | "String.f"
+    type   | prefix | func                                                | expected
+    String | "foo." | Functions.Suffix.ZERO                               | "foo.String"
+    String | ".foo" | Functions.Prefix.ZERO                               | "String.foo"
+    String | "foo"  | Functions.SuffixJoin.of(".")                        | "foo.String"
+    String | "foo"  | Functions.PrefixJoin.of(".")                        | "String.foo"
+    String | "foo"  | Functions.SuffixJoin.of(".", new Replace("oo", "")) | "f.String"
+    String | "foo"  | Functions.PrefixJoin.of(".", new Replace("oo", "")) | "String.f"
   }
 
   def "test get cached class name"() {
@@ -41,9 +41,9 @@ class QualifiedClassNameCacheTest extends DDSpecification {
     cache.getClassName(type) == expected
 
     where:
-    type             | expected
-    String           | "String"
-    Functions.Zero   | "Zero"
+    type           | expected
+    String         | "String"
+    Functions.Zero | "Zero"
   }
 
   class Replace implements Function<String, String> {

--- a/internal-api/src/test/groovy/datadog/trace/api/cache/RadixTreeCacheTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/cache/RadixTreeCacheTest.groovy
@@ -8,7 +8,7 @@ import static datadog.trace.ThreadUtils.runConcurrently
 
 class RadixTreeCacheTest extends DDSpecification {
 
-  def "cached values are equal to autoboxed values" () {
+  def "cached values are equal to autoboxed values"() {
     setup:
     RadixTreeCache<Integer> cache = new RadixTreeCache<>(4, 4, { it })
     when:
@@ -21,7 +21,7 @@ class RadixTreeCacheTest extends DDSpecification {
   }
 
 
-  def "cached values are equal to computed values" () {
+  def "cached values are equal to computed values"() {
     setup:
     RadixTreeCache<String> cache = new RadixTreeCache<>(4, 4, { it.toString() })
     when:
@@ -33,7 +33,7 @@ class RadixTreeCacheTest extends DDSpecification {
     primitive << [-1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17]
   }
 
-  def "cached values are equal to computed values with precomputing" () {
+  def "cached values are equal to computed values with precomputing"() {
     setup:
     RadixTreeCache<String> cache = new RadixTreeCache<>(4, 4,
       { it.toString() }, -1, 9)
@@ -47,7 +47,7 @@ class RadixTreeCacheTest extends DDSpecification {
   }
 
 
-  def "concurrency test" () {
+  def "concurrency test"() {
     setup:
     RadixTreeCache<String> cache = new RadixTreeCache<>(256, 256,
       { it.toString() }, -1, 9)
@@ -58,14 +58,14 @@ class RadixTreeCacheTest extends DDSpecification {
     })
   }
 
-  def "cache ports" () {
+  def "cache ports"() {
     expect:
     Integer.valueOf(port) == RadixTreeCache.PORTS.get(port)
     where:
     port << [0, 80, 443, 4444, 8080, 65535]
   }
 
-  def "cache HTTP statuses" () {
+  def "cache HTTP statuses"() {
     expect:
     Integer.valueOf(status) == RadixTreeCache.HTTP_STATUSES.get(status)
     where:

--- a/internal-api/src/test/groovy/datadog/trace/api/utils/StringsTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/utils/StringsTest.groovy
@@ -10,11 +10,11 @@ class StringsTest extends DDSpecification {
     then:
     s == expected
     where:
-    joiner     |     strings      | expected
-    ","        |  ["a", "b", "c"] | "a,b,c"
-    ","        |  ["a", "b"]      | "a,b"
-    ","        |  ["a"]           | "a"
-    ","        |  []              | ""
+    joiner | strings         | expected
+    ","    | ["a", "b", "c"] | "a,b,c"
+    ","    | ["a", "b"]      | "a,b"
+    ","    | ["a"]           | "a"
+    ","    | []              | ""
   }
 
   def "test join strings varargs"() {
@@ -24,10 +24,10 @@ class StringsTest extends DDSpecification {
     then:
     s == expected
     where:
-    joiner     |     strings      | expected
-    ","        |  ["a", "b", "c"] | "a,b,c"
-    ","        |  ["a", "b"]      | "a,b"
-    ","        |  ["a"]           | "a"
-    ","        |  []              | ""
+    joiner | strings         | expected
+    ","    | ["a", "b", "c"] | "a,b,c"
+    ","    | ["a", "b"]      | "a,b"
+    ","    | ["a"]           | "a"
+    ","    | []              | ""
   }
 }

--- a/internal-api/src/test/groovy/datadog/trace/bootstrap/instrumentation/api/Utf8ByteStringTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/bootstrap/instrumentation/api/Utf8ByteStringTest.groovy
@@ -28,16 +28,16 @@ class Utf8ByteStringTest extends DDSpecification {
     }
 
     where:
-    str               |      constant
-    null              |   false
-    "foo"             |   false
-    "bar"             |   false
-    "alongerstring"   |   false
+    str                                                           | constant
+    null                                                          | false
+    "foo"                                                         | false
+    "bar"                                                         | false
+    "alongerstring"                                               | false
     new String(new char[UTF8BytesString.Allocator.PAGE_SIZE + 1]) | false
-    null              |   true
-    "foo"             |   true
-    "bar"             |   true
-    "alongerstring"   |   true
+    null                                                          | true
+    "foo"                                                         | true
+    "bar"                                                         | true
+    "alongerstring"                                               | true
     new String(new char[UTF8BytesString.Allocator.PAGE_SIZE + 1]) | true
   }
 
@@ -57,18 +57,18 @@ class Utf8ByteStringTest extends DDSpecification {
     }
 
     where:
-    chars                                          |   constant
-    null                                           | true
-    "foo"                                          | true
-    new StringBuffer("bar")                        | true
-    new StringBuffer("someotherlongstring")        | true
-    UTF8BytesString.create("utf8string")           | true
+    chars                                                         | constant
+    null                                                          | true
+    "foo"                                                         | true
+    new StringBuffer("bar")                                       | true
+    new StringBuffer("someotherlongstring")                       | true
+    UTF8BytesString.create("utf8string")                          | true
     new String(new char[UTF8BytesString.Allocator.PAGE_SIZE + 1]) | true
-    null                                           | false
-    "foo"                                          | false
-    new StringBuffer("bar")                        | false
-    new StringBuffer("someotherlongstring")        | false
-    UTF8BytesString.create("utf8string")           | false
+    null                                                          | false
+    "foo"                                                         | false
+    new StringBuffer("bar")                                       | false
+    new StringBuffer("someotherlongstring")                       | false
+    UTF8BytesString.create("utf8string")                          | false
     new String(new char[UTF8BytesString.Allocator.PAGE_SIZE + 1]) | false
   }
 }


### PR DESCRIPTION
Uses the `PendingTrace.startNanoTicks` to provide the greatest precision.

Also remove the indexes from trace/span assertion and use just the declaration order instead.