### PR TITLE
Span.log() messages incorrect

### DIFF
--- a/dd-trace-ot/src/main/java/datadog/opentracing/DefaultLogHandler.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/DefaultLogHandler.java
@@ -15,14 +15,12 @@ public class DefaultLogHandler implements LogHandler {
   @Override
   public void log(final Map<String, ?> fields, final AgentSpan span) {
     extractError(fields, span);
-    log.debug("`log` method is not implemented. Doing nothing");
   }
 
   @Override
   public void log(
       final long timestampMicroseconds, final Map<String, ?> fields, final AgentSpan span) {
     extractError(fields, span);
-    log.debug("`log` method is not implemented. Doing nothing");
   }
 
   @Override


### PR DESCRIPTION
The log messages in `DefaultLogHandler` print out "doing nothing" even when they do.  (Probably a c/p error on my part a while ago)