### PR TITLE
Stop bundling scala with `dd-java-agent`

### DIFF
--- a/gradle/test-with-scala.gradle
+++ b/gradle/test-with-scala.gradle
@@ -3,8 +3,8 @@
 apply plugin: 'scala'
 
 dependencies {
-  implementation deps.scala
-  testImplementation deps.scala
+  compileOnly deps.scala
+  testCompile deps.scala
 }
 
 compileTestGroovy {


### PR DESCRIPTION
This change caused the scala library to be a runtime dependency of instrumentation resulting in it being bundled with the `dd-java-agent` release.

Problem introduced in #1810.