### PR TITLE
use continuation in Spring Async instrumentation

### DIFF
--- a/dd-java-agent/instrumentation/spring-scheduling-3.1/src/main/java/datadog/trace/instrumentation/springscheduling/SpringAsyncAdvice.java
+++ b/dd-java-agent/instrumentation/spring-scheduling-3.1/src/main/java/datadog/trace/instrumentation/springscheduling/SpringAsyncAdvice.java
@@ -1,7 +1,8 @@
 package datadog.trace.instrumentation.springscheduling;
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
 
+import datadog.trace.context.TraceScope;
 import net.bytebuddy.asm.Advice;
 import org.aopalliance.intercept.MethodInvocation;
 
@@ -10,6 +11,7 @@ public class SpringAsyncAdvice {
   @Advice.OnMethodEnter(suppress = Throwable.class)
   public static void scheduleAsync(
       @Advice.Argument(value = 0, readOnly = false) MethodInvocation invocation) {
-    invocation = new SpannedMethodInvocation(activeSpan(), invocation);
+    TraceScope scope = activeScope();
+    invocation = new SpannedMethodInvocation(null == scope ? null : scope.capture(), invocation);
   }
 }


### PR DESCRIPTION
I hadn't really appreciated the continuation mechanism when I added this instrumentation. This is partly here as a sample of a way to do this without field injection.