### PR TITLE
Cleanup dependency on Guava

### DIFF
--- a/dd-java-agent/agent-tooling/agent-tooling.gradle
+++ b/dd-java-agent/agent-tooling/agent-tooling.gradle
@@ -15,6 +15,7 @@ dependencies {
   compile group: 'com.blogspot.mydailyjava', name: 'weak-lock-free', version: '0.15'
   compile deps.bytebuddy
   compile deps.bytebuddyagent
+  compile deps.guava
 
   annotationProcessor deps.autoserviceProcessor
   compileOnly deps.autoserviceAnnotation

--- a/dd-java-agent/agent-tooling/agent-tooling.gradle
+++ b/dd-java-agent/agent-tooling/agent-tooling.gradle
@@ -15,8 +15,9 @@ dependencies {
   compile group: 'com.blogspot.mydailyjava', name: 'weak-lock-free', version: '0.15'
   compile deps.bytebuddy
   compile deps.bytebuddyagent
-  annotationProcessor deps.autoservice
-  implementation deps.autoservice
+
+  annotationProcessor deps.autoserviceProcessor
+  compileOnly deps.autoserviceAnnotation
 
   compile project(':dd-trace-core')
   compile project(':dd-trace-core:jfr-openjdk')

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/WeakMapSuppliers.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/WeakMapSuppliers.java
@@ -1,7 +1,6 @@
 package datadog.trace.agent.tooling;
 
 import com.blogspot.mydailyjava.weaklockfree.WeakConcurrentMap;
-import com.google.common.annotations.VisibleForTesting;
 import datadog.common.exec.AgentTaskScheduler;
 import datadog.common.exec.AgentTaskScheduler.Task;
 import datadog.trace.bootstrap.WeakMap;
@@ -31,7 +30,7 @@ class WeakMapSuppliers {
    */
   static class WeakConcurrent implements WeakMap.Implementation {
 
-    @VisibleForTesting static final long CLEAN_FREQUENCY_SECONDS = 1;
+    static final long CLEAN_FREQUENCY_SECONDS = 1;
 
     @Override
     public <K, V> WeakMap<K, V> get() {

--- a/dd-java-agent/instrumentation/elasticsearch/elasticsearch.gradle
+++ b/dd-java-agent/instrumentation/elasticsearch/elasticsearch.gradle
@@ -3,5 +3,4 @@ apply from: "$rootDir/gradle/java.gradle"
 dependencies {
   compileOnly group: 'org.elasticsearch.client', name: 'rest', version: '5.0.0'
   compileOnly group: 'org.elasticsearch', name: 'elasticsearch', version: '2.0.0'
-  compile project(':dd-java-agent:agent-tooling')
 }

--- a/dd-java-agent/instrumentation/exception-profiling/exception-profiling.gradle
+++ b/dd-java-agent/instrumentation/exception-profiling/exception-profiling.gradle
@@ -12,8 +12,6 @@ apply from: "$rootDir/gradle/java.gradle"
 apply plugin: "idea"
 
 dependencies {
-  compile project(':dd-java-agent:agent-tooling')
-
   testCompile deps.junit5
   testCompile deps.jmc
   testCompile deps.commonsMath

--- a/dd-java-agent/instrumentation/glassfish/glassfish.gradle
+++ b/dd-java-agent/instrumentation/glassfish/glassfish.gradle
@@ -24,7 +24,8 @@ testSets {
 dependencies {
   testCompile project(':dd-java-agent:instrumentation:servlet:request-3')
   testCompile project(':dd-java-agent:instrumentation:grizzly-2')
-
+  testCompile deps.guava
   testCompile group: 'org.glassfish.main.extras', name: 'glassfish-embedded-all', version: '4.0'
+
   latestDepTestCompile group: 'org.glassfish.main.extras', name: 'glassfish-embedded-all', version: '+'
 }

--- a/dd-java-agent/instrumentation/instrumentation.gradle
+++ b/dd-java-agent/instrumentation/instrumentation.gradle
@@ -53,8 +53,9 @@ subprojects { Project subProj ->
         "$jdkCompile" project(':dd-java-agent:agent-tooling')
         "$jdkCompile" deps.bytebuddy
       }
-      annotationProcessor deps.autoservice
-      implementation deps.autoservice
+
+      annotationProcessor deps.autoserviceProcessor
+      compileOnly deps.autoserviceAnnotation
 
       // Include instrumentations instrumenting core JDK classes tp ensure interoperability with other instrumentation
       testCompile project(':dd-java-agent:instrumentation:java-concurrent')
@@ -63,8 +64,8 @@ subprojects { Project subProj ->
       testCompile project(':dd-java-agent:instrumentation:classloading')
 
       testCompile project(':dd-java-agent:testing')
-      testAnnotationProcessor deps.autoservice
-      testImplementation deps.autoservice
+      testAnnotationProcessor deps.autoserviceProcessor
+      testCompileOnly deps.autoserviceAnnotation
     }
 
     // Make it so all instrumentation subproject tests can be run with a single command.

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/AsyncPropagatingDisableInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/AsyncPropagatingDisableInstrumentation.java
@@ -8,7 +8,6 @@ import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 
 import com.google.auto.service.AutoService;
-import com.google.common.collect.ImmutableMap;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.context.TraceScope;
@@ -30,26 +29,11 @@ import net.bytebuddy.matcher.ElementMatchers;
 @AutoService(Instrumenter.class)
 public final class AsyncPropagatingDisableInstrumentation implements Instrumenter {
 
-  private static final Map<
-          ElementMatcher<? super TypeDescription>, ElementMatcher<? super MethodDescription>>
-      CLASS_AND_METHODS =
-          new ImmutableMap.Builder<
-                  ElementMatcher<? super TypeDescription>,
-                  ElementMatcher<? super MethodDescription>>()
-              .put(extendsClass(named("rx.Scheduler$Worker")), named("schedulePeriodically"))
-              .build();
-
   @Override
   public AgentBuilder instrument(AgentBuilder agentBuilder) {
-
-    for (final Map.Entry<
-            ElementMatcher<? super TypeDescription>, ElementMatcher<? super MethodDescription>>
-        entry : CLASS_AND_METHODS.entrySet()) {
-      agentBuilder =
-          new DisableAsyncInstrumentation(entry.getKey(), entry.getValue())
-              .instrument(agentBuilder);
-    }
-    return agentBuilder;
+    return new DisableAsyncInstrumentation(
+            extendsClass(named("rx.Scheduler$Worker")), named("schedulePeriodically"))
+        .instrument(agentBuilder);
   }
 
   // Not Using AutoService to hook up this instrumentation

--- a/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceAnnotationsInstrumentation.java
+++ b/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceAnnotationsInstrumentation.java
@@ -9,11 +9,13 @@ import static net.bytebuddy.matcher.ElementMatchers.isAnnotatedWith;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 
 import com.google.auto.service.AutoService;
-import com.google.common.collect.Sets;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.Config;
 import datadog.trace.api.Trace;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
@@ -33,14 +35,13 @@ public final class TraceAnnotationsInstrumentation extends Instrumenter.Default 
           + PACKAGE_CLASS_NAME_REGEX
           + "\\s*;?\\s*";
 
-  private static final String[] DEFAULT_ANNOTATIONS =
-      new String[] {
-        "com.newrelic.api.agent.Trace",
-        "kamon.annotation.Trace",
-        "com.tracelytics.api.ext.LogMethod",
-        "io.opentracing.contrib.dropwizard.Trace",
-        "org.springframework.cloud.sleuth.annotation.NewSpan"
-      };
+  private static final List<String> DEFAULT_ANNOTATIONS =
+      Arrays.asList(
+          "com.newrelic.api.agent.Trace",
+          "kamon.annotation.Trace",
+          "com.tracelytics.api.ext.LogMethod",
+          "io.opentracing.contrib.dropwizard.Trace",
+          "org.springframework.cloud.sleuth.annotation.NewSpan");
 
   private final Set<String> additionalTraceAnnotations;
   private final ElementMatcher.Junction<NamedElement> methodTraceMatcher;
@@ -50,8 +51,7 @@ public final class TraceAnnotationsInstrumentation extends Instrumenter.Default 
 
     final String configString = Config.get().getTraceAnnotations();
     if (configString == null) {
-      additionalTraceAnnotations =
-          Collections.unmodifiableSet(Sets.<String>newHashSet(DEFAULT_ANNOTATIONS));
+      additionalTraceAnnotations = Collections.unmodifiableSet(new HashSet<>(DEFAULT_ANNOTATIONS));
     } else if (configString.trim().isEmpty()) {
       additionalTraceAnnotations = Collections.emptySet();
     } else if (!configString.matches(CONFIG_FORMAT)) {
@@ -60,7 +60,7 @@ public final class TraceAnnotationsInstrumentation extends Instrumenter.Default 
           configString);
       additionalTraceAnnotations = Collections.emptySet();
     } else {
-      final Set<String> annotations = Sets.newHashSet();
+      final Set<String> annotations = new HashSet<>();
       final String[] annotationClasses = configString.split(";", -1);
       for (final String annotationClass : annotationClasses) {
         if (!annotationClass.trim().isEmpty()) {

--- a/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceAnnotationsInstrumentation.java
+++ b/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceAnnotationsInstrumentation.java
@@ -60,8 +60,8 @@ public final class TraceAnnotationsInstrumentation extends Instrumenter.Default 
           configString);
       additionalTraceAnnotations = Collections.emptySet();
     } else {
-      final Set<String> annotations = new HashSet<>();
       final String[] annotationClasses = configString.split(";", -1);
+      final Set<String> annotations = new HashSet<>(annotationClasses.length);
       for (final String annotationClass : annotationClasses) {
         if (!annotationClass.trim().isEmpty()) {
           annotations.add(annotationClass.trim());

--- a/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceConfigInstrumentation.java
+++ b/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceConfigInstrumentation.java
@@ -68,8 +68,8 @@ public class TraceConfigInstrumentation implements Instrumenter {
       classMethodsToTrace = Collections.emptyMap();
 
     } else {
-      final Map<String, Set<String>> toTrace = new HashMap<>();
       final String[] classMethods = configString.split(";", -1);
+      final Map<String, Set<String>> toTrace = new HashMap<>(classMethods.length);
       for (final String classMethod : classMethods) {
         if (classMethod.trim().isEmpty()) {
           continue;

--- a/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceConfigInstrumentation.java
+++ b/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceConfigInstrumentation.java
@@ -5,12 +5,12 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers.sa
 import static net.bytebuddy.matcher.ElementMatchers.named;
 
 import com.google.auto.service.AutoService;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.Config;
 import datadog.trace.api.Trace;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
@@ -68,7 +68,7 @@ public class TraceConfigInstrumentation implements Instrumenter {
       classMethodsToTrace = Collections.emptyMap();
 
     } else {
-      final Map<String, Set<String>> toTrace = Maps.newHashMap();
+      final Map<String, Set<String>> toTrace = new HashMap<>();
       final String[] classMethods = configString.split(";", -1);
       for (final String classMethod : classMethods) {
         if (classMethod.trim().isEmpty()) {
@@ -79,8 +79,7 @@ public class TraceConfigInstrumentation implements Instrumenter {
         final String method = splitClassMethod[1].trim();
         final String methodNames = method.substring(0, method.length() - 1);
         final String[] splitMethodNames = methodNames.split(",", -1);
-        final Set<String> trimmedMethodNames =
-            Sets.newHashSetWithExpectedSize(splitMethodNames.length);
+        final Set<String> trimmedMethodNames = new HashSet<>();
         for (final String methodName : splitMethodNames) {
           final String trimmedMethodName = methodName.trim();
           if (!trimmedMethodName.isEmpty()) {

--- a/dd-java-agent/testing/testing.gradle
+++ b/dd-java-agent/testing/testing.gradle
@@ -27,9 +27,6 @@ dependencies {
   compile project(':dd-java-agent:agent-tooling')
   compile project(':utils:test-utils')
 
-  annotationProcessor deps.autoservice
-  implementation deps.autoservice
-
   compile deps.groovy
 
   testCompile project(':utils:test-utils')
@@ -40,8 +37,8 @@ dependencies {
   testCompile group: 'net.sf.jt400', name: 'jt400', version: '6.1'
 
   // We have autoservices defined in test subtree, looks like we need this to be able to properly rebuild this
-  testAnnotationProcessor deps.autoservice
-  testImplementation deps.autoservice
+  testAnnotationProcessor deps.autoserviceProcessor
+  testCompileOnly deps.autoserviceAnnotation
 }
 
 // See comment for FieldBackedProviderFieldInjectionDisabledTest about why this hack is here

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -70,7 +70,7 @@ public final class ConfigDefaults {
   static final String DEFAULT_TRACE_METHODS = null;
   static final boolean DEFAULT_TRACE_ANALYTICS_ENABLED = false;
   static final float DEFAULT_ANALYTICS_SAMPLE_RATE = 1.0f;
-  static final double DEFAULT_TRACE_RATE_LIMIT = 100;
+  static final int DEFAULT_TRACE_RATE_LIMIT = 100;
 
   private ConfigDefaults() {}
 }

--- a/dd-trace-core/dd-trace-core.gradle
+++ b/dd-trace-core/dd-trace-core.gradle
@@ -33,12 +33,11 @@ dependencies {
 
   compile deps.slf4j
   compile deps.okhttp
-  compile deps.guava
+
   compile group: 'org.hdrhistogram', name: 'HdrHistogram', version: '2.1.12'
   compile group: 'com.squareup.moshi', name: 'moshi', version: '1.9.2'
   compile group: 'com.github.jnr', name: 'jnr-unixsocket', version: "${versions.jnr_unixsocket}"
   compile group: 'org.jctools', name: 'jctools-core', version: '3.1.0'
-
 
   // We have autoservices defined in test subtree, looks like we need this to be able to properly rebuild this
   testAnnotationProcessor deps.autoserviceProcessor

--- a/dd-trace-core/dd-trace-core.gradle
+++ b/dd-trace-core/dd-trace-core.gradle
@@ -24,9 +24,6 @@ testSets {
 }
 
 dependencies {
-  annotationProcessor deps.autoservice
-  implementation deps.autoservice
-
   compile project(':dd-trace-api')
   compile project(':internal-api')
   compile project(':utils:thread-utils')
@@ -36,6 +33,7 @@ dependencies {
 
   compile deps.slf4j
   compile deps.okhttp
+  compile deps.guava
   compile group: 'org.hdrhistogram', name: 'HdrHistogram', version: '2.1.12'
   compile group: 'com.squareup.moshi', name: 'moshi', version: '1.9.2'
   compile group: 'com.github.jnr', name: 'jnr-unixsocket', version: "${versions.jnr_unixsocket}"
@@ -43,8 +41,8 @@ dependencies {
 
 
   // We have autoservices defined in test subtree, looks like we need this to be able to properly rebuild this
-  testAnnotationProcessor deps.autoservice
-  testImplementation deps.autoservice
+  testAnnotationProcessor deps.autoserviceProcessor
+  testCompileOnly deps.autoserviceAnnotation
 
   testCompile project(":dd-java-agent:testing")
   testCompile group: 'org.msgpack', name: 'msgpack-core', version: '0.8.20'

--- a/dd-trace-core/src/main/java/datadog/trace/common/sampling/RuleBasedSampler.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/sampling/RuleBasedSampler.java
@@ -10,7 +10,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -29,7 +28,7 @@ public class RuleBasedSampler implements Sampler, PrioritySampler {
       final PrioritySampler fallbackSampler) {
     this.samplingRules = samplingRules;
     this.fallbackSampler = fallbackSampler;
-    rateLimiter = new SimpleRateLimiter(rateLimit, TimeUnit.SECONDS);
+    rateLimiter = new SimpleRateLimiter(rateLimit);
 
     this.rateLimit = rateLimit;
   }

--- a/dd-trace-core/src/main/java/datadog/trace/common/sampling/RuleBasedSampler.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/sampling/RuleBasedSampler.java
@@ -1,34 +1,36 @@
 package datadog.trace.common.sampling;
 
-import com.google.common.util.concurrent.RateLimiter;
 import datadog.trace.api.sampling.PrioritySampling;
 import datadog.trace.common.sampling.SamplingRule.AlwaysMatchesSamplingRule;
 import datadog.trace.common.sampling.SamplingRule.OperationSamplingRule;
 import datadog.trace.common.sampling.SamplingRule.ServiceSamplingRule;
 import datadog.trace.core.DDSpan;
+import datadog.trace.core.util.SimpleRateLimiter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class RuleBasedSampler implements Sampler, PrioritySampler {
   private final List<SamplingRule> samplingRules;
   private final PrioritySampler fallbackSampler;
-  private final RateLimiter rateLimiter;
-  private final double rateLimit;
+  private final SimpleRateLimiter rateLimiter;
+  private final long rateLimit;
 
   public static final String SAMPLING_RULE_RATE = "_dd.rule_psr";
   public static final String SAMPLING_LIMIT_RATE = "_dd.limit_psr";
 
   public RuleBasedSampler(
       final List<SamplingRule> samplingRules,
-      final double rateLimit,
+      final long rateLimit,
       final PrioritySampler fallbackSampler) {
     this.samplingRules = samplingRules;
     this.fallbackSampler = fallbackSampler;
-    rateLimiter = RateLimiter.create(rateLimit);
+    rateLimiter = new SimpleRateLimiter(rateLimit, TimeUnit.SECONDS);
+
     this.rateLimit = rateLimit;
   }
 
@@ -36,7 +38,7 @@ public class RuleBasedSampler implements Sampler, PrioritySampler {
       final Map<String, String> serviceRules,
       final Map<String, String> operationRules,
       final Double defaultRate,
-      final double rateLimit) {
+      final long rateLimit) {
 
     final List<SamplingRule> samplingRules = new ArrayList<>();
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
@@ -1,6 +1,5 @@
 package datadog.trace.core;
 
-import com.google.common.collect.ImmutableMap;
 import datadog.trace.api.DDId;
 import datadog.trace.api.DDTags;
 import datadog.trace.api.sampling.PrioritySampling;
@@ -407,7 +406,7 @@ public class DDSpanContext implements AgentSpan.Context {
 
   public Map<String, Object> getTags() {
     synchronized (unsafeTags) {
-      return ImmutableMap.copyOf(unsafeTags);
+      return Collections.unmodifiableMap(new HashMap<>(unsafeTags));
     }
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/util/SimpleRateLimiter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/util/SimpleRateLimiter.java
@@ -34,7 +34,7 @@ public class SimpleRateLimiter {
   public boolean tryAcquire() {
     long now = timeSource.getNanoTime();
     long localRefill = lastRefillTime.get();
-    long timeElapsedSinceLastRefill = timeSource.getNanoTime() - localRefill;
+    long timeElapsedSinceLastRefill = now - localRefill;
 
     // Attempt to refill tokens if an interval has passed
     // Only refill the tokens if this thread wins a race

--- a/dd-trace-core/src/main/java/datadog/trace/core/util/SimpleRateLimiter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/util/SimpleRateLimiter.java
@@ -28,13 +28,13 @@ public class SimpleRateLimiter {
 
     tokens = new AtomicLong(capacity);
 
-    lastRefillTime = new AtomicLong(timeSource.get());
+    lastRefillTime = new AtomicLong(timeSource.getNanoTime());
   }
 
   public boolean tryAcquire() {
-    long now = timeSource.get();
+    long now = timeSource.getNanoTime();
     long localRefill = lastRefillTime.get();
-    long timeElapsedSinceLastRefill = timeSource.get() - localRefill;
+    long timeElapsedSinceLastRefill = timeSource.getNanoTime() - localRefill;
 
     // Attempt to refill tokens if an interval has passed
     // Only refill the tokens if this thread wins a race

--- a/dd-trace-core/src/main/java/datadog/trace/core/util/SimpleRateLimiter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/util/SimpleRateLimiter.java
@@ -1,0 +1,55 @@
+package datadog.trace.core.util;
+
+import java.util.concurrent.TimeUnit;
+
+/** Rate limiter that only supports non-blocking retrieval of a single token */
+public class SimpleRateLimiter {
+  private final long capacity;
+  private long tokens;
+  private long lastRefillTime;
+  private final long refillIntervalInNanos;
+  private final TimeSource timeSource;
+
+  public SimpleRateLimiter(long rate, TimeUnit unit) {
+    this(rate, unit, new SystemNanoTimeSource());
+  }
+
+  protected SimpleRateLimiter(long rate, TimeUnit unit, TimeSource timeSource) {
+    refillIntervalInNanos = unit.toNanos(1) / rate;
+    capacity = rate;
+    tokens = rate;
+    this.timeSource = timeSource;
+    lastRefillTime = timeSource.getTime();
+  }
+
+  public synchronized boolean tryAcquire() {
+    fill();
+
+    if (tokens > 0) {
+      tokens--;
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  private void fill() {
+    long timeElapsedSinceLastRefill = timeSource.getTime() - lastRefillTime;
+    long intervals = timeElapsedSinceLastRefill / refillIntervalInNanos;
+    tokens = Math.min(capacity, tokens + intervals);
+
+    lastRefillTime += intervals * refillIntervalInNanos;
+  }
+
+  // This can probably be extracted to be more generic
+  interface TimeSource {
+    long getTime();
+  }
+
+  static class SystemNanoTimeSource implements TimeSource {
+    @Override
+    public long getTime() {
+      return System.nanoTime();
+    }
+  }
+}

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/util/SimpleRateLimiterTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/util/SimpleRateLimiterTest.groovy
@@ -1,0 +1,117 @@
+package datadog.trace.core.util
+
+import datadog.trace.util.test.DDSpecification
+
+import java.util.concurrent.TimeUnit
+
+class SimpleRateLimiterTest extends DDSpecification {
+  def "initial rate available at creation"() {
+    setup:
+    def limiter = new SimpleRateLimiter(rate, TimeUnit.SECONDS, new SettableClock())
+
+    when:
+    rate.times {
+      assert limiter.tryAcquire(): "failed for $it"
+    }
+
+    then:
+    assert !limiter.tryAcquire()
+
+    where:
+    rate << [10, 100, 1000]
+  }
+
+  def "tokens never go beyond rate"() {
+    setup:
+    def clock = new SettableClock()
+    def limiter = new SimpleRateLimiter(rate, TimeUnit.SECONDS, clock)
+
+    when:
+    clock.time += TimeUnit.SECONDS.toNanos(5)
+    rate.times {
+      assert limiter.tryAcquire(): "failed for $it"
+    }
+
+    then:
+    assert !limiter.tryAcquire()
+
+    where:
+    rate << [10, 100, 1000]
+  }
+
+  def "tokens refill at unit / rate"() {
+    setup:
+    def clock = new SettableClock()
+    def limiter = new SimpleRateLimiter(rate, TimeUnit.SECONDS, clock)
+
+    when:
+    rate.times {
+      assert limiter.tryAcquire(): "failed for $it"
+    }
+
+    then:
+    assert !limiter.tryAcquire()
+
+    when:
+    clock.time += TimeUnit.SECONDS.toNanos(1) / rate
+
+    then:
+    assert limiter.tryAcquire()
+    assert !limiter.tryAcquire()
+
+    when:
+    clock.time += TimeUnit.SECONDS.toNanos(1) / rate
+    clock.time += TimeUnit.SECONDS.toNanos(1) / rate
+
+    then:
+    assert limiter.tryAcquire()
+    assert limiter.tryAcquire()
+    assert !limiter.tryAcquire()
+
+    where:
+    rate << [10, 100, 100]
+  }
+
+  def "partial intervals handled"() {
+    setup:
+    def clock = new SettableClock()
+    def limiter = new SimpleRateLimiter(rate, TimeUnit.SECONDS, clock)
+
+    when:
+    rate.times {
+      assert limiter.tryAcquire(): "failed for $it"
+    }
+
+    then:
+    assert !limiter.tryAcquire()
+
+    when: "Add an interval and a half"
+    clock.time += TimeUnit.SECONDS.toNanos(1) / rate
+    clock.time += TimeUnit.SECONDS.toNanos(1) / (2 * rate)
+
+    then: "Only one token available"
+    assert limiter.tryAcquire()
+    assert !limiter.tryAcquire()
+
+    when: "Add an interval and a half again"
+    clock.time += TimeUnit.SECONDS.toNanos(1) / rate
+    clock.time += TimeUnit.SECONDS.toNanos(1) / (2 * rate)
+
+    then: "Two tokens available"
+    assert limiter.tryAcquire()
+    assert limiter.tryAcquire()
+    assert !limiter.tryAcquire()
+
+    where:
+    rate << [10, 100, 100]
+  }
+}
+
+class SettableClock implements SimpleRateLimiter.TimeSource {
+  long time = 0
+
+  @Override
+  long getTime() {
+    return time
+  }
+}

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/util/SimpleRateLimiterTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/util/SimpleRateLimiterTest.groovy
@@ -1,5 +1,6 @@
 package datadog.trace.core.util
 
+import datadog.trace.api.time.ControllableTimeSource
 import datadog.trace.util.test.DDSpecification
 
 import java.util.concurrent.TimeUnit
@@ -7,7 +8,8 @@ import java.util.concurrent.TimeUnit
 class SimpleRateLimiterTest extends DDSpecification {
   def "initial rate available at creation"() {
     setup:
-    def limiter = new SimpleRateLimiter(rate, TimeUnit.SECONDS, new SettableClock())
+    def timeSource = new ControllableTimeSource()
+    def limiter = new SimpleRateLimiter(rate, timeSource)
 
     when:
     rate.times {
@@ -23,11 +25,11 @@ class SimpleRateLimiterTest extends DDSpecification {
 
   def "tokens never go beyond rate"() {
     setup:
-    def clock = new SettableClock()
-    def limiter = new SimpleRateLimiter(rate, TimeUnit.SECONDS, clock)
+    def timeSource = new ControllableTimeSource()
+    def limiter = new SimpleRateLimiter(rate, timeSource)
 
     when:
-    clock.time += TimeUnit.SECONDS.toNanos(5)
+    timeSource.advance(TimeUnit.SECONDS.toNanos(5))
     rate.times {
       assert limiter.tryAcquire(): "failed for $it"
     }
@@ -37,81 +39,5 @@ class SimpleRateLimiterTest extends DDSpecification {
 
     where:
     rate << [10, 100, 1000]
-  }
-
-  def "tokens refill at unit / rate"() {
-    setup:
-    def clock = new SettableClock()
-    def limiter = new SimpleRateLimiter(rate, TimeUnit.SECONDS, clock)
-
-    when:
-    rate.times {
-      assert limiter.tryAcquire(): "failed for $it"
-    }
-
-    then:
-    assert !limiter.tryAcquire()
-
-    when:
-    clock.time += TimeUnit.SECONDS.toNanos(1) / rate
-
-    then:
-    assert limiter.tryAcquire()
-    assert !limiter.tryAcquire()
-
-    when:
-    clock.time += TimeUnit.SECONDS.toNanos(1) / rate
-    clock.time += TimeUnit.SECONDS.toNanos(1) / rate
-
-    then:
-    assert limiter.tryAcquire()
-    assert limiter.tryAcquire()
-    assert !limiter.tryAcquire()
-
-    where:
-    rate << [10, 100, 100]
-  }
-
-  def "partial intervals handled"() {
-    setup:
-    def clock = new SettableClock()
-    def limiter = new SimpleRateLimiter(rate, TimeUnit.SECONDS, clock)
-
-    when:
-    rate.times {
-      assert limiter.tryAcquire(): "failed for $it"
-    }
-
-    then:
-    assert !limiter.tryAcquire()
-
-    when: "Add an interval and a half"
-    clock.time += TimeUnit.SECONDS.toNanos(1) / rate
-    clock.time += TimeUnit.SECONDS.toNanos(1) / (2 * rate)
-
-    then: "Only one token available"
-    assert limiter.tryAcquire()
-    assert !limiter.tryAcquire()
-
-    when: "Add an interval and a half again"
-    clock.time += TimeUnit.SECONDS.toNanos(1) / rate
-    clock.time += TimeUnit.SECONDS.toNanos(1) / (2 * rate)
-
-    then: "Two tokens available"
-    assert limiter.tryAcquire()
-    assert limiter.tryAcquire()
-    assert !limiter.tryAcquire()
-
-    where:
-    rate << [10, 100, 100]
-  }
-}
-
-class SettableClock implements SimpleRateLimiter.TimeSource {
-  long time = 0
-
-  @Override
-  long getTime() {
-    return time
   }
 }

--- a/dd-trace-ot/dd-trace-ot.gradle
+++ b/dd-trace-ot/dd-trace-ot.gradle
@@ -28,8 +28,8 @@ testSets {
 }
 
 dependencies {
-  annotationProcessor deps.autoservice
-  implementation deps.autoservice
+  annotationProcessor deps.autoserviceProcessor
+  compileOnly deps.autoserviceAnnotation
 
   compile project(':dd-trace-api')
   compile project(':dd-trace-core')
@@ -42,10 +42,6 @@ dependencies {
 
   compile deps.slf4j
   compile deps.okio
-
-  // We have autoservices defined in test subtree, looks like we need this to be able to properly rebuild this
-  testAnnotationProcessor deps.autoservice
-  testImplementation deps.autoservice
 
   testCompile project(":dd-java-agent:testing")
   testCompile group: 'com.github.stefanbirkner', name: 'system-rules', version: '1.19.0'

--- a/dd-trace-ot/src/main/java/datadog/opentracing/resolver/DDTracerResolver.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/resolver/DDTracerResolver.java
@@ -1,7 +1,6 @@
 package datadog.opentracing.resolver;
 
 import com.google.auto.service.AutoService;
-import com.google.common.annotations.VisibleForTesting;
 import datadog.opentracing.DDTracer;
 import datadog.trace.api.Config;
 import io.opentracing.Tracer;
@@ -12,7 +11,6 @@ import lombok.extern.slf4j.Slf4j;
 @AutoService(TracerResolver.class)
 public class DDTracerResolver extends TracerResolver {
 
-  @VisibleForTesting
   Tracer resolve(final Config config) {
     if (config.isTraceResolverEnabled()) {
       log.info("Creating DDTracer with DDTracerResolver");

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -22,24 +22,21 @@ ext {
     commons       : "3.2",
     mockito       : '3.5.10',
     testcontainers: '1.12.2',
-    jmc           : "8.0.0-SNAPSHOT"
+    jmc           : "8.0.0-SNAPSHOT",
+    autoservice   : "1.0-rc7"
   ]
 
   deps = [
     // General
-    slf4j         : "org.slf4j:slf4j-api:${versions.slf4j}",
-    guava         : "com.google.guava:guava:$versions.guava",
-    okhttp        : dependencies.create(group: 'com.squareup.okhttp3', name: 'okhttp', version: versions.okhttp),
-    okio          : dependencies.create(group: 'com.squareup.okio', name: 'okio', version: versions.okio),
-    bytebuddy     : dependencies.create(group: 'net.bytebuddy', name: 'byte-buddy', version: versions.bytebuddy),
-    bytebuddyagent: dependencies.create(group: 'net.bytebuddy', name: 'byte-buddy-agent', version: versions.bytebuddy),
-    autoservice   : [
-      dependencies.create(group: 'com.google.auto.service', name: 'auto-service', version: '1.0-rc3'),
-      dependencies.create(group: 'com.google.auto', name: 'auto-common', version: '0.8'),
-      // These are the last versions that support guava 20.0.  Upgrading has odd interactions with shadow.
-      dependencies.create(group: 'com.google.guava', name: 'guava', version: "${versions.guava}"),
-    ],
-    commonsMath   : dependencies.create(group: 'org.apache.commons', name: 'commons-math3', version: versions.commons),
+    slf4j                : "org.slf4j:slf4j-api:${versions.slf4j}",
+    guava                : "com.google.guava:guava:$versions.guava",
+    okhttp               : dependencies.create(group: 'com.squareup.okhttp3', name: 'okhttp', version: versions.okhttp),
+    okio                 : dependencies.create(group: 'com.squareup.okio', name: 'okio', version: versions.okio),
+    bytebuddy            : dependencies.create(group: 'net.bytebuddy', name: 'byte-buddy', version: versions.bytebuddy),
+    bytebuddyagent       : dependencies.create(group: 'net.bytebuddy', name: 'byte-buddy-agent', version: versions.bytebuddy),
+    autoserviceProcessor : dependencies.create(group: 'com.google.auto.service', name: 'auto-service', version: versions.autoservice),
+    autoserviceAnnotation: dependencies.create(group: 'com.google.auto.service', name: 'auto-service-annotations', version: versions.autoservice),
+    commonsMath          : dependencies.create(group: 'org.apache.commons', name: 'commons-math3', version: versions.commons),
 
     // Testing
 

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -335,7 +335,7 @@ public class Config {
   @Getter private final Map<String, String> traceSamplingServiceRules;
   @Getter private final Map<String, String> traceSamplingOperationRules;
   @Getter private final Double traceSampleRate;
-  @Getter private final Double traceRateLimit;
+  @Getter private final int traceRateLimit;
 
   @Getter private final boolean profilingEnabled;
   @Deprecated private final String profilingUrl;
@@ -548,7 +548,7 @@ public class Config {
     traceSamplingServiceRules = configProvider.getMergedMap(TRACE_SAMPLING_SERVICE_RULES);
     traceSamplingOperationRules = configProvider.getMergedMap(TRACE_SAMPLING_OPERATION_RULES);
     traceSampleRate = configProvider.getDouble(TRACE_SAMPLE_RATE);
-    traceRateLimit = configProvider.getDouble(TRACE_RATE_LIMIT, DEFAULT_TRACE_RATE_LIMIT);
+    traceRateLimit = configProvider.getInteger(TRACE_RATE_LIMIT, DEFAULT_TRACE_RATE_LIMIT);
 
     profilingEnabled = configProvider.getBoolean(PROFILING_ENABLED, DEFAULT_PROFILING_ENABLED);
     profilingUrl = configProvider.getString(PROFILING_URL);

--- a/internal-api/src/main/java/datadog/trace/api/RatelimitedLogger.java
+++ b/internal-api/src/main/java/datadog/trace/api/RatelimitedLogger.java
@@ -1,5 +1,7 @@
 package datadog.trace.api;
 
+import datadog.trace.api.time.SystemTimeSource;
+import datadog.trace.api.time.TimeSource;
 import java.util.concurrent.atomic.AtomicLong;
 import org.slf4j.Logger;
 
@@ -9,30 +11,18 @@ import org.slf4j.Logger;
  */
 public class RatelimitedLogger {
 
-  public interface TimeSourceSupplier {
-    TimeSourceSupplier DEFAULT =
-        new TimeSourceSupplier() {
-          @Override
-          public long get() {
-            return System.nanoTime();
-          }
-        };
-
-    long get();
-  }
-
   private final Logger log;
   private final long delay;
-  private final TimeSourceSupplier timeSource;
+  private final TimeSource timeSource;
 
   private final AtomicLong previousErrorLogNanos = new AtomicLong();
 
   public RatelimitedLogger(final Logger log, final long delay) {
-    this(log, delay, TimeSourceSupplier.DEFAULT);
+    this(log, delay, SystemTimeSource.INSTANCE);
   }
 
   // Visible for testing
-  RatelimitedLogger(final Logger log, final long delay, final TimeSourceSupplier timeSource) {
+  RatelimitedLogger(final Logger log, final long delay, final TimeSource timeSource) {
     this.log = log;
     this.delay = delay;
     this.timeSource = timeSource;

--- a/internal-api/src/main/java/datadog/trace/api/RatelimitedLogger.java
+++ b/internal-api/src/main/java/datadog/trace/api/RatelimitedLogger.java
@@ -36,7 +36,7 @@ public class RatelimitedLogger {
     }
     if (log.isWarnEnabled()) {
       final long previous = previousErrorLogNanos.get();
-      final long now = timeSource.get();
+      final long now = timeSource.getNanoTime();
       if (now - previous >= delay) {
         if (previousErrorLogNanos.compareAndSet(previous, now)) {
           log.warn(format + " (Will not log errors for 5 minutes)", arguments);

--- a/internal-api/src/main/java/datadog/trace/api/time/ControllableTimeSource.java
+++ b/internal-api/src/main/java/datadog/trace/api/time/ControllableTimeSource.java
@@ -12,7 +12,7 @@ public class ControllableTimeSource implements TimeSource {
   }
 
   @Override
-  public long get() {
+  public long getNanoTime() {
     return currentTime;
   }
 }

--- a/internal-api/src/main/java/datadog/trace/api/time/ControllableTimeSource.java
+++ b/internal-api/src/main/java/datadog/trace/api/time/ControllableTimeSource.java
@@ -1,0 +1,18 @@
+package datadog.trace.api.time;
+
+public class ControllableTimeSource implements TimeSource {
+  private long currentTime = 0;
+
+  public void advance(long nanosIncrement) {
+    currentTime += nanosIncrement;
+  }
+
+  public void set(long nanos) {
+    currentTime = nanos;
+  }
+
+  @Override
+  public long get() {
+    return currentTime;
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/time/SystemTimeSource.java
+++ b/internal-api/src/main/java/datadog/trace/api/time/SystemTimeSource.java
@@ -4,7 +4,7 @@ public class SystemTimeSource implements TimeSource {
   public static final TimeSource INSTANCE = new SystemTimeSource();
 
   @Override
-  public long get() {
+  public long getNanoTime() {
     return System.nanoTime();
   }
 }

--- a/internal-api/src/main/java/datadog/trace/api/time/SystemTimeSource.java
+++ b/internal-api/src/main/java/datadog/trace/api/time/SystemTimeSource.java
@@ -1,0 +1,10 @@
+package datadog.trace.api.time;
+
+public class SystemTimeSource implements TimeSource {
+  public static final TimeSource INSTANCE = new SystemTimeSource();
+
+  @Override
+  public long get() {
+    return System.nanoTime();
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/time/TimeSource.java
+++ b/internal-api/src/main/java/datadog/trace/api/time/TimeSource.java
@@ -1,5 +1,5 @@
 package datadog.trace.api.time;
 
 public interface TimeSource {
-  long get();
+  long getNanoTime();
 }

--- a/internal-api/src/main/java/datadog/trace/api/time/TimeSource.java
+++ b/internal-api/src/main/java/datadog/trace/api/time/TimeSource.java
@@ -1,0 +1,5 @@
+package datadog.trace.api.time;
+
+public interface TimeSource {
+  long get();
+}

--- a/internal-api/src/main/java/datadog/trace/api/utils/MathUtils.java
+++ b/internal-api/src/main/java/datadog/trace/api/utils/MathUtils.java
@@ -1,0 +1,24 @@
+package datadog.trace.api.utils;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+public class MathUtils {
+  /**
+   * Atomically decrements the long if its value would not go below minimum
+   *
+   * @return if the long was decremented by this call
+   */
+  public static boolean boundedDecrement(AtomicLong value, long minumum) {
+    long previous;
+    long next;
+    do {
+      previous = value.get();
+      next = previous - 1;
+
+      if (next < minumum) {
+        return false;
+      }
+    } while (!value.compareAndSet(previous, next));
+    return true;
+  }
+}

--- a/internal-api/src/test/groovy/datadog/trace/api/ControllableTimeSourceTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/ControllableTimeSourceTest.groovy
@@ -1,0 +1,29 @@
+package datadog.trace.api
+
+import datadog.trace.api.time.ControllableTimeSource
+import datadog.trace.util.test.DDSpecification
+
+class ControllableTimeSourceTest extends DDSpecification {
+  def "test time source changes"() {
+    given:
+    def timeSource = new ControllableTimeSource()
+
+    when:
+    timeSource.set(1000)
+
+    then:
+    timeSource.getNanoTime() == 1000
+
+    when:
+    timeSource.advance(500)
+
+    then:
+    timeSource.getNanoTime() == 1500
+
+    when:
+    timeSource.advance(-800)
+
+    then:
+    timeSource.getNanoTime() == 700
+  }
+}

--- a/internal-api/src/test/groovy/datadog/trace/api/RateLimitedLoggerTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/RateLimitedLoggerTest.groovy
@@ -45,7 +45,7 @@ class RateLimitedLoggerTest extends DDSpecification {
   def "warning once"() {
     setup:
     log.isWarnEnabled() >> true
-    timeSource.get() >> delay
+    timeSource.getNanoTime() >> delay
 
     when:
     def firstLog = rateLimitedLog.warn("test {} {}", "message", exception)
@@ -60,7 +60,7 @@ class RateLimitedLoggerTest extends DDSpecification {
   def "warning twice"() {
     setup:
     log.isWarnEnabled() >> true
-    timeSource.get() >>> [delay, delay * 2]
+    timeSource.getNanoTime() >>> [delay, delay * 2]
 
     when:
     def firstLog = rateLimitedLog.warn("test {} {}", "message", exception)
@@ -83,7 +83,7 @@ class RateLimitedLoggerTest extends DDSpecification {
   def "no args"() {
     setup:
     log.isWarnEnabled() >> true
-    timeSource.get() >> delay
+    timeSource.getNanoTime() >> delay
 
     when:
     rateLimitedLog.warn("test")

--- a/internal-api/src/test/groovy/datadog/trace/api/RateLimitedLoggerTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/RateLimitedLoggerTest.groovy
@@ -1,5 +1,6 @@
 package datadog.trace.api
 
+import datadog.trace.api.time.TimeSource
 import datadog.trace.util.test.DDSpecification
 import org.slf4j.Logger
 
@@ -10,7 +11,7 @@ class RateLimitedLoggerTest extends DDSpecification {
   final exception = new RuntimeException("bad thing")
 
   Logger log = Mock(Logger)
-  RatelimitedLogger.TimeSourceSupplier timeSource = Mock(RatelimitedLogger.TimeSourceSupplier)
+  TimeSource timeSource = Mock(TimeSource)
   RatelimitedLogger rateLimitedLog = new RatelimitedLogger(log, delay, timeSource)
 
   def "Debug level"() {
@@ -88,6 +89,6 @@ class RateLimitedLoggerTest extends DDSpecification {
     rateLimitedLog.warn("test")
 
     then:
-    1 *  log.warn("test (Will not log errors for 5 minutes)")
+    1 * log.warn("test (Will not log errors for 5 minutes)")
   }
 }

--- a/internal-api/src/test/groovy/datadog/trace/api/utils/MathUtilsTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/utils/MathUtilsTest.groovy
@@ -1,0 +1,53 @@
+package datadog.trace.api.utils
+
+import datadog.trace.util.test.DDSpecification
+
+import java.util.concurrent.atomic.AtomicLong
+
+class MathUtilsTest extends DDSpecification {
+
+  // Testing multithreaded code is inherently tricky
+  // This tests across multiple competing threads nothing goes wrong
+  // Its probabilistic at best and doesnt prove correctness
+  def "correct number of decrements happen across threads"() {
+    given:
+    AtomicLong trueCount = new AtomicLong(0)
+    AtomicLong falseCount = new AtomicLong(0)
+    AtomicLong variable = new AtomicLong(initialValue)
+    Random random = new Random()
+    List<Thread> threads = []
+    numThreads.times {
+      final localDecrements = decrementsPerThread
+      final localMinimum = minimum
+      threads.add(new Thread() {
+        void run() {
+          localDecrements.times {
+            Thread.sleep(random.nextInt(5))
+            boolean returnValue = MathUtils.boundedDecrement(variable, localMinimum)
+            if (returnValue) {
+              trueCount.incrementAndGet()
+            } else {
+              falseCount.incrementAndGet()
+            }
+          }
+        }
+      })
+    }
+
+    when:
+    threads.each { it.start() }
+    threads.each { it.join() }
+
+    then:
+    variable.get() == Math.max(minimum, initialValue - numThreads * decrementsPerThread)
+    trueCount.get() == Math.min(initialValue - minimum, numThreads * decrementsPerThread)
+    falseCount.get() == numThreads * decrementsPerThread - trueCount.get()
+
+    where:
+    numThreads | decrementsPerThread | initialValue | minimum
+    1          | 800                 | 1000         | 500
+    1          | 1100                | 1000         | 0
+    10         | 100                 | 500          | 0
+    10         | 1000                | 1000         | 500
+  }
+}


### PR DESCRIPTION
* Removes the inadvertent dependencies on Guava because of the lines:
```
annotationProcessor deps.autoservice
implementation deps.autoservice
```
* Removes unneeded uses of Guava
* Implements a simple rate limiter that doesn't have all of the features of the guava version (smoothing, acquiring multiple tokens, etc) but gets the job done

After this pull request, the uses of Guava are:
* GuavaWeakCache in agent-tooling
* DDCachingPoolStrategy in agent-tooling
* Instrumentations on Guava interfaces ( ListenableFuture, Ratpack, Twilio, datastax-cassandra-3)
* Tests (I left these untouched)