### PR TITLE
avoid copying tags (potentially twice) when sampling each span

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/common/sampling/RateByServiceSampler.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/sampling/RateByServiceSampler.java
@@ -63,7 +63,8 @@ public class RateByServiceSampler implements Sampler, PrioritySampler, DDAgentRe
   }
 
   private static String getSpanEnv(final DDSpan span) {
-    return null == span.getTags().get("env") ? "" : String.valueOf(span.getTags().get("env"));
+    Object env = span.getTag("env");
+    return null == env ? "" : String.valueOf(env);
   }
 
   @Override


### PR DESCRIPTION
This shows up a lot in profiles