### PR TITLE
Don't leak an internal dependency

### DIFF
--- a/dd-trace-core/dd-trace-core.gradle
+++ b/dd-trace-core/dd-trace-core.gradle
@@ -31,7 +31,6 @@ dependencies {
   compile project(':internal-api')
   compile project(':utils:thread-utils')
   compile project(':utils:container-utils')
-  compile project(':dd-java-agent:agent-logging')
 
   compile group: 'com.datadoghq', name: 'java-dogstatsd-client', version: "${versions.dogstatsd}"
 


### PR DESCRIPTION
This dependency leaked into the `pom` for `dd-trace-ot` in the published `0.63.0` version. Thanks @mar-kolya for finding this.