### PR TITLE
restrict muzzle reference creation for datadog packages, include references for java packages

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/ReferenceCreator.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/ReferenceCreator.java
@@ -35,6 +35,8 @@ public class ReferenceCreator extends ClassVisitor {
    */
   private static final String REFERENCE_CREATION_PACKAGE = "datadog.trace.instrumentation.";
 
+  private static final String DATADOG_TRACE_PACKAGE = "datadog.trace.";
+
   public static Map<String, Reference> createReferencesFrom(
       final String entryPointClassName, final ClassLoader loader) {
     return ReferenceCreator.createReferencesFrom(entryPointClassName, loader, true);
@@ -184,7 +186,8 @@ public class ReferenceCreator extends ClassVisitor {
   }
 
   private void addReference(final Reference ref) {
-    if (!ref.getClassName().startsWith("java.")) {
+    // don't create references for classes we build ourselves
+    if (!ref.getClassName().startsWith(DATADOG_TRACE_PACKAGE)) {
       Reference reference = references.get(ref.getClassName());
       if (null == reference) {
         references.put(ref.getClassName(), ref);

--- a/dd-java-agent/testing/src/test/groovy/muzzle/ReferenceCreatorTest.groovy
+++ b/dd-java-agent/testing/src/test/groovy/muzzle/ReferenceCreatorTest.groovy
@@ -19,7 +19,11 @@ class ReferenceCreatorTest extends AgentTestRunner {
     references.get('muzzle.TestClasses$MethodBodyAdvice$B') != null
     references.get('muzzle.TestClasses$MethodBodyAdvice$SomeInterface') != null
     references.get('muzzle.TestClasses$MethodBodyAdvice$SomeImplementation') != null
-    references.keySet().size() == 4
+    references.get('muzzle.TestClasses$MethodBodyAdvice$SomeImplementation') != null
+    references.get('java.lang.Object') != null
+    references.get('java.lang.CharSequence') != null
+    references.get('java.lang.String') != null
+    references.keySet().size() == 7
 
     // interface flags
     references.get('muzzle.TestClasses$MethodBodyAdvice$B').getFlags().contains(Reference.Flag.NON_INTERFACE)

--- a/dd-java-agent/testing/src/test/java/muzzle/TestClasses.java
+++ b/dd-java-agent/testing/src/test/java/muzzle/TestClasses.java
@@ -1,5 +1,6 @@
 package muzzle;
 
+import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import net.bytebuddy.asm.Advice;
 
 public class TestClasses {
@@ -16,6 +17,7 @@ public class TestClasses {
       a.b.aMethodWithArrays(new String[0]);
       B.aStaticMethod();
       A.staticB.aMethod("bar");
+      UTF8BytesString utf8BytesString = UTF8BytesString.create(String.valueOf(o));
     }
 
     public static class A {


### PR DESCRIPTION
* Adds java.* back in
* Removes datadog.trace.*