### PR TITLE
Exclude 1.8.0_262 onwards from creating scope events…

### DIFF
--- a/dd-smoke-tests/profiling-integration-tests/src/test/groovy/datadog/smoketest/ProfilingIntegrationContinuousProfilesTest.groovy
+++ b/dd-smoke-tests/profiling-integration-tests/src/test/groovy/datadog/smoketest/ProfilingIntegrationContinuousProfilesTest.groovy
@@ -11,6 +11,7 @@ import org.openjdk.jmc.common.item.IItemCollection
 import org.openjdk.jmc.common.item.ItemFilters
 import org.openjdk.jmc.common.unit.UnitLookup
 import org.openjdk.jmc.flightrecorder.JfrLoaderToolkit
+import spock.lang.IgnoreIf
 
 import java.time.Instant
 import java.util.concurrent.TimeUnit
@@ -18,6 +19,7 @@ import java.util.concurrent.TimeUnit
 class ProfilingIntegrationContinuousProfilesTest extends AbstractProfilingIntegrationTest {
   private static final int REQUEST_WAIT_TIMEOUT = 40
 
+  @IgnoreIf({ jvm.javaVersion == '1.8.0_265' })
   def "test continuous recording"() {
     setup:
     profilingServer.enqueue(new MockResponse().setResponseCode(200))

--- a/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/ExcludedVersions.java
+++ b/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/ExcludedVersions.java
@@ -1,27 +1,65 @@
 package datadog.trace.core.jfr.openjdk;
 
 import datadog.trace.core.DDTraceCoreInfo;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
 
 public class ExcludedVersions {
 
-  private static final String VERSION = DDTraceCoreInfo.JAVA_VERSION.split("\\.")[0];
-  private static final Set<String> EXCLUDED_VERSIONS;
-
-  static {
-    final Set<String> excludedVersions = new HashSet<>();
-    // Java 9 and 10 throw seg fault on MacOS if events are used in premain.
-    // Since these versions are not LTS we just disable profiling events for them.
-    excludedVersions.add("9");
-    excludedVersions.add("10");
-    EXCLUDED_VERSIONS = Collections.unmodifiableSet(excludedVersions);
+  public static void checkVersionExclusion() throws ClassNotFoundException {
+    if (isVersionExcluded(DDTraceCoreInfo.JAVA_VERSION)) {
+      throw new ClassNotFoundException("Excluded java version: " + DDTraceCoreInfo.JAVA_VERSION);
+    }
   }
 
-  public static void checkVersionExclusion() throws ClassNotFoundException {
-    if (EXCLUDED_VERSIONS.contains(VERSION)) {
-      throw new ClassNotFoundException("Excluded java version: " + DDTraceCoreInfo.JAVA_VERSION);
+  static boolean isVersionExcluded(final String version) {
+    final NumberTokenizer tokenizer = new NumberTokenizer(version);
+
+    int major = tokenizer.nextNumber();
+    if (major == 1) {
+      major = tokenizer.nextNumber(); // ignore leading 1. for pre-Java9 JDKs
+    }
+
+    final int minor = tokenizer.nextNumber();
+    final int update = tokenizer.nextNumber();
+
+    // Java 9 and 10 throw seg fault on MacOS if events are used in premain.
+    // Since these versions are not LTS we just disable profiling events for them.
+    if (major == 9 || major == 10) {
+      return true;
+    }
+
+    // Exclude 1.8.0_262 onwards due to https://bugs.openjdk.java.net/browse/JDK-8252904
+    if (major == 8 && minor == 0 && update >= 262) {
+      return true;
+    }
+
+    return false;
+  }
+
+  /** Simple number tokenizer that treats non-digit characters as delimiters. */
+  private static class NumberTokenizer {
+    private final String text;
+    private int cursor;
+
+    NumberTokenizer(final String text) {
+      this.text = text;
+    }
+
+    /** @return next number from this tokenizer */
+    public int nextNumber() {
+      int number = 0;
+      boolean parsingNumber = true;
+      while (cursor < text.length()) {
+        final char c = text.charAt(cursor);
+        if (c < '0' || c > '9') {
+          parsingNumber = false; // no more digits to add, continue to consume non-digits
+        } else if (parsingNumber) {
+          number = number * 10 + (c - '0');
+        } else {
+          break; // stop now we've reached another number, leave that for the next request
+        }
+        cursor++;
+      }
+      return number;
     }
   }
 }

--- a/dd-trace-core/jfr-openjdk/src/test/groovy/datadog/trace/core/jfr/openjdk/ExcludedVersionsTest.groovy
+++ b/dd-trace-core/jfr-openjdk/src/test/groovy/datadog/trace/core/jfr/openjdk/ExcludedVersionsTest.groovy
@@ -1,0 +1,46 @@
+package datadog.trace.core.jfr.openjdk
+
+import spock.lang.Specification
+
+class ExcludedVersionsTest extends Specification {
+  def "expect #version is #excludedDescription"() {
+
+    expect:
+    excluded == ExcludedVersions.isVersionExcluded(version)
+
+    where:
+    version     | excluded
+    '1.7'       | false
+    '1.7.0'     | false
+    '1.7.0_1'   | false
+    '1.7.0_261' | false
+    '1.7.0_262' | false
+    '1.7.0_265' | false
+    '1.8'       | false
+    '1.8.0'     | false
+    '1.8.0_1'   | false
+    '1.8.0_261' | false
+    '1.8.0_262' | true
+    '1.8.0_265' | true
+    '1.8.1'     | false
+    '1.8.1_1'   | false
+    '1.8.1_261' | false
+    '1.8.1_262' | false
+    '1.8.1_265' | false
+    '9-ea'      | true
+    '9'         | true
+    '9.0'       | true
+    '10-ea'     | true
+    '10'        | true
+    '10.0'      | true
+    '11'        | false
+    '12'        | false
+    '13'        | false
+    '14'        | false
+    '15'        | false
+    '90'        | false
+    '100'       | false
+
+    excludedDescription = excluded ? 'excluded' : 'not excluded'
+  }
+}


### PR DESCRIPTION
…due to https://bugs.openjdk.java.net/browse/JDK-8252904

Once the JDK fix is released we can set an upper-bound for the 1.8.0 exclusion, until then we leave it open-ended