### PR TITLE
Support 'dd.trace.startup.logs' system property and 'DD_TRACE_STARTUP_LOGS' environment variable

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
@@ -356,6 +356,8 @@ public class Agent {
 
     if (isDebugMode()) {
       setSystemPropertyDefault(SIMPLE_LOGGER_DEFAULT_LOG_LEVEL_PROPERTY, "DEBUG");
+    } else if (!isStartupLogsEnabled()) {
+      setSystemPropertyDefault(SIMPLE_LOGGER_DEFAULT_LOG_LEVEL_PROPERTY, "WARN");
     }
   }
 
@@ -433,6 +435,21 @@ public class Agent {
       return Boolean.parseBoolean(tracerDebugLevelEnv);
     }
     return false;
+  }
+
+  /**
+   * Determine if we should log startup info messages according to dd.trace.startup.logs
+   *
+   * @return true if we should
+   */
+  private static boolean isStartupLogsEnabled() {
+    final String startupLogsSysprop = "dd.trace.startup.logs";
+    String startupLogsEnabled = System.getProperty(startupLogsSysprop);
+    if (startupLogsEnabled == null) {
+      startupLogsEnabled = System.getenv(startupLogsSysprop.replace('.', '_').toUpperCase());
+    }
+    // assume true unless it's explicitly set to "false"
+    return !"false".equalsIgnoreCase(startupLogsEnabled);
   }
 
   /**

--- a/dd-trace-core/src/main/java/datadog/trace/core/StatusLogger.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/StatusLogger.java
@@ -20,13 +20,15 @@ import lombok.extern.slf4j.Slf4j;
 public class StatusLogger {
 
   public static void logStatus(Config config) {
-    log.info(
-        "DATADOG TRACER CONFIGURATION {}",
-        new Moshi.Builder()
-            .add(ConfigAdapter.FACTORY)
-            .build()
-            .adapter(Config.class)
-            .toJson(config));
+    if (log.isInfoEnabled()) {
+      log.info(
+          "DATADOG TRACER CONFIGURATION {}",
+          new Moshi.Builder()
+              .add(ConfigAdapter.FACTORY)
+              .build()
+              .adapter(Config.class)
+              .toJson(config));
+    }
     if (log.isDebugEnabled()) {
       log.debug("class path: {}", System.getProperty("java.class.path"));
     }


### PR DESCRIPTION
When "false" we configure the log level at startup to WARN to hide agent info messages at startup.

This doesn't affect agent warning or error messages.

The startup logs setting also has no effect when debug mode (dd.trace.debug) is enabled.

NOTE: as it stands this PR does not change the log level after the agent has finished startup, ie. it will continue to hide agent info messages but still log warnings and errors. This was considered acceptable because users setting this option typically will be only interested in warnings and errors. It also avoids introducing additional custom logging API and logic to bump the log level back once startup is "done", where we may already be dealing with multiple agent threads.