### PR TITLE
Make FieldBackedProvider respect class loader matchers

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Instrumenter.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Instrumenter.java
@@ -1,6 +1,7 @@
 package datadog.trace.agent.tooling;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers.failSafe;
+import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.any;
 import static net.bytebuddy.matcher.ElementMatchers.isAnnotatedWith;
@@ -82,7 +83,13 @@ public interface Instrumenter {
           Map<ElementMatcher<ClassLoader>, Map<String, String>> contextStores;
           Map<String, String> allClassLoaderContextStores = contextStoreForAll();
           Map<String, String> matchedContextStores = contextStore();
-          if (!allClassLoaderContextStores.isEmpty()) {
+          if (allClassLoaderContextStores.isEmpty()) {
+            if (matchedContextStores.isEmpty()) {
+              contextStores = emptyMap();
+            } else {
+              contextStores = singletonMap(classLoaderMatcher(), matchedContextStores);
+            }
+          } else {
             if (contextStore().isEmpty()) {
               contextStores = singletonMap(ANY_CLASS_LOADER, allClassLoaderContextStores);
             } else {
@@ -90,8 +97,6 @@ public interface Instrumenter {
               contextStores.put(classLoaderMatcher(), matchedContextStores);
               contextStores.put(ANY_CLASS_LOADER, allClassLoaderContextStores);
             }
-          } else {
-            contextStores = singletonMap(classLoaderMatcher(), matchedContextStores);
           }
           if (!contextStores.isEmpty()) {
             contextProvider = new FieldBackedProvider(this, contextStores);

--- a/dd-java-agent/instrumentation/akka-concurrent/src/main/java/datadog/trace/instrumentation/akka/concurrent/AkkaForkJoinPoolInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-concurrent/src/main/java/datadog/trace/instrumentation/akka/concurrent/AkkaForkJoinPoolInstrumentation.java
@@ -32,6 +32,11 @@ public final class AkkaForkJoinPoolInstrumentation extends Instrumenter.Default 
   }
 
   @Override
+  public ElementMatcher<ClassLoader> classLoaderMatcher() {
+    return AkkaForkJoinTaskInstrumentation.CLASS_LOADER_MATCHER;
+  }
+
+  @Override
   public ElementMatcher<TypeDescription> typeMatcher() {
     // This might need to be an extendsClass matcher...
     return named("akka.dispatch.forkjoin.ForkJoinPool");

--- a/dd-java-agent/instrumentation/akka-concurrent/src/main/java/datadog/trace/instrumentation/akka/concurrent/AkkaForkJoinTaskInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-concurrent/src/main/java/datadog/trace/instrumentation/akka/concurrent/AkkaForkJoinTaskInstrumentation.java
@@ -39,6 +39,8 @@ public final class AkkaForkJoinTaskInstrumentation extends Instrumenter.Default 
 
   static final String TASK_CLASS_NAME = "akka.dispatch.forkjoin.ForkJoinTask";
 
+  static final ElementMatcher<ClassLoader> CLASS_LOADER_MATCHER = hasClassesNamed(TASK_CLASS_NAME);
+
   public AkkaForkJoinTaskInstrumentation() {
     super("java_concurrent", "akka_concurrent");
   }
@@ -46,7 +48,7 @@ public final class AkkaForkJoinTaskInstrumentation extends Instrumenter.Default 
   @Override
   public ElementMatcher<ClassLoader> classLoaderMatcher() {
     // Optimization for expensive typeMatcher.
-    return hasClassesNamed(TASK_CLASS_NAME);
+    return CLASS_LOADER_MATCHER;
   }
 
   @Override
@@ -56,10 +58,14 @@ public final class AkkaForkJoinTaskInstrumentation extends Instrumenter.Default 
 
   @Override
   public Map<String, String> contextStore() {
+    return singletonMap(TASK_CLASS_NAME, State.class.getName());
+  }
+
+  @Override
+  public Map<String, String> contextStoreForAll() {
     final Map<String, String> map = new HashMap<>();
     map.put(Runnable.class.getName(), State.class.getName());
     map.put(Callable.class.getName(), State.class.getName());
-    map.put(TASK_CLASS_NAME, State.class.getName());
     return Collections.unmodifiableMap(map);
   }
 

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/AWSClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/AWSClientInstrumentation.java
@@ -29,6 +29,11 @@ public final class AWSClientInstrumentation extends Instrumenter.Default {
   }
 
   @Override
+  public ElementMatcher<ClassLoader> classLoaderMatcher() {
+    return RequestInstrumentation.CLASS_LOADER_MATCHER;
+  }
+
+  @Override
   public ElementMatcher<TypeDescription> typeMatcher() {
     return named("com.amazonaws.AmazonWebServiceClient")
         .and(declaresField(named("requestHandler2s")));

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/RequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/RequestInstrumentation.java
@@ -26,10 +26,13 @@ public final class RequestInstrumentation extends Instrumenter.Default {
     super("aws-sdk");
   }
 
+  static final ElementMatcher<ClassLoader> CLASS_LOADER_MATCHER =
+      hasClassesNamed("com.amazonaws.AmazonWebServiceRequest");
+
   @Override
   public ElementMatcher<ClassLoader> classLoaderMatcher() {
     // Optimization for expensive typeMatcher.
-    return hasClassesNamed("com.amazonaws.AmazonWebServiceRequest");
+    return CLASS_LOADER_MATCHER;
   }
 
   @Override

--- a/dd-java-agent/instrumentation/couchbase-2.6/src/main/java/datadog/trace/instrumentation/couchbase/client/CouchbaseCoreInstrumentation.java
+++ b/dd-java-agent/instrumentation/couchbase-2.6/src/main/java/datadog/trace/instrumentation/couchbase/client/CouchbaseCoreInstrumentation.java
@@ -15,7 +15,6 @@ import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.context.TraceScope;
-import java.util.Collections;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.method.MethodDescription;
@@ -30,13 +29,18 @@ public class CouchbaseCoreInstrumentation extends Instrumenter.Default {
   }
 
   @Override
+  public ElementMatcher<ClassLoader> classLoaderMatcher() {
+    return CouchbaseNetworkInstrumentation.CLASS_LOADER_MATCHER;
+  }
+
+  @Override
   public ElementMatcher<? super TypeDescription> typeMatcher() {
     return named("com.couchbase.client.core.CouchbaseCore");
   }
 
   @Override
   public Map<String, String> contextStore() {
-    return Collections.singletonMap(
+    return singletonMap(
         "com.couchbase.client.core.message.CouchbaseRequest", AgentSpan.class.getName());
   }
 

--- a/dd-java-agent/instrumentation/couchbase-2.6/src/main/java/datadog/trace/instrumentation/couchbase/client/CouchbaseNetworkInstrumentation.java
+++ b/dd-java-agent/instrumentation/couchbase-2.6/src/main/java/datadog/trace/instrumentation/couchbase/client/CouchbaseNetworkInstrumentation.java
@@ -30,10 +30,13 @@ public class CouchbaseNetworkInstrumentation extends Instrumenter.Default {
     super("couchbase");
   }
 
+  static final ElementMatcher<ClassLoader> CLASS_LOADER_MATCHER =
+      hasClassesNamed("com.couchbase.client.core.message.CouchbaseRequest");
+
   @Override
   public ElementMatcher<ClassLoader> classLoaderMatcher() {
     // Optimization for expensive typeMatcher.
-    return hasClassesNamed("com.couchbase.client.core.endpoint.AbstractGenericHandler");
+    return CLASS_LOADER_MATCHER;
   }
 
   @Override

--- a/dd-java-agent/instrumentation/google-http-client/src/main/java/datadog/trace/instrumentation/googlehttpclient/GoogleHttpClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/google-http-client/src/main/java/datadog/trace/instrumentation/googlehttpclient/GoogleHttpClientInstrumentation.java
@@ -1,11 +1,13 @@
 package datadog.trace.instrumentation.googlehttpclient;
 
+import static datadog.trace.agent.tooling.ClassLoaderMatcher.hasClassesNamed;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.googlehttpclient.GoogleHttpClientDecorator.DECORATE;
 import static datadog.trace.instrumentation.googlehttpclient.GoogleHttpClientDecorator.HTTP_REQUEST;
 import static datadog.trace.instrumentation.googlehttpclient.HeadersInjectAdapter.SETTER;
+import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.named;
@@ -21,7 +23,6 @@ import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.InstrumentationTags;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
@@ -35,6 +36,14 @@ public class GoogleHttpClientInstrumentation extends Instrumenter.Default {
     super("google-http-client");
   }
 
+  private final ElementMatcher<ClassLoader> CLASS_LOADER_MATCHER =
+      hasClassesNamed("com.google.api.client.http.HttpRequest");
+
+  @Override
+  public ElementMatcher<ClassLoader> classLoaderMatcher() {
+    return CLASS_LOADER_MATCHER;
+  }
+
   @Override
   public ElementMatcher<? super TypeDescription> typeMatcher() {
     // HttpRequest is a final class.  Only need to instrument it exactly
@@ -45,8 +54,7 @@ public class GoogleHttpClientInstrumentation extends Instrumenter.Default {
 
   @Override
   public Map<String, String> contextStore() {
-    return Collections.singletonMap(
-        "com.google.api.client.http.HttpRequest", RequestState.class.getName());
+    return singletonMap("com.google.api.client.http.HttpRequest", RequestState.class.getName());
   }
 
   @Override

--- a/dd-java-agent/instrumentation/grizzly-client-1.9/src/main/java/datadog/trace/instrumentation/grizzly/client/ClientRequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/grizzly-client-1.9/src/main/java/datadog/trace/instrumentation/grizzly/client/ClientRequestInstrumentation.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.grizzly.client;
 
+import static datadog.trace.agent.tooling.ClassLoaderMatcher.hasClassesNamed;
 import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.named;
@@ -20,9 +21,17 @@ public final class ClientRequestInstrumentation extends Instrumenter.Default {
     super("grizzly-client", "ning");
   }
 
+  static final ElementMatcher<ClassLoader> CLASS_LOADER_MATCHER =
+      hasClassesNamed("com.ning.http.client.AsyncHandler");
+
   @Override
   public Map<String, String> contextStore() {
     return singletonMap("com.ning.http.client.AsyncHandler", Pair.class.getName());
+  }
+
+  @Override
+  public ElementMatcher<ClassLoader> classLoaderMatcher() {
+    return CLASS_LOADER_MATCHER;
   }
 
   @Override

--- a/dd-java-agent/instrumentation/grizzly-client-1.9/src/main/java/datadog/trace/instrumentation/grizzly/client/ClientResponseInstrumentation.java
+++ b/dd-java-agent/instrumentation/grizzly-client-1.9/src/main/java/datadog/trace/instrumentation/grizzly/client/ClientResponseInstrumentation.java
@@ -1,6 +1,5 @@
 package datadog.trace.instrumentation.grizzly.client;
 
-import static datadog.trace.agent.tooling.ClassLoaderMatcher.hasClassesNamed;
 import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.hasSuperClass;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
@@ -29,7 +28,7 @@ public final class ClientResponseInstrumentation extends Instrumenter.Default {
 
   @Override
   public ElementMatcher<ClassLoader> classLoaderMatcher() {
-    return hasClassesNamed("com.ning.http.client.AsyncCompletionHandler");
+    return ClientRequestInstrumentation.CLASS_LOADER_MATCHER;
   }
 
   @Override

--- a/dd-java-agent/instrumentation/guava-10/src/main/java/datadog/trace/instrumentation/guava10/ListenableFutureInstrumentation.java
+++ b/dd-java-agent/instrumentation/guava-10/src/main/java/datadog/trace/instrumentation/guava10/ListenableFutureInstrumentation.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.guava10;
 
+import static datadog.trace.agent.tooling.ClassLoaderMatcher.hasClassesNamed;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
 import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.named;
@@ -26,6 +27,14 @@ public class ListenableFutureInstrumentation extends Instrumenter.Default {
 
   public ListenableFutureInstrumentation() {
     super("guava");
+  }
+
+  private final ElementMatcher<ClassLoader> CLASS_LOADER_MATCHER =
+      hasClassesNamed("com.google.common.util.concurrent.AbstractFuture");
+
+  @Override
+  public ElementMatcher<ClassLoader> classLoaderMatcher() {
+    return CLASS_LOADER_MATCHER;
   }
 
   @Override

--- a/dd-java-agent/instrumentation/hibernate/core-3.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v3_3/AbstractHibernateInstrumentation.java
+++ b/dd-java-agent/instrumentation/hibernate/core-3.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v3_3/AbstractHibernateInstrumentation.java
@@ -1,7 +1,7 @@
 package datadog.trace.instrumentation.hibernate.core.v3_3;
 
 import datadog.trace.agent.tooling.Instrumenter;
-import datadog.trace.instrumentation.hibernate.CommonMatchers;
+import datadog.trace.instrumentation.hibernate.HibernateMatchers;
 import net.bytebuddy.matcher.ElementMatcher;
 import org.hibernate.classic.Validatable;
 import org.hibernate.transaction.JBossTransactionManagerLookup;
@@ -15,7 +15,7 @@ public abstract class AbstractHibernateInstrumentation extends Instrumenter.Defa
   @Override
   public ElementMatcher<ClassLoader> classLoaderMatcher() {
     // Optimization for expensive typeMatcher.
-    return CommonMatchers.CLASS_LOADER_MATCHER;
+    return HibernateMatchers.CLASS_LOADER_MATCHER;
   }
 
   @Override

--- a/dd-java-agent/instrumentation/hibernate/core-3.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v3_3/AbstractHibernateInstrumentation.java
+++ b/dd-java-agent/instrumentation/hibernate/core-3.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v3_3/AbstractHibernateInstrumentation.java
@@ -1,8 +1,7 @@
 package datadog.trace.instrumentation.hibernate.core.v3_3;
 
-import static datadog.trace.agent.tooling.ClassLoaderMatcher.hasClassesNamed;
-
 import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.instrumentation.hibernate.CommonMatchers;
 import net.bytebuddy.matcher.ElementMatcher;
 import org.hibernate.classic.Validatable;
 import org.hibernate.transaction.JBossTransactionManagerLookup;
@@ -16,7 +15,7 @@ public abstract class AbstractHibernateInstrumentation extends Instrumenter.Defa
   @Override
   public ElementMatcher<ClassLoader> classLoaderMatcher() {
     // Optimization for expensive typeMatcher.
-    return hasClassesNamed("org.hibernate.Session");
+    return CommonMatchers.CLASS_LOADER_MATCHER;
   }
 
   @Override

--- a/dd-java-agent/instrumentation/hibernate/core-3.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v3_3/SessionFactoryInstrumentation.java
+++ b/dd-java-agent/instrumentation/hibernate/core-3.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v3_3/SessionFactoryInstrumentation.java
@@ -18,6 +18,7 @@ import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.instrumentation.hibernate.SessionState;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
@@ -36,7 +37,7 @@ public class SessionFactoryInstrumentation extends AbstractHibernateInstrumentat
     stores.put("org.hibernate.Session", SessionState.class.getName());
     stores.put("org.hibernate.StatelessSession", SessionState.class.getName());
     stores.put("org.hibernate.SharedSessionContract", SessionState.class.getName());
-    return stores;
+    return Collections.unmodifiableMap(stores);
   }
 
   @Override

--- a/dd-java-agent/instrumentation/hibernate/core-4.0/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_0/AbstractHibernateInstrumentation.java
+++ b/dd-java-agent/instrumentation/hibernate/core-4.0/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_0/AbstractHibernateInstrumentation.java
@@ -1,7 +1,7 @@
 package datadog.trace.instrumentation.hibernate.core.v4_0;
 
 import datadog.trace.agent.tooling.Instrumenter;
-import datadog.trace.instrumentation.hibernate.CommonMatchers;
+import datadog.trace.instrumentation.hibernate.HibernateMatchers;
 import net.bytebuddy.matcher.ElementMatcher;
 import org.hibernate.SharedSessionContract;
 
@@ -14,7 +14,7 @@ public abstract class AbstractHibernateInstrumentation extends Instrumenter.Defa
   @Override
   public ElementMatcher<ClassLoader> classLoaderMatcher() {
     // Optimization for expensive typeMatcher.
-    return CommonMatchers.CLASS_LOADER_MATCHER;
+    return HibernateMatchers.CLASS_LOADER_MATCHER;
   }
 
   @Override

--- a/dd-java-agent/instrumentation/hibernate/core-4.0/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_0/AbstractHibernateInstrumentation.java
+++ b/dd-java-agent/instrumentation/hibernate/core-4.0/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_0/AbstractHibernateInstrumentation.java
@@ -1,8 +1,7 @@
 package datadog.trace.instrumentation.hibernate.core.v4_0;
 
-import static datadog.trace.agent.tooling.ClassLoaderMatcher.hasClassesNamed;
-
 import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.instrumentation.hibernate.CommonMatchers;
 import net.bytebuddy.matcher.ElementMatcher;
 import org.hibernate.SharedSessionContract;
 
@@ -15,7 +14,7 @@ public abstract class AbstractHibernateInstrumentation extends Instrumenter.Defa
   @Override
   public ElementMatcher<ClassLoader> classLoaderMatcher() {
     // Optimization for expensive typeMatcher.
-    return hasClassesNamed("org.hibernate.Session");
+    return CommonMatchers.CLASS_LOADER_MATCHER;
   }
 
   @Override

--- a/dd-java-agent/instrumentation/hibernate/core-4.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_3/ProcedureCallInstrumentation.java
+++ b/dd-java-agent/instrumentation/hibernate/core-4.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_3/ProcedureCallInstrumentation.java
@@ -1,6 +1,5 @@
 package datadog.trace.instrumentation.hibernate.core.v4_3;
 
-import static datadog.trace.agent.tooling.ClassLoaderMatcher.hasClassesNamed;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers.implementsInterface;
 import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
@@ -44,7 +43,7 @@ public class ProcedureCallInstrumentation extends Instrumenter.Default {
   @Override
   public ElementMatcher<ClassLoader> classLoaderMatcher() {
     // Optimization for expensive typeMatcher.
-    return hasClassesNamed("org.hibernate.Session");
+    return SessionInstrumentation.CLASS_LOADER_MATCHER;
   }
 
   @Override

--- a/dd-java-agent/instrumentation/hibernate/core-4.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_3/SessionInstrumentation.java
+++ b/dd-java-agent/instrumentation/hibernate/core-4.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_3/SessionInstrumentation.java
@@ -31,6 +31,9 @@ public class SessionInstrumentation extends Instrumenter.Default {
     super("hibernate", "hibernate-core");
   }
 
+  static final ElementMatcher<ClassLoader> CLASS_LOADER_MATCHER =
+      hasClassesNamed("org.hibernate.Session");
+
   @Override
   public Map<String, String> contextStore() {
     final Map<String, String> map = new HashMap<>();
@@ -51,7 +54,7 @@ public class SessionInstrumentation extends Instrumenter.Default {
   @Override
   public ElementMatcher<ClassLoader> classLoaderMatcher() {
     // Optimization for expensive typeMatcher.
-    return hasClassesNamed("org.hibernate.Session");
+    return CLASS_LOADER_MATCHER;
   }
 
   @Override

--- a/dd-java-agent/instrumentation/hibernate/src/main/java/datadog/trace/instrumentation/hibernate/CommonMatchers.java
+++ b/dd-java-agent/instrumentation/hibernate/src/main/java/datadog/trace/instrumentation/hibernate/CommonMatchers.java
@@ -1,0 +1,13 @@
+package datadog.trace.instrumentation.hibernate;
+
+import static datadog.trace.agent.tooling.ClassLoaderMatcher.hasClassesNamed;
+
+import net.bytebuddy.matcher.ElementMatcher;
+
+public final class CommonMatchers {
+
+  public static final ElementMatcher<ClassLoader> CLASS_LOADER_MATCHER =
+      hasClassesNamed("org.hibernate.Session");
+
+  private CommonMatchers() {}
+}

--- a/dd-java-agent/instrumentation/hibernate/src/main/java/datadog/trace/instrumentation/hibernate/HibernateMatchers.java
+++ b/dd-java-agent/instrumentation/hibernate/src/main/java/datadog/trace/instrumentation/hibernate/HibernateMatchers.java
@@ -4,10 +4,10 @@ import static datadog.trace.agent.tooling.ClassLoaderMatcher.hasClassesNamed;
 
 import net.bytebuddy.matcher.ElementMatcher;
 
-public final class CommonMatchers {
+public final class HibernateMatchers {
 
   public static final ElementMatcher<ClassLoader> CLASS_LOADER_MATCHER =
       hasClassesNamed("org.hibernate.Session");
 
-  private CommonMatchers() {}
+  private HibernateMatchers() {}
 }

--- a/dd-java-agent/instrumentation/http-url-connection/src/main/java/datadog/trace/instrumentation/http_url_connection/HttpUrlConnectionInstrumentation.java
+++ b/dd-java-agent/instrumentation/http-url-connection/src/main/java/datadog/trace/instrumentation/http_url_connection/HttpUrlConnectionInstrumentation.java
@@ -43,7 +43,7 @@ public class HttpUrlConnectionInstrumentation extends Instrumenter.Default {
   }
 
   @Override
-  public Map<String, String> contextStore() {
+  public Map<String, String> contextStoreForAll() {
     return singletonMap("java.net.HttpURLConnection", HttpUrlState.class.getName());
   }
 

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/CallableInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/CallableInstrumentation.java
@@ -36,7 +36,7 @@ public final class CallableInstrumentation extends Instrumenter.Default {
   }
 
   @Override
-  public Map<String, String> contextStore() {
+  public Map<String, String> contextStoreForAll() {
     return singletonMap(Callable.class.getName(), State.class.getName());
   }
 

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/FutureInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/FutureInstrumentation.java
@@ -90,7 +90,7 @@ public final class FutureInstrumentation extends Instrumenter.Default {
   }
 
   @Override
-  public Map<String, String> contextStore() {
+  public Map<String, String> contextStoreForAll() {
     return singletonMap(Future.class.getName(), State.class.getName());
   }
 

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/JavaExecutorInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/JavaExecutorInstrumentation.java
@@ -32,7 +32,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 public final class JavaExecutorInstrumentation extends AbstractExecutorInstrumentation {
 
   @Override
-  public Map<String, String> contextStore() {
+  public Map<String, String> contextStoreForAll() {
     final Map<String, String> map = new HashMap<>();
     map.put(Runnable.class.getName(), State.class.getName());
     map.put(Callable.class.getName(), State.class.getName());

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/JavaForkJoinTaskInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/JavaForkJoinTaskInstrumentation.java
@@ -46,7 +46,7 @@ public final class JavaForkJoinTaskInstrumentation extends Instrumenter.Default 
   }
 
   @Override
-  public Map<String, String> contextStore() {
+  public Map<String, String> contextStoreForAll() {
     final Map<String, String> map = new HashMap<>();
     map.put(Runnable.class.getName(), State.class.getName());
     map.put(Callable.class.getName(), State.class.getName());

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/NonStandardExecutorInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/NonStandardExecutorInstrumentation.java
@@ -21,7 +21,7 @@ public final class NonStandardExecutorInstrumentation extends AbstractExecutorIn
   }
 
   @Override
-  public Map<String, String> contextStore() {
+  public Map<String, String> contextStoreForAll() {
     return singletonMap(Runnable.class.getName(), State.class.getName());
   }
 

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/RunnableInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/RunnableInstrumentation.java
@@ -35,7 +35,7 @@ public final class RunnableInstrumentation extends Instrumenter.Default {
   }
 
   @Override
-  public Map<String, String> contextStore() {
+  public Map<String, String> contextStoreForAll() {
     return singletonMap(Runnable.class.getName(), State.class.getName());
   }
 

--- a/dd-java-agent/instrumentation/jax-rs-annotations-2/src/main/java/datadog/trace/instrumentation/jaxrs2/JaxRsAnnotationsInstrumentation.java
+++ b/dd-java-agent/instrumentation/jax-rs-annotations-2/src/main/java/datadog/trace/instrumentation/jaxrs2/JaxRsAnnotationsInstrumentation.java
@@ -1,6 +1,5 @@
 package datadog.trace.instrumentation.jaxrs2;
 
-import static datadog.trace.agent.tooling.ClassLoaderMatcher.hasClassesNamed;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers.hasSuperMethod;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers.safeHasSuperType;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
@@ -46,7 +45,7 @@ public final class JaxRsAnnotationsInstrumentation extends Instrumenter.Default 
   @Override
   public ElementMatcher<ClassLoader> classLoaderMatcher() {
     // Optimization for expensive typeMatcher.
-    return hasClassesNamed("javax.ws.rs.Path");
+    return JaxRsAsyncResponseInstrumentation.CLASS_LOADER_MATCHER;
   }
 
   @Override

--- a/dd-java-agent/instrumentation/jax-rs-annotations-2/src/main/java/datadog/trace/instrumentation/jaxrs2/JaxRsAsyncResponseInstrumentation.java
+++ b/dd-java-agent/instrumentation/jax-rs-annotations-2/src/main/java/datadog/trace/instrumentation/jaxrs2/JaxRsAsyncResponseInstrumentation.java
@@ -28,6 +28,9 @@ public final class JaxRsAsyncResponseInstrumentation extends Instrumenter.Defaul
     super("jax-rs", "jaxrs", "jax-rs-annotations");
   }
 
+  static final ElementMatcher<ClassLoader> CLASS_LOADER_MATCHER =
+      hasClassesNamed("javax.ws.rs.container.AsyncResponse");
+
   @Override
   public Map<String, String> contextStore() {
     return Collections.singletonMap(
@@ -37,7 +40,7 @@ public final class JaxRsAsyncResponseInstrumentation extends Instrumenter.Defaul
   @Override
   public ElementMatcher<ClassLoader> classLoaderMatcher() {
     // Optimization for expensive typeMatcher.
-    return hasClassesNamed("javax.ws.rs.container.AsyncResponse");
+    return CLASS_LOADER_MATCHER;
   }
 
   @Override

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/ConnectionInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/ConnectionInstrumentation.java
@@ -30,6 +30,11 @@ public final class ConnectionInstrumentation extends Instrumenter.Default {
   }
 
   @Override
+  public ElementMatcher<ClassLoader> classLoaderMatcher() {
+    return PreparedStatementInstrumentation.CLASS_LOADER_MATCHER;
+  }
+
+  @Override
   public Map<String, String> contextStore() {
     return singletonMap("java.sql.PreparedStatement", UTF8BytesString.class.getName());
   }

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/PreparedStatementInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/PreparedStatementInstrumentation.java
@@ -36,9 +36,12 @@ public final class PreparedStatementInstrumentation extends Instrumenter.Default
     super("jdbc");
   }
 
+  static ElementMatcher<ClassLoader> CLASS_LOADER_MATCHER =
+      hasClassesNamed("java.sql.PreparedStatement");
+
   @Override
   public ElementMatcher<ClassLoader> classLoaderMatcher() {
-    return hasClassesNamed("java.sql.PreparedStatement");
+    return CLASS_LOADER_MATCHER;
   }
 
   @Override

--- a/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/ChannelFutureListenerInstrumentation.java
+++ b/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/ChannelFutureListenerInstrumentation.java
@@ -1,6 +1,5 @@
 package datadog.trace.instrumentation.netty38;
 
-import static datadog.trace.agent.tooling.ClassLoaderMatcher.hasClassesNamed;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers.implementsInterface;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
@@ -40,7 +39,7 @@ public class ChannelFutureListenerInstrumentation extends Instrumenter.Default {
   @Override
   public ElementMatcher<ClassLoader> classLoaderMatcher() {
     // Optimization for expensive typeMatcher.
-    return hasClassesNamed("org.jboss.netty.channel.ChannelFutureListener");
+    return NettyChannelInstrumentation.CLASS_LOADER_MATCHER;
   }
 
   @Override

--- a/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/NettyChannelInstrumentation.java
+++ b/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/NettyChannelInstrumentation.java
@@ -29,10 +29,13 @@ public class NettyChannelInstrumentation extends Instrumenter.Default {
     super(INSTRUMENTATION_NAME, ADDITIONAL_INSTRUMENTATION_NAMES);
   }
 
+  static final ElementMatcher<ClassLoader> CLASS_LOADER_MATCHER =
+      hasClassesNamed("org.jboss.netty.channel.Channel");
+
   @Override
   public ElementMatcher<ClassLoader> classLoaderMatcher() {
     // Optimization for expensive typeMatcher.
-    return hasClassesNamed("org.jboss.netty.channel.Channel");
+    return CLASS_LOADER_MATCHER;
   }
 
   @Override

--- a/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/NettyChannelPipelineInstrumentation.java
+++ b/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/NettyChannelPipelineInstrumentation.java
@@ -1,6 +1,5 @@
 package datadog.trace.instrumentation.netty38;
 
-import static datadog.trace.agent.tooling.ClassLoaderMatcher.hasClassesNamed;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers.implementsInterface;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;
@@ -48,7 +47,7 @@ public class NettyChannelPipelineInstrumentation extends Instrumenter.Default {
   @Override
   public ElementMatcher<ClassLoader> classLoaderMatcher() {
     // Optimization for expensive typeMatcher.
-    return hasClassesNamed("org.jboss.netty.channel.ChannelPipeline");
+    return NettyChannelInstrumentation.CLASS_LOADER_MATCHER;
   }
 
   @Override

--- a/dd-java-agent/instrumentation/rmi/src/main/java/datadog/trace/instrumentation/rmi/context/client/RmiClientContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/rmi/src/main/java/datadog/trace/instrumentation/rmi/context/client/RmiClientContextInstrumentation.java
@@ -55,7 +55,7 @@ public class RmiClientContextInstrumentation extends Instrumenter.Default {
   }
 
   @Override
-  public Map<String, String> contextStore() {
+  public Map<String, String> contextStoreForAll() {
     // caching if a connection can support enhanced format
     return singletonMap("sun.rmi.transport.Connection", "java.lang.Boolean");
   }

--- a/dd-java-agent/instrumentation/scala-concurrent/src/main/java/datadog/trace/instrumentation/scala/concurrent/ScalaForkJoinPoolInstrumentation.java
+++ b/dd-java-agent/instrumentation/scala-concurrent/src/main/java/datadog/trace/instrumentation/scala/concurrent/ScalaForkJoinPoolInstrumentation.java
@@ -32,6 +32,11 @@ public final class ScalaForkJoinPoolInstrumentation extends Instrumenter.Default
   }
 
   @Override
+  public ElementMatcher<ClassLoader> classLoaderMatcher() {
+    return ScalaForkJoinTaskInstrumentation.CLASS_LOADER_MATCHER;
+  }
+
+  @Override
   public ElementMatcher<TypeDescription> typeMatcher() {
     // This might need to be an extendsClass matcher...
     return named("scala.concurrent.forkjoin.ForkJoinPool");

--- a/dd-java-agent/instrumentation/scala-concurrent/src/main/java/datadog/trace/instrumentation/scala/concurrent/ScalaForkJoinTaskInstrumentation.java
+++ b/dd-java-agent/instrumentation/scala-concurrent/src/main/java/datadog/trace/instrumentation/scala/concurrent/ScalaForkJoinTaskInstrumentation.java
@@ -39,6 +39,8 @@ public final class ScalaForkJoinTaskInstrumentation extends Instrumenter.Default
 
   static final String TASK_CLASS_NAME = "scala.concurrent.forkjoin.ForkJoinTask";
 
+  static final ElementMatcher<ClassLoader> CLASS_LOADER_MATCHER = hasClassesNamed(TASK_CLASS_NAME);
+
   public ScalaForkJoinTaskInstrumentation() {
     super("java_concurrent", "scala_concurrent");
   }
@@ -46,7 +48,7 @@ public final class ScalaForkJoinTaskInstrumentation extends Instrumenter.Default
   @Override
   public ElementMatcher<ClassLoader> classLoaderMatcher() {
     // Optimization for expensive typeMatcher.
-    return hasClassesNamed(TASK_CLASS_NAME);
+    return CLASS_LOADER_MATCHER;
   }
 
   @Override
@@ -55,12 +57,16 @@ public final class ScalaForkJoinTaskInstrumentation extends Instrumenter.Default
   }
 
   @Override
-  public Map<String, String> contextStore() {
+  public Map<String, String> contextStoreForAll() {
     final Map<String, String> map = new HashMap<>();
     map.put(Runnable.class.getName(), State.class.getName());
     map.put(Callable.class.getName(), State.class.getName());
-    map.put(TASK_CLASS_NAME, State.class.getName());
     return Collections.unmodifiableMap(map);
+  }
+
+  @Override
+  public Map<String, String> contextStore() {
+    return singletonMap(TASK_CLASS_NAME, State.class.getName());
   }
 
   @Override

--- a/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/Servlet2Instrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/Servlet2Instrumentation.java
@@ -11,6 +11,7 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import net.bytebuddy.description.method.MethodDescription;
@@ -25,11 +26,14 @@ public final class Servlet2Instrumentation extends Instrumenter.Default {
   }
 
   // this is required to make sure servlet 2 instrumentation won't apply to servlet 3
+  static final ElementMatcher<ClassLoader> CLASS_LOADER_MATCHER =
+      hasClassesNamed("javax.servlet.http.HttpServletResponse")
+          .and(not(hasClassesNamed("javax.servlet.AsyncEvent", "javax.servlet.AsyncListener")));
+
   @Override
   public ElementMatcher<ClassLoader> classLoaderMatcher() {
     // Optimization for expensive typeMatcher.
-    return hasClassesNamed("javax.servlet.http.HttpServlet")
-        .and(not(hasClassesNamed("javax.servlet.AsyncEvent", "javax.servlet.AsyncListener")));
+    return CLASS_LOADER_MATCHER;
   }
 
   @Override
@@ -53,7 +57,7 @@ public final class Servlet2Instrumentation extends Instrumenter.Default {
     contextStores.put(
         "javax.servlet.http.HttpServletResponse", "javax.servlet.http.HttpServletRequest");
     contextStores.put("javax.servlet.ServletResponse", Integer.class.getName());
-    return contextStores;
+    return Collections.unmodifiableMap(contextStores);
   }
 
   /**

--- a/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/Servlet2ResponseStatusInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/Servlet2ResponseStatusInstrumentation.java
@@ -1,11 +1,9 @@
 package datadog.trace.instrumentation.servlet2;
 
-import static datadog.trace.agent.tooling.ClassLoaderMatcher.hasClassesNamed;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers.safeHasSuperType;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
 import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.named;
-import static net.bytebuddy.matcher.ElementMatchers.not;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
@@ -24,7 +22,7 @@ public final class Servlet2ResponseStatusInstrumentation extends Instrumenter.De
   // this is required to make sure servlet 2 instrumentation won't apply to servlet 3
   @Override
   public ElementMatcher<ClassLoader> classLoaderMatcher() {
-    return not(hasClassesNamed("javax.servlet.AsyncEvent", "javax.servlet.AsyncListener"));
+    return Servlet2Instrumentation.CLASS_LOADER_MATCHER;
   }
 
   @Override

--- a/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Instrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Instrumentation.java
@@ -21,10 +21,13 @@ public final class Servlet3Instrumentation extends Instrumenter.Default {
     super("servlet", "servlet-3");
   }
 
+  private final ElementMatcher<ClassLoader> CLASS_LOADER_MATCHER =
+      hasClassesNamed("javax.servlet.http.HttpServletResponse");
+
   @Override
   public ElementMatcher<ClassLoader> classLoaderMatcher() {
     // Optimization for expensive typeMatcher.
-    return hasClassesNamed("javax.servlet.http.HttpServlet");
+    return CLASS_LOADER_MATCHER;
   }
 
   @Override

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/dispatcher/RequestDispatcherInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/dispatcher/RequestDispatcherInstrumentation.java
@@ -38,10 +38,13 @@ public final class RequestDispatcherInstrumentation extends Instrumenter.Default
     super("servlet", "servlet-dispatcher");
   }
 
+  static final ElementMatcher<ClassLoader> CLASS_LOADER_MATCHER =
+      hasClassesNamed("javax.servlet.RequestDispatcher");
+
   @Override
   public ElementMatcher<ClassLoader> classLoaderMatcher() {
     // Optimization for expensive typeMatcher.
-    return hasClassesNamed("javax.servlet.RequestDispatcher");
+    return CLASS_LOADER_MATCHER;
   }
 
   @Override

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/dispatcher/ServletContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/dispatcher/ServletContextInstrumentation.java
@@ -1,6 +1,5 @@
 package datadog.trace.instrumentation.servlet.dispatcher;
 
-import static datadog.trace.agent.tooling.ClassLoaderMatcher.hasClassesNamed;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers.implementsInterface;
 import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
@@ -27,7 +26,7 @@ public final class ServletContextInstrumentation extends Instrumenter.Default {
   @Override
   public ElementMatcher<ClassLoader> classLoaderMatcher() {
     // Optimization for expensive typeMatcher.
-    return hasClassesNamed("javax.servlet.ServletContext");
+    return RequestDispatcherInstrumentation.CLASS_LOADER_MATCHER;
   }
 
   @Override

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/http/HttpServletResponseInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/http/HttpServletResponseInstrumentation.java
@@ -33,10 +33,13 @@ public final class HttpServletResponseInstrumentation extends Instrumenter.Defau
     super("servlet", "servlet-response");
   }
 
+  public static final ElementMatcher<ClassLoader> CLASS_LOADER_MATCHER =
+      hasClassesNamed("javax.servlet.http.HttpServletResponse");
+
   @Override
   public ElementMatcher<ClassLoader> classLoaderMatcher() {
     // Optimization for expensive typeMatcher.
-    return hasClassesNamed("javax.servlet.http.HttpServletResponse");
+    return CLASS_LOADER_MATCHER;
   }
 
   @Override

--- a/dd-java-agent/testing/src/test/java/context/ContextTestInstrumentation.java
+++ b/dd-java-agent/testing/src/test/java/context/ContextTestInstrumentation.java
@@ -49,7 +49,7 @@ public class ContextTestInstrumentation extends Instrumenter.Default {
   }
 
   @Override
-  public Map<String, String> contextStore() {
+  public Map<String, String> contextStoreForAll() {
     final Map<String, String> store = new HashMap<>(2);
     store.put(getClass().getName() + "$KeyClass", getClass().getName() + "$Context");
     store.put(getClass().getName() + "$UntransformableKeyClass", getClass().getName() + "$Context");


### PR DESCRIPTION
This made field injection not work in cases where a class loader matcher that didn't match declared a context store on a type that was needed by another class loader matcher.