### PR TITLE
Support 'DD_TRACE' prefix when configuring integrations

### DIFF
--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -704,11 +704,7 @@ public class Config {
   public float getInstrumentationAnalyticsSampleRate(final String... aliases) {
     for (final String alias : aliases) {
       final String configKey = alias + ".analytics.sample-rate";
-      // check "dd.trace.<integration>..." before falling back to "dd.<integration>..."
-      Float rate = configProvider.getFloat("trace." + configKey);
-      if (null == rate) {
-        rate = configProvider.getFloat(configKey);
-      }
+      final Float rate = configProvider.getFloat(configKey, "trace." + configKey);
       if (null != rate) {
         return rate;
       }
@@ -833,14 +829,8 @@ public class Config {
     boolean anyEnabled = defaultEnabled;
     for (final String name : integrationNames) {
       final String configKey = settingPrefix + name + settingSuffix;
-      // check "dd.trace.<integration>..." before falling back to "dd.<integration>..."
-      Boolean configEnabled = configProvider.getBoolean("trace." + configKey);
-      if (null == configEnabled) {
-        configEnabled = configProvider.getBoolean(configKey);
-        if (null == configEnabled) {
-          continue;
-        }
-      }
+      final boolean configEnabled =
+          configProvider.getBoolean(configKey, defaultEnabled, "trace." + configKey);
       if (defaultEnabled) {
         anyEnabled &= configEnabled;
       } else {

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -703,7 +703,12 @@ public class Config {
    */
   public float getInstrumentationAnalyticsSampleRate(final String... aliases) {
     for (final String alias : aliases) {
-      final Float rate = configProvider.getFloat(alias + ".analytics.sample-rate");
+      final String configKey = alias + ".analytics.sample-rate";
+      // check "dd.trace.<integration>..." before falling back to "dd.<integration>..."
+      Float rate = configProvider.getFloat("trace." + configKey);
+      if (null == rate) {
+        rate = configProvider.getFloat(configKey);
+      }
       if (null != rate) {
         return rate;
       }
@@ -827,8 +832,15 @@ public class Config {
     // if default is disabled, we want to disable individually.
     boolean anyEnabled = defaultEnabled;
     for (final String name : integrationNames) {
-      final boolean configEnabled =
-          configProvider.getBoolean(settingPrefix + name + settingSuffix, defaultEnabled);
+      final String configKey = settingPrefix + name + settingSuffix;
+      // check "dd.trace.<integration>..." before falling back to "dd.<integration>..."
+      Boolean configEnabled = configProvider.getBoolean("trace." + configKey);
+      if (null == configEnabled) {
+        configEnabled = configProvider.getBoolean(configKey);
+        if (null == configEnabled) {
+          continue;
+        }
+      }
       if (defaultEnabled) {
         anyEnabled &= configEnabled;
       } else {

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -704,7 +704,7 @@ public class Config {
   public float getInstrumentationAnalyticsSampleRate(final String... aliases) {
     for (final String alias : aliases) {
       final String configKey = alias + ".analytics.sample-rate";
-      final Float rate = configProvider.getFloat(configKey, "trace." + configKey);
+      final Float rate = configProvider.getFloat("trace." + configKey, configKey);
       if (null != rate) {
         return rate;
       }
@@ -830,7 +830,7 @@ public class Config {
     for (final String name : integrationNames) {
       final String configKey = settingPrefix + name + settingSuffix;
       final boolean configEnabled =
-          configProvider.getBoolean(configKey, defaultEnabled, "trace." + configKey);
+          configProvider.getBoolean("trace." + configKey, defaultEnabled, configKey);
       if (defaultEnabled) {
         anyEnabled &= configEnabled;
       } else {

--- a/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/ConfigProvider.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/ConfigProvider.java
@@ -64,8 +64,8 @@ public final class ConfigProvider {
     return get(key, null, Boolean.class);
   }
 
-  public final boolean getBoolean(String key, boolean defaultValue) {
-    return get(key, defaultValue, Boolean.class);
+  public final boolean getBoolean(String key, boolean defaultValue, String... aliases) {
+    return get(key, defaultValue, Boolean.class, aliases);
   }
 
   public final Integer getInteger(String key) {
@@ -76,8 +76,8 @@ public final class ConfigProvider {
     return get(key, defaultValue, Integer.class, aliases);
   }
 
-  public final Float getFloat(String key) {
-    return get(key, null, Float.class);
+  public final Float getFloat(String key, String... aliases) {
+    return get(key, null, Float.class, aliases);
   }
 
   public final float getFloat(String key, float defaultValue) {

--- a/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -836,31 +836,39 @@ class ConfigTest extends DDSpecification {
     environmentVariables.set("DD_ORDER_ANALYTICS_ENABLED", "false")
     environmentVariables.set("DD_TEST_ENV_ANALYTICS_ENABLED", "true")
     environmentVariables.set("DD_DISABLED_ENV_ANALYTICS_ENABLED", "false")
+    environmentVariables.set("DD_ALIAS_ENV_ANALYTICS_ENABLED", "false")
+    environmentVariables.set("DD_TRACE_ALIAS_ENV_ANALYTICS_ENABLED", "true")
 
     System.setProperty("dd.order.analytics.enabled", "true")
     System.setProperty("dd.test-prop.analytics.enabled", "true")
     System.setProperty("dd.disabled-prop.analytics.enabled", "false")
+    System.setProperty("dd.alias-prop.analytics.enabled", "false")
+    System.setProperty("dd.trace.alias-prop.analytics.enabled", "true")
 
     expect:
     Config.get().isTraceAnalyticsIntegrationEnabled(integrationNames, defaultEnabled) == expected
 
     where:
-    names                          | defaultEnabled | expected
-    []                             | true           | true
-    []                             | false          | false
-    ["invalid"]                    | true           | true
-    ["invalid"]                    | false          | false
-    ["test-prop"]                  | false          | true
-    ["test-env"]                   | false          | true
-    ["disabled-prop"]              | true           | false
-    ["disabled-env"]               | true           | false
-    ["other", "test-prop"]         | false          | true
-    ["other", "test-env"]          | false          | true
-    ["order"]                      | false          | true
-    ["test-prop", "disabled-prop"] | false          | true
-    ["disabled-env", "test-env"]   | false          | true
-    ["test-prop", "disabled-prop"] | true           | false
-    ["disabled-env", "test-env"]   | true           | false
+    names                           | defaultEnabled | expected
+    []                              | true           | true
+    []                              | false          | false
+    ["invalid"]                     | true           | true
+    ["invalid"]                     | false          | false
+    ["test-prop"]                   | false          | true
+    ["test-env"]                    | false          | true
+    ["disabled-prop"]               | true           | false
+    ["disabled-env"]                | true           | false
+    ["other", "test-prop"]          | false          | true
+    ["other", "test-env"]           | false          | true
+    ["order"]                       | false          | true
+    ["test-prop", "disabled-prop"]  | false          | true
+    ["disabled-env", "test-env"]    | false          | true
+    ["test-prop", "disabled-prop"]  | true           | false
+    ["disabled-env", "test-env"]    | true           | false
+    ["alias-prop", "disabled-prop"] | false          | true
+    ["disabled-env", "alias-env"]   | false          | true
+    ["alias-prop", "disabled-prop"] | true           | false
+    ["disabled-env", "alias-env"]   | true           | false
 
     integrationNames = new TreeSet<>(names)
   }
@@ -1139,9 +1147,13 @@ class ConfigTest extends DDSpecification {
     setup:
     environmentVariables.set("DD_FOO_ANALYTICS_SAMPLE_RATE", "0.5")
     environmentVariables.set("DD_BAR_ANALYTICS_SAMPLE_RATE", "0.9")
+    environmentVariables.set("DD_ALIAS_ENV_ANALYTICS_SAMPLE_RATE", "0.8")
+    environmentVariables.set("DD_TRACE_ALIAS_ENV_ANALYTICS_SAMPLE_RATE", "0.4")
 
     System.setProperty("dd.baz.analytics.sample-rate", "0.7")
     System.setProperty("dd.buzz.analytics.sample-rate", "0.3")
+    System.setProperty("dd.alias-prop.analytics.sample-rate", "0.1")
+    System.setProperty("dd.trace.alias-prop.analytics.sample-rate", "0.2")
 
     when:
     String[] array = services.toArray(new String[0])
@@ -1163,6 +1175,8 @@ class ConfigTest extends DDSpecification {
     ["buzz", "baz"]         | 0.3f
     ["foo", "baz"]          | 0.5f
     ["baz", "foo"]          | 0.7f
+    ["alias-env", "baz"]    | 0.4f
+    ["alias-prop", "foo"]   | 0.2f
   }
 
   def "verify api key loaded from file: #path"() {

--- a/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -836,12 +836,14 @@ class ConfigTest extends DDSpecification {
     environmentVariables.set("DD_ORDER_ANALYTICS_ENABLED", "false")
     environmentVariables.set("DD_TEST_ENV_ANALYTICS_ENABLED", "true")
     environmentVariables.set("DD_DISABLED_ENV_ANALYTICS_ENABLED", "false")
+    // trace prefix form should take precedence over the old non-prefix form
     environmentVariables.set("DD_ALIAS_ENV_ANALYTICS_ENABLED", "false")
     environmentVariables.set("DD_TRACE_ALIAS_ENV_ANALYTICS_ENABLED", "true")
 
     System.setProperty("dd.order.analytics.enabled", "true")
     System.setProperty("dd.test-prop.analytics.enabled", "true")
     System.setProperty("dd.disabled-prop.analytics.enabled", "false")
+    // trace prefix form should take precedence over the old non-prefix form
     System.setProperty("dd.alias-prop.analytics.enabled", "false")
     System.setProperty("dd.trace.alias-prop.analytics.enabled", "true")
 
@@ -1147,11 +1149,13 @@ class ConfigTest extends DDSpecification {
     setup:
     environmentVariables.set("DD_FOO_ANALYTICS_SAMPLE_RATE", "0.5")
     environmentVariables.set("DD_BAR_ANALYTICS_SAMPLE_RATE", "0.9")
+    // trace prefix form should take precedence over the old non-prefix form
     environmentVariables.set("DD_ALIAS_ENV_ANALYTICS_SAMPLE_RATE", "0.8")
     environmentVariables.set("DD_TRACE_ALIAS_ENV_ANALYTICS_SAMPLE_RATE", "0.4")
 
     System.setProperty("dd.baz.analytics.sample-rate", "0.7")
     System.setProperty("dd.buzz.analytics.sample-rate", "0.3")
+    // trace prefix form should take precedence over the old non-prefix form
     System.setProperty("dd.alias-prop.analytics.sample-rate", "0.1")
     System.setProperty("dd.trace.alias-prop.analytics.sample-rate", "0.2")
 


### PR DESCRIPTION
to match other language tracers, for example:
* `DD_<INTEGRATION>_ENABLED` --> `DD_TRACE_<INTEGRATION>_ENABLED`
* `DD_<INTEGRATION>_ANALYTICS_<OPTION>` --> `DD_TRACE_<INTEGRATION>_ANALYTICS_<OPTION>`

but still accept use of the old settings