### PR TITLE
[PROF-1988] default stackdepth

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkController.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkController.java
@@ -18,6 +18,7 @@ package com.datadog.profiling.controller.openjdk;
 import com.datadog.profiling.controller.ConfigurationException;
 import com.datadog.profiling.controller.Controller;
 import datadog.trace.api.Config;
+import datadog.trace.core.util.SystemAccess;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Map;
@@ -47,7 +48,8 @@ public final class OpenJdkController implements Controller {
     // factory and can use it.
     Class.forName("jdk.jfr.Recording");
     Class.forName("jdk.jfr.FlightRecorder");
-
+    SystemAccess.executeDiagnosticCommand(
+        "jfrConfigure", new Object[] {"stackdepth=128"}, new String[] {String[].class.getName()});
     try {
       recordingSettings =
           JfpUtils.readNamedJfpResource(JFP, config.getProfilingTemplateOverrideFile());

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkController.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkController.java
@@ -18,7 +18,6 @@ package com.datadog.profiling.controller.openjdk;
 import com.datadog.profiling.controller.ConfigurationException;
 import com.datadog.profiling.controller.Controller;
 import datadog.trace.api.Config;
-import datadog.trace.core.util.SystemAccess;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Map;
@@ -48,8 +47,6 @@ public final class OpenJdkController implements Controller {
     // factory and can use it.
     Class.forName("jdk.jfr.Recording");
     Class.forName("jdk.jfr.FlightRecorder");
-    SystemAccess.executeDiagnosticCommand(
-        "jfrConfigure", new Object[] {"stackdepth=128"}, new String[] {String[].class.getName()});
     try {
       recordingSettings =
           JfpUtils.readNamedJfpResource(JFP, config.getProfilingTemplateOverrideFile());

--- a/dd-java-agent/agent-profiling/profiling-controller/profiling-controller.gradle
+++ b/dd-java-agent/agent-profiling/profiling-controller/profiling-controller.gradle
@@ -15,6 +15,7 @@ excludedClassesCoverage += [
 dependencies {
   compile deps.slf4j
   compile project(':internal-api')
+  compile project(':dd-trace-core')
 
   testCompile deps.junit5
   testCompile deps.guava

--- a/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/ProfilingSystem.java
+++ b/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/ProfilingSystem.java
@@ -155,7 +155,6 @@ public final class ProfilingSystem {
   private static void setMaxStackDepth() {
     int maxFrames = ProfilingSystem.DEFAULT_STACK_DEPTH;
 
-    // don't set stackdepth if the client has explicitly set it
     final Optional<String> userSpecifiedStackDepth =
         readJFRStackDepth(SystemAccess.getVMArguments());
     if (userSpecifiedStackDepth.isPresent()) {

--- a/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/ProfilingSystem.java
+++ b/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/ProfilingSystem.java
@@ -17,8 +17,6 @@ package com.datadog.profiling.controller;
 
 import com.datadog.profiling.util.ProfilingThreadFactory;
 import datadog.trace.core.util.SystemAccess;
-import lombok.extern.slf4j.Slf4j;
-
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
@@ -28,6 +26,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
+import lombok.extern.slf4j.Slf4j;
 
 /** Sets up the profiling strategy and schedules the profiling recordings. */
 @Slf4j
@@ -137,7 +136,8 @@ public final class ProfilingSystem {
     int maxFrames = ProfilingSystem.DEFAULT_STACK_DEPTH;
 
     // don't set stackdepth if the client has explicitly set it
-    final Optional<String> userSpecifiedStackDepth = readJFRStackDepth(SystemAccess.vmArguments());
+    final Optional<String> userSpecifiedStackDepth =
+        readJFRStackDepth(SystemAccess.getVMArguments());
     if (userSpecifiedStackDepth.isPresent()) {
       try {
         final int stackDepth = Integer.parseInt(userSpecifiedStackDepth.get());

--- a/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/ProfilingSystem.java
+++ b/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/ProfilingSystem.java
@@ -162,11 +162,13 @@ public final class ProfilingSystem {
       maxFrames = stackDepthFromClient(userSpecifiedStackDepth.get());
     }
 
-    log.info("setting JFR.configure stackdepth=" + maxFrames);
-    SystemAccess.executeDiagnosticCommand(
-        "jfrConfigure",
-        new Object[] {new String[] {"stackdepth=" + maxFrames}},
-        new String[] {String[].class.getName()});
+    final String result =
+        SystemAccess.executeDiagnosticCommand(
+            "jfrConfigure",
+            new Object[] {new String[] {"stackdepth=" + maxFrames}},
+            new String[] {String[].class.getName()});
+
+    log.info("setting JFR.configure stackdepth: {}", result);
   }
 
   protected static Optional<String> readJFRStackDepth(final List<String> vmArgs) {

--- a/dd-java-agent/agent-profiling/profiling-controller/src/test/java/com/datadog/profiling/controller/ProfilingSystemTest.java
+++ b/dd-java-agent/agent-profiling/profiling-controller/src/test/java/com/datadog/profiling/controller/ProfilingSystemTest.java
@@ -32,6 +32,14 @@ import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.ThreadLocalRandom;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -45,15 +53,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.mockito.stubbing.Answer;
-
-import java.time.Duration;
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
-import java.util.concurrent.ThreadLocalRandom;
 
 @ExtendWith(MockitoExtension.class)
 // Proper unused stub detection doesn't work in junit5 yet,

--- a/dd-java-agent/agent-profiling/profiling-controller/src/test/java/com/datadog/profiling/controller/ProfilingSystemTest.java
+++ b/dd-java-agent/agent-profiling/profiling-controller/src/test/java/com/datadog/profiling/controller/ProfilingSystemTest.java
@@ -393,6 +393,12 @@ public class ProfilingSystemTest {
     assertEquals(expected, depth.get());
   }
 
+  @ParameterizedTest
+  @CsvSource({",256", "foo,256", "512,512", "1025,1024"})
+  public void testStackDepthFromClient(final String input, final int expected) {
+    assertEquals(expected, ProfilingSystem.stackDepthFromClient(input));
+  }
+
   private Answer<Object> generateMockRecordingData(
       final List<RecordingData> generatedRecordingData) {
     return (InvocationOnMock invocation) -> {

--- a/dd-smoke-tests/src/main/groovy/datadog/smoketest/AbstractSmokeTest.groovy
+++ b/dd-smoke-tests/src/main/groovy/datadog/smoketest/AbstractSmokeTest.groovy
@@ -36,7 +36,7 @@ abstract class AbstractSmokeTest extends Specification {
   protected BlockingQueue<TestHttpServer.HandlerApi.RequestApi> traceRequests = new LinkedBlockingQueue<>()
 
   /**
-   * Will be initialized after calling {@linkplain AbstractSomeTest#checkLog} and hold {@literal true}
+   * Will be initialized after calling {@linkplain AbstractSmokeTest#checkLog} and hold {@literal true}
    * if there are any ERROR or WARN lines in the test application log.
    */
   @Shared
@@ -87,8 +87,7 @@ abstract class AbstractSmokeTest extends Specification {
     processBuilder.environment().put("DD_API_KEY", apiKey())
 
     processBuilder.redirectErrorStream(true)
-    File log = new File("${buildDirectory}/reports/testProcess.${this.getClass().getName()}.log")
-    processBuilder.redirectOutput(ProcessBuilder.Redirect.to(log))
+    processBuilder.redirectOutput(ProcessBuilder.Redirect.to(new File(logFilePath)))
 
     testedProcess = processBuilder.start()
   }

--- a/dd-smoke-tests/wildfly/src/test/groovy/datadog/smoketest/JFRStackDepthTest.groovy
+++ b/dd-smoke-tests/wildfly/src/test/groovy/datadog/smoketest/JFRStackDepthTest.groovy
@@ -26,7 +26,6 @@ class JFRStackDepthTest extends Specification {
   @Shared
   def shadowJarPath = System.getProperty("datadog.smoketest.agent.shadowJar.path")
 
-  @Shared
   @AutoCleanup
   TestHttpServer server = httpServer {
     handlers {
@@ -45,12 +44,9 @@ class JFRStackDepthTest extends Specification {
   def managementPort = PortUtils.randomOpenPort()
   Process testedProcess
 
-  def setupSpec() {
-    server.start()
-  }
-
   def setup() {
     requests.clear()
+    server.start()
   }
 
   def cleanup() {
@@ -101,7 +97,7 @@ class JFRStackDepthTest extends Specification {
     // using VM args exposing a JMX server to query this configuration crashes JBoss
     // thus the external process call with jcmd
     def jcmdBin = System.getProperty("java.home") + "/bin/jcmd"
-    def jcmdProc = new ProcessBuilder( jcmdBin, "${pid}", "JFR.configure").start()
+    def jcmdProc = new ProcessBuilder(jcmdBin, "${pid}", "JFR.configure").start()
     jcmdProc.waitForOrKill(1000)
 
     return jcmdProc.text.lines()
@@ -122,9 +118,9 @@ class JFRStackDepthTest extends Specification {
     }
 
     where:
-    extraOpts                                   | expected
-    ""                                          | 256
-    "-XX:FlightRecorderOptions=stackdepth=512"  | 512
-    "-XX:FlightRecorderOptions=stackdepth=3000" | 1024
+    extraOpts                                                         | expected
+    ""                                                                | 256
+    "-XX:FlightRecorderOptions=stackdepth=512"                        | 512
+    "-XX:FlightRecorderOptions=globalbuffersize=10MB,stackdepth=3000" | 1024
   }
 }

--- a/dd-smoke-tests/wildfly/src/test/groovy/datadog/smoketest/JFRStackDepthTest.groovy
+++ b/dd-smoke-tests/wildfly/src/test/groovy/datadog/smoketest/JFRStackDepthTest.groovy
@@ -93,7 +93,6 @@ class JFRStackDepthTest extends Specification {
 
     PortUtils.waitForPortToOpen(httpPort, 240, TimeUnit.SECONDS, testedProcess)
 
-    Thread.sleep(1000)
     // can't use testedProcess.pid() as that's just the pid for standalone.sh
     return testedProcess.children().findFirst().get().pid()
   }

--- a/dd-smoke-tests/wildfly/src/test/groovy/datadog/smoketest/JFRStackDepthTest.groovy
+++ b/dd-smoke-tests/wildfly/src/test/groovy/datadog/smoketest/JFRStackDepthTest.groovy
@@ -2,6 +2,7 @@ package datadog.smoketest
 
 import datadog.trace.agent.test.server.http.TestHttpServer
 import datadog.trace.agent.test.utils.PortUtils
+import org.junit.Assume
 import spock.lang.AutoCleanup
 import spock.lang.Retry
 import spock.lang.Shared
@@ -88,6 +89,9 @@ class JFRStackDepthTest extends Specification {
     testedProcess = processBuilder.start()
 
     PortUtils.waitForPortToOpen(httpPort, 240, TimeUnit.SECONDS, testedProcess)
+
+    // This test can't run on Java 1.8, requires Process::children and Process::pid only present since 1.9
+    Assume.assumeFalse(System.getProperty("java.specification.version") == "1.8")
 
     // can't use testedProcess.pid() as that's just the pid for standalone.sh
     return testedProcess.children().findFirst().get().pid()

--- a/dd-smoke-tests/wildfly/src/test/groovy/datadog/smoketest/JFRStackDepthTest.groovy
+++ b/dd-smoke-tests/wildfly/src/test/groovy/datadog/smoketest/JFRStackDepthTest.groovy
@@ -30,7 +30,7 @@ class JFRStackDepthTest extends Specification {
   @AutoCleanup
   TestHttpServer server = httpServer {
     handlers {
-      all() {
+      all {
         requests.add(request)
         response.status(200).send()
       }

--- a/dd-smoke-tests/wildfly/src/test/groovy/datadog/smoketest/JFRStackDepthTest.groovy
+++ b/dd-smoke-tests/wildfly/src/test/groovy/datadog/smoketest/JFRStackDepthTest.groovy
@@ -1,0 +1,131 @@
+package datadog.smoketest
+
+import datadog.trace.agent.test.server.http.TestHttpServer
+import datadog.trace.agent.test.utils.PortUtils
+import spock.lang.AutoCleanup
+import spock.lang.Retry
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.util.concurrent.PollingConditions
+
+import java.util.concurrent.BlockingQueue
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
+
+import static datadog.trace.agent.test.server.http.TestHttpServer.httpServer
+
+@Retry(delay = 2000)
+class JFRStackDepthTest extends Specification {
+  public static final PROFILING_START_DELAY_SECONDS = 1
+  public static final int PROFILING_RECORDING_UPLOAD_PERIOD_SECONDS = 5
+
+  @Shared
+  def wildflyDirectory = new File(System.getProperty("datadog.smoketest.wildflyDir"))
+  @Shared
+  def buildDirectory = System.getProperty("datadog.smoketest.builddir")
+  @Shared
+  def shadowJarPath = System.getProperty("datadog.smoketest.agent.shadowJar.path")
+
+  @Shared
+  @AutoCleanup
+  TestHttpServer server = httpServer {
+    handlers {
+      all() {
+        requests.add(request)
+        response.status(200).send()
+      }
+    }
+  }
+
+  @Shared
+  BlockingQueue<TestHttpServer.HandlerApi.RequestApi> requests = new LinkedBlockingQueue<>()
+
+  def httpsPort = PortUtils.randomOpenPort()
+  def httpPort = PortUtils.randomOpenPort()
+  def managementPort = PortUtils.randomOpenPort()
+  Process testedProcess
+
+  def setupSpec() {
+    server.start()
+  }
+
+  def setup() {
+    requests.clear()
+  }
+
+  def cleanup() {
+    ProcessBuilder processBuilder = new ProcessBuilder(
+      "${wildflyDirectory}/bin/jboss-cli.sh",
+      "--connect",
+      "--controller=localhost:${managementPort}",
+      "command=:shutdown")
+    processBuilder.directory(wildflyDirectory)
+    Process process = processBuilder.start()
+    process.waitFor()
+  }
+
+  long startWildfly(String extraOpts) {
+    def logFilePath = "${buildDirectory}/reports/testProcess.${specificationContext.currentIteration.name}.log"
+    String[] javaOpts = [
+      "-javaagent:${shadowJarPath}",
+      "-Ddd.trace.agent.port=${server.address.port}",
+      "-Ddd.service.name=smoke-test-java-app",
+      "-Ddd.profiling.enabled=true",
+      "-Ddd.profiling.start-delay=${PROFILING_START_DELAY_SECONDS}",
+      "-Ddd.profiling.upload.period=${PROFILING_RECORDING_UPLOAD_PERIOD_SECONDS}",
+      "-Ddd.profiling.url=http://localhost:${server.address.port}",
+      "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=debug",
+      "-Dorg.slf4j.simpleLogger.defaultLogLevel=debug",
+      " -Djboss.http.port=${httpPort} -Djboss.https.port=${httpsPort}",
+      " -Djboss.management.http.port=${managementPort}",
+      extraOpts,
+    ]
+
+    ProcessBuilder processBuilder =
+      new ProcessBuilder("${wildflyDirectory}/bin/standalone.sh")
+    processBuilder.directory(wildflyDirectory)
+    processBuilder.environment().put("JAVA_OPTS", javaOpts.join(" "))
+    processBuilder.environment().put("JAVA_HOME", System.getProperty("java.home"))
+    processBuilder.environment().put("DD_API_KEY", "01234567890abcdef123456789ABCDEF")
+    processBuilder.redirectErrorStream(true)
+    processBuilder.redirectOutput(ProcessBuilder.Redirect.to(new File(logFilePath)))
+    testedProcess = processBuilder.start()
+
+    PortUtils.waitForPortToOpen(httpPort, 240, TimeUnit.SECONDS, testedProcess)
+
+    Thread.sleep(1000)
+    // can't use testedProcess.pid() as that's just the pid for standalone.sh
+    return testedProcess.children().findFirst().get().pid()
+  }
+
+  int readJFRStackdepth(long pid) {
+    // using VM args exposing a JMX server to query this configuration crashes JBoss
+    // thus the external process call with jcmd
+    def jcmdBin = System.getProperty("java.home") + "/bin/jcmd"
+    def jcmdProc = new ProcessBuilder( jcmdBin, "${pid}", "JFR.configure").start()
+    jcmdProc.waitForOrKill(1000)
+
+    return jcmdProc.text.lines()
+      .map({ it =~ /^Stack depth: (\d+)/ })
+      .filter({ it.size() > 0 })
+      .map({ it[0][1].toInteger() })
+      .findFirst()
+      .get() as int
+  }
+
+  def "verify JFR.configure stackdepth"() {
+    setup:
+    def wildflyPid = startWildfly(extraOpts)
+
+    expect:
+    new PollingConditions(timeout: 10).eventually {
+      assert expected == readJFRStackdepth(wildflyPid)
+    }
+
+    where:
+    extraOpts                                   | expected
+    ""                                          | 256
+    "-XX:FlightRecorderOptions=stackdepth=512"  | 512
+    "-XX:FlightRecorderOptions=stackdepth=3000" | 1024
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/core/util/JmxSystemAccessProvider.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/util/JmxSystemAccessProvider.java
@@ -44,7 +44,7 @@ final class JmxSystemAccessProvider implements SystemAccessProvider {
     return Integer.parseInt(pid);
   }
 
-  /** */
+  /** invokes command on {@code com.sun.management:type=DiagnosticCommand} */
   @Override
   public String executeDiagnosticCommand(
       final String command, final Object[] args, final String[] sig) {
@@ -66,9 +66,9 @@ final class JmxSystemAccessProvider implements SystemAccessProvider {
     }
   }
 
-  /** */
+  /** @return {@linkplain RuntimeMXBean#getInputArguments()} */
   @Override
-  public List<String> vmArguments() {
+  public List<String> getVMArguments() {
     List<String> args = Collections.emptyList();
     try {
       args = runtimeMXBean.getInputArguments();

--- a/dd-trace-core/src/main/java/datadog/trace/core/util/JmxSystemAccessProvider.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/util/JmxSystemAccessProvider.java
@@ -3,8 +3,12 @@ package datadog.trace.core.util;
 import java.lang.management.ManagementFactory;
 import java.lang.management.RuntimeMXBean;
 import java.lang.management.ThreadMXBean;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+import lombok.extern.slf4j.Slf4j;
 
 /** System provider based on JMX MXBeans */
+@Slf4j
 final class JmxSystemAccessProvider implements SystemAccessProvider {
   private final ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
   private final RuntimeMXBean runtimeMXBean = ManagementFactory.getRuntimeMXBean();
@@ -36,5 +40,26 @@ final class JmxSystemAccessProvider implements SystemAccessProvider {
     }
     String pid = name.substring(0, idx);
     return Integer.parseInt(pid);
+  }
+
+  /** */
+  @Override
+  public String executeDiagnosticCommand(String command, Object[] args, String[] sig) {
+    ObjectName diagnosticCommandMBean = null;
+    try {
+      diagnosticCommandMBean = new ObjectName("com.sun.management:type=DiagnosticCommand");
+    } catch (MalformedObjectNameException ex) {
+      log.debug("Error during executeDiagnosticCommand: ", ex);
+      return null;
+    }
+    try {
+      Object result =
+          ManagementFactory.getPlatformMBeanServer()
+              .invoke(diagnosticCommandMBean, command, args, sig);
+      return result != null ? result.toString() : null;
+    } catch (Exception ex) {
+      log.debug("Error invoking diagnostic command: ", ex);
+      return null;
+    }
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/util/JmxSystemAccessProvider.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/util/JmxSystemAccessProvider.java
@@ -53,16 +53,16 @@ final class JmxSystemAccessProvider implements SystemAccessProvider {
       diagnosticCommandMBean = new ObjectName("com.sun.management:type=DiagnosticCommand");
     } catch (final MalformedObjectNameException ex) {
       log.warn("Error during executeDiagnosticCommand: ", ex);
-      return null;
+      return ex.getMessage();
     }
     try {
       final Object result =
           ManagementFactory.getPlatformMBeanServer()
               .invoke(diagnosticCommandMBean, command, args, sig);
-      return result != null ? result.toString() : null;
+      return result != null ? result.toString().trim() : null;
     } catch (final Throwable ex) {
       log.warn("Error invoking diagnostic command: ", ex);
-      return null;
+      return ex.getMessage();
     }
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/util/NoneSystemAccessProvider.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/util/NoneSystemAccessProvider.java
@@ -21,7 +21,7 @@ final class NoneSystemAccessProvider implements SystemAccessProvider {
   }
 
   @Override
-  public List<String> vmArguments() {
+  public List<String> getVMArguments() {
     return Collections.emptyList();
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/util/NoneSystemAccessProvider.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/util/NoneSystemAccessProvider.java
@@ -1,5 +1,8 @@
 package datadog.trace.core.util;
 
+import java.util.Collections;
+import java.util.List;
+
 final class NoneSystemAccessProvider implements SystemAccessProvider {
   @Override
   public long getThreadCpuTime() {
@@ -12,7 +15,13 @@ final class NoneSystemAccessProvider implements SystemAccessProvider {
   }
 
   @Override
-  public String executeDiagnosticCommand(String command, Object[] args, String[] sig) {
+  public String executeDiagnosticCommand(
+      final String command, final Object[] args, final String[] sig) {
     return null;
+  }
+
+  @Override
+  public List<String> vmArguments() {
+    return Collections.emptyList();
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/util/NoneSystemAccessProvider.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/util/NoneSystemAccessProvider.java
@@ -17,7 +17,7 @@ final class NoneSystemAccessProvider implements SystemAccessProvider {
   @Override
   public String executeDiagnosticCommand(
       final String command, final Object[] args, final String[] sig) {
-    return null;
+    return "Not executed, JMX not initialized.";
   }
 
   @Override

--- a/dd-trace-core/src/main/java/datadog/trace/core/util/NoneSystemAccessProvider.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/util/NoneSystemAccessProvider.java
@@ -10,4 +10,9 @@ final class NoneSystemAccessProvider implements SystemAccessProvider {
   public int getCurrentPid() {
     return 0;
   }
+
+  @Override
+  public String executeDiagnosticCommand(String command, Object[] args, String[] sig) {
+    return null;
+  }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/util/SystemAccess.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/util/SystemAccess.java
@@ -61,4 +61,9 @@ public final class SystemAccess {
   public static int getCurrentPid() {
     return systemAccessProvider.getCurrentPid();
   }
+
+  /** */
+  public static String executeDiagnosticCommand(String command, Object[] args, String[] sig) {
+    return systemAccessProvider.executeDiagnosticCommand(command, args, sig);
+  }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/util/SystemAccess.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/util/SystemAccess.java
@@ -1,7 +1,9 @@
 package datadog.trace.core.util;
 
 import datadog.trace.api.Config;
+import java.lang.management.RuntimeMXBean;
 import java.util.List;
+import javax.management.ObjectName;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -63,14 +65,21 @@ public final class SystemAccess {
     return systemAccessProvider.getCurrentPid();
   }
 
-  /** */
+  /**
+   * Invokes command on {@code com.sun.management:type=DiagnosticCommand}. See {@link
+   * javax.management.MBeanServer#invoke(ObjectName, String, Object[], String[])}
+   */
   public static String executeDiagnosticCommand(
       final String command, final Object[] args, final String[] sig) {
     return systemAccessProvider.executeDiagnosticCommand(command, args, sig);
   }
 
-  /** */
-  public static List<String> vmArguments() {
-    return systemAccessProvider.vmArguments();
+  /**
+   * Wrapper for {@linkplain RuntimeMXBean#getInputArguments()}
+   *
+   * @return arguments passed to JVM
+   */
+  public static List<String> getVMArguments() {
+    return systemAccessProvider.getVMArguments();
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/util/SystemAccess.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/util/SystemAccess.java
@@ -1,6 +1,7 @@
 package datadog.trace.core.util;
 
 import datadog.trace.api.Config;
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -63,7 +64,13 @@ public final class SystemAccess {
   }
 
   /** */
-  public static String executeDiagnosticCommand(String command, Object[] args, String[] sig) {
+  public static String executeDiagnosticCommand(
+      final String command, final Object[] args, final String[] sig) {
     return systemAccessProvider.executeDiagnosticCommand(command, args, sig);
+  }
+
+  /** */
+  public static List<String> vmArguments() {
+    return systemAccessProvider.vmArguments();
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/util/SystemAccess.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/util/SystemAccess.java
@@ -68,6 +68,8 @@ public final class SystemAccess {
   /**
    * Invokes command on {@code com.sun.management:type=DiagnosticCommand}. See {@link
    * javax.management.MBeanServer#invoke(ObjectName, String, Object[], String[])}
+   *
+   * @return string result of invoking diagnostic command, null if nothing executed
    */
   public static String executeDiagnosticCommand(
       final String command, final Object[] args, final String[] sig) {

--- a/dd-trace-core/src/main/java/datadog/trace/core/util/SystemAccessProvider.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/util/SystemAccessProvider.java
@@ -21,5 +21,6 @@ public interface SystemAccessProvider {
   /** execute a diagnostic command */
   String executeDiagnosticCommand(String command, Object[] args, String[] sig);
 
-  List<String> vmArguments();
+  /** get arguments passed to JVM */
+  List<String> getVMArguments();
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/util/SystemAccessProvider.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/util/SystemAccessProvider.java
@@ -15,4 +15,7 @@ public interface SystemAccessProvider {
 
   /** get the current pid */
   int getCurrentPid();
+
+  /** execute a diagnostic command */
+  String executeDiagnosticCommand(String command, Object[] args, String[] sig);
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/util/SystemAccessProvider.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/util/SystemAccessProvider.java
@@ -1,5 +1,7 @@
 package datadog.trace.core.util;
 
+import java.util.List;
+
 /**
  * A pluggable system provider used by {@linkplain SystemAccess}. {@linkplain SystemAccess} may not
  * use JMX classes (even via transitive dependencies) due to potential race in j.u.l initialization.
@@ -18,4 +20,6 @@ public interface SystemAccessProvider {
 
   /** execute a diagnostic command */
   String executeDiagnosticCommand(String command, Object[] args, String[] sig);
+
+  List<String> vmArguments();
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/util/SystemAccessTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/util/SystemAccessTest.groovy
@@ -113,4 +113,72 @@ class SystemAccessTest extends DDSpecification {
     then:
     pid == 0
   }
+
+  def "JMX - getVMArguments"() {
+    setup:
+    ConfigUtils.updateConfig {
+      System.properties.setProperty("dd.${Config.PROFILING_ENABLED}", "true")
+    }
+    SystemAccess.enableJmx()
+
+    when:
+    def vmArgs = SystemAccess.getVMArguments()
+
+    then:
+    vmArgs != null
+    vmArgs.size() > 0
+
+    cleanup:
+    SystemAccess.disableJmx()
+  }
+
+  def "No JMX - getVMArguments"() {
+    setup:
+    ConfigUtils.updateConfig {
+      System.properties.setProperty("dd.${Config.PROFILING_ENABLED}", "true")
+    }
+
+    when:
+    def vmArgs = SystemAccess.getVMArguments()
+
+    then:
+    vmArgs != null
+    vmArgs.size() == 0
+  }
+
+  def "JMX - executeDiagnosticCommand"() {
+    setup:
+    ConfigUtils.updateConfig {
+      System.properties.setProperty("dd.${Config.PROFILING_ENABLED}", "true")
+    }
+    SystemAccess.enableJmx()
+
+    when:
+    SystemAccess.executeDiagnosticCommand(
+      "jfrConfigure",
+      [["stackdepth=64"].toArray() as String[]].toArray() as Object[],
+      [String[].class.getName()].toArray() as String[])
+
+    then:
+    noExceptionThrown()
+
+    cleanup:
+    SystemAccess.disableJmx()
+  }
+
+  def "No JMX - executeDiagnosticCommand"() {
+    setup:
+    ConfigUtils.updateConfig {
+      System.properties.setProperty("dd.${Config.PROFILING_ENABLED}", "true")
+    }
+
+    when:
+    SystemAccess.executeDiagnosticCommand(
+      "jfrConfigure",
+      [["stackdepth=64"].toArray() as String[]].toArray() as Object[],
+      [String[].class.getName()].toArray() as String[])
+
+    then:
+    noExceptionThrown()
+  }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/util/SystemAccessTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/util/SystemAccessTest.groovy
@@ -154,12 +154,13 @@ class SystemAccessTest extends DDSpecification {
     SystemAccess.enableJmx()
 
     when:
-    SystemAccess.executeDiagnosticCommand(
+    def result = SystemAccess.executeDiagnosticCommand(
       "jfrConfigure",
-      [["stackdepth=64"].toArray() as String[]].toArray() as Object[],
+      [["stackdepth=128"].toArray() as String[]].toArray() as Object[],
       [String[].class.getName()].toArray() as String[])
 
     then:
+    "Stack depth: 128" == result
     noExceptionThrown()
 
     cleanup:
@@ -173,12 +174,13 @@ class SystemAccessTest extends DDSpecification {
     }
 
     when:
-    SystemAccess.executeDiagnosticCommand(
+    def result = SystemAccess.executeDiagnosticCommand(
       "jfrConfigure",
-      [["stackdepth=64"].toArray() as String[]].toArray() as Object[],
+      [["stackdepth=128"].toArray() as String[]].toArray() as Object[],
       [String[].class.getName()].toArray() as String[])
 
     then:
+    "Not executed, JMX not initialized." == result
     noExceptionThrown()
   }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/util/SystemAccessTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/util/SystemAccessTest.groovy
@@ -149,7 +149,10 @@ class SystemAccessTest extends DDSpecification {
 
   def "JMX - executeDiagnosticCommand"() {
     setup:
-    Assume.assumeFalse(System.getProperty("java.specification.version") == "1.7")
+    def vmVersion = System.getProperty("java.specification.version")
+    def vmVendor = System.getProperty("java.vendor")
+    Assume.assumeFalse(vmVersion == "1.7")
+    Assume.assumeFalse(vmVersion == "1.8" && vmVendor.contains("IBM"))
     ConfigUtils.updateConfig {
       System.properties.setProperty("dd.${Config.PROFILING_ENABLED}", "true")
     }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/util/SystemAccessTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/util/SystemAccessTest.groovy
@@ -3,6 +3,7 @@ package datadog.trace.core.util
 import datadog.trace.agent.test.utils.ConfigUtils
 import datadog.trace.api.Config
 import datadog.trace.util.test.DDSpecification
+import org.junit.Assume
 
 import java.lang.management.ManagementFactory
 
@@ -148,6 +149,7 @@ class SystemAccessTest extends DDSpecification {
 
   def "JMX - executeDiagnosticCommand"() {
     setup:
+    Assume.assumeFalse(System.getProperty("java.specification.version") == "1.7")
     ConfigUtils.updateConfig {
       System.properties.setProperty("dd.${Config.PROFILING_ENABLED}", "true")
     }


### PR DESCRIPTION
Change Overview
------------------

* sets JFR profiles to use a 256 stack depth by default
* respects user-supplied over-ride for max stack depth
* limits clients to a 1024 max stack depth
* jboss (wildfly) integration tests

Observations
------------------
Based on [benchmark results](https://docs.google.com/spreadsheets/d/1E0ZuxqwrLXIK0w0n6n6ZZ9ASZ029lToB04SWK7OAW_I/edit#gid=831612831) there is little overhead increasing the `stackdepth` and not truncating typical java web application stacks, which can be regularly greater than 128.

Due to quirks in JFR initialization ([one-shot per JVM, sampling thread started as a side-effect of setting the sampling interval](https://github.com/openjdk/jdk/blob/e0cf023263fcd8ad5c8235828e025c5842807bfe/src/hotspot/share/jfr/periodic/sampling/jfrThreadSampler.cpp#L596)) and issues initializing JMX in some environments, there is a small window in which the agent can set `JFR.configure stackdepth`
1. before profiling starts
2. after JMX is initialized

As a result, it's possible the agent may fail to set `stackdepth` appropriately in some environments.  That occurrence is logged for diagnostic purposes.  The product will still function as before but some clients may get a warning in the analysis tab (as they do today) that their stacks were truncated with mediation steps.

[PROF-1988]

[PROF-1988]: https://datadoghq.atlassian.net/browse/PROF-1988