### PR TITLE
Don't treat dispatch servlet spans as top level

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
@@ -15,6 +15,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public abstract class HttpServerDecorator<REQUEST, CONNECTION, RESPONSE> extends ServerDecorator {
   public static final String DD_SPAN_ATTRIBUTE = "datadog.span";
+  public static final String DD_DISPATCH_SPAN_ATTRIBUTE = "datadog.span.dispatch";
   public static final String DD_RESPONSE_ATTRIBUTE = "datadog.response";
 
   // Source: https://www.regextester.com/22

--- a/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/AsyncContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/AsyncContextInstrumentation.java
@@ -3,6 +3,7 @@ package datadog.trace.instrumentation.servlet3;
 import static datadog.trace.agent.tooling.ClassLoaderMatcher.hasClassesNamed;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers.implementsInterface;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
+import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.DD_DISPATCH_SPAN_ATTRIBUTE;
 import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.DD_SPAN_ATTRIBUTE;
 import static datadog.trace.instrumentation.servlet3.HttpServletRequestInjectAdapter.SETTER;
 import static java.util.Collections.singletonMap;
@@ -78,6 +79,8 @@ public final class AsyncContextInstrumentation extends Instrumenter.Default {
         if (request instanceof HttpServletRequest) {
           propagate().inject(span, (HttpServletRequest) request, SETTER);
         }
+
+        request.setAttribute(DD_DISPATCH_SPAN_ATTRIBUTE, span);
         final String path;
         if (args.length == 1 && args[0] instanceof String) {
           path = (String) args[0];

--- a/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/AbstractServlet3Test.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/AbstractServlet3Test.groovy
@@ -3,6 +3,7 @@ import datadog.trace.agent.test.base.HttpServerTest
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import datadog.trace.bootstrap.instrumentation.api.Tags
+import datadog.trace.core.DDSpan
 import datadog.trace.instrumentation.servlet3.Servlet3Decorator
 import okhttp3.Request
 import okhttp3.RequestBody
@@ -21,7 +22,11 @@ import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.TIMEOU
 abstract class AbstractServlet3Test<SERVER, CONTEXT> extends HttpServerTest<SERVER> {
   @Override
   URI buildAddress() {
-    return new URI("http://localhost:$port/$context/")
+    if (dispatch) {
+      return new URI("http://localhost:$port/$context/dispatch/")
+    } else {
+      return new URI("http://localhost:$port/$context/")
+    }
   }
 
   @Override
@@ -37,6 +42,14 @@ abstract class AbstractServlet3Test<SERVER, CONTEXT> extends HttpServerTest<SERV
   @Override
   String expectedOperationName() {
     return "servlet.request"
+  }
+
+  boolean hasHandlerSpan() {
+    return isDispatch()
+  }
+
+  boolean isDispatch() {
+    return false
   }
 
   // FIXME: Add authentication tests back in...
@@ -74,8 +87,52 @@ abstract class AbstractServlet3Test<SERVER, CONTEXT> extends HttpServerTest<SERV
     super.request(uri, method, body)
   }
 
+  // Almost identical to serverSpan()
+  @Override
+  void handlerSpan(TraceAssert trace, Object parent, ServerEndpoint endpoint = SUCCESS) {
+    if (!isDispatch()) {
+      throw new UnsupportedOperationException("handlerSpan not applicable for nondispatch")
+    }
+
+    trace.span {
+      serviceName expectedServiceName()
+      operationName expectedOperationName()
+      resourceName endpoint.status == 404 ? "404" : "GET ${endpoint.resolve(address).path.replace("/dispatch", "")}"
+      spanType DDSpanTypes.HTTP_SERVER
+      errored endpoint.errored
+      childOf(parent as DDSpan)
+      tags {
+        "$Tags.COMPONENT" component
+        "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
+        "$Tags.PEER_HOST_IPV4" { it == null || it == "127.0.0.1" } // Optional
+        "$Tags.PEER_PORT" Integer
+        "$Tags.HTTP_URL" "${endpoint.resolve(address)}".replace("/dispatch", "")
+        "$Tags.HTTP_METHOD" "GET"
+        if (endpoint.status > 0) {
+          "$Tags.HTTP_STATUS" endpoint.status
+        } else {
+          "timeout" 1_000
+        }
+        if (context) {
+          "servlet.context" "/$context"
+        }
+        "servlet.path" endpoint.status == 404 ? endpoint.path : "$endpoint.path".replace("/dispatch", "")
+        if (endpoint.errored) {
+          "error.msg" { it == null || it == EXCEPTION.body }
+          "error.type" { it == null || it == Exception.name }
+          "error.stack" { it == null || it instanceof String }
+        }
+        if (endpoint.query) {
+          "$DDTags.HTTP_QUERY" endpoint.query
+        }
+        defaultTags()
+      }
+    }
+  }
+
   @Override
   void serverSpan(TraceAssert trace, BigInteger traceID = null, BigInteger parentID = null, String method = "GET", ServerEndpoint endpoint = SUCCESS) {
+    def dispatch = isDispatch()
     trace.span {
       serviceName expectedServiceName()
       operationName expectedOperationName()
@@ -103,7 +160,14 @@ abstract class AbstractServlet3Test<SERVER, CONTEXT> extends HttpServerTest<SERV
         if (context) {
           "servlet.context" "/$context"
         }
-        "servlet.path" { it == endpoint.path || it == "/dispatch$endpoint.path" }
+
+        if (dispatch) {
+          "servlet.path" endpoint.status == 404 ? endpoint.path : "/dispatch$endpoint.path"
+          "servlet.dispatch" endpoint.path
+        } else {
+          "servlet.path" endpoint.path
+        }
+
         if (endpoint.errored) {
           "error.msg" { it == null || it == EXCEPTION.body }
           "error.type" { it == null || it == Exception.name }

--- a/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/AbstractServlet3Test.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/AbstractServlet3Test.groovy
@@ -24,9 +24,9 @@ abstract class AbstractServlet3Test<SERVER, CONTEXT> extends HttpServerTest<SERV
   URI buildAddress() {
     if (dispatch) {
       return new URI("http://localhost:$port/$context/dispatch/")
-    } else {
-      return new URI("http://localhost:$port/$context/")
     }
+
+    return new URI("http://localhost:$port/$context/")
   }
 
   @Override

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
@@ -242,6 +242,7 @@ abstract class HttpServerTest<SERVER> extends AgentTestRunner {
       (1..count).eachWithIndex { val, i ->
         if (hasHandlerSpan()) {
           trace(3) {
+            sortSpansByStart()
             serverSpan(it)
             handlerSpan(it, span(0))
             controllerSpan(it, span(1))
@@ -279,6 +280,7 @@ abstract class HttpServerTest<SERVER> extends AgentTestRunner {
     cleanAndAssertTraces(1) {
       if (hasHandlerSpan()) {
         trace(3) {
+          sortSpansByStart()
           serverSpan(it, traceId, parentId)
           handlerSpan(it, span(0))
           controllerSpan(it, span(1))
@@ -311,6 +313,7 @@ abstract class HttpServerTest<SERVER> extends AgentTestRunner {
     cleanAndAssertTraces(1) {
       if (hasHandlerSpan()) {
         trace(3) {
+          sortSpansByStart()
           serverSpan(it, null, null, "GET", endpoint)
           handlerSpan(it, span(0), endpoint)
           controllerSpan(it, span(1))
@@ -343,6 +346,7 @@ abstract class HttpServerTest<SERVER> extends AgentTestRunner {
     cleanAndAssertTraces(1) {
       if (hasHandlerSpan()) {
         trace(3) {
+          sortSpansByStart()
           serverSpan(it, null, null, method, PATH_PARAM)
           handlerSpan(it, span(0), PATH_PARAM)
           controllerSpan(it, span(1))
@@ -379,6 +383,7 @@ abstract class HttpServerTest<SERVER> extends AgentTestRunner {
     cleanAndAssertTraces(1) {
       if (hasHandlerSpan()) {
         trace(3) {
+          sortSpansByStart()
           serverSpan(it, traceId, parentId)
           handlerSpan(it, span(0))
           controllerSpan(it, span(1))
@@ -411,6 +416,7 @@ abstract class HttpServerTest<SERVER> extends AgentTestRunner {
     cleanAndAssertTraces(1) {
       if (hasHandlerSpan()) {
         trace(3) {
+          sortSpansByStart()
           serverSpan(it, null, null, method, REDIRECT)
           handlerSpan(it, span(0), REDIRECT)
           controllerSpan(it, span(1))
@@ -441,6 +447,7 @@ abstract class HttpServerTest<SERVER> extends AgentTestRunner {
     cleanAndAssertTraces(1) {
       if (hasHandlerSpan()) {
         trace(3) {
+          sortSpansByStart()
           serverSpan(it, null, null, method, ERROR)
           handlerSpan(it, span(0), ERROR)
           controllerSpan(it, span(1))
@@ -474,6 +481,7 @@ abstract class HttpServerTest<SERVER> extends AgentTestRunner {
     cleanAndAssertTraces(1) {
       if (hasHandlerSpan()) {
         trace(3) {
+          sortSpansByStart()
           serverSpan(it, null, null, method, EXCEPTION)
           handlerSpan(it, span(0), EXCEPTION)
           controllerSpan(it, span(1), EXCEPTION.body)
@@ -504,6 +512,7 @@ abstract class HttpServerTest<SERVER> extends AgentTestRunner {
     cleanAndAssertTraces(1) {
       if (hasHandlerSpan()) {
         trace(2) {
+          sortSpansByStart()
           serverSpan(it, null, null, method, NOT_FOUND)
           handlerSpan(it, span(0), NOT_FOUND)
         }
@@ -535,6 +544,7 @@ abstract class HttpServerTest<SERVER> extends AgentTestRunner {
     cleanAndAssertTraces(1) {
       if (hasHandlerSpan()) {
         trace(3) {
+          sortSpansByStart()
           serverSpan(it, null, null, method, TIMEOUT)
           handlerSpan(it, span(0), TIMEOUT)
           controllerSpan(it, span(1))
@@ -566,6 +576,7 @@ abstract class HttpServerTest<SERVER> extends AgentTestRunner {
     cleanAndAssertTraces(1) {
       if (hasHandlerSpan()) {
         trace(3) {
+          sortSpansByStart()
           serverSpan(it, null, null, method, TIMEOUT_ERROR)
           handlerSpan(it, span(0), TIMEOUT_ERROR)
           controllerSpan(it, span(1))


### PR DESCRIPTION
Previously, when using dispatch, propagation information was passed from the dispatching servlet to the dispatched servlet through HTTP headers.  Using this mechanism, the new servlet span was a "top level" span creating 2 toplevel spans in the trace.  This treatment was incorrect as the new servlet request is just a continuation of the same local trace.

To change the behavior, I use `DD_DISPATCH_SPAN_ATTRIBUTE` to pass the span from the dispatching servlet to the dispatched servlet.

For the tests, things are simplified somewhat.  The dispatching servlet is the `serverSpan` and the dispatched servlet is the `handlerSpan`.

I'll create another pull request to make span sorting the default.  For this pull request, I made minimal additions to get these tests to pass.