### PR TITLE
Add file size limit to agent jar

### DIFF
--- a/dd-java-agent/dd-java-agent.gradle
+++ b/dd-java-agent/dd-java-agent.gradle
@@ -152,3 +152,15 @@ tasks.withType(Test).configureEach {
 
   dependsOn shadowJar
 }
+
+task('checkAgentJarSize') {
+  doLast {
+    // Arbitrary limit to prevent unintentional increases to the agent jar size
+    // Raise or lower as required
+    assert shadowJar.archiveFile.get().getAsFile().length() < 16 * 1024 * 1024
+  }
+
+  dependsOn shadowJar
+}
+
+check.dependsOn 'checkAgentJarSize'


### PR DESCRIPTION
Add a limit to the agent jar to prevent accidental inclusions like #1810 (fixed with #1900 )

Current jar size is ~14-15 MB.  The limit is 16MB