### PR TITLE
Add `peer.hostname` to database spans

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/DatabaseClientDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/DatabaseClientDecorator.java
@@ -26,6 +26,8 @@ public abstract class DatabaseClientDecorator<CONNECTION> extends ClientDecorato
 
   protected abstract String dbInstance(CONNECTION connection);
 
+  protected abstract String dbHostname(CONNECTION connection);
+
   /**
    * This should be called when the connection is being used, not when it's created.
    *
@@ -42,6 +44,11 @@ public abstract class DatabaseClientDecorator<CONNECTION> extends ClientDecorato
 
       if (instanceName != null && Config.get().isDbClientSplitByInstance()) {
         span.setTag(DDTags.SERVICE_NAME, instanceName);
+      }
+
+      String hostName = dbHostname(connection);
+      if (hostName != null) {
+        span.setTag(Tags.PEER_HOSTNAME, dbHostname(connection));
       }
     }
     return span;

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/DatabaseClientDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/DatabaseClientDecorator.java
@@ -26,7 +26,7 @@ public abstract class DatabaseClientDecorator<CONNECTION> extends ClientDecorato
 
   protected abstract String dbInstance(CONNECTION connection);
 
-  protected abstract String dbHostname(CONNECTION connection);
+  protected abstract CharSequence dbHostname(CONNECTION connection);
 
   /**
    * This should be called when the connection is being used, not when it's created.
@@ -46,9 +46,9 @@ public abstract class DatabaseClientDecorator<CONNECTION> extends ClientDecorato
         span.setTag(DDTags.SERVICE_NAME, instanceName);
       }
 
-      String hostName = dbHostname(connection);
+      CharSequence hostName = dbHostname(connection);
       if (hostName != null) {
-        span.setTag(Tags.PEER_HOSTNAME, dbHostname(connection));
+        span.setTag(Tags.PEER_HOSTNAME, hostName);
       }
     }
     return span;

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/DBTypeProcessingDatabaseClientDecoratorTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/DBTypeProcessingDatabaseClientDecoratorTest.groovy
@@ -71,6 +71,11 @@ class DBTypeProcessingDatabaseClientDecoratorTest extends ClientDecoratorTest {
         return map.instance
       }
 
+      @Override
+      protected String dbHostname(Map map) {
+        return map.hostname
+      }
+
       protected boolean traceAnalyticsDefault() {
         return true
       }

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/DatabaseClientDecoratorTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/DatabaseClientDecoratorTest.groovy
@@ -45,6 +45,9 @@ class DatabaseClientDecoratorTest extends ClientDecoratorTest {
     if (session) {
       1 * span.setTag(Tags.DB_USER, session.user)
       1 * span.setTag(Tags.DB_INSTANCE, session.instance)
+      if (session.hostname != null) {
+        1 * span.setTag(Tags.PEER_HOSTNAME, session.hostname)
+      }
       if (renameService && session.instance) {
         1 * span.setTag(DDTags.SERVICE_NAME, session.instance)
       }
@@ -54,8 +57,8 @@ class DatabaseClientDecoratorTest extends ClientDecoratorTest {
     where:
     renameService | session
     false         | null
-    true          | [user: "test-user"]
-    false         | [instance: "test-instance"]
+    true          | [user: "test-user", hostname: "test-hostname"]
+    false         | [instance: "test-instance", hostname: "test-hostname"]
     true          | [user: "test-user", instance: "test-instance"]
   }
 
@@ -136,6 +139,11 @@ class DatabaseClientDecoratorTest extends ClientDecoratorTest {
       @Override
       protected String dbInstance(Map map) {
         return map.instance
+      }
+
+      @Override
+      protected String dbHostname(Map map) {
+        return map.hostname
       }
 
       protected boolean traceAnalyticsDefault() {

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/OrmClientDecoratorTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/OrmClientDecoratorTest.groovy
@@ -59,6 +59,11 @@ class OrmClientDecoratorTest extends DatabaseClientDecoratorTest {
       }
 
       @Override
+      protected String dbHostname(Object o) {
+        return "test-hostname"
+      }
+
+      @Override
       protected String service() {
         return "test-service"
       }

--- a/dd-java-agent/instrumentation/couchbase-2.0/src/main/java/datadog/trace/instrumentation/couchbase/client/CouchbaseClientDecorator.java
+++ b/dd-java-agent/instrumentation/couchbase-2.0/src/main/java/datadog/trace/instrumentation/couchbase/client/CouchbaseClientDecorator.java
@@ -54,4 +54,9 @@ class CouchbaseClientDecorator extends DatabaseClientDecorator {
   protected String dbInstance(final Object o) {
     return null;
   }
+
+  @Override
+  protected String dbHostname(Object o) {
+    return null;
+  }
 }

--- a/dd-java-agent/instrumentation/datastax-cassandra-3/src/main/java/datadog/trace/instrumentation/datastax/cassandra/CassandraClientDecorator.java
+++ b/dd-java-agent/instrumentation/datastax-cassandra-3/src/main/java/datadog/trace/instrumentation/datastax/cassandra/CassandraClientDecorator.java
@@ -53,6 +53,12 @@ public class CassandraClientDecorator extends DBTypeProcessingDatabaseClientDeco
     return session.getLoggedKeyspace();
   }
 
+  @Override
+  protected String dbHostname(Session session) {
+    // Getting hostname through session.getState() seems to be expensive
+    return null;
+  }
+
   public AgentSpan onResponse(final AgentSpan span, final ResultSet result) {
     if (result != null) {
       final Host host = result.getExecutionInfo().getQueriedHost();

--- a/dd-java-agent/instrumentation/elasticsearch/src/main/java/datadog/trace/instrumentation/elasticsearch/ElasticsearchRestClientDecorator.java
+++ b/dd-java-agent/instrumentation/elasticsearch/src/main/java/datadog/trace/instrumentation/elasticsearch/ElasticsearchRestClientDecorator.java
@@ -61,6 +61,11 @@ public class ElasticsearchRestClientDecorator extends DatabaseClientDecorator {
     return null;
   }
 
+  @Override
+  protected String dbHostname(Object o) {
+    return null;
+  }
+
   public AgentSpan onRequest(final AgentSpan span, final String method, final String endpoint) {
     span.setTag(Tags.HTTP_METHOD, method);
     span.setTag(Tags.HTTP_URL, endpoint);

--- a/dd-java-agent/instrumentation/elasticsearch/src/main/java/datadog/trace/instrumentation/elasticsearch/ElasticsearchTransportClientDecorator.java
+++ b/dd-java-agent/instrumentation/elasticsearch/src/main/java/datadog/trace/instrumentation/elasticsearch/ElasticsearchTransportClientDecorator.java
@@ -60,6 +60,11 @@ public class ElasticsearchTransportClientDecorator extends DatabaseClientDecorat
     return null;
   }
 
+  @Override
+  protected String dbHostname(Object o) {
+    return null;
+  }
+
   public AgentSpan onRequest(final AgentSpan span, final Class action, final Class request) {
     if (action != null) {
       span.setTag(DDTags.RESOURCE_NAME, action.getSimpleName());

--- a/dd-java-agent/instrumentation/hibernate/src/main/java/datadog/trace/instrumentation/hibernate/HibernateDecorator.java
+++ b/dd-java-agent/instrumentation/hibernate/src/main/java/datadog/trace/instrumentation/hibernate/HibernateDecorator.java
@@ -49,6 +49,11 @@ public class HibernateDecorator extends OrmClientDecorator {
   }
 
   @Override
+  protected String dbHostname(Object o) {
+    return null;
+  }
+
+  @Override
   public String entityName(final Object entity) {
     if (entity == null) {
       return null;

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/JDBCDecorator.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/JDBCDecorator.java
@@ -76,6 +76,11 @@ public class JDBCDecorator extends DatabaseClientDecorator<DBInfo> {
     }
   }
 
+  @Override
+  protected String dbHostname(final DBInfo info) {
+    return info.getHost();
+  }
+
   public AgentSpan onConnection(final AgentSpan span, final Connection connection) {
     DBInfo dbInfo = CONNECTION_INFO.get(connection);
     /**

--- a/dd-java-agent/instrumentation/jedis-1.4/src/main/java/datadog/trace/instrumentation/jedis/JedisClientDecorator.java
+++ b/dd-java-agent/instrumentation/jedis-1.4/src/main/java/datadog/trace/instrumentation/jedis/JedisClientDecorator.java
@@ -45,4 +45,9 @@ public class JedisClientDecorator
   protected String dbInstance(final Protocol.Command session) {
     return null;
   }
+
+  @Override
+  protected String dbHostname(Protocol.Command command) {
+    return null;
+  }
 }

--- a/dd-java-agent/instrumentation/jedis-3.0/src/main/java/datadog/trace/instrumentation/jedis30/JedisClientDecorator.java
+++ b/dd-java-agent/instrumentation/jedis-3.0/src/main/java/datadog/trace/instrumentation/jedis30/JedisClientDecorator.java
@@ -47,4 +47,9 @@ public class JedisClientDecorator extends DBTypeProcessingDatabaseClientDecorato
   protected String dbInstance(final ProtocolCommand session) {
     return null;
   }
+
+  @Override
+  protected String dbHostname(ProtocolCommand protocolCommand) {
+    return null;
+  }
 }

--- a/dd-java-agent/instrumentation/lettuce-4/src/main/java8/datadog/trace/instrumentation/lettuce4/LettuceClientDecorator.java
+++ b/dd-java-agent/instrumentation/lettuce-4/src/main/java8/datadog/trace/instrumentation/lettuce4/LettuceClientDecorator.java
@@ -54,6 +54,11 @@ public class LettuceClientDecorator extends DBTypeProcessingDatabaseClientDecora
   }
 
   @Override
+  protected String dbHostname(RedisURI redisURI) {
+    return redisURI.getHost();
+  }
+
+  @Override
   public AgentSpan onConnection(final AgentSpan span, final RedisURI connection) {
     if (connection != null) {
       span.setTag(Tags.PEER_HOSTNAME, connection.getHost());

--- a/dd-java-agent/instrumentation/lettuce-5/src/main/java8/datadog/trace/instrumentation/lettuce5/LettuceClientDecorator.java
+++ b/dd-java-agent/instrumentation/lettuce-5/src/main/java8/datadog/trace/instrumentation/lettuce5/LettuceClientDecorator.java
@@ -50,6 +50,11 @@ public class LettuceClientDecorator extends DBTypeProcessingDatabaseClientDecora
   }
 
   @Override
+  protected String dbHostname(RedisURI redisURI) {
+    return redisURI.getHost();
+  }
+
+  @Override
   public AgentSpan onConnection(final AgentSpan span, final RedisURI connection) {
     if (connection != null) {
       span.setTag(Tags.PEER_HOSTNAME, connection.getHost());

--- a/dd-java-agent/instrumentation/mongo/driver-3.1/src/main/java/datadog/trace/instrumentation/mongo/MongoClientDecorator.java
+++ b/dd-java-agent/instrumentation/mongo/driver-3.1/src/main/java/datadog/trace/instrumentation/mongo/MongoClientDecorator.java
@@ -78,6 +78,16 @@ public class MongoClientDecorator
     return event.getDatabaseName();
   }
 
+  @Override
+  protected String dbHostname(CommandStartedEvent event) {
+    final ConnectionDescription connectionDescription = event.getConnectionDescription();
+    if (connectionDescription != null) {
+      return connectionDescription.getServerAddress().getHost();
+    }
+
+    return null;
+  }
+
   public AgentSpan onStatement(final AgentSpan span, final BsonDocument statement) {
 
     // scrub the Mongo command so that parameters are removed from the string

--- a/dd-java-agent/instrumentation/rediscala-1.8.0/src/main/java/datadog/trace/instrumentation/rediscala/RediscalaClientDecorator.java
+++ b/dd-java-agent/instrumentation/rediscala-1.8.0/src/main/java/datadog/trace/instrumentation/rediscala/RediscalaClientDecorator.java
@@ -51,4 +51,9 @@ public class RediscalaClientDecorator
   protected String dbInstance(final RedisCommand<? extends RedisReply, ?> session) {
     return null;
   }
+
+  @Override
+  protected String dbHostname(RedisCommand<? extends RedisReply, ?> redisCommand) {
+    return null;
+  }
 }

--- a/dd-java-agent/instrumentation/spymemcached-2.12/src/main/java/datadog/trace/instrumentation/spymemcached/MemcacheClientDecorator.java
+++ b/dd-java-agent/instrumentation/spymemcached-2.12/src/main/java/datadog/trace/instrumentation/spymemcached/MemcacheClientDecorator.java
@@ -48,6 +48,11 @@ public class MemcacheClientDecorator
     return null;
   }
 
+  @Override
+  protected String dbHostname(MemcachedConnection connection) {
+    return null;
+  }
+
   public AgentSpan onOperation(final AgentSpan span, final String methodName) {
 
     final char[] chars =


### PR DESCRIPTION
Adds `peer.hostname` to database spans, specifically JDBC.

In other instances, where hostname was immediately available, I also added it.  Many of the decorators (eg `jedis`) are generic on the wrong type, or generic on `Object`.  These can be fixed in another pull request.