### PR TITLE
fix akka/scala FJP internal push context propagation

### DIFF
--- a/dd-java-agent/instrumentation/akka-concurrent/src/main/java/datadog/trace/instrumentation/akka/concurrent/AkkaForkJoinPoolInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-concurrent/src/main/java/datadog/trace/instrumentation/akka/concurrent/AkkaForkJoinPoolInstrumentation.java
@@ -1,22 +1,19 @@
 package datadog.trace.instrumentation.akka.concurrent;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
-import static net.bytebuddy.matcher.ElementMatchers.nameMatches;
+import static java.util.Collections.singletonMap;
+import static net.bytebuddy.matcher.ElementMatchers.isFinal;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.named;
-import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import akka.dispatch.forkjoin.ForkJoinTask;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
-import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.InstrumentationContext;
-import datadog.trace.bootstrap.instrumentation.java.concurrent.ExecutorInstrumentationUtils;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.State;
 import datadog.trace.context.TraceScope;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.Executor;
 import lombok.extern.slf4j.Slf4j;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.method.MethodDescription;
@@ -32,61 +29,31 @@ public final class AkkaForkJoinPoolInstrumentation extends Instrumenter.Default 
   }
 
   @Override
-  public ElementMatcher<ClassLoader> classLoaderMatcher() {
-    return AkkaForkJoinTaskInstrumentation.CLASS_LOADER_MATCHER;
-  }
-
-  @Override
-  public ElementMatcher<TypeDescription> typeMatcher() {
-    // This might need to be an extendsClass matcher...
+  public ElementMatcher<? super TypeDescription> typeMatcher() {
     return named("akka.dispatch.forkjoin.ForkJoinPool");
   }
 
   @Override
   public Map<String, String> contextStore() {
-    return Collections.singletonMap(
-        AkkaForkJoinTaskInstrumentation.TASK_CLASS_NAME, State.class.getName());
+    return singletonMap("akka.dispatch.forkjoin.ForkJoinTask", State.class.getName());
   }
 
   @Override
   public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
-    final Map<ElementMatcher<? super MethodDescription>, String> transformers = new HashMap<>();
-    transformers.put(
-        named("execute")
-            .and(takesArgument(0, named(AkkaForkJoinTaskInstrumentation.TASK_CLASS_NAME))),
-        AkkaForkJoinPoolInstrumentation.class.getName() + "$SetAkkaForkJoinStateAdvice");
-    transformers.put(
-        named("submit")
-            .and(takesArgument(0, named(AkkaForkJoinTaskInstrumentation.TASK_CLASS_NAME))),
-        AkkaForkJoinPoolInstrumentation.class.getName() + "$SetAkkaForkJoinStateAdvice");
-    transformers.put(
-        nameMatches("invoke")
-            .and(takesArgument(0, named(AkkaForkJoinTaskInstrumentation.TASK_CLASS_NAME))),
-        AkkaForkJoinPoolInstrumentation.class.getName() + "$SetAkkaForkJoinStateAdvice");
-    return transformers;
+    return Collections.singletonMap(
+        isMethod().and(named("externalPush")).and(isFinal()),
+        getClass().getName() + "$ExternalPush");
   }
 
-  public static class SetAkkaForkJoinStateAdvice {
-
-    @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static State enterJobSubmit(
-        @Advice.This final Executor executor,
-        @Advice.Argument(value = 0, readOnly = false) final ForkJoinTask task) {
-      final TraceScope scope = activeScope();
-      if (ExecutorInstrumentationUtils.shouldAttachStateToTask(task, executor)) {
-        final ContextStore<ForkJoinTask, State> contextStore =
-            InstrumentationContext.get(ForkJoinTask.class, State.class);
-        return ExecutorInstrumentationUtils.setupState(contextStore, task, scope);
+  public static final class ExternalPush {
+    @Advice.OnMethodEnter
+    public static <T> void externalPush(@Advice.Argument(0) ForkJoinTask<T> task) {
+      TraceScope activeScope = activeScope();
+      if (null != activeScope) {
+        InstrumentationContext.get(ForkJoinTask.class, State.class)
+            .putIfAbsent(task, State.FACTORY)
+            .captureAndSetContinuation(activeScope);
       }
-      return null;
-    }
-
-    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
-    public static void exitJobSubmit(
-        @Advice.This final Executor executor,
-        @Advice.Enter final State state,
-        @Advice.Thrown final Throwable throwable) {
-      ExecutorInstrumentationUtils.cleanUpOnMethodExit(executor, state, throwable);
     }
   }
 }

--- a/dd-java-agent/instrumentation/akka-concurrent/src/main/java/datadog/trace/instrumentation/akka/concurrent/AkkaForkJoinTaskInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-concurrent/src/main/java/datadog/trace/instrumentation/akka/concurrent/AkkaForkJoinTaskInstrumentation.java
@@ -65,7 +65,7 @@ public final class AkkaForkJoinTaskInstrumentation extends Instrumenter.Default 
       return null;
     }
 
-    @Advice.OnMethodExit
+    @Advice.OnMethodExit(onThrowable = Throwable.class)
     public static void after(@Advice.Enter TraceScope scope) {
       if (null != scope) {
         scope.close();
@@ -86,7 +86,7 @@ public final class AkkaForkJoinTaskInstrumentation extends Instrumenter.Default 
   }
 
   public static final class Cancel {
-    @Advice.OnMethodExit
+    @Advice.OnMethodExit(onThrowable = Throwable.class)
     public static <T> void cancel(@Advice.This ForkJoinTask<T> task) {
       State state = InstrumentationContext.get(ForkJoinTask.class, State.class).get(task);
       if (null != state) {

--- a/dd-java-agent/instrumentation/akka-concurrent/src/main/java/datadog/trace/instrumentation/akka/concurrent/AkkaForkJoinTaskInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-concurrent/src/main/java/datadog/trace/instrumentation/akka/concurrent/AkkaForkJoinTaskInstrumentation.java
@@ -1,26 +1,18 @@
 package datadog.trace.instrumentation.akka.concurrent;
 
-import static datadog.trace.agent.tooling.ClassLoaderMatcher.hasClassesNamed;
-import static datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers.extendsClass;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
 import static java.util.Collections.singletonMap;
-import static net.bytebuddy.matcher.ElementMatchers.isAbstract;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.named;
-import static net.bytebuddy.matcher.ElementMatchers.not;
-import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
-import akka.dispatch.forkjoin.ForkJoinPool;
 import akka.dispatch.forkjoin.ForkJoinTask;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
-import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.InstrumentationContext;
-import datadog.trace.bootstrap.instrumentation.java.concurrent.AdviceUtils;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.State;
 import datadog.trace.context.TraceScope;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.Callable;
 import lombok.extern.slf4j.Slf4j;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.method.MethodDescription;
@@ -37,90 +29,69 @@ import net.bytebuddy.matcher.ElementMatcher;
 @AutoService(Instrumenter.class)
 public final class AkkaForkJoinTaskInstrumentation extends Instrumenter.Default {
 
-  static final String TASK_CLASS_NAME = "akka.dispatch.forkjoin.ForkJoinTask";
-
-  static final ElementMatcher<ClassLoader> CLASS_LOADER_MATCHER = hasClassesNamed(TASK_CLASS_NAME);
-
   public AkkaForkJoinTaskInstrumentation() {
     super("java_concurrent", "akka_concurrent");
   }
 
   @Override
-  public ElementMatcher<ClassLoader> classLoaderMatcher() {
-    // Optimization for expensive typeMatcher.
-    return CLASS_LOADER_MATCHER;
-  }
-
-  @Override
-  public ElementMatcher<TypeDescription> typeMatcher() {
-    return extendsClass(named(TASK_CLASS_NAME));
-  }
-
-  @Override
   public Map<String, String> contextStore() {
-    return singletonMap(TASK_CLASS_NAME, State.class.getName());
+    return singletonMap("akka.dispatch.forkjoin.ForkJoinTask", State.class.getName());
   }
 
   @Override
-  public Map<String, String> contextStoreForAll() {
-    final Map<String, String> map = new HashMap<>();
-    map.put(Runnable.class.getName(), State.class.getName());
-    map.put(Callable.class.getName(), State.class.getName());
-    return Collections.unmodifiableMap(map);
+  public ElementMatcher<? super TypeDescription> typeMatcher() {
+    return named("akka.dispatch.forkjoin.ForkJoinTask");
   }
 
   @Override
   public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
-    return singletonMap(
-        named("exec").and(takesArguments(0)).and(not(isAbstract())),
-        AkkaForkJoinTaskInstrumentation.class.getName() + "$ForkJoinTaskAdvice");
+    Map<ElementMatcher<MethodDescription>, String> transformers = new HashMap<>(4);
+    transformers.put(isMethod().and(named("doExec")), getClass().getName() + "$DoExec");
+    transformers.put(isMethod().and(named("fork")), getClass().getName() + "$Fork");
+    transformers.put(isMethod().and(named("cancel")), getClass().getName() + "$Cancel");
+    return transformers;
   }
 
-  public static class ForkJoinTaskAdvice {
-
-    /**
-     * When {@link ForkJoinTask} object is submitted to {@link ForkJoinPool} as {@link Runnable} or
-     * {@link Callable} it will not get wrapped, instead it will be casted to {@code ForkJoinTask}
-     * directly. This means state is still stored in {@code Runnable} or {@code Callable} and we
-     * need to use that state.
-     */
-    @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static TraceScope enter(@Advice.This final ForkJoinTask thiz) {
-      final ContextStore<ForkJoinTask, State> contextStore =
-          InstrumentationContext.get(ForkJoinTask.class, State.class);
-      TraceScope scope = AdviceUtils.startTaskScope(contextStore, thiz);
-      if (thiz instanceof Runnable) {
-        final ContextStore<Runnable, State> runnableContextStore =
-            InstrumentationContext.get(Runnable.class, State.class);
-        final TraceScope newScope =
-            AdviceUtils.startTaskScope(runnableContextStore, (Runnable) thiz);
-        if (null != newScope) {
-          if (null != scope) {
-            newScope.close();
-          } else {
-            scope = newScope;
-          }
+  public static final class DoExec {
+    @Advice.OnMethodEnter
+    public static <T> TraceScope before(@Advice.This ForkJoinTask<T> task) {
+      State state = InstrumentationContext.get(ForkJoinTask.class, State.class).get(task);
+      if (null != state) {
+        TraceScope.Continuation continuation = state.getAndResetContinuation();
+        if (null != continuation) {
+          return continuation.activate();
         }
       }
-      if (thiz instanceof Callable) {
-        final ContextStore<Callable, State> callableContextStore =
-            InstrumentationContext.get(Callable.class, State.class);
-        final TraceScope newScope =
-            AdviceUtils.startTaskScope(callableContextStore, (Callable) thiz);
-        if (null != newScope) {
-          if (null != scope) {
-            newScope.close();
-          } else {
-            scope = newScope;
-          }
-        }
-      }
-      return scope;
+      return null;
     }
 
-    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
-    public static void exit(@Advice.Enter final TraceScope scope) {
-      AdviceUtils.endTaskScope(scope);
+    @Advice.OnMethodExit
+    public static void after(@Advice.Enter TraceScope scope) {
+      if (null != scope) {
+        scope.close();
+      }
+    }
+  }
+
+  public static final class Fork {
+    @Advice.OnMethodEnter
+    public static <T> void fork(@Advice.This ForkJoinTask<T> task) {
+      TraceScope activeScope = activeScope();
+      if (null != activeScope) {
+        InstrumentationContext.get(ForkJoinTask.class, State.class)
+            .putIfAbsent(task, State.FACTORY)
+            .captureAndSetContinuation(activeScope);
+      }
+    }
+  }
+
+  public static final class Cancel {
+    @Advice.OnMethodExit
+    public static <T> void cancel(@Advice.This ForkJoinTask<T> task) {
+      State state = InstrumentationContext.get(ForkJoinTask.class, State.class).get(task);
+      if (null != state) {
+        state.closeContinuation();
+      }
     }
   }
 }

--- a/dd-java-agent/instrumentation/akka-concurrent/src/test/groovy/ForkJoinPoolPropagationTest.groovy
+++ b/dd-java-agent/instrumentation/akka-concurrent/src/test/groovy/ForkJoinPoolPropagationTest.groovy
@@ -1,0 +1,50 @@
+import akka.dispatch.forkjoin.ForkJoinPool
+import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.core.DDSpan
+
+class ForkJoinPoolPropagationTest extends AgentTestRunner {
+  def "test imbalanced recursive task propagation #parallelism FJP threads" () {
+    when:
+    ForkJoinPool fjp = new ForkJoinPool(parallelism)
+
+    Integer result = fjp.invoke(new LinearTask(depth))
+
+    then:
+    result == depth
+
+    TEST_WRITER.waitForTraces(1)
+    TEST_WRITER.size() == 1
+    List<DDSpan> trace = TEST_WRITER.get(0)
+    int i = 0
+    for (DDSpan span : trace) {
+      assert Integer.toString(++i) == span.getOperationName()
+    }
+    assert i == depth
+
+    cleanup:
+    fjp.shutdownNow()
+
+    where:
+    parallelism | depth
+    1           |    10
+    1           |    20
+    1           |    30
+    1           |    40
+    1           |    50
+    2           |    10
+    2           |    20
+    2           |    30
+    2           |    40
+    2           |    50
+    3           |    10
+    3           |    20
+    3           |    30
+    3           |    40
+    3           |    50
+    4           |    10
+    4           |    20
+    4           |    30
+    4           |    40
+    4           |    50
+  }
+}

--- a/dd-java-agent/instrumentation/akka-concurrent/src/test/java/LinearTask.java
+++ b/dd-java-agent/instrumentation/akka-concurrent/src/test/java/LinearTask.java
@@ -1,0 +1,45 @@
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+
+import akka.dispatch.forkjoin.RecursiveTask;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+
+public class LinearTask extends RecursiveTask<Integer> {
+  private final int depth;
+  private final int parent;
+
+  public LinearTask(int depth) {
+    this(0, depth);
+  }
+
+  private LinearTask(int parent, int depth) {
+    this.parent = parent;
+    this.depth = depth;
+  }
+
+  @Override
+  protected Integer compute() {
+    try {
+      // introduces delay to encourage parallelism
+      // which will expose problems with context propagation
+      Thread.sleep(5);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+    if (parent == depth) {
+      return parent;
+    } else {
+      int next = parent + 1;
+      AgentSpan span = startSpan(Integer.toString(next));
+      try (AgentScope scope = activateSpan(span)) {
+        // shouldn't be necessary with a decent API
+        scope.setAsyncPropagation(true);
+        LinearTask child = new LinearTask(next, depth);
+        return child.fork().join();
+      } finally {
+        span.finish();
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/AbstractExecutorInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/AbstractExecutorInstrumentation.java
@@ -50,7 +50,6 @@ public abstract class AbstractExecutorInstrumentation extends Instrumenter.Defau
         "akka.dispatch.Dispatcher",
         "akka.dispatch.Dispatcher$LazyExecutorServiceDelegate",
         "akka.dispatch.ExecutionContexts$sameThreadExecutionContext$",
-        "akka.dispatch.forkjoin.ForkJoinPool",
         "akka.dispatch.ForkJoinExecutorConfigurator$AkkaForkJoinPool",
         "akka.dispatch.MessageDispatcher",
         "akka.dispatch.PinnedDispatcher",

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/AbstractExecutorInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/AbstractExecutorInstrumentation.java
@@ -81,7 +81,6 @@ public abstract class AbstractExecutorInstrumentation extends Instrumenter.Defau
         "org.eclipse.jetty.util.thread.ReservedThreadExecutor",
         "org.glassfish.grizzly.threadpool.GrizzlyExecutorService",
         "play.api.libs.streams.Execution$trampoline$",
-        "scala.concurrent.forkjoin.ForkJoinPool",
         "scala.concurrent.Future$InternalCallbackExecutor$",
         "scala.concurrent.impl.ExecutionContextImpl",
       };

--- a/dd-java-agent/instrumentation/scala-concurrent/src/main/java/datadog/trace/instrumentation/scala/concurrent/ScalaForkJoinPoolInstrumentation.java
+++ b/dd-java-agent/instrumentation/scala-concurrent/src/main/java/datadog/trace/instrumentation/scala/concurrent/ScalaForkJoinPoolInstrumentation.java
@@ -1,21 +1,19 @@
 package datadog.trace.instrumentation.scala.concurrent;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
-import static net.bytebuddy.matcher.ElementMatchers.nameMatches;
+import static java.util.Collections.singletonMap;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.isPrivate;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
-import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.InstrumentationContext;
-import datadog.trace.bootstrap.instrumentation.java.concurrent.ExecutorInstrumentationUtils;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.State;
 import datadog.trace.context.TraceScope;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.Executor;
 import lombok.extern.slf4j.Slf4j;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.method.MethodDescription;
@@ -28,65 +26,45 @@ import scala.concurrent.forkjoin.ForkJoinTask;
 public final class ScalaForkJoinPoolInstrumentation extends Instrumenter.Default {
 
   public ScalaForkJoinPoolInstrumentation() {
-    super("java_concurrent", "akka_concurrent");
+    super("java_concurrent", "scala_concurrent");
   }
 
   @Override
-  public ElementMatcher<ClassLoader> classLoaderMatcher() {
-    return ScalaForkJoinTaskInstrumentation.CLASS_LOADER_MATCHER;
-  }
-
-  @Override
-  public ElementMatcher<TypeDescription> typeMatcher() {
-    // This might need to be an extendsClass matcher...
+  public ElementMatcher<? super TypeDescription> typeMatcher() {
     return named("scala.concurrent.forkjoin.ForkJoinPool");
   }
 
   @Override
   public Map<String, String> contextStore() {
-    return Collections.singletonMap(
-        ScalaForkJoinTaskInstrumentation.TASK_CLASS_NAME, State.class.getName());
+    return singletonMap("scala.concurrent.forkjoin.ForkJoinTask", State.class.getName());
   }
 
   @Override
   public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
-    final Map<ElementMatcher<? super MethodDescription>, String> transformers = new HashMap<>();
+    Map<ElementMatcher<MethodDescription>, String> transformers = new HashMap<>(4);
     transformers.put(
-        named("execute")
-            .and(takesArgument(0, named(ScalaForkJoinTaskInstrumentation.TASK_CLASS_NAME))),
-        ScalaForkJoinPoolInstrumentation.class.getName() + "$SetScalaForkJoinStateAdvice");
+        isMethod()
+            .and(named("doSubmit"))
+            .and(isPrivate())
+            .and(takesArgument(0, named("scala.concurrent.forkjoin.ForkJoinTask"))),
+        getClass().getName() + "$StartTask");
     transformers.put(
-        named("submit")
-            .and(takesArgument(0, named(ScalaForkJoinTaskInstrumentation.TASK_CLASS_NAME))),
-        ScalaForkJoinPoolInstrumentation.class.getName() + "$SetScalaForkJoinStateAdvice");
-    transformers.put(
-        nameMatches("invoke")
-            .and(takesArgument(0, named(ScalaForkJoinTaskInstrumentation.TASK_CLASS_NAME))),
-        ScalaForkJoinPoolInstrumentation.class.getName() + "$SetScalaForkJoinStateAdvice");
+        isMethod()
+            .and(named("externalPush"))
+            .and(takesArgument(0, named("scala.concurrent.forkjoin.ForkJoinTask"))),
+        getClass().getName() + "$StartTask");
     return transformers;
   }
 
-  public static class SetScalaForkJoinStateAdvice {
-
-    @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static State enterJobSubmit(
-        @Advice.This final Executor executor,
-        @Advice.Argument(value = 0, readOnly = false) final ForkJoinTask task) {
-      final TraceScope scope = activeScope();
-      if (ExecutorInstrumentationUtils.shouldAttachStateToTask(task, executor)) {
-        final ContextStore<ForkJoinTask, State> contextStore =
-            InstrumentationContext.get(ForkJoinTask.class, State.class);
-        return ExecutorInstrumentationUtils.setupState(contextStore, task, scope);
+  public static final class StartTask {
+    @Advice.OnMethodEnter
+    public static <T> void before(@Advice.Argument(0) ForkJoinTask<T> task) {
+      TraceScope activeScope = activeScope();
+      if (null != activeScope) {
+        InstrumentationContext.get(ForkJoinTask.class, State.class)
+            .putIfAbsent(task, State.FACTORY)
+            .captureAndSetContinuation(activeScope);
       }
-      return null;
-    }
-
-    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
-    public static void exitJobSubmit(
-        @Advice.This final Executor executor,
-        @Advice.Enter final State state,
-        @Advice.Thrown final Throwable throwable) {
-      ExecutorInstrumentationUtils.cleanUpOnMethodExit(executor, state, throwable);
     }
   }
 }

--- a/dd-java-agent/instrumentation/scala-concurrent/src/main/java/datadog/trace/instrumentation/scala/concurrent/ScalaForkJoinTaskInstrumentation.java
+++ b/dd-java-agent/instrumentation/scala-concurrent/src/main/java/datadog/trace/instrumentation/scala/concurrent/ScalaForkJoinTaskInstrumentation.java
@@ -66,7 +66,7 @@ public final class ScalaForkJoinTaskInstrumentation extends Instrumenter.Default
       return null;
     }
 
-    @Advice.OnMethodExit
+    @Advice.OnMethodExit(onThrowable = Throwable.class)
     public static void after(@Advice.Enter TraceScope scope) {
       if (null != scope) {
         scope.close();
@@ -87,7 +87,7 @@ public final class ScalaForkJoinTaskInstrumentation extends Instrumenter.Default
   }
 
   public static final class Cancel {
-    @Advice.OnMethodExit
+    @Advice.OnMethodExit(onThrowable = Throwable.class)
     public static <T> void cancel(@Advice.This ForkJoinTask<T> task) {
       State state = InstrumentationContext.get(ForkJoinTask.class, State.class).get(task);
       if (null != state) {

--- a/dd-java-agent/instrumentation/scala-concurrent/src/main/java/datadog/trace/instrumentation/scala/concurrent/ScalaForkJoinTaskInstrumentation.java
+++ b/dd-java-agent/instrumentation/scala-concurrent/src/main/java/datadog/trace/instrumentation/scala/concurrent/ScalaForkJoinTaskInstrumentation.java
@@ -1,30 +1,22 @@
 package datadog.trace.instrumentation.scala.concurrent;
 
-import static datadog.trace.agent.tooling.ClassLoaderMatcher.hasClassesNamed;
-import static datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers.extendsClass;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers.safeHasSuperType;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
 import static java.util.Collections.singletonMap;
-import static net.bytebuddy.matcher.ElementMatchers.isAbstract;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.named;
-import static net.bytebuddy.matcher.ElementMatchers.not;
-import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
-import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.InstrumentationContext;
-import datadog.trace.bootstrap.instrumentation.java.concurrent.AdviceUtils;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.State;
 import datadog.trace.context.TraceScope;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.Callable;
-import lombok.extern.slf4j.Slf4j;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
-import scala.concurrent.forkjoin.ForkJoinPool;
 import scala.concurrent.forkjoin.ForkJoinTask;
 
 /**
@@ -33,94 +25,74 @@ import scala.concurrent.forkjoin.ForkJoinTask;
  * <p>Note: There are quite a few separate implementations of {@code ForkJoinTask}/{@code
  * ForkJoinPool}: JVM, Akka, Scala, Netty to name a few. This class handles Scala version.
  */
-@Slf4j
 @AutoService(Instrumenter.class)
 public final class ScalaForkJoinTaskInstrumentation extends Instrumenter.Default {
-
-  static final String TASK_CLASS_NAME = "scala.concurrent.forkjoin.ForkJoinTask";
-
-  static final ElementMatcher<ClassLoader> CLASS_LOADER_MATCHER = hasClassesNamed(TASK_CLASS_NAME);
 
   public ScalaForkJoinTaskInstrumentation() {
     super("java_concurrent", "scala_concurrent");
   }
 
   @Override
-  public ElementMatcher<ClassLoader> classLoaderMatcher() {
-    // Optimization for expensive typeMatcher.
-    return CLASS_LOADER_MATCHER;
-  }
-
-  @Override
   public ElementMatcher<TypeDescription> typeMatcher() {
-    return extendsClass(named(TASK_CLASS_NAME));
-  }
-
-  @Override
-  public Map<String, String> contextStoreForAll() {
-    final Map<String, String> map = new HashMap<>();
-    map.put(Runnable.class.getName(), State.class.getName());
-    map.put(Callable.class.getName(), State.class.getName());
-    return Collections.unmodifiableMap(map);
+    // this type is constructed on entry to the JFP, and can be used to track
+    // the lifecycle of tasks
+    return safeHasSuperType(named("scala.concurrent.forkjoin.ForkJoinTask"));
   }
 
   @Override
   public Map<String, String> contextStore() {
-    return singletonMap(TASK_CLASS_NAME, State.class.getName());
+    return singletonMap("scala.concurrent.forkjoin.ForkJoinTask", State.class.getName());
   }
 
   @Override
   public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
-    return singletonMap(
-        named("exec").and(takesArguments(0)).and(not(isAbstract())),
-        ScalaForkJoinTaskInstrumentation.class.getName() + "$ForkJoinTaskAdvice");
+    Map<ElementMatcher<MethodDescription>, String> transformers = new HashMap<>(4);
+    transformers.put(isMethod().and(named("exec")), getClass().getName() + "$Exec");
+    transformers.put(isMethod().and(named("fork")), getClass().getName() + "$Fork");
+    transformers.put(isMethod().and(named("cancel")), getClass().getName() + "$Cancel");
+    return transformers;
   }
 
-  public static class ForkJoinTaskAdvice {
-
-    /**
-     * When {@link ForkJoinTask} object is submitted to {@link ForkJoinPool} as {@link Runnable} or
-     * {@link Callable} it will not get wrapped, instead it will be casted to {@code ForkJoinTask}
-     * directly. This means state is still stored in {@code Runnable} or {@code Callable} and we
-     * need to use that state.
-     */
-    @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static TraceScope enter(@Advice.This final ForkJoinTask thiz) {
-      final ContextStore<ForkJoinTask, State> contextStore =
-          InstrumentationContext.get(ForkJoinTask.class, State.class);
-      TraceScope scope = AdviceUtils.startTaskScope(contextStore, thiz);
-      if (thiz instanceof Runnable) {
-        final ContextStore<Runnable, State> runnableContextStore =
-            InstrumentationContext.get(Runnable.class, State.class);
-        final TraceScope newScope =
-            AdviceUtils.startTaskScope(runnableContextStore, (Runnable) thiz);
-        if (null != newScope) {
-          if (null != scope) {
-            newScope.close();
-          } else {
-            scope = newScope;
-          }
+  public static final class Exec {
+    @Advice.OnMethodEnter
+    public static <T> TraceScope before(@Advice.This ForkJoinTask<T> task) {
+      State state = InstrumentationContext.get(ForkJoinTask.class, State.class).get(task);
+      if (null != state) {
+        TraceScope.Continuation continuation = state.getAndResetContinuation();
+        if (null != continuation) {
+          return continuation.activate();
         }
       }
-      if (thiz instanceof Callable) {
-        final ContextStore<Callable, State> callableContextStore =
-            InstrumentationContext.get(Callable.class, State.class);
-        final TraceScope newScope =
-            AdviceUtils.startTaskScope(callableContextStore, (Callable) thiz);
-        if (null != newScope) {
-          if (null != scope) {
-            newScope.close();
-          } else {
-            scope = newScope;
-          }
-        }
-      }
-      return scope;
+      return null;
     }
 
-    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
-    public static void exit(@Advice.Enter final TraceScope scope) {
-      AdviceUtils.endTaskScope(scope);
+    @Advice.OnMethodExit
+    public static void after(@Advice.Enter TraceScope scope) {
+      if (null != scope) {
+        scope.close();
+      }
+    }
+  }
+
+  public static final class Fork {
+    @Advice.OnMethodEnter
+    public static <T> void fork(@Advice.This ForkJoinTask<T> task) {
+      TraceScope activeScope = activeScope();
+      if (null != activeScope) {
+        InstrumentationContext.get(ForkJoinTask.class, State.class)
+            .putIfAbsent(task, State.FACTORY)
+            .captureAndSetContinuation(activeScope);
+      }
+    }
+  }
+
+  public static final class Cancel {
+    @Advice.OnMethodExit
+    public static <T> void cancel(@Advice.This ForkJoinTask<T> task) {
+      State state = InstrumentationContext.get(ForkJoinTask.class, State.class).get(task);
+      if (null != state) {
+        state.closeContinuation();
+      }
     }
   }
 }

--- a/dd-java-agent/instrumentation/scala-concurrent/src/test/groovy/ForkJoinPoolPropagationTest.groovy
+++ b/dd-java-agent/instrumentation/scala-concurrent/src/test/groovy/ForkJoinPoolPropagationTest.groovy
@@ -1,0 +1,50 @@
+import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.core.DDSpan
+import scala.concurrent.forkjoin.ForkJoinPool
+
+class ForkJoinPoolPropagationTest extends AgentTestRunner {
+  def "test imbalanced recursive task propagation #parallelism FJP threads" () {
+    when:
+    ForkJoinPool fjp = new ForkJoinPool(parallelism)
+
+    Integer result = fjp.invoke(new LinearTask(depth))
+
+    then:
+    result == depth
+
+    TEST_WRITER.waitForTraces(1)
+    TEST_WRITER.size() == 1
+    List<DDSpan> trace = TEST_WRITER.get(0)
+    int i = 0
+    for (DDSpan span : trace) {
+      assert Integer.toString(++i) == span.getOperationName()
+    }
+    assert i == depth
+
+    cleanup:
+    fjp.shutdownNow()
+
+    where:
+    parallelism | depth
+    1           |    10
+    1           |    20
+    1           |    30
+    1           |    40
+    1           |    50
+    2           |    10
+    2           |    20
+    2           |    30
+    2           |    40
+    2           |    50
+    3           |    10
+    3           |    20
+    3           |    30
+    3           |    40
+    3           |    50
+    4           |    10
+    4           |    20
+    4           |    30
+    4           |    40
+    4           |    50
+  }
+}

--- a/dd-java-agent/instrumentation/scala-concurrent/src/test/java/LinearTask.java
+++ b/dd-java-agent/instrumentation/scala-concurrent/src/test/java/LinearTask.java
@@ -1,0 +1,45 @@
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import scala.concurrent.forkjoin.RecursiveTask;
+
+public class LinearTask extends RecursiveTask<Integer> {
+  private final int depth;
+  private final int parent;
+
+  public LinearTask(int depth) {
+    this(0, depth);
+  }
+
+  private LinearTask(int parent, int depth) {
+    this.parent = parent;
+    this.depth = depth;
+  }
+
+  @Override
+  protected Integer compute() {
+    try {
+      // introduces delay to encourage parallelism
+      // which will expose problems with context propagation
+      Thread.sleep(5);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+    if (parent == depth) {
+      return parent;
+    } else {
+      int next = parent + 1;
+      AgentSpan span = startSpan(Integer.toString(next));
+      try (AgentScope scope = activateSpan(span)) {
+        // shouldn't be necessary with a decent API
+        scope.setAsyncPropagation(true);
+        LinearTask child = new LinearTask(next, depth);
+        return child.fork().join();
+      } finally {
+        span.finish();
+      }
+    }
+  }
+}


### PR DESCRIPTION
Our tests for FJP context propagation only ever test the case where the work gets stolen by the pushing thread, i.e. whenever tasks were invoked on another thread, context would fail to propagate. 

This fixes this by instrumenting `ForkJoinTask`'s lifecycle, and instrumenting `ForkJoinPool.externalPush`, and not attempting to handle FJPs with executor instrumentation.

This PR currently breaks a `CompletableFuture` test (`thenComposeAsyc`) but I expect this should be fixed by correct CF instrumentation.