### PR TITLE
Write out a trace as soon as possible

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/PendingTrace.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/PendingTrace.java
@@ -29,13 +29,13 @@ import lombok.extern.slf4j.Slf4j;
  * <ul>
  *   <li>Immediate Write
  *       <ul>
- *         <li>is root && pending ref count == 0
- *         <li>not root && size exceeds partial flush
+ *         <li>pending ref count == 0 && trace not already written
+ *         <li>not root span && size exceeds partial flush
  *       </ul>
  *   <li>Delayed Write
  *       <ul>
- *         <li>is root && pending ref count > 0
- *         <li>not root && root already written
+ *         <li>is root span && pending ref count > 0
+ *         <li>not root span && pending ref count > 0 && trace already written
  *       </ul>
  * </ul>
  *
@@ -259,7 +259,7 @@ public class PendingTrace implements AgentTrace {
               "t_id={} -> registered continuation {} -- count = {}", traceId, continuation, count);
         }
       } else {
-        log.debug("continuation {} already registered in trace {}", continuation, traceId);
+        log.debug("t_id={} -> continuation {} already registered", traceId, continuation);
       }
     }
   }
@@ -281,22 +281,22 @@ public class PendingTrace implements AgentTrace {
       return;
     }
     final int count = pendingReferenceCount.decrementAndGet();
-    if (isRootSpan) {
-      if (0 < count) {
+    if (count == 0 && !rootSpanWritten.get()) {
+      // Finished with no pending work ... write immediately
+      write();
+    } else {
+      if (isRootSpan) {
         // Finished root with pending work ... delay write
         pendingTraceBuffer.enqueue(this);
       } else {
-        // Finished root and no pending work ... write immediately
-        write();
-      }
-    } else {
-      int partialFlushMinSpans = tracer.getPartialFlushMinSpans();
-      if (0 < partialFlushMinSpans && partialFlushMinSpans < size()) {
-        // Trace is getting too big, write anything completed.
-        partialFlush();
-      } else if (rootSpanWritten.get()) {
-        // Late arrival span ... delay write
-        pendingTraceBuffer.enqueue(this);
+        int partialFlushMinSpans = tracer.getPartialFlushMinSpans();
+        if (0 < partialFlushMinSpans && partialFlushMinSpans < size()) {
+          // Trace is getting too big, write anything completed.
+          partialFlush();
+        } else if (rootSpanWritten.get()) {
+          // Late arrival span ... delay write
+          pendingTraceBuffer.enqueue(this);
+        }
       }
     }
     if (log.isDebugEnabled()) {
@@ -311,9 +311,9 @@ public class PendingTrace implements AgentTrace {
 
   /** Important to note: may be called multiple times. */
   private void partialFlush() {
-    int size = write(false);
+    int size = write(true);
     if (log.isDebugEnabled()) {
-      log.debug("Writing partial trace {} of size {}", traceId, size);
+      log.debug("t_id={} -> writing partial trace of size {}", traceId, size);
     }
   }
 
@@ -322,7 +322,7 @@ public class PendingTrace implements AgentTrace {
     rootSpanWritten.set(true);
     int size = write(false);
     if (log.isDebugEnabled()) {
-      log.debug("Writing {} spans to {}.", size, tracer.writer);
+      log.debug("t_id={} -> writing {} spans to {}.", traceId, size, tracer.writer);
     }
   }
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerTest.groovy
@@ -720,9 +720,6 @@ class ScopeManagerTest extends DDSpecification {
 
     when:
     continuation.cancel()
-    // The logic in PendingTrace is broken, and says that if you cancel a continuation
-    // it can't be a root span, so instead of direct write, we wait for the trace here
-    writer.waitForTraces(1)
 
     then:
     writer == [[span]]


### PR DESCRIPTION
This change ensures that we write out a trace as soon as its reference count reaches zero.