### PR TITLE
Delay starting JMXFetch when there's a custom JMX builder

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
@@ -1,6 +1,7 @@
 package datadog.trace.bootstrap;
 
 import java.lang.instrument.Instrumentation;
+import java.lang.management.ManagementFactory;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -281,6 +282,9 @@ public class Agent {
   }
 
   private static synchronized void startJmx(final URL bootstrapURL) {
+    // load core JMX using the inherited thread-context-classloader
+    ManagementFactory.getPlatformMBeanServer();
+
     startJmxFetch(bootstrapURL);
 
     if (AGENT_CLASSLOADER == null) {

--- a/dd-java-agent/src/test/groovy/datadog/trace/agent/CustomMBeanServerBuilderTest.groovy
+++ b/dd-java-agent/src/test/groovy/datadog/trace/agent/CustomMBeanServerBuilderTest.groovy
@@ -1,0 +1,59 @@
+package datadog.trace.agent
+
+import datadog.trace.agent.test.IntegrationTestUtils
+import jvmbootstraptest.MBeanServerBuilderSetter
+import spock.lang.Specification
+import spock.lang.Timeout
+
+@Timeout(30)
+class CustomMBeanServerBuilderTest extends Specification {
+
+  private static final String DEFAULT_LOG_LEVEL = "debug"
+  private static final String API_KEY = "01234567890abcdef123456789ABCDEF"
+
+  // Run all tests using forked jvm so we try different JMX settings
+  def "JMXFetch starts up in premain with no custom MBeanServerBuilder set"() {
+    expect:
+    IntegrationTestUtils.runOnSeparateJvm(MBeanServerBuilderSetter.getName()
+      , ["-Ddd.jmxfetch.enabled=true", "-Ddd.jmxfetch.refresh-beans-period=1", "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=$DEFAULT_LOG_LEVEL"] as String[]
+      , "" as String[]
+      , ["DD_API_KEY": API_KEY]
+      , true) == 0
+  }
+
+  def "JMXFetch starts up in premain if configured MBeanServerBuilder on system classpath"() {
+    expect:
+    IntegrationTestUtils.runOnSeparateJvm(MBeanServerBuilderSetter.getName()
+      , ["-Ddd.jmxfetch.enabled=true", "-Ddd.jmxfetch.refresh-beans-period=1", "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=$DEFAULT_LOG_LEVEL", "-Djavax.management.builder.initial=jvmbootstraptest.CustomMBeanServerBuilder"] as String[]
+      , "" as String[]
+      , ["DD_API_KEY": API_KEY]
+      , true) == 0
+  }
+
+  def "JMXFetch startup is delayed with javax.management.builder.initial sysprop"() {
+    expect:
+    IntegrationTestUtils.runOnSeparateJvm(MBeanServerBuilderSetter.getName()
+      , ["-Ddd.jmxfetch.enabled=true", "-Ddd.jmxfetch.refresh-beans-period=1", "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=$DEFAULT_LOG_LEVEL", "-Djavax.management.builder.initial=jvmbootstraptest.MissingMBeanServerBuilder"] as String[]
+      , "" as String[]
+      , ["DD_API_KEY": API_KEY]
+      , true) == 0
+  }
+
+  def "JMXFetch startup is delayed with tracer custom JMX builder setting"() {
+    expect:
+    IntegrationTestUtils.runOnSeparateJvm(MBeanServerBuilderSetter.getName()
+      , ["-Ddd.jmxfetch.enabled=true", "-Ddd.jmxfetch.refresh-beans-period=1", "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=$DEFAULT_LOG_LEVEL", "-Ddd.app.customjmxbuilder=true"] as String[]
+      , "" as String[]
+      , ["DD_API_KEY": API_KEY]
+      , true) == 0
+  }
+
+  def "JMXFetch starts up in premain forced by customjmxbuilder=false"() {
+    expect:
+    IntegrationTestUtils.runOnSeparateJvm(MBeanServerBuilderSetter.getName()
+      , ["-Ddd.jmxfetch.enabled=true", "-Ddd.jmxfetch.refresh-beans-period=1", "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=$DEFAULT_LOG_LEVEL", "-Ddd.app.customjmxbuilder=false", "-Djavax.management.builder.initial=jvmbootstraptest.CustomMBeanServerBuilder"] as String[]
+      , "" as String[]
+      , ["DD_API_KEY": API_KEY]
+      , true) == 0
+  }
+}

--- a/dd-java-agent/src/test/groovy/datadog/trace/agent/CustomMBeanServerBuilderTest.groovy
+++ b/dd-java-agent/src/test/groovy/datadog/trace/agent/CustomMBeanServerBuilderTest.groovy
@@ -15,7 +15,7 @@ class CustomMBeanServerBuilderTest extends Specification {
   def "JMXFetch starts up in premain with no custom MBeanServerBuilder set"() {
     expect:
     IntegrationTestUtils.runOnSeparateJvm(MBeanServerBuilderSetter.getName()
-      , ["-Ddd.jmxfetch.enabled=true", "-Ddd.jmxfetch.refresh-beans-period=1", "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=$DEFAULT_LOG_LEVEL"] as String[]
+      , ["-Ddd.jmxfetch.enabled=true", "-Ddd.jmxfetch.refresh-beans-period=1", "-Ddd.profiling.enabled=true", "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=$DEFAULT_LOG_LEVEL"] as String[]
       , "" as String[]
       , ["DD_API_KEY": API_KEY]
       , true) == 0
@@ -24,7 +24,7 @@ class CustomMBeanServerBuilderTest extends Specification {
   def "JMXFetch starts up in premain if configured MBeanServerBuilder on system classpath"() {
     expect:
     IntegrationTestUtils.runOnSeparateJvm(MBeanServerBuilderSetter.getName()
-      , ["-Ddd.jmxfetch.enabled=true", "-Ddd.jmxfetch.refresh-beans-period=1", "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=$DEFAULT_LOG_LEVEL", "-Djavax.management.builder.initial=jvmbootstraptest.CustomMBeanServerBuilder"] as String[]
+      , ["-Ddd.jmxfetch.enabled=true", "-Ddd.jmxfetch.refresh-beans-period=1", "-Ddd.profiling.enabled=true", "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=$DEFAULT_LOG_LEVEL", "-Djavax.management.builder.initial=jvmbootstraptest.CustomMBeanServerBuilder"] as String[]
       , "" as String[]
       , ["DD_API_KEY": API_KEY]
       , true) == 0
@@ -33,7 +33,7 @@ class CustomMBeanServerBuilderTest extends Specification {
   def "JMXFetch startup is delayed with javax.management.builder.initial sysprop"() {
     expect:
     IntegrationTestUtils.runOnSeparateJvm(MBeanServerBuilderSetter.getName()
-      , ["-Ddd.jmxfetch.enabled=true", "-Ddd.jmxfetch.refresh-beans-period=1", "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=$DEFAULT_LOG_LEVEL", "-Djavax.management.builder.initial=jvmbootstraptest.MissingMBeanServerBuilder"] as String[]
+      , ["-Ddd.jmxfetch.enabled=true", "-Ddd.jmxfetch.refresh-beans-period=1", "-Ddd.profiling.enabled=true", "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=$DEFAULT_LOG_LEVEL", "-Djavax.management.builder.initial=jvmbootstraptest.MissingMBeanServerBuilder"] as String[]
       , "" as String[]
       , ["DD_API_KEY": API_KEY]
       , true) == 0
@@ -42,7 +42,7 @@ class CustomMBeanServerBuilderTest extends Specification {
   def "JMXFetch startup is delayed with tracer custom JMX builder setting"() {
     expect:
     IntegrationTestUtils.runOnSeparateJvm(MBeanServerBuilderSetter.getName()
-      , ["-Ddd.jmxfetch.enabled=true", "-Ddd.jmxfetch.refresh-beans-period=1", "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=$DEFAULT_LOG_LEVEL", "-Ddd.app.customjmxbuilder=true"] as String[]
+      , ["-Ddd.jmxfetch.enabled=true", "-Ddd.jmxfetch.refresh-beans-period=1", "-Ddd.profiling.enabled=true", "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=$DEFAULT_LOG_LEVEL", "-Ddd.app.customjmxbuilder=true"] as String[]
       , "" as String[]
       , ["DD_API_KEY": API_KEY]
       , true) == 0
@@ -51,7 +51,7 @@ class CustomMBeanServerBuilderTest extends Specification {
   def "JMXFetch starts up in premain forced by customjmxbuilder=false"() {
     expect:
     IntegrationTestUtils.runOnSeparateJvm(MBeanServerBuilderSetter.getName()
-      , ["-Ddd.jmxfetch.enabled=true", "-Ddd.jmxfetch.refresh-beans-period=1", "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=$DEFAULT_LOG_LEVEL", "-Ddd.app.customjmxbuilder=false", "-Djavax.management.builder.initial=jvmbootstraptest.CustomMBeanServerBuilder"] as String[]
+      , ["-Ddd.jmxfetch.enabled=true", "-Ddd.jmxfetch.refresh-beans-period=1", "-Ddd.profiling.enabled=true", "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=$DEFAULT_LOG_LEVEL", "-Ddd.app.customjmxbuilder=false", "-Djavax.management.builder.initial=jvmbootstraptest.CustomMBeanServerBuilder"] as String[]
       , "" as String[]
       , ["DD_API_KEY": API_KEY]
       , true) == 0

--- a/dd-java-agent/src/test/java/jvmbootstraptest/CustomMBeanServerBuilder.java
+++ b/dd-java-agent/src/test/java/jvmbootstraptest/CustomMBeanServerBuilder.java
@@ -1,0 +1,25 @@
+package jvmbootstraptest;
+
+import javax.management.MBeanServer;
+import javax.management.MBeanServerBuilder;
+import javax.management.MBeanServerDelegate;
+import javax.management.ObjectName;
+import javax.management.StandardMBean;
+
+public class CustomMBeanServerBuilder extends MBeanServerBuilder {
+  public interface TestMBean {}
+
+  @Override
+  public MBeanServer newMBeanServer(
+      final String defaultDomain, final MBeanServer outer, final MBeanServerDelegate delegate) {
+    final MBeanServer mBeanServer = super.newMBeanServer(defaultDomain, outer, delegate);
+    try {
+      mBeanServer.registerMBean(
+          new StandardMBean(new TestMBean() {}, TestMBean.class),
+          new ObjectName("test:name=custom"));
+    } catch (final Exception e) {
+      throw new IllegalStateException(e);
+    }
+    return mBeanServer;
+  }
+}

--- a/dd-java-agent/src/test/java/jvmbootstraptest/MBeanServerBuilderSetter.java
+++ b/dd-java-agent/src/test/java/jvmbootstraptest/MBeanServerBuilderSetter.java
@@ -1,0 +1,100 @@
+package jvmbootstraptest;
+
+import java.lang.management.ManagementFactory;
+import java.util.Objects;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+
+public class MBeanServerBuilderSetter {
+  public static void main(final String... args) throws Exception {
+    if (System.getProperty("dd.app.customjmxbuilder") != null) {
+      System.out.println("dd.app.customjmxbuilder != null");
+
+      if (Boolean.parseBoolean(System.getProperty("dd.app.customjmxbuilder"))) {
+        System.setProperty(
+            "javax.management.builder.initial", "jvmbootstraptest.CustomMBeanServerBuilder");
+        customAssert(
+            isCustomMBeanRegistered(),
+            true,
+            "Javaagent should not prevent setting a custom MBeanServerBuilder");
+      } else {
+        customAssert(
+            isJmxfetchStarted(false),
+            true,
+            "jmxfetch should start in premain when customjmxbuilder=false.");
+      }
+    } else if (System.getProperty("javax.management.builder.initial") != null) {
+      System.out.println("javax.management.builder.initial != null");
+
+      if (ClassLoader.getSystemResource(
+              System.getProperty("javax.management.builder.initial").replaceAll("\\.", "/")
+                  + ".class")
+          == null) {
+        customAssert(
+            isJmxfetchStarted(false),
+            false,
+            "jmxfetch startup must be delayed when management builder system property is present.");
+        // Change back to a valid MBeanServerBuilder.
+        System.setProperty(
+            "javax.management.builder.initial", "jvmbootstraptest.CustomMBeanServerBuilder");
+        customAssert(
+            isCustomMBeanRegistered(),
+            true,
+            "Javaagent should not prevent setting a custom MBeanServerBuilder");
+        customAssert(
+            isJmxfetchStarted(true),
+            true,
+            "jmxfetch should start after loading MBeanServerBuilder.");
+      } else {
+        customAssert(
+            isJmxfetchStarted(false),
+            true,
+            "jmxfetch should start in premain when custom MBeanServerBuilder found on classpath.");
+      }
+    } else {
+      System.out.println("No custom MBeanServerBuilder");
+
+      customAssert(
+          isJmxfetchStarted(false),
+          true,
+          "jmxfetch should start in premain when no custom MBeanServerBuilder is set.");
+    }
+  }
+
+  private static boolean isCustomMBeanRegistered() throws MalformedObjectNameException {
+    return ManagementFactory.getPlatformMBeanServer()
+        .isRegistered(new ObjectName("test:name=custom"));
+  }
+
+  private static void customAssert(
+      final Object got, final Object expected, final String assertionMessage) {
+    if (!Objects.equals(got, expected)) {
+      throw new RuntimeException(
+          "Assertion failed. Expected <" + expected + "> got <" + got + "> " + assertionMessage);
+    }
+  }
+
+  private static boolean isThreadStarted(final String name, final boolean wait) {
+    // Wait up to 10 seconds for thread to appear
+    for (int i = 0; i < 20; i++) {
+      for (final Thread thread : Thread.getAllStackTraces().keySet()) {
+        if (name.equals(thread.getName())) {
+          return true;
+        }
+      }
+      if (!wait) {
+        break;
+      }
+      try {
+        Thread.sleep(500);
+      } catch (final InterruptedException e) {
+        e.printStackTrace();
+      }
+    }
+    return false;
+  }
+
+  private static boolean isJmxfetchStarted(final boolean wait) {
+    return isThreadStarted("dd-jmx-collector", wait);
+  }
+}


### PR DESCRIPTION
This takes a similar approach to how we deal with custom log managers, however unlike the logging case there is no clear activating class with a static initialization block. Instead we wait for the `MBeanServerBuilder` class to be loaded and use that as an indication that we can go ahead and access JMX.

This is acceptable because `MBeanServerBuilder` is the base class for all custom JMX builders and is only used in `MBeanServerFactory` which creates the custom builder instance. Note JMX doesn't let you supply an actual builder instance - it only lets you specify the class name which `MBeanServerFactory` attempts to load, first by the current thread's context classloader, then falling back to `Class.forName`.

The place where `MBeanServerBuilder` is loaded should be where `MBeanServerFactory` is looking up the custom builder, unless the application is using `MBeanServerBuilder` itself before starting JMX. But that would be unusual because its only use is to create MBean servers and delegates for JMX. Even in that case though we should be OK because at the time the application loads `MBeanServerBuilder` the current thread's context classloader should be able to see the custom JMX builder. And since the classload hook thread inherits that context classloader then it too should be able to see that custom JMX builder. Therefore it doesn't matter if the classload hook or the application win the race to start JMX. Either one should be able to see the custom builder class at that point. (We just need to make sure we make a call to JMX before we change the classload hook thread's context classloader when starting JMXFetch.)

The only other classes loaded after `MBeanServerBuilder` would be the internal JMX classes, whose names could vary between JDKs. Alternatively we could wait for the custom JMX builder class, but there's a chance that the initial value is overridden later on and the initially named class is never loaded.
