### PR TITLE
Add a play client request to the play 2.5 smoke test

### DIFF
--- a/dd-smoke-tests/play-2.5/app/controllers/HomeController.java
+++ b/dd-smoke-tests/play-2.5/app/controllers/HomeController.java
@@ -1,17 +1,47 @@
 package controllers;
 
 import actions.*;
+import io.opentracing.Scope;
+import io.opentracing.Span;
+import io.opentracing.Tracer;
+import io.opentracing.util.GlobalTracer;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import javax.inject.Inject;
+import play.Configuration;
+import play.libs.ws.*;
 import play.mvc.*;
 import play.mvc.With;
 
 public class HomeController extends Controller {
 
+  private final WSClient ws;
+  private final String clientRequestBase;
+
+  @Inject
+  public HomeController(WSClient ws, Configuration configuration) {
+    this.ws = ws;
+    this.clientRequestBase =
+        configuration.getString("client.request.base", "http://localhost:0/broken/");
+  }
+
   @With({Action1.class, Action2.class})
-  public Result doGet(Integer id) {
-    if (id > 0) {
-      return ok("Welcome " + id + ".");
-    } else {
-      return badRequest("No ID.");
+  public CompletionStage<Result> doGet(final Integer id) {
+    Tracer tracer = GlobalTracer.get();
+    Span span = tracer.buildSpan("do-get").start();
+    Scope scope = tracer.scopeManager().activate(span);
+    try {
+      if (id > 0) {
+        return ws.url(clientRequestBase + id)
+            .get()
+            .thenApply(
+                response -> status(response.getStatus(), "Got '" + response.getBody() + "'"));
+      } else {
+        return CompletableFuture.supplyAsync(() -> badRequest("No ID."));
+      }
+    } finally {
+      scope.close();
+      span.finish();
     }
   }
 }

--- a/dd-smoke-tests/play-2.5/play-2.5.gradle
+++ b/dd-smoke-tests/play-2.5/play-2.5.gradle
@@ -41,12 +41,21 @@ repositories {
 }
 
 apply from: "$rootDir/gradle/java.gradle"
+spotless {
+  groovy {
+    excludeJava()
+    greclipse().configFile(project.rootProject.rootDir.path + '/gradle/enforcement/spotless-groovy.properties')
+  }
+}
 
 description = 'Play 2.5 Integration Tests.'
 
 dependencies {
   play "com.typesafe.play:play-logback_$scalaVersion:$playVersion"
   play "com.typesafe.play:filters-helpers_$scalaVersion:$playVersion"
+  play "com.typesafe.play:play-java-ws_$scalaVersion:$playVersion"
+  // jaxb is not there anymore in java11+
+  play "javax.xml.bind:jaxb-api:2.3.1"
 
   play project(':dd-trace-api')
   play group: 'io.opentracing', name: 'opentracing-api', version: '0.32.0'

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/MultiWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/MultiWriter.java
@@ -1,0 +1,85 @@
+package datadog.trace.common.writer;
+
+import static datadog.trace.bootstrap.instrumentation.api.WriterConstants.MULTI_WRITER_TYPE;
+
+import com.timgroup.statsd.StatsDClient;
+import datadog.trace.api.Config;
+import datadog.trace.common.sampling.Sampler;
+import datadog.trace.core.DDSpan;
+import datadog.trace.core.monitor.Monitoring;
+import java.util.List;
+
+public class MultiWriter implements Writer {
+
+  private final Writer[] writers;
+
+  public MultiWriter(
+      Config config,
+      Sampler sampler,
+      StatsDClient statsDClient,
+      Monitoring monitoring,
+      String type) {
+    String mwConfig = type.replace(MULTI_WRITER_TYPE + ":", "");
+    String[] writerConfigs = mwConfig.split(",");
+    this.writers = new Writer[writerConfigs.length];
+    int i = 0;
+
+    for (String writerConfig : writerConfigs) {
+      writers[i] =
+          WriterFactory.createWriter(config, sampler, statsDClient, monitoring, writerConfig);
+      i++;
+    }
+  }
+
+  public MultiWriter(Writer[] writers) {
+    this.writers = writers.clone();
+  }
+
+  @Override
+  public void start() {
+    for (Writer writer : writers) {
+      if (writer != null) {
+        writer.start();
+      }
+    }
+  }
+
+  @Override
+  public void write(List<DDSpan> trace) {
+    for (Writer writer : writers) {
+      if (writer != null) {
+        writer.write(trace);
+      }
+    }
+  }
+
+  @Override
+  public boolean flush() {
+    boolean flush = true;
+    for (Writer writer : writers) {
+      if (writer != null) {
+        flush &= writer.flush();
+      }
+    }
+
+    return flush;
+  }
+
+  @Override
+  public void close() {
+    for (Writer writer : writers) {
+      if (writer != null) {
+        writer.close();
+      }
+    }
+  }
+
+  @Override
+  public void incrementTraceCount() {
+    for (Writer writer : writers) {
+      if (writer != null) {
+        writer.incrementTraceCount();
+      }
+    }
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/WriterFactory.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/WriterFactory.java
@@ -1,0 +1,106 @@
+package datadog.trace.common.writer;
+
+import static datadog.trace.bootstrap.instrumentation.api.PrioritizationConstants.ENSURE_TRACE_TYPE;
+import static datadog.trace.bootstrap.instrumentation.api.WriterConstants.*;
+
+import com.timgroup.statsd.StatsDClient;
+import datadog.common.container.ServerlessInfo;
+import datadog.trace.api.Config;
+import datadog.trace.api.ConfigDefaults;
+import datadog.trace.api.config.TracerConfig;
+import datadog.trace.common.sampling.Sampler;
+import datadog.trace.common.writer.ddagent.DDAgentApi;
+import datadog.trace.common.writer.ddagent.DDAgentResponseListener;
+import datadog.trace.common.writer.ddagent.Prioritization;
+import datadog.trace.core.monitor.HealthMetrics;
+import datadog.trace.core.monitor.Monitoring;
+import java.util.concurrent.TimeUnit;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class WriterFactory {
+
+  public static Writer createWriter(
+      final Config config,
+      final Sampler sampler,
+      final StatsDClient statsDClient,
+      final Monitoring monitoring) {
+    return createWriter(config, sampler, statsDClient, monitoring, config.getWriterType());
+  }
+
+  public static Writer createWriter(
+      final Config config,
+      final Sampler sampler,
+      final StatsDClient statsDClient,
+      final Monitoring monitoring,
+      final String configuredType) {
+
+    if (LOGGING_WRITER_TYPE.equals(configuredType)) {
+      return new LoggingWriter();
+    } else if (PRINTING_WRITER_TYPE.equals(configuredType)) {
+      return new PrintingWriter(System.out, true);
+    } else if (configuredType.startsWith(TRACE_STRUCTURE_WRITER_TYPE)) {
+      return new TraceStructureWriter(configuredType.replace(TRACE_STRUCTURE_WRITER_TYPE, ""));
+    } else if (configuredType.startsWith(MULTI_WRITER_TYPE)) {
+      return new MultiWriter(config, sampler, statsDClient, monitoring, configuredType);
+    }
+
+    if (!DD_AGENT_WRITER_TYPE.equals(configuredType)) {
+      log.warn(
+          "Writer type not configured correctly: Type {} not recognized. Ignoring", configuredType);
+    }
+
+    if (config.isAgentConfiguredUsingDefault()
+        && ServerlessInfo.get().isRunningInServerlessEnvironment()) {
+      log.info("Detected serverless environment.  Using PrintingWriter");
+      return new PrintingWriter(System.out, true);
+    }
+
+    String unixDomainSocket = config.getAgentUnixDomainSocket();
+    if (unixDomainSocket != ConfigDefaults.DEFAULT_AGENT_UNIX_DOMAIN_SOCKET && isWindows()) {
+      log.warn(
+          "{} setting not supported on {}.  Reverting to the default.",
+          TracerConfig.AGENT_UNIX_DOMAIN_SOCKET,
+          System.getProperty("os.name"));
+      unixDomainSocket = ConfigDefaults.DEFAULT_AGENT_UNIX_DOMAIN_SOCKET;
+    }
+
+    final DDAgentApi ddAgentApi =
+        new DDAgentApi(
+            config.getAgentUrl(),
+            unixDomainSocket,
+            TimeUnit.SECONDS.toMillis(config.getAgentTimeout()),
+            Config.get().isTraceAgentV05Enabled(),
+            monitoring);
+
+    final String prioritizationType = config.getPrioritizationType();
+    Prioritization prioritization = null;
+    if (ENSURE_TRACE_TYPE.equals(prioritizationType)) {
+      prioritization = Prioritization.ENSURE_TRACE;
+      log.info(
+          "Using 'EnsureTrace' prioritization type. (Do not use this type if your application is running in production mode)");
+    }
+
+    final DDAgentWriter ddAgentWriter =
+        DDAgentWriter.builder()
+            .agentApi(ddAgentApi)
+            .prioritization(prioritization)
+            .healthMetrics(new HealthMetrics(statsDClient))
+            .monitoring(monitoring)
+            .build();
+
+    if (sampler instanceof DDAgentResponseListener) {
+      ddAgentWriter.addResponseListener((DDAgentResponseListener) sampler);
+    }
+
+    return ddAgentWriter;
+  }
+
+  private static boolean isWindows() {
+    // https://mkyong.com/java/how-to-detect-os-in-java-systemgetpropertyosname/
+    final String os = System.getProperty("os.name").toLowerCase();
+    return os.contains("win");
+  }
+
+  private WriterFactory() {}
+}

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -1,22 +1,13 @@
 package datadog.trace.core;
 
-import static datadog.trace.bootstrap.instrumentation.api.PrioritizationConstants.ENSURE_TRACE_TYPE;
-import static datadog.trace.bootstrap.instrumentation.api.WriterConstants.DD_AGENT_WRITER_TYPE;
-import static datadog.trace.bootstrap.instrumentation.api.WriterConstants.LOGGING_WRITER_TYPE;
-import static datadog.trace.bootstrap.instrumentation.api.WriterConstants.PRINTING_WRITER_TYPE;
-import static datadog.trace.bootstrap.instrumentation.api.WriterConstants.TRACE_STRUCTURE_WRITER_TYPE;
-
 import com.timgroup.statsd.NoOpStatsDClient;
 import com.timgroup.statsd.NonBlockingStatsDClient;
 import com.timgroup.statsd.StatsDClient;
-import datadog.common.container.ServerlessInfo;
 import datadog.trace.api.Config;
-import datadog.trace.api.ConfigDefaults;
 import datadog.trace.api.DDId;
 import datadog.trace.api.DDTags;
 import datadog.trace.api.IdGenerationStrategy;
 import datadog.trace.api.config.GeneralConfig;
-import datadog.trace.api.config.TracerConfig;
 import datadog.trace.api.interceptor.MutableSpan;
 import datadog.trace.api.interceptor.TraceInterceptor;
 import datadog.trace.api.sampling.PrioritySampling;
@@ -28,19 +19,12 @@ import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.bootstrap.instrumentation.api.ScopeSource;
 import datadog.trace.common.sampling.PrioritySampler;
 import datadog.trace.common.sampling.Sampler;
-import datadog.trace.common.writer.DDAgentWriter;
-import datadog.trace.common.writer.LoggingWriter;
-import datadog.trace.common.writer.PrintingWriter;
-import datadog.trace.common.writer.TraceStructureWriter;
 import datadog.trace.common.writer.Writer;
-import datadog.trace.common.writer.ddagent.DDAgentApi;
-import datadog.trace.common.writer.ddagent.DDAgentResponseListener;
-import datadog.trace.common.writer.ddagent.Prioritization;
+import datadog.trace.common.writer.WriterFactory;
 import datadog.trace.context.ScopeListener;
 import datadog.trace.context.TraceScope;
 import datadog.trace.core.jfr.DDNoopScopeEventFactory;
 import datadog.trace.core.jfr.DDScopeEventFactory;
-import datadog.trace.core.monitor.HealthMetrics;
 import datadog.trace.core.monitor.Monitoring;
 import datadog.trace.core.monitor.Recording;
 import datadog.trace.core.propagation.ExtractedContext;
@@ -240,7 +224,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
     }
 
     if (writer == null) {
-      this.writer = createWriter(config, sampler, this.statsDClient, monitoring);
+      this.writer = WriterFactory.createWriter(config, sampler, this.statsDClient, monitoring);
     } else {
       this.writer = writer;
     }
@@ -518,78 +502,6 @@ public class CoreTracer implements AgentTracer.TracerAPI {
       log.debug("Profiling of ScopeEvents is not available");
     }
     return new DDNoopScopeEventFactory();
-  }
-
-  private static Writer createWriter(
-      final Config config,
-      final Sampler sampler,
-      final StatsDClient statsDClient,
-      final Monitoring monitoring) {
-    final String configuredType = config.getWriterType();
-
-    if (LOGGING_WRITER_TYPE.equals(configuredType)) {
-      return new LoggingWriter();
-    } else if (PRINTING_WRITER_TYPE.equals(configuredType)) {
-      return new PrintingWriter(System.out, true);
-    } else if (configuredType.startsWith(TRACE_STRUCTURE_WRITER_TYPE)) {
-      return new TraceStructureWriter(configuredType.replace(TRACE_STRUCTURE_WRITER_TYPE, ""));
-    }
-
-    if (!DD_AGENT_WRITER_TYPE.equals(configuredType)) {
-      log.warn(
-          "Writer type not configured correctly: Type {} not recognized. Ignoring", configuredType);
-    }
-
-    if (config.isAgentConfiguredUsingDefault()
-        && ServerlessInfo.get().isRunningInServerlessEnvironment()) {
-      log.info("Detected serverless environment.  Using PrintingWriter");
-      return new PrintingWriter(System.out, true);
-    }
-
-    String unixDomainSocket = config.getAgentUnixDomainSocket();
-    if (unixDomainSocket != ConfigDefaults.DEFAULT_AGENT_UNIX_DOMAIN_SOCKET && isWindows()) {
-      log.warn(
-          "{} setting not supported on {}.  Reverting to the default.",
-          TracerConfig.AGENT_UNIX_DOMAIN_SOCKET,
-          System.getProperty("os.name"));
-      unixDomainSocket = ConfigDefaults.DEFAULT_AGENT_UNIX_DOMAIN_SOCKET;
-    }
-
-    final DDAgentApi ddAgentApi =
-        new DDAgentApi(
-            config.getAgentUrl(),
-            unixDomainSocket,
-            TimeUnit.SECONDS.toMillis(config.getAgentTimeout()),
-            Config.get().isTraceAgentV05Enabled(),
-            monitoring);
-
-    final String prioritizationType = config.getPrioritizationType();
-    Prioritization prioritization = null;
-    if (ENSURE_TRACE_TYPE.equals(prioritizationType)) {
-      prioritization = Prioritization.ENSURE_TRACE;
-      log.info(
-          "Using 'EnsureTrace' prioritization type. (Do not use this type if your application is running in production mode)");
-    }
-
-    final DDAgentWriter ddAgentWriter =
-        DDAgentWriter.builder()
-            .agentApi(ddAgentApi)
-            .prioritization(prioritization)
-            .healthMetrics(new HealthMetrics(statsDClient))
-            .monitoring(monitoring)
-            .build();
-
-    if (sampler instanceof DDAgentResponseListener) {
-      ddAgentWriter.addResponseListener((DDAgentResponseListener) sampler);
-    }
-
-    return ddAgentWriter;
-  }
-
-  private static boolean isWindows() {
-    // https://mkyong.com/java/how-to-detect-os-in-java-systemgetpropertyosname/
-    final String os = System.getProperty("os.name").toLowerCase();
-    return os.contains("win");
   }
 
   private static StatsDClient createStatsDClient(final Config config) {

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/MultiWriterTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/MultiWriterTest.groovy
@@ -1,0 +1,69 @@
+package datadog.trace.common.writer
+
+import datadog.trace.core.DDSpan
+import spock.lang.Specification
+
+class MultiWriterTest extends Specification {
+
+  def "test that multi writer delegates to all"() {
+    setup:
+    def writers = new Writer[3]
+    Writer mockW1 = Mock()
+    Writer mockW2 = Mock()
+    writers[0] = mockW1
+    // null in position 1 to check that we skip that
+    writers[2] = mockW2
+    def writer = new MultiWriter(writers)
+    List<DDSpan> trace = new LinkedList<>()
+
+    when:
+    writer.start()
+
+    then:
+    1 * mockW1.start()
+    1 * mockW2.start()
+    0 * _
+
+    when:
+    writer.write(trace)
+
+    then:
+    1 * mockW1.write({ it == trace })
+    1 * mockW2.write({ it == trace })
+    0 * _
+
+    when:
+    def flushed = writer.flush()
+
+    then:
+    1 * mockW1.flush() >> true
+    1 * mockW2.flush() >> true
+    0 * _
+    flushed
+
+    when:
+    def notFlushed = writer.flush()
+
+    then:
+    1 * mockW1.flush() >> true
+    1 * mockW2.flush() >> false
+    0 * _
+    !notFlushed
+
+    when:
+    writer.close()
+
+    then:
+    1 * mockW1.close()
+    1 * mockW2.close()
+    0 * _
+
+    when:
+    writer.incrementTraceCount()
+
+    then:
+    1 * mockW1.incrementTraceCount()
+    1 * mockW2.incrementTraceCount()
+    0 * _
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/WriterConstants.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/WriterConstants.java
@@ -5,6 +5,7 @@ public final class WriterConstants {
   public static final String LOGGING_WRITER_TYPE = "LoggingWriter";
   public static final String PRINTING_WRITER_TYPE = "PrintingWriter";
   public static final String TRACE_STRUCTURE_WRITER_TYPE = "TraceStructureWriter";
+  public static final String MULTI_WRITER_TYPE = "MultiWriter";
 
   private WriterConstants() {}
 }


### PR DESCRIPTION
* Adds some client calls to the `play-2.5` smoke test.
* Moves `Writer` creation out to a separate class, and adds a `MultiWriter` that delegates to multiple other writers.
* Allows `AbstractSmokeTest` to wait for a received trace count.