### PR TITLE
Servlet RequestDispatcher and Spring MVC 404 fixes

### DIFF
--- a/dd-java-agent/instrumentation/dropwizard/src/test/groovy/DropwizardTest.groovy
+++ b/dd-java-agent/instrumentation/dropwizard/src/test/groovy/DropwizardTest.groovy
@@ -3,7 +3,6 @@ import datadog.trace.agent.test.base.HttpServerTest
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import datadog.trace.bootstrap.instrumentation.api.Tags
-import datadog.trace.core.DDSpan
 import datadog.trace.instrumentation.jaxrs2.JaxRsAnnotationsDecorator
 import io.dropwizard.Application
 import io.dropwizard.Configuration
@@ -75,14 +74,14 @@ class DropwizardTest extends HttpServerTest<DropwizardTestSupport> {
   }
 
   @Override
-  void handlerSpan(TraceAssert trace, Object parent, ServerEndpoint endpoint = SUCCESS) {
+  void handlerSpan(TraceAssert trace, ServerEndpoint endpoint = SUCCESS) {
     trace.span {
       serviceName expectedServiceName()
       operationName "jax-rs.request"
       resourceName "${testResource().simpleName}.${endpoint.name().toLowerCase()}"
       spanType DDSpanTypes.HTTP_SERVER
       errored endpoint == EXCEPTION
-      childOf(parent as DDSpan)
+      childOfPrevious()
       tags {
         "$Tags.COMPONENT" JaxRsAnnotationsDecorator.DECORATE.component()
         if (endpoint == EXCEPTION) {

--- a/dd-java-agent/instrumentation/finatra-2.9/src/latestDepTest/groovy/FinatraServer270Test.groovy
+++ b/dd-java-agent/instrumentation/finatra-2.9/src/latestDepTest/groovy/FinatraServer270Test.groovy
@@ -9,7 +9,6 @@ import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.agent.test.base.HttpServerTest
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
-import datadog.trace.core.DDSpan
 import datadog.trace.instrumentation.finatra.FinatraDecorator
 
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR
@@ -90,7 +89,7 @@ class FinatraServer270Test extends HttpServerTest<HttpServer> {
     return "finatra.request"
   }
 
-  void handlerSpan(TraceAssert trace, Object parent, ServerEndpoint endpoint = SUCCESS) {
+  void handlerSpan(TraceAssert trace, ServerEndpoint endpoint = SUCCESS) {
     def errorEndpoint = endpoint == EXCEPTION || endpoint == ERROR
     trace.span {
       serviceName expectedServiceName()
@@ -98,7 +97,7 @@ class FinatraServer270Test extends HttpServerTest<HttpServer> {
       resourceName "FinatraController"
       spanType DDSpanTypes.HTTP_SERVER
       errored errorEndpoint
-      childOf(parent as DDSpan)
+      childOfPrevious()
       tags {
         "$Tags.COMPONENT" FinatraDecorator.DECORATE.component()
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER

--- a/dd-java-agent/instrumentation/finatra-2.9/src/test/groovy/FinatraServerTest.groovy
+++ b/dd-java-agent/instrumentation/finatra-2.9/src/test/groovy/FinatraServerTest.groovy
@@ -6,7 +6,6 @@ import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.agent.test.base.HttpServerTest
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
-import datadog.trace.core.DDSpan
 import datadog.trace.instrumentation.finatra.FinatraDecorator
 
 import java.util.concurrent.TimeoutException
@@ -72,7 +71,7 @@ class FinatraServerTest extends HttpServerTest<HttpServer> {
     return "finatra.request"
   }
 
-  void handlerSpan(TraceAssert trace, Object parent, ServerEndpoint endpoint = SUCCESS) {
+  void handlerSpan(TraceAssert trace, ServerEndpoint endpoint = SUCCESS) {
     def errorEndpoint = endpoint == EXCEPTION || endpoint == ERROR
     trace.span {
       serviceName expectedServiceName()
@@ -80,7 +79,7 @@ class FinatraServerTest extends HttpServerTest<HttpServer> {
       resourceName "FinatraController"
       spanType DDSpanTypes.HTTP_SERVER
       errored errorEndpoint
-      childOf(parent as DDSpan)
+      childOfPrevious()
       tags {
         "$Tags.COMPONENT" FinatraDecorator.DECORATE.component()
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER

--- a/dd-java-agent/instrumentation/play-2.3/src/test/groovy/server/PlayServerTest.groovy
+++ b/dd-java-agent/instrumentation/play-2.3/src/test/groovy/server/PlayServerTest.groovy
@@ -5,7 +5,6 @@ import datadog.trace.agent.test.base.HttpServerTest
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import datadog.trace.bootstrap.instrumentation.api.Tags
-import datadog.trace.core.DDSpan
 import datadog.trace.instrumentation.netty38.server.NettyHttpServerDecorator
 import datadog.trace.instrumentation.play23.PlayHttpServerDecorator
 import play.api.test.TestServer
@@ -50,13 +49,13 @@ class PlayServerTest extends HttpServerTest<TestServer> {
   }
 
   @Override
-  void handlerSpan(TraceAssert trace, Object parent, ServerEndpoint endpoint = SUCCESS) {
+  void handlerSpan(TraceAssert trace, ServerEndpoint endpoint = SUCCESS) {
     trace.span {
       serviceName expectedServiceName()
       operationName "play.request"
       spanType DDSpanTypes.HTTP_SERVER
       errored endpoint == ERROR || endpoint == EXCEPTION
-      childOf(parent as DDSpan)
+      childOfPrevious()
       tags {
         "$Tags.COMPONENT" PlayHttpServerDecorator.DECORATE.component()
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER

--- a/dd-java-agent/instrumentation/play-2.4/src/test/groovy/server/PlayServerTest.groovy
+++ b/dd-java-agent/instrumentation/play-2.4/src/test/groovy/server/PlayServerTest.groovy
@@ -5,7 +5,6 @@ import datadog.trace.agent.test.base.HttpServerTest
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import datadog.trace.bootstrap.instrumentation.api.Tags
-import datadog.trace.core.DDSpan
 import datadog.trace.instrumentation.netty40.server.NettyHttpServerDecorator
 import datadog.trace.instrumentation.play24.PlayHttpServerDecorator
 import play.mvc.Results
@@ -86,13 +85,13 @@ class PlayServerTest extends HttpServerTest<Server> {
   }
 
   @Override
-  void handlerSpan(TraceAssert trace, Object parent, ServerEndpoint endpoint = SUCCESS) {
+  void handlerSpan(TraceAssert trace, ServerEndpoint endpoint = SUCCESS) {
     trace.span {
       serviceName expectedServiceName()
       operationName "play.request"
       spanType DDSpanTypes.HTTP_SERVER
       errored endpoint == ERROR || endpoint == EXCEPTION
-      childOf(parent as DDSpan)
+      childOfPrevious()
       tags {
         "$Tags.COMPONENT" PlayHttpServerDecorator.DECORATE.component()
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER

--- a/dd-java-agent/instrumentation/play-2.6/src/test/groovy/server/PlayServerTest.groovy
+++ b/dd-java-agent/instrumentation/play-2.6/src/test/groovy/server/PlayServerTest.groovy
@@ -5,7 +5,6 @@ import datadog.trace.agent.test.base.HttpServerTest
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import datadog.trace.bootstrap.instrumentation.api.Tags
-import datadog.trace.core.DDSpan
 import datadog.trace.instrumentation.akkahttp.AkkaHttpServerDecorator
 import datadog.trace.instrumentation.play26.PlayHttpServerDecorator
 import play.BuiltInComponents
@@ -88,13 +87,13 @@ class PlayServerTest extends HttpServerTest<Server> {
   }
 
   @Override
-  void handlerSpan(TraceAssert trace, Object parent, ServerEndpoint endpoint = SUCCESS) {
+  void handlerSpan(TraceAssert trace, ServerEndpoint endpoint = SUCCESS) {
     trace.span {
       serviceName expectedServiceName()
       operationName "play.request"
       spanType DDSpanTypes.HTTP_SERVER
       errored endpoint == ERROR || endpoint == EXCEPTION
-      childOf(parent as DDSpan)
+      childOfPrevious()
       tags {
         "$Tags.COMPONENT" PlayHttpServerDecorator.DECORATE.component()
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER

--- a/dd-java-agent/instrumentation/ratpack-1.5/src/test/groovy/server/RatpackHttpServerTest.groovy
+++ b/dd-java-agent/instrumentation/ratpack-1.5/src/test/groovy/server/RatpackHttpServerTest.groovy
@@ -5,7 +5,6 @@ import datadog.trace.agent.test.base.HttpServerTest
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import datadog.trace.bootstrap.instrumentation.api.Tags
-import datadog.trace.core.DDSpan
 import datadog.trace.instrumentation.netty41.server.NettyHttpServerDecorator
 import datadog.trace.instrumentation.ratpack.RatpackServerDecorator
 import ratpack.error.ServerErrorHandler
@@ -114,13 +113,13 @@ class RatpackHttpServerTest extends HttpServerTest<EmbeddedApp> {
   }
 
   @Override
-  void handlerSpan(TraceAssert trace, Object parent, ServerEndpoint endpoint = SUCCESS) {
+  void handlerSpan(TraceAssert trace, ServerEndpoint endpoint = SUCCESS) {
     trace.span {
       serviceName expectedServiceName()
       operationName "ratpack.handler"
       spanType DDSpanTypes.HTTP_SERVER
       errored endpoint == ERROR || endpoint == EXCEPTION
-      childOf(parent as DDSpan)
+      childOfPrevious()
       tags {
         "$Tags.COMPONENT" RatpackServerDecorator.DECORATE.component()
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER

--- a/dd-java-agent/instrumentation/servlet/request-3/request-3.gradle
+++ b/dd-java-agent/instrumentation/servlet/request-3/request-3.gradle
@@ -29,6 +29,7 @@ dependencies {
     exclude group: 'org.eclipse.jetty', module: 'jetty-server'
   }
   testCompile project(':dd-java-agent:instrumentation:jetty-8') // See if there's any conflicts.
+  testCompile project(':dd-java-agent:instrumentation:servlet')
   testCompile group: 'org.eclipse.jetty', name: 'jetty-server', version: '8.2.0.v20160908'
   testCompile group: 'org.eclipse.jetty', name: 'jetty-servlet', version: '8.2.0.v20160908'
   testCompile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '8.0.41'

--- a/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/JettyServletHandlerTest.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/JettyServletHandlerTest.groovy
@@ -1,5 +1,8 @@
+import datadog.trace.agent.test.asserts.ListWriterAssert
 import datadog.trace.api.config.GeneralConfig
 import datadog.trace.api.env.CapturedEnvironment
+import groovy.transform.stc.ClosureParams
+import groovy.transform.stc.SimpleType
 import org.eclipse.jetty.server.Server
 import org.eclipse.jetty.server.handler.ErrorHandler
 import org.eclipse.jetty.servlet.ServletHandler
@@ -54,5 +57,30 @@ class JettyServletHandlerTest extends AbstractServlet3Test<Server, ServletHandle
   @Override
   boolean testNotFound() {
     false
+  }
+
+  void cleanAndAssertTraces(
+    final int size,
+    @ClosureParams(value = SimpleType, options = "datadog.trace.agent.test.asserts.ListWriterAssert")
+    @DelegatesTo(value = ListWriterAssert, strategy = Closure.DELEGATE_FIRST)
+    final Closure spec) {
+
+    // If this is failing, make sure HttpServerTestAdvice is applied correctly.
+    TEST_WRITER.waitForTraces(size * 2)
+
+    // Response instrumentation is broken with exceptions in jetty
+    // Exceptions are handled outside of the servlet flow
+    // Normally, the response spans would not be created because of the activeSpan() check
+    // Since we artificially create TEST_SPAN, the response spans are created there
+    // This removes the response spans added under TEST_SPAN
+
+    def testTrace = TEST_WRITER.findAll {
+      it.get(0).operationName.toString() == "TEST_SPAN"
+    }
+    testTrace[0].removeAll {
+      it.operationName.toString() == "servlet.response"
+    }
+
+    super.cleanAndAssertTraces(size, spec)
   }
 }

--- a/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/TestServlet3.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/TestServlet3.groovy
@@ -17,11 +17,19 @@ import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.TIMEOU
 
 class TestServlet3 {
 
+  static HttpServerTest.ServerEndpoint getEndpoint(HttpServletRequest req) {
+    // Most correct would be to get the dispatched path from the request
+    // This is not part of the spec varies by implementation so the simplest is just removing
+    // "/dispatch"
+    String truePath = req.servletPath.replace("/dispatch", "")
+    return HttpServerTest.ServerEndpoint.forPath(truePath)
+  }
+
   @WebServlet
   static class Sync extends AbstractHttpServlet {
     @Override
     protected void service(HttpServletRequest req, HttpServletResponse resp) {
-      HttpServerTest.ServerEndpoint endpoint = HttpServerTest.ServerEndpoint.forPath(req.servletPath)
+      HttpServerTest.ServerEndpoint endpoint = getEndpoint(req)
       HttpServerTest.controller(endpoint) {
         resp.contentType = "text/plain"
         switch (endpoint) {
@@ -50,7 +58,7 @@ class TestServlet3 {
   static class Async extends AbstractHttpServlet {
     @Override
     protected void service(HttpServletRequest req, HttpServletResponse resp) {
-      HttpServerTest.ServerEndpoint endpoint = HttpServerTest.ServerEndpoint.forPath(req.servletPath)
+      HttpServerTest.ServerEndpoint endpoint = getEndpoint(req)
       def phaser = new Phaser(2)
       def context = req.startAsync()
       if (endpoint.name().contains("TIMEOUT")) {
@@ -111,7 +119,7 @@ class TestServlet3 {
     protected void service(HttpServletRequest req, HttpServletResponse resp) {
       def context = req.startAsync()
       try {
-        HttpServerTest.ServerEndpoint endpoint = HttpServerTest.ServerEndpoint.forPath(req.servletPath)
+        HttpServerTest.ServerEndpoint endpoint = getEndpoint(req)
         HttpServerTest.controller(endpoint) {
           resp.contentType = "text/plain"
           switch (endpoint) {

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/dispatcher/RequestDispatcherDecorator.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/dispatcher/RequestDispatcherDecorator.java
@@ -1,12 +1,31 @@
 package datadog.trace.instrumentation.servlet.dispatcher;
 
+import static datadog.trace.api.cache.RadixTreeCache.HTTP_STATUSES;
+
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.BaseDecorator;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import javax.servlet.ServletException;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletResponse;
 
 public class RequestDispatcherDecorator extends BaseDecorator {
   public static final RequestDispatcherDecorator DECORATE = new RequestDispatcherDecorator();
   public static final CharSequence JAVA_WEB_SERVLET_DISPATCHER =
       UTF8BytesString.createConstant("java-web-servlet-dispatcher");
+
+  private static Method STATUS_CODE_METHOD;
+
+  static {
+    try {
+      STATUS_CODE_METHOD = HttpServletResponse.class.getMethod("getStatus");
+    } catch (NoSuchMethodException e) {
+      // ignore. getStatus was added in servlet 3
+    }
+  }
 
   @Override
   protected String[] instrumentationNames() {
@@ -21,5 +40,37 @@ public class RequestDispatcherDecorator extends BaseDecorator {
   @Override
   protected CharSequence component() {
     return JAVA_WEB_SERVLET_DISPATCHER;
+  }
+
+  @Override
+  public AgentSpan onError(final AgentSpan span, final Throwable throwable) {
+    if (throwable instanceof ServletException && throwable.getCause() != null) {
+      super.onError(span, throwable.getCause());
+    } else {
+      super.onError(span, throwable);
+    }
+    return span;
+  }
+
+  public AgentSpan onResponse(
+      final AgentSpan span, final ServletResponse response, Throwable throwable) {
+    if (response instanceof HttpServletResponse && STATUS_CODE_METHOD != null) {
+      try {
+        int status = (int) STATUS_CODE_METHOD.invoke(response);
+
+        if (throwable != null && status == HttpServletResponse.SC_OK) {
+          span.setTag(Tags.HTTP_STATUS, HTTP_STATUSES.get(500));
+        } else {
+          span.setTag(Tags.HTTP_STATUS, HTTP_STATUSES.get(status));
+        }
+
+        if (status == 404) {
+          span.setResourceName("404");
+        }
+      } catch (IllegalAccessException | InvocationTargetException e) {
+        // ignore. getStatus was added in servlet 3
+      }
+    }
+    return span;
   }
 }

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/http/HttpServletResponseInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/http/HttpServletResponseInstrumentation.java
@@ -5,9 +5,7 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers.im
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
-import static datadog.trace.instrumentation.servlet.ServletRequestSetter.SETTER;
 import static datadog.trace.instrumentation.servlet.http.HttpServletResponseDecorator.DECORATE;
 import static datadog.trace.instrumentation.servlet.http.HttpServletResponseDecorator.SERVLET_RESPONSE;
 import static java.util.Collections.singletonMap;
@@ -87,9 +85,6 @@ public final class HttpServletResponseInstrumentation extends Instrumenter.Defau
       DECORATE.afterStart(span);
 
       span.setTag(DDTags.RESOURCE_NAME, "HttpServletResponse." + method);
-
-      // In case we lose context, inject trace into to the request.
-      propagate().inject(span, req, SETTER);
 
       final AgentScope scope = activateSpan(span);
       scope.setAsyncPropagation(true);

--- a/dd-java-agent/instrumentation/servlet/src/test/groovy/RequestDispatcherTest.groovy
+++ b/dd-java-agent/instrumentation/servlet/src/test/groovy/RequestDispatcherTest.groovy
@@ -1,4 +1,5 @@
 import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.api.DDSpanTypes
 import datadog.trace.core.DDSpan
 
 import javax.servlet.ServletException
@@ -50,6 +51,7 @@ class RequestDispatcherTest extends AgentTestRunner {
         span {
           operationName "servlet.$operation"
           resourceName target
+          spanType DDSpanTypes.HTTP_SERVER
           childOf span(0)
           tags {
             "component" "java-web-servlet-dispatcher"
@@ -102,6 +104,7 @@ class RequestDispatcherTest extends AgentTestRunner {
         span {
           operationName "servlet.$operation"
           resourceName target
+          spanType DDSpanTypes.HTTP_SERVER
           childOf span(0)
           errored true
           tags {

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/SpringWebHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/SpringWebHttpServerDecorator.java
@@ -100,9 +100,20 @@ public class SpringWebHttpServerDecorator
         final CharSequence resourceName =
             RESOURCE_NAME_CACHE.computeIfAbsent(
                 Pair.of(method, bestMatchingPattern), RESOURCE_NAME_JOINER);
-        span.setTag(DDTags.RESOURCE_NAME, resourceName);
+        span.setResourceName(resourceName);
       }
     }
+    return span;
+  }
+
+  @Override
+  public AgentSpan onResponse(AgentSpan span, HttpServletResponse response) {
+    super.onResponse(span, response);
+
+    if (status(response) == 404) {
+      span.setResourceName("404");
+    }
+
     return span;
   }
 

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/boot/AppConfig.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/boot/AppConfig.groovy
@@ -8,7 +8,7 @@ import org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletCon
 import org.springframework.context.annotation.Bean
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter
 
-// When running in Intellij, spring sometimes the custom classloader through component scan
+// Component scan defeats the purpose of configuring with specific classes
 @SpringBootApplication(scanBasePackages = "doesnotexist")
 class AppConfig extends WebMvcConfigurerAdapter {
 

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/boot/AppConfig.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/boot/AppConfig.groovy
@@ -8,7 +8,8 @@ import org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletCon
 import org.springframework.context.annotation.Bean
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter
 
-@SpringBootApplication
+// When running in Intellij, spring sometimes the custom classloader through component scan
+@SpringBootApplication(scanBasePackages = "doesnotexist")
 class AppConfig extends WebMvcConfigurerAdapter {
 
   @Bean

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/boot/CustomBeanClassloaderTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/boot/CustomBeanClassloaderTest.groovy
@@ -8,7 +8,7 @@ import static java.util.Collections.singletonMap
 class CustomBeanClassloaderTest extends SpringBootBasedTest {
   @Override
   ConfigurableApplicationContext startServer(int port) {
-    def app = new SpringApplication(AppConfig, SecurityConfig, AuthServerConfig, CustomClassloaderConfig)
+    def app = new SpringApplication(AppConfig, SecurityConfig, AuthServerConfig, CustomClassloaderConfig, TestController)
     app.setDefaultProperties(singletonMap("server.port", port))
     def context = app.run()
     return context

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/boot/SpringBootBasedTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/boot/SpringBootBasedTest.groovy
@@ -7,7 +7,6 @@ import datadog.trace.agent.test.base.HttpServerTest
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import datadog.trace.bootstrap.instrumentation.api.Tags
-import datadog.trace.core.DDSpan
 import datadog.trace.instrumentation.servlet3.Servlet3Decorator
 import datadog.trace.instrumentation.springweb.SpringWebHttpServerDecorator
 import groovy.transform.stc.ClosureParams
@@ -144,14 +143,14 @@ class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext>
   }
 
   @Override
-  void handlerSpan(TraceAssert trace, Object parent, ServerEndpoint endpoint = SUCCESS) {
+  void handlerSpan(TraceAssert trace, ServerEndpoint endpoint = SUCCESS) {
     trace.span {
       serviceName expectedServiceName()
       operationName "spring.handler"
       resourceName "TestController.${endpoint.name().toLowerCase()}"
       spanType DDSpanTypes.HTTP_SERVER
       errored endpoint == EXCEPTION
-      childOf(parent as DDSpan)
+      childOfPrevious()
       tags {
         "$Tags.COMPONENT" SpringWebHttpServerDecorator.DECORATE.component()
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/dynamic/DynamicRoutingTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/dynamic/DynamicRoutingTest.groovy
@@ -5,7 +5,6 @@ import datadog.trace.agent.test.base.HttpServerTest
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import datadog.trace.bootstrap.instrumentation.api.Tags
-import datadog.trace.core.DDSpan
 import datadog.trace.instrumentation.springweb.SpringWebHttpServerDecorator
 import org.springframework.boot.SpringApplication
 import org.springframework.context.ConfigurableApplicationContext
@@ -38,14 +37,14 @@ class DynamicRoutingTest extends ServletFilterTest {
   }
 
   @Override
-  void handlerSpan(TraceAssert trace, Object parent, HttpServerTest.ServerEndpoint endpoint = SUCCESS) {
+  void handlerSpan(TraceAssert trace, ServerEndpoint endpoint = SUCCESS) {
     trace.span {
       serviceName expectedServiceName()
       operationName "spring.handler"
       resourceName "TestController.${formatEndpoint(endpoint)}"
       spanType DDSpanTypes.HTTP_SERVER
       errored endpoint == EXCEPTION
-      childOf(parent as DDSpan)
+      childOfPrevious()
       tags {
         "$Tags.COMPONENT" SpringWebHttpServerDecorator.DECORATE.component()
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/dynamic/DynamicRoutingTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/dynamic/DynamicRoutingTest.groovy
@@ -155,7 +155,7 @@ class DynamicRoutingTest extends HttpServerTest<ConfigurableApplicationContext> 
         "$Tags.HTTP_STATUS" endpoint.status
         "servlet.path" endpoint.path
         if (endpoint.errored) {
-          "servlet.dispatch" { it == null || "/exception" }
+          "servlet.dispatch" { it == null || it == "/exception" }
           "error.msg" { it == null || it == EXCEPTION.body }
           "error.type" { it == null || it == Exception.name }
           "error.stack" { it == null || it instanceof String }

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/dynamic/DynamicRoutingTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/dynamic/DynamicRoutingTest.groovy
@@ -155,7 +155,7 @@ class DynamicRoutingTest extends HttpServerTest<ConfigurableApplicationContext> 
         "$Tags.HTTP_STATUS" endpoint.status
         "servlet.path" endpoint.path
         if (endpoint.errored) {
-          "servlet.dispatch" { it == null || it == "/exception" }
+          "servlet.dispatch" { it == null || it == "/error" }
           "error.msg" { it == null || it == EXCEPTION.body }
           "error.type" { it == null || it == Exception.name }
           "error.stack" { it == null || it instanceof String }

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/dynamic/DynamicRoutingTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/dynamic/DynamicRoutingTest.groovy
@@ -5,17 +5,19 @@ import datadog.trace.agent.test.base.HttpServerTest
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import datadog.trace.bootstrap.instrumentation.api.Tags
+import datadog.trace.instrumentation.servlet3.Servlet3Decorator
 import datadog.trace.instrumentation.springweb.SpringWebHttpServerDecorator
 import org.springframework.boot.SpringApplication
 import org.springframework.context.ConfigurableApplicationContext
+import org.springframework.web.servlet.view.RedirectView
 import test.boot.SecurityConfig
-import test.filter.ServletFilterTest
 
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 import static java.util.Collections.singletonMap
 
-class DynamicRoutingTest extends ServletFilterTest {
+class DynamicRoutingTest extends HttpServerTest<ConfigurableApplicationContext> {
 
   @Override
   ConfigurableApplicationContext startServer(int port) {
@@ -23,6 +25,32 @@ class DynamicRoutingTest extends ServletFilterTest {
     app.setDefaultProperties(singletonMap("server.port", port))
     def context = app.run()
     return context
+  }
+
+  @Override
+  void stopServer(ConfigurableApplicationContext ctx) {
+    ctx.close()
+  }
+
+  @Override
+  String component() {
+    return Servlet3Decorator.DECORATE.component()
+  }
+
+  @Override
+  String expectedOperationName() {
+    return "servlet.request"
+  }
+
+  @Override
+  boolean testExceptionBody() {
+    false
+  }
+
+  @Override
+  boolean testNotFound() {
+    // Tested by the regular spring boot test
+    false
   }
 
   @Override
@@ -34,6 +62,52 @@ class DynamicRoutingTest extends ServletFilterTest {
   @Override
   boolean hasHandlerSpan() {
     true
+  }
+
+  int spanCount(ServerEndpoint endpoint) {
+    if (endpoint == REDIRECT) {
+      // Spring is generates a RenderView and ResponseSpan for REDIRECT
+      return super.spanCount(endpoint) + 1
+    }
+    return super.spanCount(endpoint)
+  }
+
+  @Override
+  boolean hasResponseSpan(ServerEndpoint endpoint) {
+    return endpoint == REDIRECT
+  }
+
+  @Override
+  void responseSpan(TraceAssert trace, ServerEndpoint endpoint) {
+    if (endpoint == REDIRECT) {
+      // Spring creates a RenderView span and the response span is the child the servlet
+      // This is not part of the controller hierarchy because rendering happens after the controller
+      // method returns
+
+      trace.span {
+        operationName "response.render"
+        resourceName "response.render"
+        spanType "web"
+        errored false
+        tags {
+          "$Tags.COMPONENT" "spring-webmvc"
+          "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
+          "view.type" RedirectView.simpleName
+          defaultTags()
+        }
+      }
+      trace.span {
+        operationName "servlet.response"
+        resourceName "HttpServletResponse.sendRedirect"
+        childOfPrevious()
+        tags {
+          "component" "java-web-servlet-response"
+          defaultTags()
+        }
+      }
+    } else {
+      throw new UnsupportedOperationException("responseSpan not implemented for " + endpoint)
+    }
   }
 
   @Override
@@ -56,8 +130,9 @@ class DynamicRoutingTest extends ServletFilterTest {
     }
   }
 
+  // Adds servlet.path and servlet.dispatch to normal serverSpan
   @Override
-  void serverSpan(TraceAssert trace, BigInteger traceID = null, BigInteger parentID = null, String method = "GET", HttpServerTest.ServerEndpoint endpoint = SUCCESS) {
+  void serverSpan(TraceAssert trace, BigInteger traceID = null, BigInteger parentID = null, String method = "GET", ServerEndpoint endpoint = SUCCESS) {
     trace.span {
       serviceName expectedServiceName()
       operationName expectedOperationName()
@@ -80,6 +155,7 @@ class DynamicRoutingTest extends ServletFilterTest {
         "$Tags.HTTP_STATUS" endpoint.status
         "servlet.path" endpoint.path
         if (endpoint.errored) {
+          "servlet.dispatch" { it == null || "/exception" }
           "error.msg" { it == null || it == EXCEPTION.body }
           "error.type" { it == null || it == Exception.name }
           "error.stack" { it == null || it instanceof String }

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/filter/ServletFilterTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/filter/ServletFilterTest.groovy
@@ -7,7 +7,6 @@ import datadog.trace.agent.test.base.HttpServerTest
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import datadog.trace.bootstrap.instrumentation.api.Tags
-import datadog.trace.core.DDSpan
 import datadog.trace.instrumentation.servlet3.Servlet3Decorator
 import datadog.trace.instrumentation.springweb.SpringWebHttpServerDecorator
 import groovy.transform.stc.ClosureParams
@@ -149,14 +148,14 @@ class ServletFilterTest extends HttpServerTest<ConfigurableApplicationContext> {
   }
 
   @Override
-  void handlerSpan(TraceAssert trace, Object parent, ServerEndpoint endpoint = SUCCESS) {
+  void handlerSpan(TraceAssert trace, ServerEndpoint endpoint = SUCCESS) {
     trace.span {
       serviceName expectedServiceName()
       operationName "spring.handler"
       resourceName "TestController.${endpoint.name().toLowerCase()}"
       spanType DDSpanTypes.HTTP_SERVER
       errored endpoint == EXCEPTION
-      childOf(parent as DDSpan)
+      childOfPrevious()
       tags {
         "$Tags.COMPONENT" SpringWebHttpServerDecorator.DECORATE.component()
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/SpanAssert.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/SpanAssert.groovy
@@ -12,16 +12,19 @@ import static datadog.trace.agent.test.asserts.MetricsAssert.assertMetrics
 
 class SpanAssert {
   private final DDSpan span
+  private final DDSpan previous
   private final checked = [:]
 
-  private SpanAssert(span) {
+  private SpanAssert(span, DDSpan previous) {
     this.span = span
+    this.previous = previous
   }
 
   static void assertSpan(DDSpan span,
                          @ClosureParams(value = SimpleType, options = ['datadog.trace.agent.test.asserts.SpanAssert'])
-                         @DelegatesTo(value = SpanAssert, strategy = Closure.DELEGATE_FIRST) Closure spec) {
-    def asserter = new SpanAssert(span)
+                         @DelegatesTo(value = SpanAssert, strategy = Closure.DELEGATE_FIRST) Closure spec,
+                         DDSpan previous = null) {
+    def asserter = new SpanAssert(span, previous)
     asserter.assertSpan spec
   }
 
@@ -119,6 +122,11 @@ class SpanAssert {
     checked.parentId = true
     assert span.traceId == parent.traceId
     checked.traceId = true
+  }
+
+  def childOfPrevious() {
+    assert previous != null
+    childOf(previous)
   }
 
   def threadNameStartsWith(String threadName) {

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/TraceAssert.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/TraceAssert.groovy
@@ -51,7 +51,12 @@ class TraceAssert {
       throw new ConcurrentModificationException("Trace modified during assertion")
     }
     assertedIndexes.add(index)
-    assertSpan(trace.get(index), spec)
+    if (index > 0) {
+      assertSpan(trace.get(index), spec, trace.get(index - 1))
+    } else {
+      assertSpan(trace.get(index), spec)
+    }
+
   }
 
   void assertSpansAllVerified() {


### PR DESCRIPTION
This started as a fix to the RequestDispatcher commented out tests and ended up as much more.  Lots of changes so I'm being extra detailed with this description

## Functionality fixes
* `RequestDispatcher` did not set the `HTTP_STATUS` tag (this required reflection because its only available in servlet 3)
* `RequestDispatcher` did not properly set 404 resource name when forwarding
* `RequestDispatcher` did not set 500 status when exception was thrown
* Synchronous `RequestDispatcher` did not set `servlet.dispatch` tag (only async dispatch did)
* `Spring-mvc` instrumentation did not set 404 resource name for 404 response status
* Newer versions of Jetty create multiple response spans on redirect

## Testing improvements
**Added `childOfPrevious()` to `SpanAssert`**
This simplifies span assertion declarations and allow for conditional "in between" spans without indexes being incorrect.  I'll update other non-HttpServer tests in another PR

**Added `servlet` instrumentation to the `servlet:request-3` tests**
The fact that request-3 was tested without servlet was a big hole in the testing.  Adding it however required many structural changes to how the servlet tests were run

**Added a conditional `responseSpan` to `HttpServerTest` tests**
The servlet instrumentation creates a "response span" for certain conditions.  Derived test classes can specify the conditions in which the extra response span is created.  Along with `childOfPrevious`, this simplifies `trace(){...}` blocks in `HttpServerTest` greatly.

**Enabled Servlet.forward and Servlet.include tests for Jetty and Tomcat**
This uncovered a few bugs with RequestDispatch

**Create the dispatch servlets in `AbstractServletTest**
DRY

**Enabled notFound, redirect, exception tests as appropriate**
These tests were flagged off because it wasn't possible to model before.  Enabling uncovered gaps (eg Spring 404 handling)

**Removed many `cleanAndAssertTraces` overrides**
Most of these were removing "undesirable" spans.  These spans are now properly modeled in the tests

**Spring Boot tests always ran with the `DatadogFilteringClassloader`** 
This was a result of the component scan.  The point of having two separate test classes was to run with and without