### PR TITLE
Prevent trace flush from preventing shutdown

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/TraceProcessingWorker.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/TraceProcessingWorker.java
@@ -87,7 +87,7 @@ public class TraceProcessingWorker implements AutoCloseable {
     boolean offered;
     do {
       offered = primaryQueue.offer(flush);
-    } while (!offered);
+    } while (!offered && serializerThread.isAlive());
     try {
       return latch.await(timeout, timeUnit);
     } catch (InterruptedException e) {
@@ -185,7 +185,7 @@ public class TraceProcessingWorker implements AutoCloseable {
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
       }
-      log.info("Datadog trace processor exited. Publishing traces stopped");
+      log.debug("Datadog trace processor exited. Publishing traces stopped");
     }
 
     private void runDutyCycle() throws InterruptedException {

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/TraceProcessingWorker.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/TraceProcessingWorker.java
@@ -185,7 +185,7 @@ public class TraceProcessingWorker implements AutoCloseable {
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
       }
-      log.debug("datadog trace processor exited");
+      log.info("Datadog trace processor exited. Publishing traces stopped");
     }
 
     private void runDutyCycle() throws InterruptedException {

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -882,6 +882,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
     private ShutdownHook(final CoreTracer tracer) {
       super("dd-tracer-shutdown-hook");
       reference = new WeakReference<>(tracer);
+      this.setDaemon(true);
     }
 
     @Override

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -882,7 +882,6 @@ public class CoreTracer implements AgentTracer.TracerAPI {
     private ShutdownHook(final CoreTracer tracer) {
       super("dd-tracer-shutdown-hook");
       reference = new WeakReference<>(tracer);
-      this.setDaemon(true);
     }
 
     @Override


### PR DESCRIPTION
We might stuck in busy loop in ShutdownHook when primary queue is full and we keep trying to insert into it. But "dd-trace-processor" was already interrupted and stopped and nobody is draining from that full primaryQueue anymore:

`"dd-tracer-shutdown-hook" #8 prio=5 os_prio=0 tid=0x00007fb591de0000 nid=0x59b8 runnable [0x00007fb5b43bf000]
   java.lang.Thread.State: RUNNABLE
	at datadog.trace.agent.common.writer.ddagent.TraceProcessingWorker.flush(TraceProcessingWorker.java:90)
	at datadog.trace.agent.common.writer.DDAgentWriter.flush(DDAgentWriter.java:154)
	at datadog.trace.agent.common.writer.DDAgentWriter.close(DDAgentWriter.java:181)
	at datadog.trace.agent.core.CoreTracer.close(CoreTracer.java:493)
	at datadog.trace.agent.core.CoreTracer$ShutdownHook.run(CoreTracer.java:882)`

