### PR TITLE
thread-utils is installed in the bootstrap classloader…

### DIFF
--- a/dd-java-agent/agent-profiling/agent-profiling.gradle
+++ b/dd-java-agent/agent-profiling/agent-profiling.gradle
@@ -37,6 +37,7 @@ shadowJar {
     exclude(project(':dd-java-agent:agent-logging'))
     exclude(project(':dd-trace-api'))
     exclude(project(':internal-api'))
+    exclude(project(':utils:thread-utils'))
     exclude(dependency('org.slf4j::'))
   }
 }

--- a/dd-java-agent/instrumentation/instrumentation.gradle
+++ b/dd-java-agent/instrumentation/instrumentation.gradle
@@ -92,6 +92,7 @@ shadowJar {
     exclude(project(':dd-java-agent:agent-logging'))
     exclude(project(':dd-trace-api'))
     exclude(project(':internal-api'))
+    exclude(project(':utils:thread-utils'))
     exclude(dependency('org.slf4j::'))
   }
 }


### PR DESCRIPTION
…so no need for each delegate-loader ("inst" and "profiling") to also have a copy

I was also tempted to move the two classes in `thread-utils` into `internal-api` and just remove the `thread-utils` module