### PR TITLE
Set missing async propagation on some java/scala/akka scopes

### DIFF
--- a/dd-java-agent/instrumentation/scala-concurrent/src/latestDepTest/groovy/ScalaInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/scala-concurrent/src/latestDepTest/groovy/ScalaInstrumentationTest.groovy
@@ -1,6 +1,5 @@
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.core.DDSpan
-import spock.lang.Ignore
 
 class ScalaInstrumentationTest extends AgentTestRunner {
 
@@ -20,7 +19,6 @@ class ScalaInstrumentationTest extends AgentTestRunner {
     findSpan(trace, "bad complete").context().getParentId() == trace[0].context().getSpanId()
   }
 
-  @Ignore("this is not currently handled by the scala promise instrumentation")
   def "scala propagates across futures with no traces"() {
     setup:
     ScalaConcurrentTests scalaTest = new ScalaConcurrentTests()


### PR DESCRIPTION
I can't wait until async propagation is the default behavior. I completely missed this during review.