### PR TITLE
Enable now deterministic spanner tests

### DIFF
--- a/dd-smoke-tests/springboot-grpc/src/test/groovy/datadog/smoketest/SpringBootGrpcSpannerNoAsyncTest.groovy
+++ b/dd-smoke-tests/springboot-grpc/src/test/groovy/datadog/smoketest/SpringBootGrpcSpannerNoAsyncTest.groovy
@@ -1,19 +1,25 @@
 package datadog.smoketest
 
-import spock.lang.Ignore
 
 import java.util.concurrent.atomic.AtomicInteger
 
-@Ignore("can unignore when strict continuation reference counting is dropped")
 class SpringBootGrpcSpannerNoAsyncTest extends SpringBootWithGRPCTest {
 
   @Override
   boolean isAcceptable(Map<String, AtomicInteger> traceCounts) {
-    // currently spring @Async instrumentation doesn't hold the trace back
-    // if spans are created after the @Async span finishes - compensate for this
-    for (Map.Entry<String, AtomicInteger> entry : traceCounts.entrySet()) {
-      if (entry.getKey().startsWith("[servlet.request[spring.handler[grpc.client]") && entry.getValue().get() > 0) {
-        return true
+    // because of the way spanner's session creation works, without authentication,
+    // we can't guarantee a deterministic flush with grpc.client spans attached to
+    // their parents, but orphaned root grpc client spans (those without a parent id
+    // to link to) are unacceptable because they can't be stitched together by the
+    // backend. The writer will only report traces as [grpc.client] if the parent id
+    // is zero. 
+    if (!traceCounts.containsKey("[grpc.client]")) {
+      for (Map.Entry<String, AtomicInteger> entry : traceCounts.entrySet()) {
+        if (entry.getKey().startsWith("[servlet.request[spring.handler[grpc.client]")
+          || entry.getKey().startsWith("[servlet.request[spring.handler[http.request]")
+          && entry.getValue().get() > 0) {
+          return true
+        }
       }
     }
     return false

--- a/dd-smoke-tests/springboot-grpc/src/test/groovy/datadog/smoketest/SpringBootGrpcSpannerTest.groovy
+++ b/dd-smoke-tests/springboot-grpc/src/test/groovy/datadog/smoketest/SpringBootGrpcSpannerTest.groovy
@@ -1,19 +1,24 @@
 package datadog.smoketest
 
-import spock.lang.Ignore
-
 import java.util.concurrent.atomic.AtomicInteger
 
-@Ignore("can unignore when strict continuation reference counting is dropped")
 class SpringBootGrpcSpannerTest extends SpringBootWithGRPCTest {
 
   @Override
   boolean isAcceptable(Map<String, AtomicInteger> traceCounts) {
-    // currently spring @Async instrumentation doesn't hold the trace back
-    // if spans are created after the @Async span finishes - compensate for this
-    for (Map.Entry<String, AtomicInteger> entry : traceCounts.entrySet()) {
-      if (entry.getKey().startsWith("[servlet.request[spring.handler[SpannerTask.spannerResultSet[grpc.client]") && entry.getValue().get() > 0) {
-        return true
+    // because of the way spanner's session creation works, without authentication,
+    // we can't guarantee a deterministic flush with grpc.client spans attached to
+    // their parents, but orphaned root grpc client spans (those without a parent id
+    // to link to) are unacceptable because they can't be stitched together by the
+    // backend. The writer will only report traces as [grpc.client] if the parent id
+    // is zero.
+    if (!traceCounts.containsKey("[grpc.client]")) {
+      for (Map.Entry<String, AtomicInteger> entry : traceCounts.entrySet()) {
+        if (entry.getKey().startsWith("[servlet.request[spring.handler[SpannerTask.spannerResultSet[grpc.client]")
+          || (entry.getKey().startsWith("[servlet.request[spring.handler[SpannerTask.spannerResultSet[http.request]"))
+          && entry.getValue().get() > 0) {
+          return true
+        }
       }
     }
     return false


### PR DESCRIPTION
Because of the nature of the test, where several authentication attempts will fail, a `grpc.client` span may or may not get attached to the first emitted trace, but will context will propagate to the `grpc.client` span correctly no matter what, so it will be linked to its parent in the backend. 