### PR TITLE
Add setters to span.metrics from MutableSpan

### DIFF
--- a/dd-java-agent/instrumentation/opentelemetry/src/main/java/datadog/trace/instrumentation/opentelemetry/OtelSpan.java
+++ b/dd-java-agent/instrumentation/opentelemetry/src/main/java/datadog/trace/instrumentation/opentelemetry/OtelSpan.java
@@ -202,14 +202,18 @@ public class OtelSpan implements Span, MutableSpan {
   }
 
   @Override
-  public Map<String, Number> getMetrics() {
-    return delegate.getMetrics();
+  public MutableSpan setMetric(final String metric, final int value) {
+    return delegate.setTag(metric, value);
   }
 
   @Override
-  public MutableSpan setMetric(final String metric, final Number value) {
-    delegate.setMetric(metric, value);
-    return this;
+  public MutableSpan setMetric(final String metric, final long value) {
+    return delegate.setTag(metric, value);
+  }
+
+  @Override
+  public MutableSpan setMetric(final String metric, final double value) {
+    return delegate.setTag(metric, value);
   }
 
   @Override

--- a/dd-java-agent/instrumentation/opentelemetry/src/main/java/datadog/trace/instrumentation/opentelemetry/OtelSpan.java
+++ b/dd-java-agent/instrumentation/opentelemetry/src/main/java/datadog/trace/instrumentation/opentelemetry/OtelSpan.java
@@ -207,6 +207,12 @@ public class OtelSpan implements Span, MutableSpan {
   }
 
   @Override
+  public MutableSpan setMetric(final String metric, final Number value) {
+    delegate.setMetric(metric, value);
+    return this;
+  }
+
+  @Override
   public Boolean isError() {
     return delegate.isError();
   }

--- a/dd-java-agent/instrumentation/opentelemetry/src/main/java/datadog/trace/instrumentation/opentelemetry/OtelSpan.java
+++ b/dd-java-agent/instrumentation/opentelemetry/src/main/java/datadog/trace/instrumentation/opentelemetry/OtelSpan.java
@@ -202,18 +202,18 @@ public class OtelSpan implements Span, MutableSpan {
   }
 
   @Override
-  public MutableSpan setMetric(final String metric, final int value) {
-    return delegate.setTag(metric, value);
+  public MutableSpan setMetric(final CharSequence metric, final int value) {
+    return delegate.setMetric(metric, value);
   }
 
   @Override
-  public MutableSpan setMetric(final String metric, final long value) {
-    return delegate.setTag(metric, value);
+  public MutableSpan setMetric(final CharSequence metric, final long value) {
+    return delegate.setMetric(metric, value);
   }
 
   @Override
-  public MutableSpan setMetric(final String metric, final double value) {
-    return delegate.setTag(metric, value);
+  public MutableSpan setMetric(final CharSequence metric, final double value) {
+    return delegate.setMetric(metric, value);
   }
 
   @Override

--- a/dd-java-agent/instrumentation/opentelemetry/src/main/java/datadog/trace/instrumentation/opentelemetry/OtelSpan.java
+++ b/dd-java-agent/instrumentation/opentelemetry/src/main/java/datadog/trace/instrumentation/opentelemetry/OtelSpan.java
@@ -202,6 +202,11 @@ public class OtelSpan implements Span, MutableSpan {
   }
 
   @Override
+  public Map<String, Number> getMetrics() {
+    return delegate.getMetrics();
+  }
+
+  @Override
   public Boolean isError() {
     return delegate.isError();
   }

--- a/dd-java-agent/instrumentation/opentracing/api-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/OTSpan.java
+++ b/dd-java-agent/instrumentation/opentracing/api-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/OTSpan.java
@@ -52,6 +52,12 @@ class OTSpan implements Span, MutableSpan {
   }
 
   @Override
+  public MutableSpan setMetric(final String metric, final Number value) {
+    delegate.setMetric(metric, value);
+    return this;
+  }
+
+  @Override
   public Boolean isError() {
     return delegate.isError();
   }

--- a/dd-java-agent/instrumentation/opentracing/api-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/OTSpan.java
+++ b/dd-java-agent/instrumentation/opentracing/api-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/OTSpan.java
@@ -47,20 +47,20 @@ class OTSpan implements Span, MutableSpan {
   }
 
   @Override
-  public OTSpan setMetric(final String metric, final int value) {
-    delegate.setTag(metric, value);
+  public OTSpan setMetric(final CharSequence metric, final int value) {
+    delegate.setMetric(metric, value);
     return this;
   }
 
   @Override
-  public OTSpan setMetric(final String metric, final long value) {
-    delegate.setTag(metric, value);
+  public OTSpan setMetric(final CharSequence metric, final long value) {
+    delegate.setMetric(metric, value);
     return this;
   }
 
   @Override
-  public OTSpan setMetric(final String metric, final double value) {
-    delegate.setTag(metric, value);
+  public OTSpan setMetric(final CharSequence metric, final double value) {
+    delegate.setMetric(metric, value);
     return this;
   }
 

--- a/dd-java-agent/instrumentation/opentracing/api-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/OTSpan.java
+++ b/dd-java-agent/instrumentation/opentracing/api-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/OTSpan.java
@@ -47,13 +47,20 @@ class OTSpan implements Span, MutableSpan {
   }
 
   @Override
-  public Map<String, Number> getMetrics() {
-    return delegate.getMetrics();
+  public OTSpan setMetric(final String metric, final int value) {
+    delegate.setTag(metric, value);
+    return this;
   }
 
   @Override
-  public MutableSpan setMetric(final String metric, final Number value) {
-    delegate.setMetric(metric, value);
+  public OTSpan setMetric(final String metric, final long value) {
+    delegate.setTag(metric, value);
+    return this;
+  }
+
+  @Override
+  public OTSpan setMetric(final String metric, final double value) {
+    delegate.setTag(metric, value);
     return this;
   }
 

--- a/dd-java-agent/instrumentation/opentracing/api-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/OTSpan.java
+++ b/dd-java-agent/instrumentation/opentracing/api-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/OTSpan.java
@@ -47,6 +47,11 @@ class OTSpan implements Span, MutableSpan {
   }
 
   @Override
+  public Map<String, Number> getMetrics() {
+    return delegate.getMetrics();
+  }
+
+  @Override
   public Boolean isError() {
     return delegate.isError();
   }
@@ -117,7 +122,7 @@ class OTSpan implements Span, MutableSpan {
   }
 
   @Override
-  public MutableSpan setOperationName(CharSequence serviceName) {
+  public MutableSpan setOperationName(final CharSequence serviceName) {
     delegate.setOperationName(serviceName);
     return this;
   }

--- a/dd-java-agent/instrumentation/opentracing/api-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/OTSpan.java
+++ b/dd-java-agent/instrumentation/opentracing/api-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/OTSpan.java
@@ -48,20 +48,20 @@ class OTSpan implements Span, MutableSpan {
   }
 
   @Override
-  public OTSpan setMetric(final String metric, final int value) {
-    delegate.setTag(metric, value);
+  public OTSpan setMetric(final CharSequence metric, final int value) {
+    delegate.setMetric(metric, value);
     return this;
   }
 
   @Override
-  public OTSpan setMetric(final String metric, final long value) {
-    delegate.setTag(metric, value);
+  public OTSpan setMetric(final CharSequence metric, final long value) {
+    delegate.setMetric(metric, value);
     return this;
   }
 
   @Override
-  public OTSpan setMetric(final String metric, final double value) {
-    delegate.setTag(metric, value);
+  public OTSpan setMetric(final CharSequence metric, final double value) {
+    delegate.setMetric(metric, value);
     return this;
   }
 

--- a/dd-java-agent/instrumentation/opentracing/api-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/OTSpan.java
+++ b/dd-java-agent/instrumentation/opentracing/api-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/OTSpan.java
@@ -53,6 +53,12 @@ class OTSpan implements Span, MutableSpan {
   }
 
   @Override
+  public MutableSpan setMetric(final String metric, final Number value) {
+    delegate.setMetric(metric, value);
+    return delegate;
+  }
+
+  @Override
   public Boolean isError() {
     return delegate.isError();
   }

--- a/dd-java-agent/instrumentation/opentracing/api-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/OTSpan.java
+++ b/dd-java-agent/instrumentation/opentracing/api-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/OTSpan.java
@@ -48,14 +48,21 @@ class OTSpan implements Span, MutableSpan {
   }
 
   @Override
-  public Map<String, Number> getMetrics() {
-    return delegate.getMetrics();
+  public OTSpan setMetric(final String metric, final int value) {
+    delegate.setTag(metric, value);
+    return this;
   }
 
   @Override
-  public MutableSpan setMetric(final String metric, final Number value) {
-    delegate.setMetric(metric, value);
-    return delegate;
+  public OTSpan setMetric(final String metric, final long value) {
+    delegate.setTag(metric, value);
+    return this;
+  }
+
+  @Override
+  public OTSpan setMetric(final String metric, final double value) {
+    delegate.setTag(metric, value);
+    return this;
   }
 
   @Override

--- a/dd-java-agent/instrumentation/opentracing/api-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/OTSpan.java
+++ b/dd-java-agent/instrumentation/opentracing/api-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/OTSpan.java
@@ -48,6 +48,11 @@ class OTSpan implements Span, MutableSpan {
   }
 
   @Override
+  public Map<String, Number> getMetrics() {
+    return delegate.getMetrics();
+  }
+
+  @Override
   public Boolean isError() {
     return delegate.isError();
   }
@@ -124,7 +129,7 @@ class OTSpan implements Span, MutableSpan {
   }
 
   @Override
-  public MutableSpan setOperationName(CharSequence operationName) {
+  public MutableSpan setOperationName(final CharSequence operationName) {
     delegate.setOperationName(operationName);
     return this;
   }

--- a/dd-trace-api/src/main/java/datadog/trace/api/interceptor/MutableSpan.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/interceptor/MutableSpan.java
@@ -48,6 +48,8 @@ public interface MutableSpan {
 
   Map<String, Number> getMetrics();
 
+  MutableSpan setMetric(final String metric, final Number value);
+
   Boolean isError();
 
   MutableSpan setError(boolean value);

--- a/dd-trace-api/src/main/java/datadog/trace/api/interceptor/MutableSpan.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/interceptor/MutableSpan.java
@@ -25,11 +25,11 @@ public interface MutableSpan {
   Integer getSamplingPriority();
 
   /**
+   * @param newPriority
+   * @return
    * @deprecated Use {@link io.opentracing.Span#setTag(String, boolean)} instead using either tag
    *     names {@link datadog.trace.api.DDTags#MANUAL_KEEP} or {@link
    *     datadog.trace.api.DDTags#MANUAL_DROP}.
-   * @param newPriority
-   * @return
    */
   @Deprecated
   MutableSpan setSamplingPriority(final int newPriority);
@@ -45,6 +45,8 @@ public interface MutableSpan {
   MutableSpan setTag(final String tag, final boolean value);
 
   MutableSpan setTag(final String tag, final Number value);
+
+  Map<String, Number> getMetrics();
 
   Boolean isError();
 

--- a/dd-trace-api/src/main/java/datadog/trace/api/interceptor/MutableSpan.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/interceptor/MutableSpan.java
@@ -46,11 +46,11 @@ public interface MutableSpan {
 
   MutableSpan setTag(final String tag, final Number value);
 
-  MutableSpan setMetric(final String metric, final int value);
+  MutableSpan setMetric(final CharSequence metric, final int value);
 
-  MutableSpan setMetric(final String metric, final long value);
+  MutableSpan setMetric(final CharSequence metric, final long value);
 
-  MutableSpan setMetric(final String metric, final double value);
+  MutableSpan setMetric(final CharSequence metric, final double value);
 
   Boolean isError();
 

--- a/dd-trace-api/src/main/java/datadog/trace/api/interceptor/MutableSpan.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/interceptor/MutableSpan.java
@@ -46,9 +46,11 @@ public interface MutableSpan {
 
   MutableSpan setTag(final String tag, final Number value);
 
-  Map<String, Number> getMetrics();
+  MutableSpan setMetric(final String metric, final int value);
 
-  MutableSpan setMetric(final String metric, final Number value);
+  MutableSpan setMetric(final String metric, final long value);
+
+  MutableSpan setMetric(final String metric, final double value);
 
   Boolean isError();
 

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/DDSpanJsonAdapter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/DDSpanJsonAdapter.java
@@ -64,8 +64,8 @@ class DDSpanJsonAdapter extends JsonAdapter<DDSpan> {
     writer.value(span.getError());
     writer.name("metrics");
     writer.beginObject();
-    for (final Map.Entry<String, Number> entry : span.getMetrics().entrySet()) {
-      writer.name(entry.getKey());
+    for (final Map.Entry<CharSequence, Number> entry : span.getMetrics().entrySet()) {
+      writer.name(entry.getKey().toString());
       writer.value(entry.getValue());
     }
     writer.endObject();

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -197,6 +197,24 @@ public class DDSpan implements AgentSpan, DDSpanData {
   }
 
   @Override
+  public DDSpan setMetric(final String metric, final int value) {
+    context.setMetric(metric, value);
+    return this;
+  }
+
+  @Override
+  public DDSpan setMetric(final String metric, final long value) {
+    context.setMetric(metric, value);
+    return this;
+  }
+
+  @Override
+  public DDSpan setMetric(final String metric, final double value) {
+    context.setMetric(metric, value);
+    return this;
+  }
+
+  @Override
   public DDSpan setTag(final String tag, final CharSequence value) {
     context.setTag(tag, value);
     return this;
@@ -284,12 +302,6 @@ public class DDSpan implements AgentSpan, DDSpanData {
   @Override
   public Map<String, Number> getMetrics() {
     return context.getMetrics();
-  }
-
-  @Override
-  public DDSpan setMetric(final String metric, final Number value) {
-    context.setMetric(metric, value);
-    return this;
   }
 
   @Override

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -197,19 +197,19 @@ public class DDSpan implements AgentSpan, DDSpanData {
   }
 
   @Override
-  public DDSpan setMetric(final String metric, final int value) {
+  public DDSpan setMetric(final CharSequence metric, final int value) {
     context.setMetric(metric, value);
     return this;
   }
 
   @Override
-  public DDSpan setMetric(final String metric, final long value) {
+  public DDSpan setMetric(final CharSequence metric, final long value) {
     context.setMetric(metric, value);
     return this;
   }
 
   @Override
-  public DDSpan setMetric(final String metric, final double value) {
+  public DDSpan setMetric(final CharSequence metric, final double value) {
     context.setMetric(metric, value);
     return this;
   }
@@ -300,7 +300,7 @@ public class DDSpan implements AgentSpan, DDSpanData {
    * @return metrics for this span
    */
   @Override
-  public Map<String, Number> getMetrics() {
+  public Map<CharSequence, Number> getMetrics() {
     return context.getMetrics();
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -287,6 +287,12 @@ public class DDSpan implements AgentSpan, DDSpanData {
   }
 
   @Override
+  public DDSpan setMetric(final String metric, final Number value) {
+    context.setMetric(metric, value);
+    return this;
+  }
+
+  @Override
   public long getStartTime() {
     return startTimeNano > 0 ? startTimeNano : TimeUnit.MICROSECONDS.toNanos(startTimeMicro);
   }
@@ -353,7 +359,7 @@ public class DDSpan implements AgentSpan, DDSpanData {
 
   @Override
   public String getSpanType() {
-    CharSequence spanType = context.getSpanType();
+    final CharSequence spanType = context.getSpanType();
     return null == spanType ? null : spanType.toString();
   }
 
@@ -369,7 +375,7 @@ public class DDSpan implements AgentSpan, DDSpanData {
   }
 
   @Override
-  public void processTagsAndBaggage(TagsAndBaggageConsumer consumer) {
+  public void processTagsAndBaggage(final TagsAndBaggageConsumer consumer) {
     context.processTagsAndBaggage(consumer);
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpanData.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpanData.java
@@ -23,7 +23,7 @@ public interface DDSpanData {
 
   int getError();
 
-  Map<String, Number> getMetrics();
+  Map<CharSequence, Number> getMetrics();
 
   Map<String, String> getBaggage();
 

--- a/dd-trace-ot/src/main/java/datadog/opentracing/OTSpan.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/OTSpan.java
@@ -48,20 +48,20 @@ class OTSpan implements Span, MutableSpan {
   }
 
   @Override
-  public OTSpan setMetric(final String metric, final int value) {
-    delegate.setTag(metric, value);
+  public OTSpan setMetric(final CharSequence metric, final int value) {
+    delegate.setMetric(metric, value);
     return this;
   }
 
   @Override
-  public OTSpan setMetric(final String metric, final long value) {
-    delegate.setTag(metric, value);
+  public OTSpan setMetric(final CharSequence metric, final long value) {
+    delegate.setMetric(metric, value);
     return this;
   }
 
   @Override
-  public OTSpan setMetric(final String metric, final double value) {
-    delegate.setTag(metric, value);
+  public OTSpan setMetric(final CharSequence metric, final double value) {
+    delegate.setMetric(metric, value);
     return this;
   }
 

--- a/dd-trace-ot/src/main/java/datadog/opentracing/OTSpan.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/OTSpan.java
@@ -48,6 +48,11 @@ class OTSpan implements Span, MutableSpan {
   }
 
   @Override
+  public Map<String, Number> getMetrics() {
+    return delegate.getMetrics();
+  }
+
+  @Override
   public Boolean isError() {
     return delegate.isError();
   }
@@ -109,7 +114,7 @@ class OTSpan implements Span, MutableSpan {
   }
 
   @Override
-  public Span setOperationName(String operationName) {
+  public Span setOperationName(final String operationName) {
     return setOperationName(UTF8BytesString.create(operationName));
   }
 

--- a/dd-trace-ot/src/main/java/datadog/opentracing/OTSpan.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/OTSpan.java
@@ -53,6 +53,12 @@ class OTSpan implements Span, MutableSpan {
   }
 
   @Override
+  public MutableSpan setMetric(final String metric, final Number value) {
+    delegate.setMetric(metric, value);
+    return this;
+  }
+
+  @Override
   public Boolean isError() {
     return delegate.isError();
   }

--- a/dd-trace-ot/src/main/java/datadog/opentracing/OTSpan.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/OTSpan.java
@@ -48,13 +48,20 @@ class OTSpan implements Span, MutableSpan {
   }
 
   @Override
-  public Map<String, Number> getMetrics() {
-    return delegate.getMetrics();
+  public OTSpan setMetric(final String metric, final int value) {
+    delegate.setTag(metric, value);
+    return this;
   }
 
   @Override
-  public MutableSpan setMetric(final String metric, final Number value) {
-    delegate.setMetric(metric, value);
+  public OTSpan setMetric(final String metric, final long value) {
+    delegate.setTag(metric, value);
+    return this;
+  }
+
+  @Override
+  public OTSpan setMetric(final String metric, final double value) {
+    delegate.setTag(metric, value);
     return this;
   }
 

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
@@ -25,13 +25,13 @@ public interface AgentSpan extends MutableSpan {
   AgentSpan setTag(String key, Object value);
 
   @Override
-  AgentSpan setMetric(String key, int value);
+  AgentSpan setMetric(CharSequence key, int value);
 
   @Override
-  AgentSpan setMetric(String key, long value);
+  AgentSpan setMetric(CharSequence key, long value);
 
   @Override
-  AgentSpan setMetric(String key, double value);
+  AgentSpan setMetric(CharSequence key, double value);
 
   @Override
   AgentSpan setSpanType(final CharSequence type);

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
@@ -25,7 +25,13 @@ public interface AgentSpan extends MutableSpan {
   AgentSpan setTag(String key, Object value);
 
   @Override
-  AgentSpan setMetric(String key, Number value);
+  AgentSpan setMetric(String key, int value);
+
+  @Override
+  AgentSpan setMetric(String key, long value);
+
+  @Override
+  AgentSpan setMetric(String key, double value);
 
   @Override
   AgentSpan setSpanType(final CharSequence type);

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
@@ -24,6 +24,10 @@ public interface AgentSpan extends MutableSpan {
 
   AgentSpan setTag(String key, Object value);
 
+  @Override
+  AgentSpan setMetric(String key, Number value);
+
+  @Override
   AgentSpan setSpanType(final CharSequence type);
 
   Object getTag(String key);

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -279,17 +279,17 @@ public class AgentTracer {
     }
 
     @Override
-    public AgentSpan setMetric(final String key, final int value) {
+    public AgentSpan setMetric(final CharSequence key, final int value) {
       return this;
     }
 
     @Override
-    public AgentSpan setMetric(final String key, final long value) {
+    public AgentSpan setMetric(final CharSequence key, final long value) {
       return this;
     }
 
     @Override
-    public AgentSpan setMetric(final String key, final double value) {
+    public AgentSpan setMetric(final CharSequence key, final double value) {
       return this;
     }
 

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -254,11 +254,6 @@ public class AgentTracer {
     }
 
     @Override
-    public Map<String, Number> getMetrics() {
-      return Collections.emptyMap();
-    }
-
-    @Override
     public Boolean isError() {
       return false;
     }
@@ -284,7 +279,17 @@ public class AgentTracer {
     }
 
     @Override
-    public AgentSpan setMetric(final String key, final Number value) {
+    public AgentSpan setMetric(final String key, final int value) {
+      return this;
+    }
+
+    @Override
+    public AgentSpan setMetric(final String key, final long value) {
+      return this;
+    }
+
+    @Override
+    public AgentSpan setMetric(final String key, final double value) {
       return this;
     }
 

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -284,6 +284,11 @@ public class AgentTracer {
     }
 
     @Override
+    public AgentSpan setMetric(final String key, final Number value) {
+      return this;
+    }
+
+    @Override
     public Object getTag(final String key) {
       return null;
     }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -38,7 +38,7 @@ public class AgentTracer {
     return get().activateSpan(span, ScopeSource.INSTRUMENTATION, false);
   }
 
-  public static AgentScope activateSpan(final AgentSpan span, boolean isAsyncPropagating) {
+  public static AgentScope activateSpan(final AgentSpan span, final boolean isAsyncPropagating) {
     return get().activateSpan(span, ScopeSource.INSTRUMENTATION, isAsyncPropagating);
   }
 
@@ -165,7 +165,7 @@ public class AgentTracer {
 
     @Override
     public AgentScope activateSpan(
-        final AgentSpan span, final ScopeSource source, boolean isAsyncPropagating) {
+        final AgentSpan span, final ScopeSource source, final boolean isAsyncPropagating) {
       return NoopAgentScope.INSTANCE;
     }
 
@@ -251,6 +251,11 @@ public class AgentTracer {
     @Override
     public MutableSpan setTag(final String tag, final Number value) {
       return this;
+    }
+
+    @Override
+    public Map<String, Number> getMetrics() {
+      return Collections.emptyMap();
     }
 
     @Override
@@ -354,7 +359,7 @@ public class AgentTracer {
     }
 
     @Override
-    public AgentSpan setTag(String key, CharSequence value) {
+    public AgentSpan setTag(final String key, final CharSequence value) {
       return this;
     }
 


### PR DESCRIPTION
This PR adds an accessor to the `span.metrics` through the `MutableSpan` interface. 