### PR TITLE
Remove unnecessary and confusing isEnabled method on ExcludeFilterProvider

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
@@ -105,15 +105,9 @@ public class AgentInstaller {
     for (final Instrumenter instrumenter : loader) {
       if (instrumenter instanceof ExcludeFilterProvider) {
         ExcludeFilterProvider provider = (ExcludeFilterProvider) instrumenter;
-        if (provider.isEnabled()) {
-          ExcludeFilter.add(provider.excludedClasses());
-          log.debug(
-              "Adding filtered classes from instrumentation {}", instrumenter.getClass().getName());
-        } else {
-          log.debug(
-              "Not adding filtered classes from disabled instrumentation {}",
-              instrumenter.getClass().getName());
-        }
+        ExcludeFilter.add(provider.excludedClasses());
+        log.debug(
+            "Adding filtered classes from instrumentation {}", instrumenter.getClass().getName());
       }
     }
     for (final Instrumenter instrumenter : loader) {

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/ExcludeFilterProvider.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/ExcludeFilterProvider.java
@@ -12,8 +12,6 @@ import java.util.Set;
  * exclusions immediately.
  */
 public interface ExcludeFilterProvider {
-  /** @return If this provider is enabled. */
-  boolean isEnabled();
 
   /**
    * @return A mapping from {@link ExcludeType} -> {@link Set<String>} for the class names that

--- a/dd-java-agent/instrumentation/akka-concurrent/src/main/java/datadog/trace/instrumentation/akka/concurrent/AkkaForkJoinTaskInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-concurrent/src/main/java/datadog/trace/instrumentation/akka/concurrent/AkkaForkJoinTaskInstrumentation.java
@@ -53,11 +53,6 @@ public final class AkkaForkJoinTaskInstrumentation extends Instrumenter.Default
   }
 
   @Override
-  public boolean isEnabled() {
-    return true;
-  }
-
-  @Override
   public Map<ExcludeFilter.ExcludeType, Set<String>> excludedClasses() {
     return Collections.<ExcludeFilter.ExcludeType, Set<String>>singletonMap(
         RUNNABLE_FUTURE,

--- a/dd-java-agent/instrumentation/java-concurrent/java-completablefuture/src/main/java/datadog/trace/instrumentation/java/completablefuture/CompletableFutureUniCompletionInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/java-completablefuture/src/main/java/datadog/trace/instrumentation/java/completablefuture/CompletableFutureUniCompletionInstrumentation.java
@@ -73,11 +73,6 @@ public class CompletableFutureUniCompletionInstrumentation extends Instrumenter.
   }
 
   @Override
-  public boolean isEnabled() {
-    return enabled;
-  }
-
-  @Override
   public Map<ExcludeType, Set<String>> excludedClasses() {
     if (!enabled) {
       return Collections.emptyMap();

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/JavaForkJoinTaskInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/JavaForkJoinTaskInstrumentation.java
@@ -72,11 +72,6 @@ public final class JavaForkJoinTaskInstrumentation extends Instrumenter.Default
   }
 
   @Override
-  public boolean isEnabled() {
-    return true;
-  }
-
-  @Override
   public Map<ExcludeType, Set<String>> excludedClasses() {
     return Collections.<ExcludeType, Set<String>>singletonMap(
         RUNNABLE_FUTURE,

--- a/dd-java-agent/instrumentation/scala-promise-2.10/src/main/java/datadog/trace/instrumentation/scala/promise/CallbackRunnableInstrumentation.java
+++ b/dd-java-agent/instrumentation/scala-promise-2.10/src/main/java/datadog/trace/instrumentation/scala/promise/CallbackRunnableInstrumentation.java
@@ -53,11 +53,6 @@ public class CallbackRunnableInstrumentation extends Instrumenter.Default
   }
 
   @Override
-  public boolean isEnabled() {
-    return true;
-  }
-
-  @Override
   public Map<ExcludeFilter.ExcludeType, Set<String>> excludedClasses() {
     // force other instrumentations (e.g. Runnable) not to deal with this type
     return singletonMap(RUNNABLE, Collections.singleton("scala.concurrent.impl.CallbackRunnable"));

--- a/dd-java-agent/instrumentation/scala-promise-2.13/src/main/java/datadog/trace/instrumentation/scala/concurrent/PromiseTransformationInstrumentation.java
+++ b/dd-java-agent/instrumentation/scala-promise-2.13/src/main/java/datadog/trace/instrumentation/scala/concurrent/PromiseTransformationInstrumentation.java
@@ -54,11 +54,6 @@ public final class PromiseTransformationInstrumentation extends Instrumenter.Def
   }
 
   @Override
-  public boolean isEnabled() {
-    return true;
-  }
-
-  @Override
   public Map<ExcludeFilter.ExcludeType, Set<String>> excludedClasses() {
     // make sure nothing else instruments this
     return singletonMap(

--- a/dd-java-agent/testing/src/test/java/excludefilter/ExcludeFilterProviderTestInstrumentation.java
+++ b/dd-java-agent/testing/src/test/java/excludefilter/ExcludeFilterProviderTestInstrumentation.java
@@ -46,11 +46,6 @@ public class ExcludeFilterProviderTestInstrumentation extends Instrumenter.Defau
   }
 
   @Override
-  public boolean isEnabled() {
-    return enabled;
-  }
-
-  @Override
   public Map<ExcludeFilter.ExcludeType, Set<String>> excludedClasses() {
     EnumMap<ExcludeFilter.ExcludeType, Set<String>> excludedTypes =
         new EnumMap(ExcludeFilter.ExcludeType.class);


### PR DESCRIPTION
This method deciding if an `ExcludeFilterProvider` is enabled, doesn't serve any purpose anymore since there is no _default_ behavior to fall back to for a number of the instrumentations that use this.