### PR TITLE
Fail-fast manual tracer creation in presence of java agent

### DIFF
--- a/dd-smoke-tests/opentracing/src/main/java/datadog/smoketest/opentracing/IncorrectSetupWithAgentApplication.java
+++ b/dd-smoke-tests/opentracing/src/main/java/datadog/smoketest/opentracing/IncorrectSetupWithAgentApplication.java
@@ -1,0 +1,17 @@
+package datadog.smoketest.opentracing;
+
+import datadog.opentracing.DDTracer;
+
+public class IncorrectSetupWithAgentApplication {
+  public static void main(final String[] args) {
+    try {
+      DDTracer.builder().build();
+    } catch (RuntimeException e) {
+      if (e.getMessage().startsWith("Datadog Tracer already installed")) {
+        return;
+      }
+    }
+
+    throw new RuntimeException("build() did not throw exception");
+  }
+}

--- a/dd-smoke-tests/opentracing/src/main/java/datadog/smoketest/opentracing/IncorrectSetupWithAgentApplication.java
+++ b/dd-smoke-tests/opentracing/src/main/java/datadog/smoketest/opentracing/IncorrectSetupWithAgentApplication.java
@@ -6,7 +6,7 @@ public class IncorrectSetupWithAgentApplication {
   public static void main(final String[] args) {
     try {
       DDTracer.builder().build();
-    } catch (RuntimeException e) {
+    } catch (IllegalStateException e) {
       if (e.getMessage().startsWith("Datadog Tracer already installed")) {
         return;
       }

--- a/dd-smoke-tests/opentracing/src/test/groovy/datadog/smoketest/IncorrectSetupWithAgentTest.groovy
+++ b/dd-smoke-tests/opentracing/src/test/groovy/datadog/smoketest/IncorrectSetupWithAgentTest.groovy
@@ -1,0 +1,30 @@
+package datadog.smoketest
+
+import datadog.smoketest.opentracing.IncorrectSetupWithAgentApplication
+import spock.lang.Timeout
+
+import java.util.concurrent.TimeUnit
+
+class IncorrectSetupWithAgentTest extends AbstractSmokeTest {
+  public static final int TIMEOUT_SECS = 30
+
+  @Override
+  ProcessBuilder createProcessBuilder() {
+    List<String> command = new ArrayList<>()
+    command.add(javaPath())
+    command.addAll(defaultJavaProperties)
+    command.addAll((String[]) ["-cp", System.getProperty("datadog.smoketest.shadowJar.path")])
+    command.add(IncorrectSetupWithAgentApplication.name)
+
+    ProcessBuilder processBuilder = new ProcessBuilder(command)
+    processBuilder.directory(new File(buildDirectory))
+
+    return processBuilder
+  }
+
+  @Timeout(value = TIMEOUT_SECS, unit = TimeUnit.SECONDS)
+  def "Application exits without error"() {
+    expect:
+    assert testedProcess.waitFor() == 0
+  }
+}

--- a/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
@@ -201,9 +201,9 @@ public class DDTracer implements Tracer, datadog.trace.api.Tracer {
     // Check if the tracer is already installed by the agent
     // Unable to use "instanceof" because of class renaming
     if (GlobalTracer.get().getClass().getName().equals("datadog.trace.agent.core.CoreTracer")) {
-      log.warn(
-          "Datadog Tracer already installed. NOTE: Manually creating the tracer while using the java agent is not supported");
-      throw new RuntimeException("Datadog Tracer already installed");
+      log.error(
+          "Datadog Tracer already installed by `dd-java-agent`. NOTE: Manually creating the tracer while using `dd-java-agent` is not supported");
+      throw new IllegalStateException("Datadog Tracer already installed");
     }
 
     if (logHandler != null) {

--- a/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
@@ -3,6 +3,7 @@ package datadog.opentracing;
 import com.timgroup.statsd.StatsDClient;
 import datadog.trace.api.Config;
 import datadog.trace.api.DDTags;
+import datadog.trace.api.GlobalTracer;
 import datadog.trace.api.interceptor.TraceInterceptor;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
@@ -196,6 +197,14 @@ public class DDTracer implements Tracer, datadog.trace.api.Tracer {
       final int partialFlushMinSpans,
       final LogHandler logHandler,
       final StatsDClient statsDClient) {
+
+    // Check if the tracer is already installed by the agent
+    // Unable to use "instanceof" because of class renaming
+    if (GlobalTracer.get().getClass().getName().equals("datadog.trace.agent.core.CoreTracer")) {
+      log.warn(
+          "Datadog Tracer already installed. NOTE: Manually creating the tracer while using the java agent is not supported");
+      throw new RuntimeException("Datadog Tracer already installed");
+    }
 
     if (logHandler != null) {
       converter = new TypeConverter(logHandler);


### PR DESCRIPTION
Historically, we would allow the creation of `DDTracer` even when the java agent was installed.  The failure to register was noted in the logs and the application continued normally.

Recently, creating `DDTracer` when the agent was installed causes `java.lang.NoSuchMethodError` because of class renaming.

In both cases, the newly created `DDTracer` can't be used.  This pull request changes the behavior to _fail fast_ by throwing an exception immediately.