### PR TITLE
Add missing equals and hashCode method into datadog.trace.instrumentation.opentracing32.OTSpan

### DIFF
--- a/dd-java-agent/instrumentation/opentracing/api-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/OTSpan.java
+++ b/dd-java-agent/instrumentation/opentracing/api-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/OTSpan.java
@@ -7,6 +7,7 @@ import datadog.trace.instrumentation.opentracing.LogHandler;
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * This class should be castable to MutableSpan since that is the way we've encouraged users to
@@ -203,5 +204,22 @@ class OTSpan implements Span, MutableSpan {
 
   public AgentSpan getDelegate() {
     return delegate;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final OTSpan otSpan = (OTSpan) o;
+    return delegate.equals(otSpan.delegate);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(delegate);
   }
 }

--- a/dd-java-agent/instrumentation/opentracing/api-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/OTSpan.java
+++ b/dd-java-agent/instrumentation/opentracing/api-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/OTSpan.java
@@ -8,6 +8,7 @@ import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.tag.Tag;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * This class should be castable to MutableSpan since that is the way we've encouraged users to
@@ -209,5 +210,22 @@ class OTSpan implements Span, MutableSpan {
 
   public AgentSpan getDelegate() {
     return delegate;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final OTSpan otSpan = (OTSpan) o;
+    return delegate.equals(otSpan.delegate);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(delegate);
   }
 }


### PR DESCRIPTION
It's not possible to check equality of opentracing32.OTSpan intances because it doesn't implement the equals and hashCode methods for the internal agent span. Also the opentracing32.OTSpan class is not part of public API and the getDelegate method is not assessible via the Span or MutableSpan inteface.

At the same time datadog.opentracing.OTSpan has proper implementations of the equals and hashCode methods.