### PR TITLE
Ci-App: Remove /-/ in Gitlab Pipeline URL for tests

### DIFF
--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/ci/GitLabInfo.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/ci/GitLabInfo.java
@@ -33,13 +33,22 @@ class GitLabInfo extends CIProviderInfo {
     ciPipelineId = System.getenv(GITLAB_PIPELINE_ID);
     ciPipelineName = System.getenv(GITLAB_PIPELINE_NAME);
     ciPipelineNumber = System.getenv(GITLAB_PIPELINE_NUMBER);
-    ciPipelineUrl = System.getenv(GITLAB_PIPELINE_URL);
+    ciPipelineUrl = buildPipelineUrl();
     ciJobUrl = System.getenv(GITLAB_JOB_URL);
     ciWorkspacePath = expandTilde(System.getenv(GITLAB_WORKSPACE_PATH));
     gitRepositoryUrl = filterSensitiveInfo(System.getenv(GITLAB_GIT_REPOSITORY_URL));
     gitCommit = System.getenv(GITLAB_GIT_COMMIT);
     gitBranch = normalizeRef(System.getenv(GITLAB_GIT_BRANCH));
     gitTag = normalizeRef(System.getenv(GITLAB_GIT_TAG));
+  }
+
+  private String buildPipelineUrl() {
+    final String pipelineUrl = System.getenv(GITLAB_PIPELINE_URL);
+    if (pipelineUrl == null || pipelineUrl.isEmpty()) {
+      return null;
+    }
+
+    return pipelineUrl.replace("/-/pipelines/", "/pipelines/");
   }
 
   @Override

--- a/internal-api/src/test/groovy/datadog/trace/bootstrap/instrumentation/api/ci/GitLabInfoTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/bootstrap/instrumentation/api/ci/GitLabInfoTest.groovy
@@ -22,7 +22,7 @@ class GitLabInfoTest extends CIProviderInfoTest {
     environmentVariables.set(GITLAB_PIPELINE_ID, "gitlab-pipeline-id")
     environmentVariables.set(GITLAB_PIPELINE_NAME, "gitlab-pipeline-name")
     environmentVariables.set(GITLAB_PIPELINE_NUMBER, "gitlab-pipeline-number")
-    environmentVariables.set(GITLAB_PIPELINE_URL, "gitlab-pipeline-url")
+    environmentVariables.set(GITLAB_PIPELINE_URL, gitlabPipelineUrl)
     environmentVariables.set(GITLAB_JOB_URL, "gitlab-job-url")
     environmentVariables.set(GITLAB_WORKSPACE_PATH, gitlabWorkspace)
     environmentVariables.set(GITLAB_GIT_REPOSITORY_URL, gitlabRepo)
@@ -38,7 +38,7 @@ class GitLabInfoTest extends CIProviderInfoTest {
     ciInfo.ciPipelineId == "gitlab-pipeline-id"
     ciInfo.ciPipelineName == "gitlab-pipeline-name"
     ciInfo.ciPipelineNumber == "gitlab-pipeline-number"
-    ciInfo.ciPipelineUrl == "gitlab-pipeline-url"
+    ciInfo.ciPipelineUrl == ciPipelineUrl
     ciInfo.ciJobUrl == "gitlab-job-url"
     ciInfo.ciWorkspacePath == ciInfoWorkspace
     ciInfo.gitRepositoryUrl == ciInfoRepository
@@ -47,25 +47,27 @@ class GitLabInfoTest extends CIProviderInfoTest {
     ciInfo.gitTag == ciInfoTag
 
     where:
-    gitlabWorkspace | ciInfoWorkspace       | gitlabRepo                                   | ciInfoRepository                | gitlabBranch             | gitlabTag               | ciInfoBranch  | ciInfoTag
-    null            | null                  | "sample"                                     | "sample"                        | "origin/master"          | null                    | "master"      | null
-    ""              | ""                    | "sample"                                     | "sample"                        | "origin/master"          | null                    | "master"      | null
-    "foo/bar"       | "foo/bar"             | "sample"                                     | "sample"                        | "origin/master"          | null                    | "master"      | null
-    "/foo/bar~"     | "/foo/bar~"           | "sample"                                     | "sample"                        | "origin/master"          | null                    | "master"      | null
-    "/foo/~/bar"    | "/foo/~/bar"          | "sample"                                     | "sample"                        | "origin/master"          | null                    | "master"      | null
-    "~/foo/bar"     | userHome + "/foo/bar" | "sample"                                     | "sample"                        | "origin/master"          | null                    | "master"      | null
-    "~foo/bar"      | "~foo/bar"            | "sample"                                     | "sample"                        | "origin/master"          | null                    | "master"      | null
-    "~"             | userHome              | "sample"                                     | "sample"                        | "origin/master"          | null                    | "master"      | null
-    "/foo/bar"      | "/foo/bar"            | "sample"                                     | "sample"                        | "origin/master"          | null                    | "master"      | null
-    "/foo/bar"      | "/foo/bar"            | "sample"                                     | "sample"                        | "refs/heads/master"      | null                    | "master"      | null
-    "/foo/bar"      | "/foo/bar"            | "sample"                                     | "sample"                        | "refs/heads/feature/one" | null                    | "feature/one" | null
-    "/foo/bar"      | "/foo/bar"            | "sample"                                     | "sample"                        | null                     | "origin/tags/0.1.0"     | null          | "0.1.0"
-    "/foo/bar"      | "/foo/bar"            | "sample"                                     | "sample"                        | null                     | "refs/heads/tags/0.1.0" | null          | "0.1.0"
-    "/foo/bar"      | "/foo/bar"            | "sample"                                     | "sample"                        | null                     | "0.1.0"                 | null          | "0.1.0"
-    "/foo/bar"      | "/foo/bar"            | "http://hostname.com/repo.git"               | "http://hostname.com/repo.git"  | "origin/master"          | null                    | "master"      | null
-    "/foo/bar"      | "/foo/bar"            | "http://user@hostname.com/repo.git"          | "http://hostname.com/repo.git"  | "origin/master"          | null                    | "master"      | null
-    "/foo/bar"      | "/foo/bar"            | "http://user%E2%82%AC@hostname.com/repo.git" | "http://hostname.com/repo.git"  | "origin/master"          | null                    | "master"      | null
-    "/foo/bar"      | "/foo/bar"            | "http://user:pwd@hostname.com/repo.git"      | "http://hostname.com/repo.git"  | "origin/master"          | null                    | "master"      | null
-    "/foo/bar"      | "/foo/bar"            | "git@hostname.com:org/repo.git"              | "git@hostname.com:org/repo.git" | "origin/master"          | null                    | "master"      | null
+    gitlabPipelineUrl                   | ciPipelineUrl                     | gitlabWorkspace | ciInfoWorkspace       | gitlabRepo                                   | ciInfoRepository                | gitlabBranch             | gitlabTag               | ciInfoBranch  | ciInfoTag
+    "https://foo/repo/-/pipelines/1234" | "https://foo/repo/pipelines/1234" | null            | null                  | "sample"                                     | "sample"                        | "origin/master"          | null                    | "master"      | null
+    "https://foo/repo/-/pipelines/1234" | "https://foo/repo/pipelines/1234" | ""              | ""                    | "sample"                                     | "sample"                        | "origin/master"          | null                    | "master"      | null
+    "https://foo/repo/-/pipelines/1234" | "https://foo/repo/pipelines/1234" | "foo/bar"       | "foo/bar"             | "sample"                                     | "sample"                        | "origin/master"          | null                    | "master"      | null
+    "https://foo/repo/-/pipelines/1234" | "https://foo/repo/pipelines/1234" | "/foo/bar~"     | "/foo/bar~"           | "sample"                                     | "sample"                        | "origin/master"          | null                    | "master"      | null
+    "https://foo/repo/-/pipelines/1234" | "https://foo/repo/pipelines/1234" | "/foo/~/bar"    | "/foo/~/bar"          | "sample"                                     | "sample"                        | "origin/master"          | null                    | "master"      | null
+    "https://foo/repo/-/pipelines/1234" | "https://foo/repo/pipelines/1234" | "~/foo/bar"     | userHome + "/foo/bar" | "sample"                                     | "sample"                        | "origin/master"          | null                    | "master"      | null
+    "https://foo/repo/-/pipelines/1234" | "https://foo/repo/pipelines/1234" | "~foo/bar"      | "~foo/bar"            | "sample"                                     | "sample"                        | "origin/master"          | null                    | "master"      | null
+    "https://foo/repo/-/pipelines/1234" | "https://foo/repo/pipelines/1234" | "~"             | userHome              | "sample"                                     | "sample"                        | "origin/master"          | null                    | "master"      | null
+    "https://foo/repo/-/pipelines/1234" | "https://foo/repo/pipelines/1234" | "/foo/bar"      | "/foo/bar"            | "sample"                                     | "sample"                        | "origin/master"          | null                    | "master"      | null
+    null                                | null                              | "/foo/bar"      | "/foo/bar"            | "sample"                                     | "sample"                        | "origin/master"          | null                    | "master"      | null
+    ""                                  | null                              | "/foo/bar"      | "/foo/bar"            | "sample"                                     | "sample"                        | "origin/master"          | null                    | "master"      | null
+    "https://foo/repo/-/pipelines/1234" | "https://foo/repo/pipelines/1234" | "/foo/bar"      | "/foo/bar"            | "sample"                                     | "sample"                        | "refs/heads/master"      | null                    | "master"      | null
+    "https://foo/repo/-/pipelines/1234" | "https://foo/repo/pipelines/1234" | "/foo/bar"      | "/foo/bar"            | "sample"                                     | "sample"                        | "refs/heads/feature/one" | null                    | "feature/one" | null
+    "https://foo/repo/-/pipelines/1234" | "https://foo/repo/pipelines/1234" | "/foo/bar"      | "/foo/bar"            | "sample"                                     | "sample"                        | null                     | "origin/tags/0.1.0"     | null          | "0.1.0"
+    "https://foo/repo/-/pipelines/1234" | "https://foo/repo/pipelines/1234" | "/foo/bar"      | "/foo/bar"            | "sample"                                     | "sample"                        | null                     | "refs/heads/tags/0.1.0" | null          | "0.1.0"
+    "https://foo/repo/-/pipelines/1234" | "https://foo/repo/pipelines/1234" | "/foo/bar"      | "/foo/bar"            | "sample"                                     | "sample"                        | null                     | "0.1.0"                 | null          | "0.1.0"
+    "https://foo/repo/-/pipelines/1234" | "https://foo/repo/pipelines/1234" | "/foo/bar"      | "/foo/bar"            | "http://hostname.com/repo.git"               | "http://hostname.com/repo.git"  | "origin/master"          | null                    | "master"      | null
+    "https://foo/repo/-/pipelines/1234" | "https://foo/repo/pipelines/1234" | "/foo/bar"      | "/foo/bar"            | "http://user@hostname.com/repo.git"          | "http://hostname.com/repo.git"  | "origin/master"          | null                    | "master"      | null
+    "https://foo/repo/-/pipelines/1234" | "https://foo/repo/pipelines/1234" | "/foo/bar"      | "/foo/bar"            | "http://user%E2%82%AC@hostname.com/repo.git" | "http://hostname.com/repo.git"  | "origin/master"          | null                    | "master"      | null
+    "https://foo/repo/-/pipelines/1234" | "https://foo/repo/pipelines/1234" | "/foo/bar"      | "/foo/bar"            | "http://user:pwd@hostname.com/repo.git"      | "http://hostname.com/repo.git"  | "origin/master"          | null                    | "master"      | null
+    "https://foo/repo/-/pipelines/1234" | "https://foo/repo/pipelines/1234" | "/foo/bar"      | "/foo/bar"            | "git@hostname.com:org/repo.git"              | "git@hostname.com:org/repo.git" | "origin/master"          | null                    | "master"      | null
   }
 }


### PR DESCRIPTION
This PR removes the `/-/` fragment in the GitLab Pipeline URL for tests to be aligned with the GitLab instrumentation (cc @AdrianLC )