### PR TITLE
Reduce field injection footprint

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/ExcludeFilter.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/ExcludeFilter.java
@@ -1,5 +1,6 @@
 package datadog.trace.bootstrap.instrumentation.java.concurrent;
 
+import java.util.Collection;
 import java.util.EnumMap;
 import java.util.EnumSet;
 import java.util.HashSet;
@@ -78,11 +79,11 @@ public class ExcludeFilter {
    *
    * @param excludeTypes the types to exclude
    */
-  public static void add(Map<ExcludeType, Set<String>> excludeTypes) {
+  public static void add(Map<ExcludeType, ? extends Collection<String>> excludeTypes) {
     if (excludeTypes.isEmpty()) {
       return;
     }
-    for (Map.Entry<ExcludeType, Set<String>> entry : excludeTypes.entrySet()) {
+    for (Map.Entry<ExcludeType, ? extends Collection<String>> entry : excludeTypes.entrySet()) {
       Set<String> currentExcluded = excludedClassNames.get(entry.getKey());
       currentExcluded.addAll(entry.getValue());
     }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/ExcludeFilterProvider.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/ExcludeFilterProvider.java
@@ -1,6 +1,7 @@
 package datadog.trace.agent.tooling;
 
 import datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.ExcludeType;
+import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 
@@ -17,5 +18,5 @@ public interface ExcludeFilterProvider {
    * @return A mapping from {@link ExcludeType} -> {@link Set<String>} for the class names that
    *     should be excluded from broad instrumentations like {@link Runnable}
    */
-  Map<ExcludeType, Set<String>> excludedClasses();
+  Map<ExcludeType, ? extends Collection<String>> excludedClasses();
 }

--- a/dd-java-agent/instrumentation/akka-concurrent/src/main/java/datadog/trace/instrumentation/akka/concurrent/AkkaForkJoinTaskInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-concurrent/src/main/java/datadog/trace/instrumentation/akka/concurrent/AkkaForkJoinTaskInstrumentation.java
@@ -19,11 +19,9 @@ import datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.State;
 import datadog.trace.context.TraceScope;
 import java.util.Arrays;
-import java.util.Collections;
+import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.method.MethodDescription;
@@ -57,14 +55,13 @@ public final class AkkaForkJoinTaskInstrumentation extends Instrumenter.Default
   }
 
   @Override
-  public Map<ExcludeFilter.ExcludeType, Set<String>> excludedClasses() {
-    return Collections.<ExcludeFilter.ExcludeType, Set<String>>singletonMap(
+  public Map<ExcludeFilter.ExcludeType, ? extends Collection<String>> excludedClasses() {
+    return singletonMap(
         RUNNABLE_FUTURE,
-        new HashSet<>(
-            Arrays.asList(
-                "akka.dispatch.forkjoin.ForkJoinTask$AdaptedCallable",
-                "akka.dispatch.forkjoin.ForkJoinTask$AdaptedRunnable",
-                "akka.dispatch.forkjoin.ForkJoinTask$AdaptedRunnableAction")));
+        Arrays.asList(
+            "akka.dispatch.forkjoin.ForkJoinTask$AdaptedCallable",
+            "akka.dispatch.forkjoin.ForkJoinTask$AdaptedRunnable",
+            "akka.dispatch.forkjoin.ForkJoinTask$AdaptedRunnableAction"));
   }
 
   @Override

--- a/dd-java-agent/instrumentation/java-concurrent/java-completablefuture/src/main/java/datadog/trace/instrumentation/java/completablefuture/CompletableFutureUniCompletionInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/java-completablefuture/src/main/java/datadog/trace/instrumentation/java/completablefuture/CompletableFutureUniCompletionInstrumentation.java
@@ -10,11 +10,11 @@ import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.ConcurrentState;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.ExcludeType;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumMap;
-import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
@@ -73,7 +73,7 @@ public class CompletableFutureUniCompletionInstrumentation extends Instrumenter.
   }
 
   @Override
-  public Map<ExcludeType, Set<String>> excludedClasses() {
+  public Map<ExcludeType, ? extends Collection<String>> excludedClasses() {
     if (!enabled) {
       return Collections.emptyMap();
     }
@@ -105,8 +105,8 @@ public class CompletableFutureUniCompletionInstrumentation extends Instrumenter.
       // This is not a subclass of UniCompletion and doesn't have a dependent CompletableFuture
       // "java.util.concurrent.CompletableFuture$Signaller",
     };
-    Set<String> excludedClasses = new HashSet<>(Arrays.asList(classes));
-    EnumMap<ExcludeType, Set<String>> excludedTypes = new EnumMap(ExcludeType.class);
+    List<String> excludedClasses = Arrays.asList(classes);
+    EnumMap<ExcludeType, Collection<String>> excludedTypes = new EnumMap<>(ExcludeType.class);
     excludedTypes.put(ExcludeType.RUNNABLE, excludedClasses);
     excludedTypes.put(ExcludeType.FORK_JOIN_TASK, excludedClasses);
     excludedTypes.put(ExcludeType.FUTURE, excludedClasses);

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/JavaForkJoinTaskInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/JavaForkJoinTaskInstrumentation.java
@@ -4,6 +4,7 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers.ex
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
 import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.ExcludeType.RUNNABLE_FUTURE;
+import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 
@@ -17,11 +18,10 @@ import datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.Exc
 import datadog.trace.bootstrap.instrumentation.java.concurrent.State;
 import datadog.trace.context.TraceScope;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ForkJoinTask;
 import lombok.extern.slf4j.Slf4j;
 import net.bytebuddy.asm.Advice;
@@ -59,7 +59,7 @@ public final class JavaForkJoinTaskInstrumentation extends Instrumenter.Default
 
   @Override
   public Map<String, String> contextStoreForAll() {
-    return Collections.singletonMap("java.util.concurrent.ForkJoinTask", State.class.getName());
+    return singletonMap("java.util.concurrent.ForkJoinTask", State.class.getName());
   }
 
   @Override
@@ -72,14 +72,13 @@ public final class JavaForkJoinTaskInstrumentation extends Instrumenter.Default
   }
 
   @Override
-  public Map<ExcludeType, Set<String>> excludedClasses() {
-    return Collections.<ExcludeType, Set<String>>singletonMap(
+  public Map<ExcludeType, ? extends Collection<String>> excludedClasses() {
+    return singletonMap(
         RUNNABLE_FUTURE,
-        new HashSet<>(
-            Arrays.asList(
-                "java.util.concurrent.ForkJoinTask$AdaptedCallable",
-                "java.util.concurrent.ForkJoinTask$AdaptedRunnable",
-                "java.util.concurrent.ForkJoinTask$AdaptedRunnableAction")));
+        Arrays.asList(
+            "java.util.concurrent.ForkJoinTask$AdaptedCallable",
+            "java.util.concurrent.ForkJoinTask$AdaptedRunnable",
+            "java.util.concurrent.ForkJoinTask$AdaptedRunnableAction"));
   }
 
   public static final class Exec {

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/RunnableFutureInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/RunnableFutureInstrumentation.java
@@ -5,6 +5,7 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScop
 import static datadog.trace.bootstrap.instrumentation.java.concurrent.AdviceUtils.cancelTask;
 import static datadog.trace.bootstrap.instrumentation.java.concurrent.AdviceUtils.endTaskScope;
 import static datadog.trace.bootstrap.instrumentation.java.concurrent.AdviceUtils.startTaskScope;
+import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.ExcludeType.RUNNABLE;
 import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.ExcludeType.RUNNABLE_FUTURE;
 import static java.util.Collections.singletonMap;
 import static java.util.Collections.unmodifiableMap;
@@ -14,11 +15,14 @@ import static net.bytebuddy.matcher.ElementMatchers.nameEndsWith;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 
 import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.ExcludeFilterProvider;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.State;
 import datadog.trace.context.TraceScope;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.RunnableFuture;
@@ -28,7 +32,8 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(Instrumenter.class)
-public final class RunnableFutureInstrumentation extends Instrumenter.Default {
+public final class RunnableFutureInstrumentation extends Instrumenter.Default
+    implements ExcludeFilterProvider {
   public RunnableFutureInstrumentation() {
     super("java_concurrent", "runnable-future");
   }
@@ -62,6 +67,51 @@ public final class RunnableFutureInstrumentation extends Instrumenter.Default {
     transformers.put(isMethod().and(named("run")), getClass().getName() + "$Run");
     transformers.put(isMethod().and(named("cancel")), getClass().getName() + "$Cancel");
     return unmodifiableMap(transformers);
+  }
+
+  @Override
+  public Map<ExcludeFilter.ExcludeType, ? extends Collection<String>> excludedClasses() {
+    // This is a footprint optimisation, not required for correctness.
+    // exclude as many known task implementations as possible because
+    // the fields add up. This could be removed when we stop injecting
+    // Runnables at all.
+    return singletonMap(
+        RUNNABLE,
+        Arrays.asList(
+            "java.util.concurrent.FutureTask",
+            "java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask",
+            "java.util.concurrent.ExecutorCompletionService$QueueingFuture",
+            "io.netty.util.concurrent.PromiseTask",
+            "io.netty.util.concurrent.ScheduledFutureTask",
+            "io.netty.util.concurrent.RunnableScheduledFutureTask",
+            "io.netty.util.concurrent.UnorderedThreadPoolEventExecutor$RunnableScheduledFutureTask",
+            "io.netty.util.concurrent.UnorderedThreadPoolEventExecutor$NonNotifyRunnable",
+            "io.grpc.netty.shaded.io.netty.util.concurrent.PromiseTask",
+            "io.grpc.netty.shaded.io.netty.util.concurrent.ScheduledFutureTask",
+            "io.grpc.netty.shaded.io.netty.util.concurrent.RunnableScheduledFutureTask",
+            "io.grpc.netty.shaded.io.netty.util.concurrent.UnorderedThreadPoolEventExecutor$RunnableScheduledFutureTask",
+            "io.grpc.netty.shaded.io.netty.util.concurrent.UnorderedThreadPoolEventExecutor$NonNotifyRunnable",
+            "com.couchbase.client.deps.io.netty.util.concurrent.PromiseTask",
+            "com.couchbase.client.deps.io.netty.util.concurrent.ScheduledFutureTask",
+            "com.couchbase.client.deps.io.netty.util.concurrent.RunnableScheduledFutureTask",
+            "com.couchbase.client.deps.io.netty.util.concurrent.UnorderedThreadPoolEventExecutor$RunnableScheduledFutureTask",
+            "com.couchbase.client.deps.io.netty.util.concurrent.UnorderedThreadPoolEventExecutor$NonNotifyRunnable",
+            "play.shaded.ahc.io.netty.util.concurrent.PromiseTask",
+            "play.shaded.ahc.io.netty.util.concurrent.ScheduledFutureTask",
+            "play.shaded.ahc.io.netty.util.concurrent.RunnableScheduledFutureTask",
+            "com.google.common.util.concurrent.TrustedListenableFutureTask",
+            "com.google.common.util.concurrent.ListenableFutureTask",
+            "com.google.common.util.concurrent.Futures$CombinerFuture",
+            "org.springframework.util.concurrent.ListenableFutureTask",
+            "org.springframework.util.concurrent.SettableListenableFuture$SettableTask",
+            "jersey.repackaged.com.google.common.util.concurrent.ListenableFutureTask",
+            "com.sun.jersey.client.impl.async.FutureClientResponseListener",
+            "org.apache.http.impl.client.HttpRequestFutureTask",
+            "org.glassfish.enterprise.concurrent.internal.ManagedFutureTask",
+            "org.glassfish.enterprise.concurrent.internal.ManagedScheduledThreadPoolExecutor$ManagedScheduledFutureTask",
+            "org.glassfish.enterprise.concurrent.internal.ManagedScheduledThreadPoolExecutor$ManagedTriggerSingleFutureTask",
+            "org.elasticsearch.common.util.concurrent.PrioritizedEsThreadPoolExecutor$PrioritizedFutureTask",
+            "org.apache.cassandra.concurrent.DebuggableThreadPoolExecutor$LocalSessionWrapper"));
   }
 
   public static final class Construct {

--- a/dd-java-agent/instrumentation/scala-promise-2.10/src/main/java/datadog/trace/instrumentation/scala/promise/CallbackRunnableInstrumentation.java
+++ b/dd-java-agent/instrumentation/scala-promise-2.10/src/main/java/datadog/trace/instrumentation/scala/promise/CallbackRunnableInstrumentation.java
@@ -16,10 +16,10 @@ import datadog.trace.bootstrap.instrumentation.java.concurrent.AdviceUtils;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.State;
 import datadog.trace.context.TraceScope;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
@@ -53,7 +53,7 @@ public class CallbackRunnableInstrumentation extends Instrumenter.Default
   }
 
   @Override
-  public Map<ExcludeFilter.ExcludeType, Set<String>> excludedClasses() {
+  public Map<ExcludeFilter.ExcludeType, ? extends Collection<String>> excludedClasses() {
     // force other instrumentations (e.g. Runnable) not to deal with this type
     return singletonMap(RUNNABLE, Collections.singleton("scala.concurrent.impl.CallbackRunnable"));
   }

--- a/dd-java-agent/instrumentation/scala-promise-2.13/src/main/java/datadog/trace/instrumentation/scala/concurrent/PromiseTransformationInstrumentation.java
+++ b/dd-java-agent/instrumentation/scala-promise-2.13/src/main/java/datadog/trace/instrumentation/scala/concurrent/PromiseTransformationInstrumentation.java
@@ -16,10 +16,10 @@ import datadog.trace.bootstrap.instrumentation.java.concurrent.AdviceUtils;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.State;
 import datadog.trace.context.TraceScope;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
@@ -54,7 +54,7 @@ public final class PromiseTransformationInstrumentation extends Instrumenter.Def
   }
 
   @Override
-  public Map<ExcludeFilter.ExcludeType, Set<String>> excludedClasses() {
+  public Map<ExcludeFilter.ExcludeType, ? extends Collection<String>> excludedClasses() {
     // make sure nothing else instruments this
     return singletonMap(
         RUNNABLE, Collections.singleton("scala.concurrent.impl.Promise$Transformation"));

--- a/dd-java-agent/testing/src/test/java/excludefilter/ExcludeFilterProviderTestInstrumentation.java
+++ b/dd-java-agent/testing/src/test/java/excludefilter/ExcludeFilterProviderTestInstrumentation.java
@@ -8,12 +8,11 @@ import datadog.trace.agent.tooling.ExcludeFilterProvider;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumMap;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.Callable;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
@@ -46,22 +45,19 @@ public class ExcludeFilterProviderTestInstrumentation extends Instrumenter.Defau
   }
 
   @Override
-  public Map<ExcludeFilter.ExcludeType, Set<String>> excludedClasses() {
-    EnumMap<ExcludeFilter.ExcludeType, Set<String>> excludedTypes =
-        new EnumMap(ExcludeFilter.ExcludeType.class);
+  public Map<ExcludeFilter.ExcludeType, ? extends Collection<String>> excludedClasses() {
+    EnumMap<ExcludeFilter.ExcludeType, Collection<String>> excludedTypes =
+        new EnumMap<>(ExcludeFilter.ExcludeType.class);
     excludedTypes.put(
         RUNNABLE,
-        new HashSet(
-            Arrays.asList(
-                ExcludedRunnable.class.getName(), CallableExcludedRunnable.class.getName())));
+        Arrays.asList(ExcludedRunnable.class.getName(), CallableExcludedRunnable.class.getName()));
     excludedTypes.put(
         CALLABLE,
-        new HashSet(
-            Arrays.asList(
-                ExcludedCallable.class.getName(),
-                RunnableExcludedCallable.class.getName(),
-                "net.sf.cglib.core.internal.LoadingCache$2" // Excluded for global ignore matcher
-                )));
+        Arrays.asList(
+            ExcludedCallable.class.getName(),
+            RunnableExcludedCallable.class.getName(),
+            "net.sf.cglib.core.internal.LoadingCache$2" // Excluded for global ignore matcher
+            ));
     return excludedTypes;
   }
 

--- a/dd-smoke-tests/field-injection/src/test/groovy/datadog/smoketest/FieldInjectionSmokeTest.groovy
+++ b/dd-smoke-tests/field-injection/src/test/groovy/datadog/smoketest/FieldInjectionSmokeTest.groovy
@@ -33,9 +33,8 @@ class FieldInjectionSmokeTest extends Specification {
       new HashSet<>([fieldName(ForkJoinTask)]))
     testedTypesAndExpectedFields.put(RecursiveTask.getName(),
       new HashSet<>([fieldName(ForkJoinTask)]))
-    // TODO - want rid of the Runnable field
     testedTypesAndExpectedFields.put(FutureTask.getName(),
-      new HashSet<>([fieldName(RunnableFuture), fieldName(Runnable)]))
+      new HashSet<>([fieldName(RunnableFuture)]))
     String jar = System.getProperty("datadog.smoketest.fieldinjection.shadowJar.path")
     List<String> command = new ArrayList<>()
     command.add(javaPath())


### PR DESCRIPTION
This reduces the overhead of injected fields by manually excludes as many instrumentable `RunnableFuture`s as possible to prevent `RunnableInstrumentation` from injecting these types. These changes reduces field injection footprint from `2 * depth * width` to `depth * width` in most cases.