### PR TITLE
Rename agent thread group to 'dd-trace-java'

### DIFF
--- a/internal-api/src/main/java/datadog/trace/util/DaemonThreadFactory.java
+++ b/internal-api/src/main/java/datadog/trace/util/DaemonThreadFactory.java
@@ -4,7 +4,7 @@ import java.util.concurrent.ThreadFactory;
 
 /** A {@link ThreadFactory} implementation that starts all {@link Thread} as daemons. */
 public final class DaemonThreadFactory implements ThreadFactory {
-  public static final ThreadGroup AGENT_THREAD_GROUP = new ThreadGroup("dd-java-agent");
+  public static final ThreadGroup AGENT_THREAD_GROUP = new ThreadGroup("dd-trace-java");
 
   public static final DaemonThreadFactory TRACE_MONITOR =
       new DaemonThreadFactory("dd-trace-monitor");


### PR DESCRIPTION
as suggested by @tylerbenson in https://github.com/DataDog/dd-trace-java/pull/1998#discussion_r507799700