### PR TITLE
Port kotlin coroutines intrumentation from otel

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/AdditionalLibraryIgnoresMatcher.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/AdditionalLibraryIgnoresMatcher.java
@@ -295,6 +295,9 @@ public class AdditionalLibraryIgnoresMatcher<T extends TypeDescription>
 
     // kotlin, note we do not ignore kotlinx because we instrument coroutins code
     if (name.startsWith("kotlin.")) {
+      if (name.equals("kotlin.coroutines.jvm.internal.DebugProbesKt")) {
+        return false;
+      }
       return true;
     }
 

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/AbstractExecutorInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/AbstractExecutorInstrumentation.java
@@ -45,7 +45,6 @@ public abstract class AbstractExecutorInstrumentation extends Instrumenter.Defau
       PERMITTED_EXECUTORS_PREFIXES = Collections.emptyList();
     } else {
       final String[] whitelist = {
-        "kotlinx.coroutines.scheduling.CoroutineScheduler",
         "play.api.libs.streams.Execution$trampoline$",
         "scala.concurrent.Future$InternalCallbackExecutor$",
         "scala.concurrent.impl.ExecutionContextImpl",

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/NonStandardExecutorInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/NonStandardExecutorInstrumentation.java
@@ -8,7 +8,6 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.State;
-import java.util.HashMap;
 import java.util.Map;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.matcher.ElementMatcher;
@@ -27,16 +26,8 @@ public final class NonStandardExecutorInstrumentation extends AbstractExecutorIn
 
   @Override
   public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
-    final Map<ElementMatcher<? super MethodDescription>, String> transformers = new HashMap<>();
-    transformers.put( // kotlinx.coroutines.scheduling.CoroutineScheduler
-        named("dispatch")
-            .and(takesArgument(0, Runnable.class))
-            .and(takesArgument(1, named("kotlinx.coroutines.scheduling.TaskContext"))),
-        JavaExecutorInstrumentation.class.getName() + "$SetExecuteRunnableStateAdvice");
-
-    transformers.put( // org.eclipse.jetty.util.thread.QueuedThreadPool
+    return singletonMap( // org.eclipse.jetty.util.thread.QueuedThreadPool
         named("dispatch").and(takesArguments(1)).and(takesArgument(0, Runnable.class)),
         JavaExecutorInstrumentation.class.getName() + "$SetExecuteRunnableStateAdvice");
-    return transformers;
   }
 }

--- a/dd-java-agent/instrumentation/kotlin-coroutines/kotlin-coroutines.gradle
+++ b/dd-java-agent/instrumentation/kotlin-coroutines/kotlin-coroutines.gradle
@@ -5,6 +5,9 @@ dependencies {
   implementation project(':dd-java-agent:instrumentation:java-concurrent')
   testCompile project(':dd-trace-api')
 
+  compileOnly 'org.jetbrains.kotlin:kotlin-stdlib-common:1.3.72'
+  compileOnly 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.7'
+
   testCompile deps.kotlin
   testCompile deps.coroutines
 

--- a/dd-java-agent/instrumentation/kotlin-coroutines/src/main/java/datadog/trace/instrumentation/kotlincoroutines/KotlinProbeInstrumentation.java
+++ b/dd-java-agent/instrumentation/kotlin-coroutines/src/main/java/datadog/trace/instrumentation/kotlincoroutines/KotlinProbeInstrumentation.java
@@ -79,7 +79,6 @@ public class KotlinProbeInstrumentation extends Instrumenter.Default {
         @Advice.Return(readOnly = false) kotlin.coroutines.Continuation retVal) {
       if (!(retVal instanceof CoroutineWrapper)) {
         retVal = new CoroutineWrapper(retVal);
-        ;
       }
     }
   }

--- a/dd-java-agent/instrumentation/kotlin-coroutines/src/main/java/datadog/trace/instrumentation/kotlincoroutines/KotlinProbeInstrumentation.java
+++ b/dd-java-agent/instrumentation/kotlin-coroutines/src/main/java/datadog/trace/instrumentation/kotlincoroutines/KotlinProbeInstrumentation.java
@@ -1,0 +1,206 @@
+package datadog.trace.instrumentation.kotlincoroutines;
+
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.context.TraceScope;
+import java.util.HashMap;
+import java.util.Map;
+import kotlin.coroutines.Continuation;
+import kotlin.coroutines.CoroutineContext;
+import kotlin.jvm.functions.Function2;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+@AutoService(Instrumenter.class)
+public class KotlinProbeInstrumentation extends Instrumenter.Default {
+  /*
+  Kotlin coroutines with suspend functions are a form of cooperative "userland" threading
+  (you might also know this pattern as "fibers" or "green threading", where the OS/kernel-level thread
+  has no idea of switching between tasks.  Fortunately kotlin exposes hooks for the key events: knowing when
+  coroutines are being created, when they are suspended (swapped out/inactive), and when they are resumed (about to
+  run again).
+
+  Without this instrumentation, heavy concurrency and usage of kotlin suspend functions will break causality
+  and cause nonsensical span parents/context propagation.  This is because a single JVM thread will run a series of
+  coroutines in an "arbitrary" order, and a context set by coroutine A (which then gets suspended) will be picked up
+  by completely-unrelated coroutine B.
+
+  The basic strategy here is:
+  1) Use the DebugProbes callbacks to learn about coroutine create, resume, and suspend operations
+  2) Wrap the creation Coroutine and its Context and use that wrapping to add an extra Context "key"
+  3) Use the callback for resume and suspend to manipulate our context "key" whereby an appropriate state
+     object can be found (tied to the chain of Continuations in the Coroutine).
+  */
+
+  public KotlinProbeInstrumentation() {
+    super("kotlin-coroutines");
+  }
+
+  @Override
+  public ElementMatcher<? super TypeDescription> typeMatcher() {
+    return named("kotlin.coroutines.jvm.internal.DebugProbesKt");
+  }
+
+  @Override
+  public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
+    final Map<ElementMatcher<? super MethodDescription>, String> transformers = new HashMap<>();
+    transformers.put(
+        named("probeCoroutineCreated").and(takesArguments(1)),
+        CoroutineCreatedAdvice.class.getName());
+    transformers.put(
+        named("probeCoroutineResumed").and(takesArguments(1)),
+        CoroutineResumedAdvice.class.getName());
+    transformers.put(
+        named("probeCoroutineSuspended").and(takesArguments(1)),
+        CoroutineSuspendedAdvice.class.getName());
+    return transformers;
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {
+      KotlinProbeInstrumentation.class.getName() + "$CoroutineWrapper",
+      KotlinProbeInstrumentation.class.getName() + "$TraceScopeKey",
+      KotlinProbeInstrumentation.class.getName() + "$CoroutineContextWrapper"
+    };
+  }
+
+  public static class CoroutineCreatedAdvice {
+    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
+    public static void exit(
+        @Advice.Return(readOnly = false) kotlin.coroutines.Continuation retVal) {
+      if (!(retVal instanceof CoroutineWrapper)) {
+        retVal = new CoroutineWrapper(retVal);
+        ;
+      }
+    }
+  }
+
+  public static class CoroutineResumedAdvice {
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static void enter(
+        @Advice.Argument(0) final kotlin.coroutines.Continuation continuation) {
+      final CoroutineContextWrapper w = continuation.getContext().get(TraceScopeKey.INSTANCE);
+      if (w != null) {
+        w.tracingResume();
+      }
+    }
+  }
+
+  public static class CoroutineSuspendedAdvice {
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static void enter(
+        @Advice.Argument(0) final kotlin.coroutines.Continuation continuation) {
+      final CoroutineContextWrapper w = continuation.getContext().get(TraceScopeKey.INSTANCE);
+      if (w != null) {
+        w.tracingSuspend();
+      }
+    }
+  }
+
+  public static class TraceScopeKey implements CoroutineContext.Key<CoroutineContextWrapper> {
+    public static final TraceScopeKey INSTANCE = new TraceScopeKey();
+  }
+
+  public static class CoroutineWrapper implements kotlin.coroutines.Continuation {
+    private final Continuation proxy;
+    public final CoroutineContextWrapper contextWrapper;
+
+    public CoroutineWrapper(Continuation proxy) {
+      this.proxy = proxy;
+      this.contextWrapper = new CoroutineContextWrapper(proxy.getContext());
+    }
+
+    public String toString() {
+      return proxy.toString();
+    }
+
+    @NotNull
+    @Override
+    public CoroutineContext getContext() {
+      return contextWrapper;
+    }
+
+    @Override
+    public void resumeWith(@NotNull Object o) {
+      proxy.resumeWith(o);
+    }
+  }
+
+  public static class CoroutineContextWrapper
+      implements CoroutineContext, CoroutineContext.Element {
+    private final CoroutineContext proxy;
+    private TraceScope currentScope;
+    private TraceScope.Continuation currentContinuation;
+    // private TraceScope previousScope;
+    // private TraceScope.Continuation previousContinuation;
+
+    public CoroutineContextWrapper(CoroutineContext proxy) {
+      this.proxy = proxy;
+      currentScope = activeScope();
+      if (currentScope != null) {
+        currentContinuation = activeScope().capture();
+      }
+    }
+
+    @Override
+    public <R> R fold(R r, @NotNull Function2<? super R, ? super Element, ? extends R> function2) {
+      return proxy.fold(r, function2);
+    }
+
+    @Nullable
+    @Override
+    public <E extends Element> E get(@NotNull Key<E> key) {
+      if (key == TraceScopeKey.INSTANCE) {
+        return (E) this;
+      }
+      return proxy.get(key);
+    }
+
+    @NotNull
+    @Override
+    public CoroutineContext minusKey(@NotNull Key<?> key) {
+      // I can't be removed!
+      return proxy.minusKey(key);
+    }
+
+    @NotNull
+    @Override
+    public CoroutineContext plus(@NotNull CoroutineContext coroutineContext) {
+      return proxy.plus(coroutineContext);
+    }
+
+    public String toString() {
+      return proxy.toString();
+    }
+
+    @NotNull
+    @Override
+    public Key<?> getKey() {
+      return TraceScopeKey.INSTANCE;
+    }
+
+    // Actual tracing context-switch logic
+    public void tracingSuspend() {
+      if (currentScope != null) {
+        currentContinuation = currentScope.capture();
+      }
+      currentScope = activeScope();
+    }
+
+    public void tracingResume() {
+      if (currentContinuation != null) {
+        currentScope = currentContinuation.activate();
+        currentScope.setAsyncPropagation(true);
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/kotlin-coroutines/src/main/java/datadog/trace/instrumentation/kotlincoroutines/KotlinProbeInstrumentation.java
+++ b/dd-java-agent/instrumentation/kotlin-coroutines/src/main/java/datadog/trace/instrumentation/kotlincoroutines/KotlinProbeInstrumentation.java
@@ -137,17 +137,12 @@ public class KotlinProbeInstrumentation extends Instrumenter.Default {
   public static class CoroutineContextWrapper
       implements CoroutineContext, CoroutineContext.Element {
     private final CoroutineContext proxy;
-    private TraceScope currentScope;
-    private TraceScope.Continuation currentContinuation;
-    // private TraceScope previousScope;
-    // private TraceScope.Continuation previousContinuation;
+    private TraceScope.Continuation continuation;
+    private TraceScope scope;
 
     public CoroutineContextWrapper(CoroutineContext proxy) {
       this.proxy = proxy;
-      currentScope = activeScope();
-      if (currentScope != null) {
-        currentContinuation = activeScope().capture();
-      }
+      scope = activeScope();
     }
 
     @Override
@@ -187,19 +182,14 @@ public class KotlinProbeInstrumentation extends Instrumenter.Default {
       return TraceScopeKey.INSTANCE;
     }
 
-    // Actual tracing context-switch logic
     public void tracingSuspend() {
-      if (currentScope != null) {
-        currentContinuation = currentScope.capture();
-      }
-      currentScope = activeScope();
+      continuation = scope.capture();
+      scope = continuation.activate();
     }
 
     public void tracingResume() {
-      if (currentContinuation != null) {
-        currentScope = currentContinuation.activate();
-        currentScope.setAsyncPropagation(true);
-      }
+      continuation = scope.capture();
+      scope = continuation.activate();
     }
   }
 }

--- a/dd-java-agent/instrumentation/kotlin-coroutines/src/test/groovy/KotlinCoroutineInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/kotlin-coroutines/src/test/groovy/KotlinCoroutineInstrumentationTest.groovy
@@ -8,10 +8,11 @@ class KotlinCoroutineInstrumentationTest extends AgentTestRunner {
   static dispatchersToTest = [
     Dispatchers.Default,
     Dispatchers.IO,
-    Dispatchers.Unconfined,
-    ThreadPoolDispatcherKt.newFixedThreadPoolContext(2, "Fixed-Thread-Pool"),
+    // Dispatchers.Unconfined,
     ThreadPoolDispatcherKt.newSingleThreadContext("Single-Thread"),
-  ]
+    ThreadPoolDispatcherKt.newFixedThreadPoolContext(2, "8-Fixed-Thread-Pool"),
+    ThreadPoolDispatcherKt.newFixedThreadPoolContext(8, "8-Fixed-Thread-Pool"),
+    ]
 
   def "kotlin traced across channels"() {
     setup:
@@ -65,7 +66,7 @@ class KotlinCoroutineInstrumentationTest extends AgentTestRunner {
 
   def "kotlin either deferred completion"() {
     setup:
-    KotlinCoroutineTests kotlinTest = new KotlinCoroutineTests(Dispatchers.Default)
+    KotlinCoroutineTests kotlinTest = new KotlinCoroutineTests(dispatcher)
     int expectedNumberOfSpans = kotlinTest.traceWithDeferred()
     TEST_WRITER.waitForTraces(1)
     List<DDSpan> trace = TEST_WRITER.get(0)
@@ -84,7 +85,7 @@ class KotlinCoroutineInstrumentationTest extends AgentTestRunner {
 
   def "kotlin first completed deferred"() {
     setup:
-    KotlinCoroutineTests kotlinTest = new KotlinCoroutineTests(Dispatchers.Default)
+    KotlinCoroutineTests kotlinTest = new KotlinCoroutineTests(dispatcher)
     int expectedNumberOfSpans = kotlinTest.tracedWithDeferredFirstCompletions()
     TEST_WRITER.waitForTraces(1)
     List<DDSpan> trace = TEST_WRITER.get(0)
@@ -108,4 +109,46 @@ class KotlinCoroutineInstrumentationTest extends AgentTestRunner {
     }
     return null
   }
+
+//  def "test concurrent suspend functions"() {
+//    setup:
+//    KotlinCoroutineTests kotlinTest = new KotlinCoroutineTests(Dispatchers.Default)
+//    int numIters = 100
+//    HashSet<Long> seenItersA = new HashSet<>()
+//    HashSet<Long> seenItersB = new HashSet<>()
+//    HashSet<Long> expectedIters = new HashSet<>((0L..(numIters-1)).toList())
+//
+//    when:
+//    kotlinTest.launchConcurrentSuspendFunctions(numIters)
+//
+//    then:
+//    // This generates numIters each of "a calls a2" and "b calls b2" traces.  Each
+//    // trace should have a single pair of spans (a and a2) and each of those spans
+//    // should have the same iteration number (attribute "iter").
+//    // The traces are in some random order, so let's keep track and make sure we see
+//    // each iteration # exactly once
+//    assertTraces(numIters*2) {
+//      for(int i=0; i < numIters*2; i++) {
+//        trace(i, 2) {
+//          boolean a = false
+//          long iter = -1
+//          span(0) {
+//            a = span.name.matches("a")
+//            iter = span.getAttributes().get("iter").getLongValue()
+//            (a ? seenItersA : seenItersB).add(iter)
+//            operationName(a ? "a" : "b")
+//          }
+//          span(1) {
+//            operationName(a ? "a2" : "b2")
+//            childOf(span(0))
+//            assert span.getAttributes().get("iter").getLongValue() == iter
+//
+//          }
+//        }
+//      }
+//    }
+//    assert seenItersA.equals(expectedIters)
+//    assert seenItersB.equals(expectedIters)
+//  }
+
 }

--- a/dd-java-agent/instrumentation/kotlin-coroutines/src/test/groovy/KotlinCoroutineInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/kotlin-coroutines/src/test/groovy/KotlinCoroutineInstrumentationTest.groovy
@@ -8,11 +8,11 @@ class KotlinCoroutineInstrumentationTest extends AgentTestRunner {
   static dispatchersToTest = [
     Dispatchers.Default,
     Dispatchers.IO,
-    // Dispatchers.Unconfined,
+    //Dispatchers.Unconfined,
     ThreadPoolDispatcherKt.newSingleThreadContext("Single-Thread"),
-    ThreadPoolDispatcherKt.newFixedThreadPoolContext(2, "8-Fixed-Thread-Pool"),
+    ThreadPoolDispatcherKt.newFixedThreadPoolContext(2, "2-Fixed-Thread-Pool"),
     ThreadPoolDispatcherKt.newFixedThreadPoolContext(8, "8-Fixed-Thread-Pool"),
-    ]
+  ]
 
   def "kotlin traced across channels"() {
     setup:


### PR DESCRIPTION
Move kotlin instrumentation from java-concurrent to separate instrumentation.  
Making new tests work can be in next PR