### PR TITLE
[PROF-2013] Update agent error message for 8u272

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/ControllerFactory.java
+++ b/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/ControllerFactory.java
@@ -69,13 +69,13 @@ public final class ControllerFactory {
         if (javaVendor.startsWith("Azul Systems")) {
           return "; it requires Zulu Java 8 (1.8.0_212+).";
         }
-        String javaRuntimeName = System.getProperty("java.runtime.name", "");
+        final String javaRuntimeName = System.getProperty("java.runtime.name", "");
         if (javaVendor.startsWith("Oracle") && javaRuntimeName.startsWith("OpenJDK")) {
           // this is a upstream build from openjdk docker repository for example
           return "; it requires 1.8.0_272+ OpenJDK builds (upstream)";
         }
         if (javaRuntimeName.startsWith("OpenJDK")) {
-          return "; it requires 1.8.0_262+ OpenJDK builds from the following vendors: AdoptOpenJDK, Amazon Corretto, Azul Zulu, BellSoft Liberica";
+          return "; it requires 1.8.0_272+ OpenJDK builds from the following vendors: AdoptOpenJDK, Amazon Corretto, Azul Zulu, BellSoft Liberica";
         }
       }
       return "; it requires OpenJDK 11+, Oracle Java 11+, or Zulu Java 8 (1.8.0_212+).";

--- a/dd-java-agent/agent-profiling/profiling-controller/src/test/java/com/datadog/profiling/controller/ControllerFactoryTest.java
+++ b/dd-java-agent/agent-profiling/profiling-controller/src/test/java/com/datadog/profiling/controller/ControllerFactoryTest.java
@@ -40,7 +40,7 @@ public class ControllerFactoryTest {
       expected = "Not enabling profiling; it requires Oracle Java 11+.";
     } else if ("OpenJDK Runtime Environment".equals(javaRuntimeName)) {
       expected =
-          "Not enabling profiling; it requires 1.8.0_262+ OpenJDK builds from the following vendors: AdoptOpenJDK, Amazon Corretto, Azul Zulu, BellSoft Liberica";
+          "Not enabling profiling; it requires 1.8.0_272+ OpenJDK builds from the following vendors: AdoptOpenJDK, Amazon Corretto, Azul Zulu, BellSoft Liberica";
     }
     assertEquals(
         expected,


### PR DESCRIPTION
8u272 includes JFR and will be generally available October 20, 2020

From https://wiki.openjdk.java.net/display/jdk8u/Main
> Tuesday, October 20th 2020: GA; OpenJDK 8u272 released

[PROF-2013]

[PROF-2013]: https://datadoghq.atlassian.net/browse/PROF-2013