### PR TITLE
Update Play root span only if there is one

### DIFF
--- a/dd-java-agent/instrumentation/play-2.3/src/main/java8/datadog/trace/instrumentation/play23/PlayAdvice.java
+++ b/dd-java-agent/instrumentation/play-2.3/src/main/java8/datadog/trace/instrumentation/play23/PlayAdvice.java
@@ -66,7 +66,9 @@ public class PlayAdvice {
     // span finished in RequestCompleteCallback
 
     final AgentSpan rootSpan = activeSpan();
-    // set the resource name on the upstream akka/netty span
-    DECORATE.onRequest(rootSpan, req);
+    // set the resource name on the upstream akka/netty span if there is one
+    if (rootSpan != null) {
+      DECORATE.onRequest(rootSpan, req);
+    }
   }
 }

--- a/dd-java-agent/instrumentation/play-2.4/src/main/java8/datadog/trace/instrumentation/play24/PlayAdvice.java
+++ b/dd-java-agent/instrumentation/play-2.4/src/main/java8/datadog/trace/instrumentation/play24/PlayAdvice.java
@@ -80,8 +80,10 @@ public class PlayAdvice {
     // span finished in RequestCompleteCallback
 
     final AgentSpan rootSpan = activeSpan();
-    // set the resource name on the upstream akka/netty span
-    DECORATE.onRequest(rootSpan, req);
+    // set the resource name on the upstream akka/netty span if there is one
+    if (rootSpan != null) {
+      DECORATE.onRequest(rootSpan, req);
+    }
   }
 
   // Unused method for muzzle to allow only 2.4-2.5

--- a/dd-java-agent/instrumentation/play-2.6/src/main/java8/datadog/trace/instrumentation/play26/PlayAdvice.java
+++ b/dd-java-agent/instrumentation/play-2.6/src/main/java8/datadog/trace/instrumentation/play26/PlayAdvice.java
@@ -78,7 +78,9 @@ public class PlayAdvice {
     // span finished in RequestCompleteCallback
 
     final AgentSpan rootSpan = activeSpan();
-    // set the resource name on the upstream akka/netty span
-    DECORATE.onRequest(rootSpan, req);
+    // set the resource name on the upstream akka/netty span if there is one
+    if (rootSpan != null) {
+      DECORATE.onRequest(rootSpan, req);
+    }
   }
 }


### PR DESCRIPTION
Not sure that this will ever happen in a real world setting, but it logs exceptions while running the `play` test suite with agent debug logging enabled.