### PR TITLE
pass executed Runnables through AbstractExecutorService.newTaskFor to get free context propagation

### DIFF
--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/AbstractExecutorInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/AbstractExecutorInstrumentation.java
@@ -45,30 +45,12 @@ public abstract class AbstractExecutorInstrumentation extends Instrumenter.Defau
       PERMITTED_EXECUTORS_PREFIXES = Collections.emptyList();
     } else {
       final String[] whitelist = {
-        "io.netty.channel.epoll.EpollEventLoop",
-        "io.netty.channel.epoll.EpollEventLoopGroup",
-        "io.netty.channel.MultithreadEventLoopGroup",
-        "io.netty.channel.nio.NioEventLoop",
-        "io.netty.channel.nio.NioEventLoopGroup",
-        "io.netty.channel.SingleThreadEventLoop",
-        "io.netty.util.concurrent.AbstractEventExecutor",
-        "io.netty.util.concurrent.AbstractEventExecutorGroup",
-        "io.netty.util.concurrent.AbstractScheduledEventExecutor",
-        "io.netty.util.concurrent.DefaultEventExecutor",
-        "io.netty.util.concurrent.DefaultEventExecutorGroup",
-        "io.netty.util.concurrent.GlobalEventExecutor",
-        "io.netty.util.concurrent.MultithreadEventExecutorGroup",
-        "io.netty.util.concurrent.SingleThreadEventExecutor",
-        "java.util.concurrent.AbstractExecutorService",
-        "java.util.concurrent.CompletableFuture$ThreadPerTaskExecutor",
-        "java.util.concurrent.ThreadPoolExecutor",
         "kotlinx.coroutines.scheduling.CoroutineScheduler",
-        "org.eclipse.jetty.util.thread.QueuedThreadPool",
-        "org.eclipse.jetty.util.thread.ReservedThreadExecutor",
-        "org.glassfish.grizzly.threadpool.GrizzlyExecutorService",
         "play.api.libs.streams.Execution$trampoline$",
         "scala.concurrent.Future$InternalCallbackExecutor$",
         "scala.concurrent.impl.ExecutionContextImpl",
+        "org.eclipse.jetty.util.thread.QueuedThreadPool",
+        "org.eclipse.jetty.util.thread.ReservedThreadExecutor"
       };
 
       final Set<String> executors = new HashSet<>(Config.get().getTraceExecutors());

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/NewTaskFor.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/NewTaskFor.java
@@ -1,0 +1,54 @@
+package datadog.trace.instrumentation.java.concurrent;
+
+import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.ExcludeType.RUNNABLE;
+import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.exclude;
+
+import java.lang.reflect.Method;
+import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.Executor;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.RunnableFuture;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public final class NewTaskFor {
+
+  private static final boolean SAFE_TO_PROPAGATE;
+  private static final Method NEW_TASK_FOR_RUNNABLE;
+
+  static {
+    boolean safeToPropagate = false;
+    Method newTaskFor = null;
+    try {
+      newTaskFor =
+          AbstractExecutorService.class.getDeclaredMethod(
+              "newTaskFor", Runnable.class, Object.class);
+      newTaskFor.setAccessible(true);
+      safeToPropagate = true;
+    } catch (Throwable error) {
+      log.debug("Failed to create method accessor for newTaskFor", error);
+    }
+    SAFE_TO_PROPAGATE = safeToPropagate;
+    NEW_TASK_FOR_RUNNABLE = newTaskFor;
+  }
+
+  @SuppressWarnings("unchecked")
+  public static Runnable newTaskFor(Executor executor, Runnable runnable) {
+    // TODO write a slick instrumentation and instrument these types directly
+    if (runnable instanceof RunnableFuture
+        || null == runnable
+        || !SAFE_TO_PROPAGATE
+        || exclude(RUNNABLE, runnable)
+        || runnable.getClass().getName().startsWith("slick.")) {
+      return runnable;
+    }
+    if (null != NEW_TASK_FOR_RUNNABLE && executor instanceof AbstractExecutorService) {
+      try {
+        return (RunnableFuture<Void>) NEW_TASK_FOR_RUNNABLE.invoke(executor, runnable, null);
+      } catch (Throwable t) {
+        log.debug("failed to invoke newTaskFor on {}", executor, t);
+      }
+    }
+    return new FutureTask<>(runnable, null);
+  }
+}

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/WrapRunnableAsNewTaskInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/WrapRunnableAsNewTaskInstrumentation.java
@@ -1,0 +1,81 @@
+package datadog.trace.instrumentation.java.concurrent;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
+import static datadog.trace.instrumentation.java.concurrent.NewTaskFor.newTaskFor;
+import static java.util.Collections.singletonMap;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import java.util.Map;
+import java.util.concurrent.Executor;
+import java.util.concurrent.RunnableFuture;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import net.bytebuddy.matcher.ElementMatchers;
+
+@AutoService(Instrumenter.class)
+public final class WrapRunnableAsNewTaskInstrumentation extends Instrumenter.Default {
+  public WrapRunnableAsNewTaskInstrumentation() {
+    super("java_concurrent", "new-task-for");
+  }
+
+  @Override
+  public ElementMatcher<? super TypeDescription> typeMatcher() {
+    return namedOneOf(
+        "io.netty.channel.epoll.EpollEventLoop",
+        "io.netty.channel.epoll.EpollEventLoopGroup",
+        "io.netty.channel.MultithreadEventLoopGroup",
+        "io.netty.channel.nio.NioEventLoop",
+        "io.netty.channel.nio.NioEventLoopGroup",
+        "io.netty.channel.SingleThreadEventLoop",
+        "io.netty.util.concurrent.AbstractEventExecutor",
+        "io.netty.util.concurrent.AbstractEventExecutorGroup",
+        "io.netty.util.concurrent.AbstractScheduledEventExecutor",
+        "io.netty.util.concurrent.DefaultEventExecutor",
+        "io.netty.util.concurrent.DefaultEventExecutorGroup",
+        "io.netty.util.concurrent.GlobalEventExecutor",
+        "io.netty.util.concurrent.MultithreadEventExecutorGroup",
+        "io.netty.util.concurrent.SingleThreadEventExecutor",
+        "java.util.concurrent.AbstractExecutorService",
+        "java.util.concurrent.CompletableFuture$ThreadPerTaskExecutor",
+        "java.util.concurrent.SubmissionPublisher$ThreadPerTaskExecutor",
+        "java.util.concurrent.ThreadPoolExecutor",
+        "org.glassfish.grizzly.threadpool.GrizzlyExecutorService");
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {packageName + ".NewTaskFor"};
+  }
+
+  @Override
+  public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
+    return singletonMap(
+        isMethod()
+            .and(
+                named("execute")
+                    .and(ElementMatchers.takesArgument(0, named(Runnable.class.getName())))),
+        getClass().getName() + "$Wrap");
+  }
+
+  public static final class Wrap {
+    @Advice.OnMethodEnter
+    public static void execute(
+        @Advice.This Executor executor,
+        @Advice.Argument(value = 0, readOnly = false) Runnable task) {
+      task = newTaskFor(executor, task);
+    }
+
+    @SuppressWarnings("rawtypes")
+    @Advice.OnMethodExit(onThrowable = Throwable.class)
+    public static void cancel(@Advice.Argument(0) Runnable task, @Advice.Thrown Throwable error) {
+      if (null != error && task instanceof RunnableFuture) {
+        ((RunnableFuture) task).cancel(true);
+      }
+    }
+  }
+}


### PR DESCRIPTION
This will work for any subclass of `AbstractExecutorService` and makes the `RunnableInstrumentation` otherwise unnecessary once Kotlin coroutines are moved out of this module.