### PR TITLE
Be defensive about misbehaving exception types

### DIFF
--- a/dd-java-agent/instrumentation/exception-profiling/src/main/java11/com/datadog/profiling/exceptions/ExceptionSampleEvent.java
+++ b/dd-java-agent/instrumentation/exception-profiling/src/main/java11/com/datadog/profiling/exceptions/ExceptionSampleEvent.java
@@ -36,9 +36,27 @@ public class ExceptionSampleEvent extends Event {
      * Writing these tests in java seems like would introduce more noise.
      */
     type = e.getClass().getName();
-    message = e.getMessage();
-    stackDepth = e.getStackTrace().length;
+    message = getMessage(e);
+    stackDepth = getStackDepth(e);
     this.sampled = sampled;
     this.firstOccurrence = firstOccurrence;
+  }
+
+  private static String getMessage(Throwable t) {
+    try {
+      return t.getMessage();
+    } catch (Throwable ignored) {
+      // apparently there might be exceptions throwing at least NPE when trying to get the message
+    }
+    return null;
+  }
+
+  private static int getStackDepth(Throwable t) {
+    try {
+      return t.getStackTrace().length;
+    } catch (Throwable ignored) {
+      // be defensive about exceptions choking on a call to getStackTrace()
+    }
+    return 0;
   }
 }


### PR DESCRIPTION
Apparently, there are exception types out there which will fail a call to `getMessage()` with throwing NPE 🤷 

Just to clarify - the problems are expected for exception types overriding `getMessage()` method and trying to access an additional information from the subclass. This is because the instrumentation is injected at exit point in `Throwable.<init>` and the rest of the subclassed instance may not be initialized at that moment. Unfortunately, there is no way to overcome this so the best thing we can do is to ignore the exception and pretend there is no message.