### PR TITLE
Fail-fast on DDTracer.build when writer is null or DDAgentWriter

### DIFF
--- a/dd-smoke-tests/opentracing/src/main/java/datadog/smoketest/opentracing/CorrectSetupWithAgentAndWriterApplication.java
+++ b/dd-smoke-tests/opentracing/src/main/java/datadog/smoketest/opentracing/CorrectSetupWithAgentAndWriterApplication.java
@@ -1,0 +1,15 @@
+package datadog.smoketest.opentracing;
+
+import datadog.opentracing.DDTracer;
+import datadog.trace.common.writer.ListWriter;
+
+public class CorrectSetupWithAgentAndWriterApplication {
+  public static void main(final String[] args) {
+    try {
+      final ListWriter writer = new ListWriter();
+      DDTracer.builder().writer(writer).build();
+    } catch (final IllegalStateException e) {
+      throw new RuntimeException("build() threw exception");
+    }
+  }
+}

--- a/dd-smoke-tests/opentracing/src/test/groovy/datadog/smoketest/CorrectSetupWithAgentAndWriterTest.groovy
+++ b/dd-smoke-tests/opentracing/src/test/groovy/datadog/smoketest/CorrectSetupWithAgentAndWriterTest.groovy
@@ -1,0 +1,30 @@
+package datadog.smoketest
+
+import datadog.smoketest.opentracing.CorrectSetupWithAgentAndWriterApplication
+import spock.lang.Timeout
+
+import java.util.concurrent.TimeUnit
+
+class CorrectSetupWithAgentAndWriterTest extends AbstractSmokeTest {
+  public static final int TIMEOUT_SECS = 30
+
+  @Override
+  ProcessBuilder createProcessBuilder() {
+    List<String> command = new ArrayList<>()
+    command.add(javaPath())
+    command.addAll(defaultJavaProperties)
+    command.addAll((String[]) ["-cp", System.getProperty("datadog.smoketest.shadowJar.path")])
+    command.add(CorrectSetupWithAgentAndWriterApplication.name)
+
+    ProcessBuilder processBuilder = new ProcessBuilder(command)
+    processBuilder.directory(new File(buildDirectory))
+
+    return processBuilder
+  }
+
+  @Timeout(value = TIMEOUT_SECS, unit = TimeUnit.SECONDS)
+  def "Application exits without error"() {
+    expect:
+    assert testedProcess.waitFor() == 0
+  }
+}

--- a/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
@@ -200,13 +200,12 @@ public class DDTracer implements Tracer, datadog.trace.api.Tracer {
 
     // Check if the tracer is already installed by the agent
     // Unable to use "instanceof" because of class renaming
-    if (writer == null
-        || writer.getClass().getName().equals("datadog.trace.common.writer.DDAgentWriter")) {
-      if (GlobalTracer.get().getClass().getName().equals("datadog.trace.agent.core.CoreTracer")) {
-        log.error(
-            "Datadog Tracer already installed by `dd-java-agent`. NOTE: Manually creating the tracer while using `dd-java-agent` is not supported");
-        throw new IllegalStateException("Datadog Tracer already installed");
-      }
+    if ((writer == null
+            || writer.getClass().getName().equals("datadog.trace.common.writer.DDAgentWriter"))
+        && GlobalTracer.get().getClass().getName().equals("datadog.trace.agent.core.CoreTracer")) {
+      log.error(
+          "Datadog Tracer already installed by `dd-java-agent`. NOTE: Manually creating the tracer while using `dd-java-agent` is not supported");
+      throw new IllegalStateException("Datadog Tracer already installed");
     }
 
     if (logHandler != null) {

--- a/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
@@ -200,10 +200,13 @@ public class DDTracer implements Tracer, datadog.trace.api.Tracer {
 
     // Check if the tracer is already installed by the agent
     // Unable to use "instanceof" because of class renaming
-    if (GlobalTracer.get().getClass().getName().equals("datadog.trace.agent.core.CoreTracer")) {
-      log.error(
-          "Datadog Tracer already installed by `dd-java-agent`. NOTE: Manually creating the tracer while using `dd-java-agent` is not supported");
-      throw new IllegalStateException("Datadog Tracer already installed");
+    if (writer == null
+        || writer.getClass().getName().equals("datadog.trace.common.writer.DDAgentWriter")) {
+      if (GlobalTracer.get().getClass().getName().equals("datadog.trace.agent.core.CoreTracer")) {
+        log.error(
+            "Datadog Tracer already installed by `dd-java-agent`. NOTE: Manually creating the tracer while using `dd-java-agent` is not supported");
+        throw new IllegalStateException("Datadog Tracer already installed");
+      }
     }
 
     if (logHandler != null) {
@@ -374,8 +377,9 @@ public class DDTracer implements Tracer, datadog.trace.api.Tracer {
     }
 
     @Override
-    public void forEachKey(TextMapExtract ignored, AgentPropagation.KeyClassifier classifier) {
-      for (Entry<String, String> entry : carrier) {
+    public void forEachKey(
+        final TextMapExtract ignored, final AgentPropagation.KeyClassifier classifier) {
+      for (final Entry<String, String> entry : carrier) {
         if (!classifier.accept(entry.getKey(), entry.getValue())) {
           return;
         }


### PR DESCRIPTION
After #1994, it's not possible to use the `DDTracer` with the `ListWriter` for tests and using the `dd-java-agent` in the test phase to report tests using the `JUnit4` instrumentation.

This `PR` modifies the logic to fail-fast only when the writer is `null` or `DDAgentWriter`.