### PR TITLE
Stage gradle based Play smoke tests during compilation

### DIFF
--- a/dd-smoke-tests/play-2.4/play-2.4.gradle
+++ b/dd-smoke-tests/play-2.4/play-2.4.gradle
@@ -62,7 +62,7 @@ dependencies {
   testCompile project(':dd-smoke-tests')
 }
 
-tasks.withType(Test).configureEach {
+compileTestGroovy {
   dependsOn 'stagePlayBinaryDist'
   outputs.upToDateWhen {
     !stagePlayBinaryDist.didWork

--- a/dd-smoke-tests/play-2.5/play-2.5.gradle
+++ b/dd-smoke-tests/play-2.5/play-2.5.gradle
@@ -64,7 +64,7 @@ dependencies {
   testCompile project(':dd-smoke-tests')
 }
 
-tasks.withType(Test).configureEach {
+compileTestGroovy {
   dependsOn 'stagePlayBinaryDist'
   outputs.upToDateWhen {
     !stagePlayBinaryDist.didWork

--- a/dd-smoke-tests/play-2.6/play-2.6.gradle
+++ b/dd-smoke-tests/play-2.6/play-2.6.gradle
@@ -64,7 +64,7 @@ dependencies {
   testCompile project(':dd-smoke-tests')
 }
 
-tasks.withType(Test).configureEach {
+compileTestGroovy {
   dependsOn 'stagePlayBinaryDist'
   outputs.upToDateWhen {
     !stagePlayBinaryDist.didWork


### PR DESCRIPTION
This `stage` the gradle based Play smoke tests during compilation (i.e. the `build` step on CircleCI), to avoid compiling and staging the Play application on every `test_X` step.