### PR TITLE
Update test containers version

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -21,7 +21,7 @@ ext {
     jnr_unixsocket: "0.28",
     commons       : "3.2",
     mockito       : '3.5.10',
-    testcontainers: '1.12.2',
+    testcontainers: '1.15.0-rc2',
     jmc           : "8.0.0-SNAPSHOT",
     autoservice   : "1.0-rc7"
   ]


### PR DESCRIPTION
The current version of test containers doesn't work with the latest version of Docker on Macs: https://github.com/testcontainers/testcontainers-java/issues/3166 .  I was waiting for the final release of 1.15.0, but it's been "coming soon" for a while now.