### PR TITLE
Add comment explaining the overlap situation involving Mongo 3.x and 4.x

### DIFF
--- a/dd-java-agent/instrumentation/mongo/driver-4/driver-4.gradle
+++ b/dd-java-agent/instrumentation/mongo/driver-4/driver-4.gradle
@@ -8,6 +8,9 @@ muzzle {
   pass {
     group = "org.mongodb"
     module = "mongodb-driver-core"
+    // this instrumentation is backwards compatible with early versions of the new API that shipped in 3.7
+    // the legacy API instrumented in driver-3.1 continues to be shipped in 4.x, but doesn't conflict here
+    // because they are triggered by different types: MongoClientSettings(new) vs MongoClientOptions(legacy)
     versions = "[3.7,)"
     assertInverse = true
   }


### PR DESCRIPTION
the legacy client API from 3.x continues to be shipped in 4.x, while the 4.x instrumentation is backwards compatible with early versions of the new client API that first appeared in 3.7: https://github.com/DataDog/dd-trace-java/pull/2043#discussion_r515260667