### PR TITLE
Added configuration to embed exception in message instead of using printStackTrace

### DIFF
--- a/dd-java-agent/agent-logging/src/main/java/datadog/trace/logging/simplelogger/SLCompatHelper.java
+++ b/dd-java-agent/agent-logging/src/main/java/datadog/trace/logging/simplelogger/SLCompatHelper.java
@@ -85,9 +85,31 @@ class SLCompatHelper extends LoggerHelper {
 
     buf.append(message);
 
+    if (settings.embedException) {
+      embedException(buf, t);
+    }
+
     settings.printStream.println(buf.toString());
-    if (t != null) {
+    if (!settings.embedException && t != null) {
       t.printStackTrace(settings.printStream);
+    }
+  }
+
+  private void embedException(StringBuilder buf, Throwable t) {
+    if (t != null) {
+      buf.append(" [exception:");
+      buf.append(t.toString());
+      buf.append("][stack:[");
+      boolean empty = true;
+      for (StackTraceElement element : t.getStackTrace()) {
+        if (!empty) {
+          buf.append(",");
+        } else {
+          empty = false;
+        }
+        buf.append(element.toString());
+      }
+      buf.append("]]");
     }
   }
 }

--- a/dd-java-agent/agent-logging/src/main/java/datadog/trace/logging/simplelogger/SLCompatHelper.java
+++ b/dd-java-agent/agent-logging/src/main/java/datadog/trace/logging/simplelogger/SLCompatHelper.java
@@ -99,17 +99,12 @@ class SLCompatHelper extends LoggerHelper {
     if (t != null) {
       buf.append(" [exception:");
       buf.append(t.toString());
-      buf.append("][stack:[");
-      boolean empty = true;
+      buf.append(".");
       for (StackTraceElement element : t.getStackTrace()) {
-        if (!empty) {
-          buf.append(",");
-        } else {
-          empty = false;
-        }
+        buf.append(" at ");
         buf.append(element.toString());
       }
-      buf.append("]]");
+      buf.append("]");
     }
   }
 }

--- a/dd-java-agent/agent-logging/src/main/java/datadog/trace/logging/simplelogger/SLCompatSettings.java
+++ b/dd-java-agent/agent-logging/src/main/java/datadog/trace/logging/simplelogger/SLCompatSettings.java
@@ -34,6 +34,7 @@ public class SLCompatSettings {
     public static final String DATE_TIME_FORMAT = PREFIX + "dateTimeFormat";
     public static final String SHOW_DATE_TIME = PREFIX + "showDateTime";
     public static final String DEFAULT_LOG_LEVEL = PREFIX + "defaultLogLevel";
+    public static final String EMBED_EXCEPTION = PREFIX + "embedException";
 
     // This is not available in SimpleLogger, but added here to simplify testing.
     static final String CONFIGURATION_FILE = PREFIX + "configurationFile";
@@ -50,6 +51,7 @@ public class SLCompatSettings {
     public static final String DATE_TIME_FORMAT = null;
     public static final boolean SHOW_DATE_TIME = false;
     public static final String DEFAULT_LOG_LEVEL = "INFO";
+    public static final boolean EMBED_EXCEPTION = false;
 
     public static final String CONFIGURATION_FILE = "simplelogger.properties";
   }
@@ -239,6 +241,7 @@ public class SLCompatSettings {
   final DTFormatter dateTimeFormatter;
   final boolean showDateTime;
   final LogLevel defaultLogLevel;
+  final boolean embedException;
 
   public SLCompatSettings(Properties properties) {
     this(
@@ -272,7 +275,8 @@ public class SLCompatSettings {
         getBoolean(properties, fileProperties, Keys.SHOW_DATE_TIME, Defaults.SHOW_DATE_TIME),
         LogLevel.fromString(
             getString(
-                properties, fileProperties, Keys.DEFAULT_LOG_LEVEL, Defaults.DEFAULT_LOG_LEVEL)));
+                properties, fileProperties, Keys.DEFAULT_LOG_LEVEL, Defaults.DEFAULT_LOG_LEVEL)),
+        getBoolean(properties, fileProperties, Keys.EMBED_EXCEPTION, Defaults.EMBED_EXCEPTION));
   }
 
   public SLCompatSettings(
@@ -286,7 +290,8 @@ public class SLCompatSettings {
       boolean showThreadName,
       DTFormatter dateTimeFormatter,
       boolean showDateTime,
-      LogLevel defaultLogLevel) {
+      LogLevel defaultLogLevel,
+      boolean embedException) {
     this.properties = properties;
     this.fileProperties = fileProperties;
     this.warnLevelString = warnLevelString;
@@ -298,6 +303,7 @@ public class SLCompatSettings {
     this.dateTimeFormatter = dateTimeFormatter;
     this.showDateTime = showDateTime;
     this.defaultLogLevel = defaultLogLevel;
+    this.embedException = embedException;
   }
 
   String getString(String name) {

--- a/dd-java-agent/agent-logging/src/test/groovy/datadog/trace/logging/simplelogger/SLCompatHelperTest.groovy
+++ b/dd-java-agent/agent-logging/src/test/groovy/datadog/trace/logging/simplelogger/SLCompatHelperTest.groovy
@@ -112,7 +112,7 @@ class SLCompatHelperTest extends Specification {
     }
 
     expect:
-    outputStream.toString() ==~ /^.* ERROR foo - log \[exception:java\.io\.IOException: wrong\]\[stack:\[.*\]\]\n$/
+    outputStream.toString() ==~ /^.* ERROR foo - log \[exception:java\.io\.IOException: wrong\. at .*\]\n$/
   }
 
   def "test logging without thread name and with time"() {

--- a/dd-java-agent/agent-logging/src/test/groovy/datadog/trace/logging/simplelogger/SLCompatHelperTest.groovy
+++ b/dd-java-agent/agent-logging/src/test/groovy/datadog/trace/logging/simplelogger/SLCompatHelperTest.groovy
@@ -97,6 +97,24 @@ class SLCompatHelperTest extends Specification {
     outputStream.toString() == "[$thread] ERROR foo - log\n${NoStackException.getName()}: wrong\n"
   }
 
+  def "test logging with an embedded exception in the message"() {
+    setup:
+    def outputStream = new ByteArrayOutputStream()
+    def printStream = new PrintStream(outputStream, true)
+    def props = new Properties()
+    props.setProperty(SLCompatSettings.Keys.EMBED_EXCEPTION, "true")
+    def settings = new SLCompatSettings(props, new Properties(), printStream)
+    def helper = new SLCompatHelper("foo", settings)
+    try {
+      throw new IOException("wrong")
+    } catch(Exception exception) {
+      helper.log(LogLevel.ERROR, "log", exception)
+    }
+
+    expect:
+    outputStream.toString() ==~ /^.* ERROR foo - log \[exception:java\.io\.IOException: wrong\]\[stack:\[.*\]\]\n$/
+  }
+
   def "test logging without thread name and with time"() {
     setup:
     def outputStream = new ByteArrayOutputStream()

--- a/dd-java-agent/agent-logging/src/test/groovy/datadog/trace/logging/simplelogger/SLCompatHelperTest.groovy
+++ b/dd-java-agent/agent-logging/src/test/groovy/datadog/trace/logging/simplelogger/SLCompatHelperTest.groovy
@@ -136,7 +136,7 @@ class SLCompatHelperTest extends Specification {
     def printStream = new PrintStream(outputStream, true)
     def props = new Properties()
     def dateTimeFormatter = SLCompatSettings.DTFormatter.create(dateTFS)
-    def settings = new SLCompatSettings(props, props, warnS, showB, printStream, showS, showL, showT, dateTimeFormatter, showDT, LogLevel.INFO)
+    def settings = new SLCompatSettings(props, props, warnS, showB, printStream, showS, showL, showT, dateTimeFormatter, showDT, LogLevel.INFO, false)
     def helper = new SLCompatHelper("foo.bar", settings)
     helper.log(level, 0, 4711, "thread", "log", null)
 


### PR DESCRIPTION
To avoid receiving the stack trace over multiple lines and send receive it as a single message I have added an option (`embedException`, which defaults to false for backward compatibility).

The format in case this feature is enabled looks like

```
<usual logline> <message> [exception:<exception type>: <message> <stack frame>, <stack frame>, ..]
```

where the content of the exception tag can be pasted in IntelliJ stack analyzer too.