### PR TITLE
Pin Spring Data's latest test

### DIFF
--- a/dd-java-agent/instrumentation/spring-data-1.8/spring-data-1.8.gradle
+++ b/dd-java-agent/instrumentation/spring-data-1.8/spring-data-1.8.gradle
@@ -49,6 +49,6 @@ dependencies {
   latestDepTestCompile group: 'org.springframework', name: 'spring-context', version: '+'
 
   latestDepTestCompile group: 'org.springframework.data', name: 'spring-data-commons', version: '+'
-  latestDepTestCompile group: 'org.springframework.data', name: 'spring-data-jpa', version: '+'
+  latestDepTestCompile group: 'org.springframework.data', name: 'spring-data-jpa', version: '2.3.+'
 }
 


### PR DESCRIPTION
`:dd-java-agent:instrumentation:spring-data-1.8:latestDepTest` Tests with `2.4.0` fails with the following exception:

```
org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'entityManagerFactory' defined in spring.jpa.JpaPersistenceConfig: Invocation of init method failed; nested exception is java.lang.NoClassDefFoundError: org/hibernate/resource/jdbc/spi/PhysicalConnectionHandlingMode
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:1788)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:609)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:531)
	at org.springframework.beans.factory.support.AbstractBeanFactory.lambda$doGetBean$0(AbstractBeanFactory.java:335)
	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:234)
	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:333)
	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:208)
	at org.springframework.context.support.AbstractApplicationContext.getBean(AbstractApplicationContext.java:1161)
	at org.springframework.context.support.AbstractApplicationContext.finishBeanFactoryInitialization(AbstractApplicationContext.java:915)
	at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:588)
	at org.springframework.context.annotation.AnnotationConfigApplicationContext.<init>(AnnotationConfigApplicationContext.java:93)
	at SpringJpaTest.test object method(SpringJpaTest.groovy:16)
Caused by: java.lang.NoClassDefFoundError: org/hibernate/resource/jdbc/spi/PhysicalConnectionHandlingMode
	at org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter.buildJpaPropertyMap(HibernateJpaVendorAdapter.java:160)
	at org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter.getJpaPropertyMap(HibernateJpaVendorAdapter.java:130)
	at org.springframework.orm.jpa.AbstractEntityManagerFactoryBean.afterPropertiesSet(AbstractEntityManagerFactoryBean.java:365)
	at org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean.afterPropertiesSet(LocalContainerEntityManagerFactoryBean.java:341)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.invokeInitMethods(AbstractAutowireCapableBeanFactory.java:1847)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:1784)
	... 11 more
Caused by: java.lang.ClassNotFoundException: org.hibernate.resource.jdbc.spi.PhysicalConnectionHandlingMode
	at java.net.URLClassLoader.findClass(URLClassLoader.java:382)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:418)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:352)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:351)
	... 17 more
```