### PR TITLE
RPS and error metrics

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/config/GeneralConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/GeneralConfig.java
@@ -32,6 +32,10 @@ public final class GeneralConfig {
   public static final String HEALTH_METRICS_STATSD_PORT = "trace.health.metrics.statsd.port";
   public static final String PERF_METRICS_ENABLED = "trace.perf.metrics.enabled";
 
+  public static final String TRACER_METRICS_ENABLED = "trace.tracer.metrics.enabled";
+  public static final String TRACER_METRICS_MAX_AGGREGATES = "trace.tracer.metrics.max.aggregates";
+  public static final String TRACER_METRICS_MAX_PENDING = "trace.tracer.metrics.max.pending";
+
   public static final String INTERNAL_EXIT_ON_FAILURE = "trace.internal.exit.on.failure";
 
   private GeneralConfig() {}

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/AggregateMetric.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/AggregateMetric.java
@@ -1,0 +1,42 @@
+package datadog.trace.common.metrics;
+
+public final class AggregateMetric {
+  private int errorCount;
+  private int hitCount;
+  private long duration;
+
+  public AggregateMetric addHits(int count) {
+    hitCount += count;
+    return this;
+  }
+
+  public AggregateMetric addErrors(int count) {
+    errorCount += count;
+    return this;
+  }
+
+  public AggregateMetric recordDurations(long errorMask, long... durations) {
+    for (long d : durations) {
+      duration += d;
+    }
+    return this;
+  }
+
+  public int getErrorCount() {
+    return errorCount;
+  }
+
+  public int getHitCount() {
+    return hitCount;
+  }
+
+  public long getDuration() {
+    return duration;
+  }
+
+  public void clear() {
+    this.errorCount = 0;
+    this.hitCount = 0;
+    this.duration = 0;
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/AggregateMetric.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/AggregateMetric.java
@@ -1,5 +1,6 @@
 package datadog.trace.common.metrics;
 
+/** Not thread-safe. Accumulates counts and durations. */
 public final class AggregateMetric {
   private int errorCount;
   private int hitCount;

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/Batch.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/Batch.java
@@ -1,0 +1,63 @@
+package datadog.trace.common.metrics;
+
+import java.util.Arrays;
+
+public final class Batch {
+
+  public static final Batch NULL = new Batch(null);
+
+  private volatile MetricKey key;
+
+  private int count = 0;
+  private long errorMask = 0L;
+  private final long[] durations;
+
+  Batch() {
+    this(new long[64]);
+  }
+
+  private Batch(long[] durations) {
+    this.durations = durations;
+  }
+
+  public MetricKey getKey() {
+    return key;
+  }
+
+  public Batch withKey(MetricKey key) {
+    this.key = key;
+    return this;
+  }
+
+  public boolean add(boolean error, long durationNanos) {
+    if (null != key) {
+      synchronized (this) {
+        if (null != key) {
+          if (count < 64) {
+            if (error) {
+              errorMask |= (1L << count);
+            }
+            durations[count++] = durationNanos;
+            return true;
+          }
+        }
+      }
+    }
+    return false;
+  }
+
+  public synchronized void contributeTo(AggregateMetric aggregate) {
+    this.key = null;
+    aggregate
+        .addErrors(Long.bitCount(errorMask))
+        .addHits(count)
+        .recordDurations(errorMask, durations);
+    clear();
+  }
+
+  private void clear() {
+    this.count = 0;
+    this.errorMask = 0L;
+    Arrays.fill(durations, 0L);
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/ConflatingMetricsAggregator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/ConflatingMetricsAggregator.java
@@ -1,0 +1,249 @@
+package datadog.trace.common.metrics;
+
+import static datadog.trace.util.AgentThreadFactory.AgentThread.METRICS_AGGREGATOR;
+import static datadog.trace.util.AgentThreadFactory.newAgentThread;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import datadog.trace.api.Config;
+import datadog.trace.api.WellKnownTags;
+import datadog.trace.core.DDSpanData;
+import datadog.trace.core.util.LRUCache;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import lombok.extern.slf4j.Slf4j;
+import org.jctools.queues.MpmcArrayQueue;
+import org.jctools.queues.MpscBlockingConsumerArrayQueue;
+
+@Slf4j
+public final class ConflatingMetricsAggregator implements MetricsAggregator, EventListener {
+
+  private static final Batch POISON_PILL = Batch.NULL;
+
+  private final Queue<Batch> batchPool;
+  private final ConcurrentHashMap<MetricKey, Batch> pending;
+  private final Thread thread;
+  private final BlockingQueue<Batch> inbox;
+  private final Sink sink;
+  private final Aggregator aggregator;
+
+  private volatile boolean enabled = true;
+
+  public ConflatingMetricsAggregator(Config config) {
+    this(
+        config.getWellKnownTags(),
+        new OkHttpSink(config.getAgentUrl(), config.getAgentTimeout()),
+        config.getTracerMetricsMaxAggregates(),
+        config.getTracerMetricsMaxPending());
+  }
+
+  ConflatingMetricsAggregator(
+      WellKnownTags wellKnownTags, Sink sink, int maxAggregates, int queueSize) {
+    this(wellKnownTags, sink, maxAggregates, queueSize, 10, SECONDS);
+  }
+
+  ConflatingMetricsAggregator(
+      WellKnownTags wellKnownTags,
+      Sink sink,
+      int maxAggregates,
+      int queueSize,
+      long reportingInterval,
+      TimeUnit timeUnit) {
+    this(
+        sink,
+        new SerializingMetricWriter(wellKnownTags, sink),
+        maxAggregates,
+        queueSize,
+        reportingInterval,
+        timeUnit);
+  }
+
+  ConflatingMetricsAggregator(
+      Sink sink,
+      MetricWriter metricWriter,
+      int maxAggregates,
+      int queueSize,
+      long reportingInterval,
+      TimeUnit timeUnit) {
+    this.inbox = new MpscBlockingConsumerArrayQueue<>(queueSize);
+    this.batchPool = new MpmcArrayQueue<>(maxAggregates);
+    this.pending = new ConcurrentHashMap<>(maxAggregates * 4 / 3, 0.75f);
+    this.sink = sink;
+    this.aggregator =
+        new Aggregator(
+            metricWriter, batchPool, inbox, pending, maxAggregates, reportingInterval, timeUnit);
+    this.thread = newAgentThread(METRICS_AGGREGATOR, aggregator);
+  }
+
+  @Override
+  public void start() {
+    sink.register(this);
+    thread.start();
+  }
+
+  @Override
+  public void publish(List<? extends DDSpanData> trace) {
+    if (enabled) {
+      for (DDSpanData span : trace) {
+        if (span.isMeasured()) {
+          publish(span);
+        }
+      }
+    }
+  }
+
+  private void publish(DDSpanData span) {
+    boolean error = span.getError() > 0;
+    long durationNanos = span.getDurationNano();
+    MetricKey key =
+        new MetricKey(span.getResourceName(), span.getServiceName(), span.getOperationName(), 0);
+    Batch batch = pending.get(key);
+    if (null != batch) {
+      if (batch.add(error, durationNanos)) {
+        // added to a pending batch, skip the queue
+        return;
+      }
+    }
+    batch = newBatch(key);
+    batch.add(error, durationNanos);
+    // overwrite the last one if present, it's already full
+    pending.put(key, batch);
+    inbox.offer(batch);
+  }
+
+  private Batch newBatch(MetricKey key) {
+    Batch batch = batchPool.poll();
+    return (null == batch ? new Batch() : batch).withKey(key);
+  }
+
+  public void stop() {
+    inbox.offer(POISON_PILL);
+  }
+
+  @Override
+  public void close() {
+    stop();
+  }
+
+  @Override
+  public void onEvent(EventType eventType, String message) {
+    switch (eventType) {
+      case DOWNGRADED:
+        log.debug("Disabling metric reporting because an agent downgrade was detected");
+        disable();
+        break;
+      case BAD_PAYLOAD:
+        log.debug("bad metrics payload sent to trace agent: {}", message);
+        break;
+      case ERROR:
+        log.debug("trace agent errored receiving metrics payload: {}", message);
+        break;
+      default:
+    }
+  }
+
+  private void disable() {
+    this.enabled = false;
+    this.thread.interrupt();
+    this.pending.clear();
+    this.batchPool.clear();
+    this.inbox.clear();
+    this.aggregator.clearAggregates();
+  }
+
+  private static final class Aggregator implements Runnable {
+
+    private final Queue<Batch> batchPool;
+    private final BlockingQueue<Batch> inbox;
+    private final LRUCache<MetricKey, AggregateMetric> aggregates;
+    private final ConcurrentHashMap<MetricKey, Batch> pending;
+    private final MetricWriter writer;
+    private final long reportingIntervalNanos;
+
+    private long wallClockTime = -1;
+
+    private long lastReportTime = -1;
+
+    private Aggregator(
+        MetricWriter writer,
+        Queue<Batch> batchPool,
+        BlockingQueue<Batch> inbox,
+        ConcurrentHashMap<MetricKey, Batch> pending,
+        int maxAggregates,
+        long reportingInterval,
+        TimeUnit reportingIntervalTimeUnit) {
+      this.writer = writer;
+      this.batchPool = batchPool;
+      this.inbox = inbox;
+      this.aggregates = new LRUCache<>(maxAggregates, 0.75f, maxAggregates * 4 / 3);
+      this.pending = pending;
+      this.reportingIntervalNanos = reportingIntervalTimeUnit.toNanos(reportingInterval);
+    }
+
+    public void clearAggregates() {
+      this.aggregates.clear();
+    }
+
+    @Override
+    public void run() {
+      Thread currentThread = Thread.currentThread();
+      while (!currentThread.isInterrupted()) {
+        try {
+          Batch batch = inbox.take();
+          if (batch == POISON_PILL) {
+            report(wallClockTime());
+            return;
+          } else {
+            MetricKey key = batch.getKey();
+            // important that it is still *this* batch pending, must not remove otherwise
+            pending.remove(key, batch);
+            AggregateMetric aggregate = aggregates.get(key);
+            if (null == aggregate) {
+              aggregate = new AggregateMetric();
+              aggregates.put(key, aggregate);
+            }
+            batch.contributeTo(aggregate);
+            // return the batch for reuse
+            batchPool.offer(batch);
+            reportIfNecessary();
+          }
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+      }
+    }
+
+    private void reportIfNecessary() {
+      if (lastReportTime == -1) {
+        lastReportTime = System.nanoTime();
+        wallClockTime = wallClockTime();
+      } else if (!aggregates.isEmpty()) {
+        long now = System.nanoTime();
+        long delta = now - lastReportTime;
+        if (delta > reportingIntervalNanos) {
+          report(wallClockTime + delta);
+          lastReportTime = now;
+          wallClockTime = wallClockTime();
+        }
+      }
+    }
+
+    private void report(long when) {
+      writer.startBucket(aggregates.size(), when, reportingIntervalNanos);
+      for (Map.Entry<MetricKey, AggregateMetric> aggregate : aggregates.entrySet()) {
+        writer.add(aggregate.getKey(), aggregate.getValue());
+        aggregate.getValue().clear();
+      }
+      // note that this may do IO and block
+      writer.finishBucket();
+    }
+
+    private long wallClockTime() {
+      return MILLISECONDS.toNanos(System.currentTimeMillis());
+    }
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/EventListener.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/EventListener.java
@@ -1,0 +1,12 @@
+package datadog.trace.common.metrics;
+
+public interface EventListener {
+  enum EventType {
+    BAD_PAYLOAD,
+    DOWNGRADED,
+    OK,
+    ERROR
+  }
+
+  void onEvent(EventType eventType, String message);
+}

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/MetricKey.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/MetricKey.java
@@ -1,0 +1,51 @@
+package datadog.trace.common.metrics;
+
+import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
+import java.util.Objects;
+
+public final class MetricKey {
+  private final UTF8BytesString resource;
+  private final UTF8BytesString service;
+  private final UTF8BytesString operationName;
+  private final int httpStatusCode;
+
+  public MetricKey(
+      CharSequence resource, CharSequence service, CharSequence operationName, int httpStatusCode) {
+    this.resource = UTF8BytesString.create(resource);
+    this.service = UTF8BytesString.create(service);
+    this.operationName = UTF8BytesString.create(operationName);
+    this.httpStatusCode = httpStatusCode;
+  }
+
+  public UTF8BytesString getResource() {
+    return resource;
+  }
+
+  public UTF8BytesString getService() {
+    return service;
+  }
+
+  public UTF8BytesString getOperationName() {
+    return operationName;
+  }
+
+  public int getHttpStatusCode() {
+    return httpStatusCode;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    MetricKey metricKey = (MetricKey) o;
+    return httpStatusCode == metricKey.httpStatusCode
+        && resource.equals(metricKey.resource)
+        && service.equals(metricKey.service)
+        && operationName.equals(metricKey.operationName);
+  }
+
+  @Override
+  public int hashCode() {
+    return 97 * Objects.hash(resource, service, operationName) + httpStatusCode;
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/MetricKey.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/MetricKey.java
@@ -3,6 +3,7 @@ package datadog.trace.common.metrics;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import java.util.Objects;
 
+/** The aggregation key for tracked metrics. */
 public final class MetricKey {
   private final UTF8BytesString resource;
   private final UTF8BytesString service;

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/MetricWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/MetricWriter.java
@@ -1,0 +1,9 @@
+package datadog.trace.common.metrics;
+
+public interface MetricWriter {
+  void startBucket(int metricCount, long start, long duration);
+
+  void add(MetricKey key, AggregateMetric aggregate);
+
+  void finishBucket();
+}

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/MetricsAggregator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/MetricsAggregator.java
@@ -1,0 +1,10 @@
+package datadog.trace.common.metrics;
+
+import datadog.trace.core.DDSpanData;
+import java.util.List;
+
+public interface MetricsAggregator extends AutoCloseable {
+  void start();
+
+  void publish(List<? extends DDSpanData> trace);
+}

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/MetricsAggregatorFactory.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/MetricsAggregatorFactory.java
@@ -1,0 +1,12 @@
+package datadog.trace.common.metrics;
+
+import datadog.trace.api.Config;
+
+public class MetricsAggregatorFactory {
+  public static MetricsAggregator createMetricsAggregator(Config config) {
+    if (config.isTracerMetricsEnabled()) {
+      return new ConflatingMetricsAggregator(config);
+    }
+    return NoOpMetricsAggregator.INSTANCE;
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/NoOpMetricsAggregator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/NoOpMetricsAggregator.java
@@ -1,0 +1,18 @@
+package datadog.trace.common.metrics;
+
+import datadog.trace.core.DDSpanData;
+import java.util.List;
+
+public final class NoOpMetricsAggregator implements MetricsAggregator {
+
+  static final NoOpMetricsAggregator INSTANCE = new NoOpMetricsAggregator();
+
+  @Override
+  public void start() {}
+
+  @Override
+  public void publish(List<? extends DDSpanData> trace) {}
+
+  @Override
+  public void close() {}
+}

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/OkHttpSink.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/OkHttpSink.java
@@ -1,0 +1,100 @@
+package datadog.trace.common.metrics;
+
+import static datadog.trace.common.metrics.EventListener.EventType.BAD_PAYLOAD;
+import static datadog.trace.common.metrics.EventListener.EventType.DOWNGRADED;
+import static datadog.trace.common.metrics.EventListener.EventType.ERROR;
+import static datadog.trace.common.metrics.EventListener.EventType.OK;
+import static datadog.trace.core.http.OkHttpUtils.buildHttpClient;
+import static datadog.trace.core.http.OkHttpUtils.prepareRequest;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import okhttp3.HttpUrl;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.RequestBody;
+import okio.BufferedSink;
+
+public final class OkHttpSink implements Sink, EventListener {
+
+  private final OkHttpClient client;
+  private final HttpUrl metricsUrl;
+  private final List<EventListener> listeners;
+
+  public OkHttpSink(String agentUrl, long timeoutMillis) {
+    this(buildHttpClient(HttpUrl.get(agentUrl), timeoutMillis), agentUrl, "v0.5/stats");
+  }
+
+  public OkHttpSink(OkHttpClient client, String agentUrl, String path) {
+    this.client = client;
+    this.metricsUrl = HttpUrl.get(agentUrl).resolve(path);
+    this.listeners = new CopyOnWriteArrayList<>();
+  }
+
+  @Override
+  public void accept(int messageCount, ByteBuffer buffer) {
+    try (final okhttp3.Response response =
+        client
+            .newCall(prepareRequest(metricsUrl).put(new MetricsPayload(buffer)).build())
+            .execute()) {
+      if (!response.isSuccessful()) {
+        handleFailure(response);
+      } else {
+        onEvent(OK, "");
+      }
+    } catch (IOException e) {
+      onEvent(ERROR, e.getMessage());
+    }
+  }
+
+  @Override
+  public void onEvent(EventListener.EventType eventType, String message) {
+    for (EventListener listener : listeners) {
+      listener.onEvent(eventType, message);
+    }
+  }
+
+  @Override
+  public void register(EventListener listener) {
+    this.listeners.add(listener);
+  }
+
+  private void handleFailure(okhttp3.Response response) throws IOException {
+    final int code = response.code();
+    if (code == 404) {
+      onEvent(DOWNGRADED, "could not find endpoint");
+    } else if (code >= 400 && code < 500) {
+      onEvent(BAD_PAYLOAD, response.body().string());
+    } else if (code >= 500) {
+      onEvent(ERROR, response.body().string());
+    }
+  }
+
+  private static final class MetricsPayload extends RequestBody {
+
+    private static final MediaType MSGPACK = MediaType.get("application/msgpack");
+
+    private final ByteBuffer buffer;
+
+    private MetricsPayload(ByteBuffer buffer) {
+      this.buffer = buffer;
+    }
+
+    @Override
+    public long contentLength() {
+      return buffer.remaining();
+    }
+
+    @Override
+    public MediaType contentType() {
+      return MSGPACK;
+    }
+
+    @Override
+    public void writeTo(BufferedSink sink) throws IOException {
+      sink.write(buffer);
+    }
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/SerializingMetricWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/SerializingMetricWriter.java
@@ -1,0 +1,105 @@
+package datadog.trace.common.metrics;
+
+import static datadog.trace.core.serialization.WritableFormatter.Feature.RESIZEABLE;
+import static datadog.trace.core.serialization.WritableFormatter.Feature.SINGLE_MESSAGE;
+import static java.nio.charset.StandardCharsets.US_ASCII;
+
+import datadog.trace.api.WellKnownTags;
+import datadog.trace.core.serialization.WritableFormatter;
+import datadog.trace.core.serialization.msgpack.MsgPackWriter;
+import java.nio.ByteBuffer;
+import java.util.EnumSet;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public final class SerializingMetricWriter implements MetricWriter {
+
+  private static final byte[] HOSTNAME = "Hostname".getBytes(US_ASCII);
+  private static final byte[] NAME = "Name".getBytes(US_ASCII);
+  private static final byte[] ENV = "Env".getBytes(US_ASCII);
+  private static final byte[] SERVICE = "Service".getBytes(US_ASCII);
+  private static final byte[] RESOURCE = "Resource".getBytes(US_ASCII);
+  private static final byte[] VERSION = "Version".getBytes(US_ASCII);
+  // can use this, but are not
+  // private static final byte[] OTHER_TAGS = "OtherTags".getBytes(US_ASCII);
+  private static final byte[] HITS = "Hits".getBytes(US_ASCII);
+  private static final byte[] ERRORS = "Errors".getBytes(US_ASCII);
+  private static final byte[] DURATION = "Duration".getBytes(US_ASCII);
+  private static final byte[] TOP_LEVEL = "TopLevel".getBytes(US_ASCII);
+  private static final byte[] START = "Start".getBytes(US_ASCII);
+  private static final byte[] STATS = "Stats".getBytes(US_ASCII);
+
+  private final WellKnownTags wellKnownTags;
+  private final WritableFormatter writer;
+
+  public SerializingMetricWriter(WellKnownTags wellKnownTags, Sink sink) {
+    this.wellKnownTags = wellKnownTags;
+    this.writer =
+        new MsgPackWriter(
+            // 64KB
+            sink, ByteBuffer.allocate(64 << 20), EnumSet.of(RESIZEABLE, SINGLE_MESSAGE));
+  }
+
+  @Override
+  public void startBucket(int metricCount, long start, long duration) {
+    writer.startMap(3);
+
+    writer.writeUTF8(HOSTNAME);
+    writer.writeUTF8(wellKnownTags.getHostname());
+
+    writer.writeUTF8(ENV);
+    writer.writeUTF8(wellKnownTags.getEnv());
+
+    writer.writeUTF8(STATS);
+    writer.startArray(1);
+
+    writer.startMap(3);
+
+    writer.writeUTF8(START);
+    writer.writeLong(start);
+
+    writer.writeUTF8(DURATION);
+    writer.writeLong(duration);
+
+    writer.writeUTF8(STATS);
+    writer.startArray(metricCount);
+  }
+
+  @Override
+  public void add(MetricKey key, AggregateMetric aggregate) {
+    writer.startMap(9);
+
+    writer.writeUTF8(NAME);
+    writer.writeUTF8(key.getOperationName());
+
+    writer.writeUTF8(ENV);
+    writer.writeUTF8(wellKnownTags.getEnv());
+
+    writer.writeUTF8(SERVICE);
+    writer.writeUTF8(key.getService());
+
+    writer.writeUTF8(RESOURCE);
+    writer.writeUTF8(key.getResource());
+
+    writer.writeUTF8(VERSION);
+    writer.writeUTF8(wellKnownTags.getVersion());
+
+    writer.writeUTF8(HITS);
+    writer.writeFloat(aggregate.getHitCount());
+
+    writer.writeUTF8(ERRORS);
+    writer.writeFloat(aggregate.getErrorCount());
+
+    writer.writeUTF8(DURATION);
+    writer.writeDouble(aggregate.getDuration());
+
+    writer.writeUTF8(TOP_LEVEL);
+    writer.writeFloat(0);
+    // TODO sketches go here when ready
+  }
+
+  @Override
+  public void finishBucket() {
+    writer.flush();
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/Sink.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/Sink.java
@@ -1,0 +1,8 @@
+package datadog.trace.common.metrics;
+
+import datadog.trace.core.serialization.ByteBufferConsumer;
+
+public interface Sink extends ByteBufferConsumer {
+
+  void register(EventListener listener);
+}

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/DDAgentWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/DDAgentWriter.java
@@ -59,6 +59,7 @@ public class DDAgentWriter implements Writer {
     int flushFrequencySeconds = 1;
     Monitoring monitoring = Monitoring.DISABLED;
     boolean traceAgentV05Enabled = Config.get().isTraceAgentV05Enabled();
+    boolean metricsReportingEnabled = Config.get().isTracerMetricsEnabled();
   }
 
   @lombok.Builder
@@ -74,7 +75,8 @@ public class DDAgentWriter implements Writer {
       final int flushFrequencySeconds,
       final Prioritization prioritization,
       final Monitoring monitoring,
-      final boolean traceAgentV05Enabled) {
+      final boolean traceAgentV05Enabled,
+      final boolean metricsReportingEnabled) {
     if (agentApi != null) {
       api = agentApi;
     } else {
@@ -84,6 +86,7 @@ public class DDAgentWriter implements Writer {
               unixDomainSocket,
               timeoutMillis,
               traceAgentV05Enabled,
+              metricsReportingEnabled,
               monitoring);
     }
     this.healthMetrics = healthMetrics;

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/WriterFactory.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/WriterFactory.java
@@ -71,6 +71,7 @@ public class WriterFactory {
             unixDomainSocket,
             TimeUnit.SECONDS.toMillis(config.getAgentTimeout()),
             Config.get().isTraceAgentV05Enabled(),
+            Config.get().isTracerMetricsEnabled(),
             monitoring);
 
     final String prioritizationType = config.getPrioritizationType();

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/DDAgentApi.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/DDAgentApi.java
@@ -26,7 +26,6 @@ import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
-import okio.BufferedSink;
 
 /** The API pointing to a DD agent */
 @Slf4j
@@ -144,7 +143,7 @@ public class DDAgentApi {
           prepareRequest(tracesUrl)
               .addHeader(DATADOG_CLIENT_COMPUTED_STATS, metricsReportingEnabled ? "true" : "")
               .addHeader(X_DATADOG_TRACE_COUNT, Integer.toString(payload.representativeCount()))
-              .put(new MsgPackRequestBody(payload))
+              .put(payload.toRequest())
               .build();
       this.totalTraces += payload.representativeCount();
       this.receivedTraces += payload.traceCount();
@@ -433,30 +432,6 @@ public class DDAgentApi {
 
     public final String response() {
       return response;
-    }
-  }
-
-  private static class MsgPackRequestBody extends RequestBody {
-
-    private final Payload payload;
-
-    private MsgPackRequestBody(Payload payload) {
-      this.payload = payload;
-    }
-
-    @Override
-    public MediaType contentType() {
-      return MSGPACK;
-    }
-
-    @Override
-    public long contentLength() {
-      return payload.sizeInBytes();
-    }
-
-    @Override
-    public void writeTo(BufferedSink sink) throws IOException {
-      payload.writeTo(sink);
     }
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/Payload.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/Payload.java
@@ -3,6 +3,7 @@ package datadog.trace.common.writer.ddagent;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.WritableByteChannel;
+import okhttp3.RequestBody;
 
 public abstract class Payload {
 
@@ -31,18 +32,7 @@ public abstract class Payload {
 
   abstract int sizeInBytes();
 
-  public abstract void writeTo(WritableByteChannel channel) throws IOException;
+  abstract void writeTo(WritableByteChannel channel) throws IOException;
 
-  protected static int sizeInBytes(ByteBuffer buffer) {
-    return null == buffer ? 0 : buffer.limit() - buffer.position();
-  }
-
-  protected static void writeBufferToChannel(ByteBuffer buffer, WritableByteChannel channel)
-      throws IOException {
-    if (null != buffer) {
-      while (buffer.hasRemaining()) {
-        channel.write(buffer);
-      }
-    }
-  }
+  abstract RequestBody toRequest();
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/http/OkHttpUtils.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/http/OkHttpUtils.java
@@ -1,0 +1,74 @@
+package datadog.trace.core.http;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+import datadog.common.container.ContainerInfo;
+import datadog.trace.common.writer.ddagent.unixdomainsockets.UnixDomainSocketFactory;
+import datadog.trace.core.DDTraceCoreInfo;
+import java.io.File;
+import java.util.Collections;
+import okhttp3.ConnectionSpec;
+import okhttp3.Dispatcher;
+import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+
+public final class OkHttpUtils {
+
+  private static final String DATADOG_META_LANG = "Datadog-Meta-Lang";
+  private static final String DATADOG_META_LANG_VERSION = "Datadog-Meta-Lang-Version";
+  private static final String DATADOG_META_LANG_INTERPRETER = "Datadog-Meta-Lang-Interpreter";
+  private static final String DATADOG_META_LANG_INTERPRETER_VENDOR =
+      "Datadog-Meta-Lang-Interpreter-Vendor";
+  private static final String DATADOG_META_TRACER_VERSION = "Datadog-Meta-Tracer-Version";
+  private static final String DATADOG_CONTAINER_ID = "Datadog-Container-ID";
+
+  public static OkHttpClient buildHttpClient(final HttpUrl url, final long timeoutMillis) {
+    return buildHttpClient(url.scheme(), null, timeoutMillis);
+  }
+
+  public static OkHttpClient buildHttpClient(
+      final HttpUrl url, final String unixDomainSocketPath, final long timeoutMillis) {
+    return buildHttpClient(url.scheme(), unixDomainSocketPath, timeoutMillis);
+  }
+
+  public static OkHttpClient buildHttpClient(
+      final String scheme, final String unixDomainSocketPath, final long timeoutMillis) {
+    OkHttpClient.Builder builder = new OkHttpClient.Builder();
+    if (unixDomainSocketPath != null) {
+      builder = builder.socketFactory(new UnixDomainSocketFactory(new File(unixDomainSocketPath)));
+    }
+
+    if (!"https".equals(scheme)) {
+      // force clear text when using http to avoid failures for JVMs without TLS
+      builder = builder.connectionSpecs(Collections.singletonList(ConnectionSpec.CLEARTEXT));
+    }
+
+    return builder
+        .connectTimeout(timeoutMillis, MILLISECONDS)
+        .writeTimeout(timeoutMillis, MILLISECONDS)
+        .readTimeout(timeoutMillis, MILLISECONDS)
+
+        // We don't do async so this shouldn't matter, but just to be safe...
+        .dispatcher(new Dispatcher(RejectingExecutorService.INSTANCE))
+        .build();
+  }
+
+  public static Request.Builder prepareRequest(final HttpUrl url) {
+    final Request.Builder builder =
+        new Request.Builder()
+            .url(url)
+            .addHeader(DATADOG_META_LANG, "java")
+            .addHeader(DATADOG_META_LANG_VERSION, DDTraceCoreInfo.JAVA_VERSION)
+            .addHeader(DATADOG_META_LANG_INTERPRETER, DDTraceCoreInfo.JAVA_VM_NAME)
+            .addHeader(DATADOG_META_LANG_INTERPRETER_VENDOR, DDTraceCoreInfo.JAVA_VM_VENDOR)
+            .addHeader(DATADOG_META_TRACER_VERSION, DDTraceCoreInfo.VERSION);
+
+    final String containerId = ContainerInfo.get().getContainerId();
+    if (containerId == null) {
+      return builder;
+    } else {
+      return builder.addHeader(DATADOG_CONTAINER_ID, containerId);
+    }
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/core/http/RejectingExecutorService.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/http/RejectingExecutorService.java
@@ -1,0 +1,41 @@
+package datadog.trace.core.http;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+
+/** {@link ExecutorService} that always rejects requests. */
+public final class RejectingExecutorService extends AbstractExecutorService {
+  public static final RejectingExecutorService INSTANCE = new RejectingExecutorService();
+
+  @Override
+  public void execute(final Runnable command) {
+    throw new RejectedExecutionException("Unexpected request to execute async task");
+  }
+
+  @Override
+  public void shutdown() {}
+
+  @Override
+  public List<Runnable> shutdownNow() {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public boolean isShutdown() {
+    return true;
+  }
+
+  @Override
+  public boolean isTerminated() {
+    return true;
+  }
+
+  @Override
+  public boolean awaitTermination(final long timeout, final TimeUnit unit) {
+    return true;
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/core/serialization/protobuf/ProtobufWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/serialization/protobuf/ProtobufWriter.java
@@ -11,6 +11,7 @@ import datadog.trace.core.serialization.WritableFormatter;
 import java.nio.ByteBuffer;
 import java.util.ArrayDeque;
 import java.util.Deque;
+import java.util.EnumSet;
 import java.util.Map;
 
 /**
@@ -285,7 +286,12 @@ public class ProtobufWriter extends WritableFormatter {
 
   public ProtobufWriter(
       Codec codec, ByteBufferConsumer sink, ByteBuffer buffer, boolean manualReset) {
-    super(codec, sink, buffer, manualReset, 0);
+    super(
+        codec,
+        sink,
+        buffer,
+        manualReset ? EnumSet.of(Feature.MANUAL_RESET) : EnumSet.noneOf(Feature.class),
+        0);
     this.root = new Context(buffer);
     this.active = root;
     stack.push(active);
@@ -356,7 +362,7 @@ public class ProtobufWriter extends WritableFormatter {
   }
 
   @Override
-  protected void writeHeader() {
+  protected void writeHeader(boolean writeArray) {
     buffer.position(0);
   }
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/AgentIntegrationTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/AgentIntegrationTest.groovy
@@ -1,0 +1,41 @@
+package datadog.trace.common.metrics
+
+import datadog.trace.api.WellKnownTags
+import datadog.trace.test.util.DDSpecification
+import spock.lang.Ignore
+import spock.lang.Requires
+
+import static java.util.concurrent.TimeUnit.SECONDS
+
+@Ignore("requires an upgrade to an as yet unreleased agent to run")
+@Requires({ "true" == System.getenv("CI") })
+class AgentIntegrationTest extends DDSpecification {
+
+
+  def "send metrics to trace agent should notify with OK event"() {
+    setup:
+    def listener = Mock(EventListener)
+    OkHttpSink sink = new OkHttpSink("http://localhost:8126", 5000L)
+    sink.register(listener)
+
+    when:
+    SerializingMetricWriter writer = new SerializingMetricWriter(
+      new WellKnownTags("hostname", "env", "service", "version"),
+      sink
+    )
+    writer.startBucket(2, System.nanoTime(), SECONDS.toNanos(10))
+    writer.add(
+      new MetricKey("resource1", "service1", "operation1", 0),
+      new AggregateMetric().addHits(10).addErrors(1)
+    )
+    writer.add(
+      new MetricKey("resource2", "service2", "operation2", 200),
+      new AggregateMetric().addHits(9).addErrors(1)
+    )
+    writer.finishBucket()
+
+    then:
+    1 * listener.onEvent(EventListener.EventType.OK, _)
+
+  }
+}

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/AggregateMetricTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/AggregateMetricTest.groovy
@@ -1,0 +1,118 @@
+package datadog.trace.common.metrics
+
+import datadog.trace.test.util.DDSpecification
+
+import java.util.concurrent.BlockingDeque
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.LinkedBlockingDeque
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+class AggregateMetricTest extends DDSpecification {
+
+  def "record durations sums up to total"() {
+    given:
+    AggregateMetric aggregate = new AggregateMetric()
+    when:
+    aggregate.recordDurations(0L, 1, 2, 3)
+    then:
+    aggregate.getDuration() == 6
+  }
+
+  def "clear"() {
+    given:
+    AggregateMetric aggregate = new AggregateMetric()
+    .recordDurations(0L, 5, 6, 7)
+    .addHits(10)
+    .addErrors(1)
+    when:
+    aggregate.clear()
+    then:
+    aggregate.getDuration() == 0
+    aggregate.getErrorCount() == 0
+    aggregate.getHitCount() == 0
+  }
+
+  def "contribute batch with key to aggregate"() {
+    given:
+    AggregateMetric aggregate = new AggregateMetric()
+      .addHits(10)
+      .addErrors(1)
+
+    Batch batch = new Batch().withKey(new MetricKey("foo", "bar", "qux", 0))
+    batch.add(false, 10)
+    batch.add(false, 10)
+    batch.add(false, 10)
+
+    when:
+    batch.contributeTo(aggregate)
+
+    then: "key cleared and values contributed to existing aggregate"
+    batch.getKey() == null
+    aggregate.getDuration() == 30
+    aggregate.getHitCount() == 13
+    aggregate.getErrorCount() == 1
+  }
+
+  def "ignore batches without keys"() {
+    given:
+    AggregateMetric aggregate = new AggregateMetric()
+      .addHits(10)
+      .addErrors(1)
+
+    Batch batch = new Batch()
+    batch.add(false, 10)
+
+    when:
+    batch.contributeTo(aggregate)
+
+    then: "batch ignored"
+    aggregate.getDuration() == 0
+    aggregate.getHitCount() == 10
+    aggregate.getErrorCount() == 1
+  }
+
+  def "consistent under concurrent attempts to read and write"() {
+    given:
+    AggregateMetric aggregate = new AggregateMetric()
+    MetricKey key = new MetricKey("foo", "bar", "qux", 0)
+    BlockingDeque<Batch> queue = new LinkedBlockingDeque<>(1000)
+    ExecutorService reader = Executors.newSingleThreadExecutor()
+    int writerCount = 10
+    ExecutorService writers = Executors.newFixedThreadPool(writerCount)
+    CountDownLatch readerLatch = new CountDownLatch(1)
+    CountDownLatch writerLatch = new CountDownLatch(writerCount)
+
+    AtomicInteger written = new AtomicInteger(0)
+
+    when:
+    for (int i = 0; i < writerCount; ++i) {
+      writers.submit({
+        readerLatch.await()
+        for (int j = 0; j < 10_000; ++j) {
+          Batch batch = queue.peekLast()
+          if (batch?.add(false, 1)) {
+            written.incrementAndGet()
+          } else {
+            queue.offer(new Batch().withKey(key))
+          }
+        }
+        writerLatch.countDown()
+      })
+    }
+    def future = reader.submit({
+      readerLatch.countDown()
+      while (!Thread.currentThread().isInterrupted()) {
+        Batch batch = queue.take()
+        batch.contributeTo(aggregate)
+      }
+    })
+    writerLatch.await(10, TimeUnit.SECONDS)
+    future.cancel(true)
+
+    then:
+    aggregate.getHitCount() == written.get()
+  }
+}

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/ConflatingMetricAggregatorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/ConflatingMetricAggregatorTest.groovy
@@ -1,0 +1,79 @@
+package datadog.trace.common.metrics
+
+import datadog.trace.api.WellKnownTags
+import datadog.trace.core.DDSpanData
+import datadog.trace.test.util.DDSpecification
+
+import java.util.concurrent.CountDownLatch
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS
+import static java.util.concurrent.TimeUnit.SECONDS
+
+class ConflatingMetricAggregatorTest extends DDSpecification {
+
+  def "should ignore traces with no measured spans"() {
+    setup:
+    Sink sink = Mock(Sink)
+    WellKnownTags wellKnownTags = new WellKnownTags("hostname", "env", "service", "version")
+    ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(
+      wellKnownTags,
+      sink,
+      10,
+      10,
+      1,
+      MILLISECONDS
+    )
+    aggregator.start()
+
+    when:
+    aggregator.publish([new SimpleSpan("", "", "", false, false, 0, 0)])
+
+    then:
+    0 * sink._
+
+    cleanup:
+    aggregator.close()
+  }
+
+  def "aggregate repetitive spans"() {
+    setup:
+    int reportingInterval = 10
+    CountDownLatch latch = new CountDownLatch(1)
+    MetricWriter writer = Mock(MetricWriter)
+    ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(
+      Mock(Sink), writer, 10, 10, reportingInterval, SECONDS)
+    long duration = 100
+    List<DDSpanData> trace = [
+      new SimpleSpan("service", "operation", "resource", true, false, 0, duration),
+      new SimpleSpan("service1", "operation1", "resource1", false, false, 0, 0),
+      new SimpleSpan("service2", "operation2", "resource2", true, false, 0, duration * 2)
+    ]
+    aggregator.start()
+
+
+    when:
+    for (int i = 0; i < count; ++i) {
+      aggregator.publish(trace)
+    }
+    aggregator.stop()
+    latch.await(10, SECONDS)
+
+    then: "metrics should be conflated"
+    1 * writer.finishBucket() >> { latch.countDown() }
+    1 * writer.startBucket(2, _, SECONDS.toNanos(reportingInterval))
+    1 * writer.add(new MetricKey("resource", "service", "operation", 0), _) >> {
+      MetricKey key, AggregateMetric value -> value.getHitCount() == count && value.getDuration() == count * duration
+    }
+    1 * writer.add(new MetricKey("resource2", "service2", "operation2", 0), _) >> {
+      MetricKey key, AggregateMetric value -> value.getHitCount() == count && value.getDuration() == count * duration * 2
+    }
+
+    cleanup:
+    aggregator.close()
+
+    where:
+    count << [10, 100]
+  }
+
+
+}

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/MetricsAggregatorFactoryTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/MetricsAggregatorFactoryTest.groovy
@@ -1,0 +1,25 @@
+package datadog.trace.common.metrics
+
+import datadog.trace.api.Config
+import datadog.trace.test.util.DDSpecification
+
+class MetricsAggregatorFactoryTest extends DDSpecification {
+
+  def "when metrics disabled no-op aggregator created"() {
+    setup:
+    Config config = Mock(Config)
+    config.isTracerMetricsEnabled() >> false
+    expect:
+    def aggregator = MetricsAggregatorFactory.createMetricsAggregator(config)
+    assert aggregator instanceof NoOpMetricsAggregator
+  }
+
+  def "when metrics enabled conflating aggregator created"() {
+    setup:
+    Config config = Spy(Config.get())
+    config.isTracerMetricsEnabled() >> true
+    expect:
+    def aggregator = MetricsAggregatorFactory.createMetricsAggregator(config)
+    assert aggregator instanceof ConflatingMetricsAggregator
+  }
+}

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/OkHttpSinkTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/OkHttpSinkTest.groovy
@@ -1,0 +1,69 @@
+package datadog.trace.common.metrics
+
+import datadog.trace.test.util.DDSpecification
+import okhttp3.Call
+import okhttp3.MediaType
+import okhttp3.OkHttpClient
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.ResponseBody
+
+import java.nio.ByteBuffer
+
+import static datadog.trace.common.metrics.EventListener.EventType.BAD_PAYLOAD
+import static datadog.trace.common.metrics.EventListener.EventType.DOWNGRADED
+import static datadog.trace.common.metrics.EventListener.EventType.ERROR
+import static datadog.trace.common.metrics.EventListener.EventType.OK
+
+class OkHttpSinkTest extends DDSpecification {
+
+  def "http status code #responseCode yields #eventType"() {
+    setup:
+    String agentUrl = "http://localhost:8126"
+    String path = "v0.5/stats"
+    EventListener listener = Mock(EventListener)
+    OkHttpClient client = Mock(OkHttpClient)
+
+    OkHttpSink sink = new OkHttpSink(client, agentUrl, path)
+    sink.register(listener)
+
+    when:
+    sink.accept(0, ByteBuffer.allocate(0))
+
+    then:
+    1 * client.newCall(_) >> { Request request -> respond(request, responseCode) }
+    1 * listener.onEvent(eventType, _)
+
+    where:
+    eventType   | responseCode
+    DOWNGRADED  | 404
+    ERROR       | 500
+    ERROR       | 0 // throw
+    BAD_PAYLOAD | 400
+    OK          | 200
+    OK          | 201
+  }
+
+  def respond(Request request, int code) {
+    if (0 == code) {
+      return error(request)
+    }
+    return Mock(Call) {
+      it.execute() >> new Response.Builder()
+        .code(code)
+        .request(request)
+        .protocol(Protocol.HTTP_1_1)
+        .message("message")
+        .body(ResponseBody.create(MediaType.get("text/plain"), "message"))
+        .build()
+    }
+  }
+
+  def error(Request request) {
+    return Mock(Call) {
+      it.execute() >> { throw new IOException("thrown by test") }
+    }
+  }
+
+}

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SerializingMetricWriterTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SerializingMetricWriterTest.groovy
@@ -1,0 +1,117 @@
+package datadog.trace.common.metrics
+
+import datadog.trace.api.WellKnownTags
+import datadog.trace.bootstrap.instrumentation.api.Pair
+import datadog.trace.test.util.DDSpecification
+import org.msgpack.core.MessagePack
+import org.msgpack.core.MessageUnpacker
+
+import java.nio.ByteBuffer
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS
+import static java.util.concurrent.TimeUnit.SECONDS
+
+class SerializingMetricWriterTest extends DDSpecification {
+
+  def "should produce correct message" () {
+    setup:
+    long startTime = MILLISECONDS.toNanos(System.currentTimeMillis())
+    long duration = SECONDS.toNanos(10)
+    WellKnownTags wellKnownTags = new WellKnownTags("hostname", "env", "service", "version")
+    ValidatingSink sink = new ValidatingSink(wellKnownTags, startTime, duration, content)
+    SerializingMetricWriter writer = new SerializingMetricWriter(wellKnownTags, sink)
+
+    when:
+    writer.startBucket(content.size(), startTime, duration)
+    for (Pair<MetricKey, AggregateMetric> pair : content) {
+      writer.add(pair.getLeft(), pair.getRight())
+    }
+    writer.finishBucket()
+
+    then:
+    sink.validatedInput()
+
+
+    where:
+    content << [
+      [
+        Pair.of(new MetricKey("resource1", "service1", "operation1", 0), new AggregateMetric().addHits(10).addErrors(1)),
+        Pair.of(new MetricKey("resource2", "service2", "operation2", 200), new AggregateMetric().addHits(9).addErrors(1))
+      ]
+    ]
+  }
+
+
+  class ValidatingSink implements Sink {
+
+    private final WellKnownTags wellKnownTags
+    private final long startTimeNanos
+    private final long duration
+    private boolean validated = false
+    private List<Pair<MetricKey, AggregateMetric>> content
+
+    ValidatingSink(WellKnownTags wellKnownTags, long startTimeNanos, long duration,
+                   List<Pair<MetricKey, AggregateMetric>> content) {
+      this.wellKnownTags = wellKnownTags
+      this.startTimeNanos = startTimeNanos
+      this.duration = duration
+      this.content = content
+    }
+
+    @Override
+    void register(EventListener listener) {
+
+    }
+
+    @Override
+    void accept(int messageCount, ByteBuffer buffer) {
+      MessageUnpacker unpacker = MessagePack.newDefaultUnpacker(buffer)
+      int mapSize = unpacker.unpackMapHeader()
+      assert mapSize == 3
+      assert unpacker.unpackString() == "Hostname"
+      assert unpacker.unpackString() == wellKnownTags.getHostname() as String
+      assert unpacker.unpackString() == "Env"
+      assert unpacker.unpackString() == wellKnownTags.getEnv() as String
+      assert unpacker.unpackString() == "Stats"
+      int outerLength = unpacker.unpackArrayHeader()
+      assert outerLength == 1
+      assert unpacker.unpackMapHeader() == 3
+      assert unpacker.unpackString() == "Start"
+      assert unpacker.unpackLong() == startTimeNanos
+      assert unpacker.unpackString() == "Duration"
+      assert unpacker.unpackLong() == duration
+      assert unpacker.unpackString() == "Stats"
+      int statCount = unpacker.unpackArrayHeader()
+      assert statCount == content.size()
+      for (Pair<MetricKey, AggregateMetric> pair : content) {
+        MetricKey key = pair.getLeft()
+        AggregateMetric value = pair.getRight()
+        int size = unpacker.unpackMapHeader()
+        assert size == 9
+        assert unpacker.unpackString() == "Name"
+        assert unpacker.unpackString() == key.getOperationName() as String
+        assert unpacker.unpackString() == "Env"
+        assert unpacker.unpackString() == wellKnownTags.getEnv() as String
+        assert unpacker.unpackString() == "Service"
+        assert unpacker.unpackString() == key.getService() as String
+        assert unpacker.unpackString() == "Resource"
+        assert unpacker.unpackString() == key.getResource() as String
+        assert unpacker.unpackString() == "Version"
+        assert unpacker.unpackString() == wellKnownTags.getVersion() as String
+        assert unpacker.unpackString() == "Hits"
+        assert unpacker.unpackFloat() == value.getHitCount()
+        assert unpacker.unpackString() == "Errors"
+        assert unpacker.unpackFloat() == value.getErrorCount()
+        assert unpacker.unpackString() == "Duration"
+        assert unpacker.unpackDouble() == value.getDuration()
+        assert unpacker.unpackString() == "TopLevel"
+        unpacker.skipValue() // skip top level for now
+      }
+      validated = true
+    }
+
+    boolean validatedInput() {
+      return validated
+    }
+  }
+}

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SimpleSpan.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SimpleSpan.groovy
@@ -1,0 +1,108 @@
+package datadog.trace.common.metrics
+
+import datadog.trace.api.DDId
+import datadog.trace.core.DDSpanData
+import datadog.trace.core.TagsAndBaggageConsumer
+
+class SimpleSpan implements DDSpanData {
+
+  private final String serviceName
+  private final String operationName
+  private final String resourceName
+  private final boolean measured
+  private final boolean error
+
+  private final long duration
+  private final long startTime
+
+  SimpleSpan(String serviceName,
+             String operationName,
+             String resourceName,
+             boolean measured,
+             boolean error,
+             long startTime,
+             long duration) {
+    this.serviceName = serviceName
+    this.operationName = operationName
+    this.resourceName = resourceName
+    this.measured = measured
+    this.error = error
+    this.startTime = startTime
+    this.duration = duration
+  }
+
+  @Override
+  String getServiceName() {
+    return serviceName
+  }
+
+  @Override
+  CharSequence getOperationName() {
+    return operationName
+  }
+
+  @Override
+  CharSequence getResourceName() {
+    return resourceName
+  }
+
+  @Override
+  DDId getTraceId() {
+    return DDId.ZERO
+  }
+
+  @Override
+  DDId getSpanId() {
+    return DDId.ZERO
+  }
+
+  @Override
+  DDId getParentId() {
+    return DDId.ZERO
+  }
+
+  @Override
+  long getStartTime() {
+    return startTime
+  }
+
+  @Override
+  long getDurationNano() {
+    return duration
+  }
+
+  @Override
+  int getError() {
+    return error ? 1 : 0
+  }
+
+  @Override
+  boolean isMeasured() {
+    return measured
+  }
+
+  @Override
+  Map<CharSequence, Number> getMetrics() {
+    return null
+  }
+
+  @Override
+  Map<String, String> getBaggage() {
+    return null
+  }
+
+  @Override
+  Map<String, Object> getTags() {
+    return null
+  }
+
+  @Override
+  CharSequence getType() {
+    return null
+  }
+
+  @Override
+  void processTagsAndBaggage(TagsAndBaggageConsumer consumer) {
+
+  }
+}

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddagent/TraceMapperRealAgentTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddagent/TraceMapperRealAgentTest.groovy
@@ -18,9 +18,9 @@ class TraceMapperRealAgentTest extends DDSpecification {
   @Shared
   Monitoring monitoring = new Monitoring(new NoOpStatsDClient(), 1, TimeUnit.SECONDS)
   @Shared
-  DDAgentApi v05Api = new DDAgentApi("http://localhost:8126", null, 30_000, true, monitoring)
+  DDAgentApi v05Api = new DDAgentApi("http://localhost:8126", null, 30_000, true, false, monitoring)
   @Shared
-  DDAgentApi v04Api = new DDAgentApi("http://localhost:8126", null, 30_000, false, monitoring)
+  DDAgentApi v04Api = new DDAgentApi("http://localhost:8126", null, 30_000, false, false, monitoring)
 
   def "send random traces"() {
     setup:

--- a/dd-trace-core/src/traceAgentTest/groovy/DDApiIntegrationTest.groovy
+++ b/dd-trace-core/src/traceAgentTest/groovy/DDApiIntegrationTest.groovy
@@ -128,11 +128,11 @@ class DDApiIntegrationTest extends DDSpecification {
 
   def beforeTest(boolean enableV05) {
     Monitoring monitoring = new Monitoring(statsDClient, 1, TimeUnit.SECONDS)
-    api = new DDAgentApi(String.format("http://%s:%d", agentContainerHost, agentContainerPort), null, 5000, enableV05, monitoring)
+    api = new DDAgentApi(String.format("http://%s:%d", agentContainerHost, agentContainerPort), null, 5000, enableV05, false, monitoring)
     api.addResponseListener(responseListener)
     mapper = api.selectTraceMapper()
     version = mapper instanceof TraceMapperV0_5 ? "v0.5" : "v0.4"
-    unixDomainSocketApi = new DDAgentApi(String.format("http://%s:%d", SOMEHOST, SOMEPORT), socketPath.toString(), 5000, enableV05, monitoring)
+    unixDomainSocketApi = new DDAgentApi(String.format("http://%s:%d", SOMEHOST, SOMEPORT), socketPath.toString(), 5000, enableV05, false, monitoring)
     unixDomainSocketApi.addResponseListener(responseListener)
   }
 

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -57,6 +57,9 @@ import static datadog.trace.api.DDTags.SERVICE;
 import static datadog.trace.api.DDTags.SERVICE_TAG;
 import static datadog.trace.api.IdGenerationStrategy.RANDOM;
 import static datadog.trace.api.config.GeneralConfig.RUNTIME_METRICS_ENABLED;
+import static datadog.trace.api.config.GeneralConfig.TRACER_METRICS_ENABLED;
+import static datadog.trace.api.config.GeneralConfig.TRACER_METRICS_MAX_AGGREGATES;
+import static datadog.trace.api.config.GeneralConfig.TRACER_METRICS_MAX_PENDING;
 import static datadog.trace.api.config.TraceInstrumentationConfig.HYSTRIX_TAGS_ENABLED;
 import static datadog.trace.api.config.TraceInstrumentationConfig.LOGS_MDC_TAGS_INJECTION_ENABLED;
 import static datadog.trace.api.config.TracerConfig.ENABLE_TRACE_AGENT_V05;
@@ -332,6 +335,10 @@ public class Config {
   @Getter private final Integer healthMetricsStatsdPort;
   @Getter private final boolean perfMetricsEnabled;
 
+  @Getter private final boolean tracerMetricsEnabled;
+  @Getter private final int tracerMetricsMaxAggregates;
+  @Getter private final int tracerMetricsMaxPending;
+
   @Getter private final boolean logsInjectionEnabled;
   @Getter private final boolean logsMDCTagsInjectionEnabled;
   @Getter private final boolean reportHostName;
@@ -587,6 +594,10 @@ public class Config {
         runtimeMetricsEnabled
             && configProvider.getBoolean(PERF_METRICS_ENABLED, DEFAULT_PERF_METRICS_ENABLED);
 
+    tracerMetricsEnabled = configProvider.getBoolean(TRACER_METRICS_ENABLED, false);
+    tracerMetricsMaxAggregates = configProvider.getInteger(TRACER_METRICS_MAX_AGGREGATES, 1000);
+    tracerMetricsMaxPending = configProvider.getInteger(TRACER_METRICS_MAX_PENDING, 2048);
+
     logsInjectionEnabled =
         configProvider.getBoolean(LOGS_INJECTION_ENABLED, DEFAULT_LOGS_INJECTION_ENABLED);
     logsMDCTagsInjectionEnabled = configProvider.getBoolean(LOGS_MDC_TAGS_INJECTION_ENABLED, false);
@@ -719,6 +730,10 @@ public class Config {
     }
 
     return Collections.unmodifiableMap(result);
+  }
+
+  public WellKnownTags getWellKnownTags() {
+    return new WellKnownTags(getHostName(), tags.get(ENV), serviceName, tags.get(VERSION));
   }
 
   public Map<String, String> getMergedSpanTags() {

--- a/internal-api/src/main/java/datadog/trace/api/WellKnownTags.java
+++ b/internal-api/src/main/java/datadog/trace/api/WellKnownTags.java
@@ -1,0 +1,35 @@
+package datadog.trace.api;
+
+import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
+
+public class WellKnownTags {
+
+  private final UTF8BytesString hostname;
+  private final UTF8BytesString env;
+  private final UTF8BytesString service;
+  private final UTF8BytesString version;
+
+  public WellKnownTags(
+      CharSequence hostname, CharSequence env, CharSequence service, CharSequence version) {
+    this.hostname = UTF8BytesString.create(hostname);
+    this.env = UTF8BytesString.create(env);
+    this.service = UTF8BytesString.create(service);
+    this.version = UTF8BytesString.create(version);
+  }
+
+  public UTF8BytesString getHostname() {
+    return hostname;
+  }
+
+  public UTF8BytesString getEnv() {
+    return env;
+  }
+
+  public UTF8BytesString getService() {
+    return service;
+  }
+
+  public UTF8BytesString getVersion() {
+    return version;
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/UTF8BytesString.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/UTF8BytesString.java
@@ -21,30 +21,38 @@ public final class UTF8BytesString implements CharSequence {
     } else if (sequence instanceof UTF8BytesString) {
       return (UTF8BytesString) sequence;
     } else {
-      return new UTF8BytesString(sequence);
+      return new UTF8BytesString(String.valueOf(sequence));
     }
   }
 
   private final String string;
-  private final byte[] utf8Bytes;
+  private byte[] utf8Bytes;
 
-  private UTF8BytesString(CharSequence chars) {
-    this.string = String.valueOf(chars);
-    this.utf8Bytes = string.getBytes(UTF_8);
+  private UTF8BytesString(String string) {
+    this.string = string;
   }
 
   /** Writes the UTF8 encoding of the wrapped {@code String}. */
   public void transferTo(ByteBuffer buffer) {
+    encodeIfNecessary();
     buffer.put(utf8Bytes);
   }
 
   public int encodedLength() {
+    encodeIfNecessary();
     return utf8Bytes.length;
   }
 
   @Override
   public String toString() {
     return string;
+  }
+
+  private void encodeIfNecessary() {
+    // benign and intentional race condition
+    if (null == utf8Bytes) {
+      utf8Bytes = string.getBytes(UTF_8);
+    }
   }
 
   @Override

--- a/internal-api/src/main/java/datadog/trace/util/AgentThreadFactory.java
+++ b/internal-api/src/main/java/datadog/trace/util/AgentThreadFactory.java
@@ -15,6 +15,8 @@ public final class AgentThreadFactory implements ThreadFactory {
     TRACE_PROCESSOR("dd-trace-processor"),
     TRACE_CASSANDRA_ASYNC_SESSION("dd-cassandra-session-executor"),
 
+    METRICS_AGGREGATOR("dd-metrics-aggregator"),
+
     JMX_STARTUP("dd-agent-startup-jmxfetch"),
     JMX_COLLECTOR("dd-jmx-collector"),
 

--- a/internal-api/src/test/groovy/datadog/trace/api/WellKnownTagsTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/WellKnownTagsTest.groovy
@@ -1,0 +1,17 @@
+package datadog.trace.api
+
+import datadog.trace.test.util.DDSpecification
+
+class WellKnownTagsTest extends DDSpecification {
+
+  def "well known tags doesn't modify its inputs"() {
+    given:
+    WellKnownTags wellKnownTags =
+      new WellKnownTags("hostname", "env", "service", "version")
+    expect:
+    wellKnownTags.getHostname() as String == "hostname"
+    wellKnownTags.getEnv() as String == "env"
+    wellKnownTags.getService() as String == "service"
+    wellKnownTags.getVersion() as String == "version"
+  }
+}


### PR DESCRIPTION
Some things are missing here which will be addressed in a follow up

* Latency sketches
* Break RPS down by HTTP status code (waiting for this to be acceptable as a top level property in the format the agent accepts)
* Update the docker image so the integration test can run