### PR TITLE
better logging on JFR max depth setting

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/ProfilingSystem.java
+++ b/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/ProfilingSystem.java
@@ -140,7 +140,7 @@ public final class ProfilingSystem {
       // client specified a value considered safe
       if (stackDepth <= MAX_STACK_DEPTH) {
         log.info("skip setting JFR.configure stackdepth, using " + userSpecifiedDepth);
-        return stackDepth;
+        return -1;
       }
 
       // limit how deep a stack depth we'll collect
@@ -160,6 +160,11 @@ public final class ProfilingSystem {
         readJFRStackDepth(SystemAccess.getVMArguments());
     if (userSpecifiedStackDepth.isPresent()) {
       maxFrames = stackDepthFromClient(userSpecifiedStackDepth.get());
+    }
+
+    if (maxFrames < 0) {
+      // user already specified a max stack depth considered safe, skip setting
+      return;
     }
 
     final String result =

--- a/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/ProfilingSystem.java
+++ b/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/ProfilingSystem.java
@@ -138,7 +138,7 @@ public final class ProfilingSystem {
       final int stackDepth = Integer.parseInt(userSpecifiedDepth);
 
       // client specified a value considered safe
-      if (stackDepth < MAX_STACK_DEPTH) {
+      if (stackDepth <= MAX_STACK_DEPTH) {
         log.info("skip setting JFR.configure stackdepth, using " + userSpecifiedDepth);
         return stackDepth;
       }

--- a/dd-java-agent/agent-profiling/profiling-controller/src/test/java/com/datadog/profiling/controller/ProfilingSystemTest.java
+++ b/dd-java-agent/agent-profiling/profiling-controller/src/test/java/com/datadog/profiling/controller/ProfilingSystemTest.java
@@ -394,7 +394,7 @@ public class ProfilingSystemTest {
   }
 
   @ParameterizedTest
-  @CsvSource({",256", "foo,256", "512,512", "1025,1024"})
+  @CsvSource({",256", "foo,256", "512,-1", "1024,-1", "1025,1024"})
   public void testStackDepthFromClient(final String input, final int expected) {
     assertEquals(expected, ProfilingSystem.stackDepthFromClient(input));
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/util/JmxSystemAccessProvider.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/util/JmxSystemAccessProvider.java
@@ -53,7 +53,7 @@ final class JmxSystemAccessProvider implements SystemAccessProvider {
     try {
       diagnosticCommandMBean = new ObjectName("com.sun.management:type=DiagnosticCommand");
     } catch (final MalformedObjectNameException ex) {
-      log.warn("Error during executeDiagnosticCommand: ", ex);
+      log.debug("Error during executeDiagnosticCommand: ", ex);
       return ex.getMessage();
     }
     try {
@@ -62,7 +62,7 @@ final class JmxSystemAccessProvider implements SystemAccessProvider {
               .invoke(diagnosticCommandMBean, command, args, sig);
       return result != null ? result.toString().trim() : null;
     } catch (final Throwable ex) {
-      log.warn("Error invoking diagnostic command: ", ex);
+      log.debug("Error invoking diagnostic command: ", ex);
       return ex.getMessage();
     }
   }
@@ -74,7 +74,7 @@ final class JmxSystemAccessProvider implements SystemAccessProvider {
     try {
       args = runtimeMXBean.getInputArguments();
     } catch (final Throwable ex) {
-      log.warn("Error invoking runtimeMxBean.getInputArguments: ", ex);
+      log.debug("Error invoking runtimeMxBean.getInputArguments: ", ex);
     }
     return args;
   }


### PR DESCRIPTION
* stop logging scary errors when we can't run diagnostic commands; we make a best-effort attempt to set the stack depth and shouldn't log a scary warning and exception when we can't
* remove confusing log line by not explicitly setting the max stack depth when a user has already specified a valid value