### PR TITLE
`FieldBackedProvider` should avoid modifying `Serializable` classes without `serialVersionUID`

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/context/FieldBackedProvider.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/context/FieldBackedProvider.java
@@ -2,7 +2,11 @@ package datadog.trace.agent.tooling.context;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers.safeHasSuperType;
 import static datadog.trace.agent.tooling.context.ContextStoreUtils.unpackContextStore;
+import static net.bytebuddy.matcher.ElementMatchers.declaresField;
+import static net.bytebuddy.matcher.ElementMatchers.fieldType;
+import static net.bytebuddy.matcher.ElementMatchers.isFinal;
 import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.not;
 
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.Instrumenter.Default;
@@ -14,7 +18,9 @@ import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import net.bytebuddy.ByteBuddy;
 import net.bytebuddy.agent.builder.AgentBuilder;
+import net.bytebuddy.description.field.FieldDescription;
 import net.bytebuddy.matcher.ElementMatcher;
+import net.bytebuddy.matcher.ElementMatchers;
 
 /**
  * InstrumentationContextProvider which stores context in a field that is injected into a class and
@@ -139,6 +145,14 @@ public final class FieldBackedProvider implements InstrumentationContextProvider
                     .type(safeHasSuperType(named(entry.getKey())), classLoaderMatcher)
                     .and(ShouldInjectFieldsMatcher.of(entry.getKey(), entry.getValue()))
                     .and(Default.NOT_DECORATOR_MATCHER)
+                    .and(
+                        not(safeHasSuperType(named("java.io.Serializable")))
+                            .or(
+                                declaresField(
+                                    named("serialVersionUID")
+                                        .and(ElementMatchers.<FieldDescription>isStatic())
+                                        .and(isFinal())
+                                        .and(fieldType(long.class)))))
                     .transform(
                         fieldInjector.fieldAccessTransformer(entry.getKey(), entry.getValue()));
           }

--- a/dd-java-agent/testing/src/test/java/context/ContextTestInstrumentation.java
+++ b/dd-java-agent/testing/src/test/java/context/ContextTestInstrumentation.java
@@ -7,6 +7,7 @@ import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.InstrumentationContext;
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
@@ -51,9 +52,14 @@ public class ContextTestInstrumentation extends Instrumenter.Default {
   @Override
   public Map<String, String> contextStoreForAll() {
     final Map<String, String> store = new HashMap<>(2);
-    store.put(getClass().getName() + "$KeyClass", getClass().getName() + "$Context");
-    store.put(getClass().getName() + "$UntransformableKeyClass", getClass().getName() + "$Context");
-    store.put(getClass().getName() + "$DisabledKeyClass", getClass().getName() + "$Context");
+    String prefix = getClass().getName() + "$";
+    store.put(prefix + "KeyClass", prefix + "Context");
+    store.put(prefix + "UntransformableKeyClass", prefix + "Context");
+    store.put(prefix + "DisabledKeyClass", prefix + "Context");
+    store.put(prefix + "ValidSerializableKeyClass", prefix + "Context");
+    store.put(prefix + "InvalidSerializableKeyClass", prefix + "Context");
+    store.put(prefix + "ValidInheritsSerializableKeyClass", prefix + "Context");
+    store.put(prefix + "InvalidInheritsSerializableKeyClass", prefix + "Context");
     return store;
   }
 
@@ -185,6 +191,22 @@ public class ContextTestInstrumentation extends Instrumenter.Default {
       return false;
     }
   }
+
+  /** A class that is serializable with serialVersionUID. */
+  public static class ValidSerializableKeyClass extends KeyClass implements Serializable {
+    private static final long serialVersionUID = 123;
+  }
+
+  /** A class that is serializable with no serialVersionUID. */
+  public static class InvalidSerializableKeyClass extends KeyClass implements Serializable {}
+
+  /** A class that inherits serializable with serialVersionUID. */
+  public static class ValidInheritsSerializableKeyClass extends InvalidSerializableKeyClass {
+    private static final long serialVersionUID = 456;
+  }
+
+  /** A class that inherits serializable with no serialVersionUID. */
+  public static class InvalidInheritsSerializableKeyClass extends ValidSerializableKeyClass {}
 
   public static class IncorrectKeyClassUsageKeyClass {
     public boolean isInstrumented() {


### PR DESCRIPTION
These classes may implicitly generate a serialVersionUID based on the modified class structure which would be different if we modified the class, making the serialization incompatible.