### PR TITLE
Log context extraction exceptions at debug in codec classes

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/B3HttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/B3HttpCodec.java
@@ -144,7 +144,7 @@ class B3HttpCodec {
           }
         } catch (RuntimeException e) {
           invalidateContext();
-          log.error("Exception when extracting context", e);
+          log.debug("Exception when extracting context", e);
           return false;
         }
       }

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/DatadogHttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/DatadogHttpCodec.java
@@ -142,7 +142,7 @@ class DatadogHttpCodec {
           }
         } catch (RuntimeException e) {
           invalidateContext();
-          log.error("Exception when extracting context", e);
+          log.debug("Exception when extracting context", e);
           return false;
         }
       }

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/HaystackHttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/HaystackHttpCodec.java
@@ -192,7 +192,7 @@ public class HaystackHttpCodec {
           }
         } catch (RuntimeException e) {
           invalidateContext();
-          log.error("Exception when extracting context", e);
+          log.debug("Exception when extracting context", e);
           return false;
         }
       }


### PR DESCRIPTION
This avoids spamming the logs when certain headers are blanked out during replay

If we want to keep some conditions logged as errors then let me know and I'll adjust the PR accordingly