### PR TITLE
remove counterproductive optimisations

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/InternalJarURLHandler.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/InternalJarURLHandler.java
@@ -28,14 +28,6 @@ public class InternalJarURLHandler extends URLStreamHandler {
   private final Map<String, Lock> packages = new HashMap<>();
   private final JarFile bootstrapJarFile;
 
-  private static final ThreadLocal<StringBuilder> JAR_ENTRY_QUERY =
-      new ThreadLocal<StringBuilder>() {
-        @Override
-        protected StringBuilder initialValue() {
-          return new StringBuilder(128);
-        }
-      };
-
   private WeakReference<Pair<String, JarEntry>> cache = NULL;
 
   InternalJarURLHandler(final String internalJarFileName, final URL bootstrapJarLocation) {
@@ -94,13 +86,7 @@ public class InternalJarURLHandler extends URLStreamHandler {
     // and the key will be a new object each time.
     Pair<String, JarEntry> pair = cache.get();
     if (null == pair || !filename.equals(pair.getLeft())) {
-      StringBuilder sb = JAR_ENTRY_QUERY.get();
-      sb.append(this.name).append(filename);
-      if (filename.endsWith(".class")) {
-        sb.append("data");
-      }
-      String classFileName = sb.toString();
-      sb.setLength(0);
+      String classFileName = this.name + filename + (filename.endsWith(".class") ? "data" : "");
       JarEntry entry = bootstrapJarFile.getJarEntry(classFileName);
       if (null != entry) {
         pair = Pair.of(filename, entry);

--- a/dd-trace-core/src/main/java/datadog/trace/core/processor/rule/URLAsResourceNameRule.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/processor/rule/URLAsResourceNameRule.java
@@ -8,14 +8,6 @@ public class URLAsResourceNameRule implements TraceProcessor.Rule {
 
   private static final BitSlicedBitapSearch PROTOCOL_SEARCH = new BitSlicedBitapSearch("://");
 
-  private final ThreadLocal<StringBuilder> resourceNameBuilder =
-      new ThreadLocal<StringBuilder>() {
-        @Override
-        protected StringBuilder initialValue() {
-          return new StringBuilder(100);
-        }
-      };
-
   @Override
   public String[] aliases() {
     return new String[] {"URLAsResourceName", "Status404Rule", "Status404Decorator"};
@@ -39,7 +31,7 @@ public class URLAsResourceNameRule implements TraceProcessor.Rule {
   }
 
   private String extractResourceNameFromURL(final Object method, final String url) {
-    StringBuilder resourceName = resourceNameBuilder.get();
+    StringBuilder resourceName = new StringBuilder(128);
     try {
       if (method != null) {
         final String verb = method.toString().toUpperCase().trim();

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/UTF8BytesString.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/UTF8BytesString.java
@@ -3,8 +3,6 @@ package datadog.trace.bootstrap.instrumentation.api;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Class that wraps a {@code String} and caches the UTF8 byte representation. Implements {@code
@@ -12,62 +10,36 @@ import java.util.List;
  */
 public final class UTF8BytesString implements CharSequence {
 
-  /*
-   * This method should be used judiciously for strings known not to vary much in the application's
-   * lifecycle, such as constants and effective constant (e.g. resource names)
-   */
+  @Deprecated
   public static UTF8BytesString createConstant(CharSequence string) {
-    return create(string, true);
+    return create(string);
   }
 
-  public static UTF8BytesString create(CharSequence chars) {
-    return create(chars, false);
-  }
-
-  private static UTF8BytesString create(CharSequence sequence, boolean constant) {
+  public static UTF8BytesString create(CharSequence sequence) {
     if (null == sequence) {
       return null;
     } else if (sequence instanceof UTF8BytesString) {
       return (UTF8BytesString) sequence;
     } else {
-      return new UTF8BytesString(sequence, constant);
+      return new UTF8BytesString(sequence);
     }
   }
-
-  private static final Allocator ALLOCATOR = new Allocator();
 
   private final String string;
   private final byte[] utf8Bytes;
-  private final int offset;
-  private final int length;
 
-  private UTF8BytesString(CharSequence chars, boolean constant) {
-    this(chars, constant, false);
-  }
-
-  private UTF8BytesString(CharSequence chars, boolean constant, boolean weak) {
+  private UTF8BytesString(CharSequence chars) {
     this.string = String.valueOf(chars);
-    byte[] utf8Bytes = string.getBytes(UTF_8);
-    this.length = utf8Bytes.length;
-    if (constant) {
-      Allocator.Allocation allocation = ALLOCATOR.allocate(utf8Bytes);
-      if (null != allocation) {
-        this.offset = allocation.position;
-        this.utf8Bytes = allocation.page;
-        return;
-      }
-    }
-    this.offset = 0;
-    this.utf8Bytes = utf8Bytes;
+    this.utf8Bytes = string.getBytes(UTF_8);
   }
 
   /** Writes the UTF8 encoding of the wrapped {@code String}. */
   public void transferTo(ByteBuffer buffer) {
-    buffer.put(utf8Bytes, offset, length);
+    buffer.put(utf8Bytes);
   }
 
   public int encodedLength() {
-    return length;
+    return utf8Bytes.length;
   }
 
   @Override
@@ -104,58 +76,5 @@ public final class UTF8BytesString implements CharSequence {
   @Override
   public CharSequence subSequence(int start, int end) {
     return this.string.subSequence(start, end);
-  }
-
-  private static class Allocator {
-
-    private static final class Allocation {
-      final int position;
-      final byte[] page;
-
-      private Allocation(int position, byte[] page) {
-        this.position = position;
-        this.page = page;
-      }
-    }
-
-    private static final int PAGE_SIZE = 8192;
-
-    private final List<byte[]> pages;
-    private int currentPage = -1;
-    int currentPosition = 0;
-
-    Allocator() {
-      this.pages = new ArrayList<>();
-    }
-
-    synchronized Allocation allocate(byte[] utf8) {
-      byte[] page = getPageWithCapacity(utf8.length);
-      if (null == page) { // too big
-        return null;
-      }
-      System.arraycopy(utf8, 0, page, currentPosition, utf8.length);
-      currentPosition += utf8.length;
-      return new Allocation(currentPosition - utf8.length, page);
-    }
-
-    private byte[] getPageWithCapacity(int length) {
-      if (length >= PAGE_SIZE) {
-        return null;
-      }
-      if (currentPage < 0) {
-        newPage();
-      } else if (currentPosition + length >= PAGE_SIZE) {
-        // might leave a lot of space empty at the end of the page, but
-        // this is designed for small strings
-        newPage();
-      }
-      return pages.get(currentPage);
-    }
-
-    private void newPage() {
-      this.pages.add(new byte[PAGE_SIZE]);
-      ++currentPage;
-      currentPosition = 0;
-    }
   }
 }

--- a/internal-api/src/test/groovy/datadog/trace/bootstrap/instrumentation/api/Utf8ByteStringTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/bootstrap/instrumentation/api/Utf8ByteStringTest.groovy
@@ -33,12 +33,10 @@ class Utf8ByteStringTest extends DDSpecification {
     "foo"                                                         | false
     "bar"                                                         | false
     "alongerstring"                                               | false
-    new String(new char[UTF8BytesString.Allocator.PAGE_SIZE + 1]) | false
     null                                                          | true
     "foo"                                                         | true
     "bar"                                                         | true
     "alongerstring"                                               | true
-    new String(new char[UTF8BytesString.Allocator.PAGE_SIZE + 1]) | true
   }
 
   def "behave like a proper CharSequence"() {
@@ -63,12 +61,10 @@ class Utf8ByteStringTest extends DDSpecification {
     new StringBuffer("bar")                                       | true
     new StringBuffer("someotherlongstring")                       | true
     UTF8BytesString.create("utf8string")                          | true
-    new String(new char[UTF8BytesString.Allocator.PAGE_SIZE + 1]) | true
     null                                                          | false
     "foo"                                                         | false
     new StringBuffer("bar")                                       | false
     new StringBuffer("someotherlongstring")                       | false
     UTF8BytesString.create("utf8string")                          | false
-    new String(new char[UTF8BytesString.Allocator.PAGE_SIZE + 1]) | false
   }
 }


### PR DESCRIPTION
This removes some well meaning but bad choices
* Gets rid of the constants in `UTF8BytesString` which actually put the array copies onto a slow path
* Gets rid of the `ThreadLocal<StringBuilder>` in `InternalJarURLHandler` - it was `ThreadLocal` based on the assumption that loads mostly came from very few threads but this isn't the case
* Gets rid of the `ThreadLocal<StringBuilder>` in `URLAsResourceNameRule` now we can't control which thread it runs on.