### PR TITLE
Reduce cost of rate lookup in RateByServiceSampler

### DIFF
--- a/dd-trace-core/src/test/groovy/datadog/trace/common/sampling/RateByServiceSamplerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/sampling/RateByServiceSamplerTest.groovy
@@ -10,8 +10,6 @@ import datadog.trace.core.DDSpanContext
 import datadog.trace.core.SpanFactory
 import datadog.trace.test.util.DDSpecification
 
-import static datadog.trace.common.sampling.RateByServiceSampler.DEFAULT_KEY
-
 class RateByServiceSamplerTest extends DDSpecification {
   static serializer = DDAgentApi.RESPONSE_ADAPTER
 
@@ -21,7 +19,7 @@ class RateByServiceSamplerTest extends DDSpecification {
     String response = '{"rate_by_service": {"service:,env:":' + rate + '}}'
     serviceSampler.onResponse("traces", serializer.fromJson(response))
     expect:
-    serviceSampler.serviceRates[DEFAULT_KEY].sampleRate == expectedRate
+    serviceSampler.serviceRates.getSampler(RateByServiceSampler.EnvAndService.DEFAULT).sampleRate == expectedRate
 
     where:
     rate | expectedRate


### PR DESCRIPTION
The idea here is that it's much cheaper to construct a small wrapper for lookups than to create a new string, because it allocates less memory, doesn't need to do the array copies, and doesn't invalidate the cached hash code. This comes at the cost of needing to parse the responses from the agent. Also treats the default rate specially, instead of needing to lookup in the map twice.