### PR TITLE
typed spans

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/ConflatingMetricsAggregator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/ConflatingMetricsAggregator.java
@@ -86,9 +86,9 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
   }
 
   @Override
-  public void publish(List<? extends CoreSpan> trace) {
+  public void publish(List<? extends CoreSpan<?>> trace) {
     if (enabled) {
-      for (CoreSpan span : trace) {
+      for (CoreSpan<?> span : trace) {
         if (span.isMeasured()) {
           publish(span);
         }
@@ -96,7 +96,7 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
     }
   }
 
-  private void publish(CoreSpan span) {
+  private void publish(CoreSpan<?> span) {
     boolean error = span.getError() > 0;
     long durationNanos = span.getDurationNano();
     MetricKey key =

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/ConflatingMetricsAggregator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/ConflatingMetricsAggregator.java
@@ -7,7 +7,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 
 import datadog.trace.api.Config;
 import datadog.trace.api.WellKnownTags;
-import datadog.trace.core.DDSpanData;
+import datadog.trace.core.CoreSpan;
 import datadog.trace.core.util.LRUCache;
 import java.util.List;
 import java.util.Map;
@@ -86,9 +86,9 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
   }
 
   @Override
-  public void publish(List<? extends DDSpanData> trace) {
+  public void publish(List<? extends CoreSpan> trace) {
     if (enabled) {
-      for (DDSpanData span : trace) {
+      for (CoreSpan span : trace) {
         if (span.isMeasured()) {
           publish(span);
         }
@@ -96,7 +96,7 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
     }
   }
 
-  private void publish(DDSpanData span) {
+  private void publish(CoreSpan span) {
     boolean error = span.getError() > 0;
     long durationNanos = span.getDurationNano();
     MetricKey key =

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/MetricsAggregator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/MetricsAggregator.java
@@ -6,5 +6,5 @@ import java.util.List;
 public interface MetricsAggregator extends AutoCloseable {
   void start();
 
-  void publish(List<? extends CoreSpan> trace);
+  void publish(List<? extends CoreSpan<?>> trace);
 }

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/MetricsAggregator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/MetricsAggregator.java
@@ -1,10 +1,10 @@
 package datadog.trace.common.metrics;
 
-import datadog.trace.core.DDSpanData;
+import datadog.trace.core.CoreSpan;
 import java.util.List;
 
 public interface MetricsAggregator extends AutoCloseable {
   void start();
 
-  void publish(List<? extends DDSpanData> trace);
+  void publish(List<? extends CoreSpan> trace);
 }

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/NoOpMetricsAggregator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/NoOpMetricsAggregator.java
@@ -11,7 +11,7 @@ public final class NoOpMetricsAggregator implements MetricsAggregator {
   public void start() {}
 
   @Override
-  public void publish(List<? extends CoreSpan> trace) {}
+  public void publish(List<? extends CoreSpan<?>> trace) {}
 
   @Override
   public void close() {}

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/NoOpMetricsAggregator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/NoOpMetricsAggregator.java
@@ -1,6 +1,6 @@
 package datadog.trace.common.metrics;
 
-import datadog.trace.core.DDSpanData;
+import datadog.trace.core.CoreSpan;
 import java.util.List;
 
 public final class NoOpMetricsAggregator implements MetricsAggregator {
@@ -11,7 +11,7 @@ public final class NoOpMetricsAggregator implements MetricsAggregator {
   public void start() {}
 
   @Override
-  public void publish(List<? extends DDSpanData> trace) {}
+  public void publish(List<? extends CoreSpan> trace) {}
 
   @Override
   public void close() {}

--- a/dd-trace-core/src/main/java/datadog/trace/common/sampling/AbstractSampler.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/sampling/AbstractSampler.java
@@ -1,23 +1,23 @@
 package datadog.trace.common.sampling;
 
-import datadog.trace.core.DDSpan;
+import datadog.trace.core.CoreSpan;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.regex.Pattern;
 
 @Deprecated
-public abstract class AbstractSampler implements Sampler {
+public abstract class AbstractSampler<T extends CoreSpan<T>> implements Sampler<T> {
 
   /** Sample tags */
   protected Map<String, Pattern> skipTagsPatterns = new HashMap<>();
 
   @Override
-  public boolean sample(final DDSpan span) {
+  public boolean sample(final T span) {
 
     // Filter by tag values
     for (final Entry<String, Pattern> entry : skipTagsPatterns.entrySet()) {
-      final Object value = span.getTags().get(entry.getKey());
+      final Object value = span.getTag(entry.getKey());
       if (value != null) {
         final String strValue = String.valueOf(value);
         final Pattern skipPattern = entry.getValue();
@@ -41,5 +41,5 @@ public abstract class AbstractSampler implements Sampler {
     skipTagsPatterns.put(tag, skipPattern);
   }
 
-  protected abstract boolean doSample(DDSpan span);
+  protected abstract boolean doSample(T span);
 }

--- a/dd-trace-core/src/main/java/datadog/trace/common/sampling/AllSampler.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/sampling/AllSampler.java
@@ -1,12 +1,12 @@
 package datadog.trace.common.sampling;
 
-import datadog.trace.core.DDSpan;
+import datadog.trace.core.CoreSpan;
 
 /** Sampler that always says yes... */
-public class AllSampler extends AbstractSampler {
+public class AllSampler<T extends CoreSpan<T>> extends AbstractSampler<T> {
 
   @Override
-  public boolean doSample(final DDSpan span) {
+  public boolean doSample(final T span) {
     return true;
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/common/sampling/DeterministicSampler.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/sampling/DeterministicSampler.java
@@ -1,7 +1,7 @@
 package datadog.trace.common.sampling;
 
+import datadog.trace.core.CoreSpan;
 import datadog.trace.core.CoreTracer;
-import datadog.trace.core.DDSpan;
 import java.math.BigDecimal;
 import lombok.extern.slf4j.Slf4j;
 
@@ -10,7 +10,7 @@ import lombok.extern.slf4j.Slf4j;
  * tracers for other languages
  */
 @Slf4j
-public class DeterministicSampler implements RateSampler {
+public class DeterministicSampler<T extends CoreSpan<T>> implements RateSampler<T> {
   private static final long KNUTH_FACTOR = 1111111111111111111L;
 
   private final long cutoff; // pre-calculated for the unsigned 64 bit comparison
@@ -29,7 +29,7 @@ public class DeterministicSampler implements RateSampler {
   }
 
   @Override
-  public boolean sample(final DDSpan span) {
+  public boolean sample(final T span) {
     boolean sampled = false;
     if (rate >= 1) {
       sampled = true;

--- a/dd-trace-core/src/main/java/datadog/trace/common/sampling/ForcePrioritySampler.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/sampling/ForcePrioritySampler.java
@@ -1,11 +1,11 @@
 package datadog.trace.common.sampling;
 
-import datadog.trace.core.DDSpan;
+import datadog.trace.core.CoreSpan;
 import lombok.extern.slf4j.Slf4j;
 
 /** A sampler which forces the sampling priority */
 @Slf4j
-public class ForcePrioritySampler implements Sampler, PrioritySampler {
+public class ForcePrioritySampler<T extends CoreSpan<T>> implements Sampler<T>, PrioritySampler<T> {
 
   private final int prioritySampling;
 
@@ -14,12 +14,12 @@ public class ForcePrioritySampler implements Sampler, PrioritySampler {
   }
 
   @Override
-  public boolean sample(final DDSpan span) {
+  public boolean sample(final T span) {
     return true;
   }
 
   @Override
-  public void setSamplingPriority(final DDSpan span) {
-    span.context().setSamplingPriority(prioritySampling);
+  public void setSamplingPriority(final T span) {
+    span.setSamplingPriority(prioritySampling);
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/common/sampling/PrioritySampler.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/sampling/PrioritySampler.java
@@ -1,7 +1,7 @@
 package datadog.trace.common.sampling;
 
-import datadog.trace.core.DDSpan;
+import datadog.trace.core.CoreSpan;
 
-public interface PrioritySampler {
-  void setSamplingPriority(DDSpan span);
+public interface PrioritySampler<T extends CoreSpan<T>> {
+  void setSamplingPriority(T span);
 }

--- a/dd-trace-core/src/main/java/datadog/trace/common/sampling/RateByServiceSampler.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/sampling/RateByServiceSampler.java
@@ -40,18 +40,10 @@ public class RateByServiceSampler implements Sampler, PrioritySampler, DDAgentRe
     final RateSamplersByEnvAndService rates = serviceRates;
     RateSampler sampler = rates.getSampler(new EnvAndService(env, serviceName));
 
-    final boolean priorityWasSet;
-
     if (sampler.sample(span)) {
-      priorityWasSet = span.context().setSamplingPriority(PrioritySampling.SAMPLER_KEEP);
+      span.setSamplingPriority(PrioritySampling.SAMPLER_KEEP, sampler.getSampleRate());
     } else {
-      priorityWasSet = span.context().setSamplingPriority(PrioritySampling.SAMPLER_DROP);
-    }
-
-    // Only set metrics if we actually set the sampling priority
-    // We don't know until the call is completed because the lock is internal to DDSpanContext
-    if (priorityWasSet) {
-      span.context().setMetric(SAMPLING_AGENT_RATE, sampler.getSampleRate());
+      span.setSamplingPriority(PrioritySampling.SAMPLER_DROP, sampler.getSampleRate());
     }
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/common/sampling/RateSampler.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/sampling/RateSampler.java
@@ -1,5 +1,7 @@
 package datadog.trace.common.sampling;
 
-public interface RateSampler extends Sampler {
+import datadog.trace.core.CoreSpan;
+
+public interface RateSampler<T extends CoreSpan<T>> extends Sampler<T> {
   double getSampleRate();
 }

--- a/dd-trace-core/src/main/java/datadog/trace/common/sampling/Sampler.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/sampling/Sampler.java
@@ -22,8 +22,8 @@ public interface Sampler<T extends CoreSpan<T>> {
 
   @Slf4j
   final class Builder {
-    public static Sampler forConfig(final Config config) {
-      Sampler sampler;
+    public static <T extends CoreSpan<T>> Sampler<T> forConfig(final Config config) {
+      Sampler<T> sampler;
       if (config != null) {
         final Map<String, String> serviceRules = config.getTraceSamplingServiceRules();
         final Map<String, String> operationRules = config.getTraceSamplingOperationRules();
@@ -41,28 +41,28 @@ public interface Sampler<T extends CoreSpan<T>> {
                     config.getTraceRateLimit());
           } catch (final IllegalArgumentException e) {
             log.error("Invalid sampler configuration. Using AllSampler", e);
-            sampler = new AllSampler();
+            sampler = new AllSampler<>();
           }
         } else if (config.isPrioritySamplingEnabled()) {
           if (KEEP.equalsIgnoreCase(config.getPrioritySamplingForce())) {
             log.debug("Force Sampling Priority to: SAMPLER_KEEP.");
-            sampler = new ForcePrioritySampler(PrioritySampling.SAMPLER_KEEP);
+            sampler = new ForcePrioritySampler<>(PrioritySampling.SAMPLER_KEEP);
           } else if (DROP.equalsIgnoreCase(config.getPrioritySamplingForce())) {
             log.debug("Force Sampling Priority to: SAMPLER_DROP.");
-            sampler = new ForcePrioritySampler(PrioritySampling.SAMPLER_DROP);
+            sampler = new ForcePrioritySampler<>(PrioritySampling.SAMPLER_DROP);
           } else {
-            sampler = new RateByServiceSampler();
+            sampler = new RateByServiceSampler<>();
           }
         } else {
-          sampler = new AllSampler();
+          sampler = new AllSampler<>();
         }
       } else {
-        sampler = new AllSampler();
+        sampler = new AllSampler<>();
       }
       return sampler;
     }
 
-    public static Sampler forConfig(final Properties config) {
+    public static <T extends CoreSpan<T>> Sampler<T> forConfig(final Properties config) {
       return forConfig(Config.get(config));
     }
 

--- a/dd-trace-core/src/main/java/datadog/trace/common/sampling/Sampler.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/sampling/Sampler.java
@@ -4,13 +4,13 @@ import static datadog.trace.bootstrap.instrumentation.api.SamplerConstants.DROP;
 import static datadog.trace.bootstrap.instrumentation.api.SamplerConstants.KEEP;
 
 import datadog.trace.api.Config;
-import datadog.trace.core.DDSpan;
+import datadog.trace.core.CoreSpan;
 import java.util.Map;
 import java.util.Properties;
 import lombok.extern.slf4j.Slf4j;
 
 /** Main interface to sample a collection of traces. */
-public interface Sampler {
+public interface Sampler<T extends CoreSpan<T>> {
 
   /**
    * Sample a collection of traces based on the parent span
@@ -18,7 +18,7 @@ public interface Sampler {
    * @param span the parent span with its context
    * @return true when the trace/spans has to be reported/written
    */
-  boolean sample(DDSpan span);
+  boolean sample(T span);
 
   @Slf4j
   final class Builder {

--- a/dd-trace-core/src/main/java/datadog/trace/common/sampling/SamplingRule.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/sampling/SamplingRule.java
@@ -1,72 +1,75 @@
 package datadog.trace.common.sampling;
 
-import datadog.trace.core.DDSpan;
+import datadog.trace.core.CoreSpan;
 import java.util.regex.Pattern;
 
-public abstract class SamplingRule {
-  private final RateSampler sampler;
+public abstract class SamplingRule<T extends CoreSpan<T>> {
+  private final RateSampler<T> sampler;
 
-  public SamplingRule(final RateSampler sampler) {
+  public SamplingRule(final RateSampler<T> sampler) {
     this.sampler = sampler;
   }
 
-  public abstract boolean matches(DDSpan span);
+  public abstract boolean matches(T span);
 
-  public boolean sample(final DDSpan span) {
+  public boolean sample(final T span) {
     return sampler.sample(span);
   }
 
-  public RateSampler getSampler() {
+  public RateSampler<T> getSampler() {
     return sampler;
   }
 
-  public static class AlwaysMatchesSamplingRule extends SamplingRule {
+  public static class AlwaysMatchesSamplingRule<T extends CoreSpan<T>> extends SamplingRule<T> {
 
-    public AlwaysMatchesSamplingRule(final RateSampler sampler) {
+    public AlwaysMatchesSamplingRule(final RateSampler<T> sampler) {
       super(sampler);
     }
 
     @Override
-    public boolean matches(final DDSpan span) {
+    public boolean matches(final T span) {
       return true;
     }
   }
 
-  public abstract static class PatternMatchSamplingRule extends SamplingRule {
+  public abstract static class PatternMatchSamplingRule<T extends CoreSpan<T>>
+      extends SamplingRule<T> {
     private final Pattern pattern;
 
-    public PatternMatchSamplingRule(final String regex, final RateSampler sampler) {
+    public PatternMatchSamplingRule(final String regex, final RateSampler<T> sampler) {
       super(sampler);
       this.pattern = Pattern.compile(regex);
     }
 
     @Override
-    public boolean matches(final DDSpan span) {
+    public boolean matches(final T span) {
       final CharSequence relevantString = getRelevantString(span);
       return relevantString != null && pattern.matcher(relevantString).matches();
     }
 
-    protected abstract CharSequence getRelevantString(DDSpan span);
+    protected abstract CharSequence getRelevantString(T span);
   }
 
-  public static class ServiceSamplingRule extends PatternMatchSamplingRule {
-    public ServiceSamplingRule(final String regex, final RateSampler sampler) {
+  public static class ServiceSamplingRule<T extends CoreSpan<T>>
+      extends PatternMatchSamplingRule<T> {
+    public ServiceSamplingRule(final String regex, final RateSampler<T> sampler) {
       super(regex, sampler);
     }
 
     @Override
-    protected String getRelevantString(final DDSpan span) {
+    protected String getRelevantString(final T span) {
       return span.getServiceName();
     }
   }
 
-  public static class OperationSamplingRule extends PatternMatchSamplingRule {
-    public OperationSamplingRule(final String regex, final RateSampler sampler) {
+  public static class OperationSamplingRule<T extends CoreSpan<T>>
+      extends PatternMatchSamplingRule<T> {
+    public OperationSamplingRule(final String regex, final RateSampler<T> sampler) {
       super(regex, sampler);
     }
 
     @Override
-    protected CharSequence getRelevantString(final DDSpan span) {
+    protected CharSequence getRelevantString(final T span) {
       return span.getOperationName();
     }
   }

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/PayloadDispatcher.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/PayloadDispatcher.java
@@ -1,6 +1,6 @@
 package datadog.trace.common.writer.ddagent;
 
-import datadog.trace.core.DDSpanData;
+import datadog.trace.core.CoreSpan;
 import datadog.trace.core.monitor.HealthMetrics;
 import datadog.trace.core.monitor.Monitoring;
 import datadog.trace.core.monitor.Recording;
@@ -40,7 +40,7 @@ public class PayloadDispatcher implements ByteBufferConsumer {
     droppedCount.incrementAndGet();
   }
 
-  void addTrace(List<? extends DDSpanData> trace) {
+  void addTrace(List<? extends CoreSpan> trace) {
     selectTraceMapper();
     // the call below is blocking and will trigger IO if a flush is necessary
     // there are alternative approaches to avoid blocking here, such as

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/PayloadDispatcher.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/PayloadDispatcher.java
@@ -40,7 +40,7 @@ public class PayloadDispatcher implements ByteBufferConsumer {
     droppedCount.incrementAndGet();
   }
 
-  void addTrace(List<? extends CoreSpan> trace) {
+  void addTrace(List<? extends CoreSpan<?>> trace) {
     selectTraceMapper();
     // the call below is blocking and will trigger IO if a flush is necessary
     // there are alternative approaches to avoid blocking here, such as

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/TraceMapper.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/TraceMapper.java
@@ -4,7 +4,7 @@ import datadog.trace.core.CoreSpan;
 import datadog.trace.core.serialization.Mapper;
 import java.util.List;
 
-public interface TraceMapper extends Mapper<List<? extends CoreSpan>> {
+public interface TraceMapper extends Mapper<List<? extends CoreSpan<?>>> {
 
   Payload newPayload();
 

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/TraceMapper.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/TraceMapper.java
@@ -1,10 +1,10 @@
 package datadog.trace.common.writer.ddagent;
 
-import datadog.trace.core.DDSpanData;
+import datadog.trace.core.CoreSpan;
 import datadog.trace.core.serialization.Mapper;
 import java.util.List;
 
-public interface TraceMapper extends Mapper<List<? extends DDSpanData>> {
+public interface TraceMapper extends Mapper<List<? extends CoreSpan>> {
 
   Payload newPayload();
 

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/TraceMapperV0_4.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/TraceMapperV0_4.java
@@ -93,9 +93,9 @@ public final class TraceMapperV0_4 implements TraceMapper {
   private final MetaWriter metaWriter = new MetaWriter();
 
   @Override
-  public void map(List<? extends CoreSpan> trace, final Writable writable) {
+  public void map(List<? extends CoreSpan<?>> trace, final Writable writable) {
     writable.startArray(trace.size());
-    for (CoreSpan span : trace) {
+    for (CoreSpan<?> span : trace) {
       writable.startMap(12);
       /* 1  */
       writable.writeUTF8(SERVICE);

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/TraceMapperV0_4.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/TraceMapperV0_4.java
@@ -20,7 +20,7 @@ import static java.util.Collections.singletonList;
 
 import datadog.trace.bootstrap.instrumentation.api.InstrumentationTags;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
-import datadog.trace.core.DDSpanData;
+import datadog.trace.core.CoreSpan;
 import datadog.trace.core.TagsAndBaggageConsumer;
 import datadog.trace.core.http.OkHttpUtils;
 import datadog.trace.core.serialization.Writable;
@@ -93,9 +93,9 @@ public final class TraceMapperV0_4 implements TraceMapper {
   private final MetaWriter metaWriter = new MetaWriter();
 
   @Override
-  public void map(List<? extends DDSpanData> trace, final Writable writable) {
+  public void map(List<? extends CoreSpan> trace, final Writable writable) {
     writable.startArray(trace.size());
-    for (DDSpanData span : trace) {
+    for (CoreSpan span : trace) {
       writable.startMap(12);
       /* 1  */
       writable.writeUTF8(SERVICE);
@@ -135,7 +135,7 @@ public final class TraceMapperV0_4 implements TraceMapper {
     }
   }
 
-  private static void writeMetrics(DDSpanData span, Writable writable) {
+  private static void writeMetrics(CoreSpan span, Writable writable) {
     writable.writeUTF8(METRICS);
     Map<CharSequence, Number> metrics = span.getMetrics();
     int elementCount = metrics.size() + (span.isMeasured() ? 1 : 0);

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/TraceMapperV0_5.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/TraceMapperV0_5.java
@@ -57,9 +57,9 @@ public final class TraceMapperV0_5 implements TraceMapper {
   }
 
   @Override
-  public void map(final List<? extends CoreSpan> trace, final Writable writable) {
+  public void map(final List<? extends CoreSpan<?>> trace, final Writable writable) {
     writable.startArray(trace.size());
-    for (final CoreSpan span : trace) {
+    for (final CoreSpan<?> span : trace) {
       writable.startArray(12);
       /* 1  */
       writeDictionaryEncoded(writable, span.getServiceName());

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/TraceMapperV0_5.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/TraceMapperV0_5.java
@@ -6,7 +6,7 @@ import static datadog.trace.core.serialization.Util.integerToStringBuffer;
 import static datadog.trace.core.serialization.Util.writeLongAsString;
 
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
-import datadog.trace.core.DDSpanData;
+import datadog.trace.core.CoreSpan;
 import datadog.trace.core.StringTables;
 import datadog.trace.core.TagsAndBaggageConsumer;
 import datadog.trace.core.serialization.ByteBufferConsumer;
@@ -57,9 +57,9 @@ public final class TraceMapperV0_5 implements TraceMapper {
   }
 
   @Override
-  public void map(final List<? extends DDSpanData> trace, final Writable writable) {
+  public void map(final List<? extends CoreSpan> trace, final Writable writable) {
     writable.startArray(trace.size());
-    for (final DDSpanData span : trace) {
+    for (final CoreSpan span : trace) {
       writable.startArray(12);
       /* 1  */
       writeDictionaryEncoded(writable, span.getServiceName());

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreSpan.java
@@ -27,10 +27,6 @@ public interface CoreSpan<T extends CoreSpan<T>> {
 
   Map<CharSequence, Number> getMetrics();
 
-  Map<String, String> getBaggage();
-
-  Map<String, Object> getTags();
-
   CharSequence getType();
 
   void processTagsAndBaggage(TagsAndBaggageConsumer consumer);

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreSpan.java
@@ -5,6 +5,8 @@ import java.util.Map;
 
 public interface CoreSpan<T extends CoreSpan<T>> {
 
+  T getLocalRootSpan();
+
   String getServiceName();
 
   CharSequence getOperationName();
@@ -22,6 +24,30 @@ public interface CoreSpan<T extends CoreSpan<T>> {
   long getDurationNano();
 
   int getError();
+
+  T setMeasured(boolean measured);
+
+  T setErrorMessage(final String errorMessage);
+
+  T addThrowable(final Throwable error);
+
+  T setTag(final String tag, final String value);
+
+  T setTag(final String tag, final boolean value);
+
+  T setTag(final String tag, final int value);
+
+  T setTag(final String tag, final long value);
+
+  T setTag(final String tag, final double value);
+
+  T setTag(final String tag, final Number value);
+
+  T setTag(final String tag, final CharSequence value);
+
+  T setTag(final String tag, final Object value);
+
+  T removeTag(final String tag);
 
   <U> U getTag(CharSequence name, U defaultValue);
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreSpan.java
@@ -36,4 +36,16 @@ public interface CoreSpan<T extends CoreSpan<T>> {
   void processTagsAndBaggage(TagsAndBaggageConsumer consumer);
 
   T setSamplingPriority(int samplingPriority);
+
+  T setSamplingPriority(int samplingPriority, double sampleRate);
+
+  T setMetric(CharSequence name, int value);
+
+  T setMetric(CharSequence name, long value);
+
+  T setMetric(CharSequence name, float value);
+
+  T setMetric(CharSequence name, double value);
+
+  T setFlag(CharSequence name, boolean value);
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreSpan.java
@@ -37,7 +37,7 @@ public interface CoreSpan<T extends CoreSpan<T>> {
 
   T setSamplingPriority(int samplingPriority);
 
-  T setSamplingPriority(int samplingPriority, double sampleRate);
+  T setSamplingPriority(int samplingPriority, CharSequence rate, double sampleRate);
 
   T setMetric(CharSequence name, int value);
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreSpan.java
@@ -3,7 +3,7 @@ package datadog.trace.core;
 import datadog.trace.api.DDId;
 import java.util.Map;
 
-public interface CoreSpan {
+public interface CoreSpan<T extends CoreSpan<T>> {
 
   String getServiceName();
 
@@ -34,4 +34,6 @@ public interface CoreSpan {
   CharSequence getType();
 
   void processTagsAndBaggage(TagsAndBaggageConsumer consumer);
+
+  T setSamplingPriority(int samplingPriority);
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreSpan.java
@@ -3,7 +3,7 @@ package datadog.trace.core;
 import datadog.trace.api.DDId;
 import java.util.Map;
 
-public interface DDSpanData {
+public interface CoreSpan {
 
   String getServiceName();
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreSpan.java
@@ -23,6 +23,10 @@ public interface CoreSpan<T extends CoreSpan<T>> {
 
   int getError();
 
+  <U> U getTag(CharSequence name, U defaultValue);
+
+  <U> U getTag(CharSequence name);
+
   boolean isMeasured();
 
   Map<CharSequence, Number> getMetrics();

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -109,7 +109,7 @@ public class DDSpan implements AgentSpan, CoreSpan<DDSpan> {
   }
 
   @Override
-  public AgentSpan setMeasured(boolean measured) {
+  public DDSpan setMeasured(boolean measured) {
     context.setMeasured(measured);
     return this;
   }
@@ -148,12 +148,12 @@ public class DDSpan implements AgentSpan, CoreSpan<DDSpan> {
   }
 
   @Override
-  public AgentSpan setErrorMessage(final String errorMessage) {
+  public DDSpan setErrorMessage(final String errorMessage) {
     return setTag(DDTags.ERROR_MSG, errorMessage);
   }
 
   @Override
-  public AgentSpan addThrowable(final Throwable error) {
+  public DDSpan addThrowable(final Throwable error) {
     setError(true);
 
     setTag(DDTags.ERROR_MSG, error.getMessage());
@@ -179,19 +179,19 @@ public class DDSpan implements AgentSpan, CoreSpan<DDSpan> {
   }
 
   @Override
-  public AgentSpan setTag(final String tag, final int value) {
+  public DDSpan setTag(final String tag, final int value) {
     context.setTag(tag, value);
     return this;
   }
 
   @Override
-  public AgentSpan setTag(final String tag, final long value) {
+  public DDSpan setTag(final String tag, final long value) {
     context.setTag(tag, value);
     return this;
   }
 
   @Override
-  public AgentSpan setTag(final String tag, final double value) {
+  public DDSpan setTag(final String tag, final double value) {
     context.setTag(tag, value);
     return this;
   }
@@ -245,7 +245,7 @@ public class DDSpan implements AgentSpan, CoreSpan<DDSpan> {
   }
 
   // FIXME [API] this is not on AgentSpan or MutableSpan
-  public AgentSpan removeTag(final String tag) {
+  public DDSpan removeTag(final String tag) {
     context.setTag(tag, null);
     return this;
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -426,6 +426,18 @@ public class DDSpan implements AgentSpan, CoreSpan<DDSpan> {
   }
 
   @Override
+  @SuppressWarnings("unchecked")
+  public <U> U getTag(CharSequence name, U defaultValue) {
+    Object tag = getTag(String.valueOf(name));
+    return null == tag ? defaultValue : (U) tag;
+  }
+
+  @Override
+  public <U> U getTag(CharSequence name) {
+    return getTag(name, null);
+  }
+
+  @Override
   public boolean isMeasured() {
     return context.isMeasured();
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -430,7 +430,6 @@ public class DDSpan implements AgentSpan, CoreSpan<DDSpan> {
     return context.isMeasured();
   }
 
-  @Override
   public Map<String, String> getBaggage() {
     return Collections.unmodifiableMap(context.getBaggageItems());
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -1,5 +1,7 @@
 package datadog.trace.core;
 
+import static datadog.trace.common.sampling.RateByServiceSampler.SAMPLING_AGENT_RATE;
+
 import datadog.trace.api.DDId;
 import datadog.trace.api.DDTags;
 import datadog.trace.api.sampling.PrioritySampling;
@@ -209,6 +211,12 @@ public class DDSpan implements AgentSpan, CoreSpan<DDSpan> {
   }
 
   @Override
+  public DDSpan setMetric(CharSequence name, float value) {
+    context.setMetric(name, value);
+    return this;
+  }
+
+  @Override
   public DDSpan setMetric(final CharSequence metric, final long value) {
     context.setMetric(metric, value);
     return this;
@@ -217,6 +225,12 @@ public class DDSpan implements AgentSpan, CoreSpan<DDSpan> {
   @Override
   public DDSpan setMetric(final CharSequence metric, final double value) {
     context.setMetric(metric, value);
+    return this;
+  }
+
+  @Override
+  public DDSpan setFlag(CharSequence name, boolean value) {
+    context.setMetric(name, value ? 1 : 0);
     return this;
   }
 
@@ -285,6 +299,14 @@ public class DDSpan implements AgentSpan, CoreSpan<DDSpan> {
   @Override
   public final DDSpan setSamplingPriority(final int newPriority) {
     context.setSamplingPriority(newPriority);
+    return this;
+  }
+
+  @Override
+  public DDSpan setSamplingPriority(int samplingPriority, double sampleRate) {
+    if (context.setSamplingPriority(samplingPriority)) {
+      setMetric(SAMPLING_AGENT_RATE, sampleRate);
+    }
     return this;
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -20,7 +20,7 @@ import lombok.extern.slf4j.Slf4j;
  * according to the DD agent.
  */
 @Slf4j
-public class DDSpan implements AgentSpan, CoreSpan {
+public class DDSpan implements AgentSpan, CoreSpan<DDSpan> {
 
   static DDSpan create(final long timestampMicro, final DDSpanContext context) {
     final DDSpan span = new DDSpan(timestampMicro, context);

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -20,7 +20,7 @@ import lombok.extern.slf4j.Slf4j;
  * according to the DD agent.
  */
 @Slf4j
-public class DDSpan implements AgentSpan, DDSpanData {
+public class DDSpan implements AgentSpan, CoreSpan {
 
   static DDSpan create(final long timestampMicro, final DDSpanContext context) {
     final DDSpan span = new DDSpan(timestampMicro, context);
@@ -236,10 +236,6 @@ public class DDSpan implements AgentSpan, DDSpanData {
   public AgentSpan removeTag(final String tag) {
     context.setTag(tag, null);
     return this;
-  }
-
-  public Object getAndRemoveTag(final String tag) {
-    return context.getAndRemoveTag(tag);
   }
 
   @Override

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -1,7 +1,5 @@
 package datadog.trace.core;
 
-import static datadog.trace.common.sampling.RateByServiceSampler.SAMPLING_AGENT_RATE;
-
 import datadog.trace.api.DDId;
 import datadog.trace.api.DDTags;
 import datadog.trace.api.sampling.PrioritySampling;
@@ -303,9 +301,9 @@ public class DDSpan implements AgentSpan, CoreSpan<DDSpan> {
   }
 
   @Override
-  public DDSpan setSamplingPriority(int samplingPriority, double sampleRate) {
+  public DDSpan setSamplingPriority(int samplingPriority, CharSequence rate, double sampleRate) {
     if (context.setSamplingPriority(samplingPriority)) {
-      setMetric(SAMPLING_AGENT_RATE, sampleRate);
+      setMetric(rate, sampleRate);
     }
     return this;
   }

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/ConflatingMetricAggregatorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/ConflatingMetricAggregatorTest.groovy
@@ -1,7 +1,7 @@
 package datadog.trace.common.metrics
 
 import datadog.trace.api.WellKnownTags
-import datadog.trace.core.DDSpanData
+import datadog.trace.core.CoreSpan
 import datadog.trace.test.util.DDSpecification
 
 import java.util.concurrent.CountDownLatch
@@ -43,7 +43,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(
       Mock(Sink), writer, 10, 10, reportingInterval, SECONDS)
     long duration = 100
-    List<DDSpanData> trace = [
+    List<CoreSpan> trace = [
       new SimpleSpan("service", "operation", "resource", true, false, 0, duration),
       new SimpleSpan("service1", "operation1", "resource1", false, false, 0, 0),
       new SimpleSpan("service2", "operation2", "resource2", true, false, 0, duration * 2)

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SimpleSpan.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SimpleSpan.groovy
@@ -110,4 +110,34 @@ class SimpleSpan implements CoreSpan<SimpleSpan> {
   SimpleSpan setSamplingPriority(int samplingPriority) {
     return this
   }
+
+  @Override
+  SimpleSpan setSamplingPriority(int samplingPriority, double sampleRate) {
+    return this
+  }
+
+  @Override
+  SimpleSpan setMetric(CharSequence name, int value) {
+    return this
+  }
+
+  @Override
+  SimpleSpan setMetric(CharSequence name, long value) {
+    return this
+  }
+
+  @Override
+  SimpleSpan setMetric(CharSequence name, float value) {
+    return this
+  }
+
+  @Override
+  SimpleSpan setMetric(CharSequence name, double value) {
+    return this
+  }
+
+  @Override
+  SimpleSpan setFlag(CharSequence name, boolean value) {
+    return this
+  }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SimpleSpan.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SimpleSpan.groovy
@@ -87,16 +87,6 @@ class SimpleSpan implements CoreSpan<SimpleSpan> {
   }
 
   @Override
-  Map<String, String> getBaggage() {
-    return null
-  }
-
-  @Override
-  Map<String, Object> getTags() {
-    return null
-  }
-
-  @Override
   CharSequence getType() {
     return null
   }

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SimpleSpan.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SimpleSpan.groovy
@@ -112,7 +112,7 @@ class SimpleSpan implements CoreSpan<SimpleSpan> {
   }
 
   @Override
-  SimpleSpan setSamplingPriority(int samplingPriority, double sampleRate) {
+  SimpleSpan setSamplingPriority(int samplingPriority, CharSequence rate, double sampleRate) {
     return this
   }
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SimpleSpan.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SimpleSpan.groovy
@@ -1,10 +1,10 @@
 package datadog.trace.common.metrics
 
 import datadog.trace.api.DDId
-import datadog.trace.core.DDSpanData
+import datadog.trace.core.CoreSpan
 import datadog.trace.core.TagsAndBaggageConsumer
 
-class SimpleSpan implements DDSpanData {
+class SimpleSpan implements CoreSpan {
 
   private final String serviceName
   private final String operationName

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SimpleSpan.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SimpleSpan.groovy
@@ -32,6 +32,11 @@ class SimpleSpan implements CoreSpan<SimpleSpan> {
   }
 
   @Override
+  SimpleSpan getLocalRootSpan() {
+    return this
+  }
+
+  @Override
   String getServiceName() {
     return serviceName
   }
@@ -74,6 +79,66 @@ class SimpleSpan implements CoreSpan<SimpleSpan> {
   @Override
   int getError() {
     return error ? 1 : 0
+  }
+
+  @Override
+  SimpleSpan setMeasured(boolean measured) {
+    return this
+  }
+
+  @Override
+  SimpleSpan setErrorMessage(String errorMessage) {
+    return this
+  }
+
+  @Override
+  SimpleSpan addThrowable(Throwable error) {
+    return this
+  }
+
+  @Override
+  SimpleSpan setTag(String tag, String value) {
+    return this
+  }
+
+  @Override
+  SimpleSpan setTag(String tag, boolean value) {
+    return this
+  }
+
+  @Override
+  SimpleSpan setTag(String tag, int value) {
+    return this
+  }
+
+  @Override
+  SimpleSpan setTag(String tag, long value) {
+    return this
+  }
+
+  @Override
+  SimpleSpan setTag(String tag, double value) {
+    return this
+  }
+
+  @Override
+  SimpleSpan setTag(String tag, Number value) {
+    return this
+  }
+
+  @Override
+  SimpleSpan setTag(String tag, CharSequence value) {
+    return this
+  }
+
+  @Override
+  SimpleSpan setTag(String tag, Object value) {
+    return this
+  }
+
+  @Override
+  SimpleSpan removeTag(String tag) {
+    return this
   }
 
   @Override

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SimpleSpan.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SimpleSpan.groovy
@@ -4,7 +4,7 @@ import datadog.trace.api.DDId
 import datadog.trace.core.CoreSpan
 import datadog.trace.core.TagsAndBaggageConsumer
 
-class SimpleSpan implements CoreSpan {
+class SimpleSpan implements CoreSpan<SimpleSpan> {
 
   private final String serviceName
   private final String operationName
@@ -104,5 +104,10 @@ class SimpleSpan implements CoreSpan {
   @Override
   void processTagsAndBaggage(TagsAndBaggageConsumer consumer) {
 
+  }
+
+  @Override
+  SimpleSpan setSamplingPriority(int samplingPriority) {
+    return this
   }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SimpleSpan.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SimpleSpan.groovy
@@ -77,6 +77,16 @@ class SimpleSpan implements CoreSpan<SimpleSpan> {
   }
 
   @Override
+  <U> U getTag(CharSequence name, U defaultValue) {
+    return defaultValue
+  }
+
+  @Override
+  <U> U getTag(CharSequence name) {
+    return null
+  }
+
+  @Override
   boolean isMeasured() {
     return measured
   }

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/sampling/AllSamplerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/sampling/AllSamplerTest.groovy
@@ -22,20 +22,25 @@ class AllSamplerTest extends DDSpecification {
 
   def "test skip tag sampler"() {
     setup:
-    final Map<String, Object> tags = new HashMap<>()
-    2 * span.getTags() >> tags
     sampler.addSkipTagPattern("http.url", Pattern.compile(".*/hello"))
 
     when:
-    tags.put("http.url", "http://a/hello")
+    boolean sampled = sampler.sample(span)
 
     then:
-    !sampler.sample(span)
+    1 * span.getTag("http.url") >> "http://a/hello"
+
+    expect:
+    !sampled
 
     when:
-    tags.put("http.url", "http://a/hello2")
+    sampled = sampler.sample(span)
 
     then:
-    sampler.sample(span)
+    span.getTag("http.url") >> "http://a/hello2"
+
+    expect:
+    sampled
+
   }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddagent/TraceGenerator.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddagent/TraceGenerator.groovy
@@ -189,12 +189,10 @@ class TraceGenerator {
       return metrics
     }
 
-    @Override
     Map<String, String> getBaggage() {
       return baggage
     }
 
-    @Override
     Map<String, Object> getTags() {
       return tags
     }

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddagent/TraceGenerator.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddagent/TraceGenerator.groovy
@@ -241,5 +241,15 @@ class TraceGenerator {
     PojoSpan setFlag(CharSequence name, boolean value) {
       return this
     }
+
+    @Override
+    <U> U getTag(CharSequence name, U defaultValue) {
+      return tags.get(String.valueOf(name), defaultValue) as U
+    }
+
+    @Override
+    <U> U getTag(CharSequence name) {
+      return tags.get(String.valueOf(name)) as U
+    }
   }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddagent/TraceGenerator.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddagent/TraceGenerator.groovy
@@ -86,7 +86,7 @@ class TraceGenerator {
     return new String(chars)
   }
 
-  static class PojoSpan implements CoreSpan {
+  static class PojoSpan implements CoreSpan<PojoSpan> {
 
     private final CharSequence serviceName
     private final CharSequence operationName
@@ -207,6 +207,11 @@ class TraceGenerator {
     @Override
     void processTagsAndBaggage(TagsAndBaggageConsumer consumer) {
       consumer.accept(tags, baggage)
+    }
+
+    @Override
+    PojoSpan setSamplingPriority(int samplingPriority) {
+      return this
     }
   }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddagent/TraceGenerator.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddagent/TraceGenerator.groovy
@@ -213,5 +213,35 @@ class TraceGenerator {
     PojoSpan setSamplingPriority(int samplingPriority) {
       return this
     }
+
+    @Override
+    PojoSpan setSamplingPriority(int samplingPriority, double sampleRate) {
+      return this
+    }
+
+    @Override
+    PojoSpan setMetric(CharSequence name, int value) {
+      return this
+    }
+
+    @Override
+    PojoSpan setMetric(CharSequence name, long value) {
+      return this
+    }
+
+    @Override
+    PojoSpan setMetric(CharSequence name, float value) {
+      return this
+    }
+
+    @Override
+    PojoSpan setMetric(CharSequence name, double value) {
+      return this
+    }
+
+    @Override
+    PojoSpan setFlag(CharSequence name, boolean value) {
+      return this
+    }
   }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddagent/TraceGenerator.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddagent/TraceGenerator.groovy
@@ -3,7 +3,7 @@ package datadog.trace.common.writer.ddagent
 import datadog.trace.api.DDId
 import datadog.trace.api.IdGenerationStrategy
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString
-import datadog.trace.core.DDSpanData
+import datadog.trace.core.CoreSpan
 import datadog.trace.core.TagsAndBaggageConsumer
 
 import java.util.concurrent.ThreadLocalRandom
@@ -11,8 +11,8 @@ import java.util.concurrent.TimeUnit
 
 class TraceGenerator {
 
-  static List<List<DDSpanData>> generateRandomTraces(int howMany, boolean lowCardinality) {
-    List<List<DDSpanData>> traces = new ArrayList<>(howMany)
+  static List<List<CoreSpan>> generateRandomTraces(int howMany, boolean lowCardinality) {
+    List<List<CoreSpan>> traces = new ArrayList<>(howMany)
     for (int i = 0; i < howMany; ++i) {
       int traceSize = ThreadLocalRandom.current().nextInt(2, 20)
       traces.add(generateRandomTrace(traceSize, lowCardinality))
@@ -20,8 +20,8 @@ class TraceGenerator {
     return traces
   }
 
-  private static List<DDSpanData> generateRandomTrace(int size, boolean lowCardinality) {
-    List<DDSpanData> trace = new ArrayList<>(size)
+  private static List<CoreSpan> generateRandomTrace(int size, boolean lowCardinality) {
+    List<CoreSpan> trace = new ArrayList<>(size)
     long traceId = ThreadLocalRandom.current().nextLong(1, Long.MAX_VALUE)
     for (int i = 0; i < size; ++i) {
       trace.add(randomSpan(traceId, lowCardinality))
@@ -29,7 +29,7 @@ class TraceGenerator {
     return trace
   }
 
-  private static DDSpanData randomSpan(long traceId, boolean lowCardinality) {
+  private static CoreSpan randomSpan(long traceId, boolean lowCardinality) {
     Map<String, String> baggage = new HashMap<>()
     if (ThreadLocalRandom.current().nextBoolean()) {
       baggage.put("baggage-key", lowCardinality ? "x" : randomString(100))
@@ -86,7 +86,7 @@ class TraceGenerator {
     return new String(chars)
   }
 
-  static class PojoSpan implements DDSpanData {
+  static class PojoSpan implements CoreSpan {
 
     private final CharSequence serviceName
     private final CharSequence operationName

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddagent/TraceGenerator.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddagent/TraceGenerator.groovy
@@ -135,6 +135,11 @@ class TraceGenerator {
     }
 
     @Override
+    PojoSpan getLocalRootSpan() {
+      return this
+    }
+
+    @Override
     String getServiceName() {
       return serviceName
     }
@@ -177,6 +182,66 @@ class TraceGenerator {
     @Override
     int getError() {
       return error
+    }
+
+    @Override
+    PojoSpan setMeasured(boolean measured) {
+      return this
+    }
+
+    @Override
+    PojoSpan setErrorMessage(String errorMessage) {
+      return this
+    }
+
+    @Override
+    PojoSpan addThrowable(Throwable error) {
+      return this
+    }
+
+    @Override
+    PojoSpan setTag(String tag, String value) {
+      return this
+    }
+
+    @Override
+    PojoSpan setTag(String tag, boolean value) {
+      return this
+    }
+
+    @Override
+    PojoSpan setTag(String tag, int value) {
+      return this
+    }
+
+    @Override
+    PojoSpan setTag(String tag, long value) {
+      return this
+    }
+
+    @Override
+    PojoSpan setTag(String tag, double value) {
+      return this
+    }
+
+    @Override
+    PojoSpan setTag(String tag, Number value) {
+      return this
+    }
+
+    @Override
+    PojoSpan setTag(String tag, CharSequence value) {
+      return this
+    }
+
+    @Override
+    PojoSpan setTag(String tag, Object value) {
+      return this
+    }
+
+    @Override
+    PojoSpan removeTag(String tag) {
+      return this
     }
 
     @Override

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddagent/TraceGenerator.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddagent/TraceGenerator.groovy
@@ -213,7 +213,7 @@ class TraceGenerator {
     }
 
     @Override
-    PojoSpan setSamplingPriority(int samplingPriority, double sampleRate) {
+    PojoSpan setSamplingPriority(int samplingPriority, CharSequence rate, double sampleRate) {
       return this
     }
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddagent/TraceMapperRealAgentTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddagent/TraceMapperRealAgentTest.groovy
@@ -1,7 +1,7 @@
 package datadog.trace.common.writer.ddagent
 
 import com.timgroup.statsd.NoOpStatsDClient
-import datadog.trace.core.DDSpanData
+import datadog.trace.core.CoreSpan
 import datadog.trace.core.monitor.HealthMetrics
 import datadog.trace.core.monitor.Monitoring
 import datadog.trace.test.util.DDSpecification
@@ -26,9 +26,9 @@ class TraceMapperRealAgentTest extends DDSpecification {
     setup:
     HealthMetrics healthMetrics = Mock(HealthMetrics)
     PayloadDispatcher dispatcher = new PayloadDispatcher(v05 ? v05Api : v04Api, healthMetrics, monitoring)
-    List<List<DDSpanData>> traces = generateRandomTraces(traceCount, lowCardinality)
+    List<List<CoreSpan>> traces = generateRandomTraces(traceCount, lowCardinality)
     when:
-    for (List<DDSpanData> trace : traces) {
+    for (List<CoreSpan> trace : traces) {
       dispatcher.addTrace(trace)
     }
     dispatcher.flush()

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddagent/TraceMapperV04PayloadTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddagent/TraceMapperV04PayloadTest.groovy
@@ -1,7 +1,5 @@
 package datadog.trace.common.writer.ddagent
 
-
-import datadog.trace.core.CoreSpan
 import datadog.trace.core.serialization.ByteBufferConsumer
 import datadog.trace.core.serialization.msgpack.MsgPackWriter
 import datadog.trace.test.util.DDSpecification
@@ -34,14 +32,14 @@ class TraceMapperV04PayloadTest extends DDSpecification {
 
   def "test traces written correctly"() {
     setup:
-    List<List<CoreSpan>> traces = generateRandomTraces(traceCount, lowCardinality)
+    List<List<TraceGenerator.PojoSpan>> traces = generateRandomTraces(traceCount, lowCardinality)
     TraceMapperV0_4 traceMapper = new TraceMapperV0_4()
     PayloadVerifier verifier = new PayloadVerifier(traces, traceMapper)
     MsgPackWriter packer = new MsgPackWriter(verifier, ByteBuffer.allocate(bufferSize))
     when:
     boolean tracesFitInBuffer = true
     try {
-      for (List<CoreSpan> trace : traces) {
+      for (List<TraceGenerator.PojoSpan> trace : traces) {
         packer.format(trace, traceMapper)
       }
     } catch (BufferOverflowException e) {
@@ -78,13 +76,13 @@ class TraceMapperV04PayloadTest extends DDSpecification {
 
   private static final class PayloadVerifier implements ByteBufferConsumer, WritableByteChannel {
 
-    private final List<List<CoreSpan>> expectedTraces
+    private final List<List<TraceGenerator.PojoSpan>> expectedTraces
     private final TraceMapperV0_4 mapper
     private final ByteBuffer captured = ByteBuffer.allocate(200 << 10)
 
     private int position = 0
 
-    private PayloadVerifier(List<List<CoreSpan>> traces, TraceMapperV0_4 mapper) {
+    private PayloadVerifier(List<List<TraceGenerator.PojoSpan>> traces, TraceMapperV0_4 mapper) {
       this.expectedTraces = traces
       this.mapper = mapper
     }
@@ -98,11 +96,11 @@ class TraceMapperV04PayloadTest extends DDSpecification {
         MessageUnpacker unpacker = MessagePack.newDefaultUnpacker(captured)
         int traceCount = unpacker.unpackArrayHeader()
         for (int i = 0; i < traceCount; ++i) {
-          List<CoreSpan> expectedTrace = expectedTraces.get(position++)
+          List<TraceGenerator.PojoSpan> expectedTrace = expectedTraces.get(position++)
           int spanCount = unpacker.unpackArrayHeader()
           assertEquals(expectedTrace.size(), spanCount)
           for (int k = 0; k < spanCount; ++k) {
-            CoreSpan expectedSpan = expectedTrace.get(k)
+            TraceGenerator.PojoSpan expectedSpan = expectedTrace.get(k)
             int elementCount = unpacker.unpackMapHeader()
             assertEquals(12, elementCount)
             assertEquals("service", unpacker.unpackString())

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddagent/TraceMapperV05PayloadTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddagent/TraceMapperV05PayloadTest.groovy
@@ -1,7 +1,7 @@
 package datadog.trace.common.writer.ddagent
 
 import datadog.trace.api.DDId
-import datadog.trace.core.DDSpanData
+import datadog.trace.core.CoreSpan
 import datadog.trace.core.serialization.ByteBufferConsumer
 import datadog.trace.core.serialization.msgpack.MsgPackWriter
 import datadog.trace.test.util.DDSpecification
@@ -40,7 +40,7 @@ class TraceMapperV05PayloadTest extends DDSpecification {
     int dictionarySpacePerTrace = 4 * (36 + 2)
     int dictionarySize = 10 * 1024
     int traceCountToOverflowDictionary = dictionarySize / dictionarySpacePerTrace + 1
-    List<List<DDSpanData>> traces = new ArrayList<>(traceCountToOverflowDictionary)
+    List<List<CoreSpan>> traces = new ArrayList<>(traceCountToOverflowDictionary)
     for (int i = 0; i < traceCountToOverflowDictionary; ++i) {
       // these traces must have deterministic size, but each string value
       // must be unique to ensure no dictionary code reuse
@@ -62,14 +62,14 @@ class TraceMapperV05PayloadTest extends DDSpecification {
       )))
     }
     TraceMapperV0_5 traceMapper = new TraceMapperV0_5(dictionarySize)
-    List<List<DDSpanData>> flushedTraces = new ArrayList<>(traces)
+    List<List<CoreSpan>> flushedTraces = new ArrayList<>(traces)
     // the last one won't be flushed
     flushedTraces.remove(traces.size() - 1)
     PayloadVerifier verifier = new PayloadVerifier(flushedTraces, traceMapper)
     // 100KB body
     MsgPackWriter packer = new MsgPackWriter(verifier, ByteBuffer.allocate(100 * 1024))
     when:
-    for (List<DDSpanData> trace : traces) {
+    for (List<CoreSpan> trace : traces) {
       packer.format(trace, traceMapper)
     }
     then:
@@ -83,7 +83,7 @@ class TraceMapperV05PayloadTest extends DDSpecification {
     // enough space for two traces with distinct string values, plus the header
     int dictionarySize = dictionarySpacePerTrace * 2 + 5
     TraceMapperV0_5 traceMapper = new TraceMapperV0_5(dictionarySize)
-    List<DDSpanData> repeatedTrace = Collections.singletonList(new TraceGenerator.PojoSpan(
+    List<CoreSpan> repeatedTrace = Collections.singletonList(new TraceGenerator.PojoSpan(
       UUID.randomUUID().toString(),
       UUID.randomUUID().toString(),
       UUID.randomUUID().toString(),
@@ -100,19 +100,19 @@ class TraceMapperV05PayloadTest extends DDSpecification {
       false))
     int traceSize = calculateSize(repeatedTrace)
     int tracesRequiredToOverflowBody = traceMapper.messageBufferSize() / traceSize
-    List<List<DDSpanData>> traces = new ArrayList<>(tracesRequiredToOverflowBody)
+    List<List<CoreSpan>> traces = new ArrayList<>(tracesRequiredToOverflowBody)
     for (int i = 0; i < tracesRequiredToOverflowBody; ++i) {
       traces.add(repeatedTrace)
     }
     // the last one won't be flushed
-    List<List<DDSpanData>> flushedTraces = new ArrayList<>(traces)
+    List<List<CoreSpan>> flushedTraces = new ArrayList<>(traces)
     flushedTraces.remove(traces.size() - 1)
     // need space for the overflowing buffer, the dictionary, and two small array headers
     PayloadVerifier verifier = new PayloadVerifier(flushedTraces, traceMapper, (2 << 20) + dictionarySize + 1 + 1 + 5)
     // 2MB body
     MsgPackWriter packer = new MsgPackWriter(verifier, ByteBuffer.allocate(2 << 20))
     when:
-    for (List<DDSpanData> trace : traces) {
+    for (List<CoreSpan> trace : traces) {
       packer.format(trace, traceMapper)
     }
     then:
@@ -121,14 +121,14 @@ class TraceMapperV05PayloadTest extends DDSpecification {
 
   def "test dictionary compressed traces written correctly"() {
     setup:
-    List<List<DDSpanData>> traces = generateRandomTraces(traceCount, lowCardinality)
+    List<List<CoreSpan>> traces = generateRandomTraces(traceCount, lowCardinality)
     TraceMapperV0_5 traceMapper = new TraceMapperV0_5(dictionarySize)
     PayloadVerifier verifier = new PayloadVerifier(traces, traceMapper)
     MsgPackWriter packer = new MsgPackWriter(verifier, ByteBuffer.allocate(bufferSize))
     when:
     boolean tracesFitInBuffer = true
     try {
-      for (List<DDSpanData> trace : traces) {
+      for (List<CoreSpan> trace : traces) {
         packer.format(trace, traceMapper)
       }
     } catch (BufferOverflowException e) {
@@ -176,17 +176,17 @@ class TraceMapperV05PayloadTest extends DDSpecification {
 
   private static final class PayloadVerifier implements ByteBufferConsumer, WritableByteChannel {
 
-    private final List<List<DDSpanData>> expectedTraces
+    private final List<List<CoreSpan>> expectedTraces
     private final TraceMapperV0_5 mapper
     private final ByteBuffer captured
 
     private int position = 0
 
-    private PayloadVerifier(List<List<DDSpanData>> traces, TraceMapperV0_5 mapper) {
+    private PayloadVerifier(List<List<CoreSpan>> traces, TraceMapperV0_5 mapper) {
       this (traces, mapper, 200 << 10)
     }
 
-    private PayloadVerifier(List<List<DDSpanData>> traces, TraceMapperV0_5 mapper, int size) {
+    private PayloadVerifier(List<List<CoreSpan>> traces, TraceMapperV0_5 mapper, int size) {
       this.expectedTraces = traces
       this.mapper = mapper
       this.captured = ByteBuffer.allocate(size)
@@ -208,11 +208,11 @@ class TraceMapperV05PayloadTest extends DDSpecification {
         }
         int traceCount = unpacker.unpackArrayHeader()
         for (int i = 0; i < traceCount; ++i) {
-          List<DDSpanData> expectedTrace = expectedTraces.get(position++)
+          List<CoreSpan> expectedTrace = expectedTraces.get(position++)
           int spanCount = unpacker.unpackArrayHeader()
           assertEquals(expectedTrace.size(), spanCount)
           for (int k = 0; k < spanCount; ++k) {
-            DDSpanData expectedSpan = expectedTrace.get(k)
+            CoreSpan expectedSpan = expectedTrace.get(k)
             int elementCount = unpacker.unpackArrayHeader()
             assertEquals(12, elementCount)
             String serviceName = dictionary[unpacker.unpackInt()]
@@ -330,7 +330,7 @@ class TraceMapperV05PayloadTest extends DDSpecification {
     }
   }
 
-  static int calculateSize(List<DDSpanData> trace) {
+  static int calculateSize(List<CoreSpan> trace) {
     ByteBuffer buffer = ByteBuffer.allocate(1024)
     AtomicInteger size = new AtomicInteger()
     def packer = new MsgPackWriter(new ByteBufferConsumer() {

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddagent/TraceMapperV05PayloadTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddagent/TraceMapperV05PayloadTest.groovy
@@ -1,7 +1,6 @@
 package datadog.trace.common.writer.ddagent
 
 import datadog.trace.api.DDId
-import datadog.trace.core.CoreSpan
 import datadog.trace.core.serialization.ByteBufferConsumer
 import datadog.trace.core.serialization.msgpack.MsgPackWriter
 import datadog.trace.test.util.DDSpecification
@@ -40,7 +39,7 @@ class TraceMapperV05PayloadTest extends DDSpecification {
     int dictionarySpacePerTrace = 4 * (36 + 2)
     int dictionarySize = 10 * 1024
     int traceCountToOverflowDictionary = dictionarySize / dictionarySpacePerTrace + 1
-    List<List<CoreSpan>> traces = new ArrayList<>(traceCountToOverflowDictionary)
+    List<List<TraceGenerator.PojoSpan>> traces = new ArrayList<>(traceCountToOverflowDictionary)
     for (int i = 0; i < traceCountToOverflowDictionary; ++i) {
       // these traces must have deterministic size, but each string value
       // must be unique to ensure no dictionary code reuse
@@ -62,14 +61,14 @@ class TraceMapperV05PayloadTest extends DDSpecification {
       )))
     }
     TraceMapperV0_5 traceMapper = new TraceMapperV0_5(dictionarySize)
-    List<List<CoreSpan>> flushedTraces = new ArrayList<>(traces)
+    List<List<TraceGenerator.PojoSpan>> flushedTraces = new ArrayList<>(traces)
     // the last one won't be flushed
     flushedTraces.remove(traces.size() - 1)
     PayloadVerifier verifier = new PayloadVerifier(flushedTraces, traceMapper)
     // 100KB body
     MsgPackWriter packer = new MsgPackWriter(verifier, ByteBuffer.allocate(100 * 1024))
     when:
-    for (List<CoreSpan> trace : traces) {
+    for (List<TraceGenerator.PojoSpan> trace : traces) {
       packer.format(trace, traceMapper)
     }
     then:
@@ -83,7 +82,7 @@ class TraceMapperV05PayloadTest extends DDSpecification {
     // enough space for two traces with distinct string values, plus the header
     int dictionarySize = dictionarySpacePerTrace * 2 + 5
     TraceMapperV0_5 traceMapper = new TraceMapperV0_5(dictionarySize)
-    List<CoreSpan> repeatedTrace = Collections.singletonList(new TraceGenerator.PojoSpan(
+    List<TraceGenerator.PojoSpan> repeatedTrace = Collections.singletonList(new TraceGenerator.PojoSpan(
       UUID.randomUUID().toString(),
       UUID.randomUUID().toString(),
       UUID.randomUUID().toString(),
@@ -100,19 +99,19 @@ class TraceMapperV05PayloadTest extends DDSpecification {
       false))
     int traceSize = calculateSize(repeatedTrace)
     int tracesRequiredToOverflowBody = traceMapper.messageBufferSize() / traceSize
-    List<List<CoreSpan>> traces = new ArrayList<>(tracesRequiredToOverflowBody)
+    List<List<TraceGenerator.PojoSpan>> traces = new ArrayList<>(tracesRequiredToOverflowBody)
     for (int i = 0; i < tracesRequiredToOverflowBody; ++i) {
       traces.add(repeatedTrace)
     }
     // the last one won't be flushed
-    List<List<CoreSpan>> flushedTraces = new ArrayList<>(traces)
+    List<List<TraceGenerator.PojoSpan>> flushedTraces = new ArrayList<>(traces)
     flushedTraces.remove(traces.size() - 1)
     // need space for the overflowing buffer, the dictionary, and two small array headers
     PayloadVerifier verifier = new PayloadVerifier(flushedTraces, traceMapper, (2 << 20) + dictionarySize + 1 + 1 + 5)
     // 2MB body
     MsgPackWriter packer = new MsgPackWriter(verifier, ByteBuffer.allocate(2 << 20))
     when:
-    for (List<CoreSpan> trace : traces) {
+    for (List<TraceGenerator.PojoSpan> trace : traces) {
       packer.format(trace, traceMapper)
     }
     then:
@@ -121,14 +120,14 @@ class TraceMapperV05PayloadTest extends DDSpecification {
 
   def "test dictionary compressed traces written correctly"() {
     setup:
-    List<List<CoreSpan>> traces = generateRandomTraces(traceCount, lowCardinality)
+    List<List<TraceGenerator.PojoSpan>> traces = generateRandomTraces(traceCount, lowCardinality)
     TraceMapperV0_5 traceMapper = new TraceMapperV0_5(dictionarySize)
     PayloadVerifier verifier = new PayloadVerifier(traces, traceMapper)
     MsgPackWriter packer = new MsgPackWriter(verifier, ByteBuffer.allocate(bufferSize))
     when:
     boolean tracesFitInBuffer = true
     try {
-      for (List<CoreSpan> trace : traces) {
+      for (List<TraceGenerator.PojoSpan> trace : traces) {
         packer.format(trace, traceMapper)
       }
     } catch (BufferOverflowException e) {
@@ -176,17 +175,17 @@ class TraceMapperV05PayloadTest extends DDSpecification {
 
   private static final class PayloadVerifier implements ByteBufferConsumer, WritableByteChannel {
 
-    private final List<List<CoreSpan>> expectedTraces
+    private final List<List<TraceGenerator.PojoSpan>> expectedTraces
     private final TraceMapperV0_5 mapper
     private final ByteBuffer captured
 
     private int position = 0
 
-    private PayloadVerifier(List<List<CoreSpan>> traces, TraceMapperV0_5 mapper) {
+    private PayloadVerifier(List<List<TraceGenerator.PojoSpan>> traces, TraceMapperV0_5 mapper) {
       this (traces, mapper, 200 << 10)
     }
 
-    private PayloadVerifier(List<List<CoreSpan>> traces, TraceMapperV0_5 mapper, int size) {
+    private PayloadVerifier(List<List<TraceGenerator.PojoSpan>> traces, TraceMapperV0_5 mapper, int size) {
       this.expectedTraces = traces
       this.mapper = mapper
       this.captured = ByteBuffer.allocate(size)
@@ -208,11 +207,11 @@ class TraceMapperV05PayloadTest extends DDSpecification {
         }
         int traceCount = unpacker.unpackArrayHeader()
         for (int i = 0; i < traceCount; ++i) {
-          List<CoreSpan> expectedTrace = expectedTraces.get(position++)
+          List<TraceGenerator.PojoSpan> expectedTrace = expectedTraces.get(position++)
           int spanCount = unpacker.unpackArrayHeader()
           assertEquals(expectedTrace.size(), spanCount)
           for (int k = 0; k < spanCount; ++k) {
-            CoreSpan expectedSpan = expectedTrace.get(k)
+            TraceGenerator.PojoSpan expectedSpan = expectedTrace.get(k)
             int elementCount = unpacker.unpackArrayHeader()
             assertEquals(12, elementCount)
             String serviceName = dictionary[unpacker.unpackInt()]
@@ -330,7 +329,7 @@ class TraceMapperV05PayloadTest extends DDSpecification {
     }
   }
 
-  static int calculateSize(List<CoreSpan> trace) {
+  static int calculateSize(List<TraceGenerator.PojoSpan> trace) {
     ByteBuffer buffer = ByteBuffer.allocate(1024)
     AtomicInteger size = new AtomicInteger()
     def packer = new MsgPackWriter(new ByteBufferConsumer() {

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/CoreTracerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/CoreTracerTest.groovy
@@ -359,16 +359,16 @@ class CoreTracerTest extends DDSpecification {
   }
 }
 
-class ControllableSampler implements Sampler, PrioritySampler {
+class ControllableSampler<T extends CoreSpan<T>> implements Sampler<T>, PrioritySampler<T> {
   protected int nextSamplingPriority = PrioritySampling.SAMPLER_KEEP
 
   @Override
-  void setSamplingPriority(DDSpan span) {
+  void setSamplingPriority(T span) {
     span.setSamplingPriority(nextSamplingPriority)
   }
 
   @Override
-  boolean sample(DDSpan span) {
+  boolean sample(T span) {
     return true
   }
 }


### PR DESCRIPTION
There are two motivations here

* I want to be able to write performance tests for isolated components without constructing `CoreTracer` or `PendingTrace`. The coupling of processing with `CoreTracer` via `DDSpan` is why I haven't written a suite of performance tests for processing.
* We want to be able to move to typed tracers and spans for efficiency. An F-bounded generic interface is the best way to do that. 