### PR TITLE
Fix small diff between span deque and span count

### DIFF
--- a/dd-java-agent/instrumentation/commons-httpclient-2/commons-httpclient-2.gradle
+++ b/dd-java-agent/instrumentation/commons-httpclient-2/commons-httpclient-2.gradle
@@ -4,6 +4,7 @@ muzzle {
     module = "commons-httpclient"
     versions = "[2.0,]"
     skipVersions += "3.1-jenkins-1" // odd version in jcenter
+    skipVersions += "20020423" // ancient pre-release version
     assertInverse = true
   }
 }
@@ -22,5 +23,5 @@ dependencies {
 
   testCompile group: 'commons-httpclient', name: 'commons-httpclient', version: '2.0'
 
-  latestDepTestCompile group: 'commons-httpclient', name: 'commons-httpclient', version: '+'
+  latestDepTestCompile group: 'commons-httpclient', name: 'commons-httpclient', version: '(2.0,20000000]'
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/PendingTrace.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/PendingTrace.java
@@ -177,6 +177,9 @@ public class PendingTrace implements AgentTrace {
     }
 
     finishedSpans.addFirst(span);
+    // There is a benign race here where the span added above can get written out by a writer in
+    // progress before the count has been incremented. It's being taken care of in the internal
+    // write method.
     completedSpanCount.incrementAndGet();
     decrementRefAndMaybeWrite(span == getRootSpan());
   }
@@ -261,20 +264,28 @@ public class PendingTrace implements AgentTrace {
   private int write(boolean isPartial) {
     if (!finishedSpans.isEmpty()) {
       try (Recording recording = tracer.writeTimer()) {
+        // Only one writer at a time
         synchronized (this) {
           int size = size();
-          if (!isPartial || size > tracer.getPartialFlushMinSpans()) {
+          // If we get here and size is below 0, then the writer before us wrote out at least one
+          // more trace than the size it had when it started. Those span(s) had been added to
+          // finishedSpans by some other thread(s) while the existing spans were being written, but
+          // the completedSpanCount has not yet been incremented. This means that eventually the
+          // count(s) will be incremented, and any new spans added during the period that the count
+          // was negative will be written by someone even if we don't write them right now.
+          if (size > 0 && (!isPartial || size > tracer.getPartialFlushMinSpans())) {
             List<DDSpan> trace = new ArrayList<>(size);
-
             final Iterator<DDSpan> it = finishedSpans.iterator();
+            int i = 0;
             while (it.hasNext()) {
               final DDSpan span = it.next();
               trace.add(span);
               completedSpanCount.decrementAndGet();
               it.remove();
+              i++;
             }
             tracer.write(trace);
-            return size;
+            return i;
           }
         }
       }


### PR DESCRIPTION
There was a small chance that the `completedSpanCount ` got below `0` if new spans were added while a write was in progress, and a new write happened directly after, before the `completedSpanCount` had been incremented properly.

Fixes #2076  