### PR TITLE
Exclude ancient 20020423 pre-release from commons-httpclient-2 latest version

### DIFF
--- a/dd-java-agent/instrumentation/commons-httpclient-2/commons-httpclient-2.gradle
+++ b/dd-java-agent/instrumentation/commons-httpclient-2/commons-httpclient-2.gradle
@@ -4,6 +4,7 @@ muzzle {
     module = "commons-httpclient"
     versions = "[2.0,]"
     skipVersions += "3.1-jenkins-1" // odd version in jcenter
+    skipVersions += "20020423" // ancient pre-release version
     assertInverse = true
   }
 }
@@ -22,5 +23,5 @@ dependencies {
 
   testCompile group: 'commons-httpclient', name: 'commons-httpclient', version: '2.0'
 
-  latestDepTestCompile group: 'commons-httpclient', name: 'commons-httpclient', version: '+'
+  latestDepTestCompile group: 'commons-httpclient', name: 'commons-httpclient', version: '(2.0,20000000]'
 }


### PR DESCRIPTION
For some reason an old pre-release of `commons-httpclient`, `20020423`, is now appearing as the latest version. This pre-release didn't contain classes that were in the 2.0 release. This PR excludes this specific version from the accepted muzzle range as well as avoiding picking it up for the `latestDepTest`. ~The most reasonable solution for the last case was to use `3+` for the latest dependency version, since we know that `commons-httpclient` has 3.x releases and that the 4.x releases use a different group/artifact and are handled by a different instrumentation.~ Björn provided a better range for the latest dep test.