### PR TITLE
Enable allocation sampling

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/resources/jfr/dd.jfp
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/resources/jfr/dd.jfp
@@ -243,3 +243,4 @@ datadog.Scope#enabled=true
 datadog.Scope#threshold=10 ms
 datadog.ExceptionSample#enabled=true
 datadog.ExceptionCount#enabled=true
+jdk.ObjectAllocationSample#enabled=true


### PR DESCRIPTION
Temporary PR to get the agent binaries built so they can be tested on the profiled backend services.
Not intended for merging.