### PR TITLE
latency metrics

### DIFF
--- a/dd-trace-core/dd-trace-core.gradle
+++ b/dd-trace-core/dd-trace-core.gradle
@@ -33,7 +33,8 @@ dependencies {
   compile deps.slf4j
   compile deps.okhttp
 
-  compile group: 'org.hdrhistogram', name: 'HdrHistogram', version: '2.1.12'
+
+  compile group: 'com.datadoghq', name: 'sketches-java', version: '0.4.1'
   compile group: 'com.squareup.moshi', name: 'moshi', version: '1.9.2'
   compile group: 'com.github.jnr', name: 'jnr-unixsocket', version: "${versions.jnr_unixsocket}"
   compile group: 'org.jctools', name: 'jctools-core', version: '3.1.0'

--- a/dd-trace-core/src/main/java/datadog/trace/core/monitor/CPUTimer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/monitor/CPUTimer.java
@@ -1,5 +1,6 @@
 package datadog.trace.core.monitor;
 
+import com.datadoghq.sketch.ddsketch.DDSketch;
 import com.timgroup.statsd.StatsDClient;
 import datadog.trace.core.util.SystemAccess;
 
@@ -12,8 +13,8 @@ public class CPUTimer extends Timer {
   private long start;
   private long cpuTime = 0;
 
-  CPUTimer(String name, StatsDClient statsd, long flushAfterNanos) {
-    super(name, getTags(), statsd, flushAfterNanos);
+  CPUTimer(String name, DDSketch histogram, StatsDClient statsd, long flushAfterNanos) {
+    super(name, histogram, getTags(), statsd, flushAfterNanos);
     this.name = name + ".cpu";
     this.statsd = statsd;
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/monitor/Timer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/monitor/Timer.java
@@ -3,8 +3,8 @@ package datadog.trace.core.monitor;
 import static datadog.trace.core.monitor.Utils.mergeTags;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
+import com.datadoghq.sketch.ddsketch.DDSketch;
 import com.timgroup.statsd.StatsDClient;
-import org.HdrHistogram.PackedHistogram;
 
 /**
  * A timer which records times in a histogram, and flushes stats from the histogram after a
@@ -14,17 +14,15 @@ public class Timer extends Recording {
 
   private static final long THIRTY_SECONDS_AS_NANOS = SECONDS.toNanos(30);
 
-  private static final String[] MEAN = new String[] {"stat:avg"};
   private static final String[] P_50 = new String[] {"stat:p50"};
   private static final String[] P_99 = new String[] {"stat:p99"};
   private static final String[] MAX = new String[] {"stat:max"};
 
   private final String name;
   private final StatsDClient statsd;
-  private final PackedHistogram histogram;
+  private final DDSketch histogram;
   private final long flushAfterNanos;
 
-  private final String[] meanTags;
   private final String[] p50Tags;
   private final String[] p99Tags;
   private final String[] maxTags;
@@ -32,19 +30,23 @@ public class Timer extends Recording {
   private long start;
   private long lastFlush = 0;
 
-  Timer(final String name, final String[] tags, final StatsDClient statsd, long flushAfterNanos) {
+  Timer(
+      final String name,
+      DDSketch histogram,
+      final String[] tags,
+      final StatsDClient statsd,
+      long flushAfterNanos) {
     this.name = name;
     this.statsd = statsd;
     this.flushAfterNanos = flushAfterNanos;
-    this.histogram = new PackedHistogram(THIRTY_SECONDS_AS_NANOS, 3);
-    this.meanTags = mergeTags(MEAN, tags);
+    this.histogram = histogram;
     this.p50Tags = mergeTags(P_50, tags);
     this.p99Tags = mergeTags(P_99, tags);
     this.maxTags = mergeTags(MAX, tags);
   }
 
-  Timer(final String name, final StatsDClient statsd, long flushAfterNanos) {
-    this(name, null, statsd, flushAfterNanos);
+  Timer(final String name, DDSketch histogram, final StatsDClient statsd, long flushAfterNanos) {
+    this(name, histogram, null, statsd, flushAfterNanos);
   }
 
   @Override
@@ -67,7 +69,7 @@ public class Timer extends Recording {
 
   private void record(long now) {
     // if it's longer than 30s, we have bigger problems
-    histogram.recordValue(Math.min(now - start, THIRTY_SECONDS_AS_NANOS));
+    histogram.accept(Math.min(now - start, THIRTY_SECONDS_AS_NANOS));
     if (now - lastFlush > flushAfterNanos) {
       lastFlush = now;
       flush();
@@ -76,9 +78,8 @@ public class Timer extends Recording {
 
   @Override
   public void flush() {
-    statsd.gauge(name, (long) histogram.getMean(), meanTags);
-    statsd.gauge(name, histogram.getValueAtPercentile(50), p50Tags);
-    statsd.gauge(name, histogram.getValueAtPercentile(99), p99Tags);
+    statsd.gauge(name, histogram.getValueAtQuantile(0.5), p50Tags);
+    statsd.gauge(name, histogram.getValueAtQuantile(0.99), p99Tags);
     statsd.gauge(name, histogram.getMaxValue(), maxTags);
   }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/AgentIntegrationTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/AgentIntegrationTest.groovy
@@ -5,10 +5,11 @@ import datadog.trace.test.util.DDSpecification
 import spock.lang.Ignore
 import spock.lang.Requires
 
+import static datadog.trace.api.Platform.isJavaVersionAtLeast
 import static java.util.concurrent.TimeUnit.SECONDS
 
 @Ignore("requires an upgrade to an as yet unreleased agent to run")
-@Requires({ "true" == System.getenv("CI") })
+@Requires({ "true" == System.getenv("CI") && isJavaVersionAtLeast(8) })
 class AgentIntegrationTest extends DDSpecification {
 
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/AggregateMetricTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/AggregateMetricTest.groovy
@@ -1,6 +1,7 @@
 package datadog.trace.common.metrics
 
 import datadog.trace.test.util.DDSpecification
+import spock.lang.Requires
 
 import java.util.concurrent.BlockingDeque
 import java.util.concurrent.CountDownLatch
@@ -10,6 +11,9 @@ import java.util.concurrent.LinkedBlockingDeque
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 
+import static datadog.trace.api.Platform.isJavaVersionAtLeast
+
+@Requires({ isJavaVersionAtLeast(8) })
 class AggregateMetricTest extends DDSpecification {
 
   def "record durations sums up to total"() {

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/ConflatingMetricAggregatorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/ConflatingMetricAggregatorTest.groovy
@@ -3,12 +3,15 @@ package datadog.trace.common.metrics
 import datadog.trace.api.WellKnownTags
 import datadog.trace.core.CoreSpan
 import datadog.trace.test.util.DDSpecification
+import spock.lang.Requires
 
 import java.util.concurrent.CountDownLatch
 
+import static datadog.trace.api.Platform.isJavaVersionAtLeast
 import static java.util.concurrent.TimeUnit.MILLISECONDS
 import static java.util.concurrent.TimeUnit.SECONDS
 
+@Requires({ isJavaVersionAtLeast(8) })
 class ConflatingMetricAggregatorTest extends DDSpecification {
 
   def "should ignore traces with no measured spans"() {

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/MetricsAggregatorFactoryTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/MetricsAggregatorFactoryTest.groovy
@@ -2,7 +2,11 @@ package datadog.trace.common.metrics
 
 import datadog.trace.api.Config
 import datadog.trace.test.util.DDSpecification
+import spock.lang.Requires
 
+import static datadog.trace.api.Platform.isJavaVersionAtLeast
+
+@Requires({ isJavaVersionAtLeast(8) })
 class MetricsAggregatorFactoryTest extends DDSpecification {
 
   def "when metrics disabled no-op aggregator created"() {

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/OkHttpSinkTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/OkHttpSinkTest.groovy
@@ -8,14 +8,17 @@ import okhttp3.Protocol
 import okhttp3.Request
 import okhttp3.Response
 import okhttp3.ResponseBody
+import spock.lang.Requires
 
 import java.nio.ByteBuffer
 
+import static datadog.trace.api.Platform.isJavaVersionAtLeast
 import static datadog.trace.common.metrics.EventListener.EventType.BAD_PAYLOAD
 import static datadog.trace.common.metrics.EventListener.EventType.DOWNGRADED
 import static datadog.trace.common.metrics.EventListener.EventType.ERROR
 import static datadog.trace.common.metrics.EventListener.EventType.OK
 
+@Requires({ isJavaVersionAtLeast(8) })
 class OkHttpSinkTest extends DDSpecification {
 
   def "http status code #responseCode yields #eventType"() {

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SerializingMetricWriterTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SerializingMetricWriterTest.groovy
@@ -5,12 +5,15 @@ import datadog.trace.bootstrap.instrumentation.api.Pair
 import datadog.trace.test.util.DDSpecification
 import org.msgpack.core.MessagePack
 import org.msgpack.core.MessageUnpacker
+import spock.lang.Requires
 
 import java.nio.ByteBuffer
 
+import static datadog.trace.api.Platform.isJavaVersionAtLeast
 import static java.util.concurrent.TimeUnit.MILLISECONDS
 import static java.util.concurrent.TimeUnit.SECONDS
 
+@Requires({ isJavaVersionAtLeast(8) })
 class SerializingMetricWriterTest extends DDSpecification {
 
   def "should produce correct message" () {

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -595,6 +595,7 @@ public class Config {
     healthMetricsStatsdPort = configProvider.getInteger(HEALTH_METRICS_STATSD_PORT);
     perfMetricsEnabled =
         runtimeMetricsEnabled
+            && isJavaVersionAtLeast(8)
             && configProvider.getBoolean(PERF_METRICS_ENABLED, DEFAULT_PERF_METRICS_ENABLED);
 
     tracerMetricsEnabled =

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -56,6 +56,7 @@ import static datadog.trace.api.DDTags.RUNTIME_ID_TAG;
 import static datadog.trace.api.DDTags.SERVICE;
 import static datadog.trace.api.DDTags.SERVICE_TAG;
 import static datadog.trace.api.IdGenerationStrategy.RANDOM;
+import static datadog.trace.api.Platform.isJavaVersionAtLeast;
 import static datadog.trace.api.config.GeneralConfig.RUNTIME_METRICS_ENABLED;
 import static datadog.trace.api.config.GeneralConfig.TRACER_METRICS_ENABLED;
 import static datadog.trace.api.config.GeneralConfig.TRACER_METRICS_MAX_AGGREGATES;
@@ -596,7 +597,8 @@ public class Config {
         runtimeMetricsEnabled
             && configProvider.getBoolean(PERF_METRICS_ENABLED, DEFAULT_PERF_METRICS_ENABLED);
 
-    tracerMetricsEnabled = configProvider.getBoolean(TRACER_METRICS_ENABLED, false);
+    tracerMetricsEnabled =
+        isJavaVersionAtLeast(8) && configProvider.getBoolean(TRACER_METRICS_ENABLED, false);
     tracerMetricsMaxAggregates = configProvider.getInteger(TRACER_METRICS_MAX_AGGREGATES, 1000);
     tracerMetricsMaxPending = configProvider.getInteger(TRACER_METRICS_MAX_PENDING, 2048);
 


### PR DESCRIPTION
I may need to do more to ensure the `DDSketch` class is never loaded on JDK7, but both performance monitoring and tracer metrics are now disabled on JDK7.