### PR TITLE
JMC snapshot repo for snapshots only

### DIFF
--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -129,6 +129,9 @@ repositories {
   mavenCentral()
   maven {
     url "https://adoptopenjdk.jfrog.io/adoptopenjdk/jmc-libs-snapshots"
+    mavenContent {
+      snapshotsOnly()
+    }
   }
   maven {
     url "https://repo.typesafe.com/typesafe/releases"


### PR DESCRIPTION
Doesn't fix the issue, but fixes the logging around the issue. Something about this repo config causes an error when requesting a non-snapshot file from it