### PR TITLE
Don't override user-provided service name with servlet.context

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/taginterceptor/ServletContextTagInterceptor.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/taginterceptor/ServletContextTagInterceptor.java
@@ -1,5 +1,6 @@
 package datadog.trace.core.taginterceptor;
 
+import datadog.trace.api.Config;
 import datadog.trace.api.ConfigDefaults;
 import datadog.trace.api.config.GeneralConfig;
 import datadog.trace.api.env.CapturedEnvironment;
@@ -16,6 +17,7 @@ class ServletContextTagInterceptor extends AbstractTagInterceptor {
   public boolean shouldSetTag(final ExclusiveSpan span, final String tag, final Object value) {
     String contextName = String.valueOf(value).trim();
     if (contextName.equals("/")
+        || Config.get().isServiceNameSetByUser()
         || (!span.getServiceName().equals(ConfigDefaults.DEFAULT_SERVICE_NAME)
             && !span.getServiceName()
                 .equals(CapturedEnvironment.get().getProperties().get(GeneralConfig.SERVICE_NAME))

--- a/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/CapturedEnvironmentConfigSource.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/CapturedEnvironmentConfigSource.java
@@ -2,7 +2,7 @@ package datadog.trace.bootstrap.config.provider;
 
 import datadog.trace.api.env.CapturedEnvironment;
 
-final class CapturedEnvironmentConfigSource extends ConfigProvider.Source {
+public final class CapturedEnvironmentConfigSource extends ConfigProvider.Source {
   private final CapturedEnvironment env;
 
   public CapturedEnvironmentConfigSource() {

--- a/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/ConfigProvider.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/ConfigProvider.java
@@ -47,12 +47,14 @@ public final class ConfigProvider {
     return defaultValue;
   }
 
-  public final String getStringBypassSysProps(String key, String defaultValue) {
+  public final String getStringExcludingSource(
+      String key, String defaultValue, Class clazz, String... aliases) {
     for (ConfigProvider.Source source : sources) {
-      if (source instanceof SystemPropertiesConfigSource) {
+      if (clazz.isAssignableFrom(source.getClass())) {
         continue;
       }
-      String value = source.get(key);
+
+      String value = source.get(key, aliases);
       if (value != null) {
         return value;
       }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/ConfigProvider.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/ConfigProvider.java
@@ -48,9 +48,12 @@ public final class ConfigProvider {
   }
 
   public final String getStringExcludingSource(
-      String key, String defaultValue, Class clazz, String... aliases) {
+      String key,
+      String defaultValue,
+      Class<? extends ConfigProvider.Source> excludedSource,
+      String... aliases) {
     for (ConfigProvider.Source source : sources) {
-      if (clazz.isAssignableFrom(source.getClass())) {
+      if (excludedSource.isAssignableFrom(source.getClass())) {
         continue;
       }
 

--- a/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/SystemPropertiesConfigSource.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/SystemPropertiesConfigSource.java
@@ -2,7 +2,7 @@ package datadog.trace.bootstrap.config.provider;
 
 import lombok.NonNull;
 
-final class SystemPropertiesConfigSource extends ConfigProvider.Source {
+public final class SystemPropertiesConfigSource extends ConfigProvider.Source {
   private static final String PREFIX = "dd.";
 
   @Override

--- a/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -1561,6 +1561,24 @@ class ConfigTest extends DDSpecification {
                              'service.version': 'my-svc-vers']
   }
 
+  def "explicit service name is not overridden by captured environment"() {
+    setup:
+    System.setProperty(PREFIX + serviceProperty, serviceName)
+
+    when:
+    def config = new Config()
+
+    then:
+    config.serviceName == serviceName
+    assert config.isServiceNameSetByUser()
+
+    where:
+    [serviceProperty, serviceName] << [
+      [SERVICE, SERVICE_NAME],
+      [DEFAULT_SERVICE_NAME, "my-service"]
+    ].combinations()
+  }
+
   def "detect if agent is configured using default values"() {
     setup:
     if (host != null) {


### PR DESCRIPTION
The check in `ServletContextTagInterceptor` was insufficient.  If a user's service name matched the `CapturedEnvironment` service name (eg, by matching filename of the executable jar), the tracer overrode the user provided service name with the servlet context.

With this pull request, whether or not the service name was explicitly set by the user is tracked in config.  That flag is checked inside the tag interceptor.

The tracer still has incorrect behavior if the service name is set via tag.  Too many pervasive changes would be required to track the setting of the service tag everywhere and distinguish instrumentation calls versus user calls.  Setting the service name to the jar name (or `unnamed-java-app`) as a tag seems too rare to warrant those changes.