### PR TITLE
Change context store to use Boolean values in servlet instrumentations

### DIFF
--- a/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/Servlet2Advice.java
+++ b/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/Servlet2Advice.java
@@ -44,8 +44,8 @@ public class Servlet2Advice {
 
     if (response instanceof HttpServletResponse) {
       // For use by HttpServletResponseInstrumentation:
-      InstrumentationContext.get(HttpServletResponse.class, HttpServletRequest.class)
-          .put((HttpServletResponse) response, httpServletRequest);
+      InstrumentationContext.get(HttpServletResponse.class, Boolean.class)
+          .put((HttpServletResponse) response, Boolean.TRUE);
 
       // Default value for checking for uncaught error later
       InstrumentationContext.get(ServletResponse.class, Integer.class).put(response, 200);

--- a/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/Servlet2Instrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/Servlet2Instrumentation.java
@@ -54,8 +54,7 @@ public final class Servlet2Instrumentation extends Instrumenter.Default {
   @Override
   public Map<String, String> contextStore() {
     final Map<String, String> contextStores = new HashMap<>();
-    contextStores.put(
-        "javax.servlet.http.HttpServletResponse", "javax.servlet.http.HttpServletRequest");
+    contextStores.put("javax.servlet.http.HttpServletResponse", Boolean.class.getName());
     contextStores.put("javax.servlet.ServletResponse", Integer.class.getName());
     return Collections.unmodifiableMap(contextStores);
   }

--- a/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Advice.java
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Advice.java
@@ -43,8 +43,8 @@ public class Servlet3Advice {
     final HttpServletRequest httpServletRequest = (HttpServletRequest) request;
 
     // For use by HttpServletResponseInstrumentation:
-    InstrumentationContext.get(HttpServletResponse.class, HttpServletRequest.class)
-        .put((HttpServletResponse) response, httpServletRequest);
+    InstrumentationContext.get(HttpServletResponse.class, Boolean.class)
+        .put((HttpServletResponse) response, Boolean.TRUE);
 
     final AgentSpan.Context extractedContext;
     Object dispatchSpan = request.getAttribute(DD_DISPATCH_SPAN_ATTRIBUTE);

--- a/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Instrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Instrumentation.java
@@ -48,8 +48,7 @@ public final class Servlet3Instrumentation extends Instrumenter.Default {
 
   @Override
   public Map<String, String> contextStore() {
-    return singletonMap(
-        "javax.servlet.http.HttpServletResponse", "javax.servlet.http.HttpServletRequest");
+    return singletonMap("javax.servlet.http.HttpServletResponse", Boolean.class.getName());
   }
 
   /**


### PR DESCRIPTION
The context stores in the servlet instrumentations only serve the purpose of being certain that the response object is the one previously associated with the instrumented request, but this association is costly in memory, and when the association falls back to a weak map, it will not be cleared deterministically leading to unbounded memory consumption. 

It doesn't seem to be possible to entirely remove this context store, but setting a boolean value mitigates the impact when field injection fails. 