### PR TITLE
add limit to WeakMap size in ContextStoreImplementationTemplate

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/context/ContextStoreImplementationTemplate.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/context/ContextStoreImplementationTemplate.java
@@ -11,6 +11,8 @@ final class ContextStoreImplementationTemplate implements ContextStore<Object, O
   private static final ContextStoreImplementationTemplate INSTANCE =
       new ContextStoreImplementationTemplate();
 
+  private static final int MAX_SIZE = 50_000;
+
   private volatile WeakMap map;
   private final Object synchronizationInstance = new Object();
 
@@ -89,7 +91,10 @@ final class ContextStoreImplementationTemplate implements ContextStore<Object, O
   }
 
   private void mapPut(final Object key, final Object value) {
-    getMap().put(key, value);
+    WeakMap map = getMap();
+    if (map.size() < MAX_SIZE) {
+      map.put(key, value);
+    }
   }
 
   private Object mapSynchronizeInstance(final Object key) {


### PR DESCRIPTION
When the `WeakMap` fallback is used, something has gone wrong anyway, and with this change we will degrade to incomplete instrumentation rather than unbounded memory usage.