### PR TITLE
make servletcontexttaginterceptor more efficient

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/taginterceptor/ServletContextTagInterceptor.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/taginterceptor/ServletContextTagInterceptor.java
@@ -9,28 +9,32 @@ import datadog.trace.core.ExclusiveSpan;
 
 class ServletContextTagInterceptor extends AbstractTagInterceptor {
 
+  private final boolean isServiceNameSetByUser;
+  private final String serviceName;
+
   public ServletContextTagInterceptor() {
     super(InstrumentationTags.SERVLET_CONTEXT);
+    this.isServiceNameSetByUser = Config.get().isServiceNameSetByUser();
+    this.serviceName = CapturedEnvironment.get().getProperties().get(GeneralConfig.SERVICE_NAME);
   }
 
   @Override
   public boolean shouldSetTag(final ExclusiveSpan span, final String tag, final Object value) {
-    String contextName = String.valueOf(value).trim();
-    if (contextName.equals("/")
-        || Config.get().isServiceNameSetByUser()
-        || (!span.getServiceName().equals(ConfigDefaults.DEFAULT_SERVICE_NAME)
-            && !span.getServiceName()
-                .equals(CapturedEnvironment.get().getProperties().get(GeneralConfig.SERVICE_NAME))
-            && !span.getServiceName().isEmpty())) {
+    if (isServiceNameSetByUser
+        || (!span.getServiceName().isEmpty()
+            && !span.getServiceName().equals(serviceName)
+            && !span.getServiceName().equals(ConfigDefaults.DEFAULT_SERVICE_NAME))) {
       return true;
     }
-    if (contextName.startsWith("/")) {
-      if (contextName.length() > 1) {
-        contextName = contextName.substring(1);
-      }
-    }
+    String contextName = String.valueOf(value).trim();
     if (!contextName.isEmpty()) {
-      span.setServiceName(contextName);
+      if (contextName.charAt(0) == '/') {
+        if (contextName.length() > 1) {
+          span.setServiceName(contextName.substring(1));
+        }
+      } else {
+        span.setServiceName(contextName);
+      }
     }
     return true;
   }


### PR DESCRIPTION
I noticed reviewing #2099 that there are numerous inefficiencies in this logic, including looking up a constant in a hashmap every time we set the tag, checking that the string is non-empty last, and (implicitly) checking twice that the string is equal to "/"