### PR TITLE
Only consider external dependencies when deciding transitive dependencies to list in the 'dd-trace-ot' pom.

### DIFF
--- a/dd-trace-ot/dd-trace-ot.gradle
+++ b/dd-trace-ot/dd-trace-ot.gradle
@@ -98,16 +98,17 @@ shadowJar {
 }
 
 modifyPom {
-  // We're bundling the internal dependencies.  So we need to add the transitive dependencies
+  // We're bundling the internal dependencies.  So we need to add external transitive dependencies
   // of those projects. Directly adding to the XML is the only way to prevent the shadowJar plugin
   // from removing them
   def bundledProjectNames = bundledProjects.collect { it.substring(it.lastIndexOf(":") + 1) }
+  def externalDependencies = { p -> p.configurations.getByName("compile").dependencies.withType(ExternalDependency) }
   withXml({ XmlProvider provider ->
     Node dependencies = provider.asNode().dependencies[0]
-    def addedDependencies = project.configurations.getByName("compile").dependencies.collect { it.name }
+    def addedDependencies = externalDependencies(project).collect { it.name }
     addedDependencies.addAll(bundledProjectNames)
     bundledProjects.forEach { bundledProject ->
-      project(bundledProject).configurations.getByName("compile").dependencies.forEach { transitiveDependency ->
+      externalDependencies(project(bundledProject)).forEach { transitiveDependency ->
         if (!addedDependencies.contains(transitiveDependency.name)) {
           def dependency = dependencies.appendNode("dependency")
           dependency.appendNode("groupId", transitiveDependency.group)


### PR DESCRIPTION
This avoids an issue where a project dependency is listed as a transitive dependency. In some situations, such as when running a task from a sub-directory instead of the root project, this transitive dependency may not be resolved yet and has a name of 'unspecified'. Adding it to the 'dd-trace-ot' model leads to a gradle error:
```
* What went wrong:
Execution failed for task ':compileJava'.
> Could not resolve all files for configuration ':compileClasspath'.
   > Could not find :unspecified:.
     Required by:
         project : > com.datadoghq:dd-trace-ot:0.69.0-SNAPSHOT
```
Since we're bundling project dependencies we can safely exclude them from the dependencies to add to the pom.