### PR TITLE
Automatically inject missing serialVersionUIDs when field-injecting Serializables

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/context/FieldInjectionVisitor.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/context/FieldInjectionVisitor.java
@@ -1,10 +1,13 @@
 package datadog.trace.agent.tooling.context;
 
 import datadog.trace.agent.tooling.Utils;
+import datadog.trace.api.Config;
 import datadog.trace.bootstrap.FieldBackedContextStoreAppliedMarker;
+import java.io.Serializable;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
 import net.bytebuddy.asm.AsmVisitorWrapper;
 import net.bytebuddy.description.field.FieldDescription;
 import net.bytebuddy.description.field.FieldList;
@@ -17,7 +20,9 @@ import net.bytebuddy.jar.asm.FieldVisitor;
 import net.bytebuddy.jar.asm.MethodVisitor;
 import net.bytebuddy.jar.asm.Opcodes;
 import net.bytebuddy.pool.TypePool;
+import org.objectweb.asm.commons.SerialVersionUIDAdder;
 
+@Slf4j
 final class FieldInjectionVisitor implements AsmVisitorWrapper {
 
   private static final String INJECTED_FIELDS_MARKER_CLASS_NAME =
@@ -67,6 +72,7 @@ final class FieldInjectionVisitor implements AsmVisitorWrapper {
       private boolean foundField = false;
       private boolean foundGetter = false;
       private boolean foundSetter = false;
+      private SerialVersionUIDInjector serialVersionUIDInjector;
 
       @Override
       public void visit(
@@ -82,6 +88,11 @@ final class FieldInjectionVisitor implements AsmVisitorWrapper {
         final Set<String> set = new LinkedHashSet<>(Arrays.asList(interfaces));
         set.add(INJECTED_FIELDS_MARKER_CLASS_NAME);
         set.add(interfaceType.getInternalName());
+        if (Config.get().isSerialVersionUIDFieldInjection()
+            && instrumentedType.isAssignableTo(Serializable.class)) {
+          serialVersionUIDInjector = new SerialVersionUIDInjector();
+          serialVersionUIDInjector.visit(version, access, name, signature, superName, interfaces);
+        }
         super.visit(version, access, name, signature, superName, set.toArray(new String[] {}));
       }
 
@@ -94,6 +105,8 @@ final class FieldInjectionVisitor implements AsmVisitorWrapper {
           final Object value) {
         if (name.equals(fieldName)) {
           foundField = true;
+        } else if (serialVersionUIDInjector != null) {
+          serialVersionUIDInjector.visitField(access, name, descriptor, signature, value);
         }
         return super.visitField(access, name, descriptor, signature, value);
       }
@@ -107,11 +120,20 @@ final class FieldInjectionVisitor implements AsmVisitorWrapper {
           final String[] exceptions) {
         if (name.equals(getterMethodName)) {
           foundGetter = true;
-        }
-        if (name.equals(setterMethodName)) {
+        } else if (name.equals(setterMethodName)) {
           foundSetter = true;
+        } else if (serialVersionUIDInjector != null) {
+          serialVersionUIDInjector.visitMethod(access, name, descriptor, signature, exceptions);
         }
         return super.visitMethod(access, name, descriptor, signature, exceptions);
+      }
+
+      @Override
+      public void visitInnerClass(String name, String outerName, String innerName, int access) {
+        if (serialVersionUIDInjector != null) {
+          serialVersionUIDInjector.visitInnerClass(name, outerName, innerName, access);
+        }
+        super.visitInnerClass(name, outerName, innerName, access);
       }
 
       @Override
@@ -120,6 +142,7 @@ final class FieldInjectionVisitor implements AsmVisitorWrapper {
         // public/protected methods and not fields (neither public nor private ones) when
         // they enhance a class.
         // For this reason we check separately for the field and for the two accessors.
+        boolean changedShape = false;
         if (!foundField) {
           cv.visitField(
               // Field should be transient to avoid being serialized with the object.
@@ -128,12 +151,19 @@ final class FieldInjectionVisitor implements AsmVisitorWrapper {
               contextType.getDescriptor(),
               null,
               null);
+          changedShape = true;
         }
         if (!foundGetter) {
           addGetter();
+          changedShape = true;
         }
         if (!foundSetter) {
           addSetter();
+          changedShape = true;
+        }
+        if (changedShape && serialVersionUIDInjector != null) {
+          serialVersionUIDInjector.injectSerialVersionUID(instrumentedType, cv);
+          serialVersionUIDInjector = null;
         }
         super.visitEnd();
       }
@@ -178,5 +208,27 @@ final class FieldInjectionVisitor implements AsmVisitorWrapper {
             null);
       }
     };
+  }
+
+  private static final class SerialVersionUIDInjector extends SerialVersionUIDAdder {
+    public SerialVersionUIDInjector() {
+      super(Opcodes.ASM7, null);
+    }
+
+    public void injectSerialVersionUID(
+        final TypeDescription instrumentedType, final ClassVisitor transformer) {
+      if (!hasSVUID()) {
+        try {
+          transformer.visitField(
+              Opcodes.ACC_FINAL | Opcodes.ACC_STATIC,
+              "serialVersionUID",
+              "J",
+              null,
+              computeSVUID());
+        } catch (Exception e) {
+          log.debug("Failed to add serialVersionUID to {}", instrumentedType.getActualName(), e);
+        }
+      }
+    }
   }
 }

--- a/dd-java-agent/testing/src/test/groovy/context/FieldBackedProviderTest.groovy
+++ b/dd-java-agent/testing/src/test/groovy/context/FieldBackedProviderTest.groovy
@@ -18,11 +18,16 @@ import java.lang.reflect.Method
 import java.lang.reflect.Modifier
 import java.util.concurrent.atomic.AtomicReference
 
+import static context.ContextTestInstrumentation.DisabledKeyClass
 import static context.ContextTestInstrumentation.IncorrectCallUsageKeyClass
 import static context.ContextTestInstrumentation.IncorrectContextClassUsageKeyClass
 import static context.ContextTestInstrumentation.IncorrectKeyClassUsageKeyClass
+import static context.ContextTestInstrumentation.InvalidInheritsSerializableKeyClass
+import static context.ContextTestInstrumentation.InvalidSerializableKeyClass
 import static context.ContextTestInstrumentation.KeyClass
 import static context.ContextTestInstrumentation.UntransformableKeyClass
+import static context.ContextTestInstrumentation.ValidInheritsSerializableKeyClass
+import static context.ContextTestInstrumentation.ValidSerializableKeyClass
 import static datadog.trace.bootstrap.config.provider.SystemPropertiesConfigSource.PREFIX
 
 class FieldBackedProviderTest extends AgentTestRunner {
@@ -74,12 +79,18 @@ class FieldBackedProviderTest extends AgentTestRunner {
     isTransient == shouldModifyStructure
     hasMarkerInterface == shouldModifyStructure
     hasAccessorInterface == shouldModifyStructure
-    keyClass.newInstance().isInstrumented() == shouldModifyStructure
+    keyClass.newInstance().isInstrumented() == isInstrumented
 
     where:
-    keyClass                | keyClassName             | shouldModifyStructure
-    KeyClass                | keyClass.getSimpleName() | true
-    UntransformableKeyClass | keyClass.getSimpleName() | false
+    keyClass                            | shouldModifyStructure | isInstrumented
+    KeyClass                            | true                  | true
+    UntransformableKeyClass             | false                 | false
+    ValidSerializableKeyClass           | true                  | true
+    InvalidSerializableKeyClass         | true                  | true
+    ValidInheritsSerializableKeyClass   | true                  | true
+    InvalidInheritsSerializableKeyClass | true                  | true
+
+    keyClassName = keyClass.getSimpleName()
   }
 
   def "correct api usage stores state in map"() {
@@ -107,6 +118,30 @@ class FieldBackedProviderTest extends AgentTestRunner {
     instance1                     | _
     new KeyClass()                | _
     new UntransformableKeyClass() | _
+  }
+
+  def "serializability not impacted"() {
+    expect:
+    serialVersionUID(serializable) == serialVersionUID
+
+    where:
+    serializable                        | serialVersionUID // These are calculated with the corresponding declarations in ContextTestInstrumentation removed
+    ValidSerializableKeyClass           | 123
+    InvalidSerializableKeyClass         | -7962971793425055368L
+    ValidInheritsSerializableKeyClass   | 456
+    InvalidInheritsSerializableKeyClass | 3138394217499921470L
+  }
+
+  static final long serialVersionUID(Class<? extends Serializable> klass) throws Exception {
+    try {
+      def field = klass.getDeclaredField("serialVersionUID")
+      field.setAccessible(true)
+      return (long) field.get(null)
+    } catch (NoSuchFieldException ex) {
+      def method = ObjectStreamClass.getDeclaredMethod("computeDefaultSUID", Class)
+      method.setAccessible(true)
+      return (long) method.invoke(null, klass)
+    }
   }
 
   def "works with cglib enhanced instances which duplicates context getter and setter methods"() {
@@ -195,7 +230,7 @@ class FieldBackedProviderTest extends AgentTestRunner {
 class FieldBackedProviderFieldInjectionDisabledTest extends AgentTestRunner {
   def "Check that structure is not modified when structure modification is disabled"() {
     setup:
-    def keyClass = ContextTestInstrumentation.DisabledKeyClass
+    def keyClass = DisabledKeyClass
     boolean hasField = false
     for (Field field : keyClass.getDeclaredFields()) {
       if (field.getName().startsWith("__datadog")) {

--- a/dd-java-agent/testing/src/test/java/context/ContextTestInstrumentation.java
+++ b/dd-java-agent/testing/src/test/java/context/ContextTestInstrumentation.java
@@ -7,6 +7,7 @@ import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.InstrumentationContext;
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
@@ -51,9 +52,14 @@ public class ContextTestInstrumentation extends Instrumenter.Default {
   @Override
   public Map<String, String> contextStoreForAll() {
     final Map<String, String> store = new HashMap<>(2);
-    store.put(getClass().getName() + "$KeyClass", getClass().getName() + "$Context");
-    store.put(getClass().getName() + "$UntransformableKeyClass", getClass().getName() + "$Context");
-    store.put(getClass().getName() + "$DisabledKeyClass", getClass().getName() + "$Context");
+    String prefix = getClass().getName() + "$";
+    store.put(prefix + "KeyClass", prefix + "Context");
+    store.put(prefix + "UntransformableKeyClass", prefix + "Context");
+    store.put(prefix + "DisabledKeyClass", prefix + "Context");
+    store.put(prefix + "ValidSerializableKeyClass", prefix + "Context");
+    store.put(prefix + "InvalidSerializableKeyClass", prefix + "Context");
+    store.put(prefix + "ValidInheritsSerializableKeyClass", prefix + "Context");
+    store.put(prefix + "InvalidInheritsSerializableKeyClass", prefix + "Context");
     return store;
   }
 
@@ -185,6 +191,22 @@ public class ContextTestInstrumentation extends Instrumenter.Default {
       return false;
     }
   }
+
+  /** A class that is serializable with serialVersionUID. */
+  public static class ValidSerializableKeyClass extends KeyClass implements Serializable {
+    private static final long serialVersionUID = 123;
+  }
+
+  /** A class that is serializable with no serialVersionUID. */
+  public static class InvalidSerializableKeyClass extends KeyClass implements Serializable {}
+
+  /** A class that inherits serializable with serialVersionUID. */
+  public static class ValidInheritsSerializableKeyClass extends InvalidSerializableKeyClass {
+    private static final long serialVersionUID = 456;
+  }
+
+  /** A class that inherits serializable with no serialVersionUID. */
+  public static class InvalidInheritsSerializableKeyClass extends ValidSerializableKeyClass {}
 
   public static class IncorrectKeyClassUsageKeyClass {
     public boolean isInstrumented() {

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -29,6 +29,7 @@ public final class ConfigDefaults {
   static final String DEFAULT_PRIORITIZATION_TYPE = "FastLane";
 
   static final boolean DEFAULT_RUNTIME_CONTEXT_FIELD_INJECTION = true;
+  static final boolean DEFAULT_SERIALVERSIONUID_FIELD_INJECTION = false;
 
   static final boolean DEFAULT_PRIORITY_SAMPLING_ENABLED = true;
   static final String DEFAULT_PRIORITY_SAMPLING_FORCE = null;

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
@@ -26,6 +26,8 @@ public final class TraceInstrumentationConfig {
 
   public static final String RUNTIME_CONTEXT_FIELD_INJECTION =
       "trace.runtime.context.field.injection";
+  public static final String SERIALVERSIONUID_FIELD_INJECTION =
+      "trace.serialversionuid.field.injection";
 
   public static final String LOGS_INJECTION_ENABLED = "logs.injection";
   public static final String LOGS_MDC_TAGS_INJECTION_ENABLED = "logs.mdc.tags.injection";

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -36,6 +36,7 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_PROPAGATION_STYLE_EXTRACT
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PROPAGATION_STYLE_INJECT;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_RUNTIME_CONTEXT_FIELD_INJECTION;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_SCOPE_DEPTH_LIMIT;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_SERIALVERSIONUID_FIELD_INJECTION;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_SERVICE_NAME;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_SITE;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_AGENT_PORT;
@@ -181,6 +182,8 @@ public class Config {
   public static final String PARTIAL_FLUSH_MIN_SPANS = TracerConfig.PARTIAL_FLUSH_MIN_SPANS;
   public static final String RUNTIME_CONTEXT_FIELD_INJECTION =
       TraceInstrumentationConfig.RUNTIME_CONTEXT_FIELD_INJECTION;
+  public static final String SERIALVERSIONUID_FIELD_INJECTION =
+      TraceInstrumentationConfig.SERIALVERSIONUID_FIELD_INJECTION;
   public static final String PROPAGATION_STYLE_EXTRACT = TracerConfig.PROPAGATION_STYLE_EXTRACT;
   public static final String PROPAGATION_STYLE_INJECT = TracerConfig.PROPAGATION_STYLE_INJECT;
 
@@ -320,6 +323,7 @@ public class Config {
   @Getter private final boolean scopeInheritAsyncPropagation;
   @Getter private final int partialFlushMinSpans;
   @Getter private final boolean runtimeContextFieldInjection;
+  @Getter private final boolean serialVersionUIDFieldInjection;
   @Getter private final Set<PropagationStyle> propagationStylesToExtract;
   @Getter private final Set<PropagationStyle> propagationStylesToInject;
 
@@ -578,6 +582,9 @@ public class Config {
     runtimeContextFieldInjection =
         configProvider.getBoolean(
             RUNTIME_CONTEXT_FIELD_INJECTION, DEFAULT_RUNTIME_CONTEXT_FIELD_INJECTION);
+    serialVersionUIDFieldInjection =
+        configProvider.getBoolean(
+            SERIALVERSIONUID_FIELD_INJECTION, DEFAULT_SERIALVERSIONUID_FIELD_INJECTION);
 
     propagationStylesToExtract =
         getPropagationStyleSetSettingFromEnvironmentOrDefault(


### PR DESCRIPTION
The generated serialVersionUID is based on the class shape before field-injection.