### PR TITLE
[CIAPP-634] Add test.fingerprint to test instrumentation

### DIFF
--- a/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4Decorator.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4Decorator.java
@@ -5,6 +5,7 @@ import datadog.trace.api.DisableTestTrace;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.decorator.TestDecorator;
+import datadog.trace.util.MurmurHash2;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.runner.Description;
 import org.junit.runner.notification.Failure;
@@ -42,10 +43,13 @@ public class JUnit4Decorator extends TestDecorator {
       final AgentSpan span, final Description description, final String testNameArg) {
     final String testSuite = description.getClassName();
     final String testName = (testNameArg != null) ? testNameArg : description.getMethodName();
+    final long testFingerprint = MurmurHash2.hash64(testSuite + "." + testName);
 
     span.setTag(DDTags.RESOURCE_NAME, testSuite + "." + testName);
     span.setTag(Tags.TEST_SUITE, testSuite);
     span.setTag(Tags.TEST_NAME, testName);
+    span.setTag(Tags.TEST_FINGERPRINT, testFingerprint);
+
     // We cannot set TEST_PASS status in onTestFinish(...) method because that method
     // is executed always after onTestFailure. For that reason, TEST_PASS status is preset
     // in onTestStart.

--- a/dd-java-agent/instrumentation/junit-5.3/src/main/java8/datadog/trace/instrumentation/junit5/JUnit5Decorator.java
+++ b/dd-java-agent/instrumentation/junit-5.3/src/main/java8/datadog/trace/instrumentation/junit5/JUnit5Decorator.java
@@ -4,6 +4,7 @@ import datadog.trace.api.DDTags;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.decorator.TestDecorator;
+import datadog.trace.util.MurmurHash2;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.support.descriptor.MethodSource;
@@ -36,6 +37,7 @@ public class JUnit5Decorator extends TestDecorator {
     span.setTag(DDTags.RESOURCE_NAME, testSuite + "." + testName);
     span.setTag(Tags.TEST_SUITE, testSuite);
     span.setTag(Tags.TEST_NAME, testName);
+    span.setTag(Tags.TEST_FINGERPRINT, MurmurHash2.hash64(testSuite + "." + testName));
     span.setTag(Tags.TEST_STATUS, TEST_PASS);
   }
 

--- a/dd-java-agent/instrumentation/testng-6.4/src/main/java/datadog/trace/instrumentation/testng/TestNGDecorator.java
+++ b/dd-java-agent/instrumentation/testng-6.4/src/main/java/datadog/trace/instrumentation/testng/TestNGDecorator.java
@@ -4,6 +4,7 @@ import datadog.trace.api.DDTags;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.decorator.TestDecorator;
+import datadog.trace.util.MurmurHash2;
 import lombok.extern.slf4j.Slf4j;
 import org.testng.ITestResult;
 
@@ -34,6 +35,7 @@ public class TestNGDecorator extends TestDecorator {
     span.setTag(DDTags.RESOURCE_NAME, testSuite + "." + testName);
     span.setTag(Tags.TEST_SUITE, testSuite);
     span.setTag(Tags.TEST_NAME, testName);
+    span.setTag(Tags.TEST_FINGERPRINT, MurmurHash2.hash64(testSuite + "." + testName));
   }
 
   public void onTestSuccess(final AgentSpan span) {

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/TestFrameworkTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/TestFrameworkTest.groovy
@@ -5,6 +5,7 @@ import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.bootstrap.instrumentation.decorator.TestDecorator
+import datadog.trace.util.MurmurHash2
 import spock.lang.Shared
 import spock.lang.Unroll
 
@@ -35,6 +36,7 @@ abstract class TestFrameworkTest extends AgentTestRunner {
         "$Tags.TEST_NAME" testName
         "$Tags.TEST_FRAMEWORK" testFramework
         "$Tags.TEST_STATUS" testStatus
+        "$Tags.TEST_FINGERPRINT" MurmurHash2.hash64("$testSuite.$testName")
         if (testTags) {
           testTags.each { key, val -> tag(key, val) }
         }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/Tags.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/Tags.java
@@ -34,6 +34,7 @@ public class Tags {
   public static final String TEST_SKIP_REASON = "test.skip_reason";
   public static final String TEST_TYPE = "test.type";
   public static final String TEST_ARGUMENTS = "test.arguments";
+  public static final String TEST_FINGERPRINT = "test.fingerprint";
 
   public static final String CI_PROVIDER_NAME = "ci.provider.name";
   public static final String CI_PIPELINE_ID = "ci.pipeline.id";

--- a/internal-api/src/main/java/datadog/trace/util/MurmurHash2.java
+++ b/internal-api/src/main/java/datadog/trace/util/MurmurHash2.java
@@ -1,0 +1,161 @@
+package datadog.trace.util;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Implementation of the MurmurHash2 64-bit hash functions adapted from
+ * https://github.com/apache/commons-codec/blob/master/src/main/java/org/apache/commons/codec/digest/MurmurHash2.java
+ */
+public final class MurmurHash2 {
+
+  // Constants for 64-bit variant
+  private static final long M64 = 0xc6a4a7935bd1e995L;
+  private static final int R64 = 47;
+
+  /** No instance methods. */
+  private MurmurHash2() {}
+
+  /**
+   * Generates a 64-bit hash from byte array of the given length and seed.
+   *
+   * @param data The input byte array
+   * @param length The length of the array
+   * @param seed The initial seed value
+   * @return The 64-bit hash of the given array
+   */
+  public static long hash64(final byte[] data, final int length, final int seed) {
+    long h = (seed & 0xffffffffL) ^ (length * M64);
+
+    final int nblocks = length >> 3;
+
+    // body
+    for (int i = 0; i < nblocks; i++) {
+      final int index = (i << 3);
+      long k = getLittleEndianLong(data, index);
+
+      k *= M64;
+      k ^= k >>> R64;
+      k *= M64;
+
+      h ^= k;
+      h *= M64;
+    }
+
+    final int index = (nblocks << 3);
+    switch (length - index) {
+      case 7:
+        h ^= ((long) data[index + 6] & 0xff) << 48;
+      case 6:
+        h ^= ((long) data[index + 5] & 0xff) << 40;
+      case 5:
+        h ^= ((long) data[index + 4] & 0xff) << 32;
+      case 4:
+        h ^= ((long) data[index + 3] & 0xff) << 24;
+      case 3:
+        h ^= ((long) data[index + 2] & 0xff) << 16;
+      case 2:
+        h ^= ((long) data[index + 1] & 0xff) << 8;
+      case 1:
+        h ^= ((long) data[index] & 0xff);
+        h *= M64;
+    }
+
+    h ^= h >>> R64;
+    h *= M64;
+    h ^= h >>> R64;
+
+    return h;
+  }
+
+  /**
+   * Generates a 64-bit hash from byte array with given length and a default seed value. This is a
+   * helper method that will produce the same result as:
+   *
+   * <pre>
+   * int seed = 0xe17a1465;
+   * int hash = MurmurHash2.hash64(data, length, seed);
+   * </pre>
+   *
+   * @param data The input byte array
+   * @param length The length of the array
+   * @return The 64-bit hash
+   * @see #hash64(byte[], int, int)
+   */
+  public static long hash64(final byte[] data, final int length) {
+    return hash64(data, length, 0xe17a1465);
+  }
+
+  /**
+   * Generates a 64-bit hash from a string with a default seed.
+   *
+   * <p>Before 1.14 the string was converted using default encoding. Since 1.14 the string is
+   * converted to bytes using UTF-8 encoding. This is a helper method that will produce the same
+   * result as:
+   *
+   * <pre>
+   * int seed = 0xe17a1465;
+   * byte[] bytes = data.getBytes(StandardCharsets.UTF_8);
+   * int hash = MurmurHash2.hash64(bytes, bytes.length, seed);
+   * </pre>
+   *
+   * @param text The input string
+   * @return The 64-bit hash
+   * @see #hash64(byte[], int, int)
+   */
+  public static long hash64(final String text) {
+    final byte[] bytes = Strings.getBytes(text, StandardCharsets.UTF_8);
+    return hash64(bytes, bytes.length);
+  }
+
+  /**
+   * Generates a 64-bit hash from a substring with a default seed value. The string is converted to
+   * bytes using the default encoding. This is a helper method that will produce the same result as:
+   *
+   * <pre>
+   * int seed = 0xe17a1465;
+   * byte[] bytes = text.substring(from, from + length).getBytes(StandardCharsets.UTF_8);
+   * int hash = MurmurHash2.hash64(bytes, bytes.length, seed);
+   * </pre>
+   *
+   * @param text The The input string
+   * @param from The starting index
+   * @param length The length of the substring
+   * @return The 64-bit hash
+   * @see #hash64(byte[], int, int)
+   */
+  public static long hash64(final String text, final int from, final int length) {
+    return hash64(text.substring(from, from + length));
+  }
+
+  /**
+   * Gets the little-endian int from 4 bytes starting at the specified index.
+   *
+   * @param data The data
+   * @param index The index
+   * @return The little-endian int
+   */
+  private static int getLittleEndianInt(final byte[] data, final int index) {
+    return ((data[index] & 0xff))
+        | ((data[index + 1] & 0xff) << 8)
+        | ((data[index + 2] & 0xff) << 16)
+        | ((data[index + 3] & 0xff) << 24);
+  }
+
+  /**
+   * Gets the little-endian long from 8 bytes starting at the specified index.
+   *
+   * @param data The data
+   * @param index The index
+   * @return The little-endian long
+   */
+  private static long getLittleEndianLong(final byte[] data, final int index) {
+    return (((long) data[index] & 0xff))
+        | (((long) data[index + 1] & 0xff) << 8)
+        | (((long) data[index + 2] & 0xff) << 16)
+        | (((long) data[index + 3] & 0xff) << 24)
+        | (((long) data[index + 4] & 0xff) << 32)
+        | (((long) data[index + 5] & 0xff) << 40)
+        | (((long) data[index + 6] & 0xff) << 48)
+        | (((long) data[index + 7] & 0xff) << 56);
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/util/Strings.java
+++ b/internal-api/src/main/java/datadog/trace/util/Strings.java
@@ -1,10 +1,13 @@
 package datadog.trace.util;
 
+import java.nio.charset.Charset;
+
 public final class Strings {
 
-  public static String join(CharSequence joiner, Iterable<? extends CharSequence> strings) {
-    StringBuilder sb = new StringBuilder();
-    for (CharSequence string : strings) {
+  public static String join(
+      final CharSequence joiner, final Iterable<? extends CharSequence> strings) {
+    final StringBuilder sb = new StringBuilder();
+    for (final CharSequence string : strings) {
       sb.append(string).append(joiner);
     }
     // truncate to remove the last joiner
@@ -14,9 +17,9 @@ public final class Strings {
     return sb.toString();
   }
 
-  public static String join(CharSequence joiner, CharSequence... strings) {
+  public static String join(final CharSequence joiner, final CharSequence... strings) {
     if (strings.length > 0) {
-      StringBuilder sb = new StringBuilder();
+      final StringBuilder sb = new StringBuilder();
       sb.append(strings[0]);
       for (int i = 1; i < strings.length; ++i) {
         sb.append(joiner).append(strings[i]);
@@ -24,5 +27,12 @@ public final class Strings {
       return sb.toString();
     }
     return "";
+  }
+
+  public static byte[] getBytes(final String string, final Charset charset) {
+    if (string == null) {
+      return null;
+    }
+    return string.getBytes(charset);
   }
 }

--- a/internal-api/src/test/groovy/datadog/trace/util/StringsTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/util/StringsTest.groovy
@@ -2,6 +2,8 @@ package datadog.trace.util
 
 import datadog.trace.test.util.DDSpecification
 
+import java.nio.charset.StandardCharsets
+
 class StringsTest extends DDSpecification {
 
   def "test join strings"() {
@@ -30,4 +32,16 @@ class StringsTest extends DDSpecification {
     ","    | ["a"]           | "a"
     ","    | []              | ""
   }
+
+  def "test getBytes strings charset"() {
+    when:
+    byte[] s = Strings.getBytes(string, charset)
+    then:
+    s == expected
+    where:
+    string | charset                | expected
+    null   | StandardCharsets.UTF_8 | null
+    "a"    | StandardCharsets.UTF_8 | [97]
+  }
+
 }

--- a/internal-api/src/test/java/datadog/trace/util/MurmurHash2Test.java
+++ b/internal-api/src/test/java/datadog/trace/util/MurmurHash2Test.java
@@ -1,0 +1,277 @@
+package datadog.trace.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Adapted from
+ * https://github.com/apache/commons-codec/blob/master/src/test/java/org/apache/commons/codec/digest/MurmurHash2Test.java
+ */
+public class MurmurHash2Test {
+  /** Random input data with various length. */
+  static final byte[][] input = {
+    {
+      (byte) 0xed,
+      (byte) 0x53,
+      (byte) 0xc4,
+      (byte) 0xa5,
+      (byte) 0x3b,
+      (byte) 0x1b,
+      (byte) 0xbd,
+      (byte) 0xc2,
+      (byte) 0x52,
+      (byte) 0x7d,
+      (byte) 0xc3,
+      (byte) 0xef,
+      (byte) 0x53,
+      (byte) 0x5f,
+      (byte) 0xae,
+      (byte) 0x3b
+    },
+    {
+      (byte) 0x21,
+      (byte) 0x65,
+      (byte) 0x59,
+      (byte) 0x4e,
+      (byte) 0xd8,
+      (byte) 0x12,
+      (byte) 0xf9,
+      (byte) 0x05,
+      (byte) 0x80,
+      (byte) 0xe9,
+      (byte) 0x1e,
+      (byte) 0xed,
+      (byte) 0xe4,
+      (byte) 0x56,
+      (byte) 0xbb
+    },
+    {
+      (byte) 0x2b,
+      (byte) 0x02,
+      (byte) 0xb1,
+      (byte) 0xd0,
+      (byte) 0x3d,
+      (byte) 0xce,
+      (byte) 0x31,
+      (byte) 0x3d,
+      (byte) 0x97,
+      (byte) 0xc4,
+      (byte) 0x91,
+      (byte) 0x0d,
+      (byte) 0xf7,
+      (byte) 0x17
+    },
+    {
+      (byte) 0x8e,
+      (byte) 0xa7,
+      (byte) 0x9a,
+      (byte) 0x02,
+      (byte) 0xe8,
+      (byte) 0xb9,
+      (byte) 0x6a,
+      (byte) 0xda,
+      (byte) 0x92,
+      (byte) 0xad,
+      (byte) 0xe9,
+      (byte) 0x2d,
+      (byte) 0x21
+    },
+    {
+      (byte) 0xa9,
+      (byte) 0x6d,
+      (byte) 0xea,
+      (byte) 0x77,
+      (byte) 0x06,
+      (byte) 0xce,
+      (byte) 0x1b,
+      (byte) 0x85,
+      (byte) 0x48,
+      (byte) 0x27,
+      (byte) 0x4c,
+      (byte) 0xfe
+    },
+    {
+      (byte) 0xec,
+      (byte) 0x93,
+      (byte) 0xa0,
+      (byte) 0x12,
+      (byte) 0x60,
+      (byte) 0xee,
+      (byte) 0xc8,
+      (byte) 0x0a,
+      (byte) 0xc5,
+      (byte) 0x90,
+      (byte) 0x62
+    },
+    {
+      (byte) 0x55,
+      (byte) 0x6d,
+      (byte) 0x93,
+      (byte) 0x66,
+      (byte) 0x14,
+      (byte) 0x6d,
+      (byte) 0xdf,
+      (byte) 0x00,
+      (byte) 0x58,
+      (byte) 0x99
+    },
+    {
+      (byte) 0x3c,
+      (byte) 0x72,
+      (byte) 0x20,
+      (byte) 0x1f,
+      (byte) 0xd2,
+      (byte) 0x59,
+      (byte) 0x19,
+      (byte) 0xdb,
+      (byte) 0xa1
+    },
+    {
+      (byte) 0x23,
+      (byte) 0xa8,
+      (byte) 0xb1,
+      (byte) 0x87,
+      (byte) 0x55,
+      (byte) 0xf7,
+      (byte) 0x8a,
+      (byte) 0x4b,
+    },
+    {(byte) 0xe2, (byte) 0x42, (byte) 0x1c, (byte) 0x2d, (byte) 0xc1, (byte) 0xe4, (byte) 0x3e},
+    {(byte) 0x66, (byte) 0xa6, (byte) 0xb5, (byte) 0x5a, (byte) 0x74, (byte) 0xd9},
+    {(byte) 0xe8, (byte) 0x76, (byte) 0xa8, (byte) 0x90, (byte) 0x76},
+    {(byte) 0xeb, (byte) 0x25, (byte) 0x3f, (byte) 0x87},
+    {(byte) 0x37, (byte) 0xa0, (byte) 0xa9},
+    {(byte) 0x5b, (byte) 0x5d},
+    {(byte) 0x7e},
+    {}
+  };
+
+  /*
+   * Expected results - from the original C implementation.
+   */
+
+  /** Murmur 32bit hash results, default library seed. */
+  static final int[] results32_standard = {
+    0x96814fb3,
+    0x485dcaba,
+    0x331dc4ae,
+    0xc6a7bf2f,
+    0xcdf35de0,
+    0xd9dec7cc,
+    0x63a7318a,
+    0xd0d3c2de,
+    0x90923aef,
+    0xaf35c1e2,
+    0x735377b2,
+    0x366c98f3,
+    0x9c48ee29,
+    0x0b615790,
+    0xb4308ac1,
+    0xec98125a,
+    0x106e08d9
+  };
+
+  /** Murmur 32bit hash results, special test seed. */
+  static final int[] results32_seed = {
+    0xd92e493e,
+    0x8b50903b,
+    0xc3372a7b,
+    0x48f07e9e,
+    0x8a5e4a6e,
+    0x57916df4,
+    0xa346171f,
+    0x1e319c86,
+    0x9e1a03cd,
+    0x9f973e6c,
+    0x2d8c77f5,
+    0xabed8751,
+    0x296708b6,
+    0x24f8078b,
+    0x111b1553,
+    0xa7da1996,
+    0xfe776c70
+  };
+
+  /** Murmur 64bit hash results, default library seed. */
+  static final long[] results64_standard = {
+    0x4987cb15118a83d9l,
+    0x28e2a79e3f0394d9l,
+    0x8f4600d786fc5c05l,
+    0xa09b27fea4b54af3l,
+    0x25f34447525bfd1el,
+    0x32fad4c21379c7bfl,
+    0x4b30b99a9d931921l,
+    0x4e5dab004f936cdbl,
+    0x06825c27bc96cf40l,
+    0xff4bf2f8a4823905l,
+    0x7f7e950c064e6367l,
+    0x821ade90caaa5889l,
+    0x6d28c915d791686al,
+    0x9c32649372163ba2l,
+    0xd66ae956c14d5212l,
+    0x38ed30ee5161200fl,
+    0x9bfae0a4e613fc3cl,
+  };
+
+  /** Murmur 64bit hash results, special test seed. */
+  static final long[] results64_seed = {
+    0x0822b1481a92e97bl,
+    0xf8a9223fef0822ddl,
+    0x4b49e56affae3a89l,
+    0xc970296e32e1d1c1l,
+    0xe2f9f88789f1b08fl,
+    0x2b0459d9b4c10c61l,
+    0x377e97ea9197ee89l,
+    0xd2ccad460751e0e7l,
+    0xff162ca8d6da8c47l,
+    0xf12e051405769857l,
+    0xdabba41293d5b035l,
+    0xacf326b0bb690d0el,
+    0x0617f431bc1a8e04l,
+    0x15b81f28d576e1b2l,
+    0x28c1fe59e4f8e5bal,
+    0x694dd315c9354ca9l,
+    0xa97052a8f088ae6cl
+  };
+
+  /** Dummy test text. */
+  static final String text = "Lorem ipsum dolor sit amet, consectetur adipisicing elit";
+
+  @Test
+  public void testHash64ByteArrayIntInt() {
+    for (int i = 0; i < input.length; i++) {
+      final long hash = MurmurHash2.hash64(input[i], input[i].length, 0x344d1f5c);
+      if (hash != results64_seed[i]) {
+        Assert.fail(
+            String.format(
+                "Unexpected hash64 result for example %d: 0x%016x instead of 0x%016x",
+                i, hash, results64_seed[i]));
+      }
+    }
+  }
+
+  @Test
+  public void testHash64ByteArrayInt() {
+    for (int i = 0; i < input.length; i++) {
+      final long hash = MurmurHash2.hash64(input[i], input[i].length);
+      if (hash != results64_standard[i]) {
+        Assert.fail(
+            String.format(
+                "Unexpected hash64 result for example %d: 0x%016x instead of 0x%016x",
+                i, hash, results64_standard[i]));
+      }
+    }
+  }
+
+  @Test
+  public void testHash64String() {
+    final long hash = MurmurHash2.hash64(text);
+    Assert.assertEquals(0x0920e0c1b7eeb261L, hash);
+  }
+
+  @Test
+  public void testHash64StringIntInt() {
+    final long hash = MurmurHash2.hash64(text, 2, text.length() - 4);
+    Assert.assertEquals(0xa8b33145194985a2L, hash);
+  }
+}

--- a/internal-api/src/test/java/datadog/trace/util/MurmurHash2Test.java
+++ b/internal-api/src/test/java/datadog/trace/util/MurmurHash2Test.java
@@ -150,48 +150,6 @@ public class MurmurHash2Test {
    * Expected results - from the original C implementation.
    */
 
-  /** Murmur 32bit hash results, default library seed. */
-  static final int[] results32_standard = {
-    0x96814fb3,
-    0x485dcaba,
-    0x331dc4ae,
-    0xc6a7bf2f,
-    0xcdf35de0,
-    0xd9dec7cc,
-    0x63a7318a,
-    0xd0d3c2de,
-    0x90923aef,
-    0xaf35c1e2,
-    0x735377b2,
-    0x366c98f3,
-    0x9c48ee29,
-    0x0b615790,
-    0xb4308ac1,
-    0xec98125a,
-    0x106e08d9
-  };
-
-  /** Murmur 32bit hash results, special test seed. */
-  static final int[] results32_seed = {
-    0xd92e493e,
-    0x8b50903b,
-    0xc3372a7b,
-    0x48f07e9e,
-    0x8a5e4a6e,
-    0x57916df4,
-    0xa346171f,
-    0x1e319c86,
-    0x9e1a03cd,
-    0x9f973e6c,
-    0x2d8c77f5,
-    0xabed8751,
-    0x296708b6,
-    0x24f8078b,
-    0x111b1553,
-    0xa7da1996,
-    0xfe776c70
-  };
-
   /** Murmur 64bit hash results, default library seed. */
   static final long[] results64_standard = {
     0x4987cb15118a83d9l,


### PR DESCRIPTION
This `PR` adds a `test.fingerprint` (long 64-bits) to the test instrumentations using `MurmurHash2` algorithm.
The `MurmurHash2` class has been adapted from https://github.com/apache/commons-codec/blob/master/src/main/java/org/apache/commons/codec/digest/MurmurHash2.java