### PR TITLE
bump JCTools version

### DIFF
--- a/dd-trace-core/dd-trace-core.gradle
+++ b/dd-trace-core/dd-trace-core.gradle
@@ -37,7 +37,7 @@ dependencies {
   compile group: 'org.hdrhistogram', name: 'HdrHistogram', version: '2.1.12'
   compile group: 'com.squareup.moshi', name: 'moshi', version: '1.9.2'
   compile group: 'com.github.jnr', name: 'jnr-unixsocket', version: "${versions.jnr_unixsocket}"
-  compile group: 'org.jctools', name: 'jctools-core', version: '3.1.0'
+  compile group: 'org.jctools', name: 'jctools-core', version: '3.2.0'
 
   // We have autoservices defined in test subtree, looks like we need this to be able to properly rebuild this
   testAnnotationProcessor deps.autoserviceProcessor


### PR DESCRIPTION
There are some counters in this version which are especially efficient when there are multiple threads performing updates