### PR TITLE
remove representative count tracking

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/DDAgentWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/DDAgentWriter.java
@@ -143,14 +143,12 @@ public class DDAgentWriter implements Writer {
   }
 
   private void handleDroppedTrace(final String reason, final List<DDSpan> trace) {
-    incrementTraceCount();
     log.debug("{}. Counted but dropping trace: {}", reason, trace);
     healthMetrics.onFailedPublish(UNSET);
   }
 
   private void handleDroppedTrace(
       final String reason, final List<DDSpan> trace, final int samplingPriority) {
-    incrementTraceCount();
     log.debug("{}. Counted but dropping trace: {}", reason, trace);
     healthMetrics.onFailedPublish(samplingPriority);
   }
@@ -163,11 +161,6 @@ public class DDAgentWriter implements Writer {
       }
     }
     return false;
-  }
-
-  @Override
-  public void incrementTraceCount() {
-    dispatcher.onTraceDropped();
   }
 
   public DDAgentApi getApi() {
@@ -189,4 +182,7 @@ public class DDAgentWriter implements Writer {
     traceProcessingWorker.close();
     healthMetrics.onShutdown(flushed);
   }
+
+  @Override
+  public void incrementTraceCount() {}
 }

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/LoggingWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/LoggingWriter.java
@@ -29,11 +29,6 @@ public class LoggingWriter implements Writer {
   }
 
   @Override
-  public void incrementTraceCount() {
-    log.info("incrementTraceCount()");
-  }
-
-  @Override
   public void start() {
     log.info("start()");
   }
@@ -48,6 +43,9 @@ public class LoggingWriter implements Writer {
   public void close() {
     log.info("close()");
   }
+
+  @Override
+  public void incrementTraceCount() {}
 
   @Override
   public String toString() {

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/PrintingWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/PrintingWriter.java
@@ -59,7 +59,5 @@ public class PrintingWriter implements Writer {
   }
 
   @Override
-  public void incrementTraceCount() {
-    // do nothing
-  }
+  public void incrementTraceCount() {}
 }

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/Payload.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/Payload.java
@@ -7,14 +7,8 @@ import okhttp3.RequestBody;
 
 public abstract class Payload {
 
-  private int representativeCount = 0;
   private int traceCount = 0;
   protected ByteBuffer body;
-
-  public Payload withRepresentativeCount(int representativeCount) {
-    this.representativeCount = representativeCount;
-    return this;
-  }
 
   public Payload withBody(int traceCount, ByteBuffer body) {
     this.traceCount = traceCount;
@@ -24,10 +18,6 @@ public abstract class Payload {
 
   int traceCount() {
     return traceCount;
-  }
-
-  int representativeCount() {
-    return representativeCount;
   }
 
   abstract int sizeInBytes();

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreSpan.java
@@ -74,4 +74,6 @@ public interface CoreSpan<T extends CoreSpan<T>> {
   T setMetric(CharSequence name, double value);
 
   T setFlag(CharSequence name, boolean value);
+
+  int samplingPriority();
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -446,7 +446,11 @@ public class CoreTracer implements AgentTracer.TracerAPI {
       if (sampler.sample(spanToSample)) {
         writer.write(writtenTrace);
       } else {
-        incrementTraceCount();
+        // with span streaming this won't work - it needs to be changed
+        // to track an effective sampling rate instead, however, tests
+        // checking that a hard reference on a continuation prevents
+        // reporting fail without this, so will need to be fixed first.
+        writer.incrementTraceCount();
       }
     }
   }
@@ -463,11 +467,6 @@ public class CoreTracer implements AgentTracer.TracerAPI {
 
       ((PrioritySampler<DDSpan>) sampler).setSamplingPriority(rootSpan);
     }
-  }
-
-  /** Increment the reported trace count, but do not write a trace. */
-  void incrementTraceCount() {
-    writer.incrementTraceCount();
   }
 
   @Override

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -392,6 +392,11 @@ public class DDSpan implements AgentSpan, CoreSpan<DDSpan> {
   }
 
   @Override
+  public int samplingPriority() {
+    return context.getSamplingPriority();
+  }
+
+  @Override
   public String getSpanType() {
     final CharSequence spanType = context.getSpanType();
     return null == spanType ? null : spanType.toString();

--- a/dd-trace-core/src/main/java/datadog/trace/core/monitor/HealthMetrics.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/monitor/HealthMetrics.java
@@ -98,19 +98,19 @@ public class HealthMetrics {
   }
 
   public void onSend(
-      final int representativeCount, final int sizeInBytes, final DDAgentApi.Response response) {
-    onSendAttempt(representativeCount, sizeInBytes, response);
+      final int traceCount, final int sizeInBytes, final DDAgentApi.Response response) {
+    onSendAttempt(traceCount, sizeInBytes, response);
   }
 
   public void onFailedSend(
-      final int representativeCount, final int sizeInBytes, final DDAgentApi.Response response) {
-    onSendAttempt(representativeCount, sizeInBytes, response);
+      final int traceCount, final int sizeInBytes, final DDAgentApi.Response response) {
+    onSendAttempt(traceCount, sizeInBytes, response);
   }
 
   private void onSendAttempt(
-      final int representativeCount, final int sizeInBytes, final DDAgentApi.Response response) {
+      final int traceCount, final int sizeInBytes, final DDAgentApi.Response response) {
     statsd.incrementCounter("api.requests.total", NO_TAGS);
-    statsd.count("flush.traces.total", representativeCount, NO_TAGS);
+    statsd.count("flush.traces.total", traceCount, NO_TAGS);
     // TODO: missing queue.spans (# of spans being sent)
     statsd.count("flush.bytes.total", sizeInBytes, NO_TAGS);
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SimpleSpan.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SimpleSpan.groovy
@@ -208,4 +208,9 @@ class SimpleSpan implements CoreSpan<SimpleSpan> {
   SimpleSpan setFlag(CharSequence name, boolean value) {
     return this
   }
+
+  @Override
+  int samplingPriority() {
+    return 0
+  }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentApiTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentApiTest.groovy
@@ -385,18 +385,15 @@ class DDAgentApiTest extends DDSpecification {
     packer.flush()
     return traceMapper.newPayload()
       .withBody(traceCapture.traceCount, traceCapture.buffer)
-      .withRepresentativeCount(traceCapture.representativeCount)
   }
 
   static class Traces implements ByteBufferConsumer {
     int traceCount
-    int representativeCount
     ByteBuffer buffer
 
     @Override
     void accept(int messageCount, ByteBuffer buffer) {
       this.buffer = buffer
-      this.representativeCount = messageCount
       this.traceCount = messageCount
     }
   }

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterCombinedTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterCombinedTest.groovy
@@ -94,7 +94,7 @@ class DDAgentWriterCombinedTest extends DDSpecification {
     then:
     1 * api.detectEndpointAndBuildClient() >> agentVersion
     1 * api.selectTraceMapper() >> { callRealMethod() }
-    1 * api.sendSerializedTraces({ it.traceCount() == 2 && it.representativeCount() == 2 }) >> DDAgentApi.Response.success(200)
+    1 * api.sendSerializedTraces({ it.traceCount() == 2 }) >> DDAgentApi.Response.success(200)
     0 * _
 
     cleanup:
@@ -125,7 +125,7 @@ class DDAgentWriterCombinedTest extends DDSpecification {
     then:
     1 * api.detectEndpointAndBuildClient() >> agentVersion
     1 * api.selectTraceMapper() >> { callRealMethod() }
-    1 * api.sendSerializedTraces({ it.traceCount() <= traceCount && it.representativeCount() <= traceCount }) >> DDAgentApi.Response.success(200)
+    1 * api.sendSerializedTraces({ it.traceCount() <= traceCount }) >> DDAgentApi.Response.success(200)
     0 * _
 
     cleanup:
@@ -159,7 +159,7 @@ class DDAgentWriterCombinedTest extends DDSpecification {
     1 * api.detectEndpointAndBuildClient() >> agentVersion
     1 * api.selectTraceMapper() >> { callRealMethod() }
     1 * healthMetrics.onSerialize(_)
-    1 * api.sendSerializedTraces({ it.traceCount() == 5 && it.representativeCount() == 5 }) >> DDAgentApi.Response.success(200)
+    1 * api.sendSerializedTraces({ it.traceCount() == 5 }) >> DDAgentApi.Response.success(200)
     _ * healthMetrics.onPublish(_, _)
     1 * healthMetrics.onSend(_, _, _) >> {
       phaser.arrive()
@@ -204,8 +204,8 @@ class DDAgentWriterCombinedTest extends DDSpecification {
     then:
     1 * api.detectEndpointAndBuildClient() >> agentVersion
     1 * api.selectTraceMapper() >> { callRealMethod() }
-    1 * api.sendSerializedTraces({ it.traceCount() == maxedPayloadTraceCount && it.representativeCount() == maxedPayloadTraceCount }) >> DDAgentApi.Response.success(200)
-    1 * api.sendSerializedTraces({ it.traceCount() == 1 && it.representativeCount() == 1 }) >> DDAgentApi.Response.success(200)
+    1 * api.sendSerializedTraces({ it.traceCount() == maxedPayloadTraceCount }) >> DDAgentApi.Response.success(200)
+    1 * api.sendSerializedTraces({ it.traceCount() == 1 }) >> DDAgentApi.Response.success(200)
     0 * _
 
     cleanup:

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddagent/TraceGenerator.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddagent/TraceGenerator.groovy
@@ -308,6 +308,11 @@ class TraceGenerator {
     }
 
     @Override
+    int samplingPriority() {
+      return 0
+    }
+
+    @Override
     <U> U getTag(CharSequence name, U defaultValue) {
       return tags.get(String.valueOf(name), defaultValue) as U
     }

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddagent/TraceMapperRealAgentTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddagent/TraceMapperRealAgentTest.groovy
@@ -37,6 +37,7 @@ class TraceMapperRealAgentTest extends DDSpecification {
     0 * healthMetrics.onFailedSend(_, _, _)
     _ * healthMetrics.onSend(_, _, _)
     _ * healthMetrics.onSerialize(_)
+    _ * healthMetrics.onFailedPublish(_)
     0 * _
 
     where:

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/monitor/HealthMetricsTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/monitor/HealthMetricsTest.groovy
@@ -109,11 +109,11 @@ class HealthMetricsTest extends DDSpecification {
 
   def "test onSend"() {
     when:
-    healthMetrics.onSend(representativeCount, sendSize, response)
+    healthMetrics.onSend(traceCount, sendSize, response)
 
     then:
     1 * statsD.incrementCounter('api.requests.total')
-    1 * statsD.count('flush.traces.total', representativeCount)
+    1 * statsD.count('flush.traces.total', traceCount)
     1 * statsD.count('flush.bytes.total', sendSize)
     if (response.exception()) {
       1 * statsD.incrementCounter('api.errors.total')
@@ -131,17 +131,17 @@ class HealthMetricsTest extends DDSpecification {
       DDAgentApi.Response.failed(new Throwable()),
     ]
 
-    representativeCount = ThreadLocalRandom.current().nextInt(1, 100)
+    traceCount = ThreadLocalRandom.current().nextInt(1, 100)
     sendSize = ThreadLocalRandom.current().nextInt(1, 100)
   }
 
   def "test onFailedSend"() {
     when:
-    healthMetrics.onFailedSend(representativeCount, sendSize, response)
+    healthMetrics.onFailedSend(traceCount, sendSize, response)
 
     then:
     1 * statsD.incrementCounter('api.requests.total')
-    1 * statsD.count('flush.traces.total', representativeCount)
+    1 * statsD.count('flush.traces.total', traceCount)
     1 * statsD.count('flush.bytes.total', sendSize)
     if (response.exception()) {
       1 * statsD.incrementCounter('api.errors.total')
@@ -159,7 +159,7 @@ class HealthMetricsTest extends DDSpecification {
       DDAgentApi.Response.failed(new Throwable()),
     ]
 
-    representativeCount = ThreadLocalRandom.current().nextInt(1, 100)
+    traceCount = ThreadLocalRandom.current().nextInt(1, 100)
     sendSize = ThreadLocalRandom.current().nextInt(1, 100)
   }
 }

--- a/dd-trace-core/src/traceAgentTest/groovy/DDApiIntegrationTest.groovy
+++ b/dd-trace-core/src/traceAgentTest/groovy/DDApiIntegrationTest.groovy
@@ -185,13 +185,11 @@ class DDApiIntegrationTest extends DDSpecification {
 
   static class Traces implements ByteBufferConsumer {
     int traceCount
-    int representativeCount
     ByteBuffer buffer
 
     @Override
     void accept(int messageCount, ByteBuffer buffer) {
       this.buffer = buffer
-      this.representativeCount = messageCount
       this.traceCount = messageCount
     }
   }
@@ -206,6 +204,5 @@ class DDApiIntegrationTest extends DDSpecification {
     packer.flush()
     return traceMapper.newPayload()
       .withBody(traceCapture.traceCount, traceCapture.buffer)
-      .withRepresentativeCount(traceCapture.representativeCount)
   }
 }


### PR DESCRIPTION
We go to great lengths to track the number of traces dropped in order to maintain a "representative count" which we send to the trace agent as an HTTP header... where it apparently serves no purpose! This PR removes this and results in simpler code, and we lose an atomic. We report dropped traces via statsd anyway.

/cc @gbbr 