### PR TITLE
Delay starting metric aggregation, reduce DDSketch relative accuracy, pick up changes from sketches-java 0.5.0

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/AggregateMetric.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/AggregateMetric.java
@@ -9,14 +9,14 @@ public final class AggregateMetric {
 
   private static final HistogramFactory HISTOGRAM_FACTORY = Histograms.newHistogramFactory();
 
-  private Histogram latencies;
+  private Histogram hitLatencies;
   private Histogram errorLatencies;
   private int errorCount;
   private int hitCount;
   private long duration;
 
   public AggregateMetric() {
-    latencies = HISTOGRAM_FACTORY.newHistogram();
+    hitLatencies = HISTOGRAM_FACTORY.newHistogram();
     errorLatencies = HISTOGRAM_FACTORY.newHistogram();
   }
 
@@ -37,7 +37,7 @@ public final class AggregateMetric {
       if (((errorMask >>> i) & 1) == 1) {
         errorLatencies.accept(duration);
       } else {
-        latencies.accept(duration);
+        hitLatencies.accept(duration);
       }
       ++i;
     }
@@ -56,8 +56,8 @@ public final class AggregateMetric {
     return duration;
   }
 
-  public byte[] getLatencies() {
-    return latencies.serialize();
+  public byte[] getHitLatencies() {
+    return hitLatencies.serialize();
   }
 
   public byte[] getErrorLatencies() {
@@ -68,8 +68,7 @@ public final class AggregateMetric {
     this.errorCount = 0;
     this.hitCount = 0;
     this.duration = 0;
-    // TODO add ability to clear histogram in DDSketch
-    this.latencies = HISTOGRAM_FACTORY.newHistogram();
-    this.errorLatencies = HISTOGRAM_FACTORY.newHistogram();
+    this.hitLatencies.clear();
+    this.errorLatencies.clear();
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/SerializingMetricWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/SerializingMetricWriter.java
@@ -102,7 +102,7 @@ public final class SerializingMetricWriter implements MetricWriter {
     writer.writeLong(aggregate.getDuration());
 
     writer.writeUTF8(HITS_SUMMARY);
-    writer.writeBinary(aggregate.getLatencies());
+    writer.writeBinary(aggregate.getHitLatencies());
 
     writer.writeUTF8(ERROR_SUMMARY);
     writer.writeBinary(aggregate.getErrorLatencies());

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SerializingMetricWriterTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SerializingMetricWriterTest.groovy
@@ -137,7 +137,7 @@ class SerializingMetricWriterTest extends DDSpecification {
       if (Platform.isJavaVersionAtLeast(8)) {
         int length = unpacker.unpackBinaryHeader()
         assert length > 0
-        unpacker.skipValue(length)
+        unpacker.readPayload(length)
       } else {
         unpacker.skipValue()
       }

--- a/utils/histograms/histograms.gradle
+++ b/utils/histograms/histograms.gradle
@@ -16,7 +16,7 @@ dependencies {
 
   // currently required to serialize DDSketch
   compile group: 'com.google.protobuf', name: 'protobuf-java', version: '3.14.0'
-  compile group: 'com.datadoghq', name: 'sketches-java', version: '0.4.1'
+  compile group: 'com.datadoghq', name: 'sketches-java', version: '0.5.0'
 
   testCompile project(':utils:test-utils')
 }

--- a/utils/histograms/src/main/java/datadog/trace/core/histogram/DDSketchHistogram.java
+++ b/utils/histograms/src/main/java/datadog/trace/core/histogram/DDSketchHistogram.java
@@ -1,18 +1,25 @@
 package datadog.trace.core.histogram;
 
 import com.datadoghq.sketch.ddsketch.DDSketch;
+import com.datadoghq.sketch.ddsketch.mapping.CubicallyInterpolatedMapping;
+import com.datadoghq.sketch.ddsketch.store.PaginatedStore;
 
 public class DDSketchHistogram implements Histogram, HistogramFactory {
 
   private final DDSketch sketch;
 
   public DDSketchHistogram() {
-    this.sketch = DDSketch.balancedCollapsingLowest(0.01, 1024);
+    this.sketch = new DDSketch(new CubicallyInterpolatedMapping(0.1), PaginatedStore::new);
   }
 
   @Override
   public void accept(long value) {
     sketch.accept(value);
+  }
+
+  @Override
+  public void clear() {
+    this.sketch.clear();
   }
 
   @Override

--- a/utils/histograms/src/main/java/datadog/trace/core/histogram/Histogram.java
+++ b/utils/histograms/src/main/java/datadog/trace/core/histogram/Histogram.java
@@ -4,5 +4,7 @@ public interface Histogram {
 
   void accept(long value);
 
+  void clear();
+
   byte[] serialize();
 }

--- a/utils/histograms/src/main/java/datadog/trace/core/histogram/StubHistogram.java
+++ b/utils/histograms/src/main/java/datadog/trace/core/histogram/StubHistogram.java
@@ -7,6 +7,9 @@ public class StubHistogram implements Histogram, HistogramFactory {
   public void accept(long value) {}
 
   @Override
+  public void clear() {}
+
+  @Override
   public byte[] serialize() {
     return EMPTY;
   }


### PR DESCRIPTION
This makes a few changes
* Add a random delay to starting metrics, to stop applications starting at the same time synchronising. 
* Update the DDSketch library, which now has a more memory efficient storage implementation, and a method to clear sketches, so they don't need to be reallocated
* Reduce the relative accuracy of the sketch - we are recording latencies accurate to at best microseconds in nanosecond units