### PR TITLE
remove unnecessary String.replaceAll

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Utils.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Utils.java
@@ -50,12 +50,15 @@ public class Utils {
 
   /** com/foo/Bar.class -> com.foo.Bar */
   public static String getClassName(final String resourceName) {
-    return resourceName.replaceAll("\\.class\\$", "").replace('/', '.');
+    if (resourceName.endsWith(".class")) {
+      return resourceName.substring(0, resourceName.length() - 6).replace('/', '.');
+    }
+    return resourceName.replace('/', '.');
   }
 
   /** com.foo.Bar -> com/foo/Bar */
   public static String getInternalName(final String resourceName) {
-    return resourceName.replaceAll("\\.class\\$", "").replace('.', '/');
+    return resourceName.replace('.', '/');
   }
 
   /**
@@ -65,8 +68,8 @@ public class Utils {
    * @param className class named to be converted
    * @return convertd name
    */
-  public static String converToInnerClassName(final String className) {
-    return className.replaceAll("\\.", "\\$");
+  public static String getInnerClassName(final String className) {
+    return className.replace('.', '$');
   }
 
   /**

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/context/ContextStoreUtils.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/context/ContextStoreUtils.java
@@ -87,9 +87,9 @@ final class ContextStoreUtils {
     return DYNAMIC_CLASSES_PACKAGE
         + FieldBackedProvider.class.getSimpleName()
         + "$ContextStore$"
-        + Utils.converToInnerClassName(keyClassName)
+        + Utils.getInnerClassName(keyClassName)
         + "$"
-        + Utils.converToInnerClassName(contextClassName);
+        + Utils.getInnerClassName(contextClassName);
   }
 
   static String getContextAccessorInterfaceName(
@@ -97,13 +97,13 @@ final class ContextStoreUtils {
     return DYNAMIC_CLASSES_PACKAGE
         + FieldBackedProvider.class.getSimpleName()
         + "$ContextAccessor$"
-        + Utils.converToInnerClassName(keyClassName)
+        + Utils.getInnerClassName(keyClassName)
         + "$"
-        + Utils.converToInnerClassName(contextClassName);
+        + Utils.getInnerClassName(contextClassName);
   }
 
   static String getContextFieldName(final String keyClassName) {
-    return "__datadogContext$" + Utils.converToInnerClassName(keyClassName);
+    return "__datadogContext$" + Utils.getInnerClassName(keyClassName);
   }
 
   static String getContextGetterName(final String keyClassName) {


### PR DESCRIPTION
We apparently spend roughly 1% of time in `Pattern.compile` during a startup benchmark which loads 1000 classes, and this accounts for nearly 4% of time in actually transforming classes. The `replaceAll` in `getInternalName` isn't actually required at all. `convertToInnerClassName` shows up in several other places during startup and should have been doing `char` replacements. The nearby `getClassName` is only used during the build but similar changes were made.