### PR TITLE
Support putting null contexts when falling back to weak-map

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/WeakMapTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/WeakMapTest.groovy
@@ -9,6 +9,14 @@ class WeakMapTest extends Specification {
 
   def weakMap = new WeakMap.MapAdapter<String, Integer>(new WeakHashMap<>())
 
+  def "Default WeakMap accepts null values"() {
+    when:
+    weakMap.put('key', null)
+
+    then:
+    noExceptionThrown()
+  }
+
   def "getOrCreate a value"() {
     when:
     def count = weakMap.computeIfAbsent('key', supplier)

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/WeakMapSuppliers.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/WeakMapSuppliers.java
@@ -84,7 +84,11 @@ class WeakMapSuppliers {
 
       @Override
       public void put(final K key, final V value) {
-        map.put(key, value);
+        if (null != value) {
+          map.put(key, value);
+        } else {
+          map.remove(key); // WeakConcurrentMap doesn't accept null values
+        }
       }
 
       @Override

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/WeakConcurrentSupplierTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/WeakConcurrentSupplierTest.groovy
@@ -17,6 +17,23 @@ class WeakConcurrentSupplierTest extends DDSpecification {
   @Shared
   def weakInlineSupplier = new WeakMapSuppliers.WeakConcurrent.Inline()
 
+  def "#name accepts null values"() {
+    setup:
+    WeakMap.Provider.provider.set(supplier)
+    def map = WeakMap.Provider.newWeakMap()
+
+    when:
+    map.put('key', null)
+
+    then:
+    noExceptionThrown()
+
+    where:
+    name             | supplier
+    "WeakConcurrent" | weakConcurrentSupplier
+    "WeakInline"     | weakInlineSupplier
+  }
+
   def "Calling newWeakMap on #name creates independent maps"() {
     setup:
     WeakMap.Provider.provider.set(supplier)


### PR DESCRIPTION
because some instrumentations put `null`s into their context-store and this matches field-inject behaviour

(noticed while running instrumentation tests with field-injection turned off)