### PR TITLE
remove entry from context store in servlet instrumentation

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
@@ -71,7 +71,7 @@ public abstract class HttpServerDecorator<REQUEST, CONNECTION, RESPONSE> extends
             }
           }
           final String path = url.path();
-          if (path.isEmpty()) {
+          if (null == path || path.isEmpty()) {
             urlNoParams.append("/");
           } else {
             if (!path.startsWith("/")) {

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/http/HttpServletResponseInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/http/HttpServletResponseInstrumentation.java
@@ -15,6 +15,7 @@ import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.DDTags;
 import datadog.trace.bootstrap.CallDepthThreadLocalMap;
+import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
@@ -72,11 +73,14 @@ public final class HttpServletResponseInstrumentation extends Instrumenter.Defau
         // Don't want to generate a new top-level span
         return null;
       }
-
-      if (InstrumentationContext.get(HttpServletResponse.class, Boolean.class).get(resp) == null) {
+      ContextStore<HttpServletResponse, Boolean> contextStore =
+          InstrumentationContext.get(HttpServletResponse.class, Boolean.class);
+      if (contextStore.get(resp) == null) {
         // Missing the response->request linking... probably in a wrapped instance.
         return null;
       }
+      // remove it now it's served its purpose in case it's hanging around in a weak map
+      contextStore.put(resp, null);
 
       final int callDepth = CallDepthThreadLocalMap.incrementCallDepth(HttpServletResponse.class);
       if (callDepth > 0) {


### PR DESCRIPTION
Up to and including 0.68.0, the servlet instrumentation associates `HttpServletResponse` with `HttpServletRequest` objects via field injection, so that it can be determined whether a response is the response associated with the incoming request or a wrapper. When field injection works, this is fine, but if it doesn't, a `WeakMap<HttpServletResponse, HttpServletRequest>` is populated, and isn't cleared out until GC events trigger reference processing, and if there are hard references to the `HttpServletResponse`, the map cannot be cleared out and will only grow, which results in a memory leak. 

Since 0.69.0, this has been mitigated in several ways:

* by reducing the size of what's stored in the map - we actually only need a boolean token, and not the much larger `HttpServletRequest` object (see #2102)
* by capping the size the weak map fallback can every grow to to 50k elements, meaning we degrade to incomplete instrumentation when the map grows, rather than excessive memory usage (see #2104)
* by making it possible to remove elements from the `WeakMap` fallback, making our internal API consistent with fully functional field injection (see #2131)
* this PR which removes the entry from the context store in the `HttpServletResponseInstrumentation` as soon as it has been used, in case the `WeakMap` fallback is in use, keeping the map small.