### PR TITLE
Simplify context store read check

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/context/ContextStoreReadsRewritingVisitor.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/context/ContextStoreReadsRewritingVisitor.java
@@ -110,17 +110,15 @@ final class ContextStoreReadsRewritingVisitor implements AsmVisitorWrapper {
               final String name,
               final String descriptor,
               final boolean isInterface) {
+            // Look for any calls to `InstrumentationContext.get(K.class, C.class)`
             if (Opcodes.INVOKESTATIC == opcode
                 && INSTRUMENTATION_CONTEXT_CLASS.equals(owner)
                 && GET_METHOD.equals(name)
                 && GET_METHOD_DESCRIPTOR.equals(descriptor)) {
               log.debug("Found context-store access in {}", instrumenterClassName);
-              /*
-              The idea here is that the rest if this method visitor collects last three instructions in `insnStack`
-              variable. Once we get here we check if those last three instructions constitute call that looks like
-              `InstrumentationContext.get(K.class, V.class)`. If it does the inside of this if rewrites it to call
-              dynamically injected context store implementation instead.
-               */
+              // We track the last two constants pushed onto the stack to make sure they match
+              // the expected key and context types. Matching calls are rewritten to call the
+              // dynamically injected context store implementation instead.
               if (constant1 instanceof Type && constant2 instanceof Type) {
                 final String keyClassName = ((Type) constant1).getClassName();
                 final String contextClassName = ((Type) constant2).getClassName();

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/context/ContextStoreReadsRewritingVisitor.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/context/ContextStoreReadsRewritingVisitor.java
@@ -93,13 +93,13 @@ final class ContextStoreReadsRewritingVisitor implements AsmVisitorWrapper {
         final MethodVisitor mv = super.visitMethod(access, name, descriptor, signature, exceptions);
         return new MethodVisitor(Opcodes.ASM7, mv) {
           /** The last two constants pushed onto the stack. */
-          private Object constant_1, constant_2;
+          private Object constant1, constant2;
 
           @Override
           public void visitLdcInsn(final Object value) {
             // 'first' constant gets moved over once 'second' one comes in
-            constant_1 = constant_2;
-            constant_2 = value;
+            constant1 = constant2;
+            constant2 = value;
             super.visitLdcInsn(value);
           }
 
@@ -121,9 +121,9 @@ final class ContextStoreReadsRewritingVisitor implements AsmVisitorWrapper {
               `InstrumentationContext.get(K.class, V.class)`. If it does the inside of this if rewrites it to call
               dynamically injected context store implementation instead.
                */
-              if (constant_1 instanceof Type && constant_2 instanceof Type) {
-                final String keyClassName = ((Type) constant_1).getClassName();
-                final String contextClassName = ((Type) constant_2).getClassName();
+              if (constant1 instanceof Type && constant2 instanceof Type) {
+                final String keyClassName = ((Type) constant1).getClassName();
+                final String contextClassName = ((Type) constant2).getClassName();
                 final TypeDescription contextStoreImplementationClass =
                     getContextStoreImplementation(keyClassName, contextClassName);
                 if (log.isDebugEnabled()) {
@@ -161,8 +161,8 @@ final class ContextStoreReadsRewritingVisitor implements AsmVisitorWrapper {
             }
 
             // reset constants for next method check
-            constant_1 = null;
-            constant_2 = null;
+            constant1 = null;
+            constant2 = null;
           }
         };
       }


### PR DESCRIPTION
The partial JVM simulation made this code more complex than it needed to be for the purposes of checking the last two constants loaded before the method invocation. Also replaced use of reflected method information with constants - this avoids repeated string transformations while still catching the necessary rewriting.