### PR TITLE
Restore check to avoid repeatedly adding the same context-store transformer

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/context/FieldBackedProvider.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/context/FieldBackedProvider.java
@@ -118,10 +118,10 @@ public final class FieldBackedProvider implements InstrumentationContextProvider
             }
           }
           synchronized (installedContextMatchers) {
-            if (installedContextMatchers.contains(entry)) {
+            if (!installedContextMatchers.add(entry)) {
               if (log.isDebugEnabled()) {
                 log.debug(
-                    "Skipping builder for {} with matcher {}: {} -> {}",
+                    "Skipping duplicate builder in {} for matcher {}: {} -> {}",
                     instrumenterName,
                     classLoaderMatcher,
                     entry.getKey(),


### PR DESCRIPTION
The current code checks a set to see if the context-store transformation for the classloader matcher has already been installed - but nothing updates this set, so it always applies the transformation.

The set update seems to have disappeared in https://github.com/DataDog/dd-trace-java/commit/ee4fecdad13216d480ecc6720c5eca7c488c636e#diff-63ba657f2e3bf6fda57f5e108775a3aa4d8171f14b735e786da4b41d4bbe663cL428

I assume this was an oversight so this PR puts that update back and combines it with the duplicate check.