### PR TITLE
Fix metrics aggregation

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/AggregateMetric.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/AggregateMetric.java
@@ -20,26 +20,17 @@ public final class AggregateMetric {
     errorLatencies = HISTOGRAM_FACTORY.newHistogram();
   }
 
-  public AggregateMetric addHits(int count) {
-    hitCount += count;
-    return this;
-  }
-
-  public AggregateMetric addErrors(int count) {
-    errorCount += count;
-    return this;
-  }
-
-  public AggregateMetric recordDurations(long errorMask, long... durations) {
-    int i = 0;
-    for (long duration : durations) {
+  public AggregateMetric recordDurations(int count, long errorMask, long... durations) {
+    this.hitCount += count;
+    this.errorCount += Long.bitCount(errorMask);
+    for (int i = 0; i < count && i < durations.length; ++i) {
+      long duration = durations[i];
       this.duration += duration;
       if (((errorMask >>> i) & 1) == 1) {
         errorLatencies.accept(duration);
       } else {
         hitLatencies.accept(duration);
       }
-      ++i;
     }
     return this;
   }

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/Batch.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/Batch.java
@@ -62,10 +62,7 @@ public final class Batch {
 
   public synchronized void contributeTo(AggregateMetric aggregate) {
     this.key = null;
-    aggregate
-        .addErrors(Long.bitCount(errorMask))
-        .addHits(count)
-        .recordDurations(errorMask, durations);
+    aggregate.recordDurations(count, errorMask, durations);
     clear();
   }
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SerializingMetricWriterTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SerializingMetricWriterTest.groovy
@@ -39,8 +39,8 @@ class SerializingMetricWriterTest extends DDSpecification {
     where:
     content << [
       [
-              Pair.of(new MetricKey("resource1", "service1", "operation1", "type", "", 0), new AggregateMetric().addHits(10).addErrors(1)),
-              Pair.of(new MetricKey("resource2", "service2", "operation2", "type2", "dbtype", 200), new AggregateMetric().addHits(9).addErrors(1))
+              Pair.of(new MetricKey("resource1", "service1", "operation1", "type", "", 0), new AggregateMetric().recordDurations(10, 1L)),
+              Pair.of(new MetricKey("resource2", "service2", "operation2", "type2", "dbtype", 200), new AggregateMetric().recordDurations(9, 1L))
       ]
     ]
   }


### PR DESCRIPTION
ignore trailing zeros in a batch. The fact I noticed this calls into question whether the conflation mechanism is effective.