### PR TITLE
improve string handling

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/ReferenceCreator.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/ReferenceCreator.java
@@ -81,13 +81,8 @@ public class ReferenceCreator extends ClassVisitor {
     return references;
   }
 
-  /**
-   * Get the package of an internal class name.
-   *
-   * <p>foo/bar/Baz -> foo/bar/
-   */
-  private static String internalPackageName(final String internalName) {
-    return internalName.replaceAll("/[^/]+$", "");
+  private static boolean samePackage(String from, String to) {
+    return from.regionMatches(0, to, 0, from.lastIndexOf('/') + 1);
   }
 
   /**
@@ -98,8 +93,7 @@ public class ReferenceCreator extends ClassVisitor {
   private static Reference.Flag computeMinimumClassAccess(final Type from, final Type to) {
     if (from.getInternalName().equalsIgnoreCase(to.getInternalName())) {
       return Reference.Flag.PRIVATE_OR_HIGHER;
-    } else if (internalPackageName(from.getInternalName())
-        .equals(internalPackageName(to.getInternalName()))) {
+    } else if (samePackage(from.getInternalName(), to.getInternalName())) {
       return Reference.Flag.PACKAGE_OR_HIGHER;
     } else {
       return Reference.Flag.PUBLIC;
@@ -114,8 +108,7 @@ public class ReferenceCreator extends ClassVisitor {
   private static Reference.Flag computeMinimumFieldAccess(final Type from, final Type to) {
     if (from.getInternalName().equalsIgnoreCase(to.getInternalName())) {
       return Reference.Flag.PRIVATE_OR_HIGHER;
-    } else if (internalPackageName(from.getInternalName())
-        .equals(internalPackageName(to.getInternalName()))) {
+    } else if (samePackage(from.getInternalName(), to.getInternalName())) {
       return Reference.Flag.PACKAGE_OR_HIGHER;
     } else {
       // Additional references: check the type hierarchy of FROM to distinguish public from

--- a/dd-java-agent/instrumentation/google-http-client/src/main/java/datadog/trace/instrumentation/googlehttpclient/GoogleHttpClientDecorator.java
+++ b/dd-java-agent/instrumentation/google-http-client/src/main/java/datadog/trace/instrumentation/googlehttpclient/GoogleHttpClientDecorator.java
@@ -6,8 +6,10 @@ import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpClientDecorator;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.regex.Pattern;
 
 public class GoogleHttpClientDecorator extends HttpClientDecorator<HttpRequest, HttpResponse> {
+  private static final Pattern URL_REPLACEMENT = Pattern.compile("%20");
   public static final CharSequence GOOGLE_HTTP_CLIENT =
       UTF8BytesString.createConstant("google-http-client");
   public static final CharSequence HTTP_REQUEST = UTF8BytesString.createConstant("http.request");
@@ -23,7 +25,7 @@ public class GoogleHttpClientDecorator extends HttpClientDecorator<HttpRequest, 
     // Google uses %20 (space) instead of "+" for spaces in the fragment
     // Add "+" back for consistency with the other http client instrumentations
     final String url = httpRequest.getUrl().build();
-    final String fixedUrl = url.replaceAll("%20", "+");
+    final String fixedUrl = URL_REPLACEMENT.matcher(url).replaceAll("+");
     return new URI(fixedUrl);
   }
 


### PR DESCRIPTION
I found these two uses of inefficient `String` API methods in contexts where we should probably remove them (one in reference creation during the build, the other once per span in the Google HTTP client instrumentation). 