### PR TITLE
Use same logging logic for APM and profile uploaders.

### DIFF
--- a/internal-api/src/main/java/datadog/trace/api/IOLogger.java
+++ b/internal-api/src/main/java/datadog/trace/api/IOLogger.java
@@ -1,0 +1,104 @@
+package datadog.trace.api;
+
+import java.util.concurrent.TimeUnit;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+
+/** Logger specialized on logging IO-related activity */
+public class IOLogger {
+  private static final long NANOSECONDS_BETWEEN_ERROR_LOG = TimeUnit.MINUTES.toNanos(5);
+
+  private boolean logNextSuccess = false;
+  private final Logger log;
+  private final RatelimitedLogger ratelimitedLogger;
+
+  public IOLogger(final Logger log) {
+    this(log, new RatelimitedLogger(log, NANOSECONDS_BETWEEN_ERROR_LOG));
+  }
+
+  // Visible for testing
+  IOLogger(final Logger log, final RatelimitedLogger ratelimitedLogger) {
+    this.log = log;
+    this.ratelimitedLogger = ratelimitedLogger;
+  }
+
+  /** @return true if actually logged the message, false otherwise */
+  public boolean success(final String format, final Object... arguments) {
+    if (log.isDebugEnabled()) {
+      log.debug(format, arguments);
+      return true;
+    }
+
+    if (this.logNextSuccess) {
+      this.logNextSuccess = false;
+      if (log.isInfoEnabled()) {
+        log.info(format, arguments);
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /** @return true if actually logged the message, false otherwise */
+  public boolean error(final String message) {
+    return error(message, null, null);
+  }
+
+  /** @return true if actually logged the message, false otherwise */
+  public boolean error(final String message, Exception exception) {
+    return error(message, null, exception);
+  }
+
+  /** @return true if actually logged the message, false otherwise */
+  public boolean error(final String message, Response response) {
+    return error(message, response, null);
+  }
+
+  /** @return true if actually logged the message, false otherwise */
+  public boolean error(final String message, Response response, Exception exception) {
+    if (log.isDebugEnabled()) {
+      if (response != null) {
+        log.debug(
+            "{} Status: {}, Response: {}, Body: {}",
+            message,
+            response.getStatusCode(),
+            response.getMessage(),
+            response.getBody());
+      } else if (exception != null) {
+        log.debug(message, exception);
+      } else {
+        log.debug(message);
+      }
+      return true;
+    }
+    boolean hasLogged;
+    if (response != null) {
+      hasLogged =
+          ratelimitedLogger.warn(
+              "{} Status: {} {}", message, response.getStatusCode(), response.getMessage());
+    } else if (exception != null) {
+      // NOTE: We do not pass the full exception to warn on purpose. We don't want to
+      //       print a full stacktrace unless we're in debug mode
+      hasLogged =
+          ratelimitedLogger.warn(
+              "{} {}: {}", message, exception.getClass().getName(), exception.getMessage());
+    } else {
+      hasLogged = ratelimitedLogger.warn(message);
+    }
+    if (hasLogged) {
+      this.logNextSuccess = true;
+    }
+
+    return hasLogged;
+  }
+
+  @Getter
+  @RequiredArgsConstructor
+  public static final class Response {
+    private final int statusCode;
+    private final String message;
+    private final String body;
+  }
+}

--- a/internal-api/src/test/groovy/datadog/trace/api/IOLoggerTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/IOLoggerTest.groovy
@@ -1,0 +1,162 @@
+package datadog.trace.api
+
+import datadog.trace.test.util.DDSpecification
+import org.slf4j.Logger
+
+class IOLoggerTest extends DDSpecification {
+  final response = new IOLogger.Response(404, "Not Found",
+    "The thing you were looking for does not exist")
+  final exception = new RuntimeException("Something went wrong!")
+
+  Logger log = Mock(Logger)
+  RatelimitedLogger rateLimitedLogger = Mock(RatelimitedLogger)
+  IOLogger ioLogger = new IOLogger(log, rateLimitedLogger)
+
+  def "Success - Debug level"() {
+    setup:
+    log.isDebugEnabled() >> true
+    log.isInfoEnabled() >> true
+
+    when:
+    ioLogger.success("test {}", "message")
+
+    then:
+    1 * log.debug("test {}", "message")
+  }
+
+  def "Success - Info level"() {
+    setup:
+    log.isDebugEnabled() >> false
+    log.isInfoEnabled() >> true
+
+    when:
+    ioLogger.success("test {}", "message")
+
+    then:
+    0 * log.debug(_)
+    0 * log.info(_)
+  }
+
+  def "Error - Debug level - Message"() {
+    setup:
+    log.isDebugEnabled() >> true
+    log.isInfoEnabled() >> true
+
+    when:
+    ioLogger.error("test message")
+
+    then:
+    1 * log.debug("test message")
+  }
+
+  def "Error - Debug level - Response"() {
+    setup:
+    log.isDebugEnabled() >> true
+    log.isInfoEnabled() >> true
+
+    when:
+    ioLogger.error("test message", response)
+
+    then:
+    1 * log.debug(
+      _,
+      "test message",
+      404,
+      "Not Found",
+      "The thing you were looking for does not exist"
+    )
+  }
+
+  def "Error - Debug level - Exception"() {
+    setup:
+    log.isDebugEnabled() >> true
+    log.isInfoEnabled() >> true
+
+    when:
+    ioLogger.error("test message", exception)
+
+    then:
+    1 * log.debug(
+      "test message",
+      exception
+    )
+  }
+
+  def "Error - Info level - Message"() {
+    setup:
+    log.isDebugEnabled() >> false
+    log.isInfoEnabled() >> true
+
+    when:
+    ioLogger.error("test message")
+
+    then:
+    1 * rateLimitedLogger.warn("test message")
+  }
+
+  def "Error - Info level - Response"() {
+    setup:
+    log.isDebugEnabled() >> false
+    log.isInfoEnabled() >> true
+
+    when:
+    ioLogger.error("test message", response)
+
+    then:
+    1 * rateLimitedLogger.warn(
+      _,
+      "test message",
+      404,
+      "Not Found"
+    )
+  }
+
+  def "Error - Info level - Exception"() {
+    setup:
+    log.isDebugEnabled() >> false
+    log.isInfoEnabled() >> true
+
+    when:
+    ioLogger.error("test message", exception)
+
+    then:
+    1 * rateLimitedLogger.warn(
+      _,
+      "test message",
+      "java.lang.RuntimeException",
+      "Something went wrong!"
+    )
+  }
+
+  def "Logged Error Then Success - Info level"() {
+    setup:
+    log.isDebugEnabled() >> false
+    log.isInfoEnabled() >> true
+
+    when:
+    ioLogger.error("test message")
+    ioLogger.success("very successful")
+    ioLogger.success("very successful again")
+
+    then:
+    1 * rateLimitedLogger.warn("test message") >> true
+    1 * log.info("very successful")
+    0 * log.info("very successful again")
+  }
+
+  def "Unlogged Error Then Success - Info level"() {
+    setup:
+    log.isDebugEnabled() >> false
+    log.isInfoEnabled() >> true
+
+    when:
+    ioLogger.error("test message")
+    ioLogger.success("very successful")
+    ioLogger.success("very successful again")
+
+    then:
+    1 * rateLimitedLogger.warn("test message") >> false
+    0 * log.info("very successful")
+    0 * log.info("very successful again")
+  }
+}


### PR DESCRIPTION
We have 2 uploaders in dd-trace-java. The trace one has a lot of logic to prevent it from becoming too verbose if logger level is info or above while still keeping track of the most important info. The profiling uploader did a poorer job of this and actually printed stacktraces on every IOException.

Instead of just copying more behaviour from one uploader to the other, this PR attempts to standardize logging around uploading so both trace and profile uploading logs follow the same structure and behaviour (and test it).