### PR TITLE
Select low and high version in every range for Muzzle

### DIFF
--- a/buildSrc/src/main/groovy/VersionSet.groovy
+++ b/buildSrc/src/main/groovy/VersionSet.groovy
@@ -1,0 +1,111 @@
+import org.eclipse.aether.version.Version
+
+import java.util.regex.Pattern
+
+class VersionSet {
+  private final SortedSet<ParsedVersion> sortedVersions
+
+  VersionSet(Collection<Version> versions) {
+    sortedVersions = new TreeSet<>()
+    for (Version version : versions) {
+      def parsed = new ParsedVersion(version)
+      sortedVersions.add(parsed)
+    }
+  }
+
+  List<Version> getLowAndHighForMajorMinor() {
+    ParsedVersion previous = null
+    int currentMajorMinor = -1
+    def resultSet = new TreeSet<ParsedVersion>()
+    for (ParsedVersion parsed: sortedVersions) {
+      int majorMinor = parsed.majorMinor
+      if (majorMinor != currentMajorMinor) {
+        if (previous != null) {
+          resultSet.add(previous)
+          previous = null
+        }
+        resultSet.add(parsed)
+        currentMajorMinor = majorMinor
+      } else {
+        previous = parsed
+      }
+    }
+    if (previous != null) {
+      resultSet.add(previous)
+    }
+    return resultSet.collect {it.version }
+  }
+
+  static class ParsedVersion implements Comparable<ParsedVersion> {
+    private static final Pattern dotPattern = Pattern.compile("\\.")
+    private static final int VERSION_SHIFT = 12
+
+    private final Version version
+    private final long versionNumber
+    private final String ending
+
+    ParsedVersion(Version version) {
+      this.version = version
+      def versionString = version.toString()
+      def ending = ""
+      // Remove any trailing parts from the version
+      def dash = versionString.indexOf('-')
+      if (dash > 0) {
+        ending = versionString.substring(dash + 1)
+        versionString = versionString.substring(0, dash)
+      }
+      def groups = dotPattern.split(versionString).toList()
+      int versionNumber = 0
+      int iteration = 0
+      // We assume that there are no more than 3 version numbers
+      while (iteration < 3) {
+        versionNumber <<= VERSION_SHIFT
+        if (!groups.empty && groups.head().isInteger()) {
+          versionNumber += groups.pop().toInteger()
+        }
+        iteration++
+      }
+      if (!groups.empty) {
+        def rest = groups.join('.')
+        ending = ending.empty ? rest : "$rest-$ending"
+      }
+      this.versionNumber = versionNumber
+      this.ending = ending
+    }
+
+    boolean equals(o) {
+      if (this.is(o)) return true
+      if (getClass() != o.class) return false
+      ParsedVersion that = (ParsedVersion) o
+      if (versionNumber != that.versionNumber) return false
+      if (ending != that.ending) return false
+      return true
+    }
+
+    int hashCode() {
+      return versionNumber * 31 + ending.hashCode()
+    }
+
+    @Override
+    int compareTo(ParsedVersion other) {
+      def diff = versionNumber - other.versionNumber
+      return diff != 0 ? diff : ending <=> other.ending
+    }
+
+    Version getVersion() {
+      return version
+    }
+
+    long getVersionNumber() {
+      return versionNumber
+    }
+
+    String getEnding() {
+      return ending
+    }
+
+    int getMajorMinor() {
+      return versionNumber >> VERSION_SHIFT
+    }
+  }
+}

--- a/buildSrc/src/test/groovy/VersionSetTest.groovy
+++ b/buildSrc/src/test/groovy/VersionSetTest.groovy
@@ -1,0 +1,90 @@
+import org.eclipse.aether.version.Version
+import spock.lang.Specification
+
+import static VersionSet.ParsedVersion
+
+class VersionSetTest extends Specification {
+
+  def "parse versions properly"() {
+    when:
+    def parsed = new ParsedVersion(version)
+
+    then:
+    parsed.versionNumber == versionNumber
+    parsed.ending == ending
+    parsed.majorMinor == versionNumber >> ParsedVersion.VERSION_SHIFT
+
+    where:
+    version                 | versionNumber   | ending
+    ver('1.2.3')            | num(1, 2, 3)    | ""
+    ver('4.5.6-foo')        | num(4, 5, 6)    | "foo"
+    ver('7.8.9.foo')        | num(7, 8, 9)    | "foo"
+    ver('10.11.12.foo-bar') | num(10, 11, 12) | "foo-bar"
+    ver('13.14.foo-bar')    | num(13, 14, 0)  | "foo-bar"
+    ver('15.foo')           | num(15, 0, 0)   | "foo"
+    ver('16-foo')           | num(16, 0, 0)   | "foo"
+  }
+
+  def "select low and high from major.minor"() {
+    when:
+    def versionSet = new VersionSet(versions)
+
+    then:
+    versionSet.lowAndHighForMajorMinor == expected
+
+    where:
+    versions << [[
+      ver('4.5.6'),
+      ver('1.2.3')
+    ], [
+      ver('1.2.3'),
+      ver('1.2.1'),
+      ver('1.3.0'),
+      ver('1.2.7'),
+      ver('1.4.17'),
+      ver('1.4.1'),
+      ver('1.4.0'),
+      ver('1.4.10')
+    ]]
+    expected << [[
+      ver('1.2.3'),
+      ver('4.5.6')
+    ], [
+      ver('1.2.1'),
+      ver('1.2.7'),
+      ver('1.3.0'),
+      ver('1.4.0'),
+      ver('1.4.17')
+    ]]
+  }
+
+  Version ver(String string) {
+    return new TestVersion(string)
+  }
+
+  long num(int major, int minor, int micro) {
+    long result = major
+    return (((result << 12) + minor) << 12) + micro
+  }
+
+  static class TestVersion implements Version {
+    private final String string
+
+    TestVersion(String versionString) {
+      this.string = versionString
+    }
+
+    @Override
+    int compareTo(Version o) {
+      if (o == null) return 1
+      if (! o instanceof TestVersion) return 1
+      TestVersion other = o as TestVersion
+      return string <=> other.string
+    }
+
+    @Override
+    String toString() {
+      return string
+    }
+  }
+}


### PR DESCRIPTION
This changes how we select versions to test in the muzzle step, to select  the low and high version in every `major.minor` range, and then limiting that to the max allowed number of versions by randomizing. This leads to a reduction  from `3982` muzzle tasks to `2289` since a lot of libraries have large `micro` ranges.