### PR TITLE
change JMS producers to use $ as replacement for -

### DIFF
--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/MessageExtractAdapter.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/MessageExtractAdapter.java
@@ -16,10 +16,7 @@ public class MessageExtractAdapter implements AgentPropagation.ContextVisitor<Me
       new Function<String, String>() {
         @Override
         public String apply(String key) {
-          return key.replace('$', '-')
-              // true story \/
-              .replace("__dash__", "-")
-              .toLowerCase();
+          return key.replace('$', '-').toLowerCase();
         }
       };
 

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/MessageExtractAdapter.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/MessageExtractAdapter.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.jms;
 
+import datadog.trace.api.Config;
 import datadog.trace.api.Function;
 import datadog.trace.api.cache.DDCache;
 import datadog.trace.api.cache.DDCaches;
@@ -12,10 +13,16 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class MessageExtractAdapter implements AgentPropagation.ContextVisitor<Message> {
 
+  private static final boolean USE_LEGACY_DASH_REPLACEMENT =
+      Config.get().isJmsLegacyDashReplacement();
+
   private static final Function<String, String> KEY_MAPPER =
       new Function<String, String>() {
         @Override
         public String apply(String key) {
+          if (USE_LEGACY_DASH_REPLACEMENT) {
+            return key.replace("__dash__", "-").toLowerCase();
+          }
           return key.replace('$', '-').toLowerCase();
         }
       };

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/MessageInjectAdapter.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/MessageInjectAdapter.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.jms;
 
+import datadog.trace.api.Config;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import javax.jms.JMSException;
 import javax.jms.Message;
@@ -8,11 +9,15 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class MessageInjectAdapter implements AgentPropagation.Setter<Message> {
 
+  private static final boolean USE_LEGACY_DASH_REPLACEMENT =
+      Config.get().isJmsLegacyDashReplacement();
+
   public static final MessageInjectAdapter SETTER = new MessageInjectAdapter();
 
   @Override
   public void set(final Message carrier, final String key, final String value) {
-    final String propName = key.replace('-', '$');
+    final String propName =
+        USE_LEGACY_DASH_REPLACEMENT ? key.replace("-", "__dash__") : key.replace('-', '$');
     try {
       carrier.setStringProperty(propName, value);
     } catch (final JMSException e) {

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/MessageInjectAdapter.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/MessageInjectAdapter.java
@@ -12,7 +12,7 @@ public class MessageInjectAdapter implements AgentPropagation.Setter<Message> {
 
   @Override
   public void set(final Message carrier, final String key, final String value) {
-    final String propName = key.replace("-", "__dash__");
+    final String propName = key.replace('-', '$');
     try {
       carrier.setStringProperty(propName, value);
     } catch (final JMSException e) {

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
@@ -51,5 +51,7 @@ public final class TracerConfig {
 
   public static final String ENABLE_TRACE_AGENT_V05 = "trace.agent.v0.5.enabled";
 
+  public static final String JMS_LEGACY_DASH_REPLACEMENT = "trace.jms.legacy.dash.replacement";
+
   private TracerConfig() {}
 }

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -144,6 +144,7 @@ import static datadog.trace.api.config.TracerConfig.HEADER_TAGS;
 import static datadog.trace.api.config.TracerConfig.HTTP_CLIENT_ERROR_STATUSES;
 import static datadog.trace.api.config.TracerConfig.HTTP_SERVER_ERROR_STATUSES;
 import static datadog.trace.api.config.TracerConfig.ID_GENERATION_STRATEGY;
+import static datadog.trace.api.config.TracerConfig.JMS_LEGACY_DASH_REPLACEMENT;
 import static datadog.trace.api.config.TracerConfig.PARTIAL_FLUSH_MIN_SPANS;
 import static datadog.trace.api.config.TracerConfig.PRIORITY_SAMPLING;
 import static datadog.trace.api.config.TracerConfig.PRIORITY_SAMPLING_FORCE;
@@ -371,6 +372,8 @@ public class Config {
   @Getter private final IdGenerationStrategy idGenerationStrategy;
 
   @Getter private final boolean internalExitOnFailure;
+
+  @Getter private final boolean jmsLegacyDashReplacement;
 
   @Getter private final boolean resolverUseLoadClassEnabled;
 
@@ -629,6 +632,8 @@ public class Config {
 
     traceAnalyticsEnabled =
         configProvider.getBoolean(TRACE_ANALYTICS_ENABLED, DEFAULT_TRACE_ANALYTICS_ENABLED);
+
+    jmsLegacyDashReplacement = configProvider.getBoolean(JMS_LEGACY_DASH_REPLACEMENT, false);
 
     traceSamplingServiceRules = configProvider.getMergedMap(TRACE_SAMPLING_SERVICE_RULES);
     traceSamplingOperationRules = configProvider.getMergedMap(TRACE_SAMPLING_OPERATION_RULES);


### PR DESCRIPTION
This is backward incompatible.

The consumer was updated in version 0.59.0 to start accepting `$` as a placeholder. The producer wasn't updates at that time to avoid breaking mixed deployments. This could probably be done now, with a migration note for mixed tracer version environments stating that producers >= 0.69.0 require consumers >= 0.59.0.