### PR TITLE
remove busyspin backoff logic in flaky DDAgentWriterCombinedTest

### DIFF
--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterCombinedTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterCombinedTest.groovy
@@ -30,9 +30,9 @@ import java.util.concurrent.atomic.AtomicInteger
 
 import static datadog.trace.agent.test.server.http.TestHttpServer.httpServer
 import static datadog.trace.common.writer.DDAgentWriter.BUFFER_SIZE
+import static datadog.trace.common.writer.ddagent.Prioritization.ENSURE_TRACE
 import static datadog.trace.core.SpanFactory.newSpanOf
 
-@Retry
 @Timeout(10)
 class DDAgentWriterCombinedTest extends DDSpecification {
 
@@ -182,6 +182,7 @@ class DDAgentWriterCombinedTest extends DDSpecification {
     def writer = DDAgentWriter.builder()
       .agentApi(api)
       .traceBufferSize(BUFFER_SIZE)
+      .prioritization(ENSURE_TRACE)
       .monitoring(monitoring)
       .flushFrequencySeconds(-1)
       .build()
@@ -193,11 +194,6 @@ class DDAgentWriterCombinedTest extends DDSpecification {
     int maxedPayloadTraceCount = ((int) ((mapper.messageBufferSize() - 5) / traceSize))
     (0..maxedPayloadTraceCount).each {
       writer.write(minimalTrace)
-      def start = System.nanoTime()
-      // (consumer processes a trace in about 20 microseconds
-      while (System.nanoTime() - start < TimeUnit.MICROSECONDS.toNanos(100) && !Thread.currentThread().isInterrupted()) {
-        // Busywait because we don't want to fill up the ring buffer
-      }
     }
     writer.flush()
 


### PR DESCRIPTION
I believe this test fails because it is slow, and removing the backoff logic seems to speed the test up by around 70x. I will build this PR repeatedly and verify that I don't see this:

```
test default buffer size for v0.3/traces - datadog.trace.common.writer.DDAgentWriterCombinedTest
Too many invocations for:

0 * _   (1 invocation)

Matching invocations (ordered by last occurrence):

1 * api.sendSerializedTraces(<datadog.trace.common.writer.ddagent.TraceMapperV0_4$PayloadV0_4@1a63cfba traceCount=32670 body=java.nio.HeapByteBuffer[pos=0 lim=5194533 cap=5194533]>)   <-- this triggered the error


	at org.spockframework.mock.runtime.MockInteraction.accept(MockInteraction.java:70)
	at org.spockframework.mock.runtime.MockInteractionDecorator.accept(MockInteractionDecorator.java:50)
	at org.spockframework.mock.runtime.InteractionScope$1.accept(InteractionScope.java:51)
	at org.spockframework.mock.runtime.MockController.handle(MockController.java:40)
	at org.spockframework.mock.runtime.JavaMockInterceptor.intercept(JavaMockInterceptor.java:72)
	at org.spockframework.mock.runtime.ByteBuddyInterceptorAdapter.interceptNonAbstract(ByteBuddyInterceptorAdapter.java:35)
	at datadog.trace.common.writer.ddagent.PayloadDispatcher.accept(PayloadDispatcher.java:72)
	at datadog.trace.core.serialization.WritableFormatter.flush(WritableFormatter.java:108)
	at datadog.trace.common.writer.ddagent.PayloadDispatcher.flush(PayloadDispatcher.java:33)
	at datadog.trace.common.writer.ddagent.TraceProcessingWorker$TraceSerializingHandler.onEvent(TraceProcessingWorker.java:145)
	at datadog.trace.common.writer.ddagent.TraceProcessingWorker$TraceSerializingHandler.consumeFromPrimaryQueue(TraceProcessingWorker.java:184)
	at datadog.trace.common.writer.ddagent.TraceProcessingWorker$TraceSerializingHandler.runDutyCycle(TraceProcessingWorker.java:171)
	at datadog.trace.common.writer.ddagent.TraceProcessingWorker$TraceSerializingHandler.run(TraceProcessingWorker.java:160)
	at java.lang.Thread.run(Thread.java:748)
```