### PR TITLE
clear timer histogram counts on flush

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/monitor/Timer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/monitor/Timer.java
@@ -80,5 +80,6 @@ public class Timer extends Recording {
     statsd.gauge(name, histogram.getValueAtPercentile(50), p50Tags);
     statsd.gauge(name, histogram.getValueAtPercentile(99), p99Tags);
     statsd.gauge(name, histogram.getMaxValue(), maxTags);
+    histogram.reset();
   }
 }


### PR DESCRIPTION
allows to track continuously new max, p99