### PR TITLE
Add Muzzle reference creation for interfaces

### DIFF
--- a/dd-java-agent/testing/src/test/groovy/muzzle/ReferenceCreatorTest.groovy
+++ b/dd-java-agent/testing/src/test/groovy/muzzle/ReferenceCreatorTest.groovy
@@ -67,6 +67,24 @@ class ReferenceCreatorTest extends AgentTestRunner {
     references.get('muzzle.TestClasses$MethodBodyAdvice$A') != null
   }
 
+  def "interface impl creates references"() {
+    setup:
+    Map<String, Reference> references = ReferenceCreator.createReferencesFrom(MethodBodyAdvice.SomeImplementation.getName(), this.getClass().getClassLoader())
+
+    expect:
+    references.get('muzzle.TestClasses$MethodBodyAdvice$SomeInterface') != null
+    references.size() == 1
+  }
+
+  def "child class creates references"() {
+    setup:
+    Map<String, Reference> references = ReferenceCreator.createReferencesFrom(MethodBodyAdvice.A2.getName(), this.getClass().getClassLoader())
+
+    expect:
+    references.get('muzzle.TestClasses$MethodBodyAdvice$A') != null
+    references.size() == 1
+  }
+
   def "instanceof creates references"() {
     setup:
     Map<String, Reference> references = ReferenceCreator.createReferencesFrom(InstanceofAdvice.getName(), this.getClass().getClassLoader())
@@ -82,7 +100,7 @@ class ReferenceCreatorTest extends AgentTestRunner {
     Map<String, Reference> references = ReferenceCreator.createReferencesFrom(TestClasses.InDyAdvice.getName(), this.getClass().getClassLoader())
 
     expect:
-    references.get('muzzle.TestClasses$MethodBodyAdvice$SomeImplementation') != null
+    references.get('muzzle.TestClasses$MethodBodyAdvice$HasMethod') != null
     references.get('muzzle.TestClasses$MethodBodyAdvice$B') != null
   }
 

--- a/dd-java-agent/testing/src/test/java/muzzle/TestClasses.java
+++ b/dd-java-agent/testing/src/test/java/muzzle/TestClasses.java
@@ -95,10 +95,9 @@ public class TestClasses {
 
   // Can't test this until java 7 is dropped.
   public static class InDyAdvice {
-    //    public static MethodBodyAdvice.SomeInterface indyMethod(
-    //        final MethodBodyAdvice.SomeImplementation a) {
+    //    public static MethodBodyAdvice.HasMethod indyMethod(final MethodBodyAdvice.HasMethod a) {
     //      Runnable aStaticMethod = MethodBodyAdvice.B::aStaticMethod;
-    //      return a::someMethod;
+    //      return a::requiredMethod;
     //    }
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/PendingTrace.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/PendingTrace.java
@@ -240,7 +240,8 @@ public class PendingTrace implements AgentTrace {
       }
     }
     if (log.isDebugEnabled()) {
-      log.debug("t_id={} -> expired reference. pending count={}", traceId, count);
+      log.debug(
+          "t_id={} -> expired reference. root={} pending count={}", traceId, isRootSpan, count);
     }
   }
 


### PR DESCRIPTION
This will allow muzzle to fail if an implemented interface is missing.  Additional work should be done in the future to ensure the implementation satisfies the interfaces and abstract types. (https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/1357)