### PR TITLE
Use PORTS cache for `peer.port`

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/BaseDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/BaseDecorator.java
@@ -1,5 +1,6 @@
 package datadog.trace.bootstrap.instrumentation.decorator;
 
+import static datadog.trace.api.cache.RadixTreeCache.PORTS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 import datadog.trace.api.Config;
@@ -118,7 +119,7 @@ public abstract class BaseDecorator {
       onPeerConnection(span, remoteConnection.getAddress());
 
       span.setTag(Tags.PEER_HOSTNAME, remoteConnection.getHostName());
-      span.setTag(Tags.PEER_PORT, remoteConnection.getPort());
+      setPeerPort(span, remoteConnection.getPort());
     }
     return span;
   }
@@ -133,6 +134,15 @@ public abstract class BaseDecorator {
         span.setTag(Tags.PEER_HOST_IPV6, remoteAddress.getHostAddress());
       }
     }
+    return span;
+  }
+
+  public AgentSpan setPeerPort(AgentSpan span, int port) {
+    // Negative or Zero ports might represent an unset/null value for an int type.  Skip setting.
+    if (port > 0) {
+      span.setTag(Tags.PEER_PORT, PORTS.get(port));
+    }
+
     return span;
   }
 

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpClientDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpClientDecorator.java
@@ -54,7 +54,7 @@ public abstract class HttpClientDecorator<REQUEST, RESPONSE> extends ClientDecor
               span.setTag(DDTags.SERVICE_NAME, url.getHost());
             }
             if (url.getPort() > 0) {
-              span.setTag(Tags.PEER_PORT, url.getPort());
+              setPeerPort(span, url.getPort());
               if (url.getPort() != 80 && url.getPort() != 443) {
                 urlNoParams.append(":");
                 urlNoParams.append(url.getPort());

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
@@ -1,7 +1,6 @@
 package datadog.trace.bootstrap.instrumentation.decorator;
 
 import static datadog.trace.api.cache.RadixTreeCache.HTTP_STATUSES;
-import static datadog.trace.api.cache.RadixTreeCache.PORTS;
 
 import datadog.trace.api.Config;
 import datadog.trace.api.DDTags;
@@ -106,11 +105,8 @@ public abstract class HttpServerDecorator<REQUEST, CONNECTION, RESPONSE> extends
           span.setTag(Tags.PEER_HOST_IPV6, ip);
         }
       }
-      final int port = peerPort(connection);
-      // Negative or Zero ports might represent an unset/null value for an int type.  Skip setting.
-      if (port > 0) {
-        span.setTag(Tags.PEER_PORT, PORTS.get(port));
-      }
+
+      setPeerPort(span, peerPort(connection));
     }
     return span;
   }

--- a/dd-java-agent/instrumentation/datastax-cassandra-3/src/main/java/datadog/trace/instrumentation/datastax/cassandra/CassandraClientDecorator.java
+++ b/dd-java-agent/instrumentation/datastax-cassandra-3/src/main/java/datadog/trace/instrumentation/datastax/cassandra/CassandraClientDecorator.java
@@ -5,7 +5,6 @@ import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.Session;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
-import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.DBTypeProcessingDatabaseClientDecorator;
 
@@ -62,8 +61,7 @@ public class CassandraClientDecorator extends DBTypeProcessingDatabaseClientDeco
   public AgentSpan onResponse(final AgentSpan span, final ResultSet result) {
     if (result != null) {
       final Host host = result.getExecutionInfo().getQueriedHost();
-      span.setTag(Tags.PEER_PORT, host.getSocketAddress().getPort());
-      onPeerConnection(span, host.getSocketAddress().getAddress());
+      onPeerConnection(span, host.getSocketAddress());
     }
     return span;
   }

--- a/dd-java-agent/instrumentation/elasticsearch/src/main/java/datadog/trace/instrumentation/elasticsearch/ElasticsearchRestClientDecorator.java
+++ b/dd-java-agent/instrumentation/elasticsearch/src/main/java/datadog/trace/instrumentation/elasticsearch/ElasticsearchRestClientDecorator.java
@@ -75,7 +75,7 @@ public class ElasticsearchRestClientDecorator extends DatabaseClientDecorator {
   public AgentSpan onResponse(final AgentSpan span, final Response response) {
     if (response != null && response.getHost() != null) {
       span.setTag(Tags.PEER_HOSTNAME, response.getHost().getHostName());
-      span.setTag(Tags.PEER_PORT, response.getHost().getPort());
+      setPeerPort(span, response.getHost().getPort());
     }
     return span;
   }

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/main/java/datadog/trace/instrumentation/elasticsearch2/TransportActionListener.java
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/main/java/datadog/trace/instrumentation/elasticsearch2/TransportActionListener.java
@@ -51,7 +51,7 @@ public class TransportActionListener<T extends ActionResponse> implements Action
     if (response.remoteAddress() != null) {
       span.setTag(Tags.PEER_HOSTNAME, response.remoteAddress().getHost());
       span.setTag(Tags.PEER_HOST_IPV4, response.remoteAddress().getAddress());
-      span.setTag(Tags.PEER_PORT, response.remoteAddress().getPort());
+      DECORATE.setPeerPort(span, response.remoteAddress().getPort());
     }
 
     if (response instanceof GetResponse) {

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/Elasticsearch2NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/Elasticsearch2NodeClientTest.groovy
@@ -202,7 +202,6 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "local"
             "$Tags.PEER_HOST_IPV4" "0.0.0.0"
-            "$Tags.PEER_PORT" 0
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
@@ -225,7 +224,6 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "local"
             "$Tags.PEER_HOST_IPV4" "0.0.0.0"
-            "$Tags.PEER_PORT" 0
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
@@ -263,7 +261,6 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "local"
             "$Tags.PEER_HOST_IPV4" "0.0.0.0"
-            "$Tags.PEER_PORT" 0
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/springdata/Elasticsearch2SpringRepositoryTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/springdata/Elasticsearch2SpringRepositoryTest.groovy
@@ -82,7 +82,6 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "local"
             "$Tags.PEER_HOST_IPV4" "0.0.0.0"
-            "$Tags.PEER_PORT" 0
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
@@ -130,7 +129,6 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "local"
             "$Tags.PEER_HOST_IPV4" "0.0.0.0"
-            "$Tags.PEER_PORT" 0
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
@@ -164,7 +162,6 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "local"
             "$Tags.PEER_HOST_IPV4" "0.0.0.0"
-            "$Tags.PEER_PORT" 0
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
@@ -204,7 +201,6 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "local"
             "$Tags.PEER_HOST_IPV4" "0.0.0.0"
-            "$Tags.PEER_PORT" 0
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
@@ -237,7 +233,6 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "local"
             "$Tags.PEER_HOST_IPV4" "0.0.0.0"
-            "$Tags.PEER_PORT" 0
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "DeleteAction"
             "elasticsearch.request" "DeleteRequest"

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
@@ -188,7 +188,6 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "local"
             "$Tags.PEER_HOST_IPV4" "0.0.0.0"
-            "$Tags.PEER_PORT" 0
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/main/java/datadog/trace/instrumentation/elasticsearch5_3/TransportActionListener.java
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/main/java/datadog/trace/instrumentation/elasticsearch5_3/TransportActionListener.java
@@ -54,7 +54,7 @@ public class TransportActionListener<T extends ActionResponse> implements Action
     if (response.remoteAddress() != null) {
       span.setTag(Tags.PEER_HOSTNAME, response.remoteAddress().getHost());
       span.setTag(Tags.PEER_HOST_IPV4, response.remoteAddress().getAddress());
-      span.setTag(Tags.PEER_PORT, response.remoteAddress().getPort());
+      DECORATE.setPeerPort(span, response.remoteAddress().getPort());
     }
 
     if (response instanceof GetResponse) {

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5/src/main/java/datadog/trace/instrumentation/elasticsearch5/TransportActionListener.java
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5/src/main/java/datadog/trace/instrumentation/elasticsearch5/TransportActionListener.java
@@ -53,7 +53,7 @@ public class TransportActionListener<T extends ActionResponse> implements Action
     if (response.remoteAddress() != null) {
       span.setTag(Tags.PEER_HOSTNAME, response.remoteAddress().getHost());
       span.setTag(Tags.PEER_HOST_IPV4, response.remoteAddress().getAddress());
-      span.setTag(Tags.PEER_PORT, response.remoteAddress().getPort());
+      DECORATE.setPeerPort(span, response.remoteAddress().getPort());
     }
 
     if (response instanceof GetResponse) {

--- a/dd-java-agent/instrumentation/elasticsearch/transport-6/src/main/java/datadog/trace/instrumentation/elasticsearch6/TransportActionListener.java
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-6/src/main/java/datadog/trace/instrumentation/elasticsearch6/TransportActionListener.java
@@ -3,7 +3,6 @@ package datadog.trace.instrumentation.elasticsearch6;
 import static datadog.trace.instrumentation.elasticsearch.ElasticsearchTransportClientDecorator.DECORATE;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.util.Strings;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
@@ -56,9 +55,7 @@ public class TransportActionListener<T extends ActionResponse> implements Action
   @Override
   public void onResponse(final T response) {
     if (response.remoteAddress() != null) {
-      span.setTag(Tags.PEER_HOSTNAME, response.remoteAddress().address().getHostName());
-      span.setTag(Tags.PEER_HOST_IPV4, response.remoteAddress().getAddress());
-      span.setTag(Tags.PEER_PORT, response.remoteAddress().getPort());
+      DECORATE.onPeerConnection(span, response.remoteAddress().address());
     }
 
     if (response instanceof GetResponse) {

--- a/dd-java-agent/instrumentation/elasticsearch/transport-7.3/src/main/java/datadog/trace/instrumentation/elasticsearch7_3/TransportActionListener.java
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-7.3/src/main/java/datadog/trace/instrumentation/elasticsearch7_3/TransportActionListener.java
@@ -3,7 +3,6 @@ package datadog.trace.instrumentation.elasticsearch7_3;
 import static datadog.trace.instrumentation.elasticsearch.ElasticsearchTransportClientDecorator.DECORATE;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.util.Strings;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
@@ -53,9 +52,7 @@ public class TransportActionListener<T extends ActionResponse> implements Action
   @Override
   public void onResponse(final T response) {
     if (response.remoteAddress() != null) {
-      span.setTag(Tags.PEER_HOSTNAME, response.remoteAddress().address().getHostName());
-      span.setTag(Tags.PEER_HOST_IPV4, response.remoteAddress().getAddress());
-      span.setTag(Tags.PEER_PORT, response.remoteAddress().getPort());
+      DECORATE.onPeerConnection(span, response.remoteAddress().address());
     }
 
     if (response instanceof GetResponse) {

--- a/dd-java-agent/instrumentation/http-url-connection/src/main/java/datadog/trace/instrumentation/http_url_connection/UrlInstrumentation.java
+++ b/dd-java-agent/instrumentation/http-url-connection/src/main/java/datadog/trace/instrumentation/http_url_connection/UrlInstrumentation.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.http_url_connection;
 
+import static datadog.trace.api.cache.RadixTreeCache.PORTS;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static java.util.Collections.singletonMap;
@@ -72,7 +73,7 @@ public class UrlInstrumentation extends Instrumenter.Default {
 
         try (final AgentScope scope = activateSpan(span)) {
           span.setTag(Tags.HTTP_URL, url.toString());
-          span.setTag(Tags.PEER_PORT, url.getPort() == -1 ? 80 : url.getPort());
+          span.setTag(Tags.PEER_PORT, url.getPort() > 0 ? PORTS.get(url.getPort()) : PORTS.get(80));
           span.setTag(Tags.PEER_HOSTNAME, url.getHost());
           if (Config.get().isHttpClientSplitByDomain()) {
             span.setTag(DDTags.SERVICE_NAME, url.getHost());

--- a/dd-java-agent/instrumentation/lettuce-4/src/main/java8/datadog/trace/instrumentation/lettuce4/LettuceClientDecorator.java
+++ b/dd-java-agent/instrumentation/lettuce-4/src/main/java8/datadog/trace/instrumentation/lettuce4/LettuceClientDecorator.java
@@ -62,7 +62,7 @@ public class LettuceClientDecorator extends DBTypeProcessingDatabaseClientDecora
   public AgentSpan onConnection(final AgentSpan span, final RedisURI connection) {
     if (connection != null) {
       span.setTag(Tags.PEER_HOSTNAME, connection.getHost());
-      span.setTag(Tags.PEER_PORT, connection.getPort());
+      setPeerPort(span, connection.getPort());
       span.setTag("db.redis.dbIndex", connection.getDatabase());
       span.setTag(DDTags.RESOURCE_NAME, resourceName(connection));
     }

--- a/dd-java-agent/instrumentation/lettuce-5/src/main/java8/datadog/trace/instrumentation/lettuce5/LettuceClientDecorator.java
+++ b/dd-java-agent/instrumentation/lettuce-5/src/main/java8/datadog/trace/instrumentation/lettuce5/LettuceClientDecorator.java
@@ -58,7 +58,7 @@ public class LettuceClientDecorator extends DBTypeProcessingDatabaseClientDecora
   public AgentSpan onConnection(final AgentSpan span, final RedisURI connection) {
     if (connection != null) {
       span.setTag(Tags.PEER_HOSTNAME, connection.getHost());
-      span.setTag(Tags.PEER_PORT, connection.getPort());
+      setPeerPort(span, connection.getPort());
 
       span.setTag("db.redis.dbIndex", connection.getDatabase());
       span.setTag(

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitChannelInstrumentation.java
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitChannelInstrumentation.java
@@ -38,7 +38,6 @@ import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan.Context;
 import datadog.trace.bootstrap.instrumentation.api.ContextVisitors;
-import datadog.trace.bootstrap.instrumentation.api.Tags;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -121,10 +120,8 @@ public class RabbitChannelInstrumentation extends Instrumenter.Default {
       final Connection connection = channel.getConnection();
 
       final AgentSpan span =
-          startSpan(AMQP_COMMAND)
-              .setTag(DDTags.RESOURCE_NAME, method)
-              .setTag(Tags.PEER_PORT, connection.getPort())
-              .setMeasured(true);
+          startSpan(AMQP_COMMAND).setTag(DDTags.RESOURCE_NAME, method).setMeasured(true);
+      DECORATE.setPeerPort(span, connection.getPort());
       DECORATE.afterStart(span);
       DECORATE.onPeerConnection(span, connection.getAddress());
       return activateSpan(span);
@@ -252,7 +249,7 @@ public class RabbitChannelInstrumentation extends Instrumenter.Default {
       if (response != null) {
         span.setTag("message.size", response.getBody().length);
       }
-      span.setTag(Tags.PEER_PORT, connection.getPort());
+      CONSUMER_DECORATE.setPeerPort(span, connection.getPort());
       try (final AgentScope scope = activateSpan(span)) {
         CONSUMER_DECORATE.afterStart(span);
         CONSUMER_DECORATE.onGet(span, queue);


### PR DESCRIPTION
Consistently use the PORTS cache.  Where an `InetSocketAddress` was available, I made those places use the correct `onPeerConnection`