### PR TITLE
compileOnly project(':utils:histograms') in dd-trace-core

### DIFF
--- a/dd-trace-core/dd-trace-core.gradle
+++ b/dd-trace-core/dd-trace-core.gradle
@@ -26,7 +26,7 @@ testSets {
 dependencies {
   compile project(':dd-trace-api')
   compile project(':internal-api')
-  compile project(':utils:histograms')
+  compileOnly project(':utils:histograms')
   compile project(':utils:container-utils')
 
   compile group: 'com.datadoghq', name: 'java-dogstatsd-client', version: "${versions.dogstatsd}"


### PR DESCRIPTION
test how it works