### PR TITLE
Extend DD_TRACE_METHODS to support wildcarded method argument

### DIFF
--- a/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceConfigInstrumentation.java
+++ b/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceConfigInstrumentation.java
@@ -149,8 +149,13 @@ public class TraceConfigInstrumentation implements Instrumenter {
       for (final String methodName : methodNames) {
         if (methodMatchers == null) {
           if (methodName.equals("*")) {
-//            methodMatchers = not(isAbstract()).and(noneOf("hashCode", "equals"));
-              methodMatchers = any();
+            methodMatchers =
+                not(
+                    isHashCode()
+                        .or(isEquals())
+                        .or(isToString())
+                        .or(isConstructor())
+                        .or(isSynthetic()));
           } else {
             methodMatchers = named(methodName);
           }

--- a/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceConfigInstrumentation.java
+++ b/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceConfigInstrumentation.java
@@ -35,7 +35,8 @@ import net.bytebuddy.matcher.ElementMatcher;
 public class TraceConfigInstrumentation implements Instrumenter {
 
   static final String PACKAGE_CLASS_NAME_REGEX = "[\\w .\\$]+";
-  private static final String METHOD_LIST_REGEX = "\\s*(?:\\*|(?:\\w+\\s*,)*\\s*(?:\\w+\\s*,?))\\s*";
+  private static final String METHOD_LIST_REGEX =
+      "\\s*(?:\\*|(?:\\w+\\s*,)*\\s*(?:\\w+\\s*,?))\\s*";
   private static final String CONFIG_FORMAT =
       "(?:\\s*"
           + PACKAGE_CLASS_NAME_REGEX
@@ -149,8 +150,8 @@ public class TraceConfigInstrumentation implements Instrumenter {
       ElementMatcher.Junction<MethodDescription> methodMatchers = null;
       for (final String methodName : methodNames) {
         if (methodMatchers == null) {
-          if (methodName == '*'){
-            methodMatchers = isPublic().not(isAbstract())
+          if (methodName == '*') {
+            methodMatchers = isPublic().not(isAbstract());
           } else {
             methodMatchers = named(methodName);
           }

--- a/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceConfigInstrumentation.java
+++ b/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceConfigInstrumentation.java
@@ -2,6 +2,8 @@ package datadog.trace.instrumentation.trace_annotation;
 
 import static datadog.trace.agent.tooling.ClassLoaderMatcher.hasClassesNamed;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers.safeHasSuperType;
+import static net.bytebuddy.matcher.ElementMatchers.isAbstract;
+import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 
 import com.google.auto.service.AutoService;
@@ -147,7 +149,11 @@ public class TraceConfigInstrumentation implements Instrumenter {
       ElementMatcher.Junction<MethodDescription> methodMatchers = null;
       for (final String methodName : methodNames) {
         if (methodMatchers == null) {
-          methodMatchers = named(methodName);
+          if (methodName == '*'){
+            methodMatchers = isPublic().not(isAbstract())
+          } else {
+            methodMatchers = named(methodName);
+          }
         } else {
           methodMatchers = methodMatchers.or(named(methodName));
         }

--- a/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceConfigInstrumentation.java
+++ b/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceConfigInstrumentation.java
@@ -2,10 +2,7 @@ package datadog.trace.instrumentation.trace_annotation;
 
 import static datadog.trace.agent.tooling.ClassLoaderMatcher.hasClassesNamed;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers.safeHasSuperType;
-import static net.bytebuddy.matcher.ElementMatchers.isAbstract;
-import static net.bytebuddy.matcher.ElementMatchers.isPrivate;
-import static net.bytebuddy.matcher.ElementMatchers.isPublic;
-import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.*;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
@@ -151,8 +148,8 @@ public class TraceConfigInstrumentation implements Instrumenter {
       ElementMatcher.Junction<MethodDescription> methodMatchers = null;
       for (final String methodName : methodNames) {
         if (methodMatchers == null) {
-          if (methodName == '*') {
-            methodMatchers = isPublic().not(isAbstract()).or(isPrivate().not(isAbstract()));
+          if (methodName.equals("*")) {
+            methodMatchers = not(isAbstract()).and(noneOf("hashCode", "equals"));
           } else {
             methodMatchers = named(methodName);
           }

--- a/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceConfigInstrumentation.java
+++ b/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceConfigInstrumentation.java
@@ -149,7 +149,8 @@ public class TraceConfigInstrumentation implements Instrumenter {
       for (final String methodName : methodNames) {
         if (methodMatchers == null) {
           if (methodName.equals("*")) {
-            methodMatchers = not(isAbstract()).and(noneOf("hashCode", "equals"));
+//            methodMatchers = not(isAbstract()).and(noneOf("hashCode", "equals"));
+              methodMatchers = any();
           } else {
             methodMatchers = named(methodName);
           }

--- a/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceConfigInstrumentation.java
+++ b/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceConfigInstrumentation.java
@@ -63,7 +63,7 @@ public class TraceConfigInstrumentation implements Instrumenter {
 
     } else if (!validateConfigString(configString)) {
       log.warn(
-          "Invalid trace method config '{}'. Must match 'package.Class$Name[method1,method2];*'.",
+          "Invalid trace method config '{}'. Must match 'package.Class$Name[method1,method2];*' or 'package.Class$Name[*];*'.",
           configString);
       classMethodsToTrace = Collections.emptyMap();
 

--- a/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceConfigInstrumentation.java
+++ b/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceConfigInstrumentation.java
@@ -2,7 +2,14 @@ package datadog.trace.instrumentation.trace_annotation;
 
 import static datadog.trace.agent.tooling.ClassLoaderMatcher.hasClassesNamed;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers.safeHasSuperType;
-import static net.bytebuddy.matcher.ElementMatchers.*;
+import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
+import static net.bytebuddy.matcher.ElementMatchers.isEquals;
+import static net.bytebuddy.matcher.ElementMatchers.isFinalizer;
+import static net.bytebuddy.matcher.ElementMatchers.isHashCode;
+import static net.bytebuddy.matcher.ElementMatchers.isSynthetic;
+import static net.bytebuddy.matcher.ElementMatchers.isToString;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.not;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
@@ -32,7 +39,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 @AutoService(Instrumenter.class)
 public class TraceConfigInstrumentation implements Instrumenter {
 
-  static final String PACKAGE_CLASS_NAME_REGEX = "[\\w .\\$]+";
+  static final String PACKAGE_CLASS_NAME_REGEX = "[\\w.\\$]+";
   private static final String METHOD_LIST_REGEX =
       "\\s*(?:\\*|(?:\\w+\\s*,)*\\s*(?:\\w+\\s*,?))\\s*";
   private static final String CONFIG_FORMAT =
@@ -154,6 +161,7 @@ public class TraceConfigInstrumentation implements Instrumenter {
                     isHashCode()
                         .or(isEquals())
                         .or(isToString())
+                        .or(isFinalizer())
                         .or(isConstructor())
                         .or(isSynthetic()));
           } else {

--- a/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceConfigInstrumentation.java
+++ b/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceConfigInstrumentation.java
@@ -3,6 +3,7 @@ package datadog.trace.instrumentation.trace_annotation;
 import static datadog.trace.agent.tooling.ClassLoaderMatcher.hasClassesNamed;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers.safeHasSuperType;
 import static net.bytebuddy.matcher.ElementMatchers.isAbstract;
+import static net.bytebuddy.matcher.ElementMatchers.isPrivate;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 
@@ -151,7 +152,7 @@ public class TraceConfigInstrumentation implements Instrumenter {
       for (final String methodName : methodNames) {
         if (methodMatchers == null) {
           if (methodName == '*') {
-            methodMatchers = isPublic().not(isAbstract());
+            methodMatchers = isPublic().not(isAbstract()).or(isPrivate().not(isAbstract()));
           } else {
             methodMatchers = named(methodName);
           }

--- a/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceConfigInstrumentation.java
+++ b/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceConfigInstrumentation.java
@@ -5,7 +5,9 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers.sa
 import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
 import static net.bytebuddy.matcher.ElementMatchers.isEquals;
 import static net.bytebuddy.matcher.ElementMatchers.isFinalizer;
+import static net.bytebuddy.matcher.ElementMatchers.isGetter;
 import static net.bytebuddy.matcher.ElementMatchers.isHashCode;
+import static net.bytebuddy.matcher.ElementMatchers.isSetter;
 import static net.bytebuddy.matcher.ElementMatchers.isSynthetic;
 import static net.bytebuddy.matcher.ElementMatchers.isToString;
 import static net.bytebuddy.matcher.ElementMatchers.named;
@@ -162,7 +164,9 @@ public class TraceConfigInstrumentation implements Instrumenter {
                         .or(isEquals())
                         .or(isToString())
                         .or(isFinalizer())
+                        .or(isGetter())
                         .or(isConstructor())
+                        .or(isSetter())
                         .or(isSynthetic()));
           } else {
             methodMatchers = named(methodName);

--- a/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceConfigInstrumentation.java
+++ b/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceConfigInstrumentation.java
@@ -32,8 +32,8 @@ import net.bytebuddy.matcher.ElementMatcher;
 @AutoService(Instrumenter.class)
 public class TraceConfigInstrumentation implements Instrumenter {
 
-  static final String PACKAGE_CLASS_NAME_REGEX = "[\\w.\\$]+";
-  private static final String METHOD_LIST_REGEX = "\\s*(?:\\w+\\s*,)*\\s*(?:\\w+\\s*,?)\\s*";
+  static final String PACKAGE_CLASS_NAME_REGEX = "[\\w .\\$]+";
+  private static final String METHOD_LIST_REGEX = "\\s*(?:\\*|(?:\\w+\\s*,)*\\s*(?:\\w+\\s*,?))\\s*";
   private static final String CONFIG_FORMAT =
       "(?:\\s*"
           + PACKAGE_CLASS_NAME_REGEX

--- a/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/TraceConfigTest.groovy
+++ b/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/TraceConfigTest.groovy
@@ -49,8 +49,8 @@ class TraceConfigTest extends AgentTestRunner {
   }
 
   def "test configuration based trace with wildcards"() {
-    setup:
-    injectSysConfig("dd.trace.methods", "${ConfigTracedCallable2.name}[*]")
+//    setup:
+//    injectSysConfig("dd.trace.methods", "${ConfigTracedCallable2.name}[*]")
 
     when:
     new ConfigTracedCallable2().call() == "Hello2!"

--- a/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/TraceConfigTest.groovy
+++ b/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/TraceConfigTest.groovy
@@ -56,7 +56,7 @@ class TraceConfigTest extends AgentTestRunner {
   }
 
   class Pig extends Animal {
-    public void animalSound() {
+    void animalSound() {
       System.out.println("The pig says: wee wee")
     }
   }
@@ -110,9 +110,9 @@ class TraceConfigTest extends AgentTestRunner {
   def "test wildcard configuration with class implementing interface"() {
 
     when:
-    Human charlie = new Human();
-    charlie.setName("Charlie");
-    charlie.setHeight(4);
+    Human charlie = new Human()
+    charlie.setName("Charlie")
+    charlie.setHeight(4)
 
     then:
     assertTraces(2) {
@@ -141,7 +141,7 @@ class TraceConfigTest extends AgentTestRunner {
   def "test wildcard configuration based on class extending abstract class"() {
 
     when:
-    new Pig().animalSound();
+    new Pig().animalSound()
 
     then:
     assertTraces(1) {

--- a/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/TraceConfigTest.groovy
+++ b/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/TraceConfigTest.groovy
@@ -20,6 +20,11 @@ class TraceConfigTest extends AgentTestRunner {
   }
 
   class ConfigTracedCallable2 implements Callable<String> {
+    int g
+
+    public ConfigTracedCallable2(){
+      g = 4
+    }
     @Override
     String call() throws Exception {
       return call_helper()
@@ -27,6 +32,13 @@ class TraceConfigTest extends AgentTestRunner {
 
     String call_helper() throws Exception {
       return "Hello2!"
+    }
+
+    String getValue() {
+      return "hello"
+    }
+    void setValue(int value) {
+      g = value
     }
   }
 
@@ -112,10 +124,18 @@ class TraceConfigTest extends AgentTestRunner {
   }
 
   def "test wildcard configuration"() {
-
     when:
-    new ConfigTracedCallable2().call() == "Hello2!"
+    ConfigTracedCallable2 object = new ConfigTracedCallable2()
+    object.call()
+    object.hashCode()
+    object == new ConfigTracedCallable2()
+    object.toString()
+    object.finalize()
+    object.getValue()
+    object.setValue(5)
     new Sophisticated().produceDefinition()
+
+
     then:
     assertTraces(2) {
       trace(2) {

--- a/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/TraceConfigTest.groovy
+++ b/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/TraceConfigTest.groovy
@@ -22,7 +22,7 @@ class TraceConfigTest extends AgentTestRunner {
   class ConfigTracedCallable2 implements Callable<String> {
     int g
 
-    public ConfigTracedCallable2(){
+    ConfigTracedCallable2(){
       g = 4
     }
     @Override

--- a/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/TraceConfigTest.groovy
+++ b/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/TraceConfigTest.groovy
@@ -22,42 +22,42 @@ class TraceConfigTest extends AgentTestRunner {
   class ConfigTracedCallable2 implements Callable<String> {
     @Override
     String call() throws Exception {
-      return call_helper();
+      return call_helper()
     }
 
     String call_helper() throws Exception {
-      return "Hello2!";
+      return "Hello2!"
     }
   }
 
   interface Mammal {
-    void setName(String newName);
-    void setHeight(int newHeight);
+    void setName(String newName)
+    void setHeight(int newHeight)
   }
 
   class Human implements Mammal {
-    String name;
-    String height;
+    String name
+    String height
 
     void setName(String newName){
-      name = newName;
+      name = newName
     }
     void setHeight(int newHeight){
-      height = newHeight;
+      height = newHeight
     }
   }
 
 
   abstract class Animal {
-    public abstract void animalSound();
-    public void sleep() {
-      System.out.println("Zzz");
+    abstract void animalSound()
+    void sleep() {
+      System.out.println("Zzz")
     }
   }
 
   class Pig extends Animal {
     public void animalSound() {
-      System.out.println("The pig says: wee wee");
+      System.out.println("The pig says: wee wee")
     }
   }
 


### PR DESCRIPTION
PR to extend support of DD_TRACE_METHODS configuration to support wildcards in method calls

EX: `ClassName[*] `