### PR TITLE
metric buffering + payload format change

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/Aggregator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/Aggregator.java
@@ -16,6 +16,9 @@ final class Aggregator implements Runnable {
   private final LRUCache<MetricKey, AggregateMetric> aggregates;
   private final ConcurrentHashMap<MetricKey, Batch> pending;
   private final MetricWriter writer;
+  // the reporting interval controls how much history will be buffered
+  // when the agent is unresponsive (only 10 pending requests will be
+  // buffered by OkHttpSink)
   private final long reportingIntervalNanos;
 
   private long wallClockTime = -1;

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/ConflatingMetricsAggregator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/ConflatingMetricsAggregator.java
@@ -103,7 +103,6 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
             span.getServiceName(),
             span.getOperationName(),
             span.getType(),
-            span.getTag(Tags.DB_TYPE, (CharSequence) ""),
             span.getTag(Tags.HTTP_STATUS, ZERO));
     boolean error = span.getError() > 0;
     long durationNanos = span.getDurationNano();

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/MetricKey.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/MetricKey.java
@@ -9,7 +9,6 @@ public final class MetricKey {
   private final UTF8BytesString service;
   private final UTF8BytesString operationName;
   private final UTF8BytesString type;
-  private final UTF8BytesString dbType;
   private final int httpStatusCode;
 
   public MetricKey(
@@ -17,13 +16,11 @@ public final class MetricKey {
       CharSequence service,
       CharSequence operationName,
       CharSequence type,
-      CharSequence dbType,
       int httpStatusCode) {
     this.resource = UTF8BytesString.create(null == resource ? "" : resource);
     this.service = UTF8BytesString.create(null == service ? "" : service);
     this.operationName = UTF8BytesString.create(null == operationName ? "" : operationName);
     this.type = UTF8BytesString.create(null == type ? "" : type);
-    this.dbType = UTF8BytesString.create(null == dbType ? "" : dbType);
     this.httpStatusCode = httpStatusCode;
   }
 
@@ -43,10 +40,6 @@ public final class MetricKey {
     return type;
   }
 
-  public UTF8BytesString getDbType() {
-    return dbType;
-  }
-
   public int getHttpStatusCode() {
     return httpStatusCode;
   }
@@ -60,12 +53,11 @@ public final class MetricKey {
         && resource.equals(metricKey.resource)
         && service.equals(metricKey.service)
         && operationName.equals(metricKey.operationName)
-        && type.equals(metricKey.type)
-        && dbType.equals(metricKey.dbType);
+        && type.equals(metricKey.type);
   }
 
   @Override
   public int hashCode() {
-    return 97 * Objects.hash(resource, service, operationName, type, dbType) + httpStatusCode;
+    return 97 * Objects.hash(resource, service, operationName, type) + httpStatusCode;
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/OkHttpSink.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/OkHttpSink.java
@@ -7,40 +7,103 @@ import static datadog.trace.common.metrics.EventListener.EventType.OK;
 import static datadog.trace.core.http.OkHttpUtils.buildHttpClient;
 import static datadog.trace.core.http.OkHttpUtils.msgpackRequestBodyOf;
 import static datadog.trace.core.http.OkHttpUtils.prepareRequest;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
+import datadog.trace.util.AgentTaskScheduler;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import lombok.extern.slf4j.Slf4j;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import org.jctools.queues.SpscArrayQueue;
 
+@Slf4j
 public final class OkHttpSink implements Sink, EventListener {
 
   private final OkHttpClient client;
   private final HttpUrl metricsUrl;
   private final List<EventListener> listeners;
+  private final SpscArrayQueue<Request> enqueuedRequests = new SpscArrayQueue<>(10);
+  private final AtomicLong lastRequestTime = new AtomicLong();
+  private final AtomicLong asyncRequestCounter = new AtomicLong();
+  private final long asyncThresholdLatency;
+
+  private final AtomicBoolean asyncTaskStarted = new AtomicBoolean(false);
+  private volatile AgentTaskScheduler.Scheduled<OkHttpSink> future;
 
   public OkHttpSink(String agentUrl, long timeoutMillis) {
     this(buildHttpClient(HttpUrl.get(agentUrl), timeoutMillis), agentUrl, "v0.5/stats");
   }
 
   public OkHttpSink(OkHttpClient client, String agentUrl, String path) {
+    this(client, agentUrl, path, SECONDS.toNanos(1));
+  }
+
+  public OkHttpSink(OkHttpClient client, String agentUrl, String path, long asyncThresholdLatency) {
     this.client = client;
     this.metricsUrl = HttpUrl.get(agentUrl).resolve(path);
     this.listeners = new CopyOnWriteArrayList<>();
+    this.asyncThresholdLatency = asyncThresholdLatency;
   }
 
   @Override
   public void accept(int messageCount, ByteBuffer buffer) {
-    try (final okhttp3.Response response =
-        client
-            .newCall(
-                prepareRequest(metricsUrl)
-                    .put(msgpackRequestBodyOf(Collections.singletonList(buffer)))
-                    .build())
-            .execute()) {
+    // if the agent is healthy, then we can send on this thread,
+    // without copying the buffer, otherwise this needs to be async,
+    // so need to copy and buffer the request, and let it be executed
+    // on the main task scheduler as a last resort
+    if (lastRequestTime.get() < asyncThresholdLatency) {
+      send(
+          prepareRequest(metricsUrl)
+              .put(msgpackRequestBodyOf(Collections.singletonList(buffer)))
+              .build());
+      AgentTaskScheduler.Scheduled<OkHttpSink> future = this.future;
+      if (future != null && enqueuedRequests.isEmpty()) {
+        // async mode has been started but request latency is normal,
+        // there is no pending work, so switch off async mode
+        future.cancel();
+        asyncTaskStarted.set(false);
+      }
+    } else {
+      if (asyncTaskStarted.compareAndSet(false, true)) {
+        this.future =
+            AgentTaskScheduler.INSTANCE.scheduleAtFixedRate(
+                new Sender(enqueuedRequests), this, 1, 1, SECONDS);
+      }
+      sendAsync(messageCount, buffer);
+    }
+  }
+
+  private void sendAsync(int messageCount, ByteBuffer buffer) {
+    asyncRequestCounter.getAndIncrement();
+    if (!enqueuedRequests.offer(
+        prepareRequest(metricsUrl)
+            .put(msgpackRequestBodyOf(Collections.singletonList(buffer.duplicate())))
+            .build())) {
+      log.debug(
+          "dropping payload of {} and {}B because sending queue was full",
+          messageCount,
+          buffer.limit());
+    }
+  }
+
+  public boolean isInDegradedMode() {
+    return asyncTaskStarted.get();
+  }
+
+  public long asyncRequestCount() {
+    return asyncRequestCounter.get();
+  }
+
+  private void send(Request request) {
+    long start = System.nanoTime();
+    try (final okhttp3.Response response = client.newCall(request).execute()) {
       if (!response.isSuccessful()) {
         handleFailure(response);
       } else {
@@ -48,6 +111,8 @@ public final class OkHttpSink implements Sink, EventListener {
       }
     } catch (IOException e) {
       onEvent(ERROR, e.getMessage());
+    } finally {
+      lastRequestTime.set(System.nanoTime() - start);
     }
   }
 
@@ -71,6 +136,23 @@ public final class OkHttpSink implements Sink, EventListener {
       onEvent(BAD_PAYLOAD, response.body().string());
     } else if (code >= 500) {
       onEvent(ERROR, response.body().string());
+    }
+  }
+
+  private static final class Sender implements AgentTaskScheduler.Task<OkHttpSink> {
+
+    private final SpscArrayQueue<Request> inbox;
+
+    private Sender(SpscArrayQueue<Request> inbox) {
+      this.inbox = inbox;
+    }
+
+    @Override
+    public void run(OkHttpSink target) {
+      Request request;
+      while ((request = inbox.poll()) != null) {
+        target.send(request);
+      }
     }
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/SerializingMetricWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/SerializingMetricWriter.java
@@ -24,7 +24,6 @@ public final class SerializingMetricWriter implements MetricWriter {
   private static final byte[] ERRORS = "Errors".getBytes(US_ASCII);
   private static final byte[] DURATION = "Duration".getBytes(US_ASCII);
   private static final byte[] TYPE = "Type".getBytes(US_ASCII);
-  private static final byte[] DBTYPE = "DBType".getBytes(US_ASCII);
   private static final byte[] HTTP_STATUS_CODE = "HTTPStatusCode".getBytes(US_ASCII);
   private static final byte[] START = "Start".getBytes(US_ASCII);
   private static final byte[] STATS = "Stats".getBytes(US_ASCII);
@@ -72,7 +71,7 @@ public final class SerializingMetricWriter implements MetricWriter {
 
   @Override
   public void add(MetricKey key, AggregateMetric aggregate) {
-    writer.startMap(11);
+    writer.startMap(10);
 
     writer.writeUTF8(NAME);
     writer.writeUTF8(key.getOperationName());
@@ -85,9 +84,6 @@ public final class SerializingMetricWriter implements MetricWriter {
 
     writer.writeUTF8(TYPE);
     writer.writeUTF8(key.getType());
-
-    writer.writeUTF8(DBTYPE);
-    writer.writeUTF8(key.getDbType());
 
     writer.writeUTF8(HTTP_STATUS_CODE);
     writer.writeInt(key.getHttpStatusCode());

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/AgentIntegrationTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/AgentIntegrationTest.groovy
@@ -26,11 +26,11 @@ class AgentIntegrationTest extends DDSpecification {
     )
     writer.startBucket(2, System.nanoTime(), SECONDS.toNanos(10))
     writer.add(
-      new MetricKey("resource1", "service1", "operation1", "sql", "oracle", 0),
+      new MetricKey("resource1", "service1", "operation1", "sql", 0),
       new AggregateMetric().addHits(10).addErrors(1)
     )
     writer.add(
-      new MetricKey("resource2", "service2", "operation2", "web", "", 200),
+      new MetricKey("resource2", "service2", "operation2", "web", 200),
       new AggregateMetric().addHits(9).addErrors(1)
     )
     writer.finishBucket()

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/AggregateMetricTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/AggregateMetricTest.groovy
@@ -41,7 +41,7 @@ class AggregateMetricTest extends DDSpecification {
     given:
     AggregateMetric aggregate = new AggregateMetric().recordDurations(3, 1L, 0L, 0L, 0L)
 
-    Batch batch = new Batch().withKey(new MetricKey("foo", "bar", "qux", "type", "", 0))
+    Batch batch = new Batch().withKey(new MetricKey("foo", "bar", "qux", "type", 0))
     batch.add(false, 10)
     batch.add(false, 10)
     batch.add(false, 10)
@@ -88,7 +88,7 @@ class AggregateMetricTest extends DDSpecification {
   def "consistent under concurrent attempts to read and write"() {
     given:
     AggregateMetric aggregate = new AggregateMetric()
-    MetricKey key = new MetricKey("foo", "bar", "qux", "type", "", 0)
+    MetricKey key = new MetricKey("foo", "bar", "qux", "type", 0)
     BlockingDeque<Batch> queue = new LinkedBlockingDeque<>(1000)
     ExecutorService reader = Executors.newSingleThreadExecutor()
     int writerCount = 10

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/ConflatingMetricAggregatorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/ConflatingMetricAggregatorTest.groovy
@@ -64,10 +64,10 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     then: "metrics should be conflated"
     1 * writer.finishBucket() >> { latch.countDown() }
     1 * writer.startBucket(2, _, SECONDS.toNanos(reportingInterval))
-    1 * writer.add(new MetricKey("resource", "service", "operation", "type", "", 0), _) >> {
+    1 * writer.add(new MetricKey("resource", "service", "operation", "type", 0), _) >> {
       MetricKey key, AggregateMetric value -> value.getHitCount() == count && value.getDuration() == count * duration
     }
-    1 * writer.add(new MetricKey("resource2", "service2", "operation2", "type", "", 0), _) >> {
+    1 * writer.add(new MetricKey("resource2", "service2", "operation2", "type", 0), _) >> {
       MetricKey key, AggregateMetric value -> value.getHitCount() == count && value.getDuration() == count * duration * 2
     }
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/OkHttpSinkTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/OkHttpSinkTest.groovy
@@ -11,6 +11,10 @@ import okhttp3.ResponseBody
 import spock.lang.Requires
 
 import java.nio.ByteBuffer
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 
 import static datadog.trace.api.Platform.isJavaVersionAtLeast
 import static datadog.trace.common.metrics.EventListener.EventType.BAD_PAYLOAD
@@ -27,7 +31,6 @@ class OkHttpSinkTest extends DDSpecification {
     String path = "v0.5/stats"
     EventListener listener = Mock(EventListener)
     OkHttpClient client = Mock(OkHttpClient)
-
     OkHttpSink sink = new OkHttpSink(client, agentUrl, path)
     sink.register(listener)
 
@@ -48,6 +51,53 @@ class OkHttpSinkTest extends DDSpecification {
     OK          | 201
   }
 
+  def "degrade to async mode when agent slow to respond"() {
+    // metrics payloads are relatively large and we don't want to copy them,
+    // and we typically expect the agent to respond well within the aggregation
+    // window, so will send synchronously whenever possible to avoid allocating
+    // a copy of the payload. When the agent is slow to respond, we degrade to
+    // an asynchronous mode where up to 100 seconds of requests are copied and
+    // enqueued for sending in the background, because we don't want to lose
+    // them if it's possible not to.
+    setup:
+    String agentUrl = "http://localhost:8126"
+    String path = "v0.5/stats"
+    CountDownLatch latch = new CountDownLatch(2)
+    EventListener listener = new BlockingListener(latch)
+    OkHttpClient client = Mock(OkHttpClient)
+    OkHttpSink sink = new OkHttpSink(client, agentUrl, path,
+      TimeUnit.MILLISECONDS.toNanos(100))
+    sink.register(listener)
+    AtomicBoolean first = new AtomicBoolean(true)
+
+    when: "one slow response followed by a request"
+    sink.accept(1, ByteBuffer.allocate(0))
+    sink.accept(1, ByteBuffer.allocate(0))
+    latch.await()
+    then: "the second request degrades to async mode"
+    2 * client.newCall(_) >> { Request request ->
+      if (first.compareAndSet(true, false)) {
+        Thread.sleep(101)
+      } else {
+        assert sink.isInDegradedMode()
+      }
+      respond(request, 200)
+    }
+    listener.events.size() == 2
+    for (EventListener.EventType eventType : listener.events) {
+      assert eventType == OK
+    }
+    long asyncRequests = sink.asyncRequestCount()
+    asyncRequests == 1
+    sink.isInDegradedMode()
+    when: "the agent has recovered and has responded quickly once"
+    sink.accept(1, ByteBuffer.allocate(0))
+    then: "the request was sent synchronously"
+    1 * client.newCall(_) >> { Request request -> respond(request, 200) }
+    asyncRequests == sink.asyncRequestCount()
+    !sink.isInDegradedMode()
+  }
+
   def respond(Request request, int code) {
     if (0 == code) {
       return error(request)
@@ -66,6 +116,22 @@ class OkHttpSinkTest extends DDSpecification {
   def error(Request request) {
     return Mock(Call) {
       it.execute() >> { throw new IOException("thrown by test") }
+    }
+  }
+
+  class BlockingListener implements EventListener {
+
+    private final CountDownLatch latch
+    private List<EventType> events = new CopyOnWriteArrayList<>()
+
+    BlockingListener(CountDownLatch latch) {
+      this.latch = latch
+    }
+
+    @Override
+    void onEvent(EventType eventType, String message) {
+      events.add(eventType)
+      latch.countDown()
     }
   }
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SerializingMetricWriterTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SerializingMetricWriterTest.groovy
@@ -1,6 +1,5 @@
 package datadog.trace.common.metrics
 
-import datadog.trace.api.Platform
 import datadog.trace.api.WellKnownTags
 import datadog.trace.bootstrap.instrumentation.api.Pair
 import datadog.trace.test.util.DDSpecification
@@ -39,8 +38,8 @@ class SerializingMetricWriterTest extends DDSpecification {
     where:
     content << [
       [
-              Pair.of(new MetricKey("resource1", "service1", "operation1", "type", "", 0), new AggregateMetric().recordDurations(10, 1L)),
-              Pair.of(new MetricKey("resource2", "service2", "operation2", "type2", "dbtype", 200), new AggregateMetric().recordDurations(9, 1L))
+              Pair.of(new MetricKey("resource1", "service1", "operation1", "type", 0), new AggregateMetric().recordDurations(10, 1L)),
+              Pair.of(new MetricKey("resource2", "service2", "operation2", "type2", 200), new AggregateMetric().recordDurations(9, 1L))
       ]
     ]
   }
@@ -93,7 +92,7 @@ class SerializingMetricWriterTest extends DDSpecification {
         MetricKey key = pair.getLeft()
         AggregateMetric value = pair.getRight()
         int size = unpacker.unpackMapHeader()
-        assert size == 11
+        assert size == 10
         int elementCount = 0
         assert unpacker.unpackString() == "Name"
         assert unpacker.unpackString() == key.getOperationName() as String
@@ -106,9 +105,6 @@ class SerializingMetricWriterTest extends DDSpecification {
         ++elementCount
         assert unpacker.unpackString() == "Type"
         assert unpacker.unpackString() == key.getType() as String
-        ++elementCount
-        assert unpacker.unpackString() == "DBType"
-        assert unpacker.unpackString() == key.getDbType() as String
         ++elementCount
         assert unpacker.unpackString() == "HTTPStatusCode"
         assert unpacker.unpackInt() == key.getHttpStatusCode()
@@ -134,7 +130,7 @@ class SerializingMetricWriterTest extends DDSpecification {
     }
 
     private void validateSketch(MessageUnpacker unpacker) {
-      if (Platform.isJavaVersionAtLeast(8)) {
+      if (isJavaVersionAtLeast(8)) {
         int length = unpacker.unpackBinaryHeader()
         assert length > 0
         unpacker.readPayload(length)


### PR DESCRIPTION
* We don't need dbtype on the metrics any more
* We need a buffering mechanism for when the agent is in a degraded state