### PR TITLE
Consider transitive interfaces when deciding which class to field-inject

### DIFF
--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/context/ShouldInjectFieldsMatcherTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/context/ShouldInjectFieldsMatcherTest.groovy
@@ -65,6 +65,8 @@ class ShouldInjectFieldsMatcherTest extends DDSpecification {
     "java.util.concurrent.RunnableFuture" | "java.util.concurrent.ExecutorCompletionService\$QueueingFuture"        | "java.util.concurrent.FutureTask"
     // tests the case where a class in the hierarchy does not implement the target interface but subclasses something which does
     "java.util.concurrent.RunnableFuture" | "datadog.trace.agent.test.LeafFutureTask"                               | "java.util.concurrent.FutureTask"
+    // tests the case where a direct interface in the hierarchy does not extend the target interface but an indirect interface does
+    "java.util.concurrent.Future"         | "datadog.trace.agent.test.LeafFutureTask"                               | "java.util.concurrent.FutureTask"
   }
 
 }


### PR DESCRIPTION
Also updates debug logging to only log failed redefines if we would have originally injected the class. This avoids log-spam when we inject the field into a superclass and later on the subclass is redefined.