### PR TITLE
Muzzle updates to reflect recent servlet 5 releases

### DIFF
--- a/dd-java-agent/instrumentation/jetty-8/jetty-8.gradle
+++ b/dd-java-agent/instrumentation/jetty-8/jetty-8.gradle
@@ -2,7 +2,8 @@ muzzle {
   pass {
     group = "org.eclipse.jetty"
     module = 'jetty-server'
-    versions = "[8.0.0.v20110901,)"
+    versions = "[8.0.0.v20110901,11)"
+    extraDependency "javax.servlet:javax.servlet-api:3.0.1"
     assertInverse = true
   }
 }

--- a/dd-java-agent/instrumentation/jsp-2.3/jsp-2.3.gradle
+++ b/dd-java-agent/instrumentation/jsp-2.3/jsp-2.3.gradle
@@ -5,7 +5,7 @@ muzzle {
     group = "org.apache.tomcat"
     module = "tomcat-jasper"
     // range [7.0.0,7.0.19) and version 8.0.9 missing from maven
-    versions = "[7.0.19,8.0.9),(8.0.9,)"
+    versions = "[7.0.19,8.0.9),(8.0.9,10)"
   }
 }
 

--- a/dd-java-agent/instrumentation/vertx-web-3.4/vertx-web-3.4.gradle
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/vertx-web-3.4.gradle
@@ -11,7 +11,7 @@ muzzle {
   pass {
     group = 'io.vertx'
     module = "vertx-web"
-    versions = "[3.4.0,)"
+    versions = "[3.4.0,4)"
     assertInverse = true
   }
 }


### PR DESCRIPTION
* Exclude Jetty 11 from muzzle as it requires servlet 5.0 which has different package names. Also pin the servlet spec version to fix a muzzle issue with Jetty 10 which pulls in servlet 4.0 that has a class compiled with Java 11 (it can still work with servlet 3)
* Update vertx-web muzzle range to exclude 4.0.0 which removes 'rawMethod' from its HttpServerRequest
* Update jsp muzzle range to exclude tomcat-jasper 10.0.0 as it requires servlet 5.0 which has different package names