### PR TITLE
Don't check total count of request handlers in AmazonWebServiceClient

### DIFF
--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test/groovy/AWS1ClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test/groovy/AWS1ClientTest.groovy
@@ -21,6 +21,7 @@ import com.amazonaws.services.dynamodbv2.model.CreateTableRequest
 import com.amazonaws.services.ec2.AmazonEC2ClientBuilder
 import com.amazonaws.services.kinesis.AmazonKinesisClientBuilder
 import com.amazonaws.services.kinesis.model.DeleteStreamRequest
+import com.amazonaws.services.rds.AmazonRDSClient
 import com.amazonaws.services.rds.AmazonRDSClientBuilder
 import com.amazonaws.services.rds.model.DeleteOptionGroupRequest
 import com.amazonaws.services.s3.AmazonS3Client
@@ -123,7 +124,8 @@ class AWS1ClientTest extends AgentTestRunner {
     response != null
 
     client.requestHandler2s != null
-    client.requestHandler2s.size() == handlerCount
+    client.requestHandler2s.size() == handlerCount ||
+      (client instanceof AmazonRDSClient && client.requestHandler2s.size() == (handlerCount + 1))
     client.requestHandler2s.get(0).getClass().getSimpleName() == "TracingRequestHandler"
 
     assertTraces(1) {

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test/groovy/AWS1ClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test/groovy/AWS1ClientTest.groovy
@@ -123,7 +123,8 @@ class AWS1ClientTest extends AgentTestRunner {
     response != null
 
     client.requestHandler2s != null
-    client.requestHandler2s.get(0).getClass().getSimpleName() == "TracingRequestHandler"
+    // check we instrumented with exactly one TracingRequestHandler:
+    client.requestHandler2s.findAll{ it.getClass().getSimpleName() == "TracingRequestHandler" }.size() == 1
 
     assertTraces(1) {
       trace(2) {


### PR DESCRIPTION
latest `AmazonRDSClient` seems to have extra `StartDBInstanceAutomatedBackupsReplicationPresignHandler`and the count of `requestHandler2s` becomes 5 instead of 4 in previous versions (+ we add our TracingRequestHandler during instrumentation).

This change:
- removes check for total count of requestHandler2s 
- checks that exactly one "TracingRequestHandler" was added during instrumentation

