### PR TITLE
bump DDSketch and drop protobuf-java dependency

### DIFF
--- a/dd-java-agent/dd-java-agent.gradle
+++ b/dd-java-agent/dd-java-agent.gradle
@@ -157,7 +157,7 @@ task('checkAgentJarSize') {
   doLast {
     // Arbitrary limit to prevent unintentional increases to the agent jar size
     // Raise or lower as required
-    assert shadowJar.archiveFile.get().getAsFile().length() < 16 * 1024 * 1024
+    assert shadowJar.archiveFile.get().getAsFile().length() < 14 * 1024 * 1024
   }
 
   dependsOn shadowJar

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/AggregateMetric.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/AggregateMetric.java
@@ -3,6 +3,7 @@ package datadog.trace.common.metrics;
 import datadog.trace.core.histogram.Histogram;
 import datadog.trace.core.histogram.HistogramFactory;
 import datadog.trace.core.histogram.Histograms;
+import java.nio.ByteBuffer;
 
 /** Not thread-safe. Accumulates counts and durations. */
 public final class AggregateMetric {
@@ -47,11 +48,11 @@ public final class AggregateMetric {
     return duration;
   }
 
-  public byte[] getHitLatencies() {
+  public ByteBuffer getHitLatencies() {
     return hitLatencies.serialize();
   }
 
-  public byte[] getErrorLatencies() {
+  public ByteBuffer getErrorLatencies() {
     return errorLatencies.serialize();
   }
 

--- a/utils/histograms/histograms.gradle
+++ b/utils/histograms/histograms.gradle
@@ -14,9 +14,8 @@ dependencies {
   compile deps.slf4j
   compile project(':internal-api')
 
-  // currently required to serialize DDSketch
-  compile group: 'com.google.protobuf', name: 'protobuf-java', version: '3.14.0'
-  compile group: 'com.datadoghq', name: 'sketches-java', version: '0.5.0'
+  compile group: 'com.datadoghq', name: 'sketches-java', version: '0.6.0'
 
+  testCompile group: 'com.google.protobuf', name: 'protobuf-java', version: '3.14.0'
   testCompile project(':utils:test-utils')
 }

--- a/utils/histograms/src/main/java/datadog/trace/core/histogram/DDSketchHistogram.java
+++ b/utils/histograms/src/main/java/datadog/trace/core/histogram/DDSketchHistogram.java
@@ -3,6 +3,7 @@ package datadog.trace.core.histogram;
 import com.datadoghq.sketch.ddsketch.DDSketch;
 import com.datadoghq.sketch.ddsketch.mapping.CubicallyInterpolatedMapping;
 import com.datadoghq.sketch.ddsketch.store.PaginatedStore;
+import java.nio.ByteBuffer;
 
 public class DDSketchHistogram implements Histogram, HistogramFactory {
 
@@ -23,8 +24,8 @@ public class DDSketchHistogram implements Histogram, HistogramFactory {
   }
 
   @Override
-  public byte[] serialize() {
-    return sketch.toProto().toByteArray();
+  public ByteBuffer serialize() {
+    return sketch.serialize();
   }
 
   @Override

--- a/utils/histograms/src/main/java/datadog/trace/core/histogram/Histogram.java
+++ b/utils/histograms/src/main/java/datadog/trace/core/histogram/Histogram.java
@@ -1,10 +1,12 @@
 package datadog.trace.core.histogram;
 
+import java.nio.ByteBuffer;
+
 public interface Histogram {
 
   void accept(long value);
 
   void clear();
 
-  byte[] serialize();
+  ByteBuffer serialize();
 }

--- a/utils/histograms/src/main/java/datadog/trace/core/histogram/StubHistogram.java
+++ b/utils/histograms/src/main/java/datadog/trace/core/histogram/StubHistogram.java
@@ -1,7 +1,9 @@
 package datadog.trace.core.histogram;
 
+import java.nio.ByteBuffer;
+
 public class StubHistogram implements Histogram, HistogramFactory {
-  private static final byte[] EMPTY = new byte[0];
+  private static final ByteBuffer EMPTY = ByteBuffer.allocate(0);
 
   @Override
   public void accept(long value) {}
@@ -10,7 +12,7 @@ public class StubHistogram implements Histogram, HistogramFactory {
   public void clear() {}
 
   @Override
-  public byte[] serialize() {
+  public ByteBuffer serialize() {
     return EMPTY;
   }
 

--- a/utils/histograms/src/test/groovy/HistogramsTest.groovy
+++ b/utils/histograms/src/test/groovy/HistogramsTest.groovy
@@ -6,6 +6,8 @@ import datadog.trace.core.histogram.Histograms
 import datadog.trace.core.histogram.StubHistogram
 import datadog.trace.test.util.DDSpecification
 
+import java.nio.ByteBuffer
+
 class HistogramsTest extends DDSpecification {
 
   def "histogram factory creates DDSketch"() {
@@ -18,7 +20,7 @@ class HistogramsTest extends DDSpecification {
     Histogram histogram = Histograms.newHistogramFactory().newHistogram()
     when:
     histogram.accept(42)
-    byte[] serialized = histogram.serialize()
+    ByteBuffer serialized = histogram.serialize()
     DDSketch proto = DDSketch.parseFrom(serialized)
     then:
     null != proto
@@ -31,7 +33,7 @@ class HistogramsTest extends DDSpecification {
     Histogram histogram = histogramFactory.newHistogram()
     histogram.accept(42)
     then:
-    histogram.serialize().length == 0
+    histogram.serialize().capacity() == 0
   }
 
   def "load stub"() {


### PR DESCRIPTION
DDSketch no long requires `protobuf-java` in order to serialize to protobuf (See [implementation](https://github.com/DataDog/sketches-java/pull/32), [benchmarks](https://github.com/DataDog/sketches-java/pull/40)), so this drops the dependency on protobuf-java, and reduces the threshold on jar size. 