### PR TITLE
Exception in TraceInterceptor crashes PendingTraceBuffer

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -417,8 +417,14 @@ public class CoreTracer implements AgentTracer.TracerAPI {
     List<DDSpan> writtenTrace = trace;
     if (!interceptors.isEmpty()) {
       Collection<? extends MutableSpan> interceptedTrace = new ArrayList<>(trace);
-      for (final TraceInterceptor interceptor : interceptors) {
-        interceptedTrace = interceptor.onTraceComplete(interceptedTrace);
+
+      try {
+        for (final TraceInterceptor interceptor : interceptors) {
+          interceptedTrace = interceptor.onTraceComplete(interceptedTrace);
+        }
+      } catch (Exception e) {
+        log.debug("Exception in TraceInterceptor", e);
+        return;
       }
       writtenTrace = new ArrayList<>(interceptedTrace.size());
       for (final MutableSpan span : interceptedTrace) {

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerTest.groovy
@@ -14,7 +14,6 @@ import datadog.trace.context.TraceScope
 import datadog.trace.core.CoreTracer
 import datadog.trace.core.DDSpan
 import datadog.trace.test.util.DDSpecification
-import spock.lang.Ignore
 import spock.lang.Shared
 
 import java.lang.ref.WeakReference
@@ -631,7 +630,6 @@ class ScopeManagerTest extends DDSpecification {
     span.finish()
 
     then: "exception is thrown in same thread"
-    thrown(RuntimeException)
     interceptor.lastTrace == [span]
 
     and: "scopeManager in good state"
@@ -660,8 +658,6 @@ class ScopeManagerTest extends DDSpecification {
     writer == [[span2]]
   }
 
-  // FIXME this exposes a current bug
-  @Ignore
   def "exception thrown in TraceInterceptor does not leave scope manager in bad state when reporting through PendingTraceBuffer"() {
     setup:
     def interceptor = new ExceptionThrowingInterceptor()


### PR DESCRIPTION
In the ScopeManager Audit PR, I discovered that throwing an exception in a `TraceInterceptor` crashes the PendingTraceBuffer thread and delayed reported traces never get reported again.

This PR fixes that problem with a simple `try..catch` around the interceptor call.