### PR TITLE
Extend JMS Integration to support Time Spent in Queue

### DIFF
--- a/dd-java-agent/instrumentation/jms/src/latestDepTest/groovy/JMS2Test.groovy
+++ b/dd-java-agent/instrumentation/jms/src/latestDepTest/groovy/JMS2Test.groovy
@@ -279,8 +279,6 @@ class JMS2Test extends AgentTestRunner {
           "${Tags.SPAN_KIND}" "consumer"
           if (!messageListener && !isTimestampDisabled) {
             "$InstrumentationTags.RECORD_QUEUE_TIME_MS" {it >= 0 }
-          } else if (isTimestampDisabled){
-            "$InstrumentationTags.RECORD_QUEUE_TIME_MS" {it == null }
           }
           defaultTags(true)
         }

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSDecorator.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSDecorator.java
@@ -1,5 +1,7 @@
 package datadog.trace.instrumentation.jms;
 
+import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.RECORD_QUEUE_TIME_MS;
+
 import datadog.trace.api.DDSpanTypes;
 import datadog.trace.api.DDTags;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
@@ -7,7 +9,9 @@ import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.ClientDecorator;
 import java.lang.reflect.Method;
+import java.util.concurrent.TimeUnit;
 import javax.jms.Destination;
+import javax.jms.JMSException;
 import javax.jms.Message;
 import javax.jms.Queue;
 import javax.jms.TemporaryQueue;
@@ -24,10 +28,10 @@ public final class JMSDecorator extends ClientDecorator {
   private final String spanKind;
   private final String spanType;
   public static final JMSDecorator PRODUCER_DECORATE =
-      new JMSDecorator(Tags.SPAN_KIND_PRODUCER, DDSpanTypes.MESSAGE_PRODUCER);
+    new JMSDecorator(Tags.SPAN_KIND_PRODUCER, DDSpanTypes.MESSAGE_PRODUCER);
 
   public static final JMSDecorator CONSUMER_DECORATE =
-      new JMSDecorator(Tags.SPAN_KIND_CONSUMER, DDSpanTypes.MESSAGE_CONSUMER);
+    new JMSDecorator(Tags.SPAN_KIND_CONSUMER, DDSpanTypes.MESSAGE_CONSUMER);
 
   public JMSDecorator(String spanKind, String spanType) {
     this.spanKind = spanKind;
@@ -61,6 +65,15 @@ public final class JMSDecorator extends ClientDecorator {
 
   public void onConsume(final AgentSpan span, final Message message) {
     span.setTag(DDTags.RESOURCE_NAME, "Consumed from " + toResourceName(message, null));
+
+    try {
+      final long produceTime = message.getJMSTimestamp();
+      if (produceTime > 0) {
+        final long consumeTime = TimeUnit.NANOSECONDS.toMillis(span.getStartTime());
+        span.setTag(RECORD_QUEUE_TIME_MS, Math.max(0L, consumeTime - produceTime));
+      }
+    } catch (final JMSException ignored) {
+    }
     span.setMeasured(true);
   }
 
@@ -73,7 +86,7 @@ public final class JMSDecorator extends ClientDecorator {
   }
 
   public void onProduce(
-      final AgentSpan span, final Message message, final Destination destination) {
+    final AgentSpan span, final Message message, final Destination destination) {
     span.setTag(DDTags.RESOURCE_NAME, "Produced for " + toResourceName(message, destination));
     span.setMeasured(true);
   }

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSDecorator.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSDecorator.java
@@ -28,10 +28,10 @@ public final class JMSDecorator extends ClientDecorator {
   private final String spanKind;
   private final String spanType;
   public static final JMSDecorator PRODUCER_DECORATE =
-    new JMSDecorator(Tags.SPAN_KIND_PRODUCER, DDSpanTypes.MESSAGE_PRODUCER);
+      new JMSDecorator(Tags.SPAN_KIND_PRODUCER, DDSpanTypes.MESSAGE_PRODUCER);
 
   public static final JMSDecorator CONSUMER_DECORATE =
-    new JMSDecorator(Tags.SPAN_KIND_CONSUMER, DDSpanTypes.MESSAGE_CONSUMER);
+      new JMSDecorator(Tags.SPAN_KIND_CONSUMER, DDSpanTypes.MESSAGE_CONSUMER);
 
   public JMSDecorator(String spanKind, String spanType) {
     this.spanKind = spanKind;
@@ -86,7 +86,7 @@ public final class JMSDecorator extends ClientDecorator {
   }
 
   public void onProduce(
-    final AgentSpan span, final Message message, final Destination destination) {
+      final AgentSpan span, final Message message, final Destination destination) {
     span.setTag(DDTags.RESOURCE_NAME, "Produced for " + toResourceName(message, destination));
     span.setMeasured(true);
   }

--- a/dd-java-agent/instrumentation/jms/src/test/groovy/JMS1Test.groovy
+++ b/dd-java-agent/instrumentation/jms/src/test/groovy/JMS1Test.groovy
@@ -35,8 +35,6 @@ class JMS1Test extends AgentTestRunner {
     final Connection connection = connectionFactory.createConnection()
     connection.start()
     session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE)
-
-//    final Connection connectionDisabledTimestamp = connectionFactory.createConnection()
   }
 
   def cleanupSpec() {
@@ -298,8 +296,6 @@ class JMS1Test extends AgentTestRunner {
           "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
           if (!messageListener && !isTimestampDisabled) {
             "$InstrumentationTags.RECORD_QUEUE_TIME_MS" {it >= 0 }
-          } else if (isTimestampDisabled) {
-            "$InstrumentationTags.RECORD_QUEUE_TIME_MS" {it == null}
           }
           defaultTags(true)
         }

--- a/dd-java-agent/instrumentation/spring-jms-3.1/src/test/groovy/SpringSAListenerTest.groovy
+++ b/dd-java-agent/instrumentation/spring-jms-3.1/src/test/groovy/SpringSAListenerTest.groovy
@@ -18,6 +18,7 @@
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.asserts.ListWriterAssert
 import datadog.trace.api.DDSpanTypes
+import datadog.trace.bootstrap.instrumentation.api.InstrumentationTags
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.core.DDSpan
 import org.apache.activemq.ActiveMQMessageConsumer
@@ -90,6 +91,9 @@ class SpringSAListenerTest extends AgentTestRunner {
         tags {
           "$Tags.COMPONENT" "jms"
           "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
+          if (!messageListener && "$InstrumentationTags.RECORD_QUEUE_TIME_MS") {
+            "$InstrumentationTags.RECORD_QUEUE_TIME_MS" {it >= 0 }
+          }
           defaultTags(true)
         }
       }


### PR DESCRIPTION
When consuming messages via JMS, messages sometimes includes a creation timestamp

If this is available, add the time spent in queue span tag in the consume calls