### PR TITLE
Rename hitLatencies to okLatencies

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/AggregateMetric.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/AggregateMetric.java
@@ -10,14 +10,14 @@ public final class AggregateMetric {
 
   private static final HistogramFactory HISTOGRAM_FACTORY = Histograms.newHistogramFactory();
 
-  private Histogram hitLatencies;
+  private Histogram okLatencies;
   private Histogram errorLatencies;
   private int errorCount;
   private int hitCount;
   private long duration;
 
   public AggregateMetric() {
-    hitLatencies = HISTOGRAM_FACTORY.newHistogram();
+    okLatencies = HISTOGRAM_FACTORY.newHistogram();
     errorLatencies = HISTOGRAM_FACTORY.newHistogram();
   }
 
@@ -30,7 +30,7 @@ public final class AggregateMetric {
       if (((errorMask >>> i) & 1) == 1) {
         errorLatencies.accept(duration);
       } else {
-        hitLatencies.accept(duration);
+        okLatencies.accept(duration);
       }
     }
     return this;
@@ -48,8 +48,8 @@ public final class AggregateMetric {
     return duration;
   }
 
-  public ByteBuffer getHitLatencies() {
-    return hitLatencies.serialize();
+  public ByteBuffer getOkLatencies() {
+    return okLatencies.serialize();
   }
 
   public ByteBuffer getErrorLatencies() {
@@ -60,7 +60,7 @@ public final class AggregateMetric {
     this.errorCount = 0;
     this.hitCount = 0;
     this.duration = 0;
-    this.hitLatencies.clear();
+    this.okLatencies.clear();
     this.errorLatencies.clear();
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/SerializingMetricWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/SerializingMetricWriter.java
@@ -27,7 +27,7 @@ public final class SerializingMetricWriter implements MetricWriter {
   private static final byte[] HTTP_STATUS_CODE = "HTTPStatusCode".getBytes(US_ASCII);
   private static final byte[] START = "Start".getBytes(US_ASCII);
   private static final byte[] STATS = "Stats".getBytes(US_ASCII);
-  private static final byte[] HITS_SUMMARY = "HitsSummary".getBytes(US_ASCII);
+  private static final byte[] OK_SUMMARY = "OkSummary".getBytes(US_ASCII);
   private static final byte[] ERROR_SUMMARY = "ErrorSummary".getBytes(US_ASCII);
 
   private final WellKnownTags wellKnownTags;
@@ -97,8 +97,8 @@ public final class SerializingMetricWriter implements MetricWriter {
     writer.writeUTF8(DURATION);
     writer.writeLong(aggregate.getDuration());
 
-    writer.writeUTF8(HITS_SUMMARY);
-    writer.writeBinary(aggregate.getHitLatencies());
+    writer.writeUTF8(OK_SUMMARY);
+    writer.writeBinary(aggregate.getOkLatencies());
 
     writer.writeUTF8(ERROR_SUMMARY);
     writer.writeBinary(aggregate.getErrorLatencies());

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SerializingMetricWriterTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SerializingMetricWriterTest.groovy
@@ -118,7 +118,7 @@ class SerializingMetricWriterTest extends DDSpecification {
         assert unpacker.unpackString() == "Duration"
         assert unpacker.unpackLong() == value.getDuration()
         ++elementCount
-        assert unpacker.unpackString() == "HitsSummary"
+        assert unpacker.unpackString() == "OkSummary"
         validateSketch(unpacker)
         ++elementCount
         assert unpacker.unpackString() == "ErrorSummary"


### PR DESCRIPTION
Previously we had the two following fields
- Hits: count of ok and errors spans
- HitsLatencies:  histogram of ok spans (does not include errors)

To avoid confusion with the hits prefix, renaming HitsLatencies to okLatencies. Change has already been [made on the agent]( https://github.com/DataDog/datadog-agent/blob/0bfe21364df9f1685e2a0e1f8ab7f0e67009c9e4/pkg/trace/pb/stats.proto#L32-L36)