### PR TITLE
Avoid dns lookup in mongo instrumentations

### DIFF
--- a/dd-java-agent/instrumentation/mongo/driver-3.1/src/test/groovy/MongoClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-3.1/src/test/groovy/MongoClientTest.groovy
@@ -249,7 +249,6 @@ class MongoClientTest extends MongoBaseTest {
         "$Tags.COMPONENT" "java-mongo"
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
         "$Tags.PEER_HOSTNAME" "localhost"
-        "$Tags.PEER_HOST_IPV4" "127.0.0.1"
         "$Tags.PEER_PORT" port
         "$Tags.DB_TYPE" "mongo"
         "$Tags.DB_INSTANCE" instance

--- a/dd-java-agent/instrumentation/mongo/driver-4/src/test/groovy/Mongo4ClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-4/src/test/groovy/Mongo4ClientTest.groovy
@@ -244,7 +244,6 @@ class Mongo4ClientTest extends MongoBaseTest {
         "$Tags.COMPONENT" "java-mongo"
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
         "$Tags.PEER_HOSTNAME" "localhost"
-        "$Tags.PEER_HOST_IPV4" "127.0.0.1"
         "$Tags.PEER_PORT" port
         "$Tags.DB_TYPE" "mongo"
         "$Tags.DB_INSTANCE" instance

--- a/dd-java-agent/instrumentation/mongo/driver-4/src/test/groovy/Mongo4ReactiveClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-4/src/test/groovy/Mongo4ReactiveClientTest.groovy
@@ -290,7 +290,6 @@ class Mongo4ReactiveClientTest extends MongoBaseTest {
         "$Tags.COMPONENT" "java-mongo"
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
         "$Tags.PEER_HOSTNAME" "localhost"
-        "$Tags.PEER_HOST_IPV4" "127.0.0.1"
         "$Tags.PEER_PORT" port
         "$Tags.DB_TYPE" "mongo"
         "$Tags.DB_INSTANCE" instance

--- a/dd-java-agent/instrumentation/mongo/driver-async-3.3/src/test/groovy/MongoAsyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-async-3.3/src/test/groovy/MongoAsyncClientTest.groovy
@@ -287,7 +287,6 @@ class MongoAsyncClientTest extends MongoBaseTest {
         "$Tags.COMPONENT" "java-mongo"
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
         "$Tags.PEER_HOSTNAME" "localhost"
-        "$Tags.PEER_HOST_IPV4" "127.0.0.1"
         "$Tags.PEER_PORT" port
         "$Tags.DB_TYPE" "mongo"
         "$Tags.DB_INSTANCE" instance


### PR DESCRIPTION
`ServerAddress.getSocketAddress()` is implemented as follows, so isn't safe for a tracing library to call

```java
    /**
     * Gets the underlying socket address
     *
     * @return socket address
     */
    public InetSocketAddress getSocketAddress() {
        try {
            return new InetSocketAddress(InetAddress.getByName(host), port);
        } catch (UnknownHostException e) {
            throw new MongoSocketException(e.getMessage(), this, e);
        }
    }
```