### PR TITLE
Set -XX:ErrorFile everywhere for JVM crashes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ jobs:
       - run:
           name: Build Project
           command: >-
-            GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx2G -Xms64M' -Ddatadog.forkedMaxHeapSize=2G -Ddatadog.forkedMinHeapSize=64M"
+            GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx2G -Xms64M -XX:ErrorFile=/tmp/hs_err_pid%p.log' -Ddatadog.forkedMaxHeapSize=2G -Ddatadog.forkedMinHeapSize=64M"
             ./gradlew clean :dd-java-agent:shadowJar compileTestGroovy compileLatestDepTestGroovy compileTestScala compileLatestDepTestScala compileTestJava compileLatestDepTestJava
             << pipeline.parameters.gradle_flags >>
             --max-workers=8
@@ -148,7 +148,7 @@ jobs:
       - run:
           name: Run Tests
           command: >-
-            GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx2G -Xms64M' -Ddatadog.forkedMaxHeapSize=4G -Ddatadog.forkedMinHeapSize=64M"
+            GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx2G -Xms64M -XX:ErrorFile=/tmp/hs_err_pid%p.log' -Ddatadog.forkedMaxHeapSize=4G -Ddatadog.forkedMinHeapSize=64M"
             ./gradlew <<# parameters.prefixTestTask>>testJava<</ parameters.prefixTestTask>><< parameters.testTask >>
             << pipeline.parameters.gradle_flags >>
             --max-workers=6
@@ -191,7 +191,7 @@ jobs:
       - run:
           name: Build Project
           command: >-
-            GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx2G -Xms64M' -Ddatadog.forkedMaxHeapSize=4G -Ddatadog.forkedMinHeapSize=64M"
+            GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx2G -Xms64M -XX:ErrorFile=/tmp/hs_err_pid%p.log' -Ddatadog.forkedMaxHeapSize=4G -Ddatadog.forkedMinHeapSize=64M"
             ./gradlew build -PskipTests
             << pipeline.parameters.gradle_flags >>
             --max-workers=8
@@ -201,7 +201,7 @@ jobs:
           command: |
             mvn_local_repo=$(mvn help:evaluate -Dexpression=settings.localRepository -q -DforceStdout)
             rm -rf "${mvn_local_repo}/com/datadoghq"
-            export GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx2G -Xms64M' -Ddatadog.forkedMaxHeapSize=4G -Ddatadog.forkedMinHeapSize=64M"
+            export GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx2G -Xms64M -XX:ErrorFile=/tmp/hs_err_pid%p.log' -Ddatadog.forkedMaxHeapSize=4G -Ddatadog.forkedMinHeapSize=64M"
             ./gradlew install << pipeline.parameters.gradle_flags >> --max-workers=6
             cd test-published-dependencies
             ../gradlew check
@@ -240,10 +240,18 @@ jobs:
           name: Verify Muzzle
           command: >-
             SKIP_BUILDSCAN="true"
-            GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx4G -Xms64M' -Ddatadog.forkedMaxHeapSize=4G -Ddatadog.forkedMinHeapSize=64M"
+            GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx4G -Xms64M -XX:ErrorFile=/tmp/hs_err_pid%p.log' -Ddatadog.forkedMaxHeapSize=4G -Ddatadog.forkedMinHeapSize=64M"
             ./gradlew `circleci tests split --split-by=timings workspace/build/muzzleTasks | xargs`
             << pipeline.parameters.gradle_flags >>
             --max-workers=16
+
+      - run:
+          name: Collect Reports
+          when: on_fail
+          command: .circleci/collect_reports.sh
+
+      - store_artifacts:
+          path: ./reports
 
       - store_test_results:
           path: workspace/build/muzzle-test-results

--- a/dd-java-agent/src/test/java/datadog/trace/agent/test/IntegrationTestUtils.java
+++ b/dd-java-agent/src/test/java/datadog/trace/agent/test/IntegrationTestUtils.java
@@ -189,6 +189,7 @@ public class IntegrationTestUtils {
 
     final List<String> vmArgsList = new ArrayList<>(Arrays.asList(jvmArgs));
     vmArgsList.add(getAgentArgument());
+    vmArgsList.add("-XX:ErrorFile=/tmp/hs_err_pid%p.log");
 
     final List<String> commands = new ArrayList<>();
     commands.add(path);

--- a/dd-smoke-tests/field-injection/src/test/groovy/datadog/smoketest/FieldInjectionSmokeTest.groovy
+++ b/dd-smoke-tests/field-injection/src/test/groovy/datadog/smoketest/FieldInjectionSmokeTest.groovy
@@ -41,6 +41,7 @@ class FieldInjectionSmokeTest extends Specification {
     List<String> command = new ArrayList<>()
     command.add(javaPath())
     command.add("-javaagent:${shadowJarPath}" as String)
+    command.add("-XX:ErrorFile=/tmp/hs_err_pid%p.log")
     command.add("-Ddd.writer.type=TraceStructureWriter")
     command.add("-Ddd.trace.debug=true")
     command.add("-jar")

--- a/dd-smoke-tests/slf4j-mdc/src/test/groovy/datadog/smoketest/Slf4jMDCSmokeTest.groovy
+++ b/dd-smoke-tests/slf4j-mdc/src/test/groovy/datadog/smoketest/Slf4jMDCSmokeTest.groovy
@@ -31,6 +31,7 @@ class Slf4jMDCSmokeTest extends Specification {
     List<String> command = new ArrayList<>()
     command.add(javaPath())
     command.add("-javaagent:${shadowJarPath}" as String)
+    command.add("-XX:ErrorFile=/tmp/hs_err_pid%p.log")
     command.add("-Ddd.writer.type=TraceStructureWriter")
     command.add("-Ddd.trace.debug=true")
     command.add("-Ddd.logs.injection=true")

--- a/dd-smoke-tests/src/main/groovy/datadog/smoketest/AbstractSmokeTest.groovy
+++ b/dd-smoke-tests/src/main/groovy/datadog/smoketest/AbstractSmokeTest.groovy
@@ -84,6 +84,7 @@ abstract class AbstractSmokeTest extends Specification {
 
     defaultJavaProperties = [
       "-javaagent:${shadowJarPath}",
+      "-XX:ErrorFile=/tmp/hs_err_pid%p.log",
       "-Ddd.trace.agent.port=${server.address.port}",
       "-Ddd.service.name=smoke-test-java-app",
       "-Ddd.profiling.enabled=true",


### PR DESCRIPTION
Previously, for processes we created in the jvm, we were losing the crash file.  With this PR, everywhere we create a new process, dump the crash file in a well-known location instead of the default (the current working dir).

This should help diagnose some of failing smoke test issues.