### PR TITLE
Fix Jacoco test coverage verification failing because of cache

### DIFF
--- a/gradle/jacoco.gradle
+++ b/gradle/jacoco.gradle
@@ -4,7 +4,9 @@ jacoco {
   toolVersion = "0.8.5"
 }
 
-forkedTest {
+task forkedTestJacocoData {
+  dependsOn forkedTest
+
   doLast {
     if (file("$buildDir/jacoco/forkedTest.exec").exists()) {
       jacocoTestReport {
@@ -18,7 +20,7 @@ forkedTest {
 }
 
 jacocoTestReport {
-  dependsOn test, forkedTest
+  dependsOn test, forkedTestJacocoData
   reports {
     xml.enabled true
     csv.enabled false


### PR DESCRIPTION
I ran into this issue locally where the `forkedTest` task had been run and was cached and the `executionData` for forked tests wasn't included in the report or verification, making the `check` fail.