### PR TITLE
exclude new ForkJoinTask type from RunnableFuture instrumentation

### DIFF
--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/JavaForkJoinTaskInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/JavaForkJoinTaskInstrumentation.java
@@ -78,7 +78,8 @@ public final class JavaForkJoinTaskInstrumentation extends Instrumenter.Default
         Arrays.asList(
             "java.util.concurrent.ForkJoinTask$AdaptedCallable",
             "java.util.concurrent.ForkJoinTask$AdaptedRunnable",
-            "java.util.concurrent.ForkJoinTask$AdaptedRunnableAction"));
+            "java.util.concurrent.ForkJoinTask$AdaptedRunnableAction",
+            "java.util.concurrent.ForkJoinTask$AdaptedInterruptibleCallable"));
   }
 
   public static final class Exec {


### PR DESCRIPTION
This branch will track [FJP changes](https://github.com/openjdk/jdk/pull/1646) which could break our instrumentation.  