### PR TITLE
Make advice protected call with MemberSubstitution

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/ComparableRunnable.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/ComparableRunnable.java
@@ -35,4 +35,8 @@ public final class ComparableRunnable<T extends Runnable & Comparable<T>>
   private TraceScope activate() {
     return null == continuation ? null : continuation.activate();
   }
+
+  public static <T extends Runnable & Comparable<T>> T cast(Runnable comparable) {
+    return (T) comparable;
+  }
 }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/CompositeGradlePlugin.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/CompositeGradlePlugin.java
@@ -1,0 +1,43 @@
+package datadog.trace.agent.tooling.bytebuddy;
+
+import datadog.trace.agent.tooling.bytebuddy.advice.transformation.NewTaskForAdvicePlugin;
+import datadog.trace.agent.tooling.muzzle.MuzzleGradlePlugin;
+import java.io.IOException;
+import net.bytebuddy.build.Plugin;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.dynamic.ClassFileLocator;
+import net.bytebuddy.dynamic.DynamicType;
+
+public class CompositeGradlePlugin implements Plugin {
+  private final Plugin[] delegates =
+      new Plugin[] {new MuzzleGradlePlugin(), new NewTaskForAdvicePlugin()};
+
+  @Override
+  public DynamicType.Builder<?> apply(
+      DynamicType.Builder<?> builder,
+      TypeDescription typeDescription,
+      ClassFileLocator classFileLocator) {
+    for (Plugin delegate : delegates) {
+      if (delegate.matches(typeDescription)) {
+        builder = delegate.apply(builder, typeDescription, classFileLocator);
+      }
+    }
+    return builder;
+  }
+
+  @Override
+  public void close() throws IOException {
+    for (Plugin delegate : delegates) {
+      delegate.close();
+    }
+  }
+
+  @Override
+  public boolean matches(TypeDescription target) {
+    boolean matches = false;
+    for (Plugin delegate : delegates) {
+      matches |= delegate.matches(target);
+    }
+    return matches;
+  }
+}

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/advice/transformation/NewTaskForAdvicePlugin.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/advice/transformation/NewTaskForAdvicePlugin.java
@@ -1,0 +1,124 @@
+package datadog.trace.agent.tooling.bytebuddy.advice.transformation;
+
+import static net.bytebuddy.matcher.ElementMatchers.any;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+
+import java.lang.reflect.Method;
+import java.util.concurrent.AbstractExecutorService;
+import lombok.SneakyThrows;
+import net.bytebuddy.asm.MemberSubstitution;
+import net.bytebuddy.build.Plugin;
+import net.bytebuddy.description.ByteCodeElement;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.description.type.TypeList;
+import net.bytebuddy.dynamic.ClassFileLocator;
+import net.bytebuddy.dynamic.DynamicType;
+import net.bytebuddy.implementation.bytecode.StackManipulation;
+import net.bytebuddy.implementation.bytecode.member.MethodInvocation;
+import net.bytebuddy.pool.TypePool;
+import net.bytebuddy.utility.CompoundList;
+
+/**
+ * This Plugin is responsible for modifying WrapRunnableAsNewTaskInstrumentation's advice so it is
+ * able to make a call to a protected method.
+ */
+public final class NewTaskForAdvicePlugin implements Plugin {
+  Method newTaskForMethod;
+
+  @SneakyThrows
+  public NewTaskForAdvicePlugin() {
+    newTaskForMethod =
+        AbstractExecutorService.class.getDeclaredMethod("newTaskFor", Runnable.class, Object.class);
+  }
+
+  @Override
+  public boolean matches(TypeDescription target) {
+    return named(
+            "datadog.trace.instrumentation.java.concurrent.WrapRunnableAsNewTaskInstrumentation$Wrap")
+        .matches(target);
+  }
+
+  @Override
+  public DynamicType.Builder<?> apply(
+      DynamicType.Builder<?> builder,
+      TypeDescription typeDescription,
+      ClassFileLocator classFileLocator) {
+    return builder.visit(
+        MemberSubstitution.relaxed()
+            .method(named("superNewTaskFor"))
+            // https://github.com/raphw/byte-buddy/issues/976
+            // .replaceWith(newTaskForMethod)
+            .replaceWith(new VisibilityIgnoringSubstitution(newTaskForMethod))
+            .on(any()));
+  }
+
+  @Override
+  public void close() {}
+
+  // This is a hack until https://github.com/raphw/byte-buddy/issues/976 is resolved.
+  private static final class VisibilityIgnoringSubstitution
+      implements MemberSubstitution.Substitution.Factory {
+    private final MethodDescription methodDescription;
+
+    public VisibilityIgnoringSubstitution(Method method) {
+      this.methodDescription = new MethodDescription.ForLoadedMethod(method);
+    }
+
+    @Override
+    public MemberSubstitution.Substitution make(
+        TypeDescription instrumentedType, MethodDescription instrumentedMethod, TypePool typePool) {
+      return new VisibilityIgnoringSubstitutionInvocation(
+          instrumentedType,
+          new MemberSubstitution.Substitution.ForMethodInvocation.MethodResolver.Simple(
+              methodDescription));
+    }
+  }
+
+  private static final class VisibilityIgnoringSubstitutionInvocation
+      extends MemberSubstitution.Substitution.ForMethodInvocation {
+
+    /** The index of the this reference within a non-static method. */
+    private static final int THIS_REFERENCE = 0;
+
+    private final MethodResolver methodResolver;
+
+    public VisibilityIgnoringSubstitutionInvocation(
+        TypeDescription instrumentedType, MethodResolver methodResolver) {
+      super(instrumentedType, methodResolver);
+      this.methodResolver = methodResolver;
+    }
+
+    // Copied from net.bytebuddy.asm.MemberSubstitution.Substitution.ForMethodInvocation so the
+    // visibility restrictions could be removed and other specializations.
+    @Override
+    public StackManipulation resolve(
+        TypeDescription targetType,
+        ByteCodeElement target,
+        TypeList.Generic parameters,
+        TypeDescription.Generic result,
+        int freeOffset) {
+      MethodDescription methodDescription =
+          methodResolver.resolve(targetType, target, parameters, result);
+
+      TypeList.Generic mapped =
+          methodDescription.isStatic()
+              ? methodDescription.getParameters().asTypeList()
+              : new TypeList.Generic.Explicit(
+                  CompoundList.of(
+                      methodDescription.getDeclaringType(),
+                      methodDescription.getParameters().asTypeList()));
+
+      if (!methodDescription.getReturnType().asErasure().isAssignableTo(result.asErasure())) {
+        throw new IllegalStateException(
+            "Cannot assign return value of " + methodDescription + " to " + result);
+      } else if (mapped.size() != parameters.size()) {
+        throw new IllegalStateException(
+            "Cannot invoke " + methodDescription + " on " + parameters.size() + " parameters");
+      }
+
+      return MethodInvocation.invoke(methodDescription)
+          .virtual(mapped.get(THIS_REFERENCE).asErasure());
+    }
+  }
+}

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/MuzzleGradlePlugin.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/MuzzleGradlePlugin.java
@@ -7,7 +7,6 @@ import static net.bytebuddy.matcher.ElementMatchers.not;
 
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.bootstrap.WeakMap;
-import java.io.IOException;
 import java.util.Collections;
 import java.util.WeakHashMap;
 import net.bytebuddy.build.Plugin;
@@ -41,24 +40,5 @@ public class MuzzleGradlePlugin extends Plugin.ForElementMatcher {
   }
 
   @Override
-  public void close() throws IOException {}
-
-  /** Compile-time Optimization used by gradle buildscripts. */
-  public static class NoOp implements Plugin {
-    @Override
-    public boolean matches(final TypeDescription target) {
-      return false;
-    }
-
-    @Override
-    public DynamicType.Builder<?> apply(
-        final DynamicType.Builder<?> builder,
-        final TypeDescription typeDescription,
-        final ClassFileLocator classFileLocator) {
-      return builder;
-    }
-
-    @Override
-    public void close() throws IOException {}
-  }
+  public void close() {}
 }

--- a/dd-java-agent/instrumentation/instrumentation.gradle
+++ b/dd-java-agent/instrumentation/instrumentation.gradle
@@ -24,7 +24,7 @@ subprojects { Project subProj ->
     transformation {
       // Applying NoOp optimizes build by applying bytebuddy plugin to only compileJava task
       tasks = ['compileJava', 'compileScala', 'compileKotlin']
-      plugin = 'datadog.trace.agent.tooling.muzzle.MuzzleGradlePlugin$NoOp'
+      plugin = 'net.bytebuddy.build.Plugin$NoOp'
     }
   }
 
@@ -32,7 +32,7 @@ subprojects { Project subProj ->
     subProj.byteBuddy {
       transformation {
         tasks = ['compileJava', 'compileScala', 'compileKotlin']
-        plugin = 'datadog.trace.agent.tooling.muzzle.MuzzleGradlePlugin'
+        plugin = 'datadog.trace.agent.tooling.bytebuddy.CompositeGradlePlugin'
         classPath = project(':dd-java-agent:agent-tooling').configurations.instrumentationMuzzle + subProj.configurations.compile + subProj.sourceSets.main.output
       }
     }

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/NewTaskFor.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/NewTaskFor.java
@@ -1,63 +1,37 @@
 package datadog.trace.instrumentation.java.concurrent;
 
-import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.ExcludeType.RUNNABLE;
-import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.exclude;
-
-import datadog.trace.bootstrap.instrumentation.java.concurrent.ComparableRunnable;
 import java.lang.reflect.Method;
 import java.util.concurrent.AbstractExecutorService;
 import java.util.concurrent.Executor;
-import java.util.concurrent.FutureTask;
 import java.util.concurrent.RunnableFuture;
 import lombok.extern.slf4j.Slf4j;
 
+// FIXME: DELETE
 @Slf4j
 public final class NewTaskFor {
 
-  private static final boolean SAFE_TO_PROPAGATE;
   private static final Method NEW_TASK_FOR_RUNNABLE;
 
   static {
-    boolean safeToPropagate = false;
     Method newTaskFor = null;
     try {
       newTaskFor =
           AbstractExecutorService.class.getDeclaredMethod(
               "newTaskFor", Runnable.class, Object.class);
       newTaskFor.setAccessible(true);
-      safeToPropagate = true;
     } catch (Throwable error) {
       log.debug("Failed to create method accessor for newTaskFor", error);
     }
-    SAFE_TO_PROPAGATE = safeToPropagate;
     NEW_TASK_FOR_RUNNABLE = newTaskFor;
   }
 
   @SuppressWarnings("unchecked")
   public static Runnable newTaskFor(Executor executor, Runnable runnable) {
-    // TODO write a slick instrumentation and instrument these types directly
-    if (runnable instanceof RunnableFuture
-        || null == runnable
-        || !SAFE_TO_PROPAGATE
-        || exclude(RUNNABLE, runnable)
-        || runnable.getClass().getName().startsWith("slick.")) {
-      return runnable;
+    try {
+      return (RunnableFuture<Void>) NEW_TASK_FOR_RUNNABLE.invoke(executor, runnable, null);
+    } catch (Throwable t) {
+      log.debug("failed to invoke newTaskFor on {}", executor, t);
     }
-    if (runnable instanceof Comparable) {
-      return new ComparableRunnable<>(cast(runnable));
-    }
-    if (null != NEW_TASK_FOR_RUNNABLE && executor instanceof AbstractExecutorService) {
-      try {
-        return (RunnableFuture<Void>) NEW_TASK_FOR_RUNNABLE.invoke(executor, runnable, null);
-      } catch (Throwable t) {
-        log.debug("failed to invoke newTaskFor on {}", executor, t);
-      }
-    }
-    return new FutureTask<>(runnable, null);
-  }
-
-  @SuppressWarnings("unchecked")
-  private static <T extends Runnable & Comparable<T>> T cast(Runnable comparable) {
-    return (T) comparable;
+    throw new IllegalStateException();
   }
 }


### PR DESCRIPTION
Currently still using reflection since the MemberSubstitution bytecode doesn't seem to be updating the return value properly.  Does anyone else want to take a look at this?