### PR TITLE
Fix NoClassDefFoundError with DDSpecification

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/CallDepthThreadLocalMapTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/CallDepthThreadLocalMapTest.groovy
@@ -1,8 +1,8 @@
 package datadog.trace.bootstrap
 
-import spock.lang.Specification
+import datadog.trace.test.util.DDSpecification
 
-class CallDepthThreadLocalMapTest extends Specification {
+class CallDepthThreadLocalMapTest extends DDSpecification {
 
   def "test CallDepthThreadLocalMap"() {
     setup:

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/DatadogClassLoaderTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/DatadogClassLoaderTest.groovy
@@ -1,7 +1,7 @@
 package datadog.trace.bootstrap
 
+import datadog.trace.test.util.DDSpecification
 import spock.lang.Shared
-import spock.lang.Specification
 import spock.lang.Timeout
 
 import java.util.concurrent.Callable
@@ -15,7 +15,7 @@ import java.util.concurrent.TimeUnit
 import static datadog.trace.api.Platform.isJavaVersionAtLeast
 import static org.junit.Assume.assumeTrue
 
-class DatadogClassLoaderTest extends Specification {
+class DatadogClassLoaderTest extends DDSpecification {
   @Shared
   URL testJarLocation = new File("src/test/resources/classloader-test-jar/testjar-jdk8").toURI().toURL()
 

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/ExcludeFilterTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/ExcludeFilterTest.groovy
@@ -1,11 +1,13 @@
 package datadog.trace.bootstrap
 
-import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.ExcludeType.*
-
 import datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter
-import spock.lang.Specification
+import datadog.trace.test.util.DDSpecification
 
-class ExcludeFilterTest extends Specification {
+import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.ExcludeType.CALLABLE
+import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.ExcludeType.FUTURE
+import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.ExcludeType.RUNNABLE
+
+class ExcludeFilterTest extends DDSpecification {
 
   def "test empty ExcludeFilter"() {
     setup:

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/WeakMapTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/WeakMapTest.groovy
@@ -1,9 +1,9 @@
 package datadog.trace.bootstrap
 
 import datadog.trace.api.Function
-import spock.lang.Specification
+import datadog.trace.test.util.DDSpecification
 
-class WeakMapTest extends Specification {
+class WeakMapTest extends DDSpecification {
 
   def supplier = new CounterSupplier()
 

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/WeakCacheTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/WeakCacheTest.groovy
@@ -1,9 +1,9 @@
 package datadog.trace.agent.tooling
 
 import datadog.trace.api.Function
-import spock.lang.Specification
+import datadog.trace.test.util.DDSpecification
 
-class WeakCacheTest extends Specification {
+class WeakCacheTest extends DDSpecification {
   def supplier = new CounterSupplier()
 
   def weakCache = AgentTooling.newWeakCache()

--- a/dd-java-agent/testing/src/test/groovy/utils/ThreadUtilsTest.groovy
+++ b/dd-java-agent/testing/src/test/groovy/utils/ThreadUtilsTest.groovy
@@ -1,15 +1,15 @@
 package utils
 
 import datadog.trace.agent.test.utils.ThreadUtils
+import datadog.trace.test.util.DDSpecification
 import org.spockframework.runtime.ConditionNotSatisfiedError
 import spock.lang.FailsWith
 import spock.lang.Shared
-import spock.lang.Specification
 
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger
 
-class ThreadUtilsTest extends Specification {
+class ThreadUtilsTest extends DDSpecification {
 
   @Shared
   def counter = new AtomicInteger()

--- a/dd-trace-core/jfr-openjdk/src/test/groovy/datadog/trace/core/jfr/openjdk/ExcludedVersionsTest.groovy
+++ b/dd-trace-core/jfr-openjdk/src/test/groovy/datadog/trace/core/jfr/openjdk/ExcludedVersionsTest.groovy
@@ -1,8 +1,8 @@
 package datadog.trace.core.jfr.openjdk
 
-import spock.lang.Specification
+import datadog.trace.test.util.DDSpecification
 
-class ExcludedVersionsTest extends Specification {
+class ExcludedVersionsTest extends DDSpecification {
   def "expect #version is #excludedDescription"() {
 
     expect:

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/MultiWriterTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/MultiWriterTest.groovy
@@ -1,9 +1,9 @@
 package datadog.trace.common.writer
 
 import datadog.trace.core.DDSpan
-import spock.lang.Specification
+import datadog.trace.test.util.DDSpecification
 
-class MultiWriterTest extends Specification {
+class MultiWriterTest extends DDSpecification {
 
   def "test that multi writer delegates to all"() {
     setup:

--- a/utils/test-utils/src/main/groovy/datadog/trace/test/util/DDSpecification.groovy
+++ b/utils/test-utils/src/main/groovy/datadog/trace/test/util/DDSpecification.groovy
@@ -69,6 +69,14 @@ abstract class DDSpecification extends Specification {
       configConstructor = configClass.getDeclaredConstructor()
       configConstructor.setAccessible(true)
       isConfigInstanceModifiable = true
+    } catch (ClassNotFoundException e) {
+      if (e.getMessage() == CONFIG) {
+        println("Config class not found in this classloader. Not transforming it")
+      } else {
+        configModificationFailed = true
+        println("Config will not be modifiable")
+        e.printStackTrace()
+      }
     } catch (ReflectiveOperationException | IllegalStateException e) {
       configModificationFailed = true
       println("Config will not be modifiable")

--- a/utils/test-utils/src/main/groovy/datadog/trace/test/util/DDSpecification.groovy
+++ b/utils/test-utils/src/main/groovy/datadog/trace/test/util/DDSpecification.groovy
@@ -4,6 +4,7 @@ import net.bytebuddy.agent.ByteBuddyAgent
 import net.bytebuddy.agent.builder.AgentBuilder
 import net.bytebuddy.dynamic.ClassFileLocator
 import net.bytebuddy.dynamic.Transformer
+import net.bytebuddy.utility.JavaModule
 import org.junit.Rule
 import spock.lang.Specification
 
@@ -18,7 +19,7 @@ import static net.bytebuddy.matcher.ElementMatchers.named
 import static net.bytebuddy.matcher.ElementMatchers.none
 
 abstract class DDSpecification extends Specification {
-  private static final String CONFIG = "datadog.trace.api.Config"
+  static final String CONFIG = "datadog.trace.api.Config"
 
   private static Field configInstanceField
   private static Constructor configConstructor
@@ -29,6 +30,7 @@ abstract class DDSpecification extends Specification {
 
   // Keep track of config instance already made modifiable
   private static isConfigInstanceModifiable = false
+  static configModificationFailed = false
 
   @Rule
   public final ResetControllableEnvironmentVariables environmentVariables = new ResetControllableEnvironmentVariables()
@@ -39,34 +41,36 @@ abstract class DDSpecification extends Specification {
   private static Properties originalSystemProperties
 
   static void makeConfigInstanceModifiable() {
-    if (isConfigInstanceModifiable) {
+    if (isConfigInstanceModifiable || configModificationFailed) {
       return
     }
 
-    def instrumentation = ByteBuddyAgent.install()
-    new AgentBuilder.Default()
-      .with(AgentBuilder.RedefinitionStrategy.RETRANSFORMATION)
-      .with(AgentBuilder.RedefinitionStrategy.Listener.ErrorEscalating.FAIL_FAST)
-    // Config is injected into the bootstrap, so we need to provide a locator.
-      .with(
-        new AgentBuilder.LocationStrategy.Simple(
-          ClassFileLocator.ForClassLoader.ofSystemLoader()))
-      .ignore(none()) // Allow transforming bootstrap classes
-      .type(named(CONFIG))
-      .transform { builder, typeDescription, classLoader, module ->
-        builder
-          .field(named("INSTANCE"))
-          .transform(Transformer.ForField.withModifiers(PUBLIC, STATIC, VOLATILE))
-      }
-      .installOn(instrumentation)
-
     try {
+      def instrumentation = ByteBuddyAgent.install()
+      new AgentBuilder.Default()
+        .with(AgentBuilder.RedefinitionStrategy.RETRANSFORMATION)
+        .with(AgentBuilder.RedefinitionStrategy.Listener.ErrorEscalating.FAIL_FAST)
+      // Config is injected into the bootstrap, so we need to provide a locator.
+        .with(
+          new AgentBuilder.LocationStrategy.Simple(
+            ClassFileLocator.ForClassLoader.ofSystemLoader()))
+        .ignore(none()) // Allow transforming bootstrap classes
+        .type(named(CONFIG))
+        .transform { builder, typeDescription, classLoader, module ->
+          builder
+            .field(named("INSTANCE"))
+            .transform(Transformer.ForField.withModifiers(PUBLIC, STATIC, VOLATILE))
+        }
+        .with(new ConfigInstrumentationFailedListener())
+        .installOn(instrumentation)
+
       Class configClass = Class.forName(CONFIG)
       configInstanceField = configClass.getDeclaredField("INSTANCE")
       configConstructor = configClass.getDeclaredConstructor()
       configConstructor.setAccessible(true)
       isConfigInstanceModifiable = true
-    } catch (ReflectiveOperationException e) {
+    } catch (ReflectiveOperationException | IllegalStateException e) {
+      configModificationFailed = true
       println("Config will not be modifiable")
       e.printStackTrace()
     }
@@ -78,14 +82,17 @@ abstract class DDSpecification extends Specification {
   }
 
   private void restoreProperties() {
-    Properties copy = new Properties()
-    copy.putAll(originalSystemProperties)
-    System.setProperties(copy)
+    if (originalSystemProperties != null) {
+      Properties copy = new Properties()
+      copy.putAll(originalSystemProperties)
+      System.setProperties(copy)
+    }
 
     environmentVariables?.reset()
   }
 
   void setupSpec() {
+    assert !configModificationFailed: "Config class modification failed.  Ensure all test classes extend DDSpecification"
     assert System.getenv().findAll { it.key.startsWith("DD_") }.isEmpty()
     assert System.getProperties().findAll { it.key.toString().startsWith("dd.") }.isEmpty()
 
@@ -177,5 +184,14 @@ abstract class DDSpecification extends Specification {
     assert Modifier.isStatic(configInstanceField.getModifiers())
     assert Modifier.isVolatile(configInstanceField.getModifiers())
     assert !Modifier.isFinal(configInstanceField.getModifiers())
+  }
+}
+
+class ConfigInstrumentationFailedListener extends AgentBuilder.Listener.Adapter {
+  @Override
+  void onError(String typeName, ClassLoader classLoader, JavaModule module, boolean loaded, Throwable throwable) {
+    if (DDSpecification.CONFIG == typeName) {
+      DDSpecification.configModificationFailed = true
+    }
   }
 }


### PR DESCRIPTION
All tests that touch `Config` need to extend `DDSpecification` or issues occur.  It's easier just to have all tests extend `DDSpecification` (with a few exceptions).

Previously, when the `Config` class couldn't be transformed, the first test where it fails throws `IllegalStateException`->`ExceptionInInitializer` and the second test throws `NoClassDefFoundError` (since the first attempt to load the `DDSpecification` failed.

This PR improves the error messaging when the Config class can't be transformed and updates all applicable tests to extend `DDSpecification`