### PR TITLE
Update generic signature when adding field-injection marker…

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/context/FieldInjectionVisitor.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/context/FieldInjectionVisitor.java
@@ -81,18 +81,23 @@ final class FieldInjectionVisitor implements AsmVisitorWrapper {
           final int version,
           final int access,
           final String name,
-          final String signature,
+          String signature,
           final String superName,
           String[] interfaces) {
         if (interfaces == null) {
           interfaces = new String[] {};
         }
-        final Set<String> set = new LinkedHashSet<>(Arrays.asList(interfaces));
-        set.add(INJECTED_FIELDS_MARKER_CLASS_NAME);
-        set.add(interfaceType.getInternalName());
         if (serialVersionUIDFieldInjection && instrumentedType.isAssignableTo(Serializable.class)) {
           serialVersionUIDInjector = new SerialVersionUIDInjector();
           serialVersionUIDInjector.visit(version, access, name, signature, superName, interfaces);
+        }
+        // extend interfaces and optional generic signature with marker and accessor
+        final Set<String> set = new LinkedHashSet<>(Arrays.asList(interfaces));
+        if (set.add(INJECTED_FIELDS_MARKER_CLASS_NAME) && null != signature) {
+          signature += 'L' + INJECTED_FIELDS_MARKER_CLASS_NAME + ';';
+        }
+        if (set.add(interfaceType.getInternalName()) && null != signature) {
+          signature += 'L' + interfaceType.getInternalName() + ';';
         }
         super.visit(version, access, name, signature, superName, set.toArray(new String[] {}));
       }

--- a/dd-smoke-tests/field-injection/src/main/java/datadog/smoketest/fieldinjection/FieldInjectionApp.java
+++ b/dd-smoke-tests/field-injection/src/main/java/datadog/smoketest/fieldinjection/FieldInjectionApp.java
@@ -1,6 +1,8 @@
 package datadog.smoketest.fieldinjection;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 
 public class FieldInjectionApp {
 
@@ -13,6 +15,18 @@ public class FieldInjectionApp {
             if (field.getName().startsWith("__datadogContext")) {
               System.err.println("___FIELD___:" + className + ":" + field.getName());
             }
+          }
+          for (Class<?> intf : klass.getInterfaces()) {
+            System.err.println("___INTERFACE___:" + className + ":" + intf.getName());
+          }
+          for (Type genericIntf : klass.getGenericInterfaces()) {
+            Class<?> intf;
+            if (genericIntf instanceof ParameterizedType) {
+              intf = (Class<?>) ((ParameterizedType) genericIntf).getRawType();
+            } else {
+              intf = (Class<?>) genericIntf;
+            }
+            System.err.println("___GENERIC_INTERFACE___:" + className + ":" + intf.getName());
           }
           klass = klass.getSuperclass();
         }

--- a/dd-smoke-tests/field-injection/src/test/groovy/datadog/smoketest/FieldInjectionSmokeTest.groovy
+++ b/dd-smoke-tests/field-injection/src/test/groovy/datadog/smoketest/FieldInjectionSmokeTest.groovy
@@ -56,19 +56,29 @@ class FieldInjectionSmokeTest extends Specification {
     Path testOutput = Files.createTempFile("output", "tmp")
     processBuilder.redirectError(testOutput.toFile())
     Process testedProcess = processBuilder.start()
+
     expect:
     testedProcess.waitFor() == 0
     List<String> lines = Files.readAllLines(testOutput)
     Map<String, Set<String>> foundTypesAndFields = new HashMap<>()
+    Map<String, List<String>> foundTypesAndInterfaces = new HashMap<>()
+    Map<String, List<String>> foundTypesAndGenericInterfaces = new HashMap<>()
     for (String line : lines) {
+      System.out.println(line)
       if (line.startsWith("___FIELD___")) {
         String[] parts = line.split(":")
-        foundTypesAndFields.compute(parts[1],
-          { String type, Set<String> fields -> null == fields ? new HashSet<>() : fields })
-          .add(parts[2])
+        foundTypesAndFields.computeIfAbsent(parts[1], { new HashSet<>() }).add(parts[2])
+      } else if (line.startsWith("___INTERFACE___")) {
+        String[] parts = line.split(":")
+        foundTypesAndInterfaces.computeIfAbsent(parts[1], { new HashSet<>() }).add(parts[2])
+      } else if (line.startsWith("___GENERIC_INTERFACE___")) {
+        String[] parts = line.split(":")
+        foundTypesAndGenericInterfaces.computeIfAbsent(parts[1], { new HashSet<>() }).add(parts[2])
       }
     }
     assert testedTypesAndExpectedFields == foundTypesAndFields
+    // check same list of names for interfaces and generic interfaces
+    assert foundTypesAndInterfaces == foundTypesAndGenericInterfaces
   }
 
 


### PR DESCRIPTION
…and accessor interfaces to a generic type.

If we don't do this then the result from `getInterfaces` and `getGenericInterfaces` won't be aligned which can cause issues when application/framework code inspects the class using reflection. Normally this sort of thing is managed by the Java compiler, but since we're modifying things at the bytecode level we have to manage this ourselves.

https://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html#jvms-4.3.4

> Oracle's Java Virtual Machine implementation does not check the well-formedness of the signatures described in this subsection during loading or linking. Instead, these checks are deferred until the signatures are used by reflective methods, as specified in the API of Class and members of java.lang.reflect. Future versions of a Java Virtual Machine implementation may be required to perform some or all of these checks during loading or linking