### PR TITLE
Make PendingTrace lighter-weight

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/PendingTrace.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/PendingTrace.java
@@ -65,22 +65,9 @@ public class PendingTrace implements AgentTrace {
 
   private final AtomicInteger pendingReferenceCount = new AtomicInteger(0);
 
-  // FIXME: In async frameworks we may have situations where traces do not report due to references
-  //  being held by async operators. In order to support testing in these cases we should have a way
-  //  to keep track of the fact that this trace is ready to report but is still pending. This would
-  //  likely require a change to the writer interface to allow signaling this intent. This could
-  //  also give us the benefit of being able to recover for reporting traces that get stuck due to
-  //  references being held for long periods of time.
-
   /**
    * During a trace there are cases where the root span must be accessed (e.g. priority sampling and
-   * trace-search tags).
-   *
-   * <p>Use a weak ref because we still need to handle buggy cases where the root span is not
-   * correctly closed (see SpanCleaner).
-   *
-   * <p>The root span will be available in non-buggy cases because it has either finished and
-   * strongly ref'd in this queue or is unfinished and ref'd in a ContinuableScope.
+   * trace-search tags). These use cases are an obstacle to span-streaming.
    */
   private volatile DDSpan rootSpan = null;
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/PendingTrace.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/PendingTrace.java
@@ -234,7 +234,6 @@ public class PendingTrace implements AgentTrace {
 
   /** Important to note: may be called multiple times. */
   void write() {
-    rootSpanWritten = true;
     int size = write(false);
     if (log.isDebugEnabled()) {
       log.debug("t_id={} -> wrote {} spans to {}.", traceId, size, tracer.writer);
@@ -246,6 +245,9 @@ public class PendingTrace implements AgentTrace {
       try (Recording recording = tracer.writeTimer()) {
         // Only one writer at a time
         synchronized (this) {
+          if (!isPartial) {
+            rootSpanWritten = true;
+          }
           int size = size();
           // If we get here and size is below 0, then the writer before us wrote out at least one
           // more trace than the size it had when it started. Those span(s) had been added to

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceBufferTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceBufferTest.groovy
@@ -65,7 +65,7 @@ class PendingTraceBufferTest extends DDSpecification {
     def span = newSpanOf(trace)
 
     expect:
-    !trace.rootSpanWritten.get()
+    !trace.rootSpanWritten
 
     when:
     addContinuation(span)
@@ -96,7 +96,7 @@ class PendingTraceBufferTest extends DDSpecification {
     def child = newSpanOf(parent)
 
     expect:
-    !trace.rootSpanWritten.get()
+    !trace.rootSpanWritten
 
     when:
     parent.finish() // This should enqueue
@@ -163,7 +163,7 @@ class PendingTraceBufferTest extends DDSpecification {
     then:
     trace.size() == 1
     trace.pendingReferenceCount.get() == 1
-    !trace.rootSpanWritten.get()
+    !trace.rootSpanWritten
     1 * bufferSpy.enqueue(trace)
     _ * tracer.getPartialFlushMinSpans() >> 10
     0 * _
@@ -175,7 +175,7 @@ class PendingTraceBufferTest extends DDSpecification {
     then:
     trace.size() == 2
     trace.pendingReferenceCount.get() == 1
-    !trace.rootSpanWritten.get()
+    !trace.rootSpanWritten
 
     when:
     buffer.start()
@@ -185,7 +185,7 @@ class PendingTraceBufferTest extends DDSpecification {
     then:
     trace.size() == 0
     trace.pendingReferenceCount.get() == 0
-    trace.rootSpanWritten.get()
+    trace.rootSpanWritten
     1 * tracer.writeTimer() >> Monitoring.DISABLED.newTimer("")
     1 * tracer.write({ it.size() == 2 }) >> {
       latch.countDown()
@@ -210,7 +210,7 @@ class PendingTraceBufferTest extends DDSpecification {
     then:
     trace.size() == 0
     trace.pendingReferenceCount.get() == 0
-    trace.rootSpanWritten.get()
+    trace.rootSpanWritten
     1 * tracer.writeTimer() >> Monitoring.DISABLED.newTimer("")
     1 * tracer.write({ it.size() == 1 }) >> {
       parentLatch.countDown()
@@ -226,7 +226,7 @@ class PendingTraceBufferTest extends DDSpecification {
     then:
     trace.size() == 0
     trace.pendingReferenceCount.get() == 0
-    trace.rootSpanWritten.get()
+    trace.rootSpanWritten
     1 * bufferSpy.enqueue(trace)
     _ * tracer.getPartialFlushMinSpans() >> 10
     1 * tracer.writeTimer() >> Monitoring.DISABLED.newTimer("")
@@ -249,7 +249,7 @@ class PendingTraceBufferTest extends DDSpecification {
     then:
     trace.size() == 1
     trace.pendingReferenceCount.get() == 1
-    !trace.rootSpanWritten.get()
+    !trace.rootSpanWritten
     1 * bufferSpy.enqueue(trace)
     _ * tracer.getPartialFlushMinSpans() >> 10
     0 * _
@@ -260,7 +260,7 @@ class PendingTraceBufferTest extends DDSpecification {
     then:
     trace.size() == 0
     trace.pendingReferenceCount.get() == 1
-    trace.rootSpanWritten.get()
+    trace.rootSpanWritten
     1 * tracer.writeTimer() >> Monitoring.DISABLED.newTimer("")
     1 * tracer.write({ it.size() == 1 })
     0 * _
@@ -271,7 +271,7 @@ class PendingTraceBufferTest extends DDSpecification {
     then:
     trace.size() == 1
     trace.pendingReferenceCount.get() == 0
-    trace.rootSpanWritten.get()
+    trace.rootSpanWritten
     _ * tracer.getPartialFlushMinSpans() >> 10
     1 * bufferSpy.enqueue(trace)
     0 * _

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceTest.groovy
@@ -30,7 +30,7 @@ class PendingTraceTest extends DDSpecification {
   def setup() {
     assert trace.size() == 0
     assert trace.pendingReferenceCount.get() == 1
-    assert trace.rootSpanWritten.get() == false
+    assert trace.rootSpanWritten == false
   }
 
   def "single span gets added to trace and written when finished"() {


### PR DESCRIPTION
* The CAS with the `WeakReference` when setting the root span was showing up in profiles. I don't see any harm in keeping a direct reference to the root span.
* `rootSpanWritten` could have been volatile, as currently implemented.  