### PR TITLE
represent sampling priority as a byte

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/sampling/PrioritySampling.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/sampling/PrioritySampling.java
@@ -6,15 +6,15 @@ public class PrioritySampling {
    *
    * <p>Internal value used when the priority sampling flag has not been set on the span context.
    */
-  public static final int UNSET = Integer.MIN_VALUE;
+  public static final byte UNSET = (byte) 0x80;
   /** The sampler has decided to drop the trace. */
-  public static final int SAMPLER_DROP = 0;
+  public static final byte SAMPLER_DROP = 0;
   /** The sampler has decided to keep the trace. */
-  public static final int SAMPLER_KEEP = 1;
+  public static final byte SAMPLER_KEEP = 1;
   /** The user has decided to drop the trace. */
-  public static final int USER_DROP = -1;
+  public static final byte USER_DROP = -1;
   /** The user has decided to keep the trace. */
-  public static final int USER_KEEP = 2;
+  public static final byte USER_KEEP = 2;
 
   private PrioritySampling() {}
 }

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/TraceMapper.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/TraceMapper.java
@@ -10,6 +10,7 @@ public interface TraceMapper extends Mapper<List<? extends CoreSpan<?>>> {
 
   UTF8BytesString THREAD_NAME = UTF8BytesString.create(DDTags.THREAD_NAME);
   UTF8BytesString THREAD_ID = UTF8BytesString.create(DDTags.THREAD_ID);
+  UTF8BytesString SAMPLING_PRIORITY_KEY = UTF8BytesString.create("_sampling_priority_v1");
 
   Payload newPayload();
 

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/TraceMapperV0_4.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/TraceMapperV0_4.java
@@ -144,9 +144,14 @@ public final class TraceMapperV0_4 implements TraceMapper {
     writable.writeUTF8(METRICS);
     Map<CharSequence, Number> metrics = span.getUnsafeMetrics();
     int elementCount = metrics.size();
+    elementCount += (span.hasSamplingPriority() ? 1 : 0);
     elementCount += (span.isMeasured() ? 1 : 0);
     elementCount += (span.isTopLevel() ? 1 : 0);
     writable.startMap(elementCount);
+    if (span.hasSamplingPriority()) {
+      writable.writeUTF8(SAMPLING_PRIORITY_KEY);
+      writable.writeInt(span.samplingPriority());
+    }
     if (span.isMeasured()) {
       writable.writeUTF8(InstrumentationTags.DD_MEASURED);
       writable.writeInt(1);

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/TraceMapperV0_5.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/TraceMapperV0_5.java
@@ -93,9 +93,14 @@ public final class TraceMapperV0_5 implements TraceMapper {
   private void writeMetrics(CoreSpan<?> span, Writable writable) {
     Map<CharSequence, Number> metrics = span.getUnsafeMetrics();
     int elementCount = metrics.size();
+    elementCount += (span.hasSamplingPriority() ? 1 : 0);
     elementCount += (span.isMeasured() ? 1 : 0);
     elementCount += (span.isTopLevel() ? 1 : 0);
     writable.startMap(elementCount);
+    if (span.hasSamplingPriority()) {
+      writeDictionaryEncoded(writable, SAMPLING_PRIORITY_KEY);
+      writable.writeInt(span.samplingPriority());
+    }
     if (span.isMeasured()) {
       writeDictionaryEncoded(writable, InstrumentationTags.DD_MEASURED);
       writable.writeInt(1);

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreSpan.java
@@ -53,6 +53,8 @@ public interface CoreSpan<T extends CoreSpan<T>> {
 
   <U> U getTag(CharSequence name);
 
+  boolean hasSamplingPriority();
+
   boolean isMeasured();
 
   /** @return whether this span has a different service name from its parent, or is a local root. */

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -441,6 +441,11 @@ public class DDSpan implements AgentSpan, CoreSpan<DDSpan> {
   }
 
   @Override
+  public boolean hasSamplingPriority() {
+    return context.getTrace().getRootSpan() == this;
+  }
+
+  @Override
   public boolean isMeasured() {
     return context.isMeasured();
   }

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SimpleSpan.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SimpleSpan.groovy
@@ -158,6 +158,11 @@ class SimpleSpan implements CoreSpan<SimpleSpan> {
   }
 
   @Override
+  boolean hasSamplingPriority() {
+    return false
+  }
+
+  @Override
   boolean isMeasured() {
     return measured
   }

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddagent/TraceGenerator.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddagent/TraceGenerator.groovy
@@ -342,5 +342,10 @@ class TraceGenerator {
       }
       return value as U
     }
+
+    @Override
+    boolean hasSamplingPriority() {
+      return false
+    }
   }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanTest.groovy
@@ -182,11 +182,15 @@ class DDSpanTest extends DDSpecification {
 
     expect:
     parent.context().samplingPriority == PrioritySampling.SAMPLER_KEEP
-    parent.getUnsafeMetrics().get(DDSpanContext.PRIORITY_SAMPLING_KEY) == PrioritySampling.SAMPLER_KEEP
+    parent.getSamplingPriority() == PrioritySampling.SAMPLER_KEEP
+    parent.hasSamplingPriority()
     child1.getSamplingPriority() == parent.getSamplingPriority()
-    child1.getUnsafeMetrics().get(DDSpanContext.PRIORITY_SAMPLING_KEY) == null
     child2.getSamplingPriority() == parent.getSamplingPriority()
-    child2.getUnsafeMetrics().get(DDSpanContext.PRIORITY_SAMPLING_KEY) == null
+    !child1.hasSamplingPriority()
+    !child2.hasSamplingPriority()
+    // and check the internal field itself hasn't been set
+    child1.context().samplingPriorityV1 == PrioritySampling.UNSET
+    child2.context().samplingPriorityV1 == PrioritySampling.UNSET
   }
 
   def "origin set only on root span"() {

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -342,7 +342,7 @@ public class AgentTracer {
 
     @Override
     public Integer getSamplingPriority() {
-      return PrioritySampling.UNSET;
+      return (int) PrioritySampling.UNSET;
     }
 
     @Override


### PR DESCRIPTION
This avoids storing the sampling priority in a map. I chose to represent it as a `byte` since `PrioritySampling.UNSET` is a constant local to the tracer. Currently `DDSpanContext` is already at 80 bytes, so because of alignment it will grow to 88 bytes whether we choose `byte` or `int`, but assuming we can remove fields in the future, choosing a `byte` will pay off. The main aim of this PR is not to need to store or access the value in the map.