### PR TITLE
pendingtrace streamlining

### DIFF
--- a/dd-trace-core/dd-trace-core.gradle
+++ b/dd-trace-core/dd-trace-core.gradle
@@ -39,6 +39,8 @@ dependencies {
   compile group: 'com.github.jnr', name: 'jnr-unixsocket', version: "${versions.jnr_unixsocket}"
   compile group: 'org.jctools', name: 'jctools-core', version: '3.2.0'
 
+  compileOnly group: 'com.github.spotbugs', name: 'spotbugs-annotations', version: '4.2.0'
+
   // We have autoservices defined in test subtree, looks like we need this to be able to properly rebuild this
   testAnnotationProcessor deps.autoserviceProcessor
   testCompileOnly deps.autoserviceAnnotation

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -11,6 +11,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -22,7 +23,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class DDSpan implements AgentSpan, CoreSpan<DDSpan> {
 
-  static DDSpan create(final long timestampMicro, final DDSpanContext context) {
+  static DDSpan create(final long timestampMicro, @Nonnull DDSpanContext context) {
     final DDSpan span = new DDSpan(timestampMicro, context);
     log.debug("Started span: {}", span);
     context.getTrace().registerSpan(span);
@@ -57,7 +58,7 @@ public class DDSpan implements AgentSpan, CoreSpan<DDSpan> {
    * @param timestampMicro if greater than zero, use this time instead of the current time
    * @param context the context used for the span
    */
-  private DDSpan(final long timestampMicro, final DDSpanContext context) {
+  private DDSpan(final long timestampMicro, @Nonnull DDSpanContext context) {
     this.context = context;
 
     if (timestampMicro <= 0L) {
@@ -256,6 +257,7 @@ public class DDSpan implements AgentSpan, CoreSpan<DDSpan> {
   }
 
   @Override
+  @Nonnull
   public final DDSpanContext context() {
     return context;
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/PendingTrace.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/PendingTrace.java
@@ -10,6 +10,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.atomic.AtomicInteger;
+import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -42,7 +43,7 @@ public class PendingTrace implements AgentTrace {
       this.pendingTraceBuffer = pendingTraceBuffer;
     }
 
-    PendingTrace create(final DDId traceId) {
+    PendingTrace create(@Nonnull DDId traceId) {
       return new PendingTrace(tracer, traceId, pendingTraceBuffer);
     }
   }
@@ -80,7 +81,9 @@ public class PendingTrace implements AgentTrace {
   private volatile long lastReferenced = 0;
 
   private PendingTrace(
-      final CoreTracer tracer, final DDId traceId, PendingTraceBuffer pendingTraceBuffer) {
+      @Nonnull CoreTracer tracer,
+      @Nonnull DDId traceId,
+      @Nonnull PendingTraceBuffer pendingTraceBuffer) {
     this.tracer = tracer;
     this.traceId = traceId;
     this.pendingTraceBuffer = pendingTraceBuffer;
@@ -120,12 +123,6 @@ public class PendingTrace implements AgentTrace {
   }
 
   public void registerSpan(final DDSpan span) {
-    if (traceId == null || span.context() == null) {
-      log.error(
-          "Failed to register span ({}) due to null PendingTrace traceId or null span context",
-          span);
-      return;
-    }
     if (!traceId.equals(span.context().getTraceId())) {
       log.debug("t_id={} -> registered for wrong trace {}", traceId, span);
       return;
@@ -150,18 +147,8 @@ public class PendingTrace implements AgentTrace {
       log.debug("t_id={} -> added to trace, but not complete: {}", traceId, span);
       return;
     }
-    if (traceId == null || span.context() == null) {
-      log.error(
-          "Failed to add span ({}) due to null PendingTrace traceId or null span context", span);
-      return;
-    }
     if (!traceId.equals(span.getTraceId())) {
       log.debug("t_id={} -> span expired for wrong trace {}", traceId, span);
-      return;
-    }
-    if (traceId == null || span.context() == null) {
-      log.error(
-          "Failed to expire span ({}) due to null PendingTrace traceId or null span context", span);
       return;
     }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/PendingTrace.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/PendingTrace.java
@@ -122,12 +122,7 @@ public class PendingTrace implements AgentTrace {
     return nanos < age;
   }
 
-  public void registerSpan(final DDSpan span) {
-    if (!traceId.equals(span.context().getTraceId())) {
-      log.debug("t_id={} -> registered for wrong trace {}", traceId, span);
-      return;
-    }
-
+  void registerSpan(final DDSpan span) {
     if (null == rootSpan) {
       synchronized (this) {
         if (!rootSpanWritten && null == rootSpan) {
@@ -142,13 +137,9 @@ public class PendingTrace implements AgentTrace {
     }
   }
 
-  public void addFinishedSpan(final DDSpan span) {
+  void addFinishedSpan(final DDSpan span) {
     if (span.getDurationNano() == 0) {
       log.debug("t_id={} -> added to trace, but not complete: {}", traceId, span);
-      return;
-    }
-    if (!traceId.equals(span.getTraceId())) {
-      log.debug("t_id={} -> span expired for wrong trace {}", traceId, span);
       return;
     }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/PendingTrace.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/PendingTrace.java
@@ -138,11 +138,6 @@ public class PendingTrace implements AgentTrace {
   }
 
   void addFinishedSpan(final DDSpan span) {
-    if (span.getDurationNano() == 0) {
-      log.debug("t_id={} -> added to trace, but not complete: {}", traceId, span);
-      return;
-    }
-
     finishedSpans.addFirst(span);
     // There is a benign race here where the span added above can get written out by a writer in
     // progress before the count has been incremented. It's being taken care of in the internal

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceTest.groovy
@@ -130,27 +130,6 @@ class PendingTraceTest extends DDSpecification {
     writer.traceCount.get() == 0
   }
 
-  def "register span to wrong trace fails"() {
-    setup:
-    def otherTrace = tracer.pendingTraceFactory.create(DDId.from(traceId.toLong() - 10))
-    otherTrace.registerSpan(new DDSpan(0, rootSpan.context()))
-
-    expect:
-    otherTrace.pendingReferenceCount.get() == 0
-    otherTrace.finishedSpans.asList() == []
-  }
-
-  def "add span to wrong trace fails"() {
-    setup:
-    def otherTrace = tracer.pendingTraceFactory.create(DDId.from(traceId.toLong() - 10))
-    rootSpan.finish()
-    otherTrace.addFinishedSpan(rootSpan)
-
-    expect:
-    otherTrace.pendingReferenceCount.get() == 0
-    otherTrace.finishedSpans.asList() == []
-  }
-
   def "child spans created after trace written reported separately"() {
     setup:
     rootSpan.finish()

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceTest.groovy
@@ -120,16 +120,6 @@ class PendingTraceTest extends DDSpecification {
     writer.traceCount.get() == 1
   }
 
-  def "add unfinished span to trace fails"() {
-    setup:
-    trace.addFinishedSpan(rootSpan)
-
-    expect:
-    trace.pendingReferenceCount.get() == 1
-    trace.finishedSpans.asList() == []
-    writer.traceCount.get() == 0
-  }
-
   def "child spans created after trace written reported separately"() {
     setup:
     rootSpan.finish()


### PR DESCRIPTION
* replace impossible null checks with annotations (this PR doesn't set up spotbugs in the build though)
* replace unnecessary trace id checks with trust between `DDSpan` and `PendingTrace`, with reduced access to `PendingTrace` mutators
* replace unnecessary time check with trust between `DDSpan` and `PendingTrace`, with reduced access to `PendingTrace` mutators
* ~don't call `PendingTrace.size()` twice before writing~