### PR TITLE
Single-interface Field-injection

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/FieldBackedContextAccessor.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/FieldBackedContextAccessor.java
@@ -1,0 +1,12 @@
+package datadog.trace.bootstrap;
+
+/**
+ * Accessor API for {@link ContextStore} keys that store their context in a bytecode-injected field.
+ */
+public interface FieldBackedContextAccessor {
+  /** Retrieves context from the field backing the given store. */
+  Object $get$__datadogContext$(int storeId);
+
+  /** Stores context in the field backing the given store. */
+  void $put$__datadogContext$(int storeId, Object context);
+}

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/FieldBackedContextStore.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/FieldBackedContextStore.java
@@ -1,0 +1,86 @@
+package datadog.trace.bootstrap;
+
+/**
+ * {@link ContextStore} that attempts to store context in its keys by using bytecode-injected
+ * fields. Delegates to a lazy {@link WeakMap} for keys that don't have a field for this store.
+ */
+public final class FieldBackedContextStore implements ContextStore<Object, Object> {
+  final int storeId;
+
+  FieldBackedContextStore(final int storeId) {
+    this.storeId = storeId;
+  }
+
+  @Override
+  public Object get(final Object key) {
+    if (key instanceof FieldBackedContextAccessor) {
+      return ((FieldBackedContextAccessor) key).$get$__datadogContext$(storeId);
+    } else {
+      return weakStore().get(key);
+    }
+  }
+
+  @Override
+  public void put(final Object key, final Object context) {
+    if (key instanceof FieldBackedContextAccessor) {
+      ((FieldBackedContextAccessor) key).$put$__datadogContext$(storeId, context);
+    } else {
+      weakStore().put(key, context);
+    }
+  }
+
+  @Override
+  public Object putIfAbsent(final Object key, final Object context) {
+    if (key instanceof FieldBackedContextAccessor) {
+      final FieldBackedContextAccessor accessor = (FieldBackedContextAccessor) key;
+      Object existingContext = accessor.$get$__datadogContext$(storeId);
+      if (null == existingContext) {
+        synchronized (accessor) {
+          existingContext = accessor.$get$__datadogContext$(storeId);
+          if (null == existingContext) {
+            existingContext = context;
+            accessor.$put$__datadogContext$(storeId, existingContext);
+          }
+        }
+      }
+      return existingContext;
+    } else {
+      return weakStore().putIfAbsent(key, context);
+    }
+  }
+
+  @Override
+  public Object putIfAbsent(final Object key, final Factory<Object> contextFactory) {
+    if (key instanceof FieldBackedContextAccessor) {
+      final FieldBackedContextAccessor accessor = (FieldBackedContextAccessor) key;
+      Object existingContext = accessor.$get$__datadogContext$(storeId);
+      if (null == existingContext) {
+        synchronized (accessor) {
+          existingContext = accessor.$get$__datadogContext$(storeId);
+          if (null == existingContext) {
+            existingContext = contextFactory.create();
+            accessor.$put$__datadogContext$(storeId, existingContext);
+          }
+        }
+      }
+      return existingContext;
+    } else {
+      return weakStore().putIfAbsent(key, contextFactory);
+    }
+  }
+
+  // only create WeakMap-based fall-back when we need it
+  private volatile WeakMapContextStore weakStore;
+  private final Object synchronizationInstance = new Object();
+
+  WeakMapContextStore weakStore() {
+    if (null == weakStore) {
+      synchronized (synchronizationInstance) {
+        if (null == weakStore) {
+          weakStore = new WeakMapContextStore();
+        }
+      }
+    }
+    return weakStore;
+  }
+}

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/FieldBackedContextStoreAppliedMarker.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/FieldBackedContextStoreAppliedMarker.java
@@ -1,4 +1,9 @@
 package datadog.trace.bootstrap;
 
-/** Marker interface to show that fields for FieldBackedContextStore have been applied to a class */
+/**
+ * Marker interface to show that fields for FieldBackedContextStore have been applied to a class.
+ *
+ * @deprecated not used in the new field-injection strategy
+ */
+@Deprecated
 public interface FieldBackedContextStoreAppliedMarker {}

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/FieldBackedContextStores.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/FieldBackedContextStores.java
@@ -1,0 +1,140 @@
+package datadog.trace.bootstrap;
+
+import java.util.Arrays;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.extern.slf4j.Slf4j;
+
+/** Allocates {@link ContextStore} ids and keeps track of allocated stores. */
+@Slf4j
+public final class FieldBackedContextStores {
+
+  // provide fast lookup for a fixed number of stores
+  public static final int FAST_STORE_ID_LIMIT = 32;
+
+  // these fields will be accessed directly from field-injected instrumentation
+  public static final FieldBackedContextStore contextStore0 = new FieldBackedContextStore(0);
+  public static final FieldBackedContextStore contextStore1 = new FieldBackedContextStore(1);
+  public static final FieldBackedContextStore contextStore2 = new FieldBackedContextStore(2);
+  public static final FieldBackedContextStore contextStore3 = new FieldBackedContextStore(3);
+  public static final FieldBackedContextStore contextStore4 = new FieldBackedContextStore(4);
+  public static final FieldBackedContextStore contextStore5 = new FieldBackedContextStore(5);
+  public static final FieldBackedContextStore contextStore6 = new FieldBackedContextStore(6);
+  public static final FieldBackedContextStore contextStore7 = new FieldBackedContextStore(7);
+  public static final FieldBackedContextStore contextStore8 = new FieldBackedContextStore(8);
+  public static final FieldBackedContextStore contextStore9 = new FieldBackedContextStore(9);
+  public static final FieldBackedContextStore contextStore10 = new FieldBackedContextStore(10);
+  public static final FieldBackedContextStore contextStore11 = new FieldBackedContextStore(11);
+  public static final FieldBackedContextStore contextStore12 = new FieldBackedContextStore(12);
+  public static final FieldBackedContextStore contextStore13 = new FieldBackedContextStore(13);
+  public static final FieldBackedContextStore contextStore14 = new FieldBackedContextStore(14);
+  public static final FieldBackedContextStore contextStore15 = new FieldBackedContextStore(15);
+  public static final FieldBackedContextStore contextStore16 = new FieldBackedContextStore(16);
+  public static final FieldBackedContextStore contextStore17 = new FieldBackedContextStore(17);
+  public static final FieldBackedContextStore contextStore18 = new FieldBackedContextStore(18);
+  public static final FieldBackedContextStore contextStore19 = new FieldBackedContextStore(19);
+  public static final FieldBackedContextStore contextStore20 = new FieldBackedContextStore(20);
+  public static final FieldBackedContextStore contextStore21 = new FieldBackedContextStore(21);
+  public static final FieldBackedContextStore contextStore22 = new FieldBackedContextStore(22);
+  public static final FieldBackedContextStore contextStore23 = new FieldBackedContextStore(23);
+  public static final FieldBackedContextStore contextStore24 = new FieldBackedContextStore(24);
+  public static final FieldBackedContextStore contextStore25 = new FieldBackedContextStore(25);
+  public static final FieldBackedContextStore contextStore26 = new FieldBackedContextStore(26);
+  public static final FieldBackedContextStore contextStore27 = new FieldBackedContextStore(27);
+  public static final FieldBackedContextStore contextStore28 = new FieldBackedContextStore(28);
+  public static final FieldBackedContextStore contextStore29 = new FieldBackedContextStore(29);
+  public static final FieldBackedContextStore contextStore30 = new FieldBackedContextStore(30);
+  public static final FieldBackedContextStore contextStore31 = new FieldBackedContextStore(31);
+
+  // keep track of all allocated stores so far
+  private static volatile FieldBackedContextStore[] stores = {
+    contextStore0,
+    contextStore1,
+    contextStore2,
+    contextStore3,
+    contextStore4,
+    contextStore5,
+    contextStore6,
+    contextStore7,
+    contextStore8,
+    contextStore9,
+    contextStore10,
+    contextStore11,
+    contextStore12,
+    contextStore13,
+    contextStore14,
+    contextStore15,
+    contextStore16,
+    contextStore17,
+    contextStore18,
+    contextStore19,
+    contextStore20,
+    contextStore21,
+    contextStore22,
+    contextStore23,
+    contextStore24,
+    contextStore25,
+    contextStore26,
+    contextStore27,
+    contextStore28,
+    contextStore29,
+    contextStore30,
+    contextStore31
+  };
+
+  public static FieldBackedContextStore getContextStore(final int storeId) {
+    return stores[storeId]; // createStore ensures array is big enough for allocated storeIds
+  }
+
+  private static final ConcurrentHashMap<String, FieldBackedContextStore> STORES_BY_NAME =
+      new ConcurrentHashMap<>();
+
+  public static int getContextStoreId(final String keyClassName, final String contextClassName) {
+    final String storeName = storeName(keyClassName, contextClassName);
+    FieldBackedContextStore existingStore = STORES_BY_NAME.get(storeName);
+    if (null == existingStore) {
+      synchronized (STORES_BY_NAME) {
+        // speculatively create the next store in the sequence and attempt to map this name to it;
+        // if another thread has mapped this name then the store will be kept for the next mapping
+        final int newStoreId = STORES_BY_NAME.size();
+        existingStore = STORES_BY_NAME.putIfAbsent(storeName, createStore(newStoreId));
+        if (null == existingStore) {
+          log.debug(
+              "Allocated ContextStore #{} to {} -> {}", newStoreId, keyClassName, contextClassName);
+          return newStoreId;
+        }
+      }
+    }
+    return existingStore.storeId;
+  }
+
+  private static String storeName(final String keyClassName, final String contextClassName) {
+    return keyClassName + ';' + contextClassName;
+  }
+
+  // this method should only be called while holding a synchronized lock on STORES_BY_NAME
+  private static FieldBackedContextStore createStore(final int storeId) {
+    if (storeId < FAST_STORE_ID_LIMIT) {
+      return stores[storeId]; // pre-allocated
+    }
+    if (stores.length <= storeId) {
+      stores = Arrays.copyOf(stores, storeId + 16);
+    }
+    // check in case an earlier thread created the store but didn't end up using it
+    FieldBackedContextStore store = stores[storeId];
+    if (null == store) {
+      store = new FieldBackedContextStore(storeId);
+      stores[storeId] = store;
+    }
+    return store;
+  }
+
+  /** Injection helper that immediately delegates to the weak-map for the given context store. */
+  public static Object weakGet(final Object key, final int storeId) {
+    return getContextStore(storeId).weakStore().get(key);
+  }
+
+  /** Injection helper that immediately delegates to the weak-map for the given context store. */
+  public static void weakPut(final Object key, final int storeId, final Object context) {
+    getContextStore(storeId).weakStore().put(key, context);
+  }
+}

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/WeakMapContextStore.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/WeakMapContextStore.java
@@ -1,0 +1,54 @@
+package datadog.trace.bootstrap;
+
+/**
+ * Weak {@link ContextStore} that acts as a fall-back when field-injection isn't possible.
+ *
+ * <p>This class should be created lazily because it uses weak maps with background cleanup.
+ */
+final class WeakMapContextStore implements ContextStore<Object, Object> {
+  private static final int MAX_SIZE = 50_000;
+
+  private final WeakMap<Object, Object> map = WeakMap.Provider.newWeakMap();
+
+  @Override
+  public Object get(final Object key) {
+    return map.get(key);
+  }
+
+  @Override
+  public void put(final Object key, final Object context) {
+    if (map.size() < MAX_SIZE) {
+      map.put(key, context);
+    }
+  }
+
+  @Override
+  public Object putIfAbsent(final Object key, final Object context) {
+    Object existingContext = map.get(key);
+    if (null == existingContext) {
+      synchronized (map) {
+        existingContext = map.get(key);
+        if (null == existingContext) {
+          existingContext = context;
+          put(key, existingContext);
+        }
+      }
+    }
+    return existingContext;
+  }
+
+  @Override
+  public Object putIfAbsent(final Object key, final Factory<Object> contextFactory) {
+    Object existingContext = map.get(key);
+    if (null == existingContext) {
+      synchronized (map) {
+        existingContext = map.get(key);
+        if (null == existingContext) {
+          existingContext = contextFactory.create();
+          put(key, existingContext);
+        }
+      }
+    }
+    return existingContext;
+  }
+}

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/FieldBackedContextStoresTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/FieldBackedContextStoresTest.groovy
@@ -1,0 +1,28 @@
+package datadog.trace.bootstrap
+
+import datadog.trace.agent.test.utils.ThreadUtils
+import datadog.trace.test.util.DDSpecification
+
+import java.util.concurrent.atomic.AtomicInteger
+
+class FieldBackedContextStoresTest extends DDSpecification {
+
+  def "test FieldBackedContextStore id allocation"() {
+    setup:
+      int testAllocations = 128
+      FieldBackedContextStore[] allocatedStores = new FieldBackedContextStore[testAllocations]
+      AtomicInteger keyIds = new AtomicInteger()
+
+      ThreadUtils.runConcurrently(10, testAllocations, {
+        int keyId = keyIds.getAndIncrement()
+        int storeId = FieldBackedContextStores.getContextStoreId("key${keyId}", "value${keyId}")
+        assert allocatedStores[storeId] == null
+        allocatedStores[storeId] = FieldBackedContextStores.getContextStore(storeId)
+      })
+
+    expect:
+      keyIds.get() == testAllocations
+      allocatedStores.size() == testAllocations
+      (allocatedStores as List).withIndex().collect({ store, storeId -> assert store.storeId == storeId })
+  }
+}

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Instrumenter.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Instrumenter.java
@@ -10,6 +10,7 @@ import static net.bytebuddy.matcher.ElementMatchers.not;
 
 import datadog.trace.agent.tooling.bytebuddy.DDTransformers;
 import datadog.trace.agent.tooling.bytebuddy.ExceptionHandlers;
+import datadog.trace.agent.tooling.context.FieldBackedContextProvider;
 import datadog.trace.agent.tooling.context.FieldBackedProvider;
 import datadog.trace.agent.tooling.context.InstrumentationContextProvider;
 import datadog.trace.agent.tooling.context.NoopContextProvider;
@@ -124,7 +125,11 @@ public interface Instrumenter {
             }
           }
           if (!contextStores.isEmpty()) {
-            contextProvider = new FieldBackedProvider(this, contextStores);
+            if (Config.get().isLegacyContextFieldInjection()) {
+              contextProvider = new FieldBackedProvider(this, contextStores);
+            } else {
+              contextProvider = new FieldBackedContextProvider(this, contextStores);
+            }
           } else {
             contextProvider = NoopContextProvider.INSTANCE;
           }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/context/ContextStoreImplementationTemplate.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/context/ContextStoreImplementationTemplate.java
@@ -6,7 +6,10 @@ import datadog.trace.bootstrap.WeakMap;
 /**
  * Template class used to generate the class that accesses stored context using either key
  * instance's own injected field or global hash map if field is not available.
+ *
+ * @deprecated not used in the new field-injection strategy
  */
+@Deprecated
 final class ContextStoreImplementationTemplate implements ContextStore<Object, Object> {
   private static final ContextStoreImplementationTemplate INSTANCE =
       new ContextStoreImplementationTemplate();

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/context/ContextStoreImplementationVisitor.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/context/ContextStoreImplementationVisitor.java
@@ -15,6 +15,8 @@ import net.bytebuddy.jar.asm.MethodVisitor;
 import net.bytebuddy.jar.asm.Opcodes;
 import net.bytebuddy.pool.TypePool;
 
+/** @deprecated not used in the new field-injection strategy */
+@Deprecated
 final class ContextStoreImplementationVisitor implements AsmVisitorWrapper {
 
   private final String setterName;

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/context/ContextStoreInjector.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/context/ContextStoreInjector.java
@@ -16,6 +16,8 @@ import net.bytebuddy.description.modifier.TypeManifestation;
 import net.bytebuddy.description.modifier.Visibility;
 import net.bytebuddy.dynamic.DynamicType;
 
+/** @deprecated not used in the new field-injection strategy */
+@Deprecated
 final class ContextStoreInjector {
 
   private final ByteBuddy byteBuddy;

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/context/ContextStoreUtils.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/context/ContextStoreUtils.java
@@ -46,7 +46,10 @@ final class ContextStoreUtils {
     }
   }
 
+  // ---------------- DEPRECATED METHODS ONLY USED BY THE OLD FIELD-INJECTOR ----------------
+
   /** Get transformer that forces helper injection onto bootstrap classloader. */
+  @Deprecated
   static AgentBuilder.Transformer bootstrapHelperInjector(
       final Collection<DynamicType.Unloaded<?>> types) {
     // TODO: Better to pass through the context of the Instrumenter
@@ -79,9 +82,11 @@ final class ContextStoreUtils {
    * 'module') classloaders like jboss and osgi see injected classes. This works because we
    * instrument those classloaders to load everything inside bootstrap packages.
    */
+  @Deprecated
   private static final String DYNAMIC_CLASSES_PACKAGE =
       "datadog.trace.bootstrap.instrumentation.context.";
 
+  @Deprecated
   static String getContextStoreImplementationClassName(
       final String keyClassName, final String contextClassName) {
     return DYNAMIC_CLASSES_PACKAGE
@@ -92,6 +97,7 @@ final class ContextStoreUtils {
         + Utils.getInnerClassName(contextClassName);
   }
 
+  @Deprecated
   static String getContextAccessorInterfaceName(
       final String keyClassName, final String contextClassName) {
     return DYNAMIC_CLASSES_PACKAGE
@@ -102,14 +108,17 @@ final class ContextStoreUtils {
         + Utils.getInnerClassName(contextClassName);
   }
 
+  @Deprecated
   static String getContextFieldName(final String keyClassName) {
     return "__datadogContext$" + Utils.getInnerClassName(keyClassName);
   }
 
+  @Deprecated
   static String getContextGetterName(final String keyClassName) {
     return "$get$" + getContextFieldName(keyClassName);
   }
 
+  @Deprecated
   static String getContextSetterName(final String key) {
     return "$set$" + getContextFieldName(key);
   }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/context/FieldBackedContextInjector.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/context/FieldBackedContextInjector.java
@@ -1,0 +1,507 @@
+package datadog.trace.agent.tooling.context;
+
+import static datadog.trace.agent.tooling.context.ShouldInjectFieldsMatcher.hasInjectedField;
+import static datadog.trace.bootstrap.FieldBackedContextStores.getContextStoreId;
+
+import datadog.trace.agent.tooling.Utils;
+import datadog.trace.api.Config;
+import datadog.trace.bootstrap.ContextStore;
+import datadog.trace.bootstrap.FieldBackedContextAccessor;
+import datadog.trace.bootstrap.FieldBackedContextStores;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.BitSet;
+import lombok.extern.slf4j.Slf4j;
+import net.bytebuddy.ClassFileVersion;
+import net.bytebuddy.asm.AsmVisitorWrapper;
+import net.bytebuddy.description.field.FieldDescription;
+import net.bytebuddy.description.field.FieldList;
+import net.bytebuddy.description.method.MethodList;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.implementation.Implementation;
+import net.bytebuddy.jar.asm.ClassVisitor;
+import net.bytebuddy.jar.asm.ClassWriter;
+import net.bytebuddy.jar.asm.FieldVisitor;
+import net.bytebuddy.jar.asm.Label;
+import net.bytebuddy.jar.asm.MethodVisitor;
+import net.bytebuddy.jar.asm.Opcodes;
+import net.bytebuddy.jar.asm.Type;
+import net.bytebuddy.pool.TypePool;
+
+/** Injects fields and accessors so the class can act as a surrogate {@link ContextStore}. */
+@Slf4j
+final class FieldBackedContextInjector implements AsmVisitorWrapper {
+
+  static final String FIELD_BACKED_CONTEXT_STORES_CLASS =
+      Utils.getInternalName(FieldBackedContextStores.class.getName());
+
+  static final String FIELD_BACKED_CONTEXT_ACCESSOR_CLASS =
+      Utils.getInternalName(FieldBackedContextAccessor.class.getName());
+
+  static final String CONTEXT_STORE_ACCESS_PREFIX = "__datadogContext$";
+
+  static final String GETTER_METHOD = "$get$" + CONTEXT_STORE_ACCESS_PREFIX;
+  static final String GETTER_METHOD_DESCRIPTOR =
+      Type.getMethodDescriptor(Type.getType(Object.class), Type.INT_TYPE);
+
+  static final String PUTTER_METHOD = "$put$" + CONTEXT_STORE_ACCESS_PREFIX;
+  static final String PUTTER_METHOD_DESCRIPTOR =
+      Type.getMethodDescriptor(Type.VOID_TYPE, Type.INT_TYPE, Type.getType(Object.class));
+
+  static final String WEAK_GET_METHOD = "weakGet";
+  static final String WEAK_GET_METHOD_DESCRIPTOR =
+      Type.getMethodDescriptor(
+          Type.getType(Object.class), Type.getType(Object.class), Type.INT_TYPE);
+
+  static final String WEAK_PUT_METHOD = "weakPut";
+  static final String WEAK_PUT_METHOD_DESCRIPTOR =
+      Type.getMethodDescriptor(
+          Type.VOID_TYPE, Type.getType(Object.class), Type.INT_TYPE, Type.getType(Object.class));
+
+  static final String OBJECT_DESCRIPTOR = Type.getDescriptor(Object.class);
+
+  static final String LINKAGE_ERROR_CLASS = Utils.getInternalName(LinkageError.class.getName());
+
+  /** Keeps track of injection requests for the class being transformed by the current thread. */
+  static final ThreadLocal<BitSet> INJECTED_STORE_IDS = new ThreadLocal<>();
+
+  final boolean serialVersionUIDFieldInjection = Config.get().isSerialVersionUIDFieldInjection();
+
+  final String keyClassName;
+  final String contextClassName;
+
+  public FieldBackedContextInjector(final String keyClassName, final String contextClassName) {
+    this.keyClassName = keyClassName;
+    this.contextClassName = contextClassName;
+  }
+
+  @Override
+  public int mergeWriter(final int flags) {
+    return flags | ClassWriter.COMPUTE_MAXS;
+  }
+
+  @Override
+  public int mergeReader(final int flags) {
+    return flags;
+  }
+
+  @Override
+  public ClassVisitor wrap(
+      final TypeDescription instrumentedType,
+      final ClassVisitor classVisitor,
+      final Implementation.Context implementationContext,
+      final TypePool typePool,
+      final FieldList<FieldDescription.InDefinedShape> fields,
+      final MethodList<?> methods,
+      final int writerFlags,
+      final int readerFlags) {
+    return new ClassVisitor(Opcodes.ASM7, classVisitor) {
+
+      private final boolean frames =
+          implementationContext.getClassFileVersion().isAtLeast(ClassFileVersion.JAVA_V6);
+
+      private String storeFieldName;
+
+      private boolean foundField;
+      private boolean foundGetter;
+      private boolean foundPutter;
+
+      private SerialVersionUIDInjector serialVersionUIDInjector;
+
+      @Override
+      public void visit(
+          final int version,
+          final int access,
+          final String name,
+          String signature,
+          final String superName,
+          String[] interfaces) {
+
+        // keep track of all injection requests for the class currently being transformed
+        // because we need to switch between them in the generated getter/putter methods
+        int storeId = injectContextStore(keyClassName, contextClassName);
+        storeFieldName = CONTEXT_STORE_ACCESS_PREFIX + storeId;
+
+        if (interfaces == null) {
+          interfaces = new String[] {};
+        }
+
+        if (!Arrays.asList(interfaces).contains(FIELD_BACKED_CONTEXT_ACCESSOR_CLASS)) {
+          if (serialVersionUIDFieldInjection
+              && instrumentedType.isAssignableTo(Serializable.class)) {
+            serialVersionUIDInjector = new SerialVersionUIDInjector();
+            serialVersionUIDInjector.visit(version, access, name, signature, superName, interfaces);
+          }
+
+          if (signature != null) {
+            signature += 'L' + FIELD_BACKED_CONTEXT_ACCESSOR_CLASS + ';';
+          }
+
+          interfaces = Arrays.copyOf(interfaces, interfaces.length + 1);
+          interfaces[interfaces.length - 1] = FIELD_BACKED_CONTEXT_ACCESSOR_CLASS;
+        }
+
+        super.visit(version, access, name, signature, superName, interfaces);
+      }
+
+      @Override
+      public FieldVisitor visitField(
+          final int access,
+          final String name,
+          final String descriptor,
+          final String signature,
+          final Object value) {
+        if (name.startsWith(CONTEXT_STORE_ACCESS_PREFIX)) {
+          if (storeFieldName.equals(name)) {
+            foundField = true;
+          }
+        } else if (serialVersionUIDInjector != null) {
+          serialVersionUIDInjector.visitField(access, name, descriptor, signature, value);
+        }
+        return super.visitField(access, name, descriptor, signature, value);
+      }
+
+      @Override
+      public MethodVisitor visitMethod(
+          final int access,
+          final String name,
+          final String descriptor,
+          final String signature,
+          final String[] exceptions) {
+        if (name.equals(GETTER_METHOD)) {
+          foundGetter = true;
+        } else if (name.equals(PUTTER_METHOD)) {
+          foundPutter = true;
+        } else if (serialVersionUIDInjector != null) {
+          serialVersionUIDInjector.visitMethod(access, name, descriptor, signature, exceptions);
+        }
+        return super.visitMethod(access, name, descriptor, signature, exceptions);
+      }
+
+      @Override
+      public void visitInnerClass(
+          final String name, final String outerName, final String innerName, final int access) {
+        if (serialVersionUIDInjector != null) {
+          serialVersionUIDInjector.visitInnerClass(name, outerName, innerName, access);
+        }
+        super.visitInnerClass(name, outerName, innerName, access);
+      }
+
+      @Override
+      public void visitEnd() {
+        if (!foundField) {
+          addStoreField();
+        }
+        // first injector to reach here is responsible for adding the generated getter and setter
+        // for the class - at this point all the other injectors will have recorded their requests
+        final BitSet injectedStoreIds = getInjectedContextStores();
+        if (null != injectedStoreIds) {
+          if (!foundGetter || !foundPutter) {
+            BitSet excludedStoreIds = new BitSet();
+
+            // check hierarchy to see if we might need to delegate to the superclass
+            boolean hasSuperStores =
+                hasInjectedField(instrumentedType.getSuperClass(), excludedStoreIds);
+
+            if (!foundGetter) {
+              addStoreGetter(injectedStoreIds, hasSuperStores, excludedStoreIds);
+            }
+            if (!foundPutter) {
+              addStorePutter(injectedStoreIds, hasSuperStores, excludedStoreIds);
+            }
+          }
+        }
+
+        if (serialVersionUIDInjector != null) {
+          serialVersionUIDInjector.injectSerialVersionUID(instrumentedType, cv);
+          serialVersionUIDInjector = null;
+        }
+
+        storeFieldName = null;
+
+        foundField = false;
+        foundGetter = false;
+        foundPutter = false;
+
+        super.visitEnd();
+      }
+
+      private void addStoreField() {
+        cv.visitField(
+            Opcodes.ACC_PRIVATE | Opcodes.ACC_TRANSIENT,
+            storeFieldName,
+            OBJECT_DESCRIPTOR,
+            null,
+            null);
+      }
+
+      private void addStoreGetter(
+          final BitSet injectedStoreIds,
+          final boolean hasSuperStores,
+          final BitSet excludedStoreIds) {
+        final MethodVisitor mv =
+            cv.visitMethod(Opcodes.ACC_PUBLIC, GETTER_METHOD, GETTER_METHOD_DESCRIPTOR, null, null);
+
+        mv.visitCode();
+
+        String instrumentedName = instrumentedType.getInternalName();
+        boolean hasMoreStores = hasSuperStores || !excludedStoreIds.isEmpty();
+
+        // if...else... blocks for stores injected into this class
+        int injectedStoreId = injectedStoreIds.nextSetBit(0);
+        while (injectedStoreId >= 0) {
+          int nextStoreId = injectedStoreIds.nextSetBit(injectedStoreId + 1);
+
+          // optimization: if we know the superclass hierarchy doesn't have any context store
+          // (injected or excluded) then we can skip the id check and go straight to the field
+          Label nextStoreLabel = null;
+          if (hasMoreStores || nextStoreId >= 0) {
+            nextStoreLabel = compareStoreId(mv, injectedStoreId);
+          }
+
+          getStoreField(mv, instrumentedName, injectedStoreId);
+
+          if (null != nextStoreLabel) {
+            beginNextStore(mv, nextStoreLabel);
+          }
+          injectedStoreId = nextStoreId;
+        }
+
+        // if...else... blocks for stores excluded between this class and last injected superclass
+        int excludedStoreId = excludedStoreIds.nextSetBit(0);
+        while (excludedStoreId >= 0) {
+          int nextStoreId = excludedStoreIds.nextSetBit(excludedStoreId + 1);
+          Label nextStoreLabel = compareStoreId(mv, excludedStoreId);
+
+          invokeWeakGet(mv);
+
+          beginNextStore(mv, nextStoreLabel);
+          excludedStoreId = nextStoreId;
+        }
+
+        // else... delegate to superclass - but be prepared to fall-back to weakmap
+        if (hasMoreStores) {
+          Label superStoreLabel = new Label();
+          Label defaultStoreLabel = new Label();
+
+          mv.visitTryCatchBlock(
+              superStoreLabel, defaultStoreLabel, defaultStoreLabel, LINKAGE_ERROR_CLASS);
+          beginNextStore(mv, superStoreLabel);
+
+          invokeSuperGet(mv, instrumentedType.getSuperClass().asErasure().getInternalName());
+
+          mv.visitLabel(defaultStoreLabel);
+          if (frames) {
+            mv.visitFrame(Opcodes.F_SAME1, 0, null, 1, new Object[] {LINKAGE_ERROR_CLASS});
+          }
+
+          invokeWeakGet(mv);
+        }
+
+        mv.visitMaxs(0, 0);
+        mv.visitEnd();
+      }
+
+      private void addStorePutter(
+          final BitSet injectedStoreIds,
+          final boolean hasSuperStores,
+          final BitSet excludedStoreIds) {
+        final MethodVisitor mv =
+            cv.visitMethod(Opcodes.ACC_PUBLIC, PUTTER_METHOD, PUTTER_METHOD_DESCRIPTOR, null, null);
+
+        mv.visitCode();
+
+        String instrumentedName = instrumentedType.getInternalName();
+        boolean hasMoreStores = hasSuperStores || !excludedStoreIds.isEmpty();
+
+        // if...else... blocks for stores injected into this class
+        int injectedStoreId = injectedStoreIds.nextSetBit(0);
+        while (injectedStoreId >= 0) {
+          int nextStoreId = injectedStoreIds.nextSetBit(injectedStoreId + 1);
+
+          // optimization: if we know the superclass hierarchy doesn't have any context store
+          // (injected or excluded) then we can skip the id check and go straight to the field
+          Label nextStoreLabel = null;
+          if (hasMoreStores || nextStoreId >= 0) {
+            nextStoreLabel = compareStoreId(mv, injectedStoreId);
+          }
+
+          putStoreField(mv, instrumentedName, injectedStoreId);
+
+          if (null != nextStoreLabel) {
+            beginNextStore(mv, nextStoreLabel);
+          }
+          injectedStoreId = nextStoreId;
+        }
+
+        // if...else... blocks for stores excluded between this class and last injected superclass
+        int excludedStoreId = excludedStoreIds.nextSetBit(0);
+        while (excludedStoreId >= 0) {
+          int nextStoreId = excludedStoreIds.nextSetBit(excludedStoreId + 1);
+          Label nextStoreLabel = compareStoreId(mv, excludedStoreId);
+
+          invokeWeakPut(mv);
+
+          beginNextStore(mv, nextStoreLabel);
+          excludedStoreId = nextStoreId;
+        }
+
+        // else... delegate to superclass - but be prepared to fall-back to weakmap
+        if (hasMoreStores) {
+          Label superStoreLabel = new Label();
+          Label defaultStoreLabel = new Label();
+
+          mv.visitTryCatchBlock(
+              superStoreLabel, defaultStoreLabel, defaultStoreLabel, LINKAGE_ERROR_CLASS);
+          beginNextStore(mv, superStoreLabel);
+
+          invokeSuperPut(mv, instrumentedType.getSuperClass().asErasure().getInternalName());
+
+          mv.visitLabel(defaultStoreLabel);
+          if (frames) {
+            mv.visitFrame(Opcodes.F_SAME1, 0, null, 1, new Object[] {LINKAGE_ERROR_CLASS});
+          }
+
+          invokeWeakPut(mv);
+        }
+
+        mv.visitMaxs(0, 0);
+        mv.visitEnd();
+      }
+
+      private Label compareStoreId(final MethodVisitor mv, final int storeId) {
+        mv.visitIntInsn(Opcodes.ILOAD, 1);
+        Label nextStoreLabel = new Label();
+        if (storeId == 0) {
+          mv.visitJumpInsn(Opcodes.IFNE, nextStoreLabel);
+        } else {
+          if (storeId >= 0 && storeId <= 5) {
+            mv.visitInsn(Opcodes.ICONST_0 + storeId);
+          } else {
+            mv.visitLdcInsn(storeId);
+          }
+          mv.visitJumpInsn(Opcodes.IF_ICMPNE, nextStoreLabel);
+        }
+        return nextStoreLabel;
+      }
+
+      private void beginNextStore(final MethodVisitor mv, final Label nextStoreLabel) {
+        mv.visitLabel(nextStoreLabel);
+        if (frames) {
+          mv.visitFrame(Opcodes.F_SAME, 0, null, 0, null);
+        }
+      }
+
+      private void getStoreField(
+          final MethodVisitor mv, final String instrumentedName, final int injectedStoreId) {
+        mv.visitIntInsn(Opcodes.ALOAD, 0);
+        mv.visitFieldInsn(
+            Opcodes.GETFIELD,
+            instrumentedName,
+            CONTEXT_STORE_ACCESS_PREFIX + injectedStoreId,
+            OBJECT_DESCRIPTOR);
+        mv.visitInsn(Opcodes.ARETURN);
+      }
+
+      private void putStoreField(
+          final MethodVisitor mv, final String instrumentedName, final int injectedStoreId) {
+        mv.visitIntInsn(Opcodes.ALOAD, 0);
+        mv.visitIntInsn(Opcodes.ALOAD, 2);
+        mv.visitFieldInsn(
+            Opcodes.PUTFIELD,
+            instrumentedName,
+            CONTEXT_STORE_ACCESS_PREFIX + injectedStoreId,
+            OBJECT_DESCRIPTOR);
+        mv.visitInsn(Opcodes.RETURN);
+      }
+
+      private void invokeWeakGet(final MethodVisitor mv) {
+        mv.visitIntInsn(Opcodes.ALOAD, 0);
+        mv.visitIntInsn(Opcodes.ILOAD, 1);
+        mv.visitMethodInsn(
+            Opcodes.INVOKESTATIC,
+            FIELD_BACKED_CONTEXT_STORES_CLASS,
+            WEAK_GET_METHOD,
+            WEAK_GET_METHOD_DESCRIPTOR,
+            false);
+        mv.visitInsn(Opcodes.ARETURN);
+      }
+
+      private void invokeWeakPut(final MethodVisitor mv) {
+        mv.visitIntInsn(Opcodes.ALOAD, 0);
+        mv.visitIntInsn(Opcodes.ILOAD, 1);
+        mv.visitIntInsn(Opcodes.ALOAD, 2);
+        mv.visitMethodInsn(
+            Opcodes.INVOKESTATIC,
+            FIELD_BACKED_CONTEXT_STORES_CLASS,
+            WEAK_PUT_METHOD,
+            WEAK_PUT_METHOD_DESCRIPTOR,
+            false);
+        mv.visitInsn(Opcodes.RETURN);
+      }
+
+      private void invokeSuperGet(final MethodVisitor mv, final String superName) {
+        mv.visitIntInsn(Opcodes.ALOAD, 0);
+        mv.visitIntInsn(Opcodes.ILOAD, 1);
+        mv.visitMethodInsn(
+            Opcodes.INVOKESPECIAL, superName, GETTER_METHOD, GETTER_METHOD_DESCRIPTOR, false);
+        mv.visitInsn(Opcodes.ARETURN);
+      }
+
+      private void invokeSuperPut(final MethodVisitor mv, final String superName) {
+        mv.visitIntInsn(Opcodes.ALOAD, 0);
+        mv.visitIntInsn(Opcodes.ILOAD, 1);
+        mv.visitIntInsn(Opcodes.ALOAD, 2);
+        mv.visitMethodInsn(
+            Opcodes.INVOKESPECIAL, superName, PUTTER_METHOD, PUTTER_METHOD_DESCRIPTOR, false);
+        mv.visitInsn(Opcodes.RETURN);
+      }
+    };
+  }
+
+  /** Requests injection of a context store for a key and context. */
+  static int injectContextStore(final String keyClassName, final String contextClassName) {
+    int storeId = getContextStoreId(keyClassName, contextClassName);
+
+    BitSet injectedStoreIds = INJECTED_STORE_IDS.get();
+    if (null == injectedStoreIds) {
+      injectedStoreIds = new BitSet();
+      INJECTED_STORE_IDS.set(injectedStoreIds);
+    }
+    injectedStoreIds.set(storeId);
+
+    return storeId;
+  }
+
+  /** Returns all context store injection requests for the class being transformed. */
+  static BitSet getInjectedContextStores() {
+    BitSet injectedStoreIds = INJECTED_STORE_IDS.get();
+    if (null != injectedStoreIds) {
+      INJECTED_STORE_IDS.remove();
+    }
+    return injectedStoreIds;
+  }
+
+  private static final class SerialVersionUIDInjector
+      extends datadog.trace.agent.tooling.context.asm.SerialVersionUIDAdder {
+    public SerialVersionUIDInjector() {
+      super(Opcodes.ASM7, null);
+    }
+
+    public void injectSerialVersionUID(
+        final TypeDescription instrumentedType, final ClassVisitor transformer) {
+      if (!hasSVUID()) {
+        try {
+          transformer.visitField(
+              Opcodes.ACC_FINAL | Opcodes.ACC_STATIC,
+              "serialVersionUID",
+              "J",
+              null,
+              computeSVUID());
+        } catch (final Exception e) {
+          log.debug("Failed to add serialVersionUID to {}", instrumentedType.getActualName(), e);
+        }
+      }
+    }
+  }
+}

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/context/FieldInjectionVisitor.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/context/FieldInjectionVisitor.java
@@ -21,6 +21,8 @@ import net.bytebuddy.jar.asm.MethodVisitor;
 import net.bytebuddy.jar.asm.Opcodes;
 import net.bytebuddy.pool.TypePool;
 
+/** @deprecated not used in the new field-injection strategy */
+@Deprecated
 @Slf4j
 final class FieldInjectionVisitor implements AsmVisitorWrapper {
 

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/context/FieldInjector.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/context/FieldInjector.java
@@ -16,6 +16,8 @@ import net.bytebuddy.description.modifier.Visibility;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.dynamic.DynamicType;
 
+/** @deprecated not used in the new field-injection strategy */
+@Deprecated
 final class FieldInjector {
 
   /** fields-accessor-interface-name -> fields-accessor-interface-dynamic-type */

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/context/ShouldInjectFieldsMatcher.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/context/ShouldInjectFieldsMatcher.java
@@ -1,11 +1,18 @@
 package datadog.trace.agent.tooling.context;
 
+import static datadog.trace.bootstrap.FieldBackedContextStores.getContextStoreId;
+
+import datadog.trace.api.Config;
+import datadog.trace.bootstrap.FieldBackedContextAccessor;
 import datadog.trace.bootstrap.FieldBackedContextStoreAppliedMarker;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter;
 import java.security.ProtectionDomain;
 import java.util.Arrays;
+import java.util.BitSet;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import lombok.extern.slf4j.Slf4j;
 import net.bytebuddy.agent.builder.AgentBuilder;
@@ -20,6 +27,20 @@ final class ShouldInjectFieldsMatcher implements AgentBuilder.RawMatcher {
   // context store keys, so can't get very big
   private static final ConcurrentHashMap<String, Boolean> KEY_TYPE_IS_CLASS =
       new ConcurrentHashMap<>();
+
+  private static final Class<?> FIELD_INJECTED_MARKER =
+      Config.get().isLegacyContextFieldInjection()
+          ? FieldBackedContextStoreAppliedMarker.class
+          : FieldBackedContextAccessor.class;
+
+  private static final boolean TRACK_EXCLUDED_CONTEXT_STORES =
+      !Config.get().isLegacyContextFieldInjection();
+
+  // this map will contain entries for any root type that we wanted to field-inject
+  // but were not able to - either because it was explicitly excluded, or because we
+  // failed to field-inject as the type was already loaded
+  private static final ConcurrentHashMap<String, BitSet> EXCLUDED_STORE_IDS_BY_TYPE =
+      TRACK_EXCLUDED_CONTEXT_STORES ? new ConcurrentHashMap<String, BitSet>() : null;
 
   public static AgentBuilder.RawMatcher of(String keyType, String valueType) {
     return new ShouldInjectFieldsMatcher(keyType, valueType);
@@ -46,6 +67,9 @@ final class ShouldInjectFieldsMatcher implements AgentBuilder.RawMatcher {
 
     // First check if we should skip injecting the field based on the key type
     if (skipType != null && ExcludeFilter.exclude(skipType, matchedType)) {
+      if (TRACK_EXCLUDED_CONTEXT_STORES) {
+        excludeStoreForType(matchedType, getContextStoreId(keyType, valueType));
+      }
       if (log.isDebugEnabled()) {
         log.debug("Skipping context-store field for {}: {} -> {}", matchedType, keyType, valueType);
       }
@@ -61,8 +85,7 @@ final class ShouldInjectFieldsMatcher implements AgentBuilder.RawMatcher {
      */
     boolean shouldInject =
         classBeingRedefined == null
-            || Arrays.asList(classBeingRedefined.getInterfaces())
-                .contains(FieldBackedContextStoreAppliedMarker.class);
+            || Arrays.asList(classBeingRedefined.getInterfaces()).contains(FIELD_INJECTED_MARKER);
     String injectionTarget = null;
     if (shouldInject) {
       // will always inject the key type if it's a class,
@@ -91,8 +114,15 @@ final class ShouldInjectFieldsMatcher implements AgentBuilder.RawMatcher {
             valueType,
             injectionTarget);
       } else {
+        // must be a redefine of a class that we weren't able to field-inject on startup
+        // - make sure we'd have field-injected (if we'd had the chance) before tracking
         if (keyType.equals(matchedType)
             || matchedType.equals(getInjectionTarget(typeDescription))) {
+
+          if (TRACK_EXCLUDED_CONTEXT_STORES) {
+            excludeStoreForType(matchedType, getContextStoreId(keyType, valueType));
+          }
+
           // Only log failed redefines where we would have injected this class
           log.debug(
               "Failed to add context-store field to {}: {} -> {}", matchedType, keyType, valueType);
@@ -119,7 +149,7 @@ final class ShouldInjectFieldsMatcher implements AgentBuilder.RawMatcher {
     }
     // then we don't know it's a class so need to
     // follow the type's ancestry to find out
-    TypeDescription.Generic superClass = typeDescription.getSuperClass();
+    TypeDefinition superClass = typeDescription.getSuperClass();
     String implementingClass = typeDescription.getName();
     Map<String, Boolean> visitedInterfaces = new HashMap<>();
     while (null != superClass) {
@@ -160,6 +190,69 @@ final class ShouldInjectFieldsMatcher implements AgentBuilder.RawMatcher {
           visitedInterfaces.put(interfaceName, true); // update assumption
           return true;
         }
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Keep track of which stores (per-type) were explicitly excluded or we failed to field-inject.
+   * This is used to decide when we can't apply certain store optimizations ahead of loading.
+   */
+  private static void excludeStoreForType(final String matchedType, final int storeId) {
+    BitSet excludedStoreIdsForType = EXCLUDED_STORE_IDS_BY_TYPE.get(matchedType);
+    if (null == excludedStoreIdsForType) {
+      BitSet tempStoreIds = new BitSet();
+      tempStoreIds.set(storeId);
+      excludedStoreIdsForType = EXCLUDED_STORE_IDS_BY_TYPE.putIfAbsent(matchedType, tempStoreIds);
+    }
+    // if we didn't get there first then add this store to the existing set
+    if (null != excludedStoreIdsForType) {
+      synchronized (excludedStoreIdsForType) {
+        excludedStoreIdsForType.set(storeId);
+      }
+    }
+  }
+
+  /**
+   * Scans the class hierarchy to see if it matches any known context-key types which implies it has
+   * an injected field somewhere. This avoids having to record successful field-injections which can
+   * add up to a lot of entries. Unfortunately we can't check for the marker interface because the
+   * type won't have that at this point.
+   *
+   * <p>At the same time we collect which context stores failed to be field-injected in the class
+   * hierarchy. This tells us when to redirect store requests to the weak-map vs delegating to the
+   * superclass.
+   *
+   * <p>Assumes the type has already been processed by ShouldInjectFieldsMatcher.
+   */
+  public static boolean hasInjectedField(TypeDefinition typeDefinition, BitSet excludedStoreIds) {
+    Set<String> visitedInterfaces = new HashSet<>();
+    while (null != typeDefinition) {
+      String className = typeDefinition.asErasure().getTypeName();
+      BitSet excludedStoreIdsForType = EXCLUDED_STORE_IDS_BY_TYPE.get(className);
+      if (null != excludedStoreIdsForType) {
+        synchronized (excludedStoreIdsForType) {
+          excludedStoreIds.or(excludedStoreIdsForType);
+        }
+      } else if (KEY_TYPE_IS_CLASS.containsKey(className)
+          || impliesInjectedField(typeDefinition, visitedInterfaces)) {
+        return true;
+      }
+      typeDefinition = typeDefinition.getSuperClass();
+    }
+    return false;
+  }
+
+  /** Scans transitive interfaces to see if any match known context-key types. */
+  private static boolean impliesInjectedField(
+      final TypeDefinition typeDefinition, final Set<String> visitedInterfaces) {
+    for (TypeDefinition iface : typeDefinition.getInterfaces()) {
+      String interfaceName = iface.asErasure().getTypeName();
+      if (KEY_TYPE_IS_CLASS.containsKey(interfaceName)
+          || (visitedInterfaces.add(interfaceName)
+              && impliesInjectedField(iface, visitedInterfaces))) {
+        return true;
       }
     }
     return false;

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/AgentTestRunner.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/AgentTestRunner.groovy
@@ -236,7 +236,8 @@ abstract class AgentTestRunner extends DDSpecification implements AgentBuilder.L
     }
 
     // Incorrect* classes assert on incorrect api usage. Error expected.
-    if (typeName.startsWith('context.ContextTestInstrumentation$Incorrect') && throwable.getMessage().startsWith("Incorrect Context Api Usage detected.")) {
+    if (typeName.startsWith('context.FieldInjectionTestInstrumentation$Incorrect')
+      && throwable.getMessage().startsWith("Incorrect Context Api Usage detected.")) {
       return
     }
 

--- a/dd-java-agent/testing/src/test/groovy/context/FieldInjectionLegacyForkedTest.groovy
+++ b/dd-java-agent/testing/src/test/groovy/context/FieldInjectionLegacyForkedTest.groovy
@@ -1,0 +1,261 @@
+package context
+
+import datadog.trace.agent.test.AbortTransformationException
+import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.agent.test.utils.ClasspathUtils
+import datadog.trace.api.Config
+import datadog.trace.test.util.GCUtils
+import net.bytebuddy.agent.ByteBuddyAgent
+import net.bytebuddy.utility.JavaModule
+import net.sf.cglib.proxy.Enhancer
+import net.sf.cglib.proxy.MethodInterceptor
+import net.sf.cglib.proxy.MethodProxy
+
+import java.lang.instrument.ClassDefinition
+import java.lang.ref.WeakReference
+import java.lang.reflect.Field
+import java.lang.reflect.Method
+import java.lang.reflect.Modifier
+import java.util.concurrent.atomic.AtomicReference
+
+import static context.FieldInjectionTestInstrumentation.DisabledKeyClass
+import static context.FieldInjectionTestInstrumentation.IncorrectCallUsageKeyClass
+import static context.FieldInjectionTestInstrumentation.IncorrectContextClassUsageKeyClass
+import static context.FieldInjectionTestInstrumentation.IncorrectKeyClassUsageKeyClass
+import static context.FieldInjectionTestInstrumentation.InvalidInheritsSerializableKeyClass
+import static context.FieldInjectionTestInstrumentation.InvalidSerializableKeyClass
+import static context.FieldInjectionTestInstrumentation.KeyClass
+import static context.FieldInjectionTestInstrumentation.UntransformableKeyClass
+import static context.FieldInjectionTestInstrumentation.ValidInheritsSerializableKeyClass
+import static context.FieldInjectionTestInstrumentation.ValidSerializableKeyClass
+import static org.junit.Assume.assumeTrue
+
+class FieldInjectionLegacyForkedTest extends AgentTestRunner {
+  void configurePreAgent() {
+    injectSysConfig("dd.trace.legacy.context.field.injection", "true")
+  }
+
+  @Override
+  void onDiscovery(String typeName, ClassLoader classLoader, JavaModule module, boolean loaded) {
+    if (typeName?.endsWith("UntransformableKeyClass")) {
+      throw new AbortTransformationException(
+        "Aborting transform for class name = " + typeName + ", loader = " + classLoader)
+    }
+
+    super.onDiscovery(typeName, classLoader, module, loaded)
+  }
+
+  def "#keyClassName structure modified = #shouldModifyStructure"() {
+    setup:
+    boolean hasField = false
+    boolean isPrivate = false
+    boolean isTransient = false
+    for (Field field : keyClass.getDeclaredFields()) {
+      if (field.getName().startsWith("__datadog")) {
+        isPrivate = Modifier.isPrivate(field.getModifiers())
+        isTransient = Modifier.isTransient(field.getModifiers())
+        hasField = true
+        break
+      }
+    }
+
+    boolean hasMarkerInterface = false
+    boolean hasAccessorInterface = false
+    for (Class inter : keyClass.getInterfaces()) {
+      if (inter.getName() == 'datadog.trace.bootstrap.FieldBackedContextStoreAppliedMarker') {
+        hasMarkerInterface = true
+      }
+      if (inter.getName().startsWith('datadog.trace.bootstrap.instrumentation.context.FieldBackedProvider$ContextAccessor')) {
+        hasAccessorInterface = true
+      }
+    }
+
+    expect:
+    hasField == shouldModifyStructure
+    isPrivate == shouldModifyStructure
+    isTransient == shouldModifyStructure
+    hasMarkerInterface == shouldModifyStructure
+    hasAccessorInterface == shouldModifyStructure
+    keyClass.newInstance().isInstrumented() == isInstrumented
+
+    where:
+    keyClass                            | shouldModifyStructure | isInstrumented
+    KeyClass                            | true                  | true
+    UntransformableKeyClass             | false                 | false
+    ValidSerializableKeyClass           | true                  | true
+    InvalidSerializableKeyClass         | true                  | true
+    ValidInheritsSerializableKeyClass   | true                  | true
+    InvalidInheritsSerializableKeyClass | true                  | true
+
+    keyClassName = keyClass.getSimpleName()
+  }
+
+  def "correct api usage stores state in map"() {
+    when:
+    instance1.incrementContextCount()
+
+    then:
+    instance1.incrementContextCount() == 2
+    instance2.incrementContextCount() == 1
+
+    where:
+    instance1                     | instance2
+    new KeyClass()                | new KeyClass()
+    new UntransformableKeyClass() | new UntransformableKeyClass()
+  }
+
+  def "get/put test"() {
+    when:
+    instance1.putContextCount(10)
+
+    then:
+    instance1.getContextCount() == 10
+
+    where:
+    instance1                     | _
+    new KeyClass()                | _
+    new UntransformableKeyClass() | _
+  }
+
+  def "serializability not impacted"() {
+    setup:
+    assumeTrue(Config.get().isSerialVersionUIDFieldInjection())
+
+    expect:
+    serialVersionUID(serializable) == serialVersionUID
+
+    where:
+    serializable                        | serialVersionUID // These are calculated with the corresponding declarations in FieldInjectionTestInstrumentation removed
+    ValidSerializableKeyClass           | 123
+    InvalidSerializableKeyClass         | -5663127853206342441L
+    ValidInheritsSerializableKeyClass   | 456
+    InvalidInheritsSerializableKeyClass | -4774694079403599336L
+  }
+
+  static final long serialVersionUID(Class<? extends Serializable> klass) throws Exception {
+    try {
+      def field = klass.getDeclaredField("serialVersionUID")
+      field.setAccessible(true)
+      return (long) field.get(null)
+    } catch (NoSuchFieldException ex) {
+      def method = ObjectStreamClass.getDeclaredMethod("computeDefaultSUID", Class)
+      method.setAccessible(true)
+      return (long) method.invoke(null, klass)
+    }
+  }
+
+  def "works with cglib enhanced instances which duplicates context getter and setter methods"() {
+    setup:
+    Enhancer enhancer = new Enhancer()
+    enhancer.setSuperclass(KeyClass)
+    enhancer.setCallback(new MethodInterceptor() {
+      @Override
+      Object intercept(Object arg0, Method arg1, Object[] arg2,
+                       MethodProxy arg3) throws Throwable {
+        return arg3.invokeSuper(arg0, arg2)
+      }
+    })
+
+    when:
+    (KeyClass) enhancer.create()
+
+    then:
+    noExceptionThrown()
+  }
+
+  def "backing map should not create strong refs to key class instances #keyValue.get().getClass().getName()"() {
+    when:
+    final int count = keyValue.get().incrementContextCount()
+    WeakReference<KeyClass> instanceRef = new WeakReference(keyValue.get())
+    keyValue.set(null)
+    GCUtils.awaitGC(instanceRef)
+
+    then:
+    instanceRef.get() == null
+    count == 1
+
+    where:
+    keyValue                                           | _
+    new AtomicReference(new KeyClass())                | _
+    new AtomicReference(new UntransformableKeyClass()) | _
+  }
+
+  def "context classes are retransform safe"() {
+    when:
+    ByteBuddyAgent.getInstrumentation().retransformClasses(KeyClass)
+    ByteBuddyAgent.getInstrumentation().retransformClasses(UntransformableKeyClass)
+
+    then:
+    new KeyClass().isInstrumented()
+    !new UntransformableKeyClass().isInstrumented()
+    new KeyClass().incrementContextCount() == 1
+    new UntransformableKeyClass().incrementContextCount() == 1
+  }
+
+  def "context classes are redefine safe"() {
+    when:
+    ByteBuddyAgent.getInstrumentation().redefineClasses(new ClassDefinition(KeyClass, ClasspathUtils.convertToByteArray(KeyClass)))
+    ByteBuddyAgent.getInstrumentation().redefineClasses(new ClassDefinition(UntransformableKeyClass, ClasspathUtils.convertToByteArray(UntransformableKeyClass)))
+
+    then:
+    new KeyClass().isInstrumented()
+    !new UntransformableKeyClass().isInstrumented()
+    new KeyClass().incrementContextCount() == 1
+    new UntransformableKeyClass().incrementContextCount() == 1
+  }
+
+  def "incorrect key class usage fails at class load time"() {
+    expect:
+    !new IncorrectKeyClassUsageKeyClass().isInstrumented()
+  }
+
+  def "incorrect context class usage fails at class load time"() {
+    expect:
+    !new IncorrectContextClassUsageKeyClass().isInstrumented()
+  }
+
+  def "incorrect call usage fails at class load time"() {
+    expect:
+    !new IncorrectCallUsageKeyClass().isInstrumented()
+  }
+}
+
+/**
+ * Make sure that fields don't get injected into the class if it is disabled via system properties.
+ */
+class FieldInjectionDisabledLegacyForkedTest extends AgentTestRunner {
+  void configurePreAgent() {
+    injectSysConfig("dd.trace.legacy.context.field.injection", "true")
+    injectSysConfig("dd.trace.runtime.context.field.injection", "false")
+  }
+
+  def "Check that structure is not modified when structure modification is disabled"() {
+    setup:
+    def keyClass = DisabledKeyClass
+    boolean hasField = false
+    for (Field field : keyClass.getDeclaredFields()) {
+      if (field.getName().startsWith("__datadog")) {
+        hasField = true
+        break
+      }
+    }
+
+    boolean hasMarkerInterface = false
+    boolean hasAccessorInterface = false
+    for (Class inter : keyClass.getInterfaces()) {
+      if (inter.getName() == 'datadog.trace.bootstrap.FieldBackedContextStoreAppliedMarker') {
+        hasMarkerInterface = true
+      }
+      if (inter.getName().startsWith('datadog.trace.bootstrap.instrumentation.context.FieldBackedProvider$ContextAccessor')) {
+        hasAccessorInterface = true
+      }
+    }
+
+    expect:
+    hasField == false
+    hasMarkerInterface == false
+    hasAccessorInterface == false
+    keyClass.newInstance().isInstrumented() == true
+  }
+
+}

--- a/dd-java-agent/testing/src/test/groovy/excludefilter/ExcludeFilterForkedTest.groovy
+++ b/dd-java-agent/testing/src/test/groovy/excludefilter/ExcludeFilterForkedTest.groovy
@@ -1,0 +1,89 @@
+package excludefilter
+
+import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.bootstrap.FieldBackedContextStores
+import datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter
+
+import java.lang.reflect.Field
+import java.util.concurrent.Callable
+
+import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.ExcludeType.RUNNABLE
+import static excludefilter.ExcludeFilterTestInstrumentation.CallableExcludedRunnable
+import static excludefilter.ExcludeFilterTestInstrumentation.CallableRunnable
+import static excludefilter.ExcludeFilterTestInstrumentation.ExcludedCallable
+import static excludefilter.ExcludeFilterTestInstrumentation.ExcludedRunnable
+import static excludefilter.ExcludeFilterTestInstrumentation.NormalCallable
+import static excludefilter.ExcludeFilterTestInstrumentation.NormalRunnable
+import static excludefilter.ExcludeFilterTestInstrumentation.RunnableExcludedCallable
+
+class ExcludeFilterForkedTest extends AgentTestRunner {
+  void configurePreAgent() {
+    injectSysConfig("dd.trace.legacy.context.field.injection", "false")
+  }
+
+  def "test ExcludeFilter"() {
+    expect:
+    ExcludeFilter.exclude(RUNNABLE, runnable) == excluded
+
+    where:
+    runnable               | excluded
+    new ExcludedRunnable() | true
+    new NormalRunnable()   | false
+  }
+
+  def "test field injection exclusion"() {
+    setup:
+    def runnableCheck = new InjectionCheck(clazz, Runnable, Object)
+    def callableCheck = new InjectionCheck(clazz, Callable, Object)
+
+    expect:
+    runnableCheck.hasField() == hasRunnable
+    runnableCheck.hasAccessorInterface() == hasAccessor
+    callableCheck.hasField() == hasCallable
+    callableCheck.hasAccessorInterface() == hasAccessor
+
+    where:
+    clazz                    | hasRunnable | hasCallable | hasAccessor
+    ExcludedRunnable         | false       | false       | false
+    NormalRunnable           | true        | false       | true
+    RunnableExcludedCallable | true        | false       | true
+    ExcludedCallable         | false       | false       | false
+    NormalCallable           | false       | true        | true
+    CallableExcludedRunnable | false       | true        | true
+    CallableRunnable         | true        | true        | true
+  }
+
+  static class InjectionCheck {
+    private final boolean hasField
+    private final boolean  hasAccessorInterface
+
+    InjectionCheck(Class<?> clazz, Class<?> key, Class<?> value) {
+      int storeId = FieldBackedContextStores.getContextStoreId(key.name, value.name)
+      String fieldName = "__datadogContext\$${storeId}"
+      boolean hasField = false
+      for (Field field : clazz.getDeclaredFields()) {
+        if (field.name == fieldName) {
+          hasField = true
+          break
+        }
+      }
+      this.hasField = hasField
+
+      boolean hasAccessorInterface = false
+      for (Class inter : clazz.getInterfaces()) {
+        if (inter.name == 'datadog.trace.bootstrap.FieldBackedContextAccessor') {
+          hasAccessorInterface = true
+        }
+      }
+      this.hasAccessorInterface = hasAccessorInterface
+    }
+
+    boolean hasField() {
+      return hasField
+    }
+
+    boolean hasAccessorInterface() {
+      return hasAccessorInterface
+    }
+  }
+}

--- a/dd-java-agent/testing/src/test/groovy/excludefilter/ExcludeFilterLegacyForkedTest.groovy
+++ b/dd-java-agent/testing/src/test/groovy/excludefilter/ExcludeFilterLegacyForkedTest.groovy
@@ -2,14 +2,23 @@ package excludefilter
 
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter
+
 import java.lang.reflect.Field
 import java.util.concurrent.Callable
 
-import static ExcludeFilterProviderTestInstrumentation.*
-import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.ExcludeType.*
+import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.ExcludeType.RUNNABLE
+import static excludefilter.ExcludeFilterTestInstrumentation.CallableExcludedRunnable
+import static excludefilter.ExcludeFilterTestInstrumentation.CallableRunnable
+import static excludefilter.ExcludeFilterTestInstrumentation.ExcludedCallable
+import static excludefilter.ExcludeFilterTestInstrumentation.ExcludedRunnable
+import static excludefilter.ExcludeFilterTestInstrumentation.NormalCallable
+import static excludefilter.ExcludeFilterTestInstrumentation.NormalRunnable
+import static excludefilter.ExcludeFilterTestInstrumentation.RunnableExcludedCallable
 
-
-class ExcludeFilterProviderTest extends AgentTestRunner {
+class ExcludeFilterLegacyForkedTest extends AgentTestRunner {
+  void configurePreAgent() {
+    injectSysConfig("dd.trace.legacy.context.field.injection", "true")
+  }
 
   def "test ExcludeFilter"() {
     expect:

--- a/dd-java-agent/testing/src/test/java/context/FieldInjectionTestInstrumentation.java
+++ b/dd-java-agent/testing/src/test/java/context/FieldInjectionTestInstrumentation.java
@@ -16,9 +16,9 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(Instrumenter.class)
-public class ContextTestInstrumentation extends Instrumenter.Tracing {
-  public ContextTestInstrumentation() {
-    super("context-test-isntrumenter1");
+public class FieldInjectionTestInstrumentation extends Instrumenter.Tracing {
+  public FieldInjectionTestInstrumentation() {
+    super("fieldinjection-test");
   }
 
   @Override
@@ -51,7 +51,7 @@ public class ContextTestInstrumentation extends Instrumenter.Tracing {
 
   @Override
   public Map<String, String> contextStoreForAll() {
-    final Map<String, String> store = new HashMap<>(2);
+    final Map<String, String> store = new HashMap<>();
     String prefix = getClass().getName() + "$";
     store.put(prefix + "KeyClass", prefix + "Context");
     store.put(prefix + "UntransformableKeyClass", prefix + "Context");

--- a/dd-java-agent/testing/src/test/java/excludefilter/ExcludeFilterTestInstrumentation.java
+++ b/dd-java-agent/testing/src/test/java/excludefilter/ExcludeFilterTestInstrumentation.java
@@ -19,10 +19,10 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(Instrumenter.class)
-public class ExcludeFilterProviderTestInstrumentation extends Instrumenter.Tracing
+public class ExcludeFilterTestInstrumentation extends Instrumenter.Tracing
     implements ExcludeFilterProvider {
 
-  public ExcludeFilterProviderTestInstrumentation() {
+  public ExcludeFilterTestInstrumentation() {
     super("excludefilter-test");
   }
 
@@ -48,14 +48,14 @@ public class ExcludeFilterProviderTestInstrumentation extends Instrumenter.Traci
   public Map<ExcludeFilter.ExcludeType, ? extends Collection<String>> excludedClasses() {
     EnumMap<ExcludeFilter.ExcludeType, Collection<String>> excludedTypes =
         new EnumMap<>(ExcludeFilter.ExcludeType.class);
+    String prefix = getClass().getName() + "$";
     excludedTypes.put(
-        RUNNABLE,
-        Arrays.asList(ExcludedRunnable.class.getName(), CallableExcludedRunnable.class.getName()));
+        RUNNABLE, Arrays.asList(prefix + "ExcludedRunnable", prefix + "CallableExcludedRunnable"));
     excludedTypes.put(
         CALLABLE,
         Arrays.asList(
-            ExcludedCallable.class.getName(),
-            RunnableExcludedCallable.class.getName(),
+            prefix + "ExcludedCallable",
+            prefix + "RunnableExcludedCallable",
             "net.sf.cglib.core.internal.LoadingCache$2" // Excluded for global ignore matcher
             ));
     return excludedTypes;

--- a/dd-java-agent/testing/testing.gradle
+++ b/dd-java-agent/testing/testing.gradle
@@ -15,7 +15,8 @@ excludedClassesCoverage += [
   'datadog.trace.agent.test.server.http.TestHttpServer',
   'datadog.trace.agent.test.utils.*',
   // Avoid applying jacoco instrumentation to classes instrumented by tested agent
-  'context.ContextTestInstrumentation**',
+  'context.FieldInjectionTestInstrumentation**',
+  'context.ExcludeFilterTestInstrumentation**',
 ]
 
 dependencies {
@@ -45,16 +46,3 @@ dependencies {
   testAnnotationProcessor deps.autoserviceProcessor
   testCompileOnly deps.autoserviceAnnotation
 }
-
-// See comment for FieldBackedProviderFieldInjectionDisabledTest about why this hack is here
-tasks.withType(Test).configureEach {
-  if (name != "testDisabledFieldInjection") {
-    exclude "context/FieldBackedProviderFieldInjectionDisabledTest.class"
-  }
-}
-
-tasks.register("testDisabledFieldInjection", Test) {
-  systemProperties "dd.trace.runtime.context.field.injection": "false"
-  include "context/FieldBackedProviderFieldInjectionDisabledTest.class"
-}
-test.dependsOn(testDisabledFieldInjection)

--- a/dd-smoke-tests/field-injection/src/test/groovy/datadog/smoketest/FieldInjectionLegacySmokeTest.groovy
+++ b/dd-smoke-tests/field-injection/src/test/groovy/datadog/smoketest/FieldInjectionLegacySmokeTest.groovy
@@ -11,16 +11,11 @@ import java.util.concurrent.FutureTask
 import java.util.concurrent.RecursiveTask
 import java.util.concurrent.RunnableFuture
 import java.util.concurrent.TimeUnit
-import java.util.regex.Matcher
-import java.util.regex.Pattern
 
 import static datadog.trace.test.util.ForkedTestUtils.getMaxMemoryArgumentForFork
 import static datadog.trace.test.util.ForkedTestUtils.getMinMemoryArgumentForFork
 
-class FieldInjectionSmokeTest extends Specification {
-
-  private static final Pattern CONTEXT_STORE_ALLOCATION =
-      Pattern.compile('.*Allocated ContextStore #(\\d+) to (\\S+) -> (\\S+)')
+class FieldInjectionLegacySmokeTest extends Specification {
 
   String javaPath() {
     final String separator = System.getProperty("file.separator")
@@ -54,7 +49,7 @@ class FieldInjectionSmokeTest extends Specification {
     command.add("-XX:ErrorFile=/tmp/hs_err_pid%p.log")
     command.add("-Ddd.writer.type=TraceStructureWriter")
     command.add("-Ddd.trace.debug=true")
-    command.add("-Ddd.trace.legacy.context.field.injection=false")
+    command.add("-Ddd.trace.legacy.context.field.injection=true")
     command.add("-jar")
     command.add(jar)
     for (String type : testedTypesAndExpectedFields.keySet()) {
@@ -74,12 +69,10 @@ class FieldInjectionSmokeTest extends Specification {
     Map<String, Set<String>> foundTypesAndFields = new HashMap<>()
     Map<String, List<String>> foundTypesAndInterfaces = new HashMap<>()
     Map<String, List<String>> foundTypesAndGenericInterfaces = new HashMap<>()
-    Map<String, String> storeFieldAliases = new HashMap<>()
     for (String line : lines) {
       System.out.println(line)
       if (line.startsWith("___FIELD___")) {
         String[] parts = line.split(":")
-        parts[2] = storeFieldAliases.get(parts[2])
         foundTypesAndFields.computeIfAbsent(parts[1], { new HashSet<>() }).add(parts[2])
       } else if (line.startsWith("___INTERFACE___")) {
         String[] parts = line.split(":")
@@ -87,15 +80,6 @@ class FieldInjectionSmokeTest extends Specification {
       } else if (line.startsWith("___GENERIC_INTERFACE___")) {
         String[] parts = line.split(":")
         foundTypesAndGenericInterfaces.computeIfAbsent(parts[1], { new HashSet<>() }).add(parts[2])
-      } else {
-        Matcher storeAllocation = CONTEXT_STORE_ALLOCATION.matcher(line)
-        if (storeAllocation.matches()) {
-          // assertions use context key while internally we use storeId,
-          // so we need to record the storeId alias for each context key
-          String storeId = storeAllocation.group(1)
-          String keyName = storeAllocation.group(2)
-          storeFieldAliases.put(fieldName(storeId), fieldName(keyName))
-        }
       }
     }
     assert testedTypesAndExpectedFields == foundTypesAndFields

--- a/dd-smoke-tests/osgi/src/test/groovy/datadog/smoketest/AbstractOSGiSmokeTest.groovy
+++ b/dd-smoke-tests/osgi/src/test/groovy/datadog/smoketest/AbstractOSGiSmokeTest.groovy
@@ -43,7 +43,6 @@ abstract class AbstractOSGiSmokeTest extends AbstractSmokeTest {
 
     then:
     testedProcess.exitValue() == 0
-    // temporarily ignore VM instrumentation assertion errors on IBM J9
-    !logHasErrors || System.getProperty("java.vm.name").contains("IBM J9 VM")
+    !logHasErrors
   }
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -29,6 +29,7 @@ public final class ConfigDefaults {
   static final String DEFAULT_PRIORITIZATION_TYPE = "FastLane";
 
   static final boolean DEFAULT_RUNTIME_CONTEXT_FIELD_INJECTION = true;
+  static final boolean DEFAULT_LEGACY_CONTEXT_FIELD_INJECTION = false;
   static final boolean DEFAULT_SERIALVERSIONUID_FIELD_INJECTION = true;
 
   static final boolean DEFAULT_PRIORITY_SAMPLING_ENABLED = true;

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
@@ -31,6 +31,8 @@ public final class TraceInstrumentationConfig {
 
   public static final String RUNTIME_CONTEXT_FIELD_INJECTION =
       "trace.runtime.context.field.injection";
+  public static final String LEGACY_CONTEXT_FIELD_INJECTION =
+      "trace.legacy.context.field.injection";
   public static final String SERIALVERSIONUID_FIELD_INJECTION =
       "trace.serialversionuid.field.injection";
 

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -16,6 +16,7 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_INTEGRATIONS_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_JMX_FETCH_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_JMX_FETCH_STATSD_PORT;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_KAFKA_CLIENT_PROPAGATION_ENABLED;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_LEGACY_CONTEXT_FIELD_INJECTION;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_LOGS_INJECTION_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PARTIAL_FLUSH_MIN_SPANS;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PERF_METRICS_ENABLED;
@@ -67,6 +68,7 @@ import static datadog.trace.api.config.GeneralConfig.TRACER_METRICS_MAX_PENDING;
 import static datadog.trace.api.config.TraceInstrumentationConfig.HYSTRIX_TAGS_ENABLED;
 import static datadog.trace.api.config.TraceInstrumentationConfig.JDBC_CONNECTION_CLASS_NAME;
 import static datadog.trace.api.config.TraceInstrumentationConfig.JDBC_PREPARED_STATEMENT_CLASS_NAME;
+import static datadog.trace.api.config.TraceInstrumentationConfig.LEGACY_CONTEXT_FIELD_INJECTION;
 import static datadog.trace.api.config.TraceInstrumentationConfig.LOGS_MDC_TAGS_INJECTION_ENABLED;
 import static datadog.trace.api.config.TraceInstrumentationConfig.SERIALVERSIONUID_FIELD_INJECTION;
 import static datadog.trace.api.config.TracerConfig.ENABLE_TRACE_AGENT_V05;
@@ -331,6 +333,7 @@ public class Config {
   @Getter private final boolean scopeInheritAsyncPropagation;
   @Getter private final int partialFlushMinSpans;
   @Getter private final boolean runtimeContextFieldInjection;
+  @Getter private final boolean legacyContextFieldInjection;
   @Getter private final boolean serialVersionUIDFieldInjection;
   @Getter private final Set<PropagationStyle> propagationStylesToExtract;
   @Getter private final Set<PropagationStyle> propagationStylesToInject;
@@ -601,6 +604,9 @@ public class Config {
     runtimeContextFieldInjection =
         configProvider.getBoolean(
             RUNTIME_CONTEXT_FIELD_INJECTION, DEFAULT_RUNTIME_CONTEXT_FIELD_INJECTION);
+    legacyContextFieldInjection =
+        configProvider.getBoolean(
+            LEGACY_CONTEXT_FIELD_INJECTION, DEFAULT_LEGACY_CONTEXT_FIELD_INJECTION);
     serialVersionUIDFieldInjection =
         configProvider.getBoolean(
             SERIALVERSIONUID_FIELD_INJECTION, DEFAULT_SERIALVERSIONUID_FIELD_INJECTION);


### PR DESCRIPTION
Field-injection is a technique used in the Java Tracer to associate trace-related data with objects being traced. The original field-injection design generates a lot of interfaces and helper classes at runtime, taking up metadata space. These types must be injected into the bootstrap classloader using the file-system, slowing down startup.

This PR proposes replacing these generated types with a single non-generated interface, plus a few helper classes.

The original field-injection approach has been marked as deprecated for removal, but can be re-enabled for now with:
```
-Ddd.trace.legacy.context.field.injection=true
```
or by setting this environment variable:
```
DD_TRACE_LEGACY_CONTEXT_FIELD_INJECTION=true
```

Performance results

Initial performance testing was complicated by the fact that even though we tried to avoid dead-code elimination of the benchmark method by using side-effects/blackholes the JIT was still able to do some speculative elimination of the trace advice itself. To avoid this a single JIT command was used to exclude the instrumented method from compilation while still allowing the context store code itself to be JIT'd.

| Config                                         | Time per call (ns) |
|-------------------------------|-------------------|
| untraced                                     | 90                          |
| legacy field-injection                 | 425                       |
| single-interface field-injection | 411                         |
| legacy weak-map                       | 449                       |
| single-interface weak-map.      | 437                       |

This shows a slight improvement in the new approach for both field-injection and weak-map context access. This is a very simple benchmark involving just one instrumented type. The larger advantage comes from not having to generate all the extra classes at runtime, and not having to inject them onto the bootclasspath (which involves use of a temporary jar file on the file-system.)

With full compilation there's more variability in results depending how long you run it, and the old approach can be a little bit faster. This suggests that the JIT might find it easier to optimize away the advice and context request when more specific interfaces are involved.

| Config                                         | Time per call (ns) |
|-------------------------------|-------------------|
| untraced                                     | 11                           |
| legacy field-injection                 | 12                          |
| single-interface field-injection | 13                          |
| legacy weak-map                       | 42                         |
| single-interface weak-map.      | 41                          |

Benchmark code:
```
package fieldinjection;

import java.util.concurrent.atomic.AtomicLong;
import org.openjdk.jmh.annotations.*;

public class FieldInjectionBenchmark {
  static AtomicLong count = new AtomicLong();

  @State(Scope.Benchmark)
  public static class TestRunnable implements Runnable {
    @TearDown(Level.Trial)
    public void doTearDown() {
      System.out.println("Total invocations: " + count.get());
    }

    public void run() {
      count.getAndIncrement();
    }
  }

  @Fork(jvmArgsAppend = {
    // avoid speculative JIT elimination of the Runnable advice
    "-XX:CompileCommand=exclude,fieldinjection/FieldInjectionBenchmark$TestRunnable.run",
    "-Ddd.jmxfetch.enabled=false",
    "-Ddd.profiling.enabled=false"
  })

  @Benchmark
  public long testRunnable(TestRunnable runnable) {
    runnable.run();
    return count.get();
  }
}
```


