### PR TITLE
remove unnecessary tag interception

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/ClientDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/ClientDecorator.java
@@ -1,6 +1,5 @@
 package datadog.trace.bootstrap.instrumentation.decorator;
 
-import datadog.trace.api.DDTags;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 
@@ -15,7 +14,7 @@ public abstract class ClientDecorator extends BaseDecorator {
   @Override
   public AgentSpan afterStart(final AgentSpan span) {
     if (service() != null) {
-      span.setTag(DDTags.SERVICE_NAME, service());
+      span.setServiceName(service());
     }
     span.setTag(Tags.SPAN_KIND, spanKind());
     return super.afterStart(span);

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/DatabaseClientDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/DatabaseClientDecorator.java
@@ -3,7 +3,6 @@ package datadog.trace.bootstrap.instrumentation.decorator;
 import static datadog.trace.bootstrap.instrumentation.api.Tags.DB_TYPE;
 
 import datadog.trace.api.Config;
-import datadog.trace.api.DDTags;
 import datadog.trace.api.Function;
 import datadog.trace.api.Functions;
 import datadog.trace.api.cache.DDCache;
@@ -42,7 +41,7 @@ public abstract class DatabaseClientDecorator<CONNECTION> extends ClientDecorato
       span.setTag(Tags.DB_INSTANCE, instanceName);
 
       if (instanceName != null && Config.get().isDbClientSplitByInstance()) {
-        span.setTag(DDTags.SERVICE_NAME, instanceName);
+        span.setServiceName(instanceName);
       }
 
       CharSequence hostName = dbHostname(connection);

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpClientDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpClientDecorator.java
@@ -51,7 +51,7 @@ public abstract class HttpClientDecorator<REQUEST, RESPONSE> extends ClientDecor
             urlNoParams.append(url.getHost());
             span.setTag(Tags.PEER_HOSTNAME, url.getHost());
             if (Config.get().isHttpClientSplitByDomain()) {
-              span.setTag(DDTags.SERVICE_NAME, url.getHost());
+              span.setServiceName(url.getHost());
             }
             if (url.getPort() > 0) {
               setPeerPort(span, url.getPort());

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/OrmClientDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/OrmClientDecorator.java
@@ -1,6 +1,5 @@
 package datadog.trace.bootstrap.instrumentation.decorator;
 
-import datadog.trace.api.DDTags;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 
 public abstract class OrmClientDecorator extends DatabaseClientDecorator {
@@ -11,7 +10,7 @@ public abstract class OrmClientDecorator extends DatabaseClientDecorator {
     if (entity != null) {
       final CharSequence name = entityName(entity);
       if (name != null) {
-        span.setTag(DDTags.RESOURCE_NAME, name);
+        span.setResourceName(name);
       } // else we keep any existing resource.
     }
     return span;

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/ClientDecoratorTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/ClientDecoratorTest.groovy
@@ -17,7 +17,7 @@ class ClientDecoratorTest extends BaseDecoratorTest {
 
     then:
     if (serviceName != null) {
-      1 * span.setTag(DDTags.SERVICE_NAME, serviceName)
+      1 * span.setServiceName(serviceName)
     }
     1 * span.setTag(Tags.COMPONENT, "test-component")
     1 * span.setTag(Tags.SPAN_KIND, "client")

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/DBTypeProcessingDatabaseClientDecoratorTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/DBTypeProcessingDatabaseClientDecoratorTest.groovy
@@ -18,7 +18,7 @@ class DBTypeProcessingDatabaseClientDecoratorTest extends ClientDecoratorTest {
 
     then:
     if (serviceName != null) {
-      1 * span.setTag(DDTags.SERVICE_NAME, serviceName)
+      1 * span.setServiceName(serviceName)
     }
     1 * span.setTag(Tags.COMPONENT, "test-component")
     1 * span.setTag(Tags.SPAN_KIND, "client")

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/DatabaseClientDecoratorTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/DatabaseClientDecoratorTest.groovy
@@ -19,7 +19,7 @@ class DatabaseClientDecoratorTest extends ClientDecoratorTest {
 
     then:
     if (serviceName != null) {
-      1 * span.setTag(DDTags.SERVICE_NAME, serviceName)
+      1 * span.setServiceName(serviceName)
     }
     1 * span.setTag(Tags.COMPONENT, "test-component")
     1 * span.setTag(Tags.SPAN_KIND, "client")
@@ -47,7 +47,7 @@ class DatabaseClientDecoratorTest extends ClientDecoratorTest {
         1 * span.setTag(Tags.PEER_HOSTNAME, session.hostname)
       }
       if (renameService && session.instance) {
-        1 * span.setTag(DDTags.SERVICE_NAME, session.instance)
+        1 * span.setServiceName(session.instance)
       }
     }
     0 * _

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/HttpClientDecoratorTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/HttpClientDecoratorTest.groovy
@@ -28,7 +28,7 @@ class HttpClientDecoratorTest extends ClientDecoratorTest {
       1 * span.setTag(Tags.PEER_HOSTNAME, req.url.host)
       1 * span.setTag(Tags.PEER_PORT, req.url.port)
       if (renameService) {
-        1 * span.setTag(DDTags.SERVICE_NAME, req.url.host)
+        1 * span.setServiceName(req.url.host)
       }
     }
     0 * _

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/OrmClientDecoratorTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/OrmClientDecoratorTest.groovy
@@ -1,7 +1,5 @@
 package datadog.trace.bootstrap.instrumentation.decorator
 
-import datadog.trace.api.DDTags
-
 class OrmClientDecoratorTest extends DatabaseClientDecoratorTest {
 
   def "test onOperation #testName"() {
@@ -13,7 +11,7 @@ class OrmClientDecoratorTest extends DatabaseClientDecoratorTest {
 
     then:
     if (isSet) {
-      1 * span.setTag(DDTags.RESOURCE_NAME, entityName)
+      1 * span.setResourceName(entityName)
     }
     0 * _
 

--- a/dd-java-agent/instrumentation/aerospike-4/src/main/java/datadog/trace/instrumentation/aerospike4/AerospikeClientDecorator.java
+++ b/dd-java-agent/instrumentation/aerospike-4/src/main/java/datadog/trace/instrumentation/aerospike4/AerospikeClientDecorator.java
@@ -7,7 +7,6 @@ import com.aerospike.client.cluster.Cluster;
 import com.aerospike.client.cluster.Node;
 import com.aerospike.client.cluster.Partition;
 import datadog.trace.api.Config;
-import datadog.trace.api.DDTags;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
@@ -78,7 +77,7 @@ public class AerospikeClientDecorator extends DBTypeProcessingDatabaseClientDeco
       }
       span.setTag(Tags.DB_INSTANCE, instanceName);
       if (Config.get().isDbClientSplitByInstance()) {
-        span.setTag(DDTags.SERVICE_NAME, instanceName);
+        span.setServiceName(instanceName);
       }
     }
 
@@ -86,7 +85,7 @@ public class AerospikeClientDecorator extends DBTypeProcessingDatabaseClientDeco
   }
 
   public void withMethod(final AgentSpan span, final String methodName) {
-    span.setTag(DDTags.RESOURCE_NAME, spanNameForMethod(AerospikeClient.class, methodName));
+    span.setResourceName(spanNameForMethod(AerospikeClient.class, methodName));
   }
 
   public AgentSpan startAerospikeSpan(final String methodName) {

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/AwsSdkClientDecorator.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/AwsSdkClientDecorator.java
@@ -4,7 +4,6 @@ import com.amazonaws.AmazonWebServiceRequest;
 import com.amazonaws.AmazonWebServiceResponse;
 import com.amazonaws.Request;
 import com.amazonaws.Response;
-import datadog.trace.api.DDTags;
 import datadog.trace.api.Function;
 import datadog.trace.api.Functions;
 import datadog.trace.api.cache.QualifiedClassNameCache;
@@ -56,7 +55,7 @@ public class AwsSdkClientDecorator extends HttpClientDecorator<Request, Response
     span.setTag("aws.operation", awsOperation.getSimpleName());
     span.setTag("aws.endpoint", request.getEndpoint().toString());
 
-    span.setTag(DDTags.RESOURCE_NAME, cache.getQualifiedName(awsOperation, awsServiceName));
+    span.setResourceName(cache.getQualifiedName(awsOperation, awsServiceName));
     span.setMeasured(true);
 
     if (contextStore != null) {

--- a/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java8/datadog/trace/instrumentation/aws/v2/AwsSdkClientDecorator.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java8/datadog/trace/instrumentation/aws/v2/AwsSdkClientDecorator.java
@@ -1,6 +1,5 @@
 package datadog.trace.instrumentation.aws.v2;
 
-import datadog.trace.api.DDTags;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpClientDecorator;
@@ -49,7 +48,7 @@ public class AwsSdkClientDecorator extends HttpClientDecorator<SdkHttpRequest, S
     final String awsOperation = attributes.getAttribute(SdkExecutionAttribute.OPERATION_NAME);
 
     // Resource Name has to be set after the HTTP_URL because otherwise decorators overwrite it
-    span.setTag(DDTags.RESOURCE_NAME, awsServiceName + "." + awsOperation);
+    span.setResourceName(awsServiceName + "." + awsOperation);
 
     span.setTag("aws.agent", COMPONENT_NAME);
     span.setTag("aws.service", awsServiceName);

--- a/dd-java-agent/instrumentation/couchbase-2.0/src/main/java/datadog/trace/instrumentation/couchbase/client/CouchbaseOnSubscribe.java
+++ b/dd-java-agent/instrumentation/couchbase-2.0/src/main/java/datadog/trace/instrumentation/couchbase/client/CouchbaseOnSubscribe.java
@@ -2,7 +2,6 @@ package datadog.trace.instrumentation.couchbase.client;
 
 import static datadog.trace.instrumentation.couchbase.client.CouchbaseClientDecorator.DECORATE;
 
-import datadog.trace.api.DDTags;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.instrumentation.rxjava.TracedOnSubscribe;
 import java.lang.reflect.Method;
@@ -27,7 +26,7 @@ public class CouchbaseOnSubscribe extends TracedOnSubscribe {
   protected void afterStart(final AgentSpan span) {
     super.afterStart(span);
 
-    span.setTag(DDTags.RESOURCE_NAME, resourceName);
+    span.setResourceName(resourceName);
 
     if (bucket != null) {
       span.setTag("bucket", bucket);

--- a/dd-java-agent/instrumentation/dropwizard/dropwizard-views/src/main/java/datadog/trace/instrumentation/dropwizard/view/DropwizardViewInstrumentation.java
+++ b/dd-java-agent/instrumentation/dropwizard/dropwizard-views/src/main/java/datadog/trace/instrumentation/dropwizard/view/DropwizardViewInstrumentation.java
@@ -13,7 +13,6 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
-import datadog.trace.api.DDTags;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
@@ -60,10 +59,8 @@ public final class DropwizardViewInstrumentation extends Instrumenter.Tracing {
       if (activeSpan() == null) {
         return null;
       }
-      final AgentSpan span =
-          startSpan("view.render")
-              .setTag(DDTags.RESOURCE_NAME, "View " + view.getTemplateName())
-              .setTag(Tags.COMPONENT, "dropwizard-view");
+      final AgentSpan span = startSpan("view.render").setTag(Tags.COMPONENT, "dropwizard-view");
+      span.setResourceName("View " + view.getTemplateName());
       return activateSpan(span);
     }
 

--- a/dd-java-agent/instrumentation/elasticsearch/src/main/java/datadog/trace/instrumentation/elasticsearch/ElasticsearchTransportClientDecorator.java
+++ b/dd-java-agent/instrumentation/elasticsearch/src/main/java/datadog/trace/instrumentation/elasticsearch/ElasticsearchTransportClientDecorator.java
@@ -2,7 +2,6 @@ package datadog.trace.instrumentation.elasticsearch;
 
 import static datadog.trace.bootstrap.instrumentation.api.Tags.DB_TYPE;
 
-import datadog.trace.api.DDTags;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
@@ -73,7 +72,7 @@ public class ElasticsearchTransportClientDecorator extends DatabaseClientDecorat
       if ("AutoPutMappingAction".equals(actionName)) {
         actionName = "PutMappingAction";
       }
-      span.setTag(DDTags.RESOURCE_NAME, actionName);
+      span.setResourceName(actionName);
       span.setTag("elasticsearch.action", actionName);
     }
     if (request != null) {

--- a/dd-java-agent/instrumentation/finatra-2.9/src/main/java/datadog/trace/instrumentation/finatra/FinatraInstrumentation.java
+++ b/dd-java-agent/instrumentation/finatra-2.9/src/main/java/datadog/trace/instrumentation/finatra/FinatraInstrumentation.java
@@ -22,7 +22,6 @@ import com.twitter.util.Future;
 import com.twitter.util.FutureEventListener;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.Config;
-import datadog.trace.api.DDTags;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
@@ -80,13 +79,13 @@ public class FinatraInstrumentation extends Instrumenter.Tracing {
 
       // Update the parent "netty.request"
       final AgentSpan parent = activeSpan();
-      parent.setTag(DDTags.RESOURCE_NAME, request.method().name() + " " + path);
+      parent.setResourceName(request.method().name() + " " + path);
       parent.setTag(Tags.COMPONENT, "finatra");
       parent.setSpanName(FINATRA_REQUEST);
 
       final AgentSpan span = startSpan(FINATRA_CONTROLLER);
       DECORATE.afterStart(span);
-      span.setTag(DDTags.RESOURCE_NAME, DECORATE.className(clazz));
+      span.setResourceName(DECORATE.className(clazz));
 
       final AgentScope scope = activateSpan(span);
       scope.setAsyncPropagation(true);

--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/client/TracingClientInterceptor.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/client/TracingClientInterceptor.java
@@ -8,7 +8,6 @@ import static datadog.trace.instrumentation.grpc.client.GrpcClientDecorator.GRPC
 import static datadog.trace.instrumentation.grpc.client.GrpcClientDecorator.GRPC_MESSAGE;
 import static datadog.trace.instrumentation.grpc.client.GrpcInjectAdapter.SETTER;
 
-import datadog.trace.api.DDTags;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import io.grpc.CallOptions;
@@ -31,10 +30,8 @@ public class TracingClientInterceptor implements ClientInterceptor {
       final CallOptions callOptions,
       final Channel next) {
 
-    final AgentSpan span =
-        startSpan(GRPC_CLIENT)
-            .setTag(DDTags.RESOURCE_NAME, method.getFullMethodName())
-            .setMeasured(true);
+    final AgentSpan span = startSpan(GRPC_CLIENT).setMeasured(true);
+    span.setResourceName(method.getFullMethodName());
     try (final AgentScope scope = activateSpan(span)) {
       DECORATE.afterStart(span);
       scope.setAsyncPropagation(true);

--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/TracingServerInterceptor.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/TracingServerInterceptor.java
@@ -8,7 +8,6 @@ import static datadog.trace.instrumentation.grpc.server.GrpcServerDecorator.DECO
 import static datadog.trace.instrumentation.grpc.server.GrpcServerDecorator.GRPC_MESSAGE;
 import static datadog.trace.instrumentation.grpc.server.GrpcServerDecorator.GRPC_SERVER;
 
-import datadog.trace.api.DDTags;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan.Context;
@@ -33,10 +32,8 @@ public class TracingServerInterceptor implements ServerInterceptor {
       final ServerCallHandler<ReqT, RespT> next) {
 
     final Context spanContext = propagate().extract(headers, GETTER);
-    final AgentSpan span =
-        startSpan(GRPC_SERVER, spanContext)
-            .setTag(DDTags.RESOURCE_NAME, call.getMethodDescriptor().getFullMethodName())
-            .setMeasured(true);
+    final AgentSpan span = startSpan(GRPC_SERVER, spanContext).setMeasured(true);
+    span.setResourceName(call.getMethodDescriptor().getFullMethodName());
     DECORATE.afterStart(span);
 
     final AgentScope scope = activateSpan(span);

--- a/dd-java-agent/instrumentation/http-url-connection/src/main/java/datadog/trace/instrumentation/http_url_connection/UrlInstrumentation.java
+++ b/dd-java-agent/instrumentation/http-url-connection/src/main/java/datadog/trace/instrumentation/http_url_connection/UrlInstrumentation.java
@@ -13,7 +13,6 @@ import static net.bytebuddy.matcher.ElementMatchers.named;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.Config;
-import datadog.trace.api.DDTags;
 import datadog.trace.bootstrap.InternalJarURLHandler;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
@@ -77,9 +76,10 @@ public class UrlInstrumentation extends Instrumenter.Tracing {
           span.setTag(
               Tags.PEER_PORT,
               url.getPort() > UNSET_PORT ? PORTS.get(url.getPort()) : PORTS.get(80));
-          span.setTag(Tags.PEER_HOSTNAME, url.getHost());
-          if (Config.get().isHttpClientSplitByDomain()) {
-            span.setTag(DDTags.SERVICE_NAME, url.getHost());
+          String host = url.getHost();
+          span.setTag(Tags.PEER_HOSTNAME, host);
+          if (Config.get().isHttpClientSplitByDomain() && null != host && !host.isEmpty()) {
+            span.setServiceName(host);
           }
 
           span.setError(true);

--- a/dd-java-agent/instrumentation/hystrix-1.4/src/main/java/datadog/trace/instrumentation/hystrix/HystrixDecorator.java
+++ b/dd-java-agent/instrumentation/hystrix-1.4/src/main/java/datadog/trace/instrumentation/hystrix/HystrixDecorator.java
@@ -6,7 +6,6 @@ import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.HY
 
 import com.netflix.hystrix.HystrixInvokableInfo;
 import datadog.trace.api.Config;
-import datadog.trace.api.DDTags;
 import datadog.trace.api.Functions;
 import datadog.trace.api.cache.DDCache;
 import datadog.trace.api.cache.DDCaches;
@@ -90,8 +89,7 @@ public class HystrixDecorator extends BaseDecorator {
         span.setTag(HYSTRIX_GROUP, command.getCommandGroup().name());
         span.setTag(HYSTRIX_CIRCUIT_OPEN, command.isCircuitBreakerOpen());
       }
-      span.setTag(
-          DDTags.RESOURCE_NAME,
+      span.setResourceName(
           RESOURCE_NAME_CACHE.computeIfAbsent(
               new ResourceNameCacheKey(
                   command.getCommandGroup().name(), command.getCommandKey().name(), methodName),

--- a/dd-java-agent/instrumentation/jax-rs-annotations-1/src/main/java/datadog/trace/instrumentation/jaxrs1/JaxRsAnnotationsDecorator.java
+++ b/dd-java-agent/instrumentation/jax-rs-annotations-1/src/main/java/datadog/trace/instrumentation/jaxrs1/JaxRsAnnotationsDecorator.java
@@ -1,7 +1,6 @@
 package datadog.trace.instrumentation.jaxrs1;
 
 import datadog.trace.agent.tooling.ClassHierarchyIterable;
-import datadog.trace.api.DDTags;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
@@ -53,9 +52,9 @@ public class JaxRsAnnotationsDecorator extends BaseDecorator {
     // When jax-rs is the root, we want to name using the path, otherwise use the class/method.
     final boolean isRootScope = parent == null;
     if (isRootScope && !resourceName.isEmpty()) {
-      span.setTag(DDTags.RESOURCE_NAME, resourceName);
+      span.setResourceName(resourceName);
     } else {
-      span.setTag(DDTags.RESOURCE_NAME, DECORATE.spanNameForMethod(target, method));
+      span.setResourceName(DECORATE.spanNameForMethod(target, method));
     }
   }
 
@@ -69,7 +68,7 @@ public class JaxRsAnnotationsDecorator extends BaseDecorator {
       span.setTag(Tags.COMPONENT, "jax-rs");
 
       if (!resourceName.isEmpty()) {
-        span.setTag(DDTags.RESOURCE_NAME, resourceName);
+        span.setResourceName(resourceName);
       }
     }
   }

--- a/dd-java-agent/instrumentation/jax-rs-annotations-2/src/main/java/datadog/trace/instrumentation/jaxrs2/JaxRsAnnotationsDecorator.java
+++ b/dd-java-agent/instrumentation/jax-rs-annotations-2/src/main/java/datadog/trace/instrumentation/jaxrs2/JaxRsAnnotationsDecorator.java
@@ -1,7 +1,6 @@
 package datadog.trace.instrumentation.jaxrs2;
 
 import datadog.trace.agent.tooling.ClassHierarchyIterable;
-import datadog.trace.api.DDTags;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
@@ -65,9 +64,9 @@ public class JaxRsAnnotationsDecorator extends BaseDecorator {
     // When jax-rs is the root, we want to name using the path, otherwise use the class/method.
     final boolean isRootScope = parent == null;
     if (isRootScope && !resourceName.isEmpty()) {
-      span.setTag(DDTags.RESOURCE_NAME, resourceName);
+      span.setResourceName(resourceName);
     } else {
-      span.setTag(DDTags.RESOURCE_NAME, DECORATE.spanNameForMethod(target, method));
+      span.setResourceName(DECORATE.spanNameForMethod(target, method));
     }
   }
 
@@ -81,7 +80,7 @@ public class JaxRsAnnotationsDecorator extends BaseDecorator {
       span.setTag(Tags.COMPONENT, "jax-rs");
 
       if (!resourceName.isEmpty()) {
-        span.setTag(DDTags.RESOURCE_NAME, resourceName);
+        span.setResourceName(resourceName);
       }
     }
   }

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/DataSourceInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/DataSourceInstrumentation.java
@@ -11,7 +11,6 @@ import static net.bytebuddy.matcher.ElementMatchers.named;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
-import datadog.trace.api.DDTags;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import java.util.Map;
@@ -61,7 +60,7 @@ public final class DataSourceInstrumentation extends Instrumenter.Tracing {
       final AgentSpan span = startSpan(DATABASE_CONNECTION);
       DECORATE.afterStart(span);
 
-      span.setTag(DDTags.RESOURCE_NAME, DECORATE.spanNameForMethod(ds.getClass(), "getConnection"));
+      span.setResourceName(DECORATE.spanNameForMethod(ds.getClass(), "getConnection"));
 
       final AgentScope agentScope = activateSpan(span);
       agentScope.setAsyncPropagation(true);

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/JDBCDecorator.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/JDBCDecorator.java
@@ -1,6 +1,5 @@
 package datadog.trace.instrumentation.jdbc;
 
-import datadog.trace.api.DDTags;
 import datadog.trace.api.cache.DDCache;
 import datadog.trace.api.cache.DDCaches;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
@@ -121,14 +120,14 @@ public class JDBCDecorator extends DatabaseClientDecorator<DBInfo> {
   @Override
   public AgentSpan onStatement(final AgentSpan span, final CharSequence statement) {
     final CharSequence resourceName = statement == null ? DB_QUERY : statement;
-    span.setTag(DDTags.RESOURCE_NAME, resourceName);
+    span.setResourceName(resourceName);
     span.setTag(Tags.COMPONENT, JDBC_STATEMENT);
     return super.onStatement(span, statement);
   }
 
   public AgentSpan onPreparedStatement(final AgentSpan span, UTF8BytesString sql) {
     final UTF8BytesString resourceName = sql == null ? DB_QUERY : sql;
-    span.setTag(DDTags.RESOURCE_NAME, resourceName);
+    span.setResourceName(resourceName);
     span.setTag(Tags.COMPONENT, JDBC_PREPARED_STATEMENT);
     return super.onStatement(span, sql);
   }

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSDecorator.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSDecorator.java
@@ -3,7 +3,6 @@ package datadog.trace.instrumentation.jms;
 import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.RECORD_QUEUE_TIME_MS;
 
 import datadog.trace.api.DDSpanTypes;
-import datadog.trace.api.DDTags;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
@@ -64,7 +63,7 @@ public final class JMSDecorator extends ClientDecorator {
   }
 
   public void onConsume(final AgentSpan span, final Message message) {
-    span.setTag(DDTags.RESOURCE_NAME, "Consumed from " + toResourceName(message, null));
+    span.setResourceName("Consumed from " + toResourceName(message, null));
 
     try {
       final long produceTime = message.getJMSTimestamp();
@@ -78,16 +77,16 @@ public final class JMSDecorator extends ClientDecorator {
   }
 
   public void onReceive(final AgentSpan span, final Method method) {
-    span.setTag(DDTags.RESOURCE_NAME, "JMS " + method.getName());
+    span.setResourceName("JMS " + method.getName());
   }
 
   public void onReceive(final AgentSpan span, final Message message) {
-    span.setTag(DDTags.RESOURCE_NAME, "Received from " + toResourceName(message, null));
+    span.setResourceName("Received from " + toResourceName(message, null));
   }
 
   public void onProduce(
       final AgentSpan span, final Message message, final Destination destination) {
-    span.setTag(DDTags.RESOURCE_NAME, "Produced for " + toResourceName(message, destination));
+    span.setResourceName("Produced for " + toResourceName(message, destination));
     span.setMeasured(true);
   }
 

--- a/dd-java-agent/instrumentation/jsp-2.3/src/main/java/datadog/trace/instrumentation/jsp/JSPDecorator.java
+++ b/dd-java-agent/instrumentation/jsp-2.3/src/main/java/datadog/trace/instrumentation/jsp/JSPDecorator.java
@@ -1,6 +1,5 @@
 package datadog.trace.instrumentation.jsp;
 
-import datadog.trace.api.DDTags;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
@@ -38,7 +37,7 @@ public class JSPDecorator extends BaseDecorator {
   public void onCompile(final AgentScope scope, final JspCompilationContext jspCompilationContext) {
     if (jspCompilationContext != null) {
       final AgentSpan span = scope.span();
-      span.setTag(DDTags.RESOURCE_NAME, jspCompilationContext.getJspFile());
+      span.setResourceName(jspCompilationContext.getJspFile());
 
       if (jspCompilationContext.getServletContext() != null) {
         span.setTag("servlet.context", jspCompilationContext.getServletContext().getContextPath());
@@ -58,7 +57,7 @@ public class JSPDecorator extends BaseDecorator {
     if (includeServletPath instanceof String) {
       resourceName = includeServletPath.toString();
     }
-    span.setTag(DDTags.RESOURCE_NAME, resourceName);
+    span.setResourceName(resourceName);
 
     final Object forwardOrigin = req.getAttribute(RequestDispatcher.FORWARD_SERVLET_PATH);
     if (forwardOrigin instanceof String) {

--- a/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4Decorator.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4Decorator.java
@@ -1,6 +1,5 @@
 package datadog.trace.instrumentation.junit4;
 
-import datadog.trace.api.DDTags;
 import datadog.trace.api.DisableTestTrace;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
@@ -43,7 +42,7 @@ public class JUnit4Decorator extends TestDecorator {
     final String testSuite = description.getClassName();
     final String testName = (testNameArg != null) ? testNameArg : description.getMethodName();
 
-    span.setTag(DDTags.RESOURCE_NAME, testSuite + "." + testName);
+    span.setResourceName(testSuite + "." + testName);
     span.setTag(Tags.TEST_SUITE, testSuite);
     span.setTag(Tags.TEST_NAME, testName);
     // We cannot set TEST_PASS status in onTestFinish(...) method because that method

--- a/dd-java-agent/instrumentation/junit-5.3/src/main/java8/datadog/trace/instrumentation/junit5/JUnit5Decorator.java
+++ b/dd-java-agent/instrumentation/junit-5.3/src/main/java8/datadog/trace/instrumentation/junit5/JUnit5Decorator.java
@@ -1,6 +1,5 @@
 package datadog.trace.instrumentation.junit5;
 
-import datadog.trace.api.DDTags;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.decorator.TestDecorator;
@@ -33,7 +32,7 @@ public class JUnit5Decorator extends TestDecorator {
   }
 
   public void onTestStart(final AgentSpan span, final String testSuite, final String testName) {
-    span.setTag(DDTags.RESOURCE_NAME, testSuite + "." + testName);
+    span.setResourceName(testSuite + "." + testName);
     span.setTag(Tags.TEST_SUITE, testSuite);
     span.setTag(Tags.TEST_NAME, testName);
     span.setTag(Tags.TEST_STATUS, TEST_PASS);

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/KafkaStreamsDecorator.java
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/KafkaStreamsDecorator.java
@@ -1,6 +1,5 @@
 package datadog.trace.instrumentation.kafka_streams;
 
-import datadog.trace.api.DDTags;
 import datadog.trace.api.Functions;
 import datadog.trace.api.cache.DDCache;
 import datadog.trace.api.cache.DDCaches;
@@ -48,7 +47,7 @@ public class KafkaStreamsDecorator extends ClientDecorator {
   public void onConsume(final AgentSpan span, final StampedRecord record) {
     if (record != null) {
       final String topic = record.topic() == null ? "kafka" : record.topic();
-      span.setTag(DDTags.RESOURCE_NAME, RESOURCE_NAME_CACHE.computeIfAbsent(topic, PREFIX));
+      span.setResourceName(RESOURCE_NAME_CACHE.computeIfAbsent(topic, PREFIX));
       span.setTag("partition", record.partition());
       span.setTag("offset", record.offset());
       span.setMeasured(true);

--- a/dd-java-agent/instrumentation/lettuce-4/src/main/java8/datadog/trace/instrumentation/lettuce4/LettuceClientDecorator.java
+++ b/dd-java-agent/instrumentation/lettuce-4/src/main/java8/datadog/trace/instrumentation/lettuce4/LettuceClientDecorator.java
@@ -4,7 +4,6 @@ import static datadog.trace.instrumentation.lettuce4.InstrumentationPoints.getCo
 
 import com.lambdaworks.redis.RedisURI;
 import com.lambdaworks.redis.protocol.RedisCommand;
-import datadog.trace.api.DDTags;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
@@ -64,14 +63,13 @@ public class LettuceClientDecorator extends DBTypeProcessingDatabaseClientDecora
       span.setTag(Tags.PEER_HOSTNAME, connection.getHost());
       setPeerPort(span, connection.getPort());
       span.setTag("db.redis.dbIndex", connection.getDatabase());
-      span.setTag(DDTags.RESOURCE_NAME, resourceName(connection));
+      span.setResourceName(resourceName(connection));
     }
     return super.onConnection(span, connection);
   }
 
   public AgentSpan onCommand(final AgentSpan span, final RedisCommand<?, ?, ?> command) {
-    span.setTag(
-        DDTags.RESOURCE_NAME,
+    span.setResourceName(
         null == command ? "Redis Command" : getCommandResourceName(command.getType()));
     return span;
   }

--- a/dd-java-agent/instrumentation/lettuce-5/src/main/java8/datadog/trace/instrumentation/lettuce5/LettuceClientDecorator.java
+++ b/dd-java-agent/instrumentation/lettuce-5/src/main/java8/datadog/trace/instrumentation/lettuce5/LettuceClientDecorator.java
@@ -1,6 +1,5 @@
 package datadog.trace.instrumentation.lettuce5;
 
-import datadog.trace.api.DDTags;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
@@ -61,8 +60,7 @@ public class LettuceClientDecorator extends DBTypeProcessingDatabaseClientDecora
       setPeerPort(span, connection.getPort());
 
       span.setTag("db.redis.dbIndex", connection.getDatabase());
-      span.setTag(
-          DDTags.RESOURCE_NAME,
+      span.setResourceName(
           "CONNECT:"
               + connection.getHost()
               + ":"
@@ -75,8 +73,7 @@ public class LettuceClientDecorator extends DBTypeProcessingDatabaseClientDecora
 
   public AgentSpan onCommand(final AgentSpan span, final RedisCommand command) {
     final String commandName = LettuceInstrumentationUtil.getCommandName(command);
-    span.setTag(
-        DDTags.RESOURCE_NAME, LettuceInstrumentationUtil.getCommandResourceName(commandName));
+    span.setResourceName(LettuceInstrumentationUtil.getCommandResourceName(commandName));
     return span;
   }
 }

--- a/dd-java-agent/instrumentation/mongo/driver-4/src/main/java/datadog/trace/instrumentation/mongo4/Tracing4CommandListener.java
+++ b/dd-java-agent/instrumentation/mongo/driver-4/src/main/java/datadog/trace/instrumentation/mongo4/Tracing4CommandListener.java
@@ -12,7 +12,6 @@ import com.mongodb.event.CommandListener;
 import com.mongodb.event.CommandStartedEvent;
 import com.mongodb.event.CommandSucceededEvent;
 import datadog.trace.api.Config;
-import datadog.trace.api.DDTags;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
@@ -41,7 +40,7 @@ public class Tracing4CommandListener implements CommandListener {
       if (applicationName != null) {
         span.setTag(Tags.DB_INSTANCE, applicationName);
         if (Config.get().isDbClientSplitByInstance()) {
-          span.setTag(DDTags.SERVICE_NAME, applicationName);
+          span.setServiceName(applicationName);
         }
       }
       if (event.getConnectionDescription() != null

--- a/dd-java-agent/instrumentation/play-2.3/src/main/java8/datadog/trace/instrumentation/play23/PlayHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/play-2.3/src/main/java8/datadog/trace/instrumentation/play23/PlayHttpServerDecorator.java
@@ -1,6 +1,5 @@
 package datadog.trace.instrumentation.play23;
 
-import datadog.trace.api.DDTags;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
@@ -63,7 +62,7 @@ public class PlayHttpServerDecorator extends HttpServerDecorator<Request, Reques
       final Option pathOption = request.tags().get("ROUTE_PATTERN");
       if (!pathOption.isEmpty()) {
         final String path = (String) pathOption.get();
-        span.setTag(DDTags.RESOURCE_NAME, request.method() + " " + path);
+        span.setResourceName(request.method() + " " + path);
       }
     }
     return span;

--- a/dd-java-agent/instrumentation/play-2.4/src/main/java8/datadog/trace/instrumentation/play24/PlayHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/play-2.4/src/main/java8/datadog/trace/instrumentation/play24/PlayHttpServerDecorator.java
@@ -1,6 +1,5 @@
 package datadog.trace.instrumentation.play24;
 
-import datadog.trace.api.DDTags;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
@@ -63,7 +62,7 @@ public class PlayHttpServerDecorator extends HttpServerDecorator<Request, Reques
       final Option pathOption = request.tags().get("ROUTE_PATTERN");
       if (!pathOption.isEmpty()) {
         final String path = (String) pathOption.get();
-        span.setTag(DDTags.RESOURCE_NAME, request.method() + " " + path);
+        span.setResourceName(request.method() + " " + path);
       }
     }
     return span;

--- a/dd-java-agent/instrumentation/play-2.6/src/main/java8/datadog/trace/instrumentation/play26/PlayHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/play-2.6/src/main/java8/datadog/trace/instrumentation/play26/PlayHttpServerDecorator.java
@@ -1,6 +1,5 @@
 package datadog.trace.instrumentation.play26;
 
-import datadog.trace.api.DDTags;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
@@ -107,7 +106,7 @@ public class PlayHttpServerDecorator extends HttpServerDecorator<Request, Reques
       }
       if (!defOption.isEmpty()) {
         final String path = defOption.get().path();
-        span.setTag(DDTags.RESOURCE_NAME, request.method() + " " + path);
+        span.setResourceName(request.method() + " " + path);
       }
     }
     return span;

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitChannelInstrumentation.java
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitChannelInstrumentation.java
@@ -32,7 +32,6 @@ import com.rabbitmq.client.Consumer;
 import com.rabbitmq.client.GetResponse;
 import com.rabbitmq.client.MessageProperties;
 import datadog.trace.agent.tooling.Instrumenter;
-import datadog.trace.api.DDTags;
 import datadog.trace.bootstrap.CallDepthThreadLocalMap;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
@@ -119,8 +118,8 @@ public class RabbitChannelInstrumentation extends Instrumenter.Tracing {
 
       final Connection connection = channel.getConnection();
 
-      final AgentSpan span =
-          startSpan(AMQP_COMMAND).setTag(DDTags.RESOURCE_NAME, method).setMeasured(true);
+      final AgentSpan span = startSpan(AMQP_COMMAND).setMeasured(true);
+      span.setResourceName(method);
       DECORATE.setPeerPort(span, connection.getPort());
       DECORATE.afterStart(span);
       DECORATE.onPeerConnection(span, connection.getAddress());

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitDecorator.java
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitDecorator.java
@@ -8,7 +8,6 @@ import com.rabbitmq.client.Command;
 import com.rabbitmq.client.Consumer;
 import com.rabbitmq.client.Envelope;
 import datadog.trace.api.DDSpanTypes;
-import datadog.trace.api.DDTags;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
@@ -67,7 +66,7 @@ public class RabbitDecorator extends ClientDecorator {
         routingKey == null || routingKey.isEmpty()
             ? "<all>"
             : routingKey.startsWith("amq.gen-") ? "<generated>" : routingKey;
-    span.setTag(DDTags.RESOURCE_NAME, "basic.publish " + exchangeName + " -> " + routing);
+    span.setResourceName("basic.publish " + exchangeName + " -> " + routing);
     span.setSpanType(InternalSpanTypes.MESSAGE_PRODUCER);
     span.setTag(Tags.SPAN_KIND, Tags.SPAN_KIND_PRODUCER);
     span.setTag(AMQP_COMMAND.toString(), "basic.publish");
@@ -77,7 +76,7 @@ public class RabbitDecorator extends ClientDecorator {
 
   public void onGet(final AgentSpan span, final String queue) {
     final String queueName = queue.startsWith("amq.gen-") ? "<generated>" : queue;
-    span.setTag(DDTags.RESOURCE_NAME, "basic.get " + queueName);
+    span.setResourceName("basic.get " + queueName);
 
     span.setTag(AMQP_COMMAND.toString(), "basic.get");
     span.setTag(AMQP_QUEUE, queue);
@@ -90,7 +89,7 @@ public class RabbitDecorator extends ClientDecorator {
     } else if (queue.startsWith("amq.gen-")) {
       queueName = "<generated>";
     }
-    span.setTag(DDTags.RESOURCE_NAME, "basic.deliver " + queueName);
+    span.setResourceName("basic.deliver " + queueName);
     span.setTag(AMQP_COMMAND.toString(), "basic.deliver");
 
     if (envelope != null) {
@@ -104,7 +103,7 @@ public class RabbitDecorator extends ClientDecorator {
 
     if (!name.equals("basic.publish")) {
       // Don't overwrite the name already set.
-      span.setTag(DDTags.RESOURCE_NAME, name);
+      span.setResourceName(name);
     }
     span.setTag(AMQP_COMMAND.toString(), name);
   }

--- a/dd-java-agent/instrumentation/ratpack-1.5/src/main/java8/datadog/trace/instrumentation/ratpack/RatpackServerDecorator.java
+++ b/dd-java-agent/instrumentation/ratpack-1.5/src/main/java8/datadog/trace/instrumentation/ratpack/RatpackServerDecorator.java
@@ -1,6 +1,5 @@
 package datadog.trace.instrumentation.ratpack;
 
-import datadog.trace.api.DDTags;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
@@ -73,7 +72,7 @@ public class RatpackServerDecorator extends HttpServerDecorator<Request, Request
     }
 
     final String resourceName = ctx.getRequest().getMethod().getName() + " " + description;
-    span.setTag(DDTags.RESOURCE_NAME, resourceName);
+    span.setResourceName(resourceName);
 
     return span;
   }

--- a/dd-java-agent/instrumentation/rmi/src/main/java/datadog/trace/instrumentation/rmi/client/RmiClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/rmi/src/main/java/datadog/trace/instrumentation/rmi/client/RmiClientInstrumentation.java
@@ -13,7 +13,6 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
-import datadog.trace.api.DDTags;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import java.lang.reflect.Method;
@@ -56,8 +55,8 @@ public final class RmiClientInstrumentation extends Instrumenter.Tracing {
       if (activeSpan() == null) {
         return null;
       }
-      final AgentSpan span =
-          startSpan(RMI_INVOKE).setTag(DDTags.RESOURCE_NAME, DECORATE.spanNameForMethod(method));
+      final AgentSpan span = startSpan(RMI_INVOKE);
+      span.setResourceName(DECORATE.spanNameForMethod(method));
 
       DECORATE.afterStart(span);
       return activateSpan(span);

--- a/dd-java-agent/instrumentation/rmi/src/main/java/datadog/trace/instrumentation/rmi/server/RmiServerInstrumentation.java
+++ b/dd-java-agent/instrumentation/rmi/src/main/java/datadog/trace/instrumentation/rmi/server/RmiServerInstrumentation.java
@@ -15,7 +15,6 @@ import static net.bytebuddy.matcher.ElementMatchers.not;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
-import datadog.trace.api.DDTags;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import java.lang.reflect.Method;
@@ -61,7 +60,7 @@ public final class RmiServerInstrumentation extends Instrumenter.Tracing {
         span = startSpan(RMI_REQUEST, context);
       }
 
-      span.setTag(DDTags.RESOURCE_NAME, DECORATE.spanNameForMethod(method));
+      span.setResourceName(DECORATE.spanNameForMethod(method));
 
       DECORATE.afterStart(span);
       return activateSpan(span);

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/filter/FilterInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/filter/FilterInstrumentation.java
@@ -14,7 +14,6 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
-import datadog.trace.api.DDTags;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import java.util.Map;
@@ -77,7 +76,7 @@ public final class FilterInstrumentation extends Instrumenter.Tracing {
       DECORATE.afterStart(span);
 
       // Here we use "this" instead of "the method target" to distinguish abstract filter instances.
-      span.setTag(DDTags.RESOURCE_NAME, filter.getClass().getSimpleName() + ".doFilter");
+      span.setResourceName(DECORATE.spanNameForMethod(filter.getClass(), "doFilter"));
 
       final AgentScope agentScope = activateSpan(span);
       agentScope.setAsyncPropagation(true);

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/http/HttpServletInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/http/HttpServletInstrumentation.java
@@ -17,7 +17,6 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
-import datadog.trace.api.DDTags;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import java.lang.reflect.Method;
@@ -86,7 +85,7 @@ public final class HttpServletInstrumentation extends Instrumenter.Tracing {
       DECORATE.afterStart(span);
 
       // Here we use the Method instead of "this.class.name" to distinguish calls to "super".
-      span.setTag(DDTags.RESOURCE_NAME, DECORATE.spanNameForMethod(method));
+      span.setResourceName(DECORATE.spanNameForMethod(method));
 
       final AgentScope agentScope = activateSpan(span);
       agentScope.setAsyncPropagation(true);

--- a/dd-java-agent/instrumentation/servlet/src/test/groovy/FilterTest.groovy
+++ b/dd-java-agent/instrumentation/servlet/src/test/groovy/FilterTest.groovy
@@ -1,4 +1,5 @@
 import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.instrumentation.servlet.filter.FilterDecorator
 
 import javax.servlet.Filter
 import javax.servlet.FilterChain
@@ -40,7 +41,7 @@ class FilterTest extends AgentTestRunner {
         basicSpan(it, "parent")
         span {
           operationName "servlet.filter"
-          resourceName "${filter.class.simpleName}.doFilter"
+          resourceName "${consistentClassName(filter.class)}.doFilter"
           childOf span(0)
           tags {
             "component" "java-web-servlet-filter"
@@ -78,7 +79,7 @@ class FilterTest extends AgentTestRunner {
         basicSpan(it, "parent", null, ex)
         span {
           operationName "servlet.filter"
-          resourceName "${filter.class.simpleName}.doFilter"
+          resourceName "${consistentClassName(filter.class)}.doFilter"
           childOf span(0)
           errored true
           tags {
@@ -104,5 +105,9 @@ class FilterTest extends AgentTestRunner {
     @Override
     void destroy() {
     }
+  }
+
+  def consistentClassName(Class klass) {
+    return FilterDecorator.DECORATE.className(klass)
   }
 }

--- a/dd-java-agent/instrumentation/sparkjava-2.3/src/main/java/datadog/trace/instrumentation/sparkjava/RoutesInstrumentation.java
+++ b/dd-java-agent/instrumentation/sparkjava-2.3/src/main/java/datadog/trace/instrumentation/sparkjava/RoutesInstrumentation.java
@@ -9,7 +9,6 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
-import datadog.trace.api.DDTags;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
@@ -55,7 +54,7 @@ public class RoutesInstrumentation extends Instrumenter.Tracing {
       final AgentSpan span = activeSpan();
       if (span != null && routeMatch != null) {
         final String resourceName = method.name().toUpperCase() + " " + routeMatch.getMatchUri();
-        span.setTag(DDTags.RESOURCE_NAME, resourceName);
+        span.setResourceName(resourceName);
       }
     }
   }

--- a/dd-java-agent/instrumentation/spring-data-1.8/src/main/java/datadog/trace/instrumentation/springdata/SpringDataDecorator.java
+++ b/dd-java-agent/instrumentation/spring-data-1.8/src/main/java/datadog/trace/instrumentation/springdata/SpringDataDecorator.java
@@ -2,7 +2,6 @@
 
 package datadog.trace.instrumentation.springdata;
 
-import datadog.trace.api.DDTags;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.ClientDecorator;
@@ -41,7 +40,7 @@ public final class SpringDataDecorator extends ClientDecorator {
     assert method != null;
 
     if (method != null) {
-      span.setTag(DDTags.RESOURCE_NAME, spanNameForMethod(method));
+      span.setResourceName(spanNameForMethod(method));
     }
     return span;
   }

--- a/dd-java-agent/instrumentation/spring-scheduling-3.1/src/main/java/datadog/trace/instrumentation/springscheduling/SpringSchedulingDecorator.java
+++ b/dd-java-agent/instrumentation/spring-scheduling-3.1/src/main/java/datadog/trace/instrumentation/springscheduling/SpringSchedulingDecorator.java
@@ -1,6 +1,5 @@
 package datadog.trace.instrumentation.springscheduling;
 
-import datadog.trace.api.DDTags;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.BaseDecorator;
@@ -39,7 +38,7 @@ public class SpringSchedulingDecorator extends BaseDecorator {
       } else {
         resourceName = spanNameForMethod(runnable.getClass(), "run");
       }
-      span.setTag(DDTags.RESOURCE_NAME, resourceName);
+      span.setResourceName(resourceName);
     }
     return span;
   }

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/SpringWebHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/SpringWebHttpServerDecorator.java
@@ -150,7 +150,7 @@ public class SpringWebHttpServerDecorator
     final String viewName = mv.getViewName();
     if (viewName != null) {
       span.setTag("view.name", viewName);
-      span.setTag(DDTags.RESOURCE_NAME, viewName);
+      span.setResourceName(viewName);
     }
     if (mv.getView() != null) {
       span.setTag("view.type", className(mv.getView().getClass()));

--- a/dd-java-agent/instrumentation/spymemcached-2.12/src/main/java/datadog/trace/instrumentation/spymemcached/MemcacheClientDecorator.java
+++ b/dd-java-agent/instrumentation/spymemcached-2.12/src/main/java/datadog/trace/instrumentation/spymemcached/MemcacheClientDecorator.java
@@ -1,6 +1,5 @@
 package datadog.trace.instrumentation.spymemcached;
 
-import datadog.trace.api.DDTags;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
@@ -65,7 +64,7 @@ public class MemcacheClientDecorator
     // Lowercase first letter
     chars[0] = Character.toLowerCase(chars[0]);
 
-    span.setTag(DDTags.RESOURCE_NAME, new String(chars));
+    span.setResourceName(new String(chars));
     return span;
   }
 }

--- a/dd-java-agent/instrumentation/testng-6.4/src/main/java/datadog/trace/instrumentation/testng/TestNGDecorator.java
+++ b/dd-java-agent/instrumentation/testng-6.4/src/main/java/datadog/trace/instrumentation/testng/TestNGDecorator.java
@@ -1,6 +1,5 @@
 package datadog.trace.instrumentation.testng;
 
-import datadog.trace.api.DDTags;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.decorator.TestDecorator;
@@ -31,7 +30,7 @@ public class TestNGDecorator extends TestDecorator {
     final String testName =
         (result.getTestName() != null) ? result.getTestName() : result.getMethod().getMethodName();
 
-    span.setTag(DDTags.RESOURCE_NAME, testSuite + "." + testName);
+    span.setResourceName(testSuite + "." + testName);
     span.setTag(Tags.TEST_SUITE, testSuite);
     span.setTag(Tags.TEST_NAME, testName);
   }

--- a/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceAdvice.java
+++ b/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceAdvice.java
@@ -4,7 +4,6 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSp
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.trace_annotation.TraceDecorator.DECORATE;
 
-import datadog.trace.api.DDTags;
 import datadog.trace.api.Trace;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
@@ -28,7 +27,7 @@ public class TraceAdvice {
     if (resourceName == null || resourceName.length() == 0) {
       resourceName = DECORATE.spanNameForMethod(method);
     }
-    span.setTag(DDTags.RESOURCE_NAME, resourceName);
+    span.setResourceName(resourceName);
     DECORATE.afterStart(span);
 
     final AgentScope scope = activateSpan(span);

--- a/dd-java-agent/instrumentation/twilio/src/main/java/datadog/trace/instrumentation/twilio/TwilioClientDecorator.java
+++ b/dd-java-agent/instrumentation/twilio/src/main/java/datadog/trace/instrumentation/twilio/TwilioClientDecorator.java
@@ -3,7 +3,6 @@ package datadog.trace.instrumentation.twilio;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.twilio.rest.api.v2010.account.Call;
 import com.twilio.rest.api.v2010.account.Message;
-import datadog.trace.api.DDTags;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
@@ -50,7 +49,7 @@ public class TwilioClientDecorator extends ClientDecorator {
     final String simpleClassName =
         serviceExecutor.getClass().getCanonicalName().replaceFirst("^com\\.twilio\\.rest\\.", "");
 
-    span.setTag(DDTags.RESOURCE_NAME, String.format("%s.%s", simpleClassName, methodName));
+    span.setResourceName(String.format("%s.%s", simpleClassName, methodName));
 
     return span;
   }


### PR DESCRIPTION
This gets rid of all cases where resource name or service name were being set via the tag interception mechanism.