### PR TITLE
Tweak generated field-injection getter and setter names…

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/context/ContextStoreUtils.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/context/ContextStoreUtils.java
@@ -107,10 +107,10 @@ final class ContextStoreUtils {
   }
 
   static String getContextGetterName(final String keyClassName) {
-    return "get" + getContextFieldName(keyClassName);
+    return "$get$" + getContextFieldName(keyClassName);
   }
 
   static String getContextSetterName(final String key) {
-    return "set" + getContextFieldName(key);
+    return "$set$" + getContextFieldName(key);
   }
 }


### PR DESCRIPTION
…so they are less likely to be picked up by bean-introspection

This should help with issues like https://github.com/DataDog/dd-trace-java/issues/2228