### PR TITLE
workaround for jira OSGi modules class loaders

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/ClassLoaderMatcher.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/ClassLoaderMatcher.java
@@ -56,11 +56,6 @@ public final class ClassLoaderMatcher {
       if (v != null) {
         return v;
       }
-      // workaround for jira osji modules class loaders:
-      if (cl.toString().startsWith("com.atlassian")) {
-        skipCache.put(cl, true);
-        return true;
-      }
       // when ClassloadingInstrumentation is active, checking delegatesToBootstrap() below is not
       // required, because ClassloadingInstrumentation forces all class loaders to load all of the
       // classes in Constants.BOOTSTRAP_PACKAGE_PREFIXES directly from the bootstrap class loader
@@ -85,6 +80,10 @@ public final class ClassLoaderMatcher {
         case DATADOG_CLASSLOADER_NAME:
         case DATADOG_DELEGATE_CLASSLOADER_NAME:
           return true;
+      }
+      // workaround for jira osji modules class loaders:
+      if (loader.toString().startsWith("com.atlassian")) {
+        return true;
       }
       return false;
     }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/ClassLoaderMatcher.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/ClassLoaderMatcher.java
@@ -56,6 +56,11 @@ public final class ClassLoaderMatcher {
       if (v != null) {
         return v;
       }
+      // workaround for jira osji modules class loaders:
+      if (cl.toString().startsWith("com.atlassian")) {
+        skipCache.put(cl, true);
+        return true;
+      }
       // when ClassloadingInstrumentation is active, checking delegatesToBootstrap() below is not
       // required, because ClassloadingInstrumentation forces all class loaders to load all of the
       // classes in Constants.BOOTSTRAP_PACKAGE_PREFIXES directly from the bootstrap class loader


### PR DESCRIPTION
this workaround skips atlassian OSGi (apache felix) by its toString() implementation. 