### PR TITLE
Allow disabling Status404Rule leaving URLAsResourceNameRule enabled

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/processor/TraceProcessor.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/processor/TraceProcessor.java
@@ -29,6 +29,11 @@ public class TraceProcessor {
     for (final String alias : rule.aliases()) {
       enabled &= Config.get().isRuleEnabled(alias);
     }
+    for (final String featureAlias : rule.featureAliases()) {
+      if (!Config.get().isRuleEnabled(featureAlias)) {
+        rule.disableFeature(featureAlias);
+      }
+    }
     if (!enabled) {
       log.debug("{} disabled", rule.getClass().getSimpleName());
     }
@@ -37,6 +42,10 @@ public class TraceProcessor {
 
   public interface Rule {
     String[] aliases();
+
+    String[] featureAliases();
+
+    void disableFeature(String feature);
 
     void processSpan(DDSpanContext span);
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/processor/rule/URLAsResourceNameRule.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/processor/rule/URLAsResourceNameRule.java
@@ -8,11 +8,29 @@ public class URLAsResourceNameRule implements TraceProcessor.Rule {
 
   private static final Integer NOT_FOUND = 404;
 
+  private static final String FEATURE_ALIAS_STATUS_404_RULE = "Status404Rule";
+  private static final String FEATURE_ALIAS_STATUS_404_DECORATOR = "Status404Decorator";
+
   private static final BitSlicedBitapSearch PROTOCOL_SEARCH = new BitSlicedBitapSearch("://");
+
+  private boolean status404Disabled = false;
 
   @Override
   public String[] aliases() {
-    return new String[] {"URLAsResourceName", "Status404Rule", "Status404Decorator"};
+    return new String[] {"URLAsResourceName"};
+  }
+
+  @Override
+  public String[] featureAliases() {
+    return new String[] {FEATURE_ALIAS_STATUS_404_RULE, FEATURE_ALIAS_STATUS_404_DECORATOR};
+  }
+
+  @Override
+  public void disableFeature(final String feature) {
+    if (FEATURE_ALIAS_STATUS_404_RULE.equals(feature)
+        || FEATURE_ALIAS_STATUS_404_DECORATOR.equals(feature)) {
+      status404Disabled = true;
+    }
   }
 
   @Override
@@ -21,7 +39,7 @@ public class URLAsResourceNameRule implements TraceProcessor.Rule {
       return;
     }
     final Object httpStatus = span.unsafeGetTag(Tags.HTTP_STATUS);
-    if (NOT_FOUND.equals(httpStatus) || "404".equals(httpStatus)) {
+    if (!status404Disabled && (NOT_FOUND.equals(httpStatus) || "404".equals(httpStatus))) {
       span.setResourceName("404");
       return;
     }


### PR DESCRIPTION
This change allows 404 resource name rewriting to be disabled independent of the URL resource name rewriting.  It does this by making Status404Rule and Status404Decorator sub-features of URLAsResourceNameRule.

The background is that a previous pull request allowed the disabling of decorators via config with the specific example being the status404decorator (see https://github.com/DataDog/dd-trace-java/pull/1152).  A subsequent pull request combined the status404decorator setting into an uber setting and it could no longer be set independently (see https://github.com/DataDog/dd-trace-java/pull/1551).

I have a use case where a REST API returns 404 and I'd like to be able to identify those traces by the URL of the API.