### PR TITLE
Move jcenter after maven central

### DIFF
--- a/dd-java-agent/benchmark-integration/play-perftest/play-perftest.gradle
+++ b/dd-java-agent/benchmark-integration/play-perftest/play-perftest.gradle
@@ -27,6 +27,7 @@ dependencies {
 }
 
 repositories {
+  mavenCentral()
   jcenter()
   maven {
     name "lightbend-maven-releases"

--- a/dd-smoke-tests/play-2.4/play-2.4.gradle
+++ b/dd-smoke-tests/play-2.4/play-2.4.gradle
@@ -28,6 +28,7 @@ model {
 }
 
 repositories {
+  mavenCentral()
   jcenter()
   maven {
     name "lightbend-maven-releases"

--- a/dd-smoke-tests/play-2.5/play-2.5.gradle
+++ b/dd-smoke-tests/play-2.5/play-2.5.gradle
@@ -28,6 +28,7 @@ model {
 }
 
 repositories {
+  mavenCentral()
   jcenter()
   maven {
     name "lightbend-maven-releases"

--- a/dd-smoke-tests/play-2.6/play-2.6.gradle
+++ b/dd-smoke-tests/play-2.6/play-2.6.gradle
@@ -28,6 +28,7 @@ model {
 }
 
 repositories {
+  mavenCentral()
   jcenter()
   maven {
     name "lightbend-maven-releases"

--- a/dd-trace-java.gradle
+++ b/dd-trace-java.gradle
@@ -33,8 +33,8 @@ allprojects {
 
 repositories {
   mavenLocal()
-  jcenter()
   mavenCentral()
+  jcenter()
 }
 
 description = 'dd-trace-java'

--- a/gradle/repositories.gradle
+++ b/gradle/repositories.gradle
@@ -1,7 +1,7 @@
 repositories {
   mavenLocal()
-  jcenter()
   mavenCentral()
+  jcenter()
   maven {
     url "https://adoptopenjdk.jfrog.io/adoptopenjdk/jmc-libs-snapshots"
     mavenContent {

--- a/test-published-dependencies/build.gradle
+++ b/test-published-dependencies/build.gradle
@@ -8,8 +8,8 @@ plugins {
 
 repositories {
   mavenLocal()
-  jcenter()
   mavenCentral()
+  jcenter()
 }
 
 def sharedConfigDirectory = "$rootDir/../gradle"


### PR DESCRIPTION
jcenter keeps returning `502` intermittently, so move it after maven central