### PR TITLE
Match specific direct JDBC driver implementations

### DIFF
--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/ConnectionInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/ConnectionInstrumentation.java
@@ -66,6 +66,7 @@ public final class ConnectionInstrumentation extends Instrumenter.Tracing {
     "org.sqlite.Conn",
     "org.sqlite.jdbc3.JDBC3Connection",
     "org.sqlite.jdbc4.JDBC4Connection",
+    "test.TestConnection",
     // this won't match any class unless the property is set
     Config.get().getJdbcConnectionClassName()
   };

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/ConnectionInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/ConnectionInstrumentation.java
@@ -13,6 +13,7 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers;
 import datadog.trace.api.Config;
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.InstrumentationContext;
@@ -26,6 +27,57 @@ import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(Instrumenter.class)
 public final class ConnectionInstrumentation extends Instrumenter.Tracing {
+
+  private static final String[] CONCRETE_TYPES = {
+    // jt400
+    "com.ibm.as400.access.AS400JDBCConnection",
+    // possibly need more coverage
+    "com.microsoft.sqlserver.jdbc.SQLServerConnection",
+    // should cover mysql
+    "com.mysql.jdbc.Connection",
+    "com.mysql.jdbc.jdbc1.Connection",
+    "com.mysql.jdbc.jdbc2.Connection",
+    "com.mysql.jdbc.ConnectionImpl",
+    "com.mysql.jdbc.JDBC4Connection",
+    "com.mysql.cj.jdbc.JdbcConnection",
+    // should cover derby
+    "org.apache.derby.impl.jdbc.EmbedConnection",
+    // complete
+    "org.h2.jdbc.JdbcConnection",
+    // complete
+    "org.hsqldb.jdbc.JDBCConnection",
+    "org.hsqldb.jdbc.jdbcConnection",
+    "org.apache.hive.jdbc.HiveConnection",
+    // complete
+    "org.mariadb.jdbc.MariaDbConnection",
+    "org.mariadb.jdbc.MySQLConnection",
+
+    // postgresql seems to be complete
+    "org.postgresql.jdbc.PgConnection",
+    "org.postgresql.jdbc1.Connection",
+    "org.postgresql.jdbc1.Jdbc1Connection",
+    "org.postgresql.jdbc2.Connection",
+    "org.postgresql.jdbc2.Jdbc2Connection",
+    "org.postgresql.jdbc3.Jdbc3Connection",
+    "org.postgresql.jdbc3g.Jdbc3gConnection",
+    "org.postgresql.jdbc4.Jdbc4Connection",
+    "postgresql.Connection",
+    // sqlite seems to be complete
+    "org.sqlite.Conn",
+    "org.sqlite.jdbc3.JDBC3Connection",
+    "org.sqlite.jdbc4.JDBC4Connection",
+    // this won't match any class unless the property is set
+    Config.get().getJdbcConnectionClassName()
+  };
+
+  private static final String[] ABSTRACT_TYPES = {
+    // this should cover DB2
+    "com.ibm.db2.jcc.DB2Connection",
+    // this should cover Oracle
+    "oracle.jdbc.OracleConnection",
+    // this won't match any class unless the property is set
+    Config.get().getJdbcConnectionClassName()
+  };
 
   public ConnectionInstrumentation() {
     super("jdbc");
@@ -43,52 +95,8 @@ public final class ConnectionInstrumentation extends Instrumenter.Tracing {
 
   @Override
   public ElementMatcher<TypeDescription> typeMatcher() {
-
-    return safeHasSuperType(
-        namedOneOf(
-            // jt400
-            "com.ibm.as400.access.AS400JDBCConnection",
-            // this should cover DB2
-            "com.ibm.db2.jcc.DB2Connection",
-            // this should cover Oracle
-            "oracle.jdbc.OracleConnection",
-            // possibly need more coverage
-            "com.microsoft.sqlserver.jdbc.SQLServerConnection",
-            // should cover mysql
-            "com.mysql.jdbc.Connection",
-            "com.mysql.jdbc.jdbc1.Connection",
-            "com.mysql.jdbc.jdbc2.Connection",
-            "com.mysql.jdbc.ConnectionImpl",
-            "com.mysql.jdbc.JDBC4Connection",
-            "com.mysql.cj.jdbc.JdbcConnection",
-            // should cover derby
-            "org.apache.derby.impl.jdbc.EmbedConnection",
-            // complete
-            "org.h2.jdbc.JdbcConnection",
-            // complete
-            "org.hsqldb.jdbc.JDBCConnection",
-            "org.hsqldb.jdbc.jdbcConnection",
-            "org.apache.hive.jdbc.HiveConnection",
-            // complete
-            "org.mariadb.jdbc.MariaDbConnection",
-            "org.mariadb.jdbc.MySQLConnection",
-
-            // postgresql seems to be complete
-            "org.postgresql.jdbc.PgConnection",
-            "org.postgresql.jdbc1.Connection",
-            "org.postgresql.jdbc1.Jdbc1Connection",
-            "org.postgresql.jdbc2.Connection",
-            "org.postgresql.jdbc2.Jdbc2Connection",
-            "org.postgresql.jdbc3.Jdbc3Connection",
-            "org.postgresql.jdbc3g.Jdbc3gConnection",
-            "org.postgresql.jdbc4.Jdbc4Connection",
-            "postgresql.Connection",
-            // sqlite seems to be complete
-            "org.sqlite.Conn",
-            "org.sqlite.jdbc3.JDBC3Connection",
-            "org.sqlite.jdbc4.JDBC4Connection",
-            // this won't match any class unless the property is set
-            Config.get().getJdbcConnectionClassName()));
+    return namedOneOf(CONCRETE_TYPES)
+        .or(safeHasSuperType(NameMatchers.<TypeDescription>namedOneOf(ABSTRACT_TYPES)));
   }
 
   @Override

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/PreparedStatementInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/PreparedStatementInstrumentation.java
@@ -16,6 +16,7 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers;
 import datadog.trace.api.Config;
 import datadog.trace.bootstrap.CallDepthThreadLocalMap;
 import datadog.trace.bootstrap.InstrumentationContext;
@@ -32,6 +33,85 @@ import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(Instrumenter.class)
 public final class PreparedStatementInstrumentation extends Instrumenter.Tracing {
+
+  private static final String[] CONCRETE_TYPES = {
+    // jt400
+    "com.ibm.as400.access.AS400JDBCPreparedStatement",
+    // probably patchy cover
+    "com.microsoft.sqlserver.jdbc.SQLServerPreparedStatement",
+    "com.microsoft.sqlserver.jdbc.SQLServerCallableStatement",
+    // should cover mysql
+    "com.mysql.cj.JdbcPreparedStatement",
+    "com.mysql.jdbc.PreparedStatement",
+    "com.mysql.jdbc.jdbc1.PreparedStatement",
+    "com.mysql.jdbc.jdbc2.PreparedStatement",
+    "com.mysql.jdbc.ServerPreparedStatement",
+    "com.mysql.cj.jdbc.PreparedStatement",
+    "com.mysql.cj.jdbc.ServerPreparedStatement",
+    "com.mysql.cj.JdbcCallableStatement",
+    "com.mysql.jdbc.CallableStatement",
+    "com.mysql.jdbc.jdbc1.CallableStatement",
+    "com.mysql.jdbc.jdbc2.CallableStatement",
+    "com.mysql.cj.jdbc.CallableStatement",
+    // covers hsqldb
+    "org.hsqldb.jdbc.JDBCPreparedStatement",
+    "org.hsqldb.jdbc.jdbcPreparedStatement",
+    "org.hsqldb.jdbc.JDBCCallableStatement",
+    "org.hsqldb.jdbc.jdbcCallableStatement",
+    // should cover derby
+    "org.apache.derby.impl.jdbc.EmbedPreparedStatement",
+    "org.apache.derby.impl.jdbc.EmbedCallableStatement",
+    // hive
+    "org.apache.hive.jdbc.HivePreparedStatement",
+    "org.apache.hive.jdbc.HiveCallableStatement",
+    // covers h2
+    "org.h2.jdbc.JdbcPreparedStatement",
+    "org.h2.jdbc.JdbcCallableStatement",
+    // covers mariadb
+    "org.mariadb.jdbc.JdbcPreparedStatement",
+    "org.mariadb.jdbc.JdbcCallableStatement",
+    "org.mariadb.jdbc.ServerSidePreparedStatement",
+    "org.mariadb.jdbc.ClientSidePreparedStatement",
+    "org.mariadb.jdbc.MariaDbServerPreparedStatement",
+    "org.mariadb.jdbc.MariaDbClientPreparedStatement",
+    "org.mariadb.jdbc.MySQLPreparedStatement",
+    "org.mariadb.jdbc.MySQLCallableStatement",
+    "org.mariadb.jdbc.MySQLServerSidePreparedStatement",
+    // should completely cover postgresql
+    "org.postgresql.jdbc1.PreparedStatement",
+    "org.postgresql.jdbc1.CallableStatement",
+    "org.postgresql.jdbc1.Jdbc1PreparedStatement",
+    "org.postgresql.jdbc1.Jdbc1CallableStatement",
+    "org.postgresql.jdbc2.PreparedStatement",
+    "org.postgresql.jdbc2.CallableStatement",
+    "org.postgresql.jdbc2.Jdbc2PreparedStatement",
+    "org.postgresql.jdbc2.Jdbc2CallableStatement",
+    "org.postgresql.jdbc3.Jdbc3PreparedStatement",
+    "org.postgresql.jdbc3.Jdbc3CallableStatement",
+    "org.postgresql.jdbc3g.Jdbc3gPreparedStatement",
+    "org.postgresql.jdbc3g.Jdbc3gCallableStatement",
+    "org.postgresql.jdbc4.Jdbc4PreparedStatement",
+    "org.postgresql.jdbc4.Jdbc4CallableStatement",
+    "org.postgresql.jdbc.PgPreparedStatement",
+    "org.postgresql.jdbc.PgCallableStatement",
+    "postgresql.PreparedStatement",
+    "postgresql.CallableStatement",
+    // should completely cover sqlite
+    "org.sqlite.jdbc3.JDBC3PreparedStatement",
+    "org.sqlite.jdbc4.JDBC4PreparedStatement",
+    "org.sqlite.PrepStmt",
+    // this won't match any classes unless set
+    Config.get().getJdbcPreparedStatementClassName()
+  };
+
+  private static final String[] ABSTRACT_TYPES = {
+    // should cover DB2
+    "com.ibm.db2.jcc.DB2PreparedStatement",
+    // should cover Oracle
+    "oracle.jdbc.OraclePreparedStatement",
+    // this won't match any classes unless set
+    Config.get().getJdbcPreparedStatementClassName()
+  };
 
   public PreparedStatementInstrumentation() {
     super("jdbc");
@@ -52,56 +132,8 @@ public final class PreparedStatementInstrumentation extends Instrumenter.Tracing
 
   @Override
   public ElementMatcher<TypeDescription> typeMatcher() {
-    return safeHasSuperType(
-        namedOneOf(
-            // jt400
-            "com.ibm.as400.access.AS400JDBCPreparedStatement",
-            // should cover DB2
-            "com.ibm.db2.jcc.DB2PreparedStatement",
-            // should cover Oracle
-            "oracle.jdbc.OraclePreparedStatement",
-            // probably patchy cover
-            "com.microsoft.sqlserver.jdbc.SQLServerPreparedStatement",
-            // should cover mysql
-            "com.mysql.cj.JdbcPreparedStatement",
-            "com.mysql.jdbc.PreparedStatement",
-            "com.mysql.jdbc.jdbc1.PreparedStatement",
-            "com.mysql.jdbc.jdbc2.PreparedStatement",
-            "com.mysql.jdbc.ServerPreparedStatement",
-            "com.mysql.cj.jdbc.PreparedStatement",
-            "com.mysql.cj.jdbc.ServerPreparedStatement",
-            // covers hsqldb
-            "org.hsqldb.jdbc.JDBCPreparedStatement",
-            "org.hsqldb.jdbc.jdbcPreparedStatement",
-            // should cover derby
-            "org.apache.derby.impl.jdbc.EmbedPreparedStatement",
-            "org.apache.hive.jdbc.HivePreparedStatement",
-            // covers h2
-            "org.h2.jdbc.JdbcPreparedStatement",
-            // covers mariadb
-            "org.mariadb.jdbc.JdbcPreparedStatement",
-            "org.mariadb.jdbc.ServerSidePreparedStatement",
-            "org.mariadb.jdbc.ClientSidePreparedStatement",
-            "org.mariadb.jdbc.MariaDbServerPreparedStatement",
-            "org.mariadb.jdbc.MariaDbClientPreparedStatement",
-            "org.mariadb.jdbc.MySQLPreparedStatement",
-            "org.mariadb.jdbc.MySQLServerSidePreparedStatement",
-            // should completely cover postgresql
-            "org.postgresql.jdbc1.PreparedStatement",
-            "org.postgresql.jdbc1.Jdbc1PreparedStatement",
-            "org.postgresql.jdbc2.PreparedStatement",
-            "org.postgresql.jdbc2.Jdbc2PreparedStatement",
-            "org.postgresql.jdbc3.Jdbc3PreparedStatement",
-            "org.postgresql.jdbc3g.Jdbc3gPreparedStatement",
-            "org.postgresql.jdbc4.Jdbc4PreparedStatement",
-            "org.postgresql.jdbc.PgPreparedStatement",
-            "postgresql.PreparedStatement",
-            // should completely cover sqlite
-            "org.sqlite.jdbc3.JDBC3PreparedStatement",
-            "org.sqlite.jdbc4.JDBC4PreparedStatement",
-            "org.sqlite.PrepStmt",
-            // this won't match any classes unless set
-            Config.get().getJdbcPreparedStatementClassName()));
+    return namedOneOf(CONCRETE_TYPES)
+        .or(safeHasSuperType(NameMatchers.<TypeDescription>namedOneOf(ABSTRACT_TYPES)));
   }
 
   @Override

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/PreparedStatementInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/PreparedStatementInstrumentation.java
@@ -100,6 +100,7 @@ public final class PreparedStatementInstrumentation extends Instrumenter.Tracing
     "org.sqlite.jdbc3.JDBC3PreparedStatement",
     "org.sqlite.jdbc4.JDBC4PreparedStatement",
     "org.sqlite.PrepStmt",
+    "test.TestPreparedStatement",
     // this won't match any classes unless set
     Config.get().getJdbcPreparedStatementClassName()
   };

--- a/dd-java-agent/instrumentation/jdbc/src/test/groovy/JDBCInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/jdbc/src/test/groovy/JDBCInstrumentationTest.groovy
@@ -142,6 +142,7 @@ class JDBCInstrumentationTest extends AgentTestRunner {
   void configurePreAgent() {
     super.configurePreAgent()
 
+    injectSysConfig("dd.trace.jdbc.prepared.statement.class.name", "test.TestPreparedStatement")
     injectSysConfig("dd.integration.jdbc-datasource.enabled", "true")
   }
 

--- a/dd-java-agent/instrumentation/jdbc/src/test/groovy/JDBCWrappedInterfacesTest.groovy
+++ b/dd-java-agent/instrumentation/jdbc/src/test/groovy/JDBCWrappedInterfacesTest.groovy
@@ -15,6 +15,14 @@ import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
  * H2 classes are called out because the don't implement the Wrapper interface.  They are based an older spec leading to AbstractMethodError
  */
 class JDBCWrappedInterfacesTest extends AgentTestRunner {
+
+  @Override
+  void configurePreAgent() {
+    super.configurePreAgent()
+
+    injectSysConfig("dd.trace.jdbc.prepared.statement.class.name", "test.TestPreparedStatement")
+  }
+
   static query = "SELECT 1"
 
   def "prepare on unwrapped conn, execute unwrapped stmt"() {

--- a/dd-java-agent/instrumentation/jdbc/src/test/groovy/JDBCWrappedInterfacesTest.groovy
+++ b/dd-java-agent/instrumentation/jdbc/src/test/groovy/JDBCWrappedInterfacesTest.groovy
@@ -21,6 +21,7 @@ class JDBCWrappedInterfacesTest extends AgentTestRunner {
     super.configurePreAgent()
 
     injectSysConfig("dd.trace.jdbc.prepared.statement.class.name", "test.TestPreparedStatement")
+    injectSysConfig("dd.trace.jdbc.connection.class.name", "test.TestConnection")
   }
 
   static query = "SELECT 1"

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
@@ -24,6 +24,11 @@ public final class TraceInstrumentationConfig {
   public static final String HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN = "trace.http.client.split-by-domain";
   public static final String DB_CLIENT_HOST_SPLIT_BY_INSTANCE = "trace.db.client.split-by-instance";
 
+  public static final String JDBC_PREPARED_STATEMENT_CLASS_NAME =
+      "trace.jdbc.prepared.statement.class.name";
+
+  public static final String JDBC_CONNECTION_CLASS_NAME = "trace.jdbc.connection.class.name";
+
   public static final String RUNTIME_CONTEXT_FIELD_INJECTION =
       "trace.runtime.context.field.injection";
   public static final String SERIALVERSIONUID_FIELD_INJECTION =

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -65,6 +65,8 @@ import static datadog.trace.api.config.GeneralConfig.TRACER_METRICS_ENABLED;
 import static datadog.trace.api.config.GeneralConfig.TRACER_METRICS_MAX_AGGREGATES;
 import static datadog.trace.api.config.GeneralConfig.TRACER_METRICS_MAX_PENDING;
 import static datadog.trace.api.config.TraceInstrumentationConfig.HYSTRIX_TAGS_ENABLED;
+import static datadog.trace.api.config.TraceInstrumentationConfig.JDBC_CONNECTION_CLASS_NAME;
+import static datadog.trace.api.config.TraceInstrumentationConfig.JDBC_PREPARED_STATEMENT_CLASS_NAME;
 import static datadog.trace.api.config.TraceInstrumentationConfig.LOGS_MDC_TAGS_INJECTION_ENABLED;
 import static datadog.trace.api.config.TraceInstrumentationConfig.SERIALVERSIONUID_FIELD_INJECTION;
 import static datadog.trace.api.config.TracerConfig.ENABLE_TRACE_AGENT_V05;
@@ -257,11 +259,6 @@ public class Config {
 
   public static final String KAFKA_CLIENT_BASE64_DECODING_ENABLED =
       TraceInstrumentationConfig.KAFKA_CLIENT_BASE64_DECODING_ENABLED;
-
-  private static final String JDBC_PREPARED_STATEMENT_CLASS_NAME =
-      "trace.jdbc.prepared.statement.class.name";
-
-  private static final String JDBC_CONNECTION_CLASS_NAME = "trace.jdbc.connection.class.name";
 
   private static final String TRACE_AGENT_URL_TEMPLATE = "http://%s:%d";
 

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -258,6 +258,9 @@ public class Config {
   public static final String KAFKA_CLIENT_BASE64_DECODING_ENABLED =
       TraceInstrumentationConfig.KAFKA_CLIENT_BASE64_DECODING_ENABLED;
 
+  private static final String JDBC_PREPARED_STATEMENT_CLASS_NAME =
+      "trace.jdbc.prepared.statement.class.name";
+
   private static final String TRACE_AGENT_URL_TEMPLATE = "http://%s:%d";
 
   private static final String PROFILING_REMOTE_URL_TEMPLATE = "https://intake.profile.%s/v1/input";
@@ -409,6 +412,8 @@ public class Config {
   @Getter private final boolean internalExitOnFailure;
 
   @Getter private final boolean resolverUseLoadClassEnabled;
+
+  @Getter private final String jdbcPreparedStatementClassName;
 
   private final ConfigProvider configProvider;
 
@@ -731,6 +736,9 @@ public class Config {
             DEFAULT_PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE);
 
     profilingExcludeAgentThreads = configProvider.getBoolean(PROFILING_EXCLUDE_AGENT_THREADS, true);
+
+    jdbcPreparedStatementClassName =
+        configProvider.getString(JDBC_PREPARED_STATEMENT_CLASS_NAME, "");
 
     kafkaClientPropagationEnabled =
         configProvider.getBoolean(

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -261,6 +261,8 @@ public class Config {
   private static final String JDBC_PREPARED_STATEMENT_CLASS_NAME =
       "trace.jdbc.prepared.statement.class.name";
 
+  private static final String JDBC_CONNECTION_CLASS_NAME = "trace.jdbc.connection.class.name";
+
   private static final String TRACE_AGENT_URL_TEMPLATE = "http://%s:%d";
 
   private static final String PROFILING_REMOTE_URL_TEMPLATE = "https://intake.profile.%s/v1/input";
@@ -414,6 +416,7 @@ public class Config {
   @Getter private final boolean resolverUseLoadClassEnabled;
 
   @Getter private final String jdbcPreparedStatementClassName;
+  @Getter private final String jdbcConnectionClassName;
 
   private final ConfigProvider configProvider;
 
@@ -739,6 +742,8 @@ public class Config {
 
     jdbcPreparedStatementClassName =
         configProvider.getString(JDBC_PREPARED_STATEMENT_CLASS_NAME, "");
+
+    jdbcConnectionClassName = configProvider.getString(JDBC_CONNECTION_CLASS_NAME, "");
 
     kafkaClientPropagationEnabled =
         configProvider.getBoolean(


### PR DESCRIPTION
This is here for review of the lists I have made of connection and preparedstatement implementations, in case any omissions jump out.

The motivation is twofold, both because JDBC involves lots of wrapping and we only want to create a single span:

* We currently rely on lawful unwrapping behaviour, and work around unlawful unwrapping _when we discover it_ with various approaches, including a `ClassValue<Boolean>` of bad unwrapping candidates, and _replacing_ the implementations of `unwrap` in some datanucleus wrappers. Targeting known non-delegating implementations makes this problem go away, so long as we can create a comprehensive enough list of implementation classes.
* Performance - see #2220 which improves `Connection` to `DBInfo` association, which interferes with datanucleus, but would be safe if we never matched any datanucleus classes. The much bigger gain following from this is not doing any depth tracking, unwrapping, or unwrap safety checking (see #2216).

The awkward odd one out from the big databases is Oracle, because of the licensing of its driver. I don't believe it is within the terms of the license to use the names of its implementation classes, so we need to check whether the classes implement the Oracle JDBC API. I haven't looked at the class names, so don't know if the prefix check is correct (this needs testing), and think it would be safer to just check if the interfaces are implemented, and perhaps add an oracle integration feature which can be disabled to speed up matching for users of other databases.