### PR TITLE
Log the final configured agent URL and unix-domain-socket

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/StatusLogger.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/StatusLogger.java
@@ -96,7 +96,9 @@ public class StatusLogger {
       writer.name("service");
       writer.value(config.getServiceName());
       writer.name("agent_url");
-      writer.value("http://" + config.getAgentHost() + ":" + config.getAgentPort());
+      writer.value(config.getAgentUrl());
+      writer.name("agent_unix_domain_socket");
+      writer.value(config.getAgentUnixDomainSocket());
       writer.name("agent_error");
       writer.value(!agentServiceCheck(config));
       writer.name("debug");


### PR DESCRIPTION
I missed this class when I added support for configuring the agent URL in #1929 - in most cases there's no difference in the final logged value, but since `config.getAgentUrl()` is what the code uses we should be consistent. Also log the unix domain socket as it can be configured separately and it's useful to know if it's set.