### PR TITLE
Support DD_PROXY_NO_PROXY setting for agent HTTP connections

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-uploader/src/main/java/com/datadog/profiling/uploader/ProfileUploader.java
+++ b/dd-java-agent/agent-profiling/profiling-uploader/src/main/java/com/datadog/profiling/uploader/ProfileUploader.java
@@ -24,6 +24,7 @@ import com.datadog.profiling.uploader.util.StreamUtils;
 import datadog.common.container.ContainerInfo;
 import datadog.trace.api.Config;
 import datadog.trace.api.IOLogger;
+import datadog.trace.util.AgentProxySelector;
 import datadog.trace.util.AgentThreadFactory;
 import java.io.IOException;
 import java.io.InputStream;
@@ -217,6 +218,7 @@ public final class ProfileUploader {
             .writeTimeout(requestTimeout)
             .readTimeout(requestTimeout)
             .callTimeout(requestTimeout)
+            .proxySelector(AgentProxySelector.INSTANCE)
             .dispatcher(new Dispatcher(okHttpExecutorService))
             .connectionPool(connectionPool);
 

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
@@ -21,6 +21,7 @@ public final class TracerConfig {
   public static final String AGENT_PORT_LEGACY = "agent.port";
   public static final String AGENT_UNIX_DOMAIN_SOCKET = "trace.agent.unix.domain.socket";
   public static final String AGENT_TIMEOUT = "trace.agent.timeout";
+  public static final String PROXY_NO_PROXY = "proxy.no_proxy";
   public static final String PRIORITY_SAMPLING = "priority.sampling";
   public static final String PRIORITY_SAMPLING_FORCE = "priority.sampling.force";
   public static final String TRACE_RESOLVER_ENABLED = "trace.resolver.enabled";

--- a/dd-trace-core/src/main/java/datadog/trace/core/http/OkHttpUtils.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/http/OkHttpUtils.java
@@ -5,6 +5,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import datadog.common.container.ContainerInfo;
 import datadog.trace.common.writer.ddagent.unixdomainsockets.UnixDomainSocketFactory;
 import datadog.trace.core.DDTraceCoreInfo;
+import datadog.trace.util.AgentProxySelector;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -54,6 +55,7 @@ public final class OkHttpUtils {
         .connectTimeout(timeoutMillis, MILLISECONDS)
         .writeTimeout(timeoutMillis, MILLISECONDS)
         .readTimeout(timeoutMillis, MILLISECONDS)
+        .proxySelector(AgentProxySelector.INSTANCE)
 
         // We don't do async so this shouldn't matter, but just to be safe...
         .dispatcher(new Dispatcher(RejectingExecutorService.INSTANCE))

--- a/internal-api/internal-api.gradle
+++ b/internal-api/internal-api.gradle
@@ -19,6 +19,7 @@ excludedClassesCoverage += [
   "datadog.trace.bootstrap.instrumentation.api.ScopeSource",
   "datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes",
   "datadog.trace.logging.LoggingSettingsDescription",
+  "datadog.trace.util.AgentProxySelector",
   "datadog.trace.util.AgentTaskScheduler",
   "datadog.trace.util.AgentTaskScheduler.PeriodicTask",
   "datadog.trace.util.AgentTaskScheduler.ShutdownHook",

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -527,13 +527,8 @@ public class Config {
 
     agentTimeout = configProvider.getInteger(AGENT_TIMEOUT, DEFAULT_AGENT_TIMEOUT);
 
-    String proxyNoProxy = configProvider.getString(TracerConfig.PROXY_NO_PROXY);
-    if (null != proxyNoProxy && !proxyNoProxy.isEmpty()) {
-      // DD_PROXY_NO_PROXY is specified as a space-separated list of hosts
-      noProxyHosts = new HashSet<>(Arrays.asList(proxyNoProxy.split(" ")));
-    } else {
-      noProxyHosts = Collections.emptySet();
-    }
+    // DD_PROXY_NO_PROXY is specified as a space-separated list of hosts
+    noProxyHosts = new HashSet<>(configProvider.getSpacedList(TracerConfig.PROXY_NO_PROXY));
 
     prioritySamplingEnabled =
         configProvider.getBoolean(PRIORITY_SAMPLING, DEFAULT_PRIORITY_SAMPLING_ENABLED);

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -90,6 +90,7 @@ import java.util.Arrays;
 import java.util.BitSet;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -302,6 +303,7 @@ public class Config {
   @Getter private final int agentPort;
   @Getter private final String agentUnixDomainSocket;
   @Getter private final int agentTimeout;
+  @Getter private final Set<String> noProxyHosts;
   @Getter private final boolean prioritySamplingEnabled;
   @Getter private final String prioritySamplingForce;
   @Getter private final boolean traceResolverEnabled;
@@ -524,6 +526,15 @@ public class Config {
             && agentPort == DEFAULT_TRACE_AGENT_PORT;
 
     agentTimeout = configProvider.getInteger(AGENT_TIMEOUT, DEFAULT_AGENT_TIMEOUT);
+
+    String proxyNoProxy = configProvider.getString(TracerConfig.PROXY_NO_PROXY);
+    if (null != proxyNoProxy && !proxyNoProxy.isEmpty()) {
+      // DD_PROXY_NO_PROXY is specified as a space-separated list of hosts
+      noProxyHosts = new HashSet<>(Arrays.asList(proxyNoProxy.split(" ")));
+    } else {
+      noProxyHosts = Collections.emptySet();
+    }
+
     prioritySamplingEnabled =
         configProvider.getBoolean(PRIORITY_SAMPLING, DEFAULT_PRIORITY_SAMPLING_ENABLED);
     prioritySamplingForce =

--- a/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/ConfigConverter.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/ConfigConverter.java
@@ -47,11 +47,16 @@ final class ConfigConverter {
 
   @NonNull
   static List<String> parseList(final String str) {
+    return parseList(str, ",");
+  }
+
+  @NonNull
+  static List<String> parseList(final String str, final String separator) {
     if (str == null || str.trim().isEmpty()) {
       return Collections.emptyList();
     }
 
-    final String[] tokens = str.split(",", -1);
+    final String[] tokens = str.split(separator, -1);
     // Remove whitespace from each item.
     for (int i = 0; i < tokens.length; i++) {
       tokens[i] = tokens[i].trim();

--- a/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/ConfigProvider.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/ConfigProvider.java
@@ -117,6 +117,10 @@ public final class ConfigProvider {
     return ConfigConverter.parseList(getString(key));
   }
 
+  public final List<String> getSpacedList(String key) {
+    return ConfigConverter.parseList(getString(key), " ");
+  }
+
   public final Map<String, String> getMergedMap(String key) {
     Map<String, String> merged = new HashMap<>();
     // reverse iterate to allow overrides

--- a/internal-api/src/main/java/datadog/trace/util/AgentProxySelector.java
+++ b/internal-api/src/main/java/datadog/trace/util/AgentProxySelector.java
@@ -1,0 +1,35 @@
+package datadog.trace.util;
+
+import datadog.trace.api.Config;
+import java.io.IOException;
+import java.net.Proxy;
+import java.net.ProxySelector;
+import java.net.SocketAddress;
+import java.net.URI;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+public final class AgentProxySelector extends ProxySelector {
+  public static final ProxySelector INSTANCE = new AgentProxySelector();
+
+  private static final List<Proxy> DIRECT = Collections.singletonList(Proxy.NO_PROXY);
+
+  private final Set<String> noProxyHosts = Config.get().getNoProxyHosts();
+
+  private final ProxySelector defaultProxySelector = ProxySelector.getDefault();
+
+  @Override
+  public List<Proxy> select(final URI uri) {
+    if (noProxyHosts.contains(uri.getHost())) {
+      return DIRECT;
+    } else {
+      return defaultProxySelector.select(uri);
+    }
+  }
+
+  @Override
+  public void connectFailed(final URI uri, final SocketAddress sa, final IOException ioe) {
+    defaultProxySelector.connectFailed(uri, sa, ioe);
+  }
+}


### PR DESCRIPTION
This will let users exclude agent hosts from being proxied without having to tweak their JVM or OS proxy settings.

This setting is specified in https://docs.datadoghq.com/agent/proxy/?tab=agentv6v7#environment-variables as:
```
DD_PROXY_NO_PROXY: Sets a list of hosts that should bypass the proxy. The list is space-separated
```