### PR TITLE
Enable automatic generation of missing serialVersionUid for field-injected Serializable types

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -29,7 +29,7 @@ public final class ConfigDefaults {
   static final String DEFAULT_PRIORITIZATION_TYPE = "FastLane";
 
   static final boolean DEFAULT_RUNTIME_CONTEXT_FIELD_INJECTION = true;
-  static final boolean DEFAULT_SERIALVERSIONUID_FIELD_INJECTION = false;
+  static final boolean DEFAULT_SERIALVERSIONUID_FIELD_INJECTION = true;
 
   static final boolean DEFAULT_PRIORITY_SAMPLING_ENABLED = true;
   static final String DEFAULT_PRIORITY_SAMPLING_FORCE = null;


### PR DESCRIPTION
This feature already exists in the codebase, this PR just changes the default setting to have it enabled out-of-the-box.

Performance testing indicates this doesn't introduce much overhead, and the work only occurs once per-affected-class.