### PR TITLE
Move nested helper classes to top level, add smoke test for ApacheHttpClient classloader isolation

### DIFF
--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/AkkaHttpServerInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/AkkaHttpServerInstrumentation.java
@@ -1,13 +1,6 @@
 package datadog.trace.instrumentation.akkahttp;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
-import static datadog.trace.instrumentation.akkahttp.AkkaHttpServerDecorator.AKKA_REQUEST;
-import static datadog.trace.instrumentation.akkahttp.AkkaHttpServerDecorator.DECORATE;
-import static datadog.trace.instrumentation.akkahttp.AkkaHttpServerHeaders.GETTER;
 import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
@@ -15,25 +8,11 @@ import akka.NotUsed;
 import akka.http.scaladsl.model.HttpRequest;
 import akka.http.scaladsl.model.HttpResponse;
 import akka.http.scaladsl.settings.ServerSettings;
-import akka.stream.Attributes;
-import akka.stream.BidiShape;
-import akka.stream.Inlet;
-import akka.stream.Outlet;
 import akka.stream.javadsl.BidiFlow;
 import akka.stream.scaladsl.Flow;
-import akka.stream.stage.AbstractInHandler;
-import akka.stream.stage.AbstractOutHandler;
-import akka.stream.stage.GraphStage;
-import akka.stream.stage.GraphStageLogic;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
-import datadog.trace.bootstrap.instrumentation.api.AgentScope;
-import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.bootstrap.instrumentation.api.Tags;
-import datadog.trace.context.TraceScope;
 import java.util.Map;
-import java.util.Queue;
-import java.util.concurrent.ArrayBlockingQueue;
 import lombok.extern.slf4j.Slf4j;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.method.MethodDescription;
@@ -88,13 +67,13 @@ public final class AkkaHttpServerInstrumentation extends Instrumenter.Tracing {
   @Override
   public String[] helperClassNames() {
     return new String[] {
-      getClass().getName() + "$DatadogWrapperHelper",
-      getClass().getName() + "$DatadogServerRequestResponseFlowWrapper",
-      getClass().getName() + "$DatadogServerRequestResponseFlowWrapper$1",
-      getClass().getName() + "$DatadogServerRequestResponseFlowWrapper$1$1",
-      getClass().getName() + "$DatadogServerRequestResponseFlowWrapper$1$2",
-      getClass().getName() + "$DatadogServerRequestResponseFlowWrapper$1$3",
-      getClass().getName() + "$DatadogServerRequestResponseFlowWrapper$1$4",
+      packageName + ".DatadogWrapperHelper",
+      packageName + ".DatadogServerRequestResponseFlowWrapper",
+      packageName + ".DatadogServerRequestResponseFlowWrapper$1",
+      packageName + ".DatadogServerRequestResponseFlowWrapper$1$1",
+      packageName + ".DatadogServerRequestResponseFlowWrapper$1$2",
+      packageName + ".DatadogServerRequestResponseFlowWrapper$1$3",
+      packageName + ".DatadogServerRequestResponseFlowWrapper$1$4",
       packageName + ".AkkaHttpServerHeaders",
       packageName + ".AkkaHttpServerDecorator",
       packageName + ".UriAdapter",
@@ -117,195 +96,6 @@ public final class AkkaHttpServerInstrumentation extends Instrumenter.Tracing {
       final BidiFlow<HttpResponse, HttpResponse, HttpRequest, HttpRequest, NotUsed> wrapper =
           BidiFlow.fromGraph(new DatadogServerRequestResponseFlowWrapper(settings));
       handler = wrapper.reversed().join(handler.asJava()).asScala();
-    }
-  }
-
-  public static class DatadogWrapperHelper {
-    public static AgentScope createSpan(final HttpRequest request) {
-      final AgentSpan.Context extractedContext = propagate().extract(request, GETTER);
-      final AgentSpan span = startSpan(AKKA_REQUEST, extractedContext);
-      span.setMeasured(true);
-
-      DECORATE.afterStart(span);
-      DECORATE.onConnection(span, request);
-      DECORATE.onRequest(span, request);
-
-      final AgentScope scope = activateSpan(span);
-      scope.setAsyncPropagation(true);
-      return scope;
-    }
-
-    public static void finishSpan(final AgentSpan span, final HttpResponse response) {
-      DECORATE.onResponse(span, response);
-      DECORATE.beforeFinish(span);
-
-      span.finish();
-    }
-
-    public static void finishSpan(final AgentSpan span, final Throwable t) {
-      DECORATE.onError(span, t);
-      span.setTag(Tags.HTTP_STATUS, 500);
-      DECORATE.beforeFinish(span);
-
-      span.finish();
-    }
-  }
-
-  public static class DatadogServerRequestResponseFlowWrapper
-      extends GraphStage<BidiShape<HttpResponse, HttpResponse, HttpRequest, HttpRequest>> {
-    private final Inlet<HttpRequest> requestInlet = Inlet.create("Datadog.server.requestIn");
-    private final Outlet<HttpRequest> requestOutlet = Outlet.create("Datadog.server.requestOut");
-    private final Inlet<HttpResponse> responseInlet = Inlet.create("Datadog.server.responseIn");
-    private final Outlet<HttpResponse> responseOutlet = Outlet.create("Datadog.server.responseOut");
-    private final BidiShape<HttpResponse, HttpResponse, HttpRequest, HttpRequest> shape =
-        BidiShape.of(responseInlet, responseOutlet, requestInlet, requestOutlet);
-
-    private final int pipeliningLimit;
-
-    public DatadogServerRequestResponseFlowWrapper(final ServerSettings settings) {
-      this.pipeliningLimit = settings.getPipeliningLimit();
-    }
-
-    @Override
-    public BidiShape<HttpResponse, HttpResponse, HttpRequest, HttpRequest> shape() {
-      return shape;
-    }
-
-    @Override
-    public Attributes initialAttributes() {
-      return Attributes.name("DatadogServerRequestResponseFlowWrapper");
-    }
-
-    @Override
-    public GraphStageLogic createLogic(final Attributes inheritedAttributes) throws Exception {
-      return new GraphStageLogic(shape) {
-        {
-          // The is one instance of this logic per connection, and the request/response is
-          // guaranteed to be in order according to the docs at
-          // https://doc.akka.io/docs/akka-http/current/server-side/low-level-api.html#request-response-cycle
-          // and there can never be more outstanding requests than the pipeliningLimit
-          // that this connection was created with. This means that we can safely
-          // close the span at the front of the queue when we receive the response
-          // from the user code, since it will match up to the request for that span.
-          final Queue<AgentScope> scopes = new ArrayBlockingQueue<>(pipeliningLimit);
-
-          // This is where the request comes in from the server and TCP layer
-          setHandler(
-              requestInlet,
-              new AbstractInHandler() {
-                @Override
-                public void onPush() throws Exception {
-                  final HttpRequest request = grab(requestInlet);
-                  final AgentScope scope = DatadogWrapperHelper.createSpan(request);
-                  scopes.add(scope);
-                  push(requestOutlet, request);
-                  // Since we haven't instrumented the akka stream state machine, we can't rely
-                  // on spans and scopes being propagated during the push and pull of the
-                  // element. Instead we let the scope leak intentionally here and clean it
-                  // up when the user response comes back, or in the actor message processing
-                  // instrumentation that drives this state machine.
-                }
-
-                @Override
-                public void onUpstreamFinish() throws Exception {
-                  // We will not receive any more requests from the server and TCP layer so stop
-                  // sending them
-                  complete(requestOutlet);
-                }
-
-                @Override
-                public void onUpstreamFailure(final Throwable ex) throws Exception, Exception {
-                  // We will not receive any more requests from the server and TCP layer so stop
-                  // sending them
-                  fail(requestOutlet, ex);
-                }
-              });
-
-          // This is where demand comes in from the user code
-          setHandler(
-              requestOutlet,
-              new AbstractOutHandler() {
-                @Override
-                public void onPull() throws Exception {
-                  pull(requestInlet);
-                }
-
-                @Override
-                public void onDownstreamFinish() throws Exception {
-                  // We can not send out any more requests to the user code so stop receiving them
-                  cancel(requestInlet);
-                }
-              });
-
-          // This is where the response comes back from the user code
-          setHandler(
-              responseInlet,
-              new AbstractInHandler() {
-                @Override
-                public void onPush() throws Exception {
-                  final HttpResponse response = grab(responseInlet);
-                  final AgentScope scope = scopes.poll();
-                  if (scope != null) {
-                    DatadogWrapperHelper.finishSpan(scope.span(), response);
-                    // Check if the active scope is still the scope from when the request came in,
-                    // and close it. If it's not, then it will be cleaned up actor message
-                    // processing instrumentation that drives this state machine
-                    TraceScope activeScope = activeScope();
-                    if (activeScope == scope) {
-                      scope.close();
-                    }
-                  }
-                  push(responseOutlet, response);
-                }
-
-                @Override
-                public void onUpstreamFinish() throws Exception {
-                  // We will not receive any more responses from the user code, so clean up any
-                  // remaining spans
-                  AgentScope scope = scopes.poll();
-                  while (scope != null) {
-                    scope.span().finish();
-                    scope = scopes.poll();
-                  }
-                  completeStage();
-                }
-
-                @Override
-                public void onUpstreamFailure(final Throwable ex) throws Exception {
-                  AgentScope scope = scopes.poll();
-                  if (scope != null) {
-                    // Mark the span as failed
-                    DatadogWrapperHelper.finishSpan(scope.span(), ex);
-                  }
-                  // We will not receive any more responses from the user code, so clean up any
-                  // remaining spans
-                  scope = scopes.poll();
-                  while (scope != null) {
-                    scope.span().finish();
-                    scope = scopes.poll();
-                  }
-                  fail(responseOutlet, ex);
-                }
-              });
-
-          // This is where demand comes in from the server and TCP layer
-          setHandler(
-              responseOutlet,
-              new AbstractOutHandler() {
-                @Override
-                public void onPull() throws Exception {
-                  pull(responseInlet);
-                }
-
-                @Override
-                public void onDownstreamFinish() throws Exception {
-                  // We can not send out any more responses to the server and TCP layer so stop
-                  // receiving them
-                  cancel(responseInlet);
-                }
-              });
-        }
-      };
     }
   }
 }

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/DatadogServerRequestResponseFlowWrapper.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/DatadogServerRequestResponseFlowWrapper.java
@@ -1,0 +1,177 @@
+package datadog.trace.instrumentation.akkahttp;
+
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
+
+import akka.http.scaladsl.model.HttpRequest;
+import akka.http.scaladsl.model.HttpResponse;
+import akka.http.scaladsl.settings.ServerSettings;
+import akka.stream.Attributes;
+import akka.stream.BidiShape;
+import akka.stream.Inlet;
+import akka.stream.Outlet;
+import akka.stream.stage.AbstractInHandler;
+import akka.stream.stage.AbstractOutHandler;
+import akka.stream.stage.GraphStage;
+import akka.stream.stage.GraphStageLogic;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import datadog.trace.context.TraceScope;
+import java.util.Queue;
+import java.util.concurrent.ArrayBlockingQueue;
+
+public class DatadogServerRequestResponseFlowWrapper
+    extends GraphStage<BidiShape<HttpResponse, HttpResponse, HttpRequest, HttpRequest>> {
+  private final Inlet<HttpRequest> requestInlet = Inlet.create("Datadog.server.requestIn");
+  private final Outlet<HttpRequest> requestOutlet = Outlet.create("Datadog.server.requestOut");
+  private final Inlet<HttpResponse> responseInlet = Inlet.create("Datadog.server.responseIn");
+  private final Outlet<HttpResponse> responseOutlet = Outlet.create("Datadog.server.responseOut");
+  private final BidiShape<HttpResponse, HttpResponse, HttpRequest, HttpRequest> shape =
+      BidiShape.of(responseInlet, responseOutlet, requestInlet, requestOutlet);
+
+  private final int pipeliningLimit;
+
+  public DatadogServerRequestResponseFlowWrapper(final ServerSettings settings) {
+    this.pipeliningLimit = settings.getPipeliningLimit();
+  }
+
+  @Override
+  public BidiShape<HttpResponse, HttpResponse, HttpRequest, HttpRequest> shape() {
+    return shape;
+  }
+
+  @Override
+  public Attributes initialAttributes() {
+    return Attributes.name("DatadogServerRequestResponseFlowWrapper");
+  }
+
+  @Override
+  public GraphStageLogic createLogic(final Attributes inheritedAttributes) throws Exception {
+    return new GraphStageLogic(shape) {
+      {
+        // The is one instance of this logic per connection, and the request/response is
+        // guaranteed to be in order according to the docs at
+        // https://doc.akka.io/docs/akka-http/current/server-side/low-level-api.html#request-response-cycle
+        // and there can never be more outstanding requests than the pipeliningLimit
+        // that this connection was created with. This means that we can safely
+        // close the span at the front of the queue when we receive the response
+        // from the user code, since it will match up to the request for that span.
+        final Queue<AgentScope> scopes = new ArrayBlockingQueue<>(pipeliningLimit);
+
+        // This is where the request comes in from the server and TCP layer
+        setHandler(
+            requestInlet,
+            new AbstractInHandler() {
+              @Override
+              public void onPush() throws Exception {
+                final HttpRequest request = grab(requestInlet);
+                final AgentScope scope = DatadogWrapperHelper.createSpan(request);
+                scopes.add(scope);
+                push(requestOutlet, request);
+                // Since we haven't instrumented the akka stream state machine, we can't rely
+                // on spans and scopes being propagated during the push and pull of the
+                // element. Instead we let the scope leak intentionally here and clean it
+                // up when the user response comes back, or in the actor message processing
+                // instrumentation that drives this state machine.
+              }
+
+              @Override
+              public void onUpstreamFinish() throws Exception {
+                // We will not receive any more requests from the server and TCP layer so stop
+                // sending them
+                complete(requestOutlet);
+              }
+
+              @Override
+              public void onUpstreamFailure(final Throwable ex) throws Exception, Exception {
+                // We will not receive any more requests from the server and TCP layer so stop
+                // sending them
+                fail(requestOutlet, ex);
+              }
+            });
+
+        // This is where demand comes in from the user code
+        setHandler(
+            requestOutlet,
+            new AbstractOutHandler() {
+              @Override
+              public void onPull() throws Exception {
+                pull(requestInlet);
+              }
+
+              @Override
+              public void onDownstreamFinish() throws Exception {
+                // We can not send out any more requests to the user code so stop receiving them
+                cancel(requestInlet);
+              }
+            });
+
+        // This is where the response comes back from the user code
+        setHandler(
+            responseInlet,
+            new AbstractInHandler() {
+              @Override
+              public void onPush() throws Exception {
+                final HttpResponse response = grab(responseInlet);
+                final AgentScope scope = scopes.poll();
+                if (scope != null) {
+                  DatadogWrapperHelper.finishSpan(scope.span(), response);
+                  // Check if the active scope is still the scope from when the request came in,
+                  // and close it. If it's not, then it will be cleaned up actor message
+                  // processing instrumentation that drives this state machine
+                  TraceScope activeScope = activeScope();
+                  if (activeScope == scope) {
+                    scope.close();
+                  }
+                }
+                push(responseOutlet, response);
+              }
+
+              @Override
+              public void onUpstreamFinish() throws Exception {
+                // We will not receive any more responses from the user code, so clean up any
+                // remaining spans
+                AgentScope scope = scopes.poll();
+                while (scope != null) {
+                  scope.span().finish();
+                  scope = scopes.poll();
+                }
+                completeStage();
+              }
+
+              @Override
+              public void onUpstreamFailure(final Throwable ex) throws Exception {
+                AgentScope scope = scopes.poll();
+                if (scope != null) {
+                  // Mark the span as failed
+                  DatadogWrapperHelper.finishSpan(scope.span(), ex);
+                }
+                // We will not receive any more responses from the user code, so clean up any
+                // remaining spans
+                scope = scopes.poll();
+                while (scope != null) {
+                  scope.span().finish();
+                  scope = scopes.poll();
+                }
+                fail(responseOutlet, ex);
+              }
+            });
+
+        // This is where demand comes in from the server and TCP layer
+        setHandler(
+            responseOutlet,
+            new AbstractOutHandler() {
+              @Override
+              public void onPull() throws Exception {
+                pull(responseInlet);
+              }
+
+              @Override
+              public void onDownstreamFinish() throws Exception {
+                // We can not send out any more responses to the server and TCP layer so stop
+                // receiving them
+                cancel(responseInlet);
+              }
+            });
+      }
+    };
+  }
+}

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/DatadogWrapperHelper.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/DatadogWrapperHelper.java
@@ -1,0 +1,45 @@
+package datadog.trace.instrumentation.akkahttp;
+
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+import static datadog.trace.instrumentation.akkahttp.AkkaHttpServerDecorator.AKKA_REQUEST;
+import static datadog.trace.instrumentation.akkahttp.AkkaHttpServerDecorator.DECORATE;
+import static datadog.trace.instrumentation.akkahttp.AkkaHttpServerHeaders.GETTER;
+
+import akka.http.scaladsl.model.HttpRequest;
+import akka.http.scaladsl.model.HttpResponse;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.Tags;
+
+public class DatadogWrapperHelper {
+  public static AgentScope createSpan(final HttpRequest request) {
+    final AgentSpan.Context extractedContext = propagate().extract(request, GETTER);
+    final AgentSpan span = startSpan(AKKA_REQUEST, extractedContext);
+    span.setMeasured(true);
+
+    DECORATE.afterStart(span);
+    DECORATE.onConnection(span, request);
+    DECORATE.onRequest(span, request);
+
+    final AgentScope scope = activateSpan(span);
+    scope.setAsyncPropagation(true);
+    return scope;
+  }
+
+  public static void finishSpan(final AgentSpan span, final HttpResponse response) {
+    DECORATE.onResponse(span, response);
+    DECORATE.beforeFinish(span);
+
+    span.finish();
+  }
+
+  public static void finishSpan(final AgentSpan span, final Throwable t) {
+    DECORATE.onError(span, t);
+    span.setTag(Tags.HTTP_STATUS, 500);
+    DECORATE.beforeFinish(span);
+
+    span.finish();
+  }
+}

--- a/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientInstrumentation.java
@@ -4,11 +4,9 @@ import static datadog.trace.agent.tooling.ClassLoaderMatcher.hasClassesNamed;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers.implementsInterface;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.apachehttpasyncclient.ApacheHttpAsyncClientDecorator.DECORATE;
 import static datadog.trace.instrumentation.apachehttpasyncclient.ApacheHttpAsyncClientDecorator.HTTP_REQUEST;
-import static datadog.trace.instrumentation.apachehttpasyncclient.HttpHeadersInjectAdapter.SETTER;
 import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
@@ -18,18 +16,12 @@ import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.context.TraceScope;
-import java.io.IOException;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
-import org.apache.http.HttpException;
-import org.apache.http.HttpHost;
-import org.apache.http.HttpRequest;
 import org.apache.http.concurrent.FutureCallback;
-import org.apache.http.nio.ContentEncoder;
-import org.apache.http.nio.IOControl;
 import org.apache.http.nio.protocol.HttpAsyncRequestProducer;
 import org.apache.http.protocol.HttpContext;
 
@@ -55,8 +47,8 @@ public class ApacheHttpAsyncClientInstrumentation extends Instrumenter.Tracing {
   public String[] helperClassNames() {
     return new String[] {
       packageName + ".HttpHeadersInjectAdapter",
-      getClass().getName() + "$DelegatingRequestProducer",
-      getClass().getName() + "$TraceContinuedFutureCallback",
+      packageName + ".DelegatingRequestProducer",
+      packageName + ".TraceContinuedFutureCallback",
       packageName + ".ApacheHttpAsyncClientDecorator"
     };
   }
@@ -103,153 +95,6 @@ public class ApacheHttpAsyncClientInstrumentation extends Instrumenter.Tracing {
         DECORATE.onError(span, throwable);
         DECORATE.beforeFinish(span);
         span.finish();
-      }
-    }
-  }
-
-  public static class DelegatingRequestProducer implements HttpAsyncRequestProducer {
-    final AgentSpan span;
-    final HttpAsyncRequestProducer delegate;
-
-    public DelegatingRequestProducer(
-        final AgentSpan span, final HttpAsyncRequestProducer delegate) {
-      this.span = span;
-      this.delegate = delegate;
-    }
-
-    @Override
-    public HttpHost getTarget() {
-      return delegate.getTarget();
-    }
-
-    @Override
-    public HttpRequest generateRequest() throws IOException, HttpException {
-      final HttpRequest request = delegate.generateRequest();
-      DECORATE.onRequest(span, request);
-
-      propagate().inject(span, request, SETTER);
-
-      return request;
-    }
-
-    @Override
-    public void produceContent(final ContentEncoder encoder, final IOControl ioctrl)
-        throws IOException {
-      delegate.produceContent(encoder, ioctrl);
-    }
-
-    @Override
-    public void requestCompleted(final HttpContext context) {
-      delegate.requestCompleted(context);
-    }
-
-    @Override
-    public void failed(final Exception ex) {
-      delegate.failed(ex);
-    }
-
-    @Override
-    public boolean isRepeatable() {
-      return delegate.isRepeatable();
-    }
-
-    @Override
-    public void resetRequest() throws IOException {
-      delegate.resetRequest();
-    }
-
-    @Override
-    public void close() throws IOException {
-      delegate.close();
-    }
-  }
-
-  public static class TraceContinuedFutureCallback<T> implements FutureCallback<T> {
-    private final TraceScope.Continuation parentContinuation;
-    private final AgentSpan clientSpan;
-    private final HttpContext context;
-    private final FutureCallback<T> delegate;
-
-    public TraceContinuedFutureCallback(
-        final TraceScope parentScope,
-        final AgentSpan clientSpan,
-        final HttpContext context,
-        final FutureCallback<T> delegate) {
-      if (parentScope != null) {
-        parentContinuation = parentScope.capture();
-      } else {
-        parentContinuation = null;
-      }
-      this.clientSpan = clientSpan;
-      this.context = context;
-      // Note: this can be null in real life, so we have to handle this carefully
-      this.delegate = delegate;
-    }
-
-    @Override
-    public void completed(final T result) {
-      DECORATE.onResponse(clientSpan, context);
-      DECORATE.beforeFinish(clientSpan);
-      clientSpan.finish(); // Finish span before calling delegate
-
-      if (parentContinuation == null) {
-        completeDelegate(result);
-      } else {
-        try (final TraceScope scope = parentContinuation.activate()) {
-          scope.setAsyncPropagation(true);
-          completeDelegate(result);
-        }
-      }
-    }
-
-    @Override
-    public void failed(final Exception ex) {
-      DECORATE.onResponse(clientSpan, context);
-      DECORATE.onError(clientSpan, ex);
-      DECORATE.beforeFinish(clientSpan);
-      clientSpan.finish(); // Finish span before calling delegate
-
-      if (parentContinuation == null) {
-        failDelegate(ex);
-      } else {
-        try (final TraceScope scope = parentContinuation.activate()) {
-          scope.setAsyncPropagation(true);
-          failDelegate(ex);
-        }
-      }
-    }
-
-    @Override
-    public void cancelled() {
-      DECORATE.onResponse(clientSpan, context);
-      DECORATE.beforeFinish(clientSpan);
-      clientSpan.finish(); // Finish span before calling delegate
-
-      if (parentContinuation == null) {
-        cancelDelegate();
-      } else {
-        try (final TraceScope scope = parentContinuation.activate()) {
-          scope.setAsyncPropagation(true);
-          cancelDelegate();
-        }
-      }
-    }
-
-    private void completeDelegate(final T result) {
-      if (delegate != null) {
-        delegate.completed(result);
-      }
-    }
-
-    private void failDelegate(final Exception ex) {
-      if (delegate != null) {
-        delegate.failed(ex);
-      }
-    }
-
-    private void cancelDelegate() {
-      if (delegate != null) {
-        delegate.cancelled();
       }
     }
   }

--- a/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/DelegatingRequestProducer.java
+++ b/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/DelegatingRequestProducer.java
@@ -1,0 +1,71 @@
+package datadog.trace.instrumentation.apachehttpasyncclient;
+
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
+import static datadog.trace.instrumentation.apachehttpasyncclient.ApacheHttpAsyncClientDecorator.DECORATE;
+import static datadog.trace.instrumentation.apachehttpasyncclient.HttpHeadersInjectAdapter.SETTER;
+
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import java.io.IOException;
+import org.apache.http.HttpException;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpRequest;
+import org.apache.http.nio.ContentEncoder;
+import org.apache.http.nio.IOControl;
+import org.apache.http.nio.protocol.HttpAsyncRequestProducer;
+import org.apache.http.protocol.HttpContext;
+
+public class DelegatingRequestProducer implements HttpAsyncRequestProducer {
+  final AgentSpan span;
+  final HttpAsyncRequestProducer delegate;
+
+  public DelegatingRequestProducer(final AgentSpan span, final HttpAsyncRequestProducer delegate) {
+    this.span = span;
+    this.delegate = delegate;
+  }
+
+  @Override
+  public HttpHost getTarget() {
+    return delegate.getTarget();
+  }
+
+  @Override
+  public HttpRequest generateRequest() throws IOException, HttpException {
+    final HttpRequest request = delegate.generateRequest();
+    DECORATE.onRequest(span, request);
+
+    propagate().inject(span, request, SETTER);
+
+    return request;
+  }
+
+  @Override
+  public void produceContent(final ContentEncoder encoder, final IOControl ioctrl)
+      throws IOException {
+    delegate.produceContent(encoder, ioctrl);
+  }
+
+  @Override
+  public void requestCompleted(final HttpContext context) {
+    delegate.requestCompleted(context);
+  }
+
+  @Override
+  public void failed(final Exception ex) {
+    delegate.failed(ex);
+  }
+
+  @Override
+  public boolean isRepeatable() {
+    return delegate.isRepeatable();
+  }
+
+  @Override
+  public void resetRequest() throws IOException {
+    delegate.resetRequest();
+  }
+
+  @Override
+  public void close() throws IOException {
+    delegate.close();
+  }
+}

--- a/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/TraceContinuedFutureCallback.java
+++ b/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/TraceContinuedFutureCallback.java
@@ -1,0 +1,98 @@
+package datadog.trace.instrumentation.apachehttpasyncclient;
+
+import static datadog.trace.instrumentation.apachehttpasyncclient.ApacheHttpAsyncClientDecorator.DECORATE;
+
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.context.TraceScope;
+import org.apache.http.concurrent.FutureCallback;
+import org.apache.http.protocol.HttpContext;
+
+public class TraceContinuedFutureCallback<T> implements FutureCallback<T> {
+  private final TraceScope.Continuation parentContinuation;
+  private final AgentSpan clientSpan;
+  private final HttpContext context;
+  private final FutureCallback<T> delegate;
+
+  public TraceContinuedFutureCallback(
+      final TraceScope parentScope,
+      final AgentSpan clientSpan,
+      final HttpContext context,
+      final FutureCallback<T> delegate) {
+    if (parentScope != null) {
+      parentContinuation = parentScope.capture();
+    } else {
+      parentContinuation = null;
+    }
+    this.clientSpan = clientSpan;
+    this.context = context;
+    // Note: this can be null in real life, so we have to handle this carefully
+    this.delegate = delegate;
+  }
+
+  @Override
+  public void completed(final T result) {
+    DECORATE.onResponse(clientSpan, context);
+    DECORATE.beforeFinish(clientSpan);
+    clientSpan.finish(); // Finish span before calling delegate
+
+    if (parentContinuation == null) {
+      completeDelegate(result);
+    } else {
+      try (final TraceScope scope = parentContinuation.activate()) {
+        scope.setAsyncPropagation(true);
+        completeDelegate(result);
+      }
+    }
+  }
+
+  @Override
+  public void failed(final Exception ex) {
+    DECORATE.onResponse(clientSpan, context);
+    DECORATE.onError(clientSpan, ex);
+    DECORATE.beforeFinish(clientSpan);
+    clientSpan.finish(); // Finish span before calling delegate
+
+    if (parentContinuation == null) {
+      failDelegate(ex);
+    } else {
+      try (final TraceScope scope = parentContinuation.activate()) {
+        scope.setAsyncPropagation(true);
+        failDelegate(ex);
+      }
+    }
+  }
+
+  @Override
+  public void cancelled() {
+    DECORATE.onResponse(clientSpan, context);
+    DECORATE.beforeFinish(clientSpan);
+    clientSpan.finish(); // Finish span before calling delegate
+
+    if (parentContinuation == null) {
+      cancelDelegate();
+    } else {
+      try (final TraceScope scope = parentContinuation.activate()) {
+        scope.setAsyncPropagation(true);
+        cancelDelegate();
+      }
+    }
+  }
+
+  private void completeDelegate(final T result) {
+    if (delegate != null) {
+      delegate.completed(result);
+    }
+  }
+
+  private void failDelegate(final Exception ex) {
+    if (delegate != null) {
+      delegate.failed(ex);
+    }
+  }
+
+  private void cancelDelegate() {
+    if (delegate != null) {
+      delegate.cancelled();
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/apache-httpclient-4/src/main/java/datadog/trace/instrumentation/apachehttpclient/ApacheHttpClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/apache-httpclient-4/src/main/java/datadog/trace/instrumentation/apachehttpclient/ApacheHttpClientInstrumentation.java
@@ -3,8 +3,6 @@ package datadog.trace.instrumentation.apachehttpclient;
 import static datadog.trace.agent.tooling.ClassLoaderMatcher.hasClassesNamed;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers.implementsInterface;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static net.bytebuddy.matcher.ElementMatchers.isAbstract;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.not;
@@ -15,7 +13,6 @@ import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.bootstrap.CallDepthThreadLocalMap;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
-
 import java.util.HashMap;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
@@ -268,5 +265,4 @@ public class ApacheHttpClientInstrumentation extends Instrumenter.Tracing {
       HelperMethods.doMethodExit(scope, result, throwable);
     }
   }
-
 }

--- a/dd-java-agent/instrumentation/apache-httpclient-4/src/main/java/datadog/trace/instrumentation/apachehttpclient/HelperMethods.java
+++ b/dd-java-agent/instrumentation/apache-httpclient-4/src/main/java/datadog/trace/instrumentation/apachehttpclient/HelperMethods.java
@@ -32,7 +32,7 @@ public class HelperMethods {
   }
 
   public static void doMethodExit(
-    final AgentScope scope, final Object result, final Throwable throwable) {
+      final AgentScope scope, final Object result, final Throwable throwable) {
     if (scope == null) {
       return;
     }

--- a/dd-java-agent/instrumentation/apache-httpclient-4/src/main/java/datadog/trace/instrumentation/apachehttpclient/HelperMethods.java
+++ b/dd-java-agent/instrumentation/apache-httpclient-4/src/main/java/datadog/trace/instrumentation/apachehttpclient/HelperMethods.java
@@ -1,0 +1,53 @@
+package datadog.trace.instrumentation.apachehttpclient;
+
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+import static datadog.trace.instrumentation.apachehttpclient.ApacheHttpClientDecorator.DECORATE;
+import static datadog.trace.instrumentation.apachehttpclient.ApacheHttpClientDecorator.HTTP_REQUEST;
+import static datadog.trace.instrumentation.apachehttpclient.HttpHeadersInjectAdapter.SETTER;
+
+import datadog.trace.bootstrap.CallDepthThreadLocalMap;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpUriRequest;
+
+public class HelperMethods {
+  public static AgentScope doMethodEnter(final HttpUriRequest request) {
+    final AgentSpan span = startSpan(HTTP_REQUEST);
+    span.setMeasured(true);
+    final AgentScope scope = activateSpan(span);
+
+    DECORATE.afterStart(span);
+    DECORATE.onRequest(span, request);
+
+    final boolean awsClientCall = request.getHeaders("amz-sdk-invocation-id").length > 0;
+    // AWS calls are often signed, so we can't add headers without breaking the signature.
+    if (!awsClientCall) {
+      propagate().inject(span, request, SETTER);
+    }
+    return scope;
+  }
+
+  public static void doMethodExit(
+    final AgentScope scope, final Object result, final Throwable throwable) {
+    if (scope == null) {
+      return;
+    }
+    final AgentSpan span = scope.span();
+    try {
+      if (result instanceof HttpResponse) {
+        DECORATE.onResponse(span, (HttpResponse) result);
+      } // else they probably provided a ResponseHandler.
+
+      DECORATE.onError(span, throwable);
+      DECORATE.beforeFinish(span);
+    } finally {
+      scope.close();
+      span.finish();
+      CallDepthThreadLocalMap.reset(HttpClient.class);
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/apache-httpclient-4/src/main/java/datadog/trace/instrumentation/apachehttpclient/WrappingStatusSettingResponseHandler.java
+++ b/dd-java-agent/instrumentation/apache-httpclient-4/src/main/java/datadog/trace/instrumentation/apachehttpclient/WrappingStatusSettingResponseHandler.java
@@ -3,25 +3,23 @@ package datadog.trace.instrumentation.apachehttpclient;
 import static datadog.trace.instrumentation.apachehttpclient.ApacheHttpClientDecorator.DECORATE;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import java.io.IOException;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.ResponseHandler;
-
-import java.io.IOException;
 
 public class WrappingStatusSettingResponseHandler implements ResponseHandler {
   final AgentSpan span;
   final ResponseHandler handler;
 
-  public WrappingStatusSettingResponseHandler(
-    final AgentSpan span, final ResponseHandler handler) {
+  public WrappingStatusSettingResponseHandler(final AgentSpan span, final ResponseHandler handler) {
     this.span = span;
     this.handler = handler;
   }
 
   @Override
   public Object handleResponse(final HttpResponse response)
-    throws ClientProtocolException, IOException {
+      throws ClientProtocolException, IOException {
     if (null != span) {
       DECORATE.onResponse(span, response);
     }

--- a/dd-java-agent/instrumentation/apache-httpclient-4/src/main/java/datadog/trace/instrumentation/apachehttpclient/WrappingStatusSettingResponseHandler.java
+++ b/dd-java-agent/instrumentation/apache-httpclient-4/src/main/java/datadog/trace/instrumentation/apachehttpclient/WrappingStatusSettingResponseHandler.java
@@ -1,0 +1,30 @@
+package datadog.trace.instrumentation.apachehttpclient;
+
+import static datadog.trace.instrumentation.apachehttpclient.ApacheHttpClientDecorator.DECORATE;
+
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.ResponseHandler;
+
+import java.io.IOException;
+
+public class WrappingStatusSettingResponseHandler implements ResponseHandler {
+  final AgentSpan span;
+  final ResponseHandler handler;
+
+  public WrappingStatusSettingResponseHandler(
+    final AgentSpan span, final ResponseHandler handler) {
+    this.span = span;
+    this.handler = handler;
+  }
+
+  @Override
+  public Object handleResponse(final HttpResponse response)
+    throws ClientProtocolException, IOException {
+    if (null != span) {
+      DECORATE.onResponse(span, response);
+    }
+    return handler.handleResponse(response);
+  }
+}

--- a/dd-java-agent/instrumentation/finatra-2.9/src/main/java/datadog/trace/instrumentation/finatra/Listener.java
+++ b/dd-java-agent/instrumentation/finatra-2.9/src/main/java/datadog/trace/instrumentation/finatra/Listener.java
@@ -1,0 +1,36 @@
+package datadog.trace.instrumentation.finatra;
+
+import static datadog.trace.instrumentation.finatra.FinatraDecorator.DECORATE;
+
+import com.twitter.finagle.http.Response;
+import com.twitter.util.FutureEventListener;
+import datadog.trace.api.Config;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+
+public class Listener implements FutureEventListener<Response> {
+  private final AgentScope scope;
+
+  public Listener(final AgentScope scope) {
+    this.scope = scope;
+  }
+
+  @Override
+  public void onSuccess(final Response response) {
+    // Don't use DECORATE.onResponse because this is the controller span
+    if (Config.get().getHttpServerErrorStatuses().get(DECORATE.status(response))) {
+      scope.span().setError(true);
+    }
+
+    DECORATE.beforeFinish(scope.span());
+    scope.span().finish();
+    scope.close();
+  }
+
+  @Override
+  public void onFailure(final Throwable cause) {
+    DECORATE.onError(scope.span(), cause);
+    DECORATE.beforeFinish(scope.span());
+    scope.span().finish();
+    scope.close();
+  }
+}

--- a/dd-java-agent/instrumentation/grizzly-2/src/main/java/datadog/trace/instrumentation/grizzly/GrizzlyHttpHandlerInstrumentation.java
+++ b/dd-java-agent/instrumentation/grizzly-2/src/main/java/datadog/trace/instrumentation/grizzly/GrizzlyHttpHandlerInstrumentation.java
@@ -24,7 +24,6 @@ import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
-import org.glassfish.grizzly.http.server.AfterServiceListener;
 import org.glassfish.grizzly.http.server.Request;
 
 @AutoService(Instrumenter.class)
@@ -50,7 +49,7 @@ public class GrizzlyHttpHandlerInstrumentation extends Instrumenter.Tracing {
       packageName + ".GrizzlyDecorator",
       packageName + ".GrizzlyRequestExtractAdapter",
       packageName + ".RequestURIDataAdapter",
-      getClass().getName() + "$SpanClosingListener"
+      packageName + ".SpanClosingListener"
     };
   }
 
@@ -105,22 +104,6 @@ public class GrizzlyHttpHandlerInstrumentation extends Instrumenter.Tracing {
       }
       scope.close();
       // span finished by SpanClosingListener
-    }
-  }
-
-  public static class SpanClosingListener implements AfterServiceListener {
-    public static final SpanClosingListener LISTENER = new SpanClosingListener();
-
-    @Override
-    public void onAfterService(final Request request) {
-      final Object spanAttr = request.getAttribute(DD_SPAN_ATTRIBUTE);
-      if (spanAttr instanceof AgentSpan) {
-        request.removeAttribute(DD_SPAN_ATTRIBUTE);
-        final AgentSpan span = (AgentSpan) spanAttr;
-        DECORATE.onResponse(span, request.getResponse());
-        DECORATE.beforeFinish(span);
-        span.finish();
-      }
     }
   }
 }

--- a/dd-java-agent/instrumentation/grizzly-2/src/main/java/datadog/trace/instrumentation/grizzly/SpanClosingListener.java
+++ b/dd-java-agent/instrumentation/grizzly-2/src/main/java/datadog/trace/instrumentation/grizzly/SpanClosingListener.java
@@ -1,0 +1,24 @@
+package datadog.trace.instrumentation.grizzly;
+
+import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.DD_SPAN_ATTRIBUTE;
+import static datadog.trace.instrumentation.grizzly.GrizzlyDecorator.DECORATE;
+
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import org.glassfish.grizzly.http.server.AfterServiceListener;
+import org.glassfish.grizzly.http.server.Request;
+
+public class SpanClosingListener implements AfterServiceListener {
+  public static final SpanClosingListener LISTENER = new SpanClosingListener();
+
+  @Override
+  public void onAfterService(final Request request) {
+    final Object spanAttr = request.getAttribute(DD_SPAN_ATTRIBUTE);
+    if (spanAttr instanceof AgentSpan) {
+      request.removeAttribute(DD_SPAN_ATTRIBUTE);
+      final AgentSpan span = (AgentSpan) spanAttr;
+      DECORATE.onResponse(span, request.getResponse());
+      DECORATE.beforeFinish(span);
+      span.finish();
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/jax-rs-annotations-2/src/main/java/datadog/trace/instrumentation/jaxrs2/AbstractRequestContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/jax-rs-annotations-2/src/main/java/datadog/trace/instrumentation/jaxrs2/AbstractRequestContextInstrumentation.java
@@ -3,22 +3,13 @@ package datadog.trace.instrumentation.jaxrs2;
 import static datadog.trace.agent.tooling.ClassLoaderMatcher.hasClassesNamed;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers.implementsInterface;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
-import static datadog.trace.instrumentation.jaxrs2.JaxRsAnnotationsDecorator.DECORATE;
-import static datadog.trace.instrumentation.jaxrs2.JaxRsAnnotationsDecorator.JAX_RS_REQUEST_ABORT;
 import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import datadog.trace.agent.tooling.Instrumenter;
-import datadog.trace.bootstrap.instrumentation.api.AgentScope;
-import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import java.lang.reflect.Method;
 import java.util.Map;
-import javax.ws.rs.container.ContainerRequestContext;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
@@ -46,7 +37,7 @@ public abstract class AbstractRequestContextInstrumentation extends Instrumenter
       "datadog.trace.agent.tooling.ClassHierarchyIterable$ClassIterator",
       packageName + ".JaxRsAnnotationsDecorator",
       packageName + ".JaxRsAnnotationsDecorator$1",
-      AbstractRequestContextInstrumentation.class.getName() + "$RequestFilterHelper",
+      packageName + ".RequestFilterHelper",
     };
   }
 
@@ -58,53 +49,5 @@ public abstract class AbstractRequestContextInstrumentation extends Instrumenter
             .and(takesArguments(1))
             .and(takesArgument(0, named("javax.ws.rs.core.Response"))),
         getClass().getName() + "$ContainerRequestContextAdvice");
-  }
-
-  public static class RequestFilterHelper {
-    public static AgentScope createOrUpdateAbortSpan(
-        final ContainerRequestContext context, final Class resourceClass, final Method method) {
-
-      if (method != null && resourceClass != null) {
-        context.setProperty(JaxRsAnnotationsDecorator.ABORT_HANDLED, true);
-        // The ordering of the specific and general abort instrumentation is unspecified
-        // The general instrumentation (ContainerRequestFilterInstrumentation) saves spans
-        // properties if it ran first
-        AgentSpan parent = (AgentSpan) context.getProperty(JaxRsAnnotationsDecorator.ABORT_PARENT);
-        AgentSpan span = (AgentSpan) context.getProperty(JaxRsAnnotationsDecorator.ABORT_SPAN);
-
-        if (span == null) {
-          parent = activeSpan();
-          span = startSpan(JAX_RS_REQUEST_ABORT);
-
-          final AgentScope scope = activateSpan(span);
-          scope.setAsyncPropagation(true);
-
-          DECORATE.afterStart(span);
-          DECORATE.onJaxRsSpan(span, parent, resourceClass, method);
-
-          return scope;
-        } else {
-          DECORATE.onJaxRsSpan(span, parent, resourceClass, method);
-          return null;
-        }
-      } else {
-        return null;
-      }
-    }
-
-    public static void closeSpanAndScope(final AgentScope scope, final Throwable throwable) {
-      if (scope == null) {
-        return;
-      }
-
-      final AgentSpan span = scope.span();
-      if (throwable != null) {
-        DECORATE.onError(span, throwable);
-      }
-
-      DECORATE.beforeFinish(span);
-      scope.close();
-      span.finish();
-    }
   }
 }

--- a/dd-java-agent/instrumentation/jax-rs-annotations-2/src/main/java/datadog/trace/instrumentation/jaxrs2/RequestFilterHelper.java
+++ b/dd-java-agent/instrumentation/jax-rs-annotations-2/src/main/java/datadog/trace/instrumentation/jaxrs2/RequestFilterHelper.java
@@ -1,0 +1,60 @@
+package datadog.trace.instrumentation.jaxrs2;
+
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+import static datadog.trace.instrumentation.jaxrs2.JaxRsAnnotationsDecorator.DECORATE;
+import static datadog.trace.instrumentation.jaxrs2.JaxRsAnnotationsDecorator.JAX_RS_REQUEST_ABORT;
+
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import java.lang.reflect.Method;
+import javax.ws.rs.container.ContainerRequestContext;
+
+public class RequestFilterHelper {
+  public static AgentScope createOrUpdateAbortSpan(
+      final ContainerRequestContext context, final Class resourceClass, final Method method) {
+
+    if (method != null && resourceClass != null) {
+      context.setProperty(JaxRsAnnotationsDecorator.ABORT_HANDLED, true);
+      // The ordering of the specific and general abort instrumentation is unspecified
+      // The general instrumentation (ContainerRequestFilterInstrumentation) saves spans
+      // properties if it ran first
+      AgentSpan parent = (AgentSpan) context.getProperty(JaxRsAnnotationsDecorator.ABORT_PARENT);
+      AgentSpan span = (AgentSpan) context.getProperty(JaxRsAnnotationsDecorator.ABORT_SPAN);
+
+      if (span == null) {
+        parent = activeSpan();
+        span = startSpan(JAX_RS_REQUEST_ABORT);
+
+        final AgentScope scope = activateSpan(span);
+        scope.setAsyncPropagation(true);
+
+        DECORATE.afterStart(span);
+        DECORATE.onJaxRsSpan(span, parent, resourceClass, method);
+
+        return scope;
+      } else {
+        DECORATE.onJaxRsSpan(span, parent, resourceClass, method);
+        return null;
+      }
+    } else {
+      return null;
+    }
+  }
+
+  public static void closeSpanAndScope(final AgentScope scope, final Throwable throwable) {
+    if (scope == null) {
+      return;
+    }
+
+    final AgentSpan span = scope.span();
+    if (throwable != null) {
+      DECORATE.onError(span, throwable);
+    }
+
+    DECORATE.beforeFinish(span);
+    scope.close();
+    span.finish();
+  }
+}

--- a/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/ChannelPipelineAdviceUtil.java
+++ b/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/ChannelPipelineAdviceUtil.java
@@ -1,0 +1,62 @@
+package datadog.trace.instrumentation.netty38;
+
+import datadog.trace.bootstrap.CallDepthThreadLocalMap;
+import datadog.trace.bootstrap.ContextStore;
+import datadog.trace.instrumentation.netty38.client.HttpClientRequestTracingHandler;
+import datadog.trace.instrumentation.netty38.client.HttpClientResponseTracingHandler;
+import datadog.trace.instrumentation.netty38.client.HttpClientTracingHandler;
+import datadog.trace.instrumentation.netty38.server.HttpServerRequestTracingHandler;
+import datadog.trace.instrumentation.netty38.server.HttpServerResponseTracingHandler;
+import datadog.trace.instrumentation.netty38.server.HttpServerTracingHandler;
+import org.jboss.netty.channel.Channel;
+import org.jboss.netty.channel.ChannelHandler;
+import org.jboss.netty.channel.ChannelPipeline;
+import org.jboss.netty.handler.codec.http.HttpClientCodec;
+import org.jboss.netty.handler.codec.http.HttpRequestDecoder;
+import org.jboss.netty.handler.codec.http.HttpRequestEncoder;
+import org.jboss.netty.handler.codec.http.HttpResponseDecoder;
+import org.jboss.netty.handler.codec.http.HttpResponseEncoder;
+import org.jboss.netty.handler.codec.http.HttpServerCodec;
+
+/**
+ * When certain handlers are added to the pipeline, we want to add our corresponding tracing
+ * handlers. If those handlers are later removed, we may want to remove our handlers. That is not
+ * currently implemented.
+ */
+public class ChannelPipelineAdviceUtil {
+  public static void wrapHandler(
+      final ContextStore<Channel, ChannelTraceContext> contextStore,
+      final ChannelPipeline pipeline,
+      final ChannelHandler handler) {
+    try {
+      // Server pipeline handlers
+      if (handler instanceof HttpServerCodec) {
+        pipeline.addLast(
+            HttpServerTracingHandler.class.getName(), new HttpServerTracingHandler(contextStore));
+      } else if (handler instanceof HttpRequestDecoder) {
+        pipeline.addLast(
+            HttpServerRequestTracingHandler.class.getName(),
+            new HttpServerRequestTracingHandler(contextStore));
+      } else if (handler instanceof HttpResponseEncoder) {
+        pipeline.addLast(
+            HttpServerResponseTracingHandler.class.getName(),
+            new HttpServerResponseTracingHandler(contextStore));
+      } else
+      // Client pipeline handlers
+      if (handler instanceof HttpClientCodec) {
+        pipeline.addLast(
+            HttpClientTracingHandler.class.getName(), new HttpClientTracingHandler(contextStore));
+      } else if (handler instanceof HttpRequestEncoder) {
+        pipeline.addLast(
+            HttpClientRequestTracingHandler.class.getName(),
+            new HttpClientRequestTracingHandler(contextStore));
+      } else if (handler instanceof HttpResponseDecoder) {
+        pipeline.addLast(
+            HttpClientResponseTracingHandler.class.getName(),
+            new HttpClientResponseTracingHandler(contextStore));
+      }
+    } finally {
+      CallDepthThreadLocalMap.reset(ChannelPipeline.class);
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/rediscala-1.8.0/src/main/java/datadog/trace/instrumentation/rediscala/OnCompleteHandler.java
+++ b/dd-java-agent/instrumentation/rediscala-1.8.0/src/main/java/datadog/trace/instrumentation/rediscala/OnCompleteHandler.java
@@ -1,0 +1,34 @@
+package datadog.trace.instrumentation.rediscala;
+
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
+import static datadog.trace.instrumentation.rediscala.RediscalaClientDecorator.DECORATE;
+
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.context.TraceScope;
+import scala.runtime.AbstractFunction1;
+import scala.util.Try;
+
+public class OnCompleteHandler extends AbstractFunction1<Try<Object>, Void> {
+  private final AgentSpan span;
+
+  public OnCompleteHandler(final AgentSpan span) {
+    this.span = span;
+  }
+
+  @Override
+  public Void apply(final Try<Object> result) {
+    try {
+      if (result.isFailure()) {
+        DECORATE.onError(span, result.failed().get());
+      }
+      DECORATE.beforeFinish(span);
+      final TraceScope scope = activeScope();
+      if (scope != null) {
+        scope.setAsyncPropagation(false);
+      }
+    } finally {
+      span.finish();
+    }
+    return null;
+  }
+}

--- a/dd-java-agent/instrumentation/spring-data-1.8/src/main/java/datadog/trace/instrumentation/springdata/InterceptingRepositoryProxyPostProcessor.java
+++ b/dd-java-agent/instrumentation/spring-data-1.8/src/main/java/datadog/trace/instrumentation/springdata/InterceptingRepositoryProxyPostProcessor.java
@@ -1,0 +1,24 @@
+package datadog.trace.instrumentation.springdata;
+
+import org.springframework.aop.framework.ProxyFactory;
+import org.springframework.data.repository.core.RepositoryInformation;
+import org.springframework.data.repository.core.support.RepositoryProxyPostProcessor;
+
+public final class InterceptingRepositoryProxyPostProcessor
+    implements RepositoryProxyPostProcessor {
+  public static final RepositoryProxyPostProcessor INSTANCE =
+      new InterceptingRepositoryProxyPostProcessor();
+
+  // DQH - TODO: Support older versions?
+  // The signature of postProcess changed to add RepositoryInformation in
+  // spring-data-commons 1.9.0
+  // public void postProcess(final ProxyFactory factory) {
+  //   factory.addAdvice(0, RepositoryInterceptor.INSTANCE);
+  // }
+
+  @Override
+  public void postProcess(
+      final ProxyFactory factory, final RepositoryInformation repositoryInformation) {
+    factory.addAdvice(0, RepositoryInterceptor.INSTANCE);
+  }
+}

--- a/dd-java-agent/instrumentation/spring-data-1.8/src/main/java/datadog/trace/instrumentation/springdata/RepositoryInterceptor.java
+++ b/dd-java-agent/instrumentation/spring-data-1.8/src/main/java/datadog/trace/instrumentation/springdata/RepositoryInterceptor.java
@@ -1,0 +1,52 @@
+package datadog.trace.instrumentation.springdata;
+
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+import static datadog.trace.instrumentation.springdata.SpringDataDecorator.DECORATOR;
+import static datadog.trace.instrumentation.springdata.SpringDataDecorator.REPOSITORY_OPERATION;
+
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import java.lang.reflect.Method;
+import org.aopalliance.intercept.MethodInterceptor;
+import org.aopalliance.intercept.MethodInvocation;
+import org.springframework.data.repository.Repository;
+
+final class RepositoryInterceptor implements MethodInterceptor {
+  public static final MethodInterceptor INSTANCE = new RepositoryInterceptor();
+
+  private RepositoryInterceptor() {}
+
+  @Override
+  public Object invoke(final MethodInvocation methodInvocation) throws Throwable {
+    final Method invokedMethod = methodInvocation.getMethod();
+    final Class<?> clazz = invokedMethod.getDeclaringClass();
+
+    final boolean isRepositoryOp = Repository.class.isAssignableFrom(clazz);
+    // Since this interceptor is the outer most interceptor, non-Repository methods
+    // including Object methods will also flow through here.  Don't create spans for those.
+    if (!isRepositoryOp) {
+      return methodInvocation.proceed();
+    }
+
+    final AgentSpan span = startSpan(REPOSITORY_OPERATION);
+    DECORATOR.afterStart(span);
+    DECORATOR.onOperation(span, invokedMethod);
+
+    final AgentScope scope = activateSpan(span);
+    scope.setAsyncPropagation(true);
+
+    Object result = null;
+    try {
+      result = methodInvocation.proceed();
+    } catch (final Throwable t) {
+      DECORATOR.onError(scope, t);
+      throw t;
+    } finally {
+      DECORATOR.beforeFinish(scope);
+      scope.close();
+      span.finish();
+    }
+    return result;
+  }
+}

--- a/dd-smoke-tests/agent-isolation/agent-isolation.gradle
+++ b/dd-smoke-tests/agent-isolation/agent-isolation.gradle
@@ -1,0 +1,46 @@
+plugins {
+  id "com.github.johnrengelman.shadow" version "5.2.0"
+}
+
+ext {
+  minJavaVersionForTests = JavaVersion.VERSION_1_8
+}
+
+description = 'Check declaring instrumentation classes do not leak to other agents'
+apply from: "$rootDir/gradle/java.gradle"
+
+task appJar(type: Jar, dependsOn: classes) {
+  archiveBaseName = "app"
+  from sourceSets.main.output
+  manifest {
+    attributes('Main-Class': 'datadog.smoketest.agentisolation.App')
+  }
+  include('datadog\\smoketest\\agentisolation\\App.class')
+}
+
+task agentJar(type: Jar, dependsOn: classes) {
+  archiveBaseName = "agent"
+  from sourceSets.main.output
+  manifest {
+    attributes('Premain-Class': 'datadog.smoketest.agentisolation.Agent')
+  }
+  include('datadog\\smoketest\\agentisolation\\Agent.class')
+}
+
+dependencies {
+  implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.13'
+  testCompile project(':dd-smoke-tests')
+}
+
+shadowJar {
+  exclude 'datadog\\smoketest\\agentisolation\\Agent.class'
+  manifest.inheritFrom project.tasks.appJar.manifest
+}
+
+tasks.withType(Test).configureEach {
+  dependsOn tasks.named("shadowJar")
+  dependsOn tasks.named("agentJar")
+
+  jvmArgs "-Ddatadog.smoketest.agentisolation.appJar.path=${tasks.shadowJar.archivePath}"
+  jvmArgs "-Ddatadog.smoketest.agentisolation.agentJar.path=${tasks.agentJar.archivePath}"
+}

--- a/dd-smoke-tests/agent-isolation/src/main/java/datadog/smoketest/agentisolation/Agent.java
+++ b/dd-smoke-tests/agent-isolation/src/main/java/datadog/smoketest/agentisolation/Agent.java
@@ -1,0 +1,24 @@
+package datadog.smoketest.agentisolation;
+
+import java.lang.instrument.Instrumentation;
+
+public class Agent {
+
+  public static void premain(String args, Instrumentation instrumentation) {
+    // load the classes which trigger datadog instrumentation first
+    for (String className : args.split(",")) {
+      try {
+        System.err.println("Loading" + Class.forName(className).getName());
+      } catch (ClassNotFoundException e) {
+        e.printStackTrace(System.err);
+      }
+    }
+    for (Class<?> klass : instrumentation.getAllLoadedClasses()) {
+      try {
+        System.err.println(klass.getSimpleName());
+      } catch (Throwable t) {
+        System.err.println("___ERROR____:" + klass.getName());
+      }
+    }
+  }
+}

--- a/dd-smoke-tests/agent-isolation/src/main/java/datadog/smoketest/agentisolation/App.java
+++ b/dd-smoke-tests/agent-isolation/src/main/java/datadog/smoketest/agentisolation/App.java
@@ -1,6 +1,5 @@
 package datadog.smoketest.agentisolation;
 
 public class App {
-  public static void main(String... args) {
-  }
+  public static void main(String... args) {}
 }

--- a/dd-smoke-tests/agent-isolation/src/main/java/datadog/smoketest/agentisolation/App.java
+++ b/dd-smoke-tests/agent-isolation/src/main/java/datadog/smoketest/agentisolation/App.java
@@ -1,0 +1,6 @@
+package datadog.smoketest.agentisolation;
+
+public class App {
+  public static void main(String... args) {
+  }
+}

--- a/dd-smoke-tests/agent-isolation/src/test/groovy/datadog/smoketest/AgentIsolationSmokeTest.groovy
+++ b/dd-smoke-tests/agent-isolation/src/test/groovy/datadog/smoketest/AgentIsolationSmokeTest.groovy
@@ -1,0 +1,66 @@
+package datadog.smoketest
+
+
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Timeout
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.ForkJoinTask
+import java.util.concurrent.FutureTask
+import java.util.concurrent.TimeUnit
+
+class AgentIsolationSmokeTest extends Specification {
+
+  String javaPath() {
+    final String separator = System.getProperty("file.separator")
+    return System.getProperty("java.home") + separator + "bin" + separator + "java"
+  }
+
+  @Shared
+  protected String buildDirectory = System.getProperty("datadog.smoketest.builddir")
+  @Shared
+  protected String shadowJarPath = System.getProperty("datadog.smoketest.agent.shadowJar.path")
+
+  @Timeout(value = 20, unit = TimeUnit.SECONDS)
+  def "other agents can safely call Class.getSimpleName() on loaded instrumentation classes"() {
+    setup:
+    // force transformation of instrumented types
+    def triggerTypes = ["org.apache.http.impl.client.MinimalHttpClient", ForkJoinTask.getName(), FutureTask.getName()]
+    String app = System.getProperty("datadog.smoketest.agentisolation.appJar.path")
+    String agent = System.getProperty("datadog.smoketest.agentisolation.agentJar.path")
+    List<String> command = new ArrayList<>()
+    command.add(javaPath())
+    command.add("-javaagent:${shadowJarPath}" as String)
+    command.add("-javaagent:${agent}=${triggerTypes.join(",")}" as String)
+    command.add("-XX:ErrorFile=/tmp/hs_err_pid%p.log")
+    command.add("-Ddd.writer.type=TraceStructureWriter")
+    command.add("-Ddd.trace.debug=true")
+    command.add("-jar")
+    command.add(app)
+    for (String type : triggerTypes) {
+      command.add(type)
+    }
+    ProcessBuilder processBuilder = new ProcessBuilder(command)
+    processBuilder.directory(new File(buildDirectory))
+    processBuilder.environment().put("JAVA_HOME", System.getProperty("java.home"))
+
+    Path testOutput = Files.createTempFile("output", "tmp")
+    processBuilder.redirectError(testOutput.toFile())
+    Process testedProcess = processBuilder.start()
+
+    expect:
+    testedProcess.waitFor() == 0
+    List<String> lines = Files.readAllLines(testOutput)
+
+    Set<String> errors = new HashSet<>()
+    for (String line : lines) {
+      if (line.startsWith("___ERROR____")) {
+        String[] parts = line.split(":")
+        errors.add(parts[1])
+      }
+    }
+    assert errors.isEmpty()
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -55,6 +55,7 @@ include ':utils:histograms'
 include ':utils:test-utils'
 
 // smoke tests
+include ':dd-smoke-tests:agent-isolation'
 include ':dd-smoke-tests:cli'
 include ':dd-smoke-tests:field-injection'
 include ':dd-smoke-tests:java9-modules'


### PR DESCRIPTION
Because some of `ApacheHttpClientInstrumentation`'s helper classes, which are visible to the application classloader are nested, but their enclosing class `ApacheHttpClientInstrumentation` is not made visible to the target classloader, calling `Class.getSimpleName` throws `NoClassDefFoundError`

```java
  @Override
  public String[] helperClassNames() {
    return new String[] {
      packageName + ".ApacheHttpClientDecorator",
      packageName + ".HttpHeadersInjectAdapter",
      packageName + ".HostAndRequestAsHttpUriRequest",
      getClass().getName() + "$HelperMethods",
      getClass().getName() + "$WrappingStatusSettingResponseHandler",
    };
  }
```