### PR TITLE
metrics performance

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/config/GeneralConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/GeneralConfig.java
@@ -33,6 +33,8 @@ public final class GeneralConfig {
   public static final String PERF_METRICS_ENABLED = "trace.perf.metrics.enabled";
 
   public static final String TRACER_METRICS_ENABLED = "trace.tracer.metrics.enabled";
+  public static final String TRACER_METRICS_BUFFERING_ENABLED =
+      "trace.tracer.metrics.buffering.enabled";
   public static final String TRACER_METRICS_MAX_AGGREGATES = "trace.tracer.metrics.max.aggregates";
   public static final String TRACER_METRICS_MAX_PENDING = "trace.tracer.metrics.max.pending";
 

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/ConflatingMetricsAggregator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/ConflatingMetricsAggregator.java
@@ -36,7 +36,10 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
   public ConflatingMetricsAggregator(Config config) {
     this(
         config.getWellKnownTags(),
-        new OkHttpSink(config.getAgentUrl(), config.getAgentTimeout()),
+        new OkHttpSink(
+            config.getAgentUrl(),
+            config.getAgentTimeout(),
+            config.isTracerMetricsBufferingEnabled()),
         config.getTracerMetricsMaxAggregates(),
         config.getTracerMetricsMaxPending());
   }

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/MetricKey.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/MetricKey.java
@@ -1,5 +1,7 @@
 package datadog.trace.common.metrics;
 
+import static datadog.trace.bootstrap.instrumentation.api.UTF8BytesString.EMPTY;
+
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import java.util.Objects;
 
@@ -17,10 +19,10 @@ public final class MetricKey {
       CharSequence operationName,
       CharSequence type,
       int httpStatusCode) {
-    this.resource = UTF8BytesString.create(null == resource ? "" : resource);
-    this.service = UTF8BytesString.create(null == service ? "" : service);
-    this.operationName = UTF8BytesString.create(null == operationName ? "" : operationName);
-    this.type = UTF8BytesString.create(null == type ? "" : type);
+    this.resource = null == resource ? EMPTY : UTF8BytesString.create(resource);
+    this.service = null == service ? EMPTY : UTF8BytesString.create(service);
+    this.operationName = null == operationName ? EMPTY : UTF8BytesString.create(operationName);
+    this.type = null == type ? EMPTY : UTF8BytesString.create(type);
     this.httpStatusCode = httpStatusCode;
   }
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/AgentIntegrationTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/AgentIntegrationTest.groovy
@@ -16,7 +16,7 @@ class AgentIntegrationTest extends DDSpecification {
   def "send metrics to trace agent should notify with OK event"() {
     setup:
     def listener = Mock(EventListener)
-    OkHttpSink sink = new OkHttpSink("http://localhost:8126", 5000L)
+    OkHttpSink sink = new OkHttpSink("http://localhost:8126", 5000L, false)
     sink.register(listener)
 
     when:

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/OkHttpSinkTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/OkHttpSinkTest.groovy
@@ -31,7 +31,7 @@ class OkHttpSinkTest extends DDSpecification {
     String path = "v0.5/stats"
     EventListener listener = Mock(EventListener)
     OkHttpClient client = Mock(OkHttpClient)
-    OkHttpSink sink = new OkHttpSink(client, agentUrl, path)
+    OkHttpSink sink = new OkHttpSink(client, agentUrl, path, true)
     sink.register(listener)
 
     when:
@@ -66,7 +66,7 @@ class OkHttpSinkTest extends DDSpecification {
     EventListener listener = new BlockingListener(latch)
     OkHttpClient client = Mock(OkHttpClient)
     OkHttpSink sink = new OkHttpSink(client, agentUrl, path,
-      TimeUnit.MILLISECONDS.toNanos(100))
+      TimeUnit.MILLISECONDS.toNanos(100), true)
     sink.register(listener)
     AtomicBoolean first = new AtomicBoolean(true)
 

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -59,6 +59,7 @@ import static datadog.trace.api.DDTags.SERVICE_TAG;
 import static datadog.trace.api.IdGenerationStrategy.RANDOM;
 import static datadog.trace.api.Platform.isJavaVersionAtLeast;
 import static datadog.trace.api.config.GeneralConfig.RUNTIME_METRICS_ENABLED;
+import static datadog.trace.api.config.GeneralConfig.TRACER_METRICS_BUFFERING_ENABLED;
 import static datadog.trace.api.config.GeneralConfig.TRACER_METRICS_ENABLED;
 import static datadog.trace.api.config.GeneralConfig.TRACER_METRICS_MAX_AGGREGATES;
 import static datadog.trace.api.config.GeneralConfig.TRACER_METRICS_MAX_PENDING;
@@ -345,6 +346,7 @@ public class Config {
   @Getter private final boolean perfMetricsEnabled;
 
   @Getter private final boolean tracerMetricsEnabled;
+  @Getter private final boolean tracerMetricsBufferingEnabled;
   @Getter private final int tracerMetricsMaxAggregates;
   @Getter private final int tracerMetricsMaxPending;
 
@@ -627,6 +629,8 @@ public class Config {
 
     tracerMetricsEnabled =
         isJavaVersionAtLeast(8) && configProvider.getBoolean(TRACER_METRICS_ENABLED, false);
+    tracerMetricsBufferingEnabled =
+        configProvider.getBoolean(TRACER_METRICS_BUFFERING_ENABLED, false);
     tracerMetricsMaxAggregates = configProvider.getInteger(TRACER_METRICS_MAX_AGGREGATES, 1000);
     tracerMetricsMaxPending = configProvider.getInteger(TRACER_METRICS_MAX_PENDING, 2048);
 

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/UTF8BytesString.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/UTF8BytesString.java
@@ -10,6 +10,8 @@ import java.nio.ByteBuffer;
  */
 public final class UTF8BytesString implements CharSequence {
 
+  public static final UTF8BytesString EMPTY = UTF8BytesString.create("");
+
   @Deprecated
   public static UTF8BytesString createConstant(CharSequence string) {
     return create(string);

--- a/utils/histograms/src/main/java/datadog/trace/core/histogram/DDSketchHistogram.java
+++ b/utils/histograms/src/main/java/datadog/trace/core/histogram/DDSketchHistogram.java
@@ -1,8 +1,8 @@
 package datadog.trace.core.histogram;
 
 import com.datadoghq.sketch.ddsketch.DDSketch;
-import com.datadoghq.sketch.ddsketch.mapping.CubicallyInterpolatedMapping;
-import com.datadoghq.sketch.ddsketch.store.PaginatedStore;
+import com.datadoghq.sketch.ddsketch.mapping.BitwiseLinearlyInterpolatedMapping;
+import com.datadoghq.sketch.ddsketch.store.CollapsingLowestDenseStore;
 import java.nio.ByteBuffer;
 
 public final class DDSketchHistogram implements Histogram, HistogramFactory {
@@ -10,7 +10,10 @@ public final class DDSketchHistogram implements Histogram, HistogramFactory {
   private final DDSketch sketch;
 
   public DDSketchHistogram() {
-    this.sketch = new DDSketch(new CubicallyInterpolatedMapping(0.01), PaginatedStore::new);
+    this.sketch =
+        new DDSketch(
+            new BitwiseLinearlyInterpolatedMapping(0.01),
+            () -> new CollapsingLowestDenseStore(1024));
   }
 
   @Override

--- a/utils/histograms/src/test/groovy/DDSketchHistogramTest.groovy
+++ b/utils/histograms/src/test/groovy/DDSketchHistogramTest.groovy
@@ -1,0 +1,90 @@
+import datadog.trace.core.histogram.Histogram
+import datadog.trace.core.histogram.Histograms
+import datadog.trace.test.util.DDSpecification
+import spock.lang.Shared
+
+import java.util.concurrent.ThreadLocalRandom
+
+class DDSketchHistogramTest extends DDSpecification {
+
+  @Shared
+  SplittableRandom seededRandom = new SplittableRandom(0)
+
+  @Shared
+  def poisson = { List<Double> params ->
+    return -Math.log(seededRandom.nextDouble()) / params[0]
+  }
+
+  @Shared
+  def uniform = { List<Double> params ->
+    double min = params[0]
+    double max = params[1]
+    return min + (seededRandom.nextDouble() * (max - min))
+  }
+
+  @Shared
+  def normal = { List<Double> params ->
+    double mean = params[0]
+    double stddev = params[1]
+    return mean + ThreadLocalRandom.current().nextGaussian() * stddev
+  }
+
+  @Shared
+  Double[] quantiles = [0.5D, 0.75D, 0.9D, 0.95D, 0.99D]
+
+  def "test quantiles have 1% relative error"() {
+    setup:
+    Histogram histogram = Histograms.newHistogramFactory().newHistogram()
+    when:
+    long[] data = sortedRandomData(size) {
+      scenario(params)
+    }
+    for (long value : data) {
+      histogram.accept(value)
+    }
+
+    then:
+    for (double quantile : quantiles) {
+      double relativeError = relativeError(histogram.valueAtQuantile(quantile), empiricalQuantile(data, quantile))
+      assert relativeError < 0.01
+    }
+
+    where:
+    scenario   |   size   | params
+    poisson    |   10000  | [0.01D]
+    poisson    |   100000 | [0.01D]
+    poisson    |   10000  | [0.1D]
+    poisson    |   100000 | [0.1D]
+    poisson    |   10000  | [0.99D]
+    poisson    |   100000 | [0.99D]
+    uniform    |   10000  | [1D, 200D]
+    uniform    |   100000 | [1D, 200D]
+    uniform    |   10000  | [1000D, 2000D]
+    uniform    |   100000 | [1000D, 2000D]
+    normal     |   10000  | [1000D, 10D]
+    normal     |   100000 | [1000D, 10D]
+    normal     |   10000  | [10000D, 100D]
+    normal     |   100000 | [10000D, 100D]
+  }
+
+  def relativeError(double value, double expected) {
+    if (Math.abs(expected) < 1e-5) {
+      return 0.0
+    }
+    return Math.abs(value - expected) / expected
+  }
+
+  double empiricalQuantile(long[] sortedData, double quantile) {
+    return sortedData[(int) (quantile * sortedData.length)]
+  }
+
+  long[] sortedRandomData(int size, Closure<Double> distribution) {
+    long[] data = new long[size]
+    for (int i = 0; i < size; ++i) {
+      data[i] = (long)distribution()
+    }
+    Arrays.sort(data)
+    return data
+  }
+
+}


### PR DESCRIPTION
* micro-optimisation on allocations in `MetricKey` - avoid allocating the UTF-8 encoding of the empty string
* Make it possible to _enable_ buffering when the agent is slow to respond - disable by default
* Change sketch mode to collapse from below, add statistical tests to verify this change is valid while maintaining 1% relative error in the relevant quantiles