### PR TITLE
bump trace agent image and enable integration test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,11 +175,12 @@ jobs:
     <<: *default_test_job
     docker:
       - image: *default_container
-      - image: datadog/agent:7.22.0
+      - image: datadog/agent:7.25.0-rc.10
         environment:
           - DD_APM_ENABLED=true
           - DD_BIND_HOST=0.0.0.0
           - DD_API_KEY=invalid_key_but_this_is_fine
+          - DD_APM_FEATURES=client_stats
 
   check:
     <<: *defaults

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/AgentIntegrationTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/AgentIntegrationTest.groovy
@@ -2,13 +2,11 @@ package datadog.trace.common.metrics
 
 import datadog.trace.api.WellKnownTags
 import datadog.trace.test.util.DDSpecification
-import spock.lang.Ignore
 import spock.lang.Requires
 
 import static datadog.trace.api.Platform.isJavaVersionAtLeast
 import static java.util.concurrent.TimeUnit.SECONDS
 
-@Ignore("requires an upgrade to an as yet unreleased agent to run")
 @Requires({ "true" == System.getenv("CI") && isJavaVersionAtLeast(8) })
 class AgentIntegrationTest extends DDSpecification {
 


### PR DESCRIPTION
This will fail because I have found that the trace agent does not implement DDSketch deserialisation correctly.