### PR TITLE
provide API to allow concurrent modification of arrays, and CAS operations on fields, with JVM version dependent implementations

### DIFF
--- a/dd-trace-core/dd-trace-core.gradle
+++ b/dd-trace-core/dd-trace-core.gradle
@@ -32,6 +32,8 @@ testSets {
 dependencies {
   compile project(':dd-trace-api')
   compile project(':internal-api')
+  compile project(':utils:unsafe')
+  compile project(':utils:varhandles')
   compile project(':utils:histograms')
   compile project(':utils:container-utils')
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/TestLoadCorrectConcurrentArrayOperations.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/TestLoadCorrectConcurrentArrayOperations.groovy
@@ -1,0 +1,23 @@
+package datadog.trace.core
+
+import datadog.trace.api.Platform
+import datadog.trace.core.unsafe.UnsafeConcurrentArrayOperations
+import datadog.trace.core.varhandles.VarHandleConcurrentArrayOperations
+import datadog.trace.test.util.DDSpecification
+import datadog.trace.unsafe.ConcurrentArrayOperations
+
+class TestLoadCorrectConcurrentArrayOperations extends DDSpecification {
+
+  def "unsafe concurrent array operations are not loaded on JDK9+"() {
+    // test this in core because neither unsafe nor varhandles can be
+    // loaded from internal-api itself
+    when:
+    ConcurrentArrayOperations ops = Platform.concurrentArrayOperations()
+    then:
+    if (Platform.isJavaVersionAtLeast(9)) {
+      ops instanceof VarHandleConcurrentArrayOperations
+    } else {
+      ops instanceof UnsafeConcurrentArrayOperations
+    }
+  }
+}

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/TestLoadCorrectConcurrentOperations.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/TestLoadCorrectConcurrentOperations.groovy
@@ -7,7 +7,6 @@ import datadog.trace.core.unsafe.UnsafeConcurrentArrayOperations
 import datadog.trace.core.varhandles.VarHandleCAS
 import datadog.trace.core.varhandles.VarHandleConcurrentArrayOperations
 import datadog.trace.test.util.DDSpecification
-import datadog.trace.unsafe.ReferenceCAS
 import datadog.trace.unsafe.ConcurrentArrayOperations
 
 class TestLoadCorrectConcurrentOperations extends DDSpecification {
@@ -26,13 +25,17 @@ class TestLoadCorrectConcurrentOperations extends DDSpecification {
   }
 
   def "unsafe CAS are not loaded on JDK9+"() {
-    when:
-    ReferenceCAS<String> cas = Platform.createReferenceCAS(TestObject, "testField", String)
-    then:
+    expect:
+    assertCorrectImplementationLoaded(Platform.createReferenceCAS(TestObject, "testField", String))
+    assertCorrectImplementationLoaded(Platform.createIntCAS(TestObject, "intField"))
+    assertCorrectImplementationLoaded(Platform.createLongCAS(TestObject, "longField"))
+  }
+
+  boolean assertCorrectImplementationLoaded(Object cas) {
     if (Platform.isJavaVersionAtLeast(9)) {
-      cas instanceof VarHandleCAS
+      return cas instanceof VarHandleCAS
     } else {
-      cas instanceof UnsafeCAS
+      return cas instanceof UnsafeCAS
     }
   }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/TestLoadCorrectConcurrentOperations.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/TestLoadCorrectConcurrentOperations.groovy
@@ -1,12 +1,16 @@
 package datadog.trace.core
 
+import datadog.trace.TestObject
 import datadog.trace.api.Platform
+import datadog.trace.core.unsafe.UnsafeCAS
 import datadog.trace.core.unsafe.UnsafeConcurrentArrayOperations
+import datadog.trace.core.varhandles.VarHandleCAS
 import datadog.trace.core.varhandles.VarHandleConcurrentArrayOperations
 import datadog.trace.test.util.DDSpecification
+import datadog.trace.unsafe.ReferenceCAS
 import datadog.trace.unsafe.ConcurrentArrayOperations
 
-class TestLoadCorrectConcurrentArrayOperations extends DDSpecification {
+class TestLoadCorrectConcurrentOperations extends DDSpecification {
 
   def "unsafe concurrent array operations are not loaded on JDK9+"() {
     // test this in core because neither unsafe nor varhandles can be
@@ -18,6 +22,17 @@ class TestLoadCorrectConcurrentArrayOperations extends DDSpecification {
       ops instanceof VarHandleConcurrentArrayOperations
     } else {
       ops instanceof UnsafeConcurrentArrayOperations
+    }
+  }
+
+  def "unsafe CAS are not loaded on JDK9+"() {
+    when:
+    ReferenceCAS<String> cas = Platform.createReferenceCAS(TestObject, "testField", String)
+    then:
+    if (Platform.isJavaVersionAtLeast(9)) {
+      cas instanceof VarHandleCAS
+    } else {
+      cas instanceof UnsafeCAS
     }
   }
 }

--- a/dd-trace-core/src/test/java/datadog/trace/TestObject.java
+++ b/dd-trace-core/src/test/java/datadog/trace/TestObject.java
@@ -2,4 +2,6 @@ package datadog.trace;
 
 public class TestObject {
   private String testField;
+  private int intField;
+  private long longField;
 }

--- a/dd-trace-core/src/test/java/datadog/trace/TestObject.java
+++ b/dd-trace-core/src/test/java/datadog/trace/TestObject.java
@@ -1,0 +1,5 @@
+package datadog.trace;
+
+public class TestObject {
+  private String testField;
+}

--- a/internal-api/internal-api.gradle
+++ b/internal-api/internal-api.gradle
@@ -18,6 +18,7 @@ excludedClassesCoverage += [
   "datadog.trace.bootstrap.instrumentation.api.AgentTracer.NoopAgentTrace",
   "datadog.trace.bootstrap.instrumentation.api.ScopeSource",
   "datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes",
+  "datadog.trace.api.Platform.ConcurrentArrayOperationsHolder",
   "datadog.trace.bootstrap.instrumentation.ci.git.GitInfo",
   "datadog.trace.bootstrap.instrumentation.ci.git.GitInfo.GitInfoBuilder",
   "datadog.trace.bootstrap.instrumentation.ci.git.CommitInfo",

--- a/internal-api/internal-api.gradle
+++ b/internal-api/internal-api.gradle
@@ -19,6 +19,7 @@ excludedClassesCoverage += [
   "datadog.trace.bootstrap.instrumentation.api.ScopeSource",
   "datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes",
   "datadog.trace.api.Platform.ConcurrentArrayOperationsHolder",
+  "datadog.trace.api.Platform", // tested in other modules
   "datadog.trace.bootstrap.instrumentation.ci.git.GitInfo",
   "datadog.trace.bootstrap.instrumentation.ci.git.GitInfo.GitInfoBuilder",
   "datadog.trace.bootstrap.instrumentation.ci.git.CommitInfo",

--- a/internal-api/src/main/java/datadog/trace/api/Platform.java
+++ b/internal-api/src/main/java/datadog/trace/api/Platform.java
@@ -58,65 +58,6 @@ public final class Platform {
     return ConcurrentOperationsHolder.CAS_FACTORY.createIntCAS(type, field);
   }
 
-  private static final class NonConcurrentArrayOperationsFallback
-      implements ConcurrentArrayOperations {
-
-    @Override
-    public Object getObjectVolatile(Object[] array, int index) {
-      return array[index];
-    }
-
-    @Override
-    public void putObjectVolatile(Object[] array, int index, Object x) {
-      array[index] = x;
-    }
-
-    @Override
-    public int getIntVolatile(int[] array, int index) {
-      return array[index];
-    }
-
-    @Override
-    public long getLongVolatile(long[] array, int index) {
-      return array[index];
-    }
-
-    @Override
-    public void putIntVolatile(int[] array, int index, int x) {
-      array[index] = x;
-    }
-
-    @Override
-    public boolean getBooleanVolatile(boolean[] array, int index) {
-      return array[index];
-    }
-
-    @Override
-    public void putBooleanVolatile(boolean[] array, int index, boolean x) {
-      array[index] = x;
-    }
-
-    @Override
-    public void putLongVolatile(long[] array, int index, long x) {
-      array[index] = x;
-    }
-
-    @Override
-    public void putOrderedObject(Object[] array, int index, Object x) {
-      array[index] = x;
-    }
-
-    @Override
-    public void putOrderedInt(int[] array, int index, int x) {
-      array[index] = x;
-    }
-
-    @Override
-    public void putOrderedLong(long[] array, int index, long x) {
-      array[index] = x;
-    }
-  }
-
   private static final class ConcurrentOperationsHolder {
     static final ConcurrentArrayOperations OPERATIONS;
     static final CASFactory CAS_FACTORY;
@@ -140,11 +81,9 @@ public final class Platform {
         }
       } catch (Throwable t) {
         log.debug(
-            "Unexpectedly could not load ConcurrentArrayOperations, falling back to default implementation without visibility guarantees",
+            "Unexpectedly could not load ConcurrentArrayOperations or CASFactory",
             t);
-        // Weird visibility bugs will likely follow from this,
-        // but the tracer will more or less function as expected
-        operations = new NonConcurrentArrayOperationsFallback();
+        operations = null;
         casFactory = null;
       }
       OPERATIONS = operations;

--- a/internal-api/src/main/java/datadog/trace/api/Platform.java
+++ b/internal-api/src/main/java/datadog/trace/api/Platform.java
@@ -1,14 +1,14 @@
 package datadog.trace.api;
 
+import datadog.trace.unsafe.ConcurrentArrayOperations;
 import datadog.trace.util.Strings;
+import java.lang.reflect.InvocationTargetException;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public final class Platform {
 
   private static final int JAVA_MAJOR_VERSION = getJavaMajorVersion();
-
-  public static boolean isJavaVersionAtLeast(int version) {
-    return JAVA_MAJOR_VERSION >= version;
-  }
 
   private static int getJavaMajorVersion() {
     return parseJavaVersion(System.getProperty("java.version"));
@@ -30,6 +30,113 @@ public final class Platform {
       }
     } catch (NumberFormatException e) {
       return 0;
+    }
+  }
+
+  public static boolean isJavaVersionAtLeast(int version) {
+    return JAVA_MAJOR_VERSION >= version;
+  }
+
+  public static ConcurrentArrayOperations concurrentArrayOperations() {
+    return ConcurrentArrayOperationsHolder.OPERATIONS;
+  }
+
+  private static final class NonConcurrentArrayOperationsFallback
+      implements ConcurrentArrayOperations {
+
+    @Override
+    public Object getObjectVolatile(Object[] array, int index) {
+      return array[index];
+    }
+
+    @Override
+    public void putObjectVolatile(Object[] array, int index, Object x) {
+      array[index] = x;
+    }
+
+    @Override
+    public int getIntVolatile(int[] array, int index) {
+      return array[index];
+    }
+
+    @Override
+    public long getLongVolatile(long[] array, int index) {
+      return array[index];
+    }
+
+    @Override
+    public void putIntVolatile(int[] array, int index, int x) {
+      array[index] = x;
+    }
+
+    @Override
+    public boolean getBooleanVolatile(boolean[] array, int index) {
+      return array[index];
+    }
+
+    @Override
+    public void putBooleanVolatile(boolean[] array, int index, boolean x) {
+      array[index] = x;
+    }
+
+    @Override
+    public void putLongVolatile(long[] array, int index, long x) {
+      array[index] = x;
+    }
+
+    @Override
+    public void putOrderedObject(Object[] array, int index, Object x) {
+      array[index] = x;
+    }
+
+    @Override
+    public void putOrderedInt(int[] array, int index, int x) {
+      array[index] = x;
+    }
+
+    @Override
+    public void putOrderedLong(long[] array, int index, long x) {
+      array[index] = x;
+    }
+  }
+
+  private static final class ConcurrentArrayOperationsHolder {
+    static final ConcurrentArrayOperations OPERATIONS;
+
+    static {
+      ConcurrentArrayOperations operations;
+      try {
+        if (isJavaVersionAtLeast(9)) {
+          // we need to avoid loading sun.misc.Unsafe after Java 9, because it logs
+          // the illegal access, which alarms users, and at some point in the future,
+          // it will become impossible to load.
+          operations =
+              loadAndInstantiate(
+                  "datadog.trace.core.varhandles.VarHandleConcurrentArrayOperations");
+        } else {
+          operations =
+              loadAndInstantiate("datadog.trace.core.unsafe.UnsafeConcurrentArrayOperations");
+        }
+      } catch (Throwable t) {
+        log.debug(
+            "Unexpectedly could not load ConcurrentArrayOperations, falling back to default implementation without visibility guarantees",
+            t);
+        // Weird visibility bugs will likely follow from this,
+        // but the tracer will more or less function as expected
+        operations = new NonConcurrentArrayOperationsFallback();
+      }
+      OPERATIONS = operations;
+    }
+
+    private static ConcurrentArrayOperations loadAndInstantiate(String className)
+        throws ClassNotFoundException, NoSuchMethodException, IllegalAccessException,
+            InvocationTargetException, InstantiationException {
+      return (ConcurrentArrayOperations)
+          ConcurrentArrayOperationsHolder.class
+              .getClassLoader()
+              .loadClass(className)
+              .getDeclaredConstructor()
+              .newInstance();
     }
   }
 }

--- a/internal-api/src/main/java/datadog/trace/unsafe/CASFactory.java
+++ b/internal-api/src/main/java/datadog/trace/unsafe/CASFactory.java
@@ -1,0 +1,10 @@
+package datadog.trace.unsafe;
+
+public interface CASFactory {
+
+  <T> ReferenceCAS<T> createReferenceCAS(Class<?> type, String fieldName, Class<T> fieldType);
+
+  LongCAS createLongCAS(Class<?> type, String fieldName);
+
+  IntCAS createIntCAS(Class<?> type, String fieldName);
+}

--- a/internal-api/src/main/java/datadog/trace/unsafe/ConcurrentArrayOperations.java
+++ b/internal-api/src/main/java/datadog/trace/unsafe/ConcurrentArrayOperations.java
@@ -1,0 +1,26 @@
+package datadog.trace.unsafe;
+
+public interface ConcurrentArrayOperations {
+
+  Object getObjectVolatile(Object[] array, int index);
+
+  void putObjectVolatile(Object[] array, int index, Object x);
+
+  int getIntVolatile(int[] array, int index);
+
+  void putIntVolatile(int[] array, int index, int x);
+
+  boolean getBooleanVolatile(boolean[] array, int index);
+
+  void putBooleanVolatile(boolean[] array, int index, boolean x);
+
+  long getLongVolatile(long[] array, int index);
+
+  void putLongVolatile(long[] array, int index, long x);
+
+  void putOrderedObject(Object[] array, int index, Object x);
+
+  void putOrderedInt(int[] array, int index, int x);
+
+  void putOrderedLong(long[] array, int index, long x);
+}

--- a/internal-api/src/main/java/datadog/trace/unsafe/IntCAS.java
+++ b/internal-api/src/main/java/datadog/trace/unsafe/IntCAS.java
@@ -1,0 +1,5 @@
+package datadog.trace.unsafe;
+
+public interface IntCAS {
+  boolean compareAndSet(Object holder, int expected, int newValue);
+}

--- a/internal-api/src/main/java/datadog/trace/unsafe/LongCAS.java
+++ b/internal-api/src/main/java/datadog/trace/unsafe/LongCAS.java
@@ -1,0 +1,5 @@
+package datadog.trace.unsafe;
+
+public interface LongCAS {
+  boolean compareAndSet(Object holder, long expected, long newValue);
+}

--- a/internal-api/src/main/java/datadog/trace/unsafe/ReferenceCAS.java
+++ b/internal-api/src/main/java/datadog/trace/unsafe/ReferenceCAS.java
@@ -1,0 +1,5 @@
+package datadog.trace.unsafe;
+
+public interface ReferenceCAS<T> {
+  boolean compareAndSet(Object holder, T expected, T newValue);
+}

--- a/internal-api/src/test/groovy/datadog/trace/api/PlatformTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/PlatformTest.groovy
@@ -42,34 +42,4 @@ class PlatformTest extends DDSpecification {
     "14"        | 14
     "15"        | 15
   }
-
-
-  def "test default concurrent array operations"() {
-    setup:
-    Object[] objects = new Object[2]
-    boolean[] booleans = new boolean[2]
-    int[] ints = new int[2]
-    long[] longs = new long[2]
-    when: "in the unlikely case that this class is loaded"
-    def arrayOperations = Platform.concurrentArrayOperations()
-    then: "it won't NPE"
-    null != arrayOperations
-    when: "it is used to set array values"
-    arrayOperations.putObjectVolatile(objects, 0, "foo")
-    arrayOperations.putOrderedObject(objects, 1, "bar")
-    arrayOperations.putBooleanVolatile(booleans, 0, true)
-    arrayOperations.putIntVolatile(ints, 0, 1)
-    arrayOperations.putIntVolatile(ints, 0, 1)
-    arrayOperations.putOrderedInt(ints, 1, 2)
-    arrayOperations.putLongVolatile(longs, 0, 1)
-    arrayOperations.putOrderedLong(longs, 1, 2)
-    then: "it behaves like normal array accesses"
-    arrayOperations.getObjectVolatile(objects, 0) == "foo"
-    arrayOperations.getObjectVolatile(objects, 1) == "bar"
-    arrayOperations.getBooleanVolatile(booleans, 0)
-    arrayOperations.getIntVolatile(ints, 0) == 1
-    arrayOperations.getIntVolatile(ints, 1) == 2
-    arrayOperations.getLongVolatile(longs, 0) == 1
-    arrayOperations.getLongVolatile(longs, 1) == 2
-  }
 }

--- a/internal-api/src/test/groovy/datadog/trace/api/PlatformTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/PlatformTest.groovy
@@ -43,4 +43,33 @@ class PlatformTest extends DDSpecification {
     "15"        | 15
   }
 
+
+  def "test default concurrent array operations"() {
+    setup:
+    Object[] objects = new Object[2]
+    boolean[] booleans = new boolean[2]
+    int[] ints = new int[2]
+    long[] longs = new long[2]
+    when: "in the unlikely case that this class is loaded"
+    def arrayOperations = Platform.concurrentArrayOperations()
+    then: "it won't NPE"
+    null != arrayOperations
+    when: "it is used to set array values"
+    arrayOperations.putObjectVolatile(objects, 0, "foo")
+    arrayOperations.putOrderedObject(objects, 1, "bar")
+    arrayOperations.putBooleanVolatile(booleans, 0, true)
+    arrayOperations.putIntVolatile(ints, 0, 1)
+    arrayOperations.putIntVolatile(ints, 0, 1)
+    arrayOperations.putOrderedInt(ints, 1, 2)
+    arrayOperations.putLongVolatile(longs, 0, 1)
+    arrayOperations.putOrderedLong(longs, 1, 2)
+    then: "it behaves like normal array accesses"
+    arrayOperations.getObjectVolatile(objects, 0) == "foo"
+    arrayOperations.getObjectVolatile(objects, 1) == "bar"
+    arrayOperations.getBooleanVolatile(booleans, 0)
+    arrayOperations.getIntVolatile(ints, 0) == 1
+    arrayOperations.getIntVolatile(ints, 1) == 2
+    arrayOperations.getLongVolatile(longs, 0) == 1
+    arrayOperations.getLongVolatile(longs, 1) == 2
+  }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -56,6 +56,8 @@ include ':dd-java-agent:testing'
 include ':utils:container-utils'
 include ':utils:histograms'
 include ':utils:test-utils'
+include ':utils:unsafe'
+include ':utils:varhandles'
 
 // smoke tests
 include ':dd-smoke-tests:agent-isolation'
@@ -228,3 +230,4 @@ def setBuildFile(project) {
 }
 
 setBuildFile(rootProject)
+

--- a/utils/unsafe/src/main/java/datadog/trace/core/unsafe/UnsafeAccess.java
+++ b/utils/unsafe/src/main/java/datadog/trace/core/unsafe/UnsafeAccess.java
@@ -1,0 +1,48 @@
+package datadog.trace.core.unsafe;
+
+import java.lang.reflect.Field;
+import sun.misc.Unsafe;
+
+final class UnsafeAccess {
+
+  static final Unsafe UNSAFE;
+  static final int OBJECT_ARRAY_OFFSET;
+  static final int LONG_ARRAY_OFFSET;
+  static final int INT_ARRAY_OFFSET;
+  static final int BOOLEAN_ARRAY_OFFSET;
+  private static final int ARRAY_ELEMENT_SHIFT;
+
+  static {
+    // Loading this class should be avoided from JDK9 onwards except in tests
+    Unsafe unsafe = null;
+    try {
+      Field f = Unsafe.class.getDeclaredField("theUnsafe");
+      f.setAccessible(true);
+      unsafe = (Unsafe) f.get(null);
+    } catch (Throwable ignore) {
+    }
+    UNSAFE = unsafe;
+    OBJECT_ARRAY_OFFSET = null == UNSAFE ? 0 : UNSAFE.arrayBaseOffset(Object[].class);
+    LONG_ARRAY_OFFSET = null == UNSAFE ? 0 : UNSAFE.arrayBaseOffset(long[].class);
+    INT_ARRAY_OFFSET = null == UNSAFE ? 0 : UNSAFE.arrayBaseOffset(int[].class);
+    BOOLEAN_ARRAY_OFFSET = null == UNSAFE ? 0 : UNSAFE.arrayBaseOffset(boolean[].class);
+    ARRAY_ELEMENT_SHIFT =
+        null == UNSAFE ? 0 : Integer.numberOfTrailingZeros(UNSAFE.arrayIndexScale(Object[].class));
+  }
+
+  static long objectArrayIndex(int index) {
+    return OBJECT_ARRAY_OFFSET + ((long) index << ARRAY_ELEMENT_SHIFT);
+  }
+
+  static long booleanArrayIndex(int index) {
+    return BOOLEAN_ARRAY_OFFSET + ((long) index);
+  }
+
+  static long intArrayIndex(int index) {
+    return INT_ARRAY_OFFSET + ((long) index << 2);
+  }
+
+  static long longArrayIndex(int index) {
+    return LONG_ARRAY_OFFSET + ((long) index << 3);
+  }
+}

--- a/utils/unsafe/src/main/java/datadog/trace/core/unsafe/UnsafeCAS.java
+++ b/utils/unsafe/src/main/java/datadog/trace/core/unsafe/UnsafeCAS.java
@@ -1,0 +1,32 @@
+package datadog.trace.core.unsafe;
+
+import static datadog.trace.core.unsafe.UnsafeAccess.UNSAFE;
+
+import datadog.trace.unsafe.IntCAS;
+import datadog.trace.unsafe.LongCAS;
+import datadog.trace.unsafe.ReferenceCAS;
+import java.lang.reflect.Field;
+
+public final class UnsafeCAS<T> implements ReferenceCAS<T>, IntCAS, LongCAS {
+
+  private final long offset;
+
+  public UnsafeCAS(Field field) {
+    this.offset = UNSAFE.objectFieldOffset(field);
+  }
+
+  @Override
+  public boolean compareAndSet(Object holder, int expected, int newValue) {
+    return UNSAFE.compareAndSwapInt(holder, offset, expected, newValue);
+  }
+
+  @Override
+  public boolean compareAndSet(Object holder, long expected, long newValue) {
+    return UNSAFE.compareAndSwapLong(holder, offset, expected, newValue);
+  }
+
+  @Override
+  public boolean compareAndSet(Object holder, T expected, T newValue) {
+    return UNSAFE.compareAndSwapObject(holder, offset, expected, newValue);
+  }
+}

--- a/utils/unsafe/src/main/java/datadog/trace/core/unsafe/UnsafeCASFactory.java
+++ b/utils/unsafe/src/main/java/datadog/trace/core/unsafe/UnsafeCASFactory.java
@@ -1,0 +1,40 @@
+package datadog.trace.core.unsafe;
+
+import datadog.trace.unsafe.CASFactory;
+import datadog.trace.unsafe.IntCAS;
+import datadog.trace.unsafe.LongCAS;
+import datadog.trace.unsafe.ReferenceCAS;
+import java.lang.reflect.Field;
+
+public class UnsafeCASFactory implements CASFactory {
+  @Override
+  public <T> ReferenceCAS<T> createReferenceCAS(
+      Class<?> type, String fieldName, Class<T> fieldType) {
+    return createUnsafeCAS(type, fieldName, fieldType);
+  }
+
+  @Override
+  public LongCAS createLongCAS(Class<?> type, String fieldName) {
+    return createUnsafeCAS(type, fieldName, long.class);
+  }
+
+  @Override
+  public IntCAS createIntCAS(Class<?> type, String fieldName) {
+    return createUnsafeCAS(type, fieldName, int.class);
+  }
+
+  private <T> UnsafeCAS<T> createUnsafeCAS(Class<?> type, String fieldName, Class<T> fieldType) {
+    try {
+      Field field = type.getDeclaredField(fieldName);
+      if (field.getType() != fieldType) {
+        throw new IllegalArgumentException(
+            "Trying to CAS field type: " + field.getType() + " as: " + fieldType);
+      }
+      return new UnsafeCAS<>(type.getDeclaredField(fieldName));
+    } catch (NoSuchFieldException e) {
+      // expected to be used as a static field initializer, so the
+      // failure to load the calling class would come out in testing
+      throw new IllegalArgumentException(e);
+    }
+  }
+}

--- a/utils/unsafe/src/main/java/datadog/trace/core/unsafe/UnsafeConcurrentArrayOperations.java
+++ b/utils/unsafe/src/main/java/datadog/trace/core/unsafe/UnsafeConcurrentArrayOperations.java
@@ -1,0 +1,67 @@
+package datadog.trace.core.unsafe;
+
+import static datadog.trace.core.unsafe.UnsafeAccess.UNSAFE;
+import static datadog.trace.core.unsafe.UnsafeAccess.booleanArrayIndex;
+import static datadog.trace.core.unsafe.UnsafeAccess.intArrayIndex;
+import static datadog.trace.core.unsafe.UnsafeAccess.longArrayIndex;
+import static datadog.trace.core.unsafe.UnsafeAccess.objectArrayIndex;
+
+import datadog.trace.unsafe.ConcurrentArrayOperations;
+
+public final class UnsafeConcurrentArrayOperations implements ConcurrentArrayOperations {
+
+  @Override
+  public Object getObjectVolatile(Object[] array, int index) {
+    return UNSAFE.getObjectVolatile(array, objectArrayIndex(index));
+  }
+
+  @Override
+  public void putObjectVolatile(Object[] array, int index, Object x) {
+    UNSAFE.putObjectVolatile(array, objectArrayIndex(index), x);
+  }
+
+  @Override
+  public int getIntVolatile(int[] array, int index) {
+    return UNSAFE.getIntVolatile(array, intArrayIndex(index));
+  }
+
+  @Override
+  public long getLongVolatile(long[] array, int index) {
+    return UNSAFE.getLongVolatile(array, longArrayIndex(index));
+  }
+
+  @Override
+  public void putIntVolatile(int[] array, int index, int x) {
+    UNSAFE.putIntVolatile(array, intArrayIndex(index), x);
+  }
+
+  @Override
+  public boolean getBooleanVolatile(boolean[] array, int index) {
+    return UNSAFE.getBooleanVolatile(array, booleanArrayIndex(index));
+  }
+
+  @Override
+  public void putBooleanVolatile(boolean[] array, int index, boolean x) {
+    UNSAFE.putBooleanVolatile(array, booleanArrayIndex(index), x);
+  }
+
+  @Override
+  public void putLongVolatile(long[] array, int index, long x) {
+    UNSAFE.putLongVolatile(array, longArrayIndex(index), x);
+  }
+
+  @Override
+  public void putOrderedObject(Object[] array, int index, Object x) {
+    UNSAFE.putOrderedObject(array, objectArrayIndex(index), x);
+  }
+
+  @Override
+  public void putOrderedInt(int[] array, int index, int x) {
+    UNSAFE.putOrderedInt(array, intArrayIndex(index), x);
+  }
+
+  @Override
+  public void putOrderedLong(long[] array, int index, long x) {
+    UNSAFE.putOrderedLong(array, longArrayIndex(index), x);
+  }
+}

--- a/utils/unsafe/src/test/groovy/TestUnsafeCAS.groovy
+++ b/utils/unsafe/src/test/groovy/TestUnsafeCAS.groovy
@@ -1,0 +1,48 @@
+import datadog.trace.core.unsafe.UnsafeCASFactory
+import datadog.trace.test.util.DDSpecification
+import datadog.trace.unsafe.IntCAS
+import datadog.trace.unsafe.ReferenceCAS
+
+class TestUnsafeCAS extends DDSpecification {
+
+  def "test unsafe CAS"() {
+    setup:
+    ObjectToCAS testObject = new ObjectToCAS()
+    def casFactory = new UnsafeCASFactory()
+
+    when:
+    testObject.stringField = "foo"
+    ReferenceCAS<String> casString = casFactory.createReferenceCAS(ObjectToCAS, "stringField", String)
+
+    then:
+    casString.compareAndSet(testObject, "foo", "bar")
+    !casString.compareAndSet(testObject, "foo", "bar")
+
+
+    when:
+    testObject.intField = 42
+    IntCAS casInt = casFactory.createIntCAS(ObjectToCAS, "intField")
+
+    then:
+    casInt.compareAndSet(testObject, 42, 43)
+    !casInt.compareAndSet(testObject, 42, 43)
+  }
+
+  def "field type mismatches are rejected"() {
+    setup:
+    def casFactory = new UnsafeCASFactory()
+    when:
+    casFactory.createReferenceCAS(ObjectToCAS, "stringField", List)
+    then:
+    thrown IllegalArgumentException
+  }
+
+  def "missing field are rejected"() {
+    setup:
+    def casFactory = new UnsafeCASFactory()
+    when:
+    casFactory.createReferenceCAS(ObjectToCAS, "missing", String)
+    then:
+    thrown IllegalArgumentException
+  }
+}

--- a/utils/unsafe/src/test/groovy/TestUnsafeConcurrentArrayOperations.groovy
+++ b/utils/unsafe/src/test/groovy/TestUnsafeConcurrentArrayOperations.groovy
@@ -1,0 +1,33 @@
+import datadog.trace.core.unsafe.UnsafeConcurrentArrayOperations
+import datadog.trace.test.util.DDSpecification
+
+class TestUnsafeConcurrentArrayOperations extends DDSpecification {
+
+  def "test unsafe concurrent array operations"() {
+    setup:
+    Object[] objects = new Object[2]
+    boolean[] booleans = new boolean[2]
+    int[] ints = new int[2]
+    long[] longs = new long[2]
+    def arrayOperations = new UnsafeConcurrentArrayOperations()
+
+    when: "it is used to set array values"
+    arrayOperations.putObjectVolatile(objects, 0, "foo")
+    arrayOperations.putOrderedObject(objects, 1, "bar")
+    arrayOperations.putBooleanVolatile(booleans, 0, true)
+    arrayOperations.putIntVolatile(ints, 0, 1)
+    arrayOperations.putIntVolatile(ints, 0, 1)
+    arrayOperations.putOrderedInt(ints, 1, 2)
+    arrayOperations.putLongVolatile(longs, 0, 1)
+    arrayOperations.putOrderedLong(longs, 1, 2)
+
+    then: "it behaves like normal array accesses"
+    arrayOperations.getObjectVolatile(objects, 0) == "foo"
+    arrayOperations.getObjectVolatile(objects, 1) == "bar"
+    arrayOperations.getBooleanVolatile(booleans, 0)
+    arrayOperations.getIntVolatile(ints, 0) == 1
+    arrayOperations.getIntVolatile(ints, 1) == 2
+    arrayOperations.getLongVolatile(longs, 0) == 1
+    arrayOperations.getLongVolatile(longs, 1) == 2
+  }
+}

--- a/utils/unsafe/src/test/java/ObjectToCAS.java
+++ b/utils/unsafe/src/test/java/ObjectToCAS.java
@@ -1,0 +1,7 @@
+public class ObjectToCAS {
+
+  // these all need to be public, which is a drawback of abstracting over varhandles
+  private String stringField;
+  private int intField;
+  private long longField;
+}

--- a/utils/unsafe/unsafe.gradle
+++ b/utils/unsafe/unsafe.gradle
@@ -1,0 +1,13 @@
+ext {
+  maxJavaVersionForTests = JavaVersion.VERSION_1_8
+}
+
+apply from: "$rootDir/gradle/java.gradle"
+
+minimumBranchCoverage = 0.7
+minimumInstructionCoverage = 0.7
+
+dependencies {
+  implementation project(':internal-api')
+  testCompile project(':utils:test-utils')
+}

--- a/utils/varhandles/src/main/java/datadog/trace/core/varhandles/VarHandleCAS.java
+++ b/utils/varhandles/src/main/java/datadog/trace/core/varhandles/VarHandleCAS.java
@@ -1,0 +1,35 @@
+package datadog.trace.core.varhandles;
+
+import datadog.trace.unsafe.IntCAS;
+import datadog.trace.unsafe.LongCAS;
+import datadog.trace.unsafe.ReferenceCAS;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+
+public final class VarHandleCAS<T> implements ReferenceCAS<T>, LongCAS, IntCAS {
+
+  private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
+
+  private final VarHandle varHandle;
+
+  public VarHandleCAS(Class<?> type, String fieldName, Class<T> fieldType)
+      throws NoSuchFieldException, IllegalAccessException {
+    this.varHandle =
+        MethodHandles.privateLookupIn(type, LOOKUP).findVarHandle(type, fieldName, fieldType);
+  }
+
+  @Override
+  public boolean compareAndSet(Object holder, Object expected, Object newValue) {
+    return varHandle.compareAndSet(holder, expected, newValue);
+  }
+
+  @Override
+  public boolean compareAndSet(Object holder, int expected, int newValue) {
+    return varHandle.compareAndSet(holder, expected, newValue);
+  }
+
+  @Override
+  public boolean compareAndSet(Object holder, long expected, long newValue) {
+    return varHandle.compareAndSet(holder, expected, newValue);
+  }
+}

--- a/utils/varhandles/src/main/java/datadog/trace/core/varhandles/VarHandleCASFactory.java
+++ b/utils/varhandles/src/main/java/datadog/trace/core/varhandles/VarHandleCASFactory.java
@@ -1,0 +1,33 @@
+package datadog.trace.core.varhandles;
+
+import datadog.trace.unsafe.CASFactory;
+import datadog.trace.unsafe.IntCAS;
+import datadog.trace.unsafe.LongCAS;
+import datadog.trace.unsafe.ReferenceCAS;
+
+public final class VarHandleCASFactory implements CASFactory {
+  @Override
+  public <T> ReferenceCAS<T> createReferenceCAS(
+      Class<?> type, String fieldName, Class<T> fieldType) {
+    return createVarHandleCAS(type, fieldName, fieldType);
+  }
+
+  @Override
+  public LongCAS createLongCAS(Class<?> type, String fieldName) {
+    return createVarHandleCAS(type, fieldName, long.class);
+  }
+
+  @Override
+  public IntCAS createIntCAS(Class<?> type, String fieldName) {
+    return createVarHandleCAS(type, fieldName, int.class);
+  }
+
+  private <T> VarHandleCAS<T> createVarHandleCAS(
+      Class<?> type, String fieldName, Class<T> fieldType) {
+    try {
+      return new VarHandleCAS<>(type, fieldName, fieldType);
+    } catch (Throwable error) {
+      throw new IllegalArgumentException(error);
+    }
+  }
+}

--- a/utils/varhandles/src/main/java/datadog/trace/core/varhandles/VarHandleConcurrentArrayOperations.java
+++ b/utils/varhandles/src/main/java/datadog/trace/core/varhandles/VarHandleConcurrentArrayOperations.java
@@ -1,0 +1,72 @@
+package datadog.trace.core.varhandles;
+
+import datadog.trace.unsafe.ConcurrentArrayOperations;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+
+public final class VarHandleConcurrentArrayOperations implements ConcurrentArrayOperations {
+
+  private static final VarHandle BOOLEAN_ARRAY_VAR_HANDLE =
+      MethodHandles.arrayElementVarHandle(boolean[].class);
+  private static final VarHandle INT_ARRAY_VAR_HANDLE =
+      MethodHandles.arrayElementVarHandle(int[].class);
+  private static final VarHandle LONG_ARRAY_VAR_HANDLE =
+      MethodHandles.arrayElementVarHandle(long[].class);
+  private static final VarHandle OBJECT_ARRAY_VAR_HANDLE =
+      MethodHandles.arrayElementVarHandle(Object[].class);
+
+  @Override
+  public Object getObjectVolatile(Object[] array, int index) {
+    return OBJECT_ARRAY_VAR_HANDLE.getVolatile(array, index);
+  }
+
+  @Override
+  public void putObjectVolatile(Object[] array, int index, Object x) {
+    OBJECT_ARRAY_VAR_HANDLE.setVolatile(array, index, x);
+  }
+
+  @Override
+  public int getIntVolatile(int[] array, int index) {
+    return (int) INT_ARRAY_VAR_HANDLE.getVolatile(array, index);
+  }
+
+  @Override
+  public void putIntVolatile(int[] array, int index, int x) {
+    INT_ARRAY_VAR_HANDLE.setVolatile(array, index, x);
+  }
+
+  @Override
+  public boolean getBooleanVolatile(boolean[] array, int index) {
+    return (boolean) BOOLEAN_ARRAY_VAR_HANDLE.getVolatile(array, index);
+  }
+
+  @Override
+  public void putBooleanVolatile(boolean[] array, int index, boolean x) {
+    BOOLEAN_ARRAY_VAR_HANDLE.setVolatile(array, index, x);
+  }
+
+  @Override
+  public void putLongVolatile(long[] array, int index, long x) {
+    LONG_ARRAY_VAR_HANDLE.setVolatile(array, index, x);
+  }
+
+  @Override
+  public long getLongVolatile(long[] array, int index) {
+    return (long) LONG_ARRAY_VAR_HANDLE.getVolatile(array, index);
+  }
+
+  @Override
+  public void putOrderedObject(Object[] array, int index, Object x) {
+    OBJECT_ARRAY_VAR_HANDLE.setOpaque(array, index, x);
+  }
+
+  @Override
+  public void putOrderedInt(int[] array, int index, int x) {
+    INT_ARRAY_VAR_HANDLE.setOpaque(array, index, x);
+  }
+
+  @Override
+  public void putOrderedLong(long[] array, int index, long x) {
+    LONG_ARRAY_VAR_HANDLE.setOpaque(array, index, x);
+  }
+}

--- a/utils/varhandles/src/test/groovy/TestVarHandleCAS.groovy
+++ b/utils/varhandles/src/test/groovy/TestVarHandleCAS.groovy
@@ -1,0 +1,48 @@
+import datadog.trace.core.varhandles.VarHandleCASFactory
+import datadog.trace.test.util.DDSpecification
+import datadog.trace.unsafe.IntCAS
+import datadog.trace.unsafe.ReferenceCAS
+
+class TestVarHandleCAS extends DDSpecification {
+
+  def "test varhandle CAS"() {
+    setup:
+    ObjectToCAS testObject = new ObjectToCAS()
+    def casFactory = new VarHandleCASFactory()
+
+    when:
+    testObject.stringField = "foo"
+    ReferenceCAS<String> casString = casFactory.createReferenceCAS(ObjectToCAS, "stringField", String)
+
+    then:
+    casString.compareAndSet(testObject, "foo", "bar")
+    !casString.compareAndSet(testObject, "foo", "bar")
+
+
+    when:
+    testObject.intField = 42
+    IntCAS casInt = casFactory.createIntCAS(ObjectToCAS, "intField")
+
+    then:
+    casInt.compareAndSet(testObject, 42, 43)
+    !casInt.compareAndSet(testObject, 42, 43)
+  }
+
+  def "field type mismatches are rejected"() {
+    setup:
+    def casFactory = new VarHandleCASFactory()
+    when:
+    casFactory.createReferenceCAS(ObjectToCAS, "stringField", List)
+    then:
+    thrown IllegalArgumentException
+  }
+
+  def "missing field are rejected"() {
+    setup:
+    def casFactory = new VarHandleCASFactory()
+    when:
+    casFactory.createReferenceCAS(ObjectToCAS, "missing", String)
+    then:
+    thrown IllegalArgumentException
+  }
+}

--- a/utils/varhandles/src/test/groovy/TestVarHandleConcurrentArrayOperations.groovy
+++ b/utils/varhandles/src/test/groovy/TestVarHandleConcurrentArrayOperations.groovy
@@ -1,0 +1,33 @@
+import datadog.trace.core.varhandles.VarHandleConcurrentArrayOperations
+import datadog.trace.test.util.DDSpecification
+
+class TestVarHandleConcurrentArrayOperations extends DDSpecification {
+
+  def "test varhandle concurrent array operations"() {
+    setup:
+    Object[] objects = new Object[2]
+    boolean[] booleans = new boolean[2]
+    int[] ints = new int[2]
+    long[] longs = new long[2]
+    def arrayOperations = new VarHandleConcurrentArrayOperations()
+
+    when: "it is used to set array values"
+    arrayOperations.putObjectVolatile(objects, 0, "foo")
+    arrayOperations.putOrderedObject(objects, 1, "bar")
+    arrayOperations.putBooleanVolatile(booleans, 0, true)
+    arrayOperations.putIntVolatile(ints, 0, 1)
+    arrayOperations.putIntVolatile(ints, 0, 1)
+    arrayOperations.putOrderedInt(ints, 1, 2)
+    arrayOperations.putLongVolatile(longs, 0, 1)
+    arrayOperations.putOrderedLong(longs, 1, 2)
+
+    then: "it behaves like normal array accesses"
+    arrayOperations.getObjectVolatile(objects, 0) == "foo"
+    arrayOperations.getObjectVolatile(objects, 1) == "bar"
+    arrayOperations.getBooleanVolatile(booleans, 0)
+    arrayOperations.getIntVolatile(ints, 0) == 1
+    arrayOperations.getIntVolatile(ints, 1) == 2
+    arrayOperations.getLongVolatile(longs, 0) == 1
+    arrayOperations.getLongVolatile(longs, 1) == 2
+  }
+}

--- a/utils/varhandles/src/test/java/ObjectToCAS.java
+++ b/utils/varhandles/src/test/java/ObjectToCAS.java
@@ -1,0 +1,7 @@
+public class ObjectToCAS {
+
+  // these all need to be public, which is a drawback of abstracting over varhandles
+  private String stringField;
+  private int intField;
+  private long longField;
+}

--- a/utils/varhandles/varhandles.gradle
+++ b/utils/varhandles/varhandles.gradle
@@ -1,0 +1,16 @@
+ext {
+  minJavaVersionForTests = JavaVersion.VERSION_1_9
+}
+
+apply from: "$rootDir/gradle/java.gradle"
+
+sourceCompatibility = JavaVersion.VERSION_1_9
+targetCompatibility = JavaVersion.VERSION_1_9
+
+minimumBranchCoverage = 0.7
+minimumInstructionCoverage = 0.7
+
+dependencies {
+  implementation project(':internal-api')
+  testCompile project(':utils:test-utils')
+}


### PR DESCRIPTION
This provides an API for modifying array contents concurrently, using `VarHandle` on JDK9+ and `sun.misc.Unsafe` before that was available (and before the illegal reflective access was logged).