### PR TITLE
metrics performance

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/AggregateMetric.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/AggregateMetric.java
@@ -3,10 +3,12 @@ package datadog.trace.common.metrics;
 import datadog.trace.core.histogram.Histogram;
 import datadog.trace.core.histogram.HistogramFactory;
 import datadog.trace.core.histogram.Histograms;
+import java.util.concurrent.atomic.AtomicLongArray;
 
 /** Not thread-safe. Accumulates counts and durations. */
 public final class AggregateMetric {
 
+  static final long ERROR_TAG = 0x8000000000000000L;
   private static final HistogramFactory HISTOGRAM_FACTORY = Histograms.newHistogramFactory();
 
   private final Histogram okLatencies;
@@ -20,17 +22,19 @@ public final class AggregateMetric {
     errorLatencies = HISTOGRAM_FACTORY.newHistogram();
   }
 
-  public AggregateMetric recordDurations(int count, long errorMask, long... durations) {
+  public AggregateMetric recordDurations(int count, AtomicLongArray durations) {
     this.hitCount += count;
-    this.errorCount += Long.bitCount(errorMask);
-    for (int i = 0; i < count && i < durations.length; ++i) {
-      long duration = durations[i];
-      this.duration += duration;
-      if (((errorMask >>> i) & 1) == 1) {
+    for (int i = 0; i < count && i < durations.length(); ++i) {
+      long duration = durations.getAndSet(i, 0);
+      if ((duration & ERROR_TAG) == ERROR_TAG) {
+        // then it's an error
+        duration ^= ERROR_TAG;
         errorLatencies.accept(duration);
+        ++this.errorCount;
       } else {
         okLatencies.accept(duration);
       }
+      this.duration += duration;
     }
     return this;
   }

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/Aggregator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/Aggregator.java
@@ -50,11 +50,11 @@ final class Aggregator implements Runnable {
     Thread currentThread = Thread.currentThread();
     while (!currentThread.isInterrupted()) {
       try {
-        Batch batch = inbox.take();
+        Batch batch = inbox.poll(100, MILLISECONDS);
         if (batch == ConflatingMetricsAggregator.POISON_PILL) {
           report(wallClockTime());
           return;
-        } else {
+        } else if (null != batch) {
           MetricKey key = batch.getKey();
           // important that it is still *this* batch pending, must not remove otherwise
           pending.remove(key, batch);

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/Batch.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/Batch.java
@@ -72,7 +72,9 @@ public final class Batch {
     if (count >= 0) {
       // wait for the duration to have been set.
       // note this mechanism only supports a single reader
-      while (committed.get() != count) ;
+      while (committed.get() != count) {
+        Thread.yield();
+      }
       committed.set(0);
       aggregate.recordDurations(count, durations);
     }

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/MetricKey.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/MetricKey.java
@@ -3,7 +3,6 @@ package datadog.trace.common.metrics;
 import static datadog.trace.bootstrap.instrumentation.api.UTF8BytesString.EMPTY;
 
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
-import java.util.Objects;
 
 /** The aggregation key for tracked metrics. */
 public final class MetricKey {
@@ -27,11 +26,12 @@ public final class MetricKey {
     this.httpStatusCode = httpStatusCode;
     // unrolled polynomial hashcode which avoids allocating varargs
     // the constants are 31^4, 31^3, 31^2, 31^1, 31^0
-    this.hash = 923521 * this.resource.hashCode()
-      + 29791 * this.service.hashCode()
-      + 961 * this.operationName.hashCode()
-      + 31 * this.type.hashCode()
-      + httpStatusCode;
+    this.hash =
+        923521 * this.resource.hashCode()
+            + 29791 * this.service.hashCode()
+            + 961 * this.operationName.hashCode()
+            + 31 * this.type.hashCode()
+            + httpStatusCode;
   }
 
   public UTF8BytesString getResource() {
@@ -59,12 +59,13 @@ public final class MetricKey {
     try {
       MetricKey metricKey = (MetricKey) o;
       return hash == metricKey.hash
-        && httpStatusCode == metricKey.httpStatusCode
-        && resource.equals(metricKey.resource)
-        && service.equals(metricKey.service)
-        && operationName.equals(metricKey.operationName)
-        && type.equals(metricKey.type);
-    } catch (ClassCastException unlikely) { }
+          && httpStatusCode == metricKey.httpStatusCode
+          && resource.equals(metricKey.resource)
+          && service.equals(metricKey.service)
+          && operationName.equals(metricKey.operationName)
+          && type.equals(metricKey.type);
+    } catch (ClassCastException unlikely) {
+    }
     return false;
   }
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SerializingMetricWriterTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SerializingMetricWriterTest.groovy
@@ -8,6 +8,7 @@ import org.msgpack.core.MessageUnpacker
 import spock.lang.Requires
 
 import java.nio.ByteBuffer
+import java.util.concurrent.atomic.AtomicLongArray
 
 import static datadog.trace.api.Platform.isJavaVersionAtLeast
 import static java.util.concurrent.TimeUnit.MILLISECONDS
@@ -38,8 +39,8 @@ class SerializingMetricWriterTest extends DDSpecification {
     where:
     content << [
       [
-              Pair.of(new MetricKey("resource1", "service1", "operation1", "type", 0), new AggregateMetric().recordDurations(10, 1L)),
-              Pair.of(new MetricKey("resource2", "service2", "operation2", "type2", 200), new AggregateMetric().recordDurations(9, 1L))
+        Pair.of(new MetricKey("resource1", "service1", "operation1", "type", 0), new AggregateMetric().recordDurations(10, new AtomicLongArray(1L))),
+        Pair.of(new MetricKey("resource2", "service2", "operation2", "type2", 200), new AggregateMetric().recordDurations(9, new AtomicLongArray(1L)))
       ]
     ]
   }


### PR DESCRIPTION
Makes a couple of tweaks
1. Optimise `MetricKey` for its role as a key in a hash map
2. Remove the synchronized blocks in `Batch`, uses atomics instead