### PR TITLE
Fix gradle memory overallocation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,10 +150,10 @@ jobs:
       - run:
           name: Run Tests
           command: >-
-            GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx1G -Xms64M -XX:ErrorFile=/tmp/hs_err_pid%p.log' -Ddatadog.forkedMaxHeapSize=1G -Ddatadog.forkedMinHeapSize=64M"
+            GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx2G -Xms64M -XX:ErrorFile=/tmp/hs_err_pid%p.log' -Ddatadog.forkedMaxHeapSize=1G -Ddatadog.forkedMinHeapSize=64M"
             ./gradlew <<# parameters.prefixTestTask>>testJava<</ parameters.prefixTestTask>><< parameters.testTask >>
             << pipeline.parameters.gradle_flags >>
-            --max-workers=7
+            --max-workers=5
 
       - run:
           name: Collect Reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,7 @@ jobs:
             GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx2G -Xms64M -XX:ErrorFile=/tmp/hs_err_pid%p.log' -Ddatadog.forkedMaxHeapSize=2G -Ddatadog.forkedMinHeapSize=64M"
             ./gradlew clean :dd-java-agent:shadowJar compileTestGroovy compileLatestDepTestGroovy compileTestScala compileLatestDepTestScala compileTestJava compileLatestDepTestJava
             << pipeline.parameters.gradle_flags >>
-            --max-workers=8
+            --max-workers=7
 
       - run:
           name: Collect Libs
@@ -150,10 +150,10 @@ jobs:
       - run:
           name: Run Tests
           command: >-
-            GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx2G -Xms64M -XX:ErrorFile=/tmp/hs_err_pid%p.log' -Ddatadog.forkedMaxHeapSize=4G -Ddatadog.forkedMinHeapSize=64M"
+            GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx1G -Xms64M -XX:ErrorFile=/tmp/hs_err_pid%p.log' -Ddatadog.forkedMaxHeapSize=1G -Ddatadog.forkedMinHeapSize=64M"
             ./gradlew <<# parameters.prefixTestTask>>testJava<</ parameters.prefixTestTask>><< parameters.testTask >>
             << pipeline.parameters.gradle_flags >>
-            --max-workers=6
+            --max-workers=7
 
       - run:
           name: Collect Reports
@@ -193,18 +193,18 @@ jobs:
       - run:
           name: Build Project
           command: >-
-            GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx2G -Xms64M -XX:ErrorFile=/tmp/hs_err_pid%p.log' -Ddatadog.forkedMaxHeapSize=4G -Ddatadog.forkedMinHeapSize=64M"
+            GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx2G -Xms64M -XX:ErrorFile=/tmp/hs_err_pid%p.log' -Ddatadog.forkedMaxHeapSize=2G -Ddatadog.forkedMinHeapSize=64M"
             ./gradlew build -PskipTests
             << pipeline.parameters.gradle_flags >>
-            --max-workers=8
+            --max-workers=7
 
       - run:
           name: Test Published Dependencies
           command: |
             mvn_local_repo=$(mvn help:evaluate -Dexpression=settings.localRepository -q -DforceStdout)
             rm -rf "${mvn_local_repo}/com/datadoghq"
-            export GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx2G -Xms64M -XX:ErrorFile=/tmp/hs_err_pid%p.log' -Ddatadog.forkedMaxHeapSize=4G -Ddatadog.forkedMinHeapSize=64M"
-            ./gradlew install << pipeline.parameters.gradle_flags >> --max-workers=6
+            export GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx2G -Xms64M -XX:ErrorFile=/tmp/hs_err_pid%p.log' -Ddatadog.forkedMaxHeapSize=2G -Ddatadog.forkedMinHeapSize=64M"
+            ./gradlew install << pipeline.parameters.gradle_flags >> --max-workers=7
             cd test-published-dependencies
             ../gradlew check
 

--- a/dd-java-agent/src/test/java/datadog/trace/agent/test/IntegrationTestUtils.java
+++ b/dd-java-agent/src/test/java/datadog/trace/agent/test/IntegrationTestUtils.java
@@ -1,5 +1,8 @@
 package datadog.trace.agent.test;
 
+import static datadog.trace.test.util.ForkedTestUtils.getMaxMemoryArgumentForFork;
+import static datadog.trace.test.util.ForkedTestUtils.getMinMemoryArgumentForFork;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -180,7 +183,10 @@ public class IntegrationTestUtils {
     final String path = System.getProperty("java.home") + separator + "bin" + separator + "java";
 
     final List<String> vmArgsList = new ArrayList<>(Arrays.asList(jvmArgs));
+
     vmArgsList.add(getAgentArgument());
+    vmArgsList.add(getMaxMemoryArgumentForFork());
+    vmArgsList.add(getMinMemoryArgumentForFork());
     vmArgsList.add("-XX:ErrorFile=/tmp/hs_err_pid%p.log");
 
     final List<String> commands = new ArrayList<>();

--- a/dd-smoke-tests/agent-isolation/src/test/groovy/datadog/smoketest/AgentIsolationSmokeTest.groovy
+++ b/dd-smoke-tests/agent-isolation/src/test/groovy/datadog/smoketest/AgentIsolationSmokeTest.groovy
@@ -1,6 +1,5 @@
 package datadog.smoketest
 
-
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Timeout
@@ -10,6 +9,9 @@ import java.nio.file.Path
 import java.util.concurrent.ForkJoinTask
 import java.util.concurrent.FutureTask
 import java.util.concurrent.TimeUnit
+
+import static datadog.trace.test.util.ForkedTestUtils.getMaxMemoryArgumentForFork
+import static datadog.trace.test.util.ForkedTestUtils.getMinMemoryArgumentForFork
 
 class AgentIsolationSmokeTest extends Specification {
 
@@ -32,6 +34,8 @@ class AgentIsolationSmokeTest extends Specification {
     String agent = System.getProperty("datadog.smoketest.agentisolation.agentJar.path")
     List<String> command = new ArrayList<>()
     command.add(javaPath())
+    command.add("${getMaxMemoryArgumentForFork()}" as String)
+    command.add("${getMinMemoryArgumentForFork()}" as String)
     command.add("-javaagent:${shadowJarPath}" as String)
     command.add("-javaagent:${agent}=${triggerTypes.join(",")}" as String)
     command.add("-XX:ErrorFile=/tmp/hs_err_pid%p.log")

--- a/dd-smoke-tests/field-injection/src/test/groovy/datadog/smoketest/FieldInjectionSmokeTest.groovy
+++ b/dd-smoke-tests/field-injection/src/test/groovy/datadog/smoketest/FieldInjectionSmokeTest.groovy
@@ -12,6 +12,9 @@ import java.util.concurrent.RecursiveTask
 import java.util.concurrent.RunnableFuture
 import java.util.concurrent.TimeUnit
 
+import static datadog.trace.test.util.ForkedTestUtils.getMaxMemoryArgumentForFork
+import static datadog.trace.test.util.ForkedTestUtils.getMinMemoryArgumentForFork
+
 class FieldInjectionSmokeTest extends Specification {
 
   String javaPath() {
@@ -40,6 +43,8 @@ class FieldInjectionSmokeTest extends Specification {
     String jar = System.getProperty("datadog.smoketest.fieldinjection.shadowJar.path")
     List<String> command = new ArrayList<>()
     command.add(javaPath())
+    command.add("${getMaxMemoryArgumentForFork()}" as String)
+    command.add("${getMinMemoryArgumentForFork()}" as String)
     command.add("-javaagent:${shadowJarPath}" as String)
     command.add("-XX:ErrorFile=/tmp/hs_err_pid%p.log")
     command.add("-Ddd.writer.type=TraceStructureWriter")

--- a/dd-smoke-tests/src/main/groovy/datadog/smoketest/AbstractSmokeTest.groovy
+++ b/dd-smoke-tests/src/main/groovy/datadog/smoketest/AbstractSmokeTest.groovy
@@ -15,6 +15,8 @@ import java.util.concurrent.TimeoutException
 import java.util.concurrent.atomic.AtomicInteger
 
 import static datadog.trace.agent.test.server.http.TestHttpServer.httpServer
+import static datadog.trace.test.util.ForkedTestUtils.getMaxMemoryArgumentForFork
+import static datadog.trace.test.util.ForkedTestUtils.getMinMemoryArgumentForFork
 
 abstract class AbstractSmokeTest extends Specification {
 
@@ -83,6 +85,8 @@ abstract class AbstractSmokeTest extends Specification {
     System.out.println("Mock agent started at " + server.address)
 
     defaultJavaProperties = [
+      "${getMaxMemoryArgumentForFork()}",
+      "${getMinMemoryArgumentForFork()}",
       "-javaagent:${shadowJarPath}",
       "-XX:ErrorFile=/tmp/hs_err_pid%p.log",
       "-Ddd.trace.agent.port=${server.address.port}",

--- a/utils/test-utils/src/main/java/datadog/trace/test/util/ForkedTestUtils.java
+++ b/utils/test-utils/src/main/java/datadog/trace/test/util/ForkedTestUtils.java
@@ -1,0 +1,11 @@
+package datadog.trace.test.util;
+
+public class ForkedTestUtils {
+  public static String getMaxMemoryArgumentForFork() {
+    return "-Xmx" + System.getProperty("datadog.forkedMaxHeapSize", "1g");
+  }
+
+  public static String getMinMemoryArgumentForFork() {
+    return "-Xms" + System.getProperty("datadog.forkedMinHeapSize", "64M");
+  }
+}


### PR DESCRIPTION
The memory allocated for gradle was greater than the available memory on the machine.  This lead to random `error 137` depending on how the forked tests overlapped.

For smoke tests and `runOnSeparateJvm()` tests, we weren't setting any memory parameters leading to each forked process consuming up to `.25 * 16GB = 4GB` of memory each.

The XLarge machine in CircleCI has 16GB of memory.

### With this PR
**Build job**:
The build doesn't fork any processes other than through gradle.  Therefore:
7 max workers * 2GB = 14GB total for gradle

**Test Job**
Each test task can potentially create one forked process (smoke test or `runOnSeparateJvm()`).  Therefore:
7 max workers * 2 * 1GB = 14GB total for gradle

**Check Job**
Similar to the Build job, all forks are through gradle.  Therefore:
7 max workers * 2GB = 14GB total for gradle

**muzzle**
I wasn't sure of the exact semantics of this.  Clearly it's not using 4GB*16 workers = 64GB of memory.  There is also the parallelism flag which splits this job across multiple containers.  Since its not failing, I didn't make any changes.

I left 2GB to spare because I don't think its worth figuring out _exactly_ how much memory the OS and java native allocation needs.