### PR TITLE
ignore flaky profiling tests

### DIFF
--- a/dd-smoke-tests/profiling-integration-tests/src/test/groovy/datadog/smoketest/ProfilingIntegrationContinuousProfilesTest.groovy
+++ b/dd-smoke-tests/profiling-integration-tests/src/test/groovy/datadog/smoketest/ProfilingIntegrationContinuousProfilesTest.groovy
@@ -11,7 +11,7 @@ import org.openjdk.jmc.common.item.IItemCollection
 import org.openjdk.jmc.common.item.ItemFilters
 import org.openjdk.jmc.common.unit.UnitLookup
 import org.openjdk.jmc.flightrecorder.JfrLoaderToolkit
-import spock.lang.IgnoreIf
+import spock.lang.Ignore
 
 import java.time.Instant
 import java.util.concurrent.TimeUnit
@@ -19,7 +19,9 @@ import java.util.concurrent.TimeUnit
 class ProfilingIntegrationContinuousProfilesTest extends AbstractProfilingIntegrationTest {
   private static final int REQUEST_WAIT_TIMEOUT = 40
 
-  @IgnoreIf({ jvm.javaVersion == '1.8.0_265' })
+
+  @Ignore("flaky")
+  //@IgnoreIf({ jvm.javaVersion == '1.8.0_265' })
   def "test continuous recording"() {
     setup:
     profilingServer.enqueue(new MockResponse().setResponseCode(200))

--- a/dd-smoke-tests/profiling-integration-tests/src/test/groovy/datadog/smoketest/ProfilingIntegrationShutdownTest.groovy
+++ b/dd-smoke-tests/profiling-integration-tests/src/test/groovy/datadog/smoketest/ProfilingIntegrationShutdownTest.groovy
@@ -3,6 +3,7 @@ package datadog.smoketest
 
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.RecordedRequest
+import org.junit.Ignore
 
 import java.util.concurrent.TimeUnit
 
@@ -19,6 +20,7 @@ class ProfilingIntegrationShutdownTest extends AbstractProfilingIntegrationTest 
     return RUN_APP_FOR
   }
 
+  @Ignore("flaky")
   def "test that profiling agent doesn't prevent app from exiting"() {
     setup:
     profilingServer.enqueue(new MockResponse().setResponseCode(200))


### PR DESCRIPTION
These tests fail a lot of the time. It's not clear exactly why they fail, and may not reflect a defect in the profiling agent, but it makes CI less reliable for the tracer.