### PR TITLE
Add another gradle worker but use less memory

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,10 +150,10 @@ jobs:
       - run:
           name: Run Tests
           command: >-
-            GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx2G -Xms64M -XX:ErrorFile=/tmp/hs_err_pid%p.log' -Ddatadog.forkedMaxHeapSize=1G -Ddatadog.forkedMinHeapSize=64M"
+            GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx1940M -Xms64M -XX:ErrorFile=/tmp/hs_err_pid%p.log' -Ddatadog.forkedMaxHeapSize=512M -Ddatadog.forkedMinHeapSize=64M"
             ./gradlew <<# parameters.prefixTestTask>>testJava<</ parameters.prefixTestTask>><< parameters.testTask >>
             << pipeline.parameters.gradle_flags >>
-            --max-workers=5
+            --max-workers=6
 
       - run:
           name: Collect Reports

--- a/utils/test-utils/src/main/java/datadog/trace/test/util/ForkedTestUtils.java
+++ b/utils/test-utils/src/main/java/datadog/trace/test/util/ForkedTestUtils.java
@@ -2,7 +2,7 @@ package datadog.trace.test.util;
 
 public class ForkedTestUtils {
   public static String getMaxMemoryArgumentForFork() {
-    return "-Xmx" + System.getProperty("datadog.forkedMaxHeapSize", "1g");
+    return "-Xmx" + System.getProperty("datadog.forkedMaxHeapSize", "512M");
   }
 
   public static String getMinMemoryArgumentForFork() {


### PR DESCRIPTION
This ups the test workers to 6 by reducing the memory slightly.

6 * 1940 + 6 * 512 = 14,712.  This leaves 1,672mb for the OS and native mem.