### PR TITLE
Avoid 5s pause for creation of unresolvable InetSocketAddress

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/BaseDecoratorTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/BaseDecoratorTest.groovy
@@ -46,10 +46,10 @@ class BaseDecoratorTest extends DDSpecification {
     0 * _
 
     where:
-    connection                                      | _
-    new InetSocketAddress("localhost", 888)         | _
-    new InetSocketAddress("ipv6.google.com", 999)   | _
-    new InetSocketAddress("bad.address.local", 999) | _
+    connection                                                   | _
+    new InetSocketAddress("localhost", 888)                      | _
+    new InetSocketAddress("ipv6.google.com", 999)                | _
+    InetSocketAddress.createUnresolved("bad.address.local", 999) | _
   }
 
   def "test onError"() {


### PR DESCRIPTION
Reduces time to test decorator package from 6.5s to 1.5s