### PR TITLE
reduce time spent in cassandra 4 client test by reusing the (readonly) database prerequisites

### DIFF
--- a/dd-java-agent/instrumentation/datastax-cassandra-4/src/test/groovy/CassandraClientTest.groovy
+++ b/dd-java-agent/instrumentation/datastax-cassandra-4/src/test/groovy/CassandraClientTest.groovy
@@ -27,6 +27,9 @@ class CassandraClientTest extends AgentTestRunner {
   @Shared
   int port
 
+  @Shared
+  InetSocketAddress address
+
   def setupSpec() {
     /*
      This timeout seems excessive but we've seen tests fail with timeout of 40s.
@@ -37,13 +40,8 @@ class CassandraClientTest extends AgentTestRunner {
     EmbeddedCassandraServerHelper.startEmbeddedCassandra(EmbeddedCassandraServerHelper.CASSANDRA_RNDPORT_YML_FILE, 120000L)
 
     port = EmbeddedCassandraServerHelper.getNativeTransportPort()
-  }
+    address = new InetSocketAddress(EmbeddedCassandraServerHelper.getHost(), port)
 
-  def cleanupSpec() {
-    EmbeddedCassandraServerHelper.cleanEmbeddedCassandra()
-  }
-
-  def setup() {
     runUnderTrace("setup") {
       Session session = sessionBuilder().build()
       session.execute("DROP KEYSPACE IF EXISTS test_keyspace")
@@ -53,6 +51,10 @@ class CassandraClientTest extends AgentTestRunner {
 
     TEST_WRITER.waitForTraces(1)
     TEST_WRITER.start()
+  }
+
+  def cleanupSpec() {
+    EmbeddedCassandraServerHelper.cleanEmbeddedCassandra()
   }
 
   def "test sync"() {
@@ -198,7 +200,7 @@ class CassandraClientTest extends AgentTestRunner {
       .build()
 
     return CqlSession.builder()
-      .addContactPoint(new InetSocketAddress(EmbeddedCassandraServerHelper.getHost(), EmbeddedCassandraServerHelper.getNativeTransportPort()))
+      .addContactPoint(address)
       .withLocalDatacenter("datacenter1")
       .withConfigLoader(configLoader)
   }


### PR DESCRIPTION
Reduces test time from

Task | Duration
-- | --
:dd-java-agent:instrumentation:datastax-cassandra-4 | 4m25.78s
:dd-java-agent:instrumentation:datastax-cassandra-4:test | 2m16.78s 
:dd-java-agent:instrumentation:datastax-cassandra-4:testJava8Generated | 1m55.96s

to 


Task | Duration 
-- | -- 
:dd-java-agent:instrumentation:datastax-cassandra-4 | 2m8.67s 
:dd-java-agent:instrumentation:datastax-cassandra-4:testJava8Generated | 59.295s 
:dd-java-agent:instrumentation:datastax-cassandra-4:test | 54.630s


Another approach which setup a new keyspace for each test, but avoided deleting the old one (which would allow tests which could actually mutate the database to run in parallel) was ruled out, but had some impact too:


Task | Duration 
-- | -- 
:dd-java-agent:instrumentation:datastax-cassandra-4 | 3m21.89s 
:dd-java-agent:instrumentation:datastax-cassandra-4:testJava8Generated | 1m39.58s 
:dd-java-agent:instrumentation:datastax-cassandra-4:test | 1m34.51s





