### PR TITLE
Fix double counting and State overwriting for Scala Promise/Future

### DIFF
--- a/dd-java-agent/instrumentation/scala-promise/scala-promise-2.10/src/main/java/datadog/trace/instrumentation/scala/promise/CallbackRunnableInstrumentation.java
+++ b/dd-java-agent/instrumentation/scala-promise/scala-promise-2.10/src/main/java/datadog/trace/instrumentation/scala/promise/CallbackRunnableInstrumentation.java
@@ -2,6 +2,7 @@ package datadog.trace.instrumentation.scala.promise;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
+import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.ExcludeType.EXECUTOR;
 import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.ExcludeType.RUNNABLE;
 import static java.util.Collections.singletonMap;
 import static java.util.Collections.unmodifiableMap;
@@ -57,7 +58,11 @@ public class CallbackRunnableInstrumentation extends Instrumenter.Tracing
   @Override
   public Map<ExcludeFilter.ExcludeType, ? extends Collection<String>> excludedClasses() {
     // force other instrumentations (e.g. Runnable) not to deal with this type
-    return singletonMap(RUNNABLE, Collections.singleton("scala.concurrent.impl.CallbackRunnable"));
+    Map<ExcludeFilter.ExcludeType, Collection<String>> map = new HashMap<>();
+    Collection<String> cbr = Collections.singleton("scala.concurrent.impl.CallbackRunnable");
+    map.put(RUNNABLE, cbr);
+    map.put(EXECUTOR, cbr);
+    return map;
   }
 
   /** Capture the scope when the promise is created */


### PR DESCRIPTION
This double counting and overwriting of `State` was _hidden_ by the fact that we write out partial traces. Probably not end user visible, apart from the tracer holding on to pending traces longer than necessary.

I would really like for there to be a strict mode for writing out traces, that we could use in tests to validate that the counts add up.

Oh, and this cuts the time for the tests on my machine from `26` to `13` seconds for `:dd-java-agent:instrumentation:scala-promise:scala-promise-2.10:test` and the same for `:dd-java-agent:instrumentation:scala-promise:scala-promise-2.13:test`