### PR TITLE
remove heavy debug logging

### DIFF
--- a/dd-java-agent/instrumentation/jax-rs-client-2.0/src/main/java/datadog/trace/instrumentation/jaxrs/ClientTracingFeature.java
+++ b/dd-java-agent/instrumentation/jax-rs-client-2.0/src/main/java/datadog/trace/instrumentation/jaxrs/ClientTracingFeature.java
@@ -9,7 +9,6 @@ public class ClientTracingFeature implements Feature {
   @Override
   public boolean configure(final FeatureContext context) {
     context.register(new ClientTracingFilter());
-    log.debug("ClientTracingFilter registered");
     return true;
   }
 }

--- a/dd-trace-core/dd-trace-core.gradle
+++ b/dd-trace-core/dd-trace-core.gradle
@@ -15,6 +15,7 @@ excludedClassesCoverage += [
   'datadog.trace.core.scopemanager.ScopeInterceptor.DelegatingScope',
   'datadog.trace.core.jfr.DDNoopScopeEventFactory',
   'datadog.trace.core.StatusLogger',
+  'datadog.trace.core.scopemanager.ContinuableScopeManager.SingleContinuation'
 ]
 
 apply plugin: 'org.unbroken-dome.test-sets'

--- a/dd-trace-core/src/main/java/datadog/trace/common/sampling/DeterministicSampler.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/sampling/DeterministicSampler.java
@@ -41,8 +41,6 @@ public class DeterministicSampler<T extends CoreSpan<T>> implements RateSampler<
       }
     }
 
-    log.debug("{} - Span is sampled: {}", span, sampled);
-
     return sampled;
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
@@ -260,9 +260,6 @@ public class DDSpanContext implements AgentSpan.Context {
         return false;
       } else {
         this.samplingPriorityV1 = (byte) newPriority;
-        if (log.isDebugEnabled()) {
-          log.debug("Set sampling priority to {}", samplingPriorityV1);
-        }
         return true;
       }
     }
@@ -299,9 +296,6 @@ public class DDSpanContext implements AgentSpan.Context {
         log.debug("{} : refusing to lock unset samplingPriority", this);
       } else if (!samplingPriorityLocked) {
         samplingPriorityLocked = true;
-        if (log.isDebugEnabled()) {
-          log.debug("{} : locked samplingPriority to {}", this, samplingPriorityV1);
-        }
       }
       return samplingPriorityLocked;
     }

--- a/dd-trace-core/src/main/java/datadog/trace/core/PendingTrace.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/PendingTrace.java
@@ -131,10 +131,7 @@ public class PendingTrace implements AgentTrace {
       }
     }
 
-    final int count = pendingReferenceCount.incrementAndGet();
-    if (log.isDebugEnabled()) {
-      log.debug("t_id={} -> registered span {}. count = {}", traceId, span, count);
-    }
+    pendingReferenceCount.incrementAndGet();
   }
 
   void addFinishedSpan(final DDSpan span) {
@@ -165,11 +162,7 @@ public class PendingTrace implements AgentTrace {
    */
   @Override
   public void registerContinuation(final AgentScope.Continuation continuation) {
-    final int count = pendingReferenceCount.incrementAndGet();
-    if (log.isDebugEnabled()) {
-      log.debug(
-          "t_id={} -> registered continuation {} -- count = {}", traceId, continuation, count);
-    }
+    pendingReferenceCount.incrementAndGet();
   }
 
   @Override
@@ -194,11 +187,6 @@ public class PendingTrace implements AgentTrace {
       // Late arrival span ... delay write
       pendingTraceBuffer.enqueue(this);
     }
-
-    if (log.isDebugEnabled()) {
-      log.debug(
-          "t_id={} -> expired reference. root={} pending count={}", traceId, isRootSpan, count);
-    }
   }
 
   /** Important to note: may be called multiple times. */
@@ -211,10 +199,7 @@ public class PendingTrace implements AgentTrace {
 
   /** Important to note: may be called multiple times. */
   void write() {
-    int size = write(false);
-    if (log.isDebugEnabled()) {
-      log.debug("t_id={} -> wrote {} spans to {}.", traceId, size, tracer.writer);
-    }
+    write(false);
   }
 
   private int write(boolean isPartial) {

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/DatadogHttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/DatadogHttpCodec.java
@@ -42,7 +42,6 @@ class DatadogHttpCodec {
       for (final Map.Entry<String, String> entry : context.baggageItems()) {
         setter.set(carrier, OT_BAGGAGE_PREFIX + entry.getKey(), HttpCodec.encode(entry.getValue()));
       }
-      log.debug("{} - Datadog parent context injected", context.getTraceId());
     }
   }
 


### PR DESCRIPTION
I don't see any value in any of this logging any more.

1. I have never needed to pay attention to sampling priorities or sampling decisions, this module is quite well tested and I trust that it works
2. PendingTrace used to be a component we were paranoid about - now the only interesting event is partial flushes.
3. I trust that the DatadogHttpCodec propagates the correct trace id
4. I don't think we care if or how many times the JAX-RS `ClientTracingFilter` is registered.