### PR TITLE
Restrict maven groups from certain repositories

### DIFF
--- a/gradle/repositories.gradle
+++ b/gradle/repositories.gradle
@@ -4,11 +4,18 @@ repositories {
   jcenter()
   maven {
     url "https://adoptopenjdk.jfrog.io/adoptopenjdk/jmc-libs-snapshots"
+    content {
+      includeGroup "org.openjdk.jmc"
+    }
     mavenContent {
       snapshotsOnly()
     }
   }
   maven {
     url "https://repo.typesafe.com/typesafe/releases"
+    content {
+      includeGroup "com.typesafe.play"
+      includeGroup "play"
+    }
   }
 }


### PR DESCRIPTION
Hitting all of these repos has lead to rate limits.  Restrict them to only the groups we know they contain.