### PR TITLE
Update java-dogstatsd-client to 2.11.0

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -5,7 +5,7 @@ import static datadog.trace.common.metrics.MetricsAggregatorFactory.createMetric
 import static datadog.trace.util.AgentThreadFactory.AGENT_THREAD_GROUP;
 
 import com.timgroup.statsd.NoOpStatsDClient;
-import com.timgroup.statsd.NonBlockingStatsDClient;
+import com.timgroup.statsd.NonBlockingStatsDClientBuilder;
 import com.timgroup.statsd.StatsDClient;
 import com.timgroup.statsd.StatsDClientException;
 import datadog.trace.api.Config;
@@ -547,8 +547,12 @@ public class CoreTracer implements AgentTracer.TracerAPI {
       }
 
       try {
-        return new NonBlockingStatsDClient(
-            "datadog.tracer", host, port, generateConstantTags(config));
+        return new NonBlockingStatsDClientBuilder()
+            .prefix("datadog.tracer")
+            .hostname(host)
+            .port(port)
+            .constantTags(generateConstantTags(config))
+            .build();
       } catch (final StatsDClientException e) {
         log.error("Unable to create StatsD client", e);
         return new NoOpStatsDClient();

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -21,7 +21,7 @@ ext {
     scala213      : "2.13.4",
     kotlin        : "1.3.72",
     coroutines    : "1.3.0",
-    dogstatsd     : "2.9.0",
+    dogstatsd     : "2.11.0",
     jnr_unixsocket: "0.28",
     commons       : "3.2",
     mockito       : '3.5.10',


### PR DESCRIPTION
Update to the latest client.  The previous client added 1 second per call to `trace.close()` in our tests.  Release notes for the client can be found at: https://github.com/DataDog/java-dogstatsd-client/releases