### PR TITLE
Make sure process is alive before all smoke tests

### DIFF
--- a/dd-smoke-tests/src/main/groovy/datadog/smoketest/AbstractSmokeTest.groovy
+++ b/dd-smoke-tests/src/main/groovy/datadog/smoketest/AbstractSmokeTest.groovy
@@ -70,6 +70,8 @@ abstract class AbstractSmokeTest extends Specification {
   }
 
   def setup() {
+    assert testedProcess.isAlive()
+    
     traceRequests.clear()
     traceCount.set(0)
   }

--- a/dd-smoke-tests/src/main/groovy/datadog/smoketest/AbstractSmokeTest.groovy
+++ b/dd-smoke-tests/src/main/groovy/datadog/smoketest/AbstractSmokeTest.groovy
@@ -70,8 +70,14 @@ abstract class AbstractSmokeTest extends Specification {
   }
 
   def setup() {
-    assert testedProcess.isAlive()
-    
+    // TODO: once java7 support is dropped use testedProcess.isAlive() instead
+    try {
+      testedProcess.exitValue()
+      assert false: "Process not alive before test"
+    } catch (IllegalThreadStateException ignored) {
+      // expected
+    }
+
     traceRequests.clear()
     traceCount.set(0)
   }


### PR DESCRIPTION
When the target process in smoketest dies, the tests usually fail with a timeout from a client call, spans not being generated, or something else similarly opaque.

This simple checks that the target process is alive before all tests to fail fast.