### PR TITLE
Fix classloader instrumentation error involving isolated classloaders

### DIFF
--- a/dd-java-agent/instrumentation/classloading/src/main/java/datadog/trace/instrumentation/classloading/ClassloadingInstrumentation.java
+++ b/dd-java-agent/instrumentation/classloading/src/main/java/datadog/trace/instrumentation/classloading/ClassloadingInstrumentation.java
@@ -64,8 +64,12 @@ public final class ClassloadingInstrumentation extends Instrumenter.Tracing {
   }
 
   public static class LoadClassAdvice {
-    @Advice.OnMethodEnter(skipOn = Advice.OnNonDefaultValue.class)
+    @Advice.OnMethodEnter(skipOn = Advice.OnNonDefaultValue.class, suppress = Throwable.class)
     public static Class<?> onEnter(@Advice.Argument(0) final String name) {
+      // we must access agent types used in the call-depth block like 'Constants' before entering it
+      // - otherwise we risk loading these agent types with a non-zero call-depth, which will fail
+      final String[] bootstrapPrefixes = Constants.BOOTSTRAP_PACKAGE_PREFIXES;
+
       // need to use call depth here to prevent re-entry from call to Class.forName() below
       // because on some JVMs (e.g. IBM's, though IBM bootstrap loader is explicitly excluded above)
       // Class.forName() ends up calling loadClass() on the bootstrap loader which would then come
@@ -75,14 +79,13 @@ public final class ClassloadingInstrumentation extends Instrumenter.Tracing {
         return null;
       }
       try {
-        for (final String prefix : Constants.BOOTSTRAP_PACKAGE_PREFIXES) {
+        for (final String prefix : bootstrapPrefixes) {
           if (name.startsWith(prefix)) {
-            try {
-              return Class.forName(name, false, null);
-            } catch (final ClassNotFoundException e) {
-            }
+            return Class.forName(name, false, null);
           }
         }
+      } catch (final ClassNotFoundException e) {
+        // bootstrap class not found, fall-back to original behaviour
       } finally {
         // need to reset it right away, not waiting until onExit()
         // otherwise it will prevent this instrumentation from being applied when loadClass()

--- a/dd-java-agent/src/test/groovy/datadog/trace/agent/integration/classloading/ClassLoadingTest.groovy
+++ b/dd-java-agent/src/test/groovy/datadog/trace/agent/integration/classloading/ClassLoadingTest.groovy
@@ -2,8 +2,10 @@ package datadog.trace.agent.integration.classloading
 
 import datadog.test.ClassToInstrument
 import datadog.test.ClassToInstrumentChild
+import datadog.trace.agent.test.IntegrationTestUtils
 import datadog.trace.api.Trace
 import datadog.trace.test.util.GCUtils
+import jvmbootstraptest.IsolatedClassloading
 import spock.lang.Specification
 import spock.lang.Timeout
 
@@ -112,5 +114,15 @@ class ClassLoadingTest extends Specification {
     // This test case fails on ibm j9.  Perhaps this rule only applies to OpenJdk based jvms?
 //    "datadog.trace.bootstrap.instrumentation.java.concurrent.State" | false
     resource = name.replace(".", "/") + ".class"
+  }
+
+  @Timeout(30)
+  def "classloader instrumentation works with isolated classloaders"() {
+    expect:
+    IntegrationTestUtils.runOnSeparateJvm(IsolatedClassloading.getName()
+      , ["-Ddd.trace.debug=false", "-Ddd.jmxfetch.enabled=false"] as String[]
+      , "" as String[]
+      , [:]
+      , true) == 0
   }
 }

--- a/dd-java-agent/src/test/java/jvmbootstraptest/IsolatedClassloading.java
+++ b/dd-java-agent/src/test/java/jvmbootstraptest/IsolatedClassloading.java
@@ -1,0 +1,17 @@
+package jvmbootstraptest;
+
+public class IsolatedClassloading {
+  public static void main(final String[] args) throws Exception {
+
+    // isolate an isolating classloader and then use that to try and load the target class
+    final ClassLoader isolatedLoader =
+        (ClassLoader)
+            new IsolatingClassLoader()
+                .loadClass(IsolatingClassLoader.class.getName())
+                .newInstance();
+
+    isolatedLoader.loadClass(Target.class.getName());
+  }
+
+  interface Target {}
+}

--- a/dd-java-agent/src/test/java/jvmbootstraptest/IsolatingClassLoader.java
+++ b/dd-java-agent/src/test/java/jvmbootstraptest/IsolatingClassLoader.java
@@ -1,0 +1,35 @@
+package jvmbootstraptest;
+
+import java.net.URI;
+import java.net.URL;
+import java.net.URLClassLoader;
+
+/**
+ * Isolated {@link ClassLoader} that loads all non-JDK classes from class files instead of
+ * delegating.
+ */
+public class IsolatingClassLoader extends URLClassLoader {
+  public IsolatingClassLoader() {
+    super(discoverTestClassPath());
+  }
+
+  @Override
+  public Class<?> loadClass(final String className) throws ClassNotFoundException {
+    if (className.startsWith("java.")) {
+      return super.loadClass(className);
+    }
+    return findClass(className);
+  }
+
+  private static URL[] discoverTestClassPath() {
+    final String resourceName = IsolatingClassLoader.class.getName().replace(".", "/") + ".class";
+    final URL resource = Thread.currentThread().getContextClassLoader().getResource(resourceName);
+    final String testClassesURI = resource.toString().replace(resourceName, "");
+    System.out.println("Loading isolated classes from: " + testClassesURI);
+    try {
+      return new URL[] {new URI(testClassesURI).toURL()};
+    } catch (final Exception e) {
+      throw new IllegalStateException(e);
+    }
+  }
+}


### PR DESCRIPTION
* Add test that recreates the classloader exception when instrumenting isolated classloaders

* Make sure we access agent types used in the call-depth block like `Constants` before entering it.
  If we don't then we risk loading these agent types with a non-zero call-depth, which will fail.

* Minor improvement since we know `Class.forName` will only be called at most once

* Robustness: always fall back to original classloading behaviour in the face of advice errors