### PR TITLE
scope manager efficiency improvements

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
@@ -177,11 +177,11 @@ public class ContinuableScopeManager implements AgentScopeManager {
     /** Continuation that created this scope. May be null. */
     private final ContinuableScopeManager.Continuation continuation;
     /** Flag to propagate this scope across async boundaries. */
-    private volatile boolean isAsyncPropagating;
+    private boolean isAsyncPropagating;
 
     private final byte source;
 
-    private final AtomicInteger referenceCount = new AtomicInteger(1);
+    private int referenceCount = 1;
 
     private final DDScopeEvent event;
 
@@ -250,17 +250,17 @@ public class ContinuableScopeManager implements AgentScopeManager {
     }
 
     final void incrementReferences() {
-      referenceCount.incrementAndGet();
+      ++referenceCount;
     }
 
     /** Decrements ref count -- returns true if the scope is still alive */
     final boolean decrementReferences() {
-      return referenceCount.decrementAndGet() > 0;
+      return --referenceCount > 0;
     }
 
     /** Returns true if the scope is still alive (non-zero ref count) */
     final boolean alive() {
-      return referenceCount.get() > 0;
+      return referenceCount > 0;
     }
 
     @Override

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
@@ -76,25 +76,25 @@ public class ContinuableScopeManager implements AgentScopeManager {
 
   @Override
   public AgentScope activate(final AgentSpan span, final ScopeSource source) {
-    return activate(span, source, false, /* ignored */ false);
+    return activate(span, source.id(), false, /* ignored */ false);
   }
 
   @Override
   public AgentScope activate(
       final AgentSpan span, final ScopeSource source, boolean isAsyncPropagating) {
-    return activate(span, source, true, isAsyncPropagating);
+    return activate(span, source.id(), true, isAsyncPropagating);
   }
 
   @Override
   public TraceScope.Continuation captureSpan(final AgentSpan span, final ScopeSource source) {
-    Continuation continuation = new SingleContinuation(this, span, source);
+    Continuation continuation = new SingleContinuation(this, span, source.id());
     continuation.register();
     return continuation;
   }
 
   private AgentScope activate(
       final AgentSpan span,
-      final ScopeSource source,
+      final byte source,
       final boolean overrideAsyncPropagation,
       final boolean isAsyncPropagating) {
     ScopeStack scopeStack = scopeStack();
@@ -122,7 +122,7 @@ public class ContinuableScopeManager implements AgentScopeManager {
   }
 
   private ContinuableScope handleSpan(
-      final Continuation continuation, final AgentSpan span, final ScopeSource source) {
+      final Continuation continuation, final AgentSpan span, final byte source) {
     ContinuableScope active = inheritAsyncPropagation ? scopeStack().top() : null;
     return handleSpan(active, continuation, span, source, true, true);
   }
@@ -131,7 +131,7 @@ public class ContinuableScopeManager implements AgentScopeManager {
       final ContinuableScope active,
       final Continuation continuation,
       final AgentSpan span,
-      final ScopeSource source,
+      final byte source,
       final boolean overrideAsyncPropagation,
       final boolean isAsyncPropagating) {
     // Inherit the async propagation from the active scope unless the a value is overridden
@@ -179,7 +179,7 @@ public class ContinuableScopeManager implements AgentScopeManager {
     /** Flag to propagate this scope across async boundaries. */
     private volatile boolean isAsyncPropagating;
 
-    private final ScopeSource source;
+    private final byte source;
 
     private final AtomicInteger referenceCount = new AtomicInteger(1);
 
@@ -191,7 +191,7 @@ public class ContinuableScopeManager implements AgentScopeManager {
         final ContinuableScopeManager scopeManager,
         final ContinuableScopeManager.Continuation continuation,
         final AgentSpan span,
-        final ScopeSource source,
+        final byte source,
         final boolean isAsyncPropagating) {
       this.isAsyncPropagating = isAsyncPropagating;
       this.span = span;
@@ -214,7 +214,7 @@ public class ContinuableScopeManager implements AgentScopeManager {
 
         scopeManager.statsDClient.incrementCounter("scope.close.error");
 
-        if (source == ScopeSource.MANUAL) {
+        if (source == ScopeSource.MANUAL.id()) {
           scopeManager.statsDClient.incrementCounter("scope.user.close.error");
 
           if (scopeManager.strictMode) {
@@ -376,11 +376,11 @@ public class ContinuableScopeManager implements AgentScopeManager {
 
     final ContinuableScopeManager scopeManager;
     final AgentSpan spanUnderScope;
-    final ScopeSource source;
+    final byte source;
     final AgentTrace trace;
 
     public Continuation(
-        ContinuableScopeManager scopeManager, AgentSpan spanUnderScope, ScopeSource source) {
+        ContinuableScopeManager scopeManager, AgentSpan spanUnderScope, byte source) {
       this.scopeManager = scopeManager;
       this.spanUnderScope = spanUnderScope;
       this.source = source;
@@ -407,7 +407,7 @@ public class ContinuableScopeManager implements AgentScopeManager {
     private SingleContinuation(
         final ContinuableScopeManager scopeManager,
         final AgentSpan spanUnderScope,
-        final ScopeSource source) {
+        final byte source) {
       super(scopeManager, spanUnderScope, source);
     }
 
@@ -465,7 +465,7 @@ public class ContinuableScopeManager implements AgentScopeManager {
     private ConcurrentContinuation(
         final ContinuableScopeManager scopeManager,
         final AgentSpan spanUnderScope,
-        final ScopeSource source) {
+        final byte source) {
       super(scopeManager, spanUnderScope, source);
     }
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeAndContinuationLayoutTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeAndContinuationLayoutTest.groovy
@@ -1,0 +1,27 @@
+package datadog.trace.core.scopemanager
+
+import datadog.trace.test.util.DDSpecification
+import org.openjdk.jol.info.ClassLayout
+import spock.lang.Requires
+
+@Requires({!System.getProperty("java.vendor").toUpperCase().contains("IBM")})
+class ScopeAndContinuationLayoutTest extends DDSpecification {
+
+  def "continuable scope layout"() {
+    expect: layoutAcceptable(ContinuableScopeManager.ContinuableScope, 40)
+  }
+
+  def "single continuation layout"() {
+    expect: layoutAcceptable(ContinuableScopeManager.SingleContinuation, 32)
+  }
+
+  def "concurrent continuation layout"() {
+    expect: layoutAcceptable(ContinuableScopeManager.ConcurrentContinuation, 32)
+  }
+
+  def layoutAcceptable(Class<?> klass, int acceptableSize) {
+    def layout = ClassLayout.parseClass(klass)
+    System.err.println(layout.toPrintable())
+    return layout.instanceSize() <= acceptableSize
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/ScopeSource.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/ScopeSource.java
@@ -1,6 +1,16 @@
 package datadog.trace.bootstrap.instrumentation.api;
 
 public enum ScopeSource {
-  INSTRUMENTATION,
-  MANUAL
+  INSTRUMENTATION((byte) 0),
+  MANUAL((byte) 1);
+
+  private final byte id;
+
+  ScopeSource(byte id) {
+    this.id = id;
+  }
+
+  public byte id() {
+    return id;
+  }
 }


### PR DESCRIPTION
While evaluating the change in #2215 I explored the microbenchmark below:

```java
import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
import org.openjdk.jmh.annotations.*;

import java.util.concurrent.Callable;
import java.util.concurrent.ExecutionException;
import java.util.concurrent.FutureTask;

@State(Scope.Benchmark)
public class RunFutureTask {

  @Param({"true", "false"})
  boolean activeScope;

  private Callable<?> callable;

  @Setup(Level.Trial)
  public void setup() {
    if (activeScope) {
      AgentTracer.activateSpan(AgentTracer.startSpan("foo"));
    }
    callable = (Callable<Object>) () -> "foo";
  }


  @Benchmark
  public Object runFutureTask() throws ExecutionException, InterruptedException {
    FutureTask<?> task = new FutureTask<>(callable);
    task.run();
    return task.get();
  }
}
```

When no scope is active, the overhead involved is the same as a thread local lookup to locate the active scope. 

**master**
```
Benchmark                                          (activeScope)  Mode  Cnt     Score     Error      Units
RunFutureTask.runFutureTask                                false  avgt   25    46.445 ±   1.274      ns/op
RunFutureTask.runFutureTask:instructions                   false  avgt    5   184.507 ±  21.827       #/op
```
**baseline**
```
Benchmark                                          (activeScope)  Mode  Cnt    Score    Error      Units
RunFutureTask.runFutureTask                                false  avgt   25   40.732 ±  0.046      ns/op
RunFutureTask.runFutureTask:instructions                   false  avgt    5  124.645 ±  4.196       #/op
```

We have significant overhead - just in terms of instruction count - when there is an active scope:

**master**
```
Benchmark                                          (activeScope)  Mode  Cnt    Score     Error      Units
RunFutureTask.runFutureTask                                 true  avgt   25  201.416 ±   4.741      ns/op
RunFutureTask.runFutureTask:instructions                    true  avgt    5  966.488 ± 196.951       #/op
```

**baseline**
```
Benchmark                                          (activeScope)  Mode  Cnt    Score    Error      Units
RunFutureTask.runFutureTask                                 true  avgt   25   40.746 ±  0.056      ns/op
RunFutureTask.runFutureTask:instructions                    true  avgt    5  124.743 ±  6.752       #/op
```

The changes here improve the efficiency of scope activation and capture:

**branch**
```
Benchmark                                          (activeScope)  Mode  Cnt    Score     Error      Units
RunFutureTask.runFutureTask                                 true  avgt   25  160.344 ±   1.814      ns/op
RunFutureTask.runFutureTask:instructions                    true  avgt    5  816.620 ±  64.349       #/op
```

One of the changes, to replace references to the `ScopeSource` enum with a `byte` don't actually result in lower size overhead yet, but change the layout so that the source fits into the alignment gap after the boolean, so that if/when another field is removed, there will be a much larger reduction in size because it will include removing 4 bytes of alignment shadow at the end of `ContinuableScope` - reducing the size per scope from 40 to 32 bytes (assuming compressed Oops throughout).

**master**
```
datadog.trace.core.scopemanager.ContinuableScopeManager$ContinuableScope object internals:
 OFFSET  SIZE                                                                   TYPE DESCRIPTION                               VALUE
      0    12                                                                        (object header)                           N/A
     12     1                                                                boolean ContinuableScope.isAsyncPropagating       N/A
     13     3                                                                        (alignment/padding gap)                  
     16     4                datadog.trace.core.scopemanager.ContinuableScopeManager ContinuableScope.scopeManager             N/A
     20     4   datadog.trace.core.scopemanager.ContinuableScopeManager.Continuation ContinuableScope.continuation             N/A
     24     4                datadog.trace.bootstrap.instrumentation.api.ScopeSource ContinuableScope.source                   N/A
     28     4                              java.util.concurrent.atomic.AtomicInteger ContinuableScope.referenceCount           N/A
     32     4                                    datadog.trace.core.jfr.DDScopeEvent ContinuableScope.event                    N/A
     36     4                  datadog.trace.bootstrap.instrumentation.api.AgentSpan ContinuableScope.span                     N/A
Instance size: 40 bytes
Space losses: 3 bytes internal + 0 bytes external = 3 bytes total
```

**branch**
```
datadog.trace.core.scopemanager.ContinuableScopeManager$ContinuableScope object internals:
 OFFSET  SIZE                                                                   TYPE DESCRIPTION                               VALUE
      0    12                                                                        (object header)                           N/A
     12     1                                                                boolean ContinuableScope.isAsyncPropagating       N/A
     13     1                                                                   byte ContinuableScope.source                   N/A
     14     2                                                                        (alignment/padding gap)                  
     16     4                datadog.trace.core.scopemanager.ContinuableScopeManager ContinuableScope.scopeManager             N/A
     20     4   datadog.trace.core.scopemanager.ContinuableScopeManager.Continuation ContinuableScope.continuation             N/A
     24     4                              java.util.concurrent.atomic.AtomicInteger ContinuableScope.referenceCount           N/A
     28     4                                    datadog.trace.core.jfr.DDScopeEvent ContinuableScope.event                    N/A
     32     4                  datadog.trace.bootstrap.instrumentation.api.AgentSpan ContinuableScope.span                     N/A
     36     4                                                                        (loss due to the next object alignment)
Instance size: 40 bytes
Space losses: 2 bytes internal + 4 bytes external = 6 bytes total
```

There are two good candidates for removal to get down to 32 bytes per scope - the event field and the reference count field (the latter needs to be traded off against increasing the size of the stack).