### PR TITLE
Use short for reference count in ContinuableScope

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
@@ -181,7 +181,7 @@ public class ContinuableScopeManager implements AgentScopeManager {
 
     private final byte source;
 
-    private int referenceCount = 1;
+    private short referenceCount = 1;
 
     private final DDScopeEvent event;
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeAndContinuationLayoutTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeAndContinuationLayoutTest.groovy
@@ -8,7 +8,7 @@ import spock.lang.Requires
 class ScopeAndContinuationLayoutTest extends DDSpecification {
 
   def "continuable scope layout"() {
-    expect: layoutAcceptable(ContinuableScopeManager.ContinuableScope, 40)
+    expect: layoutAcceptable(ContinuableScopeManager.ContinuableScope, 32)
   }
 
   def "single continuation layout"() {


### PR DESCRIPTION
This is functionally equivalent, so long as the _currently active_ span does not have more than 32768 scopes created per thread, and allow the reference count to be stored in an alignment gap, saving 8 bytes per scope.

**master**
```
datadog.trace.core.scopemanager.ContinuableScopeManager$ContinuableScope object internals:
 OFFSET  SIZE                                                                   TYPE DESCRIPTION                               VALUE
      0    12                                                                        (object header)                           N/A
     12     4                                                                    int ContinuableScope.referenceCount           N/A
     16     1                                                                boolean ContinuableScope.isAsyncPropagating       N/A
     17     1                                                                   byte ContinuableScope.source                   N/A
     18     2                                                                        (alignment/padding gap)                  
     20     4                datadog.trace.core.scopemanager.ContinuableScopeManager ContinuableScope.scopeManager             N/A
     24     4   datadog.trace.core.scopemanager.ContinuableScopeManager.Continuation ContinuableScope.continuation             N/A
     28     4                                    datadog.trace.core.jfr.DDScopeEvent ContinuableScope.event                    N/A
     32     4                  datadog.trace.bootstrap.instrumentation.api.AgentSpan ContinuableScope.span                     N/A
     36     4                                                                        (loss due to the next object alignment)
Instance size: 40 bytes
Space losses: 2 bytes internal + 4 bytes external = 6 bytes total
```

**branch**
```
datadog.trace.core.scopemanager.ContinuableScopeManager$ContinuableScope object internals:
 OFFSET  SIZE                                                                   TYPE DESCRIPTION                               VALUE
      0    12                                                                        (object header)                           N/A
     12     2                                                                  short ContinuableScope.referenceCount           N/A
     14     1                                                                boolean ContinuableScope.isAsyncPropagating       N/A
     15     1                                                                   byte ContinuableScope.source                   N/A
     16     4                datadog.trace.core.scopemanager.ContinuableScopeManager ContinuableScope.scopeManager             N/A
     20     4   datadog.trace.core.scopemanager.ContinuableScopeManager.Continuation ContinuableScope.continuation             N/A
     24     4                                    datadog.trace.core.jfr.DDScopeEvent ContinuableScope.event                    N/A
     28     4                  datadog.trace.bootstrap.instrumentation.api.AgentSpan ContinuableScope.span                     N/A
Instance size: 32 bytes
Space losses: 0 bytes internal + 0 bytes external = 0 bytes total
```