### PR TITLE
expunge aggregates not updated within a reporting cycle

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/Aggregator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/Aggregator.java
@@ -1,8 +1,11 @@
 package datadog.trace.common.metrics;
 
+import static datadog.trace.common.metrics.Batch.REPORT;
+import static datadog.trace.common.metrics.ConflatingMetricsAggregator.POISON_PILL;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 import datadog.trace.core.util.LRUCache;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.BlockingQueue;
@@ -21,9 +24,7 @@ final class Aggregator implements Runnable {
   // buffered by OkHttpSink)
   private final long reportingIntervalNanos;
 
-  private long wallClockTime = -1;
-
-  private long lastReportTime = -1;
+  private boolean dirty;
 
   Aggregator(
       MetricWriter writer,
@@ -50,11 +51,13 @@ final class Aggregator implements Runnable {
     Thread currentThread = Thread.currentThread();
     while (!currentThread.isInterrupted()) {
       try {
-        Batch batch = inbox.poll(100, MILLISECONDS);
-        if (batch == ConflatingMetricsAggregator.POISON_PILL) {
+        Batch batch = inbox.take();
+        if (batch == POISON_PILL) {
           report(wallClockTime());
-          return;
-        } else if (null != batch) {
+          break;
+        } else if (batch == REPORT) {
+          report(wallClockTime());
+        } else {
           MetricKey key = batch.getKey();
           // important that it is still *this* batch pending, must not remove otherwise
           pending.remove(key, batch);
@@ -64,9 +67,9 @@ final class Aggregator implements Runnable {
             aggregates.put(key, aggregate);
           }
           batch.contributeTo(aggregate);
+          dirty = true;
           // return the batch for reuse
           batchPool.offer(batch);
-          reportIfNecessary();
         }
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
@@ -74,29 +77,30 @@ final class Aggregator implements Runnable {
     }
   }
 
-  private void reportIfNecessary() {
-    if (lastReportTime == -1) {
-      lastReportTime = System.nanoTime();
-      wallClockTime = wallClockTime();
-    } else if (!aggregates.isEmpty()) {
-      long now = System.nanoTime();
-      long delta = now - lastReportTime;
-      if (delta > reportingIntervalNanos) {
-        report(wallClockTime + delta);
-        lastReportTime = now;
-        wallClockTime = wallClockTime();
+  private void report(long when) {
+    if (dirty) {
+      expungeStaleAggregates();
+      writer.startBucket(aggregates.size(), when, reportingIntervalNanos);
+      for (Map.Entry<MetricKey, AggregateMetric> aggregate : aggregates.entrySet()) {
+        if (aggregate.getValue().getHitCount() > 0) {
+          writer.add(aggregate.getKey(), aggregate.getValue());
+          aggregate.getValue().clear();
+        }
       }
+      // note that this may do IO and block
+      writer.finishBucket();
+      dirty = false;
     }
   }
 
-  private void report(long when) {
-    writer.startBucket(aggregates.size(), when, reportingIntervalNanos);
-    for (Map.Entry<MetricKey, AggregateMetric> aggregate : aggregates.entrySet()) {
-      writer.add(aggregate.getKey(), aggregate.getValue());
-      aggregate.getValue().clear();
+  private void expungeStaleAggregates() {
+    Iterator<Map.Entry<MetricKey, AggregateMetric>> it = aggregates.entrySet().iterator();
+    while (it.hasNext()) {
+      AggregateMetric metric = it.next().getValue();
+      if (metric.getHitCount() == 0) {
+        it.remove();
+      }
     }
-    // note that this may do IO and block
-    writer.finishBucket();
   }
 
   private long wallClockTime() {

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/Aggregator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/Aggregator.java
@@ -80,15 +80,17 @@ final class Aggregator implements Runnable {
   private void report(long when) {
     if (dirty) {
       expungeStaleAggregates();
-      writer.startBucket(aggregates.size(), when, reportingIntervalNanos);
-      for (Map.Entry<MetricKey, AggregateMetric> aggregate : aggregates.entrySet()) {
-        if (aggregate.getValue().getHitCount() > 0) {
-          writer.add(aggregate.getKey(), aggregate.getValue());
-          aggregate.getValue().clear();
+      if (!aggregates.isEmpty()) {
+        writer.startBucket(aggregates.size(), when, reportingIntervalNanos);
+        for (Map.Entry<MetricKey, AggregateMetric> aggregate : aggregates.entrySet()) {
+          if (aggregate.getValue().getHitCount() > 0) {
+            writer.add(aggregate.getKey(), aggregate.getValue());
+            aggregate.getValue().clear();
+          }
         }
+        // note that this may do IO and block
+        writer.finishBucket();
       }
-      // note that this may do IO and block
-      writer.finishBucket();
       dirty = false;
     }
   }

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/Batch.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/Batch.java
@@ -15,7 +15,8 @@ import java.util.concurrent.atomic.AtomicLongArray;
 public final class Batch {
 
   private static final int MAX_BATCH_SIZE = 64;
-  public static final Batch NULL = new Batch((AtomicLongArray) null);
+  static final Batch NULL = new Batch((AtomicLongArray) null);
+  static final Batch REPORT = new Batch((AtomicLongArray) null);
 
   /**
    * This counter has two states 1 - negative - the batch has been used, must not add values 2 -

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/ConflatingMetricsAggregator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/ConflatingMetricsAggregator.java
@@ -105,6 +105,14 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
   }
 
   @Override
+  public void report() {
+    boolean published;
+    do {
+      published = inbox.offer(REPORT);
+    } while (!published);
+  }
+
+  @Override
   public void publish(List<? extends CoreSpan<?>> trace) {
     if (enabled) {
       for (CoreSpan<?> span : trace) {
@@ -202,10 +210,7 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
 
     @Override
     public void run(ConflatingMetricsAggregator target) {
-      boolean published;
-      do {
-        published = target.inbox.offer(REPORT);
-      } while (!published);
+      target.report();
     }
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/ConflatingMetricsAggregator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/ConflatingMetricsAggregator.java
@@ -1,6 +1,7 @@
 package datadog.trace.common.metrics;
 
 import static datadog.trace.common.metrics.AggregateMetric.ERROR_TAG;
+import static datadog.trace.common.metrics.Batch.REPORT;
 import static datadog.trace.util.AgentThreadFactory.AgentThread.METRICS_AGGREGATOR;
 import static datadog.trace.util.AgentThreadFactory.THREAD_JOIN_TIMOUT_MS;
 import static datadog.trace.util.AgentThreadFactory.newAgentThread;
@@ -10,6 +11,7 @@ import datadog.trace.api.Config;
 import datadog.trace.api.WellKnownTags;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.core.CoreSpan;
+import datadog.trace.util.AgentTaskScheduler;
 import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.BlockingQueue;
@@ -32,8 +34,11 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
   private final BlockingQueue<Batch> inbox;
   private final Sink sink;
   private final Aggregator aggregator;
+  private final long reportingInterval;
+  private final TimeUnit reportingIntervalTimeUnit;
 
   private volatile boolean enabled = true;
+  private volatile AgentTaskScheduler.Scheduled<?> cancellation;
 
   public ConflatingMetricsAggregator(Config config) {
     this(
@@ -82,12 +87,21 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
         new Aggregator(
             metricWriter, batchPool, inbox, pending, maxAggregates, reportingInterval, timeUnit);
     this.thread = newAgentThread(METRICS_AGGREGATOR, aggregator);
+    this.reportingInterval = reportingInterval;
+    this.reportingIntervalTimeUnit = timeUnit;
   }
 
   @Override
   public void start() {
     sink.register(this);
     thread.start();
+    cancellation =
+        AgentTaskScheduler.INSTANCE.scheduleAtFixedRate(
+            new ReportTask(),
+            this,
+            reportingInterval,
+            reportingInterval,
+            reportingIntervalTimeUnit);
   }
 
   @Override
@@ -142,6 +156,9 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
   }
 
   public void stop() {
+    if (null != cancellation) {
+      cancellation.cancel();
+    }
     inbox.offer(POISON_PILL);
   }
 
@@ -178,5 +195,17 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
     this.batchPool.clear();
     this.inbox.clear();
     this.aggregator.clearAggregates();
+  }
+
+  private static final class ReportTask
+      implements AgentTaskScheduler.Task<ConflatingMetricsAggregator> {
+
+    @Override
+    public void run(ConflatingMetricsAggregator target) {
+      boolean published;
+      do {
+        published = target.inbox.offer(REPORT);
+      } while (!published);
+    }
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/MetricsAggregator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/MetricsAggregator.java
@@ -6,5 +6,7 @@ import java.util.List;
 public interface MetricsAggregator extends AutoCloseable {
   void start();
 
+  void report();
+
   void publish(List<? extends CoreSpan<?>> trace);
 }

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/NoOpMetricsAggregator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/NoOpMetricsAggregator.java
@@ -11,6 +11,9 @@ public final class NoOpMetricsAggregator implements MetricsAggregator {
   public void start() {}
 
   @Override
+  public void report() {}
+
+  @Override
   public void publish(List<? extends CoreSpan<?>> trace) {}
 
   @Override

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/ConflatingMetricAggregatorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/ConflatingMetricAggregatorTest.groovy
@@ -4,6 +4,7 @@ import datadog.trace.api.WellKnownTags
 import datadog.trace.core.CoreSpan
 import datadog.trace.test.util.DDSpecification
 import spock.lang.Requires
+import spock.lang.Shared
 
 import java.util.concurrent.CountDownLatch
 
@@ -14,6 +15,11 @@ import static java.util.concurrent.TimeUnit.SECONDS
 @Requires({ isJavaVersionAtLeast(8) })
 class ConflatingMetricAggregatorTest extends DDSpecification {
 
+  @Shared
+  long reportingInterval = 10
+  @Shared
+  int queueSize = 256
+
   def "should ignore traces with no measured spans"() {
     setup:
     Sink sink = Mock(Sink)
@@ -22,7 +28,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
       wellKnownTags,
       sink,
       10,
-      10,
+      queueSize,
       1,
       MILLISECONDS
     )
@@ -30,7 +36,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
 
     when:
     aggregator.publish([new SimpleSpan("", "", "", "", false, false, false, 0, 0)])
-
+    reportAndWaitUntilEmpty(aggregator)
     then:
     0 * sink._
 
@@ -41,31 +47,32 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
   def "unmeasured top level spans have metrics computed"() {
     setup:
     MetricWriter writer = Mock(MetricWriter)
-    CountDownLatch latch = new CountDownLatch(1)
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(
-      Mock(Sink), writer, 10, 10, 10, SECONDS)
+      Stub(Sink), writer, 10, queueSize, reportingInterval, SECONDS)
     aggregator.start()
 
     when:
+    CountDownLatch latch = new CountDownLatch(1)
     aggregator.publish([new SimpleSpan("service", "operation", "resource", "type", false, true, false, 0, 100)])
-    aggregator.stop()
-    latch.await(10, SECONDS)
+    aggregator.report()
+    latch.await(2, SECONDS)
 
     then:
-    1 * writer.finishBucket() >> { latch.countDown() }
     1 * writer.startBucket(1, _, _)
     1 * writer.add(new MetricKey("resource", "service", "operation", "type", 0), _) >> {
       MetricKey key, AggregateMetric value -> value.getHitCount() == 1 && value.getDuration() == 100
     }
+    1 * writer.finishBucket() >> { latch.countDown() }
+
+    cleanup:
+    aggregator.close()
   }
 
   def "aggregate repetitive spans"() {
     setup:
-    int reportingInterval = 10
-    CountDownLatch latch = new CountDownLatch(1)
     MetricWriter writer = Mock(MetricWriter)
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(
-      Mock(Sink), writer, 10, 10, reportingInterval, SECONDS)
+      Stub(Sink), writer, 10, queueSize, reportingInterval, SECONDS)
     long duration = 100
     List<CoreSpan> trace = [
       new SimpleSpan("service", "operation", "resource", "type", true, false, false, 0, duration),
@@ -76,11 +83,12 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
 
 
     when:
+    CountDownLatch latch = new CountDownLatch(1)
     for (int i = 0; i < count; ++i) {
       aggregator.publish(trace)
     }
-    aggregator.stop()
-    latch.await(10, SECONDS)
+    aggregator.report()
+    latch.await(2, SECONDS)
 
     then: "metrics should be conflated"
     1 * writer.finishBucket() >> { latch.countDown() }
@@ -101,24 +109,22 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
 
   def "test least recently written to aggregate flushed when size limit exceeded"(){
     setup:
-    int reportingInterval = 10
     int maxAggregates = 10
-    CountDownLatch latch = new CountDownLatch(1)
     MetricWriter writer = Mock(MetricWriter)
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(
-      Mock(Sink), writer, maxAggregates, 10, reportingInterval, SECONDS)
+      Stub(Sink), writer, maxAggregates, queueSize, reportingInterval, SECONDS)
     long duration = 100
     aggregator.start()
 
     when:
+    CountDownLatch latch = new CountDownLatch(1)
     for (int i = 0; i < 11; ++i) {
       aggregator.publish([new SimpleSpan("service" + i, "operation", "resource", "type", false, true, false, 0, duration)])
     }
-    aggregator.stop()
-    latch.await(10, SECONDS)
+    aggregator.report()
+    latch.await(2, SECONDS)
 
     then: "the first aggregate should be dropped but the rest reported"
-    1 * writer.finishBucket() >> { latch.countDown() }
     1 * writer.startBucket(10, _, SECONDS.toNanos(reportingInterval))
     for (int i = 1; i < 11; ++i) {
       1 * writer.add(new MetricKey("resource", "service" + i, "operation", "type", 0), _) >> {
@@ -126,6 +132,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
       }
     }
     0 * writer.add(new MetricKey("resource", "service0", "operation", "type", 0), _)
+    1 * writer.finishBucket() >> { latch.countDown() }
 
     cleanup:
     aggregator.close()
@@ -133,11 +140,10 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
 
   def "aggregate not updated in reporting interval not reported"() {
     setup:
-    int reportingInterval = 1
     int maxAggregates = 10
     MetricWriter writer = Mock(MetricWriter)
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(
-      Mock(Sink), writer, maxAggregates, 10, reportingInterval, SECONDS)
+      Stub(Sink), writer, maxAggregates, queueSize, reportingInterval, SECONDS)
     long duration = 100
     aggregator.start()
 
@@ -146,26 +152,27 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     for (int i = 0; i < 5; ++i) {
       aggregator.publish([new SimpleSpan("service" + i, "operation", "resource", "type", false, true, false, 0, duration)])
     }
+    aggregator.report()
     latch.await(2, SECONDS)
 
     then: "all aggregates should be reported"
-    1 * writer.finishBucket() >> { latch.countDown() }
     1 * writer.startBucket(5, _, SECONDS.toNanos(reportingInterval))
     for (int i = 0; i < 5; ++i) {
       1 * writer.add(new MetricKey("resource", "service" + i, "operation", "type", 0), _) >> {
         MetricKey key, AggregateMetric value -> value.getHitCount() == 1 && value.getDuration() == duration
       }
     }
+    1 * writer.finishBucket() >> { latch.countDown() }
 
     when:
     latch = new CountDownLatch(1)
     for (int i = 1; i < 5; ++i) {
       aggregator.publish([new SimpleSpan("service" + i, "operation", "resource", "type", false, true, false, 0, duration)])
     }
+    aggregator.report()
     latch.await(2, SECONDS)
 
     then: "aggregate not updated in cycle is not reported"
-    1 * writer.finishBucket() >> { latch.countDown() }
     1 * writer.startBucket(4, _, SECONDS.toNanos(reportingInterval))
     for (int i = 1; i < 5; ++i) {
       1 * writer.add(new MetricKey("resource", "service" + i, "operation", "type", 0), _) >> {
@@ -173,8 +180,61 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
       }
     }
     0 * writer.add(new MetricKey("resource", "service0", "operation", "type", 0), _)
+    1 * writer.finishBucket() >> { latch.countDown() }
 
     cleanup:
     aggregator.close()
+  }
+
+  def "when no aggregate is updated in reporting interval nothing is reported"() {
+    setup:
+    int maxAggregates = 10
+    MetricWriter writer = Mock(MetricWriter)
+    ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(
+      Stub(Sink), writer, maxAggregates, queueSize, reportingInterval, SECONDS)
+    long duration = 100
+    aggregator.start()
+
+    when:
+    CountDownLatch latch = new CountDownLatch(1)
+    for (int i = 0; i < 5; ++i) {
+      aggregator.publish([new SimpleSpan("service" + i, "operation", "resource", "type", false, true, false, 0, duration)])
+    }
+    aggregator.report()
+    latch.await(2, SECONDS)
+
+    then: "all aggregates should be reported"
+    1 * writer.startBucket(5, _, SECONDS.toNanos(reportingInterval))
+    for (int i = 0; i < 5; ++i) {
+      1 * writer.add(new MetricKey("resource", "service" + i, "operation", "type", 0), _) >> {
+        MetricKey key, AggregateMetric value -> value.getHitCount() == 1 && value.getDuration() == duration
+      }
+    }
+    1 * writer.finishBucket()
+
+    when:
+    reportAndWaitUntilEmpty(aggregator)
+
+    then: "aggregate not updated in cycle is not reported"
+    0 * writer.finishBucket()
+    0 * writer.startBucket(_, _, _)
+    0 * writer.add(_, _)
+
+    cleanup:
+    aggregator.close()
+  }
+
+  def reportAndWaitUntilEmpty(ConflatingMetricsAggregator aggregator) {
+    waitUntilEmpty(aggregator)
+    aggregator.report()
+    waitUntilEmpty(aggregator)
+  }
+
+
+  def waitUntilEmpty(ConflatingMetricsAggregator aggregator) {
+    int i = 0
+    while (!aggregator.inbox.isEmpty() && i++ < 100) {
+      Thread.sleep(10)
+    }
   }
 }


### PR DESCRIPTION
Aggregates which have been previously reported, but have not been updated in the last reporting cycle, would be reported as empty metrics. This PR changes this behaviour to expunge any metrics which have not been updated recently so they drop out of the LRU cache early.