### PR TITLE
Add db.operation tag to JDBC spans

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jdbc/DBQueryInfo.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jdbc/DBQueryInfo.java
@@ -1,0 +1,47 @@
+package datadog.trace.bootstrap.instrumentation.jdbc;
+
+import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
+
+public final class DBQueryInfo {
+
+  private final UTF8BytesString operation;
+  private final UTF8BytesString sql;
+
+  public DBQueryInfo(UTF8BytesString sql) {
+    this.sql = sql;
+    this.operation = UTF8BytesString.create(extractOperation(sql));
+  }
+
+  public UTF8BytesString getOperation() {
+    return operation;
+  }
+
+  public UTF8BytesString getSql() {
+    return sql;
+  }
+
+  public static CharSequence extractOperation(CharSequence sql) {
+    if (null == sql) {
+      return null;
+    }
+    int start = 0;
+    for (int i = 0; i < sql.length(); ++i) {
+      if (Character.isAlphabetic(sql.charAt(i))) {
+        start = i;
+        break;
+      }
+    }
+    int firstWhitespace = -1;
+    for (int i = start; i < sql.length(); ++i) {
+      char c = sql.charAt(i);
+      if (Character.isWhitespace(c)) {
+        firstWhitespace = i;
+        break;
+      }
+    }
+    if (firstWhitespace > -1) {
+      return sql.subSequence(start, firstWhitespace);
+    }
+    return null;
+  }
+}

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/DBQueryInfoTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/DBQueryInfoTest.groovy
@@ -1,0 +1,22 @@
+package datadog.trace.bootstrap.instrumentation
+
+import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString
+import datadog.trace.bootstrap.instrumentation.jdbc.DBQueryInfo
+import datadog.trace.test.util.DDSpecification
+
+class DBQueryInfoTest extends DDSpecification {
+  
+  def "extract operation name" () {
+    when:
+    DBQueryInfo info = new DBQueryInfo(UTF8BytesString.create(sql))
+    then:
+    info.getOperation() as String == operation
+
+    where:
+    operation         | sql
+    "INSERT"          | "INSERT INTO table_name (column1, column2, column3, ...) VALUES (value1, value2, value3, ...)"
+    "UPDATE"          | "UPDATE table_name SET column1 = value1, column2 = value2, WHERE condition;"
+    "SELECT"          | "SELECT * FROM TABLE WHERE condition"
+    "CALL"            | "{CALL STORED_PROC()}"
+  }
+}

--- a/dd-java-agent/instrumentation/datanucleus-4/src/test/groovy/DatanucleusTest.groovy
+++ b/dd-java-agent/instrumentation/datanucleus-4/src/test/groovy/DatanucleusTest.groovy
@@ -418,6 +418,7 @@ class DatanucleusTest extends AgentTestRunner {
         "$Tags.DB_TYPE" "h2"
         "$Tags.DB_INSTANCE" "nucleus"
         "$Tags.DB_USER" "sa"
+        "$Tags.DB_OPERATION" queryStart.split(" ")[0]
         defaultTags()
       }
     }

--- a/dd-java-agent/instrumentation/hibernate/core-3.3/src/test/groovy/CriteriaTest.groovy
+++ b/dd-java-agent/instrumentation/hibernate/core-3.3/src/test/groovy/CriteriaTest.groovy
@@ -67,6 +67,7 @@ class CriteriaTest extends AbstractHibernateTest {
             "$Tags.DB_TYPE" "h2"
             "$Tags.DB_INSTANCE" "db1"
             "$Tags.DB_USER" "sa"
+            "$Tags.DB_OPERATION" CharSequence
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/hibernate/core-3.3/src/test/groovy/QueryTest.groovy
+++ b/dd-java-agent/instrumentation/hibernate/core-3.3/src/test/groovy/QueryTest.groovy
@@ -72,6 +72,7 @@ class QueryTest extends AbstractHibernateTest {
             "$Tags.DB_TYPE" "h2"
             "$Tags.DB_INSTANCE" "db1"
             "$Tags.DB_USER" "sa"
+            "$Tags.DB_OPERATION" CharSequence
             defaultTags()
           }
         }
@@ -113,6 +114,7 @@ class QueryTest extends AbstractHibernateTest {
               "$Tags.DB_TYPE" "h2"
               "$Tags.DB_INSTANCE" "db1"
               "$Tags.DB_USER" "sa"
+              "$Tags.DB_OPERATION" CharSequence
               defaultTags()
             }
           }
@@ -206,6 +208,7 @@ class QueryTest extends AbstractHibernateTest {
             "$Tags.DB_TYPE" "h2"
             "$Tags.DB_INSTANCE" "db1"
             "$Tags.DB_USER" "sa"
+            "$Tags.DB_OPERATION" CharSequence
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/hibernate/core-3.3/src/test/groovy/SessionTest.groovy
+++ b/dd-java-agent/instrumentation/hibernate/core-3.3/src/test/groovy/SessionTest.groovy
@@ -87,6 +87,7 @@ class SessionTest extends AbstractHibernateTest {
               "$Tags.DB_TYPE" "h2"
               "$Tags.DB_INSTANCE" "db1"
               "$Tags.DB_USER" "sa"
+              "$Tags.DB_OPERATION" CharSequence
               defaultTags()
             }
           }
@@ -160,6 +161,7 @@ class SessionTest extends AbstractHibernateTest {
             "$Tags.DB_TYPE" "h2"
             "$Tags.DB_INSTANCE" "db1"
             "$Tags.DB_USER" "sa"
+            "$Tags.DB_OPERATION" CharSequence
             defaultTags()
           }
         }
@@ -249,6 +251,7 @@ class SessionTest extends AbstractHibernateTest {
             "$Tags.DB_TYPE" "h2"
             "$Tags.DB_INSTANCE" "db1"
             "$Tags.DB_USER" "sa"
+            "$Tags.DB_OPERATION" CharSequence
             defaultTags()
           }
         }
@@ -274,6 +277,7 @@ class SessionTest extends AbstractHibernateTest {
             "$Tags.DB_TYPE" "h2"
             "$Tags.DB_INSTANCE" "db1"
             "$Tags.DB_USER" "sa"
+            "$Tags.DB_OPERATION" CharSequence
             defaultTags()
           }
         }
@@ -410,6 +414,7 @@ class SessionTest extends AbstractHibernateTest {
             "$Tags.DB_TYPE" "h2"
             "$Tags.DB_INSTANCE" "db1"
             "$Tags.DB_USER" "sa"
+            "$Tags.DB_OPERATION" CharSequence
             defaultTags()
           }
         }
@@ -519,6 +524,7 @@ class SessionTest extends AbstractHibernateTest {
             "$Tags.DB_TYPE" "h2"
             "$Tags.DB_INSTANCE" "db1"
             "$Tags.DB_USER" "sa"
+            "$Tags.DB_OPERATION" CharSequence
             defaultTags()
           }
         }
@@ -613,6 +619,7 @@ class SessionTest extends AbstractHibernateTest {
             "$Tags.DB_TYPE" "h2"
             "$Tags.DB_INSTANCE" "db1"
             "$Tags.DB_USER" "sa"
+            "$Tags.DB_OPERATION" CharSequence
             defaultTags()
           }
         }
@@ -626,6 +633,7 @@ class SessionTest extends AbstractHibernateTest {
             "$Tags.DB_TYPE" "h2"
             "$Tags.DB_INSTANCE" "db1"
             "$Tags.DB_USER" "sa"
+            "$Tags.DB_OPERATION" CharSequence
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/hibernate/core-4.0/src/test/groovy/CriteriaTest.groovy
+++ b/dd-java-agent/instrumentation/hibernate/core-4.0/src/test/groovy/CriteriaTest.groovy
@@ -67,6 +67,7 @@ class CriteriaTest extends AbstractHibernateTest {
             "$Tags.DB_TYPE" "h2"
             "$Tags.DB_INSTANCE" "db1"
             "$Tags.DB_USER" "sa"
+            "$Tags.DB_OPERATION" "select"
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/hibernate/core-4.0/src/test/groovy/QueryTest.groovy
+++ b/dd-java-agent/instrumentation/hibernate/core-4.0/src/test/groovy/QueryTest.groovy
@@ -72,6 +72,7 @@ class QueryTest extends AbstractHibernateTest {
             "$Tags.DB_TYPE" "h2"
             "$Tags.DB_INSTANCE" "db1"
             "$Tags.DB_USER" "sa"
+            "$Tags.DB_OPERATION" CharSequence
             defaultTags()
           }
         }
@@ -113,6 +114,7 @@ class QueryTest extends AbstractHibernateTest {
               "$Tags.DB_TYPE" "h2"
               "$Tags.DB_INSTANCE" "db1"
               "$Tags.DB_USER" "sa"
+              "$Tags.DB_OPERATION" CharSequence
               defaultTags()
             }
           }
@@ -206,6 +208,7 @@ class QueryTest extends AbstractHibernateTest {
             "$Tags.DB_TYPE" "h2"
             "$Tags.DB_INSTANCE" "db1"
             "$Tags.DB_USER" "sa"
+            "$Tags.DB_OPERATION" "select"
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/hibernate/core-4.0/src/test/groovy/SessionTest.groovy
+++ b/dd-java-agent/instrumentation/hibernate/core-4.0/src/test/groovy/SessionTest.groovy
@@ -87,6 +87,7 @@ class SessionTest extends AbstractHibernateTest {
               "$Tags.DB_TYPE" "h2"
               "$Tags.DB_INSTANCE" "db1"
               "$Tags.DB_USER" "sa"
+              "$Tags.DB_OPERATION" CharSequence
               defaultTags()
             }
           }
@@ -174,6 +175,7 @@ class SessionTest extends AbstractHibernateTest {
             "$Tags.DB_TYPE" "h2"
             "$Tags.DB_INSTANCE" "db1"
             "$Tags.DB_USER" "sa"
+            "$Tags.DB_OPERATION" CharSequence
             defaultTags()
           }
         }
@@ -199,6 +201,7 @@ class SessionTest extends AbstractHibernateTest {
             "$Tags.DB_TYPE" "h2"
             "$Tags.DB_INSTANCE" "db1"
             "$Tags.DB_USER" "sa"
+            "$Tags.DB_OPERATION" CharSequence
             defaultTags()
           }
         }
@@ -335,6 +338,7 @@ class SessionTest extends AbstractHibernateTest {
             "$Tags.DB_TYPE" "h2"
             "$Tags.DB_INSTANCE" "db1"
             "$Tags.DB_USER" "sa"
+            "$Tags.DB_OPERATION" CharSequence
             defaultTags()
           }
         }
@@ -444,6 +448,7 @@ class SessionTest extends AbstractHibernateTest {
             "$Tags.DB_TYPE" "h2"
             "$Tags.DB_INSTANCE" "db1"
             "$Tags.DB_USER" "sa"
+            "$Tags.DB_OPERATION" CharSequence
             defaultTags()
           }
         }
@@ -537,6 +542,7 @@ class SessionTest extends AbstractHibernateTest {
             "$Tags.DB_TYPE" "h2"
             "$Tags.DB_INSTANCE" "db1"
             "$Tags.DB_USER" "sa"
+            "$Tags.DB_OPERATION" CharSequence
             defaultTags()
           }
         }
@@ -550,6 +556,7 @@ class SessionTest extends AbstractHibernateTest {
             "$Tags.DB_TYPE" "h2"
             "$Tags.DB_INSTANCE" "db1"
             "$Tags.DB_USER" "sa"
+            "$Tags.DB_OPERATION" CharSequence
             defaultTags()
           }
         }
@@ -611,6 +618,7 @@ class SessionTest extends AbstractHibernateTest {
             "$Tags.DB_TYPE" "h2"
             "$Tags.DB_INSTANCE" "db1"
             "$Tags.DB_USER" "sa"
+            "$Tags.DB_OPERATION" CharSequence
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/hibernate/core-4.3/src/test/groovy/ProcedureCallTest.groovy
+++ b/dd-java-agent/instrumentation/hibernate/core-4.3/src/test/groovy/ProcedureCallTest.groovy
@@ -118,6 +118,7 @@ class ProcedureCallTest extends AgentTestRunner {
             "$Tags.DB_TYPE" "hsqldb"
             "$Tags.DB_INSTANCE" "test"
             "$Tags.DB_USER" "sa"
+            "$Tags.DB_OPERATION" "call"
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/hibernate/core-4.3/src/test/groovy/SpringJpaTest.groovy
+++ b/dd-java-agent/instrumentation/hibernate/core-4.3/src/test/groovy/SpringJpaTest.groovy
@@ -38,6 +38,7 @@ class SpringJpaTest extends AgentTestRunner {
             "$Tags.DB_TYPE" "hsqldb"
             "$Tags.DB_INSTANCE" "test"
             "$Tags.DB_USER" "sa"
+            "$Tags.DB_OPERATION" "select"
             defaultTags()
           }
         }
@@ -66,6 +67,7 @@ class SpringJpaTest extends AgentTestRunner {
               "$Tags.DB_TYPE" "hsqldb"
               "$Tags.DB_INSTANCE" "test"
               "$Tags.DB_USER" "sa"
+              "$Tags.DB_OPERATION" "call"
               defaultTags()
             }
           }
@@ -82,6 +84,7 @@ class SpringJpaTest extends AgentTestRunner {
             "$Tags.DB_TYPE" "hsqldb"
             "$Tags.DB_INSTANCE" "test"
             "$Tags.DB_USER" "sa"
+            "$Tags.DB_OPERATION" "insert"
             defaultTags()
           }
         }
@@ -107,6 +110,7 @@ class SpringJpaTest extends AgentTestRunner {
             "$Tags.DB_TYPE" "hsqldb"
             "$Tags.DB_INSTANCE" "test"
             "$Tags.DB_USER" "sa"
+            "$Tags.DB_OPERATION" "select"
             defaultTags()
           }
         }
@@ -122,6 +126,7 @@ class SpringJpaTest extends AgentTestRunner {
             "$Tags.DB_TYPE" "hsqldb"
             "$Tags.DB_INSTANCE" "test"
             "$Tags.DB_USER" "sa"
+            "$Tags.DB_OPERATION" "update"
             defaultTags()
           }
         }
@@ -147,6 +152,7 @@ class SpringJpaTest extends AgentTestRunner {
             "$Tags.DB_TYPE" "hsqldb"
             "$Tags.DB_INSTANCE" "test"
             "$Tags.DB_USER" "sa"
+            "$Tags.DB_OPERATION" "select"
             defaultTags()
           }
         }
@@ -170,6 +176,7 @@ class SpringJpaTest extends AgentTestRunner {
             "$Tags.DB_TYPE" "hsqldb"
             "$Tags.DB_INSTANCE" "test"
             "$Tags.DB_USER" "sa"
+            "$Tags.DB_OPERATION" "select"
             defaultTags()
           }
         }
@@ -185,6 +192,7 @@ class SpringJpaTest extends AgentTestRunner {
             "$Tags.DB_TYPE" "hsqldb"
             "$Tags.DB_INSTANCE" "test"
             "$Tags.DB_USER" "sa"
+            "$Tags.DB_OPERATION" "delete"
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/jdbc/scalikejdbc/src/test/groovy/ScalikeJDBCInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/jdbc/scalikejdbc/src/test/groovy/ScalikeJDBCInstrumentationTest.groovy
@@ -163,6 +163,7 @@ class ScalikeJDBCInstrumentationTest extends AgentTestRunner {
             if (username != null) {
               "$Tags.DB_USER" username
             }
+            "$Tags.DB_OPERATION" "SELECT"
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/ConnectionInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/ConnectionInstrumentation.java
@@ -18,6 +18,7 @@ import datadog.trace.api.Config;
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
+import datadog.trace.bootstrap.instrumentation.jdbc.DBQueryInfo;
 import java.sql.PreparedStatement;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
@@ -91,7 +92,7 @@ public final class ConnectionInstrumentation extends Instrumenter.Tracing {
 
   @Override
   public Map<String, String> contextStore() {
-    return singletonMap("java.sql.PreparedStatement", UTF8BytesString.class.getName());
+    return singletonMap("java.sql.PreparedStatement", DBQueryInfo.class.getName());
   }
 
   @Override
@@ -121,13 +122,13 @@ public final class ConnectionInstrumentation extends Instrumenter.Tracing {
     @Advice.OnMethodExit(suppress = Throwable.class)
     public static void addDBInfo(
         @Advice.Argument(0) final String sql, @Advice.Return final PreparedStatement statement) {
-      ContextStore<PreparedStatement, UTF8BytesString> contextStore =
-          InstrumentationContext.get(PreparedStatement.class, UTF8BytesString.class);
+      ContextStore<PreparedStatement, DBQueryInfo> contextStore =
+          InstrumentationContext.get(PreparedStatement.class, DBQueryInfo.class);
       if (null == contextStore.get(statement)) {
         // Sometimes the prepared statement is not reused, but the underlying String is reused, so
         // check if we have seen this String before
         UTF8BytesString utf8Sql = PREPARED_STATEMENTS_SQL.computeIfAbsent(sql, UTF8_ENCODE);
-        contextStore.putIfAbsent(statement, utf8Sql);
+        contextStore.putIfAbsent(statement, new DBQueryInfo(utf8Sql));
       }
     }
   }

--- a/dd-java-agent/instrumentation/jdbc/src/test/groovy/JDBCInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/jdbc/src/test/groovy/JDBCInstrumentationTest.groovy
@@ -193,6 +193,7 @@ class JDBCInstrumentationTest extends AgentTestRunner {
             if (username != null) {
               "$Tags.DB_USER" username
             }
+            "$Tags.DB_OPERATION" operation
             defaultTags()
           }
         }
@@ -204,22 +205,22 @@ class JDBCInstrumentationTest extends AgentTestRunner {
     connection.close()
 
     where:
-    driver   | connection                                                           | username | renameService | query
-    "h2"     | new Driver().connect(jdbcUrls.get("h2"), null)                       | null     | false         | "SELECT 3"
-    "derby"  | new EmbeddedDriver().connect(jdbcUrls.get("derby"), null)            | "APP"    | false         | "SELECT 3 FROM SYSIBM.SYSDUMMY1"
-    "hsqldb" | new JDBCDriver().connect(jdbcUrls.get("hsqldb"), null)               | "SA"     | false         | "SELECT 3 FROM INFORMATION_SCHEMA.SYSTEM_USERS"
-    "h2"     | new Driver().connect(jdbcUrls.get("h2"), connectionProps)            | null     | true          | "SELECT 3"
-    "derby"  | new EmbeddedDriver().connect(jdbcUrls.get("derby"), connectionProps) | "APP"    | true          | "SELECT 3 FROM SYSIBM.SYSDUMMY1"
-    "hsqldb" | new JDBCDriver().connect(jdbcUrls.get("hsqldb"), connectionProps)    | "SA"     | true          | "SELECT 3 FROM INFORMATION_SCHEMA.SYSTEM_USERS"
-    "h2"     | cpDatasources.get("tomcat").get("h2").getConnection()                | null     | false         | "SELECT 3"
-    "derby"  | cpDatasources.get("tomcat").get("derby").getConnection()             | "APP"    | false         | "SELECT 3 FROM SYSIBM.SYSDUMMY1"
-    "hsqldb" | cpDatasources.get("tomcat").get("hsqldb").getConnection()            | "SA"     | true          | "SELECT 3 FROM INFORMATION_SCHEMA.SYSTEM_USERS"
-    "h2"     | cpDatasources.get("hikari").get("h2").getConnection()                | null     | false         | "SELECT 3"
-    "derby"  | cpDatasources.get("hikari").get("derby").getConnection()             | "APP"    | true          | "SELECT 3 FROM SYSIBM.SYSDUMMY1"
-    "hsqldb" | cpDatasources.get("hikari").get("hsqldb").getConnection()            | "SA"     | false         | "SELECT 3 FROM INFORMATION_SCHEMA.SYSTEM_USERS"
-    "h2"     | cpDatasources.get("c3p0").get("h2").getConnection()                  | null     | true          | "SELECT 3"
-    "derby"  | cpDatasources.get("c3p0").get("derby").getConnection()               | "APP"    | false         | "SELECT 3 FROM SYSIBM.SYSDUMMY1"
-    "hsqldb" | cpDatasources.get("c3p0").get("hsqldb").getConnection()              | "SA"     | false         | "SELECT 3 FROM INFORMATION_SCHEMA.SYSTEM_USERS"
+    driver   | connection                                                           | username | renameService | query                                           | operation
+    "h2"     | new Driver().connect(jdbcUrls.get("h2"), null)                       | null     | false         | "SELECT 3"                                      | "SELECT"
+    "derby"  | new EmbeddedDriver().connect(jdbcUrls.get("derby"), null)            | "APP"    | false         | "SELECT 3 FROM SYSIBM.SYSDUMMY1"                | "SELECT"
+    "hsqldb" | new JDBCDriver().connect(jdbcUrls.get("hsqldb"), null)               | "SA"     | false         | "SELECT 3 FROM INFORMATION_SCHEMA.SYSTEM_USERS" | "SELECT"
+    "h2"     | new Driver().connect(jdbcUrls.get("h2"), connectionProps)            | null     | true          | "SELECT 3"                                      | "SELECT"
+    "derby"  | new EmbeddedDriver().connect(jdbcUrls.get("derby"), connectionProps) | "APP"    | true          | "SELECT 3 FROM SYSIBM.SYSDUMMY1"                | "SELECT"
+    "hsqldb" | new JDBCDriver().connect(jdbcUrls.get("hsqldb"), connectionProps)    | "SA"     | true          | "SELECT 3 FROM INFORMATION_SCHEMA.SYSTEM_USERS" | "SELECT"
+    "h2"     | cpDatasources.get("tomcat").get("h2").getConnection()                | null     | false         | "SELECT 3"                                      | "SELECT"
+    "derby"  | cpDatasources.get("tomcat").get("derby").getConnection()             | "APP"    | false         | "SELECT 3 FROM SYSIBM.SYSDUMMY1"                | "SELECT"
+    "hsqldb" | cpDatasources.get("tomcat").get("hsqldb").getConnection()            | "SA"     | true          | "SELECT 3 FROM INFORMATION_SCHEMA.SYSTEM_USERS" | "SELECT"
+    "h2"     | cpDatasources.get("hikari").get("h2").getConnection()                | null     | false         | "SELECT 3"                                      | "SELECT"
+    "derby"  | cpDatasources.get("hikari").get("derby").getConnection()             | "APP"    | true          | "SELECT 3 FROM SYSIBM.SYSDUMMY1"                | "SELECT"
+    "hsqldb" | cpDatasources.get("hikari").get("hsqldb").getConnection()            | "SA"     | false         | "SELECT 3 FROM INFORMATION_SCHEMA.SYSTEM_USERS" | "SELECT"
+    "h2"     | cpDatasources.get("c3p0").get("h2").getConnection()                  | null     | true          | "SELECT 3"                                      | "SELECT"
+    "derby"  | cpDatasources.get("c3p0").get("derby").getConnection()               | "APP"    | false         | "SELECT 3 FROM SYSIBM.SYSDUMMY1"                | "SELECT"
+    "hsqldb" | cpDatasources.get("c3p0").get("hsqldb").getConnection()              | "SA"     | false         | "SELECT 3 FROM INFORMATION_SCHEMA.SYSTEM_USERS" | "SELECT"
   }
 
   @Unroll
@@ -252,6 +253,7 @@ class JDBCInstrumentationTest extends AgentTestRunner {
             if (username != null) {
               "$Tags.DB_USER" username
             }
+            "$Tags.DB_OPERATION" operation
             defaultTags()
           }
         }
@@ -263,15 +265,15 @@ class JDBCInstrumentationTest extends AgentTestRunner {
     connection.close()
 
     where:
-    driver  | connection                                                | username | query
-    "h2"    | new Driver().connect(jdbcUrls.get("h2"), null)            | null     | "SELECT 3"
-    "derby" | new EmbeddedDriver().connect(jdbcUrls.get("derby"), null) | "APP"    | "SELECT 3 FROM SYSIBM.SYSDUMMY1"
-    "h2"    | cpDatasources.get("tomcat").get("h2").getConnection()     | null     | "SELECT 3"
-    "derby" | cpDatasources.get("tomcat").get("derby").getConnection()  | "APP"    | "SELECT 3 FROM SYSIBM.SYSDUMMY1"
-    "h2"    | cpDatasources.get("hikari").get("h2").getConnection()     | null     | "SELECT 3"
-    "derby" | cpDatasources.get("hikari").get("derby").getConnection()  | "APP"    | "SELECT 3 FROM SYSIBM.SYSDUMMY1"
-    "h2"    | cpDatasources.get("c3p0").get("h2").getConnection()       | null     | "SELECT 3"
-    "derby" | cpDatasources.get("c3p0").get("derby").getConnection()    | "APP"    | "SELECT 3 FROM SYSIBM.SYSDUMMY1"
+    driver  | connection                                                | username | query                            | operation
+    "h2"    | new Driver().connect(jdbcUrls.get("h2"), null)            | null     | "SELECT 3"                       | "SELECT"
+    "derby" | new EmbeddedDriver().connect(jdbcUrls.get("derby"), null) | "APP"    | "SELECT 3 FROM SYSIBM.SYSDUMMY1" | "SELECT"
+    "h2"    | cpDatasources.get("tomcat").get("h2").getConnection()     | null     | "SELECT 3"                       | "SELECT"
+    "derby" | cpDatasources.get("tomcat").get("derby").getConnection()  | "APP"    | "SELECT 3 FROM SYSIBM.SYSDUMMY1" | "SELECT"
+    "h2"    | cpDatasources.get("hikari").get("h2").getConnection()     | null     | "SELECT 3"                       | "SELECT"
+    "derby" | cpDatasources.get("hikari").get("derby").getConnection()  | "APP"    | "SELECT 3 FROM SYSIBM.SYSDUMMY1" | "SELECT"
+    "h2"    | cpDatasources.get("c3p0").get("h2").getConnection()       | null     | "SELECT 3"                       | "SELECT"
+    "derby" | cpDatasources.get("c3p0").get("derby").getConnection()    | "APP"    | "SELECT 3 FROM SYSIBM.SYSDUMMY1" | "SELECT"
   }
 
   @Unroll
@@ -303,6 +305,7 @@ class JDBCInstrumentationTest extends AgentTestRunner {
             if (username != null) {
               "$Tags.DB_USER" username
             }
+            "$Tags.DB_OPERATION" operation
             defaultTags()
           }
         }
@@ -314,15 +317,15 @@ class JDBCInstrumentationTest extends AgentTestRunner {
     connection.close()
 
     where:
-    driver  | connection                                                | username | query
-    "h2"    | new Driver().connect(jdbcUrls.get("h2"), null)            | null     | "SELECT 3"
-    "derby" | new EmbeddedDriver().connect(jdbcUrls.get("derby"), null) | "APP"    | "SELECT 3 FROM SYSIBM.SYSDUMMY1"
-    "h2"    | cpDatasources.get("tomcat").get("h2").getConnection()     | null     | "SELECT 3"
-    "derby" | cpDatasources.get("tomcat").get("derby").getConnection()  | "APP"    | "SELECT 3 FROM SYSIBM.SYSDUMMY1"
-    "h2"    | cpDatasources.get("hikari").get("h2").getConnection()     | null     | "SELECT 3"
-    "derby" | cpDatasources.get("hikari").get("derby").getConnection()  | "APP"    | "SELECT 3 FROM SYSIBM.SYSDUMMY1"
-    "h2"    | cpDatasources.get("c3p0").get("h2").getConnection()       | null     | "SELECT 3"
-    "derby" | cpDatasources.get("c3p0").get("derby").getConnection()    | "APP"    | "SELECT 3 FROM SYSIBM.SYSDUMMY1"
+    driver  | connection                                                | username | query                            | operation
+    "h2"    | new Driver().connect(jdbcUrls.get("h2"), null)            | null     | "SELECT 3"                       | "SELECT"
+    "derby" | new EmbeddedDriver().connect(jdbcUrls.get("derby"), null) | "APP"    | "SELECT 3 FROM SYSIBM.SYSDUMMY1" | "SELECT"
+    "h2"    | cpDatasources.get("tomcat").get("h2").getConnection()     | null     | "SELECT 3"                       | "SELECT"
+    "derby" | cpDatasources.get("tomcat").get("derby").getConnection()  | "APP"    | "SELECT 3 FROM SYSIBM.SYSDUMMY1" | "SELECT"
+    "h2"    | cpDatasources.get("hikari").get("h2").getConnection()     | null     | "SELECT 3"                       | "SELECT"
+    "derby" | cpDatasources.get("hikari").get("derby").getConnection()  | "APP"    | "SELECT 3 FROM SYSIBM.SYSDUMMY1" | "SELECT"
+    "h2"    | cpDatasources.get("c3p0").get("h2").getConnection()       | null     | "SELECT 3"                       | "SELECT"
+    "derby" | cpDatasources.get("c3p0").get("derby").getConnection()    | "APP"    | "SELECT 3 FROM SYSIBM.SYSDUMMY1" | "SELECT"
   }
 
   @Unroll
@@ -354,6 +357,7 @@ class JDBCInstrumentationTest extends AgentTestRunner {
             if (username != null) {
               "$Tags.DB_USER" username
             }
+            "${Tags.DB_OPERATION}" operation
             defaultTags()
           }
         }
@@ -365,15 +369,15 @@ class JDBCInstrumentationTest extends AgentTestRunner {
     connection.close()
 
     where:
-    driver  | connection                                                | username | query
-    "h2"    | new Driver().connect(jdbcUrls.get("h2"), null)            | null     | "SELECT 3"
-    "derby" | new EmbeddedDriver().connect(jdbcUrls.get("derby"), null) | "APP"    | "SELECT 3 FROM SYSIBM.SYSDUMMY1"
-    "h2"    | cpDatasources.get("tomcat").get("h2").getConnection()     | null     | "SELECT 3"
-    "derby" | cpDatasources.get("tomcat").get("derby").getConnection()  | "APP"    | "SELECT 3 FROM SYSIBM.SYSDUMMY1"
-    "h2"    | cpDatasources.get("hikari").get("h2").getConnection()     | null     | "SELECT 3"
-    "derby" | cpDatasources.get("hikari").get("derby").getConnection()  | "APP"    | "SELECT 3 FROM SYSIBM.SYSDUMMY1"
-    "h2"    | cpDatasources.get("c3p0").get("h2").getConnection()       | null     | "SELECT 3"
-    "derby" | cpDatasources.get("c3p0").get("derby").getConnection()    | "APP"    | "SELECT 3 FROM SYSIBM.SYSDUMMY1"
+    driver  | connection                                                | username | query                            | operation
+    "h2"    | new Driver().connect(jdbcUrls.get("h2"), null)            | null     | "SELECT 3"                       | "SELECT"
+    "derby" | new EmbeddedDriver().connect(jdbcUrls.get("derby"), null) | "APP"    | "SELECT 3 FROM SYSIBM.SYSDUMMY1" | "SELECT"
+    "h2"    | cpDatasources.get("tomcat").get("h2").getConnection()     | null     | "SELECT 3"                       | "SELECT"
+    "derby" | cpDatasources.get("tomcat").get("derby").getConnection()  | "APP"    | "SELECT 3 FROM SYSIBM.SYSDUMMY1" | "SELECT"
+    "h2"    | cpDatasources.get("hikari").get("h2").getConnection()     | null     | "SELECT 3"                       | "SELECT"
+    "derby" | cpDatasources.get("hikari").get("derby").getConnection()  | "APP"    | "SELECT 3 FROM SYSIBM.SYSDUMMY1" | "SELECT"
+    "h2"    | cpDatasources.get("c3p0").get("h2").getConnection()       | null     | "SELECT 3"                       | "SELECT"
+    "derby" | cpDatasources.get("c3p0").get("derby").getConnection()    | "APP"    | "SELECT 3 FROM SYSIBM.SYSDUMMY1" | "SELECT"
   }
 
   @Unroll
@@ -405,6 +409,7 @@ class JDBCInstrumentationTest extends AgentTestRunner {
             if (username != null) {
               "$Tags.DB_USER" username
             }
+            "${Tags.DB_OPERATION}" operation
             defaultTags()
           }
         }
@@ -416,19 +421,19 @@ class JDBCInstrumentationTest extends AgentTestRunner {
     connection.close()
 
     where:
-    driver   | connection                                                | username | query
-    "h2"     | new Driver().connect(jdbcUrls.get("h2"), null)            | null     | "CREATE TABLE S_H2 (id INTEGER not NULL, PRIMARY KEY ( id ))"
-    "derby"  | new EmbeddedDriver().connect(jdbcUrls.get("derby"), null) | "APP"    | "CREATE TABLE S_DERBY (id INTEGER not NULL, PRIMARY KEY ( id ))"
-    "hsqldb" | new JDBCDriver().connect(jdbcUrls.get("hsqldb"), null)    | "SA"     | "CREATE TABLE PUBLIC.S_HSQLDB (id INTEGER not NULL, PRIMARY KEY ( id ))"
-    "h2"     | cpDatasources.get("tomcat").get("h2").getConnection()     | null     | "CREATE TABLE S_H2_TOMCAT (id INTEGER not NULL, PRIMARY KEY ( id ))"
-    "derby"  | cpDatasources.get("tomcat").get("derby").getConnection()  | "APP"    | "CREATE TABLE S_DERBY_TOMCAT (id INTEGER not NULL, PRIMARY KEY ( id ))"
-    "hsqldb" | cpDatasources.get("tomcat").get("hsqldb").getConnection() | "SA"     | "CREATE TABLE PUBLIC.S_HSQLDB_TOMCAT (id INTEGER not NULL, PRIMARY KEY ( id ))"
-    "h2"     | cpDatasources.get("hikari").get("h2").getConnection()     | null     | "CREATE TABLE S_H2_HIKARI (id INTEGER not NULL, PRIMARY KEY ( id ))"
-    "derby"  | cpDatasources.get("hikari").get("derby").getConnection()  | "APP"    | "CREATE TABLE S_DERBY_HIKARI (id INTEGER not NULL, PRIMARY KEY ( id ))"
-    "hsqldb" | cpDatasources.get("hikari").get("hsqldb").getConnection() | "SA"     | "CREATE TABLE PUBLIC.S_HSQLDB_HIKARI (id INTEGER not NULL, PRIMARY KEY ( id ))"
-    "h2"     | cpDatasources.get("c3p0").get("h2").getConnection()       | null     | "CREATE TABLE S_H2_C3P0 (id INTEGER not NULL, PRIMARY KEY ( id ))"
-    "derby"  | cpDatasources.get("c3p0").get("derby").getConnection()    | "APP"    | "CREATE TABLE S_DERBY_C3P0 (id INTEGER not NULL, PRIMARY KEY ( id ))"
-    "hsqldb" | cpDatasources.get("c3p0").get("hsqldb").getConnection()   | "SA"     | "CREATE TABLE PUBLIC.S_HSQLDB_C3P0 (id INTEGER not NULL, PRIMARY KEY ( id ))"
+    driver   | connection                                                | username | query                                                                           | operation
+    "h2"     | new Driver().connect(jdbcUrls.get("h2"), null)            | null     | "CREATE TABLE S_H2 (id INTEGER not NULL, PRIMARY KEY ( id ))"                   | "CREATE"
+    "derby"  | new EmbeddedDriver().connect(jdbcUrls.get("derby"), null) | "APP"    | "CREATE TABLE S_DERBY (id INTEGER not NULL, PRIMARY KEY ( id ))"                | "CREATE"
+    "hsqldb" | new JDBCDriver().connect(jdbcUrls.get("hsqldb"), null)    | "SA"     | "CREATE TABLE PUBLIC.S_HSQLDB (id INTEGER not NULL, PRIMARY KEY ( id ))"        | "CREATE"
+    "h2"     | cpDatasources.get("tomcat").get("h2").getConnection()     | null     | "CREATE TABLE S_H2_TOMCAT (id INTEGER not NULL, PRIMARY KEY ( id ))"            | "CREATE"
+    "derby"  | cpDatasources.get("tomcat").get("derby").getConnection()  | "APP"    | "CREATE TABLE S_DERBY_TOMCAT (id INTEGER not NULL, PRIMARY KEY ( id ))"         | "CREATE"
+    "hsqldb" | cpDatasources.get("tomcat").get("hsqldb").getConnection() | "SA"     | "CREATE TABLE PUBLIC.S_HSQLDB_TOMCAT (id INTEGER not NULL, PRIMARY KEY ( id ))" | "CREATE"
+    "h2"     | cpDatasources.get("hikari").get("h2").getConnection()     | null     | "CREATE TABLE S_H2_HIKARI (id INTEGER not NULL, PRIMARY KEY ( id ))"            | "CREATE"
+    "derby"  | cpDatasources.get("hikari").get("derby").getConnection()  | "APP"    | "CREATE TABLE S_DERBY_HIKARI (id INTEGER not NULL, PRIMARY KEY ( id ))"         | "CREATE"
+    "hsqldb" | cpDatasources.get("hikari").get("hsqldb").getConnection() | "SA"     | "CREATE TABLE PUBLIC.S_HSQLDB_HIKARI (id INTEGER not NULL, PRIMARY KEY ( id ))" | "CREATE"
+    "h2"     | cpDatasources.get("c3p0").get("h2").getConnection()       | null     | "CREATE TABLE S_H2_C3P0 (id INTEGER not NULL, PRIMARY KEY ( id ))"              | "CREATE"
+    "derby"  | cpDatasources.get("c3p0").get("derby").getConnection()    | "APP"    | "CREATE TABLE S_DERBY_C3P0 (id INTEGER not NULL, PRIMARY KEY ( id ))"           | "CREATE"
+    "hsqldb" | cpDatasources.get("c3p0").get("hsqldb").getConnection()   | "SA"     | "CREATE TABLE PUBLIC.S_HSQLDB_C3P0 (id INTEGER not NULL, PRIMARY KEY ( id ))"   | "CREATE"
   }
 
   @Unroll
@@ -459,6 +464,7 @@ class JDBCInstrumentationTest extends AgentTestRunner {
             if (username != null) {
               "$Tags.DB_USER" username
             }
+            "$Tags.DB_OPERATION" operation
             defaultTags()
           }
         }
@@ -470,15 +476,15 @@ class JDBCInstrumentationTest extends AgentTestRunner {
     connection.close()
 
     where:
-    driver  | connection                                                | username | query
-    "h2"    | new Driver().connect(jdbcUrls.get("h2"), null)            | null     | "CREATE TABLE PS_H2 (id INTEGER not NULL, PRIMARY KEY ( id ))"
-    "derby" | new EmbeddedDriver().connect(jdbcUrls.get("derby"), null) | "APP"    | "CREATE TABLE PS_DERBY (id INTEGER not NULL, PRIMARY KEY ( id ))"
-    "h2"    | cpDatasources.get("tomcat").get("h2").getConnection()     | null     | "CREATE TABLE PS_H2_TOMCAT (id INTEGER not NULL, PRIMARY KEY ( id ))"
-    "derby" | cpDatasources.get("tomcat").get("derby").getConnection()  | "APP"    | "CREATE TABLE PS_DERBY_TOMCAT (id INTEGER not NULL, PRIMARY KEY ( id ))"
-    "h2"    | cpDatasources.get("hikari").get("h2").getConnection()     | null     | "CREATE TABLE PS_H2_HIKARI (id INTEGER not NULL, PRIMARY KEY ( id ))"
-    "derby" | cpDatasources.get("hikari").get("derby").getConnection()  | "APP"    | "CREATE TABLE PS_DERBY_HIKARI (id INTEGER not NULL, PRIMARY KEY ( id ))"
-    "h2"    | cpDatasources.get("c3p0").get("h2").getConnection()       | null     | "CREATE TABLE PS_H2_C3P0 (id INTEGER not NULL, PRIMARY KEY ( id ))"
-    "derby" | cpDatasources.get("c3p0").get("derby").getConnection()    | "APP"    | "CREATE TABLE PS_DERBY_C3P0 (id INTEGER not NULL, PRIMARY KEY ( id ))"
+    driver  | connection                                                | username | query                                                                    | operation
+    "h2"    | new Driver().connect(jdbcUrls.get("h2"), null)            | null     | "CREATE TABLE PS_H2 (id INTEGER not NULL, PRIMARY KEY ( id ))"           | "CREATE"
+    "derby" | new EmbeddedDriver().connect(jdbcUrls.get("derby"), null) | "APP"    | "CREATE TABLE PS_DERBY (id INTEGER not NULL, PRIMARY KEY ( id ))"        | "CREATE"
+    "h2"    | cpDatasources.get("tomcat").get("h2").getConnection()     | null     | "CREATE TABLE PS_H2_TOMCAT (id INTEGER not NULL, PRIMARY KEY ( id ))"    | "CREATE"
+    "derby" | cpDatasources.get("tomcat").get("derby").getConnection()  | "APP"    | "CREATE TABLE PS_DERBY_TOMCAT (id INTEGER not NULL, PRIMARY KEY ( id ))" | "CREATE"
+    "h2"    | cpDatasources.get("hikari").get("h2").getConnection()     | null     | "CREATE TABLE PS_H2_HIKARI (id INTEGER not NULL, PRIMARY KEY ( id ))"    | "CREATE"
+    "derby" | cpDatasources.get("hikari").get("derby").getConnection()  | "APP"    | "CREATE TABLE PS_DERBY_HIKARI (id INTEGER not NULL, PRIMARY KEY ( id ))" | "CREATE"
+    "h2"    | cpDatasources.get("c3p0").get("h2").getConnection()       | null     | "CREATE TABLE PS_H2_C3P0 (id INTEGER not NULL, PRIMARY KEY ( id ))"      | "CREATE"
+    "derby" | cpDatasources.get("c3p0").get("derby").getConnection()    | "APP"    | "CREATE TABLE PS_DERBY_C3P0 (id INTEGER not NULL, PRIMARY KEY ( id ))"   | "CREATE"
   }
 
   @Unroll
@@ -529,6 +535,7 @@ class JDBCInstrumentationTest extends AgentTestRunner {
             if (username != null) {
               "$Tags.DB_USER" username
             }
+            "$Tags.DB_OPERATION" operation
             defaultTags()
           }
         }
@@ -544,11 +551,11 @@ class JDBCInstrumentationTest extends AgentTestRunner {
     }
 
     where:
-    prepareStatement | driver  | driverClass          | url                                            | username | query
-    true             | "h2"    | new Driver()         | "jdbc:h2:mem:" + dbName                        | null     | "SELECT 3;"
-    true             | "derby" | new EmbeddedDriver() | "jdbc:derby:memory:" + dbName + ";create=true" | "APP"    | "SELECT 3 FROM SYSIBM.SYSDUMMY1"
-    false            | "h2"    | new Driver()         | "jdbc:h2:mem:" + dbName                        | null     | "SELECT 3;"
-    false            | "derby" | new EmbeddedDriver() | "jdbc:derby:memory:" + dbName + ";create=true" | "APP"    | "SELECT 3 FROM SYSIBM.SYSDUMMY1"
+    prepareStatement | driver  | driverClass          | url                                            | username | query                            | operation
+    true             | "h2"    | new Driver()         | "jdbc:h2:mem:" + dbName                        | null     | "SELECT 3;"                      | "SELECT"
+    true             | "derby" | new EmbeddedDriver() | "jdbc:derby:memory:" + dbName + ";create=true" | "APP"    | "SELECT 3 FROM SYSIBM.SYSDUMMY1" | "SELECT"
+    false            | "h2"    | new Driver()         | "jdbc:h2:mem:" + dbName                        | null     | "SELECT 3;"                      | "SELECT"
+    false            | "derby" | new EmbeddedDriver() | "jdbc:derby:memory:" + dbName + ";create=true" | "APP"    | "SELECT 3 FROM SYSIBM.SYSDUMMY1" | "SELECT"
   }
 
   def "calling #datasource.class.simpleName getConnection generates a span when under existing trace"() {
@@ -637,6 +644,7 @@ class JDBCInstrumentationTest extends AgentTestRunner {
             "$Tags.COMPONENT" "java-jdbc-statement"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.DB_TYPE" database
+            "$Tags.DB_OPERATION" CharSequence
             defaultTags()
           }
         }
@@ -702,6 +710,7 @@ class JDBCInstrumentationTest extends AgentTestRunner {
             "$Tags.DB_TYPE" dbType
             "$Tags.DB_INSTANCE" dbName.toLowerCase()
             "$Tags.DB_USER" "SA"
+            "$Tags.DB_OPERATION" "SELECT"
             defaultTags()
           }
         }
@@ -720,6 +729,7 @@ class JDBCInstrumentationTest extends AgentTestRunner {
               "$Tags.DB_TYPE" dbType
               "$Tags.DB_INSTANCE" dbName.toLowerCase()
               "$Tags.DB_USER" "SA"
+              "$Tags.DB_OPERATION" "SELECT"
               defaultTags()
             }
           }

--- a/dd-java-agent/instrumentation/jdbc/src/test/groovy/JDBCWrappedInterfacesTest.groovy
+++ b/dd-java-agent/instrumentation/jdbc/src/test/groovy/JDBCWrappedInterfacesTest.groovy
@@ -242,7 +242,7 @@ class JDBCWrappedInterfacesTest extends AgentTestRunner {
   }
 
   // All of the tests should return the same result
-  def assertDBTraces(String database = "testdb") {
+  def assertDBTraces(String database = "testdb", String operation = "SELECT") {
     assertTraces(1) {
       trace(2) {
         basicSpan(it, "parent")
@@ -257,6 +257,7 @@ class JDBCWrappedInterfacesTest extends AgentTestRunner {
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.DB_TYPE" "${database}"
+            "$Tags.DB_OPERATION" "${operation}"
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/scala-concurrent/src/slickTest/groovy/SlickTest.groovy
+++ b/dd-java-agent/instrumentation/scala-concurrent/src/slickTest/groovy/SlickTest.groovy
@@ -40,6 +40,7 @@ class SlickTest extends AgentTestRunner {
             "$Tags.DB_TYPE" SlickUtils.Driver()
             "$Tags.DB_INSTANCE" SlickUtils.Db()
             "$Tags.DB_USER" SlickUtils.Username()
+            "$Tags.DB_OPERATION" "SELECT"
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/spring-data-1.8/src/test/groovy/SpringJpaTest.groovy
+++ b/dd-java-agent/instrumentation/spring-data-1.8/src/test/groovy/SpringJpaTest.groovy
@@ -79,6 +79,7 @@ class SpringJpaTest extends AgentTestRunner {
             "$Tags.DB_TYPE" "hsqldb"
             "$Tags.DB_INSTANCE" "test"
             "$Tags.DB_USER" "sa"
+            "$Tags.DB_OPERATION" "select"
             defaultTags()
           }
         }
@@ -114,6 +115,7 @@ class SpringJpaTest extends AgentTestRunner {
             "$Tags.DB_TYPE" "hsqldb"
             "$Tags.DB_INSTANCE" "test"
             "$Tags.DB_USER" "sa"
+            "$Tags.DB_OPERATION" "insert"
             defaultTags()
           }
         }
@@ -139,7 +141,7 @@ class SpringJpaTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span { //select
+        span {
           serviceName "hsqldb"
           spanType "sql"
           childOf(span(0))
@@ -149,6 +151,7 @@ class SpringJpaTest extends AgentTestRunner {
             "$Tags.DB_TYPE" "hsqldb"
             "$Tags.DB_INSTANCE" "test"
             "$Tags.DB_USER" "sa"
+            "$Tags.DB_OPERATION" "update"
             defaultTags()
           }
         }
@@ -162,6 +165,7 @@ class SpringJpaTest extends AgentTestRunner {
             "$Tags.DB_TYPE" "hsqldb"
             "$Tags.DB_INSTANCE" "test"
             "$Tags.DB_USER" "sa"
+            "$Tags.DB_OPERATION" "select"
             defaultTags()
           }
         }
@@ -170,7 +174,7 @@ class SpringJpaTest extends AgentTestRunner {
     TEST_WRITER.clear()
 
     when:
-    customer = repo.findByLastName("Anonymous")[0] // select
+    customer = repo.findByLastName("Anonymous")[0]
 
     then:
     assertTraces(1) {
@@ -185,7 +189,7 @@ class SpringJpaTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span { // select
+        span {
           serviceName "hsqldb"
           spanType "sql"
           childOf(span(0))
@@ -195,6 +199,7 @@ class SpringJpaTest extends AgentTestRunner {
             "$Tags.DB_TYPE" "hsqldb"
             "$Tags.DB_INSTANCE" "test"
             "$Tags.DB_USER" "sa"
+            "$Tags.DB_OPERATION" "select"
             defaultTags()
           }
         }
@@ -218,7 +223,7 @@ class SpringJpaTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span { // select
+        span {
           serviceName "hsqldb"
           spanType "sql"
           childOf(span(0))
@@ -228,10 +233,11 @@ class SpringJpaTest extends AgentTestRunner {
             "$Tags.DB_TYPE" "hsqldb"
             "$Tags.DB_INSTANCE" "test"
             "$Tags.DB_USER" "sa"
+            "$Tags.DB_OPERATION" "delete"
             defaultTags()
           }
         }
-        span { // delete
+        span {
           serviceName "hsqldb"
           spanType "sql"
           childOf(span(0))
@@ -241,6 +247,7 @@ class SpringJpaTest extends AgentTestRunner {
             "$Tags.DB_TYPE" "hsqldb"
             "$Tags.DB_INSTANCE" "test"
             "$Tags.DB_USER" "sa"
+            "$Tags.DB_OPERATION" "select"
             defaultTags()
           }
         }


### PR DESCRIPTION
This adds the `db.operation` tag recently added to mongodb spans, as part of an investigation of how hard it would be to normalise SQL prior to metrics aggregation, and specifically how cacheable data derived from SQL is.