### PR TITLE
Make timeout longer when not in CI

### DIFF
--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/utils/OkHttpUtils.java
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/utils/OkHttpUtils.java
@@ -33,7 +33,8 @@ public class OkHttpUtils {
   }
 
   static OkHttpClient.Builder clientBuilder() {
-    final TimeUnit unit = TimeUnit.MINUTES;
+    // Increase timeout locally to allow time for debugging.
+    final TimeUnit unit = System.getenv("CI") != null ? TimeUnit.MINUTES : TimeUnit.HOURS;
     return new OkHttpClient.Builder()
         .addInterceptor(LOGGING_INTERCEPTOR)
         .connectTimeout(1, unit)


### PR DESCRIPTION
This is a change I manually kept making locally when debugging http server instrumentation.  Seems more likely the right behavior for each environment.