### PR TITLE
Use NoOpStatsDClient when possible to speed up tests

### DIFF
--- a/dd-trace-core/jfr-openjdk/src/test/groovy/datadog/trace/core/jfr/openjdk/ScopeEventTest.groovy
+++ b/dd-trace-core/jfr-openjdk/src/test/groovy/datadog/trace/core/jfr/openjdk/ScopeEventTest.groovy
@@ -1,5 +1,6 @@
 package datadog.trace.core.jfr.openjdk
 
+import com.timgroup.statsd.NoOpStatsDClient
 import datadog.trace.api.DDId
 import datadog.trace.api.config.GeneralConfig
 import datadog.trace.api.config.ProfilingConfig
@@ -23,7 +24,8 @@ class ScopeEventTest extends DDSpecification {
   private static final Duration SLEEP_DURATION = Duration.ofSeconds(1)
 
   def writer = new ListWriter()
-  def tracer = CoreTracer.builder().serviceName(DEFAULT_SERVICE_NAME).writer(writer).build()
+  def tracer = CoreTracer.builder().statsDClient(new NoOpStatsDClient()).serviceName(DEFAULT_SERVICE_NAME)
+    .writer(writer).build()
 
   def parentContext =
     new DDSpanContext(

--- a/dd-trace-core/src/test/groovy/datadog/trace/api/writer/PrintingWriterTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/api/writer/PrintingWriterTest.groovy
@@ -4,15 +4,14 @@ import com.squareup.moshi.Moshi
 import com.squareup.moshi.Types
 import datadog.trace.common.writer.ListWriter
 import datadog.trace.common.writer.PrintingWriter
-import datadog.trace.core.CoreTracer
-import datadog.trace.test.util.DDSpecification
+import datadog.trace.core.test.DDCoreSpecification
 import okio.Buffer
 
 import java.nio.charset.StandardCharsets
 
-class PrintingWriterTest extends DDSpecification {
+class PrintingWriterTest extends DDCoreSpecification {
 
-  def tracer = CoreTracer.builder().writer(new ListWriter()).build()
+  def tracer = tracerBuilder().writer(new ListWriter()).build()
   def sampleTrace
   def secondTrace
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/sampling/ForcePrioritySamplerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/sampling/ForcePrioritySamplerTest.groovy
@@ -3,17 +3,16 @@ package datadog.trace.common.sampling
 import datadog.trace.api.DDTags
 import datadog.trace.common.writer.ListWriter
 import datadog.trace.common.writer.LoggingWriter
-import datadog.trace.core.CoreTracer
-import datadog.trace.test.util.DDSpecification
+import datadog.trace.core.test.DDCoreSpecification
 
-class ForcePrioritySamplerTest extends DDSpecification {
+class ForcePrioritySamplerTest extends DDCoreSpecification {
 
   def writer = new ListWriter()
 
   def "force priority sampling"() {
     setup:
     def sampler = new ForcePrioritySampler(prioritySampling)
-    def tracer = CoreTracer.builder().writer(writer).sampler(sampler).build()
+    def tracer = tracerBuilder().writer(writer).sampler(sampler).build()
 
     when:
     def span1 = tracer.buildSpan("test").start()
@@ -35,7 +34,7 @@ class ForcePrioritySamplerTest extends DDSpecification {
   def "sampling priority set"() {
     setup:
     def sampler = new ForcePrioritySampler(prioritySampling)
-    def tracer = CoreTracer.builder().writer(writer).sampler(sampler).build()
+    def tracer = tracerBuilder().writer(writer).sampler(sampler).build()
 
     when:
     def span = tracer.buildSpan("test").start()
@@ -63,7 +62,7 @@ class ForcePrioritySamplerTest extends DDSpecification {
   def "setting forced tracing via tag"() {
     when:
     def sampler = new ForcePrioritySampler(PrioritySampling.SAMPLER_KEEP)
-    def tracer = CoreTracer.builder().writer(new LoggingWriter()).sampler(sampler).build()
+    def tracer = tracerBuilder().writer(new LoggingWriter()).sampler(sampler).build()
     def span = tracer.buildSpan("root").start()
     if (tagName) {
       span.setTag(tagName, tagValue)
@@ -85,7 +84,7 @@ class ForcePrioritySamplerTest extends DDSpecification {
   def "not setting forced tracing via tag or setting it wrong value not causing exception"() {
     setup:
     def sampler = new ForcePrioritySampler(PrioritySampling.SAMPLER_KEEP)
-    def tracer = CoreTracer.builder().writer(new LoggingWriter()).sampler(sampler).build()
+    def tracer = tracerBuilder().writer(new LoggingWriter()).sampler(sampler).build()
     def span = tracer.buildSpan("root").start()
     if (tagName) {
       span.setTag(tagName, tagValue)

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/sampling/RateByServiceSamplerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/sampling/RateByServiceSamplerTest.groovy
@@ -4,12 +4,11 @@ import datadog.trace.api.DDTags
 import datadog.trace.common.writer.ListWriter
 import datadog.trace.common.writer.LoggingWriter
 import datadog.trace.common.writer.ddagent.DDAgentApi
-import datadog.trace.core.CoreTracer
 import datadog.trace.core.DDSpan
 import datadog.trace.core.DDSpanContext
-import datadog.trace.test.util.DDSpecification
+import datadog.trace.core.test.DDCoreSpecification
 
-class RateByServiceSamplerTest extends DDSpecification {
+class RateByServiceSamplerTest extends DDCoreSpecification {
   static serializer = DDAgentApi.RESPONSE_ADAPTER
 
   def "invalid rate -> 1"() {
@@ -33,7 +32,7 @@ class RateByServiceSamplerTest extends DDSpecification {
   def "rate by service name"() {
     setup:
     RateByServiceSampler serviceSampler = new RateByServiceSampler()
-    def tracer = CoreTracer.builder().writer(new ListWriter()).build()
+    def tracer = tracerBuilder().writer(new ListWriter()).build()
 
     when:
     String response = '{"rate_by_service": {"service:spock,env:test":0.0}}'
@@ -69,7 +68,7 @@ class RateByServiceSamplerTest extends DDSpecification {
   def "sampling priority set on context"() {
     setup:
     RateByServiceSampler serviceSampler = new RateByServiceSampler()
-    def tracer = CoreTracer.builder().writer(new ListWriter()).build()
+    def tracer = tracerBuilder().writer(new ListWriter()).build()
     String response = '{"rate_by_service": {"service:,env:":1.0}}'
     serviceSampler.onResponse("traces", serializer.fromJson(response))
 
@@ -93,7 +92,7 @@ class RateByServiceSamplerTest extends DDSpecification {
   def "sampling priority set when service later"() {
     def sampler = new RateByServiceSampler()
     def writer = new ListWriter()
-    def tracer = CoreTracer.builder().writer(writer).sampler(sampler).build()
+    def tracer = tracerBuilder().writer(writer).sampler(sampler).build()
 
     sampler.onResponse("test", serializer
       .fromJson('{"rate_by_service":{"service:,env:":1.0,"service:spock,env:":0.0}}'))
@@ -127,7 +126,7 @@ class RateByServiceSamplerTest extends DDSpecification {
   def "setting forced tracing via tag"() {
     when:
     def sampler = new RateByServiceSampler()
-    def tracer = CoreTracer.builder().writer(new LoggingWriter()).sampler(sampler).build()
+    def tracer = tracerBuilder().writer(new LoggingWriter()).sampler(sampler).build()
     def span = tracer.buildSpan("root").start()
     if (tagName) {
       span.setTag(tagName, tagValue)
@@ -149,7 +148,7 @@ class RateByServiceSamplerTest extends DDSpecification {
   def "not setting forced tracing via tag or setting it wrong value not causing exception"() {
     setup:
     def sampler = new RateByServiceSampler()
-    def tracer = CoreTracer.builder().writer(new LoggingWriter()).sampler(sampler).build()
+    def tracer = tracerBuilder().writer(new LoggingWriter()).sampler(sampler).build()
     def span = tracer.buildSpan("root").start()
     if (tagName) {
       span.setTag(tagName, tagValue)

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/sampling/RuleBasedSamplingTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/sampling/RuleBasedSamplingTest.groovy
@@ -1,9 +1,8 @@
 package datadog.trace.common.sampling
 
 import datadog.trace.common.writer.ListWriter
-import datadog.trace.core.CoreTracer
 import datadog.trace.core.DDSpan
-import datadog.trace.test.util.DDSpecification
+import datadog.trace.core.test.DDCoreSpecification
 
 import static datadog.trace.api.config.TracerConfig.TRACE_RATE_LIMIT
 import static datadog.trace.api.config.TracerConfig.TRACE_SAMPLE_RATE
@@ -12,7 +11,7 @@ import static datadog.trace.api.config.TracerConfig.TRACE_SAMPLING_SERVICE_RULES
 import static datadog.trace.api.sampling.PrioritySampling.SAMPLER_DROP
 import static datadog.trace.api.sampling.PrioritySampling.SAMPLER_KEEP
 
-class RuleBasedSamplingTest extends DDSpecification {
+class RuleBasedSamplingTest extends DDCoreSpecification {
   def "Rule Based Sampler is not created when properties not set"() {
     when:
     Sampler sampler = Sampler.Builder.forConfig(new Properties())
@@ -49,7 +48,7 @@ class RuleBasedSamplingTest extends DDSpecification {
     if (rateLimit != null) {
       properties.setProperty(TRACE_RATE_LIMIT, rateLimit)
     }
-    def tracer = CoreTracer.builder().writer(new ListWriter()).build()
+    def tracer = tracerBuilder().writer(new ListWriter()).build()
 
     when:
     Sampler sampler = Sampler.Builder.forConfig(properties)
@@ -140,7 +139,7 @@ class RuleBasedSamplingTest extends DDSpecification {
 
   def "Rate limit is set for rate limited spans"() {
     setup:
-    def tracer = CoreTracer.builder().writer(new ListWriter()).build()
+    def tracer = tracerBuilder().writer(new ListWriter()).build()
 
     when:
     Properties properties = new Properties()
@@ -179,7 +178,7 @@ class RuleBasedSamplingTest extends DDSpecification {
 
   def "Rate limit is set for rate limited spans (matched on different rules)"() {
     setup:
-    def tracer = CoreTracer.builder().writer(new ListWriter()).build()
+    def tracer = tracerBuilder().writer(new ListWriter()).build()
 
     when:
     Properties properties = new Properties()

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentApiTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentApiTest.groovy
@@ -12,13 +12,12 @@ import datadog.trace.common.writer.ddagent.DDAgentResponseListener
 import datadog.trace.common.writer.ddagent.Payload
 import datadog.trace.common.writer.ddagent.TraceMapperV0_4
 import datadog.trace.common.writer.ddagent.TraceMapperV0_5
-import datadog.trace.core.CoreTracer
 import datadog.trace.core.DDSpan
 import datadog.trace.core.DDSpanContext
 import datadog.trace.core.monitor.Monitoring
 import datadog.trace.core.serialization.ByteBufferConsumer
 import datadog.trace.core.serialization.msgpack.MsgPackWriter
-import datadog.trace.test.util.DDSpecification
+import datadog.trace.core.test.DDCoreSpecification
 import org.msgpack.jackson.dataformat.MessagePackFactory
 import spock.lang.Shared
 import spock.lang.Timeout
@@ -32,7 +31,7 @@ import java.util.concurrent.atomic.AtomicReference
 import static datadog.trace.agent.test.server.http.TestHttpServer.httpServer
 
 @Timeout(20)
-class DDAgentApiTest extends DDSpecification {
+class DDAgentApiTest extends DDCoreSpecification {
 
   @Shared
   Monitoring monitoring = new Monitoring(new NoOpStatsDClient(), 1, TimeUnit.SECONDS)
@@ -421,7 +420,7 @@ class DDAgentApiTest extends DDSpecification {
   }
 
   DDSpan buildSpan(long timestamp, String tag, String value) {
-    def tracer = CoreTracer.builder().writer(new ListWriter()).build()
+    def tracer = tracerBuilder().writer(new ListWriter()).build()
 
     def context = new DDSpanContext(
       DDId.from(1),

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterCombinedTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterCombinedTest.groovy
@@ -17,7 +17,7 @@ import datadog.trace.core.monitor.Monitoring
 import datadog.trace.core.serialization.ByteBufferConsumer
 import datadog.trace.core.serialization.Mapper
 import datadog.trace.core.serialization.msgpack.MsgPackWriter
-import datadog.trace.test.util.DDSpecification
+import datadog.trace.core.test.DDCoreSpecification
 import spock.lang.Retry
 import spock.lang.Timeout
 import spock.util.concurrent.PollingConditions
@@ -33,14 +33,14 @@ import static datadog.trace.common.writer.DDAgentWriter.BUFFER_SIZE
 import static datadog.trace.common.writer.ddagent.Prioritization.ENSURE_TRACE
 
 @Timeout(10)
-class DDAgentWriterCombinedTest extends DDSpecification {
+class DDAgentWriterCombinedTest extends DDCoreSpecification {
 
   def conditions = new PollingConditions(timeout: 5, initialDelay: 0, factor: 1.25)
   def monitoring = new Monitoring(new NoOpStatsDClient(), 1, TimeUnit.SECONDS)
   def phaser = new Phaser()
 
   // Only used to create spans
-  def dummyTracer = CoreTracer.builder().writer(new ListWriter()).build()
+  def dummyTracer = tracerBuilder().writer(new ListWriter()).build()
 
   def apiWithVersion(String version) {
     def api = Mock(DDAgentApi)

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterTest.groovy
@@ -3,15 +3,14 @@ package datadog.trace.common.writer
 import com.timgroup.statsd.NoOpStatsDClient
 import datadog.trace.common.writer.ddagent.DDAgentApi
 import datadog.trace.common.writer.ddagent.TraceProcessingWorker
-import datadog.trace.core.CoreTracer
 import datadog.trace.core.monitor.HealthMetrics
 import datadog.trace.core.monitor.Monitoring
-import datadog.trace.test.util.DDSpecification
+import datadog.trace.core.test.DDCoreSpecification
 import spock.lang.Subject
 
 import java.util.concurrent.TimeUnit
 
-class DDAgentWriterTest extends DDSpecification {
+class DDAgentWriterTest extends DDCoreSpecification {
 
   def api = Mock(DDAgentApi)
   def monitor = Mock(HealthMetrics)
@@ -22,7 +21,7 @@ class DDAgentWriterTest extends DDSpecification {
   def writer = new DDAgentWriter(api, monitor, monitoring, worker)
 
   // Only used to create spans
-  def dummyTracer = CoreTracer.builder().writer(new ListWriter()).build()
+  def dummyTracer = tracerBuilder().writer(new ListWriter()).build()
 
   def cleanup() {
     writer.close()

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/TraceMapperTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/TraceMapperTest.groovy
@@ -2,20 +2,19 @@ package datadog.trace.common.writer
 
 import datadog.trace.common.writer.ddagent.TraceMapper
 import datadog.trace.common.writer.ddagent.TraceMapperV0_5
-import datadog.trace.core.CoreTracer
 import datadog.trace.core.serialization.ByteBufferConsumer
 import datadog.trace.core.serialization.msgpack.MsgPackWriter
-import datadog.trace.test.util.DDSpecification
+import datadog.trace.core.test.DDCoreSpecification
 import org.msgpack.core.MessagePack
 import org.msgpack.core.MessageUnpacker
 
 import java.nio.ByteBuffer
 
-class TraceMapperTest extends DDSpecification {
+class TraceMapperTest extends DDCoreSpecification {
 
   def "test trace mapper v0.5"() {
     setup:
-    def tracer = CoreTracer.builder().writer(new ListWriter()).build()
+    def tracer = tracerBuilder().writer(new ListWriter()).build()
     def span = tracer.buildSpan(null).withTag("service.name", "my-service")
       .withTag("elasticsearch.version", "7.0").start()
     span.setBaggageItem("baggage", "item")

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/CoreSpanBuilderTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/CoreSpanBuilderTest.groovy
@@ -7,7 +7,7 @@ import datadog.trace.bootstrap.instrumentation.api.AgentTracer
 import datadog.trace.common.writer.ListWriter
 import datadog.trace.core.propagation.ExtractedContext
 import datadog.trace.core.propagation.TagContext
-import datadog.trace.test.util.DDSpecification
+import datadog.trace.core.test.DDCoreSpecification
 
 import static datadog.trace.api.DDTags.LANGUAGE_TAG_KEY
 import static datadog.trace.api.DDTags.LANGUAGE_TAG_VALUE
@@ -17,10 +17,10 @@ import static datadog.trace.api.DDTags.THREAD_NAME
 import static datadog.trace.core.DDSpanContext.ORIGIN_KEY
 import static java.util.concurrent.TimeUnit.MILLISECONDS
 
-class CoreSpanBuilderTest extends DDSpecification {
+class CoreSpanBuilderTest extends DDCoreSpecification {
 
   def writer = new ListWriter()
-  def tracer = CoreTracer.builder().writer(writer).build()
+  def tracer = tracerBuilder().writer(writer).build()
 
   def cleanup() {
     tracer.close()
@@ -345,7 +345,7 @@ class CoreSpanBuilderTest extends DDSpecification {
   def "global span tags populated on each span"() {
     setup:
     injectSysConfig("dd.trace.span.tags", tagString)
-    def customTracer = CoreTracer.builder().writer(writer).build()
+    def customTracer = tracerBuilder().writer(writer).build()
     def span = customTracer.buildSpan("op name").withServiceName("foo").start()
 
     expect:

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/CoreTracerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/CoreTracerTest.groovy
@@ -14,7 +14,7 @@ import datadog.trace.common.writer.ListWriter
 import datadog.trace.common.writer.LoggingWriter
 import datadog.trace.core.propagation.DatadogHttpCodec
 import datadog.trace.core.propagation.HttpCodec
-import datadog.trace.test.util.DDSpecification
+import datadog.trace.core.test.DDCoreSpecification
 import spock.lang.Timeout
 
 import static datadog.trace.api.config.GeneralConfig.ENV
@@ -29,7 +29,7 @@ import static datadog.trace.api.config.TracerConfig.SPAN_TAGS
 import static datadog.trace.api.config.TracerConfig.WRITER_TYPE
 
 @Timeout(10)
-class CoreTracerTest extends DDSpecification {
+class CoreTracerTest extends DDCoreSpecification {
 
   def "verify defaults on tracer"() {
     when:
@@ -121,7 +121,7 @@ class CoreTracerTest extends DDSpecification {
     injectSysConfig(PRIORITY_SAMPLING, "false")
 
     when:
-    def tracer = CoreTracer.builder().build()
+    def tracer = tracerBuilder().build()
 
     then:
     tracer.sampler instanceof AllSampler
@@ -135,7 +135,7 @@ class CoreTracerTest extends DDSpecification {
     injectSysConfig(WRITER_TYPE, "LoggingWriter")
 
     when:
-    def tracer = CoreTracer.builder().build()
+    def tracer = tracerBuilder().build()
 
     then:
     tracer.writer instanceof LoggingWriter
@@ -165,7 +165,7 @@ class CoreTracerTest extends DDSpecification {
     injectSysConfig(HEADER_TAGS, mapString)
 
     when:
-    def tracer = CoreTracer.builder().build()
+    def tracer = tracerBuilder().build()
     // Datadog extractor gets placed first
     def taggedHeaders = tracer.extractor.extractors[0].taggedHeaders
 
@@ -211,7 +211,7 @@ class CoreTracerTest extends DDSpecification {
   def "Writer is instance of LoggingWriter when property set"() {
     when:
     injectSysConfig("writer.type", "LoggingWriter")
-    def tracer = CoreTracer.builder().build()
+    def tracer = tracerBuilder().build()
 
     then:
     tracer.writer instanceof LoggingWriter
@@ -223,7 +223,7 @@ class CoreTracerTest extends DDSpecification {
   def "Shares TraceCount with DDApi with #key = #value"() {
     setup:
     injectSysConfig(key, value)
-    final CoreTracer tracer = CoreTracer.builder().build()
+    final CoreTracer tracer = tracerBuilder().build()
 
     expect:
     tracer.writer instanceof DDAgentWriter
@@ -239,7 +239,7 @@ class CoreTracerTest extends DDSpecification {
 
   def "root tags are applied only to root spans"() {
     setup:
-    def tracer = CoreTracer.builder().localRootSpanTags(['only_root': 'value']).build()
+    def tracer = tracerBuilder().localRootSpanTags(['only_root': 'value']).build()
     def root = tracer.buildSpan('my_root').start()
     def child = tracer.buildSpan('my_child').asChildOf(root).start()
 
@@ -256,7 +256,7 @@ class CoreTracerTest extends DDSpecification {
   def "priority sampling when span finishes"() {
     given:
     def writer = new ListWriter()
-    def tracer = CoreTracer.builder().writer(writer).build()
+    def tracer = tracerBuilder().writer(writer).build()
 
     when:
     def span = tracer.buildSpan("operation").start()
@@ -273,7 +273,7 @@ class CoreTracerTest extends DDSpecification {
   def "priority sampling set when child span complete"() {
     given:
     def writer = new ListWriter()
-    def tracer = CoreTracer.builder().writer(writer).build()
+    def tracer = tracerBuilder().writer(writer).build()
 
     when:
     def root = tracer.buildSpan("operation").start()
@@ -298,7 +298,7 @@ class CoreTracerTest extends DDSpecification {
   def "span priority set when injecting"() {
     given:
     injectSysConfig("writer.type", "LoggingWriter")
-    def tracer = CoreTracer.builder().build()
+    def tracer = tracerBuilder().build()
     def setter = Mock(AgentPropagation.Setter)
     def carrier = new Object()
 
@@ -321,7 +321,7 @@ class CoreTracerTest extends DDSpecification {
   def "span priority only set after first injection"() {
     given:
     def sampler = new ControllableSampler()
-    def tracer = CoreTracer.builder().writer(new LoggingWriter()).sampler(sampler).build()
+    def tracer = tracerBuilder().writer(new LoggingWriter()).sampler(sampler).build()
     def setter = Mock(AgentPropagation.Setter)
     def carrier = new Object()
 
@@ -356,7 +356,7 @@ class CoreTracerTest extends DDSpecification {
   def "injection doesn't override set priority"() {
     given:
     def sampler = new ControllableSampler()
-    def tracer = CoreTracer.builder().writer(new LoggingWriter()).sampler(sampler).build()
+    def tracer = tracerBuilder().writer(new LoggingWriter()).sampler(sampler).build()
     def setter = Mock(AgentPropagation.Setter)
     def carrier = new Object()
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanContextTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanContextTest.groovy
@@ -2,12 +2,12 @@ package datadog.trace.core
 
 import datadog.trace.api.DDTags
 import datadog.trace.common.writer.ListWriter
-import datadog.trace.test.util.DDSpecification
+import datadog.trace.core.test.DDCoreSpecification
 
-class DDSpanContextTest extends DDSpecification {
+class DDSpanContextTest extends DDCoreSpecification {
 
   def writer = new ListWriter()
-  def tracer = CoreTracer.builder().writer(writer).build()
+  def tracer = tracerBuilder().writer(writer).build()
 
   def cleanup() {
     tracer.close()

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanSerializationTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanSerializationTest.groovy
@@ -1,6 +1,5 @@
 package datadog.trace.core
 
-
 import datadog.trace.api.DDId
 import datadog.trace.api.sampling.PrioritySampling
 import datadog.trace.common.writer.ListWriter
@@ -8,7 +7,7 @@ import datadog.trace.common.writer.ddagent.TraceMapperV0_4
 import datadog.trace.common.writer.ddagent.TraceMapperV0_5
 import datadog.trace.core.serialization.ByteBufferConsumer
 import datadog.trace.core.serialization.msgpack.MsgPackWriter
-import datadog.trace.test.util.DDSpecification
+import datadog.trace.core.test.DDCoreSpecification
 import org.msgpack.core.MessageFormat
 import org.msgpack.core.MessagePack
 import org.msgpack.core.buffer.ArrayBufferInput
@@ -16,12 +15,12 @@ import org.msgpack.value.ValueType
 
 import java.nio.ByteBuffer
 
-class DDSpanSerializationTest extends DDSpecification {
+class DDSpanSerializationTest extends DDCoreSpecification {
 
   def "serialize trace with id #value as int"() {
     setup:
     def writer = new ListWriter()
-    def tracer = CoreTracer.builder().writer(writer).build()
+    def tracer = tracerBuilder().writer(writer).build()
     def context = createContext(spanType, tracer, value)
     def span = DDSpan.create(0, context)
     def buffer = ByteBuffer.allocate(1024)
@@ -73,7 +72,7 @@ class DDSpanSerializationTest extends DDSpecification {
   def "serialize trace with id #value as int v0.5"() {
     setup:
     def writer = new ListWriter()
-    def tracer = CoreTracer.builder().writer(writer).build()
+    def tracer = tracerBuilder().writer(writer).build()
     def context = createContext(spanType, tracer, value)
     def span = DDSpan.create(0, context)
     def buffer = ByteBuffer.allocate(1024)
@@ -130,7 +129,7 @@ class DDSpanSerializationTest extends DDSpecification {
   def "serialize trace with baggage and tags correctly v0.4"() {
     setup:
     def writer = new ListWriter()
-    def tracer = CoreTracer.builder().writer(writer).build()
+    def tracer = tracerBuilder().writer(writer).build()
     def context = new DDSpanContext(
       DDId.ONE,
       DDId.ONE,
@@ -201,7 +200,7 @@ class DDSpanSerializationTest extends DDSpecification {
   def "serialize trace with baggage and tags correctly v0.5"() {
     setup:
     def writer = new ListWriter()
-    def tracer = CoreTracer.builder().writer(writer).build()
+    def tracer = tracerBuilder().writer(writer).build()
     def context = new DDSpanContext(
       DDId.ONE,
       DDId.ONE,

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanTest.groovy
@@ -8,15 +8,15 @@ import datadog.trace.common.sampling.RateByServiceSampler
 import datadog.trace.common.writer.ListWriter
 import datadog.trace.core.propagation.ExtractedContext
 import datadog.trace.core.propagation.TagContext
-import datadog.trace.test.util.DDSpecification
+import datadog.trace.core.test.DDCoreSpecification
 
 import java.util.concurrent.TimeUnit
 
-class DDSpanTest extends DDSpecification {
+class DDSpanTest extends DDCoreSpecification {
 
   def writer = new ListWriter()
   def sampler = new RateByServiceSampler()
-  def tracer = CoreTracer.builder().writer(writer).sampler(sampler).build()
+  def tracer = tracerBuilder().writer(writer).sampler(sampler).build()
 
   def cleanup() {
     tracer?.close()

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceStrictWriteTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceStrictWriteTest.groovy
@@ -8,7 +8,7 @@ class PendingTraceStrictWriteTest extends PendingTraceTestBase {
   CoreTracer.CoreTracerBuilder getBuilder() {
     def props = new Properties()
     props.setProperty(TRACE_STRICT_WRITES_ENABLED, "true")
-    return CoreTracer.builder().withProperties(props)
+    return tracerBuilder().withProperties(props)
   }
 
   def "trace is not reported until unfinished continuation is closed"() {

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceTest.groovy
@@ -8,7 +8,7 @@ class PendingTraceTest extends PendingTraceTestBase {
 
   @Override
   CoreTracer.CoreTracerBuilder getBuilder() {
-    return CoreTracer.builder()
+    return tracerBuilder()
   }
 
   @Timeout(value = 60, unit = TimeUnit.SECONDS)

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceTestBase.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceTestBase.groovy
@@ -4,7 +4,7 @@ import ch.qos.logback.classic.Level
 import ch.qos.logback.classic.Logger
 import datadog.trace.common.writer.ListWriter
 import datadog.trace.core.CoreTracer.CoreTracerBuilder
-import datadog.trace.test.util.DDSpecification
+import datadog.trace.core.test.DDCoreSpecification
 import org.slf4j.LoggerFactory
 
 import java.util.concurrent.CountDownLatch
@@ -12,7 +12,7 @@ import java.util.concurrent.TimeUnit
 
 import static datadog.trace.api.config.TracerConfig.PARTIAL_FLUSH_MIN_SPANS
 
-abstract class PendingTraceTestBase extends DDSpecification {
+abstract class PendingTraceTestBase extends DDCoreSpecification {
 
   abstract CoreTracerBuilder getBuilder()
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/TraceCorrelationTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/TraceCorrelationTest.groovy
@@ -1,10 +1,10 @@
 package datadog.trace.core
 
 import datadog.trace.common.writer.ListWriter
-import datadog.trace.test.util.DDSpecification
+import datadog.trace.core.test.DDCoreSpecification
 
-class TraceCorrelationTest extends DDSpecification {
-  def tracer = CoreTracer.builder().writer(new ListWriter()).build()
+class TraceCorrelationTest extends DDCoreSpecification {
+  def tracer = tracerBuilder().writer(new ListWriter()).build()
 
   def span = tracer.buildSpan("test").start()
   def scope = tracer.activateSpan(span)

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/TraceInterceptorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/TraceInterceptorTest.groovy
@@ -5,7 +5,7 @@ import datadog.trace.api.GlobalTracer
 import datadog.trace.api.interceptor.MutableSpan
 import datadog.trace.api.interceptor.TraceInterceptor
 import datadog.trace.common.writer.ListWriter
-import datadog.trace.test.util.DDSpecification
+import datadog.trace.core.test.DDCoreSpecification
 import spock.lang.Timeout
 
 import java.util.concurrent.CountDownLatch
@@ -13,10 +13,10 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 
 @Timeout(10)
-class TraceInterceptorTest extends DDSpecification {
+class TraceInterceptorTest extends DDCoreSpecification {
 
   def writer = new ListWriter()
-  def tracer = CoreTracer.builder().writer(writer).build()
+  def tracer = tracerBuilder().writer(writer).build()
 
   def cleanup() {
     tracer?.close()

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/processor/TraceProcessorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/processor/TraceProcessorTest.groovy
@@ -3,16 +3,15 @@ package datadog.trace.core.processor
 import datadog.trace.bootstrap.instrumentation.api.InstrumentationTags
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.common.writer.ListWriter
-import datadog.trace.core.CoreTracer
 import datadog.trace.core.processor.rule.URLAsResourceNameRule
-import datadog.trace.test.util.DDSpecification
+import datadog.trace.core.test.DDCoreSpecification
 import spock.lang.Subject
 
-class TraceProcessorTest extends DDSpecification {
+class TraceProcessorTest extends DDCoreSpecification {
 
   @Subject
   def processor = new TraceProcessor()
-  def tracer = CoreTracer.builder().writer(new ListWriter()).build()
+  def tracer = tracerBuilder().writer(new ListWriter()).build()
   def span = tracer.buildSpan("fakeOperation").start()
   def trace = [span]
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/processor/URLAsResourceNameRuleTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/processor/URLAsResourceNameRuleTest.groovy
@@ -2,12 +2,11 @@ package datadog.trace.core.processor
 
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.common.writer.ListWriter
-import datadog.trace.core.CoreTracer
 import datadog.trace.core.processor.rule.URLAsResourceNameRule
-import datadog.trace.test.util.DDSpecification
+import datadog.trace.core.test.DDCoreSpecification
 import spock.lang.Subject
 
-class URLAsResourceNameRuleTest extends DDSpecification {
+class URLAsResourceNameRuleTest extends DDCoreSpecification {
 
   @Subject
   def decorator = new URLAsResourceNameRule()
@@ -110,7 +109,7 @@ class URLAsResourceNameRuleTest extends DDSpecification {
 
   def "sets the resource name"() {
     setup:
-    def tracer = CoreTracer.builder().writer(new ListWriter()).build()
+    def tracer = tracerBuilder().writer(new ListWriter()).build()
 
     when:
     def span = tracer.buildSpan("fakeOperation").start()

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/B3HttpInjectorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/B3HttpInjectorTest.groovy
@@ -3,23 +3,22 @@ package datadog.trace.core.propagation
 import datadog.trace.api.DDId
 import datadog.trace.api.sampling.PrioritySampling
 import datadog.trace.common.writer.ListWriter
-import datadog.trace.core.CoreTracer
 import datadog.trace.core.DDSpanContext
-import datadog.trace.test.util.DDSpecification
+import datadog.trace.core.test.DDCoreSpecification
 
 import static datadog.trace.core.CoreTracer.TRACE_ID_MAX
 import static datadog.trace.core.propagation.B3HttpCodec.SAMPLING_PRIORITY_KEY
 import static datadog.trace.core.propagation.B3HttpCodec.SPAN_ID_KEY
 import static datadog.trace.core.propagation.B3HttpCodec.TRACE_ID_KEY
 
-class B3HttpInjectorTest extends DDSpecification {
+class B3HttpInjectorTest extends DDCoreSpecification {
 
   HttpCodec.Injector injector = new B3HttpCodec.Injector()
 
   def "inject http headers"() {
     setup:
     def writer = new ListWriter()
-    def tracer = CoreTracer.builder().writer(writer).build()
+    def tracer = tracerBuilder().writer(writer).build()
     final DDSpanContext mockedContext =
       new DDSpanContext(
         DDId.from("$traceId"),

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/DatadogHttpInjectorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/DatadogHttpInjectorTest.groovy
@@ -3,9 +3,8 @@ package datadog.trace.core.propagation
 import datadog.trace.api.DDId
 import datadog.trace.api.sampling.PrioritySampling
 import datadog.trace.common.writer.ListWriter
-import datadog.trace.core.CoreTracer
 import datadog.trace.core.DDSpanContext
-import datadog.trace.test.util.DDSpecification
+import datadog.trace.core.test.DDCoreSpecification
 
 import static datadog.trace.core.CoreTracer.TRACE_ID_MAX
 import static datadog.trace.core.propagation.DatadogHttpCodec.ORIGIN_KEY
@@ -14,14 +13,14 @@ import static datadog.trace.core.propagation.DatadogHttpCodec.SAMPLING_PRIORITY_
 import static datadog.trace.core.propagation.DatadogHttpCodec.SPAN_ID_KEY
 import static datadog.trace.core.propagation.DatadogHttpCodec.TRACE_ID_KEY
 
-class DatadogHttpInjectorTest extends DDSpecification {
+class DatadogHttpInjectorTest extends DDCoreSpecification {
 
   HttpCodec.Injector injector = new DatadogHttpCodec.Injector()
 
   def "inject http headers"() {
     setup:
     def writer = new ListWriter()
-    def tracer = CoreTracer.builder().writer(writer).build()
+    def tracer = tracerBuilder().writer(writer).build()
     final DDSpanContext mockedContext =
       new DDSpanContext(
         DDId.from(traceId),

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HaystackHttpInjectorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HaystackHttpInjectorTest.groovy
@@ -3,9 +3,8 @@ package datadog.trace.core.propagation
 import datadog.trace.api.DDId
 import datadog.trace.api.sampling.PrioritySampling
 import datadog.trace.common.writer.ListWriter
-import datadog.trace.core.CoreTracer
 import datadog.trace.core.DDSpanContext
-import datadog.trace.test.util.DDSpecification
+import datadog.trace.core.test.DDCoreSpecification
 
 import static datadog.trace.core.CoreTracer.TRACE_ID_MAX
 import static datadog.trace.core.propagation.HaystackHttpCodec.DD_PARENT_ID_BAGGAGE_KEY
@@ -16,14 +15,14 @@ import static datadog.trace.core.propagation.HaystackHttpCodec.OT_BAGGAGE_PREFIX
 import static datadog.trace.core.propagation.HaystackHttpCodec.SPAN_ID_KEY
 import static datadog.trace.core.propagation.HaystackHttpCodec.TRACE_ID_KEY
 
-class HaystackHttpInjectorTest extends DDSpecification {
+class HaystackHttpInjectorTest extends DDCoreSpecification {
 
   HttpCodec.Injector injector = new HaystackHttpCodec.Injector()
 
   def "inject http headers"() {
     setup:
     def writer = new ListWriter()
-    def tracer = CoreTracer.builder().writer(writer).build()
+    def tracer = tracerBuilder().writer(writer).build()
     final DDSpanContext mockedContext =
       new DDSpanContext(
         DDId.from(traceId),
@@ -75,7 +74,7 @@ class HaystackHttpInjectorTest extends DDSpecification {
   def "inject http headers with haystack traceId in baggage"() {
     setup:
     def writer = new ListWriter()
-    def tracer = CoreTracer.builder().writer(writer).build()
+    def tracer = tracerBuilder().writer(writer).build()
     def haystackUuid = traceUuid
     final DDSpanContext mockedContext =
       new DDSpanContext(

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HttpInjectorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HttpInjectorTest.groovy
@@ -4,14 +4,13 @@ import datadog.trace.api.Config
 import datadog.trace.api.DDId
 import datadog.trace.api.sampling.PrioritySampling
 import datadog.trace.common.writer.ListWriter
-import datadog.trace.core.CoreTracer
 import datadog.trace.core.DDSpanContext
-import datadog.trace.test.util.DDSpecification
+import datadog.trace.core.test.DDCoreSpecification
 
 import static datadog.trace.api.PropagationStyle.B3
 import static datadog.trace.api.PropagationStyle.DATADOG
 
-class HttpInjectorTest extends DDSpecification {
+class HttpInjectorTest extends DDCoreSpecification {
 
   def "inject http headers"() {
     setup:
@@ -24,7 +23,7 @@ class HttpInjectorTest extends DDSpecification {
     def spanId = DDId.from(2)
 
     def writer = new ListWriter()
-    def tracer = CoreTracer.builder().writer(writer).build()
+    def tracer = tracerBuilder().writer(writer).build()
     final DDSpanContext mockedContext =
       new DDSpanContext(
         traceId,

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerDepthTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerDepthTest.groovy
@@ -7,13 +7,12 @@ import datadog.trace.bootstrap.instrumentation.api.AgentTracer.NoopAgentScope
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer.NoopAgentSpan
 import datadog.trace.bootstrap.instrumentation.api.ScopeSource
 import datadog.trace.common.writer.ListWriter
-import datadog.trace.core.CoreTracer
-import datadog.trace.test.util.DDSpecification
+import datadog.trace.core.test.DDCoreSpecification
 
-class ScopeManagerDepthTest extends DDSpecification {
+class ScopeManagerDepthTest extends DDCoreSpecification {
   def "scopemanager returns noop scope if depth exceeded"() {
     given:
-    def tracer = CoreTracer.builder().writer(new ListWriter()).build()
+    def tracer = tracerBuilder().writer(new ListWriter()).build()
     def scopeManager = tracer.scopeManager
 
     when: "fill up the scope stack"
@@ -54,7 +53,7 @@ class ScopeManagerDepthTest extends DDSpecification {
   def "scopemanager ignores depth limit when 0"() {
     given:
     injectSysConfig(TracerConfig.SCOPE_DEPTH_LIMIT, "0")
-    def tracer = CoreTracer.builder().writer(new ListWriter()).build()
+    def tracer = tracerBuilder().writer(new ListWriter()).build()
     def scopeManager = tracer.scopeManager
 
     when: "fill up the scope stack"
@@ -98,7 +97,7 @@ class ScopeManagerDepthTest extends DDSpecification {
     // Closed scopes that are not on top still count for depth
 
     given:
-    def tracer = CoreTracer.builder().writer(new ListWriter()).build()
+    def tracer = tracerBuilder().writer(new ListWriter()).build()
     def scopeManager = tracer.scopeManager
 
     when:

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerTest.groovy
@@ -13,7 +13,7 @@ import datadog.trace.context.ScopeListener
 import datadog.trace.context.TraceScope
 import datadog.trace.core.CoreTracer
 import datadog.trace.core.DDSpan
-import datadog.trace.test.util.DDSpecification
+import datadog.trace.core.test.DDCoreSpecification
 import spock.lang.Shared
 
 import java.lang.ref.WeakReference
@@ -25,7 +25,7 @@ import static datadog.trace.core.scopemanager.EventCountingListener.EVENT.ACTIVA
 import static datadog.trace.core.scopemanager.EventCountingListener.EVENT.CLOSE
 import static datadog.trace.test.util.GCUtils.awaitGC
 
-class ScopeManagerTest extends DDSpecification {
+class ScopeManagerTest extends DDCoreSpecification {
   private static final long TIMEOUT_MS = 10_000
 
   ListWriter writer
@@ -37,7 +37,7 @@ class ScopeManagerTest extends DDSpecification {
   def setup() {
     writer = new ListWriter()
     statsDClient = Mock()
-    tracer = CoreTracer.builder().writer(writer).statsDClient(statsDClient).build()
+    tracer = tracerBuilder().writer(writer).statsDClient(statsDClient).build()
     scopeManager = tracer.scopeManager
     eventCountingListener = new EventCountingListener()
     scopeManager.addScopeListener(eventCountingListener)

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/test/DDCoreSpecification.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/test/DDCoreSpecification.groovy
@@ -1,0 +1,21 @@
+package datadog.trace.core.test
+
+import com.timgroup.statsd.NoOpStatsDClient
+import datadog.trace.core.CoreTracer
+import datadog.trace.core.CoreTracer.CoreTracerBuilder
+import datadog.trace.test.util.DDSpecification
+
+abstract class DDCoreSpecification extends DDSpecification {
+
+  protected boolean useNoopStatsDClient() {
+    return true
+  }
+
+  protected CoreTracerBuilder tracerBuilder() {
+    def builder = CoreTracer.builder()
+    if (useNoopStatsDClient()) {
+      return builder.statsDClient(new NoOpStatsDClient())
+    }
+    return builder
+  }
+}


### PR DESCRIPTION
So `tracer.close()` will shut down the `statsDClient`, which for some reason takes roughly 1 second. This means that every test that create and close a `tracer` will take 1 second extra. This change makes `dd-trace-core:test` go from 8 minutes to 1.5 minutes on my machine.