### PR TITLE
Update printing writer to output a Map<String, List<List<Span>>>>

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/PrintingWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/PrintingWriter.java
@@ -16,26 +16,28 @@ import okio.Okio;
 public class PrintingWriter implements Writer {
   private final TraceProcessor processor = new TraceProcessor();
   private final BufferedSink sink;
-  private final JsonAdapter<Map<String, List<DDSpan>>> jsonAdapter;
+  private final JsonAdapter<Map<String, List<List<DDSpan>>>> jsonAdapter;
 
   public PrintingWriter(final OutputStream outputStream, final boolean hexIds) {
     sink = Okio.buffer(Okio.sink(outputStream));
 
     this.jsonAdapter =
-        new Moshi.Builder()
-            .add(DDSpanJsonAdapter.buildFactory(hexIds))
-            .build()
-            .adapter(
-                Types.newParameterizedType(
-                    Map.class, String.class, Types.newParameterizedType(List.class, DDSpan.class)));
+      new Moshi.Builder()
+        .add(DDSpanJsonAdapter.buildFactory(hexIds))
+        .build()
+        .adapter(
+          Types.newParameterizedType(
+            Map.class, String.class, Types.newParameterizedType(List.class,
+              Types.newParameterizedType(List.class, DDSpan.class))));
   }
 
   @Override
   public void write(final List<DDSpan> trace) {
     final List<DDSpan> processedTrace = processor.onTraceComplete(trace);
+    final List<List<DDSpan>> tracesList = Collections.singletonList(processedTrace);
     try {
       synchronized (sink) {
-        jsonAdapter.toJson(sink, Collections.singletonMap("traces", processedTrace));
+        jsonAdapter.toJson(sink, Collections.singletonMap("traces", tracesList));
         sink.flush();
       }
     } catch (final IOException e) {

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/PrintingWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/PrintingWriter.java
@@ -22,13 +22,15 @@ public class PrintingWriter implements Writer {
     sink = Okio.buffer(Okio.sink(outputStream));
 
     this.jsonAdapter =
-      new Moshi.Builder()
-        .add(DDSpanJsonAdapter.buildFactory(hexIds))
-        .build()
-        .adapter(
-          Types.newParameterizedType(
-            Map.class, String.class, Types.newParameterizedType(List.class,
-              Types.newParameterizedType(List.class, DDSpan.class))));
+        new Moshi.Builder()
+            .add(DDSpanJsonAdapter.buildFactory(hexIds))
+            .build()
+            .adapter(
+                Types.newParameterizedType(
+                    Map.class,
+                    String.class,
+                    Types.newParameterizedType(
+                        List.class, Types.newParameterizedType(List.class, DDSpan.class))));
   }
 
   @Override

--- a/dd-trace-core/src/test/groovy/datadog/trace/api/writer/PrintingWriterTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/api/writer/PrintingWriterTest.groovy
@@ -39,11 +39,11 @@ class PrintingWriterTest extends DDSpecification {
 
     when:
     writer.write(sampleTrace)
-    Map<String, List<Map>> result = adapter.fromJson(buffer.readString(StandardCharsets.UTF_8))
+    Map<String, List<List<Map>>> result = adapter.fromJson(buffer.readString(StandardCharsets.UTF_8))
 
     then:
-    result["traces"].size() == sampleTrace.size()
-    result["traces"].each {
+    result["traces"][0].size() == sampleTrace.size()
+    result["traces"][0].each {
       assert it["service"] == "fakeService"
       assert it["name"] == "fakeOperation"
       assert it["resource"] == "fakeResource"
@@ -63,8 +63,8 @@ class PrintingWriterTest extends DDSpecification {
     result = adapter.fromJson(buffer.readString(StandardCharsets.UTF_8))
 
     then:
-    result["traces"].size() == secondTrace.size()
-    result["traces"].each {
+    result["traces"][0].size() == secondTrace.size()
+    result["traces"][0].each {
       assert it["service"] == "fakeService"
       assert it["name"] == "fakeOperation"
       assert it["resource"] == "fakeResource"
@@ -88,11 +88,11 @@ class PrintingWriterTest extends DDSpecification {
 
     when:
     writer.write(sampleTrace)
-    Map<String, List<Map>> result = adapter.fromJson(buffer.readString(StandardCharsets.UTF_8))
+    Map<String, List<List<Map>>> result = adapter.fromJson(buffer.readString(StandardCharsets.UTF_8))
 
     then:
-    result["traces"].size() == sampleTrace.size()
-    result["traces"].each {
+    result["traces"][0].size() == sampleTrace.size()
+    result["traces"][0].each {
       assert it["service"] == "fakeService"
       assert it["name"] == "fakeOperation"
       assert it["resource"] == "fakeResource"

--- a/dd-trace-core/src/test/groovy/datadog/trace/api/writer/PrintingWriterTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/api/writer/PrintingWriterTest.groovy
@@ -16,7 +16,9 @@ class PrintingWriterTest extends DDSpecification {
   def sampleTrace
   def secondTrace
 
-  def adapter = new Moshi.Builder().build().adapter(Types.newParameterizedType(Map, String, Types.newParameterizedType(List, Map)))
+  def adapter = new Moshi.Builder().build().adapter(Types.newParameterizedType(Map, String,
+    Types.newParameterizedType(List,
+    Types.newParameterizedType(List, Map))))
 
   def setup() {
     def builder = tracer.buildSpan("fakeOperation")


### PR DESCRIPTION
Here is an example of PrintingWriter output:

```
{
  "traces": [
    {
      "service": "lambdainternal.AWSLambda",
      "name": "trace.annotation",
      "resource": "Handler.handleRequest",
      "trace_id": "4d16a13fbfd90a9f",
      "span_id": "61bc913f36167bb7",
      "parent_id": "0",
      "start": 1611588270763038500,
      "duration": 3574451,
      "error": 0,
      "metrics": {
        "_dd.agent_psr": 1
      },
      "meta": {
        "runtime-id": "14bfd33e-63a5-43f4-8550-b8c8bae7b2c2",
        "language": "jvm",
        "component": "trace",
        "thread.name": "main",
        "request_id": "e0ea9c2b-80ba-413a-a636-fba1da90b817",
        "thread.id": "1"
      }
    }
  ]
}
```

The output of PrintingWriter did not quite conform to the specification here: https://github.com/DataDog/architecture/blob/master/rfcs/serverless/lambda-direct-tracing/rfc.md#export-traces-to-logs . Specifically, `traces` should be a list of Traces, where each Trace is a list of Spans. 