### PR TITLE
drop p0 spans when the trace agent supports tracer-side dropping

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -26,7 +26,6 @@ public final class ConfigDefaults {
   static final boolean DEFAULT_TRACE_ENABLED = true;
   static final boolean DEFAULT_INTEGRATIONS_ENABLED = true;
   static final String DEFAULT_AGENT_WRITER_TYPE = "DDAgentWriter";
-  static final String DEFAULT_PRIORITIZATION_TYPE = "FastLane";
 
   static final boolean DEFAULT_RUNTIME_CONTEXT_FIELD_INJECTION = true;
   static final boolean DEFAULT_LEGACY_CONTEXT_FIELD_INJECTION = false;

--- a/dd-trace-api/src/main/java/datadog/trace/api/sampling/PrioritySampling.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/sampling/PrioritySampling.java
@@ -15,6 +15,8 @@ public class PrioritySampling {
   public static final byte USER_DROP = -1;
   /** The user has decided to keep the trace. */
   public static final byte USER_KEEP = 2;
+  /** This trace contains a rare span not seen within the metrics interval */
+  public static final byte METRICS_KEEP = 3;
 
   private PrioritySampling() {}
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/sampling/PrioritySampling.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/sampling/PrioritySampling.java
@@ -15,8 +15,6 @@ public class PrioritySampling {
   public static final byte USER_DROP = -1;
   /** The user has decided to keep the trace. */
   public static final byte USER_KEEP = 2;
-  /** This trace contains a rare span not seen within the metrics interval */
-  public static final byte METRICS_KEEP = 3;
 
   private PrioritySampling() {}
 }

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/Aggregator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/Aggregator.java
@@ -8,6 +8,7 @@ import datadog.trace.core.util.LRUCache;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Queue;
+import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
@@ -20,6 +21,7 @@ final class Aggregator implements Runnable {
   private final BlockingQueue<Batch> inbox;
   private final LRUCache<MetricKey, AggregateMetric> aggregates;
   private final ConcurrentHashMap<MetricKey, Batch> pending;
+  private final Set<MetricKey> newKeysInInterval;
   private final MetricWriter writer;
   // the reporting interval controls how much history will be buffered
   // when the agent is unresponsive (only 10 pending requests will be
@@ -33,12 +35,14 @@ final class Aggregator implements Runnable {
       Queue<Batch> batchPool,
       BlockingQueue<Batch> inbox,
       ConcurrentHashMap<MetricKey, Batch> pending,
+      Set<MetricKey> newKeysInInterval,
       int maxAggregates,
       long reportingInterval,
       TimeUnit reportingIntervalTimeUnit) {
     this.writer = writer;
     this.batchPool = batchPool;
     this.inbox = inbox;
+    this.newKeysInInterval = newKeysInInterval;
     this.aggregates = new LRUCache<>(maxAggregates * 4 / 3, 0.75f, maxAggregates);
     this.pending = pending;
     this.reportingIntervalNanos = reportingIntervalTimeUnit.toNanos(reportingInterval);

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/Aggregator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/Aggregator.java
@@ -21,7 +21,7 @@ final class Aggregator implements Runnable {
   private final BlockingQueue<Batch> inbox;
   private final LRUCache<MetricKey, AggregateMetric> aggregates;
   private final ConcurrentHashMap<MetricKey, Batch> pending;
-  private final Set<MetricKey> newKeysInInterval;
+  private final Set<MetricKey> commonKeys;
   private final MetricWriter writer;
   // the reporting interval controls how much history will be buffered
   // when the agent is unresponsive (only 10 pending requests will be
@@ -35,14 +35,14 @@ final class Aggregator implements Runnable {
       Queue<Batch> batchPool,
       BlockingQueue<Batch> inbox,
       ConcurrentHashMap<MetricKey, Batch> pending,
-      Set<MetricKey> newKeysInInterval,
+      Set<MetricKey> commonKeys,
       int maxAggregates,
       long reportingInterval,
       TimeUnit reportingIntervalTimeUnit) {
     this.writer = writer;
     this.batchPool = batchPool;
     this.inbox = inbox;
-    this.newKeysInInterval = newKeysInInterval;
+    this.commonKeys = commonKeys;
     this.aggregates = new LRUCache<>(maxAggregates * 4 / 3, 0.75f, maxAggregates);
     this.pending = pending;
     this.reportingIntervalNanos = reportingIntervalTimeUnit.toNanos(reportingInterval);
@@ -90,10 +90,8 @@ final class Aggregator implements Runnable {
         if (!aggregates.isEmpty()) {
           writer.startBucket(aggregates.size(), when, reportingIntervalNanos);
           for (Map.Entry<MetricKey, AggregateMetric> aggregate : aggregates.entrySet()) {
-            if (aggregate.getValue().getHitCount() > 0) {
-              writer.add(aggregate.getKey(), aggregate.getValue());
-              aggregate.getValue().clear();
-            }
+            writer.add(aggregate.getKey(), aggregate.getValue());
+            aggregate.getValue().clear();
           }
           // note that this may do IO and block
           writer.finishBucket();
@@ -109,9 +107,11 @@ final class Aggregator implements Runnable {
   private void expungeStaleAggregates() {
     Iterator<Map.Entry<MetricKey, AggregateMetric>> it = aggregates.entrySet().iterator();
     while (it.hasNext()) {
-      AggregateMetric metric = it.next().getValue();
+      Map.Entry<MetricKey, AggregateMetric> pair = it.next();
+      AggregateMetric metric = pair.getValue();
       if (metric.getHitCount() == 0) {
         it.remove();
+        commonKeys.remove(pair.getKey());
       }
     }
   }

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/ConflatingMetricsAggregator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/ConflatingMetricsAggregator.java
@@ -18,8 +18,8 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
-import org.jctools.queues.MpmcArrayQueue;
 import org.jctools.queues.MpscBlockingConsumerArrayQueue;
+import org.jctools.queues.SpmcArrayQueue;
 
 @Slf4j
 public final class ConflatingMetricsAggregator implements MetricsAggregator, EventListener {
@@ -81,7 +81,7 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
       long reportingInterval,
       TimeUnit timeUnit) {
     this.inbox = new MpscBlockingConsumerArrayQueue<>(queueSize);
-    this.batchPool = new MpmcArrayQueue<>(maxAggregates);
+    this.batchPool = new SpmcArrayQueue<>(maxAggregates);
     this.pending = new ConcurrentHashMap<>(maxAggregates * 4 / 3, 0.75f);
     this.keys = new ConcurrentHashMap<>();
     this.sink = sink;

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/ConflatingMetricsAggregator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/ConflatingMetricsAggregator.java
@@ -172,12 +172,6 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
     pending.put(key, batch);
     // must offer to the queue after adding to pending
     inbox.offer(batch);
-    // enforce a soft bound on the size of the collection,
-    // which may lead to some false positive sampler overrides
-    // when metric cardinality is high
-    if (keys.size() > 10_000) {
-      keys.remove(keys.keys().nextElement());
-    }
     // force keep keys we haven't seen before or errors
     return isNewKey || span.getError() > 0;
   }

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/MetricKey.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/MetricKey.java
@@ -56,8 +56,10 @@ public final class MetricKey {
 
   @Override
   public boolean equals(Object o) {
-    if (o == null) return false;
-    try {
+    if (this == o) {
+      return true;
+    }
+    if ((o instanceof MetricKey)) {
       MetricKey metricKey = (MetricKey) o;
       return hash == metricKey.hash
           && httpStatusCode == metricKey.httpStatusCode
@@ -65,7 +67,6 @@ public final class MetricKey {
           && service.equals(metricKey.service)
           && operationName.equals(metricKey.operationName)
           && type.equals(metricKey.type);
-    } catch (ClassCastException unlikely) {
     }
     return false;
   }

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/MetricsAggregator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/MetricsAggregator.java
@@ -8,5 +8,5 @@ public interface MetricsAggregator extends AutoCloseable {
 
   void report();
 
-  void publish(List<? extends CoreSpan<?>> trace);
+  boolean publish(List<? extends CoreSpan<?>> trace);
 }

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/NoOpMetricsAggregator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/NoOpMetricsAggregator.java
@@ -14,7 +14,9 @@ public final class NoOpMetricsAggregator implements MetricsAggregator {
   public void report() {}
 
   @Override
-  public void publish(List<? extends CoreSpan<?>> trace) {}
+  public boolean publish(List<? extends CoreSpan<?>> trace) {
+    return false;
+  }
 
   @Override
   public void close() {}

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/DDAgentWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/DDAgentWriter.java
@@ -198,7 +198,6 @@ public class DDAgentWriter implements Writer {
   @Override
   public void start() {
     if (!closed) {
-      discovery.start();
       traceProcessingWorker.start();
       healthMetrics.start();
       healthMetrics.onStart((int) getCapacity());
@@ -207,7 +206,6 @@ public class DDAgentWriter implements Writer {
 
   @Override
   public void close() {
-    discovery.close();
     final boolean flushed = flush();
     closed = true;
     traceProcessingWorker.close();

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/DDAgentWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/DDAgentWriter.java
@@ -143,7 +143,7 @@ public class DDAgentWriter implements Writer {
       } else {
         final DDSpan root = trace.get(0);
         final int samplingPriority = root.context().getSamplingPriority();
-        if (traceProcessingWorker.publish(samplingPriority, trace)) {
+        if (traceProcessingWorker.publish(root, samplingPriority, trace)) {
           healthMetrics.onPublish(trace, samplingPriority);
         } else {
           handleDroppedTrace("Trace written to overfilled buffer", trace, samplingPriority);

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/DDAgentWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/DDAgentWriter.java
@@ -105,6 +105,7 @@ public class DDAgentWriter implements Writer {
             healthMetrics,
             monitoring,
             dispatcher,
+            featureDiscovery,
             null == prioritization ? FAST_LANE : prioritization,
             flushFrequencySeconds,
             TimeUnit.SECONDS);

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ListWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ListWriter.java
@@ -25,7 +25,7 @@ public class ListWriter extends CopyOnWriteArrayList<List<DDSpan>> implements Wr
 
   @Override
   public void write(List<DDSpan> trace) {
-    incrementTraceCount();
+    incrementDropCounts(trace.size());
     synchronized (latches) {
       trace = processor.onTraceComplete(trace);
       add(trace);
@@ -89,7 +89,7 @@ public class ListWriter extends CopyOnWriteArrayList<List<DDSpan>> implements Wr
   }
 
   @Override
-  public void incrementTraceCount() {
+  public void incrementDropCounts(int spanCount) {
     traceCount.incrementAndGet();
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ListWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ListWriter.java
@@ -25,7 +25,7 @@ public class ListWriter extends CopyOnWriteArrayList<List<DDSpan>> implements Wr
 
   @Override
   public void write(List<DDSpan> trace) {
-    incrementDropCounts(trace.size());
+    traceCount.incrementAndGet();
     synchronized (latches) {
       trace = processor.onTraceComplete(trace);
       add(trace);
@@ -89,9 +89,7 @@ public class ListWriter extends CopyOnWriteArrayList<List<DDSpan>> implements Wr
   }
 
   @Override
-  public void incrementDropCounts(int spanCount) {
-    traceCount.incrementAndGet();
-  }
+  public void incrementDropCounts(int spanCount) {}
 
   @Override
   public void start() {

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/LoggingWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/LoggingWriter.java
@@ -45,7 +45,7 @@ public class LoggingWriter implements Writer {
   }
 
   @Override
-  public void incrementTraceCount() {}
+  public void incrementDropCounts(int spanCount) {}
 
   @Override
   public String toString() {

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/MultiWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/MultiWriter.java
@@ -75,10 +75,10 @@ public class MultiWriter implements Writer {
   }
 
   @Override
-  public void incrementTraceCount() {
+  public void incrementDropCounts(int spanCount) {
     for (Writer writer : writers) {
       if (writer != null) {
-        writer.incrementTraceCount();
+        writer.incrementDropCounts(spanCount);
       }
     }
   }

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/PrintingWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/PrintingWriter.java
@@ -63,5 +63,5 @@ public class PrintingWriter implements Writer {
   }
 
   @Override
-  public void incrementTraceCount() {}
+  public void incrementDropCounts(int spanCount) {}
 }

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/TraceStructureWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/TraceStructureWriter.java
@@ -139,7 +139,7 @@ public class TraceStructureWriter implements Writer {
   }
 
   @Override
-  public void incrementTraceCount() {}
+  public void incrementDropCounts(int spanCount) {}
 
   private static final class Node {
     private final CharSequence operationName;

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/Writer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/Writer.java
@@ -32,5 +32,5 @@ public interface Writer extends Closeable {
   void close();
 
   /** Count that a trace was captured for stats, but without reporting it. */
-  void incrementTraceCount();
+  void incrementDropCounts(int spanCount);
 }

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/WriterFactory.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/WriterFactory.java
@@ -1,7 +1,9 @@
 package datadog.trace.common.writer;
 
-import static datadog.trace.bootstrap.instrumentation.api.PrioritizationConstants.ENSURE_TRACE_TYPE;
+import static datadog.trace.api.config.TracerConfig.PRIORITIZATION_TYPE;
 import static datadog.trace.bootstrap.instrumentation.api.WriterConstants.*;
+import static datadog.trace.common.writer.ddagent.Prioritization.ENSURE_TRACE;
+import static datadog.trace.common.writer.ddagent.Prioritization.FAST_LANE;
 
 import com.timgroup.statsd.StatsDClient;
 import datadog.common.container.ServerlessInfo;
@@ -74,10 +76,9 @@ public class WriterFactory {
             Config.get().isTracerMetricsEnabled(),
             monitoring);
 
-    final String prioritizationType = config.getPrioritizationType();
-    Prioritization prioritization = null;
-    if (ENSURE_TRACE_TYPE.equals(prioritizationType)) {
-      prioritization = Prioritization.ENSURE_TRACE;
+    Prioritization prioritization =
+        config.getEnumValue(PRIORITIZATION_TYPE, Prioritization.class, FAST_LANE);
+    if (ENSURE_TRACE == prioritization) {
       log.info(
           "Using 'EnsureTrace' prioritization type. (Do not use this type if your application is running in production mode)");
     }

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/DDAgentApi.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/DDAgentApi.java
@@ -35,6 +35,8 @@ public class DDAgentApi {
   private static final String DATADOG_CLIENT_COMPUTED_TOP_LEVEL =
       "Datadog-Client-Computed-Top-Level";
   private static final String X_DATADOG_TRACE_COUNT = "X-Datadog-Trace-Count";
+  private static final String DATADOG_DROPPED_TRACE_COUNT = "Datadog-Client-Dropped-P0-Traces";
+  private static final String DATADOG_DROPPED_SPAN_COUNT = "Datadog-Client-Dropped-P0-Spans";
   private static final String V3_ENDPOINT = "v0.3/traces";
   private static final String V4_ENDPOINT = "v0.4/traces";
   private static final String V5_ENDPOINT = "v0.5/traces";
@@ -143,6 +145,8 @@ public class DDAgentApi {
               .addHeader(DATADOG_CLIENT_COMPUTED_TOP_LEVEL, "true")
               .addHeader(DATADOG_CLIENT_COMPUTED_STATS, metricsReportingEnabled ? "true" : "")
               .addHeader(X_DATADOG_TRACE_COUNT, Integer.toString(payload.traceCount()))
+              .addHeader(DATADOG_DROPPED_TRACE_COUNT, Long.toString(payload.droppedTraces()))
+              .addHeader(DATADOG_DROPPED_SPAN_COUNT, Long.toString(payload.droppedSpans()))
               .put(payload.toRequest())
               .build();
       this.totalTraces += payload.traceCount();

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/DDAgentApi.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/DDAgentApi.java
@@ -98,8 +98,14 @@ public class DDAgentApi {
                   DATADOG_CLIENT_COMPUTED_STATS,
                   metricsEnabled && featuresDiscovery.supportsMetrics() ? "true" : "")
               .addHeader(X_DATADOG_TRACE_COUNT, Integer.toString(payload.traceCount()))
-              .addHeader(DATADOG_DROPPED_TRACE_COUNT, featuresDiscovery.supportsDropping() ? Long.toString(payload.droppedTraces()) : "")
-              .addHeader(DATADOG_DROPPED_SPAN_COUNT, featuresDiscovery.supportsDropping() ? Long.toString(payload.droppedSpans()) : "")
+              .addHeader(
+                  DATADOG_DROPPED_TRACE_COUNT,
+                  featuresDiscovery.supportsDropping()
+                      ? Long.toString(payload.droppedTraces())
+                      : "")
+              .addHeader(
+                  DATADOG_DROPPED_SPAN_COUNT,
+                  featuresDiscovery.supportsDropping() ? Long.toString(payload.droppedSpans()) : "")
               .put(payload.toRequest())
               .build();
       this.totalTraces += payload.traceCount();

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/DDAgentApi.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/DDAgentApi.java
@@ -98,14 +98,8 @@ public class DDAgentApi {
                   DATADOG_CLIENT_COMPUTED_STATS,
                   metricsEnabled && featuresDiscovery.supportsMetrics() ? "true" : "")
               .addHeader(X_DATADOG_TRACE_COUNT, Integer.toString(payload.traceCount()))
-              .addHeader(
-                  DATADOG_DROPPED_TRACE_COUNT,
-                  featuresDiscovery.supportsDropping()
-                      ? Long.toString(payload.droppedTraces())
-                      : "")
-              .addHeader(
-                  DATADOG_DROPPED_SPAN_COUNT,
-                  featuresDiscovery.supportsDropping() ? Long.toString(payload.droppedSpans()) : "")
+              .addHeader(DATADOG_DROPPED_TRACE_COUNT, Long.toString(payload.droppedTraces()))
+              .addHeader(DATADOG_DROPPED_SPAN_COUNT, Long.toString(payload.droppedSpans()))
               .put(payload.toRequest())
               .build();
       this.totalTraces += payload.traceCount();

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/DDAgentApi.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/DDAgentApi.java
@@ -98,8 +98,8 @@ public class DDAgentApi {
                   DATADOG_CLIENT_COMPUTED_STATS,
                   metricsEnabled && featuresDiscovery.supportsMetrics() ? "true" : "")
               .addHeader(X_DATADOG_TRACE_COUNT, Integer.toString(payload.traceCount()))
-              .addHeader(DATADOG_DROPPED_TRACE_COUNT, Long.toString(payload.droppedTraces()))
-              .addHeader(DATADOG_DROPPED_SPAN_COUNT, Long.toString(payload.droppedSpans()))
+              .addHeader(DATADOG_DROPPED_TRACE_COUNT, featuresDiscovery.supportsDropping() ? Long.toString(payload.droppedTraces()) : "")
+              .addHeader(DATADOG_DROPPED_SPAN_COUNT, featuresDiscovery.supportsDropping() ? Long.toString(payload.droppedSpans()) : "")
               .put(payload.toRequest())
               .build();
       this.totalTraces += payload.traceCount();

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/DDAgentFeaturesDiscovery.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/DDAgentFeaturesDiscovery.java
@@ -6,7 +6,6 @@ import com.squareup.moshi.Types;
 import datadog.trace.core.http.OkHttpUtils;
 import datadog.trace.core.monitor.Monitoring;
 import datadog.trace.core.monitor.Recording;
-import datadog.trace.util.AgentTaskScheduler;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Collections;
@@ -197,14 +196,6 @@ public class DDAgentFeaturesDiscovery implements DroppingPolicy {
 
   @Override
   public boolean active() {
-    return supportsDropping;
-  }
-
-  private static final class Discover implements AgentTaskScheduler.Task<DDAgentFeaturesDiscovery> {
-
-    @Override
-    public void run(DDAgentFeaturesDiscovery target) {
-      target.discover();
-    }
+    return supportsMetrics() && supportsDropping;
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/DDAgentFeaturesDiscovery.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/DDAgentFeaturesDiscovery.java
@@ -19,7 +19,7 @@ import okhttp3.Request;
 import okhttp3.Response;
 
 @Slf4j
-public class DDAgentFeaturesDiscovery {
+public class DDAgentFeaturesDiscovery implements DroppingPolicy {
 
   private static final JsonAdapter<Map<String, Object>> RESPONSE_ADAPTER =
       new Moshi.Builder()
@@ -181,5 +181,10 @@ public class DDAgentFeaturesDiscovery {
 
   private void errorQueryingEndpoint(String endpoint, Throwable t) {
     log.debug("Error querying {} at {}", endpoint, agentBaseUrl, t);
+  }
+
+  @Override
+  public boolean active() {
+    return supportsDropping;
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/DDAgentFeaturesDiscovery.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/DDAgentFeaturesDiscovery.java
@@ -1,0 +1,163 @@
+package datadog.trace.common.writer.ddagent;
+
+import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.Moshi;
+import com.squareup.moshi.Types;
+import java.io.IOException;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+
+@Slf4j
+public class DDAgentFeaturesDiscovery {
+
+  private static final JsonAdapter<Map<String, Object>> RESPONSE_ADAPTER =
+      new Moshi.Builder()
+          .build()
+          .adapter(Types.newParameterizedType(Map.class, String.class, Object.class));
+
+  private static final String V3_ENDPOINT = "v0.3/traces";
+  private static final String V4_ENDPOINT = "v0.4/traces";
+  private static final String V5_ENDPOINT = "v0.5/traces";
+
+  private static final String V5_METRICS_ENDPOINT = "v0.5/stats";
+
+  private final OkHttpClient client;
+  private final HttpUrl agentBaseUrl;
+
+  private volatile String traceEndpoint;
+  private volatile String metricsEndpoint;
+  private volatile boolean supportsDropping;
+
+  private final String[] traceEndpoints;
+  private final String[] metricsEndpoints = {V5_METRICS_ENDPOINT};
+
+  public DDAgentFeaturesDiscovery(OkHttpClient client, String agentUrl, boolean enableV05Traces) {
+    this.client = client;
+    this.agentBaseUrl = HttpUrl.get(agentUrl);
+    this.traceEndpoints =
+        enableV05Traces
+            ? new String[] {V5_ENDPOINT, V4_ENDPOINT, V3_ENDPOINT}
+            : new String[] {V4_ENDPOINT, V3_ENDPOINT};
+  }
+
+  public void discover() {
+    // 1. try to fetch info about the agent, if the endpoint is there
+    // 2. try to parse the response, if it can be parsed, finish
+    // 3. fallback if the endpoint couldn't be found or the response couldn't be parsed
+    boolean fallback = true;
+    try (Response response =
+        client
+            .newCall(new Request.Builder().url(agentBaseUrl.resolve("info").url()).build())
+            .execute()) {
+      if (response.isSuccessful()) {
+        fallback = !processInfoResponse(response.body().string());
+      }
+    } catch (Throwable error) {
+      errorQueryingEndpoint("info", error);
+    }
+    if (fallback) {
+      log.debug("Falling back to probing, client dropping will be disabled");
+      this.metricsEndpoint = probeTracerMetricsEndpoint();
+      this.traceEndpoint = probeTracesEndpoint();
+    }
+  }
+
+  private String probeTracerMetricsEndpoint() {
+    String candidate = "v0.5/stats";
+    try (Response response =
+        client
+            .newCall(new Request.Builder().url(agentBaseUrl.resolve(candidate).url()).build())
+            .execute()) {
+      if (response.code() != 404) {
+        return candidate;
+      }
+    } catch (IOException e) {
+      errorQueryingEndpoint(candidate, e);
+    }
+    log.debug("No metrics endpoint found, metrics will be disabled");
+    return null;
+  }
+
+  private String probeTracesEndpoint() {
+    for (String candidate : traceEndpoints) {
+      try (Response response =
+          client
+              .newCall(new Request.Builder().url(agentBaseUrl.resolve(candidate).url()).build())
+              .execute()) {
+        if (response.code() != 404) {
+          return candidate;
+        }
+      } catch (IOException e) {
+        errorQueryingEndpoint(candidate, e);
+      }
+    }
+    return V3_ENDPOINT;
+  }
+
+  @SuppressWarnings("unchecked")
+  private boolean processInfoResponse(String response) {
+    try {
+      Map<String, Object> map = RESPONSE_ADAPTER.fromJson(response);
+      List<String> endpoints = ((List<String>) map.get("endpoints"));
+      ListIterator<String> traceAgentSupportedEndpoints = endpoints.listIterator(endpoints.size());
+      boolean traceEndpointFound = false;
+      boolean metricsEndpointFound = false;
+      while ((!traceEndpointFound || !metricsEndpointFound)
+          && traceAgentSupportedEndpoints.hasPrevious()) {
+        String traceAgentSupportedEndpoint = traceAgentSupportedEndpoints.previous();
+        if (traceAgentSupportedEndpoint.startsWith("/")
+            && traceAgentSupportedEndpoint.length() > 1) {
+          traceAgentSupportedEndpoint = traceAgentSupportedEndpoint.substring(1);
+        }
+        if (!metricsEndpointFound) {
+          for (int i = metricsEndpoints.length - 1; i >= 0; --i) {
+            if (metricsEndpoints[i].equalsIgnoreCase(traceAgentSupportedEndpoint)) {
+              this.metricsEndpoint = traceAgentSupportedEndpoint;
+              metricsEndpointFound = true;
+              break;
+            }
+          }
+        }
+        if (!traceEndpointFound) {
+          for (int i = traceEndpoints.length - 1; i >= 0; --i) {
+            if (traceEndpoints[i].equalsIgnoreCase(traceAgentSupportedEndpoint)) {
+              this.traceEndpoint = traceAgentSupportedEndpoint;
+              traceEndpointFound = true;
+              break;
+            }
+          }
+        }
+      }
+      Object canDrop = map.get("client_drop_p0s");
+      this.supportsDropping =
+          null != canDrop
+              && ("true".equalsIgnoreCase(String.valueOf(canDrop)) || Boolean.TRUE.equals(canDrop));
+      return true;
+    } catch (Throwable error) {
+      log.debug("Error parsing trace agent /info response", error);
+    }
+    return false;
+  }
+
+  public boolean supportsDropping() {
+    return supportsDropping;
+  }
+
+  public String getMetricsEndpoint() {
+    return metricsEndpoint;
+  }
+
+  public String getTraceEndpoint() {
+    return traceEndpoint;
+  }
+
+  private void errorQueryingEndpoint(String endpoint, Throwable t) {
+    log.debug("Error querying {} at {}", endpoint, agentBaseUrl, t);
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/DroppingPolicy.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/DroppingPolicy.java
@@ -1,0 +1,5 @@
+package datadog.trace.common.writer.ddagent;
+
+public interface DroppingPolicy {
+  boolean active();
+}

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/Payload.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/Payload.java
@@ -14,6 +14,8 @@ public abstract class Payload {
   private static final ByteBuffer EMPTY_ARRAY = ByteBuffer.allocate(1).put(0, (byte) 0x90);
 
   private int traceCount = 0;
+  private long droppedTraces = 0;
+  private long droppedSpans = 0;
   protected ByteBuffer body = EMPTY_ARRAY.duplicate();
 
   public Payload withBody(int traceCount, ByteBuffer body) {
@@ -24,8 +26,26 @@ public abstract class Payload {
     return this;
   }
 
+  public Payload withDroppedTraces(long droppedTraceCount) {
+    this.droppedTraces += droppedTraceCount;
+    return this;
+  }
+
+  public Payload withDroppedSpans(long droppedSpanCount) {
+    this.droppedSpans += droppedSpanCount;
+    return this;
+  }
+
   int traceCount() {
     return traceCount;
+  }
+
+  long droppedTraces() {
+    return droppedTraces;
+  }
+
+  long droppedSpans() {
+    return droppedSpans;
   }
 
   abstract int sizeInBytes();

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/Prioritization.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/Prioritization.java
@@ -13,32 +13,20 @@ public enum Prioritization {
   ENSURE_TRACE {
     @Override
     public PrioritizationStrategy create(
-        final Queue<Object> primary, final Queue<Object> secondary) {
+        final Queue<Object> primary, final Queue<Object> secondary, DroppingPolicy neverUsed) {
       return new EnsureTraceStrategy(primary, secondary);
     }
   },
   FAST_LANE {
     @Override
     public PrioritizationStrategy create(
-        final Queue<Object> primary, final Queue<Object> secondary) {
-      return new FastLaneStrategy(primary, secondary);
-    }
-  },
-  DEAD_LETTERS {
-    @Override
-    public PrioritizationStrategy create(
-        final Queue<Object> primary, final Queue<Object> secondary) {
-      return new DeadLettersStrategy(primary, secondary);
-    }
-  },
-  DROP {
-    @Override
-    public PrioritizationStrategy create(Queue<Object> primary, Queue<Object> secondary) {
-      return new DropStrategy(primary);
+        final Queue<Object> primary, final Queue<Object> secondary, DroppingPolicy droppingPolicy) {
+      return new FastLaneStrategy(primary, secondary, droppingPolicy);
     }
   };
 
-  public abstract PrioritizationStrategy create(Queue<Object> primary, Queue<Object> secondary);
+  public abstract PrioritizationStrategy create(
+      Queue<Object> primary, Queue<Object> secondary, DroppingPolicy droppingPolicy);
 
   private abstract static class PrioritizationStrategyWithFlush implements PrioritizationStrategy {
 
@@ -95,89 +83,26 @@ public enum Prioritization {
   private static final class FastLaneStrategy extends PrioritizationStrategyWithFlush {
 
     private final Queue<Object> secondary;
+    private final DroppingPolicy droppingPolicy;
 
-    private FastLaneStrategy(final Queue<Object> primary, final Queue<Object> secondary) {
+    private FastLaneStrategy(
+        final Queue<Object> primary, final Queue<Object> secondary, DroppingPolicy droppingPolicy) {
       super(primary);
       this.secondary = secondary;
+      this.droppingPolicy = droppingPolicy;
     }
 
     @Override
     public <T extends CoreSpan<T>> boolean publish(T root, int priority, List<T> trace) {
+      if (root.isForceKeep()) {
+        return primary.offer(trace);
+      }
       switch (priority) {
         case SAMPLER_DROP:
         case USER_DROP:
-          return secondary.offer(trace);
+          return !droppingPolicy.active() && secondary.offer(trace);
         default:
           return primary.offer(trace);
-      }
-    }
-  }
-
-  private static final class DeadLettersStrategy implements PrioritizationStrategy {
-
-    private final Queue<Object> primary;
-    private final Queue<Object> secondary;
-
-    private DeadLettersStrategy(final Queue<Object> primary, final Queue<Object> secondary) {
-      this.primary = primary;
-      this.secondary = secondary;
-    }
-
-    @Override
-    public <T extends CoreSpan<T>> boolean publish(T root, int priority, final List<T> trace) {
-      if (!primary.offer(trace)) {
-        switch (priority) {
-          case SAMPLER_DROP:
-          case USER_DROP:
-            return false;
-          default:
-            return secondary.offer(trace);
-        }
-      }
-      return true;
-    }
-
-    @Override
-    public boolean flush(final long timeout, final TimeUnit timeUnit) {
-      // both queues need to be flushed
-      final CountDownLatch latch = new CountDownLatch(2);
-      final FlushEvent event = new FlushEvent(latch);
-      offer(primary, event);
-      offer(secondary, event);
-      try {
-        return latch.await(timeout, timeUnit);
-      } catch (final InterruptedException e) {
-        Thread.currentThread().interrupt();
-        return false;
-      }
-    }
-
-    private void offer(final Queue<Object> queue, final FlushEvent event) {
-      boolean offered;
-      do {
-        offered = queue.offer(event);
-      } while (!offered);
-    }
-  }
-
-  private static final class DropStrategy extends PrioritizationStrategyWithFlush {
-
-    private DropStrategy(final Queue<Object> primary) {
-      super(primary);
-    }
-
-    @Override
-    public <T extends CoreSpan<T>> boolean publish(T root, int priority, final List<T> trace) {
-      if (root.isForceKeep()) {
-        return primary.offer(trace);
-      } else {
-        switch (priority) {
-          case SAMPLER_DROP:
-          case USER_DROP:
-            return false;
-          default:
-            return primary.offer(trace);
-        }
       }
     }
   }

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/Prioritization.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/Prioritization.java
@@ -3,7 +3,7 @@ package datadog.trace.common.writer.ddagent;
 import static datadog.trace.common.sampling.PrioritySampling.SAMPLER_DROP;
 import static datadog.trace.common.sampling.PrioritySampling.USER_DROP;
 
-import datadog.trace.core.DDSpan;
+import datadog.trace.core.CoreSpan;
 import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.CountDownLatch;
@@ -80,7 +80,7 @@ public enum Prioritization {
     }
 
     @Override
-    public boolean publish(final int priority, final List<DDSpan> trace) {
+    public <T extends CoreSpan<T>> boolean publish(T root, int priority, final List<T> trace) {
       switch (priority) {
         case SAMPLER_DROP:
         case USER_DROP:
@@ -102,7 +102,7 @@ public enum Prioritization {
     }
 
     @Override
-    public boolean publish(final int priority, final List<DDSpan> trace) {
+    public <T extends CoreSpan<T>> boolean publish(T root, int priority, List<T> trace) {
       switch (priority) {
         case SAMPLER_DROP:
         case USER_DROP:
@@ -124,7 +124,7 @@ public enum Prioritization {
     }
 
     @Override
-    public boolean publish(final int priority, final List<DDSpan> trace) {
+    public <T extends CoreSpan<T>> boolean publish(T root, int priority, final List<T> trace) {
       if (!primary.offer(trace)) {
         switch (priority) {
           case SAMPLER_DROP:
@@ -167,13 +167,17 @@ public enum Prioritization {
     }
 
     @Override
-    public boolean publish(final int priority, final List<DDSpan> trace) {
-      switch (priority) {
-        case SAMPLER_DROP:
-        case USER_DROP:
-          return false;
-        default:
-          return primary.offer(trace);
+    public <T extends CoreSpan<T>> boolean publish(T root, int priority, final List<T> trace) {
+      if (root.isForceKeep()) {
+        return primary.offer(trace);
+      } else {
+        switch (priority) {
+          case SAMPLER_DROP:
+          case USER_DROP:
+            return false;
+          default:
+            return primary.offer(trace);
+        }
       }
     }
   }

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/PrioritizationStrategy.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/PrioritizationStrategy.java
@@ -1,12 +1,12 @@
 package datadog.trace.common.writer.ddagent;
 
-import datadog.trace.core.DDSpan;
+import datadog.trace.core.CoreSpan;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 public interface PrioritizationStrategy {
 
-  boolean publish(int priority, List<DDSpan> trace);
+  <T extends CoreSpan<T>> boolean publish(T root, int priority, List<T> trace);
 
   boolean flush(long timeout, TimeUnit timeUnit);
 }

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/TraceMapperV0_4.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/TraceMapperV0_4.java
@@ -35,6 +35,15 @@ public final class TraceMapperV0_4 implements TraceMapper {
   public static final byte[] META = "meta".getBytes(ISO_8859_1);
 
   static final byte[] EMPTY = ByteBuffer.allocate(1).put((byte) 0x90).array();
+  private final int size;
+
+  public TraceMapperV0_4(int size) {
+    this.size = size;
+  }
+
+  public TraceMapperV0_4() {
+    this(5 << 20);
+  }
 
   private static final class MetaWriter extends MetadataConsumer {
 
@@ -173,7 +182,7 @@ public final class TraceMapperV0_4 implements TraceMapper {
 
   @Override
   public int messageBufferSize() {
-    return 5 << 20; // 5MB
+    return size; // 5MB
   }
 
   @Override

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/TraceMapperV0_5.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/TraceMapperV0_5.java
@@ -34,17 +34,23 @@ public final class TraceMapperV0_5 implements TraceMapper {
   private final GrowableBuffer dictionary;
 
   private final MetaWriter metaWriter = new MetaWriter();
+  private final int size;
 
   public TraceMapperV0_5() {
     this(2 << 20);
   }
 
-  public TraceMapperV0_5(final int bufferSize) {
+  public TraceMapperV0_5(int dictionarySize, int bufferSize) {
     // growable buffer is implicitly bounded by the fixed size buffer
     // the messages themselves are written into
     this.dictionary = new GrowableBuffer(bufferSize);
     this.dictionaryWriter = new MsgPackWriter(dictionary);
+    this.size = bufferSize;
     reset();
+  }
+
+  public TraceMapperV0_5(final int dictionarySize) {
+    this(dictionarySize, 2 << 20);
   }
 
   @Override
@@ -126,7 +132,7 @@ public final class TraceMapperV0_5 implements TraceMapper {
 
   @Override
   public int messageBufferSize() {
-    return 2 << 20; // 2MB
+    return size; // 2MB
   }
 
   @Override

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/TraceProcessingWorker.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/TraceProcessingWorker.java
@@ -39,13 +39,15 @@ public class TraceProcessingWorker implements AutoCloseable {
       final HealthMetrics healthMetrics,
       final Monitoring monitoring,
       final PayloadDispatcher dispatcher,
+      final DroppingPolicy droppingPolicy,
       final Prioritization prioritization,
       final long flushInterval,
       final TimeUnit timeUnit) {
     this.capacity = capacity;
     this.primaryQueue = createQueue(capacity);
     this.secondaryQueue = createQueue(capacity);
-    this.prioritizationStrategy = prioritization.create(primaryQueue, secondaryQueue);
+    this.prioritizationStrategy =
+        prioritization.create(primaryQueue, secondaryQueue, droppingPolicy);
     this.serializingHandler =
         new TraceSerializingHandler(
             primaryQueue,

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/TraceProcessingWorker.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/TraceProcessingWorker.java
@@ -5,6 +5,7 @@ import static datadog.trace.util.AgentThreadFactory.THREAD_JOIN_TIMOUT_MS;
 import static datadog.trace.util.AgentThreadFactory.newAgentThread;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
+import datadog.trace.core.CoreSpan;
 import datadog.trace.core.DDSpan;
 import datadog.trace.core.monitor.HealthMetrics;
 import datadog.trace.core.monitor.Monitoring;
@@ -85,8 +86,9 @@ public class TraceProcessingWorker implements AutoCloseable {
     }
   }
 
-  public boolean publish(int samplingPriority, final List<DDSpan> trace) {
-    return prioritizationStrategy.publish(samplingPriority, trace);
+  public <T extends CoreSpan<T>> boolean publish(
+      T root, int samplingPriority, final List<T> trace) {
+    return prioritizationStrategy.publish(root, samplingPriority, trace);
   }
 
   public int getCapacity() {

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreSpan.java
@@ -60,6 +60,8 @@ public interface CoreSpan<T extends CoreSpan<T>> {
   /** @return whether this span has a different service name from its parent, or is a local root. */
   boolean isTopLevel();
 
+  boolean isForceKeep();
+
   Map<CharSequence, Number> getUnsafeMetrics();
 
   CharSequence getType();

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -459,7 +459,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
         // to track an effective sampling rate instead, however, tests
         // checking that a hard reference on a continuation prevents
         // reporting fail without this, so will need to be fixed first.
-        writer.incrementTraceCount();
+        writer.incrementDropCounts(writtenTrace.size());
       }
     }
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -52,6 +52,8 @@ public class DDSpan implements AgentSpan, CoreSpan<DDSpan> {
    */
   private final AtomicLong durationNano = new AtomicLong();
 
+  private boolean forceKeep;
+
   /**
    * Spans should be constructed using the builder, not by calling the constructor directly.
    *
@@ -113,6 +115,16 @@ public class DDSpan implements AgentSpan, CoreSpan<DDSpan> {
   public DDSpan setMeasured(boolean measured) {
     context.setMeasured(measured);
     return this;
+  }
+
+  public DDSpan forceKeep(boolean forceKeep) {
+    this.forceKeep = forceKeep;
+    return this;
+  }
+
+  @Override
+  public boolean isForceKeep() {
+    return forceKeep;
   }
 
   /**

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
@@ -1,7 +1,5 @@
 package datadog.trace.core;
 
-import static datadog.trace.api.sampling.PrioritySampling.METRICS_KEEP;
-
 import datadog.trace.api.DDId;
 import datadog.trace.api.DDTags;
 import datadog.trace.api.Functions;
@@ -249,28 +247,19 @@ public class DDSpanContext implements AgentSpan.Context {
         return rootSpan.context().setSamplingPriority(newPriority);
       }
     }
-
-    // rare traces identified by metrics tracking can override
-    // already propagated priorites, so that we at least capture
-    // the local trace chunk when we see rare spans
-    if (newPriority == METRICS_KEEP) {
-      this.samplingPriorityV1 = (byte) newPriority;
-      return true;
-    } else {
-      // sync with lockSamplingPriority
-      synchronized (this) {
-        if (samplingPriorityLocked) {
-          if (log.isDebugEnabled()) {
-            log.debug(
-                "samplingPriority locked at {}. Refusing to set to {}",
-                samplingPriorityV1,
-                newPriority);
-          }
-          return false;
-        } else {
-          this.samplingPriorityV1 = (byte) newPriority;
-          return true;
+    // sync with lockSamplingPriority
+    synchronized (this) {
+      if (samplingPriorityLocked) {
+        if (log.isDebugEnabled()) {
+          log.debug(
+              "samplingPriority locked at {}. Refusing to set to {}",
+              samplingPriorityV1,
+              newPriority);
         }
+        return false;
+      } else {
+        this.samplingPriorityV1 = (byte) newPriority;
+        return true;
       }
     }
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/util/LRUCache.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/util/LRUCache.java
@@ -4,11 +4,17 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 public final class LRUCache<K, V> extends LinkedHashMap<K, V> {
+
+  public interface ExpiryListener<T, U> {
+    void accept(Map.Entry<T, U> expired);
+  }
+
   // Copied here since they for some reason are `package` and not `protected` in HashMap
   private static final int DEFAULT_INITIAL_CAPACITY = 1 << 4;
   private static final float DEFAULT_LOAD_FACTOR = 0.75f;
 
   private final int maxEntries;
+  private final ExpiryListener<K, V> expiryListener;
 
   public LRUCache(int maxEntries) {
     this(DEFAULT_INITIAL_CAPACITY, maxEntries);
@@ -19,12 +25,22 @@ public final class LRUCache<K, V> extends LinkedHashMap<K, V> {
   }
 
   public LRUCache(int initialCapacity, float loadFactor, int maxEntries) {
+    this(null, initialCapacity, loadFactor, maxEntries);
+  }
+
+  public LRUCache(
+      ExpiryListener<K, V> expiryListener, int initialCapacity, float loadFactor, int maxEntries) {
     super(initialCapacity, loadFactor, true); // keep track of access order
     this.maxEntries = maxEntries;
+    this.expiryListener = expiryListener;
   }
 
   @Override
   protected boolean removeEldestEntry(Map.Entry<K, V> eldest) {
-    return size() > maxEntries;
+    boolean expire = size() > maxEntries;
+    if (null != expiryListener && expire) {
+      expiryListener.accept(eldest);
+    }
+    return expire;
   }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SimpleSpan.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SimpleSpan.groovy
@@ -173,6 +173,11 @@ class SimpleSpan implements CoreSpan<SimpleSpan> {
   }
 
   @Override
+  boolean isForceKeep() {
+    return false
+  }
+
+  @Override
   Map<CharSequence, Number> getUnsafeMetrics() {
     return null
   }

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentApiTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentApiTest.groovy
@@ -112,7 +112,7 @@ class DDAgentApiTest extends DDCoreSpecification {
         }
       }
     }
-    def (discovery, client) = createAgentApi(agent.address.toString())
+    def client = createAgentApi(agent.address.toString())[1]
     def payload = prepareTraces(agentVersion, traces)
 
     expect:
@@ -123,13 +123,8 @@ class DDAgentApiTest extends DDCoreSpecification {
     agent.lastRequest.headers.get("Datadog-Meta-Lang-Version") == System.getProperty("java.version", "unknown")
     agent.lastRequest.headers.get("Datadog-Meta-Tracer-Version") == "Stubbed-Test-Version"
     agent.lastRequest.headers.get("X-Datadog-Trace-Count") == "${traces.size()}"
-    if (discovery.supportsDropping()) {
-      agent.lastRequest.headers.get("Datadog-Client-Dropped-P0-Traces") == "${payload.droppedTraces()}"
-      agent.lastRequest.headers.get("Datadog-Client-Dropped-P0-Spans") == "${payload.droppedSpans()}"
-    } else {
-      agent.lastRequest.headers.get("Datadog-Client-Dropped-P0-Traces") == null
-      agent.lastRequest.headers.get("Datadog-Client-Dropped-P0-Spans") == null
-    }
+    agent.lastRequest.headers.get("Datadog-Client-Dropped-P0-Traces") == "${payload.droppedTraces()}"
+    agent.lastRequest.headers.get("Datadog-Client-Dropped-P0-Spans") == "${payload.droppedSpans()}"
     convertList(agentVersion, agent.lastRequest.body) == expectedRequestBody
 
     cleanup:
@@ -199,7 +194,7 @@ class DDAgentApiTest extends DDCoreSpecification {
         }
       }
     }
-    def (discovery, client) = createAgentApi(agent.address.toString())
+    def client = createAgentApi(agent.address.toString())[1]
     client.addResponseListener(responseListener)
     def payload = prepareTraces(agentVersion, [[], [], []])
     payload.withDroppedTraces(1)
@@ -213,13 +208,8 @@ class DDAgentApiTest extends DDCoreSpecification {
     agent.lastRequest.headers.get("Datadog-Meta-Lang-Version") == System.getProperty("java.version", "unknown")
     agent.lastRequest.headers.get("Datadog-Meta-Tracer-Version") == "Stubbed-Test-Version"
     agent.lastRequest.headers.get("X-Datadog-Trace-Count") == "3" // false data shows the value provided via traceCounter.
-    if (discovery.supportsDropping()) {
-      agent.lastRequest.headers.get("Datadog-Client-Dropped-P0-Traces") == "${payload.droppedTraces()}"
-      agent.lastRequest.headers.get("Datadog-Client-Dropped-P0-Spans") == "${payload.droppedSpans()}"
-    } else {
-      agent.lastRequest.headers.get("Datadog-Client-Dropped-P0-Traces") == null
-      agent.lastRequest.headers.get("Datadog-Client-Dropped-P0-Spans") == null
-    }
+    agent.lastRequest.headers.get("Datadog-Client-Dropped-P0-Traces") == "${payload.droppedTraces()}"
+    agent.lastRequest.headers.get("Datadog-Client-Dropped-P0-Spans") == "${payload.droppedSpans()}"
 
     cleanup:
     agent.close()

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterCombinedTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterCombinedTest.groovy
@@ -253,6 +253,7 @@ class DDAgentWriterCombinedTest extends DDCoreSpecification {
     1 * healthMetrics.onFlush(_)
     1 * healthMetrics.onShutdown(_)
     1 * healthMetrics.close()
+    1 * discovery.close()
     0 * _
 
     cleanup:

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterCombinedTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterCombinedTest.groovy
@@ -253,7 +253,6 @@ class DDAgentWriterCombinedTest extends DDCoreSpecification {
     1 * healthMetrics.onFlush(_)
     1 * healthMetrics.onShutdown(_)
     1 * healthMetrics.close()
-    1 * discovery.close()
     0 * _
 
     cleanup:

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterTest.groovy
@@ -4,6 +4,7 @@ import com.timgroup.statsd.NoOpStatsDClient
 import datadog.trace.api.DDId
 import datadog.trace.api.sampling.PrioritySampling
 import datadog.trace.common.writer.ddagent.DDAgentApi
+import datadog.trace.common.writer.ddagent.DDAgentFeaturesDiscovery
 import datadog.trace.common.writer.ddagent.PayloadDispatcher
 import datadog.trace.common.writer.ddagent.TraceProcessingWorker
 import datadog.trace.core.CoreTracer
@@ -19,13 +20,14 @@ import java.util.concurrent.TimeUnit
 
 class DDAgentWriterTest extends DDCoreSpecification {
 
+  def discovery = Mock(DDAgentFeaturesDiscovery)
   def api = Mock(DDAgentApi)
   def monitor = Mock(HealthMetrics)
   def worker = Mock(TraceProcessingWorker)
   def monitoring = new Monitoring(new NoOpStatsDClient(), 1, TimeUnit.SECONDS)
 
   @Subject
-  def writer = new DDAgentWriter(api, monitor, monitoring, worker)
+  def writer = new DDAgentWriter(discovery, api, monitor, monitoring, worker)
 
   // Only used to create spans
   def dummyTracer = tracerBuilder().writer(new ListWriter()).build()

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterTest.groovy
@@ -105,7 +105,7 @@ class DDAgentWriterTest extends DDCoreSpecification {
     writer.write(trace)
 
     then: "monitor is notified of successful publication"
-    1 * worker.publish(_, trace) >> true
+    1 * worker.publish(_, _, trace) >> true
     1 * monitor.onPublish(trace, _)
     0 * _
 
@@ -113,7 +113,7 @@ class DDAgentWriterTest extends DDCoreSpecification {
     writer.write(trace)
 
     then: "monitor is notified of unsuccessful publication"
-    1 * worker.publish(_, trace) >> false
+    1 * worker.publish(_, _, trace) >> false
     1 * monitor.onFailedPublish(_)
     0 * _
   }
@@ -157,7 +157,7 @@ class DDAgentWriterTest extends DDCoreSpecification {
     writer.write(trace)
 
     then:
-    1 * worker.publish(PrioritySampling.SAMPLER_DROP, trace) >> false
+    1 * worker.publish(trace[0], PrioritySampling.SAMPLER_DROP, trace) >> false
     1 * dispatcher.onDroppedTrace(trace.size())
   }
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterTest.groovy
@@ -52,7 +52,6 @@ class DDAgentWriterTest extends DDCoreSpecification {
     then:
     1 * monitor.start()
     1 * worker.start()
-    1 * discovery.start()
     1 * worker.getCapacity() >> capacity
     1 * monitor.onStart(capacity)
     0 * _

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterTest.groovy
@@ -52,6 +52,7 @@ class DDAgentWriterTest extends DDCoreSpecification {
     then:
     1 * monitor.start()
     1 * worker.start()
+    1 * discovery.start()
     1 * worker.getCapacity() >> capacity
     1 * monitor.onStart(capacity)
     0 * _
@@ -144,11 +145,12 @@ class DDAgentWriterTest extends DDCoreSpecification {
 
   def "dropped trace is counted"() {
     setup:
+    def discovery = Mock(DDAgentFeaturesDiscovery)
     def api = Mock(DDAgentApi)
     def worker = Mock(TraceProcessingWorker)
     def monitor = Stub(HealthMetrics)
     def dispatcher = Mock(PayloadDispatcher)
-    def writer = new DDAgentWriter(api, monitor, dispatcher, worker)
+    def writer = new DDAgentWriter(discovery, api, monitor, dispatcher, worker)
     def p0 = newSpan()
     p0.setSamplingPriority(PrioritySampling.SAMPLER_DROP)
     def trace = [

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/MultiWriterTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/MultiWriterTest.groovy
@@ -59,11 +59,11 @@ class MultiWriterTest extends DDSpecification {
     0 * _
 
     when:
-    writer.incrementTraceCount()
+    writer.incrementDropCounts(0)
 
     then:
-    1 * mockW1.incrementTraceCount()
-    1 * mockW2.incrementTraceCount()
+    1 * mockW1.incrementDropCounts(0)
+    1 * mockW2.incrementDropCounts(0)
     0 * _
   }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/PayloadDispatcherTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/PayloadDispatcherTest.groovy
@@ -4,10 +4,9 @@ import com.timgroup.statsd.NoOpStatsDClient
 import datadog.trace.api.DDId
 import datadog.trace.api.sampling.PrioritySampling
 import datadog.trace.common.writer.ddagent.DDAgentApi
+import datadog.trace.common.writer.ddagent.DDAgentFeaturesDiscovery
 import datadog.trace.common.writer.ddagent.Payload
 import datadog.trace.common.writer.ddagent.PayloadDispatcher
-import datadog.trace.common.writer.ddagent.TraceMapperV0_4
-import datadog.trace.common.writer.ddagent.TraceMapperV0_5
 import datadog.trace.core.CoreTracer
 import datadog.trace.core.DDSpan
 import datadog.trace.core.DDSpanContext
@@ -32,13 +31,14 @@ class PayloadDispatcherTest extends DDSpecification {
     setup:
     AtomicBoolean flushed = new AtomicBoolean()
     HealthMetrics healthMetrics = Mock(HealthMetrics)
+    DDAgentFeaturesDiscovery discovery = Mock(DDAgentFeaturesDiscovery)
+    discovery.getTraceEndpoint() >> traceEndpoint
     DDAgentApi api = Mock(DDAgentApi)
-    api.selectTraceMapper() >> traceMapper
     api.sendSerializedTraces(_) >> {
       flushed.set(true)
       return DDAgentApi.Response.success(200)
     }
-    PayloadDispatcher dispatcher = new PayloadDispatcher(api, healthMetrics, monitoring)
+    PayloadDispatcher dispatcher = new PayloadDispatcher(discovery, api, healthMetrics, monitoring)
     List<DDSpan> trace = [realSpan()]
     when:
     while (!flushed.get()) {
@@ -49,14 +49,15 @@ class PayloadDispatcherTest extends DDSpecification {
     flushed.get()
 
     where:
-    traceMapper << [new TraceMapperV0_5(), new TraceMapperV0_4(1024)]
+    traceEndpoint << ["v0.5/traces", "v0.4/traces"]
   }
 
   def "should flush buffer on demand"() {
     setup:
     HealthMetrics healthMetrics = Mock(HealthMetrics)
+    DDAgentFeaturesDiscovery discovery = Mock(DDAgentFeaturesDiscovery)
     DDAgentApi api = Mock(DDAgentApi)
-    PayloadDispatcher dispatcher = new PayloadDispatcher(api, healthMetrics, monitoring)
+    PayloadDispatcher dispatcher = new PayloadDispatcher(discovery, api, healthMetrics, monitoring)
     List<DDSpan> trace = [realSpan()]
     when:
     for (int i = 0; i < traceCount; ++i) {
@@ -64,25 +65,26 @@ class PayloadDispatcherTest extends DDSpecification {
     }
     dispatcher.flush()
     then:
+    1 * discovery.getTraceEndpoint() >> traceEndpoint
     1 * healthMetrics.onSerialize({ it > 0 })
-    1 * api.selectTraceMapper() >> traceMapper
     1 * api.sendSerializedTraces({ it.traceCount() == traceCount }) >> DDAgentApi.Response.success(200)
 
     where:
-    traceMapper                          | traceCount
-    new TraceMapperV0_4(1024)            | 1
-    new TraceMapperV0_4(4 * 1024)        | 10
-    new TraceMapperV0_4(20 * 1024)       | 100
-    new TraceMapperV0_5(1024, 1024)      | 1
-    new TraceMapperV0_5(1024, 4096)      | 10
-    new TraceMapperV0_5(1024, 20 * 1024) | 100
+    traceEndpoint | traceCount
+    "v0.4/traces" | 1
+    "v0.4/traces" | 10
+    "v0.4/traces" | 100
+    "v0.5/traces" | 1
+    "v0.5/traces" | 10
+    "v0.5/traces" | 100
   }
 
   def "should report failed request to monitor"() {
     setup:
     HealthMetrics healthMetrics = Mock(HealthMetrics)
+    DDAgentFeaturesDiscovery discovery = Mock(DDAgentFeaturesDiscovery)
     DDAgentApi api = Mock(DDAgentApi)
-    PayloadDispatcher dispatcher = new PayloadDispatcher(api, healthMetrics, monitoring)
+    PayloadDispatcher dispatcher = new PayloadDispatcher(discovery, api, healthMetrics, monitoring)
     List<DDSpan> trace = [realSpan()]
     when:
     for (int i = 0; i < traceCount; ++i) {
@@ -91,26 +93,27 @@ class PayloadDispatcherTest extends DDSpecification {
     dispatcher.flush()
     then:
     1 * healthMetrics.onSerialize({ it > 0 })
-    1 * api.selectTraceMapper() >> traceMapper
+    1 * discovery.getTraceEndpoint() >> traceEndpoint
     1 * api.sendSerializedTraces({ it.traceCount() == traceCount }) >> DDAgentApi.Response.failed(400)
 
     where:
-    traceMapper                          | traceCount
-    new TraceMapperV0_4(1024)            | 1
-    new TraceMapperV0_4(4096)            | 10
-    new TraceMapperV0_4(20 * 1024)       | 100
-    new TraceMapperV0_5(1024, 1024)      | 1
-    new TraceMapperV0_5(1024, 4096)      | 10
-    new TraceMapperV0_5(1024, 20 * 1024) | 100
+    traceEndpoint | traceCount
+    "v0.4/traces" | 1
+    "v0.4/traces" | 10
+    "v0.4/traces" | 100
+    "v0.5/traces" | 1
+    "v0.5/traces" | 10
+    "v0.5/traces" | 100
   }
 
   def "should drop trace when there is no agent connectivity"() {
     setup:
     HealthMetrics healthMetrics = Mock(HealthMetrics)
     DDAgentApi api = Mock(DDAgentApi)
-    PayloadDispatcher dispatcher = new PayloadDispatcher(api, healthMetrics, monitoring)
+    DDAgentFeaturesDiscovery discovery = Mock(DDAgentFeaturesDiscovery)
+    PayloadDispatcher dispatcher = new PayloadDispatcher(discovery, api, healthMetrics, monitoring)
     List<DDSpan> trace = [realSpan()]
-    api.selectTraceMapper() >> null
+    discovery.getTraceEndpoint() >> null
     when:
     dispatcher.addTrace(trace)
     then:
@@ -120,10 +123,11 @@ class PayloadDispatcherTest extends DDSpecification {
   def "trace and span counts are reset after access"() {
     setup:
     HealthMetrics healthMetrics = Mock(HealthMetrics)
-    DDAgentApi api = Mock(DDAgentApi) {
-      it.selectTraceMapper() >> new TraceMapperV0_4(0)
+    DDAgentApi api = Mock(DDAgentApi)
+    DDAgentFeaturesDiscovery discovery = Mock(DDAgentFeaturesDiscovery) {
+      it.getTraceEndpoint() >> "v0.4/traces"
     }
-    PayloadDispatcher dispatcher = new PayloadDispatcher(api, healthMetrics, monitoring)
+    PayloadDispatcher dispatcher = new PayloadDispatcher(discovery, api, healthMetrics, monitoring)
 
     when:
     dispatcher.addTrace([])

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/TraceProcessingWorkerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/TraceProcessingWorkerTest.groovy
@@ -18,7 +18,6 @@ import static datadog.trace.api.sampling.PrioritySampling.SAMPLER_KEEP
 import static datadog.trace.api.sampling.PrioritySampling.UNSET
 import static datadog.trace.api.sampling.PrioritySampling.USER_DROP
 import static datadog.trace.api.sampling.PrioritySampling.USER_KEEP
-import static datadog.trace.common.writer.ddagent.Prioritization.DEAD_LETTERS
 import static datadog.trace.common.writer.ddagent.Prioritization.FAST_LANE
 
 class TraceProcessingWorkerTest extends DDSpecification {
@@ -42,6 +41,9 @@ class TraceProcessingWorkerTest extends DDSpecification {
     TraceProcessingWorker worker = new TraceProcessingWorker(10, Stub(HealthMetrics),
       monitoring,
       flushCountingPayloadDispatcher(flushCount),
+      {
+        false
+      },
       FAST_LANE,
       1,
       TimeUnit.NANOSECONDS) // stop heartbeats from being throttled
@@ -64,6 +66,9 @@ class TraceProcessingWorkerTest extends DDSpecification {
     TraceProcessingWorker worker = new TraceProcessingWorker(10, Stub(HealthMetrics),
       monitoring,
       flushCountingPayloadDispatcher(flushCount),
+      {
+        false
+      },
       FAST_LANE,
       1,
       TimeUnit.NANOSECONDS) // stop heartbeats from being throttled
@@ -87,6 +92,9 @@ class TraceProcessingWorkerTest extends DDSpecification {
     TraceProcessingWorker worker = new TraceProcessingWorker(10, Stub(HealthMetrics),
       monitoring,
       flushCountingPayloadDispatcher(flushCount),
+      {
+        false
+      },
       FAST_LANE,
       100, TimeUnit.SECONDS) // prevent heartbeats from helping the flush happen
 
@@ -124,7 +132,9 @@ class TraceProcessingWorkerTest extends DDSpecification {
       errorReported.incrementAndGet()
     }
     TraceProcessingWorker worker = new TraceProcessingWorker(10, healthMetrics,
-      monitoring, throwingDispatcher, FAST_LANE,
+      monitoring, throwingDispatcher, {
+      false
+    }, FAST_LANE,
       100, TimeUnit.SECONDS) // prevent heartbeats from helping the flush happen
     worker.start()
 
@@ -152,7 +162,9 @@ class TraceProcessingWorkerTest extends DDSpecification {
     }
     HealthMetrics healthMetrics = Mock(HealthMetrics)
     TraceProcessingWorker worker = new TraceProcessingWorker(10, healthMetrics, monitoring,
-      countingDispatcher, FAST_LANE, 100, TimeUnit.SECONDS)
+      countingDispatcher, {
+      false
+    }, FAST_LANE, 100, TimeUnit.SECONDS)
     // prevent heartbeats from helping the flush happen
     worker.start()
 
@@ -194,35 +206,17 @@ class TraceProcessingWorkerTest extends DDSpecification {
     SAMPLER_KEEP | 100        | FAST_LANE
     USER_KEEP    | 100        | FAST_LANE
     UNSET        | 100        | FAST_LANE
-    SAMPLER_DROP | 1          | DEAD_LETTERS
-    USER_DROP    | 1          | DEAD_LETTERS
-    SAMPLER_KEEP | 1          | DEAD_LETTERS
-    USER_KEEP    | 1          | DEAD_LETTERS
-    UNSET        | 1          | DEAD_LETTERS
-    SAMPLER_DROP | 10         | DEAD_LETTERS
-    USER_DROP    | 10         | DEAD_LETTERS
-    SAMPLER_KEEP | 10         | DEAD_LETTERS
-    USER_KEEP    | 10         | DEAD_LETTERS
-    UNSET        | 10         | DEAD_LETTERS
-    SAMPLER_DROP | 20         | DEAD_LETTERS
-    USER_DROP    | 20         | DEAD_LETTERS
-    SAMPLER_KEEP | 20         | DEAD_LETTERS
-    USER_KEEP    | 20         | DEAD_LETTERS
-    UNSET        | 20         | DEAD_LETTERS
-    SAMPLER_DROP | 100        | DEAD_LETTERS
-    USER_DROP    | 100        | DEAD_LETTERS
-    SAMPLER_KEEP | 100        | DEAD_LETTERS
-    USER_KEEP    | 100        | DEAD_LETTERS
-    UNSET        | 100        | DEAD_LETTERS
 
   }
 
-  def "flush of full queue after worker thread stopped will not flush but will return" () {
+  def "flush of full queue after worker thread stopped will not flush but will return"() {
     setup:
     PayloadDispatcher countingDispatcher = Mock(PayloadDispatcher)
     HealthMetrics healthMetrics = Mock(HealthMetrics)
     TraceProcessingWorker worker = new TraceProcessingWorker(10, healthMetrics, monitoring,
-      countingDispatcher, FAST_LANE, 100, TimeUnit.SECONDS)
+      countingDispatcher, {
+      false
+    }, FAST_LANE, 100, TimeUnit.SECONDS)
     worker.start()
     worker.close()
     int queueSize = 0

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/TraceProcessingWorkerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/TraceProcessingWorkerTest.groovy
@@ -129,7 +129,7 @@ class TraceProcessingWorkerTest extends DDSpecification {
     worker.start()
 
     when: "a trace is processed but can't be passed on"
-    worker.publish(priority, [Mock(DDSpan)])
+    worker.publish(Mock(DDSpan), priority, [Mock(DDSpan)])
 
     then: "the error is reported to the monitor"
     conditions.eventually {
@@ -159,7 +159,7 @@ class TraceProcessingWorkerTest extends DDSpecification {
     when: "traces are submitted"
     int submitted = 0
     for (int i = 0; i < traceCount; ++i) {
-      submitted += worker.publish(priority, [Mock(DDSpan)]) ? 1 : 0
+      submitted += worker.publish(Mock(DDSpan), priority, [Mock(DDSpan)]) ? 1 : 0
     }
 
     then: "traces are passed through unless rejected on submission"

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddagent/DDAgentFeaturesDiscoveryTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddagent/DDAgentFeaturesDiscoveryTest.groovy
@@ -1,0 +1,209 @@
+package datadog.trace.common.writer.ddagent
+
+
+import datadog.trace.test.util.DDSpecification
+import okhttp3.Call
+import okhttp3.MediaType
+import okhttp3.OkHttpClient
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.ResponseBody
+
+import java.nio.file.Files
+import java.nio.file.Paths
+
+class DDAgentFeaturesDiscoveryTest extends DDSpecification {
+
+  static final String INFO_RESPONSE = loadJsonFile("agent-info.json")
+  static final String INFO_WITH_CLIENT_DROPPING_RESPONSE = loadJsonFile("agent-info-with-client-dropping.json")
+
+  def "test parse /info response"() {
+    setup:
+    OkHttpClient client = Mock(OkHttpClient)
+    DDAgentFeaturesDiscovery features = new DDAgentFeaturesDiscovery(client, "http://localhost:8125", true)
+
+    when: "/info available"
+    features.discover()
+
+    then:
+    1 * client.newCall(_) >> { Request request -> infoResponse(request, INFO_RESPONSE) }
+    features.getMetricsEndpoint() == "v0.5/stats"
+    features.getTraceEndpoint() == "v0.5/traces"
+    !features.supportsDropping()
+  }
+
+  def "test parse /info response with client dropping"() {
+    setup:
+    OkHttpClient client = Mock(OkHttpClient)
+    DDAgentFeaturesDiscovery features = new DDAgentFeaturesDiscovery(client, "http://localhost:8125", true)
+
+    when: "/info available"
+    features.discover()
+
+    then:
+    1 * client.newCall(_) >> { Request request -> infoResponse(request, INFO_WITH_CLIENT_DROPPING_RESPONSE) }
+    features.getMetricsEndpoint() == "v0.5/stats"
+    features.getTraceEndpoint() == "v0.5/traces"
+    features.supportsDropping()
+  }
+
+  def "test fallback when /info not found" () {
+    setup:
+    OkHttpClient client = Mock(OkHttpClient)
+    DDAgentFeaturesDiscovery features = new DDAgentFeaturesDiscovery(client, "http://localhost:8125", true)
+
+    when: "/info unavailable"
+    features.discover()
+
+    then:
+    1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/info" }) >> { Request request -> notFound(request) }
+    1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.5/stats" }) >> { Request request -> clientError(request) }
+    1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.5/traces" }) >> { Request request -> clientError(request) }
+    features.getMetricsEndpoint() == "v0.5/stats"
+    features.getTraceEndpoint() == "v0.5/traces"
+    !features.supportsDropping()
+  }
+
+  def "test fallback when /info not found and agent returns ok" () {
+    setup:
+    OkHttpClient client = Mock(OkHttpClient)
+    DDAgentFeaturesDiscovery features = new DDAgentFeaturesDiscovery(client, "http://localhost:8125", true)
+
+    when: "/info unavailable"
+    features.discover()
+
+    then:
+    1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/info" }) >> { Request request -> notFound(request) }
+    1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.5/stats" }) >> { Request request -> success(request) }
+    1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.5/traces" }) >> { Request request -> success(request) }
+    features.getMetricsEndpoint() == "v0.5/stats"
+    features.getTraceEndpoint() == "v0.5/traces"
+    !features.supportsDropping()
+  }
+
+  def "test fallback when /info not found and v0.5 disabled" () {
+    setup:
+    OkHttpClient client = Mock(OkHttpClient)
+    DDAgentFeaturesDiscovery features = new DDAgentFeaturesDiscovery(client, "http://localhost:8125", false)
+
+    when: "/info unavailable"
+    features.discover()
+
+    then:
+    1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/info" }) >> { Request request -> notFound(request) }
+    1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.5/stats" }) >> { Request request -> clientError(request) }
+    1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.4/traces" }) >> { Request request -> clientError(request) }
+    features.getMetricsEndpoint() == "v0.5/stats"
+    features.getTraceEndpoint() == "v0.4/traces"
+    !features.supportsDropping()
+  }
+
+  def "test fallback when /info not found and v0.5 unavailable agent side" () {
+    setup:
+    OkHttpClient client = Mock(OkHttpClient)
+    DDAgentFeaturesDiscovery features = new DDAgentFeaturesDiscovery(client, "http://localhost:8125", true)
+
+    when: "/info unavailable"
+    features.discover()
+
+    then:
+    1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/info" }) >> { Request request -> notFound(request) }
+    1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.5/stats" }) >> { Request request -> clientError(request) }
+    1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.5/traces" }) >> { Request request -> notFound(request) }
+    1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.4/traces" }) >> { Request request -> clientError(request) }
+    features.getMetricsEndpoint() == "v0.5/stats"
+    features.getTraceEndpoint() == "v0.4/traces"
+    !features.supportsDropping()
+  }
+
+  def "test fallback on old agent" () {
+    setup:
+    OkHttpClient client = Mock(OkHttpClient)
+    DDAgentFeaturesDiscovery features = new DDAgentFeaturesDiscovery(client, "http://localhost:8125", true)
+
+    when: "/info unavailable"
+    features.discover()
+
+    then:
+    1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/info" }) >> { Request request -> notFound(request) }
+    1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.5/stats" }) >> { Request request -> notFound(request) }
+    1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.5/traces" }) >> { Request request -> notFound(request) }
+    1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.4/traces" }) >> { Request request -> clientError(request) }
+    features.getMetricsEndpoint() == null
+    features.getTraceEndpoint() == "v0.4/traces"
+    !features.supportsDropping()
+  }
+
+  def "test fallback on very old agent" () {
+    setup:
+    OkHttpClient client = Mock(OkHttpClient)
+    DDAgentFeaturesDiscovery features = new DDAgentFeaturesDiscovery(client, "http://localhost:8125", true)
+
+    when: "/info unavailable"
+    features.discover()
+
+    then:
+    1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/info" }) >> { Request request -> notFound(request) }
+    1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.5/stats" }) >> { Request request -> notFound(request) }
+    1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.5/traces" }) >> { Request request -> notFound(request) }
+    1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.4/traces" }) >> { Request request -> notFound(request) }
+    1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.3/traces" }) >> { Request request -> clientError(request) }
+    features.getMetricsEndpoint() == null
+    features.getTraceEndpoint() == "v0.3/traces"
+    !features.supportsDropping()
+  }
+
+
+  def infoResponse(Request request, String json) {
+    return Mock(Call) {
+      it.execute() >> new Response.Builder()
+        .code(200)
+        .request(request)
+        .protocol(Protocol.HTTP_1_1)
+        .message("")
+        .body(ResponseBody.create(MediaType.get("application/json"), json))
+        .build()
+    }
+  }
+
+  def notFound(Request request) {
+    return Mock(Call) {
+      it.execute() >> new Response.Builder()
+        .code(404)
+        .request(request)
+        .protocol(Protocol.HTTP_1_1)
+        .message("")
+        .body(ResponseBody.create(MediaType.get("application/json"), ""))
+        .build()
+    }
+  }
+
+  def clientError(Request request) {
+    return Mock(Call) {
+      it.execute() >> new Response.Builder()
+        .code(400)
+        .request(request)
+        .protocol(Protocol.HTTP_1_1)
+        .message("")
+        .body(ResponseBody.create(MediaType.get("application/msgpack"), ""))
+        .build()
+    }
+  }
+
+  def success(Request request) {
+    return Mock(Call) {
+      it.execute() >> new Response.Builder()
+        .code(200)
+        .request(request)
+        .protocol(Protocol.HTTP_1_1)
+        .message("")
+        .body(ResponseBody.create(MediaType.get("application/msgpack"), ""))
+        .build()
+    }
+  }
+
+  private static String loadJsonFile(String name) {
+    return new String(Files.readAllBytes(Paths.get("src/test/resources/agent-features").resolve(name)))
+  }
+}

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddagent/TraceGenerator.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddagent/TraceGenerator.groovy
@@ -256,6 +256,11 @@ class TraceGenerator {
     }
 
     @Override
+    boolean isForceKeep() {
+      return false
+    }
+
+    @Override
     Map<String, Number> getUnsafeMetrics() {
       return metrics
     }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanTest.groovy
@@ -269,32 +269,4 @@ class DDSpanTest extends DDCoreSpecification {
     ""                                    | true
     null                                  | true
   }
-
-  def "metrics keep priority overrides previously locked sampling priority"() {
-    setup:
-    DDSpanContext context =
-      new DDSpanContext(
-        DDId.from(1),
-        DDId.from(1),
-        DDId.ZERO,
-        "",
-        "fakeService",
-        "fakeOperation",
-        "fakeResource",
-        PrioritySampling.UNSET,
-        null,
-        Collections.<String, String> emptyMap(),
-        false,
-        "fakeType",
-        0,
-        tracer.pendingTraceFactory.create(DDId.ONE))
-    when: "setting a sampling priority"
-    context.setSamplingPriority(PrioritySampling.SAMPLER_DROP)
-    then: "locking succeeds"
-    context.lockSamplingPriority()
-    when: "overriding with METRICS_KEEP priority"
-    context.setSamplingPriority(PrioritySampling.METRICS_KEEP)
-    then: "sampling priority is overridden"
-    context.getSamplingPriority() == PrioritySampling.METRICS_KEEP
-  }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanTest.groovy
@@ -269,4 +269,32 @@ class DDSpanTest extends DDCoreSpecification {
     ""                                    | true
     null                                  | true
   }
+
+  def "metrics keep priority overrides previously locked sampling priority"() {
+    setup:
+    DDSpanContext context =
+      new DDSpanContext(
+        DDId.from(1),
+        DDId.from(1),
+        DDId.ZERO,
+        "",
+        "fakeService",
+        "fakeOperation",
+        "fakeResource",
+        PrioritySampling.UNSET,
+        null,
+        Collections.<String, String> emptyMap(),
+        false,
+        "fakeType",
+        0,
+        tracer.pendingTraceFactory.create(DDId.ONE))
+    when: "setting a sampling priority"
+    context.setSamplingPriority(PrioritySampling.SAMPLER_DROP)
+    then: "locking succeeds"
+    context.lockSamplingPriority()
+    when: "overriding with METRICS_KEEP priority"
+    context.setSamplingPriority(PrioritySampling.METRICS_KEEP)
+    then: "sampling priority is overridden"
+    context.getSamplingPriority() == PrioritySampling.METRICS_KEEP
+  }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/util/LRUCacheTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/util/LRUCacheTest.groovy
@@ -20,4 +20,26 @@ class LRUCacheTest extends DDSpecification {
     lruCache.size() == 5
     lruCache.values().containsAll(Arrays.asList("1", "3", "5", "6", "7"))
   }
+
+  def "Should notify listener when ejecting least recently used element"() {
+    setup:
+    List<Integer> ejected = new ArrayList<>()
+    LRUCache.ExpiryListener<Integer, String> listener = {
+      Map.Entry<Integer, String> entry -> ejected.add(entry.getKey())
+    }
+    when:
+    def lruCache = new LRUCache<Integer, String>(listener, 10, 0.75f, 5)
+    for (int i = 1; i <= 5; i++) {
+      lruCache.put(i, String.valueOf(i))
+    }
+    // now look at 2 values
+    lruCache.get(1)
+    lruCache.get(3)
+    // now insert 2 new values
+    lruCache.put(6, "6")
+    lruCache.put(7, "7")
+
+    then:
+    ejected == [2, 4]
+  }
 }

--- a/dd-trace-core/src/test/resources/agent-features/agent-info-with-client-dropping.json
+++ b/dd-trace-core/src/test/resources/agent-features/agent-info-with-client-dropping.json
@@ -1,0 +1,57 @@
+{
+  "version": "0.99.0",
+  "git_commit": "fab047e10",
+  "build_date": "2020-12-04 15:57:06.74187 +0200 EET m=+0.029001792",
+  "endpoints": [
+    "/v0.3/traces",
+    "/v0.3/services",
+    "/v0.4/traces",
+    "/v0.4/services",
+    "/v0.5/traces",
+    "/v0.5/stats",
+    "/profiling/v1/input"
+  ],
+  "feature_flags": [
+    "feature_flag"
+  ],
+  "client_drop_p0s": true,
+  "config": {
+    "default_env": "prod",
+    "bucket_interval": 1000000000,
+    "extra_aggregators": [
+      "agg:val"
+    ],
+    "extra_sample_rate": 2.4,
+    "target_tps": 11,
+    "max_eps": 12,
+    "receiver_port": 8111,
+    "receiver_socket": "/sock/path",
+    "connection_limit": 12,
+    "receiver_timeout": 100,
+    "max_request_bytes": 123,
+    "statsd_port": 123,
+    "max_memory": 1000000,
+    "max_cpu": 12345,
+    "analyzed_rate_by_service_legacy": {
+      "X": 1.2
+    },
+    "analyzed_spans_by_service": {
+      "X": {
+        "Y": 2.4
+      }
+    },
+    "obfuscation": {
+      "elastic_search": true,
+      "mongo": true,
+      "sql_exec_plan": true,
+      "sql_exec_plan_normalize": true,
+      "http": {
+        "remove_query_string": true,
+        "remove_path_digits": true
+      },
+      "remove_stack_traces": false,
+      "redis": true,
+      "memcached": false
+    }
+  }
+}

--- a/dd-trace-core/src/test/resources/agent-features/agent-info.json
+++ b/dd-trace-core/src/test/resources/agent-features/agent-info.json
@@ -1,0 +1,56 @@
+{
+  "version": "0.99.0",
+  "git_commit": "fab047e10",
+  "build_date": "2020-12-04 15:57:06.74187 +0200 EET m=+0.029001792",
+  "endpoints": [
+    "/v0.3/traces",
+    "/v0.3/services",
+    "/v0.4/traces",
+    "/v0.4/services",
+    "/v0.5/traces",
+    "/v0.5/stats",
+    "/profiling/v1/input"
+  ],
+  "feature_flags": [
+    "feature_flag"
+  ],
+  "config": {
+    "default_env": "prod",
+    "bucket_interval": 1000000000,
+    "extra_aggregators": [
+      "agg:val"
+    ],
+    "extra_sample_rate": 2.4,
+    "target_tps": 11,
+    "max_eps": 12,
+    "receiver_port": 8111,
+    "receiver_socket": "/sock/path",
+    "connection_limit": 12,
+    "receiver_timeout": 100,
+    "max_request_bytes": 123,
+    "statsd_port": 123,
+    "max_memory": 1000000,
+    "max_cpu": 12345,
+    "analyzed_rate_by_service_legacy": {
+      "X": 1.2
+    },
+    "analyzed_spans_by_service": {
+      "X": {
+        "Y": 2.4
+      }
+    },
+    "obfuscation": {
+      "elastic_search": true,
+      "mongo": true,
+      "sql_exec_plan": true,
+      "sql_exec_plan_normalize": true,
+      "http": {
+        "remove_query_string": true,
+        "remove_path_digits": true
+      },
+      "remove_stack_traces": false,
+      "redis": true,
+      "memcached": false
+    }
+  }
+}

--- a/dd-trace-core/src/traceAgentTest/groovy/TraceGenerator.groovy
+++ b/dd-trace-core/src/traceAgentTest/groovy/TraceGenerator.groovy
@@ -1,0 +1,356 @@
+
+
+import datadog.trace.api.DDId
+import datadog.trace.api.DDTags
+import datadog.trace.api.IdGenerationStrategy
+import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString
+import datadog.trace.core.CoreSpan
+import datadog.trace.core.Metadata
+import datadog.trace.core.MetadataConsumer
+
+import java.util.concurrent.ThreadLocalRandom
+import java.util.concurrent.TimeUnit
+
+class TraceGenerator {
+
+  static List<List<CoreSpan>> generateRandomTraces(int howMany, boolean lowCardinality) {
+    List<List<CoreSpan>> traces = new ArrayList<>(howMany)
+    for (int i = 0; i < howMany; ++i) {
+      int traceSize = ThreadLocalRandom.current().nextInt(2, 20)
+      traces.add(generateRandomTrace(traceSize, lowCardinality))
+    }
+    return traces
+  }
+
+  private static List<CoreSpan> generateRandomTrace(int size, boolean lowCardinality) {
+    List<CoreSpan> trace = new ArrayList<>(size)
+    long traceId = ThreadLocalRandom.current().nextLong(1, Long.MAX_VALUE)
+    for (int i = 0; i < size; ++i) {
+      trace.add(randomSpan(traceId, lowCardinality))
+    }
+    return trace
+  }
+
+  private static CoreSpan randomSpan(long traceId, boolean lowCardinality) {
+    Map<String, String> baggage = new HashMap<>()
+    if (ThreadLocalRandom.current().nextBoolean()) {
+      baggage.put("baggage-key", lowCardinality ? "x" : randomString(100))
+      if (ThreadLocalRandom.current().nextBoolean()) {
+        baggage.put("tag.1", "bar")
+        baggage.put("tag.2", "qux")
+      }
+    }
+    Map<String, Object> tags = new HashMap<>()
+    int tagCount = ThreadLocalRandom.current().nextInt(0, 20)
+    for (int i = 0; i < tagCount; ++i) {
+      tags.put("tag." + i, ThreadLocalRandom.current().nextBoolean() ? "foo" : randomString(2000))
+      tags.put("tag.1." + i, lowCardinality ? "y" : UUID.randomUUID())
+    }
+    Map<String, Number> metrics = new HashMap<>()
+    int metricCount = ThreadLocalRandom.current().nextInt(0, 20)
+    for (int i = 0; i < metricCount; ++i) {
+      metrics.put("metric." + i, ThreadLocalRandom.current().nextBoolean()
+        ? ThreadLocalRandom.current().nextInt()
+        : ThreadLocalRandom.current().nextDouble())
+    }
+    return new PojoSpan(
+      "service-" + ThreadLocalRandom.current().nextInt(lowCardinality ? 1 : 10),
+      "operation-" + ThreadLocalRandom.current().nextInt(lowCardinality ? 1 : 100),
+      UTF8BytesString.create("resource-" + ThreadLocalRandom.current().nextInt(lowCardinality ? 1 : 100)),
+      DDId.from(traceId),
+      IdGenerationStrategy.RANDOM.generate(),
+      DDId.ZERO,
+      TimeUnit.MILLISECONDS.toNanos(System.currentTimeMillis()),
+      ThreadLocalRandom.current().nextLong(500, 10_000_000),
+      ThreadLocalRandom.current().nextInt(2),
+      metrics,
+      baggage,
+      tags,
+      "type-" + ThreadLocalRandom.current().nextInt(lowCardinality ? 1 : 100),
+      ThreadLocalRandom.current().nextBoolean())
+  }
+
+  private static String randomString(int maxLength) {
+    char[] chars = new char[ThreadLocalRandom.current().nextInt(maxLength)]
+    for (int i = 0; i < chars.length; ++i) {
+      char next = (char) ThreadLocalRandom.current().nextInt((int) Character.MAX_VALUE)
+      if (Character.isSurrogate(next)) {
+        if (i < chars.length - 1) {
+          chars[i++] = '\uD801'
+          chars[i] = '\uDC01'
+        } else {
+          chars[i] = 'a'
+        }
+      } else {
+        chars[i] = next
+      }
+    }
+    return new String(chars)
+  }
+
+  static class PojoSpan implements CoreSpan<PojoSpan> {
+
+    private final CharSequence serviceName
+    private final CharSequence operationName
+    private final CharSequence resourceName
+    private final DDId traceId
+    private final DDId spanId
+    private final DDId parentId
+    private final long start
+    private final long duration
+    private final int error
+    private final Map<String, Number> metrics
+    private final String type
+    private final boolean measured
+    private final Metadata metadata
+
+    PojoSpan(
+      String serviceName,
+      String operationName,
+      CharSequence resourceName,
+      DDId traceId,
+      DDId spanId,
+      DDId parentId,
+      long start,
+      long duration,
+      int error,
+      Map<String, Number> metrics,
+      Map<String, String> baggage,
+      Map<String, Object> tags,
+      String type,
+      boolean measured) {
+      this.serviceName = UTF8BytesString.create(serviceName)
+      this.operationName = UTF8BytesString.create(operationName)
+      this.resourceName = UTF8BytesString.create(resourceName)
+      this.traceId = traceId
+      this.spanId = spanId
+      this.parentId = parentId
+      this.start = start
+      this.duration = duration
+      this.error = error
+      this.metrics = metrics
+      this.type = type
+      this.measured = measured
+      this.metadata = new Metadata(Thread.currentThread().getId(),
+      UTF8BytesString.create(Thread.currentThread().getName()), tags, baggage)
+    }
+
+    @Override
+    PojoSpan getLocalRootSpan() {
+      return this
+    }
+
+    @Override
+    String getServiceName() {
+      return serviceName
+    }
+
+    @Override
+    CharSequence getOperationName() {
+      return operationName
+    }
+
+    @Override
+    CharSequence getResourceName() {
+      return resourceName
+    }
+
+    @Override
+    DDId getTraceId() {
+      return traceId
+    }
+
+    @Override
+    DDId getSpanId() {
+      return spanId
+    }
+
+    @Override
+    DDId getParentId() {
+      return parentId
+    }
+
+    @Override
+    long getStartTime() {
+      return start
+    }
+
+    @Override
+    long getDurationNano() {
+      return duration
+    }
+
+    @Override
+    int getError() {
+      return error
+    }
+
+    @Override
+    PojoSpan setMeasured(boolean measured) {
+      return this
+    }
+
+    @Override
+    PojoSpan setErrorMessage(String errorMessage) {
+      return this
+    }
+
+    @Override
+    PojoSpan addThrowable(Throwable error) {
+      return this
+    }
+
+    @Override
+    PojoSpan setTag(String tag, String value) {
+      return this
+    }
+
+    @Override
+    PojoSpan setTag(String tag, boolean value) {
+      return this
+    }
+
+    @Override
+    PojoSpan setTag(String tag, int value) {
+      return this
+    }
+
+    @Override
+    PojoSpan setTag(String tag, long value) {
+      return this
+    }
+
+    @Override
+    PojoSpan setTag(String tag, double value) {
+      return this
+    }
+
+    @Override
+    PojoSpan setTag(String tag, Number value) {
+      return this
+    }
+
+    @Override
+    PojoSpan setTag(String tag, CharSequence value) {
+      return this
+    }
+
+    @Override
+    PojoSpan setTag(String tag, Object value) {
+      return this
+    }
+
+    @Override
+    PojoSpan removeTag(String tag) {
+      return this
+    }
+
+    @Override
+    boolean isMeasured() {
+      return measured
+    }
+
+    @Override
+    boolean isTopLevel() {
+      return false
+    }
+
+    @Override
+    boolean isForceKeep() {
+      return false
+    }
+
+    @Override
+    Map<String, Number> getUnsafeMetrics() {
+      return metrics
+    }
+
+    Map<String, String> getBaggage() {
+      return metadata.getBaggage()
+    }
+
+    Map<String, Object> getTags() {
+      return metadata.getTags()
+    }
+
+    @Override
+    String getType() {
+      return type
+    }
+
+    @Override
+    void processTagsAndBaggage(MetadataConsumer consumer) {
+      consumer.accept(metadata)
+    }
+
+    @Override
+    PojoSpan setSamplingPriority(int samplingPriority) {
+      return this
+    }
+
+    @Override
+    PojoSpan setSamplingPriority(int samplingPriority, CharSequence rate, double sampleRate) {
+      return this
+    }
+
+    @Override
+    PojoSpan setMetric(CharSequence name, int value) {
+      return this
+    }
+
+    @Override
+    PojoSpan setMetric(CharSequence name, long value) {
+      return this
+    }
+
+    @Override
+    PojoSpan setMetric(CharSequence name, float value) {
+      return this
+    }
+
+    @Override
+    PojoSpan setMetric(CharSequence name, double value) {
+      return this
+    }
+
+    @Override
+    PojoSpan setFlag(CharSequence name, boolean value) {
+      return this
+    }
+
+    @Override
+    int samplingPriority() {
+      return 0
+    }
+
+    @Override
+    <U> U getTag(CharSequence name, U defaultValue) {
+      U value = getTag(name)
+      return null == value ? defaultValue : value
+    }
+
+    @Override
+    <U> U getTag(CharSequence name) {
+      // replicate logic here because DDSpanContext has to pretend some of its
+      // fields are elements of a map for backward compatibility reasons
+      String tag = String.valueOf(name)
+      Object value = null
+      switch (tag) {
+        case DDTags.THREAD_ID:
+          value = metadata.getThreadId()
+          break
+        case DDTags.THREAD_NAME:
+          value = metadata.getThreadName()
+          break
+        default:
+          value = tags.get(tag)
+      }
+      return value as U
+    }
+
+    @Override
+    boolean hasSamplingPriority() {
+      return false
+    }
+  }
+}

--- a/dd-trace-core/src/traceAgentTest/groovy/TraceMapperRealAgentTest.groovy
+++ b/dd-trace-core/src/traceAgentTest/groovy/TraceMapperRealAgentTest.groovy
@@ -1,6 +1,9 @@
-package datadog.trace.common.writer.ddagent
+
 
 import com.timgroup.statsd.NoOpStatsDClient
+import datadog.trace.common.writer.ddagent.DDAgentApi
+import datadog.trace.common.writer.ddagent.DDAgentFeaturesDiscovery
+import datadog.trace.common.writer.ddagent.PayloadDispatcher
 import datadog.trace.core.CoreSpan
 import datadog.trace.core.http.OkHttpUtils
 import datadog.trace.core.monitor.HealthMetrics
@@ -13,7 +16,7 @@ import spock.lang.Shared
 
 import java.util.concurrent.TimeUnit
 
-import static datadog.trace.common.writer.ddagent.TraceGenerator.generateRandomTraces
+import static TraceGenerator.generateRandomTraces
 
 @Requires({ "true" == System.getenv("CI") })
 class TraceMapperRealAgentTest extends DDSpecification {

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -145,7 +145,6 @@ import static datadog.trace.api.config.TracerConfig.HTTP_CLIENT_ERROR_STATUSES;
 import static datadog.trace.api.config.TracerConfig.HTTP_SERVER_ERROR_STATUSES;
 import static datadog.trace.api.config.TracerConfig.ID_GENERATION_STRATEGY;
 import static datadog.trace.api.config.TracerConfig.PARTIAL_FLUSH_MIN_SPANS;
-import static datadog.trace.api.config.TracerConfig.PRIORITIZATION_TYPE;
 import static datadog.trace.api.config.TracerConfig.PRIORITY_SAMPLING;
 import static datadog.trace.api.config.TracerConfig.PRIORITY_SAMPLING_FORCE;
 import static datadog.trace.api.config.TracerConfig.PROPAGATION_STYLE_EXTRACT;

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -20,7 +20,6 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_LEGACY_CONTEXT_FIELD_INJE
 import static datadog.trace.api.ConfigDefaults.DEFAULT_LOGS_INJECTION_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PARTIAL_FLUSH_MIN_SPANS;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PERF_METRICS_ENABLED;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_PRIORITIZATION_TYPE;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PRIORITY_SAMPLING_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PRIORITY_SAMPLING_FORCE;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_AGENTLESS;
@@ -262,7 +261,6 @@ public class Config {
   @Getter private final boolean traceEnabled;
   @Getter private final boolean integrationsEnabled;
   @Getter private final String writerType;
-  @Getter private final String prioritizationType;
   @Getter private final boolean agentConfiguredUsingDefault;
   @Getter private final String agentUrl;
   @Getter private final String agentHost;
@@ -425,7 +423,6 @@ public class Config {
     integrationsEnabled =
         configProvider.getBoolean(INTEGRATIONS_ENABLED, DEFAULT_INTEGRATIONS_ENABLED);
     writerType = configProvider.getString(WRITER_TYPE, DEFAULT_AGENT_WRITER_TYPE);
-    prioritizationType = configProvider.getString(PRIORITIZATION_TYPE, DEFAULT_PRIORITIZATION_TYPE);
 
     idGenerationStrategy =
         configProvider.getEnum(ID_GENERATION_STRATEGY, IdGenerationStrategy.class, RANDOM);
@@ -904,6 +901,10 @@ public class Config {
   public boolean isTraceAnalyticsIntegrationEnabled(
       final boolean defaultEnabled, final String... integrationNames) {
     return isEnabled(Arrays.asList(integrationNames), "", ".analytics.enabled", defaultEnabled);
+  }
+
+  public <T extends Enum<T>> T getEnumValue(String name, Class<T> type, T defaultValue) {
+    return configProvider.getEnum(PREFIX + name, type, defaultValue);
   }
 
   private static boolean isDebugMode() {

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/PrioritizationConstants.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/PrioritizationConstants.java
@@ -1,8 +1,0 @@
-package datadog.trace.bootstrap.instrumentation.api;
-
-public final class PrioritizationConstants {
-  public static final String ENSURE_TRACE_TYPE = "EnsureTrace";
-  public static final String FAST_LANE_TYPE = "FastLane";
-
-  private PrioritizationConstants() {}
-}

--- a/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -125,7 +125,6 @@ class ConfigTest extends DDSpecification {
     prop.setProperty(TRACE_ENABLED, "false")
     prop.setProperty(ID_GENERATION_STRATEGY, "SEQUENTIAL")
     prop.setProperty(WRITER_TYPE, "LoggingWriter")
-    prop.setProperty(PRIORITIZATION_TYPE, "EnsureTrace")
     prop.setProperty(AGENT_HOST, "somehost")
     prop.setProperty(TRACE_AGENT_PORT, "123")
     prop.setProperty(AGENT_UNIX_DOMAIN_SOCKET, "somepath")
@@ -189,7 +188,6 @@ class ConfigTest extends DDSpecification {
     config.idGenerationStrategy == SEQUENTIAL
     config.traceEnabled == false
     config.writerType == "LoggingWriter"
-    config.prioritizationType == "EnsureTrace"
     config.agentHost == "somehost"
     config.agentPort == 123
     config.agentUnixDomainSocket == "somepath"
@@ -314,7 +312,6 @@ class ConfigTest extends DDSpecification {
     config.serviceName == "something else"
     config.traceEnabled == false
     config.writerType == "LoggingWriter"
-    config.prioritizationType == "EnsureTrace"
     config.agentHost == "somehost"
     config.agentPort == 123
     config.agentUnixDomainSocket == "somepath"
@@ -389,7 +386,6 @@ class ConfigTest extends DDSpecification {
     config.serviceName == "still something else"
     config.traceEnabled == false
     config.writerType == "LoggingWriter"
-    config.prioritizationType == "EnsureTrace"
     config.propagationStylesToExtract.toList() == [PropagationStyle.B3, PropagationStyle.DATADOG]
     config.propagationStylesToInject.toList() == [PropagationStyle.DATADOG, PropagationStyle.B3]
     config.jmxFetchMetricsConfigs == ["some/file"]
@@ -415,7 +411,6 @@ class ConfigTest extends DDSpecification {
     then:
     config.serviceName == "what we actually want"
     config.writerType == "DDAgentWriter"
-    config.prioritizationType == "FastLane"
     config.agentHost == "somewhere"
     config.agentPort == 123
     config.agentUrl == "http://somewhere:123"
@@ -449,7 +444,6 @@ class ConfigTest extends DDSpecification {
     config.serviceName == " "
     config.traceEnabled == true
     config.writerType == " "
-    config.prioritizationType == " "
     config.agentHost == " "
     config.agentPort == 8126
     config.agentUrl == "http:// :8126"
@@ -547,7 +541,6 @@ class ConfigTest extends DDSpecification {
     config.serviceName == "something else"
     config.traceEnabled == false
     config.writerType == "LoggingWriter"
-    config.prioritizationType == "EnsureTrace"
     config.agentHost == "somehost"
     config.agentPort == 123
     config.agentUnixDomainSocket == "somepath"
@@ -580,7 +573,6 @@ class ConfigTest extends DDSpecification {
     then:
     config.serviceName == "unnamed-java-app"
     config.writerType == "DDAgentWriter"
-    config.prioritizationType == "FastLane"
   }
 
   def "override empty properties"() {
@@ -593,7 +585,6 @@ class ConfigTest extends DDSpecification {
     then:
     config.serviceName == "unnamed-java-app"
     config.writerType == "DDAgentWriter"
-    config.prioritizationType == "FastLane"
   }
 
   def "override non empty properties"() {
@@ -607,7 +598,6 @@ class ConfigTest extends DDSpecification {
     then:
     config.serviceName == "unnamed-java-app"
     config.writerType == "DDAgentWriter"
-    config.prioritizationType == "FastLane"
   }
 
   def "captured env props override default props"() {


### PR DESCRIPTION
This PR does two things:
* refactor the way we discover agent capabilities 
   * we now query an endpoint which provides metadata about the trace agent, which endpoints it has and what features it can support. 
   * If it doesn't exist, we fall back to probing as before
* allows us to drop traces without serialising them if the trace agent supports it
   * If we discover the agent allows dropping traces early from the `/info` endpoint, we pass that information in to the `PrioritizationStrategy` which decides which queue to publish to. 
   * If the span has low sampling priority, and the agent allows it, we drop the trace
   * If a low priority trace contains a rare span (has not produced a metric point recently) or an error we always keep it
   * We refresh the metadata from the trace agent on a schedule, in case the agent is downgraded and can no longer support dropping in the tracer.