### PR TITLE
Revert "Move PendingTraceBuffer flush to consumer thread and remove sleep"

### DIFF
--- a/dd-trace-core/dd-trace-core.gradle
+++ b/dd-trace-core/dd-trace-core.gradle
@@ -14,7 +14,6 @@ excludedClassesCoverage += [
   'datadog.trace.common.writer.ddagent.unixdomainsockets.UnixDomainSocketFactory',
   'datadog.trace.core.scopemanager.ScopeInterceptor.DelegatingScope',
   'datadog.trace.core.jfr.DDNoopScopeEventFactory',
-  'datadog.trace.core.PendingTraceBuffer.DelayingPendingTraceBuffer.FlushElement',
   'datadog.trace.core.StatusLogger',
   'datadog.trace.core.scopemanager.ContinuableScopeManager.SingleContinuation'
 ]

--- a/dd-trace-core/src/main/java/datadog/trace/core/PendingTrace.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/PendingTrace.java
@@ -32,7 +32,7 @@ import lombok.extern.slf4j.Slf4j;
  * Delayed write is handled by PendingTraceBuffer. <br>
  */
 @Slf4j
-public class PendingTrace implements AgentTrace, PendingTraceBuffer.Element {
+public class PendingTrace implements AgentTrace {
 
   static class Factory {
     private final CoreTracer tracer;
@@ -153,7 +153,7 @@ public class PendingTrace implements AgentTrace, PendingTraceBuffer.Element {
   }
 
   /** @return Long.MAX_VALUE if no spans finished. */
-  public long oldestFinishedTime() {
+  long oldestFinishedTime() {
     long oldest = Long.MAX_VALUE;
     for (DDSpan span : finishedSpans) {
       oldest = Math.min(oldest, span.getStartTime() + span.getDurationNano());
@@ -206,7 +206,7 @@ public class PendingTrace implements AgentTrace, PendingTraceBuffer.Element {
   }
 
   /** Important to note: may be called multiple times. */
-  public void write() {
+  void write() {
     write(false);
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/PendingTraceBuffer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/PendingTraceBuffer.java
@@ -5,49 +5,28 @@ import static datadog.trace.util.AgentThreadFactory.THREAD_JOIN_TIMOUT_MS;
 import static datadog.trace.util.AgentThreadFactory.newAgentThread;
 
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 import org.jctools.queues.MessagePassingQueue;
 import org.jctools.queues.MpscBlockingConsumerArrayQueue;
-import org.jctools.queues.SpscArrayQueue;
 
 public abstract class PendingTraceBuffer implements AutoCloseable {
   private static final int BUFFER_SIZE = 1 << 12; // 4096
-
-  public interface Element {
-    long oldestFinishedTime();
-
-    boolean lastReferencedNanosAgo(long nanos);
-
-    void write();
-  }
 
   private static class DelayingPendingTraceBuffer extends PendingTraceBuffer {
     private static final long FORCE_SEND_DELAY_MS = TimeUnit.SECONDS.toMillis(5);
     private static final long SEND_DELAY_NS = TimeUnit.MILLISECONDS.toNanos(500);
     private static final long SLEEP_TIME_MS = 100;
 
-    private final MpscBlockingConsumerArrayQueue<Element> queue;
-    // Yes, this is a bit of an overkill, but it's easier to use the same APIs
-    private final SpscArrayQueue<Element> requeue;
-    private long firstRequeueTimeNanos = 0;
+    private final MpscBlockingConsumerArrayQueue<PendingTrace> queue;
     private final Thread worker;
 
     private volatile boolean closed = false;
-    private final AtomicInteger flushCounter = new AtomicInteger(0);
-    private final TransferDrain TRANSFER_DRAIN = new TransferDrain();
 
     /** if the queue is full, pendingTrace trace will be written immediately. */
-    public void enqueue(Element pendingTrace) {
-      enqueue(queue, pendingTrace);
-    }
-
-    private boolean enqueue(MessagePassingQueue<Element> queue, Element pendingTrace) {
-      boolean added = queue.offer(pendingTrace);
-      if (!added) {
+    public void enqueue(PendingTrace pendingTrace) {
+      if (!queue.offer(pendingTrace)) {
         // Queue is full, so we can't buffer this trace, write it out directly instead.
         pendingTrace.write();
       }
-      return added;
     }
 
     public void start() {
@@ -64,54 +43,17 @@ public abstract class PendingTraceBuffer implements AutoCloseable {
       }
     }
 
-    // Only used from within tests
     public void flush() {
-      if (worker.isAlive()) {
-        int count = flushCounter.get();
-        boolean signaled;
-        do {
-          signaled = queue.offer(FlushElement.FLUSH_ELEMENT);
-          Thread.yield();
-        } while (!closed && !signaled);
-        int newCount;
-        do {
-          newCount = flushCounter.get();
-          Thread.yield();
-        } while (!closed && count >= newCount);
-      }
+      queue.drain(WriteDrain.WRITE_DRAIN);
     }
 
-    private static final class WriteDrain implements MessagePassingQueue.Consumer<Element> {
+    private static final class WriteDrain implements MessagePassingQueue.Consumer<PendingTrace> {
       private static final WriteDrain WRITE_DRAIN = new WriteDrain();
 
       @Override
-      public void accept(Element pendingTrace) {
+      public void accept(PendingTrace pendingTrace) {
         pendingTrace.write();
       }
-    }
-
-    private final class TransferDrain implements MessagePassingQueue.Consumer<Element> {
-      @Override
-      public void accept(Element pendingTrace) {
-        enqueue(pendingTrace);
-      }
-    }
-
-    private static final class FlushElement implements Element {
-      static FlushElement FLUSH_ELEMENT = new FlushElement();
-
-      @Override
-      public long oldestFinishedTime() {
-        return 0;
-      }
-
-      @Override
-      public boolean lastReferencedNanosAgo(long nanos) {
-        return false;
-      }
-
-      @Override
-      public void write() {}
     }
 
     private final class Worker implements Runnable {
@@ -120,40 +62,8 @@ public abstract class PendingTraceBuffer implements AutoCloseable {
       public void run() {
         try {
           while (!closed && !Thread.currentThread().isInterrupted()) {
-            long sleepTimeMillis = 0;
-            if (firstRequeueTimeNanos != 0) {
-              // Have at least one trace been requeued for more than SLEEP_TIME_MILLIS?
-              sleepTimeMillis =
-                  SLEEP_TIME_MS
-                      - TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - firstRequeueTimeNanos);
-              if (sleepTimeMillis <= 0) {
-                firstRequeueTimeNanos = 0;
-                // Move all the traces back to the normal queue
-                requeue.drain(TRANSFER_DRAIN);
-              }
-            }
-            Element pendingTrace = queue.peek();
-            if (sleepTimeMillis > 0) {
-              // If we had something in the requeue but it hadn't been there long enough, then
-              // block at most the remaining time before checking again
-              pendingTrace = queue.poll(sleepTimeMillis, TimeUnit.MILLISECONDS);
-            } else {
-              // If we had something in the requeue and transferred it to the normal queue, or if
-              // there was nothing in the requeue, then just take the next element from the normal
-              // queue, potentially blocking
-              pendingTrace = queue.poll();
-            }
-            if (null == pendingTrace) {
-              continue;
-            }
 
-            if (pendingTrace instanceof FlushElement) {
-              // Since this is an MPSC queue, the drain needs to be called on the consumer thread
-              queue.drain(WriteDrain.WRITE_DRAIN);
-              requeue.drain(WriteDrain.WRITE_DRAIN);
-              flushCounter.incrementAndGet();
-              continue;
-            }
+            PendingTrace pendingTrace = queue.take(); // block until available.
 
             long oldestFinishedTime = pendingTrace.oldestFinishedTime();
 
@@ -168,23 +78,19 @@ public abstract class PendingTraceBuffer implements AutoCloseable {
               // Trace has been unmodified long enough, go ahead and write whatever is finished.
               pendingTrace.write();
             } else {
-              // Trace is too new.  Requeue it and check it later.
-              if (enqueue(requeue, pendingTrace) && firstRequeueTimeNanos == 0) {
-                // Add a time stamp so we know when to put back elements in the normal queue
-                firstRequeueTimeNanos = System.nanoTime();
-              }
+              // Trace is too new.  Requeue it and sleep to avoid a hot loop.
+              enqueue(pendingTrace);
+              Thread.sleep(SLEEP_TIME_MS);
             }
           }
         } catch (InterruptedException e) {
           Thread.currentThread().interrupt();
         }
-        closed = true;
       }
     }
 
     public DelayingPendingTraceBuffer(int bufferSize) {
       this.queue = new MpscBlockingConsumerArrayQueue<>(bufferSize);
-      this.requeue = new SpscArrayQueue<>(bufferSize);
       this.worker = newAgentThread(TRACE_MONITOR, new Worker());
     }
   }
@@ -200,7 +106,7 @@ public abstract class PendingTraceBuffer implements AutoCloseable {
     public void flush() {}
 
     @Override
-    public void enqueue(Element pendingTrace) {}
+    public void enqueue(PendingTrace pendingTrace) {}
   }
 
   public static PendingTraceBuffer delaying() {
@@ -217,5 +123,5 @@ public abstract class PendingTraceBuffer implements AutoCloseable {
 
   public abstract void flush();
 
-  public abstract void enqueue(Element pendingTrace);
+  public abstract void enqueue(PendingTrace pendingTrace);
 }


### PR DESCRIPTION
Reverts DataDog/dd-trace-java#2329

This change had a bad impact on CPU usage. The `flush` fix will be in a separate PR from any changes to the requeue logic.