### PR TITLE
Move PendingTraceBuffer flush to consumer thread

### DIFF
--- a/dd-trace-core/dd-trace-core.gradle
+++ b/dd-trace-core/dd-trace-core.gradle
@@ -14,6 +14,7 @@ excludedClassesCoverage += [
   'datadog.trace.common.writer.ddagent.unixdomainsockets.UnixDomainSocketFactory',
   'datadog.trace.core.scopemanager.ScopeInterceptor.DelegatingScope',
   'datadog.trace.core.jfr.DDNoopScopeEventFactory',
+  'datadog.trace.core.PendingTraceBuffer.DelayingPendingTraceBuffer.FlushElement',
   'datadog.trace.core.StatusLogger',
   'datadog.trace.core.scopemanager.ContinuableScopeManager.SingleContinuation'
 ]

--- a/dd-trace-core/src/main/java/datadog/trace/core/PendingTrace.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/PendingTrace.java
@@ -32,7 +32,7 @@ import lombok.extern.slf4j.Slf4j;
  * Delayed write is handled by PendingTraceBuffer. <br>
  */
 @Slf4j
-public class PendingTrace implements AgentTrace {
+public class PendingTrace implements AgentTrace, PendingTraceBuffer.Element {
 
   static class Factory {
     private final CoreTracer tracer;
@@ -153,7 +153,7 @@ public class PendingTrace implements AgentTrace {
   }
 
   /** @return Long.MAX_VALUE if no spans finished. */
-  long oldestFinishedTime() {
+  public long oldestFinishedTime() {
     long oldest = Long.MAX_VALUE;
     for (DDSpan span : finishedSpans) {
       oldest = Math.min(oldest, span.getStartTime() + span.getDurationNano());
@@ -206,7 +206,7 @@ public class PendingTrace implements AgentTrace {
   }
 
   /** Important to note: may be called multiple times. */
-  void write() {
+  public void write() {
     write(false);
   }
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceBufferTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceBufferTest.groovy
@@ -13,6 +13,8 @@ import spock.lang.Subject
 import spock.lang.Timeout
 
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
 
 import static datadog.trace.core.PendingTraceBuffer.BUFFER_SIZE
 
@@ -241,43 +243,39 @@ class PendingTraceBufferTest extends DDSpecification {
 
   def "flush clears the buffer"() {
     setup:
-    // Don't start the buffer thread
-    def trace = factory.create(DDId.ONE)
-    def parent = newSpanOf(trace)
-    def child = newSpanOf(parent)
+    buffer.start()
+    def counter = new AtomicInteger(0)
+    // Create a fake element that newer gets written
+    def element = new PendingTraceBuffer.Element() {
+      @Override
+      long oldestFinishedTime() {
+        return TimeUnit.MILLISECONDS.toNanos(System.currentTimeMillis())
+      }
+
+      @Override
+      boolean lastReferencedNanosAgo(long nanos) {
+        return false
+      }
+
+      @Override
+      void write() {
+        counter.incrementAndGet()
+      }
+    }
 
     when:
-    parent.finish() // This should enqueue
+    buffer.enqueue(element)
+    buffer.enqueue(element)
+    buffer.enqueue(element)
 
     then:
-    trace.size() == 1
-    trace.pendingReferenceCount.get() == 1
-    !trace.rootSpanWritten
-    1 * bufferSpy.enqueue(trace)
-    _ * tracer.getPartialFlushMinSpans() >> 10
-    0 * _
+    counter.get() == 0
 
     when:
     buffer.flush()
 
     then:
-    trace.size() == 0
-    trace.pendingReferenceCount.get() == 1
-    trace.rootSpanWritten
-    1 * tracer.writeTimer() >> Monitoring.DISABLED.newTimer("")
-    1 * tracer.write({ it.size() == 1 })
-    0 * _
-
-    when:
-    child.finish()
-
-    then:
-    trace.size() == 1
-    trace.pendingReferenceCount.get() == 0
-    trace.rootSpanWritten
-    _ * tracer.getPartialFlushMinSpans() >> 10
-    1 * bufferSpy.enqueue(trace)
-    0 * _
+    counter.get() == 3
   }
 
   def addContinuation(DDSpan span) {


### PR DESCRIPTION
This PR only moves the `flush` (which is a method only used from tests) handling onto the `worker` consumer thread, since the queue is an MPSC queue and should only be read from the _consumer_. It does not change the `PendingTraceBuffer` queue processing behavior. This is done to fix flakiness in tests.