### PR TITLE
Make strict trace writing the default for core and instrumentation tests

### DIFF
--- a/dd-java-agent/instrumentation/akka-concurrent/src/akka23Test/groovy/AkkaActorTest.groovy
+++ b/dd-java-agent/instrumentation/akka-concurrent/src/akka23Test/groovy/AkkaActorTest.groovy
@@ -3,11 +3,6 @@ import datadog.trace.agent.test.AgentTestRunner
 import spock.lang.Shared
 
 class AkkaActorTest extends AgentTestRunner {
-  @Override
-  boolean useStrictTraceWrites() {
-    return true
-  }
-
   @Shared
   def akkaTester = new AkkaActors()
 

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/baseTest/groovy/AkkaHttpClientInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/baseTest/groovy/AkkaHttpClientInstrumentationTest.groovy
@@ -19,11 +19,6 @@ import spock.lang.Timeout
 
 @Timeout(5)
 abstract class AkkaHttpClientInstrumentationTest extends HttpClientTest {
-  @Override
-  boolean useStrictTraceWrites() {
-    return true
-  }
-
   @Shared
   ActorSystem system = ActorSystem.create()
   @Shared

--- a/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/CouchbaseAsyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/CouchbaseAsyncClientTest.groovy
@@ -17,6 +17,12 @@ import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 class CouchbaseAsyncClientTest extends AbstractCouchbaseTest {
   static final int TIMEOUT = 10
 
+  @Override
+  boolean useStrictTraceWrites() {
+    // TODO fix this by making sure that spans get closed properly
+    return false
+  }
+
   def "test hasBucket #type"() {
     setup:
     def hasBucket = new BlockingVariable<Boolean>(TIMEOUT)

--- a/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/springdata/CouchbaseSpringRepositoryTest.groovy
+++ b/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/springdata/CouchbaseSpringRepositoryTest.groovy
@@ -32,6 +32,13 @@ class CouchbaseSpringRepositoryTest extends AbstractCouchbaseTest {
       }
     }
   }
+
+  @Override
+  boolean useStrictTraceWrites() {
+    // TODO fix this by making sure that spans get closed properly
+    return false
+  }
+
   @Shared
   ConfigurableApplicationContext applicationContext
   @Shared

--- a/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/springdata/CouchbaseSpringTemplateTest.groovy
+++ b/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/springdata/CouchbaseSpringTemplateTest.groovy
@@ -19,6 +19,12 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
 @Unroll
 class CouchbaseSpringTemplateTest extends AbstractCouchbaseTest {
 
+  @Override
+  boolean useStrictTraceWrites() {
+    // TODO fix this by making sure that spans get closed properly
+    return false
+  }
+
   @Shared
   List<CouchbaseTemplate> templates
 

--- a/dd-java-agent/instrumentation/datastax-cassandra-3/src/test/groovy/CassandraClientTest.groovy
+++ b/dd-java-agent/instrumentation/datastax-cassandra-3/src/test/groovy/CassandraClientTest.groovy
@@ -19,6 +19,12 @@ import static datadog.trace.api.config.TraceInstrumentationConfig.DB_CLIENT_HOST
 class CassandraClientTest extends AgentTestRunner {
   private static final int ASYNC_TIMEOUT_MS = 5000
 
+  @Override
+  boolean useStrictTraceWrites() {
+    // TODO fix this by making sure that spans get closed properly
+    return false
+  }
+
   @Shared
   Cluster cluster
 

--- a/dd-java-agent/instrumentation/datastax-cassandra-4/src/test/groovy/CassandraClientTest.groovy
+++ b/dd-java-agent/instrumentation/datastax-cassandra-4/src/test/groovy/CassandraClientTest.groovy
@@ -24,6 +24,12 @@ import static datadog.trace.api.config.TraceInstrumentationConfig.DB_CLIENT_HOST
 class CassandraClientTest extends AgentTestRunner {
   private static final int TIMEOUT = 30
 
+  @Override
+  boolean useStrictTraceWrites() {
+    // TODO fix this by making sure that spans get closed properly
+    return false
+  }
+
   @Shared
   int port
 

--- a/dd-java-agent/instrumentation/hibernate/core-4.3/src/test/groovy/ProcedureCallTest.groovy
+++ b/dd-java-agent/instrumentation/hibernate/core-4.3/src/test/groovy/ProcedureCallTest.groovy
@@ -18,6 +18,11 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
 
 class ProcedureCallTest extends AgentTestRunner {
 
+  @Override
+  boolean useStrictTraceWrites() {
+    // TODO fix this by making sure that spans get closed properly
+    return false
+  }
 
   @Shared
   protected SessionFactory sessionFactory

--- a/dd-java-agent/instrumentation/hystrix-1.4/src/test/groovy/HystrixObservableChainTest.groovy
+++ b/dd-java-agent/instrumentation/hystrix-1.4/src/test/groovy/HystrixObservableChainTest.groovy
@@ -14,6 +14,13 @@ import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 @Retry
 @Timeout(5)
 class HystrixObservableChainTest extends AgentTestRunner {
+
+  @Override
+  boolean useStrictTraceWrites() {
+    // TODO fix this by making sure that spans get closed properly
+    return false
+  }
+
   @Override
   void configurePreAgent() {
     super.configurePreAgent()

--- a/dd-java-agent/instrumentation/hystrix-1.4/src/test/groovy/HystrixObservableTest.groovy
+++ b/dd-java-agent/instrumentation/hystrix-1.4/src/test/groovy/HystrixObservableTest.groovy
@@ -19,6 +19,13 @@ import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 @Retry
 @Timeout(10)
 class HystrixObservableTest extends AgentTestRunner {
+
+  @Override
+  boolean useStrictTraceWrites() {
+    // TODO fix this by making sure that spans get closed properly
+    return false
+  }
+
   @Override
   void configurePreAgent() {
     super.configurePreAgent()

--- a/dd-java-agent/instrumentation/java-concurrent/java-completablefuture/src/test/groovy/CompletableFutureTest.groovy
+++ b/dd-java-agent/instrumentation/java-concurrent/java-completablefuture/src/test/groovy/CompletableFutureTest.groovy
@@ -19,11 +19,6 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScop
  */
 class CompletableFutureTest extends AgentTestRunner {
 
-  @Override
-  boolean useStrictTraceWrites() {
-    return true
-  }
-
   def "CompletableFuture test"() {
     setup:
     def pool = new ThreadPoolExecutor(1, 1, 1000, TimeUnit.NANOSECONDS, new ArrayBlockingQueue<Runnable>(1))

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTest.groovy
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTest.groovy
@@ -33,6 +33,12 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScop
 class KafkaClientTest extends AgentTestRunner {
   static final SHARED_TOPIC = "shared.topic"
 
+  @Override
+  boolean useStrictTraceWrites() {
+    // TODO fix this by making sure that spans get closed properly
+    return false
+  }
+
   @Rule
   KafkaEmbedded embeddedKafka = new KafkaEmbedded(1, true, SHARED_TOPIC)
 

--- a/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/Lettuce5ReactiveClientTest.groovy
+++ b/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/Lettuce5ReactiveClientTest.groovy
@@ -23,6 +23,12 @@ class Lettuce5ReactiveClientTest extends AgentTestRunner {
   // Disable autoreconnect so we do not get stray traces popping up on server shutdown
   public static final ClientOptions CLIENT_OPTIONS = ClientOptions.builder().autoReconnect(false).build()
 
+  @Override
+  boolean useStrictTraceWrites() {
+    // TODO fix this by making sure that spans get closed properly
+    return false
+  }
+
   @Shared
   String embeddedDbUri
 

--- a/dd-java-agent/instrumentation/netty-4.1/src/test/groovy/ReactorNettyTest.groovy
+++ b/dd-java-agent/instrumentation/netty-4.1/src/test/groovy/ReactorNettyTest.groovy
@@ -13,6 +13,12 @@ import static datadog.trace.agent.test.utils.TraceUtils.basicSpan
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 
 class ReactorNettyTest extends AgentTestRunner {
+  @Override
+  boolean useStrictTraceWrites() {
+    // TODO fix this by making sure that spans get closed properly
+    return false
+  }
+
   @AutoCleanup
   @Shared
   def server = httpServer {

--- a/dd-java-agent/instrumentation/okhttp-2/src/test/groovy/OkHttp2AsyncTest.groovy
+++ b/dd-java-agent/instrumentation/okhttp-2/src/test/groovy/OkHttp2AsyncTest.groovy
@@ -13,6 +13,12 @@ import static java.util.concurrent.TimeUnit.SECONDS
 
 class OkHttp2AsyncTest extends OkHttp2Test {
   @Override
+  boolean useStrictTraceWrites() {
+    // TODO fix this by making sure that spans get closed properly
+    return false
+  }
+
+  @Override
   int doRequest(String method, URI uri, Map<String, String> headers, Closure callback) {
     def body = HttpMethod.requiresRequestBody(method) ? RequestBody.create(MediaType.parse("text/plain"), "") : null
     def request = new Request.Builder()

--- a/dd-java-agent/instrumentation/okhttp-2/src/test/groovy/OkHttp2Test.groovy
+++ b/dd-java-agent/instrumentation/okhttp-2/src/test/groovy/OkHttp2Test.groovy
@@ -14,6 +14,12 @@ import spock.lang.Timeout
 
 @Timeout(5)
 class OkHttp2Test extends HttpClientTest {
+  @Override
+  boolean useStrictTraceWrites() {
+    // TODO fix this by making sure that spans get closed properly
+    return false
+  }
+
   @Shared
   def client = new OkHttpClient()
 

--- a/dd-java-agent/instrumentation/okhttp-3/src/test/groovy/OkHttp3AsyncTest.groovy
+++ b/dd-java-agent/instrumentation/okhttp-3/src/test/groovy/OkHttp3AsyncTest.groovy
@@ -13,7 +13,6 @@ import java.util.concurrent.atomic.AtomicReference
 import static java.util.concurrent.TimeUnit.SECONDS
 
 class OkHttp3AsyncTest extends OkHttp3Test {
-
   @Override
   int doRequest(String method, URI uri, Map<String, String> headers, Closure callback) {
     def body = HttpMethod.requiresRequestBody(method) ? RequestBody.create(MediaType.parse("text/plain"), "") : null

--- a/dd-java-agent/instrumentation/okhttp-3/src/test/groovy/OkHttp3Test.groovy
+++ b/dd-java-agent/instrumentation/okhttp-3/src/test/groovy/OkHttp3Test.groovy
@@ -13,6 +13,12 @@ import java.util.concurrent.TimeUnit
 @Timeout(5)
 class OkHttp3Test extends HttpClientTest {
 
+  @Override
+  boolean useStrictTraceWrites() {
+    // TODO fix this by making sure that spans get closed properly
+    return false
+  }
+
   def client = new OkHttpClient.Builder()
     .connectTimeout(CONNECT_TIMEOUT_MS, TimeUnit.MILLISECONDS)
     .readTimeout(READ_TIMEOUT_MS, TimeUnit.MILLISECONDS)

--- a/dd-java-agent/instrumentation/reactor-core-3.1/src/test/groovy/ReactorCoreTest.groovy
+++ b/dd-java-agent/instrumentation/reactor-core-3.1/src/test/groovy/ReactorCoreTest.groovy
@@ -22,6 +22,12 @@ class ReactorCoreTest extends AgentTestRunner {
 
   public static final String EXCEPTION_MESSAGE = "test exception"
 
+  @Override
+  boolean useStrictTraceWrites() {
+    // TODO fix this by making sure that spans get closed properly
+    return false
+  }
+
   @Shared
   def addOne = { i ->
     addOneFunc(i)

--- a/dd-java-agent/instrumentation/rxjava-2/src/test/groovy/RxJava2Test.groovy
+++ b/dd-java-agent/instrumentation/rxjava-2/src/test/groovy/RxJava2Test.groovy
@@ -20,6 +20,12 @@ class RxJava2Test extends AgentTestRunner {
 
   public static final String EXCEPTION_MESSAGE = "test exception"
 
+  @Override
+  boolean useStrictTraceWrites() {
+    // TODO fix this by making sure that spans get closed properly
+    return false
+  }
+
   @Shared
   def addOne = { i ->
     addOneFunc(i)

--- a/dd-java-agent/instrumentation/scala-concurrent/src/latestDepTest/groovy/ScalaInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/scala-concurrent/src/latestDepTest/groovy/ScalaInstrumentationTest.groovy
@@ -3,6 +3,12 @@ import datadog.trace.core.DDSpan
 
 class ScalaInstrumentationTest extends AgentTestRunner {
 
+  @Override
+  boolean useStrictTraceWrites() {
+    // TODO fix this by making sure that spans get closed properly
+    return false
+  }
+
   def "scala futures and callbacks"() {
     setup:
     ScalaConcurrentTests scalaTest = new ScalaConcurrentTests()

--- a/dd-java-agent/instrumentation/scala-concurrent/src/test/groovy/ScalaInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/scala-concurrent/src/test/groovy/ScalaInstrumentationTest.groovy
@@ -3,6 +3,12 @@ import datadog.trace.core.DDSpan
 
 class ScalaInstrumentationTest extends AgentTestRunner {
 
+  @Override
+  boolean useStrictTraceWrites() {
+    // TODO fix this by making sure that spans get closed properly
+    return false
+  }
+
   def "scala futures and callbacks"() {
     setup:
     ScalaConcurrentTests scalaTest = new ScalaConcurrentTests()

--- a/dd-java-agent/instrumentation/scala-promise/src/test/groovy/ScalaUnitPromiseTestBase.groovy
+++ b/dd-java-agent/instrumentation/scala-promise/src/test/groovy/ScalaUnitPromiseTestBase.groovy
@@ -10,6 +10,12 @@ import static org.junit.Assume.assumeTrue
 abstract class ScalaUnitPromiseTestBase extends AgentTestRunner {
 
   @Override
+  boolean useStrictTraceWrites() {
+    // TODO fix this by making sure that spans get closed properly
+    return false
+  }
+
+  @Override
   void configurePreAgent() {
     super.configurePreAgent()
 

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/test/groovy/dd/trace/instrumentation/springwebflux/client/SpringWebfluxHttpClientBase.groovy
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/test/groovy/dd/trace/instrumentation/springwebflux/client/SpringWebfluxHttpClientBase.groovy
@@ -19,6 +19,12 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
 
 abstract class SpringWebfluxHttpClientBase extends HttpClientTest {
 
+  @Override
+  boolean useStrictTraceWrites() {
+    // TODO fix this by making sure that spans get closed properly
+    return false
+  }
+
   abstract WebClient createClient(CharSequence component)
 
   abstract void check()

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/boot/SpringBootBasedTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/boot/SpringBootBasedTest.groovy
@@ -24,6 +24,12 @@ import static java.util.Collections.singletonMap
 class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext> {
 
   @Override
+  boolean useStrictTraceWrites() {
+    // TODO fix this by making sure that spans get closed properly
+    return false
+  }
+
+  @Override
   ConfigurableApplicationContext startServer(int port) {
     def app = new SpringApplication(AppConfig, SecurityConfig, AuthServerConfig, TestController)
     app.setDefaultProperties(singletonMap("server.port", port))

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/dynamic/DynamicRoutingTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/dynamic/DynamicRoutingTest.groovy
@@ -20,6 +20,12 @@ import static java.util.Collections.singletonMap
 class DynamicRoutingTest extends HttpServerTest<ConfigurableApplicationContext> {
 
   @Override
+  boolean useStrictTraceWrites() {
+    // TODO fix this by making sure that spans get closed properly
+    return false
+  }
+
+  @Override
   ConfigurableApplicationContext startServer(int port) {
     def app = new SpringApplication(DynamicRoutingAppConfig, SecurityConfig)
     app.setDefaultProperties(singletonMap("server.port", port))

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/filter/ServletFilterTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/filter/ServletFilterTest.groovy
@@ -20,6 +20,12 @@ import static java.util.Collections.singletonMap
 class ServletFilterTest extends HttpServerTest<ConfigurableApplicationContext> {
 
   @Override
+  boolean useStrictTraceWrites() {
+    // TODO fix this by making sure that spans get closed properly
+    return false
+  }
+
+  @Override
   ConfigurableApplicationContext startServer(int port) {
     def app = new SpringApplication(FilteredAppConfig, SecurityConfig)
     app.setDefaultProperties(singletonMap("server.port", port))

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/AgentTestRunner.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/AgentTestRunner.groovy
@@ -181,7 +181,7 @@ abstract class AgentTestRunner extends DDSpecification implements AgentBuilder.L
   }
 
   boolean useStrictTraceWrites() {
-    return false
+    return true
   }
 
   void assertTraces(

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/AbstractPromiseTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/AbstractPromiseTest.groovy
@@ -19,11 +19,6 @@ abstract class AbstractPromiseTest<P, M> extends AgentTestRunner {
 
   abstract boolean get(P promise)
 
-  @Override
-  boolean useStrictTraceWrites() {
-    return true
-  }
-
   // Does this instrumentation pick up the completing scope?
   // That is e.g. not how it was decided that CompletableFuture should work
   boolean picksUpCompletingScope() {

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceStrictWriteTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceStrictWriteTest.groovy
@@ -1,15 +1,6 @@
 package datadog.trace.core
 
-import static datadog.trace.api.config.TracerConfig.TRACE_STRICT_WRITES_ENABLED
-
 class PendingTraceStrictWriteTest extends PendingTraceTestBase {
-
-  @Override
-  CoreTracer.CoreTracerBuilder getBuilder() {
-    def props = new Properties()
-    props.setProperty(TRACE_STRICT_WRITES_ENABLED, "true")
-    return tracerBuilder().withProperties(props)
-  }
 
   def "trace is not reported until unfinished continuation is closed"() {
     when:

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceTest.groovy
@@ -7,8 +7,9 @@ import java.util.concurrent.TimeUnit
 class PendingTraceTest extends PendingTraceTestBase {
 
   @Override
-  CoreTracer.CoreTracerBuilder getBuilder() {
-    return tracerBuilder()
+  protected boolean useStrictTraceWrites() {
+    // This tests the behavior of the relaxed pending trace implementation
+    return false
   }
 
   @Timeout(value = 60, unit = TimeUnit.SECONDS)

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceTestBase.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceTestBase.groovy
@@ -3,7 +3,6 @@ package datadog.trace.core
 import ch.qos.logback.classic.Level
 import ch.qos.logback.classic.Logger
 import datadog.trace.common.writer.ListWriter
-import datadog.trace.core.CoreTracer.CoreTracerBuilder
 import datadog.trace.core.test.DDCoreSpecification
 import org.slf4j.LoggerFactory
 
@@ -14,10 +13,8 @@ import static datadog.trace.api.config.TracerConfig.PARTIAL_FLUSH_MIN_SPANS
 
 abstract class PendingTraceTestBase extends DDCoreSpecification {
 
-  abstract CoreTracerBuilder getBuilder()
-
   def writer = new ListWriter()
-  def tracer = getBuilder().writer(writer).build()
+  def tracer = tracerBuilder().writer(writer).build()
 
   DDSpan rootSpan = tracer.buildSpan("fakeOperation").start()
   PendingTrace trace = rootSpan.context().trace
@@ -120,7 +117,7 @@ abstract class PendingTraceTestBase extends DDCoreSpecification {
   def "partial flush"() {
     when:
     injectSysConfig(PARTIAL_FLUSH_MIN_SPANS, "1")
-    def quickTracer = getBuilder().writer(writer).build()
+    def quickTracer = tracerBuilder().writer(writer).build()
     def rootSpan = quickTracer.buildSpan("root").start()
     def trace = rootSpan.context().trace
     def child1 = quickTracer.buildSpan("child1").asChildOf(rootSpan).start()
@@ -165,7 +162,7 @@ abstract class PendingTraceTestBase extends DDCoreSpecification {
   def "partial flush with root span closed last"() {
     when:
     injectSysConfig(PARTIAL_FLUSH_MIN_SPANS, "1")
-    def quickTracer = getBuilder().writer(writer).build()
+    def quickTracer = tracerBuilder().writer(writer).build()
     def rootSpan = quickTracer.buildSpan("root").start()
     def trace = rootSpan.context().trace
     def child1 = quickTracer.buildSpan("child1").asChildOf(rootSpan).start()

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerTest.groovy
@@ -28,6 +28,12 @@ import static datadog.trace.test.util.GCUtils.awaitGC
 class ScopeManagerTest extends DDCoreSpecification {
   private static final long TIMEOUT_MS = 10_000
 
+  @Override
+  protected boolean useStrictTraceWrites() {
+    // This tests the behavior of the relaxed pending trace implementation
+    return false
+  }
+
   ListWriter writer
   CoreTracer tracer
   ContinuableScopeManager scopeManager

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/test/DDCoreSpecification.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/test/DDCoreSpecification.groovy
@@ -11,11 +11,15 @@ abstract class DDCoreSpecification extends DDSpecification {
     return true
   }
 
+  protected boolean useStrictTraceWrites() {
+    return true
+  }
+
   protected CoreTracerBuilder tracerBuilder() {
     def builder = CoreTracer.builder()
     if (useNoopStatsDClient()) {
-      return builder.statsDClient(new NoOpStatsDClient())
+      builder =  builder.statsDClient(new NoOpStatsDClient())
     }
-    return builder
+    return builder.strictTraceWrites(useStrictTraceWrites())
   }
 }


### PR DESCRIPTION
Tests that timed out or failed locally because of too many/few spans, run with the relaxed pending trace write mode. TODO comment has been added and they will be collected in a doc, so we can fix them over time.