### PR TITLE
Avoid running some resource intensive tests concurrently

### DIFF
--- a/dd-java-agent/instrumentation/exception-profiling/exception-profiling.gradle
+++ b/dd-java-agent/instrumentation/exception-profiling/exception-profiling.gradle
@@ -9,6 +9,7 @@ ext {
 }
 
 apply from: "$rootDir/gradle/java.gradle"
+apply from: "$rootDir/gradle/resource-intensive-test.gradle"
 apply plugin: "idea"
 
 dependencies {

--- a/dd-java-agent/instrumentation/java-concurrent/java-concurrent.gradle
+++ b/dd-java-agent/instrumentation/java-concurrent/java-concurrent.gradle
@@ -5,6 +5,7 @@ muzzle {
 }
 
 apply from: "$rootDir/gradle/java.gradle"
+apply from: "$rootDir/gradle/resource-intensive-test.gradle"
 
 dependencies {
   testCompile project(':dd-java-agent:instrumentation:trace-annotation')

--- a/dd-java-agent/instrumentation/spring-webflux-5/spring-webflux-5.gradle
+++ b/dd-java-agent/instrumentation/spring-webflux-5/spring-webflux-5.gradle
@@ -40,6 +40,7 @@ muzzle {
 }
 
 apply from: "$rootDir/gradle/java.gradle"
+apply from: "$rootDir/gradle/resource-intensive-test.gradle"
 
 apply plugin: 'org.unbroken-dome.test-sets'
 

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/spring-webmvc-3.1.gradle
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/spring-webmvc-3.1.gradle
@@ -28,6 +28,7 @@ muzzle {
 }
 
 apply from: "$rootDir/gradle/java.gradle"
+apply from: "$rootDir/gradle/resource-intensive-test.gradle"
 
 dependencies {
   compileOnly group: 'org.springframework', name: 'spring-webmvc', version: '3.1.0.RELEASE'

--- a/gradle/resource-intensive-test.gradle
+++ b/gradle/resource-intensive-test.gradle
@@ -1,0 +1,8 @@
+def resourceIntensiveTestLimit = gradle.sharedServices.registerIfAbsent("resourceIntensiveTestLimit", BuildService) {
+  maxParallelUsages = 2
+}
+
+tasks.withType(Test).configureEach {
+  // Limit the number of concurrent resource intesive tests
+  usesService(resourceIntensiveTestLimit)
+}


### PR DESCRIPTION
Noticed in the build scans that some of the really long running CI runs happened to have these tests running concurrently. Let's see if this makes a difference.