### PR TITLE
Avoid span.isError() boxing

### DIFF
--- a/dd-java-agent/instrumentation/opentelemetry/src/main/java/datadog/trace/instrumentation/opentelemetry/OtelSpan.java
+++ b/dd-java-agent/instrumentation/opentelemetry/src/main/java/datadog/trace/instrumentation/opentelemetry/OtelSpan.java
@@ -217,7 +217,7 @@ public class OtelSpan implements Span, MutableSpan {
   }
 
   @Override
-  public Boolean isError() {
+  public boolean isError() {
     return delegate.isError();
   }
 

--- a/dd-java-agent/instrumentation/opentracing/api-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/OTSpan.java
+++ b/dd-java-agent/instrumentation/opentracing/api-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/OTSpan.java
@@ -66,7 +66,7 @@ class OTSpan implements Span, MutableSpan {
   }
 
   @Override
-  public Boolean isError() {
+  public boolean isError() {
     return delegate.isError();
   }
 

--- a/dd-java-agent/instrumentation/opentracing/api-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/OTSpan.java
+++ b/dd-java-agent/instrumentation/opentracing/api-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/OTSpan.java
@@ -67,7 +67,7 @@ class OTSpan implements Span, MutableSpan {
   }
 
   @Override
-  public Boolean isError() {
+  public boolean isError() {
     return delegate.isError();
   }
 

--- a/dd-trace-api/src/main/java/datadog/trace/api/interceptor/MutableSpan.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/interceptor/MutableSpan.java
@@ -52,7 +52,7 @@ public interface MutableSpan {
 
   MutableSpan setMetric(final CharSequence metric, final double value);
 
-  Boolean isError();
+  boolean isError();
 
   MutableSpan setError(boolean value);
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -421,7 +421,7 @@ public class DDSpan implements AgentSpan, CoreSpan<DDSpan> {
   }
 
   @Override
-  public Boolean isError() {
+  public boolean isError() {
     return context.getErrorFlag();
   }
 

--- a/dd-trace-ot/src/main/java/datadog/opentracing/OTSpan.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/OTSpan.java
@@ -66,7 +66,7 @@ class OTSpan implements Span, MutableSpan {
   }
 
   @Override
-  public Boolean isError() {
+  public boolean isError() {
     return delegate.isError();
   }
 

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -269,7 +269,7 @@ public class AgentTracer {
     }
 
     @Override
-    public Boolean isError() {
+    public boolean isError() {
       return false;
     }
 


### PR DESCRIPTION
also avoids nullability questions.

This is a breaking binary change for anyone downstream using the `isError()` method, but it should be source compatible (as the Java compiler will handle any boxing-related differences) so they would just need to recompile against the new agent.