### PR TITLE
add jdbc tests for mysql and postgresql

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,6 +133,19 @@ jobs:
       - image: aerospike
         # This is used by mongodb smoke tests
       - image: mongo
+        # This is used by jdbc tests
+      - image: mysql
+        environment:
+          MYSQL_ROOT_PASSWORD: password
+          MYSQL_USER: sa
+          MYSQL_PASSWORD: sa
+          MYSQL_DATABASE: jdbcUnitTest
+        # This is used by jdbc tests
+      - image: postgres
+        environment:
+          POSTGRES_USER: sa
+          POSTGRES_PASSWORD: sa
+          POSTGRES_DB: jdbcUnitTest
 
     parameters:
       testTask:

--- a/dd-java-agent/instrumentation/jdbc/jdbc.gradle
+++ b/dd-java-agent/instrumentation/jdbc/jdbc.gradle
@@ -35,6 +35,12 @@ dependencies {
     force = true
   }
 
+  testCompile group: 'mysql', name: 'mysql-connector-java', version: '8.0.23'
+  testCompile group: 'org.postgresql', name: 'postgresql', version: '42.2.18'
+
+  testCompile "org.testcontainers:mysql:1.15.1"
+  testCompile "org.testcontainers:postgresql:1.15.1"
+
   latestDepTestCompile group: 'com.h2database', name: 'h2', version: '+'
   latestDepTestCompile group: 'org.apache.derby', name: 'derby', version: '10.14.+'
   latestDepTestCompile group: 'org.hsqldb', name: 'hsqldb', version: '+'

--- a/dd-java-agent/instrumentation/jdbc/src/test/groovy/RemoteJDBCInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/jdbc/src/test/groovy/RemoteJDBCInstrumentationTest.groovy
@@ -1,0 +1,479 @@
+import com.mchange.v2.c3p0.ComboPooledDataSource
+import com.zaxxer.hikari.HikariConfig
+import com.zaxxer.hikari.HikariDataSource
+import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.api.DDSpanTypes
+import datadog.trace.bootstrap.instrumentation.api.Tags
+import org.testcontainers.containers.MySQLContainer
+import org.testcontainers.containers.PostgreSQLContainer
+import spock.lang.Requires
+import spock.lang.Shared
+import spock.lang.Unroll
+
+import javax.sql.DataSource
+import java.sql.CallableStatement
+import java.sql.Connection
+import java.sql.Driver
+import java.sql.PreparedStatement
+import java.sql.ResultSet
+import java.sql.Statement
+
+import static datadog.trace.agent.test.utils.TraceUtils.basicSpan
+import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
+import static datadog.trace.api.config.TraceInstrumentationConfig.DB_CLIENT_HOST_SPLIT_BY_INSTANCE
+
+// workaround for SSLHandShakeException on J9 only with Hikari/MySQL
+@Requires({ jvm.java8Compatible && !System.getProperty("java.vendor").contains("IBM") })
+class RemoteJDBCInstrumentationTest extends AgentTestRunner {
+  @Shared
+  def dbName = "jdbcUnitTest"
+
+  @Shared
+  private Map<String, String> jdbcUrls = [
+    "postgresql": "jdbc:postgresql://localhost:5432/$dbName",
+    "mysql"     : "jdbc:mysql://localhost:3306/$dbName"
+  ]
+
+  @Shared
+  private Map<String, String> jdbcDriverClassNames = [
+    "postgresql": "org.postgresql.Driver",
+    "mysql"     : "com.mysql.jdbc.Driver"
+  ]
+
+  @Shared
+  private Map<String, String> jdbcUserNames = [
+    "postgresql": "sa",
+    "mysql"     : "sa"
+  ]
+
+  @Shared
+  private Map<String, String> jdbcPasswords = [
+    "mysql"     : "sa",
+    "postgresql": "sa"
+  ]
+
+  @Shared
+  def postgres
+  @Shared
+  def mysql
+
+  @Shared
+  private Properties peerConnectionProps = {
+    def props = new Properties()
+    props.setProperty("user", "sa")
+    props.setProperty("password", "sa")
+    return props
+  }()
+
+  // JDBC Connection pool name (i.e. HikariCP) -> Map<dbName, Datasource>
+  @Shared
+  private Map<String, Map<String, DataSource>> cpDatasources = new HashMap<>()
+
+  def prepareConnectionPoolDatasources() {
+    String[] connectionPoolNames = [
+      "tomcat", "hikari", "c3p0",
+    ]
+    connectionPoolNames.each {
+      cpName ->
+        Map<String, DataSource> dbDSMapping = new HashMap<>()
+        jdbcUrls.each {
+          dbType, jdbcUrl ->
+            dbDSMapping.put(dbType, createDS(cpName, dbType, jdbcUrl))
+        }
+        cpDatasources.put(cpName, dbDSMapping)
+    }
+  }
+
+  def createTomcatDS(String dbType, String jdbcUrl) {
+    DataSource ds = new org.apache.tomcat.jdbc.pool.DataSource()
+    ds.setUrl(jdbcUrl)
+    ds.setDriverClassName(jdbcDriverClassNames.get(dbType))
+    String username = jdbcUserNames.get(dbType)
+    if (username != null) {
+      ds.setUsername(username)
+    }
+    ds.setPassword(jdbcPasswords.get(dbType))
+    ds.setMaxActive(1) // to test proper caching, having > 1 max active connection will be hard to
+    // determine whether the connection is properly cached
+    return ds
+  }
+
+  def createHikariDS(String dbType, String jdbcUrl) {
+    HikariConfig config = new HikariConfig()
+    config.setJdbcUrl(jdbcUrl)
+    String username = jdbcUserNames.get(dbType)
+    if (username != null) {
+      config.setUsername(username)
+    }
+    config.setPassword(jdbcPasswords.get(dbType))
+    config.addDataSourceProperty("cachePrepStmts", "true")
+    config.addDataSourceProperty("prepStmtCacheSize", "250")
+    config.addDataSourceProperty("prepStmtCacheSqlLimit", "2048")
+    config.setMaximumPoolSize(1)
+
+    return new HikariDataSource(config)
+  }
+
+  def createC3P0DS(String dbType, String jdbcUrl) {
+    DataSource ds = new ComboPooledDataSource()
+    ds.setDriverClass(jdbcDriverClassNames.get(dbType))
+    def jdbcUrlToSet = dbType == "derby" ? jdbcUrl + ";create=true" : jdbcUrl
+    ds.setJdbcUrl(jdbcUrlToSet)
+    String username = jdbcUserNames.get(dbType)
+    if (username != null) {
+      ds.setUser(username)
+    }
+    ds.setPassword(jdbcPasswords.get(dbType))
+    ds.setMaxPoolSize(1)
+    return ds
+  }
+
+  def createDS(String connectionPoolName, String dbType, String jdbcUrl) {
+    DataSource ds = null
+    if (connectionPoolName == "tomcat") {
+      ds = createTomcatDS(dbType, jdbcUrl)
+    }
+    if (connectionPoolName == "hikari") {
+      ds = createHikariDS(dbType, jdbcUrl)
+    }
+    if (connectionPoolName == "c3p0") {
+      ds = createC3P0DS(dbType, jdbcUrl)
+    }
+    return ds
+  }
+
+  @Override
+  void configurePreAgent() {
+    super.configurePreAgent()
+
+    injectSysConfig("dd.trace.jdbc.prepared.statement.class.name", "test.TestPreparedStatement")
+    injectSysConfig("dd.integration.jdbc-datasource.enabled", "true")
+  }
+
+  def setupSpec() {
+    if (System.getenv("CI") != "true") {
+      postgres = new PostgreSQLContainer("postgres:11.1")
+        .withDatabaseName(dbName).withUsername("sa").withPassword("sa")
+      postgres.start()
+      jdbcUrls.put("postgresql", "${postgres.getJdbcUrl()}")
+      mysql = new MySQLContainer("mysql:8.0")
+        .withDatabaseName(dbName).withUsername("sa").withPassword("sa")
+      mysql.start()
+      jdbcUrls.put("mysql", "${mysql.getJdbcUrl()}")
+    }
+    prepareConnectionPoolDatasources()
+  }
+
+  def cleanupSpec() {
+    cpDatasources.values().each {
+      it.values().each {
+        datasource ->
+          if (datasource instanceof Closeable) {
+            datasource.close()
+          }
+      }
+    }
+    postgres?.close()
+    mysql?.close()
+  }
+
+  @Unroll
+  def "basic statement with #connection.getClass().getCanonicalName() on #driver generates spans"() {
+    setup:
+    injectSysConfig(DB_CLIENT_HOST_SPLIT_BY_INSTANCE, "$renameService")
+
+    when:
+    Statement statement = connection.createStatement()
+    ResultSet resultSet = runUnderTrace("parent") {
+      return statement.executeQuery(query)
+    }
+
+    then:
+    resultSet.next()
+    resultSet.getInt(1) == 3
+    assertTraces(1) {
+      trace(2) {
+        basicSpan(it, "parent")
+        span {
+          serviceName renameService ? dbName.toLowerCase() : driver
+          operationName "${driver}.query"
+          resourceName query
+          spanType DDSpanTypes.SQL
+          childOf span(0)
+          errored false
+          topLevel true
+          tags {
+            "$Tags.COMPONENT" "java-jdbc-statement"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" driver
+            "$Tags.DB_INSTANCE" dbName.toLowerCase()
+            "$Tags.PEER_HOSTNAME" String
+            // currently there is a bug in the instrumentation with
+            // postgresql and mysql if the connection event is missed
+            // since Connection.getClientInfo will not provide the username
+            "$Tags.DB_USER" { it == null || it == jdbcUserNames.get(driver) }
+            "$Tags.DB_OPERATION" operation
+            defaultTags()
+          }
+        }
+      }
+    }
+
+    cleanup:
+    statement.close()
+    connection.close()
+
+    where:
+    driver       | connection                                              | renameService | query                   | operation
+    "mysql"      | connectTo(driver, peerConnectionProps)                  | false         | "SELECT 3"              | "SELECT"
+    "postgresql" | connectTo(driver, peerConnectionProps)                  | false         | "SELECT 3 FROM pg_user" | "SELECT"
+    "mysql"      | cpDatasources.get("tomcat").get(driver).getConnection() | false         | "SELECT 3"              | "SELECT"
+    "postgresql" | cpDatasources.get("tomcat").get(driver).getConnection() | false         | "SELECT 3 FROM pg_user" | "SELECT"
+    "mysql"      | cpDatasources.get("hikari").get(driver).getConnection() | false         | "SELECT 3"              | "SELECT"
+    "postgresql" | cpDatasources.get("hikari").get(driver).getConnection() | false         | "SELECT 3 FROM pg_user" | "SELECT"
+    "mysql"      | cpDatasources.get("c3p0").get(driver).getConnection()   | false         | "SELECT 3"              | "SELECT"
+    "postgresql" | cpDatasources.get("c3p0").get(driver).getConnection()   | false         | "SELECT 3 FROM pg_user" | "SELECT"
+  }
+
+  @Unroll
+  def "prepared statement execute on #driver with #connection.getClass().getCanonicalName() generates a span"() {
+    setup:
+    PreparedStatement statement = connection.prepareStatement(query)
+    ResultSet resultSet = runUnderTrace("parent") {
+      assert statement.execute()
+      return statement.resultSet
+    }
+
+    expect:
+    resultSet.next()
+    resultSet.getInt(1) == 3
+    assertTraces(1) {
+      trace(2) {
+        basicSpan(it, "parent")
+        span {
+          operationName "${driver}.query"
+          serviceName driver
+          resourceName query
+          spanType DDSpanTypes.SQL
+          childOf span(0)
+          errored false
+          topLevel true
+          tags {
+            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" driver
+            "$Tags.DB_INSTANCE" dbName.toLowerCase()
+            // only set when there is an out of proc instance (postgresql, mysql)
+            "$Tags.PEER_HOSTNAME" String
+            // currently there is a bug in the instrumentation with
+            // postgresql and mysql if the connection event is missed
+            // since Connection.getClientInfo will not provide the username
+            "$Tags.DB_USER" { it == null || it == jdbcUserNames.get(driver) }
+            "$Tags.DB_OPERATION" operation
+            defaultTags()
+          }
+        }
+      }
+    }
+
+    cleanup:
+    statement.close()
+    connection.close()
+
+    where:
+    driver       | connection                                              | query                   | operation
+    "mysql"      | connectTo(driver, peerConnectionProps)                  | "SELECT 3"              | "SELECT"
+    "postgresql" | connectTo(driver, peerConnectionProps)                  | "SELECT 3 from pg_user" | "SELECT"
+    "mysql"      | cpDatasources.get("tomcat").get(driver).getConnection() | "SELECT 3"              | "SELECT"
+    "postgresql" | cpDatasources.get("tomcat").get(driver).getConnection() | "SELECT 3 from pg_user" | "SELECT"
+    "mysql"      | cpDatasources.get("hikari").get(driver).getConnection() | "SELECT 3"              | "SELECT"
+    "postgresql" | cpDatasources.get("hikari").get(driver).getConnection() | "SELECT 3 from pg_user" | "SELECT"
+    "mysql"      | cpDatasources.get("c3p0").get(driver).getConnection()   | "SELECT 3"              | "SELECT"
+    "postgresql" | cpDatasources.get("c3p0").get(driver).getConnection()   | "SELECT 3 from pg_user" | "SELECT"
+  }
+
+  @Unroll
+  def "prepared statement query on #driver with #connection.getClass().getCanonicalName() generates a span"() {
+    setup:
+    PreparedStatement statement = connection.prepareStatement(query)
+    ResultSet resultSet = runUnderTrace("parent") {
+      return statement.executeQuery()
+    }
+
+    expect:
+    resultSet.next()
+    resultSet.getInt(1) == 3
+    assertTraces(1) {
+      trace(2) {
+        basicSpan(it, "parent")
+        span {
+          operationName "${driver}.query"
+          serviceName driver
+          resourceName query
+          spanType DDSpanTypes.SQL
+          childOf span(0)
+          errored false
+          topLevel true
+          tags {
+            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" driver
+            "$Tags.DB_INSTANCE" dbName.toLowerCase()
+            // only set when there is an out of proc instance (postgresql, mysql)
+            "$Tags.PEER_HOSTNAME" String
+            // currently there is a bug in the instrumentation with
+            // postgresql and mysql if the connection event is missed
+            // since Connection.getClientInfo will not provide the username
+            "$Tags.DB_USER" { it == null || it == jdbcUserNames.get(driver) }
+            "$Tags.DB_OPERATION" operation
+            defaultTags()
+          }
+        }
+      }
+    }
+
+    cleanup:
+    statement.close()
+    connection.close()
+
+    where:
+    driver       | connection                                              | query                   | operation
+    "mysql"      | connectTo(driver, peerConnectionProps)                  | "SELECT 3"              | "SELECT"
+    "postgresql" | connectTo(driver, peerConnectionProps)                  | "SELECT 3 from pg_user" | "SELECT"
+    "mysql"      | cpDatasources.get("tomcat").get(driver).getConnection() | "SELECT 3"              | "SELECT"
+    "postgresql" | cpDatasources.get("tomcat").get(driver).getConnection() | "SELECT 3 from pg_user" | "SELECT"
+    "mysql"      | cpDatasources.get("hikari").get(driver).getConnection() | "SELECT 3"              | "SELECT"
+    "postgresql" | cpDatasources.get("hikari").get(driver).getConnection() | "SELECT 3 from pg_user" | "SELECT"
+    "mysql"      | cpDatasources.get("c3p0").get(driver).getConnection()   | "SELECT 3"              | "SELECT"
+    "postgresql" | cpDatasources.get("c3p0").get(driver).getConnection()   | "SELECT 3 from pg_user" | "SELECT"
+  }
+
+  @Unroll
+  def "prepared call on #driver with #connection.getClass().getCanonicalName() generates a span"() {
+    setup:
+    CallableStatement statement = connection.prepareCall(query)
+    ResultSet resultSet = runUnderTrace("parent") {
+      return statement.executeQuery()
+    }
+
+    expect:
+    resultSet.next()
+    resultSet.getInt(1) == 3
+    assertTraces(1) {
+      trace(2) {
+        basicSpan(it, "parent")
+        span {
+          operationName "${driver}.query"
+          serviceName driver
+          resourceName query
+          spanType DDSpanTypes.SQL
+          childOf span(0)
+          errored false
+          topLevel true
+          tags {
+            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" driver
+            "$Tags.DB_INSTANCE" dbName.toLowerCase()
+            // only set when there is an out of proc instance (postgresql, mysql)
+            "$Tags.PEER_HOSTNAME" String
+            // currently there is a bug in the instrumentation with
+            // postgresql and mysql if the connection event is missed
+            // since Connection.getClientInfo will not provide the username
+            "$Tags.DB_USER" { it == null || it == jdbcUserNames.get(driver) }
+            "${Tags.DB_OPERATION}" operation
+            defaultTags()
+          }
+        }
+      }
+    }
+
+    cleanup:
+    statement.close()
+    connection.close()
+
+    where:
+    driver       | connection                                              | query                   | operation
+    "mysql"      | connectTo(driver, peerConnectionProps)                  | "SELECT 3"              | "SELECT"
+    "postgresql" | connectTo(driver, peerConnectionProps)                  | "SELECT 3 from pg_user" | "SELECT"
+    "mysql"      | cpDatasources.get("tomcat").get(driver).getConnection() | "SELECT 3"              | "SELECT"
+    "postgresql" | cpDatasources.get("tomcat").get(driver).getConnection() | "SELECT 3 from pg_user" | "SELECT"
+    "mysql"      | cpDatasources.get("hikari").get(driver).getConnection() | "SELECT 3"              | "SELECT"
+    "postgresql" | cpDatasources.get("hikari").get(driver).getConnection() | "SELECT 3 from pg_user" | "SELECT"
+    "mysql"      | cpDatasources.get("c3p0").get(driver).getConnection()   | "SELECT 3"              | "SELECT"
+    "postgresql" | cpDatasources.get("c3p0").get(driver).getConnection()   | "SELECT 3 from pg_user" | "SELECT"
+  }
+
+  @Unroll
+  def "statement update on #driver with #connection.getClass().getCanonicalName() generates a span"() {
+    setup:
+    Statement statement = connection.createStatement()
+    def sql = connection.nativeSQL(query)
+
+    expect:
+    runUnderTrace("parent") {
+      return !statement.execute(sql)
+    }
+    statement.updateCount == 0
+    assertTraces(1) {
+      trace(2) {
+        basicSpan(it, "parent")
+        span {
+          operationName "${driver}.query"
+          serviceName driver
+          resourceName query
+          spanType DDSpanTypes.SQL
+          childOf span(0)
+          errored false
+          tags {
+            "$Tags.COMPONENT" "java-jdbc-statement"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" driver
+            "$Tags.DB_INSTANCE" dbName.toLowerCase()
+            // only set when there is an out of proc instance (postgresql, mysql)
+            "$Tags.PEER_HOSTNAME" String
+            // currently there is a bug in the instrumentation with
+            // postgresql and mysql if the connection event is missed
+            // since Connection.getClientInfo will not provide the username
+            "$Tags.DB_USER" { it == null || it == jdbcUserNames.get(driver) }
+            "${Tags.DB_OPERATION}" operation
+            defaultTags()
+          }
+        }
+      }
+    }
+
+    cleanup:
+    statement.close()
+    connection.close()
+
+    where:
+    driver       | connection                                              | query                                                                            | operation
+    "mysql"      | connectTo(driver, peerConnectionProps)                  | "CREATE TEMPORARY TABLE s_test_ (id INTEGER not NULL, PRIMARY KEY ( id ))"       | "CREATE"
+    "postgresql" | connectTo(driver, peerConnectionProps)                  | "CREATE TEMPORARY TABLE s_test (id INTEGER not NULL, PRIMARY KEY ( id ))"        | "CREATE"
+    "mysql"      | cpDatasources.get("tomcat").get(driver).getConnection() | "CREATE TEMPORARY TABLE s_tomcat_test (id INTEGER not NULL, PRIMARY KEY ( id ))" | "CREATE"
+    "postgresql" | cpDatasources.get("tomcat").get(driver).getConnection() | "CREATE TEMPORARY TABLE s_tomcat_test (id INTEGER not NULL, PRIMARY KEY ( id ))" | "CREATE"
+    "mysql"      | cpDatasources.get("hikari").get(driver).getConnection() | "CREATE TEMPORARY TABLE s_hikari_test (id INTEGER not NULL, PRIMARY KEY ( id ))" | "CREATE"
+    "postgresql" | cpDatasources.get("hikari").get(driver).getConnection() | "CREATE TEMPORARY TABLE s_hikari_test (id INTEGER not NULL, PRIMARY KEY ( id ))" | "CREATE"
+    "mysql"      | cpDatasources.get("c3p0").get(driver).getConnection()   | "CREATE TEMPORARY TABLE s_c3p0_test (id INTEGER not NULL, PRIMARY KEY ( id ))"   | "CREATE"
+    "postgresql" | cpDatasources.get("c3p0").get(driver).getConnection()   | "CREATE TEMPORARY TABLE s_c3p0_test (id INTEGER not NULL, PRIMARY KEY ( id ))"   | "CREATE"
+  }
+
+  Driver driverFor(String db) {
+    return newDriver(jdbcDriverClassNames.get(db))
+  }
+
+  Connection connectTo(String db, Properties properties) {
+    return connect(jdbcDriverClassNames.get(db), jdbcUrls.get(db), properties)
+  }
+
+  Driver newDriver(String driverClass) {
+    return ((Driver) Class.forName(driverClass)
+      .getDeclaredConstructor().newInstance())
+  }
+
+  Connection connect(String driverClass, String url, Properties properties) {
+    return newDriver(driverClass)
+      .connect(url, properties)
+  }
+}


### PR DESCRIPTION
This test needs some refactoring to support multiple drivers against the same db, e.g. mariadb-client/mysql-connector running against mysql.