### PR TITLE
Limit heap and concurrency for the generated forkedTest tasks

### DIFF
--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -384,7 +384,10 @@ tasks.withType(Test).configureEach {
   // Split up tests that want to run forked in their own separate JVM for generated tasks
   if (name.startsWith("forkedTest") || name.endsWith("ForkedTest")) {
     setIncludes(["**/*ForkedTest*"])
+    jvmArgs += ["-Xms256M", "-Xmx256M"]
     forkEvery 1
+    // Limit the number of concurrent forked tests
+    usesService(forkedTestLimit)
   } else {
     exclude("**/*ForkedTest*")
   }


### PR DESCRIPTION
Missed this in #2352 , and just got timeouts on CI for `latestDepForkedTest`