### PR TITLE
Update global ignores to add new java_concurrent Wrapper

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/GlobalIgnoresMatcher.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/GlobalIgnoresMatcher.java
@@ -100,8 +100,6 @@ public class GlobalIgnoresMatcher<T extends TypeDescription>
             // https://github.com/raphw/byte-buddy/issues/558 is fixed
             return !name.equals(
                     "datadog.trace.bootstrap.instrumentation.java.concurrent.RunnableWrapper")
-                && !name.equals(
-                    "datadog.trace.bootstrap.instrumentation.java.concurrent.CallableWrapper")
                 && !name.equals("datadog.trace.bootstrap.instrumentation.java.concurrent.Wrapper");
           }
         }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/GlobalIgnoresMatcher.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/GlobalIgnoresMatcher.java
@@ -101,7 +101,8 @@ public class GlobalIgnoresMatcher<T extends TypeDescription>
             return !name.equals(
                     "datadog.trace.bootstrap.instrumentation.java.concurrent.RunnableWrapper")
                 && !name.equals(
-                    "datadog.trace.bootstrap.instrumentation.java.concurrent.CallableWrapper");
+                    "datadog.trace.bootstrap.instrumentation.java.concurrent.CallableWrapper")
+                && !name.equals("datadog.trace.bootstrap.instrumentation.java.concurrent.Wrapper");
           }
         }
         break;


### PR DESCRIPTION
... also remove stale reference to `CallableWrapper` which was removed in #1973