### PR TITLE
Remove stale reference to CallableWrapper which was removed in #1973

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/GlobalIgnoresMatcher.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/GlobalIgnoresMatcher.java
@@ -99,9 +99,7 @@ public class GlobalIgnoresMatcher<T extends TypeDescription>
             // FIXME: We should remove this once
             // https://github.com/raphw/byte-buddy/issues/558 is fixed
             return !name.equals(
-                    "datadog.trace.bootstrap.instrumentation.java.concurrent.RunnableWrapper")
-                && !name.equals(
-                    "datadog.trace.bootstrap.instrumentation.java.concurrent.CallableWrapper");
+                "datadog.trace.bootstrap.instrumentation.java.concurrent.RunnableWrapper");
           }
         }
         break;


### PR DESCRIPTION
Avoids checking for something that no longer exists :)