### PR TITLE
Make test socket timeouts longer

### DIFF
--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
@@ -28,8 +28,8 @@ import static org.junit.Assume.assumeTrue
 @Unroll
 abstract class HttpClientTest extends AgentTestRunner {
   protected static final BODY_METHODS = ["POST", "PUT"]
-  protected static final CONNECT_TIMEOUT_MS = 1000
-  protected static final READ_TIMEOUT_MS = 2000
+  protected static final CONNECT_TIMEOUT_MS = 3000
+  protected static final READ_TIMEOUT_MS = 5000
   protected static final BASIC_AUTH_KEY = "custom_authorization_header"
   protected static final BASIC_AUTH_VAL = "plain text auth token"
 


### PR DESCRIPTION
The most common failure right now is a read or connect timeout in an http client test.