### PR TITLE
Delay starting JMXFetch (15s to match default check period)

### DIFF
--- a/dd-java-agent/src/test/groovy/datadog/trace/agent/CustomLogManagerTest.groovy
+++ b/dd-java-agent/src/test/groovy/datadog/trace/agent/CustomLogManagerTest.groovy
@@ -18,7 +18,11 @@ class CustomLogManagerTest extends Specification {
   def "agent services starts up in premain with no custom log manager set"() {
     expect:
     IntegrationTestUtils.runOnSeparateJvm(LogManagerSetter.getName()
-      , ["-Ddd.jmxfetch.enabled=true", "-Ddd.jmxfetch.refresh-beans-period=1", "-Ddd.profiling.enabled=true", "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=$DEFAULT_LOG_LEVEL"] as String[]
+      , ["-Ddd.jmxfetch.enabled=true",
+         "-Ddd.jmxfetch.start-delay=0",
+         "-Ddd.jmxfetch.refresh-beans-period=1",
+         "-Ddd.profiling.enabled=true",
+         "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=$DEFAULT_LOG_LEVEL"] as String[]
       , "" as String[]
       , ["DD_API_KEY": API_KEY]
       , true) == 0
@@ -27,7 +31,12 @@ class CustomLogManagerTest extends Specification {
   def "agent services starts up in premain if configured log manager on system classpath"() {
     expect:
     IntegrationTestUtils.runOnSeparateJvm(LogManagerSetter.getName()
-      , ["-Ddd.jmxfetch.enabled=true", "-Ddd.jmxfetch.refresh-beans-period=1", "-Ddd.profiling.enabled=true", "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=$DEFAULT_LOG_LEVEL", "-Djava.util.logging.manager=jvmbootstraptest.CustomLogManager"] as String[]
+      , ["-Ddd.jmxfetch.enabled=true",
+         "-Ddd.jmxfetch.start-delay=0",
+         "-Ddd.jmxfetch.refresh-beans-period=1",
+         "-Ddd.profiling.enabled=true",
+         "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=$DEFAULT_LOG_LEVEL",
+         "-Djava.util.logging.manager=jvmbootstraptest.CustomLogManager"] as String[]
       , "" as String[]
       , ["DD_API_KEY": API_KEY]
       , true) == 0
@@ -36,7 +45,12 @@ class CustomLogManagerTest extends Specification {
   def "agent services startup is delayed with java.util.logging.manager sysprop"() {
     expect:
     IntegrationTestUtils.runOnSeparateJvm(LogManagerSetter.getName()
-      , ["-Ddd.jmxfetch.enabled=true", "-Ddd.jmxfetch.refresh-beans-period=1", "-Ddd.profiling.enabled=true", "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=$DEFAULT_LOG_LEVEL", "-Djava.util.logging.manager=jvmbootstraptest.MissingLogManager"] as String[]
+      , ["-Ddd.jmxfetch.enabled=true",
+         "-Ddd.jmxfetch.start-delay=0",
+         "-Ddd.jmxfetch.refresh-beans-period=1",
+         "-Ddd.profiling.enabled=true",
+         "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=$DEFAULT_LOG_LEVEL",
+         "-Djava.util.logging.manager=jvmbootstraptest.MissingLogManager"] as String[]
       , "" as String[]
       , ["DD_API_KEY": API_KEY]
       , true) == 0
@@ -45,7 +59,12 @@ class CustomLogManagerTest extends Specification {
   def "agent services startup delayed with tracer custom log manager setting"() {
     expect:
     IntegrationTestUtils.runOnSeparateJvm(LogManagerSetter.getName()
-      , ["-Ddd.jmxfetch.enabled=true", "-Ddd.jmxfetch.refresh-beans-period=1", "-Ddd.profiling.enabled=true", "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=$DEFAULT_LOG_LEVEL", "-Ddd.app.customlogmanager=true"] as String[]
+      , ["-Ddd.jmxfetch.enabled=true",
+         "-Ddd.jmxfetch.start-delay=0",
+         "-Ddd.jmxfetch.refresh-beans-period=1",
+         "-Ddd.profiling.enabled=true",
+         "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=$DEFAULT_LOG_LEVEL",
+         "-Ddd.app.customlogmanager=true"] as String[]
       , "" as String[]
       , ["DD_API_KEY": API_KEY]
       , true) == 0
@@ -54,7 +73,12 @@ class CustomLogManagerTest extends Specification {
   def "agent services startup delayed with JBOSS_HOME environment variable"() {
     expect:
     IntegrationTestUtils.runOnSeparateJvm(LogManagerSetter.getName()
-      , ["-Ddd.jmxfetch.enabled=true", "-Ddd.jmxfetch.refresh-beans-period=1", "-Ddd.profiling.enabled=true", "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=$DEFAULT_LOG_LEVEL"] as String[]
+      , ["-Ddd.jmxfetch.enabled=true",
+         "-Ddd.jmxfetch.start-delay=0",
+         "-Ddd.jmxfetch.refresh-beans-period=1",
+         "-Ddd.profiling.enabled=true",
+         "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=$DEFAULT_LOG_LEVEL",
+         "-Ddd.app.customjmxbuilder=false"] as String[]
       , "" as String[]
       , ["JBOSS_HOME": "/", "DD_API_KEY": API_KEY]
       , true) == 0
@@ -63,7 +87,14 @@ class CustomLogManagerTest extends Specification {
   def "agent services startup in premain forced by customlogmanager=false"() {
     expect:
     IntegrationTestUtils.runOnSeparateJvm(LogManagerSetter.getName()
-      , ["-Ddd.jmxfetch.enabled=true", "-Ddd.jmxfetch.refresh-beans-period=1", "-Ddd.profiling.enabled=true", "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=$DEFAULT_LOG_LEVEL", "-Ddd.app.customlogmanager=false", "-Djava.util.logging.manager=jvmbootstraptest.CustomLogManager"] as String[]
+      , ["-Ddd.jmxfetch.enabled=true",
+         "-Ddd.jmxfetch.start-delay=0",
+         "-Ddd.jmxfetch.refresh-beans-period=1",
+         "-Ddd.profiling.enabled=true",
+         "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=$DEFAULT_LOG_LEVEL",
+         "-Ddd.app.customlogmanager=false",
+         "-Ddd.app.customjmxbuilder=false",
+         "-Djava.util.logging.manager=jvmbootstraptest.CustomLogManager"] as String[]
       , "" as String[]
       , ["JBOSS_HOME": "/", "DD_API_KEY": API_KEY]
       , true) == 0

--- a/dd-java-agent/src/test/groovy/datadog/trace/agent/CustomMBeanServerBuilderTest.groovy
+++ b/dd-java-agent/src/test/groovy/datadog/trace/agent/CustomMBeanServerBuilderTest.groovy
@@ -15,7 +15,11 @@ class CustomMBeanServerBuilderTest extends Specification {
   def "JMXFetch starts up in premain with no custom MBeanServerBuilder set"() {
     expect:
     IntegrationTestUtils.runOnSeparateJvm(MBeanServerBuilderSetter.getName()
-      , ["-Ddd.jmxfetch.enabled=true", "-Ddd.jmxfetch.refresh-beans-period=1", "-Ddd.profiling.enabled=true", "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=$DEFAULT_LOG_LEVEL"] as String[]
+      , ["-Ddd.jmxfetch.enabled=true",
+         "-Ddd.jmxfetch.start-delay=0",
+         "-Ddd.jmxfetch.refresh-beans-period=1",
+         "-Ddd.profiling.enabled=true",
+         "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=$DEFAULT_LOG_LEVEL"] as String[]
       , "" as String[]
       , ["DD_API_KEY": API_KEY]
       , true) == 0
@@ -24,7 +28,12 @@ class CustomMBeanServerBuilderTest extends Specification {
   def "JMXFetch starts up in premain if configured MBeanServerBuilder on system classpath"() {
     expect:
     IntegrationTestUtils.runOnSeparateJvm(MBeanServerBuilderSetter.getName()
-      , ["-Ddd.jmxfetch.enabled=true", "-Ddd.jmxfetch.refresh-beans-period=1", "-Ddd.profiling.enabled=true", "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=$DEFAULT_LOG_LEVEL", "-Djavax.management.builder.initial=jvmbootstraptest.CustomMBeanServerBuilder"] as String[]
+      , ["-Ddd.jmxfetch.enabled=true",
+         "-Ddd.jmxfetch.start-delay=0",
+         "-Ddd.jmxfetch.refresh-beans-period=1",
+         "-Ddd.profiling.enabled=true",
+         "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=$DEFAULT_LOG_LEVEL",
+         "-Djavax.management.builder.initial=jvmbootstraptest.CustomMBeanServerBuilder"] as String[]
       , "" as String[]
       , ["DD_API_KEY": API_KEY]
       , true) == 0
@@ -33,7 +42,12 @@ class CustomMBeanServerBuilderTest extends Specification {
   def "JMXFetch startup is delayed with javax.management.builder.initial sysprop"() {
     expect:
     IntegrationTestUtils.runOnSeparateJvm(MBeanServerBuilderSetter.getName()
-      , ["-Ddd.jmxfetch.enabled=true", "-Ddd.jmxfetch.refresh-beans-period=1", "-Ddd.profiling.enabled=true", "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=$DEFAULT_LOG_LEVEL", "-Djavax.management.builder.initial=jvmbootstraptest.MissingMBeanServerBuilder"] as String[]
+      , ["-Ddd.jmxfetch.enabled=true",
+         "-Ddd.jmxfetch.start-delay=0",
+         "-Ddd.jmxfetch.refresh-beans-period=1",
+         "-Ddd.profiling.enabled=true",
+         "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=$DEFAULT_LOG_LEVEL",
+         "-Djavax.management.builder.initial=jvmbootstraptest.MissingMBeanServerBuilder"] as String[]
       , "" as String[]
       , ["DD_API_KEY": API_KEY]
       , true) == 0
@@ -42,7 +56,12 @@ class CustomMBeanServerBuilderTest extends Specification {
   def "JMXFetch startup is delayed with tracer custom JMX builder setting"() {
     expect:
     IntegrationTestUtils.runOnSeparateJvm(MBeanServerBuilderSetter.getName()
-      , ["-Ddd.jmxfetch.enabled=true", "-Ddd.jmxfetch.refresh-beans-period=1", "-Ddd.profiling.enabled=true", "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=$DEFAULT_LOG_LEVEL", "-Ddd.app.customjmxbuilder=true"] as String[]
+      , ["-Ddd.jmxfetch.enabled=true",
+         "-Ddd.jmxfetch.start-delay=0",
+         "-Ddd.jmxfetch.refresh-beans-period=1",
+         "-Ddd.profiling.enabled=true",
+         "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=$DEFAULT_LOG_LEVEL",
+         "-Ddd.app.customjmxbuilder=true"] as String[]
       , "" as String[]
       , ["DD_API_KEY": API_KEY]
       , true) == 0
@@ -51,7 +70,13 @@ class CustomMBeanServerBuilderTest extends Specification {
   def "JMXFetch starts up in premain forced by customjmxbuilder=false"() {
     expect:
     IntegrationTestUtils.runOnSeparateJvm(MBeanServerBuilderSetter.getName()
-      , ["-Ddd.jmxfetch.enabled=true", "-Ddd.jmxfetch.refresh-beans-period=1", "-Ddd.profiling.enabled=true", "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=$DEFAULT_LOG_LEVEL", "-Ddd.app.customjmxbuilder=false", "-Djavax.management.builder.initial=jvmbootstraptest.CustomMBeanServerBuilder"] as String[]
+      , ["-Ddd.jmxfetch.enabled=true",
+         "-Ddd.jmxfetch.start-delay=0",
+         "-Ddd.jmxfetch.refresh-beans-period=1",
+         "-Ddd.profiling.enabled=true",
+         "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=$DEFAULT_LOG_LEVEL",
+         "-Ddd.app.customjmxbuilder=false",
+         "-Djavax.management.builder.initial=jvmbootstraptest.CustomMBeanServerBuilder"] as String[]
       , "" as String[]
       , ["DD_API_KEY": API_KEY]
       , true) == 0

--- a/dd-java-agent/src/test/groovy/datadog/trace/agent/JMXFetchTest.groovy
+++ b/dd-java-agent/src/test/groovy/datadog/trace/agent/JMXFetchTest.groovy
@@ -22,6 +22,7 @@ class JMXFetchTest extends Specification {
     DatagramSocket socket = new DatagramSocket(0)
 
     System.setProperty("dd.jmxfetch.enabled", "true")
+    System.setProperty("dd.jmxfetch.start-delay", "0")
     System.setProperty("dd.jmxfetch.statsd.port", Integer.toString(socket.localPort))
     // Overwrite writer type to disable console jmxfetch reporter
     System.setProperty("dd.writer.type", "DDAgentWriter")
@@ -56,7 +57,9 @@ class JMXFetchTest extends Specification {
     // verify the agent starts up correctly with a bogus address.
     expect:
     IntegrationTestUtils.runOnSeparateJvm(AgentLoadedChecker.getName()
-      , ["-Ddd.jmxfetch.enabled=true", "-Ddd.jmxfetch.statsd.host=example.local"] as String[]
+      , ["-Ddd.jmxfetch.enabled=true",
+         "-Ddd.jmxfetch.start-delay=0",
+         "-Ddd.jmxfetch.statsd.host=example.local"] as String[]
       , "" as String[]
       , [:]
       , true) == 0


### PR DESCRIPTION
Delay starting JMX related services in agent bootstrap 

Defaults to 15 seconds, can be configured with `-Ddd.jmxfetch.start-delay` or `DD_JMXFETCH_START_DELAY`