### PR TITLE
update byte-buddy to 1.10.20

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/DDCachingPoolStrategy.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/DDCachingPoolStrategy.java
@@ -109,6 +109,13 @@ public class DDCachingPoolStrategy implements PoolStrategy {
     return createCachingTypePool(loaderHash, loaderRef, classFileLocator);
   }
 
+  public final TypePool typePool(
+      final ClassFileLocator classFileLocator, final ClassLoader classLoader, final String name) {
+    // FIXME satisfy interface constraint that the currently instrumented type is not used in the
+    // cache
+    return typePool(classFileLocator, classLoader);
+  }
+
   private TypePool.CacheProvider createCacheProvider(
       final int loaderHash, final WeakReference<ClassLoader> loaderRef) {
     return new SharedResolutionCacheAdapter(

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -13,7 +13,7 @@ ext {
     junit5        : "5.6.2",
     logback       : "1.2.3",
     lombok        : "1.18.10",
-    bytebuddy     : "1.10.19",
+    bytebuddy     : "1.10.20",
     scala         : "2.11.12",  // Last version to support Java 7 (2.12+ require Java 8+)
     scala210      : "2.10.7",
     scala211      : "2.11.12",


### PR DESCRIPTION
This update has a low impact optimisation which prevents from allocating matchers which can be constant. See [release notes](https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.10.20)