### PR TITLE
increase timeout in testNoReplyFromServer which fails a lot in CI

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-uploader/src/test/java/com/datadog/profiling/uploader/ProfileUploaderTest.java
+++ b/dd-java-agent/agent-profiling/profiling-uploader/src/test/java/com/datadog/profiling/uploader/ProfileUploaderTest.java
@@ -390,7 +390,7 @@ public class ProfileUploaderTest {
 
   @Test
   public void testNoReplyFromServer() throws IOException, InterruptedException {
-    server.enqueue(new MockResponse().setBodyDelay(10, TimeUnit.SECONDS));
+    server.enqueue(new MockResponse().setBodyDelay(30, TimeUnit.SECONDS));
     final RecordingData recording = mockRecordingData(RECORDING_RESOURCE);
     uploader.upload(RECORDING_TYPE, recording);
 


### PR DESCRIPTION
This test fails all the time in CI and increasing its timeout has been suggested by its author as a possible resolution.