### PR TITLE
remove THREAD_PREFIX id generation strategy

### DIFF
--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/AgentTestRunner.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/AgentTestRunner.groovy
@@ -36,7 +36,7 @@ import java.util.concurrent.TimeoutException
 import java.util.concurrent.atomic.AtomicInteger
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.AdditionalLibraryIgnoresMatcher.additionalLibraryIgnoresMatcher
-import static datadog.trace.api.IdGenerationStrategy.THREAD_PREFIX
+import static datadog.trace.api.IdGenerationStrategy.SEQUENTIAL
 
 /**
  * A spock test runner which automatically applies instrumentation and exposes a global trace
@@ -123,7 +123,7 @@ abstract class AgentTestRunner extends DDSpecification implements AgentBuilder.L
     TEST_TRACER =
       CoreTracer.builder()
         .writer(TEST_WRITER)
-        .idGenerationStrategy(THREAD_PREFIX)
+        .idGenerationStrategy(SEQUENTIAL)
         .statsDClient(STATS_D_CLIENT)
         .strictTraceWrites(useStrictTraceWrites())
         .build()

--- a/dd-trace-api/src/main/java/datadog/trace/api/IdGenerationStrategy.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/IdGenerationStrategy.java
@@ -1,7 +1,6 @@
 package datadog.trace.api;
 
 import java.util.concurrent.ThreadLocalRandom;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 public enum IdGenerationStrategy {
@@ -17,23 +16,6 @@ public enum IdGenerationStrategy {
     @Override
     public DDId generate() {
       return DDId.from(id.incrementAndGet());
-    }
-  },
-  // DON'T USE THIS IN PRODUCTION - USEFUL FOR DEBUGGING WHICH THREAD IDS WERE CREATED ON
-  THREAD_PREFIX {
-    private final AtomicInteger id = new AtomicInteger(0);
-    private final AtomicInteger prefix = new AtomicInteger(0);
-    private final ThreadLocal<Integer> tls =
-        new ThreadLocal<Integer>() {
-          @Override
-          protected Integer initialValue() {
-            return prefix.getAndIncrement();
-          }
-        };
-
-    @Override
-    public DDId generate() {
-      return DDId.from((tls.get().longValue() << 32) | id.incrementAndGet());
     }
   };
 


### PR DESCRIPTION
This was never actually used for its intended purpose and now that context propagation works well, it will never serve any purpose, except to potentially create lots of thread locals.