### PR TITLE
Update Gradle to 6.8.2

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=a7ca23b3ccf265680f2bfd35f1f00b1424f4466292c7337c85d46c9641b3f053
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-all.zip
+distributionSha256Sum=1433372d903ffba27496f8d5af24265310d2da0d78bf6b4e5138831d4fe066e9
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
https://docs.gradle.org/6.8.2/release-notes.html

* fixes performance regression when file system watching is enabled on macOS / Windows
* [improved toolchain support](https://docs.gradle.org/6.8.2/release-notes.html#java-toolchain-improvements)
* [option to mark tests as flaky when re-running](https://docs.gradle.org/6.8.2/release-notes.html#test-re-run-junit-xml-reporting-enhancements)