### PR TITLE
remove test which targets a blocked port at google.com

### DIFF
--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
@@ -423,31 +423,6 @@ abstract class HttpClientTest extends AgentTestRunner {
     method = "GET"
   }
 
-  def "connection error dropped request"() {
-    given:
-    assumeTrue(testRemoteConnection())
-    // https://stackoverflow.com/a/100859
-    def uri = new URI("http://www.google.com:81/")
-
-    when:
-    runUnderTrace("parent") {
-      doRequest(method, uri)
-    }
-
-    then:
-    def ex = thrown(Exception)
-    def thrownException = ex instanceof ExecutionException ? ex.cause : ex
-    assertTraces(1) {
-      trace(size(2)) {
-        basicSpan(it, "parent", null, thrownException)
-        clientSpan(it, span(0), method, false, false, uri, null, thrownException)
-      }
-    }
-
-    where:
-    method = "HEAD"
-  }
-
   def "connection error non routable address"() {
     given:
     assumeTrue(testRemoteConnection())


### PR DESCRIPTION
I'm not sure this was testing anything `connection error non routable address` wasn't, so I've removed the test