### PR TITLE
Make Hystrix tests pass in strict mode and miscellaneous improvements

### DIFF
--- a/dd-java-agent/instrumentation/hystrix-1.4/src/main/java/datadog/trace/instrumentation/hystrix/HystrixDecorator.java
+++ b/dd-java-agent/instrumentation/hystrix-1.4/src/main/java/datadog/trace/instrumentation/hystrix/HystrixDecorator.java
@@ -12,7 +12,6 @@ import datadog.trace.api.cache.DDCaches;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.BaseDecorator;
-import java.util.Objects;
 
 public class HystrixDecorator extends BaseDecorator {
   public static HystrixDecorator DECORATE = new HystrixDecorator();
@@ -29,11 +28,11 @@ public class HystrixDecorator extends BaseDecorator {
 
   public static final CharSequence HYSTRIX = UTF8BytesString.create("hystrix");
 
-  private static final DDCache<ResourceNameCacheKey, String> RESOURCE_NAME_CACHE =
+  private static final DDCache<ResourceNameCacheKey, UTF8BytesString> RESOURCE_NAME_CACHE =
       DDCaches.newFixedSizeCache(64);
 
-  private static final Functions.ToString<ResourceNameCacheKey> TO_STRING =
-      new Functions.ToString<>();
+  private static final Functions.ToUTF8String<ResourceNameCacheKey> TO_STRING =
+      new Functions.ToUTF8String<>();
 
   private static final class ResourceNameCacheKey {
     private final String group;
@@ -52,8 +51,7 @@ public class HystrixDecorator extends BaseDecorator {
 
     @Override
     public boolean equals(Object o) {
-      if (this == o) return true;
-      if (o == null || getClass() != o.getClass()) return false;
+      if (!(o instanceof ResourceNameCacheKey)) return false;
       ResourceNameCacheKey cacheKey = (ResourceNameCacheKey) o;
       return group.equals(cacheKey.group)
           && command.equals(cacheKey.command)
@@ -62,7 +60,7 @@ public class HystrixDecorator extends BaseDecorator {
 
     @Override
     public int hashCode() {
-      return Objects.hash(group, command, methodName);
+      return 961 * group.hashCode() + 31 * command.hashCode() + methodName.hashCode();
     }
   }
 

--- a/dd-java-agent/instrumentation/hystrix-1.4/src/test/groovy/HystrixObservableChainTest.groovy
+++ b/dd-java-agent/instrumentation/hystrix-1.4/src/test/groovy/HystrixObservableChainTest.groovy
@@ -12,12 +12,6 @@ import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 class HystrixObservableChainTest extends AgentTestRunner {
 
   @Override
-  boolean useStrictTraceWrites() {
-    // TODO fix this by making sure that spans get closed properly
-    return false
-  }
-
-  @Override
   void configurePreAgent() {
     super.configurePreAgent()
 

--- a/dd-java-agent/instrumentation/hystrix-1.4/src/test/groovy/HystrixObservableTest.groovy
+++ b/dd-java-agent/instrumentation/hystrix-1.4/src/test/groovy/HystrixObservableTest.groovy
@@ -17,12 +17,6 @@ import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 class HystrixObservableTest extends AgentTestRunner {
 
   @Override
-  boolean useStrictTraceWrites() {
-    // TODO fix this by making sure that spans get closed properly
-    return false
-  }
-
-  @Override
   void configurePreAgent() {
     super.configurePreAgent()
 

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/DisableAsyncPropagationWithinConstructorInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/DisableAsyncPropagationWithinConstructorInstrumentation.java
@@ -1,0 +1,55 @@
+package datadog.trace.instrumentation.java.concurrent;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
+import static java.util.Collections.singletonMap;
+import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.context.TraceScope;
+import java.util.Map;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+@AutoService(Instrumenter.class)
+public class DisableAsyncPropagationWithinConstructorInstrumentation extends Instrumenter.Tracing {
+  public DisableAsyncPropagationWithinConstructorInstrumentation() {
+    super(AbstractExecutorInstrumentation.EXEC_NAME);
+  }
+
+  @Override
+  public ElementMatcher<? super TypeDescription> typeMatcher() {
+    return namedOneOf("rx.schedulers.CachedThreadScheduler$CachedWorkerPool");
+  }
+
+  @Override
+  public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
+    return singletonMap(isConstructor(), getClass().getName() + "$DisableAsyncPropagation");
+  }
+
+  public static final class DisableAsyncPropagation {
+    @Advice.OnMethodEnter
+    public static boolean before() {
+      TraceScope scope = activeScope();
+      if (null != scope) {
+        boolean wasEnabled = scope.isAsyncPropagating();
+        scope.setAsyncPropagation(false);
+        return wasEnabled;
+      }
+      return false;
+    }
+
+    @Advice.OnMethodExit
+    public static void after(@Advice.Enter boolean wasEnabled) {
+      if (wasEnabled) {
+        TraceScope scope = activeScope();
+        if (null != scope) {
+          scope.setAsyncPropagation(wasEnabled);
+        }
+      }
+    }
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/Functions.java
+++ b/internal-api/src/main/java/datadog/trace/api/Functions.java
@@ -170,4 +170,12 @@ public final class Functions {
       return key.toString();
     }
   }
+
+  public static final class ToUTF8String<T> implements Function<T, UTF8BytesString> {
+
+    @Override
+    public UTF8BytesString apply(T key) {
+      return UTF8BytesString.create(key.toString());
+    }
+  }
 }

--- a/internal-api/src/test/groovy/datadog/trace/api/FunctionsTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/FunctionsTest.groovy
@@ -9,11 +9,12 @@ class FunctionsTest extends DDSpecification {
     when:
     CharSequence output = fn.apply(input)
     then:
-    output == expected
+    output as String == expected
     where:
-    fn                               | input | expected
-    Functions.LowerCase.INSTANCE     | "xYz" | "xyz"
-    new Functions.ToString<String>() | "xYz" | "xYz"
+    fn                                   | input | expected
+    Functions.LowerCase.INSTANCE         | "xYz" | "xyz"
+    new Functions.ToString<String>()     | "xYz" | "xYz"
+    new Functions.ToUTF8String<String>() | "xYz" | "xYz"
   }
 
 
@@ -30,7 +31,7 @@ class FunctionsTest extends DDSpecification {
     Functions.SuffixJoin.of("~")                   | "x"  | "y"   | "x~y"
   }
 
-  def "test encode UTF8" () {
+  def "test encode UTF8"() {
     when:
     UTF8BytesString utf8 = Functions.UTF8_ENCODE.apply("foo")
     then:


### PR DESCRIPTION
* run the tests in strict mode, disable async propagation when rx workers are being set up to make this work
* minor improvements to `ResourceNameHashKey` - create `UTF8BytesString` resource name, never allocate varargs in hashing (these can usually be eliminated but not on all JVMs)
* Avoid transforming some known `Runnable`s