### PR TITLE
HttpServerDecorator performance tweaks

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
@@ -10,7 +10,6 @@ import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import java.util.BitSet;
-import java.util.regex.Pattern;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -18,11 +17,6 @@ public abstract class HttpServerDecorator<REQUEST, CONNECTION, RESPONSE> extends
   public static final String DD_SPAN_ATTRIBUTE = "datadog.span";
   public static final String DD_DISPATCH_SPAN_ATTRIBUTE = "datadog.span.dispatch";
   public static final String DD_RESPONSE_ATTRIBUTE = "datadog.response";
-
-  // Source: https://www.regextester.com/22
-  private static final Pattern VALID_IPV4_ADDRESS =
-      Pattern.compile(
-          "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$");
 
   private static final BitSet SERVER_ERROR_STATUSES = Config.get().getHttpServerErrorStatuses();
 
@@ -101,10 +95,10 @@ public abstract class HttpServerDecorator<REQUEST, CONNECTION, RESPONSE> extends
     if (connection != null) {
       final String ip = peerHostIP(connection);
       if (ip != null) {
-        if (VALID_IPV4_ADDRESS.matcher(ip).matches()) {
-          span.setTag(Tags.PEER_HOST_IPV4, ip);
-        } else if (ip.contains(":")) {
+        if (ip.indexOf(':') > 0) {
           span.setTag(Tags.PEER_HOST_IPV6, ip);
+        } else {
+          span.setTag(Tags.PEER_HOST_IPV4, ip);
         }
       }
 

--- a/dd-java-agent/instrumentation/tomcat-5.5/src/main/java/datadog/trace/instrumentation/tomcat/TomcatDecorator.java
+++ b/dd-java-agent/instrumentation/tomcat-5.5/src/main/java/datadog/trace/instrumentation/tomcat/TomcatDecorator.java
@@ -53,13 +53,16 @@ public class TomcatDecorator extends HttpServerDecorator<Request, Request, Respo
 
   @Override
   public AgentSpan onRequest(final AgentSpan span, final Request request) {
-    assert span != null;
     if (request != null) {
       String contextPath = request.getContextPath();
       String servletPath = request.getServletPath();
 
-      span.setTag("servlet.context", contextPath);
-      span.setTag("servlet.path", servletPath);
+      if (null != contextPath && !contextPath.isEmpty()) {
+        span.setTag("servlet.context", contextPath);
+      }
+      if (null != servletPath && !servletPath.isEmpty()) {
+        span.setTag("servlet.path", servletPath);
+      }
 
       // Used by AsyncContextInstrumentation because the context path may be reset
       // by the time the async context is dispatched.


### PR DESCRIPTION
Some of what's changed here really adds up, larger than e.g starting or finishing spans

![Screenshot 2021-02-10 at 15 56 26](https://user-images.githubusercontent.com/16439049/107561536-8eecf780-6bd6-11eb-939e-f64bead6e150.png)

* IPV4 regex validation towards the left
* Removing tags from an empty map in `TomcatDecorator` because the attributes are null (purple bar in the middle)
* Building the normalised URL (yellow bar to the right)
