### PR TITLE
prevent application threads from interacting directly with StatsD

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/DDAgentWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/DDAgentWriter.java
@@ -171,6 +171,7 @@ public class DDAgentWriter implements Writer {
   public void start() {
     if (!closed) {
       traceProcessingWorker.start();
+      healthMetrics.start();
       healthMetrics.onStart((int) getCapacity());
     }
   }
@@ -180,6 +181,7 @@ public class DDAgentWriter implements Writer {
     final boolean flushed = flush();
     closed = true;
     traceProcessingWorker.close();
+    healthMetrics.close();
     healthMetrics.onShutdown(flushed);
   }
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterCombinedTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterCombinedTest.groovy
@@ -243,6 +243,7 @@ class DDAgentWriterCombinedTest extends DDCoreSpecification {
     1 * healthMetrics.onFailedPublish(_)
     1 * healthMetrics.onFlush(_)
     1 * healthMetrics.onShutdown(_)
+    1 * healthMetrics.close()
     0 * _
 
     cleanup:
@@ -639,18 +640,14 @@ class DDAgentWriterCombinedTest extends DDCoreSpecification {
       }
     }
 
-    def statsd = Stub(StatsDClient)
-    statsd.incrementCounter("queue.enqueued.traces", _) >> { stat ->
+    def healthMetrics = Stub(HealthMetrics)
+    healthMetrics.onPublish(_, _) >> {
       numTracesAccepted.incrementAndGet()
     }
-    statsd.incrementCounter("api.requests.total") >> { stat ->
+    healthMetrics.onSend(_, _, _) >> {
       numRequests.incrementAndGet()
-    }
-    statsd.incrementCounter("api.responses.total", _) >> { stat, tags ->
       numResponses.incrementAndGet()
     }
-
-    def healthMetrics = new HealthMetrics(statsd)
     def writer = DDAgentWriter.builder()
       .traceAgentV05Enabled(true)
       .traceAgentPort(agent.address.port)

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterTest.groovy
@@ -41,6 +41,7 @@ class DDAgentWriterTest extends DDCoreSpecification {
     writer.start()
 
     then:
+    1 * monitor.start()
     1 * worker.start()
     1 * worker.getCapacity() >> capacity
     1 * monitor.onStart(capacity)


### PR DESCRIPTION
This batches up health metrics and publishes them to StatsD twice per minute. 