### PR TITLE
Avoid spurious failures accessing JMX classloader during test setup

### DIFF
--- a/dd-java-agent/src/test/groovy/datadog/trace/agent/JMXFetchTest.groovy
+++ b/dd-java-agent/src/test/groovy/datadog/trace/agent/JMXFetchTest.groovy
@@ -67,6 +67,7 @@ class JMXFetchTest extends Specification {
 
   def "test jmxfetch config"() {
     setup:
+    System.setProperty("dd.jmxfetch.start-delay", "0")
     names.each {
       System.setProperty("dd.jmxfetch.${it}.enabled", "$enable")
     }


### PR DESCRIPTION
(missed updating this test in my last PR)