### PR TITLE
Update JMXFetchTest to test a real process rather than use flaky reflection hacks

### DIFF
--- a/dd-java-agent/src/test/java/jvmbootstraptest/JmxStartedChecker.java
+++ b/dd-java-agent/src/test/java/jvmbootstraptest/JmxStartedChecker.java
@@ -1,0 +1,18 @@
+package jvmbootstraptest;
+
+public class JmxStartedChecker {
+  public static void main(final String[] args) throws Exception {
+    AgentLoadedChecker.main(args);
+
+    boolean jmxStarted = false;
+    for (Thread t : Thread.getAllStackTraces().keySet()) {
+      if ("dd-jmx-collector".equals(t.getName())) {
+        jmxStarted = true;
+      }
+    }
+
+    if (!jmxStarted) {
+      throw new IllegalStateException("JMXFetch did not start");
+    }
+  }
+}


### PR DESCRIPTION
This should fix a test failure I saw recently because the local `JMXFETCH_CLASSLOADER` field wasn't initialized at the time this test ran. Tests should not rely on the status of any agent attached to the build process, so I changed this to use a forked process instead.