### PR TITLE
Fix potential timing issue involving CustomLogManagerTest

### DIFF
--- a/dd-java-agent/src/test/java/jvmbootstraptest/LogManagerSetter.java
+++ b/dd-java-agent/src/test/java/jvmbootstraptest/LogManagerSetter.java
@@ -4,12 +4,16 @@ import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import java.util.logging.LogManager;
 
 public class LogManagerSetter {
+
+  // avoid CustomLogManager.class.getName() as that could initialize JUL before we've set the logger
+  private static final String CUSTOM_LOG_MANAGER_CLASS_NAME = "jvmbootstraptest.CustomLogManager";
+
   public static void main(final String... args) throws Exception {
     if (System.getProperty("dd.app.customlogmanager") != null) {
       System.out.println("dd.app.customlogmanager != null");
 
       if (Boolean.valueOf(System.getProperty("dd.app.customlogmanager"))) {
-        System.setProperty("java.util.logging.manager", CustomLogManager.class.getName());
+        System.setProperty("java.util.logging.manager", CUSTOM_LOG_MANAGER_CLASS_NAME);
         customAssert(
             LogManager.getLogManager().getClass(),
             LogManagerSetter.class
@@ -49,7 +53,7 @@ public class LogManagerSetter {
               "profiling startup must be delayed when log manager system property is present.");
         }
         // Change back to a valid LogManager.
-        System.setProperty("java.util.logging.manager", CustomLogManager.class.getName());
+        System.setProperty("java.util.logging.manager", CUSTOM_LOG_MANAGER_CLASS_NAME);
         customAssert(
             LogManager.getLogManager().getClass(),
             LogManagerSetter.class
@@ -93,7 +97,7 @@ public class LogManagerSetter {
             "profiling startup must be delayed when JBOSS_HOME property is present.");
       }
 
-      System.setProperty("java.util.logging.manager", CustomLogManager.class.getName());
+      System.setProperty("java.util.logging.manager", CUSTOM_LOG_MANAGER_CLASS_NAME);
       customAssert(
           LogManager.getLogManager().getClass(),
           LogManagerSetter.class


### PR DESCRIPTION
Avoid accessing the CustomLogManager type in the LogManagerSetter test application
because this will load jul.LogManager, which triggers our class-loading hooks, and
ends up activating various Tracer services like JMX that initialize JUL.

If this happens before we've set the custom logger system property, ie:
```
System.setProperty("java.util.logging.manager", CustomLogManager.class.getName());
```
then there's a very small window where JUL could be initialized before the updated
system property has taken effect (since the class-loading hook and follow-on services
run on a different thread.)