### PR TITLE
jdbc tweaks

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jdbc/DBQueryInfo.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jdbc/DBQueryInfo.java
@@ -8,10 +8,6 @@ import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 
 public final class DBQueryInfo {
 
-  // expect statements to be of much higher cardinality than prepared statements in typical
-  // applications
-  private static final DDCache<String, DBQueryInfo> CACHED_STATEMENTS =
-      DDCaches.newFixedSizeCache(8192);
   private static final DDCache<String, DBQueryInfo> CACHED_PREPARED_STATEMENTS =
       DDCaches.newFixedSizeCache(512);
   private static final Function<String, DBQueryInfo> NORMALIZE =
@@ -24,7 +20,7 @@ public final class DBQueryInfo {
       };
 
   public static DBQueryInfo ofStatement(String sql) {
-    return CACHED_STATEMENTS.computeIfAbsent(sql, NORMALIZE);
+    return new DBQueryInfo(sql);
   }
 
   public static DBQueryInfo ofPreparedStatement(String sql) {

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/ConnectionInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/ConnectionInstrumentation.java
@@ -38,6 +38,8 @@ public final class ConnectionInstrumentation extends Instrumenter.Tracing {
     "com.mysql.jdbc.ConnectionImpl",
     "com.mysql.jdbc.JDBC4Connection",
     "com.mysql.cj.jdbc.ConnectionImpl",
+    // should cover Oracle
+    "oracle.jdbc.driver.OracleConnection",
     // should cover derby
     "org.apache.derby.impl.jdbc.EmbedConnection",
     "org.apache.hive.jdbc.HiveConnection",
@@ -74,8 +76,6 @@ public final class ConnectionInstrumentation extends Instrumenter.Tracing {
   private static final String[] ABSTRACT_TYPES = {
     // this should cover DB2
     "com.ibm.db2.jcc.DB2Connection",
-    // this should cover Oracle
-    "oracle.jdbc.OracleConnection",
     // this won't match any class unless the property is set
     Config.get().getJdbcConnectionClassName()
   };

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/PreparedStatementInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/PreparedStatementInstrumentation.java
@@ -55,6 +55,8 @@ public final class PreparedStatementInstrumentation extends Instrumenter.Tracing
     "com.mysql.jdbc.jdbc1.CallableStatement",
     "com.mysql.jdbc.jdbc2.CallableStatement",
     "com.mysql.cj.jdbc.CallableStatement",
+    "oracle.jdbc.driver.OracleCallableStatement",
+    "oracle.jdbc.driver.OraclePreparedStatement",
     // covers hsqldb
     "org.hsqldb.jdbc.JDBCPreparedStatement",
     "org.hsqldb.jdbc.jdbcPreparedStatement",
@@ -112,8 +114,6 @@ public final class PreparedStatementInstrumentation extends Instrumenter.Tracing
   private static final String[] ABSTRACT_TYPES = {
     // should cover DB2
     "com.ibm.db2.jcc.DB2PreparedStatement",
-    // should cover Oracle
-    "oracle.jdbc.OraclePreparedStatement",
     // this won't match any classes unless set
     Config.get().getJdbcPreparedStatementClassName()
   };


### PR DESCRIPTION
* Use the concrete class names from the Oracle JDBC driver which are publicly documented in the Javadoc
* Remove the cache for `Statement` SQL since we don't know the access patterns (e.g. there could be millions of 100 character `select user.name from user where user.id = <user_id>`) and the normaliser is fast anyway
* Add paranoid error handling in the normaliser, and don't copy strings we don't need to modify.