### PR TITLE
Addresses #1043: add a serviceName attribute to the @Trace annotation

### DIFF
--- a/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceAdvice.java
+++ b/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceAdvice.java
@@ -28,6 +28,12 @@ public class TraceAdvice {
       resourceName = DECORATE.spanNameForMethod(method);
     }
     span.setResourceName(resourceName);
+
+    String serviceName = traceAnnotation == null ? null : traceAnnotation.serviceName();
+    if (serviceName != null && serviceName.length() > 0) {
+      span.setServiceName(serviceName);
+    }
+
     DECORATE.afterStart(span);
 
     final AgentScope scope = activateSpan(span);

--- a/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/TraceAnnotationsTest.groovy
+++ b/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/TraceAnnotationsTest.groovy
@@ -89,7 +89,6 @@ class TraceAnnotationsTest extends AgentTestRunner {
           serviceName "testServiceName"
           resourceName "SayTracedHello.sayHelloWithServiceName"
           operationName "trace.annotation"
-          spanType "DB"
           parent()
           errored false
           tags {

--- a/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/TraceAnnotationsTest.groovy
+++ b/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/TraceAnnotationsTest.groovy
@@ -77,6 +77,30 @@ class TraceAnnotationsTest extends AgentTestRunner {
     }
   }
 
+  def "test simple case with only service name set"() {
+    setup:
+    // Test single span in new trace
+    SayTracedHello.sayHelloWithServiceName()
+
+    expect:
+    assertTraces(1) {
+      trace(1) {
+        span {
+          serviceName "testServiceName"
+          resourceName "SayTracedHello.sayHello"
+          operationName "trace.annotation"
+          spanType "DB"
+          parent()
+          errored false
+          tags {
+            "$Tags.COMPONENT" "trace"
+            defaultTags()
+          }
+        }
+      }
+    }
+  }
+
   def "test simple case with both resource and operation name set"() {
     setup:
     // Test single span in new trace

--- a/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/TraceAnnotationsTest.groovy
+++ b/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/TraceAnnotationsTest.groovy
@@ -87,7 +87,7 @@ class TraceAnnotationsTest extends AgentTestRunner {
       trace(1) {
         span {
           serviceName "testServiceName"
-          resourceName "SayTracedHello.sayHello"
+          resourceName "SayTracedHello.sayHelloWithServiceName"
           operationName "trace.annotation"
           spanType "DB"
           parent()

--- a/dd-java-agent/instrumentation/trace-annotation/src/test/java/dd/test/trace/annotation/SayTracedHello.java
+++ b/dd-java-agent/instrumentation/trace-annotation/src/test/java/dd/test/trace/annotation/SayTracedHello.java
@@ -34,6 +34,11 @@ public class SayTracedHello {
     return "HA EARTH!!";
   }
 
+  @Trace(serviceName = "testServiceName")
+  public static String sayHelloWithServiceName() {
+    return "hello!";
+  }
+
   @Trace(operationName = "NEW_TRACE")
   public static String sayHELLOsayHA() {
     activeSpan().setTag(DDTags.SERVICE_NAME, "test2");

--- a/dd-trace-api/src/main/java/datadog/trace/api/Trace.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/Trace.java
@@ -16,4 +16,7 @@ public @interface Trace {
 
   /** The resource name. By default it uses the same value as the operation name */
   String resourceName() default "";
+
+  /** The service name. By default it will inherit the default service name */
+  String serviceName() default "";
 }


### PR DESCRIPTION
Hi there,

This PR is to address/resolve #1043. I will be the first to apologize as I have not been able to spend the time yet to setup all of the different jvms, environment, etc., in order to build and run the tests for this.

I am hoping that given this is a relatively minimal and straightforward change (essentially mirroring what is already being done for `resourceName`) this at least increases the chances of #1043 getting fixed :)

One question I have here is whether it is kosher to use `span.setServiceName(..)` versus using the pattern I've seen elsewhere of `activeSpan().setTag(DDTags.SERVICE_NAME, ..);`. I didn't look too closely at the pros/cons of using the direct method vs setting the tag value, but I'm happy to change this PR to set the tag value instead if that is preferred.

Thanks in advance for your consideration!