### PR TITLE
ddsketch optimisation

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/SerializingMetricWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/SerializingMetricWriter.java
@@ -33,8 +33,12 @@ public final class SerializingMetricWriter implements MetricWriter {
   private final GrowableBuffer buffer;
 
   public SerializingMetricWriter(WellKnownTags wellKnownTags, Sink sink) {
+    this(wellKnownTags, sink, 512 * 1024);
+  }
+
+  public SerializingMetricWriter(WellKnownTags wellKnownTags, Sink sink, int initialCapacity) {
     this.wellKnownTags = wellKnownTags;
-    this.buffer = new GrowableBuffer(512 << 10);
+    this.buffer = new GrowableBuffer(initialCapacity);
     this.writer = new MsgPackWriter(buffer);
     this.sink = sink;
   }

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SerializingMetricWriterTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SerializingMetricWriterTest.groovy
@@ -23,7 +23,7 @@ class SerializingMetricWriterTest extends DDSpecification {
     long duration = SECONDS.toNanos(10)
     WellKnownTags wellKnownTags = new WellKnownTags("hostname", "env", "service", "version")
     ValidatingSink sink = new ValidatingSink(wellKnownTags, startTime, duration, content)
-    SerializingMetricWriter writer = new SerializingMetricWriter(wellKnownTags, sink)
+    SerializingMetricWriter writer = new SerializingMetricWriter(wellKnownTags, sink, 128)
 
     when:
     writer.startBucket(content.size(), startTime, duration)
@@ -41,7 +41,10 @@ class SerializingMetricWriterTest extends DDSpecification {
       [
         Pair.of(new MetricKey("resource1", "service1", "operation1", "type", 0), new AggregateMetric().recordDurations(10, new AtomicLongArray(1L))),
         Pair.of(new MetricKey("resource2", "service2", "operation2", "type2", 200), new AggregateMetric().recordDurations(9, new AtomicLongArray(1L)))
-      ]
+      ],
+      (0..10000).collect({
+        i -> Pair.of(new MetricKey("resource" + i, "service" + i, "operation" + i, "type", 0), new AggregateMetric().recordDurations(10, new AtomicLongArray(1L)))
+      })
     ]
   }
 

--- a/utils/histograms/src/main/java/datadog/trace/core/histogram/DDSketchHistogram.java
+++ b/utils/histograms/src/main/java/datadog/trace/core/histogram/DDSketchHistogram.java
@@ -2,7 +2,7 @@ package datadog.trace.core.histogram;
 
 import com.datadoghq.sketch.ddsketch.DDSketch;
 import com.datadoghq.sketch.ddsketch.mapping.BitwiseLinearlyInterpolatedMapping;
-import com.datadoghq.sketch.ddsketch.store.PaginatedStore;
+import com.datadoghq.sketch.ddsketch.store.CollapsingLowestDenseStore;
 import java.nio.ByteBuffer;
 
 public final class DDSketchHistogram implements Histogram, HistogramFactory {
@@ -10,7 +10,10 @@ public final class DDSketchHistogram implements Histogram, HistogramFactory {
   private final DDSketch sketch;
 
   public DDSketchHistogram() {
-    this(new DDSketch(new BitwiseLinearlyInterpolatedMapping(0.01), PaginatedStore::new));
+    this(
+        new DDSketch(
+            new BitwiseLinearlyInterpolatedMapping(0.01),
+            () -> new CollapsingLowestDenseStore(1024)));
   }
 
   public DDSketchHistogram(DDSketch sketch) {


### PR DESCRIPTION
The overhead of serializing DDSketch is relatively costly:

<img width="618" alt="Screenshot 2021-02-19 at 11 16 01" src="https://user-images.githubusercontent.com/16439049/108497887-06d8b300-72a4-11eb-8f3e-64c7d63d2fa9.png">

When I wrote the serialization code I noted that serializing dense sketches was a lot faster, so this change should eliminate the overhead:

```
Benchmark            (count)                (generator)  (relativeAccuracy)  (sketchOption)        (unit)  Mode  Cnt   Score   Error  Units
Serialize.serialize   100000                    POISSON                0.01            FAST   NANOSECONDS  avgt    5   0.966 ± 0.003  us/op
Serialize.serialize   100000                    POISSON                0.01            FAST  MICROSECONDS  avgt    5   0.965 ± 0.011  us/op
Serialize.serialize   100000                    POISSON                0.01            FAST  MILLISECONDS  avgt    5   0.983 ± 0.003  us/op
Serialize.serialize   100000                    POISSON                0.01       PAGINATED   NANOSECONDS  avgt    5   4.061 ± 0.029  us/op
Serialize.serialize   100000                    POISSON                0.01       PAGINATED  MICROSECONDS  avgt    5   4.068 ± 0.023  us/op
Serialize.serialize   100000                    POISSON                0.01       PAGINATED  MILLISECONDS  avgt    5   4.114 ± 0.015  us/op
Serialize.serialize   100000  COMPOSITE_POISSON_EXTREME                0.01            FAST   NANOSECONDS  avgt    5   1.691 ± 0.009  us/op
Serialize.serialize   100000  COMPOSITE_POISSON_EXTREME                0.01            FAST  MICROSECONDS  avgt    5   1.723 ± 0.020  us/op
Serialize.serialize   100000  COMPOSITE_POISSON_EXTREME                0.01            FAST  MILLISECONDS  avgt    5   1.721 ± 0.007  us/op
Serialize.serialize   100000  COMPOSITE_POISSON_EXTREME                0.01       PAGINATED   NANOSECONDS  avgt    5  16.670 ± 0.083  us/op
Serialize.serialize   100000  COMPOSITE_POISSON_EXTREME                0.01       PAGINATED  MICROSECONDS  avgt    5  16.655 ± 0.081  us/op
Serialize.serialize   100000  COMPOSITE_POISSON_EXTREME                0.01       PAGINATED  MILLISECONDS  avgt    5  16.671 ± 0.069  us/op
Serialize.serialize   100000            TRIMODAL_NORMAL                0.01            FAST   NANOSECONDS  avgt    5   1.071 ± 0.011  us/op
Serialize.serialize   100000            TRIMODAL_NORMAL                0.01            FAST  MICROSECONDS  avgt    5   1.052 ± 0.006  us/op
Serialize.serialize   100000            TRIMODAL_NORMAL                0.01            FAST  MILLISECONDS  avgt    5   1.148 ± 0.032  us/op
Serialize.serialize   100000            TRIMODAL_NORMAL                0.01       PAGINATED   NANOSECONDS  avgt    5   9.298 ± 0.031  us/op
Serialize.serialize   100000            TRIMODAL_NORMAL                0.01       PAGINATED  MICROSECONDS  avgt    5   8.659 ± 0.028  us/op
Serialize.serialize   100000            TRIMODAL_NORMAL                0.01       PAGINATED  MILLISECONDS  avgt    5   8.899 ± 0.076  us/op
```
I have separately verified that the trace agent can decode these sketches, and am adding a test that resized metrics payloads are not corrupted.
