### PR TITLE
aggregator bugs

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/MetricWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/MetricWriter.java
@@ -6,4 +6,6 @@ public interface MetricWriter {
   void add(MetricKey key, AggregateMetric aggregate);
 
   void finishBucket();
+
+  void reset();
 }

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/SerializingMetricWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/SerializingMetricWriter.java
@@ -113,4 +113,9 @@ public final class SerializingMetricWriter implements MetricWriter {
     sink.accept(buffer.messageCount(), buffer.slice());
     buffer.reset();
   }
+
+  @Override
+  public void reset() {
+    buffer.reset();
+  }
 }

--- a/dd-trace-core/src/test/java/datadog/trace/core/serialization/msgpack/GrowableBufferTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/serialization/msgpack/GrowableBufferTest.java
@@ -1,0 +1,25 @@
+package datadog.trace.core.serialization.msgpack;
+
+import static groovy.util.GroovyTestCase.assertEquals;
+
+import datadog.trace.core.serialization.GrowableBuffer;
+import java.nio.ByteBuffer;
+import org.junit.Test;
+
+public class GrowableBufferTest {
+
+  @Test
+  public void byteBufferTriggersResize() {
+    GrowableBuffer gb = new GrowableBuffer(5);
+    ByteBuffer buffer = ByteBuffer.allocate(20);
+    for (int i = 0; i < 5; ++i) {
+      buffer.putInt(i);
+    }
+    buffer.flip();
+    gb.put(buffer);
+    ByteBuffer contentsAfterResize = gb.slice();
+    for (int i = 0; i < 5; ++i) {
+      assertEquals(i, contentsAfterResize.getInt());
+    }
+  }
+}


### PR DESCRIPTION
Fixes a bug when writing a `ByteBuffer` into a `GrowableBuffer` and adds a defensive catch block to prevent the aggregator thread from shutting down when an unexpected error occurs.