### PR TITLE
Set explicit handler to log uncaught exceptions in agent threads

### DIFF
--- a/internal-api/src/main/java/datadog/trace/util/AgentThreadFactory.java
+++ b/internal-api/src/main/java/datadog/trace/util/AgentThreadFactory.java
@@ -1,6 +1,7 @@
 package datadog.trace.util;
 
 import java.util.concurrent.ThreadFactory;
+import org.slf4j.LoggerFactory;
 
 /** A {@link ThreadFactory} implementation that starts all agent {@link Thread}s as daemons. */
 public final class AgentThreadFactory implements ThreadFactory {
@@ -59,6 +60,14 @@ public final class AgentThreadFactory implements ThreadFactory {
     final Thread thread = new Thread(AGENT_THREAD_GROUP, runnable, agentThread.threadName);
     thread.setDaemon(true);
     thread.setContextClassLoader(null);
+    thread.setUncaughtExceptionHandler(
+        new Thread.UncaughtExceptionHandler() {
+          @Override
+          public void uncaughtException(final Thread thread, final Throwable e) {
+            LoggerFactory.getLogger(runnable.getClass())
+                .error("Uncaught exception in {}", agentThread.threadName, e);
+          }
+        });
     return thread;
   }
 }


### PR DESCRIPTION
Not all workers in the Java tracer include a catch clause for `Throwable` around their work loop. Rather than continually look out for this during code reviews it's simpler to define an uncaught exception handler for agent threads that logs any uncaught exceptions.