### PR TITLE
[CIAPP] Add CIApp feature tracking json

### DIFF
--- a/ci-app-spec.json
+++ b/ci-app-spec.json
@@ -1,0 +1,21 @@
+[
+  "test.suite",
+  "test.name",
+  "test.status",
+  "test.framework",
+  "test.skip_reason",
+  "test.type",
+  "ci.provider.name",
+  "ci.pipeline.id",
+  "ci.pipeline.name",
+  "ci.pipeline.number",
+  "ci.pipeline.url",
+  "ci.stage.name",
+  "ci.job.name",
+  "ci.job.url",
+  "ci.workspace_path",
+  "git.repository_url",
+  "git.commit.sha",
+  "git.branch",
+  "git.tag"
+]


### PR DESCRIPTION
In CIAPP we use this `json` file to generate a dynamic HTML with the tags that are already supported by the tracer (CiApp context) 