### PR TITLE
Update Lombok and Gradle Lombok Plugin

### DIFF
--- a/dd-trace-java.gradle
+++ b/dd-trace-java.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id 'io.franzbecker.gradle-lombok' version '1.14' // Last to support Java 7
+  id 'io.franzbecker.gradle-lombok' version '4.0.0'
 
   id 'com.jfrog.artifactory' version '4.9.8'
   // ^ Last version to not have problems with NoSuchMethodError HttpClientBuilder.setPublicSuffixMatcher...

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -12,7 +12,7 @@ ext {
     groovy        : groovyVer,
     junit5        : "5.6.2",
     logback       : "1.2.3",
-    lombok        : "1.18.10",
+    lombok        : "1.18.18",
     bytebuddy     : "1.10.21",
     scala         : "2.11.12",  // Last version to support Java 7 (2.12+ require Java 8+)
     scala210      : "2.10.7",


### PR DESCRIPTION
Upgrade to the latest for each.
I don't think the plugin needs to be Java 7 compatible since we compile with Java 8.

(Motivated by the following error in our CI `check` task: `The value for task ':dd-trace-core:installLombok' property 'mainClass' is final and cannot be changed any further.`)