### PR TITLE
[CIAPP] Avoid reporting duplicate test spans when nested test engines are executed.

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/TestDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/TestDecorator.java
@@ -74,4 +74,13 @@ public abstract class TestDecorator extends BaseDecorator {
     }
     return testNames;
   }
+
+  public boolean isTestSpan(final AgentSpan activeSpan) {
+    if (activeSpan == null) {
+      return false;
+    }
+
+    return spanKind().equals(activeSpan.getSpanType())
+        && testType().equals(activeSpan.getTag(Tags.TEST_TYPE));
+  }
 }

--- a/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/TracingListener.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/TracingListener.java
@@ -24,6 +24,15 @@ public class TracingListener extends RunListener {
       return;
     }
 
+    // If there is an active span that represents a test
+    // we don't want to generate another child test span.
+    // This can happen when the user executes a certain test
+    // using the different test engines.
+    // (e.g. JUnit 4 tests using JUnit5 engine)
+    if (DECORATE.isTestSpan(AgentTracer.activeSpan())) {
+      return;
+    }
+
     final AgentSpan span = startSpan("junit.test");
     final AgentScope scope = activateSpan(span);
     scope.setAsyncPropagation(true);

--- a/dd-java-agent/instrumentation/junit-5.3/src/main/java8/datadog/trace/instrumentation/junit5/TracingListener.java
+++ b/dd-java-agent/instrumentation/junit-5.3/src/main/java8/datadog/trace/instrumentation/junit5/TracingListener.java
@@ -25,6 +25,15 @@ public class TracingListener implements TestExecutionListener {
       return;
     }
 
+    // If there is an active span that represents a test
+    // we don't want to generate another child test span.
+    // This can happen when the user executes a certain test
+    // using the different test engines.
+    // (e.g. JUnit 4 tests using JUnit5 engine)
+    if (DECORATE.isTestSpan(AgentTracer.activeSpan())) {
+      return;
+    }
+
     testIdentifier
         .getSource()
         .filter(testSource -> testSource instanceof MethodSource)

--- a/dd-java-agent/instrumentation/testng-6.4/src/main/java/datadog/trace/instrumentation/testng/TracingListener.java
+++ b/dd-java-agent/instrumentation/testng-6.4/src/main/java/datadog/trace/instrumentation/testng/TracingListener.java
@@ -16,6 +16,15 @@ public class TracingListener implements ITestListener {
 
   @Override
   public void onTestStart(final ITestResult result) {
+    // If there is an active span that represents a test
+    // we don't want to generate another child test span.
+    // This can happen when the user executes a certain test
+    // using the different test engines.
+    // (e.g. JUnit 4 tests using JUnit5 engine)
+    if (DECORATE.isTestSpan(AgentTracer.activeSpan())) {
+      return;
+    }
+
     final AgentSpan span = startSpan("testng.test");
     final AgentScope scope = activateSpan(span);
     scope.setAsyncPropagation(true);


### PR DESCRIPTION
In this PR, we prevent the reporting of duplicate tests spans when there are test engines executed in a nested way.
E.g., `JUnit5` engine executes a `JUnit4` test.
- Without this fix: (`JUnit5` span ( `JUnit4` span ( ....  ) ) )
- With this fix: (`JUnit5` span ( ... ) )