### PR TITLE
When building with Java 9+ lazily set compiler `--release` flag to match target

### DIFF
--- a/dd-java-agent/agent-bootstrap/agent-bootstrap.gradle
+++ b/dd-java-agent/agent-bootstrap/agent-bootstrap.gradle
@@ -3,6 +3,11 @@ plugins {
   id "com.github.johnrengelman.shadow"
 }
 
+ext {
+  // need access to sun.* packages
+  skipSettingCompilerRelease = true
+}
+
 apply from: "$rootDir/gradle/java.gradle"
 apply plugin: "idea"
 

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/profiling-controller-openjdk.gradle
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/profiling-controller-openjdk.gradle
@@ -6,6 +6,8 @@ ext {
   // By default tests with be compiled for `minJavaVersionForTests` version,
   // but in this case we would like to avoid this since we would like to run with ZULU8
   skipSettingTestJavaVersion = true
+  // need access to jdk.jfr package
+  skipSettingCompilerRelease = true
 }
 
 apply from: "$rootDir/gradle/java.gradle"

--- a/dd-java-agent/instrumentation/rmi/rmi.gradle
+++ b/dd-java-agent/instrumentation/rmi/rmi.gradle
@@ -1,3 +1,8 @@
+ext {
+  // need access to sun.rmi package
+  skipSettingCompilerRelease = true
+}
+
 muzzle {
   pass {
     coreJdk()

--- a/dd-java-agent/testing/testing.gradle
+++ b/dd-java-agent/testing/testing.gradle
@@ -1,3 +1,8 @@
+ext {
+  // need access to sun.misc package
+  skipSettingCompilerRelease = true
+}
+
 apply from: "$rootDir/gradle/java.gradle"
 
 minimumBranchCoverage = 0.5

--- a/dd-trace-core/jfr-openjdk/jfr-openjdk.gradle
+++ b/dd-trace-core/jfr-openjdk/jfr-openjdk.gradle
@@ -1,6 +1,8 @@
 // Set properties before any plugins get loaded
 ext {
   minJavaVersionForTests = JavaVersion.VERSION_11
+  // need access to jdk.jfr package
+  skipSettingCompilerRelease = true
 }
 
 apply from: "$rootDir/gradle/java.gradle"

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -40,6 +40,14 @@ if (applyCodeCoverage) {
 sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
+// when building with Java 9+, lazily set compiler --release flag to match target
+def skipSettingCompilerRelease = project.findProperty('skipSettingCompilerRelease')
+if (!skipSettingCompilerRelease && JavaVersion.current().isJava9Compatible()) {
+  compileJava.options.release = project.provider {
+    JavaVersion.toVersion(targetCompatibility).majorVersion as Integer
+  }
+}
+
 if (project.hasProperty('minJavaVersionForTests') && project.getProperty('minJavaVersionForTests') != JavaVersion.VERSION_1_7) {
   def version = JavaVersion.toVersion(project.getProperty('minJavaVersionForTests'))
   def name = "java$version.majorVersion"


### PR DESCRIPTION
... and add ability to skip this when we need compiler access to packages like `sun.rmi`