### PR TITLE
Output clear error when building profiling code without setting JAVA_11_HOME first

### DIFF
--- a/dd-java-agent/agent-bootstrap/agent-bootstrap.gradle
+++ b/dd-java-agent/agent-bootstrap/agent-bootstrap.gradle
@@ -26,10 +26,15 @@ sourceSets {
     java.srcDirs "${project.projectDir}/src/main/java11"
   }
 }
-compileMain_java11Java.options.fork = true
-compileMain_java11Java.options.forkOptions.javaHome = file(System.env.JAVA_11_HOME)
-compileMain_java11Java.sourceCompatibility = JavaVersion.VERSION_1_8
-compileMain_java11Java.targetCompatibility = JavaVersion.VERSION_1_8
+compileMain_java11Java.doFirst {
+  if (!System.env.JAVA_11_HOME) {
+    throw new GradleException('JAVA_11_HOME must be set to build profiling helpers')
+  }
+  options.fork = true
+  options.forkOptions.javaHome = file(System.env.JAVA_11_HOME)
+  sourceCompatibility = JavaVersion.VERSION_1_8
+  targetCompatibility = JavaVersion.VERSION_1_8
+}
 dependencies {
   main_java11CompileOnly project(':internal-api')
   main_java11CompileOnly "org.projectlombok:lombok:${project.lombok.version}" transitive false

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/profiling-controller-openjdk.gradle
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/profiling-controller-openjdk.gradle
@@ -33,6 +33,9 @@ targetCompatibility = JavaVersion.VERSION_1_8
 [JavaCompile, GroovyCompile].each {
   tasks.withType(it) {
     doFirst {
+      if (!System.env.JAVA_11_HOME) {
+        throw new GradleException('JAVA_11_HOME must be set to build profiling controller')
+      }
       // Disable '-processing' because some annotations are not claimed.
       // Disable '-options' because we are compiling for java8 without specifying bootstrap - intentionally.
       // Disable '-path' because we do not have some of the paths seem to be missing.

--- a/dd-java-agent/instrumentation/exception-profiling/exception-profiling.gradle
+++ b/dd-java-agent/instrumentation/exception-profiling/exception-profiling.gradle
@@ -26,6 +26,9 @@ targetCompatibility = JavaVersion.VERSION_1_7
   it.sourceCompatibility = JavaVersion.VERSION_1_8
   it.targetCompatibility = JavaVersion.VERSION_1_8
   it.doFirst {
+    if (!System.env.JAVA_11_HOME) {
+      throw new GradleException('JAVA_11_HOME must be set to build profiling instrumentation')
+    }
     // Disable '-processing' because some annotations are not claimed.
     // Disable '-options' because we are compiling for java8 without specifying bootstrap - intentionally.
     // Disable '-path' because we do not have some of the paths seem to be missing.

--- a/dd-trace-core/jfr-openjdk/jfr-openjdk.gradle
+++ b/dd-trace-core/jfr-openjdk/jfr-openjdk.gradle
@@ -25,6 +25,9 @@ targetCompatibility = JavaVersion.VERSION_1_8
 [JavaCompile, GroovyCompile].each {
   tasks.withType(it) {
     doFirst {
+      if (!System.env.JAVA_11_HOME) {
+        throw new GradleException('JAVA_11_HOME must be set to build profiling helpers')
+      }
       // Disable '-processing' because some annotations are not claimed.
       // Disable '-options' because we are compiling for java8 without specifying bootstrap - intentionally.
       // Disable '-path' because we do not have some of the paths seem to be missing.


### PR DESCRIPTION
also make Java11 configuration in `agent-bootstrap` lazy so you can still run certain tasks without needing JAVA_11_HOME