### PR TITLE
Change github actions to use correct paginate syntax and new names

### DIFF
--- a/.github/workflows/draft-release-notes-on-tag.yaml
+++ b/.github/workflows/draft-release-notes-on-tag.yaml
@@ -21,7 +21,7 @@ jobs:
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            const milestone = await github.issues.paginate(listMilestonesForRepo, {
+            const milestone = await github.paginate(github.issues.listMilestones, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: 'all'
@@ -42,7 +42,7 @@ jobs:
           github-token: ${{secrets.GITHUB_TOKEN}}
           result-encoding: string
           script: |
-            const pullRequests = await github.pulls.paginate(list, {
+            const pullRequests = await github.paginate(github.pulls.list, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: 'closed',

--- a/.github/workflows/increment-milestones-on-tag.yaml
+++ b/.github/workflows/increment-milestones-on-tag.yaml
@@ -21,7 +21,7 @@ jobs:
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            const milestone = await github.issues.paginate(listMilestonesForRepo, {
+            const milestone = await github.paginate(github.issues.listMilestones, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: 'all'

--- a/.github/workflows/update-issues-on-release.yaml
+++ b/.github/workflows/update-issues-on-release.yaml
@@ -6,6 +6,7 @@ on:
     inputs:
       milestone:
         required: true
+        default: "0.0.0"
 
 jobs:
   update_issues:
@@ -17,24 +18,23 @@ jobs:
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            if ("${{github.event_name}}" == "workflow_dispatch") {
-              return "${{github.event.inputs.milestone}}"
-            }
+            const milestone_name = ("${{github.event_name}}" == "workflow_dispatch") ?
+              "${{github.event.inputs.milestone}}" : "${{github.event.release.name}}"
 
-            const milestones = await github.issues.paginate(listMilestonesForRepo, {
+            const milestones = await github.paginate(github.issues.listMilestones, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: 'all'
             })
 
-            return milestones.find( milestone => milestone.title == "${{github.event.release.name}}" ).number
+            return milestones.find( milestone => milestone.title == milestone_name ).number
       - name: Get issues for milestone
         id: issues
         uses: actions/github-script@47f7cf65b5ced0830a325f705cad64f2f58dddf7 # 3.1.0
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            const issues = await github.issues.paginate(listForRepo, {
+            const issues = await github.paginate(github.issues.listForRepo, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: 'all',


### PR DESCRIPTION
When testing the `update-issues-on-release` workflow via the manual trigger, I found out that I had messed up the `paginate` syntax, and there had been more changes to the `method` names in the github API. I have now tried to diff our actions against the breaking changes in the release notes for `octokit/plugin-rest-endpoint-methods.js`.