### PR TITLE
Widen catch block when attempting to install JFR ScopeEventFactory

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -519,7 +519,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
       try {
         return (DDScopeEventFactory)
             Class.forName("datadog.trace.core.jfr.openjdk.ScopeEventFactory").newInstance();
-      } catch (final ClassFormatError | ReflectiveOperationException | NoClassDefFoundError e) {
+      } catch (final Throwable e) {
         log.debug("Profiling of ScopeEvents is not available");
       }
     }


### PR DESCRIPTION
J9 JVMs can throw `InternalError` here, so to be safe we catch any throwable.