### PR TITLE
[CIAPP] Add configuration tags to TestDecorator

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/TestDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/TestDecorator.java
@@ -43,6 +43,26 @@ public abstract class TestDecorator extends BaseDecorator {
     return Tags.SPAN_KIND_TEST;
   }
 
+  protected String runtimeName() {
+    return System.getProperty("java.vendor");
+  }
+
+  protected String runtimeVersion() {
+    return System.getProperty("java.version");
+  }
+
+  protected String osArch() {
+    return System.getProperty("os.arch");
+  }
+
+  protected String osPlatform() {
+    return System.getProperty("os.name");
+  }
+
+  protected String osVersion() {
+    return System.getProperty("os.version");
+  }
+
   @Override
   protected CharSequence spanType() {
     return DDSpanTypes.TEST;
@@ -54,6 +74,11 @@ public abstract class TestDecorator extends BaseDecorator {
     span.setTag(Tags.TEST_FRAMEWORK, testFramework());
     span.setTag(Tags.TEST_TYPE, testType());
     span.setSamplingPriority(PrioritySampling.SAMPLER_KEEP);
+    span.setTag(Tags.RUNTIME_NAME, runtimeName());
+    span.setTag(Tags.RUNTIME_VERSION, runtimeVersion());
+    span.setTag(Tags.OS_ARCHITECTURE, osArch());
+    span.setTag(Tags.OS_PLATFORM, osPlatform());
+    span.setTag(Tags.OS_VERSION, osVersion());
 
     for (final Map.Entry<String, String> ciTag : ciTags.entrySet()) {
       span.setTag(ciTag.getKey(), ciTag.getValue());

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/TestDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/TestDecorator.java
@@ -44,6 +44,10 @@ public abstract class TestDecorator extends BaseDecorator {
   }
 
   protected String runtimeName() {
+    return System.getProperty("java.runtime.name");
+  }
+
+  protected String runtimeVendor() {
     return System.getProperty("java.vendor");
   }
 
@@ -75,6 +79,7 @@ public abstract class TestDecorator extends BaseDecorator {
     span.setTag(Tags.TEST_TYPE, testType());
     span.setSamplingPriority(PrioritySampling.SAMPLER_KEEP);
     span.setTag(Tags.RUNTIME_NAME, runtimeName());
+    span.setTag(Tags.RUNTIME_VENDOR, runtimeVendor());
     span.setTag(Tags.RUNTIME_VERSION, runtimeVersion());
     span.setTag(Tags.OS_ARCHITECTURE, osArch());
     span.setTag(Tags.OS_PLATFORM, osPlatform());

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/TestDecoratorTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/TestDecoratorTest.groovy
@@ -24,6 +24,7 @@ class TestDecoratorTest extends BaseDecoratorTest {
     1 * span.setTag(Tags.TEST_TYPE, decorator.testType())
     1 * span.setSamplingPriority(PrioritySampling.SAMPLER_KEEP)
     1 * span.setTag(Tags.RUNTIME_NAME, decorator.runtimeName())
+    1 * span.setTag(Tags.RUNTIME_VENDOR, decorator.runtimeVendor())
     1 * span.setTag(Tags.RUNTIME_VERSION, decorator.runtimeVersion())
     1 * span.setTag(Tags.OS_ARCHITECTURE, decorator.osArch())
     1 * span.setTag(Tags.OS_PLATFORM, decorator.osPlatform())

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/TestDecoratorTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/TestDecoratorTest.groovy
@@ -23,6 +23,11 @@ class TestDecoratorTest extends BaseDecoratorTest {
     1 * span.setTag(Tags.TEST_FRAMEWORK, decorator.testFramework())
     1 * span.setTag(Tags.TEST_TYPE, decorator.testType())
     1 * span.setSamplingPriority(PrioritySampling.SAMPLER_KEEP)
+    1 * span.setTag(Tags.RUNTIME_NAME, decorator.runtimeName())
+    1 * span.setTag(Tags.RUNTIME_VERSION, decorator.runtimeVersion())
+    1 * span.setTag(Tags.OS_ARCHITECTURE, decorator.osArch())
+    1 * span.setTag(Tags.OS_PLATFORM, decorator.osPlatform())
+    1 * span.setTag(Tags.OS_VERSION, decorator.osVersion())
     decorator.ciTags.each {
       1 * span.setTag(it.key, it.value)
     }

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/TestFrameworkTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/TestFrameworkTest.groovy
@@ -49,6 +49,13 @@ abstract class TestFrameworkTest extends AgentTestRunner {
           }
         }
 
+        "$Tags.OS_VERSION" String
+        "$Tags.OS_PLATFORM" String
+        "$Tags.OS_ARCHITECTURE" String
+        "$Tags.RUNTIME_VENDOR" String
+        "$Tags.RUNTIME_NAME" String
+        "$Tags.RUNTIME_VERSION" String
+
         defaultTags()
       }
     }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/Tags.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/Tags.java
@@ -51,6 +51,12 @@ public class Tags {
   public static final String GIT_BRANCH = "git.branch";
   public static final String GIT_TAG = "git.tag";
 
+  public static final String RUNTIME_NAME = "runtime.name";
+  public static final String RUNTIME_VERSION = "runtime.version";
+  public static final String OS_ARCHITECTURE = "os.architecture";
+  public static final String OS_PLATFORM = "os.platform";
+  public static final String OS_VERSION = "os.version";
+
   public static final String DD_SERVICE = "dd.service";
   public static final String DD_VERSION = "dd.version";
   public static final String DD_ENV = "dd.env";

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/Tags.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/Tags.java
@@ -52,6 +52,7 @@ public class Tags {
   public static final String GIT_TAG = "git.tag";
 
   public static final String RUNTIME_NAME = "runtime.name";
+  public static final String RUNTIME_VENDOR = "runtime.vendor";
   public static final String RUNTIME_VERSION = "runtime.version";
   public static final String OS_ARCHITECTURE = "os.architecture";
   public static final String OS_PLATFORM = "os.platform";


### PR DESCRIPTION
This PR adds the configuration tags to the `TestDecorator`. These tags will be used to detect test outliers based on the configuration where the test was executed.