### PR TITLE
Exclude bad mule version from muzzle

### DIFF
--- a/dd-java-agent/instrumentation/mule-4/mule-4.gradle
+++ b/dd-java-agent/instrumentation/mule-4/mule-4.gradle
@@ -18,6 +18,7 @@ muzzle {
     group = 'org.mule'
     module = 'mule-core'
     versions = '[3.2.0,)' // First version where muzzle can resolve all dependencies
+    skipVersions += "3.9.5" // bad release
   }
 }
 
@@ -100,7 +101,7 @@ task extractMuleServices(type: Sync) {
 }
 
 // build the mule application via maven
-task mvnPackage(type:Exec) {
+task mvnPackage(type: Exec) {
   workingDir "$appDir"
   commandLine 'mvn', "-Ddatadog.builddir=$buildDir", "-Ddatadog.name=mule-http-test-server", "-Ddatadog.version=$version", 'package'
   outputs.dir("$buildDir/target")


### PR DESCRIPTION
```
      > Could not resolve org.mule:mule-core:3.9.5.
         > Could not parse POM https://repository.mulesoft.org/releases/org/mule/mule-core/3.9.5/mule-core-3.9.5.pom
            > Could not find org.mule:mule:3.9.5.
              Searched in the following locations:
                - https://repo.maven.apache.org/maven2/org/mule/mule/3.9.5/mule-3.9.5.pom
                - https://jcenter.bintray.com/org/mule/mule/3.9.5/mule-3.9.5.pom
                - https://maven.anypoint.mulesoft.com/api/v2/maven/org/mule/mule/3.9.5/mule-3.9.5.pom
                - https://repository.mulesoft.org/releases/org/mule/mule/3.9.5/mule-3.9.5.pom
                - https://repository.mulesoft.org/nexus/content/repositories/public/org/mule/mule/3.9.5/mule-3.9.5.pom
      > Could not resolve org.mule:mule-core:3.9.5.
         > Could not parse POM https://repository.mulesoft.org/nexus/content/repositories/public/org/mule/mule-core/3.9.5/mule-core-3.9.5.pom
            > Could not find org.mule:mule:3.9.5.
```
