### PR TITLE
Allow gRPC users to ignore specific outbound RPC calls

### DIFF
--- a/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcStreamingTest.groovy
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcStreamingTest.groovy
@@ -18,6 +18,12 @@ import java.util.concurrent.atomic.AtomicReference
 
 class GrpcStreamingTest extends AgentTestRunner {
 
+  @Override
+  protected void configurePreAgent() {
+    super.configurePreAgent()
+    injectSysConfig("dd.trace.grpc.ignored.outbound.methods", "example.Greeter/Ignore")
+  }
+
   def "test conversation #name"() {
     setup:
     def msgCount = serverMessageCount

--- a/dd-java-agent/instrumentation/grpc-1.5/src/test/proto/helloworld.proto
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/test/proto/helloworld.proto
@@ -8,6 +8,9 @@ service Greeter {
 
   rpc Conversation (stream Response) returns (stream Response) {
   }
+
+  rpc Ignore (Request) returns (Response) {
+  }
 }
 
 message Request {

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
@@ -43,6 +43,7 @@ public final class TraceInstrumentationConfig {
   public static final String KAFKA_CLIENT_BASE64_DECODING_ENABLED =
       "kafka.client.base64.decoding.enabled";
 
+  public static final String GRPC_IGNORED_OUTBOUND_METHODS = "trace.grpc.ignored.outbound.methods";
   public static final String HYSTRIX_TAGS_ENABLED = "hystrix.tags.enabled";
 
   public static final String OSGI_SEARCH_DEPTH = "osgi.search.depth";

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -110,6 +110,7 @@ import static datadog.trace.api.config.ProfilingConfig.PROFILING_UPLOAD_PERIOD;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_UPLOAD_TIMEOUT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_URL;
 import static datadog.trace.api.config.TraceInstrumentationConfig.DB_CLIENT_HOST_SPLIT_BY_INSTANCE;
+import static datadog.trace.api.config.TraceInstrumentationConfig.GRPC_IGNORED_OUTBOUND_METHODS;
 import static datadog.trace.api.config.TraceInstrumentationConfig.HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN;
 import static datadog.trace.api.config.TraceInstrumentationConfig.HTTP_CLIENT_TAG_QUERY_STRING;
 import static datadog.trace.api.config.TraceInstrumentationConfig.HTTP_SERVER_TAG_QUERY_STRING;
@@ -380,6 +381,8 @@ public class Config {
 
   @Getter private final String jdbcPreparedStatementClassName;
   @Getter private final String jdbcConnectionClassName;
+
+  @Getter private final Set<String> grpcIgnoredOutboundMethods;
 
   private final ConfigProvider configProvider;
 
@@ -721,6 +724,9 @@ public class Config {
 
     kafkaClientBase64DecodingEnabled =
         configProvider.getBoolean(KAFKA_CLIENT_BASE64_DECODING_ENABLED, false);
+
+    grpcIgnoredOutboundMethods =
+        new HashSet<>(configProvider.getList(GRPC_IGNORED_OUTBOUND_METHODS));
 
     hystrixTagsEnabled = configProvider.getBoolean(HYSTRIX_TAGS_ENABLED, false);
 


### PR DESCRIPTION
By setting `-Ddd.trace.grpc.ignored.outbound.methods=<comma separated list of full method names>` users can prevent tracing of specific outbound requests. 