### PR TITLE
Use groovy map syntax in HTTP codec tests…

### DIFF
--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/B3HttpInjectorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/B3HttpInjectorTest.groovy
@@ -30,11 +30,7 @@ class B3HttpInjectorTest extends DDCoreSpecification {
       "fakeResource",
       samplingPriority,
       "fakeOrigin",
-      new HashMap<String, String>() { {
-          put("k1", "v1")
-          put("k2", "v2")
-        }
-      },
+      ["k1" : "v1", "k2" : "v2"],
       false,
       "fakeType",
       0,

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/DatadogHttpInjectorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/DatadogHttpInjectorTest.groovy
@@ -32,11 +32,7 @@ class DatadogHttpInjectorTest extends DDCoreSpecification {
       "fakeResource",
       samplingPriority,
       origin,
-      new HashMap<String, String>() { {
-          put("k1", "v1")
-          put("k2", "v2")
-        }
-      },
+      ["k1" : "v1", "k2" : "v2"],
       false,
       "fakeType",
       0,

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HaystackHttpInjectorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HaystackHttpInjectorTest.groovy
@@ -34,11 +34,7 @@ class HaystackHttpInjectorTest extends DDCoreSpecification {
       "fakeResource",
       samplingPriority,
       origin,
-      new HashMap<String, String>() { {
-          put("k1", "v1")
-          put("k2", "v2")
-        }
-      },
+      ["k1" : "v1", "k2" : "v2"],
       false,
       "fakeType",
       0,
@@ -86,12 +82,7 @@ class HaystackHttpInjectorTest extends DDCoreSpecification {
       "fakeResource",
       samplingPriority,
       origin,
-      new HashMap<String, String>() { {
-          put("k1", "v1")
-          put("k2", "v2")
-          put(HAYSTACK_TRACE_ID_BAGGAGE_KEY, haystackUuid)
-        }
-      },
+      ["k1" : "v1", "k2" : "v2", (HAYSTACK_TRACE_ID_BAGGAGE_KEY) : haystackUuid],
       false,
       "fakeType",
       0,

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HttpInjectorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HttpInjectorTest.groovy
@@ -35,11 +35,7 @@ class HttpInjectorTest extends DDCoreSpecification {
       "fakeResource",
       samplingPriority,
       origin,
-      new HashMap<String, String>() { {
-          put("k1", "v1")
-          put("k2", "v2")
-        }
-      },
+      ["k1" : "v1", "k2" : "v2"],
       false,
       "fakeType",
       0,


### PR DESCRIPTION
…as using java-style map initializer in groovy tests causes NPE in spotless plugin