### PR TITLE
Synchronize classloads at class not package granularity

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/DatadogClassLoader.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/DatadogClassLoader.java
@@ -70,15 +70,13 @@ public class DatadogClassLoader extends URLClassLoader {
   }
 
   Class<?> loadFromPackage(String packageName, String name) throws ClassNotFoundException {
-    InternalJarURLHandler.DelegationInfo packageDelegationInfo =
-        internalJarURLHandler.getDelegationInfo(packageName);
-    if (null != packageDelegationInfo) {
+    if (internalJarURLHandler.hasPackage(packageName)) {
       synchronized (getClassLoadingLock(name)) {
         Class<?> loaded = findLoadedClass(name);
         if (loaded != null) {
           return loaded;
         }
-        if (packageDelegationInfo.delegateFailureToFindClass()) {
+        if (!packageName.startsWith("java.")) {
           return findClass(name);
         }
       }
@@ -168,15 +166,13 @@ public class DatadogClassLoader extends URLClassLoader {
     @Override
     protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
       String packageName = shared.getPackageName(name);
-      InternalJarURLHandler.DelegationInfo packageDelegationInfo =
-          internalJarURLHandler.getDelegationInfo(packageName);
-      if (null != packageDelegationInfo) {
+      if (internalJarURLHandler.hasPackage(packageName)) {
         synchronized (getClassLoadingLock(name)) {
           Class<?> loaded = findLoadedClass(name);
           if (loaded != null) {
             return loaded;
           }
-          if (packageDelegationInfo.delegateFailureToFindClass()) {
+          if (!packageName.startsWith("java.")) {
             return findClass(name);
           }
         }

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/DatadogClassLoader.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/DatadogClassLoader.java
@@ -70,14 +70,15 @@ public class DatadogClassLoader extends URLClassLoader {
   }
 
   Class<?> loadFromPackage(String packageName, String name) throws ClassNotFoundException {
-    InternalJarURLHandler.Lock packageLock = internalJarURLHandler.getPackageLock(packageName);
-    if (null != packageLock) {
-      synchronized (packageLock) {
+    InternalJarURLHandler.DelegationInfo packageDelegationInfo =
+        internalJarURLHandler.getDelegationInfo(packageName);
+    if (null != packageDelegationInfo) {
+      synchronized (getClassLoadingLock(name)) {
         Class<?> loaded = findLoadedClass(name);
         if (loaded != null) {
           return loaded;
         }
-        if (packageLock.delegateFailureToFindClass()) {
+        if (packageDelegationInfo.delegateFailureToFindClass()) {
           return findClass(name);
         }
       }
@@ -167,14 +168,15 @@ public class DatadogClassLoader extends URLClassLoader {
     @Override
     protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
       String packageName = shared.getPackageName(name);
-      InternalJarURLHandler.Lock packageLock = internalJarURLHandler.getPackageLock(packageName);
-      if (null != packageLock) {
-        synchronized (packageLock) {
+      InternalJarURLHandler.DelegationInfo packageDelegationInfo =
+          internalJarURLHandler.getDelegationInfo(packageName);
+      if (null != packageDelegationInfo) {
+        synchronized (getClassLoadingLock(name)) {
           Class<?> loaded = findLoadedClass(name);
           if (loaded != null) {
             return loaded;
           }
-          if (packageLock.delegateFailureToFindClass()) {
+          if (packageDelegationInfo.delegateFailureToFindClass()) {
             return findClass(name);
           }
         }

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/InternalJarURLHandler.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/InternalJarURLHandler.java
@@ -27,7 +27,7 @@ public class InternalJarURLHandler extends URLStreamHandler {
 
   private final String name;
   private final FileNotInInternalJar notFound;
-  private final Map<String, Lock> packages = new HashMap<>();
+  private final Map<String, DelegationInfo> packages = new HashMap<>();
   private final JarFile bootstrapJarFile;
 
   private WeakReference<Pair<String, JarEntry>> cache = NULL;
@@ -50,7 +50,7 @@ public class InternalJarURLHandler extends URLStreamHandler {
               if (name.length() > prefix) {
                 String dir = name.substring(prefix, name.length() - 1);
                 String currentPackage = dir.replace('/', '.');
-                packages.put(currentPackage, new Lock(currentPackage));
+                packages.put(currentPackage, new DelegationInfo(currentPackage));
               }
             }
           }
@@ -66,11 +66,11 @@ public class InternalJarURLHandler extends URLStreamHandler {
     this.bootstrapJarFile = jarFile;
   }
 
-  Map<String, Lock> getPackages() {
+  Map<String, DelegationInfo> getPackages() {
     return packages;
   }
 
-  Lock getPackageLock(String packageName) {
+  DelegationInfo getDelegationInfo(String packageName) {
     return packages.get(packageName);
   }
 
@@ -144,14 +144,15 @@ public class InternalJarURLHandler extends URLStreamHandler {
   }
 
   /**
-   * This {@link Lock} allows the class loading code to check if failures to find a class should be
-   * delegated to {@code findClass} or if it should fall through to {@code super.loadClass} which is
-   * needed for classes that we inject that live in the {@code java.*} package.
+   * This {@link DelegationInfo} allows the class loading code to check if failures to find a class
+   * should be delegated to {@code findClass} or if it should fall through to {@code
+   * super.loadClass} which is needed for classes that we inject that live in the {@code java.*}
+   * package.
    */
-  public static final class Lock {
+  public static final class DelegationInfo {
     private final boolean delegateFailureToFindClass;
 
-    public Lock(String packageName) {
+    public DelegationInfo(String packageName) {
       this.delegateFailureToFindClass = !packageName.startsWith("java.");
     }
 

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/InternalJarURLHandlerTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/InternalJarURLHandlerTest.groovy
@@ -13,7 +13,7 @@ class InternalJarURLHandlerTest extends DDSpecification {
     setup:
     InternalJarURLHandler handler = new InternalJarURLHandler(dir, testJarLocation)
     expect:
-    packages == handler.getPackages().keySet()
+    packages == handler.getPackages()
 
     where:
     dir      | packages


### PR DESCRIPTION
This prevents deadlock with the caffeine cache when two classes are loaded from the same package from two different threads at the same time, where a class load from one thread obtains the package level lock first, but loses the race to caffeine's lock around the key (i.e. every class load with same classloader competes for this lock), but the holder of caffeine's lock can't get the package level lock and complete the compute because it's already held. I don't think there is a way to reliably reproduce this deadlock in a unit test.

