### PR TITLE
avoid varargs allocation in Pair.hashCode

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/api/Pair.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/api/Pair.java
@@ -44,6 +44,6 @@ public final class Pair<T, U> {
 
   @Override
   public int hashCode() {
-    return Objects.hash(left, right);
+    return 31 * (null == left ? 0 : left.hashCode()) + (null == right ? 0 : right.hashCode());
   }
 }

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/api/Pair.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/api/Pair.java
@@ -1,6 +1,7 @@
 package datadog.trace.bootstrap.instrumentation.api;
 
 import java.util.Objects;
+import javax.annotation.Nullable;
 
 public final class Pair<T, U> {
 
@@ -11,15 +12,17 @@ public final class Pair<T, U> {
   private final T left;
   private final U right;
 
-  Pair(T left, U right) {
+  Pair(@Nullable T left, @Nullable U right) {
     this.left = left;
     this.right = right;
   }
 
+  @Nullable
   public T getLeft() {
     return left;
   }
 
+  @Nullable
   public U getRight() {
     return right;
   }


### PR DESCRIPTION
I don't know why the varargs allocation doesn't get eliminated here, but it doesn't 
<img width="667" alt="Screenshot 2021-03-17 at 20 09 11" src="https://user-images.githubusercontent.com/16439049/111531874-fdd0e980-875c-11eb-8b88-0469932abe20.png">

