### PR TITLE
enable tracer metrics

### DIFF
--- a/dd-java-agent/instrumentation/okhttp-3/src/test/groovy/OkHttp3Test.groovy
+++ b/dd-java-agent/instrumentation/okhttp-3/src/test/groovy/OkHttp3Test.groovy
@@ -14,6 +14,14 @@ import java.util.concurrent.TimeUnit
 class OkHttp3Test extends HttpClientTest {
 
   @Override
+  protected void configurePreAgent() {
+    super.configurePreAgent()
+    // disable tracer metrics because it uses OkHttp and class loading is
+    // not isolated in tests
+    injectSysConfig("dd.trace.tracer.metrics.enabled", "false")
+  }
+
+  @Override
   boolean useStrictTraceWrites() {
     // TODO fix this by making sure that spans get closed properly
     return false

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -601,10 +601,10 @@ public class Config {
             && configProvider.getBoolean(PERF_METRICS_ENABLED, DEFAULT_PERF_METRICS_ENABLED);
 
     tracerMetricsEnabled =
-        isJavaVersionAtLeast(8) && configProvider.getBoolean(TRACER_METRICS_ENABLED, false);
+        isJavaVersionAtLeast(8) && configProvider.getBoolean(TRACER_METRICS_ENABLED, true);
     tracerMetricsBufferingEnabled =
         configProvider.getBoolean(TRACER_METRICS_BUFFERING_ENABLED, false);
-    tracerMetricsMaxAggregates = configProvider.getInteger(TRACER_METRICS_MAX_AGGREGATES, 1000);
+    tracerMetricsMaxAggregates = configProvider.getInteger(TRACER_METRICS_MAX_AGGREGATES, 2048);
     tracerMetricsMaxPending = configProvider.getInteger(TRACER_METRICS_MAX_PENDING, 2048);
 
     logsInjectionEnabled =


### PR DESCRIPTION
This change enables a feature which tracks metrics in the tracer instead of the trace agent, and allows the tracer to drop traces the trace agent would drop before serialising them, if the trace agent version is >= 7.27.0, which can significantly reduce the overhead of tracing. This feature has been behind a feature flag for several months and is now deemed stable enough to release.

The feature can be disabled with `-Ddd.trace.tracer.metrics.enabled=false` or `DS_TRACE_TRACER_METRICS_ENABLED=false`