### PR TITLE
Clean up some runtimes in tests

### DIFF
--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/springdata/Elasticsearch2SpringRepositoryTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/springdata/Elasticsearch2SpringRepositoryTest.groovy
@@ -29,6 +29,10 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
     TEST_WRITER.waitUntilReported(cleanupSpan)
   }
 
+  def cleanupSpec() {
+    applicationContext?.close()
+  }
+
   def "test empty repo"() {
     when:
     def result = repo.findAll()

--- a/dd-java-agent/instrumentation/vertx-rx-3.5/src/test/groovy/client/VertxRxCircuitBreakerWebClientTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-rx-3.5/src/test/groovy/client/VertxRxCircuitBreakerWebClientTest.groovy
@@ -9,6 +9,7 @@ import io.vertx.ext.web.client.WebClientOptions
 import io.vertx.reactivex.circuitbreaker.CircuitBreaker
 import io.vertx.reactivex.core.Vertx
 import io.vertx.reactivex.ext.web.client.WebClient
+import spock.lang.AutoCleanup
 import spock.lang.Shared
 import spock.lang.Timeout
 
@@ -22,12 +23,18 @@ class VertxRxCircuitBreakerWebClientTest extends HttpClientTest {
     return false
   }
 
+  @AutoCleanup
   @Shared
   Vertx vertx = Vertx.vertx(new VertxOptions())
+
   @Shared
   def clientOptions = new WebClientOptions().setConnectTimeout(CONNECT_TIMEOUT_MS).setIdleTimeout(READ_TIMEOUT_MS)
+
+  @AutoCleanup
   @Shared
   WebClient client = WebClient.create(vertx, clientOptions)
+
+  @AutoCleanup
   @Shared
   CircuitBreaker breaker = CircuitBreaker.create("my-circuit-breaker", vertx,
   new CircuitBreakerOptions()

--- a/dd-java-agent/instrumentation/vertx-rx-3.5/src/test/groovy/client/VertxRxWebClientTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-rx-3.5/src/test/groovy/client/VertxRxWebClientTest.groovy
@@ -7,6 +7,7 @@ import io.vertx.core.http.HttpMethod
 import io.vertx.ext.web.client.WebClientOptions
 import io.vertx.reactivex.core.Vertx
 import io.vertx.reactivex.ext.web.client.WebClient
+import spock.lang.AutoCleanup
 import spock.lang.Shared
 import spock.lang.Timeout
 
@@ -18,10 +19,14 @@ class VertxRxWebClientTest extends HttpClientTest {
     return false
   }
 
+  @AutoCleanup
   @Shared
   Vertx vertx = Vertx.vertx(new VertxOptions())
+
   @Shared
   def clientOptions = new WebClientOptions().setConnectTimeout(CONNECT_TIMEOUT_MS).setIdleTimeout(READ_TIMEOUT_MS)
+
+  @AutoCleanup
   @Shared
   WebClient client = WebClient.create(vertx, clientOptions)
 

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/test/groovy/client/VertxHttpClientTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/test/groovy/client/VertxHttpClientTest.groovy
@@ -7,6 +7,7 @@ import io.vertx.core.VertxOptions
 import io.vertx.core.http.HttpClientOptions
 import io.vertx.core.http.HttpClientResponse
 import io.vertx.core.http.HttpMethod
+import spock.lang.AutoCleanup
 import spock.lang.Shared
 import spock.lang.Timeout
 
@@ -20,10 +21,14 @@ class VertxHttpClientTest extends HttpClientTest {
     return false
   }
 
+  @AutoCleanup
   @Shared
   def vertx = Vertx.vertx(new VertxOptions())
+
   @Shared
   def clientOptions = new HttpClientOptions().setConnectTimeout(CONNECT_TIMEOUT_MS).setIdleTimeout(READ_TIMEOUT_MS)
+
+  @AutoCleanup
   @Shared
   def httpClient = vertx.createHttpClient(clientOptions)
 


### PR DESCRIPTION
This shuts down vertx and elastic runtimes and thread pools so we don't keep ~100 threads hanging around. Hopefully this will help with the IBM tests throwing OOM.