### PR TITLE
Better mongo scrubbing

### DIFF
--- a/dd-java-agent/instrumentation/mongo/driver-3.1/src/main/java/datadog/trace/instrumentation/mongo/BsonScrubber.java
+++ b/dd-java-agent/instrumentation/mongo/driver-3.1/src/main/java/datadog/trace/instrumentation/mongo/BsonScrubber.java
@@ -1,0 +1,553 @@
+package datadog.trace.instrumentation.mongo;
+
+import java.util.Map;
+import org.bson.BsonArray;
+import org.bson.BsonBinary;
+import org.bson.BsonDbPointer;
+import org.bson.BsonDocument;
+import org.bson.BsonJavaScriptWithScope;
+import org.bson.BsonReader;
+import org.bson.BsonRegularExpression;
+import org.bson.BsonTimestamp;
+import org.bson.BsonType;
+import org.bson.BsonValue;
+import org.bson.BsonWriter;
+import org.bson.types.ObjectId;
+
+public final class BsonScrubber implements BsonWriter, AutoCloseable {
+
+  private static final ThreadLocal<Context> CONTEXT =
+      new ThreadLocal<Context>() {
+        @Override
+        protected Context initialValue() {
+          return new Context();
+        }
+      };
+
+  private final Context context;
+  private boolean obfuscate = true;
+
+  public BsonScrubber() {
+    this.context = CONTEXT.get();
+  }
+
+  @Override
+  public void close() {
+    context.clear();
+  }
+
+  public String toResourceName() {
+    return context.asString();
+  }
+
+  private void applyObfuscationPolicy(String name) {
+    if (null != name && !context.ignoreSubTree()) {
+      switch (name) {
+        case "documents":
+        case "deletes":
+        case "updates": // we don't want to record data in resource names!
+        case "$in":
+        case "$setOnInsert":
+        case "$set":
+        case "arrayFilters": // collapse long lists
+          context.discardSubTree();
+          obfuscate = true;
+          break;
+        case "writeConcern":
+        case "readConcern":
+          context.keepSubTree();
+          obfuscate = false;
+          break;
+        case "$explain":
+        case "$db":
+        case "ordered":
+        case "delete":
+        case "insert":
+        case "upsert":
+        case "update":
+        case "find":
+        case "count":
+        case "create":
+          obfuscate = false;
+          break;
+        default:
+          obfuscate = !context.disableObfuscation();
+      }
+    }
+  }
+
+  @Override
+  public void flush() {}
+
+  private void writeObfuscated() {
+    context.write("\"?\"");
+  }
+
+  @Override
+  public void writeBinaryData(BsonBinary binary) {
+    writeObfuscated();
+  }
+
+  @Override
+  public void writeBinaryData(String name, BsonBinary binary) {
+    writeName(name);
+    writeBinaryData(binary);
+  }
+
+  @Override
+  public void writeBoolean(boolean value) {
+    if (obfuscate) {
+      writeObfuscated();
+    } else {
+      context.write(value);
+    }
+  }
+
+  @Override
+  public void writeBoolean(String name, boolean value) {
+    writeName(name);
+    writeBoolean(value);
+  }
+
+  @Override
+  public void writeDateTime(long value) {
+    writeObfuscated();
+  }
+
+  @Override
+  public void writeDateTime(String name, long value) {
+    writeName(name);
+    writeDateTime(value);
+  }
+
+  @Override
+  public void writeDBPointer(BsonDbPointer value) {
+    writeObfuscated();
+  }
+
+  @Override
+  public void writeDBPointer(String name, BsonDbPointer value) {
+    writeName(name);
+    writeDBPointer(value);
+  }
+
+  @Override
+  public void writeDouble(double value) {
+    writeObfuscated();
+  }
+
+  @Override
+  public void writeDouble(String name, double value) {
+    writeName(name);
+    writeDouble(value);
+  }
+
+  @Override
+  public void writeEndArray() {
+    context.write(']');
+  }
+
+  @Override
+  public void writeEndDocument() {
+    context.write('}');
+    context.endDocument();
+  }
+
+  @Override
+  public void writeInt32(int value) {
+    if (obfuscate) {
+      writeObfuscated();
+    } else {
+      context.write(value);
+    }
+  }
+
+  @Override
+  public void writeInt32(String name, int value) {
+    writeName(name);
+    writeInt32(value);
+  }
+
+  @Override
+  public void writeInt64(long value) {
+    writeObfuscated();
+  }
+
+  @Override
+  public void writeInt64(String name, long value) {
+    writeName(name);
+    writeInt64(value);
+  }
+
+  @Override
+  public void writeJavaScript(String code) {
+    writeObfuscated();
+  }
+
+  @Override
+  public void writeJavaScript(String name, String code) {
+    writeName(name);
+    writeJavaScript(code);
+  }
+
+  @Override
+  public void writeJavaScriptWithScope(String code) {
+    writeObfuscated();
+  }
+
+  @Override
+  public void writeJavaScriptWithScope(String name, String code) {
+    writeName(name);
+    writeJavaScriptWithScope(code);
+  }
+
+  @Override
+  public void writeMaxKey() {
+    writeObfuscated();
+  }
+
+  @Override
+  public void writeMaxKey(String name) {
+    writeName(name);
+    writeMaxKey();
+  }
+
+  @Override
+  public void writeMinKey() {
+    writeObfuscated();
+  }
+
+  @Override
+  public void writeMinKey(String name) {
+    writeName(name);
+    writeMinKey();
+  }
+
+  @Override
+  public void writeName(String name) {
+    applyObfuscationPolicy(name);
+    if (name != null) {
+      context.write('\"');
+      context.write(name);
+      context.write('\"');
+      context.write(':');
+      context.write(' ');
+    }
+  }
+
+  @Override
+  public void writeNull() {
+    writeObfuscated();
+  }
+
+  @Override
+  public void writeNull(String name) {
+    writeName(name);
+    writeNull();
+  }
+
+  @Override
+  public void writeObjectId(ObjectId objectId) {
+    writeObfuscated();
+  }
+
+  @Override
+  public void writeObjectId(String name, ObjectId objectId) {
+    writeName(name);
+    writeObjectId(objectId);
+  }
+
+  @Override
+  public void writeRegularExpression(BsonRegularExpression regularExpression) {
+    writeString(regularExpression.getPattern());
+  }
+
+  @Override
+  public void writeRegularExpression(String name, BsonRegularExpression regularExpression) {
+    writeName(name);
+    writeRegularExpression(regularExpression);
+  }
+
+  @Override
+  public void writeStartArray() {
+    context.write('[');
+  }
+
+  @Override
+  public void writeStartArray(String name) {
+    writeName(name);
+    writeStartArray();
+  }
+
+  @Override
+  public void writeStartDocument() {
+    context.startDocument();
+    context.write('{');
+  }
+
+  @Override
+  public void writeStartDocument(String name) {
+    writeName(name);
+    writeStartDocument();
+  }
+
+  @Override
+  public void writeString(String value) {
+    if (value.startsWith("$")) {
+      context.write(value);
+    } else if (obfuscate) {
+      writeObfuscated();
+    } else {
+      context.write('\"');
+      context.write(value);
+      context.write('\"');
+    }
+  }
+
+  @Override
+  public void writeString(String name, String value) {
+    writeName(name);
+    writeString(value);
+  }
+
+  @Override
+  public void writeSymbol(String value) {
+    writeString(value);
+  }
+
+  @Override
+  public void writeSymbol(String name, String value) {
+    writeName(name);
+    writeSymbol(value);
+  }
+
+  @Override
+  public void writeTimestamp(BsonTimestamp value) {
+    writeObfuscated();
+  }
+
+  @Override
+  public void writeTimestamp(String name, BsonTimestamp value) {
+    writeName(name);
+    writeTimestamp(value);
+  }
+
+  @Override
+  public void writeUndefined() {
+    writeObfuscated();
+  }
+
+  @Override
+  public void writeUndefined(String name) {
+    writeName(name);
+    writeUndefined();
+  }
+
+  @Override
+  public void pipe(BsonReader reader) {
+    pipeDocument(null, reader);
+  }
+
+  private void pipeDocument(String attribute, final BsonReader reader) {
+    reader.readStartDocument();
+    if (null == attribute) {
+      writeStartDocument();
+    } else {
+      writeStartDocument(attribute);
+    }
+    BsonType type = reader.readBsonType();
+    while (type != BsonType.END_OF_DOCUMENT) {
+      pipeValue(reader.readName(), reader);
+      type = reader.readBsonType();
+      nextValue(type);
+    }
+    reader.readEndDocument();
+    writeEndDocument();
+  }
+
+  private void pipeJavascriptWithScope(String attribute, BsonReader reader) {
+    writeJavaScriptWithScope(attribute, reader.readJavaScriptWithScope());
+    pipeDocument(attribute, reader);
+  }
+
+  private void pipeValue(String attribute, BsonReader reader) {
+    switch (reader.getCurrentBsonType()) {
+      case DOCUMENT:
+        pipeDocument(attribute, reader);
+        break;
+      case ARRAY:
+        pipeArray(attribute, reader);
+        break;
+      case DOUBLE:
+        writeDouble(attribute, reader.readDouble());
+        break;
+      case STRING:
+        writeString(attribute, reader.readString());
+        break;
+      case BINARY:
+        writeBinaryData(attribute, reader.readBinaryData());
+        break;
+      case UNDEFINED:
+        reader.readUndefined();
+        writeUndefined();
+        break;
+      case OBJECT_ID:
+        writeObjectId(attribute, reader.readObjectId());
+        break;
+      case BOOLEAN:
+        writeBoolean(attribute, reader.readBoolean());
+        break;
+      case DATE_TIME:
+        writeDateTime(attribute, reader.readDateTime());
+        break;
+      case NULL:
+        reader.readNull();
+        writeNull(attribute);
+        break;
+      case REGULAR_EXPRESSION:
+        writeRegularExpression(attribute, reader.readRegularExpression());
+        break;
+      case JAVASCRIPT:
+        writeJavaScript(attribute, reader.readJavaScript());
+        break;
+      case SYMBOL:
+        writeSymbol(attribute, reader.readSymbol());
+        break;
+      case JAVASCRIPT_WITH_SCOPE:
+        pipeJavascriptWithScope(attribute, reader);
+        break;
+      case INT32:
+        writeInt32(attribute, reader.readInt32());
+        break;
+      case TIMESTAMP:
+        writeTimestamp(attribute, reader.readTimestamp());
+        break;
+      case INT64:
+        writeInt64(attribute, reader.readInt64());
+        break;
+      case MIN_KEY:
+        reader.readMinKey();
+        writeMinKey(attribute);
+        break;
+      case DB_POINTER:
+        writeDBPointer(attribute, reader.readDBPointer());
+        break;
+      case MAX_KEY:
+        reader.readMaxKey();
+        writeMaxKey(attribute);
+        break;
+      default:
+        reader.skipValue();
+        writeUndefined(attribute);
+    }
+  }
+
+  private void pipeDocument(String attribute, BsonDocument value) {
+    writeStartDocument(attribute);
+    for (Map.Entry<String, BsonValue> cur : value.entrySet()) {
+      pipeValue(cur.getKey(), cur.getValue());
+    }
+    writeEndDocument();
+  }
+
+  private void pipeArray(String attribute, BsonReader reader) {
+    reader.readStartArray();
+    writeStartArray(attribute);
+    BsonType type = reader.readBsonType();
+    while (type != BsonType.END_OF_DOCUMENT) {
+      pipeValue(null, reader);
+      type = reader.readBsonType();
+      nextValue(type);
+    }
+    reader.readEndArray();
+    writeEndArray();
+  }
+
+  private void pipeArray(String attribute, final BsonArray array) {
+    writeStartArray(attribute);
+    for (BsonValue cur : array) {
+      pipeValue(null, cur);
+    }
+    writeEndArray();
+  }
+
+  private void pipeJavascriptWithScope(
+      String attribute, final BsonJavaScriptWithScope javaScriptWithScope) {
+    writeJavaScriptWithScope(javaScriptWithScope.getCode());
+    pipeDocument(attribute, javaScriptWithScope.getScope());
+  }
+
+  private void pipeValue(String attribute, final BsonValue value) {
+    switch (value.getBsonType()) {
+      case DOCUMENT:
+        pipeDocument(attribute, value.asDocument());
+        break;
+      case ARRAY:
+        pipeArray(attribute, value.asArray());
+        break;
+      case DOUBLE:
+        writeDouble(attribute, value.asDouble().getValue());
+        break;
+      case STRING:
+        writeString(attribute, value.asString().getValue());
+        break;
+      case BINARY:
+        writeBinaryData(attribute, value.asBinary());
+        break;
+      case UNDEFINED:
+        writeUndefined();
+        break;
+      case OBJECT_ID:
+        writeObjectId(attribute, value.asObjectId().getValue());
+        break;
+      case BOOLEAN:
+        writeBoolean(attribute, value.asBoolean().getValue());
+        break;
+      case DATE_TIME:
+        writeDateTime(attribute, value.asDateTime().getValue());
+        break;
+      case NULL:
+        writeNull();
+        break;
+      case REGULAR_EXPRESSION:
+        writeRegularExpression(attribute, value.asRegularExpression());
+        break;
+      case JAVASCRIPT:
+        writeJavaScript(attribute, value.asJavaScript().getCode());
+        break;
+      case SYMBOL:
+        writeSymbol(attribute, value.asSymbol().getSymbol());
+        break;
+      case JAVASCRIPT_WITH_SCOPE:
+        pipeJavascriptWithScope(attribute, value.asJavaScriptWithScope());
+        break;
+      case INT32:
+        writeInt32(attribute, value.asInt32().getValue());
+        break;
+      case TIMESTAMP:
+        writeTimestamp(attribute, value.asTimestamp());
+        break;
+      case INT64:
+        writeInt64(attribute, value.asInt64().getValue());
+        break;
+      case MIN_KEY:
+        writeMinKey(attribute);
+        break;
+      case DB_POINTER:
+        writeDBPointer(attribute, value.asDBPointer());
+        break;
+      case MAX_KEY:
+        writeMaxKey(attribute);
+        break;
+      default:
+        writeUndefined(attribute);
+    }
+  }
+
+  private void nextValue(BsonType type) {
+    if (type != BsonType.END_OF_DOCUMENT) {
+      context.write(',');
+      context.write(' ');
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/mongo/driver-3.1/src/main/java/datadog/trace/instrumentation/mongo/Context.java
+++ b/dd-java-agent/instrumentation/mongo/driver-3.1/src/main/java/datadog/trace/instrumentation/mongo/Context.java
@@ -1,0 +1,90 @@
+package datadog.trace.instrumentation.mongo;
+
+final class Context {
+
+  private final StringBuilder buffer = new StringBuilder();
+
+  // specifies the depth below which everything must be discarded,
+  // e.g. because we're inside an $in clause we want to collapse
+  private int discardDepth = 64;
+  private int keepDepth = 64;
+  private int depth;
+
+  void discardSubTree() {
+    if (depth < discardDepth) {
+      this.discardDepth = depth;
+    }
+  }
+
+  void keepSubTree() {
+    if (depth < keepDepth) {
+      this.keepDepth = depth;
+    }
+  }
+
+  public void startDocument() {
+    ++depth;
+  }
+
+  public void endDocument() {
+    --depth;
+    if (discardDepth == depth) {
+      discardDepth = 64;
+    }
+    if (keepDepth == depth) {
+      keepDepth = 64;
+    }
+  }
+
+  boolean disableObfuscation() {
+    return depth > keepDepth;
+  }
+
+  boolean ignoreSubTree() {
+    return depth > discardDepth;
+  }
+
+  private boolean tooDeep() {
+    // this means we are parsing a huge document, which we will truncate anyway
+    // note that MongoDB sets a default max nested depth of 100, and MongoDB users
+    // are generally advised to avoid deep nesting for the sake of database performance
+    return depth >= 64;
+  }
+
+  private boolean shouldWrite() {
+    return !tooDeep() && (depth > keepDepth || depth < discardDepth + 1);
+  }
+
+  void write(char symbol) {
+    if (shouldWrite()) {
+      buffer.append(symbol);
+    }
+  }
+
+  void write(long number) {
+    if (shouldWrite()) {
+      buffer.append(number);
+    }
+  }
+
+  void write(boolean value) {
+    if (shouldWrite()) {
+      buffer.append(value);
+    }
+  }
+
+  void write(String string) {
+    if (shouldWrite()) {
+      buffer.append(string);
+    }
+  }
+
+  void clear() {
+    buffer.setLength(0);
+    depth = 0;
+  }
+
+  String asString() {
+    return buffer.toString();
+  }
+}

--- a/dd-java-agent/instrumentation/mongo/driver-3.1/src/main/java/datadog/trace/instrumentation/mongo/MongoClientDecorator.java
+++ b/dd-java-agent/instrumentation/mongo/driver-3.1/src/main/java/datadog/trace/instrumentation/mongo/MongoClientDecorator.java
@@ -9,13 +9,8 @@ import datadog.trace.api.DDSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.DBTypeProcessingDatabaseClientDecorator;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import org.bson.BsonArray;
 import org.bson.BsonDocument;
-import org.bson.BsonString;
-import org.bson.BsonValue;
+import org.bson.BsonDocumentReader;
 
 public class MongoClientDecorator
     extends DBTypeProcessingDatabaseClientDecorator<CommandStartedEvent> {
@@ -88,55 +83,14 @@ public class MongoClientDecorator
   }
 
   public AgentSpan onStatement(final AgentSpan span, final BsonDocument statement) {
-
-    // scrub the Mongo command so that parameters are removed from the string
-    final BsonDocument scrubbed = scrub(statement);
-    final String mongoCmd = scrubbed.toString();
-
-    span.setResourceName(mongoCmd);
+    span.setResourceName(scrub(statement));
     return span;
   }
 
-  /**
-   * The values of these mongo fields will not be scrubbed out. This allows the non-sensitive
-   * collection names to be captured.
-   */
-  private static final List<String> UNSCRUBBED_FIELDS =
-      Arrays.asList("ordered", "insert", "count", "find", "create");
-
-  private static final BsonValue HIDDEN_CHAR = new BsonString("?");
-
-  private static BsonDocument scrub(final BsonDocument origin) {
-    final BsonDocument scrub = new BsonDocument();
-    for (final Map.Entry<String, BsonValue> entry : origin.entrySet()) {
-      if (UNSCRUBBED_FIELDS.contains(entry.getKey()) && entry.getValue().isString()) {
-        scrub.put(entry.getKey(), entry.getValue());
-      } else {
-        final BsonValue child = scrub(entry.getValue());
-        scrub.put(entry.getKey(), child);
-      }
+  private static String scrub(final BsonDocument origin) {
+    try (BsonScrubber scrubber = new BsonScrubber()) {
+      scrubber.pipe(new BsonDocumentReader(origin));
+      return scrubber.toResourceName();
     }
-    return scrub;
-  }
-
-  private static BsonValue scrub(final BsonArray origin) {
-    final BsonArray scrub = new BsonArray();
-    for (final BsonValue value : origin) {
-      final BsonValue child = scrub(value);
-      scrub.add(child);
-    }
-    return scrub;
-  }
-
-  private static BsonValue scrub(final BsonValue origin) {
-    final BsonValue scrubbed;
-    if (origin.isDocument()) {
-      scrubbed = scrub(origin.asDocument());
-    } else if (origin.isArray()) {
-      scrubbed = scrub(origin.asArray());
-    } else {
-      scrubbed = HIDDEN_CHAR;
-    }
-    return scrubbed;
   }
 }

--- a/dd-java-agent/instrumentation/mongo/driver-3.1/src/main/java/datadog/trace/instrumentation/mongo/MongoClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/mongo/driver-3.1/src/main/java/datadog/trace/instrumentation/mongo/MongoClientInstrumentation.java
@@ -33,7 +33,12 @@ public final class MongoClientInstrumentation extends Instrumenter.Tracing {
   @Override
   public String[] helperClassNames() {
     return new String[] {
-      packageName + ".MongoClientDecorator", packageName + ".TracingCommandListener"
+      packageName + ".MongoClientDecorator",
+      packageName + ".BsonScrubber",
+      packageName + ".BsonScrubber$1",
+      packageName + ".BsonScrubber$2",
+      packageName + ".Context",
+      packageName + ".TracingCommandListener"
     };
   }
 

--- a/dd-java-agent/instrumentation/mongo/driver-3.1/src/test/groovy/BsonScrubberTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-3.1/src/test/groovy/BsonScrubberTest.groovy
@@ -1,0 +1,30 @@
+import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.instrumentation.mongo.BsonScrubber
+import org.bson.BsonDocument
+import org.bson.BsonDocumentReader
+
+class BsonScrubberTest extends AgentTestRunner {
+
+  def "test BSON scrubber"() {
+    setup:
+    BsonDocument doc = BsonDocument.parse(input)
+
+    when:
+    BsonScrubber scrubber = new BsonScrubber()
+    scrubber.pipe(new BsonDocumentReader(doc))
+    String resourceName = scrubber.toResourceName()
+
+    then:
+    resourceName == expected
+
+    cleanup:
+    scrubber.close()
+
+    where:
+    input                                                                                                                                                                                                                                                                                | expected
+    "{ _id : { project_id : '\$project_id', date : '\$VehicleEntry.@Date' }, passed : { \$sum : { \$cond : [ { \$eq : [ '\$VehicleEntry.VehicleStatus', 'PASSED' ] }, 1, 0 ] } }, failed : { \$sum : { \$cond : [ { \$eq : [ '\$VehicleEntry.VehicleStatus', 'FAILED' ] }, 1, 0 ] } } }" | "{\"_id\": {\"project_id\": \$project_id, \"date\": \$VehicleEntry.@Date}, \"passed\": {\"\$sum\": {\"\$cond\": [{\"\$eq\": [\$VehicleEntry.VehicleStatus, \"?\"]}, \"?\", \"?\"]}}, \"failed\": {\"\$sum\": {\"\$cond\": [{\"\$eq\": [\$VehicleEntry.VehicleStatus, \"?\"]}, \"?\", \"?\"]}}}"
+    "{\"update\": \"topics\", \"ordered\": true, \"writeConcern\": {\"w\": \"majority\"}, \"txnNumber\": \"?\", \"\$db\": \"database\", \"\$clusterTime\": {\"clusterTime\": \"?\", \"signature\": {\"hash\": \"?\", \"keyId\": \"?\"}}, \"lsid\": {\"id\": \"?\"}, \"updates\": \"?\"}" | "{\"update\": \"topics\", \"ordered\": true, \"writeConcern\": {\"w\": \"majority\"}, \"txnNumber\": \"?\", \"\$db\": \"database\", \"\$clusterTime\": {\"clusterTime\": \"?\", \"signature\": {\"hash\": \"?\", \"keyId\": \"?\"}}, \"lsid\": {\"id\": \"?\"}, \"updates\": \"?\"}"
+    "{\"update\" : \"orders\", \"ordered\" : false, \"writeConcern\" : { \"w\" : \"majority\" }, \"updates\": [{ \"q\" : { \"_id\" : 1 }, \"u\" : { \"orderId\" : \"Account1\", \"qty\" : 10 } } ]}"                                                                                 | "{\"update\": \"orders\", \"ordered\": false, \"writeConcern\": {\"w\": \"majority\"}, \"updates\": []}"
+    "{\"insert\" : \"stuff\", \"ordered\" : true, \"writeConcern\" : { \"w\" : 10 }, \"documents\": [{ \"_id\" : { \"s\" : 0, \"i\": \"DEADBEEF\" }, \"array\" : [0, \"foo\", {\"foo\": 10}], \"qty\" : 10 } ]}"                                                                      | "{\"insert\": \"stuff\", \"ordered\": true, \"writeConcern\": {\"w\": 10}, \"documents\": []}"
+  }
+}

--- a/dd-java-agent/instrumentation/mongo/driver-3.1/src/test/groovy/MongoClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-3.1/src/test/groovy/MongoClientTest.groovy
@@ -20,6 +20,11 @@ import static datadog.trace.api.config.TraceInstrumentationConfig.DB_CLIENT_HOST
 class MongoClientTest extends MongoBaseTest {
   static final String DB_NAME = "v3_test_db"
 
+  @Override
+  def dbName() {
+    return DB_NAME
+  }
+
   @Shared
   MongoClient client
 
@@ -110,7 +115,7 @@ class MongoClientTest extends MongoBaseTest {
     collection.count() == 1
     assertTraces(2) {
       trace(1) {
-        mongoSpan(it, 0, "insert", "{\"insert\":\"$collectionName\",\"ordered\":\"?\",\"documents\":[{\"_id\":\"?\",\"password\":\"?\"}]}")
+        mongoSpan(it, 0, "insert", "{\"insert\":\"$collectionName\",\"ordered\":true,\"documents\":[]}")
       }
       trace(1) {
         mongoSpan(it, 0, "count", "{\"count\":\"$collectionName\",\"query\":{}}")
@@ -143,7 +148,7 @@ class MongoClientTest extends MongoBaseTest {
     collection.count() == 1
     assertTraces(2) {
       trace(1) {
-        mongoSpan(it, 0, "update", "{\"update\":\"?\",\"ordered\":\"?\",\"updates\":[{\"q\":{\"password\":\"?\"},\"u\":{\"\$set\":{\"password\":\"?\"}}}]}")
+        mongoSpan(it, 0, "update", "{\"update\":\"$collectionName\",\"ordered\":true,\"updates\":[]}")
       }
       trace(1) {
         mongoSpan(it, 0, "count", "{\"count\":\"$collectionName\",\"query\":{}}")
@@ -174,7 +179,7 @@ class MongoClientTest extends MongoBaseTest {
     collection.count() == 0
     assertTraces(2) {
       trace(1) {
-        mongoSpan(it, 0, "delete", "{\"delete\":\"?\",\"ordered\":\"?\",\"deletes\":[{\"q\":{\"password\":\"?\"},\"limit\":\"?\"}]}")
+        mongoSpan(it, 0, "delete", "{\"delete\":\"$collectionName\",\"ordered\":true,\"deletes\":[]}")
       }
       trace(1) {
         mongoSpan(it, 0, "count", "{\"count\":\"$collectionName\",\"query\":{}}")

--- a/dd-java-agent/instrumentation/mongo/driver-4/src/main/java/datadog/trace/instrumentation/mongo4/BsonScrubber.java
+++ b/dd-java-agent/instrumentation/mongo/driver-4/src/main/java/datadog/trace/instrumentation/mongo4/BsonScrubber.java
@@ -1,0 +1,568 @@
+package datadog.trace.instrumentation.mongo4;
+
+import java.util.Map;
+import org.bson.BsonArray;
+import org.bson.BsonBinary;
+import org.bson.BsonDbPointer;
+import org.bson.BsonDocument;
+import org.bson.BsonJavaScriptWithScope;
+import org.bson.BsonReader;
+import org.bson.BsonRegularExpression;
+import org.bson.BsonTimestamp;
+import org.bson.BsonType;
+import org.bson.BsonValue;
+import org.bson.BsonWriter;
+import org.bson.types.Decimal128;
+import org.bson.types.ObjectId;
+
+public class BsonScrubber implements BsonWriter, AutoCloseable {
+
+  private static final ThreadLocal<Context> CONTEXT =
+      new ThreadLocal<Context>() {
+        @Override
+        protected Context initialValue() {
+          return new Context();
+        }
+      };
+
+  private final Context context = CONTEXT.get();
+  private boolean obfuscate = true;
+
+  @Override
+  public void close() {
+    context.clear();
+  }
+
+  public String toResourceName() {
+    return context.asString();
+  }
+
+  private void applyObfuscationPolicy(String name) {
+    if (null != name && !context.ignoreSubTree()) {
+      switch (name) {
+        case "documents":
+        case "deletes":
+        case "updates": // we don't want to record data in resource names!
+        case "$in":
+        case "$setOnInsert":
+        case "$set":
+        case "arrayFilters": // collapse long lists
+          context.discardSubTree();
+          obfuscate = true;
+          break;
+        case "writeConcern":
+        case "readConcern":
+          context.keepSubTree();
+          obfuscate = false;
+          break;
+        case "$explain":
+        case "$db":
+        case "ordered":
+        case "delete":
+        case "insert":
+        case "upsert":
+        case "update":
+        case "find":
+        case "count":
+        case "create":
+          obfuscate = false;
+          break;
+        default:
+          obfuscate = !context.disableObfuscation();
+      }
+    }
+  }
+
+  @Override
+  public void flush() {}
+
+  private void writeObfuscated() {
+    context.write("\"?\"");
+  }
+
+  @Override
+  public void writeBinaryData(BsonBinary binary) {
+    writeObfuscated();
+  }
+
+  @Override
+  public void writeBinaryData(String name, BsonBinary binary) {
+    writeName(name);
+    writeBinaryData(binary);
+  }
+
+  @Override
+  public void writeBoolean(boolean value) {
+    if (obfuscate) {
+      writeObfuscated();
+    } else {
+      context.write(value);
+    }
+  }
+
+  @Override
+  public void writeBoolean(String name, boolean value) {
+    writeName(name);
+    writeBoolean(value);
+  }
+
+  @Override
+  public void writeDateTime(long value) {
+    writeObfuscated();
+  }
+
+  @Override
+  public void writeDateTime(String name, long value) {
+    writeName(name);
+    writeDateTime(value);
+  }
+
+  @Override
+  public void writeDBPointer(BsonDbPointer value) {
+    writeObfuscated();
+  }
+
+  @Override
+  public void writeDBPointer(String name, BsonDbPointer value) {
+    writeName(name);
+    writeDBPointer(value);
+  }
+
+  @Override
+  public void writeDouble(double value) {
+    writeObfuscated();
+  }
+
+  @Override
+  public void writeDouble(String name, double value) {
+    writeName(name);
+    writeDouble(value);
+  }
+
+  @Override
+  public void writeEndArray() {
+    // overwrites an eagerly added comma
+    context.write(']');
+  }
+
+  @Override
+  public void writeEndDocument() {
+    context.write('}');
+    context.endDocument();
+  }
+
+  @Override
+  public void writeInt32(int value) {
+    if (obfuscate) {
+      writeObfuscated();
+    } else {
+      context.write(value);
+    }
+  }
+
+  @Override
+  public void writeInt32(String name, int value) {
+    writeName(name);
+    writeInt32(value);
+  }
+
+  @Override
+  public void writeInt64(long value) {
+    writeObfuscated();
+  }
+
+  @Override
+  public void writeInt64(String name, long value) {
+    writeName(name);
+    writeInt64(value);
+  }
+
+  @Override
+  public void writeDecimal128(Decimal128 value) {
+    writeObfuscated();
+  }
+
+  @Override
+  public void writeDecimal128(String name, Decimal128 value) {
+    writeName(name);
+    writeDecimal128(value);
+  }
+
+  @Override
+  public void writeJavaScript(String code) {
+    writeObfuscated();
+  }
+
+  @Override
+  public void writeJavaScript(String name, String code) {
+    writeName(name);
+    writeJavaScript(code);
+  }
+
+  @Override
+  public void writeJavaScriptWithScope(String code) {
+    writeObfuscated();
+  }
+
+  @Override
+  public void writeJavaScriptWithScope(String name, String code) {
+    writeName(name);
+    writeJavaScriptWithScope(code);
+  }
+
+  @Override
+  public void writeMaxKey() {
+    writeObfuscated();
+  }
+
+  @Override
+  public void writeMaxKey(String name) {
+    writeName(name);
+    writeMaxKey();
+  }
+
+  @Override
+  public void writeMinKey() {
+    writeObfuscated();
+  }
+
+  @Override
+  public void writeMinKey(String name) {
+    writeName(name);
+    writeMinKey();
+  }
+
+  @Override
+  public void writeName(String name) {
+    applyObfuscationPolicy(name);
+    if (name != null) {
+      context.write('\"');
+      context.write(name);
+      context.write('\"');
+      context.write(':');
+      context.write(' ');
+    }
+  }
+
+  @Override
+  public void writeNull() {
+    writeObfuscated();
+  }
+
+  @Override
+  public void writeNull(String name) {
+    writeName(name);
+    writeNull();
+  }
+
+  @Override
+  public void writeObjectId(ObjectId objectId) {
+    writeObfuscated();
+  }
+
+  @Override
+  public void writeObjectId(String name, ObjectId objectId) {
+    writeName(name);
+    writeObjectId(objectId);
+  }
+
+  @Override
+  public void writeRegularExpression(BsonRegularExpression regularExpression) {
+    writeString(regularExpression.getPattern());
+  }
+
+  @Override
+  public void writeRegularExpression(String name, BsonRegularExpression regularExpression) {
+    writeName(name);
+    writeRegularExpression(regularExpression);
+  }
+
+  @Override
+  public void writeStartArray() {
+    context.write('[');
+  }
+
+  @Override
+  public void writeStartArray(String name) {
+    writeName(name);
+    writeStartArray();
+  }
+
+  @Override
+  public void writeStartDocument() {
+    context.startDocument();
+    context.write('{');
+  }
+
+  @Override
+  public void writeStartDocument(String name) {
+    writeName(name);
+    writeStartDocument();
+  }
+
+  @Override
+  public void writeString(String value) {
+    if (value.startsWith("$")) {
+      context.write(value);
+    } else if (obfuscate) {
+      writeObfuscated();
+    } else {
+      context.write('\"');
+      context.write(value);
+      context.write('\"');
+    }
+  }
+
+  @Override
+  public void writeString(String name, String value) {
+    writeName(name);
+    writeString(value);
+  }
+
+  @Override
+  public void writeSymbol(String value) {
+    writeString(value);
+  }
+
+  @Override
+  public void writeSymbol(String name, String value) {
+    writeName(name);
+    writeSymbol(value);
+  }
+
+  @Override
+  public void writeTimestamp(BsonTimestamp value) {
+    writeObfuscated();
+  }
+
+  @Override
+  public void writeTimestamp(String name, BsonTimestamp value) {
+    writeName(name);
+    writeTimestamp(value);
+  }
+
+  @Override
+  public void writeUndefined() {
+    writeObfuscated();
+  }
+
+  @Override
+  public void writeUndefined(String name) {
+    writeName(name);
+    writeUndefined();
+  }
+
+  @Override
+  public void pipe(BsonReader reader) {
+    pipeDocument(null, reader);
+  }
+
+  private void pipeDocument(String attribute, final BsonReader reader) {
+    reader.readStartDocument();
+    if (null == attribute) {
+      writeStartDocument();
+    } else {
+      writeStartDocument(attribute);
+    }
+    BsonType type = reader.readBsonType();
+    while (type != BsonType.END_OF_DOCUMENT) {
+      pipeValue(reader.readName(), reader);
+      type = reader.readBsonType();
+      nextValue(type);
+    }
+    reader.readEndDocument();
+    writeEndDocument();
+  }
+
+  private void pipeJavascriptWithScope(String attribute, BsonReader reader) {
+    writeJavaScriptWithScope(attribute, reader.readJavaScriptWithScope());
+    pipeDocument(attribute, reader);
+  }
+
+  private void pipeValue(String attribute, BsonReader reader) {
+    switch (reader.getCurrentBsonType()) {
+      case DOCUMENT:
+        pipeDocument(attribute, reader);
+        break;
+      case ARRAY:
+        pipeArray(attribute, reader);
+        break;
+      case DOUBLE:
+        writeDouble(attribute, reader.readDouble());
+        break;
+      case STRING:
+        writeString(attribute, reader.readString());
+        break;
+      case BINARY:
+        writeBinaryData(attribute, reader.readBinaryData());
+        break;
+      case UNDEFINED:
+        reader.readUndefined();
+        writeUndefined();
+        break;
+      case OBJECT_ID:
+        writeObjectId(attribute, reader.readObjectId());
+        break;
+      case BOOLEAN:
+        writeBoolean(attribute, reader.readBoolean());
+        break;
+      case DECIMAL128:
+        writeDecimal128(attribute, reader.readDecimal128());
+        break;
+      case DATE_TIME:
+        writeDateTime(attribute, reader.readDateTime());
+        break;
+      case NULL:
+        reader.readNull();
+        writeNull(attribute);
+        break;
+      case REGULAR_EXPRESSION:
+        writeRegularExpression(attribute, reader.readRegularExpression());
+        break;
+      case JAVASCRIPT:
+        writeJavaScript(attribute, reader.readJavaScript());
+        break;
+      case SYMBOL:
+        writeSymbol(attribute, reader.readSymbol());
+        break;
+      case JAVASCRIPT_WITH_SCOPE:
+        pipeJavascriptWithScope(attribute, reader);
+        break;
+      case INT32:
+        writeInt32(attribute, reader.readInt32());
+        break;
+      case TIMESTAMP:
+        writeTimestamp(attribute, reader.readTimestamp());
+        break;
+      case INT64:
+        writeInt64(attribute, reader.readInt64());
+        break;
+      case MIN_KEY:
+        reader.readMinKey();
+        writeMinKey(attribute);
+        break;
+      case DB_POINTER:
+        writeDBPointer(attribute, reader.readDBPointer());
+        break;
+      case MAX_KEY:
+        reader.readMaxKey();
+        writeMaxKey(attribute);
+        break;
+      default:
+        reader.skipValue();
+        writeUndefined(attribute);
+    }
+  }
+
+  private void pipeDocument(String attribute, BsonDocument value) {
+    writeStartDocument(attribute);
+    for (Map.Entry<String, BsonValue> cur : value.entrySet()) {
+      pipeValue(cur.getKey(), cur.getValue());
+    }
+    writeEndDocument();
+  }
+
+  private void pipeArray(String attribute, BsonReader reader) {
+    reader.readStartArray();
+    writeStartArray(attribute);
+    BsonType type = reader.readBsonType();
+    while (type != BsonType.END_OF_DOCUMENT) {
+      pipeValue(null, reader);
+      type = reader.readBsonType();
+      nextValue(type);
+    }
+    reader.readEndArray();
+    writeEndArray();
+  }
+
+  private void pipeArray(String attribute, final BsonArray array) {
+    writeStartArray(attribute);
+    for (BsonValue cur : array) {
+      pipeValue(null, cur);
+    }
+    writeEndArray();
+  }
+
+  private void pipeJavascriptWithScope(
+      String attribute, final BsonJavaScriptWithScope javaScriptWithScope) {
+    writeJavaScriptWithScope(javaScriptWithScope.getCode());
+    pipeDocument(attribute, javaScriptWithScope.getScope());
+  }
+
+  private void pipeValue(String attribute, final BsonValue value) {
+    switch (value.getBsonType()) {
+      case DOCUMENT:
+        pipeDocument(attribute, value.asDocument());
+        break;
+      case ARRAY:
+        pipeArray(attribute, value.asArray());
+        break;
+      case DOUBLE:
+        writeDouble(attribute, value.asDouble().getValue());
+        break;
+      case STRING:
+        writeString(attribute, value.asString().getValue());
+        break;
+      case BINARY:
+        writeBinaryData(attribute, value.asBinary());
+        break;
+      case UNDEFINED:
+        writeUndefined();
+        break;
+      case OBJECT_ID:
+        writeObjectId(attribute, value.asObjectId().getValue());
+        break;
+      case BOOLEAN:
+        writeBoolean(attribute, value.asBoolean().getValue());
+        break;
+      case DECIMAL128:
+        writeDecimal128(attribute, value.asDecimal128().getValue());
+        break;
+      case DATE_TIME:
+        writeDateTime(attribute, value.asDateTime().getValue());
+        break;
+      case NULL:
+        writeNull();
+        break;
+      case REGULAR_EXPRESSION:
+        writeRegularExpression(attribute, value.asRegularExpression());
+        break;
+      case JAVASCRIPT:
+        writeJavaScript(attribute, value.asJavaScript().getCode());
+        break;
+      case SYMBOL:
+        writeSymbol(attribute, value.asSymbol().getSymbol());
+        break;
+      case JAVASCRIPT_WITH_SCOPE:
+        pipeJavascriptWithScope(attribute, value.asJavaScriptWithScope());
+        break;
+      case INT32:
+        writeInt32(attribute, value.asInt32().getValue());
+        break;
+      case TIMESTAMP:
+        writeTimestamp(attribute, value.asTimestamp());
+        break;
+      case INT64:
+        writeInt64(attribute, value.asInt64().getValue());
+        break;
+      case MIN_KEY:
+        writeMinKey(attribute);
+        break;
+      case DB_POINTER:
+        writeDBPointer(attribute, value.asDBPointer());
+        break;
+      case MAX_KEY:
+        writeMaxKey(attribute);
+        break;
+      default:
+        writeUndefined(attribute);
+    }
+  }
+
+  private void nextValue(BsonType type) {
+    if (type != BsonType.END_OF_DOCUMENT) {
+      context.write(',');
+      context.write(' ');
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/mongo/driver-4/src/main/java/datadog/trace/instrumentation/mongo4/Context.java
+++ b/dd-java-agent/instrumentation/mongo/driver-4/src/main/java/datadog/trace/instrumentation/mongo4/Context.java
@@ -1,0 +1,90 @@
+package datadog.trace.instrumentation.mongo4;
+
+final class Context {
+
+  private final StringBuilder buffer = new StringBuilder();
+
+  // specifies the depth below which everything must be discarded,
+  // e.g. because we're inside an $in clause we want to collapse
+  private int discardDepth = 64;
+  private int keepDepth = 64;
+  private int depth;
+
+  void discardSubTree() {
+    if (depth < discardDepth) {
+      this.discardDepth = depth;
+    }
+  }
+
+  void keepSubTree() {
+    if (depth < keepDepth) {
+      this.keepDepth = depth;
+    }
+  }
+
+  public void startDocument() {
+    ++depth;
+  }
+
+  public void endDocument() {
+    --depth;
+    if (discardDepth == depth) {
+      discardDepth = 64;
+    }
+    if (keepDepth == depth) {
+      keepDepth = 64;
+    }
+  }
+
+  boolean disableObfuscation() {
+    return depth > keepDepth;
+  }
+
+  boolean ignoreSubTree() {
+    return depth > discardDepth;
+  }
+
+  private boolean tooDeep() {
+    // this means we are parsing a huge document, which we will truncate anyway
+    // note that MongoDB sets a default max nested depth of 100, and MongoDB users
+    // are generally advised to avoid deep nesting for the sake of database performance
+    return depth >= 64;
+  }
+
+  private boolean shouldWrite() {
+    return !tooDeep() && (depth > keepDepth || depth < discardDepth + 1);
+  }
+
+  void write(char symbol) {
+    if (shouldWrite()) {
+      buffer.append(symbol);
+    }
+  }
+
+  void write(long number) {
+    if (shouldWrite()) {
+      buffer.append(number);
+    }
+  }
+
+  void write(boolean value) {
+    if (shouldWrite()) {
+      buffer.append(value);
+    }
+  }
+
+  void write(String string) {
+    if (shouldWrite()) {
+      buffer.append(string);
+    }
+  }
+
+  void clear() {
+    buffer.setLength(0);
+    depth = 0;
+  }
+
+  String asString() {
+    return buffer.toString();
+  }
+}

--- a/dd-java-agent/instrumentation/mongo/driver-4/src/main/java/datadog/trace/instrumentation/mongo4/Mongo4ClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/mongo/driver-4/src/main/java/datadog/trace/instrumentation/mongo4/Mongo4ClientInstrumentation.java
@@ -34,7 +34,12 @@ public final class Mongo4ClientInstrumentation extends Instrumenter.Tracing {
   @Override
   public String[] helperClassNames() {
     return new String[] {
-      packageName + ".Mongo4ClientDecorator", packageName + ".Tracing4CommandListener"
+      packageName + ".Mongo4ClientDecorator",
+      packageName + ".BsonScrubber",
+      packageName + ".BsonScrubber$1",
+      packageName + ".BsonScrubber$2",
+      packageName + ".Context",
+      packageName + ".Tracing4CommandListener"
     };
   }
 

--- a/dd-java-agent/instrumentation/mongo/driver-4/src/test/groovy/BsonScrubberTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-4/src/test/groovy/BsonScrubberTest.groovy
@@ -1,0 +1,30 @@
+import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.instrumentation.mongo4.BsonScrubber
+import org.bson.BsonDocument
+import org.bson.BsonDocumentReader
+
+class BsonScrubberTest extends AgentTestRunner {
+
+  def "test BSON scrubber"() {
+    setup:
+    BsonDocument doc = BsonDocument.parse(input)
+
+    when:
+    BsonScrubber scrubber = new BsonScrubber()
+    scrubber.pipe(new BsonDocumentReader(doc))
+    String resourceName = scrubber.toResourceName()
+
+    then:
+    resourceName == expected
+
+    cleanup:
+    scrubber.close()
+
+    where:
+    input                                                                                                                                                                                                                                                                                | expected
+    "{ _id : { project_id : '\$project_id', date : '\$VehicleEntry.@Date' }, passed : { \$sum : { \$cond : [ { \$eq : [ '\$VehicleEntry.VehicleStatus', 'PASSED' ] }, 1, 0 ] } }, failed : { \$sum : { \$cond : [ { \$eq : [ '\$VehicleEntry.VehicleStatus', 'FAILED' ] }, 1, 0 ] } } }" | "{\"_id\": {\"project_id\": \$project_id, \"date\": \$VehicleEntry.@Date}, \"passed\": {\"\$sum\": {\"\$cond\": [{\"\$eq\": [\$VehicleEntry.VehicleStatus, \"?\"]}, \"?\", \"?\"]}}, \"failed\": {\"\$sum\": {\"\$cond\": [{\"\$eq\": [\$VehicleEntry.VehicleStatus, \"?\"]}, \"?\", \"?\"]}}}"
+    "{\"update\": \"topics\", \"ordered\": true, \"writeConcern\": {\"w\": \"majority\"}, \"txnNumber\": \"?\", \"\$db\": \"database\", \"\$clusterTime\": {\"clusterTime\": \"?\", \"signature\": {\"hash\": \"?\", \"keyId\": \"?\"}}, \"lsid\": {\"id\": \"?\"}, \"updates\": \"?\"}" | "{\"update\": \"topics\", \"ordered\": true, \"writeConcern\": {\"w\": \"majority\"}, \"txnNumber\": \"?\", \"\$db\": \"database\", \"\$clusterTime\": {\"clusterTime\": \"?\", \"signature\": {\"hash\": \"?\", \"keyId\": \"?\"}}, \"lsid\": {\"id\": \"?\"}, \"updates\": \"?\"}"
+    "{\"update\" : \"orders\", \"ordered\" : false, \"writeConcern\" : { \"w\" : \"majority\" }, \"updates\": [{ \"q\" : { \"_id\" : 1 }, \"u\" : { \"orderId\" : \"Account1\", \"qty\" : 10 } } ]}"                                                                                 | "{\"update\": \"orders\", \"ordered\": false, \"writeConcern\": {\"w\": \"majority\"}, \"updates\": []}"
+    "{\"insert\" : \"stuff\", \"ordered\" : true, \"writeConcern\" : { \"w\" : 10 }, \"documents\": [{ \"_id\" : { \"s\" : 0, \"i\": \"DEADBEEF\" }, \"array\" : [0, \"foo\", {\"foo\": 10}], \"qty\" : 10 } ]}"                                                                      | "{\"insert\": \"stuff\", \"ordered\": true, \"writeConcern\": {\"w\": 10}, \"documents\": []}"
+  }
+}

--- a/dd-java-agent/instrumentation/mongo/driver-4/src/test/groovy/Mongo4ClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-4/src/test/groovy/Mongo4ClientTest.groovy
@@ -32,6 +32,11 @@ class Mongo4ClientTest extends MongoBaseTest {
     client = null
   }
 
+  @Override
+  def dbName() {
+    return DB_NAME
+  }
+
   def "test create collection"() {
     setup:
     MongoDatabase db = client.getDatabase(DB_NAME)
@@ -106,7 +111,7 @@ class Mongo4ClientTest extends MongoBaseTest {
     collection.estimatedDocumentCount() == 1
     assertTraces(2) {
       trace(1) {
-        mongoSpan(it, 0, "insert", "{\"insert\":\"$collectionName\",\"ordered\":\"?\",\"documents\":[{\"_id\":\"?\",\"password\":\"?\"}]}")
+        mongoSpan(it, 0, "insert", "{\"insert\":\"$collectionName\",\"ordered\":true,\"documents\":[]}")
       }
       trace(1) {
         mongoSpan(it, 0, "count", "{\"count\":\"$collectionName\",\"query\":{}}")
@@ -139,7 +144,7 @@ class Mongo4ClientTest extends MongoBaseTest {
     collection.estimatedDocumentCount() == 1
     assertTraces(2) {
       trace(1) {
-        mongoSpan(it, 0, "update", "{\"update\":\"?\",\"ordered\":\"?\",\"updates\":[{\"q\":{\"password\":\"?\"},\"u\":{\"\$set\":{\"password\":\"?\"}}}]}")
+        mongoSpan(it, 0, "update", "{\"update\":\"$collectionName\",\"ordered\":true,\"updates\":[]}")
       }
       trace(1) {
         mongoSpan(it, 0, "count", "{\"count\":\"$collectionName\",\"query\":{}}")
@@ -170,7 +175,7 @@ class Mongo4ClientTest extends MongoBaseTest {
     collection.estimatedDocumentCount() == 0
     assertTraces(2) {
       trace(1) {
-        mongoSpan(it, 0, "delete", "{\"delete\":\"?\",\"ordered\":\"?\",\"deletes\":[{\"q\":{\"password\":\"?\"},\"limit\":\"?\"}]}")
+        mongoSpan(it, 0, "delete", "{\"delete\":\"$collectionName\",\"ordered\":true,\"deletes\":[]}")
       }
       trace(1) {
         mongoSpan(it, 0, "count", "{\"count\":\"$collectionName\",\"query\":{}}")

--- a/dd-java-agent/instrumentation/mongo/driver-4/src/test/groovy/Mongo4ClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-4/src/test/groovy/Mongo4ClientTest.groovy
@@ -17,7 +17,6 @@ import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 import static datadog.trace.api.config.TraceInstrumentationConfig.DB_CLIENT_HOST_SPLIT_BY_INSTANCE
 
 class Mongo4ClientTest extends MongoBaseTest {
-  static final String DB_NAME = "v3_test_db"
 
   @Shared
   MongoClient client
@@ -27,19 +26,13 @@ class Mongo4ClientTest extends MongoBaseTest {
   }
 
   def cleanup() throws Exception {
-    client.getDatabase(DB_NAME).drop()
     client?.close()
     client = null
   }
 
-  @Override
-  def dbName() {
-    return DB_NAME
-  }
-
   def "test create collection"() {
     setup:
-    MongoDatabase db = client.getDatabase(DB_NAME)
+    MongoDatabase db = client.getDatabase(databaseName)
     injectSysConfig(DB_CLIENT_HOST_SPLIT_BY_INSTANCE, "$renameService")
 
     when:
@@ -59,7 +52,7 @@ class Mongo4ClientTest extends MongoBaseTest {
 
   def "test create collection no description"() {
     setup:
-    MongoDatabase db = MongoClients.create("mongodb://localhost:$port").getDatabase(DB_NAME)
+    MongoDatabase db = MongoClients.create("mongodb://localhost:$port").getDatabase(databaseName)
 
     when:
     db.createCollection(collectionName)
@@ -67,7 +60,7 @@ class Mongo4ClientTest extends MongoBaseTest {
     then:
     assertTraces(1) {
       trace(1) {
-        mongoSpan(it, 0, "create","{\"create\":\"$collectionName\",\"capped\":\"?\"}", false, DB_NAME)
+        mongoSpan(it, 0, "create","{\"create\":\"$collectionName\",\"capped\":\"?\"}", false, databaseName)
       }
     }
 
@@ -77,7 +70,7 @@ class Mongo4ClientTest extends MongoBaseTest {
 
   def "test get collection"() {
     setup:
-    MongoDatabase db = client.getDatabase(DB_NAME)
+    MongoDatabase db = client.getDatabase(databaseName)
 
     when:
     int count = db.getCollection(collectionName).estimatedDocumentCount()
@@ -97,7 +90,7 @@ class Mongo4ClientTest extends MongoBaseTest {
   def "test insert"() {
     setup:
     MongoCollection<Document> collection = runUnderTrace("setup") {
-      MongoDatabase db = client.getDatabase(DB_NAME)
+      MongoDatabase db = client.getDatabase(databaseName)
       db.createCollection(collectionName)
       return db.getCollection(collectionName)
     }
@@ -125,7 +118,7 @@ class Mongo4ClientTest extends MongoBaseTest {
   def "test update"() {
     setup:
     MongoCollection<Document> collection = runUnderTrace("setup") {
-      MongoDatabase db = client.getDatabase(DB_NAME)
+      MongoDatabase db = client.getDatabase(databaseName)
       db.createCollection(collectionName)
       def coll = db.getCollection(collectionName)
       coll.insertOne(new Document("password", "OLDPW"))
@@ -158,7 +151,7 @@ class Mongo4ClientTest extends MongoBaseTest {
   def "test delete"() {
     setup:
     MongoCollection<Document> collection = runUnderTrace("setup") {
-      MongoDatabase db = client.getDatabase(DB_NAME)
+      MongoDatabase db = client.getDatabase(databaseName)
       db.createCollection(collectionName)
       def coll = db.getCollection(collectionName)
       coll.insertOne(new Document("password", "SECRET"))
@@ -189,7 +182,7 @@ class Mongo4ClientTest extends MongoBaseTest {
   def "test error"() {
     setup:
     MongoCollection<Document> collection = runUnderTrace("setup") {
-      MongoDatabase db = client.getDatabase(DB_NAME)
+      MongoDatabase db = client.getDatabase(databaseName)
       db.createCollection(collectionName)
       return db.getCollection(collectionName)
     }
@@ -213,7 +206,7 @@ class Mongo4ClientTest extends MongoBaseTest {
     def client = MongoClients.create("mongodb://localhost:$UNUSABLE_PORT/?serverselectiontimeoutms=10")
 
     when:
-    MongoDatabase db = client.getDatabase(DB_NAME)
+    MongoDatabase db = client.getDatabase(databaseName)
     db.createCollection(collectionName)
 
     then:

--- a/dd-java-agent/instrumentation/mongo/driver-4/src/test/groovy/Mongo4ReactiveClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-4/src/test/groovy/Mongo4ReactiveClientTest.groovy
@@ -139,7 +139,7 @@ class Mongo4ReactiveClientTest extends MongoBaseTest {
     count.get() == 1
     assertTraces(2) {
       trace(1) {
-        mongoSpan(it, 0, "insert", "{\"insert\":\"$collectionName\",\"ordered\":\"?\",\"documents\":[{\"_id\":\"?\",\"password\":\"?\"}]}")
+        mongoSpan(it, 0, "insert", "{\"insert\":\"$collectionName\",\"ordered\":true,\"documents\":[]}")
       }
       trace(1) {
         mongoSpan(it, 0, "count", "{\"count\":\"$collectionName\",\"query\":{}}")
@@ -170,7 +170,7 @@ class Mongo4ReactiveClientTest extends MongoBaseTest {
     count.get() == 1
     assertTraces(2) {
       trace(1) {
-        mongoSpan(it, 0, "update", "{\"update\":\"?\",\"ordered\":\"?\",\"updates\":[{\"q\":{\"password\":\"?\"},\"u\":{\"\$set\":{\"password\":\"?\"}}}]}")
+        mongoSpan(it, 0, "update", "{\"update\":\"$collectionName\",\"ordered\":true,\"updates\":[]}")
       }
       trace(1) {
         mongoSpan(it, 0, "count", "{\"count\":\"$collectionName\",\"query\":{}}")
@@ -199,7 +199,7 @@ class Mongo4ReactiveClientTest extends MongoBaseTest {
     count.get() == 0
     assertTraces(2) {
       trace(1) {
-        mongoSpan(it, 0, "delete", "{\"delete\":\"?\",\"ordered\":\"?\",\"deletes\":[{\"q\":{\"password\":\"?\"},\"limit\":\"?\"}]}")
+        mongoSpan(it, 0, "delete", "{\"delete\":\"$collectionName\",\"ordered\":true,\"deletes\":[]}")
       }
       trace(1) {
         mongoSpan(it, 0, "count", "{\"count\":\"$collectionName\",\"query\":{}}")

--- a/dd-java-agent/instrumentation/mongo/driver-async-3.3/src/main/java/datadog/trace/instrumentation/mongo/MongoAsyncClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/mongo/driver-async-3.3/src/main/java/datadog/trace/instrumentation/mongo/MongoAsyncClientInstrumentation.java
@@ -41,7 +41,12 @@ public final class MongoAsyncClientInstrumentation extends Instrumenter.Tracing 
   @Override
   public String[] helperClassNames() {
     return new String[] {
-      packageName + ".MongoClientDecorator", packageName + ".TracingCommandListener"
+      packageName + ".MongoClientDecorator",
+      packageName + ".BsonScrubber",
+      packageName + ".BsonScrubber$1",
+      packageName + ".BsonScrubber$2",
+      packageName + ".Context",
+      packageName + ".TracingCommandListener"
     };
   }
 

--- a/dd-java-agent/instrumentation/mongo/driver-async-3.3/src/test/groovy/MongoAsyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-async-3.3/src/test/groovy/MongoAsyncClientTest.groovy
@@ -27,6 +27,11 @@ import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 class MongoAsyncClientTest extends MongoBaseTest {
   static final String DB_NAME = "v3_async_test_db"
 
+  @Override
+  def dbName() {
+    return DB_NAME
+  }
+
   @Shared
   MongoClient client
 
@@ -128,7 +133,7 @@ class MongoAsyncClientTest extends MongoBaseTest {
     count.get() == 1
     assertTraces(2) {
       trace(1) {
-        mongoSpan(it, 0, "insert", "{\"insert\":\"$collectionName\",\"ordered\":\"?\",\"documents\":[{\"_id\":\"?\",\"password\":\"?\"}]}")
+        mongoSpan(it, 0, "insert", "{\"insert\":\"$collectionName\",\"ordered\":true,\"documents\":[]}")
       }
       trace(1) {
         mongoSpan(it, 0, "count", "{\"count\":\"$collectionName\",\"query\":{}}")
@@ -170,7 +175,7 @@ class MongoAsyncClientTest extends MongoBaseTest {
     count.get() == 1
     assertTraces(2) {
       trace(1) {
-        mongoSpan(it, 0, "update", "{\"update\":\"?\",\"ordered\":\"?\",\"updates\":[{\"q\":{\"password\":\"?\"},\"u\":{\"\$set\":{\"password\":\"?\"}}}]}")
+        mongoSpan(it, 0, "update", "{\"update\":\"$collectionName\",\"ordered\":true,\"updates\":[]}")
       }
       trace(1) {
         mongoSpan(it, 0, "count", "{\"count\":\"$collectionName\",\"query\":{}}")
@@ -210,7 +215,7 @@ class MongoAsyncClientTest extends MongoBaseTest {
     count.get() == 0
     assertTraces(2) {
       trace(1) {
-        mongoSpan(it, 0, "delete", "{\"delete\":\"?\",\"ordered\":\"?\",\"deletes\":[{\"q\":{\"password\":\"?\"},\"limit\":\"?\"}]}")
+        mongoSpan(it, 0, "delete", "{\"delete\":\"$collectionName\",\"ordered\":true,\"deletes\":[]}")
       }
       trace(1) {
         mongoSpan(it, 0, "count", "{\"count\":\"$collectionName\",\"query\":{}}")

--- a/dd-java-agent/instrumentation/mongo/src/test/groovy/MongoBaseTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/src/test/groovy/MongoBaseTest.groovy
@@ -16,6 +16,10 @@ import spock.lang.Shared
  * they downloader is at risk of a race condition.
  */
 class MongoBaseTest extends AgentTestRunner {
+
+  @Shared
+  def databaseName = "database"
+
   // https://github.com/flapdoodle-oss/de.flapdoodle.embed.mongo#executable-collision
   private static final MongodStarter STARTER = MongodStarter.getDefaultInstance()
 
@@ -59,14 +63,9 @@ class MongoBaseTest extends AgentTestRunner {
     return "testCollection-" + UUID.randomUUID()
   }
 
-  def dbName() {
-    return "?"
-  }
-
   def matchesStatement(statement) {
-    String dbName = dbName()
     return {
-      assert it.replace(" ", "").replace(",\"\$db\":\"$dbName\"", "").replace(',"lsid":{"id":"?"}', '').replace(',"readPreference":{"node":"?"}', '') == statement
+      assert it.replace(" ", "").replace(",\"\$db\":\"$databaseName\"", "").replace(',"lsid":{"id":"?"}', '').replace(',"readPreference":{"node":"?"}', '') == statement
       return true
     }
   }

--- a/dd-java-agent/instrumentation/mongo/src/test/groovy/MongoBaseTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/src/test/groovy/MongoBaseTest.groovy
@@ -59,9 +59,14 @@ class MongoBaseTest extends AgentTestRunner {
     return "testCollection-" + UUID.randomUUID()
   }
 
+  def dbName() {
+    return "?"
+  }
+
   def matchesStatement(statement) {
+    String dbName = dbName()
     return {
-      assert it.replace(" ", "").replace(',"$db":"?"', '').replace(',"lsid":{"id":"?"}', '').replace(',"readPreference":{"node":"?"}', '') == statement
+      assert it.replace(" ", "").replace(",\"\$db\":\"$dbName\"", "").replace(',"lsid":{"id":"?"}', '').replace(',"readPreference":{"node":"?"}', '') == statement
       return true
     }
   }


### PR DESCRIPTION
* Uses MongoDB's driver's ability to pipe a document reader through a writer. This implements a custom writer to give better control over obfuscation policy.
* Improves the obfuscation policy
   * Include collection names for updates and deletes
   * Include the database name
   * Include whether the query was ordered or not, since this has a significant impact on query performance
   * Include whether the query will yield an explain plan
   * Exclude the contents of delete, insert, and update commands
   * Exclude the contents of large sets, such as `$in` clauses and `$set`s used in upserts
