### PR TITLE
[CIAPP] Add test.parameters tag to JUnit5 tests

### DIFF
--- a/dd-java-agent/instrumentation/junit-5.3/src/main/java8/datadog/trace/instrumentation/junit5/JUnit5Decorator.java
+++ b/dd-java-agent/instrumentation/junit-5.3/src/main/java8/datadog/trace/instrumentation/junit5/JUnit5Decorator.java
@@ -5,6 +5,7 @@ import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.decorator.TestDecorator;
 import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.support.descriptor.MethodSource;
+import org.junit.platform.launcher.TestIdentifier;
 
 public class JUnit5Decorator extends TestDecorator {
 
@@ -25,8 +26,18 @@ public class JUnit5Decorator extends TestDecorator {
     return "junit";
   }
 
-  public void onTestStart(final AgentSpan span, final MethodSource methodSource) {
+  public void onTestStart(
+      final AgentSpan span, final MethodSource methodSource, final TestIdentifier testIdentifier) {
     onTestStart(span, methodSource.getClassName(), methodSource.getMethodName());
+
+    if (hasParameters(methodSource)) {
+      // No public access to the test parameters map in JUnit5.
+      // In this case, we store the displayName in the "metadata.test_name" object.
+      // The test display name used to have the parameters.
+      span.setTag(
+          Tags.TEST_PARAMETERS,
+          "{\"metadata\":{\"test_name\":\"" + testIdentifier.getDisplayName() + "\"}}");
+    }
   }
 
   public void onTestStart(final AgentSpan span, final String testSuite, final String testName) {
@@ -60,5 +71,10 @@ public class JUnit5Decorator extends TestDecorator {
     onTestStart(span, testSuite, testName);
     span.setTag(Tags.TEST_STATUS, TEST_SKIP);
     span.setTag(Tags.TEST_SKIP_REASON, reason);
+  }
+
+  private boolean hasParameters(final MethodSource methodSource) {
+    return methodSource.getMethodParameterTypes() != null
+        && !methodSource.getMethodParameterTypes().isEmpty();
   }
 }

--- a/dd-java-agent/instrumentation/junit-5.3/src/main/java8/datadog/trace/instrumentation/junit5/TracingListener.java
+++ b/dd-java-agent/instrumentation/junit-5.3/src/main/java8/datadog/trace/instrumentation/junit5/TracingListener.java
@@ -45,7 +45,7 @@ public class TracingListener implements TestExecutionListener {
               scope.setAsyncPropagation(true);
 
               DECORATE.afterStart(span);
-              DECORATE.onTestStart(span, methodSource);
+              DECORATE.onTestStart(span, methodSource, testIdentifier);
             });
   }
 

--- a/dd-java-agent/instrumentation/junit-5.3/src/test/groovy/JUnit5Test.groovy
+++ b/dd-java-agent/instrumentation/junit-5.3/src/test/groovy/JUnit5Test.groovy
@@ -61,12 +61,16 @@ class JUnit5Test extends TestFrameworkTest {
     expect:
     assertTraces(2) {
       trace(1) {
-        testSpan(it, 0, "org.example.TestParameterized", "test_parameterized", TestDecorator.TEST_PASS)
+        testSpan(it, 0, "org.example.TestParameterized", "test_parameterized", TestDecorator.TEST_PASS, testTags_0)
       }
       trace(1) {
-        testSpan(it, 0, "org.example.TestParameterized", "test_parameterized", TestDecorator.TEST_PASS)
+        testSpan(it, 0, "org.example.TestParameterized", "test_parameterized", TestDecorator.TEST_PASS, testTags_1)
       }
     }
+
+    where:
+    testTags_0 = ["$Tags.TEST_PARAMETERS": "{\"metadata\":{\"test_name\":\"[1] 0, 0, 0\"}}"]
+    testTags_1 = ["$Tags.TEST_PARAMETERS": "{\"metadata\":{\"test_name\":\"[2] 1, 1, 2\"}}"]
   }
 
   def "test repeated generates spans"() {
@@ -97,12 +101,16 @@ class JUnit5Test extends TestFrameworkTest {
     expect:
     assertTraces(2) {
       trace(1) {
-        testSpan(it, 0, "org.example.TestTemplate", "test_template", TestDecorator.TEST_PASS)
+        testSpan(it, 0, "org.example.TestTemplate", "test_template", TestDecorator.TEST_PASS, testTags_0)
       }
       trace(1) {
-        testSpan(it, 0, "org.example.TestTemplate", "test_template", TestDecorator.TEST_PASS)
+        testSpan(it, 0, "org.example.TestTemplate", "test_template", TestDecorator.TEST_PASS, testTags_1)
       }
     }
+
+    where:
+    testTags_0 = ["$Tags.TEST_PARAMETERS": "{\"metadata\":{\"test_name\":\"test_template_1\"}}"]
+    testTags_1 = ["$Tags.TEST_PARAMETERS": "{\"metadata\":{\"test_name\":\"test_template_2\"}}"]
   }
 
   def "test factory generates spans"() {

--- a/dd-java-agent/instrumentation/junit-5.3/src/test/java/org/example/TestTemplate.java
+++ b/dd-java-agent/instrumentation/junit-5.3/src/test/java/org/example/TestTemplate.java
@@ -48,8 +48,8 @@ public class TestTemplate {
     public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(
         final ExtensionContext context) {
       return Stream.of(
-          featureEnabledContext(new SampleTestCase("test_template", 0, 0, 0)),
-          featureEnabledContext(new SampleTestCase("test_template", 1, 1, 2)));
+          featureEnabledContext(new SampleTestCase("test_template_1", 0, 0, 0)),
+          featureEnabledContext(new SampleTestCase("test_template_2", 1, 1, 2)));
     }
 
     private TestTemplateInvocationContext featureEnabledContext(

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/Tags.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/Tags.java
@@ -34,7 +34,7 @@ public class Tags {
   public static final String TEST_FRAMEWORK = "test.framework";
   public static final String TEST_SKIP_REASON = "test.skip_reason";
   public static final String TEST_TYPE = "test.type";
-  public static final String TEST_ARGUMENTS = "test.arguments";
+  public static final String TEST_PARAMETERS = "test.parameters";
 
   public static final String CI_PROVIDER_NAME = "ci.provider.name";
   public static final String CI_PIPELINE_ID = "ci.pipeline.id";


### PR DESCRIPTION
Add `test.parameters` tag to JUnit5 tests.
