### PR TITLE
Fix milestone fetching in github actions

### DIFF
--- a/.github/workflows/draft-release-notes-on-tag.yaml
+++ b/.github/workflows/draft-release-notes-on-tag.yaml
@@ -21,13 +21,13 @@ jobs:
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            const milestone = await github.paginate(github.issues.listMilestones, {
+            const milestones = await github.paginate(github.issues.listMilestones, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: 'all'
-            }).then((milestones) => {
-              milestones.find(milestone => milestone.title == '${{steps.milestoneTitle.outputs.result}}')
             })
+
+            const milestone = milestones.find(milestone => milestone.title == '${{steps.milestoneTitle.outputs.result}}')
 
             if (milestone) {
               return milestone.number

--- a/.github/workflows/increment-milestones-on-tag.yaml
+++ b/.github/workflows/increment-milestones-on-tag.yaml
@@ -21,13 +21,13 @@ jobs:
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            const milestone = await github.paginate(github.issues.listMilestones, {
+            const milestones = await github.paginate(github.issues.listMilestones, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: 'all'
-            }).then((milestones) => {
-              milestones.find(milestone => milestone.title == '${{steps.milestoneTitle.outputs.result}}')
             })
+
+            const milestone = milestones.find(milestone => milestone.title == '${{steps.milestoneTitle.outputs.result}}')
 
             if (milestone) {
               return milestone.number


### PR DESCRIPTION
This PR fixes the `draft release notes on tag` and `increment milestones on tag` github actions.  

`await` syntax and `then()` aren't mixable in the manner used in the file


**Submitter please read!**

NO are you making any modifications to a non thread-safe data structure in a method or an advice that might happen on multiple theads at the same time?
