### PR TITLE
Update the OpenJDK 8 exclusion range.

### DIFF
--- a/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/ExcludedVersions.java
+++ b/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/ExcludedVersions.java
@@ -27,8 +27,9 @@ public class ExcludedVersions {
       return true;
     }
 
-    // Exclude 1.8.0_262 onwards due to https://bugs.openjdk.java.net/browse/JDK-8252904
-    if (major == 8 && minor == 0 && update >= 262) {
+    // Exclude <1.8.0_262, 1.8.0_282) due to https://bugs.openjdk.java.net/browse/JDK-8252904 (fixed
+    // in 8u282)
+    if (major == 8 && minor == 0 && update >= 262 && update < 282) {
       return true;
     }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -656,7 +656,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
         return (DDScopeEventFactory)
             Class.forName("datadog.trace.core.jfr.openjdk.ScopeEventFactory").newInstance();
       } catch (final Throwable e) {
-        log.debug("Profiling of ScopeEvents is not available");
+        log.debug("Profiling of ScopeEvents is not available. {}", e.getMessage());
       }
     }
     return DDNoopScopeEventFactory.INSTANCE;


### PR DESCRIPTION
The bug preventing usage of ScopeEvents introduced in 8u262 was fixed in 8u282.
As an additional change the error message printed when `ScopeEventFactory` is not available is enhanced by the exception message to make it easier to figure out the root cause for the factory being unavailable.

[no] are you making any modifications to a non thread-safe data structure in a method or an advice that might happen on multiple theads at the same time?
