### PR TITLE
Avoid calling `SdkClientBuilder.overrideConfiguration`…

### DIFF
--- a/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java/datadog/trace/instrumentation/aws/v2/AwsClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java/datadog/trace/instrumentation/aws/v2/AwsClientInstrumentation.java
@@ -1,21 +1,19 @@
 package datadog.trace.instrumentation.aws.v2;
 
 import static datadog.trace.agent.tooling.ClassLoaderMatcher.hasClassesNamed;
-import static datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers.implementsInterface;
-import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.nameStartsWith;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
-import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
+import java.util.List;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
-import software.amazon.awssdk.core.client.builder.SdkClientBuilder;
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 
 /** AWS SDK v2 instrumentation */
 @AutoService(Instrumenter.class)
@@ -24,29 +22,30 @@ public final class AwsClientInstrumentation extends AbstractAwsClientInstrumenta
   @Override
   public ElementMatcher<ClassLoader> classLoaderMatcher() {
     // Optimization for expensive typeMatcher.
-    return hasClassesNamed("software.amazon.awssdk.core.client.builder.SdkClientBuilder");
+    return hasClassesNamed("software.amazon.awssdk.core.client.builder.SdkDefaultClientBuilder");
   }
 
   @Override
   public ElementMatcher<TypeDescription> typeMatcher() {
-    return nameStartsWith("software.amazon.awssdk.")
-        .and(
-            implementsInterface(
-                named("software.amazon.awssdk.core.client.builder.SdkClientBuilder")));
+    return named("software.amazon.awssdk.core.client.builder.SdkDefaultClientBuilder");
   }
 
   @Override
   public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
     return singletonMap(
-        isMethod().and(isPublic()).and(named("build")),
+        isMethod().and(named("resolveExecutionInterceptors")),
         AwsClientInstrumentation.class.getName() + "$AwsBuilderAdvice");
   }
 
   public static class AwsBuilderAdvice {
-
-    @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static void methodEnter(@Advice.This final SdkClientBuilder thiz) {
-      TracingExecutionInterceptor.overrideConfiguration(thiz);
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    public static void methodExit(@Advice.Return final List<ExecutionInterceptor> interceptors) {
+      for (ExecutionInterceptor interceptor : interceptors) {
+        if (interceptor instanceof TracingExecutionInterceptor) {
+          return; // list already has our interceptor, return to builder
+        }
+      }
+      interceptors.add(new TracingExecutionInterceptor());
     }
   }
 }

--- a/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java8/datadog/trace/instrumentation/aws/v2/TracingExecutionInterceptor.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java8/datadog/trace/instrumentation/aws/v2/TracingExecutionInterceptor.java
@@ -7,9 +7,6 @@ import static datadog.trace.instrumentation.aws.v2.AwsSdkClientDecorator.DECORAT
 
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import java.util.function.Consumer;
-import software.amazon.awssdk.core.client.builder.SdkClientBuilder;
-import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.interceptor.Context;
 import software.amazon.awssdk.core.interceptor.ExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
@@ -17,12 +14,6 @@ import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 
 /** AWS request execution interceptor */
 public class TracingExecutionInterceptor implements ExecutionInterceptor {
-
-  // Note: it looks like this lambda doesn't get generated as a separate class file so we do not
-  // need to inject helper for it.
-  private static final Consumer<ClientOverrideConfiguration.Builder>
-      OVERRIDE_CONFIGURATION_CONSUMER =
-          builder -> builder.addExecutionInterceptor(new TracingExecutionInterceptor());
 
   private static final ExecutionAttribute<AgentSpan> SPAN_ATTRIBUTE =
       new ExecutionAttribute<>("DatadogSpan");
@@ -83,14 +74,6 @@ public class TracingExecutionInterceptor implements ExecutionInterceptor {
       DECORATE.beforeFinish(span);
       span.finish();
     }
-  }
-
-  /**
-   * We keep this method here because it references Java8 classes and we would like to avoid
-   * compiling this for instrumentation code that should load into Java7.
-   */
-  public static void overrideConfiguration(final SdkClientBuilder client) {
-    client.overrideConfiguration(OVERRIDE_CONFIGURATION_CONSUMER);
   }
 
   public static void muzzleCheck() {


### PR DESCRIPTION
…because AWS only honours the last call; previously overridden config will be discarded.

Instead we intercept the `resolveExecutionInterceptors` implementation method and add our tracing interceptor as necessary.
