### PR TITLE
improvements in trace annotation instrumentation

### DIFF
--- a/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceAnnotationsInstrumentation.java
+++ b/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceAnnotationsInstrumentation.java
@@ -2,7 +2,6 @@ package datadog.trace.instrumentation.trace_annotation;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers.safeHasSuperType;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
-import static datadog.trace.instrumentation.trace_annotation.TraceConfigInstrumentation.PACKAGE_CLASS_NAME_REGEX;
 import static net.bytebuddy.matcher.ElementMatchers.declaresMethod;
 import static net.bytebuddy.matcher.ElementMatchers.isAnnotatedWith;
 
@@ -24,12 +23,7 @@ import org.slf4j.LoggerFactory;
 @AutoService(Instrumenter.class)
 public final class TraceAnnotationsInstrumentation extends Instrumenter.Tracing {
 
-  static final String CONFIG_FORMAT =
-      "(?:\\s*"
-          + PACKAGE_CLASS_NAME_REGEX
-          + "\\s*;)*\\s*"
-          + PACKAGE_CLASS_NAME_REGEX
-          + "\\s*;?\\s*";
+  static final String CONFIG_FORMAT = "(?:\\s*[\\w.$]+\\s*;)*\\s*[\\w.$]+\\s*;?\\s*";
 
   private final ElementMatcher.Junction<NamedElement> methodTraceMatcher;
 

--- a/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/ConfiguredTraceAnnotationsTest.groovy
+++ b/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/ConfiguredTraceAnnotationsTest.groovy
@@ -1,18 +1,15 @@
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.bootstrap.instrumentation.api.Tags
-import datadog.trace.instrumentation.trace_annotation.TraceAnnotationsInstrumentation
 import dd.test.trace.annotation.SayTracedHello
 
 import java.util.concurrent.Callable
-
-import static datadog.trace.instrumentation.trace_annotation.TraceAnnotationsInstrumentation.DEFAULT_ANNOTATIONS
 
 class ConfiguredTraceAnnotationsTest extends AgentTestRunner {
 
   @Override
   void configurePreAgent() {
     super.configurePreAgent()
-    injectSysConfig("dd.trace.annotations", "package.Class\$Name;${OuterClass.InterestingMethod.name}")
+    injectSysConfig("dd.trace.annotations", " package.Class\$Name; something.else.Here ;${OuterClass.InterestingMethod.name} ; ")
   }
 
   def "test disabled nr annotation"() {
@@ -43,30 +40,6 @@ class ConfiguredTraceAnnotationsTest extends AgentTestRunner {
         }
       }
     }
-  }
-
-  def "test configuration #value"() {
-    setup:
-    if (value) {
-      injectSysConfig("dd.trace.annotations", value)
-    } else {
-      removeSysConfig("dd.trace.annotations")
-    }
-
-    expect:
-    new HashSet<>(Arrays.asList(new TraceAnnotationsInstrumentation().additionalTraceAnnotations)) == expected.toSet()
-
-    where:
-    value                               | expected
-    null                                | Arrays.asList(DEFAULT_ANNOTATIONS)
-    " "                                 | []
-    "some.Invalid[]"                    | []
-    "some.package.ClassName "           | ["some.package.ClassName"]
-    " some.package.Class\$Name"         | ["some.package.Class\$Name"]
-    "  ClassName  "                     | ["ClassName"]
-    "ClassName"                         | ["ClassName"]
-    "Class\$1;Class\$2;"                | ["Class\$1", "Class\$2"]
-    "Duplicate ;Duplicate ;Duplicate; " | ["Duplicate"]
   }
 
   class AnnotationTracedCallable implements Callable<String> {

--- a/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/TraceConfigTest.groovy
+++ b/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/TraceConfigTest.groovy
@@ -245,6 +245,7 @@ class TraceConfigTest extends AgentTestRunner {
     value                                                           | expected
     null                                                            | [:]
     " "                                                             | [:]
+    "*"                                                             | [:]
     "some.package.ClassName"                                        | [:]
     "some.package.ClassName[ , ]"                                   | [:]
     "some.package.ClassName[ , method]"                             | [:]
@@ -252,10 +253,13 @@ class TraceConfigTest extends AgentTestRunner {
     "ClassName[ method1,]"                                          | ["ClassName": ["method1"].toSet()]
     "ClassName[method1 , method2]"                                  | ["ClassName": ["method1", "method2"].toSet()]
     "Class\$1[method1 ] ; Class\$2[ method2];"                      | ["Class\$1": ["method1"].toSet(), "Class\$2": ["method2"].toSet()]
-    "Duplicate[method1] ; Duplicate[method2]  ;Duplicate[method3];" | ["Duplicate": ["method3"].toSet()]
+    "Duplicate[method1] ; Duplicate[method2]  ;Duplicate[method3];" | ["Duplicate": ["method1", "method2", "method3"].toSet()]
     "ClassName[*]"                                                  | ["ClassName": ["*"].toSet()]
     "ClassName[*,asdfg]"                                            | [:]
     "ClassName[asdfg,*]"                                            | [:]
     "Class[*] ; Class\$2[ method2];"                                | ["Class": ["*"].toSet(), "Class\$2": ["method2"].toSet()]
+    "Class[*] ; Class\$2[ method2];      "                          | ["Class": ["*"].toSet(), "Class\$2": ["method2"].toSet()]
+    "     Class[*] ; Class\$2[ method2];      "                     | ["Class": ["*"].toSet(), "Class\$2": ["method2"].toSet()]
+    "     Class[*] ; Class\$2[ method2];"                           | ["Class": ["*"].toSet(), "Class\$2": ["method2"].toSet()]
   }
 }


### PR DESCRIPTION
* Remove the class loader matcher from the trace annotation instrumentation since `@Trace` is always loaded by the bootstrap classloader, it never has any effect
* improve config parsing in trace annotation instrumentations