### PR TITLE
validate agent is capable of receiving metrics before enabling metrics aggregation

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/OkHttpSink.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/OkHttpSink.java
@@ -141,6 +141,19 @@ public final class OkHttpSink implements Sink, EventListener {
     this.listeners.add(listener);
   }
 
+  @Override
+  public boolean validate() {
+    try (final okhttp3.Response response =
+        client.newCall(prepareRequest(metricsUrl).build()).execute()) {
+      if (response.code() != 404 && response.code() < 500) {
+        return true;
+      }
+    } catch (Throwable ignore) {
+      log.debug("Error validating metrics endpoint", ignore);
+    }
+    return false;
+  }
+
   private void handleFailure(okhttp3.Response response) throws IOException {
     final int code = response.code();
     if (code == 404) {

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/Sink.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/Sink.java
@@ -5,4 +5,6 @@ import datadog.trace.core.serialization.ByteBufferConsumer;
 public interface Sink extends ByteBufferConsumer {
 
   void register(EventListener listener);
+
+  boolean validate();
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/ConflatingMetricAggregatorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/ConflatingMetricAggregatorTest.groovy
@@ -25,6 +25,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
   def "should ignore traces with no measured spans"() {
     setup:
     Sink sink = Mock(Sink)
+    sink.validate() >> true
     WellKnownTags wellKnownTags = new WellKnownTags("hostname", "env", "service", "version")
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(
       wellKnownTags,
@@ -49,8 +50,10 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
   def "unmeasured top level spans have metrics computed"() {
     setup:
     MetricWriter writer = Mock(MetricWriter)
+    Sink sink = Stub(Sink)
+    sink.validate() >> true
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(
-      Stub(Sink), writer, 10, queueSize, reportingInterval, SECONDS)
+      sink, writer, 10, queueSize, reportingInterval, SECONDS)
     aggregator.start()
 
     when:
@@ -73,8 +76,10 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
   def "measured spans do not contribute to top level count"() {
     setup:
     MetricWriter writer = Mock(MetricWriter)
+    Sink sink = Stub(Sink)
+    sink.validate() >> true
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(
-      Stub(Sink), writer, 10, queueSize, reportingInterval, SECONDS)
+      sink, writer, 10, queueSize, reportingInterval, SECONDS)
     aggregator.start()
 
     when:
@@ -105,8 +110,10 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
   def "aggregate repetitive spans"() {
     setup:
     MetricWriter writer = Mock(MetricWriter)
+    Sink sink = Stub(Sink)
+    sink.validate() >> true
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(
-      Stub(Sink), writer, 10, queueSize, reportingInterval, SECONDS)
+      sink, writer, 10, queueSize, reportingInterval, SECONDS)
     long duration = 100
     List<CoreSpan> trace = [
       new SimpleSpan("service", "operation", "resource", "type", true, false, false, 0, duration),
@@ -145,8 +152,10 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     setup:
     int maxAggregates = 10
     MetricWriter writer = Mock(MetricWriter)
+    Sink sink = Stub(Sink)
+    sink.validate() >> true
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(
-      Stub(Sink), writer, maxAggregates, queueSize, reportingInterval, SECONDS)
+      sink, writer, maxAggregates, queueSize, reportingInterval, SECONDS)
     long duration = 100
     aggregator.start()
 
@@ -178,8 +187,10 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     setup:
     int maxAggregates = 10
     MetricWriter writer = Mock(MetricWriter)
+    Sink sink = Stub(Sink)
+    sink.validate() >> true
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(
-      Stub(Sink), writer, maxAggregates, queueSize, reportingInterval, SECONDS)
+      sink, writer, maxAggregates, queueSize, reportingInterval, SECONDS)
     long duration = 100
     aggregator.start()
 
@@ -230,8 +241,10 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     setup:
     int maxAggregates = 10
     MetricWriter writer = Mock(MetricWriter)
+    Sink sink = Stub(Sink)
+    sink.validate() >> true
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(
-      Stub(Sink), writer, maxAggregates, queueSize, reportingInterval, SECONDS)
+      sink, writer, maxAggregates, queueSize, reportingInterval, SECONDS)
     long duration = 100
     aggregator.start()
 
@@ -270,8 +283,10 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     setup:
     int maxAggregates = 10
     MetricWriter writer = Mock(MetricWriter)
+    Sink sink = Stub(Sink)
+    sink.validate() >> true
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(
-      Stub(Sink), writer, maxAggregates, queueSize, 1, SECONDS)
+      sink, writer, maxAggregates, queueSize, 1, SECONDS)
     long duration = 100
     aggregator.start()
 
@@ -301,8 +316,10 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     setup:
     int maxAggregates = 10
     MetricWriter writer = Mock(MetricWriter)
+    Sink sink = Stub(Sink)
+    sink.validate() >> true
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(
-      Stub(Sink), writer, maxAggregates, queueSize, 1, SECONDS)
+      sink, writer, maxAggregates, queueSize, 1, SECONDS)
     long duration = 100
     aggregator.start()
 
@@ -336,8 +353,10 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     setup:
     int maxAggregates = 10
     MetricWriter writer = Mock(MetricWriter)
+    Sink sink = Stub(Sink)
+    sink.validate() >> true
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(
-      Stub(Sink), writer, maxAggregates, queueSize, 1, SECONDS)
+      sink, writer, maxAggregates, queueSize, 1, SECONDS)
     long duration = 100
     aggregator.start()
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/FootprintTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/FootprintTest.groovy
@@ -25,6 +25,7 @@ class FootprintTest extends DDSpecification {
     setup:
     CountDownLatch latch = new CountDownLatch(1)
     Sink sink = Mock(Sink)
+    sink.validate() >> true
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(
       new WellKnownTags("hostname", "env", "service", "version"),
       sink,

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/OkHttpSinkTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/OkHttpSinkTest.groovy
@@ -27,6 +27,31 @@ import static datadog.trace.common.metrics.EventListener.EventType.OK
 })
 class OkHttpSinkTest extends DDSpecification {
 
+  def "validate responds to status code"() {
+    setup:
+    String agentUrl = "http://localhost:8126"
+    String path = "v0.5/stats"
+    OkHttpClient client = Mock(OkHttpClient)
+    OkHttpSink sink = new OkHttpSink(client, agentUrl, path, true)
+
+    when:
+    boolean validated = sink.validate()
+
+    then:
+    1 * client.newCall(_) >> { Request request -> respond(request, responseCode) }
+    validated == expected
+
+    where:
+    responseCode | expected
+    404          | false
+    500          | false
+    0            | false
+    400          | true
+    200          | true
+    201          | true
+  }
+
+
   def "http status code #responseCode yields #eventType"() {
     setup:
     String agentUrl = "http://localhost:8126"

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SerializingMetricWriterTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SerializingMetricWriterTest.groovy
@@ -72,6 +72,11 @@ class SerializingMetricWriterTest extends DDSpecification {
     }
 
     @Override
+    boolean validate() {
+      return true
+    }
+
+    @Override
     void accept(int messageCount, ByteBuffer buffer) {
       MessageUnpacker unpacker = MessagePack.newDefaultUnpacker(buffer)
       int mapSize = unpacker.unpackMapHeader()


### PR DESCRIPTION
When an old agent is deployed with a new tracer, it takes a cycle of metrics publishing to figure out whether the agent supports metrics, which leads to queue build up and live locks the scheduler thread. This PR changes this behaviour so we check before enabling, and removes the live lock condition.