### PR TITLE
Early filtering of transformation and re-transformation requests

### DIFF
--- a/dd-java-agent/agent-tooling/agent-tooling.gradle
+++ b/dd-java-agent/agent-tooling/agent-tooling.gradle
@@ -1,4 +1,5 @@
 apply from: "$rootDir/gradle/java.gradle"
+apply plugin: "idea"
 
 minimumBranchCoverage = 0.6
 excludedClassesCoverage += ['datadog.trace.agent.tooling.*']
@@ -24,4 +25,36 @@ dependencies {
 
   instrumentationMuzzle sourceSets.main.output
   instrumentationMuzzle configurations.compile
+}
+
+// Use Java 11 to build a delegating ClassFileTransformer that understands Java modules
+sourceSets {
+  "main_java11" {
+    java.srcDirs "${project.projectDir}/src/main/java11"
+  }
+}
+compileMain_java11Java.doFirst {
+  if (!System.env.JAVA_11_HOME) {
+    throw new GradleException('JAVA_11_HOME must be set to build transformer helpers')
+  }
+  options.fork = true
+  options.forkOptions.javaHome = file(System.env.JAVA_11_HOME)
+  sourceCompatibility = JavaVersion.VERSION_1_9
+  targetCompatibility = JavaVersion.VERSION_1_9
+}
+dependencies {
+  main_java11CompileOnly deps.bytebuddy
+  main_java11CompileOnly sourceSets.main.output
+  runtime sourceSets.main_java11.output
+}
+jar {
+  from sourceSets.main_java11.output
+}
+forbiddenApisMain_java11 {
+  failOnMissingClasses = false
+}
+idea {
+  module {
+    jdkName = '11'
+  }
 }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
@@ -82,8 +82,9 @@ public class AgentInstaller {
         new AgentBuilder.Default()
             .disableClassFormatChanges()
             .assureReadEdgeTo(INSTRUMENTATION, FieldBackedContextAccessor.class)
+            .with(AgentTooling.transformerDecorator())
             .with(AgentBuilder.RedefinitionStrategy.RETRANSFORMATION)
-            .with(AgentBuilder.RedefinitionStrategy.DiscoveryStrategy.Reiterating.INSTANCE)
+            .with(AgentTooling.rediscoveryStrategy())
             .with(AgentBuilder.DescriptionStrategy.Default.POOL_ONLY)
             .with(AgentTooling.poolStrategy())
             .with(new ClassLoadListener())
@@ -103,7 +104,7 @@ public class AgentInstaller {
       agentBuilder =
           agentBuilder
               .with(AgentBuilder.RedefinitionStrategy.RETRANSFORMATION)
-              .with(AgentBuilder.RedefinitionStrategy.DiscoveryStrategy.Reiterating.INSTANCE)
+              .with(AgentTooling.rediscoveryStrategy())
               .with(new RedefinitionLoggingListener())
               .with(new TransformLoggingListener());
     }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentTooling.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentTooling.java
@@ -1,11 +1,15 @@
 package datadog.trace.agent.tooling;
 
 import datadog.trace.agent.tooling.bytebuddy.DDCachingPoolStrategy;
+import datadog.trace.agent.tooling.bytebuddy.DDClassFileTransformer;
 import datadog.trace.agent.tooling.bytebuddy.DDLocationStrategy;
+import datadog.trace.agent.tooling.bytebuddy.DDRediscoveryStrategy;
 import datadog.trace.api.Config;
+import datadog.trace.api.Platform;
 import datadog.trace.bootstrap.WeakCache;
 import datadog.trace.bootstrap.WeakCache.Provider;
 import datadog.trace.bootstrap.WeakMap;
+import net.bytebuddy.agent.builder.AgentBuilder.TransformerDecorator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,12 +45,30 @@ public class AgentTooling {
     }
   }
 
+  private static TransformerDecorator loadTranformerDecorator() {
+    if (Platform.isJavaVersionAtLeast(9)) {
+      try {
+        return (TransformerDecorator)
+            AgentInstaller.class
+                .getClassLoader()
+                .loadClass("datadog.trace.agent.tooling.bytebuddy.DDJava9ClassFileTransformer")
+                .getField("DECORATOR")
+                .get(null);
+      } catch (Throwable e) {
+        log.warn("Problem loading Java9 Module support, falling back to legacy transformer", e);
+      }
+    }
+    return DDClassFileTransformer.DECORATOR;
+  }
+
   private static final long DEFAULT_CACHE_CAPACITY = 32;
   private static final Provider weakCacheProvider = loadWeakCacheProvider();
 
+  private static final DDRediscoveryStrategy REDISCOVERY_STRATEGY = new DDRediscoveryStrategy();
   private static final DDLocationStrategy LOCATION_STRATEGY = new DDLocationStrategy();
   private static final DDCachingPoolStrategy POOL_STRATEGY =
       new DDCachingPoolStrategy(Config.get().isResolverUseLoadClassEnabled());
+  private static final TransformerDecorator TRANSFORMER_DECORATOR = loadTranformerDecorator();
 
   public static <K, V> WeakCache<K, V> newWeakCache() {
     return newWeakCache(DEFAULT_CACHE_CAPACITY);
@@ -56,11 +78,19 @@ public class AgentTooling {
     return weakCacheProvider.newWeakCache(maxSize);
   }
 
+  public static DDRediscoveryStrategy rediscoveryStrategy() {
+    return REDISCOVERY_STRATEGY;
+  }
+
   public static DDLocationStrategy locationStrategy() {
     return LOCATION_STRATEGY;
   }
 
   public static DDCachingPoolStrategy poolStrategy() {
     return POOL_STRATEGY;
+  }
+
+  public static TransformerDecorator transformerDecorator() {
+    return TRANSFORMER_DECORATOR;
   }
 }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/DDClassFileTransformer.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/DDClassFileTransformer.java
@@ -1,0 +1,46 @@
+package datadog.trace.agent.tooling.bytebuddy;
+
+import static datadog.trace.agent.tooling.ClassLoaderMatcher.canSkipClassLoaderByName;
+
+import java.lang.instrument.IllegalClassFormatException;
+import java.security.ProtectionDomain;
+import net.bytebuddy.agent.builder.AgentBuilder.TransformerDecorator;
+import net.bytebuddy.agent.builder.ResettableClassFileTransformer;
+
+/**
+ * Intercepts transformation requests before ByteBuddy so we can perform some initial filtering.
+ *
+ * <p>This class is only used on Java 7/8, for Java 9+ see {@link DDJava9ClassFileTransformer}.
+ */
+public final class DDClassFileTransformer extends ResettableClassFileTransformer.WithDelegation {
+
+  public static final TransformerDecorator DECORATOR =
+      new TransformerDecorator() {
+        @Override
+        public ResettableClassFileTransformer decorate(
+            final ResettableClassFileTransformer classFileTransformer) {
+          return new DDClassFileTransformer(classFileTransformer);
+        }
+      };
+
+  public DDClassFileTransformer(final ResettableClassFileTransformer classFileTransformer) {
+    super(classFileTransformer);
+  }
+
+  @Override
+  public byte[] transform(
+      final ClassLoader classLoader,
+      final String internalClassName,
+      final Class<?> classBeingRedefined,
+      final ProtectionDomain protectionDomain,
+      final byte[] classFileBuffer)
+      throws IllegalClassFormatException {
+
+    if (null != classLoader && canSkipClassLoaderByName(classLoader)) {
+      return null;
+    }
+
+    return classFileTransformer.transform(
+        classLoader, internalClassName, classBeingRedefined, protectionDomain, classFileBuffer);
+  }
+}

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/DDRediscoveryStrategy.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/DDRediscoveryStrategy.java
@@ -1,0 +1,116 @@
+package datadog.trace.agent.tooling.bytebuddy;
+
+import static datadog.trace.agent.tooling.ClassLoaderMatcher.canSkipClassLoaderByName;
+
+import datadog.trace.agent.tooling.bytebuddy.matcher.GlobalIgnoresMatcher;
+import java.lang.instrument.ClassFileTransformer;
+import java.lang.instrument.Instrumentation;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Set;
+import net.bytebuddy.agent.builder.AgentBuilder.RedefinitionStrategy;
+
+/**
+ * Selects specific classes loaded during agent installation that we want to re-transform.
+ *
+ * <p>This handles a situation where our ByteBuddy transformer won't be notified of "definitions of
+ * classes upon which any registered transformer is dependent". These classes are already loaded so
+ * we cannot make structural changes, but we can still add method advice by re-transforming them.
+ *
+ * <p>Each round of re-transformation can result in more types to re-transform, so the iterator
+ * repeats until no more types need re-transforming. Typically only one or two rounds are needed
+ * before we run out of types to re-transform, but we impose a hard limit as a precaution.
+ *
+ * @see Instrumentation#addTransformer(ClassFileTransformer, boolean)
+ */
+public final class DDRediscoveryStrategy implements RedefinitionStrategy.DiscoveryStrategy {
+  static final int MAX_ROUNDS = 10;
+
+  @Override
+  public Iterable<Iterable<Class<?>>> resolve(final Instrumentation instrumentation) {
+    return new Iterable<Iterable<Class<?>>>() {
+      @Override
+      public Iterator<Iterable<Class<?>>> iterator() {
+        final Set<Class<?>> visited = new HashSet<>(256);
+        return new Iterator<Iterable<Class<?>>>() {
+          private int round = 0;
+
+          @Override
+          public boolean hasNext() {
+            return round < MAX_ROUNDS;
+          }
+
+          @Override
+          public Iterable<Class<?>> next() {
+            if (!hasNext()) {
+              throw new NoSuchElementException();
+            }
+            List<Class<?>> next = selectClassesForRetransformation(instrumentation, visited);
+            if (next.isEmpty()) {
+              round = MAX_ROUNDS; // halt iterator, nothing more to re-transform
+            } else {
+              round++;
+            }
+            return next;
+          }
+
+          @Override
+          public void remove() {
+            throw new UnsupportedOperationException();
+          }
+        };
+      }
+    };
+  }
+
+  /** Selects classes to retransform from already loaded classes that we haven't previously seen. */
+  static List<Class<?>> selectClassesForRetransformation(
+      final Instrumentation instrumentation, final Set<Class<?>> visited) {
+    List<Class<?>> retransforming = new ArrayList<>();
+    for (Class<?> clazz : instrumentation.getAllLoadedClasses()) {
+      ClassLoader classLoader = clazz.getClassLoader();
+      if ((null == classLoader
+              ? shouldRetransformBootstrapClass(clazz.getName())
+              : !canSkipClassLoaderByName(classLoader))
+          && visited.add(clazz)) {
+        retransforming.add(clazz);
+      }
+    }
+    return retransforming;
+  }
+
+  /**
+   * This can be viewed as the inverse of {@link GlobalIgnoresMatcher} - it only lists bootstrap
+   * classes loaded during agent installation that we explicitly want to be re-transformed.
+   */
+  static boolean shouldRetransformBootstrapClass(final String name) {
+    switch (name) {
+      case "java.lang.Throwable":
+      case "java.net.HttpURLConnection":
+      case "java.net.URL":
+      case "sun.net.www.http.HttpClient":
+      case "datadog.trace.bootstrap.instrumentation.java.concurrent.RunnableWrapper":
+        return true;
+    }
+    if (name.startsWith("java.util.concurrent.")
+        || name.startsWith("java.rmi.")
+        || name.startsWith("sun.rmi.server.")
+        || name.startsWith("sun.rmi.transport.")) {
+      return true;
+    }
+    if (name.startsWith("sun.net.www.protocol.")) {
+      // ignore internal Java Runtime protocol, helps avoid a second round of transformation
+      return !name.startsWith("sun.net.www.protocol.jrt");
+    }
+    if (name.startsWith("java.util.logging.")) {
+      // concurrent instrumentation modifies the structure of the Cleaner class incompatibly
+      // with java9+ modules. Excluding it as a workaround until a long-term fix for modules
+      // can be put in place.
+      return !name.equals("java.util.logging.LogManager$Cleaner");
+    }
+    return false;
+  }
+}

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/GlobalIgnoresMatcher.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/GlobalIgnoresMatcher.java
@@ -1,5 +1,6 @@
 package datadog.trace.agent.tooling.bytebuddy.matcher;
 
+import datadog.trace.agent.tooling.bytebuddy.DDRediscoveryStrategy;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
@@ -47,6 +48,8 @@ public class GlobalIgnoresMatcher<T extends TypeDescription>
    * Be very careful about the types of matchers used in this section as they are called on every
    * class load, so they must be fast. Generally speaking try to only use name matchers as they
    * don't have to load additional info.
+   *
+   * @see DDRediscoveryStrategy#shouldRetransformBootstrapClass(String)
    */
   @Override
   public boolean matches(final T target) {
@@ -116,6 +119,10 @@ public class GlobalIgnoresMatcher<T extends TypeDescription>
         if (name.startsWith("jdk.")) {
           return true;
         }
+        /**
+         * Any changes involving bootstrap types should also be reflected in {@link
+         * DDRediscoveryStrategy#shouldRetransformBootstrapClass(String)}
+         */
         if (name.startsWith("java.")) {
           // allow exception profiling instrumentation
           if (name.equals("java.lang.Throwable")) {
@@ -173,6 +180,10 @@ public class GlobalIgnoresMatcher<T extends TypeDescription>
       case 'r' - 'a':
         break;
       case 's' - 'a':
+        /**
+         * Any changes involving bootstrap types should also be reflected in {@link
+         * DDRediscoveryStrategy#shouldRetransformBootstrapClass(String)}
+         */
         if (name.startsWith("sun.")) {
           return !name.startsWith("sun.net.www.protocol.")
               && !name.startsWith("sun.rmi.server")

--- a/dd-java-agent/agent-tooling/src/main/java11/datadog/trace/agent/tooling/bytebuddy/DDJava9ClassFileTransformer.java
+++ b/dd-java-agent/agent-tooling/src/main/java11/datadog/trace/agent/tooling/bytebuddy/DDJava9ClassFileTransformer.java
@@ -1,0 +1,70 @@
+package datadog.trace.agent.tooling.bytebuddy;
+
+import static datadog.trace.agent.tooling.ClassLoaderMatcher.canSkipClassLoaderByName;
+
+import java.lang.instrument.IllegalClassFormatException;
+import java.security.ProtectionDomain;
+import net.bytebuddy.agent.builder.AgentBuilder.TransformerDecorator;
+import net.bytebuddy.agent.builder.ResettableClassFileTransformer;
+
+/**
+ * Intercepts transformation requests before ByteBuddy so we can perform some initial filtering.
+ *
+ * <p>This class is only used on Java 9+, for Java 7/8 see {@link DDClassFileTransformer}.
+ */
+public final class DDJava9ClassFileTransformer
+    extends ResettableClassFileTransformer.WithDelegation {
+
+  public static final TransformerDecorator DECORATOR =
+      new TransformerDecorator() {
+        @Override
+        public ResettableClassFileTransformer decorate(
+            final ResettableClassFileTransformer classFileTransformer) {
+          return new DDJava9ClassFileTransformer(classFileTransformer);
+        }
+      };
+
+  public DDJava9ClassFileTransformer(final ResettableClassFileTransformer classFileTransformer) {
+    super(classFileTransformer);
+  }
+
+  @Override
+  public byte[] transform(
+      final ClassLoader classLoader,
+      final String internalClassName,
+      final Class<?> classBeingRedefined,
+      final ProtectionDomain protectionDomain,
+      final byte[] classFileBuffer)
+      throws IllegalClassFormatException {
+
+    if (null != classLoader && canSkipClassLoaderByName(classLoader)) {
+      return null;
+    }
+
+    return classFileTransformer.transform(
+        classLoader, internalClassName, classBeingRedefined, protectionDomain, classFileBuffer);
+  }
+
+  @Override
+  public byte[] transform(
+      final Module module,
+      final ClassLoader classLoader,
+      final String internalClassName,
+      final Class<?> classBeingRedefined,
+      final ProtectionDomain protectionDomain,
+      final byte[] classFileBuffer)
+      throws IllegalClassFormatException {
+
+    if (null != classLoader && canSkipClassLoaderByName(classLoader)) {
+      return null;
+    }
+
+    return classFileTransformer.transform(
+        module,
+        classLoader,
+        internalClassName,
+        classBeingRedefined,
+        protectionDomain,
+        classFileBuffer);
+  }
+}


### PR DESCRIPTION
This PR decorates ByteBuddy's class transformers so we can do some preliminary filtering of class load events before entering ByteBuddy. It also introduces a custom strategy for discovering classes that we missed while installing the actual agent and now need to re-transform.

Most of the complexity here is to handle different `ClassFileTransformer` decorators for Java8 vs Java9 and above, which introduced a new callback for classes loaded from the modulepath. The default implementation of this new callback calls the non-module method, but this drops the module information breaking ByteBuddy's support for patching modules so key types are visible. We need to have a Java9 specific `ClassFileTransformer` that delegates each `transform` method to its equivalent in ByteBuddy.