### PR TITLE
cancel scheduled reporting task when metrics is disabled

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/ConflatingMetricsAggregator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/ConflatingMetricsAggregator.java
@@ -236,6 +236,10 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
 
   private void disable() {
     this.enabled = false;
+    AgentTaskScheduler.Scheduled<?> cancellation = this.cancellation;
+    if (null != cancellation) {
+      cancellation.cancel();
+    }
     this.thread.interrupt();
     this.pending.clear();
     this.batchPool.clear();


### PR DESCRIPTION
#2549 was implemented hastily and should have included this change. Having excluded this change is benign, but this change prevents the attempts to report periodically.