### PR TITLE
Address various JDBC instrumentation issues

### DIFF
--- a/dd-java-agent/instrumentation/jdbc/jdbc.gradle
+++ b/dd-java-agent/instrumentation/jdbc/jdbc.gradle
@@ -1,6 +1,7 @@
 muzzle {
   pass {
     coreJdk()
+    extraDependency 'com.ibm.db2:jcc:11.1.4.4'
   }
 }
 

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/AbstractConnectionInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/AbstractConnectionInstrumentation.java
@@ -44,7 +44,7 @@ public abstract class AbstractConnectionInstrumentation extends Instrumenter.Tra
       ContextStore<PreparedStatement, DBQueryInfo> contextStore =
           InstrumentationContext.get(PreparedStatement.class, DBQueryInfo.class);
       if (null == contextStore.get(statement)) {
-        contextStore.putIfAbsent(statement, DBQueryInfo.ofPreparedStatement(sql));
+        contextStore.put(statement, DBQueryInfo.ofPreparedStatement(sql));
       }
     }
   }

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/AbstractConnectionInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/AbstractConnectionInstrumentation.java
@@ -1,0 +1,51 @@
+package datadog.trace.instrumentation.jdbc;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers.hasInterface;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.nameStartsWith;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static java.util.Collections.singletonMap;
+import static net.bytebuddy.matcher.ElementMatchers.returns;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.bootstrap.ContextStore;
+import datadog.trace.bootstrap.InstrumentationContext;
+import datadog.trace.bootstrap.instrumentation.jdbc.DBQueryInfo;
+import java.sql.PreparedStatement;
+import java.util.Map;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+public abstract class AbstractConnectionInstrumentation extends Instrumenter.Tracing {
+  public AbstractConnectionInstrumentation(String instrumentationName, String... additionalNames) {
+    super(instrumentationName, additionalNames);
+  }
+
+  @Override
+  public Map<String, String> contextStore() {
+    return singletonMap("java.sql.PreparedStatement", DBQueryInfo.class.getName());
+  }
+
+  @Override
+  public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
+    return singletonMap(
+        nameStartsWith("prepare")
+            .and(takesArgument(0, String.class))
+            // Also include CallableStatement, which is a sub type of PreparedStatement
+            .and(returns(hasInterface(named("java.sql.PreparedStatement")))),
+        AbstractConnectionInstrumentation.class.getName() + "$ConnectionPrepareAdvice");
+  }
+
+  public static class ConnectionPrepareAdvice {
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    public static void addDBInfo(
+        @Advice.Argument(0) final String sql, @Advice.Return final PreparedStatement statement) {
+      ContextStore<PreparedStatement, DBQueryInfo> contextStore =
+          InstrumentationContext.get(PreparedStatement.class, DBQueryInfo.class);
+      if (null == contextStore.get(statement)) {
+        contextStore.putIfAbsent(statement, DBQueryInfo.ofPreparedStatement(sql));
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/AbstractPreparedStatementInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/AbstractPreparedStatementInstrumentation.java
@@ -1,0 +1,103 @@
+package datadog.trace.instrumentation.jdbc;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.nameStartsWith;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+import static datadog.trace.instrumentation.jdbc.JDBCDecorator.DATABASE_QUERY;
+import static datadog.trace.instrumentation.jdbc.JDBCDecorator.DECORATE;
+import static java.util.Collections.singletonMap;
+import static net.bytebuddy.matcher.ElementMatchers.isPublic;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.bootstrap.ContextStore;
+import datadog.trace.bootstrap.InstrumentationContext;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.jdbc.DBInfo;
+import datadog.trace.bootstrap.instrumentation.jdbc.DBQueryInfo;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.HashMap;
+import java.util.Map;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+public abstract class AbstractPreparedStatementInstrumentation extends Instrumenter.Tracing {
+  public AbstractPreparedStatementInstrumentation(
+      String instrumentationName, String... additionalNames) {
+    super(instrumentationName, additionalNames);
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {
+      packageName + ".JDBCDecorator",
+    };
+  }
+
+  @Override
+  public Map<String, String> contextStore() {
+    Map<String, String> contextStore = new HashMap<>(4);
+    contextStore.put("java.sql.PreparedStatement", DBQueryInfo.class.getName());
+    contextStore.put("java.sql.Statement", Boolean.class.getName());
+    contextStore.put("java.sql.Connection", DBInfo.class.getName());
+    return contextStore;
+  }
+
+  @Override
+  public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
+    return singletonMap(
+        nameStartsWith("execute").and(takesArguments(0)).and(isPublic()),
+        AbstractPreparedStatementInstrumentation.class.getName() + "$PreparedStatementAdvice");
+  }
+
+  public static class PreparedStatementAdvice {
+
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static AgentScope onEnter(@Advice.This final PreparedStatement statement) {
+      ContextStore<Statement, Boolean> interceptionTracker =
+          InstrumentationContext.get(Statement.class, Boolean.class);
+      if (Boolean.TRUE.equals(interceptionTracker.get(statement))) {
+        return null;
+      }
+      interceptionTracker.put(statement, Boolean.TRUE);
+      try {
+        Connection connection = statement.getConnection();
+        DBQueryInfo queryInfo =
+            InstrumentationContext.get(PreparedStatement.class, DBQueryInfo.class).get(statement);
+        if (null == queryInfo) {
+          return null;
+        }
+
+        final AgentSpan span = startSpan(DATABASE_QUERY);
+        DECORATE.afterStart(span);
+        DECORATE.onConnection(
+            span, connection, InstrumentationContext.get(Connection.class, DBInfo.class));
+        DECORATE.onPreparedStatement(span, queryInfo);
+        return activateSpan(span);
+      } catch (SQLException e) {
+        // if we can't get the connection for any reason
+        return null;
+      }
+    }
+
+    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
+    public static void stopSpan(
+        @Advice.This PreparedStatement statement,
+        @Advice.Enter final AgentScope scope,
+        @Advice.Thrown final Throwable throwable) {
+      if (scope == null) {
+        return;
+      }
+      DECORATE.onError(scope.span(), throwable);
+      DECORATE.beforeFinish(scope.span());
+      scope.close();
+      scope.span().finish();
+      InstrumentationContext.get(Statement.class, Boolean.class).put(statement, null);
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/DB2ConnectionInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/DB2ConnectionInstrumentation.java
@@ -1,0 +1,27 @@
+package datadog.trace.instrumentation.jdbc;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers.implementsInterface;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static datadog.trace.instrumentation.jdbc.DB2PreparedStatementInstrumentation.CLASS_LOADER_MATCHER;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+@AutoService(Instrumenter.class)
+public class DB2ConnectionInstrumentation extends AbstractConnectionInstrumentation {
+  public DB2ConnectionInstrumentation() {
+    super("jdbc", "db2");
+  }
+
+  @Override
+  public ElementMatcher<? super TypeDescription> typeMatcher() {
+    return implementsInterface(named("com.ibm.db2.jcc.DB2Connection"));
+  }
+
+  @Override
+  public ElementMatcher<ClassLoader> classLoaderMatcher() {
+    return CLASS_LOADER_MATCHER;
+  }
+}

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/DB2PreparedStatementInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/DB2PreparedStatementInstrumentation.java
@@ -1,0 +1,30 @@
+package datadog.trace.instrumentation.jdbc;
+
+import static datadog.trace.agent.tooling.ClassLoaderMatcher.hasClassesNamed;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers.implementsInterface;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+@AutoService(Instrumenter.class)
+public class DB2PreparedStatementInstrumentation extends AbstractPreparedStatementInstrumentation {
+  public DB2PreparedStatementInstrumentation() {
+    super("jdbc", "db2");
+  }
+
+  public static final ElementMatcher<ClassLoader> CLASS_LOADER_MATCHER =
+      hasClassesNamed("com.ibm.db2.jcc.DB2PreparedStatement");
+
+  @Override
+  public ElementMatcher<? super TypeDescription> typeMatcher() {
+    return implementsInterface(named("com.ibm.db2.jcc.DB2PreparedStatement"));
+  }
+
+  @Override
+  public ElementMatcher<ClassLoader> classLoaderMatcher() {
+    return CLASS_LOADER_MATCHER;
+  }
+}

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/DriverInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/DriverInstrumentation.java
@@ -70,7 +70,7 @@ public final class DriverInstrumentation extends Instrumenter.Tracing {
         // Exception was probably thrown.
         return;
       }
-      final DBInfo dbInfo = JDBCConnectionUrlParser.parse(url, props);
+      final DBInfo dbInfo = JDBCConnectionUrlParser.extractDBInfo(url, props);
       InstrumentationContext.get(Connection.class, DBInfo.class).put(connection, dbInfo);
     }
   }

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/JDBCDecorator.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/JDBCDecorator.java
@@ -89,10 +89,10 @@ public class JDBCDecorator extends DatabaseClientDecorator<DBInfo> {
           final String url = metaData.getURL();
           if (url != null) {
             try {
-              dbInfo = JDBCConnectionUrlParser.parse(url, connection.getClientInfo());
+              dbInfo = JDBCConnectionUrlParser.extractDBInfo(url, connection.getClientInfo());
             } catch (final Throwable ex) {
               // getClientInfo is likely not allowed.
-              dbInfo = JDBCConnectionUrlParser.parse(url, null);
+              dbInfo = JDBCConnectionUrlParser.extractDBInfo(url, null);
             }
           } else {
             dbInfo = DBInfo.DEFAULT;

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/PreparedStatementInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/PreparedStatementInstrumentation.java
@@ -1,40 +1,16 @@
 package datadog.trace.instrumentation.jdbc;
 
-import static datadog.trace.agent.tooling.ClassLoaderMatcher.hasClassesNamed;
-import static datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers.safeHasSuperType;
-import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.nameStartsWith;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
-import static datadog.trace.instrumentation.jdbc.JDBCDecorator.DATABASE_QUERY;
-import static datadog.trace.instrumentation.jdbc.JDBCDecorator.DECORATE;
-import static java.util.Collections.singletonMap;
-import static net.bytebuddy.matcher.ElementMatchers.isPublic;
-import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
-import datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers;
 import datadog.trace.api.Config;
-import datadog.trace.bootstrap.ContextStore;
-import datadog.trace.bootstrap.InstrumentationContext;
-import datadog.trace.bootstrap.instrumentation.api.AgentScope;
-import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.bootstrap.instrumentation.jdbc.DBInfo;
-import datadog.trace.bootstrap.instrumentation.jdbc.DBQueryInfo;
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.util.HashMap;
-import java.util.Map;
-import net.bytebuddy.asm.Advice;
-import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(Instrumenter.class)
-public final class PreparedStatementInstrumentation extends Instrumenter.Tracing {
+public final class PreparedStatementInstrumentation
+    extends AbstractPreparedStatementInstrumentation {
 
   private static final String[] CONCRETE_TYPES = {
     // redshift
@@ -114,97 +90,12 @@ public final class PreparedStatementInstrumentation extends Instrumenter.Tracing
     Config.get().getJdbcPreparedStatementClassName()
   };
 
-  private static final String[] ABSTRACT_TYPES = {
-    // should cover DB2
-    "com.ibm.db2.jcc.DB2PreparedStatement",
-    // this won't match any classes unless set
-    Config.get().getJdbcPreparedStatementClassName()
-  };
-
   public PreparedStatementInstrumentation() {
     super("jdbc");
   }
 
-  static ElementMatcher<ClassLoader> CLASS_LOADER_MATCHER =
-      hasClassesNamed("java.sql.PreparedStatement");
-
-  @Override
-  public ElementMatcher<ClassLoader> classLoaderMatcher() {
-    return CLASS_LOADER_MATCHER;
-  }
-
-  @Override
-  public Map<String, String> contextStore() {
-    Map<String, String> contextStore = new HashMap<>(4);
-    contextStore.put("java.sql.PreparedStatement", DBQueryInfo.class.getName());
-    contextStore.put("java.sql.Statement", Boolean.class.getName());
-    contextStore.put("java.sql.Connection", DBInfo.class.getName());
-    return contextStore;
-  }
-
   @Override
   public ElementMatcher<TypeDescription> typeMatcher() {
-    return namedOneOf(CONCRETE_TYPES)
-        .or(safeHasSuperType(NameMatchers.<TypeDescription>namedOneOf(ABSTRACT_TYPES)));
-  }
-
-  @Override
-  public String[] helperClassNames() {
-    return new String[] {
-      packageName + ".JDBCDecorator",
-    };
-  }
-
-  @Override
-  public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
-    return singletonMap(
-        nameStartsWith("execute").and(takesArguments(0)).and(isPublic()),
-        PreparedStatementInstrumentation.class.getName() + "$PreparedStatementAdvice");
-  }
-
-  public static class PreparedStatementAdvice {
-
-    @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static AgentScope onEnter(@Advice.This final PreparedStatement statement) {
-      ContextStore<Statement, Boolean> interceptionTracker =
-          InstrumentationContext.get(Statement.class, Boolean.class);
-      if (Boolean.TRUE.equals(interceptionTracker.get(statement))) {
-        return null;
-      }
-      interceptionTracker.put(statement, Boolean.TRUE);
-      try {
-        Connection connection = statement.getConnection();
-        DBQueryInfo queryInfo =
-            InstrumentationContext.get(PreparedStatement.class, DBQueryInfo.class).get(statement);
-        if (null == queryInfo) {
-          return null;
-        }
-
-        final AgentSpan span = startSpan(DATABASE_QUERY);
-        DECORATE.afterStart(span);
-        DECORATE.onConnection(
-            span, connection, InstrumentationContext.get(Connection.class, DBInfo.class));
-        DECORATE.onPreparedStatement(span, queryInfo);
-        return activateSpan(span);
-      } catch (SQLException e) {
-        // if we can't get the connection for any reason
-        return null;
-      }
-    }
-
-    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
-    public static void stopSpan(
-        @Advice.This PreparedStatement statement,
-        @Advice.Enter final AgentScope scope,
-        @Advice.Thrown final Throwable throwable) {
-      if (scope == null) {
-        return;
-      }
-      DECORATE.onError(scope.span(), throwable);
-      DECORATE.beforeFinish(scope.span());
-      scope.close();
-      scope.span().finish();
-      InstrumentationContext.get(Statement.class, Boolean.class).put(statement, null);
-    }
+    return namedOneOf(CONCRETE_TYPES);
   }
 }

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/PreparedStatementInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/PreparedStatementInstrumentation.java
@@ -15,6 +15,7 @@ public final class PreparedStatementInstrumentation
   private static final String[] CONCRETE_TYPES = {
     // redshift
     "com.amazon.redshift.jdbc.RedshiftPreparedStatement",
+    "com.amazon.redshift.jdbc.RedshiftCallableStatement",
     // jt400
     "com.ibm.as400.access.AS400JDBCPreparedStatement",
     // probably patchy cover

--- a/dd-java-agent/instrumentation/jdbc/src/test/groovy/JDBCConnectionUrlParserTest.groovy
+++ b/dd-java-agent/instrumentation/jdbc/src/test/groovy/JDBCConnectionUrlParserTest.groovy
@@ -2,7 +2,7 @@ import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.bootstrap.instrumentation.jdbc.DBInfo
 import spock.lang.Shared
 
-import static datadog.trace.bootstrap.instrumentation.jdbc.JDBCConnectionUrlParser.parse
+import static datadog.trace.bootstrap.instrumentation.jdbc.JDBCConnectionUrlParser.extractDBInfo
 
 class JDBCConnectionUrlParserTest extends AgentTestRunner {
 
@@ -24,7 +24,7 @@ class JDBCConnectionUrlParserTest extends AgentTestRunner {
 
   def "invalid url returns default"() {
     expect:
-    parse(url, null) == DBInfo.DEFAULT
+    extractDBInfo(url, null) == DBInfo.DEFAULT
 
     where:
     url            | _
@@ -37,7 +37,7 @@ class JDBCConnectionUrlParserTest extends AgentTestRunner {
 
   def "verify #type:#subtype parsing of #url"() {
     setup:
-    def info = parse(url, props)
+    def info = extractDBInfo(url, props)
 
     expect:
     info.url == expected.url


### PR DESCRIPTION
This PR makes a few changes to the JDBC instrumentation

1. Caches connection URL parsing since some applications connect frequently, the parsing is quite slow, and connecting often takes a driver level lock. This should fix an issue for Apache Phoenix users where connection creation is more common than in applications using traditional connection pools.
2. Separates out and namespaces DB2 `Connection` and `PreparedStatement` instrumentations, which have expensive type matchers. This means that unless DB2 is being used, JDBC matching is about as cheap as it can get.
3. Add Redshift's `CallableStatement` implementation, which was missed in #2511
