### PR TITLE
Centralize route handling and add a flag for resource naming

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/RouteHandlerDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/RouteHandlerDecorator.java
@@ -1,0 +1,41 @@
+package datadog.trace.bootstrap.instrumentation.decorator;
+
+import datadog.trace.api.Config;
+import datadog.trace.api.Function;
+import datadog.trace.api.Pair;
+import datadog.trace.api.cache.DDCache;
+import datadog.trace.api.cache.DDCaches;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.Tags;
+import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
+
+public class RouteHandlerDecorator {
+  public static final RouteHandlerDecorator ROUTE_HANDLER_DECORATOR = new RouteHandlerDecorator();
+
+  private static final Function<Pair<CharSequence, CharSequence>, CharSequence>
+      RESOURCE_NAME_JOINER =
+          new Function<Pair<CharSequence, CharSequence>, CharSequence>() {
+            @Override
+            public CharSequence apply(Pair<CharSequence, CharSequence> input) {
+              if (input.getLeft() == null) {
+                return input.getRight();
+              }
+              return UTF8BytesString.create(
+                  input.getLeft().toString().toUpperCase() + " " + input.getRight());
+            }
+          };
+
+  private static final DDCache<Pair<CharSequence, CharSequence>, CharSequence> RESOURCE_NAME_CACHE =
+      DDCaches.newFixedSizeCache(64);
+
+  public final AgentSpan withRoute(
+      final AgentSpan span, final CharSequence method, final CharSequence route) {
+    span.setTag(Tags.HTTP_ROUTE, route);
+    if (Config.get().isHttpServerRouteBasedNaming()) {
+      final CharSequence resourceName =
+          RESOURCE_NAME_CACHE.computeIfAbsent(Pair.of(method, route), RESOURCE_NAME_JOINER);
+      span.setResourceName(resourceName);
+    }
+    return span;
+  }
+}

--- a/dd-java-agent/instrumentation/dropwizard/src/test/groovy/DropwizardTest.groovy
+++ b/dd-java-agent/instrumentation/dropwizard/src/test/groovy/DropwizardTest.groovy
@@ -137,6 +137,7 @@ class DropwizardTest extends HttpServerTest<DropwizardTestSupport> {
         "$Tags.PEER_PORT" Integer
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
+        "$Tags.HTTP_ROUTE" "/${endpoint.rawPath()}"
         "$Tags.HTTP_STATUS" endpoint.status
         if (endpoint.errored) {
           "error.msg" { it == null || it == EXCEPTION.body }

--- a/dd-java-agent/instrumentation/finatra-2.9/src/latestDepTest/groovy/FinatraServer270Test.groovy
+++ b/dd-java-agent/instrumentation/finatra-2.9/src/latestDepTest/groovy/FinatraServer270Test.groovy
@@ -89,6 +89,11 @@ class FinatraServer270Test extends HttpServerTest<HttpServer> {
     return "finatra.request"
   }
 
+  @Override
+  boolean tagServerSpanWithRoute() {
+    return true
+  }
+
   void handlerSpan(TraceAssert trace, ServerEndpoint endpoint = SUCCESS) {
     def errorEndpoint = endpoint == EXCEPTION || endpoint == ERROR
     trace.span {

--- a/dd-java-agent/instrumentation/finatra-2.9/src/main/java/datadog/trace/instrumentation/finatra/FinatraInstrumentation.java
+++ b/dd-java-agent/instrumentation/finatra-2.9/src/main/java/datadog/trace/instrumentation/finatra/FinatraInstrumentation.java
@@ -7,6 +7,7 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+import static datadog.trace.bootstrap.instrumentation.decorator.RouteHandlerDecorator.ROUTE_HANDLER_DECORATOR;
 import static datadog.trace.instrumentation.finatra.FinatraDecorator.DECORATE;
 import static datadog.trace.instrumentation.finatra.FinatraDecorator.FINATRA_CONTROLLER;
 import static datadog.trace.instrumentation.finatra.FinatraDecorator.FINATRA_REQUEST;
@@ -72,7 +73,7 @@ public class FinatraInstrumentation extends Instrumenter.Tracing {
 
       // Update the parent "netty.request"
       final AgentSpan parent = activeSpan();
-      parent.setResourceName(request.method().name() + " " + path);
+      ROUTE_HANDLER_DECORATOR.withRoute(parent, request.method().name(), path);
       parent.setTag(Tags.COMPONENT, "finatra");
       parent.setSpanName(FINATRA_REQUEST);
 

--- a/dd-java-agent/instrumentation/finatra-2.9/src/test/groovy/FinatraServerTest.groovy
+++ b/dd-java-agent/instrumentation/finatra-2.9/src/test/groovy/FinatraServerTest.groovy
@@ -7,6 +7,7 @@ import datadog.trace.agent.test.base.HttpServerTest
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.instrumentation.finatra.FinatraDecorator
+
 import java.util.concurrent.TimeUnit
 
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR
@@ -62,6 +63,11 @@ class FinatraServerTest extends HttpServerTest<HttpServer> {
   @Override
   String expectedOperationName() {
     return "finatra.request"
+  }
+
+  @Override
+  boolean tagServerSpanWithRoute() {
+    return true
   }
 
   void handlerSpan(TraceAssert trace, ServerEndpoint endpoint = SUCCESS) {

--- a/dd-java-agent/instrumentation/jax-rs-annotations-1/src/main/java/datadog/trace/instrumentation/jaxrs1/JaxRsAnnotationsDecorator.java
+++ b/dd-java-agent/instrumentation/jax-rs-annotations-1/src/main/java/datadog/trace/instrumentation/jaxrs1/JaxRsAnnotationsDecorator.java
@@ -1,7 +1,10 @@
 package datadog.trace.instrumentation.jaxrs1;
 
+import static datadog.trace.bootstrap.instrumentation.decorator.RouteHandlerDecorator.ROUTE_HANDLER_DECORATOR;
+
 import datadog.trace.agent.tooling.ClassHierarchyIterable;
 import datadog.trace.api.GenericClassValue;
+import datadog.trace.api.Pair;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
@@ -17,8 +20,8 @@ import javax.ws.rs.Path;
 public class JaxRsAnnotationsDecorator extends BaseDecorator {
   public static JaxRsAnnotationsDecorator DECORATE = new JaxRsAnnotationsDecorator();
 
-  private static final ClassValue<ConcurrentHashMap<Method, String>> RESOURCE_NAMES =
-      GenericClassValue.constructing(ConcurrentHashMap.class);
+  private static final ClassValue<ConcurrentHashMap<Method, Pair<CharSequence, CharSequence>>>
+      RESOURCE_NAMES = GenericClassValue.constructing(ConcurrentHashMap.class);
 
   public static final CharSequence JAX_RS_CONTROLLER = UTF8BytesString.create("jax-rs-controller");
 
@@ -40,45 +43,37 @@ public class JaxRsAnnotationsDecorator extends BaseDecorator {
   public void onJaxRsSpan(
       final AgentSpan span, final AgentSpan parent, final Class<?> target, final Method method) {
 
-    final String resourceName = getPathResourceName(target, method);
-    updateRootSpan(parent, resourceName);
-
+    final Pair<CharSequence, CharSequence> httpMethodAndRoute =
+        getHttpMethodAndRoute(target, method);
     span.setSpanType(InternalSpanTypes.HTTP_SERVER);
 
     // When jax-rs is the root, we want to name using the path, otherwise use the class/method.
     final boolean isRootScope = parent == null;
-    if (isRootScope && !resourceName.isEmpty()) {
-      span.setResourceName(resourceName);
+    if (isRootScope) {
+      ROUTE_HANDLER_DECORATOR.withRoute(
+          span, httpMethodAndRoute.getLeft(), httpMethodAndRoute.getRight());
     } else {
+      if (!parent.getLocalRootSpan().hasResourceName()) {
+        ROUTE_HANDLER_DECORATOR.withRoute(
+            parent.getLocalRootSpan(), httpMethodAndRoute.getLeft(), httpMethodAndRoute.getRight());
+        parent.getLocalRootSpan().setTag(Tags.COMPONENT, "jax-rs");
+      }
+
       span.setResourceName(DECORATE.spanNameForMethod(target, method));
     }
   }
 
-  private void updateRootSpan(AgentSpan span, final String resourceName) {
-    if (span == null) {
-      return;
-    }
-    span = span.getLocalRootSpan();
-
-    if (!span.hasResourceName()) {
-      span.setTag(Tags.COMPONENT, "jax-rs");
-
-      if (!resourceName.isEmpty()) {
-        span.setResourceName(resourceName);
-      }
-    }
-  }
-
   /**
-   * Returns the resource name given a JaxRS annotated method. Results are cached so this method can
-   * be called multiple times without significantly impacting performance.
+   * Returns the resource name parts given a JaxRS annotated method. Results are cached so this
+   * method can be called multiple times without significantly impacting performance.
    *
    * @return The result can be an empty string but will never be {@code null}.
    */
-  private String getPathResourceName(final Class<?> target, final Method method) {
-    Map<Method, String> classMap = RESOURCE_NAMES.get(target);
-    String resourceName = classMap.get(method);
-    if (resourceName == null) {
+  private Pair<CharSequence, CharSequence> getHttpMethodAndRoute(
+      final Class<?> target, final Method method) {
+    Map<Method, Pair<CharSequence, CharSequence>> classMap = RESOURCE_NAMES.get(target);
+    Pair<CharSequence, CharSequence> httpMethodAndRoute = classMap.get(method);
+    if (httpMethodAndRoute == null) {
       String httpMethod = null;
       Path methodPath = null;
       final Path classPath = findClassPath(target);
@@ -103,11 +98,12 @@ public class JaxRsAnnotationsDecorator extends BaseDecorator {
           }
         }
       }
-      resourceName = buildResourceName(httpMethod, classPath, methodPath);
-      classMap.put(method, resourceName);
+      httpMethodAndRoute =
+          Pair.<CharSequence, CharSequence>of(httpMethod, buildRoutePath(classPath, methodPath));
+      classMap.put(method, httpMethodAndRoute);
     }
 
-    return resourceName;
+    return httpMethodAndRoute;
   }
 
   private String locateHttpMethod(final Method method) {
@@ -162,20 +158,15 @@ public class JaxRsAnnotationsDecorator extends BaseDecorator {
     return null;
   }
 
-  private String buildResourceName(
-      final String httpMethod, final Path classPath, final Path methodPath) {
-    final String resourceName;
-    final StringBuilder resourceNameBuilder = new StringBuilder();
-    if (httpMethod != null) {
-      resourceNameBuilder.append(httpMethod);
-      resourceNameBuilder.append(" ");
-    }
+  private String buildRoutePath(final Path classPath, final Path methodPath) {
+    final StringBuilder route = new StringBuilder();
+
     boolean skipSlash = false;
     if (classPath != null) {
       if (!classPath.value().startsWith("/")) {
-        resourceNameBuilder.append("/");
+        route.append("/");
       }
-      resourceNameBuilder.append(classPath.value());
+      route.append(classPath.value());
       skipSlash = classPath.value().endsWith("/");
     }
 
@@ -186,12 +177,11 @@ public class JaxRsAnnotationsDecorator extends BaseDecorator {
           path = path.length() == 1 ? "" : path.substring(1);
         }
       } else if (!path.startsWith("/")) {
-        resourceNameBuilder.append("/");
+        route.append("/");
       }
-      resourceNameBuilder.append(path);
+      route.append(path);
     }
 
-    resourceName = resourceNameBuilder.toString().trim();
-    return resourceName;
+    return route.toString().trim();
   }
 }

--- a/dd-java-agent/instrumentation/jax-rs-annotations-1/src/main/java/datadog/trace/instrumentation/jaxrs1/JaxRsAnnotationsInstrumentation.java
+++ b/dd-java-agent/instrumentation/jax-rs-annotations-1/src/main/java/datadog/trace/instrumentation/jaxrs1/JaxRsAnnotationsInstrumentation.java
@@ -52,7 +52,7 @@ public final class JaxRsAnnotationsInstrumentation extends Instrumenter.Tracing 
     return new String[] {
       "datadog.trace.agent.tooling.ClassHierarchyIterable",
       "datadog.trace.agent.tooling.ClassHierarchyIterable$ClassIterator",
-      packageName + ".JaxRsAnnotationsDecorator"
+      packageName + ".JaxRsAnnotationsDecorator",
     };
   }
 

--- a/dd-java-agent/instrumentation/jax-rs-annotations-1/src/test/groovy/JaxRsAnnotations1InstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/jax-rs-annotations-1/src/test/groovy/JaxRsAnnotations1InstrumentationTest.groovy
@@ -32,6 +32,7 @@ class JaxRsAnnotations1InstrumentationTest extends AgentTestRunner {
           spanType "web"
           tags {
             "$Tags.COMPONENT" "jax-rs-controller"
+            "$Tags.HTTP_ROUTE" "/a"
             defaultTags()
           }
         }
@@ -54,6 +55,7 @@ class JaxRsAnnotations1InstrumentationTest extends AgentTestRunner {
           parent()
           tags {
             "$Tags.COMPONENT" "jax-rs"
+            "$Tags.HTTP_ROUTE" name.split(" ").last()
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/jax-rs-annotations-1/src/test/groovy/JerseyTest.groovy
+++ b/dd-java-agent/instrumentation/jax-rs-annotations-1/src/test/groovy/JerseyTest.groovy
@@ -34,6 +34,7 @@ class JerseyTest extends AgentTestRunner {
           resourceName expectedResourceName
           tags {
             "$Tags.COMPONENT" "jax-rs"
+            "$Tags.HTTP_ROUTE" expectedResourceName.split(" ").last()
             defaultTags()
           }
         }
@@ -76,6 +77,7 @@ class JerseyTest extends AgentTestRunner {
           resourceName parentResourceName
           tags {
             "$Tags.COMPONENT" "jax-rs"
+            "$Tags.HTTP_ROUTE" parentResourceName.split(" ").last()
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/jax-rs-annotations-2/src/main/java/datadog/trace/instrumentation/jaxrs2/JaxRsAnnotationsDecorator.java
+++ b/dd-java-agent/instrumentation/jax-rs-annotations-2/src/main/java/datadog/trace/instrumentation/jaxrs2/JaxRsAnnotationsDecorator.java
@@ -1,7 +1,10 @@
 package datadog.trace.instrumentation.jaxrs2;
 
+import static datadog.trace.bootstrap.instrumentation.decorator.RouteHandlerDecorator.ROUTE_HANDLER_DECORATOR;
+
 import datadog.trace.agent.tooling.ClassHierarchyIterable;
 import datadog.trace.api.GenericClassValue;
+import datadog.trace.api.Pair;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
@@ -28,10 +31,10 @@ public class JaxRsAnnotationsDecorator extends BaseDecorator {
       "datadog.trace.instrumentation.jaxrs2.filter.abort.parent";
   public static final String ABORT_SPAN = "datadog.trace.instrumentation.jaxrs2.filter.abort.span";
 
-  public static final JaxRsAnnotationsDecorator DECORATE = new JaxRsAnnotationsDecorator();
+  public static JaxRsAnnotationsDecorator DECORATE = new JaxRsAnnotationsDecorator();
 
-  private static final ClassValue<ConcurrentHashMap<Method, String>> RESOURCE_NAMES =
-      GenericClassValue.constructing(ConcurrentHashMap.class);
+  private static final ClassValue<ConcurrentHashMap<Method, Pair<CharSequence, CharSequence>>>
+      RESOURCE_NAMES = GenericClassValue.constructing(ConcurrentHashMap.class);
 
   @Override
   protected String[] instrumentationNames() {
@@ -51,46 +54,37 @@ public class JaxRsAnnotationsDecorator extends BaseDecorator {
   public void onJaxRsSpan(
       final AgentSpan span, final AgentSpan parent, final Class<?> target, final Method method) {
 
-    final String resourceName = getPathResourceName(target, method);
-    updateRootSpan(parent, resourceName);
-
+    final Pair<CharSequence, CharSequence> httpMethodAndRoute =
+        getHttpMethodAndRoute(target, method);
     span.setSpanType(InternalSpanTypes.HTTP_SERVER);
 
     // When jax-rs is the root, we want to name using the path, otherwise use the class/method.
     final boolean isRootScope = parent == null;
-    if (isRootScope && !resourceName.isEmpty()) {
-      span.setResourceName(resourceName);
+    if (isRootScope) {
+      ROUTE_HANDLER_DECORATOR.withRoute(
+          span, httpMethodAndRoute.getLeft(), httpMethodAndRoute.getRight());
     } else {
+      if (!parent.getLocalRootSpan().hasResourceName()) {
+        ROUTE_HANDLER_DECORATOR.withRoute(
+            parent.getLocalRootSpan(), httpMethodAndRoute.getLeft(), httpMethodAndRoute.getRight());
+        parent.getLocalRootSpan().setTag(Tags.COMPONENT, "jax-rs");
+      }
+
       span.setResourceName(DECORATE.spanNameForMethod(target, method));
     }
   }
 
-  private void updateRootSpan(AgentSpan span, final String resourceName) {
-    if (span == null) {
-      return;
-    }
-    span = span.getLocalRootSpan();
-
-    if (!span.hasResourceName()) {
-      span.setTag(Tags.COMPONENT, "jax-rs");
-
-      if (!resourceName.isEmpty()) {
-        span.setResourceName(resourceName);
-      }
-    }
-  }
-
   /**
-   * Returns the resource name given a JaxRS annotated method. Results are cached so this method can
-   * be called multiple times without significantly impacting performance.
+   * Returns the resource name parts given a JaxRS annotated method. Results are cached so this
+   * method can be called multiple times without significantly impacting performance.
    *
    * @return The result can be an empty string but will never be {@code null}.
    */
-  private String getPathResourceName(final Class<?> target, final Method method) {
-    Map<Method, String> classMap = RESOURCE_NAMES.get(target);
-
-    String resourceName = classMap.get(method);
-    if (resourceName == null) {
+  private Pair<CharSequence, CharSequence> getHttpMethodAndRoute(
+      final Class<?> target, final Method method) {
+    Map<Method, Pair<CharSequence, CharSequence>> classMap = RESOURCE_NAMES.get(target);
+    Pair<CharSequence, CharSequence> httpMethodAndRoute = classMap.get(method);
+    if (httpMethodAndRoute == null) {
       String httpMethod = null;
       Path methodPath = null;
       final Path classPath = findClassPath(target);
@@ -115,11 +109,12 @@ public class JaxRsAnnotationsDecorator extends BaseDecorator {
           }
         }
       }
-      resourceName = buildResourceName(httpMethod, classPath, methodPath);
-      classMap.put(method, resourceName);
+      httpMethodAndRoute =
+          Pair.<CharSequence, CharSequence>of(httpMethod, buildRoutePath(classPath, methodPath));
+      classMap.put(method, httpMethodAndRoute);
     }
 
-    return resourceName;
+    return httpMethodAndRoute;
   }
 
   private String locateHttpMethod(final Method method) {
@@ -174,20 +169,15 @@ public class JaxRsAnnotationsDecorator extends BaseDecorator {
     return null;
   }
 
-  private String buildResourceName(
-      final String httpMethod, final Path classPath, final Path methodPath) {
-    final String resourceName;
-    final StringBuilder resourceNameBuilder = new StringBuilder();
-    if (httpMethod != null) {
-      resourceNameBuilder.append(httpMethod);
-      resourceNameBuilder.append(" ");
-    }
+  private String buildRoutePath(final Path classPath, final Path methodPath) {
+    final StringBuilder route = new StringBuilder();
+
     boolean skipSlash = false;
     if (classPath != null) {
       if (!classPath.value().startsWith("/")) {
-        resourceNameBuilder.append("/");
+        route.append("/");
       }
-      resourceNameBuilder.append(classPath.value());
+      route.append(classPath.value());
       skipSlash = classPath.value().endsWith("/");
     }
 
@@ -198,12 +188,11 @@ public class JaxRsAnnotationsDecorator extends BaseDecorator {
           path = path.length() == 1 ? "" : path.substring(1);
         }
       } else if (!path.startsWith("/")) {
-        resourceNameBuilder.append("/");
+        route.append("/");
       }
-      resourceNameBuilder.append(path);
+      route.append(path);
     }
 
-    resourceName = resourceNameBuilder.toString().trim();
-    return resourceName;
+    return route.toString().trim();
   }
 }

--- a/dd-java-agent/instrumentation/jax-rs-annotations-2/src/test/groovy/JaxRsAnnotations2InstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/jax-rs-annotations-2/src/test/groovy/JaxRsAnnotations2InstrumentationTest.groovy
@@ -32,6 +32,7 @@ class JaxRsAnnotations2InstrumentationTest extends AgentTestRunner {
           spanType "web"
           tags {
             "$Tags.COMPONENT" "jax-rs-controller"
+            "$Tags.HTTP_ROUTE" "/a"
             defaultTags()
           }
         }
@@ -54,6 +55,7 @@ class JaxRsAnnotations2InstrumentationTest extends AgentTestRunner {
           parent()
           tags {
             "$Tags.COMPONENT" "jax-rs"
+            "$Tags.HTTP_ROUTE" name.split(" ").last()
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/jax-rs-annotations-2/src/test/groovy/JaxRsFilterTest.groovy
+++ b/dd-java-agent/instrumentation/jax-rs-annotations-2/src/test/groovy/JaxRsFilterTest.groovy
@@ -62,6 +62,9 @@ abstract class JaxRsFilterTest extends AgentTestRunner {
           resourceName parentResourceName
           tags {
             "$Tags.COMPONENT" "jax-rs"
+            if (httpRoute) {
+              "$Tags.HTTP_ROUTE" httpRoute
+            }
             defaultTags()
           }
         }
@@ -79,21 +82,21 @@ abstract class JaxRsFilterTest extends AgentTestRunner {
     }
 
     where:
-    resource           | abortNormal | abortPrematch | parentResourceName         | controllerName                 | expectedResponse
-    "/test/hello/bob"  | false       | false         | "POST /test/hello/{name}"  | "Test1.hello"                  | "Test1 bob!"
-    "/test2/hello/bob" | false       | false         | "POST /test2/hello/{name}" | "Test2.hello"                  | "Test2 bob!"
-    "/test3/hi/bob"    | false       | false         | "POST /test3/hi/{name}"    | "Test3.hello"                  | "Test3 bob!"
+    resource           | abortNormal | abortPrematch | parentResourceName         | httpRoute | controllerName                 | expectedResponse
+    "/test/hello/bob"  | false       | false         | "POST /test/hello/{name}"  | "/test/hello/{name}" | "Test1.hello"                  | "Test1 bob!"
+    "/test2/hello/bob" | false       | false         | "POST /test2/hello/{name}" | "/test2/hello/{name}" | "Test2.hello"                  | "Test2 bob!"
+    "/test3/hi/bob"    | false       | false         | "POST /test3/hi/{name}"    | "/test3/hi/{name}" | "Test3.hello"                  | "Test3 bob!"
 
     // Resteasy and Jersey give different resource class names for just the below case
     // Resteasy returns "SubResource.class"
     // Jersey returns "Test1.class
     // "/test/hello/bob"  | true        | false         | "POST /test/hello/{name}"  | "Test1.hello"                  | "Aborted"
 
-    "/test2/hello/bob" | true        | false         | "POST /test2/hello/{name}" | "Test2.hello"                  | "Aborted"
-    "/test3/hi/bob"    | true        | false         | "POST /test3/hi/{name}"    | "Test3.hello"                  | "Aborted"
-    "/test/hello/bob"  | false       | true          | "test.span"                | "PrematchRequestFilter.filter" | "Aborted Prematch"
-    "/test2/hello/bob" | false       | true          | "test.span"                | "PrematchRequestFilter.filter" | "Aborted Prematch"
-    "/test3/hi/bob"    | false       | true          | "test.span"                | "PrematchRequestFilter.filter" | "Aborted Prematch"
+    "/test2/hello/bob" | true        | false         | "POST /test2/hello/{name}" | "/test2/hello/{name}" | "Test2.hello"                  | "Aborted"
+    "/test3/hi/bob"    | true        | false         | "POST /test3/hi/{name}"    | "/test3/hi/{name}" | "Test3.hello"                  | "Aborted"
+    "/test/hello/bob"  | false       | true          | "test.span"                | null | "PrematchRequestFilter.filter" | "Aborted Prematch"
+    "/test2/hello/bob" | false       | true          | "test.span"                | null | "PrematchRequestFilter.filter" | "Aborted Prematch"
+    "/test3/hi/bob"    | false       | true          | "test.span"                | null | "PrematchRequestFilter.filter" | "Aborted Prematch"
   }
 
   def "test nested call"() {
@@ -121,6 +124,7 @@ abstract class JaxRsFilterTest extends AgentTestRunner {
           resourceName parentResourceName
           tags {
             "$Tags.COMPONENT" "jax-rs"
+            "$Tags.HTTP_ROUTE" resource
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/play-2.3/src/main/java8/datadog/trace/instrumentation/play23/PlayHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/play-2.3/src/main/java8/datadog/trace/instrumentation/play23/PlayHttpServerDecorator.java
@@ -1,5 +1,7 @@
 package datadog.trace.instrumentation.play23;
 
+import static datadog.trace.bootstrap.instrumentation.decorator.RouteHandlerDecorator.ROUTE_HANDLER_DECORATOR;
+
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
@@ -7,6 +9,7 @@ import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.UndeclaredThrowableException;
+import play.api.Routes;
 import play.api.mvc.Request;
 import play.api.mvc.Result;
 import scala.Option;
@@ -61,10 +64,10 @@ public class PlayHttpServerDecorator extends HttpServerDecorator<Request, Reques
     if (request != null) {
       // more about routes here:
       // https://github.com/playframework/playframework/blob/master/documentation/manual/releases/release26/migration26/Migration26.md#router-tags-are-now-attributes
-      final Option pathOption = request.tags().get("ROUTE_PATTERN");
+      final Option pathOption = request.tags().get(Routes.ROUTE_PATTERN());
       if (!pathOption.isEmpty()) {
         final String path = (String) pathOption.get();
-        span.setResourceName(request.method() + " " + path);
+        ROUTE_HANDLER_DECORATOR.withRoute(span, request.method(), path);
       }
     }
     return span;

--- a/dd-java-agent/instrumentation/play-2.3/src/test/groovy/server/PlayServerTest.groovy
+++ b/dd-java-agent/instrumentation/play-2.3/src/test/groovy/server/PlayServerTest.groovy
@@ -52,6 +52,8 @@ class PlayServerTest extends HttpServerTest<TestServer> {
         "$Tags.HTTP_URL" String
         "$Tags.HTTP_METHOD" String
         "$Tags.HTTP_STATUS" Integer
+        // BUG
+        //        "$Tags.HTTP_ROUTE" String
         if (endpoint == EXCEPTION) {
           errorTags(Exception, EXCEPTION.body)
         }

--- a/dd-java-agent/instrumentation/play-2.4/src/main/java8/datadog/trace/instrumentation/play24/PlayHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/play-2.4/src/main/java8/datadog/trace/instrumentation/play24/PlayHttpServerDecorator.java
@@ -1,5 +1,7 @@
 package datadog.trace.instrumentation.play24;
 
+import static datadog.trace.bootstrap.instrumentation.decorator.RouteHandlerDecorator.ROUTE_HANDLER_DECORATOR;
+
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
@@ -64,7 +66,7 @@ public class PlayHttpServerDecorator extends HttpServerDecorator<Request, Reques
       final Option pathOption = request.tags().get("ROUTE_PATTERN");
       if (!pathOption.isEmpty()) {
         final String path = (String) pathOption.get();
-        span.setResourceName(request.method() + " " + path);
+        ROUTE_HANDLER_DECORATOR.withRoute(span, request.method(), path);
       }
     }
     return span;

--- a/dd-java-agent/instrumentation/play-2.4/src/test/groovy/server/PlayServerTest.groovy
+++ b/dd-java-agent/instrumentation/play-2.4/src/test/groovy/server/PlayServerTest.groovy
@@ -95,6 +95,8 @@ class PlayServerTest extends HttpServerTest<Server> {
         "$Tags.HTTP_URL" String
         "$Tags.HTTP_METHOD" String
         "$Tags.HTTP_STATUS" Integer
+        // BUG
+        //        "$Tags.HTTP_ROUTE" String
         if (endpoint == EXCEPTION) {
           errorTags(Exception, EXCEPTION.body)
         }

--- a/dd-java-agent/instrumentation/play-2.6/src/main/java8/datadog/trace/instrumentation/play26/PlayHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/play-2.6/src/main/java8/datadog/trace/instrumentation/play26/PlayHttpServerDecorator.java
@@ -1,5 +1,7 @@
 package datadog.trace.instrumentation.play26;
 
+import static datadog.trace.bootstrap.instrumentation.decorator.RouteHandlerDecorator.ROUTE_HANDLER_DECORATOR;
+
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
@@ -107,7 +109,7 @@ public class PlayHttpServerDecorator extends HttpServerDecorator<Request, Reques
       }
       if (!defOption.isEmpty()) {
         final String path = defOption.get().path();
-        span.setResourceName(request.method() + " " + path);
+        ROUTE_HANDLER_DECORATOR.withRoute(span, request.method(), path);
       }
     }
     return span;

--- a/dd-java-agent/instrumentation/play-2.6/src/test/groovy/server/PlayServerTest.groovy
+++ b/dd-java-agent/instrumentation/play-2.6/src/test/groovy/server/PlayServerTest.groovy
@@ -102,6 +102,8 @@ class PlayServerTest extends HttpServerTest<Server> {
         "$Tags.HTTP_URL" String
         "$Tags.HTTP_METHOD" String
         "$Tags.HTTP_STATUS" Integer
+        // BUG
+        //        "$Tags.HTTP_ROUTE" String
         if (endpoint == EXCEPTION) {
           errorTags(Exception, EXCEPTION.body)
         }

--- a/dd-java-agent/instrumentation/ratpack-1.5/src/main/java8/datadog/trace/instrumentation/ratpack/RatpackServerDecorator.java
+++ b/dd-java-agent/instrumentation/ratpack-1.5/src/main/java8/datadog/trace/instrumentation/ratpack/RatpackServerDecorator.java
@@ -1,5 +1,7 @@
 package datadog.trace.instrumentation.ratpack;
 
+import static datadog.trace.bootstrap.instrumentation.decorator.RouteHandlerDecorator.ROUTE_HANDLER_DECORATOR;
+
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
@@ -68,8 +70,7 @@ public class RatpackServerDecorator extends HttpServerDecorator<Request, Request
       description = "/" + description;
     }
 
-    final String resourceName = ctx.getRequest().getMethod().getName() + " " + description;
-    span.setResourceName(resourceName);
+    ROUTE_HANDLER_DECORATOR.withRoute(span, ctx.getRequest().getMethod().getName(), description);
 
     return span;
   }

--- a/dd-java-agent/instrumentation/ratpack-1.5/src/test/groovy/RatpackOtherTest.groovy
+++ b/dd-java-agent/instrumentation/ratpack-1.5/src/test/groovy/RatpackOtherTest.groovy
@@ -76,6 +76,7 @@ class RatpackOtherTest extends AgentTestRunner {
             "$Tags.HTTP_URL" "${app.address.resolve(path)}"
             "$Tags.HTTP_METHOD" "GET"
             "$Tags.HTTP_STATUS" 200
+            "$Tags.HTTP_ROUTE" "/$route"
             defaultTags()
           }
         }
@@ -93,6 +94,7 @@ class RatpackOtherTest extends AgentTestRunner {
             "$Tags.HTTP_URL" "${app.address.resolve(path)}"
             "$Tags.HTTP_METHOD" "GET"
             "$Tags.HTTP_STATUS" 200
+            "$Tags.HTTP_ROUTE" "/$route"
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/ratpack-1.5/src/test/groovy/server/RatpackHttpServerTest.groovy
+++ b/dd-java-agent/instrumentation/ratpack-1.5/src/test/groovy/server/RatpackHttpServerTest.groovy
@@ -108,6 +108,11 @@ class RatpackHttpServerTest extends HttpServerTest<EmbeddedApp> {
   }
 
   @Override
+  boolean tagServerSpanWithRoute() {
+    true
+  }
+
+  @Override
   void handlerSpan(TraceAssert trace, ServerEndpoint endpoint = SUCCESS) {
     trace.span {
       serviceName expectedServiceName()
@@ -123,6 +128,7 @@ class RatpackHttpServerTest extends HttpServerTest<EmbeddedApp> {
         "$Tags.HTTP_URL" String
         "$Tags.HTTP_METHOD" String
         "$Tags.HTTP_STATUS" Integer
+        "$Tags.HTTP_ROUTE" String
         if (endpoint == EXCEPTION) {
           errorTags(Exception, EXCEPTION.body)
         }

--- a/dd-java-agent/instrumentation/sparkjava-2.3/src/main/java/datadog/trace/instrumentation/sparkjava/RoutesInstrumentation.java
+++ b/dd-java-agent/instrumentation/sparkjava-2.3/src/main/java/datadog/trace/instrumentation/sparkjava/RoutesInstrumentation.java
@@ -2,6 +2,7 @@ package datadog.trace.instrumentation.sparkjava;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
+import static datadog.trace.bootstrap.instrumentation.decorator.RouteHandlerDecorator.ROUTE_HANDLER_DECORATOR;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.returns;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
@@ -50,8 +51,7 @@ public class RoutesInstrumentation extends Instrumenter.Tracing {
 
       final AgentSpan span = activeSpan();
       if (span != null && routeMatch != null) {
-        final String resourceName = method.name().toUpperCase() + " " + routeMatch.getMatchUri();
-        span.setResourceName(resourceName);
+        ROUTE_HANDLER_DECORATOR.withRoute(span, method.name(), routeMatch.getMatchUri());
       }
     }
   }

--- a/dd-java-agent/instrumentation/sparkjava-2.3/src/test/groovy/SparkJavaBasedTest.groovy
+++ b/dd-java-agent/instrumentation/sparkjava-2.3/src/test/groovy/SparkJavaBasedTest.groovy
@@ -59,6 +59,7 @@ class SparkJavaBasedTest extends AgentTestRunner {
             "$Tags.HTTP_URL" "http://localhost:$port/param/asdf1234"
             "$Tags.HTTP_METHOD" "GET"
             "$Tags.HTTP_STATUS" 200
+            "$Tags.HTTP_ROUTE" String
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/spring-cloud-zuul-2/src/test/groovy/SpringBootZuulTest.groovy
+++ b/dd-java-agent/instrumentation/spring-cloud-zuul-2/src/test/groovy/SpringBootZuulTest.groovy
@@ -159,6 +159,7 @@ class SpringBootZuulTest extends HttpServerTest<ConfigurableApplicationContext> 
       tags {
         "$Tags.COMPONENT" "java-web-servlet-dispatcher"
         "servlet.path" endpoint.path
+        "$Tags.HTTP_ROUTE" String
 
         if (endpoint.throwsException) {
           "error.msg" EXCEPTION.body
@@ -213,6 +214,7 @@ class SpringBootZuulTest extends HttpServerTest<ConfigurableApplicationContext> 
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
         "$Tags.HTTP_STATUS" endpoint.status
+        "$Tags.HTTP_ROUTE" String
         "servlet.path" endpoint.path
         if (endpoint.errored) {
           "error.msg" { it == null || it == EXCEPTION.body }

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/boot20Test/groovy/SpringWebfluxTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/boot20Test/groovy/SpringWebfluxTest.groovy
@@ -62,6 +62,8 @@ class SpringWebfluxTest extends AgentTestRunner {
             "$Tags.HTTP_URL" url
             "$Tags.HTTP_METHOD" "GET"
             "$Tags.HTTP_STATUS" 200
+            // BUG
+            if (!testName.startsWith("functional")) { "$Tags.HTTP_ROUTE" "$urlPathWithVariables" }
             defaultTags()
           }
         }
@@ -135,6 +137,8 @@ class SpringWebfluxTest extends AgentTestRunner {
             "$Tags.HTTP_URL" url
             "$Tags.HTTP_METHOD" "GET"
             "$Tags.HTTP_STATUS" 200
+            // BUG
+            if (!testName.startsWith("functional")) { "$Tags.HTTP_ROUTE" "$urlPathWithVariables" }
             defaultTags()
           }
         }
@@ -283,6 +287,8 @@ class SpringWebfluxTest extends AgentTestRunner {
             "$Tags.HTTP_URL" url
             "$Tags.HTTP_METHOD" "GET"
             "$Tags.HTTP_STATUS" 404
+            // BUG
+            "$Tags.HTTP_ROUTE" "/**"
             defaultTags()
           }
         }
@@ -333,6 +339,7 @@ class SpringWebfluxTest extends AgentTestRunner {
             "$Tags.HTTP_URL" url
             "$Tags.HTTP_METHOD" "POST"
             "$Tags.HTTP_STATUS" 202
+            // BUG "$Tags.HTTP_ROUTE" "/echo"
             defaultTags()
           }
         }
@@ -391,6 +398,8 @@ class SpringWebfluxTest extends AgentTestRunner {
             "$Tags.HTTP_URL" url
             "$Tags.HTTP_METHOD" "GET"
             "$Tags.HTTP_STATUS" 500
+            // BUG
+            if (!testName.startsWith("functional")) { "$Tags.HTTP_ROUTE" "$urlPathWithVariables" }
             defaultTags()
           }
         }
@@ -464,6 +473,7 @@ class SpringWebfluxTest extends AgentTestRunner {
             "$Tags.HTTP_URL" url
             "$Tags.HTTP_METHOD" "GET"
             "$Tags.HTTP_STATUS" 307
+            // BUG "$Tags.HTTP_ROUTE" "/double-greet-redirect"
             defaultTags()
           }
         }
@@ -498,6 +508,7 @@ class SpringWebfluxTest extends AgentTestRunner {
             "$Tags.HTTP_URL" finalUrl
             "$Tags.HTTP_METHOD" "GET"
             "$Tags.HTTP_STATUS" 200
+            // BUG "$Tags.HTTP_ROUTE" "/double-greet"
             defaultTags()
           }
         }
@@ -548,6 +559,8 @@ class SpringWebfluxTest extends AgentTestRunner {
               "$Tags.HTTP_URL" url
               "$Tags.HTTP_METHOD" "GET"
               "$Tags.HTTP_STATUS" 200
+              // BUG
+              if (!testName.startsWith("functional")) { "$Tags.HTTP_ROUTE" "$urlPathWithVariables" }
               defaultTags()
             }
           }

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/boot24Test/groovy/SpringWebfluxTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/boot24Test/groovy/SpringWebfluxTest.groovy
@@ -62,6 +62,7 @@ class SpringWebfluxTest extends AgentTestRunner {
             "$Tags.HTTP_URL" url
             "$Tags.HTTP_METHOD" "GET"
             "$Tags.HTTP_STATUS" 200
+            "$Tags.HTTP_ROUTE" "$urlPathWithVariables"
             defaultTags()
           }
         }
@@ -135,6 +136,7 @@ class SpringWebfluxTest extends AgentTestRunner {
             "$Tags.HTTP_URL" url
             "$Tags.HTTP_METHOD" "GET"
             "$Tags.HTTP_STATUS" 200
+            "$Tags.HTTP_ROUTE" "$urlPathWithVariables"
             defaultTags()
           }
         }
@@ -283,6 +285,7 @@ class SpringWebfluxTest extends AgentTestRunner {
             "$Tags.HTTP_URL" url
             "$Tags.HTTP_METHOD" "GET"
             "$Tags.HTTP_STATUS" 404
+            "$Tags.HTTP_ROUTE" "/**"
             defaultTags()
           }
         }
@@ -333,6 +336,7 @@ class SpringWebfluxTest extends AgentTestRunner {
             "$Tags.HTTP_URL" url
             "$Tags.HTTP_METHOD" "POST"
             "$Tags.HTTP_STATUS" 202
+            "$Tags.HTTP_ROUTE" "/echo"
             defaultTags()
           }
         }
@@ -391,6 +395,7 @@ class SpringWebfluxTest extends AgentTestRunner {
             "$Tags.HTTP_URL" url
             "$Tags.HTTP_METHOD" "GET"
             "$Tags.HTTP_STATUS" 500
+            "$Tags.HTTP_ROUTE" "$urlPathWithVariables"
             defaultTags()
           }
         }
@@ -464,6 +469,7 @@ class SpringWebfluxTest extends AgentTestRunner {
             "$Tags.HTTP_URL" url
             "$Tags.HTTP_METHOD" "GET"
             "$Tags.HTTP_STATUS" 307
+            "$Tags.HTTP_ROUTE" "/double-greet-redirect"
             defaultTags()
           }
         }
@@ -498,6 +504,7 @@ class SpringWebfluxTest extends AgentTestRunner {
             "$Tags.HTTP_URL" finalUrl
             "$Tags.HTTP_METHOD" "GET"
             "$Tags.HTTP_STATUS" 200
+            "$Tags.HTTP_ROUTE" "/double-greet"
             defaultTags()
           }
         }
@@ -548,6 +555,7 @@ class SpringWebfluxTest extends AgentTestRunner {
               "$Tags.HTTP_URL" url
               "$Tags.HTTP_METHOD" "GET"
               "$Tags.HTTP_STATUS" 200
+              "$Tags.HTTP_ROUTE" String
               defaultTags()
             }
           }

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java8/datadog/trace/instrumentation/springwebflux/server/HandlerAdapterAdvice.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java8/datadog/trace/instrumentation/springwebflux/server/HandlerAdapterAdvice.java
@@ -1,8 +1,8 @@
 package datadog.trace.instrumentation.springwebflux.server;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.bootstrap.instrumentation.decorator.RouteHandlerDecorator.ROUTE_HANDLER_DECORATOR;
 import static datadog.trace.instrumentation.springwebflux.server.AdviceUtils.constructOperationName;
-import static datadog.trace.instrumentation.springwebflux.server.AdviceUtils.constructResourceName;
 import static datadog.trace.instrumentation.springwebflux.server.SpringWebfluxHttpServerDecorator.DECORATE;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
@@ -47,9 +47,8 @@ public class HandlerAdapterAdvice {
     final PathPattern bestPattern =
         exchange.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE);
     if (parentSpan != null && bestPattern != null) {
-      parentSpan.setResourceName(
-          constructResourceName(
-              exchange.getRequest().getMethodValue(), bestPattern.getPatternString()));
+      ROUTE_HANDLER_DECORATOR.withRoute(
+          parentSpan, exchange.getRequest().getMethodValue(), bestPattern.getPatternString());
     }
 
     return scope;

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/BeanFactoryInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/BeanFactoryInstrumentation.java
@@ -44,7 +44,6 @@ public class BeanFactoryInstrumentation extends Instrumenter.Tracing {
   public String[] helperClassNames() {
     return new String[] {
       packageName + ".SpringWebHttpServerDecorator",
-      packageName + ".SpringWebHttpServerDecorator$1",
       packageName + ".ServletRequestURIAdapter",
       packageName + ".HandlerMappingResourceNameFilter",
       packageName + ".HandlerMappingResourceNameFilter$BeanDefinition",

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/DispatcherServletInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/DispatcherServletInstrumentation.java
@@ -42,7 +42,6 @@ public final class DispatcherServletInstrumentation extends Instrumenter.Tracing
     return new String[] {
       packageName + ".SpringWebHttpServerDecorator",
       packageName + ".ServletRequestURIAdapter",
-      packageName + ".SpringWebHttpServerDecorator$1",
       packageName + ".HandlerMappingResourceNameFilter",
     };
   }

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/HandlerAdapterInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/HandlerAdapterInstrumentation.java
@@ -45,9 +45,7 @@ public final class HandlerAdapterInstrumentation extends Instrumenter.Tracing {
   @Override
   public String[] helperClassNames() {
     return new String[] {
-      packageName + ".SpringWebHttpServerDecorator",
-      packageName + ".ServletRequestURIAdapter",
-      packageName + ".SpringWebHttpServerDecorator$1"
+      packageName + ".SpringWebHttpServerDecorator", packageName + ".ServletRequestURIAdapter",
     };
   }
 

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/SpringWebHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/SpringWebHttpServerDecorator.java
@@ -1,9 +1,7 @@
 package datadog.trace.instrumentation.springweb;
 
-import datadog.trace.api.Function;
-import datadog.trace.api.Pair;
-import datadog.trace.api.cache.DDCache;
-import datadog.trace.api.cache.DDCaches;
+import static datadog.trace.bootstrap.instrumentation.decorator.RouteHandlerDecorator.ROUTE_HANDLER_DECORATOR;
+
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
@@ -23,16 +21,6 @@ public class SpringWebHttpServerDecorator
 
   public static final CharSequence SPRING_HANDLER = UTF8BytesString.create("spring.handler");
   public static final CharSequence RESPONSE_RENDER = UTF8BytesString.create("response.render");
-
-  private static final Function<Pair<String, Object>, CharSequence> RESOURCE_NAME_JOINER =
-      new Function<Pair<String, Object>, CharSequence>() {
-        @Override
-        public CharSequence apply(Pair<String, Object> input) {
-          return UTF8BytesString.create(input.getLeft() + " " + input.getRight());
-        }
-      };
-  private static final DDCache<Pair<String, Object>, CharSequence> RESOURCE_NAME_CACHE =
-      DDCaches.newFixedSizeCache(64);
 
   private final CharSequence component;
 
@@ -97,10 +85,7 @@ public class SpringWebHttpServerDecorator
           request.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE);
       if (method != null && bestMatchingPattern != null && !bestMatchingPattern.equals("/**")) {
         // universal matching is not helpful (and prevents 404 renaming in URLAsResourceNameRule).
-        final CharSequence resourceName =
-            RESOURCE_NAME_CACHE.computeIfAbsent(
-                Pair.of(method, bestMatchingPattern), RESOURCE_NAME_JOINER);
-        span.setResourceName(resourceName);
+        ROUTE_HANDLER_DECORATOR.withRoute(span, method, bestMatchingPattern.toString());
       }
     }
     return span;

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/WebApplicationContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/WebApplicationContextInstrumentation.java
@@ -43,7 +43,6 @@ public class WebApplicationContextInstrumentation extends Instrumenter.Tracing {
   public String[] helperClassNames() {
     return new String[] {
       packageName + ".SpringWebHttpServerDecorator",
-      packageName + ".SpringWebHttpServerDecorator$1",
       packageName + ".ServletRequestURIAdapter",
       packageName + ".HandlerMappingResourceNameFilter",
       packageName + ".HandlerMappingResourceNameFilter$BeanDefinition",

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/boot/SpringBootBasedTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/boot/SpringBootBasedTest.groovy
@@ -257,6 +257,7 @@ class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext>
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
         "$Tags.HTTP_STATUS" endpoint.status
+        if (endpoint != LOGIN && endpoint != NOT_FOUND) { "$Tags.HTTP_ROUTE" String }
         "servlet.path" endpoint.path
         if (endpoint.errored) {
           "error.msg" { it == null || it == EXCEPTION.body }

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/filter/ServletFilterTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/filter/ServletFilterTest.groovy
@@ -132,6 +132,7 @@ class ServletFilterTest extends HttpServerTest<ConfigurableApplicationContext> {
       tags {
         "$Tags.COMPONENT" SpringWebHttpServerDecorator.DECORATE.component()
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
+        "$Tags.HTTP_ROUTE" String
         if (endpoint == EXCEPTION) {
           errorTags(Exception, EXCEPTION.body)
         }
@@ -163,6 +164,7 @@ class ServletFilterTest extends HttpServerTest<ConfigurableApplicationContext> {
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
         "$Tags.HTTP_STATUS" endpoint.status
+        "$Tags.HTTP_ROUTE" String
         "servlet.path" endpoint.path
         if (endpoint.errored) {
           "error.msg" { it == null || it == EXCEPTION.body }

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
@@ -105,6 +105,12 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
     null
   }
 
+  boolean tagServerSpanWithRoute() {
+    false
+  }
+
+
+
   enum ServerEndpoint {
     SUCCESS("success", 200, "success"),
     REDIRECT("redirect", 302, "/redirected"),
@@ -626,6 +632,7 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
 
   // parent span must be cast otherwise it breaks debugging classloading (junit loads it early)
   void serverSpan(TraceAssert trace, BigInteger traceID = null, BigInteger parentID = null, String method = "GET", ServerEndpoint endpoint = SUCCESS) {
+    boolean tagServerSpanWithRoute = tagServerSpanWithRoute()
     trace.span {
       serviceName expectedServiceName()
       operationName expectedOperationName()
@@ -646,6 +653,9 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
         "$Tags.HTTP_STATUS" endpoint.status
+        if (tagServerSpanWithRoute) {
+          "$Tags.HTTP_ROUTE" String
+        }
         if (endpoint.query) {
           "$DDTags.HTTP_QUERY" endpoint.query
         }

--- a/dd-smoke-tests/springboot-openliberty/snapshots/datadog.smoketest.SpringBootOpenLibertySnapshotTest.exception404.snap
+++ b/dd-smoke-tests/springboot-openliberty/snapshots/datadog.smoketest.SpringBootOpenLibertySnapshotTest.exception404.snap
@@ -75,6 +75,7 @@
                "duration" 75162908
                "meta" {"env" "smoketest"
                        "version" "99"
+                       "http.route" "/error"
                        "thread.name" "Default Executor-thread-13"
                        "thread.id" "62"
                        "error.msg" "No converter for [class java.util.LinkedHashMap] with preset Content-Type 'text/html;charset=UTF-8'"

--- a/dd-smoke-tests/springboot-openliberty/snapshots/datadog.smoketest.SpringBootOpenLibertySnapshotTest.nested.snap
+++ b/dd-smoke-tests/springboot-openliberty/snapshots/datadog.smoketest.SpringBootOpenLibertySnapshotTest.nested.snap
@@ -20,6 +20,7 @@
            "http.status_code" "200"
            "span.kind" "server"
            "http.method" "GET"
+           "http.route" "/connect"
            "thread.id" "58"
            "servlet.path" "/connect"}
    "metrics" {"_dd.agent_psr" 1.0
@@ -88,6 +89,7 @@
                        "http.status_code" "200"
                        "span.kind" "server"
                        "http.method" "GET"
+                       "http.route" "/connect/{user}"
                        "thread.id" "47"
                        "servlet.path" "/connect/92"}
                "metrics" {"_dd.measured" 1

--- a/dd-smoke-tests/springboot-openliberty/snapshots/datadog.smoketest.SpringBootOpenLibertySnapshotTest.simple.snap
+++ b/dd-smoke-tests/springboot-openliberty/snapshots/datadog.smoketest.SpringBootOpenLibertySnapshotTest.simple.snap
@@ -20,6 +20,7 @@
            "http.status_code" "200"
            "span.kind" "server"
            "http.method" "GET"
+           "http.route" "/connect/{user}"
            "thread.id" "44"
            "servlet.path" "/connect/0"}
    "metrics" {"_dd.agent_psr" 1.0

--- a/dd-smoke-tests/src/main/groovy/datadog/smoketest/AbstractTestAgentSmokeTest.groovy
+++ b/dd-smoke-tests/src/main/groovy/datadog/smoketest/AbstractTestAgentSmokeTest.groovy
@@ -95,7 +95,6 @@ abstract class AbstractTestAgentSmokeTest extends ProcessManager {
     assert response.code() == 200
 
     func.call()
-
     Thread.sleep(1500)
 
     //resend the test agent results to query the snapshot comparison results that the test agent does

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -34,6 +34,7 @@ public final class ConfigDefaults {
   static final String DEFAULT_PRIORITY_SAMPLING_FORCE = null;
   static final boolean DEFAULT_TRACE_RESOLVER_ENABLED = true;
   static final boolean DEFAULT_HTTP_SERVER_TAG_QUERY_STRING = false;
+  static final boolean DEFAULT_HTTP_SERVER_ROUTE_BASED_NAMING = true;
   static final boolean DEFAULT_HTTP_CLIENT_TAG_QUERY_STRING = false;
   static final boolean DEFAULT_HTTP_CLIENT_SPLIT_BY_DOMAIN = false;
   static final boolean DEFAULT_DB_CLIENT_HOST_SPLIT_BY_INSTANCE = false;

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
@@ -20,6 +20,7 @@ public final class TraceInstrumentationConfig {
   public static final String TRACE_TESTS_ENABLED = "trace.tests.enabled";
 
   public static final String HTTP_SERVER_TAG_QUERY_STRING = "http.server.tag.query-string";
+  public static final String HTTP_SERVER_ROUTE_BASED_NAMING = "http.server.route-based-naming";
   public static final String HTTP_CLIENT_TAG_QUERY_STRING = "http.client.tag.query-string";
   public static final String HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN = "trace.http.client.split-by-domain";
   public static final String DB_CLIENT_HOST_SPLIT_BY_INSTANCE = "trace.db.client.split-by-instance";

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -12,6 +12,7 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_HTTP_CLIENT_ERROR_STATUSE
 import static datadog.trace.api.ConfigDefaults.DEFAULT_HTTP_CLIENT_SPLIT_BY_DOMAIN;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_HTTP_CLIENT_TAG_QUERY_STRING;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_HTTP_SERVER_ERROR_STATUSES;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_HTTP_SERVER_ROUTE_BASED_NAMING;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_HTTP_SERVER_TAG_QUERY_STRING;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_INTEGRATIONS_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_JMX_FETCH_ENABLED;
@@ -118,6 +119,7 @@ import static datadog.trace.api.config.TraceInstrumentationConfig.DB_CLIENT_HOST
 import static datadog.trace.api.config.TraceInstrumentationConfig.GRPC_IGNORED_OUTBOUND_METHODS;
 import static datadog.trace.api.config.TraceInstrumentationConfig.HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN;
 import static datadog.trace.api.config.TraceInstrumentationConfig.HTTP_CLIENT_TAG_QUERY_STRING;
+import static datadog.trace.api.config.TraceInstrumentationConfig.HTTP_SERVER_ROUTE_BASED_NAMING;
 import static datadog.trace.api.config.TraceInstrumentationConfig.HTTP_SERVER_TAG_QUERY_STRING;
 import static datadog.trace.api.config.TraceInstrumentationConfig.HYSTRIX_MEASURED_ENABLED;
 import static datadog.trace.api.config.TraceInstrumentationConfig.HYSTRIX_TAGS_ENABLED;
@@ -270,6 +272,7 @@ public class Config {
   private final BitSet httpServerErrorStatuses;
   private final BitSet httpClientErrorStatuses;
   private final boolean httpServerTagQueryString;
+  private final boolean httpServerRouteBasedNaming;
   private final boolean httpClientTagQueryString;
   private final boolean httpClientSplitByDomain;
   private final boolean dbClientSplitByInstance;
@@ -535,6 +538,10 @@ public class Config {
     httpServerTagQueryString =
         configProvider.getBoolean(
             HTTP_SERVER_TAG_QUERY_STRING, DEFAULT_HTTP_SERVER_TAG_QUERY_STRING);
+
+    httpServerRouteBasedNaming =
+        configProvider.getBoolean(
+            HTTP_SERVER_ROUTE_BASED_NAMING, DEFAULT_HTTP_SERVER_ROUTE_BASED_NAMING);
 
     httpClientTagQueryString =
         configProvider.getBoolean(
@@ -855,6 +862,10 @@ public class Config {
 
   public boolean isHttpServerTagQueryString() {
     return httpServerTagQueryString;
+  }
+
+  public boolean isHttpServerRouteBasedNaming() {
+    return httpServerRouteBasedNaming;
   }
 
   public boolean isHttpClientTagQueryString() {
@@ -1671,6 +1682,8 @@ public class Config {
         + httpClientErrorStatuses
         + ", httpServerTagQueryString="
         + httpServerTagQueryString
+        + ", httpServerRouteBasedNaming="
+        + httpServerRouteBasedNaming
         + ", httpClientTagQueryString="
         + httpClientTagQueryString
         + ", httpClientSplitByDomain="

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/Tags.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/Tags.java
@@ -10,6 +10,7 @@ public class Tags {
   public static final String SPAN_KIND_TEST = "test";
 
   public static final String HTTP_URL = "http.url";
+  public static final String HTTP_ROUTE = "http.route";
   public static final String HTTP_STATUS = "http.status_code";
   public static final String HTTP_METHOD = "http.method";
   public static final String PEER_HOST_IPV4 = "peer.ipv4";


### PR DESCRIPTION
- [x] Finatra
- [x] Jax RS 1 - Doesn't use central decorator component, inlines the code
- [x] Jax RS 2 - Doesn't use central decorator component, inlines the code
- [x] Play 2.3
- [x] Play 2.4
- [x] Play 2.6
- [x] Ratpack 1.5
- [x] Sparkjava 2.3
- [x] Webflux
- [x] Webmvc

Servers that don't do routes that probably should:

- [ ] Akka-http
- [ ] Dropwizard
- [ ] Grizzly
- [ ] Vertx