### PR TITLE
Added smoke test functionality to run a test agent in the background

### DIFF
--- a/dd-smoke-tests/dd-smoke-tests.gradle
+++ b/dd-smoke-tests/dd-smoke-tests.gradle
@@ -5,6 +5,7 @@ description = 'dd-smoke-tests'
 dependencies {
   compile deps.spock
   compile project(':dd-java-agent:testing')
+  compile 'org.testcontainers:testcontainers:1.15.2'
 }
 
 def smokeTestLimit = gradle.sharedServices.registerIfAbsent("smokeTestLimit", BuildService) {

--- a/dd-smoke-tests/springboot-openliberty/snapshots/datadog.smoketest.SpringBootOpenLibertySnapshotTest.nested.snap
+++ b/dd-smoke-tests/springboot-openliberty/snapshots/datadog.smoketest.SpringBootOpenLibertySnapshotTest.nested.snap
@@ -1,0 +1,113 @@
+[[{"name" "servlet.request"
+   "service" "smoke-test-java-app"
+   "resource" "GET /connect"
+   "type" "web"
+   "error" 0
+   "span_id" 0
+   "trace_id" 0
+   "parent_id" nil
+   "start" 1617385000067147336
+   "duration" 127240507
+   "meta" {"env" "smoketest"
+           "language" "jvm"
+           "runtime-id" "e73fdb27-bae3-4852-bb31-ddb0a182aec6"
+           "version" "99"
+           "peer.port" "55726"
+           "http.url" "http://localhost:55617/connect"
+           "component" "java-web-servlet"
+           "thread.name" "Default Executor-thread-7"
+           "peer.ipv4" "127.0.0.1"
+           "http.status_code" "200"
+           "span.kind" "server"
+           "http.method" "GET"
+           "thread.id" "54"
+           "servlet.path" "/connect"}
+   "metrics" {"_dd.agent_psr" 1.0
+              "_dd.measured" 1
+              "_sampling_priority_v1" 1
+              "_dd.top_level" 1}}
+      {"name" "spring.handler"
+       "service" "smoke-test-java-app"
+       "resource" "DemoController.connect"
+       "type" "web"
+       "error" 0
+       "span_id" 1
+       "trace_id" 0
+       "parent_id" 0
+       "start" 1617385000069610393
+       "duration" 123989308
+       "meta" {"env" "smoketest"
+               "language" "jvm"
+               "version" "99"
+               "thread.name" "Default Executor-thread-7"
+               "thread.id" "54"
+               "component" "spring-web-controller"
+               "span.kind" "server"}
+       "metrics" {"_dd.measured" 1}}
+          {"name" "http.request"
+           "service" "smoke-test-java-app"
+           "resource" "GET /connect/?"
+           "type" "http"
+           "error" 0
+           "span_id" 2
+           "trace_id" 0
+           "parent_id" 1
+           "start" 1617385000162337477
+           "duration" 23747395
+           "meta" {"env" "smoketest"
+                   "version" "99"
+                   "peer.port" "55617"
+                   "http.url" "http://localhost:55617/connect/38"
+                   "component" "http-url-connection"
+                   "thread.name" "Default Executor-thread-7"
+                   "http.status_code" "200"
+                   "span.kind" "client"
+                   "http.method" "GET"
+                   "peer.hostname" "localhost"
+                   "thread.id" "54"}
+           "metrics" {}}
+              {"name" "servlet.request"
+               "service" "smoke-test-java-app"
+               "resource" "GET /connect/{user}"
+               "type" "web"
+               "error" 0
+               "span_id" 3
+               "trace_id" 0
+               "parent_id" 2
+               "start" 1617385000178045065
+               "duration" 6245483
+               "meta" {"env" "smoketest"
+                       "language" "jvm"
+                       "runtime-id" "e73fdb27-bae3-4852-bb31-ddb0a182aec6"
+                       "version" "99"
+                       "peer.port" "55727"
+                       "http.url" "http://localhost:55617/connect/38"
+                       "component" "java-web-servlet"
+                       "thread.name" "Default Executor-thread-11"
+                       "peer.ipv4" "127.0.0.1"
+                       "http.status_code" "200"
+                       "span.kind" "server"
+                       "http.method" "GET"
+                       "thread.id" "61"
+                       "servlet.path" "/connect/38"}
+               "metrics" {"_dd.measured" 1
+                          "_sampling_priority_v1" 1
+                          "_dd.top_level" 1}}
+                  {"name" "spring.handler"
+                   "service" "smoke-test-java-app"
+                   "resource" "DemoController.connectFinal"
+                   "type" "web"
+                   "error" 0
+                   "span_id" 4
+                   "trace_id" 0
+                   "parent_id" 3
+                   "start" 1617385000180780194
+                   "duration" 2988885
+                   "meta" {"env" "smoketest"
+                           "language" "jvm"
+                           "version" "99"
+                           "thread.name" "Default Executor-thread-11"
+                           "thread.id" "61"
+                           "component" "spring-web-controller"
+                           "span.kind" "server"}
+                   "metrics" {"_dd.measured" 1}}]]

--- a/dd-smoke-tests/springboot-openliberty/snapshots/datadog.smoketest.SpringBootOpenLibertySnapshotTest.simple.snap
+++ b/dd-smoke-tests/springboot-openliberty/snapshots/datadog.smoketest.SpringBootOpenLibertySnapshotTest.simple.snap
@@ -1,0 +1,46 @@
+[[{"name" "servlet.request"
+   "service" "smoke-test-java-app"
+   "resource" "GET /connect/{user}"
+   "type" "web"
+   "error" 0
+   "span_id" 0
+   "trace_id" 0
+   "parent_id" nil
+   "start" 1617384998837488823
+   "duration" 141690778
+   "meta" {"env" "smoketest"
+           "language" "jvm"
+           "runtime-id" "e73fdb27-bae3-4852-bb31-ddb0a182aec6"
+           "version" "99"
+           "peer.port" "55723"
+           "http.url" "http://localhost:55617/connect/0"
+           "component" "java-web-servlet"
+           "thread.name" "Default Executor-thread-4"
+           "peer.ipv4" "127.0.0.1"
+           "http.status_code" "200"
+           "span.kind" "server"
+           "http.method" "GET"
+           "thread.id" "48"
+           "servlet.path" "/connect/0"}
+   "metrics" {"_dd.agent_psr" 1.0
+              "_dd.measured" 1
+              "_sampling_priority_v1" 1
+              "_dd.top_level" 1}}
+      {"name" "spring.handler"
+       "service" "smoke-test-java-app"
+       "resource" "DemoController.connectFinal"
+       "type" "web"
+       "error" 0
+       "span_id" 1
+       "trace_id" 0
+       "parent_id" 0
+       "start" 1617384998898788931
+       "duration" 74330915
+       "meta" {"env" "smoketest"
+               "language" "jvm"
+               "version" "99"
+               "thread.name" "Default Executor-thread-4"
+               "thread.id" "48"
+               "component" "spring-web-controller"
+               "span.kind" "server"}
+       "metrics" {"_dd.measured" 1}}]]

--- a/dd-smoke-tests/springboot-openliberty/src/test/groovy/datadog/smoketest/SpringBootOpenLibertySmokeTest.groovy
+++ b/dd-smoke-tests/springboot-openliberty/src/test/groovy/datadog/smoketest/SpringBootOpenLibertySmokeTest.groovy
@@ -1,7 +1,11 @@
 package datadog.smoketest
 
 import datadog.trace.agent.test.utils.ThreadUtils
+import okhttp3.FormBody
+import okhttp3.MediaType
 import okhttp3.Request
+import okhttp3.RequestBody
+import okio.BufferedSink
 import spock.lang.Requires
 import spock.lang.Shared
 
@@ -49,7 +53,7 @@ class SpringBootOpenLibertySmokeTest extends AbstractServerSmokeTest {
 
   def "Test concurrent requests to Spring Boot running Open Liberty"() {
     setup:
-    String url = "http://localhost:${httpPort}/connect"
+    def url = "http://localhost:${httpPort}/connect"
     def request = new Request.Builder().url(url).get().build()
 
     expect:
@@ -62,5 +66,25 @@ class SpringBootOpenLibertySmokeTest extends AbstractServerSmokeTest {
     })
 
     waitForTraceCount(2 * totalInvocations) == 2 * totalInvocations
+  }
+
+  def "Test concurrent high load requests to Spring Boot running Open Liberty"() {
+    def url = "http://localhost:${httpPort}/connect/0"
+    def formBody = new FormBody.Builder()
+    def value = new StringBuilder()
+    for (int i = 0; i < 10000; i++) value.append("@@@@@@@@@@")
+    for (int i = 0; i < 100; i++) formBody.add("test" + i, value.toString())
+    def request = new Request.Builder().url(url).post(formBody.build()).build()
+
+    expect:
+    ThreadUtils.runConcurrently(10, totalInvocations, {
+      def response = client.newCall(request).execute()
+
+      assert response.body().string() != null
+      assert response.body().contentType().toString().contains("text/plain")
+      assert response.code() == 200
+    })
+
+    waitForTraceCount(totalInvocations) ==  totalInvocations
   }
 }

--- a/dd-smoke-tests/springboot-openliberty/src/test/groovy/datadog/smoketest/SpringBootOpenLibertySmokeTest.groovy
+++ b/dd-smoke-tests/springboot-openliberty/src/test/groovy/datadog/smoketest/SpringBootOpenLibertySmokeTest.groovy
@@ -2,10 +2,7 @@ package datadog.smoketest
 
 import datadog.trace.agent.test.utils.ThreadUtils
 import okhttp3.FormBody
-import okhttp3.MediaType
 import okhttp3.Request
-import okhttp3.RequestBody
-import okio.BufferedSink
 import spock.lang.Requires
 import spock.lang.Shared
 
@@ -72,8 +69,12 @@ class SpringBootOpenLibertySmokeTest extends AbstractServerSmokeTest {
     def url = "http://localhost:${httpPort}/connect/0"
     def formBody = new FormBody.Builder()
     def value = new StringBuilder()
-    for (int i = 0; i < 10000; i++) value.append("@@@@@@@@@@")
-    for (int i = 0; i < 100; i++) formBody.add("test" + i, value.toString())
+    for (int i = 0; i < 10000; i++) {
+      value.append("@@@@@@@@@@")
+    }
+    for (int i = 0; i < 100; i++) {
+      formBody.add("test" + i, value.toString())
+    }
     def request = new Request.Builder().url(url).post(formBody.build()).build()
 
     expect:

--- a/dd-smoke-tests/springboot-openliberty/src/test/groovy/datadog/smoketest/SpringBootOpenLibertySnapshotTest.groovy
+++ b/dd-smoke-tests/springboot-openliberty/src/test/groovy/datadog/smoketest/SpringBootOpenLibertySnapshotTest.groovy
@@ -28,7 +28,7 @@ class SpringBootOpenLibertySnapshotTest extends AbstractTestAgentSmokeTest {
     return processBuilder
   }
 
-  def "Test Simple Request"() {
+  def "Test trace snapshot of sending single request to Openliberty server"() {
     setup:
     Response response
     snapshot("datadog.smoketest.SpringBootOpenLibertySnapshotTest.simple", {
@@ -42,7 +42,7 @@ class SpringBootOpenLibertySnapshotTest extends AbstractTestAgentSmokeTest {
     response.code() == 200
   }
 
-  def "Test nested Request"() {
+  def "Test trace snapshot of sending nested request to Openliberty server"() {
     setup:
     Response response
     String[] ignoredKeys =  ['meta.http.url', 'meta.thread.name', 'meta.peer.port', 'meta.thread.id', "meta.servlet.path"]

--- a/dd-smoke-tests/springboot-openliberty/src/test/groovy/datadog/smoketest/SpringBootOpenLibertySnapshotTest.groovy
+++ b/dd-smoke-tests/springboot-openliberty/src/test/groovy/datadog/smoketest/SpringBootOpenLibertySnapshotTest.groovy
@@ -1,0 +1,59 @@
+package datadog.smoketest
+
+import okhttp3.Request
+import okhttp3.Response
+import spock.lang.Requires
+import spock.lang.Shared
+
+@Requires({ !System.getProperty("").contains("IBM J9 VM") && System.getenv("CI") != "true" })
+class SpringBootOpenLibertySnapshotTest extends AbstractTestAgentSmokeTest {
+
+  @Shared
+  String openLibertyShadowJar = System.getProperty("datadog.smoketest.openliberty.jar.path")
+
+  @Override
+  ProcessBuilder createProcessBuilder() {
+    List<String> command = new ArrayList<>()
+    command.add(javaPath())
+    command.addAll(defaultJavaProperties)
+    command.addAll((String[]) [
+      "-Ddd.jmxfetch.enabled=false",
+      "-jar",
+      openLibertyShadowJar,
+      "--server.port=${httpPort}"
+    ])
+
+    ProcessBuilder processBuilder = new ProcessBuilder(command)
+    processBuilder.directory(new File(buildDirectory))
+    return processBuilder
+  }
+
+  def "Test Simple Request"() {
+    setup:
+    Response response
+    snapshot("datadog.smoketest.SpringBootOpenLibertySnapshotTest.simple", {
+      def url = "http://localhost:${httpPort}/connect/0"
+      def request = new Request.Builder().url(url).get().build()
+      response = client.newCall(request).execute()
+    })
+
+    expect:
+    response != null
+    response.code() == 200
+  }
+
+  def "Test nested Request"() {
+    setup:
+    Response response
+    String[] ignoredKeys =  ['meta.http.url', 'meta.thread.name', 'meta.peer.port', 'meta.thread.id', "meta.servlet.path"]
+    snapshot("datadog.smoketest.SpringBootOpenLibertySnapshotTest.nested", ignoredKeys, {
+      def url = "http://localhost:${httpPort}/connect"
+      def request = new Request.Builder().url(url).get().build()
+      response = client.newCall(request).execute()
+    })
+
+    expect:
+    response != null
+    response.code() == 200
+  }
+}

--- a/dd-smoke-tests/springboot-openliberty/src/test/groovy/datadog/smoketest/SpringBootOpenLibertySnapshotTest.groovy
+++ b/dd-smoke-tests/springboot-openliberty/src/test/groovy/datadog/smoketest/SpringBootOpenLibertySnapshotTest.groovy
@@ -5,7 +5,9 @@ import okhttp3.Response
 import spock.lang.Requires
 import spock.lang.Shared
 
-@Requires({ !System.getProperty("java.vm.name").contains("IBM J9 VM") && System.getenv("CI") != "true" })
+@Requires({
+  !System.getProperty("java.vm.name").contains("IBM J9 VM") && System.getenv("CI") != "true"
+})
 class SpringBootOpenLibertySnapshotTest extends AbstractTestAgentSmokeTest {
 
   @Shared

--- a/dd-smoke-tests/springboot-openliberty/src/test/groovy/datadog/smoketest/SpringBootOpenLibertySnapshotTest.groovy
+++ b/dd-smoke-tests/springboot-openliberty/src/test/groovy/datadog/smoketest/SpringBootOpenLibertySnapshotTest.groovy
@@ -5,7 +5,7 @@ import okhttp3.Response
 import spock.lang.Requires
 import spock.lang.Shared
 
-@Requires({ !System.getProperty("").contains("IBM J9 VM") && System.getenv("CI") != "true" })
+@Requires({ !System.getProperty("java.vm.name").contains("IBM J9 VM") && System.getenv("CI") != "true" })
 class SpringBootOpenLibertySnapshotTest extends AbstractTestAgentSmokeTest {
 
   @Shared

--- a/dd-smoke-tests/src/main/groovy/datadog/smoketest/AbstractSmokeTest.groovy
+++ b/dd-smoke-tests/src/main/groovy/datadog/smoketest/AbstractSmokeTest.groovy
@@ -18,44 +18,12 @@ import static datadog.trace.agent.test.server.http.TestHttpServer.httpServer
 import static datadog.trace.test.util.ForkedTestUtils.getMaxMemoryArgumentForFork
 import static datadog.trace.test.util.ForkedTestUtils.getMinMemoryArgumentForFork
 
-abstract class AbstractSmokeTest extends Specification {
-
-  public static final PROFILING_START_DELAY_SECONDS = 1
-  public static final int PROFILING_RECORDING_UPLOAD_PERIOD_SECONDS = 5
-  public static final String SERVICE_NAME = "smoke-test-java-app"
-  public static final String ENV = "smoketest"
-  public static final String VERSION = "99"
-
-  @Shared
-  protected String workingDirectory = System.getProperty("user.dir")
-  @Shared
-  protected String buildDirectory = System.getProperty("datadog.smoketest.builddir")
-  @Shared
-  protected String shadowJarPath = System.getProperty("datadog.smoketest.agent.shadowJar.path")
-  @Shared
-  protected static int profilingPort = -1
-
-  @Shared
-  protected String[] defaultJavaProperties
-
-  @Shared
-  protected Process testedProcess
-
+abstract class AbstractSmokeTest extends ProcessManager {
   @Shared
   protected BlockingQueue<TestHttpServer.HandlerApi.RequestApi> traceRequests = new LinkedBlockingQueue<>()
 
   @Shared
   protected AtomicInteger traceCount = new AtomicInteger()
-
-  /**
-   * Will be initialized after calling {@linkplain AbstractSmokeTest#checkLog} and hold {@literal true}
-   * if there are any ERROR or WARN lines in the test application log.
-   */
-  @Shared
-  def logHasErrors
-
-  @Shared
-  def logFilePath = "${buildDirectory}/reports/testProcess.${this.getClass().getName()}.log"
 
   @Shared
   @AutoCleanup
@@ -72,97 +40,35 @@ abstract class AbstractSmokeTest extends Specification {
     }
   }
 
-  def setup() {
-    // TODO: once java7 support is dropped use testedProcess.isAlive() instead
-    try {
-      testedProcess.exitValue()
-      assert false: "Process not alive before test"
-    } catch (IllegalThreadStateException ignored) {
-      // expected
-    }
+  @Shared
+  protected String[] defaultJavaProperties = [
+    "${getMaxMemoryArgumentForFork()}",
+    "${getMinMemoryArgumentForFork()}",
+    "-javaagent:${shadowJarPath}",
+    "-XX:ErrorFile=/tmp/hs_err_pid%p.log",
+    "-Ddd.trace.agent.port=${server.address.port}",
+    "-Ddd.service.name=${SERVICE_NAME}",
+    "-Ddd.env=${ENV}",
+    "-Ddd.version=${VERSION}",
+    "-Ddd.profiling.enabled=true",
+    "-Ddd.profiling.start-delay=${PROFILING_START_DELAY_SECONDS}",
+    "-Ddd.profiling.upload.period=${PROFILING_RECORDING_UPLOAD_PERIOD_SECONDS}",
+    "-Ddd.profiling.url=${getProfilingUrl()}",
+    "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=debug",
+    "-Dorg.slf4j.simpleLogger.defaultLogLevel=debug"
+  ]
 
+  def setup() {
     traceRequests.clear()
     traceCount.set(0)
   }
 
   def setupSpec() {
-    if (buildDirectory == null || shadowJarPath == null) {
-      throw new AssertionError("Expected system properties not found. Smoke tests have to be run from Gradle. Please make sure that is the case.")
-    }
-    assert Files.isDirectory(Paths.get(buildDirectory))
-    assert Files.isRegularFile(Paths.get(shadowJarPath))
-
     startServer()
-    System.out.println("Mock agent started at " + server.address)
-
-    defaultJavaProperties = [
-      "${getMaxMemoryArgumentForFork()}",
-      "${getMinMemoryArgumentForFork()}",
-      "-javaagent:${shadowJarPath}",
-      "-XX:ErrorFile=/tmp/hs_err_pid%p.log",
-      "-Ddd.trace.agent.port=${server.address.port}",
-      "-Ddd.service.name=${SERVICE_NAME}",
-      "-Ddd.env=${ENV}",
-      "-Ddd.version=${VERSION}",
-      "-Ddd.profiling.enabled=true",
-      "-Ddd.profiling.start-delay=${PROFILING_START_DELAY_SECONDS}",
-      "-Ddd.profiling.upload.period=${PROFILING_RECORDING_UPLOAD_PERIOD_SECONDS}",
-      "-Ddd.profiling.url=${getProfilingUrl()}",
-      "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=debug",
-      "-Dorg.slf4j.simpleLogger.defaultLogLevel=debug"
-    ]
-
-    ProcessBuilder processBuilder = createProcessBuilder()
-
-    processBuilder.environment().put("JAVA_HOME", System.getProperty("java.home"))
-    processBuilder.environment().put("DD_API_KEY", apiKey())
-
-    processBuilder.redirectErrorStream(true)
-    processBuilder.redirectOutput(ProcessBuilder.Redirect.to(new File(logFilePath)))
-
-    testedProcess = processBuilder.start()
-  }
-
-  String javaPath() {
-    final String separator = System.getProperty("file.separator")
-    return System.getProperty("java.home") + separator + "bin" + separator + "java"
   }
 
   def cleanupSpec() {
-    int maxAttempts = 10
-    Integer exitValue
-    for (int attempt = 1; attempt <= maxAttempts != null; attempt++) {
-      try {
-        exitValue = testedProcess?.exitValue()
-        break
-      }
-      catch (Throwable e) {
-        if (attempt == 1) {
-          System.out.println("Destroying instrumented process")
-          testedProcess.destroy()
-        }
-        if (attempt == maxAttempts - 1) {
-          System.out.println("Destroying instrumented process (forced)")
-          testedProcess.destroyForcibly()
-        }
-        sleep 1_000
-      }
-    }
-
     stopServer()
-
-    if (exitValue != null) {
-      System.out.println("Instrumented process exited with " + exitValue)
-    } else if (testedProcess != null) {
-      throw new TimeoutException("Instrumented process failed to exit")
-    }
-  }
-
-  def getProfilingUrl() {
-    if (profilingPort == -1) {
-      profilingPort = PortUtils.randomOpenPort()
-    }
-    return "http://localhost:${profilingPort}/"
   }
 
   def startServer() {
@@ -171,33 +77,6 @@ abstract class AbstractSmokeTest extends Specification {
 
   def stopServer() {
     // do nothing; 'server' is autocleanup
-  }
-
-  /**
-   * Check the test application log and set {@linkplain AbstractSmokeTest#logHasErrors} variable
-   * @param checker custom closure to run on each log line
-   */
-  def checkLog(Closure checker) {
-    new File(logFilePath).eachLine {
-      if (it.contains("ERROR") || it.contains("ASSERTION FAILED")) {
-        println it
-        logHasErrors = true
-      }
-      checker(it)
-    }
-    if (logHasErrors) {
-      println "Test application log is containing errors. See full run logs in ${logFilePath}"
-    }
-  }
-
-  def checkLog() {
-    checkLog {}
-  }
-
-  abstract ProcessBuilder createProcessBuilder()
-
-  String apiKey() {
-    return "01234567890abcdef123456789ABCDEF"
   }
 
   int waitForTraceCount(int count) {

--- a/dd-smoke-tests/src/main/groovy/datadog/smoketest/AbstractSmokeTest.groovy
+++ b/dd-smoke-tests/src/main/groovy/datadog/smoketest/AbstractSmokeTest.groovy
@@ -1,13 +1,8 @@
 package datadog.smoketest
 
 import datadog.trace.agent.test.server.http.TestHttpServer
-import datadog.trace.agent.test.utils.PortUtils
 import spock.lang.AutoCleanup
 import spock.lang.Shared
-import spock.lang.Specification
-
-import java.nio.file.Files
-import java.nio.file.Paths
 import java.util.concurrent.BlockingQueue
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit

--- a/dd-smoke-tests/src/main/groovy/datadog/smoketest/AbstractTestAgentSmokeTest.groovy
+++ b/dd-smoke-tests/src/main/groovy/datadog/smoketest/AbstractTestAgentSmokeTest.groovy
@@ -1,0 +1,119 @@
+package datadog.smoketest
+
+import datadog.trace.agent.test.utils.OkHttpUtils
+import datadog.trace.agent.test.utils.PortUtils
+import okhttp3.HttpUrl
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import org.testcontainers.containers.FixedHostPortGenericContainer
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.wait.strategy.Wait
+import spock.lang.Shared
+import java.util.concurrent.TimeUnit
+import static datadog.trace.test.util.ForkedTestUtils.getMaxMemoryArgumentForFork
+import static datadog.trace.test.util.ForkedTestUtils.getMinMemoryArgumentForFork
+
+abstract class AbstractTestAgentSmokeTest extends ProcessManager {
+
+  @Shared
+  protected String snapshotDirectory
+
+  @Shared
+  protected GenericContainer testAgent
+
+  @Shared
+  protected int testAgentMappedPort = PortUtils.randomOpenPort()
+
+  @Shared
+  protected int testAgentPort = 8126
+
+  @Shared
+  int httpPort = PortUtils.randomOpenPort()
+
+  @Shared
+  String[] defaultJavaProperties = [
+    "${getMaxMemoryArgumentForFork()}",
+    "${getMinMemoryArgumentForFork()}",
+    "-javaagent:${shadowJarPath}",
+    "-XX:ErrorFile=/tmp/hs_err_pid%p.log",
+    "-Ddd.trace.agent.port=${testAgentMappedPort}",
+    "-Ddd.service.name=${SERVICE_NAME}",
+    "-Ddd.env=${ENV}",
+    "-Ddd.version=${VERSION}",
+    "-Ddd.profiling.enabled=false",
+    "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=debug",
+    "-Dorg.slf4j.simpleLogger.defaultLogLevel=debug"
+  ]
+
+  protected OkHttpClient client = OkHttpUtils.client()
+
+  def setupSpec() {
+    //In CI, there a container will be standup so no need to use test containers
+    PortUtils.waitForPortToOpen(httpPort, 240, TimeUnit.SECONDS, testedProcess)
+    snapshotDirectory = "${workingDirectory}/snapshots"
+
+    assert new File(snapshotDirectory).exists() : "snapshot directory doesn't exist"
+
+    if ("true" != System.getenv("CI")) {
+      testAgent = new FixedHostPortGenericContainer("kyleverhoog/dd-trace-test-agent:latest")
+        .withFixedExposedPort(testAgentMappedPort, testAgentPort)
+        .withEnv("SNAPSHOT_DIR", "/snaps")
+        .withFileSystemBind(snapshotDirectory, "/snaps")
+        .waitingFor(
+        Wait.forLogMessage(".*Started server on port.*\\n", 1)
+        )
+      testAgent.start()
+      testAgentMappedPort = testAgent.getMappedPort(testAgentPort)
+    }
+  }
+
+  /**
+   * Assert trace structure by sending traces synchronously to the test agent
+   * @param testTokenID the key of the test agent. For the test to work, a .snap file of the same name should exist in the /snapshots directory of the project folder
+   * @param ignoredKeys list of keys in a trace snapshot that the test agent should ignore
+   * @param func the command whose generated trace should be asserted by the testAgent
+   */
+  def snapshot(String testTokenID, String[] ignoredKeys = ['meta.http.url', 'meta.thread.name', 'meta.peer.port', 'meta.thread.id'], Closure func) {
+    println "The user dir is " + snapshotDirectory
+    //let test agent know the test is started
+    def url = "http://localhost:${testAgentMappedPort}/test/start"
+    def urlBuilder = HttpUrl.parse(url).newBuilder().addQueryParameter("token", testTokenID)
+
+    def request = new Request.Builder().url(urlBuilder.build()).get().build()
+    Response response = client.newCall(request).execute()
+
+    assert response != null
+    assert response.code() == 200
+
+    func.call()
+
+    Thread.sleep(1000)
+    if (testAgent != null) printLogToFile(testTokenID)
+
+    //resend the test agent results to query the snapshot comparison results that the test agent does
+    url = "http://localhost:${testAgentMappedPort}/test/snapshot"
+    urlBuilder = HttpUrl.parse(url).newBuilder()
+      .addEncodedQueryParameter("ignores", String.join(",", ignoredKeys) )
+      .addQueryParameter("token", testTokenID)
+
+    request = new Request.Builder().url(urlBuilder.build()).get().build()
+    response = client.newCall(request).execute()
+
+    assert response != null
+    println response.body().string()
+    assert response.code() == 200
+  }
+
+  def printLogToFile(String fileName) {
+    File logFile = new File("${buildDirectory}/reports/${fileName}.log")
+    if (!logFile.exists()) logFile.createNewFile()
+    logFile.write(testAgent.getLogs())
+  }
+
+  def cleanupSpec() {
+    if (testAgent != null) {
+      testAgent.stop()
+    }
+  }
+}

--- a/dd-smoke-tests/src/main/groovy/datadog/smoketest/AbstractTestAgentSmokeTest.groovy
+++ b/dd-smoke-tests/src/main/groovy/datadog/smoketest/AbstractTestAgentSmokeTest.groovy
@@ -89,7 +89,9 @@ abstract class AbstractTestAgentSmokeTest extends ProcessManager {
     func.call()
 
     Thread.sleep(1000)
-    if (testAgent != null) printLogToFile(testTokenID)
+    if (testAgent != null) {
+      printLogToFile(testTokenID)
+    }
 
     //resend the test agent results to query the snapshot comparison results that the test agent does
     url = "http://localhost:${testAgentMappedPort}/test/snapshot"
@@ -107,7 +109,9 @@ abstract class AbstractTestAgentSmokeTest extends ProcessManager {
 
   def printLogToFile(String fileName) {
     File logFile = new File("${buildDirectory}/reports/${fileName}.log")
-    if (!logFile.exists()) logFile.createNewFile()
+    if (!logFile.exists()) {
+      logFile.createNewFile()
+    }
     logFile.write(testAgent.getLogs())
   }
 

--- a/dd-smoke-tests/src/main/groovy/datadog/smoketest/ProcessManager.groovy
+++ b/dd-smoke-tests/src/main/groovy/datadog/smoketest/ProcessManager.groovy
@@ -1,0 +1,137 @@
+package datadog.smoketest
+
+import datadog.trace.agent.test.utils.PortUtils
+import spock.lang.Shared
+import spock.lang.Specification
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.util.concurrent.TimeoutException
+
+abstract class ProcessManager extends Specification {
+
+  public static final PROFILING_START_DELAY_SECONDS = 1
+  public static final int PROFILING_RECORDING_UPLOAD_PERIOD_SECONDS = 5
+  public static final String SERVICE_NAME = "smoke-test-java-app"
+  public static final String ENV = "smoketest"
+  public static final String VERSION = "99"
+
+  @Shared
+  protected String workingDirectory = System.getProperty("user.dir")
+  @Shared
+  protected String buildDirectory = System.getProperty("datadog.smoketest.builddir")
+  @Shared
+  protected String shadowJarPath = System.getProperty("datadog.smoketest.agent.shadowJar.path")
+  @Shared
+  protected static int profilingPort = -1
+
+  @Shared
+  protected String[] defaultJavaProperties
+
+  @Shared
+  protected Process testedProcess
+
+  /**
+   * Will be initialized after calling {@linkplain AbstractSmokeTest#checkLog} and hold {@literal true}
+   * if there are any ERROR or WARN lines in the test application log.
+   */
+  @Shared
+  def logHasErrors
+
+  @Shared
+  def logFilePath = "${buildDirectory}/reports/testProcess.${this.getClass().getName()}.log"
+
+  def setup() {
+    // TODO: once java7 support is dropped use testedProcess.isAlive() instead
+    try {
+      testedProcess.exitValue()
+      assert false: "Process not alive before test"
+    } catch (IllegalThreadStateException ignored) {
+      // expected
+    }
+  }
+
+  def setupSpec() {
+    if (buildDirectory == null || shadowJarPath == null) {
+      throw new AssertionError("Expected system properties not found. Smoke tests have to be run from Gradle. Please make sure that is the case.")
+    }
+    assert Files.isDirectory(Paths.get(buildDirectory))
+    assert Files.isRegularFile(Paths.get(shadowJarPath))
+
+    ProcessBuilder processBuilder = createProcessBuilder()
+
+    processBuilder.environment().put("JAVA_HOME", System.getProperty("java.home"))
+    processBuilder.environment().put("DD_API_KEY", apiKey())
+
+    processBuilder.redirectErrorStream(true)
+    processBuilder.redirectOutput(ProcessBuilder.Redirect.to(new File(logFilePath)))
+
+    testedProcess = processBuilder.start()
+  }
+
+  String javaPath() {
+    final String separator = System.getProperty("file.separator")
+    return System.getProperty("java.home") + separator + "bin" + separator + "java"
+  }
+
+  def cleanupSpec() {
+    int maxAttempts = 10
+    Integer exitValue
+    for (int attempt = 1; attempt <= maxAttempts != null; attempt++) {
+      try {
+        exitValue = testedProcess?.exitValue()
+        break
+      }
+      catch (Throwable e) {
+        if (attempt == 1) {
+          System.out.println("Destroying instrumented process")
+          testedProcess.destroy()
+        }
+        if (attempt == maxAttempts - 1) {
+          System.out.println("Destroying instrumented process (forced)")
+          testedProcess.destroyForcibly()
+        }
+        sleep 1_000
+      }
+    }
+
+    if (exitValue != null) {
+      System.out.println("Instrumented process exited with " + exitValue)
+    } else if (testedProcess != null) {
+      throw new TimeoutException("Instrumented process failed to exit")
+    }
+  }
+
+  def getProfilingUrl() {
+    if (profilingPort == -1) {
+      profilingPort = PortUtils.randomOpenPort()
+    }
+    return "http://localhost:${profilingPort}/"
+  }
+
+  /**
+   * Check the test application log and set {@linkplain AbstractSmokeTest#logHasErrors} variable
+   * @param checker custom closure to run on each log line
+   */
+  def checkLog(Closure checker) {
+    new File(logFilePath).eachLine {
+      if (it.contains("ERROR") || it.contains("ASSERTION FAILED")) {
+        println it
+        logHasErrors = true
+      }
+      checker(it)
+    }
+    if (logHasErrors) {
+      println "Test application log is containing errors. See full run logs in ${logFilePath}"
+    }
+  }
+
+  def checkLog() {
+    checkLog {}
+  }
+
+  abstract ProcessBuilder createProcessBuilder()
+
+  String apiKey() {
+    return "01234567890abcdef123456789ABCDEF"
+  }
+}


### PR DESCRIPTION
Added an extra abstract class for smoke tests to run a test agent the in background. This enables the testing of tags and other span info in smoketests through the comparison of snapshots (See `SpringBootOpenLibertySnapshotTest.groovy` for more details). Currently, this PR does not enable the test agent smoke tests to run on CI (will create another PR for that in the near future).