### PR TITLE
Update CircleCI config to not build on tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -277,10 +277,7 @@ jobs:
 workflows:
   build_test_deploy:
     jobs:
-      - build:
-          filters:
-            tags:
-              only: /.*/
+      - build
 
       - default_test_job:
           requires:
@@ -290,42 +287,27 @@ workflows:
           matrix:
             parameters:
               testTask: [ "7", "IBM8", "ZULU8","ORACLE8", "11", "ZULU11", "ZULU13", "15" ]
-          filters:
-            tags:
-              only: /.*/
 
       - default_test_job:
           requires:
             - build
           name: test_8
           testTask: test jacocoTestReport jacocoTestCoverageVerification
-          filters:
-            tags:
-              only: /.*/
 
       - default_test_job:
           requires:
             - build
           name: test_latest8
           testTask: latestDepTest
-          filters:
-            tags:
-              only: /.*/
 
       - agent_integration_tests:
           requires:
             - build
           testTask: traceAgentTest
-          filters:
-            tags:
-              only: /.*/
 
       - check:
           requires:
             - build
-          filters:
-            tags:
-              only: /.*/
 
       - muzzle:
           requires:

--- a/.github/workflows/add-assets-to-release.yaml
+++ b/.github/workflows/add-assets-to-release.yaml
@@ -8,9 +8,9 @@ jobs:
   dd-java-agent:
     runs-on: ubuntu-latest
     steps:
-      - name: Download from Maven Central
+      - name: Download from Sonatype
         run: |
-          wget https://repo1.maven.org/maven2/com/datadoghq/dd-java-agent/$VERSION/dd-java-agent-$VERSION.jar
+          wget https://oss.sonatype.org/service/local/repositories/releases/content/com/datadoghq/dd-java-agent/$VERSION/dd-java-agent-$VERSION.jar
       - name: Upload to release
         uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # 1.0.2
         env:
@@ -23,9 +23,9 @@ jobs:
   dd-trace-api:
     runs-on: ubuntu-latest
     steps:
-      - name: Download from Maven Central
+      - name: Download from Sonatype
         run: |
-          wget https://repo1.maven.org/maven2/com/datadoghq/dd-trace-api/$VERSION/dd-trace-api-$VERSION.jar
+          wget https://oss.sonatype.org/service/local/repositories/releases/content/com/datadoghq/dd-trace-api/$VERSION/dd-trace-api-$VERSION.jar
       - name: Upload to release
         uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # 1.0.2
         env:
@@ -38,9 +38,9 @@ jobs:
   dd-trace-ot:
     runs-on: ubuntu-latest
     steps:
-      - name: Download from Maven Central
+      - name: Download from Sonatype
         run: |
-          wget https://repo1.maven.org/maven2/com/datadoghq/dd-trace-ot/$VERSION/dd-trace-ot-$VERSION.jar
+          wget https://oss.sonatype.org/service/local/repositories/releases/content/com/datadoghq/dd-trace-ot/$VERSION/dd-trace-ot-$VERSION.jar
       - name: Upload to release
         uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # 1.0.2
         env:


### PR DESCRIPTION
Also download release artifacts from Sonatype rather than Maven Central as they're more immediately available there.