### PR TITLE
avoid converting binary document to tree when possible on later mongo driver versions

### DIFF
--- a/dd-java-agent/instrumentation/mongo/driver-3.1/src/main/java/datadog/trace/instrumentation/mongo/ByteBufBsonDocumentInstrumentation.java
+++ b/dd-java-agent/instrumentation/mongo/driver-3.1/src/main/java/datadog/trace/instrumentation/mongo/ByteBufBsonDocumentInstrumentation.java
@@ -1,0 +1,55 @@
+package datadog.trace.instrumentation.mongo;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static java.util.Collections.singletonMap;
+import static net.bytebuddy.matcher.ElementMatchers.declaresField;
+import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
+
+import com.google.auto.service.AutoService;
+import com.mongodb.MongoClientOptions;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers;
+import datadog.trace.bootstrap.InstrumentationContext;
+import java.util.Map;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import org.bson.BsonDocument;
+import org.bson.ByteBuf;
+
+@AutoService(Instrumenter.class)
+public class ByteBufBsonDocumentInstrumentation extends Instrumenter.Tracing {
+
+  public ByteBufBsonDocumentInstrumentation() {
+    super("mongo");
+  }
+
+  @Override
+  public ElementMatcher<? super TypeDescription> typeMatcher() {
+    return NameMatchers.<TypeDescription>named("com.mongodb.connection.ByteBufBsonDocument")
+        .and(declaresField(named("byteBuf")));
+  }
+
+  @Override
+  public Map<String, String> contextStore() {
+    return singletonMap("org.bson.BsonDocument", "org.bson.ByteBuf");
+  }
+
+  @Override
+  public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
+    return singletonMap(isConstructor(), getClass().getName() + "$ExposeBuffer");
+  }
+
+  public static final class ExposeBuffer {
+    @Advice.OnMethodExit
+    public static void exposeBuffer(
+        @Advice.This BsonDocument doc, @Advice.FieldValue("byteBuf") ByteBuf byteBuf) {
+      InstrumentationContext.get(BsonDocument.class, ByteBuf.class).put(doc, byteBuf);
+    }
+
+    public static void muzzleCheck() {
+      MongoClientOptions.builder().addCommandListener(null).build();
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/mongo/driver-4/src/main/java/datadog/trace/instrumentation/mongo4/Mongo4ClientDecorator.java
+++ b/dd-java-agent/instrumentation/mongo/driver-4/src/main/java/datadog/trace/instrumentation/mongo4/Mongo4ClientDecorator.java
@@ -7,7 +7,6 @@ import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.DBTypeProcessingDatabaseClientDecorator;
 import org.bson.BsonDocument;
-import org.bson.BsonDocumentReader;
 
 public class Mongo4ClientDecorator
     extends DBTypeProcessingDatabaseClientDecorator<CommandStartedEvent> {
@@ -71,7 +70,7 @@ public class Mongo4ClientDecorator
 
   private static String scrub(final BsonDocument origin) {
     try (BsonScrubber scrubber = new BsonScrubber()) {
-      scrubber.pipe(new BsonDocumentReader(origin));
+      scrubber.pipe(origin.asBsonReader());
       return scrubber.toResourceName();
     }
   }

--- a/dd-java-agent/instrumentation/mongo/driver-async-3.3/src/main/java/datadog/trace/instrumentation/mongo/MongoAsyncClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/mongo/driver-async-3.3/src/main/java/datadog/trace/instrumentation/mongo/MongoAsyncClientInstrumentation.java
@@ -11,12 +11,15 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 import com.google.auto.service.AutoService;
 import com.mongodb.event.CommandListener;
 import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.bootstrap.InstrumentationContext;
 import java.util.List;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
+import org.bson.BsonDocument;
+import org.bson.ByteBuf;
 
 @AutoService(Instrumenter.class)
 public final class MongoAsyncClientInstrumentation extends Instrumenter.Tracing {
@@ -51,6 +54,11 @@ public final class MongoAsyncClientInstrumentation extends Instrumenter.Tracing 
   }
 
   @Override
+  public Map<String, String> contextStore() {
+    return singletonMap("org.bson.BsonDocument", "org.bson.ByteBuf");
+  }
+
+  @Override
   public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
     return singletonMap(
         isMethod().and(isPublic()).and(named("build")).and(takesArguments(0)),
@@ -66,7 +74,9 @@ public final class MongoAsyncClientInstrumentation extends Instrumenter.Tracing 
           && listeners.get(listeners.size() - 1).getClass().getName().startsWith("datadog.")) {
         return;
       }
-      listeners.add(new TracingCommandListener());
+      listeners.add(
+          new TracingCommandListener(
+              InstrumentationContext.get(BsonDocument.class, ByteBuf.class)));
     }
   }
 }


### PR DESCRIPTION
Newer mongo driver versions allow more efficient reading of BSON documents. Unfortunately this isn't possible on older driver versions, so I added some instrumentation to extract the document's buffer and do the same thing manually.