### PR TITLE
Fork the Vert.x tests to avoid shutdown/startup issues

### DIFF
--- a/dd-java-agent/instrumentation/vertx-rx-3.5/src/test/groovy/client/VertxRxCircuitBreakerWebClientForkedTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-rx-3.5/src/test/groovy/client/VertxRxCircuitBreakerWebClientForkedTest.groovy
@@ -16,7 +16,7 @@ import spock.lang.Timeout
 import java.util.concurrent.CompletableFuture
 
 @Timeout(10)
-class VertxRxCircuitBreakerWebClientTest extends HttpClientTest {
+class VertxRxCircuitBreakerWebClientForkedTest extends HttpClientTest {
 
   @Override
   boolean useStrictTraceWrites() {

--- a/dd-java-agent/instrumentation/vertx-rx-3.5/src/test/groovy/client/VertxRxWebClientForkedTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-rx-3.5/src/test/groovy/client/VertxRxWebClientForkedTest.groovy
@@ -12,7 +12,7 @@ import spock.lang.Shared
 import spock.lang.Timeout
 
 @Timeout(10)
-class VertxRxWebClientTest extends HttpClientTest {
+class VertxRxWebClientForkedTest extends HttpClientTest {
 
   @Override
   boolean useStrictTraceWrites() {

--- a/dd-java-agent/instrumentation/vertx-rx-3.5/src/test/groovy/server/VertxRxCircuitBreakerHttpServerForkedTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-rx-3.5/src/test/groovy/server/VertxRxCircuitBreakerHttpServerForkedTest.groovy
@@ -16,7 +16,7 @@ import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.REDIRE
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 import static server.VertxTestServer.CONFIG_HTTP_SERVER_PORT
 
-class VertxRxCircuitBreakerHttpServerTest extends VertxHttpServerTest {
+class VertxRxCircuitBreakerHttpServerForkedTest extends VertxHttpServerForkedTest {
 
   @Override
   protected Class<AbstractVerticle> verticle() {

--- a/dd-java-agent/instrumentation/vertx-rx-3.5/src/test/groovy/server/VertxRxHttpServerForkedTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-rx-3.5/src/test/groovy/server/VertxRxHttpServerForkedTest.groovy
@@ -15,7 +15,7 @@ import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCES
 import static server.VertxTestServer.CONFIG_HTTP_SERVER_PORT
 
 @Ignore("This test isn't different from VertxHttpServerTest. Needs rework to meet intent")
-class VertxRxHttpServerTest extends VertxHttpServerTest {
+class VertxRxHttpServerForkedTest extends VertxHttpServerForkedTest {
 
   @Override
   protected Class<AbstractVerticle> verticle() {

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/test/groovy/client/VertxHttpClientForkedTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/test/groovy/client/VertxHttpClientForkedTest.groovy
@@ -14,7 +14,7 @@ import spock.lang.Timeout
 import java.util.concurrent.CompletableFuture
 
 @Timeout(10)
-class VertxHttpClientTest extends HttpClientTest {
+class VertxHttpClientForkedTest extends HttpClientTest {
 
   @Override
   boolean useStrictTraceWrites() {

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/test/groovy/server/VertxHttpServerForkedTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/test/groovy/server/VertxHttpServerForkedTest.groovy
@@ -20,7 +20,7 @@ import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.NOT_FO
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 import static server.VertxTestServer.CONFIG_HTTP_SERVER_PORT
 
-class VertxHttpServerTest extends HttpServerTest<Vertx> {
+class VertxHttpServerForkedTest extends HttpServerTest<Vertx> {
   @Override
   Vertx startServer(int port) {
     def server = Vertx.vertx(new VertxOptions()
@@ -118,7 +118,7 @@ class VertxHttpServerTest extends HttpServerTest<Vertx> {
   }
 }
 
-class VertxChainingHttpServerTest extends VertxHttpServerTest {
+class VertxChainingHttpServerForkedTest extends VertxHttpServerForkedTest {
   @Override
   protected Class<AbstractVerticle> verticle() {
     VertxChainingTestServer


### PR DESCRIPTION
The Vert.x tests seem to account for the majority of timeout stalls on the IBM8 tests, and if I run them locally I can provoke two different (but probably the same) issues.

```
*** java.lang.instrument ASSERTION FAILED ***: "!errorOutstanding" with message transform method call failed at JPLISAgent.c line: 844
```

or

```
java.util.concurrent.RejectedExecutionException: event executor terminated
        at io.netty.util.concurrent.SingleThreadEventExecutor.reject(SingleThreadEventExecutor.java:821)
        at io.netty.util.concurrent.SingleThreadEventExecutor.offerTask(SingleThreadEventExecutor.java:327)
        at io.netty.util.concurrent.SingleThreadEventExecutor.addTask(SingleThreadEventExecutor.java:320)
        at io.netty.util.concurrent.SingleThreadEventExecutor.execute(SingleThreadEventExecutor.java:746)
        at io.netty.util.concurrent.DefaultPromise.safeExecute(DefaultPromise.java:760)
    ... // ad inifinitum
```

I have not been able to reproduce any of these if I only run one of the Vert.x test specs, but only if I run multiple after each other. There seems to be some shutdown/startup issue involved here, so I've made the tests into `forked` tests.