### PR TITLE
Cap the latest Mongo 4 test version to 4.2.x

### DIFF
--- a/dd-java-agent/instrumentation/mongo/driver-4/driver-4.gradle
+++ b/dd-java-agent/instrumentation/mongo/driver-4/driver-4.gradle
@@ -34,6 +34,6 @@ dependencies {
 
   testCompile group: 'org.mongodb', name: 'mongodb-driver-sync', version: '4.0.0'
   testCompile group: 'org.mongodb', name: 'mongodb-driver-reactivestreams', version: '4.0.0'
-  latestDepTestCompile group: 'org.mongodb', name: 'mongodb-driver-sync', version: '+'
-  latestDepTestCompile group: 'org.mongodb', name: 'mongodb-driver-reactivestreams', version: '+'
+  latestDepTestCompile group: 'org.mongodb', name: 'mongodb-driver-sync', version: '4.2+'
+  latestDepTestCompile group: 'org.mongodb', name: 'mongodb-driver-reactivestreams', version: '4.2+'
 }


### PR DESCRIPTION
The newly released `4.3.0-beta1` version of the drivers fail on some of the tests.