### PR TITLE
Decrease AWS client test timeout

### DIFF
--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test/groovy/AWS1ClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test/groovy/AWS1ClientTest.groovy
@@ -328,7 +328,7 @@ class AWS1ClientTest extends AgentTestRunner {
         }
       }
     }
-    AmazonS3Client client = new AmazonS3Client(new ClientConfiguration().withRequestTimeout(50 /* ms */))
+    AmazonS3Client client = new AmazonS3Client(new ClientConfiguration().withRequestTimeout(1 /* ms */))
       .withEndpoint("http://localhost:$server.address.port")
 
     when:


### PR DESCRIPTION
Trying to reduce chance of `InterruptedIOException` instead of `RequestAbortedException`