### PR TITLE
setMeasured for hystrix spans by system property (off by default)

### DIFF
--- a/dd-java-agent/instrumentation/hystrix-1.4/src/main/java/datadog/trace/instrumentation/hystrix/HystrixDecorator.java
+++ b/dd-java-agent/instrumentation/hystrix-1.4/src/main/java/datadog/trace/instrumentation/hystrix/HystrixDecorator.java
@@ -18,13 +18,15 @@ public class HystrixDecorator extends BaseDecorator {
   public static HystrixDecorator DECORATE = new HystrixDecorator();
 
   private final boolean extraTags;
+  private final boolean measured;
 
-  private HystrixDecorator(boolean extraTags) {
+  private HystrixDecorator(boolean extraTags, boolean measured) {
     this.extraTags = extraTags;
+    this.measured = measured;
   }
 
   private HystrixDecorator() {
-    this(Config.get().isHystrixTagsEnabled());
+    this(Config.get().isHystrixTagsEnabled(), Config.get().isHystrixMeasuredEnabled());
   }
 
   public static final CharSequence HYSTRIX = UTF8BytesString.create("hystrix");
@@ -88,6 +90,9 @@ public class HystrixDecorator extends BaseDecorator {
         span.setTag(HYSTRIX_COMMAND, command.getCommandKey().name());
         span.setTag(HYSTRIX_GROUP, command.getCommandGroup().name());
         span.setTag(HYSTRIX_CIRCUIT_OPEN, command.isCircuitBreakerOpen());
+      }
+      if (measured) {
+        span.setMeasured(true);
       }
       span.setResourceName(
           RESOURCE_NAME_CACHE.computeIfAbsent(

--- a/dd-java-agent/instrumentation/hystrix-1.4/src/test/groovy/HystrixObservableChainTest.groovy
+++ b/dd-java-agent/instrumentation/hystrix-1.4/src/test/groovy/HystrixObservableChainTest.groovy
@@ -1,35 +1,18 @@
 import com.netflix.hystrix.HystrixObservableCommand
-import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.Trace
 import datadog.trace.bootstrap.instrumentation.api.Tags
-import datadog.trace.instrumentation.hystrix.HystrixDecorator
 import rx.Observable
 import rx.schedulers.Schedulers
 
 import static com.netflix.hystrix.HystrixCommandGroupKey.Factory.asKey
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 
-class HystrixObservableChainTest extends AgentTestRunner {
+class HystrixObservableChainTest extends HystrixTestRunner {
 
   @Override
   boolean useStrictTraceWrites() {
     // TODO fix this by making sure that spans get closed properly
     return false
-  }
-
-  @Override
-  void configurePreAgent() {
-    super.configurePreAgent()
-
-    // Disable so failure testing below doesn't inadvertently change the behavior.
-    System.setProperty("hystrix.command.default.circuitBreaker.enabled", "false")
-
-    // hack to guarantee that that extra tags is enabled since it can't be guaranteed that
-    // the Config singleton will not be initialised before this block runs.
-    HystrixDecorator.DECORATE = new HystrixDecorator(true)
-
-    // Uncomment for debugging:
-    // System.setProperty("hystrix.command.default.execution.timeout.enabled", "false")
   }
 
   def "test command #action"() {

--- a/dd-java-agent/instrumentation/hystrix-1.4/src/test/groovy/HystrixObservableTest.groovy
+++ b/dd-java-agent/instrumentation/hystrix-1.4/src/test/groovy/HystrixObservableTest.groovy
@@ -1,10 +1,8 @@
 import com.netflix.hystrix.HystrixObservable
 import com.netflix.hystrix.HystrixObservableCommand
 import com.netflix.hystrix.exception.HystrixRuntimeException
-import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.Trace
 import datadog.trace.bootstrap.instrumentation.api.Tags
-import datadog.trace.instrumentation.hystrix.HystrixDecorator
 import rx.Observable
 import rx.schedulers.Schedulers
 
@@ -14,27 +12,12 @@ import java.util.concurrent.LinkedBlockingQueue
 import static com.netflix.hystrix.HystrixCommandGroupKey.Factory.asKey
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 
-class HystrixObservableTest extends AgentTestRunner {
+class HystrixObservableTest extends HystrixTestRunner {
 
   @Override
   boolean useStrictTraceWrites() {
     // TODO fix this by making sure that spans get closed properly
     return false
-  }
-
-  @Override
-  void configurePreAgent() {
-    super.configurePreAgent()
-
-    // Disable so failure testing below doesn't inadvertently change the behavior.
-    System.setProperty("hystrix.command.default.circuitBreaker.enabled", "false")
-
-    // hack to guarantee that that extra tags is enabled since it can't be guaranteed that
-    // the Config singleton will not be initialised before this block runs.
-    HystrixDecorator.DECORATE = new HystrixDecorator(true)
-
-    // Uncomment for debugging:
-    // System.setProperty("hystrix.command.default.execution.timeout.enabled", "false")
   }
 
   def "test command #action"() {

--- a/dd-java-agent/instrumentation/hystrix-1.4/src/test/groovy/HystrixTest.groovy
+++ b/dd-java-agent/instrumentation/hystrix-1.4/src/test/groovy/HystrixTest.groovy
@@ -1,6 +1,7 @@
 import com.netflix.hystrix.HystrixCommand
-import datadog.trace.agent.test.AgentTestRunner
+import com.netflix.hystrix.HystrixCommandGroupKey
 import datadog.trace.api.Trace
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.instrumentation.hystrix.HystrixDecorator
 import spock.lang.Timeout
@@ -12,22 +13,7 @@ import static com.netflix.hystrix.HystrixCommandGroupKey.Factory.asKey
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 
 @Timeout(10)
-class HystrixTest extends AgentTestRunner {
-  @Override
-  void configurePreAgent() {
-    super.configurePreAgent()
-
-    // Disable so failure testing below doesn't inadvertently change the behavior.
-    System.setProperty("hystrix.command.default.circuitBreaker.enabled", "false")
-
-    // hack to guarantee that that extra tags is enabled since it can't be guaranteed that
-    // the Config singleton will not be initialised before this block runs.
-    HystrixDecorator.DECORATE = new HystrixDecorator(true)
-
-    // Uncomment for debugging:
-    // System.setProperty("hystrix.command.default.execution.timeout.enabled", "false")
-  }
-
+class HystrixTest extends HystrixTestRunner {
   def "test command #action"() {
     setup:
     def command = new HystrixCommand<String>(asKey("ExampleGroup")) {
@@ -189,5 +175,26 @@ class HystrixTest extends AgentTestRunner {
       }
       queue.take()
     }
+  }
+
+  def "test setMeasured called if explicitly enabled by property"() {
+    setup:
+    def span = Mock(AgentSpan)
+
+    when:
+    HystrixDecorator.DECORATE.onCommand(span, new HystrixCommand(new HystrixCommandGroupKey() {
+        @Override
+        String name() {
+          return "test group key name"
+        }
+      }) {
+        @Override
+        protected Object run() throws Exception {
+          return null
+        }
+      }, "test method")
+
+    then:
+    1 * span.setMeasured(true)
   }
 }

--- a/dd-java-agent/instrumentation/hystrix-1.4/src/test/groovy/HystrixTestRunner.groovy
+++ b/dd-java-agent/instrumentation/hystrix-1.4/src/test/groovy/HystrixTestRunner.groovy
@@ -1,0 +1,19 @@
+import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.instrumentation.hystrix.HystrixDecorator
+
+abstract class HystrixTestRunner extends AgentTestRunner {
+  @Override
+  void configurePreAgent() {
+    super.configurePreAgent()
+
+    // Disable so failure testing below doesn't inadvertently change the behavior.
+    System.setProperty("hystrix.command.default.circuitBreaker.enabled", "false")
+
+    // hack to guarantee that that extra tags is enabled since it can't be guaranteed that
+    // the Config singleton will not be initialised before this block runs.
+    HystrixDecorator.DECORATE = new HystrixDecorator(true, true)
+
+    // Uncomment for debugging:
+    // System.setProperty("hystrix.command.default.execution.timeout.enabled", "false")
+  }
+}

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
@@ -43,6 +43,7 @@ public final class TraceInstrumentationConfig {
 
   public static final String GRPC_IGNORED_OUTBOUND_METHODS = "trace.grpc.ignored.outbound.methods";
   public static final String HYSTRIX_TAGS_ENABLED = "hystrix.tags.enabled";
+  public static final String HYSTRIX_MEASURED_ENABLED = "hystrix.measured.enabled";
 
   public static final String OSGI_SEARCH_DEPTH = "osgi.search.depth";
 

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -113,6 +113,7 @@ import static datadog.trace.api.config.TraceInstrumentationConfig.GRPC_IGNORED_O
 import static datadog.trace.api.config.TraceInstrumentationConfig.HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN;
 import static datadog.trace.api.config.TraceInstrumentationConfig.HTTP_CLIENT_TAG_QUERY_STRING;
 import static datadog.trace.api.config.TraceInstrumentationConfig.HTTP_SERVER_TAG_QUERY_STRING;
+import static datadog.trace.api.config.TraceInstrumentationConfig.HYSTRIX_MEASURED_ENABLED;
 import static datadog.trace.api.config.TraceInstrumentationConfig.HYSTRIX_TAGS_ENABLED;
 import static datadog.trace.api.config.TraceInstrumentationConfig.INTEGRATIONS_ENABLED;
 import static datadog.trace.api.config.TraceInstrumentationConfig.JDBC_CONNECTION_CLASS_NAME;
@@ -342,6 +343,7 @@ public class Config {
   private final boolean kafkaClientBase64DecodingEnabled;
 
   private final boolean hystrixTagsEnabled;
+  private final boolean hystrixMeasuredEnabled;
 
   private final int osgiSearchDepth;
 
@@ -709,6 +711,7 @@ public class Config {
         new HashSet<>(configProvider.getList(GRPC_IGNORED_OUTBOUND_METHODS));
 
     hystrixTagsEnabled = configProvider.getBoolean(HYSTRIX_TAGS_ENABLED, false);
+    hystrixMeasuredEnabled = configProvider.getBoolean(HYSTRIX_MEASURED_ENABLED, false);
 
     osgiSearchDepth = configProvider.getInteger(OSGI_SEARCH_DEPTH, 1);
 
@@ -1070,6 +1073,10 @@ public class Config {
 
   public boolean isHystrixTagsEnabled() {
     return hystrixTagsEnabled;
+  }
+
+  public boolean isHystrixMeasuredEnabled() {
+    return hystrixMeasuredEnabled;
   }
 
   public int getOsgiSearchDepth() {
@@ -1749,6 +1756,8 @@ public class Config {
         + kafkaClientBase64DecodingEnabled
         + ", hystrixTagsEnabled="
         + hystrixTagsEnabled
+        + ", hystrixMeasuredEnabled="
+        + hystrixMeasuredEnabled
         + ", osgiSearchDepth="
         + osgiSearchDepth
         + ", servletPrincipalEnabled="


### PR DESCRIPTION
Measured for hystrix spans stays off by default, but can be enabled by setting DD_HYSTRIX_MEASURED_ENABLED to true