### PR TITLE
Change smoke test to run snapshots in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,14 +148,15 @@ jobs:
           POSTGRES_USER: sa
           POSTGRES_PASSWORD: sa
           POSTGRES_DB: jdbcUnitTest
+        # This is used by smoke tests
       - image: kyleverhoog/dd-trace-test-agent
-          ports:
-            - "127.0.0.1:8126:8126"
-          volumes:
-            - ./dd-smoke-tests:/dd-smoke-tests
-          environment:
-            - SNAPSHOT_DIR=/dd-smoke-tests
-            - SNAPSHOT_CI
+        ports:
+          - "127.0.0.1:8126:8126"
+        volumes:
+          - ./dd-smoke-tests:/dd-smoke-tests
+        environment:
+          - SNAPSHOT_DIR=/dd-smoke-tests
+          - SNAPSHOT_CI
 
 
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,14 +163,6 @@ jobs:
           <<: *cache_keys
 
       - run:
-          # runs the test agent for smoke tests
-          name: Setup Test Agent for Smoke Tests
-          command: sudo chmod +x test-agent && sudo ./test-agent
-          environment:
-            SNAPSHOT_DIR: ~/dd-trace-java/dd-smoke-tests
-          background: true
-
-      - run:
           name: Run Tests
           command: >-
             GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx1940M -Xms64M -XX:ErrorFile=/tmp/hs_err_pid%p.log' -Ddatadog.forkedMaxHeapSize=512M -Ddatadog.forkedMinHeapSize=64M"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,7 +169,7 @@ jobs:
           environment:
             SNAPSHOT_DIR: ./dd-smoke-tests
           background: true
-          
+
       - run:
           name: Run Tests
           command: >-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,7 +167,7 @@ jobs:
           name: Setup Test Agent for Smoke Tests
           command: sudo chmod +x test-agent && sudo ./test-agent
           environment:
-            SNAPSHOT_DIR: ./dd-smoke-tests
+            SNAPSHOT_DIR: ~/dd-trace-java/dd-smoke-tests
           background: true
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,7 +168,8 @@ jobs:
           command: sudo chmod +x test-agent && sudo ./test-agent
           environment:
             SNAPSHOT_DIR: ./dd-smoke-tests
-
+          background: true
+          
       - run:
           name: Run Tests
           command: >-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,16 +148,6 @@ jobs:
           POSTGRES_USER: sa
           POSTGRES_PASSWORD: sa
           POSTGRES_DB: jdbcUnitTest
-        # This is used by smoke tests
-      - image: kyleverhoog/dd-trace-test-agent
-        ports:
-          - "127.0.0.1:8126:8126"
-        volumes:
-          - ./dd-smoke-tests:/dd-smoke-tests
-        environment:
-          - SNAPSHOT_DIR=/dd-smoke-tests
-          - SNAPSHOT_CI
-
 
     parameters:
       testTask:
@@ -171,6 +161,13 @@ jobs:
 
       - restore_cache:
           <<: *cache_keys
+
+      - run:
+          # runs the test agent for smoke tests
+          name: Setup Test Agent for Smoke Tests
+          command: ./test-agent
+          environment:
+            SNAPSHOT_DIR: ./dd-smoke-tests
 
       - run:
           name: Run Tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,7 +165,7 @@ jobs:
       - run:
           # runs the test agent for smoke tests
           name: Setup Test Agent for Smoke Tests
-          command: ./test-agent
+          command: sudo chmod +x test-agent && sudo ./test-agent
           environment:
             SNAPSHOT_DIR: ./dd-smoke-tests
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,6 +148,15 @@ jobs:
           POSTGRES_USER: sa
           POSTGRES_PASSWORD: sa
           POSTGRES_DB: jdbcUnitTest
+      - image: kyleverhoog/dd-trace-test-agent
+          ports:
+            - "127.0.0.1:8126:8126"
+          volumes:
+            - ./tests/snapshots:/snapshots
+          environment:
+            - SNAPSHOT_DIR=/snapshots
+            - SNAPSHOT_CI
+
 
     parameters:
       testTask:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,9 +152,9 @@ jobs:
           ports:
             - "127.0.0.1:8126:8126"
           volumes:
-            - ./tests/snapshots:/snapshots
+            - ./dd-smoke-tests:/dd-smoke-tests
           environment:
-            - SNAPSHOT_DIR=/snapshots
+            - SNAPSHOT_DIR=/dd-smoke-tests
             - SNAPSHOT_CI
 
 

--- a/dd-smoke-tests/dd-smoke-tests.gradle
+++ b/dd-smoke-tests/dd-smoke-tests.gradle
@@ -20,6 +20,9 @@ subprojects { subProject ->
     jvmArgs "-Ddatadog.smoketest.builddir=${buildDir}"
     jvmArgs "-Ddatadog.smoketest.agent.shadowJar.path=${project(':dd-java-agent').tasks.shadowJar.archivePath}"
 
+    // The jar path for the test agent (taken from https://github.com/DataDog/dd-trace-test-agent )
+    jvmArgs "-Ddatadog.smoketest.test.agent.dir=${project.getRootDir()}/dd-smoke-tests/src/main/resources/test-agent.jar"
+
     // Only one smoke test at a time
     usesService(smokeTestLimit)
   }

--- a/dd-smoke-tests/dd-smoke-tests.gradle
+++ b/dd-smoke-tests/dd-smoke-tests.gradle
@@ -5,7 +5,6 @@ description = 'dd-smoke-tests'
 dependencies {
   compile deps.spock
   compile project(':dd-java-agent:testing')
-  compile 'org.testcontainers:testcontainers:1.15.2'
 }
 
 def smokeTestLimit = gradle.sharedServices.registerIfAbsent("smokeTestLimit", BuildService) {

--- a/dd-smoke-tests/dd-smoke-tests.gradle
+++ b/dd-smoke-tests/dd-smoke-tests.gradle
@@ -20,7 +20,7 @@ subprojects { subProject ->
     jvmArgs "-Ddatadog.smoketest.agent.shadowJar.path=${project(':dd-java-agent').tasks.shadowJar.archivePath}"
 
     // The jar path for the test agent (taken from https://github.com/DataDog/dd-trace-test-agent )
-    jvmArgs "-Ddatadog.smoketest.test.agent.dir=${project.getRootDir()}/dd-smoke-tests/src/main/resources/test-agent.jar"
+    jvmArgs "-Ddatadog.smoketest.test.agent.dir=${project.getRootDir()}/dd-smoke-tests/src/main/resources/datadog.smoketest.test.agent.jar"
 
     // Only one smoke test at a time
     usesService(smokeTestLimit)

--- a/dd-smoke-tests/springboot-openliberty/src/test/groovy/datadog/smoketest/SpringBootOpenLibertySnapshotTest.groovy
+++ b/dd-smoke-tests/springboot-openliberty/src/test/groovy/datadog/smoketest/SpringBootOpenLibertySnapshotTest.groovy
@@ -6,7 +6,7 @@ import spock.lang.Requires
 import spock.lang.Shared
 
 @Requires({
-  !System.getProperty("java.vm.name").contains("IBM J9 VM") //&& System.getenv("CI") != "true"
+  !System.getProperty("java.vm.name").contains("IBM J9 VM")
 })
 class SpringBootOpenLibertySnapshotTest extends AbstractTestAgentSmokeTest {
 

--- a/dd-smoke-tests/springboot-openliberty/src/test/groovy/datadog/smoketest/SpringBootOpenLibertySnapshotTest.groovy
+++ b/dd-smoke-tests/springboot-openliberty/src/test/groovy/datadog/smoketest/SpringBootOpenLibertySnapshotTest.groovy
@@ -6,7 +6,7 @@ import spock.lang.Requires
 import spock.lang.Shared
 
 @Requires({
-  !System.getProperty("java.vm.name").contains("IBM J9 VM") && System.getenv("CI") != "true"
+  !System.getProperty("java.vm.name").contains("IBM J9 VM") //&& System.getenv("CI") != "true"
 })
 class SpringBootOpenLibertySnapshotTest extends AbstractTestAgentSmokeTest {
 

--- a/dd-smoke-tests/src/main/groovy/datadog/smoketest/AbstractTestAgentSmokeTest.groovy
+++ b/dd-smoke-tests/src/main/groovy/datadog/smoketest/AbstractTestAgentSmokeTest.groovy
@@ -87,7 +87,8 @@ abstract class AbstractTestAgentSmokeTest extends ProcessManager {
 
     func.call()
 
-    Thread.sleep(1000)
+    //makes sure that the test agent receives it, this might cause race conditions
+    Thread.sleep(1500)
     if (testAgent != null) {
       printLogToFile(testTokenID)
     }

--- a/dd-smoke-tests/src/main/groovy/datadog/smoketest/AbstractTestAgentSmokeTest.groovy
+++ b/dd-smoke-tests/src/main/groovy/datadog/smoketest/AbstractTestAgentSmokeTest.groovy
@@ -23,7 +23,7 @@ abstract class AbstractTestAgentSmokeTest extends ProcessManager {
   protected GenericContainer testAgent
 
   @Shared
-  protected int testAgentMappedPort = PortUtils.randomOpenPort()
+  protected int testAgentMappedPort = "true" == System.getenv("CI") ? 8126 : PortUtils.randomOpenPort()
 
   @Shared
   protected int testAgentPort = 8126
@@ -64,7 +64,6 @@ abstract class AbstractTestAgentSmokeTest extends ProcessManager {
         Wait.forLogMessage(".*Started server on port.*\\n", 1)
         )
       testAgent.start()
-      testAgentMappedPort = testAgent.getMappedPort(testAgentPort)
     }
   }
 

--- a/dd-smoke-tests/src/main/groovy/datadog/smoketest/ProcessManager.groovy
+++ b/dd-smoke-tests/src/main/groovy/datadog/smoketest/ProcessManager.groovy
@@ -21,6 +21,7 @@ abstract class ProcessManager extends Specification {
   protected String buildDirectory = System.getProperty("datadog.smoketest.builddir")
   @Shared
   protected String shadowJarPath = System.getProperty("datadog.smoketest.agent.shadowJar.path")
+
   @Shared
   protected static int profilingPort = -1
 


### PR DESCRIPTION
Changed the test agent from running in a test container to running as a process on the local machine. This avoids the process of setting up a separate test agent container in CI.