### PR TITLE
enable bypassing of sampling priority lock to force keep local trace chunks, plus lock-free priority locking

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/taginterceptor/TagInterceptor.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/taginterceptor/TagInterceptor.java
@@ -3,9 +3,7 @@ package datadog.trace.core.taginterceptor;
 import static datadog.trace.api.DDTags.ANALYTICS_SAMPLE_RATE;
 import static datadog.trace.api.DDTags.SPAN_TYPE;
 import static datadog.trace.api.sampling.PrioritySampling.USER_DROP;
-import static datadog.trace.api.sampling.PrioritySampling.USER_KEEP;
 import static datadog.trace.core.taginterceptor.RuleFlags.Feature.FORCE_MANUAL_DROP;
-import static datadog.trace.core.taginterceptor.RuleFlags.Feature.FORCE_MANUAL_KEEP;
 import static datadog.trace.core.taginterceptor.RuleFlags.Feature.PEER_SERVICE;
 import static datadog.trace.core.taginterceptor.RuleFlags.Feature.RESOURCE_NAME;
 import static datadog.trace.core.taginterceptor.RuleFlags.Feature.SERVICE_NAME;
@@ -58,7 +56,11 @@ public class TagInterceptor {
       case Tags.PEER_SERVICE:
         return interceptServiceName(PEER_SERVICE, span, value);
       case DDTags.MANUAL_KEEP:
-        return interceptSamplingPriority(FORCE_MANUAL_KEEP, USER_KEEP, span, value);
+        if (asBoolean(value)) {
+          span.forceKeep();
+          return true;
+        }
+        return false;
       case DDTags.MANUAL_DROP:
         return interceptSamplingPriority(FORCE_MANUAL_DROP, USER_DROP, span, value);
       case InstrumentationTags.SERVLET_CONTEXT:


### PR DESCRIPTION
This has two features:

1. Setting the tag `manual.keep:true` to keep a span is guaranteed to keep the local trace chunk, even if it has already propagated. Currently this is only guaranteed to work in a gateway process, which usually doesn't have enough context to keep traces. So if a user sets the tag early enough in manual instrumentation, they can keep large portions of traces despite sampling decisions made with less context upstream.
2. Changes the locking mechanism to use CAS ops, but changes the semantics slightly: setting the priority the first time to anything but `UNSET` effectively locks the sampling priority, and only `manual.keep:true` resulting in a call to`forceKeep()` can subsequently override it. If there are applications out there where our direct API is used to call `setSamplingPriority(int)` over and over again, they will break, but this was nondeterministic anyway.