### PR TITLE
allow exclusion of traces from metrics collection via a config property

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/config/GeneralConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/GeneralConfig.java
@@ -37,6 +37,8 @@ public final class GeneralConfig {
       "trace.tracer.metrics.buffering.enabled";
   public static final String TRACER_METRICS_MAX_AGGREGATES = "trace.tracer.metrics.max.aggregates";
   public static final String TRACER_METRICS_MAX_PENDING = "trace.tracer.metrics.max.pending";
+  public static final String TRACER_METRICS_IGNORED_RESOURCES =
+      "trace.tracer.metrics.ignored.resources";
 
   public static final String INTERNAL_EXIT_ON_FAILURE = "trace.internal.exit.on.failure";
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/FootprintTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/FootprintTest.groovy
@@ -28,6 +28,7 @@ class FootprintTest extends DDSpecification {
     sink.validate() >> true
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(
       new WellKnownTags("hostname", "env", "service", "version"),
+      [].toSet() as Set<String>,
       sink,
       1000,
       1000,

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SimpleSpan.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SimpleSpan.groovy
@@ -8,7 +8,7 @@ class SimpleSpan implements CoreSpan<SimpleSpan> {
 
   private final String serviceName
   private final String operationName
-  private final String resourceName
+  private final CharSequence resourceName
   private final String type
   private final boolean measured
   private final boolean topLevel
@@ -19,7 +19,7 @@ class SimpleSpan implements CoreSpan<SimpleSpan> {
 
   SimpleSpan(String serviceName,
   String operationName,
-  String resourceName,
+  CharSequence resourceName,
   String type,
   boolean measured,
   boolean topLevel,

--- a/internal-api/internal-api.gradle
+++ b/internal-api/internal-api.gradle
@@ -35,6 +35,7 @@ excludedClassesCoverage += [
   "datadog.trace.util.AgentTaskScheduler.ShutdownHook",
   "datadog.trace.util.AgentThreadFactory",
   "datadog.trace.util.AgentThreadFactory.1",
+  "datadog.trace.util.CollectionUtils",
 ]
 
 dependencies {

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -74,6 +74,7 @@ import static datadog.trace.api.config.GeneralConfig.SITE;
 import static datadog.trace.api.config.GeneralConfig.TAGS;
 import static datadog.trace.api.config.GeneralConfig.TRACER_METRICS_BUFFERING_ENABLED;
 import static datadog.trace.api.config.GeneralConfig.TRACER_METRICS_ENABLED;
+import static datadog.trace.api.config.GeneralConfig.TRACER_METRICS_IGNORED_RESOURCES;
 import static datadog.trace.api.config.GeneralConfig.TRACER_METRICS_MAX_AGGREGATES;
 import static datadog.trace.api.config.GeneralConfig.TRACER_METRICS_MAX_PENDING;
 import static datadog.trace.api.config.GeneralConfig.VERSION;
@@ -167,6 +168,7 @@ import static datadog.trace.api.config.TracerConfig.TRACE_SAMPLING_OPERATION_RUL
 import static datadog.trace.api.config.TracerConfig.TRACE_SAMPLING_SERVICE_RULES;
 import static datadog.trace.api.config.TracerConfig.TRACE_STRICT_WRITES_ENABLED;
 import static datadog.trace.api.config.TracerConfig.WRITER_TYPE;
+import static datadog.trace.util.CollectionUtils.immutableSet;
 import static datadog.trace.util.Strings.toEnvVar;
 
 import datadog.trace.api.config.GeneralConfig;
@@ -1149,6 +1151,10 @@ public class Config {
 
   public WellKnownTags getWellKnownTags() {
     return new WellKnownTags(getHostName(), getEnv(), serviceName, getVersion());
+  }
+
+  public Set<String> getMetricsIgnoredResources() {
+    return immutableSet(new HashSet<>(configProvider.getList(TRACER_METRICS_IGNORED_RESOURCES)));
   }
 
   public String getEnv() {

--- a/internal-api/src/main/java/datadog/trace/util/CollectionUtils.java
+++ b/internal-api/src/main/java/datadog/trace/util/CollectionUtils.java
@@ -1,0 +1,36 @@
+package datadog.trace.util;
+
+import static datadog.trace.api.Platform.isJavaVersionAtLeast;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.util.Collections;
+import java.util.Set;
+
+public final class CollectionUtils {
+
+  private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
+  private static final MethodHandle IMMUTABLE_COPY_OF_SET = findCopyOf(Set.class);
+
+  @SuppressWarnings("unchecked")
+  public static <T> Set<T> immutableSet(Set<T> set) {
+    if (null != IMMUTABLE_COPY_OF_SET) {
+      try {
+        return (Set<T>) IMMUTABLE_COPY_OF_SET.invokeExact(set);
+      } catch (Throwable ignore) {
+      }
+    }
+    return Collections.unmodifiableSet(set);
+  }
+
+  private static MethodHandle findCopyOf(Class<?> clazz) {
+    if (isJavaVersionAtLeast(10)) {
+      try {
+        return LOOKUP.findStatic(clazz, "copyOf", MethodType.methodType(clazz, clazz));
+      } catch (NoSuchMethodException | IllegalAccessException ignore) {
+      }
+    }
+    return null;
+  }
+}

--- a/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -29,6 +29,7 @@ import static datadog.trace.api.config.GeneralConfig.PERF_METRICS_ENABLED
 import static datadog.trace.api.config.GeneralConfig.SERVICE_NAME
 import static datadog.trace.api.config.GeneralConfig.SITE
 import static datadog.trace.api.config.GeneralConfig.TAGS
+import static datadog.trace.api.config.GeneralConfig.TRACER_METRICS_IGNORED_RESOURCES
 import static datadog.trace.api.config.GeneralConfig.VERSION
 import static datadog.trace.api.config.JmxFetchConfig.JMX_FETCH_CHECK_PERIOD
 import static datadog.trace.api.config.JmxFetchConfig.JMX_FETCH_ENABLED
@@ -1824,6 +1825,16 @@ class ConfigTest extends DDSpecification {
     "1234"                            | "http://localhost:8126" | "localhost"  | 8126         | "/path/to/socket"
     ":1234"                           | "http://localhost:8126" | "localhost"  | 8126         | "/path/to/socket"
     // spotless:on
+  }
+
+  def "test get ignored resource names"(){
+    setup:
+    System.setProperty(PREFIX + TRACER_METRICS_IGNORED_RESOURCES, "GET /healthcheck,SELECT foo from bar")
+
+    when:
+    def config = new Config()
+    then:
+    config.getMetricsIgnoredResources() == ["GET /healthcheck", "SELECT foo from bar"].toSet()
   }
 
   static class ClassThrowsExceptionForValueOfMethod {


### PR DESCRIPTION
This requirement was missed during analysis of the tracer metrics feature. This allows users to specify resources to skip via a config parameter.