### PR TITLE
metrics updates

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/OkHttpSink.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/OkHttpSink.java
@@ -4,6 +4,7 @@ import static datadog.trace.common.metrics.EventListener.EventType.BAD_PAYLOAD;
 import static datadog.trace.common.metrics.EventListener.EventType.DOWNGRADED;
 import static datadog.trace.common.metrics.EventListener.EventType.ERROR;
 import static datadog.trace.common.metrics.EventListener.EventType.OK;
+import static datadog.trace.common.writer.ddagent.DDAgentFeaturesDiscovery.V6_METRICS_ENDPOINT;
 import static datadog.trace.core.http.OkHttpUtils.buildHttpClient;
 import static datadog.trace.core.http.OkHttpUtils.msgpackRequestBodyOf;
 import static datadog.trace.core.http.OkHttpUtils.prepareRequest;
@@ -45,7 +46,7 @@ public final class OkHttpSink implements Sink, EventListener {
     this(
         buildHttpClient(HttpUrl.get(agentUrl), timeoutMillis),
         agentUrl,
-        "v0.5/stats",
+        V6_METRICS_ENDPOINT,
         bufferingEnabled);
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/DDAgentFeaturesDiscovery.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/DDAgentFeaturesDiscovery.java
@@ -32,14 +32,14 @@ public class DDAgentFeaturesDiscovery implements DroppingPolicy {
   public static final String V4_ENDPOINT = "v0.4/traces";
   public static final String V5_ENDPOINT = "v0.5/traces";
 
-  private static final String V5_METRICS_ENDPOINT = "v0.5/stats";
+  public static final String V6_METRICS_ENDPOINT = "v0.6/stats";
   private static final String DATADOG_AGENT_STATE = "Datadog-Agent-State";
 
   private final OkHttpClient client;
   private final HttpUrl agentBaseUrl;
   private final Recording discoveryTimer;
   private final String[] traceEndpoints;
-  private final String[] metricsEndpoints = {V5_METRICS_ENDPOINT};
+  private final String[] metricsEndpoints = {V6_METRICS_ENDPOINT};
   private final boolean metricsEnabled;
 
   private volatile String traceEndpoint;

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/ConflatingMetricAggregatorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/ConflatingMetricAggregatorTest.groovy
@@ -29,7 +29,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     setup:
     Sink sink = Mock(Sink)
     sink.validate() >> true
-    WellKnownTags wellKnownTags = new WellKnownTags("hostname", "env", "service", "version")
+    WellKnownTags wellKnownTags = new WellKnownTags("runtimeid", "hostname", "env", "service", "version")
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(
       wellKnownTags,
       empty,
@@ -56,7 +56,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     String ignoredResourceName = "foo"
     Sink sink = Mock(Sink)
     sink.validate() >> true
-    WellKnownTags wellKnownTags = new WellKnownTags("hostname", "env", "service", "version")
+    WellKnownTags wellKnownTags = new WellKnownTags("runtimeid", "hostname", "env", "service", "version")
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(
       wellKnownTags,
       [ignoredResourceName].toSet(),

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/FootprintTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/FootprintTest.groovy
@@ -26,7 +26,7 @@ class FootprintTest extends DDSpecification {
     CountDownLatch latch = new CountDownLatch(1)
     ValidatingSink sink = new ValidatingSink(latch)
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(
-      new WellKnownTags("hostname", "env", "service", "version"),
+      new WellKnownTags("runtimeid","hostname", "env", "service", "version"),
       [].toSet() as Set<String>,
       sink,
       1000,

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/OkHttpSinkTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/OkHttpSinkTest.groovy
@@ -21,6 +21,7 @@ import static datadog.trace.common.metrics.EventListener.EventType.BAD_PAYLOAD
 import static datadog.trace.common.metrics.EventListener.EventType.DOWNGRADED
 import static datadog.trace.common.metrics.EventListener.EventType.ERROR
 import static datadog.trace.common.metrics.EventListener.EventType.OK
+import static datadog.trace.common.writer.ddagent.DDAgentFeaturesDiscovery.V6_METRICS_ENDPOINT
 
 @Requires({
   isJavaVersionAtLeast(8)
@@ -30,7 +31,7 @@ class OkHttpSinkTest extends DDSpecification {
   def "validate responds to status code"() {
     setup:
     String agentUrl = "http://localhost:8126"
-    String path = "v0.5/stats"
+    String path = V6_METRICS_ENDPOINT
     OkHttpClient client = Mock(OkHttpClient)
     OkHttpSink sink = new OkHttpSink(client, agentUrl, path, true)
 
@@ -55,7 +56,7 @@ class OkHttpSinkTest extends DDSpecification {
   def "http status code #responseCode yields #eventType"() {
     setup:
     String agentUrl = "http://localhost:8126"
-    String path = "v0.5/stats"
+    String path = V6_METRICS_ENDPOINT
     EventListener listener = Mock(EventListener)
     OkHttpClient client = Mock(OkHttpClient)
     OkHttpSink sink = new OkHttpSink(client, agentUrl, path, true)
@@ -88,7 +89,7 @@ class OkHttpSinkTest extends DDSpecification {
     // them if it's possible not to.
     setup:
     String agentUrl = "http://localhost:8126"
-    String path = "v0.5/stats"
+    String path = V6_METRICS_ENDPOINT
     CountDownLatch latch = new CountDownLatch(2)
     EventListener listener = new BlockingListener(latch)
     OkHttpClient client = Mock(OkHttpClient)

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SerializingMetricWriterTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SerializingMetricWriterTest.groovy
@@ -23,7 +23,7 @@ class SerializingMetricWriterTest extends DDSpecification {
     setup:
     long startTime = MILLISECONDS.toNanos(System.currentTimeMillis())
     long duration = SECONDS.toNanos(10)
-    WellKnownTags wellKnownTags = new WellKnownTags("hostname", "env", "service", "version")
+    WellKnownTags wellKnownTags = new WellKnownTags("runtimeid", "hostname", "env", "service", "version")
     ValidatingSink sink = new ValidatingSink(wellKnownTags, startTime, duration, content)
     SerializingMetricWriter writer = new SerializingMetricWriter(wellKnownTags, sink, 128)
 
@@ -80,7 +80,11 @@ class SerializingMetricWriterTest extends DDSpecification {
     void accept(int messageCount, ByteBuffer buffer) {
       MessageUnpacker unpacker = MessagePack.newDefaultUnpacker(buffer)
       int mapSize = unpacker.unpackMapHeader()
-      assert mapSize == 4
+      assert mapSize == 6
+      assert unpacker.unpackString() == "RuntimeId"
+      assert unpacker.unpackString() == wellKnownTags.getRuntimeId() as String
+      assert unpacker.unpackString() == "Seq"
+      assert unpacker.unpackLong() == 0L
       assert unpacker.unpackString() == "Hostname"
       assert unpacker.unpackString() == wellKnownTags.getHostname() as String
       assert unpacker.unpackString() == "Env"

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddagent/DDAgentFeaturesDiscoveryTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddagent/DDAgentFeaturesDiscoveryTest.groovy
@@ -18,6 +18,8 @@ import java.nio.file.Paths
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
+import static datadog.trace.common.writer.ddagent.DDAgentFeaturesDiscovery.V6_METRICS_ENDPOINT
+
 class DDAgentFeaturesDiscoveryTest extends DDSpecification {
 
   @Shared
@@ -39,7 +41,7 @@ class DDAgentFeaturesDiscoveryTest extends DDSpecification {
 
     then:
     1 * client.newCall(_) >> { Request request -> infoResponse(request, INFO_RESPONSE) }
-    features.getMetricsEndpoint() == "v0.5/stats"
+    features.getMetricsEndpoint() == V6_METRICS_ENDPOINT
     features.supportsMetrics()
     features.getTraceEndpoint() == "v0.5/traces"
     !features.supportsDropping()
@@ -55,7 +57,7 @@ class DDAgentFeaturesDiscoveryTest extends DDSpecification {
 
     then:
     1 * client.newCall(_) >> { Request request -> infoResponse(request, INFO_WITH_CLIENT_DROPPING_RESPONSE) }
-    features.getMetricsEndpoint() == "v0.5/stats"
+    features.getMetricsEndpoint() == V6_METRICS_ENDPOINT
     features.supportsMetrics()
     features.getTraceEndpoint() == "v0.5/traces"
     features.supportsDropping()
@@ -71,7 +73,7 @@ class DDAgentFeaturesDiscoveryTest extends DDSpecification {
 
     then:
     1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/info" }) >> { Request request -> notFound(request) }
-    0 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.5/stats" }) >> { Request request -> clientError(request) }
+    0 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.6/stats" }) >> { Request request -> clientError(request) }
     1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.5/traces" }) >> { Request request -> clientError(request) }
     features.getMetricsEndpoint() == null
     !features.supportsMetrics()
@@ -89,7 +91,7 @@ class DDAgentFeaturesDiscoveryTest extends DDSpecification {
 
     then:
     1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/info" }) >> { Request request -> notFound(request) }
-    0 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.5/stats" }) >> { Request request -> success(request) }
+    0 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.6/stats" }) >> { Request request -> success(request) }
     1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.5/traces" }) >> { Request request -> success(request) }
     features.getMetricsEndpoint() == null
     !features.supportsMetrics()
@@ -107,7 +109,7 @@ class DDAgentFeaturesDiscoveryTest extends DDSpecification {
 
     then:
     1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/info" }) >> { Request request -> notFound(request) }
-    0 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.5/stats" }) >> { Request request -> clientError(request) }
+    0 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.6/stats" }) >> { Request request -> clientError(request) }
     1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.4/traces" }) >> { Request request -> clientError(request) }
     features.getMetricsEndpoint() == null
     !features.supportsMetrics()
@@ -125,7 +127,7 @@ class DDAgentFeaturesDiscoveryTest extends DDSpecification {
 
     then:
     1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/info" }) >> { Request request -> notFound(request) }
-    0 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.5/stats" }) >> { Request request -> clientError(request) }
+    0 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.6/stats" }) >> { Request request -> clientError(request) }
     1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.5/traces" }) >> { Request request -> notFound(request) }
     1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.4/traces" }) >> { Request request -> clientError(request) }
     features.getMetricsEndpoint() == null
@@ -144,7 +146,7 @@ class DDAgentFeaturesDiscoveryTest extends DDSpecification {
 
     then:
     1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/info" }) >> { Request request -> notFound(request) }
-    0 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.5/stats" }) >> { Request request -> notFound(request) }
+    0 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.6/stats" }) >> { Request request -> notFound(request) }
     1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.5/traces" }) >> { Request request -> notFound(request) }
     1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.4/traces" }) >> { Request request -> clientError(request) }
     features.getMetricsEndpoint() == null
@@ -163,7 +165,7 @@ class DDAgentFeaturesDiscoveryTest extends DDSpecification {
 
     then:
     1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/info" }) >> { Request request -> notFound(request) }
-    0 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.5/stats" }) >> { Request request -> notFound(request) }
+    0 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.6/stats" }) >> { Request request -> notFound(request) }
     1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.5/traces" }) >> { Request request -> notFound(request) }
     1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.4/traces" }) >> { Request request -> notFound(request) }
     1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.3/traces" }) >> { Request request -> clientError(request) }
@@ -184,7 +186,7 @@ class DDAgentFeaturesDiscoveryTest extends DDSpecification {
     then: "metrics endpoint not probed, metrics and dropping not supported"
     1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/info" }) >> { Request request -> notFound(request) }
     1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.5/traces" }) >> { Request request -> success(request) }
-    0 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.5/stats" })
+    0 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.6/stats" })
     !features.supportsMetrics()
     !features.supportsDropping()
     !(features as DroppingPolicy).active()

--- a/dd-trace-core/src/test/resources/agent-features/agent-info-with-client-dropping.json
+++ b/dd-trace-core/src/test/resources/agent-features/agent-info-with-client-dropping.json
@@ -8,7 +8,7 @@
     "/v0.4/traces",
     "/v0.4/services",
     "/v0.5/traces",
-    "/v0.5/stats",
+    "/v0.6/stats",
     "/profiling/v1/input"
   ],
   "feature_flags": [

--- a/dd-trace-core/src/test/resources/agent-features/agent-info.json
+++ b/dd-trace-core/src/test/resources/agent-features/agent-info.json
@@ -8,7 +8,7 @@
     "/v0.4/traces",
     "/v0.4/services",
     "/v0.5/traces",
-    "/v0.5/stats",
+    "/v0.6/stats",
     "/profiling/v1/input"
   ],
   "feature_flags": [

--- a/dd-trace-core/src/traceAgentTest/groovy/MetricsIntegrationTest.groovy
+++ b/dd-trace-core/src/traceAgentTest/groovy/MetricsIntegrationTest.groovy
@@ -8,6 +8,7 @@ import datadog.trace.common.metrics.MetricKey
 import datadog.trace.common.metrics.OkHttpSink
 import datadog.trace.common.metrics.SerializingMetricWriter
 import datadog.trace.test.util.DDSpecification
+import spock.lang.Ignore
 import spock.lang.Requires
 
 import java.util.concurrent.CopyOnWriteArrayList
@@ -18,6 +19,7 @@ import static datadog.trace.api.Platform.isJavaVersionAtLeast
 import static datadog.trace.common.metrics.EventListener.EventType.OK
 import static java.util.concurrent.TimeUnit.SECONDS
 
+@Ignore("requires unreleased trace agent image to pass")
 @Requires({
   "true" == System.getenv("CI") && isJavaVersionAtLeast(8)
 })

--- a/dd-trace-core/src/traceAgentTest/groovy/MetricsIntegrationTest.groovy
+++ b/dd-trace-core/src/traceAgentTest/groovy/MetricsIntegrationTest.groovy
@@ -33,7 +33,7 @@ class MetricsIntegrationTest extends DDSpecification {
 
     when:
     SerializingMetricWriter writer = new SerializingMetricWriter(
-      new WellKnownTags("hostname", "env", "service", "version"),
+      new WellKnownTags("runtimeid","hostname", "env", "service", "version"),
       sink
       )
     writer.startBucket(2, System.nanoTime(), SECONDS.toNanos(10))

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -1150,7 +1150,7 @@ public class Config {
   }
 
   public WellKnownTags getWellKnownTags() {
-    return new WellKnownTags(getHostName(), getEnv(), serviceName, getVersion());
+    return new WellKnownTags(getRuntimeId(), getHostName(), getEnv(), serviceName, getVersion());
   }
 
   public Set<String> getMetricsIgnoredResources() {

--- a/internal-api/src/main/java/datadog/trace/api/WellKnownTags.java
+++ b/internal-api/src/main/java/datadog/trace/api/WellKnownTags.java
@@ -4,17 +4,27 @@ import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 
 public class WellKnownTags {
 
+  private final UTF8BytesString runtimeId;
   private final UTF8BytesString hostname;
   private final UTF8BytesString env;
   private final UTF8BytesString service;
   private final UTF8BytesString version;
 
   public WellKnownTags(
-      CharSequence hostname, CharSequence env, CharSequence service, CharSequence version) {
+      CharSequence runtimeId,
+      CharSequence hostname,
+      CharSequence env,
+      CharSequence service,
+      CharSequence version) {
+    this.runtimeId = UTF8BytesString.create(runtimeId);
     this.hostname = UTF8BytesString.create(hostname);
     this.env = UTF8BytesString.create(env);
     this.service = UTF8BytesString.create(service);
     this.version = UTF8BytesString.create(version);
+  }
+
+  public UTF8BytesString getRuntimeId() {
+    return runtimeId;
   }
 
   public UTF8BytesString getHostname() {

--- a/internal-api/src/test/groovy/datadog/trace/api/WellKnownTagsTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/WellKnownTagsTest.groovy
@@ -7,8 +7,9 @@ class WellKnownTagsTest extends DDSpecification {
   def "well known tags doesn't modify its inputs"() {
     given:
     WellKnownTags wellKnownTags =
-      new WellKnownTags("hostname", "env", "service", "version")
+      new WellKnownTags("runtimeid", "hostname", "env", "service", "version")
     expect:
+    wellKnownTags.getRuntimeId() as String == "runtimeid"
     wellKnownTags.getHostname() as String == "hostname"
     wellKnownTags.getEnv() as String == "env"
     wellKnownTags.getService() as String == "service"

--- a/utils/histograms/src/main/java/datadog/trace/core/histogram/DDSketchHistogram.java
+++ b/utils/histograms/src/main/java/datadog/trace/core/histogram/DDSketchHistogram.java
@@ -12,7 +12,7 @@ public final class DDSketchHistogram implements Histogram, HistogramFactory {
   public DDSketchHistogram() {
     this(
         new DDSketch(
-            new BitwiseLinearlyInterpolatedMapping(0.01),
+            new BitwiseLinearlyInterpolatedMapping(1.0 / 128.0),
             () -> new CollapsingLowestDenseStore(1024)));
   }
 


### PR DESCRIPTION
* Add fields to uniquely identify payloads
* Target v0.6/stats endpoint as v0.5/stats has been retired
* Adjust relative accuracy to match format used elsewhere