### PR TITLE
Various flaky test fixes

### DIFF
--- a/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/CouchbaseAsyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/CouchbaseAsyncClientTest.groovy
@@ -15,13 +15,7 @@ import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 @Retry
 @Unroll
 class CouchbaseAsyncClientTest extends AbstractCouchbaseTest {
-  static final int TIMEOUT = 10
-
-  @Override
-  boolean useStrictTraceWrites() {
-    // TODO fix this by making sure that spans get closed properly
-    return false
-  }
+  static final int TIMEOUT = 30
 
   def "test hasBucket #type"() {
     setup:

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/AsyncPropagatingDisableInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/AsyncPropagatingDisableInstrumentation.java
@@ -32,7 +32,10 @@ public final class AsyncPropagatingDisableInstrumentation implements Instrumente
   public AgentBuilder instrument(AgentBuilder agentBuilder) {
     return new DisableAsyncInstrumentation(
             extendsClass(named("rx.Scheduler$Worker")), named("schedulePeriodically"))
-        .instrument(agentBuilder);
+        .instrument(
+            new DisableAsyncInstrumentation(
+                    named("rx.internal.operators.OperatorTimeoutBase"), named("call"))
+                .instrument(agentBuilder));
   }
 
   @Override


### PR DESCRIPTION
1. `AggregateMetricTest`: "consistent under concurrent attempts to read and write" - the reader fails to terminate every now and then because of the termination condition. 
2. `FootPrintTest`: The cause was that sometimes it can take a while for JOL to parse the object graph, leading to a timeout. The timeout is increased. Also previously only tested the size dominated by `aggregator.aggregator.aggregates`, which is brittle to refactoring, but now asserts about the relative increase (which allows for exclusion of things like classes and class loaders) in size dominated by the root class, which requires a larger threshold. 
3. `CouchbaseAsyncClientTest` - I believe this test fails because it is running in non-strict mode and is nondeterministic. I added instrumentation to disable async propagation in `rx.internal.operators.OperatorTimeout.call` to make it pass in strict mode, and increased the timeout.