### PR TITLE
Use PID controller to modulate the target window sample rate

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/ProfilingSystem.java
+++ b/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/ProfilingSystem.java
@@ -190,10 +190,11 @@ public final class ProfilingSystem {
       final RecordingType recordingType = RecordingType.CONTINUOUS;
       try {
         log.debug("Creating profiler snapshot");
-        final RecordingData recordingData = recording.snapshot(lastSnapshot, Instant.now());
+        Instant now = Instant.now();
+        final RecordingData recordingData = recording.snapshot(lastSnapshot, now);
         // The hope here is that we do not get chunk rotated after taking snapshot and before we
-        // take this timestamp otherwise we will start losing data.
-        lastSnapshot = Instant.now();
+        // take this timestamp otherwise we will start losing data
+        lastSnapshot = now;
         if (recordingData != null) {
           dataListener.onNewData(recordingType, recordingData);
         }

--- a/dd-java-agent/agent-profiling/profiling-uploader/src/main/java/com/datadog/profiling/uploader/ProfileUploader.java
+++ b/dd-java-agent/agent-profiling/profiling-uploader/src/main/java/com/datadog/profiling/uploader/ProfileUploader.java
@@ -149,9 +149,6 @@ public final class ProfileUploader {
     }
   }
 
-  static final int SEED_EXPECTED_REQUEST_SIZE = 2 * 1024 * 1024; // 2MB;
-  static final int REQUEST_SIZE_HISTORY_SIZE = 10;
-
   private final ExecutorService okHttpExecutorService;
   private final OkHttpClient client;
   private final Callback responseCallback;

--- a/internal-api/internal-api-8/src/main/java/datadog/trace/api/sampling/AdaptiveSampler.java
+++ b/internal-api/internal-api-8/src/main/java/datadog/trace/api/sampling/AdaptiveSampler.java
@@ -70,7 +70,6 @@ public final class AdaptiveSampler {
 
   // these attributes are accessed solely from the window maintenance thread
   private double totalCountRunningAverage = 0d;
-  private double avgSamples;
 
   // accessed exclusively from the window maintenance task - does not require any synchronization
   private int countsSlotIdx = 0;
@@ -81,7 +80,8 @@ public final class AdaptiveSampler {
    * See https://en.wikipedia.org/wiki/PID_controller for more details.
    * The following fields are the integration, derivation and proportional coefficients, respectively.
    * The values were derived based on the AdaptiveSamplerTest repeatable runs such that the error margins
-   * are acceptable.
+   * are acceptable. These parameters are validated for up to 50000 events per window which should
+   * cover the typical range of frequencies of incoming data.
    */
   private static final double KI = 0.02d;
   private static final double KD = 0.8d;

--- a/internal-api/internal-api-8/src/test/java/datadog/trace/api/sampling/AdaptiveSamplerTest.java
+++ b/internal-api/internal-api-8/src/test/java/datadog/trace/api/sampling/AdaptiveSamplerTest.java
@@ -21,8 +21,9 @@ import org.apache.commons.math3.stat.descriptive.moment.Mean;
 import org.apache.commons.math3.stat.descriptive.moment.StandardDeviation;
 import org.apache.commons.math3.util.Pair;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -173,7 +174,7 @@ class AdaptiveSamplerTest {
 
   private static final StandardDeviation STANDARD_DEVIATION = new StandardDeviation();
   private static final int WINDOWS = 120;
-  private static final int SAMPLES_PER_WINDOW = 100;
+  private static final int SAMPLES_PER_WINDOW = 20;
   private static final int LOOKBACK = 30;
 
   @Mock AgentTaskScheduler taskScheduler;
@@ -192,91 +193,105 @@ class AdaptiveSamplerTest {
             same(TimeUnit.NANOSECONDS));
   }
 
-  @Test
-  public void testBurstLowProbability() throws Exception {
-    testSampler(new BurstingWindowsEventsSupplier(0.1d, 5, 5000), 40);
+  @ParameterizedTest
+  @CsvSource({"5, 50", "10, 50", "50, 50", "100, 50", "300, 50"})
+  public void testBurstLowProbability(int samples, int error) throws Exception {
+    testSampler(new BurstingWindowsEventsSupplier(0.1d, 5, 5000), samples, error);
   }
 
-  @Test
-  public void testBurstHighProbability() throws Exception {
-    testSampler(new BurstingWindowsEventsSupplier(0.8d, 5, 5000), 20);
+  @ParameterizedTest
+  @CsvSource({"5, 10", "10, 5", "50, 4", "100, 3", "300, 3"})
+  public void testBurstHighProbability(int samples, int error) throws Exception {
+    testSampler(new BurstingWindowsEventsSupplier(0.8d, 5, 5000), samples, error);
   }
 
-  @Test
-  public void testPoissonLowFrequency() throws Exception {
-    testSampler(new PoissonWindowEventsSupplier(153), 15);
+  @ParameterizedTest
+  @CsvSource({"5, 10", "10, 5", "50, 4", "100, 3", "300, 3"})
+  public void testPoissonLowFrequency(int samples, int error) throws Exception {
+    testSampler(new PoissonWindowEventsSupplier(153), samples, error);
   }
 
-  @Test
-  public void testPoissonMidFrequency() throws Exception {
-    testSampler(new PoissonWindowEventsSupplier(283), 15);
+  @ParameterizedTest
+  @CsvSource({"5, 10", "10, 5", "50, 4", "100, 3", "300, 3"})
+  public void testPoissonMidFrequency(int samples, int error) throws Exception {
+    testSampler(new PoissonWindowEventsSupplier(283), samples, error);
   }
 
-  @Test
-  public void testPoissonHighFrequency() throws Exception {
-    testSampler(new PoissonWindowEventsSupplier(1013), 15);
+  @ParameterizedTest
+  @CsvSource({"5, 10", "10, 5", "50, 4", "100, 3", "300, 3"})
+  public void testPoissonHighFrequency(int samples, int error) throws Exception {
+    testSampler(new PoissonWindowEventsSupplier(1013), samples, error);
   }
 
-  @Test
-  public void testConstantVeryLowLoad() throws Exception {
-    testSampler(new ConstantWindowsEventsSupplier(1), 10);
+  @ParameterizedTest
+  @CsvSource({"5, 10", "10, 5", "50, 4", "100, 3", "300, 3"})
+  public void testConstantVeryLowLoad(int samples, int error) throws Exception {
+    testSampler(new ConstantWindowsEventsSupplier(1), samples, error);
   }
 
-  @Test
-  public void testConstantLowLoad() throws Exception {
-    testSampler(new ConstantWindowsEventsSupplier(153), 15);
+  @ParameterizedTest
+  @CsvSource({"5, 10", "10, 5", "50, 4", "100, 3", "300, 3"})
+  public void testConstantLowLoad(int samples, int error) throws Exception {
+    testSampler(new ConstantWindowsEventsSupplier(153), samples, error);
   }
 
-  @Test
-  public void testConstantMediumLoad() throws Exception {
-    testSampler(new ConstantWindowsEventsSupplier(713), 15);
+  @ParameterizedTest
+  @CsvSource({"5, 10", "10, 5", "50, 4", "100, 3", "300, 3"})
+  public void testConstantMediumLoad(int samples, int error) throws Exception {
+    testSampler(new ConstantWindowsEventsSupplier(713), samples, error);
   }
 
-  @Test
-  public void testConstantHighLoad() throws Exception {
-    testSampler(new ConstantWindowsEventsSupplier(5211), 15);
+  @ParameterizedTest
+  @CsvSource({"5, 10", "10, 5", "50, 4", "100, 3", "300, 3"})
+  public void testConstantHighLoad(int samples, int error) throws Exception {
+    testSampler(new ConstantWindowsEventsSupplier(5211), samples, error);
   }
 
-  @Test
-  public void testRepeatingSemiRandom() throws Exception {
+  @ParameterizedTest
+  @CsvSource({"5, 10", "10, 5", "50, 4", "100, 3", "300, 3"})
+  public void testRepeatingSemiRandom(int samples, int error) throws Exception {
     testSampler(
         new RepeatingWindowsEventsSupplier(180, 200, 0, 0, 0, 1500, 1000, 430, 200, 115, 115, 900),
-        15);
+        samples,
+        error);
   }
 
-  @Test
-  public void testRepeatingRegularStartWithBurst() throws Exception {
-    testSampler(new RepeatingWindowsEventsSupplier(1000, 0, 1000, 0, 1000, 0), 15);
+  @ParameterizedTest
+  @CsvSource({"5, 10", "10, 5", "50, 4", "100, 3", "300, 3"})
+  public void testRepeatingRegularStartWithBurst(int samples, int error) throws Exception {
+    testSampler(new RepeatingWindowsEventsSupplier(1000, 0, 1000, 0, 1000, 0), samples, error);
   }
 
-  @Test
-  public void testRepeatingRegularStartWithLow() throws Exception {
-    testSampler(new RepeatingWindowsEventsSupplier(0, 1000, 0, 1000, 0, 1000), 15);
+  @ParameterizedTest
+  @CsvSource({"5, 10", "10, 5", "50, 4", "100, 3", "300, 3"})
+  public void testRepeatingRegularStartWithLow(int samples, int error) throws Exception {
+    testSampler(new RepeatingWindowsEventsSupplier(0, 1000, 0, 1000, 0, 1000), samples, error);
   }
 
-  private void testSampler(final IntSupplier windowEventsSupplier, final int maxErrorPercent)
+  private void testSampler(
+      final IntSupplier windowEventsSupplier, final int samples, final int maxErrorPercent)
       throws Exception {
     int iterations =
         Integer.parseInt(
-            System.getProperty("com.datadog.profiling.exceptions.test-iterations", "1"));
+            System.getProperty("com.datadog.profiling.exceptions.test-iterations", "100"));
     for (int i = 0; i < iterations; i++) {
-      testSamplerInline(windowEventsSupplier, maxErrorPercent);
+      testSamplerInline(windowEventsSupplier, samples, maxErrorPercent);
       for (int numOfThreads = 1; numOfThreads <= 64; numOfThreads *= 2) {
-        testSamplerConcurrently(numOfThreads, windowEventsSupplier, maxErrorPercent);
+        testSamplerConcurrently(numOfThreads, windowEventsSupplier, samples, maxErrorPercent);
       }
     }
   }
 
   private void testSamplerInline(
-      final IntSupplier windowEventsSupplier, final int maxErrorPercent) {
+      final IntSupplier windowEventsSupplier, final int samples, final int maxErrorPercent) {
     log.info(
         "> mode: {}, windows: {}, SAMPLES_PER_WINDOW: {}, LOOKBACK: {}, max error: {}%",
-        windowEventsSupplier, WINDOWS, SAMPLES_PER_WINDOW, LOOKBACK, maxErrorPercent);
+        windowEventsSupplier, WINDOWS, samples, LOOKBACK, maxErrorPercent);
     final AdaptiveSampler sampler =
-        new AdaptiveSampler(WINDOW_DURATION, SAMPLES_PER_WINDOW, LOOKBACK, taskScheduler);
+        new AdaptiveSampler(WINDOW_DURATION, samples, LOOKBACK, taskScheduler);
 
     // simulate event generation and sampling for the given number of sampling windows
-    final long expectedSamples = WINDOWS * SAMPLES_PER_WINDOW;
+    final long expectedSamples = WINDOWS * samples;
 
     long allSamples = 0L;
     long allEvents = 0L;
@@ -408,7 +423,10 @@ class AdaptiveSamplerTest {
   }
 
   private void testSamplerConcurrently(
-      final int threadCount, final IntSupplier windowEventsSupplier, final int maxErrorPercent)
+      final int threadCount,
+      final IntSupplier windowEventsSupplier,
+      int windowSamples,
+      final int maxErrorPercent)
       throws Exception {
     log.info(
         "> threads: {}, mode: {}, windows: {}, SAMPLES_PER_WINDOW: {}, LOOKBACK: {}, max error: {}",
@@ -423,12 +441,12 @@ class AdaptiveSamplerTest {
      * This test attempts to simulate concurrent computations by making sure that sampling requests and the window maintenance routine are run in parallel.
      * It does not provide coverage of all possible execution sequences but should be good enough for getting the 'ballpark' numbers.
      */
-    final long expectedSamples = SAMPLES_PER_WINDOW * WINDOWS;
+    final long expectedSamples = windowSamples * WINDOWS;
     final AtomicLong allSamples = new AtomicLong(0);
     final AtomicLong receivedEvents = new AtomicLong(0);
 
     final AdaptiveSampler sampler =
-        new AdaptiveSampler(WINDOW_DURATION, SAMPLES_PER_WINDOW, LOOKBACK, taskScheduler);
+        new AdaptiveSampler(WINDOW_DURATION, windowSamples, LOOKBACK, taskScheduler);
     final CyclicBarrier startBarrier = new CyclicBarrier(threadCount);
     final CyclicBarrier endBarrier = new CyclicBarrier(threadCount, this::rollWindow);
     final Mean[] means = new Mean[threadCount];


### PR DESCRIPTION
This is an attempt to use a [PID controller](https://en.wikipedia.org/wiki/PID_controller) for modulating the next window sample rate instead of relying on average data from a number of previous windows.

As expected, this change improves the average error margin (from cca. 15% down to cca. 5%) while not deteriorating the worst case of a very bursty process where single bursts of very hight amounts of events are interspersed with comparatively long periods with almost no events.