### PR TITLE
Reusable StatsD client

### DIFF
--- a/dd-java-agent/agent-jmxfetch/src/main/java/datadog/trace/agent/jmxfetch/AgentStatsdReporter.java
+++ b/dd-java-agent/agent-jmxfetch/src/main/java/datadog/trace/agent/jmxfetch/AgentStatsdReporter.java
@@ -1,0 +1,58 @@
+package datadog.trace.agent.jmxfetch;
+
+import datadog.trace.api.StatsDClient;
+import org.datadog.jmxfetch.Instance;
+import org.datadog.jmxfetch.JmxAttribute;
+import org.datadog.jmxfetch.reporter.Reporter;
+
+/** Based on {@link org.datadog.jmxfetch.reporter.StatsdReporter}. */
+public final class AgentStatsdReporter extends Reporter {
+
+  private final StatsDClient statsd;
+
+  public AgentStatsdReporter(final StatsDClient statsd) {
+    this.statsd = statsd;
+  }
+
+  @Override
+  protected void sendMetricPoint(
+      final String metricType, final String metricName, final double value, final String[] tags) {
+    if ("monotonic_count".equals(metricType)) {
+      statsd.count(metricName, (long) value, tags);
+    } else if ("histogram".equals(metricType)) {
+      statsd.histogram(metricName, value, tags);
+    } else { // JMXFetch treats everything else as a gauge
+      statsd.gauge(metricName, value, tags);
+    }
+  }
+
+  @Override
+  protected void doSendServiceCheck(
+      final String serviceCheckName,
+      final String status,
+      final String message,
+      final String[] tags) {
+    statsd.serviceCheck(serviceCheckName, status, message, tags);
+  }
+
+  @Override
+  public void displayMetricReached() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void displayMatchingAttributeName(
+      final JmxAttribute jmxAttribute, final int rank, final int limit) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void displayNonMatchingAttributeName(final JmxAttribute jmxAttribute) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void displayInstanceName(final Instance instance) {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/dd-java-agent/src/test/groovy/datadog/trace/agent/JMXFetchTest.groovy
+++ b/dd-java-agent/src/test/groovy/datadog/trace/agent/JMXFetchTest.groovy
@@ -37,10 +37,11 @@ class JMXFetchTest extends Specification {
     DatagramPacket packet = new DatagramPacket(buf, buf.length)
     jmxStatsSocket.receive(packet)
     String received = new String(packet.getData(), 0, packet.getLength())
+    def tags = (received =~ /\|#(.*)/)[0][1].tokenize(',')
 
     expect:
     returnCode == 0
-    received.contains("#service:${JmxStartedChecker.getName()}")
+    tags.contains("service:${JmxStartedChecker.getName()}" as String)
   }
 
   def "Agent loads when JmxFetch is misconfigured"() {

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/AgentTestRunner.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/AgentTestRunner.groovy
@@ -4,12 +4,12 @@ import ch.qos.logback.classic.Level
 import ch.qos.logback.classic.Logger
 import ch.qos.logback.classic.util.ContextInitializer
 import com.google.common.collect.Sets
-import com.timgroup.statsd.StatsDClient
 import datadog.trace.agent.test.asserts.ListWriterAssert
 import datadog.trace.agent.tooling.AgentInstaller
 import datadog.trace.agent.tooling.Instrumenter
 import datadog.trace.agent.tooling.TracerInstaller
 import datadog.trace.api.Config
+import datadog.trace.api.StatsDClient
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer.TracerAPI
 import datadog.trace.common.writer.ListWriter

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -44,6 +44,7 @@ public final class ConfigDefaults {
   static final boolean DEFAULT_JMX_FETCH_ENABLED = true;
   static final boolean DEFAULT_TRACE_AGENT_V05_ENABLED = false;
 
+  static final int DEFAULT_DOGSTATSD_START_DELAY = 15; // seconds
   static final int DEFAULT_JMX_FETCH_STATSD_PORT = 8125;
 
   static final boolean DEFAULT_HEALTH_METRICS_ENABLED = true;

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/GeneralConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/GeneralConfig.java
@@ -25,6 +25,7 @@ public final class GeneralConfig {
   @Deprecated // Use dd.tags instead
   public static final String GLOBAL_TAGS = "trace.global.tags";
 
+  public static final String DOGSTATSD_START_DELAY = "dogstatsd.start-delay";
   public static final String RUNTIME_METRICS_ENABLED = "runtime.metrics.enabled";
 
   public static final String HEALTH_METRICS_ENABLED = "trace.health.metrics.enabled";

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/JmxFetchConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/JmxFetchConfig.java
@@ -9,6 +9,7 @@ package datadog.trace.api.config;
 public final class JmxFetchConfig {
   public static final String JMX_TAGS = "trace.jmx.tags";
   public static final String JMX_FETCH_ENABLED = "jmxfetch.enabled";
+  public static final String JMX_FETCH_START_DELAY = "jmxfetch.start-delay";
   public static final String JMX_FETCH_CONFIG_DIR = "jmxfetch.config.dir";
   public static final String JMX_FETCH_CONFIG = "jmxfetch.config";
   @Deprecated public static final String JMX_FETCH_METRICS_CONFIGS = "jmxfetch.metrics-configs";

--- a/dd-trace-core/dd-trace-core.gradle
+++ b/dd-trace-core/dd-trace-core.gradle
@@ -18,6 +18,7 @@ excludedClassesCoverage += [
   'datadog.trace.common.writer.ddagent.unixdomainsockets.UnixDomainSocketFactory',
   'datadog.trace.core.scopemanager.ScopeInterceptor.DelegatingScope',
   'datadog.trace.core.jfr.DDNoopScopeEventFactory',
+  'datadog.trace.core.monitor.LoggingStatsDClient',
   'datadog.trace.core.PendingTraceBuffer.DelayingPendingTraceBuffer.FlushElement',
   'datadog.trace.core.StatusLogger',
   'datadog.trace.core.scopemanager.ContinuableScopeManager.SingleContinuation'

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/DDAgentWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/DDAgentWriter.java
@@ -8,8 +8,8 @@ import static datadog.trace.api.sampling.PrioritySampling.UNSET;
 import static datadog.trace.common.writer.ddagent.Prioritization.FAST_LANE;
 import static datadog.trace.core.http.OkHttpUtils.buildHttpClient;
 
-import com.timgroup.statsd.NoOpStatsDClient;
 import datadog.trace.api.Config;
+import datadog.trace.api.StatsDClient;
 import datadog.trace.common.writer.ddagent.DDAgentApi;
 import datadog.trace.common.writer.ddagent.DDAgentFeaturesDiscovery;
 import datadog.trace.common.writer.ddagent.DDAgentResponseListener;
@@ -65,7 +65,7 @@ public class DDAgentWriter implements Writer {
     String unixDomainSocket = DEFAULT_AGENT_UNIX_DOMAIN_SOCKET;
     long timeoutMillis = TimeUnit.SECONDS.toMillis(DEFAULT_AGENT_TIMEOUT);
     int traceBufferSize = BUFFER_SIZE;
-    HealthMetrics healthMetrics = new HealthMetrics(new NoOpStatsDClient());
+    HealthMetrics healthMetrics = new HealthMetrics(StatsDClient.NO_OP);
     int flushFrequencySeconds = 1;
     Monitoring monitoring = Monitoring.DISABLED;
     boolean traceAgentV05Enabled = Config.get().isTraceAgentV05Enabled();

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/MultiWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/MultiWriter.java
@@ -2,8 +2,8 @@ package datadog.trace.common.writer;
 
 import static datadog.trace.bootstrap.instrumentation.api.WriterConstants.MULTI_WRITER_TYPE;
 
-import com.timgroup.statsd.StatsDClient;
 import datadog.trace.api.Config;
+import datadog.trace.api.StatsDClient;
 import datadog.trace.common.sampling.Sampler;
 import datadog.trace.core.DDSpan;
 import datadog.trace.core.monitor.Monitoring;

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/WriterFactory.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/WriterFactory.java
@@ -6,10 +6,10 @@ import static datadog.trace.common.writer.ddagent.Prioritization.ENSURE_TRACE;
 import static datadog.trace.common.writer.ddagent.Prioritization.FAST_LANE;
 import static datadog.trace.core.http.OkHttpUtils.buildHttpClient;
 
-import com.timgroup.statsd.StatsDClient;
 import datadog.common.container.ServerlessInfo;
 import datadog.trace.api.Config;
 import datadog.trace.api.ConfigDefaults;
+import datadog.trace.api.StatsDClient;
 import datadog.trace.api.config.TracerConfig;
 import datadog.trace.common.sampling.Sampler;
 import datadog.trace.common.writer.ddagent.DDAgentApi;

--- a/dd-trace-core/src/main/java/datadog/trace/core/monitor/CPUTimer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/monitor/CPUTimer.java
@@ -1,6 +1,6 @@
 package datadog.trace.core.monitor;
 
-import com.timgroup.statsd.StatsDClient;
+import datadog.trace.api.StatsDClient;
 import datadog.trace.core.util.SystemAccess;
 
 public class CPUTimer extends Timer {

--- a/dd-trace-core/src/main/java/datadog/trace/core/monitor/DDAgentStatsDClient.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/monitor/DDAgentStatsDClient.java
@@ -1,0 +1,94 @@
+package datadog.trace.core.monitor;
+
+import com.timgroup.statsd.ServiceCheck;
+import datadog.trace.api.Function;
+import datadog.trace.api.StatsDClient;
+
+final class DDAgentStatsDClient implements StatsDClient {
+  private final DDAgentStatsDConnection connection;
+  private final Function<String, String> nameMapping;
+  private final Function<String[], String[]> tagMapping;
+
+  DDAgentStatsDClient(
+      final DDAgentStatsDConnection connection,
+      final Function<String, String> nameMapping,
+      final Function<String[], String[]> tagMapping) {
+    this.connection = connection;
+    this.nameMapping = nameMapping;
+    this.tagMapping = tagMapping;
+
+    connection.acquire();
+  }
+
+  @Override
+  public void incrementCounter(final String metricName, final String... tags) {
+    connection.statsd.count(nameMapping.apply(metricName), 1L, tagMapping.apply(tags));
+  }
+
+  @Override
+  public void count(final String metricName, final long value, final String... tags) {
+    connection.statsd.count(nameMapping.apply(metricName), value, tagMapping.apply(tags));
+  }
+
+  @Override
+  public void gauge(final String metricName, final long value, final String... tags) {
+    connection.statsd.recordGaugeValue(
+        nameMapping.apply(metricName), value, tagMapping.apply(tags));
+  }
+
+  @Override
+  public void gauge(final String metricName, final double value, final String... tags) {
+    connection.statsd.recordGaugeValue(
+        nameMapping.apply(metricName), value, tagMapping.apply(tags));
+  }
+
+  @Override
+  public void histogram(final String metricName, final long value, final String... tags) {
+    connection.statsd.recordHistogramValue(
+        nameMapping.apply(metricName), value, tagMapping.apply(tags));
+  }
+
+  @Override
+  public void histogram(final String metricName, final double value, final String... tags) {
+    connection.statsd.recordHistogramValue(
+        nameMapping.apply(metricName), value, tagMapping.apply(tags));
+  }
+
+  @Override
+  public void serviceCheck(
+      final String serviceCheckName,
+      final String status,
+      final String message,
+      final String... tags) {
+
+    ServiceCheck serviceCheck =
+        ServiceCheck.builder()
+            .withName(nameMapping.apply(serviceCheckName))
+            .withStatus(serviceCheckStatus(status))
+            .withMessage(message)
+            .withTags(tagMapping.apply(tags))
+            .build();
+
+    connection.statsd.recordServiceCheckRun(serviceCheck);
+  }
+
+  static ServiceCheck.Status serviceCheckStatus(final String status) {
+    switch (status) {
+      case "OK":
+        return ServiceCheck.Status.OK;
+      case "WARN":
+      case "WARNING":
+        return ServiceCheck.Status.WARNING;
+      case "CRITICAL":
+      case "ERROR":
+        return ServiceCheck.Status.CRITICAL;
+      default:
+        return ServiceCheck.Status.UNKNOWN;
+    }
+  }
+
+  @Override
+  public void close() {
+    connection.release();
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/core/monitor/DDAgentStatsDClientManager.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/monitor/DDAgentStatsDClientManager.java
@@ -1,0 +1,124 @@
+package datadog.trace.core.monitor;
+
+import static datadog.trace.bootstrap.instrumentation.api.WriterConstants.LOGGING_WRITER_TYPE;
+
+import datadog.trace.api.Config;
+import datadog.trace.api.Function;
+import datadog.trace.api.Functions;
+import datadog.trace.api.StatsDClient;
+import datadog.trace.api.StatsDClientManager;
+import datadog.trace.api.cache.DDCache;
+import datadog.trace.api.cache.DDCaches;
+
+public final class DDAgentStatsDClientManager implements StatsDClientManager {
+  private static final DDAgentStatsDClientManager INSTANCE = new DDAgentStatsDClientManager();
+
+  private static final boolean USE_LOGGING_CLIENT =
+      LOGGING_WRITER_TYPE.equals(Config.get().getWriterType());
+
+  public static StatsDClientManager statsDClientManager() {
+    return INSTANCE;
+  }
+
+  private final DDCache<String, DDAgentStatsDConnection> connectionPool =
+      DDCaches.newUnboundedCache(4);
+
+  @Override
+  public StatsDClient statsDClient(
+      final String host, final int port, final String namespace, final String[] constantTags) {
+    Function<String, String> nameMapping = Functions.<String>zero();
+    Function<String[], String[]> tagMapping = Functions.<String[]>zero();
+
+    if (null != namespace) {
+      nameMapping = new NameResolver(namespace);
+    }
+
+    if (null != constantTags && constantTags.length > 0) {
+      tagMapping = new TagCombiner(constantTags);
+    }
+
+    if (USE_LOGGING_CLIENT) {
+      return new LoggingStatsDClient(host, port, nameMapping, tagMapping);
+    } else {
+      return new DDAgentStatsDClient(getConnection(host, port), nameMapping, tagMapping);
+    }
+  }
+
+  private DDAgentStatsDConnection getConnection(final String host, final int port) {
+    String connectionKey = "statsd:" + host + ':' + port;
+    return connectionPool.computeIfAbsent(
+        connectionKey,
+        new Function<String, DDAgentStatsDConnection>() {
+          @Override
+          public DDAgentStatsDConnection apply(final String unused) {
+            return new DDAgentStatsDConnection(host, port);
+          }
+        });
+  }
+
+  /** Resolves metrics names by prepending a namespace prefix. */
+  static final class NameResolver implements Function<String, String> {
+    private final DDCache<String, String> resolvedNames = DDCaches.newFixedSizeCache(32);
+    private final Function<String, String> namePrefixer;
+
+    NameResolver(final String namespace) {
+      this.namePrefixer =
+          new Function<String, String>() {
+            private final String prefix = namespace + '.';
+
+            @Override
+            public String apply(final String metricName) {
+              return prefix + metricName;
+            }
+          };
+    }
+
+    @Override
+    public String apply(final String metricName) {
+      return resolvedNames.computeIfAbsent(metricName, namePrefixer);
+    }
+  }
+
+  /** Combines per-call metrics tags with pre-packed constant tags. */
+  static final class TagCombiner implements Function<String[], String[]> {
+    private final DDCache<String[], String[]> combinedTags = DDCaches.newFixedSizeArrayKeyCache(64);
+    // single-element array containing the pre-packed constant tags
+    private final String[] packedTags;
+    private final Function<String[], String[]> tagsInserter;
+
+    public TagCombiner(final String[] constantTags) {
+      this.packedTags = pack(constantTags);
+      this.tagsInserter =
+          new Function<String[], String[]>() {
+            @Override
+            public String[] apply(final String[] tags) {
+              // extend per-call array by one to add the pre-packed constant tags
+              String[] result = new String[tags.length + 1];
+              System.arraycopy(tags, 0, result, 1, tags.length);
+              result[0] = packedTags[0];
+              return result;
+            }
+          };
+    }
+
+    @Override
+    public String[] apply(final String[] tags) {
+      if (null == tags || tags.length == 0) {
+        return packedTags; // no per-call tags so we can use the pre-packed array
+      } else {
+        return combinedTags.computeIfAbsent(tags, tagsInserter);
+      }
+    }
+
+    /**
+     * Packs the constant tags into a single element array using the same separator as DogStatsD.
+     */
+    private static String[] pack(final String[] tags) {
+      StringBuilder buf = new StringBuilder(tags[0]);
+      for (int i = 1; i < tags.length; i++) {
+        buf.append(',').append(tags[i]);
+      }
+      return new String[] {buf.toString()};
+    }
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/core/monitor/DDAgentStatsDConnection.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/monitor/DDAgentStatsDConnection.java
@@ -1,0 +1,119 @@
+package datadog.trace.core.monitor;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import com.timgroup.statsd.NoOpStatsDClient;
+import com.timgroup.statsd.NonBlockingStatsDClient;
+import com.timgroup.statsd.StatsDClientErrorHandler;
+import datadog.trace.api.Config;
+import datadog.trace.util.AgentTaskScheduler;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+final class DDAgentStatsDConnection implements StatsDClientErrorHandler {
+  private static final Logger log = LoggerFactory.getLogger(DDAgentStatsDConnection.class);
+
+  private static final com.timgroup.statsd.StatsDClient NO_OP = new NoOpStatsDClient();
+
+  private final String host;
+  private final int port;
+
+  private final AtomicInteger clientCount = new AtomicInteger(0);
+  volatile com.timgroup.statsd.StatsDClient statsd = NO_OP;
+
+  DDAgentStatsDConnection(final String host, final int port) {
+    this.host = host;
+    this.port = port;
+  }
+
+  @Override
+  public void handle(final Exception e) {
+    log.error(
+        "{} in StatsD client - {}", e.getClass().getSimpleName(), statsDAddress(host, port), e);
+  }
+
+  public void acquire() {
+    if (clientCount.getAndIncrement() == 0) {
+      scheduleConnect();
+    }
+  }
+
+  public void release() {
+    if (clientCount.decrementAndGet() == 0) {
+      doClose();
+    }
+  }
+
+  private void scheduleConnect() {
+    long remainingDelay =
+        Config.get().getDogStatsDStartDelay()
+            - MILLISECONDS.toSeconds(
+                System.currentTimeMillis() - Config.get().getStartTimeMillis());
+
+    if (remainingDelay > 0) {
+      if (log.isDebugEnabled()) {
+        log.debug(
+            "Scheduling StatsD connection in {} seconds - {}",
+            remainingDelay,
+            statsDAddress(host, port));
+      }
+      AgentTaskScheduler.INSTANCE.scheduleWithJitter(
+          ConnectTask.INSTANCE, this, remainingDelay, SECONDS);
+    } else {
+      doConnect();
+    }
+  }
+
+  private void doConnect() {
+    synchronized (this) {
+      if (NO_OP == statsd && clientCount.get() > 0) {
+        if (log.isDebugEnabled()) {
+          log.debug("Creating StatsD client - {}", statsDAddress(host, port));
+        }
+        // when using UDS, set "entity-id" to "none" to avoid having the DogStatsD
+        // server add origin tags (see https://github.com/DataDog/jmxfetch/pull/264)
+        String entityID = port == 0 ? "none" : null;
+        try {
+          statsd =
+              new NonBlockingStatsDClient(
+                  null, host, port, Integer.MAX_VALUE, null, this, entityID);
+        } catch (final Exception e) {
+          log.error("Unable to create StatsD client - {}", statsDAddress(host, port), e);
+        }
+      }
+    }
+  }
+
+  private void doClose() {
+    synchronized (this) {
+      if (NO_OP != statsd && 0 == clientCount.get()) {
+        if (log.isDebugEnabled()) {
+          log.debug("Closing StatsD client - {}", statsDAddress(host, port));
+        }
+        try {
+          statsd.close();
+        } catch (final Exception e) {
+          log.debug("Problem closing StatsD client - {}", statsDAddress(host, port), e);
+        } finally {
+          statsd = NO_OP;
+        }
+      }
+    }
+  }
+
+  static String statsDAddress(final String host, final int port) {
+    return port > 0 ? host + ':' + port : host;
+  }
+
+  private static final class ConnectTask
+      implements AgentTaskScheduler.Task<DDAgentStatsDConnection> {
+    public static final ConnectTask INSTANCE = new ConnectTask();
+
+    @Override
+    public void run(final DDAgentStatsDConnection target) {
+      target.doConnect();
+    }
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/core/monitor/HealthMetrics.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/monitor/HealthMetrics.java
@@ -6,8 +6,8 @@ import static datadog.trace.api.sampling.PrioritySampling.USER_DROP;
 import static datadog.trace.api.sampling.PrioritySampling.USER_KEEP;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
-import com.timgroup.statsd.StatsDClient;
 import datadog.trace.api.IntFunction;
+import datadog.trace.api.StatsDClient;
 import datadog.trace.api.cache.RadixTreeCache;
 import datadog.trace.common.writer.ddagent.DDAgentApi;
 import datadog.trace.core.DDSpan;
@@ -95,7 +95,7 @@ public class HealthMetrics implements AutoCloseable {
   }
 
   public void onStart(final int queueCapacity) {
-    statsd.recordGaugeValue("queue.max_length", queueCapacity, NO_TAGS);
+    statsd.gauge("queue.max_length", queueCapacity, NO_TAGS);
   }
 
   public void onShutdown(final boolean flushSuccess) {}

--- a/dd-trace-core/src/main/java/datadog/trace/core/monitor/LoggingStatsDClient.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/monitor/LoggingStatsDClient.java
@@ -1,0 +1,132 @@
+package datadog.trace.core.monitor;
+
+import static datadog.trace.core.monitor.DDAgentStatsDClient.serviceCheckStatus;
+import static datadog.trace.core.monitor.DDAgentStatsDConnection.statsDAddress;
+
+import datadog.trace.api.Function;
+import datadog.trace.api.StatsDClient;
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.util.Locale;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class LoggingStatsDClient implements StatsDClient {
+  private static final Logger log = LoggerFactory.getLogger(LoggingStatsDClient.class);
+
+  // logging format is based on the StatsD datagram format
+  private static final String COUNT_FORMAT = "{} - {}:{}|c{}";
+  private static final String GAUGE_FORMAT = "{} - {}:{}|g{}";
+  private static final String HISTOGRAM_FORMAT = "{} - {}:{}|h{}";
+  private static final String SERVICE_CHECK_FORMAT = "{} - _sc|{}|{}{}{}";
+
+  private static final DecimalFormat DECIMAL_FORMAT;
+
+  static {
+    DECIMAL_FORMAT = new DecimalFormat("0", DecimalFormatSymbols.getInstance(Locale.ENGLISH));
+    DECIMAL_FORMAT.setMaximumFractionDigits(6);
+  }
+
+  private final String statsDAddress;
+  private final Function<String, String> nameMapping;
+  private final Function<String[], String[]> tagMapping;
+
+  public LoggingStatsDClient(
+      final String host,
+      final int port,
+      final Function<String, String> nameMapping,
+      final Function<String[], String[]> tagMapping) {
+    this.statsDAddress = statsDAddress(host, port);
+    this.nameMapping = nameMapping;
+    this.tagMapping = tagMapping;
+  }
+
+  @Override
+  public void incrementCounter(final String metricName, final String... tags) {
+    log.info(
+        COUNT_FORMAT,
+        statsDAddress,
+        nameMapping.apply(metricName),
+        1,
+        join(tagMapping.apply(tags)));
+  }
+
+  @Override
+  public void count(final String metricName, final long delta, final String... tags) {
+    log.info(
+        COUNT_FORMAT,
+        statsDAddress,
+        nameMapping.apply(metricName),
+        delta,
+        join(tagMapping.apply(tags)));
+  }
+
+  @Override
+  public void gauge(final String metricName, final long value, final String... tags) {
+    log.info(
+        GAUGE_FORMAT,
+        statsDAddress,
+        nameMapping.apply(metricName),
+        value,
+        join(tagMapping.apply(tags)));
+  }
+
+  @Override
+  public void gauge(final String metricName, final double value, final String... tags) {
+    log.info(
+        GAUGE_FORMAT,
+        statsDAddress,
+        nameMapping.apply(metricName),
+        DECIMAL_FORMAT.format(value),
+        join(tagMapping.apply(tags)));
+  }
+
+  @Override
+  public void histogram(final String metricName, final long value, final String... tags) {
+    log.info(
+        HISTOGRAM_FORMAT,
+        statsDAddress,
+        nameMapping.apply(metricName),
+        value,
+        join(tagMapping.apply(tags)));
+  }
+
+  @Override
+  public void histogram(final String metricName, final double value, final String... tags) {
+    log.info(
+        HISTOGRAM_FORMAT,
+        statsDAddress,
+        nameMapping.apply(metricName),
+        DECIMAL_FORMAT.format(value),
+        join(tagMapping.apply(tags)));
+  }
+
+  @Override
+  public void serviceCheck(
+      final String serviceCheckName,
+      final String status,
+      final String message,
+      final String... tags) {
+    log.info(
+        SERVICE_CHECK_FORMAT,
+        statsDAddress,
+        nameMapping.apply(serviceCheckName),
+        serviceCheckStatus(status).ordinal(),
+        join(tagMapping.apply(tags)),
+        null != message ? "|m:" + message : "");
+  }
+
+  @Override
+  public void close() {}
+
+  private static String join(final String... tags) {
+    if (null == tags || tags.length == 0) {
+      return "";
+    }
+    StringBuilder buf = new StringBuilder("|#").append(tags[0]);
+    for (int i = 1; i < tags.length; i++) {
+      buf.append(',').append(tags[i]);
+    }
+    return buf.toString();
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/core/monitor/Monitoring.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/monitor/Monitoring.java
@@ -2,8 +2,7 @@ package datadog.trace.core.monitor;
 
 import static datadog.trace.api.Platform.isJavaVersionAtLeast;
 
-import com.timgroup.statsd.NoOpStatsDClient;
-import com.timgroup.statsd.StatsDClient;
+import datadog.trace.api.StatsDClient;
 import java.util.concurrent.TimeUnit;
 
 public final class Monitoring {
@@ -21,7 +20,7 @@ public final class Monitoring {
   }
 
   private Monitoring() {
-    this.statsd = new NoOpStatsDClient();
+    this.statsd = StatsDClient.NO_OP;
     this.flushAfterNanos = 0;
     this.enabled = false;
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/monitor/StatsDCounter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/monitor/StatsDCounter.java
@@ -2,7 +2,7 @@ package datadog.trace.core.monitor;
 
 import static datadog.trace.core.monitor.Utils.mergeTags;
 
-import com.timgroup.statsd.StatsDClient;
+import datadog.trace.api.StatsDClient;
 
 public final class StatsDCounter implements Counter {
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/monitor/Timer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/monitor/Timer.java
@@ -4,7 +4,7 @@ import static datadog.trace.core.monitor.Utils.mergeTags;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
-import com.timgroup.statsd.StatsDClient;
+import datadog.trace.api.StatsDClient;
 import datadog.trace.core.histogram.Histogram;
 import datadog.trace.core.histogram.Histograms;
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
@@ -2,7 +2,7 @@ package datadog.trace.core.scopemanager;
 
 import static datadog.trace.api.ConfigDefaults.DEFAULT_ASYNC_PROPAGATING;
 
-import com.timgroup.statsd.StatsDClient;
+import datadog.trace.api.StatsDClient;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentScopeManager;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentApiTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentApiTest.groovy
@@ -2,8 +2,8 @@ package datadog.trace.common.writer
 
 import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.timgroup.statsd.NoOpStatsDClient
 import datadog.trace.api.DDId
+import datadog.trace.api.StatsDClient
 import datadog.trace.api.sampling.PrioritySampling
 import datadog.trace.bootstrap.instrumentation.api.InstrumentationTags
 import datadog.trace.common.sampling.RateByServiceSampler
@@ -39,7 +39,7 @@ import static datadog.trace.agent.test.server.http.TestHttpServer.httpServer
 class DDAgentApiTest extends DDCoreSpecification {
 
   @Shared
-  Monitoring monitoring = new Monitoring(new NoOpStatsDClient(), 1, TimeUnit.SECONDS)
+  Monitoring monitoring = new Monitoring(StatsDClient.NO_OP, 1, TimeUnit.SECONDS)
   static mapper = new ObjectMapper(new MessagePackFactory())
 
   static newAgent(String latestVersion) {

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterCombinedTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterCombinedTest.groovy
@@ -1,8 +1,7 @@
 package datadog.trace.common.writer
 
-import com.timgroup.statsd.NoOpStatsDClient
-import com.timgroup.statsd.StatsDClient
 import datadog.trace.api.DDId
+import datadog.trace.api.StatsDClient
 import datadog.trace.api.sampling.PrioritySampling
 import datadog.trace.common.writer.ddagent.DDAgentApi
 import datadog.trace.common.writer.ddagent.DDAgentFeaturesDiscovery
@@ -39,7 +38,7 @@ import static datadog.trace.common.writer.ddagent.Prioritization.ENSURE_TRACE
 class DDAgentWriterCombinedTest extends DDCoreSpecification {
 
   def conditions = new PollingConditions(timeout: 5, initialDelay: 0, factor: 1.25)
-  def monitoring = new Monitoring(new NoOpStatsDClient(), 1, TimeUnit.SECONDS)
+  def monitoring = new Monitoring(StatsDClient.NO_OP, 1, TimeUnit.SECONDS)
   def phaser = new Phaser()
 
   // Only used to create spans

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterTest.groovy
@@ -1,7 +1,7 @@
 package datadog.trace.common.writer
 
-import com.timgroup.statsd.NoOpStatsDClient
 import datadog.trace.api.DDId
+import datadog.trace.api.StatsDClient
 import datadog.trace.api.sampling.PrioritySampling
 import datadog.trace.common.writer.ddagent.DDAgentApi
 import datadog.trace.common.writer.ddagent.DDAgentFeaturesDiscovery
@@ -24,7 +24,7 @@ class DDAgentWriterTest extends DDCoreSpecification {
   def api = Mock(DDAgentApi)
   def monitor = Mock(HealthMetrics)
   def worker = Mock(TraceProcessingWorker)
-  def monitoring = new Monitoring(new NoOpStatsDClient(), 1, TimeUnit.SECONDS)
+  def monitoring = new Monitoring(StatsDClient.NO_OP, 1, TimeUnit.SECONDS)
 
   @Subject
   def writer = new DDAgentWriter(discovery, api, monitor, monitoring, worker)

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/PayloadDispatcherTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/PayloadDispatcherTest.groovy
@@ -1,7 +1,7 @@
 package datadog.trace.common.writer
 
-import com.timgroup.statsd.NoOpStatsDClient
 import datadog.trace.api.DDId
+import datadog.trace.api.StatsDClient
 import datadog.trace.api.sampling.PrioritySampling
 import datadog.trace.common.writer.ddagent.DDAgentApi
 import datadog.trace.common.writer.ddagent.DDAgentFeaturesDiscovery
@@ -24,7 +24,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 class PayloadDispatcherTest extends DDSpecification {
 
   @Shared
-  Monitoring monitoring = new Monitoring(new NoOpStatsDClient(), 1, TimeUnit.SECONDS)
+  Monitoring monitoring = new Monitoring(StatsDClient.NO_OP, 1, TimeUnit.SECONDS)
 
   @Timeout(5)
   def "flush automatically when data limit is breached"() {

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/TraceProcessingWorkerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/TraceProcessingWorkerTest.groovy
@@ -1,6 +1,6 @@
 package datadog.trace.common.writer
 
-import com.timgroup.statsd.NoOpStatsDClient
+import datadog.trace.api.StatsDClient
 import datadog.trace.common.writer.ddagent.PayloadDispatcher
 import datadog.trace.common.writer.ddagent.TraceProcessingWorker
 import datadog.trace.core.DDSpan
@@ -23,7 +23,7 @@ import static datadog.trace.common.writer.ddagent.Prioritization.FAST_LANE
 class TraceProcessingWorkerTest extends DDSpecification {
 
   @Shared
-  Monitoring monitoring = new Monitoring(new NoOpStatsDClient(), 1, TimeUnit.SECONDS)
+  Monitoring monitoring = new Monitoring(StatsDClient.NO_OP, 1, TimeUnit.SECONDS)
 
   def conditions = new PollingConditions(timeout: 5, initialDelay: 0, factor: 1.25)
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddagent/DDAgentFeaturesDiscoveryTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddagent/DDAgentFeaturesDiscoveryTest.groovy
@@ -1,6 +1,6 @@
 package datadog.trace.common.writer.ddagent
 
-import com.timgroup.statsd.NoOpStatsDClient
+import datadog.trace.api.StatsDClient
 import datadog.trace.core.monitor.Monitoring
 import datadog.trace.test.util.DDSpecification
 import okhttp3.Call
@@ -23,7 +23,7 @@ import static datadog.trace.common.writer.ddagent.DDAgentFeaturesDiscovery.V6_ME
 class DDAgentFeaturesDiscoveryTest extends DDSpecification {
 
   @Shared
-  Monitoring monitoring = new Monitoring(new NoOpStatsDClient(), 1, TimeUnit.SECONDS)
+  Monitoring monitoring = new Monitoring(StatsDClient.NO_OP, 1, TimeUnit.SECONDS)
 
   @Shared
   HttpUrl agentUrl = HttpUrl.get("http://localhost:8125")

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/CoreTracerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/CoreTracerTest.groovy
@@ -1,8 +1,7 @@
 package datadog.trace.core
 
-import com.timgroup.statsd.NoOpStatsDClient
-import com.timgroup.statsd.NonBlockingStatsDClient
 import datadog.trace.api.Config
+import datadog.trace.api.StatsDClient
 import datadog.trace.api.sampling.PrioritySampling
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation
 import datadog.trace.common.sampling.AllSampler
@@ -39,7 +38,7 @@ class CoreTracerTest extends DDCoreSpecification {
     tracer.serviceName != ""
     tracer.sampler instanceof RateByServiceSampler
     tracer.writer instanceof DDAgentWriter
-    tracer.statsDClient instanceof NonBlockingStatsDClient
+    tracer.statsDClient != null && tracer.statsDClient != StatsDClient.NO_OP
 
     tracer.injector instanceof HttpCodec.CompoundInjector
     tracer.extractor instanceof HttpCodec.CompoundExtractor
@@ -56,7 +55,7 @@ class CoreTracerTest extends DDCoreSpecification {
     def tracer = CoreTracer.builder().build()
 
     then:
-    tracer.statsDClient instanceof NoOpStatsDClient
+    tracer.statsDClient == StatsDClient.NO_OP
 
     cleanup:
     tracer.close()

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceBufferTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceBufferTest.groovy
@@ -1,7 +1,7 @@
 package datadog.trace.core
 
-import com.timgroup.statsd.NoOpStatsDClient
 import datadog.trace.api.DDId
+import datadog.trace.api.StatsDClient
 import datadog.trace.api.sampling.PrioritySampling
 import datadog.trace.bootstrap.instrumentation.api.ScopeSource
 import datadog.trace.context.TraceScope
@@ -24,7 +24,7 @@ class PendingTraceBufferTest extends DDSpecification {
   def bufferSpy = Spy(buffer)
 
   def tracer = Mock(CoreTracer)
-  def scopeManager = new ContinuableScopeManager(10, new NoOpStatsDClient(), true, true)
+  def scopeManager = new ContinuableScopeManager(10, StatsDClient.NO_OP, true, true)
   def factory = new PendingTrace.Factory(tracer, bufferSpy, false)
   List<TraceScope.Continuation> continuations = []
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/monitor/CounterTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/monitor/CounterTest.groovy
@@ -1,6 +1,6 @@
 package datadog.trace.core.monitor
 
-import com.timgroup.statsd.StatsDClient
+import datadog.trace.api.StatsDClient
 import datadog.trace.test.util.DDSpecification
 import org.junit.Assert
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/monitor/DDAgentStatsDClientTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/monitor/DDAgentStatsDClientTest.groovy
@@ -1,0 +1,178 @@
+package datadog.trace.core.monitor
+
+
+import datadog.trace.test.util.DDSpecification
+
+import static datadog.trace.api.config.GeneralConfig.DOGSTATSD_START_DELAY
+import static datadog.trace.core.monitor.DDAgentStatsDClientManager.statsDClientManager
+
+class DDAgentStatsDClientTest extends DDSpecification {
+
+  def "single statsd client"() {
+    setup:
+    injectSysConfig(DOGSTATSD_START_DELAY, '0')
+    def server = new StatsDServer()
+    server.start()
+
+    def client = statsDClientManager().statsDClient('127.0.0.1', server.socket.localPort, namespace, constantTags as String[])
+
+    String metricName = "test.metric"
+    String checkName = "test.check"
+    String[] tags = ["type:BufferPool", "jmx_domain:java.nio"]
+
+    expect:
+
+    client.incrementCounter(metricName, tags)
+    server.waitForMessage() == "$expectedMetricName:1|c|#$expectedTags"
+
+    client.count(metricName, Integer.MIN_VALUE, tags)
+    server.waitForMessage() == "$expectedMetricName:-2147483648|c|#$expectedTags"
+    client.count(metricName, Integer.MAX_VALUE, tags)
+    server.waitForMessage() == "$expectedMetricName:2147483647|c|#$expectedTags"
+    client.count(metricName, Long.MIN_VALUE, tags)
+    server.waitForMessage() == "$expectedMetricName:-9223372036854775808|c|#$expectedTags"
+    client.count(metricName, Long.MAX_VALUE, tags)
+    server.waitForMessage() == "$expectedMetricName:9223372036854775807|c|#$expectedTags"
+
+    client.gauge(metricName, Integer.MIN_VALUE, tags)
+    server.waitForMessage() == "$expectedMetricName:-2147483648|g|#$expectedTags"
+    client.gauge(metricName, Integer.MAX_VALUE, tags)
+    server.waitForMessage() == "$expectedMetricName:2147483647|g|#$expectedTags"
+    client.gauge(metricName, Long.MIN_VALUE, tags)
+    server.waitForMessage() == "$expectedMetricName:-9223372036854775808|g|#$expectedTags"
+    client.gauge(metricName, Long.MAX_VALUE, tags)
+    server.waitForMessage() == "$expectedMetricName:9223372036854775807|g|#$expectedTags"
+
+    client.gauge(metricName, -Math.E, tags)
+    server.waitForMessage() == "$expectedMetricName:-2.718282|g|#$expectedTags"
+    client.gauge(metricName, Math.PI, tags)
+    server.waitForMessage() == "$expectedMetricName:3.141593|g|#$expectedTags"
+
+    client.histogram(metricName, Integer.MIN_VALUE, tags)
+    server.waitForMessage() == "$expectedMetricName:-2147483648|h|#$expectedTags"
+    client.histogram(metricName, Integer.MAX_VALUE, tags)
+    server.waitForMessage() == "$expectedMetricName:2147483647|h|#$expectedTags"
+    client.histogram(metricName, Long.MIN_VALUE, tags)
+    server.waitForMessage() == "$expectedMetricName:-9223372036854775808|h|#$expectedTags"
+    client.histogram(metricName, Long.MAX_VALUE, tags)
+    server.waitForMessage() == "$expectedMetricName:9223372036854775807|h|#$expectedTags"
+
+    client.histogram(metricName, -Math.E, tags)
+    server.waitForMessage() == "$expectedMetricName:-2.718282|h|#$expectedTags"
+    client.histogram(metricName, Math.PI, tags)
+    server.waitForMessage() == "$expectedMetricName:3.141593|h|#$expectedTags"
+
+    client.serviceCheck(checkName, "OK", null, tags)
+    server.waitForMessage() == "_sc|$expectedCheckName|0|#$expectedTags"
+    client.serviceCheck(checkName, "WARN", null, tags)
+    server.waitForMessage() == "_sc|$expectedCheckName|1|#$expectedTags"
+    client.serviceCheck(checkName, "WARNING", null, tags)
+    server.waitForMessage() == "_sc|$expectedCheckName|1|#$expectedTags"
+    client.serviceCheck(checkName, "CRITICAL", null, tags)
+    server.waitForMessage() == "_sc|$expectedCheckName|2|#$expectedTags"
+    client.serviceCheck(checkName, "ERROR", null, tags)
+    server.waitForMessage() == "_sc|$expectedCheckName|2|#$expectedTags"
+    client.serviceCheck(checkName, "_UNKNOWN_", null, tags)
+    server.waitForMessage() == "_sc|$expectedCheckName|3|#$expectedTags"
+
+    client.serviceCheck(checkName, "OK", "testing", tags)
+    server.waitForMessage() == "_sc|$expectedCheckName|0|#$expectedTags|m:testing"
+    client.serviceCheck(checkName, "WARN", "testing", tags)
+    server.waitForMessage() == "_sc|$expectedCheckName|1|#$expectedTags|m:testing"
+    client.serviceCheck(checkName, "WARNING", "testing", tags)
+    server.waitForMessage() == "_sc|$expectedCheckName|1|#$expectedTags|m:testing"
+    client.serviceCheck(checkName, "CRITICAL", "testing", tags)
+    server.waitForMessage() == "_sc|$expectedCheckName|2|#$expectedTags|m:testing"
+    client.serviceCheck(checkName, "ERROR", "testing", tags)
+    server.waitForMessage() == "_sc|$expectedCheckName|2|#$expectedTags|m:testing"
+    client.serviceCheck(checkName, "_UNKNOWN_", "testing", tags)
+    server.waitForMessage() == "_sc|$expectedCheckName|3|#$expectedTags|m:testing"
+
+    cleanup:
+    client.close()
+    server.close()
+
+    where:
+    // spotless:off
+    namespace | constantTags                        | expectedMetricName    | expectedCheckName    | expectedTags
+    null      | null                                | "test.metric"         | "test.check"         | "jmx_domain:java.nio,type:BufferPool"
+    null      | ["lang:java", "lang_version:1.8.0"] | "test.metric"         | "test.check"         | "jmx_domain:java.nio,type:BufferPool,lang:java,lang_version:1.8.0"
+    "example" | null                                | "example.test.metric" | "example.test.check" | "jmx_domain:java.nio,type:BufferPool"
+    "example" | ["lang:java", "lang_version:1.8.0"] | "example.test.metric" | "example.test.check" | "jmx_domain:java.nio,type:BufferPool,lang:java,lang_version:1.8.0"
+    // spotless:on
+  }
+
+  def "multiple statsd clients"() {
+    setup:
+    injectSysConfig(DOGSTATSD_START_DELAY, '0')
+    def server = new StatsDServer()
+    server.start()
+
+    def client1 = statsDClientManager().statsDClient('127.0.0.1', server.socket.localPort, null, null)
+    def client2 = statsDClientManager().statsDClient('127.0.0.1', server.socket.localPort, "example", null)
+    def client3 = statsDClientManager().statsDClient('127.0.0.1', server.socket.localPort, null, ["lang:java", "lang_version:1.8.0"] as String[])
+    def client4 = statsDClientManager().statsDClient('127.0.0.1', server.socket.localPort, "example", ["lang:java", "lang_version:1.8.0"] as String[])
+
+    String metricName = "test.metric"
+    String[] metricTags = ["type:BufferPool", "jmx_domain:java.nio"]
+
+    expect:
+    client1.incrementCounter(metricName, metricTags)
+    server.waitForMessage() == "test.metric:1|c|#jmx_domain:java.nio,type:BufferPool"
+    client1.close()
+
+    client2.incrementCounter(metricName, metricTags)
+    server.waitForMessage() == "example.test.metric:1|c|#jmx_domain:java.nio,type:BufferPool"
+    client2.close()
+
+    client3.incrementCounter(metricName, metricTags)
+    server.waitForMessage() == "test.metric:1|c|#jmx_domain:java.nio,type:BufferPool,lang:java,lang_version:1.8.0"
+    client3.close()
+
+    client4.incrementCounter(metricName, metricTags)
+    server.waitForMessage() == "example.test.metric:1|c|#jmx_domain:java.nio,type:BufferPool,lang:java,lang_version:1.8.0"
+    client4.close()
+
+    cleanup:
+    server.close()
+  }
+
+  private static class StatsDServer extends Thread {
+    private final DatagramSocket socket
+    private volatile String lastMessage
+
+    StatsDServer() {
+      socket = new DatagramSocket()
+    }
+
+    void run() {
+      byte[] buf = new byte[1024]
+      DatagramPacket packet = new DatagramPacket(buf, buf.length)
+      while ('stop' != lastMessage) {
+        socket.receive(packet)
+        lastMessage = new String(packet.getData(), 0, packet.getLength())
+      }
+      socket.close()
+    }
+
+    String lastMessage() {
+      return lastMessage
+    }
+
+    String waitForMessage() {
+      while (null == lastMessage) {
+        yield()
+      }
+      try {
+        return lastMessage
+      } finally {
+        lastMessage = null
+      }
+    }
+
+    void close() {
+      lastMessage = 'stop'
+      interrupt()
+    }
+  }
+}

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/monitor/HealthMetricsTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/monitor/HealthMetricsTest.groovy
@@ -1,6 +1,6 @@
 package datadog.trace.core.monitor
 
-import com.timgroup.statsd.StatsDClient
+import datadog.trace.api.StatsDClient
 import datadog.trace.api.sampling.PrioritySampling
 import datadog.trace.common.writer.DDAgentWriter
 import datadog.trace.common.writer.ddagent.DDAgentApi

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/monitor/TimingTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/monitor/TimingTest.groovy
@@ -1,7 +1,7 @@
 package datadog.trace.core.monitor
 
-import com.timgroup.statsd.StatsDClient
 import datadog.trace.api.Platform
+import datadog.trace.api.StatsDClient
 import datadog.trace.core.util.SystemAccess
 import datadog.trace.test.util.DDSpecification
 import org.junit.Assert

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerTest.groovy
@@ -1,8 +1,8 @@
 package datadog.trace.core.scopemanager
 
-import com.timgroup.statsd.StatsDClient
 import datadog.trace.agent.test.utils.ThreadUtils
 import datadog.trace.api.DDId
+import datadog.trace.api.StatsDClient
 import datadog.trace.api.interceptor.MutableSpan
 import datadog.trace.api.interceptor.TraceInterceptor
 import datadog.trace.bootstrap.instrumentation.api.AgentScope

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/test/DDCoreSpecification.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/test/DDCoreSpecification.groovy
@@ -1,6 +1,6 @@
 package datadog.trace.core.test
 
-import com.timgroup.statsd.NoOpStatsDClient
+import datadog.trace.api.StatsDClient
 import datadog.trace.core.CoreTracer
 import datadog.trace.core.CoreTracer.CoreTracerBuilder
 import datadog.trace.test.util.DDSpecification
@@ -18,7 +18,7 @@ abstract class DDCoreSpecification extends DDSpecification {
   protected CoreTracerBuilder tracerBuilder() {
     def builder = CoreTracer.builder()
     if (useNoopStatsDClient()) {
-      builder =  builder.statsDClient(new NoOpStatsDClient())
+      builder =  builder.statsDClient(StatsDClient.NO_OP)
     }
     return builder.strictTraceWrites(useStrictTraceWrites())
   }

--- a/dd-trace-core/src/traceAgentTest/groovy/DDApiIntegrationTest.groovy
+++ b/dd-trace-core/src/traceAgentTest/groovy/DDApiIntegrationTest.groovy
@@ -1,5 +1,4 @@
-import com.timgroup.statsd.NonBlockingStatsDClient
-import com.timgroup.statsd.StatsDClient
+import datadog.trace.api.StatsDClient
 import datadog.trace.common.writer.ListWriter
 import datadog.trace.common.writer.ddagent.DDAgentApi
 import datadog.trace.common.writer.ddagent.DDAgentFeaturesDiscovery
@@ -53,8 +52,6 @@ class DDApiIntegrationTest extends DDSpecification {
   Process process
   @Shared
   File socketPath
-  @Shared
-  StatsDClient statsDClient
 
   def discovery
   def udsDiscovery
@@ -72,8 +69,6 @@ class DDApiIntegrationTest extends DDSpecification {
   }
 
   def setupSpec() {
-    statsDClient = new NonBlockingStatsDClient("itest", agentContainerHost, 8125)
-
     /*
      CI will provide us with agent container running along side our build.
      When building locally, however, we need to take matters into our own hands
@@ -119,14 +114,11 @@ class DDApiIntegrationTest extends DDSpecification {
     if (agentContainer) {
       agentContainer.stop()
     }
-    if (null != statsDClient) {
-      statsDClient.close()
-    }
     process.destroy()
   }
 
   def beforeTest(boolean enableV05) {
-    Monitoring monitoring = new Monitoring(statsDClient, 1, TimeUnit.SECONDS)
+    Monitoring monitoring = new Monitoring(StatsDClient.NO_OP, 1, TimeUnit.SECONDS)
     HttpUrl agentUrl = HttpUrl.get(String.format("http://%s:%d", agentContainerHost, agentContainerPort))
     OkHttpClient httpClient = OkHttpUtils.buildHttpClient(agentUrl, 5000)
     discovery = new DDAgentFeaturesDiscovery(httpClient, monitoring, agentUrl, enableV05, true)

--- a/dd-trace-core/src/traceAgentTest/groovy/TraceMapperRealAgentTest.groovy
+++ b/dd-trace-core/src/traceAgentTest/groovy/TraceMapperRealAgentTest.groovy
@@ -1,6 +1,6 @@
 
 
-import com.timgroup.statsd.NoOpStatsDClient
+import datadog.trace.api.StatsDClient
 import datadog.trace.common.writer.ddagent.DDAgentApi
 import datadog.trace.common.writer.ddagent.DDAgentFeaturesDiscovery
 import datadog.trace.common.writer.ddagent.PayloadDispatcher
@@ -29,7 +29,7 @@ class TraceMapperRealAgentTest extends DDSpecification {
   OkHttpClient client = OkHttpUtils.buildHttpClient(agentUrl, 30_000)
 
   @Shared
-  Monitoring monitoring = new Monitoring(new NoOpStatsDClient(), 1, TimeUnit.SECONDS)
+  Monitoring monitoring = new Monitoring(StatsDClient.NO_OP, 1, TimeUnit.SECONDS)
   @Shared
   DDAgentFeaturesDiscovery v05Discovery = new DDAgentFeaturesDiscovery(client, monitoring, agentUrl, true, true)
   @Shared

--- a/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
@@ -1,9 +1,9 @@
 package datadog.opentracing;
 
-import com.timgroup.statsd.StatsDClient;
 import datadog.trace.api.Config;
 import datadog.trace.api.DDTags;
 import datadog.trace.api.GlobalTracer;
+import datadog.trace.api.StatsDClient;
 import datadog.trace.api.interceptor.TraceInterceptor;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/OpenTracingAPITest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/OpenTracingAPITest.groovy
@@ -1,7 +1,7 @@
 package datadog.opentracing
 
-import com.timgroup.statsd.StatsDClient
 import datadog.trace.api.DDTags
+import datadog.trace.api.StatsDClient
 import datadog.trace.api.config.TracerConfig
 import datadog.trace.api.interceptor.MutableSpan
 import datadog.trace.api.interceptor.TraceInterceptor

--- a/internal-api/internal-api.gradle
+++ b/internal-api/internal-api.gradle
@@ -4,6 +4,8 @@ minimumBranchCoverage = 0.7
 minimumInstructionCoverage = 0.8
 
 excludedClassesCoverage += [
+  "datadog.trace.api.StatsDClient",
+  "datadog.trace.api.NoOpStatsDClient",
   "datadog.trace.bootstrap.instrumentation.api.Tags",
   "datadog.trace.bootstrap.instrumentation.api.CommonTagValues",
   "datadog.trace.bootstrap.instrumentation.api.AgentTracer.NoopAgentPropagation",

--- a/internal-api/src/main/java/datadog/trace/api/NoOpStatsDClient.java
+++ b/internal-api/src/main/java/datadog/trace/api/NoOpStatsDClient.java
@@ -1,0 +1,32 @@
+package datadog.trace.api;
+
+final class NoOpStatsDClient implements StatsDClient {
+
+  @Override
+  public void incrementCounter(final String metricName, final String... tags) {}
+
+  @Override
+  public void count(final String metricName, final long delta, final String... tags) {}
+
+  @Override
+  public void gauge(final String metricName, final long value, final String... tags) {}
+
+  @Override
+  public void gauge(final String metricName, final double value, final String... tags) {}
+
+  @Override
+  public void histogram(final String metricName, final long value, final String... tags) {}
+
+  @Override
+  public void histogram(final String metricName, final double value, final String... tags) {}
+
+  @Override
+  public void serviceCheck(
+      final String serviceCheckName,
+      final String status,
+      final String message,
+      final String... tags) {}
+
+  @Override
+  public void close() {}
+}

--- a/internal-api/src/main/java/datadog/trace/api/StatsDClient.java
+++ b/internal-api/src/main/java/datadog/trace/api/StatsDClient.java
@@ -1,0 +1,24 @@
+package datadog.trace.api;
+
+import java.io.Closeable;
+
+public interface StatsDClient extends Closeable {
+  StatsDClient NO_OP = new NoOpStatsDClient();
+
+  void incrementCounter(String metricName, String... tags);
+
+  void count(String metricName, long delta, String... tags);
+
+  void gauge(String metricName, long value, String... tags);
+
+  void gauge(String metricName, double value, String... tags);
+
+  void histogram(String metricName, long value, String... tags);
+
+  void histogram(String metricName, double value, String... tags);
+
+  void serviceCheck(String serviceCheckName, String status, String message, String... tags);
+
+  @Override
+  void close();
+}

--- a/internal-api/src/main/java/datadog/trace/api/StatsDClientManager.java
+++ b/internal-api/src/main/java/datadog/trace/api/StatsDClientManager.java
@@ -1,0 +1,5 @@
+package datadog.trace.api;
+
+public interface StatsDClientManager {
+  StatsDClient statsDClient(String host, int port, String namespace, String[] constantTags);
+}

--- a/internal-api/src/main/java/datadog/trace/api/cache/DDCaches.java
+++ b/internal-api/src/main/java/datadog/trace/api/cache/DDCaches.java
@@ -9,13 +9,24 @@ public final class DDCaches {
    * between low cardinality but potentially unbounded keys with values, without risking using
    * unbounded space.
    *
+   * <p>When using immutable array keys prefer {@link #newFixedSizeArrayKeyCache(int)}.
+   *
    * @param capacity the cache's fixed capacity
    * @param <K> the key type
    * @param <V> the value type
    * @return the value associated with the key
    */
   public static <K, V> DDCache<K, V> newFixedSizeCache(final int capacity) {
-    return new FixedSizeCache<>(capacity);
+    return new FixedSizeCache.ObjectHash<>(capacity);
+  }
+
+  /**
+   * Specialized fixed-size cache that uses {@link java.util.Arrays} for key hashing and equality.
+   *
+   * @see #newFixedSizeCache(int)
+   */
+  public static <K, V> DDCache<K[], V> newFixedSizeArrayKeyCache(final int capacity) {
+    return new FixedSizeCache.ArrayHash<>(capacity);
   }
 
   /**


### PR DESCRIPTION
* Extract minimal `StatsDClient` interface for the tracer
* DogStatsD implementation of `StatsDClient`
* Use `StatsDClient` in `CoreTracer` and `JMXFetch`
* Support different constant tags and namespaces
* Introduce pooling of `StatsDClient` connections
* Support `-Ddd.dogstatsd.start-delay` property (overrides `-Ddd.jmxfetch.start-delay` if both set)
* Add logging `StatsDClient`
* Support caching of combined StatsD tags