### PR TITLE
cache interface lookups

### DIFF
--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/bytebuddy/matcher/HasInterfaceMatcherTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/bytebuddy/matcher/HasInterfaceMatcherTest.groovy
@@ -65,6 +65,7 @@ class HasInterfaceMatcherTest extends DDSpecification {
     1 * interfaces.iterator() >> it
     1 * type.getSuperClass() >> { throw new Exception("getSuperClass exception") }
     2 * type.getTypeName() >> "type-name"
+    1 * interfaces.size()
     0 * _
   }
 }

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/bytebuddy/matcher/ImplementsInterfaceMatcherTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/bytebuddy/matcher/ImplementsInterfaceMatcherTest.groovy
@@ -87,6 +87,7 @@ class ImplementsInterfaceMatcherTest extends DDSpecification {
     1 * interfaces.iterator() >> it
     2 * type.getTypeName() >> "type-name"
     1 * type.getSuperClass() >> { throw new Exception("getSuperClass exception") }
+    1 * interfaces.size()
     0 * _
   }
 }


### PR DESCRIPTION
We spend a lot of time looking up interfaces from type definitions during startup.

<img width="1190" alt="Screenshot 2021-04-14 at 10 42 51" src="https://user-images.githubusercontent.com/16439049/114691455-9c764900-9d0f-11eb-8742-f18aea9dac66.png">

The cache is sized to try to cover independent matchers traversing the type hierarchy for the same target type sequentially, plus some history for recently loaded classes. It may be necessary to introduce an LRU cache to keep interfaces for common super types. It looks like byte-buddy does this caching itself in some places, so I'm not yet sure how effective this will be.