### PR TITLE
Reduce the number of intermittent failures

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/ProfilingSystem.java
+++ b/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/ProfilingSystem.java
@@ -190,10 +190,11 @@ public final class ProfilingSystem {
       final RecordingType recordingType = RecordingType.CONTINUOUS;
       try {
         log.debug("Creating profiler snapshot");
-        final RecordingData recordingData = recording.snapshot(lastSnapshot, Instant.now());
+        Instant now = Instant.now();
+        final RecordingData recordingData = recording.snapshot(lastSnapshot, now);
         // The hope here is that we do not get chunk rotated after taking snapshot and before we
-        // take this timestamp otherwise we will start losing data.
-        lastSnapshot = Instant.now();
+        // take this timestamp otherwise we will start losing data
+        lastSnapshot = now;
         if (recordingData != null) {
           dataListener.onNewData(recordingType, recordingData);
         }

--- a/dd-java-agent/agent-profiling/profiling-uploader/src/main/java/com/datadog/profiling/uploader/ProfileUploader.java
+++ b/dd-java-agent/agent-profiling/profiling-uploader/src/main/java/com/datadog/profiling/uploader/ProfileUploader.java
@@ -149,9 +149,6 @@ public final class ProfileUploader {
     }
   }
 
-  static final int SEED_EXPECTED_REQUEST_SIZE = 2 * 1024 * 1024; // 2MB;
-  static final int REQUEST_SIZE_HISTORY_SIZE = 10;
-
   private final ExecutorService okHttpExecutorService;
   private final OkHttpClient client;
   private final Callback responseCallback;


### PR DESCRIPTION
### Relax the assertion checking upload time interval

The upload task is executed at fixed interval and due to thread scheduling the next interval can elapse shortly after the previous task has been finished. Perhaps, it would be more correct to have `scheduleWithFixedDelay` functionality in the `AgentTaskScheduler` but since we have been seeing this kind of failure only in CI so far we might get away with just not being so strict in expectations.

### Clean up test processes when retrying
The retry logic was leaving orphaned target processes behind.