### PR TITLE
Rearchitect ScopeEvents to reduce cputime calls

### DIFF
--- a/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/ScopeEvent.java
+++ b/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/ScopeEvent.java
@@ -46,8 +46,9 @@ public final class ScopeEvent extends Event {
   }
 
   /**
-   * Cpu time between start and finish without subtracting time spent in child scopes
-   * Only valid after this event is finished and if scope events are enabled
+   * Cpu time between start and finish without subtracting time spent in child scopes.
+   *
+   * <p>Only valid after this event is finished and if scope events are enabled
    */
   public long getRawCpuTime() {
     return rawCpuTime;
@@ -57,10 +58,11 @@ public final class ScopeEvent extends Event {
     if (cpuTimeStart > 0) {
       rawCpuTime = SystemAccess.getCurrentThreadCpuTime() - cpuTimeStart;
       cpuTime = rawCpuTime - childCpuTime;
-      end();
-      if (shouldCommit()) {
-        commit();
-      }
+    }
+
+    end();
+    if (shouldCommit()) {
+      commit();
     }
   }
 

--- a/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/ScopeEventFactory.java
+++ b/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/ScopeEventFactory.java
@@ -27,14 +27,10 @@ public class ScopeEventFactory implements ExtendedScopeListener {
     if (scopeEvent == null) {
       // Empty stack
       stack.push(new ScopeEvent(traceId, spanId));
-    } else if (scopeEvent.getTraceId() == traceId.toLong()
-        && scopeEvent.getSpanId() == spanId.toLong()) {
+    } else if (scopeEvent.getTraceId() != traceId.toLong()
+        || scopeEvent.getSpanId() != spanId.toLong()) {
 
-      // Reactivation
-      scopeEvent.resume();
-    } else {
       // Top being pushed down
-      scopeEvent.pause();
       stack.push(new ScopeEvent(traceId, spanId));
     }
   }
@@ -45,5 +41,10 @@ public class ScopeEventFactory implements ExtendedScopeListener {
 
     ScopeEvent scopeEvent = stack.pop();
     scopeEvent.finish();
+
+    ScopeEvent parent = stack.peek();
+    if (parent != null) {
+      parent.addChildCpuTime(scopeEvent.getRawCpuTime());
+    }
   }
 }


### PR DESCRIPTION
Calls to `getCurrentThreadCpuTime()` add up especially when there are a lot of scopes created. With this PR, there are at most 2 calls per `ScopeEvent` instead of a call at every pause and resume.

The simple case of a scope with two child scopes:
Activate Scope A
Activate Scope B
Finish Scope B
Activate Scope C
Finish Scope C
Finish Scope A

Goes from 10 calls down to 6.