### PR TITLE
replace hierarchy searches for implementations of closed interfaces with literal implementation matches

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Instrumenter.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Instrumenter.java
@@ -313,13 +313,41 @@ public interface Instrumenter {
 
   /** Parent class for all tracing related instrumentations */
   abstract class Tracing extends Default {
+
+    private final boolean shortCutEnabled;
+
     public Tracing(String instrumentationName, String... additionalNames) {
+      this(false, instrumentationName, additionalNames);
+    }
+
+    public Tracing(
+        boolean defaultToShortCutMatching, String instrumentationName, String... additionalNames) {
       super(instrumentationName, additionalNames);
+      this.shortCutEnabled =
+          Config.get()
+              .isIntegrationShortCutMatchingEnabled(
+                  Collections.singletonList(instrumentationName), defaultToShortCutMatching);
     }
 
     @Override
     public boolean isApplicable(Set<TargetSystem> enabledSystems) {
       return enabledSystems.contains(TargetSystem.TRACING);
+    }
+
+    @Override
+    public ElementMatcher<? super TypeDescription> typeMatcher() {
+      if (shortCutEnabled) {
+        return shortCutMatcher();
+      }
+      return hierarchyMatcher();
+    }
+
+    public ElementMatcher<? super TypeDescription> shortCutMatcher() {
+      throw new IllegalStateException("shortCutMatcher not implemented");
+    }
+
+    public ElementMatcher<? super TypeDescription> hierarchyMatcher() {
+      throw new IllegalStateException("hierarchyMatcher not implemented");
     }
   }
 

--- a/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientInstrumentation.java
@@ -3,6 +3,7 @@ package datadog.trace.instrumentation.apachehttpasyncclient;
 import static datadog.trace.agent.tooling.ClassLoaderMatcher.hasClassesNamed;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers.implementsInterface;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.apachehttpasyncclient.ApacheHttpAsyncClientDecorator.DECORATE;
@@ -39,7 +40,19 @@ public class ApacheHttpAsyncClientInstrumentation extends Instrumenter.Tracing {
   }
 
   @Override
-  public ElementMatcher<TypeDescription> typeMatcher() {
+  public ElementMatcher<TypeDescription> shortCutMatcher() {
+    return namedOneOf(
+        "org.apache.http.impl.nio.client.AbstractHttpAsyncClient",
+        "org.apache.http.impl.nio.client.CloseableHttpAsyncClient",
+        "org.apache.http.impl.nio.client.CloseableHttpAsyncClientBase",
+        "org.apache.http.impl.nio.client.CloseableHttpPipeliningClient",
+        "org.apache.http.impl.nio.client.DefaultHttpAsyncClient",
+        "org.apache.http.impl.nio.client.InternalHttpAsyncClient",
+        "org.apache.http.impl.nio.client.MinimalHttpAsyncClient");
+  }
+
+  @Override
+  public ElementMatcher<? super TypeDescription> hierarchyMatcher() {
     return implementsInterface(named("org.apache.http.nio.client.HttpAsyncClient"));
   }
 

--- a/dd-java-agent/instrumentation/apache-httpclient-4/src/main/java/datadog/trace/instrumentation/apachehttpclient/ApacheHttpClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/apache-httpclient-4/src/main/java/datadog/trace/instrumentation/apachehttpclient/ApacheHttpClientInstrumentation.java
@@ -3,6 +3,7 @@ package datadog.trace.instrumentation.apachehttpclient;
 import static datadog.trace.agent.tooling.ClassLoaderMatcher.hasClassesNamed;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers.implementsInterface;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
 import static net.bytebuddy.matcher.ElementMatchers.isAbstract;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.not;
@@ -40,7 +41,24 @@ public class ApacheHttpClientInstrumentation extends Instrumenter.Tracing {
   }
 
   @Override
-  public ElementMatcher<TypeDescription> typeMatcher() {
+  public ElementMatcher<? super TypeDescription> shortCutMatcher() {
+    return namedOneOf(
+        "org.apache.http.impl.client.AbstractHttpClient",
+        "software.amazon.awssdk.http.apache.internal.impl.ApacheSdkHttpClient",
+        "org.apache.http.impl.client.AutoRetryHttpClient",
+        "org.apache.http.impl.client.CloseableHttpClient",
+        "org.apache.http.impl.client.ContentEncodingHttpClient",
+        "org.apache.http.impl.client.DecompressingHttpClient",
+        "org.apache.http.impl.client.DefaultHttpClient",
+        "org.apache.http.impl.client.InternalHttpClient",
+        "org.apache.http.impl.client.MinimalHttpClient",
+        "org.apache.http.impl.client.SystemDefaultHttpClient",
+        "com.netflix.http4.NFHttpClient",
+        "com.amazonaws.http.apache.client.impl.SdkHttpClient");
+  }
+
+  @Override
+  public ElementMatcher<? super TypeDescription> hierarchyMatcher() {
     return implementsInterface(named("org.apache.http.client.HttpClient"));
   }
 

--- a/dd-java-agent/instrumentation/datanucleus-4/src/main/java/datadog/trace/instrumentation/datanucleus/ExecutionContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/datanucleus-4/src/main/java/datadog/trace/instrumentation/datanucleus/ExecutionContextInstrumentation.java
@@ -39,7 +39,13 @@ public class ExecutionContextInstrumentation extends Instrumenter.Tracing {
   }
 
   @Override
-  public ElementMatcher<? super TypeDescription> typeMatcher() {
+  public ElementMatcher<? super TypeDescription> shortCutMatcher() {
+    return namedOneOf(
+        "org.datanucleus.ExecutionContextImpl", "org.datanucleus.ExecutionContextThreadedImpl");
+  }
+
+  @Override
+  public ElementMatcher<? super TypeDescription> hierarchyMatcher() {
     return implementsInterface(named("org.datanucleus.ExecutionContext"));
   }
 

--- a/dd-java-agent/instrumentation/dropwizard/dropwizard-views/src/main/java/datadog/trace/instrumentation/dropwizard/view/DropwizardViewInstrumentation.java
+++ b/dd-java-agent/instrumentation/dropwizard/dropwizard-views/src/main/java/datadog/trace/instrumentation/dropwizard/view/DropwizardViewInstrumentation.java
@@ -3,6 +3,7 @@ package datadog.trace.instrumentation.dropwizard.view;
 import static datadog.trace.agent.tooling.ClassLoaderMatcher.hasClassesNamed;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers.implementsInterface;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
@@ -27,7 +28,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 public final class DropwizardViewInstrumentation extends Instrumenter.Tracing {
 
   public DropwizardViewInstrumentation() {
-    super("dropwizard", "dropwizard-view");
+    super(true, "dropwizard", "dropwizard-view");
   }
 
   @Override
@@ -37,7 +38,14 @@ public final class DropwizardViewInstrumentation extends Instrumenter.Tracing {
   }
 
   @Override
-  public ElementMatcher<TypeDescription> typeMatcher() {
+  public ElementMatcher<TypeDescription> shortCutMatcher() {
+    return namedOneOf(
+        "io.dropwizard.views.freemarker.FreemarkerViewRenderer",
+        "io.dropwizard.views.mustache.MustacheViewRenderer");
+  }
+
+  @Override
+  public ElementMatcher<TypeDescription> hierarchyMatcher() {
     return implementsInterface(named("io.dropwizard.views.ViewRenderer"));
   }
 

--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/GrpcServerBuilderInstrumentation.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/GrpcServerBuilderInstrumentation.java
@@ -1,6 +1,6 @@
 package datadog.trace.instrumentation.grpc.server;
 
-import static datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers.safeHasSuperType;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers.extendsClass;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
@@ -26,7 +26,7 @@ public class GrpcServerBuilderInstrumentation extends Instrumenter.Tracing {
 
   @Override
   public ElementMatcher<TypeDescription> typeMatcher() {
-    return safeHasSuperType(named("io.grpc.ServerBuilder"));
+    return extendsClass(named("io.grpc.ServerBuilder"));
   }
 
   @Override

--- a/dd-java-agent/instrumentation/hibernate/core-3.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v3_3/AbstractHibernateInstrumentation.java
+++ b/dd-java-agent/instrumentation/hibernate/core-3.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v3_3/AbstractHibernateInstrumentation.java
@@ -7,7 +7,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 public abstract class AbstractHibernateInstrumentation extends Instrumenter.Tracing {
 
   public AbstractHibernateInstrumentation() {
-    super("hibernate", "hibernate-core");
+    super(true, "hibernate", "hibernate-core");
   }
 
   @Override

--- a/dd-java-agent/instrumentation/hibernate/core-3.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v3_3/CriteriaInstrumentation.java
+++ b/dd-java-agent/instrumentation/hibernate/core-3.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v3_3/CriteriaInstrumentation.java
@@ -32,7 +32,13 @@ public class CriteriaInstrumentation extends AbstractHibernateInstrumentation {
   }
 
   @Override
-  public ElementMatcher<TypeDescription> typeMatcher() {
+  public ElementMatcher<TypeDescription> shortCutMatcher() {
+    return namedOneOf(
+        "org.hibernate.impl.CriteriaImpl", "org.hibernate.impl.CriteriaImpl$Subcriteria");
+  }
+
+  @Override
+  public ElementMatcher<? super TypeDescription> hierarchyMatcher() {
     return implementsInterface(named("org.hibernate.Criteria"));
   }
 

--- a/dd-java-agent/instrumentation/hibernate/core-3.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v3_3/QueryInstrumentation.java
+++ b/dd-java-agent/instrumentation/hibernate/core-3.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v3_3/QueryInstrumentation.java
@@ -34,8 +34,17 @@ public class QueryInstrumentation extends AbstractHibernateInstrumentation {
   }
 
   @Override
-  public ElementMatcher<TypeDescription> typeMatcher() {
+  public ElementMatcher<? super TypeDescription> hierarchyMatcher() {
     return implementsInterface(named("org.hibernate.Query"));
+  }
+
+  @Override
+  public ElementMatcher<TypeDescription> shortCutMatcher() {
+    return namedOneOf(
+        "org.hibernate.impl.AbstractQueryImpl",
+        "org.hibernate.impl.CollectionFilterImpl",
+        "org.hibernate.impl.QueryImpl",
+        "org.hibernate.impl.SQLQueryImpl");
   }
 
   @Override

--- a/dd-java-agent/instrumentation/hibernate/core-3.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v3_3/SessionFactoryInstrumentation.java
+++ b/dd-java-agent/instrumentation/hibernate/core-3.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v3_3/SessionFactoryInstrumentation.java
@@ -43,7 +43,12 @@ public class SessionFactoryInstrumentation extends AbstractHibernateInstrumentat
   }
 
   @Override
-  public ElementMatcher<TypeDescription> typeMatcher() {
+  public ElementMatcher<TypeDescription> shortCutMatcher() {
+    return named("org.hibernate.impl.SessionFactoryImpl");
+  }
+
+  @Override
+  public ElementMatcher<TypeDescription> hierarchyMatcher() {
     return implementsInterface(named("org.hibernate.SessionFactory"));
   }
 

--- a/dd-java-agent/instrumentation/hibernate/core-3.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v3_3/SessionInstrumentation.java
+++ b/dd-java-agent/instrumentation/hibernate/core-3.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v3_3/SessionInstrumentation.java
@@ -50,7 +50,12 @@ public class SessionInstrumentation extends AbstractHibernateInstrumentation {
   }
 
   @Override
-  public ElementMatcher<TypeDescription> typeMatcher() {
+  public ElementMatcher<TypeDescription> shortCutMatcher() {
+    return namedOneOf("org.hibernate.impl.SessionImpl", "org.hibernate.impl.StatelessSessionImpl");
+  }
+
+  @Override
+  public ElementMatcher<TypeDescription> hierarchyMatcher() {
     return implementsInterface(
         namedOneOf("org.hibernate.Session", "org.hibernate.StatelessSession"));
   }

--- a/dd-java-agent/instrumentation/hibernate/core-3.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v3_3/TransactionInstrumentation.java
+++ b/dd-java-agent/instrumentation/hibernate/core-3.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v3_3/TransactionInstrumentation.java
@@ -2,6 +2,7 @@ package datadog.trace.instrumentation.hibernate.core.v3_3;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers.implementsInterface;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
 import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
@@ -31,7 +32,16 @@ public class TransactionInstrumentation extends AbstractHibernateInstrumentation
   }
 
   @Override
-  public ElementMatcher<TypeDescription> typeMatcher() {
+  public ElementMatcher<TypeDescription> shortCutMatcher() {
+    return namedOneOf(
+        "org.hibernate.engine.transaction.spi.CMTTransaction",
+        "org.hibernate.transaction.CMTTransaction",
+        "org.hibernate.transaction.JDBCTransaction",
+        "org.hibernate.transaction.JTATransaction");
+  }
+
+  @Override
+  public ElementMatcher<? super TypeDescription> hierarchyMatcher() {
     return implementsInterface(named("org.hibernate.Transaction"));
   }
 

--- a/dd-java-agent/instrumentation/hibernate/core-3.3/src/test/groovy/HierarchyMatcherCriteriaTest.groovy
+++ b/dd-java-agent/instrumentation/hibernate/core-3.3/src/test/groovy/HierarchyMatcherCriteriaTest.groovy
@@ -1,0 +1,7 @@
+class HierarchyMatcherCriteriaTest extends CriteriaTest {
+  @Override
+  protected void configurePreAgent() {
+    super.configurePreAgent()
+    injectSysConfig("dd.integration.hibernate.matching.shortcut.enabled", "false")
+  }
+}

--- a/dd-java-agent/instrumentation/hibernate/core-3.3/src/test/groovy/HierarchyMatcherQueryTest.groovy
+++ b/dd-java-agent/instrumentation/hibernate/core-3.3/src/test/groovy/HierarchyMatcherQueryTest.groovy
@@ -1,0 +1,7 @@
+class HierarchyMatcherQueryTest extends QueryTest {
+  @Override
+  protected void configurePreAgent() {
+    super.configurePreAgent()
+    injectSysConfig("dd.integration.hibernate.matching.shortcut.enabled", "false")
+  }
+}

--- a/dd-java-agent/instrumentation/hibernate/core-3.3/src/test/groovy/HierarchyMatcherSessionTest.groovy
+++ b/dd-java-agent/instrumentation/hibernate/core-3.3/src/test/groovy/HierarchyMatcherSessionTest.groovy
@@ -1,0 +1,7 @@
+class HierarchyMatcherSessionTest extends SessionTest {
+  @Override
+  protected void configurePreAgent() {
+    super.configurePreAgent()
+    injectSysConfig("dd.integration.hibernate.matching.shortcut.enabled", "false")
+  }
+}

--- a/dd-java-agent/instrumentation/hibernate/core-4.0/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_0/AbstractHibernateInstrumentation.java
+++ b/dd-java-agent/instrumentation/hibernate/core-4.0/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_0/AbstractHibernateInstrumentation.java
@@ -7,7 +7,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 public abstract class AbstractHibernateInstrumentation extends Instrumenter.Tracing {
 
   public AbstractHibernateInstrumentation() {
-    super("hibernate", "hibernate-core");
+    super(true, "hibernate", "hibernate-core");
   }
 
   @Override

--- a/dd-java-agent/instrumentation/hibernate/core-4.0/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_0/CriteriaInstrumentation.java
+++ b/dd-java-agent/instrumentation/hibernate/core-4.0/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_0/CriteriaInstrumentation.java
@@ -31,7 +31,13 @@ public class CriteriaInstrumentation extends AbstractHibernateInstrumentation {
   }
 
   @Override
-  public ElementMatcher<TypeDescription> typeMatcher() {
+  public ElementMatcher<TypeDescription> shortCutMatcher() {
+    return namedOneOf(
+        "org.hibernate.internal.CriteriaImpl", "org.hibernate.internal.CriteriaImpl$Subcriteria");
+  }
+
+  @Override
+  public ElementMatcher<? super TypeDescription> hierarchyMatcher() {
     return implementsInterface(named("org.hibernate.Criteria"));
   }
 

--- a/dd-java-agent/instrumentation/hibernate/core-4.0/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_0/QueryInstrumentation.java
+++ b/dd-java-agent/instrumentation/hibernate/core-4.0/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_0/QueryInstrumentation.java
@@ -33,8 +33,18 @@ public class QueryInstrumentation extends AbstractHibernateInstrumentation {
   }
 
   @Override
-  public ElementMatcher<TypeDescription> typeMatcher() {
+  public ElementMatcher<? super TypeDescription> hierarchyMatcher() {
     return implementsInterface(named("org.hibernate.Query"));
+  }
+
+  @Override
+  public ElementMatcher<TypeDescription> shortCutMatcher() {
+    return namedOneOf(
+        "org.hibernate.query.internal.AbstractProducedQuery",
+        "org.hibernate.internal.AbstractQueryImpl",
+        "org.hibernate.internal.CollectionFilterImpl",
+        "org.hibernate.internal.QueryImpl",
+        "org.hibernate.internal.SQLQueryImpl");
   }
 
   @Override

--- a/dd-java-agent/instrumentation/hibernate/core-4.0/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_0/SessionFactoryInstrumentation.java
+++ b/dd-java-agent/instrumentation/hibernate/core-4.0/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_0/SessionFactoryInstrumentation.java
@@ -33,7 +33,12 @@ public class SessionFactoryInstrumentation extends AbstractHibernateInstrumentat
   }
 
   @Override
-  public ElementMatcher<TypeDescription> typeMatcher() {
+  public ElementMatcher<TypeDescription> shortCutMatcher() {
+    return named("org.hibernate.internal.SessionFactoryImpl");
+  }
+
+  @Override
+  public ElementMatcher<TypeDescription> hierarchyMatcher() {
     return implementsInterface(named("org.hibernate.SessionFactory"));
   }
 

--- a/dd-java-agent/instrumentation/hibernate/core-4.0/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_0/SessionInstrumentation.java
+++ b/dd-java-agent/instrumentation/hibernate/core-4.0/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_0/SessionInstrumentation.java
@@ -46,7 +46,13 @@ public class SessionInstrumentation extends AbstractHibernateInstrumentation {
   }
 
   @Override
-  public ElementMatcher<TypeDescription> typeMatcher() {
+  public ElementMatcher<TypeDescription> shortCutMatcher() {
+    return namedOneOf(
+        "org.hibernate.internal.SessionImpl", "org.hibernate.internal.StatelessSessionImpl");
+  }
+
+  @Override
+  public ElementMatcher<TypeDescription> hierarchyMatcher() {
     return implementsInterface(named("org.hibernate.SharedSessionContract"));
   }
 

--- a/dd-java-agent/instrumentation/hibernate/core-4.0/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_0/TransactionInstrumentation.java
+++ b/dd-java-agent/instrumentation/hibernate/core-4.0/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_0/TransactionInstrumentation.java
@@ -2,6 +2,7 @@ package datadog.trace.instrumentation.hibernate.core.v4_0;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers.implementsInterface;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
 import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
@@ -30,7 +31,16 @@ public class TransactionInstrumentation extends AbstractHibernateInstrumentation
   }
 
   @Override
-  public ElementMatcher<TypeDescription> typeMatcher() {
+  public ElementMatcher<TypeDescription> shortCutMatcher() {
+    return namedOneOf(
+        "org.hibernate.engine.transaction.spi.AbstractTransactionImpl",
+        "org.hibernate.engine.transaction.internal.jta.CMTTransaction",
+        "org.hibernate.engine.transaction.internal.jdbc.JdbcTransaction",
+        "org.hibernate.engine.transaction.internal.jta.JtaTransaction");
+  }
+
+  @Override
+  public ElementMatcher<? super TypeDescription> hierarchyMatcher() {
     return implementsInterface(named("org.hibernate.Transaction"));
   }
 

--- a/dd-java-agent/instrumentation/hibernate/core-4.0/src/test/groovy/HierarchyMatcherCriteriaTest.groovy
+++ b/dd-java-agent/instrumentation/hibernate/core-4.0/src/test/groovy/HierarchyMatcherCriteriaTest.groovy
@@ -1,0 +1,7 @@
+class HierarchyMatcherCriteriaTest extends CriteriaTest {
+  @Override
+  protected void configurePreAgent() {
+    super.configurePreAgent()
+    injectSysConfig("dd.integration.hibernate.matching.shortcut.enabled", "false")
+  }
+}

--- a/dd-java-agent/instrumentation/hibernate/core-4.0/src/test/groovy/HierarchyMatcherQueryTest.groovy
+++ b/dd-java-agent/instrumentation/hibernate/core-4.0/src/test/groovy/HierarchyMatcherQueryTest.groovy
@@ -1,0 +1,7 @@
+class HierarchyMatcherQueryTest extends QueryTest {
+  @Override
+  protected void configurePreAgent() {
+    super.configurePreAgent()
+    injectSysConfig("dd.integration.hibernate.matching.shortcut.enabled", "false")
+  }
+}

--- a/dd-java-agent/instrumentation/hibernate/core-4.0/src/test/groovy/HierarchyMatcherSessionTest.groovy
+++ b/dd-java-agent/instrumentation/hibernate/core-4.0/src/test/groovy/HierarchyMatcherSessionTest.groovy
@@ -1,0 +1,7 @@
+class HierarchyMatcherSessionTest extends SessionTest {
+  @Override
+  protected void configurePreAgent() {
+    super.configurePreAgent()
+    injectSysConfig("dd.integration.hibernate.matching.shortcut.enabled", "false")
+  }
+}

--- a/dd-java-agent/instrumentation/hibernate/core-4.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_3/ProcedureCallInstrumentation.java
+++ b/dd-java-agent/instrumentation/hibernate/core-4.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_3/ProcedureCallInstrumentation.java
@@ -23,7 +23,7 @@ import org.hibernate.procedure.ProcedureCall;
 public class ProcedureCallInstrumentation extends Instrumenter.Tracing {
 
   public ProcedureCallInstrumentation() {
-    super("hibernate", "hibernate-core");
+    super(true, "hibernate", "hibernate-core");
   }
 
   @Override
@@ -47,7 +47,12 @@ public class ProcedureCallInstrumentation extends Instrumenter.Tracing {
   }
 
   @Override
-  public ElementMatcher<TypeDescription> typeMatcher() {
+  public ElementMatcher<TypeDescription> shortCutMatcher() {
+    return named("org.hibernate.procedure.internal.ProcedureCallImpl");
+  }
+
+  @Override
+  public ElementMatcher<TypeDescription> hierarchyMatcher() {
     return implementsInterface(named("org.hibernate.procedure.ProcedureCall"));
   }
 

--- a/dd-java-agent/instrumentation/hibernate/core-4.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_3/SessionInstrumentation.java
+++ b/dd-java-agent/instrumentation/hibernate/core-4.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_3/SessionInstrumentation.java
@@ -4,6 +4,7 @@ import static datadog.trace.agent.tooling.ClassLoaderMatcher.hasClassesNamed;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers.hasInterface;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers.implementsInterface;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
 import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.returns;
@@ -28,7 +29,7 @@ import org.hibernate.procedure.ProcedureCall;
 public class SessionInstrumentation extends Instrumenter.Tracing {
 
   public SessionInstrumentation() {
-    super("hibernate", "hibernate-core");
+    super(true, "hibernate", "hibernate-core");
   }
 
   static final ElementMatcher<ClassLoader> CLASS_LOADER_MATCHER =
@@ -58,8 +59,19 @@ public class SessionInstrumentation extends Instrumenter.Tracing {
   }
 
   @Override
-  public ElementMatcher<TypeDescription> typeMatcher() {
+  public ElementMatcher<? super TypeDescription> hierarchyMatcher() {
     return implementsInterface(named("org.hibernate.SharedSessionContract"));
+  }
+
+  @Override
+  public ElementMatcher<TypeDescription> shortCutMatcher() {
+    return namedOneOf(
+        "org.hibernate.internal.AbstractSessionImpl",
+        "org.hibernate.internal.AbstractSharedSessionContract",
+        "org.hibernate.impl.SessionImpl",
+        "org.hibernate.impl.StatelessSessionImpl",
+        "org.hibernate.internal.SessionImpl",
+        "org.hibernate.internal.StatelessSessionImpl");
   }
 
   @Override

--- a/dd-java-agent/instrumentation/hibernate/core-4.3/src/test/groovy/HierarchyMatcherProcedureCallTest.groovy
+++ b/dd-java-agent/instrumentation/hibernate/core-4.3/src/test/groovy/HierarchyMatcherProcedureCallTest.groovy
@@ -1,0 +1,17 @@
+class HierarchyMatcherProcedureCallTest extends ProcedureCallTest {
+  @Override
+  protected void configurePreAgent() {
+    super.configurePreAgent()
+    injectSysConfig("dd.integration.hibernate.matching.shortcut.enabled", "false")
+  }
+
+  @Override
+  def storedProcName() {
+    return "ANOTHER_TEST_PROC"
+  }
+
+  @Override
+  def storedProcSQL() {
+    return "CREATE PROCEDURE ${storedProcName()}() MODIFIES SQL DATA BEGIN ATOMIC INSERT INTO Value VALUES (999, 'wilma'); END"
+  }
+}

--- a/dd-java-agent/instrumentation/hibernate/core-4.3/src/test/groovy/HierarchyMatcherSpringJpaTest.groovy
+++ b/dd-java-agent/instrumentation/hibernate/core-4.3/src/test/groovy/HierarchyMatcherSpringJpaTest.groovy
@@ -1,0 +1,8 @@
+class HierarchyMatcherSpringJpaTest extends SpringJpaTest {
+
+  @Override
+  protected void configurePreAgent() {
+    super.configurePreAgent()
+    injectSysConfig("dd.integration.hibernate.matching.shortcut.enabled", "false")
+  }
+}

--- a/dd-java-agent/instrumentation/hibernate/core-4.3/src/test/groovy/ProcedureCallTest.groovy
+++ b/dd-java-agent/instrumentation/hibernate/core-4.3/src/test/groovy/ProcedureCallTest.groovy
@@ -47,7 +47,7 @@ class ProcedureCallTest extends AgentTestRunner {
       // Create a stored procedure.
       Connection conn = DriverManager.getConnection("jdbc:hsqldb:mem:test", "sa", "1")
       Statement stmt = conn.createStatement()
-      stmt.execute("CREATE PROCEDURE TEST_PROC() MODIFIES SQL DATA BEGIN ATOMIC INSERT INTO Value VALUES (420, 'fred'); END")
+      stmt.execute(storedProcSQL())
       stmt.close()
       conn.close()
 
@@ -62,13 +62,21 @@ class ProcedureCallTest extends AgentTestRunner {
     }
   }
 
+  def storedProcSQL() {
+    return "CREATE PROCEDURE ${storedProcName()}() MODIFIES SQL DATA BEGIN ATOMIC INSERT INTO Value VALUES (420, 'fred'); END"
+  }
+
+  def storedProcName() {
+    return "TEST_PROC"
+  }
+
   def "test ProcedureCall"() {
     setup:
 
     Session session = sessionFactory.openSession()
     session.beginTransaction()
 
-    ProcedureCall call = session.createStoredProcedureCall("TEST_PROC")
+    ProcedureCall call = session.createStoredProcedureCall(storedProcName())
     call.getOutputs()
 
     session.getTransaction().commit()
@@ -104,7 +112,7 @@ class ProcedureCallTest extends AgentTestRunner {
         }
         span {
           serviceName "hibernate"
-          resourceName "TEST_PROC"
+          resourceName storedProcName()
           operationName "hibernate.procedure.getOutputs"
           spanType DDSpanTypes.HIBERNATE
           childOf span(0)
@@ -138,7 +146,7 @@ class ProcedureCallTest extends AgentTestRunner {
     Session session = sessionFactory.openSession()
     session.beginTransaction()
 
-    ProcedureCall call = session.createStoredProcedureCall("TEST_PROC")
+    ProcedureCall call = session.createStoredProcedureCall(storedProcName())
     call.registerParameter("nonexistent", Long, ParameterMode.IN)
     call.getParameterRegistration("nonexistent").bindValue(420L)
     try {
@@ -179,7 +187,7 @@ class ProcedureCallTest extends AgentTestRunner {
         }
         span {
           serviceName "hibernate"
-          resourceName "TEST_PROC"
+          resourceName storedProcName()
           operationName "hibernate.procedure.getOutputs"
           spanType DDSpanTypes.HIBERNATE
           childOf span(0)

--- a/dd-java-agent/instrumentation/quartz-2/src/main/java/datadog/trace/instrumentation/quartz/QuartzSchedulingInstrumentation.java
+++ b/dd-java-agent/instrumentation/quartz-2/src/main/java/datadog/trace/instrumentation/quartz/QuartzSchedulingInstrumentation.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.quartz;
 
+import static datadog.trace.agent.tooling.ClassLoaderMatcher.hasClassesNamed;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers.implementsInterface;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
@@ -25,6 +26,11 @@ public final class QuartzSchedulingInstrumentation extends Instrumenter.Tracing 
 
   public QuartzSchedulingInstrumentation() {
     super("quartz");
+  }
+
+  @Override
+  public ElementMatcher<ClassLoader> classLoaderMatcher() {
+    return hasClassesNamed("org.quartz.Job");
   }
 
   @Override

--- a/dd-java-agent/instrumentation/rediscala-1.8.0/src/main/java/datadog/trace/instrumentation/rediscala/RediscalaInstrumentation.java
+++ b/dd-java-agent/instrumentation/rediscala-1.8.0/src/main/java/datadog/trace/instrumentation/rediscala/RediscalaInstrumentation.java
@@ -16,6 +16,7 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import java.util.Map;
@@ -41,12 +42,14 @@ public final class RediscalaInstrumentation extends Instrumenter.Tracing {
 
   @Override
   public ElementMatcher<TypeDescription> typeMatcher() {
-    return safeHasSuperType(
-        namedOneOf(
-            "redis.ActorRequest",
-            "redis.Request",
-            "redis.BufferedRequest",
-            "redis.RoundRobinPoolRequest"));
+    return NameMatchers.nameStartsWith("redis.")
+        .and(
+            safeHasSuperType(
+                namedOneOf(
+                    "redis.ActorRequest",
+                    "redis.Request",
+                    "redis.BufferedRequest",
+                    "redis.RoundRobinPoolRequest")));
   }
 
   @Override

--- a/dd-java-agent/instrumentation/scala-concurrent/src/main/java/datadog/trace/instrumentation/scala/concurrent/ScalaForkJoinTaskInstrumentation.java
+++ b/dd-java-agent/instrumentation/scala-concurrent/src/main/java/datadog/trace/instrumentation/scala/concurrent/ScalaForkJoinTaskInstrumentation.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.scala.concurrent;
 
+import static datadog.trace.agent.tooling.ClassLoaderMatcher.hasClassesNamed;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers.extendsClass;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
@@ -32,6 +33,11 @@ public final class ScalaForkJoinTaskInstrumentation extends Instrumenter.Tracing
 
   public ScalaForkJoinTaskInstrumentation() {
     super("java_concurrent", "scala_concurrent");
+  }
+
+  @Override
+  public ElementMatcher<ClassLoader> classLoaderMatcher() {
+    return hasClassesNamed("scala.concurrent.forkjoin.ForkJoinTask");
   }
 
   @Override

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -1300,6 +1300,12 @@ public class Config {
     return isEnabled(integrationNames, "integration.", ".enabled", defaultEnabled);
   }
 
+  public boolean isIntegrationShortCutMatchingEnabled(
+      final Iterable<String> integrationNames, final boolean defaultEnabled) {
+    return isEnabled(
+        integrationNames, "integration.", ".matching.shortcut.enabled", defaultEnabled);
+  }
+
   public boolean isJmxFetchIntegrationEnabled(
       final Iterable<String> integrationNames, final boolean defaultEnabled) {
     return isEnabled(integrationNames, "jmxfetch.", ".enabled", defaultEnabled);


### PR DESCRIPTION
When a framework's interface is effectively closed and not open for external implementation, we don't need to support _any_ implementation, just the names of the implementations. There are more places we can do this safely (e.g. rabbitmq `Channel`) but I believe all of the changes here are interfaces not implemented externally.

`Tracing` instrumentations now have optionally two type matching concepts:

* `shortCutMatcher()` - disabled by default, fast, will match all known implementations, may miss custom implementations. Arguably provides the best experience for a balance of coverage against startup performance, but if we made it default it would be annoying for users where things "just work" in ways we don't know about and they need to set a property to maintain tracing and metrics. Enabled by `-Ddd.integration.<instrumentation name>.matching.shortcut.enabled=true` e.g. `-Ddd.integration.httpclient.matching.shortcut.enabled=true` 
* `hierarchyMatcher()` - enabled by default, will search the type hierarchy for all implementations, but it's slow. 

Instrumenters don't need to make this distinction: they can just override `Tracing.typeMatcher`. Some interfaces are not suitable for short cut matching - e.g. runnables, listeners, promises, anything with a template method, anything where the API involves inheriting or implementing a type, so we should reserve the short cuts for closed interfaces.

I enabled short cuts by default for
* Dropwizard Views
* Hibernate (has the added benefit of distinguishing between versions prior to muzzle, reducing the number of failing muzzle match attempts)

I'm open to suggestions about whether these are wise choices.