### PR TITLE
Force new line in PrintingWriter

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/PrintingWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/PrintingWriter.java
@@ -7,6 +7,7 @@ import datadog.trace.core.DDSpan;
 import datadog.trace.core.processor.TraceProcessor;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -40,6 +41,7 @@ public class PrintingWriter implements Writer {
     try {
       synchronized (sink) {
         jsonAdapter.toJson(sink, Collections.singletonMap("traces", tracesList));
+        sink.writeString("\n", StandardCharsets.UTF_8);
         sink.flush();
       }
     } catch (final IOException e) {

--- a/dd-trace-core/src/test/groovy/datadog/trace/api/writer/PrintingWriterTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/api/writer/PrintingWriterTest.groovy
@@ -108,4 +108,48 @@ class PrintingWriterTest extends DDCoreSpecification {
       assert it["meta"] instanceof Map
     }
   }
+
+  def "test printing multiple traces"() {
+    given:
+    def buffer = new Buffer()
+    def writer = new PrintingWriter(buffer.outputStream(), false)
+
+    when:
+    writer.write(sampleTrace)
+    writer.write(secondTrace)
+    Map<String, List<List<Map>>> result1 = adapter.fromJson(buffer.readUtf8Line())
+    Map<String, List<List<Map>>> result2 = adapter.fromJson(buffer.readUtf8Line())
+
+    then:
+    result1["traces"][0].size() == sampleTrace.size()
+    result2["traces"][0].each {
+      assert it["service"] == "fakeService"
+      assert it["name"] == "fakeOperation"
+      assert it["resource"] == "fakeResource"
+      assert it["type"] == "fakeType"
+      assert it["trace_id"] instanceof Number
+      assert it["span_id"] instanceof Number
+      assert it["parent_id"] instanceof Number
+      assert it["start"] instanceof Number
+      assert it["duration"] instanceof Number
+      assert it["error"] == 0
+      assert it["metrics"] instanceof Map
+      assert it["meta"] instanceof Map
+    }
+    result2["traces"][0].size() == secondTrace.size()
+    result2["traces"][0].each {
+      assert it["service"] == "fakeService"
+      assert it["name"] == "fakeOperation"
+      assert it["resource"] == "fakeResource"
+      assert it["type"] == "fakeType"
+      assert it["trace_id"] instanceof Number
+      assert it["span_id"] instanceof Number
+      assert it["parent_id"] instanceof Number
+      assert it["start"] instanceof Number
+      assert it["duration"] instanceof Number
+      assert it["error"] == 0
+      assert it["metrics"] instanceof Map
+      assert it["meta"] instanceof Map
+    }
+  }
 }


### PR DESCRIPTION
The JSON for traces and metrics on AWS Lambda are sometimes logged on the same line, leading to invalid JSON.