### PR TITLE
Test for parsing ContainerID from another cgroups file format

### DIFF
--- a/utils/container-utils/src/test/groovy/ContainerInfoTest.groovy
+++ b/utils/container-utils/src/test/groovy/ContainerInfoTest.groovy
@@ -127,6 +127,7 @@ class ContainerInfoTest extends DDSpecification {
 3:net_cls,net_prio:/kubepods/besteffort/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1
 2:hugetlb:/kubepods/besteffort/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1
 1:name=systemd:/kubepods/besteffort/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1"""
+    "7b8952daecf4c0e44bbcefe1b5c5ebc7b4839d4eefeccefe694709d3809b6199" | "2d3da189_6407_48e3_9ab6_78188d75e609" | 1 | "1:name=systemd:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod2d3da189_6407_48e3_9ab6_78188d75e609.slice/docker-7b8952daecf4c0e44bbcefe1b5c5ebc7b4839d4eefeccefe694709d3809b6199.scope"
 
     // ECS
     "38fac3e99302b3622be089dd41e7ccf38aff368a86cc339972075136ee2710ce" | null                                   | 9    | """9:perf_event:/ecs/haissam-ecs-classic/5a0d5ceddf6c44c1928d367a815d890f/38fac3e99302b3622be089dd41e7ccf38aff368a86cc339972075136ee2710ce


### PR DESCRIPTION
Python recently had an issue with container ID parsing in https://github.com/DataDog/dd-trace-py/issues/2314. This adds the problematic format to our test suite to ensure we are not affected

