### PR TITLE
premain low hanging fruit

### DIFF
--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -224,11 +224,6 @@ public class Config {
 
   private static final Logger log = LoggerFactory.getLogger(Config.class);
 
-  private static final String TRACE_AGENT_URL_TEMPLATE = "http://%s:%d";
-
-  private static final String PROFILING_REMOTE_URL_TEMPLATE = "https://intake.profile.%s/v1/input";
-  private static final String PROFILING_LOCAL_URL_TEMPLATE = "http://%s:%d/profiling/v1/input";
-
   private static final Pattern ENV_REPLACEMENT = Pattern.compile("[^a-zA-Z0-9_]");
   private static final String SPLIT_BY_SPACE_OR_COMMA_REGEX = "[,\\s]+";
 
@@ -476,7 +471,7 @@ public class Config {
     }
 
     if (rebuildAgentUrl) {
-      agentUrl = String.format(TRACE_AGENT_URL_TEMPLATE, agentHost, agentPort);
+      agentUrl = "http://" + agentHost + ":" + agentPort;
     } else {
       agentUrl = agentUrlFromEnvironment;
     }
@@ -1287,10 +1282,10 @@ public class Config {
       return profilingUrl;
     } else if (profilingAgentless) {
       // when agentless profiling is turned on we send directly to our intake
-      return String.format(PROFILING_REMOTE_URL_TEMPLATE, site);
+      return "https://intake.profile." + site + "/v1/input";
     } else {
       // when profilingUrl and agentless are not set we send to the dd trace agent running locally
-      return String.format(PROFILING_LOCAL_URL_TEMPLATE, agentHost, agentPort);
+      return "http://" + agentHost + ":" + agentPort + "/profiling/v1/input";
     }
   }
 

--- a/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/EnvironmentConfigSource.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/EnvironmentConfigSource.java
@@ -1,28 +1,11 @@
 package datadog.trace.bootstrap.config.provider;
 
-import java.util.regex.Pattern;
-import javax.annotation.Nonnull;
+import static datadog.trace.util.Strings.propertyNameToEnvironmentVariableName;
 
 final class EnvironmentConfigSource extends ConfigProvider.Source {
-  private static final Pattern ENV_REPLACEMENT = Pattern.compile("[^a-zA-Z0-9_]");
 
   @Override
   protected String get(String key) {
     return System.getenv(propertyNameToEnvironmentVariableName(key));
-  }
-
-  /**
-   * Converts the property name, e.g. 'service.name' into a public environment variable name, e.g.
-   * `DD_SERVICE_NAME`.
-   *
-   * @param setting The setting name, e.g. `service.name`
-   * @return The public facing environment variable name
-   */
-  @Nonnull
-  private static String propertyNameToEnvironmentVariableName(final String setting) {
-    return ENV_REPLACEMENT
-        .matcher(
-            SystemPropertiesConfigSource.propertyNameToSystemPropertyName(setting).toUpperCase())
-        .replaceAll("_");
   }
 }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/PropertiesConfigSource.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/PropertiesConfigSource.java
@@ -1,5 +1,7 @@
 package datadog.trace.bootstrap.config.provider;
 
+import static datadog.trace.util.Strings.propertyNameToSystemPropertyName;
+
 import java.util.Properties;
 
 final class PropertiesConfigSource extends ConfigProvider.Source {
@@ -14,9 +16,6 @@ final class PropertiesConfigSource extends ConfigProvider.Source {
 
   @Override
   protected String get(String key) {
-    return props.getProperty(
-        useSystemPropertyFormat
-            ? SystemPropertiesConfigSource.propertyNameToSystemPropertyName(key)
-            : key);
+    return props.getProperty(useSystemPropertyFormat ? propertyNameToSystemPropertyName(key) : key);
   }
 }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/SystemPropertiesConfigSource.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/SystemPropertiesConfigSource.java
@@ -1,24 +1,11 @@
 package datadog.trace.bootstrap.config.provider;
 
-import javax.annotation.Nonnull;
+import static datadog.trace.util.Strings.propertyNameToSystemPropertyName;
 
 public final class SystemPropertiesConfigSource extends ConfigProvider.Source {
-  private static final String PREFIX = "dd.";
 
   @Override
   protected String get(String key) {
     return System.getProperty(propertyNameToSystemPropertyName(key));
-  }
-
-  /**
-   * Converts the property name, e.g. 'service.name' into a public system property name, e.g.
-   * `dd.service.name`.
-   *
-   * @param setting The setting name, e.g. `service.name`
-   * @return The public facing system property name
-   */
-  @Nonnull
-  static String propertyNameToSystemPropertyName(final String setting) {
-    return PREFIX + setting;
   }
 }

--- a/internal-api/src/main/java/datadog/trace/util/Strings.java
+++ b/internal-api/src/main/java/datadog/trace/util/Strings.java
@@ -1,5 +1,7 @@
 package datadog.trace.util;
 
+import javax.annotation.Nonnull;
+
 public final class Strings {
 
   public static String toEnvVar(String string) {
@@ -79,5 +81,29 @@ public final class Strings {
     int i = sb.indexOf(delimiter);
     if (i != -1) sb.replace(i, i + delimiter.length(), replacement);
     return sb.toString();
+  }
+
+  /**
+   * Converts the property name, e.g. 'service.name' into a public environment variable name, e.g.
+   * `DD_SERVICE_NAME`.
+   *
+   * @param setting The setting name, e.g. `service.name`
+   * @return The public facing environment variable name
+   */
+  @Nonnull
+  public static String propertyNameToEnvironmentVariableName(final String setting) {
+    return "DD_" + setting.replace('.', '_').replace('-', '_').toUpperCase();
+  }
+
+  /**
+   * Converts the property name, e.g. 'service.name' into a public system property name, e.g.
+   * `dd.service.name`.
+   *
+   * @param setting The setting name, e.g. `service.name`
+   * @return The public facing system property name
+   */
+  @Nonnull
+  public static String propertyNameToSystemPropertyName(final String setting) {
+    return "dd." + setting;
   }
 }

--- a/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -85,9 +85,11 @@ import static datadog.trace.api.config.TracerConfig.TRACE_SAMPLE_RATE
 import static datadog.trace.api.config.TracerConfig.TRACE_SAMPLING_OPERATION_RULES
 import static datadog.trace.api.config.TracerConfig.TRACE_SAMPLING_SERVICE_RULES
 import static datadog.trace.api.config.TracerConfig.WRITER_TYPE
-import static datadog.trace.bootstrap.config.provider.SystemPropertiesConfigSource.PREFIX
 
 class ConfigTest extends DDSpecification {
+
+  static final String PREFIX = "dd."
+
   @Rule
   public final FixedCapturedEnvironment fixedCapturedEnvironment = new FixedCapturedEnvironment()
 

--- a/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -913,7 +913,11 @@ class ConfigTest extends DDSpecification {
     "key 1!:va|ue_1,"                                             | ["key 1!": "va|ue_1"]
     "key 1!:va|ue_1 "                                             | ["key 1!": "va|ue_1"]
     " key1 :value1 ,\t key2:  value2"                             | [key1: "value1", key2: "value2"]
+    // allowing this feels inconsistent
     "a:b,c,d"                                                     | [a: "b,c,d"]
+    // see above
+    "a:b,c,d,k:v"                                                 | [:]
+    "key1 :value1  \t key2:  value2"                              | [key1: "value1", key2: "value2"]
     "dyno:web.1 dynotype:web buildpackversion:dev appname:******" | ["dyno": "web.1", "dynotype": "web", "buildpackversion": "dev", "appname": "******"]
     // Invalid strings:
     ""                                                            | [:]
@@ -921,10 +925,14 @@ class ConfigTest extends DDSpecification {
     "a"                                                           | [:]
     "a,1"                                                         | [:]
     "in:val:id"                                                   | [:]
+    "a:b,in:val:id,x:y"                                           | [:]
     "a:b:c:d"                                                     | [:]
     "!a"                                                          | [:]
-    // ambiguous - is properties are space separated they must be trimmed
-    "key1 :value1  \t key2:  value2"                              | [:]
+    "    "                                                        | [:]
+    ",,,,"                                                        | [:]
+    ":,:,:,:,"                                                    | [:]
+    ": : : : "                                                    | [:]
+    "::::"                                                        | [:]
     // spotless:on
   }
 


### PR DESCRIPTION
I saw `String.format` and `Pattern` construction show up in premain in benchmarks which load thousands of classes and run for nearly 10 seconds, so this PR replaces them with manual alternatives.