### PR TITLE
Upgrade jmxfetch to 0.43.0

### DIFF
--- a/dd-java-agent/agent-jmxfetch/agent-jmxfetch.gradle
+++ b/dd-java-agent/agent-jmxfetch/agent-jmxfetch.gradle
@@ -4,7 +4,7 @@ plugins {
 apply from: "$rootDir/gradle/java.gradle"
 
 dependencies {
-  compile('com.datadoghq:jmxfetch:0.39.0') {
+  compile('com.datadoghq:jmxfetch:0.43.0') {
     exclude group: 'org.apache.logging.log4j', module: 'log4j-slf4j-impl'
     exclude group: 'org.apache.logging.log4j', module: 'log4j-core'
     exclude group: 'org.slf4j', module: 'slf4j-api'

--- a/dd-java-agent/agent-jmxfetch/src/main/java/datadog/trace/agent/jmxfetch/AgentStatsdReporter.java
+++ b/dd-java-agent/agent-jmxfetch/src/main/java/datadog/trace/agent/jmxfetch/AgentStatsdReporter.java
@@ -3,6 +3,7 @@ package datadog.trace.agent.jmxfetch;
 import datadog.trace.api.StatsDClient;
 import org.datadog.jmxfetch.Instance;
 import org.datadog.jmxfetch.JmxAttribute;
+import org.datadog.jmxfetch.reporter.LoggingErrorHandler;
 import org.datadog.jmxfetch.reporter.Reporter;
 
 /** Based on {@link org.datadog.jmxfetch.reporter.StatsdReporter}. */
@@ -12,6 +13,7 @@ public final class AgentStatsdReporter extends Reporter {
 
   public AgentStatsdReporter(final StatsDClient statsd) {
     this.statsd = statsd;
+    this.handler = new ErrorHandler();
   }
 
   @Override
@@ -54,5 +56,18 @@ public final class AgentStatsdReporter extends Reporter {
   @Override
   public void displayInstanceName(final Instance instance) {
     throw new UnsupportedOperationException();
+  }
+
+  /** Handler that delegates to the shared statsd connection for error tracking purposes. */
+  final class ErrorHandler extends LoggingErrorHandler {
+    @Override
+    public void handle(final Exception error) {
+      statsd.error(error);
+    }
+
+    @Override
+    public int getErrors() {
+      return statsd.getErrorCount();
+    }
   }
 }

--- a/dd-java-agent/agent-jmxfetch/src/main/java/datadog/trace/agent/jmxfetch/JMXFetch.java
+++ b/dd-java-agent/agent-jmxfetch/src/main/java/datadog/trace/agent/jmxfetch/JMXFetch.java
@@ -5,6 +5,7 @@ import static datadog.trace.util.AgentThreadFactory.newAgentThread;
 import static org.datadog.jmxfetch.AppConfig.ACTION_COLLECT;
 
 import datadog.trace.api.Config;
+import datadog.trace.api.StatsDClient;
 import datadog.trace.api.StatsDClientManager;
 import de.thetaphi.forbiddenapis.SuppressForbidden;
 import java.io.IOException;
@@ -19,7 +20,6 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import org.datadog.jmxfetch.App;
 import org.datadog.jmxfetch.AppConfig;
-import org.datadog.jmxfetch.reporter.Reporter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -84,8 +84,7 @@ public class JMXFetch {
           "statsd:" + host + ":" + port);
     }
 
-    final Reporter reporter =
-        new AgentStatsdReporter(statsDClientManager.statsDClient(host, port, null, null));
+    final StatsDClient statsd = statsDClientManager.statsDClient(host, port, null, null);
 
     final AppConfig.AppConfigBuilder configBuilder =
         AppConfig.builder()
@@ -101,7 +100,7 @@ public class JMXFetch {
             .metricConfigFiles(metricsConfigs)
             .refreshBeansPeriod(refreshBeansPeriod)
             .globalTags(globalTags)
-            .reporter(reporter);
+            .reporter(new AgentStatsdReporter(statsd));
 
     if (checkPeriod != null) {
       configBuilder.checkPeriod(checkPeriod);

--- a/dd-trace-core/src/main/java/datadog/trace/core/monitor/DDAgentStatsDClient.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/monitor/DDAgentStatsDClient.java
@@ -88,6 +88,16 @@ final class DDAgentStatsDClient implements StatsDClient {
   }
 
   @Override
+  public void error(final Exception error) {
+    connection.handle(error);
+  }
+
+  @Override
+  public int getErrorCount() {
+    return connection.getErrorCount();
+  }
+
+  @Override
   public void close() {
     connection.release();
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/monitor/DDAgentStatsDConnection.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/monitor/DDAgentStatsDConnection.java
@@ -21,6 +21,7 @@ final class DDAgentStatsDConnection implements StatsDClientErrorHandler {
   private final int port;
 
   private final AtomicInteger clientCount = new AtomicInteger(0);
+  private final AtomicInteger errorCount = new AtomicInteger(0);
   volatile com.timgroup.statsd.StatsDClient statsd = NO_OP;
 
   DDAgentStatsDConnection(final String host, final int port) {
@@ -30,6 +31,7 @@ final class DDAgentStatsDConnection implements StatsDClientErrorHandler {
 
   @Override
   public void handle(final Exception e) {
+    errorCount.incrementAndGet();
     log.error(
         "{} in StatsD client - {}", e.getClass().getSimpleName(), statsDAddress(host, port), e);
   }
@@ -44,6 +46,10 @@ final class DDAgentStatsDConnection implements StatsDClientErrorHandler {
     if (clientCount.decrementAndGet() == 0) {
       doClose();
     }
+  }
+
+  public int getErrorCount() {
+    return errorCount.get();
   }
 
   private void scheduleConnect() {

--- a/dd-trace-core/src/main/java/datadog/trace/core/monitor/LoggingStatsDClient.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/monitor/LoggingStatsDClient.java
@@ -117,6 +117,14 @@ public final class LoggingStatsDClient implements StatsDClient {
   }
 
   @Override
+  public void error(final Exception error) {}
+
+  @Override
+  public int getErrorCount() {
+    return 0;
+  }
+
+  @Override
   public void close() {}
 
   private static String join(final String... tags) {

--- a/internal-api/src/main/java/datadog/trace/api/NoOpStatsDClient.java
+++ b/internal-api/src/main/java/datadog/trace/api/NoOpStatsDClient.java
@@ -28,5 +28,13 @@ final class NoOpStatsDClient implements StatsDClient {
       final String... tags) {}
 
   @Override
+  public void error(Exception error) {}
+
+  @Override
+  public int getErrorCount() {
+    return 0;
+  }
+
+  @Override
   public void close() {}
 }

--- a/internal-api/src/main/java/datadog/trace/api/StatsDClient.java
+++ b/internal-api/src/main/java/datadog/trace/api/StatsDClient.java
@@ -19,6 +19,10 @@ public interface StatsDClient extends Closeable {
 
   void serviceCheck(String serviceCheckName, String status, String message, String... tags);
 
+  void error(Exception error);
+
+  int getErrorCount();
+
   @Override
   void close();
 }


### PR DESCRIPTION
https://github.com/DataDog/jmxfetch/releases

JMXFetch 0.40.1 added tracking of client errors - this PR adds support for this with the shared StatsD connection.