### PR TITLE
Introduce configuration guard for scope events (code hotspots)

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
@@ -41,6 +41,7 @@ public final class ProfilingConfig {
   public static final String PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE =
       "profiling.exception.histogram.max-collection-size";
   public static final String PROFILING_EXCLUDE_AGENT_THREADS = "profiling.exclude.agent-threads";
+  public static final String PROFILING_HOTSPTOTS_ENABLED = "profiling.hotspots.enabled";
 
   // Not intended for production use
   public static final String PROFILING_AGENTLESS = "profiling.agentless";

--- a/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/ScopeEvent.java
+++ b/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/ScopeEvent.java
@@ -42,7 +42,7 @@ public final class ScopeEvent extends Event {
   }
 
   public void addChildCpuTime(long rawCpuTime) {
-    this.childCpuTime += childCpuTime;
+    this.childCpuTime += rawCpuTime;
   }
 
   /**

--- a/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/ScopeEvent.java
+++ b/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/ScopeEvent.java
@@ -1,6 +1,8 @@
 package datadog.trace.core.jfr.openjdk;
 
 import datadog.trace.api.DDId;
+import datadog.trace.api.config.ProfilingConfig;
+import datadog.trace.bootstrap.config.provider.ConfigProvider;
 import datadog.trace.core.util.SystemAccess;
 import jdk.jfr.Category;
 import jdk.jfr.Description;
@@ -16,6 +18,9 @@ import jdk.jfr.Timespan;
 @Category("Datadog")
 @StackTrace(false)
 public final class ScopeEvent extends Event {
+  private static final boolean COLLECT_THREAD_CPU_TIME =
+      ConfigProvider.createDefault().getBoolean(ProfilingConfig.PROFILING_HOTSPTOTS_ENABLED, false);
+
   @Label("Trace Id")
   private final long traceId;
 
@@ -36,7 +41,8 @@ public final class ScopeEvent extends Event {
     this.spanId = spanId.toLong();
 
     if (isEnabled()) {
-      cpuTimeStart = SystemAccess.getCurrentThreadCpuTime();
+      cpuTimeStart =
+          COLLECT_THREAD_CPU_TIME ? SystemAccess.getCurrentThreadCpuTime() : Long.MIN_VALUE;
       begin();
     }
   }
@@ -55,7 +61,7 @@ public final class ScopeEvent extends Event {
   }
 
   public void finish() {
-    if (cpuTimeStart > 0) {
+    if (COLLECT_THREAD_CPU_TIME && cpuTimeStart > 0) {
       rawCpuTime = SystemAccess.getCurrentThreadCpuTime() - cpuTimeStart;
       cpuTime = rawCpuTime - childCpuTime;
     }

--- a/dd-trace-core/jfr-openjdk/src/test/groovy/datadog/trace/core/jfr/openjdk/ScopeEventTest.groovy
+++ b/dd-trace-core/jfr-openjdk/src/test/groovy/datadog/trace/core/jfr/openjdk/ScopeEventTest.groovy
@@ -23,6 +23,7 @@ class ScopeEventTest extends DDSpecification {
 
   def setup() {
     injectSysConfig(ProfilingConfig.PROFILING_ENABLED, "true")
+    injectSysConfig(ProfilingConfig.PROFILING_HOTSPTOTS_ENABLED, "true")
     tracer = CoreTracer.builder().writer(new ListWriter()).build()
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -652,20 +652,16 @@ public class CoreTracer implements AgentTracer.TracerAPI {
 
   @SuppressForbidden
   private static void createScopeEventFactory(ContinuableScopeManager continuableScopeManager) {
-    if (Config.get().isProfilingHotspotsEnabled()) {
-      try {
-        ExtendedScopeListener scopeListener =
-            (ExtendedScopeListener)
-                Class.forName("datadog.trace.core.jfr.openjdk.ScopeEventFactory")
-                    .getDeclaredConstructor()
-                    .newInstance();
+    try {
+      ExtendedScopeListener scopeListener =
+          (ExtendedScopeListener)
+              Class.forName("datadog.trace.core.jfr.openjdk.ScopeEventFactory")
+                  .getDeclaredConstructor()
+                  .newInstance();
 
-        continuableScopeManager.addExtendedScopeListener(scopeListener);
-      } catch (final Throwable e) {
-        log.debug("Profiling code hotspots are not available. {}", e.getMessage());
-      }
-    } else {
-      log.debug("Profiling code hotspots are disabled");
+      continuableScopeManager.addExtendedScopeListener(scopeListener);
+    } catch (final Throwable e) {
+      log.debug("Profiling code hotspots are not available. {}", e.getMessage());
     }
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -652,16 +652,20 @@ public class CoreTracer implements AgentTracer.TracerAPI {
 
   @SuppressForbidden
   private static void createScopeEventFactory(ContinuableScopeManager continuableScopeManager) {
-    try {
-      ExtendedScopeListener scopeListener =
-          (ExtendedScopeListener)
-              Class.forName("datadog.trace.core.jfr.openjdk.ScopeEventFactory")
-                  .getDeclaredConstructor()
-                  .newInstance();
+    if (Config.get().isProfilingHotspotsEnabled()) {
+      try {
+        ExtendedScopeListener scopeListener =
+            (ExtendedScopeListener)
+                Class.forName("datadog.trace.core.jfr.openjdk.ScopeEventFactory")
+                    .getDeclaredConstructor()
+                    .newInstance();
 
-      continuableScopeManager.addExtendedScopeListener(scopeListener);
-    } catch (final Throwable e) {
-      log.debug("Profiling of ScopeEvents is not available. {}", e.getMessage());
+        continuableScopeManager.addExtendedScopeListener(scopeListener);
+      } catch (final Throwable e) {
+        log.debug("Profiling code hotspots are not available. {}", e.getMessage());
+      }
+    } else {
+      log.debug("Profiling code hotspots are disabled");
     }
   }
 

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -100,6 +100,7 @@ import static datadog.trace.api.config.ProfilingConfig.PROFILING_EXCEPTION_HISTO
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_EXCEPTION_SAMPLE_LIMIT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_EXCLUDE_AGENT_THREADS;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_HOTSPTOTS_ENABLED;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_PROXY_HOST;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_PROXY_PASSWORD;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_PROXY_PORT;
@@ -346,6 +347,7 @@ public class Config {
   private final int profilingExceptionHistogramTopItems;
   private final int profilingExceptionHistogramMaxCollectionSize;
   private final boolean profilingExcludeAgentThreads;
+  private final boolean profilingHotspotsEnabled;
 
   private final boolean kafkaClientPropagationEnabled;
   private final boolean kafkaClientBase64DecodingEnabled;
@@ -706,6 +708,9 @@ public class Config {
             DEFAULT_PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE);
 
     profilingExcludeAgentThreads = configProvider.getBoolean(PROFILING_EXCLUDE_AGENT_THREADS, true);
+
+    // code hotspots are disabled by default because of potential perf overhead they can incur
+    profilingHotspotsEnabled = configProvider.getBoolean(PROFILING_HOTSPTOTS_ENABLED, false);
 
     jdbcPreparedStatementClassName =
         configProvider.getString(JDBC_PREPARED_STATEMENT_CLASS_NAME, "");
@@ -1081,6 +1086,10 @@ public class Config {
 
   public boolean isProfilingExcludeAgentThreads() {
     return profilingExcludeAgentThreads;
+  }
+
+  public boolean isProfilingHotspotsEnabled() {
+    return profilingHotspotsEnabled;
   }
 
   public boolean isKafkaClientPropagationEnabled() {


### PR DESCRIPTION
This change adds a configuration flag for enabling the code hotspots support in the agent.
By default this support is disabled due to possible performance  overhead it may incur.

When code hotspots support is disabled the whole scope event machinery is detached from the tracer and no residual overhead is present