### PR TITLE
evaluate simple name based matching as RawMatcher

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Instrumenter.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Instrumenter.java
@@ -10,6 +10,7 @@ import static net.bytebuddy.matcher.ElementMatchers.isAnnotatedWith;
 import static net.bytebuddy.matcher.ElementMatchers.not;
 
 import datadog.trace.agent.tooling.bytebuddy.ExceptionHandlers;
+import datadog.trace.agent.tooling.bytebuddy.matcher.FailSafe;
 import datadog.trace.agent.tooling.context.FieldBackedContextProvider;
 import datadog.trace.agent.tooling.context.InstrumentationContextProvider;
 import datadog.trace.agent.tooling.context.NoopContextProvider;
@@ -157,7 +158,7 @@ public interface Instrumenter {
     private AgentBuilder.Identified.Narrowable filter(AgentBuilder agentBuilder) {
       final AgentBuilder.Identified.Narrowable narrowable;
       ElementMatcher<? super TypeDescription> typeMatcher = typeMatcher();
-      if (typeMatcher instanceof AgentBuilder.RawMatcher) {
+      if (typeMatcher instanceof AgentBuilder.RawMatcher && typeMatcher instanceof FailSafe) {
         narrowable = agentBuilder.type((AgentBuilder.RawMatcher) typeMatcher);
       } else {
         narrowable =

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/DDElementMatchers.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/DDElementMatchers.java
@@ -46,8 +46,12 @@ public class DDElementMatchers {
    * @return A matcher that returns {@code false} in case that the given matcher throws an
    *     exception.
    */
-  public static <T> ElementMatcher.Junction<T> failSafe(
+  @SuppressWarnings("unchecked")
+  public static <T> ElementMatcher<T> failSafe(
       final ElementMatcher<? super T> matcher, final String description) {
+    if (matcher instanceof FailSafe) {
+      return (ElementMatcher<T>) matcher;
+    }
     return new LoggingFailSafeMatcher<>(matcher, false, description);
   }
 

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/FailSafe.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/FailSafe.java
@@ -1,0 +1,3 @@
+package datadog.trace.agent.tooling.bytebuddy.matcher;
+
+public interface FailSafe {}

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/NameMatchers.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/NameMatchers.java
@@ -1,16 +1,20 @@
 package datadog.trace.agent.tooling.bytebuddy.matcher;
 
 import datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter;
+import java.security.ProtectionDomain;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import net.bytebuddy.agent.builder.AgentBuilder;
 import net.bytebuddy.description.NamedElement;
+import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
+import net.bytebuddy.utility.JavaModule;
 
 public final class NameMatchers<T extends NamedElement>
-    extends ElementMatcher.Junction.AbstractBase<T> {
+    extends ElementMatcher.Junction.AbstractBase<T> implements AgentBuilder.RawMatcher {
 
   private static final int NAMED = 0;
   private static final int NAME_STARTS_WITH = 1;
@@ -142,7 +146,10 @@ public final class NameMatchers<T extends NamedElement>
 
   @Override
   public boolean matches(T target) {
-    String name = target.getActualName();
+    return match(target.getActualName());
+  }
+
+  private boolean match(String name) {
     switch (mode) {
       case NAMED:
         return name.equals(data);
@@ -168,5 +175,15 @@ public final class NameMatchers<T extends NamedElement>
 
   private static Set<String> toSet(String... strings) {
     return new HashSet<>(Arrays.asList(strings));
+  }
+
+  @Override
+  public boolean matches(
+      TypeDescription typeDescription,
+      ClassLoader classLoader,
+      JavaModule module,
+      Class<?> classBeingRedefined,
+      ProtectionDomain protectionDomain) {
+    return match(typeDescription.getName());
   }
 }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/NameMatchers.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/NameMatchers.java
@@ -14,7 +14,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 import net.bytebuddy.utility.JavaModule;
 
 public final class NameMatchers<T extends NamedElement>
-    extends ElementMatcher.Junction.AbstractBase<T> implements AgentBuilder.RawMatcher {
+    extends ElementMatcher.Junction.AbstractBase<T> implements AgentBuilder.RawMatcher, FailSafe {
 
   private static final int NAMED = 0;
   private static final int NAME_STARTS_WITH = 1;


### PR DESCRIPTION
This bypasses a lot of setup, reduces the depth of the stack, and avoids calling no-op classloader/module matchers.