### PR TITLE
add shortcut matchers for gRPC

### DIFF
--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/client/GrpcClientBuilderInstrumentation.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/client/GrpcClientBuilderInstrumentation.java
@@ -8,6 +8,7 @@ import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers;
 import io.grpc.ClientInterceptor;
 import java.util.List;
 import java.util.Map;
@@ -20,12 +21,20 @@ import net.bytebuddy.matcher.ElementMatcher;
 public class GrpcClientBuilderInstrumentation extends Instrumenter.Tracing {
 
   public GrpcClientBuilderInstrumentation() {
-    super("grpc", "grpc-client");
+    super(true, "grpc", "grpc-client");
   }
 
   @Override
-  public ElementMatcher<TypeDescription> typeMatcher() {
+  public ElementMatcher<TypeDescription> hierarchyMatcher() {
     return extendsClass(named("io.grpc.ManagedChannelBuilder"))
+        .and(declaresField(named("interceptors")));
+  }
+
+  @Override
+  public ElementMatcher<? super TypeDescription> shortCutMatcher() {
+    return NameMatchers.<TypeDescription>namedOneOf(
+            "io.grpc.internal.AbstractManagedChannelImplBuilder",
+            "io.grpc.internal.ManagedChannelImplBuilder")
         .and(declaresField(named("interceptors")));
   }
 

--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/GrpcServerBuilderInstrumentation.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/GrpcServerBuilderInstrumentation.java
@@ -2,6 +2,7 @@ package datadog.trace.instrumentation.grpc.server;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers.extendsClass;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
@@ -21,12 +22,24 @@ import net.bytebuddy.matcher.ElementMatcher;
 public class GrpcServerBuilderInstrumentation extends Instrumenter.Tracing {
 
   public GrpcServerBuilderInstrumentation() {
-    super("grpc", "grpc-server");
+    super(true, "grpc", "grpc-server");
   }
 
   @Override
-  public ElementMatcher<TypeDescription> typeMatcher() {
+  public ElementMatcher<TypeDescription> hierarchyMatcher() {
     return extendsClass(named("io.grpc.ServerBuilder"));
+  }
+
+  @Override
+  public ElementMatcher<? super TypeDescription> shortCutMatcher() {
+    return namedOneOf(
+        "io.grpc.internal.AbstractServerImplBuilder",
+        "io.grpc.alts.AltsServerBuilder",
+        "io.grpc.ForwardingServerBuilder",
+        "io.grpc.inprocess.InProcessServerBuilder",
+        "io.grpc.netty.NettyServerBuilder",
+        "io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder",
+        "io.grpc.internal.ServerImplBuilder");
   }
 
   @Override

--- a/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/HierarchyMatcherGrpcStreamingTest.groovy
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/HierarchyMatcherGrpcStreamingTest.groovy
@@ -1,0 +1,7 @@
+class HierarchyMatcherGrpcStreamingTest extends GrpcStreamingTest {
+  @Override
+  protected void configurePreAgent() {
+    super.configurePreAgent()
+    injectSysConfig("dd.integration.grpc.matching.shortcut.enabled", "false")
+  }
+}

--- a/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/HierarchyMatcherGrpcTest.groovy
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/HierarchyMatcherGrpcTest.groovy
@@ -1,0 +1,7 @@
+class HierarchyMatcherGrpcTest extends GrpcTest {
+  @Override
+  protected void configurePreAgent() {
+    super.configurePreAgent()
+    injectSysConfig("dd.integration.grpc.matching.shortcut.enabled", "false")
+  }
+}


### PR DESCRIPTION
The gRPC instrumentation will now only activate with a predefined set of `ServerBuilder` and `ManagedChannelBuilder`s. This can be disabled by setting `-Ddd.integration.grpc.matching.shortcut.enabled=false`