### PR TITLE
Change Vert.x 3.9 MySQLClient spans to not enclose the handler

### DIFF
--- a/dd-java-agent/instrumentation/vertx-mysql-client-3.9/src/main/java8/datadog/trace/instrumentation/vertx_sql_client/CursorReadAdvice.java
+++ b/dd-java-agent/instrumentation/vertx-mysql-client-3.9/src/main/java8/datadog/trace/instrumentation/vertx_sql_client/CursorReadAdvice.java
@@ -1,10 +1,15 @@
 package datadog.trace.instrumentation.vertx_sql_client;
 
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.captureSpan;
 import static datadog.trace.instrumentation.vertx_sql_client.VertxSqlClientDecorator.DECORATE;
 
 import datadog.trace.api.Pair;
 import datadog.trace.bootstrap.InstrumentationContext;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.context.TraceScope;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.mysqlclient.MySQLConnection;
@@ -16,18 +21,32 @@ import net.bytebuddy.implementation.bytecode.assign.Assigner;
 
 public class CursorReadAdvice {
   @Advice.OnMethodEnter(suppress = Throwable.class)
-  public static void beforeRead(
+  public static AgentScope beforeRead(
       @Advice.Argument(value = 1, readOnly = false) Handler<AsyncResult<RowSet<Row>>> handler,
       @Advice.FieldValue(value = "ps", typing = Assigner.Typing.DYNAMIC)
           final PreparedStatement ps) {
     if (handler instanceof QueryResultHandlerWrapper) {
-      return;
+      return null;
     }
-    final AgentSpan span =
+    final AgentSpan parentSpan = activeSpan();
+    final TraceScope.Continuation parentContinuation =
+        null == parentSpan ? null : captureSpan(parentSpan);
+    final AgentSpan clientSpan =
         DECORATE.startAndDecorateSpanForStatement(
             ps, InstrumentationContext.get(PreparedStatement.class, Pair.class), true);
-    if (null != span) {
-      handler = new QueryResultHandlerWrapper<>(handler, span);
+    if (null == clientSpan) {
+      return null;
+    }
+    handler = new QueryResultHandlerWrapper<>(handler, clientSpan, parentContinuation);
+
+    return activateSpan(clientSpan, true);
+  }
+
+  @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
+  public static void afterRead(
+      @Advice.Thrown final Throwable throwable, @Advice.Enter final AgentScope clientScope) {
+    if (null != clientScope) {
+      clientScope.close();
     }
   }
 

--- a/dd-java-agent/instrumentation/vertx-mysql-client-3.9/src/main/java8/datadog/trace/instrumentation/vertx_sql_client/QueryAdvice.java
+++ b/dd-java-agent/instrumentation/vertx-mysql-client-3.9/src/main/java8/datadog/trace/instrumentation/vertx_sql_client/QueryAdvice.java
@@ -1,11 +1,16 @@
 package datadog.trace.instrumentation.vertx_sql_client;
 
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.captureSpan;
 import static datadog.trace.instrumentation.vertx_sql_client.VertxSqlClientDecorator.DECORATE;
 
 import datadog.trace.api.Pair;
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.InstrumentationContext;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.context.TraceScope;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.mysqlclient.MySQLConnection;
@@ -31,7 +36,7 @@ public class QueryAdvice {
 
   public static class Execute {
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static <T, R extends SqlResult<T>> void beforeExecute(
+    public static <T, R extends SqlResult<T>> AgentScope beforeExecute(
         @Advice.This final Query<?> zis,
         @Advice.Argument(
                 value = 0,
@@ -42,16 +47,31 @@ public class QueryAdvice {
         @Advice.Argument(value = 1, readOnly = false, optional = true)
             Handler<AsyncResult<R>> handler) {
       final boolean prepared = !(maybeHandler instanceof Handler);
-      final AgentSpan span =
+
+      final AgentSpan parentSpan = activeSpan();
+      final TraceScope.Continuation parentContinuation =
+          null == parentSpan ? null : captureSpan(parentSpan);
+      final AgentSpan clientSpan =
           DECORATE.startAndDecorateSpanForStatement(
               zis, InstrumentationContext.get(Query.class, Pair.class), prepared);
-      if (null != span) {
-        if (prepared) {
-          handler = new QueryResultHandlerWrapper<>(handler, span);
-        } else {
-          maybeHandler =
-              new QueryResultHandlerWrapper<>((Handler<AsyncResult<R>>) maybeHandler, span);
-        }
+      if (null == clientSpan) {
+        return null;
+      }
+      if (prepared) {
+        handler = new QueryResultHandlerWrapper<>(handler, clientSpan, parentContinuation);
+      } else {
+        maybeHandler =
+            new QueryResultHandlerWrapper<>(
+                (Handler<AsyncResult<R>>) maybeHandler, clientSpan, parentContinuation);
+      }
+      return activateSpan(clientSpan);
+    }
+
+    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
+    public static void afterExecute(
+        @Advice.Thrown final Throwable throwable, @Advice.Enter final AgentScope clientScope) {
+      if (null != clientScope) {
+        clientScope.close();
       }
     }
 

--- a/dd-java-agent/instrumentation/vertx-mysql-client-3.9/src/main/java8/datadog/trace/instrumentation/vertx_sql_client/QueryResultHandlerWrapper.java
+++ b/dd-java-agent/instrumentation/vertx-mysql-client-3.9/src/main/java8/datadog/trace/instrumentation/vertx_sql_client/QueryResultHandlerWrapper.java
@@ -1,9 +1,7 @@
 package datadog.trace.instrumentation.vertx_sql_client;
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
-
-import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.context.TraceScope;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.sqlclient.SqlResult;
@@ -11,26 +9,33 @@ import io.vertx.sqlclient.SqlResult;
 public class QueryResultHandlerWrapper<T, R extends SqlResult<T>>
     implements Handler<AsyncResult<R>> {
   private final Handler<AsyncResult<R>> handler;
-  private final AgentSpan span;
+  private final AgentSpan clientSpan;
+  private final TraceScope.Continuation parentContinuation;
 
-  public QueryResultHandlerWrapper(final Handler<AsyncResult<R>> handler, final AgentSpan span) {
+  public QueryResultHandlerWrapper(
+      final Handler<AsyncResult<R>> handler,
+      final AgentSpan clientSpan,
+      final TraceScope.Continuation parentContinuation) {
     this.handler = handler;
-    this.span = span;
+    this.clientSpan = clientSpan;
+    this.parentContinuation = parentContinuation;
   }
 
   @Override
   public void handle(final AsyncResult<R> event) {
-    AgentScope scope = null;
+    TraceScope scope = null;
     try {
-      if (null != span) {
-        scope = activateSpan(span);
+      if (null != clientSpan) {
+        clientSpan.finish();
+      }
+      if (null != parentContinuation) {
+        scope = parentContinuation.activate();
       }
       handler.handle(event);
     } finally {
       if (null != scope) {
         scope.close();
       }
-      span.finish();
     }
   }
 }


### PR DESCRIPTION
The `handler` spans were incorrectly reported as a child of the `client` span instead of the span where the request originated.