### PR TITLE
Guard against NoSuchElementException

### DIFF
--- a/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/ScopeEventFactory.java
+++ b/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/ScopeEventFactory.java
@@ -51,12 +51,14 @@ public class ScopeEventFactory implements ExtendedScopeListener {
   public void afterScopeClosed() {
     Deque<ScopeEvent> stack = scopeEventStack.get();
 
-    ScopeEvent scopeEvent = stack.pop();
-    scopeEvent.finish();
+    ScopeEvent scopeEvent = stack.poll();
+    if (scopeEvent != null) {
+      scopeEvent.finish();
 
-    ScopeEvent parent = stack.peek();
-    if (parent != null) {
-      parent.addChildCpuTime(scopeEvent.getRawCpuTime());
+      ScopeEvent parent = stack.peek();
+      if (parent != null) {
+        parent.addChildCpuTime(scopeEvent.getRawCpuTime());
+      }
     }
   }
 }


### PR DESCRIPTION
This is a quick remedy for `NoSuchElementException` thrown from the `ScopeEventFactory`.

There still is the question of what happens to spans activated before the listener is added - currently, they will just disappear. This is rather sub-optimal but the correct solution will require more work - the stack tracking listener would need to be separated from the scope event factory so it can be added early in the startup without clashing with the JFR init prerequisites.
I would defer that work for the time when we are revisiting the tracer/profiler integration related to span activation.