### PR TITLE
unpack packages in internal jar file once

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/InternalJarURLHandlerTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/InternalJarURLHandlerTest.groovy
@@ -8,10 +8,13 @@ class InternalJarURLHandlerTest extends DDSpecification {
   @Shared
   URL testJarLocation = new File("src/test/resources/classloader-test-jar/testjar-jdk8").toURI().toURL()
 
+  @Shared
+  DatadogClassLoader.JarIndex index = new DatadogClassLoader.JarIndex(testJarLocation)
+
 
   def "test extract packages"() {
     setup:
-    InternalJarURLHandler handler = new InternalJarURLHandler(dir, testJarLocation)
+    InternalJarURLHandler handler = new InternalJarURLHandler(dir, index.getPackages(dir), index.jarFile)
     expect:
     packages == handler.getPackages()
 
@@ -23,7 +26,7 @@ class InternalJarURLHandlerTest extends DDSpecification {
 
   def "test get URL"() {
     setup:
-    InternalJarURLHandler handler = new InternalJarURLHandler(dir, testJarLocation)
+    InternalJarURLHandler handler = new InternalJarURLHandler(dir, index.getPackages(dir), index.jarFile)
     when:
     URLConnection connection = handler.openConnection(new File(file).toURI().toURL())
     assert connection != null
@@ -46,7 +49,7 @@ class InternalJarURLHandlerTest extends DDSpecification {
   def "test read class twice"() {
     // guards against caching the stream
     setup:
-    InternalJarURLHandler handler = new InternalJarURLHandler(dir, testJarLocation)
+    InternalJarURLHandler handler = new InternalJarURLHandler(dir, index.getPackages(dir), index.jarFile)
     when:
     URLConnection connection = handler.openConnection(new File(file).toURI().toURL())
     assert connection != null
@@ -73,7 +76,7 @@ class InternalJarURLHandlerTest extends DDSpecification {
 
   def "handle not found"() {
     setup:
-    InternalJarURLHandler handler = new InternalJarURLHandler(dir, testJarLocation)
+    InternalJarURLHandler handler = new InternalJarURLHandler(dir, index.getPackages(dir), index.jarFile)
     when:
     handler.openConnection(new File(file).toURI().toURL())
     then:


### PR DESCRIPTION
The jar file is currently split in to 4 parts `shared`, `inst`, `metrics`, and `profiling`, one for each isolated class loader. When we load each class loader, we scan the entire jar file looking for packages below the prefix for the class loader, but we can do this all in one go by creating an "index". The sharing of the index isn't the prettiest, but this happens very early in the program so I want to keep it as simple and lean as possible.