### PR TITLE
Make SpringBootWebfluxIntegrationTest wait for traces before checking

### DIFF
--- a/dd-smoke-tests/spring-boot-2.5-webflux/src/test/groovy/datadog/smoketest/SpringBootWebfluxIntegrationTest.groovy
+++ b/dd-smoke-tests/spring-boot-2.5-webflux/src/test/groovy/datadog/smoketest/SpringBootWebfluxIntegrationTest.groovy
@@ -13,7 +13,7 @@ class SpringBootWebfluxIntegrationTest extends AbstractServerSmokeTest {
     command.add(javaPath())
     command.addAll(defaultJavaProperties)
     command.addAll((String[]) [
-      "-Ddd.writer.type=TraceStructureWriter:${output.getAbsolutePath()}",
+      "-Ddd.writer.type=MultiWriter:TraceStructureWriter:${output.getAbsolutePath()},DDAgentWriter",
       "-jar",
       springBootShadowJar,
       "--server.port=${httpPort}"
@@ -43,5 +43,6 @@ class SpringBootWebfluxIntegrationTest extends AbstractServerSmokeTest {
     def responseBodyStr = response.body().string()
     responseBodyStr != null
     responseBodyStr.contains("Hello world")
+    waitForTraceCount(1)
   }
 }


### PR DESCRIPTION
Since WebFlux has problems with strict writing, there is a possibility that the response is received, checked, and the traces read and checked before the actual trace is written and flushed.