### PR TITLE
Don't inject empty tags in logging MDC

### DIFF
--- a/dd-java-agent/instrumentation/jboss-logmanager/src/main/java/datadog/trace/instrumentation/jbosslogmanager/ExtLogRecordInstrumentation.java
+++ b/dd-java-agent/instrumentation/jboss-logmanager/src/main/java/datadog/trace/instrumentation/jbosslogmanager/ExtLogRecordInstrumentation.java
@@ -91,13 +91,22 @@ public class ExtLogRecordInstrumentation extends Instrumenter.Tracing {
       switch (key) {
         case Tags.DD_SERVICE:
           value = Config.get().getServiceName();
-          return;
+          if (null != value && value.isEmpty()) {
+            value = null;
+          }
+          break;
         case Tags.DD_ENV:
           value = Config.get().getEnv();
-          return;
+          if (null != value && value.isEmpty()) {
+            value = null;
+          }
+          break;
         case Tags.DD_VERSION:
           value = Config.get().getVersion();
-          return;
+          if (null != value && value.isEmpty()) {
+            value = null;
+          }
+          break;
         case "dd.trace_id":
           {
             AgentSpan.Context context =
@@ -105,8 +114,8 @@ public class ExtLogRecordInstrumentation extends Instrumenter.Tracing {
             if (context != null) {
               value = context.getTraceId().toString();
             }
-            return;
           }
+          break;
         case "dd.span_id":
           {
             AgentSpan.Context context =
@@ -114,9 +123,9 @@ public class ExtLogRecordInstrumentation extends Instrumenter.Tracing {
             if (context != null) {
               value = context.getSpanId().toString();
             }
-
-            return;
           }
+          break;
+        default:
       }
     }
   }
@@ -150,9 +159,18 @@ public class ExtLogRecordInstrumentation extends Instrumenter.Tracing {
       }
 
       if (mdcTagsInjectionEnabled) {
-        correlationValues.put(Tags.DD_SERVICE, Config.get().getServiceName());
-        correlationValues.put(Tags.DD_ENV, Config.get().getEnv());
-        correlationValues.put(Tags.DD_VERSION, Config.get().getVersion());
+        String serviceName = Config.get().getServiceName();
+        if (null != serviceName && !serviceName.isEmpty()) {
+          correlationValues.put(Tags.DD_SERVICE, serviceName);
+        }
+        String env = Config.get().getEnv();
+        if (null != env && !env.isEmpty()) {
+          correlationValues.put(Tags.DD_ENV, env);
+        }
+        String version = Config.get().getVersion();
+        if (null != version && !version.isEmpty()) {
+          correlationValues.put(Tags.DD_VERSION, version);
+        }
       }
 
       if (mdc == null) {

--- a/dd-java-agent/instrumentation/log4j-2.7/src/main/java/datadog/trace/instrumentation/log4j27/SpanDecoratingContextDataInjector.java
+++ b/dd-java-agent/instrumentation/log4j-2.7/src/main/java/datadog/trace/instrumentation/log4j27/SpanDecoratingContextDataInjector.java
@@ -32,9 +32,18 @@ public final class SpanDecoratingContextDataInjector implements ContextDataInjec
     StringMap newContextData = new SortedArrayStringMap(contextData.size() + 5);
 
     if (Config.get().isLogsMDCTagsInjectionEnabled()) {
-      newContextData.putValue(Tags.DD_ENV, Config.get().getEnv());
-      newContextData.putValue(Tags.DD_SERVICE, Config.get().getServiceName());
-      newContextData.putValue(Tags.DD_VERSION, Config.get().getVersion());
+      String env = Config.get().getEnv();
+      if (null != env && !env.isEmpty()) {
+        newContextData.putValue(Tags.DD_ENV, env);
+      }
+      String serviceName = Config.get().getServiceName();
+      if (null != serviceName && !serviceName.isEmpty()) {
+        newContextData.putValue(Tags.DD_SERVICE, serviceName);
+      }
+      String version = Config.get().getVersion();
+      if (null != version && !version.isEmpty()) {
+        newContextData.putValue(Tags.DD_VERSION, version);
+      }
     }
 
     AgentSpan span = activeSpan();

--- a/dd-java-agent/instrumentation/log4j1/src/main/java/datadog/trace/instrumentation/log4j1/LoggingEventInstrumentation.java
+++ b/dd-java-agent/instrumentation/log4j1/src/main/java/datadog/trace/instrumentation/log4j1/LoggingEventInstrumentation.java
@@ -75,13 +75,22 @@ public class LoggingEventInstrumentation extends Instrumenter.Tracing {
       switch (key) {
         case Tags.DD_SERVICE:
           value = Config.get().getServiceName();
-          return;
+          if (null != value && ((String) value).isEmpty()) {
+            value = null;
+          }
+          break;
         case Tags.DD_ENV:
           value = Config.get().getEnv();
-          return;
+          if (null != value && ((String) value).isEmpty()) {
+            value = null;
+          }
+          break;
         case Tags.DD_VERSION:
           value = Config.get().getVersion();
-          return;
+          if (null != value && ((String) value).isEmpty()) {
+            value = null;
+          }
+          break;
         case "dd.trace_id":
           {
             AgentSpan.Context context =
@@ -89,8 +98,8 @@ public class LoggingEventInstrumentation extends Instrumenter.Tracing {
             if (context != null) {
               value = context.getTraceId().toString();
             }
-            return;
           }
+          break;
         case "dd.span_id":
           {
             AgentSpan.Context context =
@@ -98,9 +107,9 @@ public class LoggingEventInstrumentation extends Instrumenter.Tracing {
             if (context != null) {
               value = context.getSpanId().toString();
             }
-
-            return;
           }
+          break;
+        default:
       }
     }
   }
@@ -119,9 +128,18 @@ public class LoggingEventInstrumentation extends Instrumenter.Tracing {
         Hashtable mdc = new Hashtable();
 
         if (Config.get().isLogsMDCTagsInjectionEnabled()) {
-          mdc.put(Tags.DD_SERVICE, Config.get().getServiceName());
-          mdc.put(Tags.DD_ENV, Config.get().getEnv());
-          mdc.put(Tags.DD_VERSION, Config.get().getVersion());
+          String serviceName = Config.get().getServiceName();
+          if (null != serviceName && !serviceName.isEmpty()) {
+            mdc.put(Tags.DD_SERVICE, serviceName);
+          }
+          String env = Config.get().getEnv();
+          if (null != env && !env.isEmpty()) {
+            mdc.put(Tags.DD_ENV, env);
+          }
+          String version = Config.get().getVersion();
+          if (null != version && !version.isEmpty()) {
+            mdc.put(Tags.DD_VERSION, version);
+          }
         }
 
         AgentSpan.Context context =

--- a/dd-java-agent/instrumentation/logback-1/src/main/java/datadog/trace/instrumentation/logback/LoggingEventInstrumentation.java
+++ b/dd-java-agent/instrumentation/logback-1/src/main/java/datadog/trace/instrumentation/logback/LoggingEventInstrumentation.java
@@ -97,9 +97,18 @@ public class LoggingEventInstrumentation extends Instrumenter.Tracing {
       }
 
       if (mdcTagsInjectionEnabled) {
-        correlationValues.put(Tags.DD_SERVICE, Config.get().getServiceName());
-        correlationValues.put(Tags.DD_ENV, Config.get().getEnv());
-        correlationValues.put(Tags.DD_VERSION, Config.get().getVersion());
+        String serviceName = Config.get().getServiceName();
+        if (null != serviceName && !serviceName.isEmpty()) {
+          correlationValues.put(Tags.DD_SERVICE, serviceName);
+        }
+        String env = Config.get().getEnv();
+        if (null != env && !env.isEmpty()) {
+          correlationValues.put(Tags.DD_ENV, env);
+        }
+        String version = Config.get().getVersion();
+        if (null != version && !version.isEmpty()) {
+          correlationValues.put(Tags.DD_VERSION, version);
+        }
       }
 
       if (mdc == null) {


### PR DESCRIPTION
Setting empty values for `dd.env` or `dd.version` in logs can interfere with tags set by the Datadog agent. See #2653 