### PR TITLE
Expose jmxfetch "initial refresh beans period" config.

### DIFF
--- a/dd-java-agent/agent-jmxfetch/src/main/java/datadog/trace/agent/jmxfetch/JMXFetch.java
+++ b/dd-java-agent/agent-jmxfetch/src/main/java/datadog/trace/agent/jmxfetch/JMXFetch.java
@@ -57,6 +57,7 @@ public class JMXFetch {
     final List<String> metricsConfigs = config.getJmxFetchMetricsConfigs();
     final Integer checkPeriod = config.getJmxFetchCheckPeriod();
     final Integer refreshBeansPeriod = config.getJmxFetchRefreshBeansPeriod();
+    final Integer initialRefreshBeansPeriod = config.getJmxFetchInitialRefreshBeansPeriod();
     final Map<String, String> globalTags = config.getMergedJmxTags();
 
     String host =
@@ -73,12 +74,13 @@ public class JMXFetch {
 
     if (log.isDebugEnabled()) {
       log.debug(
-          "JMXFetch config: {} {} {} {} {} {} {} {}",
+          "JMXFetch config: {} {} {} {} {} {} {} {} {}",
           jmxFetchConfigDir,
           jmxFetchConfigs,
           internalMetricsConfigs,
           metricsConfigs,
           checkPeriod,
+          initialRefreshBeansPeriod,
           refreshBeansPeriod,
           globalTags,
           "statsd:" + host + ":" + port);
@@ -98,6 +100,7 @@ public class JMXFetch {
             .instanceConfigResources(DEFAULT_CONFIGS)
             .metricConfigResources(internalMetricsConfigs)
             .metricConfigFiles(metricsConfigs)
+            .initialRefreshBeansPeriod(initialRefreshBeansPeriod)
             .refreshBeansPeriod(refreshBeansPeriod)
             .globalTags(globalTags)
             .reporter(new AgentStatsdReporter(statsd));

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/JmxFetchConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/JmxFetchConfig.java
@@ -14,6 +14,8 @@ public final class JmxFetchConfig {
   public static final String JMX_FETCH_CONFIG = "jmxfetch.config";
   @Deprecated public static final String JMX_FETCH_METRICS_CONFIGS = "jmxfetch.metrics-configs";
   public static final String JMX_FETCH_CHECK_PERIOD = "jmxfetch.check-period";
+  public static final String JMX_FETCH_INITIAL_REFRESH_BEANS_PERIOD =
+      "jmxfetch.initial-refresh-beans-period";
   public static final String JMX_FETCH_REFRESH_BEANS_PERIOD = "jmxfetch.refresh-beans-period";
   public static final String JMX_FETCH_STATSD_HOST = "jmxfetch.statsd.host";
   public static final String JMX_FETCH_STATSD_PORT = "jmxfetch.statsd.port";

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -84,6 +84,7 @@ import static datadog.trace.api.config.JmxFetchConfig.JMX_FETCH_CHECK_PERIOD;
 import static datadog.trace.api.config.JmxFetchConfig.JMX_FETCH_CONFIG;
 import static datadog.trace.api.config.JmxFetchConfig.JMX_FETCH_CONFIG_DIR;
 import static datadog.trace.api.config.JmxFetchConfig.JMX_FETCH_ENABLED;
+import static datadog.trace.api.config.JmxFetchConfig.JMX_FETCH_INITIAL_REFRESH_BEANS_PERIOD;
 import static datadog.trace.api.config.JmxFetchConfig.JMX_FETCH_METRICS_CONFIGS;
 import static datadog.trace.api.config.JmxFetchConfig.JMX_FETCH_REFRESH_BEANS_PERIOD;
 import static datadog.trace.api.config.JmxFetchConfig.JMX_FETCH_START_DELAY;
@@ -288,6 +289,7 @@ public class Config {
   private final List<String> jmxFetchConfigs;
   @Deprecated private final List<String> jmxFetchMetricsConfigs;
   private final Integer jmxFetchCheckPeriod;
+  private final Integer jmxFetchInitialRefreshBeansPeriod;
   private final Integer jmxFetchRefreshBeansPeriod;
   private final String jmxFetchStatsdHost;
   private final Integer jmxFetchStatsdPort;
@@ -584,6 +586,8 @@ public class Config {
     jmxFetchConfigs = configProvider.getList(JMX_FETCH_CONFIG);
     jmxFetchMetricsConfigs = configProvider.getList(JMX_FETCH_METRICS_CONFIGS);
     jmxFetchCheckPeriod = configProvider.getInteger(JMX_FETCH_CHECK_PERIOD);
+    jmxFetchInitialRefreshBeansPeriod =
+        configProvider.getInteger(JMX_FETCH_INITIAL_REFRESH_BEANS_PERIOD);
     jmxFetchRefreshBeansPeriod = configProvider.getInteger(JMX_FETCH_REFRESH_BEANS_PERIOD);
     jmxFetchStatsdHost = configProvider.getString(JMX_FETCH_STATSD_HOST);
     jmxFetchStatsdPort =
@@ -926,6 +930,10 @@ public class Config {
 
   public Integer getJmxFetchRefreshBeansPeriod() {
     return jmxFetchRefreshBeansPeriod;
+  }
+
+  public Integer getJmxFetchInitialRefreshBeansPeriod() {
+    return jmxFetchInitialRefreshBeansPeriod;
   }
 
   public String getJmxFetchStatsdHost() {
@@ -1693,6 +1701,8 @@ public class Config {
         + jmxFetchMetricsConfigs
         + ", jmxFetchCheckPeriod="
         + jmxFetchCheckPeriod
+        + ", jmxFetchInitialRefreshBeansPeriod="
+        + jmxFetchInitialRefreshBeansPeriod
         + ", jmxFetchRefreshBeansPeriod="
         + jmxFetchRefreshBeansPeriod
         + ", jmxFetchStatsdHost='"


### PR DESCRIPTION
## Motivation

A new feature has been added to jmxfetch allowing to have a configurable period for the 1st bean refresh (for more details, please refer to the related PR https://github.com/DataDog/jmxfetch/pull/349), the goal of this PR is to propagate the required changes to benefit from this new feature in the Java Agent

## Modifications:

* Adds a system property  `jmxfetch.initial-refresh-beans-period` to be able to set the value
* Provides the value of this property to the configuration of jmxfetch

## Result

It is now possible to easily set a period for the 1st bean refresh from the Java Agent thanks to a System property