### PR TITLE
Try to avoid duplicate profiling data

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkOngoingRecording.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkOngoingRecording.java
@@ -25,7 +25,7 @@ public class OpenJdkOngoingRecording implements OngoingRecording {
   }
 
   @Override
-  public OpenJdkRecordingData snapshot(final Instant start, final Instant end) {
+  public OpenJdkRecordingData snapshot(final Instant start) {
     if (recording.getState() != RecordingState.RUNNING) {
       throw new IllegalStateException("Cannot snapshot recording that is not running");
     }

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkOngoingRecording.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkOngoingRecording.java
@@ -32,7 +32,10 @@ public class OpenJdkOngoingRecording implements OngoingRecording {
 
     final Recording snapshot = FlightRecorder.getFlightRecorder().takeSnapshot();
     snapshot.setName(recording.getName()); // Copy name from original recording
-    return new OpenJdkRecordingData(snapshot, start, end);
+    // Since we just requested a snapshot, the end time of the snapshot will be
+    // very close to now, so use that end time to minimize the risk of gaps or
+    // overlaps in the data.
+    return new OpenJdkRecordingData(snapshot, start, snapshot.getStopTime());
   }
 
   @Override

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/test/java/com/datadog/profiling/controller/openjdk/OpenJdkOngoingRecordingTest.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/test/java/com/datadog/profiling/controller/openjdk/OpenJdkOngoingRecordingTest.java
@@ -65,7 +65,7 @@ public class OpenJdkOngoingRecordingTest {
     final OpenJdkRecordingData recordingData = ongoingRecording.snapshot(start, end);
     assertEquals(TEST_NAME, recordingData.getName());
     assertEquals(start, recordingData.getStart());
-    assertEquals(end, recordingData.getEnd());
+    assertEquals(recordingData.getRecording().getStopTime(), recordingData.getEnd());
     assertNotEquals(
         recording, recordingData.getRecording(), "make sure we didn't get our mocked recording");
 

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/test/java/com/datadog/profiling/controller/openjdk/OpenJdkOngoingRecordingTest.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/test/java/com/datadog/profiling/controller/openjdk/OpenJdkOngoingRecordingTest.java
@@ -62,7 +62,7 @@ public class OpenJdkOngoingRecordingTest {
 
   @Test
   public void testSnapshot() {
-    final OpenJdkRecordingData recordingData = ongoingRecording.snapshot(start, end);
+    final OpenJdkRecordingData recordingData = ongoingRecording.snapshot(start);
     assertEquals(TEST_NAME, recordingData.getName());
     assertEquals(start, recordingData.getStart());
     assertEquals(recordingData.getRecording().getStopTime(), recordingData.getEnd());
@@ -82,7 +82,7 @@ public class OpenJdkOngoingRecordingTest {
     assertThrows(
         IllegalStateException.class,
         () -> {
-          ongoingRecording.snapshot(start, end);
+          ongoingRecording.snapshot(start);
         });
 
     verify(recording, never()).stop();

--- a/dd-java-agent/agent-profiling/profiling-controller-oracle/src/main/java/com/datadog/profiling/controller/oracle/OracleJdkOngoingRecording.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-oracle/src/main/java/com/datadog/profiling/controller/oracle/OracleJdkOngoingRecording.java
@@ -47,8 +47,8 @@ public class OracleJdkOngoingRecording implements OngoingRecording {
 
   @Override
   @Nonnull
-  public OracleJdkRecordingData snapshot(@Nonnull final Instant start, @Nonnull final Instant end) {
-    log.warn("Taking recording snapshot for time range {} - {}", start, end);
+  public OracleJdkRecordingData snapshot(@Nonnull final Instant start) {
+    log.warn("Taking recording snapshot for time range {} - {}", start, Instant.now());
     ObjectName targetName = recordingId;
     try {
       if (!(boolean) helper.getRecordingAttribute(targetName, "Running")) {

--- a/dd-java-agent/agent-profiling/profiling-controller-oracle/src/main/java/com/datadog/profiling/controller/oracle/OracleJdkOngoingRecording.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-oracle/src/main/java/com/datadog/profiling/controller/oracle/OracleJdkOngoingRecording.java
@@ -56,7 +56,9 @@ public class OracleJdkOngoingRecording implements OngoingRecording {
       }
 
       targetName = helper.cloneRecording(targetName);
-      return new OracleJdkRecordingData(name, targetName, start, end, helper);
+      // Set the end time of the data to now, which is after the snapshot was made
+      // TODO get the recording end from the helper?
+      return new OracleJdkRecordingData(name, targetName, start, Instant.now(), helper);
     } catch (IOException e) {
       throw new RuntimeException("Unable to take snapshot for recording " + name, e);
     }

--- a/dd-java-agent/agent-profiling/profiling-controller-oracle/src/main/java/com/datadog/profiling/controller/oracle/OracleJdkRecordingData.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-oracle/src/main/java/com/datadog/profiling/controller/oracle/OracleJdkRecordingData.java
@@ -23,13 +23,9 @@ import java.time.Instant;
 import java.util.Date;
 import javax.annotation.Nonnull;
 import javax.management.ObjectName;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /** Implementation for profiling recordings. */
 public class OracleJdkRecordingData extends RecordingData {
-  private static final Logger log = LoggerFactory.getLogger(OracleJdkRecordingData.class);
-
   private final ObjectName recordingId;
   private final String name;
 
@@ -41,23 +37,10 @@ public class OracleJdkRecordingData extends RecordingData {
       @Nonnull Instant start,
       @Nonnull Instant end,
       @Nonnull JfrMBeanHelper helper) {
-    super(start, getEndTime(helper, recordingId, end));
+    super(start, end);
     this.name = name;
     this.recordingId = recordingId;
     this.helper = helper;
-  }
-
-  private static Instant getEndTime(
-      JfrMBeanHelper helper, ObjectName recordingId, Instant defaultEndTime) {
-    try {
-      return helper.getDataEndTime(recordingId);
-    } catch (IOException e) {
-      log.debug(
-          "Unable to retrieve the data end time for recording {}. ({})",
-          recordingId.getKeyProperty("name"),
-          e.toString());
-    }
-    return defaultEndTime;
   }
 
   @Override

--- a/dd-java-agent/agent-profiling/profiling-controller-oracle/src/main/java/com/datadog/profiling/controller/oracle/OracleJdkRecordingData.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-oracle/src/main/java/com/datadog/profiling/controller/oracle/OracleJdkRecordingData.java
@@ -23,9 +23,13 @@ import java.time.Instant;
 import java.util.Date;
 import javax.annotation.Nonnull;
 import javax.management.ObjectName;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Implementation for profiling recordings. */
 public class OracleJdkRecordingData extends RecordingData {
+  private static final Logger log = LoggerFactory.getLogger(OracleJdkRecordingData.class);
+
   private final ObjectName recordingId;
   private final String name;
 
@@ -37,10 +41,23 @@ public class OracleJdkRecordingData extends RecordingData {
       @Nonnull Instant start,
       @Nonnull Instant end,
       @Nonnull JfrMBeanHelper helper) {
-    super(start, end);
+    super(start, getEndTime(helper, recordingId, end));
     this.name = name;
     this.recordingId = recordingId;
     this.helper = helper;
+  }
+
+  private static Instant getEndTime(
+      JfrMBeanHelper helper, ObjectName recordingId, Instant defaultEndTime) {
+    try {
+      return helper.getDataEndTime(recordingId);
+    } catch (IOException e) {
+      log.debug(
+          "Unable to retrieve the data end time for recording {}. ({})",
+          recordingId.getKeyProperty("name"),
+          e.toString());
+    }
+    return defaultEndTime;
   }
 
   @Override

--- a/dd-java-agent/agent-profiling/profiling-controller-oracle/src/test/java/com/datadog/profiling/controller/oracle/OracleJdkControllerTest.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-oracle/src/test/java/com/datadog/profiling/controller/oracle/OracleJdkControllerTest.java
@@ -42,7 +42,8 @@ class OracleJdkControllerTest {
 
       assertNotNull(snapshot);
       assertEquals(start, snapshot.getStart());
-      assertEquals(end, snapshot.getEnd());
+      assertTrue(snapshot.getEnd().compareTo(end) >= 0);
+      assertTrue(snapshot.getEnd().compareTo(Instant.now()) <= 0);
       assertEquals(recordingName, snapshot.getName());
 
       try (InputStream is = snapshot.getStream()) {

--- a/dd-java-agent/agent-profiling/profiling-controller-oracle/src/test/java/com/datadog/profiling/controller/oracle/OracleJdkControllerTest.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-oracle/src/test/java/com/datadog/profiling/controller/oracle/OracleJdkControllerTest.java
@@ -38,7 +38,7 @@ class OracleJdkControllerTest {
       // sleep a while to allow a few events to be collected
       Thread.sleep(300);
       Instant end = Instant.now();
-      OracleJdkRecordingData snapshot = recording.snapshot(start, end);
+      OracleJdkRecordingData snapshot = recording.snapshot(start);
 
       assertNotNull(snapshot);
       assertEquals(start, snapshot.getStart());
@@ -68,7 +68,7 @@ class OracleJdkControllerTest {
     OracleJdkOngoingRecording recording = instance.createRecording(recordingName);
     assertNotNull(recording);
     recording.close();
-    assertThrows(Throwable.class, () -> recording.snapshot(start, Instant.now()));
+    assertThrows(Throwable.class, () -> recording.snapshot(start));
   }
 
   @Test
@@ -113,7 +113,7 @@ class OracleJdkControllerTest {
       assertNotNull(snapshot);
       assertEquals(recordingName, snapshot.getName());
 
-      assertThrows(Throwable.class, () -> recording.snapshot(start, Instant.now()));
+      assertThrows(Throwable.class, () -> recording.snapshot(start));
     }
   }
 

--- a/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/OngoingRecording.java
+++ b/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/OngoingRecording.java
@@ -23,7 +23,7 @@ public interface OngoingRecording extends Closeable {
    * @return {@link RecordingData} with snapshot information
    */
   @Nonnull
-  RecordingData snapshot(@Nonnull final Instant start, @Nonnull final Instant end);
+  RecordingData snapshot(@Nonnull final Instant start);
 
   /** Close recording without capturing any data */
   @Override

--- a/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/OngoingRecording.java
+++ b/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/OngoingRecording.java
@@ -20,7 +20,6 @@ public interface OngoingRecording extends Closeable {
    * called.
    *
    * @param start start time of the snapshot
-   * @param end end time of the snapshot
    * @return {@link RecordingData} with snapshot information
    */
   @Nonnull

--- a/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/ProfilingSystem.java
+++ b/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/ProfilingSystem.java
@@ -191,8 +191,7 @@ public final class ProfilingSystem {
       final RecordingType recordingType = RecordingType.CONTINUOUS;
       try {
         log.debug("Creating profiler snapshot");
-        Instant now = Instant.now();
-        final RecordingData recordingData = recording.snapshot(lastSnapshot, now);
+        final RecordingData recordingData = recording.snapshot(lastSnapshot);
         if (recordingData != null) {
           // To make sure that we don't get data twice, we say that the next start should be
           // the last recording end time plus one nano second. The reason for this is that when
@@ -201,7 +200,7 @@ public final class ProfilingSystem {
           lastSnapshot = recordingData.getEnd().plus(ONE_NANO);
           dataListener.onNewData(recordingType, recordingData);
         } else {
-          lastSnapshot = now;
+          lastSnapshot = Instant.now();
         }
       } catch (final Exception e) {
         log.error("Exception in profiling thread, continuing", e);

--- a/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/ProfilingSystem.java
+++ b/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/ProfilingSystem.java
@@ -179,6 +179,7 @@ public final class ProfilingSystem {
   }
 
   private final class SnapshotRecording {
+    private final Duration ONE_NANO = Duration.ofNanos(1);
 
     private Instant lastSnapshot;
 
@@ -192,11 +193,15 @@ public final class ProfilingSystem {
         log.debug("Creating profiler snapshot");
         Instant now = Instant.now();
         final RecordingData recordingData = recording.snapshot(lastSnapshot, now);
-        // The hope here is that we do not get chunk rotated after taking snapshot and before we
-        // take this timestamp otherwise we will start losing data
-        lastSnapshot = now;
         if (recordingData != null) {
+          // To make sure that we don't get data twice, we say that the next start should be
+          // the last recording end time plus one nano second. The reason for this is that when
+          // JFR is filtering the stream it will only discard earlier chunks that have an end
+          // time that is before (not before or equal to) the requested start time of the filter.
+          lastSnapshot = recordingData.getEnd().plus(ONE_NANO);
           dataListener.onNewData(recordingType, recordingData);
+        } else {
+          lastSnapshot = now;
         }
       } catch (final Exception e) {
         log.error("Exception in profiling thread, continuing", e);

--- a/dd-java-agent/agent-profiling/profiling-controller/src/test/java/com/datadog/profiling/controller/ProfilingSystemTest.java
+++ b/dd-java-agent/agent-profiling/profiling-controller/src/test/java/com/datadog/profiling/controller/ProfilingSystemTest.java
@@ -74,7 +74,7 @@ public class ProfilingSystemTest {
   public void setup() {
     when(controller.createRecording(ProfilingSystem.RECORDING_NAME)).thenReturn(recording);
     when(threadLocalRandom.nextInt(eq(1), anyInt())).thenReturn(1);
-    when(recordingData.getEnd()).thenReturn(Instant.now());
+    when(recordingData.getEnd()).thenAnswer(mockInvocation -> Instant.now());
   }
 
   @AfterEach
@@ -210,7 +210,7 @@ public class ProfilingSystemTest {
   @Test
   public void testDoesntSendPeriodicRecordingIfPeriodicRecordingIsDisabled()
       throws InterruptedException, ConfigurationException {
-    when(recording.snapshot(any(), any())).thenReturn(recordingData);
+    when(recording.snapshot(any())).thenReturn(recordingData);
     final ProfilingSystem system =
         new ProfilingSystem(
             controller,
@@ -275,7 +275,7 @@ public class ProfilingSystemTest {
   public void testRecordingSnapshotError() throws ConfigurationException {
     final Duration uploadPeriod = Duration.ofMillis(300);
     final List<RecordingData> generatedRecordingData = new ArrayList<>();
-    when(recording.snapshot(any(), any()))
+    when(recording.snapshot(any()))
         .thenThrow(new RuntimeException("Test"))
         .thenAnswer(generateMockRecordingData(generatedRecordingData));
 
@@ -303,7 +303,7 @@ public class ProfilingSystemTest {
   public void testRecordingSnapshotNoData() throws ConfigurationException {
     final Duration uploadPeriod = Duration.ofMillis(300);
     final List<RecordingData> generatedRecordingData = new ArrayList<>();
-    when(recording.snapshot(any(), any()))
+    when(recording.snapshot(any()))
         .thenReturn(null)
         .thenAnswer(generateMockRecordingData(generatedRecordingData));
 
@@ -400,7 +400,7 @@ public class ProfilingSystemTest {
     return (InvocationOnMock invocation) -> {
       final RecordingData recordingData = mock(RecordingData.class);
       when(recordingData.getStart()).thenReturn(invocation.getArgument(0, Instant.class));
-      when(recordingData.getEnd()).thenReturn(invocation.getArgument(1, Instant.class));
+      when(recordingData.getEnd()).thenAnswer(mockInvocation -> Instant.now());
       generatedRecordingData.add(recordingData);
       return recordingData;
     };

--- a/dd-java-agent/agent-profiling/profiling-controller/src/test/java/com/datadog/profiling/controller/ProfilingSystemTest.java
+++ b/dd-java-agent/agent-profiling/profiling-controller/src/test/java/com/datadog/profiling/controller/ProfilingSystemTest.java
@@ -74,6 +74,7 @@ public class ProfilingSystemTest {
   public void setup() {
     when(controller.createRecording(ProfilingSystem.RECORDING_NAME)).thenReturn(recording);
     when(threadLocalRandom.nextInt(eq(1), anyInt())).thenReturn(1);
+    when(recordingData.getEnd()).thenReturn(Instant.now());
   }
 
   @AfterEach

--- a/dd-smoke-tests/profiling-integration-tests/src/test/java/datadog/smoketest/ProfilingIntegrationTest.java
+++ b/dd-smoke-tests/profiling-integration-tests/src/test/java/datadog/smoketest/ProfilingIntegrationTest.java
@@ -193,8 +193,9 @@ class ProfilingIntegrationTest {
       rangeStartAndEnd = getRangeStartAndEnd(events);
       Instant secondRangeStart = rangeStartAndEnd.getLeft();
       Instant secondRangeEnd = rangeStartAndEnd.getRight();
-      // As long as the OracleJdkOngoingRecording can't pull out the proper end time
-      // of the recording, we can't check these invariants =(
+      // So the OracleJdkOngoingRecording and underlying recording seems to
+      // either lose precision in the reported times, or filter a bit differently
+      // so we can't check these invariants =(
       if (!System.getProperty("java.vendor").contains("Oracle")
           || !System.getProperty("java.version").contains("1.8")) {
         assertTrue(


### PR DESCRIPTION
The changes in #2587 shortened the diff between the `end` time in the `RecordingData` from the `snapshot` call and the next `start` time in the following `snapshot` call. Since the filtering of the `RecordingInputStream` that happens inside the JFR code will include chunks that started but didn't finish before `start`, and chunks that started but didn't finish before `end`, we could get some of the same chunks in consecutive snapshots that would lead to double counting.

This change tries to minimize the risk of getting the same chunks by using the actual time from the underlying `snapshot` recording as the `end` time of the `RecordingData` and add a small offset as the next `start` time.

Since the other change has not been released, there should not be a release note for this.