### PR TITLE
Fix :dd-java-agent:shadowJar build with config on demand

### DIFF
--- a/buildSrc/src/main/groovy/MuzzlePlugin.groovy
+++ b/buildSrc/src/main/groovy/MuzzlePlugin.groovy
@@ -87,8 +87,9 @@ class MuzzlePlugin implements Plugin<Project> {
         assertionMethod.invoke(null, instrumentationCL)
       }
     }
-    compileMuzzle.dependsOn(bootstrapProject.tasks.compileJava)
-    compileMuzzle.dependsOn(toolingProject.tasks.compileJava)
+    [bootstrapProject, toolingProject]*.afterEvaluate {
+      compileMuzzle.dependsOn it.tasks.compileJava
+    }
     project.afterEvaluate {
       compileMuzzle.dependsOn(project.tasks.compileJava)
       if (project.tasks.getNames().contains('compileScala')) {

--- a/dd-java-agent/dd-java-agent.gradle
+++ b/dd-java-agent/dd-java-agent.gradle
@@ -71,15 +71,15 @@ def includeShadowJar(shadowJarTask, jarname) {
   shadowJarTask.configure generalShadowJarConfig
 }
 
-project(':dd-java-agent:instrumentation').afterEvaluate {
-  includeShadowJar(it.tasks.shadowJar, 'inst')
+def includeSubprojShadowJar(String projName, String jarname) {
+  evaluationDependsOn projName
+  def proj = project(projName)
+  includeShadowJar proj.tasks.shadowJar, jarname
 }
-project(':dd-java-agent:agent-jmxfetch').afterEvaluate {
-  includeShadowJar(it.tasks.shadowJar, 'metrics')
-}
-project(':dd-java-agent:agent-profiling').afterEvaluate {
-  includeShadowJar(it.tasks.shadowJar, 'profiling')
-}
+
+includeSubprojShadowJar ':dd-java-agent:instrumentation', 'inst'
+includeSubprojShadowJar ':dd-java-agent:agent-jmxfetch', 'metrics'
+includeSubprojShadowJar ':dd-java-agent:agent-profiling', 'profiling'
 
 task sharedShadowJar(type: ShadowJar) {
   configurations = [project.configurations.sharedShadowInclude]

--- a/dd-java-agent/instrumentation/instrumentation.gradle
+++ b/dd-java-agent/instrumentation/instrumentation.gradle
@@ -20,6 +20,9 @@ subprojects { Project subProj ->
   apply plugin: "net.bytebuddy.byte-buddy"
   apply plugin: 'muzzle'
 
+  // needs fetching this project's configurations.instrumentationMuzzle
+  evaluationDependsOn ':dd-java-agent:agent-tooling'
+
   subProj.byteBuddy {
     transformation {
       // Applying NoOp optimizes build by applying bytebuddy plugin to only compileJava task


### PR DESCRIPTION
With `org.gradle.configureondemand=true` in gradle.properties, some
subprojects (incl. all the instrumentation subprojects) were not
evaluated unless some task is requested from them in the same gradle
invocation. This results in a bogus shadow jar, which is missing  most
of the files.