### PR TITLE
Remove Typesafe Repo

### DIFF
--- a/buildSrc/src/main/groovy/MuzzlePlugin.groovy
+++ b/buildSrc/src/main/groovy/MuzzlePlugin.groovy
@@ -50,7 +50,7 @@ class MuzzlePlugin implements Plugin<Project> {
     RemoteRepository akka = new RemoteRepository.Builder("akka", "default", "https://dl.bintray.com/akka/maven/").build()
     RemoteRepository atlassian = new RemoteRepository.Builder("atlassian", "default", "https://maven.atlassian.com/content/repositories/atlassian-public/").build()
 //    MUZZLE_REPOS = Arrays.asList(central, sonatype, jcenter, spring, jboss, typesafe, akka, atlassian)
-    MUZZLE_REPOS = Collections.unmodifiableList(Arrays.asList(central, jcenter, typesafe))
+    MUZZLE_REPOS = Collections.unmodifiableList(Arrays.asList(central, jcenter))
   }
 
   @Override

--- a/dd-java-agent/instrumentation/play-2.3/play-2.3.gradle
+++ b/dd-java-agent/instrumentation/play-2.3/play-2.3.gradle
@@ -8,7 +8,7 @@ muzzle {
   pass {
     group = 'com.typesafe.play'
     module = 'play_2.11'
-    versions = '[2.3.0,2.4)'
+    versions = '[2.3.9,2.4)'
     assertInverse = true
   }
   fail {
@@ -35,7 +35,7 @@ testSets {
 }
 
 dependencies {
-  main_java8Compile group: 'com.typesafe.play', name: 'play_2.11', version: '2.3.0'
+  main_java8Compile group: 'com.typesafe.play', name: 'play_2.11', version: '2.3.9'
 
   testCompile project(':dd-java-agent:instrumentation:netty-3.8')
   testCompile project(':dd-java-agent:instrumentation:akka-concurrent')
@@ -44,9 +44,9 @@ dependencies {
   testCompile project(':dd-java-agent:instrumentation:scala-promise:scala-promise-2.10')
   testCompile project(':dd-java-agent:instrumentation:scala-promise:scala-promise-2.13')
 
-  testCompile group: 'com.typesafe.play', name: 'play-java_2.11', version: '2.3.0'
-  testCompile group: 'com.typesafe.play', name: 'play-java-ws_2.11', version: '2.3.0'
-  testCompile(group: 'com.typesafe.play', name: 'play-test_2.11', version: '2.3.0') {
+  testCompile group: 'com.typesafe.play', name: 'play-java_2.11', version: '2.3.9'
+  testCompile group: 'com.typesafe.play', name: 'play-java-ws_2.11', version: '2.3.9'
+  testCompile(group: 'com.typesafe.play', name: 'play-test_2.11', version: '2.3.9') {
     exclude group: 'org.eclipse.jetty', module: 'jetty-websocket'
   }
 

--- a/gradle/repositories.gradle
+++ b/gradle/repositories.gradle
@@ -11,11 +11,4 @@ repositories {
       snapshotsOnly()
     }
   }
-  maven {
-    url "https://repo.typesafe.com/typesafe/releases"
-    content {
-      includeGroup "com.typesafe.play"
-      includeGroup "play"
-    }
-  }
 }


### PR DESCRIPTION
And change play version we compile against to earliest version in maven central.

(Typesafe repo is not working right now and this seems like the easiest way to unblock.)