### PR TITLE
Invert control when defining transformers

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/MuzzleVisitor.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/MuzzleVisitor.java
@@ -11,6 +11,7 @@ import net.bytebuddy.ClassFileVersion;
 import net.bytebuddy.asm.AsmVisitorWrapper;
 import net.bytebuddy.description.field.FieldDescription;
 import net.bytebuddy.description.field.FieldList;
+import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.method.MethodList;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.implementation.Implementation;
@@ -21,6 +22,7 @@ import net.bytebuddy.jar.asm.Label;
 import net.bytebuddy.jar.asm.MethodVisitor;
 import net.bytebuddy.jar.asm.Opcodes;
 import net.bytebuddy.jar.asm.Type;
+import net.bytebuddy.matcher.ElementMatcher;
 import net.bytebuddy.pool.TypePool;
 
 /** Visit a class and add: a private instrumenationMuzzle field and getter */
@@ -126,7 +128,16 @@ public class MuzzleVisitor implements AsmVisitorWrapper {
       final Set<String> referenceSources = new HashSet<>();
       final Map<String, Reference> references = new LinkedHashMap<>();
 
-      for (String adviceClass : instrumenter.transformers().values()) {
+      final Set<String> adviceClasses = new HashSet<>();
+      instrumenter.adviceTransformations(
+          new Instrumenter.AdviceTransformation() {
+            @Override
+            public void applyAdvice(
+                ElementMatcher<? super MethodDescription> matcher, String name) {
+              adviceClasses.add(name);
+            }
+          });
+      for (String adviceClass : adviceClasses) {
         if (referenceSources.add(adviceClass)) {
           for (Map.Entry<String, Reference> entry :
               ReferenceCreator.createReferencesFrom(

--- a/dd-java-agent/instrumentation/rxjava-2/src/main/java/datadog/trace/instrumentation/rxjava2/ObservableInstrumentation.java
+++ b/dd-java-agent/instrumentation/rxjava-2/src/main/java/datadog/trace/instrumentation/rxjava2/ObservableInstrumentation.java
@@ -16,10 +16,8 @@ import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import io.reactivex.Observable;
 import io.reactivex.Observer;
-import java.util.HashMap;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
-import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
@@ -47,16 +45,14 @@ public final class ObservableInstrumentation extends Instrumenter.Tracing {
   }
 
   @Override
-  public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
-    Map<ElementMatcher<? super MethodDescription>, String> transformers = new HashMap<>();
-    transformers.put(isConstructor(), getClass().getName() + "$CaptureParentSpanAdvice");
-    transformers.put(
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(isConstructor(), getClass().getName() + "$CaptureParentSpanAdvice");
+    transformation.applyAdvice(
         isMethod()
             .and(named("subscribe"))
             .and(takesArguments(1))
             .and(takesArgument(0, named("io.reactivex.Observer"))),
         getClass().getName() + "$PropagateParentSpanAdvice");
-    return transformers;
   }
 
   public static class CaptureParentSpanAdvice {


### PR DESCRIPTION
This mainly reduces the number of maps that need to be constructed and avoids the risk of sizing incorrectly.

This is just a preliminary step.  The stated benefits won't apply until subclasses have migrated.