### PR TITLE
Set forwarded info as separate tag rather than replace peer

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
@@ -53,20 +53,25 @@ public abstract class HttpServerDecorator<REQUEST, CONNECTION, RESPONSE> extends
       final AgentSpan.Context.Extracted context) {
 
     if (context != null) {
-      if (context.getForwarded() != null) {
-        span.setTag(Tags.HTTP_FORWARDED, context.getForwarded());
+      String forwarded = context.getForwarded();
+      if (forwarded != null) {
+        span.setTag(Tags.HTTP_FORWARDED, forwarded);
       }
-      if (context.getForwardedProto() != null) {
-        span.setTag(Tags.HTTP_FORWARDED_PROTO, context.getForwardedProto());
+      String forwardedProto = context.getForwardedProto();
+      if (forwardedProto != null) {
+        span.setTag(Tags.HTTP_FORWARDED_PROTO, forwardedProto);
       }
-      if (context.getForwardedHost() != null) {
-        span.setTag(Tags.HTTP_FORWARDED_HOST, context.getForwardedHost());
+      String forwardedHost = context.getForwardedHost();
+      if (forwardedHost != null) {
+        span.setTag(Tags.HTTP_FORWARDED_HOST, forwardedHost);
       }
-      if (context.getForwardedIp() != null) {
-        span.setTag(Tags.HTTP_FORWARDED_IP, context.getForwardedIp());
+      String forwardedIp = context.getForwardedIp();
+      if (forwardedIp != null) {
+        span.setTag(Tags.HTTP_FORWARDED_IP, forwardedIp);
       }
-      if (context.getForwardedPort() != null) {
-        span.setTag(Tags.HTTP_FORWARDED_PORT, context.getForwardedPort());
+      String forwardedPort = context.getForwardedPort();
+      if (forwardedPort != null) {
+        span.setTag(Tags.HTTP_FORWARDED_PORT, forwardedPort);
       }
     }
 

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecoratorTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecoratorTest.groovy
@@ -83,11 +83,11 @@ class HttpServerDecoratorTest extends ServerDecoratorTest {
     decorator.onRequest(span, conn, null, ctx)
 
     then:
-    1 * ctx.getForwarded() >> null
-    1 * ctx.getForwardedProto() >> null
-    1 * ctx.getForwardedHost() >> null
-    1 * ctx.getForwardedIp() >> null
-    1 * ctx.getForwardedPort() >> null
+    _ * ctx.getForwarded() >> null
+    _ * ctx.getForwardedProto() >> null
+    _ * ctx.getForwardedHost() >> null
+    _ * ctx.getForwardedIp() >> null
+    _ * ctx.getForwardedPort() >> null
     if (conn) {
       1 * span.setTag(Tags.PEER_PORT, 555)
       if (ipv4) {
@@ -102,11 +102,11 @@ class HttpServerDecoratorTest extends ServerDecoratorTest {
     decorator.onRequest(span, conn, null, ctx)
 
     then:
-    2 * ctx.getForwarded() >> "by=<identifier>;for=<identifier>;host=<host>;proto=<http|https>"
-    2 * ctx.getForwardedProto() >> "https"
-    2 * ctx.getForwardedHost() >> "somehost"
-    2 * ctx.getForwardedIp() >> (ipv4 ? "10.1.1.1, 192.168.1.1" : "0::1")
-    2 * ctx.getForwardedPort() >> "123"
+    _ * ctx.getForwarded() >> "by=<identifier>;for=<identifier>;host=<host>;proto=<http|https>"
+    _ * ctx.getForwardedProto() >> "https"
+    _ * ctx.getForwardedHost() >> "somehost"
+    _ * ctx.getForwardedIp() >> (ipv4 ? "10.1.1.1, 192.168.1.1" : "0::1")
+    _ * ctx.getForwardedPort() >> "123"
     1 * span.setTag(Tags.HTTP_FORWARDED, "by=<identifier>;for=<identifier>;host=<host>;proto=<http|https>")
     1 * span.setTag(Tags.HTTP_FORWARDED_PROTO, "https")
     1 * span.setTag(Tags.HTTP_FORWARDED_HOST, "somehost")

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/baseTest/groovy/AkkaHttpServerInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/baseTest/groovy/AkkaHttpServerInstrumentationTest.groovy
@@ -12,6 +12,7 @@ import spock.lang.Shared
 import java.util.concurrent.atomic.AtomicInteger
 
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.FORWARDED
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
 abstract class AkkaHttpServerInstrumentationTest extends HttpServerTest<AkkaHttpTestWebServer> {
@@ -50,8 +51,8 @@ abstract class AkkaHttpServerInstrumentationTest extends HttpServerTest<AkkaHttp
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
         "$Tags.HTTP_STATUS" endpoint.status
-        if (endpoint == ServerEndpoint.FORWARDED) {
-          "$Tags.PEER_HOST_IPV4" endpoint.body
+        if (endpoint == FORWARDED) {
+          "$Tags.HTTP_FORWARDED_IP" endpoint.body
         }
         if (endpoint.errored) {
           "error.msg" { it == null || it == EXCEPTION.body }

--- a/dd-java-agent/instrumentation/dropwizard/src/test/groovy/DropwizardTest.groovy
+++ b/dd-java-agent/instrumentation/dropwizard/src/test/groovy/DropwizardTest.groovy
@@ -133,12 +133,15 @@ class DropwizardTest extends HttpServerTest<DropwizardTestSupport> {
       tags {
         "$Tags.COMPONENT" component
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
-        "$Tags.PEER_HOST_IPV4" { endpoint == FORWARDED ? it == endpoint.body : (it == null || it == "127.0.0.1") }
+        "$Tags.PEER_HOST_IPV4" { it == (endpoint == FORWARDED ? endpoint.body : "127.0.0.1") }
         "$Tags.PEER_PORT" Integer
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
         "$Tags.HTTP_ROUTE" "/${endpoint.rawPath()}"
         "$Tags.HTTP_STATUS" endpoint.status
+        if (endpoint == FORWARDED) {
+          "$Tags.HTTP_FORWARDED_IP" endpoint.body
+        }
         if (endpoint.errored) {
           "error.msg" { it == null || it == EXCEPTION.body }
           "error.type" { it == null || it == Exception.name }

--- a/dd-java-agent/instrumentation/glassfish/src/test/groovy/GlassFishServerTest.groovy
+++ b/dd-java-agent/instrumentation/glassfish/src/test/groovy/GlassFishServerTest.groovy
@@ -20,6 +20,7 @@ import java.nio.channels.ServerSocketChannel
 import java.util.concurrent.TimeoutException
 
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.FORWARDED
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
 /**
@@ -127,11 +128,14 @@ class GlassFishServerTest extends HttpServerTest<GlassFish> {
       tags {
         "$Tags.COMPONENT" component
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
-        "$Tags.PEER_HOST_IPV4" { endpoint == ServerEndpoint.FORWARDED ? it == endpoint.body : (it == null || it == "127.0.0.1") }
+        "$Tags.PEER_HOST_IPV4" "127.0.0.1"
         "$Tags.PEER_PORT" Integer
         "$Tags.HTTP_STATUS" endpoint.status
         "$Tags.HTTP_METHOD" method
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
+        if (endpoint == FORWARDED) {
+          "$Tags.HTTP_FORWARDED_IP" endpoint.body
+        }
         "servlet.context" "/$context"
         "servlet.path" endpoint.path
         if (endpoint.errored) {

--- a/dd-java-agent/instrumentation/jetty-7.0/src/test/groovy/Jetty70Test.groovy
+++ b/dd-java-agent/instrumentation/jetty-7.0/src/test/groovy/Jetty70Test.groovy
@@ -154,11 +154,14 @@ class Jetty70Test extends HttpServerTest<Server> {
       tags {
         "$Tags.COMPONENT" component
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
-        "$Tags.PEER_HOST_IPV4" { endpoint == FORWARDED ? it == endpoint.body : (it == null || it == "127.0.0.1") }
+        "$Tags.PEER_HOST_IPV4" "127.0.0.1"
         "$Tags.PEER_PORT" Integer
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
         "$Tags.HTTP_STATUS" endpoint.status
+        if (endpoint == FORWARDED) {
+          "$Tags.HTTP_FORWARDED_IP" endpoint.body
+        }
         if (endpoint.errored) {
           "error.msg" { it == null || it == EXCEPTION.body }
           "error.type" { it == null || it == Exception.name }

--- a/dd-java-agent/instrumentation/jetty-7.6/src/test/groovy/Jetty76Test.groovy
+++ b/dd-java-agent/instrumentation/jetty-7.6/src/test/groovy/Jetty76Test.groovy
@@ -154,11 +154,14 @@ class Jetty76Test extends HttpServerTest<Server> {
       tags {
         "$Tags.COMPONENT" component
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
-        "$Tags.PEER_HOST_IPV4" { endpoint == FORWARDED ? it == endpoint.body : (it == null || it == "127.0.0.1") }
+        "$Tags.PEER_HOST_IPV4" "127.0.0.1"
         "$Tags.PEER_PORT" Integer
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
         "$Tags.HTTP_STATUS" endpoint.status
+        if (endpoint == FORWARDED) {
+          "$Tags.HTTP_FORWARDED_IP" endpoint.body
+        }
         if (endpoint.errored) {
           "error.msg" { it == null || it == EXCEPTION.body }
           "error.type" { it == null || it == Exception.name }

--- a/dd-java-agent/instrumentation/jetty-9/src/test/groovy/Jetty9Test.groovy
+++ b/dd-java-agent/instrumentation/jetty-9/src/test/groovy/Jetty9Test.groovy
@@ -155,11 +155,14 @@ class Jetty9Test extends HttpServerTest<Server> {
       tags {
         "$Tags.COMPONENT" component
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
-        "$Tags.PEER_HOST_IPV4" { endpoint == FORWARDED ? it == endpoint.body : (it == null || it == "127.0.0.1") }
+        "$Tags.PEER_HOST_IPV4" "127.0.0.1"
         "$Tags.PEER_PORT" Integer
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
         "$Tags.HTTP_STATUS" endpoint.status
+        if (endpoint == FORWARDED) {
+          "$Tags.HTTP_FORWARDED_IP" endpoint.body
+        }
         if (endpoint.errored) {
           "error.msg" { it == null || it == EXCEPTION.body }
           "error.type" { it == null || it == Exception.name }

--- a/dd-java-agent/instrumentation/opentelemetry/src/test/groovy/OpenTelemetryTest.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/src/test/groovy/OpenTelemetryTest.groovy
@@ -139,10 +139,10 @@ class OpenTelemetryTest extends AgentTestRunner {
     setup:
     def builder = tracer.spanBuilder("some name")
     if (parentId) {
-      builder.setParent(tracer.converter.toSpanContext(new ExtractedContext(DDId.ONE, DDId.from(parentId), 0, null, null, null, [:], [:])))
+      builder.setParent(tracer.converter.toSpanContext(new ExtractedContext(DDId.ONE, DDId.from(parentId), 0, null, null, null, null, null, null, [:], [:])))
     }
     if (linkId) {
-      builder.addLink(tracer.converter.toSpanContext(new ExtractedContext(DDId.ONE, DDId.from(linkId), 0, null, null, null, [:], [:])))
+      builder.addLink(tracer.converter.toSpanContext(new ExtractedContext(DDId.ONE, DDId.from(linkId), 0, null, null, null, null, null, null, [:], [:])))
     }
     def result = builder.startSpan()
 

--- a/dd-java-agent/instrumentation/opentracing/api-0.31/src/test/groovy/OpenTracing31Test.groovy
+++ b/dd-java-agent/instrumentation/opentracing/api-0.31/src/test/groovy/OpenTracing31Test.groovy
@@ -31,7 +31,7 @@ class OpenTracing31Test extends AgentTestRunner {
         .withTag("boolean", true)
     }
     if (addReference) {
-      builder.addReference(addReference, tracer.tracer.converter.toSpanContext(new ExtractedContext(DDId.ONE, DDId.from(2), 0, null, null, null, [:], [:])))
+      builder.addReference(addReference, tracer.tracer.converter.toSpanContext(new ExtractedContext(DDId.ONE, DDId.from(2), 0, null, null, null, null, null, null, [:], [:])))
     }
     def result = builder.start()
     if (tagSpan) {

--- a/dd-java-agent/instrumentation/opentracing/api-0.32/src/test/groovy/OpenTracing32Test.groovy
+++ b/dd-java-agent/instrumentation/opentracing/api-0.32/src/test/groovy/OpenTracing32Test.groovy
@@ -31,7 +31,7 @@ class OpenTracing32Test extends AgentTestRunner {
         .withTag("boolean", true)
     }
     if (addReference) {
-      builder.addReference(addReference, tracer.tracer.converter.toSpanContext(new ExtractedContext(DDId.ONE, DDId.from(2), 0, null, null, null, [:], [:])))
+      builder.addReference(addReference, tracer.tracer.converter.toSpanContext(new ExtractedContext(DDId.ONE, DDId.from(2), 0, null, null, null, null, null, null, [:], [:])))
     }
     def result = builder.start()
     if (tagSpan) {

--- a/dd-java-agent/instrumentation/play-2.3/src/test/groovy/server/PlayServerTest.groovy
+++ b/dd-java-agent/instrumentation/play-2.3/src/test/groovy/server/PlayServerTest.groovy
@@ -12,6 +12,7 @@ import play.api.test.TestServer
 
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.FORWARDED
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
 class PlayServerTest extends HttpServerTest<TestServer> {
@@ -48,7 +49,7 @@ class PlayServerTest extends HttpServerTest<TestServer> {
       tags {
         "$Tags.COMPONENT" PlayHttpServerDecorator.DECORATE.component()
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
-        "$Tags.PEER_HOST_IPV4" { endpoint == ServerEndpoint.FORWARDED ? it == endpoint.body : (it == null || it == "127.0.0.1") }
+        "$Tags.PEER_HOST_IPV4" { it == (endpoint == FORWARDED ? endpoint.body : "127.0.0.1") }
         "$Tags.HTTP_URL" String
         "$Tags.HTTP_METHOD" String
         "$Tags.HTTP_STATUS" Integer

--- a/dd-java-agent/instrumentation/play-2.4/src/test/groovy/server/PlayServerTest.groovy
+++ b/dd-java-agent/instrumentation/play-2.4/src/test/groovy/server/PlayServerTest.groovy
@@ -91,7 +91,7 @@ class PlayServerTest extends HttpServerTest<Server> {
       tags {
         "$Tags.COMPONENT" PlayHttpServerDecorator.DECORATE.component()
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
-        "$Tags.PEER_HOST_IPV4" { endpoint == FORWARDED ? it == endpoint.body : (it == null || it == "127.0.0.1") }
+        "$Tags.PEER_HOST_IPV4" { it == (endpoint == FORWARDED ? endpoint.body : "127.0.0.1") }
         "$Tags.HTTP_URL" String
         "$Tags.HTTP_METHOD" String
         "$Tags.HTTP_STATUS" Integer

--- a/dd-java-agent/instrumentation/play-2.6/src/test/groovy/server/PlayServerTest.groovy
+++ b/dd-java-agent/instrumentation/play-2.6/src/test/groovy/server/PlayServerTest.groovy
@@ -98,7 +98,7 @@ class PlayServerTest extends HttpServerTest<Server> {
       tags {
         "$Tags.COMPONENT" PlayHttpServerDecorator.DECORATE.component()
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
-        "$Tags.PEER_HOST_IPV4" { endpoint == FORWARDED ? it == endpoint.body : (it == null || it == "127.0.0.1") }
+        "$Tags.PEER_HOST_IPV4" { it == (endpoint == FORWARDED ? endpoint.body : "127.0.0.1") }
         "$Tags.HTTP_URL" String
         "$Tags.HTTP_METHOD" String
         "$Tags.HTTP_STATUS" Integer
@@ -131,10 +131,13 @@ class PlayServerTest extends HttpServerTest<Server> {
       tags {
         "$Tags.COMPONENT" component
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
-        "$Tags.PEER_HOST_IPV4" { endpoint == FORWARDED ? it == endpoint.body : (it == null || it == "127.0.0.1") }
+        "$Tags.PEER_HOST_IPV4" { it == (endpoint == FORWARDED ? endpoint.body : "127.0.0.1") }
         "$Tags.HTTP_STATUS" endpoint.status
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
+        if (endpoint == FORWARDED) {
+          "$Tags.HTTP_FORWARDED_IP" endpoint.body
+        }
         if (endpoint.errored) {
           "error.msg" { it == null || it == EXCEPTION.body }
           "error.type" { it == null || it == Exception.name }

--- a/dd-java-agent/instrumentation/servlet/request-2/src/test/groovy/JettyServlet2Test.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-2/src/test/groovy/JettyServlet2Test.groovy
@@ -150,11 +150,14 @@ class JettyServlet2Test extends HttpServerTest<Server> {
       tags {
         "$Tags.COMPONENT" component
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
-        "$Tags.PEER_HOST_IPV4"(endpoint == FORWARDED ? endpoint.body : "127.0.0.1")
+        "$Tags.PEER_HOST_IPV4" "127.0.0.1"
         "$Tags.PEER_PORT" Integer
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
         "$Tags.HTTP_STATUS" endpoint.status
+        if (endpoint == FORWARDED) {
+          "$Tags.HTTP_FORWARDED_IP" endpoint.body
+        }
         "servlet.context" "/$CONTEXT"
         "servlet.path" endpoint.path
         if (endpoint.errored) {

--- a/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/JettyServlet3Test.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/JettyServlet3Test.groovy
@@ -18,6 +18,7 @@ import static TestServlet3.SERVLET_TIMEOUT
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.CUSTOM_EXCEPTION
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.FORWARDED
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
@@ -161,11 +162,14 @@ abstract class JettyServlet3Test extends AbstractServlet3Test<Server, ServletCon
       tags {
         "$Tags.COMPONENT" component
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
-        "$Tags.PEER_HOST_IPV4" { endpoint == ServerEndpoint.FORWARDED ? it == endpoint.body : (it == null || it == "127.0.0.1") }
+        "$Tags.PEER_HOST_IPV4" "127.0.0.1"
         "$Tags.PEER_PORT" Integer
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
         "$Tags.HTTP_STATUS" { it == endpoint.status || !bubblesResponse }
+        if (endpoint == FORWARDED) {
+          "$Tags.HTTP_FORWARDED_IP" endpoint.body
+        }
         if (context) {
           "servlet.context" "/$context"
         }

--- a/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/JettyServletHandlerTest.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/JettyServletHandlerTest.groovy
@@ -18,6 +18,7 @@ import static JettyServlet3Test.IS_LATEST
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.CUSTOM_EXCEPTION
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.FORWARDED
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
@@ -129,11 +130,14 @@ class JettyServletHandlerTest extends AbstractServlet3Test<Server, ServletHandle
       tags {
         "$Tags.COMPONENT" component
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
-        "$Tags.PEER_HOST_IPV4" { endpoint == ServerEndpoint.FORWARDED ? it == endpoint.body : (it == null || it == "127.0.0.1") }
+        "$Tags.PEER_HOST_IPV4" "127.0.0.1"
         "$Tags.PEER_PORT" Integer
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
         "$Tags.HTTP_STATUS" { it == endpoint.status || !bubblesResponse }
+        if (endpoint == FORWARDED) {
+          "$Tags.HTTP_FORWARDED_IP" endpoint.body
+        }
         if (context) {
           "servlet.context" "/$context"
         }

--- a/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/TomcatServlet3Test.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/TomcatServlet3Test.groovy
@@ -26,6 +26,7 @@ import static TestServlet3.SERVLET_TIMEOUT
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.CUSTOM_EXCEPTION
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.FORWARDED
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.TIMEOUT
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.TIMEOUT_ERROR
@@ -149,11 +150,14 @@ abstract class TomcatServlet3Test extends AbstractServlet3Test<Tomcat, Context> 
       tags {
         "$Tags.COMPONENT" component
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
-        "$Tags.PEER_HOST_IPV4" { endpoint == ServerEndpoint.FORWARDED ? it == endpoint.body : (it == null || it == "127.0.0.1") }
+        "$Tags.PEER_HOST_IPV4" "127.0.0.1"
         "$Tags.PEER_PORT" Integer
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
         "$Tags.HTTP_STATUS" { it == endpoint.status || !bubblesResponse }
+        if (endpoint == FORWARDED) {
+          "$Tags.HTTP_FORWARDED_IP" endpoint.body
+        }
         if (context) {
           "servlet.context" "/$context"
         }

--- a/dd-java-agent/instrumentation/spring-cloud-zuul-2/src/test/groovy/SpringBootZuulTest.groovy
+++ b/dd-java-agent/instrumentation/spring-cloud-zuul-2/src/test/groovy/SpringBootZuulTest.groovy
@@ -12,6 +12,7 @@ import org.springframework.context.ConfigurableApplicationContext
 import org.springframework.web.servlet.view.RedirectView
 
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.FORWARDED
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
@@ -209,12 +210,15 @@ class SpringBootZuulTest extends HttpServerTest<ConfigurableApplicationContext> 
       tags {
         "$Tags.COMPONENT" component
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
-        "$Tags.PEER_HOST_IPV4" { endpoint == ServerEndpoint.FORWARDED ? it == endpoint.body : (it == null || it == "127.0.0.1") }
+        "$Tags.PEER_HOST_IPV4" "127.0.0.1"
         "$Tags.PEER_PORT" Integer
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
         "$Tags.HTTP_STATUS" endpoint.status
         "$Tags.HTTP_ROUTE" String
+        if (endpoint == FORWARDED) {
+          "$Tags.HTTP_FORWARDED_IP" endpoint.body
+        }
         "servlet.path" endpoint.path
         if (endpoint.errored) {
           "error.msg" { it == null || it == EXCEPTION.body }

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/boot/SpringBootBasedTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/boot/SpringBootBasedTest.groovy
@@ -17,6 +17,7 @@ import org.springframework.web.servlet.view.RedirectView
 import spock.lang.Shared
 
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.FORWARDED
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.LOGIN
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.NOT_HERE
@@ -252,12 +253,15 @@ class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext>
       tags {
         "$Tags.COMPONENT" component
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
-        "$Tags.PEER_HOST_IPV4" { endpoint == ServerEndpoint.FORWARDED ? it == endpoint.body : (it == null || it == "127.0.0.1") }
+        "$Tags.PEER_HOST_IPV4" "127.0.0.1"
         "$Tags.PEER_PORT" Integer
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
         "$Tags.HTTP_STATUS" endpoint.status
         if (endpoint != LOGIN && endpoint != NOT_FOUND) { "$Tags.HTTP_ROUTE" String }
+        if (endpoint == FORWARDED) {
+          "$Tags.HTTP_FORWARDED_IP" endpoint.body
+        }
         "servlet.path" endpoint.path
         if (endpoint.errored) {
           "error.msg" { it == null || it == EXCEPTION.body }

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/dynamic/DynamicRoutingTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/dynamic/DynamicRoutingTest.groovy
@@ -15,6 +15,7 @@ import org.springframework.web.servlet.view.RedirectView
 import test.boot.SecurityConfig
 
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.FORWARDED
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 import static java.util.Collections.singletonMap
@@ -177,11 +178,14 @@ class DynamicRoutingTest extends HttpServerTest<ConfigurableApplicationContext> 
       tags {
         "$Tags.COMPONENT" component
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
-        "$Tags.PEER_HOST_IPV4" { endpoint == ServerEndpoint.FORWARDED ? it == endpoint.body : (it == null || it == "127.0.0.1") }
+        "$Tags.PEER_HOST_IPV4" "127.0.0.1"
         "$Tags.PEER_PORT" Integer
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
         "$Tags.HTTP_STATUS" endpoint.status
+        if (endpoint == FORWARDED) {
+          "$Tags.HTTP_FORWARDED_IP" endpoint.body
+        }
         "servlet.path" endpoint.path
         if (endpoint.errored) {
           "error.msg" { it == null || it == EXCEPTION.body }

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/filter/ServletFilterTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/filter/ServletFilterTest.groovy
@@ -15,6 +15,7 @@ import test.boot.SecurityConfig
 
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.FORWARDED
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 import static java.util.Collections.singletonMap
@@ -159,12 +160,15 @@ class ServletFilterTest extends HttpServerTest<ConfigurableApplicationContext> {
       tags {
         "$Tags.COMPONENT" component
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
-        "$Tags.PEER_HOST_IPV4" { endpoint == ServerEndpoint.FORWARDED ? it == endpoint.body : (it == null || it == "127.0.0.1") }
+        "$Tags.PEER_HOST_IPV4" "127.0.0.1"
         "$Tags.PEER_PORT" Integer
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
         "$Tags.HTTP_STATUS" endpoint.status
         "$Tags.HTTP_ROUTE" String
+        if (endpoint == FORWARDED) {
+          "$Tags.HTTP_FORWARDED_IP" endpoint.body
+        }
         "servlet.path" endpoint.path
         if (endpoint.errored) {
           "error.msg" { it == null || it == EXCEPTION.body }

--- a/dd-java-agent/instrumentation/tomcat-5.5/src/latestDepTest/groovy/TomcatServletTest.groovy
+++ b/dd-java-agent/instrumentation/tomcat-5.5/src/latestDepTest/groovy/TomcatServletTest.groovy
@@ -167,10 +167,13 @@ class TomcatServletTest extends AbstractServletTest<Tomcat, Context> {
       tags {
         "$Tags.COMPONENT" component
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
-        "$Tags.PEER_HOST_IPV4" { endpoint == FORWARDED ? it == endpoint.body : (it == null || it == "127.0.0.1") }
+        "$Tags.PEER_HOST_IPV4" "127.0.0.1"
         "$Tags.PEER_PORT" Integer
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
+        if (endpoint == FORWARDED) {
+          "$Tags.HTTP_FORWARDED_IP" endpoint.body
+        }
         if (endpoint != TIMEOUT && endpoint != TIMEOUT_ERROR) {
           "$Tags.HTTP_STATUS" { it == endpoint.status || !bubblesResponse }
         } else {

--- a/dd-java-agent/instrumentation/tomcat-5.5/src/test/groovy/TomcatServletTest.groovy
+++ b/dd-java-agent/instrumentation/tomcat-5.5/src/test/groovy/TomcatServletTest.groovy
@@ -22,6 +22,7 @@ import javax.servlet.ServletException
 
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.CUSTOM_EXCEPTION
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.FORWARDED
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.TIMEOUT
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.TIMEOUT_ERROR
@@ -185,10 +186,13 @@ class TomcatServletTest extends AbstractServletTest<Embedded, Context> {
       tags {
         "$Tags.COMPONENT" component
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
-        "$Tags.PEER_HOST_IPV4" { endpoint == ServerEndpoint.FORWARDED ? it == endpoint.body : (it == null || it == "127.0.0.1") }
+        "$Tags.PEER_HOST_IPV4" "127.0.0.1"
         "$Tags.PEER_PORT" Integer
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
+        if (endpoint == FORWARDED) {
+          "$Tags.HTTP_FORWARDED_IP" endpoint.body
+        }
         if (endpoint != TIMEOUT && endpoint != TIMEOUT_ERROR) {
           "$Tags.HTTP_STATUS" { it == endpoint.status || !bubblesResponse }
         } else {

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
@@ -649,10 +649,13 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
         "$Tags.COMPONENT" component
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
         "$Tags.PEER_PORT" Integer
-        "$Tags.PEER_HOST_IPV4" { endpoint == FORWARDED ? it == endpoint.body : (it == null || it == "127.0.0.1") }
+        "$Tags.PEER_HOST_IPV4" { it == "127.0.0.1" || (endpoint == FORWARDED && it == endpoint.body) }
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
         "$Tags.HTTP_STATUS" endpoint.status
+        if (endpoint == FORWARDED) {
+          "$Tags.HTTP_FORWARDED_IP" endpoint.body
+        }
         if (tagServerSpanWithRoute) {
           "$Tags.HTTP_ROUTE" String
         }

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ContextInterpreter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ContextInterpreter.java
@@ -63,35 +63,27 @@ public abstract class ContextInterpreter implements AgentPropagation.KeyClassifi
   }
 
   protected final boolean handledForwarding(String key, String value) {
-    if (FORWARDED_KEY.equalsIgnoreCase(key)) {
-      if (null != value) {
+    if (null != value) {
+      if (FORWARDED_KEY.equalsIgnoreCase(key)) {
         forwarded = value;
+        return true;
       }
-      return true;
-    }
-    if (FORWARDED_PROTO_KEY.equalsIgnoreCase(key)) {
-      if (null != value) {
+      if (FORWARDED_PROTO_KEY.equalsIgnoreCase(key)) {
         forwardedProto = value;
+        return true;
       }
-      return true;
-    }
-    if (FORWARDED_HOST_KEY.equalsIgnoreCase(key)) {
-      if (null != value) {
+      if (FORWARDED_HOST_KEY.equalsIgnoreCase(key)) {
         forwardedHost = value;
+        return true;
       }
-      return true;
-    }
-    if (FORWARDED_FOR_KEY.equalsIgnoreCase(key)) {
-      if (null != value) {
+      if (FORWARDED_FOR_KEY.equalsIgnoreCase(key)) {
         forwardedIp = value;
+        return true;
       }
-      return true;
-    }
-    if (FORWARDED_PORT_KEY.equalsIgnoreCase(key)) {
-      if (null != value) {
+      if (FORWARDED_PORT_KEY.equalsIgnoreCase(key)) {
         forwardedPort = value;
+        return true;
       }
-      return true;
     }
     return false;
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ContextInterpreter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ContextInterpreter.java
@@ -1,8 +1,10 @@
 package datadog.trace.core.propagation;
 
 import static datadog.trace.core.propagation.HttpCodec.FORWARDED_FOR_KEY;
+import static datadog.trace.core.propagation.HttpCodec.FORWARDED_HOST_KEY;
+import static datadog.trace.core.propagation.HttpCodec.FORWARDED_KEY;
 import static datadog.trace.core.propagation.HttpCodec.FORWARDED_PORT_KEY;
-import static datadog.trace.core.propagation.HttpCodec.firstHeaderValue;
+import static datadog.trace.core.propagation.HttpCodec.FORWARDED_PROTO_KEY;
 
 import datadog.trace.api.DDId;
 import datadog.trace.api.Functions;
@@ -24,7 +26,10 @@ public abstract class ContextInterpreter implements AgentPropagation.KeyClassifi
   protected Map<String, String> tags;
   protected Map<String, String> baggage;
   protected String origin;
-  protected String forwardedFor;
+  protected String forwarded;
+  protected String forwardedProto;
+  protected String forwardedHost;
+  protected String forwardedIp;
   protected String forwardedPort;
   protected boolean valid;
 
@@ -58,17 +63,33 @@ public abstract class ContextInterpreter implements AgentPropagation.KeyClassifi
   }
 
   protected final boolean handledForwarding(String key, String value) {
+    if (FORWARDED_KEY.equalsIgnoreCase(key)) {
+      if (null != value) {
+        forwarded = value;
+      }
+      return true;
+    }
+    if (FORWARDED_PROTO_KEY.equalsIgnoreCase(key)) {
+      if (null != value) {
+        forwardedProto = value;
+      }
+      return true;
+    }
+    if (FORWARDED_HOST_KEY.equalsIgnoreCase(key)) {
+      if (null != value) {
+        forwardedHost = value;
+      }
+      return true;
+    }
     if (FORWARDED_FOR_KEY.equalsIgnoreCase(key)) {
-      String firstValue = firstHeaderValue(value);
-      if (null != firstValue) {
-        forwardedFor = firstValue;
+      if (null != value) {
+        forwardedIp = value;
       }
       return true;
     }
     if (FORWARDED_PORT_KEY.equalsIgnoreCase(key)) {
-      String firstValue = firstHeaderValue(value);
-      if (null != firstValue) {
-        forwardedPort = firstValue;
+      if (null != value) {
+        forwardedPort = value;
       }
       return true;
     }
@@ -80,7 +101,10 @@ public abstract class ContextInterpreter implements AgentPropagation.KeyClassifi
     spanId = DDId.ZERO;
     samplingPriority = defaultSamplingPriority();
     origin = null;
-    forwardedFor = null;
+    forwarded = null;
+    forwardedProto = null;
+    forwardedHost = null;
+    forwardedIp = null;
     forwardedPort = null;
     tags = Collections.emptyMap();
     baggage = Collections.emptyMap();
@@ -97,17 +121,24 @@ public abstract class ContextInterpreter implements AgentPropagation.KeyClassifi
                 spanId,
                 samplingPriority,
                 origin,
-                forwardedFor,
+                forwarded,
+                forwardedProto,
+                forwardedHost,
+                forwardedIp,
                 forwardedPort,
                 baggage,
                 tags);
         context.lockSamplingPriority();
         return context;
       } else if (origin != null
-          || forwardedFor != null
+          || forwarded != null
+          || forwardedProto != null
+          || forwardedHost != null
+          || forwardedIp != null
           || forwardedPort != null
           || !tags.isEmpty()) {
-        return new TagContext(origin, forwardedFor, forwardedPort, tags);
+        return new TagContext(
+            origin, forwarded, forwardedProto, forwardedHost, forwardedIp, forwardedPort, tags);
       }
     }
     return null;

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ExtractedContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ExtractedContext.java
@@ -19,11 +19,14 @@ public class ExtractedContext extends TagContext {
       final DDId spanId,
       final int samplingPriority,
       final String origin,
-      String fowardedFor,
-      String forwardedPort,
+      final String forwarded,
+      final String forwardedProto,
+      final String forwardedHost,
+      final String forwardedIp,
+      final String forwardedPort,
       final Map<String, String> baggage,
       final Map<String, String> tags) {
-    super(origin, fowardedFor, forwardedPort, tags);
+    super(origin, forwarded, forwardedProto, forwardedHost, forwardedIp, forwardedPort, tags);
     this.traceId = traceId;
     this.spanId = spanId;
     this.samplingPriority = samplingPriority;

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/HttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/HttpCodec.java
@@ -16,6 +16,10 @@ import org.slf4j.LoggerFactory;
 public class HttpCodec {
 
   private static final Logger log = LoggerFactory.getLogger(HttpCodec.class);
+  // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded
+  static final String FORWARDED_KEY = "forwarded";
+  static final String FORWARDED_PROTO_KEY = "x-forwarded-proto";
+  static final String FORWARDED_HOST_KEY = "x-forwarded-host";
   static final String FORWARDED_FOR_KEY = "x-forwarded-for";
   static final String FORWARDED_PORT_KEY = "x-forwarded-port";
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/TagContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/TagContext.java
@@ -13,17 +13,26 @@ import java.util.Map;
  */
 public class TagContext implements AgentSpan.Context.Extracted {
   private final String origin;
-  private final String forwardedFor;
+  private final String forwarded;
+  private final String forwardedProto;
+  private final String forwardedHost;
+  private final String forwardedIp;
   private final String forwardedPort;
   private final Map<String, String> tags;
 
   public TagContext(
       final String origin,
-      String forwardedFor,
+      String forwarded,
+      String forwardedProto,
+      String forwardedHost,
+      String forwardedIp,
       String forwardedPort,
       final Map<String, String> tags) {
     this.origin = origin;
-    this.forwardedFor = forwardedFor;
+    this.forwarded = forwarded;
+    this.forwardedProto = forwardedProto;
+    this.forwardedHost = forwardedHost;
+    this.forwardedIp = forwardedIp;
     this.forwardedPort = forwardedPort;
     this.tags = tags;
   }
@@ -32,9 +41,22 @@ public class TagContext implements AgentSpan.Context.Extracted {
     return origin;
   }
 
+  public String getForwarded() {
+    return forwarded;
+  }
+
   @Override
-  public String getForwardedFor() {
-    return forwardedFor;
+  public String getForwardedProto() {
+    return forwardedProto;
+  }
+
+  public String getForwardedHost() {
+    return forwardedHost;
+  }
+
+  @Override
+  public String getForwardedIp() {
+    return forwardedIp;
   }
 
   @Override

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/CoreSpanBuilderTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/CoreSpanBuilderTest.groovy
@@ -316,9 +316,9 @@ class CoreSpanBuilderTest extends DDCoreSpecification {
       (THREAD_NAME)     : thread.name, (THREAD_ID): thread.id]
 
     where:
-    extractedContext                                                                                                                                | _
-    new ExtractedContext(DDId.ONE, DDId.from(2), 0, null, null, null, [:], [:])                                                                     | _
-    new ExtractedContext(DDId.from(3), DDId.from(4), 1, "some-origin", null, null, ["asdf": "qwer"], [(ORIGIN_KEY): "some-origin", "zxcv": "1234"]) | _
+    extractedContext                                                                                                                                                  | _
+    new ExtractedContext(DDId.ONE, DDId.from(2), 0, null, null, null, null, null, null, [:], [:])                                                                     | _
+    new ExtractedContext(DDId.from(3), DDId.from(4), 1, "some-origin", null, null, null, null, null, ["asdf": "qwer"], [(ORIGIN_KEY): "some-origin", "zxcv": "1234"]) | _
   }
 
   def "TagContext should populate default span details"() {
@@ -337,9 +337,9 @@ class CoreSpanBuilderTest extends DDCoreSpecification {
       (THREAD_NAME)     : thread.name, (THREAD_ID): thread.id]
 
     where:
-    tagContext                                                                               | _
-    new TagContext(null, null, null, [:])                                                    | _
-    new TagContext("some-origin", null, null, [(ORIGIN_KEY): "some-origin", "asdf": "qwer"]) | _
+    tagContext                                                                                                 | _
+    new TagContext(null, null, null, null, null, null, [:])                                                    | _
+    new TagContext("some-origin", null, null, null, null, null, [(ORIGIN_KEY): "some-origin", "asdf": "qwer"]) | _
   }
 
   def "global span tags populated on each span"() {

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanTest.groovy
@@ -193,9 +193,9 @@ class DDSpanTest extends DDCoreSpecification {
     child.@origin == null // Access field directly instead of getter.
 
     where:
-    extractedContext                                                                     | _
-    new TagContext("some-origin", null, null, [:])                                       | _
-    new ExtractedContext(DDId.ONE, DDId.from(2), 0, "some-origin", null, null, [:], [:]) | _
+    extractedContext                                                                                       | _
+    new TagContext("some-origin", null, null, null, null, null, [:])                                       | _
+    new ExtractedContext(DDId.ONE, DDId.from(2), 0, "some-origin", null, null, null, null, null, [:], [:]) | _
   }
 
   def "isRootSpan() in and not in the context of distributed tracing"() {
@@ -212,9 +212,9 @@ class DDSpanTest extends DDCoreSpecification {
     root.finish()
 
     where:
-    extractedContext                                                                     | isTraceRootSpan
-    null                                                                                 | true
-    new ExtractedContext(DDId.from(123), DDId.from(456), 1, "789", null, null, [:], [:]) | false
+    extractedContext                                                                                       | isTraceRootSpan
+    null                                                                                                   | true
+    new ExtractedContext(DDId.from(123), DDId.from(456), 1, "789", null, null, null, null, null, [:], [:]) | false
   }
 
   def "getApplicationRootSpan() in and not in the context of distributed tracing"() {
@@ -234,9 +234,9 @@ class DDSpanTest extends DDCoreSpecification {
     root.finish()
 
     where:
-    extractedContext                                                                     | isTraceRootSpan
-    null                                                                                 | true
-    new ExtractedContext(DDId.from(123), DDId.from(456), 1, "789", null, null, [:], [:]) | false
+    extractedContext                                                                                       | isTraceRootSpan
+    null                                                                                                   | true
+    new ExtractedContext(DDId.from(123), DDId.from(456), 1, "789", null, null, null, null, null, [:], [:]) | false
   }
 
   def "infer top level from parent service name"() {

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/B3HttpExtractorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/B3HttpExtractorTest.groovy
@@ -102,7 +102,7 @@ class B3HttpExtractorTest extends DDSpecification {
     then:
     context != null
     !(context instanceof ExtractedContext)
-    context.forwardedFor == forwardedFor
+    context.forwardedIp == forwardedIp
     context.forwardedPort == forwardedPort
 
     when:
@@ -112,21 +112,21 @@ class B3HttpExtractorTest extends DDSpecification {
     context instanceof ExtractedContext
     context.traceId.toLong() == 1
     context.spanId.toLong() == 2
-    context.forwardedFor == forwardedFor
-    context.forwardedFor == forwardedFor
+    context.forwardedIp == forwardedIp
+    context.forwardedIp == forwardedIp
     context.forwardedPort == forwardedPort
 
     where:
-    forwardedFor = "1.2.3.4"
+    forwardedIp = "1.2.3.4"
     forwardedPort = "1234"
     tagOnlyCtx = [
-      "X-Forwarded-For" : forwardedFor,
+      "X-Forwarded-For" : forwardedIp,
       "X-Forwarded-Port": forwardedPort
     ]
     fullCtx = [
       (TRACE_ID_KEY.toUpperCase()): 1,
       (SPAN_ID_KEY.toUpperCase()) : 2,
-      "x-forwarded-for"           : forwardedFor,
+      "x-forwarded-for"           : forwardedIp,
       "x-forwarded-port"          : forwardedPort
     ]
   }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/DatadogHttpExtractorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/DatadogHttpExtractorTest.groovy
@@ -78,7 +78,7 @@ class DatadogHttpExtractorTest extends DDSpecification {
     then:
     context != null
     !(context instanceof ExtractedContext)
-    context.forwardedFor == forwardedFor
+    context.forwardedIp == forwardedIp
     context.forwardedPort == forwardedPort
 
     when:
@@ -88,21 +88,21 @@ class DatadogHttpExtractorTest extends DDSpecification {
     context instanceof ExtractedContext
     context.traceId.toLong() == 1
     context.spanId.toLong() == 2
-    context.forwardedFor == forwardedFor
-    context.forwardedFor == forwardedFor
+    context.forwardedIp == forwardedIp
+    context.forwardedIp == forwardedIp
     context.forwardedPort == forwardedPort
 
     where:
-    forwardedFor = "1.2.3.4"
+    forwardedIp = "1.2.3.4"
     forwardedPort = "1234"
     tagOnlyCtx = [
-      "X-Forwarded-For" : forwardedFor,
+      "X-Forwarded-For" : forwardedIp,
       "X-Forwarded-Port": forwardedPort
     ]
     fullCtx = [
       (TRACE_ID_KEY.toUpperCase()): 1,
       (SPAN_ID_KEY.toUpperCase()) : 2,
-      "x-forwarded-for"           : forwardedFor,
+      "x-forwarded-for"           : forwardedIp,
       "x-forwarded-port"          : forwardedPort
     ]
   }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HaystackHttpExtractorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HaystackHttpExtractorTest.groovy
@@ -65,7 +65,7 @@ class HaystackHttpExtractorTest extends DDSpecification {
     then:
     context != null
     !(context instanceof ExtractedContext)
-    context.forwardedFor == forwardedFor
+    context.forwardedIp == forwardedIp
     context.forwardedPort == forwardedPort
 
     when:
@@ -75,21 +75,21 @@ class HaystackHttpExtractorTest extends DDSpecification {
     context instanceof ExtractedContext
     context.traceId.toLong() == 1
     context.spanId.toLong() == 2
-    context.forwardedFor == forwardedFor
-    context.forwardedFor == forwardedFor
+    context.forwardedIp == forwardedIp
+    context.forwardedIp == forwardedIp
     context.forwardedPort == forwardedPort
 
     where:
-    forwardedFor = "1.2.3.4"
+    forwardedIp = "1.2.3.4"
     forwardedPort = "123"
     tagOnlyCtx = [
-      "X-Forwarded-For" : forwardedFor,
+      "X-Forwarded-For" : forwardedIp,
       "X-Forwarded-Port": forwardedPort
     ]
     fullCtx = [
       (TRACE_ID_KEY.toUpperCase()): 1,
       (SPAN_ID_KEY.toUpperCase()) : 2,
-      "x-forwarded-for"           : forwardedFor,
+      "x-forwarded-for"           : forwardedIp,
       "x-forwarded-port"          : forwardedPort
     ]
   }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
@@ -86,7 +86,13 @@ public interface AgentSpan extends MutableSpan {
     Iterable<Map.Entry<String, String>> baggageItems();
 
     interface Extracted extends Context {
-      String getForwardedFor();
+      String getForwarded();
+
+      String getForwardedProto();
+
+      String getForwardedHost();
+
+      String getForwardedIp();
 
       String getForwardedPort();
     }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -551,7 +551,22 @@ public class AgentTracer {
     }
 
     @Override
-    public String getForwardedFor() {
+    public String getForwarded() {
+      return null;
+    }
+
+    @Override
+    public String getForwardedProto() {
+      return null;
+    }
+
+    @Override
+    public String getForwardedHost() {
+      return null;
+    }
+
+    @Override
+    public String getForwardedIp() {
       return null;
     }
 

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/Tags.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/Tags.java
@@ -13,6 +13,11 @@ public class Tags {
   public static final String HTTP_ROUTE = "http.route";
   public static final String HTTP_STATUS = "http.status_code";
   public static final String HTTP_METHOD = "http.method";
+  public static final String HTTP_FORWARDED = "http.forwarded";
+  public static final String HTTP_FORWARDED_PROTO = "http.forwarded.proto";
+  public static final String HTTP_FORWARDED_HOST = "http.forwarded.host";
+  public static final String HTTP_FORWARDED_IP = "http.forwarded.ip";
+  public static final String HTTP_FORWARDED_PORT = "http.forwarded.port";
   public static final String PEER_HOST_IPV4 = "peer.ipv4";
   public static final String PEER_HOST_IPV6 = "peer.ipv6";
   public static final String PEER_SERVICE = "peer.service";


### PR DESCRIPTION
This avoids the complexity of managing multiple levels of forwarding presented as a comma separated list.

Also captures additional headers: `forwarded`, `x-forwarded-proto`, `x-forwarded-host`