### PR TITLE
Add a JFR event to report available processors

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkController.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkController.java
@@ -18,11 +18,13 @@ package com.datadog.profiling.controller.openjdk;
 import com.datadog.profiling.controller.ConfigurationException;
 import com.datadog.profiling.controller.Controller;
 import com.datadog.profiling.controller.jfr.JfpUtils;
+import com.datadog.profiling.controller.openjdk.events.AvailableProcessorsEvent;
 import datadog.trace.api.Config;
 import de.thetaphi.forbiddenapis.SuppressForbidden;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Map;
+import jdk.jfr.FlightRecorder;
 import jdk.jfr.Recording;
 
 /**
@@ -55,6 +57,7 @@ public final class OpenJdkController implements Controller {
     } catch (final IOException e) {
       throw new ConfigurationException(e);
     }
+    FlightRecorder.addPeriodicEvent(AvailableProcessorsEvent.class, AvailableProcessorsEvent::emit);
   }
 
   @Override

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkController.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkController.java
@@ -18,7 +18,7 @@ package com.datadog.profiling.controller.openjdk;
 import com.datadog.profiling.controller.ConfigurationException;
 import com.datadog.profiling.controller.Controller;
 import com.datadog.profiling.controller.jfr.JfpUtils;
-import com.datadog.profiling.controller.openjdk.events.AvailableProcessorsEvent;
+import com.datadog.profiling.controller.openjdk.events.AvailableProcessorCoresEvent;
 import datadog.trace.api.Config;
 import de.thetaphi.forbiddenapis.SuppressForbidden;
 import java.io.IOException;
@@ -57,7 +57,7 @@ public final class OpenJdkController implements Controller {
       throw new ConfigurationException(e);
     }
     // Register periodic events
-    AvailableProcessorsEvent.register();
+    AvailableProcessorCoresEvent.register();
   }
 
   @Override

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkController.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkController.java
@@ -24,7 +24,6 @@ import de.thetaphi.forbiddenapis.SuppressForbidden;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Map;
-import jdk.jfr.FlightRecorder;
 import jdk.jfr.Recording;
 
 /**
@@ -57,7 +56,8 @@ public final class OpenJdkController implements Controller {
     } catch (final IOException e) {
       throw new ConfigurationException(e);
     }
-    FlightRecorder.addPeriodicEvent(AvailableProcessorsEvent.class, AvailableProcessorsEvent::emit);
+    // Register periodic events
+    AvailableProcessorsEvent.register();
   }
 
   @Override

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/events/AvailableProcessorCoresEvent.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/events/AvailableProcessorCoresEvent.java
@@ -10,32 +10,32 @@ import jdk.jfr.Label;
 import jdk.jfr.Name;
 import jdk.jfr.Period;
 
-@Name("datadog.AvailableProcessors")
-@Label("Available Processors Count")
-@Description("The number of available processors as reported by the runtime")
+@Name("datadog.AvailableProcessorCores")
+@Label("Available Processor Core Count")
+@Description("The number of available processor cores as reported by the runtime")
 @Category("Datadog")
 @Period("beginChunk")
 @Enabled
-public class AvailableProcessorsEvent extends Event {
+public class AvailableProcessorCoresEvent extends Event {
   private static final AtomicBoolean registered = new AtomicBoolean(false);
 
-  @Label("Available Processors")
-  @Description("The number of available processors as reported by the runtime")
-  private int availableProcessors;
+  @Label("Available Processor Cores")
+  @Description("The number of available processor cores as reported by the runtime")
+  private int availableProcessorCores;
 
-  private AvailableProcessorsEvent() {
-    this.availableProcessors = Runtime.getRuntime().availableProcessors();
+  private AvailableProcessorCoresEvent() {
+    this.availableProcessorCores = Runtime.getRuntime().availableProcessors();
   }
 
   public static void emit() {
-    new AvailableProcessorsEvent().commit();
+    new AvailableProcessorCoresEvent().commit();
   }
 
   public static void register() {
     // Make sure the periodic event is registered only once
     if (registered.compareAndSet(false, true)) {
       FlightRecorder.addPeriodicEvent(
-          AvailableProcessorsEvent.class, AvailableProcessorsEvent::emit);
+          AvailableProcessorCoresEvent.class, AvailableProcessorCoresEvent::emit);
     }
   }
 }

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/events/AvailableProcessorsEvent.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/events/AvailableProcessorsEvent.java
@@ -1,9 +1,11 @@
 package com.datadog.profiling.controller.openjdk.events;
 
+import java.util.concurrent.atomic.AtomicBoolean;
 import jdk.jfr.Category;
 import jdk.jfr.Description;
 import jdk.jfr.Enabled;
 import jdk.jfr.Event;
+import jdk.jfr.FlightRecorder;
 import jdk.jfr.Label;
 import jdk.jfr.Name;
 import jdk.jfr.Period;
@@ -15,6 +17,8 @@ import jdk.jfr.Period;
 @Period("beginChunk")
 @Enabled
 public class AvailableProcessorsEvent extends Event {
+  private static final AtomicBoolean registered = new AtomicBoolean(false);
+
   @Label("Available Processors")
   @Description("The number of available processors as reported by the runtime")
   private int availableProcessors;
@@ -25,5 +29,13 @@ public class AvailableProcessorsEvent extends Event {
 
   public static void emit() {
     new AvailableProcessorsEvent().commit();
+  }
+
+  public static void register() {
+    // Make sure the periodic event is registered only once
+    if (registered.compareAndSet(false, true)) {
+      FlightRecorder.addPeriodicEvent(
+          AvailableProcessorsEvent.class, AvailableProcessorsEvent::emit);
+    }
   }
 }

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/events/AvailableProcessorsEvent.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/events/AvailableProcessorsEvent.java
@@ -1,0 +1,29 @@
+package com.datadog.profiling.controller.openjdk.events;
+
+import jdk.jfr.Category;
+import jdk.jfr.Description;
+import jdk.jfr.Enabled;
+import jdk.jfr.Event;
+import jdk.jfr.Label;
+import jdk.jfr.Name;
+import jdk.jfr.Period;
+
+@Name("datadog.AvailableProcessors")
+@Label("Available Processors Count")
+@Description("The number of available processors as reported by the runtime")
+@Category("Datadog")
+@Period("beginChunk")
+@Enabled
+public class AvailableProcessorsEvent extends Event {
+  @Label("Available Processors")
+  @Description("The number of available processors as reported by the runtime")
+  private int availableProcessors;
+
+  private AvailableProcessorsEvent() {
+    this.availableProcessors = Runtime.getRuntime().availableProcessors();
+  }
+
+  public static void emit() {
+    new AvailableProcessorsEvent().commit();
+  }
+}

--- a/dd-smoke-tests/profiling-integration-tests/src/test/java/datadog/smoketest/ProfilingIntegrationTest.java
+++ b/dd-smoke-tests/profiling-integration-tests/src/test/java/datadog/smoketest/ProfilingIntegrationTest.java
@@ -396,6 +396,19 @@ class ProfilingIntegrationTest {
     // check deadlock events
     assertTrue(events.apply(ItemFilters.type("datadog.Deadlock")).hasItems());
     assertTrue(events.apply(ItemFilters.type("datadog.DeadlockedThread")).hasItems());
+
+    // check available processor events
+    IItemCollection availableProcessorsEvents =
+        events.apply(ItemFilters.type("datadog.AvailableProcessors"));
+    assertTrue(availableProcessorsEvents.hasItems());
+    IAttribute<IQuantity> cpuCountAttr =
+        Attribute.attr("availableProcessors", "availableProcessors", UnitLookup.NUMBER);
+    long val =
+        ((IQuantity)
+                availableProcessorsEvents.getAggregate(
+                    Aggregators.min("datadog.AvailableProcessors", cpuCountAttr)))
+            .longValue();
+    System.out.println(val);
   }
 
   private static String getStringParameter(String name, Multimap<String, Object> parameters) {

--- a/dd-smoke-tests/profiling-integration-tests/src/test/java/datadog/smoketest/ProfilingIntegrationTest.java
+++ b/dd-smoke-tests/profiling-integration-tests/src/test/java/datadog/smoketest/ProfilingIntegrationTest.java
@@ -408,7 +408,7 @@ class ProfilingIntegrationTest {
                 availableProcessorsEvents.getAggregate(
                     Aggregators.min("datadog.AvailableProcessors", cpuCountAttr)))
             .longValue();
-    System.out.println(val);
+    assertEquals(Runtime.getRuntime().availableProcessors(), val);
   }
 
   private static String getStringParameter(String name, Multimap<String, Object> parameters) {

--- a/dd-smoke-tests/profiling-integration-tests/src/test/java/datadog/smoketest/ProfilingIntegrationTest.java
+++ b/dd-smoke-tests/profiling-integration-tests/src/test/java/datadog/smoketest/ProfilingIntegrationTest.java
@@ -399,14 +399,14 @@ class ProfilingIntegrationTest {
 
     // check available processor events
     IItemCollection availableProcessorsEvents =
-        events.apply(ItemFilters.type("datadog.AvailableProcessors"));
+        events.apply(ItemFilters.type("datadog.AvailableProcessorCores"));
     assertTrue(availableProcessorsEvents.hasItems());
     IAttribute<IQuantity> cpuCountAttr =
-        Attribute.attr("availableProcessors", "availableProcessors", UnitLookup.NUMBER);
+        Attribute.attr("availableProcessorCores", "availableProcessorCores", UnitLookup.NUMBER);
     long val =
         ((IQuantity)
                 availableProcessorsEvents.getAggregate(
-                    Aggregators.min("datadog.AvailableProcessors", cpuCountAttr)))
+                    Aggregators.min("datadog.AvailableProcessorCores", cpuCountAttr)))
             .longValue();
     assertEquals(Runtime.getRuntime().availableProcessors(), val);
   }

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
@@ -41,7 +41,7 @@ public final class ProfilingConfig {
   public static final String PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE =
       "profiling.exception.histogram.max-collection-size";
   public static final String PROFILING_EXCLUDE_AGENT_THREADS = "profiling.exclude.agent-threads";
-  public static final String PROFILING_HOTSPTOTS_ENABLED = "profiling.hotspots.enabled";
+  public static final String PROFILING_HOTSTOTS_ENABLED = "profiling.hotspots.enabled";
 
   // Not intended for production use
   public static final String PROFILING_AGENTLESS = "profiling.agentless";

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
@@ -41,7 +41,7 @@ public final class ProfilingConfig {
   public static final String PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE =
       "profiling.exception.histogram.max-collection-size";
   public static final String PROFILING_EXCLUDE_AGENT_THREADS = "profiling.exclude.agent-threads";
-  public static final String PROFILING_HOTSTOTS_ENABLED = "profiling.hotspots.enabled";
+  public static final String PROFILING_HOTSPOTS_ENABLED = "profiling.hotspots.enabled";
 
   // Not intended for production use
   public static final String PROFILING_AGENTLESS = "profiling.agentless";

--- a/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/ScopeEventFactory.java
+++ b/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/ScopeEventFactory.java
@@ -12,7 +12,7 @@ import jdk.jfr.EventType;
 /** Event factory for {@link ScopeEvent} */
 public class ScopeEventFactory implements ExtendedScopeListener {
   private static final ThreadCpuTimeProvider THREAD_CPU_TIME_PROVIDER =
-      ConfigProvider.createDefault().getBoolean(ProfilingConfig.PROFILING_HOTSPTOTS_ENABLED, false)
+      ConfigProvider.createDefault().getBoolean(ProfilingConfig.PROFILING_HOTSTOTS_ENABLED, false)
           ? SystemAccess::getCurrentThreadCpuTime
           : () -> Long.MIN_VALUE;
 

--- a/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/ScopeEventFactory.java
+++ b/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/ScopeEventFactory.java
@@ -12,7 +12,7 @@ import jdk.jfr.EventType;
 /** Event factory for {@link ScopeEvent} */
 public class ScopeEventFactory implements ExtendedScopeListener {
   private static final ThreadCpuTimeProvider THREAD_CPU_TIME_PROVIDER =
-      ConfigProvider.createDefault().getBoolean(ProfilingConfig.PROFILING_HOTSTOTS_ENABLED, false)
+      ConfigProvider.createDefault().getBoolean(ProfilingConfig.PROFILING_HOTSPOTS_ENABLED, false)
           ? SystemAccess::getCurrentThreadCpuTime
           : () -> Long.MIN_VALUE;
 

--- a/dd-trace-core/jfr-openjdk/src/test/groovy/datadog/trace/core/jfr/openjdk/ScopeEventTest.groovy
+++ b/dd-trace-core/jfr-openjdk/src/test/groovy/datadog/trace/core/jfr/openjdk/ScopeEventTest.groovy
@@ -23,7 +23,7 @@ class ScopeEventTest extends DDSpecification {
 
   def setup() {
     injectSysConfig(ProfilingConfig.PROFILING_ENABLED, "true")
-    injectSysConfig(ProfilingConfig.PROFILING_HOTSTOTS_ENABLED, "true")
+    injectSysConfig(ProfilingConfig.PROFILING_HOTSPOTS_ENABLED, "true")
     tracer = CoreTracer.builder().writer(new ListWriter()).build()
     GlobalTracer.forceRegister(tracer)
     tracer.addScopeListener(new ScopeEventFactory())

--- a/dd-trace-core/jfr-openjdk/src/test/groovy/datadog/trace/core/jfr/openjdk/ScopeEventTest.groovy
+++ b/dd-trace-core/jfr-openjdk/src/test/groovy/datadog/trace/core/jfr/openjdk/ScopeEventTest.groovy
@@ -23,7 +23,7 @@ class ScopeEventTest extends DDSpecification {
 
   def setup() {
     injectSysConfig(ProfilingConfig.PROFILING_ENABLED, "true")
-    injectSysConfig(ProfilingConfig.PROFILING_HOTSPTOTS_ENABLED, "true")
+    injectSysConfig(ProfilingConfig.PROFILING_HOTSTOTS_ENABLED, "true")
     tracer = CoreTracer.builder().writer(new ListWriter()).build()
     GlobalTracer.forceRegister(tracer)
     tracer.addScopeListener(new ScopeEventFactory())

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -101,7 +101,7 @@ import static datadog.trace.api.config.ProfilingConfig.PROFILING_EXCEPTION_HISTO
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_EXCEPTION_SAMPLE_LIMIT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_EXCLUDE_AGENT_THREADS;
-import static datadog.trace.api.config.ProfilingConfig.PROFILING_HOTSTOTS_ENABLED;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_HOTSPOTS_ENABLED;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_PROXY_HOST;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_PROXY_PASSWORD;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_PROXY_PORT;
@@ -709,7 +709,7 @@ public class Config {
     profilingExcludeAgentThreads = configProvider.getBoolean(PROFILING_EXCLUDE_AGENT_THREADS, true);
 
     // code hotspots are disabled by default because of potential perf overhead they can incur
-    profilingHotspotsEnabled = configProvider.getBoolean(PROFILING_HOTSTOTS_ENABLED, false);
+    profilingHotspotsEnabled = configProvider.getBoolean(PROFILING_HOTSPOTS_ENABLED, false);
 
     jdbcPreparedStatementClassName =
         configProvider.getString(JDBC_PREPARED_STATEMENT_CLASS_NAME, "");

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -101,7 +101,7 @@ import static datadog.trace.api.config.ProfilingConfig.PROFILING_EXCEPTION_HISTO
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_EXCEPTION_SAMPLE_LIMIT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_EXCLUDE_AGENT_THREADS;
-import static datadog.trace.api.config.ProfilingConfig.PROFILING_HOTSPTOTS_ENABLED;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_HOTSTOTS_ENABLED;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_PROXY_HOST;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_PROXY_PASSWORD;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_PROXY_PORT;
@@ -709,7 +709,7 @@ public class Config {
     profilingExcludeAgentThreads = configProvider.getBoolean(PROFILING_EXCLUDE_AGENT_THREADS, true);
 
     // code hotspots are disabled by default because of potential perf overhead they can incur
-    profilingHotspotsEnabled = configProvider.getBoolean(PROFILING_HOTSPTOTS_ENABLED, false);
+    profilingHotspotsEnabled = configProvider.getBoolean(PROFILING_HOTSTOTS_ENABLED, false);
 
     jdbcPreparedStatementClassName =
         configProvider.getString(JDBC_PREPARED_STATEMENT_CLASS_NAME, "");


### PR DESCRIPTION
JFR reports the total number of processor - not taking into account any restrictions put by the container.
However, the CPU time heuristics in profiler backend needs convert the CPU load which is calculated using the number of available cores rather than the total number of cores. Therefore we need this information captured in an extra JFR event.