### PR TITLE
Optimizations for activating spans and noop spans

### DIFF
--- a/dd-java-agent/instrumentation/akka-concurrent/src/main/java/datadog/trace/instrumentation/akka/concurrent/AkkaActorCellInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-concurrent/src/main/java/datadog/trace/instrumentation/akka/concurrent/AkkaActorCellInstrumentation.java
@@ -1,7 +1,7 @@
 package datadog.trace.instrumentation.akka.concurrent;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateNoopScope;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
 import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
@@ -10,8 +10,6 @@ import akka.dispatch.Envelope;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.bootstrap.InstrumentationContext;
-import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.AdviceUtils;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.State;
 import datadog.trace.context.TraceScope;
@@ -63,10 +61,9 @@ public class AkkaActorCellInstrumentation extends Instrumenter.Tracing {
       if (scope != null) {
         return scope;
       }
-      // If there is no scope created from the envelope, we create our own noopSpan to make sure
+      // If there is no scope created from the envelope, we create our own noopScope to make sure
       // that we can close all scopes up until this position after exit.
-      AgentSpan span = new AgentTracer.NoopAgentSpan();
-      return activateSpan(span, false);
+      return activateNoopScope();
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)

--- a/dd-java-agent/instrumentation/akka-concurrent/src/main/java/datadog/trace/instrumentation/akka/concurrent/AkkaMailboxInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-concurrent/src/main/java/datadog/trace/instrumentation/akka/concurrent/AkkaMailboxInstrumentation.java
@@ -1,7 +1,7 @@
 package datadog.trace.instrumentation.akka.concurrent;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateNoopScope;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
@@ -11,8 +11,6 @@ import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.ExcludeFilterProvider;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
-import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter;
 import datadog.trace.context.TraceScope;
 import java.util.Collection;
@@ -67,10 +65,9 @@ public class AkkaMailboxInstrumentation extends Instrumenter.Tracing
   public static final class SuppressMailboxRunAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static AgentScope enter() {
-      // Create our own noopSpan to make sure that we close all scopes up until this
+      // Create our own noopScope to make sure that we close all scopes up until this
       // position after exit
-      AgentSpan span = new AgentTracer.NoopAgentSpan();
-      return activateSpan(span, false);
+      return activateNoopScope();
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)

--- a/dd-trace-core/src/jmh/java/datadog/trace/core/ActivateSpan.java
+++ b/dd-trace-core/src/jmh/java/datadog/trace/core/ActivateSpan.java
@@ -1,0 +1,168 @@
+package datadog.trace.core;
+
+import datadog.trace.api.DDId;
+import datadog.trace.api.GlobalTracer;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import datadog.trace.common.writer.Writer;
+import datadog.trace.context.ScopeListener;
+import java.util.Collections;
+import java.util.List;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.infra.Blackhole;
+
+@State(Scope.Benchmark)
+public class ActivateSpan {
+
+  CoreTracer tracer;
+  PendingTrace trace;
+  DDSpan span1;
+  DDSpan span2;
+  CountingScopeListener countingScopeListener;
+
+  @Setup(Level.Trial)
+  public void init() {
+    tracer = CoreTracer.builder().writer(new VoidWriter()).strictTraceWrites(true).build();
+
+    DDId traceId = DDId.from(1);
+    trace = tracer.createTrace(traceId);
+    GlobalTracer.forceRegister(tracer);
+    countingScopeListener = new CountingScopeListener();
+    tracer.addScopeListener(countingScopeListener);
+
+    span1 =
+        DDSpan.create(
+            System.currentTimeMillis() * 1000,
+            new DDSpanContext(
+                traceId,
+                DDId.from(2),
+                DDId.ZERO,
+                null,
+                "service",
+                "operation",
+                "resource",
+                1,
+                null,
+                Collections.<String, String>emptyMap(),
+                false,
+                "type",
+                0,
+                trace));
+    span2 =
+        DDSpan.create(
+            System.currentTimeMillis() * 1000,
+            new DDSpanContext(
+                traceId,
+                DDId.from(3),
+                DDId.from(1),
+                null,
+                "service",
+                "operation",
+                "resource",
+                1,
+                null,
+                Collections.<String, String>emptyMap(),
+                false,
+                "type",
+                0,
+                trace));
+  }
+
+  @TearDown(Level.Trial)
+  public void end(Blackhole blackhole) {
+    blackhole.consume(countingScopeListener.getCount());
+  }
+
+  @Benchmark
+  public void singleScope(Blackhole blackhole) {
+    AgentScope scope = tracer.activateSpan(span1);
+    blackhole.consume(scope);
+    scope.close();
+  }
+
+  @Benchmark
+  public void singleNoopScope(Blackhole blackhole) {
+    AgentScope scope = tracer.activateSpan(AgentTracer.NoopAgentSpan.INSTANCE);
+    blackhole.consume(scope);
+    scope.close();
+  }
+
+  @Benchmark
+  public void singleActivateNoopScope(Blackhole blackhole) {
+    AgentScope scope = tracer.activateNoopScope();
+    blackhole.consume(scope);
+    scope.close();
+  }
+
+  @Benchmark
+  public void dualScope(Blackhole blackhole) {
+    AgentScope scope1 = tracer.activateSpan(span1);
+    AgentScope scope2 = tracer.activateSpan(span2);
+    blackhole.consume(scope2);
+    scope2.close();
+    blackhole.consume(scope1);
+    scope1.close();
+  }
+
+  @Benchmark
+  public void dualNoopScope(Blackhole blackhole) {
+    AgentScope scope1 = tracer.activateSpan(AgentTracer.NoopAgentSpan.INSTANCE);
+    AgentScope scope2 = tracer.activateSpan(AgentTracer.NoopAgentSpan.INSTANCE);
+    blackhole.consume(scope2);
+    scope2.close();
+    blackhole.consume(scope1);
+    scope1.close();
+  }
+
+  @Benchmark
+  public void dualActivateNoopScope(Blackhole blackhole) {
+    AgentScope scope1 = tracer.activateNoopScope();
+    AgentScope scope2 = tracer.activateNoopScope();
+    blackhole.consume(scope2);
+    scope2.close();
+    blackhole.consume(scope1);
+    scope1.close();
+  }
+
+  public static final class VoidWriter implements Writer {
+    @Override
+    public void write(List<DDSpan> trace) {}
+
+    @Override
+    public void start() {}
+
+    @Override
+    public boolean flush() {
+      return true;
+    }
+
+    @Override
+    public void close() {}
+
+    @Override
+    public void incrementDropCounts(int spanCount) {}
+  }
+
+  public static final class CountingScopeListener implements ScopeListener {
+    private long count;
+
+    @Override
+    public void afterScopeActivated() {
+      count++;
+    }
+
+    @Override
+    public void afterScopeClosed() {
+      count++;
+    }
+
+    public long getCount() {
+      return count;
+    }
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -478,6 +478,11 @@ public class CoreTracer implements AgentTracer.TracerAPI {
   }
 
   @Override
+  public AgentScope activateNoopScope() {
+    return scopeManager.activateNoopScope(ScopeSource.INSTRUMENTATION);
+  }
+
+  @Override
   public TraceScope.Continuation captureSpan(final AgentSpan span, ScopeSource source) {
     return scopeManager.captureSpan(span, source);
   }

--- a/dd-trace-core/src/test/resources/logback.xml
+++ b/dd-trace-core/src/test/resources/logback.xml
@@ -9,7 +9,7 @@
     </layout>
   </appender>
 
-  <root level="debug">
+  <root level="${logging-root-level:-DEBUG}">
     <appender-ref ref="console" />
   </root>
 

--- a/dd-trace-ot/src/main/java/datadog/opentracing/CustomScopeManagerWrapper.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/CustomScopeManagerWrapper.java
@@ -3,6 +3,7 @@ package datadog.opentracing;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentScopeManager;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.bootstrap.instrumentation.api.ScopeSource;
 import datadog.trace.context.TraceScope;
 import io.opentracing.Scope;
@@ -142,5 +143,10 @@ class CustomScopeManagerWrapper implements AgentScopeManager {
     public int hashCode() {
       return Objects.hash(delegate);
     }
+  }
+
+  @Override
+  public AgentScope activateNoopScope(ScopeSource source) {
+    return activate(AgentTracer.NoopAgentSpan.INSTANCE, source);
   }
 }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentScopeManager.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentScopeManager.java
@@ -16,4 +16,6 @@ public interface AgentScopeManager {
   AgentSpan activeSpan();
 
   TraceScope.Continuation captureSpan(AgentSpan span, ScopeSource source);
+
+  AgentScope activateNoopScope(ScopeSource source);
 }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -42,6 +42,10 @@ public class AgentTracer {
     return get().activateSpan(span, ScopeSource.INSTRUMENTATION, isAsyncPropagating);
   }
 
+  public static AgentScope activateNoopScope() {
+    return get().activateNoopScope();
+  }
+
   public static TraceScope.Continuation captureSpan(final AgentSpan span) {
     return get().captureSpan(span, ScopeSource.INSTRUMENTATION);
   }
@@ -99,6 +103,8 @@ public class AgentTracer {
     AgentScope activateSpan(AgentSpan span, ScopeSource source);
 
     AgentScope activateSpan(AgentSpan span, ScopeSource source, boolean isAsyncPropagating);
+
+    AgentScope activateNoopScope();
 
     TraceScope.Continuation captureSpan(AgentSpan span, ScopeSource source);
 
@@ -176,6 +182,11 @@ public class AgentTracer {
     @Override
     public AgentScope activateSpan(
         final AgentSpan span, final ScopeSource source, final boolean isAsyncPropagating) {
+      return NoopAgentScope.INSTANCE;
+    }
+
+    @Override
+    public AgentScope activateNoopScope() {
       return NoopAgentScope.INSTANCE;
     }
 


### PR DESCRIPTION
Add a special case for creating and activating a noop scope, that has a unique noop span, so it can be used to _clear_ the scope stack up to a specific point. 

Here are some benchmark results. Please note that the `dualNoopScope` case will be faster since it will short circuit and only increment a counter, as well as not call the scope listeners for the second scope.

```
Baseline
--------
Benchmark                                                             Mode  Cnt         Score         Error   Units
ActivateSpan.dualActivateNoopScope                                   thrpt    5  18829190.268 ±  253216.602   ops/s
ActivateSpan.dualActivateNoopScope:·gc.alloc.rate.norm               thrpt    5        48.000 ±       0.001    B/op
ActivateSpan.dualNoopScope                                           thrpt    5  21652267.455 ±  282995.940   ops/s
ActivateSpan.dualNoopScope:·gc.alloc.rate.norm                       thrpt    5        56.000 ±       0.001    B/op
ActivateSpan.dualScope                                               thrpt    5  14622150.909 ±  151840.159   ops/s
ActivateSpan.dualScope:·gc.alloc.rate.norm                           thrpt    5        64.000 ±       0.001    B/op
ActivateSpan.singleActivateNoopScope                                 thrpt    5  40515772.995 ±  141214.736   ops/s
ActivateSpan.singleActivateNoopScope:·gc.alloc.rate.norm             thrpt    5        ≈ 10⁻⁶                  B/op
ActivateSpan.singleNoopScope                                         thrpt    5  35828640.968 ± 2786135.485   ops/s
ActivateSpan.singleNoopScope:·gc.alloc.rate.norm                     thrpt    5        32.000 ±       0.001    B/op
ActivateSpan.singleScope                                             thrpt    5  33812503.141 ±  921420.259   ops/s
ActivateSpan.singleScope:·gc.alloc.rate.norm                         thrpt    5        32.000 ±       0.001    B/op

After optimizations
-------------------
Benchmark                                                             Mode  Cnt         Score         Error   Units
ActivateSpan.dualActivateNoopScope                                   thrpt    5  25208889.394 ±  157284.648   ops/s
ActivateSpan.dualActivateNoopScope:·gc.alloc.rate.norm               thrpt    5        ≈ 10⁻⁶                  B/op
ActivateSpan.dualNoopScope                                           thrpt    5  32535700.161 ± 1932828.890   ops/s
ActivateSpan.dualNoopScope:·gc.alloc.rate.norm                       thrpt    5        32.000 ±       0.001    B/op
ActivateSpan.dualScope                                               thrpt    5  21630399.414 ±  110936.129   ops/s
ActivateSpan.dualScope:·gc.alloc.rate.norm                           thrpt    5        64.000 ±       0.001    B/op
ActivateSpan.singleActivateNoopScope                                 thrpt    5  53024539.589 ±  233989.977   ops/s
ActivateSpan.singleActivateNoopScope:·gc.alloc.rate.norm             thrpt    5        ≈ 10⁻⁶                  B/op
ActivateSpan.singleNoopScope                                         thrpt    5  45480336.216 ±  940120.777   ops/s
ActivateSpan.singleNoopScope:·gc.alloc.rate.norm                     thrpt    5        32.000 ±       0.001    B/op
ActivateSpan.singleScope                                             thrpt    5  44521703.601 ± 3362219.385   ops/s
ActivateSpan.singleScope:·gc.alloc.rate.norm                         thrpt    5        32.000 ±       0.001    B/op
```