### PR TITLE
Disable PeerServiceTagInterceptor by default

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/taginterceptor/RuleFlags.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/taginterceptor/RuleFlags.java
@@ -7,17 +7,22 @@ public class RuleFlags {
   public enum Feature {
     // These names all derive from the simple class names which
     // were exposed as config at some point in the past.
-    RESOURCE_NAME("ResourceNameRule", true),
-    DB_STATEMENT("DBStatementRule", true),
-    FORCE_MANUAL_DROP("ForceManualDropTagInterceptor", true),
-    FORCE_MANUAL_KEEP("ForceManualKeepTagInterceptor", true),
+    RESOURCE_NAME("ResourceNameRule"),
+    DB_STATEMENT("DBStatementRule"),
+    FORCE_MANUAL_DROP("ForceManualDropTagInterceptor"),
+    FORCE_MANUAL_KEEP("ForceManualKeepTagInterceptor"),
     PEER_SERVICE("PeerServiceTagInterceptor", false),
-    SERVICE_NAME("ServiceNameTagInterceptor", true),
-    SERVLET_CONTEXT("ServletContextTagInterceptor", true);
+    SERVICE_NAME("ServiceNameTagInterceptor"),
+    SERVLET_CONTEXT("ServletContextTagInterceptor");
 
     private final String name;
 
     private final boolean defaultEnabled;
+
+    Feature(String name) {
+      this.name = name;
+      this.defaultEnabled = true;
+    }
 
     Feature(String name, boolean defaultEnabled) {
       this.name = name;

--- a/dd-trace-core/src/main/java/datadog/trace/core/taginterceptor/RuleFlags.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/taginterceptor/RuleFlags.java
@@ -7,18 +7,21 @@ public class RuleFlags {
   public enum Feature {
     // These names all derive from the simple class names which
     // were exposed as config at some point in the past.
-    RESOURCE_NAME("ResourceNameRule"),
-    DB_STATEMENT("DBStatementRule"),
-    FORCE_MANUAL_DROP("ForceManualDropTagInterceptor"),
-    FORCE_MANUAL_KEEP("ForceManualKeepTagInterceptor"),
-    PEER_SERVICE("PeerServiceTagInterceptor"),
-    SERVICE_NAME("ServiceNameTagInterceptor"),
-    SERVLET_CONTEXT("ServletContextTagInterceptor");
+    RESOURCE_NAME("ResourceNameRule", true),
+    DB_STATEMENT("DBStatementRule", true),
+    FORCE_MANUAL_DROP("ForceManualDropTagInterceptor", true),
+    FORCE_MANUAL_KEEP("ForceManualKeepTagInterceptor", true),
+    PEER_SERVICE("PeerServiceTagInterceptor", false),
+    SERVICE_NAME("ServiceNameTagInterceptor", true),
+    SERVLET_CONTEXT("ServletContextTagInterceptor", true);
 
     private final String name;
 
-    Feature(String name) {
+    private final boolean defaultEnabled;
+
+    Feature(String name, boolean defaultEnabled) {
       this.name = name;
+      this.defaultEnabled = defaultEnabled;
     }
   }
 
@@ -32,7 +35,7 @@ public class RuleFlags {
     Feature[] features = Feature.values();
     this.flags = new boolean[features.length];
     for (Feature feature : features) {
-      if (config.isRuleEnabled(feature.name)) {
+      if (config.isRuleEnabled(feature.name, feature.defaultEnabled)) {
         flags[feature.ordinal()] = true;
       }
     }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/taginterceptor/TagInterceptorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/taginterceptor/TagInterceptorTest.groovy
@@ -24,6 +24,7 @@ class TagInterceptorTest extends DDCoreSpecification {
 
   def "set service name"() {
     setup:
+    injectSysConfig("dd.trace.PeerServiceTagInterceptor.enabled", "true")
     def tracer = tracerBuilder()
       .serviceName("wrong-service")
       .writer(new LoggingWriter())
@@ -213,6 +214,7 @@ class TagInterceptorTest extends DDCoreSpecification {
 
   def "split-by-tags then peer-service via builder"() {
     setup:
+    injectSysConfig("dd.trace.PeerServiceTagInterceptor.enabled", "$enabled")
     def tracer = createSplittingTracer(Tags.MESSAGE_BUS_DESTINATION)
 
     when:
@@ -223,14 +225,18 @@ class TagInterceptorTest extends DDCoreSpecification {
     span.finish()
 
     then:
-    span.serviceName == "peer-service"
+    (span.serviceName == "peer-service") == enabled
 
     cleanup:
     tracer.close()
+
+    where:
+    enabled << [true, false]
   }
 
   def "split-by-tags then peer-service via setTag"() {
     setup:
+    injectSysConfig("dd.trace.PeerServiceTagInterceptor.enabled", "true")
     def tracer = createSplittingTracer(Tags.MESSAGE_BUS_DESTINATION)
 
     when:

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -1329,8 +1329,14 @@ public class Config {
   }
 
   public boolean isRuleEnabled(final String name) {
-    return configProvider.getBoolean("trace." + name + ".enabled", true)
-        && configProvider.getBoolean("trace." + name.toLowerCase() + ".enabled", true);
+    return isRuleEnabled(name, true);
+  }
+
+  public boolean isRuleEnabled(final String name, boolean defaultEnabled) {
+    boolean enabled = configProvider.getBoolean("trace." + name + ".enabled", defaultEnabled);
+    boolean lowerEnabled =
+        configProvider.getBoolean("trace." + name.toLowerCase() + ".enabled", defaultEnabled);
+    return defaultEnabled ? enabled && lowerEnabled : enabled || lowerEnabled;
   }
 
   /**


### PR DESCRIPTION
Can be reenabled: `-Ddd.trace.PeerServiceTagInterceptor.enabled=true`