### PR TITLE
Reduce jsp exception log level to avoid risk of log spam

### DIFF
--- a/dd-java-agent/instrumentation/jsp-2.3/src/main/java/datadog/trace/instrumentation/jsp/JSPDecorator.java
+++ b/dd-java-agent/instrumentation/jsp-2.3/src/main/java/datadog/trace/instrumentation/jsp/JSPDecorator.java
@@ -72,7 +72,7 @@ public class JSPDecorator extends BaseDecorator {
           "jsp.requestURL", (new URI(req.getRequestURL().toString())).normalize().toString());
     } catch (final URISyntaxException uriSE) {
       LoggerFactory.getLogger(HttpJspPage.class)
-          .warn("Failed to get and normalize request URL: " + uriSE.getMessage());
+          .debug("Failed to get and normalize request URL: " + uriSE.getMessage());
     }
   }
 }


### PR DESCRIPTION
The tag is not critical enough to warrant logging at `warn` level.