### PR TITLE
implement checkpoint API for profiler integration

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -66,6 +66,7 @@ public final class ConfigDefaults {
   static final int DEFAULT_PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS = 50;
   static final int DEFAULT_PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE = 10000;
   static final boolean DEFAULT_PROFILING_AGENTLESS = false;
+  static final boolean DEFAULT_PROFILING_LEGACY_TRACING_INTEGRATION = true;
 
   static final boolean DEFAULT_KAFKA_CLIENT_PROPAGATION_ENABLED = true;
 

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
@@ -43,6 +43,9 @@ public final class ProfilingConfig {
   public static final String PROFILING_EXCLUDE_AGENT_THREADS = "profiling.exclude.agent-threads";
   public static final String PROFILING_HOTSPOTS_ENABLED = "profiling.hotspots.enabled";
 
+  public static final String PROFILING_LEGACY_TRACING_INTEGRATION =
+      "profiling.legacy.tracing.integration";
+
   // Not intended for production use
   public static final String PROFILING_AGENTLESS = "profiling.agentless";
 

--- a/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/CheckpointEvent.java
+++ b/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/CheckpointEvent.java
@@ -1,0 +1,46 @@
+package datadog.trace.core.jfr.openjdk;
+
+import static datadog.trace.api.Checkpointer.CPU;
+import static datadog.trace.api.Checkpointer.SPAN;
+import static datadog.trace.api.Checkpointer.THREAD_MIGRATION;
+
+import datadog.trace.core.util.SystemAccess;
+import jdk.jfr.Category;
+import jdk.jfr.Description;
+import jdk.jfr.Event;
+import jdk.jfr.Label;
+import jdk.jfr.Name;
+import jdk.jfr.StackTrace;
+
+@Name("datadog.Checkpoint")
+@Label("Checkpoint")
+@Description("Datadog event corresponding to a tracing checkpoint.")
+@Category("Datadog")
+@StackTrace(false)
+public class CheckpointEvent extends Event {
+
+  private static final int RECORD_CPU_TIME = CPU | SPAN | THREAD_MIGRATION;
+
+  @Label("Trace Id")
+  private final long traceId;
+
+  @Label("Span Id")
+  private final long spanId;
+
+  @Label("Flags")
+  private final int flags;
+
+  @Label("Thread CPU Time")
+  private final long cpuTime;
+
+  public CheckpointEvent(long traceId, long spanId, int flags) {
+    this.traceId = traceId;
+    this.spanId = spanId;
+    this.flags = flags;
+    if ((flags & RECORD_CPU_TIME) != 0 && isEnabled()) {
+      this.cpuTime = SystemAccess.getCurrentThreadCpuTime();
+    } else {
+      this.cpuTime = 0L;
+    }
+  }
+}

--- a/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/JFRCheckpointer.java
+++ b/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/JFRCheckpointer.java
@@ -1,0 +1,11 @@
+package datadog.trace.core.jfr.openjdk;
+
+import datadog.trace.api.Checkpointer;
+import datadog.trace.api.DDId;
+
+public final class JFRCheckpointer implements Checkpointer {
+  @Override
+  public void checkpoint(DDId traceId, DDId spanId, int flags) {
+    new CheckpointEvent(traceId.toLong(), spanId.toLong(), flags).commit();
+  }
+}

--- a/dd-trace-core/jfr-openjdk/src/test/groovy/datadog/trace/core/jfr/openjdk/ScopeEventTest.groovy
+++ b/dd-trace-core/jfr-openjdk/src/test/groovy/datadog/trace/core/jfr/openjdk/ScopeEventTest.groovy
@@ -13,6 +13,10 @@ import spock.lang.Requires
 
 import java.time.Duration
 
+import static datadog.trace.api.Checkpointer.CPU
+import static datadog.trace.api.Checkpointer.SPAN
+import static datadog.trace.api.Checkpointer.THREAD_MIGRATION
+
 @Requires({
   jvm.java11Compatible
 })
@@ -280,5 +284,34 @@ class ScopeEventTest extends DDSpecification {
 
     cleanup:
     noProfilingTracer.close()
+  }
+
+  def "checkpoint events written when checkpointer registered"() {
+    setup:
+    SystemAccess.enableJmx()
+    def recording = JfrHelper.startRecording()
+    tracer.registerCheckpointer(new JFRCheckpointer())
+
+    when: "span goes through lifecycle without activation"
+    def span = tracer.startSpan("test")
+    span.startThreadMigration()
+    span.finishThreadMigration()
+    span.finish()
+    then: "checkpoints emitted"
+    def events = JfrHelper.stopRecording(recording)
+    events.size() == 4
+    events.each {
+      assert it.eventType.name == "datadog.Checkpoint"
+      assert it.getLong("traceId") == span.getTraceId().toLong()
+      assert it.getLong("spanId") == span.getSpanId().toLong()
+      int flags = it.getInt("flags")
+      long cpuTime = it.getLong("cpuTime")
+      if ((flags & (CPU | SPAN | THREAD_MIGRATION)) != 0) {
+        assert cpuTime > 0
+      } else {
+        assert cpuTime == 0L
+      }
+
+    }
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -1,5 +1,8 @@
 package datadog.trace.core;
 
+import static datadog.trace.api.sampling.PrioritySampling.SAMPLER_DROP;
+import static datadog.trace.api.sampling.PrioritySampling.USER_DROP;
+
 import datadog.trace.api.DDId;
 import datadog.trace.api.DDTags;
 import datadog.trace.api.sampling.PrioritySampling;
@@ -306,13 +309,18 @@ public class DDSpan implements AgentSpan, CoreSpan<DDSpan> {
 
   @Override
   public boolean eligibleForDropping() {
-    switch (context.getSamplingPriority()) {
-      case PrioritySampling.USER_DROP:
-      case PrioritySampling.SAMPLER_DROP:
-        return !context.getErrorFlag() & !forceKeep;
-      default:
-        return false;
-    }
+    int samplingPriority = context.getSamplingPriority();
+    return samplingPriority == USER_DROP || samplingPriority == SAMPLER_DROP;
+  }
+
+  @Override
+  public void startThreadMigration() {
+    context.getTracer().onStartThreadMigration(this);
+  }
+
+  @Override
+  public void finishThreadMigration() {
+    context.getTracer().onFinishThreadMigration(this);
   }
 
   /**

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
@@ -349,7 +349,6 @@ public class DDSpanContext implements AgentSpan.Context {
     return trace;
   }
 
-  @Deprecated
   public CoreTracer getTracer() {
     return trace.getTracer();
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/PendingTrace.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/PendingTrace.java
@@ -139,11 +139,13 @@ public class PendingTrace implements AgentTrace, PendingTraceBuffer.Element {
   }
 
   void registerSpan(final DDSpan span) {
+    tracer.onStart(span);
     ROOT_SPAN.compareAndSet(this, null, span);
     PENDING_REFERENCE_COUNT.incrementAndGet(this);
   }
 
   void addFinishedSpan(final DDSpan span) {
+    tracer.onFinish(span);
     finishedSpans.addFirst(span);
     // There is a benign race here where the span added above can get written out by a writer in
     // progress before the count has been incremented. It's being taken care of in the internal

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
@@ -423,6 +423,7 @@ public class ContinuableScopeManager implements AgentScopeManager {
     }
 
     Continuation register() {
+      spanUnderScope.startThreadMigration();
       trace.registerContinuation(this);
       return this;
     }
@@ -450,6 +451,7 @@ public class ContinuableScopeManager implements AgentScopeManager {
 
     @Override
     public AgentScope activate() {
+      spanUnderScope.finishThreadMigration();
       if (USED.compareAndSet(this, 0, 1)) {
         return scopeManager.handleSpan(this, spanUnderScope, source);
       } else {
@@ -537,6 +539,7 @@ public class ContinuableScopeManager implements AgentScopeManager {
     @Override
     public AgentScope activate() {
       if (tryActivate()) {
+        spanUnderScope.finishThreadMigration();
         return scopeManager.handleSpan(this, spanUnderScope, source);
       } else {
         return null;

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanTest.groovy
@@ -1,5 +1,6 @@
 package datadog.trace.core
 
+import datadog.trace.api.Checkpointer
 import datadog.trace.api.DDId
 import datadog.trace.api.sampling.PrioritySampling
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan
@@ -11,6 +12,10 @@ import datadog.trace.core.propagation.TagContext
 import datadog.trace.core.test.DDCoreSpecification
 
 import java.util.concurrent.TimeUnit
+
+import static datadog.trace.api.Checkpointer.END
+import static datadog.trace.api.Checkpointer.SPAN
+import static datadog.trace.api.Checkpointer.THREAD_MIGRATION
 
 class DDSpanTest extends DDCoreSpecification {
 
@@ -268,5 +273,46 @@ class DDSpanTest extends DDCoreSpecification {
     UTF8BytesString.create("fakeService") | false
     ""                                    | true
     null                                  | true
+  }
+
+  def "span start and finish emit checkpoints"() {
+    setup:
+    Checkpointer checkpointer = Mock()
+    tracer.registerCheckpointer(checkpointer)
+    DDSpanContext context =
+      new DDSpanContext(
+      DDId.from(1),
+      DDId.from(1),
+      DDId.ZERO,
+      null,
+      "fakeService",
+      "fakeOperation",
+      "fakeResource",
+      PrioritySampling.UNSET,
+      null,
+      Collections.<String, String> emptyMap(),
+      false,
+      "fakeType",
+      0,
+      tracer.pendingTraceFactory.create(DDId.ONE))
+
+    when:
+    DDSpan span = DDSpan.create(1, context)
+    then:
+    1 * checkpointer.checkpoint(context.getTraceId(), context.getSpanId(), SPAN)
+
+    when:
+    span.startThreadMigration()
+    then:
+    1 * checkpointer.checkpoint(context.getTraceId(), context.getSpanId(), THREAD_MIGRATION)
+    when:
+    span.finishThreadMigration()
+    then:
+    1 * checkpointer.checkpoint(context.getTraceId(), context.getSpanId(), THREAD_MIGRATION | END)
+
+    when:
+    span.finish()
+    then:
+    1 * checkpointer.checkpoint(context.getTraceId(), context.getSpanId(), SPAN | END)
   }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceBufferTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceBufferTest.groovy
@@ -77,6 +77,8 @@ class PendingTraceBufferTest extends DDSpecification {
     trace.pendingReferenceCount == 1
     1 * bufferSpy.enqueue(trace)
     _ * tracer.getPartialFlushMinSpans() >> 10
+    1 * tracer.onStartThreadMigration(span)
+    1 * tracer.onFinish(span)
     0 * _
 
     when:
@@ -107,6 +109,7 @@ class PendingTraceBufferTest extends DDSpecification {
     trace.pendingReferenceCount == 1
     1 * bufferSpy.enqueue(trace)
     _ * tracer.getPartialFlushMinSpans() >> 10
+    1 * tracer.onFinish(parent)
     0 * _
 
     when:
@@ -118,6 +121,7 @@ class PendingTraceBufferTest extends DDSpecification {
     1 * tracer.write({ it.size() == 2 })
     1 * tracer.writeTimer() >> Monitoring.DISABLED.newTimer("")
     _ * tracer.getPartialFlushMinSpans() >> 10
+    1 * tracer.onFinish(child)
     0 * _
   }
 
@@ -135,6 +139,9 @@ class PendingTraceBufferTest extends DDSpecification {
     buffer.queue.capacity() * bufferSpy.enqueue(_)
     _ * tracer.getPartialFlushMinSpans() >> 10
     _ * tracer.mapServiceName(_)
+    _ * tracer.onStart(_)
+    _ * tracer.onStartThreadMigration(_)
+    _ * tracer.onFinish(_)
     0 * _
 
     when:
@@ -146,6 +153,9 @@ class PendingTraceBufferTest extends DDSpecification {
     1 * tracer.write({ it.size() == 1 })
     _ * tracer.getPartialFlushMinSpans() >> 10
     _ * tracer.mapServiceName(_)
+    1 * tracer.onStart(_)
+    1 * tracer.onStartThreadMigration(_)
+    1 * tracer.onFinish(_)
     0 * _
   }
 
@@ -169,6 +179,7 @@ class PendingTraceBufferTest extends DDSpecification {
     !trace.rootSpanWritten
     1 * bufferSpy.enqueue(trace)
     _ * tracer.getPartialFlushMinSpans() >> 10
+    1 * tracer.onFinish(parent)
     0 * _
 
     when:
@@ -219,6 +230,7 @@ class PendingTraceBufferTest extends DDSpecification {
       parentLatch.countDown()
     }
     _ * tracer.getPartialFlushMinSpans() >> 10
+    1 * tracer.onFinish(parent)
     0 * _
 
     when:
@@ -237,6 +249,8 @@ class PendingTraceBufferTest extends DDSpecification {
       childLatch.countDown()
     }
     _ * tracer.mapServiceName(_)
+    1 * tracer.onStart(_)
+    1 * tracer.onFinish(_)
     0 * _
   }
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceTestBase.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceTestBase.groovy
@@ -2,6 +2,7 @@ package datadog.trace.core
 
 import ch.qos.logback.classic.Level
 import ch.qos.logback.classic.Logger
+import datadog.trace.api.Checkpointer
 import datadog.trace.common.writer.ListWriter
 import datadog.trace.core.test.DDCoreSpecification
 import org.slf4j.LoggerFactory
@@ -9,6 +10,8 @@ import org.slf4j.LoggerFactory
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
+import static datadog.trace.api.Checkpointer.END
+import static datadog.trace.api.Checkpointer.SPAN
 import static datadog.trace.api.config.TracerConfig.PARTIAL_FLUSH_MIN_SPANS
 
 abstract class PendingTraceTestBase extends DDCoreSpecification {
@@ -263,5 +266,26 @@ abstract class PendingTraceTestBase extends DDCoreSpecification {
     5           | 2000
     10          | 1000
     50          | 500
+  }
+
+  def "start and finish span emits checkpoints from PendingTrace"() {
+    // this test is kept close to pending trace despite not exercising
+    // its methods directly because this is where the reponsibility lies
+    // for emitting the checkpoints, and this is the least surprising place
+    // for a test to fail when modifying PendingTrace
+    setup:
+    Checkpointer checkpointer = Mock()
+    tracer.registerCheckpointer(checkpointer)
+
+    // unfortunately the span can't be
+    when:
+    def span = tracer.buildSpan("test").start()
+    then:
+    1 * checkpointer.checkpoint(_, _, SPAN)
+
+    when:
+    span.finish()
+    then:
+    1 * checkpointer.checkpoint(_, _, SPAN | END)
   }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerTest.groovy
@@ -1,6 +1,7 @@
 package datadog.trace.core.scopemanager
 
 import datadog.trace.agent.test.utils.ThreadUtils
+import datadog.trace.api.Checkpointer
 import datadog.trace.api.DDId
 import datadog.trace.api.StatsDClient
 import datadog.trace.api.interceptor.MutableSpan
@@ -23,6 +24,9 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
 
+import static datadog.trace.api.Checkpointer.END
+import static datadog.trace.api.Checkpointer.SPAN
+import static datadog.trace.api.Checkpointer.THREAD_MIGRATION
 import static datadog.trace.core.scopemanager.EVENT.ACTIVATE
 import static datadog.trace.core.scopemanager.EVENT.CLOSE
 import static datadog.trace.test.util.GCUtils.awaitGC
@@ -46,11 +50,14 @@ class ScopeManagerTest extends DDCoreSpecification {
   StatsDClient statsDClient
   EventCountingListener eventCountingListener
   EventCountingExtendedListener eventCountingExtendedListener
+  Checkpointer checkpointer
 
   def setup() {
+    checkpointer = Mock()
     writer = new ListWriter()
     statsDClient = Mock()
     tracer = tracerBuilder().writer(writer).statsDClient(statsDClient).build()
+    tracer.registerCheckpointer(checkpointer)
     scopeManager = tracer.scopeManager
     eventCountingListener = new EventCountingListener()
     scopeManager.addScopeListener(eventCountingListener)
@@ -455,6 +462,8 @@ class ScopeManagerTest extends DDCoreSpecification {
 
     then:
     assertEvents([ACTIVATE, ACTIVATE])
+    2 * checkpointer.checkpoint(_, _, SPAN) // two spans started by test
+    1 * checkpointer.checkpoint(_, _, SPAN | END) // span ended by test
     1 * statsDClient.incrementCounter("scope.close.error")
     0 * _
 
@@ -463,6 +472,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     secondScope.close()
 
     then:
+    1 * checkpointer.checkpoint(_, _, SPAN | END) // span ended by test
     assertEvents([ACTIVATE, ACTIVATE, CLOSE, CLOSE])
     0 * _
 
@@ -488,6 +498,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     tracer.activeSpan() == firstSpan
     tracer.activeScope() == firstScope
     assertEvents([ACTIVATE])
+    1 * checkpointer.checkpoint(_, _, SPAN) // span started by test
     0 * _
 
     when:
@@ -495,6 +506,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     AgentScope secondScope = tracer.activateSpan(secondSpan)
 
     then:
+    1 * checkpointer.checkpoint(_, _, SPAN) // span started by test
     assertEvents([ACTIVATE, ACTIVATE])
     tracer.activeSpan() == secondSpan
     tracer.activeScope() == secondScope
@@ -506,6 +518,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     AgentScope thirdScope = tracer.activateSpan(thirdSpan)
 
     then:
+    1 * checkpointer.checkpoint(_, _, SPAN) // span started by test
     assertEvents([ACTIVATE, ACTIVATE, ACTIVATE])
     tracer.activeSpan() == thirdSpan
     tracer.activeScope() == thirdScope
@@ -582,6 +595,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     0 * _
 
     then:
+    1 * checkpointer.checkpoint(_, _, SPAN) // span started by test
     assertEvents([ACTIVATE, ACTIVATE])
     tracer.activeSpan() == thirdSpan
     tracer.activeScope() == thirdScope
@@ -602,6 +616,7 @@ class ScopeManagerTest extends DDCoreSpecification {
 
     then: 'Closing scope above multiple activated scope does not close it'
     assertEvents([ACTIVATE, ACTIVATE, CLOSE, ACTIVATE])
+    1 * checkpointer.checkpoint(_, _, SPAN | END) // span finished by test
     0 * _
 
     when:
@@ -933,6 +948,56 @@ class ScopeManagerTest extends DDCoreSpecification {
     false               | true
     true                | false
     true                | true
+  }
+
+  def "continuation capture and activation emits checkpoints"() {
+    setup:
+    def span = tracer.buildSpan("test").start()
+
+    when:
+    def scope = tracer.activateSpan(span)
+    def continuation = scope.capture()
+
+    then:
+    1 * checkpointer.checkpoint(span.getTraceId(), span.context().getSpanId(), THREAD_MIGRATION)
+    0 * _
+
+    when:
+    continuation.activate()
+
+    then:
+    1 * checkpointer.checkpoint(span.getTraceId(), span.context().getSpanId(), THREAD_MIGRATION | END)
+    0 * _
+
+    when:
+    span.finish()
+    then:
+    1 * checkpointer.checkpoint(span.getTraceId(), span.context().getSpanId(), SPAN | END)
+  }
+
+  def "concurrent continuation capture and activation emits checkpoints"() {
+    setup:
+    def span = tracer.buildSpan("test").start()
+
+    when:
+    def scope = tracer.activateSpan(span)
+    def continuation = scope.captureConcurrent()
+
+    then:
+    1 * checkpointer.checkpoint(span.getTraceId(), span.context().getSpanId(), THREAD_MIGRATION)
+    0 * _
+
+    when:
+    continuation.activate()
+
+    then:
+    1 * checkpointer.checkpoint(span.getTraceId(), span.context().getSpanId(), THREAD_MIGRATION | END)
+    0 * _
+
+    when:
+    span.finish()
+    then:
+    1 * checkpointer.checkpoint(span.getTraceId(), span.context().getSpanId(), SPAN | END)
   }
 
   boolean spanFinished(AgentSpan span) {

--- a/internal-api/src/main/java/datadog/trace/api/Checkpointer.java
+++ b/internal-api/src/main/java/datadog/trace/api/Checkpointer.java
@@ -1,0 +1,33 @@
+package datadog.trace.api;
+
+public interface Checkpointer {
+
+  /**
+   * Modifier tag to make an event an end event. The LSB is chosen to allow for good varint
+   * compression.
+   */
+  int END = 0x1;
+  /** Marks the start of a span */
+  int SPAN = 0x2;
+  /**
+   * Indicates that the instrumentation expects synchronous CPU bound work to take place. The CPU
+   * work is considered to end when the next event for the same span without this flag set is
+   * received.
+   */
+  int CPU = 0x4;
+  /**
+   * Indicates that the instrumentation expects the span to make a thread migration and resume on
+   * another thread. This does not mean that the work on the current thread will cease, unless it is
+   * the last event for the span on the thread.
+   */
+  int THREAD_MIGRATION = 0x8;
+
+  /**
+   * Notifies the profiler that the span has reached a certain state
+   *
+   * @param traceId the traceId of the trace the span belongs to.
+   * @param spanId the span's identifier
+   * @param flags a description of the event
+   */
+  void checkpoint(DDId traceId, DDId spanId, int flags);
+}

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -26,6 +26,7 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_EXCEPTION_SAMPLE_LIMIT;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_LEGACY_TRACING_INTEGRATION;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_PROXY_PORT;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_START_DELAY;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_START_FORCE_FIRST;
@@ -103,6 +104,7 @@ import static datadog.trace.api.config.ProfilingConfig.PROFILING_EXCEPTION_HISTO
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_EXCEPTION_SAMPLE_LIMIT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_EXCLUDE_AGENT_THREADS;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_HOTSPOTS_ENABLED;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_LEGACY_TRACING_INTEGRATION;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_PROXY_HOST;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_PROXY_PASSWORD;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_PROXY_PORT;
@@ -329,6 +331,7 @@ public class Config {
 
   private final boolean profilingEnabled;
   private final boolean profilingAgentless;
+  private final boolean profilingLegacyTracingIntegrationEnabled;
   @Deprecated private final String profilingUrl;
   private final Map<String, String> profilingTags;
   private final int profilingStartDelay;
@@ -651,6 +654,9 @@ public class Config {
     profilingEnabled = configProvider.getBoolean(PROFILING_ENABLED, DEFAULT_PROFILING_ENABLED);
     profilingAgentless =
         configProvider.getBoolean(PROFILING_AGENTLESS, DEFAULT_PROFILING_AGENTLESS);
+    profilingLegacyTracingIntegrationEnabled =
+        configProvider.getBoolean(
+            PROFILING_LEGACY_TRACING_INTEGRATION, DEFAULT_PROFILING_LEGACY_TRACING_INTEGRATION);
     profilingUrl = configProvider.getString(PROFILING_URL);
 
     if (tmpApiKey == null) {
@@ -1866,5 +1872,9 @@ public class Config {
         + ", configProvider="
         + configProvider
         + '}';
+  }
+
+  public boolean isProfilingLegacyTracingIntegrationEnabled() {
+    return profilingLegacyTracingIntegrationEnabled;
   }
 }

--- a/internal-api/src/main/java/datadog/trace/api/SamplingCheckpointer.java
+++ b/internal-api/src/main/java/datadog/trace/api/SamplingCheckpointer.java
@@ -1,0 +1,84 @@
+package datadog.trace.api;
+
+import static datadog.trace.api.Checkpointer.CPU;
+import static datadog.trace.api.Checkpointer.END;
+import static datadog.trace.api.Checkpointer.SPAN;
+import static datadog.trace.api.Checkpointer.THREAD_MIGRATION;
+
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class SamplingCheckpointer implements SpanCheckpointer {
+
+  public static SamplingCheckpointer create() {
+    return new SamplingCheckpointer(NoOpCheckpointer.NO_OP);
+  }
+
+  private static final Logger log = LoggerFactory.getLogger(SamplingCheckpointer.class);
+
+  private static final AtomicReferenceFieldUpdater<SamplingCheckpointer, Checkpointer> CAS =
+      AtomicReferenceFieldUpdater.newUpdater(
+          SamplingCheckpointer.class, Checkpointer.class, "checkpointer");
+
+  private volatile Checkpointer checkpointer;
+
+  public SamplingCheckpointer(Checkpointer checkpointer) {
+    this.checkpointer = checkpointer;
+  }
+
+  public void register(Checkpointer checkpointer) {
+    if (!CAS.compareAndSet(this, NoOpCheckpointer.NO_OP, checkpointer)) {
+      log.debug(
+          "failed to register checkpointer {} - {} already registered",
+          checkpointer.getClass(),
+          this.checkpointer.getClass());
+    }
+  }
+
+  @Override
+  public void checkpoint(AgentSpan span, int flags) {
+    if (!span.eligibleForDropping()) {
+      checkpointer.checkpoint(span.getTraceId(), span.getSpanId(), flags);
+    }
+  }
+
+  @Override
+  public void onStart(AgentSpan span) {
+    checkpoint(span, SPAN);
+  }
+
+  @Override
+  public void onStartWork(AgentSpan span) {
+    checkpoint(span, CPU);
+  }
+
+  @Override
+  public void onFinishWork(AgentSpan span) {
+    checkpoint(span, CPU | END);
+  }
+
+  @Override
+  public void onStartThreadMigration(AgentSpan span) {
+    checkpoint(span, THREAD_MIGRATION);
+  }
+
+  @Override
+  public void onFinishThreadMigration(AgentSpan span) {
+    checkpoint(span, THREAD_MIGRATION | END);
+  }
+
+  @Override
+  public void onFinish(AgentSpan span) {
+    checkpoint(span, SPAN | END);
+  }
+
+  private static final class NoOpCheckpointer implements Checkpointer {
+
+    static final NoOpCheckpointer NO_OP = new NoOpCheckpointer();
+
+    @Override
+    public void checkpoint(DDId traceId, DDId spanId, int flags) {}
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/SpanCheckpointer.java
+++ b/internal-api/src/main/java/datadog/trace/api/SpanCheckpointer.java
@@ -1,0 +1,19 @@
+package datadog.trace.api;
+
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+
+public interface SpanCheckpointer {
+  void checkpoint(AgentSpan span, int flags);
+
+  void onStart(AgentSpan span);
+
+  void onStartWork(AgentSpan span);
+
+  void onFinishWork(AgentSpan span);
+
+  void onStartThreadMigration(AgentSpan span);
+
+  void onFinishThreadMigration(AgentSpan span);
+
+  void onFinish(AgentSpan span);
+}

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
@@ -8,6 +8,8 @@ public interface AgentSpan extends MutableSpan {
 
   DDId getTraceId();
 
+  DDId getSpanId();
+
   @Override
   AgentSpan setTag(String key, boolean value);
 
@@ -75,6 +77,12 @@ public interface AgentSpan extends MutableSpan {
   AgentSpan setResourceName(final CharSequence resourceName);
 
   boolean eligibleForDropping();
+
+  /** mark that the span has been captured in some task which will resume asynchronously. */
+  void startThreadMigration();
+
+  /** mark that the work associated with the span has resumed on a new thread */
+  void finishThreadMigration();
 
   interface Context {
     DDId getTraceId();

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -2,7 +2,9 @@ package datadog.trace.bootstrap.instrumentation.api;
 
 import static datadog.trace.api.ConfigDefaults.DEFAULT_ASYNC_PROPAGATING;
 
+import datadog.trace.api.Checkpointer;
 import datadog.trace.api.DDId;
+import datadog.trace.api.SpanCheckpointer;
 import datadog.trace.api.interceptor.TraceInterceptor;
 import datadog.trace.api.sampling.PrioritySampling;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan.Context;
@@ -87,7 +89,7 @@ public class AgentTracer {
   // Not intended to be constructed.
   private AgentTracer() {}
 
-  public interface TracerAPI extends datadog.trace.api.Tracer, AgentPropagation {
+  public interface TracerAPI extends datadog.trace.api.Tracer, AgentPropagation, SpanCheckpointer {
     AgentSpan startSpan(CharSequence spanName);
 
     AgentSpan startSpan(CharSequence spanName, long startTimeMicros);
@@ -115,6 +117,13 @@ public class AgentTracer {
     void close();
 
     void flush();
+
+    /**
+     * Registers the checkpointer
+     *
+     * @param checkpointer
+     */
+    void registerCheckpointer(Checkpointer checkpointer);
   }
 
   public interface SpanBuilder {
@@ -234,6 +243,9 @@ public class AgentTracer {
     public void addScopeListener(final ScopeListener listener) {}
 
     @Override
+    public void registerCheckpointer(Checkpointer checkpointer) {}
+
+    @Override
     public TraceScope.Continuation capture() {
       return null;
     }
@@ -248,6 +260,27 @@ public class AgentTracer {
     public <C> Context.Extracted extract(final C carrier, final ContextVisitor<C> getter) {
       return null;
     }
+
+    @Override
+    public void checkpoint(AgentSpan span, int flags) {}
+
+    @Override
+    public void onStart(AgentSpan span) {}
+
+    @Override
+    public void onStartWork(AgentSpan span) {}
+
+    @Override
+    public void onFinishWork(AgentSpan span) {}
+
+    @Override
+    public void onStartThreadMigration(AgentSpan span) {}
+
+    @Override
+    public void onFinishThreadMigration(AgentSpan span) {}
+
+    @Override
+    public void onFinish(AgentSpan span) {}
   }
 
   public static class NoopAgentSpan implements AgentSpan {
@@ -255,6 +288,11 @@ public class AgentTracer {
 
     @Override
     public DDId getTraceId() {
+      return DDId.ZERO;
+    }
+
+    @Override
+    public DDId getSpanId() {
       return DDId.ZERO;
     }
 
@@ -357,6 +395,12 @@ public class AgentTracer {
     public boolean eligibleForDropping() {
       return true;
     }
+
+    @Override
+    public void startThreadMigration() {}
+
+    @Override
+    public void finishThreadMigration() {}
 
     @Override
     public Integer getSamplingPriority() {

--- a/internal-api/src/test/groovy/datadog/trace/api/SamplingCheckpointerTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/SamplingCheckpointerTest.groovy
@@ -1,0 +1,77 @@
+package datadog.trace.api
+
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan
+import datadog.trace.test.util.DDSpecification
+
+import static datadog.trace.api.Checkpointer.CPU
+import static datadog.trace.api.Checkpointer.END
+import static datadog.trace.api.Checkpointer.SPAN
+import static datadog.trace.api.Checkpointer.THREAD_MIGRATION
+
+class SamplingCheckpointerTest extends DDSpecification {
+
+  def "test sampling and fallback"() {
+    setup:
+    Checkpointer checkpointer = Mock()
+    SamplingCheckpointer sut = SamplingCheckpointer.create()
+    if (register) {
+      sut.register(checkpointer)
+    }
+    DDId traceId = DDId.from(1)
+    DDId spanId = DDId.from(2)
+    AgentSpan span = Stub(AgentSpan)
+    span.eligibleForDropping() >> drop
+    span.getTraceId() >> traceId
+    span.getSpanId() >> spanId
+    int count = register ? drop ? 0 : 1 : 0
+
+    when:
+    sut.onStart(span)
+    then:
+    count * checkpointer.checkpoint(traceId, spanId, SPAN)
+    0 * _
+
+    when:
+    sut.onStartWork(span)
+    then:
+    count * checkpointer.checkpoint(traceId, spanId, CPU)
+    0 * _
+
+    when:
+    sut.onFinishWork(span)
+    then:
+    count * checkpointer.checkpoint(traceId, spanId, CPU | END)
+    0 * _
+
+    when:
+    sut.onStartThreadMigration(span)
+    then:
+    count * checkpointer.checkpoint(traceId, spanId, THREAD_MIGRATION)
+    0 * _
+
+    when:
+    sut.onFinishThreadMigration(span)
+    then:
+    count * checkpointer.checkpoint(traceId, spanId, THREAD_MIGRATION | END)
+    0 * _
+
+    when:
+    sut.checkpoint(span, CPU | SPAN)
+    then:
+    count * checkpointer.checkpoint(traceId, spanId, CPU | SPAN)
+    0 * _
+
+    when:
+    sut.onFinish(span)
+    then:
+    count * checkpointer.checkpoint(traceId, spanId, SPAN | END)
+    0 * _
+
+    where:
+    drop | register
+    true | true
+    true | false
+    false | true
+    false | false
+  }
+}


### PR DESCRIPTION
Captures span start, finish and thread migration, allows instrumentation to trigger recording of CPU intensive work.

Mutually exclusive with scope events. Activated by `-Ddd.profiling.legacy.tracing.integration=false` (which disables scope events).