### PR TITLE
Don't create noop scopes for akka messaging unless necessary

### DIFF
--- a/dd-java-agent/instrumentation/akka-concurrent/src/main/java/datadog/trace/instrumentation/akka/concurrent/AkkaActorCellInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-concurrent/src/main/java/datadog/trace/instrumentation/akka/concurrent/AkkaActorCellInstrumentation.java
@@ -3,6 +3,7 @@ package datadog.trace.instrumentation.akka.concurrent;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 
@@ -10,7 +11,6 @@ import akka.dispatch.Envelope;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.bootstrap.InstrumentationContext;
-import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.AdviceUtils;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.State;
@@ -56,29 +56,40 @@ public class AkkaActorCellInstrumentation extends Instrumenter.Tracing {
    */
   public static class InvokeAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static TraceScope enter(@Advice.Argument(value = 0) Envelope envelope) {
-      TraceScope scope =
+    public static TraceScope enter(
+        @Advice.Argument(value = 0) Envelope envelope,
+        @Advice.Local(value = "localScope") TraceScope localScope) {
+      TraceScope activeScope = activeScope();
+      localScope =
           AdviceUtils.startTaskScope(
               InstrumentationContext.get(Envelope.class, State.class), envelope);
-      if (scope != null) {
-        return scope;
+      // There was a scope created from the envelop, so use that
+      if (localScope != null) {
+        return activeScope;
       }
-      // If there is no scope created from the envelope, we create our own noopSpan to make sure
-      // that we can close all scopes up until this position after exit.
-      AgentSpan span = new AgentTracer.NoopAgentSpan();
-      return activateSpan(span, false);
+      // If there is no active scope, we can clean all the way to the bottom
+      if (null == activeScope) {
+        return null;
+      }
+      // If there is a noop span in the active scope, we can clean all the way to this scope
+      if (activeSpan() instanceof AgentTracer.NoopAgentSpan) {
+        return activeScope;
+      }
+      // Create an active scope with a noop span, and clean all the way to the previous scope
+      localScope = activateSpan(AgentTracer.NoopAgentSpan.INSTANCE, false);
+      return activeScope;
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
-    public static void exit(@Advice.Enter TraceScope scope) {
+    public static void exit(
+        @Advice.Enter TraceScope scope, @Advice.Local(value = "localScope") TraceScope localScope) {
+      if (localScope != null) {
+        localScope.close();
+      }
       // Clean up any leaking scopes from akka-streams/akka-http et.c.
       TraceScope activeScope = activeScope();
       while (activeScope != null && activeScope != scope) {
         activeScope.close();
-        activeScope = activeScope();
-      }
-      while (activeScope == scope) {
-        scope.close();
         activeScope = activeScope();
       }
     }

--- a/dd-java-agent/instrumentation/akka-concurrent/src/main/java/datadog/trace/instrumentation/akka/concurrent/AkkaMailboxInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-concurrent/src/main/java/datadog/trace/instrumentation/akka/concurrent/AkkaMailboxInstrumentation.java
@@ -3,14 +3,13 @@ package datadog.trace.instrumentation.akka.concurrent;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 import static java.util.Collections.singletonList;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.ExcludeFilterProvider;
 import datadog.trace.agent.tooling.Instrumenter;
-import datadog.trace.bootstrap.instrumentation.api.AgentScope;
-import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter;
 import datadog.trace.context.TraceScope;
@@ -64,23 +63,27 @@ public class AkkaMailboxInstrumentation extends Instrumenter.Tracing
    */
   public static final class SuppressMailboxRunAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static AgentScope enter() {
-      // Create our own noopSpan to make sure that we close all scopes up until this
-      // position after exit
-      AgentSpan span = new AgentTracer.NoopAgentSpan();
-      return activateSpan(span, false);
+    public static TraceScope enter() {
+      TraceScope activeScope = activeScope();
+      // If there is no active scope, we can clean all the way to the bottom
+      if (null == activeScope) {
+        return null;
+      }
+      // If there is a noop span in the active scope, we can clean all the way to this scope
+      if (activeSpan() instanceof AgentTracer.NoopAgentSpan) {
+        return activeScope;
+      }
+      // Create an active scope with a noop span, and clean all the way to the previous scope
+      activateSpan(AgentTracer.NoopAgentSpan.INSTANCE, false);
+      return activeScope;
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
-    public static void exit(@Advice.Enter final AgentScope scope) {
+    public static void exit(@Advice.Enter final TraceScope scope) {
       // Clean up any leaking scopes from akka-streams/akka-http et.c.
       TraceScope activeScope = activeScope();
       while (activeScope != null && activeScope != scope) {
         activeScope.close();
-        activeScope = activeScope();
-      }
-      while (activeScope == scope) {
-        scope.close();
         activeScope = activeScope();
       }
     }


### PR DESCRIPTION
This change tries to minimize the work done when there is no span travelling across an akka message send.

Here are some numbers for an akka message sending benchmark that don't have any spans active.

|Version  | Average time (s) | stdev | overhead %|
|---------|------------------|-------|-----------|
|none     |            1.676 | 0.132 |      0.000|
|0.75.0   |            4.163 | 0.588 |    148.426|
|0.76.0   |            4.675 | 0.845 |    178.973|
|0.76.1   |            4.051 | 0.473 |    141.741|
|0.77.0   |           11.723 | 3.888 |    599.550|
|0.78.1   |            9.756 | 3.390 |    482.148|
|0.78.2   |            7.253 | 0.811 |    332.792|
|0.78.3   |            4.276 | 0.364 |    155.163|
|0.79.0   |            4.147 | 0.381 |    147.496|
|this PR |            1.980 | 0.218 |     18.169|
