### PR TITLE
Minimize size of final JAR

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -10,6 +10,10 @@ gradlePlugin {
       id = "muzzle"
       implementationClass = "MuzzlePlugin"
     }
+    create("minimize-plugin") {
+      id = "minimize"
+      implementationClass = "MinimizePlugin"
+    }
   }
 }
 
@@ -30,6 +34,8 @@ dependencies {
   implementation("com.google.guava", "guava", "20.0")
   implementation("org.ow2.asm", "asm", "9.0")
   implementation("org.ow2.asm", "asm-tree", "9.0")
+
+  implementation("org.vafer", "jdependency", "2.6.0")
 
   testImplementation("org.spockframework", "spock-core", "2.0-M4-groovy-2.5")
   testImplementation("org.codehaus.groovy", "groovy-all", "2.5.13")

--- a/buildSrc/src/main/groovy/MinimizePlugin.groovy
+++ b/buildSrc/src/main/groovy/MinimizePlugin.groovy
@@ -1,0 +1,141 @@
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.file.FileVisitDetails
+import org.gradle.api.file.RegularFile
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Input
+import org.gradle.jvm.tasks.Jar
+import org.vafer.jdependency.Clazz
+import org.vafer.jdependency.Clazzpath
+import org.vafer.jdependency.ClazzpathUnit
+
+import java.util.regex.Pattern
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+class MinimizePlugin implements Plugin<Project> {
+
+  @Override
+  void apply(Project project) {
+    def extension = project.extensions.create('minimize', MinimizePluginExtension)
+
+    Jar shadowJarTask = project.tasks['shadowJar']
+
+    def minShadowJarTask = project.task('minShadowJar', type: MinimizeJarTask) {
+      group = 'build'
+      description = 'Filters out unused classes from shadowJar'
+
+      archiveClassifier.set 'minimized'
+      unusedClassFiles.set(extension.additionalInclusions)
+
+      dependsOn shadowJarTask
+    }
+
+    // Separate configuration task to work-around the fact
+    // that zipTree eagerly evaluates the shadowJarTask.archiveFile
+    project.task('configureMinShadowJar') { configureMinShadowJarTask ->
+      Provider<RegularFile> shadowJarFile = shadowJarTask.archiveFile
+
+      doFirst {
+        List<ClazzpathUnit> ddUnits = []
+        def clazzpath = new Clazzpath()
+
+        Set<String> firstLevelFiles =
+          filesOfFirstLevelDatadogDependencies(project, shadowJarTask)
+
+        List<Pattern> additionalInclusions = extension.additionalInclusions.get()
+
+        // inspect the original shadow jar
+        project.zipTree(shadowJarFile).visit { FileVisitDetails fdet ->
+          def relPath = fdet.relativePath as String
+          if (!fdet.directory && relPath =~ /\.class$/) {
+            // create temporary zip file with just this class to workaround
+            // jdependency API limitations
+            ByteArrayOutputStream baos = new ByteArrayOutputStream()
+            new ZipOutputStream(baos).withCloseable { zos ->
+              ZipEntry entry = new ZipEntry(relPath)
+              zos.putNextEntry(entry)
+              fdet.file.withInputStream {is ->
+                zos << is
+              }
+              zos.closeEntry()
+            }
+
+            ClazzpathUnit unit = clazzpath.addClazzpathUnit(
+              new ByteArrayInputStream(baos.toByteArray()), relPath)
+
+            // two criteria for inclusion:
+            // 1. path of class contains datadog in some first
+            // 2. the path can be found in the jars of shadowJar direct dependencies
+            //    whose names includes 'datadog'. Other inputs of the shadowJar are
+            //    not considered
+            // 3. If the path matches any of additional inclusions
+            if (relPath =~ /^com\/datadoghq\b/ || relPath =~ /^com\/datadog\b/
+              || relPath =~ /^datadog\// || relPath in firstLevelFiles ||
+              additionalInclusions.any {relPath =~ it}) {
+              ddUnits << unit
+            }
+          }
+        }
+
+        Set<Clazz> unused = clazzpath.clazzes
+        ddUnits.each {
+          unused.removeAll(it.clazzes)
+          unused.removeAll(it.transitiveDependencies)
+        }
+
+        minShadowJarTask.configure {
+          from(project.zipTree(shadowJarFile)) {
+            exclude unused.collect { "${it.toString().replaceAll(/\./, '/')}.class" }
+          }
+        }
+      }
+
+      dependsOn shadowJarTask
+      minShadowJarTask.dependsOn configureMinShadowJarTask
+    }
+  }
+
+  private Set<String> filesOfFirstLevelDatadogDependencies(Project project, Jar shadowJarTask) {
+    shadowJarTask.configurations.collectMany {
+      it.resolvedConfiguration.firstLevelModuleDependencies
+    }.findAll {
+      it.name =~ /datadog/
+    }.collectMany {
+      it.moduleArtifacts*.file
+    }.collectMany {
+      def files = [] as Set
+      project.zipTree(it).visit { FileVisitDetails det ->
+        if (!det.directory) {
+          files << det.relativePath.toString()
+        }
+      }
+      files
+    } as Set
+  }
+}
+
+/* Extends Jar task and adds an input property to avoid the minimized jar
+ * being considered up-to-date even after changing the additionInclusions
+ * extension property */
+class MinimizeJarTask extends Jar {
+  @Input
+  final ListProperty<Pattern> unusedClassFiles
+
+  MinimizeJarTask() {
+    ObjectFactory objectFactory = project.objects
+    unusedClassFiles = objectFactory.listProperty(Pattern)
+    unusedClassFiles.convention([])
+  }
+}
+
+class MinimizePluginExtension {
+  // includes dependencies thereof
+  ListProperty<Pattern> additionalInclusions
+
+  MinimizePluginExtension(ObjectFactory objects) {
+    additionalInclusions = objects.listProperty(Pattern)
+  }
+}

--- a/dd-java-agent/agent-jmxfetch/agent-jmxfetch.gradle
+++ b/dd-java-agent/agent-jmxfetch/agent-jmxfetch.gradle
@@ -2,6 +2,7 @@ plugins {
   id "com.github.johnrengelman.shadow"
 }
 apply from: "$rootDir/gradle/java.gradle"
+apply plugin: 'minimize'
 
 dependencies {
   compile('com.datadoghq:jmxfetch:0.43.1') {

--- a/dd-java-agent/agent-profiling/agent-profiling.gradle
+++ b/dd-java-agent/agent-profiling/agent-profiling.gradle
@@ -11,6 +11,7 @@ ext {
 apply from: "$rootDir/gradle/java.gradle"
 // We do not publish separate jar, but having version file is useful
 apply from: "$rootDir/gradle/version.gradle"
+apply plugin: 'minimize'
 
 dependencies {
   compile deps.slf4j
@@ -40,6 +41,14 @@ shadowJar {
     exclude(project(':internal-api'))
     exclude(dependency('org.slf4j::'))
   }
+}
+minimize {
+  additionalInclusions = [
+    // https://github.com/lz4/lz4-java/blob/55bede61a72803574c638a1ef1a70eadc6cefa6e/src/java/net/jpountz/lz4/LZ4Factory.java#L193-L196
+    ~'^net/jpountz/lz4/LZ4',
+    // https://github.com/lz4/lz4-java/blob/55bede61a72803574c638a1ef1a70eadc6cefa6e/src/java/net/jpountz/xxhash/XXHashFactory.java#L179-L182
+    ~'^net/jpountz/xxhash/(?:Streaming)?XXHash\\d{2}'
+  ]
 }
 
 jar {

--- a/dd-java-agent/dd-java-agent.gradle
+++ b/dd-java-agent/dd-java-agent.gradle
@@ -1,6 +1,18 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import org.vafer.jdependency.Clazz
+import org.vafer.jdependency.Clazzpath
+import org.vafer.jdependency.ClazzpathUnit
 
 import java.util.concurrent.atomic.AtomicBoolean
+
+buildscript {
+  repositories {
+    mavenCentral()
+  }
+  dependencies {
+    classpath group: 'org.vafer', name: 'jdependency', version: '2.6.0'
+  }
+}
 
 plugins {
   id "com.github.johnrengelman.shadow"
@@ -42,7 +54,7 @@ ext.generalShadowJarConfig = {
   }
 }
 
-def includeShadowJar(shadowJarTask, jarname) {
+def includeShadowJar(shadowJarTask, jarname, Closure customizeZipProcessing = null) {
   def opentracingFound = new AtomicBoolean()
   project.processResources {
     doFirst {
@@ -64,32 +76,101 @@ def includeShadowJar(shadowJarTask, jarname) {
       rename '(^.*)\\.class$', '$1.classdata'
       // Rename LICENSE file since it clashes with license dir on non-case sensitive FSs (i.e. Mac)
       rename '^LICENSE$', 'LICENSE.renamed'
+      if (customizeZipProcessing) {
+        customizeZipProcessing.delegate = it
+        customizeZipProcessing.call(it)
+      }
     }
   }
 
   project.processResources.dependsOn shadowJarTask
-  shadowJarTask.configure generalShadowJarConfig
 }
 
-def includeSubprojShadowJar(String projName, String jarname) {
+// these include the shared dependencies of the subprojects' shadowJars,
+// which are not included in those shadowJars themselves
+task sharedShadowJar(type: ShadowJar) {
+  configure generalShadowJarConfig
+  configurations = [project.configurations.sharedShadowInclude]
+  archiveClassifier = 'shared'
+
+  project.processResources.dependsOn it
+}
+// used to keep track of the shared classes that are actually used by the
+// subprojects' shadowJars. The scanning is done in scanUsedClassesFor* tasks
+def sharedClassesUsage = [
+  clazzpath: new Clazzpath(),
+
+  // Units for subprojects' shadowJars. Classes in these units will be deemed used
+  clazzpathUnits: [],
+
+  // the tasks of the subprojects' shadowJars.
+  // configureSharedShadowJar (and transitively, the shadowJar) tasks will depend on them
+  tasks: []]
+def includeSubprojShadowJar = { String projName, String jarname ->
   evaluationDependsOn projName
   def proj = project(projName)
-  includeShadowJar proj.tasks.shadowJar, jarname
+  def shadowJarTask = proj.tasks['shadowJar']
+
+  shadowJarTask.configure generalShadowJarConfig
+
+  def finalJarTask = proj.tasks.findByName('minShadowJar') ?
+    proj.tasks['minShadowJar'] : shadowJarTask
+
+  includeShadowJar finalJarTask, jarname
+
+  // register class uses for shared shadow jar minimization
+  project.tasks.sharedShadowJar.inputs.file finalJarTask.archiveFile
+  def scanTask = project.tasks.create("scanUsedClassesFor${jarname.capitalize()}") {
+    inputs.file(finalJarTask.archiveFile)
+
+    doFirst {
+      sharedClassesUsage.clazzpathUnits <<
+        sharedClassesUsage.clazzpath.addClazzpathUnit(finalJarTask.archiveFile.get().getAsFile())
+    }
+
+    dependsOn finalJarTask
+  }
+  sharedClassesUsage.tasks << scanTask
 }
 
 includeSubprojShadowJar ':dd-java-agent:instrumentation', 'inst'
 includeSubprojShadowJar ':dd-java-agent:agent-jmxfetch', 'metrics'
 includeSubprojShadowJar ':dd-java-agent:agent-profiling', 'profiling'
 
-task sharedShadowJar(type: ShadowJar) {
-  configurations = [project.configurations.sharedShadowInclude]
+task configureSharedShadowJar {
+  // late configuration of shared shadow jar, depending on the contents
+  // of the subprojects' shadow jars
+  doFirst {
+    def allDeps = tasks.sharedShadowJar.configurations.collectMany {
+      it.resolve()
+    } as Set
+    allDeps.each {
+      sharedClassesUsage.clazzpath.addClazzpathUnit(it)
+    }
+
+    Set<Clazz> unused = sharedClassesUsage.clazzpath.clazzes
+    sharedClassesUsage.clazzpathUnits.each { ClazzpathUnit subprojShadowJarUnit ->
+      unused.removeAll(subprojShadowJarUnit.clazzes)
+      unused.removeAll(subprojShadowJarUnit.transitiveDependencies)
+    }
+
+    includeShadowJar(sharedShadowJar, 'shared') {
+      exclude unused.collect {clazz ->
+        "${clazz.toString().replace('.', '/')}.class"
+      }
+    }
+  }
+
+  dependsOn sharedClassesUsage.tasks
+  sharedShadowJar.dependsOn it
 }
-includeShadowJar(sharedShadowJar, 'shared')
+
 
 shadowJar generalShadowJarConfig >> {
   configurations = [project.configurations.shadowInclude]
 
   archiveClassifier = ''
+  includeEmptyDirs = false
 
   manifest {
     attributes(

--- a/dd-java-agent/dd-java-agent.gradle
+++ b/dd-java-agent/dd-java-agent.gradle
@@ -154,9 +154,24 @@ task configureSharedShadowJar {
       unused.removeAll(subprojShadowJarUnit.transitiveDependencies)
     }
 
+    def manualInclusions = [
+      // https://github.com/jnr/jffi/blob/96a2e8ae0c11eb86d9c718ad0d0421e6360f1a8b/src/main/java/com/kenai/jffi/internal/StubLoader.java#L51
+      ~'\\Acom/kenai/jffi/Version\\.class\\z',
+      // https://github.com/jnr/jffi/blob/39cfdaff1b7882823dd21f17a11ca68fbf974a92/src/main/java/com/kenai/jffi/Init.java#L51
+      ~'\\Acom/kenai/jffi/internal/StubLoader\\.class\\z',
+      // https://github.com/jnr/jnr-ffi/blob/a6271ada96075823b6e4417698cdae8d041e8d6b/src/main/java/jnr/ffi/provider/FFIProvider.java#L68
+      ~'\\Ajnr/ffi/provider/jffi/Provider\\.class\\z',
+      // https://github.com/jnr/jnr-ffi/blob/a6271ada96075823b6e4417698cdae8d041e8d6b/src/main/java/jnr/ffi/provider/jffi/NativeRuntime.java#L95
+      ~'\\Ajnr/ffi/provider/jffi/platform/.+/TypeAliases\\.class\\z',
+      // see ConstantResolver / ConstantSet
+      ~'\\Ajnr/constants/',
+    ]
+
     includeShadowJar(sharedShadowJar, 'shared') {
-      exclude unused.collect {clazz ->
+      exclude unused.collect { clazz ->
         "${clazz.toString().replace('.', '/')}.class"
+      }.findAll { entryName ->
+        !manualInclusions.any { entryName =~ it }
       }
     }
   }

--- a/dd-java-agent/instrumentation/instrumentation.gradle
+++ b/dd-java-agent/instrumentation/instrumentation.gradle
@@ -14,6 +14,7 @@ plugins {
   id "com.github.johnrengelman.shadow"
 }
 apply from: "$rootDir/gradle/java.gradle"
+apply plugin: 'minimize'
 
 Project instr_project = project
 subprojects { Project subProj ->


### PR DESCRIPTION
( Built on top of https://github.com/DataDog/dd-trace-java/pull/2664 )

Size difference is 1.35 MB:

```
glopes ~/repos/dd-trace-java (master *+%>) $ gradle --no-daemon clean dd-java-agent:shadowJar
...
BUILD SUCCESSFUL in 36s
546 actionable tasks: 545 executed, 1 up-to-date
glopes ~/repos/dd-trace-java (master *+%>) $ ls -l dd-java-agent/build/libs/dd-java-agent-0.79.0-SNAPSHOT.jar 
-rw-rw-r-- 1 glopes glopes 12094832 mai  5 19:18 dd-java-agent/build/libs/dd-java-agent-0.79.0-SNAPSHOT.jar

glopes ~/repos/dd-trace-java (master *+%>) $ git stash
Saved working directory and index state WIP on master: 65ef5eb7a Fix :dd-java-agent:shadowJar build with config on demand
glopes ~/repos/dd-trace-java (master %>) $ gradle --no-daemon clean dd-java-agent:shadowJar
...
BUILD SUCCESSFUL in 35s
542 actionable tasks: 541 executed, 1 up-to-date
glopes ~/repos/dd-trace-java (master %>) $ ls -l dd-java-agent/build/libs/dd-java-agent-0.79.0-SNAPSHOT.jar 
-rw-rw-r-- 1 glopes glopes 13510830 mai  5 19:20 dd-java-agent/build/libs/dd-java-agent-0.79.0-SNAPSHOT.jar
```

Diff of classes [in this gist](https://gist.github.com/cataphract/a41ed1c05e126f3b360b703562edd72b).

The owasp.encoder library was completely eliminated. IIRC, only dependent was `org.openjdk.jmc.common.util.XmlToolkit`, which is unused.