### PR TITLE
add test + fix for old postgres driver

### DIFF
--- a/dd-java-agent/instrumentation/jdbc/jdbc.gradle
+++ b/dd-java-agent/instrumentation/jdbc/jdbc.gradle
@@ -17,6 +17,10 @@ testSets {
   latestDepTest {
     dirName = 'test'
   }
+
+  oldPostgresTest {
+    dirName = 'test'
+  }
 }
 
 dependencies {
@@ -35,6 +39,8 @@ dependencies {
   oldH2TestCompile(group: 'com.h2database', name: 'h2', version: '1.3.168') {
     force = true
   }
+
+  oldPostgresTestCompile group: 'org.postgresql', name: 'postgresql', version: '9.4-1201-jdbc41'
 
   testCompile group: 'mysql', name: 'mysql-connector-java', version: '8.0.23'
   testCompile group: 'org.postgresql', name: 'postgresql', version: '42.2.18'

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/AbstractConnectionInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/AbstractConnectionInstrumentation.java
@@ -14,6 +14,7 @@ import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.jdbc.DBQueryInfo;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
+import java.sql.Statement;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
 
@@ -24,7 +25,7 @@ public abstract class AbstractConnectionInstrumentation extends Instrumenter.Tra
 
   @Override
   public Map<String, String> contextStore() {
-    return singletonMap("java.sql.PreparedStatement", DBQueryInfo.class.getName());
+    return singletonMap("java.sql.Statement", DBQueryInfo.class.getName());
   }
 
   @Override
@@ -50,8 +51,8 @@ public abstract class AbstractConnectionInstrumentation extends Instrumenter.Tra
         @Advice.This Connection connection,
         @Advice.Argument(0) final String sql,
         @Advice.Return final PreparedStatement statement) {
-      ContextStore<PreparedStatement, DBQueryInfo> contextStore =
-          InstrumentationContext.get(PreparedStatement.class, DBQueryInfo.class);
+      ContextStore<Statement, DBQueryInfo> contextStore =
+          InstrumentationContext.get(Statement.class, DBQueryInfo.class);
       if (null == contextStore.get(statement)) {
         DBQueryInfo info = DBQueryInfo.ofPreparedStatement(sql);
         contextStore.put(statement, info);

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/AbstractPreparedStatementInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/AbstractPreparedStatementInstrumentation.java
@@ -11,14 +11,13 @@ import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import datadog.trace.agent.tooling.Instrumenter;
-import datadog.trace.bootstrap.ContextStore;
+import datadog.trace.bootstrap.CallDepthThreadLocalMap;
 import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.jdbc.DBInfo;
 import datadog.trace.bootstrap.instrumentation.jdbc.DBQueryInfo;
 import java.sql.Connection;
-import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.HashMap;
@@ -42,8 +41,7 @@ public abstract class AbstractPreparedStatementInstrumentation extends Instrumen
   @Override
   public Map<String, String> contextStore() {
     Map<String, String> contextStore = new HashMap<>(4);
-    contextStore.put("java.sql.PreparedStatement", DBQueryInfo.class.getName());
-    contextStore.put("java.sql.Statement", Boolean.class.getName());
+    contextStore.put("java.sql.Statement", DBQueryInfo.class.getName());
     contextStore.put("java.sql.Connection", DBInfo.class.getName());
     return contextStore;
   }
@@ -58,17 +56,15 @@ public abstract class AbstractPreparedStatementInstrumentation extends Instrumen
   public static class PreparedStatementAdvice {
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static AgentScope onEnter(@Advice.This final PreparedStatement statement) {
-      ContextStore<Statement, Boolean> interceptionTracker =
-          InstrumentationContext.get(Statement.class, Boolean.class);
-      if (Boolean.TRUE.equals(interceptionTracker.get(statement))) {
+    public static AgentScope onEnter(@Advice.This final Statement statement) {
+      int depth = CallDepthThreadLocalMap.incrementCallDepth(Statement.class);
+      if (depth > 0) {
         return null;
       }
-      interceptionTracker.put(statement, Boolean.TRUE);
       try {
         Connection connection = statement.getConnection();
         DBQueryInfo queryInfo =
-            InstrumentationContext.get(PreparedStatement.class, DBQueryInfo.class).get(statement);
+            InstrumentationContext.get(Statement.class, DBQueryInfo.class).get(statement);
         if (null == queryInfo) {
           logMissingQueryInfo(statement);
           return null;
@@ -89,9 +85,7 @@ public abstract class AbstractPreparedStatementInstrumentation extends Instrumen
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
     public static void stopSpan(
-        @Advice.This PreparedStatement statement,
-        @Advice.Enter final AgentScope scope,
-        @Advice.Thrown final Throwable throwable) {
+        @Advice.Enter final AgentScope scope, @Advice.Thrown final Throwable throwable) {
       if (scope == null) {
         return;
       }
@@ -99,7 +93,7 @@ public abstract class AbstractPreparedStatementInstrumentation extends Instrumen
       DECORATE.beforeFinish(scope.span());
       scope.close();
       scope.span().finish();
-      InstrumentationContext.get(Statement.class, Boolean.class).put(statement, null);
+      CallDepthThreadLocalMap.reset(Statement.class);
     }
   }
 }


### PR DESCRIPTION
In postgres jdbc 9.4-1201-jdbc41, `org.postgresql.jdbc4.Jdbc4Connection` implements `PreparedStatement` in an indirect way - it inherits the methods of the same name as `PreparedStatement` from `org.postgresql.jdbc2.AbstractJdbc2Statement` which does not implement `PreparedStatement`. So we correctly match `org.postgresql.jdbc4.Jdbc4Connection`  but it has no methods we can transform, and we cannot apply the advice to `org.postgresql.jdbc2.AbstractJdbc2Statement` because it doesn't implement `PreparedStatement`.

This relaxes the supertype requirement to `Statement`, and adds a test for an old postgres library. In the future I will refactor the tests to add a test directory per database, and test set per version worth testing to reduce the cost of testing multiple driver versions.