### PR TITLE
Remove jmc core library to save 500kB

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-uploader/profiling-uploader.gradle
+++ b/dd-java-agent/agent-profiling/profiling-uploader/profiling-uploader.gradle
@@ -1,6 +1,5 @@
 // Set properties before any plugins get loaded
 ext {
-  jmcVersion = '8.0.0-SNAPSHOT'
 }
 
 apply from: "$rootDir/gradle/java.gradle"
@@ -25,8 +24,6 @@ dependencies {
   compile project(':internal-api')
 
   compile project(':dd-java-agent:agent-profiling:profiling-controller')
-
-  compile "org.openjdk.jmc:common:$jmcVersion"
 
   compile deps.okhttp
   compile group: 'com.github.jnr', name: 'jnr-posix', version: '3.0.52'


### PR DESCRIPTION
We are adding ~500kB of JMC core libraries worth just for one call.
It feels much better to copy-paste those 6 lines and get rid off 500kB library.