### PR TITLE
Log full stacktrace on transformation errors...

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
@@ -227,8 +227,7 @@ public class AgentInstaller {
         final Throwable throwable,
         final List<Class<?>> types) {
       if (DEBUG) {
-        log.debug(
-            "Exception while retransforming " + batch.size() + " classes: " + batch, throwable);
+        log.debug("Exception while retransforming {} classes: {}", batch.size(), batch, throwable);
       }
       return Collections.emptyList();
     }
@@ -253,10 +252,10 @@ public class AgentInstaller {
         final Throwable throwable) {
       if (DEBUG) {
         log.debug(
-            "Failed to handle {} for transformation on classloader {}: {}",
+            "Failed to handle {} for transformation on classloader {}",
             typeName,
             classLoader,
-            throwable.getMessage());
+            throwable);
       }
     }
 


### PR DESCRIPTION
...to help with problem-determination in debug mode

Original change to log just the message happened in https://github.com/DataDog/dd-trace-java/commit/4a1db505db3f8970f37289514927d1016d586b10#diff-43f94d6ebfae87ea462a0197877d2a19a8c8ef574428fca1ef7561225637a942R91 but it's not clear why this was done.

A number of times during triage it would have really helped to have the full exception details including the stack trace.