### PR TITLE
CPU time improvements

### DIFF
--- a/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/CheckpointEvent.java
+++ b/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/CheckpointEvent.java
@@ -1,8 +1,6 @@
 package datadog.trace.core.jfr.openjdk;
 
 import static datadog.trace.api.Checkpointer.CPU;
-import static datadog.trace.api.Checkpointer.SPAN;
-import static datadog.trace.api.Checkpointer.THREAD_MIGRATION;
 
 import datadog.trace.core.util.SystemAccess;
 import jdk.jfr.Category;
@@ -18,8 +16,6 @@ import jdk.jfr.StackTrace;
 @Category("Datadog")
 @StackTrace(false)
 public class CheckpointEvent extends Event {
-
-  private static final int RECORD_CPU_TIME = CPU | SPAN | THREAD_MIGRATION;
 
   @Label("Trace Id")
   private final long traceId;
@@ -37,7 +33,7 @@ public class CheckpointEvent extends Event {
     this.traceId = traceId;
     this.spanId = spanId;
     this.flags = flags;
-    if ((flags & RECORD_CPU_TIME) != 0 && isEnabled()) {
+    if ((flags & CPU) != 0 && isEnabled()) {
       this.cpuTime = SystemAccess.getCurrentThreadCpuTime();
     } else {
       this.cpuTime = 0L;

--- a/dd-trace-core/src/main/java/datadog/trace/core/util/JmxSystemAccessProvider.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/util/JmxSystemAccessProvider.java
@@ -5,8 +5,9 @@ import java.lang.management.ThreadMXBean;
 
 /** System provider based on JMX MXBeans */
 final class JmxSystemAccessProvider implements SystemAccessProvider {
-  private final ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
-  private final boolean cpuTimeSupported = threadMXBean.isCurrentThreadCpuTimeSupported();
+  private static final ThreadMXBean THREAD_MX_BEAN = ManagementFactory.getThreadMXBean();
+  private static final boolean CPU_TIME_SUPPORTED =
+      THREAD_MX_BEAN.isCurrentThreadCpuTimeSupported();
 
   public static final JmxSystemAccessProvider INSTANCE = new JmxSystemAccessProvider();
 
@@ -16,6 +17,6 @@ final class JmxSystemAccessProvider implements SystemAccessProvider {
    */
   @Override
   public long getThreadCpuTime() {
-    return cpuTimeSupported ? threadMXBean.getCurrentThreadCpuTime() : Long.MIN_VALUE;
+    return CPU_TIME_SUPPORTED ? THREAD_MX_BEAN.getCurrentThreadCpuTime() : 0;
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/util/SystemAccess.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/util/SystemAccess.java
@@ -1,7 +1,6 @@
 package datadog.trace.core.util;
 
 import datadog.trace.api.Config;
-import de.thetaphi.forbiddenapis.SuppressForbidden;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -19,7 +18,6 @@ public final class SystemAccess {
   }
 
   /** Enable JMX accesses */
-  @SuppressForbidden
   public static void enableJmx() {
     if (!Config.get().isProfilingEnabled() && !Config.get().isHealthMetricsEnabled()) {
       log.debug("Will not enable JMX access. Profiling and metrics are both disabled.");
@@ -38,7 +36,10 @@ public final class SystemAccess {
        */
       systemAccessProvider =
           (SystemAccessProvider)
-              Class.forName("datadog.trace.core.util.JmxSystemAccessProvider")
+              Class.forName(
+                      "datadog.trace.core.util.JmxSystemAccessProvider",
+                      false,
+                      SystemAccess.class.getClassLoader())
                   .getField("INSTANCE")
                   .get(null);
     } catch (final ClassNotFoundException | NoSuchFieldException | IllegalAccessException e) {

--- a/internal-api/src/main/java/datadog/trace/api/Checkpointer.java
+++ b/internal-api/src/main/java/datadog/trace/api/Checkpointer.java
@@ -7,20 +7,20 @@ public interface Checkpointer {
    * compression.
    */
   int END = 0x1;
-  /** Marks the start of a span */
-  int SPAN = 0x2;
   /**
    * Indicates that the instrumentation expects synchronous CPU bound work to take place. The CPU
    * work is considered to end when the next event for the same span without this flag set is
    * received.
    */
-  int CPU = 0x4;
+  int CPU = 0x2;
+  /** Marks the start of a span */
+  int SPAN = 0x4 | CPU;
   /**
    * Indicates that the instrumentation expects the span to make a thread migration and resume on
    * another thread. This does not mean that the work on the current thread will cease, unless it is
    * the last event for the span on the thread.
    */
-  int THREAD_MIGRATION = 0x8;
+  int THREAD_MIGRATION = 0x8 | CPU;
 
   /**
    * Notifies the profiler that the span has reached a certain state


### PR DESCRIPTION
* Stricter meaning of `CPU` in checkpoint events - it now means "record CPU time" in memory and means "CPU time was recorded" to the backend
* Don't initialise the `JmxSystemAccessProvider` class when loading it
* Make `JmxSystemAccessProvider`'s state static as it's a singleton and this leads to the elimination of the enabled check
* Return zero when CPU time can't be recorded since it can be varint encoded in 1 byte instead of 10.