### PR TITLE
Force the old version of postgres and run the tests

### DIFF
--- a/dd-java-agent/instrumentation/jdbc/jdbc.gradle
+++ b/dd-java-agent/instrumentation/jdbc/jdbc.gradle
@@ -40,7 +40,9 @@ dependencies {
     force = true
   }
 
-  oldPostgresTestCompile group: 'org.postgresql', name: 'postgresql', version: '9.4-1201-jdbc41'
+  oldPostgresTestCompile(group: 'org.postgresql', name: 'postgresql', version: '9.4-1201-jdbc41') {
+    force =true
+  }
 
   testCompile group: 'mysql', name: 'mysql-connector-java', version: '8.0.23'
   testCompile group: 'org.postgresql', name: 'postgresql', version: '42.2.18'
@@ -59,3 +61,4 @@ dependencies {
 }
 
 test.dependsOn oldH2Test
+test.dependsOn oldPostgresTest


### PR DESCRIPTION
As noted by @tylerbenson in #2694 `gradle` needs to force override the version of the old postgres driver.