### PR TITLE
emit a CPU end event when async tasks are finished

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/AdviceUtils.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/AdviceUtils.java
@@ -1,6 +1,7 @@
 package datadog.trace.bootstrap.instrumentation.java.concurrent;
 
 import datadog.trace.bootstrap.ContextStore;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.context.TraceScope;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,6 +34,9 @@ public class AdviceUtils {
   }
 
   public static void endTaskScope(final TraceScope scope) {
+    if (scope instanceof AgentScope) {
+      ((AgentScope) scope).span().finishWork();
+    }
     if (scope != null) {
       scope.close();
     }

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -323,6 +323,11 @@ public class DDSpan implements AgentSpan, CoreSpan<DDSpan> {
     context.getTracer().onFinishThreadMigration(this);
   }
 
+  @Override
+  public void finishWork() {
+    context.getTracer().onFinishWork(this);
+  }
+
   /**
    * Set the sampling priority of the root span of this span's trace
    *

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanTest.groovy
@@ -13,6 +13,7 @@ import datadog.trace.core.test.DDCoreSpecification
 
 import java.util.concurrent.TimeUnit
 
+import static datadog.trace.api.Checkpointer.CPU
 import static datadog.trace.api.Checkpointer.END
 import static datadog.trace.api.Checkpointer.SPAN
 import static datadog.trace.api.Checkpointer.THREAD_MIGRATION
@@ -309,6 +310,11 @@ class DDSpanTest extends DDCoreSpecification {
     span.finishThreadMigration()
     then:
     1 * checkpointer.checkpoint(context.getTraceId(), context.getSpanId(), THREAD_MIGRATION | END)
+
+    when:
+    span.finishWork()
+    then:
+    1 * checkpointer.checkpoint(context.getTraceId(), context.getSpanId(), CPU | END)
 
     when:
     span.finish()

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
@@ -84,6 +84,9 @@ public interface AgentSpan extends MutableSpan {
   /** mark that the work associated with the span has resumed on a new thread */
   void finishThreadMigration();
 
+  /** Mark the end of a task associated with the span */
+  void finishWork();
+
   interface Context {
     DDId getTraceId();
 

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -403,6 +403,9 @@ public class AgentTracer {
     public void finishThreadMigration() {}
 
     @Override
+    public void finishWork() {}
+
+    @Override
     public Integer getSamplingPriority() {
       return (int) PrioritySampling.UNSET;
     }


### PR DESCRIPTION
This just makes sure that leaf async tasks (do not migrate to other threads) get a terminal JFR event so the CPU time can be calculated.