### PR TITLE
Optimize circleci resource_class and run instrumentation tests as a separate task

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,6 @@ version: 2.1
 
 defaults: &defaults
   working_directory: ~/dd-trace-java
-  resource_class: xlarge
   docker:
     - image: &default_container datadog/dd-trace-java-docker-build:latest
 
@@ -66,6 +65,7 @@ commands:
 jobs:
   build:
     <<: *defaults
+    resource_class: xlarge
 
     steps:
       - setup_code
@@ -76,10 +76,10 @@ jobs:
       - run:
           name: Build Project
           command: >-
-            GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx2G -Xms64M -XX:ErrorFile=/tmp/hs_err_pid%p.log' -Ddatadog.forkedMaxHeapSize=2G -Ddatadog.forkedMinHeapSize=64M"
-            ./gradlew clean :dd-java-agent:shadowJar compileTestGroovy compileLatestDepTestGroovy compileTestScala compileLatestDepTestScala compileTestJava compileLatestDepTestJava
+            GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx1900M -Xms64M -XX:ErrorFile=/tmp/hs_err_pid%p.log'"
+            ./gradlew clean compile shadowJar
             << pipeline.parameters.gradle_flags >>
-            --max-workers=7
+            --max-workers=8
 
       - run:
           name: Collect Libs
@@ -119,6 +119,53 @@ jobs:
 
   default_test_job: &default_test_job
     <<: *defaults
+    resource_class: xlarge
+
+    docker:
+      - image: *default_container
+        # This is used by mongodb smoke tests
+      - image: mongo
+
+    parameters:
+      testTask:
+        type: string
+      prefixTestTask:
+        default: false
+        type: boolean
+
+    steps:
+      - setup_code
+
+      - restore_cache:
+          <<: *cache_keys
+
+      - run:
+          name: Run Tests
+          command: >-
+            GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx1940M -Xms512M -XX:ErrorFile=/tmp/hs_err_pid%p.log' -Ddatadog.forkedMaxHeapSize=400M -Ddatadog.forkedMinHeapSize=128M"
+            ./gradlew <<# parameters.prefixTestTask>>testJava<</ parameters.prefixTestTask>><< parameters.testTask >> -PskipInstTests
+            << pipeline.parameters.gradle_flags >>
+            --max-workers=8
+
+      - run:
+          name: Collect Reports
+          when: on_fail
+          command: .circleci/collect_reports.sh
+
+      - store_artifacts:
+          path: ./reports
+
+      - run:
+          name: Collect Test Results
+          when: always
+          command: .circleci/collect_results.sh
+
+      - store_test_results:
+          path: ./results
+
+  default_inst_test_job: &default_inst_test_job
+    <<: *default_test_job
+    resource_class: xlarge
 
     docker:
       - image: *default_container
@@ -128,7 +175,7 @@ jobs:
       - image: rabbitmq
         # This is used by aerospike instrumentation tests
       - image: aerospike:5.5.0.9
-        # This is used by mongodb smoke tests
+        # This is used by mongodb instrumentation tests
       - image: mongo
         # This is used by jdbc and vert.x tests
       - image: mysql
@@ -160,10 +207,10 @@ jobs:
       - run:
           name: Run Tests
           command: >-
-            GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx1940M -Xms64M -XX:ErrorFile=/tmp/hs_err_pid%p.log' -Ddatadog.forkedMaxHeapSize=512M -Ddatadog.forkedMinHeapSize=64M"
-            ./gradlew <<# parameters.prefixTestTask>>testJava<</ parameters.prefixTestTask>><< parameters.testTask >>
+            GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx1940M -Xms512M -XX:ErrorFile=/tmp/hs_err_pid%p.log' -Ddatadog.forkedMaxHeapSize=400M -Ddatadog.forkedMinHeapSize=128M"
+            ./gradlew :dd-java-agent:instrumentation:<<# parameters.prefixTestTask>>testJava<</ parameters.prefixTestTask>><< parameters.testTask >>
             << pipeline.parameters.gradle_flags >>
-            --max-workers=6
+            --max-workers=8
 
       - run:
           name: Collect Reports
@@ -183,6 +230,7 @@ jobs:
 
   agent_integration_tests:
     <<: *default_test_job
+    resource_class: medium
     docker:
       - image: *default_container
       - image: datadog/agent:7.25.0
@@ -194,6 +242,7 @@ jobs:
 
   check:
     <<: *defaults
+    resource_class: medium+
 
     steps:
       - setup_code
@@ -204,20 +253,20 @@ jobs:
       - run:
           name: Build Project
           command: >-
-            GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx2G -Xms64M -XX:ErrorFile=/tmp/hs_err_pid%p.log' -Ddatadog.forkedMaxHeapSize=2G -Ddatadog.forkedMinHeapSize=64M"
+            GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx1800M -Xms64M -XX:ErrorFile=/tmp/hs_err_pid%p.log'"
             ./gradlew build -PskipTests
             << pipeline.parameters.gradle_flags >>
-            --max-workers=7
+            --max-workers=3
 
       - run:
           name: Test Published Dependencies
           command: |
             mvn_local_repo=$(mvn help:evaluate -Dexpression=settings.localRepository -q -DforceStdout)
             rm -rf "${mvn_local_repo}/com/datadoghq"
-            export GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx2G -Xms64M -XX:ErrorFile=/tmp/hs_err_pid%p.log' -Ddatadog.forkedMaxHeapSize=2G -Ddatadog.forkedMinHeapSize=64M"
-            ./gradlew publishToMavenLocal << pipeline.parameters.gradle_flags >> --max-workers=7
+            export GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx1900M -Xms64M -XX:ErrorFile=/tmp/hs_err_pid%p.log'"
+            ./gradlew publishToMavenLocal << pipeline.parameters.gradle_flags >> --max-workers=3
             cd test-published-dependencies
-            ../gradlew check
+            ../gradlew check --max-workers=3
 
       - run:
           name: Collect Reports
@@ -229,7 +278,8 @@ jobs:
 
   muzzle:
     <<: *defaults
-    parallelism: 8
+    resource_class: medium
+    parallelism: 4
     steps:
       - setup_code
 
@@ -247,16 +297,16 @@ jobs:
             SKIP_BUILDSCAN="true"
             ./gradlew writeMuzzleTasksToFile
             << pipeline.parameters.gradle_flags >>
-            --max-workers=8
+            --max-workers=3
 
       - run:
           name: Verify Muzzle
           command: >-
             SKIP_BUILDSCAN="true"
-            GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx4G -Xms64M -XX:ErrorFile=/tmp/hs_err_pid%p.log' -Ddatadog.forkedMaxHeapSize=4G -Ddatadog.forkedMinHeapSize=64M"
+            GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx4G -Xms64M -XX:ErrorFile=/tmp/hs_err_pid%p.log'"
             ./gradlew `circleci tests split --split-by=timings workspace/build/muzzleTasks | xargs`
             << pipeline.parameters.gradle_flags >>
-            --max-workers=16
+            --max-workers=6
 
       - run:
           name: Collect Reports
@@ -289,10 +339,25 @@ workflows:
           name: test_8
           testTask: test jacocoTestReport jacocoTestCoverageVerification
 
-      - default_test_job:
+      - default_inst_test_job:
           requires:
             - build
-          name: test_latest8
+          prefixTestTask: true
+          name: test_<< matrix.testTask >>_inst
+          matrix:
+            parameters:
+              testTask: [ "7", "IBM8", "ZULU8","ORACLE8", "11", "ZULU11", "ZULU13", "15" ]
+
+      - default_inst_test_job:
+          requires:
+            - build
+          name: test_8_inst
+          testTask: test
+
+      - default_inst_test_job:
+          requires:
+            - build
+          name: test_8_inst_latest
           testTask: latestDepTest
 
       - agent_integration_tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,10 +108,10 @@ jobs:
       - run:
           name: Build Project
           command: >-
-            GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx2G -Xms64M -XX:ErrorFile=/tmp/hs_err_pid%p.log' -Ddatadog.forkedMaxHeapSize=2G -Ddatadog.forkedMinHeapSize=64M"
-            ./gradlew clean :dd-java-agent:shadowJar compileTestGroovy compileLatestDepTestGroovy compileTestScala compileLatestDepTestScala compileTestJava compileLatestDepTestJava
+            GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx1900M -Xms64M -XX:ErrorFile=/tmp/hs_err_pid%p.log'"
+            ./gradlew clean compile shadowJar
             << pipeline.parameters.gradle_flags >>
-            --max-workers=7
+            --max-workers=8
 
       - save_cache:
           key: dd-trace-java-v3-{{ .Branch }}-{{ epoch }}
@@ -123,8 +123,6 @@ jobs:
 
     docker:
       - image: *default_container
-        # This is used by mongodb smoke tests
-      - image: mongo
 
     parameters:
       testTask:
@@ -143,7 +141,7 @@ jobs:
           name: Run Tests
           command: >-
             GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx1940M -Xms512M -XX:ErrorFile=/tmp/hs_err_pid%p.log' -Ddatadog.forkedMaxHeapSize=400M -Ddatadog.forkedMinHeapSize=128M"
-            ./gradlew <<# parameters.prefixTestTask>>testJava<</ parameters.prefixTestTask>><< parameters.testTask >> -PskipInstTests
+            ./gradlew <<# parameters.prefixTestTask>>testJava<</ parameters.prefixTestTask>><< parameters.testTask >> -PskipInstTests -PskipSmokeTests
             << pipeline.parameters.gradle_flags >>
             --max-workers=8
 
@@ -211,6 +209,52 @@ jobs:
             ./gradlew :dd-java-agent:instrumentation:<<# parameters.prefixTestTask>>testJava<</ parameters.prefixTestTask>><< parameters.testTask >>
             << pipeline.parameters.gradle_flags >>
             --max-workers=8
+
+      - run:
+          name: Collect Reports
+          when: on_fail
+          command: .circleci/collect_reports.sh
+
+      - store_artifacts:
+          path: ./reports
+
+      - run:
+          name: Collect Test Results
+          when: always
+          command: .circleci/collect_results.sh
+
+      - store_test_results:
+          path: ./results
+
+  default_smoke_test_job: &default_inst_test_job
+    <<: *default_test_job
+    resource_class: medium
+
+    docker:
+      - image: *default_container
+        # This is used by mongodb smoke tests
+      - image: mongo
+
+    parameters:
+      testTask:
+        type: string
+      prefixTestTask:
+        default: false
+        type: boolean
+
+    steps:
+      - setup_code
+
+      - restore_cache:
+          <<: *cache_keys
+
+      - run:
+          name: Run Tests
+          command: >-
+            GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx1940M -Xms512M -XX:ErrorFile=/tmp/hs_err_pid%p.log' -Ddatadog.forkedMaxHeapSize=400M -Ddatadog.forkedMinHeapSize=128M"
+            ./gradlew stagePlayBinaryDist :dd-smoke-test:<<# parameters.prefixTestTask>>testJava<</ parameters.prefixTestTask>><< parameters.testTask >>
+            << pipeline.parameters.gradle_flags >>
+            --max-workers=2
 
       - run:
           name: Collect Reports
@@ -359,6 +403,21 @@ workflows:
             - build
           name: test_8_inst_latest
           testTask: latestDepTest
+
+      - default_smoke_test_job:
+          requires:
+            - build
+          prefixTestTask: true
+          name: test_<< matrix.testTask >>_smoke
+          matrix:
+            parameters:
+              testTask: [ "7", "IBM8", "ZULU8","ORACLE8", "11", "ZULU11", "ZULU13", "15" ]
+
+      - default_smoke_test_job:
+          requires:
+            - build
+          name: test_8_smoke
+          testTask: test
 
       - agent_integration_tests:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,7 +140,7 @@ jobs:
       - run:
           name: Run Tests
           command: >-
-            GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx1940M -Xms512M -XX:ErrorFile=/tmp/hs_err_pid%p.log' -Ddatadog.forkedMaxHeapSize=400M -Ddatadog.forkedMinHeapSize=128M"
+            GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx1940M -Xms512M -XX:ErrorFile=/tmp/hs_err_pid%p.log' -Ddatadog.forkedMaxHeapSize=512M -Ddatadog.forkedMinHeapSize=128M"
             ./gradlew <<# parameters.prefixTestTask>>testJava<</ parameters.prefixTestTask>><< parameters.testTask >> -PskipInstTests -PskipSmokeTests
             << pipeline.parameters.gradle_flags >>
             --max-workers=8
@@ -205,7 +205,7 @@ jobs:
       - run:
           name: Run Tests
           command: >-
-            GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx1940M -Xms512M -XX:ErrorFile=/tmp/hs_err_pid%p.log' -Ddatadog.forkedMaxHeapSize=400M -Ddatadog.forkedMinHeapSize=128M"
+            GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx1940M -Xms512M -XX:ErrorFile=/tmp/hs_err_pid%p.log' -Ddatadog.forkedMaxHeapSize=512M -Ddatadog.forkedMinHeapSize=128M"
             ./gradlew :dd-java-agent:instrumentation:<<# parameters.prefixTestTask>>testJava<</ parameters.prefixTestTask>><< parameters.testTask >>
             << pipeline.parameters.gradle_flags >>
             --max-workers=8
@@ -251,7 +251,7 @@ jobs:
       - run:
           name: Run Tests
           command: >-
-            GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx1940M -Xms512M -XX:ErrorFile=/tmp/hs_err_pid%p.log' -Ddatadog.forkedMaxHeapSize=400M -Ddatadog.forkedMinHeapSize=128M"
+            GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx1940M -Xms512M -XX:ErrorFile=/tmp/hs_err_pid%p.log' -Ddatadog.forkedMaxHeapSize=512M -Ddatadog.forkedMinHeapSize=128M"
             ./gradlew stagePlayBinaryDist :dd-smoke-test:<<# parameters.prefixTestTask>>testJava<</ parameters.prefixTestTask>><< parameters.testTask >>
             << pipeline.parameters.gradle_flags >>
             --max-workers=2
@@ -323,7 +323,7 @@ jobs:
   muzzle:
     <<: *defaults
     resource_class: medium
-    parallelism: 4
+    parallelism: 3
     steps:
       - setup_code
 
@@ -347,10 +347,10 @@ jobs:
           name: Verify Muzzle
           command: >-
             SKIP_BUILDSCAN="true"
-            GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx4G -Xms64M -XX:ErrorFile=/tmp/hs_err_pid%p.log'"
+            GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx950M -Xms64M -XX:ErrorFile=/tmp/hs_err_pid%p.log'"
             ./gradlew `circleci tests split --split-by=timings workspace/build/muzzleTasks | xargs`
             << pipeline.parameters.gradle_flags >>
-            --max-workers=6
+            --max-workers=4
 
       - run:
           name: Collect Reports

--- a/dd-java-agent/instrumentation/instrumentation.gradle
+++ b/dd-java-agent/instrumentation/instrumentation.gradle
@@ -15,6 +15,8 @@ plugins {
 }
 apply from: "$rootDir/gradle/java.gradle"
 
+tasks.register("latestDepTest")
+
 Project instr_project = project
 subprojects { Project subProj ->
   apply plugin: "net.bytebuddy.byte-buddy"
@@ -74,9 +76,15 @@ subprojects { Project subProj ->
       testCompileOnly deps.autoserviceAnnotation
     }
 
-    // Make it so all instrumentation subproject tests can be run with a single command.
-    instr_project.tasks.named("test").configure {
-      dependsOn(subProj.tasks.named("test"))
+    subProj.tasks.withType(Test).configureEach { subTask ->
+      onlyIf { !project.rootProject.hasProperty("skipInstTests") }
+
+      // Make it so all instrumentation subproject tests can be run with a single command.
+      if (instr_project.hasProperty(subTask.name)) {
+        instr_project.tasks.named(subTask.name).configure {
+          dependsOn(subTask)
+        }
+      }
     }
   }
 

--- a/dd-java-agent/instrumentation/instrumentation.gradle
+++ b/dd-java-agent/instrumentation/instrumentation.gradle
@@ -17,7 +17,7 @@ apply from: "$rootDir/gradle/java.gradle"
 
 tasks.register("latestDepTest")
 
-Project instr_project = project
+Project parent_project = project
 subprojects { Project subProj ->
   apply plugin: "net.bytebuddy.byte-buddy"
   apply plugin: 'muzzle'
@@ -80,15 +80,15 @@ subprojects { Project subProj ->
       onlyIf { !project.rootProject.hasProperty("skipInstTests") }
 
       // Make it so all instrumentation subproject tests can be run with a single command.
-      if (instr_project.hasProperty(subTask.name)) {
-        instr_project.tasks.named(subTask.name).configure {
+      if (parent_project.hasProperty(subTask.name)) {
+        parent_project.tasks.named(subTask.name).configure {
           dependsOn(subTask)
         }
       }
     }
   }
 
-  instr_project.dependencies {
+  parent_project.dependencies {
     compile(project(subProj.getPath()))
   }
 }

--- a/dd-java-agent/instrumentation/mule-4/mule-4.gradle
+++ b/dd-java-agent/instrumentation/mule-4/mule-4.gradle
@@ -63,7 +63,7 @@ sourceSets {
   }
 }
 
-compileTestGroovy {
+tasks.named("compileTestGroovy").configure {
   dependsOn 'mvnPackage', 'extractMuleServices'
 }
 

--- a/dd-smoke-tests/dd-smoke-tests.gradle
+++ b/dd-smoke-tests/dd-smoke-tests.gradle
@@ -11,12 +11,15 @@ def smokeTestLimit = gradle.sharedServices.registerIfAbsent("smokeTestLimit", Bu
   maxParallelUsages = 1
 }
 
+Project parent_project = project
 subprojects { Project subProj ->
   // Don't need javadoc task run for internal projects.
   subProj.tasks.withType(Javadoc).configureEach { enabled = false }
 
-  subProj.tasks.withType(Test).configureEach {
+  subProj.tasks.withType(Test).configureEach { subTask ->
     dependsOn project(':dd-java-agent').tasks.named("shadowJar")
+
+    onlyIf { !project.rootProject.hasProperty("skipSmokeTests") }
 
     // Tests depend on this to know where to run things and what agent jar to use
     jvmArgs "-Ddatadog.smoketest.builddir=${buildDir}"
@@ -27,5 +30,12 @@ subprojects { Project subProj ->
 
     // Only one smoke test at a time
     usesService(smokeTestLimit)
+
+    // Make it so all smoke tests can be run with a single command.
+    if (parent_project.hasProperty(subTask.name)) {
+      parent_project.tasks.named(subTask.name).configure {
+        dependsOn(subTask)
+      }
+    }
   }
 }

--- a/dd-smoke-tests/play-2.4/play-2.4.gradle
+++ b/dd-smoke-tests/play-2.4/play-2.4.gradle
@@ -57,7 +57,7 @@ dependencies {
   testCompile project(':dd-smoke-tests')
 }
 
-compileTestGroovy {
+tasks.named("compileTestGroovy").configure {
   dependsOn 'stagePlayBinaryDist'
   outputs.upToDateWhen {
     !stagePlayBinaryDist.didWork

--- a/dd-smoke-tests/play-2.5/play-2.5.gradle
+++ b/dd-smoke-tests/play-2.5/play-2.5.gradle
@@ -59,7 +59,7 @@ dependencies {
   testCompile project(':dd-smoke-tests')
 }
 
-compileTestGroovy {
+tasks.named("compileTestGroovy").configure {
   dependsOn 'stagePlayBinaryDist'
   outputs.upToDateWhen {
     !stagePlayBinaryDist.didWork

--- a/dd-smoke-tests/play-2.6/play-2.6.gradle
+++ b/dd-smoke-tests/play-2.6/play-2.6.gradle
@@ -59,7 +59,7 @@ dependencies {
   testCompile project(':dd-smoke-tests')
 }
 
-compileTestGroovy {
+tasks.named("compileTestGroovy").configure {
   dependsOn 'stagePlayBinaryDist'
   outputs.upToDateWhen {
     !stagePlayBinaryDist.didWork

--- a/dd-smoke-tests/play-2.7/play-2.7.gradle
+++ b/dd-smoke-tests/play-2.7/play-2.7.gradle
@@ -25,7 +25,7 @@ tasks.register('sbtStage', Exec) {
   inputs.dir("$appDir/project")
 }
 
-compileTestGroovy {
+tasks.named("compileTestGroovy").configure {
   dependsOn 'sbtStage'
   outputs.upToDateWhen {
     !sbtStage.didWork

--- a/dd-smoke-tests/play-2.8/play-2.8.gradle
+++ b/dd-smoke-tests/play-2.8/play-2.8.gradle
@@ -25,7 +25,7 @@ tasks.register('sbtStage', Exec) {
   inputs.dir("$appDir/project")
 }
 
-compileTestGroovy {
+tasks.named("compileTestGroovy").configure {
   dependsOn 'sbtStage'
   outputs.upToDateWhen {
     !sbtStage.didWork

--- a/dd-smoke-tests/quarkus/quarkus.gradle
+++ b/dd-smoke-tests/quarkus/quarkus.gradle
@@ -23,7 +23,7 @@ quarkusBuild {
   dependsOn project(':dd-trace-api').tasks.named("jar")
 }
 
-compileTestGroovy {
+tasks.named("compileTestGroovy").configure {
   dependsOn 'quarkusBuild'
   outputs.upToDateWhen {
     !quarkusBuild.didWork

--- a/dd-smoke-tests/springboot-openliberty/springboot-openliberty.gradle
+++ b/dd-smoke-tests/springboot-openliberty/springboot-openliberty.gradle
@@ -18,7 +18,7 @@ tasks.register('mvnStage', Exec) {
   commandLine './mvnw', 'package'
 }
 
-compileTestGroovy {
+tasks.named("compileTestGroovy").configure {
   dependsOn 'mvnStage'
   outputs.upToDateWhen {
     !mvnStage.didWork

--- a/dd-trace-java.gradle
+++ b/dd-trace-java.gradle
@@ -29,6 +29,8 @@ def isCI = System.getenv("CI") != null
 apply from: "$rootDir/gradle/scm.gradle"
 apply from: "$rootDir/gradle/spotless.gradle"
 
+def compileTask = tasks.register("compile")
+
 allprojects {
   group = 'com.datadoghq'
   version = scmVersion.version
@@ -39,6 +41,10 @@ allprojects {
 
   apply from: "$rootDir/gradle/dependencies.gradle"
   apply from: "$rootDir/gradle/util.gradle"
+
+  compileTask.configure {
+    dependsOn tasks.withType(AbstractCompile)
+  }
 }
 
 repositories {


### PR DESCRIPTION
This also runs smoke tests separately on a smaller instance because we force them to run serially, so it doesn't make sense tying up a big resource waiting for that.

For reference: https://circleci.com/docs/2.0/configuration-reference/#resourceclass