### PR TITLE
Make Haystack propagation use DDId with original String

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/DDId.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/DDId.java
@@ -1,5 +1,6 @@
 package datadog.trace.api;
 
+import datadog.trace.api.compat.Function;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
@@ -83,6 +84,22 @@ public class DDId {
     int len = s.length();
     int trimmed = Math.min(s.length(), 16);
     return new DDIdOriginal(parseUnsignedLongHex(s, len - trimmed, trimmed), s);
+  }
+
+  /**
+   * Create a new {@code DDId} from the given {@code String} by converting that into an unsigned 64
+   * bit hex representation of an id, while retaining the original {@code String} representation for
+   * use in headers.
+   *
+   * @param s String in hex of unsigned 64 bit id
+   * @param converter Function that translates the String s into a hex String representing the
+   *     unsigned 64 bit id.
+   * @return DDId
+   * @throws NumberFormatException
+   */
+  public static DDId fromStringWithOriginal(String s, Function<String, String> converter)
+      throws NumberFormatException {
+    return new DDIdOriginal(parseUnsignedLongHex(converter.apply(s)), s);
   }
 
   private final long id;
@@ -284,6 +301,18 @@ public class DDId {
   }
 
   /**
+   * Returns the converted {@code String} representation, of the unsigned 64 bit id, or the original
+   * {@code String} used to create this {@code DDId}. The converted {@code String} will NOT be
+   * cached.
+   *
+   * @param converter Function that translates the DDId into a custom String representation
+   * @return non zero padded hex String
+   */
+  public String toStringOrOriginal(Function<DDId, String> converter) {
+    return converter.apply(this);
+  }
+
+  /**
    * Returns the id as a long representing the bits of the unsigned 64 bit id. This means that
    * values larger than Long.MAX_VALUE will be represented as negative numbers.
    *
@@ -307,6 +336,11 @@ public class DDId {
 
     @Override
     public String toHexStringOrOriginal() {
+      return this.original;
+    }
+
+    @Override
+    public String toStringOrOriginal(Function<DDId, String> converter) {
       return this.original;
     }
   }

--- a/dd-trace-api/src/main/java/datadog/trace/api/compat/Function.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/compat/Function.java
@@ -1,0 +1,5 @@
+package datadog.trace.api.compat;
+
+public interface Function<T, U> {
+  U apply(T input);
+}

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HaystackHttpExtractorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HaystackHttpExtractorTest.groovy
@@ -6,6 +6,7 @@ import datadog.trace.bootstrap.instrumentation.api.ContextVisitors
 import datadog.trace.test.util.DDSpecification
 
 import static datadog.trace.core.CoreTracer.TRACE_ID_MAX
+import static datadog.trace.core.propagation.HaystackHttpCodec.CONVERT_DDID_TO_UUID_STRING
 import static datadog.trace.core.propagation.HaystackHttpCodec.OT_BAGGAGE_PREFIX
 import static datadog.trace.core.propagation.HaystackHttpCodec.SPAN_ID_KEY
 import static datadog.trace.core.propagation.HaystackHttpCodec.TRACE_ID_KEY
@@ -30,6 +31,8 @@ class HaystackHttpExtractorTest extends DDSpecification {
 
     then:
     context.traceId == DDId.from(traceId)
+    context.traceId.toStringOrOriginal(CONVERT_DDID_TO_UUID_STRING) == traceUuid
+    context.spanId.toStringOrOriginal(CONVERT_DDID_TO_UUID_STRING) == spanUuid
     context.spanId == DDId.from(spanId)
     context.baggage == ["k1": "v1", "k2": "v2", "Haystack-Trace-ID": traceUuid, "Haystack-Span-ID": spanUuid]
     context.tags == ["some-tag": "my-interesting-info"]
@@ -38,10 +41,10 @@ class HaystackHttpExtractorTest extends DDSpecification {
 
     where:
     traceId               | spanId                | samplingPriority              | origin | traceUuid                              | spanUuid
-    "1"                   | "2"                   | PrioritySampling.SAMPLER_KEEP | null   | "44617461-646f-6721-0000-000000000001" | "44617461-646f-6721-0000-000000000002"
-    "2"                   | "3"                   | PrioritySampling.SAMPLER_KEEP | null   | "44617461-646f-6721-0000-000000000002" | "44617461-646f-6721-0000-000000000003"
-    "${TRACE_ID_MAX}"     | "${TRACE_ID_MAX - 6}" | PrioritySampling.SAMPLER_KEEP | null   | "44617461-646f-6721-ffff-ffffffffffff" | "44617461-646f-6721-ffff-fffffffffff9"
-    "${TRACE_ID_MAX - 1}" | "${TRACE_ID_MAX - 7}" | PrioritySampling.SAMPLER_KEEP | null   | "44617461-646f-6721-ffff-fffffffffffe" | "44617461-646f-6721-ffff-fffffffffff8"
+    "1"                   | "2"                   | PrioritySampling.SAMPLER_KEEP | null   | "45617461-646f-6721-0000-000000000001" | "48617461-646f-6721-0000-000000000002"
+    "2"                   | "3"                   | PrioritySampling.SAMPLER_KEEP | null   | "46617461-646f-6721-0000-000000000002" | "47617461-646f-6721-0000-000000000003"
+    "${TRACE_ID_MAX}"     | "${TRACE_ID_MAX - 6}" | PrioritySampling.SAMPLER_KEEP | null   | "47617461-646f-6721-ffff-ffffffffffff" | "46617461-646f-6721-ffff-fffffffffff9"
+    "${TRACE_ID_MAX - 1}" | "${TRACE_ID_MAX - 7}" | PrioritySampling.SAMPLER_KEEP | null   | "48617461-646f-6721-ffff-fffffffffffe" | "45617461-646f-6721-ffff-fffffffffff8"
   }
 
   def "extract header tags with no propagation"() {
@@ -165,6 +168,8 @@ class HaystackHttpExtractorTest extends DDSpecification {
     if (expectedTraceId) {
       assert context.traceId == expectedTraceId
       assert context.spanId == expectedSpanId
+      assert context.traceId.toStringOrOriginal(CONVERT_DDID_TO_UUID_STRING) == traceId
+      assert context.spanId.toStringOrOriginal(CONVERT_DDID_TO_UUID_STRING) == spanId
     } else {
       assert context == null
     }
@@ -177,7 +182,7 @@ class HaystackHttpExtractorTest extends DDSpecification {
     "00001"                                | "00001"                                | DDId.ONE                       | DDId.ONE
     "463ac35c9f6413ad"                     | "463ac35c9f6413ad"                     | DDId.from(5060571933882717101) | DDId.from(5060571933882717101)
     "463ac35c9f6413ad48485a3953bb6124"     | "1"                                    | DDId.from(5208512171318403364) | DDId.ONE
-    "44617461-646f-6721-463a-c35c9f6413ad" | "44617461-646f-6721-463a-c35c9f6413ad" | DDId.from(5060571933882717101) | DDId.from(5060571933882717101)
+    "74617461-646f-6721-463a-c35c9f6413ad" | "47617461-646f-6721-463a-c35c9f6413ad" | DDId.from(5060571933882717101) | DDId.from(5060571933882717101)
     "f" * 16                               | "1"                                    | DDId.MAX                       | DDId.ONE
     "a" * 16 + "f" * 16                    | "1"                                    | DDId.MAX                       | DDId.ONE
     "1" + "f" * 32                         | "1"                                    | null                           | DDId.ONE

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HaystackHttpInjectorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HaystackHttpInjectorTest.groovy
@@ -7,6 +7,7 @@ import datadog.trace.core.DDSpanContext
 import datadog.trace.core.test.DDCoreSpecification
 
 import static datadog.trace.core.CoreTracer.TRACE_ID_MAX
+import static datadog.trace.core.propagation.HaystackHttpCodec.CONVERT_UUID_TO_HEX_STRING
 import static datadog.trace.core.propagation.HaystackHttpCodec.DD_PARENT_ID_BAGGAGE_KEY
 import static datadog.trace.core.propagation.HaystackHttpCodec.DD_SPAN_ID_BAGGAGE_KEY
 import static datadog.trace.core.propagation.HaystackHttpCodec.DD_TRACE_ID_BAGGAGE_KEY
@@ -70,11 +71,10 @@ class HaystackHttpInjectorTest extends DDCoreSpecification {
     setup:
     def writer = new ListWriter()
     def tracer = tracerBuilder().writer(writer).build()
-    def haystackUuid = traceUuid
     final DDSpanContext mockedContext =
       new DDSpanContext(
-      DDId.from(traceId),
-      DDId.from(spanId),
+      DDId.fromStringWithOriginal(traceUuid, CONVERT_UUID_TO_HEX_STRING),
+      DDId.fromStringWithOriginal(spanUuid, CONVERT_UUID_TO_HEX_STRING),
       DDId.ZERO,
       null,
       "fakeService",
@@ -82,7 +82,7 @@ class HaystackHttpInjectorTest extends DDCoreSpecification {
       "fakeResource",
       samplingPriority,
       origin,
-      ["k1" : "v1", "k2" : "v2", (HAYSTACK_TRACE_ID_BAGGAGE_KEY) : haystackUuid],
+      ["k1" : "v1", "k2" : "v2"],
       false,
       "fakeType",
       0,
@@ -106,9 +106,9 @@ class HaystackHttpInjectorTest extends DDCoreSpecification {
 
     where:
     traceId               | spanId                | samplingPriority              | origin | traceUuid                              | spanUuid
-    "1"                   | "2"                   | PrioritySampling.SAMPLER_KEEP | null   | "54617461-646f-6721-0000-000000000001" | "44617461-646f-6721-0000-000000000002"
-    "1"                   | "2"                   | PrioritySampling.SAMPLER_KEEP | null   | "54617461-646f-6721-0000-000000000001" | "44617461-646f-6721-0000-000000000002"
-    "$TRACE_ID_MAX"       | "${TRACE_ID_MAX - 1}" | PrioritySampling.SAMPLER_KEEP | null   | "54617461-646f-6721-ffff-ffffffffffff" | "44617461-646f-6721-ffff-fffffffffffe"
-    "${TRACE_ID_MAX - 1}" | "$TRACE_ID_MAX"       | PrioritySampling.SAMPLER_KEEP | null   | "54617461-646f-6721-ffff-fffffffffffe" | "44617461-646f-6721-ffff-ffffffffffff"
+    "1"                   | "2"                   | PrioritySampling.SAMPLER_KEEP | null   | "54617461-646f-6721-0000-000000000001" | "45617461-646f-6721-0000-000000000002"
+    "1"                   | "2"                   | PrioritySampling.SAMPLER_KEEP | null   | "54617461-646f-6721-0000-000000000001" | "45617461-646f-6721-0000-000000000002"
+    "$TRACE_ID_MAX"       | "${TRACE_ID_MAX - 1}" | PrioritySampling.SAMPLER_KEEP | null   | "54617461-646f-6721-ffff-ffffffffffff" | "45617461-646f-6721-ffff-fffffffffffe"
+    "${TRACE_ID_MAX - 1}" | "$TRACE_ID_MAX"       | PrioritySampling.SAMPLER_KEEP | null   | "54617461-646f-6721-ffff-fffffffffffe" | "45617461-646f-6721-ffff-ffffffffffff"
   }
 }


### PR DESCRIPTION
Make Haystack propagation use DDId with original String instead of propagating the original via baggage.

The open question is if the duplicate adding of information to the baggage can be removed.