### PR TITLE
Disable some unnecessary tasks, make lazy, and optimize dependencies

### DIFF
--- a/dd-java-agent/agent-jmxfetch/agent-jmxfetch.gradle
+++ b/dd-java-agent/agent-jmxfetch/agent-jmxfetch.gradle
@@ -49,10 +49,12 @@ tasks.register("copyMetricConfigs", Exec) {
     // Ensure the resources directory is available.
     file(sourceSets.main.output.resourcesDir).mkdirs()
   }
+  dependsOn "submodulesUpdate"
+  // In CI, there seems to be a race condition where processResources overwrites the copied metric config files.
+  // Ensure that task runs last to avoid this problem.
+  mustRunAfter "processResources"
 }
 
-copyMetricConfigs.dependsOn submodulesUpdate
-processResources.finalizedBy copyMetricConfigs
-copyMetricConfigs.mustRunAfter processResources
-// In CI, there seems to be a race condition where processResources overwrites the copied metric config files.
-// Ensure that task runs last to avoid this problem.
+tasks.named("processResources").configure {
+  finalizedBy copyMetricConfigs
+}

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/profiling-controller-openjdk.gradle
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/profiling-controller-openjdk.gradle
@@ -35,7 +35,7 @@ sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
 [JavaCompile, GroovyCompile].each {
-  tasks.withType(it) {
+  tasks.withType(it).configureEach {
     doFirst {
       if (!System.env.JAVA_11_HOME) {
         throw new GradleException('JAVA_11_HOME must be set to build profiling controller')

--- a/dd-java-agent/agent-profiling/profiling-controller-oracle/profiling-controller-oracle.gradle
+++ b/dd-java-agent/agent-profiling/profiling-controller-oracle/profiling-controller-oracle.gradle
@@ -34,12 +34,12 @@ sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
 // Oracle JDK requires extra JVM arguments to enable JFR
-tasks.withType(Test).all {
-  it.onlyIf {
+tasks.withType(Test).configureEach {
+  onlyIf {
     it.name.contains('ORACLE8')
   }
 
-  it.jvmArgs += [
+  jvmArgs += [
     "-XX:+IgnoreUnrecognizedVMOptions",
     "-XX:+UnlockCommercialFeatures",
     "-XX:+FlightRecorder"

--- a/dd-java-agent/benchmark/benchmark.gradle
+++ b/dd-java-agent/benchmark/benchmark.gradle
@@ -38,7 +38,9 @@ jmh {
   jmhVersion = '1.23' // Specifies JMH version
 }
 
-tasks.jmh.dependsOn project(':dd-java-agent').shadowJar
+tasks.named('jmh').configure {
+  dependsOn ':dd-java-agent:shadowJar'
+}
 
 /*
  If using libasyncProfiler, use the following to generate nice svg flamegraphs.

--- a/dd-java-agent/dd-java-agent.gradle
+++ b/dd-java-agent/dd-java-agent.gradle
@@ -42,7 +42,7 @@ ext.generalShadowJarConfig = {
   }
 }
 
-def includeShadowJar(shadowJarTask, jarname) {
+def includeShadowJar(TaskProvider<ShadowJar> shadowJarTask, String jarname) {
   def opentracingFound = new AtomicBoolean()
   project.processResources {
     doFirst {
@@ -59,7 +59,7 @@ def includeShadowJar(shadowJarTask, jarname) {
       }
     }
 
-    from(zipTree(shadowJarTask.archiveFile)) {
+    from(zipTree(shadowJarTask.get().archiveFile)) {
       into jarname
       rename '(^.*)\\.class$', '$1.classdata'
       // Rename LICENSE file since it clashes with license dir on non-case sensitive FSs (i.e. Mac)
@@ -67,21 +67,23 @@ def includeShadowJar(shadowJarTask, jarname) {
     }
   }
 
-  project.processResources.dependsOn shadowJarTask
+  project.tasks.named("processResources").configure {
+    dependsOn shadowJarTask
+  }
   shadowJarTask.configure generalShadowJarConfig
 }
 
 def includeSubprojShadowJar(String projName, String jarname) {
   evaluationDependsOn projName
   def proj = project(projName)
-  includeShadowJar proj.tasks.shadowJar, jarname
+  includeShadowJar proj.tasks.named("shadowJar"), jarname
 }
 
 includeSubprojShadowJar ':dd-java-agent:instrumentation', 'inst'
 includeSubprojShadowJar ':dd-java-agent:agent-jmxfetch', 'metrics'
 includeSubprojShadowJar ':dd-java-agent:agent-profiling', 'profiling'
 
-task sharedShadowJar(type: ShadowJar) {
+def sharedShadowJar = tasks.register('sharedShadowJar', ShadowJar) {
   configurations = [project.configurations.sharedShadowInclude]
 }
 includeShadowJar(sharedShadowJar, 'shared')
@@ -100,6 +102,11 @@ shadowJar generalShadowJarConfig >> {
       "Can-Retransform-Classes": true,
       )
   }
+}
+
+subprojects { Project subProj ->
+  // Don't need javadoc task run for internal projects.
+  subProj.tasks.withType(Javadoc).configureEach { enabled = false }
 }
 
 // We don't want bundled dependencies to show up in the pom.
@@ -151,17 +158,19 @@ tasks.withType(Test).configureEach {
     exclude 'datadog/trace/agent/integration/classloading/ShadowPackageRenamingTest.class'
   }
 
-  dependsOn shadowJar
+  dependsOn "shadowJar"
 }
 
-task('checkAgentJarSize') {
+tasks.register('checkAgentJarSize').configure {
   doLast {
     // Arbitrary limit to prevent unintentional increases to the agent jar size
     // Raise or lower as required
     assert shadowJar.archiveFile.get().getAsFile().length() < 14 * 1024 * 1024
   }
 
-  dependsOn shadowJar
+  dependsOn "shadowJar"
 }
 
-check.dependsOn 'checkAgentJarSize'
+tasks.named('check').configure {
+  dependsOn 'checkAgentJarSize'
+}

--- a/dd-java-agent/instrumentation/akka-concurrent/akka-concurrent.gradle
+++ b/dd-java-agent/instrumentation/akka-concurrent/akka-concurrent.gradle
@@ -27,7 +27,7 @@ testSets {
   }
 }
 
-compileAkka23TestGroovy {
+tasks.named("compileAkka23TestGroovy").configure {
   classpath += files(sourceSets.akka23Test.scala.classesDirectory)
 }
 
@@ -50,7 +50,7 @@ sourceSets {
     }
   }
 }
-compileLatestDepTestGroovy {
+tasks.named("compileLatestDepTestGroovy").configure {
   classpath += files(sourceSets.latestDepTest.scala.classesDirectory)
 }
 
@@ -75,4 +75,6 @@ dependencies {
 }
 
 // Run 2.3 tests along with the rest of unit tests
-test.dependsOn akka23Test
+tasks.named("test").configure {
+  dependsOn "akka23Test"
+}

--- a/dd-java-agent/instrumentation/akka-http-10.0/akka-http-10.0.gradle
+++ b/dd-java-agent/instrumentation/akka-http-10.0/akka-http-10.0.gradle
@@ -119,21 +119,23 @@ dependencies {
   lagomTestCompile group: 'com.lightbend.lagom', name: 'lagom-javadsl-testkit_2.11', version: '1.4.0'
 }
 
-test.dependsOn baseTest
-test.dependsOn version101Test
-test.dependsOn lagomTest
+tasks.named("test").configure {
+  dependsOn "baseTest"
+  dependsOn "version101Test"
+  dependsOn "lagomTest"
+}
 
 compileBaseTestGroovy {
   classpath = classpath.plus(files(compileBaseTestScala.destinationDir))
-  dependsOn compileBaseTestScala
+  dependsOn "compileBaseTestScala"
 }
 
 compileVersion101TestGroovy {
   classpath = classpath.plus(files(compileVersion101TestScala.destinationDir))
-  dependsOn compileVersion101TestScala
+  dependsOn "compileVersion101TestScala"
 }
 
 compileLatestDepTestGroovy {
   classpath = classpath.plus(files(compileLatestDepTestScala.destinationDir))
-  dependsOn compileLatestDepTestScala
+  dependsOn "compileLatestDepTestScala"
 }

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/aws-java-sdk-1.11.0.gradle
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/aws-java-sdk-1.11.0.gradle
@@ -77,4 +77,6 @@ dependencies {
   latestDepTestCompile group: 'com.amazonaws', name: 'aws-java-sdk-dynamodb', version: '+'
 }
 
-test.dependsOn test_before_1_11_106
+tasks.named("test").configure {
+  dependsOn "test_before_1_11_106"
+}

--- a/dd-java-agent/instrumentation/datanucleus-4/datanucleus-4.gradle
+++ b/dd-java-agent/instrumentation/datanucleus-4/datanucleus-4.gradle
@@ -47,7 +47,7 @@ def datanucleusVersion = '4.0.5'
 // LatestDepTest can't be used because the enhancer class generates incompatible code
 // Specifically, org.datanucleus.enhancer.Persistable changes package
 // Only one version can be set as the script classpath in the 'buildScript' block
-task enhance {
+tasks.register('enhance') {
   doLast {
     def outputUrls = (sourceSets.test.output.classesDirs.files + sourceSets.test.output.resourcesDir)
       .collect { it.toURI().toURL() } as URL[]
@@ -61,11 +61,11 @@ task enhance {
     enhancer.enhance()
   }
 
-  dependsOn testClasses
+  dependsOn "testClasses"
 }
 
 tasks.withType(Test).configureEach {
-  dependsOn enhance
+  dependsOn "enhance"
 }
 
 dependencies {

--- a/dd-java-agent/instrumentation/finatra-2.9/finatra-2.9.gradle
+++ b/dd-java-agent/instrumentation/finatra-2.9/finatra-2.9.gradle
@@ -48,14 +48,16 @@ dependencies {
   latestDepTestCompile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.11.0'
 }
 
-compileLatestDepTestGroovy {
+tasks.named("compileLatestDepTestGroovy").configure {
   classpath = classpath.plus(files(compileLatestDepTestScala.destinationDir))
-  dependsOn compileLatestDepTestScala
+  dependsOn "compileLatestDepTestScala"
 }
 
-compileLatestPre207TestGroovy {
+tasks.named("compileLatestPre207TestGroovy").configure {
   classpath = classpath.plus(files(compileLatestPre207TestScala.destinationDir))
-  dependsOn compileLatestPre207TestScala
+  dependsOn "compileLatestPre207TestScala"
 }
 
-latestDepTest.finalizedBy latestPre207Test
+tasks.named("latestDepTest").configure {
+  finalizedBy latestPre207Test
+}

--- a/dd-java-agent/instrumentation/instrumentation.gradle
+++ b/dd-java-agent/instrumentation/instrumentation.gradle
@@ -20,6 +20,8 @@ subprojects { Project subProj ->
   apply plugin: "net.bytebuddy.byte-buddy"
   apply plugin: 'muzzle'
 
+  subProj.tasks.withType(Javadoc).configureEach { enabled = false }
+
   // needs fetching this project's configurations.instrumentationMuzzle
   evaluationDependsOn ':dd-java-agent:agent-tooling'
 
@@ -73,7 +75,9 @@ subprojects { Project subProj ->
     }
 
     // Make it so all instrumentation subproject tests can be run with a single command.
-    instr_project.tasks.test.dependsOn(subProj.tasks.test)
+    instr_project.tasks.named("test").configure {
+      dependsOn(subProj.tasks.named("test"))
+    }
   }
 
   instr_project.dependencies {
@@ -87,7 +91,7 @@ dependencies {
   }
 }
 
-shadowJar {
+tasks.named('shadowJar').configure {
   duplicatesStrategy = DuplicatesStrategy.FAIL
   dependencies deps.sharedInverse
   dependencies {

--- a/dd-java-agent/instrumentation/jax-rs-annotations-2/jax-rs-annotations-2.gradle
+++ b/dd-java-agent/instrumentation/jax-rs-annotations-2/jax-rs-annotations-2.gradle
@@ -51,4 +51,6 @@ dependencies {
   latestDepTestCompile group: 'org.jboss.resteasy', name: 'resteasy-jaxrs', version: '+'
 }
 
-test.dependsOn resteasy31Test
+tasks.named("test").configure {
+  dependsOn "resteasy31Test"
+}

--- a/dd-java-agent/instrumentation/jdbc/jdbc.gradle
+++ b/dd-java-agent/instrumentation/jdbc/jdbc.gradle
@@ -41,7 +41,7 @@ dependencies {
   }
 
   oldPostgresTestCompile(group: 'org.postgresql', name: 'postgresql', version: '9.4-1201-jdbc41') {
-    force =true
+    force = true
   }
 
   testCompile group: 'mysql', name: 'mysql-connector-java', version: '8.0.23'
@@ -60,5 +60,7 @@ dependencies {
   latestDepTestCompile group: 'com.mchange', name: 'c3p0', version: '+'
 }
 
-test.dependsOn oldH2Test
-test.dependsOn oldPostgresTest
+tasks.named("test").configure {
+  dependsOn "oldH2Test"
+  dependsOn "oldPostgresTest"
+}

--- a/dd-java-agent/instrumentation/jdbc/scalikejdbc/scalikejdbc.gradle
+++ b/dd-java-agent/instrumentation/jdbc/scalikejdbc/scalikejdbc.gradle
@@ -18,13 +18,13 @@ testSets {
   }
 }
 
-compileTestGroovy {
-  dependsOn compileTestScala
+tasks.named("compileTestGroovy").configure {
+  dependsOn "compileTestScala"
   classpath += files(compileTestScala.destinationDir)
 }
 
-compileLatestDepTestGroovy {
-  dependsOn compileLatestDepTestScala
+tasks.named("compileLatestDepTestGroovy").configure {
+  dependsOn "compileLatestDepTestScala"
   classpath += files(compileLatestDepTestScala.destinationDir)
 }
 

--- a/dd-java-agent/instrumentation/liberty-20/liberty-20.gradle
+++ b/dd-java-agent/instrumentation/liberty-20/liberty-20.gradle
@@ -18,7 +18,7 @@ dependencies {
 }
 
 //unzips the dependencies from the 'zipped' configuration so 'compileOnly' can reference it
-task installOpenLibertyDeps(type: Sync) {
+tasks.register('installOpenLibertyDeps', Sync) {
   def extractDir = "${buildDir}/openliberty-jars"
   ext.extractedJars = fileTree(extractDir) {
     include "**/*.jar"

--- a/dd-java-agent/instrumentation/mongo/mongo.gradle
+++ b/dd-java-agent/instrumentation/mongo/mongo.gradle
@@ -6,7 +6,7 @@ dependencies {
 
 // Forcing strict test execution order (no parallel execution) to ensure proper mongo executable initialization.
 List<Test> testTasks = []
-tasks.withType(Test) { Test testTask ->
+tasks.withType(Test).configureEach { Test testTask ->
   testTasks.each {
     testTask.shouldRunAfter(it)
   }
@@ -14,7 +14,7 @@ tasks.withType(Test) { Test testTask ->
 }
 subprojects {
   afterEvaluate {
-    tasks.withType(Test) { Test testTask ->
+    tasks.withType(Test).configureEach { Test testTask ->
       testTasks.each {
         testTask.shouldRunAfter(it)
       }

--- a/dd-java-agent/instrumentation/mule-4/mule-4.gradle
+++ b/dd-java-agent/instrumentation/mule-4/mule-4.gradle
@@ -87,7 +87,7 @@ dependencies {
 }
 
 // extract the enabled services into the mule base directory
-task extractMuleServices(type: Sync) {
+tasks.register('extractMuleServices', Sync) {
   dependsOn configurations.muleServices
 
   configurations.muleServices.resolvedConfiguration.resolvedArtifacts.findAll {
@@ -103,7 +103,7 @@ task extractMuleServices(type: Sync) {
 }
 
 // build the mule application via maven
-task mvnPackage(type: Exec) {
+tasks.register('mvnPackage', Exec) {
   workingDir "$appDir"
   commandLine 'mvn', "-Ddatadog.builddir=$buildDir", "-Ddatadog.name=mule-test-application", "-Ddatadog.version=$version", 'package'
   outputs.dir("$buildDir/target")
@@ -113,7 +113,7 @@ task mvnPackage(type: Exec) {
 }
 
 // generate a properties file so the test knows where to run mule, and what jar to deploy
-task generateAppResources {
+tasks.register('generateAppResources') {
   outputs.dir generatedResourcesDir
   doLast {
     def generated = new File(generatedResourcesDir, "test-build.properties")
@@ -123,7 +123,7 @@ task generateAppResources {
   }
 }
 
-tasks.test {
+tasks.named("test").configure {
   outputs.upToDateWhen {
     !mvnPackage.didWork && !extractMuleServices.didWork
   }

--- a/dd-java-agent/instrumentation/netty-promise-4/netty-promise-4.gradle
+++ b/dd-java-agent/instrumentation/netty-promise-4/netty-promise-4.gradle
@@ -29,4 +29,6 @@ dependencies {
   latestDepTestCompile group: 'io.netty', name: 'netty-common', version: '+'
 }
 
-tasks.latestDepTest.dependsOn tasks.latestDep4Test
+tasks.named("latestDepTest").configure {
+  dependsOn "latestDep4Test"
+}

--- a/dd-java-agent/instrumentation/rmi/rmi.gradle
+++ b/dd-java-agent/instrumentation/rmi/rmi.gradle
@@ -11,10 +11,13 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-task "rmic", dependsOn: testClasses {
+def rmic = tasks.register('rmic') {
+  dependsOn testClasses
   def clazz = 'rmi.app.ServerLegacy'
   String command = """rmic -g -keep -classpath ${sourceSets.test.output.classesDirs.asPath} -d ${buildDir}/classes/java/test ${clazz}"""
   command.execute().text
 }
 
-test.dependsOn "rmic"
+tasks.named("test").configure {
+  dependsOn "rmic"
+}

--- a/dd-java-agent/instrumentation/scala-concurrent/scala-concurrent.gradle
+++ b/dd-java-agent/instrumentation/scala-concurrent/scala-concurrent.gradle
@@ -29,17 +29,16 @@ testSets {
     dirName = 'test'
   }
 }
-
-compileTestGroovy {
+tasks.named("compileTestGroovy").configure {
   classpath += files(sourceSets.test.scala.classesDirectory)
 }
-compileLatest12TestGroovy {
+tasks.named("compileLatest12TestGroovy").configure {
   classpath += files(sourceSets.latest12Test.scala.classesDirectory)
 }
-compileLatest11TestGroovy {
+tasks.named("compileLatest11TestGroovy").configure {
   classpath += files(sourceSets.latest11Test.scala.classesDirectory)
 }
-compileLatestDepTestGroovy {
+tasks.named("compileLatestDepTestGroovy").configure {
   classpath += files(sourceSets.latestDepTest.scala.classesDirectory)
 }
 
@@ -56,6 +55,7 @@ dependencies {
   latestDepTestCompile project(':dd-java-agent:instrumentation:scala-promise:scala-promise-2.13')
 }
 
-// Run extra tests along with the rest of unit tests
-test.dependsOn latest11Test
-test.dependsOn latest12Test
+tasks.named("latestDepTest").configure {
+  dependsOn "latest11Test"
+  dependsOn "latest12Test"
+}

--- a/dd-java-agent/instrumentation/scala-promise/scala-promise-2.10/scala-promise-2.10.gradle
+++ b/dd-java-agent/instrumentation/scala-promise/scala-promise-2.10/scala-promise-2.10.gradle
@@ -51,23 +51,24 @@ sourceSets {
   latestDepForkedTest.scala.srcDir project(':dd-java-agent:instrumentation:scala-promise').sourceSets.test.scala
 }
 
-compileTestGroovy {
+tasks.named("compileTestGroovy").configure {
   classpath += files(sourceSets.test.scala.classesDirectory)
-  dependsOn compileTestScala
+  dependsOn "compileTestScala"
 }
 
-compileLatestDepTestGroovy {
+tasks.named("compileLatestDepTestGroovy").configure {
   classpath += files(sourceSets.latestDepTest.scala.classesDirectory)
-  dependsOn compileLatestDepTestScala
+  dependsOn "compileLatestDepTestScala"
 }
 
-compileLatestDepForkedTestGroovy {
+tasks.named("compileLatestDepForkedTestGroovy").configure {
   classpath += files(sourceSets.latestDepForkedTest.scala.classesDirectory)
-  dependsOn compileLatestDepForkedTestScala
+  dependsOn "compileLatestDepForkedTestScala"
 }
 
-latestDepTest {
-  dependsOn latestDepForkedTest
+tasks.named("latestDepTest").configure {
+  dependsOn "latestDepForkedTest"
+
 }
 
 dependencies {

--- a/dd-java-agent/instrumentation/scala-promise/scala-promise-2.13/scala-promise-2.13.gradle
+++ b/dd-java-agent/instrumentation/scala-promise/scala-promise-2.13/scala-promise-2.13.gradle
@@ -51,20 +51,20 @@ sourceSets {
   latestDepForkedTest.scala.srcDir project(':dd-java-agent:instrumentation:scala-promise').sourceSets.test.scala
 }
 
-compileTestGroovy {
+tasks.named("compileTestGroovy").configure {
   classpath += files(sourceSets.test.scala.classesDirectory)
 }
 
-compileLatestDepTestGroovy {
+tasks.named("compileLatestDepTestGroovy").configure {
   classpath += files(sourceSets.latestDepTest.scala.classesDirectory)
 }
 
-compileLatestDepForkedTestGroovy {
+tasks.named("compileLatestDepForkedTestGroovy").configure {
   classpath += files(sourceSets.latestDepForkedTest.scala.classesDirectory)
 }
 
-latestDepTest {
-  dependsOn latestDepForkedTest
+tasks.named("latestDepTest").configure {
+  dependsOn "latestDepForkedTest"
 }
 
 dependencies {

--- a/dd-java-agent/instrumentation/scala-promise/scala-promise.gradle
+++ b/dd-java-agent/instrumentation/scala-promise/scala-promise.gradle
@@ -13,7 +13,7 @@ muzzle {
 apply from: "$rootDir/gradle/java.gradle"
 apply plugin: 'scala'
 
-compileTestGroovy {
+tasks.named("compileTestGroovy").configure {
   classpath += files(sourceSets.test.scala.classesDirectory)
 }
 

--- a/dd-java-agent/instrumentation/slick/slick.gradle
+++ b/dd-java-agent/instrumentation/slick/slick.gradle
@@ -19,13 +19,13 @@ testSets {
   }
 }
 
-compileTestGroovy {
-  dependsOn compileTestScala
+tasks.named("compileTestGroovy").configure {
+  dependsOn "compileTestScala"
   classpath += files(compileTestScala.destinationDir)
 }
 
-compileLatestDepTestGroovy {
-  dependsOn compileLatestDepTestScala
+tasks.named("compileLatestDepTestGroovy").configure {
+  dependsOn "compileLatestDepTestScala"
   classpath += files(compileLatestDepTestScala.destinationDir)
 }
 

--- a/dd-java-agent/instrumentation/spring-webflux-5/spring-webflux-5.gradle
+++ b/dd-java-agent/instrumentation/spring-webflux-5/spring-webflux-5.gradle
@@ -94,7 +94,11 @@ dependencies {
   latestBoot24TestCompile group: 'org.springframework.boot', name: 'spring-boot-starter-reactor-netty', version: '2.4.+'
 }
 
-test.dependsOn boot20Test
-latestDepTest.dependsOn latestBoot20Test
-test.dependsOn boot24Test
-latestDepTest.dependsOn latestBoot24Test
+tasks.named("test").configure {
+  dependsOn "boot20Test"
+  dependsOn "boot24Test"
+}
+tasks.named("latestDepTest").configure {
+  dependsOn "latestBoot20Test"
+  dependsOn "latestBoot24Test"
+}

--- a/dd-java-agent/load-generator/load-generator.gradle
+++ b/dd-java-agent/load-generator/load-generator.gradle
@@ -8,7 +8,7 @@ dependencies {
   compile deps.guava
 }
 
-task launch(type: JavaExec) {
+tasks.register('launch', JavaExec) {
   classpath = sourceSets.main.runtimeClasspath
   main = 'datadog.loadgenerator.LoadGenerator'
   jvmArgs = [
@@ -17,5 +17,5 @@ task launch(type: JavaExec) {
   ]
   systemProperties System.properties
 
-  dependsOn project(':dd-java-agent').shadowJar
+  dependsOn project(':dd-java-agent').tasks.named("shadowJar")
 }

--- a/dd-smoke-tests/cli/cli.gradle
+++ b/dd-smoke-tests/cli/cli.gradle
@@ -18,7 +18,7 @@ dependencies {
 }
 
 tasks.withType(Test).configureEach {
-  dependsOn shadowJar
+  dependsOn "shadowJar"
 
   jvmArgs "-Ddatadog.smoketest.cli.shadowJar.path=${tasks.shadowJar.archivePath}"
 }

--- a/dd-smoke-tests/dd-smoke-tests.gradle
+++ b/dd-smoke-tests/dd-smoke-tests.gradle
@@ -11,9 +11,12 @@ def smokeTestLimit = gradle.sharedServices.registerIfAbsent("smokeTestLimit", Bu
   maxParallelUsages = 1
 }
 
-subprojects { subProject ->
-  subProject.tasks.withType(Test).configureEach {
-    dependsOn project(':dd-java-agent').shadowJar
+subprojects { Project subProj ->
+  // Don't need javadoc task run for internal projects.
+  subProj.tasks.withType(Javadoc).configureEach { enabled = false }
+
+  subProj.tasks.withType(Test).configureEach {
+    dependsOn project(':dd-java-agent').tasks.named("shadowJar")
 
     // Tests depend on this to know where to run things and what agent jar to use
     jvmArgs "-Ddatadog.smoketest.builddir=${buildDir}"

--- a/dd-smoke-tests/field-injection/field-injection.gradle
+++ b/dd-smoke-tests/field-injection/field-injection.gradle
@@ -24,7 +24,7 @@ dependencies {
 }
 
 tasks.withType(Test).configureEach {
-  dependsOn shadowJar
+  dependsOn "shadowJar"
 
   jvmArgs "-Ddatadog.smoketest.fieldinjection.shadowJar.path=${tasks.shadowJar.archivePath}"
 }

--- a/dd-smoke-tests/java9-modules/java9-modules.gradle
+++ b/dd-smoke-tests/java9-modules/java9-modules.gradle
@@ -48,7 +48,7 @@ if (JavaVersion.VERSION_1_9.compareTo(JavaVersion.current()) > 0) {
 // java.gradle generates a test task per jdk and assigns the test task its own java executable
 // For each Test task, this loop creates a jlink image using the test's executable
 // At the end, we have 1 jlink image per JVM: each one used by a testXXXGenerated task
-tasks.withType(Test).each {
+tasks.withType(Test).configureEach {
   def javaExecutable = it.executable
   def javaVersion = getJavaExecutableVersion(javaExecutable)
 
@@ -63,7 +63,7 @@ tasks.withType(Test).each {
   def jdkModulesPath = specificJDKHome + "/jmods"
   def generatedImageDir = "${buildDir}/${it.name}image"
 
-  it.doFirst {
+  doFirst {
     delete generatedImageDir
 
     // Run the jlink command to create the image
@@ -74,8 +74,8 @@ tasks.withType(Test).each {
     }
   }
 
-  it.jvmArgs "-Ddatadog.smoketest.module.image=${generatedImageDir}"
-  it.dependsOn jar
+  jvmArgs "-Ddatadog.smoketest.module.image=${generatedImageDir}"
+  dependsOn "jar"
 }
 
 dependencies {

--- a/dd-smoke-tests/log-injection/log-injection.gradle
+++ b/dd-smoke-tests/log-injection/log-injection.gradle
@@ -123,7 +123,7 @@ dependencies {
 
 def generateTestingJar(String interfaceName, String backend, List<Configuration> configurationsList) {
   def name = interfaceName + "Interface" + backend + "Backend"
-  tasks.create(name: name, type: ShadowJar) {
+  tasks.register(name, ShadowJar).configure {
     from sourceSets.main.output
     from sourceSets.logging.output
 

--- a/dd-smoke-tests/opentracing/opentracing.gradle
+++ b/dd-smoke-tests/opentracing/opentracing.gradle
@@ -13,7 +13,7 @@ dependencies {
 }
 
 tasks.withType(Test).configureEach {
-  dependsOn shadowJar
+  dependsOn "shadowJar"
 
   jvmArgs "-Ddatadog.smoketest.shadowJar.path=${tasks.shadowJar.archivePath}"
 }

--- a/dd-smoke-tests/osgi/osgi.gradle
+++ b/dd-smoke-tests/osgi/osgi.gradle
@@ -44,7 +44,7 @@ jar {
 
 import aQute.bnd.gradle.Bundle
 
-task commonBundle(type: Bundle) {
+tasks.register('commonBundle', Bundle) {
   classifier = 'common'
   from sourceSets.main.output
   include 'datadog/smoketest/osgi/common/**'
@@ -53,7 +53,7 @@ task commonBundle(type: Bundle) {
   }
 }
 
-task clientBundle(type: Bundle) {
+tasks.register('clientBundle', Bundle) {
   classifier = 'client'
   from sourceSets.main.output
   include 'datadog/smoketest/osgi/client/**'
@@ -62,7 +62,7 @@ task clientBundle(type: Bundle) {
   }
 }
 
-task messagingBundle(type: Bundle) {
+tasks.register('messagingBundle', Bundle) {
   classifier = 'messaging'
   from sourceSets.main.output
   include 'datadog/smoketest/osgi/messaging/**'
@@ -71,7 +71,7 @@ task messagingBundle(type: Bundle) {
   }
 }
 
-task publishingBundle(type: Bundle) {
+tasks.register('publishingBundle', Bundle) {
   classifier = 'publishing'
   from sourceSets.main.output
   include 'datadog/smoketest/osgi/publishing/**'
@@ -80,7 +80,7 @@ task publishingBundle(type: Bundle) {
   }
 }
 
-task subscribingBundle(type: Bundle) {
+tasks.register('subscribingBundle', Bundle) {
   classifier = 'subscribing'
   from sourceSets.main.output
   include 'datadog/smoketest/osgi/subscribing/**'
@@ -90,7 +90,7 @@ task subscribingBundle(type: Bundle) {
 }
 
 tasks.withType(Test).configureEach {
-  dependsOn commonBundle, clientBundle, messagingBundle, publishingBundle, subscribingBundle, jar
+  dependsOn "commonBundle", "clientBundle", "messagingBundle", "publishingBundle", "subscribingBundle", "jar"
 
   jvmArgs "-Ddatadog.smoketest.osgi.appJar.path=${tasks.jar.archivePath}"
   jvmArgs "-Ddatadog.smoketest.osgi.equinoxJar.path=${configurations.equinox.first().path}"

--- a/dd-smoke-tests/play-2.7/play-2.7.gradle
+++ b/dd-smoke-tests/play-2.7/play-2.7.gradle
@@ -16,7 +16,7 @@ dependencies {
 
 def appDir = "$projectDir/application"
 // define the task that builds the play project
-task sbtStage(type:Exec) {
+tasks.register('sbtStage', Exec) {
   workingDir "$appDir"
   commandLine './sbt', "-Dsbt.ivy=true", "-Dplay.version=$playVersion", "-Dscala.version=$scalaVersion", "-Ddatadog.smoketest.builddir=$buildDir", 'stage'
   outputs.dir("$buildDir/target")

--- a/dd-smoke-tests/play-2.8/play-2.8.gradle
+++ b/dd-smoke-tests/play-2.8/play-2.8.gradle
@@ -16,7 +16,7 @@ dependencies {
 
 def appDir = "$projectDir/application"
 // define the task that builds the play project
-task sbtStage(type:Exec) {
+tasks.register('sbtStage', Exec) {
   workingDir "$appDir"
   commandLine './sbt', "-Dsbt.ivy=true", "-Dplay.version=$playVersion", "-Dscala.version=$scalaVersion", "-Ddatadog.smoketest.builddir=$buildDir", 'stage'
   outputs.dir("$buildDir/target")

--- a/dd-smoke-tests/profiling-integration-tests/profiling-integration-tests.gradle
+++ b/dd-smoke-tests/profiling-integration-tests/profiling-integration-tests.gradle
@@ -33,7 +33,7 @@ dependencies {
 }
 
 tasks.withType(Test).configureEach {
-  dependsOn shadowJar
+  dependsOn "shadowJar"
 
   onlyIf { !name.contains('IBM') }
 

--- a/dd-smoke-tests/quarkus/quarkus.gradle
+++ b/dd-smoke-tests/quarkus/quarkus.gradle
@@ -11,16 +11,16 @@ dependencies {
 def appDir = "$projectDir/application"
 def appBuildDir = "$buildDir/application"
 // define the task that builds the quarkus project
-task quarkusBuild(type:Exec) {
+tasks.register('quarkusBuild', Exec) {
   workingDir "$appDir"
   environment += ["GRADLE_OPTS": "-Xmx512M"]
-  commandLine "$rootDir/gradlew", "build", "--no-daemon", "--max-workers=4", "-PappBuildDir=$appBuildDir", "-PapiJar=${project(':dd-trace-api').tasks.jar.archiveFile}"
+  commandLine "$rootDir/gradlew", "build", "--no-daemon", "--max-workers=4", "-PappBuildDir=$appBuildDir", "-PapiJar=${project(':dd-trace-api').tasks.jar.archivePath}"
   outputs.dir(appBuildDir)
   inputs.dir(appDir)
 }
 
 quarkusBuild {
-  dependsOn project(':dd-trace-api').tasks.jar
+  dependsOn project(':dd-trace-api').tasks.named("jar")
 }
 
 compileTestGroovy {

--- a/dd-smoke-tests/spring-boot-2.4-webflux/spring-boot-2.4-webflux.gradle
+++ b/dd-smoke-tests/spring-boot-2.4-webflux/spring-boot-2.4-webflux.gradle
@@ -27,7 +27,7 @@ dependencies {
 }
 
 tasks.withType(Test).configureEach {
-  dependsOn shadowJar
+  dependsOn "shadowJar"
 
   jvmArgs "-Ddatadog.smoketest.springboot.shadowJar.path=${tasks.shadowJar.archivePath}"
 }

--- a/dd-smoke-tests/spring-boot-2.5-webflux/spring-boot-2.5-webflux.gradle
+++ b/dd-smoke-tests/spring-boot-2.5-webflux/spring-boot-2.5-webflux.gradle
@@ -33,7 +33,7 @@ dependencies {
 }
 
 tasks.withType(Test).configureEach {
-  dependsOn shadowJar
+  dependsOn "shadowJar"
 
   jvmArgs "-Ddatadog.smoketest.springboot.shadowJar.path=${tasks.shadowJar.archivePath}"
 }

--- a/dd-smoke-tests/springboot-grpc/springboot-grpc.gradle
+++ b/dd-smoke-tests/springboot-grpc/springboot-grpc.gradle
@@ -50,7 +50,7 @@ dependencies {
 }
 
 tasks.withType(Test).configureEach {
-  dependsOn shadowJar
+  dependsOn "shadowJar"
 
   jvmArgs "-Ddatadog.smoketest.springboot-grpc.shadowJar.path=${tasks.shadowJar.archivePath}"
 }

--- a/dd-smoke-tests/springboot-mongo/springboot-mongo.gradle
+++ b/dd-smoke-tests/springboot-mongo/springboot-mongo.gradle
@@ -29,7 +29,7 @@ dependencies {
 }
 
 tasks.withType(Test).configureEach {
-  dependsOn shadowJar
+  dependsOn "shadowJar"
 
   jvmArgs "-Ddatadog.smoketest.springboot.shadowJar.path=${tasks.shadowJar.archivePath}"
 }

--- a/dd-smoke-tests/springboot-openliberty/springboot-openliberty.gradle
+++ b/dd-smoke-tests/springboot-openliberty/springboot-openliberty.gradle
@@ -13,7 +13,7 @@ def appDir = "$projectDir/application"
 def jarName = "demo-open-liberty-app.jar"
 
 // compile the Open liberty spring boot server
-task mvnStage(type:Exec) {
+tasks.register('mvnStage', Exec) {
   workingDir "$appDir"
   commandLine './mvnw', 'package'
 }

--- a/dd-smoke-tests/springboot/springboot.gradle
+++ b/dd-smoke-tests/springboot/springboot.gradle
@@ -19,7 +19,7 @@ dependencies {
 }
 
 tasks.withType(Test).configureEach {
-  dependsOn shadowJar
+  dependsOn "shadowJar"
 
   jvmArgs "-Ddatadog.smoketest.springboot.shadowJar.path=${tasks.shadowJar.archivePath}"
 }

--- a/dd-smoke-tests/wildfly/wildfly.gradle
+++ b/dd-smoke-tests/wildfly/wildfly.gradle
@@ -51,7 +51,7 @@ tasks.register("unzip", Copy) {
 }
 
 tasks.withType(Test).configureEach {
-  dependsOn unzip
+  dependsOn "unzip"
 
   jvmArgs "-Ddatadog.smoketest.wildflyDir=${buildDir}/${serverName}-${serverModule}-${serverVersion}"
 }

--- a/dd-trace-core/jfr-openjdk/jfr-openjdk.gradle
+++ b/dd-trace-core/jfr-openjdk/jfr-openjdk.gradle
@@ -25,7 +25,7 @@ sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
 [JavaCompile, GroovyCompile].each {
-  tasks.withType(it) {
+  tasks.withType(it).configureEach {
     doFirst {
       if (!System.env.JAVA_11_HOME) {
         throw new GradleException('JAVA_11_HOME must be set to build profiling helpers')

--- a/dd-trace-java.gradle
+++ b/dd-trace-java.gradle
@@ -83,7 +83,7 @@ allprojects {
   }
 }
 
-task writeMuzzleTasksToFile {
+tasks.register('writeMuzzleTasksToFile') {
   doLast {
     def muzzleFile = file("${buildDir}/muzzleTasks")
     assert muzzleFile.parentFile.mkdirs() || muzzleFile.parentFile.directory

--- a/dd-trace-ot/dd-trace-ot.gradle
+++ b/dd-trace-ot/dd-trace-ot.gradle
@@ -68,8 +68,9 @@ dependencies {
   }
 }
 
-test.finalizedBy ot31CompatabilityTest
-test.finalizedBy ot33CompatabilityTest
+tasks.named("test").configure {
+  finalizedBy "ot31CompatabilityTest", "ot33CompatabilityTest"
+}
 
 jar {
   archiveClassifier = 'unbundled'

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,8 +1,8 @@
-def groovyVer = "2.5.13"
-def spockGroovyVer = groovyVer.replaceAll(/\.\d+$/, '')
+final class CachedData {
+  static groovyVer = "2.5.13"
+  static spockGroovyVer = groovyVer.replaceAll(/\.\d+$/, '')
 
-ext {
-  versions = [
+  static versions = [
     slf4j         : "1.7.30",
     guava         : "20.0", // Last version to support Java 7
     okhttp        : "3.12.12", // 3.12.x is last version to support Java7)
@@ -29,73 +29,71 @@ ext {
     autoservice   : "1.0-rc7"
   ]
 
-  deps = [
+  static deps = [
     // General
     slf4j                : "org.slf4j:slf4j-api:${versions.slf4j}",
     guava                : "com.google.guava:guava:$versions.guava",
-    okhttp               : dependencies.create(group: 'com.squareup.okhttp3', name: 'okhttp', version: versions.okhttp),
-    okio                 : dependencies.create(group: 'com.squareup.okio', name: 'okio', version: versions.okio),
-    bytebuddy            : dependencies.create(group: 'net.bytebuddy', name: 'byte-buddy', version: versions.bytebuddy),
-    bytebuddyagent       : dependencies.create(group: 'net.bytebuddy', name: 'byte-buddy-agent', version: versions.bytebuddy),
-    autoserviceProcessor : dependencies.create(group: 'com.google.auto.service', name: 'auto-service', version: versions.autoservice),
-    autoserviceAnnotation: dependencies.create(group: 'com.google.auto.service', name: 'auto-service-annotations', version: versions.autoservice),
-    commonsMath          : dependencies.create(group: 'org.apache.commons', name: 'commons-math3', version: versions.commons),
+    okhttp               : "com.squareup.okhttp3:okhttp:${versions.okhttp}",
+    okio                 : "com.squareup.okio:okio:${versions.okio}",
+    bytebuddy            : "net.bytebuddy:byte-buddy:${versions.bytebuddy}",
+    bytebuddyagent       : "net.bytebuddy:byte-buddy-agent:${versions.bytebuddy}",
+    autoserviceProcessor : "com.google.auto.service:auto-service:${versions.autoservice}",
+    autoserviceAnnotation: "com.google.auto.service:auto-service-annotations:${versions.autoservice}",
+    commonsMath          : "org.apache.commons:commons-math3:${versions.commons}",
 
     // Testing
 
-    spock         : [
-      dependencies.create("org.spockframework:spock-core:${versions.spock}", {
-        exclude group: 'org.codehaus.groovy', module: 'groovy-all'
-      }),
+    spock                : [
+      "org.spockframework:spock-core:${versions.spock}",
       // Used by Spock for mocking:
-      dependencies.create(group: 'org.objenesis', name: 'objenesis', version: '2.6') // Last version to support Java7
+      "org.objenesis:objenesis:2.6" // Last version to support Java7
     ],
-    groovy        : "org.codehaus.groovy:groovy-all:${versions.groovy}",
-    junit5        : [
-      dependencies.create(group: 'org.junit.jupiter', name: 'junit-jupiter', version: versions.junit5),
-      dependencies.create(group: 'org.junit.jupiter', name: 'junit-jupiter-params', version: versions.junit5)
+    groovy               : "org.codehaus.groovy:groovy-all:${versions.groovy}",
+    junit5               : [
+      "org.junit.jupiter:junit-jupiter:${versions.junit5}",
+      "org.junit.jupiter:junit-jupiter-params:${versions.junit5}"
     ],
-    mockito       : [
-      dependencies.create(group: 'org.mockito', name: 'mockito-core', version: versions.mockito),
-      dependencies.create(group: 'org.mockito', name: 'mockito-junit-jupiter', version: versions.mockito)
+    mockito              : [
+      "org.mockito:mockito-core:${versions.mockito}",
+      "org.mockito:mockito-junit-jupiter:${versions.mockito}"
     ],
-    testcontainers: "org.testcontainers:testcontainers:${versions.testcontainers}",
-    testLogging   : [
-      dependencies.create(group: 'ch.qos.logback', name: 'logback-classic', version: versions.logback),
-      dependencies.create(group: 'org.slf4j', name: 'log4j-over-slf4j', version: versions.slf4j),
-      dependencies.create(group: 'org.slf4j', name: 'jcl-over-slf4j', version: versions.slf4j),
-      dependencies.create(group: 'org.slf4j', name: 'jul-to-slf4j', version: versions.slf4j),
+    testcontainers       : "org.testcontainers:testcontainers:${versions.testcontainers}",
+    testLogging          : [
+      "ch.qos.logback:logback-classic:${versions.logback}",
+      "org.slf4j:log4j-over-slf4j:${versions.slf4j}",
+      "org.slf4j:jcl-over-slf4j:${versions.slf4j}",
+      "org.slf4j:jul-to-slf4j:${versions.slf4j}",
     ],
-    scala         : dependencies.create(group: 'org.scala-lang', name: 'scala-library', version: "${versions.scala}"),
-    scala210      : dependencies.create(group: 'org.scala-lang', name: 'scala-library', version: "${versions.scala210}"),
-    scala211      : dependencies.create(group: 'org.scala-lang', name: 'scala-library', version: "${versions.scala211}"),
-    scala212      : dependencies.create(group: 'org.scala-lang', name: 'scala-library', version: "${versions.scala212}"),
-    scala213      : dependencies.create(group: 'org.scala-lang', name: 'scala-library', version: "${versions.scala213}"),
-    kotlin        : dependencies.create(group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib', version: "${versions.kotlin}"),
-    coroutines    : dependencies.create(group: 'org.jetbrains.kotlinx', name: 'kotlinx-coroutines-core', version: "${versions.coroutines}"),
+    scala                : "org.scala-lang:scala-library:${versions.scala}",
+    scala210             : "org.scala-lang:scala-library:${versions.scala210}",
+    scala211             : "org.scala-lang:scala-library:${versions.scala211}",
+    scala212             : "org.scala-lang:scala-library:${versions.scala212}",
+    scala213             : "org.scala-lang:scala-library:${versions.scala213}",
+    kotlin               : "org.jetbrains.kotlin:kotlin-stdlib:${versions.kotlin}",
+    coroutines           : "org.jetbrains.kotlinx:kotlinx-coroutines-core:${versions.coroutines}",
 
-    jmc           : [
-      dependencies.create(group: 'org.openjdk.jmc', name: 'common', version: versions.jmc),
-      dependencies.create(group: 'org.openjdk.jmc', name: 'flightrecorder', version: versions.jmc),
-      dependencies.create(group: 'org.openjdk.jmc', name: 'flightrecorder', version: versions.jmc),
-      dependencies.create(group: 'org.openjdk.jmc', name: 'flightrecorder', version: versions.jmc)
+    jmc                  : [
+      "org.openjdk.jmc:common:${versions.jmc}",
+      "org.openjdk.jmc:flightrecorder:${versions.jmc}",
+      "org.openjdk.jmc:flightrecorder:${versions.jmc}",
+      "org.openjdk.jmc:flightrecorder:${versions.jmc}"
     ],
 
     // Shared between agent tooling, instrumentation, JMXFetch, and profiling
-    shared        : [
-      dependencies.create(group: 'com.squareup.okhttp3', name: 'okhttp', version: versions.okhttp),
+    shared               : [
+      "com.squareup.okhttp3:okhttp:${versions.okhttp}",
       // Force specific version of okio required by com.squareup.moshi:moshi
       // When all of the dependencies are declared in dd-trace-core, moshi overrides the okhttp's
       // transitive dependency.  Since okhttp is declared here and moshi is not, this lead to an incompatible version
-      dependencies.create(group: 'com.squareup.okio', name: 'okio', version: versions.okio),
-      dependencies.create(group: 'com.datadoghq', name: 'java-dogstatsd-client', version: versions.dogstatsd),
-      dependencies.create(group: 'com.github.jnr', name: 'jnr-unixsocket', version: versions.jnr_unixsocket)
+      "com.squareup.okio:okio:${versions.okio}",
+      "com.datadoghq:java-dogstatsd-client:${versions.dogstatsd}",
+      "com.github.jnr:jnr-unixsocket:${versions.jnr_unixsocket}"
     ],
 
     // Inverse of "shared".  These exclude directives are part of shadowJar's DSL
     // which is similar but not exactly the same as the regular gradle dependency{} block
     // Also, transitive dependencies have to be explicitly listed
-    sharedInverse : (Closure) {
+    sharedInverse        : (Closure) {
       // dogstatsd and its transitives
       exclude(dependency('com.datadoghq:java-dogstatsd-client'))
       exclude(dependency('com.github.jnr::'))
@@ -106,4 +104,9 @@ ext {
       exclude(dependency('com.squareup.okio:okio'))
     }
   ]
+}
+
+ext {
+  versions = CachedData.versions
+  deps = CachedData.deps
 }

--- a/gradle/jacoco.gradle
+++ b/gradle/jacoco.gradle
@@ -4,8 +4,8 @@ jacoco {
   toolVersion = "0.8.5"
 }
 
-task forkedTestJacocoData {
-  dependsOn forkedTest
+tasks.register('forkedTestJacocoData') {
+  dependsOn "forkedTest"
 
   doLast {
     if (file("$buildDir/jacoco/forkedTest.exec").exists()) {
@@ -19,8 +19,8 @@ task forkedTestJacocoData {
   }
 }
 
-jacocoTestReport {
-  dependsOn test, forkedTestJacocoData
+tasks.named('jacocoTestReport').configure {
+  dependsOn('test', 'forkedTestJacocoData')
   reports {
     xml.enabled true
     csv.enabled false
@@ -45,14 +45,7 @@ project.ext.minimumBranchCoverage = 0.9
 project.ext.minimumInstructionCoverage = 0.9
 
 afterEvaluate {
-  test {
-    jacoco {
-      // Make sure that excluded classes do not get jacoco instrumentation applied since it may confuse apm agent in some cases
-      excludes = project.excludedClassesCoverage
-    }
-  }
-
-  forkedTest {
+  tasks.withType(Test).configureEach {
     jacoco {
       // Make sure that excluded classes do not get jacoco instrumentation applied since it may confuse apm agent in some cases
       excludes = project.excludedClassesCoverage
@@ -84,6 +77,10 @@ afterEvaluate {
     onlyIf { !project.rootProject.hasProperty("skipTests") }
   }
 
-  jacocoTestCoverageVerification.dependsOn jacocoTestReport
-  check.dependsOn jacocoTestCoverageVerification
+  tasks.named('jacocoTestCoverageVerification').configure {
+    dependsOn('jacocoTestReport')
+  }
+  tasks.named('check').configure {
+    dependsOn('jacocoTestCoverageVerification')
+  }
 }

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -14,7 +14,7 @@ def forkedTestLimit = gradle.sharedServices.registerIfAbsent("forkedTestLimit", 
 }
 
 // Task for tests that want to run forked in their own separate JVM
-task forkedTest(type: Test) {
+tasks.register('forkedTest', Test) {
   setIncludes(["**/*ForkedTest*"])
   jvmArgs += ["-Xms256M", "-Xmx256M"]
   forkEvery 1
@@ -24,7 +24,7 @@ task forkedTest(type: Test) {
 
 test {
   exclude("**/*ForkedTest*")
-  dependsOn forkedTest
+  dependsOn "forkedTest"
 }
 
 def applyCodeCoverage = !(
@@ -93,7 +93,7 @@ java {
 }
 
 [JavaCompile, ScalaCompile].each { type ->
-  tasks.withType(type) {
+  tasks.withType(type).configureEach {
     doFirst {
       // We do this specifically for Java7 bytecode generation because we would like to be able to compile
       // with Java8+ compiler. This likely would require some modifications when we switch to java11 compiler.
@@ -107,17 +107,6 @@ java {
       }
     }
   }
-}
-
-apply plugin: "eclipse"
-eclipse {
-  classpath {
-    downloadSources = true
-    downloadJavadoc = true
-  }
-}
-if (configurations.find { it.name == 'jmh' }) {
-  eclipse.classpath.plusConfigurations += [configurations.jmh]
 }
 
 jar {
@@ -293,11 +282,13 @@ for (def env : System.getenv().entrySet()) {
     continue
   }
 
-  def parentTask = task "testJava${javaName}"() {
+  def parentTask = tasks.register("testJava${javaName}") {
     group = 'Verification'
     description = "Run tests for Java ${javaName}"
   }
-  tasks.check.dependsOn parentTask
+  tasks.named('check').configure {
+    dependsOn parentTask
+  }
 
   tasks.withType(Test).all {
     //if (name.endsWith("Generated")) {
@@ -307,7 +298,7 @@ for (def env : System.getenv().entrySet()) {
     }
 
     def clonedTask = it
-    def newTask = task "${clonedTask.name}Java${javaName}Generated"(type: clonedTask.class) {
+    def newTask = tasks.register("${clonedTask.name}Java${javaName}Generated", clonedTask.class) {
       description "Runs $clonedTask.name under java ${javaName}"
       executable = javaPath
 
@@ -323,10 +314,10 @@ for (def env : System.getenv().entrySet()) {
           enabled = false
         }
       }
-
     }
-
-    parentTask.dependsOn newTask
+    parentTask.configure {
+      dependsOn newTask
+    }
   }
 }
 
@@ -382,13 +373,5 @@ tasks.withType(Test).configureEach {
     // Always run all tests that are runnable on JVM used for compilation
     onlyIf { isJavaVersionAllowed(JavaVersion.current()) }
     it.executable = "$currentJavaHome/bin/java"
-  }
-}
-
-plugins.withType(BasePlugin) {
-  project.afterEvaluate {
-    def deleteTasks = tasks.withType(Delete) + project.tasks.findByPath('clean')
-    def otherTasks = tasks - deleteTasks
-    otherTasks*.mustRunAfter deleteTasks
   }
 }

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -58,7 +58,7 @@ publishing {
 
 if (project.plugins.hasPlugin('com.github.johnrengelman.shadow')) {
   // Disable gradle module metadata to avoid publishing contradictory info.
-  tasks.withType(GenerateModuleMetadata) {
+  tasks.withType(GenerateModuleMetadata).configureEach {
     enabled = false
   }
 }

--- a/gradle/spotless.gradle
+++ b/gradle/spotless.gradle
@@ -67,5 +67,9 @@ spotless {
   }
 }
 
-task formatCode(dependsOn: ['spotlessApply'])
-check.dependsOn 'spotlessCheck'
+tasks.register('formatCode') {
+  dependsOn 'spotlessApply'
+}
+check.configure {
+  dependsOn 'spotlessCheck'
+}

--- a/gradle/test-with-kotlin.gradle
+++ b/gradle/test-with-kotlin.gradle
@@ -1,7 +1,7 @@
 // Enable testing kotlin code in groovy spock tests.
 apply plugin: 'kotlin'
 
-compileTestGroovy {
+tasks.named("compileTestGroovy").configure {
   //Note: look like it should be `classpath += files(sourceSets.test.kotlin.classesDirectory)`
   //instead, but kotlin plugin doesn't support it (yet?)
   classpath += files(compileTestKotlin.destinationDir)

--- a/gradle/test-with-scala.gradle
+++ b/gradle/test-with-scala.gradle
@@ -7,6 +7,6 @@ dependencies {
   testCompile deps.scala
 }
 
-compileTestGroovy {
+tasks.named("compileTestGroovy").configure {
   classpath += files(sourceSets.test.scala.classesDirectory)
 }

--- a/gradle/version.gradle
+++ b/gradle/version.gradle
@@ -20,4 +20,6 @@ tasks.register("writeVersionNumberFile") {
   }
 }
 
-compileJava.dependsOn writeVersionNumberFile
+tasks.withType(JavaCompile).configureEach {
+  dependsOn "writeVersionNumberFile"
+}


### PR DESCRIPTION
Avoid recreating the dependencies for every project.
Remove clean ordering config which makes config phase expensive.

Somewhat inspired by https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/2949

Before:
![image](https://user-images.githubusercontent.com/734411/117862258-76858b00-b260-11eb-9ad8-a0eb764db1e3.png)

After:
![image](https://user-images.githubusercontent.com/734411/117862293-7f765c80-b260-11eb-9a39-a798ef7ce62b.png)
