### PR TITLE
remove clojure class patterns from GlobalIgnoresMatcher

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/GlobalIgnoresMatcher.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/GlobalIgnoresMatcher.java
@@ -185,18 +185,6 @@ public class GlobalIgnoresMatcher<T extends TypeDescription>
 
     final int firstDollar = name.indexOf('$');
     if (firstDollar > -1) {
-      // clojure class patterns
-      if (name.startsWith("loader__", firstDollar + 1)) {
-        return true;
-      }
-      int dollar = firstDollar;
-      while (dollar > -1) {
-        if (name.startsWith("fn__", dollar + 1) || name.startsWith("reify__", dollar + 1)) {
-          return true;
-        }
-        dollar = name.indexOf('$', dollar + 1);
-      }
-
       if (name.contains("$JaxbAccessor")
           || name.contains("CGLIB$$")
           || name.contains("$__sisu")


### PR DESCRIPTION
There have been various mitigations which improve clojure performance since these were added
* Field injection fixes (these won't fall back to weak maps any more)
* Callable instrumentation was removed

This PR does not regress on the simple clojure startup benchmark used to justify the change in the first place. We still ignore the clojure standard library.