### PR TITLE
store all numeric tags as metrics except for HTTP status code

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpClientDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpClientDecorator.java
@@ -1,6 +1,5 @@
 package datadog.trace.bootstrap.instrumentation.decorator;
 
-import static datadog.trace.api.cache.RadixTreeCache.HTTP_STATUSES;
 import static datadog.trace.api.cache.RadixTreeCache.UNSET_STATUS;
 
 import datadog.trace.api.Config;
@@ -88,7 +87,7 @@ public abstract class HttpClientDecorator<REQUEST, RESPONSE> extends ClientDecor
     if (response != null) {
       final int status = status(response);
       if (status > UNSET_STATUS) {
-        span.setTag(Tags.HTTP_STATUS, HTTP_STATUSES.get(status));
+        span.setHttpStatusCode(status);
       }
       if (CLIENT_ERROR_STATUSES.get(status)) {
         span.setError(true);

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
@@ -1,6 +1,5 @@
 package datadog.trace.bootstrap.instrumentation.decorator;
 
-import static datadog.trace.api.cache.RadixTreeCache.HTTP_STATUSES;
 import static datadog.trace.api.cache.RadixTreeCache.UNSET_STATUS;
 
 import datadog.trace.api.Config;
@@ -22,9 +21,6 @@ public abstract class HttpServerDecorator<REQUEST, CONNECTION, RESPONSE> extends
   public static final String DD_RESPONSE_ATTRIBUTE = "datadog.response";
 
   private static final BitSet SERVER_ERROR_STATUSES = Config.get().getHttpServerErrorStatuses();
-
-  // Assigned here to avoid repeat boxing and cache lookup.
-  public static final Integer _500 = HTTP_STATUSES.get(500);
 
   protected abstract String method(REQUEST request);
 
@@ -113,7 +109,7 @@ public abstract class HttpServerDecorator<REQUEST, CONNECTION, RESPONSE> extends
     if (response != null) {
       final int status = status(response);
       if (status > UNSET_STATUS) {
-        span.setTag(Tags.HTTP_STATUS, HTTP_STATUSES.get(status));
+        span.setHttpStatusCode(status);
       }
       if (SERVER_ERROR_STATUSES.get(status)) {
         span.setError(true);

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/HttpClientDecoratorTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/HttpClientDecoratorTest.groovy
@@ -95,7 +95,7 @@ class HttpClientDecoratorTest extends ClientDecoratorTest {
 
     then:
     if (status) {
-      1 * span.setTag(Tags.HTTP_STATUS, status)
+      1 * span.setHttpStatusCode(status)
     }
     if (error) {
       1 * span.setError(true)

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecoratorTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecoratorTest.groovy
@@ -142,7 +142,7 @@ class HttpServerDecoratorTest extends ServerDecoratorTest {
 
     then:
     if (status) {
-      1 * span.setTag(Tags.HTTP_STATUS, status)
+      1 * span.setHttpStatusCode(status)
     }
     if (error) {
       1 * span.setError(true)

--- a/dd-java-agent/instrumentation/aerospike-4/src/test/groovy/datadog/trace/instrumentation/aerospike4/AerospikeBaseTest.groovy
+++ b/dd-java-agent/instrumentation/aerospike-4/src/test/groovy/datadog/trace/instrumentation/aerospike4/AerospikeBaseTest.groovy
@@ -69,10 +69,13 @@ abstract class AerospikeBaseTest extends AgentTestRunner {
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
         "$Tags.PEER_HOSTNAME" aerospikeHost
         "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-        "$Tags.PEER_PORT" aerospikePort
         "$Tags.DB_TYPE" "aerospike"
         "$Tags.DB_INSTANCE" "test"
         defaultTags()
+      }
+      metrics {
+        "$Tags.PEER_PORT" aerospikePort
+        defaultMetrics()
       }
     }
   }

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/baseTest/groovy/AkkaHttpServerInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/baseTest/groovy/AkkaHttpServerInstrumentationTest.groovy
@@ -45,12 +45,12 @@ abstract class AkkaHttpServerInstrumentationTest extends HttpServerTest<AkkaHttp
       } else {
         parent()
       }
+      statusCode endpoint.status
       tags {
         "$Tags.COMPONENT" component
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
-        "$Tags.HTTP_STATUS" endpoint.status
         if (endpoint == FORWARDED) {
           "$Tags.HTTP_FORWARDED_IP" endpoint.body
         }

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/lagomTest/groovy/LagomTest.groovy
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/lagomTest/groovy/LagomTest.groovy
@@ -63,12 +63,12 @@ class LagomTest extends AgentTestRunner {
           resourceName "GET /echo"
           spanType DDSpanTypes.HTTP_SERVER
           errored false
+          statusCode 101
           tags {
             "$Tags.COMPONENT" "akka-http-server"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
             "$Tags.HTTP_URL" "ws://localhost:${server.port()}/echo"
             "$Tags.HTTP_METHOD" "GET"
-            "$Tags.HTTP_STATUS" 101
             defaultTags()
           }
         }
@@ -105,12 +105,12 @@ class LagomTest extends AgentTestRunner {
           resourceName "GET /error"
           spanType DDSpanTypes.HTTP_SERVER
           errored true
+          statusCode 500
           tags {
             "$Tags.COMPONENT" "akka-http-server"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
             "$Tags.HTTP_URL" "ws://localhost:${server.port()}/error"
             "$Tags.HTTP_METHOD" "GET"
-            "$Tags.HTTP_STATUS" 500
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test/groovy/AWS1ClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test/groovy/AWS1ClientTest.groovy
@@ -134,13 +134,13 @@ class AWS1ClientTest extends AgentTestRunner {
           resourceName "$service.$operation"
           spanType DDSpanTypes.HTTP_CLIENT
           errored false
+          statusCode 200
           parent()
           tags {
             "$Tags.COMPONENT" "java-aws-sdk"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.HTTP_URL" "$server.address/"
             "$Tags.HTTP_METHOD" "$method"
-            "$Tags.HTTP_STATUS" 200
             "$Tags.PEER_PORT" server.address.port
             "$Tags.PEER_HOSTNAME" "localhost"
             "aws.service" { it.contains(service) }
@@ -159,6 +159,7 @@ class AWS1ClientTest extends AgentTestRunner {
           spanType DDSpanTypes.HTTP_CLIENT
           errored false
           childOf(span(0))
+          statusCode 200
           tags {
             "$Tags.COMPONENT" "apache-httpclient"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -166,7 +167,6 @@ class AWS1ClientTest extends AgentTestRunner {
             "$Tags.PEER_PORT" server.address.port
             "$Tags.HTTP_URL" "${server.address}${path}"
             "$Tags.HTTP_METHOD" "$method"
-            "$Tags.HTTP_STATUS" 200
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test/groovy/AWS1ClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test/groovy/AWS1ClientTest.groovy
@@ -141,7 +141,6 @@ class AWS1ClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.HTTP_URL" "$server.address/"
             "$Tags.HTTP_METHOD" "$method"
-            "$Tags.PEER_PORT" server.address.port
             "$Tags.PEER_HOSTNAME" "localhost"
             "aws.service" { it.contains(service) }
             "aws.endpoint" "$server.address"
@@ -151,6 +150,10 @@ class AWS1ClientTest extends AgentTestRunner {
               "$addedTag.key" "$addedTag.value"
             }
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" server.address.port
+            defaultMetrics()
           }
         }
         span {
@@ -164,10 +167,13 @@ class AWS1ClientTest extends AgentTestRunner {
             "$Tags.COMPONENT" "apache-httpclient"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "localhost"
-            "$Tags.PEER_PORT" server.address.port
             "$Tags.HTTP_URL" "${server.address}${path}"
             "$Tags.HTTP_METHOD" "$method"
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" server.address.port
+            defaultMetrics()
           }
         }
       }
@@ -238,7 +244,6 @@ class AWS1ClientTest extends AgentTestRunner {
             "$Tags.HTTP_URL" "http://localhost:${UNUSABLE_PORT}/"
             "$Tags.HTTP_METHOD" "$method"
             "$Tags.PEER_HOSTNAME" "localhost"
-            "$Tags.PEER_PORT" 61
             "aws.service" { it.contains(service) }
             "aws.endpoint" "http://localhost:${UNUSABLE_PORT}"
             "aws.operation" "${operation}Request"
@@ -248,6 +253,10 @@ class AWS1ClientTest extends AgentTestRunner {
             }
             errorTags SdkClientException, ~/Unable to execute HTTP request/
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" 61
+            defaultMetrics()
           }
         }
         span {
@@ -260,11 +269,14 @@ class AWS1ClientTest extends AgentTestRunner {
             "$Tags.COMPONENT" "apache-httpclient"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "localhost"
-            "$Tags.PEER_PORT" UNUSABLE_PORT
             "$Tags.HTTP_URL" "http://localhost:${UNUSABLE_PORT}/$url"
             "$Tags.HTTP_METHOD" "$method"
             errorTags HttpHostConnectException, ~/Connection refused/
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" UNUSABLE_PORT
+            defaultMetrics()
           }
         }
       }
@@ -353,7 +365,6 @@ class AWS1ClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.HTTP_URL" "$server.address/"
             "$Tags.HTTP_METHOD" "GET"
-            "$Tags.PEER_PORT" server.address.port
             "$Tags.PEER_HOSTNAME" "localhost"
             "aws.service" "Amazon S3"
             "aws.endpoint" "$server.address"
@@ -367,6 +378,10 @@ class AWS1ClientTest extends AgentTestRunner {
             }
             defaultTags()
           }
+          metrics {
+            "$Tags.PEER_PORT" server.address.port
+            defaultMetrics()
+          }
         }
         (1..4).each {
           span {
@@ -379,7 +394,6 @@ class AWS1ClientTest extends AgentTestRunner {
               "$Tags.COMPONENT" "apache-httpclient"
               "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
               "$Tags.PEER_HOSTNAME" "localhost"
-              "$Tags.PEER_PORT" server.address.port
               "$Tags.HTTP_URL" "$server.address/someBucket/someKey"
               "$Tags.HTTP_METHOD" "GET"
               try {
@@ -388,6 +402,10 @@ class AWS1ClientTest extends AgentTestRunner {
                 errorTags RequestAbortedException, "Request aborted"
               }
               defaultTags()
+            }
+            metrics {
+              "$Tags.PEER_PORT" server.address.port
+              defaultMetrics()
             }
           }
         }

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test_before_1_11_106/groovy/AWS0ClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test_before_1_11_106/groovy/AWS0ClientTest.groovy
@@ -98,12 +98,12 @@ class AWS0ClientTest extends AgentTestRunner {
           spanType DDSpanTypes.HTTP_CLIENT
           errored false
           parent()
+          statusCode 200
           tags {
             "$Tags.COMPONENT" "java-aws-sdk"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.HTTP_URL" "$server.address/"
             "$Tags.HTTP_METHOD" "$method"
-            "$Tags.HTTP_STATUS" 200
             "$Tags.PEER_PORT" server.address.port
             "$Tags.PEER_HOSTNAME" "localhost"
             "aws.service" { it.contains(service) }
@@ -122,6 +122,7 @@ class AWS0ClientTest extends AgentTestRunner {
           spanType DDSpanTypes.HTTP_CLIENT
           errored false
           childOf(span(0))
+          statusCode 200
           tags {
             "$Tags.COMPONENT" "apache-httpclient"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -129,7 +130,6 @@ class AWS0ClientTest extends AgentTestRunner {
             "$Tags.PEER_PORT" server.address.port
             "$Tags.HTTP_URL" "${server.address}${path}"
             "$Tags.HTTP_METHOD" "$method"
-            "$Tags.HTTP_STATUS" 200
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test_before_1_11_106/groovy/AWS0ClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test_before_1_11_106/groovy/AWS0ClientTest.groovy
@@ -104,7 +104,6 @@ class AWS0ClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.HTTP_URL" "$server.address/"
             "$Tags.HTTP_METHOD" "$method"
-            "$Tags.PEER_PORT" server.address.port
             "$Tags.PEER_HOSTNAME" "localhost"
             "aws.service" { it.contains(service) }
             "aws.endpoint" "$server.address"
@@ -114,6 +113,10 @@ class AWS0ClientTest extends AgentTestRunner {
               "$addedTag.key" "$addedTag.value"
             }
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" server.address.port
+            defaultMetrics()
           }
         }
         span {
@@ -127,10 +130,13 @@ class AWS0ClientTest extends AgentTestRunner {
             "$Tags.COMPONENT" "apache-httpclient"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "localhost"
-            "$Tags.PEER_PORT" server.address.port
             "$Tags.HTTP_URL" "${server.address}${path}"
             "$Tags.HTTP_METHOD" "$method"
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" server.address.port
+            defaultMetrics()
           }
         }
       }
@@ -182,7 +188,6 @@ class AWS0ClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.HTTP_URL" "http://localhost:${UNUSABLE_PORT}/"
             "$Tags.HTTP_METHOD" "$method"
-            "$Tags.PEER_PORT" 61
             "$Tags.PEER_HOSTNAME" "localhost"
             "aws.service" { it.contains(service) }
             "aws.endpoint" "http://localhost:${UNUSABLE_PORT}"
@@ -193,6 +198,10 @@ class AWS0ClientTest extends AgentTestRunner {
             }
             errorTags AmazonClientException, ~/Unable to execute HTTP request/
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" 61
+            defaultMetrics()
           }
         }
         span {
@@ -205,11 +214,14 @@ class AWS0ClientTest extends AgentTestRunner {
             "$Tags.COMPONENT" "apache-httpclient"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "localhost"
-            "$Tags.PEER_PORT" UNUSABLE_PORT
             "$Tags.HTTP_URL" "http://localhost:${UNUSABLE_PORT}/$url"
             "$Tags.HTTP_METHOD" "$method"
             errorTags HttpHostConnectException, ~/Connection refused/
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" UNUSABLE_PORT
+            defaultMetrics()
           }
         }
       }
@@ -298,7 +310,6 @@ class AWS0ClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.HTTP_URL" "$server.address/"
             "$Tags.HTTP_METHOD" "GET"
-            "$Tags.PEER_PORT" server.address.port
             "$Tags.PEER_HOSTNAME" "localhost"
             "aws.service" "Amazon S3"
             "aws.endpoint" "http://localhost:$server.address.port"
@@ -307,6 +318,10 @@ class AWS0ClientTest extends AgentTestRunner {
             "aws.bucket.name" "someBucket"
             errorTags AmazonClientException, ~/Unable to execute HTTP request/
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" server.address.port
+            defaultMetrics()
           }
         }
         (1..4).each {
@@ -320,7 +335,6 @@ class AWS0ClientTest extends AgentTestRunner {
               "$Tags.COMPONENT" "apache-httpclient"
               "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
               "$Tags.PEER_HOSTNAME" "localhost"
-              "$Tags.PEER_PORT" server.address.port
               "$Tags.HTTP_URL" "$server.address/someBucket/someKey"
               "$Tags.HTTP_METHOD" "GET"
               try {
@@ -329,6 +343,10 @@ class AWS0ClientTest extends AgentTestRunner {
                 errorTags RequestAbortedException, "Request aborted"
               }
               defaultTags()
+            }
+            metrics {
+              "$Tags.PEER_PORT" server.address.port
+              defaultMetrics()
             }
           }
         }

--- a/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/test/groovy/Aws2ClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/test/groovy/Aws2ClientTest.groovy
@@ -96,6 +96,7 @@ class Aws2ClientTest extends AgentTestRunner {
           spanType DDSpanTypes.HTTP_CLIENT
           errored false
           parent()
+          statusCode 200
           tags {
             "$Tags.COMPONENT" "java-aws-sdk"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -103,7 +104,6 @@ class Aws2ClientTest extends AgentTestRunner {
             "$Tags.PEER_PORT" server.address.port
             "$Tags.HTTP_URL" "${server.address}${path}"
             "$Tags.HTTP_METHOD" "$method"
-            "$Tags.HTTP_STATUS" 200
             "aws.service" "$service"
             "aws.operation" "${operation}"
             "aws.agent" "java-aws-sdk"
@@ -128,6 +128,7 @@ class Aws2ClientTest extends AgentTestRunner {
           spanType DDSpanTypes.HTTP_CLIENT
           errored false
           childOf(span(0))
+          statusCode 200
           tags {
             "$Tags.COMPONENT" "apache-httpclient"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -135,7 +136,6 @@ class Aws2ClientTest extends AgentTestRunner {
             "$Tags.PEER_PORT" server.address.port
             "$Tags.HTTP_URL" "${server.address}${path}"
             "$Tags.HTTP_METHOD" "$method"
-            "$Tags.HTTP_STATUS" 200
             defaultTags()
           }
         }
@@ -210,6 +210,7 @@ class Aws2ClientTest extends AgentTestRunner {
           spanType DDSpanTypes.HTTP_CLIENT
           errored false
           parent()
+          statusCode 200
           tags {
             "$Tags.COMPONENT" "java-aws-sdk"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -217,7 +218,6 @@ class Aws2ClientTest extends AgentTestRunner {
             "$Tags.PEER_PORT" server.address.port
             "$Tags.HTTP_URL" "${server.address}${path}"
             "$Tags.HTTP_METHOD" "$method"
-            "$Tags.HTTP_STATUS" 200
             "aws.service" "$service"
             "aws.operation" "${operation}"
             "aws.agent" "java-aws-sdk"
@@ -245,6 +245,7 @@ class Aws2ClientTest extends AgentTestRunner {
           spanType DDSpanTypes.HTTP_CLIENT
           errored false
           parent()
+          statusCode 200
           tags {
             "$Tags.COMPONENT" "netty-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -253,7 +254,6 @@ class Aws2ClientTest extends AgentTestRunner {
             "$Tags.PEER_PORT" server.address.port
             "$Tags.HTTP_URL" "${server.address}${path}"
             "$Tags.HTTP_METHOD" "$method"
-            "$Tags.HTTP_STATUS" 200
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/test/groovy/Aws2ClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/test/groovy/Aws2ClientTest.groovy
@@ -101,7 +101,6 @@ class Aws2ClientTest extends AgentTestRunner {
             "$Tags.COMPONENT" "java-aws-sdk"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "localhost"
-            "$Tags.PEER_PORT" server.address.port
             "$Tags.HTTP_URL" "${server.address}${path}"
             "$Tags.HTTP_METHOD" "$method"
             "aws.service" "$service"
@@ -121,6 +120,10 @@ class Aws2ClientTest extends AgentTestRunner {
             }
             defaultTags()
           }
+          metrics {
+            "$Tags.PEER_PORT" server.address.port
+            defaultMetrics()
+          }
         }
         span {
           operationName "http.request"
@@ -133,10 +136,13 @@ class Aws2ClientTest extends AgentTestRunner {
             "$Tags.COMPONENT" "apache-httpclient"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "localhost"
-            "$Tags.PEER_PORT" server.address.port
             "$Tags.HTTP_URL" "${server.address}${path}"
             "$Tags.HTTP_METHOD" "$method"
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" server.address.port
+            defaultMetrics()
           }
         }
       }
@@ -215,7 +221,6 @@ class Aws2ClientTest extends AgentTestRunner {
             "$Tags.COMPONENT" "java-aws-sdk"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "localhost"
-            "$Tags.PEER_PORT" server.address.port
             "$Tags.HTTP_URL" "${server.address}${path}"
             "$Tags.HTTP_METHOD" "$method"
             "aws.service" "$service"
@@ -235,6 +240,10 @@ class Aws2ClientTest extends AgentTestRunner {
             }
             defaultTags()
           }
+          metrics {
+            "$Tags.PEER_PORT" server.address.port
+            defaultMetrics()
+          }
         }
       }
       // TODO: this should be part of the same trace but netty instrumentation doesn't cooperate
@@ -251,10 +260,13 @@ class Aws2ClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "localhost"
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-            "$Tags.PEER_PORT" server.address.port
             "$Tags.HTTP_URL" "${server.address}${path}"
             "$Tags.HTTP_METHOD" "$method"
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" server.address.port
+            defaultMetrics()
           }
         }
       }
@@ -335,7 +347,6 @@ class Aws2ClientTest extends AgentTestRunner {
             "$Tags.COMPONENT" "java-aws-sdk"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "localhost"
-            "$Tags.PEER_PORT" server.address.port
             "$Tags.HTTP_URL" "$server.address/somebucket/somekey"
             "$Tags.HTTP_METHOD" "GET"
             "aws.service" "S3"
@@ -344,6 +355,10 @@ class Aws2ClientTest extends AgentTestRunner {
             "aws.bucket.name" "somebucket"
             errorTags SdkClientException, "Unable to execute HTTP request: Read timed out"
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" server.address.port
+            defaultMetrics()
           }
         }
         (1..4).each {
@@ -357,11 +372,14 @@ class Aws2ClientTest extends AgentTestRunner {
               "$Tags.COMPONENT" "apache-httpclient"
               "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
               "$Tags.PEER_HOSTNAME" "localhost"
-              "$Tags.PEER_PORT" server.address.port
               "$Tags.HTTP_URL" "$server.address/somebucket/somekey"
               "$Tags.HTTP_METHOD" "GET"
               errorTags SocketTimeoutException, "Read timed out"
               defaultTags()
+            }
+            metrics {
+              "$Tags.PEER_PORT" server.address.port
+              defaultMetrics()
             }
           }
         }

--- a/dd-java-agent/instrumentation/couchbase-2.6/src/test/groovy/CouchbaseSpanUtil.groovy
+++ b/dd-java-agent/instrumentation/couchbase-2.6/src/test/groovy/CouchbaseSpanUtil.groovy
@@ -24,7 +24,6 @@ class CouchbaseSpanUtil {
 
         // Because of caching, not all requests hit the server so these tags may be absent
         "$Tags.PEER_HOSTNAME" { it == "localhost" || it == "127.0.0.1" || it == null }
-        "$Tags.PEER_PORT" { it == null || Number }
 
         "$Tags.DB_TYPE" "couchbase"
         if (bucketName != null) {
@@ -39,6 +38,10 @@ class CouchbaseSpanUtil {
         // that do have operation ids
         "couchbase.operation_id" { it == null || String }
         defaultTags()
+      }
+      metrics {
+        "$Tags.PEER_PORT" { it == null || Number }
+        defaultMetrics()
       }
     }
   }

--- a/dd-java-agent/instrumentation/datastax-cassandra-3/src/test/groovy/CassandraClientTest.groovy
+++ b/dd-java-agent/instrumentation/datastax-cassandra-3/src/test/groovy/CassandraClientTest.groovy
@@ -150,10 +150,13 @@ class CassandraClientTest extends AgentTestRunner {
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
         "$Tags.PEER_HOSTNAME" "localhost"
         "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-        "$Tags.PEER_PORT" port
         "$Tags.DB_TYPE" "cassandra"
         "$Tags.DB_INSTANCE" keyspace
         defaultTags()
+      }
+      metrics {
+        "$Tags.PEER_PORT" port
+        defaultMetrics()
       }
     }
   }

--- a/dd-java-agent/instrumentation/datastax-cassandra-4/src/test/groovy/CassandraClientTest.groovy
+++ b/dd-java-agent/instrumentation/datastax-cassandra-4/src/test/groovy/CassandraClientTest.groovy
@@ -228,7 +228,6 @@ class CassandraClientTest extends AgentTestRunner {
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
         "$Tags.PEER_HOSTNAME" "localhost"
         "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-        "$Tags.PEER_PORT" port
         "$Tags.DB_TYPE" "cassandra"
         "$Tags.DB_INSTANCE" keyspace
 
@@ -236,6 +235,10 @@ class CassandraClientTest extends AgentTestRunner {
           errorTags(throwable)
         }
         defaultTags()
+      }
+      metrics {
+        "$Tags.PEER_PORT" port
+        defaultMetrics()
       }
     }
   }

--- a/dd-java-agent/instrumentation/dropwizard/src/test/groovy/DropwizardTest.groovy
+++ b/dd-java-agent/instrumentation/dropwizard/src/test/groovy/DropwizardTest.groovy
@@ -135,7 +135,6 @@ class DropwizardTest extends HttpServerTest<DropwizardTestSupport> {
         "$Tags.COMPONENT" component
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
         "$Tags.PEER_HOST_IPV4" { it == (endpoint == FORWARDED ? endpoint.body : "127.0.0.1") }
-        "$Tags.PEER_PORT" Integer
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
         "$Tags.HTTP_ROUTE" "/${endpoint.rawPath()}"
@@ -151,6 +150,10 @@ class DropwizardTest extends HttpServerTest<DropwizardTestSupport> {
           "$DDTags.HTTP_QUERY" endpoint.query
         }
         defaultTags(true)
+      }
+      metrics {
+        "$Tags.PEER_PORT" Integer
+        defaultMetrics()
       }
     }
   }

--- a/dd-java-agent/instrumentation/dropwizard/src/test/groovy/DropwizardTest.groovy
+++ b/dd-java-agent/instrumentation/dropwizard/src/test/groovy/DropwizardTest.groovy
@@ -130,6 +130,7 @@ class DropwizardTest extends HttpServerTest<DropwizardTestSupport> {
       } else {
         parent()
       }
+      statusCode endpoint.status
       tags {
         "$Tags.COMPONENT" component
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
@@ -138,7 +139,6 @@ class DropwizardTest extends HttpServerTest<DropwizardTestSupport> {
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
         "$Tags.HTTP_ROUTE" "/${endpoint.rawPath()}"
-        "$Tags.HTTP_STATUS" endpoint.status
         if (endpoint == FORWARDED) {
           "$Tags.HTTP_FORWARDED_IP" endpoint.body
         }

--- a/dd-java-agent/instrumentation/elasticsearch/rest-5/src/latestDepTest/groovy/Elasticsearch6RestClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/rest-5/src/latestDepTest/groovy/Elasticsearch6RestClientTest.groovy
@@ -86,11 +86,14 @@ class Elasticsearch6RestClientTest extends AgentTestRunner {
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" httpTransportAddress.address
-            "$Tags.PEER_PORT" httpTransportAddress.port
             "$Tags.HTTP_URL" "_cluster/health"
             "$Tags.HTTP_METHOD" "GET"
             "$Tags.DB_TYPE" "elasticsearch"
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" httpTransportAddress.port
+            defaultMetrics()
           }
         }
         span {

--- a/dd-java-agent/instrumentation/elasticsearch/rest-5/src/latestDepTest/groovy/Elasticsearch6RestClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/rest-5/src/latestDepTest/groovy/Elasticsearch6RestClientTest.groovy
@@ -99,12 +99,12 @@ class Elasticsearch6RestClientTest extends AgentTestRunner {
           operationName "http.request"
           spanType DDSpanTypes.HTTP_CLIENT
           childOf span(0)
+          statusCode 200
           tags {
             "$Tags.COMPONENT" "apache-httpasyncclient"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.HTTP_URL" "_cluster/health"
             "$Tags.HTTP_METHOD" "GET"
-            "$Tags.HTTP_STATUS" 200
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/elasticsearch/rest-5/src/test/groovy/Elasticsearch5RestClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/rest-5/src/test/groovy/Elasticsearch5RestClientTest.groovy
@@ -91,11 +91,14 @@ class Elasticsearch5RestClientTest extends AgentTestRunner {
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" httpTransportAddress.address
-            "$Tags.PEER_PORT" httpTransportAddress.port
             "$Tags.HTTP_URL" "_cluster/health"
             "$Tags.HTTP_METHOD" "GET"
             "$Tags.DB_TYPE" "elasticsearch"
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" httpTransportAddress.port
+            defaultMetrics()
           }
         }
         span {

--- a/dd-java-agent/instrumentation/elasticsearch/rest-5/src/test/groovy/Elasticsearch5RestClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/rest-5/src/test/groovy/Elasticsearch5RestClientTest.groovy
@@ -104,12 +104,12 @@ class Elasticsearch5RestClientTest extends AgentTestRunner {
           operationName "http.request"
           spanType DDSpanTypes.HTTP_CLIENT
           childOf span(0)
+          statusCode 200
           tags {
             "$Tags.COMPONENT" "apache-httpasyncclient"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.HTTP_URL" "_cluster/health"
             "$Tags.HTTP_METHOD" "GET"
-            "$Tags.HTTP_STATUS" 200
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/elasticsearch/rest-6.4/src/latestDepTest/groovy/Elasticsearch6RestClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/rest-6.4/src/latestDepTest/groovy/Elasticsearch6RestClientTest.groovy
@@ -91,11 +91,14 @@ class Elasticsearch6RestClientTest extends AgentTestRunner {
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" httpTransportAddress.address
-            "$Tags.PEER_PORT" httpTransportAddress.port
             "$Tags.HTTP_URL" "_cluster/health"
             "$Tags.HTTP_METHOD" "GET"
             "$Tags.DB_TYPE" "elasticsearch"
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" httpTransportAddress.port
+            defaultMetrics()
           }
         }
         span {

--- a/dd-java-agent/instrumentation/elasticsearch/rest-6.4/src/latestDepTest/groovy/Elasticsearch6RestClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/rest-6.4/src/latestDepTest/groovy/Elasticsearch6RestClientTest.groovy
@@ -104,12 +104,12 @@ class Elasticsearch6RestClientTest extends AgentTestRunner {
           operationName "http.request"
           spanType DDSpanTypes.HTTP_CLIENT
           childOf span(0)
+          statusCode 200
           tags {
             "$Tags.COMPONENT" "apache-httpasyncclient"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.HTTP_URL" "_cluster/health"
             "$Tags.HTTP_METHOD" "GET"
-            "$Tags.HTTP_STATUS" 200
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/elasticsearch/rest-6.4/src/test/groovy/Elasticsearch6RestClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/rest-6.4/src/test/groovy/Elasticsearch6RestClientTest.groovy
@@ -86,11 +86,14 @@ class Elasticsearch6RestClientTest extends AgentTestRunner {
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" httpTransportAddress.address
-            "$Tags.PEER_PORT" httpTransportAddress.port
             "$Tags.HTTP_URL" "_cluster/health"
             "$Tags.HTTP_METHOD" "GET"
             "$Tags.DB_TYPE" "elasticsearch"
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" httpTransportAddress.port
+            defaultMetrics()
           }
         }
         span {

--- a/dd-java-agent/instrumentation/elasticsearch/rest-6.4/src/test/groovy/Elasticsearch6RestClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/rest-6.4/src/test/groovy/Elasticsearch6RestClientTest.groovy
@@ -99,12 +99,12 @@ class Elasticsearch6RestClientTest extends AgentTestRunner {
           operationName "http.request"
           spanType DDSpanTypes.HTTP_CLIENT
           childOf span(0)
+          statusCode 200
           tags {
             "$Tags.COMPONENT" "apache-httpasyncclient"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.HTTP_URL" "_cluster/health"
             "$Tags.HTTP_METHOD" "GET"
-            "$Tags.HTTP_STATUS" 200
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/elasticsearch/rest-7/src/test/groovy/Elasticsearch7RestClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/rest-7/src/test/groovy/Elasticsearch7RestClientTest.groovy
@@ -90,11 +90,14 @@ class Elasticsearch7RestClientTest extends AgentTestRunner {
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" httpTransportAddress.address
-            "$Tags.PEER_PORT" httpTransportAddress.port
             "$Tags.HTTP_URL" "_cluster/health"
             "$Tags.HTTP_METHOD" "GET"
             "$Tags.DB_TYPE" "elasticsearch"
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" httpTransportAddress.port
+            defaultMetrics()
           }
         }
         span {

--- a/dd-java-agent/instrumentation/elasticsearch/rest-7/src/test/groovy/Elasticsearch7RestClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/rest-7/src/test/groovy/Elasticsearch7RestClientTest.groovy
@@ -103,12 +103,12 @@ class Elasticsearch7RestClientTest extends AgentTestRunner {
           operationName "http.request"
           spanType DDSpanTypes.HTTP_CLIENT
           childOf span(0)
+          statusCode 200
           tags {
             "$Tags.COMPONENT" "apache-httpasyncclient"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.HTTP_URL" "_cluster/health"
             "$Tags.HTTP_METHOD" "GET"
-            "$Tags.HTTP_STATUS" 200
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/Elasticsearch2TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/Elasticsearch2TransportClientTest.groovy
@@ -90,11 +90,14 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" tcpPublishAddress.host
             "$Tags.PEER_HOST_IPV4" tcpPublishAddress.address
-            "$Tags.PEER_PORT" tcpPublishAddress.port
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" tcpPublishAddress.port
+            defaultMetrics()
           }
         }
       }
@@ -187,12 +190,15 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" tcpPublishAddress.host
             "$Tags.PEER_HOST_IPV4" tcpPublishAddress.address
-            "$Tags.PEER_PORT" tcpPublishAddress.port
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "CreateIndexAction"
             "elasticsearch.request" "CreateIndexRequest"
             "elasticsearch.request.indices" indexName
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" tcpPublishAddress.port
+            defaultMetrics()
           }
         }
       }
@@ -207,11 +213,14 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" tcpPublishAddress.host
             "$Tags.PEER_HOST_IPV4" tcpPublishAddress.address
-            "$Tags.PEER_PORT" tcpPublishAddress.port
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" tcpPublishAddress.port
+            defaultMetrics()
           }
         }
       }
@@ -226,15 +235,18 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" tcpPublishAddress.host
             "$Tags.PEER_HOST_IPV4" tcpPublishAddress.address
-            "$Tags.PEER_PORT" tcpPublishAddress.port
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
             "elasticsearch.type" indexType
             "elasticsearch.id" "1"
-            "elasticsearch.version"(-1)
             defaultTags()
+          }
+          metrics {
+            "elasticsearch.version"(-1)
+            "$Tags.PEER_PORT" tcpPublishAddress.port
+            defaultMetrics()
           }
         }
       }
@@ -249,13 +261,16 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" tcpPublishAddress.host
             "$Tags.PEER_HOST_IPV4" tcpPublishAddress.address
-            "$Tags.PEER_PORT" tcpPublishAddress.port
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
             "elasticsearch.request.write.type" indexType
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" tcpPublishAddress.port
+            defaultMetrics()
           }
         }
       }
@@ -287,15 +302,18 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" tcpPublishAddress.host
             "$Tags.PEER_HOST_IPV4" tcpPublishAddress.address
-            "$Tags.PEER_PORT" tcpPublishAddress.port
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
             "elasticsearch.type" indexType
             "elasticsearch.id" "1"
-            "elasticsearch.version" 1
             defaultTags()
+          }
+          metrics {
+            "elasticsearch.version" 1
+            "$Tags.PEER_PORT" tcpPublishAddress.port
+            defaultMetrics()
           }
         }
       }

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/Elasticsearch2NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/Elasticsearch2NodeClientTest.groovy
@@ -208,8 +208,11 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
             "elasticsearch.request.indices" indexName
             "elasticsearch.type" indexType
             "elasticsearch.id" "1"
-            "elasticsearch.version"(-1)
             defaultTags()
+          }
+          metrics {
+            "elasticsearch.version"(-1)
+            defaultMetrics()
           }
         }
       }
@@ -267,8 +270,11 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
             "elasticsearch.request.indices" indexName
             "elasticsearch.type" indexType
             "elasticsearch.id" "1"
-            "elasticsearch.version" 1
             defaultTags()
+          }
+          metrics {
+            "elasticsearch.version" 1
+            defaultMetrics()
           }
         }
       }

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/Elasticsearch2TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/Elasticsearch2TransportClientTest.groovy
@@ -92,11 +92,14 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" tcpPublishAddress.host
             "$Tags.PEER_HOST_IPV4" tcpPublishAddress.address
-            "$Tags.PEER_PORT" tcpPublishAddress.port
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" tcpPublishAddress.port
+            defaultMetrics()
           }
         }
       }
@@ -126,12 +129,15 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" tcpPublishAddress.host
             "$Tags.PEER_HOST_IPV4" tcpPublishAddress.address
-            "$Tags.PEER_PORT" tcpPublishAddress.port
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "ClusterStatsAction"
             "elasticsearch.request" "ClusterStatsRequest"
             "elasticsearch.node.cluster.name" clusterName
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" tcpPublishAddress.port
+            defaultMetrics()
           }
         }
       }
@@ -224,12 +230,15 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" tcpPublishAddress.host
             "$Tags.PEER_HOST_IPV4" tcpPublishAddress.address
-            "$Tags.PEER_PORT" tcpPublishAddress.port
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "CreateIndexAction"
             "elasticsearch.request" "CreateIndexRequest"
             "elasticsearch.request.indices" indexName
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" tcpPublishAddress.port
+            defaultMetrics()
           }
         }
       }
@@ -244,11 +253,14 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" tcpPublishAddress.host
             "$Tags.PEER_HOST_IPV4" tcpPublishAddress.address
-            "$Tags.PEER_PORT" tcpPublishAddress.port
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" tcpPublishAddress.port
+            defaultMetrics()
           }
         }
       }
@@ -263,15 +275,18 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" tcpPublishAddress.host
             "$Tags.PEER_HOST_IPV4" tcpPublishAddress.address
-            "$Tags.PEER_PORT" tcpPublishAddress.port
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
             "elasticsearch.type" indexType
             "elasticsearch.id" "1"
-            "elasticsearch.version"(-1)
             defaultTags()
+          }
+          metrics {
+            "elasticsearch.version"(-1)
+            "$Tags.PEER_PORT" tcpPublishAddress.port
+            defaultMetrics()
           }
         }
       }
@@ -286,13 +301,16 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" tcpPublishAddress.host
             "$Tags.PEER_HOST_IPV4" tcpPublishAddress.address
-            "$Tags.PEER_PORT" tcpPublishAddress.port
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
             "elasticsearch.request.write.type" indexType
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" tcpPublishAddress.port
+            defaultMetrics()
           }
         }
       }
@@ -324,15 +342,18 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" tcpPublishAddress.host
             "$Tags.PEER_HOST_IPV4" tcpPublishAddress.address
-            "$Tags.PEER_PORT" tcpPublishAddress.port
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
             "elasticsearch.type" indexType
             "elasticsearch.id" "1"
-            "elasticsearch.version" 1
             defaultTags()
+          }
+          metrics {
+            "elasticsearch.version" 1
+            "$Tags.PEER_PORT" tcpPublishAddress.port
+            defaultMetrics()
           }
         }
       }

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/springdata/Elasticsearch2SpringRepositoryTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/springdata/Elasticsearch2SpringRepositoryTest.groovy
@@ -107,10 +107,13 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
             "elasticsearch.action" "RefreshAction"
             "elasticsearch.request" "RefreshRequest"
             "elasticsearch.request.indices" indexName
+            defaultTags()
+          }
+          metrics {
             "elasticsearch.shard.broadcast.failed" 0
             "elasticsearch.shard.broadcast.successful" 5
             "elasticsearch.shard.broadcast.total" 10
-            defaultTags()
+            defaultMetrics()
           }
         }
       }
@@ -187,10 +190,13 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
             "elasticsearch.action" "RefreshAction"
             "elasticsearch.request" "RefreshRequest"
             "elasticsearch.request.indices" indexName
+            defaultTags()
+          }
+          metrics {
             "elasticsearch.shard.broadcast.failed" 0
             "elasticsearch.shard.broadcast.successful" 5
             "elasticsearch.shard.broadcast.total" 10
-            defaultTags()
+            defaultMetrics()
           }
         }
       }
@@ -211,8 +217,11 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
             "elasticsearch.request.indices" indexName
             "elasticsearch.type" "doc"
             "elasticsearch.id" "1"
-            "elasticsearch.version" Number
             defaultTags()
+          }
+          metrics {
+            "elasticsearch.version" Number
+            defaultMetrics()
           }
         }
       }
@@ -258,10 +267,13 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
             "elasticsearch.action" "RefreshAction"
             "elasticsearch.request" "RefreshRequest"
             "elasticsearch.request.indices" indexName
+            defaultTags()
+          }
+          metrics {
             "elasticsearch.shard.broadcast.failed" 0
             "elasticsearch.shard.broadcast.successful" 5
             "elasticsearch.shard.broadcast.total" 10
-            defaultTags()
+            defaultMetrics()
           }
         }
       }

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
@@ -227,10 +227,13 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
             "elasticsearch.action" "RefreshAction"
             "elasticsearch.request" "RefreshRequest"
             "elasticsearch.request.indices" indexName
+            defaultTags()
+          }
+          metrics {
             "elasticsearch.shard.broadcast.failed" 0
             "elasticsearch.shard.broadcast.successful" 5
             "elasticsearch.shard.broadcast.total" 10
-            defaultTags()
+            defaultMetrics()
           }
         }
       }

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/Elasticsearch53NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/Elasticsearch53NodeClientTest.groovy
@@ -213,8 +213,11 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
             "elasticsearch.request.indices" indexName
             "elasticsearch.type" indexType
             "elasticsearch.id" "1"
-            "elasticsearch.version"(-1)
             defaultTags()
+          }
+          metrics {
+            "elasticsearch.version"(-1)
+            defaultMetrics()
           }
         }
       }
@@ -232,12 +235,15 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
             "elasticsearch.request.write.type" indexType
+            defaultTags()
+          }
+          metrics {
             "elasticsearch.request.write.version"(-3)
             "elasticsearch.response.status" 201
             "elasticsearch.shard.replication.total" 2
             "elasticsearch.shard.replication.successful" 1
             "elasticsearch.shard.replication.failed" 0
-            defaultTags()
+            defaultMetrics()
           }
         }
       }
@@ -272,8 +278,11 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
             "elasticsearch.request.indices" indexName
             "elasticsearch.type" indexType
             "elasticsearch.id" "1"
-            "elasticsearch.version" 1
             defaultTags()
+          }
+          metrics {
+            "elasticsearch.version" 1
+            defaultMetrics()
           }
         }
       }

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/Elasticsearch53TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/Elasticsearch53TransportClientTest.groovy
@@ -98,11 +98,14 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" tcpPublishAddress.host
             "$Tags.PEER_HOST_IPV4" tcpPublishAddress.address
-            "$Tags.PEER_PORT" tcpPublishAddress.port
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" tcpPublishAddress.port
+            defaultMetrics()
           }
         }
       }
@@ -195,12 +198,15 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" tcpPublishAddress.host
             "$Tags.PEER_HOST_IPV4" tcpPublishAddress.address
-            "$Tags.PEER_PORT" tcpPublishAddress.port
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "CreateIndexAction"
             "elasticsearch.request" "CreateIndexRequest"
             "elasticsearch.request.indices" indexName
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" tcpPublishAddress.port
+            defaultMetrics()
           }
         }
       }
@@ -215,15 +221,18 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" tcpPublishAddress.host
             "$Tags.PEER_HOST_IPV4" tcpPublishAddress.address
-            "$Tags.PEER_PORT" tcpPublishAddress.port
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
             "elasticsearch.type" indexType
             "elasticsearch.id" "1"
-            "elasticsearch.version"(-1)
             defaultTags()
+          }
+          metrics {
+            "elasticsearch.version" -1
+            "$Tags.PEER_PORT" tcpPublishAddress.port
+            defaultMetrics()
           }
         }
       }
@@ -238,18 +247,21 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" tcpPublishAddress.host
             "$Tags.PEER_HOST_IPV4" tcpPublishAddress.address
-            "$Tags.PEER_PORT" tcpPublishAddress.port
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
             "elasticsearch.request.write.type" indexType
+            defaultTags()
+          }
+          metrics {
             "elasticsearch.request.write.version"(-3)
             "elasticsearch.response.status" 201
             "elasticsearch.shard.replication.total" 2
             "elasticsearch.shard.replication.successful" 1
             "elasticsearch.shard.replication.failed" 0
-            defaultTags()
+            "$Tags.PEER_PORT" tcpPublishAddress.port
+            defaultMetrics()
           }
         }
       }
@@ -280,15 +292,18 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" tcpPublishAddress.host
             "$Tags.PEER_HOST_IPV4" tcpPublishAddress.address
-            "$Tags.PEER_PORT" tcpPublishAddress.port
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
             "elasticsearch.type" indexType
             "elasticsearch.id" "1"
-            "elasticsearch.version" 1
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" tcpPublishAddress.port
+            "elasticsearch.version" 1
+            defaultMetrics()
           }
         }
       }

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/Elasticsearch53TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/Elasticsearch53TransportClientTest.groovy
@@ -230,7 +230,7 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
             defaultTags()
           }
           metrics {
-            "elasticsearch.version" -1
+            "elasticsearch.version"(-1)
             "$Tags.PEER_PORT" tcpPublishAddress.port
             defaultMetrics()
           }

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/springdata/Elasticsearch53SpringRepositoryTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/springdata/Elasticsearch53SpringRepositoryTest.groovy
@@ -152,12 +152,15 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
             "elasticsearch.request.write.type" "doc"
+            defaultTags()
+          }
+          metrics {
             "elasticsearch.request.write.version"(-3)
             "elasticsearch.response.status" 201
             "elasticsearch.shard.replication.failed" 0
             "elasticsearch.shard.replication.successful" 1
             "elasticsearch.shard.replication.total" 2
-            defaultTags()
+            defaultMetrics()
           }
         }
         span {
@@ -172,10 +175,13 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
             "elasticsearch.action" "RefreshAction"
             "elasticsearch.request" "RefreshRequest"
             "elasticsearch.request.indices" indexName
+            defaultTags()
+          }
+          metrics {
             "elasticsearch.shard.broadcast.failed" 0
             "elasticsearch.shard.broadcast.successful" 5
             "elasticsearch.shard.broadcast.total" 10
-            defaultTags()
+            defaultMetrics()
           }
         }
       }
@@ -230,8 +236,11 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
             "elasticsearch.request.indices" indexName
             "elasticsearch.type" "doc"
             "elasticsearch.id" "1"
-            "elasticsearch.version" Number
             defaultTags()
+          }
+          metrics {
+            "elasticsearch.version" Number
+            defaultMetrics()
           }
         }
       }
@@ -271,12 +280,15 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
             "elasticsearch.request.write.type" "doc"
+            defaultTags()
+          }
+          metrics {
             "elasticsearch.request.write.version"(-3)
             "elasticsearch.response.status" 200
             "elasticsearch.shard.replication.failed" 0
             "elasticsearch.shard.replication.successful" 1
             "elasticsearch.shard.replication.total" 2
-            defaultTags()
+            defaultMetrics()
           }
         }
         span {
@@ -291,10 +303,13 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
             "elasticsearch.action" "RefreshAction"
             "elasticsearch.request" "RefreshRequest"
             "elasticsearch.request.indices" indexName
+            defaultTags()
+          }
+          metrics {
             "elasticsearch.shard.broadcast.failed" 0
             "elasticsearch.shard.broadcast.successful" 5
             "elasticsearch.shard.broadcast.total" 10
-            defaultTags()
+            defaultMetrics()
           }
         }
       }
@@ -324,8 +339,11 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
             "elasticsearch.request.indices" indexName
             "elasticsearch.type" "doc"
             "elasticsearch.id" "1"
-            "elasticsearch.version" Number
             defaultTags()
+          }
+          metrics {
+            "elasticsearch.version" Number
+            defaultMetrics()
           }
         }
       }
@@ -364,11 +382,14 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
             "elasticsearch.request" "DeleteRequest"
             "elasticsearch.request.indices" indexName
             "elasticsearch.request.write.type" "doc"
+            defaultTags()
+          }
+          metrics {
             "elasticsearch.request.write.version"(-3)
             "elasticsearch.shard.replication.failed" 0
             "elasticsearch.shard.replication.successful" 1
             "elasticsearch.shard.replication.total" 2
-            defaultTags()
+            defaultMetrics()
           }
         }
         span {
@@ -383,10 +404,13 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
             "elasticsearch.action" "RefreshAction"
             "elasticsearch.request" "RefreshRequest"
             "elasticsearch.request.indices" indexName
+            defaultTags()
+          }
+          metrics {
             "elasticsearch.shard.broadcast.failed" 0
             "elasticsearch.shard.broadcast.successful" 5
             "elasticsearch.shard.broadcast.total" 10
-            defaultTags()
+            defaultMetrics()
           }
         }
       }

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/springdata/Elasticsearch53SpringTemplateTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/springdata/Elasticsearch53SpringTemplateTest.groovy
@@ -215,12 +215,15 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
             "elasticsearch.request.write.type" indexType
+            defaultTags()
+          }
+          metrics {
             "elasticsearch.request.write.version"(-3)
             "elasticsearch.response.status" 201
             "elasticsearch.shard.replication.failed" 0
             "elasticsearch.shard.replication.successful" 1
             "elasticsearch.shard.replication.total" 2
-            defaultTags()
+            defaultMetrics()
           }
         }
       }
@@ -253,10 +256,13 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
             "elasticsearch.action" "RefreshAction"
             "elasticsearch.request" "RefreshRequest"
             "elasticsearch.request.indices" indexName
+            defaultTags()
+          }
+          metrics {
             "elasticsearch.shard.broadcast.failed" 0
             "elasticsearch.shard.broadcast.successful" 5
             "elasticsearch.shard.broadcast.total" 10
-            defaultTags()
+            defaultMetrics()
           }
         }
       }

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5/src/test/groovy/Elasticsearch5NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5/src/test/groovy/Elasticsearch5NodeClientTest.groovy
@@ -213,8 +213,11 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
             "elasticsearch.request.indices" indexName
             "elasticsearch.type" indexType
             "elasticsearch.id" "1"
-            "elasticsearch.version"(-1)
             defaultTags()
+          }
+          metrics {
+            "elasticsearch.version"(-1)
+            defaultMetrics()
           }
         }
       }
@@ -232,11 +235,14 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
             "elasticsearch.request.write.type" indexType
+            defaultTags()
+          }
+          metrics {
             "elasticsearch.response.status" 201
             "elasticsearch.shard.replication.total" 2
             "elasticsearch.shard.replication.successful" 1
             "elasticsearch.shard.replication.failed" 0
-            defaultTags()
+            defaultMetrics()
           }
         }
       }
@@ -271,8 +277,11 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
             "elasticsearch.request.indices" indexName
             "elasticsearch.type" indexType
             "elasticsearch.id" "1"
-            "elasticsearch.version" 1
             defaultTags()
+          }
+          metrics {
+            "elasticsearch.version" 1
+            defaultMetrics()
           }
         }
       }

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5/src/test/groovy/Elasticsearch5TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5/src/test/groovy/Elasticsearch5TransportClientTest.groovy
@@ -226,10 +226,10 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
             "elasticsearch.request.indices" indexName
             "elasticsearch.type" indexType
             "elasticsearch.id" "1"
-            "elasticsearch.version"(-1)
             defaultTags()
           }
           metrics {
+            "elasticsearch.version"(-1)
             "$Tags.PEER_PORT" tcpPublishAddress.port
             defaultMetrics()
           }

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5/src/test/groovy/Elasticsearch5TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5/src/test/groovy/Elasticsearch5TransportClientTest.groovy
@@ -97,11 +97,14 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" String
             "$Tags.PEER_HOST_IPV4" tcpPublishAddress.address
-            "$Tags.PEER_PORT" tcpPublishAddress.port
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" tcpPublishAddress.port
+            defaultMetrics()
           }
         }
       }
@@ -194,12 +197,15 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" String
             "$Tags.PEER_HOST_IPV4" tcpPublishAddress.address
-            "$Tags.PEER_PORT" tcpPublishAddress.port
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "CreateIndexAction"
             "elasticsearch.request" "CreateIndexRequest"
             "elasticsearch.request.indices" indexName
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" tcpPublishAddress.port
+            defaultMetrics()
           }
         }
       }
@@ -214,7 +220,6 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" String
             "$Tags.PEER_HOST_IPV4" tcpPublishAddress.address
-            "$Tags.PEER_PORT" tcpPublishAddress.port
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
@@ -223,6 +228,10 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
             "elasticsearch.id" "1"
             "elasticsearch.version"(-1)
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" tcpPublishAddress.port
+            defaultMetrics()
           }
         }
       }
@@ -237,17 +246,20 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" String
             "$Tags.PEER_HOST_IPV4" tcpPublishAddress.address
-            "$Tags.PEER_PORT" tcpPublishAddress.port
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
             "elasticsearch.request.write.type" indexType
+            defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" tcpPublishAddress.port
             "elasticsearch.response.status" 201
             "elasticsearch.shard.replication.total" 2
             "elasticsearch.shard.replication.successful" 1
             "elasticsearch.shard.replication.failed" 0
-            defaultTags()
+            defaultMetrics()
           }
         }
       }
@@ -278,15 +290,18 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" String
             "$Tags.PEER_HOST_IPV4" tcpPublishAddress.address
-            "$Tags.PEER_PORT" tcpPublishAddress.port
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
             "elasticsearch.type" indexType
             "elasticsearch.id" "1"
-            "elasticsearch.version" 1
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" tcpPublishAddress.port
+            "elasticsearch.version" 1
+            defaultMetrics()
           }
         }
       }

--- a/dd-java-agent/instrumentation/elasticsearch/transport-6/src/test/groovy/Elasticsearch6NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-6/src/test/groovy/Elasticsearch6NodeClientTest.groovy
@@ -193,8 +193,11 @@ class Elasticsearch6NodeClientTest extends AgentTestRunner {
             "elasticsearch.request.indices" indexName
             "elasticsearch.type" indexType
             "elasticsearch.id" "1"
-            "elasticsearch.version"(-1)
             defaultTags()
+          }
+          metrics {
+            "elasticsearch.version"(-1)
+            defaultMetrics()
           }
         }
       }
@@ -212,12 +215,15 @@ class Elasticsearch6NodeClientTest extends AgentTestRunner {
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
             "elasticsearch.request.write.type" indexType
+            defaultTags()
+          }
+          metrics {
             "elasticsearch.request.write.version"(-3)
             "elasticsearch.response.status" 201
             "elasticsearch.shard.replication.total" 2
             "elasticsearch.shard.replication.successful" 1
             "elasticsearch.shard.replication.failed" 0
-            defaultTags()
+            defaultMetrics()
           }
         }
       }
@@ -252,8 +258,11 @@ class Elasticsearch6NodeClientTest extends AgentTestRunner {
             "elasticsearch.request.indices" indexName
             "elasticsearch.type" indexType
             "elasticsearch.id" "1"
-            "elasticsearch.version" 1
             defaultTags()
+          }
+          metrics {
+            "elasticsearch.version" 1
+            defaultMetrics()
           }
         }
       }

--- a/dd-java-agent/instrumentation/elasticsearch/transport-6/src/test/groovy/Elasticsearch6TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-6/src/test/groovy/Elasticsearch6TransportClientTest.groovy
@@ -93,11 +93,14 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "localhost"
             "$Tags.PEER_HOST_IPV4" tcpPublishAddress.address
-            "$Tags.PEER_PORT" tcpPublishAddress.port
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" tcpPublishAddress.port
+            defaultMetrics()
           }
         }
       }
@@ -190,12 +193,15 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "localhost"
             "$Tags.PEER_HOST_IPV4" tcpPublishAddress.address
-            "$Tags.PEER_PORT" tcpPublishAddress.port
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "CreateIndexAction"
             "elasticsearch.request" "CreateIndexRequest"
             "elasticsearch.request.indices" indexName
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" tcpPublishAddress.port
+            defaultMetrics()
           }
         }
       }
@@ -210,15 +216,18 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "localhost"
             "$Tags.PEER_HOST_IPV4" tcpPublishAddress.address
-            "$Tags.PEER_PORT" tcpPublishAddress.port
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
             "elasticsearch.type" indexType
             "elasticsearch.id" "1"
-            "elasticsearch.version"(-1)
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" tcpPublishAddress.port
+            "elasticsearch.version"(-1)
+            defaultMetrics()
           }
         }
       }
@@ -233,18 +242,21 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "localhost"
             "$Tags.PEER_HOST_IPV4" tcpPublishAddress.address
-            "$Tags.PEER_PORT" tcpPublishAddress.port
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
             "elasticsearch.request.write.type" indexType
+            defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" tcpPublishAddress.port
             "elasticsearch.request.write.version"(-3)
             "elasticsearch.response.status" 201
             "elasticsearch.shard.replication.total" 2
             "elasticsearch.shard.replication.successful" 1
             "elasticsearch.shard.replication.failed" 0
-            defaultTags()
+            defaultMetrics()
           }
         }
       }
@@ -275,15 +287,18 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "localhost"
             "$Tags.PEER_HOST_IPV4" tcpPublishAddress.address
-            "$Tags.PEER_PORT" tcpPublishAddress.port
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
             "elasticsearch.type" indexType
             "elasticsearch.id" "1"
-            "elasticsearch.version" 1
             defaultTags()
+          }
+          metrics {
+            "elasticsearch.version" 1
+            "$Tags.PEER_PORT" tcpPublishAddress.port
+            defaultMetrics()
           }
         }
       }

--- a/dd-java-agent/instrumentation/elasticsearch/transport-7.3/src/test/groovy/Elasticsearch73NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-7.3/src/test/groovy/Elasticsearch73NodeClientTest.groovy
@@ -200,8 +200,11 @@ class Elasticsearch73NodeClientTest extends AgentTestRunner {
             "elasticsearch.request.indices" indexName
             "elasticsearch.type" indexType
             "elasticsearch.id" "1"
-            "elasticsearch.version"(-1)
             defaultTags()
+          }
+          metrics {
+            "elasticsearch.version"(-1)
+            defaultMetrics()
           }
         }
       }
@@ -220,12 +223,15 @@ class Elasticsearch73NodeClientTest extends AgentTestRunner {
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
             "elasticsearch.request.write.type" indexType
+            defaultTags()
+          }
+          metrics {
             "elasticsearch.request.write.version"(-3)
             "elasticsearch.response.status" 201
             "elasticsearch.shard.replication.total" 2
             "elasticsearch.shard.replication.successful" 1
             "elasticsearch.shard.replication.failed" 0
-            defaultTags()
+            defaultMetrics()
           }
         }
       }
@@ -262,8 +268,11 @@ class Elasticsearch73NodeClientTest extends AgentTestRunner {
             "elasticsearch.request.indices" indexName
             "elasticsearch.type" indexType
             "elasticsearch.id" "1"
-            "elasticsearch.version" 1
             defaultTags()
+          }
+          metrics {
+            "elasticsearch.version" 1
+            defaultMetrics()
           }
         }
       }

--- a/dd-java-agent/instrumentation/elasticsearch/transport-7.3/src/test/groovy/Elasticsearch73TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-7.3/src/test/groovy/Elasticsearch73TransportClientTest.groovy
@@ -97,11 +97,14 @@ class Elasticsearch73TransportClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "localhost"
             "$Tags.PEER_HOST_IPV4" tcpPublishAddress.address
-            "$Tags.PEER_PORT" tcpPublishAddress.port
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" tcpPublishAddress.port
+            defaultMetrics()
           }
         }
       }
@@ -196,12 +199,15 @@ class Elasticsearch73TransportClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "localhost"
             "$Tags.PEER_HOST_IPV4" tcpPublishAddress.address
-            "$Tags.PEER_PORT" tcpPublishAddress.port
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "CreateIndexAction"
             "elasticsearch.request" "CreateIndexRequest"
             "elasticsearch.request.indices" indexName
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" tcpPublishAddress.port
+            defaultMetrics()
           }
         }
       }
@@ -217,15 +223,18 @@ class Elasticsearch73TransportClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "localhost"
             "$Tags.PEER_HOST_IPV4" tcpPublishAddress.address
-            "$Tags.PEER_PORT" tcpPublishAddress.port
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
             "elasticsearch.type" indexType
             "elasticsearch.id" "1"
-            "elasticsearch.version"(-1)
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" tcpPublishAddress.port
+            "elasticsearch.version"(-1)
+            defaultMetrics()
           }
         }
       }
@@ -241,18 +250,21 @@ class Elasticsearch73TransportClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "localhost"
             "$Tags.PEER_HOST_IPV4" tcpPublishAddress.address
-            "$Tags.PEER_PORT" tcpPublishAddress.port
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
             "elasticsearch.request.write.type" indexType
+            defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" tcpPublishAddress.port
             "elasticsearch.request.write.version"(-3)
             "elasticsearch.response.status" 201
             "elasticsearch.shard.replication.total" 2
             "elasticsearch.shard.replication.successful" 1
             "elasticsearch.shard.replication.failed" 0
-            defaultTags()
+            defaultMetrics()
           }
         }
       }
@@ -285,15 +297,18 @@ class Elasticsearch73TransportClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "localhost"
             "$Tags.PEER_HOST_IPV4" tcpPublishAddress.address
-            "$Tags.PEER_PORT" tcpPublishAddress.port
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
             "elasticsearch.type" indexType
             "elasticsearch.id" "1"
-            "elasticsearch.version" 1
             defaultTags()
+          }
+          metrics {
+            "elasticsearch.version" 1
+            "$Tags.PEER_PORT" tcpPublishAddress.port
+            defaultMetrics()
           }
         }
       }

--- a/dd-java-agent/instrumentation/glassfish/src/test/groovy/GlassFishServerTest.groovy
+++ b/dd-java-agent/instrumentation/glassfish/src/test/groovy/GlassFishServerTest.groovy
@@ -130,7 +130,6 @@ class GlassFishServerTest extends HttpServerTest<GlassFish> {
         "$Tags.COMPONENT" component
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
         "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-        "$Tags.PEER_PORT" Integer
         "$Tags.HTTP_METHOD" method
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         if (endpoint == FORWARDED) {
@@ -147,6 +146,10 @@ class GlassFishServerTest extends HttpServerTest<GlassFish> {
           "$DDTags.HTTP_QUERY" endpoint.query
         }
         defaultTags(true)
+      }
+      metrics {
+        "$Tags.PEER_PORT" Integer
+        defaultMetrics()
       }
     }
   }

--- a/dd-java-agent/instrumentation/glassfish/src/test/groovy/GlassFishServerTest.groovy
+++ b/dd-java-agent/instrumentation/glassfish/src/test/groovy/GlassFishServerTest.groovy
@@ -125,12 +125,12 @@ class GlassFishServerTest extends HttpServerTest<GlassFish> {
       } else {
         parent()
       }
+      statusCode endpoint.status
       tags {
         "$Tags.COMPONENT" component
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
         "$Tags.PEER_HOST_IPV4" "127.0.0.1"
         "$Tags.PEER_PORT" Integer
-        "$Tags.HTTP_STATUS" endpoint.status
         "$Tags.HTTP_METHOD" method
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         if (endpoint == FORWARDED) {

--- a/dd-java-agent/instrumentation/google-http-client/src/test/groovy/AbstractGoogleHttpClientTest.groovy
+++ b/dd-java-agent/instrumentation/google-http-client/src/test/groovy/AbstractGoogleHttpClientTest.groovy
@@ -69,7 +69,7 @@ abstract class AbstractGoogleHttpClientTest extends HttpClientTest {
           resourceName "$method $uri.path"
           spanType DDSpanTypes.HTTP_CLIENT
           errored true
-          statusCode Integer
+          statusCode { it != 0 }
           tags {
             "$Tags.COMPONENT" "google-http-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT

--- a/dd-java-agent/instrumentation/google-http-client/src/test/groovy/AbstractGoogleHttpClientTest.groovy
+++ b/dd-java-agent/instrumentation/google-http-client/src/test/groovy/AbstractGoogleHttpClientTest.groovy
@@ -74,11 +74,14 @@ abstract class AbstractGoogleHttpClientTest extends HttpClientTest {
             "$Tags.COMPONENT" "google-http-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "localhost"
-            "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_URL" String
             "$Tags.HTTP_METHOD" String
             "$DDTags.ERROR_MSG" "Server Error"
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" Integer
+            defaultMetrics()
           }
         }
       }

--- a/dd-java-agent/instrumentation/google-http-client/src/test/groovy/AbstractGoogleHttpClientTest.groovy
+++ b/dd-java-agent/instrumentation/google-http-client/src/test/groovy/AbstractGoogleHttpClientTest.groovy
@@ -69,6 +69,7 @@ abstract class AbstractGoogleHttpClientTest extends HttpClientTest {
           resourceName "$method $uri.path"
           spanType DDSpanTypes.HTTP_CLIENT
           errored true
+          statusCode Integer
           tags {
             "$Tags.COMPONENT" "google-http-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -76,7 +77,6 @@ abstract class AbstractGoogleHttpClientTest extends HttpClientTest {
             "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_URL" String
             "$Tags.HTTP_METHOD" String
-            "$Tags.HTTP_STATUS" Integer
             "$DDTags.ERROR_MSG" "Server Error"
             defaultTags()
           }

--- a/dd-java-agent/instrumentation/hazelcast-3.9/src/test/groovy/test/hazelcast/v39/AbstractHazelcastTest.groovy
+++ b/dd-java-agent/instrumentation/hazelcast-3.9/src/test/groovy/test/hazelcast/v39/AbstractHazelcastTest.groovy
@@ -100,8 +100,11 @@ abstract class AbstractHazelcastTest extends AgentTestRunner {
         "hazelcast.operation" matcher.group("operation")
         "hazelcast.service" matcher.group("service")
         "hazelcast.instance" client.name
-        "hazelcast.correlationId" Long
         defaultTags()
+      }
+      metrics {
+        "hazelcast.correlationId" Long
+        defaultMetrics()
       }
     }
   }

--- a/dd-java-agent/instrumentation/hazelcast-3.9/src/test/groovy/test/hazelcast/v39/HazelcastTest.groovy
+++ b/dd-java-agent/instrumentation/hazelcast-3.9/src/test/groovy/test/hazelcast/v39/HazelcastTest.groovy
@@ -246,9 +246,12 @@ class HazelcastTest extends AbstractHazelcastTest {
             "hazelcast.name" randomName
             "hazelcast.operation" "List.get"
             "hazelcast.instance" client.getName()
-            "hazelcast.correlationId" Long
             errorTags(ex)
             defaultTags()
+          }
+          metrics {
+            "hazelcast.correlationId" Long
+            defaultMetrics()
           }
         }
       }

--- a/dd-java-agent/instrumentation/hazelcast-4.0/src/test/groovy/test/hazelcast/v4/AbstractHazelcastTest.groovy
+++ b/dd-java-agent/instrumentation/hazelcast-4.0/src/test/groovy/test/hazelcast/v4/AbstractHazelcastTest.groovy
@@ -94,8 +94,11 @@ abstract class AbstractHazelcastTest extends AgentTestRunner {
           "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
           "hazelcast.operation" "Event.Handle"
           "hazelcast.service" "Event"
-          "hazelcast.correlationId" Long
           defaultTags()
+        }
+        metrics {
+          "hazelcast.correlationId" Long
+          defaultMetrics()
         }
       }
     }
@@ -129,8 +132,11 @@ abstract class AbstractHazelcastTest extends AgentTestRunner {
         "hazelcast.operation" matcher.group("operation")
         "hazelcast.service" matcher.group("service")
         "hazelcast.instance" client.name
-        "hazelcast.correlationId" Long
         defaultTags()
+      }
+      metrics {
+        "hazelcast.correlationId" Long
+        defaultMetrics()
       }
     }
   }

--- a/dd-java-agent/instrumentation/hazelcast-4.0/src/test/groovy/test/hazelcast/v4/HazelcastTest.groovy
+++ b/dd-java-agent/instrumentation/hazelcast-4.0/src/test/groovy/test/hazelcast/v4/HazelcastTest.groovy
@@ -224,9 +224,12 @@ class HazelcastTest extends AbstractHazelcastTest {
             "hazelcast.name" randomName
             "hazelcast.operation" "List.Get"
             "hazelcast.instance" client.getName()
-            "hazelcast.correlationId" Long
             errorTags(ex)
             defaultTags()
+          }
+          metrics {
+            "hazelcast.correlationId" Long
+            defaultMetrics()
           }
         }
       }

--- a/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionTest.groovy
+++ b/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionTest.groovy
@@ -106,10 +106,13 @@ class HttpUrlConnectionTest extends HttpClientTest {
             "$Tags.COMPONENT" "http-url-connection"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "localhost"
-            "$Tags.PEER_PORT" server.address.port
             "$Tags.HTTP_URL" "$url"
             "$Tags.HTTP_METHOD" "GET"
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" server.address.port
+            defaultMetrics()
           }
         }
         span {
@@ -126,10 +129,13 @@ class HttpUrlConnectionTest extends HttpClientTest {
             "$Tags.COMPONENT" "http-url-connection"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "localhost"
-            "$Tags.PEER_PORT" server.address.port
             "$Tags.HTTP_URL" "$url"
             "$Tags.HTTP_METHOD" "GET"
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" server.address.port
+            defaultMetrics()
           }
         }
       }
@@ -196,10 +202,13 @@ class HttpUrlConnectionTest extends HttpClientTest {
             "$Tags.COMPONENT" "http-url-connection"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "localhost"
-            "$Tags.PEER_PORT" server.address.port
             "$Tags.HTTP_URL" "$url"
             "$Tags.HTTP_METHOD" "GET"
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" server.address.port
+            defaultMetrics()
           }
         }
         span {
@@ -216,10 +225,13 @@ class HttpUrlConnectionTest extends HttpClientTest {
             "$Tags.COMPONENT" "http-url-connection"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "localhost"
-            "$Tags.PEER_PORT" server.address.port
             "$Tags.HTTP_URL" "$url"
             "$Tags.HTTP_METHOD" "GET"
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" server.address.port
+            defaultMetrics()
           }
         }
       }
@@ -271,10 +283,13 @@ class HttpUrlConnectionTest extends HttpClientTest {
             "$Tags.COMPONENT" "http-url-connection"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "localhost"
-            "$Tags.PEER_PORT" server.address.port
             "$Tags.HTTP_URL" "$url"
             "$Tags.HTTP_METHOD" "GET"
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" server.address.port
+            defaultMetrics()
           }
         }
       }
@@ -342,10 +357,13 @@ class HttpUrlConnectionTest extends HttpClientTest {
             "$Tags.COMPONENT" "http-url-connection"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "localhost"
-            "$Tags.PEER_PORT" server.address.port
             "$Tags.HTTP_URL" "$url"
             "$Tags.HTTP_METHOD" "POST"
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" server.address.port
+            defaultMetrics()
           }
         }
       }

--- a/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionTest.groovy
+++ b/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionTest.groovy
@@ -101,6 +101,7 @@ class HttpUrlConnectionTest extends HttpClientTest {
           spanType DDSpanTypes.HTTP_CLIENT
           childOf span(0)
           errored false
+          statusCode STATUS
           tags {
             "$Tags.COMPONENT" "http-url-connection"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -108,7 +109,6 @@ class HttpUrlConnectionTest extends HttpClientTest {
             "$Tags.PEER_PORT" server.address.port
             "$Tags.HTTP_URL" "$url"
             "$Tags.HTTP_METHOD" "GET"
-            "$Tags.HTTP_STATUS" STATUS
             defaultTags()
           }
         }
@@ -121,6 +121,7 @@ class HttpUrlConnectionTest extends HttpClientTest {
           spanType DDSpanTypes.HTTP_CLIENT
           childOf span(0)
           errored false
+          statusCode STATUS
           tags {
             "$Tags.COMPONENT" "http-url-connection"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -128,7 +129,6 @@ class HttpUrlConnectionTest extends HttpClientTest {
             "$Tags.PEER_PORT" server.address.port
             "$Tags.HTTP_URL" "$url"
             "$Tags.HTTP_METHOD" "GET"
-            "$Tags.HTTP_STATUS" STATUS
             defaultTags()
           }
         }
@@ -191,6 +191,7 @@ class HttpUrlConnectionTest extends HttpClientTest {
           spanType DDSpanTypes.HTTP_CLIENT
           childOf span(0)
           errored false
+          statusCode STATUS
           tags {
             "$Tags.COMPONENT" "http-url-connection"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -198,7 +199,6 @@ class HttpUrlConnectionTest extends HttpClientTest {
             "$Tags.PEER_PORT" server.address.port
             "$Tags.HTTP_URL" "$url"
             "$Tags.HTTP_METHOD" "GET"
-            "$Tags.HTTP_STATUS" STATUS
             defaultTags()
           }
         }
@@ -211,6 +211,7 @@ class HttpUrlConnectionTest extends HttpClientTest {
           spanType DDSpanTypes.HTTP_CLIENT
           childOf span(0)
           errored false
+          statusCode STATUS
           tags {
             "$Tags.COMPONENT" "http-url-connection"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -218,7 +219,6 @@ class HttpUrlConnectionTest extends HttpClientTest {
             "$Tags.PEER_PORT" server.address.port
             "$Tags.HTTP_URL" "$url"
             "$Tags.HTTP_METHOD" "GET"
-            "$Tags.HTTP_STATUS" STATUS
             defaultTags()
           }
         }
@@ -266,6 +266,7 @@ class HttpUrlConnectionTest extends HttpClientTest {
           spanType DDSpanTypes.HTTP_CLIENT
           childOf span(0)
           errored false
+          statusCode STATUS
           tags {
             "$Tags.COMPONENT" "http-url-connection"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -273,7 +274,6 @@ class HttpUrlConnectionTest extends HttpClientTest {
             "$Tags.PEER_PORT" server.address.port
             "$Tags.HTTP_URL" "$url"
             "$Tags.HTTP_METHOD" "GET"
-            "$Tags.HTTP_STATUS" STATUS
             defaultTags()
           }
         }
@@ -337,6 +337,7 @@ class HttpUrlConnectionTest extends HttpClientTest {
           spanType DDSpanTypes.HTTP_CLIENT
           childOf span(0)
           errored false
+          statusCode STATUS
           tags {
             "$Tags.COMPONENT" "http-url-connection"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -344,7 +345,6 @@ class HttpUrlConnectionTest extends HttpClientTest {
             "$Tags.PEER_PORT" server.address.port
             "$Tags.HTTP_URL" "$url"
             "$Tags.HTTP_METHOD" "POST"
-            "$Tags.HTTP_STATUS" STATUS
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/UrlConnectionTest.groovy
+++ b/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/UrlConnectionTest.groovy
@@ -51,11 +51,14 @@ class UrlConnectionTest extends AgentTestRunner {
             "$Tags.COMPONENT" "http-url-connection"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "localhost"
-            "$Tags.PEER_PORT" UNUSABLE_PORT
             "$Tags.HTTP_URL" "$url/"
             "$Tags.HTTP_METHOD" "GET"
             errorTags ConnectException, String
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" UNUSABLE_PORT
+            defaultMetrics()
           }
         }
       }
@@ -103,11 +106,14 @@ class UrlConnectionTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT" UrlInstrumentation.COMPONENT
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.PEER_PORT" 80
             // FIXME: These tags really make no sense for non-http connections, why do we set them?
             "$Tags.HTTP_URL" "$url"
             errorTags IllegalArgumentException, String
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" 80
+            defaultMetrics()
           }
         }
       }

--- a/dd-java-agent/instrumentation/jetty-7.0/src/test/groovy/Jetty70Test.groovy
+++ b/dd-java-agent/instrumentation/jetty-7.0/src/test/groovy/Jetty70Test.groovy
@@ -159,7 +159,6 @@ class Jetty70Test extends HttpServerTest<Server> {
         "$Tags.COMPONENT" component
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
         "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-        "$Tags.PEER_PORT" Integer
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
         if (endpoint == FORWARDED) {
@@ -174,6 +173,10 @@ class Jetty70Test extends HttpServerTest<Server> {
           "$DDTags.HTTP_QUERY" endpoint.query
         }
         defaultTags(true)
+      }
+      metrics {
+        "$Tags.PEER_PORT" Integer
+        defaultMetrics()
       }
     }
   }

--- a/dd-java-agent/instrumentation/jetty-7.0/src/test/groovy/Jetty70Test.groovy
+++ b/dd-java-agent/instrumentation/jetty-7.0/src/test/groovy/Jetty70Test.groovy
@@ -154,6 +154,7 @@ class Jetty70Test extends HttpServerTest<Server> {
       } else {
         parent()
       }
+      statusCode endpoint.status
       tags {
         "$Tags.COMPONENT" component
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
@@ -161,7 +162,6 @@ class Jetty70Test extends HttpServerTest<Server> {
         "$Tags.PEER_PORT" Integer
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
-        "$Tags.HTTP_STATUS" endpoint.status
         if (endpoint == FORWARDED) {
           "$Tags.HTTP_FORWARDED_IP" endpoint.body
         }

--- a/dd-java-agent/instrumentation/jetty-7.6/src/test/groovy/Jetty76Test.groovy
+++ b/dd-java-agent/instrumentation/jetty-7.6/src/test/groovy/Jetty76Test.groovy
@@ -156,7 +156,6 @@ class Jetty76Test extends HttpServerTest<Server> {
         "$Tags.COMPONENT" component
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
         "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-        "$Tags.PEER_PORT" Integer
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
         if (endpoint == FORWARDED) {
@@ -171,6 +170,10 @@ class Jetty76Test extends HttpServerTest<Server> {
           "$DDTags.HTTP_QUERY" endpoint.query
         }
         defaultTags(true)
+      }
+      metrics {
+        "$Tags.PEER_PORT" Integer
+        defaultMetrics()
       }
     }
   }

--- a/dd-java-agent/instrumentation/jetty-7.6/src/test/groovy/Jetty76Test.groovy
+++ b/dd-java-agent/instrumentation/jetty-7.6/src/test/groovy/Jetty76Test.groovy
@@ -151,6 +151,7 @@ class Jetty76Test extends HttpServerTest<Server> {
       } else {
         parent()
       }
+      statusCode endpoint.status
       tags {
         "$Tags.COMPONENT" component
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
@@ -158,7 +159,6 @@ class Jetty76Test extends HttpServerTest<Server> {
         "$Tags.PEER_PORT" Integer
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
-        "$Tags.HTTP_STATUS" endpoint.status
         if (endpoint == FORWARDED) {
           "$Tags.HTTP_FORWARDED_IP" endpoint.body
         }

--- a/dd-java-agent/instrumentation/jetty-9/src/test/groovy/Jetty9Test.groovy
+++ b/dd-java-agent/instrumentation/jetty-9/src/test/groovy/Jetty9Test.groovy
@@ -157,7 +157,6 @@ class Jetty9Test extends HttpServerTest<Server> {
         "$Tags.COMPONENT" component
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
         "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-        "$Tags.PEER_PORT" Integer
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
         if (endpoint == FORWARDED) {
@@ -172,6 +171,10 @@ class Jetty9Test extends HttpServerTest<Server> {
           "$DDTags.HTTP_QUERY" endpoint.query
         }
         defaultTags(true)
+      }
+      metrics {
+        "$Tags.PEER_PORT" Integer
+        defaultMetrics()
       }
     }
   }

--- a/dd-java-agent/instrumentation/jetty-9/src/test/groovy/Jetty9Test.groovy
+++ b/dd-java-agent/instrumentation/jetty-9/src/test/groovy/Jetty9Test.groovy
@@ -152,6 +152,7 @@ class Jetty9Test extends HttpServerTest<Server> {
       } else {
         parent()
       }
+      statusCode endpoint.status
       tags {
         "$Tags.COMPONENT" component
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
@@ -159,7 +160,6 @@ class Jetty9Test extends HttpServerTest<Server> {
         "$Tags.PEER_PORT" Integer
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
-        "$Tags.HTTP_STATUS" endpoint.status
         if (endpoint == FORWARDED) {
           "$Tags.HTTP_FORWARDED_IP" endpoint.body
         }

--- a/dd-java-agent/instrumentation/jms/src/latestDepTest/groovy/JMS2Test.groovy
+++ b/dd-java-agent/instrumentation/jms/src/latestDepTest/groovy/JMS2Test.groovy
@@ -281,10 +281,13 @@ class JMS2Test extends AgentTestRunner {
         tags {
           "${Tags.COMPONENT}" "jms"
           "${Tags.SPAN_KIND}" "consumer"
+          defaultTags(true)
+        }
+        metrics {
           if (!messageListener && !isTimestampDisabled) {
             "$InstrumentationTags.RECORD_QUEUE_TIME_MS" {it >= 0 }
           }
-          defaultTags(true)
+          defaultMetrics()
         }
       }
     }

--- a/dd-java-agent/instrumentation/jms/src/test/groovy/JMS1Test.groovy
+++ b/dd-java-agent/instrumentation/jms/src/test/groovy/JMS1Test.groovy
@@ -218,8 +218,11 @@ class JMS1Test extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT" "jms"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
-            "$InstrumentationTags.RECORD_QUEUE_TIME_MS" {it >= 0 }
             defaultTags()
+          }
+          metrics {
+            "$InstrumentationTags.RECORD_QUEUE_TIME_MS" {it >= 0 }
+            defaultMetrics()
           }
         }
       }
@@ -297,10 +300,13 @@ class JMS1Test extends AgentTestRunner {
         tags {
           "$Tags.COMPONENT" "jms"
           "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
+          defaultTags(true)
+        }
+        metrics {
           if (!messageListener && !isTimestampDisabled) {
             "$InstrumentationTags.RECORD_QUEUE_TIME_MS" {it >= 0 }
           }
-          defaultTags(true)
+          defaultMetrics()
         }
       }
     }

--- a/dd-java-agent/instrumentation/jsp-2.3/src/test/groovy/JSPInstrumentationBasicTests.groovy
+++ b/dd-java-agent/instrumentation/jsp-2.3/src/test/groovy/JSPInstrumentationBasicTests.groovy
@@ -28,6 +28,7 @@ class JSPInstrumentationBasicTests extends JSPTestBase {
           resourceName "GET /$jspWebappContext/$jspFileName"
           spanType DDSpanTypes.HTTP_SERVER
           errored false
+          statusCode 200
           tags {
             "$Tags.COMPONENT" "java-web-servlet"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
@@ -35,7 +36,6 @@ class JSPInstrumentationBasicTests extends JSPTestBase {
             "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_URL" "http://localhost:$port/$jspWebappContext/$jspFileName"
             "$Tags.HTTP_METHOD" "GET"
-            "$Tags.HTTP_STATUS" 200
             "servlet.context" "/$jspWebappContext"
             "servlet.path" "/$jspFileName"
             defaultTags()
@@ -101,6 +101,7 @@ class JSPInstrumentationBasicTests extends JSPTestBase {
           resourceName "GET /$jspWebappContext/getQuery.jsp"
           spanType DDSpanTypes.HTTP_SERVER
           errored false
+          statusCode 200
           tags {
             "$Tags.COMPONENT" "java-web-servlet"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
@@ -108,7 +109,6 @@ class JSPInstrumentationBasicTests extends JSPTestBase {
             "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_URL" "http://localhost:$port/$jspWebappContext/getQuery.jsp"
             "$Tags.HTTP_METHOD" "GET"
-            "$Tags.HTTP_STATUS" 200
             "servlet.context" "/$jspWebappContext"
             "servlet.path" "/getQuery.jsp"
             defaultTags()
@@ -171,6 +171,7 @@ class JSPInstrumentationBasicTests extends JSPTestBase {
           resourceName "POST /$jspWebappContext/post.jsp"
           spanType DDSpanTypes.HTTP_SERVER
           errored false
+          statusCode 200
           tags {
             "$Tags.COMPONENT" "java-web-servlet"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
@@ -178,7 +179,6 @@ class JSPInstrumentationBasicTests extends JSPTestBase {
             "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_URL" "http://localhost:$port/$jspWebappContext/post.jsp"
             "$Tags.HTTP_METHOD" "POST"
-            "$Tags.HTTP_STATUS" 200
             "servlet.context" "/$jspWebappContext"
             "servlet.path" "/post.jsp"
             defaultTags()
@@ -238,6 +238,7 @@ class JSPInstrumentationBasicTests extends JSPTestBase {
           resourceName "GET /$jspWebappContext/$jspFileName"
           spanType DDSpanTypes.HTTP_SERVER
           errored true
+          statusCode 500
           tags {
             "$Tags.COMPONENT" "java-web-servlet"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
@@ -245,7 +246,6 @@ class JSPInstrumentationBasicTests extends JSPTestBase {
             "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_URL" "http://localhost:$port/$jspWebappContext/$jspFileName"
             "$Tags.HTTP_METHOD" "GET"
-            "$Tags.HTTP_STATUS" 500
             "servlet.context" "/$jspWebappContext"
             "servlet.path" "/$jspFileName"
             "error.type" { String tagExceptionType ->
@@ -324,6 +324,7 @@ class JSPInstrumentationBasicTests extends JSPTestBase {
           resourceName "GET /$jspWebappContext/includes/includeHtml.jsp"
           spanType DDSpanTypes.HTTP_SERVER
           errored false
+          statusCode 200
           tags {
             "$Tags.COMPONENT" "java-web-servlet"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
@@ -331,7 +332,6 @@ class JSPInstrumentationBasicTests extends JSPTestBase {
             "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_URL" "http://localhost:$port/$jspWebappContext/includes/includeHtml.jsp"
             "$Tags.HTTP_METHOD" "GET"
-            "$Tags.HTTP_STATUS" 200
             "servlet.context" "/$jspWebappContext"
             "servlet.path" "/includes/includeHtml.jsp"
             defaultTags()
@@ -390,6 +390,7 @@ class JSPInstrumentationBasicTests extends JSPTestBase {
           resourceName "GET /$jspWebappContext/includes/includeMulti.jsp"
           spanType DDSpanTypes.HTTP_SERVER
           errored false
+          statusCode 200
           tags {
             "$Tags.COMPONENT" "java-web-servlet"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
@@ -397,7 +398,6 @@ class JSPInstrumentationBasicTests extends JSPTestBase {
             "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_URL" "http://localhost:$port/$jspWebappContext/includes/includeMulti.jsp"
             "$Tags.HTTP_METHOD" "GET"
-            "$Tags.HTTP_STATUS" 200
             "servlet.context" "/$jspWebappContext"
             "servlet.path" "/includes/includeMulti.jsp"
             defaultTags()
@@ -510,6 +510,7 @@ class JSPInstrumentationBasicTests extends JSPTestBase {
           resourceName "GET /$jspWebappContext/$jspFileName"
           spanType DDSpanTypes.HTTP_SERVER
           errored true
+          statusCode 500
           tags {
             "$Tags.COMPONENT" "java-web-servlet"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
@@ -517,7 +518,6 @@ class JSPInstrumentationBasicTests extends JSPTestBase {
             "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_URL" "http://localhost:$port/$jspWebappContext/$jspFileName"
             "$Tags.HTTP_METHOD" "GET"
-            "$Tags.HTTP_STATUS" 500
             "servlet.context" "/$jspWebappContext"
             "servlet.path" "/$jspFileName"
             errorTags(JasperException, String)
@@ -572,6 +572,7 @@ class JSPInstrumentationBasicTests extends JSPTestBase {
           resourceName "GET /$jspWebappContext/$staticFile"
           spanType DDSpanTypes.HTTP_SERVER
           errored false
+          statusCode 200
           tags {
             "$Tags.COMPONENT" "java-web-servlet"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
@@ -579,7 +580,6 @@ class JSPInstrumentationBasicTests extends JSPTestBase {
             "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_URL" "http://localhost:$port/$jspWebappContext/$staticFile"
             "$Tags.HTTP_METHOD" "GET"
-            "$Tags.HTTP_STATUS" 200
             "servlet.context" "/$jspWebappContext"
             "servlet.path" "/$staticFile"
             defaultTags()

--- a/dd-java-agent/instrumentation/jsp-2.3/src/test/groovy/JSPInstrumentationBasicTests.groovy
+++ b/dd-java-agent/instrumentation/jsp-2.3/src/test/groovy/JSPInstrumentationBasicTests.groovy
@@ -33,12 +33,15 @@ class JSPInstrumentationBasicTests extends JSPTestBase {
             "$Tags.COMPONENT" "java-web-servlet"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-            "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_URL" "http://localhost:$port/$jspWebappContext/$jspFileName"
             "$Tags.HTTP_METHOD" "GET"
             "servlet.context" "/$jspWebappContext"
             "servlet.path" "/$jspFileName"
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" Integer
+            defaultMetrics()
           }
         }
         span {
@@ -106,12 +109,15 @@ class JSPInstrumentationBasicTests extends JSPTestBase {
             "$Tags.COMPONENT" "java-web-servlet"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-            "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_URL" "http://localhost:$port/$jspWebappContext/getQuery.jsp"
             "$Tags.HTTP_METHOD" "GET"
             "servlet.context" "/$jspWebappContext"
             "servlet.path" "/getQuery.jsp"
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" Integer
+            defaultMetrics()
           }
         }
         span {
@@ -176,12 +182,15 @@ class JSPInstrumentationBasicTests extends JSPTestBase {
             "$Tags.COMPONENT" "java-web-servlet"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-            "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_URL" "http://localhost:$port/$jspWebappContext/post.jsp"
             "$Tags.HTTP_METHOD" "POST"
             "servlet.context" "/$jspWebappContext"
             "servlet.path" "/post.jsp"
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" Integer
+            defaultMetrics()
           }
         }
         span {
@@ -243,7 +252,6 @@ class JSPInstrumentationBasicTests extends JSPTestBase {
             "$Tags.COMPONENT" "java-web-servlet"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-            "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_URL" "http://localhost:$port/$jspWebappContext/$jspFileName"
             "$Tags.HTTP_METHOD" "GET"
             "servlet.context" "/$jspWebappContext"
@@ -256,6 +264,10 @@ class JSPInstrumentationBasicTests extends JSPTestBase {
             }
             "error.stack" String
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" Integer
+            defaultMetrics()
           }
         }
         span {
@@ -329,12 +341,15 @@ class JSPInstrumentationBasicTests extends JSPTestBase {
             "$Tags.COMPONENT" "java-web-servlet"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-            "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_URL" "http://localhost:$port/$jspWebappContext/includes/includeHtml.jsp"
             "$Tags.HTTP_METHOD" "GET"
             "servlet.context" "/$jspWebappContext"
             "servlet.path" "/includes/includeHtml.jsp"
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" Integer
+            defaultMetrics()
           }
         }
         span {
@@ -395,12 +410,15 @@ class JSPInstrumentationBasicTests extends JSPTestBase {
             "$Tags.COMPONENT" "java-web-servlet"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-            "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_URL" "http://localhost:$port/$jspWebappContext/includes/includeMulti.jsp"
             "$Tags.HTTP_METHOD" "GET"
             "servlet.context" "/$jspWebappContext"
             "servlet.path" "/includes/includeMulti.jsp"
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" Integer
+            defaultMetrics()
           }
         }
         span {
@@ -515,13 +533,16 @@ class JSPInstrumentationBasicTests extends JSPTestBase {
             "$Tags.COMPONENT" "java-web-servlet"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-            "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_URL" "http://localhost:$port/$jspWebappContext/$jspFileName"
             "$Tags.HTTP_METHOD" "GET"
             "servlet.context" "/$jspWebappContext"
             "servlet.path" "/$jspFileName"
             errorTags(JasperException, String)
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" Integer
+            defaultMetrics()
           }
         }
         span {
@@ -577,12 +598,15 @@ class JSPInstrumentationBasicTests extends JSPTestBase {
             "$Tags.COMPONENT" "java-web-servlet"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-            "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_URL" "http://localhost:$port/$jspWebappContext/$staticFile"
             "$Tags.HTTP_METHOD" "GET"
             "servlet.context" "/$jspWebappContext"
             "servlet.path" "/$staticFile"
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" Integer
+            defaultMetrics()
           }
         }
       }

--- a/dd-java-agent/instrumentation/jsp-2.3/src/test/groovy/JSPInstrumentationForwardTests.groovy
+++ b/dd-java-agent/instrumentation/jsp-2.3/src/test/groovy/JSPInstrumentationForwardTests.groovy
@@ -26,6 +26,7 @@ class JSPInstrumentationForwardTests extends JSPTestBase {
           resourceName "GET /$jspWebappContext/$forwardFromFileName"
           spanType DDSpanTypes.HTTP_SERVER
           errored false
+          statusCode 200
           tags {
             "$Tags.COMPONENT" "java-web-servlet"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
@@ -33,7 +34,6 @@ class JSPInstrumentationForwardTests extends JSPTestBase {
             "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_URL" "http://localhost:$port/$jspWebappContext/$forwardFromFileName"
             "$Tags.HTTP_METHOD" "GET"
-            "$Tags.HTTP_STATUS" 200
             "servlet.context" "/$jspWebappContext"
             "servlet.path" "/$forwardFromFileName"
             defaultTags()
@@ -125,6 +125,7 @@ class JSPInstrumentationForwardTests extends JSPTestBase {
           resourceName "GET /$jspWebappContext/forwards/forwardToHtml.jsp"
           spanType DDSpanTypes.HTTP_SERVER
           errored false
+          statusCode 200
           tags {
             "$Tags.COMPONENT" "java-web-servlet"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
@@ -132,7 +133,6 @@ class JSPInstrumentationForwardTests extends JSPTestBase {
             "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_URL" "http://localhost:$port/$jspWebappContext/forwards/forwardToHtml.jsp"
             "$Tags.HTTP_METHOD" "GET"
-            "$Tags.HTTP_STATUS" 200
             "servlet.context" "/$jspWebappContext"
             "servlet.path" "/forwards/forwardToHtml.jsp"
             defaultTags()
@@ -191,6 +191,7 @@ class JSPInstrumentationForwardTests extends JSPTestBase {
           resourceName "GET /$jspWebappContext/forwards/forwardToIncludeMulti.jsp"
           spanType DDSpanTypes.HTTP_SERVER
           errored false
+          statusCode 200
           tags {
             "$Tags.COMPONENT" "java-web-servlet"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
@@ -198,7 +199,6 @@ class JSPInstrumentationForwardTests extends JSPTestBase {
             "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_URL" "http://localhost:$port/$jspWebappContext/forwards/forwardToIncludeMulti.jsp"
             "$Tags.HTTP_METHOD" "GET"
-            "$Tags.HTTP_STATUS" 200
             "servlet.context" "/$jspWebappContext"
             "servlet.path" "/forwards/forwardToIncludeMulti.jsp"
             defaultTags()
@@ -341,6 +341,7 @@ class JSPInstrumentationForwardTests extends JSPTestBase {
           resourceName "GET /$jspWebappContext/forwards/forwardToJspForward.jsp"
           spanType DDSpanTypes.HTTP_SERVER
           errored false
+          statusCode 200
           tags {
             "$Tags.COMPONENT" "java-web-servlet"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
@@ -348,7 +349,6 @@ class JSPInstrumentationForwardTests extends JSPTestBase {
             "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_URL" "http://localhost:$port/$jspWebappContext/forwards/forwardToJspForward.jsp"
             "$Tags.HTTP_METHOD" "GET"
-            "$Tags.HTTP_STATUS" 200
             "servlet.context" "/$jspWebappContext"
             "servlet.path" "/forwards/forwardToJspForward.jsp"
             defaultTags()
@@ -463,6 +463,7 @@ class JSPInstrumentationForwardTests extends JSPTestBase {
           resourceName "GET /$jspWebappContext/forwards/forwardToCompileError.jsp"
           spanType DDSpanTypes.HTTP_SERVER
           errored true
+          statusCode 500
           tags {
             "$Tags.COMPONENT" "java-web-servlet"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
@@ -470,7 +471,6 @@ class JSPInstrumentationForwardTests extends JSPTestBase {
             "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_URL" "http://localhost:$port/$jspWebappContext/forwards/forwardToCompileError.jsp"
             "$Tags.HTTP_METHOD" "GET"
-            "$Tags.HTTP_STATUS" 500
             "servlet.context" "/$jspWebappContext"
             "servlet.path" "/forwards/forwardToCompileError.jsp"
             errorTags(JasperException, String)
@@ -546,6 +546,7 @@ class JSPInstrumentationForwardTests extends JSPTestBase {
           resourceName "404"
           spanType DDSpanTypes.HTTP_SERVER
           errored false
+          statusCode 404
           tags {
             "$Tags.COMPONENT" "java-web-servlet"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
@@ -553,7 +554,6 @@ class JSPInstrumentationForwardTests extends JSPTestBase {
             "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_URL" "http://localhost:$port/$jspWebappContext/forwards/forwardToNonExistent.jsp"
             "$Tags.HTTP_METHOD" "GET"
-            "$Tags.HTTP_STATUS" 404
             "servlet.context" "/$jspWebappContext"
             "servlet.path" "/forwards/forwardToNonExistent.jsp"
             defaultTags()

--- a/dd-java-agent/instrumentation/jsp-2.3/src/test/groovy/JSPInstrumentationForwardTests.groovy
+++ b/dd-java-agent/instrumentation/jsp-2.3/src/test/groovy/JSPInstrumentationForwardTests.groovy
@@ -31,12 +31,15 @@ class JSPInstrumentationForwardTests extends JSPTestBase {
             "$Tags.COMPONENT" "java-web-servlet"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-            "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_URL" "http://localhost:$port/$jspWebappContext/$forwardFromFileName"
             "$Tags.HTTP_METHOD" "GET"
             "servlet.context" "/$jspWebappContext"
             "servlet.path" "/$forwardFromFileName"
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" Integer
+            defaultMetrics()
           }
         }
         span {
@@ -130,12 +133,15 @@ class JSPInstrumentationForwardTests extends JSPTestBase {
             "$Tags.COMPONENT" "java-web-servlet"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-            "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_URL" "http://localhost:$port/$jspWebappContext/forwards/forwardToHtml.jsp"
             "$Tags.HTTP_METHOD" "GET"
             "servlet.context" "/$jspWebappContext"
             "servlet.path" "/forwards/forwardToHtml.jsp"
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" Integer
+            defaultMetrics()
           }
         }
         span {
@@ -196,12 +202,15 @@ class JSPInstrumentationForwardTests extends JSPTestBase {
             "$Tags.COMPONENT" "java-web-servlet"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-            "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_URL" "http://localhost:$port/$jspWebappContext/forwards/forwardToIncludeMulti.jsp"
             "$Tags.HTTP_METHOD" "GET"
             "servlet.context" "/$jspWebappContext"
             "servlet.path" "/forwards/forwardToIncludeMulti.jsp"
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" Integer
+            defaultMetrics()
           }
         }
         span {
@@ -346,12 +355,15 @@ class JSPInstrumentationForwardTests extends JSPTestBase {
             "$Tags.COMPONENT" "java-web-servlet"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-            "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_URL" "http://localhost:$port/$jspWebappContext/forwards/forwardToJspForward.jsp"
             "$Tags.HTTP_METHOD" "GET"
             "servlet.context" "/$jspWebappContext"
             "servlet.path" "/forwards/forwardToJspForward.jsp"
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" Integer
+            defaultMetrics()
           }
         }
         span {
@@ -468,13 +480,16 @@ class JSPInstrumentationForwardTests extends JSPTestBase {
             "$Tags.COMPONENT" "java-web-servlet"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-            "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_URL" "http://localhost:$port/$jspWebappContext/forwards/forwardToCompileError.jsp"
             "$Tags.HTTP_METHOD" "GET"
             "servlet.context" "/$jspWebappContext"
             "servlet.path" "/forwards/forwardToCompileError.jsp"
             errorTags(JasperException, String)
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" Integer
+            defaultMetrics()
           }
         }
         span {
@@ -551,12 +566,15 @@ class JSPInstrumentationForwardTests extends JSPTestBase {
             "$Tags.COMPONENT" "java-web-servlet"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-            "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_URL" "http://localhost:$port/$jspWebappContext/forwards/forwardToNonExistent.jsp"
             "$Tags.HTTP_METHOD" "GET"
             "servlet.context" "/$jspWebappContext"
             "servlet.path" "/forwards/forwardToNonExistent.jsp"
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" Integer
+            defaultMetrics()
           }
         }
         span {

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTest.groovy
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTest.groovy
@@ -346,7 +346,7 @@ class KafkaClientTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT" "java-kafka"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
-
+            "tombstone" true
             defaultTags(true)
           }
           metrics {
@@ -609,10 +609,6 @@ class KafkaClientTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT" "java-kafka"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
-            "$InstrumentationTags.PARTITION" { it >= 0 }
-            "$InstrumentationTags.OFFSET" 2
-            "$InstrumentationTags.RECORD_QUEUE_TIME_MS" { it >= 0 }
-            "$InstrumentationTags.RECORD_END_TO_END_DURATION_MS" { it >= 0 }
             defaultTags(true)
           }
           metrics {
@@ -637,10 +633,6 @@ class KafkaClientTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT" "java-kafka"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
-            "$InstrumentationTags.PARTITION" { it >= 0 }
-            "$InstrumentationTags.OFFSET" 2
-            "$InstrumentationTags.RECORD_QUEUE_TIME_MS" { it >= 0 }
-            "$InstrumentationTags.RECORD_END_TO_END_DURATION_MS" { it >= 0 }
             defaultTags(true)
           }
           metrics {

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTest.groovy
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTest.groovy
@@ -135,13 +135,16 @@ class KafkaClientTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT" "java-kafka"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
+
+            defaultTags(true)
+          }
+          metrics {
             "$InstrumentationTags.PARTITION" { it >= 0 }
             "$InstrumentationTags.OFFSET" 0
             "$InstrumentationTags.RECORD_QUEUE_TIME_MS" { it >= 0 }
             // TODO - test with and without feature enabled once Config is easier to control
             "$InstrumentationTags.RECORD_END_TO_END_DURATION_MS" { it >= 0 }
-
-            defaultTags(true)
+            defaultMetrics()
           }
         }
       }
@@ -241,13 +244,16 @@ class KafkaClientTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT" "java-kafka"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
+
+            defaultTags(true)
+          }
+          metrics {
             "$InstrumentationTags.PARTITION" { it >= 0 }
             "$InstrumentationTags.OFFSET" 0
             "$InstrumentationTags.RECORD_QUEUE_TIME_MS" { it >= 0 }
             // TODO - test with and without feature enabled once Config is easier to control
             "$InstrumentationTags.RECORD_END_TO_END_DURATION_MS" { it >= 0 }
-
-            defaultTags(true)
+            defaultMetrics()
           }
         }
       }
@@ -340,14 +346,17 @@ class KafkaClientTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT" "java-kafka"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
+
+            defaultTags(true)
+          }
+          metrics {
             "$InstrumentationTags.PARTITION" { it >= 0 }
             "$InstrumentationTags.OFFSET" 0
             "$InstrumentationTags.RECORD_QUEUE_TIME_MS" { it >= 0 }
             "$InstrumentationTags.TOMBSTONE" true
             // TODO - test with and without feature enabled once Config is easier to control
             "$InstrumentationTags.RECORD_END_TO_END_DURATION_MS" { it >= 0 }
-
-            defaultTags(true)
+            defaultMetrics()
           }
         }
       }
@@ -406,8 +415,11 @@ class KafkaClientTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT" "java-kafka"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_PRODUCER
-            "$InstrumentationTags.PARTITION" { it >= 0 }
             defaultTags(true)
+          }
+          metrics {
+            "$InstrumentationTags.PARTITION" { it >= 0 }
+            defaultMetrics()
           }
         }
       }
@@ -423,13 +435,16 @@ class KafkaClientTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT" "java-kafka"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
+
+            defaultTags(true)
+          }
+          metrics {
             "$InstrumentationTags.PARTITION" { it >= 0 }
             "$InstrumentationTags.OFFSET" 0
             "$InstrumentationTags.RECORD_QUEUE_TIME_MS" { it >= 0 }
             // TODO - test with and without feature enabled once Config is easier to control
             "$InstrumentationTags.RECORD_END_TO_END_DURATION_MS" { it >= 0 }
-
-            defaultTags(true)
+            defaultMetrics()
           }
         }
       }
@@ -491,8 +506,11 @@ class KafkaClientTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT" "java-kafka"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_PRODUCER
-            "$InstrumentationTags.PARTITION" { it >= 0 }
             defaultTags(true)
+          }
+          metrics {
+            "$InstrumentationTags.PARTITION" { it >= 0 }
+            defaultMetrics()
           }
         }
       }
@@ -507,8 +525,11 @@ class KafkaClientTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT" "java-kafka"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_PRODUCER
-            "$InstrumentationTags.PARTITION" { it >= 0 }
             defaultTags(true)
+          }
+          metrics {
+            "$InstrumentationTags.PARTITION" { it >= 0 }
+            defaultMetrics()
           }
         }
       }
@@ -523,8 +544,11 @@ class KafkaClientTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT" "java-kafka"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_PRODUCER
-            "$InstrumentationTags.PARTITION" { it >= 0 }
             defaultTags(true)
+          }
+          metrics {
+            "$InstrumentationTags.PARTITION" { it >= 0 }
+            defaultMetrics()
           }
         }
       }
@@ -541,11 +565,14 @@ class KafkaClientTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT" "java-kafka"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
+            defaultTags(true)
+          }
+          metrics {
             "$InstrumentationTags.PARTITION" { it >= 0 }
             "$InstrumentationTags.OFFSET" 0
             "$InstrumentationTags.RECORD_QUEUE_TIME_MS" { it >= 0 }
             "$InstrumentationTags.RECORD_END_TO_END_DURATION_MS" { it >= 0 }
-            defaultTags(true)
+            defaultMetrics()
           }
         }
       }
@@ -560,11 +587,14 @@ class KafkaClientTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT" "java-kafka"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
+            defaultTags(true)
+          }
+          metrics {
             "$InstrumentationTags.PARTITION" { it >= 0 }
             "$InstrumentationTags.OFFSET" 1
             "$InstrumentationTags.RECORD_QUEUE_TIME_MS" { it >= 0 }
             "$InstrumentationTags.RECORD_END_TO_END_DURATION_MS" { it >= 0 }
-            defaultTags(true)
+            defaultMetrics()
           }
         }
       }
@@ -584,6 +614,13 @@ class KafkaClientTest extends AgentTestRunner {
             "$InstrumentationTags.RECORD_QUEUE_TIME_MS" { it >= 0 }
             "$InstrumentationTags.RECORD_END_TO_END_DURATION_MS" { it >= 0 }
             defaultTags(true)
+          }
+          metrics {
+            "$InstrumentationTags.PARTITION" { it >= 0 }
+            "$InstrumentationTags.OFFSET" 2
+            "$InstrumentationTags.RECORD_QUEUE_TIME_MS" { it >= 0 }
+            "$InstrumentationTags.RECORD_END_TO_END_DURATION_MS" { it >= 0 }
+            defaultMetrics()
           }
         }
       }
@@ -606,6 +643,13 @@ class KafkaClientTest extends AgentTestRunner {
             "$InstrumentationTags.RECORD_END_TO_END_DURATION_MS" { it >= 0 }
             defaultTags(true)
           }
+          metrics {
+            "$InstrumentationTags.PARTITION" { it >= 0 }
+            "$InstrumentationTags.OFFSET" 2
+            "$InstrumentationTags.RECORD_QUEUE_TIME_MS" { it >= 0 }
+            "$InstrumentationTags.RECORD_END_TO_END_DURATION_MS" { it >= 0 }
+            defaultMetrics()
+          }
         }
       }
       trace(1) {
@@ -619,11 +663,14 @@ class KafkaClientTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT" "java-kafka"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
+            defaultTags(true)
+          }
+          metrics {
             "$InstrumentationTags.PARTITION" { it >= 0 }
             "$InstrumentationTags.OFFSET" 1
             "$InstrumentationTags.RECORD_QUEUE_TIME_MS" { it >= 0 }
             "$InstrumentationTags.RECORD_END_TO_END_DURATION_MS" { it >= 0 }
-            defaultTags(true)
+            defaultMetrics()
           }
         }
       }
@@ -638,11 +685,14 @@ class KafkaClientTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT" "java-kafka"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
+            defaultTags(true)
+          }
+          metrics {
             "$InstrumentationTags.PARTITION" { it >= 0 }
             "$InstrumentationTags.OFFSET" 0
             "$InstrumentationTags.RECORD_QUEUE_TIME_MS" { it >= 0 }
             "$InstrumentationTags.RECORD_END_TO_END_DURATION_MS" { it >= 0 }
-            defaultTags(true)
+            defaultMetrics()
           }
         }
       }
@@ -761,12 +811,15 @@ class KafkaClientTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT" "java-kafka"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
+
+            defaultTags(true)
+          }
+          metrics {
             "$InstrumentationTags.PARTITION" { it >= 0 }
             "$InstrumentationTags.OFFSET" 0
             "$InstrumentationTags.RECORD_QUEUE_TIME_MS" { it >= 0 }
             "$InstrumentationTags.RECORD_END_TO_END_DURATION_MS" { it >= 0 }
-
-            defaultTags(true)
+            defaultMetrics()
           }
         }
       }
@@ -780,12 +833,15 @@ class KafkaClientTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT" "java-kafka"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
+
+            defaultTags(true)
+          }
+          metrics {
             "$InstrumentationTags.PARTITION" { it >= 0 }
             "$InstrumentationTags.OFFSET" { it >= 0 && it < 2 }
             "$InstrumentationTags.RECORD_QUEUE_TIME_MS" { it >= 0 }
             "$InstrumentationTags.RECORD_END_TO_END_DURATION_MS" { it >= 0 }
-
-            defaultTags(true)
+            defaultMetrics()
           }
         }
       }
@@ -799,12 +855,15 @@ class KafkaClientTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT" "java-kafka"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
+
+            defaultTags(true)
+          }
+          metrics {
             "$InstrumentationTags.PARTITION" { it >= 0 }
             "$InstrumentationTags.OFFSET" { it >= 0 && it < 2 }
             "$InstrumentationTags.RECORD_QUEUE_TIME_MS" { it >= 0 }
             "$InstrumentationTags.RECORD_END_TO_END_DURATION_MS" { it >= 0 }
-
-            defaultTags(true)
+            defaultMetrics()
           }
         }
       }

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/src/test/groovy/KafkaStreamsTest.groovy
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/src/test/groovy/KafkaStreamsTest.groovy
@@ -146,10 +146,13 @@ class KafkaStreamsTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT" "java-kafka"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
+            defaultTags(true)
+          }
+          metrics {
             "$InstrumentationTags.PARTITION" { it >= 0 }
             "$InstrumentationTags.OFFSET" 0
             "$InstrumentationTags.RECORD_QUEUE_TIME_MS" { it >= 0 }
-            defaultTags(true)
+            defaultMetrics()
           }
         }
       }
@@ -183,10 +186,13 @@ class KafkaStreamsTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT" "java-kafka"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
-            "$InstrumentationTags.PARTITION" { it >= 0 }
-            "$InstrumentationTags.OFFSET" 0
             "asdf" "testing"
             defaultTags(true)
+          }
+          metrics {
+            "$InstrumentationTags.PARTITION" { it >= 0 }
+            "$InstrumentationTags.OFFSET" 0
+            defaultMetrics()
           }
         }
       }
@@ -202,11 +208,14 @@ class KafkaStreamsTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT" "java-kafka"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
+            defaultTags(true)
+          }
+          metrics {
             "$InstrumentationTags.PARTITION" { it >= 0 }
             "$InstrumentationTags.OFFSET" 0
             "$InstrumentationTags.RECORD_QUEUE_TIME_MS" { it >= 0 }
             "testing" 123
-            defaultTags(true)
+            defaultMetrics()
           }
         }
       }

--- a/dd-java-agent/instrumentation/lettuce-4/src/test/groovy/Lettuce4AsyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/lettuce-4/src/test/groovy/Lettuce4AsyncClientTest.groovy
@@ -123,10 +123,10 @@ class Lettuce4AsyncClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" HOST
             "$Tags.DB_TYPE" "redis"
-            "db.redis.dbIndex" 0
             defaultTags()
           }
           metrics {
+            "db.redis.dbIndex" 0
             "$Tags.PEER_PORT" port
             defaultMetrics()
           }

--- a/dd-java-agent/instrumentation/lettuce-4/src/test/groovy/Lettuce4AsyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/lettuce-4/src/test/groovy/Lettuce4AsyncClientTest.groovy
@@ -122,10 +122,13 @@ class Lettuce4AsyncClientTest extends AgentTestRunner {
             "$Tags.COMPONENT" "redis-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" HOST
-            "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
             "db.redis.dbIndex" 0
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" port
+            defaultMetrics()
           }
         }
       }
@@ -160,11 +163,14 @@ class Lettuce4AsyncClientTest extends AgentTestRunner {
             "$Tags.COMPONENT" "redis-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" HOST
-            "$Tags.PEER_PORT" incorrectPort
             "$Tags.DB_TYPE" "redis"
-            "db.redis.dbIndex" 0
             errorTags RedisConnectionException, String
             defaultTags()
+          }
+          metrics {
+            "db.redis.dbIndex" 0
+            "$Tags.PEER_PORT" incorrectPort
+            defaultMetrics()
           }
         }
       }

--- a/dd-java-agent/instrumentation/lettuce-4/src/test/groovy/Lettuce4SyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/lettuce-4/src/test/groovy/Lettuce4SyncClientTest.groovy
@@ -103,10 +103,13 @@ class Lettuce4SyncClientTest extends AgentTestRunner {
             "$Tags.COMPONENT" "redis-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" HOST
-            "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
-            "db.redis.dbIndex" 0
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" port
+            "db.redis.dbIndex" 0
+            defaultMetrics()
           }
         }
       }
@@ -139,11 +142,14 @@ class Lettuce4SyncClientTest extends AgentTestRunner {
             "$Tags.COMPONENT" "redis-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" HOST
-            "$Tags.PEER_PORT" incorrectPort
             "$Tags.DB_TYPE" "redis"
-            "db.redis.dbIndex" 0
             errorTags RedisConnectionException, String
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" incorrectPort
+            "db.redis.dbIndex" 0
+            defaultMetrics()
           }
         }
       }

--- a/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/Lettuce5AsyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/Lettuce5AsyncClientTest.groovy
@@ -125,10 +125,13 @@ class Lettuce5AsyncClientTest extends AgentTestRunner {
             "$Tags.COMPONENT" "redis-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" HOST
-            "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
-            "db.redis.dbIndex" 0
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" port
+            "db.redis.dbIndex" 0
+            defaultMetrics()
           }
         }
       }
@@ -164,11 +167,14 @@ class Lettuce5AsyncClientTest extends AgentTestRunner {
             "$Tags.COMPONENT" "redis-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" HOST
-            "$Tags.PEER_PORT" incorrectPort
             "$Tags.DB_TYPE" "redis"
-            "db.redis.dbIndex" 0
             errorTags CompletionException, String
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" incorrectPort
+            "db.redis.dbIndex" 0
+            defaultMetrics()
           }
         }
       }

--- a/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/Lettuce5ReactiveClientTest.groovy
+++ b/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/Lettuce5ReactiveClientTest.groovy
@@ -231,8 +231,11 @@ class Lettuce5ReactiveClientTest extends AgentTestRunner {
             "$Tags.COMPONENT" "redis-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.DB_TYPE" "redis"
-            "db.command.results.count" 157
             defaultTags()
+          }
+          metrics {
+            "db.command.results.count" 157
+            defaultMetrics()
           }
         }
       }
@@ -258,8 +261,11 @@ class Lettuce5ReactiveClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.DB_TYPE" "redis"
             "db.command.cancelled" true
-            "db.command.results.count" 2
             defaultTags()
+          }
+          metrics {
+            "db.command.results.count" 2
+            defaultMetrics()
           }
         }
       }

--- a/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/Lettuce5SyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/Lettuce5SyncClientTest.groovy
@@ -105,10 +105,13 @@ class Lettuce5SyncClientTest extends AgentTestRunner {
             "$Tags.COMPONENT" "redis-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" HOST
-            "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
-            "db.redis.dbIndex" 0
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" port
+            "db.redis.dbIndex" 0
+            defaultMetrics()
           }
         }
       }
@@ -141,11 +144,14 @@ class Lettuce5SyncClientTest extends AgentTestRunner {
             "$Tags.COMPONENT" "redis-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" HOST
-            "$Tags.PEER_PORT" incorrectPort
             "$Tags.DB_TYPE" "redis"
-            "db.redis.dbIndex" 0
             errorTags CompletionException, String
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" incorrectPort
+            "db.redis.dbIndex" 0
+            defaultMetrics()
           }
         }
       }

--- a/dd-java-agent/instrumentation/mongo/driver-3.1/src/test/groovy/MongoClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-3.1/src/test/groovy/MongoClientTest.groovy
@@ -239,11 +239,14 @@ class MongoClientTest extends MongoBaseTest {
         "$Tags.COMPONENT" "java-mongo"
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
         "$Tags.PEER_HOSTNAME" "localhost"
-        "$Tags.PEER_PORT" port
         "$Tags.DB_TYPE" "mongo"
         "$Tags.DB_INSTANCE" instance
         "$Tags.DB_OPERATION" operation
         defaultTags()
+      }
+      metrics {
+        "$Tags.PEER_PORT" port
+        defaultMetrics()
       }
     }
   }

--- a/dd-java-agent/instrumentation/mongo/driver-4/src/test/groovy/Mongo4ClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-4/src/test/groovy/Mongo4ClientTest.groovy
@@ -234,11 +234,14 @@ class Mongo4ClientTest extends MongoBaseTest {
         "$Tags.COMPONENT" "java-mongo"
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
         "$Tags.PEER_HOSTNAME" "localhost"
-        "$Tags.PEER_PORT" port
         "$Tags.DB_TYPE" "mongo"
         "$Tags.DB_INSTANCE" instance
         "$Tags.DB_OPERATION" operation
         defaultTags()
+      }
+      metrics {
+        "$Tags.PEER_PORT" port
+        defaultMetrics()
       }
     }
   }

--- a/dd-java-agent/instrumentation/mongo/driver-4/src/test/groovy/Mongo4ReactiveClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-4/src/test/groovy/Mongo4ReactiveClientTest.groovy
@@ -247,11 +247,14 @@ class Mongo4ReactiveClientTest extends MongoBaseTest {
         "$Tags.COMPONENT" "java-mongo"
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
         "$Tags.PEER_HOSTNAME" "localhost"
-        "$Tags.PEER_PORT" port
         "$Tags.DB_TYPE" "mongo"
         "$Tags.DB_INSTANCE" instance
         "$Tags.DB_OPERATION" operation
         defaultTags()
+      }
+      metrics {
+        "$Tags.PEER_PORT" port
+        defaultMetrics()
       }
     }
   }

--- a/dd-java-agent/instrumentation/mongo/driver-async-3.3/src/test/groovy/MongoAsyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-async-3.3/src/test/groovy/MongoAsyncClientTest.groovy
@@ -246,11 +246,14 @@ class MongoAsyncClientTest extends MongoBaseTest {
         "$Tags.COMPONENT" "java-mongo"
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
         "$Tags.PEER_HOSTNAME" "localhost"
-        "$Tags.PEER_PORT" port
         "$Tags.DB_TYPE" "mongo"
         "$Tags.DB_INSTANCE" instance
         "$Tags.DB_OPERATION" operation
         defaultTags()
+      }
+      metrics {
+        "$Tags.PEER_PORT" port
+        defaultMetrics()
       }
     }
   }

--- a/dd-java-agent/instrumentation/mule-4/src/test/groovy/mule4/MuleForkedTest.groovy
+++ b/dd-java-agent/instrumentation/mule-4/src/test/groovy/mule4/MuleForkedTest.groovy
@@ -97,11 +97,11 @@ class MuleForkedTest extends WithHttpServer<MuleTestContainer> {
           operationName "grizzly.request"
           resourceName "GET /client-request"
           spanType DDSpanTypes.HTTP_SERVER
+          statusCode 200
           tags {
             "$Tags.COMPONENT" "grizzly-filterchain-server"
             "$Tags.SPAN_KIND" "server"
             "$Tags.HTTP_METHOD" "GET"
-            "$Tags.HTTP_STATUS" 200
             "$Tags.HTTP_URL" "${address.resolve("/client-request")}"
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
             "$Tags.PEER_PORT" { true } // is this really the best way to ignore tags?
@@ -113,11 +113,11 @@ class MuleForkedTest extends WithHttpServer<MuleTestContainer> {
           operationName "http.request"
           resourceName "GET /remote-client-request"
           spanType DDSpanTypes.HTTP_CLIENT
+          statusCode 200
           tags {
             "$Tags.COMPONENT" "grizzly-http-async-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.HTTP_METHOD" "GET"
-            "$Tags.HTTP_STATUS" 200
             "$Tags.HTTP_URL" "${requestServer.address.resolve("/remote-client-request")}"
             "$Tags.PEER_HOSTNAME" "localhost"
             "$Tags.PEER_PORT" { true } // is this really the best way to ignore tags?
@@ -150,11 +150,11 @@ class MuleForkedTest extends WithHttpServer<MuleTestContainer> {
           operationName "grizzly.request"
           resourceName "PUT /pfe-request"
           spanType DDSpanTypes.HTTP_SERVER
+          statusCode 200
           tags {
             "$Tags.COMPONENT" "grizzly-filterchain-server"
             "$Tags.SPAN_KIND" "server"
             "$Tags.HTTP_METHOD" "PUT"
-            "$Tags.HTTP_STATUS" 200
             "$Tags.HTTP_URL" "${address.resolve("/pfe-request")}"
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
             "$Tags.PEER_PORT" { true } // is this really the best way to ignore tags?
@@ -167,11 +167,11 @@ class MuleForkedTest extends WithHttpServer<MuleTestContainer> {
             operationName "http.request"
             resourceName "GET /remote-pfe-request"
             spanType DDSpanTypes.HTTP_CLIENT
+            statusCode 200
             tags {
               "$Tags.COMPONENT" "grizzly-http-async-client"
               "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
               "$Tags.HTTP_METHOD" "GET"
-              "$Tags.HTTP_STATUS" 200
               "$Tags.HTTP_URL" "${requestServer.address.resolve("/remote-pfe-request")}"
               "$Tags.PEER_HOSTNAME" "localhost"
               "$Tags.PEER_PORT" { true } // is this really the best way to ignore tags?

--- a/dd-java-agent/instrumentation/mule-4/src/test/groovy/mule4/MuleForkedTest.groovy
+++ b/dd-java-agent/instrumentation/mule-4/src/test/groovy/mule4/MuleForkedTest.groovy
@@ -104,7 +104,6 @@ class MuleForkedTest extends WithHttpServer<MuleTestContainer> {
             "$Tags.HTTP_METHOD" "GET"
             "$Tags.HTTP_URL" "${address.resolve("/client-request")}"
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-            "$Tags.PEER_PORT" { true } // is this really the best way to ignore tags?
             defaultTags()
           }
         }
@@ -120,7 +119,6 @@ class MuleForkedTest extends WithHttpServer<MuleTestContainer> {
             "$Tags.HTTP_METHOD" "GET"
             "$Tags.HTTP_URL" "${requestServer.address.resolve("/remote-client-request")}"
             "$Tags.PEER_HOSTNAME" "localhost"
-            "$Tags.PEER_PORT" { true } // is this really the best way to ignore tags?
             defaultTags()
           }
         }
@@ -157,7 +155,6 @@ class MuleForkedTest extends WithHttpServer<MuleTestContainer> {
             "$Tags.HTTP_METHOD" "PUT"
             "$Tags.HTTP_URL" "${address.resolve("/pfe-request")}"
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-            "$Tags.PEER_PORT" { true } // is this really the best way to ignore tags?
             defaultTags()
           }
         }
@@ -174,7 +171,6 @@ class MuleForkedTest extends WithHttpServer<MuleTestContainer> {
               "$Tags.HTTP_METHOD" "GET"
               "$Tags.HTTP_URL" "${requestServer.address.resolve("/remote-pfe-request")}"
               "$Tags.PEER_HOSTNAME" "localhost"
-              "$Tags.PEER_PORT" { true } // is this really the best way to ignore tags?
               defaultTags()
             }
           }

--- a/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/server/HttpServerResponseTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/server/HttpServerResponseTracingHandler.java
@@ -1,13 +1,11 @@
 package datadog.trace.instrumentation.netty38.server;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
-import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator._500;
 import static datadog.trace.instrumentation.netty38.server.NettyHttpServerDecorator.DECORATE;
 
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.instrumentation.netty38.ChannelTraceContext;
 import org.jboss.netty.channel.Channel;
 import org.jboss.netty.channel.ChannelHandlerContext;
@@ -43,7 +41,7 @@ public class HttpServerResponseTracingHandler extends SimpleChannelDownstreamHan
         ctx.sendDownstream(msg);
       } catch (final Throwable throwable) {
         DECORATE.onError(span, throwable);
-        span.setTag(Tags.HTTP_STATUS, _500);
+        span.setHttpStatusCode(500);
         span.finish(); // Finish the span manually since finishSpanOnClose was false
         throw throwable;
       }

--- a/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/server/HttpServerResponseTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/server/HttpServerResponseTracingHandler.java
@@ -1,13 +1,11 @@
 package datadog.trace.instrumentation.netty40.server;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
-import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator._500;
 import static datadog.trace.instrumentation.netty40.AttributeKeys.SPAN_ATTRIBUTE_KEY;
 import static datadog.trace.instrumentation.netty40.server.NettyHttpServerDecorator.DECORATE;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.bootstrap.instrumentation.api.Tags;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOutboundHandlerAdapter;
@@ -33,7 +31,7 @@ public class HttpServerResponseTracingHandler extends ChannelOutboundHandlerAdap
         ctx.write(msg, prm);
       } catch (final Throwable throwable) {
         DECORATE.onError(span, throwable);
-        span.setTag(Tags.HTTP_STATUS, _500);
+        span.setHttpStatusCode(500);
         span.finish(); // Finish the span manually since finishSpanOnClose was false
         throw throwable;
       }

--- a/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/server/HttpServerResponseTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/server/HttpServerResponseTracingHandler.java
@@ -1,13 +1,11 @@
 package datadog.trace.instrumentation.netty41.server;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
-import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator._500;
 import static datadog.trace.instrumentation.netty41.AttributeKeys.SPAN_ATTRIBUTE_KEY;
 import static datadog.trace.instrumentation.netty41.server.NettyHttpServerDecorator.DECORATE;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.bootstrap.instrumentation.api.Tags;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOutboundHandlerAdapter;
@@ -33,7 +31,7 @@ public class HttpServerResponseTracingHandler extends ChannelOutboundHandlerAdap
         ctx.write(msg, prm);
       } catch (final Throwable throwable) {
         DECORATE.onError(span, throwable);
-        span.setTag(Tags.HTTP_STATUS, _500);
+        span.setHttpStatusCode(500);
         span.finish(); // Finish the span manually since finishSpanOnClose was false
         throw throwable;
       }

--- a/dd-java-agent/instrumentation/netty-4.1/src/test/groovy/ReactorNettyTest.groovy
+++ b/dd-java-agent/instrumentation/netty-4.1/src/test/groovy/ReactorNettyTest.groovy
@@ -79,10 +79,13 @@ class ReactorNettyTest extends AgentTestRunner {
         "$Tags.PEER_HOSTNAME" uri.host
 
         "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-        "$Tags.PEER_PORT" uri.port
         "$Tags.HTTP_URL" "${uri.resolve(uri.path)}"
         "$Tags.HTTP_METHOD" method
         defaultTags()
+      }
+      metrics {
+        "$Tags.PEER_PORT" uri.port
+        defaultMetrics()
       }
     }
   }

--- a/dd-java-agent/instrumentation/netty-4.1/src/test/groovy/ReactorNettyTest.groovy
+++ b/dd-java-agent/instrumentation/netty-4.1/src/test/groovy/ReactorNettyTest.groovy
@@ -72,6 +72,7 @@ class ReactorNettyTest extends AgentTestRunner {
       resourceName "$method $uri.path"
       spanType DDSpanTypes.HTTP_CLIENT
       errored false
+      statusCode status
       tags {
         "$Tags.COMPONENT" "netty-client"
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -81,7 +82,6 @@ class ReactorNettyTest extends AgentTestRunner {
         "$Tags.PEER_PORT" uri.port
         "$Tags.HTTP_URL" "${uri.resolve(uri.path)}"
         "$Tags.HTTP_METHOD" method
-        "$Tags.HTTP_STATUS" status
         defaultTags()
       }
     }

--- a/dd-java-agent/instrumentation/opentelemetry/src/test/groovy/OpenTelemetryTest.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/src/test/groovy/OpenTelemetryTest.groovy
@@ -68,16 +68,19 @@ class OpenTelemetryTest extends AgentTestRunner {
           tags {
             if (tagSpan) {
               "string" "b"
-              "number" 2
               "boolean" false
             } else if (tagBuilder) {
               "string" "a"
-              "number" 1
               "boolean" true
             }
             defaultTags()
           }
           metrics {
+            if (tagSpan) {
+              "number" 2
+            } else if (tagBuilder) {
+              "number" 1
+            }
             defaultMetrics()
           }
         }

--- a/dd-java-agent/instrumentation/opentracing/api-0.31/src/test/groovy/OpenTracing31Test.groovy
+++ b/dd-java-agent/instrumentation/opentracing/api-0.31/src/test/groovy/OpenTracing31Test.groovy
@@ -82,11 +82,9 @@ class OpenTracing31Test extends AgentTestRunner {
           tags {
             if (tagSpan) {
               "string" "b"
-              "number" 2
               "boolean" false
             } else if (tagBuilder) {
               "string" "a"
-              "number" 1
               "boolean" true
             }
             if (exception) {
@@ -95,6 +93,11 @@ class OpenTracing31Test extends AgentTestRunner {
             defaultTags(addReference != null)
           }
           metrics {
+            if (tagSpan) {
+              "number" 2
+            } else if (tagBuilder) {
+              "number" 1
+            }
             defaultMetrics()
           }
         }

--- a/dd-java-agent/instrumentation/opentracing/api-0.32/src/test/groovy/OpenTracing32Test.groovy
+++ b/dd-java-agent/instrumentation/opentracing/api-0.32/src/test/groovy/OpenTracing32Test.groovy
@@ -82,11 +82,9 @@ class OpenTracing32Test extends AgentTestRunner {
           tags {
             if (tagSpan) {
               "string" "b"
-              "number" 2
               "boolean" false
             } else if (tagBuilder) {
               "string" "a"
-              "number" 1
               "boolean" true
             }
             if (exception) {
@@ -95,6 +93,11 @@ class OpenTracing32Test extends AgentTestRunner {
             defaultTags(addReference != null)
           }
           metrics {
+            if (tagSpan) {
+              "number" 2
+            } else if (tagBuilder) {
+              "number" 1
+            }
             defaultMetrics()
           }
         }

--- a/dd-java-agent/instrumentation/play-2.3/src/main/java8/datadog/trace/instrumentation/play23/PlayAdvice.java
+++ b/dd-java-agent/instrumentation/play-2.3/src/main/java8/datadog/trace/instrumentation/play23/PlayAdvice.java
@@ -4,7 +4,6 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSp
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
-import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator._500;
 import static datadog.trace.instrumentation.play23.PlayHeaders.GETTER;
 import static datadog.trace.instrumentation.play23.PlayHttpServerDecorator.DECORATE;
 import static datadog.trace.instrumentation.play23.PlayHttpServerDecorator.PLAY_REQUEST;
@@ -12,7 +11,6 @@ import static datadog.trace.instrumentation.play23.PlayHttpServerDecorator.PLAY_
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan.Context;
-import datadog.trace.bootstrap.instrumentation.api.Tags;
 import net.bytebuddy.asm.Advice;
 import play.api.mvc.Action;
 import play.api.mvc.Request;
@@ -57,7 +55,7 @@ public class PlayAdvice {
           ((Action) thisAction).executionContext());
     } else {
       DECORATE.onError(playControllerSpan, throwable);
-      playControllerSpan.setTag(Tags.HTTP_STATUS, _500);
+      playControllerSpan.setHttpStatusCode(500);
       DECORATE.beforeFinish(playControllerSpan);
       playControllerSpan.finish();
     }

--- a/dd-java-agent/instrumentation/play-2.3/src/main/java8/datadog/trace/instrumentation/play23/PlayHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/play-2.3/src/main/java8/datadog/trace/instrumentation/play23/PlayHttpServerDecorator.java
@@ -3,7 +3,6 @@ package datadog.trace.instrumentation.play23;
 import static datadog.trace.bootstrap.instrumentation.decorator.RouteHandlerDecorator.ROUTE_HANDLER_DECORATOR;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
@@ -75,7 +74,7 @@ public class PlayHttpServerDecorator extends HttpServerDecorator<Request, Reques
 
   @Override
   public AgentSpan onError(final AgentSpan span, Throwable throwable) {
-    span.setTag(Tags.HTTP_STATUS, _500);
+    span.setHttpStatusCode(500);
     if (throwable != null
         // This can be moved to instanceof check when using Java 8.
         && throwable.getClass().getName().equals("java.util.concurrent.CompletionException")

--- a/dd-java-agent/instrumentation/play-2.3/src/test/groovy/server/PlayServerTest.groovy
+++ b/dd-java-agent/instrumentation/play-2.3/src/test/groovy/server/PlayServerTest.groovy
@@ -46,13 +46,13 @@ class PlayServerTest extends HttpServerTest<TestServer> {
       spanType DDSpanTypes.HTTP_SERVER
       errored endpoint == ERROR || endpoint == EXCEPTION
       childOfPrevious()
+      statusCode Integer
       tags {
         "$Tags.COMPONENT" PlayHttpServerDecorator.DECORATE.component()
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
         "$Tags.PEER_HOST_IPV4" { it == (endpoint == FORWARDED ? endpoint.body : "127.0.0.1") }
         "$Tags.HTTP_URL" String
         "$Tags.HTTP_METHOD" String
-        "$Tags.HTTP_STATUS" Integer
         // BUG
         //        "$Tags.HTTP_ROUTE" String
         if (endpoint == EXCEPTION) {

--- a/dd-java-agent/instrumentation/play-2.3/src/test/groovy/server/PlayServerTest.groovy
+++ b/dd-java-agent/instrumentation/play-2.3/src/test/groovy/server/PlayServerTest.groovy
@@ -46,7 +46,7 @@ class PlayServerTest extends HttpServerTest<TestServer> {
       spanType DDSpanTypes.HTTP_SERVER
       errored endpoint == ERROR || endpoint == EXCEPTION
       childOfPrevious()
-      statusCode Integer
+      statusCode { it != 0 }
       tags {
         "$Tags.COMPONENT" PlayHttpServerDecorator.DECORATE.component()
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER

--- a/dd-java-agent/instrumentation/play-2.4/src/main/java8/datadog/trace/instrumentation/play24/PlayAdvice.java
+++ b/dd-java-agent/instrumentation/play-2.4/src/main/java8/datadog/trace/instrumentation/play24/PlayAdvice.java
@@ -4,7 +4,6 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSp
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
-import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator._500;
 import static datadog.trace.instrumentation.play24.PlayHeaders.GETTER;
 import static datadog.trace.instrumentation.play24.PlayHttpServerDecorator.DECORATE;
 import static datadog.trace.instrumentation.play24.PlayHttpServerDecorator.PLAY_REQUEST;
@@ -12,7 +11,6 @@ import static datadog.trace.instrumentation.play24.PlayHttpServerDecorator.PLAY_
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan.Context;
-import datadog.trace.bootstrap.instrumentation.api.Tags;
 import net.bytebuddy.asm.Advice;
 import play.api.mvc.Action;
 import play.api.mvc.Request;
@@ -71,7 +69,7 @@ public class PlayAdvice {
           ((Action) thisAction).executionContext());
     } else {
       DECORATE.onError(playControllerSpan, throwable);
-      playControllerSpan.setTag(Tags.HTTP_STATUS, _500);
+      playControllerSpan.setHttpStatusCode(500);
       DECORATE.beforeFinish(playControllerSpan);
       playControllerSpan.finish();
     }

--- a/dd-java-agent/instrumentation/play-2.4/src/main/java8/datadog/trace/instrumentation/play24/PlayHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/play-2.4/src/main/java8/datadog/trace/instrumentation/play24/PlayHttpServerDecorator.java
@@ -3,7 +3,6 @@ package datadog.trace.instrumentation.play24;
 import static datadog.trace.bootstrap.instrumentation.decorator.RouteHandlerDecorator.ROUTE_HANDLER_DECORATOR;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
@@ -74,7 +73,7 @@ public class PlayHttpServerDecorator extends HttpServerDecorator<Request, Reques
 
   @Override
   public AgentSpan onError(final AgentSpan span, Throwable throwable) {
-    span.setTag(Tags.HTTP_STATUS, _500);
+    span.setHttpStatusCode(500);
     if (throwable != null
         // This can be moved to instanceof check when using Java 8.
         && throwable.getClass().getName().equals("java.util.concurrent.CompletionException")

--- a/dd-java-agent/instrumentation/play-2.4/src/test/groovy/server/PlayServerTest.groovy
+++ b/dd-java-agent/instrumentation/play-2.4/src/test/groovy/server/PlayServerTest.groovy
@@ -88,13 +88,13 @@ class PlayServerTest extends HttpServerTest<Server> {
       spanType DDSpanTypes.HTTP_SERVER
       errored endpoint == ERROR || endpoint == EXCEPTION
       childOfPrevious()
+      statusCode Integer
       tags {
         "$Tags.COMPONENT" PlayHttpServerDecorator.DECORATE.component()
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
         "$Tags.PEER_HOST_IPV4" { it == (endpoint == FORWARDED ? endpoint.body : "127.0.0.1") }
         "$Tags.HTTP_URL" String
         "$Tags.HTTP_METHOD" String
-        "$Tags.HTTP_STATUS" Integer
         // BUG
         //        "$Tags.HTTP_ROUTE" String
         if (endpoint == EXCEPTION) {

--- a/dd-java-agent/instrumentation/play-2.4/src/test/groovy/server/PlayServerTest.groovy
+++ b/dd-java-agent/instrumentation/play-2.4/src/test/groovy/server/PlayServerTest.groovy
@@ -88,7 +88,7 @@ class PlayServerTest extends HttpServerTest<Server> {
       spanType DDSpanTypes.HTTP_SERVER
       errored endpoint == ERROR || endpoint == EXCEPTION
       childOfPrevious()
-      statusCode Integer
+      statusCode { it != 0 }
       tags {
         "$Tags.COMPONENT" PlayHttpServerDecorator.DECORATE.component()
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER

--- a/dd-java-agent/instrumentation/play-2.6/src/main/java8/datadog/trace/instrumentation/play26/PlayHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/play-2.6/src/main/java8/datadog/trace/instrumentation/play26/PlayHttpServerDecorator.java
@@ -3,7 +3,6 @@ package datadog.trace.instrumentation.play26;
 import static datadog.trace.bootstrap.instrumentation.decorator.RouteHandlerDecorator.ROUTE_HANDLER_DECORATOR;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
@@ -117,7 +116,7 @@ public class PlayHttpServerDecorator extends HttpServerDecorator<Request, Reques
 
   @Override
   public AgentSpan onError(final AgentSpan span, Throwable throwable) {
-    span.setTag(Tags.HTTP_STATUS, _500);
+    span.setHttpStatusCode(500);
     if (throwable instanceof CompletionException && throwable.getCause() != null) {
       throwable = throwable.getCause();
     }

--- a/dd-java-agent/instrumentation/play-2.6/src/test/groovy/server/PlayServerTest.groovy
+++ b/dd-java-agent/instrumentation/play-2.6/src/test/groovy/server/PlayServerTest.groovy
@@ -95,7 +95,7 @@ class PlayServerTest extends HttpServerTest<Server> {
       spanType DDSpanTypes.HTTP_SERVER
       errored endpoint == ERROR || endpoint == EXCEPTION
       childOfPrevious()
-      statusCode Integer
+      statusCode { it != 0 }
       tags {
         "$Tags.COMPONENT" PlayHttpServerDecorator.DECORATE.component()
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER

--- a/dd-java-agent/instrumentation/play-2.6/src/test/groovy/server/PlayServerTest.groovy
+++ b/dd-java-agent/instrumentation/play-2.6/src/test/groovy/server/PlayServerTest.groovy
@@ -95,13 +95,13 @@ class PlayServerTest extends HttpServerTest<Server> {
       spanType DDSpanTypes.HTTP_SERVER
       errored endpoint == ERROR || endpoint == EXCEPTION
       childOfPrevious()
+      statusCode Integer
       tags {
         "$Tags.COMPONENT" PlayHttpServerDecorator.DECORATE.component()
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
         "$Tags.PEER_HOST_IPV4" { it == (endpoint == FORWARDED ? endpoint.body : "127.0.0.1") }
         "$Tags.HTTP_URL" String
         "$Tags.HTTP_METHOD" String
-        "$Tags.HTTP_STATUS" Integer
         // BUG
         //        "$Tags.HTTP_ROUTE" String
         if (endpoint == EXCEPTION) {
@@ -128,11 +128,11 @@ class PlayServerTest extends HttpServerTest<Server> {
       } else {
         parent()
       }
+      statusCode endpoint.status
       tags {
         "$Tags.COMPONENT" component
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
         "$Tags.PEER_HOST_IPV4" { it == (endpoint == FORWARDED ? endpoint.body : "127.0.0.1") }
-        "$Tags.HTTP_STATUS" endpoint.status
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
         if (endpoint == FORWARDED) {

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/test/groovy/RabbitMQTest.groovy
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/test/groovy/RabbitMQTest.groovy
@@ -384,7 +384,6 @@ class RabbitMQTest extends AgentTestRunner {
         "$Tags.PEER_HOSTNAME" { it == null || it instanceof String }
         "$Tags.PEER_HOST_IPV4" { it == null || it == "127.0.0.1" }
         "$Tags.PEER_HOST_IPV6" { it == null || it == "0:0:0:0:0:0:0:1" }
-        "$Tags.PEER_PORT" { it == null || it instanceof Integer }
         if (expectTimestamp) {
           "$InstrumentationTags.RECORD_QUEUE_TIME_MS" { it instanceof Long && it >= 0 }
         }
@@ -401,20 +400,16 @@ class RabbitMQTest extends AgentTestRunner {
             "amqp.routing_key" {
               it == null || it == "some-routing-key" || it == "some-routing-queue" || it.startsWith("amq.gen-")
             }
-            "amqp.delivery_mode" { it == null || it == 2 }
-            "message.size" Integer
             break
           case "basic.get":
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
             "amqp.command" "basic.get"
             "amqp.queue" { it == "some-queue" || it == "some-routing-queue" || it.startsWith("amq.gen-") }
-            "message.size" { it == null || it instanceof Integer }
             break
           case "basic.deliver":
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
             "amqp.command" "basic.deliver"
             "amqp.exchange" { it == "some-exchange" || it == "some-error-exchange" }
-            "message.size" Integer
             break
           default:
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -424,6 +419,12 @@ class RabbitMQTest extends AgentTestRunner {
           errorTags(exception.class, errorMsg)
         }
         defaultTags(distributedRootSpan)
+      }
+      metrics {
+        "message.size" { it == null || it instanceof Integer }
+        "amqp.delivery_mode" { it == null || it == 2 }
+        "$Tags.PEER_PORT" { it == null || it instanceof Integer }
+        defaultMetrics()
       }
     }
   }

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/test/groovy/RabbitMQTest.groovy
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/test/groovy/RabbitMQTest.groovy
@@ -384,13 +384,6 @@ class RabbitMQTest extends AgentTestRunner {
         "$Tags.PEER_HOSTNAME" { it == null || it instanceof String }
         "$Tags.PEER_HOST_IPV4" { it == null || it == "127.0.0.1" }
         "$Tags.PEER_HOST_IPV6" { it == null || it == "0:0:0:0:0:0:0:1" }
-        if (expectTimestamp) {
-          "$InstrumentationTags.RECORD_QUEUE_TIME_MS" { it instanceof Long && it >= 0 }
-        }
-
-        // FIXME: this is broken in the instrumentation
-        // `it` should never be null
-        "$InstrumentationTags.RECORD_END_TO_END_DURATION_MS" { it == null || it >= 0 }
 
         switch (tag("amqp.command")) {
           case "basic.publish":
@@ -424,6 +417,10 @@ class RabbitMQTest extends AgentTestRunner {
         "message.size" { it == null || it instanceof Integer }
         "amqp.delivery_mode" { it == null || it == 2 }
         "$Tags.PEER_PORT" { it == null || it instanceof Integer }
+        if (expectTimestamp) {
+          "$InstrumentationTags.RECORD_QUEUE_TIME_MS" { it instanceof Long && it >= 0 }
+        }
+        "$InstrumentationTags.RECORD_END_TO_END_DURATION_MS" { it == null || it >= 0 }
         defaultMetrics()
       }
     }

--- a/dd-java-agent/instrumentation/ratpack-1.5/src/test/groovy/RatpackOtherTest.groovy
+++ b/dd-java-agent/instrumentation/ratpack-1.5/src/test/groovy/RatpackOtherTest.groovy
@@ -73,11 +73,14 @@ class RatpackOtherTest extends AgentTestRunner {
             "$Tags.COMPONENT" "netty"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-            "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_URL" "${app.address.resolve(path)}"
             "$Tags.HTTP_METHOD" "GET"
             "$Tags.HTTP_ROUTE" "/$route"
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" Integer
+            defaultMetrics()
           }
         }
         span {
@@ -91,11 +94,14 @@ class RatpackOtherTest extends AgentTestRunner {
             "$Tags.COMPONENT" "ratpack"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-            "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_URL" "${app.address.resolve(path)}"
             "$Tags.HTTP_METHOD" "GET"
             "$Tags.HTTP_ROUTE" "/$route"
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" Integer
+            defaultMetrics()
           }
         }
       }

--- a/dd-java-agent/instrumentation/ratpack-1.5/src/test/groovy/RatpackOtherTest.groovy
+++ b/dd-java-agent/instrumentation/ratpack-1.5/src/test/groovy/RatpackOtherTest.groovy
@@ -68,6 +68,7 @@ class RatpackOtherTest extends AgentTestRunner {
           spanType DDSpanTypes.HTTP_SERVER
           parent()
           errored false
+          statusCode 200
           tags {
             "$Tags.COMPONENT" "netty"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
@@ -75,7 +76,6 @@ class RatpackOtherTest extends AgentTestRunner {
             "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_URL" "${app.address.resolve(path)}"
             "$Tags.HTTP_METHOD" "GET"
-            "$Tags.HTTP_STATUS" 200
             "$Tags.HTTP_ROUTE" "/$route"
             defaultTags()
           }
@@ -86,6 +86,7 @@ class RatpackOtherTest extends AgentTestRunner {
           spanType DDSpanTypes.HTTP_SERVER
           childOf(span(0))
           errored false
+          statusCode 200
           tags {
             "$Tags.COMPONENT" "ratpack"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
@@ -93,7 +94,6 @@ class RatpackOtherTest extends AgentTestRunner {
             "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_URL" "${app.address.resolve(path)}"
             "$Tags.HTTP_METHOD" "GET"
-            "$Tags.HTTP_STATUS" 200
             "$Tags.HTTP_ROUTE" "/$route"
             defaultTags()
           }

--- a/dd-java-agent/instrumentation/ratpack-1.5/src/test/groovy/server/RatpackHttpServerTest.groovy
+++ b/dd-java-agent/instrumentation/ratpack-1.5/src/test/groovy/server/RatpackHttpServerTest.groovy
@@ -125,7 +125,6 @@ class RatpackHttpServerTest extends HttpServerTest<EmbeddedApp> {
         "$Tags.COMPONENT" RatpackServerDecorator.DECORATE.component()
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
         "$Tags.PEER_HOST_IPV4" "127.0.0.1" // This span ignores "x-forwards-from".
-        "$Tags.PEER_PORT" Integer
         "$Tags.HTTP_URL" String
         "$Tags.HTTP_METHOD" String
         "$Tags.HTTP_ROUTE" String
@@ -136,6 +135,10 @@ class RatpackHttpServerTest extends HttpServerTest<EmbeddedApp> {
           "$DDTags.HTTP_QUERY" endpoint.query
         }
         defaultTags()
+      }
+      metrics {
+        "$Tags.PEER_PORT" Integer
+        defaultMetrics()
       }
     }
   }

--- a/dd-java-agent/instrumentation/ratpack-1.5/src/test/groovy/server/RatpackHttpServerTest.groovy
+++ b/dd-java-agent/instrumentation/ratpack-1.5/src/test/groovy/server/RatpackHttpServerTest.groovy
@@ -120,7 +120,7 @@ class RatpackHttpServerTest extends HttpServerTest<EmbeddedApp> {
       spanType DDSpanTypes.HTTP_SERVER
       errored endpoint == ERROR || endpoint == EXCEPTION
       childOfPrevious()
-      statusCode Integer
+      statusCode { it != 0 }
       tags {
         "$Tags.COMPONENT" RatpackServerDecorator.DECORATE.component()
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER

--- a/dd-java-agent/instrumentation/ratpack-1.5/src/test/groovy/server/RatpackHttpServerTest.groovy
+++ b/dd-java-agent/instrumentation/ratpack-1.5/src/test/groovy/server/RatpackHttpServerTest.groovy
@@ -120,6 +120,7 @@ class RatpackHttpServerTest extends HttpServerTest<EmbeddedApp> {
       spanType DDSpanTypes.HTTP_SERVER
       errored endpoint == ERROR || endpoint == EXCEPTION
       childOfPrevious()
+      statusCode Integer
       tags {
         "$Tags.COMPONENT" RatpackServerDecorator.DECORATE.component()
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
@@ -127,7 +128,6 @@ class RatpackHttpServerTest extends HttpServerTest<EmbeddedApp> {
         "$Tags.PEER_PORT" Integer
         "$Tags.HTTP_URL" String
         "$Tags.HTTP_METHOD" String
-        "$Tags.HTTP_STATUS" Integer
         "$Tags.HTTP_ROUTE" String
         if (endpoint == EXCEPTION) {
           errorTags(Exception, EXCEPTION.body)

--- a/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/Servlet2Advice.java
+++ b/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/Servlet2Advice.java
@@ -4,7 +4,6 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSp
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.DD_SPAN_ATTRIBUTE;
-import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator._500;
 import static datadog.trace.instrumentation.servlet2.HttpServletRequestExtractAdapter.GETTER;
 import static datadog.trace.instrumentation.servlet2.Servlet2Decorator.DECORATE;
 import static datadog.trace.instrumentation.servlet2.Servlet2Decorator.SERVLET_REQUEST;
@@ -16,7 +15,6 @@ import datadog.trace.api.GlobalTracer;
 import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.bootstrap.instrumentation.api.Tags;
 import java.security.Principal;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
@@ -102,7 +100,7 @@ public class Servlet2Advice {
           && InstrumentationContext.get(ServletResponse.class, Integer.class).get(response)
               == HttpServletResponse.SC_OK) {
         // exception was thrown but status code wasn't set
-        span.setTag(Tags.HTTP_STATUS, _500);
+        span.setHttpStatusCode(500);
       }
       DECORATE.onError(span, throwable);
     }

--- a/dd-java-agent/instrumentation/servlet/request-2/src/test/groovy/JettyServlet2Test.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-2/src/test/groovy/JettyServlet2Test.groovy
@@ -147,6 +147,7 @@ class JettyServlet2Test extends HttpServerTest<Server> {
       } else {
         parent()
       }
+      statusCode endpoint.status
       tags {
         "$Tags.COMPONENT" component
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
@@ -154,7 +155,6 @@ class JettyServlet2Test extends HttpServerTest<Server> {
         "$Tags.PEER_PORT" Integer
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
-        "$Tags.HTTP_STATUS" endpoint.status
         if (endpoint == FORWARDED) {
           "$Tags.HTTP_FORWARDED_IP" endpoint.body
         }

--- a/dd-java-agent/instrumentation/servlet/request-2/src/test/groovy/JettyServlet2Test.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-2/src/test/groovy/JettyServlet2Test.groovy
@@ -152,7 +152,6 @@ class JettyServlet2Test extends HttpServerTest<Server> {
         "$Tags.COMPONENT" component
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
         "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-        "$Tags.PEER_PORT" Integer
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
         if (endpoint == FORWARDED) {
@@ -169,6 +168,10 @@ class JettyServlet2Test extends HttpServerTest<Server> {
           "$DDTags.HTTP_QUERY" endpoint.query
         }
         defaultTags(true)
+      }
+      metrics {
+        "$Tags.PEER_PORT" Integer
+        defaultMetrics()
       }
     }
   }

--- a/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Advice.java
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Advice.java
@@ -5,7 +5,6 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.DD_DISPATCH_SPAN_ATTRIBUTE;
 import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.DD_SPAN_ATTRIBUTE;
-import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator._500;
 import static datadog.trace.instrumentation.servlet3.HttpServletRequestExtractAdapter.GETTER;
 import static datadog.trace.instrumentation.servlet3.Servlet3Decorator.DECORATE;
 import static datadog.trace.instrumentation.servlet3.Servlet3Decorator.SERVLET_REQUEST;
@@ -16,7 +15,6 @@ import datadog.trace.api.DDTags;
 import datadog.trace.api.GlobalTracer;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.bootstrap.instrumentation.api.Tags;
 import java.security.Principal;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.servlet.ServletRequest;
@@ -109,7 +107,7 @@ public class Servlet3Advice {
           DECORATE.onResponse(span, resp);
           if (resp.getStatus() == HttpServletResponse.SC_OK) {
             // exception is thrown in filter chain, but status code is likely incorrect
-            span.setTag(Tags.HTTP_STATUS, _500);
+            span.setHttpStatusCode(500);
           }
         }
         DECORATE.onError(span, throwable);

--- a/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/TagSettingAsyncListener.java
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/TagSettingAsyncListener.java
@@ -1,12 +1,10 @@
 package datadog.trace.instrumentation.servlet3;
 
 import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.TIMEOUT;
-import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator._500;
 import static datadog.trace.instrumentation.servlet3.Servlet3Decorator.DECORATE;
 
 import datadog.trace.api.Config;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.bootstrap.instrumentation.api.Tags;
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.servlet.AsyncEvent;
@@ -65,9 +63,10 @@ public class TagSettingAsyncListener implements AsyncListener {
         if (((HttpServletResponse) event.getSuppliedResponse()).getStatus()
             == HttpServletResponse.SC_OK) {
           // exception is thrown in filter chain, but status code is incorrect
-          span.setTag(Tags.HTTP_STATUS, _500);
+          span.setHttpStatusCode(500);
         }
       }
+
       DECORATE.onError(span, event.getThrowable());
       DECORATE.beforeFinish(span);
       span.finish();

--- a/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/JettyServlet3Test.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/JettyServlet3Test.groovy
@@ -205,9 +205,6 @@ abstract class JettyServlet3Test extends AbstractServlet3Test<Server, ServletCon
       childOfPrevious()
       tags {
         "$Tags.COMPONENT" AsyncDispatcherDecorator.DECORATE.component()
-        if (endpoint == TIMEOUT || endpoint == TIMEOUT_ERROR) {
-          "timeout" SERVLET_TIMEOUT
-        }
         if (context) {
           "servlet.context" "/$context"
         }
@@ -218,6 +215,12 @@ abstract class JettyServlet3Test extends AbstractServlet3Test<Server, ServletCon
           "error.stack" String
         }
         defaultTags()
+      }
+      metrics {
+        if (endpoint == TIMEOUT || endpoint == TIMEOUT_ERROR) {
+          "timeout" SERVLET_TIMEOUT
+        }
+        defaultMetrics()
       }
     }
   }

--- a/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/JettyServlet3Test.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/JettyServlet3Test.groovy
@@ -159,6 +159,7 @@ abstract class JettyServlet3Test extends AbstractServlet3Test<Server, ServletCon
       } else {
         parent()
       }
+      statusCode { it == endpoint.status || !bubblesResponse }
       tags {
         "$Tags.COMPONENT" component
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
@@ -166,7 +167,6 @@ abstract class JettyServlet3Test extends AbstractServlet3Test<Server, ServletCon
         "$Tags.PEER_PORT" Integer
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
-        "$Tags.HTTP_STATUS" { it == endpoint.status || !bubblesResponse }
         if (endpoint == FORWARDED) {
           "$Tags.HTTP_FORWARDED_IP" endpoint.body
         }

--- a/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/JettyServlet3Test.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/JettyServlet3Test.groovy
@@ -164,7 +164,6 @@ abstract class JettyServlet3Test extends AbstractServlet3Test<Server, ServletCon
         "$Tags.COMPONENT" component
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
         "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-        "$Tags.PEER_PORT" Integer
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
         if (endpoint == FORWARDED) {
@@ -189,6 +188,10 @@ abstract class JettyServlet3Test extends AbstractServlet3Test<Server, ServletCon
           "$DDTags.HTTP_QUERY" endpoint.query
         }
         defaultTags(true)
+      }
+      metrics {
+        "$Tags.PEER_PORT" Integer
+        defaultMetrics()
       }
     }
   }

--- a/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/JettyServletHandlerTest.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/JettyServletHandlerTest.groovy
@@ -132,7 +132,6 @@ class JettyServletHandlerTest extends AbstractServlet3Test<Server, ServletHandle
         "$Tags.COMPONENT" component
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
         "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-        "$Tags.PEER_PORT" Integer
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
         if (endpoint == FORWARDED) {
@@ -157,6 +156,10 @@ class JettyServletHandlerTest extends AbstractServlet3Test<Server, ServletHandle
           "$DDTags.HTTP_QUERY" endpoint.query
         }
         defaultTags(true)
+      }
+      metrics {
+        "$Tags.PEER_PORT" Integer
+        defaultMetrics()
       }
     }
   }

--- a/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/JettyServletHandlerTest.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/JettyServletHandlerTest.groovy
@@ -127,6 +127,7 @@ class JettyServletHandlerTest extends AbstractServlet3Test<Server, ServletHandle
       } else {
         parent()
       }
+      statusCode { it == endpoint.status || !bubblesResponse }
       tags {
         "$Tags.COMPONENT" component
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
@@ -134,7 +135,6 @@ class JettyServletHandlerTest extends AbstractServlet3Test<Server, ServletHandle
         "$Tags.PEER_PORT" Integer
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
-        "$Tags.HTTP_STATUS" { it == endpoint.status || !bubblesResponse }
         if (endpoint == FORWARDED) {
           "$Tags.HTTP_FORWARDED_IP" endpoint.body
         }

--- a/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/TomcatServlet3Test.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/TomcatServlet3Test.groovy
@@ -194,9 +194,6 @@ abstract class TomcatServlet3Test extends AbstractServlet3Test<Tomcat, Context> 
       childOfPrevious()
       tags {
         "$Tags.COMPONENT" AsyncDispatcherDecorator.DECORATE.component()
-        if (endpoint == TIMEOUT || endpoint == TIMEOUT_ERROR) {
-          "timeout" SERVLET_TIMEOUT
-        }
         if (context) {
           "servlet.context" "/$context"
         }
@@ -207,6 +204,12 @@ abstract class TomcatServlet3Test extends AbstractServlet3Test<Tomcat, Context> 
           "error.stack" String
         }
         defaultTags()
+      }
+      metrics {
+        if (endpoint == TIMEOUT || endpoint == TIMEOUT_ERROR) {
+          "timeout" SERVLET_TIMEOUT
+        }
+        defaultMetrics()
       }
     }
   }

--- a/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/TomcatServlet3Test.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/TomcatServlet3Test.groovy
@@ -147,6 +147,7 @@ abstract class TomcatServlet3Test extends AbstractServlet3Test<Tomcat, Context> 
       } else {
         parent()
       }
+      statusCode { it == endpoint.status || !bubblesResponse }
       tags {
         "$Tags.COMPONENT" component
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
@@ -154,7 +155,6 @@ abstract class TomcatServlet3Test extends AbstractServlet3Test<Tomcat, Context> 
         "$Tags.PEER_PORT" Integer
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
-        "$Tags.HTTP_STATUS" { it == endpoint.status || !bubblesResponse }
         if (endpoint == FORWARDED) {
           "$Tags.HTTP_FORWARDED_IP" endpoint.body
         }

--- a/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/TomcatServlet3Test.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/TomcatServlet3Test.groovy
@@ -152,7 +152,6 @@ abstract class TomcatServlet3Test extends AbstractServlet3Test<Tomcat, Context> 
         "$Tags.COMPONENT" component
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
         "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-        "$Tags.PEER_PORT" Integer
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
         if (endpoint == FORWARDED) {
@@ -178,6 +177,10 @@ abstract class TomcatServlet3Test extends AbstractServlet3Test<Tomcat, Context> 
           "$DDTags.HTTP_QUERY" endpoint.query
         }
         defaultTags(true)
+      }
+      metrics {
+        "$Tags.PEER_PORT" Integer
+        defaultMetrics()
       }
     }
   }

--- a/dd-java-agent/instrumentation/servlet/src/test/groovy/HttpServletResponseTest.groovy
+++ b/dd-java-agent/instrumentation/servlet/src/test/groovy/HttpServletResponseTest.groovy
@@ -89,12 +89,12 @@ class HttpServletResponseTest extends AgentTestRunner {
           operationName "servlet.request"
           spanType "web"
           errored true
+          statusCode { it != 0 }
           tags {
             "component" "java-web-servlet"
             "http.method" "GET"
             "http.url" "/"
             "span.kind" "server"
-            "http.status_code" Integer
             defaultTags()
             errorTags(ex.class, ex.message)
           }

--- a/dd-java-agent/instrumentation/sparkjava-2.3/src/test/groovy/SparkJavaBasedTest.groovy
+++ b/dd-java-agent/instrumentation/sparkjava-2.3/src/test/groovy/SparkJavaBasedTest.groovy
@@ -51,6 +51,7 @@ class SparkJavaBasedTest extends AgentTestRunner {
           spanType DDSpanTypes.HTTP_SERVER
           errored false
           parent()
+          statusCode 200
           tags {
             "$Tags.COMPONENT" "jetty-server"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
@@ -58,7 +59,6 @@ class SparkJavaBasedTest extends AgentTestRunner {
             "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_URL" "http://localhost:$port/param/asdf1234"
             "$Tags.HTTP_METHOD" "GET"
-            "$Tags.HTTP_STATUS" 200
             "$Tags.HTTP_ROUTE" String
             defaultTags()
           }

--- a/dd-java-agent/instrumentation/sparkjava-2.3/src/test/groovy/SparkJavaBasedTest.groovy
+++ b/dd-java-agent/instrumentation/sparkjava-2.3/src/test/groovy/SparkJavaBasedTest.groovy
@@ -56,11 +56,14 @@ class SparkJavaBasedTest extends AgentTestRunner {
             "$Tags.COMPONENT" "jetty-server"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-            "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_URL" "http://localhost:$port/param/asdf1234"
             "$Tags.HTTP_METHOD" "GET"
             "$Tags.HTTP_ROUTE" String
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" Integer
+            defaultMetrics()
           }
         }
       }

--- a/dd-java-agent/instrumentation/spring-cloud-zuul-2/src/test/groovy/SpringBootZuulTest.groovy
+++ b/dd-java-agent/instrumentation/spring-cloud-zuul-2/src/test/groovy/SpringBootZuulTest.groovy
@@ -207,6 +207,7 @@ class SpringBootZuulTest extends HttpServerTest<ConfigurableApplicationContext> 
       } else {
         parent()
       }
+      statusCode endpoint.status
       tags {
         "$Tags.COMPONENT" component
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
@@ -214,7 +215,6 @@ class SpringBootZuulTest extends HttpServerTest<ConfigurableApplicationContext> 
         "$Tags.PEER_PORT" Integer
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
-        "$Tags.HTTP_STATUS" endpoint.status
         "$Tags.HTTP_ROUTE" String
         if (endpoint == FORWARDED) {
           "$Tags.HTTP_FORWARDED_IP" endpoint.body

--- a/dd-java-agent/instrumentation/spring-cloud-zuul-2/src/test/groovy/SpringBootZuulTest.groovy
+++ b/dd-java-agent/instrumentation/spring-cloud-zuul-2/src/test/groovy/SpringBootZuulTest.groovy
@@ -212,7 +212,6 @@ class SpringBootZuulTest extends HttpServerTest<ConfigurableApplicationContext> 
         "$Tags.COMPONENT" component
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
         "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-        "$Tags.PEER_PORT" Integer
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
         "$Tags.HTTP_ROUTE" String
@@ -229,6 +228,10 @@ class SpringBootZuulTest extends HttpServerTest<ConfigurableApplicationContext> 
           "$DDTags.HTTP_QUERY" endpoint.query
         }
         defaultTags(true)
+      }
+      metrics {
+        "$Tags.PEER_PORT" Integer
+        defaultMetrics()
       }
     }
   }

--- a/dd-java-agent/instrumentation/spring-jms-3.1/src/test/groovy/SpringSAListenerTest.groovy
+++ b/dd-java-agent/instrumentation/spring-jms-3.1/src/test/groovy/SpringSAListenerTest.groovy
@@ -91,10 +91,13 @@ class SpringSAListenerTest extends AgentTestRunner {
         tags {
           "$Tags.COMPONENT" "jms"
           "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
+          defaultTags(true)
+        }
+        metrics {
           if (!messageListener && "$InstrumentationTags.RECORD_QUEUE_TIME_MS") {
             "$InstrumentationTags.RECORD_QUEUE_TIME_MS" {it >= 0 }
           }
-          defaultTags(true)
+          defaultMetrics()
         }
       }
     }

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/boot20Test/groovy/SpringWebfluxTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/boot20Test/groovy/SpringWebfluxTest.groovy
@@ -54,6 +54,7 @@ class SpringWebfluxTest extends AgentTestRunner {
           operationName "netty.request"
           spanType DDSpanTypes.HTTP_SERVER
           parent()
+          statusCode 200
           tags {
             "$Tags.COMPONENT" "netty"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
@@ -61,7 +62,6 @@ class SpringWebfluxTest extends AgentTestRunner {
             "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_URL" url
             "$Tags.HTTP_METHOD" "GET"
-            "$Tags.HTTP_STATUS" 200
             // BUG
             if (!testName.startsWith("functional")) { "$Tags.HTTP_ROUTE" "$urlPathWithVariables" }
             defaultTags()
@@ -129,6 +129,7 @@ class SpringWebfluxTest extends AgentTestRunner {
           operationName "netty.request"
           spanType DDSpanTypes.HTTP_SERVER
           parent()
+          statusCode 200
           tags {
             "$Tags.COMPONENT" "netty"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
@@ -136,7 +137,6 @@ class SpringWebfluxTest extends AgentTestRunner {
             "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_URL" url
             "$Tags.HTTP_METHOD" "GET"
-            "$Tags.HTTP_STATUS" 200
             // BUG
             if (!testName.startsWith("functional")) { "$Tags.HTTP_ROUTE" "$urlPathWithVariables" }
             defaultTags()
@@ -279,6 +279,7 @@ class SpringWebfluxTest extends AgentTestRunner {
           operationName "netty.request"
           spanType DDSpanTypes.HTTP_SERVER
           parent()
+          statusCode 404
           tags {
             "$Tags.COMPONENT" "netty"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
@@ -286,7 +287,6 @@ class SpringWebfluxTest extends AgentTestRunner {
             "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_URL" url
             "$Tags.HTTP_METHOD" "GET"
-            "$Tags.HTTP_STATUS" 404
             // BUG
             "$Tags.HTTP_ROUTE" "/**"
             defaultTags()
@@ -331,6 +331,7 @@ class SpringWebfluxTest extends AgentTestRunner {
           operationName "netty.request"
           spanType DDSpanTypes.HTTP_SERVER
           parent()
+          statusCode 202
           tags {
             "$Tags.COMPONENT" "netty"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
@@ -338,7 +339,6 @@ class SpringWebfluxTest extends AgentTestRunner {
             "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_URL" url
             "$Tags.HTTP_METHOD" "POST"
-            "$Tags.HTTP_STATUS" 202
             // BUG "$Tags.HTTP_ROUTE" "/echo"
             defaultTags()
           }
@@ -390,6 +390,7 @@ class SpringWebfluxTest extends AgentTestRunner {
           spanType DDSpanTypes.HTTP_SERVER
           errored true
           parent()
+          statusCode 500
           tags {
             "$Tags.COMPONENT" "netty"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
@@ -397,7 +398,6 @@ class SpringWebfluxTest extends AgentTestRunner {
             "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_URL" url
             "$Tags.HTTP_METHOD" "GET"
-            "$Tags.HTTP_STATUS" 500
             // BUG
             if (!testName.startsWith("functional")) { "$Tags.HTTP_ROUTE" "$urlPathWithVariables" }
             defaultTags()
@@ -465,6 +465,7 @@ class SpringWebfluxTest extends AgentTestRunner {
           operationName "netty.request"
           spanType DDSpanTypes.HTTP_SERVER
           parent()
+          statusCode 307
           tags {
             "$Tags.COMPONENT" "netty"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
@@ -472,7 +473,6 @@ class SpringWebfluxTest extends AgentTestRunner {
             "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_URL" url
             "$Tags.HTTP_METHOD" "GET"
-            "$Tags.HTTP_STATUS" 307
             // BUG "$Tags.HTTP_ROUTE" "/double-greet-redirect"
             defaultTags()
           }
@@ -500,6 +500,7 @@ class SpringWebfluxTest extends AgentTestRunner {
           operationName "netty.request"
           spanType DDSpanTypes.HTTP_SERVER
           parent()
+          statusCode 200
           tags {
             "$Tags.COMPONENT" "netty"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
@@ -507,7 +508,6 @@ class SpringWebfluxTest extends AgentTestRunner {
             "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_URL" finalUrl
             "$Tags.HTTP_METHOD" "GET"
-            "$Tags.HTTP_STATUS" 200
             // BUG "$Tags.HTTP_ROUTE" "/double-greet"
             defaultTags()
           }
@@ -551,6 +551,7 @@ class SpringWebfluxTest extends AgentTestRunner {
             operationName "netty.request"
             spanType DDSpanTypes.HTTP_SERVER
             parent()
+            statusCode 200
             tags {
               "$Tags.COMPONENT" "netty"
               "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
@@ -558,7 +559,6 @@ class SpringWebfluxTest extends AgentTestRunner {
               "$Tags.PEER_PORT" Integer
               "$Tags.HTTP_URL" url
               "$Tags.HTTP_METHOD" "GET"
-              "$Tags.HTTP_STATUS" 200
               // BUG
               if (!testName.startsWith("functional")) { "$Tags.HTTP_ROUTE" "$urlPathWithVariables" }
               defaultTags()

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/boot20Test/groovy/SpringWebfluxTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/boot20Test/groovy/SpringWebfluxTest.groovy
@@ -59,12 +59,15 @@ class SpringWebfluxTest extends AgentTestRunner {
             "$Tags.COMPONENT" "netty"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-            "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_URL" url
             "$Tags.HTTP_METHOD" "GET"
             // BUG
             if (!testName.startsWith("functional")) { "$Tags.HTTP_ROUTE" "$urlPathWithVariables" }
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" Integer
+            defaultMetrics()
           }
         }
         span {
@@ -134,12 +137,15 @@ class SpringWebfluxTest extends AgentTestRunner {
             "$Tags.COMPONENT" "netty"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-            "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_URL" url
             "$Tags.HTTP_METHOD" "GET"
             // BUG
             if (!testName.startsWith("functional")) { "$Tags.HTTP_ROUTE" "$urlPathWithVariables" }
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" Integer
+            defaultMetrics()
           }
         }
         span {
@@ -284,12 +290,15 @@ class SpringWebfluxTest extends AgentTestRunner {
             "$Tags.COMPONENT" "netty"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-            "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_URL" url
             "$Tags.HTTP_METHOD" "GET"
             // BUG
             "$Tags.HTTP_ROUTE" "/**"
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" Integer
+            defaultMetrics()
           }
         }
         span {
@@ -336,11 +345,14 @@ class SpringWebfluxTest extends AgentTestRunner {
             "$Tags.COMPONENT" "netty"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-            "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_URL" url
             "$Tags.HTTP_METHOD" "POST"
             // BUG "$Tags.HTTP_ROUTE" "/echo"
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" Integer
+            defaultMetrics()
           }
         }
         span {
@@ -395,12 +407,15 @@ class SpringWebfluxTest extends AgentTestRunner {
             "$Tags.COMPONENT" "netty"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-            "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_URL" url
             "$Tags.HTTP_METHOD" "GET"
             // BUG
             if (!testName.startsWith("functional")) { "$Tags.HTTP_ROUTE" "$urlPathWithVariables" }
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" Integer
+            defaultMetrics()
           }
         }
         span {
@@ -470,11 +485,14 @@ class SpringWebfluxTest extends AgentTestRunner {
             "$Tags.COMPONENT" "netty"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-            "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_URL" url
             "$Tags.HTTP_METHOD" "GET"
             // BUG "$Tags.HTTP_ROUTE" "/double-greet-redirect"
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" Integer
+            defaultMetrics()
           }
         }
         span {
@@ -505,11 +523,14 @@ class SpringWebfluxTest extends AgentTestRunner {
             "$Tags.COMPONENT" "netty"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-            "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_URL" finalUrl
             "$Tags.HTTP_METHOD" "GET"
             // BUG "$Tags.HTTP_ROUTE" "/double-greet"
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" Integer
+            defaultMetrics()
           }
         }
         span {
@@ -556,12 +577,15 @@ class SpringWebfluxTest extends AgentTestRunner {
               "$Tags.COMPONENT" "netty"
               "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
               "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-              "$Tags.PEER_PORT" Integer
               "$Tags.HTTP_URL" url
               "$Tags.HTTP_METHOD" "GET"
               // BUG
               if (!testName.startsWith("functional")) { "$Tags.HTTP_ROUTE" "$urlPathWithVariables" }
               defaultTags()
+            }
+            metrics {
+              "$Tags.PEER_PORT" Integer
+              defaultMetrics()
             }
           }
           span {

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/boot24Test/groovy/SpringWebfluxTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/boot24Test/groovy/SpringWebfluxTest.groovy
@@ -54,6 +54,7 @@ class SpringWebfluxTest extends AgentTestRunner {
           operationName "netty.request"
           spanType DDSpanTypes.HTTP_SERVER
           parent()
+          statusCode 200
           tags {
             "$Tags.COMPONENT" "netty"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
@@ -61,7 +62,6 @@ class SpringWebfluxTest extends AgentTestRunner {
             "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_URL" url
             "$Tags.HTTP_METHOD" "GET"
-            "$Tags.HTTP_STATUS" 200
             "$Tags.HTTP_ROUTE" "$urlPathWithVariables"
             defaultTags()
           }
@@ -128,6 +128,7 @@ class SpringWebfluxTest extends AgentTestRunner {
           operationName "netty.request"
           spanType DDSpanTypes.HTTP_SERVER
           parent()
+          statusCode 200
           tags {
             "$Tags.COMPONENT" "netty"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
@@ -135,7 +136,6 @@ class SpringWebfluxTest extends AgentTestRunner {
             "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_URL" url
             "$Tags.HTTP_METHOD" "GET"
-            "$Tags.HTTP_STATUS" 200
             "$Tags.HTTP_ROUTE" "$urlPathWithVariables"
             defaultTags()
           }
@@ -277,6 +277,7 @@ class SpringWebfluxTest extends AgentTestRunner {
           operationName "netty.request"
           spanType DDSpanTypes.HTTP_SERVER
           parent()
+          statusCode 404
           tags {
             "$Tags.COMPONENT" "netty"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
@@ -284,7 +285,6 @@ class SpringWebfluxTest extends AgentTestRunner {
             "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_URL" url
             "$Tags.HTTP_METHOD" "GET"
-            "$Tags.HTTP_STATUS" 404
             "$Tags.HTTP_ROUTE" "/**"
             defaultTags()
           }
@@ -328,6 +328,7 @@ class SpringWebfluxTest extends AgentTestRunner {
           operationName "netty.request"
           spanType DDSpanTypes.HTTP_SERVER
           parent()
+          statusCode 202
           tags {
             "$Tags.COMPONENT" "netty"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
@@ -335,7 +336,6 @@ class SpringWebfluxTest extends AgentTestRunner {
             "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_URL" url
             "$Tags.HTTP_METHOD" "POST"
-            "$Tags.HTTP_STATUS" 202
             "$Tags.HTTP_ROUTE" "/echo"
             defaultTags()
           }
@@ -387,6 +387,7 @@ class SpringWebfluxTest extends AgentTestRunner {
           spanType DDSpanTypes.HTTP_SERVER
           errored true
           parent()
+          statusCode 500
           tags {
             "$Tags.COMPONENT" "netty"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
@@ -394,7 +395,6 @@ class SpringWebfluxTest extends AgentTestRunner {
             "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_URL" url
             "$Tags.HTTP_METHOD" "GET"
-            "$Tags.HTTP_STATUS" 500
             "$Tags.HTTP_ROUTE" "$urlPathWithVariables"
             defaultTags()
           }
@@ -461,6 +461,7 @@ class SpringWebfluxTest extends AgentTestRunner {
           operationName "netty.request"
           spanType DDSpanTypes.HTTP_SERVER
           parent()
+          statusCode 307
           tags {
             "$Tags.COMPONENT" "netty"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
@@ -468,7 +469,6 @@ class SpringWebfluxTest extends AgentTestRunner {
             "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_URL" url
             "$Tags.HTTP_METHOD" "GET"
-            "$Tags.HTTP_STATUS" 307
             "$Tags.HTTP_ROUTE" "/double-greet-redirect"
             defaultTags()
           }
@@ -496,6 +496,7 @@ class SpringWebfluxTest extends AgentTestRunner {
           operationName "netty.request"
           spanType DDSpanTypes.HTTP_SERVER
           parent()
+          statusCode 200
           tags {
             "$Tags.COMPONENT" "netty"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
@@ -503,7 +504,6 @@ class SpringWebfluxTest extends AgentTestRunner {
             "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_URL" finalUrl
             "$Tags.HTTP_METHOD" "GET"
-            "$Tags.HTTP_STATUS" 200
             "$Tags.HTTP_ROUTE" "/double-greet"
             defaultTags()
           }
@@ -548,6 +548,7 @@ class SpringWebfluxTest extends AgentTestRunner {
             operationName "netty.request"
             spanType DDSpanTypes.HTTP_SERVER
             parent()
+            statusCode 200
             tags {
               "$Tags.COMPONENT" "netty"
               "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
@@ -555,7 +556,6 @@ class SpringWebfluxTest extends AgentTestRunner {
               "$Tags.PEER_PORT" Integer
               "$Tags.HTTP_URL" url
               "$Tags.HTTP_METHOD" "GET"
-              "$Tags.HTTP_STATUS" 200
               "$Tags.HTTP_ROUTE" String
               defaultTags()
             }

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/boot24Test/groovy/SpringWebfluxTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/boot24Test/groovy/SpringWebfluxTest.groovy
@@ -59,11 +59,14 @@ class SpringWebfluxTest extends AgentTestRunner {
             "$Tags.COMPONENT" "netty"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-            "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_URL" url
             "$Tags.HTTP_METHOD" "GET"
             "$Tags.HTTP_ROUTE" "$urlPathWithVariables"
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" Integer
+            defaultMetrics()
           }
         }
         span {
@@ -133,11 +136,14 @@ class SpringWebfluxTest extends AgentTestRunner {
             "$Tags.COMPONENT" "netty"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-            "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_URL" url
             "$Tags.HTTP_METHOD" "GET"
             "$Tags.HTTP_ROUTE" "$urlPathWithVariables"
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" Integer
+            defaultMetrics()
           }
         }
         span {
@@ -282,11 +288,14 @@ class SpringWebfluxTest extends AgentTestRunner {
             "$Tags.COMPONENT" "netty"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-            "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_URL" url
             "$Tags.HTTP_METHOD" "GET"
             "$Tags.HTTP_ROUTE" "/**"
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" Integer
+            defaultMetrics()
           }
         }
         span {
@@ -333,11 +342,14 @@ class SpringWebfluxTest extends AgentTestRunner {
             "$Tags.COMPONENT" "netty"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-            "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_URL" url
             "$Tags.HTTP_METHOD" "POST"
             "$Tags.HTTP_ROUTE" "/echo"
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" Integer
+            defaultMetrics()
           }
         }
         span {
@@ -392,11 +404,14 @@ class SpringWebfluxTest extends AgentTestRunner {
             "$Tags.COMPONENT" "netty"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-            "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_URL" url
             "$Tags.HTTP_METHOD" "GET"
             "$Tags.HTTP_ROUTE" "$urlPathWithVariables"
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" Integer
+            defaultMetrics()
           }
         }
         span {
@@ -466,11 +481,14 @@ class SpringWebfluxTest extends AgentTestRunner {
             "$Tags.COMPONENT" "netty"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-            "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_URL" url
             "$Tags.HTTP_METHOD" "GET"
             "$Tags.HTTP_ROUTE" "/double-greet-redirect"
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" Integer
+            defaultMetrics()
           }
         }
         span {
@@ -501,11 +519,14 @@ class SpringWebfluxTest extends AgentTestRunner {
             "$Tags.COMPONENT" "netty"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-            "$Tags.PEER_PORT" Integer
             "$Tags.HTTP_URL" finalUrl
             "$Tags.HTTP_METHOD" "GET"
             "$Tags.HTTP_ROUTE" "/double-greet"
             defaultTags()
+          }
+          metrics {
+            "$Tags.PEER_PORT" Integer
+            defaultMetrics()
           }
         }
         span {
@@ -553,11 +574,14 @@ class SpringWebfluxTest extends AgentTestRunner {
               "$Tags.COMPONENT" "netty"
               "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
               "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-              "$Tags.PEER_PORT" Integer
               "$Tags.HTTP_URL" url
               "$Tags.HTTP_METHOD" "GET"
               "$Tags.HTTP_ROUTE" String
               defaultTags()
+            }
+            metrics {
+              "$Tags.PEER_PORT" Integer
+              defaultMetrics()
             }
           }
           span {

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/test/groovy/dd/trace/instrumentation/springwebflux/client/SpringWebfluxHttpClientBase.groovy
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/test/groovy/dd/trace/instrumentation/springwebflux/client/SpringWebfluxHttpClientBase.groovy
@@ -72,6 +72,9 @@ abstract class SpringWebfluxHttpClientBase extends HttpClientTest {
         resourceName "$method $uri.path"
         spanType DDSpanTypes.HTTP_CLIENT
         errored exception != null
+        if (status) {
+          statusCode status
+        }
         tags {
           "$Tags.COMPONENT" NettyHttpClientDecorator.DECORATE.component()
           "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -80,9 +83,6 @@ abstract class SpringWebfluxHttpClientBase extends HttpClientTest {
           "$Tags.PEER_HOST_IPV4" { it == null || it == "127.0.0.1" } // Optional
           "$Tags.HTTP_URL" "${uri.resolve(uri.path)}"
           "$Tags.HTTP_METHOD" method
-          if (status) {
-            "$Tags.HTTP_STATUS" status
-          }
           if (tagQueryString) {
             "$DDTags.HTTP_QUERY" uri.query
             "$DDTags.HTTP_FRAGMENT" { it == null || it == uri.fragment } // Optional

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/test/groovy/dd/trace/instrumentation/springwebflux/client/SpringWebfluxHttpClientBase.groovy
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/test/groovy/dd/trace/instrumentation/springwebflux/client/SpringWebfluxHttpClientBase.groovy
@@ -79,7 +79,6 @@ abstract class SpringWebfluxHttpClientBase extends HttpClientTest {
           "$Tags.COMPONENT" NettyHttpClientDecorator.DECORATE.component()
           "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
           "$Tags.PEER_HOSTNAME" "localhost"
-          "$Tags.PEER_PORT" uri.port
           "$Tags.PEER_HOST_IPV4" { it == null || it == "127.0.0.1" } // Optional
           "$Tags.HTTP_URL" "${uri.resolve(uri.path)}"
           "$Tags.HTTP_METHOD" method
@@ -91,6 +90,10 @@ abstract class SpringWebfluxHttpClientBase extends HttpClientTest {
             errorTags(exception.class, exception.message)
           }
           defaultTags()
+        }
+        metrics {
+          "$Tags.PEER_PORT" uri.port
+          defaultMetrics()
         }
       }
     }

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/boot/SpringBootBasedTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/boot/SpringBootBasedTest.groovy
@@ -250,6 +250,7 @@ class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext>
       } else {
         parent()
       }
+      statusCode endpoint.status
       tags {
         "$Tags.COMPONENT" component
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
@@ -257,7 +258,6 @@ class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext>
         "$Tags.PEER_PORT" Integer
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
-        "$Tags.HTTP_STATUS" endpoint.status
         if (endpoint != LOGIN && endpoint != NOT_FOUND) { "$Tags.HTTP_ROUTE" String }
         if (endpoint == FORWARDED) {
           "$Tags.HTTP_FORWARDED_IP" endpoint.body

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/boot/SpringBootBasedTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/boot/SpringBootBasedTest.groovy
@@ -255,7 +255,6 @@ class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext>
         "$Tags.COMPONENT" component
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
         "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-        "$Tags.PEER_PORT" Integer
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
         if (endpoint != LOGIN && endpoint != NOT_FOUND) { "$Tags.HTTP_ROUTE" String }
@@ -272,6 +271,10 @@ class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext>
           "$DDTags.HTTP_QUERY" endpoint.query
         }
         defaultTags(true)
+      }
+      metrics {
+        "$Tags.PEER_PORT" Integer
+        defaultMetrics()
       }
     }
   }

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/dynamic/DynamicRoutingTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/dynamic/DynamicRoutingTest.groovy
@@ -180,7 +180,6 @@ class DynamicRoutingTest extends HttpServerTest<ConfigurableApplicationContext> 
         "$Tags.COMPONENT" component
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
         "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-        "$Tags.PEER_PORT" Integer
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
         if (endpoint == FORWARDED) {
@@ -196,6 +195,10 @@ class DynamicRoutingTest extends HttpServerTest<ConfigurableApplicationContext> 
           "$DDTags.HTTP_QUERY" endpoint.query
         }
         defaultTags(true)
+      }
+      metrics {
+        "$Tags.PEER_PORT" Integer
+        defaultMetrics()
       }
     }
   }

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/dynamic/DynamicRoutingTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/dynamic/DynamicRoutingTest.groovy
@@ -175,6 +175,7 @@ class DynamicRoutingTest extends HttpServerTest<ConfigurableApplicationContext> 
       } else {
         parent()
       }
+      statusCode endpoint.status
       tags {
         "$Tags.COMPONENT" component
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
@@ -182,7 +183,6 @@ class DynamicRoutingTest extends HttpServerTest<ConfigurableApplicationContext> 
         "$Tags.PEER_PORT" Integer
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
-        "$Tags.HTTP_STATUS" endpoint.status
         if (endpoint == FORWARDED) {
           "$Tags.HTTP_FORWARDED_IP" endpoint.body
         }

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/filter/ServletFilterTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/filter/ServletFilterTest.groovy
@@ -157,6 +157,7 @@ class ServletFilterTest extends HttpServerTest<ConfigurableApplicationContext> {
       } else {
         parent()
       }
+      statusCode endpoint.status
       tags {
         "$Tags.COMPONENT" component
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
@@ -164,7 +165,6 @@ class ServletFilterTest extends HttpServerTest<ConfigurableApplicationContext> {
         "$Tags.PEER_PORT" Integer
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
-        "$Tags.HTTP_STATUS" endpoint.status
         "$Tags.HTTP_ROUTE" String
         if (endpoint == FORWARDED) {
           "$Tags.HTTP_FORWARDED_IP" endpoint.body

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/filter/ServletFilterTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/filter/ServletFilterTest.groovy
@@ -162,7 +162,6 @@ class ServletFilterTest extends HttpServerTest<ConfigurableApplicationContext> {
         "$Tags.COMPONENT" component
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
         "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-        "$Tags.PEER_PORT" Integer
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
         "$Tags.HTTP_ROUTE" String
@@ -179,6 +178,10 @@ class ServletFilterTest extends HttpServerTest<ConfigurableApplicationContext> {
           "$DDTags.HTTP_QUERY" endpoint.query
         }
         defaultTags(true)
+      }
+      metrics {
+        "$Tags.PEER_PORT" Integer
+        defaultMetrics()
       }
     }
   }

--- a/dd-java-agent/instrumentation/synapse-3/src/test/groovy/datadog/trace/instrumentation/synapse3/SynapseServerTest.groovy
+++ b/dd-java-agent/instrumentation/synapse-3/src/test/groovy/datadog/trace/instrumentation/synapse3/SynapseServerTest.groovy
@@ -175,6 +175,7 @@ class SynapseServerTest extends AgentTestRunner {
         childOf((DDSpan) parentSpan)
       }
       topLevel parentSpan == null
+      statusCode statusCode
       tags {
         "$Tags.COMPONENT" "synapse-server"
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
@@ -182,7 +183,6 @@ class SynapseServerTest extends AgentTestRunner {
         "$Tags.PEER_PORT" Integer
         "$Tags.HTTP_URL" "/services/SimpleStockQuoteService"
         "$Tags.HTTP_METHOD" method
-        "$Tags.HTTP_STATUS" statusCode
         defaultTags()
       }
     }

--- a/dd-java-agent/instrumentation/synapse-3/src/test/groovy/datadog/trace/instrumentation/synapse3/SynapseServerTest.groovy
+++ b/dd-java-agent/instrumentation/synapse-3/src/test/groovy/datadog/trace/instrumentation/synapse3/SynapseServerTest.groovy
@@ -180,10 +180,13 @@ class SynapseServerTest extends AgentTestRunner {
         "$Tags.COMPONENT" "synapse-server"
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
         "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-        "$Tags.PEER_PORT" Integer
         "$Tags.HTTP_URL" "/services/SimpleStockQuoteService"
         "$Tags.HTTP_METHOD" method
         defaultTags()
+      }
+      metrics {
+        "$Tags.PEER_PORT" Integer
+        defaultMetrics()
       }
     }
   }

--- a/dd-java-agent/instrumentation/synapse-3/src/test/groovy/datadog/trace/instrumentation/synapse3/SynapseServerTest.groovy
+++ b/dd-java-agent/instrumentation/synapse-3/src/test/groovy/datadog/trace/instrumentation/synapse3/SynapseServerTest.groovy
@@ -162,20 +162,20 @@ class SynapseServerTest extends AgentTestRunner {
     statusCode == 500
   }
 
-  def httpSpan(TraceAssert trace, int index, String method, int statusCode, Object parentSpan = null) {
+  def httpSpan(TraceAssert trace, int index, String method, int httpStatus, Object parentSpan = null) {
     trace.span {
       serviceName expectedServiceName()
       operationName "http.request"
       resourceName "${method} /services/SimpleStockQuoteService"
       spanType DDSpanTypes.HTTP_SERVER
-      errored statusCode >= 500
+      errored httpStatus >= 500
       if (parentSpan == null) {
         parent()
       } else {
         childOf((DDSpan) parentSpan)
       }
       topLevel parentSpan == null
-      statusCode statusCode
+      statusCode httpStatus
       tags {
         "$Tags.COMPONENT" "synapse-server"
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER

--- a/dd-java-agent/instrumentation/tomcat-5.5/src/latestDepTest/groovy/TomcatServletTest.groovy
+++ b/dd-java-agent/instrumentation/tomcat-5.5/src/latestDepTest/groovy/TomcatServletTest.groovy
@@ -171,7 +171,6 @@ class TomcatServletTest extends AbstractServletTest<Tomcat, Context> {
         "$Tags.COMPONENT" component
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
         "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-        "$Tags.PEER_PORT" Integer
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
         if (endpoint == FORWARDED) {
@@ -200,6 +199,10 @@ class TomcatServletTest extends AbstractServletTest<Tomcat, Context> {
           "$DDTags.HTTP_QUERY" endpoint.query
         }
         defaultTags(true)
+      }
+      metrics {
+        "$Tags.PEER_PORT" Integer
+        defaultMetrics()
       }
     }
   }

--- a/dd-java-agent/instrumentation/tomcat-5.5/src/latestDepTest/groovy/TomcatServletTest.groovy
+++ b/dd-java-agent/instrumentation/tomcat-5.5/src/latestDepTest/groovy/TomcatServletTest.groovy
@@ -164,6 +164,9 @@ class TomcatServletTest extends AbstractServletTest<Tomcat, Context> {
       } else {
         parent()
       }
+      if (endpoint != TIMEOUT && endpoint != TIMEOUT_ERROR) {
+        statusCode { it == endpoint.status || !bubblesResponse }
+      }
       tags {
         "$Tags.COMPONENT" component
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
@@ -174,9 +177,7 @@ class TomcatServletTest extends AbstractServletTest<Tomcat, Context> {
         if (endpoint == FORWARDED) {
           "$Tags.HTTP_FORWARDED_IP" endpoint.body
         }
-        if (endpoint != TIMEOUT && endpoint != TIMEOUT_ERROR) {
-          "$Tags.HTTP_STATUS" { it == endpoint.status || !bubblesResponse }
-        } else {
+        if (!(endpoint != TIMEOUT && endpoint != TIMEOUT_ERROR)) {
           "timeout" 1_000
         }
         if (context) {

--- a/dd-java-agent/instrumentation/tomcat-5.5/src/test/groovy/TomcatServletTest.groovy
+++ b/dd-java-agent/instrumentation/tomcat-5.5/src/test/groovy/TomcatServletTest.groovy
@@ -183,6 +183,7 @@ class TomcatServletTest extends AbstractServletTest<Embedded, Context> {
       } else {
         parent()
       }
+      statusCode { it == endpoint.status || !bubblesResponse }
       tags {
         "$Tags.COMPONENT" component
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
@@ -193,9 +194,7 @@ class TomcatServletTest extends AbstractServletTest<Embedded, Context> {
         if (endpoint == FORWARDED) {
           "$Tags.HTTP_FORWARDED_IP" endpoint.body
         }
-        if (endpoint != TIMEOUT && endpoint != TIMEOUT_ERROR) {
-          "$Tags.HTTP_STATUS" { it == endpoint.status || !bubblesResponse }
-        } else {
+        if (!(endpoint != TIMEOUT && endpoint != TIMEOUT_ERROR)) {
           "timeout" 1_000
         }
         if (context) {

--- a/dd-java-agent/instrumentation/tomcat-5.5/src/test/groovy/TomcatServletTest.groovy
+++ b/dd-java-agent/instrumentation/tomcat-5.5/src/test/groovy/TomcatServletTest.groovy
@@ -188,14 +188,10 @@ class TomcatServletTest extends AbstractServletTest<Embedded, Context> {
         "$Tags.COMPONENT" component
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
         "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-        "$Tags.PEER_PORT" Integer
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
         if (endpoint == FORWARDED) {
           "$Tags.HTTP_FORWARDED_IP" endpoint.body
-        }
-        if (!(endpoint != TIMEOUT && endpoint != TIMEOUT_ERROR)) {
-          "timeout" 1_000
         }
         if (context) {
           "servlet.context" "/$context"
@@ -217,6 +213,13 @@ class TomcatServletTest extends AbstractServletTest<Embedded, Context> {
           "$DDTags.HTTP_QUERY" endpoint.query
         }
         defaultTags(true)
+      }
+      metrics {
+        if (!(endpoint != TIMEOUT && endpoint != TIMEOUT_ERROR)) {
+          "timeout" 1_000
+        }
+        "$Tags.PEER_PORT" Integer
+        defaultMetrics()
       }
     }
   }

--- a/dd-java-agent/instrumentation/twilio/src/test/groovy/test/TwilioClientTest.groovy
+++ b/dd-java-agent/instrumentation/twilio/src/test/groovy/test/TwilioClientTest.groovy
@@ -286,7 +286,7 @@ class TwilioClientTest extends AgentTestRunner {
           resourceName "POST /?/Accounts/abc/Messages.json"
           spanType DDSpanTypes.HTTP_CLIENT
           errored false
-          statusCode Integer
+          statusCode { it != 0 }
           tags {
             "$Tags.COMPONENT" "apache-httpclient"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -390,7 +390,7 @@ class TwilioClientTest extends AgentTestRunner {
           resourceName "POST /?/Accounts/abc/Messages.json"
           spanType DDSpanTypes.HTTP_CLIENT
           errored false
-          statusCode Integer
+          statusCode { it != 0 }
           tags {
             "$Tags.COMPONENT" "apache-httpclient"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -535,7 +535,7 @@ class TwilioClientTest extends AgentTestRunner {
           resourceName "POST /?/Accounts/abc/Messages.json"
           spanType DDSpanTypes.HTTP_CLIENT
           errored false
-          statusCode Integer
+          statusCode { it != 0 }
           tags {
             "$Tags.COMPONENT" "apache-httpclient"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT

--- a/dd-java-agent/instrumentation/twilio/src/test/groovy/test/TwilioClientTest.groovy
+++ b/dd-java-agent/instrumentation/twilio/src/test/groovy/test/TwilioClientTest.groovy
@@ -286,13 +286,13 @@ class TwilioClientTest extends AgentTestRunner {
           resourceName "POST /?/Accounts/abc/Messages.json"
           spanType DDSpanTypes.HTTP_CLIENT
           errored false
+          statusCode Integer
           tags {
             "$Tags.COMPONENT" "apache-httpclient"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" String
             "$Tags.HTTP_URL" String
             "$Tags.HTTP_METHOD" String
-            "$Tags.HTTP_STATUS" Integer
             defaultTags()
           }
         }
@@ -390,13 +390,13 @@ class TwilioClientTest extends AgentTestRunner {
           resourceName "POST /?/Accounts/abc/Messages.json"
           spanType DDSpanTypes.HTTP_CLIENT
           errored false
+          statusCode Integer
           tags {
             "$Tags.COMPONENT" "apache-httpclient"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" String
             "$Tags.HTTP_URL" String
             "$Tags.HTTP_METHOD" String
-            "$Tags.HTTP_STATUS" Integer
             defaultTags()
           }
         }
@@ -406,13 +406,13 @@ class TwilioClientTest extends AgentTestRunner {
           resourceName "POST /?/Accounts/abc/Messages.json"
           spanType DDSpanTypes.HTTP_CLIENT
           errored false
+          statusCode 500
           tags {
             "$Tags.COMPONENT" "apache-httpclient"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "api.twilio.com"
             "$Tags.HTTP_URL" "https://api.twilio.com/2010-04-01/Accounts/abc/Messages.json"
             "$Tags.HTTP_METHOD" "POST"
-            "$Tags.HTTP_STATUS" 500
             defaultTags()
           }
         }
@@ -535,13 +535,13 @@ class TwilioClientTest extends AgentTestRunner {
           resourceName "POST /?/Accounts/abc/Messages.json"
           spanType DDSpanTypes.HTTP_CLIENT
           errored false
+          statusCode Integer
           tags {
             "$Tags.COMPONENT" "apache-httpclient"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" String
             "$Tags.HTTP_URL" String
             "$Tags.HTTP_METHOD" String
-            "$Tags.HTTP_STATUS" Integer
             defaultTags()
           }
         }
@@ -551,13 +551,13 @@ class TwilioClientTest extends AgentTestRunner {
           resourceName "POST /?/Accounts/abc/Messages.json"
           spanType DDSpanTypes.HTTP_CLIENT
           errored false
+          statusCode 500
           tags {
             "$Tags.COMPONENT" "apache-httpclient"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.PEER_HOSTNAME" "api.twilio.com"
             "$Tags.HTTP_URL" "https://api.twilio.com/2010-04-01/Accounts/abc/Messages.json"
             "$Tags.HTTP_METHOD" "POST"
-            "$Tags.HTTP_STATUS" 500
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/test/groovy/server/VertxHttpServerForkedTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/test/groovy/server/VertxHttpServerForkedTest.groovy
@@ -122,10 +122,10 @@ class VertxHttpServerForkedTest extends HttpServerTest<Vertx> {
       spanType DDSpanTypes.HTTP_SERVER
       errored endpoint == ERROR || endpoint == EXCEPTION
       childOfPrevious()
+      statusCode Integer
       tags {
         "$Tags.COMPONENT" VertxRouterDecorator.DECORATE.component()
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
-        "$Tags.HTTP_STATUS" Integer
         if (endpoint == EXCEPTION && this.testExceptionTag()) {
           errorTags(RuntimeException, EXCEPTION.body)
         }
@@ -159,10 +159,10 @@ class VertxChainingHttpServerForkedTest extends VertxHttpServerForkedTest {
       spanType DDSpanTypes.HTTP_SERVER
       errored endpoint == ERROR || endpoint == EXCEPTION
       childOfPrevious()
+      statusCode Integer
       tags {
         "$Tags.COMPONENT" VertxRouterDecorator.DECORATE.component()
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
-        "$Tags.HTTP_STATUS" Integer
         "chain" true
         if (endpoint == EXCEPTION && this.testExceptionTag()) {
           errorTags(RuntimeException, EXCEPTION.body)

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/test/groovy/server/VertxHttpServerForkedTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/test/groovy/server/VertxHttpServerForkedTest.groovy
@@ -122,7 +122,7 @@ class VertxHttpServerForkedTest extends HttpServerTest<Vertx> {
       spanType DDSpanTypes.HTTP_SERVER
       errored endpoint == ERROR || endpoint == EXCEPTION
       childOfPrevious()
-      statusCode Integer
+      statusCode { it != 0 }
       tags {
         "$Tags.COMPONENT" VertxRouterDecorator.DECORATE.component()
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
@@ -159,7 +159,7 @@ class VertxChainingHttpServerForkedTest extends VertxHttpServerForkedTest {
       spanType DDSpanTypes.HTTP_SERVER
       errored endpoint == ERROR || endpoint == EXCEPTION
       childOfPrevious()
-      statusCode Integer
+      statusCode { it != 0 }
       tags {
         "$Tags.COMPONENT" VertxRouterDecorator.DECORATE.component()
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/SpanAssert.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/SpanAssert.groovy
@@ -73,6 +73,11 @@ class SpanAssert {
     checked.resourceName = true
   }
 
+  def statusCode(int statusCode) {
+    assert span.httpStatusCode == statusCode
+    checked.statusCode = true
+  }
+
   def resourceName(Closure<Boolean> eval) {
     assert eval(span.resourceName.toString())
     checked.resourceName = true

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/SpanAssert.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/SpanAssert.groovy
@@ -73,8 +73,14 @@ class SpanAssert {
     checked.resourceName = true
   }
 
-  def statusCode(int statusCode) {
-    assert span.httpStatusCode == statusCode
+  def statusCode(Object value) {
+    if (value instanceof Class) {
+      assert ((Class) value).isInstance(span.httpStatusCode)
+    } else if (value instanceof Closure) {
+      assert ((Closure) value).call(span.httpStatusCode)
+    } else {
+      assert span.httpStatusCode == value
+    }
     checked.statusCode = true
   }
 

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/SpanAssert.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/SpanAssert.groovy
@@ -74,12 +74,10 @@ class SpanAssert {
   }
 
   def statusCode(Object value) {
-    if (value instanceof Class) {
-      assert ((Class) value).isInstance(span.httpStatusCode)
-    } else if (value instanceof Closure) {
+    if (value instanceof Closure) {
       assert ((Closure) value).call(span.httpStatusCode)
     } else {
-      assert span.httpStatusCode == value
+      assert value instanceof Number && span.httpStatusCode == (value as Number).shortValue()
     }
     checked.statusCode = true
   }

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
@@ -529,7 +529,6 @@ abstract class HttpClientTest extends AgentTestRunner {
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
         "$Tags.PEER_HOSTNAME" uri.host
         "$Tags.PEER_HOST_IPV4" { it == null || it == "127.0.0.1" } // Optional
-        "$Tags.PEER_PORT" { it == uri.port || it == proxy.port || it == 443 || it == null }
         "$Tags.HTTP_URL" "${uri.resolve(uri.path)}" // remove fragment
         "$Tags.HTTP_METHOD" method
         if (tagQueryString) {
@@ -542,6 +541,7 @@ abstract class HttpClientTest extends AgentTestRunner {
         defaultTags()
       }
       metrics {
+        "$Tags.PEER_PORT" { it == uri.port || it == proxy.port || it == 443 || it == null }
         defaultMetrics()
       }
     }

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
@@ -521,6 +521,9 @@ abstract class HttpClientTest extends AgentTestRunner {
       resourceName "$method $uri.path"
       spanType DDSpanTypes.HTTP_CLIENT
       errored exception != null
+      if (status) {
+        statusCode status
+      }
       tags {
         "$Tags.COMPONENT" component
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -529,9 +532,6 @@ abstract class HttpClientTest extends AgentTestRunner {
         "$Tags.PEER_PORT" { it == uri.port || it == proxy.port || it == 443 || it == null }
         "$Tags.HTTP_URL" "${uri.resolve(uri.path)}" // remove fragment
         "$Tags.HTTP_METHOD" method
-        if (status) {
-          "$Tags.HTTP_STATUS" status
-        }
         if (tagQueryString) {
           "$DDTags.HTTP_QUERY" uri.query
           "$DDTags.HTTP_FRAGMENT" { it == null || it == uri.fragment } // Optional

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
@@ -639,6 +639,7 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
       resourceName endpoint.resource(method, address, testPathParam())
       spanType DDSpanTypes.HTTP_SERVER
       errored endpoint.errored
+      statusCode endpoint.status
       if (parentID != null) {
         traceId traceID
         parentId parentID
@@ -652,7 +653,6 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
         "$Tags.PEER_HOST_IPV4" { it == "127.0.0.1" || (endpoint == FORWARDED && it == endpoint.body) }
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
-        "$Tags.HTTP_STATUS" endpoint.status
         if (endpoint == FORWARDED) {
           "$Tags.HTTP_FORWARDED_IP" endpoint.body
         }

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
@@ -649,7 +649,6 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
       tags {
         "$Tags.COMPONENT" component
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
-        "$Tags.PEER_PORT" Integer
         "$Tags.PEER_HOST_IPV4" { it == "127.0.0.1" || (endpoint == FORWARDED && it == endpoint.body) }
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method
@@ -669,6 +668,7 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
         defaultTags(true)
       }
       metrics {
+        "$Tags.PEER_PORT" Integer
         defaultMetrics()
       }
     }

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/TestFrameworkTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/TestFrameworkTest.groovy
@@ -27,7 +27,6 @@ abstract class TestFrameworkTest extends AgentTestRunner {
       resourceName "$testSuite.$testName"
       spanType DDSpanTypes.TEST
       errored exception != null
-      statusCode testStatus
       tags {
         "$Tags.COMPONENT" component
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_TEST
@@ -35,6 +34,7 @@ abstract class TestFrameworkTest extends AgentTestRunner {
         "$Tags.TEST_SUITE" testSuite
         "$Tags.TEST_NAME" testName
         "$Tags.TEST_FRAMEWORK" testFramework
+        "$Tags.TEST_STATUS" testStatus
         if (testTags) {
           testTags.each { key, val -> tag(key, val) }
         }

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/TestFrameworkTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/TestFrameworkTest.groovy
@@ -27,6 +27,7 @@ abstract class TestFrameworkTest extends AgentTestRunner {
       resourceName "$testSuite.$testName"
       spanType DDSpanTypes.TEST
       errored exception != null
+      statusCode testStatus
       tags {
         "$Tags.COMPONENT" component
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_TEST
@@ -34,7 +35,6 @@ abstract class TestFrameworkTest extends AgentTestRunner {
         "$Tags.TEST_SUITE" testSuite
         "$Tags.TEST_NAME" testName
         "$Tags.TEST_FRAMEWORK" testFramework
-        "$Tags.TEST_STATUS" testStatus
         if (testTags) {
           testTags.each { key, val -> tag(key, val) }
         }

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/ConflatingMetricsAggregator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/ConflatingMetricsAggregator.java
@@ -13,7 +13,6 @@ import datadog.trace.api.Config;
 import datadog.trace.api.WellKnownTags;
 import datadog.trace.api.cache.DDCache;
 import datadog.trace.api.cache.DDCaches;
-import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.core.CoreSpan;
 import datadog.trace.util.AgentTaskScheduler;
@@ -173,7 +172,7 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
             SERVICE_NAMES.computeIfAbsent(span.getServiceName(), UTF8_ENCODE),
             span.getOperationName(),
             span.getType(),
-            span.getTag(Tags.HTTP_STATUS, ZERO));
+            span.getHttpStatusCode());
     boolean isNewKey = false;
     MetricKey key = keys.putIfAbsent(newKey, newKey);
     if (null == key) {

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/TraceMapper.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/TraceMapper.java
@@ -1,6 +1,7 @@
 package datadog.trace.common.writer.ddagent;
 
 import datadog.trace.api.DDTags;
+import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.core.CoreSpan;
 import datadog.trace.core.serialization.Mapper;
@@ -8,6 +9,7 @@ import java.util.List;
 
 public interface TraceMapper extends Mapper<List<? extends CoreSpan<?>>> {
 
+  UTF8BytesString HTTP_STATUS = UTF8BytesString.create(Tags.HTTP_STATUS);
   UTF8BytesString THREAD_NAME = UTF8BytesString.create(DDTags.THREAD_NAME);
   UTF8BytesString THREAD_ID = UTF8BytesString.create(DDTags.THREAD_ID);
   UTF8BytesString SAMPLING_PRIORITY_KEY = UTF8BytesString.create("_sampling_priority_v1");

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/TraceMapperV0_4.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/TraceMapperV0_4.java
@@ -74,6 +74,10 @@ public final class TraceMapperV0_4 implements TraceMapper {
           ++i;
         }
       }
+      UTF8BytesString httpStatus = metadata.getHttpStatusCode();
+      if (null != httpStatus) {
+        ++size;
+      }
       writable.startMap(size);
       int i = 0;
       for (Map.Entry<String, String> entry : metadata.getBaggage().entrySet()) {
@@ -83,6 +87,11 @@ public final class TraceMapperV0_4 implements TraceMapper {
           writable.writeString(entry.getValue(), null);
         }
         ++i;
+      }
+      // http status is special because it must be a string for metrics purposes
+      if (null != httpStatus) {
+        writable.writeUTF8(HTTP_STATUS);
+        writable.writeUTF8(httpStatus);
       }
       writable.writeUTF8(THREAD_NAME);
       writable.writeUTF8(metadata.getThreadName());

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/TraceMapperV0_5.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/TraceMapperV0_5.java
@@ -235,6 +235,10 @@ public final class TraceMapperV0_5 implements TraceMapper {
           ++i;
         }
       }
+      UTF8BytesString httpStatus = metadata.getHttpStatusCode();
+      if (null != httpStatus) {
+        ++size;
+      }
       writable.startMap(size);
       int i = 0;
       for (final Map.Entry<String, String> entry : metadata.getBaggage().entrySet()) {
@@ -244,6 +248,10 @@ public final class TraceMapperV0_5 implements TraceMapper {
           writeDictionaryEncoded(writable, entry.getValue());
         }
         ++i;
+      }
+      if (null != httpStatus) {
+        writeDictionaryEncoded(writable, HTTP_STATUS);
+        writeDictionaryEncoded(writable, httpStatus);
       }
       writeDictionaryEncoded(writable, THREAD_NAME);
       writeDictionaryEncoded(writable, metadata.getThreadName());

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreSpan.java
@@ -25,6 +25,8 @@ public interface CoreSpan<T extends CoreSpan<T>> {
 
   int getError();
 
+  short getHttpStatusCode();
+
   T setMeasured(boolean measured);
 
   T setErrorMessage(final String errorMessage);

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -2,6 +2,7 @@ package datadog.trace.core;
 
 import static datadog.trace.api.sampling.PrioritySampling.SAMPLER_DROP;
 import static datadog.trace.api.sampling.PrioritySampling.USER_DROP;
+import static datadog.trace.bootstrap.instrumentation.api.Tags.HTTP_STATUS;
 
 import datadog.trace.api.DDId;
 import datadog.trace.api.DDTags;
@@ -184,6 +185,17 @@ public class DDSpan implements AgentSpan, CoreSpan<DDSpan> {
   }
 
   @Override
+  public AgentSpan setHttpStatusCode(int statusCode) {
+    context.setHttpStatusCode((short) statusCode);
+    return this;
+  }
+
+  @Override
+  public short getHttpStatusCode() {
+    return context.getHttpStatusCode();
+  }
+
+  @Override
   public final DDSpan setTag(final String tag, final String value) {
     context.setTag(tag, value);
     return this;
@@ -197,25 +209,30 @@ public class DDSpan implements AgentSpan, CoreSpan<DDSpan> {
 
   @Override
   public DDSpan setTag(final String tag, final int value) {
-    context.setTag(tag, value);
+    // can't use tag interceptor because it might set a metric
+    // http.status is important because it is expected to be a string downstream
+    if (HTTP_STATUS.equals(tag)) {
+      context.setHttpStatusCode((short) value);
+    }
+    context.setMetric(tag, value);
     return this;
   }
 
   @Override
   public DDSpan setTag(final String tag, final long value) {
-    context.setTag(tag, value);
+    context.setMetric(tag, value);
     return this;
   }
 
   @Override
   public DDSpan setTag(final String tag, final double value) {
-    context.setTag(tag, value);
+    context.setMetric(tag, value);
     return this;
   }
 
   @Override
   public DDSpan setTag(final String tag, final Number value) {
-    context.setTag(tag, value);
+    context.setMetric(tag, value);
     return this;
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
@@ -407,7 +407,11 @@ public class DDSpanContext implements AgentSpan.Context {
     synchronized (unsafeTags) {
       for (final Map.Entry<String, ? extends Object> tag : map.entrySet()) {
         if (!tagInterceptor.interceptTag(this, tag.getKey(), tag.getValue())) {
-          unsafeSetTag(tag.getKey(), tag.getValue());
+          if (tag.getValue() instanceof Number) {
+            setMetric(tag.getKey(), (Number) tag.getValue());
+          } else {
+            unsafeSetTag(tag.getKey(), tag.getValue());
+          }
         }
       }
     }

--- a/dd-trace-core/src/main/java/datadog/trace/core/Metadata.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/Metadata.java
@@ -8,16 +8,23 @@ public class Metadata {
   private final UTF8BytesString threadName;
   private final Map<String, Object> tags;
   private final Map<String, String> baggage;
+  private final UTF8BytesString httpStatusCode;
 
   public Metadata(
       long threadId,
       UTF8BytesString threadName,
       Map<String, Object> tags,
-      Map<String, String> baggage) {
+      Map<String, String> baggage,
+      UTF8BytesString httpStatusCode) {
     this.threadId = threadId;
     this.threadName = threadName;
     this.tags = tags;
     this.baggage = baggage;
+    this.httpStatusCode = httpStatusCode;
+  }
+
+  public UTF8BytesString getHttpStatusCode() {
+    return httpStatusCode;
   }
 
   public long getThreadId() {

--- a/dd-trace-core/src/main/java/datadog/trace/core/processor/rule/URLAsResourceNameRule.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/processor/rule/URLAsResourceNameRule.java
@@ -1,12 +1,14 @@
 package datadog.trace.core.processor.rule;
 
+import datadog.trace.api.cache.RadixTreeCache;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
+import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.core.DDSpanContext;
 import datadog.trace.core.processor.TraceProcessor;
 
 public class URLAsResourceNameRule implements TraceProcessor.Rule {
 
-  private static final Integer NOT_FOUND = 404;
+  private static final UTF8BytesString NOT_FOUND = RadixTreeCache.HTTP_STATUSES.get(404);
 
   private static final String FEATURE_ALIAS_STATUS_404_RULE = "Status404Rule";
   private static final String FEATURE_ALIAS_STATUS_404_DECORATOR = "Status404Decorator";
@@ -38,9 +40,8 @@ public class URLAsResourceNameRule implements TraceProcessor.Rule {
     if (span.isResourceNameSet()) {
       return;
     }
-    final Object httpStatus = span.unsafeGetTag(Tags.HTTP_STATUS);
-    if (!status404Disabled && (NOT_FOUND.equals(httpStatus) || "404".equals(httpStatus))) {
-      span.setResourceName("404");
+    if (!status404Disabled && span.getHttpStatusCode() == 404) {
+      span.setResourceName(NOT_FOUND);
       return;
     }
     final Object url = span.unsafeGetTag(Tags.HTTP_URL);

--- a/dd-trace-core/src/main/java/datadog/trace/core/taginterceptor/TagInterceptor.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/taginterceptor/TagInterceptor.java
@@ -3,6 +3,7 @@ package datadog.trace.core.taginterceptor;
 import static datadog.trace.api.DDTags.ANALYTICS_SAMPLE_RATE;
 import static datadog.trace.api.DDTags.SPAN_TYPE;
 import static datadog.trace.api.sampling.PrioritySampling.USER_DROP;
+import static datadog.trace.bootstrap.instrumentation.api.Tags.HTTP_STATUS;
 import static datadog.trace.core.taginterceptor.RuleFlags.Feature.FORCE_MANUAL_DROP;
 import static datadog.trace.core.taginterceptor.RuleFlags.Feature.PEER_SERVICE;
 import static datadog.trace.core.taginterceptor.RuleFlags.Feature.RESOURCE_NAME;
@@ -71,6 +72,9 @@ public class TagInterceptor {
         return interceptAnalyticsSampleRate(span, value);
       case Tags.ERROR:
         return interceptError(span, value);
+      case HTTP_STATUS:
+        // not set internally but may come from manual instrumentation
+        return interceptHttpStatusCode(span, value);
       default:
         return intercept(span, tag, value);
     }
@@ -80,6 +84,19 @@ public class TagInterceptor {
     if (splitServiceTags.contains(tag)) {
       span.setServiceName(String.valueOf(value));
       return true;
+    }
+    return false;
+  }
+
+  private boolean interceptHttpStatusCode(DDSpanContext span, Object statusCode) {
+    if (statusCode instanceof Number) {
+      span.setHttpStatusCode(((Number) statusCode).shortValue());
+      return true;
+    }
+    try {
+      span.setHttpStatusCode(Short.parseShort(String.valueOf(statusCode)));
+      return true;
+    } catch (Throwable ignore) {
     }
     return false;
   }

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/ConflatingMetricAggregatorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/ConflatingMetricAggregatorTest.groovy
@@ -20,6 +20,8 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
 
   static Set<String> empty = new HashSet<>()
 
+  static final int HTTP_OK = 200
+
   @Shared
   long reportingInterval = 10
   @Shared
@@ -42,7 +44,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     aggregator.start()
 
     when:
-    aggregator.publish([new SimpleSpan("", "", "", "", false, false, false, 0, 0)])
+    aggregator.publish([new SimpleSpan("", "", "", "", false, false, false, 0, 0, HTTP_OK)])
     reportAndWaitUntilEmpty(aggregator)
     then:
     0 * sink._
@@ -69,12 +71,14 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     aggregator.start()
 
     when: "publish ignored resource names"
-    aggregator.publish([new SimpleSpan("", "", ignoredResourceName, "", true, true, false, 0, 0)])
-    aggregator.publish([new SimpleSpan("", "", UTF8BytesString.create(ignoredResourceName), "", true, true, false, 0, 0)])
+    aggregator.publish([new SimpleSpan("", "", ignoredResourceName, "", true, true, false, 0, 0, HTTP_OK)])
     aggregator.publish([
-      new SimpleSpan("", "", ignoredResourceName, "", true, true, false, 0, 0),
+      new SimpleSpan("", "", UTF8BytesString.create(ignoredResourceName), "", true, true, false, 0, 0, HTTP_OK)
+    ])
+    aggregator.publish([
+      new SimpleSpan("", "", ignoredResourceName, "", true, true, false, 0, 0, HTTP_OK),
       new SimpleSpan("", "",
-      "measured, not ignored, but child of ignored, so should be ignored", "", true, true, false, 0, 0)
+      "measured, not ignored, but child of ignored, so should be ignored", "", true, true, false, 0, 0, HTTP_OK)
     ])
     reportAndWaitUntilEmpty(aggregator)
     then:
@@ -95,13 +99,13 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
 
     when:
     CountDownLatch latch = new CountDownLatch(1)
-    aggregator.publish([new SimpleSpan("service", "operation", "resource", "type", false, true, false, 0, 100)])
+    aggregator.publish([new SimpleSpan("service", "operation", "resource", "type", false, true, false, 0, 100, HTTP_OK)])
     aggregator.report()
     latch.await(2, SECONDS)
 
     then:
     1 * writer.startBucket(1, _, _)
-    1 * writer.add(new MetricKey("resource", "service", "operation", "type", 0), _) >> { MetricKey key, AggregateMetric value ->
+    1 * writer.add(new MetricKey("resource", "service", "operation", "type", HTTP_OK), _) >> { MetricKey key, AggregateMetric value ->
       value.getHitCount() == 1 && value.getTopLevelCount() == 1 && value.getDuration() == 100
     }
     1 * writer.finishBucket() >> { latch.countDown() }
@@ -122,14 +126,14 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     when:
     CountDownLatch latch = new CountDownLatch(1)
     aggregator.publish([
-      new SimpleSpan("service", "operation", "resource", "type", measured, topLevel, false, 0, 100)
+      new SimpleSpan("service", "operation", "resource", "type", measured, topLevel, false, 0, 100, HTTP_OK)
     ])
     aggregator.report()
     latch.await(2, SECONDS)
 
     then:
     1 * writer.startBucket(1, _, _)
-    1 * writer.add(new MetricKey("resource", "service", "operation", "type", 0), _) >> { MetricKey key, AggregateMetric value ->
+    1 * writer.add(new MetricKey("resource", "service", "operation", "type", HTTP_OK), _) >> { MetricKey key, AggregateMetric value ->
       value.getHitCount() == 1 && value.getTopLevelCount() == topLevelCount && value.getDuration() == 100
     }
     1 * writer.finishBucket() >> { latch.countDown() }
@@ -153,9 +157,9 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
       sink, writer, 10, queueSize, reportingInterval, SECONDS)
     long duration = 100
     List<CoreSpan> trace = [
-      new SimpleSpan("service", "operation", "resource", "type", true, false, false, 0, duration),
-      new SimpleSpan("service1", "operation1", "resource1", "type", false, false, false, 0, 0),
-      new SimpleSpan("service2", "operation2", "resource2", "type", true, false, false, 0, duration * 2)
+      new SimpleSpan("service", "operation", "resource", "type", true, false, false, 0, duration, HTTP_OK),
+      new SimpleSpan("service1", "operation1", "resource1", "type", false, false, false, 0, 0, HTTP_OK),
+      new SimpleSpan("service2", "operation2", "resource2", "type", true, false, false, 0, duration * 2, HTTP_OK)
     ]
     aggregator.start()
 
@@ -171,10 +175,10 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     then: "metrics should be conflated"
     1 * writer.finishBucket() >> { latch.countDown() }
     1 * writer.startBucket(2, _, SECONDS.toNanos(reportingInterval))
-    1 * writer.add(new MetricKey("resource", "service", "operation", "type", 0), _) >> { MetricKey key, AggregateMetric value ->
+    1 * writer.add(new MetricKey("resource", "service", "operation", "type", HTTP_OK), _) >> { MetricKey key, AggregateMetric value ->
       value.getHitCount() == count && value.getDuration() == count * duration
     }
-    1 * writer.add(new MetricKey("resource2", "service2", "operation2", "type", 0), _) >> { MetricKey key, AggregateMetric value ->
+    1 * writer.add(new MetricKey("resource2", "service2", "operation2", "type", HTTP_OK), _) >> { MetricKey key, AggregateMetric value ->
       value.getHitCount() == count && value.getDuration() == count * duration * 2
     }
 
@@ -200,7 +204,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     CountDownLatch latch = new CountDownLatch(1)
     for (int i = 0; i < 11; ++i) {
       aggregator.publish([
-        new SimpleSpan("service" + i, "operation", "resource", "type", false, true, false, 0, duration)
+        new SimpleSpan("service" + i, "operation", "resource", "type", false, true, false, 0, duration, HTTP_OK)
       ])
     }
     aggregator.report()
@@ -209,11 +213,11 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     then: "the first aggregate should be dropped but the rest reported"
     1 * writer.startBucket(10, _, SECONDS.toNanos(reportingInterval))
     for (int i = 1; i < 11; ++i) {
-      1 * writer.add(new MetricKey("resource", "service" + i, "operation", "type", 0), _) >> { MetricKey key, AggregateMetric value ->
+      1 * writer.add(new MetricKey("resource", "service" + i, "operation", "type", HTTP_OK), _) >> { MetricKey key, AggregateMetric value ->
         value.getHitCount() == 1 && value.getDuration() == duration
       }
     }
-    0 * writer.add(new MetricKey("resource", "service0", "operation", "type", 0), _)
+    0 * writer.add(new MetricKey("resource", "service0", "operation", "type", HTTP_OK), _)
     1 * writer.finishBucket() >> { latch.countDown() }
 
     cleanup:
@@ -235,7 +239,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     CountDownLatch latch = new CountDownLatch(1)
     for (int i = 0; i < 5; ++i) {
       aggregator.publish([
-        new SimpleSpan("service" + i, "operation", "resource", "type", false, true, false, 0, duration)
+        new SimpleSpan("service" + i, "operation", "resource", "type", false, true, false, 0, duration, HTTP_OK)
       ])
     }
     aggregator.report()
@@ -244,7 +248,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     then: "all aggregates should be reported"
     1 * writer.startBucket(5, _, SECONDS.toNanos(reportingInterval))
     for (int i = 0; i < 5; ++i) {
-      1 * writer.add(new MetricKey("resource", "service" + i, "operation", "type", 0), _) >> { MetricKey key, AggregateMetric value ->
+      1 * writer.add(new MetricKey("resource", "service" + i, "operation", "type", HTTP_OK), _) >> { MetricKey key, AggregateMetric value ->
         value.getHitCount() == 1 && value.getDuration() == duration
       }
     }
@@ -254,7 +258,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     latch = new CountDownLatch(1)
     for (int i = 1; i < 5; ++i) {
       aggregator.publish([
-        new SimpleSpan("service" + i, "operation", "resource", "type", false, true, false, 0, duration)
+        new SimpleSpan("service" + i, "operation", "resource", "type", false, true, false, 0, duration, HTTP_OK)
       ])
     }
     aggregator.report()
@@ -263,11 +267,11 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     then: "aggregate not updated in cycle is not reported"
     1 * writer.startBucket(4, _, SECONDS.toNanos(reportingInterval))
     for (int i = 1; i < 5; ++i) {
-      1 * writer.add(new MetricKey("resource", "service" + i, "operation", "type", 0), _) >> { MetricKey key, AggregateMetric value ->
+      1 * writer.add(new MetricKey("resource", "service" + i, "operation", "type", HTTP_OK), _) >> { MetricKey key, AggregateMetric value ->
         value.getHitCount() == 1 && value.getDuration() == duration
       }
     }
-    0 * writer.add(new MetricKey("resource", "service0", "operation", "type", 0), _)
+    0 * writer.add(new MetricKey("resource", "service0", "operation", "type", HTTP_OK), _)
     1 * writer.finishBucket() >> { latch.countDown() }
 
     cleanup:
@@ -289,7 +293,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     CountDownLatch latch = new CountDownLatch(1)
     for (int i = 0; i < 5; ++i) {
       aggregator.publish([
-        new SimpleSpan("service" + i, "operation", "resource", "type", false, true, false, 0, duration)
+        new SimpleSpan("service" + i, "operation", "resource", "type", false, true, false, 0, duration, HTTP_OK)
       ])
     }
     aggregator.report()
@@ -298,7 +302,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     then: "all aggregates should be reported"
     1 * writer.startBucket(5, _, SECONDS.toNanos(reportingInterval))
     for (int i = 0; i < 5; ++i) {
-      1 * writer.add(new MetricKey("resource", "service" + i, "operation", "type", 0), _) >> { MetricKey key, AggregateMetric value ->
+      1 * writer.add(new MetricKey("resource", "service" + i, "operation", "type", HTTP_OK), _) >> { MetricKey key, AggregateMetric value ->
         value.getHitCount() == 1 && value.getDuration() == duration
       }
     }
@@ -331,7 +335,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     CountDownLatch latch = new CountDownLatch(1)
     for (int i = 0; i < 5; ++i) {
       aggregator.publish([
-        new SimpleSpan("service" + i, "operation", "resource", "type", false, true, false, 0, duration)
+        new SimpleSpan("service" + i, "operation", "resource", "type", false, true, false, 0, duration, HTTP_OK)
       ])
     }
     latch.await(2, SECONDS)
@@ -339,7 +343,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     then: "all aggregates should be reported"
     1 * writer.startBucket(5, _, SECONDS.toNanos(1))
     for (int i = 0; i < 5; ++i) {
-      1 * writer.add(new MetricKey("resource", "service" + i, "operation", "type", 0), _) >> { MetricKey key, AggregateMetric value ->
+      1 * writer.add(new MetricKey("resource", "service" + i, "operation", "type", HTTP_OK), _) >> { MetricKey key, AggregateMetric value ->
         value.getHitCount() == 1 && value.getDuration() == duration
       }
     }
@@ -364,12 +368,12 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     def overrides = new boolean[10]
     for (int i = 0; i < 5; ++i) {
       overrides[i] = aggregator.publish([
-        new SimpleSpan("service" + i, "operation", "resource", "type", false, true, false, 0, duration)
+        new SimpleSpan("service" + i, "operation", "resource", "type", false, true, false, 0, duration, HTTP_OK)
       ])
     }
     for (int i = 0; i < 5; ++i) {
       overrides[i + 5] = aggregator.publish([
-        new SimpleSpan("service" + i, "operation", "resource", "type", false, true, false, 0, duration)
+        new SimpleSpan("service" + i, "operation", "resource", "type", false, true, false, 0, duration, HTTP_OK)
       ])
     }
 
@@ -401,7 +405,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     CountDownLatch latch = new CountDownLatch(1)
     for (int i = 0; i < 5; ++i) {
       aggregator.publish([
-        new SimpleSpan("service" + i, "operation", "resource", "type", false, true, false, 0, duration)
+        new SimpleSpan("service" + i, "operation", "resource", "type", false, true, false, 0, duration, HTTP_OK)
       ])
     }
     latch.await(2, SECONDS)

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/FootprintTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/FootprintTest.groovy
@@ -54,7 +54,7 @@ class FootprintTest extends DDSpecification {
       boolean isError = ThreadLocalRandom.current().nextInt(traceCount) < errorThreshold
       aggregator.publish([
         new SimpleSpan(serviceName, operation, resourceName, type, true, true, isError, System.nanoTime(),
-        isError ? expDistributedNanoseconds(0.99) : expDistributedNanoseconds(0.01))
+        isError ? expDistributedNanoseconds(0.99) : expDistributedNanoseconds(0.01), 200)
       ])
     }
     aggregator.report()

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SimpleSpan.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SimpleSpan.groovy
@@ -16,6 +16,7 @@ class SimpleSpan implements CoreSpan<SimpleSpan> {
 
   private final long duration
   private final long startTime
+  private final short statusCode
 
   SimpleSpan(String serviceName,
   String operationName,
@@ -25,7 +26,8 @@ class SimpleSpan implements CoreSpan<SimpleSpan> {
   boolean topLevel,
   boolean error,
   long startTime,
-  long duration) {
+  long duration,
+  int statusCode) {
     this.serviceName = serviceName
     this.operationName = operationName
     this.resourceName = resourceName
@@ -35,6 +37,7 @@ class SimpleSpan implements CoreSpan<SimpleSpan> {
     this.error = error
     this.startTime = startTime
     this.duration = duration
+    this.statusCode = (short)statusCode
   }
 
   @Override
@@ -85,6 +88,11 @@ class SimpleSpan implements CoreSpan<SimpleSpan> {
   @Override
   int getError() {
     return error ? 1 : 0
+  }
+
+  @Override
+  short getHttpStatusCode() {
+    return statusCode
   }
 
   @Override

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddagent/TraceGenerator.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddagent/TraceGenerator.groovy
@@ -67,7 +67,8 @@ class TraceGenerator {
       baggage,
       tags,
       "type-" + ThreadLocalRandom.current().nextInt(lowCardinality ? 1 : 100),
-      ThreadLocalRandom.current().nextBoolean())
+      ThreadLocalRandom.current().nextBoolean(),
+      200)
   }
 
   private static String randomString(int maxLength) {
@@ -103,6 +104,7 @@ class TraceGenerator {
     private final String type
     private final boolean measured
     private final Metadata metadata
+    private final short statusCode
 
     PojoSpan(
     String serviceName,
@@ -118,7 +120,8 @@ class TraceGenerator {
     Map<String, String> baggage,
     Map<String, Object> tags,
     String type,
-    boolean measured) {
+    boolean measured,
+    int statusCode) {
       this.serviceName = UTF8BytesString.create(serviceName)
       this.operationName = UTF8BytesString.create(operationName)
       this.resourceName = UTF8BytesString.create(resourceName)
@@ -131,8 +134,9 @@ class TraceGenerator {
       this.metrics = metrics
       this.type = type
       this.measured = measured
+      this.statusCode = (short)statusCode
       this.metadata = new Metadata(Thread.currentThread().getId(),
-        UTF8BytesString.create(Thread.currentThread().getName()), tags, baggage)
+        UTF8BytesString.create(Thread.currentThread().getName()), tags, baggage, statusCode == 0 ? null : UTF8BytesString.create(Integer.toString(statusCode)))
     }
 
     @Override
@@ -183,6 +187,11 @@ class TraceGenerator {
     @Override
     int getError() {
       return error
+    }
+
+    @Override
+    short getHttpStatusCode() {
+      return statusCode
     }
 
     @Override

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddagent/TraceMapperV04PayloadTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddagent/TraceMapperV04PayloadTest.groovy
@@ -1,5 +1,6 @@
 package datadog.trace.common.writer.ddagent
 
+import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.core.serialization.ByteBufferConsumer
 import datadog.trace.core.serialization.FlushingBuffer
 import datadog.trace.core.serialization.msgpack.MsgPackWriter
@@ -190,11 +191,15 @@ class TraceMapperV04PayloadTest extends DDSpecification {
               meta.put(unpacker.unpackString(), unpacker.unpackString())
             }
             for (Map.Entry<String, String> entry : meta.entrySet()) {
-              Object tag = expectedSpan.getTag(entry.getKey())
-              if (null != tag) {
-                assertEquals(String.valueOf(tag), entry.getValue())
+              if (Tags.HTTP_STATUS.equals(entry.getKey())) {
+                assertEquals(String.valueOf(expectedSpan.getHttpStatusCode()), entry.getValue())
               } else {
-                assertEquals(expectedSpan.getBaggage().get(entry.getKey()), entry.getValue())
+                Object tag = expectedSpan.getTag(entry.getKey())
+                if (null != tag) {
+                  assertEquals(String.valueOf(tag), entry.getValue())
+                } else {
+                  assertEquals(expectedSpan.getBaggage().get(entry.getKey()), entry.getValue())
+                }
               }
             }
           }

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddagent/TraceMapperV05PayloadTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddagent/TraceMapperV05PayloadTest.groovy
@@ -1,6 +1,7 @@
 package datadog.trace.common.writer.ddagent
 
 import datadog.trace.api.DDId
+import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.core.serialization.ByteBufferConsumer
 import datadog.trace.core.serialization.FlushingBuffer
 import datadog.trace.core.serialization.msgpack.MsgPackWriter
@@ -53,7 +54,7 @@ class TraceMapperV05PayloadTest extends DDSpecification {
       Collections.emptyMap(),
       Collections.emptyMap(),
       UUID.randomUUID().toString(),
-      false))
+      false, 0))
     int traceSize = calculateSize(repeatedTrace)
     // 30KB body
     int bufferSize = 30 << 10
@@ -199,11 +200,15 @@ class TraceMapperV05PayloadTest extends DDSpecification {
               meta.put(dictionary[unpacker.unpackInt()], dictionary[unpacker.unpackInt()])
             }
             for (Map.Entry<String, String> entry : meta.entrySet()) {
-              Object tag = expectedSpan.getTag(entry.getKey())
-              if (null != tag) {
-                assertEquals(String.valueOf(tag), entry.getValue())
+              if (Tags.HTTP_STATUS.equals(entry.getKey())) {
+                assertEquals(String.valueOf(expectedSpan.getHttpStatusCode()), entry.getValue())
               } else {
-                assertEquals(expectedSpan.getBaggage().get(entry.getKey()), entry.getValue())
+                Object tag = expectedSpan.getTag(entry.getKey())
+                if (null != tag) {
+                  assertEquals(String.valueOf(tag), entry.getValue())
+                } else {
+                  assertEquals(expectedSpan.getBaggage().get(entry.getKey()), entry.getValue())
+                }
               }
             }
             int metricsSize = unpacker.unpackMapHeader()

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/CoreSpanBuilderTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/CoreSpanBuilderTest.groovy
@@ -40,6 +40,8 @@ class CoreSpanBuilderTest extends DDCoreSpecification {
     def tags = [
       "1": true,
       "2": "fakeString",
+    ]
+    def metrics = [
       "3": 42.0,
     ]
 
@@ -49,6 +51,9 @@ class CoreSpanBuilderTest extends DDCoreSpecification {
     tags.each {
       builder = builder.withTag(it.key, it.value)
     }
+    metrics.each {
+      builder = builder.withTag(it.key, it.value)
+    }
 
     when:
     DDSpan span = builder.start()
@@ -56,6 +61,7 @@ class CoreSpanBuilderTest extends DDCoreSpecification {
     then:
     span.getOperationName() == expectedName
     span.tags.subMap(tags.keySet()) == tags
+    span.unsafeMetrics.subMap(metrics.keySet()) == metrics
 
 
     when:

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/TraceInterceptorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/TraceInterceptorTest.groovy
@@ -155,14 +155,14 @@ class TraceInterceptorTest extends DDCoreSpecification {
     def tags = span.context().tags
 
     tags["boolean-tag"] == true
-    tags["number-tag"] == 5.0
+    span.context().unsafeMetrics["number-tag"] == 5.0
     tags["string-tag"] == "howdy"
 
     tags["thread.name"] != null
     tags["thread.id"] != null
     tags["runtime-id"] != null
     tags["language"] != null
-    tags.size() == 7
+    tags.size() == 6
   }
 
   def "register interceptor through bridge"() {

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/processor/TraceProcessorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/processor/TraceProcessorTest.groovy
@@ -66,7 +66,7 @@ class TraceProcessorTest extends DDCoreSpecification {
     processor.onTraceComplete(trace)
 
     then:
-    span.getResourceName() == "404"
+    span.getResourceName() as String == "404"
   }
 
   def "resource name set with url path #url to #resourceName"() {

--- a/dd-trace-core/src/traceAgentTest/groovy/TraceGenerator.groovy
+++ b/dd-trace-core/src/traceAgentTest/groovy/TraceGenerator.groovy
@@ -67,7 +67,8 @@ class TraceGenerator {
       baggage,
       tags,
       "type-" + ThreadLocalRandom.current().nextInt(lowCardinality ? 1 : 100),
-      ThreadLocalRandom.current().nextBoolean())
+      ThreadLocalRandom.current().nextBoolean(),
+      200)
   }
 
   private static String randomString(int maxLength) {
@@ -103,6 +104,7 @@ class TraceGenerator {
     private final String type
     private final boolean measured
     private final Metadata metadata
+    private final short statusCode
 
     PojoSpan(
     String serviceName,
@@ -118,7 +120,8 @@ class TraceGenerator {
     Map<String, String> baggage,
     Map<String, Object> tags,
     String type,
-    boolean measured) {
+    boolean measured,
+    int statusCode) {
       this.serviceName = UTF8BytesString.create(serviceName)
       this.operationName = UTF8BytesString.create(operationName)
       this.resourceName = UTF8BytesString.create(resourceName)
@@ -131,8 +134,10 @@ class TraceGenerator {
       this.metrics = metrics
       this.type = type
       this.measured = measured
+      this.statusCode = (short)statusCode
       this.metadata = new Metadata(Thread.currentThread().getId(),
-        UTF8BytesString.create(Thread.currentThread().getName()), tags, baggage)
+        UTF8BytesString.create(Thread.currentThread().getName()), tags, baggage,
+        statusCode == 0 ? null : UTF8BytesString.create(Integer.toString(statusCode)))
     }
 
     @Override
@@ -183,6 +188,11 @@ class TraceGenerator {
     @Override
     int getError() {
       return error
+    }
+
+    @Override
+    short getHttpStatusCode() {
+      return statusCode
     }
 
     @Override

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/OpenTracingAPITest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/OpenTracingAPITest.groovy
@@ -103,8 +103,11 @@ class OpenTracingAPITest extends DDSpecification {
           tags {
             "$datadog.trace.bootstrap.instrumentation.api.Tags.COMPONENT" "test-component"
             "someBoolean" true
-            "someNumber" 1
             defaultTags()
+          }
+          metrics {
+            "someNumber" 1
+            defaultMetrics()
           }
         }
       }

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/OpenTracingAPITest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/OpenTracingAPITest.groovy
@@ -144,8 +144,11 @@ class OpenTracingAPITest extends DDSpecification {
           tags {
             "$datadog.trace.bootstrap.instrumentation.api.Tags.COMPONENT" "test-component"
             "someBoolean" true
-            "someNumber" 1
             defaultTags()
+          }
+          metrics {
+            "someNumber" 1
+            defaultMetrics()
           }
         }
       }

--- a/internal-api/src/main/java/datadog/trace/api/cache/RadixTreeCache.java
+++ b/internal-api/src/main/java/datadog/trace/api/cache/RadixTreeCache.java
@@ -1,6 +1,7 @@
 package datadog.trace.api.cache;
 
 import datadog.trace.api.IntFunction;
+import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 
 /** Sparse cache of values associated with a small integer */
@@ -14,12 +15,21 @@ public final class RadixTreeCache<T> {
         }
       };
 
+  private static final IntFunction<UTF8BytesString> TO_STRING =
+      new IntFunction<UTF8BytesString>() {
+        @Override
+        public UTF8BytesString apply(int value) {
+          return UTF8BytesString.create(Integer.toString(value));
+        }
+      };
+
   public static final int UNSET_STATUS = 0;
   // should cover range [0, 512) to cover all standard HTTP statuses
   // 16 pages of 32 should keep the tree sparse with typical pages
   // covering ranges [192, 224), [288, 320), [384, 416), [480, 512)
-  public static final RadixTreeCache<Integer> HTTP_STATUSES =
-      new RadixTreeCache<>(16, 32, AUTOBOX, 200, 201, 301, 307, 400, 401, 403, 404, 500, 502, 503);
+  public static final RadixTreeCache<UTF8BytesString> HTTP_STATUSES =
+      new RadixTreeCache<>(
+          16, 32, TO_STRING, 200, 201, 301, 307, 400, 401, 403, 404, 500, 502, 503);
 
   public static final int UNSET_PORT = 0;
   // should cover range [0, 2^16)

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
@@ -52,6 +52,10 @@ public interface AgentSpan extends MutableSpan {
 
   AgentSpan addThrowable(Throwable throwable);
 
+  AgentSpan setHttpStatusCode(int statusCode);
+
+  short getHttpStatusCode();
+
   @Override
   AgentSpan getLocalRootSpan();
 

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -466,6 +466,16 @@ public class AgentTracer {
     }
 
     @Override
+    public AgentSpan setHttpStatusCode(int statusCode) {
+      return this;
+    }
+
+    @Override
+    public short getHttpStatusCode() {
+      return 0;
+    }
+
+    @Override
     public AgentSpan getLocalRootSpan() {
       return this;
     }

--- a/internal-api/src/test/groovy/datadog/trace/api/cache/RadixTreeCacheTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/cache/RadixTreeCacheTest.groovy
@@ -127,7 +127,7 @@ class RadixTreeCacheTest extends DDSpecification {
 
   def "cache HTTP statuses"() {
     expect:
-    Integer.valueOf(status) == RadixTreeCache.HTTP_STATUSES.get(status)
+    Integer.toString(status) == RadixTreeCache.HTTP_STATUSES.get(status) as String
     where:
     status << [0, 200, 201, 404, 329, 599, 700]
   }


### PR DESCRIPTION
Currently we write out all tags to `meta` which means we coerce them to strings, which means open tracing users have no way to create custom measures from facets. This changes that so all numeric tags except for `http.status` are written out to `metrics` instead. `http.status` is expected to be a string downstream so must be treated specially, which makes this change a little messy.

This change is quite convenient for tracer metrics though because getting the HTTP status tag shows up in profiles a lot - replacing it with a field access will improve this but not enough to bother benchmarking.