### PR TITLE
Revert check configuration of spotless dependency

### DIFF
--- a/gradle/spotless.gradle
+++ b/gradle/spotless.gradle
@@ -67,9 +67,5 @@ spotless {
   }
 }
 
-tasks.register('formatCode') {
-  dependsOn 'spotlessApply'
-}
-check.configure {
-  dependsOn 'spotlessCheck'
-}
+task formatCode(dependsOn: ['spotlessApply'])
+check.dependsOn 'spotlessCheck'


### PR DESCRIPTION
This makes the `check` task pass again. For some reason the changed configuration ran `spotlessXml` without excluding the `build` directories.
