### PR TITLE
Use simple job to do fan-in in on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,7 +124,7 @@ jobs:
           key: dd-trace-java-v3-{{ .Branch }}-{{ epoch }}
           <<: *save_cache_paths
 
-  default_test_job: &default_test_job
+  base_tests: &base_tests
     <<: *defaults
     resource_class: xlarge
 
@@ -169,8 +169,8 @@ jobs:
       - store_test_results:
           path: ./results
 
-  default_inst_test_job:
-    <<: *default_test_job
+  instrumentation_tests:
+    <<: *base_tests
     resource_class: xlarge
 
     docker:
@@ -235,8 +235,8 @@ jobs:
       - store_test_results:
           path: ./results
 
-  default_smoke_test_job:
-    <<: *default_test_job
+  smoke_tests:
+    <<: *base_tests
     resource_class: medium
 
     docker:
@@ -285,7 +285,7 @@ jobs:
   # The only way to do fan-in in CircleCI seems to have a proper job, so let's have one that
   # doesn't consume so many resources. The execution time for this including spin up seems to
   # be around 6 seconds.
-  default_fan_in_tests_job:
+  fan_in:
     resource_class: small
 
     docker:
@@ -301,7 +301,7 @@ jobs:
           command: echo 'All tests passed!'
 
   agent_integration_tests:
-    <<: *default_test_job
+    <<: *base_tests
     resource_class: medium
 
     docker:
@@ -398,68 +398,68 @@ workflows:
     jobs:
       - build
 
-      - default_test_job:
+      - base_tests:
           requires:
             - build
           prefixTestTask: true
-          name: test_<< matrix.testTask >>_base
+          name: z_test_<< matrix.testTask >>_base
           matrix:
             <<: *test_matrix
 
-      - default_test_job:
+      - base_tests:
           requires:
             - build
-          name: test_8_base
+          name: z_test_8_base
           testTask: test jacocoTestReport jacocoTestCoverageVerification
 
-      - default_inst_test_job:
+      - instrumentation_tests:
           requires:
             - build
           prefixTestTask: true
-          name: test_<< matrix.testTask >>_inst
+          name: z_test_<< matrix.testTask >>_inst
           matrix:
             <<: *test_matrix
 
-      - default_inst_test_job:
+      - instrumentation_tests:
           requires:
             - build
-          name: test_8_inst
+          name: z_test_8_inst
           testTask: test
 
-      - default_inst_test_job:
+      - instrumentation_tests:
           requires:
             - build
           name: test_8_inst_latest
           testTask: latestDepTest
 
-      - default_smoke_test_job:
+      - smoke_tests:
           requires:
             - build
           prefixTestTask: true
-          name: test_<< matrix.testTask >>_smoke
+          name: z_test_<< matrix.testTask >>_smoke
           matrix:
             <<: *test_matrix
 
-      - default_smoke_test_job:
+      - smoke_tests:
           requires:
             - build
-          name: test_8_smoke
+          name: z_test_8_smoke
           testTask: test
 
-      - default_fan_in_tests_job:
+      - fan_in:
           requires:
-            - test_<< matrix.testTask >>_base
-            - test_<< matrix.testTask >>_inst
-            - test_<< matrix.testTask >>_smoke
+            - z_test_<< matrix.testTask >>_base
+            - z_test_<< matrix.testTask >>_inst
+            - z_test_<< matrix.testTask >>_smoke
           name: test_<< matrix.testTask >>
           matrix:
             <<: *test_matrix
 
-      - default_fan_in_tests_job:
+      - fan_in:
           requires:
-            - test_8_base
-            - test_8_inst
-            - test_8_smoke
+            - z_test_8_base
+            - z_test_8_inst
+            - z_test_8_smoke
           name: test_8
           testTask: "8"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,10 @@ save_cache_paths: &save_cache_paths
     # Cached dependencies for sbt handled by coursier
     - ~/.cache/coursier
 
+test_matrix: &test_matrix
+  parameters:
+    testTask: [ "7", "IBM8", "ZULU8","ORACLE8", "11", "ZULU11", "ZULU13", "15" ]
+
 parameters:
   gradle_flags:
     # Using no-daemon is important for the caches to be in a consistent state
@@ -165,7 +169,7 @@ jobs:
       - store_test_results:
           path: ./results
 
-  default_inst_test_job: &default_inst_test_job
+  default_inst_test_job:
     <<: *default_test_job
     resource_class: xlarge
 
@@ -231,7 +235,7 @@ jobs:
       - store_test_results:
           path: ./results
 
-  default_smoke_test_job: &default_inst_test_job
+  default_smoke_test_job:
     <<: *default_test_job
     resource_class: medium
 
@@ -278,9 +282,28 @@ jobs:
       - store_test_results:
           path: ./results
 
+  # The only way to do fan-in in CircleCI seems to have a proper job, so let's have one that
+  # doesn't consume so many resources. The execution time for this including spin up seems to
+  # be around 6 seconds.
+  default_fan_in_tests_job:
+    resource_class: small
+
+    docker:
+      - image: alpine
+
+    parameters:
+      testTask:
+        type: string
+
+    steps:
+      - run:
+          name: All tests for << parameters.testTask >> passed!
+          command: echo 'All tests passed!'
+
   agent_integration_tests:
     <<: *default_test_job
     resource_class: medium
+
     docker:
       - image: *default_container
       - image: datadog/agent:7.25.0
@@ -379,15 +402,14 @@ workflows:
           requires:
             - build
           prefixTestTask: true
-          name: test_<< matrix.testTask >>
+          name: test_<< matrix.testTask >>_base
           matrix:
-            parameters:
-              testTask: [ "7", "IBM8", "ZULU8","ORACLE8", "11", "ZULU11", "ZULU13", "15" ]
+            <<: *test_matrix
 
       - default_test_job:
           requires:
             - build
-          name: test_8
+          name: test_8_base
           testTask: test jacocoTestReport jacocoTestCoverageVerification
 
       - default_inst_test_job:
@@ -396,8 +418,7 @@ workflows:
           prefixTestTask: true
           name: test_<< matrix.testTask >>_inst
           matrix:
-            parameters:
-              testTask: [ "7", "IBM8", "ZULU8","ORACLE8", "11", "ZULU11", "ZULU13", "15" ]
+            <<: *test_matrix
 
       - default_inst_test_job:
           requires:
@@ -417,14 +438,30 @@ workflows:
           prefixTestTask: true
           name: test_<< matrix.testTask >>_smoke
           matrix:
-            parameters:
-              testTask: [ "7", "IBM8", "ZULU8","ORACLE8", "11", "ZULU11", "ZULU13", "15" ]
+            <<: *test_matrix
 
       - default_smoke_test_job:
           requires:
             - build
           name: test_8_smoke
           testTask: test
+
+      - default_fan_in_tests_job:
+          requires:
+            - test_<< matrix.testTask >>_base
+            - test_<< matrix.testTask >>_inst
+            - test_<< matrix.testTask >>_smoke
+          name: test_<< matrix.testTask >>
+          matrix:
+            <<: *test_matrix
+
+      - default_fan_in_tests_job:
+          requires:
+            - test_8_base
+            - test_8_inst
+            - test_8_smoke
+          name: test_8
+          testTask: "8"
 
       - agent_integration_tests:
           requires:


### PR DESCRIPTION
* Create a fan-in job for every fan-out group so that we can keep the number of required rules small
* Rename the fan-out jobs so that they get sorted last in the GitHub UI
