### PR TITLE
Remove spotlessXml since it keeps processing build artifacts

### DIFF
--- a/gradle/spotless.gradle
+++ b/gradle/spotless.gradle
@@ -56,15 +56,6 @@ spotless {
     trimTrailingWhitespace()
     endWithNewline()
   }
-
-  format 'xml', {
-    toggleOffOn()
-    target 'src/**/*.xml', 'src/**/*.xsd', 'gradle/**/*.xml', 'gradle/**/*.xsd', 'conf/**/*.xml', 'conf/**/*.xsd', 'application/**/*.xml', 'application/**/*.xsd'
-    targetExclude '**/build/**', '**/target/**', '**/logback.xml'
-    trimTrailingWhitespace()
-    endWithNewline()
-    eclipseWtp('xml').configFile(configPath + '/enforcement/spotless-xml.properties')
-  }
 }
 
 tasks.register('formatCode') {


### PR DESCRIPTION
Spurious CI failures on this form keeps happening in the `check` job:

```
org.gradle.api.tasks.TaskExecutionException: Execution failed for task ':spotlessXml'.
...
Caused by: org.gradle.api.UncheckedIOException: Unable to store input properties for task ':spotlessXml'. Property 'lineEndingsPolicy' with value 'com.diffplug.spotless.extra.GitAttributesLineEndings$RelocatablePolicy@16138' cannot be serialized.
...
Caused by: org.gradle.api.GradleException: Could not read path '/home/circleci/dd-trace-java/workspace/dd-java-agent/build/resources/main/shared/jnr/ffi/util'
...
```