### PR TITLE
Remove guava classLoaderMatcher

### DIFF
--- a/dd-java-agent/instrumentation/guava-10/src/main/java/datadog/trace/instrumentation/guava10/ListenableFutureInstrumentation.java
+++ b/dd-java-agent/instrumentation/guava-10/src/main/java/datadog/trace/instrumentation/guava10/ListenableFutureInstrumentation.java
@@ -1,6 +1,5 @@
 package datadog.trace.instrumentation.guava10;
 
-import static datadog.trace.agent.tooling.ClassLoaderMatcher.hasClassesNamed;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
 import static java.util.Collections.singletonMap;
@@ -26,14 +25,6 @@ public class ListenableFutureInstrumentation extends Instrumenter.Tracing {
 
   public ListenableFutureInstrumentation() {
     super("guava");
-  }
-
-  private final ElementMatcher<ClassLoader> CLASS_LOADER_MATCHER =
-      hasClassesNamed("com.google.common.util.concurrent.AbstractFuture");
-
-  @Override
-  public ElementMatcher<ClassLoader> classLoaderMatcher() {
-    return CLASS_LOADER_MATCHER;
   }
 
   @Override


### PR DESCRIPTION
The instrumentation uses a `named` matcher, so it doesn't need it.