### PR TITLE
use NonBlockingHashMap in ConflatingMetricsAggregator

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/Aggregator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/Aggregator.java
@@ -10,8 +10,8 @@ import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import org.jctools.maps.NonBlockingHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -22,7 +22,7 @@ final class Aggregator implements Runnable {
   private final Queue<Batch> batchPool;
   private final BlockingQueue<Batch> inbox;
   private final LRUCache<MetricKey, AggregateMetric> aggregates;
-  private final ConcurrentHashMap<MetricKey, Batch> pending;
+  private final NonBlockingHashMap<MetricKey, Batch> pending;
   private final Set<MetricKey> commonKeys;
   private final MetricWriter writer;
   // the reporting interval controls how much history will be buffered
@@ -36,7 +36,7 @@ final class Aggregator implements Runnable {
       MetricWriter writer,
       Queue<Batch> batchPool,
       BlockingQueue<Batch> inbox,
-      ConcurrentHashMap<MetricKey, Batch> pending,
+      NonBlockingHashMap<MetricKey, Batch> pending,
       final Set<MetricKey> commonKeys,
       int maxAggregates,
       long reportingInterval,

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/ConflatingMetricsAggregator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/ConflatingMetricsAggregator.java
@@ -20,8 +20,8 @@ import java.util.List;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import org.jctools.maps.NonBlockingHashMap;
 import org.jctools.queues.MpscBlockingConsumerArrayQueue;
 import org.jctools.queues.SpmcArrayQueue;
 import org.slf4j.Logger;
@@ -38,8 +38,8 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
 
   private final Set<String> ignoredResources;
   private final Queue<Batch> batchPool;
-  private final ConcurrentHashMap<MetricKey, Batch> pending;
-  private final ConcurrentHashMap<MetricKey, MetricKey> keys;
+  private final NonBlockingHashMap<MetricKey, Batch> pending;
+  private final NonBlockingHashMap<MetricKey, MetricKey> keys;
   private final Thread thread;
   private final BlockingQueue<Batch> inbox;
   private final Sink sink;
@@ -100,8 +100,8 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
     this.ignoredResources = ignoredResources;
     this.inbox = new MpscBlockingConsumerArrayQueue<>(queueSize);
     this.batchPool = new SpmcArrayQueue<>(maxAggregates);
-    this.pending = new ConcurrentHashMap<>(maxAggregates * 4 / 3, 0.75f);
-    this.keys = new ConcurrentHashMap<>();
+    this.pending = new NonBlockingHashMap<>(maxAggregates * 4 / 3);
+    this.keys = new NonBlockingHashMap<>();
     this.sink = sink;
     this.aggregator =
         new Aggregator(


### PR DESCRIPTION
About half the time publishing metrics on the application threads is spent in CHM operations, this use NonBlockingHashMap which performed better in some microbenchmarks I ran. 
<img width="583" alt="Screenshot 2021-05-20 at 13 13 14" src="https://user-images.githubusercontent.com/16439049/118976833-63b03c00-b96d-11eb-91ab-7cb4097b2648.png">
