### PR TITLE
remove capturing lambda and use ALFU in AdaptiveSampler

### DIFF
--- a/internal-api/internal-api-8/internal-api-8.gradle
+++ b/internal-api/internal-api-8/internal-api-8.gradle
@@ -1,3 +1,7 @@
+plugins {
+  id 'me.champeau.jmh'
+}
+
 ext {
   enableJunitPlatform = true
   minJavaVersionForTests = JavaVersion.VERSION_1_8
@@ -19,4 +23,9 @@ dependencies {
   testCompile deps.mockito
   testCompile deps.slf4j
   testCompile project(":utils:test-utils")
+}
+
+jmh {
+  jmhVersion = '1.28'
+  duplicateClassesStrategy = DuplicatesStrategy.EXCLUDE
 }

--- a/internal-api/internal-api-8/src/jmh/java/datadog/trace/api/sampling/AdaptiveSamplerBenchmark.java
+++ b/internal-api/internal-api-8/src/jmh/java/datadog/trace/api/sampling/AdaptiveSamplerBenchmark.java
@@ -1,0 +1,56 @@
+package datadog.trace.api.sampling;
+
+import static datadog.trace.api.sampling.AdaptiveSamplerBenchmark.ITERATION_TIME_MILLIS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+@Warmup(iterations = 5, time = ITERATION_TIME_MILLIS, timeUnit = MILLISECONDS)
+@Measurement(iterations = 5, time = ITERATION_TIME_MILLIS, timeUnit = MILLISECONDS)
+@OutputTimeUnit(MILLISECONDS)
+@BenchmarkMode(Mode.Throughput)
+@State(Scope.Benchmark)
+public class AdaptiveSamplerBenchmark {
+
+  public static final int ITERATION_TIME_MILLIS = 1000;
+
+  @Param("5000")
+  int samplesPerWindow;
+
+  @Param("500")
+  long durationWindowMillis;
+
+  private AdaptiveSampler sampler;
+
+  @Setup(Level.Iteration)
+  public void setup() {
+    int lookback = (int) (ITERATION_TIME_MILLIS / durationWindowMillis);
+    sampler =
+        new AdaptiveSampler(
+            Duration.of(durationWindowMillis, ChronoUnit.MILLIS), samplesPerWindow, lookback);
+  }
+
+  @Threads(4)
+  @Benchmark
+  public boolean sample(SamplerCounters counters) {
+    boolean sampled = sampler.sample();
+    if (sampled) {
+      ++counters.sampled;
+    }
+    ++counters.tests;
+    return sampled;
+  }
+}

--- a/internal-api/internal-api-8/src/jmh/java/datadog/trace/api/sampling/SamplerCounters.java
+++ b/internal-api/internal-api-8/src/jmh/java/datadog/trace/api/sampling/SamplerCounters.java
@@ -1,0 +1,33 @@
+package datadog.trace.api.sampling;
+
+import org.openjdk.jmh.annotations.AuxCounters;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+@State(Scope.Thread)
+@AuxCounters(AuxCounters.Type.EVENTS)
+public class SamplerCounters {
+
+  long tests;
+  long sampled;
+
+  public long tests() {
+    return tests;
+  }
+
+  public long sampled() {
+    return sampled;
+  }
+
+  public double sampleRate() {
+    return (double) sampled / tests;
+  }
+
+  @Setup(Level.Iteration)
+  public void reset() {
+    tests = 0;
+    sampled = 0;
+  }
+}


### PR DESCRIPTION
I just spotted a capturing lambda here which this removes. Also uses `AtomicLongFieldUpdater`, not because I have evidence it is better, but because I like them.