### PR TITLE
don't treat broken pipes as errors

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/BaseDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/BaseDecorator.java
@@ -102,7 +102,6 @@ public abstract class BaseDecorator {
 
   public AgentSpan onError(final AgentSpan span, final Throwable throwable) {
     if (throwable != null) {
-      span.setError(true);
       span.addThrowable(throwable instanceof ExecutionException ? throwable.getCause() : throwable);
     }
     return span;

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/BaseDecoratorTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/BaseDecoratorTest.groovy
@@ -58,7 +58,6 @@ class BaseDecoratorTest extends DDSpecification {
 
     then:
     if (error) {
-      1 * span.setError(true)
       1 * span.addThrowable(error)
     }
     0 * _

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -172,14 +172,20 @@ public class DDSpan implements AgentSpan, CoreSpan<DDSpan> {
 
   @Override
   public DDSpan addThrowable(final Throwable error) {
-    setError(true);
+    String message = error.getMessage();
+    if (!"broken pipe".equalsIgnoreCase(message)) {
+      // broken pipes happen when clients abort connections,
+      // which might happen because the application is overloaded
+      // or warming up - capturing the stack trace and keeping
+      // the trace may exacerbate existing problems.
+      setError(true);
+      final StringWriter errorString = new StringWriter();
+      error.printStackTrace(new PrintWriter(errorString));
+      setTag(DDTags.ERROR_STACK, errorString.toString());
+    }
 
-    setTag(DDTags.ERROR_MSG, error.getMessage());
+    setTag(DDTags.ERROR_MSG, message);
     setTag(DDTags.ERROR_TYPE, error.getClass().getName());
-
-    final StringWriter errorString = new StringWriter();
-    error.printStackTrace(new PrintWriter(errorString));
-    setTag(DDTags.ERROR_STACK, errorString.toString());
 
     return this;
   }


### PR DESCRIPTION
Broken pipes happen when the client aborts the connection, and this tends to be a symptom of a web application being in an overloaded state, or warming up. Always keeping the trace because it is marked as an error, and then recording the stack trace (which is expensive) exacerbates this. This PR changes `BaseDecorator` to allow `DDSpan` to decide when a span with an error is considered an error, and avoids situations where we have errors with status code 200 (the response is never sent so the status code is not updated). `DDSpan` just excludes errors with the name "Broken pipe".

<img width="638" alt="Screenshot 2021-05-24 at 13 55 16" src="https://user-images.githubusercontent.com/16439049/119351414-57432080-bc98-11eb-9e91-d93e792db35f.png">
<img width="622" alt="Screenshot 2021-05-24 at 14 00 21" src="https://user-images.githubusercontent.com/16439049/119351474-63c77900-bc98-11eb-89a5-696c668e39d7.png">
