### PR TITLE
Fix latestDepTest for SpringAmqpTest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -342,7 +342,7 @@ jobs:
           name: Build Project
           command: >-
             MAVEN_OPTS="-Xms64M -Xmx256M"
-            GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx1900M -Xms64M -XX:ErrorFile=/tmp/hs_err_pid%p.log'"
+            GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx1750M -Xms256M -XX:ErrorFile=/tmp/hs_err_pid%p.log'"
             ./gradlew build -PskipTests
             << pipeline.parameters.gradle_flags >>
             --max-workers=3
@@ -352,7 +352,7 @@ jobs:
           command: |
             mvn_local_repo=$(mvn help:evaluate -Dexpression=settings.localRepository -q -DforceStdout)
             rm -rf "${mvn_local_repo}/com/datadoghq"
-            export GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx1900M -Xms64M -XX:ErrorFile=/tmp/hs_err_pid%p.log'"
+            export GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx1750M -Xms256M -XX:ErrorFile=/tmp/hs_err_pid%p.log'"
             ./gradlew publishToMavenLocal << pipeline.parameters.gradle_flags >> --max-workers=3
             cd test-published-dependencies
             ../gradlew check --max-workers=3

--- a/dd-java-agent/instrumentation/spring-rabbit/src/main/java/datadog/trace/instrumentation/springamqp/AbstractMessageListenerContainerInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-rabbit/src/main/java/datadog/trace/instrumentation/springamqp/AbstractMessageListenerContainerInstrumentation.java
@@ -1,14 +1,19 @@
 package datadog.trace.instrumentation.springamqp;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.ExcludeType.RUNNABLE;
+import static java.util.Collections.singleton;
 import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.ExcludeFilterProvider;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.bootstrap.InstrumentationContext;
+import datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.State;
 import datadog.trace.context.TraceScope;
+import java.util.Collection;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
@@ -16,7 +21,8 @@ import net.bytebuddy.matcher.ElementMatcher;
 import org.springframework.amqp.core.Message;
 
 @AutoService(Instrumenter.class)
-public class AbstractMessageListenerContainerInstrumentation extends Instrumenter.Tracing {
+public class AbstractMessageListenerContainerInstrumentation extends Instrumenter.Tracing
+    implements ExcludeFilterProvider {
 
   public AbstractMessageListenerContainerInstrumentation() {
     super("spring-rabbit");
@@ -30,6 +36,14 @@ public class AbstractMessageListenerContainerInstrumentation extends Instrumente
   @Override
   public Map<String, String> contextStore() {
     return singletonMap("org.springframework.amqp.core.Message", State.class.getName());
+  }
+
+  @Override
+  public Map<ExcludeFilter.ExcludeType, ? extends Collection<String>> excludedClasses() {
+    // Even though this class isn't immediately relevant to spring-rabbit, it's loaded by the test.
+    return singletonMap(
+        RUNNABLE,
+        singleton("org.springframework.boot.logging.logback.LogbackLoggingSystem$ShutdownHandler"));
   }
 
   @Override


### PR DESCRIPTION
Runnable class was ignored by additional matcher.  The class has been around for a while, but likely just wasn't loaded during our test until `2.5.0` was released.