### PR TITLE
Minimal Instrumentation Gateway API and test

### DIFF
--- a/internal-api/internal-api.gradle
+++ b/internal-api/internal-api.gradle
@@ -47,4 +47,5 @@ dependencies {
   api deps.slf4j
 
   testImplementation project(":utils:test-utils")
+  testImplementation("org.assertj:assertj-core:2.9.1")
 }

--- a/internal-api/src/main/java/datadog/trace/api/function/BiConsumer.java
+++ b/internal-api/src/main/java/datadog/trace/api/function/BiConsumer.java
@@ -1,0 +1,5 @@
+package datadog.trace.api.function;
+
+public interface BiConsumer<T, U> {
+  void accept(T t, U u);
+}

--- a/internal-api/src/main/java/datadog/trace/api/function/BiFunction.java
+++ b/internal-api/src/main/java/datadog/trace/api/function/BiFunction.java
@@ -1,0 +1,5 @@
+package datadog.trace.api.function;
+
+public interface BiFunction<T, U, R> {
+  R apply(T t, U u);
+}

--- a/internal-api/src/main/java/datadog/trace/api/function/Supplier.java
+++ b/internal-api/src/main/java/datadog/trace/api/function/Supplier.java
@@ -1,0 +1,5 @@
+package datadog.trace.api.function;
+
+public interface Supplier<T> {
+  T get();
+}

--- a/internal-api/src/main/java/datadog/trace/api/function/TriConsumer.java
+++ b/internal-api/src/main/java/datadog/trace/api/function/TriConsumer.java
@@ -1,0 +1,5 @@
+package datadog.trace.api.function;
+
+public interface TriConsumer<S, T, U> {
+  void accept(S s, T t, U u);
+}

--- a/internal-api/src/main/java/datadog/trace/api/gateway/CallbackProvider.java
+++ b/internal-api/src/main/java/datadog/trace/api/gateway/CallbackProvider.java
@@ -1,0 +1,6 @@
+package datadog.trace.api.gateway;
+
+/** The API used by the producers to retrieve callbacks. */
+public interface CallbackProvider {
+  <C> C getCallback(EventType<C> eventType);
+}

--- a/internal-api/src/main/java/datadog/trace/api/gateway/EventType.java
+++ b/internal-api/src/main/java/datadog/trace/api/gateway/EventType.java
@@ -1,0 +1,29 @@
+package datadog.trace.api.gateway;
+
+/**
+ * The {@code EventType} is a unique identifier for an event.
+ *
+ * @param <C> The type of the callback related to the {@code EventType}
+ */
+public class EventType<C> {
+  private final String name;
+  private final int id;
+
+  protected EventType(final String name, final int id) {
+    this.name = name;
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  int getId() {
+    return id;
+  }
+
+  @Override
+  public String toString() {
+    return "EventType{" + "name='" + name + '\'' + '}';
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/gateway/Events.java
+++ b/internal-api/src/main/java/datadog/trace/api/gateway/Events.java
@@ -1,0 +1,39 @@
+package datadog.trace.api.gateway;
+
+import datadog.trace.api.Function;
+import datadog.trace.api.function.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public final class Events {
+  private static final AtomicInteger nextId = new AtomicInteger(0);
+
+  /** A request started * */
+  public static final EventType<Supplier<Flow<RequestContext>>> REQUEST_STARTED =
+      new ET<>("request.started");
+
+  /** A request ended * */
+  public static final EventType<Function<RequestContext, Flow<Void>>> REQUEST_ENDED =
+      new ET<>("request.ended");
+
+  /** A request header as a key and values separated by , */
+  public static final EventType<TriConsumer<RequestContext, String, String>> REQUEST_HEADER =
+      new ET<>("server.request.header");
+
+  /** All request headers have been provided */
+  public static final EventType<Function<RequestContext, Flow<Void>>> REQUEST_HEADER_DONE =
+      new ET<>("server.request.header.done");
+
+  /** The unparsed request uri, incl. the query string. */
+  public static final EventType<BiFunction<RequestContext, String, Flow<Void>>> REQUEST_URI_RAW =
+      new ET<>("server.request.uri.raw");
+
+  public static final int MAX_EVENTS = nextId.get();
+
+  private static final class ET<T> extends EventType<T> {
+    public ET(String type) {
+      super(type, nextId.getAndIncrement());
+    }
+  }
+
+  private Events() {}
+}

--- a/internal-api/src/main/java/datadog/trace/api/gateway/Flow.java
+++ b/internal-api/src/main/java/datadog/trace/api/gateway/Flow.java
@@ -1,0 +1,27 @@
+package datadog.trace.api.gateway;
+
+public interface Flow<T> {
+  Flow.Action getAction();
+
+  T getResult();
+
+  interface Action {}
+
+  class ResultFlow<R> implements Flow<R> {
+    private final R result;
+
+    public ResultFlow(R result) {
+      this.result = result;
+    }
+
+    @Override
+    public Action getAction() {
+      return null;
+    }
+
+    @Override
+    public R getResult() {
+      return result;
+    }
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/gateway/InstrumentationGateway.java
+++ b/internal-api/src/main/java/datadog/trace/api/gateway/InstrumentationGateway.java
@@ -1,0 +1,46 @@
+package datadog.trace.api.gateway;
+
+import static datadog.trace.api.gateway.Events.MAX_EVENTS;
+
+import java.util.concurrent.atomic.AtomicReferenceArray;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class InstrumentationGateway implements CallbackProvider, SubscriptionService {
+  private static final Logger log = LoggerFactory.getLogger(InstrumentationGateway.class);
+
+  private final AtomicReferenceArray<Object> callbacks;
+
+  public InstrumentationGateway() {
+    callbacks = new AtomicReferenceArray<>(MAX_EVENTS);
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public <C> C getCallback(EventType<C> eventType) {
+    return (C) callbacks.get(eventType.getId());
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public <C> Subscription registerCallback(final EventType<C> eventType, final C callback) {
+    if (!callbacks.compareAndSet(eventType.getId(), null, callback)) {
+      C existing = (C) callbacks.get(eventType.getId());
+      String message =
+          "Trying to overwrite existing callback " + existing + " for event type " + eventType;
+      log.warn(message);
+      throw new IllegalStateException(message);
+    }
+
+    return new Subscription() {
+      @Override
+      public void cancel() {
+        if (!callbacks.compareAndSet(eventType.getId(), callback, null)) {
+          if (log.isDebugEnabled()) {
+            log.debug("Failed to unregister callback {} for event type {}", callback, eventType);
+          }
+        }
+      }
+    };
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/gateway/RequestContext.java
+++ b/internal-api/src/main/java/datadog/trace/api/gateway/RequestContext.java
@@ -1,0 +1,7 @@
+package datadog.trace.api.gateway;
+
+/**
+ * This is the context that will travel along with the request and be presented to the
+ * Instrumentation Gateway subscribers.
+ */
+public interface RequestContext {}

--- a/internal-api/src/main/java/datadog/trace/api/gateway/Subscription.java
+++ b/internal-api/src/main/java/datadog/trace/api/gateway/Subscription.java
@@ -1,0 +1,5 @@
+package datadog.trace.api.gateway;
+
+public interface Subscription {
+  void cancel();
+}

--- a/internal-api/src/main/java/datadog/trace/api/gateway/SubscriptionService.java
+++ b/internal-api/src/main/java/datadog/trace/api/gateway/SubscriptionService.java
@@ -1,0 +1,6 @@
+package datadog.trace.api.gateway;
+
+/** The API used by the consumers to register callbacks. */
+public interface SubscriptionService {
+  <C> Subscription registerCallback(EventType<C> eventType, C callback);
+}

--- a/internal-api/src/test/java/datadog/trace/api/gateway/InstrumentationGatewayTest.java
+++ b/internal-api/src/test/java/datadog/trace/api/gateway/InstrumentationGatewayTest.java
@@ -1,0 +1,97 @@
+package datadog.trace.api.gateway;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import datadog.trace.api.Function;
+import datadog.trace.api.function.Supplier;
+import org.assertj.core.api.ThrowableAssert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class InstrumentationGatewayTest {
+
+  private InstrumentationGateway gateway;
+  private RequestContext context;
+  private Supplier<Flow<RequestContext>> callback;
+  private Subscription subscription;
+
+  @Before
+  public void setUp() {
+    gateway = new InstrumentationGateway();
+    context = new RequestContext() {};
+    callback =
+        new Supplier<Flow<RequestContext>>() {
+          @Override
+          public Flow<RequestContext> get() {
+            return new Flow.ResultFlow<>(context);
+          }
+        };
+    subscription = gateway.registerCallback(Events.REQUEST_STARTED, callback);
+  }
+
+  @Test
+  public void testGetCallback() {
+    // check event without registered callback
+    assertThat(gateway.getCallback(Events.REQUEST_ENDED)).isNull();
+    // check event with registered callback
+    Supplier<Flow<RequestContext>> cback = gateway.getCallback(Events.REQUEST_STARTED);
+    assertThat(cback).isEqualTo(callback);
+    Flow<RequestContext> flow = cback.get();
+    assertThat(flow.getAction()).isNull();
+    RequestContext ctxt = flow.getResult();
+    assertThat(ctxt).isEqualTo(context);
+  }
+
+  @Test
+  public void testRegisterCallback() {
+    // check event without registered callback
+    assertThat(gateway.getCallback(Events.REQUEST_ENDED)).isNull();
+    // check event with registered callback
+    assertThat(gateway.getCallback(Events.REQUEST_STARTED)).isEqualTo(callback);
+    // check that we can register a callback
+    Function<RequestContext, Flow<Void>> cb =
+        new Function<RequestContext, Flow<Void>>() {
+          @Override
+          public Flow<Void> apply(RequestContext input) {
+            return new Flow.ResultFlow<>(null);
+          }
+        };
+    Subscription s = gateway.registerCallback(Events.REQUEST_ENDED, cb);
+    assertThat(gateway.getCallback(Events.REQUEST_ENDED)).isEqualTo(cb);
+    // check that we can cancel a callback
+    subscription.cancel();
+    assertThat(gateway.getCallback(Events.REQUEST_STARTED)).isNull();
+    // check that we didn't remove the other callback
+    assertThat(gateway.getCallback(Events.REQUEST_ENDED)).isEqualTo(cb);
+  }
+
+  @Test
+  public void testDoubleRegistration() {
+    // check event with registered callback
+    assertThat(gateway.getCallback(Events.REQUEST_STARTED)).isEqualTo(callback);
+    // check that we can't overwrite the callback
+    assertThatThrownBy(
+            new ThrowableAssert.ThrowingCallable() {
+              @Override
+              public void call() throws Throwable {
+                gateway.registerCallback(Events.REQUEST_STARTED, callback);
+              }
+            })
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageStartingWith("Trying to overwrite existing callback ")
+        .hasMessageContaining(Events.REQUEST_STARTED.toString());
+  }
+
+  @Test
+  public void testDoubleCancel() {
+    // check event with registered callback
+    assertThat(gateway.getCallback(Events.REQUEST_STARTED)).isEqualTo(callback);
+    // check that we can cancel a callback
+    subscription.cancel();
+    assertThat(gateway.getCallback(Events.REQUEST_STARTED)).isNull();
+    // check that we can cancel a callback
+    subscription.cancel();
+    assertThat(gateway.getCallback(Events.REQUEST_STARTED)).isNull();
+  }
+}


### PR DESCRIPTION
A minimal Instrumentation Gateway interface that only supports one subscriber to each `EventType`.

The whole API is based around callbacks, that try to provide the least expensive version of the data from the instrumentation/tracer point of view. Grouping of the data should be done on the subscriber side, i.e. combining headers into a `Map` to send to `PowerWAF`.

There will be a separate PR for hooking this into the tracer/instrumentations.