### PR TITLE
Don't wrap runnables in ScheduledThreadPoolExecutor.execute

### DIFF
--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/ThreadPoolExecutorInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/ThreadPoolExecutorInstrumentation.java
@@ -23,6 +23,7 @@ import java.util.concurrent.RunnableFuture;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
+import net.bytebuddy.matcher.ElementMatchers;
 
 @AutoService(Instrumenter.class)
 public final class ThreadPoolExecutorInstrumentation extends Instrumenter.Tracing
@@ -34,7 +35,9 @@ public final class ThreadPoolExecutorInstrumentation extends Instrumenter.Tracin
 
   @Override
   public ElementMatcher<? super TypeDescription> typeMatcher() {
-    return extendsClass(named("java.util.concurrent.ThreadPoolExecutor"));
+    return ElementMatchers.<TypeDescription>not(
+            named("java.util.concurrent.ScheduledThreadPoolExecutor"))
+        .and(extendsClass(named("java.util.concurrent.ThreadPoolExecutor")));
   }
 
   @Override


### PR DESCRIPTION
I found this digging in to something else - when runnables are executed by `ScheduledThreadPoolExecutor` they are actually scheduled, so wrapped in a `ScheduledFutureTask` anyway.