### PR TITLE
Remove duplication of prefix 'dd' on config.getEnumValue

### DIFF
--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -1390,8 +1390,9 @@ public class Config {
     return isEnabled(Arrays.asList(integrationNames), "", ".analytics.enabled", defaultEnabled);
   }
 
-  public <T extends Enum<T>> T getEnumValue(String name, Class<T> type, T defaultValue) {
-    return configProvider.getEnum(PREFIX + name, type, defaultValue);
+  public <T extends Enum<T>> T getEnumValue(
+      final String name, final Class<T> type, final T defaultValue) {
+    return configProvider.getEnum(name, type, defaultValue);
   }
 
   private static boolean isDebugMode() {


### PR DESCRIPTION
This PR removes the `PREFIX` added on `getEnumValue` because the prefix is already added when the `ConfigProvider` tries to obtain the property from `ConfigProvider.Source`.

This was not easily detected because it was only used to configure the `prioritization.type` for development mode (CI App).