### PR TITLE
Log error when dd-java-agent is used with dd-trace-ot.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -303,7 +303,7 @@ jobs:
           name: Run Tests
           command: >-
             MAVEN_OPTS="-Xms64M -Xmx512M"
-            GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx1940M -Xms512M -XX:ErrorFile=/tmp/hs_err_pid%p.log' -Ddatadog.forkedMaxHeapSize=512M -Ddatadog.forkedMinHeapSize=128M"
+            GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx1750M -Xms512M -XX:ErrorFile=/tmp/hs_err_pid%p.log' -Ddatadog.forkedMaxHeapSize=512M -Ddatadog.forkedMinHeapSize=128M"
             ./gradlew stagePlayBinaryDist :dd-smoke-test:<<# parameters.prefixTestTask>>testJava<</ parameters.prefixTestTask>><< parameters.testTask >>
             << pipeline.parameters.gradle_flags >>
             --max-workers=2
@@ -378,7 +378,7 @@ jobs:
           name: Build Project
           command: >-
             MAVEN_OPTS="-Xms64M -Xmx256M"
-            GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx1750M -Xms256M -XX:ErrorFile=/tmp/hs_err_pid%p.log'"
+            GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx1550M -Xms512M -XX:ErrorFile=/tmp/hs_err_pid%p.log'"
             ./gradlew build -PskipTests
             << pipeline.parameters.gradle_flags >>
             --max-workers=3

--- a/dd-java-agent/src/main/java/datadog/trace/bootstrap/AgentBootstrap.java
+++ b/dd-java-agent/src/main/java/datadog/trace/bootstrap/AgentBootstrap.java
@@ -48,11 +48,13 @@ public final class AgentBootstrap {
 
   public static void agentmain(final String agentArgs, final Instrumentation inst) {
     try {
-
       final URL bootstrapURL = installBootstrapJar(inst);
 
       final Class<?> agentClass =
           ClassLoader.getSystemClassLoader().loadClass("datadog.trace.bootstrap.Agent");
+      if (agentClass.getClassLoader() != null) {
+        throw new Exception("DD Java Agent NOT added to bootstrap classpath.");
+      }
       final Method startMethod = agentClass.getMethod("start", Instrumentation.class, URL.class);
       startMethod.invoke(null, inst, bootstrapURL);
     } catch (final Throwable ex) {

--- a/dd-java-agent/src/main/java/datadog/trace/bootstrap/AgentBootstrap.java
+++ b/dd-java-agent/src/main/java/datadog/trace/bootstrap/AgentBootstrap.java
@@ -53,7 +53,7 @@ public final class AgentBootstrap {
       final Class<?> agentClass =
           ClassLoader.getSystemClassLoader().loadClass("datadog.trace.bootstrap.Agent");
       if (agentClass.getClassLoader() != null) {
-        throw new Exception("DD Java Agent NOT added to bootstrap classpath.");
+        throw new IllegalStateException("DD Java Agent NOT added to bootstrap classpath.");
       }
       final Method startMethod = agentClass.getMethod("start", Instrumentation.class, URL.class);
       startMethod.invoke(null, inst, bootstrapURL);
@@ -97,14 +97,14 @@ public final class AgentBootstrap {
         if (agentArgument == null) {
           agentArgument = arg;
         } else {
-          throw new RuntimeException(
+          throw new IllegalStateException(
               "Multiple javaagents specified and code source unavailable, not installing tracing agent");
         }
       }
     }
 
     if (agentArgument == null) {
-      throw new RuntimeException(
+      throw new IllegalStateException(
           "Could not find javaagent parameter and code source unavailable, not installing tracing agent");
     }
 
@@ -112,12 +112,12 @@ public final class AgentBootstrap {
     final Matcher matcher = Pattern.compile("-javaagent:([^=]+).*").matcher(agentArgument);
 
     if (!matcher.matches()) {
-      throw new RuntimeException("Unable to parse javaagent parameter: " + agentArgument);
+      throw new IllegalStateException("Unable to parse javaagent parameter: " + agentArgument);
     }
 
     final File javaagentFile = new File(matcher.group(1));
     if (!(javaagentFile.exists() || javaagentFile.isFile())) {
-      throw new RuntimeException("Unable to find javaagent file: " + javaagentFile);
+      throw new IllegalStateException("Unable to find javaagent file: " + javaagentFile);
     }
     ddJavaAgentJarURL = javaagentFile.toURI().toURL();
     checkJarManifestMainClassIsThis(ddJavaAgentJarURL);
@@ -178,7 +178,7 @@ public final class AgentBootstrap {
         }
       }
     }
-    throw new RuntimeException(
+    throw new IllegalStateException(
         "dd-java-agent is not installed, because class '"
             + thisClass.getCanonicalName()
             + "' is located in '"

--- a/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
@@ -54,7 +54,7 @@ public class DDTracer implements Tracer, datadog.trace.api.Tracer {
         } else {
           log.error("dd-java-agent should not be on the classpath.");
         }
-      } catch (ClassNotFoundException ex) {
+      } catch (ClassNotFoundException expected) {
         // ignore
       }
     }

--- a/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
@@ -41,6 +41,25 @@ public class DDTracer implements Tracer, datadog.trace.api.Tracer {
 
   private static final Logger log = LoggerFactory.getLogger(DDTracer.class);
 
+  static {
+    ClassLoader classLoader = DDTracer.class.getClassLoader();
+    if (classLoader == null) {
+      log.error("dd-trace-ot should not be on the bootstrap classpath.");
+    } else {
+      try {
+        Class<?> bootstrapClass =
+            Class.forName("datadog.trace.bootstrap.AgentBootstrap", false, classLoader);
+        if (bootstrapClass.getClassLoader() == null) {
+          log.error("dd-trace-ot should not be used with dd-java-agent.");
+        } else {
+          log.error("dd-java-agent should not be on the classpath.");
+        }
+      } catch (ClassNotFoundException ex) {
+        // ignore
+      }
+    }
+  }
+
   public static DDTracerBuilder builder() {
     return new DDTracerBuilder();
   }

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -205,7 +205,8 @@ if (project.plugins.hasPlugin('com.github.johnrengelman.shadow')) {
 
 if (project.hasProperty("removeJarVersionNumbers") && removeJarVersionNumbers) {
   tasks.withType(AbstractArchiveTask).configureEach {
-    archiveVersion = null
+    archiveVersion.convention(null)
+    archiveVersion.set(null)
   }
 }
 


### PR DESCRIPTION
These should not be used together.  Also, dd-trace-java should never be declared as a dependency, but rather only on the classpath via `-javaagent`. (Unfortunately this is harder to detect and warn about.)