### PR TITLE
record thread migrations more accurately

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/ContinuationClaim.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/ContinuationClaim.java
@@ -1,0 +1,18 @@
+package datadog.trace.bootstrap.instrumentation.java.concurrent;
+
+import datadog.trace.context.TraceScope;
+
+final class ContinuationClaim implements TraceScope.Continuation {
+
+  public static final ContinuationClaim CLAIMED = new ContinuationClaim();
+
+  @Override
+  public TraceScope activate() {
+    throw new IllegalStateException();
+  }
+
+  @Override
+  public void cancel() {
+    throw new IllegalStateException();
+  }
+}

--- a/dd-java-agent/instrumentation/guava-10/src/main/java/datadog/trace/instrumentation/guava10/ListenableFutureInstrumentation.java
+++ b/dd-java-agent/instrumentation/guava-10/src/main/java/datadog/trace/instrumentation/guava10/ListenableFutureInstrumentation.java
@@ -66,7 +66,9 @@ public class ListenableFutureInstrumentation extends Instrumenter.Tracing {
         task = newTask;
         final ContextStore<Runnable, State> contextStore =
             InstrumentationContext.get(Runnable.class, State.class);
-        return ExecutorInstrumentationUtils.setupState(contextStore, newTask, scope);
+        State state = ExecutorInstrumentationUtils.setupState(contextStore, newTask, scope);
+        state.startThreadMigration();
+        return state;
       }
       return null;
     }

--- a/dd-java-agent/instrumentation/java-concurrent/java-completablefuture/src/main/java/datadog/trace/instrumentation/java/completablefuture/AsyncTaskInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/java-completablefuture/src/main/java/datadog/trace/instrumentation/java/completablefuture/AsyncTaskInstrumentation.java
@@ -1,0 +1,107 @@
+package datadog.trace.instrumentation.java.completablefuture;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
+import static datadog.trace.bootstrap.instrumentation.java.concurrent.AdviceUtils.endTaskScope;
+import static datadog.trace.bootstrap.instrumentation.java.concurrent.AdviceUtils.startTaskScope;
+import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.ExcludeType.FORK_JOIN_TASK;
+import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.ExcludeType.RUNNABLE;
+import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.ExcludeFilterProvider;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.bootstrap.InstrumentationContext;
+import datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter;
+import datadog.trace.bootstrap.instrumentation.java.concurrent.State;
+import datadog.trace.context.TraceScope;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.concurrent.ForkJoinTask;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+/**
+ * Instruments classes used internally by {@code CompletableFuture} which are double instrumented as
+ * {@code Runnable} and {@code ForkJoinTask} and can't be excluded because they can be used in
+ * either context. This double instrumentation otherwsie leads to excess scope creation and
+ * duplicate checkpoint emission.
+ */
+@AutoService(Instrumenter.class)
+public final class AsyncTaskInstrumentation extends Instrumenter.Tracing
+    implements ExcludeFilterProvider {
+
+  private static final String[] CLASS_NAMES = {
+    "java.util.concurrent.CompletableFuture$AsyncSupply",
+    "java.util.concurrent.CompletableFuture$AsyncRun",
+  };
+
+  public AsyncTaskInstrumentation() {
+    super("java_completablefuture", "java_concurrent");
+  }
+
+  @Override
+  public ElementMatcher<? super TypeDescription> typeMatcher() {
+    return namedOneOf(CLASS_NAMES);
+  }
+
+  @Override
+  public Map<String, String> contextStore() {
+    return Collections.singletonMap("java.util.concurrent.ForkJoinTask", State.class.getName());
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(isConstructor(), getClass().getName() + "$Construct");
+    transformation.applyAdvice(named("run"), getClass().getName() + "$Run");
+    transformation.applyAdvice(named("cancel"), getClass().getName() + "$Cancel");
+  }
+
+  @Override
+  public Map<ExcludeFilter.ExcludeType, ? extends Collection<String>> excludedClasses() {
+    EnumMap<ExcludeFilter.ExcludeType, Collection<String>> excluded =
+        new EnumMap<>(ExcludeFilter.ExcludeType.class);
+    excluded.put(FORK_JOIN_TASK, Arrays.asList(CLASS_NAMES));
+    excluded.put(RUNNABLE, Arrays.asList(CLASS_NAMES));
+    return excluded;
+  }
+
+  public static class Construct {
+    @Advice.OnMethodExit
+    public static void construct(@Advice.This ForkJoinTask<?> zis) {
+      TraceScope scope = activeScope();
+      if (null != scope) {
+        InstrumentationContext.get(ForkJoinTask.class, State.class)
+            .putIfAbsent(zis, State.FACTORY)
+            .captureAndSetContinuation(scope);
+      }
+    }
+  }
+
+  public static class Run {
+    @Advice.OnMethodEnter
+    public static TraceScope before(@Advice.This ForkJoinTask<?> zis) {
+      return startTaskScope(InstrumentationContext.get(ForkJoinTask.class, State.class), zis);
+    }
+
+    @Advice.OnMethodExit
+    public static void after(@Advice.Enter TraceScope scope) {
+      endTaskScope(scope);
+    }
+  }
+
+  public static class Cancel {
+    @Advice.OnMethodExit
+    public static <T> void cancel(@Advice.This ForkJoinTask<T> task) {
+      State state = InstrumentationContext.get(ForkJoinTask.class, State.class).get(task);
+      if (null != state) {
+        state.closeContinuation();
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/java-concurrent/java-completablefuture/src/test/groovy/TestFanout.groovy
+++ b/dd-java-agent/instrumentation/java-concurrent/java-completablefuture/src/test/groovy/TestFanout.groovy
@@ -4,6 +4,10 @@ import java.util.concurrent.Executors
 import java.util.concurrent.ForkJoinPool
 
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
+import static datadog.trace.api.Checkpointer.CPU
+import static datadog.trace.api.Checkpointer.END
+import static datadog.trace.api.Checkpointer.SPAN
+import static datadog.trace.api.Checkpointer.THREAD_MIGRATION
 
 class TestFanout extends AgentTestRunner {
 
@@ -14,7 +18,7 @@ class TestFanout extends AgentTestRunner {
     }
     then:
     assertTraces(1) {
-      trace (4) {
+      trace(4) {
         span(0) {
           resourceName "parent"
         }
@@ -33,11 +37,66 @@ class TestFanout extends AgentTestRunner {
       }
     }
 
+    cleanup:
+    executor.shutdownNow()
+
     where:
     executor << [
-      Executors.newSingleThreadExecutor() ,
+      Executors.newSingleThreadExecutor(),
       Executors.newFixedThreadPool(3),
       ForkJoinPool.commonPool()
     ]
+  }
+
+  def "test completablefuture fanout checkpoints"() {
+    when:
+    runUnderTrace("parent") {
+      new Fanout(executor, 3, traceChildTasks).execute()
+    }
+    then:
+    TEST_WRITER.waitForTraces(1)
+    (traceChildTasks ? 4 : 1) * TEST_CHECKPOINTER.checkpoint(_, _, SPAN)
+    3 * TEST_CHECKPOINTER.checkpoint(_, _, THREAD_MIGRATION)
+    3 * TEST_CHECKPOINTER.checkpoint(_, _, THREAD_MIGRATION | END)
+    _ * TEST_CHECKPOINTER.checkpoint(_, _, CPU | END)
+    (traceChildTasks ? 4 : 1) * TEST_CHECKPOINTER.checkpoint(_, _, SPAN | END)
+
+    cleanup:
+    executor.shutdownNow()
+
+    where:
+    executor                            | traceChildTasks
+    Executors.newSingleThreadExecutor() | true
+    Executors.newFixedThreadPool(3)     | true
+    ForkJoinPool.commonPool()           | true
+    Executors.newSingleThreadExecutor() | false
+    Executors.newFixedThreadPool(3)     | false
+    ForkJoinPool.commonPool()           | false
+  }
+
+  def "test completablefuture two level fanout checkpoints"() {
+    when:
+    runUnderTrace("parent") {
+      new Fanout(executor, 3, traceChildTasks).executeTwoLevels()
+    }
+    then:
+    TEST_WRITER.waitForTraces(1)
+    (traceChildTasks ? 7 : 1) * TEST_CHECKPOINTER.checkpoint(_, _, SPAN)
+    6 * TEST_CHECKPOINTER.checkpoint(_, _, THREAD_MIGRATION)
+    6 * TEST_CHECKPOINTER.checkpoint(_, _, THREAD_MIGRATION | END)
+    _ * TEST_CHECKPOINTER.checkpoint(_, _, CPU | END)
+    (traceChildTasks ? 7 : 1) * TEST_CHECKPOINTER.checkpoint(_, _, SPAN | END)
+
+    cleanup:
+    executor.shutdownNow()
+
+    where:
+    executor                            | traceChildTasks
+    Executors.newSingleThreadExecutor() | true
+    Executors.newFixedThreadPool(3)     | true
+    ForkJoinPool.commonPool()           | true
+    Executors.newSingleThreadExecutor() | false
+    Executors.newFixedThreadPool(3)     | false
+    ForkJoinPool.commonPool()           | false
   }
 }

--- a/dd-java-agent/instrumentation/java-concurrent/java-completablefuture/src/test/groovy/TestFanout.groovy
+++ b/dd-java-agent/instrumentation/java-concurrent/java-completablefuture/src/test/groovy/TestFanout.groovy
@@ -1,0 +1,43 @@
+import datadog.trace.agent.test.AgentTestRunner
+
+import java.util.concurrent.Executors
+import java.util.concurrent.ForkJoinPool
+
+import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
+
+class TestFanout extends AgentTestRunner {
+
+  def "test propagate with fanout"() {
+    when:
+    runUnderTrace("parent") {
+      new Fanout(executor, 3, true).execute()
+    }
+    then:
+    assertTraces(1) {
+      trace (4) {
+        span(0) {
+          resourceName "parent"
+        }
+        span(1) {
+          resourceName "Fanout.tracedWork"
+          childOf span(0)
+        }
+        span(2) {
+          resourceName "Fanout.tracedWork"
+          childOf span(0)
+        }
+        span(3) {
+          resourceName "Fanout.tracedWork"
+          childOf span(0)
+        }
+      }
+    }
+
+    where:
+    executor << [
+      Executors.newSingleThreadExecutor() ,
+      Executors.newFixedThreadPool(3),
+      ForkJoinPool.commonPool()
+    ]
+  }
+}

--- a/dd-java-agent/instrumentation/java-concurrent/java-completablefuture/src/test/java/Fanout.java
+++ b/dd-java-agent/instrumentation/java-concurrent/java-completablefuture/src/test/java/Fanout.java
@@ -1,3 +1,5 @@
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
+
 import datadog.trace.api.Trace;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -19,9 +21,29 @@ public class Fanout {
 
   public void execute() {
     try {
-      Runnable task = traceChild ? this::tracedWork : this::untracedWork;
       Stream<CompletableFuture<?>> futures =
-          IntStream.range(0, tasks).mapToObj(i -> CompletableFuture.runAsync(task, executor));
+          IntStream.range(0, tasks)
+              .mapToObj(
+                  i ->
+                      CompletableFuture.runAsync(
+                          traceChild ? this::tracedWork : this::untracedWork, executor));
+      // Wait for those threads to finish work
+      CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new)).get();
+    } catch (InterruptedException | ExecutionException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public void executeTwoLevels() {
+    try {
+      Stream<CompletableFuture<?>> futures =
+          IntStream.range(0, tasks)
+              .mapToObj(
+                  i ->
+                      CompletableFuture.runAsync(
+                              traceChild ? this::tracedWork : this::untracedWork, executor)
+                          .thenRunAsync(
+                              traceChild ? this::tracedWork : this::untracedWork, executor));
       // Wait for those threads to finish work
       CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new)).get();
     } catch (InterruptedException | ExecutionException e) {
@@ -30,19 +52,11 @@ public class Fanout {
   }
 
   private void untracedWork() {
-    try {
-      Thread.sleep(10);
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
-    }
+    assert null != activeScope();
   }
 
   @Trace
   private void tracedWork() {
-    try {
-      Thread.sleep(10);
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
-    }
+    assert null != activeScope();
   }
 }

--- a/dd-java-agent/instrumentation/java-concurrent/java-completablefuture/src/test/java/Fanout.java
+++ b/dd-java-agent/instrumentation/java-concurrent/java-completablefuture/src/test/java/Fanout.java
@@ -1,0 +1,48 @@
+import datadog.trace.api.Trace;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+public class Fanout {
+
+  private final Executor executor;
+  private final int tasks;
+  private final boolean traceChild;
+
+  public Fanout(Executor executor, int tasks, boolean traceChild) {
+    this.executor = executor;
+    this.tasks = tasks;
+    this.traceChild = traceChild;
+  }
+
+  public void execute() {
+    try {
+      Runnable task = traceChild ? this::tracedWork : this::untracedWork;
+      Stream<CompletableFuture<?>> futures =
+          IntStream.range(0, tasks).mapToObj(i -> CompletableFuture.runAsync(task, executor));
+      // Wait for those threads to finish work
+      CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new)).get();
+    } catch (InterruptedException | ExecutionException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private void untracedWork() {
+    try {
+      Thread.sleep(10);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  @Trace
+  private void tracedWork() {
+    try {
+      Thread.sleep(10);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/JavaExecutorInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/JavaExecutorInstrumentation.java
@@ -55,7 +55,9 @@ public final class JavaExecutorInstrumentation extends AbstractExecutorInstrumen
           task = newTask;
           final ContextStore<Runnable, State> contextStore =
               InstrumentationContext.get(Runnable.class, State.class);
-          return ExecutorInstrumentationUtils.setupState(contextStore, newTask, scope);
+          State state = ExecutorInstrumentationUtils.setupState(contextStore, newTask, scope);
+          state.startThreadMigration();
+          return state;
         }
       }
       return null;

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/JavaForkJoinPoolInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/JavaForkJoinPoolInstrumentation.java
@@ -2,9 +2,10 @@ package datadog.trace.instrumentation.java.concurrent;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
 import static datadog.trace.bootstrap.instrumentation.java.concurrent.AdviceUtils.cancelTask;
+import static datadog.trace.bootstrap.instrumentation.java.concurrent.AdviceUtils.capture;
 import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.ExcludeType.FORK_JOIN_TASK;
+import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.exclude;
 import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 
@@ -12,9 +13,7 @@ import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.Platform;
 import datadog.trace.bootstrap.InstrumentationContext;
-import datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.State;
-import datadog.trace.context.TraceScope;
 import java.util.Map;
 import java.util.concurrent.ForkJoinTask;
 import net.bytebuddy.asm.Advice;
@@ -54,13 +53,8 @@ public class JavaForkJoinPoolInstrumentation extends Instrumenter.Tracing {
   public static final class ExternalPush {
     @Advice.OnMethodEnter
     public static <T> void externalPush(@Advice.Argument(0) ForkJoinTask<T> task) {
-      TraceScope activeScope = activeScope();
-      if (null != activeScope) {
-        if (!ExcludeFilter.exclude(FORK_JOIN_TASK, task)) {
-          InstrumentationContext.get(ForkJoinTask.class, State.class)
-              .putIfAbsent(task, State.FACTORY)
-              .captureAndSetContinuation(activeScope);
-        }
+      if (!exclude(FORK_JOIN_TASK, task)) {
+        capture(InstrumentationContext.get(ForkJoinTask.class, State.class), task, true);
       }
     }
 

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/RunnableFutureInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/RunnableFutureInstrumentation.java
@@ -3,8 +3,8 @@ package datadog.trace.instrumentation.java.concurrent;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers.extendsClass;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.nameEndsWith;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
 import static datadog.trace.bootstrap.instrumentation.java.concurrent.AdviceUtils.cancelTask;
+import static datadog.trace.bootstrap.instrumentation.java.concurrent.AdviceUtils.capture;
 import static datadog.trace.bootstrap.instrumentation.java.concurrent.AdviceUtils.endTaskScope;
 import static datadog.trace.bootstrap.instrumentation.java.concurrent.AdviceUtils.startTaskScope;
 import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.ExcludeType.RUNNABLE;
@@ -111,12 +111,7 @@ public final class RunnableFutureInstrumentation extends Instrumenter.Tracing
 
     @Advice.OnMethodExit
     public static <T> void captureScope(@Advice.This RunnableFuture<T> task) {
-      TraceScope activeScope = activeScope();
-      if (null != activeScope) {
-        InstrumentationContext.get(RunnableFuture.class, State.class)
-            .putIfAbsent(task, State.FACTORY)
-            .captureAndSetContinuation(activeScope);
-      }
+      capture(InstrumentationContext.get(RunnableFuture.class, State.class), task, true);
     }
   }
 

--- a/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/CheckpointThreadMigrationTest.groovy
+++ b/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/CheckpointThreadMigrationTest.groovy
@@ -1,0 +1,71 @@
+import datadog.trace.agent.test.AgentTestRunner
+import io.netty.util.concurrent.DefaultEventExecutorGroup
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+
+import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
+import static datadog.trace.api.Checkpointer.CPU
+import static datadog.trace.api.Checkpointer.END
+import static datadog.trace.api.Checkpointer.SPAN
+import static datadog.trace.api.Checkpointer.THREAD_MIGRATION
+import static java.util.concurrent.TimeUnit.SECONDS
+
+class CheckpointThreadMigrationTest extends AgentTestRunner {
+
+  def "emit checkpoints on #executor submission"() {
+    when:
+    runUnderTrace("parent") {
+      executor.submit(new CheckpointTask(traceChildTasks)).get()
+    }
+    then:
+    TEST_WRITER.waitForTraces(1)
+    (traceChildTasks ? 2 : 1) * TEST_CHECKPOINTER.checkpoint(_, _, SPAN)
+    1 * TEST_CHECKPOINTER.checkpoint(_, _, THREAD_MIGRATION)
+    1 * TEST_CHECKPOINTER.checkpoint(_, _, THREAD_MIGRATION | END)
+    _ * TEST_CHECKPOINTER.checkpoint(_, _, CPU | END)
+    (traceChildTasks ? 2 : 1) * TEST_CHECKPOINTER.checkpoint(_, _, SPAN | END)
+
+    cleanup:
+    executor.shutdownNow()
+
+    where:
+    executor                            | traceChildTasks
+    Executors.newScheduledThreadPool(1) | true
+    Executors.newFixedThreadPool(1)     | true
+    new DefaultEventExecutorGroup(1)    | true
+    Executors.newScheduledThreadPool(1) | false
+    Executors.newFixedThreadPool(1)     | false
+    new DefaultEventExecutorGroup(1)    | false
+  }
+
+  def "emit checkpoints on #executor execution"() {
+    // execution is typically handled differently than when a future
+    // is produced
+    when:
+    runUnderTrace("parent") {
+      CountDownLatch latch = new CountDownLatch(1)
+      executor.execute(new CheckpointTask(traceChildTasks, latch))
+      latch.await(30, SECONDS)
+    }
+    then:
+    TEST_WRITER.waitForTraces(1)
+    (traceChildTasks ? 2 : 1) * TEST_CHECKPOINTER.checkpoint(_, _, SPAN)
+    1 * TEST_CHECKPOINTER.checkpoint(_, _, THREAD_MIGRATION)
+    1 * TEST_CHECKPOINTER.checkpoint(_, _, THREAD_MIGRATION | END)
+    _ * TEST_CHECKPOINTER.checkpoint(_, _, CPU | END)
+    (traceChildTasks ? 2 : 1) * TEST_CHECKPOINTER.checkpoint(_, _, SPAN | END)
+
+    cleanup:
+    executor.shutdownNow()
+
+    where:
+    executor                            | traceChildTasks
+    Executors.newScheduledThreadPool(1) | true
+    Executors.newFixedThreadPool(1)     | true
+    new DefaultEventExecutorGroup(1)    | true
+    Executors.newScheduledThreadPool(1) | false
+    Executors.newFixedThreadPool(1)     | false
+    new DefaultEventExecutorGroup(1)    | false
+  }
+}

--- a/dd-java-agent/instrumentation/java-concurrent/src/test/java/CheckpointTask.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/test/java/CheckpointTask.java
@@ -1,0 +1,32 @@
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
+
+import datadog.trace.api.Trace;
+import java.util.concurrent.CountDownLatch;
+
+public class CheckpointTask implements Runnable {
+
+  private final boolean traceChild;
+  private final CountDownLatch latch;
+
+  public CheckpointTask(boolean traceChild) {
+    this(traceChild, new CountDownLatch(0));
+  }
+
+  public CheckpointTask(boolean traceChild, CountDownLatch latch) {
+    this.traceChild = traceChild;
+    this.latch = latch;
+  }
+
+  @Override
+  public void run() {
+    if (traceChild) {
+      traceableChild();
+    }
+    latch.countDown();
+  }
+
+  @Trace
+  private void traceableChild() {
+    assert null != activeScope();
+  }
+}

--- a/dd-java-agent/instrumentation/opentelemetry/src/test/groovy/OpenTelemetryTest.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/src/test/groovy/OpenTelemetryTest.groovy
@@ -210,6 +210,7 @@ class OpenTelemetryTest extends AgentTestRunner {
     tracer.currentSpan.delegate == secondScope.delegate.span()
     1 * STATS_D_CLIENT.incrementCounter("scope.close.error")
     1 * STATS_D_CLIENT.incrementCounter("scope.user.close.error")
+    _ * TEST_CHECKPOINTER._
     0 * _
 
     when:
@@ -218,6 +219,7 @@ class OpenTelemetryTest extends AgentTestRunner {
 
     then:
     tracer.currentSpan == null
+    _ * TEST_CHECKPOINTER._
     0 * _
   }
 

--- a/dd-java-agent/instrumentation/opentracing/api-0.31/src/test/groovy/OpenTracing31Test.groovy
+++ b/dd-java-agent/instrumentation/opentracing/api-0.31/src/test/groovy/OpenTracing31Test.groovy
@@ -230,6 +230,7 @@ class OpenTracing31Test extends AgentTestRunner {
     tracer.scopeManager().active().delegate == secondScope.delegate
     1 * STATS_D_CLIENT.incrementCounter("scope.close.error")
     1 * STATS_D_CLIENT.incrementCounter("scope.user.close.error")
+    _ * TEST_CHECKPOINTER._
     0 * _
 
     when:

--- a/dd-java-agent/instrumentation/opentracing/api-0.32/src/test/groovy/OpenTracing32Test.groovy
+++ b/dd-java-agent/instrumentation/opentracing/api-0.32/src/test/groovy/OpenTracing32Test.groovy
@@ -240,6 +240,7 @@ class OpenTracing32Test extends AgentTestRunner {
     tracer.scopeManager().active().delegate == secondScope.delegate
     1 * STATS_D_CLIENT.incrementCounter("scope.close.error")
     1 * STATS_D_CLIENT.incrementCounter("scope.user.close.error")
+    _ * TEST_CHECKPOINTER._
     0 * _
 
     when:

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
@@ -413,6 +413,7 @@ public class ContinuableScopeManager implements AgentScopeManager {
     final AgentSpan spanUnderScope;
     final byte source;
     final AgentTrace trace;
+    protected volatile boolean migrated;
 
     public Continuation(
         ContinuableScopeManager scopeManager, AgentSpan spanUnderScope, byte source) {
@@ -423,7 +424,6 @@ public class ContinuableScopeManager implements AgentScopeManager {
     }
 
     Continuation register() {
-      spanUnderScope.startThreadMigration();
       trace.registerContinuation(this);
       return this;
     }
@@ -451,8 +451,10 @@ public class ContinuableScopeManager implements AgentScopeManager {
 
     @Override
     public AgentScope activate() {
-      spanUnderScope.finishThreadMigration();
       if (USED.compareAndSet(this, 0, 1)) {
+        if (migrated) {
+          spanUnderScope.finishThreadMigration();
+        }
         return scopeManager.handleSpan(this, spanUnderScope, source);
       } else {
         log.debug(
@@ -468,6 +470,12 @@ public class ContinuableScopeManager implements AgentScopeManager {
       } else {
         log.debug("Failed to close continuation {}. Already used.", this);
       }
+    }
+
+    @Override
+    public void migrate() {
+      this.migrated = true;
+      spanUnderScope.startThreadMigration();
     }
 
     @Override
@@ -495,10 +503,12 @@ public class ContinuableScopeManager implements AgentScopeManager {
    * way, and close the scopes without fear of closing the related {@link AgentSpan} prematurely.
    */
   private static final class ConcurrentContinuation extends Continuation {
-    private static final int START = 1;
+    private static final int START = 2;
     private static final int CLOSED = Integer.MIN_VALUE >> 1;
     private static final int BARRIER = Integer.MIN_VALUE >> 2;
+    private static final int MIGRATED = 1;
 
+    // the counter is incremented/decremented by 2 so the lsb can represent migrated status
     private volatile int count = START;
 
     private static final AtomicIntegerFieldUpdater<ConcurrentContinuation> COUNT =
@@ -512,9 +522,9 @@ public class ContinuableScopeManager implements AgentScopeManager {
     }
 
     private boolean tryActivate() {
-      int current = COUNT.incrementAndGet(this);
+      int current = COUNT.addAndGet(this, 2);
       if (current < START) {
-        COUNT.decrementAndGet(this);
+        COUNT.addAndGet(this, -2);
       }
       return current > START;
     }
@@ -525,7 +535,7 @@ public class ContinuableScopeManager implements AgentScopeManager {
         return false;
       }
       // Now decrement the counter
-      current = COUNT.decrementAndGet(this);
+      current = COUNT.addAndGet(this, -2);
       // Try to close this if we are between START and BARRIER
       while (current < START && current > BARRIER) {
         if (COUNT.compareAndSet(this, current, CLOSED)) {
@@ -536,10 +546,25 @@ public class ContinuableScopeManager implements AgentScopeManager {
       return false;
     }
 
+    private void tryFinishThreadMigration() {
+      // loop until the MIGRATED bit is unset on the count
+      int current;
+      do {
+        current = COUNT.get(this);
+      } while ((current & MIGRATED) == MIGRATED
+          && !COUNT.compareAndSet(this, current, current ^ MIGRATED));
+      if ((current & MIGRATED) == MIGRATED) {
+        // if the MIGRATED bit is set on the last snapshot, we
+        // must have been the one to switch it off, so can finish
+        // the thread migration here
+        spanUnderScope.finishThreadMigration();
+      }
+    }
+
     @Override
     public AgentScope activate() {
       if (tryActivate()) {
-        spanUnderScope.finishThreadMigration();
+        tryFinishThreadMigration();
         return scopeManager.handleSpan(this, spanUnderScope, source);
       } else {
         return null;
@@ -552,6 +577,17 @@ public class ContinuableScopeManager implements AgentScopeManager {
         trace.cancelContinuation(this);
       }
       log.debug("t_id={} -> canceling continuation {}", spanUnderScope.getTraceId(), this);
+    }
+
+    @Override
+    public void migrate() {
+      // loop until the MIGRATED bit has been set on the count by CAS, or by someone else
+      int snapshot;
+      do {
+        snapshot = COUNT.get(this);
+      } while ((snapshot & MIGRATED) != MIGRATED
+          && !COUNT.compareAndSet(this, snapshot, snapshot | MIGRATED));
+      spanUnderScope.startThreadMigration();
     }
 
     @Override

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceBufferTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceBufferTest.groovy
@@ -77,7 +77,6 @@ class PendingTraceBufferTest extends DDSpecification {
     trace.pendingReferenceCount == 1
     1 * bufferSpy.enqueue(trace)
     _ * tracer.getPartialFlushMinSpans() >> 10
-    1 * tracer.onStartThreadMigration(span)
     1 * tracer.onFinish(span)
     0 * _
 
@@ -140,7 +139,6 @@ class PendingTraceBufferTest extends DDSpecification {
     _ * tracer.getPartialFlushMinSpans() >> 10
     _ * tracer.mapServiceName(_)
     _ * tracer.onStart(_)
-    _ * tracer.onStartThreadMigration(_)
     _ * tracer.onFinish(_)
     0 * _
 
@@ -154,7 +152,6 @@ class PendingTraceBufferTest extends DDSpecification {
     _ * tracer.getPartialFlushMinSpans() >> 10
     _ * tracer.mapServiceName(_)
     1 * tracer.onStart(_)
-    1 * tracer.onStartThreadMigration(_)
     1 * tracer.onFinish(_)
     0 * _
   }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentScope.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentScope.java
@@ -12,5 +12,14 @@ public interface AgentScope extends TraceScope, Closeable {
   @Override
   void close();
 
-  interface Continuation extends TraceScope.Continuation {}
+  interface Continuation extends TraceScope.Continuation {
+    /**
+     * Mark that the continuation will migrate to another thread. Calling this method will lead to
+     * emitting events to allow the profiler to know that the span has forked from the current
+     * thread and will resume elsewhere. It does not need to be called except when thread migration
+     * is expected to happen, and should not be called for e.g. future style APIs where a
+     * continuation will be created, awaited, and closed all on the same thread.
+     */
+    void migrate();
+  }
 }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -585,6 +585,9 @@ public class AgentTracer {
 
     @Override
     public void cancel() {}
+
+    @Override
+    public void migrate() {}
   }
 
   public static class NoopContext implements Context.Extracted {


### PR DESCRIPTION
Because of futures and promises, capturing a continuation is far too general and frequent an event to represent a span migrating thread - it can happen at any time, e.g. blocking the current thread to wait for completable futures will capture and cancel a continuation:
```java
CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new)).get();
```

This PR limits the cases where a thread migration event is emitted to the following cases:
* an instrumented `RunnableFuture` is constructed - this practically always means submission to a thread pool
* a `ForkJoinTask` is pushed from an external thread, or `ForkJoinTask.fork` is called
* `execute` is called on instrumented `Executor`s
* we construct a `Wrapper` - which only exists for context propagation
* a `UniRun` or `UniApply`, which wrap user code, is constructed

We also don't want to end the thread migration multiple times when there are several layers of instrumentation and wrapping. For instance, `CompletableFuture.runAsync(runnable)` lifts the runnable to `CompletableFuture` and creates an `AsyncRun`, which is instrumented as both a `Runnable` and a `ForkJoinTask`, and its `exec` calls its `run`. If the `CompletableFuture` executes in a `ForkJoinPool`, there will be 3 continuation activations - one for `exec()`, one for `run()`, and one for the completion of the `CompletableFuture`. Two of these can be removed easily (which also reduces field-injection footprint) by instrumenting `AsyncRun` and excluding it from other instrumentation, so that only `run` is instrumented.

For subsequent stages of a `CompletableFuture` after lifting (e.g. `thenRun*` or `thenApply*`) the `UniCompletion` instrumentation is changed to start a thread migration only for `UniRun` and `UniApply`, which marks the `Continuation` as having migrated. If a continuation has migrated, then the thread migration is ended in `Continuation.activate()`. This requires changes to `Continuation` so that it can track migration status, including a method on `TraceScope.Continuation` to record when a `Continuation` is expected to migrate.