### PR TITLE
Ignore exceptions thrown during couchbase cleanup

### DIFF
--- a/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/util/AbstractCouchbaseTest.groovy
+++ b/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/util/AbstractCouchbaseTest.groovy
@@ -123,7 +123,11 @@ abstract class AbstractCouchbaseTest extends AgentTestRunner {
       }
       activeSpan()
     }
-    TEST_WRITER.waitUntilReported(cleanupSpan)
+    try {
+      TEST_WRITER.waitUntilReported(cleanupSpan)
+    } catch (Throwable ex) {
+      // ignore
+    }
   }
 
   protected void cleanupCluster(CouchbaseCluster cluster, CouchbaseEnvironment environment) {

--- a/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/util/AbstractCouchbaseTest.groovy
+++ b/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/util/AbstractCouchbaseTest.groovy
@@ -115,8 +115,12 @@ abstract class AbstractCouchbaseTest extends AgentTestRunner {
 
   protected void cleanupCluster(CouchbaseAsyncCluster cluster, CouchbaseEnvironment environment) {
     def cleanupSpan = runUnderTrace("cleanup") {
-      cluster?.disconnect()?.timeout(10, TimeUnit.SECONDS)?.toBlocking()?.single()
-      environment.shutdown()
+      try {
+        cluster?.disconnect()?.timeout(10, TimeUnit.SECONDS)?.toBlocking()?.single()
+        environment.shutdown()
+      } catch (Throwable ex) {
+        // ignore
+      }
       activeSpan()
     }
     TEST_WRITER.waitUntilReported(cleanupSpan)


### PR DESCRIPTION
Many of the test failures seem related to errors during cleanup.