### PR TITLE
Upgrade JMH gradle plugin to 0.6.5 to fix issue where it was attempting to unzip a class file

### DIFF
--- a/dd-trace-java.gradle
+++ b/dd-trace-java.gradle
@@ -19,7 +19,7 @@ plugins {
   id 'io.github.gradle-nexus.publish-plugin' version '1.0.0'
 
   id "com.github.johnrengelman.shadow" version "5.2.0" apply false
-  id "me.champeau.jmh" version "0.6.2" apply false
+  id "me.champeau.jmh" version "0.6.5" apply false
 }
 
 description = 'dd-trace-java'


### PR DESCRIPTION
```
./gradlew :dd-trace-core:jmhJar
```
```
* What went wrong:
Execution failed for task ':dd-trace-core:jmhJar'.
> Could not expand ZIP 'dd-java-agent/agent-tooling/build/classes/java/main_java11/datadog/trace/agent/tooling/bytebuddy/DDJava9ClassFileTransformer$1.class'.
```
The fix went into 0.6.3 as https://github.com/melix/jmh-gradle-plugin/commit/bc5a3d4f0fce332c420b2ba22f41e54cb72be398 but we might as well upgrade to the latest version