### PR TITLE
ByteBuddy 1.11.1

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/HelperInjector.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/HelperInjector.java
@@ -200,8 +200,9 @@ public class HelperInjector implements Transformer {
 
           if (!target.canRead(helperModule)) {
             log.debug("Adding module read from {} to {}", target, helperModule);
-            target.modify(
+            ClassInjector.UsingInstrumentation.redefineModule(
                 AgentInstaller.getInstrumentation(),
+                target,
                 Collections.singleton(helperModule),
                 Collections.<String, Set<JavaModule>>emptyMap(),
                 Collections.<String, Set<JavaModule>>emptyMap(),

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -13,7 +13,7 @@ final class CachedData {
     groovy        : groovyVer,
     junit5        : "5.6.2",
     logback       : "1.2.3",
-    bytebuddy     : "1.11.0",
+    bytebuddy     : "1.11.1",
     scala         : "2.11.12",  // Last version to support Java 7 (2.12+ require Java 8+)
     scala210      : "2.10.7",
     scala211      : "2.11.12",


### PR DESCRIPTION
https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.11.1

- Add JNA based ClassInjector for use if JNA is already available.
- Allow HashCodeEqualsPlugin to derive hash code from instrumented type rather then lowest type in hierarchy.
- Retain this variable name for index 0 when using advice with remapped locals.
- Rework AnnotationDescription for TypePool to mirror JVM behavior if annotation properties are changed inconsistently.
- Add several StackManipulations for common operations.
- Remove unwanted dependency to Instrumentation API from JavaModule type.
- Rework use of reflection to use JavaDispatcher API which also allows for custom generation of proxies without use of reflection.
- Fully rework JavaConstant API to integrate with Java's ConstantDesc API and to allow for production of such descriptions.
- Fix different bugs to properly support representation sealed classes.