### PR TITLE
Stop collecting http status code on play span by default

### DIFF
--- a/dd-java-agent/instrumentation/play-2.3/src/main/java8/datadog/trace/instrumentation/play23/PlayAdvice.java
+++ b/dd-java-agent/instrumentation/play-2.3/src/main/java8/datadog/trace/instrumentation/play23/PlayAdvice.java
@@ -7,6 +7,7 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.play23.PlayHeaders.GETTER;
 import static datadog.trace.instrumentation.play23.PlayHttpServerDecorator.DECORATE;
 import static datadog.trace.instrumentation.play23.PlayHttpServerDecorator.PLAY_REQUEST;
+import static datadog.trace.instrumentation.play23.PlayHttpServerDecorator.REPORT_HTTP_STATUS;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
@@ -55,7 +56,9 @@ public class PlayAdvice {
           ((Action) thisAction).executionContext());
     } else {
       DECORATE.onError(playControllerSpan, throwable);
-      playControllerSpan.setHttpStatusCode(500);
+      if (REPORT_HTTP_STATUS) {
+        playControllerSpan.setHttpStatusCode(500);
+      }
       DECORATE.beforeFinish(playControllerSpan);
       playControllerSpan.finish();
     }

--- a/dd-java-agent/instrumentation/play-2.3/src/main/java8/datadog/trace/instrumentation/play23/PlayHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/play-2.3/src/main/java8/datadog/trace/instrumentation/play23/PlayHttpServerDecorator.java
@@ -2,6 +2,7 @@ package datadog.trace.instrumentation.play23;
 
 import static datadog.trace.bootstrap.instrumentation.decorator.RouteHandlerDecorator.ROUTE_HANDLER_DECORATOR;
 
+import datadog.trace.api.Config;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
@@ -14,6 +15,7 @@ import play.api.mvc.Result;
 import scala.Option;
 
 public class PlayHttpServerDecorator extends HttpServerDecorator<Request, Request, Result> {
+  public static final boolean REPORT_HTTP_STATUS = Config.get().getPlayReportHttpStatus();
   public static final CharSequence PLAY_REQUEST = UTF8BytesString.create("play.request");
   public static final CharSequence PLAY_ACTION = UTF8BytesString.create("play-action");
   public static final PlayHttpServerDecorator DECORATE = new PlayHttpServerDecorator();
@@ -74,7 +76,9 @@ public class PlayHttpServerDecorator extends HttpServerDecorator<Request, Reques
 
   @Override
   public AgentSpan onError(final AgentSpan span, Throwable throwable) {
-    span.setHttpStatusCode(500);
+    if (REPORT_HTTP_STATUS) {
+      span.setHttpStatusCode(500);
+    }
     if (throwable != null
         // This can be moved to instanceof check when using Java 8.
         && throwable.getClass().getName().equals("java.util.concurrent.CompletionException")

--- a/dd-java-agent/instrumentation/play-2.3/src/main/java8/datadog/trace/instrumentation/play23/RequestCompleteCallback.java
+++ b/dd-java-agent/instrumentation/play-2.3/src/main/java8/datadog/trace/instrumentation/play23/RequestCompleteCallback.java
@@ -2,6 +2,7 @@ package datadog.trace.instrumentation.play23;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
 import static datadog.trace.instrumentation.play23.PlayHttpServerDecorator.DECORATE;
+import static datadog.trace.instrumentation.play23.PlayHttpServerDecorator.REPORT_HTTP_STATUS;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.context.TraceScope;
@@ -25,7 +26,9 @@ public class RequestCompleteCallback extends scala.runtime.AbstractFunction1<Try
       if (result.isFailure()) {
         DECORATE.onError(span, result.failed().get());
       } else {
-        DECORATE.onResponse(span, result.get());
+        if (REPORT_HTTP_STATUS) {
+          DECORATE.onResponse(span, result.get());
+        }
       }
       DECORATE.beforeFinish(span);
       final TraceScope scope = activeScope();

--- a/dd-java-agent/instrumentation/play-2.3/src/test/groovy/server/PlayServerTest.groovy
+++ b/dd-java-agent/instrumentation/play-2.3/src/test/groovy/server/PlayServerTest.groovy
@@ -10,7 +10,6 @@ import datadog.trace.instrumentation.netty38.server.NettyHttpServerDecorator
 import datadog.trace.instrumentation.play23.PlayHttpServerDecorator
 import play.api.test.TestServer
 
-import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.FORWARDED
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
@@ -44,7 +43,7 @@ class PlayServerTest extends HttpServerTest<TestServer> {
       serviceName expectedServiceName()
       operationName "play.request"
       spanType DDSpanTypes.HTTP_SERVER
-      errored endpoint == ERROR || endpoint == EXCEPTION
+      errored endpoint == EXCEPTION
       childOfPrevious()
       tags {
         "$Tags.COMPONENT" PlayHttpServerDecorator.DECORATE.component()
@@ -52,7 +51,6 @@ class PlayServerTest extends HttpServerTest<TestServer> {
         "$Tags.PEER_HOST_IPV4" { it == (endpoint == FORWARDED ? endpoint.body : "127.0.0.1") }
         "$Tags.HTTP_URL" String
         "$Tags.HTTP_METHOD" String
-        "$Tags.HTTP_STATUS" Integer
         // BUG
         //        "$Tags.HTTP_ROUTE" String
         if (endpoint == EXCEPTION) {

--- a/dd-java-agent/instrumentation/play-2.4/src/main/java8/datadog/trace/instrumentation/play24/PlayAdvice.java
+++ b/dd-java-agent/instrumentation/play-2.4/src/main/java8/datadog/trace/instrumentation/play24/PlayAdvice.java
@@ -7,6 +7,7 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.play24.PlayHeaders.GETTER;
 import static datadog.trace.instrumentation.play24.PlayHttpServerDecorator.DECORATE;
 import static datadog.trace.instrumentation.play24.PlayHttpServerDecorator.PLAY_REQUEST;
+import static datadog.trace.instrumentation.play24.PlayHttpServerDecorator.REPORT_HTTP_STATUS;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
@@ -69,7 +70,9 @@ public class PlayAdvice {
           ((Action) thisAction).executionContext());
     } else {
       DECORATE.onError(playControllerSpan, throwable);
-      playControllerSpan.setHttpStatusCode(500);
+      if (REPORT_HTTP_STATUS) {
+        playControllerSpan.setHttpStatusCode(500);
+      }
       DECORATE.beforeFinish(playControllerSpan);
       playControllerSpan.finish();
     }

--- a/dd-java-agent/instrumentation/play-2.4/src/main/java8/datadog/trace/instrumentation/play24/PlayHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/play-2.4/src/main/java8/datadog/trace/instrumentation/play24/PlayHttpServerDecorator.java
@@ -2,6 +2,7 @@ package datadog.trace.instrumentation.play24;
 
 import static datadog.trace.bootstrap.instrumentation.decorator.RouteHandlerDecorator.ROUTE_HANDLER_DECORATOR;
 
+import datadog.trace.api.Config;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
@@ -13,6 +14,7 @@ import play.api.mvc.Result;
 import scala.Option;
 
 public class PlayHttpServerDecorator extends HttpServerDecorator<Request, Request, Result> {
+  public static final boolean REPORT_HTTP_STATUS = Config.get().getPlayReportHttpStatus();
   public static final CharSequence PLAY_REQUEST = UTF8BytesString.create("play.request");
   public static final CharSequence PLAY_ACTION = UTF8BytesString.create("play-action");
   public static final PlayHttpServerDecorator DECORATE = new PlayHttpServerDecorator();
@@ -73,7 +75,9 @@ public class PlayHttpServerDecorator extends HttpServerDecorator<Request, Reques
 
   @Override
   public AgentSpan onError(final AgentSpan span, Throwable throwable) {
-    span.setHttpStatusCode(500);
+    if (REPORT_HTTP_STATUS) {
+      span.setHttpStatusCode(500);
+    }
     if (throwable != null
         // This can be moved to instanceof check when using Java 8.
         && throwable.getClass().getName().equals("java.util.concurrent.CompletionException")

--- a/dd-java-agent/instrumentation/play-2.4/src/main/java8/datadog/trace/instrumentation/play24/RequestCompleteCallback.java
+++ b/dd-java-agent/instrumentation/play-2.4/src/main/java8/datadog/trace/instrumentation/play24/RequestCompleteCallback.java
@@ -2,6 +2,7 @@ package datadog.trace.instrumentation.play24;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
 import static datadog.trace.instrumentation.play24.PlayHttpServerDecorator.DECORATE;
+import static datadog.trace.instrumentation.play24.PlayHttpServerDecorator.REPORT_HTTP_STATUS;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.context.TraceScope;
@@ -24,7 +25,9 @@ public class RequestCompleteCallback extends scala.runtime.AbstractFunction1<Try
       if (result.isFailure()) {
         DECORATE.onError(span, result.failed().get());
       } else {
-        DECORATE.onResponse(span, result.get());
+        if (REPORT_HTTP_STATUS) {
+          DECORATE.onResponse(span, result.get());
+        }
       }
       DECORATE.beforeFinish(span);
       final TraceScope scope = activeScope();

--- a/dd-java-agent/instrumentation/play-2.4/src/test/groovy/server/PlayServerTest.groovy
+++ b/dd-java-agent/instrumentation/play-2.4/src/test/groovy/server/PlayServerTest.groovy
@@ -86,7 +86,7 @@ class PlayServerTest extends HttpServerTest<Server> {
       serviceName expectedServiceName()
       operationName "play.request"
       spanType DDSpanTypes.HTTP_SERVER
-      errored endpoint == ERROR || endpoint == EXCEPTION
+      errored endpoint == EXCEPTION
       childOfPrevious()
       tags {
         "$Tags.COMPONENT" PlayHttpServerDecorator.DECORATE.component()
@@ -94,7 +94,6 @@ class PlayServerTest extends HttpServerTest<Server> {
         "$Tags.PEER_HOST_IPV4" { it == (endpoint == FORWARDED ? endpoint.body : "127.0.0.1") }
         "$Tags.HTTP_URL" String
         "$Tags.HTTP_METHOD" String
-        "$Tags.HTTP_STATUS" Integer
         // BUG
         //        "$Tags.HTTP_ROUTE" String
         if (endpoint == EXCEPTION) {

--- a/dd-java-agent/instrumentation/play-2.6/src/main/java8/datadog/trace/instrumentation/play26/PlayHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/play-2.6/src/main/java8/datadog/trace/instrumentation/play26/PlayHttpServerDecorator.java
@@ -2,6 +2,7 @@ package datadog.trace.instrumentation.play26;
 
 import static datadog.trace.bootstrap.instrumentation.decorator.RouteHandlerDecorator.ROUTE_HANDLER_DECORATOR;
 
+import datadog.trace.api.Config;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
@@ -20,6 +21,7 @@ import play.routing.Router;
 import scala.Option;
 
 public class PlayHttpServerDecorator extends HttpServerDecorator<Request, Request, Result> {
+  public static final boolean REPORT_HTTP_STATUS = Config.get().getPlayReportHttpStatus();
   public static final CharSequence PLAY_REQUEST = UTF8BytesString.create("play.request");
   public static final CharSequence PLAY_ACTION = UTF8BytesString.create("play-action");
   public static final PlayHttpServerDecorator DECORATE = new PlayHttpServerDecorator();
@@ -116,7 +118,9 @@ public class PlayHttpServerDecorator extends HttpServerDecorator<Request, Reques
 
   @Override
   public AgentSpan onError(final AgentSpan span, Throwable throwable) {
-    span.setHttpStatusCode(500);
+    if (REPORT_HTTP_STATUS) {
+      span.setHttpStatusCode(500);
+    }
     if (throwable instanceof CompletionException && throwable.getCause() != null) {
       throwable = throwable.getCause();
     }

--- a/dd-java-agent/instrumentation/play-2.6/src/main/java8/datadog/trace/instrumentation/play26/RequestCompleteCallback.java
+++ b/dd-java-agent/instrumentation/play-2.6/src/main/java8/datadog/trace/instrumentation/play26/RequestCompleteCallback.java
@@ -2,6 +2,7 @@ package datadog.trace.instrumentation.play26;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
 import static datadog.trace.instrumentation.play26.PlayHttpServerDecorator.DECORATE;
+import static datadog.trace.instrumentation.play26.PlayHttpServerDecorator.REPORT_HTTP_STATUS;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.context.TraceScope;
@@ -26,7 +27,9 @@ public class RequestCompleteCallback extends scala.runtime.AbstractFunction1<Try
       if (result.isFailure()) {
         DECORATE.onError(span, result.failed().get());
       } else {
-        DECORATE.onResponse(span, result.get());
+        if (REPORT_HTTP_STATUS) {
+          DECORATE.onResponse(span, result.get());
+        }
       }
       DECORATE.beforeFinish(span);
       final TraceScope scope = activeScope();

--- a/dd-java-agent/instrumentation/play-2.6/src/test/groovy/server/PlayServerTest.groovy
+++ b/dd-java-agent/instrumentation/play-2.6/src/test/groovy/server/PlayServerTest.groovy
@@ -93,7 +93,7 @@ class PlayServerTest extends HttpServerTest<Server> {
       serviceName expectedServiceName()
       operationName "play.request"
       spanType DDSpanTypes.HTTP_SERVER
-      errored endpoint == ERROR || endpoint == EXCEPTION
+      errored endpoint == EXCEPTION
       childOfPrevious()
       tags {
         "$Tags.COMPONENT" PlayHttpServerDecorator.DECORATE.component()
@@ -101,7 +101,6 @@ class PlayServerTest extends HttpServerTest<Server> {
         "$Tags.PEER_HOST_IPV4" { it == (endpoint == FORWARDED ? endpoint.body : "127.0.0.1") }
         "$Tags.HTTP_URL" String
         "$Tags.HTTP_METHOD" String
-        "$Tags.HTTP_STATUS" Integer
         // BUG
         //        "$Tags.HTTP_ROUTE" String
         if (endpoint == EXCEPTION) {

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
@@ -52,6 +52,8 @@ public final class TraceInstrumentationConfig {
 
   public static final String OSGI_SEARCH_DEPTH = "osgi.search.depth";
 
+  public static final String PLAY_REPORT_HTTP_STATUS = "trace.play.report-http-status";
+
   public static final String SERVLET_PRINCIPAL_ENABLED = "trace.servlet.principal.enabled";
   public static final String SERVLET_ASYNC_TIMEOUT_ERROR = "trace.servlet.async-timeout.error";
 

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -135,6 +135,7 @@ import static datadog.trace.api.config.TraceInstrumentationConfig.KAFKA_CLIENT_P
 import static datadog.trace.api.config.TraceInstrumentationConfig.LOGS_INJECTION_ENABLED;
 import static datadog.trace.api.config.TraceInstrumentationConfig.LOGS_MDC_TAGS_INJECTION_ENABLED;
 import static datadog.trace.api.config.TraceInstrumentationConfig.OSGI_SEARCH_DEPTH;
+import static datadog.trace.api.config.TraceInstrumentationConfig.PLAY_REPORT_HTTP_STATUS;
 import static datadog.trace.api.config.TraceInstrumentationConfig.RESOLVER_USE_LOADCLASS;
 import static datadog.trace.api.config.TraceInstrumentationConfig.RUNTIME_CONTEXT_FIELD_INJECTION;
 import static datadog.trace.api.config.TraceInstrumentationConfig.SERIALVERSIONUID_FIELD_INJECTION;
@@ -361,6 +362,9 @@ public class Config {
   private final boolean igniteCacheIncludeKeys;
 
   private final int osgiSearchDepth;
+
+  // TODO: remove at a future point.
+  private final boolean playReportHttpStatus;
 
   private final boolean servletPrincipalEnabled;
   private final boolean servletAsyncTimeoutError;
@@ -752,6 +756,8 @@ public class Config {
     igniteCacheIncludeKeys = configProvider.getBoolean(IGNITE_CACHE_INCLUDE_KEYS, false);
 
     osgiSearchDepth = configProvider.getInteger(OSGI_SEARCH_DEPTH, 1);
+
+    playReportHttpStatus = configProvider.getBoolean(PLAY_REPORT_HTTP_STATUS, false);
 
     servletPrincipalEnabled = configProvider.getBoolean(SERVLET_PRINCIPAL_ENABLED, false);
 
@@ -1147,6 +1153,10 @@ public class Config {
 
   public int getOsgiSearchDepth() {
     return osgiSearchDepth;
+  }
+
+  public boolean getPlayReportHttpStatus() {
+    return playReportHttpStatus;
   }
 
   public boolean isServletPrincipalEnabled() {


### PR DESCRIPTION
There have been cases where the status code is wrong/different when compared with the parent server span.

This behavior can be reenabled using the following config:
```
-Ddd.trace.play.report-http-status=true
```