### PR TITLE
persist trace and span ids as double to avoid varint encoding

### DIFF
--- a/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/CheckpointEvent.java
+++ b/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/CheckpointEvent.java
@@ -18,10 +18,10 @@ import jdk.jfr.StackTrace;
 public class CheckpointEvent extends Event {
 
   @Label("Trace Id")
-  private final long traceId;
+  private final double traceId;
 
   @Label("Span Id")
-  private final long spanId;
+  private final double spanId;
 
   @Label("Flags")
   private final int flags;
@@ -30,8 +30,8 @@ public class CheckpointEvent extends Event {
   private final long cpuTime;
 
   public CheckpointEvent(long traceId, long spanId, int flags) {
-    this.traceId = traceId;
-    this.spanId = spanId;
+    this.traceId = Double.longBitsToDouble(traceId);
+    this.spanId = Double.longBitsToDouble(spanId);
     this.flags = flags;
     if ((flags & CPU) != 0 && isEnabled()) {
       this.cpuTime = SystemAccess.getCurrentThreadCpuTime();

--- a/dd-trace-core/jfr-openjdk/src/test/groovy/datadog/trace/core/jfr/openjdk/ScopeEventTest.groovy
+++ b/dd-trace-core/jfr-openjdk/src/test/groovy/datadog/trace/core/jfr/openjdk/ScopeEventTest.groovy
@@ -298,9 +298,10 @@ class ScopeEventTest extends DDSpecification {
     def events = filterEvents(JfrHelper.stopRecording(recording), ["datadog.Checkpoint", "datadog.Route"])
     events.size() == 5
     events.each {
-      assert it.getLong("traceId") == span.getTraceId().toLong()
+      assert it.eventType.name in ["datadog.Checkpoint", "datadog.Route"]
+      assert Double.doubleToRawLongBits(it.getDouble("traceId")) == span.getTraceId().toLong()
       if (it.eventType.name == "datadog.Checkpoint") {
-        assert it.getLong("spanId") == span.getSpanId().toLong()
+        assert Double.doubleToRawLongBits(it.getDouble("spanId")) == span.getSpanId().toLong()
         int flags = it.getInt("flags")
         long cpuTime = it.getLong("cpuTime")
         if ((flags & CPU) != 0) {


### PR DESCRIPTION
These events are about 40% faster to commit in benchmarks. The profiling backend will invert the translation.