### PR TITLE
implement deterministic sampling with floating point arithmetic

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/common/sampling/DeterministicSampler.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/sampling/DeterministicSampler.java
@@ -1,10 +1,6 @@
 package datadog.trace.common.sampling;
 
 import datadog.trace.core.CoreSpan;
-import datadog.trace.core.CoreTracer;
-import java.math.BigDecimal;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * This implements the deterministic sampling algorithm used by the Datadog Agent as well as the
@@ -12,42 +8,34 @@ import org.slf4j.LoggerFactory;
  */
 public class DeterministicSampler<T extends CoreSpan<T>> implements RateSampler<T> {
 
-  private static final Logger log = LoggerFactory.getLogger(DeterministicSampler.class);
   private static final long KNUTH_FACTOR = 1111111111111111111L;
 
-  private final long cutoff; // pre-calculated for the unsigned 64 bit comparison
-  private final double rate;
+  private static final double MAX = Math.pow(2, 64) - 1;
+
+  private final float rate;
 
   public DeterministicSampler(final double rate) {
-    this.rate = rate;
-    cutoff =
-        new BigDecimal(rate)
-                .multiply(new BigDecimal(CoreTracer.TRACE_ID_MAX))
-                .toBigInteger()
-                .longValue()
-            + Long.MIN_VALUE;
-
-    log.debug("Initializing the RateSampler, sampleRate: {} %", rate * 100);
+    this.rate = (float) rate;
   }
 
   @Override
   public boolean sample(final T span) {
-    boolean sampled = false;
-    if (rate >= 1) {
-      sampled = true;
-    } else if (rate > 0) {
-      long mod = span.getTraceId().toLong() * KNUTH_FACTOR;
-      // unsigned 64 bit comparison with pre-calculated cutoff
-      if (mod + Long.MIN_VALUE < cutoff) {
-        sampled = true;
-      }
-    }
-
-    return sampled;
+    // unsigned 64 bit comparison with cutoff
+    return span.getTraceId().toLong() * KNUTH_FACTOR + Long.MIN_VALUE < cutoff(rate);
   }
 
   @Override
   public double getSampleRate() {
     return rate;
+  }
+
+  public static long cutoff(double rate) {
+    if (rate < 0.5) {
+      return (long) (rate * MAX) + Long.MIN_VALUE;
+    }
+    if (rate < 1.0) {
+      return (long) ((rate * MAX) + Long.MIN_VALUE);
+    }
+    return Long.MAX_VALUE;
   }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/sampling/DeterministicSamplerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/sampling/DeterministicSamplerTest.groovy
@@ -360,4 +360,17 @@ class DeterministicSamplerTest extends DDSpecification {
     true     | "9908585559158765387"
     true     | "9956202364908137547"
   }
+
+  def "test cutoff calculation"() {
+    when:
+    long cutoff = DeterministicSampler.cutoff(rate / 10000F)
+    then:
+    Math.abs(cutoff - new BigDecimal(rate / 10000D)
+      .multiply(new BigDecimal(BigInteger.valueOf(2).pow(64).subtract(BigInteger.ONE)))
+      .toBigInteger()
+      .longValue() + Long.MIN_VALUE) <= 1
+
+    where:
+    rate << (0..10000)
+  }
 }


### PR DESCRIPTION
`BigDecimal` and `BigInteger` are surprisingly expensive, even if used relatively infrequently 
![Screenshot 2021-06-07 at 12 01 37](https://user-images.githubusercontent.com/16439049/121006499-df412400-c788-11eb-93b3-9f9ee0fa8189.png)
![Screenshot 2021-06-07 at 12 03 40](https://user-images.githubusercontent.com/16439049/121006514-e23c1480-c788-11eb-8b11-0993734d9df8.png)

This reimplements the cutoff logic with floating point arithmetic and verifies it produces the same cutoffs plus or minus 1 for each increment of 0.0001 (I have tested this for 2 orders of magnitude smaller increments but the test takes too long).


