### PR TITLE
[CIAPP] Add runtime & bundle configuration tags for ci-app

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,7 +187,7 @@ jobs:
       - run:
           name: Upload test results to Datadog
           when: always
-          command: set +o pipefail && datadog-ci junit upload --service dd-trace-java ./results || true
+          command: ./upload_ciapp.sh base << parameters.testTask >> || true
 
   instrumentation_tests:
     <<: *base_tests
@@ -260,7 +260,7 @@ jobs:
       - run:
           name: Upload test results to Datadog
           when: always
-          command: set +o pipefail && datadog-ci junit upload --service dd-trace-java ./results || true
+          command: ./upload_ciapp.sh instrumentation << parameters.testTask >> || true
 
   smoke_tests:
     <<: *base_tests
@@ -314,7 +314,7 @@ jobs:
       - run:
           name: Upload test results to Datadog
           when: always
-          command: set +o pipefail && datadog-ci junit upload --service dd-trace-java ./results || true
+          command: ./upload_ciapp.sh smoke << parameters.testTask >> || true
 
   # The only way to do fan-in in CircleCI seems to have a proper job, so let's have one that
   # doesn't consume so many resources. The execution time for this including spin up seems to

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,7 +187,7 @@ jobs:
       - run:
           name: Upload test results to Datadog
           when: always
-          command: ./upload_ciapp.sh base << parameters.testTask >> || true
+          command: .circleci/upload_ciapp.sh base << parameters.testTask >> || true
 
   instrumentation_tests:
     <<: *base_tests
@@ -260,7 +260,7 @@ jobs:
       - run:
           name: Upload test results to Datadog
           when: always
-          command: ./upload_ciapp.sh instrumentation << parameters.testTask >> || true
+          command: .circleci/upload_ciapp.sh instrumentation << parameters.testTask >> || true
 
   smoke_tests:
     <<: *base_tests
@@ -314,7 +314,7 @@ jobs:
       - run:
           name: Upload test results to Datadog
           when: always
-          command: ./upload_ciapp.sh smoke << parameters.testTask >> || true
+          command: .circleci/upload_ciapp.sh smoke << parameters.testTask >> || true
 
   # The only way to do fan-in in CircleCI seems to have a proper job, so let's have one that
   # doesn't consume so many resources. The execution time for this including spin up seems to

--- a/.circleci/upload_ciapp.sh
+++ b/.circleci/upload_ciapp.sh
@@ -14,9 +14,7 @@ java_prop () {
 # based on tracer implementation: https://github.com/DataDog/dd-trace-java/blob/master/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/TestDecorator.java#L55-L77
 TAGS="test.bundle:$1,\
 runtime.name:$(java_prop java.runtime.name),runtime.vendor:$(java_prop java.vendor),runtime.version:$(java_prop java.version),\
-os.arch:$(java_prop os.arch),os.name:$(java_prop os.name),os.version:$(java_prop os.version)\
+os.architecture:$(java_prop os.arch),os.platform:$(java_prop os.name),os.version:$(java_prop os.version)\
 "
-
-echo $TAGS
 
 DD_TAGS="${TAGS}" datadog-ci junit upload --service $SERVICE_NAME ./results

--- a/.circleci/upload_ciapp.sh
+++ b/.circleci/upload_ciapp.sh
@@ -17,4 +17,6 @@ runtime.name:$(java_prop java.runtime.name),runtime.vendor:$(java_prop java.vend
 os.arch:$(java_prop os.arch),os.name:$(java_prop os.name),os.version:$(java_prop os.version)\
 "
 
+echo $TAGS
+
 datadog-ci junit upload --service $SERVICE_NAME --tags "${TAGS}" ./results

--- a/.circleci/upload_ciapp.sh
+++ b/.circleci/upload_ciapp.sh
@@ -1,13 +1,20 @@
 #!/usr/bin/env bash
 SERVICE_NAME="dd-trace-java"
-TEST_BUNDLE=$1
-JDK_STR=$2
 
-TAGS="test.bundle:${TEST_BUNDLE}"
-if [[ $JDK_STR =~ ([^0-9]*)([0-9]+) ]]; then
-    JDK_NAME=${BASH_REMATCH[1]:-"adoptOpenJDK"}
-    JDK_VERSION=${BASH_REMATCH[2]}
-    TAGS="${TAGS},runtime.name:${JDK_NAME},runtime.version:${JDK_VERSION}"
+# JAVA_???_HOME are set in the base image for each used JDK https://github.com/DataDog/dd-trace-java-docker-build/blob/master/Dockerfile#L86
+java_bin="\$JAVA_$2_HOME/bin/java"
+if [ ! -x $java_bin ]; then
+    java_bin=$(which java)
 fi
+java_props=$($java_bin -XshowSettings:properties -version 2>&1)
+java_prop () {
+    echo "$(echo "$java_props" | grep $1 | head -n1 | cut -d'=' -f2 | xargs)"
+}
 
-datadog-ci junit upload --service $SERVICE --tags $TAGS ./results
+# based on tracer implementation: https://github.com/DataDog/dd-trace-java/blob/master/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/TestDecorator.java#L55-L77
+TAGS="test.bundle:$1,\
+runtime.name:$(java_prop java.runtime.name),runtime.vendor:$(java_prop java.vendor),runtime.version:$(java_prop java.version),\
+os.arch:$(java_prop os.arch),os.name:$(java_prop os.name),os.version:$(java_prop os.version)\
+"
+
+datadog-ci junit upload --service $SERVICE_NAME --tags "${TAGS}" ./results

--- a/.circleci/upload_ciapp.sh
+++ b/.circleci/upload_ciapp.sh
@@ -19,4 +19,4 @@ os.arch:$(java_prop os.arch),os.name:$(java_prop os.name),os.version:$(java_prop
 
 echo $TAGS
 
-datadog-ci junit upload --service $SERVICE_NAME --tags "${TAGS}" ./results
+DD_TAGS="${TAGS}" datadog-ci junit upload --service $SERVICE_NAME ./results

--- a/.circleci/upload_ciapp.sh
+++ b/.circleci/upload_ciapp.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+SERVICE_NAME="dd-trace-java"
+TEST_BUNDLE=$1
+JDK_STR=$2
+
+TAGS="test.bundle:${TEST_BUNDLE}"
+if [[ $JDK_STR =~ ([^0-9]*)([0-9]+) ]]; then
+    JDK_NAME=${BASH_REMATCH[1]:-"adoptOpenJDK"}
+    JDK_VERSION=${BASH_REMATCH[2]}
+    TAGS="${TAGS},runtime.name:${JDK_NAME},runtime.version:${JDK_VERSION}"
+fi
+
+datadog-ci junit upload --service $SERVICE --tags $TAGS ./results


### PR DESCRIPTION
This enables a new facet to filter tests by: `base`, `instrumentation` or `smoke` across all jobs.

More importantly it adds `runtime.name` and `runtime.version` tags so that we can separate flakiness depending on runtime.