### PR TITLE
Instrumentation Gateway improvement proposal

### DIFF
--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/AppSecSystem.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/AppSecSystem.java
@@ -1,7 +1,10 @@
 package com.datadog.appsec;
 
+import com.datadog.appsec.gateway.AppSecRequestContext;
 import datadog.trace.api.Config;
 import java.util.concurrent.atomic.AtomicBoolean;
+
+import datadog.trace.api.gateway.InstrGateway;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -10,7 +13,7 @@ public class AppSecSystem {
   private static final Logger log = LoggerFactory.getLogger(AppSecSystem.class);
   private static final AtomicBoolean STARTED = new AtomicBoolean();
 
-  public static void start() {
+  public static void start(InstrGateway gw) {
     final Config config = Config.get();
     if (!config.isAppSecEnabled()) {
       log.debug("AppSec: disabled");
@@ -18,6 +21,8 @@ public class AppSecSystem {
     }
     log.info("AppSec has started");
     STARTED.set(true);
+
+    gw.registerRequestContextFactory(AppSecRequestContext::new);
   }
 
   public static boolean isStarted() {

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/AppSecRequestContext.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/AppSecRequestContext.java
@@ -1,0 +1,29 @@
+package com.datadog.appsec.gateway;
+
+import datadog.trace.api.gateway.Flow;
+import datadog.trace.api.gateway.RequestContext;
+
+/**
+ * AppSec specific RequestContext implementation
+ */
+@SuppressWarnings("rawtypes")
+public class AppSecRequestContext implements RequestContext {
+
+  @Override
+  public void addHeader(String key, String value) {
+  }
+
+  @Override
+  public void addCookie(String key, String value) {
+  }
+
+  @Override
+  public Flow finishHeaders() {
+    return Flow.ResultFlow.empty();
+  }
+
+  @Override
+  public Flow setRawURI(String uri) {
+    return Flow.ResultFlow.empty();
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/gateway/InstrGateway.java
+++ b/internal-api/src/main/java/datadog/trace/api/gateway/InstrGateway.java
@@ -1,0 +1,35 @@
+package datadog.trace.api.gateway;
+
+import java.util.LinkedList;
+import java.util.List;
+
+public class InstrGateway {
+
+  private final List<RequestContextFactory> factories = new LinkedList<>();
+
+  public interface RequestContextFactory {
+    RequestContext createRequestContext();
+  }
+
+  /**
+   * Method allows to register factory that allows to instantiate RequestContext
+   * implementations from Event consumer
+   */
+  public void registerRequestContextFactory(RequestContextFactory factory) {
+    factories.add(factory);
+  }
+
+  /**
+   * Method to create new RequestContext with all nested implementations
+   */
+  public RequestContext createRequestContext() {
+    RequestContextDelegator ctx = new RequestContextDelegator();
+
+    for (RequestContextFactory callback : factories) {
+      RequestContext delegate = callback.createRequestContext();
+      ctx.addDelegate(delegate);
+    }
+
+    return ctx;
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/gateway/RequestContext.java
+++ b/internal-api/src/main/java/datadog/trace/api/gateway/RequestContext.java
@@ -4,4 +4,10 @@ package datadog.trace.api.gateway;
  * This is the context that will travel along with the request and be presented to the
  * Instrumentation Gateway subscribers.
  */
-public interface RequestContext {}
+public interface RequestContext {
+
+  void addHeader(String key, String value);
+  void addCookie(String key, String value);
+  Flow finishHeaders();
+  Flow setRawURI(String uri);
+}

--- a/internal-api/src/main/java/datadog/trace/api/gateway/RequestContextDelegator.java
+++ b/internal-api/src/main/java/datadog/trace/api/gateway/RequestContextDelegator.java
@@ -1,0 +1,49 @@
+package datadog.trace.api.gateway;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * This class retain and call all delegated implementations
+ */
+@SuppressWarnings("rawtypes")
+public class RequestContextDelegator implements RequestContext {
+
+  private final List<RequestContext> ctxDelegates = new LinkedList<>();
+
+  public void addDelegate(RequestContext ctx) {
+    ctxDelegates.add(ctx);
+  }
+
+  @Override
+  public void addHeader(String key, String value) {
+    for (RequestContext ctxDelegate : ctxDelegates) {
+      ctxDelegate.addHeader(key, value);
+    }
+  }
+
+  @Override
+  public void addCookie(String key, String value) {
+    for (RequestContext ctxDelegate : ctxDelegates) {
+      ctxDelegate.addCookie(key, value);
+    }
+  }
+
+  @Override
+  public Flow finishHeaders() {
+    Flow flow = null;
+    for (RequestContext ctxDelegate : ctxDelegates) {
+      flow = ctxDelegate.finishHeaders();
+    }
+    return flow;
+  }
+
+  @Override
+  public Flow setRawURI(String uri) {
+    Flow flow = null;
+    for (RequestContext ctxDelegate : ctxDelegates) {
+      flow = ctxDelegate.setRawURI(uri);
+    }
+    return flow;
+  }
+}


### PR DESCRIPTION
I suggest looking at an alternative Instrumentation Gateway implementation.

Here I decided to abandon events classification - this means that each event is transmitted through its own method: `addHeader(...)`, `addCookie(...)`, `setRawUri(...)`, etc.

Also, this implementation avoids the use of `cast` (which we talked about here https://github.com/DataDog/dd-trace-java/pull/2725#discussion_r646189162)
Each created `RequestContext` will (through delegation) consist of many implementations from each module that listens for events. In this way, we can ensure very fast calling correct implementations without casting.

In the image below, you can see how the event from the instrumentation calls `RequestContex.addHeader`, which calls all implementations of this interface from different modules (each module listens for events)
![Untitled - IG proposal](https://user-images.githubusercontent.com/7569471/121195045-f0b52980-c877-11eb-899c-bd3f4b06b0cd.jpg)

The usage from the tracer side will look like:
```
// Some global singleton
InstrumentationGateway gw = InstrumentationGateway.getInstance();

// The AppSec module registers factory to instantiate implementation
RequestContext ctx = gw.registerRequestContextFactory(AppSecRequestContext::new);

// Store request data
Flow flow = ctx.setRawURI(uri);
ctx.addHeader(key, value);
ctx.addCookie(key, value);
flow = ctx.finishHeaders();

// Dispose context when request finished
ctx.close();
```

I would welcome criticism / doubts, what do you think of the proposed solution? Am I missing something?