### PR TITLE
[AppSec] Move callback casting inside Events class

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
@@ -222,7 +222,7 @@ public abstract class HttpServerDecorator<REQUEST, CONNECTION, RESPONSE> extends
     RequestContext requestContext = span.getRequestContext();
     if (null != cbp && null != requestContext) {
       BiFunction<RequestContext, String, Flow<Void>> callback =
-          cbp.getCallback(Events.REQUEST_URI_RAW);
+          cbp.getCallback(Events.requestUriRaw());
       if (null != callback) {
         // TODO:appsec pull this out and add it to the URIDataAdapter
         String query = url.query();

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/HttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/HttpCodec.java
@@ -117,14 +117,14 @@ public class HttpCodec {
 
       if (null != callbackProvider) {
         Supplier<Flow<RequestContext>> startedCB =
-            callbackProvider.getCallback(Events.REQUEST_STARTED);
+            callbackProvider.getCallback(Events.requestStarted());
         if (null != startedCB) {
           requestContext = startedCB.get().getResult();
           IGKeyClassifier igKeyClassifier =
               IGKeyClassifier.create(
                   requestContext,
-                  callbackProvider.getCallback(Events.REQUEST_HEADER),
-                  callbackProvider.getCallback(Events.REQUEST_HEADER_DONE));
+                  callbackProvider.getCallback(Events.requestHeader()),
+                  callbackProvider.getCallback(Events.requestHeaderDone()));
           if (null != igKeyClassifier) {
             getter.forEachKey(carrier, igKeyClassifier);
             igKeyClassifier.done();

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HttpExtractorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HttpExtractorTest.groovy
@@ -96,13 +96,13 @@ class HttpExtractorTest extends DDSpecification {
     def ig = new InstrumentationGateway()
     def callbacks = new IGCallBacks(reqContext)
     if (reqStarted) {
-      ig.registerCallback(Events.REQUEST_STARTED, callbacks)
+      ig.registerCallback(Events.requestStarted(), callbacks)
     }
     if (reqHeader) {
-      ig.registerCallback(Events.REQUEST_HEADER, callbacks)
+      ig.registerCallback(Events.requestHeader(), callbacks)
     }
     if (reqHeaderDone) {
-      ig.registerCallback(Events.REQUEST_HEADER_DONE, callbacks)
+      ig.registerCallback(Events.requestHeaderDone(), callbacks)
     }
     Map<String, String> headers = ["foo": "bar", "some": "thing", "another": "value"]
     Config config = Mock(Config) {

--- a/internal-api/src/main/java/datadog/trace/api/gateway/Events.java
+++ b/internal-api/src/main/java/datadog/trace/api/gateway/Events.java
@@ -7,25 +7,52 @@ import java.util.concurrent.atomic.AtomicInteger;
 public final class Events {
   private static final AtomicInteger nextId = new AtomicInteger(0);
 
+  @SuppressWarnings("rawtypes")
+  private static final EventType REQUEST_STARTED = new ET<>("request.started");
+
   /** A request started * */
-  public static final EventType<Supplier<Flow<RequestContext>>> REQUEST_STARTED =
-      new ET<>("request.started");
+  @SuppressWarnings("unchecked")
+  public static <C extends RequestContext> EventType<Supplier<Flow<C>>> requestStarted() {
+    return (EventType<Supplier<Flow<C>>>) REQUEST_STARTED;
+  }
+
+  @SuppressWarnings("rawtypes")
+  private static final EventType REQUEST_ENDED = new ET<>("request.ended");
 
   /** A request ended * */
-  public static final EventType<Function<RequestContext, Flow<Void>>> REQUEST_ENDED =
-      new ET<>("request.ended");
+  @SuppressWarnings("unchecked")
+  public static <C extends RequestContext> EventType<Function<C, Flow<Void>>> requestEnded() {
+    return (EventType<Function<C, Flow<Void>>>) REQUEST_ENDED;
+  }
+
+  @SuppressWarnings("rawtypes")
+  private static final EventType REQUEST_HEADER = new ET<>("server.request.header");
 
   /** A request header as a key and values separated by , */
-  public static final EventType<TriConsumer<RequestContext, String, String>> REQUEST_HEADER =
-      new ET<>("server.request.header");
+  @SuppressWarnings("unchecked")
+  public static <C extends RequestContext>
+      EventType<TriConsumer<C, String, String>> requestHeader() {
+    return (EventType<TriConsumer<C, String, String>>) REQUEST_HEADER;
+  }
+
+  @SuppressWarnings("rawtypes")
+  private static final EventType REQUEST_HEADER_DONE = new ET<>("server.request.header.done");
 
   /** All request headers have been provided */
-  public static final EventType<Function<RequestContext, Flow<Void>>> REQUEST_HEADER_DONE =
-      new ET<>("server.request.header.done");
+  @SuppressWarnings("unchecked")
+  public static <C extends RequestContext> EventType<Function<C, Flow<Void>>> requestHeaderDone() {
+    return (EventType<Function<C, Flow<Void>>>) REQUEST_HEADER_DONE;
+  }
+
+  @SuppressWarnings("rawtypes")
+  private static final EventType REQUEST_URI_RAW = new ET<>("server.request.uri.raw");
 
   /** The unparsed request uri, incl. the query string. */
-  public static final EventType<BiFunction<RequestContext, String, Flow<Void>>> REQUEST_URI_RAW =
-      new ET<>("server.request.uri.raw");
+  @SuppressWarnings("unchecked")
+  public static <C extends RequestContext>
+      EventType<BiFunction<C, String, Flow<Void>>> requestUriRaw() {
+    return (EventType<BiFunction<C, String, Flow<Void>>>) REQUEST_URI_RAW;
+  }
 
   public static final int MAX_EVENTS = nextId.get();
 

--- a/internal-api/src/test/java/datadog/trace/api/gateway/InstrumentationGatewayTest.java
+++ b/internal-api/src/test/java/datadog/trace/api/gateway/InstrumentationGatewayTest.java
@@ -27,15 +27,15 @@ public class InstrumentationGatewayTest {
             return new Flow.ResultFlow<>(context);
           }
         };
-    subscription = gateway.registerCallback(Events.REQUEST_STARTED, callback);
+    subscription = gateway.registerCallback(Events.requestStarted(), callback);
   }
 
   @Test
   public void testGetCallback() {
     // check event without registered callback
-    assertThat(gateway.getCallback(Events.REQUEST_ENDED)).isNull();
+    assertThat(gateway.getCallback(Events.requestEnded())).isNull();
     // check event with registered callback
-    Supplier<Flow<RequestContext>> cback = gateway.getCallback(Events.REQUEST_STARTED);
+    Supplier<Flow<RequestContext>> cback = gateway.getCallback(Events.requestStarted());
     assertThat(cback).isEqualTo(callback);
     Flow<RequestContext> flow = cback.get();
     assertThat(flow.getAction()).isNull();
@@ -46,9 +46,9 @@ public class InstrumentationGatewayTest {
   @Test
   public void testRegisterCallback() {
     // check event without registered callback
-    assertThat(gateway.getCallback(Events.REQUEST_ENDED)).isNull();
+    assertThat(gateway.getCallback(Events.requestEnded())).isNull();
     // check event with registered callback
-    assertThat(gateway.getCallback(Events.REQUEST_STARTED)).isEqualTo(callback);
+    assertThat(gateway.getCallback(Events.requestStarted())).isEqualTo(callback);
     // check that we can register a callback
     Function<RequestContext, Flow<Void>> cb =
         new Function<RequestContext, Flow<Void>>() {
@@ -57,41 +57,41 @@ public class InstrumentationGatewayTest {
             return new Flow.ResultFlow<>(null);
           }
         };
-    Subscription s = gateway.registerCallback(Events.REQUEST_ENDED, cb);
-    assertThat(gateway.getCallback(Events.REQUEST_ENDED)).isEqualTo(cb);
+    Subscription s = gateway.registerCallback(Events.requestEnded(), cb);
+    assertThat(gateway.getCallback(Events.requestEnded())).isEqualTo(cb);
     // check that we can cancel a callback
     subscription.cancel();
-    assertThat(gateway.getCallback(Events.REQUEST_STARTED)).isNull();
+    assertThat(gateway.getCallback(Events.requestStarted())).isNull();
     // check that we didn't remove the other callback
-    assertThat(gateway.getCallback(Events.REQUEST_ENDED)).isEqualTo(cb);
+    assertThat(gateway.getCallback(Events.requestEnded())).isEqualTo(cb);
   }
 
   @Test
   public void testDoubleRegistration() {
     // check event with registered callback
-    assertThat(gateway.getCallback(Events.REQUEST_STARTED)).isEqualTo(callback);
+    assertThat(gateway.getCallback(Events.requestStarted())).isEqualTo(callback);
     // check that we can't overwrite the callback
     assertThatThrownBy(
             new ThrowableAssert.ThrowingCallable() {
               @Override
               public void call() throws Throwable {
-                gateway.registerCallback(Events.REQUEST_STARTED, callback);
+                gateway.registerCallback(Events.requestStarted(), callback);
               }
             })
         .isInstanceOf(IllegalStateException.class)
         .hasMessageStartingWith("Trying to overwrite existing callback ")
-        .hasMessageContaining(Events.REQUEST_STARTED.toString());
+        .hasMessageContaining(Events.requestStarted().toString());
   }
 
   @Test
   public void testDoubleCancel() {
     // check event with registered callback
-    assertThat(gateway.getCallback(Events.REQUEST_STARTED)).isEqualTo(callback);
+    assertThat(gateway.getCallback(Events.requestStarted())).isEqualTo(callback);
     // check that we can cancel a callback
     subscription.cancel();
-    assertThat(gateway.getCallback(Events.REQUEST_STARTED)).isNull();
+    assertThat(gateway.getCallback(Events.requestStarted())).isNull();
     // check that we can cancel a callback
     subscription.cancel();
-    assertThat(gateway.getCallback(Events.REQUEST_STARTED)).isNull();
+    assertThat(gateway.getCallback(Events.requestStarted())).isNull();
   }
 }


### PR DESCRIPTION
Another way to avoid end user casting of the `RequestContext` that avoids adding the methods to the context itself as in #2812

This is not a complete solution, but just a rough draft to show one other possibility.