### PR TITLE
Fix handling of jdk.OldObjectSample config for <17 JDKs

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-controller-jfr/src/main/java/com/datadog/profiling/controller/jfr/JfpUtils.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-jfr/src/main/java/com/datadog/profiling/controller/jfr/JfpUtils.java
@@ -19,7 +19,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -69,8 +68,8 @@ public final class JfpUtils {
       if (!overridesFileName.toLowerCase().endsWith(JFP_EXTENSION)) {
         overridesFileName = overridesFileName + JFP_EXTENSION;
       }
-      File override = new File(overridesFileName);
-      try (InputStream overrideStream =
+      final File override = new File(overridesFileName);
+      try (final InputStream overrideStream =
           override.exists()
               ? new FileInputStream(override)
               : getNamedResource(OVERRIDES_PATH + overridesFileName)) {
@@ -81,6 +80,6 @@ public final class JfpUtils {
         }
       }
     }
-    return Collections.unmodifiableMap(result);
+    return result;
   }
 }

--- a/dd-java-agent/agent-profiling/profiling-controller-oracle/src/main/java/com/datadog/profiling/controller/oracle/OracleJdkController.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-oracle/src/main/java/com/datadog/profiling/controller/oracle/OracleJdkController.java
@@ -6,6 +6,7 @@ import com.datadog.profiling.controller.jfr.JfpUtils;
 import datadog.trace.api.Config;
 import java.io.IOException;
 import java.time.Duration;
+import java.util.Collections;
 import java.util.Map;
 import javax.annotation.Nonnull;
 import org.slf4j.Logger;
@@ -33,8 +34,9 @@ public final class OracleJdkController implements Controller {
       log.debug("Initializing Oracle JFR controller");
       helper = new JfrMBeanHelper();
       eventSettings =
-          JfpUtils.readNamedJfpResource(
-              JfpUtils.DEFAULT_JFP, config.getProfilingTemplateOverrideFile());
+          Collections.unmodifiableMap(
+              JfpUtils.readNamedJfpResource(
+                  JfpUtils.DEFAULT_JFP, config.getProfilingTemplateOverrideFile()));
     } catch (final IOException e) {
       throw new ConfigurationException(e);
     }
@@ -47,7 +49,7 @@ public final class OracleJdkController implements Controller {
       log.debug("Attempting to create a new recording with name '{}'", recordingName);
       return new OracleJdkOngoingRecording(
           helper, recordingName, RECORDING_MAX_SIZE, RECORDING_MAX_AGE, eventSettings);
-    } catch (IOException e) {
+    } catch (final IOException e) {
       throw new RuntimeException("Unable to create a new recording with name " + recordingName, e);
     }
   }


### PR DESCRIPTION
Fixes regression when enabling `jdk.OldObjectSample` on JDKs < 17
causes profiling to be disabled.