### PR TITLE
Fix Java 7 Build

### DIFF
--- a/dd-java-agent/instrumentation/trace-annotation/trace-annotation.gradle
+++ b/dd-java-agent/instrumentation/trace-annotation/trace-annotation.gradle
@@ -10,5 +10,5 @@ muzzle {
 apply from: "$rootDir/gradle/java.gradle"
 
 dependencies {
-  testImplementation group: 'com.newrelic.agent.java', name: 'newrelic-api', version: '+'
+  testImplementation group: 'com.newrelic.agent.java', name: 'newrelic-api', version: '6.+'
 }


### PR DESCRIPTION
[Latest NR version dropped support for java 7](https://github.com/newrelic/newrelic-java-agent/commit/efa51bda0de8e605e70000341a0c4825306a7370), so we need to pin to the prior version.

TODO: We probably don't need this test anymore...