### PR TITLE
[AppSec] IG tweaks proposal

### DIFF
--- a/internal-api/src/main/java/datadog/trace/api/gateway/EventCallback.java
+++ b/internal-api/src/main/java/datadog/trace/api/gateway/EventCallback.java
@@ -1,0 +1,3 @@
+package datadog.trace.api.gateway;
+
+public interface EventCallback {}

--- a/internal-api/src/main/java/datadog/trace/api/gateway/Events.java
+++ b/internal-api/src/main/java/datadog/trace/api/gateway/Events.java
@@ -9,40 +9,35 @@ public final class Events {
   /** A request started * */
   public static final EventType<RequestStarted> REQUEST_STARTED = new ET<>("request.started");
 
-  @SuppressWarnings("rawtypes")
-  public interface RequestStarted<C extends RequestContext> {
+  public interface RequestStarted<C extends RequestContext> extends EventCallback {
     C get();
   }
 
   /** A request ended * */
   public static final EventType<RequestEnded> REQUEST_ENDED = new ET<>("request.ended");
 
-  @SuppressWarnings("rawtypes")
-  public interface RequestEnded<C extends RequestContext> {
+  public interface RequestEnded<C extends RequestContext> extends EventCallback {
     void apply(C ctx);
   }
 
   /** A request header as a key and values separated by , */
   public static final EventType<RequestHeader> REQUEST_HEADER = new ET<>("server.request.header");
 
-  @SuppressWarnings("rawtypes")
-  public interface RequestHeader<C extends RequestContext> {
+  public interface RequestHeader<C extends RequestContext> extends EventCallback {
     void accept(C ctx, String key, String value);
   }
 
   /** All request headers have been provided */
   public static final EventType<RequestHeaderDone> REQUEST_HEADER_DONE = new ET<>("server.request.header.done");
 
-  @SuppressWarnings("rawtypes")
-  public interface RequestHeaderDone<C extends RequestContext> {
+  public interface RequestHeaderDone<C extends RequestContext> extends EventCallback {
     Flow<C> apply(C ctx);
   }
 
   /** The unparsed request uri, incl. the query string. */
   public static final EventType<RequestUriRaw> REQUEST_URI_RAW = new ET<>("server.request.uri.raw");
 
-  @SuppressWarnings("rawtypes")
-  public interface RequestUriRaw<C extends RequestContext> {
+  public interface RequestUriRaw<C extends RequestContext> extends EventCallback {
     Flow<C> apply(C ctx, String uri);
   }
 

--- a/internal-api/src/main/java/datadog/trace/api/gateway/Events.java
+++ b/internal-api/src/main/java/datadog/trace/api/gateway/Events.java
@@ -1,58 +1,52 @@
 package datadog.trace.api.gateway;
 
-import datadog.trace.api.Function;
-import datadog.trace.api.function.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public final class Events {
   private static final AtomicInteger nextId = new AtomicInteger(0);
 
-  @SuppressWarnings("rawtypes")
-  private static final EventType REQUEST_STARTED = new ET<>("request.started");
 
   /** A request started * */
-  @SuppressWarnings("unchecked")
-  public static <C extends RequestContext> EventType<Supplier<Flow<C>>> requestStarted() {
-    return (EventType<Supplier<Flow<C>>>) REQUEST_STARTED;
-  }
+  public static final EventType<RequestStarted> REQUEST_STARTED = new ET<>("request.started");
 
   @SuppressWarnings("rawtypes")
-  private static final EventType REQUEST_ENDED = new ET<>("request.ended");
+  public interface RequestStarted<C extends RequestContext> {
+    C get();
+  }
 
   /** A request ended * */
-  @SuppressWarnings("unchecked")
-  public static <C extends RequestContext> EventType<Function<C, Flow<Void>>> requestEnded() {
-    return (EventType<Function<C, Flow<Void>>>) REQUEST_ENDED;
-  }
+  public static final EventType<RequestEnded> REQUEST_ENDED = new ET<>("request.ended");
 
   @SuppressWarnings("rawtypes")
-  private static final EventType REQUEST_HEADER = new ET<>("server.request.header");
+  public interface RequestEnded<C extends RequestContext> {
+    void apply(C ctx);
+  }
 
   /** A request header as a key and values separated by , */
-  @SuppressWarnings("unchecked")
-  public static <C extends RequestContext>
-      EventType<TriConsumer<C, String, String>> requestHeader() {
-    return (EventType<TriConsumer<C, String, String>>) REQUEST_HEADER;
-  }
+  public static final EventType<RequestHeader> REQUEST_HEADER = new ET<>("server.request.header");
 
   @SuppressWarnings("rawtypes")
-  private static final EventType REQUEST_HEADER_DONE = new ET<>("server.request.header.done");
+  public interface RequestHeader<C extends RequestContext> {
+    void accept(C ctx, String key, String value);
+  }
 
   /** All request headers have been provided */
-  @SuppressWarnings("unchecked")
-  public static <C extends RequestContext> EventType<Function<C, Flow<Void>>> requestHeaderDone() {
-    return (EventType<Function<C, Flow<Void>>>) REQUEST_HEADER_DONE;
-  }
+  public static final EventType<RequestHeaderDone> REQUEST_HEADER_DONE = new ET<>("server.request.header.done");
 
   @SuppressWarnings("rawtypes")
-  private static final EventType REQUEST_URI_RAW = new ET<>("server.request.uri.raw");
+  public interface RequestHeaderDone<C extends RequestContext> {
+    Flow<C> apply(C ctx);
+  }
 
   /** The unparsed request uri, incl. the query string. */
-  @SuppressWarnings("unchecked")
-  public static <C extends RequestContext>
-      EventType<BiFunction<C, String, Flow<Void>>> requestUriRaw() {
-    return (EventType<BiFunction<C, String, Flow<Void>>>) REQUEST_URI_RAW;
+  public static final EventType<RequestUriRaw> REQUEST_URI_RAW = new ET<>("server.request.uri.raw");
+
+  @SuppressWarnings("rawtypes")
+  public interface RequestUriRaw<C extends RequestContext> {
+    Flow<C> apply(C ctx, String uri);
   }
+
+
 
   public static final int MAX_EVENTS = nextId.get();
 

--- a/internal-api/src/main/java/datadog/trace/api/gateway/InstrumentationGateway.java
+++ b/internal-api/src/main/java/datadog/trace/api/gateway/InstrumentationGateway.java
@@ -23,7 +23,7 @@ public class InstrumentationGateway implements CallbackProvider, SubscriptionSer
 
   @Override
   @SuppressWarnings("unchecked")
-  public <C> Subscription registerCallback(final EventType<C> eventType, final C callback) {
+  public <C extends EventCallback> Subscription registerCallback(final EventType<C> eventType, final C callback) {
     if (!callbacks.compareAndSet(eventType.getId(), null, callback)) {
       C existing = (C) callbacks.get(eventType.getId());
       String message =

--- a/internal-api/src/main/java/datadog/trace/api/gateway/SubscriptionService.java
+++ b/internal-api/src/main/java/datadog/trace/api/gateway/SubscriptionService.java
@@ -2,5 +2,5 @@ package datadog.trace.api.gateway;
 
 /** The API used by the consumers to register callbacks. */
 public interface SubscriptionService {
-  <C> Subscription registerCallback(EventType<C> eventType, C callback);
+  <C extends EventCallback> Subscription registerCallback(EventType<C> eventType, C callback);
 }


### PR DESCRIPTION
@bantonsson I like your recent tweaks solution, and I've done some types improvements. Dedicated interfaces allows to have clearer IG usage without using common functions. Unfortunately, using the common interfaces `BiFunction`,` TriConsumer`, etc .. can be confusing and obscure the names of the callback arguments. The proposed explicit interfaces, in my opinion, are more transparent to use.

Usage example:
```
InstrumentationGateway ig = new InstrumentationGateway();

// Prepare callback for REQUEST_STARTED event
Object requestStartedCallback = new Events.RequestStarted<AppSecContext>() {
  @Override
  AppSecContext get() {
    return new AppSecContext();
  }
}

// Register callback for event
ig.registerCallback(Events.REQUEST_STARTED, requestStartedCallback);

// Get and call REQUEST_STARTED event callback
RequestContext ctx = ig.getCallback(Events.REQUEST_STARTED).get();
```

In addition, I've changed some return types for callbacks. So, callback for `RequestStarted` returns plain` RequestContext`, and `RequestEnded` callback returns void. I suppose, we shouldn't use `Flow` here, because both callbacks are service events and cannot change execution flow (from logical standpoint). Also proposed type-tweaks allows to return objects directly without extra `Flow` wrapping.

However, `Flow` still used for` REQUEST_HEADER_DONE` and `REQUEST_URI_RAW`, because this events, can change execution flow.