### PR TITLE
Ensure ClassLoaderMatchers aren't bypassed when using RawMatchers

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Instrumenter.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Instrumenter.java
@@ -163,8 +163,11 @@ public interface Instrumenter {
 
     private AgentBuilder.Identified.Narrowable filter(AgentBuilder agentBuilder) {
       final AgentBuilder.Identified.Narrowable narrowable;
+      ElementMatcher<ClassLoader> classLoaderMatcher = classLoaderMatcher();
       ElementMatcher<? super TypeDescription> typeMatcher = typeMatcher();
-      if (typeMatcher instanceof AgentBuilder.RawMatcher && typeMatcher instanceof FailSafe) {
+      if (classLoaderMatcher == ANY_CLASS_LOADER // Don't bypass the classLoaderMatcher
+          && typeMatcher instanceof AgentBuilder.RawMatcher
+          && typeMatcher instanceof FailSafe) {
         narrowable = agentBuilder.type((AgentBuilder.RawMatcher) typeMatcher);
       } else {
         narrowable =
@@ -173,7 +176,7 @@ public interface Instrumenter {
                     typeMatcher,
                     "Instrumentation type matcher unexpected exception: " + getClass().getName()),
                 failSafe(
-                    classLoaderMatcher(),
+                    classLoaderMatcher,
                     "Instrumentation class loader matcher unexpected exception: "
                         + getClass().getName()));
       }


### PR DESCRIPTION
#2633 introduced a regression that resulted in the ClassLoaderMatcher being ignored when the TypeMatcher was a "RawMatcher". This caused both OpenTracing instrumentation classes to be applied resulting in a duplicate "register" attempt.
(There might be other instrumentation effected by this as well.)