### PR TITLE
[CIAPP] Fix configuration tags for JDK in CI-App script

### DIFF
--- a/.circleci/upload_ciapp.sh
+++ b/.circleci/upload_ciapp.sh
@@ -2,7 +2,8 @@
 SERVICE_NAME="dd-trace-java"
 
 # JAVA_???_HOME are set in the base image for each used JDK https://github.com/DataDog/dd-trace-java-docker-build/blob/master/Dockerfile#L86
-java_bin="\$JAVA_$2_HOME/bin/java"
+java_home="JAVA_$2_HOME"
+java_bin="${!java_home}/bin/java"
 echo "JAVA_BIN: $java_bin"
 if [ ! -x $java_bin ]; then
     java_bin=$(which java)

--- a/.circleci/upload_ciapp.sh
+++ b/.circleci/upload_ciapp.sh
@@ -6,13 +6,15 @@ java_bin="\$JAVA_$2_HOME/bin/java"
 if [ ! -x $java_bin ]; then
     java_bin=$(which java)
 fi
+echo "JAVA_BIN: $java_bin"
+
 java_props=$($java_bin -XshowSettings:properties -version 2>&1)
 java_prop () {
     echo "$(echo "$java_props" | grep $1 | head -n1 | cut -d'=' -f2 | xargs)"
 }
 
 # based on tracer implementation: https://github.com/DataDog/dd-trace-java/blob/master/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/TestDecorator.java#L55-L77
-TAGS="test.bundle:$1,\
+TAGS="test.traits:{\"marker\":[\"$1\"]},\
 runtime.name:$(java_prop java.runtime.name),runtime.vendor:$(java_prop java.vendor),runtime.version:$(java_prop java.version),\
 os.architecture:$(java_prop os.arch),os.platform:$(java_prop os.name),os.version:$(java_prop os.version)\
 "

--- a/.circleci/upload_ciapp.sh
+++ b/.circleci/upload_ciapp.sh
@@ -4,11 +4,9 @@ SERVICE_NAME="dd-trace-java"
 # JAVA_???_HOME are set in the base image for each used JDK https://github.com/DataDog/dd-trace-java-docker-build/blob/master/Dockerfile#L86
 java_home="JAVA_$2_HOME"
 java_bin="${!java_home}/bin/java"
-echo "JAVA_BIN: $java_bin"
 if [ ! -x $java_bin ]; then
     java_bin=$(which java)
 fi
-echo "JAVA_BIN: $java_bin"
 
 java_props=$($java_bin -XshowSettings:properties -version 2>&1)
 java_prop () {
@@ -20,6 +18,5 @@ TAGS="test.traits:{\"marker\":[\"$1\"]},\
 runtime.name:$(java_prop java.runtime.name),runtime.vendor:$(java_prop java.vendor),runtime.version:$(java_prop java.version),\
 os.architecture:$(java_prop os.arch),os.platform:$(java_prop os.name),os.version:$(java_prop os.version)\
 "
-echo "${TAGS}"
 
 DD_TAGS="${TAGS}" datadog-ci junit upload --service $SERVICE_NAME ./results

--- a/.circleci/upload_ciapp.sh
+++ b/.circleci/upload_ciapp.sh
@@ -3,6 +3,7 @@ SERVICE_NAME="dd-trace-java"
 
 # JAVA_???_HOME are set in the base image for each used JDK https://github.com/DataDog/dd-trace-java-docker-build/blob/master/Dockerfile#L86
 java_bin="\$JAVA_$2_HOME/bin/java"
+echo "JAVA_BIN: $java_bin"
 if [ ! -x $java_bin ]; then
     java_bin=$(which java)
 fi
@@ -18,5 +19,6 @@ TAGS="test.traits:{\"marker\":[\"$1\"]},\
 runtime.name:$(java_prop java.runtime.name),runtime.vendor:$(java_prop java.vendor),runtime.version:$(java_prop java.version),\
 os.architecture:$(java_prop os.arch),os.platform:$(java_prop os.name),os.version:$(java_prop os.version)\
 "
+echo "${TAGS}"
 
 DD_TAGS="${TAGS}" datadog-ci junit upload --service $SERVICE_NAME ./results

--- a/.circleci/upload_ciapp.sh
+++ b/.circleci/upload_ciapp.sh
@@ -14,9 +14,12 @@ java_prop () {
 }
 
 # based on tracer implementation: https://github.com/DataDog/dd-trace-java/blob/master/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/TestDecorator.java#L55-L77
-TAGS="test.traits:{\"marker\":[\"$1\"]},\
-runtime.name:$(java_prop java.runtime.name),runtime.vendor:$(java_prop java.vendor),runtime.version:$(java_prop java.version),\
-os.architecture:$(java_prop os.arch),os.platform:$(java_prop os.name),os.version:$(java_prop os.version)\
-"
-
-DD_TAGS="${TAGS}" datadog-ci junit upload --service $SERVICE_NAME ./results
+datadog-ci junit upload --service $SERVICE_NAME \
+    --tags "test.traits:{\"marker\":[\"$1\"]}" \
+    --tags "runtime.name:$(java_prop java.runtime.name)" \
+    --tags "runtime.vendor:$(java_prop java.vendor)" \
+    --tags "runtime.version:$(java_prop java.version)" \
+    --tags "os.architecture:$(java_prop os.arch)" \
+    --tags "os.platform:$(java_prop os.name)" \
+    --tags "os.version:$(java_prop os.version)" \
+./results


### PR DESCRIPTION
The expanding of `JAVA_(JDK)_HOME` was not working properly and we were falling back always to `which java`.