### PR TITLE
Better Gitlab cache

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,7 +23,7 @@ variables:
     - export GRADLE_USER_HOME=`pwd`/.gradle
 
 cache:
-  key: '$CI_SERVER_VERSION' # Reset the cache every time gitlab is upgraded.  ~Every couple months
+  key: 'cache-$CI_SERVER_VERSION' # Reset the cache every time gitlab is upgraded.  ~Every couple months
   paths:
     - .gradle/wrapper
     - .gradle/caches

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,13 +21,12 @@ variables:
   image: datadog/dd-trace-java-docker-build:latest
   before_script:
     - export GRADLE_USER_HOME=`pwd`/.gradle
-
-cache:
-  key: 'cache-$CI_SERVER_VERSION' # Reset the cache every time gitlab is upgraded.  ~Every couple months
-  paths:
-    - .gradle/wrapper
-    - .gradle/caches
-  policy: pull
+  cache:
+    key: '$CI_SERVER_VERSION' # Reset the cache every time gitlab is upgraded.  ~Every couple months
+    paths:
+      - .gradle/wrapper
+      - .gradle/caches
+    policy: pull
 
 build: &build
   <<: *gradle_build
@@ -42,19 +41,12 @@ build: &build
 
 build_with_cache:
   <<: *build
-  rules:
-    - if: '$POPULATE_CACHE'
-      when: on_success
-    - when: manual
   cache:
     policy: push
 
 deploy_to_reliability_env:
   stage: deploy
-  rules:
-    - if: '$POPULATE_CACHE'
-      when: never
-    - when: on_success
+  when: on_success
   trigger:
     project: DataDog/datadog-reliability-env
     branch: $DOWNSTREAM_BRANCH

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,13 +21,15 @@ variables:
   image: datadog/dd-trace-java-docker-build:latest
   before_script:
     - export GRADLE_USER_HOME=`pwd`/.gradle
-  cache:
-    key: '$CI_COMMIT_REF_SLUG' # Cache per branch
-    paths:
-      - .gradle/wrapper
-      - .gradle/caches
 
-build:
+cache:
+  key: '$CI_SERVER_VERSION' # Reset the cache every time gitlab is upgraded.  ~Every couple months
+  paths:
+    - .gradle/wrapper
+    - .gradle/caches
+  policy: pull
+
+build: &build
   <<: *gradle_build
   stage: build
   script:
@@ -38,9 +40,21 @@ build:
       - 'workspace/dd-java-agent/build/libs/*.jar'
       - 'upstream.env'
 
+build_with_cache:
+  <<: *build
+  rules:
+    - if: '$POPULATE_CACHE'
+      when: on_success
+    - when: manual
+  cache:
+    policy: push
+
 deploy_to_reliability_env:
   stage: deploy
-  when: on_success
+  rules:
+    - if: '$POPULATE_CACHE'
+      when: never
+    - when: on_success
   trigger:
     project: DataDog/datadog-reliability-env
     branch: $DOWNSTREAM_BRANCH

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -46,6 +46,7 @@ build_with_cache:
     - if: '$POPULATE_CACHE'
       when: on_success
     - when: manual
+      allow_failure: true
   cache:
     <<: *default_cache
     policy: push

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,17 +16,18 @@ variables:
 .common: &common
   tags: [ "runner:main", "size:large" ]
 
+cache: &default_cache
+  key: '$CI_SERVER_VERSION' # Reset the cache every time gitlab is upgraded.  ~Every couple months
+  paths:
+    - .gradle/wrapper
+    - .gradle/caches
+  policy: pull
+
 .gradle_build: &gradle_build
   <<: *common
   image: datadog/dd-trace-java-docker-build:latest
   before_script:
     - export GRADLE_USER_HOME=`pwd`/.gradle
-  cache:
-    key: '$CI_SERVER_VERSION' # Reset the cache every time gitlab is upgraded.  ~Every couple months
-    paths:
-      - .gradle/wrapper
-      - .gradle/caches
-    policy: pull
 
 build: &build
   <<: *gradle_build
@@ -41,12 +42,20 @@ build: &build
 
 build_with_cache:
   <<: *build
+  rules:
+    - if: '$POPULATE_CACHE'
+      when: on_success
+    - when: manual
   cache:
+    <<: *default_cache
     policy: push
 
 deploy_to_reliability_env:
   stage: deploy
-  when: on_success
+  rules:
+    - if: '$POPULATE_CACHE'
+      when: never
+    - when: on_success
   trigger:
     project: DataDog/datadog-reliability-env
     branch: $DOWNSTREAM_BRANCH

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,6 +32,10 @@ cache: &default_cache
 build: &build
   <<: *gradle_build
   stage: build
+  rules:
+    - if: '$POPULATE_CACHE'
+      when: never
+    - when: on_success
   script:
     - GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx1G -Xms64M' -Ddatadog.forkedMaxHeapSize=1G -Ddatadog.forkedMinHeapSize=64M" ./gradlew clean :dd-java-agent:shadowJar --build-cache --parallel --stacktrace --no-daemon --max-workers=8
     - echo UPSTREAM_TRACER_VERSION=$(java -jar workspace/dd-java-agent/build/libs/*.jar) >> upstream.env


### PR DESCRIPTION
Previously, the gitlab cache would continue grow and slow down the build. This PR fixes that in the following ways:

- Single cache based on master build.  Some inefficiencies on branches, but almost all of the cache is applicable to all branches
- Most jobs **_only pull_** from the cache
- A single job (`build_with_cache`) that pushes to the cache

That single job can be run on a schedule.

This PR takes build time in gitlab from 8-10 minutes to 2-3 minutes.