### PR TITLE
Upgrade to JMXFetch 0.44.1 and DogStatsD 2.13.0

### DIFF
--- a/dd-java-agent/agent-jmxfetch/agent-jmxfetch.gradle
+++ b/dd-java-agent/agent-jmxfetch/agent-jmxfetch.gradle
@@ -4,7 +4,7 @@ plugins {
 apply from: "$rootDir/gradle/java.gradle"
 
 dependencies {
-  api('com.datadoghq:jmxfetch:0.43.1') {
+  api('com.datadoghq:jmxfetch:0.44.1') {
     exclude group: 'org.apache.logging.log4j', module: 'log4j-slf4j-impl'
     exclude group: 'org.apache.logging.log4j', module: 'log4j-core'
     exclude group: 'org.slf4j', module: 'slf4j-api'

--- a/dd-trace-core/dd-trace-core.gradle
+++ b/dd-trace-core/dd-trace-core.gradle
@@ -13,11 +13,9 @@ excludedClassesCoverage += [
   'datadog.trace.common.writer.ListWriter',
   'datadog.trace.common.writer.DDAgentWriter.DDAgentWriterBuilder',
   'datadog.trace.common.sampling.PrioritySampling',
-  // This code is copied from okHttp samples and we have integration tests to verify that it works.
-  'datadog.trace.common.writer.ddagent.unixdomainsockets.TunnelingUnixSocket',
-  'datadog.trace.common.writer.ddagent.unixdomainsockets.UnixDomainSocketFactory',
   'datadog.trace.core.scopemanager.ScopeInterceptor.DelegatingScope',
   'datadog.trace.core.jfr.DDNoopScopeEventFactory',
+  'datadog.trace.core.monitor.DDAgentStatsDConnection',
   'datadog.trace.core.monitor.LoggingStatsDClient',
   'datadog.trace.core.PendingTraceBuffer.DelayingPendingTraceBuffer.FlushElement',
   'datadog.trace.core.StatusLogger',

--- a/dd-trace-core/src/main/java/datadog/trace/core/monitor/DDAgentStatsDConnection.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/monitor/DDAgentStatsDConnection.java
@@ -105,9 +105,9 @@ final class DDAgentStatsDConnection implements StatsDClientErrorHandler {
                 .port(port)
                 .errorHandler(this)
                 .entityID(entityID);
-        // when using UDS set the datagram size to 8k
+        // when using UDS set the datagram size to 8k (2k on Mac due to lower OS default)
         if (this.port == 0) {
-          clientBuilder.maxPacketSizeBytes(8192);
+          clientBuilder.maxPacketSizeBytes(Platform.isMac() ? 2048 : 8192);
         }
         try {
           statsd = clientBuilder.build();

--- a/dd-trace-core/src/main/java/datadog/trace/core/monitor/DDAgentStatsDConnection.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/monitor/DDAgentStatsDConnection.java
@@ -1,16 +1,18 @@
 package datadog.trace.core.monitor;
 
 import static datadog.trace.api.ConfigDefaults.DEFAULT_DOGSTATSD_SOCKET_PATH;
+import static datadog.trace.util.AgentThreadFactory.AgentThread.STATSD_CLIENT;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 import com.timgroup.statsd.NoOpStatsDClient;
-import com.timgroup.statsd.NonBlockingStatsDClient;
+import com.timgroup.statsd.NonBlockingStatsDClientBuilder;
 import com.timgroup.statsd.StatsDClientErrorHandler;
 import datadog.trace.api.Config;
 import datadog.trace.api.IOLogger;
 import datadog.trace.api.Platform;
 import datadog.trace.util.AgentTaskScheduler;
+import datadog.trace.util.AgentThreadFactory;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.File;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -24,6 +26,9 @@ final class DDAgentStatsDConnection implements StatsDClientErrorHandler {
   private static final com.timgroup.statsd.StatsDClient NO_OP = new NoOpStatsDClient();
 
   private static final String UNIX_DOMAIN_SOCKET_PREFIX = "unix://";
+
+  private static final AgentThreadFactory STATSD_CLIENT_THREAD_FACTORY =
+      new AgentThreadFactory(STATSD_CLIENT);
 
   private boolean usingDefaultPort;
   private volatile String host;
@@ -92,10 +97,20 @@ final class DDAgentStatsDConnection implements StatsDClientErrorHandler {
         // when using UDS, set "entity-id" to "none" to avoid having the DogStatsD
         // server add origin tags (see https://github.com/DataDog/jmxfetch/pull/264)
         String entityID = port == 0 ? "none" : null;
+        NonBlockingStatsDClientBuilder clientBuilder =
+            new NonBlockingStatsDClientBuilder()
+                .threadFactory(STATSD_CLIENT_THREAD_FACTORY)
+                .enableTelemetry(false)
+                .hostname(host)
+                .port(port)
+                .errorHandler(this)
+                .entityID(entityID);
+        // when using UDS set the datagram size to 8k
+        if (this.port == 0) {
+          clientBuilder.maxPacketSizeBytes(8192);
+        }
         try {
-          statsd =
-              new NonBlockingStatsDClient(
-                  null, host, port, Integer.MAX_VALUE, null, this, entityID);
+          statsd = clientBuilder.build();
         } catch (final Exception e) {
           log.error("Unable to create StatsD client - {}", statsDAddress(host, port), e);
         }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/monitor/DDAgentStatsDClientTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/monitor/DDAgentStatsDClientTest.groovy
@@ -164,7 +164,7 @@ class DDAgentStatsDClientTest extends DDSpecification {
         yield()
       }
       try {
-        return lastMessage
+        return lastMessage.trim()
       } finally {
         lastMessage = null
       }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -21,7 +21,7 @@ final class CachedData {
     scala213      : "2.13.4",
     kotlin        : "1.3.72",
     coroutines    : "1.3.0",
-    dogstatsd     : "2.9.0",
+    dogstatsd     : "2.13.0",
     jnr_unixsocket: "0.28",
     commons       : "3.2",
     mockito       : '3.5.10',

--- a/internal-api/src/main/java/datadog/trace/api/Platform.java
+++ b/internal-api/src/main/java/datadog/trace/api/Platform.java
@@ -103,4 +103,9 @@ public final class Platform {
     final String os = System.getProperty("os.name").toLowerCase();
     return os.contains("win");
   }
+
+  public static boolean isMac() {
+    final String os = System.getProperty("os.name").toLowerCase();
+    return os.contains("mac");
+  }
 }

--- a/internal-api/src/main/java/datadog/trace/util/AgentThreadFactory.java
+++ b/internal-api/src/main/java/datadog/trace/util/AgentThreadFactory.java
@@ -19,6 +19,7 @@ public final class AgentThreadFactory implements ThreadFactory {
     TRACE_CASSANDRA_ASYNC_SESSION("dd-cassandra-session-executor"),
 
     METRICS_AGGREGATOR("dd-metrics-aggregator"),
+    STATSD_CLIENT("dd-statsd-client"),
 
     JMX_STARTUP("dd-agent-startup-jmxfetch"),
     JMX_COLLECTOR("dd-jmx-collector"),


### PR DESCRIPTION
... and switch to use the new client builder for DogStatsD

For reference, here's a similar change in JMXFetch when they upgraded their DogStatsD dependency:

https://github.com/DataDog/jmxfetch/commit/20d5e6297e476c3f64cb78bfb3de45e4f7057a71#diff-e65e4230f75557bac2c582a0c18a5a6c0327e6fc7c7dea6ed10f5ffb14c20298L44

one thing to note: this reduces the StatsD processing queue limit from `Integer.MAX_VALUE` to the new default of `4096` (the StatsD client will start to drop messages if the processing queue limit is ever reached.)  We can restore the original limit if we wish, or we can use the smaller limit like JMXFetch.