### PR TITLE
Fix encoding of boolean tags causing payloads to be dropped

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/TraceMapperV0_4.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/TraceMapperV0_4.java
@@ -109,7 +109,7 @@ public final class TraceMapperV0_4 implements TraceMapper {
       for (Map.Entry<String, Object> entry : metadata.getTags().entrySet()) {
         if (!(entry.getValue() instanceof Number)) {
           writable.writeString(entry.getKey(), null);
-          writable.writeObject(entry.getValue(), null);
+          writable.writeObjectString(entry.getValue(), null);
         }
       }
     }

--- a/dd-trace-core/src/main/java/datadog/trace/core/serialization/Writable.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/serialization/Writable.java
@@ -11,6 +11,8 @@ public interface Writable {
 
   void writeObject(Object value, EncodingCache encodingCache);
 
+  void writeObjectString(Object value, EncodingCache encodingCache);
+
   void writeMap(Map<? extends CharSequence, ?> map, EncodingCache encodingCache);
 
   void writeString(CharSequence s, EncodingCache encodingCache);

--- a/dd-trace-core/src/main/java/datadog/trace/core/serialization/msgpack/MsgPackWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/serialization/msgpack/MsgPackWriter.java
@@ -133,6 +133,28 @@ public class MsgPackWriter implements WritableFormatter {
   }
 
   @Override
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  public void writeObjectString(Object value, EncodingCache encodingCache) {
+    // unpeel a very common case, but should try to move away from sending
+    // UTF8BytesString down this codepath at all
+    if (value instanceof UTF8BytesString) {
+      writeUTF8((UTF8BytesString) value);
+    } else if (null == value) {
+      writeNull();
+    } else {
+      String s = String.valueOf(value);
+      if (null != encodingCache) {
+        byte[] utf8 = encodingCache.encode(s);
+        if (null != utf8) {
+          writeUTF8(utf8);
+          return;
+        }
+      }
+      writeUTF8(s.getBytes(UTF_8));
+    }
+  }
+
+  @Override
   public void writeNull() {
     buffer.put(NULL);
   }

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddagent/TraceGenerator.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddagent/TraceGenerator.groovy
@@ -47,6 +47,7 @@ class TraceGenerator {
     for (int i = 0; i < tagCount; ++i) {
       tags.put("tag." + i, ThreadLocalRandom.current().nextBoolean() ? "foo" : randomString(2000))
       tags.put("tag.1." + i, lowCardinality ? "y" : UUID.randomUUID())
+      tags.put("tag.2." + i, ThreadLocalRandom.current().nextBoolean())
     }
     int metricCount = ThreadLocalRandom.current().nextInt(0, 20)
     for (int i = 0; i < metricCount; ++i) {
@@ -134,7 +135,7 @@ class TraceGenerator {
       this.metadata = new Metadata(Thread.currentThread().getId(),
         UTF8BytesString.create(Thread.currentThread().getName()), tags, baggage, UNSET, measured, topLevel,
         statusCode == 0 ? null : UTF8BytesString.create(Integer.toString(statusCode)))
-      this.httpStatusCode = (short)statusCode
+      this.httpStatusCode = (short) statusCode
     }
 
     @Override


### PR DESCRIPTION
Introduced in #2729 with the payload encoding changes.  This ensures that values encoded in the `meta` section are encoded as strings as expected by the agent.