### PR TITLE
Make couchbase async test not strict and remove retry

### DIFF
--- a/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/CouchbaseAsyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/CouchbaseAsyncClientTest.groovy
@@ -4,7 +4,6 @@ import com.couchbase.client.java.document.JsonDocument
 import com.couchbase.client.java.document.json.JsonObject
 import com.couchbase.client.java.env.CouchbaseEnvironment
 import com.couchbase.client.java.query.N1qlQuery
-import spock.lang.Retry
 import spock.lang.Unroll
 import spock.util.concurrent.BlockingVariable
 import util.AbstractCouchbaseTest
@@ -12,10 +11,15 @@ import util.AbstractCouchbaseTest
 import static datadog.trace.agent.test.utils.TraceUtils.basicSpan
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 
-@Retry
 @Unroll
 class CouchbaseAsyncClientTest extends AbstractCouchbaseTest {
   static final int TIMEOUT = 30
+
+  @Override
+  boolean useStrictTraceWrites() {
+    // Async spans often finish out of order, so allow buffering.
+    return false
+  }
 
   def "test hasBucket #type"() {
     setup:


### PR DESCRIPTION
Retry was causing cleanup to fail because it can't be shutdown called multiple times with the same instance.

Strict is needed because we can't guarantee root span is finished last.