### PR TITLE
Log PendingTrace state after span finish

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -401,7 +401,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
     }
 
     this.pendingTraceBuffer =
-        strictTraceWrites ? PendingTraceBuffer.mute() : PendingTraceBuffer.delaying();
+        strictTraceWrites ? PendingTraceBuffer.discarding() : PendingTraceBuffer.delaying();
     pendingTraceFactory = new PendingTrace.Factory(this, pendingTraceBuffer, strictTraceWrites);
     pendingTraceBuffer.start();
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -87,8 +87,8 @@ public class DDSpan implements AgentSpan, CoreSpan<DDSpan> {
   private void finishAndAddToTrace(final long durationNano) {
     // ensure a min duration of 1
     if (this.durationNano.compareAndSet(0, Math.max(1, durationNano))) {
-      log.debug("Finished span: {}", this);
-      context.getTrace().addFinishedSpan(this);
+      PendingTrace.FinishState finishState = context.getTrace().addFinishedSpan(this);
+      log.debug("Finished span ({}): {}", finishState, this);
     } else {
       log.debug("Already finished: {}", this);
     }
@@ -274,6 +274,7 @@ public class DDSpan implements AgentSpan, CoreSpan<DDSpan> {
   }
 
   // FIXME [API] this is not on AgentSpan or MutableSpan
+  @Override
   public DDSpan removeTag(final String tag) {
     context.setTag(tag, null);
     return this;

--- a/dd-trace-core/src/main/java/datadog/trace/core/PendingTrace.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/PendingTrace.java
@@ -155,6 +155,7 @@ public class PendingTrace implements AgentTrace, PendingTraceBuffer.Element {
     return decrementRefAndMaybeWrite(span == getRootSpan());
   }
 
+  @Override
   public DDSpan getRootSpan() {
     return rootSpan;
   }
@@ -186,6 +187,7 @@ public class PendingTrace implements AgentTrace, PendingTraceBuffer.Element {
   enum FinishState {
     WRITTEN,
     PARTIAL_FLUSH,
+    ROOT_BUFFERED,
     BUFFERED,
     PENDING
   }
@@ -204,7 +206,7 @@ public class PendingTrace implements AgentTrace, PendingTraceBuffer.Element {
     } else if (isRootSpan) {
       // Finished root with pending work ... delay write
       pendingTraceBuffer.enqueue(this);
-      return FinishState.BUFFERED;
+      return FinishState.ROOT_BUFFERED;
     } else if (0 < partialFlushMinSpans && partialFlushMinSpans < size()) {
       // Trace is getting too big, write anything completed.
       partialFlush();

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceBufferTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceBufferTest.groovy
@@ -271,6 +271,11 @@ class PendingTraceBufferTest extends DDSpecification {
         void write() {
           counter.incrementAndGet()
         }
+
+        @Override
+        DDSpan getRootSpan() {
+          return null
+        }
       }
 
     when:


### PR DESCRIPTION
When troubleshooting async tracing behavior, it is helpful to understand the state of the pending trace.  Added that extra bit of info to the span finished log message rather than create a new log.

I also added a debug message to report that a trace is being discarded when using `strictTraceWrites`.