### PR TITLE
Don't try and load java.lang.ProcessHandle on Java 8

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-uploader/src/main/java/com/datadog/profiling/uploader/util/PidHelper.java
+++ b/dd-java-agent/agent-profiling/profiling-uploader/src/main/java/com/datadog/profiling/uploader/util/PidHelper.java
@@ -1,5 +1,6 @@
 package com.datadog.profiling.uploader.util;
 
+import datadog.trace.api.Platform;
 import de.thetaphi.forbiddenapis.SuppressForbidden;
 import jnr.posix.POSIX;
 import jnr.posix.POSIXFactory;
@@ -20,12 +21,14 @@ public class PidHelper {
   public static final Long PID = getPid();
 
   private static Long getPid() {
-    try {
-      final Class<?> processHandler = Class.forName("java.lang.ProcessHandle");
-      final Object object = processHandler.getMethod("current").invoke(null);
-      return (Long) processHandler.getMethod("pid").invoke(object);
-    } catch (final Exception e) {
-      log.debug("Cannot get PID through JVM API, trying POSIX instead", e);
+    if (Platform.isJavaVersionAtLeast(9)) {
+      try {
+        final Class<?> processHandler = Class.forName("java.lang.ProcessHandle");
+        final Object object = processHandler.getMethod("current").invoke(null);
+        return (Long) processHandler.getMethod("pid").invoke(object);
+      } catch (final Exception e) {
+        log.debug("Cannot get PID through JVM API, trying POSIX instead", e);
+      }
     }
 
     try {


### PR DESCRIPTION
avoids leaving a lengthy exception stack in the logs when we know this class won't be available