### PR TITLE
Run instrument task before tests as well

### DIFF
--- a/buildSrc/src/main/groovy/InstrumentPlugin.groovy
+++ b/buildSrc/src/main/groovy/InstrumentPlugin.groovy
@@ -10,6 +10,7 @@ import org.gradle.api.Project
 import org.gradle.api.file.Directory
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.tasks.compile.AbstractCompile
+import org.gradle.api.tasks.testing.Test
 
 class InstrumentPlugin implements Plugin<Project> {
 
@@ -58,9 +59,12 @@ class InstrumentPlugin implements Plugin<Project> {
             it.argument({ it.value = extension.plugins.get() })
           }
 
-          // insert task between compile and jar
+          // insert task between compile and jar, and before test*
           byteBuddyTask.dependsOn(compileTask)
           project.tasks.findByName('jar')?.dependsOn(byteBuddyTask)
+          project.tasks.withType(Test).configureEach {
+            dependsOn(byteBuddyTask)
+          }
         }
       }
     }


### PR DESCRIPTION
After way too much time wondering about what I had broken, and cleaning/compiling/jaring I finally came up with this. Not sure it's completely right but it fixes my issues.

Without this change, running something like
```
./gradlew :dd-java-agent:instrumentation:jetty-9:clean
./gradlew :dd-java-agent:instrumentation:jetty-9:test -Prerun.tests.jetty-9
```
would result in instrumentations not being applied, and the test failing in mysterious ways.