### PR TITLE
Rework how JFR events are disabled based on JVM version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@ examples/**/build/
 .classpath
 # Eclipse is odd in assuming in can use bin to put temp files into it
 # This assumes we do not have sub-projects that actually need bin files committed
-*/bin/
+bin/
 
 # OS generated files #
 ######################

--- a/dd-java-agent/agent-profiling/profiling-controller-jfr/src/main/java/com/datadog/profiling/controller/jfr/JfpUtils.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-jfr/src/main/java/com/datadog/profiling/controller/jfr/JfpUtils.java
@@ -56,30 +56,33 @@ public final class JfpUtils {
     return JfpUtils.class.getClassLoader().getResourceAsStream(name);
   }
 
-  public static Map<String, String> readNamedJfpResource(
-      final String name, String overridesFileName) throws IOException {
-    final Map<String, String> result = new HashMap<>();
-
-    try (final InputStream stream = getNamedResource(name)) {
-      result.putAll(readJfpFile(stream));
-    }
-
-    if (overridesFileName != null) {
-      if (!overridesFileName.toLowerCase().endsWith(JFP_EXTENSION)) {
-        overridesFileName = overridesFileName + JFP_EXTENSION;
-      }
-      final File override = new File(overridesFileName);
-      try (final InputStream overrideStream =
-          override.exists()
-              ? new FileInputStream(override)
-              : getNamedResource(OVERRIDES_PATH + overridesFileName)) {
-        if (overrideStream != null) {
-          result.putAll(readJfpFile(overrideStream));
-        } else {
-          throw new IOException("Invalid override file " + overridesFileName);
-        }
-      }
-    }
+  public static Map<String, String> readJfpResources(final String name, String overridesFileName)
+      throws IOException {
+    Map<String, String> result = readNamedJfpResource(name);
+    result.putAll(readOverrideJfpResource(overridesFileName));
     return result;
+  }
+
+  public static Map<String, String> readNamedJfpResource(final String name) throws IOException {
+    try (final InputStream stream = getNamedResource(name)) {
+      return readJfpFile(stream);
+    }
+  }
+
+  public static Map<String, String> readOverrideJfpResource(String name) throws IOException {
+    if (name != null) {
+      if (!name.toLowerCase().endsWith(JFP_EXTENSION)) {
+        name = name + JFP_EXTENSION;
+      }
+      final File file = new File(name);
+      try (final InputStream stream =
+          file.exists() ? new FileInputStream(file) : getNamedResource(OVERRIDES_PATH + name)) {
+        if (stream == null) {
+          throw new IOException("Invalid override file " + name);
+        }
+        return readJfpFile(stream);
+      }
+    }
+    return new HashMap<>();
   }
 }

--- a/dd-java-agent/agent-profiling/profiling-controller-jfr/src/test/java/com/datadog/profiling/controller/jfr/JfpUtilsTest.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-jfr/src/test/java/com/datadog/profiling/controller/jfr/JfpUtilsTest.java
@@ -18,27 +18,29 @@ public class JfpUtilsTest {
       JfpUtilsTest.class.getClassLoader().getResource("overrides.jfp").getFile();
   public static final String OVERRIDES_OLD_OBJECT_SAMPLE =
       JfpUtilsTest.class.getClassLoader().getResource("overrides-oldobjectsample.jfp").getFile();
+  public static final String OVERRIDES_OBJECT_ALLOCATION =
+      JfpUtilsTest.class.getClassLoader().getResource("overrides-objectallocation.jfp").getFile();
+  public static final String OVERRIDES_NATIVE_METHOD_SAMPLE =
+      JfpUtilsTest.class.getClassLoader().getResource("overrides-nativemethodsample.jfp").getFile();
 
   @Test
   public void testLoadingInvalidOverride() throws IOException {
     final String INVALID_OVERRIDE = "really_non_existent_file.jfp";
 
     assertThrows(
-        IOException.class,
-        () -> JfpUtils.readNamedJfpResource(JfpUtils.DEFAULT_JFP, INVALID_OVERRIDE));
+        IOException.class, () -> JfpUtils.readJfpResources(JfpUtils.DEFAULT_JFP, INVALID_OVERRIDE));
   }
 
   @Test
   public void testLoadingContinuousConfig() throws IOException {
-    final Map<String, String> config = JfpUtils.readNamedJfpResource(JfpUtils.DEFAULT_JFP, null);
+    final Map<String, String> config = JfpUtils.readJfpResources(JfpUtils.DEFAULT_JFP, null);
     assertEquals("true", config.get(CONFIG_ENTRY));
     assertNull(config.get(CONFIG_OVERRIDE_ENTRY));
   }
 
   @Test
   public void testLoadingContinuousConfigWithOverride() throws IOException {
-    final Map<String, String> config =
-        JfpUtils.readNamedJfpResource(JfpUtils.DEFAULT_JFP, OVERRIDES);
+    final Map<String, String> config = JfpUtils.readJfpResources(JfpUtils.DEFAULT_JFP, OVERRIDES);
     assertEquals("true", config.get(CONFIG_ENTRY));
     assertEquals("200", config.get(CONFIG_OVERRIDE_ENTRY));
   }
@@ -46,7 +48,7 @@ public class JfpUtilsTest {
   @ParameterizedTest
   @ValueSource(strings = {"minimal", "minimal.jfp"})
   public void testLoadingConfigMinimal(String override) throws IOException {
-    Map<String, String> config = JfpUtils.readNamedJfpResource(JfpUtils.DEFAULT_JFP, override);
+    Map<String, String> config = JfpUtils.readJfpResources(JfpUtils.DEFAULT_JFP, override);
     assertEquals("500 ms", config.get("jdk.ThreadSleep#threshold"));
     assertEquals("false", config.get("jdk.OldObjectSample#enabled"));
     assertEquals("false", config.get("jdk.ObjectAllocationInNewTLAB#enabled"));
@@ -55,7 +57,7 @@ public class JfpUtilsTest {
   @ParameterizedTest
   @ValueSource(strings = {"comprehensive", "comprehensive.jfp"})
   public void testLoadingConfigComprehensive(String override) throws IOException {
-    Map<String, String> config = JfpUtils.readNamedJfpResource(JfpUtils.DEFAULT_JFP, override);
+    Map<String, String> config = JfpUtils.readJfpResources(JfpUtils.DEFAULT_JFP, override);
     assertEquals("10 ms", config.get("jdk.ThreadSleep#threshold"));
     assertEquals("true", config.get("jdk.OldObjectSample#enabled"));
     assertEquals("true", config.get("jdk.ObjectAllocationInNewTLAB#enabled"));

--- a/dd-java-agent/agent-profiling/profiling-controller-jfr/src/test/resources/overrides-nativemethodsample.jfp
+++ b/dd-java-agent/agent-profiling/profiling-controller-jfr/src/test/resources/overrides-nativemethodsample.jfp
@@ -1,0 +1,1 @@
+jdk.NativeMethodSample#enabled=true

--- a/dd-java-agent/agent-profiling/profiling-controller-jfr/src/test/resources/overrides-objectallocation.jfp
+++ b/dd-java-agent/agent-profiling/profiling-controller-jfr/src/test/resources/overrides-objectallocation.jfp
@@ -1,0 +1,2 @@
+jdk.ObjectAllocationInNewTLAB#enabled=true
+jdk.ObjectAllocationOutsideTLAB#enabled=true

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/test/java/com/datadog/profiling/controller/openjdk/OpenJdkControllerTest.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/test/java/com/datadog/profiling/controller/openjdk/OpenJdkControllerTest.java
@@ -5,7 +5,6 @@ import static datadog.trace.api.Platform.isJavaVersionAtLeast;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
 
-import com.datadog.profiling.controller.jfr.JfpUtils;
 import com.datadog.profiling.controller.jfr.JfpUtilsTest;
 import datadog.trace.api.Config;
 import jdk.jfr.Recording;
@@ -27,9 +26,6 @@ public class OpenJdkControllerTest {
     OpenJdkController controller = new OpenJdkController(config);
     try (final Recording recording = controller.createRecording(TEST_NAME).stop().getRecording()) {
       assertEquals(TEST_NAME, recording.getName());
-      assertEquals(
-          JfpUtils.readNamedJfpResource(JfpUtils.DEFAULT_JFP, JfpUtilsTest.OVERRIDES),
-          recording.getSettings());
       assertEquals(OpenJdkController.RECORDING_MAX_SIZE, recording.getMaxSize());
       assertEquals(OpenJdkController.RECORDING_MAX_AGE, recording.getMaxAge());
     }
@@ -37,8 +33,6 @@ public class OpenJdkControllerTest {
 
   @Test
   public void testOldObjectSampleIsDisabledOnUnsupportedVersion() throws Exception {
-    when(config.getProfilingTemplateOverrideFile())
-        .thenReturn(JfpUtilsTest.OVERRIDES_OLD_OBJECT_SAMPLE);
     OpenJdkController controller = new OpenJdkController(config);
     try (final Recording recording = controller.createRecording(TEST_NAME).stop().getRecording()) {
       if (!((isJavaVersion(11) && isJavaVersionAtLeast(11, 0, 12))
@@ -48,6 +42,84 @@ public class OpenJdkControllerTest {
         assertEquals(
             Boolean.parseBoolean(recording.getSettings().get("jdk.OldObjectSample#enabled")),
             false);
+      }
+    }
+  }
+
+  @Test
+  public void testOldObjectSampleIsStillOverriddenOnUnsupportedVersion() throws Exception {
+    when(config.getProfilingTemplateOverrideFile())
+        .thenReturn(JfpUtilsTest.OVERRIDES_OLD_OBJECT_SAMPLE);
+    OpenJdkController controller = new OpenJdkController(config);
+    try (final Recording recording = controller.createRecording(TEST_NAME).stop().getRecording()) {
+      if (!((isJavaVersion(11) && isJavaVersionAtLeast(11, 0, 12))
+          || (isJavaVersion(15) && isJavaVersionAtLeast(15, 0, 4))
+          || (isJavaVersion(16) && isJavaVersionAtLeast(16, 0, 2))
+          || isJavaVersionAtLeast(17))) {
+        assertEquals(
+            Boolean.parseBoolean(recording.getSettings().get("jdk.OldObjectSample#enabled")), true);
+      }
+    }
+  }
+
+  @Test
+  public void testObjectAllocationIsDisabledOnUnsupportedVersion() throws Exception {
+    OpenJdkController controller = new OpenJdkController(config);
+    try (final Recording recording = controller.createRecording(TEST_NAME).stop().getRecording()) {
+      if (!(isJavaVersionAtLeast(16))) {
+        assertEquals(
+            Boolean.parseBoolean(
+                recording.getSettings().get("jdk.ObjectAllocationInNewTLAB#enabled")),
+            false);
+        assertEquals(
+            Boolean.parseBoolean(
+                recording.getSettings().get("jdk.ObjectAllocationOutsideTLAB#enabled")),
+            false);
+      }
+    }
+  }
+
+  @Test
+  public void testObjectAllocationIsStillOverriddenOnUnsupportedVersion() throws Exception {
+    when(config.getProfilingTemplateOverrideFile())
+        .thenReturn(JfpUtilsTest.OVERRIDES_OBJECT_ALLOCATION);
+    OpenJdkController controller = new OpenJdkController(config);
+    try (final Recording recording = controller.createRecording(TEST_NAME).stop().getRecording()) {
+      if (!(isJavaVersionAtLeast(16))) {
+        assertEquals(
+            Boolean.parseBoolean(
+                recording.getSettings().get("jdk.ObjectAllocationInNewTLAB#enabled")),
+            true);
+        assertEquals(
+            Boolean.parseBoolean(
+                recording.getSettings().get("jdk.ObjectAllocationOutsideTLAB#enabled")),
+            true);
+      }
+    }
+  }
+
+  @Test
+  public void testNativeMethodSampleIsDisabledOnUnsupportedVersion() throws Exception {
+    OpenJdkController controller = new OpenJdkController(config);
+    try (final Recording recording = controller.createRecording(TEST_NAME).stop().getRecording()) {
+      if (!((isJavaVersion(8) && isJavaVersionAtLeast(8, 0, 302)) || isJavaVersionAtLeast(11))) {
+        assertEquals(
+            Boolean.parseBoolean(recording.getSettings().get("jdk.NativeMethodSample#enabled")),
+            false);
+      }
+    }
+  }
+
+  @Test
+  public void testNativeMethodSampleIsStillOverriddenOnUnsupportedVersion() throws Exception {
+    when(config.getProfilingTemplateOverrideFile())
+        .thenReturn(JfpUtilsTest.OVERRIDES_NATIVE_METHOD_SAMPLE);
+    OpenJdkController controller = new OpenJdkController(config);
+    try (final Recording recording = controller.createRecording(TEST_NAME).stop().getRecording()) {
+      if (!((isJavaVersion(8) && isJavaVersionAtLeast(8, 0, 302)) || isJavaVersionAtLeast(11))) {
+        assertEquals(
+            Boolean.parseBoolean(recording.getSettings().get("jdk.NativeMethodSample#enabled")),
+            true);
       }
     }
   }

--- a/dd-java-agent/agent-profiling/profiling-controller-oracle/src/main/java/com/datadog/profiling/controller/oracle/OracleJdkController.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-oracle/src/main/java/com/datadog/profiling/controller/oracle/OracleJdkController.java
@@ -35,7 +35,7 @@ public final class OracleJdkController implements Controller {
       helper = new JfrMBeanHelper();
       eventSettings =
           Collections.unmodifiableMap(
-              JfpUtils.readNamedJfpResource(
+              JfpUtils.readJfpResources(
                   JfpUtils.DEFAULT_JFP, config.getProfilingTemplateOverrideFile()));
     } catch (final IOException e) {
       throw new ConfigurationException(e);

--- a/dd-java-agent/agent-profiling/profiling-controller-oracle/src/test/java/com/datadog/profiling/controller/oracle/JfrMBeanHelperTest.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-oracle/src/test/java/com/datadog/profiling/controller/oracle/JfrMBeanHelperTest.java
@@ -22,7 +22,7 @@ class JfrMBeanHelperTest {
 
   @BeforeAll
   static void setupStatic() throws Exception {
-    eventSettings = JfpUtils.readNamedJfpResource(JfpUtils.DEFAULT_JFP, null);
+    eventSettings = JfpUtils.readJfpResources(JfpUtils.DEFAULT_JFP, null);
   }
 
   @BeforeEach


### PR DESCRIPTION
We want to disable events enabled by default in dd.jfp based on the
version. For example, OldObjectSample or NativeMethodSample have poor
performance on older versions. We don't want to penalize customers who
are on these older versions and just use the default profile.

However, we still want to allow users to override any settings they
want as they may have perfectly valid reasons to do so and to accept to
pay the cost for them.