### PR TITLE
Fix regression where HTTPS requests don't propagate trace if connect() is called first

### DIFF
--- a/dd-java-agent/instrumentation/http-url-connection/src/main/java/datadog/trace/instrumentation/http_url_connection/HttpUrlConnectionInstrumentation.java
+++ b/dd-java-agent/instrumentation/http-url-connection/src/main/java/datadog/trace/instrumentation/http_url_connection/HttpUrlConnectionInstrumentation.java
@@ -30,7 +30,9 @@ public class HttpUrlConnectionInstrumentation extends Instrumenter.Tracing {
   @Override
   public ElementMatcher<TypeDescription> typeMatcher() {
     return namedOneOf(
-        "sun.net.www.protocol.https.HttpsURLConnection",
+        // these classes define connect/stream methods that must be instrumented,
+        // we deliberately exclude various subclasses that are simple delegators
+        "sun.net.www.protocol.https.AbstractDelegateHttpsURLConnection",
         "sun.net.www.protocol.http.HttpURLConnection",
         "java.net.HttpURLConnection");
   }

--- a/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionConnectFirstTest.groovy
+++ b/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionConnectFirstTest.groovy
@@ -1,0 +1,41 @@
+import datadog.trace.agent.test.base.HttpClientTest
+import datadog.trace.bootstrap.instrumentation.httpurlconnection.HttpUrlConnectionDecorator
+import spock.lang.Timeout
+
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope
+
+@Timeout(5)
+class HttpUrlConnectionConnectFirstTest extends HttpClientTest {
+
+  @Override
+  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+    HttpURLConnection connection = uri.toURL().openConnection()
+    try {
+      connection.setRequestMethod(method)
+      headers.each { connection.setRequestProperty(it.key, it.value) }
+      connection.setRequestProperty("Connection", "close")
+      connection.connectTimeout = CONNECT_TIMEOUT_MS
+      connection.readTimeout = READ_TIMEOUT_MS
+      def parentSpan = activeScope()
+      connection.connect() // test connect before getting stream
+      def stream = connection.inputStream
+      assert activeScope() == parentSpan
+      stream.readLines()
+      stream.close()
+      callback?.call()
+      return connection.getResponseCode()
+    } finally {
+      connection.disconnect()
+    }
+  }
+
+  @Override
+  CharSequence component() {
+    return HttpUrlConnectionDecorator.DECORATE.component()
+  }
+
+  @Override
+  boolean testCircularRedirects() {
+    false
+  }
+}

--- a/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionConnectFirstTest.groovy
+++ b/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionConnectFirstTest.groovy
@@ -1,9 +1,12 @@
 import datadog.trace.agent.test.base.HttpClientTest
 import datadog.trace.bootstrap.instrumentation.httpurlconnection.HttpUrlConnectionDecorator
+import spock.lang.Requires
 import spock.lang.Timeout
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope
 
+// This fails on IBM JVM because it uses different HTTPS connection types
+@Requires({ !System.getProperty("java.vm.name").contains("IBM J9 VM") })
 @Timeout(5)
 class HttpUrlConnectionConnectFirstTest extends HttpClientTest {
 


### PR DESCRIPTION
#2614 greatly simplified the `HTTPUrlConnection` matchers by changing the subclass test to a simple list of types.

Unfortunately `sun.net.www.protocol.https.AbstractDelegateHttpsURLConnection` was missed out of that list - this type overrides the `connect()` method in such a way that in certain scenarios the original `connect()` method is not called, but the `connected` flag is still set. This means we then miss the chance to add our trace propagation headers.

This can be demonstrated by adding another aspect to the `HttpURLConnection` tests that  always calls `connect()` before calling `getInputStream`. The original `connect()` method is never called, it instead calls a protected method named `plainConnect` which does the work.
```
java.net.SocketTimeoutException: connect timed out
       	at java.net.PlainSocketImpl.socketConnect(Native Method)
       	at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:476)
       	at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:218)
       	at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:200)
       	at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:394)
       	at java.net.Socket.connect(Socket.java:606)
       	at sun.security.ssl.SSLSocketImpl.connect(SSLSocketImpl.java:287)
       	at sun.net.NetworkClient.doConnect(NetworkClient.java:175)
       	at sun.net.www.http.HttpClient.openServer(HttpClient.java:463)
       	at sun.net.www.http.HttpClient.openServer(HttpClient.java:558)
       	at sun.net.www.protocol.https.HttpsClient.<init>(HttpsClient.java:292)
       	at sun.net.www.protocol.https.HttpsClient.New(HttpsClient.java:395)
       	at sun.net.www.protocol.https.AbstractDelegateHttpsURLConnection.getNewHttpClient(AbstractDelegateHttpsURLConnection.java:191)
       	at sun.net.www.protocol.http.HttpURLConnection.plainConnect0(HttpURLConnection.java:1162)
       	at sun.net.www.protocol.http.HttpURLConnection.plainConnect(HttpURLConnection.java:1056)
       	at sun.net.www.protocol.https.AbstractDelegateHttpsURLConnection.connect(AbstractDelegateHttpsURLConnection.java:177)
       	at sun.net.www.protocol.https.HttpsURLConnectionImpl.connect(HttpsURLConnectionImpl.java:167)
       	at sun.net.www.protocol.https.HttpsURLConnectionImpl$connect$1.call(Unknown Source)
       	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:47)
       	at sun.net.www.protocol.http.HttpURLConnection$connect$1.call(Unknown Source)
       	at HttpUrlConnectionConnectFirstTest.doRequest(HttpUrlConnectionConnectFirstTest.groovy:20)
```

I also removed `sun.net.www.protocol.https.HttpsURLConnection` from the list because I could not find any mention of this class in any JDK library. If someone can point me to somewhere that references this class I can add it back.