### PR TITLE
Fix regression where HTTPS requests don't propagate trace if connect() is called first

### DIFF
--- a/dd-java-agent/instrumentation/http-url-connection/src/main/java/datadog/trace/instrumentation/http_url_connection/HttpUrlConnectionInstrumentation.java
+++ b/dd-java-agent/instrumentation/http-url-connection/src/main/java/datadog/trace/instrumentation/http_url_connection/HttpUrlConnectionInstrumentation.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.http_url_connection;
 
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
 import static datadog.trace.bootstrap.instrumentation.httpurlconnection.HeadersInjectAdapter.SETTER;
@@ -46,7 +47,7 @@ public class HttpUrlConnectionInstrumentation extends Instrumenter.Tracing {
         isMethod().and(isPublic()).and(namedOneOf("connect", "getOutputStream", "getInputStream")),
         HttpUrlConnectionInstrumentation.class.getName() + "$HttpUrlConnectionAdvice");
     transformation.applyAdvice(
-        isMethod().and(isProtected()).and(namedOneOf("plainConnect")),
+        isMethod().and(isProtected()).and(named("plainConnect")),
         HttpUrlConnectionInstrumentation.class.getName() + "$HttpUrlConnectionAdvice");
   }
 

--- a/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionConnectFirstTest.groovy
+++ b/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionConnectFirstTest.groovy
@@ -1,0 +1,41 @@
+import datadog.trace.agent.test.base.HttpClientTest
+import datadog.trace.bootstrap.instrumentation.httpurlconnection.HttpUrlConnectionDecorator
+import spock.lang.Timeout
+
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope
+
+@Timeout(5)
+class HttpUrlConnectionConnectFirstTest extends HttpClientTest {
+
+  @Override
+  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+    HttpURLConnection connection = uri.toURL().openConnection()
+    try {
+      connection.setRequestMethod(method)
+      headers.each { connection.setRequestProperty(it.key, it.value) }
+      connection.setRequestProperty("Connection", "close")
+      connection.connectTimeout = CONNECT_TIMEOUT_MS
+      connection.readTimeout = READ_TIMEOUT_MS
+      def parentSpan = activeScope()
+      connection.connect() // test connect before getting stream
+      def stream = connection.inputStream
+      assert activeScope() == parentSpan
+      stream.readLines()
+      stream.close()
+      callback?.call()
+      return connection.getResponseCode()
+    } finally {
+      connection.disconnect()
+    }
+  }
+
+  @Override
+  CharSequence component() {
+    return HttpUrlConnectionDecorator.DECORATE.component()
+  }
+
+  @Override
+  boolean testCircularRedirects() {
+    false
+  }
+}


### PR DESCRIPTION
Alternative fix for #2859 - this has the benefit of also working for IBM JDKs which we weren't instrumenting before.