### PR TITLE
emit checkpoints on Envelope construction and invocation

### DIFF
--- a/dd-java-agent/instrumentation/akka-concurrent/src/akka23Test/groovy/AkkaActorTest.groovy
+++ b/dd-java-agent/instrumentation/akka-concurrent/src/akka23Test/groovy/AkkaActorTest.groovy
@@ -99,24 +99,24 @@ class AkkaActorTest extends AgentTestRunner {
     TEST_WRITER.waitForTraces(1)
     then:
     (2 * n + 1) * TEST_CHECKPOINTER.checkpoint(_, _, SPAN)
-    n * threadMigrations * TEST_CHECKPOINTER.checkpoint(_, _, THREAD_MIGRATION)
-    n * threadMigrations * TEST_CHECKPOINTER.checkpoint(_, _, THREAD_MIGRATION | END)
-    n * invocations * TEST_CHECKPOINTER.checkpoint(_, _, CPU | END)
+    n * envelopes * TEST_CHECKPOINTER.checkpoint(_, _, THREAD_MIGRATION)
+    n * envelopes * TEST_CHECKPOINTER.checkpoint(_, _, THREAD_MIGRATION | END)
+    n * envelopes * TEST_CHECKPOINTER.checkpoint(_, _, CPU | END)
     (2 * n + 1) * TEST_CHECKPOINTER.checkpoint(_, _, SPAN | END)
 
     where:
-    name      | n   | threadMigrations     | invocations
-    "ask"     | 1   | 3                    | 3
-    "tell"    | 1   | 3                    | 3
-    "route"   | 1   | 4                    | 3
-    "forward" | 1   | 4                    | 4
-    "ask"     | 2   | 3                    | 3
-    "tell"    | 2   | 3                    | 3
-    "route"   | 2   | 4                    | 3
-    "forward" | 2   | 4                    | 4
-    "ask"     | 10  | 3                    | 3
-    "tell"    | 10  | 3                    | 3
-    "route"   | 10  | 4                    | 3
-    "forward" | 10  | 4                    | 4
+    name      | n   | envelopes
+    "ask"     | 1   | 3
+    "tell"    | 1   | 3
+    "route"   | 1   | 4
+    "forward" | 1   | 4
+    "ask"     | 2   | 3
+    "tell"    | 2   | 3
+    "route"   | 2   | 4
+    "forward" | 2   | 4
+    "ask"     | 10  | 3
+    "tell"    | 10  | 3
+    "route"   | 10  | 4
+    "forward" | 10  | 4
   }
 }

--- a/dd-java-agent/instrumentation/akka-concurrent/src/main/java/datadog/trace/instrumentation/akka/concurrent/AkkaActorCellInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-concurrent/src/main/java/datadog/trace/instrumentation/akka/concurrent/AkkaActorCellInstrumentation.java
@@ -11,6 +11,7 @@ import akka.dispatch.Envelope;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.bootstrap.InstrumentationContext;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.AdviceUtils;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.State;
@@ -84,6 +85,10 @@ public class AkkaActorCellInstrumentation extends Instrumenter.Tracing {
     public static void exit(
         @Advice.Enter TraceScope scope, @Advice.Local(value = "localScope") TraceScope localScope) {
       if (localScope != null) {
+        if (localScope instanceof AgentScope) {
+          // then we have invoked an Envelope and need to mark the work complete
+          ((AgentScope) localScope).span().finishWork();
+        }
         localScope.close();
       }
       // Clean up any leaking scopes from akka-streams/akka-http et.c.

--- a/dd-java-agent/instrumentation/akka-concurrent/src/main/java/datadog/trace/instrumentation/akka/concurrent/AkkaEnvelopeInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-concurrent/src/main/java/datadog/trace/instrumentation/akka/concurrent/AkkaEnvelopeInstrumentation.java
@@ -2,6 +2,7 @@ package datadog.trace.instrumentation.akka.concurrent;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
+import static datadog.trace.bootstrap.instrumentation.java.concurrent.AdviceUtils.capture;
 import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
 
@@ -41,12 +42,7 @@ public class AkkaEnvelopeInstrumentation extends Instrumenter.Tracing {
   public static class ConstructAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
     public static void afterInit(@Advice.This Envelope zis) {
-      TraceScope activeScope = activeScope();
-      if (null != activeScope) {
-        InstrumentationContext.get(Envelope.class, State.class)
-            .putIfAbsent(zis, State.FACTORY)
-            .captureAndSetContinuation(activeScope);
-      }
+      capture(InstrumentationContext.get(Envelope.class, State.class), zis, true);
     }
   }
 }

--- a/dd-java-agent/instrumentation/akka-concurrent/src/main/java/datadog/trace/instrumentation/akka/concurrent/AkkaEnvelopeInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-concurrent/src/main/java/datadog/trace/instrumentation/akka/concurrent/AkkaEnvelopeInstrumentation.java
@@ -1,7 +1,6 @@
 package datadog.trace.instrumentation.akka.concurrent;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
 import static datadog.trace.bootstrap.instrumentation.java.concurrent.AdviceUtils.capture;
 import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
@@ -11,7 +10,6 @@ import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.State;
-import datadog.trace.context.TraceScope;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;

--- a/dd-java-agent/instrumentation/akka-concurrent/src/main/java/datadog/trace/instrumentation/akka/concurrent/AkkaForkJoinExecutorTaskInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-concurrent/src/main/java/datadog/trace/instrumentation/akka/concurrent/AkkaForkJoinExecutorTaskInstrumentation.java
@@ -2,7 +2,7 @@ package datadog.trace.instrumentation.akka.concurrent;
 
 import static datadog.trace.agent.tooling.ClassLoaderMatcher.hasClassesNamed;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
+import static datadog.trace.bootstrap.instrumentation.java.concurrent.AdviceUtils.capture;
 import static datadog.trace.bootstrap.instrumentation.java.concurrent.AdviceUtils.endTaskScope;
 import static datadog.trace.bootstrap.instrumentation.java.concurrent.AdviceUtils.startTaskScope;
 import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
@@ -60,12 +60,7 @@ public final class AkkaForkJoinExecutorTaskInstrumentation extends Instrumenter.
   public static final class Construct {
     @Advice.OnMethodExit
     public static void construct(@Advice.Argument(0) Runnable wrapped) {
-      TraceScope activeScope = activeScope();
-      if (null != activeScope) {
-        InstrumentationContext.get(Runnable.class, State.class)
-            .putIfAbsent(wrapped, State.FACTORY)
-            .captureAndSetContinuation(activeScope);
-      }
+      capture(InstrumentationContext.get(Runnable.class, State.class), wrapped, true);
     }
   }
 

--- a/dd-java-agent/instrumentation/akka-concurrent/src/main/java/datadog/trace/instrumentation/akka/concurrent/AkkaForkJoinPoolInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-concurrent/src/main/java/datadog/trace/instrumentation/akka/concurrent/AkkaForkJoinPoolInstrumentation.java
@@ -2,8 +2,10 @@ package datadog.trace.instrumentation.akka.concurrent;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
 import static datadog.trace.bootstrap.instrumentation.java.concurrent.AdviceUtils.cancelTask;
+import static datadog.trace.bootstrap.instrumentation.java.concurrent.AdviceUtils.capture;
+import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.ExcludeType.FORK_JOIN_TASK;
+import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.exclude;
 import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 
@@ -12,7 +14,6 @@ import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.State;
-import datadog.trace.context.TraceScope;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
@@ -45,11 +46,8 @@ public final class AkkaForkJoinPoolInstrumentation extends Instrumenter.Tracing 
   public static final class ExternalPush {
     @Advice.OnMethodEnter
     public static <T> void externalPush(@Advice.Argument(0) ForkJoinTask<T> task) {
-      TraceScope activeScope = activeScope();
-      if (null != activeScope) {
-        InstrumentationContext.get(ForkJoinTask.class, State.class)
-            .putIfAbsent(task, State.FACTORY)
-            .captureAndSetContinuation(activeScope);
+      if (!exclude(FORK_JOIN_TASK, task)) {
+        capture(InstrumentationContext.get(ForkJoinTask.class, State.class), task, true);
       }
     }
 

--- a/dd-java-agent/instrumentation/akka-concurrent/src/main/java/datadog/trace/instrumentation/akka/concurrent/AkkaRoutedActorCellInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-concurrent/src/main/java/datadog/trace/instrumentation/akka/concurrent/AkkaRoutedActorCellInstrumentation.java
@@ -9,6 +9,7 @@ import akka.routing.RoutedActorCell;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.bootstrap.InstrumentationContext;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.AdviceUtils;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.State;
 import datadog.trace.context.TraceScope;
@@ -67,6 +68,10 @@ public class AkkaRoutedActorCellInstrumentation extends Instrumenter.Tracing {
     public static void exit(@Advice.Enter TraceScope scope) {
       if (null != scope) {
         scope.close();
+        if (scope instanceof AgentScope) {
+          // then we have invoked an Envelope and need to mark the work complete
+          ((AgentScope) scope).span().finishWork();
+        }
       }
     }
   }

--- a/dd-java-agent/instrumentation/scala-concurrent/src/main/java/datadog/trace/instrumentation/scala/concurrent/ScalaForkJoinPoolInstrumentation.java
+++ b/dd-java-agent/instrumentation/scala-concurrent/src/main/java/datadog/trace/instrumentation/scala/concurrent/ScalaForkJoinPoolInstrumentation.java
@@ -2,8 +2,10 @@ package datadog.trace.instrumentation.scala.concurrent;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
 import static datadog.trace.bootstrap.instrumentation.java.concurrent.AdviceUtils.cancelTask;
+import static datadog.trace.bootstrap.instrumentation.java.concurrent.AdviceUtils.capture;
+import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.ExcludeType.FORK_JOIN_TASK;
+import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.exclude;
 import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
@@ -12,7 +14,6 @@ import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.State;
-import datadog.trace.context.TraceScope;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
@@ -48,11 +49,8 @@ public final class ScalaForkJoinPoolInstrumentation extends Instrumenter.Tracing
   public static final class StartTask {
     @Advice.OnMethodEnter
     public static <T> void before(@Advice.Argument(0) ForkJoinTask<T> task) {
-      TraceScope activeScope = activeScope();
-      if (null != activeScope) {
-        InstrumentationContext.get(ForkJoinTask.class, State.class)
-            .putIfAbsent(task, State.FACTORY)
-            .captureAndSetContinuation(activeScope);
+      if (!exclude(FORK_JOIN_TASK, task)) {
+        capture(InstrumentationContext.get(ForkJoinTask.class, State.class), task, true);
       }
     }
 


### PR DESCRIPTION
This tracks akka envelopes, enforces exclusion of mailbox scheduling and prevents tracing of a `ForkJoinTask` internal to `Dispatcher`