### PR TITLE
Adding async-profiler as an auxiliary profiling data source

### DIFF
--- a/dd-java-agent/agent-profiling/agent-profiling.gradle
+++ b/dd-java-agent/agent-profiling/agent-profiling.gradle
@@ -16,6 +16,7 @@ dependencies {
   api deps.slf4j
   api project(':internal-api')
 
+  api project(':dd-java-agent:agent-profiling:profiling-auxiliary-async')
   api project(':dd-java-agent:agent-profiling:profiling-uploader')
   api project(':dd-java-agent:agent-profiling:profiling-controller')
   api project(':dd-java-agent:agent-profiling:profiling-controller-openjdk')

--- a/dd-java-agent/agent-profiling/agent-profiling.gradle
+++ b/dd-java-agent/agent-profiling/agent-profiling.gradle
@@ -16,7 +16,8 @@ dependencies {
   api deps.slf4j
   api project(':internal-api')
 
-  api project(':dd-java-agent:agent-profiling:profiling-auxiliary-async')
+  api project(':dd-java-agent:agent-profiling:profiling-auxiliary')
+  implementation project(path: ':dd-java-agent:agent-profiling:profiling-auxiliary-async', configuration: 'shadow')
   api project(':dd-java-agent:agent-profiling:profiling-uploader')
   api project(':dd-java-agent:agent-profiling:profiling-controller')
   api project(':dd-java-agent:agent-profiling:profiling-controller-openjdk')

--- a/dd-java-agent/agent-profiling/profiling-auxiliary-async/profiling-auxiliary-async.gradle
+++ b/dd-java-agent/agent-profiling/profiling-auxiliary-async/profiling-auxiliary-async.gradle
@@ -4,23 +4,37 @@ plugins {
 
 apply from: "$rootDir/gradle/java.gradle"
 
+minimumInstructionCoverage = 0.5
+minimumBranchCoverage = 0.5
+
+excludedClassesCoverage += [
+  // enums with no additional functionality
+  'com.datadog.profiling.controller.async.Arch',
+  'com.datadog.profiling.controller.async.OperatingSystem',
+  // --
+  // although it is quite well covered jacoco complains about branch coverage due to exception handlers
+  'com.datadog.profiling.auxiliary.async.AsyncProfilerRecording'
+]
+
 dependencies {
   api project(':dd-java-agent:agent-profiling:profiling-controller')
+  api project(':dd-java-agent:agent-profiling:profiling-auxiliary')
   implementation 'tools.profiler:async-profiler:1.8.3'
+
+  annotationProcessor deps.autoserviceProcessor
+  compileOnly deps.autoserviceAnnotation
 
   implementation deps.slf4j
 
+  testImplementation deps.jmc
   testImplementation deps.junit5
 }
-
-excludedClassesCoverage += ['com.datadog.profiling.controller.jfr.JdkTypeIDs']
-
-
-// Shared JFR implementation. The earliest Java version JFR is working on is Java 8
 
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
+// TODO: There might be more os/arch supports coming
+// Monitor https://github.com/jvm-profiling-tools/async-profiler/releases for newly supported archs
 ['macos-x64', 'linux-x64', 'linux-x86', 'linux-musl-x64', 'linux-arm', 'linux-aarch64'].each {
   def platform = it
 

--- a/dd-java-agent/agent-profiling/profiling-auxiliary-async/profiling-auxiliary-async.gradle
+++ b/dd-java-agent/agent-profiling/profiling-auxiliary-async/profiling-auxiliary-async.gradle
@@ -1,5 +1,6 @@
 plugins {
   id "de.undercouch.download" version "4.1.1"
+  id "com.github.johnrengelman.shadow"
 }
 
 apply from: "$rootDir/gradle/java.gradle"
@@ -16,10 +17,19 @@ excludedClassesCoverage += [
   'com.datadog.profiling.auxiliary.async.AsyncProfilerRecording'
 ]
 
+def AP_VERSION = project.findProperty("dd.async_profiler")
+AP_VERSION = AP_VERSION != null ? AP_VERSION : "1.8.3"
+
+repositories {
+  maven {
+    url = uri("https://gitlab.ddbuild.io/api/v4/projects/2193/packages/maven")
+  }
+}
+
 dependencies {
   api project(':dd-java-agent:agent-profiling:profiling-controller')
   api project(':dd-java-agent:agent-profiling:profiling-auxiliary')
-  implementation 'tools.profiler:async-profiler:1.8.3'
+  implementation "tools.profiler:async-profiler:${AP_VERSION}"
 
   annotationProcessor deps.autoserviceProcessor
   compileOnly deps.autoserviceAnnotation
@@ -35,7 +45,7 @@ targetCompatibility = JavaVersion.VERSION_1_8
 
 // TODO: There might be more os/arch supports coming
 // Monitor https://github.com/jvm-profiling-tools/async-profiler/releases for newly supported archs
-['macos-x64', 'linux-x64', 'linux-x86', 'linux-musl-x64', 'linux-arm', 'linux-aarch64'].each {
+['macos-x64', 'linux-x86', 'linux-musl-x64', 'linux-arm', 'linux-aarch64'].each {
   def platform = it
 
   tasks.create(type: Download, name: "downloadAsyncProfiler_${platform}") {
@@ -61,3 +71,18 @@ targetCompatibility = JavaVersion.VERSION_1_8
 
   processResources.dependsOn "asyncProfilerResources_${platform}"
 }
+
+shadowJar {
+  classifier ""
+  include {
+    def rslt = false
+    rslt |= it.path == "com" || it.path == "com/datadog" || it.path.startsWith("com/datadog/")
+    rslt |= it.path == "META-INF" || it.path == "META-INF/services" || it.path.startsWith("META-INF/services/")
+    rslt |= it.path == "native-libs" || it.path.startsWith("native-libs")
+    rslt |= (it.path.contains("async-profiler") && it.path.endsWith(".jar"))
+
+    return rslt
+  }
+}
+
+build.dependsOn shadowJar

--- a/dd-java-agent/agent-profiling/profiling-auxiliary-async/profiling-auxiliary-async.gradle
+++ b/dd-java-agent/agent-profiling/profiling-auxiliary-async/profiling-auxiliary-async.gradle
@@ -18,13 +18,7 @@ excludedClassesCoverage += [
 ]
 
 def AP_VERSION = project.findProperty("dd.async_profiler")
-AP_VERSION = AP_VERSION != null ? AP_VERSION : "1.8.3"
-
-repositories {
-  maven {
-    url = uri("https://gitlab.ddbuild.io/api/v4/projects/2193/packages/maven")
-  }
-}
+AP_VERSION = AP_VERSION != null ? AP_VERSION : "2.5-DD"
 
 dependencies {
   api project(':dd-java-agent:agent-profiling:profiling-controller')
@@ -42,35 +36,6 @@ dependencies {
 
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
-
-// TODO: There might be more os/arch supports coming
-// Monitor https://github.com/jvm-profiling-tools/async-profiler/releases for newly supported archs
-['macos-x64', 'linux-x86', 'linux-musl-x64', 'linux-arm', 'linux-aarch64'].each {
-  def platform = it
-
-  tasks.create(type: Download, name: "downloadAsyncProfiler_${platform}") {
-    src "https://github.com/jvm-profiling-tools/async-profiler/releases/download/v2.0/async-profiler-2.0-${platform}.tar.gz"
-    dest "${buildDir}/external/"
-    overwrite false
-    doLast {
-      copy {
-        from tarTree(resources.gzip("${buildDir}/external/async-profiler-2.0-${platform}.tar.gz"))
-        into "${buildDir}/external/"
-      }
-    }
-    doFirst {
-      mkdir "${buildDir}/external/"
-    }
-  }
-  def rsrcTask = tasks.create(type: Copy, name: "asyncProfilerResources_${platform}") {
-    dependsOn "downloadAsyncProfiler_${platform}"
-    from "${buildDir}/external/async-profiler-2.0-${platform}/build/"
-    into "${buildDir}/resources/main/native-libs/${platform}/"
-    include '**/*.so'
-  }
-
-  processResources.dependsOn "asyncProfilerResources_${platform}"
-}
 
 shadowJar {
   classifier ""

--- a/dd-java-agent/agent-profiling/profiling-auxiliary-async/profiling-auxiliary-async.gradle
+++ b/dd-java-agent/agent-profiling/profiling-auxiliary-async/profiling-auxiliary-async.gradle
@@ -18,12 +18,12 @@ excludedClassesCoverage += [
 ]
 
 def AP_VERSION = project.findProperty("dd.async_profiler")
-AP_VERSION = AP_VERSION != null ? AP_VERSION : "2.5-DD"
+AP_VERSION = AP_VERSION != null ? AP_VERSION : "2.5-DD-SNAPSHOT"
 
 dependencies {
   api project(':dd-java-agent:agent-profiling:profiling-controller')
   api project(':dd-java-agent:agent-profiling:profiling-auxiliary')
-  implementation "tools.profiler:async-profiler:${AP_VERSION}"
+  implementation group: "tools.profiler", name: "async-profiler", version: "${AP_VERSION}", changing: true
 
   annotationProcessor deps.autoserviceProcessor
   compileOnly deps.autoserviceAnnotation
@@ -42,12 +42,17 @@ shadowJar {
   include {
     def rslt = false
     rslt |= it.path == "com" || it.path == "com/datadog" || it.path.startsWith("com/datadog/")
+    rslt |= it.path == "one" || it.path == "one/profiler" || it.path.startsWith("one/profiler/")
     rslt |= it.path == "META-INF" || it.path == "META-INF/services" || it.path.startsWith("META-INF/services/")
-    rslt |= it.path == "native-libs" || it.path.startsWith("native-libs")
+    // TODO: modify the filter to include other OS/arch combinations once the overhead is evaluated
+    rslt |= it.path == "native-libs" || it.path.startsWith("native-libs/linux-arm64")
     rslt |= (it.path.contains("async-profiler") && it.path.endsWith(".jar"))
-
     return rslt
   }
 }
 
 build.dependsOn shadowJar
+
+configurations.all {
+  resolutionStrategy.cacheChangingModulesFor 0, 'seconds'
+}

--- a/dd-java-agent/agent-profiling/profiling-auxiliary-async/src/main/java/com/datadog/profiling/auxiliary/async/Arch.java
+++ b/dd-java-agent/agent-profiling/profiling-auxiliary-async/src/main/java/com/datadog/profiling/auxiliary/async/Arch.java
@@ -1,0 +1,34 @@
+package com.datadog.profiling.auxiliary.async;
+
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.Set;
+
+/** A simple implementation to detect the current architecture */
+enum Arch {
+  x64("x86_64", "amd64", "k8"),
+  x86("x86", "i386", "i486", "i586", "i686"),
+  arm("ARM", "arm64"),
+  aarch64("aarch64"),
+  unknown();
+
+  private final Set<String> identifiers;
+
+  Arch(String... identifiers) {
+    this.identifiers = new HashSet<>(Arrays.asList(identifiers));
+  }
+
+  public static Arch of(String identifier) {
+    for (Arch arch : EnumSet.allOf(Arch.class)) {
+      if (arch.identifiers.contains(identifier)) {
+        return arch;
+      }
+    }
+    return unknown;
+  }
+
+  public static Arch current() {
+    return Arch.of(System.getProperty("os.arch"));
+  }
+}

--- a/dd-java-agent/agent-profiling/profiling-auxiliary-async/src/main/java/com/datadog/profiling/auxiliary/async/AsyncProfilerRecording.java
+++ b/dd-java-agent/agent-profiling/profiling-auxiliary-async/src/main/java/com/datadog/profiling/auxiliary/async/AsyncProfilerRecording.java
@@ -1,0 +1,67 @@
+package com.datadog.profiling.auxiliary.async;
+
+import com.datadog.profiling.controller.OngoingRecording;
+import com.datadog.profiling.controller.RecordingData;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import javax.annotation.Nonnull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+final class AsyncProfilerRecording implements OngoingRecording {
+  private static final Logger log = LoggerFactory.getLogger(AsyncProfilerRecording.class);
+
+  private final AuxiliaryAsyncProfiler profiler;
+  private volatile Path recordingFile;
+  private final Instant started = Instant.now();
+
+  /**
+   * Do not use this constructor directly. Rather use {@linkplain AuxiliaryAsyncProfiler#start()}
+   *
+   * @param profiler the associated profiler
+   * @throws IOException
+   */
+  AsyncProfilerRecording(AuxiliaryAsyncProfiler profiler) throws IOException {
+    this.profiler = profiler;
+    this.recordingFile = profiler.newRecording();
+  }
+
+  @Nonnull
+  @Override
+  public RecordingData stop() {
+    profiler.stopProfiler();
+    return new AysncProfilerRecordingData(recordingFile, started, Instant.now());
+  }
+
+  @Nonnull
+  @Override
+  public RecordingData snapshot(@Nonnull Instant start) {
+    profiler.stop(this);
+    RecordingData data = new AysncProfilerRecordingData(recordingFile, start, Instant.now());
+    try {
+      recordingFile = profiler.newRecording();
+    } catch (IOException | IllegalStateException e) {
+      if (log.isDebugEnabled()) {
+        log.warn("Unable to start async profiler recording", e);
+      } else {
+        log.warn("Unable to start async profiler recording: {}", e.getMessage());
+      }
+    }
+    return data;
+  }
+
+  @Override
+  public void close() {
+    try {
+      Files.deleteIfExists(recordingFile);
+    } catch (IOException ignored) {
+    }
+  }
+
+  // used for tests only
+  Path getRecordingFile() {
+    return recordingFile;
+  }
+}

--- a/dd-java-agent/agent-profiling/profiling-auxiliary-async/src/main/java/com/datadog/profiling/auxiliary/async/AuxiliaryAsyncProfiler.java
+++ b/dd-java-agent/agent-profiling/profiling-auxiliary-async/src/main/java/com/datadog/profiling/auxiliary/async/AuxiliaryAsyncProfiler.java
@@ -1,0 +1,228 @@
+package com.datadog.profiling.auxiliary.async;
+
+import com.datadog.profiling.auxiliary.AuxiliaryImplementation;
+import com.datadog.profiling.auxiliary.LibraryHelper;
+import com.datadog.profiling.auxiliary.ProfilingMode;
+import com.datadog.profiling.controller.OngoingRecording;
+import com.datadog.profiling.controller.RecordingData;
+import com.google.auto.service.AutoService;
+import datadog.trace.api.config.ProfilingConfig;
+import datadog.trace.bootstrap.config.provider.ConfigProvider;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.EnumSet;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.LockSupport;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import one.profiler.AsyncProfiler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class AuxiliaryAsyncProfiler implements AuxiliaryImplementation {
+  private static final Logger log = LoggerFactory.getLogger(AuxiliaryAsyncProfiler.class);
+
+  public static final String TYPE = "async";
+
+  @AutoService(AuxiliaryImplementation.Provider.class)
+  public static final class ImplementerProvider implements AuxiliaryImplementation.Provider {
+    @Override
+    public boolean canProvide(String expectedType) {
+      return TYPE.equals(expectedType);
+    }
+
+    @Override
+    @Nonnull
+    public AuxiliaryImplementation provide(ConfigProvider configProvider) {
+      return new AuxiliaryAsyncProfiler(configProvider);
+    }
+  }
+
+  private final AtomicBoolean recordingFlag = new AtomicBoolean(false);
+  private final ConfigProvider configProvider;
+  private final AsyncProfiler asyncProfiler;
+  private final Set<ProfilingMode> profilingModes = EnumSet.noneOf(ProfilingMode.class);
+
+  public AuxiliaryAsyncProfiler(ConfigProvider configProvider) {
+    this.configProvider = configProvider;
+    AsyncProfiler instance = null;
+    String libDir = configProvider.getString(ProfilingConfig.PROFILING_ASYNC_LIBPATH);
+    if (libDir != null && Files.exists(Paths.get(libDir))) {
+      // the library from configuration takes precedence
+      instance = AsyncProfiler.getInstance(libDir);
+    } else {
+      instance = inferFromOsAndArch();
+    }
+    if (configProvider.getBoolean(ProfilingConfig.PROFILING_ASYNC_ALLOC_ENABLED, false)) {
+      profilingModes.add(ProfilingMode.ALLOCATION);
+    }
+    if (configProvider.getBoolean(ProfilingConfig.PROFILING_ASYNC_CPU_ENABLED, true)) {
+      profilingModes.add(ProfilingMode.CPU);
+    }
+    try {
+      // sanity test - force load async profiler to catch it not being available early
+      instance.execute("status");
+    } catch (Throwable t) {
+      log.debug("Async Profiler is not available", t);
+      instance = null;
+    }
+    asyncProfiler = instance;
+  }
+
+  private static AsyncProfiler inferFromOsAndArch() {
+    Arch arch = Arch.current();
+    OperatingSystem os = OperatingSystem.current();
+    try {
+      if (os != OperatingSystem.unknown) {
+        if (arch != Arch.unknown) {
+          try {
+            return profilerForOsAndArch(os, arch, false);
+          } catch (FileNotFoundException e) {
+            if (os == OperatingSystem.linux) {
+              // Might be a MUSL distribution
+              return profilerForOsAndArch(os, arch, true);
+            }
+            throw e;
+          }
+        }
+      }
+    } catch (Throwable t) {
+      if (log.isDebugEnabled()) {
+        log.info(
+            "Unable to instantiate async profiler for the detected environment: arch={}, os={}",
+            arch,
+            os,
+            t);
+      } else {
+        log.info(
+            "Unable to instantiate async profiler for the detected environment: arch={}, os={}, cause={}",
+            arch,
+            os,
+            t.getMessage());
+      }
+    }
+    return null;
+  }
+
+  private static AsyncProfiler profilerForOsAndArch(OperatingSystem os, Arch arch, boolean musl)
+      throws IOException {
+    String libDir = os.name() + (musl ? "-musl-" : "-") + arch.name();
+    File localLib =
+        LibraryHelper.libraryFromClasspath("/native-libs/" + libDir + "/libasyncProfiler.so");
+    return AsyncProfiler.getInstance(localLib.getAbsolutePath());
+  }
+
+  @Override
+  public boolean isAvailable() {
+    return asyncProfiler != null;
+  }
+
+  @Override
+  @Nullable
+  public OngoingRecording start() {
+    if (asyncProfiler != null) {
+      log.debug("Starting profiling");
+      try {
+        return new AsyncProfilerRecording(this);
+      } catch (IOException | IllegalStateException e) {
+        return null;
+      }
+    }
+    return null;
+  }
+
+  @Override
+  @Nullable
+  public RecordingData stop(OngoingRecording recording) {
+    if (asyncProfiler != null) {
+      log.debug("Stopping profiling");
+      return recording.stop();
+    }
+    return null;
+  }
+
+  /** A call-back from {@linkplain AsyncProfilerRecording#stop()} */
+  void stopProfiler() {
+    if (asyncProfiler != null) {
+      if (recordingFlag.compareAndSet(true, false)) {
+        asyncProfiler.stop();
+        if (isActive()) {
+          log.debug("Profiling is still active. Waiting to stop.");
+          while (isActive()) {
+            LockSupport.parkNanos(10_000_000L);
+          }
+        }
+      }
+    }
+  }
+
+  @Override
+  public Set<ProfilingMode> enabledModes() {
+    return profilingModes;
+  }
+
+  boolean isActive() {
+    try {
+      String status = executeProfilerCmd("status");
+      log.debug("Async Profiler Status = {}", status);
+      return !status.contains("not active");
+    } catch (IOException ignored) {
+    }
+    return false;
+  }
+
+  String executeProfilerCmd(String cmd) throws IOException {
+    return asyncProfiler.execute(cmd);
+  }
+
+  Path newRecording() throws IOException, IllegalStateException {
+    if (recordingFlag.compareAndSet(false, true)) {
+      Path recFile = Files.createTempFile("dd-profiler-", ".jfr");
+      String cmd = cmdStartProfiling(recFile);
+      try {
+        String rslt = executeProfilerCmd(cmd);
+        log.debug("AsyncProfiler.execute({}) = {}", cmd, rslt);
+      } catch (IOException | IllegalStateException e) {
+        if (log.isDebugEnabled()) {
+          log.warn("Unable to start async profiler recording", e);
+        } else {
+          log.warn("Unable to start async profiler recording: {}", e.getMessage());
+        }
+        recordingFlag.set(false);
+        throw e;
+      }
+      return recFile;
+    }
+    throw new IllegalStateException("Async profiler session has already been started");
+  }
+
+  String cmdStartProfiling(Path file) throws IllegalStateException {
+    // 'start' = start, 'jfr=7' = store in JFR format ready for concatenation
+    StringBuilder cmd = new StringBuilder("start,jfr=7,file=").append(file.toAbsolutePath());
+    if (profilingModes.contains(ProfilingMode.CPU)) {
+      // enable 'itimer' event to collect CPU samples
+      cmd.append(",event=itimer");
+      if (profilingModes.contains(ProfilingMode.ALLOCATION)) {
+        // if combined with allocation profiling just set the allocation interval
+        cmd.append(",alloc=")
+            .append(
+                configProvider.getString(
+                    ProfilingConfig.PROFILING_ASYNC_ALLOC_INTERVAL,
+                    ProfilingConfig.PROFILING_ASYNC_ALLOC_INTERVAL_DEFAULT));
+      }
+    } else if (profilingModes.contains(ProfilingMode.ALLOCATION)) {
+      // only allocation profiling is enabled
+      cmd.append(",event=alloc,alloc=")
+          .append(
+              configProvider.getString(
+                  ProfilingConfig.PROFILING_ASYNC_ALLOC_INTERVAL,
+                  ProfilingConfig.PROFILING_ASYNC_ALLOC_INTERVAL_DEFAULT));
+    }
+    return cmd.toString();
+  }
+}

--- a/dd-java-agent/agent-profiling/profiling-auxiliary-async/src/main/java/com/datadog/profiling/auxiliary/async/AuxiliaryAsyncProfiler.java
+++ b/dd-java-agent/agent-profiling/profiling-auxiliary-async/src/main/java/com/datadog/profiling/auxiliary/async/AuxiliaryAsyncProfiler.java
@@ -24,7 +24,7 @@ import one.profiler.AsyncProfiler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public final class AuxiliaryAsyncProfiler implements AuxiliaryImplementation {
+final class AuxiliaryAsyncProfiler implements AuxiliaryImplementation {
   private static final Logger log = LoggerFactory.getLogger(AuxiliaryAsyncProfiler.class);
 
   public static final String TYPE = "async";
@@ -48,7 +48,7 @@ public final class AuxiliaryAsyncProfiler implements AuxiliaryImplementation {
   private final AsyncProfiler asyncProfiler;
   private final Set<ProfilingMode> profilingModes = EnumSet.noneOf(ProfilingMode.class);
 
-  public AuxiliaryAsyncProfiler(ConfigProvider configProvider) {
+  AuxiliaryAsyncProfiler(ConfigProvider configProvider) {
     this.configProvider = configProvider;
     AsyncProfiler instance = null;
     String libDir = configProvider.getString(ProfilingConfig.PROFILING_ASYNC_LIBPATH);

--- a/dd-java-agent/agent-profiling/profiling-auxiliary-async/src/main/java/com/datadog/profiling/auxiliary/async/AuxiliaryAsyncProfiler.java
+++ b/dd-java-agent/agent-profiling/profiling-auxiliary-async/src/main/java/com/datadog/profiling/auxiliary/async/AuxiliaryAsyncProfiler.java
@@ -111,7 +111,8 @@ final class AuxiliaryAsyncProfiler implements AuxiliaryImplementation {
 
   private static AsyncProfiler profilerForOsAndArch(OperatingSystem os, Arch arch, boolean musl)
       throws IOException {
-    String libDir = os.name() + (musl ? "-musl-" : "-") + arch.name();
+    String libDir =
+        os.name() + (os.name().equals("macos") ? "" : (musl ? "-musl-" : "-") + arch.name());
     File localLib =
         LibraryHelper.libraryFromClasspath("/native-libs/" + libDir + "/libasyncProfiler.so");
     return AsyncProfiler.getInstance(localLib.getAbsolutePath());

--- a/dd-java-agent/agent-profiling/profiling-auxiliary-async/src/main/java/com/datadog/profiling/auxiliary/async/AysncProfilerRecordingData.java
+++ b/dd-java-agent/agent-profiling/profiling-auxiliary-async/src/main/java/com/datadog/profiling/auxiliary/async/AysncProfilerRecordingData.java
@@ -1,0 +1,39 @@
+package com.datadog.profiling.auxiliary.async;
+
+import com.datadog.profiling.controller.RecordingData;
+import com.datadog.profiling.controller.RecordingInputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import javax.annotation.Nonnull;
+
+final class AysncProfilerRecordingData extends RecordingData {
+  private final Path recordingFile;
+
+  public AysncProfilerRecordingData(Path recordingFile, Instant start, Instant end) {
+    super(start, end);
+    this.recordingFile = recordingFile;
+  }
+
+  @Nonnull
+  @Override
+  public RecordingInputStream getStream() throws IOException {
+    return new RecordingInputStream(Files.newInputStream(recordingFile));
+  }
+
+  @Override
+  public void release() {
+    try {
+      Files.deleteIfExists(recordingFile);
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+  }
+
+  @Nonnull
+  @Override
+  public String getName() {
+    return "async-profiler";
+  }
+}

--- a/dd-java-agent/agent-profiling/profiling-auxiliary-async/src/main/java/com/datadog/profiling/auxiliary/async/OperatingSystem.java
+++ b/dd-java-agent/agent-profiling/profiling-auxiliary-async/src/main/java/com/datadog/profiling/auxiliary/async/OperatingSystem.java
@@ -1,0 +1,32 @@
+package com.datadog.profiling.auxiliary.async;
+
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.Set;
+
+/** A simple way to detect the current operating system */
+enum OperatingSystem {
+  linux("Linux", "linux"),
+  macos("Mac OS X", "macOS", "mac"),
+  unknown();
+
+  private final Set<String> identifiers;
+
+  OperatingSystem(String... identifiers) {
+    this.identifiers = new HashSet<>(Arrays.asList(identifiers));
+  }
+
+  public static OperatingSystem of(String identifier) {
+    for (OperatingSystem os : EnumSet.allOf(OperatingSystem.class)) {
+      if (os.identifiers.contains(identifier)) {
+        return os;
+      }
+    }
+    return unknown;
+  }
+
+  public static OperatingSystem current() {
+    return OperatingSystem.of(System.getProperty("os.name"));
+  }
+}

--- a/dd-java-agent/agent-profiling/profiling-auxiliary-async/src/test/java/com/datadog/profiling/auxiliary/async/AsyncProfilerRecordingTest.java
+++ b/dd-java-agent/agent-profiling/profiling-auxiliary-async/src/test/java/com/datadog/profiling/auxiliary/async/AsyncProfilerRecordingTest.java
@@ -1,0 +1,67 @@
+package com.datadog.profiling.auxiliary.async;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.datadog.profiling.controller.RecordingData;
+import datadog.trace.bootstrap.config.provider.ConfigProvider;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.time.Instant;
+import org.junit.Assume;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class AsyncProfilerRecordingTest {
+  private static final Logger log = LoggerFactory.getLogger(AsyncProfilerRecordingTest.class);
+
+  private AuxiliaryAsyncProfiler profiler;
+  private AsyncProfilerRecording recording;
+
+  @BeforeEach
+  void setup() throws Exception {
+    profiler = new AuxiliaryAsyncProfiler(ConfigProvider.getInstance());
+    log.info(
+        "Async Profiler: available={}, active={}", profiler.isAvailable(), profiler.isActive());
+    Assume.assumeTrue(profiler.isAvailable());
+    Assume.assumeFalse(profiler.isActive());
+
+    recording = (AsyncProfilerRecording) profiler.start();
+    Assume.assumeTrue(recording != null);
+  }
+
+  @AfterEach
+  void shutdown() throws Exception {
+    // Apparently, failed 'assume' does not prevent shutdown from running
+    // Do a sanity check before invoking profiler methods
+    if (profiler != null && recording != null) {
+      profiler.stop(recording);
+    }
+  }
+
+  @Test
+  void testClose() throws Exception {
+    assertTrue(Files.exists(recording.getRecordingFile()));
+    recording.close();
+    assertFalse(Files.exists(recording.getRecordingFile()));
+  }
+
+  @Test
+  void testStop() throws Exception {
+    RecordingData data = recording.stop();
+    assertNotNull(data);
+    assertTrue(Files.exists(recording.getRecordingFile()));
+  }
+
+  @Test
+  void testSnapshot() throws Exception {
+    RecordingData data = recording.snapshot(Instant.now());
+    assertNotNull(data);
+    assertTrue(Files.exists(recording.getRecordingFile()));
+    InputStream inputStream = data.getStream();
+    assertNotNull(inputStream);
+    assertTrue(inputStream.available() > 0);
+  }
+}

--- a/dd-java-agent/agent-profiling/profiling-auxiliary-async/src/test/java/com/datadog/profiling/auxiliary/async/AuxiliaryAsyncProfilerTest.java
+++ b/dd-java-agent/agent-profiling/profiling-auxiliary-async/src/test/java/com/datadog/profiling/auxiliary/async/AuxiliaryAsyncProfilerTest.java
@@ -1,0 +1,102 @@
+package com.datadog.profiling.auxiliary.async;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.datadog.profiling.auxiliary.ProfilingMode;
+import com.datadog.profiling.controller.OngoingRecording;
+import com.datadog.profiling.controller.RecordingData;
+import datadog.trace.api.config.ProfilingConfig;
+import datadog.trace.bootstrap.config.provider.ConfigProvider;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Properties;
+import java.util.UUID;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.openjdk.jmc.common.item.IItemCollection;
+import org.openjdk.jmc.flightrecorder.JfrLoaderToolkit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class AuxiliaryAsyncProfilerTest {
+  private static final Logger log = LoggerFactory.getLogger(AuxiliaryAsyncProfilerTest.class);
+
+  @Test
+  void test() throws Exception {
+    AuxiliaryAsyncProfiler profiler = new AuxiliaryAsyncProfiler(ConfigProvider.getInstance());
+    if (!profiler.isAvailable()) {
+      log.warn("Async Profiler not available. Skipping test.");
+      return;
+    }
+    assertFalse(profiler.enabledModes().isEmpty());
+
+    if (profiler.isActive()) {
+      // apparently the CI is already running with async profiler attached (?)
+      log.warn("Async profiler is already running. Skipping the test.");
+      return;
+    }
+
+    OngoingRecording recording = profiler.start();
+    if (recording != null) {
+      try {
+        long cumulative = 0L;
+        for (int i = 0; i < 5000; i++) {
+          cumulative ^= UUID.randomUUID().getLeastSignificantBits();
+        }
+        log.info("calculated: {}", cumulative);
+        RecordingData data = profiler.stop(recording);
+        assertNotNull(data);
+        IItemCollection events = JfrLoaderToolkit.loadEvents(data.getStream());
+        assertTrue(events.hasItems());
+      } finally {
+        recording.stop();
+      }
+    } else {
+      log.warn("Async Profiler is not available. Skipping test.");
+    }
+  }
+
+  @Test
+  void testProvider() {
+    AuxiliaryAsyncProfiler.ImplementerProvider provider =
+        new AuxiliaryAsyncProfiler.ImplementerProvider();
+    assertTrue(provider.canProvide(AuxiliaryAsyncProfiler.TYPE));
+    assertFalse(provider.canProvide(null));
+    assertFalse(provider.canProvide(""));
+    assertFalse(provider.canProvide("unknown"));
+
+    assertNotNull(provider.provide(ConfigProvider.getInstance()));
+  }
+
+  @ParameterizedTest
+  @MethodSource("profilingModes")
+  void testStartCmd(boolean cpu, boolean alloc) {
+    Properties props = new Properties();
+    props.put(ProfilingConfig.PROFILING_ASYNC_CPU_ENABLED, Boolean.toString(cpu));
+    props.put(ProfilingConfig.PROFILING_ASYNC_ALLOC_ENABLED, Boolean.toString(alloc));
+
+    AuxiliaryAsyncProfiler profiler =
+        new AuxiliaryAsyncProfiler(ConfigProvider.withPropertiesOverride(props));
+
+    Path targetFile = Paths.get("/tmp/target.jfr");
+    String cmd = profiler.cmdStartProfiling(targetFile);
+
+    if (profiler.enabledModes().contains(ProfilingMode.CPU)) {
+      assertTrue(cmd.contains("event=itimer"));
+    }
+    if (profiler.enabledModes().contains(ProfilingMode.ALLOCATION)) {
+      assertTrue(cmd.contains("event=alloc") || cmd.contains("alloc="));
+    }
+  }
+
+  private static Stream<Arguments> profilingModes() {
+    return Stream.of(
+        Arguments.of(false, false),
+        Arguments.of(false, true),
+        Arguments.of(true, false),
+        Arguments.of(true, true));
+  }
+}

--- a/dd-java-agent/agent-profiling/profiling-auxiliary/profiling-auxiliary.gradle
+++ b/dd-java-agent/agent-profiling/profiling-auxiliary/profiling-auxiliary.gradle
@@ -1,0 +1,24 @@
+apply from: "$rootDir/gradle/java.gradle"
+
+//// We have some general logging paths that are hard to test
+//minimumInstructionCoverage = 0.8
+minimumBranchCoverage = 0.7
+
+excludedClassesCoverage += [// an enum with no additional functionality
+  'com.datadog.profiling.auxiliary.ProfilingMode']
+
+dependencies {
+  api deps.slf4j
+  api project(':dd-java-agent:agent-profiling:profiling-controller')
+
+  annotationProcessor deps.autoserviceProcessor
+  compileOnly deps.autoserviceAnnotation
+
+  testImplementation deps.junit5
+  testImplementation deps.mockito
+  testCompile deps.autoserviceAnnotation
+  testAnnotationProcessor deps.autoserviceProcessor
+}
+
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8

--- a/dd-java-agent/agent-profiling/profiling-auxiliary/src/main/java/com/datadog/profiling/auxiliary/AuxiliaryImplementation.java
+++ b/dd-java-agent/agent-profiling/profiling-auxiliary/src/main/java/com/datadog/profiling/auxiliary/AuxiliaryImplementation.java
@@ -1,0 +1,89 @@
+package com.datadog.profiling.auxiliary;
+
+import com.datadog.profiling.controller.OngoingRecording;
+import com.datadog.profiling.controller.RecordingData;
+import datadog.trace.bootstrap.config.provider.ConfigProvider;
+import java.util.Collections;
+import java.util.Set;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/** An interface to be implemented by a particular auxiliary profiler implementation */
+public interface AuxiliaryImplementation {
+  /** A singleton representing a no-op auxiliary implementation */
+  AuxiliaryImplementation NULL =
+      new AuxiliaryImplementation() {
+        @Override
+        public boolean isAvailable() {
+          return false;
+        }
+
+        @Override
+        public OngoingRecording start() {
+          return null;
+        }
+
+        @Override
+        public RecordingData stop(OngoingRecording recording) {
+          return null;
+        }
+
+        @Override
+        public Set<ProfilingMode> enabledModes() {
+          return Collections.emptySet();
+        }
+      };
+
+  /**
+   * An implementation provider.<br>
+   * A provider can respond to a requested profiler type and provide the corresponding {@linkplain
+   * AuxiliaryImplementation} instance.
+   */
+  interface Provider {
+    /**
+     * Check whether this provider can handle this particular profiler type
+     *
+     * @param expectedType the expected profiler type
+     * @return {@literal true} when the provider can handle this profiler type
+     */
+    boolean canProvide(@Nonnull String expectedType);
+
+    /**
+     * Create a new {@linkplain AuxiliaryImplementation} instance using the provided {@linkplain
+     * ConfigProvider}
+     *
+     * @param configProvider the configuration
+     * @return a new {@linkplain AuxiliaryImplementation} instance
+     */
+    @Nonnull
+    AuxiliaryImplementation provide(@Nonnull ConfigProvider configProvider);
+  }
+
+  /**
+   * Checks whether this particular implementation is available.<br>
+   * The availability depends on the environment and agent settings.
+   *
+   * @return {@literal true} if this implementation is available
+   */
+  boolean isAvailable();
+
+  /** @return a set of {@link ProfilingMode profiling modes} enabled for this implementation */
+  @Nonnull
+  Set<ProfilingMode> enabledModes();
+
+  /**
+   * Start the profiling process and open a new {@linkplain OngoingRecording} instance
+   *
+   * @return the associated {@linkplain OngoingRecording} instance or {@literal null}
+   */
+  @Nullable
+  OngoingRecording start();
+
+  /**
+   * Stop the profiling.
+   *
+   * @param recording the associated {@linkplain OngoingRecording} instance or {@literal null}
+   */
+  @Nullable
+  RecordingData stop(OngoingRecording recording);
+}

--- a/dd-java-agent/agent-profiling/profiling-auxiliary/src/main/java/com/datadog/profiling/auxiliary/AuxiliaryProfiler.java
+++ b/dd-java-agent/agent-profiling/profiling-auxiliary/src/main/java/com/datadog/profiling/auxiliary/AuxiliaryProfiler.java
@@ -1,0 +1,110 @@
+package com.datadog.profiling.auxiliary;
+
+import com.datadog.profiling.controller.OngoingRecording;
+import datadog.trace.api.config.ProfilingConfig;
+import datadog.trace.bootstrap.config.provider.ConfigProvider;
+import java.util.ServiceLoader;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A pluggable auxiliary profiler.<br>
+ * An auxiliary profiler is an external profiler implementation which provides an added value on top
+ * of the built in JFR. An example of such auxiliary profiler would be <a
+ * href="https://github.com/jvm-profiling-tools/async-profiler">Async Profiler</a> <br>
+ * <br>
+ * The profiler implementations must extend {@linkplain AuxiliaryImplementation} interface and are
+ * instantiated via an {@linkplain AuxiliaryImplementation.Provider} instance registered in {@code
+ * META-INF/services}.<br>
+ * The actual auxiliary implementaion is selected via setting the {@linkplain
+ * ProfilingConfig#PROFILING_AUXILIARY_TYPE} configuration key to a value which is recognized by a
+ * particular implementation provider.
+ */
+public final class AuxiliaryProfiler {
+  Logger log = LoggerFactory.getLogger(AuxiliaryProfiler.class);
+
+  private static final class Singleton {
+    private static final AuxiliaryProfiler INSTANCE = new AuxiliaryProfiler();
+  }
+
+  private final AuxiliaryImplementation implementation;
+
+  private AuxiliaryProfiler() {
+    this(ConfigProvider.getInstance());
+  }
+
+  AuxiliaryProfiler(ConfigProvider configProvider) {
+    String auxilliaryType =
+        configProvider.getString(
+            ProfilingConfig.PROFILING_AUXILIARY_TYPE,
+            ProfilingConfig.PROFILING_AUXILIARY_TYPE_DEFAULT);
+    log.debug("Requested auxiliary profiler: {}", auxilliaryType);
+    AuxiliaryImplementation impl = AuxiliaryImplementation.NULL;
+    log.debug("Iterating auxilliary implementation providers");
+    for (AuxiliaryImplementation.Provider provider :
+        ServiceLoader.load(
+            AuxiliaryImplementation.Provider.class, AuxiliaryProfiler.class.getClassLoader())) {
+      log.debug(
+          "Checking auxilliary implementation {}: {}",
+          provider,
+          provider.canProvide(auxilliaryType));
+      if (provider.canProvide(auxilliaryType)) {
+        impl = provider.provide(configProvider);
+        break;
+      }
+    }
+    this.implementation = impl != null ? impl : AuxiliaryImplementation.NULL;
+  }
+
+  AuxiliaryProfiler(AuxiliaryImplementation impl) {
+    this.implementation = impl;
+  }
+
+  /**
+   * Retrieve the signleton instance using the implementation specified in the agent configuration.
+   *
+   * @return the signleton instance using the implementation specified in the * agent configuration
+   */
+  public static AuxiliaryProfiler getInstance() {
+    return Singleton.INSTANCE;
+  }
+
+  /**
+   * Check whether the auxiliary profiler is enabled.<br>
+   * In order for the profiler to be enabled there must be at least one implementation registered
+   * and the configuration must be set to use one of the registered implementations.
+   *
+   * @return {@literal true} if the auxiliary profiler is enabled
+   */
+  public boolean isEnabled() {
+    return implementation.isAvailable();
+  }
+
+  /**
+   * Start the auxiliary recording
+   *
+   * @return the corresponding {@linkplain OngoingRecording}
+   */
+  public OngoingRecording start() {
+    return implementation.start();
+  }
+
+  /**
+   * Stop the ongoing recording
+   *
+   * @param recording the ongoing recording
+   */
+  public void stop(OngoingRecording recording) {
+    implementation.stop(recording);
+  }
+
+  /**
+   * Query the currently enabled {@link ProfilingMode profiling modes}
+   *
+   * @return the currently enabled {@link ProfilingMode profiling modes}
+   */
+  public Set<ProfilingMode> enabledModes() {
+    return implementation.enabledModes();
+  }
+}

--- a/dd-java-agent/agent-profiling/profiling-auxiliary/src/main/java/com/datadog/profiling/auxiliary/AuxiliaryProfiler.java
+++ b/dd-java-agent/agent-profiling/profiling-auxiliary/src/main/java/com/datadog/profiling/auxiliary/AuxiliaryProfiler.java
@@ -41,12 +41,12 @@ public final class AuxiliaryProfiler {
             ProfilingConfig.PROFILING_AUXILIARY_TYPE_DEFAULT);
     log.debug("Requested auxiliary profiler: {}", auxilliaryType);
     AuxiliaryImplementation impl = AuxiliaryImplementation.NULL;
-    log.debug("Iterating auxilliary implementation providers");
+    log.debug("Iterating auxiliary implementation providers");
     for (AuxiliaryImplementation.Provider provider :
         ServiceLoader.load(
             AuxiliaryImplementation.Provider.class, AuxiliaryProfiler.class.getClassLoader())) {
       log.debug(
-          "Checking auxilliary implementation {}: {}",
+          "Checking auxiliary implementation {}: {}",
           provider,
           provider.canProvide(auxilliaryType));
       if (provider.canProvide(auxilliaryType)) {

--- a/dd-java-agent/agent-profiling/profiling-auxiliary/src/main/java/com/datadog/profiling/auxiliary/AuxiliaryRecordingData.java
+++ b/dd-java-agent/agent-profiling/profiling-auxiliary/src/main/java/com/datadog/profiling/auxiliary/AuxiliaryRecordingData.java
@@ -1,0 +1,91 @@
+package com.datadog.profiling.auxiliary;
+
+import com.datadog.profiling.controller.RecordingData;
+import com.datadog.profiling.controller.RecordingInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.SequenceInputStream;
+import java.time.Instant;
+import java.util.Enumeration;
+import javax.annotation.Nonnull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Allows creating auxiliary multi-part recordings.<br>
+ * A multi-part recording consists of several self-standing recordings simply concatenated into one
+ * binary file.
+ */
+public final class AuxiliaryRecordingData extends RecordingData {
+  private static final Logger log = LoggerFactory.getLogger(AuxiliaryRecordingData.class);
+
+  private static final byte[] EMPTY_ARRAY = new byte[0];
+
+  private final RecordingData mainData;
+  private final RecordingData[] secondaryData;
+
+  public AuxiliaryRecordingData(
+      Instant start, Instant end, @Nonnull RecordingData main, RecordingData... secondary) {
+    super(start, end);
+    if (main == null) {
+      throw new IllegalArgumentException("Main data must be specified and not null");
+    }
+    this.mainData = main;
+    this.secondaryData = secondary;
+  }
+
+  @Nonnull
+  @Override
+  public RecordingInputStream getStream() throws IOException {
+    RecordingInputStream mainStream = mainData.getStream();
+
+    if (mainStream.isEmpty()) {
+      log.debug("Main stream is empty");
+      // do not append the auxiliary data to an empty main stream
+      return mainStream;
+    }
+
+    Enumeration<InputStream> streams =
+        new Enumeration<InputStream>() {
+          int position = -1;
+
+          @Override
+          public boolean hasMoreElements() {
+            return position < secondaryData.length;
+          }
+
+          @Override
+          public InputStream nextElement() {
+            try {
+              return position == -1 ? mainStream : secondaryData[position].getStream();
+            } catch (IOException e) {
+              if (log.isDebugEnabled()) {
+                log.warn(
+                    "Unable to retrieve {} data stream at position",
+                    position == -1 ? "main" : "auxiliary");
+              }
+            } finally {
+              position++;
+            }
+            return new ByteArrayInputStream(EMPTY_ARRAY);
+          }
+        };
+
+    return new RecordingInputStream(new SequenceInputStream(streams));
+  }
+
+  @Override
+  public void release() {
+    mainData.release();
+    for (RecordingData data : secondaryData) {
+      data.release();
+    }
+  }
+
+  @Nonnull
+  @Override
+  public String getName() {
+    return mainData.getName();
+  }
+}

--- a/dd-java-agent/agent-profiling/profiling-auxiliary/src/main/java/com/datadog/profiling/auxiliary/AuxiliaryRecordingData.java
+++ b/dd-java-agent/agent-profiling/profiling-auxiliary/src/main/java/com/datadog/profiling/auxiliary/AuxiliaryRecordingData.java
@@ -2,15 +2,9 @@ package com.datadog.profiling.auxiliary;
 
 import com.datadog.profiling.controller.RecordingData;
 import com.datadog.profiling.controller.RecordingInputStream;
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.SequenceInputStream;
 import java.time.Instant;
-import java.util.Enumeration;
 import javax.annotation.Nonnull;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Allows creating auxiliary multi-part recordings.<br>
@@ -18,10 +12,6 @@ import org.slf4j.LoggerFactory;
  * binary file.
  */
 public final class AuxiliaryRecordingData extends RecordingData {
-  private static final Logger log = LoggerFactory.getLogger(AuxiliaryRecordingData.class);
-
-  private static final byte[] EMPTY_ARRAY = new byte[0];
-
   private final RecordingData mainData;
   private final RecordingData[] secondaryData;
 
@@ -38,41 +28,8 @@ public final class AuxiliaryRecordingData extends RecordingData {
   @Nonnull
   @Override
   public RecordingInputStream getStream() throws IOException {
-    RecordingInputStream mainStream = mainData.getStream();
-
-    if (mainStream.isEmpty()) {
-      log.debug("Main stream is empty");
-      // do not append the auxiliary data to an empty main stream
-      return mainStream;
-    }
-
-    Enumeration<InputStream> streams =
-        new Enumeration<InputStream>() {
-          int position = -1;
-
-          @Override
-          public boolean hasMoreElements() {
-            return position < secondaryData.length;
-          }
-
-          @Override
-          public InputStream nextElement() {
-            try {
-              return position == -1 ? mainStream : secondaryData[position].getStream();
-            } catch (IOException e) {
-              if (log.isDebugEnabled()) {
-                log.warn(
-                    "Unable to retrieve {} data stream at position",
-                    position == -1 ? "main" : "auxiliary");
-              }
-            } finally {
-              position++;
-            }
-            return new ByteArrayInputStream(EMPTY_ARRAY);
-          }
-        };
-
-    return new RecordingInputStream(new SequenceInputStream(streams));
+    return new RecordingInputStream(
+        new AuxiliaryRecordingStreams(mainData, secondaryData).asSequenceInputStream());
   }
 
   @Override

--- a/dd-java-agent/agent-profiling/profiling-auxiliary/src/main/java/com/datadog/profiling/auxiliary/AuxiliaryRecordingStreams.java
+++ b/dd-java-agent/agent-profiling/profiling-auxiliary/src/main/java/com/datadog/profiling/auxiliary/AuxiliaryRecordingStreams.java
@@ -1,0 +1,59 @@
+package com.datadog.profiling.auxiliary;
+
+import com.datadog.profiling.controller.RecordingData;
+import com.datadog.profiling.controller.RecordingInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.SequenceInputStream;
+import java.util.Enumeration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+final class AuxiliaryRecordingStreams implements Enumeration<InputStream> {
+  private static final Logger log = LoggerFactory.getLogger(AuxiliaryRecordingStreams.class);
+
+  private static final byte[] EMPTY_ARRAY = new byte[0];
+
+  private int position = -1;
+  private boolean isMainDataEmpty = true;
+  private final RecordingData mainData;
+  private final RecordingData[] auxiliaryData;
+
+  AuxiliaryRecordingStreams(RecordingData mainData, RecordingData[] auxiliaryData) {
+    this.mainData = mainData;
+    this.auxiliaryData = auxiliaryData;
+  }
+
+  SequenceInputStream asSequenceInputStream() {
+    return new SequenceInputStream(this);
+  }
+
+  @Override
+  public boolean hasMoreElements() {
+    if (position == 0 && isMainDataEmpty) {
+      // if the main recording is empty do not attach any auxiliary streams
+      return false;
+    }
+    return position < auxiliaryData.length;
+  }
+
+  @Override
+  public InputStream nextElement() {
+    try {
+      if (position == -1) {
+        RecordingInputStream is = mainData.getStream();
+        isMainDataEmpty = is.isEmpty();
+        return is;
+      }
+      return auxiliaryData[position].getStream();
+    } catch (IOException e) {
+      if (log.isDebugEnabled()) {
+        log.warn("Unable to retrieve {} data stream", position == -1 ? "main" : "auxiliary", e);
+      }
+    } finally {
+      position++;
+    }
+    return new ByteArrayInputStream(EMPTY_ARRAY);
+  }
+}

--- a/dd-java-agent/agent-profiling/profiling-auxiliary/src/main/java/com/datadog/profiling/auxiliary/LibraryHelper.java
+++ b/dd-java-agent/agent-profiling/profiling-auxiliary/src/main/java/com/datadog/profiling/auxiliary/LibraryHelper.java
@@ -1,0 +1,71 @@
+package com.datadog.profiling.auxiliary;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+public final class LibraryHelper {
+  /**
+   * Locates a library on class-path (eg. in a JAR) and creates a publicly accessible temporary copy
+   * of the library which can then be used by the application by its absolute path.
+   *
+   * @param path The resource path designating the library - must start with {@code '/'} (absolute
+   *     path)
+   * @return The library absolute path. The caller should properly dispose of the file once it is
+   *     not needed. The file is marked for 'delete-on-exit' so it won't survive a JVM restart.
+   * @throws IOException
+   */
+  public static File libraryFromClasspath(String path) throws IOException {
+
+    if (!path.startsWith("/")) {
+      throw new IllegalArgumentException("The path has to be absolute (start with '/').");
+    }
+
+    // Get the file name (the last part in path)
+    File libPath = new File(path);
+    String filename = libPath.getName();
+
+    // Split filename to prexif and suffix (extension)
+    String prefix = "";
+    String suffix = null;
+    int idx = filename.lastIndexOf('.');
+    if (idx > -1) {
+      prefix = filename.substring(0, idx);
+      suffix = filename.substring(idx);
+    } else {
+      prefix = filename;
+      suffix = null;
+    }
+
+    // Check if the filename is okay
+    if (prefix.length() < 3) {
+      throw new IllegalArgumentException("The filename expects at least 3 characters.");
+    }
+
+    // Prepare temporary file
+    File temp = File.createTempFile(prefix, suffix);
+    temp.deleteOnExit();
+
+    // Prepare buffer for data copying
+    byte[] buffer = new byte[8192];
+    int readBytes;
+
+    // Open and check input stream
+    try (InputStream is = LibraryHelper.class.getResourceAsStream(path)) {
+      if (is == null) {
+        throw new FileNotFoundException("File " + path + " was not found on classpath.");
+      }
+
+      // Open output stream and copy data between source file in JAR and the temporary file
+      try (OutputStream os = new FileOutputStream(temp)) {
+        while ((readBytes = is.read(buffer)) != -1) {
+          os.write(buffer, 0, readBytes);
+        }
+      }
+    }
+    return temp;
+  }
+}

--- a/dd-java-agent/agent-profiling/profiling-auxiliary/src/main/java/com/datadog/profiling/auxiliary/ProfilingMode.java
+++ b/dd-java-agent/agent-profiling/profiling-auxiliary/src/main/java/com/datadog/profiling/auxiliary/ProfilingMode.java
@@ -1,0 +1,8 @@
+package com.datadog.profiling.auxiliary;
+
+/** Various profiling modes that can be supported by auxiliary profilers */
+public enum ProfilingMode {
+  CPU,
+  WALLCLOCK,
+  ALLOCATION;
+}

--- a/dd-java-agent/agent-profiling/profiling-auxiliary/src/test/java/com/datadog/profiling/auxiliary/AuxiliaryProfilerTest.java
+++ b/dd-java-agent/agent-profiling/profiling-auxiliary/src/test/java/com/datadog/profiling/auxiliary/AuxiliaryProfilerTest.java
@@ -1,0 +1,84 @@
+package com.datadog.profiling.auxiliary;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.datadog.profiling.controller.OngoingRecording;
+import datadog.trace.api.config.ProfilingConfig;
+import datadog.trace.bootstrap.config.provider.ConfigProvider;
+import java.util.EnumSet;
+import java.util.Properties;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
+import org.mockito.internal.verification.VerificationModeFactory;
+import org.mockito.stubbing.Answer;
+
+class AuxiliaryProfilerTest {
+  @ParameterizedTest
+  @ValueSource(strings = {"", "none", "custom"})
+  void testNoAuxiliary(String auxiliaryType) {
+    Properties props = new Properties();
+    props.put(ProfilingConfig.PROFILING_AUXILIARY_TYPE, auxiliaryType);
+    ConfigProvider configProvider = ConfigProvider.withPropertiesOverride(props);
+
+    AuxiliaryProfiler profiler = new AuxiliaryProfiler(configProvider);
+    assertFalse(profiler.isEnabled());
+    assertTrue(profiler.enabledModes().isEmpty());
+
+    OngoingRecording rec = profiler.start();
+    assertNull(rec);
+    assertDoesNotThrow(() -> profiler.stop(rec));
+  }
+
+  @Test
+  void testAuxiliaryFromServiceLoader() {
+    Properties props = new Properties();
+    props.put(ProfilingConfig.PROFILING_AUXILIARY_TYPE, TestAuxiliaryProfilerImplementation.TYPE);
+    ConfigProvider configProvider = ConfigProvider.withPropertiesOverride(props);
+
+    AuxiliaryProfiler profiler = new AuxiliaryProfiler(configProvider);
+    assertTrue(profiler.isEnabled());
+    assertFalse(profiler.enabledModes().isEmpty());
+
+    OngoingRecording rec = profiler.start();
+    assertNotNull(rec);
+    assertDoesNotThrow(() -> profiler.stop(rec));
+  }
+
+  @Test
+  void testAuxiliary() {
+    AuxiliaryImplementation impl = Mockito.mock(AuxiliaryImplementation.class);
+    Mockito.when(impl.isAvailable()).thenReturn(true);
+    Mockito.when(impl.enabledModes()).thenReturn(EnumSet.allOf(ProfilingMode.class));
+    Mockito.when(impl.start())
+        .then((Answer<OngoingRecording>) invocation -> Mockito.mock(OngoingRecording.class));
+
+    AuxiliaryProfiler profiler = new AuxiliaryProfiler(impl);
+
+    assertTrue(profiler.isEnabled());
+    assertFalse(profiler.enabledModes().isEmpty());
+
+    OngoingRecording rec = profiler.start();
+    assertNotNull(rec);
+    assertDoesNotThrow(() -> profiler.stop(rec));
+
+    Mockito.verify(impl, VerificationModeFactory.times(1)).start();
+    Mockito.verify(impl, VerificationModeFactory.times(1))
+        .stop(ArgumentMatchers.any(OngoingRecording.class));
+  }
+
+  @Test
+  void testSingletonDefault() {
+    // this will default to 'none' auxiliary profiler
+    AuxiliaryProfiler profiler = AuxiliaryProfiler.getInstance();
+
+    assertFalse(profiler.isEnabled());
+    assertTrue(profiler.enabledModes().isEmpty());
+
+    OngoingRecording rec = profiler.start();
+    assertNull(rec);
+    assertDoesNotThrow(() -> profiler.stop(rec));
+  }
+}

--- a/dd-java-agent/agent-profiling/profiling-auxiliary/src/test/java/com/datadog/profiling/auxiliary/AuxiliaryRecordingDataTest.java
+++ b/dd-java-agent/agent-profiling/profiling-auxiliary/src/test/java/com/datadog/profiling/auxiliary/AuxiliaryRecordingDataTest.java
@@ -1,0 +1,156 @@
+package com.datadog.profiling.auxiliary;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.datadog.profiling.controller.RecordingData;
+import com.datadog.profiling.controller.RecordingInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import javax.annotation.Nonnull;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class AuxiliaryRecordingDataTest {
+  private static final byte[] MAIN_DATA = new byte[] {1, 2, 3};
+  private static final byte[] AUXILIARY_DATA = new byte[] {4, 5, 6};
+
+  private static class TestRecordingData extends RecordingData {
+    private final String name;
+    private final byte[] testData;
+    volatile boolean isReleased = false;
+
+    public TestRecordingData(String name, Instant start, Instant end, byte[] testData) {
+      super(start, end);
+      this.name = name;
+      this.testData = testData;
+    }
+
+    @Nonnull
+    @Override
+    public RecordingInputStream getStream() throws IOException {
+      return new RecordingInputStream(new ByteArrayInputStream(testData));
+    }
+
+    @Override
+    public void release() {
+      isReleased = true;
+    }
+
+    @Nonnull
+    @Override
+    public String getName() {
+      return name;
+    }
+  }
+
+  @Test
+  void testNullMaindata() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new AuxiliaryRecordingData(Instant.now(), Instant.now(), null));
+  }
+
+  @Test
+  void testMainDataThrowing() throws IOException {
+    RecordingData mainData = Mockito.mock(RecordingData.class);
+    RecordingData auxiliaryData = Mockito.mock(RecordingData.class);
+
+    byte[] auxDataRaw = new byte[10];
+    Mockito.when(mainData.getStream()).thenThrow(new IOException());
+    Mockito.when(auxiliaryData.getStream())
+        .thenReturn(new RecordingInputStream(new ByteArrayInputStream(auxDataRaw)));
+
+    AuxiliaryRecordingData combined =
+        new AuxiliaryRecordingData(Instant.now(), Instant.now(), mainData, auxiliaryData);
+
+    assertThrows(IOException.class, () -> readFromStream(combined.getStream()));
+  }
+
+  @Test
+  void testAuxiliaryDataThrowing() throws IOException {
+    RecordingData mainData = Mockito.mock(RecordingData.class);
+    RecordingData auxiliaryData = Mockito.mock(RecordingData.class);
+
+    byte[] mainDataRaw = new byte[10];
+    Mockito.when(mainData.getStream())
+        .thenReturn(new RecordingInputStream(new ByteArrayInputStream(mainDataRaw)));
+    Mockito.when(auxiliaryData.getStream()).thenThrow(new IOException());
+
+    AuxiliaryRecordingData combined =
+        new AuxiliaryRecordingData(Instant.now(), Instant.now(), mainData, auxiliaryData);
+
+    assertEquals(mainDataRaw.length, readFromStream(combined.getStream()));
+  }
+
+  private int readFromStream(InputStream stream) throws IOException {
+    byte[] buffer = new byte[128];
+    int allBytes = 0;
+    int read = 0;
+    while ((read = stream.read(buffer)) > 0) {
+      allBytes += read;
+    }
+    return allBytes;
+  }
+
+  @Test
+  void testMainDataOnly() throws IOException {
+    String mainName = "main";
+    TestRecordingData mainData =
+        new TestRecordingData(
+            mainName, Instant.now(), Instant.now().plus(5, ChronoUnit.MINUTES), MAIN_DATA);
+    AuxiliaryRecordingData data =
+        new AuxiliaryRecordingData(
+            Instant.now(), Instant.now().plus(5, ChronoUnit.MINUTES), mainData);
+
+    assertEquals(mainName, data.getName());
+    assertFalse(mainData.isReleased);
+
+    byte[] buffer = new byte[3];
+    int read = data.getStream().read(buffer);
+    assertEquals(buffer.length, read);
+    assertArrayEquals(MAIN_DATA, buffer);
+
+    data.release();
+    assertTrue(mainData.isReleased);
+  }
+
+  @Test
+  void testCombinedData() throws IOException {
+    String mainName = "main";
+    String auxName = "auxiliary";
+    TestRecordingData mainData =
+        new TestRecordingData(
+            mainName, Instant.now(), Instant.now().plus(5, ChronoUnit.MINUTES), MAIN_DATA);
+    TestRecordingData auxiliaryData =
+        new TestRecordingData(
+            auxName, Instant.now(), Instant.now().plus(5, ChronoUnit.MINUTES), AUXILIARY_DATA);
+
+    AuxiliaryRecordingData data =
+        new AuxiliaryRecordingData(
+            Instant.now(), Instant.now().plus(5, ChronoUnit.MINUTES), mainData, auxiliaryData);
+
+    assertEquals(mainName, data.getName());
+    assertFalse(mainData.isReleased);
+    assertFalse(auxiliaryData.isReleased);
+
+    byte[] expected = new byte[6];
+    System.arraycopy(MAIN_DATA, 0, expected, 0, 3);
+    System.arraycopy(AUXILIARY_DATA, 0, expected, 3, 3);
+    byte[] buffer = new byte[6];
+    InputStream dataStream = data.getStream();
+    int pos = 0;
+    int read = 0;
+    while ((read = dataStream.read(buffer, pos, buffer.length - pos)) > 0) {
+      pos += read;
+    }
+    assertEquals(buffer.length, pos);
+    assertArrayEquals(expected, buffer);
+
+    data.release();
+    assertTrue(mainData.isReleased);
+    assertTrue(auxiliaryData.isReleased);
+  }
+}

--- a/dd-java-agent/agent-profiling/profiling-auxiliary/src/test/java/com/datadog/profiling/auxiliary/AuxiliaryRecordingDataTest.java
+++ b/dd-java-agent/agent-profiling/profiling-auxiliary/src/test/java/com/datadog/profiling/auxiliary/AuxiliaryRecordingDataTest.java
@@ -66,7 +66,7 @@ class AuxiliaryRecordingDataTest {
     AuxiliaryRecordingData combined =
         new AuxiliaryRecordingData(Instant.now(), Instant.now(), mainData, auxiliaryData);
 
-    assertThrows(IOException.class, () -> readFromStream(combined.getStream()));
+    assertEquals(0, readFromStream(combined.getStream()));
   }
 
   @Test

--- a/dd-java-agent/agent-profiling/profiling-auxiliary/src/test/java/com/datadog/profiling/auxiliary/LibraryHelperTest.java
+++ b/dd-java-agent/agent-profiling/profiling-auxiliary/src/test/java/com/datadog/profiling/auxiliary/LibraryHelperTest.java
@@ -1,0 +1,37 @@
+package com.datadog.profiling.auxiliary;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.File;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+class LibraryHelperTest {
+  @Test
+  void testExistingLib() {
+    File libFile = assertDoesNotThrow(() -> LibraryHelper.libraryFromClasspath("/libDummy.so"));
+    assertNotNull(libFile);
+    assertTrue(libFile.exists());
+  }
+
+  @Test
+  void testNonexistentLib() {
+    assertThrows(IOException.class, () -> LibraryHelper.libraryFromClasspath("/libNone.so"));
+  }
+
+  @Test
+  void testRelativePath() {
+    assertThrows(
+        IllegalArgumentException.class, () -> LibraryHelper.libraryFromClasspath("no_lib.so"));
+  }
+
+  @Test
+  void testTooShortPath() {
+    assertThrows(IllegalArgumentException.class, () -> LibraryHelper.libraryFromClasspath("/a.so"));
+  }
+
+  @Test
+  void testNoExtension() {
+    assertThrows(IOException.class, () -> LibraryHelper.libraryFromClasspath("/libNone"));
+  }
+}

--- a/dd-java-agent/agent-profiling/profiling-auxiliary/src/test/java/com/datadog/profiling/auxiliary/TestAuxiliaryProfilerImplementation.java
+++ b/dd-java-agent/agent-profiling/profiling-auxiliary/src/test/java/com/datadog/profiling/auxiliary/TestAuxiliaryProfilerImplementation.java
@@ -1,0 +1,51 @@
+package com.datadog.profiling.auxiliary;
+
+import com.datadog.profiling.controller.OngoingRecording;
+import com.datadog.profiling.controller.RecordingData;
+import com.google.auto.service.AutoService;
+import datadog.trace.bootstrap.config.provider.ConfigProvider;
+import java.util.EnumSet;
+import java.util.Set;
+import org.mockito.Mockito;
+
+public class TestAuxiliaryProfilerImplementation implements AuxiliaryImplementation {
+  public static final String TYPE = "test";
+
+  @AutoService(AuxiliaryImplementation.Provider.class)
+  public static final class Provider implements AuxiliaryImplementation.Provider {
+    @Override
+    public boolean canProvide(String expectedType) {
+      return expectedType.equals(TYPE);
+    }
+
+    @Override
+    public AuxiliaryImplementation provide(ConfigProvider configProvider) {
+      return new TestAuxiliaryProfilerImplementation();
+    }
+  }
+
+  boolean isStarted = false;
+  boolean isStopped = false;
+
+  @Override
+  public boolean isAvailable() {
+    return true;
+  }
+
+  @Override
+  public Set<ProfilingMode> enabledModes() {
+    return EnumSet.allOf(ProfilingMode.class);
+  }
+
+  @Override
+  public OngoingRecording start() {
+    isStarted = true;
+    return Mockito.mock(OngoingRecording.class);
+  }
+
+  @Override
+  public RecordingData stop(OngoingRecording recording) {
+    isStopped = true;
+    return Mockito.mock(RecordingData.class);
+  }
+}

--- a/dd-java-agent/agent-profiling/profiling-auxiliary/src/test/resources/libDummy.so
+++ b/dd-java-agent/agent-profiling/profiling-auxiliary/src/test/resources/libDummy.so
@@ -1,0 +1,1 @@
+# dummy lib

--- a/dd-java-agent/agent-profiling/profiling-auxiliary/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/dd-java-agent/agent-profiling/profiling-auxiliary/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/dd-java-agent/agent-profiling/profiling-controller-jfr/profiling-controller-jfr.gradle
+++ b/dd-java-agent/agent-profiling/profiling-controller-jfr/profiling-controller-jfr.gradle
@@ -20,30 +20,3 @@ excludedClassesCoverage += ['com.datadog.profiling.controller.jfr.JdkTypeIDs']
 
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
-
-['macos-x64', 'linux-x64', 'linux-x86', 'linux-musl-x64', 'linux-arm', 'linux-aarch64'].each {
-  def platform = it
-
-  tasks.create(type: Download, name: "downloadAsyncProfiler_${platform}") {
-    src "https://github.com/jvm-profiling-tools/async-profiler/releases/download/v2.0/async-profiler-2.0-${platform}.tar.gz"
-    dest "${buildDir}/external/"
-    overwrite false
-    doLast {
-      copy {
-        from tarTree(resources.gzip("${buildDir}/external/async-profiler-2.0-${platform}.tar.gz"))
-        into "${buildDir}/external/"
-      }
-    }
-    doFirst {
-      mkdir "${buildDir}/external/"
-    }
-  }
-  def rsrcTask = tasks.create(type: Copy, name: "asyncProfilerResources_${platform}") {
-    dependsOn "downloadAsyncProfiler_${platform}"
-    from "${buildDir}/external/async-profiler-2.0-${platform}/build/"
-    into "${buildDir}/resources/main/native-libs/${platform}/"
-    include '**/*.so'
-  }
-
-  processResources.dependsOn "asyncProfilerResources_${platform}"
-}

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/profiling-controller-openjdk.gradle
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/profiling-controller-openjdk.gradle
@@ -16,6 +16,7 @@ apply plugin: 'idea'
 dependencies {
   api deps.slf4j
   api project(':internal-api')
+  api project(':dd-java-agent:agent-profiling:profiling-auxiliary')
   api project(':dd-java-agent:agent-profiling:profiling-controller')
   api project(':dd-java-agent:agent-profiling:profiling-controller-jfr')
 

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkController.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkController.java
@@ -28,7 +28,6 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
-import jdk.jfr.Recording;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -152,12 +151,7 @@ public final class OpenJdkController implements Controller {
 
   @Override
   public OpenJdkOngoingRecording createRecording(final String recordingName) {
-    final Recording recording = new Recording();
-    recording.setName(recordingName);
-    recording.setSettings(recordingSettings);
-    recording.setMaxSize(RECORDING_MAX_SIZE);
-    recording.setMaxAge(RECORDING_MAX_AGE);
-    recording.start();
-    return new OpenJdkOngoingRecording(recording);
+    return new OpenJdkOngoingRecording(
+        recordingName, recordingSettings, RECORDING_MAX_SIZE, RECORDING_MAX_AGE);
   }
 }

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkOngoingRecording.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkOngoingRecording.java
@@ -74,6 +74,12 @@ public class OpenJdkOngoingRecording implements OngoingRecording {
             log.info("Disabling built-in allocation profiling events");
             recording.disable("jdk.ObjectAllocationOutsideTLAB");
             recording.disable("jdk.ObjectAllocationInNewTLAB");
+            recording.disable("jdk.ObjectAllocationSample");
+            break;
+          }
+        case WALLCLOCK:
+          {
+            // do nothing here for now - this mode is not really supported yet
             break;
           }
         default:

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkOngoingRecording.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkOngoingRecording.java
@@ -1,31 +1,105 @@
 package com.datadog.profiling.controller.openjdk;
 
+import com.datadog.profiling.auxiliary.AuxiliaryProfiler;
+import com.datadog.profiling.auxiliary.AuxiliaryRecordingData;
+import com.datadog.profiling.auxiliary.ProfilingMode;
 import com.datadog.profiling.controller.OngoingRecording;
+import com.datadog.profiling.controller.RecordingData;
+import java.time.Duration;
 import java.time.Instant;
+import java.util.Map;
 import jdk.jfr.FlightRecorder;
 import jdk.jfr.Recording;
 import jdk.jfr.RecordingState;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class OpenJdkOngoingRecording implements OngoingRecording {
+  private static final Logger log = LoggerFactory.getLogger(OpenJdkOngoingRecording.class);
 
   private final Recording recording;
+  private final OngoingRecording auxiliaryRecording;
+  private final AuxiliaryProfiler auxiliaryProfiler;
 
-  OpenJdkOngoingRecording(final Recording recording) {
+  OpenJdkOngoingRecording(
+      String recordingName, Map<String, String> settings, int maxSize, Duration maxAge) {
+    log.debug("Creating new recording: {}", recordingName);
+    recording = new Recording();
+    recording.setName(recordingName);
+    recording.setSettings(settings);
+    recording.setMaxSize(maxSize);
+    recording.setMaxAge(maxAge);
+    this.auxiliaryProfiler = AuxiliaryProfiler.getInstance();
+    if (auxiliaryProfiler.isEnabled()) {
+      auxiliaryRecording = auxiliaryProfiler.start();
+      if (auxiliaryRecording != null) {
+        disableOverridenEvents();
+      }
+    } else {
+      auxiliaryRecording = null;
+    }
+    recording.start();
+    log.debug("Recording {} started", recordingName);
+  }
+
+  OpenJdkOngoingRecording(Recording recording) {
     this.recording = recording;
+    this.auxiliaryProfiler = AuxiliaryProfiler.getInstance();
+    if (auxiliaryProfiler.isEnabled()) {
+      auxiliaryRecording = auxiliaryProfiler.start();
+      if (auxiliaryRecording != null) {
+        disableOverridenEvents();
+      }
+    } else {
+      auxiliaryRecording = null;
+    }
+    recording.start();
+    log.debug("Recording {} started", recording.getName());
+  }
+
+  private void disableOverridenEvents() {
+    for (ProfilingMode mode : auxiliaryProfiler.enabledModes()) {
+      switch (mode) {
+        case CPU:
+          {
+            // CPU execution profiling will take over these events
+            log.info("Disabling built-in CPU profiling events");
+            recording.disable("jdk.ExecutionSample");
+            recording.disable("jdk.NativeMethodSample");
+            break;
+          }
+        case ALLOCATION:
+          {
+            // allocation profiling will take over these events
+            log.info("Disabling built-in allocation profiling events");
+            recording.disable("jdk.ObjectAllocationOutsideTLAB");
+            recording.disable("jdk.ObjectAllocationInNewTLAB");
+            break;
+          }
+        default:
+          {
+            // do nothing
+          }
+      }
+    }
   }
 
   @Override
-  public OpenJdkRecordingData stop() {
+  public RecordingData stop() {
     if (recording.getState() != RecordingState.RUNNING) {
       throw new IllegalStateException("Cannot stop recording that is not running");
     }
 
     recording.stop();
-    return new OpenJdkRecordingData(recording);
+    OpenJdkRecordingData mainData = new OpenJdkRecordingData(recording);
+    return auxiliaryRecording != null
+        ? new AuxiliaryRecordingData(
+            mainData.getStart(), mainData.getEnd(), mainData, auxiliaryRecording.stop())
+        : mainData;
   }
 
   @Override
-  public OpenJdkRecordingData snapshot(final Instant start) {
+  public RecordingData snapshot(final Instant start) {
     if (recording.getState() != RecordingState.RUNNING) {
       throw new IllegalStateException("Cannot snapshot recording that is not running");
     }
@@ -35,11 +109,19 @@ public class OpenJdkOngoingRecording implements OngoingRecording {
     // Since we just requested a snapshot, the end time of the snapshot will be
     // very close to now, so use that end time to minimize the risk of gaps or
     // overlaps in the data.
-    return new OpenJdkRecordingData(snapshot, start, snapshot.getStopTime());
+    OpenJdkRecordingData openJdkData =
+        new OpenJdkRecordingData(snapshot, start, snapshot.getStopTime());
+    return auxiliaryRecording != null
+        ? new AuxiliaryRecordingData(
+            start, snapshot.getStopTime(), openJdkData, auxiliaryRecording.snapshot(start))
+        : openJdkData;
   }
 
   @Override
   public void close() {
     recording.close();
+    if (auxiliaryRecording != null) {
+      auxiliaryRecording.close();
+    }
   }
 }

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/test/java/com/datadog/profiling/controller/openjdk/OpenJdkControllerTest.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/test/java/com/datadog/profiling/controller/openjdk/OpenJdkControllerTest.java
@@ -74,7 +74,8 @@ public class OpenJdkControllerTest {
   public void testOldObjectSampleIsStillOverriddenThroughConfig() throws Exception {
     when(config.isProfilingHeapEnabled()).thenReturn(true);
     OpenJdkController controller = new OpenJdkController(config);
-    try (final Recording recording = controller.createRecording(TEST_NAME).stop().getRecording()) {
+    try (final Recording recording =
+        ((OpenJdkRecordingData) controller.createRecording(TEST_NAME).stop()).getRecording()) {
       assertEquals(
           Boolean.parseBoolean(recording.getSettings().get("jdk.OldObjectSample#enabled")), true);
     }

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/test/java/com/datadog/profiling/controller/openjdk/OpenJdkControllerTest.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/test/java/com/datadog/profiling/controller/openjdk/OpenJdkControllerTest.java
@@ -3,8 +3,10 @@ package com.datadog.profiling.controller.openjdk;
 import static datadog.trace.api.Platform.isJavaVersion;
 import static datadog.trace.api.Platform.isJavaVersionAtLeast;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
+import com.datadog.profiling.controller.RecordingData;
 import com.datadog.profiling.controller.jfr.JfpUtilsTest;
 import datadog.trace.api.Config;
 import jdk.jfr.Recording;
@@ -24,7 +26,9 @@ public class OpenJdkControllerTest {
   public void testCreateContinuousRecording() throws Exception {
     when(config.getProfilingTemplateOverrideFile()).thenReturn(JfpUtilsTest.OVERRIDES);
     OpenJdkController controller = new OpenJdkController(config);
-    try (final Recording recording = controller.createRecording(TEST_NAME).stop().getRecording()) {
+    RecordingData data = controller.createRecording(TEST_NAME).stop();
+    assertTrue(data instanceof OpenJdkRecordingData);
+    try (final Recording recording = ((OpenJdkRecordingData) data).getRecording()) {
       assertEquals(TEST_NAME, recording.getName());
       assertEquals(OpenJdkController.RECORDING_MAX_SIZE, recording.getMaxSize());
       assertEquals(OpenJdkController.RECORDING_MAX_AGE, recording.getMaxAge());
@@ -34,7 +38,9 @@ public class OpenJdkControllerTest {
   @Test
   public void testOldObjectSampleIsDisabledOnUnsupportedVersion() throws Exception {
     OpenJdkController controller = new OpenJdkController(config);
-    try (final Recording recording = controller.createRecording(TEST_NAME).stop().getRecording()) {
+    RecordingData data = controller.createRecording(TEST_NAME).stop();
+    assertTrue(data instanceof OpenJdkRecordingData);
+    try (final Recording recording = ((OpenJdkRecordingData) data).getRecording()) {
       if (!((isJavaVersion(11) && isJavaVersionAtLeast(11, 0, 12))
           || (isJavaVersion(15) && isJavaVersionAtLeast(15, 0, 4))
           || (isJavaVersion(16) && isJavaVersionAtLeast(16, 0, 2))
@@ -51,7 +57,9 @@ public class OpenJdkControllerTest {
     when(config.getProfilingTemplateOverrideFile())
         .thenReturn(JfpUtilsTest.OVERRIDES_OLD_OBJECT_SAMPLE);
     OpenJdkController controller = new OpenJdkController(config);
-    try (final Recording recording = controller.createRecording(TEST_NAME).stop().getRecording()) {
+    RecordingData data = controller.createRecording(TEST_NAME).stop();
+    assertTrue(data instanceof OpenJdkRecordingData);
+    try (final Recording recording = ((OpenJdkRecordingData) data).getRecording()) {
       if (!((isJavaVersion(11) && isJavaVersionAtLeast(11, 0, 12))
           || (isJavaVersion(15) && isJavaVersionAtLeast(15, 0, 4))
           || (isJavaVersion(16) && isJavaVersionAtLeast(16, 0, 2))
@@ -75,7 +83,9 @@ public class OpenJdkControllerTest {
   @Test
   public void testObjectAllocationIsDisabledOnUnsupportedVersion() throws Exception {
     OpenJdkController controller = new OpenJdkController(config);
-    try (final Recording recording = controller.createRecording(TEST_NAME).stop().getRecording()) {
+    RecordingData data = controller.createRecording(TEST_NAME).stop();
+    assertTrue(data instanceof OpenJdkRecordingData);
+    try (final Recording recording = ((OpenJdkRecordingData) data).getRecording()) {
       if (!(isJavaVersionAtLeast(16))) {
         assertEquals(
             false,
@@ -94,7 +104,9 @@ public class OpenJdkControllerTest {
     when(config.getProfilingTemplateOverrideFile())
         .thenReturn(JfpUtilsTest.OVERRIDES_OBJECT_ALLOCATION);
     OpenJdkController controller = new OpenJdkController(config);
-    try (final Recording recording = controller.createRecording(TEST_NAME).stop().getRecording()) {
+    RecordingData data = controller.createRecording(TEST_NAME).stop();
+    assertTrue(data instanceof OpenJdkRecordingData);
+    try (final Recording recording = ((OpenJdkRecordingData) data).getRecording()) {
       if (!(isJavaVersionAtLeast(16))) {
         assertEquals(
             true,
@@ -112,7 +124,8 @@ public class OpenJdkControllerTest {
   public void testObjectAllocationIsStillOverriddenThroughConfig() throws Exception {
     when(config.isProfilingAllocationEnabled()).thenReturn(true);
     OpenJdkController controller = new OpenJdkController(config);
-    try (final Recording recording = controller.createRecording(TEST_NAME).stop().getRecording()) {
+    try (final Recording recording =
+        ((OpenJdkRecordingData) controller.createRecording(TEST_NAME).stop()).getRecording()) {
       assertEquals(
           Boolean.parseBoolean(
               recording.getSettings().get("jdk.ObjectAllocationInNewTLAB#enabled")),
@@ -127,7 +140,9 @@ public class OpenJdkControllerTest {
   @Test
   public void testNativeMethodSampleIsDisabledOnUnsupportedVersion() throws Exception {
     OpenJdkController controller = new OpenJdkController(config);
-    try (final Recording recording = controller.createRecording(TEST_NAME).stop().getRecording()) {
+    RecordingData data = controller.createRecording(TEST_NAME).stop();
+    assertTrue(data instanceof OpenJdkRecordingData);
+    try (final Recording recording = ((OpenJdkRecordingData) data).getRecording()) {
       if (!((isJavaVersion(8) && isJavaVersionAtLeast(8, 0, 302)) || isJavaVersionAtLeast(11))) {
         assertEquals(
             false,
@@ -141,7 +156,9 @@ public class OpenJdkControllerTest {
     when(config.getProfilingTemplateOverrideFile())
         .thenReturn(JfpUtilsTest.OVERRIDES_NATIVE_METHOD_SAMPLE);
     OpenJdkController controller = new OpenJdkController(config);
-    try (final Recording recording = controller.createRecording(TEST_NAME).stop().getRecording()) {
+    RecordingData data = controller.createRecording(TEST_NAME).stop();
+    assertTrue(data instanceof OpenJdkRecordingData);
+    try (final Recording recording = ((OpenJdkRecordingData) data).getRecording()) {
       if (!((isJavaVersion(8) && isJavaVersionAtLeast(8, 0, 302)) || isJavaVersionAtLeast(11))) {
         assertEquals(
             true,

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/test/java/com/datadog/profiling/controller/openjdk/OpenJdkOngoingRecordingTest.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/test/java/com/datadog/profiling/controller/openjdk/OpenJdkOngoingRecordingTest.java
@@ -1,12 +1,11 @@
 package com.datadog.profiling.controller.openjdk;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.datadog.profiling.controller.RecordingData;
 import java.time.Instant;
 import jdk.jfr.Recording;
 import jdk.jfr.RecordingState;
@@ -42,7 +41,9 @@ public class OpenJdkOngoingRecordingTest {
 
   @Test
   public void testStop() {
-    assertEquals(recording, ongoingRecording.stop().getRecording());
+    RecordingData data = ongoingRecording.stop();
+    assertTrue(data instanceof OpenJdkRecordingData);
+    assertEquals(recording, ((OpenJdkRecordingData) data).getRecording());
 
     verify(recording).stop();
   }
@@ -62,12 +63,17 @@ public class OpenJdkOngoingRecordingTest {
 
   @Test
   public void testSnapshot() {
-    final OpenJdkRecordingData recordingData = ongoingRecording.snapshot(start);
+    final RecordingData recordingData = ongoingRecording.snapshot(start);
+    assertTrue(recordingData instanceof OpenJdkRecordingData);
     assertEquals(TEST_NAME, recordingData.getName());
     assertEquals(start, recordingData.getStart());
-    assertEquals(recordingData.getRecording().getStopTime(), recordingData.getEnd());
+    assertEquals(
+        ((OpenJdkRecordingData) recordingData).getRecording().getStopTime(),
+        recordingData.getEnd());
     assertNotEquals(
-        recording, recordingData.getRecording(), "make sure we didn't get our mocked recording");
+        recording,
+        ((OpenJdkRecordingData) recordingData).getRecording(),
+        "make sure we didn't get our mocked recording");
 
     // We got real recording so we should clean it up
     recordingData.release();

--- a/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/Controller.java
+++ b/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/Controller.java
@@ -18,8 +18,8 @@ package com.datadog.profiling.controller;
 import javax.annotation.Nonnull;
 
 /**
- * Interface for the low lever flight recorder control functionality. Needed since we will likely
- * want to support multiple version later.
+ * Interface for the low level flight recorder control functionality. Needed since we will likely
+ * want to support multiple versions later.
  */
 public interface Controller {
   /**

--- a/dd-java-agent/dd-java-agent.gradle
+++ b/dd-java-agent/dd-java-agent.gradle
@@ -185,7 +185,7 @@ tasks.register('checkAgentJarSize').configure {
   doLast {
     // Arbitrary limit to prevent unintentional increases to the agent jar size
     // Raise or lower as required
-    assert shadowJar.archiveFile.get().getAsFile().length() < 18 * 1024 * 1024
+    assert shadowJar.archiveFile.get().getAsFile().length() < 19 * 1024 * 1024
   }
 
   dependsOn "shadowJar"

--- a/dd-smoke-tests/profiling-integration-tests/src/test/java/datadog/smoketest/ProfilingIntegrationTest.java
+++ b/dd-smoke-tests/profiling-integration-tests/src/test/java/datadog/smoketest/ProfilingIntegrationTest.java
@@ -186,6 +186,8 @@ class ProfilingIntegrationTest {
       byte[] byteData = getParameter("chunk-data", byte[].class, firstRequestParameters);
       assertNotNull(byteData);
 
+      dumpJfrRecording(byteData);
+
       assertFalse(logHasErrors(logFilePath));
       IItemCollection events = JfrLoaderToolkit.loadEvents(new ByteArrayInputStream(byteData));
       assertTrue(events.hasItems());
@@ -217,6 +219,8 @@ class ProfilingIntegrationTest {
 
       byteData = getParameter("chunk-data", byte[].class, secondRequestParameters);
       assertNotNull(byteData);
+      dumpJfrRecording(byteData);
+
       events = JfrLoaderToolkit.loadEvents(new ByteArrayInputStream(byteData));
       assertTrue(events.hasItems());
       rangeStartAndEnd = getRangeStartAndEnd(events);
@@ -252,6 +256,15 @@ class ProfilingIntegrationTest {
         targetProcess.destroyForcibly();
       }
       targetProcess = null;
+    }
+  }
+
+  private void dumpJfrRecording(byte[] byteData) {
+    try {
+      Path dumpPath = Files.createTempFile("dd-dump-", ".jfr");
+      Files.write(dumpPath, byteData);
+      log.debug("Received profile stored at: {}", dumpPath.toAbsolutePath());
+    } catch (IOException ignored) {
     }
   }
 
@@ -564,7 +577,8 @@ class ProfilingIntegrationTest {
             "-Ddd.env=smoketest",
             "-Ddd.version=99",
             "-Ddd.profiling.enabled=true",
-            "-DD.profiling.agentless=" + (apiKey != null),
+            "-Ddd.profiling.auxiliary=async",
+            "-Ddd.profiling.agentless=" + (apiKey != null),
             "-Ddd.profiling.start-delay=" + profilingStartDelaySecs,
             "-Ddd.profiling.upload.period=" + profilingUploadPeriodSecs,
             "-Ddd.profiling.url=http://localhost:" + profilerPort,

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
@@ -45,6 +45,15 @@ public final class ProfilingConfig {
   public static final String PROFILING_EXCLUDE_AGENT_THREADS = "profiling.exclude.agent-threads";
   public static final String PROFILING_HOTSPOTS_ENABLED = "profiling.hotspots.enabled";
 
+  public static final String PROFILING_AUXILIARY_TYPE = "profiling.auxiliary";
+  public static final String PROFILING_AUXILIARY_TYPE_DEFAULT = "none";
+
+  public static final String PROFILING_ASYNC_LIBPATH = "profiling.async.lib";
+  public static final String PROFILING_ASYNC_ALLOC_ENABLED = "profiling.async.alloc.enabled";
+  public static final String PROFILING_ASYNC_ALLOC_INTERVAL = "profiling.async.alloc.interval";
+  public static final String PROFILING_ASYNC_ALLOC_INTERVAL_DEFAULT = "256k";
+  public static final String PROFILING_ASYNC_CPU_ENABLED = "profiling.async.cpu.enabled";
+
   public static final String PROFILING_LEGACY_TRACING_INTEGRATION =
       "profiling.legacy.tracing.integration";
   public static final String PROFILING_CHECKPOINTS_RECORD_CPU_TIME =

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -27,7 +27,7 @@ final class CachedData {
     mockito       : '3.5.10',
     moshi         : '1.9.2',
     testcontainers: '1.15.0-rc2',
-    jmc           : "8.0.0-SNAPSHOT",
+    jmc           : "8.1.0-SNAPSHOT",
     autoservice   : "1.0-rc7"
   ]
 
@@ -77,8 +77,6 @@ final class CachedData {
 
     jmc                  : [
       "org.openjdk.jmc:common:${versions.jmc}",
-      "org.openjdk.jmc:flightrecorder:${versions.jmc}",
-      "org.openjdk.jmc:flightrecorder:${versions.jmc}",
       "org.openjdk.jmc:flightrecorder:${versions.jmc}"
     ],
 

--- a/gradle/repositories.gradle
+++ b/gradle/repositories.gradle
@@ -11,4 +11,9 @@ repositories {
       snapshotsOnly()
     }
   }
+  maven {
+    // M2 package repository for the custom Datadog build of async-profiler
+    url 'https://raw.githubusercontent.com/DataDog/async-profiler/maven2'
+    name "GitHub - DD AsyncProfiler"
+  }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -44,6 +44,8 @@ include ':dd-java-agent:agent-logging'
 include ':dd-java-agent:load-generator'
 
 include ':dd-java-agent:agent-profiling'
+include ':dd-java-agent:agent-profiling:profiling-auxiliary'
+include ':dd-java-agent:agent-profiling:profiling-auxiliary-async'
 include ':dd-java-agent:agent-profiling:profiling-controller'
 include ':dd-java-agent:agent-profiling:profiling-controller-jfr'
 include ':dd-java-agent:agent-profiling:profiling-controller-openjdk'


### PR DESCRIPTION
With this change we will be able to use [Async Profiler](https://github.com/jvm-profiling-tools/async-profiler) to gather enhanced full-stack CPU samples instead of the built-in JFR execution (only Java) samples.

The integration is utilising the fact that it is legal to simply concatenate two or more JFR recordings into a single blob and the JFR parser(s) will deal with this by considering each part being a separate chunk but all chunks would form one single event stream. This also allows a small optimisation when the 'auxiliary' recordings can completely omit the metadata descriptions as the metadata is already described in the main JFR recording (this is true only if the auxiliary recordings are not adding new types which are not present in JDK).

---

The concept of auxiliary profiler(s) is decoupled from the async profiler, which happens to be just one of the possible implementations. Design-wise the main entry point is `AuxiliaryProfiler` class which will lookup registered providers of `AuxiliaryImplementation` interface using the standard service loader mechanism. 

Which of those providers will then be chosen to be used is defined in the agent config using the `profiling.auxiliary` key. The value of this key defaults to `none` which means that OOTB there will be no auxiliary profiler active. For the async profiler the value would be `async` and it can be set via the usual means (system property, env variable ...). Any failure to instantiate the picked auxiliary profiler implementation will result in deactivating the auxiliary profiler functionality but without further effects on the main profiler or the whole agent.

---

As for the async profiler integration - it can be configured via the usual means using the following keys:
- `profiling.async.cpu.enabled` - turns on/off the cpu profiling; defaults to `true`
- `profiling.async.alloc.enabled` - turns on/off the allocation profiling; defaults to `false` and should be used with utmost caution as it may cause quite unexpected overhead
- `profiling.async.alloc.interval` - when the allocation profiling is enabled the value of this key will specify the amount of allocated memory between two consecutive samples; for the details about allowed values see https://github.com/jvm-profiling-tools/async-profiler#allocation-profiling