### PR TITLE
Better activity recording for Apache HttpAsyncClient

### DIFF
--- a/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientInstrumentation.java
@@ -81,7 +81,7 @@ public class ApacheHttpAsyncClientInstrumentation extends Instrumenter.Tracing {
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static AgentSpan methodEnter(
         @Advice.Argument(value = 0, readOnly = false) HttpAsyncRequestProducer requestProducer,
-        @Advice.Argument(2) final HttpContext context,
+        @Advice.Argument(2) HttpContext context,
         @Advice.Argument(value = 3, readOnly = false) FutureCallback<?> futureCallback) {
 
       final TraceScope parentScope = activeScope();
@@ -92,6 +92,7 @@ public class ApacheHttpAsyncClientInstrumentation extends Instrumenter.Tracing {
       requestProducer = new DelegatingRequestProducer(clientSpan, requestProducer);
       futureCallback =
           new TraceContinuedFutureCallback(parentScope, clientSpan, context, futureCallback);
+      clientSpan.startThreadMigration();
 
       return clientSpan;
     }

--- a/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/BasicFutureInstrumentation.java
+++ b/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/BasicFutureInstrumentation.java
@@ -1,0 +1,56 @@
+package datadog.trace.instrumentation.apachehttpasyncclient;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static java.util.Collections.singletonMap;
+import static net.bytebuddy.matcher.ElementMatchers.declaresField;
+import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers;
+import datadog.trace.bootstrap.InstrumentationContext;
+import java.util.Map;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import org.apache.http.concurrent.BasicFuture;
+import org.apache.http.concurrent.FutureCallback;
+
+@AutoService(Instrumenter.class)
+public final class BasicFutureInstrumentation extends Instrumenter.Tracing {
+  public BasicFutureInstrumentation() {
+    super("httpasyncclient", "apache-httpasyncclient");
+  }
+
+  @Override
+  public Map<String, String> contextStore() {
+    return singletonMap(
+        "org.apache.http.concurrent.BasicFuture", "org.apache.http.concurrent.FutureCallback");
+  }
+
+  @Override
+  public ElementMatcher<? super TypeDescription> typeMatcher() {
+    return NameMatchers.<TypeDescription>named("org.apache.http.concurrent.BasicFuture")
+        .and(declaresField(named("callback")));
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(isConstructor(), getClass().getName() + "$StealCallback");
+  }
+
+  // TODO there are numerous cases of using context stores to access immutable private fields
+  //  where the field value is copied into a context field so it can be accessed via
+  //  instrumentation context (e.g. MongoDB), but this has a footprint cost and can't be used
+  //  for mutable fields. This mechanism could be enhanced to direct ContextStore.get to a
+  //  generated field accessor, which would eliminate both these concerns.
+  public static final class StealCallback {
+    @Advice.OnMethodExit
+    public static <T> void postConstruct(
+        @Advice.This BasicFuture<T> future,
+        @Advice.FieldValue("callback") FutureCallback<T> callback) {
+      // the callback can now be accessed elsewhere in the processing pipeline
+      InstrumentationContext.get(BasicFuture.class, FutureCallback.class).put(future, callback);
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/HttpAsyncClientExchangeHandlerInstrumentation.java
+++ b/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/HttpAsyncClientExchangeHandlerInstrumentation.java
@@ -1,0 +1,90 @@
+package datadog.trace.instrumentation.apachehttpasyncclient;
+
+import static datadog.trace.agent.tooling.ClassLoaderMatcher.hasClassesNamed;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers.implementsInterface;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static java.util.Collections.singletonMap;
+import static net.bytebuddy.matcher.ElementMatchers.declaresField;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers;
+import datadog.trace.bootstrap.InstrumentationContext;
+import java.util.Map;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import net.bytebuddy.matcher.ElementMatchers;
+import org.apache.http.concurrent.BasicFuture;
+import org.apache.http.concurrent.FutureCallback;
+
+@AutoService(Instrumenter.class)
+public class HttpAsyncClientExchangeHandlerInstrumentation extends Instrumenter.Tracing {
+
+  public HttpAsyncClientExchangeHandlerInstrumentation() {
+    super("httpasyncclient", "apache-httpasyncclient");
+  }
+
+  @Override
+  public ElementMatcher<ClassLoader> classLoaderMatcher() {
+    return hasClassesNamed("org.apache.http.nio.protocol.HttpAsyncClientExchangeHandler");
+  }
+
+  @Override
+  public ElementMatcher<? super TypeDescription> shortCutMatcher() {
+    return NameMatchers.<TypeDescription>namedOneOf(
+            "org.apache.http.impl.nio.client.DefaultClientExchangeHandlerImpl",
+            "org.apache.http.impl.nio.client.PipeliningClientExchangeHandlerImpl",
+            "org.apache.http.impl.nio.client.MinimalClientExchangeHandlerImpl")
+        .and(declaresField(named("resultFuture")));
+  }
+
+  @Override
+  public ElementMatcher<? super TypeDescription> hierarchyMatcher() {
+    // must ensure the field is declared (if it is no longer declared, we miss a profiler event,
+    // but tracing is unaffected
+    return ElementMatchers.<TypeDescription>declaresField(named("resultFuture"))
+        .and(
+            implementsInterface(
+                named("org.apache.http.nio.protocol.HttpAsyncClientExchangeHandler")));
+  }
+
+  @Override
+  public Map<String, String> contextStore() {
+    return singletonMap(
+        "org.apache.http.concurrent.BasicFuture", "org.apache.http.concurrent.FutureCallback");
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {
+      packageName + ".HttpHeadersInjectAdapter",
+      packageName + ".DelegatingRequestProducer",
+      packageName + ".TraceContinuedFutureCallback",
+      packageName + ".ApacheHttpAsyncClientDecorator"
+    };
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(
+        named("responseReceived")
+            .and(takesArguments(1).and(takesArgument(0, named("org.apache.http.HttpResponse")))),
+        getClass().getName() + "$ResponseReceived");
+  }
+
+  public static final class ResponseReceived {
+    // callback executed once the remote server responds
+    @Advice.OnMethodEnter
+    public static void responseReceived(
+        @Advice.FieldValue("resultFuture") BasicFuture<?> resultFuture) {
+      FutureCallback<?> callback =
+          InstrumentationContext.get(BasicFuture.class, FutureCallback.class).get(resultFuture);
+      if (callback instanceof TraceContinuedFutureCallback) {
+        ((TraceContinuedFutureCallback<?>) callback).responseReceived();
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/TraceContinuedFutureCallback.java
+++ b/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/TraceContinuedFutureCallback.java
@@ -29,6 +29,13 @@ public class TraceContinuedFutureCallback<T> implements FutureCallback<T> {
     this.delegate = delegate;
   }
 
+  public void responseReceived() {
+    // happens once the the response has been received,
+    // and captures activity like serialization which
+    // we want to notify profiling about
+    clientSpan.finishThreadMigration();
+  }
+
   @Override
   public void completed(final T result) {
     DECORATE.onResponse(clientSpan, context);

--- a/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/test/groovy/CheckpointEmissionTest.groovy
+++ b/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/test/groovy/CheckpointEmissionTest.groovy
@@ -1,0 +1,130 @@
+import datadog.trace.agent.test.AgentTestRunner
+import org.apache.http.HttpResponse
+import org.apache.http.client.config.RequestConfig
+import org.apache.http.concurrent.FutureCallback
+import org.apache.http.impl.nio.client.HttpAsyncClients
+import org.apache.http.message.BasicHeader
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+
+import java.util.concurrent.CountDownLatch
+
+import static datadog.trace.agent.test.server.http.TestHttpServer.httpServer
+import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
+import static datadog.trace.api.Checkpointer.END
+import static datadog.trace.api.Checkpointer.SPAN
+import static datadog.trace.api.Checkpointer.THREAD_MIGRATION
+
+class CheckpointEmissionTest extends AgentTestRunner {
+
+  @AutoCleanup
+  @Shared
+  def server = httpServer {
+    handlers {
+      prefix("/") {
+        handleDistributedRequest()
+        response.status(200).send("hello")
+      }
+    }
+  }
+
+  @Shared
+  RequestConfig requestConfig = RequestConfig.custom()
+  .setConnectTimeout(1000)
+  .setSocketTimeout(1000)
+  .build()
+
+  @AutoCleanup
+  @Shared
+  def client = HttpAsyncClients.custom()
+  .setDefaultRequestConfig(requestConfig)
+  .build()
+
+  def setupSpec() {
+    client.start()
+  }
+
+  def "emit checkpoints"() {
+    setup:
+    def runnerThreadName = Thread.currentThread().name
+    when:
+    runUnderTrace("parent") {
+      executeRequest("GET", server.address, [:])
+    }
+    // note that the test http server is also traced and needs to be accounted for below
+    TEST_WRITER.waitForTraces(2)
+    then:
+    3 * TEST_CHECKPOINTER.checkpoint(_, _, SPAN)
+    1 * TEST_CHECKPOINTER.checkpoint(_, _, THREAD_MIGRATION) >> {
+      assert Thread.currentThread().name == runnerThreadName
+    }
+    1 * TEST_CHECKPOINTER.checkpoint(_, _, THREAD_MIGRATION | END) >> {
+      assert Thread.currentThread().name.contains("I/O dispatcher")
+    }
+    3 * TEST_CHECKPOINTER.checkpoint(_, _, SPAN | END)
+    2 * TEST_CHECKPOINTER.onRootSpanPublished(_, _)
+    0 * _
+  }
+
+  def "emit checkpoints with callback"() {
+    setup:
+    def runnerThreadName = Thread.currentThread().name
+    when:
+    runUnderTrace("parent") {
+      executeRequest("GET", server.address, [:], {
+        runUnderTrace("child") {}
+      })
+    }
+    // note that the test http server is also traced and needs to be accounted for below
+    TEST_WRITER.waitForTraces(2)
+    then:
+    4 * TEST_CHECKPOINTER.checkpoint(_, _, SPAN)
+    1 * TEST_CHECKPOINTER.checkpoint(_, _, THREAD_MIGRATION) >> {
+      assert Thread.currentThread().name == runnerThreadName
+    }
+    1 * TEST_CHECKPOINTER.checkpoint(_, _, THREAD_MIGRATION | END)  >> {
+      assert Thread.currentThread().name.contains("I/O dispatcher")
+    }
+    4 * TEST_CHECKPOINTER.checkpoint(_, _, SPAN | END)
+    2 * TEST_CHECKPOINTER.onRootSpanPublished(_, _)
+    0 * _
+  }
+
+
+  def executeRequest(String method, URI uri, Map<String, String> headers, Closure callback = null) {
+    def request = new HttpUriRequest(method, uri)
+    headers.entrySet().each {
+      request.addHeader(new BasicHeader(it.key, it.value))
+    }
+
+    def latch = new CountDownLatch(callback == null ? 0 : 1)
+
+    def handler = callback == null ? null : new FutureCallback<HttpResponse>() {
+
+        @Override
+        void completed(HttpResponse result) {
+          callback()
+          latch.countDown()
+        }
+
+        @Override
+        void failed(Exception ex) {
+          latch.countDown()
+        }
+
+        @Override
+        void cancelled() {
+          latch.countDown()
+        }
+      }
+
+    try {
+      def response = client.execute(request, handler).get()
+      response.entity?.content?.close()
+      latch.await()
+      response.statusLine.statusCode
+    } finally {
+      blockUntilChildSpansFinished(1)
+    }
+  }
+}


### PR DESCRIPTION
HttpAsyncClient calls work like this

```
caller thread:              t0 |-| t1
server:                          |xxxxxxxxxxxxxx|
io thread:                                   t2 |----------| t3
```

Where `t0` is the time the request is made, `t1` is the request returns control to the caller (`t0`~`t1`), `t2` is when the client receives a response from the server and starts doing things like downloading and deserializing content, and `t3` is when the response is complete. If the server doesn't respond or there is an error, the gantt chart is similar.

Currently we only record that a span has started at `t0`, and that it has finished at `t3`. This PR emits an event at `t1` to indicate that span activity will migrate to an IO thread, and completes this migration at `t2` so that `[t2, t3]` can be correlated with profiling data.

The easiest way to do this is to modify the `BasicFuture` class so our callback can be extracted, which has another lifecycle method added.