### PR TITLE
Capture exceptions passed through our Netty handlers

### DIFF
--- a/dd-java-agent/instrumentation/netty-3.8/src/latestDepTest/groovy/Netty38ServerTest.groovy
+++ b/dd-java-agent/instrumentation/netty-3.8/src/latestDepTest/groovy/Netty38ServerTest.groovy
@@ -172,4 +172,9 @@ class Netty38ServerTest extends HttpServerTest<ServerBootstrap> {
   String expectedOperationName() {
     "netty.request"
   }
+
+  @Override
+  boolean hasExtraErrorInformation() {
+    true
+  }
 }

--- a/dd-java-agent/instrumentation/netty-3.8/src/test/groovy/Netty38ServerTest.groovy
+++ b/dd-java-agent/instrumentation/netty-3.8/src/test/groovy/Netty38ServerTest.groovy
@@ -172,4 +172,9 @@ class Netty38ServerTest extends HttpServerTest<ServerBootstrap> {
   String expectedOperationName() {
     "netty.request"
   }
+
+  @Override
+  boolean hasExtraErrorInformation() {
+    true
+  }
 }

--- a/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/client/HttpClientResponseTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/client/HttpClientResponseTracingHandler.java
@@ -42,4 +42,18 @@ public class HttpClientResponseTracingHandler extends ChannelInboundHandlerAdapt
       ctx.fireChannelRead(msg);
     }
   }
+
+  @Override
+  public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+    final AgentSpan span = ctx.channel().attr(SPAN_ATTRIBUTE_KEY).get();
+    if (span != null) {
+      // If an exception is passed to this point, it likely means it was unhandled and the
+      // client span won't be finished with a proper response, so we should finish the span here.
+      span.setError(true);
+      DECORATE.onError(span, cause);
+      DECORATE.beforeFinish(span);
+      span.finish();
+    }
+    super.exceptionCaught(ctx, cause);
+  }
 }

--- a/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/server/HttpServerRequestTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/server/HttpServerRequestTracingHandler.java
@@ -61,4 +61,18 @@ public class HttpServerRequestTracingHandler extends ChannelInboundHandlerAdapte
       }
     }
   }
+
+  @Override
+  public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+    final AgentSpan span = ctx.channel().attr(SPAN_ATTRIBUTE_KEY).get();
+    if (span != null) {
+      // If an exception is passed to this point, it likely means it was unhandled and the
+      // server span won't be finished with a proper response, so we should finish the span here.
+      span.setError(true);
+      DECORATE.onError(span, cause);
+      DECORATE.beforeFinish(span);
+      span.finish();
+    }
+    super.exceptionCaught(ctx, cause);
+  }
 }

--- a/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/server/HttpServerResponseTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/server/HttpServerResponseTracingHandler.java
@@ -40,4 +40,18 @@ public class HttpServerResponseTracingHandler extends ChannelOutboundHandlerAdap
       span.finish(); // Finish the span manually since finishSpanOnClose was false
     }
   }
+
+  @Override
+  public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+    final AgentSpan span = ctx.channel().attr(SPAN_ATTRIBUTE_KEY).get();
+    if (span != null) {
+      // If an exception is passed to this point, it likely means it was unhandled and the
+      // server span won't be finished with a proper response, so we should finish the span here.
+      span.setError(true);
+      DECORATE.onError(span, cause);
+      DECORATE.beforeFinish(span);
+      span.finish();
+    }
+    super.exceptionCaught(ctx, cause);
+  }
 }

--- a/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/client/HttpClientResponseTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/client/HttpClientResponseTracingHandler.java
@@ -8,6 +8,7 @@ import static datadog.trace.instrumentation.netty41.client.NettyHttpClientDecora
 
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.instrumentation.netty41.server.NettyHttpServerDecorator;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
@@ -41,5 +42,19 @@ public class HttpClientResponseTracingHandler extends ChannelInboundHandlerAdapt
       scope.setAsyncPropagation(true);
       ctx.fireChannelRead(msg);
     }
+  }
+
+  @Override
+  public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+    final AgentSpan span = ctx.channel().attr(SPAN_ATTRIBUTE_KEY).get();
+    if (span != null) {
+      // If an exception is passed to this point, it likely means it was unhandled and the
+      // client span won't be finished with a proper response, so we should finish the span here.
+      span.setError(true);
+      NettyHttpServerDecorator.DECORATE.onError(span, cause);
+      NettyHttpServerDecorator.DECORATE.beforeFinish(span);
+      span.finish();
+    }
+    super.exceptionCaught(ctx, cause);
   }
 }

--- a/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/server/HttpServerRequestTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/server/HttpServerRequestTracingHandler.java
@@ -61,4 +61,18 @@ public class HttpServerRequestTracingHandler extends ChannelInboundHandlerAdapte
       }
     }
   }
+
+  @Override
+  public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+    final AgentSpan span = ctx.channel().attr(SPAN_ATTRIBUTE_KEY).get();
+    if (span != null) {
+      // If an exception is passed to this point, it likely means it was unhandled and the
+      // server span won't be finished with a proper response, so we should finish the span here.
+      span.setError(true);
+      DECORATE.onError(span, cause);
+      DECORATE.beforeFinish(span);
+      span.finish();
+    }
+    super.exceptionCaught(ctx, cause);
+  }
 }

--- a/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/server/HttpServerResponseTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/server/HttpServerResponseTracingHandler.java
@@ -40,4 +40,18 @@ public class HttpServerResponseTracingHandler extends ChannelOutboundHandlerAdap
       span.finish(); // Finish the span manually since finishSpanOnClose was false
     }
   }
+
+  @Override
+  public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+    final AgentSpan span = ctx.channel().attr(SPAN_ATTRIBUTE_KEY).get();
+    if (span != null) {
+      // If an exception is passed to this point, it likely means it was unhandled and the
+      // server span won't be finished with a proper response, so we should finish the span here.
+      span.setError(true);
+      DECORATE.onError(span, cause);
+      DECORATE.beforeFinish(span);
+      span.finish();
+    }
+    super.exceptionCaught(ctx, cause);
+  }
 }


### PR DESCRIPTION
This is not likely to be very helpful since most frameworks should handle the exceptions before this point, but we should capture it just in case.

TODO: try to identify some tests that exercises this behavior.