### PR TITLE
Update task-tree to 2.1.0

### DIFF
--- a/dd-trace-java.gradle
+++ b/dd-trace-java.gradle
@@ -11,7 +11,7 @@ plugins {
 
   id "com.diffplug.spotless" version "5.12.5"
   id 'com.github.spotbugs' version '4.6.0'
-  id 'com.dorongold.task-tree' version '1.5'
+  id 'com.dorongold.task-tree' version '2.1.0'
   id "de.thetaphi.forbiddenapis" version "3.1"
 
   id 'org.unbroken-dome.test-sets' version '3.0.1'


### PR DESCRIPTION
Adds support for the version of gradle we're using (`6.8.x`).
https://github.com/dorongold/gradle-task-tree/releases