### PR TITLE
Limit workers during build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,7 +104,7 @@ jobs:
             GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx1900M -Xms64M -XX:ErrorFile=/tmp/hs_err_pid%p.log'"
             ./gradlew clean compile shadowJar
             << pipeline.parameters.gradle_flags >>
-            --max-workers=8
+            --max-workers=4
 
       - run:
           name: Collect Libs
@@ -140,7 +140,7 @@ jobs:
             GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx1900M -Xms64M -XX:ErrorFile=/tmp/hs_err_pid%p.log'"
             ./gradlew clean compile shadowJar
             << pipeline.parameters.gradle_flags >>
-            --max-workers=7
+            --max-workers=4
 
       - save_cache:
           key: dd-trace-java-v3-{{ .Branch }}-{{ epoch }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,7 +140,7 @@ jobs:
             GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx1900M -Xms64M -XX:ErrorFile=/tmp/hs_err_pid%p.log'"
             ./gradlew clean compile shadowJar
             << pipeline.parameters.gradle_flags >>
-            --max-workers=8
+            --max-workers=7
 
       - save_cache:
           key: dd-trace-java-v3-{{ .Branch }}-{{ epoch }}


### PR DESCRIPTION
Now the weekly build with a clean cache from `master` failed with an OOM as well. This limits the number of workers during the build in an attempt to not exhaust the available memory of the node (since we're already running on an XL instance)