### PR TITLE
Add config toggle for Allocation Profiler

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkController.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkController.java
@@ -112,8 +112,17 @@ public final class OpenJdkController implements Controller {
     // Toggle settings from config
 
     if (config.isProfilingAllocationEnabled()) {
+      if (!Boolean.parseBoolean(recordingSettings.get("jdk.ObjectAllocationInNewTLAB#enabled"))
+          || !Boolean.parseBoolean(
+              recordingSettings.get("jdk.ObjectAllocationOutsideTLAB#enabled"))) {
+        if (isJavaVersionAtLeast(16)) {
+          // It was enabled based on JDK version so disabled by override file
+          log.warn(
+              "The ObjectAllocationInNewTLAB and ObjectAllocationOutsideTLAB JFR events are disabled with the override file but enabled with the config.");
+        }
+      }
       log.debug(
-          "Enabling ObjectAllocationInNewTLAB and ObjectAllocationOutsideTLAB JFR events from the command line or environment variable.");
+          "Enabling ObjectAllocationInNewTLAB and ObjectAllocationOutsideTLAB JFR events with the config.");
       recordingSettings.put("jdk.ObjectAllocationInNewTLAB#enabled", "true");
       recordingSettings.put("jdk.ObjectAllocationOutsideTLAB#enabled", "true");
     }

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkController.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkController.java
@@ -100,11 +100,22 @@ public final class OpenJdkController implements Controller {
       }
     }
 
+    // Toggle settings from override file
+
     try {
       recordingSettings.putAll(
           JfpUtils.readOverrideJfpResource(config.getProfilingTemplateOverrideFile()));
     } catch (final IOException e) {
       throw new ConfigurationException(e);
+    }
+
+    // Toggle settings from config
+
+    if (config.isProfilingAllocationEnabled()) {
+      log.debug(
+          "Enabling ObjectAllocationInNewTLAB and ObjectAllocationOutsideTLAB JFR events from the command line or environment variable.");
+      recordingSettings.put("jdk.ObjectAllocationInNewTLAB#enabled", "true");
+      recordingSettings.put("jdk.ObjectAllocationOutsideTLAB#enabled", "true");
     }
 
     this.recordingSettings = Collections.unmodifiableMap(recordingSettings);

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/test/java/com/datadog/profiling/controller/openjdk/OpenJdkControllerTest.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/test/java/com/datadog/profiling/controller/openjdk/OpenJdkControllerTest.java
@@ -99,6 +99,22 @@ public class OpenJdkControllerTest {
   }
 
   @Test
+  public void testObjectAllocationIsStillOverriddenThroughProp() throws Exception {
+    when(config.isProfilingAllocationEnabled()).thenReturn(true);
+    OpenJdkController controller = new OpenJdkController(config);
+    try (final Recording recording = controller.createRecording(TEST_NAME).stop().getRecording()) {
+      assertEquals(
+          Boolean.parseBoolean(
+              recording.getSettings().get("jdk.ObjectAllocationInNewTLAB#enabled")),
+          true);
+      assertEquals(
+          Boolean.parseBoolean(
+              recording.getSettings().get("jdk.ObjectAllocationOutsideTLAB#enabled")),
+          true);
+    }
+  }
+
+  @Test
   public void testNativeMethodSampleIsDisabledOnUnsupportedVersion() throws Exception {
     OpenJdkController controller = new OpenJdkController(config);
     try (final Recording recording = controller.createRecording(TEST_NAME).stop().getRecording()) {

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -57,6 +57,7 @@ public final class ConfigDefaults {
   static final boolean DEFAULT_LOGS_INJECTION_ENABLED = true;
 
   static final boolean DEFAULT_PROFILING_ENABLED = false;
+  static final boolean DEFAULT_PROFILING_ALLOCATION_ENABLED = false;
   static final int DEFAULT_PROFILING_START_DELAY = 10;
   static final boolean DEFAULT_PROFILING_START_FORCE_FIRST = false;
   static final int DEFAULT_PROFILING_UPLOAD_PERIOD = 60; // 1 min

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
@@ -8,6 +8,7 @@ package datadog.trace.api.config;
  */
 public final class ProfilingConfig {
   public static final String PROFILING_ENABLED = "profiling.enabled";
+  public static final String PROFILING_ALLOCATION_ENABLED = "profiling.allocation.enabled";
   @Deprecated // Use dd.site instead
   public static final String PROFILING_URL = "profiling.url";
   @Deprecated // Use dd.api-key instead

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -22,6 +22,7 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_PERF_METRICS_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PRIORITY_SAMPLING_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PRIORITY_SAMPLING_FORCE;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_AGENTLESS;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_ALLOCATION_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS;
@@ -95,6 +96,7 @@ import static datadog.trace.api.config.JmxFetchConfig.JMX_FETCH_STATSD_HOST;
 import static datadog.trace.api.config.JmxFetchConfig.JMX_FETCH_STATSD_PORT;
 import static datadog.trace.api.config.JmxFetchConfig.JMX_TAGS;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_AGENTLESS;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_ALLOCATION_ENABLED;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_API_KEY_FILE_OLD;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_API_KEY_FILE_VERY_OLD;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_API_KEY_OLD;
@@ -340,6 +342,7 @@ public class Config {
   private final int traceRateLimit;
 
   private final boolean profilingEnabled;
+  private final boolean profilingAllocationEnabled;
   private final boolean profilingAgentless;
   private final boolean profilingLegacyTracingIntegrationEnabled;
   @Deprecated private final String profilingUrl;
@@ -675,6 +678,9 @@ public class Config {
     traceRateLimit = configProvider.getInteger(TRACE_RATE_LIMIT, DEFAULT_TRACE_RATE_LIMIT);
 
     profilingEnabled = configProvider.getBoolean(PROFILING_ENABLED, DEFAULT_PROFILING_ENABLED);
+    profilingAllocationEnabled =
+        configProvider.getBoolean(
+            PROFILING_ALLOCATION_ENABLED, DEFAULT_PROFILING_ALLOCATION_ENABLED);
     profilingAgentless =
         configProvider.getBoolean(PROFILING_AGENTLESS, DEFAULT_PROFILING_AGENTLESS);
     profilingLegacyTracingIntegrationEnabled =
@@ -1089,6 +1095,10 @@ public class Config {
 
   public boolean isProfilingEnabled() {
     return profilingEnabled;
+  }
+
+  public boolean isProfilingAllocationEnabled() {
+    return profilingAllocationEnabled;
   }
 
   public boolean isProfilingAgentless() {
@@ -1847,6 +1857,8 @@ public class Config {
         + traceRateLimit
         + ", profilingEnabled="
         + profilingEnabled
+        + ", profilingAllocationEnabled="
+        + profilingAllocationEnabled
         + ", profilingAgentless="
         + profilingAgentless
         + ", profilingUrl='"


### PR DESCRIPTION
We want to make it as easy as possible to enable the Allocation
Profiler. The override files are a neat and complete solution but are
not as easy to use. Customers can now enable the Allocation Profiler
with either:
- the command line parameter: `-Ddd.profiling.allocation.enabled=true`
- the environment variable: `DD_PROFILING_ALLOCATION_ENABLED=true`

It can always be enabled with https://docs.datadoghq.com/tracing/profiler/profiler_troubleshooting/#enabling-the-allocation-profiler