### PR TITLE
Temporarily skip spring-cloud-netflix-zuul 2.2.9.RELEASE

### DIFF
--- a/dd-java-agent/instrumentation/spring-cloud-zuul-2/spring-cloud-zuul-2.gradle
+++ b/dd-java-agent/instrumentation/spring-cloud-zuul-2/spring-cloud-zuul-2.gradle
@@ -11,6 +11,7 @@ muzzle {
     extraDependency "com.netflix.zuul:zuul-core:1.3.1"
     extraDependency "javax.servlet:javax.servlet-api:3.1.0"
     assertInverse = true
+    skipVersions += '2.2.9.RELEASE' // missing a dependency.  (bad release?)
   }
 }
 


### PR DESCRIPTION
because it has a missing dependency: spring-cloud-starter-2.2.9.RELEASE which breaks muzzle

This can be reverted if/when the missing dependency appears on Maven central