### PR TITLE
Exclude Mule instrumentation while https cert is broken

### DIFF
--- a/dd-java-agent/instrumentation/spring-cloud-zuul-2/spring-cloud-zuul-2.gradle
+++ b/dd-java-agent/instrumentation/spring-cloud-zuul-2/spring-cloud-zuul-2.gradle
@@ -11,6 +11,7 @@ muzzle {
     extraDependency "com.netflix.zuul:zuul-core:1.3.1"
     extraDependency "javax.servlet:javax.servlet-api:3.1.0"
     assertInverse = true
+    skipVersions += '2.2.9.RELEASE' // missing a dependency.  (bad release?)
   }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -177,7 +177,9 @@ include ':dd-java-agent:instrumentation:mongo'
 include ':dd-java-agent:instrumentation:mongo:driver-3.1'
 include ':dd-java-agent:instrumentation:mongo:driver-4'
 include ':dd-java-agent:instrumentation:mongo:driver-async-3.3'
-include ':dd-java-agent:instrumentation:mule-4'
+// TODO this was excluded since mulesoft https certificate had expired and failed all builds
+//  it needs to be added back again before there is a new release
+//include ':dd-java-agent:instrumentation:mule-4'
 include ':dd-java-agent:instrumentation:netty-3.8'
 include ':dd-java-agent:instrumentation:netty-4.0'
 include ':dd-java-agent:instrumentation:netty-4.1'


### PR DESCRIPTION
### There can be no release while the mulesoft https cert is broken, since that instrumentation needs to be added back in!