### PR TITLE
Improve runnable future constructor instrumentation efficiency

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/AdviceUtils.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/AdviceUtils.java
@@ -51,7 +51,11 @@ public class AdviceUtils {
       ContextStore<T, State> contextStore, T task, boolean startThreadMigration) {
     TraceScope activeScope = activeScope();
     if (null != activeScope) {
-      State state = contextStore.putIfAbsent(task, State.FACTORY);
+      State state = contextStore.get(task);
+      if (null == state) {
+        state = State.FACTORY.create();
+        contextStore.put(task, state);
+      }
       if (state.captureAndSetContinuation(activeScope) && startThreadMigration) {
         state.startThreadMigration();
       }


### PR DESCRIPTION
I have been meaning to do this for a while:
* `AdviceUtils.capture` calls `ContextStore.putIfAbsent` which locks the object. This is quite a risky thing to do if the object is shared and the lock is contended, but it almost never is anyway as it is almost always called on exit from a constructor. Fixing `ContextStore.putIfAbsent` to make `FieldBackedContextAccessor` use an `AtomicReferenceFieldUpdater` to CAS the injected field is a possible mitigation that I have attempted before but a nontrivial unit of work. 
* We instrument every constructor in the hierarchies under `java.util.concurrent.FutureTask`, `*.com.google.common.util.concurrent.TrustedListenableFutureTask`, and `*.netty.util.concurrent.PromiseTask` (so all shaded versions of the last two) which means the same capturing logic is called over and over again and we do more instrumentation than we need to. This is easy to avoid - we only need to instrument all constructors in `FutureTask` and `TrustedListenableFutureTask` which do not call each other and are invoked by all subclasses, and the canonical constructor for `PromiseTask` which can be identified by its arguments. Since `AdviceUtils.capture` is always idempotent on the same thread, it doesn't matter if this changes, unless a new constructor is added to `PromiseTask` which does not call the current canonical constructor, but netty is a stable code base.