### PR TITLE
[CIAPP] Support `GIT_URL_1` to extract repository url info in tests executed in Jenkins

### DIFF
--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/ci/JenkinsInfo.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/ci/JenkinsInfo.java
@@ -19,13 +19,14 @@ class JenkinsInfo extends CIProviderInfo {
   public static final String JENKINS_JOB_URL = "JOB_URL";
   public static final String JENKINS_WORKSPACE_PATH = "WORKSPACE";
   public static final String JENKINS_GIT_REPOSITORY_URL = "GIT_URL";
+  public static final String JENKINS_GIT_REPOSITORY_URL_ALT = "GIT_URL_1";
   public static final String JENKINS_GIT_COMMIT = "GIT_COMMIT";
   public static final String JENKINS_GIT_BRANCH = "GIT_BRANCH";
 
   @Override
   protected GitInfo buildCIGitInfo() {
     return new GitInfo(
-        filterSensitiveInfo(System.getenv(JENKINS_GIT_REPOSITORY_URL)),
+        filterSensitiveInfo(buildGitRepositoryUrl()),
         buildGitBranch(),
         buildGitTag(),
         new CommitInfo(System.getenv(JENKINS_GIT_COMMIT)));
@@ -43,6 +44,12 @@ class JenkinsInfo extends CIProviderInfo {
         .ciPipelineUrl(System.getenv(JENKINS_PIPELINE_URL))
         .ciWorkspace(expandTilde(System.getenv(JENKINS_WORKSPACE_PATH)))
         .build();
+  }
+
+  private String buildGitRepositoryUrl() {
+    return System.getenv(JENKINS_GIT_REPOSITORY_URL) != null
+        ? System.getenv(JENKINS_GIT_REPOSITORY_URL)
+        : System.getenv(JENKINS_GIT_REPOSITORY_URL_ALT);
   }
 
   private String buildGitBranch() {

--- a/internal-api/src/test/resources/ci/jenkins.json
+++ b/internal-api/src/test/resources/ci/jenkins.json
@@ -6,6 +6,30 @@
       "BUILD_URL": "jenkins-pipeline-url",
       "GIT_BRANCH": "origin/master",
       "GIT_COMMIT": "jenkins-git-commit",
+      "GIT_URL_1": "sample",
+      "GIT_URL_2": "otherSample",
+      "JENKINS_URL": "jenkins",
+      "JOB_NAME": "jobName",
+      "JOB_URL": "jenkins-job-url"
+    },
+    {
+      "ci.pipeline.id": "jenkins-pipeline-id",
+      "ci.pipeline.name": "jobName",
+      "ci.pipeline.number": "jenkins-pipeline-number",
+      "ci.pipeline.url": "jenkins-pipeline-url",
+      "ci.provider.name": "jenkins",
+      "git.branch": "master",
+      "git.commit.sha": "jenkins-git-commit",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "BUILD_NUMBER": "jenkins-pipeline-number",
+      "BUILD_TAG": "jenkins-pipeline-id",
+      "BUILD_URL": "jenkins-pipeline-url",
+      "GIT_BRANCH": "origin/master",
+      "GIT_COMMIT": "jenkins-git-commit",
       "GIT_URL": "sample",
       "JENKINS_URL": "jenkins",
       "JOB_NAME": "jobName",


### PR DESCRIPTION
Sometimes multiple repositories can be involved (e.g. forks). Jenkins can use the pattern `GIT_URL_N` with `N` {1,2,…}. 
By convention, `GIT_URL_1` should be the same as `GIT_URL`.