### PR TITLE
Change AgentTracer.activeScope() to return AgentScope

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/ComparableRunnable.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/ComparableRunnable.java
@@ -1,11 +1,11 @@
 package datadog.trace.bootstrap.instrumentation.java.concurrent;
 
-import datadog.trace.context.TraceScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 
 public final class ComparableRunnable<T extends Runnable & Comparable<T>> extends Wrapper<T>
     implements Comparable<ComparableRunnable<T>> {
 
-  public ComparableRunnable(T delegate, TraceScope.Continuation continuation) {
+  public ComparableRunnable(T delegate, AgentScope.Continuation continuation) {
     super(delegate, continuation);
   }
 

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/ContinuationClaim.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/ContinuationClaim.java
@@ -1,13 +1,24 @@
 package datadog.trace.bootstrap.instrumentation.java.concurrent;
 
-import datadog.trace.context.TraceScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 
-final class ContinuationClaim implements TraceScope.Continuation {
+final class ContinuationClaim implements AgentScope.Continuation {
 
   public static final ContinuationClaim CLAIMED = new ContinuationClaim();
 
   @Override
-  public TraceScope activate() {
+  public AgentScope activate() {
+    throw new IllegalStateException();
+  }
+
+  @Override
+  public void migrate() {
+    throw new IllegalStateException();
+  }
+
+  @Override
+  public AgentSpan getSpan() {
     throw new IllegalStateException();
   }
 

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/ExecutorInstrumentationUtils.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/ExecutorInstrumentationUtils.java
@@ -4,7 +4,7 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScop
 import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.ExcludeType;
 
 import datadog.trace.bootstrap.ContextStore;
-import datadog.trace.context.TraceScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import java.util.concurrent.Executor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,7 +30,7 @@ public final class ExecutorInstrumentationUtils {
       return false;
     }
 
-    final TraceScope scope = activeScope();
+    final AgentScope scope = activeScope();
 
     return scope != null && scope.isAsyncPropagating();
   }
@@ -45,7 +45,7 @@ public final class ExecutorInstrumentationUtils {
    * @return new state
    */
   public static <T> State setupState(
-      final ContextStore<T, State> contextStore, final T task, final TraceScope scope) {
+      final ContextStore<T, State> contextStore, final T task, final AgentScope scope) {
 
     final State state = contextStore.putIfAbsent(task, State.FACTORY);
 

--- a/dd-java-agent/instrumentation/aerospike-4/src/main/java/datadog/trace/instrumentation/aerospike4/TracingListener.java
+++ b/dd-java-agent/instrumentation/aerospike-4/src/main/java/datadog/trace/instrumentation/aerospike4/TracingListener.java
@@ -17,9 +17,9 @@ import com.aerospike.client.listener.RecordArrayListener;
 import com.aerospike.client.listener.RecordListener;
 import com.aerospike.client.listener.RecordSequenceListener;
 import com.aerospike.client.listener.WriteListener;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope.Continuation;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.context.TraceScope;
-import datadog.trace.context.TraceScope.Continuation;
 import java.util.List;
 
 public final class TracingListener
@@ -73,7 +73,7 @@ public final class TracingListener
     clientSpan.finish();
 
     if (listener != null) {
-      try (final TraceScope scope = continuation.activate()) {
+      try (final AgentScope scope = continuation.activate()) {
         if (listener instanceof ExistsListener) {
           ((ExistsListener) listener).onSuccess(key, exists);
         } else if (listener instanceof DeleteListener) {
@@ -91,7 +91,7 @@ public final class TracingListener
     clientSpan.finish();
 
     if (listener != null) {
-      try (final TraceScope scope = continuation.activate()) {
+      try (final AgentScope scope = continuation.activate()) {
         ((ExistsArrayListener) listener).onSuccess(keys, exists);
       }
     } else {
@@ -105,7 +105,7 @@ public final class TracingListener
     clientSpan.finish();
 
     if (listener != null) {
-      try (final TraceScope scope = continuation.activate()) {
+      try (final AgentScope scope = continuation.activate()) {
         ((RecordListener) listener).onSuccess(key, record);
       }
     } else {
@@ -119,7 +119,7 @@ public final class TracingListener
     clientSpan.finish();
 
     if (listener != null) {
-      try (final TraceScope scope = continuation.activate()) {
+      try (final AgentScope scope = continuation.activate()) {
         ((RecordArrayListener) listener).onSuccess(keys, records);
       }
     } else {
@@ -133,7 +133,7 @@ public final class TracingListener
     clientSpan.finish();
 
     if (listener != null) {
-      try (final TraceScope scope = continuation.activate()) {
+      try (final AgentScope scope = continuation.activate()) {
         ((BatchListListener) listener).onSuccess(records);
       }
     } else {
@@ -147,7 +147,7 @@ public final class TracingListener
     clientSpan.finish();
 
     if (listener != null) {
-      try (final TraceScope scope = continuation.activate()) {
+      try (final AgentScope scope = continuation.activate()) {
         ((WriteListener) listener).onSuccess(key);
       }
     } else {
@@ -161,7 +161,7 @@ public final class TracingListener
     clientSpan.finish();
 
     if (listener != null) {
-      try (final TraceScope scope = continuation.activate()) {
+      try (final AgentScope scope = continuation.activate()) {
         ((ExecuteListener) listener).onSuccess(key, obj);
       }
     } else {
@@ -175,7 +175,7 @@ public final class TracingListener
     clientSpan.finish();
 
     if (listener != null) {
-      try (final TraceScope scope = continuation.activate()) {
+      try (final AgentScope scope = continuation.activate()) {
         if (listener instanceof ExistsSequenceListener) {
           ((ExistsSequenceListener) listener).onSuccess();
         } else if (listener instanceof RecordSequenceListener) {
@@ -196,7 +196,7 @@ public final class TracingListener
     clientSpan.finish();
 
     if (listener != null) {
-      try (final TraceScope scope = continuation.activate()) {
+      try (final AgentScope scope = continuation.activate()) {
         if (listener instanceof ExistsListener) {
           ((ExistsListener) listener).onFailure(error);
         } else if (listener instanceof ExistsSequenceListener) {

--- a/dd-java-agent/instrumentation/akka-concurrent/src/main/java/datadog/trace/instrumentation/akka/concurrent/AkkaForkJoinExecutorTaskInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-concurrent/src/main/java/datadog/trace/instrumentation/akka/concurrent/AkkaForkJoinExecutorTaskInstrumentation.java
@@ -12,8 +12,8 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.bootstrap.InstrumentationContext;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.State;
-import datadog.trace.context.TraceScope;
 import java.util.Collections;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
@@ -66,12 +66,12 @@ public final class AkkaForkJoinExecutorTaskInstrumentation extends Instrumenter.
 
   public static final class Run {
     @Advice.OnMethodEnter
-    public static TraceScope before(@Advice.Argument(0) Runnable wrapped) {
+    public static AgentScope before(@Advice.Argument(0) Runnable wrapped) {
       return startTaskScope(InstrumentationContext.get(Runnable.class, State.class), wrapped);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class)
-    public static void after(@Advice.Enter TraceScope scope) {
+    public static void after(@Advice.Enter AgentScope scope) {
       endTaskScope(scope);
     }
   }

--- a/dd-java-agent/instrumentation/akka-concurrent/src/main/java/datadog/trace/instrumentation/akka/concurrent/AkkaForkJoinTaskInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-concurrent/src/main/java/datadog/trace/instrumentation/akka/concurrent/AkkaForkJoinTaskInstrumentation.java
@@ -18,9 +18,9 @@ import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.ExcludeFilterProvider;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.bootstrap.InstrumentationContext;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.State;
-import datadog.trace.context.TraceScope;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.EnumMap;
@@ -84,12 +84,12 @@ public final class AkkaForkJoinTaskInstrumentation extends Instrumenter.Tracing
 
   public static final class Exec {
     @Advice.OnMethodEnter
-    public static <T> TraceScope before(@Advice.This ForkJoinTask<T> task) {
+    public static <T> AgentScope before(@Advice.This ForkJoinTask<T> task) {
       return startTaskScope(InstrumentationContext.get(ForkJoinTask.class, State.class), task);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class)
-    public static void after(@Advice.Enter TraceScope scope) {
+    public static void after(@Advice.Enter AgentScope scope) {
       endTaskScope(scope);
     }
   }

--- a/dd-java-agent/instrumentation/akka-concurrent/src/main/java/datadog/trace/instrumentation/akka/concurrent/AkkaMailboxInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-concurrent/src/main/java/datadog/trace/instrumentation/akka/concurrent/AkkaMailboxInstrumentation.java
@@ -10,9 +10,9 @@ import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.ExcludeFilterProvider;
 import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter;
-import datadog.trace.context.TraceScope;
 import java.util.Collection;
 import java.util.EnumMap;
 import java.util.List;
@@ -63,8 +63,8 @@ public class AkkaMailboxInstrumentation extends Instrumenter.Tracing
    */
   public static final class SuppressMailboxRunAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static TraceScope enter() {
-      TraceScope activeScope = activeScope();
+    public static AgentScope enter() {
+      AgentScope activeScope = activeScope();
       // If there is no active scope, we can clean all the way to the bottom
       if (null == activeScope) {
         return null;
@@ -79,9 +79,9 @@ public class AkkaMailboxInstrumentation extends Instrumenter.Tracing
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
-    public static void exit(@Advice.Enter final TraceScope scope) {
+    public static void exit(@Advice.Enter final AgentScope scope) {
       // Clean up any leaking scopes from akka-streams/akka-http et.c.
-      TraceScope activeScope = activeScope();
+      AgentScope activeScope = activeScope();
       while (activeScope != null && activeScope != scope) {
         activeScope.close();
         activeScope = activeScope();

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/DatadogServerRequestResponseFlowWrapper.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/DatadogServerRequestResponseFlowWrapper.java
@@ -14,7 +14,6 @@ import akka.stream.stage.AbstractOutHandler;
 import akka.stream.stage.GraphStage;
 import akka.stream.stage.GraphStageLogic;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
-import datadog.trace.context.TraceScope;
 import java.util.Queue;
 import java.util.concurrent.ArrayBlockingQueue;
 
@@ -117,7 +116,7 @@ public class DatadogServerRequestResponseFlowWrapper
                   // Check if the active scope is still the scope from when the request came in,
                   // and close it. If it's not, then it will be cleaned up actor message
                   // processing instrumentation that drives this state machine
-                  TraceScope activeScope = activeScope();
+                  AgentScope activeScope = activeScope();
                   if (activeScope == scope) {
                     scope.close();
                   }

--- a/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientInstrumentation.java
@@ -14,8 +14,8 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.context.TraceScope;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
@@ -84,7 +84,7 @@ public class ApacheHttpAsyncClientInstrumentation extends Instrumenter.Tracing {
         @Advice.Argument(2) HttpContext context,
         @Advice.Argument(value = 3, readOnly = false) FutureCallback<?> futureCallback) {
 
-      final TraceScope parentScope = activeScope();
+      final AgentScope parentScope = activeScope();
       final AgentSpan clientSpan = startSpan(HTTP_REQUEST);
       DECORATE.afterStart(clientSpan);
 

--- a/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/TraceContinuedFutureCallback.java
+++ b/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/TraceContinuedFutureCallback.java
@@ -2,19 +2,19 @@ package datadog.trace.instrumentation.apachehttpasyncclient;
 
 import static datadog.trace.instrumentation.apachehttpasyncclient.ApacheHttpAsyncClientDecorator.DECORATE;
 
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.context.TraceScope;
 import org.apache.http.concurrent.FutureCallback;
 import org.apache.http.protocol.HttpContext;
 
 public class TraceContinuedFutureCallback<T> implements FutureCallback<T> {
-  private final TraceScope.Continuation parentContinuation;
+  private final AgentScope.Continuation parentContinuation;
   private final AgentSpan clientSpan;
   private final HttpContext context;
   private final FutureCallback<T> delegate;
 
   public TraceContinuedFutureCallback(
-      final TraceScope parentScope,
+      final AgentScope parentScope,
       final AgentSpan clientSpan,
       final HttpContext context,
       final FutureCallback<T> delegate) {
@@ -47,7 +47,7 @@ public class TraceContinuedFutureCallback<T> implements FutureCallback<T> {
     if (parentContinuation == null) {
       completeDelegate(result);
     } else {
-      try (final TraceScope scope = parentContinuation.activate()) {
+      try (final AgentScope scope = parentContinuation.activate()) {
         scope.setAsyncPropagation(true);
         completeDelegate(result);
       }
@@ -68,7 +68,7 @@ public class TraceContinuedFutureCallback<T> implements FutureCallback<T> {
     if (parentContinuation == null) {
       failDelegate(ex);
     } else {
-      try (final TraceScope scope = parentContinuation.activate()) {
+      try (final AgentScope scope = parentContinuation.activate()) {
         scope.setAsyncPropagation(true);
         failDelegate(ex);
       }
@@ -85,7 +85,7 @@ public class TraceContinuedFutureCallback<T> implements FutureCallback<T> {
     if (parentContinuation == null) {
       cancelDelegate();
     } else {
-      try (final TraceScope scope = parentContinuation.activate()) {
+      try (final AgentScope scope = parentContinuation.activate()) {
         scope.setAsyncPropagation(true);
         cancelDelegate();
       }

--- a/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java/datadog/trace/instrumentation/aws/v2/AwsHttpClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java/datadog/trace/instrumentation/aws/v2/AwsHttpClientInstrumentation.java
@@ -11,7 +11,7 @@ import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
-import datadog.trace.context.TraceScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
@@ -63,7 +63,7 @@ public final class AwsHttpClientInstrumentation extends AbstractAwsClientInstrum
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static boolean methodEnter(@Advice.This final Object thiz) {
       if (thiz instanceof MakeAsyncHttpRequestStage) {
-        final TraceScope scope = activeScope();
+        final AgentScope scope = activeScope();
         if (scope != null) {
           scope.close();
           return true;
@@ -75,7 +75,7 @@ public final class AwsHttpClientInstrumentation extends AbstractAwsClientInstrum
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
     public static void methodExit(@Advice.Enter final boolean scopeAlreadyClosed) {
       if (!scopeAlreadyClosed) {
-        final TraceScope scope = activeScope();
+        final AgentScope scope = activeScope();
         if (scope != null) {
           scope.close();
         }

--- a/dd-java-agent/instrumentation/elasticsearch/transport/src/main/java/datadog/trace/instrumentation/elasticsearch/ThreadedActionListenerInstrumentation.java
+++ b/dd-java-agent/instrumentation/elasticsearch/transport/src/main/java/datadog/trace/instrumentation/elasticsearch/ThreadedActionListenerInstrumentation.java
@@ -12,8 +12,8 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.bootstrap.InstrumentationContext;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.State;
-import datadog.trace.context.TraceScope;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
@@ -63,13 +63,13 @@ public final class ThreadedActionListenerInstrumentation extends Instrumenter.Tr
   @SuppressWarnings("rawtypes")
   public static final class OnResponse {
     @Advice.OnMethodEnter
-    public static TraceScope before(@Advice.This ThreadedActionListener listener) {
+    public static AgentScope before(@Advice.This ThreadedActionListener listener) {
       return startTaskScope(
           InstrumentationContext.get(ThreadedActionListener.class, State.class), listener);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class)
-    public static void after(@Advice.Enter TraceScope scope) {
+    public static void after(@Advice.Enter AgentScope scope) {
       endTaskScope(scope);
     }
   }

--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/client/ClientStreamListenerImplInstrumentation.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/client/ClientStreamListenerImplInstrumentation.java
@@ -14,7 +14,6 @@ import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.context.TraceScope;
 import io.grpc.Status;
 import io.grpc.internal.ClientStreamListener;
 import java.util.Collections;
@@ -67,9 +66,9 @@ public class ClientStreamListenerImplInstrumentation extends Instrumenter.Tracin
     @Advice.OnMethodExit
     public static void capture(@Advice.This ClientStreamListener listener) {
       // instrumentation of ClientCallImpl::start ensures this scope is present and valid
-      TraceScope scope = activeScope();
-      if (scope instanceof AgentScope) {
-        AgentSpan span = ((AgentScope) scope).span();
+      AgentScope scope = activeScope();
+      if (null != scope) {
+        AgentSpan span = scope.span();
         InstrumentationContext.get(ClientStreamListener.class, AgentSpan.class).put(listener, span);
         // Initiate the span thread migration - the listener may be called on any thread
         span.startThreadMigration();

--- a/dd-java-agent/instrumentation/guava-10/src/main/java/datadog/trace/instrumentation/guava10/ListenableFutureInstrumentation.java
+++ b/dd-java-agent/instrumentation/guava-10/src/main/java/datadog/trace/instrumentation/guava10/ListenableFutureInstrumentation.java
@@ -10,10 +10,10 @@ import com.google.common.util.concurrent.AbstractFuture;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.InstrumentationContext;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.ExecutorInstrumentationUtils;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.RunnableWrapper;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.State;
-import datadog.trace.context.TraceScope;
 import java.util.Map;
 import java.util.concurrent.Executor;
 import net.bytebuddy.asm.Advice;
@@ -58,7 +58,7 @@ public class ListenableFutureInstrumentation extends Instrumenter.Tracing {
     public static State addListenerEnter(
         @Advice.Argument(value = 0, readOnly = false) Runnable task,
         @Advice.Argument(1) final Executor executor) {
-      final TraceScope scope = activeScope();
+      final AgentScope scope = activeScope();
       final Runnable newTask = RunnableWrapper.wrapIfNeeded(task);
       // It is important to check potentially wrapped task if we can instrument task in this
       // executor. Some executors do not support wrapped tasks.

--- a/dd-java-agent/instrumentation/hystrix-1.4/src/main/java/datadog/trace/instrumentation/hystrix/HystrixThreadPoolInstrumentation.java
+++ b/dd-java-agent/instrumentation/hystrix-1.4/src/main/java/datadog/trace/instrumentation/hystrix/HystrixThreadPoolInstrumentation.java
@@ -7,7 +7,7 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
-import datadog.trace.context.TraceScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
@@ -36,7 +36,7 @@ public class HystrixThreadPoolInstrumentation extends Instrumenter.Tracing {
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static boolean enableAsyncTracking() {
-      final TraceScope scope = activeScope();
+      final AgentScope scope = activeScope();
       if (scope != null) {
         if (!scope.isAsyncPropagating()) {
           scope.setAsyncPropagation(true);
@@ -49,7 +49,7 @@ public class HystrixThreadPoolInstrumentation extends Instrumenter.Tracing {
     @Advice.OnMethodExit(suppress = Throwable.class)
     public static void disableAsyncTracking(@Advice.Enter final boolean wasEnabled) {
       if (wasEnabled) {
-        final TraceScope scope = activeScope();
+        final AgentScope scope = activeScope();
         if (scope != null) {
           scope.setAsyncPropagation(false);
         }

--- a/dd-java-agent/instrumentation/java-concurrent/java-completablefuture/src/main/java/datadog/trace/instrumentation/java/completablefuture/AsyncTaskInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/java-completablefuture/src/main/java/datadog/trace/instrumentation/java/completablefuture/AsyncTaskInstrumentation.java
@@ -13,9 +13,9 @@ import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.ExcludeFilterProvider;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.bootstrap.InstrumentationContext;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.State;
-import datadog.trace.context.TraceScope;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -80,12 +80,12 @@ public final class AsyncTaskInstrumentation extends Instrumenter.Tracing
 
   public static class Run {
     @Advice.OnMethodEnter
-    public static TraceScope before(@Advice.This ForkJoinTask<?> zis) {
+    public static AgentScope before(@Advice.This ForkJoinTask<?> zis) {
       return startTaskScope(InstrumentationContext.get(ForkJoinTask.class, State.class), zis);
     }
 
     @Advice.OnMethodExit
-    public static void after(@Advice.Enter TraceScope scope) {
+    public static void after(@Advice.Enter AgentScope scope) {
       endTaskScope(scope);
     }
   }

--- a/dd-java-agent/instrumentation/java-concurrent/java-completablefuture/src/main/java8/java/util/concurrent/CompletableFutureAdvice.java
+++ b/dd-java-agent/instrumentation/java-concurrent/java-completablefuture/src/main/java8/java/util/concurrent/CompletableFutureAdvice.java
@@ -5,8 +5,8 @@ import static java.util.concurrent.CompletableFuture.ASYNC;
 
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.InstrumentationContext;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.ConcurrentState;
-import datadog.trace.context.TraceScope;
 import java.util.concurrent.CompletableFuture.UniCompletion;
 import net.bytebuddy.asm.Advice;
 
@@ -16,7 +16,7 @@ public final class CompletableFutureAdvice {
   public static final class UniConstructor {
     @Advice.OnMethodExit(suppress = Throwable.class)
     public static void afterInit(@Advice.This UniCompletion zis) {
-      TraceScope scope = activeScope();
+      AgentScope scope = activeScope();
       if (zis.isLive() && scope != null) {
         ContextStore<UniCompletion, ConcurrentState> contextStore =
             InstrumentationContext.get(UniCompletion.class, ConcurrentState.class);
@@ -31,7 +31,7 @@ public final class CompletableFutureAdvice {
 
   public static final class UniSubTryFire {
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static TraceScope enter(
+    public static AgentScope enter(
         @Advice.This UniCompletion zis,
         @Advice.Local("hadExecutor") boolean hadExecutor,
         @Advice.Local("wasClaimed") boolean wasClaimed,
@@ -50,7 +50,7 @@ public final class CompletableFutureAdvice {
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
     public static void exit(
-        @Advice.Enter TraceScope scope,
+        @Advice.Enter AgentScope scope,
         @Advice.Thrown final Throwable throwable,
         @Advice.This UniCompletion zis,
         @Advice.Argument(0) int mode,

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/AsyncPropagatingDisableInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/AsyncPropagatingDisableInstrumentation.java
@@ -13,7 +13,7 @@ import static net.bytebuddy.matcher.ElementMatchers.isTypeInitializer;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers;
-import datadog.trace.context.TraceScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.field.FieldDescription;
 import net.bytebuddy.description.type.TypeDescription;
@@ -167,8 +167,8 @@ public final class AsyncPropagatingDisableInstrumentation extends Instrumenter.T
   public static class DisableAsyncAdvice {
 
     @Advice.OnMethodEnter
-    public static TraceScope before() {
-      TraceScope scope = activeScope();
+    public static AgentScope before() {
+      AgentScope scope = activeScope();
       if (null != scope && scope.isAsyncPropagating()) {
         scope.setAsyncPropagation(false);
         return scope;
@@ -177,7 +177,7 @@ public final class AsyncPropagatingDisableInstrumentation extends Instrumenter.T
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class)
-    public static void after(@Advice.Enter TraceScope scope) {
+    public static void after(@Advice.Enter AgentScope scope) {
       if (null != scope) {
         scope.setAsyncPropagation(true);
       }

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/ConsumerTaskInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/ConsumerTaskInstrumentation.java
@@ -11,8 +11,8 @@ import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.bootstrap.InstrumentationContext;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.State;
-import datadog.trace.context.TraceScope;
 import java.util.Map;
 import java.util.concurrent.ForkJoinTask;
 import net.bytebuddy.asm.Advice;
@@ -45,7 +45,7 @@ public class ConsumerTaskInstrumentation extends Instrumenter.Tracing {
   public static class Construct {
     @Advice.OnMethodExit
     public static void construct(@Advice.This ForkJoinTask<?> task) {
-      TraceScope activeScope = activeScope();
+      AgentScope activeScope = activeScope();
       if (null != activeScope) {
         State state = State.FACTORY.create();
         state.captureAndSetContinuation(activeScope);
@@ -56,12 +56,12 @@ public class ConsumerTaskInstrumentation extends Instrumenter.Tracing {
 
   public static final class Run {
     @Advice.OnMethodEnter
-    public static <T> TraceScope before(@Advice.This ForkJoinTask<T> task) {
+    public static <T> AgentScope before(@Advice.This ForkJoinTask<T> task) {
       return startTaskScope(InstrumentationContext.get(ForkJoinTask.class, State.class), task);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class)
-    public static void after(@Advice.Enter TraceScope scope) {
+    public static void after(@Advice.Enter AgentScope scope) {
       endTaskScope(scope);
     }
   }

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/JavaExecutorInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/JavaExecutorInstrumentation.java
@@ -9,10 +9,10 @@ import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.InstrumentationContext;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.ExecutorInstrumentationUtils;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.RunnableWrapper;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.State;
-import datadog.trace.context.TraceScope;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.Executor;
@@ -46,7 +46,7 @@ public final class JavaExecutorInstrumentation extends AbstractExecutorInstrumen
       // there are cased like ScheduledExecutorService.submit (which we instrument)
       // which calls ScheduledExecutorService.schedule (which we also instrument)
       // where all of this could be dodged the second time
-      final TraceScope scope = activeScope();
+      final AgentScope scope = activeScope();
       if (null != scope) {
         final Runnable newTask = RunnableWrapper.wrapIfNeeded(task);
         // It is important to check potentially wrapped task if we can instrument task in this

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/JavaForkJoinTaskInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/JavaForkJoinTaskInstrumentation.java
@@ -18,9 +18,9 @@ import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.ExcludeFilterProvider;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.bootstrap.InstrumentationContext;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.ExcludeType;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.State;
-import datadog.trace.context.TraceScope;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
@@ -76,14 +76,14 @@ public final class JavaForkJoinTaskInstrumentation extends Instrumenter.Tracing
 
   public static final class Exec {
     @Advice.OnMethodEnter
-    public static <T> TraceScope before(@Advice.This ForkJoinTask<T> task) {
+    public static <T> AgentScope before(@Advice.This ForkJoinTask<T> task) {
       return exclude(FORK_JOIN_TASK, task)
           ? null
           : startTaskScope(InstrumentationContext.get(ForkJoinTask.class, State.class), task);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class)
-    public static void after(@Advice.Enter TraceScope scope) {
+    public static void after(@Advice.Enter AgentScope scope) {
       endTaskScope(scope);
     }
   }

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/RunnableFutureInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/RunnableFutureInstrumentation.java
@@ -20,9 +20,9 @@ import datadog.trace.agent.tooling.ExcludeFilterProvider;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers;
 import datadog.trace.bootstrap.InstrumentationContext;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.State;
-import datadog.trace.context.TraceScope;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
@@ -133,12 +133,12 @@ public final class RunnableFutureInstrumentation extends Instrumenter.Tracing
 
   public static final class Run {
     @Advice.OnMethodEnter
-    public static <T> TraceScope activate(@Advice.This RunnableFuture<T> task) {
+    public static <T> AgentScope activate(@Advice.This RunnableFuture<T> task) {
       return startTaskScope(InstrumentationContext.get(RunnableFuture.class, State.class), task);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class)
-    public static void close(@Advice.Enter TraceScope scope) {
+    public static void close(@Advice.Enter AgentScope scope) {
       endTaskScope(scope);
     }
   }

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/RunnableInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/RunnableInstrumentation.java
@@ -13,9 +13,9 @@ import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.InstrumentationContext;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.AdviceUtils;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.State;
-import datadog.trace.context.TraceScope;
 import java.util.Map;
 import java.util.concurrent.RunnableFuture;
 import net.bytebuddy.asm.Advice;
@@ -52,14 +52,14 @@ public final class RunnableInstrumentation extends Instrumenter.Tracing {
   public static class RunnableAdvice {
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static TraceScope enter(@Advice.This final Runnable thiz) {
+    public static AgentScope enter(@Advice.This final Runnable thiz) {
       final ContextStore<Runnable, State> contextStore =
           InstrumentationContext.get(Runnable.class, State.class);
       return AdviceUtils.startTaskScope(contextStore, thiz);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
-    public static void exit(@Advice.Enter final TraceScope scope) {
+    public static void exit(@Advice.Enter final AgentScope scope) {
       AdviceUtils.endTaskScope(scope);
     }
   }

--- a/dd-java-agent/instrumentation/java-concurrent/src/test/java/Descendant.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/test/java/Descendant.java
@@ -1,8 +1,8 @@
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.context.TraceScope;
 
 public final class Descendant implements Runnable {
 
@@ -15,7 +15,7 @@ public final class Descendant implements Runnable {
   @Override
   public void run() {
     AgentSpan span = startSpan(parent + "-child");
-    try (TraceScope scope = activateSpan(span)) {
+    try (AgentScope scope = activateSpan(span)) {
 
     } finally {
       span.finish();

--- a/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/TracingListener.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/TracingListener.java
@@ -7,7 +7,6 @@ import static datadog.trace.instrumentation.junit4.JUnit4Decorator.DECORATE;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
-import datadog.trace.context.TraceScope;
 import java.util.ArrayList;
 import java.util.List;
 import junit.runner.Version;
@@ -59,7 +58,7 @@ public class TracingListener extends RunListener {
       return;
     }
 
-    final TraceScope scope = AgentTracer.activeScope();
+    final AgentScope scope = AgentTracer.activeScope();
     if (scope != null) {
       scope.close();
     }

--- a/dd-java-agent/instrumentation/junit-5.3/src/main/java8/datadog/trace/instrumentation/junit5/TracingListener.java
+++ b/dd-java-agent/instrumentation/junit-5.3/src/main/java8/datadog/trace/instrumentation/junit5/TracingListener.java
@@ -7,7 +7,6 @@ import static datadog.trace.instrumentation.junit5.JUnit5Decorator.DECORATE;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
-import datadog.trace.context.TraceScope;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -88,7 +87,7 @@ public class TracingListener implements TestExecutionListener {
                 return;
               }
 
-              final TraceScope scope = AgentTracer.activeScope();
+              final AgentScope scope = AgentTracer.activeScope();
               if (scope != null) {
                 scope.close();
               }

--- a/dd-java-agent/instrumentation/lettuce-5/src/main/java8/datadog/trace/instrumentation/lettuce5/rx/RedisSubscriptionSubscribeAdvice.java
+++ b/dd-java-agent/instrumentation/lettuce-5/src/main/java8/datadog/trace/instrumentation/lettuce5/rx/RedisSubscriptionSubscribeAdvice.java
@@ -7,18 +7,18 @@ import static datadog.trace.instrumentation.lettuce5.LettuceClientDecorator.REDI
 import static datadog.trace.instrumentation.lettuce5.LettuceInstrumentationUtil.expectsResponse;
 
 import datadog.trace.bootstrap.InstrumentationContext;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.context.TraceScope;
 import io.lettuce.core.protocol.RedisCommand;
 import net.bytebuddy.asm.Advice;
 import org.reactivestreams.Subscription;
 
 public class RedisSubscriptionSubscribeAdvice {
   public static final class State {
-    public final TraceScope parentScope;
+    public final AgentScope parentScope;
     public final AgentSpan span;
 
-    public State(TraceScope parentScope, AgentSpan span) {
+    public State(AgentScope parentScope, AgentSpan span) {
       this.parentScope = parentScope;
       this.span = span;
     }
@@ -30,7 +30,7 @@ public class RedisSubscriptionSubscribeAdvice {
       @Advice.FieldValue("command") RedisCommand command,
       @Advice.FieldValue("subscriptionCommand") RedisCommand subscriptionCommand) {
 
-    TraceScope parentScope = null;
+    AgentScope parentScope = null;
     RedisSubscriptionState state =
         InstrumentationContext.get(Subscription.class, RedisSubscriptionState.class)
             .get(subscription);

--- a/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/ChannelTraceContext.java
+++ b/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/ChannelTraceContext.java
@@ -1,8 +1,8 @@
 package datadog.trace.instrumentation.netty38;
 
 import datadog.trace.bootstrap.ContextStore;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.context.TraceScope;
 
 public class ChannelTraceContext {
   public static class Factory implements ContextStore.Factory<ChannelTraceContext> {
@@ -14,12 +14,12 @@ public class ChannelTraceContext {
     }
   }
 
-  TraceScope.Continuation connectionContinuation;
+  AgentScope.Continuation connectionContinuation;
   AgentSpan serverSpan;
   AgentSpan clientSpan;
   AgentSpan clientParentSpan;
 
-  public TraceScope.Continuation getConnectionContinuation() {
+  public AgentScope.Continuation getConnectionContinuation() {
     return connectionContinuation;
   }
 
@@ -35,7 +35,7 @@ public class ChannelTraceContext {
     return clientParentSpan;
   }
 
-  public void setConnectionContinuation(TraceScope.Continuation connectionContinuation) {
+  public void setConnectionContinuation(AgentScope.Continuation connectionContinuation) {
     this.connectionContinuation = connectionContinuation;
   }
 

--- a/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/NettyChannelInstrumentation.java
+++ b/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/NettyChannelInstrumentation.java
@@ -13,7 +13,7 @@ import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.InstrumentationContext;
-import datadog.trace.context.TraceScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import java.util.Collections;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
@@ -68,9 +68,9 @@ public class NettyChannelInstrumentation extends Instrumenter.Tracing {
   public static class ChannelConnectAdvice extends AbstractNettyAdvice {
     @Advice.OnMethodEnter
     public static void addConnectContinuation(@Advice.This final Channel channel) {
-      final TraceScope scope = activeScope();
+      final AgentScope scope = activeScope();
       if (scope != null) {
-        final TraceScope.Continuation continuation = scope.capture();
+        final AgentScope.Continuation continuation = scope.capture();
         if (continuation != null) {
           final ContextStore<Channel, ChannelTraceContext> contextStore =
               InstrumentationContext.get(Channel.class, ChannelTraceContext.class);

--- a/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/client/HttpClientRequestTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/client/HttpClientRequestTracingHandler.java
@@ -12,7 +12,6 @@ import static datadog.trace.instrumentation.netty38.client.NettyResponseInjectAd
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.context.TraceScope;
 import datadog.trace.instrumentation.netty38.ChannelTraceContext;
 import java.net.InetSocketAddress;
 import org.jboss.netty.channel.Channel;
@@ -41,8 +40,8 @@ public class HttpClientRequestTracingHandler extends SimpleChannelDownstreamHand
     final ChannelTraceContext channelTraceContext =
         contextStore.putIfAbsent(ctx.getChannel(), ChannelTraceContext.Factory.INSTANCE);
 
-    TraceScope parentScope = null;
-    final TraceScope.Continuation continuation = channelTraceContext.getConnectionContinuation();
+    AgentScope parentScope = null;
+    final AgentScope.Continuation continuation = channelTraceContext.getConnectionContinuation();
     if (continuation != null) {
       parentScope = continuation.activate();
       channelTraceContext.setConnectionContinuation(null);

--- a/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/AttributeKeys.java
+++ b/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/AttributeKeys.java
@@ -3,8 +3,8 @@ package datadog.trace.instrumentation.netty40;
 import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.DD_SPAN_ATTRIBUTE;
 
 import datadog.trace.api.GenericClassValue;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.context.TraceScope;
 import io.netty.util.AttributeKey;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -19,7 +19,7 @@ public final class AttributeKeys {
   public static final AttributeKey<AgentSpan> CLIENT_PARENT_ATTRIBUTE_KEY =
       attributeKey("datadog.client.parent.span");
 
-  public static final AttributeKey<TraceScope.Continuation>
+  public static final AttributeKey<AgentScope.Continuation>
       CONNECT_PARENT_CONTINUATION_ATTRIBUTE_KEY =
           attributeKey("datadog.connect.parent.continuation");
 

--- a/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/ChannelFutureListenerInstrumentation.java
+++ b/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/ChannelFutureListenerInstrumentation.java
@@ -15,7 +15,6 @@ import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
-import datadog.trace.context.TraceScope;
 import datadog.trace.instrumentation.netty40.server.NettyHttpServerDecorator;
 import io.netty.channel.ChannelFuture;
 import net.bytebuddy.asm.Advice;
@@ -71,7 +70,7 @@ public class ChannelFutureListenerInstrumentation extends Instrumenter.Tracing {
 
   public static class OperationCompleteAdvice {
     @Advice.OnMethodEnter
-    public static TraceScope activateScope(@Advice.Argument(0) final ChannelFuture future) {
+    public static AgentScope activateScope(@Advice.Argument(0) final ChannelFuture future) {
       /*
       Idea here is:
        - To return scope only if we have captured it.
@@ -81,12 +80,12 @@ public class ChannelFutureListenerInstrumentation extends Instrumenter.Tracing {
       if (cause == null) {
         return null;
       }
-      final TraceScope.Continuation continuation =
+      final AgentScope.Continuation continuation =
           future.channel().attr(CONNECT_PARENT_CONTINUATION_ATTRIBUTE_KEY).getAndRemove();
       if (continuation == null) {
         return null;
       }
-      final TraceScope parentScope = continuation.activate();
+      final AgentScope parentScope = continuation.activate();
 
       final AgentSpan errorSpan = startSpan(NETTY_CONNECT).setTag(Tags.COMPONENT, "netty");
       try (final AgentScope scope = activateSpan(errorSpan)) {
@@ -99,7 +98,7 @@ public class ChannelFutureListenerInstrumentation extends Instrumenter.Tracing {
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
-    public static void deactivateScope(@Advice.Enter final TraceScope scope) {
+    public static void deactivateScope(@Advice.Enter final AgentScope scope) {
       if (scope != null) {
         scope.close();
       }

--- a/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/NettyChannelHandlerContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/NettyChannelHandlerContextInstrumentation.java
@@ -14,9 +14,9 @@ import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
-import datadog.trace.context.TraceScope;
 import datadog.trace.instrumentation.netty40.client.NettyHttpClientDecorator;
 import datadog.trace.instrumentation.netty40.server.NettyHttpServerDecorator;
 import io.netty.channel.ChannelHandlerContext;
@@ -61,7 +61,7 @@ public class NettyChannelHandlerContextInstrumentation extends Instrumenter.Trac
 
   public static class FireAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static TraceScope scopeSpan(@Advice.This final ChannelHandlerContext ctx) {
+    public static AgentScope scopeSpan(@Advice.This final ChannelHandlerContext ctx) {
       final AgentSpan channelSpan = ctx.channel().attr(SPAN_ATTRIBUTE_KEY).get();
       if (channelSpan == null || channelSpan == activeSpan()) {
         // don't modify the scope
@@ -71,7 +71,7 @@ public class NettyChannelHandlerContextInstrumentation extends Instrumenter.Trac
     }
 
     @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class)
-    public static void close(@Advice.Enter final TraceScope scope) {
+    public static void close(@Advice.Enter final AgentScope scope) {
       scope.close();
     }
 

--- a/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/NettyChannelPipelineInstrumentation.java
+++ b/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/NettyChannelPipelineInstrumentation.java
@@ -13,7 +13,7 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.bootstrap.CallDepthThreadLocalMap;
-import datadog.trace.context.TraceScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.instrumentation.netty40.client.HttpClientRequestTracingHandler;
 import datadog.trace.instrumentation.netty40.client.HttpClientResponseTracingHandler;
 import datadog.trace.instrumentation.netty40.client.HttpClientTracingHandler;
@@ -169,11 +169,11 @@ public class NettyChannelPipelineInstrumentation extends Instrumenter.Tracing {
   public static class ConnectAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static void addParentSpan(@Advice.This final ChannelPipeline pipeline) {
-      final TraceScope scope = activeScope();
+      final AgentScope scope = activeScope();
       if (scope != null) {
-        final TraceScope.Continuation continuation = scope.capture();
+        final AgentScope.Continuation continuation = scope.capture();
         if (null != continuation) {
-          final Attribute<TraceScope.Continuation> attribute =
+          final Attribute<AgentScope.Continuation> attribute =
               pipeline.channel().attr(CONNECT_PARENT_CONTINUATION_ATTRIBUTE_KEY);
           if (!attribute.compareAndSet(null, continuation)) {
             continuation.cancel();

--- a/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/client/HttpClientRequestTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/client/HttpClientRequestTracingHandler.java
@@ -16,7 +16,6 @@ import datadog.trace.api.Config;
 import datadog.trace.api.PropagationStyle;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.context.TraceScope;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOutboundHandlerAdapter;
@@ -49,8 +48,8 @@ public class HttpClientRequestTracingHandler extends ChannelOutboundHandlerAdapt
       return;
     }
 
-    TraceScope parentScope = null;
-    final TraceScope.Continuation continuation =
+    AgentScope parentScope = null;
+    final AgentScope.Continuation continuation =
         ctx.channel().attr(CONNECT_PARENT_CONTINUATION_ATTRIBUTE_KEY).getAndRemove();
     if (continuation != null) {
       parentScope = continuation.activate();

--- a/dd-java-agent/instrumentation/netty-4.1-shared/src/main/java/datadog/trace/instrumentation/netty41/AttributeKeys.java
+++ b/dd-java-agent/instrumentation/netty-4.1-shared/src/main/java/datadog/trace/instrumentation/netty41/AttributeKeys.java
@@ -3,8 +3,8 @@ package datadog.trace.instrumentation.netty41;
 import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.DD_SPAN_ATTRIBUTE;
 
 import datadog.trace.api.GenericClassValue;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.context.TraceScope;
 import io.netty.util.AttributeKey;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -19,7 +19,7 @@ public final class AttributeKeys {
   public static final AttributeKey<AgentSpan> CLIENT_PARENT_ATTRIBUTE_KEY =
       attributeKey("datadog.client.parent.span");
 
-  public static final AttributeKey<TraceScope.Continuation>
+  public static final AttributeKey<AgentScope.Continuation>
       CONNECT_PARENT_CONTINUATION_ATTRIBUTE_KEY =
           attributeKey("datadog.connect.parent.continuation");
 

--- a/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/NettyChannelHandlerContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/NettyChannelHandlerContextInstrumentation.java
@@ -14,9 +14,9 @@ import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
-import datadog.trace.context.TraceScope;
 import datadog.trace.instrumentation.netty41.client.NettyHttpClientDecorator;
 import datadog.trace.instrumentation.netty41.server.NettyHttpServerDecorator;
 import io.netty.channel.ChannelHandlerContext;
@@ -61,7 +61,7 @@ public class NettyChannelHandlerContextInstrumentation extends Instrumenter.Trac
 
   public static class FireAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static TraceScope scopeSpan(@Advice.This final ChannelHandlerContext ctx) {
+    public static AgentScope scopeSpan(@Advice.This final ChannelHandlerContext ctx) {
       final AgentSpan channelSpan = ctx.channel().attr(SPAN_ATTRIBUTE_KEY).get();
       if (channelSpan == null || channelSpan == activeSpan()) {
         // don't modify the scope
@@ -71,7 +71,7 @@ public class NettyChannelHandlerContextInstrumentation extends Instrumenter.Trac
     }
 
     @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class)
-    public static void close(@Advice.Enter final TraceScope scope) {
+    public static void close(@Advice.Enter final AgentScope scope) {
       scope.close();
     }
 

--- a/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/NettyChannelPipelineInstrumentation.java
+++ b/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/NettyChannelPipelineInstrumentation.java
@@ -13,7 +13,7 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.bootstrap.CallDepthThreadLocalMap;
-import datadog.trace.context.TraceScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.instrumentation.netty41.client.HttpClientRequestTracingHandler;
 import datadog.trace.instrumentation.netty41.client.HttpClientResponseTracingHandler;
 import datadog.trace.instrumentation.netty41.client.HttpClientTracingHandler;
@@ -169,11 +169,11 @@ public class NettyChannelPipelineInstrumentation extends Instrumenter.Tracing {
   public static class ConnectAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static void addParentSpan(@Advice.This final ChannelPipeline pipeline) {
-      final TraceScope scope = activeScope();
+      final AgentScope scope = activeScope();
       if (scope != null) {
-        final TraceScope.Continuation continuation = scope.capture();
+        final AgentScope.Continuation continuation = scope.capture();
         if (null != continuation) {
-          final Attribute<TraceScope.Continuation> attribute =
+          final Attribute<AgentScope.Continuation> attribute =
               pipeline.channel().attr(CONNECT_PARENT_CONTINUATION_ATTRIBUTE_KEY);
           if (!attribute.compareAndSet(null, continuation)) {
             continuation.cancel();

--- a/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/client/HttpClientRequestTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/client/HttpClientRequestTracingHandler.java
@@ -16,7 +16,6 @@ import datadog.trace.api.Config;
 import datadog.trace.api.PropagationStyle;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.context.TraceScope;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOutboundHandlerAdapter;
@@ -49,8 +48,8 @@ public class HttpClientRequestTracingHandler extends ChannelOutboundHandlerAdapt
       return;
     }
 
-    TraceScope parentScope = null;
-    final TraceScope.Continuation continuation =
+    AgentScope parentScope = null;
+    final AgentScope.Continuation continuation =
         ctx.channel().attr(CONNECT_PARENT_CONTINUATION_ATTRIBUTE_KEY).getAndRemove();
     if (continuation != null) {
       parentScope = continuation.activate();

--- a/dd-java-agent/instrumentation/netty-promise-4/src/main/java/datadog/trace/instrumentation/netty4/promise/ListenerWrapper.java
+++ b/dd-java-agent/instrumentation/netty-promise-4/src/main/java/datadog/trace/instrumentation/netty4/promise/ListenerWrapper.java
@@ -4,8 +4,8 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSp
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.context.TraceScope;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
 import io.netty.util.concurrent.GenericProgressiveFutureListener;
@@ -14,7 +14,7 @@ import io.netty.util.concurrent.ProgressiveFuture;
 public final class ListenerWrapper {
 
   public static GenericFutureListener wrapIfNeeded(final GenericFutureListener listener) {
-    TraceScope scope = activeScope();
+    AgentScope scope = activeScope();
     AgentSpan span = activeSpan();
 
     if (listener != null
@@ -34,17 +34,17 @@ public final class ListenerWrapper {
   private static class GenericWrapper<T extends Future<?>> implements GenericFutureListener<T> {
 
     private final GenericFutureListener<T> listener;
-    private final TraceScope.Continuation continuation;
+    private final AgentScope.Continuation continuation;
 
     public GenericWrapper(
-        final GenericFutureListener<T> listener, TraceScope.Continuation continuation) {
+        final GenericFutureListener<T> listener, AgentScope.Continuation continuation) {
       this.listener = listener;
       this.continuation = continuation;
     }
 
     @Override
     public void operationComplete(T future) throws Exception {
-      try (TraceScope scope = continuation.activate()) {
+      try (AgentScope scope = continuation.activate()) {
         listener.operationComplete(future);
       }
     }
@@ -59,7 +59,7 @@ public final class ListenerWrapper {
     public GenericProgressiveWrapper(
         GenericProgressiveFutureListener<S> listener,
         AgentSpan span,
-        TraceScope.Continuation continuation) {
+        AgentScope.Continuation continuation) {
       super(listener, continuation);
       this.listener = listener;
       this.span = span;
@@ -67,7 +67,7 @@ public final class ListenerWrapper {
 
     @Override
     public void operationProgressed(S future, long progress, long total) throws Exception {
-      try (TraceScope scope = activateSpan(span)) {
+      try (AgentScope scope = activateSpan(span)) {
         listener.operationProgressed(future, progress, total);
       }
     }

--- a/dd-java-agent/instrumentation/opentelemetry/src/main/java/datadog/trace/instrumentation/opentelemetry/OtelScope.java
+++ b/dd-java-agent/instrumentation/opentelemetry/src/main/java/datadog/trace/instrumentation/opentelemetry/OtelScope.java
@@ -35,8 +35,4 @@ public class OtelScope implements Scope, TraceScope {
   public void setAsyncPropagation(final boolean value) {
     delegate.setAsyncPropagation(value);
   }
-
-  public AgentScope getDelegate() {
-    return delegate;
-  }
 }

--- a/dd-java-agent/instrumentation/opentracing/api-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/GlobalTracerInstrumentation.java
+++ b/dd-java-agent/instrumentation/opentracing/api-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/GlobalTracerInstrumentation.java
@@ -43,7 +43,6 @@ public class GlobalTracerInstrumentation extends Instrumenter.Tracing {
       packageName + ".OTTextMapSetter",
       packageName + ".OTScopeManager",
       packageName + ".OTScopeManager$OTScope",
-      packageName + ".OTScopeManager$OTTraceScope",
       packageName + ".TypeConverter",
       packageName + ".OTSpan",
       packageName + ".OTSpanContext",

--- a/dd-java-agent/instrumentation/opentracing/api-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/OTScopeManager.java
+++ b/dd-java-agent/instrumentation/opentracing/api-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/OTScopeManager.java
@@ -37,7 +37,7 @@ public class OTScopeManager implements ScopeManager {
     return converter.toScope(tracer.activeScope(), false);
   }
 
-  static class OTScope implements Scope {
+  static class OTScope implements Scope, TraceScope {
     private final AgentScope delegate;
     private final boolean finishSpanOnClose;
     private final TypeConverter converter;
@@ -61,18 +61,6 @@ public class OTScopeManager implements ScopeManager {
     @Override
     public Span span() {
       return converter.toSpan(delegate.span());
-    }
-  }
-
-  static class OTTraceScope extends OTScope implements TraceScope {
-    private final TraceScope delegate;
-
-    OTTraceScope(
-        final TraceScope delegate, final boolean finishSpanOnClose, final TypeConverter converter) {
-      // All instances of TraceScope implement agent scope (but not vice versa)
-      super((AgentScope) delegate, finishSpanOnClose, converter);
-
-      this.delegate = delegate;
     }
 
     @Override

--- a/dd-java-agent/instrumentation/opentracing/api-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/TypeConverter.java
+++ b/dd-java-agent/instrumentation/opentracing/api-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/TypeConverter.java
@@ -3,7 +3,6 @@ package datadog.trace.instrumentation.opentracing31;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
-import datadog.trace.context.TraceScope;
 import datadog.trace.instrumentation.opentracing.LogHandler;
 import io.opentracing.Scope;
 import io.opentracing.Span;
@@ -33,17 +32,11 @@ public class TypeConverter {
     return new OTSpan(agentSpan, this, logHandler);
   }
 
-  // FIXME [API] Need to use the runtime type not compile-time type so "Object" is used
-  // That fact that some methods return AgentScope and other TraceScope even though its the same
-  // underlying object needs to be cleaned up
-  public Scope toScope(final Object scope, final boolean finishSpanOnClose) {
+  public Scope toScope(final AgentScope scope, final boolean finishSpanOnClose) {
     if (scope == null) {
       return null;
-    } else if (scope instanceof TraceScope) {
-      return new OTScopeManager.OTTraceScope((TraceScope) scope, finishSpanOnClose, this);
-    } else {
-      return new OTScopeManager.OTScope((AgentScope) scope, finishSpanOnClose, this);
     }
+    return new OTScopeManager.OTScope(scope, finishSpanOnClose, this);
   }
 
   public SpanContext toSpanContext(final AgentSpan.Context context) {

--- a/dd-java-agent/instrumentation/opentracing/api-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/GlobalTracerInstrumentation.java
+++ b/dd-java-agent/instrumentation/opentracing/api-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/GlobalTracerInstrumentation.java
@@ -36,7 +36,6 @@ public class GlobalTracerInstrumentation extends Instrumenter.Tracing {
       packageName + ".OTTextMapInjectSetter",
       packageName + ".OTScopeManager",
       packageName + ".OTScopeManager$OTScope",
-      packageName + ".OTScopeManager$OTTraceScope",
       packageName + ".TypeConverter",
       packageName + ".OTSpan",
       packageName + ".OTSpanContext",

--- a/dd-java-agent/instrumentation/opentracing/api-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/OTScopeManager.java
+++ b/dd-java-agent/instrumentation/opentracing/api-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/OTScopeManager.java
@@ -47,7 +47,7 @@ public class OTScopeManager implements ScopeManager {
     return converter.toSpan(tracer.activeSpan());
   }
 
-  static class OTScope implements Scope {
+  static class OTScope implements Scope, TraceScope {
     private final AgentScope delegate;
     private final boolean finishSpanOnClose;
     private final TypeConverter converter;
@@ -71,18 +71,6 @@ public class OTScopeManager implements ScopeManager {
     @Override
     public Span span() {
       return converter.toSpan(delegate.span());
-    }
-  }
-
-  static class OTTraceScope extends OTScope implements TraceScope {
-    private final TraceScope delegate;
-
-    OTTraceScope(
-        final TraceScope delegate, final boolean finishSpanOnClose, final TypeConverter converter) {
-      // All instances of TraceScope implement agent scope (but not vice versa)
-      super((AgentScope) delegate, finishSpanOnClose, converter);
-
-      this.delegate = delegate;
     }
 
     @Override

--- a/dd-java-agent/instrumentation/opentracing/api-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/TypeConverter.java
+++ b/dd-java-agent/instrumentation/opentracing/api-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/TypeConverter.java
@@ -3,7 +3,6 @@ package datadog.trace.instrumentation.opentracing32;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
-import datadog.trace.context.TraceScope;
 import datadog.trace.instrumentation.opentracing.LogHandler;
 import io.opentracing.Scope;
 import io.opentracing.Span;
@@ -33,17 +32,11 @@ public class TypeConverter {
     return new OTSpan(agentSpan, this, logHandler);
   }
 
-  // FIXME [API] Need to use the runtime type not compile-time type so "Object" is used
-  // That fact that some methods return AgentScope and other TraceScope even though its the same
-  // underlying object needs to be cleaned up
-  public Scope toScope(final Object scope, final boolean finishSpanOnClose) {
+  public Scope toScope(final AgentScope scope, final boolean finishSpanOnClose) {
     if (scope == null) {
       return null;
-    } else if (scope instanceof TraceScope) {
-      return new OTScopeManager.OTTraceScope((TraceScope) scope, finishSpanOnClose, this);
-    } else {
-      return new OTScopeManager.OTScope((AgentScope) scope, finishSpanOnClose, this);
     }
+    return new OTScopeManager.OTScope(scope, finishSpanOnClose, this);
   }
 
   public SpanContext toSpanContext(final AgentSpan.Context context) {

--- a/dd-java-agent/instrumentation/play-2.3/src/main/java8/datadog/trace/instrumentation/play23/RequestCompleteCallback.java
+++ b/dd-java-agent/instrumentation/play-2.3/src/main/java8/datadog/trace/instrumentation/play23/RequestCompleteCallback.java
@@ -4,8 +4,8 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScop
 import static datadog.trace.instrumentation.play23.PlayHttpServerDecorator.DECORATE;
 import static datadog.trace.instrumentation.play23.PlayHttpServerDecorator.REPORT_HTTP_STATUS;
 
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.context.TraceScope;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import play.api.mvc.Result;
@@ -31,7 +31,7 @@ public class RequestCompleteCallback extends scala.runtime.AbstractFunction1<Try
         }
       }
       DECORATE.beforeFinish(span);
-      final TraceScope scope = activeScope();
+      final AgentScope scope = activeScope();
       if (scope != null) {
         scope.setAsyncPropagation(false);
       }

--- a/dd-java-agent/instrumentation/play-2.4/src/main/java8/datadog/trace/instrumentation/play24/RequestCompleteCallback.java
+++ b/dd-java-agent/instrumentation/play-2.4/src/main/java8/datadog/trace/instrumentation/play24/RequestCompleteCallback.java
@@ -4,8 +4,8 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScop
 import static datadog.trace.instrumentation.play24.PlayHttpServerDecorator.DECORATE;
 import static datadog.trace.instrumentation.play24.PlayHttpServerDecorator.REPORT_HTTP_STATUS;
 
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.context.TraceScope;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import play.api.mvc.Result;
@@ -30,7 +30,7 @@ public class RequestCompleteCallback extends scala.runtime.AbstractFunction1<Try
         }
       }
       DECORATE.beforeFinish(span);
-      final TraceScope scope = activeScope();
+      final AgentScope scope = activeScope();
       if (scope != null) {
         scope.setAsyncPropagation(false);
       }

--- a/dd-java-agent/instrumentation/play-2.6/src/main/java8/datadog/trace/instrumentation/play26/RequestCompleteCallback.java
+++ b/dd-java-agent/instrumentation/play-2.6/src/main/java8/datadog/trace/instrumentation/play26/RequestCompleteCallback.java
@@ -4,8 +4,8 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScop
 import static datadog.trace.instrumentation.play26.PlayHttpServerDecorator.DECORATE;
 import static datadog.trace.instrumentation.play26.PlayHttpServerDecorator.REPORT_HTTP_STATUS;
 
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.context.TraceScope;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import play.api.mvc.Result;
@@ -32,7 +32,7 @@ public class RequestCompleteCallback extends scala.runtime.AbstractFunction1<Try
         }
       }
       DECORATE.beforeFinish(span);
-      final TraceScope scope = activeScope();
+      final AgentScope scope = activeScope();
       if (scope != null) {
         scope.setAsyncPropagation(false);
       }

--- a/dd-java-agent/instrumentation/play-ws-1/src/main/java/datadog/trace/instrumentation/playws1/AsyncHandlerWrapper.java
+++ b/dd-java-agent/instrumentation/play-ws-1/src/main/java/datadog/trace/instrumentation/playws1/AsyncHandlerWrapper.java
@@ -3,8 +3,8 @@ package datadog.trace.instrumentation.playws1;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
 import static datadog.trace.instrumentation.playws.PlayWSClientDecorator.DECORATE;
 
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.context.TraceScope;
 import play.shaded.ahc.org.asynchttpclient.AsyncHandler;
 import play.shaded.ahc.org.asynchttpclient.HttpResponseBodyPart;
 import play.shaded.ahc.org.asynchttpclient.HttpResponseHeaders;
@@ -14,7 +14,7 @@ import play.shaded.ahc.org.asynchttpclient.Response;
 public class AsyncHandlerWrapper implements AsyncHandler {
   private final AsyncHandler delegate;
   private final AgentSpan span;
-  private final TraceScope.Continuation continuation;
+  private final AgentScope.Continuation continuation;
 
   private final Response.ResponseBuilder builder = new Response.ResponseBuilder();
 
@@ -53,7 +53,7 @@ public class AsyncHandlerWrapper implements AsyncHandler {
     span.finish();
 
     if (continuation != null) {
-      try (final TraceScope scope = continuation.activate()) {
+      try (final AgentScope scope = continuation.activate()) {
         scope.setAsyncPropagation(true);
         return delegate.onCompleted();
       }
@@ -69,7 +69,7 @@ public class AsyncHandlerWrapper implements AsyncHandler {
     span.finish();
 
     if (continuation != null) {
-      try (final TraceScope scope = continuation.activate()) {
+      try (final AgentScope scope = continuation.activate()) {
         scope.setAsyncPropagation(true);
         delegate.onThrowable(throwable);
       }

--- a/dd-java-agent/instrumentation/play-ws-2.1/src/main/java/datadog/trace/instrumentation/playws21/AsyncHandlerWrapper.java
+++ b/dd-java-agent/instrumentation/play-ws-2.1/src/main/java/datadog/trace/instrumentation/playws21/AsyncHandlerWrapper.java
@@ -3,8 +3,8 @@ package datadog.trace.instrumentation.playws21;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
 import static datadog.trace.instrumentation.playws.PlayWSClientDecorator.DECORATE;
 
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.context.TraceScope;
 import java.net.InetSocketAddress;
 import java.util.List;
 import javax.net.ssl.SSLSession;
@@ -19,7 +19,7 @@ import play.shaded.ahc.org.asynchttpclient.netty.request.NettyRequest;
 public class AsyncHandlerWrapper implements AsyncHandler {
   private final AsyncHandler delegate;
   private final AgentSpan span;
-  private final TraceScope.Continuation continuation;
+  private final AgentScope.Continuation continuation;
 
   private final Response.ResponseBuilder builder = new Response.ResponseBuilder();
 
@@ -58,7 +58,7 @@ public class AsyncHandlerWrapper implements AsyncHandler {
     span.finish();
 
     if (continuation != null) {
-      try (final TraceScope scope = continuation.activate()) {
+      try (final AgentScope scope = continuation.activate()) {
         scope.setAsyncPropagation(true);
         return delegate.onCompleted();
       }
@@ -74,7 +74,7 @@ public class AsyncHandlerWrapper implements AsyncHandler {
     span.finish();
 
     if (continuation != null) {
-      try (final TraceScope scope = continuation.activate()) {
+      try (final AgentScope scope = continuation.activate()) {
         scope.setAsyncPropagation(true);
         delegate.onThrowable(throwable);
       }

--- a/dd-java-agent/instrumentation/play-ws-2/src/main/java/datadog/trace/instrumentation/playws2/AsyncHandlerWrapper.java
+++ b/dd-java-agent/instrumentation/play-ws-2/src/main/java/datadog/trace/instrumentation/playws2/AsyncHandlerWrapper.java
@@ -3,8 +3,8 @@ package datadog.trace.instrumentation.playws2;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
 import static datadog.trace.instrumentation.playws.PlayWSClientDecorator.DECORATE;
 
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.context.TraceScope;
 import java.net.InetSocketAddress;
 import java.util.List;
 import play.shaded.ahc.io.netty.channel.Channel;
@@ -18,7 +18,7 @@ import play.shaded.ahc.org.asynchttpclient.netty.request.NettyRequest;
 public class AsyncHandlerWrapper implements AsyncHandler {
   private final AsyncHandler delegate;
   private final AgentSpan span;
-  private final TraceScope.Continuation continuation;
+  private final AgentScope.Continuation continuation;
 
   private final Response.ResponseBuilder builder = new Response.ResponseBuilder();
 
@@ -57,7 +57,7 @@ public class AsyncHandlerWrapper implements AsyncHandler {
     span.finish();
 
     if (continuation != null) {
-      try (final TraceScope scope = continuation.activate()) {
+      try (final AgentScope scope = continuation.activate()) {
         scope.setAsyncPropagation(true);
         return delegate.onCompleted();
       }
@@ -73,7 +73,7 @@ public class AsyncHandlerWrapper implements AsyncHandler {
     span.finish();
 
     if (continuation != null) {
-      try (final TraceScope scope = continuation.activate()) {
+      try (final AgentScope scope = continuation.activate()) {
         scope.setAsyncPropagation(true);
         delegate.onThrowable(throwable);
       }

--- a/dd-java-agent/instrumentation/reactor-core-3.1/src/main/java8/datadog/trace/instrumentation/reactor/core/TracingSubscriber.java
+++ b/dd-java-agent/instrumentation/reactor-core-3.1/src/main/java8/datadog/trace/instrumentation/reactor/core/TracingSubscriber.java
@@ -2,8 +2,8 @@ package datadog.trace.instrumentation.reactor.core;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.context.TraceScope;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
@@ -32,21 +32,21 @@ public class TracingSubscriber<T> implements CoreSubscriber<T> {
 
   @Override
   public void onNext(final T o) {
-    try (TraceScope scope = activateSpan(span)) {
+    try (AgentScope scope = activateSpan(span)) {
       subscriber.onNext(o);
     }
   }
 
   @Override
   public void onError(final Throwable throwable) {
-    try (TraceScope scope = activateSpan(span)) {
+    try (AgentScope scope = activateSpan(span)) {
       subscriber.onError(throwable);
     }
   }
 
   @Override
   public void onComplete() {
-    try (TraceScope scope = activateSpan(span)) {
+    try (AgentScope scope = activateSpan(span)) {
       subscriber.onComplete();
     }
   }

--- a/dd-java-agent/instrumentation/reactor-netty-1/src/main/java8/datadog/trace/instrumentation/reactor/netty/TransferConnectSpan.java
+++ b/dd-java-agent/instrumentation/reactor-netty-1/src/main/java8/datadog/trace/instrumentation/reactor/netty/TransferConnectSpan.java
@@ -1,10 +1,10 @@
 package datadog.trace.instrumentation.reactor.netty;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.captureSpan;
-import static datadog.trace.context.TraceScope.Continuation;
 import static datadog.trace.instrumentation.netty41.AttributeKeys.CONNECT_PARENT_CONTINUATION_ATTRIBUTE_KEY;
 import static datadog.trace.instrumentation.reactor.netty.CaptureConnectSpan.CONNECT_SPAN;
 
+import datadog.trace.bootstrap.instrumentation.api.AgentScope.Continuation;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import java.util.function.BiConsumer;
 import reactor.netty.Connection;

--- a/dd-java-agent/instrumentation/rediscala-1.8.0/src/main/java/datadog/trace/instrumentation/rediscala/OnCompleteHandler.java
+++ b/dd-java-agent/instrumentation/rediscala-1.8.0/src/main/java/datadog/trace/instrumentation/rediscala/OnCompleteHandler.java
@@ -5,7 +5,6 @@ import static datadog.trace.instrumentation.rediscala.RediscalaClientDecorator.D
 
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.context.TraceScope;
 import scala.runtime.AbstractFunction1;
 import scala.util.Try;
 
@@ -16,9 +15,9 @@ public final class OnCompleteHandler extends AbstractFunction1<Try<Object>, Void
   @Override
   public Void apply(final Try<Object> result) {
     // propagation handled by scala promise instrumentation
-    TraceScope activeScope = activeScope();
-    if (activeScope instanceof AgentScope) {
-      AgentSpan span = ((AgentScope) activeScope).span();
+    AgentScope activeScope = activeScope();
+    if (null != activeScope) {
+      AgentSpan span = activeScope.span();
       try {
         if (result.isFailure()) {
           DECORATE.onError(span, result.failed().get());

--- a/dd-java-agent/instrumentation/rxjava-1/src/main/java/datadog/trace/instrumentation/rxjava/TracedOnSubscribe.java
+++ b/dd-java-agent/instrumentation/rxjava-1/src/main/java/datadog/trace/instrumentation/rxjava/TracedOnSubscribe.java
@@ -7,7 +7,6 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.decorator.BaseDecorator;
-import datadog.trace.context.TraceScope;
 import rx.DDTracingUtil;
 import rx.Observable;
 import rx.Subscriber;
@@ -16,7 +15,7 @@ public class TracedOnSubscribe<T> implements Observable.OnSubscribe<T> {
 
   private final Observable.OnSubscribe<?> delegate;
   private final String operationName;
-  private final TraceScope.Continuation continuation;
+  private final AgentScope.Continuation continuation;
   private final BaseDecorator decorator;
 
   public TracedOnSubscribe(
@@ -34,7 +33,7 @@ public class TracedOnSubscribe<T> implements Observable.OnSubscribe<T> {
   public void call(final Subscriber<? super T> subscriber) {
     final AgentSpan span; // span finished by TracedSubscriber
     if (continuation != null) {
-      try (final TraceScope scope = continuation.activate()) {
+      try (final AgentScope scope = continuation.activate()) {
         span = startSpan(operationName);
       }
     } else {

--- a/dd-java-agent/instrumentation/rxjava-2/src/main/java/datadog/trace/instrumentation/rxjava2/TracingCompletableObserver.java
+++ b/dd-java-agent/instrumentation/rxjava-2/src/main/java/datadog/trace/instrumentation/rxjava2/TracingCompletableObserver.java
@@ -2,8 +2,8 @@ package datadog.trace.instrumentation.rxjava2;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.context.TraceScope;
 import io.reactivex.CompletableObserver;
 import io.reactivex.disposables.Disposable;
 
@@ -25,14 +25,14 @@ public final class TracingCompletableObserver implements CompletableObserver {
 
   @Override
   public void onError(final Throwable e) {
-    try (final TraceScope scope = activateSpan(parentSpan)) {
+    try (final AgentScope scope = activateSpan(parentSpan)) {
       observer.onError(e);
     }
   }
 
   @Override
   public void onComplete() {
-    try (final TraceScope scope = activateSpan(parentSpan)) {
+    try (final AgentScope scope = activateSpan(parentSpan)) {
       observer.onComplete();
     }
   }

--- a/dd-java-agent/instrumentation/rxjava-2/src/main/java/datadog/trace/instrumentation/rxjava2/TracingMaybeObserver.java
+++ b/dd-java-agent/instrumentation/rxjava-2/src/main/java/datadog/trace/instrumentation/rxjava2/TracingMaybeObserver.java
@@ -2,8 +2,8 @@ package datadog.trace.instrumentation.rxjava2;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.context.TraceScope;
 import io.reactivex.MaybeObserver;
 import io.reactivex.disposables.Disposable;
 
@@ -24,21 +24,21 @@ public final class TracingMaybeObserver<T> implements MaybeObserver<T> {
 
   @Override
   public void onSuccess(final T value) {
-    try (final TraceScope scope = activateSpan(parentSpan)) {
+    try (final AgentScope scope = activateSpan(parentSpan)) {
       observer.onSuccess(value);
     }
   }
 
   @Override
   public void onError(final Throwable e) {
-    try (final TraceScope scope = activateSpan(parentSpan)) {
+    try (final AgentScope scope = activateSpan(parentSpan)) {
       observer.onError(e);
     }
   }
 
   @Override
   public void onComplete() {
-    try (final TraceScope scope = activateSpan(parentSpan)) {
+    try (final AgentScope scope = activateSpan(parentSpan)) {
       observer.onComplete();
     }
   }

--- a/dd-java-agent/instrumentation/rxjava-2/src/main/java/datadog/trace/instrumentation/rxjava2/TracingObserver.java
+++ b/dd-java-agent/instrumentation/rxjava-2/src/main/java/datadog/trace/instrumentation/rxjava2/TracingObserver.java
@@ -2,8 +2,8 @@ package datadog.trace.instrumentation.rxjava2;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.context.TraceScope;
 import io.reactivex.Observer;
 import io.reactivex.disposables.Disposable;
 
@@ -24,21 +24,21 @@ public final class TracingObserver<T> implements Observer<T> {
 
   @Override
   public void onNext(final T value) {
-    try (final TraceScope scope = activateSpan(parentSpan)) {
+    try (final AgentScope scope = activateSpan(parentSpan)) {
       observer.onNext(value);
     }
   }
 
   @Override
   public void onError(final Throwable e) {
-    try (final TraceScope scope = activateSpan(parentSpan)) {
+    try (final AgentScope scope = activateSpan(parentSpan)) {
       observer.onError(e);
     }
   }
 
   @Override
   public void onComplete() {
-    try (final TraceScope scope = activateSpan(parentSpan)) {
+    try (final AgentScope scope = activateSpan(parentSpan)) {
       observer.onComplete();
     }
   }

--- a/dd-java-agent/instrumentation/rxjava-2/src/main/java/datadog/trace/instrumentation/rxjava2/TracingSingleObserver.java
+++ b/dd-java-agent/instrumentation/rxjava-2/src/main/java/datadog/trace/instrumentation/rxjava2/TracingSingleObserver.java
@@ -2,8 +2,8 @@ package datadog.trace.instrumentation.rxjava2;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.context.TraceScope;
 import io.reactivex.SingleObserver;
 import io.reactivex.disposables.Disposable;
 
@@ -24,14 +24,14 @@ public final class TracingSingleObserver<T> implements SingleObserver<T> {
 
   @Override
   public void onSuccess(final T value) {
-    try (final TraceScope scope = activateSpan(parentSpan)) {
+    try (final AgentScope scope = activateSpan(parentSpan)) {
       observer.onSuccess(value);
     }
   }
 
   @Override
   public void onError(final Throwable e) {
-    try (final TraceScope scope = activateSpan(parentSpan)) {
+    try (final AgentScope scope = activateSpan(parentSpan)) {
       observer.onError(e);
     }
   }

--- a/dd-java-agent/instrumentation/rxjava-2/src/main/java/datadog/trace/instrumentation/rxjava2/TracingSubscriber.java
+++ b/dd-java-agent/instrumentation/rxjava-2/src/main/java/datadog/trace/instrumentation/rxjava2/TracingSubscriber.java
@@ -2,8 +2,8 @@ package datadog.trace.instrumentation.rxjava2;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.context.TraceScope;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
@@ -24,21 +24,21 @@ public final class TracingSubscriber<T> implements Subscriber<T> {
 
   @Override
   public void onNext(final T value) {
-    try (final TraceScope scope = activateSpan(parentSpan)) {
+    try (final AgentScope scope = activateSpan(parentSpan)) {
       subscriber.onNext(value);
     }
   }
 
   @Override
   public void onError(final Throwable e) {
-    try (final TraceScope scope = activateSpan(parentSpan)) {
+    try (final AgentScope scope = activateSpan(parentSpan)) {
       subscriber.onError(e);
     }
   }
 
   @Override
   public void onComplete() {
-    try (final TraceScope scope = activateSpan(parentSpan)) {
+    try (final AgentScope scope = activateSpan(parentSpan)) {
       subscriber.onComplete();
     }
   }

--- a/dd-java-agent/instrumentation/scala-concurrent/src/main/java/datadog/trace/instrumentation/scala/concurrent/ScalaForkJoinTaskInstrumentation.java
+++ b/dd-java-agent/instrumentation/scala-concurrent/src/main/java/datadog/trace/instrumentation/scala/concurrent/ScalaForkJoinTaskInstrumentation.java
@@ -20,9 +20,9 @@ import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.ExcludeFilterProvider;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.bootstrap.InstrumentationContext;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.State;
-import datadog.trace.context.TraceScope;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
@@ -84,12 +84,12 @@ public final class ScalaForkJoinTaskInstrumentation extends Instrumenter.Tracing
 
   public static final class Exec {
     @Advice.OnMethodEnter
-    public static <T> TraceScope before(@Advice.This ForkJoinTask<T> task) {
+    public static <T> AgentScope before(@Advice.This ForkJoinTask<T> task) {
       return startTaskScope(InstrumentationContext.get(ForkJoinTask.class, State.class), task);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class)
-    public static void after(@Advice.Enter TraceScope scope) {
+    public static void after(@Advice.Enter AgentScope scope) {
       endTaskScope(scope);
     }
   }

--- a/dd-java-agent/instrumentation/scala-promise/src/main/java/datadog/trace/instrumentation/scala/PromiseHelper.java
+++ b/dd-java-agent/instrumentation/scala-promise/src/main/java/datadog/trace/instrumentation/scala/PromiseHelper.java
@@ -1,14 +1,12 @@
 package datadog.trace.instrumentation.scala;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.captureSpan;
 
 import datadog.trace.api.Config;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.State;
-import datadog.trace.context.TraceScope;
 import java.util.Collections;
 import scala.util.Failure;
 import scala.util.Success;
@@ -27,16 +25,11 @@ public class PromiseHelper {
    * @return the Span or null
    */
   public static AgentSpan getSpan() {
-    AgentSpan span = null;
-    final TraceScope scope = activeScope();
+    final AgentScope scope = activeScope();
     if (null != scope && scope.isAsyncPropagating()) {
-      if (scope instanceof AgentScope) {
-        span = ((AgentScope) scope).span();
-      } else {
-        span = activeSpan();
-      }
+      return scope.span();
     }
-    return span;
+    return null;
   }
 
   /**
@@ -79,8 +72,8 @@ public class PromiseHelper {
       // TODO Optimization
       // One could possibly peek at the Span in the existing Continuation and not do anything if it
       // was the same Span
-      TraceScope.Continuation continuation = captureSpan(span);
-      TraceScope.Continuation existing = null;
+      AgentScope.Continuation continuation = captureSpan(span);
+      AgentScope.Continuation existing = null;
       if (null != state) {
         existing = state.getAndResetContinuation();
       } else {

--- a/dd-java-agent/instrumentation/slick/src/main/java/datadog.trace.instrumentation.slick/SlickRunnableInstrumentation.java
+++ b/dd-java-agent/instrumentation/slick/src/main/java/datadog.trace.instrumentation.slick/SlickRunnableInstrumentation.java
@@ -10,9 +10,9 @@ import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers;
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.InstrumentationContext;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.AdviceUtils;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.State;
-import datadog.trace.context.TraceScope;
 import java.util.Collections;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
@@ -52,14 +52,14 @@ public final class SlickRunnableInstrumentation extends Instrumenter.Tracing {
 
   public static final class Run {
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static TraceScope enter(@Advice.This final Runnable zis) {
+    public static AgentScope enter(@Advice.This final Runnable zis) {
       final ContextStore<Runnable, State> contextStore =
           InstrumentationContext.get(Runnable.class, State.class);
       return AdviceUtils.startTaskScope(contextStore, zis);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
-    public static void exit(@Advice.Enter final TraceScope scope) {
+    public static void exit(@Advice.Enter final AgentScope scope) {
       AdviceUtils.endTaskScope(scope);
     }
   }

--- a/dd-java-agent/instrumentation/spring-rabbit/src/main/java/datadog/trace/instrumentation/springamqp/AbstractMessageListenerContainerInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-rabbit/src/main/java/datadog/trace/instrumentation/springamqp/AbstractMessageListenerContainerInstrumentation.java
@@ -18,7 +18,6 @@ import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.State;
-import datadog.trace.context.TraceScope;
 import java.util.Collection;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
@@ -71,9 +70,9 @@ public class AbstractMessageListenerContainerInstrumentation extends Instrumente
         Message message = (Message) data;
         State state = InstrumentationContext.get(Message.class, State.class).get(message);
         if (null != state) {
-          TraceScope.Continuation continuation = state.getAndResetContinuation();
+          AgentScope.Continuation continuation = state.getAndResetContinuation();
           if (null != continuation) {
-            try (TraceScope scope = continuation.activate()) {
+            try (AgentScope scope = continuation.activate()) {
               AgentSpan span = startSpan(AMQP_CONSUME);
               span.setMeasured(true);
               DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/spring-rabbit/src/main/java/datadog/trace/instrumentation/springamqp/DeliveryInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-rabbit/src/main/java/datadog/trace/instrumentation/springamqp/DeliveryInstrumentation.java
@@ -8,8 +8,8 @@ import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.bootstrap.InstrumentationContext;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.State;
-import datadog.trace.context.TraceScope;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
@@ -40,7 +40,7 @@ public class DeliveryInstrumentation extends Instrumenter.Tracing {
   public static class CaptureActiveScope {
     @Advice.OnMethodExit
     public static void captureActiveScope(@Advice.This Delivery delivery) {
-      TraceScope scope = activeScope();
+      AgentScope scope = activeScope();
       if (null != scope) {
         State state = State.FACTORY.create();
         state.captureAndSetContinuation(scope);

--- a/dd-java-agent/instrumentation/spring-scheduling-3.1/src/main/java/datadog/trace/instrumentation/springscheduling/SpannedMethodInvocation.java
+++ b/dd-java-agent/instrumentation/spring-scheduling-3.1/src/main/java/datadog/trace/instrumentation/springscheduling/SpannedMethodInvocation.java
@@ -6,17 +6,16 @@ import static datadog.trace.instrumentation.springscheduling.SpringSchedulingDec
 
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.context.TraceScope;
 import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Method;
 import org.aopalliance.intercept.MethodInvocation;
 
 public class SpannedMethodInvocation implements MethodInvocation {
 
-  private final TraceScope.Continuation continuation;
+  private final AgentScope.Continuation continuation;
   private final MethodInvocation delegate;
 
-  public SpannedMethodInvocation(TraceScope.Continuation continuation, MethodInvocation delegate) {
+  public SpannedMethodInvocation(AgentScope.Continuation continuation, MethodInvocation delegate) {
     this.continuation = continuation;
     this.delegate = delegate;
   }
@@ -38,7 +37,7 @@ public class SpannedMethodInvocation implements MethodInvocation {
   }
 
   private Object invokeWithContinuation(CharSequence spanName) throws Throwable {
-    try (TraceScope scope = continuation.activate()) {
+    try (AgentScope scope = continuation.activate()) {
       scope.setAsyncPropagation(true);
       return invokeWithSpan(spanName);
     }

--- a/dd-java-agent/instrumentation/spring-scheduling-3.1/src/main/java/datadog/trace/instrumentation/springscheduling/SpringAsyncAdvice.java
+++ b/dd-java-agent/instrumentation/spring-scheduling-3.1/src/main/java/datadog/trace/instrumentation/springscheduling/SpringAsyncAdvice.java
@@ -2,7 +2,7 @@ package datadog.trace.instrumentation.springscheduling;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
 
-import datadog.trace.context.TraceScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import net.bytebuddy.asm.Advice;
 import org.aopalliance.intercept.MethodInvocation;
 
@@ -11,7 +11,7 @@ public class SpringAsyncAdvice {
   @Advice.OnMethodEnter(suppress = Throwable.class)
   public static void scheduleAsync(
       @Advice.Argument(value = 0, readOnly = false) MethodInvocation invocation) {
-    TraceScope scope = activeScope();
+    AgentScope scope = activeScope();
     invocation = new SpannedMethodInvocation(null == scope ? null : scope.capture(), invocation);
   }
 }

--- a/dd-java-agent/instrumentation/synapse-3/src/main/java/datadog/trace/instrumentation/synapse3/SynapseClientWorkerInstrumentation.java
+++ b/dd-java-agent/instrumentation/synapse-3/src/main/java/datadog/trace/instrumentation/synapse3/SynapseClientWorkerInstrumentation.java
@@ -12,7 +12,6 @@ import static net.bytebuddy.matcher.ElementMatchers.takesNoArguments;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
-import datadog.trace.context.TraceScope;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
@@ -52,7 +51,7 @@ public final class SynapseClientWorkerInstrumentation extends Instrumenter.Traci
   public static final class NewClientWorkerAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static void createWorker(@Advice.Argument(2) final TargetResponse response) {
-      TraceScope scope = activeScope();
+      AgentScope scope = activeScope();
       if (null != scope) {
         response
             .getConnection()
@@ -66,11 +65,11 @@ public final class SynapseClientWorkerInstrumentation extends Instrumenter.Traci
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static AgentScope beginResponse(
         @Advice.FieldValue("response") final TargetResponse response) {
-      TraceScope.Continuation continuation =
-          (TraceScope.Continuation)
+      AgentScope.Continuation continuation =
+          (AgentScope.Continuation)
               response.getConnection().getContext().removeAttribute(SYNAPSE_CONTINUATION_KEY);
       if (null != continuation) {
-        return (AgentScope) continuation.activate();
+        return continuation.activate();
       }
       return null;
     }

--- a/dd-java-agent/instrumentation/synapse-3/src/main/java/datadog/trace/instrumentation/synapse3/SynapseServerWorkerInstrumentation.java
+++ b/dd-java-agent/instrumentation/synapse-3/src/main/java/datadog/trace/instrumentation/synapse3/SynapseServerWorkerInstrumentation.java
@@ -14,7 +14,6 @@ import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.context.TraceScope;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
@@ -54,7 +53,7 @@ public final class SynapseServerWorkerInstrumentation extends Instrumenter.Traci
   public static final class NewServerWorkerAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static void createWorker(@Advice.Argument(0) final SourceRequest request) {
-      TraceScope scope = activeScope();
+      AgentScope scope = activeScope();
       if (null != scope) {
         request
             .getConnection()
@@ -68,11 +67,11 @@ public final class SynapseServerWorkerInstrumentation extends Instrumenter.Traci
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static AgentScope beginResponse(
         @Advice.FieldValue("request") final SourceRequest request) {
-      TraceScope.Continuation continuation =
-          (TraceScope.Continuation)
+      AgentScope.Continuation continuation =
+          (AgentScope.Continuation)
               request.getConnection().getContext().removeAttribute(SYNAPSE_CONTINUATION_KEY);
       if (null != continuation) {
-        return (AgentScope) continuation.activate();
+        return continuation.activate();
       }
       return null;
     }

--- a/dd-java-agent/instrumentation/testng-6.4/src/main/java/datadog/trace/instrumentation/testng/TracingListener.java
+++ b/dd-java-agent/instrumentation/testng-6.4/src/main/java/datadog/trace/instrumentation/testng/TracingListener.java
@@ -7,7 +7,6 @@ import static datadog.trace.instrumentation.testng.TestNGDecorator.DECORATE;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
-import datadog.trace.context.TraceScope;
 import org.testng.ITestContext;
 import org.testng.ITestListener;
 import org.testng.ITestResult;
@@ -46,7 +45,7 @@ public class TracingListener implements ITestListener {
       return;
     }
 
-    final TraceScope scope = AgentTracer.activeScope();
+    final AgentScope scope = AgentTracer.activeScope();
     if (scope != null) {
       scope.close();
     }
@@ -63,7 +62,7 @@ public class TracingListener implements ITestListener {
       return;
     }
 
-    final TraceScope scope = AgentTracer.activeScope();
+    final AgentScope scope = AgentTracer.activeScope();
     if (scope != null) {
       scope.close();
     }
@@ -80,7 +79,7 @@ public class TracingListener implements ITestListener {
       return;
     }
 
-    final TraceScope scope = AgentTracer.activeScope();
+    final AgentScope scope = AgentTracer.activeScope();
     if (scope != null) {
       scope.close();
     }

--- a/dd-java-agent/instrumentation/vertx-mysql-client-3.9/src/main/java8/datadog/trace/instrumentation/vertx_sql_client/CursorReadAdvice.java
+++ b/dd-java-agent/instrumentation/vertx-mysql-client-3.9/src/main/java8/datadog/trace/instrumentation/vertx_sql_client/CursorReadAdvice.java
@@ -9,7 +9,6 @@ import datadog.trace.api.Pair;
 import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.context.TraceScope;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.mysqlclient.MySQLConnection;
@@ -29,7 +28,7 @@ public class CursorReadAdvice {
       return null;
     }
     final AgentSpan parentSpan = activeSpan();
-    final TraceScope.Continuation parentContinuation =
+    final AgentScope.Continuation parentContinuation =
         null == parentSpan ? null : captureSpan(parentSpan);
     final AgentSpan clientSpan =
         DECORATE.startAndDecorateSpanForStatement(

--- a/dd-java-agent/instrumentation/vertx-mysql-client-3.9/src/main/java8/datadog/trace/instrumentation/vertx_sql_client/QueryAdvice.java
+++ b/dd-java-agent/instrumentation/vertx-mysql-client-3.9/src/main/java8/datadog/trace/instrumentation/vertx_sql_client/QueryAdvice.java
@@ -10,7 +10,6 @@ import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.context.TraceScope;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.mysqlclient.MySQLConnection;
@@ -49,7 +48,7 @@ public class QueryAdvice {
       final boolean prepared = !(maybeHandler instanceof Handler);
 
       final AgentSpan parentSpan = activeSpan();
-      final TraceScope.Continuation parentContinuation =
+      final AgentScope.Continuation parentContinuation =
           null == parentSpan ? null : captureSpan(parentSpan);
       final AgentSpan clientSpan =
           DECORATE.startAndDecorateSpanForStatement(

--- a/dd-java-agent/instrumentation/vertx-mysql-client-3.9/src/main/java8/datadog/trace/instrumentation/vertx_sql_client/QueryResultHandlerWrapper.java
+++ b/dd-java-agent/instrumentation/vertx-mysql-client-3.9/src/main/java8/datadog/trace/instrumentation/vertx_sql_client/QueryResultHandlerWrapper.java
@@ -1,7 +1,7 @@
 package datadog.trace.instrumentation.vertx_sql_client;
 
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.context.TraceScope;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.sqlclient.SqlResult;
@@ -10,12 +10,12 @@ public class QueryResultHandlerWrapper<T, R extends SqlResult<T>>
     implements Handler<AsyncResult<R>> {
   private final Handler<AsyncResult<R>> handler;
   private final AgentSpan clientSpan;
-  private final TraceScope.Continuation parentContinuation;
+  private final AgentScope.Continuation parentContinuation;
 
   public QueryResultHandlerWrapper(
       final Handler<AsyncResult<R>> handler,
       final AgentSpan clientSpan,
-      final TraceScope.Continuation parentContinuation) {
+      final AgentScope.Continuation parentContinuation) {
     this.handler = handler;
     this.clientSpan = clientSpan;
     this.parentContinuation = parentContinuation;
@@ -23,7 +23,7 @@ public class QueryResultHandlerWrapper<T, R extends SqlResult<T>>
 
   @Override
   public void handle(final AsyncResult<R> event) {
-    TraceScope scope = null;
+    AgentScope scope = null;
     try {
       if (null != clientSpan) {
         clientSpan.finish();

--- a/dd-java-agent/instrumentation/vertx-redis-client-3.9/src/main/java8/datadog/trace/instrumentation/vertx_redis_client/RedisAPICallAdvice.java
+++ b/dd-java-agent/instrumentation/vertx-redis-client-3.9/src/main/java8/datadog/trace/instrumentation/vertx_redis_client/RedisAPICallAdvice.java
@@ -7,8 +7,8 @@ import static datadog.trace.instrumentation.vertx_redis_client.VertxRedisClientD
 
 import datadog.trace.bootstrap.CallDepthThreadLocalMap;
 import datadog.trace.bootstrap.InstrumentationContext;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.context.TraceScope;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.redis.RedisClient;
@@ -24,7 +24,7 @@ public class RedisAPICallAdvice {
   public static boolean beforeCall(
       @Advice.Origin final Method currentMethod,
       @Advice.This final RedisAPI self,
-      @Advice.Local("callScope") TraceScope scope,
+      @Advice.Local("callScope") AgentScope scope,
       @Advice.Argument(
               value = 0,
               readOnly = false,
@@ -104,7 +104,7 @@ public class RedisAPICallAdvice {
 
     final AgentSpan parentSpan = activeSpan();
     final AgentSpan clientSpan = DECORATE.startAndDecorateSpan(method.getName());
-    TraceScope.Continuation parentContinuation =
+    AgentScope.Continuation parentContinuation =
         null == parentSpan ? null : captureSpan(parentSpan);
     /*
     Opens a new scope.
@@ -150,7 +150,7 @@ public class RedisAPICallAdvice {
   public static void afterCall(
       @Advice.Thrown final Throwable throwable,
       @Advice.This final RedisAPI self,
-      @Advice.Local("callScope") TraceScope scope,
+      @Advice.Local("callScope") AgentScope scope,
       @Advice.Enter final boolean decrement) {
     if (decrement) {
       CallDepthThreadLocalMap.decrementCallDepth(RedisAPI.class);

--- a/dd-java-agent/instrumentation/vertx-redis-client-3.9/src/main/java8/datadog/trace/instrumentation/vertx_redis_client/RedisSendAdvice.java
+++ b/dd-java-agent/instrumentation/vertx-redis-client-3.9/src/main/java8/datadog/trace/instrumentation/vertx_redis_client/RedisSendAdvice.java
@@ -12,7 +12,6 @@ import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
-import datadog.trace.context.TraceScope;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.redis.RedisClient;
@@ -53,7 +52,7 @@ public class RedisSendAdvice {
     }
 
     AgentSpan parentSan = activeSpan();
-    TraceScope.Continuation parentContinuation = null == parentSan ? null : captureSpan(parentSan);
+    AgentScope.Continuation parentContinuation = null == parentSan ? null : captureSpan(parentSan);
     final AgentSpan clientSpan =
         DECORATE.startAndDecorateSpan(
             request.command(), InstrumentationContext.get(Command.class, UTF8BytesString.class));

--- a/dd-java-agent/instrumentation/vertx-redis-client-3.9/src/main/java8/datadog/trace/instrumentation/vertx_redis_client/ResponseHandlerWrapper.java
+++ b/dd-java-agent/instrumentation/vertx-redis-client-3.9/src/main/java8/datadog/trace/instrumentation/vertx_redis_client/ResponseHandlerWrapper.java
@@ -1,7 +1,7 @@
 package datadog.trace.instrumentation.vertx_redis_client;
 
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.context.TraceScope;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.redis.client.Response;
@@ -9,13 +9,13 @@ import io.vertx.redis.client.Response;
 public class ResponseHandlerWrapper implements Handler<AsyncResult<Response>> {
   private final Handler<AsyncResult<Response>> handler;
   private final AgentSpan clientSpan;
-  private final TraceScope.Continuation parentContinuation;
+  private final AgentScope.Continuation parentContinuation;
   private boolean handled = false;
 
   public ResponseHandlerWrapper(
       final Handler<AsyncResult<Response>> handler,
       final AgentSpan clientSpan,
-      final TraceScope.Continuation parentContinuation) {
+      final AgentScope.Continuation parentContinuation) {
     this.handler = handler;
     this.clientSpan = clientSpan;
     this.parentContinuation = parentContinuation;
@@ -31,7 +31,7 @@ public class ResponseHandlerWrapper implements Handler<AsyncResult<Response>> {
        already set so the handler state must be tracked here to prevent double execution
     */
     if (!handled) {
-      TraceScope scope = null;
+      AgentScope scope = null;
       try {
         if (null != clientSpan) {
           // need to 'resume' the span first

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -37,7 +37,6 @@ import datadog.trace.common.writer.DDAgentWriter;
 import datadog.trace.common.writer.Writer;
 import datadog.trace.common.writer.WriterFactory;
 import datadog.trace.context.ScopeListener;
-import datadog.trace.context.TraceScope;
 import datadog.trace.core.monitor.MonitoringImpl;
 import datadog.trace.core.propagation.ExtractedContext;
 import datadog.trace.core.propagation.HttpCodec;
@@ -141,8 +140,8 @@ public class CoreTracer implements AgentTracer.TracerAPI {
   private final InstrumentationGateway instrumentationGateway;
 
   @Override
-  public TraceScope.Continuation capture() {
-    final TraceScope activeScope = activeScope();
+  public AgentScope.Continuation capture() {
+    final AgentScope activeScope = activeScope();
 
     return activeScope == null ? null : activeScope.capture();
   }
@@ -584,7 +583,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
   }
 
   @Override
-  public TraceScope.Continuation captureSpan(final AgentSpan span, ScopeSource source) {
+  public AgentScope.Continuation captureSpan(final AgentSpan span, ScopeSource source) {
     return scopeManager.captureSpan(span, source);
   }
 
@@ -602,7 +601,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
   }
 
   @Override
-  public TraceScope activeScope() {
+  public AgentScope activeScope() {
     return scopeManager.active();
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
@@ -12,7 +12,6 @@ import datadog.trace.bootstrap.instrumentation.api.AgentTrace;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.bootstrap.instrumentation.api.ScopeSource;
 import datadog.trace.context.ScopeListener;
-import datadog.trace.context.TraceScope;
 import java.util.ArrayDeque;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -70,7 +69,7 @@ public class ContinuableScopeManager implements AgentScopeManager {
   }
 
   @Override
-  public TraceScope.Continuation captureSpan(final AgentSpan span, final ScopeSource source) {
+  public AgentScope.Continuation captureSpan(final AgentSpan span, final ScopeSource source) {
     Continuation continuation = new SingleContinuation(this, span, source.id());
     continuation.register();
     return continuation;
@@ -133,7 +132,7 @@ public class ContinuableScopeManager implements AgentScopeManager {
   }
 
   @Override
-  public TraceScope active() {
+  public AgentScope active() {
     return scopeStack().top();
   }
 

--- a/dd-trace-ot/src/main/java/datadog/opentracing/CustomScopeManagerWrapper.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/CustomScopeManagerWrapper.java
@@ -4,11 +4,9 @@ import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentScopeManager;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.ScopeSource;
-import datadog.trace.context.TraceScope;
 import io.opentracing.Scope;
 import io.opentracing.ScopeManager;
 import io.opentracing.Span;
-import java.util.Objects;
 
 /**
  * Allows custom OpenTracing ScopeManagers used by CoreTracer
@@ -38,8 +36,7 @@ class CustomScopeManagerWrapper implements AgentScopeManager {
   public AgentScope activate(final AgentSpan agentSpan, final ScopeSource source) {
     final Span span = converter.toSpan(agentSpan);
     final Scope scope = delegate.activate(span);
-
-    return new CustomScopeManagerScope(scope);
+    return converter.toAgentScope(scope);
   }
 
   @Override
@@ -47,15 +44,14 @@ class CustomScopeManagerWrapper implements AgentScopeManager {
       final AgentSpan agentSpan, final ScopeSource source, boolean isAsyncPropagating) {
     final Span span = converter.toSpan(agentSpan);
     final Scope scope = delegate.activate(span);
-    final AgentScope agentScope = new CustomScopeManagerScope(scope);
+    final AgentScope agentScope = converter.toAgentScope(scope);
     agentScope.setAsyncPropagation(isAsyncPropagating);
-
     return agentScope;
   }
 
   @Override
-  public TraceScope active() {
-    return new CustomScopeManagerScope(delegate.active());
+  public AgentScope active() {
+    return converter.toAgentScope(delegate.active());
   }
 
   @Override
@@ -64,91 +60,10 @@ class CustomScopeManagerWrapper implements AgentScopeManager {
   }
 
   @Override
-  public TraceScope.Continuation captureSpan(final AgentSpan span, ScopeSource source) {
+  public AgentScope.Continuation captureSpan(final AgentSpan span, ScopeSource source) {
     // I can't see a better way to do this, and I don't know if this even makes sense.
     try (AgentScope scope = this.activate(span, source)) {
       return scope.capture();
-    }
-  }
-
-  class CustomScopeManagerScope implements AgentScope, TraceScope {
-    private final Scope delegate;
-    private final boolean traceScope;
-
-    private CustomScopeManagerScope(final Scope delegate) {
-      this.delegate = delegate;
-
-      // Handle case where the custom scope manager returns TraceScopes
-      traceScope = delegate instanceof TraceScope;
-    }
-
-    @Override
-    public AgentSpan span() {
-      return converter.toAgentSpan(delegate.span());
-    }
-
-    @Override
-    public void setAsyncPropagation(final boolean value) {
-      if (traceScope) {
-        ((TraceScope) delegate).setAsyncPropagation(value);
-      }
-    }
-
-    @Override
-    public boolean checkpointed() {
-      if (delegate instanceof AgentScope) {
-        return ((AgentScope) delegate).checkpointed();
-      }
-      return false;
-    }
-
-    @Override
-    public boolean isAsyncPropagating() {
-      return traceScope && ((TraceScope) delegate).isAsyncPropagating();
-    }
-
-    @Override
-    public TraceScope.Continuation capture() {
-      if (traceScope) {
-        return ((TraceScope) delegate).capture();
-      } else {
-        return null;
-      }
-    }
-
-    @Override
-    public TraceScope.Continuation captureConcurrent() {
-      if (traceScope) {
-        return ((TraceScope) delegate).captureConcurrent();
-      } else {
-        return null;
-      }
-    }
-
-    @Override
-    public void close() {
-      delegate.close();
-    }
-
-    Scope getDelegate() {
-      return delegate;
-    }
-
-    @Override
-    public boolean equals(final Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
-      final CustomScopeManagerScope that = (CustomScopeManagerScope) o;
-      return delegate.equals(that.delegate);
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(delegate);
     }
   }
 }

--- a/dd-trace-ot/src/main/java/datadog/opentracing/OTScopeManager.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/OTScopeManager.java
@@ -49,7 +49,7 @@ class OTScopeManager implements ScopeManager {
     return converter.toSpan(tracer.activeSpan());
   }
 
-  static class OTScope implements Scope {
+  static class OTScope implements Scope, TraceScope {
     private final AgentScope delegate;
     private final boolean finishSpanOnClose;
     private final TypeConverter converter;
@@ -91,18 +91,6 @@ class OTScopeManager implements ScopeManager {
     public int hashCode() {
       return Objects.hash(delegate);
     }
-  }
-
-  static class OTTraceScope extends OTScope implements TraceScope {
-    private final TraceScope delegate;
-
-    OTTraceScope(
-        final TraceScope delegate, final boolean finishSpanOnClose, final TypeConverter converter) {
-      // All instances of TraceScope implement agent scope (but not vice versa)
-      super((AgentScope) delegate, finishSpanOnClose, converter);
-
-      this.delegate = delegate;
-    }
 
     @Override
     public Continuation capture() {
@@ -122,6 +110,14 @@ class OTScopeManager implements ScopeManager {
     @Override
     public void setAsyncPropagation(final boolean value) {
       delegate.setAsyncPropagation(value);
+    }
+
+    AgentScope unwrap() {
+      return delegate;
+    }
+
+    boolean finishSpanOnClose() {
+      return finishSpanOnClose;
     }
   }
 }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentPropagation.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentPropagation.java
@@ -1,11 +1,10 @@
 package datadog.trace.bootstrap.instrumentation.api;
 
 import datadog.trace.api.PropagationStyle;
-import datadog.trace.context.TraceScope;
 
 public interface AgentPropagation {
 
-  TraceScope.Continuation capture();
+  AgentScope.Continuation capture();
 
   <C> void inject(AgentSpan span, C carrier, Setter<C> setter);
 

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentScope.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentScope.java
@@ -7,6 +7,12 @@ public interface AgentScope extends TraceScope, Closeable {
   AgentSpan span();
 
   @Override
+  Continuation capture();
+
+  @Override
+  Continuation captureConcurrent();
+
+  @Override
   void setAsyncPropagation(boolean value);
 
   boolean checkpointed();
@@ -15,6 +21,10 @@ public interface AgentScope extends TraceScope, Closeable {
   void close();
 
   interface Continuation extends TraceScope.Continuation {
+
+    @Override
+    AgentScope activate();
+
     /**
      * Mark that the continuation will migrate to another thread. Calling this method will lead to
      * emitting events to allow the profiler to know that the span has forked from the current

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentScopeManager.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentScopeManager.java
@@ -1,7 +1,5 @@
 package datadog.trace.bootstrap.instrumentation.api;
 
-import datadog.trace.context.TraceScope;
-
 /**
  * Allows custom scope managers. See OTScopeManager, CustomScopeManager, and ContextualScopeManager
  */
@@ -11,9 +9,9 @@ public interface AgentScopeManager {
 
   AgentScope activate(AgentSpan span, ScopeSource source, boolean isAsyncPropagating);
 
-  TraceScope active();
+  AgentScope active();
 
   AgentSpan activeSpan();
 
-  TraceScope.Continuation captureSpan(AgentSpan span, ScopeSource source);
+  AgentScope.Continuation captureSpan(AgentSpan span, ScopeSource source);
 }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -12,7 +12,6 @@ import datadog.trace.api.interceptor.TraceInterceptor;
 import datadog.trace.api.sampling.PrioritySampling;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan.Context;
 import datadog.trace.context.ScopeListener;
-import datadog.trace.context.TraceScope;
 import java.util.Collections;
 import java.util.Map;
 
@@ -69,7 +68,7 @@ public class AgentTracer {
     return get().activateSpan(span, ScopeSource.INSTRUMENTATION, isAsyncPropagating);
   }
 
-  public static TraceScope.Continuation captureSpan(final AgentSpan span) {
+  public static AgentScope.Continuation captureSpan(final AgentSpan span) {
     return get().captureSpan(span, ScopeSource.INSTRUMENTATION);
   }
 
@@ -77,7 +76,7 @@ public class AgentTracer {
     return get().activeSpan();
   }
 
-  public static TraceScope activeScope() {
+  public static AgentScope activeScope() {
     return get().activeScope();
   }
 
@@ -131,11 +130,11 @@ public class AgentTracer {
 
     AgentScope activateSpan(AgentSpan span, ScopeSource source, boolean isAsyncPropagating);
 
-    TraceScope.Continuation captureSpan(AgentSpan span, ScopeSource source);
+    AgentScope.Continuation captureSpan(AgentSpan span, ScopeSource source);
 
     AgentSpan activeSpan();
 
-    TraceScope activeScope();
+    AgentScope activeScope();
 
     AgentPropagation propagate();
 
@@ -227,7 +226,7 @@ public class AgentTracer {
     }
 
     @Override
-    public TraceScope.Continuation captureSpan(final AgentSpan span, final ScopeSource source) {
+    public AgentScope.Continuation captureSpan(final AgentSpan span, final ScopeSource source) {
       return NoopContinuation.INSTANCE;
     }
 
@@ -237,7 +236,7 @@ public class AgentTracer {
     }
 
     @Override
-    public TraceScope activeScope() {
+    public AgentScope activeScope() {
       return null;
     }
 
@@ -284,7 +283,7 @@ public class AgentTracer {
     public void registerCheckpointer(Checkpointer checkpointer) {}
 
     @Override
-    public TraceScope.Continuation capture() {
+    public AgentScope.Continuation capture() {
       return null;
     }
 
@@ -607,7 +606,7 @@ public class AgentTracer {
     }
   }
 
-  public static class NoopAgentScope implements AgentScope, TraceScope {
+  public static class NoopAgentScope implements AgentScope {
     public static final NoopAgentScope INSTANCE = new NoopAgentScope();
 
     @Override
@@ -669,7 +668,7 @@ public class AgentTracer {
     static final NoopContinuation INSTANCE = new NoopContinuation();
 
     @Override
-    public TraceScope activate() {
+    public AgentScope activate() {
       return NoopAgentScope.INSTANCE;
     }
 


### PR DESCRIPTION
This changes a number of internal APIs and some non-public types in `dd-trace-ot`

It also updates a test to check that internal scopes are handled correctly when a custom scope manager is used. 