### PR TITLE
Use DDAgentFeaturesDiscovery to enable/disable metrics aggregator

### DIFF
--- a/communication/src/main/java/datadog/communication/ddagent/SharedCommunicationObjects.java
+++ b/communication/src/main/java/datadog/communication/ddagent/SharedCommunicationObjects.java
@@ -27,6 +27,10 @@ public class SharedCommunicationObjects {
           OkHttpUtils.buildHttpClient(
               agentUrl, unixDomainSocket, TimeUnit.SECONDS.toMillis(config.getAgentTimeout()));
     }
+    featuresDiscovery(config);
+  }
+
+  public DDAgentFeaturesDiscovery featuresDiscovery(Config config) {
     if (featuresDiscovery == null) {
       featuresDiscovery =
           new DDAgentFeaturesDiscovery(
@@ -36,5 +40,6 @@ public class SharedCommunicationObjects {
               config.isTraceAgentV05Enabled(),
               config.isTracerMetricsEnabled());
     }
+    return featuresDiscovery;
   }
 }

--- a/communication/src/test/resources/agent-features/agent-info-without-metrics.json
+++ b/communication/src/test/resources/agent-features/agent-info-without-metrics.json
@@ -1,0 +1,56 @@
+{
+  "version": "0.99.0",
+  "git_commit": "fab047e10",
+  "build_date": "2020-12-04 15:57:06.74187 +0200 EET m=+0.029001792",
+  "endpoints": [
+    "/v0.3/traces",
+    "/v0.3/services",
+    "/v0.4/traces",
+    "/v0.4/services",
+    "/v0.5/traces",
+    "/profiling/v1/input"
+  ],
+  "feature_flags": [
+    "feature_flag"
+  ],
+  "client_drop_p0s": true,
+  "config": {
+    "default_env": "prod",
+    "bucket_interval": 1000000000,
+    "extra_aggregators": [
+      "agg:val"
+    ],
+    "extra_sample_rate": 2.4,
+    "target_tps": 11,
+    "max_eps": 12,
+    "receiver_port": 8111,
+    "receiver_socket": "/sock/path",
+    "connection_limit": 12,
+    "receiver_timeout": 100,
+    "max_request_bytes": 123,
+    "statsd_port": 123,
+    "max_memory": 1000000,
+    "max_cpu": 12345,
+    "analyzed_rate_by_service_legacy": {
+      "X": 1.2
+    },
+    "analyzed_spans_by_service": {
+      "X": {
+        "Y": 2.4
+      }
+    },
+    "obfuscation": {
+      "elastic_search": true,
+      "mongo": true,
+      "sql_exec_plan": true,
+      "sql_exec_plan_normalize": true,
+      "http": {
+        "remove_query_string": true,
+        "remove_path_digits": true
+      },
+      "remove_stack_traces": false,
+      "redis": true,
+      "memcached": false
+    }
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/ConflatingMetricsAggregator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/ConflatingMetricsAggregator.java
@@ -261,15 +261,17 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
 
   private void disable() {
     features.discover();
-    AgentTaskScheduler.Scheduled<?> cancellation = this.cancellation;
-    if (null != cancellation) {
-      cancellation.cancel();
+    if (!features.supportsMetrics()) {
+      AgentTaskScheduler.Scheduled<?> cancellation = this.cancellation;
+      if (null != cancellation) {
+        cancellation.cancel();
+      }
+      this.thread.interrupt();
+      this.pending.clear();
+      this.batchPool.clear();
+      this.inbox.clear();
+      this.aggregator.clearAggregates();
     }
-    this.thread.interrupt();
-    this.pending.clear();
-    this.batchPool.clear();
-    this.inbox.clear();
-    this.aggregator.clearAggregates();
   }
 
   private static final class ReportTask

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/ConflatingMetricsAggregator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/ConflatingMetricsAggregator.java
@@ -120,21 +120,16 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
 
   @Override
   public void start() {
-    if (sink.validate()) {
-      sink.register(this);
-      thread.start();
-      cancellation =
-          AgentTaskScheduler.INSTANCE.scheduleAtFixedRate(
-              new ReportTask(),
-              this,
-              reportingInterval,
-              reportingInterval,
-              reportingIntervalTimeUnit);
-      log.debug("started metrics aggregator");
-    } else {
-      enabled = false;
-      log.debug("metrics aggregator not started because sink could not be validated");
-    }
+    sink.register(this);
+    thread.start();
+    cancellation =
+        AgentTaskScheduler.INSTANCE.scheduleAtFixedRate(
+            new ReportTask(),
+            this,
+            reportingInterval,
+            reportingInterval,
+            reportingIntervalTimeUnit);
+    log.debug("started metrics aggregator");
   }
 
   @Override

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/MetricsAggregatorFactory.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/MetricsAggregatorFactory.java
@@ -1,5 +1,6 @@
 package datadog.trace.common.metrics;
 
+import datadog.communication.ddagent.DDAgentFeaturesDiscovery;
 import datadog.trace.api.Config;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -7,10 +8,11 @@ import org.slf4j.LoggerFactory;
 public class MetricsAggregatorFactory {
   private static final Logger log = LoggerFactory.getLogger(MetricsAggregatorFactory.class);
 
-  public static MetricsAggregator createMetricsAggregator(Config config) {
+  public static MetricsAggregator createMetricsAggregator(
+      Config config, DDAgentFeaturesDiscovery discovery) {
     if (config.isTracerMetricsEnabled()) {
       log.debug("tracer metrics enabled");
-      return new ConflatingMetricsAggregator(config);
+      return new ConflatingMetricsAggregator(config, discovery);
     }
     log.debug("tracer metrics disabled");
     return NoOpMetricsAggregator.INSTANCE;

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/Sink.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/Sink.java
@@ -5,6 +5,4 @@ import datadog.communication.serialization.ByteBufferConsumer;
 public interface Sink extends ByteBufferConsumer {
 
   void register(EventListener listener);
-
-  boolean validate();
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -6,6 +6,7 @@ import static datadog.trace.common.metrics.MetricsAggregatorFactory.createMetric
 import static datadog.trace.util.AgentThreadFactory.AGENT_THREAD_GROUP;
 import static datadog.trace.util.CollectionUtils.tryMakeImmutableMap;
 
+import datadog.communication.ddagent.DDAgentFeaturesDiscovery;
 import datadog.communication.ddagent.SharedCommunicationObjects;
 import datadog.communication.monitor.Monitoring;
 import datadog.communication.monitor.Recording;
@@ -418,6 +419,8 @@ public class CoreTracer implements AgentTracer.TracerAPI {
       this.writer = writer;
     }
 
+    DDAgentFeaturesDiscovery discovery = sharedCommunicationObjects.featuresDiscovery(config);
+
     this.pendingTraceBuffer =
         strictTraceWrites ? PendingTraceBuffer.discarding() : PendingTraceBuffer.delaying();
     pendingTraceFactory = new PendingTrace.Factory(this, pendingTraceBuffer, strictTraceWrites);
@@ -425,7 +428,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
 
     this.writer.start();
 
-    metricsAggregator = createMetricsAggregator(config);
+    metricsAggregator = createMetricsAggregator(config, discovery);
     // Schedule the metrics aggregator to begin reporting after a random delay of 1 to 10 seconds
     // (using milliseconds granularity.) This avoids a fleet of traced applications starting at the
     // same time from sending metrics in sync.

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/ConflatingMetricAggregatorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/ConflatingMetricAggregatorTest.groovy
@@ -1,5 +1,6 @@
 package datadog.trace.common.metrics
 
+import datadog.communication.ddagent.DDAgentFeaturesDiscovery
 import datadog.trace.api.WellKnownTags
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString
 import datadog.trace.core.CoreSpan
@@ -30,11 +31,13 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
   def "should ignore traces with no measured spans"() {
     setup:
     Sink sink = Mock(Sink)
-    sink.validate() >> true
+    DDAgentFeaturesDiscovery features = Mock(DDAgentFeaturesDiscovery)
+    features.supportsMetrics() >> true
     WellKnownTags wellKnownTags = new WellKnownTags("runtimeid", "hostname", "env", "service", "version")
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(
       wellKnownTags,
       empty,
+      features,
       sink,
       10,
       queueSize,
@@ -57,11 +60,13 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     setup:
     String ignoredResourceName = "foo"
     Sink sink = Mock(Sink)
-    sink.validate() >> true
+    DDAgentFeaturesDiscovery features = Mock(DDAgentFeaturesDiscovery)
+    features.supportsMetrics() >> true
     WellKnownTags wellKnownTags = new WellKnownTags("runtimeid", "hostname", "env", "service", "version")
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(
       wellKnownTags,
       [ignoredResourceName].toSet(),
+      features,
       sink,
       10,
       queueSize,
@@ -92,9 +97,10 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     setup:
     MetricWriter writer = Mock(MetricWriter)
     Sink sink = Stub(Sink)
-    sink.validate() >> true
+    DDAgentFeaturesDiscovery features = Mock(DDAgentFeaturesDiscovery)
+    features.supportsMetrics() >> true
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
-      sink, writer, 10, queueSize, reportingInterval, SECONDS)
+      features, sink, writer, 10, queueSize, reportingInterval, SECONDS)
     aggregator.start()
 
     when:
@@ -118,8 +124,9 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     setup:
     MetricWriter writer = Mock(MetricWriter)
     Sink sink = Stub(Sink)
-    sink.validate() >> true
-    ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
+    DDAgentFeaturesDiscovery features = Mock(DDAgentFeaturesDiscovery)
+    features.supportsMetrics() >> true
+    ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty, features,
       sink, writer, 10, queueSize, reportingInterval, SECONDS)
     aggregator.start()
 
@@ -152,9 +159,10 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     setup:
     MetricWriter writer = Mock(MetricWriter)
     Sink sink = Stub(Sink)
-    sink.validate() >> true
+    DDAgentFeaturesDiscovery features = Mock(DDAgentFeaturesDiscovery)
+    features.supportsMetrics() >> true
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
-      sink, writer, 10, queueSize, reportingInterval, SECONDS)
+      features, sink, writer, 10, queueSize, reportingInterval, SECONDS)
     long duration = 100
     List<CoreSpan> trace = [
       new SimpleSpan("service", "operation", "resource", "type", true, false, false, 0, duration, HTTP_OK),
@@ -194,9 +202,10 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     int maxAggregates = 10
     MetricWriter writer = Mock(MetricWriter)
     Sink sink = Stub(Sink)
-    sink.validate() >> true
+    DDAgentFeaturesDiscovery features = Mock(DDAgentFeaturesDiscovery)
+    features.supportsMetrics() >> true
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
-      sink, writer, maxAggregates, queueSize, reportingInterval, SECONDS)
+      features, sink, writer, maxAggregates, queueSize, reportingInterval, SECONDS)
     long duration = 100
     aggregator.start()
 
@@ -229,9 +238,10 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     int maxAggregates = 10
     MetricWriter writer = Mock(MetricWriter)
     Sink sink = Stub(Sink)
-    sink.validate() >> true
+    DDAgentFeaturesDiscovery features = Mock(DDAgentFeaturesDiscovery)
+    features.supportsMetrics() >> true
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
-      sink, writer, maxAggregates, queueSize, reportingInterval, SECONDS)
+      features, sink, writer, maxAggregates, queueSize, reportingInterval, SECONDS)
     long duration = 100
     aggregator.start()
 
@@ -283,9 +293,10 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     int maxAggregates = 10
     MetricWriter writer = Mock(MetricWriter)
     Sink sink = Stub(Sink)
-    sink.validate() >> true
+    DDAgentFeaturesDiscovery features = Mock(DDAgentFeaturesDiscovery)
+    features.supportsMetrics() >> true
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
-      sink, writer, maxAggregates, queueSize, reportingInterval, SECONDS)
+      features, sink, writer, maxAggregates, queueSize, reportingInterval, SECONDS)
     long duration = 100
     aggregator.start()
 
@@ -325,9 +336,10 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     int maxAggregates = 10
     MetricWriter writer = Mock(MetricWriter)
     Sink sink = Stub(Sink)
-    sink.validate() >> true
+    DDAgentFeaturesDiscovery features = Mock(DDAgentFeaturesDiscovery)
+    features.supportsMetrics() >> true
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
-      sink, writer, maxAggregates, queueSize, 1, SECONDS)
+      features, sink, writer, maxAggregates, queueSize, 1, SECONDS)
     long duration = 100
     aggregator.start()
 
@@ -358,9 +370,10 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     int maxAggregates = 10
     MetricWriter writer = Mock(MetricWriter)
     Sink sink = Stub(Sink)
-    sink.validate() >> true
+    DDAgentFeaturesDiscovery features = Mock(DDAgentFeaturesDiscovery)
+    features.supportsMetrics() >> true
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
-      sink, writer, maxAggregates, queueSize, 1, SECONDS)
+      features, sink, writer, maxAggregates, queueSize, 1, SECONDS)
     long duration = 100
     aggregator.start()
 
@@ -395,9 +408,10 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     int maxAggregates = 10
     MetricWriter writer = Mock(MetricWriter)
     Sink sink = Stub(Sink)
-    sink.validate() >> true
+    DDAgentFeaturesDiscovery features = Mock(DDAgentFeaturesDiscovery)
+    features.supportsMetrics() >> true
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
-      sink, writer, maxAggregates, queueSize, 1, SECONDS)
+      features, sink, writer, maxAggregates, queueSize, 1, SECONDS)
     long duration = 100
     aggregator.start()
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/FootprintTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/FootprintTest.groovy
@@ -125,11 +125,6 @@ class FootprintTest extends DDSpecification {
     }
 
     @Override
-    boolean validate() {
-      return true
-    }
-
-    @Override
     void accept(int messageCount, ByteBuffer buffer) {
       latch.countDown()
     }

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/FootprintTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/FootprintTest.groovy
@@ -1,5 +1,6 @@
 package datadog.trace.common.metrics
 
+import datadog.communication.ddagent.DDAgentFeaturesDiscovery
 import datadog.trace.api.WellKnownTags
 import datadog.trace.test.util.DDSpecification
 import org.openjdk.jol.info.GraphLayout
@@ -25,9 +26,12 @@ class FootprintTest extends DDSpecification {
     setup:
     CountDownLatch latch = new CountDownLatch(1)
     ValidatingSink sink = new ValidatingSink(latch)
+    DDAgentFeaturesDiscovery features = Mock(DDAgentFeaturesDiscovery)
+    features.supportsMetrics() >> true
     ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(
       new WellKnownTags("runtimeid","hostname", "env", "service", "version"),
       [].toSet() as Set<String>,
+      features,
       sink,
       1000,
       1000,

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/MetricsAggregatorFactoryTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/MetricsAggregatorFactoryTest.groovy
@@ -1,5 +1,6 @@
 package datadog.trace.common.metrics
 
+import datadog.communication.ddagent.DDAgentFeaturesDiscovery
 import datadog.trace.api.Config
 import datadog.trace.test.util.DDSpecification
 import spock.lang.Requires
@@ -16,7 +17,7 @@ class MetricsAggregatorFactoryTest extends DDSpecification {
     Config config = Mock(Config)
     config.isTracerMetricsEnabled() >> false
     expect:
-    def aggregator = MetricsAggregatorFactory.createMetricsAggregator(config)
+    def aggregator = MetricsAggregatorFactory.createMetricsAggregator(config, Mock(DDAgentFeaturesDiscovery))
     assert aggregator instanceof NoOpMetricsAggregator
   }
 
@@ -25,7 +26,7 @@ class MetricsAggregatorFactoryTest extends DDSpecification {
     Config config = Spy(Config.get())
     config.isTracerMetricsEnabled() >> true
     expect:
-    def aggregator = MetricsAggregatorFactory.createMetricsAggregator(config)
+    def aggregator = MetricsAggregatorFactory.createMetricsAggregator(config, Mock(DDAgentFeaturesDiscovery))
     assert aggregator instanceof ConflatingMetricsAggregator
   }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/OkHttpSinkTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/OkHttpSinkTest.groovy
@@ -28,31 +28,6 @@ import static datadog.communication.ddagent.DDAgentFeaturesDiscovery.V6_METRICS_
 })
 class OkHttpSinkTest extends DDSpecification {
 
-  def "validate responds to status code"() {
-    setup:
-    String agentUrl = "http://localhost:8126"
-    String path = V6_METRICS_ENDPOINT
-    OkHttpClient client = Mock(OkHttpClient)
-    OkHttpSink sink = new OkHttpSink(client, agentUrl, path, true)
-
-    when:
-    boolean validated = sink.validate()
-
-    then:
-    1 * client.newCall(_) >> { Request request -> respond(request, responseCode) }
-    validated == expected
-
-    where:
-    responseCode | expected
-    404          | false
-    500          | false
-    0            | false
-    400          | true
-    200          | true
-    201          | true
-  }
-
-
   def "http status code #responseCode yields #eventType"() {
     setup:
     String agentUrl = "http://localhost:8126"

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SerializingMetricWriterTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SerializingMetricWriterTest.groovy
@@ -72,11 +72,6 @@ class SerializingMetricWriterTest extends DDSpecification {
     }
 
     @Override
-    boolean validate() {
-      return true
-    }
-
-    @Override
     void accept(int messageCount, ByteBuffer buffer) {
       MessageUnpacker unpacker = MessagePack.newDefaultUnpacker(buffer)
       int mapSize = unpacker.unpackMapHeader()


### PR DESCRIPTION
This fixes a bug which would occur if the application started up before a trace agent with tracer metrics enabled, and the metric sink would fail validation, disabling metrics aggregation. The tracer would eventually receive a response from the trace agent once it would start up, and find that it supports metrics, setting a header to indicate that tracer metrics had already been computed, bypassing metrics aggregation in the trace agent. This is remedied by making `DDAgentFeaturesDiscovery` the golden source of trace agent feature availability, making inconsistency impossible.