### PR TITLE
Avoid NPE when noProxyHosts is backed by an immutable set that disallows null arguments (Java9+)

### DIFF
--- a/internal-api/src/main/java/datadog/trace/util/AgentProxySelector.java
+++ b/internal-api/src/main/java/datadog/trace/util/AgentProxySelector.java
@@ -21,7 +21,7 @@ public final class AgentProxySelector extends ProxySelector {
 
   @Override
   public List<Proxy> select(final URI uri) {
-    if (noProxyHosts.contains(uri.getHost())) {
+    if (null != uri.getHost() && noProxyHosts.contains(uri.getHost())) {
       return DIRECT;
     } else {
       return defaultProxySelector.select(uri);


### PR DESCRIPTION
The 0.83.0 release contains a change that means `Config.get().getNoProxyHosts()` will be backed by an immutable collection on recent JDKs. Unfortunately immutable collections have stronger restrictions over their arguments compared to regular collections. For example, `noProxyHosts.contains(null)` will throw a NPE with the new immutable set, whereas the same call would simply return `false` for a regular `HashSet`.

This PR fixes the regression by checking that the host is not `null` before checking the set.

I'll expand our tests of this code in a separate PR, I want to get this out asap so I'm keeping this PR as just the fix.