### PR TITLE
cheaper capturing of non-async-propagating scopes

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/AdviceUtils.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/AdviceUtils.java
@@ -50,7 +50,7 @@ public class AdviceUtils {
   public static <T> void capture(
       ContextStore<T, State> contextStore, T task, boolean startThreadMigration) {
     TraceScope activeScope = activeScope();
-    if (null != activeScope) {
+    if (null != activeScope && activeScope.isAsyncPropagating()) {
       State state = contextStore.get(task);
       if (null == state) {
         state = State.FACTORY.create();


### PR DESCRIPTION
This prevents from allocating a new `State` object when we won't capture the scope, and is a necessary step towards making `Continuation.activate()` calls monomorphic when restoring context (i.e. make `NoopContinuation` redundant).