### PR TITLE
emit checkpoints in span finishing bifunction

### DIFF
--- a/dd-java-agent/instrumentation/lettuce-5/src/main/java8/datadog/trace/instrumentation/lettuce5/LettuceAsyncBiFunction.java
+++ b/dd-java-agent/instrumentation/lettuce-5/src/main/java8/datadog/trace/instrumentation/lettuce5/LettuceAsyncBiFunction.java
@@ -22,10 +22,12 @@ public class LettuceAsyncBiFunction<T extends Object, U extends Throwable, R ext
 
   public LettuceAsyncBiFunction(final AgentSpan span) {
     this.span = span;
+    span.startThreadMigration();
   }
 
   @Override
   public R apply(final T t, final Throwable throwable) {
+    span.finishThreadMigration();
     if (throwable instanceof CancellationException) {
       span.setTag("db.command.cancelled", true);
     } else {


### PR DESCRIPTION
Tracks the entry of `LettuceAsyncBiFunction` into the fork join pool. There are some odd events still but this is because of the netty instrumentation.

Before

```
Activity checkpoints by thread ordered by time
Test worker:                      |-startSpan/1-|-suspend/1-|----------|-suspend/1-|-suspend/1-|-suspend/1-|-----------|-----------|----------|-----------|----------|----------|----------|-----------|-startSpan/2-|-suspend/2-|----------|-suspend/2-|-----------|----------|-----------|-startSpan/3-|-suspend/3-|-suspend/3-|-suspend/3-|-suspend/3-|----------|-----------|-----------|----------|-----------|----------|----------|----------|-----------|
lettuce-nioEventLoop-4-1:         |-------------|-----------|-resume/1-|-----------|-----------|-----------|-suspend/1-|-endTask/1-|-resume/1-|-endTask/1-|-resume/1-|-resume/1-|-resume/1-|-----------|-------------|-----------|-resume/2-|-----------|-endTask/2-|-resume/2-|-----------|-------------|-----------|-----------|-----------|-----------|----------|-----------|-----------|----------|-----------|----------|----------|----------|-----------|
ForkJoinPool.commonPool-worker-3: |-------------|-----------|----------|-----------|-----------|-----------|-----------|-----------|----------|-----------|----------|----------|----------|-endSpan/1-|-------------|-----------|----------|-----------|-----------|----------|-endSpan/2-|-------------|-----------|-----------|-----------|-----------|----------|-----------|-----------|----------|-----------|----------|----------|----------|-endSpan/3-|
lettuce-nioEventLoop-8-1:         |-------------|-----------|----------|-----------|-----------|-----------|-----------|-----------|----------|-----------|----------|----------|----------|-----------|-------------|-----------|----------|-----------|-----------|----------|-----------|-------------|-----------|-----------|-----------|-----------|-resume/3-|-suspend/3-|-endTask/3-|-resume/3-|-endTask/3-|-resume/3-|-resume/3-|-resume/3-|-----------|
```

After
```
Activity checkpoints by thread ordered by time
Test worker:                      |-startSpan/1-|-suspend/1-|----------|-suspend/1-|-suspend/1-|-suspend/1-|-----------|-----------|----------|-----------|----------|----------|----------|-----------|-startSpan/2-|-suspend/2-|----------|-suspend/2-|-----------|----------|-----------|-startSpan/3-|-----------|-----------|-----------|
lettuce-nioEventLoop-4-1:         |-------------|-----------|-resume/1-|-----------|-----------|-----------|-suspend/1-|-endTask/1-|-resume/1-|-endTask/1-|-resume/1-|-resume/1-|----------|-----------|-------------|-----------|-resume/2-|-----------|-endTask/2-|----------|-----------|-------------|-----------|-----------|-----------|
ForkJoinPool.commonPool-worker-3: |-------------|-----------|----------|-----------|-----------|-----------|-----------|-----------|----------|-----------|----------|----------|-resume/1-|-endSpan/1-|-------------|-----------|----------|-----------|-----------|-resume/2-|-endSpan/2-|-------------|-----------|-----------|-endSpan/3-|
lettuce-nioEventLoop-8-1:         |-------------|-----------|----------|-----------|-----------|-----------|-----------|-----------|----------|-----------|----------|----------|----------|-----------|-------------|-----------|----------|-----------|-----------|----------|-----------|-------------|-endTask/3-|-endTask/3-|-----------|
```