### PR TITLE
emit checkpoints to track kakfa producer span migration

### DIFF
--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerCallback.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerCallback.java
@@ -22,6 +22,10 @@ public class KafkaProducerCallback implements Callback {
 
   @Override
   public void onCompletion(final RecordMetadata metadata, final Exception exception) {
+    // this is too late, this should be emitted before any work is done,
+    // but it's also impossible to do that because of the way Kafka's
+    // batching works.
+    span.finishThreadMigration();
     PRODUCER_DECORATE.onError(span, exception);
     PRODUCER_DECORATE.beforeFinish(span);
     span.finish();
@@ -29,7 +33,9 @@ public class KafkaProducerCallback implements Callback {
       if (parent != null) {
         try (final AgentScope scope = activateSpan(parent)) {
           scope.setAsyncPropagation(true);
+          parent.finishThreadMigration();
           callback.onCompletion(metadata, exception);
+          parent.finishWork();
         }
       } else {
         callback.onCompletion(metadata, exception);


### PR DESCRIPTION
Before:
```
Activity checkpoints by thread ordered by time
Test worker:                                |-startSpan/1-|-startSpan/2-|-----------|-------------|-------------|-----------|-endSpan/1-|-----------|
kafka-producer-network-thread | producer-1: |-------------|-------------|-endSpan/2-|-------------|-startSpan/4-|-endSpan/4-|-----------|-----------|
-C-1:                                       |-------------|-------------|-----------|-startSpan/3-|-------------|-----------|-----------|-endSpan/3-|
```

After:

```
Activity checkpoints by thread ordered by time
Test worker:                                |-startSpan/1-|-startSpan/2-|-suspend/2-|----------|-----------|----------|-------------|-------------|-----------|-----------|-endSpan/1-|-----------|
kafka-producer-network-thread | producer-1: |-------------|-------------|-----------|-resume/2-|-endSpan/2-|-resume/1-|-------------|-startSpan/4-|-endSpan/4-|-endTask/1-|-----------|-----------|
-C-1:                                       |-------------|-------------|-----------|----------|-----------|----------|-startSpan/3-|-------------|-----------|-----------|-----------|-endSpan/3-|
```