### PR TITLE
Experiment: detection of scope leaks in production

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
@@ -78,5 +78,7 @@ public final class TraceInstrumentationConfig {
 
   public static final String RESOLVER_USE_LOADCLASS = "resolver.use.loadclass";
 
+  public static final String SCOPE_LEAK_DETECTION = "scope.leak.detection";
+
   private TraceInstrumentationConfig() {}
 }

--- a/dd-trace-core/dd-trace-core.gradle
+++ b/dd-trace-core/dd-trace-core.gradle
@@ -20,7 +20,10 @@ excludedClassesCoverage += [
   'datadog.trace.core.PendingTraceBuffer.DelayingPendingTraceBuffer.FlushElement',
   'datadog.trace.core.StatusLogger',
   'datadog.trace.core.scopemanager.ContinuableScopeManager.SingleContinuation',
-  'datadog.trace.core.SpanCorrelationImpl'
+  'datadog.trace.core.SpanCorrelationImpl',
+  'datadog.trace.core.util.ScopeLeakCheckpointer',
+  'datadog.trace.core.util.ScopeLeakCheckpointer.Fingerprint',
+  'datadog.trace.core.util.ScopeLeakCheckpointer.LeakCandidate'
 ]
 
 apply plugin: 'org.unbroken-dome.test-sets'

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -43,6 +43,7 @@ import datadog.trace.core.propagation.TagContext;
 import datadog.trace.core.scopemanager.ContinuableScopeManager;
 import datadog.trace.core.taginterceptor.RuleFlags;
 import datadog.trace.core.taginterceptor.TagInterceptor;
+import datadog.trace.core.util.ScopeLeakCheckpointer;
 import datadog.trace.util.AgentTaskScheduler;
 import java.lang.ref.WeakReference;
 import java.math.BigInteger;
@@ -387,6 +388,10 @@ public class CoreTracer implements AgentTracer.TracerAPI {
         null == idGenerationStrategy
             ? Config.get().getIdGenerationStrategy()
             : idGenerationStrategy;
+
+    if (config.getScopeLeakDetectionFile() != null) {
+      registerCheckpointer(new ScopeLeakCheckpointer(config.getScopeLeakDetectionFile()));
+    }
 
     if (statsDClient != null) {
       this.statsDClient = statsDClient;

--- a/dd-trace-core/src/main/java/datadog/trace/core/util/ScopeLeakCheckpointer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/util/ScopeLeakCheckpointer.java
@@ -1,0 +1,198 @@
+package datadog.trace.core.util;
+
+import static java.lang.Boolean.TRUE;
+import static java.lang.System.lineSeparator;
+
+import datadog.trace.api.Checkpointer;
+import datadog.trace.api.DDId;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class ScopeLeakCheckpointer implements Checkpointer {
+  static final Logger log = LoggerFactory.getLogger(ScopeLeakCheckpointer.class);
+
+  private static final int LARGE_TRACE_SIZE = 500;
+  private static final int FINGERPRINT_SIZE = 10;
+
+  private final ConcurrentHashMap<Fingerprint, Boolean> fingerprints = new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<DDId, LeakCandidate> leakCandidates = new ConcurrentHashMap<>();
+  private final PrintStream out;
+
+  public ScopeLeakCheckpointer(final String outputFile) {
+    PrintStream out = null;
+    if (!outputFile.isEmpty() && !"log".equalsIgnoreCase(outputFile)) {
+      try {
+        out = new PrintStream(outputFile);
+      } catch (IOException e) {
+        log.warn("Could not open {}, will log scope leaks instead", outputFile, e);
+      }
+    }
+    this.out = out;
+  }
+
+  @Override
+  public void checkpoint(final DDId traceId, final DDId spanId, final int flags) {
+    LeakCandidate leakCandidate;
+    switch (flags) {
+      case THREAD_MIGRATION:
+        Fingerprint caller = buildStackFingerprint();
+        if (fingerprints.putIfAbsent(caller, TRUE) == null) {
+          // not seen this migration before, see if there's an existing candidate to tie it to
+          leakCandidate = new LeakCandidate();
+          LeakCandidate oldCandidate = leakCandidates.putIfAbsent(traceId, leakCandidate);
+          if (oldCandidate != null) {
+            leakCandidate = oldCandidate;
+          }
+          leakCandidate.markMigrationPoint(caller);
+        }
+        break;
+      case THREAD_MIGRATION | END:
+        leakCandidate = leakCandidates.get(traceId);
+        if (leakCandidate != null) {
+          // if we've already done this migration in this trace then this could be a scope leak
+          if (!leakCandidate.markMigrationPoint(buildStackFingerprint())) {
+            leakCandidates.remove(traceId);
+            leakCandidate.printMigrationPoints(traceId, out);
+          }
+        }
+        break;
+      case SPAN:
+        leakCandidate = leakCandidates.get(traceId);
+        // very large trace could indicate a scope leak, so print out details of any migrations
+        if (leakCandidate != null && leakCandidate.markSpanStart() > LARGE_TRACE_SIZE) {
+          leakCandidates.remove(traceId);
+          leakCandidate.printMigrationPoints(traceId, out);
+        }
+        break;
+      case SPAN | END:
+        leakCandidate = leakCandidates.get(traceId);
+        if (leakCandidate != null) {
+          leakCandidate.markSpanEnd();
+        }
+        break;
+      default:
+        // ignore other events
+        break;
+    }
+  }
+
+  @Override
+  public void onRootSpanPublished(final String route, final DDId traceId) {
+    leakCandidates.remove(traceId);
+  }
+
+  private Fingerprint buildStackFingerprint() {
+    StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
+    int from = 0, to = 0;
+    // walk stack until we have a large enough fingerprint
+    while (to - from < FINGERPRINT_SIZE && to < stackTrace.length) {
+      // ignore everything from the top of the stack until after our datadog frames
+      if ((from == 0 || from == to) && stackTrace[to].getClassName().startsWith("datadog.")) {
+        from = ++to;
+      } else {
+        ++to;
+      }
+    }
+    return new Fingerprint(stackTrace, from, to);
+  }
+
+  /** Represents a potential scope leak, marks a series of migration points between threads. */
+  static final class LeakCandidate {
+    private static final AtomicIntegerFieldUpdater<LeakCandidate> spanCountUpdater =
+        AtomicIntegerFieldUpdater.newUpdater(LeakCandidate.class, "spanCount");
+
+    private final Map<Fingerprint, String> migrationPath = new LinkedHashMap<>();
+    private volatile int spanCount = 0;
+
+    public boolean markMigrationPoint(final Fingerprint caller) {
+      synchronized (migrationPath) {
+        return migrationPath.put(caller, Thread.currentThread().getName()) == null;
+      }
+    }
+
+    public void printMigrationPoints(final DDId traceId, final PrintStream out) {
+      StringBuilder buf = new StringBuilder();
+      String prefix = "    trace " + traceId.toHexString() + " from ";
+      for (Map.Entry<Fingerprint, String> point : migrationPath.entrySet()) {
+        buf.append(lineSeparator())
+            .append(prefix)
+            .append(point.getValue())
+            .append(':')
+            .append(point.getKey());
+        prefix = "    migrated to ";
+      }
+      if (out != null) {
+        out.println("Potential scope leak!" + buf);
+      } else {
+        log.warn("Potential scope leak!{}", buf);
+      }
+    }
+
+    public int markSpanStart() {
+      return spanCountUpdater.getAndIncrement(this);
+    }
+
+    public int markSpanEnd() {
+      return spanCountUpdater.getAndDecrement(this);
+    }
+  }
+
+  /** Represents a short snippet of a stack trace that can act as a fingerprint. */
+  static final class Fingerprint {
+    private final StackTraceElement[] stackTrace;
+    private final int from, to;
+    private final int hashCode;
+
+    Fingerprint(final StackTraceElement[] stackTrace, final int from, final int to) {
+      this.stackTrace = stackTrace;
+      this.from = from;
+      this.to = to;
+      // precompute hashCode
+      int hashCode = 1;
+      for (int i = from; i < to; i++) {
+        hashCode = 31 * hashCode + stackTrace[i].hashCode();
+      }
+      this.hashCode = hashCode;
+    }
+
+    @Override
+    public boolean equals(final Object other) {
+      if (other == this) {
+        return true;
+      }
+      if (!(other instanceof Fingerprint)) {
+        return false;
+      }
+      Fingerprint fingerprint = (Fingerprint) other;
+      if (hashCode != fingerprint.hashCode || to - from != fingerprint.to - fingerprint.from) {
+        return false;
+      }
+      for (int i = from, j = fingerprint.from; i < to; i++, j++) {
+        if (!stackTrace[i].equals(fingerprint.stackTrace[j])) {
+          return false;
+        }
+      }
+      return true;
+    }
+
+    @Override
+    public int hashCode() {
+      return hashCode;
+    }
+
+    @Override
+    public String toString() {
+      StringBuilder buf = new StringBuilder();
+      for (int i = from; i < to; i++) {
+        buf.append(lineSeparator()).append("\tat ").append(stackTrace[i]);
+      }
+      return buf.toString();
+    }
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -157,6 +157,7 @@ import static datadog.trace.api.config.TraceInstrumentationConfig.RABBIT_PROPAGA
 import static datadog.trace.api.config.TraceInstrumentationConfig.RABBIT_PROPAGATION_ENABLED;
 import static datadog.trace.api.config.TraceInstrumentationConfig.RESOLVER_USE_LOADCLASS;
 import static datadog.trace.api.config.TraceInstrumentationConfig.RUNTIME_CONTEXT_FIELD_INJECTION;
+import static datadog.trace.api.config.TraceInstrumentationConfig.SCOPE_LEAK_DETECTION;
 import static datadog.trace.api.config.TraceInstrumentationConfig.SERIALVERSIONUID_FIELD_INJECTION;
 import static datadog.trace.api.config.TraceInstrumentationConfig.SERVLET_ASYNC_TIMEOUT_ERROR;
 import static datadog.trace.api.config.TraceInstrumentationConfig.SERVLET_PRINCIPAL_ENABLED;
@@ -420,6 +421,8 @@ public class Config {
   private final boolean internalExitOnFailure;
 
   private final boolean resolverUseLoadClassEnabled;
+
+  private final String scopeLeakDetectionFile;
 
   private final String jdbcPreparedStatementClassName;
   private final String jdbcConnectionClassName;
@@ -854,6 +857,11 @@ public class Config {
     internalExitOnFailure = configProvider.getBoolean(INTERNAL_EXIT_ON_FAILURE, false);
 
     resolverUseLoadClassEnabled = configProvider.getBoolean(RESOLVER_USE_LOADCLASS, true);
+
+    boolean scopeLeakDetectionEnabled = configProvider.getBoolean(SCOPE_LEAK_DETECTION, false);
+    scopeLeakDetectionFile =
+        configProvider.getString(
+            SCOPE_LEAK_DETECTION + ".file", scopeLeakDetectionEnabled ? "log" : null);
 
     // Setting this last because we have a few places where this can come from
     apiKey = tmpApiKey;
@@ -1336,6 +1344,10 @@ public class Config {
 
   public boolean isResolverUseLoadClassEnabled() {
     return resolverUseLoadClassEnabled;
+  }
+
+  public String getScopeLeakDetectionFile() {
+    return scopeLeakDetectionFile;
   }
 
   public String getJdbcPreparedStatementClassName() {
@@ -2054,6 +2066,8 @@ public class Config {
         + internalExitOnFailure
         + ", resolverUseLoadClassEnabled="
         + resolverUseLoadClassEnabled
+        + ", scopeLeakDetectionFile="
+        + scopeLeakDetectionFile
         + ", jdbcPreparedStatementClassName='"
         + jdbcPreparedStatementClassName
         + '\''


### PR DESCRIPTION
*work-in-progress, not for review*

Enable with `-Ddd.scope.leak.detection=true` or `DD_SCOPE_LEAK_DETECTION=true`

Logs potential scope leaks as WARNings by default, but can be configured to use a file:

`-Ddd.scope.leak.detection.file=scope_leaks.log` or `DD_SCOPE_LEAK_DETECTION_FILE=scope_leaks.log`

Uses a fingerprint approach to limit the amount of tracking required.
