### PR TITLE
prevent context from leaking into okhttp3 ConnectionPool

### DIFF
--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/AsyncPropagatingDisableInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/AsyncPropagatingDisableInstrumentation.java
@@ -71,7 +71,8 @@ public final class AsyncPropagatingDisableInstrumentation extends Instrumenter.T
             "io.netty.channel.kqueue.AbstractKQueueChannel$AbstractKQueueUnsafe",
             "io.grpc.netty.shaded.io.netty.channel.kqueue.AbstractKQueueChannel$AbstractKQueueUnsafe",
             "rx.internal.util.ObjectPool",
-            "io.grpc.internal.ServerImpl$ServerTransportListenerImpl")
+            "io.grpc.internal.ServerImpl$ServerTransportListenerImpl",
+            "okhttp3.ConnectionPool")
         .or(RX_WORKERS)
         .or(GRPC_MANAGED_CHANNEL)
         .or(REACTOR_DISABLED_TYPE_INITIALIZERS);
@@ -105,6 +106,8 @@ public final class AsyncPropagatingDisableInstrumentation extends Instrumenter.T
         advice);
     transformation.applyAdvice(
         named("start").and(isDeclaredBy(named("rx.internal.util.ObjectPool"))), advice);
+    transformation.applyAdvice(
+        named("put").and(isDeclaredBy(named("okhttp3.ConnectionPool"))), advice);
     transformation.applyAdvice(
         isTypeInitializer().and(isDeclaredBy(REACTOR_DISABLED_TYPE_INITIALIZERS)), advice);
   }


### PR DESCRIPTION
Prevents context from leaking in to this:

```java
void put(RealConnection connection) {
  assert (Thread.holdsLock(this));
  if (!cleanupRunning) {
    cleanupRunning = true;
    executor.execute(cleanupRunnable);
  }
  connections.add(connection);
}
```

Before:
```
Activity checkpoints by thread ordered by time
Test worker:           |-startSpan/11-|-suspend/11-|-----------|--------------|------------|-endSpan/11-|
OkHttp ConnectionPool: |--------------|------------|-resume/11-|--------------|------------|------------|
qtp1515428219-41:      |--------------|------------|-----------|-startSpan/12-|-endSpan/12-|------------|
```

After
```
Activity checkpoints by thread ordered by time
Test worker:      |-startSpan/11-|--------------|------------|-endSpan/11-|
qtp1729586410-41: |--------------|-startSpan/12-|-endSpan/12-|------------|
```