### PR TITLE
make rediscala instrumentation scala-promise aware

### DIFF
--- a/dd-java-agent/instrumentation/rediscala-1.8.0/rediscala-1.8.0.gradle
+++ b/dd-java-agent/instrumentation/rediscala-1.8.0/rediscala-1.8.0.gradle
@@ -59,6 +59,9 @@ testSets {
 dependencies {
   compileOnly group: 'com.github.etaty', name: 'rediscala_2.11', version: '1.8.0'
 
+  testImplementation project(':dd-java-agent:instrumentation:scala-promise:scala-promise-2.10')
+  testImplementation project(':dd-java-agent:instrumentation:scala-concurrent')
+
   testImplementation group: 'com.github.etaty', name: 'rediscala_2.11', version: '1.8.0'
   testImplementation group: 'com.github.kstyrc', name: 'embedded-redis', version: '0.6'
 

--- a/dd-java-agent/instrumentation/rediscala-1.8.0/src/main/java/datadog/trace/instrumentation/rediscala/OnCompleteHandler.java
+++ b/dd-java-agent/instrumentation/rediscala-1.8.0/src/main/java/datadog/trace/instrumentation/rediscala/OnCompleteHandler.java
@@ -3,31 +3,30 @@ package datadog.trace.instrumentation.rediscala;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
 import static datadog.trace.instrumentation.rediscala.RediscalaClientDecorator.DECORATE;
 
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.context.TraceScope;
 import scala.runtime.AbstractFunction1;
 import scala.util.Try;
 
-public class OnCompleteHandler extends AbstractFunction1<Try<Object>, Void> {
-  private final AgentSpan span;
+public final class OnCompleteHandler extends AbstractFunction1<Try<Object>, Void> {
 
-  public OnCompleteHandler(final AgentSpan span) {
-    this.span = span;
-  }
+  public static final OnCompleteHandler INSTANCE = new OnCompleteHandler();
 
   @Override
   public Void apply(final Try<Object> result) {
-    try {
-      if (result.isFailure()) {
-        DECORATE.onError(span, result.failed().get());
+    // propagation handled by scala promise instrumentation
+    TraceScope activeScope = activeScope();
+    if (activeScope instanceof AgentScope) {
+      AgentSpan span = ((AgentScope) activeScope).span();
+      try {
+        if (result.isFailure()) {
+          DECORATE.onError(span, result.failed().get());
+        }
+        DECORATE.beforeFinish(span);
+      } finally {
+        span.finish();
       }
-      DECORATE.beforeFinish(span);
-      final TraceScope scope = activeScope();
-      if (scope != null) {
-        scope.setAsyncPropagation(false);
-      }
-    } finally {
-      span.finish();
     }
     return null;
   }

--- a/dd-java-agent/instrumentation/rediscala-1.8.0/src/main/java/datadog/trace/instrumentation/rediscala/RediscalaInstrumentation.java
+++ b/dd-java-agent/instrumentation/rediscala-1.8.0/src/main/java/datadog/trace/instrumentation/rediscala/RediscalaInstrumentation.java
@@ -87,7 +87,7 @@ public final class RediscalaInstrumentation extends Instrumenter.Tracing {
       final AgentSpan span = scope.span();
 
       if (throwable == null) {
-        responseFuture.onComplete(new OnCompleteHandler(span), ctx);
+        responseFuture.onComplete(OnCompleteHandler.INSTANCE, ctx);
       } else {
         DECORATE.onError(span, throwable);
         DECORATE.beforeFinish(span);


### PR DESCRIPTION
The rediscala instrumentation relies on `CallbackRunnable` but doesn't make good use of it, and since we instrument `CallbackRunnable` our testing is unrealistic. This makes the tests depend on the supporting instrumentation which will be active when the instrumentation is active for real, and removes the allocation of the completion handler. We can also see that the checkpoints emitted cover activity over the entire execution:

```
Activity checkpoints by thread ordered by time
Test worker:                                            |-startSpan/2-|-suspend/2-|----------|-----------|----------|-----------|----------|-----------|----------|-----------|----------|-----------|----------|-----------|-----------|-startSpan/3-|-suspend/3-|----------|-----------|----------|-----------|----------|-----------|----------|-----------|----------|-----------|-----------|----------|-----------|-----------|
default-rediscala.rediscala-client-worker-dispatcher-6: |-------------|-----------|-resume/2-|-suspend/2-|----------|-suspend/2-|----------|-----------|-resume/2-|-suspend/2-|----------|-----------|-resume/2-|-endSpan/2-|-endTask/2-|-------------|-----------|-resume/3-|-suspend/3-|----------|-suspend/3-|----------|-----------|-resume/3-|-suspend/3-|----------|-----------|-----------|-resume/3-|-endSpan/3-|-endTask/3-|
default-rediscala.rediscala-client-worker-dispatcher-7: |-------------|-----------|----------|-----------|-resume/2-|-----------|----------|-----------|----------|-----------|-resume/2-|-suspend/2-|----------|-----------|-----------|-------------|-----------|----------|-----------|-resume/3-|-----------|----------|-----------|----------|-----------|-resume/3-|-endTask/3-|-suspend/3-|----------|-----------|-----------|
default-akka.actor.default-dispatcher-3:                |-------------|-----------|----------|-----------|----------|-----------|-resume/2-|-suspend/2-|----------|-----------|----------|-----------|----------|-----------|-----------|-------------|-----------|----------|-----------|----------|-----------|-resume/3-|-suspend/3-|----------|-----------|----------|-----------|-----------|----------|-----------|-----------|
```

Before, this was reported, which looked wrong, but was just an unrealistic set up.
```
Activity checkpoints by thread ordered by time
Test worker:                                            |-startSpan/2-|-----------|-startSpan/3-|-----------|
default-rediscala.rediscala-client-worker-dispatcher-6: |-------------|-endSpan/2-|-------------|-endSpan/3-|
```