### PR TITLE
straighten out checkpoints in slick database driver

### DIFF
--- a/dd-java-agent/instrumentation/slick/slick.gradle
+++ b/dd-java-agent/instrumentation/slick/slick.gradle
@@ -37,6 +37,8 @@ dependencies {
   testImplementation project(':dd-java-agent:instrumentation:java-concurrent')
   testImplementation project(':dd-java-agent:instrumentation:java-concurrent:java-completablefuture')
   testImplementation project(':dd-java-agent:instrumentation:trace-annotation')
+  testImplementation project(':dd-java-agent:instrumentation:scala-promise:scala-promise-2.10')
+  testImplementation project(':dd-java-agent:instrumentation:scala-concurrent')
   testImplementation project(':dd-java-agent:instrumentation:jdbc')
   testImplementation deps.scala
   testImplementation group: 'com.typesafe.slick', name: 'slick_2.11', version: '3.2.0'

--- a/dd-java-agent/instrumentation/slick/src/main/java/datadog.trace.instrumentation.slick/SlickRunnableInstrumentation.java
+++ b/dd-java-agent/instrumentation/slick/src/main/java/datadog.trace.instrumentation.slick/SlickRunnableInstrumentation.java
@@ -2,7 +2,6 @@ package datadog.trace.instrumentation.slick;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers.hasInterface;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
 import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
 import static net.bytebuddy.matcher.ElementMatchers.takesNoArguments;
 
@@ -47,12 +46,7 @@ public final class SlickRunnableInstrumentation extends Instrumenter.Tracing {
   public static final class Construct {
     @Advice.OnMethodExit
     public static void capture(@Advice.This Runnable zis) {
-      TraceScope activeScope = activeScope();
-      if (null != activeScope) {
-        InstrumentationContext.get(Runnable.class, State.class)
-            .putIfAbsent(zis, State.FACTORY)
-            .captureAndSetContinuation(activeScope);
-      }
+      AdviceUtils.capture(InstrumentationContext.get(Runnable.class, State.class), zis, true);
     }
   }
 


### PR DESCRIPTION
Checkpoints now balance properly

Before:
```
Activity checkpoints by thread ordered by time
Test worker: |-startSpan/5-|-------------|-----------|-----------|----------|-----------|-endSpan/5-|-----------|-startSpan/7-|-------------|-----------|-----------|-endSpan/7-|-startSpan/9-|--------------|------------|-----------|-endSpan/9-|
test-1:      |-------------|-startSpan/6-|-endSpan/6-|-suspend/5-|-resume/5-|-endTask/5-|-----------|-endTask/5-|-------------|-startSpan/8-|-endSpan/8-|-endTask/7-|-----------|-------------|-startSpan/10-|-endSpan/10-|-endTask/9-|-----------|
```

After:

```
Activity checkpoints by thread ordered by time
Test worker: |-startSpan/5-|-suspend/5-|----------|-suspend/5-|-------------|-----------|----------|-----------|-----------|-endSpan/5-|-startSpan/7-|-suspend/7-|----------|-------------|-----------|-----------|-endSpan/7-|-startSpan/9-|-suspend/9-|----------|--------------|------------|-----------|-endSpan/9-|
test-1:      |-------------|-----------|-resume/5-|-----------|-startSpan/6-|-endSpan/6-|-resume/5-|-endTask/5-|-endTask/5-|-----------|-------------|-----------|-resume/7-|-startSpan/8-|-endSpan/8-|-endTask/7-|-----------|-------------|-----------|-resume/9-|-startSpan/10-|-endSpan/10-|-endTask/9-|-----------|
```

The inner capture could be eliminated in future as a performance optimisation.