### PR TITLE
namespace RunnableInstrumentation so it can be disabled in clojure apps

### DIFF
--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/RunnableInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/RunnableInstrumentation.java
@@ -27,7 +27,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 public final class RunnableInstrumentation extends Instrumenter.Tracing {
 
   public RunnableInstrumentation() {
-    super(AbstractExecutorInstrumentation.EXEC_NAME);
+    super(AbstractExecutorInstrumentation.EXEC_NAME, "runnable");
   }
 
   @Override


### PR DESCRIPTION
This allows the `RunnableInstrumentation`, which is _mostly_ unnecessary now we instrument other things like `RunnableFuture`, to be disabled by users who understand the **potential** risk for broken traces, but also prevents us from transforming every `AFn` in clojure applications.

To disable the instrumentation, set `-Ddd.integration.runnable.enabled=false`