### PR TITLE
prevent double registration of tracing interceptor when server builder is reused

### DIFF
--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/GrpcServerBuilderInstrumentation.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/GrpcServerBuilderInstrumentation.java
@@ -3,6 +3,8 @@ package datadog.trace.instrumentation.grpc.server;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers.extendsClass;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
+import static datadog.trace.bootstrap.CallDepthThreadLocalMap.incrementCallDepth;
+import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
@@ -10,7 +12,10 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.bootstrap.CallDepthThreadLocalMap;
+import datadog.trace.bootstrap.ContextStore;
+import datadog.trace.bootstrap.InstrumentationContext;
 import io.grpc.ServerBuilder;
+import java.util.Map;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
@@ -40,6 +45,11 @@ public class GrpcServerBuilderInstrumentation extends Instrumenter.Tracing {
   }
 
   @Override
+  public Map<String, String> contextStore() {
+    return singletonMap("io.grpc.ServerBuilder", Boolean.class.getName());
+  }
+
+  @Override
   public String[] helperClassNames() {
     return new String[] {
       packageName + ".GrpcServerDecorator",
@@ -61,16 +71,25 @@ public class GrpcServerBuilderInstrumentation extends Instrumenter.Tracing {
   public static class BuildAdvice {
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static void onEnter(@Advice.This ServerBuilder<?> serverBuilder) {
-      int callDepth = CallDepthThreadLocalMap.incrementCallDepth(ServerBuilder.class);
-      if (callDepth == 0) {
-        serverBuilder.intercept(TracingServerInterceptor.INSTANCE);
+    public static boolean onEnter(@Advice.This ServerBuilder<?> serverBuilder) {
+      ContextStore<ServerBuilder, Boolean> interceptedStore =
+          InstrumentationContext.get(ServerBuilder.class, Boolean.class);
+      if (interceptedStore.get(serverBuilder) == null) {
+        int callDepth = incrementCallDepth(ServerBuilder.class);
+        if (callDepth == 0) {
+          interceptedStore.put(serverBuilder, Boolean.TRUE);
+          serverBuilder.intercept(TracingServerInterceptor.INSTANCE);
+        }
+        return true;
       }
+      return false;
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
-    public static void onExit() {
-      CallDepthThreadLocalMap.decrementCallDepth(ServerBuilder.class);
+    public static void onExit(@Advice.Enter boolean decrement) {
+      if (decrement) {
+        CallDepthThreadLocalMap.decrementCallDepth(ServerBuilder.class);
+      }
     }
   }
 }

--- a/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcTest.groovy
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcTest.groovy
@@ -55,7 +55,9 @@ class GrpcTest extends AgentTestRunner {
           }
         }
       }
-    Server server = InProcessServerBuilder.forName(getClass().name).addService(greeter).executor(executor).build().start()
+    def builder = InProcessServerBuilder.forName(getClass().name).addService(greeter).executor(executor)
+    (0..extraBuildCalls).each {builder.build()}
+    Server server = builder.build().start()
 
     ManagedChannel channel = InProcessChannelBuilder.forName(getClass().name).build()
     GreeterGrpc.GreeterBlockingStub client = GreeterGrpc.newBlockingStub(channel)
@@ -145,13 +147,19 @@ class GrpcTest extends AgentTestRunner {
     }
 
     where:
-    name              | executor                            | contexts
-    "some name"       | MoreExecutors.directExecutor()      | 1
-    "some other name" | MoreExecutors.directExecutor()      | 1
-    "some name"       | newWorkStealingPool()               | 3
-    "some other name" | newWorkStealingPool()               | 3
-    "some name"       | Executors.newSingleThreadExecutor() | 3
-    "some other name" | Executors.newSingleThreadExecutor() | 3
+    name              | executor                            | contexts | extraBuildCalls
+    "some name"       | MoreExecutors.directExecutor()      | 1        | 0
+    "some other name" | MoreExecutors.directExecutor()      | 1        | 0
+    "some name"       | newWorkStealingPool()               | 3        | 0
+    "some other name" | newWorkStealingPool()               | 3        | 0
+    "some name"       | Executors.newSingleThreadExecutor() | 3        | 0
+    "some other name" | Executors.newSingleThreadExecutor() | 3        | 0
+    "some name"       | MoreExecutors.directExecutor()      | 1        | 1
+    "some other name" | MoreExecutors.directExecutor()      | 1        | 1
+    "some name"       | newWorkStealingPool()               | 3        | 1
+    "some other name" | newWorkStealingPool()               | 3        | 1
+    "some name"       | Executors.newSingleThreadExecutor() | 3        | 1
+    "some other name" | Executors.newSingleThreadExecutor() | 3        | 1
   }
 
   def "test error - #name"() {


### PR DESCRIPTION
We have the same problem as OpenTelemetry had for server registration (https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/3544), but not for client registration where there was already a guard against double registration.