### PR TITLE
only emit end checkpoints when a scope underwent a thread migration

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/AdviceUtils.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/AdviceUtils.java
@@ -33,7 +33,10 @@ public class AdviceUtils {
 
   public static void endTaskScope(final TraceScope scope) {
     if (scope instanceof AgentScope) {
-      ((AgentScope) scope).span().finishWork();
+      AgentScope agentScope = (AgentScope) scope;
+      if (agentScope.checkpointed()) {
+        agentScope.span().finishWork();
+      }
     }
     if (scope != null) {
       scope.close();

--- a/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/CheckpointThreadMigrationTest.groovy
+++ b/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/CheckpointThreadMigrationTest.groovy
@@ -23,7 +23,7 @@ class CheckpointThreadMigrationTest extends AgentTestRunner {
     (traceChildTasks ? 2 : 1) * TEST_CHECKPOINTER.checkpoint(_, _, SPAN)
     1 * TEST_CHECKPOINTER.checkpoint(_, _, THREAD_MIGRATION)
     1 * TEST_CHECKPOINTER.checkpoint(_, _, THREAD_MIGRATION | END)
-    _ * TEST_CHECKPOINTER.checkpoint(_, _, CPU | END)
+    1 * TEST_CHECKPOINTER.checkpoint(_, _, CPU | END)
     (traceChildTasks ? 2 : 1) * TEST_CHECKPOINTER.checkpoint(_, _, SPAN | END)
 
     cleanup:
@@ -53,7 +53,7 @@ class CheckpointThreadMigrationTest extends AgentTestRunner {
     (traceChildTasks ? 2 : 1) * TEST_CHECKPOINTER.checkpoint(_, _, SPAN)
     1 * TEST_CHECKPOINTER.checkpoint(_, _, THREAD_MIGRATION)
     1 * TEST_CHECKPOINTER.checkpoint(_, _, THREAD_MIGRATION | END)
-    _ * TEST_CHECKPOINTER.checkpoint(_, _, CPU | END)
+    1 * TEST_CHECKPOINTER.checkpoint(_, _, CPU | END)
     (traceChildTasks ? 2 : 1) * TEST_CHECKPOINTER.checkpoint(_, _, SPAN | END)
 
     cleanup:

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
@@ -289,6 +289,11 @@ public class ContinuableScopeManager implements AgentScopeManager {
       isAsyncPropagating = value;
     }
 
+    @Override
+    public boolean checkpointed() {
+      return null != continuation && continuation.migrated;
+    }
+
     /**
      * The continuation returned must be closed or activated or the trace will not finish.
      *

--- a/dd-trace-ot/src/main/java/datadog/opentracing/CustomScopeManagerWrapper.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/CustomScopeManagerWrapper.java
@@ -95,6 +95,14 @@ class CustomScopeManagerWrapper implements AgentScopeManager {
     }
 
     @Override
+    public boolean checkpointed() {
+      if (delegate instanceof AgentScope) {
+        return ((AgentScope) delegate).checkpointed();
+      }
+      return false;
+    }
+
+    @Override
     public boolean isAsyncPropagating() {
       return traceScope && ((TraceScope) delegate).isAsyncPropagating();
     }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentScope.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentScope.java
@@ -9,6 +9,8 @@ public interface AgentScope extends TraceScope, Closeable {
   @Override
   void setAsyncPropagation(boolean value);
 
+  boolean checkpointed();
+
   @Override
   void close();
 

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -537,6 +537,11 @@ public class AgentTracer {
     public void setAsyncPropagation(final boolean value) {}
 
     @Override
+    public boolean checkpointed() {
+      return false;
+    }
+
+    @Override
     public AgentScope.Continuation capture() {
       return NoopContinuation.INSTANCE;
     }


### PR DESCRIPTION
This fixes an issue where we see duplicate endTask events in akka-http, and will allow for other events to be eliminated (e.g. slick runnables).