### PR TITLE
Cap HikariCP to 4.+ for latestDepTest because 5.+ requires Java 11

### DIFF
--- a/dd-java-agent/instrumentation/jdbc/jdbc.gradle
+++ b/dd-java-agent/instrumentation/jdbc/jdbc.gradle
@@ -21,6 +21,11 @@ testSets {
   oldPostgresTest {
     dirName = 'test'
   }
+
+  latestDepJava11Test {
+    extendsFrom latestDepTest
+    dirName = 'test'
+  }
 }
 
 dependencies {
@@ -60,11 +65,22 @@ dependencies {
 
   latestDepTestImplementation group: 'org.apache.tomcat', name: 'tomcat-jdbc', version: '+'
   latestDepTestImplementation group: 'org.apache.tomcat', name: 'tomcat-juli', version: '+'
-  latestDepTestImplementation group: 'com.zaxxer', name: 'HikariCP', version: '+'
+  latestDepTestImplementation group: 'com.zaxxer', name: 'HikariCP', version: '4.+' // 5+ requires Java 11
   latestDepTestImplementation group: 'com.mchange', name: 'c3p0', version: '+'
+
+  latestDepJava11TestImplementation group: 'com.zaxxer', name: 'HikariCP', version: '+'
 }
 
 tasks.named("test").configure {
   dependsOn "oldH2Test"
   dependsOn "oldPostgresTest"
+}
+
+tasks.named("latestDepJava11Test").configure {
+  doFirst {
+    if (!System.env.JAVA_11_HOME) {
+      throw new GradleException('JAVA_11_HOME must be set for latestDepJava11Test')
+    }
+    executable = file("${System.env.JAVA_11_HOME}/bin/java")
+  }
 }

--- a/dd-java-agent/instrumentation/jdbc/scalikejdbc/scalikejdbc.gradle
+++ b/dd-java-agent/instrumentation/jdbc/scalikejdbc/scalikejdbc.gradle
@@ -50,6 +50,6 @@ dependencies {
   latestDepTestImplementation group: 'org.hsqldb', name: 'hsqldb', version: '2.5+'
   latestDepTestImplementation group: 'org.apache.tomcat', name: 'tomcat-jdbc', version: '+'
   latestDepTestImplementation group: 'org.apache.tomcat', name: 'tomcat-juli', version: '+'
-  latestDepTestImplementation group: 'com.zaxxer', name: 'HikariCP', version: '+'
+  latestDepTestImplementation group: 'com.zaxxer', name: 'HikariCP', version: '4.+' // 5+ requires Java 11
   latestDepTestImplementation group: 'com.mchange', name: 'c3p0', version: '+'
 }


### PR DESCRIPTION
Also introduce latestDepJava11Test to test HikariCP 5.+