### PR TITLE
Include 'api' and 'implementation' direct dependencies…

### DIFF
--- a/dd-trace-ot/dd-trace-ot.gradle
+++ b/dd-trace-ot/dd-trace-ot.gradle
@@ -103,7 +103,11 @@ shadowJar {
  *  from removing them
  */
 def bundledProjectNames = bundledProjects.collect { it.substring(it.lastIndexOf(":") + 1) }
-def externalDependencies = { p -> p.configurations.getByName("compile").dependencies.withType(ExternalDependency) }
+def externalDependencies = { p ->
+  p.configurations
+    .matching { it.name in ['compile', 'api', 'implementation']}
+    .collectMany { it.dependencies.withType(ExternalDependency) }
+}
 tasks.withType(GenerateMavenPom).configureEach { task ->
   doFirst {
     task.pom.withXml { XmlProvider provider ->


### PR DESCRIPTION
…of bundled projects when generating `dd-trace-ot` Maven pom