### PR TITLE
Skip bad release version jedis-3.6.2 from muzzle check…

### DIFF
--- a/dd-java-agent/instrumentation/jedis-3.0/jedis-3.0.gradle
+++ b/dd-java-agent/instrumentation/jedis-3.0/jedis-3.0.gradle
@@ -3,6 +3,7 @@ muzzle {
     group = "redis.clients"
     module = "jedis"
     versions = "[,3.0.0)"
+    skipVersions += "jedis-3.6.2" // bad release version ("jedis-" prefix)
   }
 
   pass {


### PR DESCRIPTION
…because it has an unexpected 'jedis-' prefix

See https://repo1.maven.org/maven2/redis/clients/jedis/

3.6.2 (good) vs jedis-3.6.2 (bad)