### PR TITLE
Add printing mode for TimelineCheckpointer

### DIFF
--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/TimelineCheckpointer.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/TimelineCheckpointer.groovy
@@ -3,6 +3,8 @@ package datadog.trace.agent.test
 import datadog.trace.api.Checkpointer
 import datadog.trace.api.DDId
 
+import java.io.File
+import java.io.PrintStream
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArrayList
 
@@ -55,7 +57,19 @@ class TimelineCheckpointer implements Checkpointer {
   }
 
   void printActivity() {
-    printTimeLine()
+    if (!encounterOrder.isEmpty()) {
+      if (Boolean.parseBoolean(System.getenv("TIMELINECHECKPOINTER_PRINT_PROFILING_TESTCASE"))) {
+        PrintStream out = new PrintStream(File.createTempFile("checkpointer-events", ".csv", null));
+        out.println("eventName,traceId,spanId,threadName")
+        for (Event event : encounterOrder) {
+          out.println(String.format("%s,%s,%s,%s", event.eventName, event.traceId, event.spanId, event.threadName))
+        }
+        out.flush()
+        out.close()
+      } else {
+        printTimeLine()
+      }
+    }
   }
 
   void printTimeLine() {
@@ -142,6 +156,10 @@ class TimelineCheckpointer implements Checkpointer {
 
     DDId getSpanId() {
       return spanId
+    }
+
+    String getThreadName() {
+      return threadName;
     }
   }
 }

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/TimelineCheckpointer.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/TimelineCheckpointer.groovy
@@ -3,8 +3,6 @@ package datadog.trace.agent.test
 import datadog.trace.api.Checkpointer
 import datadog.trace.api.DDId
 
-import java.io.File
-import java.io.PrintStream
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArrayList
 
@@ -40,9 +38,9 @@ class TimelineCheckpointer implements Checkpointer {
   void printActivity() {
     if (!encounterOrder.isEmpty()) {
       if (Boolean.parseBoolean(System.getenv("TIMELINECHECKPOINTER_PRINT_PROFILING_TESTCASE"))) {
-        PrintStream out = null;
+        PrintStream out = null
         try {
-          out = new PrintStream(File.createTempFile("checkpointer-events", ".csv", null));
+          out = new PrintStream(File.createTempFile("checkpointer-events", ".csv", null))
           out.println("eventFlags,traceId,spanId,threadId")
           for (Event event : encounterOrder) {
             out.println(String.format("%d,%s,%s,%d", event.flags, event.traceId.toHexString(), event.spanId.toHexString(), event.threadId))
@@ -155,7 +153,7 @@ class TimelineCheckpointer implements Checkpointer {
     }
 
     int getFlags() {
-      return flags;
+      return flags
     }
 
     DDId getTraceId() {
@@ -167,11 +165,11 @@ class TimelineCheckpointer implements Checkpointer {
     }
 
     long getThreadId() {
-      return threadId;
+      return threadId
     }
 
     String getThreadName() {
-      return threadName;
+      return threadName
     }
   }
 }

--- a/dd-java-agent/testing/testing.gradle
+++ b/dd-java-agent/testing/testing.gradle
@@ -21,7 +21,7 @@ excludedClassesCoverage += [
   // Avoid applying jacoco instrumentation to classes instrumented by tested agent
   'context.FieldInjectionTestInstrumentation**',
   'context.ExcludeFilterTestInstrumentation**',
-  'datadog.trace.agent.test.TimelineCheckpointer',
+  'datadog.trace.agent.test.TimelineCheckpointer**',
 ]
 
 dependencies {


### PR DESCRIPTION
This mode is used for generating test cases for the profiling backend.

The generated files are parsed for test cases, and the profiling backend
uses them to verify that it can reconstruct the timeline appropriately.
We need "real world" scenarios for the profiling backend to support
every possible cases of valid (or not so valid) sequence of checkpoints.