### PR TITLE
Add configuration knob to enable Heap Profiler

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkController.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkController.java
@@ -111,6 +111,23 @@ public final class OpenJdkController implements Controller {
 
     // Toggle settings from config
 
+    if (config.isProfilingHeapEnabled()) {
+      // TODO: when jdk.OldObjectSample is enabled by default in dd.jfp, uncomment the following
+      // if (!Boolean.parseBoolean(recordingSettings.get("jdk.OldObjectSample#enabled"))) {
+      //   if (((isJavaVersion(11) && isJavaVersionAtLeast(11, 0, 12))
+      //       || (isJavaVersion(15) && isJavaVersionAtLeast(15, 0, 4))
+      //       || (isJavaVersion(16) && isJavaVersionAtLeast(16, 0, 2))
+      //       || isJavaVersionAtLeast(17))) {
+      //     // It was enabled based on JDK version so disabled by override file
+      //     log.warn(
+      //         "The OldObjectSample JFR event is disabled with the override file but enabled with
+      // the config.");
+      //   }
+      // }
+      log.debug("Enabling OldObjectSample JFR event with the config.");
+      recordingSettings.put("jdk.OldObjectSample#enabled", "true");
+    }
+
     if (config.isProfilingAllocationEnabled()) {
       if (!Boolean.parseBoolean(recordingSettings.get("jdk.ObjectAllocationInNewTLAB#enabled"))
           || !Boolean.parseBoolean(

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/test/java/com/datadog/profiling/controller/openjdk/OpenJdkControllerTest.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/test/java/com/datadog/profiling/controller/openjdk/OpenJdkControllerTest.java
@@ -63,6 +63,16 @@ public class OpenJdkControllerTest {
   }
 
   @Test
+  public void testOldObjectSampleIsStillOverriddenThroughConfig() throws Exception {
+    when(config.isProfilingHeapEnabled()).thenReturn(true);
+    OpenJdkController controller = new OpenJdkController(config);
+    try (final Recording recording = controller.createRecording(TEST_NAME).stop().getRecording()) {
+      assertEquals(
+          Boolean.parseBoolean(recording.getSettings().get("jdk.OldObjectSample#enabled")), true);
+    }
+  }
+
+  @Test
   public void testObjectAllocationIsDisabledOnUnsupportedVersion() throws Exception {
     OpenJdkController controller = new OpenJdkController(config);
     try (final Recording recording = controller.createRecording(TEST_NAME).stop().getRecording()) {
@@ -99,7 +109,7 @@ public class OpenJdkControllerTest {
   }
 
   @Test
-  public void testObjectAllocationIsStillOverriddenThroughProp() throws Exception {
+  public void testObjectAllocationIsStillOverriddenThroughConfig() throws Exception {
     when(config.isProfilingAllocationEnabled()).thenReturn(true);
     OpenJdkController controller = new OpenJdkController(config);
     try (final Recording recording = controller.createRecording(TEST_NAME).stop().getRecording()) {

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -59,6 +59,7 @@ public final class ConfigDefaults {
 
   static final boolean DEFAULT_PROFILING_ENABLED = false;
   static final boolean DEFAULT_PROFILING_ALLOCATION_ENABLED = false;
+  static final boolean DEFAULT_PROFILING_HEAP_ENABLED = false;
   static final int DEFAULT_PROFILING_START_DELAY = 10;
   static final boolean DEFAULT_PROFILING_START_FORCE_FIRST = false;
   static final int DEFAULT_PROFILING_UPLOAD_PERIOD = 60; // 1 min

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
@@ -9,6 +9,7 @@ package datadog.trace.api.config;
 public final class ProfilingConfig {
   public static final String PROFILING_ENABLED = "profiling.enabled";
   public static final String PROFILING_ALLOCATION_ENABLED = "profiling.allocation.enabled";
+  public static final String PROFILING_HEAP_ENABLED = "profiling.heap.enabled";
   @Deprecated // Use dd.site instead
   public static final String PROFILING_URL = "profiling.url";
   @Deprecated // Use dd.api-key instead

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -28,6 +28,7 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_EXCEPTION_SAMPLE_LIMIT;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_HEAP_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_LEGACY_TRACING_INTEGRATION;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_PROXY_PORT;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_START_DELAY;
@@ -109,6 +110,7 @@ import static datadog.trace.api.config.ProfilingConfig.PROFILING_EXCEPTION_HISTO
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_EXCEPTION_SAMPLE_LIMIT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_EXCLUDE_AGENT_THREADS;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_HEAP_ENABLED;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_HOTSPOTS_ENABLED;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_LEGACY_TRACING_INTEGRATION;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_PROXY_HOST;
@@ -350,6 +352,7 @@ public class Config {
 
   private final boolean profilingEnabled;
   private final boolean profilingAllocationEnabled;
+  private final boolean profilingHeapEnabled;
   private final boolean profilingAgentless;
   private final boolean profilingLegacyTracingIntegrationEnabled;
   @Deprecated private final String profilingUrl;
@@ -698,6 +701,8 @@ public class Config {
     profilingAllocationEnabled =
         configProvider.getBoolean(
             PROFILING_ALLOCATION_ENABLED, DEFAULT_PROFILING_ALLOCATION_ENABLED);
+    profilingHeapEnabled =
+        configProvider.getBoolean(PROFILING_HEAP_ENABLED, DEFAULT_PROFILING_HEAP_ENABLED);
     profilingAgentless =
         configProvider.getBoolean(PROFILING_AGENTLESS, DEFAULT_PROFILING_AGENTLESS);
     profilingLegacyTracingIntegrationEnabled =
@@ -1129,6 +1134,10 @@ public class Config {
 
   public boolean isProfilingAllocationEnabled() {
     return profilingAllocationEnabled;
+  }
+
+  public boolean isProfilingHeapEnabled() {
+    return profilingHeapEnabled;
   }
 
   public boolean isProfilingAgentless() {
@@ -1901,6 +1910,8 @@ public class Config {
         + profilingEnabled
         + ", profilingAllocationEnabled="
         + profilingAllocationEnabled
+        + ", profilingHeapEnabled="
+        + profilingHeapEnabled
         + ", profilingAgentless="
         + profilingAgentless
         + ", profilingUrl='"


### PR DESCRIPTION
As it's still very much in Beta, we want to make it as easy as possible
for customers to try it out, without enabling it by default.