### PR TITLE
Add config option to disable context propagation for specified JMS topics and queues

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jms/MessageConsumerState.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jms/MessageConsumerState.java
@@ -9,11 +9,14 @@ public final class MessageConsumerState {
   private final int ackMode;
   private final UTF8BytesString resourceName;
   private final ThreadLocal<AgentScope> currentScope = new ThreadLocal<>();
+  private final String destinationName;
 
-  public MessageConsumerState(Object session, int ackMode, UTF8BytesString resourceName) {
+  public MessageConsumerState(
+      Object session, int ackMode, UTF8BytesString resourceName, String destinationName) {
     this.session = session;
     this.ackMode = ackMode;
     this.resourceName = resourceName;
+    this.destinationName = destinationName;
   }
 
   @SuppressWarnings("unchecked")
@@ -36,6 +39,10 @@ public final class MessageConsumerState {
 
   public UTF8BytesString getResourceName() {
     return resourceName;
+  }
+
+  public String getDestinationName() {
+    return destinationName;
   }
 
   public void capture(AgentScope scope) {

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/SessionInstrumentation.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/SessionInstrumentation.java
@@ -82,22 +82,23 @@ public class SessionInstrumentation extends Instrumenter.Tracing {
         // logic inlined from JMSDecorator to avoid
         // JMSException: A consumer is consuming from the temporary destination
         String resourceName = "Consumed from Destination";
+        String destinationName = "";
         try {
           // put the common case first
           if (destination instanceof Queue) {
-            String queueName = ((Queue) destination).getQueueName();
-            if ((destination instanceof TemporaryQueue || queueName.startsWith("$TMP$"))) {
+            destinationName = ((Queue) destination).getQueueName();
+            if ((destination instanceof TemporaryQueue || destinationName.startsWith("$TMP$"))) {
               resourceName = "Consumed from Temporary Queue";
             } else {
-              resourceName = "Consumed from Queue " + queueName;
+              resourceName = "Consumed from Queue " + destinationName;
             }
           } else if (destination instanceof Topic) {
-            String topicName = ((Topic) destination).getTopicName();
+            destinationName = ((Topic) destination).getTopicName();
             // this is an odd thing to do so put it second
-            if (destination instanceof TemporaryTopic || topicName.startsWith("$TMP$")) {
+            if (destination instanceof TemporaryTopic || destinationName.startsWith("$TMP$")) {
               resourceName = "Consumed from Temporary Topic";
             } else {
-              resourceName = "Consumed from Topic " + topicName;
+              resourceName = "Consumed from Topic " + destinationName;
             }
           }
         } catch (JMSException ignore) {
@@ -110,7 +111,7 @@ public class SessionInstrumentation extends Instrumenter.Tracing {
         contextStore.put(
             consumer,
             new MessageConsumerState(
-                session, acknowledgeMode, UTF8BytesString.create(resourceName)));
+                session, acknowledgeMode, UTF8BytesString.create(resourceName), destinationName));
       }
     }
   }

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -75,6 +75,7 @@ public final class ConfigDefaults {
   static final boolean DEFAULT_APPSEC_ENABLED = false;
 
   static final boolean DEFAULT_KAFKA_CLIENT_PROPAGATION_ENABLED = true;
+  static final boolean DEFAULT_JMS_PROPAGATION_ENABLED = true;
 
   static final boolean DEFAULT_TRACE_REPORT_HOSTNAME = false;
   static final String DEFAULT_TRACE_ANNOTATIONS = null;

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
@@ -46,6 +46,10 @@ public final class TraceInstrumentationConfig {
   public static final String KAFKA_CLIENT_BASE64_DECODING_ENABLED =
       "kafka.client.base64.decoding.enabled";
 
+  public static final String JMS_PROPAGATION_ENABLED = "jms.propagation.enabled";
+  public static final String JMS_PROPAGATION_DISABLED_TOPICS = "jms.propagation.disabled.topics";
+  public static final String JMS_PROPAGATION_DISABLED_QUEUES = "jms.propagation.disabled.queues";
+
   public static final String GRPC_IGNORED_OUTBOUND_METHODS = "trace.grpc.ignored.outbound.methods";
   public static final String GRPC_SERVER_TRIM_PACKAGE_RESOURCE =
       "trace.grpc.server.trim-package-resource";

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -15,6 +15,7 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_HTTP_SERVER_ERROR_STATUSE
 import static datadog.trace.api.ConfigDefaults.DEFAULT_HTTP_SERVER_ROUTE_BASED_NAMING;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_HTTP_SERVER_TAG_QUERY_STRING;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_INTEGRATIONS_ENABLED;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_JMS_PROPAGATION_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_JMX_FETCH_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_KAFKA_CLIENT_PROPAGATION_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_LOGS_INJECTION_ENABLED;
@@ -140,6 +141,9 @@ import static datadog.trace.api.config.TraceInstrumentationConfig.IGNITE_CACHE_I
 import static datadog.trace.api.config.TraceInstrumentationConfig.INTEGRATIONS_ENABLED;
 import static datadog.trace.api.config.TraceInstrumentationConfig.JDBC_CONNECTION_CLASS_NAME;
 import static datadog.trace.api.config.TraceInstrumentationConfig.JDBC_PREPARED_STATEMENT_CLASS_NAME;
+import static datadog.trace.api.config.TraceInstrumentationConfig.JMS_PROPAGATION_DISABLED_QUEUES;
+import static datadog.trace.api.config.TraceInstrumentationConfig.JMS_PROPAGATION_DISABLED_TOPICS;
+import static datadog.trace.api.config.TraceInstrumentationConfig.JMS_PROPAGATION_ENABLED;
 import static datadog.trace.api.config.TraceInstrumentationConfig.KAFKA_CLIENT_BASE64_DECODING_ENABLED;
 import static datadog.trace.api.config.TraceInstrumentationConfig.KAFKA_CLIENT_PROPAGATION_DISABLED_TOPICS;
 import static datadog.trace.api.config.TraceInstrumentationConfig.KAFKA_CLIENT_PROPAGATION_ENABLED;
@@ -378,6 +382,10 @@ public class Config {
   private final boolean kafkaClientPropagationEnabled;
   private final Set<String> kafkaClientPropagationDisabledTopics;
   private final boolean kafkaClientBase64DecodingEnabled;
+
+  private final boolean jmsPropagationEnabled;
+  private final Set<String> jmsPropagationDisabledTopics;
+  private final Set<String> jmsPropagationDisabledQueues;
 
   private final boolean hystrixTagsEnabled;
   private final boolean hystrixMeasuredEnabled;
@@ -793,6 +801,15 @@ public class Config {
 
     kafkaClientBase64DecodingEnabled =
         configProvider.getBoolean(KAFKA_CLIENT_BASE64_DECODING_ENABLED, false);
+
+    jmsPropagationEnabled =
+        configProvider.getBoolean(JMS_PROPAGATION_ENABLED, DEFAULT_JMS_PROPAGATION_ENABLED);
+
+    jmsPropagationDisabledTopics =
+        tryMakeImmutableSet(configProvider.getList(JMS_PROPAGATION_DISABLED_TOPICS));
+
+    jmsPropagationDisabledQueues =
+        tryMakeImmutableSet(configProvider.getList(JMS_PROPAGATION_DISABLED_QUEUES));
 
     grpcIgnoredOutboundMethods =
         tryMakeImmutableSet(configProvider.getList(GRPC_IGNORED_OUTBOUND_METHODS));
@@ -1218,6 +1235,18 @@ public class Config {
 
   public Set<String> getKafkaClientPropagationDisabledTopics() {
     return kafkaClientPropagationDisabledTopics;
+  }
+
+  public boolean isJMSPropagationEnabled() {
+    return jmsPropagationEnabled;
+  }
+
+  public Set<String> getJMSPropagationDisabledTopics() {
+    return jmsPropagationDisabledTopics;
+  }
+
+  public Set<String> getJMSPropagationDisabledQueues() {
+    return jmsPropagationDisabledQueues;
   }
 
   public boolean isKafkaClientBase64DecodingEnabled() {
@@ -1957,6 +1986,12 @@ public class Config {
         + kafkaClientPropagationDisabledTopics
         + ", kafkaClientBase64DecodingEnabled="
         + kafkaClientBase64DecodingEnabled
+        + ", jmsPropagationEnabled="
+        + jmsPropagationEnabled
+        + ", jmsPropagationDisabledTopics="
+        + jmsPropagationDisabledTopics
+        + ", jmsPropagationDisabledQueues="
+        + jmsPropagationDisabledQueues
         + ", hystrixTagsEnabled="
         + hystrixTagsEnabled
         + ", hystrixMeasuredEnabled="


### PR DESCRIPTION
New config options:
- jms.propagation.enabled
- jms.propagation.disabled.topics
- jms.propagation.disabled.queues