### PR TITLE
Attempting to activate a null span should not leave the scope stack in an invalid state

### DIFF
--- a/dd-java-agent/instrumentation/opentelemetry/src/main/java/datadog/trace/instrumentation/opentelemetry/OtelTracer.java
+++ b/dd-java-agent/instrumentation/opentelemetry/src/main/java/datadog/trace/instrumentation/opentelemetry/OtelTracer.java
@@ -33,6 +33,10 @@ public class OtelTracer implements Tracer {
 
   @Override
   public Scope withSpan(final Span span) {
+    if (null == span) {
+      return null;
+    }
+
     final AgentSpan agentSpan = converter.toAgentSpan(span);
     final AgentScope agentScope = tracer.activateSpan(agentSpan, ScopeSource.MANUAL);
     return converter.toScope(agentScope);

--- a/dd-java-agent/instrumentation/opentelemetry/src/test/groovy/OpenTelemetryTest.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/src/test/groovy/OpenTelemetryTest.groovy
@@ -293,6 +293,22 @@ class OpenTelemetryTest extends AgentTestRunner {
     PrioritySampling.USER_DROP    | PrioritySampling.USER_DROP
   }
 
+  def "tolerate null span activation"() {
+    when:
+    try {
+      tracer.withSpan(null)?.close()
+    } catch (Exception ignored) {}
+
+    // make sure scope stack has been left in a valid state
+    def testSpan = tracer.spanBuilder("some name").startSpan()
+    def testScope = tracer.withSpan(testSpan)
+    testSpan.end()
+    testScope.close()
+
+    then:
+    tracer.currentSpan == null
+  }
+
   static class TextMapGetter implements HttpTextFormat.Getter<Map<String, String>> {
     @Override
     String get(Map<String, String> carrier, String key) {

--- a/dd-java-agent/instrumentation/opentracing/api-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/OTScopeManager.java
+++ b/dd-java-agent/instrumentation/opentracing/api-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/OTScopeManager.java
@@ -20,6 +20,10 @@ public class OTScopeManager implements ScopeManager {
 
   @Override
   public Scope activate(final Span span, final boolean finishSpanOnClose) {
+    if (null == span) {
+      return null;
+    }
+
     final AgentSpan agentSpan = converter.toAgentSpan(span);
     final AgentScope agentScope = tracer.activateSpan(agentSpan, ScopeSource.MANUAL);
 

--- a/dd-java-agent/instrumentation/opentracing/api-0.31/src/test/groovy/OpenTracing31Test.groovy
+++ b/dd-java-agent/instrumentation/opentracing/api-0.31/src/test/groovy/OpenTracing31Test.groovy
@@ -288,6 +288,22 @@ class OpenTracing31Test extends AgentTestRunner {
     PrioritySampling.USER_DROP    | PrioritySampling.USER_DROP
   }
 
+  def "tolerate null span activation"() {
+    when:
+    try {
+      tracer.scopeManager().activate(null, false)?.close()
+    } catch (Exception ignored) {}
+
+    // make sure scope stack has been left in a valid state
+    Span testSpan = tracer.buildSpan("someOperation").start()
+    Scope testScope =  tracer.scopeManager().activate(testSpan, false)
+    testSpan.finish()
+    testScope.close()
+
+    then:
+    assert tracer.scopeManager().active() == null
+  }
+
   static class TextMapAdapter implements TextMap {
     private final Map<String, String> map
 

--- a/dd-java-agent/instrumentation/opentracing/api-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/OTScopeManager.java
+++ b/dd-java-agent/instrumentation/opentracing/api-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/OTScopeManager.java
@@ -25,6 +25,10 @@ public class OTScopeManager implements ScopeManager {
 
   @Override
   public Scope activate(final Span span, final boolean finishSpanOnClose) {
+    if (null == span) {
+      return null;
+    }
+
     final AgentSpan agentSpan = converter.toAgentSpan(span);
     final AgentScope agentScope = tracer.activateSpan(agentSpan, ScopeSource.MANUAL);
 

--- a/dd-java-agent/instrumentation/opentracing/api-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/OTTracer.java
+++ b/dd-java-agent/instrumentation/opentracing/api-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/OTTracer.java
@@ -43,6 +43,10 @@ public class OTTracer implements Tracer {
 
   @Override
   public Scope activateSpan(final Span span) {
+    if (null == span) {
+      return null;
+    }
+
     return converter.toScope(
         tracer.activateSpan(converter.toAgentSpan(span), ScopeSource.MANUAL), false);
   }

--- a/dd-java-agent/instrumentation/opentracing/api-0.32/src/test/groovy/OpenTracing32Test.groovy
+++ b/dd-java-agent/instrumentation/opentracing/api-0.32/src/test/groovy/OpenTracing32Test.groovy
@@ -298,6 +298,26 @@ class OpenTracing32Test extends AgentTestRunner {
     PrioritySampling.USER_DROP    | PrioritySampling.USER_DROP
   }
 
+  def "tolerate null span activation"() {
+    when:
+    try {
+      tracer.scopeManager().activate(null)?.close()
+    } catch (Exception ignored) {}
+
+    try {
+      tracer.activateSpan(null)?.close()
+    } catch (Exception ignored) {}
+
+    // make sure scope stack has been left in a valid state
+    Span testSpan = tracer.buildSpan("someOperation").start()
+    Scope testScope = tracer.scopeManager().activate(testSpan)
+    testSpan.finish()
+    testScope.close()
+
+    then:
+    assert tracer.scopeManager().active() == null
+  }
+
   static class TextMapAdapter implements TextMap {
     private final Map<String, String> map
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
@@ -118,6 +118,8 @@ public class ContinuableScopeManager implements AgentScopeManager {
       final byte source,
       final boolean overrideAsyncPropagation,
       final boolean isAsyncPropagating) {
+    assert span != null;
+
     // Inherit the async propagation from the active scope unless the a value is overridden
     boolean asyncPropagation =
         overrideAsyncPropagation

--- a/dd-trace-ot/src/main/java/datadog/opentracing/OTScopeManager.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/OTScopeManager.java
@@ -27,6 +27,10 @@ class OTScopeManager implements ScopeManager {
 
   @Override
   public Scope activate(final Span span, final boolean finishSpanOnClose) {
+    if (null == span) {
+      return null;
+    }
+
     final AgentSpan agentSpan = converter.toAgentSpan(span);
     final AgentScope agentScope = tracer.activateSpan(agentSpan, ScopeSource.MANUAL);
 


### PR DESCRIPTION
This makes sure that bad requests via the public OpenTracing/OpenTelemetry APIs don't affect auto-instrumentation traces.