### PR TITLE
Defer creation of JMS transacted span queue…

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jms/SessionState.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jms/SessionState.java
@@ -30,11 +30,10 @@ public final class SessionState {
     Queue<AgentSpan> q = queue;
     if (null == q) {
       synchronized (this) {
-        q = queue;
-        if (null == q) {
-          q = new ArrayBlockingQueue<AgentSpan>(CAPACITY);
-          queue = q;
+        if (null == queue) {
+          queue = new ArrayBlockingQueue<AgentSpan>(CAPACITY);
         }
+        q = queue;
       }
     }
     if (q.offer(span)) {

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/jms/SessionStateTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/jms/SessionStateTest.groovy
@@ -7,7 +7,7 @@ class SessionStateTest extends DDSpecification {
 
   def "commit transaction"() {
     setup:
-    SessionState sessionState = new SessionState(true)
+    SessionState sessionState = new SessionState()
     def span1 = Mock(AgentSpan)
     def span2 = Mock(AgentSpan)
     when:
@@ -26,7 +26,7 @@ class SessionStateTest extends DDSpecification {
 
   def "when buffer overflows, spans are finished eagerly"() {
     setup:
-    SessionState sessionState = new SessionState(true)
+    SessionState sessionState = new SessionState()
     AgentSpan span1 = Mock(AgentSpan)
     AgentSpan span2 = Mock(AgentSpan)
     when: "fill the buffer"
@@ -44,17 +44,5 @@ class SessionStateTest extends DDSpecification {
     sessionState.add(span2)
     then: "span is enqueued and not finished"
     0 * span2.finish()
-  }
-
-  def "non-transacted sessionstate"() {
-    setup:
-    SessionState sessionState = new SessionState(false)
-    AgentSpan span = Mock()
-    when:
-    sessionState.add(span)
-    sessionState.onCommit()
-    then:
-    0 * span.finish()
-    sessionState.isEmpty()
   }
 }

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/SessionInstrumentation.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/SessionInstrumentation.java
@@ -129,14 +129,8 @@ public class SessionInstrumentation extends Instrumenter.Tracing {
   public static final class Construct {
     @Advice.OnMethodExit
     public static void createSessionState(@Advice.This Session session) {
-      boolean transacted;
-      try {
-        transacted = session.getTransacted();
-      } catch (JMSException ignore) {
-        transacted = false;
-      }
       InstrumentationContext.get(Session.class, SessionState.class)
-          .put(session, new SessionState(transacted));
+          .put(session, new SessionState());
     }
   }
 }


### PR DESCRIPTION
…to avoid needing to check session.getTransacted() in the session constructor.

Some JMS session implementations involve delegates that are not always available immediately after the constructor (they are set shortly after via a setter method) so we cannot call getTransacted() on exit from their constructor. To handle this we instead make the transacted span queue lazy and only construct it on-demand.

Note the SessionState.add() method is already only called from consumers whose session uses SESSION_TRANSACTED.