### PR TITLE
Avoid potential scope leak in spring-jms' DefaultMessageListenerContainer

### DIFF
--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/AsyncPropagatingDisableInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/AsyncPropagatingDisableInstrumentation.java
@@ -81,7 +81,8 @@ public final class AsyncPropagatingDisableInstrumentation extends Instrumenter.T
             "org.eclipse.jetty.io.SelectorManager",
             "org.jvnet.hk2.internal.ServiceLocatorImpl",
             "com.zaxxer.hikari.pool.HikariPool",
-            "net.sf.ehcache.store.disk.DiskStorageFactory")
+            "net.sf.ehcache.store.disk.DiskStorageFactory",
+            "org.springframework.jms.listener.DefaultMessageListenerContainer")
         .or(RX_WORKERS)
         .or(GRPC_MANAGED_CHANNEL)
         .or(REACTOR_DISABLED_TYPE_INITIALIZERS);
@@ -148,6 +149,12 @@ public final class AsyncPropagatingDisableInstrumentation extends Instrumenter.T
         advice);
     transformation.applyAdvice(
         named("schedule").and(isDeclaredBy(named("net.sf.ehcache.store.disk.DiskStorageFactory"))),
+        advice);
+    transformation.applyAdvice(
+        named("doRescheduleTask")
+            .and(
+                isDeclaredBy(
+                    named("org.springframework.jms.listener.DefaultMessageListenerContainer"))),
         advice);
     transformation.applyAdvice(
         isTypeInitializer().and(isDeclaredBy(REACTOR_DISABLED_TYPE_INITIALIZERS)), advice);


### PR DESCRIPTION
this class uses a pool of invoker threads to deliver incoming messages to listeners

(the JMS message carries the span context so we don't need async propagation here, and as the invokers are re-used we don't want to risk scopes being captured when creating/rescheduling invokers)