### PR TITLE
Fix instrumentation for Kafka Streams 2.6+

### DIFF
--- a/dd-java-agent/instrumentation/kafka-streams-0.11/kafka-streams-0.11.gradle
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/kafka-streams-0.11.gradle
@@ -11,9 +11,7 @@ apply from: "$rootDir/gradle/java.gradle"
 apply plugin: 'org.unbroken-dome.test-sets'
 
 testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
+  latestDepTest
 }
 
 dependencies {
@@ -33,12 +31,10 @@ dependencies {
 
   // Include latest version of kafka itself along with latest version of client libs.
   // This seems to help with jar compatibility hell.
-  latestDepTestImplementation group: 'org.apache.kafka', name: 'kafka_2.11', version: '2.3.+'
-  // (Pinning to 2.3.x: 2.4.0 introduces an error when executing compileLatestDepTestGroovy)
-  //  Caused by: java.lang.NoClassDefFoundError: org.I0Itec.zkclient.ZkClient
-  latestDepTestImplementation group: 'org.apache.kafka', name: 'kafka-clients', version: '2.3.+'
-  latestDepTestImplementation group: 'org.apache.kafka', name: 'kafka-streams', version: '2.3.+'
-  latestDepTestImplementation group: 'org.springframework.kafka', name: 'spring-kafka', version: '2.2.+'
-  latestDepTestImplementation group: 'org.springframework.kafka', name: 'spring-kafka-test', version: '2.2.+'
-  latestDepTestImplementation group: 'org.assertj', name: 'assertj-core', version: '3.19.+'
+  latestDepTestImplementation group: 'org.apache.kafka', name: 'kafka_2.13', version: '2.+'
+  latestDepTestImplementation group: 'org.apache.kafka', name: 'kafka-clients', version: '2.+'
+  latestDepTestImplementation group: 'org.apache.kafka', name: 'kafka-streams', version: '2.+'
+  latestDepTestImplementation group: 'org.springframework.kafka', name: 'spring-kafka', version: '2.+'
+  latestDepTestImplementation group: 'org.springframework.kafka', name: 'spring-kafka-test', version: '2.+'
+  latestDepTestImplementation group: 'org.assertj', name: 'assertj-core', version: '3.+'
 }

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/KafkaStreamsProcessorInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/KafkaStreamsProcessorInstrumentation.java
@@ -13,7 +13,6 @@ import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.isPackagePrivate;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.returns;
-import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
@@ -103,7 +102,7 @@ public class KafkaStreamsProcessorInstrumentation {
     @Override
     public void adviceTransformations(AdviceTransformation transformation) {
       transformation.applyAdvice(
-          isMethod().and(isPublic()).and(named("process")).and(takesArguments(0)),
+          isMethod().and(isPublic()).and(named("process")),
           StopInstrumentation.class.getName() + "$StopSpanAdvice");
     }
 

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/KafkaStreamsProcessorInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/KafkaStreamsProcessorInstrumentation.java
@@ -13,6 +13,8 @@ import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.isPackagePrivate;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.returns;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
@@ -102,7 +104,11 @@ public class KafkaStreamsProcessorInstrumentation {
     @Override
     public void adviceTransformations(AdviceTransformation transformation) {
       transformation.applyAdvice(
-          isMethod().and(isPublic()).and(named("process")),
+          isMethod()
+              .and(isPublic())
+              .and(named("process"))
+              // Method signature changed in 2.6.
+              .and(takesArguments(0).or(takesArguments(1).and(takesArgument(0, long.class)))),
           StopInstrumentation.class.getName() + "$StopSpanAdvice");
     }
 


### PR DESCRIPTION
The method signature of what we're instrumenting changed in 2.6 from `process()` to `process(long)`.  By removing the no arg constraint, we now instrument either method.

I've also extended the test to verify the latest version of the library. In order to do so, I had to split the tests to resolve a compilation issue.

Inspired by https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/3438.  Thanks @GuillaumeWaignier!