### PR TITLE
update additional ignores matcher ignore to avoid spurious context propagation

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/AdditionalLibraryIgnoresMatcher.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/AdditionalLibraryIgnoresMatcher.java
@@ -121,13 +121,10 @@ public class AdditionalLibraryIgnoresMatcher<T extends TypeDescription>
       }
 
       if (name.startsWith("org.springframework.cglib.")) {
-        // This class contains nested Callable instance that we'd happily not touch, but
-        // unfortunately our field injection code is not flexible enough to realize that, so instead
-        // we instrument this Callable to make tests happy.
-        if (name.startsWith("org.springframework.cglib.core.internal.LoadingCache$")) {
-          return false;
-        }
-        return true;
+        // LoadingCache.createEntry constructs FutureTasks which it executes synchronously,
+        // which leads to pointless context propagation and checkpoint emission, so we need
+        // to instrument this class to disable async propagation to make the tests happy
+        return !name.startsWith("org.springframework.cglib.core.internal.LoadingCache");
       }
 
       if (name.startsWith("org.springframework.context.")) {

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/AsyncPropagatingDisableInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/AsyncPropagatingDisableInstrumentation.java
@@ -73,7 +73,8 @@ public final class AsyncPropagatingDisableInstrumentation extends Instrumenter.T
             "rx.internal.util.ObjectPool",
             "io.grpc.internal.ServerImpl$ServerTransportListenerImpl",
             "okhttp3.ConnectionPool",
-            "org.elasticsearch.transport.netty4.Netty4TcpChannel")
+            "org.elasticsearch.transport.netty4.Netty4TcpChannel",
+            "org.springframework.cglib.core.internal.LoadingCache")
         .or(RX_WORKERS)
         .or(GRPC_MANAGED_CHANNEL)
         .or(REACTOR_DISABLED_TYPE_INITIALIZERS);
@@ -112,6 +113,10 @@ public final class AsyncPropagatingDisableInstrumentation extends Instrumenter.T
     transformation.applyAdvice(
         named("sendMessage")
             .and(isDeclaredBy(named("org.elasticsearch.transport.netty4.Netty4TcpChannel"))),
+        advice);
+    transformation.applyAdvice(
+        named("createEntry")
+            .and(isDeclaredBy(named("org.springframework.cglib.core.internal.LoadingCache"))),
         advice);
     transformation.applyAdvice(
         isTypeInitializer().and(isDeclaredBy(REACTOR_DISABLED_TYPE_INITIALIZERS)), advice);


### PR DESCRIPTION
This class was already special cased, but wasn't updated when we stopped instrumenting `Callable` in favour of `RunnableFuture`, because we would instrument this code:

```java
   protected V createEntry(final K key, KK cacheKey, Object v) {
        boolean creator = false;
        FutureTask task;
        Object result;
        if (v != null) {
            task = (FutureTask)v;
        } else {
            task = new FutureTask(new Callable<V>() {
                public V call() throws Exception {
                    return LoadingCache.this.loader.apply(key);
                }
            });
            result = this.map.putIfAbsent(cacheKey, task);
            if (result == null) {
                creator = true;
                task.run();
            } else {
                if (!(result instanceof FutureTask)) {
                    return result;
                }

                task = (FutureTask)result;
            }
        }

        try {
            result = task.get();
        } catch (InterruptedException var9) {
            throw new IllegalStateException("Interrupted while loading cache item", var9);
        } catch (ExecutionException var10) {
            Throwable cause = var10.getCause();
            if (cause instanceof RuntimeException) {
                throw (RuntimeException)cause;
            }

            throw new IllegalStateException("Unable to load cache item", cause);
        }

        if (creator) {
            this.map.put(cacheKey, result);
        }

        return result;
    }
```
This would affect handling of Spring `@Async`

Before:
```
Activity checkpoints by thread ordered by time
Test worker:               |-startSpan/1-|-suspend/1-|----------|-------------|-----------|----------|-----------|-----------|----------|-----------|-------------|-----------|-----------|-----------|-endSpan/1-|
SimpleAsyncTaskExecutor-1: |-------------|-----------|-resume/1-|-startSpan/2-|-suspend/2-|-resume/2-|-endTask/2-|-suspend/2-|-resume/2-|-endTask/2-|-startSpan/3-|-endSpan/3-|-endSpan/2-|-endTask/1-|-----------|
```

After:

```
Activity checkpoints by thread ordered by time
Test worker:               |-startSpan/1-|-suspend/1-|----------|-------------|-------------|-----------|-----------|-----------|-endSpan/1-|
SimpleAsyncTaskExecutor-1: |-------------|-----------|-resume/1-|-startSpan/2-|-startSpan/3-|-endSpan/3-|-endSpan/2-|-endTask/1-|-----------|
```