### PR TITLE
prevent leaking into flusher event loop

### DIFF
--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/AsyncPropagatingDisableInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/AsyncPropagatingDisableInstrumentation.java
@@ -74,7 +74,8 @@ public final class AsyncPropagatingDisableInstrumentation extends Instrumenter.T
             "io.grpc.internal.ServerImpl$ServerTransportListenerImpl",
             "okhttp3.ConnectionPool",
             "org.elasticsearch.transport.netty4.Netty4TcpChannel",
-            "org.springframework.cglib.core.internal.LoadingCache")
+            "org.springframework.cglib.core.internal.LoadingCache",
+            "com.datastax.oss.driver.internal.core.channel.DefaultWriteCoalescer$Flusher")
         .or(RX_WORKERS)
         .or(GRPC_MANAGED_CHANNEL)
         .or(REACTOR_DISABLED_TYPE_INITIALIZERS);
@@ -117,6 +118,13 @@ public final class AsyncPropagatingDisableInstrumentation extends Instrumenter.T
     transformation.applyAdvice(
         named("createEntry")
             .and(isDeclaredBy(named("org.springframework.cglib.core.internal.LoadingCache"))),
+        advice);
+    transformation.applyAdvice(
+        named("runOnEventLoop")
+            .and(
+                isDeclaredBy(
+                    named(
+                        "com.datastax.oss.driver.internal.core.channel.DefaultWriteCoalescer$Flusher"))),
         advice);
     transformation.applyAdvice(
         isTypeInitializer().and(isDeclaredBy(REACTOR_DISABLED_TYPE_INITIALIZERS)), advice);


### PR DESCRIPTION
Prevents propagation into this event loop:

```java
    private void runOnEventLoop() {
      assert eventLoop.inEventLoop();

      boolean didSomeWork = false;
      Write write;
      while ((write = writes.poll()) != null) {
        Channel channel = write.channel;
        channels.add(channel);
        channel.write(write.message, write.writePromise);
        didSomeWork = true;
      }

      for (Channel channel : channels) {
        channel.flush();
      }
      channels.clear();

      if (didSomeWork) {
        runsWithNoWork = 0;
      } else if (++runsWithNoWork > maxRunsWithNoWork) {
        // Prepare to stop
        running.set(false);
        // If no new writes have been enqueued since the previous line, we can return safely
        if (writes.isEmpty()) {
          return;
        }
        // Otherwise check if those writes have triggered a new run. If not, we need to do that
        // ourselves (i.e. not return yet)
        if (!running.compareAndSet(false, true)) {
          return;
        }
      }
      if (!eventLoop.isShuttingDown()) {
        eventLoop.schedule(this::runOnEventLoop, rescheduleIntervalNanos, TimeUnit.NANOSECONDS);
      }
    }
```

Leads to sensible checkpoints:

Before:

```
Activity checkpoints by thread ordered by time
Test worker: |-startSpan/14-|-startSpan/15-|-suspend/15-|-----------|------------|------------|-----------|------------|------------|------------|--------------|------------|-----------|------------|------------|-----------|------------|------------|-----------|------------|------------|-----------|------------|------------|-----------|------------|-endSpan/14-|
s4-io-1:     |--------------|--------------|------------|-resume/15-|-suspend/15-|-endTask/15-|-resume/15-|-suspend/15-|-endTask/15-|-endSpan/15-|-startSpan/16-|-endSpan/16-|-resume/15-|-suspend/15-|-endTask/15-|-resume/15-|-suspend/15-|-endTask/15-|-resume/15-|-suspend/15-|-endTask/15-|-resume/15-|-suspend/15-|-endTask/15-|-resume/15-|-endTask/15-|------------|
```

After
```
Activity checkpoints by thread ordered by time
Test worker: |-startSpan/14-|-startSpan/15-|-suspend/15-|-----------|------------|------------|--------------|------------|-endSpan/14-|
s4-io-1:     |--------------|--------------|------------|-resume/15-|-endTask/15-|-endSpan/15-|-startSpan/16-|-endSpan/16-|------------|
```