### PR TITLE
Add config option to disable context propagation for specified rabbit queues and exchanges

### DIFF
--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitChannelInstrumentation.java
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitChannelInstrumentation.java
@@ -32,6 +32,7 @@ import com.rabbitmq.client.Consumer;
 import com.rabbitmq.client.GetResponse;
 import com.rabbitmq.client.MessageProperties;
 import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.api.Config;
 import datadog.trace.bootstrap.CallDepthThreadLocalMap;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
@@ -162,7 +163,10 @@ public class RabbitChannelInstrumentation extends Instrumenter.Tracing {
         Map<String, Object> headers = props.getHeaders();
         headers = (headers == null) ? new HashMap<String, Object>() : new HashMap<>(headers);
 
-        propagate().inject(span, headers, SETTER);
+        if (Config.get().isRabbitPropagationEnabled()
+            && !Config.get().getRabbitPropagationDisabledExchanges().contains(exchange)) {
+          propagate().inject(span, headers, SETTER);
+        }
 
         props =
             new AMQP.BasicProperties(

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -76,6 +76,7 @@ public final class ConfigDefaults {
 
   static final boolean DEFAULT_KAFKA_CLIENT_PROPAGATION_ENABLED = true;
   static final boolean DEFAULT_JMS_PROPAGATION_ENABLED = true;
+  static final boolean DEFAULT_RABBIT_PROPAGATION_ENABLED = true;
 
   static final boolean DEFAULT_TRACE_REPORT_HOSTNAME = false;
   static final String DEFAULT_TRACE_ANNOTATIONS = null;
@@ -87,5 +88,6 @@ public final class ConfigDefaults {
 
   public static final boolean DEFAULT_ASYNC_PROPAGATING = true;
 
-  private ConfigDefaults() {}
+  private ConfigDefaults() {
+  }
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
@@ -28,31 +28,37 @@ public final class TraceInstrumentationConfig {
   public static final String DB_CLIENT_HOST_SPLIT_BY_INSTANCE = "trace.db.client.split-by-instance";
 
   public static final String JDBC_PREPARED_STATEMENT_CLASS_NAME =
-      "trace.jdbc.prepared.statement.class.name";
+          "trace.jdbc.prepared.statement.class.name";
 
   public static final String JDBC_CONNECTION_CLASS_NAME = "trace.jdbc.connection.class.name";
 
   public static final String RUNTIME_CONTEXT_FIELD_INJECTION =
-      "trace.runtime.context.field.injection";
+          "trace.runtime.context.field.injection";
   public static final String SERIALVERSIONUID_FIELD_INJECTION =
-      "trace.serialversionuid.field.injection";
+          "trace.serialversionuid.field.injection";
 
   public static final String LOGS_INJECTION_ENABLED = "logs.injection";
   public static final String LOGS_MDC_TAGS_INJECTION_ENABLED = "logs.mdc.tags.injection";
 
   public static final String KAFKA_CLIENT_PROPAGATION_ENABLED = "kafka.client.propagation.enabled";
   public static final String KAFKA_CLIENT_PROPAGATION_DISABLED_TOPICS =
-      "kafka.client.propagation.disabled.topics";
+          "kafka.client.propagation.disabled.topics";
   public static final String KAFKA_CLIENT_BASE64_DECODING_ENABLED =
-      "kafka.client.base64.decoding.enabled";
+          "kafka.client.base64.decoding.enabled";
 
   public static final String JMS_PROPAGATION_ENABLED = "jms.propagation.enabled";
   public static final String JMS_PROPAGATION_DISABLED_TOPICS = "jms.propagation.disabled.topics";
   public static final String JMS_PROPAGATION_DISABLED_QUEUES = "jms.propagation.disabled.queues";
 
+  public static final String RABBIT_PROPAGATION_ENABLED = "rabbit.propagation.enabled";
+  public static final String RABBIT_PROPAGATION_DISABLED_QUEUES =
+          "rabbit.propagation.disabled.queues";
+  public static final String RABBIT_PROPAGATION_DISABLED_EXCHANGES =
+          "rabbit.propagation.disabled.exchanges";
+
   public static final String GRPC_IGNORED_OUTBOUND_METHODS = "trace.grpc.ignored.outbound.methods";
   public static final String GRPC_SERVER_TRIM_PACKAGE_RESOURCE =
-      "trace.grpc.server.trim-package-resource";
+          "trace.grpc.server.trim-package-resource";
   public static final String HYSTRIX_TAGS_ENABLED = "hystrix.tags.enabled";
   public static final String HYSTRIX_MEASURED_ENABLED = "hystrix.measured.enabled";
 
@@ -66,11 +72,12 @@ public final class TraceInstrumentationConfig {
   public static final String SERVLET_ASYNC_TIMEOUT_ERROR = "trace.servlet.async-timeout.error";
 
   public static final String SERVLET_ROOT_CONTEXT_SERVICE_NAME =
-      "trace.servlet.root-context.service.name";
+          "trace.servlet.root-context.service.name";
 
   public static final String TEMP_JARS_CLEAN_ON_BOOT = "temp.jars.clean.on.boot";
 
   public static final String RESOLVER_USE_LOADCLASS = "resolver.use.loadclass";
 
-  private TraceInstrumentationConfig() {}
+  private TraceInstrumentationConfig() {
+  }
 }


### PR DESCRIPTION
Config to disable queues (from consumer side): `rabbit.propagation.disabled.queues`
Config to disable exchanges (from producer side): `rabbit.propagation.disabled.exchanges`