### PR TITLE
Print stacktraces for spans which have invalid sequence of events

### DIFF
--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/checkpoints/Event.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/checkpoints/Event.groovy
@@ -62,13 +62,12 @@ class Event {
 
   String toString() {
     return "${name}/${spanId} (thread: ${threadName})\n" +
-        String.join("\n",
-            stackTrace.stream()
-                .filter {
-                    !(it.className.startsWith("org.codehaus.groovy") || it.className.startsWith("groovy")) &&
-                    !(it.className.startsWith("org.spockframework")) }
-                .map { "  " + it.toString() }
-                .collect(Collectors.toList())) +
+        stackTrace.stream()
+            .filter {
+                !(it.className.startsWith("org.codehaus.groovy") || it.className.startsWith("groovy")) &&
+                !(it.className.startsWith("org.spockframework")) }
+            .map { "  " + it.toString() }
+            .collect(Collectors.joining("\n")) +
         "\n"
   }
 }

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/checkpoints/Event.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/checkpoints/Event.groovy
@@ -62,12 +62,13 @@ class Event {
 
   String toString() {
     return "${name}/${spanId} (thread: ${threadName})\n" +
-        stackTrace.stream()
-            .filter {
-                !(it.className.startsWith("org.codehaus.groovy") || it.className.startsWith("groovy")) &&
-                !(it.className.startsWith("org.spockframework")) }
-            .map { "  " + it.toString() }
-            .collect(Collectors.joining("\n")) +
-        "\n"
+      stackTrace.stream()
+      .filter {
+        !(it.className.startsWith("org.codehaus.groovy") || it.className.startsWith("groovy")) &&
+          !(it.className.startsWith("org.spockframework"))
+      }
+      .map { "  " + it.toString() }
+      .collect(Collectors.joining("\n")) +
+      "\n"
   }
 }

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/checkpoints/TimelineCheckpointer.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/checkpoints/TimelineCheckpointer.groovy
@@ -3,8 +3,6 @@ package datadog.trace.agent.test.checkpoints
 import datadog.trace.api.Checkpointer
 import datadog.trace.api.DDId
 
-import java.util.stream.Collectors
-
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArrayList
 


### PR DESCRIPTION
This allows to more specifically pinpoint where the events were created,
and diagnose why an event was wrongfully created or should have been
created.