### PR TITLE
Remove cassandra and okhttp2 leaks

### DIFF
--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/AsyncPropagatingDisableInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/AsyncPropagatingDisableInstrumentation.java
@@ -73,6 +73,7 @@ public final class AsyncPropagatingDisableInstrumentation extends Instrumenter.T
             "rx.internal.util.ObjectPool",
             "io.grpc.internal.ServerImpl$ServerTransportListenerImpl",
             "okhttp3.ConnectionPool",
+            "com.squareup.okhttp.ConnectionPool",
             "org.elasticsearch.transport.netty4.Netty4TcpChannel",
             "org.springframework.cglib.core.internal.LoadingCache",
             "com.datastax.oss.driver.internal.core.channel.DefaultWriteCoalescer$Flusher",
@@ -110,6 +111,9 @@ public final class AsyncPropagatingDisableInstrumentation extends Instrumenter.T
         advice);
     transformation.applyAdvice(
         named("start").and(isDeclaredBy(named("rx.internal.util.ObjectPool"))), advice);
+    transformation.applyAdvice(
+        named("addConnection").and(isDeclaredBy(named("com.squareup.okhttp.ConnectionPool"))),
+        advice);
     transformation.applyAdvice(
         named("put").and(isDeclaredBy(named("okhttp3.ConnectionPool"))), advice);
     transformation.applyAdvice(

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/AsyncPropagatingDisableInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/AsyncPropagatingDisableInstrumentation.java
@@ -75,7 +75,8 @@ public final class AsyncPropagatingDisableInstrumentation extends Instrumenter.T
             "okhttp3.ConnectionPool",
             "org.elasticsearch.transport.netty4.Netty4TcpChannel",
             "org.springframework.cglib.core.internal.LoadingCache",
-            "com.datastax.oss.driver.internal.core.channel.DefaultWriteCoalescer$Flusher")
+            "com.datastax.oss.driver.internal.core.channel.DefaultWriteCoalescer$Flusher",
+            "com.datastax.oss.driver.api.core.session.SessionBuilder")
         .or(RX_WORKERS)
         .or(GRPC_MANAGED_CHANNEL)
         .or(REACTOR_DISABLED_TYPE_INITIALIZERS);
@@ -125,6 +126,10 @@ public final class AsyncPropagatingDisableInstrumentation extends Instrumenter.T
                 isDeclaredBy(
                     named(
                         "com.datastax.oss.driver.internal.core.channel.DefaultWriteCoalescer$Flusher"))),
+        advice);
+    transformation.applyAdvice(
+        named("buildAsync")
+            .and(isDeclaredBy(named("com.datastax.oss.driver.api.core.session.SessionBuilder"))),
         advice);
     transformation.applyAdvice(
         isTypeInitializer().and(isDeclaredBy(REACTOR_DISABLED_TYPE_INITIALIZERS)), advice);


### PR DESCRIPTION
Cassandra: 

before:

```
=== Invalid checkpoint events encountered
resume/1 (thread: s0-admin-0)

=== Activity checkpoints by thread ordered by time
===== Invalid event sequences were detected. Affected spans are highlited by '***'
Test worker: |-startSpan/1-|-suspend/1-|----------|-suspend/1-|-suspend/1-|-----------|----------|-----------|-----------|----------|-----------|-----------|-----------|----------|-----------|-----------|----------|-----------|-----------|----------|-----------|-----------|----------|-----------|-----------|-----------|----------|-----------|----------|-----------|-----------|-----------|----------|-----------|-----------|----------|-----------|-----------|-----------|----------|-----------|----------|-----------|-----------|----------|-----------|-----------|----------|-----------|-----------|----------|-----------|-----------|-----------|----------|-----------|-----------|----------|-----------|-----------|-----------|-----------|----------|-----------|-----------|----------|-----------|----------|----------|-----------|----------|----------------|-startSpan/2-|-suspend/2-|----------|-----------|-endSpan/2-|-startSpan/3-|-suspend/3-|----------|-----------|-endSpan/3-|-startSpan/4-|-suspend/4-|----------|-----------|-endSpan/4-|-endSpan/1-|-startSpan/5-|-suspend/5-|----------|-----------|-endSpan/5-|
s0-admin-0:  |-------------|-----------|-resume/1-|-----------|-----------|-suspend/1-|----------|-endTask/1-|-----------|----------|-----------|-----------|-----------|----------|-----------|-----------|-resume/1-|-----------|-endTask/1-|-resume/1-|-endTask/1-|-----------|----------|-----------|-----------|-----------|----------|-----------|----------|-----------|-suspend/1-|-suspend/1-|----------|-----------|-suspend/1-|----------|-----------|-suspend/1-|-----------|----------|-----------|----------|-----------|-suspend/1-|----------|-----------|-suspend/1-|----------|-----------|-suspend/1-|----------|-----------|-----------|-suspend/1-|----------|-----------|-----------|----------|-----------|-suspend/1-|-suspend/1-|-suspend/1-|----------|-----------|-suspend/1-|----------|-----------|-resume/1-|-resume/1-|-endTask/1-|-resume/1-|-***resume/1***-|-------------|-----------|----------|-----------|-----------|-------------|-----------|----------|-----------|-----------|-------------|-----------|----------|-----------|-----------|-----------|-------------|-----------|----------|-----------|-----------|
s0-admin-1:  |-------------|-----------|----------|-----------|-----------|-----------|-resume/1-|-----------|-suspend/1-|----------|-endTask/1-|-----------|-----------|----------|-----------|-suspend/1-|----------|-suspend/1-|-----------|----------|-----------|-suspend/1-|----------|-----------|-suspend/1-|-----------|----------|-----------|----------|-----------|-----------|-----------|-resume/1-|-endTask/1-|-----------|----------|-----------|-----------|-----------|----------|-----------|----------|-----------|-----------|-resume/1-|-endTask/1-|-----------|-resume/1-|-endTask/1-|-----------|-resume/1-|-suspend/1-|-endTask/1-|-----------|----------|-----------|-----------|----------|-----------|-----------|-----------|-----------|----------|-----------|-----------|-resume/1-|-endTask/1-|----------|----------|-----------|----------|----------------|-------------|-----------|----------|-----------|-----------|-------------|-----------|----------|-----------|-----------|-------------|-----------|----------|-----------|-----------|-----------|-------------|-----------|----------|-----------|-----------|
s0-io-0:     |-------------|-----------|----------|-----------|-----------|-----------|----------|-----------|-----------|-resume/1-|-----------|-suspend/1-|-endTask/1-|-resume/1-|-endTask/1-|-----------|----------|-----------|-----------|----------|-----------|-----------|-resume/1-|-endTask/1-|-----------|-suspend/1-|-resume/1-|-endTask/1-|-resume/1-|-endTask/1-|-----------|-----------|----------|-----------|-----------|-resume/1-|-endTask/1-|-----------|-suspend/1-|-resume/1-|-endTask/1-|-resume/1-|-endTask/1-|-----------|----------|-----------|-----------|----------|-----------|-----------|----------|-----------|-----------|-----------|----------|-----------|-----------|----------|-----------|-----------|-----------|-----------|----------|-----------|-----------|----------|-----------|----------|----------|-----------|----------|----------------|-------------|-----------|----------|-----------|-----------|-------------|-----------|----------|-----------|-----------|-------------|-----------|----------|-----------|-----------|-----------|-------------|-----------|----------|-----------|-----------|
s0-io-1:     |-------------|-----------|----------|-----------|-----------|-----------|----------|-----------|-----------|----------|-----------|-----------|-----------|----------|-----------|-----------|----------|-----------|-----------|----------|-----------|-----------|----------|-----------|-----------|-----------|----------|-----------|----------|-----------|-----------|-----------|----------|-----------|-----------|----------|-----------|-----------|-----------|----------|-----------|----------|-----------|-----------|----------|-----------|-----------|----------|-----------|-----------|----------|-----------|-----------|-----------|-resume/1-|-suspend/1-|-endTask/1-|-resume/1-|-endTask/1-|-----------|-----------|-----------|-resume/1-|-endTask/1-|-----------|----------|-----------|----------|----------|-----------|----------|----------------|-------------|-----------|-resume/2-|-endTask/2-|-----------|-------------|-----------|-resume/3-|-endTask/3-|-----------|-------------|-----------|-resume/4-|-endTask/4-|-----------|-----------|-------------|-----------|----------|-----------|-----------|
s1-io-1:     |-------------|-----------|----------|-----------|-----------|-----------|----------|-----------|-----------|----------|-----------|-----------|-----------|----------|-----------|-----------|----------|-----------|-----------|----------|-----------|-----------|----------|-----------|-----------|-----------|----------|-----------|----------|-----------|-----------|-----------|----------|-----------|-----------|----------|-----------|-----------|-----------|----------|-----------|----------|-----------|-----------|----------|-----------|-----------|----------|-----------|-----------|----------|-----------|-----------|-----------|----------|-----------|-----------|----------|-----------|-----------|-----------|-----------|----------|-----------|-----------|----------|-----------|----------|----------|-----------|----------|----------------|-------------|-----------|----------|-----------|-----------|-------------|-----------|----------|-----------|-----------|-------------|-----------|----------|-----------|-----------|-----------|-------------|-----------|-resume/5-|-endTask/5-|-----------|
```

after:

```
=== Activity checkpoints by thread ordered by time
Test worker: |-startSpan/1-|-startSpan/2-|-suspend/2-|----------|-----------|-endSpan/2-|-startSpan/3-|-suspend/3-|----------|-----------|-endSpan/3-|-startSpan/4-|-suspend/4-|----------|-----------|-endSpan/4-|-endSpan/1-|-startSpan/5-|-suspend/5-|----------|-----------|-endSpan/5-|
s0-io-1:     |-------------|-------------|-----------|-resume/2-|-endTask/2-|-----------|-------------|-----------|-resume/3-|-endTask/3-|-----------|-------------|-----------|-resume/4-|-endTask/4-|-----------|-----------|-------------|-----------|----------|-----------|-----------|
s1-io-1:     |-------------|-------------|-----------|----------|-----------|-----------|-------------|-----------|----------|-----------|-----------|-------------|-----------|----------|-----------|-----------|-----------|-------------|-----------|-resume/5-|-endTask/5-|-----------|
```

okhttp2:

before:
```
=== Invalid checkpoint events encountered
resume/19 (thread: OkHttp ConnectionPool)

=== Activity checkpoints by thread ordered by time
===== Invalid event sequences were detected. Affected spans are highlited by '***'
Test worker:           |-startSpan/19-|--------------|------------|-suspend/19-|-endSpan/19-|-----------------|
qtp536301114-31:       |--------------|-startSpan/20-|-endSpan/20-|------------|------------|-----------------|
OkHttp ConnectionPool: |--------------|--------------|------------|------------|------------|-***resume/19***-|
```

after:

```
=== Activity checkpoints by thread ordered by time
Test worker:     |-startSpan/19-|--------------|------------|-endSpan/19-|
qtp185226311-31: |--------------|-startSpan/20-|-endSpan/20-|------------|
```