### PR TITLE
Prevent DDSpan from escaping unwrapped with OT

### DIFF
--- a/dd-trace-ot/src/main/java/datadog/opentracing/OTSpan.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/OTSpan.java
@@ -71,18 +71,19 @@ class OTSpan implements Span, MutableSpan {
   }
 
   @Override
-  public MutableSpan setError(final boolean value) {
-    return delegate.setError(value);
+  public OTSpan setError(final boolean value) {
+    delegate.setError(value);
+    return this;
   }
 
   @Override
-  public MutableSpan getRootSpan() {
-    return delegate.getLocalRootSpan();
+  public OTSpan getRootSpan() {
+    return getLocalRootSpan();
   }
 
   @Override
-  public MutableSpan getLocalRootSpan() {
-    return delegate.getLocalRootSpan();
+  public OTSpan getLocalRootSpan() {
+    return converter.toSpan(delegate.getLocalRootSpan());
   }
 
   @Override
@@ -92,31 +93,31 @@ class OTSpan implements Span, MutableSpan {
   }
 
   @Override
-  public Span log(final Map<String, ?> fields) {
+  public OTSpan log(final Map<String, ?> fields) {
     logHandler.log(fields, delegate);
     return this;
   }
 
   @Override
-  public Span log(final long timestampMicroseconds, final Map<String, ?> fields) {
+  public OTSpan log(final long timestampMicroseconds, final Map<String, ?> fields) {
     logHandler.log(timestampMicroseconds, fields, delegate);
     return this;
   }
 
   @Override
-  public Span log(final String event) {
+  public OTSpan log(final String event) {
     logHandler.log(event, delegate);
     return this;
   }
 
   @Override
-  public Span log(final long timestampMicroseconds, final String event) {
+  public OTSpan log(final long timestampMicroseconds, final String event) {
     logHandler.log(timestampMicroseconds, event, delegate);
     return this;
   }
 
   @Override
-  public Span setBaggageItem(final String key, final String value) {
+  public OTSpan setBaggageItem(final String key, final String value) {
     delegate.setBaggageItem(key, value);
     return this;
   }
@@ -127,7 +128,7 @@ class OTSpan implements Span, MutableSpan {
   }
 
   @Override
-  public Span setOperationName(final String operationName) {
+  public OTSpan setOperationName(final String operationName) {
     return setOperationName(UTF8BytesString.create(operationName));
   }
 
@@ -158,8 +159,9 @@ class OTSpan implements Span, MutableSpan {
   }
 
   @Override
-  public MutableSpan setServiceName(final String serviceName) {
-    return delegate.setServiceName(serviceName);
+  public OTSpan setServiceName(final String serviceName) {
+    delegate.setServiceName(serviceName);
+    return this;
   }
 
   @Override
@@ -168,8 +170,9 @@ class OTSpan implements Span, MutableSpan {
   }
 
   @Override
-  public MutableSpan setResourceName(final CharSequence resourceName) {
-    return delegate.setResourceName(resourceName);
+  public OTSpan setResourceName(final CharSequence resourceName) {
+    delegate.setResourceName(resourceName);
+    return this;
   }
 
   @Override
@@ -178,8 +181,9 @@ class OTSpan implements Span, MutableSpan {
   }
 
   @Override
-  public MutableSpan setSamplingPriority(final int newPriority) {
-    return delegate.setSamplingPriority(newPriority);
+  public OTSpan setSamplingPriority(final int newPriority) {
+    delegate.setSamplingPriority(newPriority);
+    return this;
   }
 
   @Override
@@ -188,8 +192,9 @@ class OTSpan implements Span, MutableSpan {
   }
 
   @Override
-  public MutableSpan setSpanType(final CharSequence type) {
-    return delegate.setSpanType(type);
+  public OTSpan setSpanType(final CharSequence type) {
+    delegate.setSpanType(type);
+    return this;
   }
 
   @Override

--- a/dd-trace-ot/src/main/java/datadog/opentracing/TypeConverter.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/TypeConverter.java
@@ -29,7 +29,7 @@ class TypeConverter {
     }
   }
 
-  public Span toSpan(final AgentSpan agentSpan) {
+  public OTSpan toSpan(final AgentSpan agentSpan) {
     if (agentSpan == null) {
       return null;
     }


### PR DESCRIPTION
Various methods in OTSpan are returning the underlying span object, not the wrapped one.  This is problematic because users expect to be able to cast back to an OT type.