### PR TITLE
emit thread migrations in TagSettingAsyncListener

### DIFF
--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/AsyncPropagatingDisableInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/AsyncPropagatingDisableInstrumentation.java
@@ -77,7 +77,8 @@ public final class AsyncPropagatingDisableInstrumentation extends Instrumenter.T
             "org.elasticsearch.transport.netty4.Netty4TcpChannel",
             "org.springframework.cglib.core.internal.LoadingCache",
             "com.datastax.oss.driver.internal.core.channel.DefaultWriteCoalescer$Flusher",
-            "com.datastax.oss.driver.api.core.session.SessionBuilder")
+            "com.datastax.oss.driver.api.core.session.SessionBuilder",
+            "org.jvnet.hk2.internal.ServiceLocatorImpl")
         .or(RX_WORKERS)
         .or(GRPC_MANAGED_CHANNEL)
         .or(REACTOR_DISABLED_TYPE_INITIALIZERS);
@@ -134,6 +135,10 @@ public final class AsyncPropagatingDisableInstrumentation extends Instrumenter.T
     transformation.applyAdvice(
         named("buildAsync")
             .and(isDeclaredBy(named("com.datastax.oss.driver.api.core.session.SessionBuilder"))),
+        advice);
+    transformation.applyAdvice(
+        namedOneOf("getInjecteeDescriptor", "getService")
+            .and(isDeclaredBy(named("org.jvnet.hk2.internal.ServiceLocatorImpl"))),
         advice);
     transformation.applyAdvice(
         isTypeInitializer().and(isDeclaredBy(REACTOR_DISABLED_TYPE_INITIALIZERS)), advice);


### PR DESCRIPTION
This is enough to get servlet checkpoints to line up, ignoring out of order span finishes, which are tolerated. The way the servlet instrumentations layer, it can be ambiguous which span is active, which is hard to address and isn't important except for things like profiler integration.

This also revealed some scope leaks in the glassfish service locator.

```
=== Activity checkpoints by thread ordered by time
===== Invalid event sequences were detected. Affected spans are highlited by '***'
dw-42:                |-startSpan/1-|-------------|-----------|----------|-suspend/1-|-------------|----------|-----------|-------------|-------------|-----------|-----------|----------|-------------|----------|-----------|-----------------|-----------------|-startSpan/7-|-------------|-----------|-suspend/7-|----------|-------------|----------|-----------|-----------------|--------------|--------------|------------|------------|-----------|-----------------|-----------------|-----------------|-----------|-----------|-----------|--------------|-----------|------------|------------------|------------------|------------|
dw-42 - GET /success: |-------------|-startSpan/2-|-suspend/2-|----------|-----------|-------------|----------|-----------|-------------|-------------|-----------|-----------|----------|-------------|----------|-----------|-----------------|-----------------|-------------|-startSpan/8-|-suspend/8-|-----------|----------|-------------|----------|-----------|-----------------|--------------|--------------|------------|------------|-----------|-----------------|-----------------|-----------------|-----------|-----------|-----------|--------------|-----------|------------|------------------|------------------|------------|
pool-2-thread-1:      |-------------|-------------|-----------|-resume/2-|-----------|-startSpan/3-|-resume/1-|-endSpan/1-|-------------|-------------|-----------|-----------|----------|-------------|----------|-----------|-***endSpan/2***-|-----------------|-------------|-------------|-----------|-----------|----------|-------------|----------|-----------|-----------------|--------------|--------------|------------|------------|-----------|-----------------|-----------------|-***endSpan/3***-|-----------|-endTask/2-|-----------|--------------|-----------|------------|------------------|------------------|------------|
dw-57:                |-------------|-------------|-----------|----------|-----------|-------------|----------|-----------|-startSpan/4-|-------------|-----------|-suspend/4-|----------|-------------|----------|-----------|-----------------|-----------------|-------------|-------------|-----------|-----------|----------|-------------|----------|-----------|-----------------|-startSpan/10-|--------------|------------|-suspend/10-|-----------|-----------------|-----------------|-----------------|-----------|-----------|-----------|--------------|-----------|------------|------------------|------------------|------------|
dw-57 - GET /success: |-------------|-------------|-----------|----------|-----------|-------------|----------|-----------|-------------|-startSpan/5-|-suspend/5-|-----------|----------|-------------|----------|-----------|-----------------|-----------------|-------------|-------------|-----------|-----------|----------|-------------|----------|-----------|-----------------|--------------|-startSpan/11-|-suspend/11-|------------|-----------|-----------------|-----------------|-----------------|-----------|-----------|-----------|--------------|-----------|------------|------------------|------------------|------------|
pool-3-thread-1:      |-------------|-------------|-----------|----------|-----------|-------------|----------|-----------|-------------|-------------|-----------|-----------|-resume/5-|-startSpan/6-|-resume/4-|-endSpan/4-|-----------------|-***endSpan/5***-|-------------|-------------|-----------|-----------|----------|-------------|----------|-----------|-----------------|--------------|--------------|------------|------------|-----------|-----------------|-***endSpan/6***-|-----------------|-endTask/5-|-----------|-----------|--------------|-----------|------------|------------------|------------------|------------|
pool-4-thread-1:      |-------------|-------------|-----------|----------|-----------|-------------|----------|-----------|-------------|-------------|-----------|-----------|----------|-------------|----------|-----------|-----------------|-----------------|-------------|-------------|-----------|-----------|-resume/8-|-startSpan/9-|-resume/7-|-endSpan/7-|-***endSpan/8***-|--------------|--------------|------------|------------|-----------|-***endSpan/9***-|-----------------|-----------------|-----------|-----------|-endTask/8-|--------------|-----------|------------|------------------|------------------|------------|
pool-5-thread-1:      |-------------|-------------|-----------|----------|-----------|-------------|----------|-----------|-------------|-------------|-----------|-----------|----------|-------------|----------|-----------|-----------------|-----------------|-------------|-------------|-----------|-----------|----------|-------------|----------|-----------|-----------------|--------------|--------------|------------|------------|-resume/11-|-----------------|-----------------|-----------------|-----------|-----------|-----------|-startSpan/12-|-resume/10-|-endSpan/10-|-***endSpan/11***-|-***endSpan/12***-|-endTask/11-|
```
