### PR TITLE
httpasyncclient checkpoints resilience

### DIFF
--- a/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/test/groovy/CheckpointEmissionTest.groovy
+++ b/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/test/groovy/CheckpointEmissionTest.groovy
@@ -53,8 +53,8 @@ class CheckpointEmissionTest extends AgentTestRunner {
     TEST_WRITER.waitForTraces(2)
     then:
     3 * TEST_CHECKPOINTER.checkpoint(_, _, SPAN)
-    1 * TEST_CHECKPOINTER.checkpoint(_, _, THREAD_MIGRATION)
-    1 * TEST_CHECKPOINTER.checkpoint(_, _, THREAD_MIGRATION | END)
+    2 * TEST_CHECKPOINTER.checkpoint(_, _, THREAD_MIGRATION)
+    2 * TEST_CHECKPOINTER.checkpoint(_, _, THREAD_MIGRATION | END)
     3 * TEST_CHECKPOINTER.checkpoint(_, _, SPAN | END)
     _ * TEST_CHECKPOINTER.onRootSpanPublished(_, _)
     0 * _
@@ -71,8 +71,8 @@ class CheckpointEmissionTest extends AgentTestRunner {
     TEST_WRITER.waitForTraces(2)
     then:
     4 * TEST_CHECKPOINTER.checkpoint(_, _, SPAN)
-    1 * TEST_CHECKPOINTER.checkpoint(_, _, THREAD_MIGRATION)
-    1 * TEST_CHECKPOINTER.checkpoint(_, _, THREAD_MIGRATION | END)
+    2 * TEST_CHECKPOINTER.checkpoint(_, _, THREAD_MIGRATION)
+    2 * TEST_CHECKPOINTER.checkpoint(_, _, THREAD_MIGRATION | END)
     4 * TEST_CHECKPOINTER.checkpoint(_, _, SPAN | END)
     _ * TEST_CHECKPOINTER.onRootSpanPublished(_, _)
     0 * _


### PR DESCRIPTION
Making the state machine resilient to redirects and failure is complicated, so this change cheats for finishing the span - it _always_ resumes before finishing.

The most interesting callbacks worth profiling are here:

```java
public void consumeContent(
        final InternalState state,
        final ContentDecoder decoder,
        final IOControl ioctrl) throws IOException {
    if (this.log.isDebugEnabled()) {
        this.log.debug("[exchange: " + state.getId() + "] Consume content");
    }
    if (state.getFinalResponse() != null) {
        final HttpAsyncResponseConsumer<?> responseConsumer = state.getResponseConsumer();
        responseConsumer.consumeContent(decoder, ioctrl);
    } else {
        final ByteBuffer tmpbuf = state.getTmpbuf();
        tmpbuf.clear();
        decoder.read(tmpbuf);
    }
}


public void produceContent(
        final InternalState state,
        final ContentEncoder encoder,
        final IOControl ioctrl) throws IOException {
    if (this.log.isDebugEnabled()) {
        this.log.debug("[exchange: " + state.getId() + "] produce content");
    }
    final HttpAsyncRequestProducer requestProducer = state.getRequestProducer();
    state.setRequestContentProduced();
    requestProducer.produceContent(encoder, ioctrl);
    if (encoder.isCompleted()) {
        requestProducer.resetRequest();
    }
}
```

The instrumentation  now ensures we resume and suspend around these methods, so that it doesn't matter how many redirects there are or if there is a failure, checkpoints always balance and span the most interesting work.

All tests validate after this change.