### PR TITLE
migrate parent span to network thread before it is reactivated on completion

### DIFF
--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerCallback.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerCallback.java
@@ -18,6 +18,12 @@ public class KafkaProducerCallback implements Callback {
     this.callback = callback;
     this.parent = parent;
     this.span = span;
+    if (null != parent) {
+      // we will activate it on the network thread on completion
+      // span is not migrated here so that serialization on the
+      // current thread is captured
+      parent.startThreadMigration();
+    }
   }
 
   @Override


### PR DESCRIPTION
This fixes checkpoint validation for kafka-client and kafka-streams so it can be included for checkpoint regression testing