### PR TITLE
Remove unused org.eclipse.jetty.io.SelectorManager type matcher

### DIFF
--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/AsyncPropagatingDisableInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/AsyncPropagatingDisableInstrumentation.java
@@ -78,7 +78,6 @@ public final class AsyncPropagatingDisableInstrumentation extends Instrumenter.T
             "org.springframework.cglib.core.internal.LoadingCache",
             "com.datastax.oss.driver.internal.core.channel.DefaultWriteCoalescer$Flusher",
             "com.datastax.oss.driver.api.core.session.SessionBuilder",
-            "org.eclipse.jetty.io.SelectorManager",
             "org.jvnet.hk2.internal.ServiceLocatorImpl",
             "com.zaxxer.hikari.pool.HikariPool",
             "net.sf.ehcache.store.disk.DiskStorageFactory",


### PR DESCRIPTION
This matcher was added in #2963 - that PR originally disabled async propagation for `SelectorManager.connect`:

https://github.com/DataDog/dd-trace-java/commit/f56cf48#diff-95106a2e3e98d1d80bf3c90929ae2377454a9e151cd3eddb4990e3a97789501cR131

but during the life of the PR that `SelectorManager.connect` advice was removed:

https://github.com/DataDog/dd-trace-java/pull/2963/files#diff-95106a2e3e98d1d80bf3c90929ae2377454a9e151cd3eddb4990e3a97789501cR81

Since there no longer appears to be a context leak in `jetty-client` after the other changes from #2963 this PR simply removes the unused type matcher.