### PR TITLE
Prevent DDSpan from escaping unwrapped with OpenTracing Via the Agent

### DIFF
--- a/dd-java-agent/instrumentation/opentracing/api-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/OTSpan.java
+++ b/dd-java-agent/instrumentation/opentracing/api-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/OTSpan.java
@@ -71,46 +71,47 @@ class OTSpan implements Span, MutableSpan {
   }
 
   @Override
-  public MutableSpan setError(final boolean value) {
-    return delegate.setError(value);
+  public OTSpan setError(final boolean value) {
+    delegate.setError(value);
+    return this;
   }
 
   @Override
-  public MutableSpan getRootSpan() {
-    return delegate.getLocalRootSpan();
+  public OTSpan getRootSpan() {
+    return getLocalRootSpan();
   }
 
   @Override
-  public MutableSpan getLocalRootSpan() {
-    return delegate.getLocalRootSpan();
+  public OTSpan getLocalRootSpan() {
+    return converter.toSpan(delegate.getLocalRootSpan());
   }
 
   @Override
-  public Span log(final Map<String, ?> fields) {
+  public OTSpan log(final Map<String, ?> fields) {
     logHandler.log(fields, delegate);
     return this;
   }
 
   @Override
-  public Span log(final long timestampMicroseconds, final Map<String, ?> fields) {
+  public OTSpan log(final long timestampMicroseconds, final Map<String, ?> fields) {
     logHandler.log(timestampMicroseconds, fields, delegate);
     return this;
   }
 
   @Override
-  public Span log(final String event) {
+  public OTSpan log(final String event) {
     logHandler.log(event, delegate);
     return this;
   }
 
   @Override
-  public Span log(final long timestampMicroseconds, final String event) {
+  public OTSpan log(final long timestampMicroseconds, final String event) {
     logHandler.log(timestampMicroseconds, event, delegate);
     return this;
   }
 
   @Override
-  public Span setBaggageItem(final String key, final String value) {
+  public OTSpan setBaggageItem(final String key, final String value) {
     delegate.setBaggageItem(key, value);
     return this;
   }
@@ -131,13 +132,13 @@ class OTSpan implements Span, MutableSpan {
   }
 
   @Override
-  public String getOperationName() {
-    return String.valueOf(delegate.getOperationName());
+  public CharSequence getOperationName() {
+    return delegate.getOperationName();
   }
 
   @Override
-  public MutableSpan setOperationName(final CharSequence serviceName) {
-    delegate.setOperationName(serviceName);
+  public OTSpan setOperationName(final CharSequence operationName) {
+    delegate.setOperationName(operationName);
     return this;
   }
 
@@ -153,8 +154,9 @@ class OTSpan implements Span, MutableSpan {
   }
 
   @Override
-  public MutableSpan setServiceName(final String serviceName) {
-    return delegate.setServiceName(serviceName);
+  public OTSpan setServiceName(final String serviceName) {
+    delegate.setServiceName(serviceName);
+    return this;
   }
 
   @Override
@@ -163,8 +165,9 @@ class OTSpan implements Span, MutableSpan {
   }
 
   @Override
-  public MutableSpan setResourceName(final CharSequence resourceName) {
-    return delegate.setResourceName(resourceName);
+  public OTSpan setResourceName(final CharSequence resourceName) {
+    delegate.setResourceName(resourceName);
+    return this;
   }
 
   @Override
@@ -173,8 +176,9 @@ class OTSpan implements Span, MutableSpan {
   }
 
   @Override
-  public MutableSpan setSamplingPriority(final int newPriority) {
-    return delegate.setSamplingPriority(newPriority);
+  public OTSpan setSamplingPriority(final int newPriority) {
+    delegate.setSamplingPriority(newPriority);
+    return this;
   }
 
   @Override
@@ -183,8 +187,9 @@ class OTSpan implements Span, MutableSpan {
   }
 
   @Override
-  public MutableSpan setSpanType(final CharSequence type) {
-    return delegate.setSpanType(type);
+  public OTSpan setSpanType(final CharSequence type) {
+    delegate.setSpanType(type);
+    return this;
   }
 
   @Override

--- a/dd-java-agent/instrumentation/opentracing/api-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/TypeConverter.java
+++ b/dd-java-agent/instrumentation/opentracing/api-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/TypeConverter.java
@@ -26,7 +26,7 @@ public class TypeConverter {
     return null == span ? null : AgentTracer.NoopAgentSpan.INSTANCE;
   }
 
-  public Span toSpan(final AgentSpan agentSpan) {
+  public OTSpan toSpan(final AgentSpan agentSpan) {
     if (agentSpan == null) {
       return null;
     }

--- a/dd-java-agent/instrumentation/opentracing/api-0.31/src/test/groovy/OpenTracing31Test.groovy
+++ b/dd-java-agent/instrumentation/opentracing/api-0.31/src/test/groovy/OpenTracing31Test.groovy
@@ -48,7 +48,7 @@ class OpenTracing31Test extends AgentTestRunner {
 
     expect:
     result instanceof MutableSpan
-    (result as MutableSpan).localRootSpan == result.delegate
+    (result as MutableSpan).localRootSpan.delegate == result.delegate
     (result as MutableSpan).isError() == (exception != null)
     tracer.activeSpan() == null
     result.context().baggageItems().isEmpty()
@@ -296,7 +296,7 @@ class OpenTracing31Test extends AgentTestRunner {
 
     // make sure scope stack has been left in a valid state
     Span testSpan = tracer.buildSpan("someOperation").start()
-    Scope testScope =  tracer.scopeManager().activate(testSpan, false)
+    Scope testScope = tracer.scopeManager().activate(testSpan, false)
     testSpan.finish()
     testScope.close()
 

--- a/dd-java-agent/instrumentation/opentracing/api-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/OTSpan.java
+++ b/dd-java-agent/instrumentation/opentracing/api-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/OTSpan.java
@@ -72,18 +72,19 @@ class OTSpan implements Span, MutableSpan {
   }
 
   @Override
-  public MutableSpan setError(final boolean value) {
-    return delegate.setError(value);
+  public OTSpan setError(final boolean value) {
+    delegate.setError(value);
+    return this;
   }
 
   @Override
-  public MutableSpan getRootSpan() {
-    return delegate.getLocalRootSpan();
+  public OTSpan getRootSpan() {
+    return getLocalRootSpan();
   }
 
   @Override
-  public MutableSpan getLocalRootSpan() {
-    return delegate.getLocalRootSpan();
+  public OTSpan getLocalRootSpan() {
+    return converter.toSpan(delegate.getLocalRootSpan());
   }
 
   @Override
@@ -93,31 +94,31 @@ class OTSpan implements Span, MutableSpan {
   }
 
   @Override
-  public Span log(final Map<String, ?> fields) {
+  public OTSpan log(final Map<String, ?> fields) {
     logHandler.log(fields, delegate);
     return this;
   }
 
   @Override
-  public Span log(final long timestampMicroseconds, final Map<String, ?> fields) {
+  public OTSpan log(final long timestampMicroseconds, final Map<String, ?> fields) {
     logHandler.log(timestampMicroseconds, fields, delegate);
     return this;
   }
 
   @Override
-  public Span log(final String event) {
+  public OTSpan log(final String event) {
     logHandler.log(event, delegate);
     return this;
   }
 
   @Override
-  public Span log(final long timestampMicroseconds, final String event) {
+  public OTSpan log(final long timestampMicroseconds, final String event) {
     logHandler.log(timestampMicroseconds, event, delegate);
     return this;
   }
 
   @Override
-  public Span setBaggageItem(final String key, final String value) {
+  public OTSpan setBaggageItem(final String key, final String value) {
     delegate.setBaggageItem(key, value);
     return this;
   }
@@ -138,19 +139,20 @@ class OTSpan implements Span, MutableSpan {
   }
 
   @Override
-  public String getOperationName() {
-    return String.valueOf(delegate.getOperationName());
+  public CharSequence getOperationName() {
+    return delegate.getOperationName();
   }
 
   @Override
-  public MutableSpan setOperationName(final CharSequence operationName) {
+  public OTSpan setOperationName(final CharSequence operationName) {
     delegate.setOperationName(operationName);
     return this;
   }
 
   @Override
   public OTSpan setOperationName(final String operationName) {
-    return (OTSpan) setOperationName(UTF8BytesString.create(operationName));
+    delegate.setOperationName(UTF8BytesString.create(operationName));
+    return this;
   }
 
   @Override
@@ -159,8 +161,9 @@ class OTSpan implements Span, MutableSpan {
   }
 
   @Override
-  public MutableSpan setServiceName(final String serviceName) {
-    return delegate.setServiceName(serviceName);
+  public OTSpan setServiceName(final String serviceName) {
+    delegate.setServiceName(serviceName);
+    return this;
   }
 
   @Override
@@ -169,8 +172,9 @@ class OTSpan implements Span, MutableSpan {
   }
 
   @Override
-  public MutableSpan setResourceName(final CharSequence resourceName) {
-    return delegate.setResourceName(resourceName);
+  public OTSpan setResourceName(final CharSequence resourceName) {
+    delegate.setResourceName(resourceName);
+    return this;
   }
 
   @Override
@@ -179,8 +183,9 @@ class OTSpan implements Span, MutableSpan {
   }
 
   @Override
-  public MutableSpan setSamplingPriority(final int newPriority) {
-    return delegate.setSamplingPriority(newPriority);
+  public OTSpan setSamplingPriority(final int newPriority) {
+    delegate.setSamplingPriority(newPriority);
+    return this;
   }
 
   @Override
@@ -189,8 +194,9 @@ class OTSpan implements Span, MutableSpan {
   }
 
   @Override
-  public MutableSpan setSpanType(final CharSequence type) {
-    return delegate.setSpanType(type);
+  public OTSpan setSpanType(final CharSequence type) {
+    delegate.setSpanType(type);
+    return this;
   }
 
   @Override

--- a/dd-java-agent/instrumentation/opentracing/api-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/TypeConverter.java
+++ b/dd-java-agent/instrumentation/opentracing/api-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/TypeConverter.java
@@ -26,7 +26,7 @@ public class TypeConverter {
     return null == span ? null : AgentTracer.NoopAgentSpan.INSTANCE;
   }
 
-  public Span toSpan(final AgentSpan agentSpan) {
+  public OTSpan toSpan(final AgentSpan agentSpan) {
     if (agentSpan == null) {
       return null;
     }

--- a/dd-java-agent/instrumentation/opentracing/api-0.32/src/test/groovy/OpenTracing32Test.groovy
+++ b/dd-java-agent/instrumentation/opentracing/api-0.32/src/test/groovy/OpenTracing32Test.groovy
@@ -48,7 +48,7 @@ class OpenTracing32Test extends AgentTestRunner {
 
     expect:
     result instanceof MutableSpan
-    (result as MutableSpan).localRootSpan == result.delegate
+    (result as MutableSpan).localRootSpan.delegate == result.delegate
     (result as MutableSpan).isError() == (exception != null)
     tracer.activeSpan() == null
     result.context().baggageItems().isEmpty()

--- a/dd-smoke-tests/opentracing/src/main/java/datadog/smoketest/opentracing/OTWithAgentApplication.java
+++ b/dd-smoke-tests/opentracing/src/main/java/datadog/smoketest/opentracing/OTWithAgentApplication.java
@@ -1,6 +1,7 @@
 package datadog.smoketest.opentracing;
 
 import datadog.trace.api.DDTags;
+import datadog.trace.api.interceptor.MutableSpan;
 import io.opentracing.Scope;
 import io.opentracing.Span;
 import io.opentracing.Tracer;
@@ -14,6 +15,8 @@ public class OTWithAgentApplication {
     final Span span = tracer.buildSpan("someOperation").start();
     try (final Scope scope = tracer.activateSpan(span)) {
       span.setTag(DDTags.SERVICE_NAME, "someService");
+      // Verify that the returned object is wrapped correctly.
+      Span root = (Span) ((MutableSpan) tracer.activeSpan()).getLocalRootSpan();
     }
 
     span.finish();

--- a/dd-trace-ot/src/main/java/datadog/opentracing/OTSpan.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/OTSpan.java
@@ -128,11 +128,6 @@ class OTSpan implements Span, MutableSpan {
   }
 
   @Override
-  public OTSpan setOperationName(final String operationName) {
-    return setOperationName(UTF8BytesString.create(operationName));
-  }
-
-  @Override
   public long getStartTime() {
     return delegate.getStartTime();
   }
@@ -150,6 +145,12 @@ class OTSpan implements Span, MutableSpan {
   @Override
   public OTSpan setOperationName(final CharSequence operationName) {
     delegate.setOperationName(operationName);
+    return this;
+  }
+
+  @Override
+  public OTSpan setOperationName(final String operationName) {
+    delegate.setOperationName(UTF8BytesString.create(operationName));
     return this;
   }
 


### PR DESCRIPTION
This was previously fixed with `dd-trace-ot` in #2967, but I forgot to apply the same change to the agent.

Also make OTSpan copies more consistent.