### PR TITLE
Ignore exceptions thrown when canceling GRPC streaming

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/ContextStore.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/ContextStore.java
@@ -25,7 +25,7 @@ public interface ContextStore<K, C> {
   /**
    * Get context given the key
    *
-   * @param key the key to looup
+   * @param key the key to lookup
    * @return context object
    */
   C get(K key);
@@ -56,4 +56,12 @@ public interface ContextStore<K, C> {
    * @return old instance if it was present, or new instance
    */
   C putIfAbsent(K key, Factory<C> contextFactory);
+
+  /**
+   * Removes the existing value for key and return it.
+   *
+   * @param key the key remove
+   * @return removed context object
+   */
+  C remove(K key);
 }

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/FieldBackedContextStore.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/FieldBackedContextStore.java
@@ -69,6 +69,25 @@ public final class FieldBackedContextStore implements ContextStore<Object, Objec
     }
   }
 
+  @Override
+  public Object remove(Object key) {
+    if (key instanceof FieldBackedContextAccessor) {
+      final FieldBackedContextAccessor accessor = (FieldBackedContextAccessor) key;
+      Object existingContext = accessor.$get$__datadogContext$(storeId);
+      if (null != existingContext) {
+        synchronized (accessor) {
+          existingContext = accessor.$get$__datadogContext$(storeId);
+          if (null != existingContext) {
+            accessor.$put$__datadogContext$(storeId, null);
+          }
+        }
+      }
+      return existingContext;
+    } else {
+      return weakStore().remove(key);
+    }
+  }
+
   // only create WeakMap-based fall-back when we need it
   private volatile WeakMapContextStore weakStore;
   private final Object synchronizationInstance = new Object();

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/WeakMap.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/WeakMap.java
@@ -17,6 +17,8 @@ public interface WeakMap<K, V> {
 
   V computeIfAbsent(K key, Function<? super K, ? extends V> supplier);
 
+  V remove(K key);
+
   class Provider {
     private static final AtomicReferenceFieldUpdater<Provider, Implementation> UPDATER =
         AtomicReferenceFieldUpdater.newUpdater(Provider.class, Implementation.class, "provider");

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/WeakMapContextStore.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/WeakMapContextStore.java
@@ -51,4 +51,9 @@ final class WeakMapContextStore implements ContextStore<Object, Object> {
     }
     return existingContext;
   }
+
+  @Override
+  public Object remove(final Object key) {
+    return map.remove(key);
+  }
 }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/WeakMapSuppliers.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/WeakMapSuppliers.java
@@ -107,6 +107,11 @@ class WeakMapSuppliers {
         }
         return value;
       }
+
+      @Override
+      public V remove(K key) {
+        return map.remove(key);
+      }
     }
   }
 }

--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/client/ClientCallImplInstrumentation.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/client/ClientCallImplInstrumentation.java
@@ -109,7 +109,7 @@ public final class ClientCallImplInstrumentation extends Instrumenter.Tracing {
   public static final class Cancel {
     @Advice.OnMethodEnter
     public static void before(@Advice.This ClientCall<?, ?> call) {
-      AgentSpan span = InstrumentationContext.get(ClientCall.class, AgentSpan.class).get(call);
+      AgentSpan span = InstrumentationContext.get(ClientCall.class, AgentSpan.class).remove(call);
       if (null != span) {
         span.finish();
       }
@@ -139,7 +139,7 @@ public final class ClientCallImplInstrumentation extends Instrumenter.Tracing {
     @Advice.OnMethodExit(onThrowable = Throwable.class)
     public static void closeObserver(
         @Advice.This ClientCall<?, ?> call, @Advice.Argument(1) Status status) {
-      AgentSpan span = InstrumentationContext.get(ClientCall.class, AgentSpan.class).get(call);
+      AgentSpan span = InstrumentationContext.get(ClientCall.class, AgentSpan.class).remove(call);
       if (null != span) {
         DECORATE.onClose(span, status);
         span.finish();

--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/GrpcServerDecorator.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/GrpcServerDecorator.java
@@ -81,8 +81,8 @@ public class GrpcServerDecorator extends ServerDecorator {
     span.setTag("status.code", status.getCode().name());
     span.setTag("status.description", status.getDescription());
 
-    onError(span, status.getCause());
-    if (!status.isOk()) {
+    if (!status.isOk() && status != Status.CANCELLED) {
+      onError(span, status.getCause());
       span.setError(true);
     }
 

--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/TracingServerInterceptor.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/TracingServerInterceptor.java
@@ -18,6 +18,7 @@ import io.grpc.ServerCall;
 import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
 import io.grpc.Status;
+import java.util.concurrent.CancellationException;
 
 public class TracingServerInterceptor implements ServerInterceptor {
 
@@ -124,6 +125,9 @@ public class TracingServerInterceptor implements ServerInterceptor {
       try (final AgentScope scope = activateSpan(span)) {
         delegate().onCancel();
         span.setTag("canceled", true);
+      } catch (CancellationException e) {
+        // No need to report an exception or mark as error that it was canceled.
+        throw e;
       } catch (final Throwable e) {
         DECORATE.onError(span, e);
         throw e;

--- a/dd-trace-core/src/jmh/java/datadog/trace/core/PendingTraceWrite.java
+++ b/dd-trace-core/src/jmh/java/datadog/trace/core/PendingTraceWrite.java
@@ -83,8 +83,8 @@ public class PendingTraceWrite {
       trace.registerSpan(span);
     }
     for (int i = 0; i < depthPerThread; ++i) {
-      trace.addFinishedSpan(span);
+      trace.onPublish(span);
     }
-    trace.addFinishedSpan(root);
+    trace.onPublish(root);
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -53,8 +53,11 @@ public class DDSpan implements AgentSpan, CoreSpan<DDSpan> {
   private final long startTimeNano;
 
   /**
-   * The duration in nanoseconds computed using the startTimeMicro or startTimeNano. Span is
-   * considered finished when this is set.
+   * The duration in nanoseconds computed using the startTimeMicro or startTimeNano.<hr> The span's
+   * states are defined as follows:
+   * <li>eq 0 -> unfinished.
+   * <li>lt 0 -> finished but unpublished.
+   * <li>gt 0 -> finished and published.
    */
   private final AtomicLong durationNano = new AtomicLong();
 
@@ -88,8 +91,9 @@ public class DDSpan implements AgentSpan, CoreSpan<DDSpan> {
   private void finishAndAddToTrace(final long durationNano) {
     // ensure a min duration of 1
     if (this.durationNano.compareAndSet(0, Math.max(1, durationNano))) {
-      PendingTrace.FinishState finishState = context.getTrace().addFinishedSpan(this);
-      log.debug("Finished span ({}): {}", finishState, this);
+      context.getTrace().onFinish(this);
+      PendingTrace.PublishState publishState = context.getTrace().onPublish(this);
+      log.debug("Finished span ({}): {}", publishState, this);
     } else {
       log.debug("Already finished: {}", this);
     }
@@ -109,6 +113,38 @@ public class DDSpan implements AgentSpan, CoreSpan<DDSpan> {
   public final void finish(final long stoptimeMicros) {
     context.getTrace().touch(); // Update timestamp
     finishAndAddToTrace(TimeUnit.MICROSECONDS.toNanos(stoptimeMicros - startTimeMicro));
+  }
+
+  @Override
+  public final boolean phasedFinish() {
+    long durationNano;
+    if (startTimeNano > 0) {
+      durationNano = context.getTrace().getCurrentTimeNano() - startTimeNano;
+    } else {
+      durationNano = TimeUnit.MICROSECONDS.toNanos(Clock.currentMicroTime() - startTimeMicro);
+    }
+    // Flip the negative bit of the result to allow verifying that publish() is only called once.
+    if (this.durationNano.compareAndSet(0, Math.max(1, durationNano) | Long.MIN_VALUE)) {
+      context.getTrace().onFinish(this);
+      log.debug("Finished span (PHASED): {}", this);
+      return true;
+    } else {
+      log.debug("Already finished: {}", this);
+      return false;
+    }
+  }
+
+  @Override
+  public final void publish() {
+    long durationNano = this.durationNano.get();
+    if (durationNano == 0) {
+      log.debug("Can't publish unfinished span: {}", this);
+    } else if (durationNano > 0) {
+      log.debug("Already published: {}", this);
+    } else if (this.durationNano.compareAndSet(durationNano, durationNano & Long.MAX_VALUE)) {
+      PendingTrace.PublishState publishState = context.getTrace().onPublish(this);
+      log.debug("Published span ({}): {}", publishState, this);
+    }
   }
 
   @Override

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
@@ -72,6 +72,20 @@ public interface AgentSpan extends MutableSpan {
 
   void finish(long finishMicros);
 
+  /**
+   * Finishes the span but does not publish it. The {@link #publish()} method MUST be called once
+   * otherwise the trace will not be reported.
+   *
+   * @return true if the span was successfully finished, false if it was already finished.
+   */
+  boolean phasedFinish();
+
+  /**
+   * Publish a span that was previously finished by calling {@link #phasedFinish()}. Must be called
+   * once and only once per span.
+   */
+  void publish();
+
   CharSequence getSpanName();
 
   void setSpanName(CharSequence spanName);

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -526,6 +526,14 @@ public class AgentTracer {
     public void finish(final long finishMicros) {}
 
     @Override
+    public boolean phasedFinish() {
+      return false;
+    }
+
+    @Override
+    public void publish() {}
+
+    @Override
     public String getSpanName() {
       return "";
     }


### PR DESCRIPTION
The stacktrace is unlikely to be useful and not something that should be treated as an error.