### PR TITLE
Limit tomcat latest test to 10.0.+

### DIFF
--- a/dd-java-agent/instrumentation/classloading/tomcat-testing/tomcat-testing.gradle
+++ b/dd-java-agent/instrumentation/classloading/tomcat-testing/tomcat-testing.gradle
@@ -24,5 +24,6 @@ dependencies {
   //Older versions would require slightly different instrumentation.
   testImplementation group: 'org.apache.tomcat', name: 'tomcat-catalina', version: '8.0.14'
 
-  latestDepTestImplementation group: 'org.apache.tomcat', name: 'tomcat-catalina', version: '+'
+  // Tomcat 10.1.+ seems to require Java 11. Limit to fix build.
+  latestDepTestImplementation group: 'org.apache.tomcat', name: 'tomcat-catalina', version: '10.0.+'
 }

--- a/dd-java-agent/instrumentation/java-concurrent/lambda-testing/lambda-testing.gradle
+++ b/dd-java-agent/instrumentation/java-concurrent/lambda-testing/lambda-testing.gradle
@@ -19,5 +19,7 @@ dependencies {
   testImplementation project(':dd-java-agent:instrumentation:trace-annotation')
 
   testImplementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '7.0.0'
-  latestDepTestImplementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '+'
+  // Tomcat 10.1.+ seems to require Java 11. Limit to fix build.
+  // TODO: Tomcat 10.0.10 has a copy of the JSR166 ThreadPoolExecutor so it needs special instrumentation
+  latestDepTestImplementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '10.0.8'
 }

--- a/dd-java-agent/instrumentation/jdbc/jdbc.gradle
+++ b/dd-java-agent/instrumentation/jdbc/jdbc.gradle
@@ -63,8 +63,9 @@ dependencies {
   latestDepTestImplementation group: 'org.apache.derby', name: 'derby', version: '10.14.+'
   latestDepTestImplementation group: 'org.hsqldb', name: 'hsqldb', version: '2.5+'
 
-  latestDepTestImplementation group: 'org.apache.tomcat', name: 'tomcat-jdbc', version: '+'
-  latestDepTestImplementation group: 'org.apache.tomcat', name: 'tomcat-juli', version: '+'
+  // Tomcat 10.1.+ seems to require Java 11. Limit to fix build.
+  latestDepTestImplementation group: 'org.apache.tomcat', name: 'tomcat-jdbc', version: '10.0.+'
+  latestDepTestImplementation group: 'org.apache.tomcat', name: 'tomcat-juli', version: '10.0.+'
   latestDepTestImplementation group: 'com.zaxxer', name: 'HikariCP', version: '4.+' // 5+ requires Java 11
   latestDepTestImplementation group: 'com.mchange', name: 'c3p0', version: '+'
 

--- a/dd-java-agent/instrumentation/jdbc/scalikejdbc/scalikejdbc.gradle
+++ b/dd-java-agent/instrumentation/jdbc/scalikejdbc/scalikejdbc.gradle
@@ -48,8 +48,9 @@ dependencies {
   latestDepTestImplementation group: 'com.h2database', name: 'h2', version: '+'
   latestDepTestImplementation group: 'org.apache.derby', name: 'derby', version: '10.14.+'
   latestDepTestImplementation group: 'org.hsqldb', name: 'hsqldb', version: '2.5+'
-  latestDepTestImplementation group: 'org.apache.tomcat', name: 'tomcat-jdbc', version: '+'
-  latestDepTestImplementation group: 'org.apache.tomcat', name: 'tomcat-juli', version: '+'
+  // Tomcat 10.1.+ seems to require Java 11. Limit to fix build.
+  latestDepTestImplementation group: 'org.apache.tomcat', name: 'tomcat-jdbc', version: '10.0.+'
+  latestDepTestImplementation group: 'org.apache.tomcat', name: 'tomcat-juli', version: '10.0.+'
   latestDepTestImplementation group: 'com.zaxxer', name: 'HikariCP', version: '4.+' // 5+ requires Java 11
   latestDepTestImplementation group: 'com.mchange', name: 'c3p0', version: '+'
 }

--- a/dd-java-agent/instrumentation/servlet/request-3/request-3.gradle
+++ b/dd-java-agent/instrumentation/servlet/request-3/request-3.gradle
@@ -45,6 +45,7 @@ dependencies {
   latestDepTestImplementation group: 'org.eclipse.jetty', name: 'jetty-servlet', version: '9.+'
 
   // FIXME: 9.0.24 seems to have changed something...
-  latestDepTestImplementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.+'
-  latestDepTestImplementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-jasper', version: '9.+'
+  // TODO: Tomcat 9.0.52 has a copy of the JSR166 ThreadPoolExecutor so it needs special instrumentation
+  latestDepTestImplementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.0.50'
+  latestDepTestImplementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-jasper', version: '9.0.50'
 }

--- a/dd-java-agent/instrumentation/tomcat-5.5/tomcat-5.5.gradle
+++ b/dd-java-agent/instrumentation/tomcat-5.5/tomcat-5.5.gradle
@@ -64,7 +64,8 @@ dependencies {
   testImplementation group: 'commons-modeler', name: 'commons-modeler', version: '2.0.1'
   testImplementation group: 'javax.servlet', name: 'servlet-api', version: '2.4'
 
-  latestDepTestImplementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '+'
+  // Tomcat 10.1.+ seems to require Java 11. Limit to fix build.
+  latestDepTestImplementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '10.0.+'
 }
 
 // Exclude all the dependencies from test for latestDepTest since the names are completely different.


### PR DESCRIPTION
10.1+ seems will require Java 11 which is not compatible with our build currently.