### PR TITLE
Ensure all "client" and a few "server" spans are marked as "measured"

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/ClientDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/ClientDecorator.java
@@ -17,6 +17,9 @@ public abstract class ClientDecorator extends BaseDecorator {
       span.setServiceName(service());
     }
     span.setTag(Tags.SPAN_KIND, spanKind());
+
+    // Generate metrics for all client spans.
+    span.setMeasured(true);
     return super.afterStart(span);
   }
 }

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/DatabaseClientDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/DatabaseClientDecorator.java
@@ -39,7 +39,6 @@ public abstract class DatabaseClientDecorator<CONNECTION> extends ClientDecorato
       span.setTag(Tags.DB_USER, dbUser(connection));
       final String instanceName = dbInstance(connection);
       span.setTag(Tags.DB_INSTANCE, instanceName);
-      span.setMeasured(true);
 
       if (instanceName != null && Config.get().isDbClientSplitByInstance()) {
         span.setServiceName(instanceName);

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/rmi/RmiServerDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/rmi/RmiServerDecorator.java
@@ -1,5 +1,6 @@
 package datadog.trace.bootstrap.instrumentation.rmi;
 
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.ServerDecorator;
@@ -22,5 +23,11 @@ public class RmiServerDecorator extends ServerDecorator {
   @Override
   protected CharSequence component() {
     return RMI_SERVER;
+  }
+
+  @Override
+  public AgentSpan afterStart(final AgentSpan span) {
+    span.setMeasured(true);
+    return super.afterStart(span);
   }
 }

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/BaseDecoratorTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/BaseDecoratorTest.groovy
@@ -21,6 +21,7 @@ class BaseDecoratorTest extends DDSpecification {
     1 * span.setSpanType(decorator.spanType())
     1 * span.setTag(Tags.COMPONENT, "test-component")
     _ * span.setTag(_, _) // Want to allow other calls from child implementations.
+    _ * span.setMeasured(true)
     _ * span.setMetric(_, _)
     _ * span.setServiceName(_)
     _ * span.setOperationName(_)

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/ClientDecoratorTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/ClientDecoratorTest.groovy
@@ -19,6 +19,7 @@ class ClientDecoratorTest extends BaseDecoratorTest {
     if (serviceName != null) {
       1 * span.setServiceName(serviceName)
     }
+    1 * span.setMeasured(true)
     1 * span.setTag(Tags.COMPONENT, "test-component")
     1 * span.setTag(Tags.SPAN_KIND, "client")
     1 * span.setSpanType(decorator.spanType())

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/DBTypeProcessingDatabaseClientDecoratorTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/DBTypeProcessingDatabaseClientDecoratorTest.groovy
@@ -20,6 +20,7 @@ class DBTypeProcessingDatabaseClientDecoratorTest extends ClientDecoratorTest {
     if (serviceName != null) {
       1 * span.setServiceName(serviceName)
     }
+    1 * span.setMeasured(true)
     1 * span.setTag(Tags.COMPONENT, "test-component")
     1 * span.setTag(Tags.SPAN_KIND, "client")
     1 * span.setSpanType("test-type")

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/DatabaseClientDecoratorTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/DatabaseClientDecoratorTest.groovy
@@ -21,6 +21,7 @@ class DatabaseClientDecoratorTest extends ClientDecoratorTest {
     if (serviceName != null) {
       1 * span.setServiceName(serviceName)
     }
+    1 * span.setMeasured(true)
     1 * span.setTag(Tags.COMPONENT, "test-component")
     1 * span.setTag(Tags.SPAN_KIND, "client")
     1 * span.setSpanType("test-type")
@@ -43,7 +44,6 @@ class DatabaseClientDecoratorTest extends ClientDecoratorTest {
     if (session) {
       1 * span.setTag(Tags.DB_USER, session.user)
       1 * span.setTag(Tags.DB_INSTANCE, session.instance)
-      1 * span.setMeasured(true)
       if (session.hostname != null) {
         1 * span.setTag(Tags.PEER_HOSTNAME, session.hostname)
       }

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/AkkaHttpSingleRequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/AkkaHttpSingleRequestInstrumentation.java
@@ -73,7 +73,6 @@ public final class AkkaHttpSingleRequestInstrumentation extends Instrumenter.Tra
       }
 
       final AgentSpan span = startSpan(AKKA_CLIENT_REQUEST);
-      span.setMeasured(true);
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, request);
 

--- a/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientInstrumentation.java
@@ -86,7 +86,6 @@ public class ApacheHttpAsyncClientInstrumentation extends Instrumenter.Tracing {
 
       final TraceScope parentScope = activeScope();
       final AgentSpan clientSpan = startSpan(HTTP_REQUEST);
-      clientSpan.setMeasured(true);
       DECORATE.afterStart(clientSpan);
 
       requestProducer = new DelegatingRequestProducer(clientSpan, requestProducer);

--- a/dd-java-agent/instrumentation/apache-httpclient-4/src/main/java/datadog/trace/instrumentation/apachehttpclient/HelperMethods.java
+++ b/dd-java-agent/instrumentation/apache-httpclient-4/src/main/java/datadog/trace/instrumentation/apachehttpclient/HelperMethods.java
@@ -17,7 +17,6 @@ import org.apache.http.client.methods.HttpUriRequest;
 public class HelperMethods {
   public static AgentScope doMethodEnter(final HttpUriRequest request) {
     final AgentSpan span = startSpan(HTTP_REQUEST);
-    span.setMeasured(true);
     final AgentScope scope = activateSpan(span);
 
     DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/AWSHttpClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/AWSHttpClientInstrumentation.java
@@ -63,7 +63,6 @@ public class AWSHttpClientInstrumentation extends Instrumenter.Tracing {
         if (scope != null) {
           request.addHandlerContext(SCOPE_CONTEXT_KEY, null);
           final AgentSpan span = scope.span();
-          span.setMeasured(true);
           DECORATE.onError(span, throwable);
           DECORATE.beforeFinish(span);
           scope.close();
@@ -112,7 +111,6 @@ public class AWSHttpClientInstrumentation extends Instrumenter.Tracing {
           if (scope != null) {
             request.addHandlerContext(SCOPE_CONTEXT_KEY, null);
             final AgentSpan span = scope.span();
-            span.setMeasured(true);
             DECORATE.onError(span, throwable);
             DECORATE.beforeFinish(span);
             scope.close();

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/AwsSdkClientDecorator.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/AwsSdkClientDecorator.java
@@ -53,7 +53,6 @@ public class AwsSdkClientDecorator extends HttpClientDecorator<Request, Response
     span.setTag("aws.endpoint", request.getEndpoint().toString());
 
     span.setResourceName(cache.getQualifiedName(awsOperation, awsServiceName));
-    span.setMeasured(true);
 
     RequestAccess access = RequestAccess.of(originalRequest);
     String bucketName = access.getBucketName(originalRequest);

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test/groovy/AWS1ClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test/groovy/AWS1ClientTest.groovy
@@ -134,6 +134,7 @@ class AWS1ClientTest extends AgentTestRunner {
           resourceName "$service.$operation"
           spanType DDSpanTypes.HTTP_CLIENT
           errored false
+          measured true
           parent()
           tags {
             "$Tags.COMPONENT" "java-aws-sdk"
@@ -158,6 +159,7 @@ class AWS1ClientTest extends AgentTestRunner {
           resourceName "$method $path"
           spanType DDSpanTypes.HTTP_CLIENT
           errored false
+          measured true
           childOf(span(0))
           tags {
             "$Tags.COMPONENT" "apache-httpclient"
@@ -231,6 +233,7 @@ class AWS1ClientTest extends AgentTestRunner {
           resourceName "$service.$operation"
           spanType DDSpanTypes.HTTP_CLIENT
           errored true
+          measured true
           parent()
           tags {
             "$Tags.COMPONENT" "java-aws-sdk"
@@ -255,6 +258,7 @@ class AWS1ClientTest extends AgentTestRunner {
           resourceName "$method /$url"
           spanType DDSpanTypes.HTTP_CLIENT
           errored true
+          measured true
           childOf(span(0))
           tags {
             "$Tags.COMPONENT" "apache-httpclient"
@@ -299,6 +303,7 @@ class AWS1ClientTest extends AgentTestRunner {
           resourceName "S3.HeadBucket"
           spanType DDSpanTypes.HTTP_CLIENT
           errored true
+          measured true
           parent()
           tags {
             "$Tags.COMPONENT" "java-aws-sdk"
@@ -347,6 +352,7 @@ class AWS1ClientTest extends AgentTestRunner {
           resourceName "S3.GetObject"
           spanType DDSpanTypes.HTTP_CLIENT
           errored true
+          measured true
           parent()
           tags {
             "$Tags.COMPONENT" "java-aws-sdk"
@@ -374,6 +380,7 @@ class AWS1ClientTest extends AgentTestRunner {
             resourceName "GET /someBucket/someKey"
             spanType DDSpanTypes.HTTP_CLIENT
             errored true
+            measured true
             childOf(span(0))
             tags {
               "$Tags.COMPONENT" "apache-httpclient"

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test_before_1_11_106/groovy/AWS0ClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test_before_1_11_106/groovy/AWS0ClientTest.groovy
@@ -97,6 +97,7 @@ class AWS0ClientTest extends AgentTestRunner {
           resourceName "$service.$operation"
           spanType DDSpanTypes.HTTP_CLIENT
           errored false
+          measured true
           parent()
           tags {
             "$Tags.COMPONENT" "java-aws-sdk"
@@ -121,6 +122,7 @@ class AWS0ClientTest extends AgentTestRunner {
           resourceName "$method $path"
           spanType DDSpanTypes.HTTP_CLIENT
           errored false
+          measured true
           childOf(span(0))
           tags {
             "$Tags.COMPONENT" "apache-httpclient"
@@ -176,6 +178,7 @@ class AWS0ClientTest extends AgentTestRunner {
           resourceName "$service.$operation"
           spanType DDSpanTypes.HTTP_CLIENT
           errored true
+          measured true
           parent()
           tags {
             "$Tags.COMPONENT" "java-aws-sdk"
@@ -200,6 +203,7 @@ class AWS0ClientTest extends AgentTestRunner {
           resourceName "$method /$url"
           spanType DDSpanTypes.HTTP_CLIENT
           errored true
+          measured true
           childOf(span(0))
           tags {
             "$Tags.COMPONENT" "apache-httpclient"
@@ -244,6 +248,7 @@ class AWS0ClientTest extends AgentTestRunner {
           resourceName "S3.GetObject"
           spanType DDSpanTypes.HTTP_CLIENT
           errored true
+          measured true
           parent()
           tags {
             "$Tags.COMPONENT" "java-aws-sdk"
@@ -292,6 +297,7 @@ class AWS0ClientTest extends AgentTestRunner {
           resourceName "S3.GetObject"
           spanType DDSpanTypes.HTTP_CLIENT
           errored true
+          measured true
           parent()
           tags {
             "$Tags.COMPONENT" "java-aws-sdk"
@@ -315,6 +321,7 @@ class AWS0ClientTest extends AgentTestRunner {
             resourceName "GET /someBucket/someKey"
             spanType DDSpanTypes.HTTP_CLIENT
             errored true
+            measured true
             childOf(span(0))
             tags {
               "$Tags.COMPONENT" "apache-httpclient"

--- a/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java8/datadog/trace/instrumentation/aws/v2/AwsSdkClientDecorator.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java8/datadog/trace/instrumentation/aws/v2/AwsSdkClientDecorator.java
@@ -53,7 +53,6 @@ public class AwsSdkClientDecorator extends HttpClientDecorator<SdkHttpRequest, S
     span.setTag("aws.agent", COMPONENT_NAME);
     span.setTag("aws.service", awsServiceName);
     span.setTag("aws.operation", awsOperation);
-    span.setMeasured(true);
 
     return span;
   }

--- a/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java8/datadog/trace/instrumentation/aws/v2/TracingExecutionInterceptor.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java8/datadog/trace/instrumentation/aws/v2/TracingExecutionInterceptor.java
@@ -22,7 +22,6 @@ public class TracingExecutionInterceptor implements ExecutionInterceptor {
   public void beforeExecution(
       final Context.BeforeExecution context, final ExecutionAttributes executionAttributes) {
     final AgentSpan span = startSpan(AWS_HTTP);
-    span.setMeasured(true);
     try (final AgentScope scope = activateSpan(span)) {
       DECORATE.afterStart(span);
       executionAttributes.putAttribute(SPAN_ATTRIBUTE, span);

--- a/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/test/groovy/Aws2ClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/test/groovy/Aws2ClientTest.groovy
@@ -100,6 +100,7 @@ class Aws2ClientTest extends AgentTestRunner {
           resourceName "$service.$operation"
           spanType DDSpanTypes.HTTP_CLIENT
           errored false
+          measured true
           parent()
           tags {
             "$Tags.COMPONENT" "java-aws-sdk"
@@ -132,6 +133,7 @@ class Aws2ClientTest extends AgentTestRunner {
           resourceName "$method $path"
           spanType DDSpanTypes.HTTP_CLIENT
           errored false
+          measured true
           childOf(span(0))
           tags {
             "$Tags.COMPONENT" "apache-httpclient"
@@ -222,6 +224,7 @@ class Aws2ClientTest extends AgentTestRunner {
           resourceName "$service.$operation"
           spanType DDSpanTypes.HTTP_CLIENT
           errored false
+          measured true
           parent()
           tags {
             "$Tags.COMPONENT" "java-aws-sdk"
@@ -257,6 +260,7 @@ class Aws2ClientTest extends AgentTestRunner {
           resourceName "$method $path"
           spanType DDSpanTypes.HTTP_CLIENT
           errored false
+          measured true
           parent()
           tags {
             "$Tags.COMPONENT" "netty-client"

--- a/dd-java-agent/instrumentation/google-http-client/src/main/java/datadog/trace/instrumentation/googlehttpclient/GoogleHttpClientDecorator.java
+++ b/dd-java-agent/instrumentation/google-http-client/src/main/java/datadog/trace/instrumentation/googlehttpclient/GoogleHttpClientDecorator.java
@@ -34,7 +34,6 @@ public class GoogleHttpClientDecorator extends HttpClientDecorator<HttpRequest, 
   }
 
   public AgentSpan prepareSpan(AgentSpan span, HttpRequest request) {
-    span.setMeasured(true);
     DECORATE.afterStart(span);
     DECORATE.onRequest(span, request);
     propagate().inject(span, request, SETTER);

--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/client/GrpcClientDecorator.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/client/GrpcClientDecorator.java
@@ -72,7 +72,6 @@ public class GrpcClientDecorator extends ClientDecorator {
     }
     AgentSpan span =
         startSpan(GRPC_CLIENT)
-            .setMeasured(true)
             .setTag("request.type", requestMessageType(method))
             .setTag("response.type", responseMessageType(method));
     span.setResourceName(method.getFullMethodName());

--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/GrpcServerDecorator.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/GrpcServerDecorator.java
@@ -59,6 +59,12 @@ public class GrpcServerDecorator extends ServerDecorator {
     return COMPONENT_NAME;
   }
 
+  @Override
+  public AgentSpan afterStart(final AgentSpan span) {
+    span.setMeasured(true);
+    return super.afterStart(span);
+  }
+
   public <RespT, ReqT> AgentSpan onCall(final AgentSpan span, ServerCall<ReqT, RespT> call) {
     if (TRIM_RESOURCE_PACKAGE_NAME) {
       span.setResourceName(

--- a/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcTest.groovy
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcTest.groovy
@@ -81,6 +81,7 @@ class GrpcTest extends AgentTestRunner {
           spanType DDSpanTypes.RPC
           childOf span(0)
           errored false
+          measured true
           tags {
             "$Tags.COMPONENT" "grpc-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -96,6 +97,7 @@ class GrpcTest extends AgentTestRunner {
           spanType DDSpanTypes.RPC
           childOf span(1)
           errored false
+          measured true
           tags {
             "$Tags.COMPONENT" "grpc-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -111,6 +113,7 @@ class GrpcTest extends AgentTestRunner {
           spanType DDSpanTypes.RPC
           childOf trace(0).get(1)
           errored false
+          measured true
           tags {
             "$Tags.COMPONENT" "grpc-server"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
@@ -124,6 +127,7 @@ class GrpcTest extends AgentTestRunner {
           spanType DDSpanTypes.RPC
           childOf span(0)
           errored false
+          measured true
           tags {
             "$Tags.COMPONENT" "grpc-server"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
@@ -195,6 +199,7 @@ class GrpcTest extends AgentTestRunner {
           spanType DDSpanTypes.RPC
           parent()
           errored true
+          measured true
           tags {
             "$Tags.COMPONENT" "grpc-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -213,6 +218,7 @@ class GrpcTest extends AgentTestRunner {
           spanType DDSpanTypes.RPC
           childOf trace(0).get(0)
           errored true
+          measured true
           tags {
             "$Tags.COMPONENT" "grpc-server"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
@@ -230,6 +236,7 @@ class GrpcTest extends AgentTestRunner {
           spanType DDSpanTypes.RPC
           childOf span(0)
           errored false
+          measured true
           tags {
             "$Tags.COMPONENT" "grpc-server"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
@@ -290,6 +297,7 @@ class GrpcTest extends AgentTestRunner {
           spanType DDSpanTypes.RPC
           parent()
           errored true
+          measured true
           tags {
             "$Tags.COMPONENT" "grpc-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -307,6 +315,7 @@ class GrpcTest extends AgentTestRunner {
           spanType DDSpanTypes.RPC
           childOf trace(0).get(0)
           errored true
+          measured true
           tags {
             "$Tags.COMPONENT" "grpc-server"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
@@ -320,6 +329,7 @@ class GrpcTest extends AgentTestRunner {
           spanType DDSpanTypes.RPC
           childOf span(0)
           errored false
+          measured true
           tags {
             "$Tags.COMPONENT" "grpc-server"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
@@ -407,6 +417,7 @@ class GrpcTest extends AgentTestRunner {
           spanType DDSpanTypes.RPC
           parentDDId DDId.ZERO
           errored false
+          measured true
           tags {
             "$Tags.COMPONENT" "grpc-server"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
@@ -420,6 +431,7 @@ class GrpcTest extends AgentTestRunner {
           spanType DDSpanTypes.RPC
           childOf span(0)
           errored false
+          measured true
           tags {
             "$Tags.COMPONENT" "grpc-server"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER

--- a/dd-java-agent/instrumentation/hazelcast-3.6/src/test/groovy/test/hazelcast/v3/AbstractHazelcastTest.groovy
+++ b/dd-java-agent/instrumentation/hazelcast-3.6/src/test/groovy/test/hazelcast/v3/AbstractHazelcastTest.groovy
@@ -16,8 +16,10 @@ import spock.lang.Shared
 
 abstract class AbstractHazelcastTest extends AgentTestRunner {
 
-  @Shared HazelcastInstance h1, client
-  @Shared String randomName
+  @Shared
+  HazelcastInstance h1, client
+  @Shared
+  String randomName
 
   final resourceNamePattern = ~/^(?<name>(?<service>\w+)\[[^]]+])\.(?<operation>\w+)$/
 
@@ -84,6 +86,7 @@ abstract class AbstractHazelcastTest extends AgentTestRunner {
       operationName "hazelcast.invoke"
       spanType DDSpanTypes.HTTP_CLIENT
       errored false
+      measured true
       if (isParent) {
         parent()
       } else {

--- a/dd-java-agent/instrumentation/hazelcast-3.9/src/test/groovy/test/hazelcast/v39/AbstractHazelcastTest.groovy
+++ b/dd-java-agent/instrumentation/hazelcast-3.9/src/test/groovy/test/hazelcast/v39/AbstractHazelcastTest.groovy
@@ -18,8 +18,10 @@ import spock.lang.Shared
 
 abstract class AbstractHazelcastTest extends AgentTestRunner {
 
-  @Shared String randomName
-  @Shared HazelcastInstance h1, client
+  @Shared
+  String randomName
+  @Shared
+  HazelcastInstance h1, client
 
   final resourceNamePattern = ~/^(?<operation>(?<service>[A-Z]\w+)\.[a-z]\w+)(?: (?<name>.+))?$/
 
@@ -88,6 +90,7 @@ abstract class AbstractHazelcastTest extends AgentTestRunner {
       operationName "hazelcast.invoke"
       spanType DDSpanTypes.HTTP_CLIENT
       errored false
+      measured true
       if (isParent) {
         parent()
       } else {

--- a/dd-java-agent/instrumentation/hazelcast-4.0/src/test/groovy/test/hazelcast/v4/AbstractHazelcastTest.groovy
+++ b/dd-java-agent/instrumentation/hazelcast-4.0/src/test/groovy/test/hazelcast/v4/AbstractHazelcastTest.groovy
@@ -18,8 +18,10 @@ import spock.lang.Shared
 
 abstract class AbstractHazelcastTest extends AgentTestRunner {
 
-  @Shared HazelcastInstance h1, client
-  @Shared String randomName
+  @Shared
+  HazelcastInstance h1, client
+  @Shared
+  String randomName
 
   final resourceNamePattern = ~/^(?<operation>(?<service>[A-Z]\w+)\.[A-Z]\w+)(?: (?<name>.+))?$/
 
@@ -117,6 +119,7 @@ abstract class AbstractHazelcastTest extends AgentTestRunner {
       operationName "hazelcast.invoke"
       spanType DDSpanTypes.HTTP_CLIENT
       errored false
+      measured true
       if (isParent) {
         parent()
       } else {

--- a/dd-java-agent/instrumentation/jax-rs-client-1.1/src/main/java/datadog/trace/instrumentation/jaxrs/v1/JaxRsClientV1Instrumentation.java
+++ b/dd-java-agent/instrumentation/jax-rs-client-1.1/src/main/java/datadog/trace/instrumentation/jaxrs/v1/JaxRsClientV1Instrumentation.java
@@ -70,7 +70,6 @@ public final class JaxRsClientV1Instrumentation extends Instrumenter.Tracing {
       final boolean isRootClientHandler = null == request.getProperties().get(DD_SPAN_ATTRIBUTE);
       if (isRootClientHandler) {
         final AgentSpan span = startSpan(JAX_RS_CLIENT_CALL);
-        span.setMeasured(true);
         DECORATE.afterStart(span);
         DECORATE.onRequest(span, request);
         request.getProperties().put(DD_SPAN_ATTRIBUTE, span);

--- a/dd-java-agent/instrumentation/jax-rs-client-2.0/src/main/java/datadog/trace/instrumentation/jaxrs/ClientTracingFilter.java
+++ b/dd-java-agent/instrumentation/jax-rs-client-2.0/src/main/java/datadog/trace/instrumentation/jaxrs/ClientTracingFilter.java
@@ -24,7 +24,6 @@ public class ClientTracingFilter implements ClientRequestFilter, ClientResponseF
   public void filter(final ClientRequestContext requestContext) {
     final AgentSpan span = startSpan(JAX_RS_CLIENT_CALL);
     try (final AgentScope scope = activateSpan(span)) {
-      span.setMeasured(true);
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, requestContext);
 
@@ -40,7 +39,6 @@ public class ClientTracingFilter implements ClientRequestFilter, ClientResponseF
     final Object spanObj = requestContext.getProperty(SPAN_PROPERTY_NAME);
     if (spanObj instanceof AgentSpan) {
       final AgentSpan span = (AgentSpan) spanObj;
-      span.setMeasured(true);
       DECORATE.onResponse(span, responseContext);
       DECORATE.beforeFinish(span);
       span.finish();

--- a/dd-java-agent/instrumentation/jetty-client-9.1/src/main/java/datadog/trace/instrumentation/jetty_client/JettyClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-client-9.1/src/main/java/datadog/trace/instrumentation/jetty_client/JettyClientInstrumentation.java
@@ -81,7 +81,6 @@ public class JettyClientInstrumentation extends Instrumenter.Tracing
         @Advice.Argument(0) Request request,
         @Advice.Argument(1) List<Response.ResponseListener> responseListeners) {
       AgentSpan span = startSpan(HTTP_REQUEST);
-      span.setMeasured(true);
       InstrumentationContext.get(Request.class, AgentSpan.class).put(request, span);
       // make sure the span is finished before onComplete callbacks execute
       responseListeners.add(0, new SpanFinishingCompleteListener(span));

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSDecorator.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSDecorator.java
@@ -73,13 +73,11 @@ public final class JMSDecorator extends ClientDecorator {
       }
     } catch (final JMSException ignored) {
     }
-    span.setMeasured(true);
   }
 
   public void onProduce(
       final AgentSpan span, final Message message, final Destination destination) {
     span.setResourceName("Produced for " + toResourceName(message, destination));
-    span.setMeasured(true);
   }
 
   private static final String TIBCO_TMP_PREFIX = "$TMP$";

--- a/dd-java-agent/instrumentation/jms/src/test/groovy/JMS1Test.groovy
+++ b/dd-java-agent/instrumentation/jms/src/test/groovy/JMS1Test.groovy
@@ -465,6 +465,7 @@ class JMS1Test extends AgentTestRunner {
       resourceName "Produced for $jmsResourceName"
       spanType DDSpanTypes.MESSAGE_PRODUCER
       errored false
+      measured true
       parent()
 
       tags {
@@ -488,6 +489,7 @@ class JMS1Test extends AgentTestRunner {
       resourceName "Consumed from $jmsResourceName"
       spanType DDSpanTypes.MESSAGE_CONSUMER
       errored false
+      measured true
       childOf parentSpan
 
       tags {

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaDecorator.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaDecorator.java
@@ -78,7 +78,6 @@ public class KafkaDecorator extends ClientDecorator {
       span.setResourceName(CONSUMER_RESOURCE_NAME_CACHE.computeIfAbsent(topic, CONSUMER_PREFIX));
       span.setTag(PARTITION, record.partition());
       span.setTag(OFFSET, record.offset());
-      span.setMeasured(true);
       // TODO - do we really need both? This mechanism already adds a lot of... baggage.
       // check to not record a duration if the message was sent from an old Kafka client
       if (record.timestampType() != TimestampType.NO_TIMESTAMP_TYPE) {
@@ -116,7 +115,6 @@ public class KafkaDecorator extends ClientDecorator {
       }
       final String topic = record.topic() == null ? "kafka" : record.topic();
       span.setResourceName(PRODUCER_RESOURCE_NAME_CACHE.computeIfAbsent(topic, PRODUCER_PREFIX));
-      span.setMeasured(true);
     }
   }
 }

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTest.groovy
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTest.groovy
@@ -117,6 +117,7 @@ class KafkaClientTest extends AgentTestRunner {
           resourceName "Produce Topic $SHARED_TOPIC"
           spanType "queue"
           errored false
+          measured true
           childOf span(0)
           tags {
             "$Tags.COMPONENT" "java-kafka"
@@ -133,6 +134,7 @@ class KafkaClientTest extends AgentTestRunner {
           resourceName "Consume Topic $SHARED_TOPIC"
           spanType "queue"
           errored false
+          measured true
           childOf trace(0)[2]
           tags {
             "$Tags.COMPONENT" "java-kafka"
@@ -223,6 +225,7 @@ class KafkaClientTest extends AgentTestRunner {
           resourceName "Produce Topic $SHARED_TOPIC"
           spanType "queue"
           errored false
+          measured true
           childOf span(0)
           tags {
             "$Tags.COMPONENT" "java-kafka"
@@ -239,6 +242,7 @@ class KafkaClientTest extends AgentTestRunner {
           resourceName "Consume Topic $SHARED_TOPIC"
           spanType "queue"
           errored false
+          measured true
           childOf trace(0)[2]
           tags {
             "$Tags.COMPONENT" "java-kafka"
@@ -321,6 +325,7 @@ class KafkaClientTest extends AgentTestRunner {
           resourceName "Produce Topic $SHARED_TOPIC"
           spanType "queue"
           errored false
+          measured true
           parent()
           tags {
             "$Tags.COMPONENT" "java-kafka"
@@ -338,6 +343,7 @@ class KafkaClientTest extends AgentTestRunner {
           resourceName "Consume Topic $SHARED_TOPIC"
           spanType "queue"
           errored false
+          measured true
           childOf trace(0)[0]
           tags {
             "$Tags.COMPONENT" "java-kafka"
@@ -403,6 +409,7 @@ class KafkaClientTest extends AgentTestRunner {
           resourceName "Produce Topic $SHARED_TOPIC"
           spanType "queue"
           errored false
+          measured true
           parent()
           tags {
             "$Tags.COMPONENT" "java-kafka"
@@ -420,6 +427,7 @@ class KafkaClientTest extends AgentTestRunner {
           resourceName "Consume Topic $SHARED_TOPIC"
           spanType "queue"
           errored false
+          measured true
           childOf trace(0)[0]
           tags {
             "$Tags.COMPONENT" "java-kafka"
@@ -486,6 +494,7 @@ class KafkaClientTest extends AgentTestRunner {
           resourceName "Produce Topic $SHARED_TOPIC"
           spanType "queue"
           errored false
+          measured true
           parent()
           tags {
             "$Tags.COMPONENT" "java-kafka"
@@ -503,6 +512,7 @@ class KafkaClientTest extends AgentTestRunner {
           resourceName "Consume Topic $SHARED_TOPIC"
           spanType "queue"
           errored false
+          measured true
           childOf trace(0)[0]
           tags {
             "$Tags.COMPONENT" "java-kafka"
@@ -570,6 +580,7 @@ class KafkaClientTest extends AgentTestRunner {
           resourceName "Produce Topic $SHARED_TOPIC"
           spanType "queue"
           errored false
+          measured true
           parent()
           tags {
             "$Tags.COMPONENT" "java-kafka"
@@ -587,6 +598,7 @@ class KafkaClientTest extends AgentTestRunner {
           resourceName "Consume Topic $SHARED_TOPIC"
           spanType "queue"
           errored false
+          measured true
           childOf trace(0)[0]
           tags {
             "$Tags.COMPONENT" "java-kafka"
@@ -655,6 +667,7 @@ class KafkaClientTest extends AgentTestRunner {
           resourceName "Produce Topic $SHARED_TOPIC"
           spanType "queue"
           errored false
+          measured true
           parent()
           tags {
             "$Tags.COMPONENT" "java-kafka"
@@ -671,6 +684,7 @@ class KafkaClientTest extends AgentTestRunner {
           resourceName "Produce Topic $SHARED_TOPIC"
           spanType "queue"
           errored false
+          measured true
           parent()
           tags {
             "$Tags.COMPONENT" "java-kafka"
@@ -687,6 +701,7 @@ class KafkaClientTest extends AgentTestRunner {
           resourceName "Produce Topic $SHARED_TOPIC"
           spanType "queue"
           errored false
+          measured true
           parent()
           tags {
             "$Tags.COMPONENT" "java-kafka"
@@ -705,6 +720,7 @@ class KafkaClientTest extends AgentTestRunner {
           resourceName "Consume Topic $SHARED_TOPIC"
           spanType "queue"
           errored false
+          measured true
           childOf trace(0)[0]
           tags {
             "$Tags.COMPONENT" "java-kafka"
@@ -724,6 +740,7 @@ class KafkaClientTest extends AgentTestRunner {
           resourceName "Consume Topic $SHARED_TOPIC"
           spanType "queue"
           errored false
+          measured true
           childOf trace(1)[0]
           tags {
             "$Tags.COMPONENT" "java-kafka"
@@ -743,6 +760,7 @@ class KafkaClientTest extends AgentTestRunner {
           resourceName "Consume Topic $SHARED_TOPIC"
           spanType "queue"
           errored false
+          measured true
           childOf trace(2)[0]
           tags {
             "$Tags.COMPONENT" "java-kafka"
@@ -764,6 +782,7 @@ class KafkaClientTest extends AgentTestRunner {
           resourceName "Consume Topic $SHARED_TOPIC"
           spanType "queue"
           errored false
+          measured true
           childOf trace(2)[0]
           tags {
             "$Tags.COMPONENT" "java-kafka"
@@ -783,6 +802,7 @@ class KafkaClientTest extends AgentTestRunner {
           resourceName "Consume Topic $SHARED_TOPIC"
           spanType "queue"
           errored false
+          measured true
           childOf trace(1)[0]
           tags {
             "$Tags.COMPONENT" "java-kafka"
@@ -802,6 +822,7 @@ class KafkaClientTest extends AgentTestRunner {
           resourceName "Consume Topic $SHARED_TOPIC"
           spanType "queue"
           errored false
+          measured true
           childOf trace(0)[0]
           tags {
             "$Tags.COMPONENT" "java-kafka"
@@ -883,6 +904,7 @@ class KafkaClientTest extends AgentTestRunner {
           resourceName "Produce Topic $SHARED_TOPIC"
           spanType "queue"
           errored false
+          measured true
           childOf span(0)
           tags {
             "$Tags.COMPONENT" "java-kafka"
@@ -897,6 +919,7 @@ class KafkaClientTest extends AgentTestRunner {
           resourceName "Produce Topic $SHARED_TOPIC"
           spanType "queue"
           errored false
+          measured true
           childOf span(0)
           tags {
             "$Tags.COMPONENT" "java-kafka"
@@ -911,6 +934,7 @@ class KafkaClientTest extends AgentTestRunner {
           resourceName "Produce Topic $SHARED_TOPIC"
           spanType "queue"
           errored false
+          measured true
           childOf span(0)
           tags {
             "$Tags.COMPONENT" "java-kafka"
@@ -926,6 +950,7 @@ class KafkaClientTest extends AgentTestRunner {
           resourceName "Consume Topic $SHARED_TOPIC"
           spanType "queue"
           errored false
+          measured true
           tags {
             "$Tags.COMPONENT" "java-kafka"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
@@ -945,6 +970,7 @@ class KafkaClientTest extends AgentTestRunner {
           resourceName "Consume Topic $SHARED_TOPIC"
           spanType "queue"
           errored false
+          measured true
           tags {
             "$Tags.COMPONENT" "java-kafka"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
@@ -964,6 +990,7 @@ class KafkaClientTest extends AgentTestRunner {
           resourceName "Consume Topic $SHARED_TOPIC"
           spanType "queue"
           errored false
+          measured true
           tags {
             "$Tags.COMPONENT" "java-kafka"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/KafkaStreamsDecorator.java
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/KafkaStreamsDecorator.java
@@ -50,7 +50,6 @@ public class KafkaStreamsDecorator extends ClientDecorator {
       span.setResourceName(RESOURCE_NAME_CACHE.computeIfAbsent(topic, PREFIX));
       span.setTag("partition", record.partition());
       span.setTag("offset", record.offset());
-      span.setMeasured(true);
     }
   }
 }

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/src/test/groovy/KafkaStreamsTest.groovy
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/src/test/groovy/KafkaStreamsTest.groovy
@@ -106,6 +106,7 @@ class KafkaStreamsTest extends AgentTestRunner {
           resourceName "Produce Topic $STREAM_PENDING"
           spanType "queue"
           errored false
+          measured true
           parent()
           tags {
             "$Tags.COMPONENT" "java-kafka"
@@ -122,6 +123,7 @@ class KafkaStreamsTest extends AgentTestRunner {
           resourceName "Consume Topic $STREAM_PENDING"
           spanType "queue"
           errored false
+          measured true
           childOf trace(0)[0]
           tags {
             "$Tags.COMPONENT" "java-kafka"
@@ -143,6 +145,7 @@ class KafkaStreamsTest extends AgentTestRunner {
           resourceName "Consume Topic $STREAM_PENDING"
           spanType "queue"
           errored false
+          measured true
           childOf trace(0)[0]
 
           tags {
@@ -162,6 +165,7 @@ class KafkaStreamsTest extends AgentTestRunner {
           resourceName "Produce Topic $STREAM_PROCESSED"
           spanType "queue"
           errored false
+          measured true
           childOf span(0)
 
           tags {
@@ -179,6 +183,7 @@ class KafkaStreamsTest extends AgentTestRunner {
           resourceName "Consume Topic $STREAM_PROCESSED"
           spanType "queue"
           errored false
+          measured true
           childOf trace(2)[0]
           tags {
             "$Tags.COMPONENT" "java-kafka"

--- a/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/client/HttpClientRequestTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/client/HttpClientRequestTracingHandler.java
@@ -55,7 +55,6 @@ public class HttpClientRequestTracingHandler extends SimpleChannelDownstreamHand
     NettyHttpClientDecorator decorate = isSecure ? DECORATE_SECURE : DECORATE;
 
     final AgentSpan span = startSpan(NETTY_CLIENT_REQUEST);
-    span.setMeasured(true);
     try (final AgentScope scope = activateSpan(span)) {
       decorate.afterStart(span);
       decorate.onRequest(span, request);

--- a/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/client/HttpClientRequestTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/client/HttpClientRequestTracingHandler.java
@@ -61,7 +61,6 @@ public class HttpClientRequestTracingHandler extends ChannelOutboundHandlerAdapt
     NettyHttpClientDecorator decorate = isSecure ? DECORATE_SECURE : DECORATE;
 
     final AgentSpan span = startSpan(NETTY_CLIENT_REQUEST);
-    span.setMeasured(true);
     try (final AgentScope scope = activateSpan(span)) {
       decorate.afterStart(span);
       decorate.onRequest(span, request);

--- a/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/client/HttpClientRequestTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/client/HttpClientRequestTracingHandler.java
@@ -61,7 +61,6 @@ public class HttpClientRequestTracingHandler extends ChannelOutboundHandlerAdapt
     NettyHttpClientDecorator decorate = isSecure ? DECORATE_SECURE : DECORATE;
 
     final AgentSpan span = startSpan(NETTY_CLIENT_REQUEST);
-    span.setMeasured(true);
     try (final AgentScope scope = activateSpan(span)) {
       decorate.afterStart(span);
       decorate.onRequest(span, request);

--- a/dd-java-agent/instrumentation/okhttp-2/src/main/java/datadog/trace/instrumentation/okhttp2/TracingInterceptor.java
+++ b/dd-java-agent/instrumentation/okhttp-2/src/main/java/datadog/trace/instrumentation/okhttp2/TracingInterceptor.java
@@ -18,7 +18,6 @@ public class TracingInterceptor implements Interceptor {
   @Override
   public Response intercept(final Chain chain) throws IOException {
     final AgentSpan span = startSpan(OKHTTP_REQUEST);
-    span.setMeasured(true);
 
     try (final AgentScope scope = activateSpan(span)) {
       DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/okhttp-3/src/main/java/datadog/trace/instrumentation/okhttp3/TracingInterceptor.java
+++ b/dd-java-agent/instrumentation/okhttp-3/src/main/java/datadog/trace/instrumentation/okhttp3/TracingInterceptor.java
@@ -22,7 +22,6 @@ public class TracingInterceptor implements Interceptor {
     }
 
     final AgentSpan span = startSpan(OKHTTP_REQUEST);
-    span.setMeasured(true);
 
     try (final AgentScope scope = activateSpan(span)) {
       DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/play-ws-1/src/main/java/datadog/trace/instrumentation/playws1/PlayWSClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/play-ws-1/src/main/java/datadog/trace/instrumentation/playws1/PlayWSClientInstrumentation.java
@@ -25,7 +25,6 @@ public class PlayWSClientInstrumentation extends BasePlayWSClientInstrumentation
         @Advice.Argument(value = 1, readOnly = false) AsyncHandler asyncHandler) {
 
       final AgentSpan span = startSpan(PLAY_WS_REQUEST);
-      span.setMeasured(true);
 
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, request);

--- a/dd-java-agent/instrumentation/play-ws-2.1/src/main/java/datadog/trace/instrumentation/playws21/PlayWSClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/play-ws-2.1/src/main/java/datadog/trace/instrumentation/playws21/PlayWSClientInstrumentation.java
@@ -25,7 +25,6 @@ public class PlayWSClientInstrumentation extends BasePlayWSClientInstrumentation
         @Advice.Argument(value = 1, readOnly = false) AsyncHandler asyncHandler) {
 
       final AgentSpan span = startSpan(PLAY_WS_REQUEST);
-      span.setMeasured(true);
 
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, request);

--- a/dd-java-agent/instrumentation/play-ws-2/src/main/java/datadog/trace/instrumentation/playws2/PlayWSClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/play-ws-2/src/main/java/datadog/trace/instrumentation/playws2/PlayWSClientInstrumentation.java
@@ -25,7 +25,6 @@ public class PlayWSClientInstrumentation extends BasePlayWSClientInstrumentation
         @Advice.Argument(value = 1, readOnly = false) AsyncHandler asyncHandler) {
 
       final AgentSpan span = startSpan(PLAY_WS_REQUEST);
-      span.setMeasured(true);
 
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, request);

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitChannelInstrumentation.java
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitChannelInstrumentation.java
@@ -114,7 +114,7 @@ public class RabbitChannelInstrumentation extends Instrumenter.Tracing {
 
       final Connection connection = channel.getConnection();
 
-      final AgentSpan span = startSpan(AMQP_COMMAND).setMeasured(true);
+      final AgentSpan span = startSpan(AMQP_COMMAND);
       span.setResourceName(method);
       DECORATE.setPeerPort(span, connection.getPort());
       DECORATE.afterStart(span);
@@ -243,7 +243,6 @@ public class RabbitChannelInstrumentation extends Instrumenter.Tracing {
       } else {
         span = startSpan(AMQP_COMMAND, TimeUnit.MILLISECONDS.toMicros(startTime));
       }
-      span.setMeasured(true);
       if (response != null) {
         span.setTag("message.size", response.getBody().length);
       }

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/TracedDelegatingConsumer.java
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/TracedDelegatingConsumer.java
@@ -89,9 +89,7 @@ public class TracedDelegatingConsumer implements Consumer {
       // TODO: check dynamically bound queues -
       // https://github.com/DataDog/dd-trace-java/pull/2955#discussion_r677787875
       final AgentSpan span =
-          startSpan(AMQP_COMMAND, context)
-              .setTag(MESSAGE_SIZE, body == null ? 0 : body.length)
-              .setMeasured(true);
+          startSpan(AMQP_COMMAND, context).setTag(MESSAGE_SIZE, body == null ? 0 : body.length);
 
       CONSUMER_DECORATE.afterStart(span);
       CONSUMER_DECORATE.onDeliver(span, queue, envelope);

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/test/groovy/RabbitMQTest.groovy
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/test/groovy/RabbitMQTest.groovy
@@ -495,6 +495,7 @@ class RabbitMQTest extends AgentTestRunner {
       }
 
       errored exception != null
+      measured true
 
       tags {
         "$Tags.COMPONENT" "rabbitmq-amqp"

--- a/dd-java-agent/instrumentation/rmi/src/test/groovy/RmiTest.groovy
+++ b/dd-java-agent/instrumentation/rmi/src/test/groovy/RmiTest.groovy
@@ -43,6 +43,7 @@ class RmiTest extends AgentTestRunner {
           operationName "rmi.invoke"
           childOf span(0)
           spanType DDSpanTypes.RPC
+          measured true
 
           tags {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -56,6 +57,7 @@ class RmiTest extends AgentTestRunner {
           resourceName "Server.hello"
           operationName "rmi.request"
           spanType DDSpanTypes.RPC
+          measured true
 
           tags {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
@@ -67,6 +69,7 @@ class RmiTest extends AgentTestRunner {
           resourceName "Server.someMethod"
           operationName "rmi.request"
           spanType DDSpanTypes.RPC
+          measured true
           tags {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
             "$Tags.COMPONENT" "rmi-server"
@@ -121,6 +124,7 @@ class RmiTest extends AgentTestRunner {
           childOf span(0)
           errored true
           spanType DDSpanTypes.RPC
+          measured true
 
           tags {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -136,6 +140,7 @@ class RmiTest extends AgentTestRunner {
           operationName "rmi.request"
           errored true
           spanType DDSpanTypes.RPC
+          measured true
 
           tags {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
@@ -172,6 +177,7 @@ class RmiTest extends AgentTestRunner {
           operationName "rmi.invoke"
           spanType DDSpanTypes.RPC
           childOf span(0)
+          measured true
           tags {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.COMPONENT" "rmi-client"
@@ -185,6 +191,7 @@ class RmiTest extends AgentTestRunner {
           resourceName "ServerLegacy.hello"
           operationName "rmi.request"
           spanType DDSpanTypes.RPC
+          measured true
           tags {
             "$Tags.COMPONENT" "rmi-server"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER

--- a/dd-java-agent/instrumentation/spring-data-1.8/src/test/groovy/SpringJpaTest.groovy
+++ b/dd-java-agent/instrumentation/spring-data-1.8/src/test/groovy/SpringJpaTest.groovy
@@ -63,6 +63,7 @@ class SpringJpaTest extends AgentTestRunner {
           operationName "repository.operation"
           resourceName "JpaRepository.findAll"
           errored false
+          measured true
           tags {
             "$Tags.COMPONENT" "spring-data"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -73,6 +74,7 @@ class SpringJpaTest extends AgentTestRunner {
           // select
           serviceName "hsqldb"
           spanType "sql"
+          measured true
           childOf(span(0))
           tags {
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
@@ -100,6 +102,7 @@ class SpringJpaTest extends AgentTestRunner {
           operationName "repository.operation"
           resourceName "CrudRepository.save"
           errored false
+          measured true
           tags {
             "$Tags.COMPONENT" "spring-data"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -110,6 +113,7 @@ class SpringJpaTest extends AgentTestRunner {
           // insert
           serviceName "hsqldb"
           spanType "sql"
+          measured true
           childOf(span(0))
           tags {
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
@@ -137,6 +141,7 @@ class SpringJpaTest extends AgentTestRunner {
           operationName "repository.operation"
           resourceName "CrudRepository.save"
           errored false
+          measured true
           tags {
             "$Tags.COMPONENT" "spring-data"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -146,6 +151,7 @@ class SpringJpaTest extends AgentTestRunner {
         span {
           serviceName "hsqldb"
           spanType "sql"
+          measured true
           childOf(span(0))
           tags {
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
@@ -161,6 +167,7 @@ class SpringJpaTest extends AgentTestRunner {
           //update
           serviceName "hsqldb"
           spanType "sql"
+          measured true
           childOf(span(0))
           tags {
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
@@ -186,6 +193,7 @@ class SpringJpaTest extends AgentTestRunner {
           operationName "repository.operation"
           resourceName "JpaCustomerRepository.findByLastName"
           errored false
+          measured true
           tags {
             "$Tags.COMPONENT" "spring-data"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -195,6 +203,7 @@ class SpringJpaTest extends AgentTestRunner {
         span {
           serviceName "hsqldb"
           spanType "sql"
+          measured true
           childOf(span(0))
           tags {
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
@@ -220,6 +229,7 @@ class SpringJpaTest extends AgentTestRunner {
           operationName "repository.operation"
           resourceName "CrudRepository.delete"
           errored false
+          measured true
           tags {
             "$Tags.COMPONENT" "spring-data"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -229,6 +239,7 @@ class SpringJpaTest extends AgentTestRunner {
         span {
           serviceName "hsqldb"
           spanType "sql"
+          measured true
           childOf(span(0))
           tags {
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
@@ -243,6 +254,7 @@ class SpringJpaTest extends AgentTestRunner {
         span {
           serviceName "hsqldb"
           spanType "sql"
+          measured true
           childOf(span(0))
           tags {
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/test/groovy/dd/trace/instrumentation/springwebflux/client/SpringWebfluxHttpClientBase.groovy
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/test/groovy/dd/trace/instrumentation/springwebflux/client/SpringWebfluxHttpClientBase.groovy
@@ -72,6 +72,7 @@ abstract class SpringWebfluxHttpClientBase extends HttpClientTest {
         resourceName "$method $uri.path"
         spanType DDSpanTypes.HTTP_CLIENT
         errored exception != null
+        measured true
         tags {
           "$Tags.COMPONENT" NettyHttpClientDecorator.DECORATE.component()
           "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT

--- a/dd-java-agent/instrumentation/synapse-3/src/main/java/datadog/trace/instrumentation/synapse3/SynapseClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/synapse-3/src/main/java/datadog/trace/instrumentation/synapse3/SynapseClientInstrumentation.java
@@ -83,7 +83,6 @@ public final class SynapseClientInstrumentation extends Instrumenter.Tracing {
         span = startSpan(SYNAPSE_REQUEST);
       }
 
-      span.setMeasured(true);
       DECORATE.afterStart(span);
 
       // add trace id to client-side request before it gets submitted as an HttpRequest

--- a/dd-java-agent/instrumentation/twilio/src/test/groovy/test/TwilioClientTest.groovy
+++ b/dd-java-agent/instrumentation/twilio/src/test/groovy/test/TwilioClientTest.groovy
@@ -146,6 +146,7 @@ class TwilioClientTest extends AgentTestRunner {
           resourceName "api.v2010.account.MessageCreator.create"
           spanType DDSpanTypes.HTTP_CLIENT
           errored false
+          measured true
           tags {
             "$Tags.COMPONENT" "twilio-sdk"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -197,6 +198,7 @@ class TwilioClientTest extends AgentTestRunner {
           resourceName "api.v2010.account.CallCreator.create"
           spanType DDSpanTypes.HTTP_CLIENT
           errored false
+          measured true
           tags {
             "$Tags.COMPONENT" "twilio-sdk"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -270,6 +272,7 @@ class TwilioClientTest extends AgentTestRunner {
           resourceName "api.v2010.account.MessageCreator.create"
           spanType DDSpanTypes.HTTP_CLIENT
           errored false
+          measured true
           tags {
             "$Tags.COMPONENT" "twilio-sdk"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -286,6 +289,7 @@ class TwilioClientTest extends AgentTestRunner {
           resourceName "POST /?/Accounts/abc/Messages.json"
           spanType DDSpanTypes.HTTP_CLIENT
           errored false
+          measured true
           tags {
             "$Tags.COMPONENT" "apache-httpclient"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -374,6 +378,7 @@ class TwilioClientTest extends AgentTestRunner {
           resourceName "api.v2010.account.MessageCreator.create"
           spanType DDSpanTypes.HTTP_CLIENT
           errored false
+          measured true
           tags {
             "$Tags.COMPONENT" "twilio-sdk"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -390,6 +395,7 @@ class TwilioClientTest extends AgentTestRunner {
           resourceName "POST /?/Accounts/abc/Messages.json"
           spanType DDSpanTypes.HTTP_CLIENT
           errored false
+          measured true
           tags {
             "$Tags.COMPONENT" "apache-httpclient"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -406,6 +412,7 @@ class TwilioClientTest extends AgentTestRunner {
           resourceName "POST /?/Accounts/abc/Messages.json"
           spanType DDSpanTypes.HTTP_CLIENT
           errored false
+          measured true
           tags {
             "$Tags.COMPONENT" "apache-httpclient"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -501,6 +508,7 @@ class TwilioClientTest extends AgentTestRunner {
           resourceName "api.v2010.account.MessageCreator.createAsync"
           spanType DDSpanTypes.HTTP_CLIENT
           errored false
+          measured true
           tags {
             "$Tags.COMPONENT" "twilio-sdk"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -517,6 +525,7 @@ class TwilioClientTest extends AgentTestRunner {
           resourceName "api.v2010.account.MessageCreator.create"
           spanType DDSpanTypes.HTTP_CLIENT
           errored false
+          measured true
           tags {
             "$Tags.COMPONENT" "twilio-sdk"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -535,6 +544,7 @@ class TwilioClientTest extends AgentTestRunner {
           resourceName "POST /?/Accounts/abc/Messages.json"
           spanType DDSpanTypes.HTTP_CLIENT
           errored false
+          measured true
           tags {
             "$Tags.COMPONENT" "apache-httpclient"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -551,6 +561,7 @@ class TwilioClientTest extends AgentTestRunner {
           resourceName "POST /?/Accounts/abc/Messages.json"
           spanType DDSpanTypes.HTTP_CLIENT
           errored false
+          measured true
           tags {
             "$Tags.COMPONENT" "apache-httpclient"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -608,6 +619,7 @@ class TwilioClientTest extends AgentTestRunner {
           resourceName "api.v2010.account.MessageCreator.create"
           spanType DDSpanTypes.HTTP_CLIENT
           errored true
+          measured true
           tags {
             "$Tags.COMPONENT" "twilio-sdk"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -644,6 +656,7 @@ class TwilioClientTest extends AgentTestRunner {
           parent()
           spanType DDSpanTypes.HTTP_CLIENT
           errored false
+          measured true
           tags {
             "$Tags.COMPONENT" "twilio-sdk"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -704,6 +717,7 @@ class TwilioClientTest extends AgentTestRunner {
           resourceName "api.v2010.account.MessageCreator.createAsync"
           spanType DDSpanTypes.HTTP_CLIENT
           errored false
+          measured true
           tags {
             "$Tags.COMPONENT" "twilio-sdk"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -720,6 +734,7 @@ class TwilioClientTest extends AgentTestRunner {
           resourceName "api.v2010.account.MessageCreator.create"
           spanType DDSpanTypes.HTTP_CLIENT
           errored false
+          measured true
           tags {
             "$Tags.COMPONENT" "twilio-sdk"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -788,6 +803,7 @@ class TwilioClientTest extends AgentTestRunner {
           resourceName "api.v2010.account.MessageCreator.createAsync"
           spanType DDSpanTypes.HTTP_CLIENT
           errored true
+          measured true
           tags {
             "$Tags.COMPONENT" "twilio-sdk"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -801,6 +817,7 @@ class TwilioClientTest extends AgentTestRunner {
           resourceName "api.v2010.account.MessageCreator.create"
           spanType DDSpanTypes.HTTP_CLIENT
           errored true
+          measured true
           tags {
             "$Tags.COMPONENT" "twilio-sdk"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
@@ -521,6 +521,7 @@ abstract class HttpClientTest extends AgentTestRunner {
       resourceName "$method $uri.path"
       spanType DDSpanTypes.HTTP_CLIENT
       errored exception != null
+      measured true
       tags {
         "$Tags.COMPONENT" component
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT

--- a/dd-smoke-tests/springboot-openliberty/snapshots/datadog.smoketest.SpringBootOpenLibertySnapshotTest.nested.snap
+++ b/dd-smoke-tests/springboot-openliberty/snapshots/datadog.smoketest.SpringBootOpenLibertySnapshotTest.nested.snap
@@ -64,7 +64,8 @@
                    "span.kind" "client"
                    "http.method" "GET"
                    "peer.hostname" "localhost"}
-           "metrics" {"peer.port" 57690
+            "metrics" {"_dd.measured" 1
+                      "peer.port" 57690
                       "thread.id" 58}}
               {"name" "servlet.request"
                "service" "smoke-test-java-app"

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
@@ -495,6 +495,9 @@ public class DDSpanContext implements AgentSpan.Context {
     if (errorFlag) {
       s.append(" *errored*");
     }
+    if (measured) {
+      s.append(" *measured*");
+    }
 
     synchronized (unsafeTags) {
       s.append(" tags=").append(new TreeMap<>(getTags()));


### PR DESCRIPTION
Rather than doing this for each client integration, I moved the logic to the `ClientDecorator`.  I removed the duplicate asserts from the relevant instrumentation. I also added asserts for it to a bunch of tests to ensure I didn't miss something.

While doing this, I also discovered a few server spans (rmi and grpc) that weren't measured that probably should be. I included those changes here too.