### PR TITLE
Unmask most test cases passing the checkpoint validator

### DIFF
--- a/dd-java-agent/instrumentation/akka-http-10.0/src/baseTest/groovy/AkkaHttpClientInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/baseTest/groovy/AkkaHttpClientInstrumentationTest.groovy
@@ -125,7 +125,6 @@ class AkkaHttpJavaClientInstrumentationTest extends AkkaHttpClientInstrumentatio
   def setup() {
     CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
       CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.SUSPEND_RESUME,
       CheckpointValidationMode.THREAD_SEQUENCE)
   }
 }
@@ -148,7 +147,6 @@ class AkkaHttpScalaClientInstrumentationTest extends AkkaHttpClientInstrumentati
   def setup() {
     CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
       CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.SUSPEND_RESUME,
       CheckpointValidationMode.THREAD_SEQUENCE)
   }
 }

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/baseTest/groovy/AkkaHttpServerInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/baseTest/groovy/AkkaHttpServerInstrumentationTest.groovy
@@ -97,14 +97,6 @@ class AkkaHttpServerInstrumentationSyncTest extends AkkaHttpServerInstrumentatio
   HttpServer server() {
     return new AkkaHttpTestWebServer(AkkaHttpTestWebServer.BindAndHandleSync())
   }
-
-  @Override
-  def setup() {
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.SUSPEND_RESUME,
-      CheckpointValidationMode.THREAD_SEQUENCE)
-  }
 }
 
 class AkkaHttpServerInstrumentationAsyncTest extends AkkaHttpServerInstrumentationTest {
@@ -116,9 +108,7 @@ class AkkaHttpServerInstrumentationAsyncTest extends AkkaHttpServerInstrumentati
   @Override
   def setup() {
     CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.SUSPEND_RESUME,
-      CheckpointValidationMode.THREAD_SEQUENCE)
+      CheckpointValidationMode.INTERVALS)
   }
 }
 
@@ -136,9 +126,7 @@ class AkkaHttpServerInstrumentationBindAndHandleTest extends AkkaHttpServerInstr
   @Override
   def setup() {
     CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.SUSPEND_RESUME,
-      CheckpointValidationMode.THREAD_SEQUENCE)
+      CheckpointValidationMode.INTERVALS)
   }
 }
 
@@ -156,9 +144,7 @@ class AkkaHttpServerInstrumentationBindAndHandleAsyncWithRouteAsyncHandlerTest e
   @Override
   def setup() {
     CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.SUSPEND_RESUME,
-      CheckpointValidationMode.THREAD_SEQUENCE)
+      CheckpointValidationMode.INTERVALS)
   }
 }
 
@@ -171,8 +157,6 @@ class AkkaHttpServerInstrumentationAsyncHttp2Test extends AkkaHttpServerInstrume
   @Override
   def setup() {
     CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.SUSPEND_RESUME,
-      CheckpointValidationMode.THREAD_SEQUENCE)
+      CheckpointValidationMode.INTERVALS)
   }
 }

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/latestDepTest/groovy/AkkaHttp102ServerInstrumentationTests.groovy
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/latestDepTest/groovy/AkkaHttp102ServerInstrumentationTests.groovy
@@ -38,12 +38,6 @@ class AkkaHttp102ServerInstrumentationBindSyncTest extends AkkaHttpServerInstrum
   HttpServer server() {
     return new AkkaHttpTestWebServer(AkkaHttp102TestWebServer.ServerBuilderBindSync())
   }
-
-  @Override
-  def setup() {
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.INTERVALS)
-  }
 }
 
 class AkkaHttp102ServerInstrumentationBindAsyncHttp2Test extends AkkaHttpServerInstrumentationTest {

--- a/dd-java-agent/instrumentation/datastax-cassandra-3/src/test/groovy/CassandraClientTest.groovy
+++ b/dd-java-agent/instrumentation/datastax-cassandra-3/src/test/groovy/CassandraClientTest.groovy
@@ -62,7 +62,6 @@ class CassandraClientTest extends AgentTestRunner {
     setup:
     CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
       CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.SUSPEND_RESUME,
       CheckpointValidationMode.THREAD_SEQUENCE)
 
     Session session = cluster.connect(keyspace)
@@ -99,7 +98,6 @@ class CassandraClientTest extends AgentTestRunner {
     setup:
     CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
       CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.SUSPEND_RESUME,
       CheckpointValidationMode.THREAD_SEQUENCE)
 
     def callbackExecuted = new CountDownLatch(1)

--- a/dd-java-agent/instrumentation/java-concurrent/java-completablefuture/src/test/groovy/CompletableFuturePromiseTest.groovy
+++ b/dd-java-agent/instrumentation/java-concurrent/java-completablefuture/src/test/groovy/CompletableFuturePromiseTest.groovy
@@ -1,6 +1,4 @@
 import datadog.trace.agent.test.base.AbstractPromiseTest
-import datadog.trace.agent.test.checkpoints.CheckpointValidator
-import datadog.trace.agent.test.checkpoints.CheckpointValidationMode
 import spock.lang.Shared
 
 import java.util.concurrent.CompletableFuture
@@ -53,11 +51,6 @@ abstract class CompletableFuturePromiseTest extends AbstractPromiseTest<Completa
 
   def "test call with no parent"() {
     setup:
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.SUSPEND_RESUME,
-      CheckpointValidationMode.THREAD_SEQUENCE)
-
     def promise = newPromise()
 
     when:

--- a/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/ForkJoinPoolPropagationTest.groovy
+++ b/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/ForkJoinPoolPropagationTest.groovy
@@ -1,16 +1,10 @@
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.checkpoints.CheckpointValidator
-import datadog.trace.agent.test.checkpoints.CheckpointValidationMode
 import datadog.trace.core.DDSpan
 
 import java.util.concurrent.ForkJoinPool
 
 class ForkJoinPoolPropagationTest extends AgentTestRunner {
   def "test imbalanced recursive task propagation #parallelism FJP threads (async #async)" () {
-    setup:
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.INTERVALS)
-
     when:
     ForkJoinPool fjp = new ForkJoinPool(parallelism,
       ForkJoinPool.defaultForkJoinWorkerThreadFactory, null, async)

--- a/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/NettyExecutorInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/NettyExecutorInstrumentationTest.groovy
@@ -1,6 +1,4 @@
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.checkpoints.CheckpointValidator
-import datadog.trace.agent.test.checkpoints.CheckpointValidationMode
 import datadog.trace.api.Trace
 import datadog.trace.core.DDSpan
 import io.netty.channel.DefaultEventLoopGroup
@@ -201,10 +199,6 @@ class NettyExecutorInstrumentationTest extends AgentTestRunner {
 
   def "#poolImpl '#name' reports after canceled jobs"() {
     setup:
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.SUSPEND_RESUME,
-      CheckpointValidationMode.THREAD_SEQUENCE)
-
     assumeTrue(poolImpl != null) // skip for non-Linux Netty EPoll
     def pool = poolImpl
     def m = method

--- a/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/RejectedExecutionTest.groovy
+++ b/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/RejectedExecutionTest.groovy
@@ -1,6 +1,4 @@
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.checkpoints.CheckpointValidator
-import datadog.trace.agent.test.checkpoints.CheckpointValidationMode
 import datadog.trace.api.DDId
 import datadog.trace.core.DDSpan
 import io.netty.util.concurrent.DefaultEventExecutor
@@ -30,10 +28,6 @@ class RejectedExecutionTest extends AgentTestRunner {
     // provoked (most of the time) by submitting a lot of tasks very
     // quickly
     setup:
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.SUSPEND_RESUME,
-      CheckpointValidationMode.THREAD_SEQUENCE)
-
     ForkJoinPool fjp = new ForkJoinPool()
     fjp.shutdownNow()
 
@@ -52,10 +46,6 @@ class RejectedExecutionTest extends AgentTestRunner {
 
   def "trace reported when thread pool shut down"() {
     setup:
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.SUSPEND_RESUME,
-      CheckpointValidationMode.THREAD_SEQUENCE)
-
     def testClosure = setupShutdownExecutor(new ThreadPoolExecutor.AbortPolicy())
 
     when:
@@ -71,10 +61,6 @@ class RejectedExecutionTest extends AgentTestRunner {
 
   def "trace reported when thread pool shut down with #rejectedExecutionHandler"() {
     setup:
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.SUSPEND_RESUME,
-      CheckpointValidationMode.THREAD_SEQUENCE)
-
     def testClosure = setupShutdownExecutor(rejectedExecutionHandler)
 
     when:
@@ -98,10 +84,6 @@ class RejectedExecutionTest extends AgentTestRunner {
 
   def "trace reported when live thread pool rejects work and throws with #rejectedExecutionHandler"() {
     setup:
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.SUSPEND_RESUME,
-      CheckpointValidationMode.THREAD_SEQUENCE)
-
     def testClosure = setupBackloggedExecutor(rejectedExecutionHandler)
 
     when:
@@ -123,10 +105,6 @@ class RejectedExecutionTest extends AgentTestRunner {
 
   def "trace reported when live thread pool rejects and discards work with #rejectedExecutionHandler"() {
     setup:
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.SUSPEND_RESUME,
-      CheckpointValidationMode.THREAD_SEQUENCE)
-
     def testClosure = setupBackloggedExecutor(rejectedExecutionHandler)
 
     when:
@@ -147,10 +125,6 @@ class RejectedExecutionTest extends AgentTestRunner {
 
   def "trace reported when live thread pool rejects and runs work with #rejectedExecutionHandler"() {
     setup:
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.SUSPEND_RESUME,
-      CheckpointValidationMode.THREAD_SEQUENCE)
-
     def testClosure = setupBackloggedExecutor(rejectedExecutionHandler)
 
     when:
@@ -176,10 +150,6 @@ class RejectedExecutionTest extends AgentTestRunner {
 
   def "trace reported with swallowing netty rejected execution handler" () {
     setup:
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.SUSPEND_RESUME,
-      CheckpointValidationMode.THREAD_SEQUENCE)
-
     DefaultEventExecutor executor = new DefaultEventExecutor(null, new DefaultThreadFactory(DefaultEventExecutor),
       1, handler)
     CountDownLatch latch = new CountDownLatch(1)

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientCustomPropagationConfigTest.groovy
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientCustomPropagationConfigTest.groovy
@@ -1,6 +1,4 @@
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.checkpoints.CheckpointValidationMode
-import datadog.trace.agent.test.checkpoints.CheckpointValidator
 import datadog.trace.api.config.TraceInstrumentationConfig
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan
 import org.apache.kafka.clients.consumer.ConsumerRecord
@@ -60,9 +58,6 @@ class KafkaClientCustomPropagationConfigTest extends AgentTestRunner {
   @Unroll
   def "test kafka client header propagation with topic filters"() {
     setup:
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.INTERVALS)
-
     injectSysConfig(TraceInstrumentationConfig.KAFKA_CLIENT_PROPAGATION_DISABLED_TOPICS, value as String)
 
     def senderProps = KafkaTestUtils.senderProps(embeddedKafka.getBrokersAsString())
@@ -169,9 +164,6 @@ class KafkaClientCustomPropagationConfigTest extends AgentTestRunner {
   @Unroll
   def "test consumer with topic filters"() {
     setup:
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.INTERVALS)
-
     injectSysConfig(TraceInstrumentationConfig.KAFKA_CLIENT_PROPAGATION_DISABLED_TOPICS, value as String)
 
     def senderProps = KafkaTestUtils.senderProps(embeddedKafka.getBrokersAsString())

--- a/dd-java-agent/instrumentation/kotlin-coroutines/src/test/groovy/KotlinCoroutineInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/kotlin-coroutines/src/test/groovy/KotlinCoroutineInstrumentationTest.groovy
@@ -1,7 +1,5 @@
 import datadog.trace.core.DDSpan
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.checkpoints.CheckpointValidator
-import datadog.trace.agent.test.checkpoints.CheckpointValidationMode
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ThreadPoolDispatcherKt
 
@@ -17,11 +15,6 @@ class KotlinCoroutineInstrumentationTest extends AgentTestRunner {
 
   def "kotlin traced across channels"() {
     setup:
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.SUSPEND_RESUME,
-      CheckpointValidationMode.THREAD_SEQUENCE)
-
     KotlinCoroutineTests kotlinTest = new KotlinCoroutineTests(dispatcher)
     int expectedNumberOfSpans = kotlinTest.tracedAcrossChannels()
     TEST_WRITER.waitForTraces(1)
@@ -39,11 +32,6 @@ class KotlinCoroutineInstrumentationTest extends AgentTestRunner {
 
   def "kotlin cancellation prevents trace"() {
     setup:
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.SUSPEND_RESUME,
-      CheckpointValidationMode.THREAD_SEQUENCE)
-
     KotlinCoroutineTests kotlinTest = new KotlinCoroutineTests(dispatcher)
     int expectedNumberOfSpans = kotlinTest.tracePreventedByCancellation()
     TEST_WRITER.waitForTraces(1)
@@ -61,11 +49,6 @@ class KotlinCoroutineInstrumentationTest extends AgentTestRunner {
 
   def "kotlin propagates across nested jobs"() {
     setup:
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.SUSPEND_RESUME,
-      CheckpointValidationMode.THREAD_SEQUENCE)
-
     KotlinCoroutineTests kotlinTest = new KotlinCoroutineTests(dispatcher)
     int expectedNumberOfSpans = kotlinTest.tracedAcrossThreadsWithNested()
     TEST_WRITER.waitForTraces(1)
@@ -82,11 +65,6 @@ class KotlinCoroutineInstrumentationTest extends AgentTestRunner {
 
   def "kotlin either deferred completion"() {
     setup:
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.SUSPEND_RESUME,
-      CheckpointValidationMode.THREAD_SEQUENCE)
-
     KotlinCoroutineTests kotlinTest = new KotlinCoroutineTests(Dispatchers.Default)
     int expectedNumberOfSpans = kotlinTest.traceWithDeferred()
     TEST_WRITER.waitForTraces(1)
@@ -106,11 +84,6 @@ class KotlinCoroutineInstrumentationTest extends AgentTestRunner {
 
   def "kotlin first completed deferred"() {
     setup:
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.SUSPEND_RESUME,
-      CheckpointValidationMode.THREAD_SEQUENCE)
-
     KotlinCoroutineTests kotlinTest = new KotlinCoroutineTests(Dispatchers.Default)
     int expectedNumberOfSpans = kotlinTest.tracedWithDeferredFirstCompletions()
     TEST_WRITER.waitForTraces(1)

--- a/dd-java-agent/instrumentation/lettuce-4/src/test/groovy/Lettuce4AsyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/lettuce-4/src/test/groovy/Lettuce4AsyncClientTest.groovy
@@ -104,7 +104,6 @@ class Lettuce4AsyncClientTest extends AgentTestRunner {
     setup:
     CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
       CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.SUSPEND_RESUME,
       CheckpointValidationMode.THREAD_SEQUENCE)
 
     RedisClient testConnectionClient = RedisClient.create(embeddedDbUri)
@@ -146,7 +145,6 @@ class Lettuce4AsyncClientTest extends AgentTestRunner {
     setup:
     CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
       CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.SUSPEND_RESUME,
       CheckpointValidationMode.THREAD_SEQUENCE)
 
     RedisClient testConnectionClient = RedisClient.create(dbUriNonExistent)
@@ -187,7 +185,6 @@ class Lettuce4AsyncClientTest extends AgentTestRunner {
     setup:
     CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
       CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.SUSPEND_RESUME,
       CheckpointValidationMode.THREAD_SEQUENCE)
 
     RedisFuture<String> redisFuture = asyncCommands.set("TESTSETKEY", "TESTSETVAL")
@@ -219,7 +216,6 @@ class Lettuce4AsyncClientTest extends AgentTestRunner {
     setup:
     CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
       CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.SUSPEND_RESUME,
       CheckpointValidationMode.THREAD_SEQUENCE)
 
     def conds = new AsyncConditions()
@@ -264,7 +260,6 @@ class Lettuce4AsyncClientTest extends AgentTestRunner {
     setup:
     CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
       CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.SUSPEND_RESUME,
       CheckpointValidationMode.THREAD_SEQUENCE)
 
     def conds = new AsyncConditions()
@@ -319,7 +314,6 @@ class Lettuce4AsyncClientTest extends AgentTestRunner {
     setup:
     CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
       CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.SUSPEND_RESUME,
       CheckpointValidationMode.THREAD_SEQUENCE)
 
     def conds = new AsyncConditions()
@@ -362,7 +356,6 @@ class Lettuce4AsyncClientTest extends AgentTestRunner {
     setup:
     CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
       CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.SUSPEND_RESUME,
       CheckpointValidationMode.THREAD_SEQUENCE)
 
     def conds = new AsyncConditions()
@@ -440,7 +433,6 @@ class Lettuce4AsyncClientTest extends AgentTestRunner {
     setup:
     CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
       CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.SUSPEND_RESUME,
       CheckpointValidationMode.THREAD_SEQUENCE)
 
     // turn off auto flush to complete the command exceptionally manually
@@ -491,7 +483,6 @@ class Lettuce4AsyncClientTest extends AgentTestRunner {
     setup:
     CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
       CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.SUSPEND_RESUME,
       CheckpointValidationMode.THREAD_SEQUENCE)
 
     asyncCommands.setAutoFlushCommands(false)
@@ -536,7 +527,6 @@ class Lettuce4AsyncClientTest extends AgentTestRunner {
     setup:
     CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
       CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.SUSPEND_RESUME,
       CheckpointValidationMode.THREAD_SEQUENCE)
 
     asyncCommands.debugSegfault()
@@ -567,7 +557,6 @@ class Lettuce4AsyncClientTest extends AgentTestRunner {
     setup:
     CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
       CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.SUSPEND_RESUME,
       CheckpointValidationMode.THREAD_SEQUENCE)
 
     asyncCommands.shutdown(false)

--- a/dd-java-agent/instrumentation/lettuce-4/src/test/groovy/Lettuce4SyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/lettuce-4/src/test/groovy/Lettuce4SyncClientTest.groovy
@@ -87,7 +87,6 @@ class Lettuce4SyncClientTest extends AgentTestRunner {
     setup:
     CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
       CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.SUSPEND_RESUME,
       CheckpointValidationMode.THREAD_SEQUENCE)
 
     RedisClient testConnectionClient = RedisClient.create(embeddedDbUri)
@@ -127,7 +126,6 @@ class Lettuce4SyncClientTest extends AgentTestRunner {
     setup:
     CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
       CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.SUSPEND_RESUME,
       CheckpointValidationMode.THREAD_SEQUENCE)
 
     RedisClient testConnectionClient = RedisClient.create(dbUriNonExistent)
@@ -166,7 +164,6 @@ class Lettuce4SyncClientTest extends AgentTestRunner {
     setup:
     CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
       CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.SUSPEND_RESUME,
       CheckpointValidationMode.THREAD_SEQUENCE)
 
     String res = syncCommands.set("TESTSETKEY", "TESTSETVAL")
@@ -197,7 +194,6 @@ class Lettuce4SyncClientTest extends AgentTestRunner {
     setup:
     CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
       CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.SUSPEND_RESUME,
       CheckpointValidationMode.THREAD_SEQUENCE)
 
     String res = syncCommands.get("TESTKEY")
@@ -228,7 +224,6 @@ class Lettuce4SyncClientTest extends AgentTestRunner {
     setup:
     CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
       CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.SUSPEND_RESUME,
       CheckpointValidationMode.THREAD_SEQUENCE)
 
     String res = syncCommands.get("NON_EXISTENT_KEY")
@@ -259,7 +254,6 @@ class Lettuce4SyncClientTest extends AgentTestRunner {
     setup:
     CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
       CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.SUSPEND_RESUME,
       CheckpointValidationMode.THREAD_SEQUENCE)
 
     def keyRetrieved = syncCommands.randomkey()
@@ -290,7 +284,6 @@ class Lettuce4SyncClientTest extends AgentTestRunner {
     setup:
     CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
       CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.SUSPEND_RESUME,
       CheckpointValidationMode.THREAD_SEQUENCE)
 
     long res = syncCommands.lpush("TESTLIST", "TESTLIST ELEMENT")
@@ -321,7 +314,6 @@ class Lettuce4SyncClientTest extends AgentTestRunner {
     setup:
     CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
       CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.SUSPEND_RESUME,
       CheckpointValidationMode.THREAD_SEQUENCE)
 
     def res = syncCommands.hmset("user", testHashMap)
@@ -352,7 +344,6 @@ class Lettuce4SyncClientTest extends AgentTestRunner {
     setup:
     CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
       CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.SUSPEND_RESUME,
       CheckpointValidationMode.THREAD_SEQUENCE)
 
     Map<String, String> res = syncCommands.hgetall("TESTHM")
@@ -383,7 +374,6 @@ class Lettuce4SyncClientTest extends AgentTestRunner {
     setup:
     CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
       CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.SUSPEND_RESUME,
       CheckpointValidationMode.THREAD_SEQUENCE)
 
     syncCommands.debugSegfault()
@@ -413,7 +403,6 @@ class Lettuce4SyncClientTest extends AgentTestRunner {
     setup:
     CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
       CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.SUSPEND_RESUME,
       CheckpointValidationMode.THREAD_SEQUENCE)
 
     syncCommands.shutdown(false)

--- a/dd-java-agent/instrumentation/opentelemetry/src/test/groovy/OpenTelemetryTest.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/src/test/groovy/OpenTelemetryTest.groovy
@@ -1,6 +1,4 @@
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.checkpoints.CheckpointValidator
-import datadog.trace.agent.test.checkpoints.CheckpointValidationMode
 import datadog.trace.api.DDId
 import datadog.trace.api.DDTags
 import datadog.trace.api.interceptor.MutableSpan
@@ -198,10 +196,6 @@ class OpenTelemetryTest extends AgentTestRunner {
   }
 
   def "test closing scope when not on top"() {
-    setup:
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.INTERVALS)
-
     when:
     Span firstSpan = tracer.spanBuilder("someOperation").startSpan()
     Scope firstScope = tracer.withSpan(firstSpan)
@@ -231,9 +225,6 @@ class OpenTelemetryTest extends AgentTestRunner {
 
   def "test continuation"() {
     setup:
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.INTERVALS)
-
     def span = tracer.spanBuilder("some name").startSpan()
     TraceScope scope = tracer.withSpan(span)
     scope.setAsyncPropagation(true)
@@ -266,11 +257,6 @@ class OpenTelemetryTest extends AgentTestRunner {
 
   def "test inject extract"() {
     setup:
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.SUSPEND_RESUME,
-      CheckpointValidationMode.THREAD_SEQUENCE)
-
     def span = tracer.spanBuilder("some name").startSpan()
     def context = TracingContextUtils.withSpan(span, Context.current())
     def textMap = [:]
@@ -308,10 +294,6 @@ class OpenTelemetryTest extends AgentTestRunner {
   }
 
   def "tolerate null span activation"() {
-    setup:
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.INTERVALS)
-
     when:
     try {
       tracer.withSpan(null)?.close()

--- a/dd-java-agent/instrumentation/opentracing/api-0.31/src/test/groovy/OpenTracing31Test.groovy
+++ b/dd-java-agent/instrumentation/opentracing/api-0.31/src/test/groovy/OpenTracing31Test.groovy
@@ -1,6 +1,4 @@
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.checkpoints.CheckpointValidator
-import datadog.trace.agent.test.checkpoints.CheckpointValidationMode
 import datadog.trace.api.DDId
 import datadog.trace.api.DDTags
 import datadog.trace.api.interceptor.MutableSpan
@@ -112,9 +110,6 @@ class OpenTracing31Test extends AgentTestRunner {
 
   def "test ignoreParent"() {
     setup:
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.INTERVALS)
-
     def otherSpan = runUnderTrace("parent") {
       tracer.buildSpan("other").ignoreActiveSpan().start()
     }
@@ -126,11 +121,6 @@ class OpenTracing31Test extends AgentTestRunner {
 
   def "test startActive"() {
     setup:
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.SUSPEND_RESUME,
-      CheckpointValidationMode.THREAD_SEQUENCE)
-
     def scope = tracer.buildSpan("some name").startActive(finishSpan)
 
     expect:
@@ -149,11 +139,6 @@ class OpenTracing31Test extends AgentTestRunner {
 
   def "test scopemanager"() {
     setup:
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.SUSPEND_RESUME,
-      CheckpointValidationMode.THREAD_SEQUENCE)
-
     def span = tracer.buildSpan("some name").start()
     def scope = tracer.scopeManager().activate(span, finishSpan)
     (scope as TraceScope).setAsyncPropagation(false)
@@ -194,11 +179,6 @@ class OpenTracing31Test extends AgentTestRunner {
 
   def "test scopemanager with non OTSpan"() {
     setup:
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.SUSPEND_RESUME,
-      CheckpointValidationMode.THREAD_SEQUENCE)
-
     def span = NoopSpan.INSTANCE
     def scope = tracer.scopeManager().activate(span, true)
 
@@ -219,11 +199,6 @@ class OpenTracing31Test extends AgentTestRunner {
 
   def "test continuation"() {
     setup:
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.SUSPEND_RESUME,
-      CheckpointValidationMode.THREAD_SEQUENCE)
-
     def span = tracer.buildSpan("some name").start()
     TraceScope scope = tracer.scopeManager().activate(span, false)
     scope.setAsyncPropagation(true)
@@ -254,10 +229,6 @@ class OpenTracing31Test extends AgentTestRunner {
   }
 
   def "closing scope when not on top"() {
-    setup:
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.INTERVALS)
-
     when:
     Span firstSpan = tracer.buildSpan("someOperation").start()
     Scope firstScope = tracer.scopeManager().activate(firstSpan, false)
@@ -285,11 +256,6 @@ class OpenTracing31Test extends AgentTestRunner {
 
   def "test inject extract"() {
     setup:
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.SUSPEND_RESUME,
-      CheckpointValidationMode.THREAD_SEQUENCE)
-
     def context = tracer.buildSpan("some name").start().context()
     def textMap = [:]
     def adapter = new TextMapAdapter(textMap)
@@ -323,10 +289,6 @@ class OpenTracing31Test extends AgentTestRunner {
   }
 
   def "tolerate null span activation"() {
-    setup:
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.INTERVALS)
-
     when:
     try {
       tracer.scopeManager().activate(null, false)?.close()

--- a/dd-java-agent/instrumentation/opentracing/api-0.32/src/test/groovy/OpenTracing32Test.groovy
+++ b/dd-java-agent/instrumentation/opentracing/api-0.32/src/test/groovy/OpenTracing32Test.groovy
@@ -1,6 +1,4 @@
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.checkpoints.CheckpointValidator
-import datadog.trace.agent.test.checkpoints.CheckpointValidationMode
 import datadog.trace.api.DDId
 import datadog.trace.api.DDTags
 import datadog.trace.api.interceptor.MutableSpan
@@ -112,9 +110,6 @@ class OpenTracing32Test extends AgentTestRunner {
 
   def "test ignoreParent"() {
     setup:
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.INTERVALS)
-
     def otherSpan = runUnderTrace("parent") {
       tracer.buildSpan("other").ignoreActiveSpan().start()
     }
@@ -126,11 +121,6 @@ class OpenTracing32Test extends AgentTestRunner {
 
   def "test startActive"() {
     setup:
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.SUSPEND_RESUME,
-      CheckpointValidationMode.THREAD_SEQUENCE)
-
     def scope = tracer.buildSpan("some name").startActive(finishSpan)
 
     expect:
@@ -154,11 +144,6 @@ class OpenTracing32Test extends AgentTestRunner {
 
   def "test scopemanager"() {
     setup:
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.SUSPEND_RESUME,
-      CheckpointValidationMode.THREAD_SEQUENCE)
-
     def span = tracer.buildSpan("some name").start()
     def scope = tracer.scopeManager().activate(span, finishSpan)
     (scope as TraceScope).setAsyncPropagation(false)
@@ -204,11 +189,6 @@ class OpenTracing32Test extends AgentTestRunner {
 
   def "test scopemanager with non OTSpan"() {
     setup:
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.SUSPEND_RESUME,
-      CheckpointValidationMode.THREAD_SEQUENCE)
-
     def span = NoopSpan.INSTANCE
     def scope = tracer.scopeManager().activate(span, true)
 
@@ -229,11 +209,6 @@ class OpenTracing32Test extends AgentTestRunner {
 
   def "test continuation"() {
     setup:
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.SUSPEND_RESUME,
-      CheckpointValidationMode.THREAD_SEQUENCE)
-
     def span = tracer.buildSpan("some name").start()
     TraceScope scope = tracer.scopeManager().activate(span, false)
     scope.setAsyncPropagation(true)
@@ -264,10 +239,6 @@ class OpenTracing32Test extends AgentTestRunner {
   }
 
   def "closing scope when not on top"() {
-    setup:
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.INTERVALS)
-
     when:
     Span firstSpan = tracer.buildSpan("someOperation").start()
     Scope firstScope = tracer.scopeManager().activate(firstSpan)
@@ -295,11 +266,6 @@ class OpenTracing32Test extends AgentTestRunner {
 
   def "test inject extract"() {
     setup:
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.SUSPEND_RESUME,
-      CheckpointValidationMode.THREAD_SEQUENCE)
-
     def context = tracer.buildSpan("some name").start().context()
     def textMap = [:]
     def adapter = new TextMapAdapter(textMap)
@@ -333,10 +299,6 @@ class OpenTracing32Test extends AgentTestRunner {
   }
 
   def "tolerate null span activation"() {
-    setup:
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.INTERVALS)
-
     when:
     try {
       tracer.scopeManager().activate(null)?.close()

--- a/dd-java-agent/instrumentation/play-2.3/src/test/groovy/server/PlayAsyncServerTest.groovy
+++ b/dd-java-agent/instrumentation/play-2.3/src/test/groovy/server/PlayAsyncServerTest.groovy
@@ -9,9 +9,7 @@ class PlayAsyncServerTest extends PlayServerTest {
   @Override
   def setup() {
     CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.SUSPEND_RESUME,
-      CheckpointValidationMode.THREAD_SEQUENCE)
+      CheckpointValidationMode.INTERVALS)
   }
 
   @Override

--- a/dd-java-agent/instrumentation/play-2.4/src/test/groovy/server/PlayAsyncServerTest.groovy
+++ b/dd-java-agent/instrumentation/play-2.4/src/test/groovy/server/PlayAsyncServerTest.groovy
@@ -24,9 +24,7 @@ class PlayAsyncServerTest extends PlayServerTest {
   @Override
   def setup() {
     CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.SUSPEND_RESUME,
-      CheckpointValidationMode.THREAD_SEQUENCE)
+      CheckpointValidationMode.INTERVALS)
   }
 
   @Override

--- a/dd-java-agent/instrumentation/play-2.6/src/test/groovy/server/PlayAsyncServerTest.groovy
+++ b/dd-java-agent/instrumentation/play-2.6/src/test/groovy/server/PlayAsyncServerTest.groovy
@@ -29,9 +29,7 @@ class PlayAsyncServerTest extends PlayServerTest {
   @Override
   def setup() {
     CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.SUSPEND_RESUME,
-      CheckpointValidationMode.THREAD_SEQUENCE)
+      CheckpointValidationMode.INTERVALS)
   }
 
   def cleanupSpec() {

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/boot24Test/groovy/SpringWebfluxTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/boot24Test/groovy/SpringWebfluxTest.groovy
@@ -552,7 +552,8 @@ class SpringWebfluxTest extends AgentTestRunner {
   def "Multiple GETs to delaying route #testName"() {
     setup:
     CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.INTERVALS)
+      CheckpointValidationMode.INTERVALS,
+      CheckpointValidationMode.THREAD_SEQUENCE)
 
     def requestsCount = 50 // Should be more than 2x CPUs to fish out some bugs
     String url = "http://localhost:$port$urlPath"

--- a/dd-java-agent/instrumentation/vertx-redis-client-3.9/src/test/groovy/VertxRedisAPITestBase.groovy
+++ b/dd-java-agent/instrumentation/vertx-redis-client-3.9/src/test/groovy/VertxRedisAPITestBase.groovy
@@ -145,7 +145,6 @@ class VertxRedisAPIRedisForkedTest extends VertxRedisAPITestBase {
   def setup() {
     CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
       CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.SUSPEND_RESUME,
       CheckpointValidationMode.THREAD_SEQUENCE)
   }
 }
@@ -170,7 +169,6 @@ class VertxRedisAPIRedisConnectionForkedTest extends VertxRedisAPITestBase {
   def setup() {
     CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
       CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.SUSPEND_RESUME,
       CheckpointValidationMode.THREAD_SEQUENCE)
   }
 }

--- a/dd-java-agent/instrumentation/vertx-redis-client-3.9/src/test/groovy/VertxRedisClientForkedTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-redis-client-3.9/src/test/groovy/VertxRedisClientForkedTest.groovy
@@ -1,5 +1,3 @@
-import datadog.trace.agent.test.checkpoints.CheckpointValidator
-import datadog.trace.agent.test.checkpoints.CheckpointValidationMode
 import io.vertx.core.AsyncResult
 import io.vertx.core.Handler
 import io.vertx.redis.RedisClient
@@ -20,11 +18,6 @@ class VertxRedisClientForkedTest extends VertxRedisTestBase {
   }
 
   def "set and get command"() {
-    setup:
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.SUSPEND_RESUME,
-      CheckpointValidationMode.THREAD_SEQUENCE)
-
     when:
     runWithParentAndHandler({ Handler<AsyncResult<Void>> h ->
       redisClient.set("foo", "baz", h)
@@ -42,11 +35,6 @@ class VertxRedisClientForkedTest extends VertxRedisTestBase {
   }
 
   def "set and get command without parent"() {
-    setup:
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.SUSPEND_RESUME,
-      CheckpointValidationMode.THREAD_SEQUENCE)
-
     when:
     runWithHandler({ Handler<AsyncResult<Void>> h ->
       redisClient.set("foo", "baz", h)

--- a/dd-java-agent/instrumentation/vertx-redis-client-3.9/src/test/groovy/VertxRedisForkedTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-redis-client-3.9/src/test/groovy/VertxRedisForkedTest.groovy
@@ -1,5 +1,3 @@
-import datadog.trace.agent.test.checkpoints.CheckpointValidator
-import datadog.trace.agent.test.checkpoints.CheckpointValidationMode
 import io.vertx.core.AsyncResult
 import io.vertx.core.Handler
 import io.vertx.redis.client.Command
@@ -11,11 +9,6 @@ import static datadog.trace.agent.test.utils.TraceUtils.basicSpan
 class VertxRedisForkedTest extends VertxRedisTestBase {
 
   def "set and get command"() {
-    setup:
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.SUSPEND_RESUME,
-      CheckpointValidationMode.THREAD_SEQUENCE)
-
     when:
     def set = runWithParentAndHandler({ Handler<AsyncResult<Response>> h ->
       redis.send(Request.cmd(Command.SET).arg("foo").arg("bar"), h)
@@ -34,11 +27,6 @@ class VertxRedisForkedTest extends VertxRedisTestBase {
   }
 
   def "set and get command without parent"() {
-    setup:
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.SUSPEND_RESUME,
-      CheckpointValidationMode.THREAD_SEQUENCE)
-
     when:
     def set = runWithHandler({ Handler<AsyncResult<Response>> h ->
       redis.send(Request.cmd(Command.SET).arg("foo").arg("bar"), h)
@@ -68,10 +56,6 @@ class VertxRedisForkedTest extends VertxRedisTestBase {
 
   def "work with reused request"() {
     setup:
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.SUSPEND_RESUME,
-      CheckpointValidationMode.THREAD_SEQUENCE)
-
     def request = Request.cmd(Command.SET).arg("foo").arg("bar")
 
     when:

--- a/dd-java-agent/instrumentation/vertx-rx-3.5/src/test/groovy/client/VertxRxCircuitBreakerWebClientForkedTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-rx-3.5/src/test/groovy/client/VertxRxCircuitBreakerWebClientForkedTest.groovy
@@ -1,8 +1,6 @@
 package client
 
 import datadog.trace.agent.test.base.HttpClientTest
-import datadog.trace.agent.test.checkpoints.CheckpointValidator
-import datadog.trace.agent.test.checkpoints.CheckpointValidationMode
 import datadog.trace.instrumentation.netty41.client.NettyHttpClientDecorator
 import io.vertx.circuitbreaker.CircuitBreakerOptions
 import io.vertx.core.VertxOptions
@@ -90,12 +88,5 @@ class VertxRxCircuitBreakerWebClientForkedTest extends HttpClientTest {
   boolean testRemoteConnection() {
     // FIXME: figure out how to configure timeouts.
     false
-  }
-
-  @Override
-  def setup() {
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.SUSPEND_RESUME,
-      CheckpointValidationMode.THREAD_SEQUENCE)
   }
 }

--- a/dd-java-agent/instrumentation/vertx-rx-3.5/src/test/groovy/client/VertxRxWebClientForkedTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-rx-3.5/src/test/groovy/client/VertxRxWebClientForkedTest.groovy
@@ -1,8 +1,6 @@
 package client
 
 import datadog.trace.agent.test.base.HttpClientTest
-import datadog.trace.agent.test.checkpoints.CheckpointValidator
-import datadog.trace.agent.test.checkpoints.CheckpointValidationMode
 import datadog.trace.instrumentation.netty41.client.NettyHttpClientDecorator
 import io.vertx.core.VertxOptions
 import io.vertx.core.http.HttpMethod
@@ -67,12 +65,5 @@ class VertxRxWebClientForkedTest extends HttpClientTest {
   boolean testRemoteConnection() {
     // FIXME: figure out how to configure timeouts.
     false
-  }
-
-  @Override
-  def setup() {
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.SUSPEND_RESUME,
-      CheckpointValidationMode.THREAD_SEQUENCE)
   }
 }

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/test/groovy/client/VertxHttpClientForkedTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/test/groovy/client/VertxHttpClientForkedTest.groovy
@@ -1,8 +1,6 @@
 package client
 
 import datadog.trace.agent.test.base.HttpClientTest
-import datadog.trace.agent.test.checkpoints.CheckpointValidator
-import datadog.trace.agent.test.checkpoints.CheckpointValidationMode
 import datadog.trace.instrumentation.netty41.client.NettyHttpClientDecorator
 import io.vertx.core.Vertx
 import io.vertx.core.VertxOptions
@@ -75,12 +73,5 @@ class VertxHttpClientForkedTest extends HttpClientTest {
   boolean testRemoteConnection() {
     // FIXME: figure out how to configure timeouts.
     false
-  }
-
-  @Override
-  def setup() {
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.SUSPEND_RESUME,
-      CheckpointValidationMode.THREAD_SEQUENCE)
   }
 }

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/checkpoints/CheckpointValidator.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/checkpoints/CheckpointValidator.groovy
@@ -57,7 +57,16 @@ class CheckpointValidator {
 
     if (!invalidEvents.empty) {
       out.println("=== Invalid checkpoint events encountered: ${invalidEvents*.mode.toSet().sort()}")
-      invalidEvents.each { out.println(it) }
+      invalidEvents*.event.spanId.toSet().sort().each { spanId ->
+        orderedEvents.findAll { event -> event.spanId == spanId }.each { event ->
+          def invalidEvent = invalidEvents.find { it.event == event }
+          if (invalidEvent != null) {
+            out.println(invalidEvent)
+          } else {
+            out.println(event)
+          }
+        }
+      }
     }
 
     return invalidEvents.collectEntries {

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/checkpoints/CheckpointValidator.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/checkpoints/CheckpointValidator.groovy
@@ -21,7 +21,7 @@ class CheckpointValidator {
   }
 
   static Set<CheckpointValidationMode> getExcludedValidations() {
-    return excludedValidations.clone()
+    return excludedValidations
   }
 
   static void clear() {

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/checkpoints/TimelineCheckpointer.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/checkpoints/TimelineCheckpointer.groovy
@@ -37,10 +37,8 @@ class TimelineCheckpointer implements Checkpointer {
 
     def validatedEvents = CheckpointValidator.validate(spanEvents, threadEvents, orderedEvents, trackedSpanIds, out)
 
-    TimelinePrinter.print(spanEvents, threadEvents, orderedEvents, validatedEvents*.key.event, out)
-
     // The set of excluded validations
-    def excludedValidations = CheckpointValidator.excludedValidations
+    def excludedValidations = CheckpointValidator.excludedValidations.clone()
 
     // The set of included validations
     def includedValidations = EnumSet.allOf(CheckpointValidationMode)
@@ -63,7 +61,7 @@ class TimelineCheckpointer implements Checkpointer {
       "Included & Failed: ${includedAndFailedValidations.sort()}\n" +
       "Excluded & Passed: ${excludedAndPassedValidations.sort()}\n")
 
-    out.println()
+    TimelinePrinter.print(spanEvents, threadEvents, orderedEvents, validatedEvents*.key.event, out)
 
     out.flush()
 


### PR DESCRIPTION
This wraps up enabling most test cases which are passing the checkpoint validator. Now most test cases which are disabled fail consistently the checkpoint sequence validator without much noise.