### PR TITLE
Suppress extra span from Kafka Streams internal queuing

### DIFF
--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaConsumerInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaConsumerInstrumentation.java
@@ -35,6 +35,7 @@ public final class KafkaConsumerInstrumentation extends Instrumenter.Tracing {
     return new String[] {
       packageName + ".KafkaDecorator",
       packageName + ".TextMapExtractAdapter",
+      packageName + ".TracingIterableDelegator",
       packageName + ".TracingIterable",
       packageName + ".TracingIterator",
       packageName + ".TracingList",

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TracingIterable.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TracingIterable.java
@@ -3,7 +3,7 @@ package datadog.trace.instrumentation.kafka_clients;
 import java.util.Iterator;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 
-public class TracingIterable implements Iterable<ConsumerRecord<?, ?>> {
+public class TracingIterable implements Iterable<ConsumerRecord<?, ?>>, TracingIterableDelegator {
   private final Iterable<ConsumerRecord<?, ?>> delegate;
   private final CharSequence operationName;
   private final KafkaDecorator decorator;
@@ -21,5 +21,10 @@ public class TracingIterable implements Iterable<ConsumerRecord<?, ?>> {
   public Iterator<ConsumerRecord<?, ?>> iterator() {
     // every iteration will add spans. Not only the very first one
     return new TracingIterator(delegate.iterator(), operationName, decorator);
+  }
+
+  @Override
+  public Iterable<ConsumerRecord<?, ?>> getDelegate() {
+    return delegate;
   }
 }

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TracingIterableDelegator.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TracingIterableDelegator.java
@@ -1,0 +1,8 @@
+package datadog.trace.instrumentation.kafka_clients;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+
+public interface TracingIterableDelegator {
+  // Used by the streams instrumentation to unwrap (disable) the iteration advice.
+  Iterable<ConsumerRecord<?, ?>> getDelegate();
+}

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TracingList.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TracingList.java
@@ -6,7 +6,7 @@ import java.util.List;
 import java.util.ListIterator;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 
-public class TracingList implements List<ConsumerRecord<?, ?>> {
+public class TracingList implements List<ConsumerRecord<?, ?>>, TracingIterableDelegator {
 
   private final List<ConsumerRecord<?, ?>> delegate;
   private final CharSequence operationName;
@@ -138,7 +138,7 @@ public class TracingList implements List<ConsumerRecord<?, ?>> {
     return new TracingList(delegate.subList(fromIndex, toIndex), operationName, decorator);
   }
 
-  // Used by the streams instrumentation to unwrap (disable) the iteration advice.
+  @Override
   public List<ConsumerRecord<?, ?>> getDelegate() {
     return delegate;
   }

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TracingList.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TracingList.java
@@ -7,6 +7,7 @@ import java.util.ListIterator;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 
 public class TracingList implements List<ConsumerRecord<?, ?>> {
+
   private final List<ConsumerRecord<?, ?>> delegate;
   private final CharSequence operationName;
   private final KafkaDecorator decorator;
@@ -135,5 +136,10 @@ public class TracingList implements List<ConsumerRecord<?, ?>> {
   @Override
   public List<ConsumerRecord<?, ?>> subList(final int fromIndex, final int toIndex) {
     return new TracingList(delegate.subList(fromIndex, toIndex), operationName, decorator);
+  }
+
+  // Used by the streams instrumentation to unwrap (disable) the iteration advice.
+  public List<ConsumerRecord<?, ?>> getDelegate() {
+    return delegate;
   }
 }

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/kafka-streams-0.11.gradle
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/kafka-streams-0.11.gradle
@@ -17,8 +17,7 @@ testSets {
 dependencies {
   compileOnly group: 'org.apache.kafka', name: 'kafka-streams', version: '0.11.0.0'
 
-  // Include kafka-clients instrumentation for tests.
-  testImplementation project(':dd-java-agent:instrumentation:kafka-clients-0.11')
+  implementation project(':dd-java-agent:instrumentation:kafka-clients-0.11')
 
   testImplementation group: 'org.apache.kafka', name: 'kafka-clients', version: '0.11.0.0'
   testImplementation group: 'org.apache.kafka', name: 'kafka-streams', version: '0.11.0.0'

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/src/latestDepTest/groovy/KafkaStreamsTest.groovy
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/src/latestDepTest/groovy/KafkaStreamsTest.groovy
@@ -58,7 +58,7 @@ class KafkaStreamsTest extends AgentTestRunner {
         void onMessage(ConsumerRecord<String, String> record) {
           // ensure consistent ordering of traces
           // this is the last processing step so we should see 2 traces here
-          TEST_WRITER.waitForTraces(3)
+          TEST_WRITER.waitForTraces(2)
           TEST_TRACER.activeSpan().setTag("testing", 123)
           records.add(record)
         }
@@ -77,7 +77,7 @@ class KafkaStreamsTest extends AgentTestRunner {
       .mapValues(new ValueMapper<String, String>() {
         @Override
         String apply(String textLine) {
-          TEST_WRITER.waitForTraces(2) // ensure consistent ordering of traces
+          TEST_WRITER.waitForTraces(1) // ensure consistent ordering of traces
           TEST_TRACER.activeSpan().setTag("asdf", "testing")
           return textLine.toLowerCase()
         }
@@ -102,7 +102,7 @@ class KafkaStreamsTest extends AgentTestRunner {
     received.value() == greeting.toLowerCase()
     received.key() == null
 
-    assertTraces(4) {
+    assertTraces(3) {
       trace(1) {
         // PRODUCER span 0
         span {
@@ -111,30 +111,12 @@ class KafkaStreamsTest extends AgentTestRunner {
           resourceName "Produce Topic $STREAM_PENDING"
           spanType "queue"
           errored false
+          measured true
           parent()
           tags {
             "$Tags.COMPONENT" "java-kafka"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_PRODUCER
             defaultTags()
-          }
-        }
-      }
-      trace(1) {
-        // CONSUMER span 0
-        span {
-          serviceName "kafka"
-          operationName "kafka.consume"
-          resourceName "Consume Topic $STREAM_PENDING"
-          spanType "queue"
-          errored false
-          childOf trace(0)[0]
-          tags {
-            "$Tags.COMPONENT" "java-kafka"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
-            "$InstrumentationTags.PARTITION" { it >= 0 }
-            "$InstrumentationTags.OFFSET" 0
-            "$InstrumentationTags.RECORD_QUEUE_TIME_MS" { it >= 0 }
-            defaultTags(true)
           }
         }
       }
@@ -148,6 +130,7 @@ class KafkaStreamsTest extends AgentTestRunner {
           resourceName "Consume Topic $STREAM_PENDING"
           spanType "queue"
           errored false
+          measured true
           childOf trace(0)[0]
 
           tags {
@@ -167,6 +150,7 @@ class KafkaStreamsTest extends AgentTestRunner {
           resourceName "Produce Topic $STREAM_PROCESSED"
           spanType "queue"
           errored false
+          measured true
           childOf span(0)
 
           tags {
@@ -184,7 +168,8 @@ class KafkaStreamsTest extends AgentTestRunner {
           resourceName "Consume Topic $STREAM_PROCESSED"
           spanType "queue"
           errored false
-          childOf trace(2)[0]
+          measured true
+          childOf trace(1)[0]
           tags {
             "$Tags.COMPONENT" "java-kafka"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
@@ -200,8 +185,8 @@ class KafkaStreamsTest extends AgentTestRunner {
 
     def headers = received.headers()
     headers.iterator().hasNext()
-    new String(headers.headers("x-datadog-trace-id").iterator().next().value()) == "${TEST_WRITER[2][0].traceId}"
-    new String(headers.headers("x-datadog-parent-id").iterator().next().value()) == "${TEST_WRITER[2][0].spanId}"
+    new String(headers.headers("x-datadog-trace-id").iterator().next().value()) == "${TEST_WRITER[1][0].traceId}"
+    new String(headers.headers("x-datadog-parent-id").iterator().next().value()) == "${TEST_WRITER[1][0].spanId}"
 
 
     cleanup:

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/KafkaStreamTaskInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/KafkaStreamTaskInstrumentation.java
@@ -1,0 +1,61 @@
+package datadog.trace.instrumentation.kafka_streams;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.instrumentation.kafka_clients.TracingList;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+
+@AutoService(Instrumenter.class)
+public class KafkaStreamTaskInstrumentation extends Instrumenter.Tracing {
+
+  public KafkaStreamTaskInstrumentation() {
+    super("kafka", "kafka-streams");
+  }
+
+  @Override
+  public ElementMatcher<TypeDescription> typeMatcher() {
+    return named("org.apache.kafka.streams.processor.internals.StreamTask");
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {
+      "datadog.trace.instrumentation.kafka_clients.KafkaDecorator",
+      "datadog.trace.instrumentation.kafka_clients.TextMapExtractAdapter",
+      "datadog.trace.instrumentation.kafka_clients.TracingIterable",
+      "datadog.trace.instrumentation.kafka_clients.TracingIterator",
+      "datadog.trace.instrumentation.kafka_clients.TracingList",
+      "datadog.trace.instrumentation.kafka_clients.TracingListIterator",
+      "datadog.trace.instrumentation.kafka_clients.Base64Decoder",
+    };
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(
+        isMethod().and(named("addRecords")).and(takesArgument(1, named("java.lang.Iterable"))),
+        KafkaStreamTaskInstrumentation.class.getName() + "$UnwrapIterableAdvice");
+  }
+
+  public static class UnwrapIterableAdvice {
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static void onEnter(
+        @Advice.Argument(value = 1, readOnly = false) Iterable<ConsumerRecord<?, ?>> records) {
+      // This method adds the records to a queue, so we want to bypass the kafka instrumentation
+      // since the resulting spans are very short and uninteresting.
+      // KafkaStreamsProcessorInstrumentation will create a new span instead.
+
+      // Expecting a TracingList because TaskManager.addRecordsToTasks calls records(partition).
+      if (records instanceof TracingList) {
+        records = ((TracingList) records).getDelegate();
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/KafkaStreamTaskInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/KafkaStreamTaskInstrumentation.java
@@ -6,7 +6,7 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
-import datadog.trace.instrumentation.kafka_clients.TracingList;
+import datadog.trace.instrumentation.kafka_clients.TracingIterableDelegator;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
@@ -27,13 +27,7 @@ public class KafkaStreamTaskInstrumentation extends Instrumenter.Tracing {
   @Override
   public String[] helperClassNames() {
     return new String[] {
-      "datadog.trace.instrumentation.kafka_clients.KafkaDecorator",
-      "datadog.trace.instrumentation.kafka_clients.TextMapExtractAdapter",
-      "datadog.trace.instrumentation.kafka_clients.TracingIterable",
-      "datadog.trace.instrumentation.kafka_clients.TracingIterator",
-      "datadog.trace.instrumentation.kafka_clients.TracingList",
-      "datadog.trace.instrumentation.kafka_clients.TracingListIterator",
-      "datadog.trace.instrumentation.kafka_clients.Base64Decoder",
+      "datadog.trace.instrumentation.kafka_clients.TracingIterableDelegator",
     };
   }
 
@@ -53,8 +47,8 @@ public class KafkaStreamTaskInstrumentation extends Instrumenter.Tracing {
       // KafkaStreamsProcessorInstrumentation will create a new span instead.
 
       // Expecting a TracingList because TaskManager.addRecordsToTasks calls records(partition).
-      if (records instanceof TracingList) {
-        records = ((TracingList) records).getDelegate();
+      if (records instanceof TracingIterableDelegator) {
+        records = ((TracingIterableDelegator) records).getDelegate();
       }
     }
   }


### PR DESCRIPTION
Internally `StreamTask` iterates through each `ConsumerRecord` and adds them to the queue.  This iteration triggers an extra span from the kafka instrumentation.  While evaluating implementation of #3001, I realized we could achieve similar behavior by unwrapping the Iterable.  This relies on specific behavior between the kafka and kafka streams instrumentation, but accomplishes the removal of the extra span.