### PR TITLE
Capture JMS session state in consumer state

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jms/MessageConsumerState.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jms/MessageConsumerState.java
@@ -3,6 +3,7 @@ package datadog.trace.bootstrap.instrumentation.jms;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 
+/** Tracks message scopes and spans when consuming messages with {@code receive}. */
 public final class MessageConsumerState {
   private final ThreadLocal<AgentScope> currentScope = new ThreadLocal<>();
 
@@ -29,8 +30,9 @@ public final class MessageConsumerState {
     return destinationName;
   }
 
-  public void capture(AgentScope scope) {
-    this.currentScope.set(scope);
+  /** Closes the given message scope when the next message is consumed or the consumer is closed. */
+  public void closeOnIteration(AgentScope scope) {
+    currentScope.set(scope);
   }
 
   public void closePreviousMessageScope() {

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jms/MessageConsumerState.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jms/MessageConsumerState.java
@@ -4,37 +4,21 @@ import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 
 public final class MessageConsumerState {
-
-  private final Object session;
-  private final int ackMode;
-  private final UTF8BytesString resourceName;
   private final ThreadLocal<AgentScope> currentScope = new ThreadLocal<>();
+
+  private final SessionState sessionState;
+  private final UTF8BytesString resourceName;
   private final String destinationName;
 
   public MessageConsumerState(
-      Object session, int ackMode, UTF8BytesString resourceName, String destinationName) {
-    this.session = session;
-    this.ackMode = ackMode;
+      SessionState sessionState, UTF8BytesString resourceName, String destinationName) {
+    this.sessionState = sessionState;
     this.resourceName = resourceName;
     this.destinationName = destinationName;
   }
 
-  @SuppressWarnings("unchecked")
-  public <T> T getSession() {
-    return (T) session;
-  }
-
-  public boolean isTransactedSession() {
-    return ackMode == 0; /* Session.SESSION_TRANSACTED */
-  }
-
-  public boolean isAutoAcknowledge() {
-    return ackMode == 1 || ackMode == 3; /*Session.AUTO_ACKNOWLEDGE Session.DUPS_OK_ACKNOWLEDGE */
-  }
-
-  public boolean isClientAcknowledge() {
-    /* Session.CLIENT_ACKNOWLEDGE */
-    return ackMode == 2;
+  public SessionState getSessionState() {
+    return sessionState;
   }
 
   public UTF8BytesString getResourceName() {
@@ -56,7 +40,7 @@ public final class MessageConsumerState {
       // be quite a long time before another message arrives
       currentScope.remove();
       scope.close();
-      if (isAutoAcknowledge()) {
+      if (sessionState.isAutoAcknowledge()) {
         scope.span().finish();
       }
     }

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jms/SessionState.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jms/SessionState.java
@@ -13,12 +13,31 @@ public final class SessionState {
 
   public static final int CAPACITY = 8192;
 
+  private final int ackMode;
+
   // hard bound at 8192 pending spans, degrade to finishing spans early
   // if transactions are very large, rather than use lots of space
   private volatile Queue<AgentSpan> queue;
   private static final AtomicIntegerFieldUpdater<SessionState> SEQUENCE =
       AtomicIntegerFieldUpdater.newUpdater(SessionState.class, "sequence");
   private volatile int sequence;
+
+  public SessionState(int ackMode) {
+    this.ackMode = ackMode;
+    // defer creating queue as we only need it for transacted sessions
+  }
+
+  public boolean isTransactedSession() {
+    return ackMode == 0; /* Session.SESSION_TRANSACTED */
+  }
+
+  public boolean isAutoAcknowledge() {
+    return ackMode == 1 || ackMode == 3; /* Session.AUTO_ACKNOWLEDGE, Session.DUPS_OK_ACKNOWLEDGE */
+  }
+
+  public boolean isClientAcknowledge() {
+    return ackMode == 2; /* Session.CLIENT_ACKNOWLEDGE */
+  }
 
   // only used for testing
   boolean isEmpty() {

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/jms/SessionStateTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/jms/SessionStateTest.groovy
@@ -7,42 +7,46 @@ class SessionStateTest extends DDSpecification {
 
   def "commit transaction"() {
     setup:
-    SessionState sessionState = new SessionState()
+    SessionState sessionState = new SessionState(0)
     def span1 = Mock(AgentSpan)
     def span2 = Mock(AgentSpan)
     when:
-    sessionState.add(span1)
-    sessionState.add(span2)
+    sessionState.finishOnCommit(span1)
+    sessionState.finishOnCommit(span2)
     then:
     0 * span1.finish()
     0 * span2.finish()
+    sessionState.capturedSpanCount == 2
     when: "transaction committed"
     sessionState.onCommit()
     then: "spans finished and queues empty"
     1 * span1.finish()
     1 * span2.finish()
-    sessionState.isEmpty()
+    sessionState.capturedSpanCount == 0
   }
 
   def "when buffer overflows, spans are finished eagerly"() {
     setup:
-    SessionState sessionState = new SessionState()
+    SessionState sessionState = new SessionState(0)
     AgentSpan span1 = Mock(AgentSpan)
     AgentSpan span2 = Mock(AgentSpan)
     when: "fill the buffer"
-    for (int i = 0; i < SessionState.CAPACITY; ++i) {
-      sessionState.add(span1)
+    for (int i = 0; i < SessionState.MAX_CAPTURED_SPANS; ++i) {
+      sessionState.finishOnCommit(span1)
     }
     then: "spans are not finished on entry"
     0 * span1.finish()
+    sessionState.capturedSpanCount == SessionState.MAX_CAPTURED_SPANS
     when: "buffer overflows"
-    sessionState.add(span2)
+    sessionState.finishOnCommit(span2)
     then: "span is finished on entry"
     1 * span2.finish()
+    sessionState.capturedSpanCount == SessionState.MAX_CAPTURED_SPANS
     when: "commit and add span"
     sessionState.onCommit()
-    sessionState.add(span2)
+    sessionState.finishOnCommit(span2)
     then: "span is enqueued and not finished"
     0 * span2.finish()
+    sessionState.capturedSpanCount == 1
   }
 }

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSDecorator.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSDecorator.java
@@ -9,7 +9,6 @@ import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.ClientDecorator;
 import java.util.concurrent.TimeUnit;
 import javax.jms.Destination;
-import javax.jms.JMSException;
 import javax.jms.Message;
 import javax.jms.Queue;
 import javax.jms.TemporaryQueue;
@@ -71,7 +70,7 @@ public final class JMSDecorator extends ClientDecorator {
         final long consumeTime = TimeUnit.NANOSECONDS.toMillis(span.getStartTime());
         span.setTag(RECORD_QUEUE_TIME_MS, Math.max(0L, consumeTime - produceTime));
       }
-    } catch (final JMSException ignored) {
+    } catch (Exception ignored) {
     }
   }
 
@@ -86,7 +85,7 @@ public final class JMSDecorator extends ClientDecorator {
     Destination jmsDestination = null;
     try {
       jmsDestination = message.getJMSDestination();
-    } catch (final Exception e) {
+    } catch (Exception ignored) {
     }
     if (jmsDestination == null) {
       jmsDestination = destination;
@@ -108,7 +107,7 @@ public final class JMSDecorator extends ClientDecorator {
           return "Topic " + topicName;
         }
       }
-    } catch (final Exception e) {
+    } catch (Exception ignored) {
     }
     return "Destination";
   }

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageConsumerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageConsumerInstrumentation.java
@@ -91,12 +91,12 @@ public final class JMSMessageConsumerInstrumentation extends Instrumenter.Tracin
 
     @Advice.OnMethodEnter
     public static void beforeReceive(@Advice.This final MessageConsumer consumer) {
-      MessageConsumerState messageConsumerState =
+      MessageConsumerState consumerState =
           InstrumentationContext.get(MessageConsumer.class, MessageConsumerState.class)
               .get(consumer);
-      if (null != messageConsumerState) {
+      if (null != consumerState) {
         // closes the scope, and finishes the span for AUTO_ACKNOWLEDGE
-        messageConsumerState.closePreviousMessageScope();
+        consumerState.closePreviousMessageScope();
       }
     }
 
@@ -109,13 +109,13 @@ public final class JMSMessageConsumerInstrumentation extends Instrumenter.Tracin
         // don't create spans (traces) for each poll if the queue is empty
         return;
       }
-      MessageConsumerState messageConsumerState =
+      MessageConsumerState consumerState =
           InstrumentationContext.get(MessageConsumer.class, MessageConsumerState.class)
               .get(consumer);
-      if (null != messageConsumerState) {
+      if (null != consumerState) {
         final AgentSpan span;
 
-        String destinationName = messageConsumerState.getDestinationName();
+        String destinationName = consumerState.getDestinationName();
 
         if (!Config.get().isJMSPropagationDisabledForDestination(destinationName)) {
           AgentSpan.Context extractedContext = propagate().extract(message, GETTER);
@@ -127,17 +127,17 @@ public final class JMSMessageConsumerInstrumentation extends Instrumenter.Tracin
         // it stays open until the next call to get a
         // message, or the consumer is closed
         AgentScope scope = activateSpan(span);
-        messageConsumerState.capture(scope);
+        consumerState.closeOnIteration(scope);
         CONSUMER_DECORATE.afterStart(span);
-        CONSUMER_DECORATE.onConsume(span, message, messageConsumerState.getResourceName());
+        CONSUMER_DECORATE.onConsume(span, message, consumerState.getResourceName());
         CONSUMER_DECORATE.onError(span, throwable);
-        SessionState sessionState = messageConsumerState.getSessionState();
+        SessionState sessionState = consumerState.getSessionState();
         if (sessionState.isClientAcknowledge()) {
           // span will be finished by a call to Message.acknowledge
           InstrumentationContext.get(Message.class, AgentSpan.class).put(message, span);
         } else if (sessionState.isTransactedSession()) {
-          // span will be finished by Session.commit
-          sessionState.add(span);
+          // span will be finished by Session.commit/rollback/close
+          sessionState.finishOnCommit(span);
         }
         // for AUTO_ACKNOWLEDGE, span is not finished until next call to receive, or close
       }
@@ -147,11 +147,11 @@ public final class JMSMessageConsumerInstrumentation extends Instrumenter.Tracin
   public static class Close {
     @Advice.OnMethodEnter
     public static void beforeClose(@Advice.This final MessageConsumer consumer) {
-      MessageConsumerState messageConsumerState =
+      MessageConsumerState consumerState =
           InstrumentationContext.get(MessageConsumer.class, MessageConsumerState.class)
               .get(consumer);
-      if (null != messageConsumerState) {
-        messageConsumerState.closePreviousMessageScope();
+      if (null != consumerState) {
+        consumerState.closePreviousMessageScope();
       }
     }
   }
@@ -162,15 +162,15 @@ public final class JMSMessageConsumerInstrumentation extends Instrumenter.Tracin
         @Advice.This MessageConsumer messageConsumer,
         @Advice.Argument(value = 0, readOnly = false) MessageListener listener) {
       if (!(listener instanceof DatadogMessageListener)) {
-        MessageConsumerState messageConsumerState =
+        MessageConsumerState consumerState =
             InstrumentationContext.get(MessageConsumer.class, MessageConsumerState.class)
                 .get(messageConsumer);
-        if (null != messageConsumerState) {
+        if (null != consumerState) {
           listener =
               new DatadogMessageListener(
                   InstrumentationContext.get(Message.class, AgentSpan.class),
-                  listener,
-                  messageConsumerState);
+                  consumerState,
+                  listener);
         }
       }
     }

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/MessageInjectAdapter.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/MessageInjectAdapter.java
@@ -2,13 +2,11 @@ package datadog.trace.instrumentation.jms;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import de.thetaphi.forbiddenapis.SuppressForbidden;
-import javax.jms.JMSException;
 import javax.jms.Message;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class MessageInjectAdapter implements AgentPropagation.Setter<Message> {
-
   private static final Logger log = LoggerFactory.getLogger(MessageInjectAdapter.class);
 
   public static final MessageInjectAdapter SETTER = new MessageInjectAdapter();
@@ -19,7 +17,7 @@ public class MessageInjectAdapter implements AgentPropagation.Setter<Message> {
     final String propName = key.replace("-", "__dash__");
     try {
       carrier.setStringProperty(propName, value);
-    } catch (final JMSException e) {
+    } catch (Exception e) {
       if (log.isDebugEnabled()) {
         log.debug("Failure setting jms property: " + propName, e);
       }

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/MessageInstrumentation.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/MessageInstrumentation.java
@@ -3,6 +3,7 @@ package datadog.trace.instrumentation.jms;
 import static datadog.trace.agent.tooling.ClassLoaderMatcher.hasClassesNamed;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers.implementsInterface;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.takesNoArguments;
 
@@ -10,7 +11,6 @@ import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import java.util.Collections;
 import java.util.Map;
 import javax.jms.Message;
 import net.bytebuddy.asm.Advice;
@@ -36,7 +36,7 @@ public class MessageInstrumentation extends Instrumenter.Tracing {
 
   @Override
   public Map<String, String> contextStore() {
-    return Collections.singletonMap("javax.jms.Message", AgentSpan.class.getName());
+    return singletonMap("javax.jms.Message", AgentSpan.class.getName());
   }
 
   @Override

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/SessionInstrumentation.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/SessionInstrumentation.java
@@ -3,7 +3,6 @@ package datadog.trace.instrumentation.jms;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers.hasInterface;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
-import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
@@ -60,7 +59,6 @@ public class SessionInstrumentation extends Instrumenter.Tracing {
     transformation.applyAdvice(
         namedOneOf("commit", "close", "rollback").and(takesNoArguments()),
         getClass().getName() + "$Commit");
-    transformation.applyAdvice(isConstructor(), getClass().getName() + "$Construct");
   }
 
   public static final class CreateConsumer {
@@ -69,16 +67,16 @@ public class SessionInstrumentation extends Instrumenter.Tracing {
         @Advice.This Session session,
         @Advice.Argument(0) Destination destination,
         @Advice.Return MessageConsumer consumer) {
-      int acknowledgeMode;
-      try {
-        acknowledgeMode = session.getAcknowledgeMode();
-      } catch (JMSException e) {
-        acknowledgeMode = Session.AUTO_ACKNOWLEDGE;
-      }
-      ContextStore<MessageConsumer, MessageConsumerState> contextStore =
+      ContextStore<MessageConsumer, MessageConsumerState> consumerStateStore =
           InstrumentationContext.get(MessageConsumer.class, MessageConsumerState.class);
       // avoid doing the same thing more than once when there is delegation to overloads
-      if (contextStore.get(consumer) == null) {
+      if (consumerStateStore.get(consumer) == null) {
+        int ackMode;
+        try {
+          ackMode = session.getAcknowledgeMode();
+        } catch (JMSException e) {
+          ackMode = Session.AUTO_ACKNOWLEDGE;
+        }
         // logic inlined from JMSDecorator to avoid
         // JMSException: A consumer is consuming from the temporary destination
         String resourceName = "Consumed from Destination";
@@ -103,15 +101,21 @@ public class SessionInstrumentation extends Instrumenter.Tracing {
           }
         } catch (JMSException ignore) {
         }
+        ContextStore<Session, SessionState> sessionStateStore =
+            InstrumentationContext.get(Session.class, SessionState.class);
+        SessionState sessionState = sessionStateStore.get(session);
+        if (null == sessionState) {
+          sessionState = sessionStateStore.putIfAbsent(session, new SessionState(ackMode));
+        }
         // all known MessageConsumer implementations reference
         // the Session so there is no risk of creating a memory
         // leak here. MessageConsumerState could drop the reference
         // to the session to save a bit of space if the implementations
         // were instrumented instead of the interfaces.
-        contextStore.put(
+        consumerStateStore.put(
             consumer,
             new MessageConsumerState(
-                session, acknowledgeMode, UTF8BytesString.create(resourceName), destinationName));
+                sessionState, UTF8BytesString.create(resourceName), destinationName));
       }
     }
   }
@@ -119,19 +123,11 @@ public class SessionInstrumentation extends Instrumenter.Tracing {
   public static final class Commit {
     @Advice.OnMethodEnter
     public static void commit(@Advice.This Session session) {
-      SessionState state =
+      SessionState sessionState =
           InstrumentationContext.get(Session.class, SessionState.class).get(session);
-      if (null != state) {
-        state.onCommit();
+      if (null != sessionState) {
+        sessionState.onCommit();
       }
-    }
-  }
-
-  public static final class Construct {
-    @Advice.OnMethodExit
-    public static void createSessionState(@Advice.This Session session) {
-      InstrumentationContext.get(Session.class, SessionState.class)
-          .put(session, new SessionState());
     }
   }
 }


### PR DESCRIPTION
... and create it lazily when the consumer is created instead of when the session is constructed

No change in external behaviour - this refactoring makes it easier to add features like time-in-queue spans.