### PR TITLE
[AppSec] Added smoke test to validate WAF

### DIFF
--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/report/ReportServiceImpl.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/report/ReportServiceImpl.java
@@ -3,6 +3,7 @@ package com.datadog.appsec.report;
 import com.datadog.appsec.report.raw.dtos.intake.IntakeBatch;
 import com.datadog.appsec.report.raw.events.AppSecEvent100;
 import com.datadog.appsec.util.StandardizedLogging;
+import datadog.trace.api.Config;
 import datadog.trace.util.AgentTaskScheduler;
 import java.util.ArrayList;
 import java.util.List;
@@ -88,9 +89,12 @@ public class ReportServiceImpl implements ReportService {
       return;
     }
 
+    int initialDelay = Config.get().getAppSecReportMinTimeout();
+    int period = Config.get().getAppSecReportMaxTimeout();
+
     scheduledTask =
         taskScheduler.scheduleAtFixedRate(
-            PeriodicFlush.INSTANCE, this, 5 /* initial delay */, 30 /* period */, TimeUnit.SECONDS);
+            PeriodicFlush.INSTANCE, this, initialDelay, period, TimeUnit.SECONDS);
   }
 
   @Override

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/report/ReportStrategy.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/report/ReportStrategy.java
@@ -2,6 +2,8 @@ package com.datadog.appsec.report;
 
 import com.datadog.appsec.report.raw.events.AppSecEvent100;
 import com.datadog.appsec.util.JvmTime;
+import datadog.trace.api.Config;
+import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnull;
 
 public interface ReportStrategy {
@@ -10,8 +12,10 @@ public interface ReportStrategy {
   boolean shouldFlush(@Nonnull AppSecEvent100 event);
 
   class Default implements ReportStrategy {
-    private static final long MIN_INTERVAL_NANOS = 5L * 1000L * 1000L * 1000L;
-    private static final long MAX_INTERVAL_NANOS = 60L * 1000L * 1000L * 1000L;
+    private static final long MIN_INTERVAL_NANOS =
+        TimeUnit.SECONDS.toNanos(Config.get().getAppSecReportMinTimeout());
+    private static final long MAX_INTERVAL_NANOS =
+        TimeUnit.SECONDS.toNanos(Config.get().getAppSecReportMaxTimeout());
     private static final int MAX_QUEUED_ITEMS = 50;
 
     private final JvmTime jvmTime;

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/report/ReportServiceImplTests.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/report/ReportServiceImplTests.groovy
@@ -47,7 +47,7 @@ class ReportServiceImplTests extends DDSpecification {
     testee.reportEvent(event)
 
     then:
-    1 * scheduler.scheduleAtFixedRate(_, testee, 5, 30, TimeUnit.SECONDS) >>
+    1 * scheduler.scheduleAtFixedRate(_, testee, 5, 60, TimeUnit.SECONDS) >>
       new AgentTaskScheduler.Scheduled(new Object())
     1 * api.sendIntakeBatch(
       _ as IntakeBatch,
@@ -89,7 +89,7 @@ class ReportServiceImplTests extends DDSpecification {
     testee.reportEvent(event)
 
     then:
-    1 * scheduler.scheduleAtFixedRate(_, { it.is(testee) }, 5, 30, TimeUnit.SECONDS) >>
+    1 * scheduler.scheduleAtFixedRate(_, { it.is(testee) }, 5, 60, TimeUnit.SECONDS) >>
     { task = it[0]; scheduled }
     0 * api._(*_)
 

--- a/dd-smoke-tests/appsec/appsec.gradle
+++ b/dd-smoke-tests/appsec/appsec.gradle
@@ -1,0 +1,7 @@
+apply from: "$rootDir/gradle/java.gradle"
+
+description = 'appsec-smoke-tests'
+
+dependencies {
+  api project(':dd-smoke-tests')
+}

--- a/dd-smoke-tests/appsec/springboot/springboot.gradle
+++ b/dd-smoke-tests/appsec/springboot/springboot.gradle
@@ -1,0 +1,30 @@
+plugins {
+  id "com.github.johnrengelman.shadow"
+}
+
+ext {
+  minJavaVersionForTests = JavaVersion.VERSION_1_8
+}
+
+apply from: "$rootDir/gradle/java.gradle"
+description = 'SpringBoot Smoke Tests.'
+
+// The standard spring-boot plugin doesn't play nice with our project
+// so we'll build a fat jar instead
+jar {
+  manifest {
+    attributes('Main-Class': 'datadog.smoketest.appsec.springboot.SpringbootApplication')
+  }
+}
+
+dependencies {
+  implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: '2.6.0'
+
+  testImplementation project(':dd-smoke-tests:appsec')
+}
+
+tasks.withType(Test).configureEach {
+  dependsOn "shadowJar"
+
+  jvmArgs "-Ddatadog.smoketest.appsec.springboot.shadowJar.path=${tasks.shadowJar.archivePath}"
+}

--- a/dd-smoke-tests/appsec/springboot/src/main/java/datadog/smoketest/appsec/springboot/SpringbootApplication.java
+++ b/dd-smoke-tests/appsec/springboot/src/main/java/datadog/smoketest/appsec/springboot/SpringbootApplication.java
@@ -1,0 +1,14 @@
+package datadog.smoketest.appsec.springboot;
+
+import java.lang.management.ManagementFactory;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class SpringbootApplication {
+
+  public static void main(final String[] args) {
+    SpringApplication.run(SpringbootApplication.class, args);
+    System.out.println("Started in " + ManagementFactory.getRuntimeMXBean().getUptime() + "ms");
+  }
+}

--- a/dd-smoke-tests/appsec/springboot/src/main/java/datadog/smoketest/appsec/springboot/controller/WebController.java
+++ b/dd-smoke-tests/appsec/springboot/src/main/java/datadog/smoketest/appsec/springboot/controller/WebController.java
@@ -1,0 +1,12 @@
+package datadog.smoketest.appsec.springboot.controller;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class WebController {
+  @RequestMapping("/greeting")
+  public String greeting() {
+    return "Sup AppSec Dawg";
+  }
+}

--- a/dd-smoke-tests/appsec/springboot/src/main/resources/application.properties
+++ b/dd-smoke-tests/appsec/springboot/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+logging.level.root=WARN

--- a/dd-smoke-tests/appsec/springboot/src/test/groovy/datadog/smoketest/appsec/SpringBootSmokeTest.groovy
+++ b/dd-smoke-tests/appsec/springboot/src/test/groovy/datadog/smoketest/appsec/SpringBootSmokeTest.groovy
@@ -1,0 +1,54 @@
+package datadog.smoketest.appsec
+
+import okhttp3.Request
+import spock.util.concurrent.PollingConditions
+
+import java.util.concurrent.TimeUnit
+
+class SpringBootSmokeTest extends AbstractAppSecServerSmokeTest {
+
+  // Timeout for individual requests
+  public static final int REQUEST_TIMEOUT = 5
+
+  @Override
+  ProcessBuilder createProcessBuilder() {
+    String springBootShadowJar = System.getProperty("datadog.smoketest.appsec.springboot.shadowJar.path")
+
+    List<String> command = new ArrayList<>()
+    command.add(javaPath())
+    command.addAll(defaultJavaProperties)
+    command.addAll(defaultAppSecProperties)
+    command.addAll((String[]) ["-jar", springBootShadowJar, "--server.port=${httpPort}"])
+
+    ProcessBuilder processBuilder = new ProcessBuilder(command)
+    processBuilder.directory(new File(buildDirectory))
+  }
+
+  def "malicious WAF request #n th time"() {
+    setup:
+    String url = "http://localhost:${httpPort}/greeting"
+    def request = new Request.Builder()
+      .url(url)
+      . addHeader("User-Agent", "Arachni/v1")
+      .build()
+
+    when:
+    def response = client.newCall(request).execute()
+    def conditions = new PollingConditions()
+
+    then:
+    def responseBodyStr = response.body().string()
+    responseBodyStr != null
+    responseBodyStr.contains("Sup AppSec Dawg")
+    response.body().contentType().toString().contains("text/plain")
+    response.code() == 200
+
+    conditions.eventually {
+      // Expect reported WAF attack event
+      appSecEvents.poll(REQUEST_TIMEOUT, TimeUnit.SECONDS)?.get("event_type") == "security_scanner"
+    }
+
+    where:
+    n << (1..200)
+  }
+}

--- a/dd-smoke-tests/appsec/src/main/groovy/datadog/smoketest/appsec/AbstractAppSecServerSmokeTest.groovy
+++ b/dd-smoke-tests/appsec/src/main/groovy/datadog/smoketest/appsec/AbstractAppSecServerSmokeTest.groovy
@@ -1,0 +1,64 @@
+package datadog.smoketest.appsec
+
+import datadog.smoketest.AbstractServerSmokeTest
+import datadog.trace.agent.test.server.http.TestHttpServer
+import groovy.json.JsonSlurper
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+
+import java.util.concurrent.BlockingQueue
+import java.util.concurrent.LinkedBlockingQueue
+
+import static datadog.trace.agent.test.server.http.TestHttpServer.httpServer
+
+abstract class AbstractAppSecServerSmokeTest extends AbstractServerSmokeTest {
+
+  @Shared
+  protected BlockingQueue<Map<String, Object>> appSecEvents = new LinkedBlockingQueue<>()
+
+  @AutoCleanup
+  @Shared
+  protected TestHttpServer appSecServer = httpServer {
+    handlers {
+      prefix("/appsec/proxy/api/v2/appsecevts") {
+        JsonSlurper jsonParser = new JsonSlurper()
+        Map<String, Object> attack = jsonParser.parse(request.body) as Map
+
+        if (attack.containsKey("events")) {
+          appSecEvents.addAll(attack.get("events"))
+        }
+
+        response.status(200).send("hello")
+      }
+    }
+  }
+
+  @Shared
+  protected String[] defaultAppSecProperties = [
+    "-Ddd.appsec.enabled=true",
+    "-Ddd.appsec.report.timeout=0",
+    // immediately commit event
+    "-Ddd.profiling.enabled=false",
+    "-Ddd.trace.agent.port=${appSecServer.address.port}"
+  ]
+
+  def setup() {
+    appSecEvents.clear()
+  }
+
+  def setupSpec() {
+    startServer()
+  }
+
+  def cleanupSpec() {
+    stopServer()
+  }
+
+  def startServer() {
+    appSecServer.start()
+  }
+
+  def stopServer() {
+    // do nothing; 'server' is autocleanup
+  }
+}

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/AppSecConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/AppSecConfig.java
@@ -5,6 +5,7 @@ public final class AppSecConfig {
 
   public static final String APPSEC_ENABLED = "appsec.enabled";
   public static final String APPSEC_RULES_FILE = "appsec.rules";
+  public static final String APPSEC_REPORT_TIMEOUT_SEC = "appsec.report.timeout";
 
   private AppSecConfig() {}
 }

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -74,6 +74,7 @@ import static datadog.trace.api.DDTags.SERVICE_TAG;
 import static datadog.trace.api.IdGenerationStrategy.RANDOM;
 import static datadog.trace.api.Platform.isJavaVersionAtLeast;
 import static datadog.trace.api.config.AppSecConfig.APPSEC_ENABLED;
+import static datadog.trace.api.config.AppSecConfig.APPSEC_REPORT_TIMEOUT_SEC;
 import static datadog.trace.api.config.AppSecConfig.APPSEC_RULES_FILE;
 import static datadog.trace.api.config.CiVisibilityConfig.CIVISIBILITY_ENABLED;
 import static datadog.trace.api.config.CwsConfig.CWS_ENABLED;
@@ -412,6 +413,8 @@ public class Config {
 
   private final boolean appSecEnabled;
   private final String appSecRulesFile;
+  private final int appSecReportMinTimeout;
+  private final int appSecReportMaxTimeout;
 
   private final boolean ciVisibilityEnabled;
 
@@ -857,6 +860,10 @@ public class Config {
 
     appSecEnabled = configProvider.getBoolean(APPSEC_ENABLED, DEFAULT_APPSEC_ENABLED);
     appSecRulesFile = configProvider.getString(APPSEC_RULES_FILE, null);
+
+    // Default AppSec report timeout min=5, max=60
+    appSecReportMaxTimeout = configProvider.getInteger(APPSEC_REPORT_TIMEOUT_SEC, 60);
+    appSecReportMinTimeout = Math.min(appSecReportMaxTimeout, 5);
 
     ciVisibilityEnabled =
         configProvider.getBoolean(CIVISIBILITY_ENABLED, DEFAULT_CIVISIBILITY_ENABLED);
@@ -1358,6 +1365,14 @@ public class Config {
 
   public boolean isAppSecEnabled() {
     return appSecEnabled;
+  }
+
+  public int getAppSecReportMinTimeout() {
+    return appSecReportMinTimeout;
+  }
+
+  public int getAppSecReportMaxTimeout() {
+    return appSecReportMaxTimeout;
   }
 
   public boolean isCiVisibilityEnabled() {

--- a/settings.gradle
+++ b/settings.gradle
@@ -91,6 +91,8 @@ include ':dd-smoke-tests:springboot-openliberty'
 include ':dd-smoke-tests:vertx-3.9'
 include ':dd-smoke-tests:vertx-3.9-resteasy'
 include ':dd-smoke-tests:wildfly'
+include ':dd-smoke-tests:appsec'
+include ':dd-smoke-tests:appsec:springboot'
 
 // instrumentation:
 include ':dd-java-agent:instrumentation:aerospike-4'


### PR DESCRIPTION
AppSec smoke test implemented based on SpringBoot smoke test.
Added AppSec report simulator to track if the malicious request reported correctly.
Thу test is a sequence of 200 malicious requests. Each request will be detected by AppSec and should be sent 200 events to the backend with corresponding information about the attack. To validate AppSec we are checking events reported by AppSec.

Since the event dispatch mechanism has a timeout (minimum and maximum time between dispatches), I added the `appsec.report.timeout` configuration option to force the maximum interval between dispatches. Thus, for tests, we set the value `-Dappsec.report.timeout=0`, which allows perform tests fast as possible (event commitment happens almost instantly).

To use the additional option, I had to modify `Config.java`, but after switching to AppSec Span Interface, I need to get rid of this option.