### PR TITLE
DRY messaging propagation checks

### DIFF
--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageConsumerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageConsumerInstrumentation.java
@@ -21,7 +21,6 @@ import datadog.trace.api.Config;
 import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.bootstrap.instrumentation.api.AgentSpan.Context;
 import datadog.trace.bootstrap.instrumentation.jms.MessageConsumerState;
 import datadog.trace.bootstrap.instrumentation.jms.SessionState;
 import java.util.HashMap;
@@ -120,10 +119,8 @@ public final class JMSMessageConsumerInstrumentation extends Instrumenter.Tracin
 
         String destinationName = messageConsumerState.getDestinationName();
 
-        if (destinationName == null
-            || (!Config.get().getJMSPropagationDisabledTopics().contains(destinationName)
-                && !Config.get().getJMSPropagationDisabledQueues().contains(destinationName))) {
-          final Context extractedContext = propagate().extract(message, GETTER);
+        if (Config.get().isJMSPropagationEnabledForDestination(destinationName)) {
+          AgentSpan.Context extractedContext = propagate().extract(message, GETTER);
           span = startSpan(JMS_CONSUME, extractedContext);
         } else {
           span = startSpan(JMS_CONSUME, null);

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageConsumerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageConsumerInstrumentation.java
@@ -119,7 +119,7 @@ public final class JMSMessageConsumerInstrumentation extends Instrumenter.Tracin
 
         String destinationName = messageConsumerState.getDestinationName();
 
-        if (Config.get().isJMSPropagationEnabledForDestination(destinationName)) {
+        if (!Config.get().isJMSPropagationDisabledForDestination(destinationName)) {
           AgentSpan.Context extractedContext = propagate().extract(message, GETTER);
           span = startSpan(JMS_CONSUME, extractedContext);
         } else {

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageProducerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageProducerInstrumentation.java
@@ -96,12 +96,8 @@ public final class JMSMessageProducerInstrumentation extends Instrumenter.Tracin
       PRODUCER_DECORATE.afterStart(span);
       PRODUCER_DECORATE.onProduce(span, message, defaultDestination);
 
-      if (Config.get().isJMSPropagationEnabled()) {
-        if (destinationName == null
-            || (!Config.get().getJMSPropagationDisabledTopics().contains(destinationName)
-                && !Config.get().getJMSPropagationDisabledQueues().contains(destinationName))) {
-          propagate().inject(span, message, SETTER);
-        }
+      if (Config.get().isJMSPropagationEnabledForDestination(destinationName)) {
+        propagate().inject(span, message, SETTER);
       }
       return activateSpan(span);
     }
@@ -147,10 +143,7 @@ public final class JMSMessageProducerInstrumentation extends Instrumenter.Tracin
       } catch (final JMSException e) {
       }
 
-      if (Config.get().isJMSPropagationEnabled()
-          && (destinationName == null
-              || (!Config.get().getJMSPropagationDisabledTopics().contains(destinationName)
-                  && !Config.get().getJMSPropagationDisabledQueues().contains(destinationName)))) {
+      if (Config.get().isJMSPropagationEnabledForDestination(destinationName)) {
         propagate().inject(span, message, SETTER);
       }
       return activateSpan(span);

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageProducerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageProducerInstrumentation.java
@@ -96,7 +96,8 @@ public final class JMSMessageProducerInstrumentation extends Instrumenter.Tracin
       PRODUCER_DECORATE.afterStart(span);
       PRODUCER_DECORATE.onProduce(span, message, defaultDestination);
 
-      if (Config.get().isJMSPropagationEnabledForDestination(destinationName)) {
+      if (Config.get().isJMSPropagationEnabled()
+          && !Config.get().isJMSPropagationDisabledForDestination(destinationName)) {
         propagate().inject(span, message, SETTER);
       }
       return activateSpan(span);
@@ -143,7 +144,8 @@ public final class JMSMessageProducerInstrumentation extends Instrumenter.Tracin
       } catch (final JMSException e) {
       }
 
-      if (Config.get().isJMSPropagationEnabledForDestination(destinationName)) {
+      if (Config.get().isJMSPropagationEnabled()
+          && !Config.get().isJMSPropagationDisabledForDestination(destinationName)) {
         propagate().inject(span, message, SETTER);
       }
       return activateSpan(span);

--- a/dd-java-agent/instrumentation/jms/src/test/groovy/JMS1Test.groovy
+++ b/dd-java-agent/instrumentation/jms/src/test/groovy/JMS1Test.groovy
@@ -4,7 +4,6 @@ import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.Trace
 import datadog.trace.api.config.TraceInstrumentationConfig
-import datadog.trace.bootstrap.instrumentation.api.AgentSpan
 import datadog.trace.bootstrap.instrumentation.api.InstrumentationTags
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.core.DDSpan
@@ -20,12 +19,6 @@ import javax.jms.Session
 import javax.jms.TextMessage
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.atomic.AtomicReference
-
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan
-import static datadog.trace.instrumentation.jms.JMSDecorator.JMS_PRODUCE
-import static datadog.trace.instrumentation.jms.JMSDecorator.PRODUCER_DECORATE
-import static datadog.trace.instrumentation.jms.MessageInjectAdapter.SETTER
 
 class JMS1Test extends AgentTestRunner {
   @Shared

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerInstrumentation.java
@@ -84,7 +84,8 @@ public final class KafkaProducerInstrumentation extends Instrumenter.Tracing {
       // headers attempt to read messages that were produced by clients > 0.11 and the magic
       // value of the broker(s) is >= 2
       if (apiVersions.maxUsableProduceMagic() >= RecordBatch.MAGIC_VALUE_V2
-          && Config.get().isKafkaClientPropagationEnabledForTopic(record.topic())) {
+          && Config.get().isKafkaClientPropagationEnabled()
+          && !Config.get().isKafkaClientPropagationDisabledForTopic(record.topic())) {
         try {
           propagate().inject(span, record.headers(), SETTER);
         } catch (final IllegalStateException e) {

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerInstrumentation.java
@@ -84,8 +84,7 @@ public final class KafkaProducerInstrumentation extends Instrumenter.Tracing {
       // headers attempt to read messages that were produced by clients > 0.11 and the magic
       // value of the broker(s) is >= 2
       if (apiVersions.maxUsableProduceMagic() >= RecordBatch.MAGIC_VALUE_V2
-          && Config.get().isKafkaClientPropagationEnabled()
-          && !Config.get().getKafkaClientPropagationDisabledTopics().contains(record.topic())) {
+          && Config.get().isKafkaClientPropagationEnabledForTopic(record.topic())) {
         try {
           propagate().inject(span, record.headers(), SETTER);
         } catch (final IllegalStateException e) {

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TracingIterator.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TracingIterator.java
@@ -61,7 +61,7 @@ public class TracingIterator implements Iterator<ConsumerRecord<?, ?>> {
     try {
       final AgentSpan span;
       if (val != null) {
-        if (!Config.get().getKafkaClientPropagationDisabledTopics().contains(val.topic())) {
+        if (Config.get().isKafkaClientPropagationEnabledForTopic(val.topic())) {
           final Context spanContext = propagate().extract(val.headers(), GETTER);
           span = startSpan(operationName, spanContext);
         } else {

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TracingIterator.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TracingIterator.java
@@ -61,7 +61,7 @@ public class TracingIterator implements Iterator<ConsumerRecord<?, ?>> {
     try {
       final AgentSpan span;
       if (val != null) {
-        if (Config.get().isKafkaClientPropagationEnabledForTopic(val.topic())) {
+        if (!Config.get().isKafkaClientPropagationDisabledForTopic(val.topic())) {
           final Context spanContext = propagate().extract(val.headers(), GETTER);
           span = startSpan(operationName, spanContext);
         } else {

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientCustomPropagationConfigTest.groovy
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientCustomPropagationConfigTest.groovy
@@ -1,6 +1,6 @@
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.checkpoints.CheckpointValidator
 import datadog.trace.agent.test.checkpoints.CheckpointValidationMode
+import datadog.trace.agent.test.checkpoints.CheckpointValidator
 import datadog.trace.api.config.TraceInstrumentationConfig
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan
 import org.apache.kafka.clients.consumer.ConsumerRecord
@@ -24,10 +24,8 @@ import java.util.concurrent.TimeUnit
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan
 import static datadog.trace.instrumentation.kafka_clients.KafkaDecorator.KAFKA_PRODUCE
-import static datadog.trace.instrumentation.kafka_clients.TextMapInjectAdapter.SETTER
 
 class KafkaClientCustomPropagationConfigTest extends AgentTestRunner {
   static final SHARED_TOPIC = ["topic1", "topic2", "topic3", "topic4"]

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitChannelInstrumentation.java
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitChannelInstrumentation.java
@@ -163,7 +163,8 @@ public class RabbitChannelInstrumentation extends Instrumenter.Tracing {
         Map<String, Object> headers = props.getHeaders();
         headers = (headers == null) ? new HashMap<String, Object>() : new HashMap<>(headers);
 
-        if (Config.get().isRabbitPropagationEnabledForDestination(exchange)) {
+        if (Config.get().isRabbitPropagationEnabled()
+            && !Config.get().isRabbitPropagationDisabledForDestination(exchange)) {
           propagate().inject(span, headers, SETTER);
         }
 

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitChannelInstrumentation.java
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitChannelInstrumentation.java
@@ -163,8 +163,7 @@ public class RabbitChannelInstrumentation extends Instrumenter.Tracing {
         Map<String, Object> headers = props.getHeaders();
         headers = (headers == null) ? new HashMap<String, Object>() : new HashMap<>(headers);
 
-        if (Config.get().isRabbitPropagationEnabled()
-            && !Config.get().getRabbitPropagationDisabledExchanges().contains(exchange)) {
+        if (Config.get().isRabbitPropagationEnabledForDestination(exchange)) {
           propagate().inject(span, headers, SETTER);
         }
 

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/TracedDelegatingConsumer.java
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/TracedDelegatingConsumer.java
@@ -41,7 +41,7 @@ public class TracedDelegatingConsumer implements Consumer {
   public TracedDelegatingConsumer(
       final String queue, final Consumer delegate, boolean traceStartTimeEnabled) {
     this.queue = queue;
-    this.propagate = !Config.get().getRabbitPropagationDisabledQueues().contains(queue);
+    this.propagate = Config.get().isRabbitPropagationEnabledForDestination(queue);
     this.delegate = delegate;
     this.traceStartTimeEnabled = traceStartTimeEnabled;
   }

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/TracedDelegatingConsumer.java
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/TracedDelegatingConsumer.java
@@ -41,7 +41,7 @@ public class TracedDelegatingConsumer implements Consumer {
   public TracedDelegatingConsumer(
       final String queue, final Consumer delegate, boolean traceStartTimeEnabled) {
     this.queue = queue;
-    this.propagate = Config.get().isRabbitPropagationEnabledForDestination(queue);
+    this.propagate = !Config.get().isRabbitPropagationDisabledForDestination(queue);
     this.delegate = delegate;
     this.traceStartTimeEnabled = traceStartTimeEnabled;
   }

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/test/groovy/RabbitMQTest.groovy
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/test/groovy/RabbitMQTest.groovy
@@ -459,7 +459,7 @@ class RabbitMQTest extends AgentTestRunner {
     where:
     exchangeName    | routingKey         | queueName       | config          | nullParent
     "some-exchange" | "some-routing-key" | "queueNameTest" | "queueNameTest" | true
-    "some-exchange" | "some-routing-key" | "queueNameTest" | "some-exchange" | false
+    "some-exchange" | "some-routing-key" | "queueNameTest" | "some-exchange" | true  // we merge disabled queue/exchange names
     "some-exchange" | "some-routing-key" | "queueNameTest" | ""              | false
   }
 

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -1254,16 +1254,11 @@ public class Config {
     return kafkaClientPropagationDisabledTopics;
   }
 
-  public boolean isJMSPropagationEnabled() {
-    return jmsPropagationEnabled;
-  }
-
-  public Set<String> getJMSPropagationDisabledTopics() {
-    return jmsPropagationDisabledTopics;
-  }
-
-  public Set<String> getJMSPropagationDisabledQueues() {
-    return jmsPropagationDisabledQueues;
+  public boolean isJMSPropagationEnabledForDestination(final String queueOrTopic) {
+    return jmsPropagationEnabled
+        && (null == queueOrTopic
+            || (!jmsPropagationDisabledQueues.contains(queueOrTopic)
+                && !jmsPropagationDisabledTopics.contains(queueOrTopic)));
   }
 
   public boolean isKafkaClientBase64DecodingEnabled() {

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -391,9 +391,9 @@ public class Config {
   private final Set<String> jmsPropagationDisabledTopics;
   private final Set<String> jmsPropagationDisabledQueues;
 
-  private final boolean RabbitPropagationEnabled;
-  private final Set<String> RabbitPropagationDisabledQueues;
-  private final Set<String> RabbitPropagationDisabledExchanges;
+  private final boolean rabbitPropagationEnabled;
+  private final Set<String> rabbitPropagationDisabledQueues;
+  private final Set<String> rabbitPropagationDisabledExchanges;
 
   private final boolean hystrixTagsEnabled;
   private final boolean hystrixMeasuredEnabled;
@@ -819,13 +819,13 @@ public class Config {
     jmsPropagationDisabledQueues =
         tryMakeImmutableSet(configProvider.getList(JMS_PROPAGATION_DISABLED_QUEUES));
 
-    RabbitPropagationEnabled =
+    rabbitPropagationEnabled =
         configProvider.getBoolean(RABBIT_PROPAGATION_ENABLED, DEFAULT_RABBIT_PROPAGATION_ENABLED);
 
-    RabbitPropagationDisabledQueues =
+    rabbitPropagationDisabledQueues =
         tryMakeImmutableSet(configProvider.getList(RABBIT_PROPAGATION_DISABLED_QUEUES));
 
-    RabbitPropagationDisabledExchanges =
+    rabbitPropagationDisabledExchanges =
         tryMakeImmutableSet(configProvider.getList(RABBIT_PROPAGATION_DISABLED_EXCHANGES));
 
     grpcIgnoredOutboundMethods =
@@ -1262,16 +1262,11 @@ public class Config {
     return kafkaClientBase64DecodingEnabled;
   }
 
-  public boolean isRabbitPropagationEnabled() {
-    return RabbitPropagationEnabled;
-  }
-
-  public Set<String> getRabbitPropagationDisabledQueues() {
-    return RabbitPropagationDisabledQueues;
-  }
-
-  public Set<String> getRabbitPropagationDisabledExchanges() {
-    return RabbitPropagationDisabledExchanges;
+  public boolean isRabbitPropagationEnabledForDestination(final String queueOrExchange) {
+    return rabbitPropagationEnabled
+        && (null == queueOrExchange
+            || (!rabbitPropagationDisabledQueues.contains(queueOrExchange)
+                && !rabbitPropagationDisabledExchanges.contains(queueOrExchange)));
   }
 
   public boolean isHystrixTagsEnabled() {
@@ -2014,11 +2009,11 @@ public class Config {
         + ", jmsPropagationDisabledQueues="
         + jmsPropagationDisabledQueues
         + ", RabbitPropagationEnabled="
-        + RabbitPropagationEnabled
+        + rabbitPropagationEnabled
         + ", RabbitPropagationDisabledQueues="
-        + RabbitPropagationDisabledQueues
+        + rabbitPropagationDisabledQueues
         + ", RabbitPropagationDisabledExchanges="
-        + RabbitPropagationDisabledExchanges
+        + rabbitPropagationDisabledExchanges
         + ", hystrixTagsEnabled="
         + hystrixTagsEnabled
         + ", hystrixMeasuredEnabled="

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -1246,12 +1246,9 @@ public class Config {
     return appSecEnabled;
   }
 
-  public boolean isKafkaClientPropagationEnabled() {
-    return kafkaClientPropagationEnabled;
-  }
-
-  public Set<String> getKafkaClientPropagationDisabledTopics() {
-    return kafkaClientPropagationDisabledTopics;
+  public boolean isKafkaClientPropagationEnabledForTopic(String topic) {
+    return kafkaClientPropagationEnabled
+        && (null == topic || !kafkaClientPropagationDisabledTopics.contains(topic));
   }
 
   public boolean isJMSPropagationEnabledForDestination(final String queueOrTopic) {

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -1246,27 +1246,36 @@ public class Config {
     return appSecEnabled;
   }
 
-  public boolean isKafkaClientPropagationEnabledForTopic(String topic) {
-    return kafkaClientPropagationEnabled
-        && (null == topic || !kafkaClientPropagationDisabledTopics.contains(topic));
+  public boolean isKafkaClientPropagationEnabled() {
+    return kafkaClientPropagationEnabled;
   }
 
-  public boolean isJMSPropagationEnabledForDestination(final String queueOrTopic) {
-    return jmsPropagationEnabled
-        && (null == queueOrTopic
-            || (!jmsPropagationDisabledQueues.contains(queueOrTopic)
-                && !jmsPropagationDisabledTopics.contains(queueOrTopic)));
+  public boolean isKafkaClientPropagationDisabledForTopic(String topic) {
+    return null != topic && kafkaClientPropagationDisabledTopics.contains(topic);
+  }
+
+  public boolean isJMSPropagationEnabled() {
+    return jmsPropagationEnabled;
+  }
+
+  public boolean isJMSPropagationDisabledForDestination(final String queueOrTopic) {
+    return null != queueOrTopic
+        && (jmsPropagationDisabledQueues.contains(queueOrTopic)
+            || jmsPropagationDisabledTopics.contains(queueOrTopic));
   }
 
   public boolean isKafkaClientBase64DecodingEnabled() {
     return kafkaClientBase64DecodingEnabled;
   }
 
-  public boolean isRabbitPropagationEnabledForDestination(final String queueOrExchange) {
-    return rabbitPropagationEnabled
-        && (null == queueOrExchange
-            || (!rabbitPropagationDisabledQueues.contains(queueOrExchange)
-                && !rabbitPropagationDisabledExchanges.contains(queueOrExchange)));
+  public boolean isRabbitPropagationEnabled() {
+    return rabbitPropagationEnabled;
+  }
+
+  public boolean isRabbitPropagationDisabledForDestination(final String queueOrExchange) {
+    return null != queueOrExchange
+        && (rabbitPropagationDisabledQueues.contains(queueOrExchange)
+            || rabbitPropagationDisabledExchanges.contains(queueOrExchange));
   }
 
   public boolean isHystrixTagsEnabled() {


### PR DESCRIPTION
Move destination checks into `Config` rather than repeat the same pattern many times.