### PR TITLE
Globally exclude `com.contrastsecurity` types from instrumentation

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/GlobalIgnoresMatcher.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/GlobalIgnoresMatcher.java
@@ -69,7 +69,8 @@ public class GlobalIgnoresMatcher<T extends TypeDescription>
               || name.startsWith("com.appdynamics.")
               || name.startsWith("com.singularity.")
               || name.startsWith("com.jinspired.")
-              || name.startsWith("com.intellij.rt.debugger.")) {
+              || name.startsWith("com.intellij.rt.debugger.")
+              || name.startsWith("com.contrastsecurity.")) {
             return true;
           }
           if (name.startsWith("com.sun.")) {


### PR DESCRIPTION
This avoids recursive interactions between the two agents which eventually complete, but take up a lot of startup time.