### PR TITLE
Kafka Streams: remove span/scope from task

### DIFF
--- a/dd-java-agent/instrumentation/kafka-streams-0.11/src/latestDepTest/groovy/KafkaStreamsTest.groovy
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/src/latestDepTest/groovy/KafkaStreamsTest.groovy
@@ -120,6 +120,7 @@ class KafkaStreamsTest extends AgentTestRunner {
           }
         }
       }
+      def producerSpan = null
       trace(2) {
         sortSpansByStart()
 
@@ -146,6 +147,7 @@ class KafkaStreamsTest extends AgentTestRunner {
 
         // STREAMING span 1
         span {
+          producerSpan = it.span
           serviceName "kafka"
           operationName "kafka.produce"
           resourceName "Produce Topic $STREAM_PROCESSED"
@@ -170,7 +172,7 @@ class KafkaStreamsTest extends AgentTestRunner {
           spanType "queue"
           errored false
           measured true
-          childOf trace(1)[0]
+          childOf producerSpan
           tags {
             "$Tags.COMPONENT" "java-kafka"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/KafkaStreamTaskInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/KafkaStreamTaskInstrumentation.java
@@ -166,7 +166,8 @@ public class KafkaStreamTaskInstrumentation extends Instrumenter.Tracing {
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
     public static void stop(
         @Advice.Thrown final Throwable throwable, @Advice.This StreamTask task) {
-      AgentScope scope = InstrumentationContext.get(StreamTask.class, AgentScope.class).get(task);
+      AgentScope scope =
+          InstrumentationContext.get(StreamTask.class, AgentScope.class).remove(task);
       if (scope != null) {
         AgentSpan span = scope.span();
         CONSUMER_DECORATE.onError(span, throwable);

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/src/test/groovy/KafkaStreamsTest.groovy
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/src/test/groovy/KafkaStreamsTest.groovy
@@ -115,6 +115,7 @@ class KafkaStreamsTest extends AgentTestRunner {
           }
         }
       }
+      def producerSpan = null
       trace(2) {
         sortSpansByStart()
 
@@ -141,6 +142,7 @@ class KafkaStreamsTest extends AgentTestRunner {
 
         // STREAMING span 1
         span {
+          producerSpan = it.span
           serviceName "kafka"
           operationName "kafka.produce"
           resourceName "Produce Topic $STREAM_PROCESSED"
@@ -165,7 +167,7 @@ class KafkaStreamsTest extends AgentTestRunner {
           spanType "queue"
           errored false
           measured true
-          childOf trace(1)[0]
+          childOf producerSpan
           tags {
             "$Tags.COMPONENT" "java-kafka"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER


### PR DESCRIPTION
When finishing the span, remove it to allow it to be GC'd and not linger.  Don't think it's causing any problems... just more sanitary.

Also fix a flake in the test.