### PR TITLE
Add gitlab trigger for system tests project

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,9 +6,12 @@ stages:
 variables:
   REGISTRY: 486234852809.dkr.ecr.us-east-1.amazonaws.com
   SONATYPE_USERNAME: robot-sonatype-apm-java
-  DOWNSTREAM_BRANCH:
+  DOWNSTREAM_REL_BRANCH:
     value: "master"
     description: "Run a specific datadog-reliability-env branch downstream"
+  DOWNSTREAM_SYS_TEST_BRANCH:
+    value: "master"
+    description: "Run a specific system test branch downstream"
   FORCE_TRIGGER:
     value: "false"
     description: "Set to true to override rules in the reliability-env pipeline (e.g. override 'only deploy master')"
@@ -63,7 +66,7 @@ deploy_to_reliability_env:
     - when: on_success
   trigger:
     project: DataDog/datadog-reliability-env
-    branch: $DOWNSTREAM_BRANCH
+    branch: $DOWNSTREAM_REL_BRANCH
   variables:
     UPSTREAM_PACKAGE_JOB: build
     UPSTREAM_PROJECT_ID: $CI_PROJECT_ID
@@ -72,6 +75,23 @@ deploy_to_reliability_env:
     UPSTREAM_BRANCH: $CI_COMMIT_REF_NAME
     UPSTREAM_COMMIT_SHA: $CI_COMMIT_SHA
     FORCE_TRIGGER: $FORCE_TRIGGER
+
+deploy_to_system_test:
+  stage: deploy
+  rules:
+    - if: '$POPULATE_CACHE'
+      when: never
+    - when: on_success
+  trigger:
+    project: DataDog/system-tests
+    branch: $DOWNSTREAM_SYS_TEST_BRANCH
+  variables:
+    UPSTREAM_PACKAGE_JOB: build
+    UPSTREAM_PROJECT_ID: $CI_PROJECT_ID
+    UPSTREAM_PROJECT_NAME: $CI_PROJECT_NAME
+    UPSTREAM_PIPELINE_ID: $CI_PIPELINE_ID
+    UPSTREAM_BRANCH: $CI_COMMIT_REF_NAME
+    UPSTREAM_COMMIT_SHA: $CI_COMMIT_SHA
 
 deploy_to_sonatype:
   <<: *gradle_build


### PR DESCRIPTION
This PR adds a gitlab trigger for the [system tests project](https://github.com/DataDog/system-tests). The system tests project aims to verify the behaviors of all of the tracers externally.