### PR TITLE
Simplify management of active message scopes by tracking them per-session-thread

### DIFF
--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageConsumerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageConsumerInstrumentation.java
@@ -145,7 +145,7 @@ public final class JMSMessageConsumerInstrumentation extends Instrumenter.Tracin
           InstrumentationContext.get(MessageConsumer.class, MessageConsumerState.class)
               .get(consumer);
       if (null != consumerState) {
-        consumerState.onClose();
+        consumerState.closePreviousMessageScope();
       }
     }
   }


### PR DESCRIPTION
Follow on to #3026

This assumes that if a thread receives a message from the same session, any previous message scope associated with that thread is closed whether the message is received via the same consumer or not.

All active message scopes are still closed when the session is closed.