### PR TITLE
Finish any pending message spans if client-ack/transacted session is closed early

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jms/SessionState.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jms/SessionState.java
@@ -141,8 +141,8 @@ public final class SessionState {
       maybeCloseScope(scope);
     }
     activeScopes.clear();
-    if (isTransactedSession()) {
-      onCommitOrRollback(); // implicit rollback of any active transaction
+    if (!isAutoAcknowledge()) {
+      finishCapturedSpans();
     }
   }
 


### PR DESCRIPTION
Only time we don't need to do this is when the session is using auto-acknowledgement