### PR TITLE
Avoid overwriting test results with same test name

### DIFF
--- a/.circleci/collect_results.sh
+++ b/.circleci/collect_results.sh
@@ -11,5 +11,7 @@ TEST_RESULTS_DIR=./results
 mkdir -p $TEST_RESULTS_DIR >/dev/null 2>&1
 
 echo "saving test results"
-mkdir -p $TEST_RESULTS_DIR/results
-find workspace/**/build/test-results -name \*.xml -exec cp {} $TEST_RESULTS_DIR \;
+mkdir -p $TEST_RESULTS_DIR
+find workspace/**/build/test-results -name \*.xml -exec sh -c '
+  file=$(echo "$0" | rev | cut -d "/" -f 1,2,5 | rev | tr "/" "_")
+  cp "$0" "$1/$file"' {} $TEST_RESULTS_DIR \;


### PR DESCRIPTION
After having a test that failed 5 times in a row not show up in the CI app, I realized that the script will clobber tests with identical names, which is very common using the test sets.

CircleCI doesn't need a flat directory structure, but it looks better in the UI if it is flat.

This could also be the reason that sometimes we can't see the pretty test result in CircleCI, since the failing XML was clobbered by an XML that succeeded.