### PR TITLE
Call onStart after the PendingTrace registration is finished

### DIFF
--- a/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/JFRCheckpointer.java
+++ b/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/JFRCheckpointer.java
@@ -101,9 +101,6 @@ public class JFRCheckpointer implements Checkpointer {
 
   void emitCheckpoint(final AgentSpan span, final int flags) {
     AgentSpan rootSpan = span.getLocalRootSpan();
-    if (rootSpan == null) {
-      rootSpan = span;
-    }
     new CheckpointEvent(rootSpan.getSpanId().toLong(), span.getSpanId().toLong(), flags & MASK)
         .commit();
     emitted.increment();

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -181,17 +181,12 @@ public class DDSpan implements AgentSpan, CoreSpan<DDSpan> {
     This is to ensure consistency in the emitted checkpoints where the whole
     local root span subtree must either be fully covered or no checkpoints should
     be emitted at all.
-     */
-    AgentSpan rootSpan = getLocalRootSpan();
-    if (rootSpan == null) {
-      rootSpan = this;
-    }
-    // rootSpan will always be an instance of DDSpan
-    DDSpan span = (DDSpan) rootSpan;
-    if (span.emittingCheckpoints == null) {
-      span.emittingCheckpoints = value;
+    */
+    DDSpan rootSpan = getLocalRootSpan();
+    if (rootSpan.emittingCheckpoints == null) {
+      rootSpan.emittingCheckpoints = value;
       if (value) {
-        span.setTag(CHECKPOINTED_TAG, value);
+        rootSpan.setTag(CHECKPOINTED_TAG, value);
       }
     }
   }
@@ -203,11 +198,8 @@ public class DDSpan implements AgentSpan, CoreSpan<DDSpan> {
     This is to ensure consistency in the emitted checkpoints where the whole
     local root span subtree must either be fully covered or no checkpoints should
     be emitted at all.
-     */
-    DDSpan rootSpan = getLocalRootSpan();
-    return (rootSpan != null && this != rootSpan)
-        ? rootSpan.emittingCheckpoints
-        : emittingCheckpoints;
+    */
+    return getLocalRootSpan().emittingCheckpoints;
   }
 
   /**

--- a/dd-trace-core/src/main/java/datadog/trace/core/PendingTrace.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/PendingTrace.java
@@ -140,9 +140,9 @@ public class PendingTrace implements AgentTrace, PendingTraceBuffer.Element {
   }
 
   void registerSpan(final DDSpan span) {
-    tracer.onStart(span);
     ROOT_SPAN.compareAndSet(this, null, span);
     PENDING_REFERENCE_COUNT.incrementAndGet(this);
+    tracer.onStart(span);
   }
 
   void onFinish(final DDSpan span) {


### PR DESCRIPTION
Since `onStart` was called before the span was registered in the pending trace, the first span, aka root span, would return `null` when asked for its root span.