### PR TITLE
Remove obsolete checkpoint validate exclusions for jetty client

### DIFF
--- a/dd-java-agent/instrumentation/jetty-client-9.1/src/test/groovy/JettyClientTest.groovy
+++ b/dd-java-agent/instrumentation/jetty-client-9.1/src/test/groovy/JettyClientTest.groovy
@@ -1,6 +1,4 @@
 import datadog.trace.agent.test.base.HttpClientTest
-import datadog.trace.agent.test.checkpoints.CheckpointValidator
-import datadog.trace.agent.test.checkpoints.CheckpointValidationMode
 import org.eclipse.jetty.client.HttpClient
 import org.eclipse.jetty.client.HttpProxy
 import org.eclipse.jetty.client.api.Request
@@ -81,12 +79,5 @@ class JettyClientTest extends HttpClientTest {
   @Override
   boolean testProxy() {
     false // doesn't produce CONNECT span.
-  }
-
-  @Override
-  def setup() {
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.THREAD_SEQUENCE)
   }
 }


### PR DESCRIPTION
This is just to remove unneeded exclusions - the instrumentation was fixed in https://github.com/DataDog/dd-trace-java/pull/2963