### PR TITLE
 Dump information when a profile fails to upload because it's too big

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-uploader/profiling-uploader.gradle
+++ b/dd-java-agent/agent-profiling/profiling-uploader/profiling-uploader.gradle
@@ -15,7 +15,10 @@ excludedClassesCoverage += [
   'com.datadog.profiling.uploader.ByteCountingInputStream',
   'com.datadog.profiling.uploader.ByteCountingOutputStream',
   // A call-back inner class holds few enough instructions to make not testing with different log levels to breach the jacoco limits
-  'com.datadog.profiling.uploader.ProfileUploader.1'
+  'com.datadog.profiling.uploader.ProfileUploader.1',
+  // When running on Java 8 without `jfr`, no code is executed
+  'com.datadog.profiling.uploader.util.JfrCliHelper',
+  'com.datadog.profiling.uploader.util.JfrCliHelper.Event'
 ]
 
 dependencies {

--- a/dd-java-agent/agent-profiling/profiling-uploader/src/main/java/com/datadog/profiling/uploader/ProfileUploader.java
+++ b/dd-java-agent/agent-profiling/profiling-uploader/src/main/java/com/datadog/profiling/uploader/ProfileUploader.java
@@ -319,7 +319,9 @@ public final class ProfileUploader {
               public void onFailure(Call call, IOException e) {
                 if (isEmptyReplyFromServer(e)) {
                   ioLogger.error(
-                      "Failed to upload profile, received empty reply from " + call.request().url() + " after uploading profile");
+                      "Failed to upload profile, received empty reply from "
+                          + call.request().url()
+                          + " after uploading profile");
                 } else {
                   ioLogger.error("Failed to upload profile to " + call.request().url(), e);
                 }
@@ -346,7 +348,8 @@ public final class ProfileUploader {
                   }
                 }
 
-                // Note: this whole callback never touches body and would be perfectly happy even if server
+                // Note: this whole callback never touches body and would be perfectly happy even if
+                // server
                 // never sends it.
                 response.close();
 
@@ -377,9 +380,11 @@ public final class ProfileUploader {
               }
 
               private boolean isEmptyReplyFromServer(final IOException e) {
-                // The server in datadog-agent triggers 'unexpected end of stream' caused by EOFException.
+                // The server in datadog-agent triggers 'unexpected end of stream' caused by
+                // EOFException.
                 // The MockWebServer in tests triggers an InterruptedIOException with SocketPolicy
-                // NO_RESPONSE. This is because in tests we can't cleanly terminate the connection on the
+                // NO_RESPONSE. This is because in tests we can't cleanly terminate the connection
+                // on the
                 // server side without resetting.
                 return (e instanceof InterruptedIOException)
                     || (e.getCause() != null && e.getCause() instanceof java.io.EOFException);

--- a/dd-java-agent/agent-profiling/profiling-uploader/src/main/java/com/datadog/profiling/uploader/ProfileUploader.java
+++ b/dd-java-agent/agent-profiling/profiling-uploader/src/main/java/com/datadog/profiling/uploader/ProfileUploader.java
@@ -99,6 +99,7 @@ public final class ProfileUploader {
   private final OkHttpClient client;
   private final IOLogger ioLogger;
   private final boolean agentless;
+  private final boolean summaryOn413;
   private final String apiKey;
   private final String url;
   private final String containerId;
@@ -123,6 +124,7 @@ public final class ProfileUploader {
     url = config.getFinalProfilingUrl();
     apiKey = config.getApiKey();
     agentless = config.isProfilingAgentless();
+    summaryOn413 = config.isProfilingUploadSummaryOn413Enabled();
     this.ioLogger = ioLogger;
     this.containerId = containerId;
     this.terminationTimeout = terminationTimeout;
@@ -339,7 +341,7 @@ public final class ProfileUploader {
                     // if no API key and not found error we assume we're sending to the agent
                     ioLogger.error(
                         "Failed to upload profile. Datadog Agent is not accepting profiles. Agent-based profiling deployments require Datadog Agent >= 7.20");
-                  } else if (response.code() == 413) {
+                  } else if (response.code() == 413 && summaryOn413) {
                     ioLogger.error(
                         "Failed to upload profile, it's too big. Dumping information about the profile");
                     JfrCliHelper.invokeOn(data, ioLogger);

--- a/dd-java-agent/agent-profiling/profiling-uploader/src/main/java/com/datadog/profiling/uploader/ProfileUploader.java
+++ b/dd-java-agent/agent-profiling/profiling-uploader/src/main/java/com/datadog/profiling/uploader/ProfileUploader.java
@@ -20,6 +20,7 @@ import static datadog.trace.util.AgentThreadFactory.AgentThread.PROFILER_HTTP_DI
 
 import com.datadog.profiling.controller.RecordingData;
 import com.datadog.profiling.controller.RecordingType;
+import com.datadog.profiling.uploader.util.JfrCliHelper;
 import com.datadog.profiling.uploader.util.PidHelper;
 import datadog.common.container.ContainerInfo;
 import datadog.common.socket.UnixDomainSocketFactory;
@@ -336,6 +337,10 @@ public final class ProfileUploader {
                     // if no API key and not found error we assume we're sending to the agent
                     ioLogger.error(
                         "Failed to upload profile. Datadog Agent is not accepting profiles. Agent-based profiling deployments require Datadog Agent >= 7.20");
+                  } else if (response.code() == 413) {
+                    ioLogger.error(
+                        "Failed to upload profile, it's too big. Dumping information about the profile");
+                    JfrCliHelper.invokeOn(data, ioLogger);
                   } else {
                     ioLogger.error("Failed to upload profile", getLoggerResponse(response));
                   }

--- a/dd-java-agent/agent-profiling/profiling-uploader/src/main/java/com/datadog/profiling/uploader/ProfileUploader.java
+++ b/dd-java-agent/agent-profiling/profiling-uploader/src/main/java/com/datadog/profiling/uploader/ProfileUploader.java
@@ -94,67 +94,9 @@ public final class ProfileUploader {
       Headers.of(
           "Content-Disposition", "form-data; name=\"" + DATA_PARAM + "\"; filename=\"profile\"");
 
-  private static final class ResponseCallback implements Callback {
-
-    private final IOLogger ioLogger;
-
-    public ResponseCallback(final IOLogger ioLogger) {
-      this.ioLogger = ioLogger;
-    }
-
-    @Override
-    public void onFailure(final Call call, final IOException e) {
-      if (isEmptyReplyFromServer(e)) {
-        ioLogger.error(
-            "Received empty reply from " + call.request().url() + " after uploading profile");
-      } else {
-        ioLogger.error("Failed to upload profile to " + call.request().url(), e);
-      }
-    }
-
-    @Override
-    public void onResponse(final Call call, final Response response) {
-      if (response.isSuccessful()) {
-        ioLogger.success("Upload done");
-      } else {
-        final String apiKey = call.request().header(HEADER_DD_API_KEY);
-        if (response.code() == 404 && apiKey == null) {
-          // if no API key and not found error we assume we're sending to the agent
-          ioLogger.error(
-              "Datadog Agent is not accepting profiles. Agent-based profiling deployments require Datadog Agent >= 7.20");
-        }
-
-        ioLogger.error("Failed to upload profile", getLoggerResponse(response));
-      }
-      // Note: this whole callback never touches body and would be perfectly happy even if server
-      // never sends it.
-      response.close();
-    }
-
-    private static IOLogger.Response getLoggerResponse(final okhttp3.Response response) {
-      if (response != null) {
-        try {
-          return new IOLogger.Response(
-              response.code(), response.message(), response.body().string().trim());
-        } catch (final NullPointerException | IOException ignored) {
-        }
-      }
-      return null;
-    }
-
-    private static boolean isEmptyReplyFromServer(final IOException e) {
-      // The server in datadog-agent triggers 'unexpected end of stream' caused by EOFException.
-      // The MockWebServer in tests triggers an InterruptedIOException with SocketPolicy
-      // NO_RESPONSE. This is because in tests we can't cleanly terminate the connection on the
-      // server side without resetting.
-      return (e instanceof InterruptedIOException)
-          || (e.getCause() != null && e.getCause() instanceof java.io.EOFException);
-    }
-  }
-
   private final ExecutorService okHttpExecutorService;
   private final OkHttpClient client;
-  private final Callback responseCallback;
+  private final IOLogger ioLogger;
   private final boolean agentless;
   private final String apiKey;
   private final String url;
@@ -180,7 +122,7 @@ public final class ProfileUploader {
     url = config.getFinalProfilingUrl();
     apiKey = config.getApiKey();
     agentless = config.isProfilingAgentless();
-    responseCallback = new ResponseCallback(ioLogger);
+    this.ioLogger = ioLogger;
     this.containerId = containerId;
     this.terminationTimeout = terminationTimeout;
 
@@ -374,15 +316,35 @@ public final class ProfileUploader {
             new Callback() {
               @Override
               public void onFailure(Call call, IOException e) {
-                logDebug("Failed to upload profile");
-                responseCallback.onFailure(call, e);
+                if (isEmptyReplyFromServer(e)) {
+                  ioLogger.error(
+                      "Failed to upload profile, received empty reply from " + call.request().url() + " after uploading profile");
+                } else {
+                  ioLogger.error("Failed to upload profile to " + call.request().url(), e);
+                }
+
                 onCompletion.run();
               }
 
               @Override
               public void onResponse(Call call, Response response) throws IOException {
-                logDebug("Uploaded profile");
-                responseCallback.onResponse(call, response);
+                if (response.isSuccessful()) {
+                  ioLogger.success("Upload done");
+                } else {
+                  final String apiKey = call.request().header(HEADER_DD_API_KEY);
+                  if (response.code() == 404 && apiKey == null) {
+                    // if no API key and not found error we assume we're sending to the agent
+                    ioLogger.error(
+                        "Failed to upload profile. Datadog Agent is not accepting profiles. Agent-based profiling deployments require Datadog Agent >= 7.20");
+                  } else {
+                    ioLogger.error("Failed to upload profile", getLoggerResponse(response));
+                  }
+                }
+
+                // Note: this whole callback never touches body and would be perfectly happy even if server
+                // never sends it.
+                response.close();
+
                 onCompletion.run();
               }
 
@@ -396,6 +358,26 @@ public final class ProfileUploader {
                       body.getReadBytes(),
                       body.getWrittenBytes());
                 }
+              }
+
+              private IOLogger.Response getLoggerResponse(final okhttp3.Response response) {
+                if (response != null) {
+                  try {
+                    return new IOLogger.Response(
+                        response.code(), response.message(), response.body().string().trim());
+                  } catch (final NullPointerException | IOException ignored) {
+                  }
+                }
+                return null;
+              }
+
+              private boolean isEmptyReplyFromServer(final IOException e) {
+                // The server in datadog-agent triggers 'unexpected end of stream' caused by EOFException.
+                // The MockWebServer in tests triggers an InterruptedIOException with SocketPolicy
+                // NO_RESPONSE. This is because in tests we can't cleanly terminate the connection on the
+                // server side without resetting.
+                return (e instanceof InterruptedIOException)
+                    || (e.getCause() != null && e.getCause() instanceof java.io.EOFException);
               }
             });
   }

--- a/dd-java-agent/agent-profiling/profiling-uploader/src/main/java/com/datadog/profiling/uploader/util/JfrCliHelper.java
+++ b/dd-java-agent/agent-profiling/profiling-uploader/src/main/java/com/datadog/profiling/uploader/util/JfrCliHelper.java
@@ -27,13 +27,14 @@ import java.util.regex.Pattern;
 /** Call the `jfr` cli on the given recording */
 public class JfrCliHelper {
 
-  private static ExecutorService executorService = new ThreadPoolExecutor(
-    0,
-    Integer.MAX_VALUE,
-    60,
-    TimeUnit.SECONDS,
-    new SynchronousQueue<>(),
-    new AgentThreadFactory(PROFILER_HTTP_DISPATCHER));
+  private static ExecutorService executorService =
+      new ThreadPoolExecutor(
+          0,
+          Integer.MAX_VALUE,
+          60,
+          TimeUnit.SECONDS,
+          new SynchronousQueue<>(),
+          new AgentThreadFactory(PROFILER_HTTP_DISPATCHER));
 
   private static Pattern lineSeparatorRegex = Pattern.compile(System.lineSeparator());
   private static Pattern metadataSeparatorRegex = Pattern.compile("^=+$");
@@ -69,10 +70,12 @@ public class JfrCliHelper {
       Process process = builder.start();
 
       try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
-        Future<?> asyncRedirect = executorService.submit(() -> {
-          redirect(process.getInputStream(), out);
-          return true;
-        });
+        Future<?> asyncRedirect =
+            executorService.submit(
+                () -> {
+                  redirect(process.getInputStream(), out);
+                  return true;
+                });
 
         if (!process.waitFor(30, TimeUnit.SECONDS)) {
           ioLogger.error("Failed to gather information on recording, `jfr` never finished");
@@ -123,10 +126,10 @@ public class JfrCliHelper {
           .limit(10)
           .forEach(
               event -> {
-                  ioLogger.error(
-                      String.format(
-                          "Event: %s, size = %d, count = %d",
-                          event.getType(), event.getSize(), event.getCount()));
+                ioLogger.error(
+                    String.format(
+                        "Event: %s, size = %d, count = %d",
+                        event.getType(), event.getSize(), event.getCount()));
               });
     } catch (Exception e) {
       ioLogger.error("Failed to gather information on recording", e);

--- a/dd-java-agent/agent-profiling/profiling-uploader/src/main/java/com/datadog/profiling/uploader/util/JfrCliHelper.java
+++ b/dd-java-agent/agent-profiling/profiling-uploader/src/main/java/com/datadog/profiling/uploader/util/JfrCliHelper.java
@@ -35,6 +35,7 @@ public class JfrCliHelper {
     new SynchronousQueue<>(),
     new AgentThreadFactory(PROFILER_HTTP_DISPATCHER));
 
+  private static Pattern lineSeparatorRegex = Pattern.compile(System.lineSeparator());
   private static Pattern metadataSeparatorRegex = Pattern.compile("^=+$");
   private static Pattern columnSeparatorRegex = Pattern.compile("\\s+");
 
@@ -81,7 +82,7 @@ public class JfrCliHelper {
 
         asyncRedirect.get();
 
-        stdout = out.toString().split(System.lineSeparator());
+        stdout = lineSeparatorRegex.split(out.toString());
       }
 
       // Skip metadata from stdout

--- a/dd-java-agent/agent-profiling/profiling-uploader/src/main/java/com/datadog/profiling/uploader/util/JfrCliHelper.java
+++ b/dd-java-agent/agent-profiling/profiling-uploader/src/main/java/com/datadog/profiling/uploader/util/JfrCliHelper.java
@@ -1,0 +1,148 @@
+package com.datadog.profiling.uploader.util;
+
+import com.datadog.profiling.controller.RecordingData;
+import datadog.trace.api.IOLogger;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+/** Call the `jfr` cli on the given recording */
+public class JfrCliHelper {
+  public static void invokeOn(final RecordingData data, final IOLogger ioLogger) {
+    System.err.println("Hello World (1)");
+    try {
+      String javaHome = System.getProperty("java.home");
+      if (javaHome == null || javaHome.isEmpty()) {
+        ioLogger.error("Failed to gather information on recording, can't find JAVA_HOME");
+        return;
+      }
+
+      Path jfr = Paths.get(javaHome, "bin", "jfr");
+      if (!Files.exists(jfr)) {
+        ioLogger.error("Failed to gather information on recording, can't find `jfr`");
+        return;
+      }
+
+      // Create temporary file to save recording to
+      File tmp = File.createTempFile("recording-", ".jfr");
+      // Make sure files don't accumulate on the host
+      tmp.deleteOnExit();
+
+      // Save recording to temporary file
+      InputStream in = data.getStream();
+      try (FileOutputStream out = new FileOutputStream(tmp)) {
+        redirect(in, out);
+      }
+
+      String[] stdout;
+
+      // Launch `jfr` on temporary file and get stdout
+      ProcessBuilder builder = new ProcessBuilder(jfr.toString(), "summary", tmp.getAbsolutePath());
+      builder.redirectInput(ProcessBuilder.Redirect.INHERIT);
+      builder.redirectOutput(ProcessBuilder.Redirect.PIPE); // we'll want to read stdout
+      builder.redirectError(ProcessBuilder.Redirect.INHERIT);
+
+      Process process = builder.start();
+
+      try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+        redirect(process.getInputStream(), out);
+        process.waitFor();
+
+        stdout = out.toString().split(System.lineSeparator());
+      }
+
+      // Skip metadata from stdout
+      int i = 0;
+      for (; i < stdout.length; i++) {
+        String line = stdout[i];
+        if (line.matches("^=+$")) {
+          // we reached the separation line between the metadata and the data
+          i += 1;
+          break;
+        }
+      }
+
+      // Extract list of events from stdout
+      List<Event> events = new ArrayList<Event>();
+      for (; i < stdout.length; i++) {
+        String line = stdout[i];
+        if (line.isEmpty()) {
+          break;
+        }
+
+        String[] columns = line.trim().split("\\s+", 3);
+        if (columns.length < 3) {
+          ioLogger.error("Failed to gather information on recording, line format is unexpected");
+          return;
+        }
+
+        String type = columns[0];
+        int count = Integer.parseInt(columns[1]);
+        int size = Integer.parseInt(columns[2]);
+
+        events.add(new Event(type, count, size));
+      }
+
+      System.err.println("Hello World (2)");
+
+      // Log top 10 biggest events by size
+      events.stream()
+          .sorted(Comparator.comparing(Event::getSize).reversed())
+          .limit(10)
+          .forEach(
+              event -> {
+                  System.err.println("Hello World (3)");
+                  ioLogger.error(
+                      String.format(
+                          "Event: %s, size = %d, count = %d",
+                          event.getType(), event.getSize(), event.getCount()));
+              });
+    } catch (Exception e) {
+      ioLogger.error("Failed to gather information on recording", e);
+      return;
+    }
+  }
+
+  private static final int BUFFER_SIZE = 8192;
+
+  private static void redirect(InputStream in, OutputStream out) throws IOException {
+    byte[] buffer = new byte[BUFFER_SIZE];
+    int read;
+    while ((read = in.read(buffer, 0, BUFFER_SIZE)) >= 0) {
+      out.write(buffer, 0, read);
+    }
+  }
+
+  private static class Event {
+    private final String type;
+    private final int count;
+    private final int size;
+
+    Event(String type, int count, int size) {
+      this.type = type;
+      this.count = count;
+      this.size = size;
+    }
+
+    public String getType() {
+      return type;
+    }
+
+    public int getCount() {
+      return count;
+    }
+
+    public int getSize() {
+      return size;
+    }
+  }
+}

--- a/dd-java-agent/agent-profiling/profiling-uploader/src/test/java/com/datadog/profiling/uploader/ProfileUploaderTest.java
+++ b/dd-java-agent/agent-profiling/profiling-uploader/src/test/java/com/datadog/profiling/uploader/ProfileUploaderTest.java
@@ -456,7 +456,12 @@ public class ProfileUploaderTest {
     // Shutting down uploader ensures all callbacks are called on http client
     uploader.shutdown();
     verify(recording).release();
-    verify(ioLogger).error(eq("Failed to upload profile, received empty reply from " + url + " after uploading profile"));
+    verify(ioLogger)
+        .error(
+            eq(
+                "Failed to upload profile, received empty reply from "
+                    + url
+                    + " after uploading profile"));
   }
 
   @Test

--- a/dd-java-agent/agent-profiling/profiling-uploader/src/test/java/com/datadog/profiling/uploader/ProfileUploaderTest.java
+++ b/dd-java-agent/agent-profiling/profiling-uploader/src/test/java/com/datadog/profiling/uploader/ProfileUploaderTest.java
@@ -456,7 +456,7 @@ public class ProfileUploaderTest {
     // Shutting down uploader ensures all callbacks are called on http client
     uploader.shutdown();
     verify(recording).release();
-    verify(ioLogger).error(eq("Received empty reply from " + url + " after uploading profile"));
+    verify(ioLogger).error(eq("Failed to upload profile, received empty reply from " + url + " after uploading profile"));
   }
 
   @Test

--- a/dd-java-agent/agent-profiling/profiling-uploader/src/test/java/com/datadog/profiling/uploader/util/JfrCliHelperTest.java
+++ b/dd-java-agent/agent-profiling/profiling-uploader/src/test/java/com/datadog/profiling/uploader/util/JfrCliHelperTest.java
@@ -1,7 +1,7 @@
 package com.datadog.profiling.uploader.util;
 
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;

--- a/dd-java-agent/agent-profiling/profiling-uploader/src/test/java/com/datadog/profiling/uploader/util/JfrCliHelperTest.java
+++ b/dd-java-agent/agent-profiling/profiling-uploader/src/test/java/com/datadog/profiling/uploader/util/JfrCliHelperTest.java
@@ -12,12 +12,13 @@ import static org.mockito.Mockito.withSettings;
 import com.datadog.profiling.controller.RecordingData;
 import com.datadog.profiling.controller.RecordingInputStream;
 import datadog.trace.api.IOLogger;
-import datadog.trace.api.Platform;
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.time.Instant;
 import java.util.HashSet;
 import java.util.Set;
@@ -25,7 +26,6 @@ import java.util.zip.GZIPOutputStream;
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentMatcher;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.stubbing.Answer;
@@ -48,7 +48,7 @@ public class JfrCliHelperTest {
 
     JfrCliHelper.invokeOn(recording, ioLogger);
 
-    if (Platform.isJavaVersion(8)) {
+    if (!hasJfr()) {
       verify(ioLogger).error(eq("Failed to gather information on recording, can't find `jfr`"));
     } else {
       Set<String> messages = new HashSet<String>();
@@ -68,6 +68,10 @@ public class JfrCliHelperTest {
       verify(ioLogger, times(messages.size()))
           .error(argThat(message -> messages.contains(message)));
     }
+  }
+
+  private boolean hasJfr() {
+    return Files.exists(Paths.get(System.getProperty("java.home"), "bin", "jfr"));
   }
 
   private RecordingData mockRecordingData() throws IOException {

--- a/dd-java-agent/agent-profiling/profiling-uploader/src/test/java/com/datadog/profiling/uploader/util/JfrCliHelperTest.java
+++ b/dd-java-agent/agent-profiling/profiling-uploader/src/test/java/com/datadog/profiling/uploader/util/JfrCliHelperTest.java
@@ -1,0 +1,100 @@
+package com.datadog.profiling.uploader.util;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+
+import com.datadog.profiling.controller.RecordingData;
+import com.datadog.profiling.controller.RecordingInputStream;
+import datadog.trace.api.IOLogger;
+import datadog.trace.api.Platform;
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.zip.GZIPOutputStream;
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatcher;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.stubbing.Answer;
+
+@ExtendWith(MockitoExtension.class)
+public class JfrCliHelperTest {
+
+  private static final String RECORDING_RESOURCE = "/test-recording.jfr";
+  private static final String RECODING_NAME_PREFIX = "test-recording-";
+
+  private static final int SEQUENCE_NUMBER = 123;
+  private static final int PROFILE_START = 1000;
+  private static final int PROFILE_END = 1100;
+
+  @Mock private IOLogger ioLogger;
+
+  @Test
+  public void testInvokeOn() throws Exception {
+    final RecordingData recording = mockRecordingData();
+
+    JfrCliHelper.invokeOn(recording, ioLogger);
+
+    if (Platform.isJavaVersion(8)) {
+      verify(ioLogger).error(eq("Failed to gather information on recording, can't find `jfr`"));
+    } else {
+      Set<String> messages = new HashSet<String>();
+      messages.add("Event: jdk.CheckPoint, size = 2727591, count = 29");
+      messages.add("Event: jdk.Metadata, size = 208257, count = 3");
+      messages.add("Event: jdk.ClassLoad, size = 140225, count = 6679");
+      messages.add("Event: jdk.SystemProcess, size = 132771, count = 1389");
+      messages.add("Event: jdk.NativeLibrary, size = 83591, count = 927");
+      messages.add("Event: jdk.ClassDefine, size = 78876, count = 4624");
+      messages.add("Event: jdk.BooleanFlag, size = 66249, count = 1935");
+      messages.add("Event: jdk.ActiveSetting, size = 48732, count = 1470");
+      messages.add("Event: jdk.JavaMonitorWait, size = 35170, count = 1232");
+      messages.add("Event: jdk.InitialSystemProperty, size = 31164, count = 81");
+
+      // tried using `messages.remove(message)` to guarantee we are not duplicating
+      // the calls but Mockito complained for some reasons
+      verify(ioLogger, times(messages.size()))
+          .error(argThat(message -> messages.contains(message)));
+    }
+  }
+
+  private RecordingData mockRecordingData() throws IOException {
+    return mockRecordingData(false);
+  }
+
+  private RecordingData mockRecordingData(boolean zip) throws IOException {
+    final RecordingData recordingData = mock(RecordingData.class, withSettings().lenient());
+    when(recordingData.getStream())
+        .then(
+            (Answer<InputStream>)
+                invocation -> spy(new RecordingInputStream(recordingStream(zip))));
+    when(recordingData.getName()).thenReturn(RECODING_NAME_PREFIX + SEQUENCE_NUMBER);
+    when(recordingData.getStart()).thenReturn(Instant.ofEpochSecond(PROFILE_START));
+    when(recordingData.getEnd()).thenReturn(Instant.ofEpochSecond(PROFILE_END));
+    return recordingData;
+  }
+
+  private static InputStream recordingStream(boolean gzip) throws IOException {
+    InputStream dataStream = JfrCliHelper.class.getResourceAsStream(RECORDING_RESOURCE);
+    if (gzip) {
+      ByteArrayOutputStream baos = new ByteArrayOutputStream();
+      try (GZIPOutputStream zos = new GZIPOutputStream(baos)) {
+        IOUtils.copy(dataStream, zos);
+      }
+      dataStream = new ByteArrayInputStream(baos.toByteArray());
+    }
+    return new BufferedInputStream(dataStream);
+  }
+}

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -71,6 +71,7 @@ public final class ConfigDefaults {
   static final int DEFAULT_PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE = 10000;
   static final boolean DEFAULT_PROFILING_AGENTLESS = false;
   static final boolean DEFAULT_PROFILING_LEGACY_TRACING_INTEGRATION = true;
+  static final boolean DEFAULT_PROFILING_UPLOAD_SUMMARY_ON_413 = false;
 
   static final boolean DEFAULT_APPSEC_ENABLED = false;
 

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
@@ -55,5 +55,7 @@ public final class ProfilingConfig {
   // Not intended for production use
   public static final String PROFILING_AGENTLESS = "profiling.agentless";
 
+  public static final String PROFILING_UPLOAD_SUMMARY_ON_413 = "profiling.upload.summary-on-413";
+
   private ProfilingConfig() {}
 }

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -36,6 +36,7 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_START_DELAY;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_START_FORCE_FIRST;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_UPLOAD_COMPRESSION;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_UPLOAD_PERIOD;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_UPLOAD_SUMMARY_ON_413;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_UPLOAD_TIMEOUT;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PROPAGATION_EXTRACT_LOG_HEADER_NAMES_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PROPAGATION_STYLE_EXTRACT;
@@ -125,6 +126,7 @@ import static datadog.trace.api.config.ProfilingConfig.PROFILING_TAGS;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_TEMPLATE_OVERRIDE_FILE;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_UPLOAD_COMPRESSION;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_UPLOAD_PERIOD;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_UPLOAD_SUMMARY_ON_413;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_UPLOAD_TIMEOUT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_URL;
 import static datadog.trace.api.config.TraceInstrumentationConfig.DB_CLIENT_HOST_SPLIT_BY_INSTANCE;
@@ -380,6 +382,7 @@ public class Config {
   private final int profilingExceptionHistogramMaxCollectionSize;
   private final boolean profilingExcludeAgentThreads;
   private final boolean profilingHotspotsEnabled;
+  private final boolean profilingUploadSummaryOn413Enabled;
 
   private final boolean appSecEnabled;
 
@@ -792,6 +795,10 @@ public class Config {
 
     // code hotspots are disabled by default because of potential perf overhead they can incur
     profilingHotspotsEnabled = configProvider.getBoolean(PROFILING_HOTSPOTS_ENABLED, false);
+
+    profilingUploadSummaryOn413Enabled =
+        configProvider.getBoolean(
+            PROFILING_UPLOAD_SUMMARY_ON_413, DEFAULT_PROFILING_UPLOAD_SUMMARY_ON_413);
 
     appSecEnabled = configProvider.getBoolean(APPSEC_ENABLED, DEFAULT_APPSEC_ENABLED);
 
@@ -1236,6 +1243,10 @@ public class Config {
 
   public boolean isProfilingHotspotsEnabled() {
     return profilingHotspotsEnabled;
+  }
+
+  public boolean isProfilingUploadSummaryOn413Enabled() {
+    return profilingUploadSummaryOn413Enabled;
   }
 
   public boolean isProfilingLegacyTracingIntegrationEnabled() {


### PR DESCRIPTION
When receiving a 413 error code, we only know that the profile is too
big to be accepted by the backend. However, we have no idea why the
profile is too big.

With this change, we try to extract information about the size of the
events and log it to the command line. This allows us to ask customers
for more informations, and react accordingly. For example, if the
profile is too big due to too many exceptions being thrown and
overloading the profile, we can advise the customer to disable the
Exception profiler.
