### PR TITLE
Fix jetty-client instrumentation for 9.4+

### DIFF
--- a/dd-java-agent/instrumentation/jetty-client-9.1/src/main/java/datadog/trace/instrumentation/jetty_client/ResponseListenerAdapterInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-client-9.1/src/main/java/datadog/trace/instrumentation/jetty_client/ResponseListenerAdapterInstrumentation.java
@@ -1,6 +1,5 @@
 package datadog.trace.instrumentation.jetty_client;
 
-import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
 
 import com.google.auto.service.AutoService;
@@ -23,7 +22,9 @@ public final class ResponseListenerAdapterInstrumentation extends Instrumenter.T
 
   @Override
   public ElementMatcher<? super TypeDescription> typeMatcher() {
-    return named("org.eclipse.jetty.client.api.Response$Listener$Adapter");
+    return namedOneOf(
+        "org.eclipse.jetty.client.api.Response$Listener$Adapter",
+        "org.eclipse.jetty.client.api.Response$Listener");
   }
 
   @Override

--- a/dd-java-agent/instrumentation/jetty-client-9.1/src/test/groovy/JettyClientTest.groovy
+++ b/dd-java-agent/instrumentation/jetty-client-9.1/src/test/groovy/JettyClientTest.groovy
@@ -1,6 +1,4 @@
 import datadog.trace.agent.test.base.HttpClientTest
-import datadog.trace.agent.test.checkpoints.CheckpointValidator
-import datadog.trace.agent.test.checkpoints.CheckpointValidationMode
 import org.eclipse.jetty.client.HttpClient
 import org.eclipse.jetty.client.HttpProxy
 import org.eclipse.jetty.client.api.Request
@@ -81,12 +79,5 @@ class JettyClientTest extends HttpClientTest {
   @Override
   boolean testProxy() {
     false // doesn't produce CONNECT span.
-  }
-
-  @Override
-  def setup() {
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.THREAD_SEQUENCE)
   }
 }


### PR DESCRIPTION
In Jetty Client 9.4.* the default implementation of `org.eclipse.jetty.client.api.Response$Listener.onBegin()` and `org.eclipse.jetty.client.api.Response$Listener.onFailure()` methods was moved from `org.eclipse.jetty.client.api.Response$Listener$Adapter` abstract class back to the `org.eclipse.jetty.client.api.Response$Listener` interface (with it targeting Java 8 it is possible to use the interface default methods).
That move broke the instrumentation emitting the 'resume span' checkpoint. This patch is fixing the instrumentation and removing the checkpoint sequence validation exclusions.