### PR TITLE
Fix Hibernate checkpoints sequence

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/RouteHandlerDecoratorTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/RouteHandlerDecoratorTest.groovy
@@ -25,7 +25,7 @@ class RouteHandlerDecoratorTest extends DDSpecification {
 
   def "test that resource name is not changed"() {
     given:
-    AgentSpan span = tracer.startSpan("test")
+    AgentSpan span = tracer.startSpan("test", true)
 
     when:
     def scope = AgentTracer.activateSpan(span)

--- a/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/test/groovy/GrizzlyByteBodyInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/test/groovy/GrizzlyByteBodyInstrumentationTest.groovy
@@ -39,7 +39,7 @@ class GrizzlyByteBodyInstrumentationTest extends AgentTestRunner {
     RequestContext requestContext = Mock()
     TagContext ctx = Mock(TagContext)
     _ * ctx.requestContext >> requestContext
-    def agentSpan = AgentTracer.startSpan('test-span', ctx)
+    def agentSpan = AgentTracer.startSpan('test-span', ctx, true)
     this.scope = AgentTracer.activateSpan(agentSpan)
 
     ig.registerCallback(Events.REQUEST_BODY_START, { RequestContext reqContext, StoredBodySupplier sup ->

--- a/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/test/groovy/GrizzlyCharBodyInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/test/groovy/GrizzlyCharBodyInstrumentationTest.groovy
@@ -34,7 +34,7 @@ class GrizzlyCharBodyInstrumentationTest extends AgentTestRunner {
     RequestContext requestContext = Mock()
     TagContext ctx = Mock(TagContext)
     _ * ctx.requestContext >> requestContext
-    def agentSpan = AgentTracer.startSpan('test-span', ctx)
+    def agentSpan = AgentTracer.startSpan('test-span', ctx, true)
     this.scope = AgentTracer.activateSpan(agentSpan)
 
     ig.registerCallback(Events.REQUEST_BODY_START, { RequestContext reqContext, StoredBodySupplier sup ->

--- a/dd-java-agent/instrumentation/hibernate/core-3.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v3_3/SessionFactoryInstrumentation.java
+++ b/dd-java-agent/instrumentation/hibernate/core-3.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v3_3/SessionFactoryInstrumentation.java
@@ -68,7 +68,7 @@ public class SessionFactoryInstrumentation extends AbstractHibernateInstrumentat
     @Advice.OnMethodExit(suppress = Throwable.class)
     public static void openSession(@Advice.Return final Object session) {
 
-      final AgentSpan span = startSpan(HIBERNATE_SESSION);
+      final AgentSpan span = startSpan(HIBERNATE_SESSION, false);
       DECORATOR.afterStart(span);
       DECORATOR.onConnection(span, session);
 

--- a/dd-java-agent/instrumentation/hibernate/core-3.3/src/test/groovy/SessionTest.groovy
+++ b/dd-java-agent/instrumentation/hibernate/core-3.3/src/test/groovy/SessionTest.groovy
@@ -1,5 +1,3 @@
-import datadog.trace.agent.test.checkpoints.CheckpointValidator
-import datadog.trace.agent.test.checkpoints.CheckpointValidationMode
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.AgentScope
 import datadog.trace.bootstrap.instrumentation.api.Tags
@@ -545,10 +543,6 @@ class SessionTest extends AbstractHibernateTest {
 
 
   def "test hibernate overlapping Sessions"() {
-    setup:
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.INTERVALS)
-
     AgentScope scope = activateSpan(startSpan("overlapping Sessions"))
 
     def session1 = sessionFactory.openSession()

--- a/dd-java-agent/instrumentation/hibernate/core-4.0/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_0/SessionFactoryInstrumentation.java
+++ b/dd-java-agent/instrumentation/hibernate/core-4.0/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_0/SessionFactoryInstrumentation.java
@@ -56,7 +56,7 @@ public class SessionFactoryInstrumentation extends AbstractHibernateInstrumentat
     @Advice.OnMethodExit(suppress = Throwable.class)
     public static void openSession(@Advice.Return final SharedSessionContract session) {
 
-      final AgentSpan span = startSpan(HIBERNATE_SESSION);
+      final AgentSpan span = startSpan(HIBERNATE_SESSION, false);
       DECORATOR.afterStart(span);
       DECORATOR.onConnection(span, session);
 

--- a/dd-java-agent/instrumentation/jax-rs-client-2.0/src/test/groovy/JaxRsClientAsyncTest.groovy
+++ b/dd-java-agent/instrumentation/jax-rs-client-2.0/src/test/groovy/JaxRsClientAsyncTest.groovy
@@ -21,6 +21,10 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
 abstract class JaxRsClientAsyncTest extends HttpClientTest {
+  @Override
+  def setup() {
+    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(CheckpointValidationMode.INTERVALS)
+  }
 
   @Override
   int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/latestDepTest/groovy/KafkaClientTest.groovy
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/latestDepTest/groovy/KafkaClientTest.groovy
@@ -1,4 +1,6 @@
 import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.agent.test.checkpoints.CheckpointValidationMode
+import datadog.trace.agent.test.checkpoints.CheckpointValidator
 import datadog.trace.api.config.TraceInstrumentationConfig
 import datadog.trace.bootstrap.instrumentation.api.InstrumentationTags
 import datadog.trace.bootstrap.instrumentation.api.Tags
@@ -49,6 +51,11 @@ class KafkaClientTest extends AgentTestRunner {
     super.configurePreAgent()
 
     injectSysConfig("dd.kafka.e2e.duration.enabled", "true")
+  }
+
+  @Override
+  def setup() {
+    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(CheckpointValidationMode.INTERVALS)
   }
 
   def "test kafka produce and consume"() {

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientCustomPropagationConfigTest.groovy
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientCustomPropagationConfigTest.groovy
@@ -1,4 +1,6 @@
 import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.agent.test.checkpoints.CheckpointValidationMode
+import datadog.trace.agent.test.checkpoints.CheckpointValidator
 import datadog.trace.api.config.TraceInstrumentationConfig
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan
 import org.apache.kafka.clients.consumer.ConsumerRecord
@@ -53,6 +55,11 @@ class KafkaClientCustomPropagationConfigTest extends AgentTestRunner {
     super.configurePreAgent()
 
     injectSysConfig("dd.kafka.e2e.duration.enabled", "true")
+  }
+
+  @Override
+  def setup() {
+    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(CheckpointValidationMode.INTERVALS)
   }
 
   @Unroll

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTest.groovy
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTest.groovy
@@ -1,4 +1,6 @@
 import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.agent.test.checkpoints.CheckpointValidationMode
+import datadog.trace.agent.test.checkpoints.CheckpointValidator
 import datadog.trace.api.config.TraceInstrumentationConfig
 import datadog.trace.bootstrap.instrumentation.api.InstrumentationTags
 import datadog.trace.bootstrap.instrumentation.api.Tags
@@ -49,6 +51,11 @@ class KafkaClientTest extends AgentTestRunner {
     super.configurePreAgent()
 
     injectSysConfig("dd.kafka.e2e.duration.enabled", "true")
+  }
+
+  @Override
+  def setup() {
+    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(CheckpointValidationMode.INTERVALS)
   }
 
   def "test kafka produce and consume"() {

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/src/latestDepTest/groovy/KafkaStreamsTest.groovy
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/src/latestDepTest/groovy/KafkaStreamsTest.groovy
@@ -1,4 +1,6 @@
 import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.agent.test.checkpoints.CheckpointValidationMode
+import datadog.trace.agent.test.checkpoints.CheckpointValidator
 import datadog.trace.bootstrap.instrumentation.api.InstrumentationTags
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import org.apache.kafka.clients.consumer.ConsumerRecord
@@ -37,6 +39,7 @@ class KafkaStreamsTest extends AgentTestRunner {
 
   def "test kafka produce and consume with streams in-between"() {
     setup:
+    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(CheckpointValidationMode.INTERVALS)
     def config = new Properties()
     def producerProps = KafkaTestUtils.producerProps(embeddedKafka.getBrokersAsString())
     config.putAll(producerProps)

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/src/test/groovy/KafkaStreamsTest.groovy
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/src/test/groovy/KafkaStreamsTest.groovy
@@ -1,4 +1,6 @@
 import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.agent.test.checkpoints.CheckpointValidationMode
+import datadog.trace.agent.test.checkpoints.CheckpointValidator
 import datadog.trace.bootstrap.instrumentation.api.InstrumentationTags
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import org.apache.kafka.clients.consumer.ConsumerRecord
@@ -33,6 +35,7 @@ class KafkaStreamsTest extends AgentTestRunner {
 
   def "test kafka produce and consume with streams in-between"() {
     setup:
+    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(CheckpointValidationMode.INTERVALS)
     def config = new Properties()
     def senderProps = KafkaTestUtils.senderProps(embeddedKafka.getBrokersAsString())
     config.putAll(senderProps)

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/test/groovy/dd/trace/instrumentation/springwebflux/client/SpringWebfluxHttpClientBase.groovy
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/test/groovy/dd/trace/instrumentation/springwebflux/client/SpringWebfluxHttpClientBase.groovy
@@ -2,6 +2,8 @@ package dd.trace.instrumentation.springwebflux.client
 
 import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.agent.test.base.HttpClientTest
+import datadog.trace.agent.test.checkpoints.CheckpointValidationMode
+import datadog.trace.agent.test.checkpoints.CheckpointValidator
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import datadog.trace.bootstrap.instrumentation.api.Tags
@@ -18,6 +20,12 @@ import reactor.core.publisher.Mono
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
 
 abstract class SpringWebfluxHttpClientBase extends HttpClientTest {
+
+  @Override
+  def setup() {
+    // netty induced out-of-band span closes are causing the interval check to fail
+    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(CheckpointValidationMode.INTERVALS)
+  }
 
   @Override
   boolean useStrictTraceWrites() {

--- a/dd-java-agent/instrumentation/vertx-rx-3.5/src/test/groovy/client/VertxRxCircuitBreakerWebClientForkedTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-rx-3.5/src/test/groovy/client/VertxRxCircuitBreakerWebClientForkedTest.groovy
@@ -1,6 +1,8 @@
 package client
 
 import datadog.trace.agent.test.base.HttpClientTest
+import datadog.trace.agent.test.checkpoints.CheckpointValidationMode
+import datadog.trace.agent.test.checkpoints.CheckpointValidator
 import datadog.trace.instrumentation.netty41.client.NettyHttpClientDecorator
 import io.vertx.circuitbreaker.CircuitBreakerOptions
 import io.vertx.core.VertxOptions
@@ -40,6 +42,11 @@ class VertxRxCircuitBreakerWebClientForkedTest extends HttpClientTest {
   new CircuitBreakerOptions()
   .setTimeout(-1) // Disable the timeout otherwise it makes each test take this long.
   )
+
+  @Override
+  def setup() {
+    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(CheckpointValidationMode.INTERVALS)
+  }
 
   @Override
   int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {

--- a/dd-java-agent/instrumentation/vertx-rx-3.5/src/test/groovy/client/VertxRxWebClientForkedTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-rx-3.5/src/test/groovy/client/VertxRxWebClientForkedTest.groovy
@@ -1,6 +1,8 @@
 package client
 
 import datadog.trace.agent.test.base.HttpClientTest
+import datadog.trace.agent.test.checkpoints.CheckpointValidationMode
+import datadog.trace.agent.test.checkpoints.CheckpointValidator
 import datadog.trace.instrumentation.netty41.client.NettyHttpClientDecorator
 import io.vertx.core.VertxOptions
 import io.vertx.core.http.HttpMethod
@@ -29,6 +31,11 @@ class VertxRxWebClientForkedTest extends HttpClientTest {
   @AutoCleanup
   @Shared
   WebClient client = WebClient.create(vertx, clientOptions)
+
+  @Override
+  def setup() {
+    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(CheckpointValidationMode.INTERVALS)
+  }
 
   @Override
   int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/test/groovy/client/VertxHttpClientForkedTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/test/groovy/client/VertxHttpClientForkedTest.groovy
@@ -1,6 +1,8 @@
 package client
 
 import datadog.trace.agent.test.base.HttpClientTest
+import datadog.trace.agent.test.checkpoints.CheckpointValidationMode
+import datadog.trace.agent.test.checkpoints.CheckpointValidator
 import datadog.trace.instrumentation.netty41.client.NettyHttpClientDecorator
 import io.vertx.core.Vertx
 import io.vertx.core.VertxOptions
@@ -31,6 +33,11 @@ class VertxHttpClientForkedTest extends HttpClientTest {
   @AutoCleanup
   @Shared
   def httpClient = vertx.createHttpClient(clientOptions)
+
+  @Override
+  def setup() {
+    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(CheckpointValidationMode.INTERVALS)
+  }
 
   @Override
   int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/server/http/TestHttpServer.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/server/http/TestHttpServer.groovy
@@ -366,7 +366,7 @@ class TestHttpServer implements AutoCloseable {
       if (isDDServer) {
         final AgentSpan.Context extractedContext = propagate().extract(req.orig, GETTER)
         if (extractedContext != null) {
-          startSpan("test-http-server", extractedContext)
+          startSpan("test-http-server", extractedContext, true)
             .setTag("path", request.path)
             .setTag(Tags.SPAN_KIND, Tags.SPAN_KIND_SERVER).finish()
         } else {

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/utils/TraceUtils.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/utils/TraceUtils.groovy
@@ -32,7 +32,7 @@ class TraceUtils {
   }
 
   static <T> T runUnderTrace(final String rootOperationName, final boolean inheritCurrent, final Callable<T> r) {
-    final AgentSpan span = inheritCurrent ? startSpan(rootOperationName) : startSpan(rootOperationName, null)
+    final AgentSpan span = inheritCurrent ? startSpan(rootOperationName, true) : startSpan(rootOperationName, null, true)
     DECORATOR.afterStart(span)
 
     AgentScope scope = activateSpan(span)

--- a/dd-java-agent/testing/src/test/groovy/TraceCorrelationTest.groovy
+++ b/dd-java-agent/testing/src/test/groovy/TraceCorrelationTest.groovy
@@ -5,7 +5,7 @@ class TraceCorrelationTest extends AgentTestRunner {
 
   def "access trace correlation only under trace"() {
     when:
-    def span = TEST_TRACER.startSpan("myspan")
+    def span = TEST_TRACER.startSpan("myspan", true)
     def scope = TEST_TRACER.activateSpan(span)
 
     then:

--- a/dd-java-agent/testing/src/test/groovy/checkpoints/IntervalValidatorTest.groovy
+++ b/dd-java-agent/testing/src/test/groovy/checkpoints/IntervalValidatorTest.groovy
@@ -20,6 +20,17 @@ class IntervalValidatorTest extends Specification {
     tracker.endSequence()
   }
 
+  def "start endtask endspan"() {
+    expect:
+    tracker.startSpan(1L)
+    tracker.suspendSpan(1L)
+    tracker.resumeSpan(1L)
+    tracker.endTask(1L)
+    tracker.resumeSpan(1L)
+    tracker.endSpan(1L)
+    tracker.endSequence()
+  }
+
   def "end span on other thread"() {
     expect:
     tracker.startSpan(1L)
@@ -137,5 +148,19 @@ class IntervalValidatorTest extends Specification {
     // tracker.endTask(2L)         // T1
     tracker.endSpan(2L)            // T2
     // tracker.endSpan(1L)         // T1
+  }
+
+  def "interleaving intervals with suspend on the same thread"() {
+    expect:
+    tracker.startSpan(1L)
+    tracker.suspendSpan(1L)
+    tracker.startSpan(2L)
+    tracker.suspendSpan(2L)
+    tracker.resumeSpan(1L)
+    tracker.endTask(1L)
+    tracker.resumeSpan(1L)
+    tracker.endSpan(1L)
+    tracker.resumeSpan(2L)
+    tracker.endSpan(2L)
   }
 }

--- a/dd-trace-core/jfr-openjdk/src/test/groovy/datadog/trace/core/jfr/openjdk/ScopeEventTest.groovy
+++ b/dd-trace-core/jfr-openjdk/src/test/groovy/datadog/trace/core/jfr/openjdk/ScopeEventTest.groovy
@@ -323,7 +323,7 @@ class ScopeEventTest extends DDSpecification {
     tracer.registerCheckpointer(new JFRCheckpointer(null, ConfigProvider.getInstance()))
 
     when: "span goes through lifecycle without activation"
-    AgentSpan span = tracer.startSpan("test")
+    AgentSpan span = tracer.startSpan("test", true)
     span.startThreadMigration()
     span.finishThreadMigration()
     span.setResourceName("foo")

--- a/dd-trace-core/src/main/java/datadog/trace/core/PendingTrace.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/PendingTrace.java
@@ -142,11 +142,15 @@ public class PendingTrace implements AgentTrace, PendingTraceBuffer.Element {
   void registerSpan(final DDSpan span) {
     ROOT_SPAN.compareAndSet(this, null, span);
     PENDING_REFERENCE_COUNT.incrementAndGet(this);
-    tracer.onStart(span);
+    if (span.hasCheckpoints()) {
+      tracer.onStart(span);
+    }
   }
 
   void onFinish(final DDSpan span) {
-    tracer.onFinish(span);
+    if (span.hasCheckpoints()) {
+      tracer.onFinish(span);
+    }
   }
 
   PublishState onPublish(final DDSpan span) {

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceTestBase.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceTestBase.groovy
@@ -223,7 +223,7 @@ abstract class PendingTraceTestBase extends DDCoreSpecification {
         try {
           latch.await()
           def spans = (1..spanCount).collect {
-            tracer.startSpan("child", rootSpan.context())
+            tracer.startSpan("child", rootSpan.context(), true)
           }
           spans.each {
             it.finish()

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
@@ -68,6 +68,8 @@ public interface AgentSpan extends MutableSpan, IGSpanInfo {
    */
   Boolean isEmittingCheckpoints();
 
+  boolean hasCheckpoints();
+
   @Override
   AgentSpan getLocalRootSpan();
 

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -19,23 +19,45 @@ public class AgentTracer {
 
   // Implicit parent
   public static AgentSpan startSpan(final CharSequence spanName) {
-    return get().startSpan(spanName);
+    return startSpan(spanName, true);
+  }
+
+  public static AgentSpan startSpan(final CharSequence spanName, boolean withCheckpoints) {
+    return get().startSpan(spanName, withCheckpoints);
   }
 
   // Implicit parent
   public static AgentSpan startSpan(final CharSequence spanName, final long startTimeMicros) {
-    return get().startSpan(spanName, startTimeMicros);
+    return startSpan(spanName, startTimeMicros, true);
+  }
+
+  public static AgentSpan startSpan(
+      final CharSequence spanName, final long startTimeMicros, boolean withCheckpoints) {
+    return get().startSpan(spanName, startTimeMicros, withCheckpoints);
   }
 
   // Explicit parent
   public static AgentSpan startSpan(final CharSequence spanName, final AgentSpan.Context parent) {
-    return get().startSpan(spanName, parent);
+    return startSpan(spanName, parent, true);
+  }
+
+  public static AgentSpan startSpan(
+      final CharSequence spanName, final AgentSpan.Context parent, boolean withCheckpoints) {
+    return get().startSpan(spanName, parent, withCheckpoints);
   }
 
   // Explicit parent
   public static AgentSpan startSpan(
       final CharSequence spanName, final AgentSpan.Context parent, final long startTimeMicros) {
-    return get().startSpan(spanName, parent, startTimeMicros);
+    return startSpan(spanName, parent, startTimeMicros, true);
+  }
+
+  public static AgentSpan startSpan(
+      final CharSequence spanName,
+      final AgentSpan.Context parent,
+      final long startTimeMicros,
+      boolean withCheckpoints) {
+    return get().startSpan(spanName, parent, startTimeMicros, withCheckpoints);
   }
 
   public static AgentScope activateSpan(final AgentSpan span) {
@@ -92,13 +114,17 @@ public class AgentTracer {
   private AgentTracer() {}
 
   public interface TracerAPI extends datadog.trace.api.Tracer, AgentPropagation, SpanCheckpointer {
-    AgentSpan startSpan(CharSequence spanName);
+    AgentSpan startSpan(CharSequence spanName, boolean emitCheckpoint);
 
-    AgentSpan startSpan(CharSequence spanName, long startTimeMicros);
+    AgentSpan startSpan(CharSequence spanName, long startTimeMicros, boolean emitCheckpoint);
 
-    AgentSpan startSpan(CharSequence spanName, AgentSpan.Context parent);
+    AgentSpan startSpan(CharSequence spanName, AgentSpan.Context parent, boolean emitCheckpoint);
 
-    AgentSpan startSpan(CharSequence spanName, AgentSpan.Context parent, long startTimeMicros);
+    AgentSpan startSpan(
+        CharSequence spanName,
+        AgentSpan.Context parent,
+        long startTimeMicros,
+        boolean emitCheckpoint);
 
     AgentScope activateSpan(AgentSpan span, ScopeSource source);
 
@@ -154,6 +180,8 @@ public class AgentTracer {
     SpanBuilder withErrorFlag();
 
     SpanBuilder withSpanType(CharSequence spanType);
+
+    SpanBuilder suppressCheckpoints();
   }
 
   static class NoopTracerAPI implements TracerAPI {
@@ -161,23 +189,28 @@ public class AgentTracer {
     protected NoopTracerAPI() {}
 
     @Override
-    public AgentSpan startSpan(final CharSequence spanName) {
-      return NoopAgentSpan.INSTANCE;
-    }
-
-    @Override
-    public AgentSpan startSpan(final CharSequence spanName, final long startTimeMicros) {
-      return NoopAgentSpan.INSTANCE;
-    }
-
-    @Override
-    public AgentSpan startSpan(final CharSequence spanName, final Context parent) {
+    public AgentSpan startSpan(final CharSequence spanName, boolean withCheckpoints) {
       return NoopAgentSpan.INSTANCE;
     }
 
     @Override
     public AgentSpan startSpan(
-        final CharSequence spanName, final Context parent, final long startTimeMicros) {
+        final CharSequence spanName, final long startTimeMicros, boolean withCheckpoints) {
+      return NoopAgentSpan.INSTANCE;
+    }
+
+    @Override
+    public AgentSpan startSpan(
+        final CharSequence spanName, final Context parent, boolean withCheckpoints) {
+      return NoopAgentSpan.INSTANCE;
+    }
+
+    @Override
+    public AgentSpan startSpan(
+        final CharSequence spanName,
+        final Context parent,
+        final long startTimeMicros,
+        boolean withCheckpoints) {
       return NoopAgentSpan.INSTANCE;
     }
 
@@ -552,6 +585,11 @@ public class AgentTracer {
     @Override
     public Boolean isEmittingCheckpoints() {
       return Boolean.FALSE;
+    }
+
+    @Override
+    public boolean hasCheckpoints() {
+      return false;
     }
   }
 


### PR DESCRIPTION
Current state of the instrumentation will open a new span when a hibernate session is created. This span is closed when the session is closed. From the checkpoint PoV this has the consequence of attributing any work done between opening and closing the session (with the closing possibly happening on a completely different thread) would be attributed to hibernate, if not enclosed in some other span.

While it would be possible to pepper the checkpoint sequence with suspends/resumes which would put the session span to 'sleep' immediately after it has been created and then wake it up just for the time while an operation is being executed on behalf of that session this would create quite a lot of checkpoints without any additional value.

Therefore I am proposing to enhance the internal API for starting a span to specify a flag to disable checkpoint generation - this would be used for the session span here, making totally transparent from the checkpoint PoV.

Unfortunately, fixing this issue unearthed a problem in the checkpoint interval validator and fixing that problem, in turn, showed more places in integrations where I had to put the checkpoint validation excludes to make the tests passing. All of those places are in integrations we already know have some issues with checkpoints so the overall state is not changing at all.