### PR TITLE
Support synthetic "time-in-queue" for JMS

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jms/MessageBatchState.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jms/MessageBatchState.java
@@ -1,0 +1,27 @@
+package datadog.trace.bootstrap.instrumentation.jms;
+
+import datadog.trace.api.Config;
+import datadog.trace.api.IdGenerationStrategy;
+
+/** Holds time-in-queue related information about a batch of messages. */
+public final class MessageBatchState {
+  private static final IdGenerationStrategy ID_STRATEGY = Config.get().getIdGenerationStrategy();
+
+  final long batchId;
+  final long startMillis;
+  final int commitSequence; // used to decide when to assign a new batch state
+
+  MessageBatchState(int commitSequence) {
+    this.batchId = ID_STRATEGY.generate().toLong();
+    this.startMillis = System.currentTimeMillis();
+    this.commitSequence = commitSequence;
+  }
+
+  public long getBatchId() {
+    return batchId;
+  }
+
+  public long getStartMillis() {
+    return startMillis;
+  }
+}

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jms/MessageConsumerState.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jms/MessageConsumerState.java
@@ -7,22 +7,43 @@ import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 public final class MessageConsumerState {
 
   private final SessionState sessionState;
-  private final CharSequence resourceName;
+  private final CharSequence brokerResourceName;
+  private final String brokerServiceName;
+  private final CharSequence consumerResourceName;
   private final boolean propagationDisabled;
 
   public MessageConsumerState(
-      SessionState sessionState, CharSequence resourceName, boolean propagationDisabled) {
+      SessionState sessionState,
+      CharSequence brokerResourceName,
+      CharSequence consumerResourceName,
+      boolean propagationDisabled) {
     this.sessionState = sessionState;
-    this.resourceName = resourceName;
+    this.brokerResourceName = brokerResourceName;
+    this.consumerResourceName = consumerResourceName;
     this.propagationDisabled = propagationDisabled;
+
+    String brokerServiceName = brokerResourceName.toString();
+    if (brokerServiceName.startsWith("Queue ") || brokerServiceName.startsWith("Topic ")) {
+      this.brokerServiceName = brokerServiceName.substring(6);
+    } else {
+      this.brokerServiceName = brokerServiceName;
+    }
   }
 
   public SessionState getSessionState() {
     return sessionState;
   }
 
-  public CharSequence getResourceName() {
-    return resourceName;
+  public CharSequence getBrokerResourceName() {
+    return brokerResourceName;
+  }
+
+  public String getBrokerServiceName() {
+    return brokerServiceName;
+  }
+
+  public CharSequence getConsumerResourceName() {
+    return consumerResourceName;
   }
 
   public boolean isPropagationDisabled() {

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jms/MessageConsumerState.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jms/MessageConsumerState.java
@@ -1,6 +1,7 @@
 package datadog.trace.bootstrap.instrumentation.jms;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 
 /** Tracks message scopes and spans when consuming messages with {@code receive}. */
 public final class MessageConsumerState {
@@ -36,5 +37,20 @@ public final class MessageConsumerState {
   /** Closes the scope previously registered by closeOnIteration, assumes same calling thread. */
   public void closePreviousMessageScope() {
     sessionState.closePreviousMessageScope(); // tracked per-session-thread
+  }
+
+  /** Gets the current time-in-queue span; returns {@code null} if this is a new batch. */
+  public AgentSpan getTimeInQueueSpan(long batchId) {
+    return sessionState.getTimeInQueueSpan(batchId); // tracked per-session-thread
+  }
+
+  /** Starts tracking a new time-in-queue span. */
+  public void setTimeInQueueSpan(long batchId, AgentSpan span) {
+    sessionState.setTimeInQueueSpan(batchId, span); // tracked per-session-thread
+  }
+
+  /** Finishes the current time-in-queue span and optionally stops tracking it. */
+  public void finishTimeInQueueSpan(boolean clear) {
+    sessionState.finishTimeInQueueSpan(clear); // tracked per-session-thread
   }
 }

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jms/MessageConsumerState.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jms/MessageConsumerState.java
@@ -22,6 +22,7 @@ public final class MessageConsumerState {
     this.consumerResourceName = consumerResourceName;
     this.propagationDisabled = propagationDisabled;
 
+    // use the destination as the service name, with no prefix
     String brokerServiceName = brokerResourceName.toString();
     if (brokerServiceName.startsWith("Queue ") || brokerServiceName.startsWith("Topic ")) {
       this.brokerServiceName = brokerServiceName.substring(6);

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jms/MessageProducerState.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jms/MessageProducerState.java
@@ -24,4 +24,9 @@ public final class MessageProducerState {
   public boolean isPropagationDisabled() {
     return propagationDisabled;
   }
+
+  /** Retrieves details about the current message batch being produced in this session. */
+  public MessageBatchState currentBatchState() {
+    return sessionState.currentBatchState(); // tracked per-session
+  }
 }

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jms/SessionState.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jms/SessionState.java
@@ -77,7 +77,7 @@ public final class SessionState {
   }
 
   /** Retrieves details about the current message batch being produced in this session. */
-  public MessageBatchState currentBatchState() {
+  MessageBatchState currentBatchState() {
     MessageBatchState oldBatch = batchState;
     if (null != oldBatch && oldBatch.commitSequence == commitSequence) {
       return oldBatch;

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jms/SessionState.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jms/SessionState.java
@@ -112,11 +112,13 @@ public final class SessionState {
       Iterator<AgentScope> activeScopeIterator = activeScopes.values().iterator();
       Iterator<TimeInQueue> timeInQueueIterator = timeInQueueSpans.values().iterator();
 
+      // first close any session-related scopes that are still open
       while (activeScopeIterator.hasNext()) {
         maybeCloseScope(activeScopeIterator.next());
         activeScopeIterator.remove();
       }
 
+      // next finish any message spans captured during this session
       int spansToFinish;
       boolean finishingFlipped;
       synchronized (capturedSpans) {
@@ -143,6 +145,7 @@ public final class SessionState {
         }
       }
 
+      // lastly finish any time-in-queue parent spans for this session
       while (timeInQueueIterator.hasNext()) {
         maybeFinishTimeInQueueSpan(timeInQueueIterator.next());
         timeInQueueIterator.remove();

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jms/TimeInQueue.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jms/TimeInQueue.java
@@ -1,0 +1,14 @@
+package datadog.trace.bootstrap.instrumentation.jms;
+
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+
+/** Holds the synthetic time-in-queue span for a batch of messages. */
+final class TimeInQueue {
+  final long batchId;
+  final AgentSpan span;
+
+  TimeInQueue(long batchId, AgentSpan span) {
+    this.batchId = batchId;
+    this.span = span;
+  }
+}

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/jms/SessionStateTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/jms/SessionStateTest.groovy
@@ -59,10 +59,10 @@ class SessionStateTest extends DDSpecification {
       Thread.start { sessionState.closeOnIteration(Mock(AgentScope)) }.join()
     }
     then:
-    sessionState.scopeCount == 100
+    sessionState.activeScopeCount == 100
     when: "trigger cleanup"
     sessionState.closeOnIteration(Mock(AgentScope))
     then:
-    sessionState.scopeCount == 1
+    sessionState.activeScopeCount == 1
   }
 }

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/jms/SessionStateTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/jms/SessionStateTest.groovy
@@ -4,11 +4,13 @@ import datadog.trace.bootstrap.instrumentation.api.AgentScope
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan
 import datadog.trace.test.util.DDSpecification
 
+import java.util.concurrent.CountDownLatch
+
 class SessionStateTest extends DDSpecification {
 
   def "commit transaction"() {
     setup:
-    SessionState sessionState = new SessionState(0)
+    def sessionState = new SessionState(0)
     def span1 = Mock(AgentSpan)
     def span2 = Mock(AgentSpan)
     when:
@@ -28,9 +30,9 @@ class SessionStateTest extends DDSpecification {
 
   def "when buffer overflows, spans are finished eagerly"() {
     setup:
-    SessionState sessionState = new SessionState(0)
-    AgentSpan span1 = Mock(AgentSpan)
-    AgentSpan span2 = Mock(AgentSpan)
+    def sessionState = new SessionState(0)
+    def span1 = Mock(AgentSpan)
+    def span2 = Mock(AgentSpan)
     when: "fill the buffer"
     for (int i = 0; i < SessionState.MAX_CAPTURED_SPANS; ++i) {
       sessionState.finishOnCommit(span1)
@@ -51,18 +53,77 @@ class SessionStateTest extends DDSpecification {
     sessionState.capturedSpanCount == 1
   }
 
-  def "stale scopes are cleaned up from session"() {
+  def "stale scopes are evicted from session"() {
     setup:
-    SessionState sessionState = new SessionState(0)
-    when: "add thread scopes without triggering cleanup"
-    for (int i = 0; i < 100; ++i) {
-      Thread.start { sessionState.closeOnIteration(Mock(AgentScope)) }.join()
+    def started = new CountDownLatch(100)
+    def stopped = new CountDownLatch(1)
+    def sessionState = new SessionState(0)
+    def closingTimes = []
+    when: "add thread scopes without triggering eviction"
+    def workers = (1..100).collect {
+      def span = Mock(AgentSpan)
+      def scope = Mock(AgentScope)
+      def startMillis = it * 1000
+      scope.span() >> span
+      scope.close() >> { closingTimes += startMillis }
+      span.startTime >> startMillis
+      Thread.start {
+        sessionState.closeOnIteration(scope)
+        started.countDown()
+        stopped.await()
+      }
     }
-    then:
+    started.await()
+    then: "nothing has been closed yet"
     sessionState.activeScopeCount == 100
-    when: "trigger cleanup"
-    sessionState.closeOnIteration(Mock(AgentScope))
-    then:
+    closingTimes == []
+    when: "trigger eviction of oldest scopes"
+    (1..1).each { Thread.start { sessionState.closeOnIteration(Mock(AgentScope)) }.join() }
+    then: "ten oldest scopes should have been closed"
+    sessionState.activeScopeCount == 91
+    closingTimes as Set == (1..10).collect { it * 1000 } as Set
+    when: "trigger eviction of stopped workers"
+    stopped.countDown()
+    workers.each { it.join() }
+    (1..10).each { Thread.start { sessionState.closeOnIteration(Mock(AgentScope)) }.join() }
+    then: "all worker scopes should have been closed"
     sessionState.activeScopeCount == 1
+    closingTimes as Set == (1..100).collect { it * 1000 } as Set
+  }
+
+  def "stale time-in-queue spans are evicted from session"() {
+    setup:
+    def started = new CountDownLatch(100)
+    def stopped = new CountDownLatch(1)
+    def sessionState = new SessionState(0, false)
+    def finishingTimes = []
+    when: "add time-in-queue spans without triggering eviction"
+    def workers = (1..100).collect {
+      def span = Mock(AgentSpan)
+      def startMillis = it * 1000
+      span.finish() >> { finishingTimes += startMillis }
+      span.startTime >> startMillis
+      Thread.start {
+        sessionState.setTimeInQueueSpan(0, span)
+        started.countDown()
+        stopped.await()
+      }
+    }
+    started.await()
+    then: "nothing has been finished yet"
+    sessionState.timeInQueueSpanCount == 100
+    finishingTimes == []
+    when: "trigger eviction of oldest time-in-queue spans"
+    (1..1).each { Thread.start { sessionState.setTimeInQueueSpan(0, Mock(AgentSpan)) }.join() }
+    then: "ten oldest time-in-queue spans should have been finished"
+    sessionState.timeInQueueSpanCount == 91
+    finishingTimes as Set == (1..10).collect { it * 1000 } as Set
+    when: "trigger eviction of stopped workers"
+    stopped.countDown()
+    workers.each { it.join() }
+    (1..10).each { Thread.start { sessionState.setTimeInQueueSpan(0, Mock(AgentSpan)) }.join() }
+    then: "all worker time-in-queue spans should have been finished"
+    sessionState.timeInQueueSpanCount == 1
+    finishingTimes as Set == (1..100).collect { it * 1000 } as Set
   }
 }

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/DatadogMessageListener.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/DatadogMessageListener.java
@@ -55,6 +55,7 @@ public class DatadogMessageListener implements MessageListener {
         sessionState.finishOnCommit(span);
       } else { // Session.AUTO_ACKNOWLEDGE
         span.finish();
+        consumerState.finishTimeInQueueSpan(false);
       }
     }
   }

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSDecorator.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSDecorator.java
@@ -91,7 +91,7 @@ public final class JMSDecorator extends ClientDecorator {
 
   @Override
   protected String service() {
-    return "jms";
+    return serviceName;
   }
 
   @Override

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSDecorator.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSDecorator.java
@@ -2,13 +2,13 @@ package datadog.trace.instrumentation.jms;
 
 import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.RECORD_QUEUE_TIME_MS;
 
-import datadog.trace.api.DDSpanTypes;
 import datadog.trace.api.Function;
 import datadog.trace.api.Functions.Join;
 import datadog.trace.api.Functions.PrefixJoin;
 import datadog.trace.api.cache.DDCache;
 import datadog.trace.api.cache.DDCaches;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.ClientDecorator;
@@ -41,15 +41,17 @@ public final class JMSDecorator extends ClientDecorator {
   private final Function<CharSequence, CharSequence> topicResourceJoiner;
 
   private final String spanKind;
-  private final String spanType;
+  private final CharSequence spanType;
 
   public static final JMSDecorator PRODUCER_DECORATE =
-      new JMSDecorator("Produced for ", Tags.SPAN_KIND_PRODUCER, DDSpanTypes.MESSAGE_PRODUCER);
+      new JMSDecorator(
+          "Produced for ", Tags.SPAN_KIND_PRODUCER, InternalSpanTypes.MESSAGE_PRODUCER);
 
   public static final JMSDecorator CONSUMER_DECORATE =
-      new JMSDecorator("Consumed from ", Tags.SPAN_KIND_CONSUMER, DDSpanTypes.MESSAGE_CONSUMER);
+      new JMSDecorator(
+          "Consumed from ", Tags.SPAN_KIND_CONSUMER, InternalSpanTypes.MESSAGE_CONSUMER);
 
-  public JMSDecorator(String resourcePrefix, String spanKind, String spanType) {
+  public JMSDecorator(String resourcePrefix, String spanKind, CharSequence spanType) {
     this.resourcePrefix = resourcePrefix;
 
     this.queueTempResourceName = UTF8BytesString.create(resourcePrefix + "Temporary Queue");

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSDecorator.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSDecorator.java
@@ -55,7 +55,7 @@ public final class JMSDecorator extends ClientDecorator {
           "Produced for ",
           Tags.SPAN_KIND_PRODUCER,
           InternalSpanTypes.MESSAGE_PRODUCER,
-          Config.get().isJmsLegacyTracingEnabled() ? "jms" : Config.get().getServiceName());
+          Config.get().isJmsLegacyTracingEnabled() ? "jms" : null /* inherit service name */);
 
   public static final JMSDecorator CONSUMER_DECORATE =
       new JMSDecorator(
@@ -65,7 +65,11 @@ public final class JMSDecorator extends ClientDecorator {
           Config.get().isJmsLegacyTracingEnabled() ? "jms" : Config.get().getServiceName());
 
   public static final JMSDecorator BROKER_DECORATE =
-      new JMSDecorator("", Tags.SPAN_KIND_BROKER, DDSpanTypes.MESSAGE_BROKER, "jms");
+      new JMSDecorator(
+          "",
+          Tags.SPAN_KIND_BROKER,
+          DDSpanTypes.MESSAGE_BROKER,
+          null /* will be set per-queue or topic */);
 
   public JMSDecorator(
       String resourcePrefix, String spanKind, CharSequence spanType, String serviceName) {
@@ -129,8 +133,7 @@ public final class JMSDecorator extends ClientDecorator {
     }
   }
 
-  public void onTimeInQueue(
-      final AgentSpan span, final CharSequence resourceName, final String serviceName) {
+  public void onTimeInQueue(AgentSpan span, CharSequence resourceName, String serviceName) {
     if (null != resourceName) {
       span.setResourceName(resourceName);
     }

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSDecorator.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSDecorator.java
@@ -21,8 +21,11 @@ import javax.jms.Queue;
 import javax.jms.TemporaryQueue;
 import javax.jms.TemporaryTopic;
 import javax.jms.Topic;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class JMSDecorator extends ClientDecorator {
+  private static final Logger log = LoggerFactory.getLogger(JMSDecorator.class);
 
   public static final CharSequence JMS = UTF8BytesString.create("jms");
   public static final CharSequence JMS_CONSUME = UTF8BytesString.create("jms.consume");
@@ -115,7 +118,8 @@ public final class JMSDecorator extends ClientDecorator {
         final long consumeTime = TimeUnit.NANOSECONDS.toMillis(span.getStartTime());
         span.setTag(RECORD_QUEUE_TIME_MS, Math.max(0L, consumeTime - produceTime));
       }
-    } catch (Exception ignored) {
+    } catch (Exception e) {
+      log.debug("Unable to get jms timestamp", e);
     }
   }
 
@@ -166,7 +170,8 @@ public final class JMSDecorator extends ClientDecorator {
           name = ((Topic) destination).getTopicName();
         }
       }
-    } catch (Exception ignored) {
+    } catch (Exception e) {
+      log.debug("Unable to get jms destination name", e);
     }
     return null != name && !name.startsWith(TIBCO_TMP_PREFIX) ? name : null;
   }

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSDecorator.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSDecorator.java
@@ -164,12 +164,13 @@ public final class JMSDecorator extends ClientDecorator {
     String name = null;
     try {
       if (destination instanceof Queue) {
-        // WebLogic mixes all destination APIs in its JMS extension, so always use the name
+        // WebLogic mixes all JMS Destination interfaces in a single base type which means we can't
+        // rely on instanceof and have to instead check the result of getQueueName vs getTopicName
         if (!(destination instanceof TemporaryQueue) || isWebLogicDestination(destination)) {
           name = ((Queue) destination).getQueueName();
         }
       }
-      // handle WebLogic by falling back to the Topic name when the Queue name is missing
+      // check Topic name if Queue name is null because this might be a WebLogic destination
       if (null == name && destination instanceof Topic) {
         if (!(destination instanceof TemporaryTopic) || isWebLogicDestination(destination)) {
           name = ((Topic) destination).getTopicName();

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSDecorator.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSDecorator.java
@@ -191,6 +191,6 @@ public final class JMSDecorator extends ClientDecorator {
   }
 
   private static boolean isWebLogicDestination(Destination destination) {
-    return "weblogic.jms.common.DestinationImpl".equals(destination.getClass().getName());
+    return destination.getClass().getName().startsWith("weblogic.jms.common.");
   }
 }

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageConsumerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageConsumerInstrumentation.java
@@ -96,6 +96,10 @@ public final class JMSMessageConsumerInstrumentation extends Instrumenter.Tracin
       if (null != consumerState) {
         // closes the scope, and finishes the span for AUTO_ACKNOWLEDGE
         consumerState.closePreviousMessageScope();
+        if (consumerState.getSessionState().isAutoAcknowledge()) {
+          // likewise, finish any AUTO_ACKNOWLEDGE'd time-in-queue span
+          consumerState.finishTimeInQueueSpan(false);
+        }
       }
     }
 
@@ -149,6 +153,7 @@ public final class JMSMessageConsumerInstrumentation extends Instrumenter.Tracin
               .get(consumer);
       if (null != consumerState) {
         consumerState.closePreviousMessageScope();
+        consumerState.finishTimeInQueueSpan(true);
       }
     }
   }

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageProducerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageProducerInstrumentation.java
@@ -99,6 +99,9 @@ public final class JMSMessageProducerInstrumentation extends Instrumenter.Tracin
       if (Config.get().isJMSPropagationEnabled() && !producerState.isPropagationDisabled()) {
         propagate().inject(span, message, SETTER);
       }
+      if (!Config.get().isJmsLegacyTracingEnabled()) {
+        SETTER.injectTimeInQueue(message, producerState.getSessionState());
+      }
       return activateSpan(span);
     }
 
@@ -121,9 +124,17 @@ public final class JMSMessageProducerInstrumentation extends Instrumenter.Tracin
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static AgentScope beforeSend(
         @Advice.Argument(0) final Destination destination,
-        @Advice.Argument(1) final Message message) {
+        @Advice.Argument(1) final Message message,
+        @Advice.This final MessageProducer producer) {
       final int callDepth = CallDepthThreadLocalMap.incrementCallDepth(MessageProducer.class);
       if (callDepth > 0) {
+        return null;
+      }
+
+      MessageProducerState producerState =
+          InstrumentationContext.get(MessageProducer.class, MessageProducerState.class)
+              .get(producer);
+      if (null == producerState) {
         return null;
       }
 
@@ -137,6 +148,9 @@ public final class JMSMessageProducerInstrumentation extends Instrumenter.Tracin
       if (Config.get().isJMSPropagationEnabled()
           && !Config.get().isJMSPropagationDisabledForDestination(destinationName)) {
         propagate().inject(span, message, SETTER);
+      }
+      if (!Config.get().isJmsLegacyTracingEnabled()) {
+        SETTER.injectTimeInQueue(message, producerState.getSessionState());
       }
       return activateSpan(span);
     }

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageProducerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageProducerInstrumentation.java
@@ -100,7 +100,7 @@ public final class JMSMessageProducerInstrumentation extends Instrumenter.Tracin
         propagate().inject(span, message, SETTER);
       }
       if (!Config.get().isJmsLegacyTracingEnabled()) {
-        SETTER.injectTimeInQueue(message, producerState.getSessionState());
+        SETTER.injectTimeInQueue(message, producerState);
       }
       return activateSpan(span);
     }
@@ -150,7 +150,7 @@ public final class JMSMessageProducerInstrumentation extends Instrumenter.Tracin
         propagate().inject(span, message, SETTER);
       }
       if (!Config.get().isJmsLegacyTracingEnabled()) {
-        SETTER.injectTimeInQueue(message, producerState.getSessionState());
+        SETTER.injectTimeInQueue(message, producerState);
       }
       return activateSpan(span);
     }

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageProducerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageProducerInstrumentation.java
@@ -25,7 +25,6 @@ import java.util.Map;
 import javax.jms.Destination;
 import javax.jms.Message;
 import javax.jms.MessageProducer;
-import javax.jms.Queue;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
@@ -138,9 +137,9 @@ public final class JMSMessageProducerInstrumentation extends Instrumenter.Tracin
         return null;
       }
 
+      boolean isQueue = PRODUCER_DECORATE.isQueue(destination);
       String destinationName = PRODUCER_DECORATE.getDestinationName(destination);
-      CharSequence resourceName =
-          PRODUCER_DECORATE.toResourceName(destinationName, destination instanceof Queue);
+      CharSequence resourceName = PRODUCER_DECORATE.toResourceName(destinationName, isQueue);
 
       final AgentSpan span = startSpan(JMS_PRODUCE);
       PRODUCER_DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/MessageExtractAdapter.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/MessageExtractAdapter.java
@@ -11,8 +11,11 @@ import de.thetaphi.forbiddenapis.SuppressForbidden;
 import java.util.Enumeration;
 import javax.jms.JMSException;
 import javax.jms.Message;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class MessageExtractAdapter implements AgentPropagation.ContextVisitor<Message> {
+  private static final Logger log = LoggerFactory.getLogger(MessageExtractAdapter.class);
 
   private static final Function<String, String> KEY_MAPPER =
       new Function<String, String>() {
@@ -51,7 +54,8 @@ public final class MessageExtractAdapter implements AgentPropagation.ContextVisi
       if (carrier.propertyExists(JMS_PRODUCED_KEY)) {
         return carrier.getLongProperty(JMS_PRODUCED_KEY);
       }
-    } catch (Exception ignored) {
+    } catch (Exception e) {
+      log.debug("Unable to get jms produced time", e);
     }
     return 0;
   }
@@ -61,7 +65,8 @@ public final class MessageExtractAdapter implements AgentPropagation.ContextVisi
       if (carrier.propertyExists(JMS_BATCH_ID_KEY)) {
         return carrier.getLongProperty(JMS_BATCH_ID_KEY);
       }
-    } catch (Exception ignored) {
+    } catch (Exception e) {
+      log.debug("Unable to get jms batch id", e);
     }
     return 0;
   }

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/MessageExtractAdapter.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/MessageExtractAdapter.java
@@ -1,5 +1,8 @@
 package datadog.trace.instrumentation.jms;
 
+import static datadog.trace.instrumentation.jms.MessageInjectAdapter.JMS_BATCH_ID_KEY;
+import static datadog.trace.instrumentation.jms.MessageInjectAdapter.JMS_PRODUCED_KEY;
+
 import datadog.trace.api.Function;
 import datadog.trace.api.cache.DDCache;
 import datadog.trace.api.cache.DDCaches;
@@ -41,5 +44,25 @@ public final class MessageExtractAdapter implements AgentPropagation.ContextVisi
     } catch (JMSException e) {
       throw new RuntimeException(e);
     }
+  }
+
+  public long extractTimeInQueueStart(final Message carrier) {
+    try {
+      if (carrier.propertyExists(JMS_PRODUCED_KEY)) {
+        return carrier.getLongProperty(JMS_PRODUCED_KEY);
+      }
+    } catch (Exception ignored) {
+    }
+    return 0;
+  }
+
+  public long extractMessageBatchId(final Message carrier) {
+    try {
+      if (carrier.propertyExists(JMS_BATCH_ID_KEY)) {
+        return carrier.getLongProperty(JMS_BATCH_ID_KEY);
+      }
+    } catch (Exception ignored) {
+    }
+    return 0;
   }
 }

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/MessageInjectAdapter.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/MessageInjectAdapter.java
@@ -2,7 +2,7 @@ package datadog.trace.instrumentation.jms;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.jms.MessageBatchState;
-import datadog.trace.bootstrap.instrumentation.jms.SessionState;
+import datadog.trace.bootstrap.instrumentation.jms.MessageProducerState;
 import de.thetaphi.forbiddenapis.SuppressForbidden;
 import javax.jms.Message;
 import org.slf4j.Logger;
@@ -29,10 +29,10 @@ public class MessageInjectAdapter implements AgentPropagation.Setter<Message> {
     }
   }
 
-  public void injectTimeInQueue(final Message carrier, final SessionState sessionState) {
+  public void injectTimeInQueue(final Message carrier, final MessageProducerState producerState) {
     try {
-      if (sessionState.isTransactedSession()) {
-        MessageBatchState batchState = sessionState.currentBatchState();
+      if (producerState.getSessionState().isTransactedSession()) {
+        MessageBatchState batchState = producerState.currentBatchState();
         carrier.setLongProperty(JMS_BATCH_ID_KEY, batchState.getBatchId());
         carrier.setLongProperty(JMS_PRODUCED_KEY, batchState.getStartMillis());
       } else {

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/MessageInjectAdapter.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/MessageInjectAdapter.java
@@ -23,9 +23,7 @@ public class MessageInjectAdapter implements AgentPropagation.Setter<Message> {
     try {
       carrier.setStringProperty(propName, value);
     } catch (Exception e) {
-      if (log.isDebugEnabled()) {
-        log.debug("Failure setting jms property: " + propName, e);
-      }
+      log.debug("Failure setting jms property: {}", propName, e);
     }
   }
 
@@ -38,7 +36,8 @@ public class MessageInjectAdapter implements AgentPropagation.Setter<Message> {
       } else {
         carrier.setLongProperty(JMS_PRODUCED_KEY, System.currentTimeMillis());
       }
-    } catch (Exception ignored) {
+    } catch (Exception e) {
+      log.debug("Failure setting jms batch details", e);
     }
   }
 }

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/MessageInjectAdapter.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/MessageInjectAdapter.java
@@ -1,6 +1,8 @@
 package datadog.trace.instrumentation.jms;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
+import datadog.trace.bootstrap.instrumentation.jms.MessageBatchState;
+import datadog.trace.bootstrap.instrumentation.jms.SessionState;
 import de.thetaphi.forbiddenapis.SuppressForbidden;
 import javax.jms.Message;
 import org.slf4j.Logger;
@@ -10,6 +12,9 @@ public class MessageInjectAdapter implements AgentPropagation.Setter<Message> {
   private static final Logger log = LoggerFactory.getLogger(MessageInjectAdapter.class);
 
   public static final MessageInjectAdapter SETTER = new MessageInjectAdapter();
+
+  public static final String JMS_PRODUCED_KEY = "x_datadog_jms_produced";
+  public static final String JMS_BATCH_ID_KEY = "x_datadog_jms_batch_id";
 
   @SuppressForbidden
   @Override
@@ -21,6 +26,19 @@ public class MessageInjectAdapter implements AgentPropagation.Setter<Message> {
       if (log.isDebugEnabled()) {
         log.debug("Failure setting jms property: " + propName, e);
       }
+    }
+  }
+
+  public void injectTimeInQueue(final Message carrier, final SessionState sessionState) {
+    try {
+      if (sessionState.isTransactedSession()) {
+        MessageBatchState batchState = sessionState.currentBatchState();
+        carrier.setLongProperty(JMS_BATCH_ID_KEY, batchState.getBatchId());
+        carrier.setLongProperty(JMS_PRODUCED_KEY, batchState.getStartMillis());
+      } else {
+        carrier.setLongProperty(JMS_PRODUCED_KEY, System.currentTimeMillis());
+      }
+    } catch (Exception ignored) {
     }
   }
 }

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/SessionInstrumentation.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/SessionInstrumentation.java
@@ -25,7 +25,6 @@ import java.util.Map;
 import javax.jms.Destination;
 import javax.jms.MessageConsumer;
 import javax.jms.MessageProducer;
-import javax.jms.Queue;
 import javax.jms.Session;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
@@ -108,7 +107,7 @@ public class SessionInstrumentation extends Instrumenter.Tracing {
           sessionState = sessionStateStore.putIfAbsent(session, new SessionState(ackMode));
         }
 
-        boolean isQueue = null == destination || destination instanceof Queue;
+        boolean isQueue = PRODUCER_DECORATE.isQueue(destination);
         String destinationName = PRODUCER_DECORATE.getDestinationName(destination);
         CharSequence resourceName = PRODUCER_DECORATE.toResourceName(destinationName, isQueue);
 
@@ -147,7 +146,7 @@ public class SessionInstrumentation extends Instrumenter.Tracing {
           sessionState = sessionStateStore.putIfAbsent(session, new SessionState(ackMode));
         }
 
-        boolean isQueue = null == destination || destination instanceof Queue;
+        boolean isQueue = CONSUMER_DECORATE.isQueue(destination);
         String destinationName = CONSUMER_DECORATE.getDestinationName(destination);
         CharSequence brokerResourceName =
             Config.get().isJmsLegacyTracingEnabled()

--- a/dd-java-agent/instrumentation/jms/src/test/groovy/TimeInQueueForkedTest.groovy
+++ b/dd-java-agent/instrumentation/jms/src/test/groovy/TimeInQueueForkedTest.groovy
@@ -1,0 +1,349 @@
+import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.agent.test.asserts.ListWriterAssert
+import datadog.trace.agent.test.asserts.TraceAssert
+import datadog.trace.api.DDSpanTypes
+import datadog.trace.api.config.GeneralConfig
+import datadog.trace.api.config.TraceInstrumentationConfig
+import datadog.trace.bootstrap.instrumentation.api.InstrumentationTags
+import datadog.trace.bootstrap.instrumentation.api.Tags
+import datadog.trace.core.DDSpan
+import org.apache.activemq.junit.EmbeddedActiveMQBroker
+import spock.lang.Shared
+
+import javax.jms.Connection
+import javax.jms.Session
+import javax.jms.TextMessage
+
+class TimeInQueueForkedTest extends AgentTestRunner {
+  @Shared
+  EmbeddedActiveMQBroker broker = new EmbeddedActiveMQBroker()
+  @Shared
+  Connection connection
+  @Shared
+  Session session
+  @Shared
+  String messageText1 = "a message"
+  @Shared
+  String messageText2 = "another message"
+  @Shared
+  String messageText3 = "yet another message"
+  @Shared
+  String messageText4 = "another message again"
+  @Shared
+  String messageText5 = "just one more message"
+
+  TextMessage message1 = session.createTextMessage(messageText1)
+  TextMessage message2 = session.createTextMessage(messageText2)
+  TextMessage message3 = session.createTextMessage(messageText3)
+  TextMessage message4 = session.createTextMessage(messageText4)
+  TextMessage message5 = session.createTextMessage(messageText5)
+
+  @Override
+  protected void configurePreAgent() {
+    injectSysConfig(TraceInstrumentationConfig.JMS_LEGACY_TRACING_ENABLED, 'false')
+    injectSysConfig(GeneralConfig.SERVICE_NAME, 'myService')
+  }
+
+  def setupSpec() {
+    broker.start()
+    connection = broker.createConnectionFactory().createConnection()
+    connection.start()
+    session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE)
+  }
+
+  def cleanupSpec() {
+    broker.stop()
+  }
+
+  def "sending messages to #jmsResourceName generates time-in-queue spans"() {
+    setup:
+    def producerSession = connection.createSession(false, Session.AUTO_ACKNOWLEDGE)
+    def producer = producerSession.createProducer(destination)
+    def consumerSession = connection.createSession(false, Session.AUTO_ACKNOWLEDGE)
+    def consumer = consumerSession.createConsumer(destination)
+
+    when:
+    producer.send(message1)
+    producer.send(message2)
+    producer.send(message3)
+    producer.send(message4)
+    producer.send(message5)
+
+    def receivedMessage1 = consumer.receive()
+    def receivedMessage2 = consumer.receive()
+    def receivedMessage3 = consumer.receive()
+    def receivedMessage4 = consumer.receive()
+    def receivedMessage5 = consumer.receive()
+
+    then:
+    receivedMessage1.text == messageText1
+    receivedMessage2.text == messageText2
+    receivedMessage3.text == messageText3
+    receivedMessage4.text == messageText4
+    receivedMessage5.text == messageText5
+    // only four consume traces will be finished at this point
+    assertTraces(9) {
+      producerTrace(it, jmsResourceName)
+      producerTrace(it, jmsResourceName)
+      producerTrace(it, jmsResourceName)
+      producerTrace(it, jmsResourceName)
+      producerTrace(it, jmsResourceName)
+      consumerTrace(it, jmsResourceName, trace(0)[0])
+      consumerTrace(it, jmsResourceName, trace(1)[0])
+      consumerTrace(it, jmsResourceName, trace(2)[0])
+      consumerTrace(it, jmsResourceName, trace(3)[0])
+    }
+
+    when:
+    consumer.receiveNoWait()
+
+    then:
+    // now the last consume trace will also be finished
+    assertTraces(10) {
+      producerTrace(it, jmsResourceName)
+      producerTrace(it, jmsResourceName)
+      producerTrace(it, jmsResourceName)
+      producerTrace(it, jmsResourceName)
+      producerTrace(it, jmsResourceName)
+      consumerTrace(it, jmsResourceName, trace(0)[0])
+      consumerTrace(it, jmsResourceName, trace(1)[0])
+      consumerTrace(it, jmsResourceName, trace(2)[0])
+      consumerTrace(it, jmsResourceName, trace(3)[0])
+      consumerTrace(it, jmsResourceName, trace(4)[0])
+    }
+
+    cleanup:
+    producerSession.close()
+    consumerSession.close()
+
+    where:
+    destination                              | jmsResourceName
+    session.createQueue("someQueue") | "Queue someQueue"
+    session.createTopic("someTopic") | "Topic someTopic"
+    session.createTemporaryQueue()   | "Temporary Queue"
+    session.createTemporaryTopic()   | "Temporary Topic"
+  }
+
+  def "sending messages to #jmsResourceName with manual acknowledgement generates time-in-queue spans"() {
+    setup:
+    def producerSession = connection.createSession(false, Session.AUTO_ACKNOWLEDGE)
+    def producer = producerSession.createProducer(destination)
+    def consumerSession = connection.createSession(false, Session.CLIENT_ACKNOWLEDGE)
+    def consumer = consumerSession.createConsumer(destination)
+
+    when:
+    producer.send(message1)
+    producer.send(message2)
+    producer.send(message3)
+    producer.send(message4)
+    producer.send(message5)
+
+    def receivedMessage1 = consumer.receive()
+    def receivedMessage2 = consumer.receive()
+    def receivedMessage3 = consumer.receive()
+    receivedMessage2.acknowledge()
+    def receivedMessage4 = consumer.receive()
+    def receivedMessage5 = consumer.receive()
+
+    then:
+    receivedMessage1.text == messageText1
+    receivedMessage2.text == messageText2
+    receivedMessage3.text == messageText3
+    receivedMessage4.text == messageText4
+    receivedMessage5.text == messageText5
+    // only three consume traces will be finished at this point
+    assertTraces(6) {
+      producerTrace(it, jmsResourceName)
+      producerTrace(it, jmsResourceName)
+      producerTrace(it, jmsResourceName)
+      producerTrace(it, jmsResourceName)
+      producerTrace(it, jmsResourceName)
+      trace(4) {
+        timeInQueueSpan(it, jmsResourceName, trace(0)[0])
+        consumerSpan(it, jmsResourceName, trace(5)[0], false)
+        consumerSpan(it, jmsResourceName, trace(5)[0], false)
+        consumerSpan(it, jmsResourceName, trace(5)[0], false)
+      }
+    }
+
+    when:
+    receivedMessage5.acknowledge()
+
+    then:
+    // now the other consume traces will be finished
+    assertTraces(7) {
+      producerTrace(it, jmsResourceName)
+      producerTrace(it, jmsResourceName)
+      producerTrace(it, jmsResourceName)
+      producerTrace(it, jmsResourceName)
+      producerTrace(it, jmsResourceName)
+      trace(4) {
+        timeInQueueSpan(it, jmsResourceName, trace(0)[0])
+        consumerSpan(it, jmsResourceName, trace(5)[0], false)
+        consumerSpan(it, jmsResourceName, trace(5)[0], false)
+        consumerSpan(it, jmsResourceName, trace(5)[0], false)
+      }
+      trace(3) {
+        timeInQueueSpan(it, jmsResourceName, trace(3)[0])
+        consumerSpan(it, jmsResourceName, trace(6)[0], false)
+        consumerSpan(it, jmsResourceName, trace(6)[0], false)
+      }
+    }
+
+    cleanup:
+    producerSession.close()
+    consumerSession.close()
+
+    where:
+    destination                              | jmsResourceName
+    session.createQueue("someQueue") | "Queue someQueue"
+    session.createTopic("someTopic") | "Topic someTopic"
+    session.createTemporaryQueue()   | "Temporary Queue"
+    session.createTemporaryTopic()   | "Temporary Topic"
+  }
+
+  def "sending messages to #jmsResourceName with transacted acknowledgement generates time-in-queue spans"() {
+    setup:
+    def producerSession = connection.createSession(false, Session.AUTO_ACKNOWLEDGE)
+    def producer = producerSession.createProducer(destination)
+    def consumerSession = connection.createSession(true, Session.SESSION_TRANSACTED)
+    def consumer = consumerSession.createConsumer(destination)
+
+    when:
+    producer.send(message1)
+    producer.send(message2)
+    producer.send(message3)
+    producer.send(message4)
+    producer.send(message5)
+
+    def receivedMessage1 = consumer.receive()
+    def receivedMessage2 = consumer.receive()
+    consumerSession.commit()
+    def receivedMessage3 = consumer.receive()
+    def receivedMessage4 = consumer.receive()
+    def receivedMessage5 = consumer.receive()
+
+    then:
+    receivedMessage1.text == messageText1
+    receivedMessage2.text == messageText2
+    receivedMessage3.text == messageText3
+    receivedMessage4.text == messageText4
+    receivedMessage5.text == messageText5
+    // only two consume traces will be finished at this point
+    assertTraces(6) {
+      producerTrace(it, jmsResourceName)
+      producerTrace(it, jmsResourceName)
+      producerTrace(it, jmsResourceName)
+      producerTrace(it, jmsResourceName)
+      producerTrace(it, jmsResourceName)
+      trace(3) {
+        timeInQueueSpan(it, jmsResourceName, trace(0)[0])
+        consumerSpan(it, jmsResourceName, trace(5)[0], false)
+        consumerSpan(it, jmsResourceName, trace(5)[0], false)
+      }
+    }
+
+    when:
+    consumerSession.commit()
+
+    then:
+    // now the other consume traces will be finished
+    assertTraces(7) {
+      producerTrace(it, jmsResourceName)
+      producerTrace(it, jmsResourceName)
+      producerTrace(it, jmsResourceName)
+      producerTrace(it, jmsResourceName)
+      producerTrace(it, jmsResourceName)
+      trace(3) {
+        timeInQueueSpan(it, jmsResourceName, trace(0)[0])
+        consumerSpan(it, jmsResourceName, trace(5)[0], false)
+        consumerSpan(it, jmsResourceName, trace(5)[0], false)
+      }
+      trace(4) {
+        timeInQueueSpan(it, jmsResourceName, trace(2)[0])
+        consumerSpan(it, jmsResourceName, trace(6)[0], false)
+        consumerSpan(it, jmsResourceName, trace(6)[0], false)
+        consumerSpan(it, jmsResourceName, trace(6)[0], false)
+      }
+    }
+
+    cleanup:
+    producerSession.close()
+    consumerSession.close()
+
+    where:
+    destination                              | jmsResourceName
+    session.createQueue("someQueue") | "Queue someQueue"
+    session.createTopic("someTopic") | "Topic someTopic"
+    session.createTemporaryQueue()   | "Temporary Queue"
+    session.createTemporaryTopic()   | "Temporary Topic"
+  }
+
+  static producerTrace(ListWriterAssert writer, String jmsResourceName) {
+    writer.trace(1) {
+      producerSpan(it, jmsResourceName)
+    }
+  }
+
+  static producerSpan(TraceAssert traceAssert, String jmsResourceName) {
+    return traceAssert.span {
+      serviceName "myService"
+      operationName "jms.produce"
+      resourceName "Produced for $jmsResourceName"
+      spanType DDSpanTypes.MESSAGE_PRODUCER
+      errored false
+      measured true
+      parent()
+
+      tags {
+        "$Tags.COMPONENT" "jms"
+        "$Tags.SPAN_KIND" Tags.SPAN_KIND_PRODUCER
+        defaultTags()
+      }
+    }
+  }
+
+  static consumerTrace(ListWriterAssert writer, String jmsResourceName, DDSpan parentSpan, boolean isTimestampDisabled = false) {
+    writer.trace(2) {
+      timeInQueueSpan(it, jmsResourceName, parentSpan)
+      consumerSpan(it, jmsResourceName, span(0), isTimestampDisabled)
+    }
+  }
+
+  static consumerSpan(TraceAssert traceAssert, String jmsResourceName, DDSpan parentSpan, boolean isTimestampDisabled = false) {
+    return traceAssert.span {
+      serviceName "myService"
+      operationName "jms.consume"
+      resourceName "Consumed from $jmsResourceName"
+      spanType DDSpanTypes.MESSAGE_CONSUMER
+      errored false
+      measured true
+      childOf parentSpan
+
+      tags {
+        "$Tags.COMPONENT" "jms"
+        "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
+        if (!isTimestampDisabled) {
+          "$InstrumentationTags.RECORD_QUEUE_TIME_MS" { it >= 0 }
+        }
+        defaultTags(false)
+      }
+    }
+  }
+
+  static timeInQueueSpan(TraceAssert traceAssert, String jmsResourceName, DDSpan parentSpan) {
+    return traceAssert.span {
+      serviceName "${jmsResourceName.replaceFirst(/(Queue |Topic )/,'')}"
+      operationName "jms.deliver"
+      resourceName "$jmsResourceName"
+      spanType DDSpanTypes.MESSAGE_BROKER
+      errored false
+      childOf parentSpan
+      tags {
+        "$Tags.COMPONENT" "jms"
+        "$Tags.SPAN_KIND" Tags.SPAN_KIND_BROKER
+        defaultTags(true)
+      }
+    }
+  }
+}

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
@@ -46,6 +46,7 @@ public final class TraceInstrumentationConfig {
   public static final String KAFKA_CLIENT_BASE64_DECODING_ENABLED =
       "kafka.client.base64.decoding.enabled";
 
+  public static final String JMS_LEGACY_TRACING_ENABLED = "jms.legacy.tracing.enabled";
   public static final String JMS_PROPAGATION_ENABLED = "jms.propagation.enabled";
   public static final String JMS_PROPAGATION_DISABLED_TOPICS = "jms.propagation.disabled.topics";
   public static final String JMS_PROPAGATION_DISABLED_QUEUES = "jms.propagation.disabled.queues";

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -145,6 +145,7 @@ import static datadog.trace.api.config.TraceInstrumentationConfig.IGNITE_CACHE_I
 import static datadog.trace.api.config.TraceInstrumentationConfig.INTEGRATIONS_ENABLED;
 import static datadog.trace.api.config.TraceInstrumentationConfig.JDBC_CONNECTION_CLASS_NAME;
 import static datadog.trace.api.config.TraceInstrumentationConfig.JDBC_PREPARED_STATEMENT_CLASS_NAME;
+import static datadog.trace.api.config.TraceInstrumentationConfig.JMS_LEGACY_TRACING_ENABLED;
 import static datadog.trace.api.config.TraceInstrumentationConfig.JMS_PROPAGATION_DISABLED_QUEUES;
 import static datadog.trace.api.config.TraceInstrumentationConfig.JMS_PROPAGATION_DISABLED_TOPICS;
 import static datadog.trace.api.config.TraceInstrumentationConfig.JMS_PROPAGATION_ENABLED;
@@ -393,6 +394,7 @@ public class Config {
   private final Set<String> kafkaClientPropagationDisabledTopics;
   private final boolean kafkaClientBase64DecodingEnabled;
 
+  private final boolean jmsLegacyTracingEnabled;
   private final boolean jmsPropagationEnabled;
   private final Set<String> jmsPropagationDisabledTopics;
   private final Set<String> jmsPropagationDisabledQueues;
@@ -821,6 +823,8 @@ public class Config {
 
     kafkaClientBase64DecodingEnabled =
         configProvider.getBoolean(KAFKA_CLIENT_BASE64_DECODING_ENABLED, false);
+
+    jmsLegacyTracingEnabled = configProvider.getBoolean(JMS_LEGACY_TRACING_ENABLED, true);
 
     jmsPropagationEnabled =
         configProvider.getBoolean(JMS_PROPAGATION_ENABLED, DEFAULT_JMS_PROPAGATION_ENABLED);
@@ -1274,6 +1278,10 @@ public class Config {
 
   public boolean isKafkaClientPropagationDisabledForTopic(String topic) {
     return null != topic && kafkaClientPropagationDisabledTopics.contains(topic);
+  }
+
+  public boolean isJmsLegacyTracingEnabled() {
+    return jmsLegacyTracingEnabled;
   }
 
   public boolean isJMSPropagationEnabled() {
@@ -2037,6 +2045,8 @@ public class Config {
         + kafkaClientPropagationDisabledTopics
         + ", kafkaClientBase64DecodingEnabled="
         + kafkaClientBase64DecodingEnabled
+        + ", jmsLegacyTracingEnabled="
+        + jmsLegacyTracingEnabled
         + ", jmsPropagationEnabled="
         + jmsPropagationEnabled
         + ", jmsPropagationDisabledTopics="


### PR DESCRIPTION
To enable the new “time-in-queue” feature set the following system property to turn off the legacy JMS mode:
```
-Ddd.jms.legacy.tracing.enabled=false
```
or alternatively set this environment variable:
```
DD_JMS_LEGACY_TRACING_ENABLED=false
```
When legacy mode is off you should see JMS queues/topics appear in the service map, with connections to the services that use them.