### PR TITLE
[CIAPP] Allow setting manual Git information via env vars

### DIFF
--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/ci/CIProviderInfo.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/ci/CIProviderInfo.java
@@ -212,212 +212,171 @@ public abstract class CIProviderInfo {
 
     public CITagsBuilder withGitRepositoryUrl(
         final GitInfo userSuppliedGitInfo, final GitInfo ciGitInfo, final GitInfo localGitInfo) {
-      if (userSuppliedGitInfo.getRepositoryURL() != null) {
-        return this.putTagValue(Tags.GIT_REPOSITORY_URL, userSuppliedGitInfo.getRepositoryURL());
-      } else {
-        return this.putTagValue(
-            Tags.GIT_REPOSITORY_URL, ciGitInfo.getRepositoryURL(), localGitInfo.getRepositoryURL());
-      }
+      return this.putTagValue(
+          Tags.GIT_REPOSITORY_URL,
+          userSuppliedGitInfo.getRepositoryURL(),
+          ciGitInfo.getRepositoryURL(),
+          localGitInfo.getRepositoryURL());
     }
 
     public CITagsBuilder withGitCommit(
         final GitInfo userSuppliedGitInfo, final GitInfo ciGitInfo, final GitInfo localGitInfo) {
-      if (userSuppliedGitInfo.getCommit().getSha() != null) {
-        return this.putTagValue(Tags.GIT_COMMIT_SHA, userSuppliedGitInfo.getCommit().getSha());
-      } else {
-        return this.putTagValue(
-            Tags.GIT_COMMIT_SHA, ciGitInfo.getCommit().getSha(), localGitInfo.getCommit().getSha());
-      }
+      return this.putTagValue(
+          Tags.GIT_COMMIT_SHA,
+          userSuppliedGitInfo.getCommit().getSha(),
+          ciGitInfo.getCommit().getSha(),
+          localGitInfo.getCommit().getSha());
     }
 
     public CITagsBuilder withGitBranch(
         final GitInfo userSuppliedGitInfo, final GitInfo ciGitInfo, final GitInfo localGitInfo) {
-      if (userSuppliedGitInfo.getBranch() != null) {
-        return this.putTagValue(Tags.GIT_BRANCH, userSuppliedGitInfo.getBranch());
-      } else {
-        return this.putTagValue(Tags.GIT_BRANCH, ciGitInfo.getBranch(), localGitInfo.getBranch());
-      }
+      return this.putTagValue(
+          Tags.GIT_BRANCH,
+          userSuppliedGitInfo.getBranch(),
+          ciGitInfo.getBranch(),
+          localGitInfo.getBranch());
     }
 
     public CITagsBuilder withGitTag(
         final GitInfo userSuppliedGitInfo, final GitInfo ciGitInfo, final GitInfo localGitInfo) {
-      if (userSuppliedGitInfo.getTag() != null) {
-        return this.putTagValue(Tags.GIT_TAG, userSuppliedGitInfo.getTag());
-      } else {
-        return this.putTagValue(Tags.GIT_TAG, ciGitInfo.getTag(), localGitInfo.getTag());
-      }
+      return this.putTagValue(
+          Tags.GIT_TAG, userSuppliedGitInfo.getTag(), ciGitInfo.getTag(), localGitInfo.getTag());
     }
 
     public CITagsBuilder withGitCommitAuthorName(
         final GitInfo userSuppliedGitInfo, final GitInfo ciGitInfo, final GitInfo localGitInfo) {
-
-      if (userSuppliedGitInfo.getCommit().getAuthor().getName() != null) {
-        this.putTagValue(
-            Tags.GIT_COMMIT_AUTHOR_NAME, userSuppliedGitInfo.getCommit().getAuthor().getName());
-        return this;
-      } else if (ciGitInfo.getCommit().getAuthor().getName() != null) {
-        this.putTagValue(Tags.GIT_COMMIT_AUTHOR_NAME, ciGitInfo.getCommit().getAuthor().getName());
-        return this;
-      }
-
-      return this.putTagValueIfCommitEquals(
+      final String userSuppliedGitAuthorName =
+          userSuppliedGitInfo.getCommit().getAuthor().getName();
+      final String ciGitAuthorName = ciGitInfo.getCommit().getAuthor().getName();
+      final String localGitAuthorName =
+          isCommitShaEquals(ciGitInfo, localGitInfo)
+              ? localGitInfo.getCommit().getAuthor().getName()
+              : null;
+      return this.putTagValue(
           Tags.GIT_COMMIT_AUTHOR_NAME,
-          ciGitInfo.getCommit().getSha(),
-          localGitInfo.getCommit().getSha(),
-          localGitInfo.getCommit().getAuthor().getName());
+          userSuppliedGitAuthorName,
+          ciGitAuthorName,
+          localGitAuthorName);
     }
 
     public CITagsBuilder withGitCommitAuthorEmail(
         final GitInfo userSuppliedGitInfo, final GitInfo ciGitInfo, final GitInfo localGitInfo) {
-
-      if (userSuppliedGitInfo.getCommit().getAuthor().getEmail() != null) {
-        this.putTagValue(
-            Tags.GIT_COMMIT_AUTHOR_EMAIL, userSuppliedGitInfo.getCommit().getAuthor().getEmail());
-        return this;
-      } else if (ciGitInfo.getCommit().getAuthor().getEmail() != null) {
-        this.putTagValue(
-            Tags.GIT_COMMIT_AUTHOR_EMAIL, ciGitInfo.getCommit().getAuthor().getEmail());
-        return this;
-      }
-
-      return this.putTagValueIfCommitEquals(
+      final String userSuppliedGitAuthorEmail =
+          userSuppliedGitInfo.getCommit().getAuthor().getEmail();
+      final String ciGitAuthorEmail = ciGitInfo.getCommit().getAuthor().getEmail();
+      final String localGitAuthorEmail =
+          isCommitShaEquals(ciGitInfo, localGitInfo)
+              ? localGitInfo.getCommit().getAuthor().getName()
+              : null;
+      return this.putTagValue(
           Tags.GIT_COMMIT_AUTHOR_EMAIL,
-          ciGitInfo.getCommit().getSha(),
-          localGitInfo.getCommit().getSha(),
-          localGitInfo.getCommit().getAuthor().getEmail());
+          userSuppliedGitAuthorEmail,
+          ciGitAuthorEmail,
+          localGitAuthorEmail);
     }
 
     public CITagsBuilder withGitCommitAuthorDate(
         final GitInfo userSuppliedGitInfo, final GitInfo ciGitInfo, final GitInfo localGitInfo) {
-
-      if (userSuppliedGitInfo.getCommit().getAuthor().getISO8601Date() != null) {
-        this.putTagValue(
-            Tags.GIT_COMMIT_AUTHOR_DATE,
-            userSuppliedGitInfo.getCommit().getAuthor().getISO8601Date());
-        return this;
-      } else if (ciGitInfo.getCommit().getAuthor().getISO8601Date() != null) {
-        this.putTagValue(
-            Tags.GIT_COMMIT_AUTHOR_DATE, ciGitInfo.getCommit().getAuthor().getISO8601Date());
-        return this;
-      }
-
-      return this.putTagValueIfCommitEquals(
+      final String userSuppliedGitAuthorDate =
+          userSuppliedGitInfo.getCommit().getAuthor().getISO8601Date();
+      final String ciGitAuthorDate = ciGitInfo.getCommit().getAuthor().getISO8601Date();
+      final String localGitAuthorDate =
+          isCommitShaEquals(ciGitInfo, localGitInfo)
+              ? localGitInfo.getCommit().getAuthor().getISO8601Date()
+              : null;
+      return this.putTagValue(
           Tags.GIT_COMMIT_AUTHOR_DATE,
-          ciGitInfo.getCommit().getSha(),
-          localGitInfo.getCommit().getSha(),
-          localGitInfo.getCommit().getAuthor().getISO8601Date());
+          userSuppliedGitAuthorDate,
+          ciGitAuthorDate,
+          localGitAuthorDate);
     }
 
     public CITagsBuilder withGitCommitCommitterName(
         final GitInfo userSuppliedGitInfo, final GitInfo ciGitInfo, final GitInfo localGitInfo) {
-
-      if (userSuppliedGitInfo.getCommit().getCommitter().getName() != null) {
-        this.putTagValue(
-            Tags.GIT_COMMIT_COMMITTER_NAME,
-            userSuppliedGitInfo.getCommit().getCommitter().getName());
-        return this;
-      } else if (ciGitInfo.getCommit().getCommitter().getName() != null) {
-        this.putTagValue(
-            Tags.GIT_COMMIT_COMMITTER_NAME, ciGitInfo.getCommit().getCommitter().getName());
-        return this;
-      }
-
-      return this.putTagValueIfCommitEquals(
+      final String userSuppliedGitCommitterName =
+          userSuppliedGitInfo.getCommit().getCommitter().getName();
+      final String ciGitCommitterName = ciGitInfo.getCommit().getCommitter().getName();
+      final String localGitCommitterName =
+          isCommitShaEquals(ciGitInfo, localGitInfo)
+              ? localGitInfo.getCommit().getCommitter().getName()
+              : null;
+      return this.putTagValue(
           Tags.GIT_COMMIT_COMMITTER_NAME,
-          ciGitInfo.getCommit().getSha(),
-          localGitInfo.getCommit().getSha(),
-          localGitInfo.getCommit().getCommitter().getName());
+          userSuppliedGitCommitterName,
+          ciGitCommitterName,
+          localGitCommitterName);
     }
 
     public CITagsBuilder withGitCommitCommitterEmail(
         final GitInfo userSuppliedGitInfo, final GitInfo ciGitInfo, final GitInfo localGitInfo) {
-
-      if (userSuppliedGitInfo.getCommit().getCommitter().getEmail() != null) {
-        this.putTagValue(
-            Tags.GIT_COMMIT_COMMITTER_EMAIL,
-            userSuppliedGitInfo.getCommit().getCommitter().getEmail());
-        return this;
-      } else if (ciGitInfo.getCommit().getCommitter().getEmail() != null) {
-        this.putTagValue(
-            Tags.GIT_COMMIT_COMMITTER_EMAIL, ciGitInfo.getCommit().getCommitter().getEmail());
-        return this;
-      }
-
-      return this.putTagValueIfCommitEquals(
+      final String userSuppliedGitCommitterEmail =
+          userSuppliedGitInfo.getCommit().getCommitter().getEmail();
+      final String ciGitCommitterEmail = ciGitInfo.getCommit().getCommitter().getEmail();
+      final String localCommitterEmail =
+          isCommitShaEquals(ciGitInfo, localGitInfo)
+              ? localGitInfo.getCommit().getCommitter().getEmail()
+              : null;
+      return this.putTagValue(
           Tags.GIT_COMMIT_COMMITTER_EMAIL,
-          ciGitInfo.getCommit().getSha(),
-          localGitInfo.getCommit().getSha(),
-          localGitInfo.getCommit().getCommitter().getEmail());
+          userSuppliedGitCommitterEmail,
+          ciGitCommitterEmail,
+          localCommitterEmail);
     }
 
     public CITagsBuilder withGitCommitCommitterDate(
         final GitInfo userSuppliedGitInfo, final GitInfo ciGitInfo, final GitInfo localGitInfo) {
-
-      if (userSuppliedGitInfo.getCommit().getCommitter().getISO8601Date() != null) {
-        this.putTagValue(
-            Tags.GIT_COMMIT_COMMITTER_DATE,
-            userSuppliedGitInfo.getCommit().getCommitter().getISO8601Date());
-        return this;
-      } else if (ciGitInfo.getCommit().getCommitter().getISO8601Date() != null) {
-        this.putTagValue(
-            Tags.GIT_COMMIT_COMMITTER_DATE, ciGitInfo.getCommit().getCommitter().getISO8601Date());
-        return this;
-      }
-
-      return this.putTagValueIfCommitEquals(
+      final String userSuppliedGitCommitterDate =
+          userSuppliedGitInfo.getCommit().getCommitter().getISO8601Date();
+      final String ciGitCommitterDate = ciGitInfo.getCommit().getCommitter().getISO8601Date();
+      final String localGitCommitterDate =
+          isCommitShaEquals(ciGitInfo, localGitInfo)
+              ? localGitInfo.getCommit().getCommitter().getISO8601Date()
+              : null;
+      return this.putTagValue(
           Tags.GIT_COMMIT_COMMITTER_DATE,
-          ciGitInfo.getCommit().getSha(),
-          localGitInfo.getCommit().getSha(),
-          localGitInfo.getCommit().getCommitter().getISO8601Date());
+          userSuppliedGitCommitterDate,
+          ciGitCommitterDate,
+          localGitCommitterDate);
     }
 
     public CITagsBuilder withGitCommitMessage(
         final GitInfo userSuppliedGitInfo, final GitInfo ciGitInfo, final GitInfo localGitInfo) {
-
-      if (userSuppliedGitInfo.getCommit().getFullMessage() != null) {
-        this.putTagValue(Tags.GIT_COMMIT_MESSAGE, userSuppliedGitInfo.getCommit().getFullMessage());
-        return this;
-      } else if (ciGitInfo.getCommit().getFullMessage() != null) {
-        this.putTagValue(Tags.GIT_COMMIT_MESSAGE, ciGitInfo.getCommit().getFullMessage());
-        return this;
-      }
-
-      return this.putTagValueIfCommitEquals(
+      final String userSuppliedGitCommitMessage = userSuppliedGitInfo.getCommit().getFullMessage();
+      final String ciGitCommitMessage = ciGitInfo.getCommit().getFullMessage();
+      final String localGitCommitMessage =
+          isCommitShaEquals(ciGitInfo, localGitInfo)
+              ? localGitInfo.getCommit().getFullMessage()
+              : null;
+      return this.putTagValue(
           Tags.GIT_COMMIT_MESSAGE,
-          ciGitInfo.getCommit().getSha(),
-          localGitInfo.getCommit().getSha(),
-          localGitInfo.getCommit().getFullMessage());
+          userSuppliedGitCommitMessage,
+          ciGitCommitMessage,
+          localGitCommitMessage);
     }
 
     public Map<String, String> build() {
       return ciTags;
     }
 
-    private CITagsBuilder putTagValue(final String tagKey, final String tagValue) {
-      return this.putTagValue(tagKey, tagValue, null);
-    }
-
     private CITagsBuilder putTagValue(
-        final String tagKey, final String tagValue, final String fallbackValue) {
+        final String tagKey, final String tagValue, final String... fallbackValues) {
       if (tagValue != null) {
         ciTags.put(tagKey, tagValue);
-      } else if (fallbackValue != null) {
-        ciTags.put(tagKey, fallbackValue);
+      } else {
+        for (final String fallbackValue : fallbackValues) {
+          if (fallbackValue != null) {
+            ciTags.put(tagKey, fallbackValue);
+            break;
+          }
+        }
       }
       return this;
     }
 
-    private CITagsBuilder putTagValueIfCommitEquals(
-        final String tagKey,
-        final String ciGitCommit,
-        final String localFSGitCommit,
-        final String tagValue) {
-      // As we're calculating the commit from localFS, we want to ensure that
-      // ciGitCommit is equals to localFSGitCommit before we put the information in the tag map.
-      if (ciGitCommit == null || ciGitCommit.equalsIgnoreCase(localFSGitCommit)) {
-        this.putTagValue(tagKey, tagValue);
-      }
-      return this;
+    private boolean isCommitShaEquals(GitInfo ciGitInfo, GitInfo localGitInfo) {
+      final String ciGitCommit = ciGitInfo.getCommit().getSha();
+      final String localFSGitCommit = localGitInfo.getCommit().getSha();
+      return ciGitCommit == null || ciGitCommit.equalsIgnoreCase(localFSGitCommit);
     }
   }
 

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/ci/git/GitInfo.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/ci/git/GitInfo.java
@@ -6,6 +6,18 @@ public class GitInfo {
 
   public static final GitInfo NOOP = new GitInfo(null, null, null, CommitInfo.NOOP);
 
+  public static final String DD_GIT_REPOSITORY_URL = "DD_GIT_REPOSITORY_URL";
+  public static final String DD_GIT_BRANCH = "DD_GIT_BRANCH";
+  public static final String DD_GIT_TAG = "DD_GIT_TAG";
+  public static final String DD_GIT_COMMIT_SHA = "DD_GIT_COMMIT_SHA";
+  public static final String DD_GIT_COMMIT_MESSAGE = "DD_GIT_COMMIT_MESSAGE";
+  public static final String DD_GIT_COMMIT_AUTHOR_NAME = "DD_GIT_COMMIT_AUTHOR_NAME";
+  public static final String DD_GIT_COMMIT_AUTHOR_EMAIL = "DD_GIT_COMMIT_AUTHOR_EMAIL";
+  public static final String DD_GIT_COMMIT_AUTHOR_DATE = "DD_GIT_COMMIT_AUTHOR_DATE";
+  public static final String DD_GIT_COMMIT_COMMITTER_NAME = "DD_GIT_COMMIT_COMMITTER_NAME";
+  public static final String DD_GIT_COMMIT_COMMITTER_EMAIL = "DD_GIT_COMMIT_COMMITTER_EMAIL";
+  public static final String DD_GIT_COMMIT_COMMITTER_DATE = "DD_GIT_COMMIT_COMMITTER_DATE";
+
   private final String repositoryURL;
   private final String branch;
   private final String tag;

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/ci/git/PersonInfo.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/ci/git/PersonInfo.java
@@ -13,8 +13,7 @@ public class PersonInfo {
 
   private final String name;
   private final String email;
-  private final long when;
-  private final int tzOffset;
+  private final String ISO8601Date;
 
   public PersonInfo() {
     this(null, null, 0, 0);
@@ -24,21 +23,16 @@ public class PersonInfo {
     this(name, email, 0, 0);
   }
 
+  public PersonInfo(final String name, final String email, final String iso8601date) {
+    this.name = name;
+    this.email = email;
+    this.ISO8601Date = iso8601date;
+  }
+
   public PersonInfo(String name, String email, long when, int tzOffset) {
     this.name = name;
     this.email = email;
-    this.when = when;
-    this.tzOffset = tzOffset;
-  }
-
-  public String getISO8601Date() {
-    if (when <= 0) {
-      return null;
-    }
-
-    final SimpleDateFormat sdf = new SimpleDateFormat(DATE_FORMAT_ISO8601);
-    sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
-    return sdf.format(new Date(when));
+    this.ISO8601Date = buildISO8601Date(when);
   }
 
   public String getName() {
@@ -49,12 +43,8 @@ public class PersonInfo {
     return email;
   }
 
-  public long getWhen() {
-    return when;
-  }
-
-  public int getTzOffset() {
-    return tzOffset;
+  public String getISO8601Date() {
+    return this.ISO8601Date;
   }
 
   @Override
@@ -62,15 +52,14 @@ public class PersonInfo {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     PersonInfo that = (PersonInfo) o;
-    return when == that.when
-        && tzOffset == that.tzOffset
-        && Objects.equals(name, that.name)
-        && Objects.equals(email, that.email);
+    return Objects.equals(name, that.name)
+        && Objects.equals(email, that.email)
+        && Objects.equals(ISO8601Date, that.ISO8601Date);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, email, when, tzOffset);
+    return Objects.hash(name, email, ISO8601Date);
   }
 
   @Override
@@ -82,10 +71,19 @@ public class PersonInfo {
         + ", email='"
         + email
         + '\''
-        + ", when="
-        + when
-        + ", tzOffset="
-        + tzOffset
+        + ", ISO8601Date='"
+        + ISO8601Date
+        + '\''
         + '}';
+  }
+
+  private static String buildISO8601Date(final long when) {
+    if (when <= 0) {
+      return null;
+    }
+
+    final SimpleDateFormat sdf = new SimpleDateFormat(DATE_FORMAT_ISO8601);
+    sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
+    return sdf.format(new Date(when));
   }
 }

--- a/internal-api/src/test/groovy/datadog/trace/bootstrap/instrumentation/ci/CIProviderInfoTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/bootstrap/instrumentation/ci/CIProviderInfoTest.groovy
@@ -1,7 +1,6 @@
 package datadog.trace.bootstrap.instrumentation.ci
 
 import datadog.trace.bootstrap.instrumentation.api.Tags
-import datadog.trace.test.util.DDSpecification
 import org.junit.Rule
 import org.junit.contrib.java.lang.system.EnvironmentVariables
 import org.junit.contrib.java.lang.system.RestoreSystemProperties

--- a/internal-api/src/test/groovy/datadog/trace/bootstrap/instrumentation/ci/CIProviderInfoTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/bootstrap/instrumentation/ci/CIProviderInfoTest.groovy
@@ -5,6 +5,7 @@ import datadog.trace.test.util.DDSpecification
 import org.junit.Rule
 import org.junit.contrib.java.lang.system.EnvironmentVariables
 import org.junit.contrib.java.lang.system.RestoreSystemProperties
+import spock.lang.Specification
 
 import java.nio.file.Paths
 
@@ -20,7 +21,7 @@ import static GithubActionsInfo.GHACTIONS
 import static JenkinsInfo.JENKINS
 import static TravisInfo.TRAVIS
 
-abstract class CIProviderInfoTest extends DDSpecification {
+abstract class CIProviderInfoTest extends Specification {
 
   private static final CI_WORKSPACE_PATH_FOR_TESTS = "ci/ci_workspace_for_tests"
   public static final GIT_FOLDER_FOR_TESTS = "git_folder_for_tests"

--- a/internal-api/src/test/groovy/datadog/trace/bootstrap/instrumentation/ci/UserSuppliedCIInfoTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/bootstrap/instrumentation/ci/UserSuppliedCIInfoTest.groovy
@@ -1,0 +1,14 @@
+package datadog.trace.bootstrap.instrumentation.ci
+
+class UserSuppliedCIInfoTest extends CIProviderInfoTest {
+
+  @Override
+  CIProviderInfo instanceProvider() {
+    return new NoopCIInfo()
+  }
+
+  @Override
+  String getProviderName() {
+    return "usersupplied"
+  }
+}

--- a/internal-api/src/test/resources/ci/usersupplied.json
+++ b/internal-api/src/test/resources/ci/usersupplied.json
@@ -1,0 +1,54 @@
+[
+  [
+    {
+      "DD_GIT_BRANCH": "usersupplied-branch",
+      "DD_GIT_COMMIT_AUTHOR_DATE": "usersupplied-authordate",
+      "DD_GIT_COMMIT_AUTHOR_EMAIL": "usersupplied-authoremail",
+      "DD_GIT_COMMIT_AUTHOR_NAME": "usersupplied-authorname",
+      "DD_GIT_COMMIT_COMMITTER_DATE": "usersupplied-comitterdate",
+      "DD_GIT_COMMIT_COMMITTER_EMAIL": "usersupplied-comitteremail",
+      "DD_GIT_COMMIT_COMMITTER_NAME": "usersupplied-comittername",
+      "DD_GIT_COMMIT_MESSAGE": "usersupplied-message",
+      "DD_GIT_COMMIT_SHA": "usersupplied-commit",
+      "DD_GIT_REPOSITORY_URL": "usersupplied-repo"
+    },
+    {
+      "git.branch": "usersupplied-branch",
+      "git.commit.author.date": "usersupplied-authordate",
+      "git.commit.author.email": "usersupplied-authoremail",
+      "git.commit.author.name": "usersupplied-authorname",
+      "git.commit.committer.date": "usersupplied-comitterdate",
+      "git.commit.committer.email": "usersupplied-comitteremail",
+      "git.commit.committer.name": "usersupplied-comittername",
+      "git.commit.message": "usersupplied-message",
+      "git.commit.sha": "usersupplied-commit",
+      "git.repository_url": "usersupplied-repo"
+    }
+  ],
+  [
+    {
+      "DD_GIT_COMMIT_AUTHOR_DATE": "usersupplied-authordate",
+      "DD_GIT_COMMIT_AUTHOR_EMAIL": "usersupplied-authoremail",
+      "DD_GIT_COMMIT_AUTHOR_NAME": "usersupplied-authorname",
+      "DD_GIT_COMMIT_COMMITTER_DATE": "usersupplied-comitterdate",
+      "DD_GIT_COMMIT_COMMITTER_EMAIL": "usersupplied-comitteremail",
+      "DD_GIT_COMMIT_COMMITTER_NAME": "usersupplied-comittername",
+      "DD_GIT_COMMIT_MESSAGE": "usersupplied-message",
+      "DD_GIT_COMMIT_SHA": "usersupplied-commit",
+      "DD_GIT_REPOSITORY_URL": "usersupplied-repo",
+      "DD_GIT_TAG": "0.0.2"
+    },
+    {
+      "git.commit.author.date": "usersupplied-authordate",
+      "git.commit.author.email": "usersupplied-authoremail",
+      "git.commit.author.name": "usersupplied-authorname",
+      "git.commit.committer.date": "usersupplied-comitterdate",
+      "git.commit.committer.email": "usersupplied-comitteremail",
+      "git.commit.committer.name": "usersupplied-comittername",
+      "git.commit.message": "usersupplied-message",
+      "git.commit.sha": "usersupplied-commit",
+      "git.repository_url": "usersupplied-repo",
+      "git.tag": "0.0.2"
+    }
+  ]
+]


### PR DESCRIPTION
This PR extends the `CIProviderInfo` logic to allow setting manual Git information via environment variables.