### PR TITLE
Rework UnionMap to allow mutable operations

### DIFF
--- a/dd-java-agent/agent-tooling/agent-tooling.gradle
+++ b/dd-java-agent/agent-tooling/agent-tooling.gradle
@@ -22,6 +22,7 @@ dependencies {
   api project(':dd-trace-core:jfr-openjdk')
 
   testImplementation project(':dd-java-agent:testing')
+  testImplementation group: 'com.google.guava', name: 'guava-testlib', version: '20.0'
 }
 
 // Use Java 11 to build a delegating ClassFileTransformer that understands Java modules

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/log/UnionMapTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/log/UnionMapTest.groovy
@@ -11,16 +11,108 @@ import junit.framework.TestResult
 
 class UnionMapTest extends DDSpecification {
 
-  def "test UnionMap behaviour"() {
+  def "test map behaviour when primary is empty"() {
     setup:
-    def testResult = new TestResult()
-    MapTestSuiteBuilder.using(new TestStringMapGenerator() {
+    def testResult = runMapTests("UnionMap - secondary only", new TestStringMapGenerator() {
+        @Override
+        protected Map<String, String> create(Map.Entry<String, String>[] entries) {
+          Map<String, String> secondary = new HashMap<>()
+          for (Map.Entry<String, String> entry : entries) {
+            secondary.put(entry.key, entry.value)
+          }
+          return new UnionMap<>(new HashMap<>(), secondary)
+        }
+      })
+
+    expect:
+    testResult.wasSuccessful()
+  }
+
+  def "test map behaviour when secondary is empty"() {
+    setup:
+    def testResult = runMapTests("UnionMap - primary only", new TestStringMapGenerator() {
+        @Override
+        protected Map<String, String> create(Map.Entry<String, String>[] entries) {
+          Map<String, String> primary = new HashMap<>()
+          for (Map.Entry<String, String> entry : entries) {
+            primary.put(entry.key, entry.value)
+          }
+          return new UnionMap<>(primary, new HashMap<>())
+        }
+      })
+
+    expect:
+    testResult.wasSuccessful()
+  }
+
+  def "test map behaviour when primary is same as secondary"() {
+    setup:
+    def testResult = runMapTests("UnionMap - duplicates", new TestStringMapGenerator() {
         @Override
         protected Map<String, String> create(Map.Entry<String, String>[] entries) {
           Map<String, String> primary = new HashMap<>()
           Map<String, String> secondary = new HashMap<>()
-          boolean addNextToPrimary = true
           for (Map.Entry<String, String> entry : entries) {
+            primary.put(entry.key, entry.value)
+            secondary.put(entry.key, entry.value)
+          }
+          return new UnionMap<>(primary, secondary)
+        }
+      })
+
+    expect:
+    testResult.wasSuccessful()
+  }
+
+  def "test map behaviour when secondary is all nulls"() {
+    setup:
+    def testResult = runMapTests("UnionMap - primary only", new TestStringMapGenerator() {
+        @Override
+        protected Map<String, String> create(Map.Entry<String, String>[] entries) {
+          Map<String, String> primary = new HashMap<>()
+          Map<String, String> secondary = new HashMap<>()
+          for (Map.Entry<String, String> entry : entries) {
+            primary.put(entry.key, entry.value)
+            secondary.put(entry.key, null)
+          }
+          return new UnionMap<>(primary, secondary)
+        }
+      })
+
+    expect:
+    testResult.wasSuccessful()
+  }
+
+  def "test map behaviour when secondary has different values"() {
+    setup:
+    def testResult = runMapTests("UnionMap - primary only", new TestStringMapGenerator() {
+        @Override
+        protected Map<String, String> create(Map.Entry<String, String>[] entries) {
+          Map<String, String> primary = new HashMap<>()
+          Map<String, String> secondary = new HashMap<>()
+          for (Map.Entry<String, String> entry : entries) {
+            primary.put(entry.key, entry.value)
+            secondary.put(entry.key, "")
+          }
+          return new UnionMap<>(primary, secondary)
+        }
+      })
+
+    expect:
+    testResult.wasSuccessful()
+  }
+
+  def "test map behaviour when entries are mixed between primary and secondary"() {
+    setup:
+    def testResult = runMapTests("UnionMap - mixture", new TestStringMapGenerator() {
+        @Override
+        protected Map<String, String> create(Map.Entry<String, String>[] entries) {
+          Map<String, String> primary = new HashMap<>()
+          Map<String, String> secondary = new HashMap<>()
+          boolean addNextToPrimary = false
+          for (Map.Entry<String, String> entry : entries) {
+            // if the key is already in primary then put the duplicate there
+            // because adding it to the secondary won't override the primary
             if (addNextToPrimary || primary.containsKey(entry.key)) {
               primary.put(entry.key, entry.value)
               addNextToPrimary = false
@@ -32,19 +124,28 @@ class UnionMapTest extends DDSpecification {
           return new UnionMap<>(primary, secondary)
         }
       })
-      .named("UnionMap")
+
+    expect:
+    testResult.wasSuccessful()
+  }
+
+
+  def runMapTests(name, generator) {
+    def testResult = new TestResult()
+
+    MapTestSuiteBuilder
+      .using(generator)
+      .named(name)
       .withFeatures(
       MapFeature.GENERAL_PURPOSE,
       MapFeature.ALLOWS_NULL_KEYS,
       MapFeature.ALLOWS_NULL_VALUES,
       MapFeature.ALLOWS_ANY_NULL_QUERIES,
-      MapFeature.FAILS_FAST_ON_CONCURRENT_MODIFICATION,
       CollectionFeature.SUPPORTS_ITERATOR_REMOVE,
       CollectionSize.ANY)
       .createTestSuite()
       .run(testResult)
 
-    expect:
-    testResult.wasSuccessful()
+    return testResult
   }
 }

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/log/UnionMapTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/log/UnionMapTest.groovy
@@ -1,0 +1,50 @@
+package datadog.trace.agent.tooling.log
+
+
+import com.google.common.collect.testing.MapTestSuiteBuilder
+import com.google.common.collect.testing.TestStringMapGenerator
+import com.google.common.collect.testing.features.CollectionFeature
+import com.google.common.collect.testing.features.CollectionSize
+import com.google.common.collect.testing.features.MapFeature
+import datadog.trace.test.util.DDSpecification
+import junit.framework.TestResult
+
+class UnionMapTest extends DDSpecification {
+
+  def "test UnionMap behaviour"() {
+    setup:
+    def testResult = new TestResult()
+    MapTestSuiteBuilder.using(new TestStringMapGenerator() {
+        @Override
+        protected Map<String, String> create(Map.Entry<String, String>[] entries) {
+          Map<String, String> primary = new HashMap<>()
+          Map<String, String> secondary = new HashMap<>()
+          boolean addNextToPrimary = true
+          for (Map.Entry<String, String> entry : entries) {
+            if (addNextToPrimary || primary.containsKey(entry.key)) {
+              primary.put(entry.key, entry.value)
+              addNextToPrimary = false
+            } else {
+              secondary.put(entry.key, entry.value)
+              addNextToPrimary = true
+            }
+          }
+          return new UnionMap<>(primary, secondary)
+        }
+      })
+      .named("UnionMap")
+      .withFeatures(
+      MapFeature.GENERAL_PURPOSE,
+      MapFeature.ALLOWS_NULL_KEYS,
+      MapFeature.ALLOWS_NULL_VALUES,
+      MapFeature.ALLOWS_ANY_NULL_QUERIES,
+      MapFeature.FAILS_FAST_ON_CONCURRENT_MODIFICATION,
+      CollectionFeature.SUPPORTS_ITERATOR_REMOVE,
+      CollectionSize.ANY)
+      .createTestSuite()
+      .run(testResult)
+
+    expect:
+    testResult.wasSuccessful()
+  }
+}

--- a/dd-java-agent/instrumentation/jboss-logmanager/src/main/java/datadog/trace/instrumentation/jbosslogmanager/ExtLogRecordInstrumentation.java
+++ b/dd-java-agent/instrumentation/jboss-logmanager/src/main/java/datadog/trace/instrumentation/jbosslogmanager/ExtLogRecordInstrumentation.java
@@ -66,8 +66,8 @@ public class ExtLogRecordInstrumentation extends Instrumenter.Tracing {
   public String[] helperClassNames() {
     return new String[] {
       "datadog.trace.agent.tooling.log.UnionMap",
-      "datadog.trace.agent.tooling.log.UnionMap$ConcatenatedSet",
-      "datadog.trace.agent.tooling.log.UnionMap$ConcatenatedSet$ConcatenatedSetIterator",
+      "datadog.trace.agent.tooling.log.UnionMap$1",
+      "datadog.trace.agent.tooling.log.UnionMap$1$1",
     };
   }
 
@@ -146,7 +146,7 @@ public class ExtLogRecordInstrumentation extends Instrumenter.Tracing {
         return;
       }
 
-      Map<String, String> correlationValues = new HashMap<>();
+      Map<String, String> correlationValues = new HashMap<>(8);
 
       if (context != null) {
         correlationValues.put(
@@ -169,11 +169,7 @@ public class ExtLogRecordInstrumentation extends Instrumenter.Tracing {
         }
       }
 
-      if (mdc == null) {
-        mdc = correlationValues;
-      } else {
-        mdc = new UnionMap<>(mdc, correlationValues);
-      }
+      mdc = null != mdc ? new UnionMap<>(mdc, correlationValues) : correlationValues;
     }
   }
 }

--- a/dd-java-agent/instrumentation/logback-1/src/main/java/datadog/trace/instrumentation/logback/LoggingEventInstrumentation.java
+++ b/dd-java-agent/instrumentation/logback-1/src/main/java/datadog/trace/instrumentation/logback/LoggingEventInstrumentation.java
@@ -62,8 +62,8 @@ public class LoggingEventInstrumentation extends Instrumenter.Tracing {
   public String[] helperClassNames() {
     return new String[] {
       "datadog.trace.agent.tooling.log.UnionMap",
-      "datadog.trace.agent.tooling.log.UnionMap$ConcatenatedSet",
-      "datadog.trace.agent.tooling.log.UnionMap$ConcatenatedSet$ConcatenatedSetIterator",
+      "datadog.trace.agent.tooling.log.UnionMap$1",
+      "datadog.trace.agent.tooling.log.UnionMap$1$1",
     };
   }
 
@@ -87,7 +87,7 @@ public class LoggingEventInstrumentation extends Instrumenter.Tracing {
         return;
       }
 
-      Map<String, String> correlationValues = new HashMap<>();
+      Map<String, String> correlationValues = new HashMap<>(8);
 
       if (context != null) {
         correlationValues.put(
@@ -110,11 +110,7 @@ public class LoggingEventInstrumentation extends Instrumenter.Tracing {
         }
       }
 
-      if (mdc == null) {
-        mdc = correlationValues;
-      } else {
-        mdc = new UnionMap<>(mdc, correlationValues);
-      }
+      mdc = null != mdc ? new UnionMap<>(mdc, correlationValues) : correlationValues;
     }
   }
 }


### PR DESCRIPTION
Also reduce capacity of correlation map to match expected size

Behaviour of the reworked `UnionMap` is validated by using Guava's `MapTestSuiteBuilder`