### PR TITLE
[AppSec] Attack events contains decimal spanId and traceId

### DIFF
--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/report/EventEnrichment.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/report/EventEnrichment.java
@@ -208,7 +208,7 @@ public class EventEnrichment {
       if (spanId == null) {
         spanId = DDId.ZERO;
       }
-      span.setId(spanId.toHexStringOrOriginal());
+      span.setId(spanId.toString());
     }
 
     Tags010 tags = (Tags010) eventCtx.getTags();
@@ -241,7 +241,7 @@ public class EventEnrichment {
       if (traceId == null) {
         traceId = DDId.ZERO;
       }
-      trace.setId(traceId.toHexStringOrOriginal());
+      trace.setId(traceId.toString());
     }
 
     Host010 host = (Host010) eventCtx.getHost();

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/report/EventEnrichmentSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/report/EventEnrichmentSpecification.groovy
@@ -85,7 +85,7 @@ class EventEnrichmentSpecification extends DDSpecification {
       }
       with(span) {
         contextVersion == '0.1.0'
-        id == spanId.toHexStringOrOriginal()
+        id == spanId.toString()
       }
       with(tags) {
         contextVersion == '0.1.0'
@@ -93,7 +93,7 @@ class EventEnrichmentSpecification extends DDSpecification {
       }
       with(trace) {
         contextVersion == '0.1.0'
-        id == traceId.toHexStringOrOriginal()
+        id == traceId.toString()
       }
       with(tracer) {
         contextVersion == '0.1.0'


### PR DESCRIPTION
Fixed inconsistent between apm traces and appsec event