### PR TITLE
Setting up codescanning for dd-trace-java

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,49 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ master ]
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'java' ]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        languages: ${{ matrix.language }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+        # queries: ./path/to/local/query, your-org/your-repo/queries@main
+
+    # Building the project dd-trace-java for creating CodeQL database
+    - run: |
+       sudo apt-get update && sudo apt-get install openjdk-11-jdk && JAVA_11_HOME=/usr/lib/jvm/java-11-openjdk-amd64 ./gradlew clean :dd-java-agent:shadowJar --build-cache --parallel --stacktrace --no-daemon --max-workers=8
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1
+      
+    - name: upload_artifact
+      uses: actions/upload-artifact@v2
+      with:
+         name: CodeQL Analysis Sarif
+         path: /home/runner/work/dd-trace-java/results/java.sarif    

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,9 +35,8 @@ jobs:
         # Prefix the list here with "+" to use these queries and those in the config file.
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
-    # Building the project dd-trace-java for creating CodeQL database
-    - run: |
-       sudo apt-get update && sudo apt-get install openjdk-11-jdk && JAVA_11_HOME=/usr/lib/jvm/java-11-openjdk-amd64 ./gradlew clean :dd-java-agent:shadowJar --build-cache --parallel --stacktrace --no-daemon --max-workers=8
+    - name: Build dd-trace-java for creating the CodeQL database
+      run: JAVA_11_HOME=$JAVA_HOME_11_X64 ./gradlew clean :dd-java-agent:shadowJar --build-cache --parallel --stacktrace --no-daemon --max-workers=8
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1


### PR DESCRIPTION
Static code analysis on dd-trace-java using Github's Code Scanning.

This PR has Github workflow configs to trigger the Code Scanning on every PR and on push to default branch. As of now only default security based CodeQL queries are configured. We can gradually add queries for Code Quality later. The SARIF results for the code-scanning job is uploaded as an artifact for reference.

The alerts will not show up on master branch until the PR gets merged. However we can see the code-scanning alerts introduced with this PR from here: https://github.com/DataDog/dd-trace-java/security/code-scanning?query=pr%3A3072+tool%3ACodeQL