### PR TITLE
Make UnionMap deduplication lazy

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/log/UnionMap.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/log/UnionMap.java
@@ -9,27 +9,43 @@ import java.util.Set;
 /**
  * Mutable view over two maps with entries in the primary map taking precedence over the secondary.
  * New entries are put in the primary map while old entries are deleted from both, as appropriate.
+ * Lazy deduplication occurs once: before iterating over entries/values, or when combining sizes.
  */
 public final class UnionMap<K, V> extends AbstractMap<K, V> {
   private final Map<K, V> primaryMap;
   private final Map<K, V> secondaryMap;
   private transient Set<Map.Entry<K, V>> entrySet;
+  private transient volatile boolean deduped;
 
   public UnionMap(Map<K, V> primaryMap, Map<K, V> secondaryMap) {
     this.primaryMap = primaryMap;
     this.secondaryMap = secondaryMap;
+  }
 
-    // drop keys from secondary that already exist in primary
-    Iterator<K> itr = secondaryMap.keySet().iterator();
-    while (itr.hasNext()) {
-      if (primaryMap.containsKey(itr.next())) {
-        itr.remove();
+  private void dedup() {
+    if (!deduped) {
+      if (primaryMap.isEmpty()) {
+        deduped = true;
+        return; // nothing to deduplicate
+      }
+      synchronized (this) {
+        if (!deduped) {
+          // drop keys from secondary that already exist in primary
+          Iterator<K> itr = secondaryMap.keySet().iterator();
+          while (itr.hasNext()) {
+            if (primaryMap.containsKey(itr.next())) {
+              itr.remove();
+            }
+          }
+          deduped = true;
+        }
       }
     }
   }
 
   @Override
   public int size() {
+    dedup();
     return primaryMap.size() + secondaryMap.size();
   }
 
@@ -45,25 +61,38 @@ public final class UnionMap<K, V> extends AbstractMap<K, V> {
 
   @Override
   public boolean containsValue(Object value) {
-    return primaryMap.containsValue(value) || secondaryMap.containsValue(value);
+    if (primaryMap.containsValue(value)) {
+      return true;
+    } else {
+      dedup();
+      return secondaryMap.containsValue(value);
+    }
   }
 
   @Override
   public V get(Object key) {
     V result = primaryMap.get(key);
-    return null != result ? result : secondaryMap.get(key);
+    return null != result || primaryMap.containsKey(key) ? result : secondaryMap.get(key);
   }
 
   @Override
   public V put(K key, V value) {
-    V result = primaryMap.put(key, value);
-    return null != result ? result : secondaryMap.remove(key);
+    if (primaryMap.containsKey(key)) {
+      return primaryMap.put(key, value);
+    } else {
+      primaryMap.put(key, value);
+      return secondaryMap.remove(key);
+    }
   }
 
   @Override
   public V remove(Object key) {
-    V result = primaryMap.remove(key);
-    return null != result ? result : secondaryMap.remove(key);
+    if (primaryMap.containsKey(key)) {
+      secondaryMap.remove(key);
+      return primaryMap.remove(key);
+    } else {
+      return secondaryMap.remove(key);
+    }
   }
 
   @Override
@@ -71,6 +100,7 @@ public final class UnionMap<K, V> extends AbstractMap<K, V> {
     primaryMap.clear();
     secondaryMap.clear();
     entrySet = primaryMap.entrySet(); // optimization: secondary will now always be empty
+    deduped = true;
   }
 
   @Override
@@ -85,6 +115,8 @@ public final class UnionMap<K, V> extends AbstractMap<K, V> {
 
             @Override
             public Iterator<Map.Entry<K, V>> iterator() {
+              UnionMap.this.dedup();
+
               return new Iterator<Map.Entry<K, V>>() {
                 private Iterator<Map.Entry<K, V>> itr = primaryMap.entrySet().iterator();
                 private volatile boolean trySecondaryNext = !secondaryMap.isEmpty();


### PR DESCRIPTION
Optimizes for the common case where only `get` is called as well as when the primary MDC map is empty.