### PR TITLE
Fix scope activation in vertx-redis client

### DIFF
--- a/dd-java-agent/instrumentation/vertx-redis-client-3.9/src/main/java/datadog/trace/instrumentation/vertx_redis_client/RedisAPIInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-redis-client-3.9/src/main/java/datadog/trace/instrumentation/vertx_redis_client/RedisAPIInstrumentation.java
@@ -1,14 +1,19 @@
 package datadog.trace.instrumentation.vertx_redis_client;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
 import static net.bytebuddy.matcher.ElementMatchers.isDefaultMethod;
 import static net.bytebuddy.matcher.ElementMatchers.isVirtual;
+import static net.bytebuddy.matcher.ElementMatchers.not;
 import static net.bytebuddy.matcher.ElementMatchers.returns;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
+import java.util.HashMap;
+import java.util.Map;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
+import net.bytebuddy.matcher.ElementMatchers;
 
 @AutoService(Instrumenter.class)
 public class RedisAPIInstrumentation extends Instrumenter.Tracing {
@@ -24,8 +29,15 @@ public class RedisAPIInstrumentation extends Instrumenter.Tracing {
   }
 
   @Override
+  public Map<String, String> contextStore() {
+    Map<String, String> contextStores = new HashMap<>();
+    contextStores.put("io.vertx.redis.client.RedisAPI", packageName + ".ResponseHandlerWrapper");
+    return contextStores;
+  }
+
+  @Override
   public ElementMatcher<? super TypeDescription> typeMatcher() {
-    return named("io.vertx.redis.client.RedisAPI");
+    return namedOneOf("io.vertx.redis.client.RedisAPI", "io.vertx.redis.client.impl.RedisAPIImpl");
   }
 
   @Override
@@ -33,5 +45,10 @@ public class RedisAPIInstrumentation extends Instrumenter.Tracing {
     transformation.applyAdvice(
         isVirtual().and(isDefaultMethod()).and(returns(named("io.vertx.redis.client.RedisAPI"))),
         packageName + ".RedisAPICallAdvice");
+    transformation.applyAdvice(
+        named("send")
+            .and(not(ElementMatchers.isDefaultMethod()))
+            .and(returns(named("io.vertx.core.Future"))),
+        packageName + ".RedisAPIImplSendAdvice");
   }
 }

--- a/dd-java-agent/instrumentation/vertx-redis-client-3.9/src/main/java8/datadog/trace/instrumentation/vertx_redis_client/RedisAPIImplSendAdvice.java
+++ b/dd-java-agent/instrumentation/vertx-redis-client-3.9/src/main/java8/datadog/trace/instrumentation/vertx_redis_client/RedisAPIImplSendAdvice.java
@@ -1,0 +1,32 @@
+package datadog.trace.instrumentation.vertx_redis_client;
+
+import datadog.trace.bootstrap.InstrumentationContext;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.redis.RedisClient;
+import io.vertx.redis.client.Redis;
+import io.vertx.redis.client.RedisAPI;
+import net.bytebuddy.asm.Advice;
+
+public class RedisAPIImplSendAdvice {
+  @Advice.OnMethodExit(suppress = Throwable.class)
+  public static void afterSend(@Advice.This RedisAPI self, @Advice.Return Future future) {
+    ResponseHandlerWrapper handler =
+        InstrumentationContext.get(RedisAPI.class, ResponseHandlerWrapper.class).get(self);
+    if (handler != null && !future.isComplete()) {
+      // add the handler only when the future is not already completed
+      future.setHandler(handler);
+    }
+    if (handler != null && future.isComplete()) {
+      // check whether the future has completed some time when adding the handler
+      // this might lead to executing the handler twice so the handler must be able to deal with it
+      handler.handle(((AsyncResult) future.result()));
+    }
+  }
+
+  // Only apply this advice for versions that we instrument 3.9.x
+  private static void muzzleCheck() {
+    RedisClient.create(null); // removed in 4.0.x
+    Redis.createClient(null, "somehost"); // added in 3.9.x
+  }
+}

--- a/dd-java-agent/instrumentation/vertx-redis-client-3.9/src/main/java8/datadog/trace/instrumentation/vertx_redis_client/ResponseHandlerWrapper.java
+++ b/dd-java-agent/instrumentation/vertx-redis-client-3.9/src/main/java8/datadog/trace/instrumentation/vertx_redis_client/ResponseHandlerWrapper.java
@@ -10,6 +10,7 @@ public class ResponseHandlerWrapper implements Handler<AsyncResult<Response>> {
   private final Handler<AsyncResult<Response>> handler;
   private final AgentSpan clientSpan;
   private final TraceScope.Continuation parentContinuation;
+  private boolean handled = false;
 
   public ResponseHandlerWrapper(
       final Handler<AsyncResult<Response>> handler,
@@ -22,18 +23,28 @@ public class ResponseHandlerWrapper implements Handler<AsyncResult<Response>> {
 
   @Override
   public void handle(final AsyncResult<Response> event) {
-    TraceScope scope = null;
-    try {
-      if (null != clientSpan) {
-        clientSpan.finish();
-      }
-      if (null != parentContinuation) {
-        scope = parentContinuation.activate();
-      }
-      handler.handle(event);
-    } finally {
-      if (null != scope) {
-        scope.close();
+    /*
+    Same handler can be called twice
+     - there is no indication whether a handler was added to an already completed Future
+     - we check the Future state right after adding the handler and if it is completed
+       we execute the handler; of course the Future might have completed with the handler
+       already set so the handler state must be tracked here to prevent double execution
+    */
+    if (!handled) {
+      TraceScope scope = null;
+      try {
+        if (null != clientSpan) {
+          clientSpan.finish();
+        }
+        if (null != parentContinuation) {
+          scope = parentContinuation.activate();
+        }
+        handler.handle(event);
+      } finally {
+        if (null != scope) {
+          scope.close();
+        }
+        handled = true;
       }
     }
   }

--- a/dd-java-agent/instrumentation/vertx-redis-client-3.9/src/test/groovy/VertxRedisAPITestBase.groovy
+++ b/dd-java-agent/instrumentation/vertx-redis-client-3.9/src/test/groovy/VertxRedisAPITestBase.groovy
@@ -1,5 +1,3 @@
-import datadog.trace.agent.test.checkpoints.CheckpointValidator
-import datadog.trace.agent.test.checkpoints.CheckpointValidationMode
 import io.vertx.core.AsyncResult
 import io.vertx.core.Handler
 import io.vertx.redis.client.RedisAPI
@@ -140,13 +138,6 @@ class VertxRedisAPIRedisForkedTest extends VertxRedisAPITestBase {
   def setupSpec() {
     redisAPI = RedisAPI.api(redis)
   }
-
-  @Override
-  def setup() {
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.THREAD_SEQUENCE)
-  }
 }
 
 class VertxRedisAPIRedisConnectionForkedTest extends VertxRedisAPITestBase {
@@ -167,8 +158,8 @@ class VertxRedisAPIRedisConnectionForkedTest extends VertxRedisAPITestBase {
 
   @Override
   def setup() {
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.THREAD_SEQUENCE)
+    //    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
+    //      CheckpointValidationMode.INTERVALS,
+    //      CheckpointValidationMode.THREAD_SEQUENCE)
   }
 }

--- a/dd-java-agent/instrumentation/vertx-redis-client-3.9/src/test/groovy/VertxRedisAPITestBase.groovy
+++ b/dd-java-agent/instrumentation/vertx-redis-client-3.9/src/test/groovy/VertxRedisAPITestBase.groovy
@@ -155,11 +155,4 @@ class VertxRedisAPIRedisConnectionForkedTest extends VertxRedisAPITestBase {
     latch.await(10, TimeUnit.SECONDS)
     assert redisAPI
   }
-
-  @Override
-  def setup() {
-    //    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-    //      CheckpointValidationMode.INTERVALS,
-    //      CheckpointValidationMode.THREAD_SEQUENCE)
-  }
 }


### PR DESCRIPTION
In this PR the main point of change is actually activating the span started in `RedisAPICallAdvice` and dealing with the `Future` handler in `RedisAPIImplSendAdvice` where we are hooking into `RedisAPIImpl.send()` method to be able to get our hands on the `Future` instance we need to set the handler to.

In that advice we will try to add the handler if the future is not already completed and simply run the handler if the future is completed. However, this still does not prevent double firing because the future may be completed in between two checks for being complete - therefore the handler is enhanced to ignore the second attempt to run the handling logic.