### PR TITLE
Remove trailing slash from HTTP resource name

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/RouteHandlerDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/RouteHandlerDecorator.java
@@ -29,9 +29,13 @@ public class RouteHandlerDecorator {
       DDCaches.newFixedSizeCache(64);
 
   public final AgentSpan withRoute(
-      final AgentSpan span, final CharSequence method, final CharSequence route) {
+      final AgentSpan span, final CharSequence method, CharSequence route) {
     span.setTag(Tags.HTTP_ROUTE, route);
     if (Config.get().isHttpServerRouteBasedNaming()) {
+      int routeLastChar = route.length() - 1;
+      if (route.charAt(routeLastChar) == '/') {
+        route = route.subSequence(0, routeLastChar);
+      }
       final CharSequence resourceName =
           RESOURCE_NAME_CACHE.computeIfAbsent(Pair.of(method, route), RESOURCE_NAME_JOINER);
       span.setResourceName(resourceName);

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecoratorTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecoratorTest.groovy
@@ -37,7 +37,7 @@ class HttpServerDecoratorTest extends ServerDecoratorTest {
     [method: "test-method", url: URI.create("http://test-url?some=query"), path: '/']         | "http://test-url/"
     [method: "test-method", url: URI.create("http://a:80/"), path: '/']                       | "http://a/"
     [method: "test-method", url: URI.create("https://10.0.0.1:443"), path: '/']               | "https://10.0.0.1/"
-    [method: "test-method", url: URI.create("https://localhost:0/1/"), path: '/?/']           | "https://localhost/1/"
+    [method: "test-method", url: URI.create("https://localhost:0/1/"), path: '/?']           | "https://localhost/1/"
     [method: "test-method", url: URI.create("http://123:8080/some/path"), path: '/some/path'] | "http://123:8080/some/path"
   }
 

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test/groovy/AWS1ClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test/groovy/AWS1ClientTest.groovy
@@ -139,7 +139,7 @@ class AWS1ClientTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT" "java-aws-sdk"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.HTTP_URL" "$server.address/"
+            "$Tags.HTTP_URL" "$server.address"
             "$Tags.HTTP_METHOD" "$method"
             "$Tags.HTTP_STATUS" 200
             "$Tags.PEER_PORT" server.address.port
@@ -179,7 +179,7 @@ class AWS1ClientTest extends AgentTestRunner {
 
     where:
     service      | operation           | method | path                  | client                                                                                                                                             | call                                                                            | additionalTags                    | body
-    "S3"         | "CreateBucket"      | "PUT"  | "/testbucket/"        | AmazonS3ClientBuilder.standard().withPathStyleAccessEnabled(true).withEndpointConfiguration(endpoint).withCredentials(credentialsProvider).build() | { client -> client.createBucket("testbucket") }                                 | ["aws.bucket.name": "testbucket"] | ""
+    "S3"         | "CreateBucket"      | "PUT"  | "/testbucket"         | AmazonS3ClientBuilder.standard().withPathStyleAccessEnabled(true).withEndpointConfiguration(endpoint).withCredentials(credentialsProvider).build() | { client -> client.createBucket("testbucket") }                                 | ["aws.bucket.name": "testbucket"] | ""
     "S3"         | "GetObject"         | "GET"  | "/someBucket/someKey" | AmazonS3ClientBuilder.standard().withPathStyleAccessEnabled(true).withEndpointConfiguration(endpoint).withCredentials(credentialsProvider).build() | { client -> client.getObject("someBucket", "someKey") }                         | ["aws.bucket.name": "someBucket"] | ""
     "DynamoDBv2" | "CreateTable"       | "POST" | "/"                   | AmazonDynamoDBClientBuilder.standard().withEndpointConfiguration(endpoint).withCredentials(credentialsProvider).build()                            | { c -> c.createTable(new CreateTableRequest("sometable", null)) }               | ["aws.table.name": "sometable"]   | ""
     "Kinesis"    | "DeleteStream"      | "POST" | "/"                   | AmazonKinesisClientBuilder.standard().withEndpointConfiguration(endpoint).withCredentials(credentialsProvider).build()                             | { c -> c.deleteStream(new DeleteStreamRequest().withStreamName("somestream")) } | ["aws.stream.name": "somestream"] | ""

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test_before_1_11_106/groovy/AWS0ClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test_before_1_11_106/groovy/AWS0ClientTest.groovy
@@ -102,7 +102,7 @@ class AWS0ClientTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT" "java-aws-sdk"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.HTTP_URL" "$server.address/"
+            "$Tags.HTTP_URL" "$server.address"
             "$Tags.HTTP_METHOD" "$method"
             "$Tags.HTTP_STATUS" 200
             "$Tags.PEER_PORT" server.address.port
@@ -142,7 +142,7 @@ class AWS0ClientTest extends AgentTestRunner {
 
     where:
     service | operation           | method | path                  | handlerCount | client                                                                      | additionalTags                    | call                                                                                                                                   | body
-    "S3"    | "CreateBucket"      | "PUT"  | "/testbucket/"        | 1            | new AmazonS3Client().withEndpoint("http://localhost:$server.address.port")  | ["aws.bucket.name": "testbucket"] | { client -> client.setS3ClientOptions(S3ClientOptions.builder().setPathStyleAccess(true).build()); client.createBucket("testbucket") } | ""
+    "S3"    | "CreateBucket"      | "PUT"  | "/testbucket"         | 1            | new AmazonS3Client().withEndpoint("http://localhost:$server.address.port")  | ["aws.bucket.name": "testbucket"] | { client -> client.setS3ClientOptions(S3ClientOptions.builder().setPathStyleAccess(true).build()); client.createBucket("testbucket") } | ""
     "S3"    | "GetObject"         | "GET"  | "/someBucket/someKey" | 1            | new AmazonS3Client().withEndpoint("http://localhost:$server.address.port")  | ["aws.bucket.name": "someBucket"] | { client -> client.getObject("someBucket", "someKey") }                                                                                | ""
     "EC2"   | "AllocateAddress"   | "POST" | "/"                   | 4            | new AmazonEC2Client().withEndpoint("http://localhost:$server.address.port") | [:]                               | { client -> client.allocateAddress() }                                                                                                 | """
             <AllocateAddressResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">

--- a/internal-api/src/main/java/datadog/trace/api/http/SimplePathNormalizer.java
+++ b/internal-api/src/main/java/datadog/trace/api/http/SimplePathNormalizer.java
@@ -9,6 +9,7 @@ final class SimplePathNormalizer extends PathNormalizer {
     }
     StringBuilder sb = new StringBuilder();
     int inEncoding = 0;
+    int lastIndex = path.length() - 1;
     for (int i = 0; i < path.length(); ) {
       int nextSlash = path.indexOf('/', i);
       if (nextSlash != i) {
@@ -48,7 +49,7 @@ final class SimplePathNormalizer extends PathNormalizer {
       } else {
         ++i;
       }
-      if (nextSlash != -1) {
+      if ((nextSlash != -1) && (nextSlash != lastIndex)) {
         sb.append('/');
       }
     }

--- a/internal-api/src/test/groovy/datadog/trace/api/http/SimplePathNormalizerTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/http/SimplePathNormalizerTest.groovy
@@ -44,9 +44,9 @@ class SimplePathNormalizerTest extends DDSpecification {
     "/1"               | "/?"
     "/9999"            | "/?"
     "/user/1"          | "/user/?"
-    "/user/1/"         | "/user/?/"
+    "/user/1/"         | "/user/?"
     "/user/1/repo/50"  | "/user/?/repo/?"
-    "/user/1/repo/50/" | "/user/?/repo/?/"
+    "/user/1/repo/50/" | "/user/?/repo/?"
   }
 
   def "should replace segments with mixed-characters"() {
@@ -78,7 +78,7 @@ class SimplePathNormalizerTest extends DDSpecification {
 
     where:
     input      | _
-    "/v0/"     | _
+    "/v0"      | _
     "/v10/xyz" | _
     "/a-b"     | _
     "/a_b"     | _


### PR DESCRIPTION
2 URLs http://localhost/foo and http://localhost/foo/ should
yield the same resource name