### PR TITLE
ActiveMQ's Transaction class creates two instances of `FutureTask` that are only ever used synchronously and could be re-used

### DIFF
--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/AsyncPropagatingDisableInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/AsyncPropagatingDisableInstrumentation.java
@@ -81,7 +81,8 @@ public final class AsyncPropagatingDisableInstrumentation extends Instrumenter.T
             "org.jvnet.hk2.internal.ServiceLocatorImpl",
             "com.zaxxer.hikari.pool.HikariPool",
             "net.sf.ehcache.store.disk.DiskStorageFactory",
-            "org.springframework.jms.listener.DefaultMessageListenerContainer")
+            "org.springframework.jms.listener.DefaultMessageListenerContainer",
+            "org.apache.activemq.broker.TransactionBroker")
         .or(RX_WORKERS)
         .or(GRPC_MANAGED_CHANNEL)
         .or(REACTOR_DISABLED_TYPE_INITIALIZERS);
@@ -154,6 +155,10 @@ public final class AsyncPropagatingDisableInstrumentation extends Instrumenter.T
             .and(
                 isDeclaredBy(
                     named("org.springframework.jms.listener.DefaultMessageListenerContainer"))),
+        advice);
+    transformation.applyAdvice(
+        named("beginTransaction")
+            .and(isDeclaredBy(named("org.apache.activemq.broker.TransactionBroker"))),
         advice);
     transformation.applyAdvice(
         isTypeInitializer().and(isDeclaredBy(REACTOR_DISABLED_TYPE_INITIALIZERS)), advice);


### PR DESCRIPTION
Turning off async propagation for `TransactionBroker.beginTransaction` stops those `FutureTask` instances from being captured when the transaction is constructed and results in better checkpoints for ActiveMQ (we can't exclude these instances by type because their type is `FutureTask`, ie. they don't extend it.)

Before:
```
Test worker:                                    |-startSpan/1-|-suspend/1-|----------|-endSpan/1-|-startSpan/2-|-endSpan/2-|-startSpan/3-|-endSpan/3-|-----------|-----------|----------|-----------|----------|-----------|----------|-----------|-----------|-----------|----------|-----------|----------|-----------|-startSpan/4-|-----------|-----------|----------|-suspend/4-|-----------|-----------|----------|-endSpan/4-|----------|-----------|-----------|-----------|----------|-----------|-----------|-startSpan/5-|-----------|-----------|-suspend/5-|----------|-endSpan/5-|-----------|----------|-----------|----------|-----------|----------|-----------|-----------|----------|-----------|-----------|----------|-----------|-----------|----------|-----------|-----------|-startSpan/6-|-startSpan/7-|-startSpan/8-|-endSpan/8-|-endSpan/7-|-endSpan/6-|-startSpan/9-|-startSpan/10-|-startSpan/11-|-startSpan/12-|-endSpan/12-|-endSpan/11-|-endSpan/10-|-endSpan/9-|
ActiveMQ VMTransport: vm://embedded-broker#1-1: |-------------|-----------|-resume/1-|-----------|-------------|-----------|-------------|-----------|-suspend/1-|-suspend/1-|-resume/1-|-endTask/1-|-resume/1-|-suspend/1-|----------|-endTask/1-|-suspend/1-|-suspend/1-|----------|-endTask/1-|----------|-----------|-------------|-----------|-----------|----------|-----------|-----------|-----------|----------|-----------|----------|-----------|-----------|-----------|----------|-----------|-----------|-------------|-----------|-----------|-----------|----------|-----------|-----------|-resume/4-|-endTask/4-|-resume/4-|-suspend/4-|----------|-endTask/4-|-----------|----------|-----------|-----------|----------|-----------|-----------|----------|-----------|-----------|-------------|-------------|-------------|-----------|-----------|-----------|-------------|--------------|--------------|--------------|------------|------------|------------|-----------|
ActiveMQ BrokerService[embedded-broker] Task-2: |-------------|-----------|----------|-----------|-------------|-----------|-------------|-----------|-----------|-----------|----------|-----------|----------|-----------|-resume/1-|-----------|-----------|-----------|----------|-----------|----------|-----------|-------------|-----------|-suspend/1-|----------|-----------|-----------|-endTask/1-|----------|-----------|----------|-----------|-----------|-----------|----------|-----------|-----------|-------------|-----------|-----------|-----------|----------|-----------|-----------|----------|-----------|----------|-----------|----------|-----------|-----------|-resume/4-|-----------|-suspend/4-|----------|-endTask/4-|-----------|----------|-----------|-----------|-------------|-------------|-------------|-----------|-----------|-----------|-------------|--------------|--------------|--------------|------------|------------|------------|-----------|
ActiveMQ VMTransport: vm://embedded-broker#0-2: |-------------|-----------|----------|-----------|-------------|-----------|-------------|-----------|-----------|-----------|----------|-----------|----------|-----------|----------|-----------|-----------|-----------|-resume/1-|-----------|----------|-endTask/1-|-------------|-----------|-----------|----------|-----------|-----------|-----------|-resume/1-|-----------|----------|-suspend/1-|-----------|-endTask/1-|----------|-----------|-----------|-------------|-----------|-----------|-----------|----------|-----------|-----------|----------|-----------|----------|-----------|----------|-----------|-----------|----------|-----------|-----------|-resume/4-|-----------|-suspend/4-|----------|-endTask/4-|-----------|-------------|-------------|-------------|-----------|-----------|-----------|-------------|--------------|--------------|--------------|------------|------------|------------|-----------|
ActiveMQ VMTransport: vm://embedded-broker#1-2: |-------------|-----------|----------|-----------|-------------|-----------|-------------|-----------|-----------|-----------|----------|-----------|----------|-----------|----------|-----------|-----------|-----------|----------|-----------|-resume/1-|-----------|-------------|-endTask/1-|-----------|----------|-----------|-----------|-----------|----------|-----------|-resume/4-|-----------|-----------|-----------|----------|-suspend/4-|-----------|-------------|-suspend/4-|-endTask/4-|-----------|-resume/5-|-----------|-endTask/5-|----------|-----------|----------|-----------|----------|-----------|-----------|----------|-----------|-----------|----------|-----------|-----------|----------|-----------|-----------|-------------|-------------|-------------|-----------|-----------|-----------|-------------|--------------|--------------|--------------|------------|------------|------------|-----------|
ActiveMQ BrokerService[embedded-broker] Task-1: |-------------|-----------|----------|-----------|-------------|-----------|-------------|-----------|-----------|-----------|----------|-----------|----------|-----------|----------|-----------|-----------|-----------|----------|-----------|----------|-----------|-------------|-----------|-----------|-resume/1-|-----------|-suspend/1-|-----------|----------|-----------|----------|-----------|-endTask/1-|-----------|----------|-----------|-----------|-------------|-----------|-----------|-----------|----------|-----------|-----------|----------|-----------|----------|-----------|-resume/4-|-----------|-suspend/4-|----------|-endTask/4-|-----------|----------|-----------|-----------|----------|-----------|-----------|-------------|-------------|-------------|-----------|-----------|-----------|-------------|--------------|--------------|--------------|------------|------------|------------|-----------|
ActiveMQ Session Task-1:                        |-------------|-----------|----------|-----------|-------------|-----------|-------------|-----------|-----------|-----------|----------|-----------|----------|-----------|----------|-----------|-----------|-----------|----------|-----------|----------|-----------|-------------|-----------|-----------|----------|-----------|-----------|-----------|----------|-----------|----------|-----------|-----------|-----------|-resume/1-|-----------|-endTask/1-|-------------|-----------|-----------|-----------|----------|-----------|-----------|----------|-----------|----------|-----------|----------|-----------|-----------|----------|-----------|-----------|----------|-----------|-----------|-resume/4-|-----------|-endTask/4-|-------------|-------------|-------------|-----------|-----------|-----------|-------------|--------------|--------------|--------------|------------|------------|------------|-----------|
```

After:
```
Test worker:                                    |-startSpan/1-|-suspend/1-|----------|-endSpan/1-|-startSpan/2-|-endSpan/2-|-startSpan/3-|-endSpan/3-|-----------|----------|-----------|----------|-----------|-----------|----------|-----------|-startSpan/4-|-----------|-----------|-suspend/4-|-----------|----------|-endSpan/4-|----------|-----------|----------|-----------|-startSpan/5-|-----------|----------|-suspend/5-|-----------|-----------|----------|-endSpan/5-|-----------|-----------|-startSpan/6-|-startSpan/7-|-startSpan/8-|-endSpan/8-|-endSpan/7-|-endSpan/6-|-startSpan/9-|-startSpan/10-|-startSpan/11-|-startSpan/12-|-endSpan/12-|-endSpan/11-|-endSpan/10-|-endSpan/9-|
ActiveMQ VMTransport: vm://embedded-broker#1-1: |-------------|-----------|-resume/1-|-----------|-------------|-----------|-------------|-----------|-suspend/1-|----------|-suspend/1-|----------|-suspend/1-|-----------|----------|-endTask/1-|-------------|-----------|-----------|-----------|-----------|----------|-----------|----------|-----------|----------|-----------|-------------|-----------|----------|-----------|-----------|-----------|-resume/5-|-----------|-----------|-endTask/5-|-------------|-------------|-------------|-----------|-----------|-----------|-------------|--------------|--------------|--------------|------------|------------|------------|-----------|
ActiveMQ BrokerService[embedded-broker] Task-2: |-------------|-----------|----------|-----------|-------------|-----------|-------------|-----------|-----------|-resume/1-|-----------|----------|-----------|-----------|----------|-----------|-------------|-----------|-suspend/1-|-----------|-endTask/1-|----------|-----------|----------|-----------|----------|-----------|-------------|-----------|----------|-----------|-----------|-----------|----------|-----------|-----------|-----------|-------------|-------------|-------------|-----------|-----------|-----------|-------------|--------------|--------------|--------------|------------|------------|------------|-----------|
ActiveMQ VMTransport: vm://embedded-broker#0-1: |-------------|-----------|----------|-----------|-------------|-----------|-------------|-----------|-----------|----------|-----------|-resume/1-|-----------|-endTask/1-|----------|-----------|-------------|-----------|-----------|-----------|-----------|----------|-----------|----------|-----------|-resume/1-|-----------|-------------|-suspend/1-|----------|-----------|-----------|-endTask/1-|----------|-----------|-----------|-----------|-------------|-------------|-------------|-----------|-----------|-----------|-------------|--------------|--------------|--------------|------------|------------|------------|-----------|
ActiveMQ VMTransport: vm://embedded-broker#1-2: |-------------|-----------|----------|-----------|-------------|-----------|-------------|-----------|-----------|----------|-----------|----------|-----------|-----------|-resume/1-|-----------|-------------|-endTask/1-|-----------|-----------|-----------|----------|-----------|-resume/4-|-----------|----------|-----------|-------------|-----------|----------|-----------|-endTask/4-|-----------|----------|-----------|-----------|-----------|-------------|-------------|-------------|-----------|-----------|-----------|-------------|--------------|--------------|--------------|------------|------------|------------|-----------|
ActiveMQ BrokerService[embedded-broker] Task-1: |-------------|-----------|----------|-----------|-------------|-----------|-------------|-----------|-----------|----------|-----------|----------|-----------|-----------|----------|-----------|-------------|-----------|-----------|-----------|-----------|-resume/1-|-----------|----------|-suspend/1-|----------|-endTask/1-|-------------|-----------|----------|-----------|-----------|-----------|----------|-----------|-----------|-----------|-------------|-------------|-------------|-----------|-----------|-----------|-------------|--------------|--------------|--------------|------------|------------|------------|-----------|
ActiveMQ Session Task-1:                        |-------------|-----------|----------|-----------|-------------|-----------|-------------|-----------|-----------|----------|-----------|----------|-----------|-----------|----------|-----------|-------------|-----------|-----------|-----------|-----------|----------|-----------|----------|-----------|----------|-----------|-------------|-----------|-resume/1-|-----------|-----------|-----------|----------|-----------|-endTask/1-|-----------|-------------|-------------|-------------|-----------|-----------|-----------|-------------|--------------|--------------|--------------|------------|------------|------------|-----------|
```

The unusual sequences like `|-suspend/1-|-suspend/1-|-resume/1-|-endTask/1-|-resume/1-|-suspend/1-|` are now gone.