### PR TITLE
Fix TraceConfig wildcard matcher to ignore type-initializers…

### DIFF
--- a/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/TraceConfigTest.groovy
+++ b/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/TraceConfigTest.groovy
@@ -80,6 +80,9 @@ class TraceConfigTest extends AgentTestRunner {
   }
 
   abstract class DictionaryElement{
+    static {
+      System.out.println("Static initializer (should not be included in wildcard)")
+    }
     abstract void produceDefinition()
   }
 


### PR DESCRIPTION
…since TraceAdvice expects methods

Rather than include an extra clause to the `not` filter for `isTypeInitializer()` it was easier to check `isMethod()` first for both wildcard and named cases. That way we can be sure we're only matching against elements that can be converted to `Method` for the `TraceAdvice`
