### PR TITLE
Move AppSec HTTP header extraction to HttpServerDecorator

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecoratorTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecoratorTest.groovy
@@ -1,6 +1,7 @@
 package datadog.trace.bootstrap.instrumentation.decorator
 
 import datadog.trace.api.DDTags
+import datadog.trace.bootstrap.instrumentation.api.AgentPropagation
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan
 import datadog.trace.bootstrap.instrumentation.api.URIDefaultDataAdapter
 import datadog.trace.bootstrap.instrumentation.api.Tags
@@ -13,6 +14,10 @@ import static datadog.trace.api.config.TraceInstrumentationConfig.HTTP_SERVER_TA
 class HttpServerDecoratorTest extends ServerDecoratorTest {
 
   def span = Mock(AgentSpan)
+
+  def "test startSpan"() {
+    // TODO test it
+  }
 
   def "test onRequest"() {
     setup:
@@ -207,7 +212,7 @@ class HttpServerDecoratorTest extends ServerDecoratorTest {
 
   @Override
   def newDecorator() {
-    return new HttpServerDecorator<Map, Map, Map>() {
+    return new HttpServerDecorator<Map, Map, Map, Map>() {
         @Override
         protected String[] instrumentationNames() {
           return ["test1", "test2"]
@@ -216,6 +221,16 @@ class HttpServerDecoratorTest extends ServerDecoratorTest {
         @Override
         protected CharSequence component() {
           return "test-component"
+        }
+
+        @Override
+        protected AgentPropagation.ContextVisitor<Map> getter() {
+          return null
+        }
+
+        @Override
+        CharSequence spanName() {
+          return "http-test-span"
         }
 
         @Override

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/AkkaHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/AkkaHttpServerDecorator.java
@@ -1,16 +1,20 @@
 package datadog.trace.instrumentation.akkahttp;
 
+import static datadog.trace.instrumentation.akkahttp.AkkaHttpServerHeaders.GETTER;
+
 import akka.http.scaladsl.model.HttpRequest;
 import akka.http.scaladsl.model.HttpResponse;
+import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
 
 public class AkkaHttpServerDecorator
-    extends HttpServerDecorator<HttpRequest, HttpRequest, HttpResponse> {
-  public static final CharSequence AKKA_REQUEST = UTF8BytesString.create("akka-http.request");
-  public static final CharSequence AKKA_HTTP_SERVER = UTF8BytesString.create("akka-http-server");
+    extends HttpServerDecorator<HttpRequest, HttpRequest, HttpResponse, HttpRequest> {
   public static final AkkaHttpServerDecorator DECORATE = new AkkaHttpServerDecorator();
+
+  private static final CharSequence AKKA_REQUEST = UTF8BytesString.create("akka-http.request");
+  private static final CharSequence AKKA_HTTP_SERVER = UTF8BytesString.create("akka-http-server");
 
   @Override
   protected String[] instrumentationNames() {
@@ -20,6 +24,16 @@ public class AkkaHttpServerDecorator
   @Override
   protected CharSequence component() {
     return AKKA_HTTP_SERVER;
+  }
+
+  @Override
+  protected AgentPropagation.ContextVisitor<HttpRequest> getter() {
+    return GETTER;
+  }
+
+  @Override
+  public CharSequence spanName() {
+    return AKKA_REQUEST;
   }
 
   @Override

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/DatadogWrapperHelper.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/DatadogWrapperHelper.java
@@ -1,11 +1,7 @@
 package datadog.trace.instrumentation.akkahttp;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
-import static datadog.trace.instrumentation.akkahttp.AkkaHttpServerDecorator.AKKA_REQUEST;
 import static datadog.trace.instrumentation.akkahttp.AkkaHttpServerDecorator.DECORATE;
-import static datadog.trace.instrumentation.akkahttp.AkkaHttpServerHeaders.GETTER;
 
 import akka.http.scaladsl.model.HttpRequest;
 import akka.http.scaladsl.model.HttpResponse;
@@ -14,10 +10,8 @@ import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 
 public class DatadogWrapperHelper {
   public static AgentScope createSpan(final HttpRequest request) {
-    final AgentSpan.Context.Extracted extractedContext = propagate().extract(request, GETTER);
-    final AgentSpan span = startSpan(AKKA_REQUEST, extractedContext);
-    span.setMeasured(true);
-
+    final AgentSpan.Context.Extracted extractedContext = DECORATE.extract(request);
+    final AgentSpan span = DECORATE.startSpan(request, extractedContext);
     DECORATE.afterStart(span);
     DECORATE.onRequest(span, request, request, extractedContext);
 

--- a/dd-java-agent/instrumentation/axway-api/src/main/java/datadog/trace/instrumentation/axway/AxwayHTTPPluginDecorator.java
+++ b/dd-java-agent/instrumentation/axway-api/src/main/java/datadog/trace/instrumentation/axway/AxwayHTTPPluginDecorator.java
@@ -2,6 +2,7 @@ package datadog.trace.instrumentation.axway;
 
 import static java.lang.invoke.MethodType.methodType;
 
+import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
@@ -19,7 +20,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 // request = is com.vordel.circuit.net.State,  connection = com.vordel.dwe.http.ServerTransaction
-public class AxwayHTTPPluginDecorator extends HttpServerDecorator<Object, Object, Object> {
+public class AxwayHTTPPluginDecorator extends HttpServerDecorator<Object, Object, Object, Void> {
   private static final Logger log = LoggerFactory.getLogger(AxwayHTTPPluginDecorator.class);
 
   public static final CharSequence AXWAY_REQUEST = UTF8BytesString.create("axway.request");
@@ -130,6 +131,16 @@ public class AxwayHTTPPluginDecorator extends HttpServerDecorator<Object, Object
   @Override
   protected String component() {
     return "axway-http";
+  }
+
+  @Override
+  protected AgentPropagation.ContextVisitor<Void> getter() {
+    return null;
+  }
+
+  @Override
+  public CharSequence spanName() {
+    return AXWAY_REQUEST;
   }
 
   @Override

--- a/dd-java-agent/instrumentation/axway-api/src/main/java/datadog/trace/instrumentation/axway/HTTPPluginAdvice.java
+++ b/dd-java-agent/instrumentation/axway-api/src/main/java/datadog/trace/instrumentation/axway/HTTPPluginAdvice.java
@@ -2,7 +2,6 @@ package datadog.trace.instrumentation.axway;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
-import static datadog.trace.instrumentation.axway.AxwayHTTPPluginDecorator.AXWAY_REQUEST;
 import static datadog.trace.instrumentation.axway.AxwayHTTPPluginDecorator.DECORATE;
 import static datadog.trace.instrumentation.axway.AxwayHTTPPluginDecorator.SERVER_TRANSACTION_CLASS;
 
@@ -15,12 +14,11 @@ public class HTTPPluginAdvice {
 
   @Advice.OnMethodEnter(suppress = Throwable.class)
   public static AgentScope onEnter(@Advice.Argument(value = 2) final Object serverTransaction) {
-    final AgentSpan span = startSpan(AXWAY_REQUEST);
-    final AgentScope scope = activateSpan(span);
-    span.setMeasured(true);
+    final AgentSpan span = startSpan(DECORATE.spanName()).setMeasured(true);
     DECORATE.afterStart(span);
     // serverTransaction is like request + connection in one object:
     DECORATE.onRequest(span, serverTransaction, serverTransaction, null);
+    final AgentScope scope = activateSpan(span);
     return scope;
   }
 

--- a/dd-java-agent/instrumentation/finatra-2.9/src/main/java/datadog/trace/instrumentation/finatra/FinatraDecorator.java
+++ b/dd-java-agent/instrumentation/finatra-2.9/src/main/java/datadog/trace/instrumentation/finatra/FinatraDecorator.java
@@ -2,23 +2,34 @@ package datadog.trace.instrumentation.finatra;
 
 import com.twitter.finagle.http.Request;
 import com.twitter.finagle.http.Response;
+import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.bootstrap.instrumentation.api.URIDefaultDataAdapter;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
 import java.net.URI;
 
-public class FinatraDecorator extends HttpServerDecorator<Request, Request, Response> {
+public class FinatraDecorator extends HttpServerDecorator<Request, Request, Response, Void> {
 
   public static final CharSequence FINATRA = UTF8BytesString.create("finatra");
   public static final CharSequence FINATRA_CONTROLLER =
       UTF8BytesString.create("finatra.controller");
-  public static final CharSequence FINATRA_REQUEST = UTF8BytesString.create("finatra.request");
+  private static final CharSequence FINATRA_REQUEST = UTF8BytesString.create("finatra.request");
   public static final FinatraDecorator DECORATE = new FinatraDecorator();
 
   @Override
   protected CharSequence component() {
     return FINATRA;
+  }
+
+  @Override
+  protected AgentPropagation.ContextVisitor<Void> getter() {
+    return null;
+  }
+
+  @Override
+  public CharSequence spanName() {
+    return FINATRA_REQUEST;
   }
 
   @Override

--- a/dd-java-agent/instrumentation/finatra-2.9/src/main/java/datadog/trace/instrumentation/finatra/FinatraInstrumentation.java
+++ b/dd-java-agent/instrumentation/finatra-2.9/src/main/java/datadog/trace/instrumentation/finatra/FinatraInstrumentation.java
@@ -10,7 +10,6 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.bootstrap.instrumentation.decorator.RouteHandlerDecorator.ROUTE_HANDLER_DECORATOR;
 import static datadog.trace.instrumentation.finatra.FinatraDecorator.DECORATE;
 import static datadog.trace.instrumentation.finatra.FinatraDecorator.FINATRA_CONTROLLER;
-import static datadog.trace.instrumentation.finatra.FinatraDecorator.FINATRA_REQUEST;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
@@ -75,7 +74,7 @@ public class FinatraInstrumentation extends Instrumenter.Tracing {
       final AgentSpan parent = activeSpan();
       ROUTE_HANDLER_DECORATOR.withRoute(parent, request.method().name(), path);
       parent.setTag(Tags.COMPONENT, "finatra");
-      parent.setSpanName(FINATRA_REQUEST);
+      parent.setSpanName(DECORATE.spanName());
 
       final AgentSpan span = startSpan(FINATRA_CONTROLLER);
       DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/grizzly-2/src/main/java/datadog/trace/instrumentation/grizzly/GrizzlyDecorator.java
+++ b/dd-java-agent/instrumentation/grizzly-2/src/main/java/datadog/trace/instrumentation/grizzly/GrizzlyDecorator.java
@@ -1,15 +1,28 @@
 package datadog.trace.instrumentation.grizzly;
 
+import static datadog.trace.instrumentation.grizzly.GrizzlyRequestExtractAdapter.GETTER;
+
+import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
 import org.glassfish.grizzly.http.server.Request;
 import org.glassfish.grizzly.http.server.Response;
 
-public class GrizzlyDecorator extends HttpServerDecorator<Request, Request, Response> {
+public class GrizzlyDecorator extends HttpServerDecorator<Request, Request, Response, Request> {
   public static final CharSequence GRIZZLY = UTF8BytesString.create("grizzly");
   public static final CharSequence GRIZZLY_REQUEST = UTF8BytesString.create("grizzly.request");
   public static final GrizzlyDecorator DECORATE = new GrizzlyDecorator();
+
+  @Override
+  protected AgentPropagation.ContextVisitor<Request> getter() {
+    return GETTER;
+  }
+
+  @Override
+  public CharSequence spanName() {
+    return GRIZZLY_REQUEST;
+  }
 
   @Override
   protected String method(final Request request) {

--- a/dd-java-agent/instrumentation/grizzly-2/src/main/java/datadog/trace/instrumentation/grizzly/GrizzlyHttpHandlerInstrumentation.java
+++ b/dd-java-agent/instrumentation/grizzly-2/src/main/java/datadog/trace/instrumentation/grizzly/GrizzlyHttpHandlerInstrumentation.java
@@ -2,12 +2,8 @@ package datadog.trace.instrumentation.grizzly;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.DD_SPAN_ATTRIBUTE;
 import static datadog.trace.instrumentation.grizzly.GrizzlyDecorator.DECORATE;
-import static datadog.trace.instrumentation.grizzly.GrizzlyDecorator.GRIZZLY_REQUEST;
-import static datadog.trace.instrumentation.grizzly.GrizzlyRequestExtractAdapter.GETTER;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
@@ -68,9 +64,8 @@ public class GrizzlyHttpHandlerInstrumentation extends Instrumenter.Tracing {
         return null;
       }
 
-      final Context.Extracted parentContext = propagate().extract(request, GETTER);
-      final AgentSpan span = startSpan(GRIZZLY_REQUEST, parentContext);
-      span.setMeasured(true);
+      final Context.Extracted parentContext = DECORATE.extract(request);
+      final AgentSpan span = DECORATE.startSpan(request, parentContext);
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, request, request, parentContext);
 

--- a/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/main/java/datadog/trace/instrumentation/grizzlyhttp232/ExtractAdapter.java
+++ b/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/main/java/datadog/trace/instrumentation/grizzlyhttp232/ExtractAdapter.java
@@ -2,14 +2,14 @@ package datadog.trace.instrumentation.grizzlyhttp232;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import java.nio.charset.StandardCharsets;
-import org.glassfish.grizzly.http.HttpHeader;
+import org.glassfish.grizzly.http.HttpRequestPacket;
 import org.glassfish.grizzly.http.util.MimeHeaders;
 
-public class ExtractAdapter implements AgentPropagation.ContextVisitor<HttpHeader> {
+public class ExtractAdapter implements AgentPropagation.ContextVisitor<HttpRequestPacket> {
   public static final ExtractAdapter GETTER = new ExtractAdapter();
 
   @Override
-  public void forEachKey(HttpHeader carrier, AgentPropagation.KeyClassifier classifier) {
+  public void forEachKey(HttpRequestPacket carrier, AgentPropagation.KeyClassifier classifier) {
     MimeHeaders headers = carrier.getHeaders();
     for (int i = 0; i < headers.size(); ++i) {
       if (!classifier.accept(

--- a/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/main/java/datadog/trace/instrumentation/grizzlyhttp232/GrizzlyDecorator.java
+++ b/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/main/java/datadog/trace/instrumentation/grizzlyhttp232/GrizzlyDecorator.java
@@ -1,9 +1,8 @@
 package datadog.trace.instrumentation.grizzlyhttp232;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 
+import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
@@ -15,7 +14,8 @@ import org.glassfish.grizzly.http.HttpRequestPacket;
 import org.glassfish.grizzly.http.HttpResponsePacket;
 
 public class GrizzlyDecorator
-    extends HttpServerDecorator<HttpRequestPacket, HttpRequestPacket, HttpResponsePacket> {
+    extends HttpServerDecorator<
+        HttpRequestPacket, HttpRequestPacket, HttpResponsePacket, HttpRequestPacket> {
 
   public static final CharSequence GRIZZLY_FILTER_CHAIN_SERVER =
       UTF8BytesString.create("grizzly-filterchain-server");
@@ -23,6 +23,16 @@ public class GrizzlyDecorator
   public static final CharSequence GRIZZLY_REQUEST = UTF8BytesString.create("grizzly.request");
 
   public static final GrizzlyDecorator DECORATE = new GrizzlyDecorator();
+
+  @Override
+  protected AgentPropagation.ContextVisitor<HttpRequestPacket> getter() {
+    return ExtractAdapter.GETTER;
+  }
+
+  @Override
+  public CharSequence spanName() {
+    return GRIZZLY_REQUEST;
+  }
 
   @Override
   protected String method(final HttpRequestPacket httpRequest) {
@@ -77,8 +87,8 @@ public class GrizzlyDecorator
     }
     HttpRequestPacket httpRequest = (HttpRequestPacket) httpHeader;
     HttpResponsePacket httpResponse = httpRequest.getResponse();
-    AgentSpan.Context.Extracted context = propagate().extract(httpHeader, ExtractAdapter.GETTER);
-    AgentSpan span = startSpan(GRIZZLY_REQUEST, context);
+    AgentSpan.Context.Extracted context = DECORATE.extract(httpRequest);
+    AgentSpan span = DECORATE.startSpan(httpRequest, context);
     AgentScope scope = activateSpan(span);
     scope.setAsyncPropagation(true);
     DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/test/groovy/GrizzlyByteBodyInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/test/groovy/GrizzlyByteBodyInstrumentationTest.groovy
@@ -5,7 +5,7 @@ import datadog.trace.api.gateway.Flow
 import datadog.trace.api.gateway.RequestContext
 import datadog.trace.api.http.StoredBodySupplier
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer
-import datadog.trace.core.propagation.TagContext
+import datadog.trace.bootstrap.instrumentation.api.TagContext
 import datadog.trace.instrumentation.grizzlyhttp232.GrizzlyByteBodyInstrumentation
 import org.glassfish.grizzly.Buffer
 import org.glassfish.grizzly.attributes.AttributeHolder
@@ -37,8 +37,7 @@ class GrizzlyByteBodyInstrumentationTest extends AgentTestRunner {
     1 * attributeHolder.setAttribute('datadog.intercepted_request_body', Boolean.TRUE)
 
     RequestContext requestContext = Mock()
-    TagContext ctx = Mock(TagContext)
-    _ * ctx.requestContext >> requestContext
+    TagContext ctx = TagContext.empty().withRequestContext(requestContext)
     def agentSpan = AgentTracer.startSpan('test-span', ctx, true)
     this.scope = AgentTracer.activateSpan(agentSpan)
 

--- a/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/test/groovy/GrizzlyCharBodyInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/test/groovy/GrizzlyCharBodyInstrumentationTest.groovy
@@ -5,7 +5,7 @@ import datadog.trace.api.gateway.Flow
 import datadog.trace.api.gateway.RequestContext
 import datadog.trace.api.http.StoredBodySupplier
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer
-import datadog.trace.core.propagation.TagContext
+import datadog.trace.bootstrap.instrumentation.api.TagContext
 import datadog.trace.instrumentation.grizzlyhttp232.GrizzlyCharBodyInstrumentation
 import org.glassfish.grizzly.attributes.AttributeHolder
 import org.glassfish.grizzly.http.HttpHeader
@@ -32,7 +32,7 @@ class GrizzlyCharBodyInstrumentationTest extends AgentTestRunner {
     1 * attributeHolder.setAttribute('datadog.intercepted_request_body', Boolean.TRUE)
 
     RequestContext requestContext = Mock()
-    TagContext ctx = Mock(TagContext)
+    TagContext ctx = TagContext.empty().withRequestContext(requestContext)
     _ * ctx.requestContext >> requestContext
     def agentSpan = AgentTracer.startSpan('test-span', ctx, true)
     this.scope = AgentTracer.activateSpan(agentSpan)

--- a/dd-java-agent/instrumentation/jetty-7.0/src/main/java/datadog/trace/instrumentation/jetty70/JettyDecorator.java
+++ b/dd-java-agent/instrumentation/jetty-7.0/src/main/java/datadog/trace/instrumentation/jetty70/JettyDecorator.java
@@ -1,7 +1,10 @@
 package datadog.trace.instrumentation.jetty70;
 
+import static datadog.trace.instrumentation.jetty70.RequestExtractAdapter.GETTER;
+
 import datadog.trace.api.Config;
 import datadog.trace.api.DDTags;
+import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
@@ -11,7 +14,7 @@ import org.eclipse.jetty.server.HttpConnection;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
 
-public class JettyDecorator extends HttpServerDecorator<Request, Request, Response> {
+public class JettyDecorator extends HttpServerDecorator<Request, Request, Response, Request> {
   public static final CharSequence SERVLET_REQUEST = UTF8BytesString.create("servlet.request");
   public static final CharSequence JETTY_SERVER = UTF8BytesString.create("jetty-server");
   public static final JettyDecorator DECORATE = new JettyDecorator();
@@ -26,6 +29,16 @@ public class JettyDecorator extends HttpServerDecorator<Request, Request, Respon
   @Override
   protected CharSequence component() {
     return JETTY_SERVER;
+  }
+
+  @Override
+  protected AgentPropagation.ContextVisitor<Request> getter() {
+    return GETTER;
+  }
+
+  @Override
+  public CharSequence spanName() {
+    return SERVLET_REQUEST;
   }
 
   @Override

--- a/dd-java-agent/instrumentation/jetty-7.0/src/main/java/datadog/trace/instrumentation/jetty70/JettyServerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-7.0/src/main/java/datadog/trace/instrumentation/jetty70/JettyServerInstrumentation.java
@@ -2,12 +2,8 @@ package datadog.trace.instrumentation.jetty70;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.DD_SPAN_ATTRIBUTE;
 import static datadog.trace.instrumentation.jetty70.JettyDecorator.DECORATE;
-import static datadog.trace.instrumentation.jetty70.JettyDecorator.SERVLET_REQUEST;
-import static datadog.trace.instrumentation.jetty70.RequestExtractAdapter.GETTER;
 import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
@@ -103,9 +99,8 @@ public final class JettyServerInstrumentation extends Instrumenter.Tracing {
         return activateSpan((AgentSpan) existingSpan);
       }
 
-      final AgentSpan.Context.Extracted extractedContext = propagate().extract(req, GETTER);
-
-      final AgentSpan span = startSpan(SERVLET_REQUEST, extractedContext).setMeasured(true);
+      final AgentSpan.Context.Extracted extractedContext = DECORATE.extract(req);
+      final AgentSpan span = DECORATE.startSpan(req, extractedContext);
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, req, req, extractedContext);
 

--- a/dd-java-agent/instrumentation/jetty-7.6/src/main/java/datadog/trace/instrumentation/jetty76/JettyDecorator.java
+++ b/dd-java-agent/instrumentation/jetty-7.6/src/main/java/datadog/trace/instrumentation/jetty76/JettyDecorator.java
@@ -1,7 +1,10 @@
 package datadog.trace.instrumentation.jetty76;
 
+import static datadog.trace.instrumentation.jetty76.RequestExtractAdapter.GETTER;
+
 import datadog.trace.api.Config;
 import datadog.trace.api.DDTags;
+import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
@@ -11,7 +14,7 @@ import org.eclipse.jetty.server.AbstractHttpConnection;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
 
-public class JettyDecorator extends HttpServerDecorator<Request, Request, Response> {
+public class JettyDecorator extends HttpServerDecorator<Request, Request, Response, Request> {
   public static final CharSequence SERVLET_REQUEST = UTF8BytesString.create("servlet.request");
   public static final CharSequence JETTY_SERVER = UTF8BytesString.create("jetty-server");
   public static final JettyDecorator DECORATE = new JettyDecorator();
@@ -26,6 +29,16 @@ public class JettyDecorator extends HttpServerDecorator<Request, Request, Respon
   @Override
   protected CharSequence component() {
     return JETTY_SERVER;
+  }
+
+  @Override
+  protected AgentPropagation.ContextVisitor<Request> getter() {
+    return GETTER;
+  }
+
+  @Override
+  public CharSequence spanName() {
+    return SERVLET_REQUEST;
   }
 
   @Override

--- a/dd-java-agent/instrumentation/jetty-7.6/src/main/java/datadog/trace/instrumentation/jetty76/JettyServerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-7.6/src/main/java/datadog/trace/instrumentation/jetty76/JettyServerInstrumentation.java
@@ -2,12 +2,8 @@ package datadog.trace.instrumentation.jetty76;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.DD_SPAN_ATTRIBUTE;
 import static datadog.trace.instrumentation.jetty76.JettyDecorator.DECORATE;
-import static datadog.trace.instrumentation.jetty76.JettyDecorator.SERVLET_REQUEST;
-import static datadog.trace.instrumentation.jetty76.RequestExtractAdapter.GETTER;
 import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
 import static net.bytebuddy.matcher.ElementMatchers.takesNoArguments;
@@ -102,9 +98,8 @@ public final class JettyServerInstrumentation extends Instrumenter.Tracing {
         return activateSpan((AgentSpan) existingSpan);
       }
 
-      final AgentSpan.Context.Extracted extractedContext = propagate().extract(req, GETTER);
-
-      final AgentSpan span = startSpan(SERVLET_REQUEST, extractedContext).setMeasured(true);
+      final AgentSpan.Context.Extracted extractedContext = DECORATE.extract(req);
+      final AgentSpan span = DECORATE.startSpan(req, extractedContext);
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, req, req, extractedContext);
 

--- a/dd-java-agent/instrumentation/jetty-9/src/main/java/datadog/trace/instrumentation/jetty9/JettyDecorator.java
+++ b/dd-java-agent/instrumentation/jetty-9/src/main/java/datadog/trace/instrumentation/jetty9/JettyDecorator.java
@@ -1,7 +1,10 @@
 package datadog.trace.instrumentation.jetty9;
 
+import static datadog.trace.instrumentation.jetty9.RequestExtractAdapter.GETTER;
+
 import datadog.trace.api.Config;
 import datadog.trace.api.DDTags;
+import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
@@ -11,7 +14,7 @@ import org.eclipse.jetty.server.HttpChannel;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
 
-public class JettyDecorator extends HttpServerDecorator<Request, Request, Response> {
+public class JettyDecorator extends HttpServerDecorator<Request, Request, Response, Request> {
   public static final CharSequence SERVLET_REQUEST = UTF8BytesString.create("servlet.request");
   public static final CharSequence JETTY_SERVER = UTF8BytesString.create("jetty-server");
   public static final JettyDecorator DECORATE = new JettyDecorator();
@@ -26,6 +29,16 @@ public class JettyDecorator extends HttpServerDecorator<Request, Request, Respon
   @Override
   protected CharSequence component() {
     return JETTY_SERVER;
+  }
+
+  @Override
+  protected AgentPropagation.ContextVisitor<Request> getter() {
+    return GETTER;
+  }
+
+  @Override
+  public CharSequence spanName() {
+    return SERVLET_REQUEST;
   }
 
   @Override

--- a/dd-java-agent/instrumentation/jetty-9/src/main/java/datadog/trace/instrumentation/jetty9/JettyServerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-9/src/main/java/datadog/trace/instrumentation/jetty9/JettyServerInstrumentation.java
@@ -3,13 +3,9 @@ package datadog.trace.instrumentation.jetty9;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.DD_SPAN_ATTRIBUTE;
 import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.ExcludeType.RUNNABLE;
 import static datadog.trace.instrumentation.jetty9.JettyDecorator.DECORATE;
-import static datadog.trace.instrumentation.jetty9.JettyDecorator.SERVLET_REQUEST;
-import static datadog.trace.instrumentation.jetty9.RequestExtractAdapter.GETTER;
 import static net.bytebuddy.matcher.ElementMatchers.declaresMethod;
 import static net.bytebuddy.matcher.ElementMatchers.takesNoArguments;
 
@@ -105,9 +101,8 @@ public final class JettyServerInstrumentation extends Instrumenter.Tracing
         return activateSpan((AgentSpan) existingSpan);
       }
 
-      final AgentSpan.Context.Extracted extractedContext = propagate().extract(req, GETTER);
-
-      final AgentSpan span = startSpan(SERVLET_REQUEST, extractedContext).setMeasured(true);
+      final AgentSpan.Context.Extracted extractedContext = DECORATE.extract(req);
+      final AgentSpan span = DECORATE.startSpan(req, extractedContext);
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, req, req, extractedContext);
 

--- a/dd-java-agent/instrumentation/liberty-20/src/main/java/datadog/trace/instrumentation/liberty20/LibertyDecorator.java
+++ b/dd-java-agent/instrumentation/liberty-20/src/main/java/datadog/trace/instrumentation/liberty20/LibertyDecorator.java
@@ -1,9 +1,12 @@
 package datadog.trace.instrumentation.liberty20;
 
+import static datadog.trace.instrumentation.liberty20.RequestExtractAdapter.GETTER;
+
 import com.ibm.ws.webcontainer.srt.SRTServletResponse;
 import com.ibm.ws.webcontainer.webapp.WebAppErrorReport;
 import datadog.trace.api.Config;
 import datadog.trace.api.DDTags;
+import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
@@ -13,7 +16,8 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 public class LibertyDecorator
-    extends HttpServerDecorator<HttpServletRequest, HttpServletRequest, HttpServletResponse> {
+    extends HttpServerDecorator<
+        HttpServletRequest, HttpServletRequest, HttpServletResponse, HttpServletRequest> {
 
   public static final CharSequence SERVLET_REQUEST = UTF8BytesString.create("servlet.request");
   public static final CharSequence LIBERTY_SERVER = UTF8BytesString.create("liberty-server");
@@ -30,6 +34,16 @@ public class LibertyDecorator
   @Override
   protected CharSequence component() {
     return LIBERTY_SERVER;
+  }
+
+  @Override
+  protected AgentPropagation.ContextVisitor<HttpServletRequest> getter() {
+    return GETTER;
+  }
+
+  @Override
+  public CharSequence spanName() {
+    return SERVLET_REQUEST;
   }
 
   @Override

--- a/dd-java-agent/instrumentation/liberty-20/src/main/java/datadog/trace/instrumentation/liberty20/LibertyServerInstrumentation.java
+++ b/dd-java-agent/instrumentation/liberty-20/src/main/java/datadog/trace/instrumentation/liberty20/LibertyServerInstrumentation.java
@@ -2,12 +2,9 @@ package datadog.trace.instrumentation.liberty20;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
 import static datadog.trace.instrumentation.liberty20.LibertyDecorator.DD_EXTRACTED_CONTEXT_ATTRIBUTE;
 import static datadog.trace.instrumentation.liberty20.LibertyDecorator.DD_SPAN_ATTRIBUTE;
 import static datadog.trace.instrumentation.liberty20.LibertyDecorator.DECORATE;
-import static datadog.trace.instrumentation.liberty20.LibertyDecorator.SERVLET_REQUEST;
-import static datadog.trace.instrumentation.liberty20.RequestExtractAdapter.GETTER;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
@@ -18,7 +15,6 @@ import datadog.trace.api.CorrelationIdentifier;
 import datadog.trace.api.GlobalTracer;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import javax.servlet.ServletRequest;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
@@ -73,10 +69,9 @@ public final class LibertyServerInstrumentation extends Instrumenter.Tracing {
       } catch (NullPointerException e) {
       }
 
-      final AgentSpan.Context.Extracted extractedContext = propagate().extract(request, GETTER);
+      final AgentSpan.Context.Extracted extractedContext = DECORATE.extract(request);
       request.setAttribute(DD_EXTRACTED_CONTEXT_ATTRIBUTE, extractedContext);
-      final AgentSpan span =
-          AgentTracer.startSpan(SERVLET_REQUEST, extractedContext).setMeasured(true);
+      final AgentSpan span = DECORATE.startSpan(request, extractedContext);
 
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, request, request, extractedContext);

--- a/dd-java-agent/instrumentation/liberty-20/src/main/java/datadog/trace/instrumentation/liberty20/RequestFinishInstrumentation.java
+++ b/dd-java-agent/instrumentation/liberty-20/src/main/java/datadog/trace/instrumentation/liberty20/RequestFinishInstrumentation.java
@@ -25,7 +25,9 @@ public class RequestFinishInstrumentation extends Instrumenter.Tracing {
   @Override
   public String[] helperClassNames() {
     return new String[] {
-      packageName + ".LibertyDecorator", packageName + ".RequestURIDataAdapter",
+      packageName + ".RequestExtractAdapter",
+      packageName + ".LibertyDecorator",
+      packageName + ".RequestURIDataAdapter",
     };
   }
 

--- a/dd-java-agent/instrumentation/liberty-20/src/main/java/datadog/trace/instrumentation/liberty20/ResponseFinishInstrumentation.java
+++ b/dd-java-agent/instrumentation/liberty-20/src/main/java/datadog/trace/instrumentation/liberty20/ResponseFinishInstrumentation.java
@@ -24,7 +24,9 @@ public class ResponseFinishInstrumentation extends Instrumenter.Tracing {
   @Override
   public String[] helperClassNames() {
     return new String[] {
-      packageName + ".LibertyDecorator", packageName + ".RequestURIDataAdapter",
+      packageName + ".RequestExtractAdapter",
+      packageName + ".LibertyDecorator",
+      packageName + ".RequestURIDataAdapter",
     };
   }
 

--- a/dd-java-agent/instrumentation/micronaut-http-server-netty-2/src/main/java8/datadog/trace/instrumentation/micronaut/ChannelRead0Advice.java
+++ b/dd-java-agent/instrumentation/micronaut-http-server-netty-2/src/main/java8/datadog/trace/instrumentation/micronaut/ChannelRead0Advice.java
@@ -4,7 +4,6 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSp
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.micronaut.MicronautDecorator.DECORATE;
-import static datadog.trace.instrumentation.micronaut.MicronautDecorator.MICRONAUT_CONTROLLER;
 import static datadog.trace.instrumentation.micronaut.MicronautDecorator.PARENT_SPAN_ATTRIBUTE;
 import static datadog.trace.instrumentation.micronaut.MicronautDecorator.SPAN_ATTRIBUTE;
 
@@ -23,11 +22,8 @@ public class ChannelRead0Advice {
       // Micronaut-netty uses Netty so there needs to be a Netty span
       return null;
     }
-    final AgentSpan span = startSpan(MICRONAUT_CONTROLLER);
+    final AgentSpan span = startSpan(DECORATE.spanName()).setMeasured(true);
     DECORATE.afterStart(span);
-
-    span.setMeasured(true);
-
     request.setAttribute(SPAN_ATTRIBUTE, span);
     request.setAttribute(PARENT_SPAN_ATTRIBUTE, nettySpan);
 

--- a/dd-java-agent/instrumentation/micronaut-http-server-netty-2/src/main/java8/datadog/trace/instrumentation/micronaut/MicronautDecorator.java
+++ b/dd-java-agent/instrumentation/micronaut-http-server-netty-2/src/main/java8/datadog/trace/instrumentation/micronaut/MicronautDecorator.java
@@ -2,6 +2,7 @@ package datadog.trace.instrumentation.micronaut;
 
 import static datadog.trace.bootstrap.instrumentation.decorator.RouteHandlerDecorator.ROUTE_HANDLER_DECORATOR;
 
+import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
@@ -14,11 +15,9 @@ import io.micronaut.web.router.RouteMatch;
 import io.micronaut.web.router.UriRouteMatch;
 
 public class MicronautDecorator
-    extends HttpServerDecorator<HttpRequest, HttpRequest, MutableHttpResponse> {
-
-  public static final CharSequence MICRONAUT_CONTROLLER =
+    extends HttpServerDecorator<HttpRequest, HttpRequest, MutableHttpResponse, Void> {
+  private static final CharSequence MICRONAUT_CONTROLLER =
       UTF8BytesString.create("micronaut-controller");
-
   public static final String SPAN_ATTRIBUTE = "datadog.trace.instrumentation.micronaut-netty.Span";
   public static final String PARENT_SPAN_ATTRIBUTE =
       "datadog.trace.instrumentation.micronaut-netty.ParentSpan";
@@ -28,6 +27,16 @@ public class MicronautDecorator
   @Override
   protected String[] instrumentationNames() {
     return new String[0];
+  }
+
+  @Override
+  protected AgentPropagation.ContextVisitor<Void> getter() {
+    return null;
+  }
+
+  @Override
+  public CharSequence spanName() {
+    return MICRONAUT_CONTROLLER;
   }
 
   @Override

--- a/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/server/HttpServerRequestTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/server/HttpServerRequestTracingHandler.java
@@ -1,21 +1,18 @@
 package datadog.trace.instrumentation.netty38.server;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.netty38.server.NettyHttpServerDecorator.DECORATE;
-import static datadog.trace.instrumentation.netty38.server.NettyHttpServerDecorator.NETTY_REQUEST;
 
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan.Context;
-import datadog.trace.bootstrap.instrumentation.api.ContextVisitors;
 import datadog.trace.instrumentation.netty38.ChannelTraceContext;
 import org.jboss.netty.channel.Channel;
 import org.jboss.netty.channel.ChannelHandlerContext;
 import org.jboss.netty.channel.MessageEvent;
 import org.jboss.netty.channel.SimpleChannelUpstreamHandler;
+import org.jboss.netty.handler.codec.http.HttpHeaders;
 import org.jboss.netty.handler.codec.http.HttpRequest;
 
 public class HttpServerRequestTracingHandler extends SimpleChannelUpstreamHandler {
@@ -47,12 +44,10 @@ public class HttpServerRequestTracingHandler extends SimpleChannelUpstreamHandle
     }
 
     final HttpRequest request = (HttpRequest) msg.getMessage();
+    final HttpHeaders headers = request.headers();
+    final Context.Extracted context = DECORATE.extract(headers);
+    final AgentSpan span = DECORATE.startSpan(headers, context);
 
-    final Context.Extracted context =
-        propagate().extract(request.headers(), ContextVisitors.stringValuesEntrySet());
-
-    final AgentSpan span = startSpan(NETTY_REQUEST, context);
-    span.setMeasured(true);
     try (final AgentScope scope = activateSpan(span)) {
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, ctx.getChannel(), request, context);

--- a/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/server/NettyHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/server/NettyHttpServerDecorator.java
@@ -2,6 +2,8 @@ package datadog.trace.instrumentation.netty38.server;
 
 import static org.jboss.netty.handler.codec.http.HttpHeaders.Names.HOST;
 
+import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
+import datadog.trace.bootstrap.instrumentation.api.ContextVisitors;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.bootstrap.instrumentation.api.URIDefaultDataAdapter;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
@@ -10,11 +12,12 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.net.URI;
 import org.jboss.netty.channel.Channel;
+import org.jboss.netty.handler.codec.http.HttpHeaders;
 import org.jboss.netty.handler.codec.http.HttpRequest;
 import org.jboss.netty.handler.codec.http.HttpResponse;
 
 public class NettyHttpServerDecorator
-    extends HttpServerDecorator<HttpRequest, Channel, HttpResponse> {
+    extends HttpServerDecorator<HttpRequest, Channel, HttpResponse, HttpHeaders> {
   public static final CharSequence NETTY = UTF8BytesString.create("netty");
   public static final CharSequence NETTY_CONNECT = UTF8BytesString.create("netty.connect");
   public static final CharSequence NETTY_REQUEST = UTF8BytesString.create("netty.request");
@@ -28,6 +31,16 @@ public class NettyHttpServerDecorator
   @Override
   protected CharSequence component() {
     return NETTY;
+  }
+
+  @Override
+  protected AgentPropagation.ContextVisitor<HttpHeaders> getter() {
+    return ContextVisitors.stringValuesEntrySet();
+  }
+
+  @Override
+  public CharSequence spanName() {
+    return NETTY_REQUEST;
   }
 
   @Override

--- a/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/server/HttpServerRequestTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/server/HttpServerRequestTracingHandler.java
@@ -1,19 +1,16 @@
 package datadog.trace.instrumentation.netty40.server;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.netty40.AttributeKeys.SPAN_ATTRIBUTE_KEY;
 import static datadog.trace.instrumentation.netty40.server.NettyHttpServerDecorator.DECORATE;
-import static datadog.trace.instrumentation.netty40.server.NettyHttpServerDecorator.NETTY_REQUEST;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan.Context;
-import datadog.trace.bootstrap.instrumentation.api.ContextVisitors;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpRequest;
 
 @ChannelHandler.Sharable
@@ -37,12 +34,10 @@ public class HttpServerRequestTracingHandler extends ChannelInboundHandlerAdapte
     }
 
     final HttpRequest request = (HttpRequest) msg;
+    final HttpHeaders headers = request.headers();
+    final Context.Extracted extractedContext = DECORATE.extract(headers);
+    final AgentSpan span = DECORATE.startSpan(headers, extractedContext);
 
-    final Context.Extracted extractedContext =
-        propagate().extract(request.headers(), ContextVisitors.stringValuesEntrySet());
-
-    final AgentSpan span = startSpan(NETTY_REQUEST, extractedContext);
-    span.setMeasured(true);
     try (final AgentScope scope = activateSpan(span)) {
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, ctx.channel(), request, extractedContext);

--- a/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/server/NettyHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/server/NettyHttpServerDecorator.java
@@ -2,11 +2,14 @@ package datadog.trace.instrumentation.netty40.server;
 
 import static io.netty.handler.codec.http.HttpHeaders.Names.HOST;
 
+import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
+import datadog.trace.bootstrap.instrumentation.api.ContextVisitors;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.bootstrap.instrumentation.api.URIDefaultDataAdapter;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
 import io.netty.channel.Channel;
+import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
 import java.net.InetSocketAddress;
@@ -14,7 +17,7 @@ import java.net.SocketAddress;
 import java.net.URI;
 
 public class NettyHttpServerDecorator
-    extends HttpServerDecorator<HttpRequest, Channel, HttpResponse> {
+    extends HttpServerDecorator<HttpRequest, Channel, HttpResponse, HttpHeaders> {
   public static final CharSequence NETTY = UTF8BytesString.create("netty");
   public static final CharSequence NETTY_CONNECT = UTF8BytesString.create("netty.connect");
   public static final CharSequence NETTY_REQUEST = UTF8BytesString.create("netty.request");
@@ -28,6 +31,16 @@ public class NettyHttpServerDecorator
   @Override
   protected CharSequence component() {
     return NETTY;
+  }
+
+  @Override
+  protected AgentPropagation.ContextVisitor<HttpHeaders> getter() {
+    return ContextVisitors.stringValuesEntrySet();
+  }
+
+  @Override
+  public CharSequence spanName() {
+    return NETTY_REQUEST;
   }
 
   @Override

--- a/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/server/NettyHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/server/NettyHttpServerDecorator.java
@@ -2,11 +2,14 @@ package datadog.trace.instrumentation.netty41.server;
 
 import static io.netty.handler.codec.http.HttpHeaderNames.HOST;
 
+import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
+import datadog.trace.bootstrap.instrumentation.api.ContextVisitors;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.bootstrap.instrumentation.api.URIDefaultDataAdapter;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
 import io.netty.channel.Channel;
+import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
 import java.net.InetSocketAddress;
@@ -14,7 +17,7 @@ import java.net.SocketAddress;
 import java.net.URI;
 
 public class NettyHttpServerDecorator
-    extends HttpServerDecorator<HttpRequest, Channel, HttpResponse> {
+    extends HttpServerDecorator<HttpRequest, Channel, HttpResponse, HttpHeaders> {
   public static final CharSequence NETTY = UTF8BytesString.create("netty");
   public static final CharSequence NETTY_CONNECT = UTF8BytesString.create("netty.connect");
   public static final CharSequence NETTY_REQUEST = UTF8BytesString.create("netty.request");
@@ -28,6 +31,16 @@ public class NettyHttpServerDecorator
   @Override
   protected CharSequence component() {
     return NETTY;
+  }
+
+  @Override
+  protected AgentPropagation.ContextVisitor<HttpHeaders> getter() {
+    return ContextVisitors.stringValuesEntrySet();
+  }
+
+  @Override
+  public CharSequence spanName() {
+    return NETTY_REQUEST;
   }
 
   @Override

--- a/dd-java-agent/instrumentation/play-2.3/src/main/java8/datadog/trace/instrumentation/play23/PlayAdvice.java
+++ b/dd-java-agent/instrumentation/play-2.3/src/main/java8/datadog/trace/instrumentation/play23/PlayAdvice.java
@@ -2,9 +2,7 @@ package datadog.trace.instrumentation.play23;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
-import static datadog.trace.instrumentation.play23.PlayHeaders.GETTER;
 import static datadog.trace.instrumentation.play23.PlayHttpServerDecorator.DECORATE;
 import static datadog.trace.instrumentation.play23.PlayHttpServerDecorator.PLAY_REQUEST;
 import static datadog.trace.instrumentation.play23.PlayHttpServerDecorator.REPORT_HTTP_STATUS;
@@ -14,6 +12,7 @@ import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan.Context;
 import net.bytebuddy.asm.Advice;
 import play.api.mvc.Action;
+import play.api.mvc.Headers;
 import play.api.mvc.Request;
 import play.api.mvc.Result;
 import scala.concurrent.Future;
@@ -23,14 +22,15 @@ public class PlayAdvice {
   public static AgentScope onEnter(@Advice.Argument(0) final Request req) {
     final AgentSpan span;
     if (activeSpan() == null) {
-      final Context extractedContext = propagate().extract(req.headers(), GETTER);
-      span = startSpan(PLAY_REQUEST, extractedContext);
+      Headers headers = req.headers();
+      final Context.Extracted extractedContext = DECORATE.extract(headers);
+      span = DECORATE.startSpan(headers, extractedContext);
     } else {
       // An upstream framework (e.g. akka-http, netty) has already started the span.
       // Do not extract the context.
       span = startSpan(PLAY_REQUEST);
+      span.setMeasured(true);
     }
-    span.setMeasured(true);
     DECORATE.afterStart(span);
 
     final AgentScope scope = activateSpan(span);

--- a/dd-java-agent/instrumentation/play-2.3/src/main/java8/datadog/trace/instrumentation/play23/PlayHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/play-2.3/src/main/java8/datadog/trace/instrumentation/play23/PlayHttpServerDecorator.java
@@ -1,8 +1,10 @@
 package datadog.trace.instrumentation.play23;
 
 import static datadog.trace.bootstrap.instrumentation.decorator.RouteHandlerDecorator.ROUTE_HANDLER_DECORATOR;
+import static datadog.trace.instrumentation.play23.PlayHeaders.GETTER;
 
 import datadog.trace.api.Config;
+import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
@@ -10,11 +12,13 @@ import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.UndeclaredThrowableException;
 import play.api.Routes;
+import play.api.mvc.Headers;
 import play.api.mvc.Request;
 import play.api.mvc.Result;
 import scala.Option;
 
-public class PlayHttpServerDecorator extends HttpServerDecorator<Request, Request, Result> {
+public class PlayHttpServerDecorator
+    extends HttpServerDecorator<Request, Request, Result, Headers> {
   public static final boolean REPORT_HTTP_STATUS = Config.get().getPlayReportHttpStatus();
   public static final CharSequence PLAY_REQUEST = UTF8BytesString.create("play.request");
   public static final CharSequence PLAY_ACTION = UTF8BytesString.create("play-action");
@@ -28,6 +32,16 @@ public class PlayHttpServerDecorator extends HttpServerDecorator<Request, Reques
   @Override
   protected CharSequence component() {
     return PLAY_ACTION;
+  }
+
+  @Override
+  protected AgentPropagation.ContextVisitor<Headers> getter() {
+    return GETTER;
+  }
+
+  @Override
+  public CharSequence spanName() {
+    return PLAY_REQUEST;
   }
 
   @Override

--- a/dd-java-agent/instrumentation/play-2.4/src/main/java8/datadog/trace/instrumentation/play24/PlayAdvice.java
+++ b/dd-java-agent/instrumentation/play-2.4/src/main/java8/datadog/trace/instrumentation/play24/PlayAdvice.java
@@ -2,9 +2,7 @@ package datadog.trace.instrumentation.play24;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
-import static datadog.trace.instrumentation.play24.PlayHeaders.GETTER;
 import static datadog.trace.instrumentation.play24.PlayHttpServerDecorator.DECORATE;
 import static datadog.trace.instrumentation.play24.PlayHttpServerDecorator.PLAY_REQUEST;
 import static datadog.trace.instrumentation.play24.PlayHttpServerDecorator.REPORT_HTTP_STATUS;
@@ -14,6 +12,7 @@ import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan.Context;
 import net.bytebuddy.asm.Advice;
 import play.api.mvc.Action;
+import play.api.mvc.Headers;
 import play.api.mvc.Request;
 import play.api.mvc.Result;
 import scala.concurrent.Future;
@@ -29,14 +28,15 @@ public class PlayAdvice {
     }
 
     if (activeSpan() == null) {
-      final Context extractedContext = propagate().extract(req.headers(), GETTER);
-      span = startSpan(PLAY_REQUEST, extractedContext);
+      final Headers headers = req.headers();
+      final Context.Extracted extractedContext = DECORATE.extract(headers);
+      span = DECORATE.startSpan(headers, extractedContext);
     } else {
       // An upstream framework (e.g. akka-http, netty) has already started the span.
       // Do not extract the context.
       span = startSpan(PLAY_REQUEST);
+      span.setMeasured(true);
     }
-    span.setMeasured(true);
     DECORATE.afterStart(span);
 
     final AgentScope scope = activateSpan(span);

--- a/dd-java-agent/instrumentation/play-2.4/src/main/java8/datadog/trace/instrumentation/play24/PlayHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/play-2.4/src/main/java8/datadog/trace/instrumentation/play24/PlayHttpServerDecorator.java
@@ -1,19 +1,23 @@
 package datadog.trace.instrumentation.play24;
 
 import static datadog.trace.bootstrap.instrumentation.decorator.RouteHandlerDecorator.ROUTE_HANDLER_DECORATOR;
+import static datadog.trace.instrumentation.play24.PlayHeaders.GETTER;
 
 import datadog.trace.api.Config;
+import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.UndeclaredThrowableException;
+import play.api.mvc.Headers;
 import play.api.mvc.Request;
 import play.api.mvc.Result;
 import scala.Option;
 
-public class PlayHttpServerDecorator extends HttpServerDecorator<Request, Request, Result> {
+public class PlayHttpServerDecorator
+    extends HttpServerDecorator<Request, Request, Result, Headers> {
   public static final boolean REPORT_HTTP_STATUS = Config.get().getPlayReportHttpStatus();
   public static final CharSequence PLAY_REQUEST = UTF8BytesString.create("play.request");
   public static final CharSequence PLAY_ACTION = UTF8BytesString.create("play-action");
@@ -27,6 +31,16 @@ public class PlayHttpServerDecorator extends HttpServerDecorator<Request, Reques
   @Override
   protected CharSequence component() {
     return PLAY_ACTION;
+  }
+
+  @Override
+  protected AgentPropagation.ContextVisitor<Headers> getter() {
+    return GETTER;
+  }
+
+  @Override
+  public CharSequence spanName() {
+    return PLAY_REQUEST;
   }
 
   @Override

--- a/dd-java-agent/instrumentation/play-2.6/src/main/java8/datadog/trace/instrumentation/play26/PlayAdvice.java
+++ b/dd-java-agent/instrumentation/play-2.6/src/main/java8/datadog/trace/instrumentation/play26/PlayAdvice.java
@@ -2,9 +2,7 @@ package datadog.trace.instrumentation.play26;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
-import static datadog.trace.instrumentation.play26.PlayHeaders.GETTER;
 import static datadog.trace.instrumentation.play26.PlayHttpServerDecorator.DECORATE;
 import static datadog.trace.instrumentation.play26.PlayHttpServerDecorator.PLAY_REQUEST;
 
@@ -13,6 +11,7 @@ import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan.Context;
 import net.bytebuddy.asm.Advice;
 import play.api.mvc.Action;
+import play.api.mvc.Headers;
 import play.api.mvc.Request;
 import play.api.mvc.Result;
 import scala.concurrent.Future;
@@ -28,8 +27,9 @@ public class PlayAdvice {
     }
 
     if (activeSpan() == null) {
-      final Context extractedContext = propagate().extract(req.headers(), GETTER);
-      span = startSpan(PLAY_REQUEST, extractedContext);
+      final Headers headers = req.headers();
+      final Context.Extracted extractedContext = DECORATE.extract(headers);
+      span = DECORATE.startSpan(headers, extractedContext);
     } else {
       // An upstream framework (e.g. akka-http, netty) has already started the span.
       // Do not extract the context.

--- a/dd-java-agent/instrumentation/play-2.6/src/main/java8/datadog/trace/instrumentation/play26/PlayHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/play-2.6/src/main/java8/datadog/trace/instrumentation/play26/PlayHttpServerDecorator.java
@@ -1,8 +1,10 @@
 package datadog.trace.instrumentation.play26;
 
 import static datadog.trace.bootstrap.instrumentation.decorator.RouteHandlerDecorator.ROUTE_HANDLER_DECORATOR;
+import static datadog.trace.instrumentation.play26.PlayHeaders.GETTER;
 
 import datadog.trace.api.Config;
+import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
@@ -13,6 +15,7 @@ import java.lang.invoke.MethodType;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.UndeclaredThrowableException;
 import java.util.concurrent.CompletionException;
+import play.api.mvc.Headers;
 import play.api.mvc.Request;
 import play.api.mvc.Result;
 import play.api.routing.HandlerDef;
@@ -20,7 +23,8 @@ import play.libs.typedmap.TypedKey;
 import play.routing.Router;
 import scala.Option;
 
-public class PlayHttpServerDecorator extends HttpServerDecorator<Request, Request, Result> {
+public class PlayHttpServerDecorator
+    extends HttpServerDecorator<Request, Request, Result, Headers> {
   public static final boolean REPORT_HTTP_STATUS = Config.get().getPlayReportHttpStatus();
   public static final CharSequence PLAY_REQUEST = UTF8BytesString.create("play.request");
   public static final CharSequence PLAY_ACTION = UTF8BytesString.create("play-action");
@@ -59,6 +63,16 @@ public class PlayHttpServerDecorator extends HttpServerDecorator<Request, Reques
   @Override
   protected CharSequence component() {
     return PLAY_ACTION;
+  }
+
+  @Override
+  protected AgentPropagation.ContextVisitor<Headers> getter() {
+    return GETTER;
+  }
+
+  @Override
+  public CharSequence spanName() {
+    return PLAY_REQUEST;
   }
 
   @Override

--- a/dd-java-agent/instrumentation/ratpack-1.5/src/main/java8/datadog/trace/instrumentation/ratpack/RatpackServerDecorator.java
+++ b/dd-java-agent/instrumentation/ratpack-1.5/src/main/java8/datadog/trace/instrumentation/ratpack/RatpackServerDecorator.java
@@ -2,6 +2,7 @@ package datadog.trace.instrumentation.ratpack;
 
 import static datadog.trace.bootstrap.instrumentation.decorator.RouteHandlerDecorator.ROUTE_HANDLER_DECORATOR;
 
+import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
@@ -11,7 +12,7 @@ import ratpack.http.Request;
 import ratpack.http.Response;
 import ratpack.http.Status;
 
-public class RatpackServerDecorator extends HttpServerDecorator<Request, Request, Response> {
+public class RatpackServerDecorator extends HttpServerDecorator<Request, Request, Response, Void> {
   public static final CharSequence RATPACK_HANDLER = UTF8BytesString.create("ratpack.handler");
   public static final CharSequence RATPACK = UTF8BytesString.create("ratpack");
   public static final RatpackServerDecorator DECORATE = new RatpackServerDecorator();
@@ -29,6 +30,16 @@ public class RatpackServerDecorator extends HttpServerDecorator<Request, Request
   @Override
   protected boolean traceAnalyticsDefault() {
     return false;
+  }
+
+  @Override
+  protected AgentPropagation.ContextVisitor<Void> getter() {
+    return null;
+  }
+
+  @Override
+  public CharSequence spanName() {
+    return RATPACK_HANDLER;
   }
 
   @Override

--- a/dd-java-agent/instrumentation/ratpack-1.5/src/main/java8/datadog/trace/instrumentation/ratpack/TracingHandler.java
+++ b/dd-java-agent/instrumentation/ratpack-1.5/src/main/java8/datadog/trace/instrumentation/ratpack/TracingHandler.java
@@ -4,7 +4,6 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSp
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.DD_SPAN_ATTRIBUTE;
 import static datadog.trace.instrumentation.ratpack.RatpackServerDecorator.DECORATE;
-import static datadog.trace.instrumentation.ratpack.RatpackServerDecorator.RATPACK_HANDLER;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
@@ -30,8 +29,7 @@ public final class TracingHandler implements Handler {
     final AgentSpan nettySpan = spanAttribute.get();
 
     // Relying on executor instrumentation to assume the netty span is in context as the parent.
-    final AgentSpan ratpackSpan = startSpan(RATPACK_HANDLER);
-    ratpackSpan.setMeasured(true);
+    final AgentSpan ratpackSpan = startSpan(DECORATE.spanName()).setMeasured(true);
     DECORATE.afterStart(ratpackSpan);
     DECORATE.onRequest(ratpackSpan, request, request, null);
     ctx.getExecution().add(ratpackSpan);

--- a/dd-java-agent/instrumentation/restlet-2.2/src/main/java/datadog/trace/instrumentation/restlet/RestletDecorator.java
+++ b/dd-java-agent/instrumentation/restlet-2.2/src/main/java/datadog/trace/instrumentation/restlet/RestletDecorator.java
@@ -1,12 +1,15 @@
 package datadog.trace.instrumentation.restlet;
 
+import static datadog.trace.instrumentation.restlet.RestletExtractAdapter.GETTER;
+
 import com.sun.net.httpserver.HttpExchange;
+import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
 
 public class RestletDecorator
-    extends HttpServerDecorator<HttpExchange, HttpExchange, HttpExchange> {
+    extends HttpServerDecorator<HttpExchange, HttpExchange, HttpExchange, HttpExchange> {
   public static final CharSequence RESTLET_REQUEST = UTF8BytesString.create("restlet-http.request");
   public static final CharSequence RESTLET_HTTP_SERVER =
       UTF8BytesString.create("restlet-http-server");
@@ -20,6 +23,16 @@ public class RestletDecorator
   @Override
   protected CharSequence component() {
     return RESTLET_HTTP_SERVER;
+  }
+
+  @Override
+  protected AgentPropagation.ContextVisitor<HttpExchange> getter() {
+    return GETTER;
+  }
+
+  @Override
+  public CharSequence spanName() {
+    return RESTLET_REQUEST;
   }
 
   @Override

--- a/dd-java-agent/instrumentation/restlet-2.2/src/main/java/datadog/trace/instrumentation/restlet/RestletInstrumentation.java
+++ b/dd-java-agent/instrumentation/restlet-2.2/src/main/java/datadog/trace/instrumentation/restlet/RestletInstrumentation.java
@@ -2,10 +2,7 @@ package datadog.trace.instrumentation.restlet;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.restlet.RestletDecorator.DECORATE;
-import static datadog.trace.instrumentation.restlet.RestletDecorator.RESTLET_REQUEST;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
@@ -52,11 +49,8 @@ public final class RestletInstrumentation extends Instrumenter.Tracing {
   public static class RestletHandleAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static AgentScope beginRequest(@Advice.Argument(0) final HttpExchange exchange) {
-      AgentSpan.Context.Extracted context =
-          propagate().extract(exchange, RestletExtractAdapter.GETTER);
-
-      AgentSpan span = startSpan(RESTLET_REQUEST, context);
-      span.setMeasured(true);
+      AgentSpan.Context.Extracted context = DECORATE.extract(exchange);
+      AgentSpan span = DECORATE.startSpan(exchange, context);
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, exchange, exchange, context);
       DECORATE.onPeerConnection(span, exchange.getRemoteAddress());

--- a/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/Servlet2Advice.java
+++ b/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/Servlet2Advice.java
@@ -1,12 +1,8 @@
 package datadog.trace.instrumentation.servlet2;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.DD_SPAN_ATTRIBUTE;
-import static datadog.trace.instrumentation.servlet2.HttpServletRequestExtractAdapter.GETTER;
 import static datadog.trace.instrumentation.servlet2.Servlet2Decorator.DECORATE;
-import static datadog.trace.instrumentation.servlet2.Servlet2Decorator.SERVLET_REQUEST;
 
 import datadog.trace.api.Config;
 import datadog.trace.api.CorrelationIdentifier;
@@ -50,11 +46,8 @@ public class Servlet2Advice {
       InstrumentationContext.get(ServletResponse.class, Integer.class).put(response, 200);
     }
 
-    final AgentSpan.Context.Extracted extractedContext =
-        propagate().extract(httpServletRequest, GETTER);
-
-    final AgentSpan span = startSpan(SERVLET_REQUEST, extractedContext).setMeasured(true);
-
+    final AgentSpan.Context.Extracted extractedContext = DECORATE.extract(httpServletRequest);
+    final AgentSpan span = DECORATE.startSpan(httpServletRequest, extractedContext);
     DECORATE.afterStart(span);
     DECORATE.onRequest(span, httpServletRequest, httpServletRequest, extractedContext);
 

--- a/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/Servlet2Decorator.java
+++ b/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/Servlet2Decorator.java
@@ -1,5 +1,8 @@
 package datadog.trace.instrumentation.servlet2;
 
+import static datadog.trace.instrumentation.servlet2.HttpServletRequestExtractAdapter.GETTER;
+
+import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
@@ -7,7 +10,8 @@ import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
 import javax.servlet.http.HttpServletRequest;
 
 public class Servlet2Decorator
-    extends HttpServerDecorator<HttpServletRequest, HttpServletRequest, Integer> {
+    extends HttpServerDecorator<
+        HttpServletRequest, HttpServletRequest, Integer, HttpServletRequest> {
   public static final CharSequence SERVLET_REQUEST = UTF8BytesString.create("servlet.request");
   public static final CharSequence JAVA_WEB_SERVLET = UTF8BytesString.create("java-web-servlet");
   public static final Servlet2Decorator DECORATE = new Servlet2Decorator();
@@ -20,6 +24,16 @@ public class Servlet2Decorator
   @Override
   protected CharSequence component() {
     return JAVA_WEB_SERVLET;
+  }
+
+  @Override
+  protected AgentPropagation.ContextVisitor<HttpServletRequest> getter() {
+    return GETTER;
+  }
+
+  @Override
+  public CharSequence spanName() {
+    return SERVLET_REQUEST;
   }
 
   @Override

--- a/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Advice.java
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Advice.java
@@ -1,13 +1,9 @@
 package datadog.trace.instrumentation.servlet3;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.DD_DISPATCH_SPAN_ATTRIBUTE;
 import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.DD_SPAN_ATTRIBUTE;
-import static datadog.trace.instrumentation.servlet3.HttpServletRequestExtractAdapter.GETTER;
 import static datadog.trace.instrumentation.servlet3.Servlet3Decorator.DECORATE;
-import static datadog.trace.instrumentation.servlet3.Servlet3Decorator.SERVLET_REQUEST;
 
 import datadog.trace.api.Config;
 import datadog.trace.api.CorrelationIdentifier;
@@ -54,10 +50,8 @@ public class Servlet3Advice {
       return null;
     }
 
-    final AgentSpan.Context.Extracted extractedContext =
-        propagate().extract(httpServletRequest, GETTER);
-
-    final AgentSpan span = startSpan(SERVLET_REQUEST, extractedContext).setMeasured(true);
+    final AgentSpan.Context.Extracted extractedContext = DECORATE.extract(httpServletRequest);
+    final AgentSpan span = DECORATE.startSpan(httpServletRequest, extractedContext);
 
     DECORATE.afterStart(span);
     DECORATE.onRequest(span, httpServletRequest, httpServletRequest, extractedContext);

--- a/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Decorator.java
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Decorator.java
@@ -1,5 +1,8 @@
 package datadog.trace.instrumentation.servlet3;
 
+import static datadog.trace.instrumentation.servlet3.HttpServletRequestExtractAdapter.GETTER;
+
+import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
@@ -9,7 +12,8 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 public class Servlet3Decorator
-    extends HttpServerDecorator<HttpServletRequest, HttpServletRequest, HttpServletResponse> {
+    extends HttpServerDecorator<
+        HttpServletRequest, HttpServletRequest, HttpServletResponse, HttpServletRequest> {
   public static final CharSequence SERVLET_REQUEST = UTF8BytesString.create("servlet.request");
   public static final CharSequence JAVA_WEB_SERVLET = UTF8BytesString.create("java-web-servlet");
   public static final Servlet3Decorator DECORATE = new Servlet3Decorator();
@@ -24,6 +28,16 @@ public class Servlet3Decorator
   @Override
   protected CharSequence component() {
     return JAVA_WEB_SERVLET;
+  }
+
+  @Override
+  protected AgentPropagation.ContextVisitor<HttpServletRequest> getter() {
+    return GETTER;
+  }
+
+  @Override
+  public CharSequence spanName() {
+    return SERVLET_REQUEST;
   }
 
   @Override

--- a/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Instrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Instrumentation.java
@@ -36,9 +36,9 @@ public final class Servlet3Instrumentation extends Instrumenter.Tracing {
   @Override
   public String[] helperClassNames() {
     return new String[] {
+      packageName + ".HttpServletRequestExtractAdapter",
       packageName + ".Servlet3Decorator",
       packageName + ".ServletRequestURIAdapter",
-      packageName + ".HttpServletRequestExtractAdapter",
       packageName + ".TagSettingAsyncListener"
     };
   }

--- a/dd-java-agent/instrumentation/spray-1.3/src/main/scala/datadog/trace/instrumentation/spray/SprayHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/spray-1.3/src/main/scala/datadog/trace/instrumentation/spray/SprayHttpServerDecorator.java
@@ -1,5 +1,8 @@
 package datadog.trace.instrumentation.spray;
 
+import static datadog.trace.instrumentation.spray.SprayHeaders.GETTER;
+
+import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
@@ -8,12 +11,22 @@ import spray.http.HttpResponse;
 import spray.routing.RequestContext;
 
 public class SprayHttpServerDecorator
-    extends HttpServerDecorator<HttpRequest, RequestContext, HttpResponse> {
+    extends HttpServerDecorator<HttpRequest, RequestContext, HttpResponse, HttpRequest> {
   public static final CharSequence SPRAY_HTTP_REQUEST =
       UTF8BytesString.create("spray-http.request");
   public static final CharSequence SPRAY_HTTP_SERVER = UTF8BytesString.create("spray-http-server");
 
   public static final SprayHttpServerDecorator DECORATE = new SprayHttpServerDecorator();
+
+  @Override
+  protected AgentPropagation.ContextVisitor<HttpRequest> getter() {
+    return GETTER;
+  }
+
+  @Override
+  public CharSequence spanName() {
+    return SPRAY_HTTP_REQUEST;
+  }
 
   @Override
   protected String method(HttpRequest request) {

--- a/dd-java-agent/instrumentation/spray-1.3/src/main/scala/datadog/trace/instrumentation/spray/SprayHttpServerRunSealedRouteAdvice.java
+++ b/dd-java-agent/instrumentation/spray-1.3/src/main/scala/datadog/trace/instrumentation/spray/SprayHttpServerRunSealedRouteAdvice.java
@@ -2,15 +2,14 @@ package datadog.trace.instrumentation.spray;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
-import static datadog.trace.instrumentation.spray.SprayHeaders.GETTER;
 import static datadog.trace.instrumentation.spray.SprayHttpServerDecorator.DECORATE;
 import static datadog.trace.instrumentation.spray.SprayHttpServerDecorator.SPRAY_HTTP_REQUEST;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import net.bytebuddy.asm.Advice;
+import spray.http.HttpRequest;
 import spray.routing.RequestContext;
 
 public class SprayHttpServerRunSealedRouteAdvice {
@@ -20,8 +19,9 @@ public class SprayHttpServerRunSealedRouteAdvice {
     if (activeSpan() == null) {
       // Propagate context in case income request was going through several routes
       // TODO: Add test for it
-      final AgentSpan.Context extractedContext = propagate().extract(ctx.request(), GETTER);
-      span = startSpan(SPRAY_HTTP_REQUEST, extractedContext);
+      final HttpRequest request = ctx.request();
+      final AgentSpan.Context.Extracted extractedContext = DECORATE.extract(request);
+      span = DECORATE.startSpan(request, extractedContext);
     } else {
       span = startSpan(SPRAY_HTTP_REQUEST);
     }

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/HandlerAdapterInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/HandlerAdapterInstrumentation.java
@@ -9,7 +9,6 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.DD_SPAN_ATTRIBUTE;
 import static datadog.trace.instrumentation.springweb.SpringWebHttpServerDecorator.DECORATE;
-import static datadog.trace.instrumentation.springweb.SpringWebHttpServerDecorator.SPRING_HANDLER;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
@@ -78,8 +77,7 @@ public final class HandlerAdapterInstrumentation extends Instrumenter.Tracing {
 
       // Now create a span for handler/controller execution.
 
-      final AgentSpan span = startSpan(SPRING_HANDLER);
-      span.setMeasured(true);
+      final AgentSpan span = startSpan(DECORATE.spanName()).setMeasured(true);
       DECORATE.afterStart(span);
       DECORATE.onHandle(span, handler);
 

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/SpringWebHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/SpringWebHttpServerDecorator.java
@@ -2,6 +2,7 @@ package datadog.trace.instrumentation.springweb;
 
 import static datadog.trace.bootstrap.instrumentation.decorator.RouteHandlerDecorator.ROUTE_HANDLER_DECORATOR;
 
+import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
@@ -17,9 +18,9 @@ import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.Controller;
 
 public class SpringWebHttpServerDecorator
-    extends HttpServerDecorator<HttpServletRequest, HttpServletRequest, HttpServletResponse> {
+    extends HttpServerDecorator<HttpServletRequest, HttpServletRequest, HttpServletResponse, Void> {
 
-  public static final CharSequence SPRING_HANDLER = UTF8BytesString.create("spring.handler");
+  private static final CharSequence SPRING_HANDLER = UTF8BytesString.create("spring.handler");
   public static final CharSequence RESPONSE_RENDER = UTF8BytesString.create("response.render");
 
   private final CharSequence component;
@@ -46,6 +47,16 @@ public class SpringWebHttpServerDecorator
   @Override
   protected boolean traceAnalyticsDefault() {
     return false;
+  }
+
+  @Override
+  protected AgentPropagation.ContextVisitor<Void> getter() {
+    return null;
+  }
+
+  @Override
+  public CharSequence spanName() {
+    return SPRING_HANDLER;
   }
 
   @Override

--- a/dd-java-agent/instrumentation/synapse-3/src/main/java/datadog/trace/instrumentation/synapse3/SynapseServerDecorator.java
+++ b/dd-java-agent/instrumentation/synapse-3/src/main/java/datadog/trace/instrumentation/synapse3/SynapseServerDecorator.java
@@ -2,7 +2,9 @@ package datadog.trace.instrumentation.synapse3;
 
 import static datadog.trace.api.cache.RadixTreeCache.UNSET_PORT;
 import static datadog.trace.api.cache.RadixTreeCache.UNSET_STATUS;
+import static datadog.trace.instrumentation.synapse3.HttpRequestExtractAdapter.GETTER;
 
+import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.bootstrap.instrumentation.api.URIDefaultDataAdapter;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
@@ -14,7 +16,7 @@ import org.apache.http.HttpResponse;
 import org.apache.http.nio.NHttpConnection;
 
 public final class SynapseServerDecorator
-    extends HttpServerDecorator<HttpRequest, NHttpConnection, HttpResponse> {
+    extends HttpServerDecorator<HttpRequest, NHttpConnection, HttpResponse, HttpRequest> {
   public static final SynapseServerDecorator DECORATE = new SynapseServerDecorator();
 
   public static final CharSequence SYNAPSE_REQUEST = UTF8BytesString.create("http.request");
@@ -31,6 +33,16 @@ public final class SynapseServerDecorator
   @Override
   protected CharSequence component() {
     return SYNAPSE_SERVER;
+  }
+
+  @Override
+  protected AgentPropagation.ContextVisitor<HttpRequest> getter() {
+    return GETTER;
+  }
+
+  @Override
+  public CharSequence spanName() {
+    return SYNAPSE_REQUEST;
   }
 
   @Override

--- a/dd-java-agent/instrumentation/synapse-3/src/main/java/datadog/trace/instrumentation/synapse3/SynapseServerInstrumentation.java
+++ b/dd-java-agent/instrumentation/synapse-3/src/main/java/datadog/trace/instrumentation/synapse3/SynapseServerInstrumentation.java
@@ -3,9 +3,7 @@ package datadog.trace.instrumentation.synapse3;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
-import static datadog.trace.instrumentation.synapse3.HttpRequestExtractAdapter.GETTER;
 import static datadog.trace.instrumentation.synapse3.SynapseServerDecorator.DECORATE;
 import static datadog.trace.instrumentation.synapse3.SynapseServerDecorator.SYNAPSE_REQUEST;
 import static datadog.trace.instrumentation.synapse3.SynapseServerDecorator.SYNAPSE_SPAN_KEY;
@@ -67,16 +65,15 @@ public final class SynapseServerInstrumentation extends Instrumenter.Tracing {
 
       // check incoming request for distributed trace ids
       HttpRequest request = connection.getHttpRequest();
-      AgentSpan.Context.Extracted extractedContext = propagate().extract(request, GETTER);
+      AgentSpan.Context.Extracted extractedContext = DECORATE.extract(request);
 
       AgentSpan span;
       if (null != extractedContext) {
-        span = startSpan(SYNAPSE_REQUEST, extractedContext);
+        span = DECORATE.startSpan(request, extractedContext);
       } else {
         span = startSpan(SYNAPSE_REQUEST);
+        span.setMeasured(true);
       }
-
-      span.setMeasured(true);
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, connection, request, extractedContext);
 

--- a/dd-java-agent/instrumentation/synapse-3/src/main/java/datadog/trace/instrumentation/synapse3/SynapseServerWorkerInstrumentation.java
+++ b/dd-java-agent/instrumentation/synapse-3/src/main/java/datadog/trace/instrumentation/synapse3/SynapseServerWorkerInstrumentation.java
@@ -36,7 +36,7 @@ public final class SynapseServerWorkerInstrumentation extends Instrumenter.Traci
   @Override
   public String[] helperClassNames() {
     return new String[] {
-      packageName + ".SynapseServerDecorator",
+      packageName + ".HttpRequestExtractAdapter", packageName + ".SynapseServerDecorator",
     };
   }
 

--- a/dd-java-agent/instrumentation/tomcat-5.5/src/main/java/datadog/trace/instrumentation/tomcat/RequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/tomcat-5.5/src/main/java/datadog/trace/instrumentation/tomcat/RequestInstrumentation.java
@@ -30,7 +30,9 @@ public final class RequestInstrumentation extends Instrumenter.Tracing {
   @Override
   public String[] helperClassNames() {
     return new String[] {
-      packageName + ".TomcatDecorator", packageName + ".RequestURIDataAdapter",
+      packageName + ".RequestExtractAdapter",
+      packageName + ".TomcatDecorator",
+      packageName + ".RequestURIDataAdapter",
     };
   }
 

--- a/dd-java-agent/instrumentation/tomcat-5.5/src/main/java/datadog/trace/instrumentation/tomcat/ResponseInstrumentation.java
+++ b/dd-java-agent/instrumentation/tomcat-5.5/src/main/java/datadog/trace/instrumentation/tomcat/ResponseInstrumentation.java
@@ -30,7 +30,9 @@ public final class ResponseInstrumentation extends Instrumenter.Tracing {
   @Override
   public String[] helperClassNames() {
     return new String[] {
-      packageName + ".TomcatDecorator", packageName + ".RequestURIDataAdapter",
+      packageName + ".RequestExtractAdapter",
+      packageName + ".TomcatDecorator",
+      packageName + ".RequestURIDataAdapter",
     };
   }
 

--- a/dd-java-agent/instrumentation/tomcat-5.5/src/main/java/datadog/trace/instrumentation/tomcat/TomcatDecorator.java
+++ b/dd-java-agent/instrumentation/tomcat-5.5/src/main/java/datadog/trace/instrumentation/tomcat/TomcatDecorator.java
@@ -1,7 +1,10 @@
 package datadog.trace.instrumentation.tomcat;
 
+import static datadog.trace.instrumentation.tomcat.RequestExtractAdapter.GETTER;
+
 import datadog.trace.api.Config;
 import datadog.trace.api.DDTags;
+import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
@@ -9,7 +12,8 @@ import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
 import org.apache.catalina.connector.Request;
 import org.apache.catalina.connector.Response;
 
-public class TomcatDecorator extends HttpServerDecorator<Request, Request, Response> {
+public class TomcatDecorator
+    extends HttpServerDecorator<Request, Request, Response, org.apache.coyote.Request> {
   public static final CharSequence SERVLET_REQUEST = UTF8BytesString.create("servlet.request");
   public static final CharSequence TOMCAT_SERVER = UTF8BytesString.create("tomcat-server");
   public static final TomcatDecorator DECORATE = new TomcatDecorator();
@@ -25,6 +29,16 @@ public class TomcatDecorator extends HttpServerDecorator<Request, Request, Respo
   @Override
   protected CharSequence component() {
     return TOMCAT_SERVER;
+  }
+
+  @Override
+  protected AgentPropagation.ContextVisitor<org.apache.coyote.Request> getter() {
+    return GETTER;
+  }
+
+  @Override
+  public CharSequence spanName() {
+    return SERVLET_REQUEST;
   }
 
   @Override

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java8/datadog/trace/instrumentation/vertx_3_4/server/VertxRouterDecorator.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java8/datadog/trace/instrumentation/vertx_3_4/server/VertxRouterDecorator.java
@@ -4,6 +4,7 @@ import datadog.trace.api.Function;
 import datadog.trace.api.Pair;
 import datadog.trace.api.cache.DDCache;
 import datadog.trace.api.cache.DDCaches;
+import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapterBase;
@@ -13,7 +14,7 @@ import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.RoutingContext;
 
 public class VertxRouterDecorator
-    extends HttpServerDecorator<RoutingContext, RoutingContext, HttpServerResponse> {
+    extends HttpServerDecorator<RoutingContext, RoutingContext, HttpServerResponse, Void> {
 
   static final CharSequence INSTRUMENTATION_NAME = UTF8BytesString.create("vertx.route-handler");
 
@@ -34,6 +35,16 @@ public class VertxRouterDecorator
   @Override
   protected CharSequence component() {
     return COMPONENT_NAME;
+  }
+
+  @Override
+  protected AgentPropagation.ContextVisitor<Void> getter() {
+    return null;
+  }
+
+  @Override
+  public CharSequence spanName() {
+    return INSTRUMENTATION_NAME;
   }
 
   @Override

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/WithHttpServer.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/WithHttpServer.groovy
@@ -17,7 +17,7 @@ abstract class WithHttpServer<SERVER> extends AgentTestRunner {
   @Subject
   HttpServer server = server()
   @Shared
-  OkHttpClient client = OkHttpUtils.client()
+  OkHttpClient client = OkHttpUtils.client(15, 15, TimeUnit.SECONDS)
   @Shared
   URI address = null
 

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/utils/OkHttpUtils.java
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/utils/OkHttpUtils.java
@@ -47,8 +47,17 @@ public class OkHttpUtils {
     return client(false);
   }
 
+  public static OkHttpClient client(long connectTimeout, long readTimeout, TimeUnit unit) {
+    return client(
+        clientBuilder().connectTimeout(connectTimeout, unit).readTimeout(readTimeout, unit), false);
+  }
+
   public static OkHttpClient client(final boolean followRedirects) {
-    return clientBuilder().followRedirects(followRedirects).build();
+    return client(clientBuilder(), followRedirects);
+  }
+
+  static OkHttpClient client(final OkHttpClient.Builder builder, final boolean followRedirects) {
+    return builder.followRedirects(followRedirects).build();
   }
 
   public static OkHttpClient client(

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -524,6 +524,10 @@ public class CoreTracer implements AgentTracer.TracerAPI {
 
   @Override
   public AgentSpan startSpan(final CharSequence spanName, boolean emitCheckpoint) {
+    if (null == spanName) {
+      System.err.println("--> SRSLY 1");
+      new IllegalArgumentException("WTF?").printStackTrace(System.err);
+    }
     AgentTracer.SpanBuilder builder = buildSpan(spanName);
     if (!emitCheckpoint) {
       builder = builder.suppressCheckpoints();

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -28,6 +28,7 @@ import datadog.trace.bootstrap.instrumentation.api.AgentScopeManager;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.bootstrap.instrumentation.api.ScopeSource;
+import datadog.trace.bootstrap.instrumentation.api.TagContext;
 import datadog.trace.common.metrics.MetricsAggregator;
 import datadog.trace.common.sampling.PrioritySampler;
 import datadog.trace.common.sampling.Sampler;
@@ -39,7 +40,6 @@ import datadog.trace.context.TraceScope;
 import datadog.trace.core.monitor.MonitoringImpl;
 import datadog.trace.core.propagation.ExtractedContext;
 import datadog.trace.core.propagation.HttpCodec;
-import datadog.trace.core.propagation.TagContext;
 import datadog.trace.core.scopemanager.ContinuableScopeManager;
 import datadog.trace.core.taginterceptor.RuleFlags;
 import datadog.trace.core.taginterceptor.TagInterceptor;
@@ -314,7 +314,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
       sampler(Sampler.Builder.<DDSpan>forConfig(config));
       instrumentationGateway(new InstrumentationGateway());
       injector(HttpCodec.createInjector(config));
-      extractor(HttpCodec.createExtractor(config, config.getHeaderTags(), instrumentationGateway));
+      extractor(HttpCodec.createExtractor(config, config.getHeaderTags()));
       // Explicitly skip setting scope manager because it depends on statsDClient
       localRootSpanTags(config.getLocalRootSpanTags());
       defaultSpanTags(config.getMergedSpanTags());
@@ -524,10 +524,6 @@ public class CoreTracer implements AgentTracer.TracerAPI {
 
   @Override
   public AgentSpan startSpan(final CharSequence spanName, boolean emitCheckpoint) {
-    if (null == spanName) {
-      System.err.println("--> SRSLY 1");
-      new IllegalArgumentException("WTF?").printStackTrace(System.err);
-    }
     AgentTracer.SpanBuilder builder = buildSpan(spanName);
     if (!emitCheckpoint) {
       builder = builder.suppressCheckpoints();

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
@@ -353,7 +353,6 @@ public class DDSpanContext implements AgentSpan.Context {
     return trace;
   }
 
-  @Override
   public RequestContext getRequestContext() {
     return requestContext;
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ContextInterpreter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ContextInterpreter.java
@@ -13,6 +13,7 @@ import datadog.trace.api.cache.DDCache;
 import datadog.trace.api.cache.DDCaches;
 import datadog.trace.api.sampling.PrioritySampling;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
+import datadog.trace.bootstrap.instrumentation.api.TagContext;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ExtractedContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ExtractedContext.java
@@ -1,6 +1,7 @@
 package datadog.trace.core.propagation;
 
 import datadog.trace.api.DDId;
+import datadog.trace.bootstrap.instrumentation.api.TagContext;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/TagContextExtractor.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/TagContextExtractor.java
@@ -1,6 +1,7 @@
 package datadog.trace.core.propagation;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
+import datadog.trace.bootstrap.instrumentation.api.TagContext;
 import java.util.Map;
 
 public class TagContextExtractor implements HttpCodec.Extractor {

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/CoreSpanBuilderTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/CoreSpanBuilderTest.groovy
@@ -6,7 +6,7 @@ import datadog.trace.bootstrap.instrumentation.api.AgentScope
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer
 import datadog.trace.common.writer.ListWriter
 import datadog.trace.core.propagation.ExtractedContext
-import datadog.trace.core.propagation.TagContext
+import datadog.trace.bootstrap.instrumentation.api.TagContext
 import datadog.trace.core.test.DDCoreSpecification
 
 import static datadog.trace.api.DDTags.LANGUAGE_TAG_KEY

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanTest.groovy
@@ -9,7 +9,7 @@ import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString
 import datadog.trace.common.sampling.RateByServiceSampler
 import datadog.trace.common.writer.ListWriter
 import datadog.trace.core.propagation.ExtractedContext
-import datadog.trace.core.propagation.TagContext
+import datadog.trace.bootstrap.instrumentation.api.TagContext
 import datadog.trace.core.test.DDCoreSpecification
 
 import java.util.concurrent.TimeUnit

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/B3HttpExtractorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/B3HttpExtractorTest.groovy
@@ -1,6 +1,7 @@
 package datadog.trace.core.propagation
 
 import datadog.trace.api.DDId
+import datadog.trace.bootstrap.instrumentation.api.TagContext
 import datadog.trace.api.sampling.PrioritySampling
 import datadog.trace.bootstrap.instrumentation.api.ContextVisitors
 import datadog.trace.test.util.DDSpecification

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/B3HttpInjectorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/B3HttpInjectorTest.groovy
@@ -1,6 +1,7 @@
 package datadog.trace.core.propagation
 
 import datadog.trace.api.DDId
+import datadog.trace.bootstrap.instrumentation.api.TagContext
 import datadog.trace.api.sampling.PrioritySampling
 import datadog.trace.bootstrap.instrumentation.api.ContextVisitors
 import datadog.trace.common.writer.ListWriter

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/DatadogHttpExtractorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/DatadogHttpExtractorTest.groovy
@@ -1,6 +1,7 @@
 package datadog.trace.core.propagation
 
 import datadog.trace.api.DDId
+import datadog.trace.bootstrap.instrumentation.api.TagContext
 import datadog.trace.api.sampling.PrioritySampling
 import datadog.trace.bootstrap.instrumentation.api.ContextVisitors
 import datadog.trace.test.util.DDSpecification

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HaystackHttpExtractorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HaystackHttpExtractorTest.groovy
@@ -1,6 +1,7 @@
 package datadog.trace.core.propagation
 
 import datadog.trace.api.DDId
+import datadog.trace.bootstrap.instrumentation.api.TagContext
 import datadog.trace.api.sampling.PrioritySampling
 import datadog.trace.bootstrap.instrumentation.api.ContextVisitors
 import datadog.trace.test.util.DDSpecification

--- a/internal-api/internal-api.gradle
+++ b/internal-api/internal-api.gradle
@@ -30,6 +30,7 @@ excludedClassesCoverage += [
   "datadog.trace.bootstrap.instrumentation.api.AgentTracer.NoopAgentTrace",
   "datadog.trace.bootstrap.instrumentation.api.ScopeSource",
   "datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes",
+  "datadog.trace.bootstrap.instrumentation.api.TagContext",
   "datadog.trace.bootstrap.instrumentation.ci.git.GitInfo",
   "datadog.trace.bootstrap.instrumentation.ci.git.GitInfo.GitInfoBuilder",
   "datadog.trace.bootstrap.instrumentation.ci.git.CommitInfo",

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
@@ -135,9 +135,6 @@ public interface AgentSpan extends MutableSpan, IGSpanInfo {
 
     Iterable<Map.Entry<String, String>> baggageItems();
 
-    /** RequestContext for the Instrumentation Gateway */
-    RequestContext getRequestContext();
-
     interface Extracted extends Context {
       String getForwarded();
 

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -88,16 +88,16 @@ public class AgentTracer {
     return get().noopSpan();
   }
 
-  private static final TracerAPI DEFAULT = new NoopTracerAPI();
+  public static final TracerAPI NOOP_TRACER = new NoopTracerAPI();
 
-  private static volatile TracerAPI provider = DEFAULT;
+  private static volatile TracerAPI provider = NOOP_TRACER;
 
   public static boolean isRegistered() {
-    return provider != DEFAULT;
+    return provider != NOOP_TRACER;
   }
 
   public static synchronized void registerIfAbsent(final TracerAPI tracer) {
-    if (tracer != null && tracer != DEFAULT) {
+    if (tracer != null && tracer != NOOP_TRACER) {
       provider = tracer;
     }
   }
@@ -708,11 +708,6 @@ public class AgentTracer {
 
     @Override
     public String getForwardedPort() {
-      return null;
-    }
-
-    @Override
-    public RequestContext getRequestContext() {
       return null;
     }
   }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/TagContext.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/TagContext.java
@@ -1,10 +1,7 @@
-package datadog.trace.core.propagation;
+package datadog.trace.bootstrap.instrumentation.api;
 
 import datadog.trace.api.DDId;
 import datadog.trace.api.gateway.RequestContext;
-import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.bootstrap.instrumentation.api.AgentTrace;
-import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import java.util.Collections;
 import java.util.Map;
 
@@ -95,13 +92,11 @@ public class TagContext implements AgentSpan.Context.Extracted {
     return AgentTracer.NoopAgentTrace.INSTANCE;
   }
 
-  @Override
   public RequestContext getRequestContext() {
     return requestContext;
   }
 
-  // Package reachable to allow setting from the {@code CompoundExtractor}
-  TagContext withRequestContext(RequestContext requestContext) {
+  public TagContext withRequestContext(RequestContext requestContext) {
     this.requestContext = requestContext;
     return this;
   }


### PR DESCRIPTION
This PR moves the AppSec events out from the `HttpCodec.Extractor` and into the `HttpServerDecorator` so we can ensure that there is always a `Span` available that the `RequestContext` can be associated with. This touches a lot of files in a mechanical way, since the extraction and span creation has moved into the `HttpServerDecorator`.