### PR TITLE
Store local service name for JMS in static field

### DIFF
--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSDecorator.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSDecorator.java
@@ -35,6 +35,9 @@ public final class JMSDecorator extends ClientDecorator {
   private static final Join QUEUE_JOINER = PrefixJoin.of("Queue ");
   private static final Join TOPIC_JOINER = PrefixJoin.of("Topic ");
 
+  private static final String LOCAL_SERVICE_NAME =
+      Config.get().isJmsLegacyTracingEnabled() ? "jms" : Config.get().getServiceName();
+
   private final DDCache<CharSequence, CharSequence> resourceNameCache =
       DDCaches.newFixedSizeCache(32);
 
@@ -55,14 +58,14 @@ public final class JMSDecorator extends ClientDecorator {
           "Produced for ",
           Tags.SPAN_KIND_PRODUCER,
           InternalSpanTypes.MESSAGE_PRODUCER,
-          Config.get().isJmsLegacyTracingEnabled() ? "jms" : null /* inherit service name */);
+          LOCAL_SERVICE_NAME);
 
   public static final JMSDecorator CONSUMER_DECORATE =
       new JMSDecorator(
           "Consumed from ",
           Tags.SPAN_KIND_CONSUMER,
           InternalSpanTypes.MESSAGE_CONSUMER,
-          Config.get().isJmsLegacyTracingEnabled() ? "jms" : Config.get().getServiceName());
+          LOCAL_SERVICE_NAME);
 
   public static final JMSDecorator BROKER_DECORATE =
       new JMSDecorator(


### PR DESCRIPTION
This follows the same pattern as in RabbitMQ, where the producer and consumer both use the configured service name for the new "time-in-queue" approach.