### PR TITLE
[CIAPP] Escape test parameters to be JSON compatible.

### DIFF
--- a/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4Decorator.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4Decorator.java
@@ -4,6 +4,7 @@ import datadog.trace.api.DisableTestTrace;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.decorator.TestDecorator;
+import datadog.trace.util.Strings;
 import org.junit.runner.Description;
 import org.junit.runner.notification.Failure;
 
@@ -53,7 +54,9 @@ public class JUnit4Decorator extends TestDecorator {
     if (!fullTestName.equals(normalizedTestName)) {
       // No public access to the test parameters map in JUnit4.
       // In this case, we store the fullTestName in the "metadata.test_name" object.
-      span.setTag(Tags.TEST_PARAMETERS, "{\"metadata\":{\"test_name\":\"" + fullTestName + "\"}}");
+      span.setTag(
+          Tags.TEST_PARAMETERS,
+          "{\"metadata\":{\"test_name\":\"" + Strings.escapeToJson(fullTestName) + "\"}}");
     }
 
     // We cannot set TEST_PASS status in onTestFinish(...) method because that method

--- a/dd-java-agent/instrumentation/junit-4.10/src/test/groovy/JUnit4Test.groovy
+++ b/dd-java-agent/instrumentation/junit-4.10/src/test/groovy/JUnit4Test.groovy
@@ -142,8 +142,8 @@ class JUnit4Test extends TestFrameworkTest {
     }
 
     where:
-    testTags_0 = ["$Tags.TEST_PARAMETERS": "{\"metadata\":{\"test_name\":\"parameterized_test_succeed[0]\"}}"]
-    testTags_1 = ["$Tags.TEST_PARAMETERS": "{\"metadata\":{\"test_name\":\"parameterized_test_succeed[1]\"}}"]
+    testTags_0 = ["$Tags.TEST_PARAMETERS": '{"metadata":{"test_name":"parameterized_test_succeed[0]"}}']
+    testTags_1 = ["$Tags.TEST_PARAMETERS": '{"metadata":{"test_name":"parameterized_test_succeed[1]"}}']
   }
 
   @Override

--- a/dd-java-agent/instrumentation/junit-4.10/src/test/java/org/example/TestParameterized.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/test/java/org/example/TestParameterized.java
@@ -14,7 +14,7 @@ public class TestParameterized {
   @Parameterized.Parameters
   public static Collection<Object[]> data() {
     return Arrays.asList(
-        new Object[][] {{new ParamObject(), "str1", 0}, {new ParamObject(), "str2", 1}});
+        new Object[][] {{new ParamObject(), "str1", 0}, {new ParamObject(), "\"str2\"", 1}});
   }
 
   public TestParameterized(final ParamObject param1, final String param2, final int param3) {}

--- a/dd-java-agent/instrumentation/junit-5.3/src/main/java8/datadog/trace/instrumentation/junit5/JUnit5Decorator.java
+++ b/dd-java-agent/instrumentation/junit-5.3/src/main/java8/datadog/trace/instrumentation/junit5/JUnit5Decorator.java
@@ -3,6 +3,7 @@ package datadog.trace.instrumentation.junit5;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.decorator.TestDecorator;
+import datadog.trace.util.Strings;
 import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.support.descriptor.MethodSource;
 import org.junit.platform.launcher.TestIdentifier;
@@ -36,7 +37,9 @@ public class JUnit5Decorator extends TestDecorator {
       // The test display name used to have the parameters.
       span.setTag(
           Tags.TEST_PARAMETERS,
-          "{\"metadata\":{\"test_name\":\"" + testIdentifier.getDisplayName() + "\"}}");
+          "{\"metadata\":{\"test_name\":\""
+              + Strings.escapeToJson(testIdentifier.getDisplayName())
+              + "\"}}");
     }
   }
 

--- a/dd-java-agent/instrumentation/junit-5.3/src/test/groovy/JUnit5Test.groovy
+++ b/dd-java-agent/instrumentation/junit-5.3/src/test/groovy/JUnit5Test.groovy
@@ -69,8 +69,8 @@ class JUnit5Test extends TestFrameworkTest {
     }
 
     where:
-    testTags_0 = ["$Tags.TEST_PARAMETERS": "{\"metadata\":{\"test_name\":\"[1] 0, 0, 0\"}}"]
-    testTags_1 = ["$Tags.TEST_PARAMETERS": "{\"metadata\":{\"test_name\":\"[2] 1, 1, 2\"}}"]
+    testTags_0 = ["$Tags.TEST_PARAMETERS": '{"metadata":{"test_name":"[1] 0, 0, 0, some:\\\"parameter\\\""}}']
+    testTags_1 = ["$Tags.TEST_PARAMETERS": '{"metadata":{"test_name":"[2] 1, 1, 2, some:\\\"parameter\\\""}}']
   }
 
   def "test repeated generates spans"() {

--- a/dd-java-agent/instrumentation/junit-5.3/src/test/java/org/example/TestParameterized.java
+++ b/dd-java-agent/instrumentation/junit-5.3/src/test/java/org/example/TestParameterized.java
@@ -1,6 +1,7 @@
 package org.example;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.Arrays;
 import java.util.List;
@@ -11,13 +12,17 @@ import org.junit.jupiter.params.provider.MethodSource;
 public class TestParameterized {
 
   static List<Arguments> parameters() {
-    return Arrays.asList(() -> new Object[] {0, 0, 0}, () -> new Object[] {1, 1, 2});
+    return Arrays.asList(
+        () -> new Object[] {0, 0, "0", "some:\"parameter\""},
+        () -> new Object[] {1, 1, 2, "some:\"parameter\""});
   }
 
   @ParameterizedTest
   @MethodSource("parameters")
-  public void test_parameterized(final int first, final int second, final int expectedSum) {
+  public void test_parameterized(
+      final int first, final int second, final int expectedSum, final String message) {
     final int actualSum = first + second;
     assertEquals(expectedSum, actualSum);
+    assertNotNull(message);
   }
 }

--- a/dd-java-agent/instrumentation/testng-6.4/src/main/java/datadog/trace/instrumentation/testng/TestNGDecorator.java
+++ b/dd-java-agent/instrumentation/testng-6.4/src/main/java/datadog/trace/instrumentation/testng/TestNGDecorator.java
@@ -3,6 +3,7 @@ package datadog.trace.instrumentation.testng;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.decorator.TestDecorator;
+import datadog.trace.util.Strings;
 import org.testng.ITestResult;
 
 public class TestNGDecorator extends TestDecorator {
@@ -68,7 +69,11 @@ public class TestNGDecorator extends TestDecorator {
   private String buildParametersTagValue(final ITestResult result) {
     final StringBuilder sb = new StringBuilder("{\"arguments\":{");
     for (int i = 0; i < result.getParameters().length; i++) {
-      sb.append("\"").append(i).append("\":\"").append(result.getParameters()[i]).append("\"");
+      sb.append("\"")
+          .append(i)
+          .append("\":\"")
+          .append(Strings.escapeToJson(result.getParameters()[i].toString()))
+          .append("\"");
       if (i != result.getParameters().length - 1) {
         sb.append(",");
       }

--- a/dd-java-agent/instrumentation/testng-6.4/src/test/groovy/TestNGTest.groovy
+++ b/dd-java-agent/instrumentation/testng-6.4/src/test/groovy/TestNGTest.groovy
@@ -155,8 +155,8 @@ class TestNGTest extends TestFrameworkTest {
     }
 
     where:
-    testTags_0 = ["$Tags.TEST_PARAMETERS": "{\"arguments\":{\"0\":\"hello\",\"1\":\"true\"}}"]
-    testTags_1 = ["$Tags.TEST_PARAMETERS": "{\"arguments\":{\"0\":\"goodbye\",\"1\":\"false\"}}"]
+    testTags_0 = ["$Tags.TEST_PARAMETERS": '{"arguments":{"0":"hello","1":"true"}}']
+    testTags_1 = ["$Tags.TEST_PARAMETERS": '{"arguments":{"0":"\\\"goodbye\\\"","1":"false"}}']
   }
 
   @Override

--- a/dd-java-agent/instrumentation/testng-6.4/src/test/java/org/example/TestParameterized.java
+++ b/dd-java-agent/instrumentation/testng-6.4/src/test/java/org/example/TestParameterized.java
@@ -11,7 +11,7 @@ public class TestParameterized {
   public static Object[][] data() {
     return new Object[][] {
       {"hello", true},
-      {"goodbye", false}
+      {"\"goodbye\"", false}
     };
   }
 

--- a/internal-api/src/main/java/datadog/trace/util/Strings.java
+++ b/internal-api/src/main/java/datadog/trace/util/Strings.java
@@ -1,8 +1,73 @@
 package datadog.trace.util;
 
+import java.util.Locale;
 import javax.annotation.Nonnull;
 
 public final class Strings {
+
+  public static String escapeJavaScript(String string) {
+    if (string == null) {
+      return "";
+    }
+
+    final StringBuilder sb = new StringBuilder();
+    int sz = string.length();
+    for (int i = 0; i < sz; ++i) {
+      char ch = string.charAt(i);
+      if (ch > 4095) {
+        sb.append("\\u").append(hex(ch));
+      } else if (ch > 255) {
+        sb.append("\\u0").append(hex(ch));
+      } else if (ch > 127) {
+        sb.append("\\u00").append(hex(ch));
+      } else if (ch < ' ') {
+        switch (ch) {
+          case '\b':
+            sb.append((char) 92).append((char) 98);
+            break;
+          case '\t':
+            sb.append((char) 92).append((char) 116);
+            break;
+          case '\n':
+            sb.append((char) 92).append((char) 110);
+            break;
+          case '\u000b':
+          default:
+            if (ch > 15) {
+              sb.append("\\u00").append(hex(ch));
+            } else {
+              sb.append("\\u000").append(hex(ch));
+            }
+            break;
+          case '\f':
+            sb.append((char) 92).append((char) 102);
+            break;
+          case '\r':
+            sb.append((char) 92).append((char) 114);
+            break;
+        }
+      } else {
+        switch (ch) {
+          case '"':
+            sb.append((char) 92).append((char) 34);
+            break;
+          case '\'':
+            sb.append((char) 92).append((char) 39);
+            break;
+          case '/':
+            sb.append((char) 92).append((char) 47);
+            break;
+          case '\\':
+            sb.append((char) 92).append((char) 92);
+            break;
+          default:
+            sb.append(ch);
+        }
+      }
+    }
+
+    return sb.toString();
+  }
 
   public static String toEnvVar(String string) {
     return string.replace('.', '_').replace('-', '_').toUpperCase();
@@ -105,5 +170,9 @@ public final class Strings {
   @Nonnull
   public static String propertyNameToSystemPropertyName(final String setting) {
     return "dd." + setting;
+  }
+
+  private static String hex(char ch) {
+    return Integer.toHexString(ch).toUpperCase(Locale.ENGLISH);
   }
 }

--- a/internal-api/src/main/java/datadog/trace/util/Strings.java
+++ b/internal-api/src/main/java/datadog/trace/util/Strings.java
@@ -6,7 +6,7 @@ import javax.annotation.Nonnull;
 public final class Strings {
 
   public static String escapeToJson(String string) {
-    if (string == null) {
+    if (string == null || "".equals(string)) {
       return "";
     }
 

--- a/internal-api/src/main/java/datadog/trace/util/Strings.java
+++ b/internal-api/src/main/java/datadog/trace/util/Strings.java
@@ -6,7 +6,7 @@ import javax.annotation.Nonnull;
 public final class Strings {
 
   public static String escapeToJson(String string) {
-    if (string == null || "".equals(string)) {
+    if (string == null || string.isEmpty()) {
       return "";
     }
 

--- a/internal-api/src/main/java/datadog/trace/util/Strings.java
+++ b/internal-api/src/main/java/datadog/trace/util/Strings.java
@@ -5,7 +5,7 @@ import javax.annotation.Nonnull;
 
 public final class Strings {
 
-  public static String escapeJavaScript(String string) {
+  public static String escapeToJson(String string) {
     if (string == null) {
       return "";
     }

--- a/internal-api/src/test/groovy/datadog/trace/util/StringsTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/util/StringsTest.groovy
@@ -80,7 +80,9 @@ class StringsTest extends DDSpecification {
     escaped == expected
 
     where:
+    // spotless:off
     string | expected
     '"' | '\\"'
+    // spotless:on
   }
 }

--- a/internal-api/src/test/groovy/datadog/trace/util/StringsTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/util/StringsTest.groovy
@@ -71,4 +71,16 @@ class StringsTest extends DDSpecification {
     "tetetetete" | "tet"     | "e"         | "eeeete"          | "eetetete"
     // spotless:on
   }
+
+  def "test escape javascript"() {
+    when:
+    String escaped = Strings.escapeJavaScript(string)
+
+    then:
+    escaped == expected
+
+    where:
+    string | expected
+    '"' | '\\"'
+  }
 }

--- a/internal-api/src/test/groovy/datadog/trace/util/StringsTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/util/StringsTest.groovy
@@ -74,15 +74,26 @@ class StringsTest extends DDSpecification {
 
   def "test escape javascript"() {
     when:
-    String escaped = Strings.escapeJavaScript(string)
+    String escaped = Strings.escapeToJson(string)
 
     then:
     escaped == expected
 
     where:
-    // spotless:off
     string | expected
+    ((char)4096).toString() | '\\u1000'
+    ((char)256).toString() | '\\u0100'
+    ((char)128).toString() | '\\u0080'
+    "\b"|"\\b"
+    "\t"|"\\t"
+    "\n"|"\\n"
+    "\f"|"\\f"
+    "\r"|"\\r"
     '"' | '\\"'
-    // spotless:on
+    '\'' | '\\\''
+    '/' | '\\/'
+    '\\' | '\\\\'
+    "\u000b"|"\\u000B"
+    "a"|"a"
   }
 }

--- a/internal-api/src/test/groovy/datadog/trace/util/StringsTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/util/StringsTest.groovy
@@ -81,6 +81,8 @@ class StringsTest extends DDSpecification {
 
     where:
     string | expected
+    null | ""
+    "" | ""
     ((char)4096).toString() | '\\u1000'
     ((char)256).toString() | '\\u0100'
     ((char)128).toString() | '\\u0080'


### PR DESCRIPTION
This PRs adds the `escapeToJson` method to the `Strings` class to prepare the string used as argument to be JSON compatible. 
This method is used in the builder to create the `test.parameters` JSON attribute for the test instrumentation.