### PR TITLE
Add config knob to capture stacktraces on CheckpointEvent

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkController.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkController.java
@@ -144,6 +144,11 @@ public final class OpenJdkController implements Controller {
       recordingSettings.put("jdk.ObjectAllocationOutsideTLAB#enabled", "true");
     }
 
+    if (config.isProfilingCheckpointsStacktraceEnabled()) {
+      log.debug("Enabling Checkpoint stacktraces with the config");
+      recordingSettings.put("datadog.Checkpoint#stackTrace", "true");
+    }
+
     this.recordingSettings = Collections.unmodifiableMap(recordingSettings);
 
     // Register periodic events

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -72,6 +72,7 @@ public final class ConfigDefaults {
   static final boolean DEFAULT_PROFILING_AGENTLESS = false;
   static final boolean DEFAULT_PROFILING_LEGACY_TRACING_INTEGRATION = true;
   static final boolean DEFAULT_PROFILING_UPLOAD_SUMMARY_ON_413 = false;
+  static final boolean DEFAULT_PROFILING_CHECKPOINTS_STACKTRACE_ENABLED = false;
 
   static final boolean DEFAULT_APPSEC_ENABLED = false;
 

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
@@ -56,7 +56,8 @@ public final class ProfilingConfig {
   public static final boolean PROFILING_ENDPOINT_COLLECTION_ENABLED_DEFAULT = true;
 
   // Not intended for production use
-  public static final String PROFILING_CHECKPOINTS_STACKTRACE_ENABLED = "profiling.checkpoints.stacktrace";
+  public static final String PROFILING_CHECKPOINTS_STACKTRACE_ENABLED =
+      "profiling.checkpoints.stacktrace";
 
   // Not intended for production use
   public static final String PROFILING_AGENTLESS = "profiling.agentless";

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
@@ -56,6 +56,9 @@ public final class ProfilingConfig {
   public static final boolean PROFILING_ENDPOINT_COLLECTION_ENABLED_DEFAULT = true;
 
   // Not intended for production use
+  public static final String PROFILING_CHECKPOINTS_STACKTRACE_ENABLED = "profiling.checkpoints.stacktrace";
+
+  // Not intended for production use
   public static final String PROFILING_AGENTLESS = "profiling.agentless";
 
   public static final String PROFILING_UPLOAD_SUMMARY_ON_413 = "profiling.upload.summary-on-413";

--- a/dd-trace-core/jfr-openjdk/src/test/groovy/datadog/trace/core/jfr/openjdk/ScopeEventTest.groovy
+++ b/dd-trace-core/jfr-openjdk/src/test/groovy/datadog/trace/core/jfr/openjdk/ScopeEventTest.groovy
@@ -315,8 +315,9 @@ class ScopeEventTest extends DDSpecification {
     noProfilingTracer.close()
   }
 
-  def "checkpoint events written when checkpointer registered"() {
+  def "checkpoint events written when checkpointer registered with stackTrace=#stackTrace"() {
     setup:
+    injectSysConfig(ProfilingConfig.PROFILING_CHECKPOINTS_STACKTRACE_ENABLED, String.valueOf(stackTrace))
     addScopeEventFactory()
     SystemAccess.enableJmx()
     def recording = JfrHelper.startRecording()
@@ -335,9 +336,13 @@ class ScopeEventTest extends DDSpecification {
       assert it.getLong("localRootSpanId") == span.getLocalRootSpan().getSpanId().toLong()
       if (it.eventType.name == "datadog.Checkpoint") {
         assert it.getLong("spanId") == span.getSpanId().toLong()
+        assert (it.getStackTrace() != null) == stackTrace
       } else {
         it.getString("endpoint") == "foo"
       }
     }
+
+    where:
+    stackTrace << [true, false]
   }
 }

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -38,6 +38,7 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_UPLOAD_COMPRESS
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_UPLOAD_PERIOD;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_UPLOAD_SUMMARY_ON_413;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_UPLOAD_TIMEOUT;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_CHECKPOINTS_STACKTRACE_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PROPAGATION_EXTRACT_LOG_HEADER_NAMES_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PROPAGATION_STYLE_EXTRACT;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PROPAGATION_STYLE_INJECT;
@@ -130,6 +131,7 @@ import static datadog.trace.api.config.ProfilingConfig.PROFILING_UPLOAD_PERIOD;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_UPLOAD_SUMMARY_ON_413;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_UPLOAD_TIMEOUT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_URL;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_CHECKPOINTS_STACKTRACE_ENABLED;
 import static datadog.trace.api.config.TraceInstrumentationConfig.DB_CLIENT_HOST_SPLIT_BY_INSTANCE;
 import static datadog.trace.api.config.TraceInstrumentationConfig.GRPC_IGNORED_OUTBOUND_METHODS;
 import static datadog.trace.api.config.TraceInstrumentationConfig.GRPC_SERVER_TRIM_PACKAGE_RESOURCE;
@@ -385,6 +387,7 @@ public class Config {
   private final int profilingExceptionHistogramMaxCollectionSize;
   private final boolean profilingExcludeAgentThreads;
   private final boolean profilingHotspotsEnabled;
+  private final boolean profilingCheckpointsStacktraceEnabled;
   private final boolean profilingUploadSummaryOn413Enabled;
 
   private final boolean appSecEnabled;
@@ -801,6 +804,8 @@ public class Config {
 
     // code hotspots are disabled by default because of potential perf overhead they can incur
     profilingHotspotsEnabled = configProvider.getBoolean(PROFILING_HOTSPOTS_ENABLED, false);
+
+    profilingCheckpointsStacktraceEnabled = configProvider.getBoolean(PROFILING_CHECKPOINTS_STACKTRACE_ENABLED, DEFAULT_PROFILING_CHECKPOINTS_STACKTRACE_ENABLED);
 
     profilingUploadSummaryOn413Enabled =
         configProvider.getBoolean(
@@ -1254,6 +1259,10 @@ public class Config {
 
   public boolean isProfilingHotspotsEnabled() {
     return profilingHotspotsEnabled;
+  }
+
+  public boolean isProfilingCheckpointsStacktraceEnabled() {
+    return profilingCheckpointsStacktraceEnabled;
   }
 
   public boolean isProfilingUploadSummaryOn413Enabled() {

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -25,6 +25,7 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_PRIORITY_SAMPLING_ENABLED
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PRIORITY_SAMPLING_FORCE;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_AGENTLESS;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_ALLOCATION_ENABLED;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_CHECKPOINTS_STACKTRACE_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS;
@@ -38,7 +39,6 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_UPLOAD_COMPRESS
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_UPLOAD_PERIOD;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_UPLOAD_SUMMARY_ON_413;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_UPLOAD_TIMEOUT;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_CHECKPOINTS_STACKTRACE_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PROPAGATION_EXTRACT_LOG_HEADER_NAMES_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PROPAGATION_STYLE_EXTRACT;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PROPAGATION_STYLE_INJECT;
@@ -110,6 +110,7 @@ import static datadog.trace.api.config.ProfilingConfig.PROFILING_API_KEY_FILE_OL
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_API_KEY_FILE_VERY_OLD;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_API_KEY_OLD;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_API_KEY_VERY_OLD;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_CHECKPOINTS_STACKTRACE_ENABLED;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_ENABLED;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS;
@@ -131,7 +132,6 @@ import static datadog.trace.api.config.ProfilingConfig.PROFILING_UPLOAD_PERIOD;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_UPLOAD_SUMMARY_ON_413;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_UPLOAD_TIMEOUT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_URL;
-import static datadog.trace.api.config.ProfilingConfig.PROFILING_CHECKPOINTS_STACKTRACE_ENABLED;
 import static datadog.trace.api.config.TraceInstrumentationConfig.DB_CLIENT_HOST_SPLIT_BY_INSTANCE;
 import static datadog.trace.api.config.TraceInstrumentationConfig.GRPC_IGNORED_OUTBOUND_METHODS;
 import static datadog.trace.api.config.TraceInstrumentationConfig.GRPC_SERVER_TRIM_PACKAGE_RESOURCE;
@@ -805,7 +805,10 @@ public class Config {
     // code hotspots are disabled by default because of potential perf overhead they can incur
     profilingHotspotsEnabled = configProvider.getBoolean(PROFILING_HOTSPOTS_ENABLED, false);
 
-    profilingCheckpointsStacktraceEnabled = configProvider.getBoolean(PROFILING_CHECKPOINTS_STACKTRACE_ENABLED, DEFAULT_PROFILING_CHECKPOINTS_STACKTRACE_ENABLED);
+    profilingCheckpointsStacktraceEnabled =
+        configProvider.getBoolean(
+            PROFILING_CHECKPOINTS_STACKTRACE_ENABLED,
+            DEFAULT_PROFILING_CHECKPOINTS_STACKTRACE_ENABLED);
 
     profilingUploadSummaryOn413Enabled =
         configProvider.getBoolean(


### PR DESCRIPTION
This is not intended for production use, only for debugging purposes.