### PR TITLE
Avoid potential JMS call depth leak

### DIFF
--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageProducerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageProducerInstrumentation.java
@@ -80,15 +80,15 @@ public final class JMSMessageProducerInstrumentation extends Instrumenter.Tracin
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static AgentScope beforeSend(
         @Advice.Argument(0) final Message message, @Advice.This final MessageProducer producer) {
-      final int callDepth = CallDepthThreadLocalMap.incrementCallDepth(MessageProducer.class);
-      if (callDepth > 0) {
-        return null;
-      }
-
       MessageProducerState producerState =
           InstrumentationContext.get(MessageProducer.class, MessageProducerState.class)
               .get(producer);
       if (null == producerState) {
+        return null;
+      }
+
+      final int callDepth = CallDepthThreadLocalMap.incrementCallDepth(MessageProducer.class);
+      if (callDepth > 0) {
         return null;
       }
 
@@ -125,15 +125,15 @@ public final class JMSMessageProducerInstrumentation extends Instrumenter.Tracin
         @Advice.Argument(0) final Destination destination,
         @Advice.Argument(1) final Message message,
         @Advice.This final MessageProducer producer) {
-      final int callDepth = CallDepthThreadLocalMap.incrementCallDepth(MessageProducer.class);
-      if (callDepth > 0) {
-        return null;
-      }
-
       MessageProducerState producerState =
           InstrumentationContext.get(MessageProducer.class, MessageProducerState.class)
               .get(producer);
       if (null == producerState) {
+        return null;
+      }
+
+      final int callDepth = CallDepthThreadLocalMap.incrementCallDepth(MessageProducer.class);
+      if (callDepth > 0) {
         return null;
       }
 


### PR DESCRIPTION
This hasn't been seen in practice (the session instrumentation sets up the producer's state before this call) but I'd like to remove any chance of a call-depth leak here. At the same time we can avoid looking up the producer's state when using an unbound producer to send to different destinations.