### PR TITLE
AWS SQS message propagation

### DIFF
--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/aws-java-sdk-1.11.0.gradle
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/aws-java-sdk-1.11.0.gradle
@@ -53,6 +53,9 @@ dependencies {
   // needed for kinesis:
   testImplementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-cbor', version: versions.jackson
 
+  // SQS x-ray testing:
+  testImplementation group: 'org.elasticmq', name: 'elasticmq-rest-sqs_2.13', version: '1.2.3'
+
   test_before_1_11_106Implementation(group: 'com.amazonaws', name: 'aws-java-sdk-s3') {
     version {
       strictly '1.11.0'

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/aws-java-sdk-1.11.0.gradle
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/aws-java-sdk-1.11.0.gradle
@@ -36,6 +36,8 @@ testSets {
 
 dependencies {
   compileOnly group: 'com.amazonaws', name: 'aws-java-sdk-core', version: '1.11.0'
+  compileOnly group: 'com.amazonaws', name: 'aws-java-sdk-sqs', version: '1.11.0'
+  compileOnly group: 'com.amazonaws', name: 'amazon-sqs-java-messaging-lib', version: '1.0.0'
 
   // Include httpclient instrumentation for testing because it is a dependency for aws-sdk.
   testImplementation project(':dd-java-agent:instrumentation:apache-httpclient-4')

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/aws-java-sdk-1.11.0.gradle
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/aws-java-sdk-1.11.0.gradle
@@ -55,6 +55,7 @@ dependencies {
 
   // SQS x-ray testing:
   testImplementation group: 'org.elasticmq', name: 'elasticmq-rest-sqs_2.13', version: '1.2.3'
+  testImplementation group: 'com.amazonaws', name: 'amazon-sqs-java-messaging-lib', version: '1.0.8'
 
   test_before_1_11_106Implementation(group: 'com.amazonaws', name: 'aws-java-sdk-s3') {
     version {

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/AwsSdkClientDecorator.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/AwsSdkClientDecorator.java
@@ -60,6 +60,7 @@ public class AwsSdkClientDecorator extends HttpClientDecorator<Request, Response
       case "SQS.SendMessage":
       case "SQS.SendMessageBatch":
       case "SQS.ReceiveMessage":
+      case "SQS.DeleteMessage":
         span.setServiceName("sqs");
         break;
       case "SNS.Publish":

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/SqsJmsMessageInstrumentation.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/SqsJmsMessageInstrumentation.java
@@ -1,0 +1,64 @@
+package datadog.trace.instrumentation.aws.v0;
+
+import static com.amazon.sqs.javamessaging.SQSMessagingClientConstants.STRING;
+import static datadog.trace.agent.tooling.ClassLoaderMatcher.hasClassesNamed;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+
+import com.amazon.sqs.javamessaging.message.SQSMessage;
+import com.amazonaws.services.sqs.model.Message;
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.api.Config;
+import java.util.Map;
+import javax.jms.JMSException;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+@AutoService(Instrumenter.class)
+public class SqsJmsMessageInstrumentation extends Instrumenter.Tracing {
+  public SqsJmsMessageInstrumentation() {
+    super("aws-sdk");
+  }
+
+  @Override
+  protected boolean defaultEnabled() {
+    return super.defaultEnabled() && Config.get().isSqsPropagationEnabled();
+  }
+
+  @Override
+  public ElementMatcher<ClassLoader> classLoaderMatcher() {
+    return hasClassesNamed("com.amazon.sqs.javamessaging.message.SQSMessage");
+  }
+
+  @Override
+  public ElementMatcher<TypeDescription> typeMatcher() {
+    return named("com.amazon.sqs.javamessaging.message.SQSMessage");
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(
+        isConstructor().and(takesArgument(2, named("com.amazonaws.services.sqs.model.Message"))),
+        getClass().getName() + "$CopyTracePropertyAdvice");
+  }
+
+  public static class CopyTracePropertyAdvice {
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    public static void onExit(
+        @Advice.Argument(2) Message sqsMessage, @Advice.FieldValue("properties") Map properties)
+        throws JMSException {
+      Map<String, String> systemAttributes = sqsMessage.getAttributes();
+      if (null != systemAttributes) {
+        String awsTraceHeader = systemAttributes.get("AWSTraceHeader");
+        if (null != awsTraceHeader && !awsTraceHeader.isEmpty()) {
+          properties.put(
+              "x__dash__amzn__dash__trace__dash__id", // X-Amzn-Trace-Id, encoded for JMS
+              new SQSMessage.JMSMessagePropertyValue(awsTraceHeader, STRING));
+        }
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/SqsReceiveRequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/SqsReceiveRequestInstrumentation.java
@@ -1,0 +1,89 @@
+package datadog.trace.instrumentation.aws.v0;
+
+import static datadog.trace.agent.tooling.ClassLoaderMatcher.hasClassesNamed;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
+import static java.util.Arrays.asList;
+import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
+import static net.bytebuddy.matcher.ElementMatchers.isDeclaredBy;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+
+import com.amazonaws.services.sqs.model.ReceiveMessageRequest;
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.api.Config;
+import java.util.List;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+@AutoService(Instrumenter.class)
+public class SqsReceiveRequestInstrumentation extends Instrumenter.Tracing {
+  public SqsReceiveRequestInstrumentation() {
+    super("aws-sdk");
+  }
+
+  @Override
+  protected boolean defaultEnabled() {
+    return super.defaultEnabled() && Config.get().isSqsPropagationEnabled();
+  }
+
+  @Override
+  public ElementMatcher<ClassLoader> classLoaderMatcher() {
+    return hasClassesNamed("com.amazonaws.services.sqs.model.ReceiveMessageRequest");
+  }
+
+  @Override
+  public ElementMatcher<TypeDescription> typeMatcher() {
+    return namedOneOf(
+        "com.amazonaws.services.sqs.model.ReceiveMessageRequest",
+        "com.amazonaws.services.sqs.buffered.QueueBufferConfig");
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(
+        (isConstructor().or(isMethod().and(namedOneOf("setAttributeNames", "withAttributeNames"))))
+            .and(isDeclaredBy(named("com.amazonaws.services.sqs.model.ReceiveMessageRequest"))),
+        getClass().getName() + "$ReceiveMessageRequestAdvice");
+    transformation.applyAdvice(
+        (isConstructor()
+                .or(
+                    isMethod()
+                        .and(namedOneOf("setReceiveAttributeNames", "withReceiveAttributeNames"))))
+            .and(isDeclaredBy(named("com.amazonaws.services.sqs.buffered.QueueBufferConfig"))),
+        getClass().getName() + "$QueueBufferConfigAdvice");
+  }
+
+  public static class ReceiveMessageRequestAdvice {
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    public static void onExit(@Advice.This ReceiveMessageRequest request) {
+      // ReceiveMessageRequest always returns a mutable list which we can append to
+      List<String> attributeNames = request.getAttributeNames();
+      for (String name : attributeNames) {
+        if ("AWSTraceHeader".equals(name) || "All".equals(name)) {
+          return;
+        }
+      }
+      attributeNames.add("AWSTraceHeader");
+    }
+  }
+
+  public static class QueueBufferConfigAdvice {
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    public static void onExit(
+        @Advice.FieldValue(value = "receiveAttributeNames", readOnly = false)
+            List<String> receiveAttributeNames) {
+      // QueueBufferConfig maintains an immutable list which we may need to replace
+      for (String name : receiveAttributeNames) {
+        if ("AWSTraceHeader".equals(name) || "All".equals(name)) {
+          return;
+        }
+      }
+      int oldLength = receiveAttributeNames.size();
+      String[] nameArray = receiveAttributeNames.toArray(new String[oldLength + 1]);
+      nameArray[oldLength] = "AWSTraceHeader";
+      receiveAttributeNames = asList(nameArray);
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test/groovy/SqsClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test/groovy/SqsClientTest.groovy
@@ -1,3 +1,6 @@
+import com.amazon.sqs.javamessaging.ProviderConfiguration
+import com.amazon.sqs.javamessaging.SQSConnectionFactory
+import com.amazon.sqs.javamessaging.message.SQSTextMessage
 import com.amazonaws.SDKGlobalConfiguration
 import com.amazonaws.auth.AWSCredentialsProviderChain
 import com.amazonaws.auth.AWSStaticCredentialsProvider
@@ -14,6 +17,8 @@ import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import org.elasticmq.rest.sqs.SQSRestServerBuilder
 import spock.lang.Shared
+
+import javax.jms.Session
 
 import static datadog.trace.agent.test.utils.TraceUtils.basicSpan
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
@@ -48,18 +53,25 @@ class SqsClientTest extends AgentTestRunner {
 
   def "trace details propagated via SQS system message attributes"() {
     setup:
-    def client = AmazonSQSClientBuilder.standard().withEndpointConfiguration(endpoint).withCredentials(credentialsProvider).build()
+    def client = AmazonSQSClientBuilder.standard()
+      .withEndpointConfiguration(endpoint)
+      .withCredentials(credentialsProvider)
+      .build()
     def queueUrl = client.createQueue('somequeue').queueUrl
     TEST_WRITER.clear()
 
     when:
-    def sendTraceId = TraceUtils.runUnderTrace('parent', {
+    TraceUtils.runUnderTrace('parent', {
       client.sendMessage(queueUrl, 'sometext')
-      return activeSpan().traceId
     })
     def messages = client.receiveMessage(queueUrl).messages
 
     then:
+    def sendSpan = TEST_WRITER.get(0).get(2)
+    assert messages[0].attributes['AWSTraceHeader'] ==
+    "Root=1-00000000-00000000${sendSpan.traceId.toHexStringPadded(16)};" +
+    "Parent=${sendSpan.spanId.toHexStringPadded(16)};Sampled=1"
+
     assertTraces(2) {
       trace(3) {
         basicSpan(it, "parent")
@@ -151,7 +163,181 @@ class SqsClientTest extends AgentTestRunner {
         }
       }
     }
-    assert messages[0].attributes['AWSTraceHeader'] ==
-    "Root=1-00000000-00000000${sendTraceId.toHexStringPadded(16)};Parent=0000000000000005;Sampled=1"
+
+    cleanup:
+    client.shutdown()
+  }
+
+  def "trace details propagated from SQS to JMS"() {
+    setup:
+    def client = AmazonSQSClientBuilder.standard()
+      .withEndpointConfiguration(endpoint)
+      .withCredentials(credentialsProvider)
+      .build()
+
+    def connectionFactory = new SQSConnectionFactory(new ProviderConfiguration(), client)
+    def connection = connectionFactory.createConnection()
+    def session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE)
+    def queue = session.createQueue('somequeue')
+    def producer = session.createProducer(queue)
+    def consumer = session.createConsumer(queue)
+
+    TEST_WRITER.clear()
+
+    when:
+    connection.start()
+    TraceUtils.runUnderTrace('parent', {
+      producer.send(new SQSTextMessage('sometext'))
+    })
+    def message = consumer.receive()
+    consumer.receiveNoWait()
+
+    then:
+    def expectedTraceProperty = 'X-Amzn-Trace-Id'.toLowerCase(Locale.ENGLISH).replace('-', '__dash__')
+    def sendSpan = TEST_WRITER.get(0).get(2)
+    assert message.getStringProperty(expectedTraceProperty) ==
+    "Root=1-00000000-00000000${sendSpan.traceId.toHexStringPadded(16)};" +
+    "Parent=${sendSpan.spanId.toHexStringPadded(16)};Sampled=1"
+
+    assertTraces(3) {
+      trace(2) {
+        span {
+          serviceName "sqs"
+          operationName "aws.http"
+          resourceName "SQS.ReceiveMessage"
+          spanType DDSpanTypes.HTTP_CLIENT
+          errored false
+          measured true
+          parent()
+          tags {
+            "$Tags.COMPONENT" "java-aws-sdk"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.HTTP_URL" "http://localhost:${address.port}/"
+            "$Tags.HTTP_METHOD" "POST"
+            "$Tags.HTTP_STATUS" 200
+            "$Tags.PEER_PORT" address.port
+            "$Tags.PEER_HOSTNAME" "localhost"
+            "aws.service" "AmazonSQS"
+            "aws.endpoint" "http://localhost:${address.port}"
+            "aws.operation" "ReceiveMessageRequest"
+            "aws.agent" "java-aws-sdk"
+            "aws.queue.url" "http://localhost:${address.port}/000000000000/somequeue"
+            defaultTags()
+          }
+        }
+        span {
+          operationName "http.request"
+          resourceName "POST /?/somequeue"
+          spanType DDSpanTypes.HTTP_CLIENT
+          errored false
+          measured true
+          childOf(span(0))
+          tags {
+            "$Tags.COMPONENT" "apache-httpclient"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" "localhost"
+            "$Tags.PEER_PORT" address.port
+            "$Tags.HTTP_URL" "http://localhost:${address.port}/000000000000/somequeue"
+            "$Tags.HTTP_METHOD" "POST"
+            "$Tags.HTTP_STATUS" 200
+            defaultTags()
+          }
+        }
+      }
+      trace(3) {
+        basicSpan(it, "parent")
+        span {
+          serviceName "sqs"
+          operationName "aws.http"
+          resourceName "SQS.SendMessage"
+          spanType DDSpanTypes.HTTP_CLIENT
+          errored false
+          measured true
+          childOf(span(0))
+          tags {
+            "$Tags.COMPONENT" "java-aws-sdk"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.HTTP_URL" "http://localhost:${address.port}/"
+            "$Tags.HTTP_METHOD" "POST"
+            "$Tags.HTTP_STATUS" 200
+            "$Tags.PEER_PORT" address.port
+            "$Tags.PEER_HOSTNAME" "localhost"
+            "aws.service" "AmazonSQS"
+            "aws.endpoint" "http://localhost:${address.port}"
+            "aws.operation" "SendMessageRequest"
+            "aws.agent" "java-aws-sdk"
+            "aws.queue.url" "http://localhost:${address.port}/000000000000/somequeue"
+            defaultTags()
+          }
+        }
+        span {
+          operationName "http.request"
+          resourceName "POST /?/somequeue"
+          spanType DDSpanTypes.HTTP_CLIENT
+          errored false
+          measured true
+          childOf(span(1))
+          tags {
+            "$Tags.COMPONENT" "apache-httpclient"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" "localhost"
+            "$Tags.PEER_PORT" address.port
+            "$Tags.HTTP_URL" "http://localhost:${address.port}/000000000000/somequeue"
+            "$Tags.HTTP_METHOD" "POST"
+            "$Tags.HTTP_STATUS" 200
+            defaultTags()
+          }
+        }
+      }
+      trace(2) {
+        span {
+          serviceName "sqs"
+          operationName "aws.http"
+          resourceName "SQS.DeleteMessage"
+          spanType DDSpanTypes.HTTP_CLIENT
+          errored false
+          measured true
+          parent()
+          tags {
+            "$Tags.COMPONENT" "java-aws-sdk"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.HTTP_URL" "http://localhost:${address.port}/"
+            "$Tags.HTTP_METHOD" "POST"
+            "$Tags.HTTP_STATUS" 200
+            "$Tags.PEER_PORT" address.port
+            "$Tags.PEER_HOSTNAME" "localhost"
+            "aws.service" "AmazonSQS"
+            "aws.endpoint" "http://localhost:${address.port}"
+            "aws.operation" "DeleteMessageRequest"
+            "aws.agent" "java-aws-sdk"
+            "aws.queue.url" "http://localhost:${address.port}/000000000000/somequeue"
+            defaultTags()
+          }
+        }
+        span {
+          operationName "http.request"
+          resourceName "POST /?/somequeue"
+          spanType DDSpanTypes.HTTP_CLIENT
+          errored false
+          measured true
+          childOf(span(0))
+          tags {
+            "$Tags.COMPONENT" "apache-httpclient"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" "localhost"
+            "$Tags.PEER_PORT" address.port
+            "$Tags.HTTP_URL" "http://localhost:${address.port}/000000000000/somequeue"
+            "$Tags.HTTP_METHOD" "POST"
+            "$Tags.HTTP_STATUS" 200
+            defaultTags()
+          }
+        }
+      }
+    }
+
+    cleanup:
+    session.close()
+    connection.stop()
+    client.shutdown()
   }
 }

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test/groovy/SqsClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test/groovy/SqsClientTest.groovy
@@ -1,0 +1,157 @@
+import com.amazonaws.SDKGlobalConfiguration
+import com.amazonaws.auth.AWSCredentialsProviderChain
+import com.amazonaws.auth.AWSStaticCredentialsProvider
+import com.amazonaws.auth.AnonymousAWSCredentials
+import com.amazonaws.auth.EnvironmentVariableCredentialsProvider
+import com.amazonaws.auth.InstanceProfileCredentialsProvider
+import com.amazonaws.auth.SystemPropertiesCredentialsProvider
+import com.amazonaws.auth.profile.ProfileCredentialsProvider
+import com.amazonaws.client.builder.AwsClientBuilder
+import com.amazonaws.services.sqs.AmazonSQSClientBuilder
+import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.agent.test.utils.TraceUtils
+import datadog.trace.api.DDSpanTypes
+import datadog.trace.bootstrap.instrumentation.api.Tags
+import org.elasticmq.rest.sqs.SQSRestServerBuilder
+import spock.lang.Shared
+
+import static datadog.trace.agent.test.utils.TraceUtils.basicSpan
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
+
+class SqsClientTest extends AgentTestRunner {
+
+  private static final CREDENTIALS_PROVIDER_CHAIN = new AWSCredentialsProviderChain(
+  new EnvironmentVariableCredentialsProvider(),
+  new SystemPropertiesCredentialsProvider(),
+  new ProfileCredentialsProvider(),
+  new InstanceProfileCredentialsProvider())
+
+  def setup() {
+    System.setProperty(SDKGlobalConfiguration.ACCESS_KEY_SYSTEM_PROPERTY, "my-access-key")
+    System.setProperty(SDKGlobalConfiguration.SECRET_KEY_SYSTEM_PROPERTY, "my-secret-key")
+  }
+
+  @Shared
+  def credentialsProvider = new AWSStaticCredentialsProvider(new AnonymousAWSCredentials())
+  @Shared
+  def server = SQSRestServerBuilder.withInterface("localhost").start()
+  @Shared
+  def address = server.waitUntilStarted().localAddress()
+  @Shared
+  def endpoint = new AwsClientBuilder.EndpointConfiguration("http://localhost:${address.port}", "elasticmq")
+
+  def cleanupSpec() {
+    if (server != null) {
+      server.stopAndWait()
+    }
+  }
+
+  def "trace details propagated via SQS system message attributes"() {
+    setup:
+    def client = AmazonSQSClientBuilder.standard().withEndpointConfiguration(endpoint).withCredentials(credentialsProvider).build()
+    def queueUrl = client.createQueue('somequeue').queueUrl
+    TEST_WRITER.clear()
+
+    when:
+    def sendTraceId = TraceUtils.runUnderTrace('parent', {
+      client.sendMessage(queueUrl, 'sometext')
+      return activeSpan().traceId
+    })
+    def messages = client.receiveMessage(queueUrl).messages
+
+    then:
+    assertTraces(2) {
+      trace(3) {
+        basicSpan(it, "parent")
+        span {
+          serviceName "sqs"
+          operationName "aws.http"
+          resourceName "SQS.SendMessage"
+          spanType DDSpanTypes.HTTP_CLIENT
+          errored false
+          measured true
+          childOf(span(0))
+          tags {
+            "$Tags.COMPONENT" "java-aws-sdk"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.HTTP_URL" "http://localhost:${address.port}/"
+            "$Tags.HTTP_METHOD" "POST"
+            "$Tags.HTTP_STATUS" 200
+            "$Tags.PEER_PORT" address.port
+            "$Tags.PEER_HOSTNAME" "localhost"
+            "aws.service" "AmazonSQS"
+            "aws.endpoint" "http://localhost:${address.port}"
+            "aws.operation" "SendMessageRequest"
+            "aws.agent" "java-aws-sdk"
+            "aws.queue.url" "http://localhost:${address.port}/000000000000/somequeue"
+            defaultTags()
+          }
+        }
+        span {
+          operationName "http.request"
+          resourceName "POST /?/somequeue"
+          spanType DDSpanTypes.HTTP_CLIENT
+          errored false
+          measured true
+          childOf(span(1))
+          tags {
+            "$Tags.COMPONENT" "apache-httpclient"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" "localhost"
+            "$Tags.PEER_PORT" address.port
+            "$Tags.HTTP_URL" "http://localhost:${address.port}/000000000000/somequeue"
+            "$Tags.HTTP_METHOD" "POST"
+            "$Tags.HTTP_STATUS" 200
+            defaultTags()
+          }
+        }
+      }
+      trace(2) {
+        span {
+          serviceName "sqs"
+          operationName "aws.http"
+          resourceName "SQS.ReceiveMessage"
+          spanType DDSpanTypes.HTTP_CLIENT
+          errored false
+          measured true
+          parent()
+          tags {
+            "$Tags.COMPONENT" "java-aws-sdk"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.HTTP_URL" "http://localhost:${address.port}/"
+            "$Tags.HTTP_METHOD" "POST"
+            "$Tags.HTTP_STATUS" 200
+            "$Tags.PEER_PORT" address.port
+            "$Tags.PEER_HOSTNAME" "localhost"
+            "aws.service" "AmazonSQS"
+            "aws.endpoint" "http://localhost:${address.port}"
+            "aws.operation" "ReceiveMessageRequest"
+            "aws.agent" "java-aws-sdk"
+            "aws.queue.url" "http://localhost:${address.port}/000000000000/somequeue"
+            defaultTags()
+          }
+        }
+        span {
+          operationName "http.request"
+          resourceName "POST /?/somequeue"
+          spanType DDSpanTypes.HTTP_CLIENT
+          errored false
+          measured true
+          childOf(span(0))
+          tags {
+            "$Tags.COMPONENT" "apache-httpclient"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" "localhost"
+            "$Tags.PEER_PORT" address.port
+            "$Tags.HTTP_URL" "http://localhost:${address.port}/000000000000/somequeue"
+            "$Tags.HTTP_METHOD" "POST"
+            "$Tags.HTTP_STATUS" 200
+            defaultTags()
+          }
+        }
+      }
+    }
+    assert messages[0].attributes['AWSTraceHeader'] ==
+    "Root=1-00000000-00000000${sendTraceId.toHexStringPadded(16)};Parent=0000000000000005;Sampled=1"
+  }
+}

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -76,6 +76,7 @@ public final class ConfigDefaults {
   static final boolean DEFAULT_APPSEC_ENABLED = false;
 
   static final boolean DEFAULT_AWS_PROPAGATION_ENABLED = true;
+  static final boolean DEFAULT_SQS_PROPAGATION_ENABLED = true;
   static final boolean DEFAULT_KAFKA_CLIENT_PROPAGATION_ENABLED = true;
   static final boolean DEFAULT_JMS_PROPAGATION_ENABLED = true;
   static final boolean DEFAULT_RABBIT_PROPAGATION_ENABLED = true;

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
@@ -41,6 +41,7 @@ public final class TraceInstrumentationConfig {
   public static final String LOGS_MDC_TAGS_INJECTION_ENABLED = "logs.mdc.tags.injection";
 
   public static final String AWS_PROPAGATION_ENABLED = "aws.propagation.enabled";
+  public static final String SQS_PROPAGATION_ENABLED = "sqs.propagation.enabled";
 
   public static final String KAFKA_CLIENT_PROPAGATION_ENABLED = "kafka.client.propagation.enabled";
   public static final String KAFKA_CLIENT_PROPAGATION_DISABLED_TOPICS =

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -49,6 +49,7 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_SERIALVERSIONUID_FIELD_IN
 import static datadog.trace.api.ConfigDefaults.DEFAULT_SERVICE_NAME;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_SERVLET_ROOT_CONTEXT_SERVICE_NAME;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_SITE;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_SQS_PROPAGATION_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_AGENT_PORT;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_AGENT_V05_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_ANALYTICS_ENABLED;
@@ -168,6 +169,7 @@ import static datadog.trace.api.config.TraceInstrumentationConfig.SERIALVERSIONU
 import static datadog.trace.api.config.TraceInstrumentationConfig.SERVLET_ASYNC_TIMEOUT_ERROR;
 import static datadog.trace.api.config.TraceInstrumentationConfig.SERVLET_PRINCIPAL_ENABLED;
 import static datadog.trace.api.config.TraceInstrumentationConfig.SERVLET_ROOT_CONTEXT_SERVICE_NAME;
+import static datadog.trace.api.config.TraceInstrumentationConfig.SQS_PROPAGATION_ENABLED;
 import static datadog.trace.api.config.TraceInstrumentationConfig.TEMP_JARS_CLEAN_ON_BOOT;
 import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_ANNOTATIONS;
 import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_CLASSES_EXCLUDE;
@@ -393,6 +395,7 @@ public class Config {
   private final String appSecRulesFile;
 
   private final boolean awsPropagationEnabled;
+  private final boolean sqsPropagationEnabled;
 
   private final boolean kafkaClientPropagationEnabled;
   private final Set<String> kafkaClientPropagationDisabledTopics;
@@ -820,6 +823,9 @@ public class Config {
 
     awsPropagationEnabled =
         configProvider.getBoolean(AWS_PROPAGATION_ENABLED, DEFAULT_AWS_PROPAGATION_ENABLED);
+    sqsPropagationEnabled =
+        awsPropagationEnabled
+            && configProvider.getBoolean(SQS_PROPAGATION_ENABLED, DEFAULT_SQS_PROPAGATION_ENABLED);
 
     kafkaClientPropagationEnabled =
         configProvider.getBoolean(
@@ -1281,6 +1287,10 @@ public class Config {
 
   public boolean isAwsPropagationEnabled() {
     return awsPropagationEnabled;
+  }
+
+  public boolean isSqsPropagationEnabled() {
+    return sqsPropagationEnabled;
   }
 
   public boolean isKafkaClientPropagationEnabled() {
@@ -2052,6 +2062,8 @@ public class Config {
         + profilingExcludeAgentThreads
         + ", awsPropagationEnabled="
         + awsPropagationEnabled
+        + ", sqsPropagationEnabled="
+        + sqsPropagationEnabled
         + ", kafkaClientPropagationEnabled="
         + kafkaClientPropagationEnabled
         + ", kafkaClientPropagationDisabledTopics="


### PR DESCRIPTION
Automatically requests `AWSTraceHeader` system attribute when receiving SQS messages, and uses that to populate a special JMS property `x__dash__amzn__dash__trace__dash__id`* when wrapping SQS messages with `amazon-sqs-java-messaging-lib` to behave like JMS messages.

(* this property is `X-Amzn-Trace-Id`, encoded for JMS using the same rules as our JMS property injector/extractor.)

Note: the Datadog codec was previously updated in #3104 to automatically process the `X-Amzn-Trace-Id` header, after the header has been decoded.