### PR TITLE
Fix checkpoint emission for servlet/request-3

### DIFF
--- a/dd-java-agent/instrumentation/jetty-7.0/src/main/java/datadog/trace/instrumentation/jetty70/JettyServerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-7.0/src/main/java/datadog/trace/instrumentation/jetty70/JettyServerInstrumentation.java
@@ -109,6 +109,8 @@ public final class JettyServerInstrumentation extends Instrumenter.Tracing {
       req.setAttribute(DD_SPAN_ATTRIBUTE, span);
       req.setAttribute(CorrelationIdentifier.getTraceIdKey(), GlobalTracer.get().getTraceId());
       req.setAttribute(CorrelationIdentifier.getSpanIdKey(), GlobalTracer.get().getSpanId());
+      // request may be processed on any thread; signal thread migration
+      span.startThreadMigration();
       return scope;
     }
 
@@ -131,7 +133,8 @@ public final class JettyServerInstrumentation extends Instrumenter.Tracing {
       if (spanObj instanceof AgentSpan) {
         final AgentSpan span = (AgentSpan) spanObj;
         DECORATE.onResponse(span, channel);
-        DECORATE.beforeFinish(span);
+        // span could have been originated on a different thread and migrated
+        span.finishThreadMigration();
         span.finish();
       }
     }

--- a/dd-java-agent/instrumentation/jetty-9/src/main/java/datadog/trace/instrumentation/jetty9/JettyServerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-9/src/main/java/datadog/trace/instrumentation/jetty9/JettyServerInstrumentation.java
@@ -111,6 +111,8 @@ public final class JettyServerInstrumentation extends Instrumenter.Tracing
       req.setAttribute(DD_SPAN_ATTRIBUTE, span);
       req.setAttribute(CorrelationIdentifier.getTraceIdKey(), GlobalTracer.get().getTraceId());
       req.setAttribute(CorrelationIdentifier.getSpanIdKey(), GlobalTracer.get().getSpanId());
+      // request may be processed on any thread; signal thread migration
+      span.startThreadMigration();
       return scope;
     }
 
@@ -133,6 +135,8 @@ public final class JettyServerInstrumentation extends Instrumenter.Tracing
         final AgentSpan span = (AgentSpan) spanObj;
         DECORATE.onResponse(span, channel);
         DECORATE.beforeFinish(span);
+        // span could have been originated on a different thread and migrated
+        span.finishThreadMigration();
         span.finish();
       }
     }

--- a/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/AsyncContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/AsyncContextInstrumentation.java
@@ -90,6 +90,8 @@ public final class AsyncContextInstrumentation extends Instrumenter.Tracing {
         } else if (args.length == 2 && args[1] instanceof String) {
           span.setResourceName((String) args[1]);
         }
+        // request may be processed on any thread; signal thread migration
+        span.startThreadMigration();
       }
       return true;
     }

--- a/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Advice.java
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Advice.java
@@ -39,6 +39,8 @@ public class Servlet3Advice {
       // Activate the dispatch span as the request span so it can be finished with the request.
       // We don't want to create a new servlet.request span since this is internal processing.
       AgentSpan castDispatchSpan = (AgentSpan) dispatchSpan;
+      // span could have been originated on a different thread and migrated
+      castDispatchSpan.finishThreadMigration();
       return activateSpan(castDispatchSpan);
     }
 

--- a/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/JettyServlet3Test.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/JettyServlet3Test.groovy
@@ -1,7 +1,5 @@
 import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.agent.test.base.HttpServer
-import datadog.trace.agent.test.checkpoints.CheckpointValidator
-import datadog.trace.agent.test.checkpoints.CheckpointValidationMode
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.instrumentation.servlet3.AsyncDispatcherDecorator
 import org.eclipse.jetty.server.Request
@@ -228,13 +226,6 @@ class JettyServlet3TestAsync extends JettyServlet3Test {
   boolean testTimeout() {
     true
   }
-
-  @Override
-  def setup() {
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.THREAD_SEQUENCE)
-  }
 }
 
 class JettyServlet3TestFakeAsync extends JettyServlet3Test {
@@ -363,12 +354,5 @@ class JettyServlet3TestDispatchAsync extends JettyServlet3Test {
     super.setupServlets(context)
     setupDispatchServlets(context, TestServlet3.DispatchAsync)
     addServlet(context, "/dispatch/recursive", TestServlet3.DispatchRecursive)
-  }
-
-  @Override
-  def setup() {
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.THREAD_SEQUENCE)
   }
 }

--- a/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/TomcatServlet3Test.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/TomcatServlet3Test.groovy
@@ -1,8 +1,6 @@
 import com.google.common.io.Files
 import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.agent.test.base.HttpServer
-import datadog.trace.agent.test.checkpoints.CheckpointValidator
-import datadog.trace.agent.test.checkpoints.CheckpointValidationMode
 import datadog.trace.api.CorrelationIdentifier
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.instrumentation.servlet3.AsyncDispatcherDecorator
@@ -358,13 +356,6 @@ class TomcatServlet3TestAsync extends TomcatServlet3Test {
     // The exception will just cause an async timeout
     false
   }
-
-  @Override
-  def setup() {
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.THREAD_SEQUENCE)
-  }
 }
 
 class TomcatServlet3TestFakeAsync extends TomcatServlet3Test {
@@ -496,12 +487,5 @@ class TomcatServlet3TestDispatchAsync extends TomcatServlet3Test {
     super.setupServlets(context)
     setupDispatchServlets(context, TestServlet3.DispatchAsync)
     addServlet(context, "/dispatch/recursive", TestServlet3.DispatchRecursive)
-  }
-
-  @Override
-  def setup() {
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.THREAD_SEQUENCE)
   }
 }

--- a/dd-java-agent/instrumentation/tomcat-5.5/src/main/java/datadog/trace/instrumentation/tomcat/RequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/tomcat-5.5/src/main/java/datadog/trace/instrumentation/tomcat/RequestInstrumentation.java
@@ -66,6 +66,8 @@ public final class RequestInstrumentation extends Instrumenter.Tracing {
         final AgentSpan span = (AgentSpan) spanObj;
         DECORATE.onResponse(span, resp);
         DECORATE.beforeFinish(span);
+        // span could have been originated on a different thread and migrated
+        span.finishThreadMigration();
         span.finish();
       }
     }

--- a/dd-java-agent/instrumentation/tomcat-5.5/src/main/java/datadog/trace/instrumentation/tomcat/TomcatServerInstrumentation.java
+++ b/dd-java-agent/instrumentation/tomcat-5.5/src/main/java/datadog/trace/instrumentation/tomcat/TomcatServerInstrumentation.java
@@ -105,6 +105,8 @@ public final class TomcatServerInstrumentation extends Instrumenter.Tracing
       req.setAttribute(DD_SPAN_ATTRIBUTE, span);
       req.setAttribute(CorrelationIdentifier.getTraceIdKey(), GlobalTracer.get().getTraceId());
       req.setAttribute(CorrelationIdentifier.getSpanIdKey(), GlobalTracer.get().getSpanId());
+      // request may be processed on any thread; signal thread migration
+      span.startThreadMigration();
       return scope;
     }
 

--- a/dd-java-agent/instrumentation/tomcat-5.5/src/test/groovy/TomcatServletTest.groovy
+++ b/dd-java-agent/instrumentation/tomcat-5.5/src/test/groovy/TomcatServletTest.groovy
@@ -212,8 +212,8 @@ class TomcatServletTest extends AbstractServletTest<Embedded, Context> {
     TEST_WRITER.waitForTraces(1)
     then: "2 synchronous spans"
     2 * TEST_CHECKPOINTER.checkpoint(_, SPAN)
-    0 * TEST_CHECKPOINTER.checkpoint(_, THREAD_MIGRATION)
-    0 * TEST_CHECKPOINTER.checkpoint(_, THREAD_MIGRATION | END)
+    _ * TEST_CHECKPOINTER.checkpoint(_, THREAD_MIGRATION)
+    _ * TEST_CHECKPOINTER.checkpoint(_, THREAD_MIGRATION | END)
     0 * TEST_CHECKPOINTER.checkpoint(_, CPU | END)
     2 * TEST_CHECKPOINTER.checkpoint(_, SPAN | END)
 


### PR DESCRIPTION
The primary change is initiating span thread migration when the span is assigned to a request - since the request can be worked on by any thread so the span needs to be marked in case it becomes active on other thread than the one that created it. Of course, we need to add the proper 'resume' checkpoint when we need to activate such span.