### PR TITLE
Allow configuring the checkpoint sampler rate limiter 'sensitivity'

### DIFF
--- a/dd-smoke-tests/src/main/groovy/datadog/smoketest/AbstractTestAgentSmokeTest.groovy
+++ b/dd-smoke-tests/src/main/groovy/datadog/smoketest/AbstractTestAgentSmokeTest.groovy
@@ -44,7 +44,7 @@ abstract class AbstractTestAgentSmokeTest extends ProcessManager {
     "-Ddd.env=${ENV}",
     "-Ddd.version=${VERSION}",
     "-Ddd.profiling.enabled=false",
-    "-Ddd.${ProfilingConfig.PROFILING_CHECKPOINTS_RATE_LIMIT}=0",
+    "-Ddd.${ProfilingConfig.PROFILING_CHECKPOINTS_SAMPLER_RATE_LIMIT}=0",
     "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=debug",
     "-Dorg.slf4j.simpleLogger.defaultLogLevel=debug"
   ]

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
@@ -49,11 +49,12 @@ public final class ProfilingConfig {
       "profiling.legacy.tracing.integration";
   public static final String PROFILING_CHECKPOINTS_RECORD_CPU_TIME =
       "profiling.checkpoints.record.cpu.time";
-  public static final String PROFILING_CHECKPOINTS_RATE_LIMIT = "profiling.checkpoints.rate.limit";
-  public static final int PROFILING_CHECKPOINTS_RATE_LIMIT_DEFAULT = 100000;
-  public static final String PROFILING_CHECKPOINTS_RATE_SENSITIVITY_MS =
-      "profiling.checkpoints.rate.sensitivity.ms";
-  public static final int PROFILING_CHECKPOINTS_RATE_SENSITIVITY_MS_DEFAULT = 5000;
+  public static final String PROFILING_CHECKPOINTS_SAMPLER_RATE_LIMIT =
+      "profiling.checkpoints.sampler.rate-limit";
+  public static final int PROFILING_CHECKPOINTS_SAMPLER_RATE_LIMIT_DEFAULT = 100000;
+  public static final String PROFILING_CHECKPOINTS_SAMPLER_WINDOW_MS =
+      "profiling.checkpoints.sampler.sliding-window.ms";
+  public static final int PROFILING_CHECKPOINTS_SAMPLER_WINDOW_MS_DEFAULT = 5000;
   public static final String PROFILING_ENDPOINT_COLLECTION_ENABLED =
       "profiling.endpoint.collection.enabled";
   public static final boolean PROFILING_ENDPOINT_COLLECTION_ENABLED_DEFAULT = true;

--- a/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/JFRCheckpointer.java
+++ b/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/JFRCheckpointer.java
@@ -186,13 +186,8 @@ public class JFRCheckpointer implements Checkpointer {
     }
     Duration windowSize = Duration.of(getSamplerWindowMs(configProvider), ChronoUnit.MILLIS);
 
-    /*
-    Due to coarse grained sampling (at the level of a local root span) and extremely high variability of
-    the number of checkpoints generated from such a root span, anywhere between 1 and 100000 seems to be
-    quite common - with both fat tails, the expected limit must be somewhat adjusted since it will be
-    almost always 'overshot' by a large margin.
-    '0.6' seems to be the magic number to do the trick ...
-    */
+    // the rate limit is defined per 1 minute (recording length) - need to divide it by 60000 to get
+    // the value per ms
     final float limitPerMs = limit / 60000f;
     float samplesPerWindow = limitPerMs * windowSize.toMillis();
 
@@ -219,8 +214,8 @@ public class JFRCheckpointer implements Checkpointer {
   private static int getRateLimit(final ConfigProvider configProvider) {
     return Math.min(
         configProvider.getInteger(
-            ProfilingConfig.PROFILING_CHECKPOINTS_RATE_LIMIT,
-            ProfilingConfig.PROFILING_CHECKPOINTS_RATE_LIMIT_DEFAULT),
+            ProfilingConfig.PROFILING_CHECKPOINTS_SAMPLER_RATE_LIMIT,
+            ProfilingConfig.PROFILING_CHECKPOINTS_SAMPLER_RATE_LIMIT_DEFAULT),
         MAX_SAMPLER_RATE);
   }
 
@@ -228,8 +223,8 @@ public class JFRCheckpointer implements Checkpointer {
     return Math.max(
         Math.min(
             configProvider.getInteger(
-                ProfilingConfig.PROFILING_CHECKPOINTS_RATE_SENSITIVITY_MS,
-                ProfilingConfig.PROFILING_CHECKPOINTS_RATE_SENSITIVITY_MS_DEFAULT),
+                ProfilingConfig.PROFILING_CHECKPOINTS_SAMPLER_WINDOW_MS,
+                ProfilingConfig.PROFILING_CHECKPOINTS_SAMPLER_WINDOW_MS_DEFAULT),
             MAX_SAMPLER_WINDOW_SIZE_MS),
         MIN_SAMPLER_WINDOW_SIZE_MS);
   }

--- a/dd-trace-core/jfr-openjdk/src/test/groovy/datadog/trace/core/jfr/openjdk/JfrCheckpointerTest.groovy
+++ b/dd-trace-core/jfr-openjdk/src/test/groovy/datadog/trace/core/jfr/openjdk/JfrCheckpointerTest.groovy
@@ -40,8 +40,8 @@ class JfrCheckpointerTest extends DDSpecification {
   def "test sampler configuration"() {
     setup:
     Properties props = new Properties()
-    props.put(ProfilingConfig.PROFILING_CHECKPOINTS_RATE_LIMIT, String.valueOf(rateLimit))
-    props.put(ProfilingConfig.PROFILING_CHECKPOINTS_RATE_SENSITIVITY_MS, String.valueOf(sensitivity))
+    props.put(ProfilingConfig.PROFILING_CHECKPOINTS_SAMPLER_RATE_LIMIT, String.valueOf(rateLimit))
+    props.put(ProfilingConfig.PROFILING_CHECKPOINTS_SAMPLER_WINDOW_MS, String.valueOf(sensitivity))
     def configProvider = ConfigProvider.withPropertiesOverride(props)
     when:
     def config = JFRCheckpointer.getSamplerConfiguration(configProvider)


### PR DESCRIPTION
This change allows configuring the internal adaptive sampler sampling window parameter.
The sampling window defines the amount of time the sampler would use the previously computed probability to sample incoming data. In cases where the checkpoints are generated in large bursts in very short time it may help to increase the sampling window and therefore 'distribute' the burst over larger time period thus making the sampler more stable.

~I must admit I am not completely satisfied with the parameter name but I was not able to come up with any alternative which would be short, descriptive and wouldn't expose the internal implementation details too much. If you can think of a better name I would be glad to change it.~