### PR TITLE
Ignore internal OSGi URL handlers used to locate class resources

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/GlobalIgnoresMatcher.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/GlobalIgnoresMatcher.java
@@ -156,6 +156,11 @@ public class GlobalIgnoresMatcher<T extends TypeDescription>
         break;
       case 'o' - 'a':
         if (name.startsWith("org.")) {
+          if (name.startsWith("org.apache.felix.framework.URLHandlers")
+              || name.startsWith("org.eclipse.osgi.framework.internal.protocol.")
+              || name.startsWith("org.eclipse.osgi.internal.url.")) {
+            return true;
+          }
           if (name.startsWith("org.aspectj.") || name.startsWith("org.jinspired.")) {
             return true;
           }


### PR DESCRIPTION
We don't need to trace them and this avoids some complex interactions on J9 with other transformation checks.

```
Blocked on: com/ibm/ws/bootstrap/ExtClassLoader@0x0000000400BD71F8 Owned by: "server.startup : 1"
at java/lang/ClassLoader.loadClassHelper(ClassLoader.java:907(Compiled Code))
at java/lang/ClassLoader.loadClass(ClassLoader.java:882(Compiled Code))
at com/ibm/ws/bootstrap/ExtClassLoader.loadClass(ExtClassLoader.java:135(Compiled Code))
at java/lang/ClassLoader.loadClass(ClassLoader.java:865(Compiled Code))
at com/ibm/ws/eba/internal/framework/EBAClassLoader.loadClass(EBAClassLoader.java:87)
   (entered lock: com/ibm/ws/eba/internal/framework/EBAClassLoader@0x0000000780162E60, entry count: 1)
at org/eclipse/osgi/launch/EquinoxFWClassLoader.loadClass(EquinoxFWClassLoader.java:46)
at java/lang/ClassLoader.loadClassHelper(ClassLoader.java:926(Compiled Code))
   (entered lock: sun/reflect/DelegatingClassLoader@0x000000078017ECA0, entry count: 1)
at java/lang/ClassLoader.loadClass(ClassLoader.java:882(Compiled Code))
at java/lang/ClassLoader.loadClass(ClassLoader.java:865(Compiled Code))
at sun/misc/Unsafe.defineClass(Native Method)
at sun/reflect/ClassDefiner.defineClass(ClassDefiner.java:75)
at sun/reflect/MethodAccessorGenerator$1.run(MethodAccessorGenerator.java:411(Compiled Code))
at sun/reflect/MethodAccessorGenerator$1.run(MethodAccessorGenerator.java:406)
at java/security/AccessController.doPrivileged(AccessController.java:647(Compiled Code))
at sun/reflect/MethodAccessorGenerator.generate(MethodAccessorGenerator.java:405(Compiled Code))
at sun/reflect/MethodAccessorGenerator.generateMethod(MethodAccessorGenerator.java:87)
at sun/reflect/NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:81(Compiled Code))
at sun/reflect/DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:55(Compiled Code))
at java/lang/reflect/Method.invoke(Method.java:508(Compiled Code))
at org/eclipse/osgi/framework/internal/protocol/MultiplexingFactory.findAuthorizedFactory(MultiplexingFactory.java:128)
at org/eclipse/osgi/framework/internal/protocol/StreamHandlerFactory.findAuthorizedURLStreamHandler(StreamHandlerFactory.java:194)
at org/eclipse/osgi/framework/internal/protocol/StreamHandlerFactory.createURLStreamHandler(StreamHandlerFactory.java:112)
at java/net/URL.getURLStreamHandler(URL.java:1154(Compiled Code))
at java/net/URL.<init>(URL.java:611(Compiled Code))
at java/net/URL.<init>(URL.java:502(Compiled Code))
at java/net/URL.<init>(URL.java:451(Compiled Code))
at sun/net/www/protocol/jar/Handler.parseAbsoluteSpec(Handler.java:188(Compiled Code))
at sun/net/www/protocol/jar/Handler.parseURL(Handler.java:163(Compiled Code))
at java/net/URL.<init>(URL.java:634(Compiled Code))
at com/ibm/oti/vm/AbstractClassLoader.findResourceImpl(AbstractClassLoader.java:215(Compiled Code))
at com/ibm/oti/vm/AbstractClassLoader.access$100(AbstractClassLoader.java:41(Compiled Code))
at com/ibm/oti/vm/AbstractClassLoader$1.run(AbstractClassLoader.java:185(Compiled Code))
at java/security/AccessController.doPrivileged(AccessController.java:647(Compiled Code))
at com/ibm/oti/vm/AbstractClassLoader.findResource(AbstractClassLoader.java:182(Compiled Code))
at java/lang/ClassLoader.getResource(ClassLoader.java:586(Compiled Code))
at java/net/URLClassLoader.getResourceAsStream(URLClassLoader.java:365(Compiled Code))
at datadog/trace/agent/tooling/bytebuddy/DDClassFileLocator.loadClassResource(DDClassFileLocator.java:56(Compiled Code))
at datadog/trace/agent/tooling/bytebuddy/DDClassFileLocator.locate(DDClassFileLocator.java:30(Compiled Code))
at net/bytebuddy/dynamic/ClassFileLocator$Compound.locate(ClassFileLocator.java:1858(Compiled Code))
at net/bytebuddy/pool/TypePool$Default.doDescribe(TypePool.java:789(Compiled Code))
at net/bytebuddy/pool/TypePool$Default$WithLazyResolution.access$001(TypePool.java:871(Compiled Code))
at net/bytebuddy/pool/TypePool$Default$WithLazyResolution.doResolve(TypePool.java:969(Compiled Code))
at net/bytebuddy/pool/TypePool$Default$WithLazyResolution$LazyTypeDescription.delegate(TypePool.java:1038(Compiled Code))
at net/bytebuddy/description/type/TypeDescription$AbstractBase$OfSimpleType$WithDelegation.getInterfaces(TypeDescription.java:8217(Compiled Code))
at net/bytebuddy/description/type/TypeDescription$Generic$OfNonGenericType.getInterfaces(TypeDescription.java:3558(Compiled Code))
at datadog/trace/agent/tooling/bytebuddy/matcher/SafeHasSuperTypeMatcher$SafeInterfaceIterator.<init>(SafeHasSuperTypeMatcher.java:176(Compiled Code))
at datadog/trace/agent/tooling/bytebuddy/matcher/SafeHasSuperTypeMatcher$SafeInterfaceIterator.<init>(SafeHasSuperTypeMatcher.java:166(Compiled Code))
at datadog/trace/agent/tooling/bytebuddy/matcher/SafeHasSuperTypeMatcher.safeGetInterfaces(SafeHasSuperTypeMatcher.java:117(Compiled Code))
at datadog/trace/agent/tooling/bytebuddy/matcher/SafeHasSuperTypeMatcher.hasInterface(SafeHasSuperTypeMatcher.java:103(Compiled Code))
at datadog/trace/agent/tooling/bytebuddy/matcher/SafeHasSuperTypeMatcher.hasInterface(SafeHasSuperTypeMatcher.java:108(Compiled Code))
at datadog/trace/agent/tooling/bytebuddy/matcher/SafeHasSuperTypeMatcher.matches(SafeHasSuperTypeMatcher.java:73(Compiled Code))
at datadog/trace/agent/tooling/bytebuddy/matcher/SafeHasSuperTypeMatcher.matches(SafeHasSuperTypeMatcher.java:33(Compiled Code))
at net/bytebuddy/agent/builder/AgentBuilder$RawMatcher$ForElementMatchers.matches(AgentBuilder.java:1793(Compiled Code))
at net/bytebuddy/agent/builder/AgentBuilder$RawMatcher$Conjunction.matches(AgentBuilder.java:1628(Compiled Code))
at net/bytebuddy/agent/builder/AgentBuilder$Default$ExecutingTransformer.doTransform(AgentBuilder.java:10907(Compiled Code))
at net/bytebuddy/agent/builder/AgentBuilder$Default$ExecutingTransformer.transform(AgentBuilder.java:10866(Compiled Code))
at net/bytebuddy/agent/builder/AgentBuilder$Default$ExecutingTransformer.access$1700(AgentBuilder.java:10584(Compiled Code))
at net/bytebuddy/agent/builder/AgentBuilder$Default$ExecutingTransformer$LegacyVmDispatcher.run(AgentBuilder.java:11258(Compiled Code))
at net/bytebuddy/agent/builder/AgentBuilder$Default$ExecutingTransformer$LegacyVmDispatcher.run(AgentBuilder.java:11205(Compiled Code))
at java/security/AccessController.doPrivileged(AccessController.java:673)
at net/bytebuddy/agent/builder/AgentBuilder$Default$ExecutingTransformer.doPrivileged(AgentBuilder.java(Compiled Code))
at net/bytebuddy/agent/builder/AgentBuilder$Default$ExecutingTransformer.transform(AgentBuilder.java:10773(Compiled Code))
at datadog/trace/agent/tooling/bytebuddy/DDClassFileTransformer.transform(DDClassFileTransformer.java:43(Compiled Code))
at sun/instrument/TransformerManager.transform(TransformerManager.java:200(Compiled Code))
at sun/instrument/InstrumentationImpl.transform(InstrumentationImpl.java:450(Compiled Code))
at java/lang/ClassLoader.defineClassImpl(Native Method)
at java/lang/ClassLoader.defineClassInternal(ClassLoader.java:391(Compiled Code))
at java/lang/ClassLoader.defineClass(ClassLoader.java:360(Compiled Code))
at java/security/SecureClassLoader.defineClass(SecureClassLoader.java:154(Compiled Code))
at java/net/URLClassLoader.defineClass(URLClassLoader.java:730(Compiled Code))
at java/net/URLClassLoader.access$400(URLClassLoader.java:96(Compiled Code))
at java/net/URLClassLoader$ClassFinder.run(URLClassLoader.java:1187(Compiled Code))
at java/security/AccessController.doPrivileged(AccessController.java:739)
at java/net/URLClassLoader.findClass(URLClassLoader.java:605(Compiled Code))
at org/eclipse/osgi/launch/EquinoxFWClassLoader.loadClass(EquinoxFWClassLoader.java:38)
at java/lang/ClassLoader.loadClass(ClassLoader.java:865(Compiled Code))
at org/eclipse/osgi/framework/internal/core/Framework.installContentHandlerFactory(Framework.java:1458)
```

```
Blocked on: org/eclipse/osgi/launch/EquinoxFWClassLoader@0x000000078017EB78 Owned by: "Blueprint Extender: 3"
at java/lang/Class.getMethodImpl(Native Method)
at java/lang/Class.getMethodHelper(Class.java:1257(Compiled Code))
at java/lang/Class.getMethod(Class.java:1187(Compiled Code))
at org/eclipse/osgi/framework/internal/protocol/MultiplexingFactory.findAuthorizedFactory(MultiplexingFactory.java:127)
at org/eclipse/osgi/framework/internal/protocol/StreamHandlerFactory.findAuthorizedURLStreamHandler(StreamHandlerFactory.java:194)
at org/eclipse/osgi/framework/internal/protocol/StreamHandlerFactory.createURLStreamHandler(StreamHandlerFactory.java:112)
at java/net/URL.getURLStreamHandler(URL.java:1154(Compiled Code))
at java/net/URL.<init>(URL.java:611(Compiled Code))
at java/net/URL.<init>(URL.java:502(Compiled Code))
at java/net/URL.<init>(URL.java:451(Compiled Code))
at sun/net/www/protocol/jar/Handler.parseAbsoluteSpec(Handler.java:188(Compiled Code))
at sun/net/www/protocol/jar/Handler.parseURL(Handler.java:163(Compiled Code))
at java/net/URL.<init>(URL.java:634(Compiled Code))
at com/ibm/oti/vm/AbstractClassLoader.findResourceImpl(AbstractClassLoader.java:215(Compiled Code))
at com/ibm/oti/vm/AbstractClassLoader.access$100(AbstractClassLoader.java:41(Compiled Code))
at com/ibm/oti/vm/AbstractClassLoader$1.run(AbstractClassLoader.java:185(Compiled Code))
at java/security/AccessController.doPrivileged(AccessController.java:647(Compiled Code))
at com/ibm/oti/vm/AbstractClassLoader.findResource(AbstractClassLoader.java:182(Compiled Code))
at java/lang/ClassLoader.getResource(ClassLoader.java:586(Compiled Code))
at java/net/URLClassLoader.getResourceAsStream(URLClassLoader.java:365(Compiled Code))
at datadog/trace/agent/tooling/bytebuddy/DDClassFileLocator.loadClassResource(DDClassFileLocator.java:56(Compiled Code))
at datadog/trace/agent/tooling/bytebuddy/DDClassFileLocator.locate(DDClassFileLocator.java:30(Compiled Code))
at net/bytebuddy/dynamic/ClassFileLocator$Compound.locate(ClassFileLocator.java:1858(Compiled Code))
at net/bytebuddy/pool/TypePool$Default.doDescribe(TypePool.java:789(Compiled Code))
at net/bytebuddy/pool/TypePool$Default$WithLazyResolution.access$001(TypePool.java:871(Compiled Code))
at net/bytebuddy/pool/TypePool$Default$WithLazyResolution.doResolve(TypePool.java:969(Compiled Code))
at net/bytebuddy/pool/TypePool$Default$WithLazyResolution$LazyTypeDescription.delegate(TypePool.java:1038(Compiled Code))
at net/bytebuddy/description/type/TypeDescription$AbstractBase$OfSimpleType$WithDelegation.getModifiers(TypeDescription.java:8301(Compiled Code))
at net/bytebuddy/description/ModifierReviewable$AbstractBase.matchesMask(ModifierReviewable.java:618(Compiled Code))
at net/bytebuddy/description/ModifierReviewable$AbstractBase.isPublic(ModifierReviewable.java:336(Compiled Code))
at net/bytebuddy/description/type/TypeDescription$AbstractBase.isVisibleTo(TypeDescription.java:7781(Compiled Code))
at net/bytebuddy/matcher/VisibilityMatcher.matches(VisibilityMatcher.java:48(Compiled Code))
at net/bytebuddy/matcher/VisibilityMatcher.matches(VisibilityMatcher.java:27(Compiled Code))
at net/bytebuddy/matcher/NegatingMatcher.matches(NegatingMatcher.java:46(Compiled Code))
at net/bytebuddy/matcher/ErasureMatcher.matches(ErasureMatcher.java:50(Compiled Code))
at net/bytebuddy/matcher/ErasureMatcher.matches(ErasureMatcher.java:29(Compiled Code))
at net/bytebuddy/matcher/MethodParameterTypeMatcher.matches(MethodParameterTypeMatcher.java:48(Compiled Code))
at net/bytebuddy/matcher/MethodParameterTypeMatcher.matches(MethodParameterTypeMatcher.java:27(Compiled Code))
at net/bytebuddy/matcher/CollectionItemMatcher.matches(CollectionItemMatcher.java:48(Compiled Code))
at net/bytebuddy/matcher/CollectionItemMatcher.matches(CollectionItemMatcher.java:26(Compiled Code))
at net/bytebuddy/matcher/NegatingMatcher.matches(NegatingMatcher.java:46(Compiled Code))
at net/bytebuddy/matcher/MethodParametersMatcher.matches(MethodParametersMatcher.java:49(Compiled Code))
at net/bytebuddy/matcher/MethodParametersMatcher.matches(MethodParametersMatcher.java:28(Compiled Code))
at net/bytebuddy/matcher/ElementMatcher$Junction$Conjunction.matches(ElementMatcher.java:144(Compiled Code))
at net/bytebuddy/dynamic/scaffold/MethodRegistry$Default.prepare(MethodRegistry.java:481(Compiled Code))
at net/bytebuddy/dynamic/scaffold/inline/RedefinitionDynamicTypeBuilder.make(RedefinitionDynamicTypeBuilder.java:204)
at net/bytebuddy/agent/builder/AgentBuilder$Default$ExecutingTransformer.doTransform(AgentBuilder.java:10930(Compiled Code))
at net/bytebuddy/agent/builder/AgentBuilder$Default$ExecutingTransformer.transform(AgentBuilder.java:10866(Compiled Code))
at net/bytebuddy/agent/builder/AgentBuilder$Default$ExecutingTransformer.access$1700(AgentBuilder.java:10584(Compiled Code))
at net/bytebuddy/agent/builder/AgentBuilder$Default$ExecutingTransformer$LegacyVmDispatcher.run(AgentBuilder.java:11258(Compiled Code))
at net/bytebuddy/agent/builder/AgentBuilder$Default$ExecutingTransformer$LegacyVmDispatcher.run(AgentBuilder.java:11205(Compiled Code))
at java/security/AccessController.doPrivileged(AccessController.java:673)
at net/bytebuddy/agent/builder/AgentBuilder$Default$ExecutingTransformer.doPrivileged(AgentBuilder.java(Compiled Code))
at net/bytebuddy/agent/builder/AgentBuilder$Default$ExecutingTransformer.transform(AgentBuilder.java:10773(Compiled Code))
at datadog/trace/agent/tooling/bytebuddy/DDClassFileTransformer.transform(DDClassFileTransformer.java:43(Compiled Code))
at sun/instrument/TransformerManager.transform(TransformerManager.java:200(Compiled Code))
at sun/instrument/InstrumentationImpl.transform(InstrumentationImpl.java:450(Compiled Code))
at java/lang/ClassLoader.defineClassImpl(Native Method)
at java/lang/ClassLoader.defineClassInternal(ClassLoader.java:391(Compiled Code))
at java/lang/ClassLoader.defineClass(ClassLoader.java:360(Compiled Code))
at java/security/SecureClassLoader.defineClass(SecureClassLoader.java:154(Compiled Code))
at java/net/URLClassLoader.defineClass(URLClassLoader.java:818)
at java/net/URLClassLoader.findClass(URLClassLoader.java:591(Compiled Code))
at com/ibm/ws/bootstrap/ExtClassLoader.findClass(ExtClassLoader.java:244(Compiled Code))
at java/lang/ClassLoader.loadClassHelper(ClassLoader.java:937(Compiled Code))
   (entered lock: com/ibm/ws/bootstrap/ExtClassLoader@0x0000000400BD71F8, entry count: 1)
at java/lang/ClassLoader.loadClass(ClassLoader.java:882(Compiled Code))
at com/ibm/ws/bootstrap/ExtClassLoader.loadClass(ExtClassLoader.java:135(Compiled Code))
at java/lang/ClassLoader.loadClass(ClassLoader.java:865(Compiled Code))
```
