### PR TITLE
Remove checkpoint sequence validation exclusions

### DIFF
--- a/dd-java-agent/instrumentation/vertx-rx-3.5/src/test/groovy/client/VertxRxCircuitBreakerWebClientForkedTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-rx-3.5/src/test/groovy/client/VertxRxCircuitBreakerWebClientForkedTest.groovy
@@ -1,8 +1,6 @@
 package client
 
 import datadog.trace.agent.test.base.HttpClientTest
-import datadog.trace.agent.test.checkpoints.CheckpointValidationMode
-import datadog.trace.agent.test.checkpoints.CheckpointValidator
 import datadog.trace.instrumentation.netty41.client.NettyHttpClientDecorator
 import io.vertx.circuitbreaker.CircuitBreakerOptions
 import io.vertx.core.VertxOptions
@@ -42,11 +40,6 @@ class VertxRxCircuitBreakerWebClientForkedTest extends HttpClientTest {
   new CircuitBreakerOptions()
   .setTimeout(-1) // Disable the timeout otherwise it makes each test take this long.
   )
-
-  @Override
-  def setup() {
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(CheckpointValidationMode.INTERVALS)
-  }
 
   @Override
   int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {

--- a/dd-java-agent/instrumentation/vertx-rx-3.5/src/test/groovy/client/VertxRxWebClientForkedTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-rx-3.5/src/test/groovy/client/VertxRxWebClientForkedTest.groovy
@@ -1,8 +1,6 @@
 package client
 
 import datadog.trace.agent.test.base.HttpClientTest
-import datadog.trace.agent.test.checkpoints.CheckpointValidationMode
-import datadog.trace.agent.test.checkpoints.CheckpointValidator
 import datadog.trace.instrumentation.netty41.client.NettyHttpClientDecorator
 import io.vertx.core.VertxOptions
 import io.vertx.core.http.HttpMethod
@@ -31,11 +29,6 @@ class VertxRxWebClientForkedTest extends HttpClientTest {
   @AutoCleanup
   @Shared
   WebClient client = WebClient.create(vertx, clientOptions)
-
-  @Override
-  def setup() {
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(CheckpointValidationMode.INTERVALS)
-  }
 
   @Override
   int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {

--- a/dd-java-agent/instrumentation/vertx-rx-3.5/src/test/groovy/server/VertxRxCircuitBreakerHttpServerForkedTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-rx-3.5/src/test/groovy/server/VertxRxCircuitBreakerHttpServerForkedTest.groovy
@@ -1,8 +1,6 @@
 package server
 
 import datadog.trace.agent.test.base.HttpServerTest
-import datadog.trace.agent.test.checkpoints.CheckpointValidator
-import datadog.trace.agent.test.checkpoints.CheckpointValidationMode
 import io.vertx.circuitbreaker.CircuitBreakerOptions
 import io.vertx.core.Future
 import io.vertx.reactivex.circuitbreaker.CircuitBreaker
@@ -170,11 +168,5 @@ class VertxRxCircuitBreakerHttpServerForkedTest extends VertxHttpServerForkedTes
         .requestHandler { router.accept(it) }
         .listen(port) { startFuture.complete() }
     }
-  }
-
-  @Override
-  def setup() {
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.THREAD_SEQUENCE)
   }
 }


### PR DESCRIPTION
The other vertx related changes apparently fixed the checkpoint sequences in vertx-rx integration as well.
Removing the exclusions from the tests.