### PR TITLE
Add option to turn off generation of the random runtime-id

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/config/GeneralConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/GeneralConfig.java
@@ -30,6 +30,7 @@ public final class GeneralConfig {
   public static final String DOGSTATSD_PORT = "dogstatsd.port";
 
   public static final String RUNTIME_METRICS_ENABLED = "runtime.metrics.enabled";
+  public static final String RUNTIME_ID_ENABLED = "runtime-id.enabled";
 
   public static final String HEALTH_METRICS_ENABLED = "trace.health.metrics.enabled";
   public static final String HEALTH_METRICS_STATSD_HOST = "trace.health.metrics.statsd.host";

--- a/internal-api/src/test/groovy/datadog/trace/api/ConfigForkedTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/ConfigForkedTest.groovy
@@ -1,0 +1,20 @@
+package datadog.trace.api
+
+import spock.lang.Specification
+
+import static datadog.trace.api.config.GeneralConfig.RUNTIME_ID_ENABLED
+
+class ConfigForkedTest extends Specification {
+
+  static final String PREFIX = "dd."
+
+  def "test random runtime id generation can be turned off"(){
+    setup:
+    System.setProperty(PREFIX + RUNTIME_ID_ENABLED, "false")
+
+    when:
+    def config = new Config()
+    then:
+    config.runtimeId == ""
+  }
+}

--- a/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -1656,7 +1656,7 @@ class ConfigTest extends DDSpecification {
       properties.setProperty(TRACE_AGENT_PORT, propertyPort)
     }
 
-    def childConfig = new Config(Config.get().runtimeId, ConfigProvider.withPropertiesOverride(properties))
+    def childConfig = new Config(ConfigProvider.withPropertiesOverride(properties))
 
     then:
     childConfig.isAgentConfiguredUsingDefault() == childConfiguredUsingDefault


### PR DESCRIPTION
System property:
```
-Ddd.runtime-id.enabled=false
```

Environment variable:
```
DD_RUNTIME_ID_ENABLED=false
```

This can be used for very short-lived instances or situations where metrics are captured by an external process which doesn't have access to the runtime-id. (Longer term we may decide to publish the random runtime-id via JMX so that external processes can pick it up.)