### PR TITLE
Add fall-back when producer wasn't created via standard `Session.createProducer` API

### DIFF
--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageProducerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageProducerInstrumentation.java
@@ -80,26 +80,42 @@ public final class JMSMessageProducerInstrumentation extends Instrumenter.Tracin
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static AgentScope beforeSend(
         @Advice.Argument(0) final Message message, @Advice.This final MessageProducer producer) {
-      MessageProducerState producerState =
-          InstrumentationContext.get(MessageProducer.class, MessageProducerState.class)
-              .get(producer);
-      if (null == producerState) {
-        return null;
-      }
-
       final int callDepth = CallDepthThreadLocalMap.incrementCallDepth(MessageProducer.class);
       if (callDepth > 0) {
         return null;
       }
 
+      MessageProducerState producerState =
+          InstrumentationContext.get(MessageProducer.class, MessageProducerState.class)
+              .get(producer);
+
+      CharSequence resourceName;
+
+      if (null != producerState) {
+        resourceName = producerState.getResourceName();
+      } else {
+        try {
+          // fall-back when producer wasn't created via standard Session.createProducer API
+          Destination destination = producer.getDestination();
+          boolean isQueue = PRODUCER_DECORATE.isQueue(destination);
+          String destinationName = PRODUCER_DECORATE.getDestinationName(destination);
+          resourceName = PRODUCER_DECORATE.toResourceName(destinationName, isQueue);
+        } catch (Exception ignored) {
+          resourceName = "Unknown Destination";
+        }
+      }
+
       final AgentSpan span = startSpan(JMS_PRODUCE);
       PRODUCER_DECORATE.afterStart(span);
-      PRODUCER_DECORATE.onProduce(span, producerState.getResourceName());
-      if (Config.get().isJMSPropagationEnabled() && !producerState.isPropagationDisabled()) {
+      PRODUCER_DECORATE.onProduce(span, resourceName);
+      if (Config.get().isJMSPropagationEnabled()
+          && (null == producerState || !producerState.isPropagationDisabled())) {
         propagate().inject(span, message, SETTER);
       }
       if (!Config.get().isJmsLegacyTracingEnabled()) {
-        SETTER.injectTimeInQueue(message, producerState);
+        if (null != producerState) {
+          SETTER.injectTimeInQueue(message, producerState);
+        }
       }
       return activateSpan(span);
     }


### PR DESCRIPTION
This helps with a corner-case found when tracing the pro version of WebLogic JMS - Producer instances that hadn't been created via the standard `Session.createProducer` API were being used to send messages (as otherwise we would have created a `ProducerState` capturing the session state along with other static details when the producer was created from the session.)

When we detect this has happened we fall back to creating the resource name from the producer's destination (JMS destination resource names are cached in the decorator, so this is not too expensive a fall-back.)