### PR TITLE
Remove checkpoint sequence validation exclusions

### DIFF
--- a/dd-java-agent/instrumentation/lettuce-4/src/test/groovy/Lettuce4AsyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/lettuce-4/src/test/groovy/Lettuce4AsyncClientTest.groovy
@@ -9,8 +9,6 @@ import com.lambdaworks.redis.api.sync.RedisCommands
 import com.lambdaworks.redis.codec.Utf8StringCodec
 import com.lambdaworks.redis.protocol.AsyncCommand
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.checkpoints.CheckpointValidator
-import datadog.trace.agent.test.checkpoints.CheckpointValidationMode
 import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
@@ -102,10 +100,6 @@ class Lettuce4AsyncClientTest extends AgentTestRunner {
 
   def "connect using get on ConnectionFuture"() {
     setup:
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.THREAD_SEQUENCE)
-
     RedisClient testConnectionClient = RedisClient.create(embeddedDbUri)
     testConnectionClient.setOptions(CLIENT_OPTIONS)
 
@@ -143,10 +137,6 @@ class Lettuce4AsyncClientTest extends AgentTestRunner {
 
   def "connect exception inside the connection future"() {
     setup:
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.THREAD_SEQUENCE)
-
     RedisClient testConnectionClient = RedisClient.create(dbUriNonExistent)
     testConnectionClient.setOptions(CLIENT_OPTIONS)
 
@@ -183,10 +173,6 @@ class Lettuce4AsyncClientTest extends AgentTestRunner {
 
   def "set command using Future get with timeout"() {
     setup:
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.THREAD_SEQUENCE)
-
     RedisFuture<String> redisFuture = asyncCommands.set("TESTSETKEY", "TESTSETVAL")
     String res = redisFuture.get(3, TimeUnit.SECONDS)
 
@@ -214,10 +200,6 @@ class Lettuce4AsyncClientTest extends AgentTestRunner {
 
   def "get command chained with thenAccept"() {
     setup:
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.THREAD_SEQUENCE)
-
     def conds = new AsyncConditions()
     Consumer<String> consumer = new Consumer<String>() {
         @Override
@@ -258,10 +240,6 @@ class Lettuce4AsyncClientTest extends AgentTestRunner {
   // recording metrics
   def "get non existent key command with handleAsync and chained with thenApply"() {
     setup:
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.THREAD_SEQUENCE)
-
     def conds = new AsyncConditions()
     final String successStr = "KEY MISSING"
     BiFunction<String, Throwable, String> firstStage = new BiFunction<String, Throwable, String>() {
@@ -312,10 +290,6 @@ class Lettuce4AsyncClientTest extends AgentTestRunner {
 
   def "command with no arguments using a biconsumer"() {
     setup:
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.THREAD_SEQUENCE)
-
     def conds = new AsyncConditions()
     BiConsumer<String, Throwable> biConsumer = new BiConsumer<String, Throwable>() {
         @Override
@@ -354,10 +328,6 @@ class Lettuce4AsyncClientTest extends AgentTestRunner {
 
   def "hash set and then nest apply to hash getall"() {
     setup:
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.THREAD_SEQUENCE)
-
     def conds = new AsyncConditions()
 
     when:
@@ -431,10 +401,6 @@ class Lettuce4AsyncClientTest extends AgentTestRunner {
 
   def "command completes exceptionally"() {
     setup:
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.THREAD_SEQUENCE)
-
     // turn off auto flush to complete the command exceptionally manually
     asyncCommands.setAutoFlushCommands(false)
     def conds = new AsyncConditions()
@@ -481,10 +447,6 @@ class Lettuce4AsyncClientTest extends AgentTestRunner {
 
   def "cancel command before it finishes"() {
     setup:
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.THREAD_SEQUENCE)
-
     asyncCommands.setAutoFlushCommands(false)
     def conds = new AsyncConditions()
     RedisFuture redisFuture = asyncCommands.sadd("SKEY", "1", "2")
@@ -525,10 +487,6 @@ class Lettuce4AsyncClientTest extends AgentTestRunner {
 
   def "debug segfault command (returns void) with no argument should produce span"() {
     setup:
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.THREAD_SEQUENCE)
-
     asyncCommands.debugSegfault()
 
     expect:
@@ -555,10 +513,6 @@ class Lettuce4AsyncClientTest extends AgentTestRunner {
 
   def "shutdown command (returns void) should produce a span"() {
     setup:
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.THREAD_SEQUENCE)
-
     asyncCommands.shutdown(false)
 
     expect:

--- a/dd-java-agent/instrumentation/lettuce-4/src/test/groovy/Lettuce4SyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/lettuce-4/src/test/groovy/Lettuce4SyncClientTest.groovy
@@ -4,8 +4,6 @@ import com.lambdaworks.redis.RedisConnectionException
 import com.lambdaworks.redis.api.StatefulConnection
 import com.lambdaworks.redis.api.sync.RedisCommands
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.checkpoints.CheckpointValidator
-import datadog.trace.agent.test.checkpoints.CheckpointValidationMode
 import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
@@ -85,10 +83,6 @@ class Lettuce4SyncClientTest extends AgentTestRunner {
 
   def "connect"() {
     setup:
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.THREAD_SEQUENCE)
-
     RedisClient testConnectionClient = RedisClient.create(embeddedDbUri)
     testConnectionClient.setOptions(CLIENT_OPTIONS)
 
@@ -124,10 +118,6 @@ class Lettuce4SyncClientTest extends AgentTestRunner {
 
   def "connect exception"() {
     setup:
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.THREAD_SEQUENCE)
-
     RedisClient testConnectionClient = RedisClient.create(dbUriNonExistent)
     testConnectionClient.setOptions(CLIENT_OPTIONS)
 
@@ -162,10 +152,6 @@ class Lettuce4SyncClientTest extends AgentTestRunner {
 
   def "set command"() {
     setup:
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.THREAD_SEQUENCE)
-
     String res = syncCommands.set("TESTSETKEY", "TESTSETVAL")
 
     expect:
@@ -192,10 +178,6 @@ class Lettuce4SyncClientTest extends AgentTestRunner {
 
   def "get command"() {
     setup:
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.THREAD_SEQUENCE)
-
     String res = syncCommands.get("TESTKEY")
 
     expect:
@@ -222,10 +204,6 @@ class Lettuce4SyncClientTest extends AgentTestRunner {
 
   def "get non existent key command"() {
     setup:
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.THREAD_SEQUENCE)
-
     String res = syncCommands.get("NON_EXISTENT_KEY")
 
     expect:
@@ -252,10 +230,6 @@ class Lettuce4SyncClientTest extends AgentTestRunner {
 
   def "command with no arguments"() {
     setup:
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.THREAD_SEQUENCE)
-
     def keyRetrieved = syncCommands.randomkey()
 
     expect:
@@ -282,10 +256,6 @@ class Lettuce4SyncClientTest extends AgentTestRunner {
 
   def "list command"() {
     setup:
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.THREAD_SEQUENCE)
-
     long res = syncCommands.lpush("TESTLIST", "TESTLIST ELEMENT")
 
     expect:
@@ -312,10 +282,6 @@ class Lettuce4SyncClientTest extends AgentTestRunner {
 
   def "hash set command"() {
     setup:
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.THREAD_SEQUENCE)
-
     def res = syncCommands.hmset("user", testHashMap)
 
     expect:
@@ -342,10 +308,6 @@ class Lettuce4SyncClientTest extends AgentTestRunner {
 
   def "hash getall command"() {
     setup:
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.THREAD_SEQUENCE)
-
     Map<String, String> res = syncCommands.hgetall("TESTHM")
 
     expect:
@@ -372,10 +334,6 @@ class Lettuce4SyncClientTest extends AgentTestRunner {
 
   def "debug segfault command (returns void) with no argument should produce span"() {
     setup:
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.THREAD_SEQUENCE)
-
     syncCommands.debugSegfault()
 
     expect:
@@ -401,10 +359,6 @@ class Lettuce4SyncClientTest extends AgentTestRunner {
 
   def "shutdown command (returns void) should produce a span"() {
     setup:
-    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(
-      CheckpointValidationMode.INTERVALS,
-      CheckpointValidationMode.THREAD_SEQUENCE)
-
     syncCommands.shutdown(false)
 
     expect:


### PR DESCRIPTION
This one is a trivial removal of the checkpoint sequence validation excludes as the tests are all passing here.