### PR TITLE
[CIAPP] Normalize branch value from Git info supplied by user

### DIFF
--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/ci/CIProviderInfo.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/ci/CIProviderInfo.java
@@ -89,8 +89,21 @@ public abstract class CIProviderInfo {
 
   private GitInfo buildCIUserSuppliedGitInfo() {
     final String gitRepositoryUrl = System.getenv(DD_GIT_REPOSITORY_URL);
-    final String gitBranch = System.getenv(DD_GIT_BRANCH);
-    final String gitTag = System.getenv(DD_GIT_TAG);
+
+    // The user can set the DD_GIT_BRANCH manually but
+    // using the value returned by the CI Provider, so
+    // we need to normalize the value. Also, it can contain
+    // the tag (e.g. origin/tags/0.1.0)
+    String gitTag = System.getenv(DD_GIT_TAG);
+    String gitBranch = null;
+    final String rawGitBranchOrTag = System.getenv(DD_GIT_BRANCH);
+    if (rawGitBranchOrTag != null) {
+      if (!rawGitBranchOrTag.contains("tags")) {
+        gitBranch = normalizeRef(rawGitBranchOrTag);
+      } else if (gitTag == null) {
+        gitTag = normalizeRef(rawGitBranchOrTag);
+      }
+    }
     final String gitCommitSha = System.getenv(DD_GIT_COMMIT_SHA);
     final String gitCommitMessage = System.getenv(DD_GIT_COMMIT_MESSAGE);
     final String gitCommitAuthorName = System.getenv(DD_GIT_COMMIT_AUTHOR_NAME);

--- a/internal-api/src/test/resources/ci/usersupplied.json
+++ b/internal-api/src/test/resources/ci/usersupplied.json
@@ -27,6 +27,110 @@
   ],
   [
     {
+      "DD_GIT_BRANCH": "origin/usersupplied-branch",
+      "DD_GIT_COMMIT_AUTHOR_DATE": "usersupplied-authordate",
+      "DD_GIT_COMMIT_AUTHOR_EMAIL": "usersupplied-authoremail",
+      "DD_GIT_COMMIT_AUTHOR_NAME": "usersupplied-authorname",
+      "DD_GIT_COMMIT_COMMITTER_DATE": "usersupplied-comitterdate",
+      "DD_GIT_COMMIT_COMMITTER_EMAIL": "usersupplied-comitteremail",
+      "DD_GIT_COMMIT_COMMITTER_NAME": "usersupplied-comittername",
+      "DD_GIT_COMMIT_MESSAGE": "usersupplied-message",
+      "DD_GIT_COMMIT_SHA": "usersupplied-commit",
+      "DD_GIT_REPOSITORY_URL": "usersupplied-repo"
+    },
+    {
+      "git.branch": "usersupplied-branch",
+      "git.commit.author.date": "usersupplied-authordate",
+      "git.commit.author.email": "usersupplied-authoremail",
+      "git.commit.author.name": "usersupplied-authorname",
+      "git.commit.committer.date": "usersupplied-comitterdate",
+      "git.commit.committer.email": "usersupplied-comitteremail",
+      "git.commit.committer.name": "usersupplied-comittername",
+      "git.commit.message": "usersupplied-message",
+      "git.commit.sha": "usersupplied-commit",
+      "git.repository_url": "usersupplied-repo"
+    }
+  ],
+  [
+    {
+      "DD_GIT_BRANCH": "refs/heads/usersupplied-branch",
+      "DD_GIT_COMMIT_AUTHOR_DATE": "usersupplied-authordate",
+      "DD_GIT_COMMIT_AUTHOR_EMAIL": "usersupplied-authoremail",
+      "DD_GIT_COMMIT_AUTHOR_NAME": "usersupplied-authorname",
+      "DD_GIT_COMMIT_COMMITTER_DATE": "usersupplied-comitterdate",
+      "DD_GIT_COMMIT_COMMITTER_EMAIL": "usersupplied-comitteremail",
+      "DD_GIT_COMMIT_COMMITTER_NAME": "usersupplied-comittername",
+      "DD_GIT_COMMIT_MESSAGE": "usersupplied-message",
+      "DD_GIT_COMMIT_SHA": "usersupplied-commit",
+      "DD_GIT_REPOSITORY_URL": "usersupplied-repo"
+    },
+    {
+      "git.branch": "usersupplied-branch",
+      "git.commit.author.date": "usersupplied-authordate",
+      "git.commit.author.email": "usersupplied-authoremail",
+      "git.commit.author.name": "usersupplied-authorname",
+      "git.commit.committer.date": "usersupplied-comitterdate",
+      "git.commit.committer.email": "usersupplied-comitteremail",
+      "git.commit.committer.name": "usersupplied-comittername",
+      "git.commit.message": "usersupplied-message",
+      "git.commit.sha": "usersupplied-commit",
+      "git.repository_url": "usersupplied-repo"
+    }
+  ],
+  [
+    {
+      "DD_GIT_BRANCH": "origin/tags/0.1.0",
+      "DD_GIT_COMMIT_AUTHOR_DATE": "usersupplied-authordate",
+      "DD_GIT_COMMIT_AUTHOR_EMAIL": "usersupplied-authoremail",
+      "DD_GIT_COMMIT_AUTHOR_NAME": "usersupplied-authorname",
+      "DD_GIT_COMMIT_COMMITTER_DATE": "usersupplied-comitterdate",
+      "DD_GIT_COMMIT_COMMITTER_EMAIL": "usersupplied-comitteremail",
+      "DD_GIT_COMMIT_COMMITTER_NAME": "usersupplied-comittername",
+      "DD_GIT_COMMIT_MESSAGE": "usersupplied-message",
+      "DD_GIT_COMMIT_SHA": "usersupplied-commit",
+      "DD_GIT_REPOSITORY_URL": "usersupplied-repo"
+    },
+    {
+      "git.commit.author.date": "usersupplied-authordate",
+      "git.commit.author.email": "usersupplied-authoremail",
+      "git.commit.author.name": "usersupplied-authorname",
+      "git.commit.committer.date": "usersupplied-comitterdate",
+      "git.commit.committer.email": "usersupplied-comitteremail",
+      "git.commit.committer.name": "usersupplied-comittername",
+      "git.commit.message": "usersupplied-message",
+      "git.commit.sha": "usersupplied-commit",
+      "git.repository_url": "usersupplied-repo",
+      "git.tag": "0.1.0"
+    }
+  ],
+  [
+    {
+      "DD_GIT_BRANCH": "refs/heads/tags/0.1.0",
+      "DD_GIT_COMMIT_AUTHOR_DATE": "usersupplied-authordate",
+      "DD_GIT_COMMIT_AUTHOR_EMAIL": "usersupplied-authoremail",
+      "DD_GIT_COMMIT_AUTHOR_NAME": "usersupplied-authorname",
+      "DD_GIT_COMMIT_COMMITTER_DATE": "usersupplied-comitterdate",
+      "DD_GIT_COMMIT_COMMITTER_EMAIL": "usersupplied-comitteremail",
+      "DD_GIT_COMMIT_COMMITTER_NAME": "usersupplied-comittername",
+      "DD_GIT_COMMIT_MESSAGE": "usersupplied-message",
+      "DD_GIT_COMMIT_SHA": "usersupplied-commit",
+      "DD_GIT_REPOSITORY_URL": "usersupplied-repo"
+    },
+    {
+      "git.commit.author.date": "usersupplied-authordate",
+      "git.commit.author.email": "usersupplied-authoremail",
+      "git.commit.author.name": "usersupplied-authorname",
+      "git.commit.committer.date": "usersupplied-comitterdate",
+      "git.commit.committer.email": "usersupplied-comitteremail",
+      "git.commit.committer.name": "usersupplied-comittername",
+      "git.commit.message": "usersupplied-message",
+      "git.commit.sha": "usersupplied-commit",
+      "git.repository_url": "usersupplied-repo",
+      "git.tag": "0.1.0"
+    }
+  ],
+  [
+    {
       "DD_GIT_COMMIT_AUTHOR_DATE": "usersupplied-authordate",
       "DD_GIT_COMMIT_AUTHOR_EMAIL": "usersupplied-authoremail",
       "DD_GIT_COMMIT_AUTHOR_NAME": "usersupplied-authorname",


### PR DESCRIPTION
This PR normalizes the value of the `DD_GIT_BRANCH` environment variable.
The user can set the `DD_GIT_BRANCH` manually but using the value returned by the CI Provider, so we need to normalize the value. Also, it can contain the tag (e.g. `origin/tags/0.1.0`)