### PR TITLE
Make EndpointEvent durational to ease debugging any slack issues

### DIFF
--- a/dd-java-agent/instrumentation/akka-http-10.0/src/baseTest/groovy/AkkaHttpServerInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/baseTest/groovy/AkkaHttpServerInstrumentationTest.groovy
@@ -85,7 +85,8 @@ abstract class AkkaHttpServerInstrumentationTest extends HttpServerTest<AkkaHttp
     _ * TEST_CHECKPOINTER.checkpoint(_, THREAD_MIGRATION)
     _ * TEST_CHECKPOINTER.checkpoint(_, THREAD_MIGRATION | END)
     _ * TEST_CHECKPOINTER.checkpoint(_, CPU | END)
-    _ * TEST_CHECKPOINTER.onRootSpan(_, _, _)
+    _ * TEST_CHECKPOINTER.onRootSpanWritten(_, _, _)
+    _ * TEST_CHECKPOINTER.onRootSpanStarted(_)
     0 * TEST_CHECKPOINTER._
   }
 }

--- a/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/test/groovy/CheckpointEmissionTest.groovy
+++ b/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/test/groovy/CheckpointEmissionTest.groovy
@@ -56,7 +56,8 @@ class CheckpointEmissionTest extends AgentTestRunner {
     2 * TEST_CHECKPOINTER.checkpoint(_, THREAD_MIGRATION)
     2 * TEST_CHECKPOINTER.checkpoint(_, THREAD_MIGRATION | END)
     3 * TEST_CHECKPOINTER.checkpoint(_, SPAN | END)
-    _ * TEST_CHECKPOINTER.onRootSpan(_, _, _)
+    _ * TEST_CHECKPOINTER.onRootSpanWritten(_, _, _)
+    _ * TEST_CHECKPOINTER.onRootSpanStarted(_)
     0 * _
   }
 
@@ -74,7 +75,8 @@ class CheckpointEmissionTest extends AgentTestRunner {
     2 * TEST_CHECKPOINTER.checkpoint(_, THREAD_MIGRATION)
     2 * TEST_CHECKPOINTER.checkpoint(_, THREAD_MIGRATION | END)
     4 * TEST_CHECKPOINTER.checkpoint(_, SPAN | END)
-    _ * TEST_CHECKPOINTER.onRootSpan(_, _, _)
+    _ * TEST_CHECKPOINTER.onRootSpanWritten(_, _, _)
+    _ * TEST_CHECKPOINTER.onRootSpanStarted(_)
     0 * _
   }
 

--- a/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/test/groovy/Aws2ClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/test/groovy/Aws2ClientTest.groovy
@@ -159,7 +159,8 @@ class Aws2ClientTest extends AgentTestRunner {
     2 * TEST_CHECKPOINTER.checkpoint(_, SPAN | END)
     1 * TEST_CHECKPOINTER.checkpoint(_, THREAD_MIGRATION)
     1 * TEST_CHECKPOINTER.checkpoint(_, THREAD_MIGRATION | END)
-    _ * TEST_CHECKPOINTER.onRootSpan(_, _, _)
+    _ * TEST_CHECKPOINTER.onRootSpanWritten(_, _, _)
+    _ * TEST_CHECKPOINTER.onRootSpanStarted(_)
     0 * TEST_CHECKPOINTER._
 
     where:
@@ -297,7 +298,8 @@ class Aws2ClientTest extends AgentTestRunner {
     2 * TEST_CHECKPOINTER.checkpoint(_, SPAN | END)
     2 * TEST_CHECKPOINTER.checkpoint(_, THREAD_MIGRATION)
     2 * TEST_CHECKPOINTER.checkpoint(_, THREAD_MIGRATION | END)
-    _ * TEST_CHECKPOINTER.onRootSpan(_, _,_)
+    _ * TEST_CHECKPOINTER.onRootSpanWritten(_, _,_)
+    _ * TEST_CHECKPOINTER.onRootSpanStarted(_)
     0 * TEST_CHECKPOINTER._
 
     where:

--- a/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcTest.groovy
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcTest.groovy
@@ -146,7 +146,8 @@ class GrpcTest extends AgentTestRunner {
     _ * TEST_CHECKPOINTER.checkpoint(_, THREAD_MIGRATION)
     _ * TEST_CHECKPOINTER.checkpoint(_, THREAD_MIGRATION | END)
     _ * TEST_CHECKPOINTER.checkpoint(_, CPU | END)
-    _ * TEST_CHECKPOINTER.onRootSpan(_, _, _)
+    _ * TEST_CHECKPOINTER.onRootSpanStarted(_)
+    _ * TEST_CHECKPOINTER.onRootSpanWritten(_, _, _)
     0 * TEST_CHECKPOINTER._
 
     cleanup:
@@ -256,7 +257,8 @@ class GrpcTest extends AgentTestRunner {
     _ * TEST_CHECKPOINTER.checkpoint(_, THREAD_MIGRATION)
     _ * TEST_CHECKPOINTER.checkpoint(_, THREAD_MIGRATION | END)
     _ * TEST_CHECKPOINTER.checkpoint(_, CPU | END)
-    _ * TEST_CHECKPOINTER.onRootSpan(_, _, _)
+    _ * TEST_CHECKPOINTER.onRootSpanStarted(_)
+    _ * TEST_CHECKPOINTER.onRootSpanWritten(_, _, _)
     0 * TEST_CHECKPOINTER._
 
     cleanup:
@@ -353,7 +355,8 @@ class GrpcTest extends AgentTestRunner {
     _ * TEST_CHECKPOINTER.checkpoint(_, THREAD_MIGRATION)
     _ * TEST_CHECKPOINTER.checkpoint(_, THREAD_MIGRATION | END)
     _ * TEST_CHECKPOINTER.checkpoint(_, CPU | END)
-    _ * TEST_CHECKPOINTER.onRootSpan(_, _, _)
+    _ * TEST_CHECKPOINTER.onRootSpanStarted(_)
+    _ * TEST_CHECKPOINTER.onRootSpanWritten(_, _, _)
     0 * TEST_CHECKPOINTER._
 
     cleanup:

--- a/dd-java-agent/instrumentation/jdbc/src/test/groovy/RemoteJDBCInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/jdbc/src/test/groovy/RemoteJDBCInstrumentationTest.groovy
@@ -218,7 +218,8 @@ class RemoteJDBCInstrumentationTest extends AgentTestRunner {
     }
     2 * TEST_CHECKPOINTER.checkpoint(_, SPAN)
     2 * TEST_CHECKPOINTER.checkpoint(_, SPAN | END)
-    _ * TEST_CHECKPOINTER.onRootSpan(_, _, _)
+    _ * TEST_CHECKPOINTER.onRootSpanWritten(_, _, _)
+    _ * TEST_CHECKPOINTER.onRootSpanStarted(_)
     0 * _
 
     cleanup:
@@ -282,7 +283,8 @@ class RemoteJDBCInstrumentationTest extends AgentTestRunner {
     }
     2 * TEST_CHECKPOINTER.checkpoint(_, SPAN)
     2 * TEST_CHECKPOINTER.checkpoint(_, SPAN | END)
-    _ * TEST_CHECKPOINTER.onRootSpan(_, _, _)
+    _ * TEST_CHECKPOINTER.onRootSpanWritten(_, _, _)
+    _ * TEST_CHECKPOINTER.onRootSpanStarted(_)
     0 * _
 
     cleanup:
@@ -344,7 +346,8 @@ class RemoteJDBCInstrumentationTest extends AgentTestRunner {
     }
     2 * TEST_CHECKPOINTER.checkpoint(_, SPAN)
     2 * TEST_CHECKPOINTER.checkpoint(_, SPAN | END)
-    _ * TEST_CHECKPOINTER.onRootSpan(_, _, _)
+    _ * TEST_CHECKPOINTER.onRootSpanWritten(_, _, _)
+    _ * TEST_CHECKPOINTER.onRootSpanStarted(_)
     0 * _
 
     cleanup:
@@ -406,7 +409,8 @@ class RemoteJDBCInstrumentationTest extends AgentTestRunner {
     }
     2 * TEST_CHECKPOINTER.checkpoint(_, SPAN)
     2 * TEST_CHECKPOINTER.checkpoint(_, SPAN | END)
-    _ * TEST_CHECKPOINTER.onRootSpan(_, _, _)
+    _ * TEST_CHECKPOINTER.onRootSpanWritten(_, _, _)
+    _ * TEST_CHECKPOINTER.onRootSpanStarted(_)
     0 * _
 
     cleanup:
@@ -468,7 +472,8 @@ class RemoteJDBCInstrumentationTest extends AgentTestRunner {
     }
     2 * TEST_CHECKPOINTER.checkpoint(_, SPAN)
     2 * TEST_CHECKPOINTER.checkpoint(_, SPAN | END)
-    _ * TEST_CHECKPOINTER.onRootSpan(_, _, _)
+    _ * TEST_CHECKPOINTER.onRootSpanWritten(_, _, _)
+    _ * TEST_CHECKPOINTER.onRootSpanStarted(_)
     0 * _
 
     cleanup:

--- a/dd-java-agent/instrumentation/mongo/driver-3.10-sync-test/src/test/groovy/MongoSyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-3.10-sync-test/src/test/groovy/MongoSyncClientTest.groovy
@@ -50,7 +50,8 @@ class MongoSyncClientTest extends MongoBaseTest {
     and: "synchronous checkpoints span the driver activity"
     1 * TEST_CHECKPOINTER.checkpoint(_, SPAN)
     1 * TEST_CHECKPOINTER.checkpoint(_, SPAN | END)
-    _ * TEST_CHECKPOINTER.onRootSpan(_, _, _)
+    _ * TEST_CHECKPOINTER.onRootSpanStarted(_)
+    _ * TEST_CHECKPOINTER.onRootSpanWritten(_, _, _)
     0 * TEST_CHECKPOINTER._
 
     where:
@@ -93,7 +94,8 @@ class MongoSyncClientTest extends MongoBaseTest {
     and: "synchronous checkpoints span the driver activity"
     1 * TEST_CHECKPOINTER.checkpoint(_, SPAN)
     1 * TEST_CHECKPOINTER.checkpoint(_, SPAN | END)
-    _ * TEST_CHECKPOINTER.onRootSpan(_, _, _)
+    _ * TEST_CHECKPOINTER.onRootSpanStarted(_)
+    _ * TEST_CHECKPOINTER.onRootSpanWritten(_, _, _)
     0 * TEST_CHECKPOINTER._
 
     where:
@@ -128,7 +130,8 @@ class MongoSyncClientTest extends MongoBaseTest {
     and: "syncronous checkpoints span the driver activity"
     2 * TEST_CHECKPOINTER.checkpoint(_, SPAN)
     2 * TEST_CHECKPOINTER.checkpoint(_, SPAN | END)
-    _ * TEST_CHECKPOINTER.onRootSpan(_, _, _)
+    _ * TEST_CHECKPOINTER.onRootSpanStarted(_)
+    _ * TEST_CHECKPOINTER.onRootSpanWritten(_, _, _)
     0 * TEST_CHECKPOINTER._
 
     where:
@@ -168,7 +171,8 @@ class MongoSyncClientTest extends MongoBaseTest {
     and: "syncronous checkpoints span the driver activity"
     2 * TEST_CHECKPOINTER.checkpoint(_, SPAN)
     2 * TEST_CHECKPOINTER.checkpoint(_, SPAN | END)
-    _ * TEST_CHECKPOINTER.onRootSpan(_, _, _)
+    _ * TEST_CHECKPOINTER.onRootSpanStarted(_)
+    _ * TEST_CHECKPOINTER.onRootSpanWritten(_, _, _)
     0 * TEST_CHECKPOINTER._
 
     where:
@@ -206,7 +210,8 @@ class MongoSyncClientTest extends MongoBaseTest {
     and: "syncronous checkpoints span the driver activity"
     2 * TEST_CHECKPOINTER.checkpoint(_, SPAN)
     2 * TEST_CHECKPOINTER.checkpoint(_, SPAN | END)
-    _ * TEST_CHECKPOINTER.onRootSpan(_, _, _)
+    _ * TEST_CHECKPOINTER.onRootSpanStarted(_)
+    _ * TEST_CHECKPOINTER.onRootSpanWritten(_, _, _)
     0 * TEST_CHECKPOINTER._
 
     where:

--- a/dd-java-agent/instrumentation/mongo/driver-3.7-core-test/src/test/groovy/MongoCore37ClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-3.7-core-test/src/test/groovy/MongoCore37ClientTest.groovy
@@ -50,7 +50,8 @@ class MongoCore37ClientTest extends MongoBaseTest {
     and: "synchronous checkpoints span the driver activity"
     1 * TEST_CHECKPOINTER.checkpoint(_, SPAN)
     1 * TEST_CHECKPOINTER.checkpoint(_, SPAN | END)
-    _ * TEST_CHECKPOINTER.onRootSpan(_, _, _)
+    _ * TEST_CHECKPOINTER.onRootSpanWritten(_, _, _)
+    _ * TEST_CHECKPOINTER.onRootSpanStarted(_)
     0 * TEST_CHECKPOINTER._
 
     where:
@@ -93,7 +94,8 @@ class MongoCore37ClientTest extends MongoBaseTest {
     and: "synchronous checkpoints span the driver activity"
     1 * TEST_CHECKPOINTER.checkpoint(_, SPAN)
     1 * TEST_CHECKPOINTER.checkpoint(_, SPAN | END)
-    _ * TEST_CHECKPOINTER.onRootSpan(_, _, _)
+    _ * TEST_CHECKPOINTER.onRootSpanWritten(_, _, _)
+    _ * TEST_CHECKPOINTER.onRootSpanStarted(_)
     0 * TEST_CHECKPOINTER._
 
     where:
@@ -128,7 +130,8 @@ class MongoCore37ClientTest extends MongoBaseTest {
     and: "synchronous checkpoints span the driver activity"
     2 * TEST_CHECKPOINTER.checkpoint(_, SPAN)
     2 * TEST_CHECKPOINTER.checkpoint(_, SPAN | END)
-    _ * TEST_CHECKPOINTER.onRootSpan(_, _, _)
+    _ * TEST_CHECKPOINTER.onRootSpanWritten(_, _, _)
+    _ * TEST_CHECKPOINTER.onRootSpanStarted(_)
     0 * TEST_CHECKPOINTER._
 
     where:
@@ -168,7 +171,8 @@ class MongoCore37ClientTest extends MongoBaseTest {
     and: "synchronous checkpoints span the driver activity"
     2 * TEST_CHECKPOINTER.checkpoint(_, SPAN)
     2 * TEST_CHECKPOINTER.checkpoint(_, SPAN | END)
-    _ * TEST_CHECKPOINTER.onRootSpan(_, _, _)
+    _ * TEST_CHECKPOINTER.onRootSpanWritten(_, _, _)
+    _ * TEST_CHECKPOINTER.onRootSpanStarted(_)
     0 * TEST_CHECKPOINTER._
 
     where:
@@ -206,7 +210,8 @@ class MongoCore37ClientTest extends MongoBaseTest {
     and: "synchronous checkpoints span the driver activity"
     2 * TEST_CHECKPOINTER.checkpoint(_, SPAN)
     2 * TEST_CHECKPOINTER.checkpoint(_, SPAN | END)
-    _ * TEST_CHECKPOINTER.onRootSpan(_, _, _)
+    _ * TEST_CHECKPOINTER.onRootSpanWritten(_, _, _)
+    _ * TEST_CHECKPOINTER.onRootSpanStarted(_)
     0 * TEST_CHECKPOINTER._
 
     where:

--- a/dd-java-agent/instrumentation/mongo/driver-4.0-test/src/test/groovy/Mongo4ClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-4.0-test/src/test/groovy/Mongo4ClientTest.groovy
@@ -50,7 +50,8 @@ class Mongo4ClientTest extends MongoBaseTest {
     and: "synchronous checkpoints span the driver activity"
     1 * TEST_CHECKPOINTER.checkpoint(_, SPAN)
     1 * TEST_CHECKPOINTER.checkpoint(_, SPAN | END)
-    _ * TEST_CHECKPOINTER.onRootSpan(_, _, _)
+    _ * TEST_CHECKPOINTER.onRootSpanWritten(_, _, _)
+    _ * TEST_CHECKPOINTER.onRootSpanStarted(_)
     0 * TEST_CHECKPOINTER._
 
     where:
@@ -93,7 +94,8 @@ class Mongo4ClientTest extends MongoBaseTest {
     and: "synchronous checkpoints span the driver activity"
     1 * TEST_CHECKPOINTER.checkpoint(_, SPAN)
     1 * TEST_CHECKPOINTER.checkpoint(_, SPAN | END)
-    _ * TEST_CHECKPOINTER.onRootSpan(_, _, _)
+    _ * TEST_CHECKPOINTER.onRootSpanWritten(_, _, _)
+    _ * TEST_CHECKPOINTER.onRootSpanStarted(_)
     0 * TEST_CHECKPOINTER._
 
     where:
@@ -128,7 +130,8 @@ class Mongo4ClientTest extends MongoBaseTest {
     and: "syncronous checkpoints span the driver activity"
     2 * TEST_CHECKPOINTER.checkpoint(_, SPAN)
     2 * TEST_CHECKPOINTER.checkpoint(_, SPAN | END)
-    _ * TEST_CHECKPOINTER.onRootSpan(_, _, _)
+    _ * TEST_CHECKPOINTER.onRootSpanWritten(_, _, _)
+    _ * TEST_CHECKPOINTER.onRootSpanStarted(_)
     0 * TEST_CHECKPOINTER._
 
     where:
@@ -168,7 +171,8 @@ class Mongo4ClientTest extends MongoBaseTest {
     and: "syncronous checkpoints span the driver activity"
     2 * TEST_CHECKPOINTER.checkpoint(_, SPAN)
     2 * TEST_CHECKPOINTER.checkpoint(_, SPAN | END)
-    _ * TEST_CHECKPOINTER.onRootSpan(_, _, _)
+    _ * TEST_CHECKPOINTER.onRootSpanWritten(_, _, _)
+    _ * TEST_CHECKPOINTER.onRootSpanStarted(_)
     0 * TEST_CHECKPOINTER._
 
     where:
@@ -206,7 +210,8 @@ class Mongo4ClientTest extends MongoBaseTest {
     and: "syncronous checkpoints span the driver activity"
     2 * TEST_CHECKPOINTER.checkpoint(_, SPAN)
     2 * TEST_CHECKPOINTER.checkpoint(_, SPAN | END)
-    _ * TEST_CHECKPOINTER.onRootSpan(_, _, _)
+    _ * TEST_CHECKPOINTER.onRootSpanWritten(_, _, _)
+    _ * TEST_CHECKPOINTER.onRootSpanStarted(_)
     0 * TEST_CHECKPOINTER._
 
     where:

--- a/dd-java-agent/instrumentation/netty-4.1/src/test/groovy/NettyClientCheckpointsTest.groovy
+++ b/dd-java-agent/instrumentation/netty-4.1/src/test/groovy/NettyClientCheckpointsTest.groovy
@@ -54,7 +54,8 @@ class NettyClientCheckpointsTest extends AgentTestRunner {
     (2.._) * TEST_CHECKPOINTER.checkpoint(_, THREAD_MIGRATION | END)
     (2.._) * TEST_CHECKPOINTER.checkpoint(_, CPU | END)
     3 * TEST_CHECKPOINTER.checkpoint(_, SPAN | END)
-    _ * TEST_CHECKPOINTER.onRootSpan(_, _, _)
+    _ * TEST_CHECKPOINTER.onRootSpanWritten(_, _, _)
+    _ * TEST_CHECKPOINTER.onRootSpanStarted(_)
     0 * _
   }
 
@@ -73,7 +74,8 @@ class NettyClientCheckpointsTest extends AgentTestRunner {
     (2.._) * TEST_CHECKPOINTER.checkpoint(_, THREAD_MIGRATION | END)
     (2.._) * TEST_CHECKPOINTER.checkpoint(_, CPU | END)
     4 * TEST_CHECKPOINTER.checkpoint(_, SPAN | END)
-    _ * TEST_CHECKPOINTER.onRootSpan(_, _, _)
+    _ * TEST_CHECKPOINTER.onRootSpanWritten(_, _, _)
+    _ * TEST_CHECKPOINTER.onRootSpanStarted(_)
     0 * _
   }
 

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/checkpoints/TimelineCheckpointer.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/checkpoints/TimelineCheckpointer.groovy
@@ -28,7 +28,7 @@ class TimelineCheckpointer implements Checkpointer {
   }
 
   @Override
-  void onRootSpanWritten(AgentSpan rootSpan, boolean traceSampled, boolean checkpointsSampled) {
+  void onRootSpanWritten(AgentSpan rootSpan, boolean published, boolean checkpointsSampled) {
   }
 
   @Override

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/checkpoints/TimelineCheckpointer.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/checkpoints/TimelineCheckpointer.groovy
@@ -28,8 +28,11 @@ class TimelineCheckpointer implements Checkpointer {
   }
 
   @Override
-  void onRootSpan(AgentSpan rootSpan, boolean published, boolean checkpointsSampled) {
+  void onRootSpanWritten(AgentSpan rootSpan, boolean traceSampled, boolean checkpointsSampled) {
   }
+
+  @Override
+  void onRootSpanStarted(AgentSpan rootSpan) {}
 
   void throwOnInvalidSequence(Collection<DDId> trackedSpanIds) {
     String charset = StandardCharsets.UTF_8.name()

--- a/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/EndpointEvent.java
+++ b/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/EndpointEvent.java
@@ -32,8 +32,11 @@ public class EndpointEvent extends Event implements EndpointTracker {
   @Label("Trace Sampled")
   private boolean traceSampled = false;
 
-  @Label("Trace Eligible for Dropping")
-  private boolean eligibleForDropping;
+  @Label("Trace Eligible for Dropping (start)")
+  private final boolean eligibleForDropping1;
+
+  @Label("Trace Eligible for Dropping (end)")
+  private boolean eligibleForDropping2;
 
   @Label("Checkpoints Sampled")
   private boolean checkpointsSampled = false;
@@ -41,6 +44,7 @@ public class EndpointEvent extends Event implements EndpointTracker {
   public EndpointEvent(final DDSpan span) {
     this.traceId = span.getTraceId().toLong();
     this.localRootSpanId = span.getSpanId().toLong();
+    this.eligibleForDropping1 = span.eligibleForDropping();
     begin();
   }
 
@@ -49,7 +53,7 @@ public class EndpointEvent extends Event implements EndpointTracker {
     if (shouldCommit()) {
       end();
       this.endpoint = span.getResourceName().toString();
-      this.eligibleForDropping = span.eligibleForDropping();
+      this.eligibleForDropping2 = span.eligibleForDropping();
       this.traceSampled = traceSampled;
       this.checkpointsSampled = checkpointsSampled;
       commit();

--- a/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/EndpointEvent.java
+++ b/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/EndpointEvent.java
@@ -32,12 +32,15 @@ public class EndpointEvent extends Event implements EndpointTracker {
   @Label("Trace Sampled")
   private boolean traceSampled = false;
 
+  @Label("Trace Eligible for Dropping")
+  private boolean eligibleForDropping;
+
   @Label("Checkpoints Sampled")
   private boolean checkpointsSampled = false;
 
-  public EndpointEvent(final long traceId, final long localRootSpanId) {
-    this.traceId = traceId;
-    this.localRootSpanId = localRootSpanId;
+  public EndpointEvent(final DDSpan span) {
+    this.traceId = span.getTraceId().toLong();
+    this.localRootSpanId = span.getSpanId().toLong();
     begin();
   }
 
@@ -46,6 +49,7 @@ public class EndpointEvent extends Event implements EndpointTracker {
     if (shouldCommit()) {
       end();
       this.endpoint = span.getResourceName().toString();
+      this.eligibleForDropping = span.eligibleForDropping();
       this.traceSampled = traceSampled;
       this.checkpointsSampled = checkpointsSampled;
       commit();

--- a/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/EndpointEvent.java
+++ b/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/EndpointEvent.java
@@ -32,11 +32,11 @@ public class EndpointEvent extends Event implements EndpointTracker {
   @Label("Trace Sampled")
   private boolean traceSampled = false;
 
-  @Label("Trace Eligible for Dropping (start)")
-  private final boolean eligibleForDropping1;
+  @Label("Trace Sampling Priority (start)")
+  private final int samplingPriorityStart;
 
-  @Label("Trace Eligible for Dropping (end)")
-  private boolean eligibleForDropping2;
+  @Label("Trace Sampling Priority (end)")
+  private int samplingPriorityEnd;
 
   @Label("Checkpoints Sampled")
   private boolean checkpointsSampled = false;
@@ -44,7 +44,7 @@ public class EndpointEvent extends Event implements EndpointTracker {
   public EndpointEvent(final DDSpan span) {
     this.traceId = span.getTraceId().toLong();
     this.localRootSpanId = span.getSpanId().toLong();
-    this.eligibleForDropping1 = span.eligibleForDropping();
+    this.samplingPriorityStart = span.samplingPriority();
     begin();
   }
 
@@ -53,7 +53,7 @@ public class EndpointEvent extends Event implements EndpointTracker {
     if (shouldCommit()) {
       end();
       this.endpoint = span.getResourceName().toString();
-      this.eligibleForDropping2 = span.eligibleForDropping();
+      this.samplingPriorityEnd = span.samplingPriority();
       this.traceSampled = traceSampled;
       this.checkpointsSampled = checkpointsSampled;
       commit();

--- a/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/JFRCheckpointer.java
+++ b/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/JFRCheckpointer.java
@@ -197,8 +197,7 @@ public class JFRCheckpointer implements Checkpointer {
     if (isEndpointCollectionEnabled) {
       if (rootSpan instanceof DDSpan) {
         DDSpan span = (DDSpan) rootSpan;
-        span.setEndpointTracker(
-            new EndpointEvent(rootSpan.getTraceId().toLong(), rootSpan.getSpanId().toLong()));
+        span.setEndpointTracker(new EndpointEvent(span));
       }
     }
   }

--- a/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/JFRCheckpointer.java
+++ b/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/JFRCheckpointer.java
@@ -180,12 +180,13 @@ public class JFRCheckpointer implements Checkpointer {
 
   @Override
   public final void onRootSpanWritten(
-      final AgentSpan rootSpan, final boolean traceSampled, final boolean checkpointsSampled) {
+      final AgentSpan rootSpan, final boolean published, final boolean checkpointsSampled) {
     if (isEndpointCollectionEnabled) {
       if (rootSpan instanceof DDSpan) {
         DDSpan span = (DDSpan) rootSpan;
         EndpointTracker tracker = span.getEndpointTracker();
         if (tracker != null) {
+          boolean traceSampled = published && !span.eligibleForDropping();
           tracker.endpointWritten(span, traceSampled, checkpointsSampled);
         }
       }

--- a/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/JFRCheckpointer.java
+++ b/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/JFRCheckpointer.java
@@ -8,6 +8,7 @@ import datadog.trace.api.sampling.Sampler;
 import datadog.trace.bootstrap.config.provider.ConfigProvider;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.core.DDSpan;
+import datadog.trace.core.EndpointTracker;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.Objects;
@@ -178,25 +179,26 @@ public class JFRCheckpointer implements Checkpointer {
   }
 
   @Override
-  public final void onRootSpan(
-      final AgentSpan rootSpan, final boolean published, final boolean checkpointsSampled) {
+  public final void onRootSpanWritten(
+      final AgentSpan rootSpan, final boolean traceSampled, final boolean checkpointsSampled) {
     if (isEndpointCollectionEnabled) {
       if (rootSpan instanceof DDSpan) {
         DDSpan span = (DDSpan) rootSpan;
-        /*
-        Here we need to track the sampling status of the trace.
-        Simply using the 'published' flag is not enough as a trace may be published even though
-        it is supposed to be dropped. Thus we need to check both the `published` flag and
-        the eligibility to be dropped.
-         */
-        boolean traceSampled = published && !span.eligibleForDropping();
-        new EndpointEvent(
-                rootSpan.getResourceName().toString(),
-                rootSpan.getTraceId().toLong(),
-                rootSpan.getSpanId().toLong(),
-                traceSampled,
-                checkpointsSampled)
-            .commit();
+        EndpointTracker tracker = span.getEndpointTracker();
+        if (tracker != null) {
+          tracker.endpointWritten(span, traceSampled, checkpointsSampled);
+        }
+      }
+    }
+  }
+
+  @Override
+  public void onRootSpanStarted(AgentSpan rootSpan) {
+    if (isEndpointCollectionEnabled) {
+      if (rootSpan instanceof DDSpan) {
+        DDSpan span = (DDSpan) rootSpan;
+        span.setEndpointTracker(
+            new EndpointEvent(rootSpan.getTraceId().toLong(), rootSpan.getSpanId().toLong()));
       }
     }
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -183,8 +183,13 @@ public class CoreTracer implements AgentTracer.TracerAPI {
   }
 
   @Override
-  public void onRootSpan(AgentSpan root, boolean published) {
-    checkpointer.onRootSpan(root, published);
+  public void onRootSpanFinished(AgentSpan root, boolean published) {
+    checkpointer.onRootSpanFinished(root, published);
+  }
+
+  @Override
+  public void onRootSpanStarted(AgentSpan root) {
+    checkpointer.onRootSpanStarted(root);
   }
 
   public static class CoreTracerBuilder {
@@ -520,7 +525,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
 
   @Override
   public CoreSpanBuilder buildSpan(final CharSequence operationName) {
-    return new CoreSpanBuilder(operationName);
+    return new CoreSpanBuilder(operationName, this);
   }
 
   @Override
@@ -702,7 +707,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
         writer.incrementDropCounts(writtenTrace.size());
       }
       if (null != rootSpan) {
-        onRootSpan(rootSpan, published);
+        onRootSpanFinished(rootSpan, published);
       }
     }
   }
@@ -828,6 +833,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
   /** Spans are built using this builder */
   public class CoreSpanBuilder implements AgentTracer.SpanBuilder {
     private final CharSequence operationName;
+    private final CoreTracer tracer;
 
     // Builder attributes
     private Map<String, Object> tags;
@@ -840,8 +846,9 @@ public class CoreTracer implements AgentTracer.TracerAPI {
     private boolean ignoreScope = false;
     private boolean emitCheckpoints = true;
 
-    public CoreSpanBuilder(final CharSequence operationName) {
+    CoreSpanBuilder(final CharSequence operationName, CoreTracer tracer) {
       this.operationName = operationName;
+      this.tracer = tracer;
     }
 
     @Override
@@ -851,7 +858,11 @@ public class CoreTracer implements AgentTracer.TracerAPI {
     }
 
     private DDSpan buildSpan() {
-      return DDSpan.create(timestampMicro, buildSpanContext(), emitCheckpoints);
+      DDSpan span = DDSpan.create(timestampMicro, buildSpanContext(), emitCheckpoints);
+      if (span.isLocalRootSpan()) {
+        tracer.onRootSpanStarted(span);
+      }
+      return span;
     }
 
     @Override

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -75,6 +76,8 @@ public class DDSpan implements AgentSpan, CoreSpan<DDSpan> {
   volatile Boolean emittingCheckpoints = null;
 
   private final boolean withCheckpoints;
+
+  private volatile EndpointTracker endpointTracker;
 
   /**
    * Spans should be constructed using the builder, not by calling the constructor directly.
@@ -241,6 +244,15 @@ public class DDSpan implements AgentSpan, CoreSpan<DDSpan> {
   @Override
   public DDSpan getLocalRootSpan() {
     return context.getTrace().getRootSpan();
+  }
+
+  /**
+   * Checks whether the span is also the local root span
+   *
+   * @return {@literal true} if this span is the same as {@linkplain #getLocalRootSpan()}
+   */
+  public boolean isLocalRootSpan() {
+    return getLocalRootSpan().equals(this);
   }
 
   @Override
@@ -623,6 +635,43 @@ public class DDSpan implements AgentSpan, CoreSpan<DDSpan> {
   @Override
   public boolean isTopLevel() {
     return context.isTopLevel();
+  }
+
+  /**
+   * Retrieve the {@linkplain EndpointTracker} instance associated with the corresponding local root
+   * span
+   *
+   * @return an {@linkplain EndpointTracker} instance or {@literal null}
+   */
+  @Nullable
+  public EndpointTracker getEndpointTracker() {
+    DDSpan localRootSpan = getLocalRootSpan();
+    if (localRootSpan == null) {
+      return null;
+    }
+    if (this.equals(localRootSpan)) {
+      return endpointTracker;
+    }
+    return localRootSpan.endpointTracker;
+  }
+
+  /**
+   * Attach an end-point tracker to the corresponding local root span. When this method is called
+   * multiple times the last invocation will 'win'
+   *
+   * @param endpointTracker the end-point tracker instance
+   */
+  public void setEndpointTracker(@Nonnull EndpointTracker endpointTracker) {
+    DDSpan localRootSpan = getLocalRootSpan();
+    if (localRootSpan == null) {
+      log.warn("Span {} has no associated local root span", this);
+      return;
+    }
+    if (this.equals(localRootSpan)) {
+      this.endpointTracker = endpointTracker;
+    } else {
+      localRootSpan.endpointTracker = endpointTracker;
+    }
   }
 
   public Map<String, String> getBaggage() {

--- a/dd-trace-core/src/main/java/datadog/trace/core/EndpointTracker.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/EndpointTracker.java
@@ -1,0 +1,14 @@
+package datadog.trace.core;
+
+/** A simple listener-like interface for tracking the end-point writes */
+public interface EndpointTracker {
+  /**
+   * Called when a local root span (associated with an end-point) is written
+   *
+   * @param span the local root span
+   * @param traceSampled {@literal true} if the containing trace is to be kept (sampled)
+   * @param checkpointsSampled {@literal true} if the checkpoints for the local root span and its
+   *     subtree were kept (sampled)
+   */
+  void endpointWritten(DDSpan span, boolean traceSampled, boolean checkpointsSampled);
+}

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerTest.groovy
@@ -464,6 +464,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     2 * checkpointer.checkpoint(_, SPAN) // two spans started by test
     1 * checkpointer.checkpoint(_, SPAN | END) // span ended by test
     1 * statsDClient.incrementCounter("scope.close.error")
+    1 * checkpointer.onRootSpanStarted(_)
     0 * _
 
     when:
@@ -472,7 +473,7 @@ class ScopeManagerTest extends DDCoreSpecification {
 
     then:
     1 * checkpointer.checkpoint(_, SPAN | END) // span ended by test
-    1 * checkpointer.onRootSpan(_, _, _)
+    1 * checkpointer.onRootSpanWritten(_, _, _)
     assertEvents([ACTIVATE, ACTIVATE, CLOSE, CLOSE])
     0 * _
 
@@ -499,6 +500,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     tracer.activeScope() == firstScope
     assertEvents([ACTIVATE])
     1 * checkpointer.checkpoint(_, SPAN) // span started by test
+    1 * checkpointer.onRootSpanStarted(_)
     0 * _
 
     when:

--- a/internal-api/src/main/java/datadog/trace/api/Checkpointer.java
+++ b/internal-api/src/main/java/datadog/trace/api/Checkpointer.java
@@ -36,7 +36,15 @@ public interface Checkpointer {
    * Callback to be called when a root span is written (together with the trace)
    *
    * @param rootSpan the local root span of the trace
-   * @param published {@literal true} the trace and root span published
+   * @param traceSampled {@literal true} the trace and root span published
+   * @param checkpointsSampled {@literal true} the checkpoints were sampled
    */
-  void onRootSpan(AgentSpan rootSpan, boolean published, boolean checkpointsSampled);
+  void onRootSpanWritten(AgentSpan rootSpan, boolean published, boolean checkpointsSampled);
+
+  /**
+   * Callback to be called when a root span is started
+   *
+   * @param rootSpan the local root span of the trace
+   */
+  void onRootSpanStarted(AgentSpan rootSpan);
 }

--- a/internal-api/src/main/java/datadog/trace/api/Checkpointer.java
+++ b/internal-api/src/main/java/datadog/trace/api/Checkpointer.java
@@ -36,7 +36,7 @@ public interface Checkpointer {
    * Callback to be called when a root span is written (together with the trace)
    *
    * @param rootSpan the local root span of the trace
-   * @param traceSampled {@literal true} the trace and root span published
+   * @param published {@literal true} the trace and root span published
    * @param checkpointsSampled {@literal true} the checkpoints were sampled
    */
   void onRootSpanWritten(AgentSpan rootSpan, boolean published, boolean checkpointsSampled);

--- a/internal-api/src/main/java/datadog/trace/api/SamplingCheckpointer.java
+++ b/internal-api/src/main/java/datadog/trace/api/SamplingCheckpointer.java
@@ -84,10 +84,15 @@ public final class SamplingCheckpointer implements SpanCheckpointer {
   }
 
   @Override
-  public void onRootSpan(final AgentSpan rootSpan, final boolean published) {
+  public void onRootSpanFinished(final AgentSpan rootSpan, final boolean published) {
     final Boolean emittingCheckpoints = rootSpan.isEmittingCheckpoints();
-    checkpointer.onRootSpan(
+    checkpointer.onRootSpanWritten(
         rootSpan, published, emittingCheckpoints != null && emittingCheckpoints);
+  }
+
+  @Override
+  public void onRootSpanStarted(AgentSpan root) {
+    checkpointer.onRootSpanStarted(root);
   }
 
   private static final class NoOpCheckpointer implements Checkpointer {
@@ -98,7 +103,10 @@ public final class SamplingCheckpointer implements SpanCheckpointer {
     public void checkpoint(final AgentSpan span, final int flags) {}
 
     @Override
-    public void onRootSpan(
-        final AgentSpan rootSpan, final boolean published, final boolean checkpointsSampled) {}
+    public void onRootSpanWritten(
+        final AgentSpan rootSpan, final boolean traceSampled, final boolean checkpointsSampled) {}
+
+    @Override
+    public void onRootSpanStarted(AgentSpan rootSpan) {}
   }
 }

--- a/internal-api/src/main/java/datadog/trace/api/SamplingCheckpointer.java
+++ b/internal-api/src/main/java/datadog/trace/api/SamplingCheckpointer.java
@@ -104,7 +104,7 @@ public final class SamplingCheckpointer implements SpanCheckpointer {
 
     @Override
     public void onRootSpanWritten(
-        final AgentSpan rootSpan, final boolean traceSampled, final boolean checkpointsSampled) {}
+        final AgentSpan rootSpan, final boolean published, final boolean checkpointsSampled) {}
 
     @Override
     public void onRootSpanStarted(AgentSpan rootSpan) {}

--- a/internal-api/src/main/java/datadog/trace/api/SpanCheckpointer.java
+++ b/internal-api/src/main/java/datadog/trace/api/SpanCheckpointer.java
@@ -17,5 +17,7 @@ public interface SpanCheckpointer {
 
   void onFinish(AgentSpan span);
 
-  void onRootSpan(AgentSpan root, boolean published);
+  void onRootSpanStarted(AgentSpan root);
+
+  void onRootSpanFinished(AgentSpan root, boolean published);
 }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -324,7 +324,10 @@ public class AgentTracer {
     public void onFinish(AgentSpan span) {}
 
     @Override
-    public void onRootSpan(AgentSpan root, boolean published) {}
+    public void onRootSpanFinished(AgentSpan root, boolean published) {}
+
+    @Override
+    public void onRootSpanStarted(AgentSpan root) {}
 
     @Override
     public InstrumentationGateway instrumentationGateway() {

--- a/internal-api/src/test/groovy/datadog/trace/api/SamplingCheckpointerTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/SamplingCheckpointerTest.groovy
@@ -76,14 +76,19 @@ class SamplingCheckpointerTest extends DDSpecification {
     0 * _
 
     when:
-    sut.onRootSpan(rootSpan, true)
+    sut.onRootSpanStarted(rootSpan)
     then:
-    rootSpanCount * checkpointer.onRootSpan(rootSpan, true, emitCheckpoints)
+    rootSpanCount * checkpointer.onRootSpanStarted(rootSpan)
 
     when:
-    sut.onRootSpan(rootSpan, false)
+    sut.onRootSpanFinished(rootSpan, true)
     then:
-    rootSpanCount * checkpointer.onRootSpan(rootSpan, false, emitCheckpoints)
+    rootSpanCount * checkpointer.onRootSpanWritten(rootSpan, true, emitCheckpoints)
+
+    when:
+    sut.onRootSpanFinished(rootSpan, false)
+    then:
+    rootSpanCount * checkpointer.onRootSpanWritten(rootSpan, false, emitCheckpoints)
 
     where:
     drop  | register | emitCheckpoints


### PR DESCRIPTION
We seem to be having a problem with a slack between the checkpoints generated for a certain local root span and the corresponding `EndpointEvent` - the checkpoints _may_ all get written into a recording preceding the one containing the `EndpointEvent` for that particular local root span. 

In order to ease debugging and allow us to confirm or reject this assumption this PR is modifying the `EndpointEvent` to capture the start and end time as well as the time it took to handle that endpoint.

Most of the changes are in the checkpoint tests where it is necessary to match a new call `onRootSpanStarted()` when a local root span is created/started. 
The rest is rather straightforward and the only 'controversial' thing may be adding a new volatile field to `DDSpan` - if there is a better way to achieve this functionality I would gladly make the change, so please let me know.