### PR TITLE
Add database client by host split by instance type suffix

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/DatabaseClientDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/DatabaseClientDecorator.java
@@ -41,7 +41,10 @@ public abstract class DatabaseClientDecorator<CONNECTION> extends ClientDecorato
       span.setTag(Tags.DB_INSTANCE, instanceName);
 
       if (instanceName != null && Config.get().isDbClientSplitByInstance()) {
-        span.setServiceName(Config.get().getDbClientSplitByInstancePrefix() + instanceName);
+        span.setServiceName(
+            Config.get().isDbClientSplitByInstanceTypeSuffix()
+                ? instanceName + "_" + dbType()
+                : instanceName);
       }
 
       CharSequence hostName = dbHostname(connection);

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/DatabaseClientDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/DatabaseClientDecorator.java
@@ -43,7 +43,7 @@ public abstract class DatabaseClientDecorator<CONNECTION> extends ClientDecorato
       if (instanceName != null && Config.get().isDbClientSplitByInstance()) {
         span.setServiceName(
             Config.get().isDbClientSplitByInstanceTypeSuffix()
-                ? instanceName + "_" + dbType()
+                ? instanceName + "-" + dbType()
                 : instanceName);
       }
 

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/DatabaseClientDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/DatabaseClientDecorator.java
@@ -41,7 +41,7 @@ public abstract class DatabaseClientDecorator<CONNECTION> extends ClientDecorato
       span.setTag(Tags.DB_INSTANCE, instanceName);
 
       if (instanceName != null && Config.get().isDbClientSplitByInstance()) {
-        span.setServiceName(instanceName);
+        span.setServiceName(Config.get().getDbClientSplitByInstancePrefix() + instanceName);
       }
 
       CharSequence hostName = dbHostname(connection);

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -41,6 +41,7 @@ public final class ConfigDefaults {
   static final boolean DEFAULT_HTTP_CLIENT_TAG_QUERY_STRING = false;
   static final boolean DEFAULT_HTTP_CLIENT_SPLIT_BY_DOMAIN = false;
   static final boolean DEFAULT_DB_CLIENT_HOST_SPLIT_BY_INSTANCE = false;
+  static final String DEFAULT_DB_CLIENT_HOST_SPLIT_BY_INSTANCE_PREFIX = "";
   static final int DEFAULT_SCOPE_DEPTH_LIMIT = 100;
   static final int DEFAULT_PARTIAL_FLUSH_MIN_SPANS = 1000;
   static final boolean DEFAULT_PROPAGATION_EXTRACT_LOG_HEADER_NAMES_ENABLED = false;

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -41,7 +41,7 @@ public final class ConfigDefaults {
   static final boolean DEFAULT_HTTP_CLIENT_TAG_QUERY_STRING = false;
   static final boolean DEFAULT_HTTP_CLIENT_SPLIT_BY_DOMAIN = false;
   static final boolean DEFAULT_DB_CLIENT_HOST_SPLIT_BY_INSTANCE = false;
-  static final String DEFAULT_DB_CLIENT_HOST_SPLIT_BY_INSTANCE_PREFIX = "";
+  static final boolean DEFAULT_DB_CLIENT_HOST_SPLIT_BY_INSTANCE_TYPE_SUFFIX = false;
   static final int DEFAULT_SCOPE_DEPTH_LIMIT = 100;
   static final int DEFAULT_PARTIAL_FLUSH_MIN_SPANS = 1000;
   static final boolean DEFAULT_PROPAGATION_EXTRACT_LOG_HEADER_NAMES_ENABLED = false;

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
@@ -26,8 +26,8 @@ public final class TraceInstrumentationConfig {
   public static final String HTTP_CLIENT_TAG_QUERY_STRING = "http.client.tag.query-string";
   public static final String HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN = "trace.http.client.split-by-domain";
   public static final String DB_CLIENT_HOST_SPLIT_BY_INSTANCE = "trace.db.client.split-by-instance";
-  public static final String DB_CLIENT_HOST_SPLIT_BY_INSTANCE_PREFIX =
-      "trace.db.client.split-by-instance.prefix";
+  public static final String DB_CLIENT_HOST_SPLIT_BY_INSTANCE_TYPE_SUFFIX =
+      "trace.db.client.split-by-instance.type.suffix";
 
   public static final String JDBC_PREPARED_STATEMENT_CLASS_NAME =
       "trace.jdbc.prepared.statement.class.name";

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
@@ -26,6 +26,7 @@ public final class TraceInstrumentationConfig {
   public static final String HTTP_CLIENT_TAG_QUERY_STRING = "http.client.tag.query-string";
   public static final String HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN = "trace.http.client.split-by-domain";
   public static final String DB_CLIENT_HOST_SPLIT_BY_INSTANCE = "trace.db.client.split-by-instance";
+  public static final String DB_CLIENT_HOST_SPLIT_BY_INSTANCE_PREFIX = "trace.db.client.split-by-instance.prefix";
 
   public static final String JDBC_PREPARED_STATEMENT_CLASS_NAME =
       "trace.jdbc.prepared.statement.class.name";

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
@@ -26,7 +26,8 @@ public final class TraceInstrumentationConfig {
   public static final String HTTP_CLIENT_TAG_QUERY_STRING = "http.client.tag.query-string";
   public static final String HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN = "trace.http.client.split-by-domain";
   public static final String DB_CLIENT_HOST_SPLIT_BY_INSTANCE = "trace.db.client.split-by-instance";
-  public static final String DB_CLIENT_HOST_SPLIT_BY_INSTANCE_PREFIX = "trace.db.client.split-by-instance.prefix";
+  public static final String DB_CLIENT_HOST_SPLIT_BY_INSTANCE_PREFIX =
+      "trace.db.client.split-by-instance.prefix";
 
   public static final String JDBC_PREPARED_STATEMENT_CLASS_NAME =
       "trace.jdbc.prepared.statement.class.name";

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -9,7 +9,7 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_AWS_PROPAGATION_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_CWS_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_CWS_TLS_REFRESH;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_DB_CLIENT_HOST_SPLIT_BY_INSTANCE;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_DB_CLIENT_HOST_SPLIT_BY_INSTANCE_PREFIX;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_DB_CLIENT_HOST_SPLIT_BY_INSTANCE_TYPE_SUFFIX;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_DOGSTATSD_START_DELAY;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_HEALTH_METRICS_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_HTTP_CLIENT_ERROR_STATUSES;
@@ -140,7 +140,7 @@ import static datadog.trace.api.config.ProfilingConfig.PROFILING_UPLOAD_TIMEOUT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_URL;
 import static datadog.trace.api.config.TraceInstrumentationConfig.AWS_PROPAGATION_ENABLED;
 import static datadog.trace.api.config.TraceInstrumentationConfig.DB_CLIENT_HOST_SPLIT_BY_INSTANCE;
-import static datadog.trace.api.config.TraceInstrumentationConfig.DB_CLIENT_HOST_SPLIT_BY_INSTANCE_PREFIX;
+import static datadog.trace.api.config.TraceInstrumentationConfig.DB_CLIENT_HOST_SPLIT_BY_INSTANCE_TYPE_SUFFIX;
 import static datadog.trace.api.config.TraceInstrumentationConfig.GRPC_IGNORED_OUTBOUND_METHODS;
 import static datadog.trace.api.config.TraceInstrumentationConfig.GRPC_SERVER_TRIM_PACKAGE_RESOURCE;
 import static datadog.trace.api.config.TraceInstrumentationConfig.HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN;
@@ -322,7 +322,7 @@ public class Config {
   private final boolean httpClientTagQueryString;
   private final boolean httpClientSplitByDomain;
   private final boolean dbClientSplitByInstance;
-  private final String dbClientSplitByInstancePrefix;
+  private final boolean dbClientSplitByInstanceTypeSuffix;
   private final Set<String> splitByTags;
   private final int scopeDepthLimit;
   private final boolean scopeStrictMode;
@@ -642,10 +642,10 @@ public class Config {
         configProvider.getBoolean(
             DB_CLIENT_HOST_SPLIT_BY_INSTANCE, DEFAULT_DB_CLIENT_HOST_SPLIT_BY_INSTANCE);
 
-    dbClientSplitByInstancePrefix =
-        configProvider.getString(
-            DB_CLIENT_HOST_SPLIT_BY_INSTANCE_PREFIX,
-            DEFAULT_DB_CLIENT_HOST_SPLIT_BY_INSTANCE_PREFIX);
+    dbClientSplitByInstanceTypeSuffix =
+        configProvider.getBoolean(
+            DB_CLIENT_HOST_SPLIT_BY_INSTANCE_TYPE_SUFFIX,
+            DEFAULT_DB_CLIENT_HOST_SPLIT_BY_INSTANCE_TYPE_SUFFIX);
 
     splitByTags = tryMakeImmutableSet(configProvider.getList(SPLIT_BY_TAGS));
 
@@ -1051,8 +1051,8 @@ public class Config {
     return dbClientSplitByInstance;
   }
 
-  public String getDbClientSplitByInstancePrefix() {
-    return dbClientSplitByInstancePrefix;
+  public boolean isDbClientSplitByInstanceTypeSuffix() {
+    return dbClientSplitByInstanceTypeSuffix;
   }
 
   public Set<String> getSplitByTags() {
@@ -1968,8 +1968,8 @@ public class Config {
         + httpClientSplitByDomain
         + ", dbClientSplitByInstance="
         + dbClientSplitByInstance
-        + ", dbClientSplitByInstancePrefix="
-        + dbClientSplitByInstancePrefix
+        + ", dbClientSplitByInstanceTypeSuffix="
+        + dbClientSplitByInstanceTypeSuffix
         + ", splitByTags="
         + splitByTags
         + ", scopeDepthLimit="

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -644,7 +644,8 @@ public class Config {
 
     dbClientSplitByInstancePrefix =
         configProvider.getString(
-            DB_CLIENT_HOST_SPLIT_BY_INSTANCE_PREFIX, DEFAULT_DB_CLIENT_HOST_SPLIT_BY_INSTANCE_PREFIX);
+            DB_CLIENT_HOST_SPLIT_BY_INSTANCE_PREFIX,
+            DEFAULT_DB_CLIENT_HOST_SPLIT_BY_INSTANCE_PREFIX);
 
     splitByTags = tryMakeImmutableSet(configProvider.getList(SPLIT_BY_TAGS));
 

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -9,6 +9,7 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_AWS_PROPAGATION_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_CWS_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_CWS_TLS_REFRESH;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_DB_CLIENT_HOST_SPLIT_BY_INSTANCE;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_DB_CLIENT_HOST_SPLIT_BY_INSTANCE_PREFIX;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_DOGSTATSD_START_DELAY;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_HEALTH_METRICS_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_HTTP_CLIENT_ERROR_STATUSES;
@@ -139,6 +140,7 @@ import static datadog.trace.api.config.ProfilingConfig.PROFILING_UPLOAD_TIMEOUT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_URL;
 import static datadog.trace.api.config.TraceInstrumentationConfig.AWS_PROPAGATION_ENABLED;
 import static datadog.trace.api.config.TraceInstrumentationConfig.DB_CLIENT_HOST_SPLIT_BY_INSTANCE;
+import static datadog.trace.api.config.TraceInstrumentationConfig.DB_CLIENT_HOST_SPLIT_BY_INSTANCE_PREFIX;
 import static datadog.trace.api.config.TraceInstrumentationConfig.GRPC_IGNORED_OUTBOUND_METHODS;
 import static datadog.trace.api.config.TraceInstrumentationConfig.GRPC_SERVER_TRIM_PACKAGE_RESOURCE;
 import static datadog.trace.api.config.TraceInstrumentationConfig.HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN;
@@ -320,6 +322,7 @@ public class Config {
   private final boolean httpClientTagQueryString;
   private final boolean httpClientSplitByDomain;
   private final boolean dbClientSplitByInstance;
+  private final String dbClientSplitByInstancePrefix;
   private final Set<String> splitByTags;
   private final int scopeDepthLimit;
   private final boolean scopeStrictMode;
@@ -638,6 +641,10 @@ public class Config {
     dbClientSplitByInstance =
         configProvider.getBoolean(
             DB_CLIENT_HOST_SPLIT_BY_INSTANCE, DEFAULT_DB_CLIENT_HOST_SPLIT_BY_INSTANCE);
+
+    dbClientSplitByInstancePrefix =
+        configProvider.getString(
+            DB_CLIENT_HOST_SPLIT_BY_INSTANCE_PREFIX, DEFAULT_DB_CLIENT_HOST_SPLIT_BY_INSTANCE_PREFIX);
 
     splitByTags = tryMakeImmutableSet(configProvider.getList(SPLIT_BY_TAGS));
 
@@ -1041,6 +1048,10 @@ public class Config {
 
   public boolean isDbClientSplitByInstance() {
     return dbClientSplitByInstance;
+  }
+
+  public String getDbClientSplitByInstancePrefix() {
+    return dbClientSplitByInstancePrefix;
   }
 
   public Set<String> getSplitByTags() {
@@ -1956,6 +1967,8 @@ public class Config {
         + httpClientSplitByDomain
         + ", dbClientSplitByInstance="
         + dbClientSplitByInstance
+        + ", dbClientSplitByInstancePrefix="
+        + dbClientSplitByInstancePrefix
         + ", splitByTags="
         + splitByTags
         + ", scopeDepthLimit="

--- a/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -58,6 +58,7 @@ import static datadog.trace.api.config.ProfilingConfig.PROFILING_UPLOAD_PERIOD
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_UPLOAD_TIMEOUT
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_URL
 import static datadog.trace.api.config.TraceInstrumentationConfig.DB_CLIENT_HOST_SPLIT_BY_INSTANCE
+import static datadog.trace.api.config.TraceInstrumentationConfig.DB_CLIENT_HOST_SPLIT_BY_INSTANCE_PREFIX
 import static datadog.trace.api.config.TraceInstrumentationConfig.HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN
 import static datadog.trace.api.config.TraceInstrumentationConfig.RUNTIME_CONTEXT_FIELD_INJECTION
 import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_ENABLED
@@ -143,6 +144,7 @@ class ConfigTest extends DDSpecification {
     prop.setProperty(HTTP_CLIENT_ERROR_STATUSES, "111")
     prop.setProperty(HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN, "true")
     prop.setProperty(DB_CLIENT_HOST_SPLIT_BY_INSTANCE, "true")
+    prop.setProperty(DB_CLIENT_HOST_SPLIT_BY_INSTANCE_PREFIX, "db_")
     prop.setProperty(SPLIT_BY_TAGS, "some.tag1,some.tag2,some.tag1")
     prop.setProperty(PARTIAL_FLUSH_MIN_SPANS, "15")
     prop.setProperty(TRACE_REPORT_HOSTNAME, "true")
@@ -205,6 +207,7 @@ class ConfigTest extends DDSpecification {
     config.httpClientErrorStatuses == toBitSet((111..111))
     config.httpClientSplitByDomain == true
     config.dbClientSplitByInstance == true
+    config.dbClientSplitByInstancePrefix == "db_"
     config.splitByTags == ["some.tag1", "some.tag2"].toSet()
     config.partialFlushMinSpans == 15
     config.reportHostName == true
@@ -268,6 +271,7 @@ class ConfigTest extends DDSpecification {
     System.setProperty(PREFIX + HTTP_CLIENT_ERROR_STATUSES, "111")
     System.setProperty(PREFIX + HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN, "true")
     System.setProperty(PREFIX + DB_CLIENT_HOST_SPLIT_BY_INSTANCE, "true")
+    System.setProperty(PREFIX + DB_CLIENT_HOST_SPLIT_BY_INSTANCE_PREFIX, "db_")
     System.setProperty(PREFIX + SPLIT_BY_TAGS, "some.tag3, some.tag2, some.tag1")
     System.setProperty(PREFIX + PARTIAL_FLUSH_MIN_SPANS, "25")
     System.setProperty(PREFIX + TRACE_REPORT_HOSTNAME, "true")
@@ -329,6 +333,7 @@ class ConfigTest extends DDSpecification {
     config.httpClientErrorStatuses == toBitSet((111..111))
     config.httpClientSplitByDomain == true
     config.dbClientSplitByInstance == true
+    config.dbClientSplitByInstancePrefix == "db_"
     config.splitByTags == ["some.tag3", "some.tag2", "some.tag1"].toSet()
     config.partialFlushMinSpans == 25
     config.reportHostName == true
@@ -459,6 +464,7 @@ class ConfigTest extends DDSpecification {
     config.httpClientErrorStatuses == toBitSet((400..499))
     config.httpClientSplitByDomain == false
     config.dbClientSplitByInstance == false
+    config.dbClientSplitByInstancePrefix == ""
     config.splitByTags == [].toSet()
     config.propagationStylesToExtract.toList() == [PropagationStyle.DATADOG]
     config.propagationStylesToInject.toList() == [PropagationStyle.DATADOG]
@@ -530,6 +536,7 @@ class ConfigTest extends DDSpecification {
     properties.setProperty(HTTP_CLIENT_ERROR_STATUSES, "111")
     properties.setProperty(HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN, "true")
     properties.setProperty(DB_CLIENT_HOST_SPLIT_BY_INSTANCE, "true")
+    properties.setProperty(DB_CLIENT_HOST_SPLIT_BY_INSTANCE_PREFIX, "db_")
     properties.setProperty(PARTIAL_FLUSH_MIN_SPANS, "15")
     properties.setProperty(PROPAGATION_STYLE_EXTRACT, "B3 Datadog")
     properties.setProperty(PROPAGATION_STYLE_INJECT, "Datadog B3")
@@ -560,6 +567,7 @@ class ConfigTest extends DDSpecification {
     config.httpClientErrorStatuses == toBitSet((111..111))
     config.httpClientSplitByDomain == true
     config.dbClientSplitByInstance == true
+    config.dbClientSplitByInstancePrefix == "db_"
     config.splitByTags == [].toSet()
     config.partialFlushMinSpans == 15
     config.propagationStylesToExtract.toList() == [PropagationStyle.B3, PropagationStyle.DATADOG]

--- a/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -58,7 +58,7 @@ import static datadog.trace.api.config.ProfilingConfig.PROFILING_UPLOAD_PERIOD
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_UPLOAD_TIMEOUT
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_URL
 import static datadog.trace.api.config.TraceInstrumentationConfig.DB_CLIENT_HOST_SPLIT_BY_INSTANCE
-import static datadog.trace.api.config.TraceInstrumentationConfig.DB_CLIENT_HOST_SPLIT_BY_INSTANCE_PREFIX
+import static datadog.trace.api.config.TraceInstrumentationConfig.DB_CLIENT_HOST_SPLIT_BY_INSTANCE_TYPE_SUFFIX
 import static datadog.trace.api.config.TraceInstrumentationConfig.HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN
 import static datadog.trace.api.config.TraceInstrumentationConfig.RUNTIME_CONTEXT_FIELD_INJECTION
 import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_ENABLED
@@ -144,7 +144,7 @@ class ConfigTest extends DDSpecification {
     prop.setProperty(HTTP_CLIENT_ERROR_STATUSES, "111")
     prop.setProperty(HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN, "true")
     prop.setProperty(DB_CLIENT_HOST_SPLIT_BY_INSTANCE, "true")
-    prop.setProperty(DB_CLIENT_HOST_SPLIT_BY_INSTANCE_PREFIX, "db_")
+    prop.setProperty(DB_CLIENT_HOST_SPLIT_BY_INSTANCE_TYPE_SUFFIX, "true")
     prop.setProperty(SPLIT_BY_TAGS, "some.tag1,some.tag2,some.tag1")
     prop.setProperty(PARTIAL_FLUSH_MIN_SPANS, "15")
     prop.setProperty(TRACE_REPORT_HOSTNAME, "true")
@@ -207,7 +207,7 @@ class ConfigTest extends DDSpecification {
     config.httpClientErrorStatuses == toBitSet((111..111))
     config.httpClientSplitByDomain == true
     config.dbClientSplitByInstance == true
-    config.dbClientSplitByInstancePrefix == "db_"
+    config.dbClientSplitByInstanceTypeSuffix == true
     config.splitByTags == ["some.tag1", "some.tag2"].toSet()
     config.partialFlushMinSpans == 15
     config.reportHostName == true
@@ -271,7 +271,7 @@ class ConfigTest extends DDSpecification {
     System.setProperty(PREFIX + HTTP_CLIENT_ERROR_STATUSES, "111")
     System.setProperty(PREFIX + HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN, "true")
     System.setProperty(PREFIX + DB_CLIENT_HOST_SPLIT_BY_INSTANCE, "true")
-    System.setProperty(PREFIX + DB_CLIENT_HOST_SPLIT_BY_INSTANCE_PREFIX, "db_")
+    System.setProperty(PREFIX + DB_CLIENT_HOST_SPLIT_BY_INSTANCE_TYPE_SUFFIX, "true")
     System.setProperty(PREFIX + SPLIT_BY_TAGS, "some.tag3, some.tag2, some.tag1")
     System.setProperty(PREFIX + PARTIAL_FLUSH_MIN_SPANS, "25")
     System.setProperty(PREFIX + TRACE_REPORT_HOSTNAME, "true")
@@ -333,7 +333,7 @@ class ConfigTest extends DDSpecification {
     config.httpClientErrorStatuses == toBitSet((111..111))
     config.httpClientSplitByDomain == true
     config.dbClientSplitByInstance == true
-    config.dbClientSplitByInstancePrefix == "db_"
+    config.dbClientSplitByInstanceTypeSuffix == true
     config.splitByTags == ["some.tag3", "some.tag2", "some.tag1"].toSet()
     config.partialFlushMinSpans == 25
     config.reportHostName == true
@@ -464,7 +464,7 @@ class ConfigTest extends DDSpecification {
     config.httpClientErrorStatuses == toBitSet((400..499))
     config.httpClientSplitByDomain == false
     config.dbClientSplitByInstance == false
-    config.dbClientSplitByInstancePrefix == ""
+    config.dbClientSplitByInstanceTypeSuffix == false
     config.splitByTags == [].toSet()
     config.propagationStylesToExtract.toList() == [PropagationStyle.DATADOG]
     config.propagationStylesToInject.toList() == [PropagationStyle.DATADOG]
@@ -536,7 +536,7 @@ class ConfigTest extends DDSpecification {
     properties.setProperty(HTTP_CLIENT_ERROR_STATUSES, "111")
     properties.setProperty(HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN, "true")
     properties.setProperty(DB_CLIENT_HOST_SPLIT_BY_INSTANCE, "true")
-    properties.setProperty(DB_CLIENT_HOST_SPLIT_BY_INSTANCE_PREFIX, "db_")
+    properties.setProperty(DB_CLIENT_HOST_SPLIT_BY_INSTANCE_TYPE_SUFFIX, "true")
     properties.setProperty(PARTIAL_FLUSH_MIN_SPANS, "15")
     properties.setProperty(PROPAGATION_STYLE_EXTRACT, "B3 Datadog")
     properties.setProperty(PROPAGATION_STYLE_INJECT, "Datadog B3")
@@ -567,7 +567,7 @@ class ConfigTest extends DDSpecification {
     config.httpClientErrorStatuses == toBitSet((111..111))
     config.httpClientSplitByDomain == true
     config.dbClientSplitByInstance == true
-    config.dbClientSplitByInstancePrefix == "db_"
+    config.dbClientSplitByInstanceTypeSuffix == true
     config.splitByTags == [].toSet()
     config.partialFlushMinSpans == 15
     config.propagationStylesToExtract.toList() == [PropagationStyle.B3, PropagationStyle.DATADOG]


### PR DESCRIPTION
### Problem

#### Given: 
- `DB_CLIENT_HOST_SPLIT_BY_INSTANCE` is set to `true` and
-  The database name is the same as the service name (for example `jdbc:postgresql://db.example.com:5432/myservice` gives database name `myservice`)

#### Expected: 
Two services with the same name `myservice` but different types. one of type web and another of type db. 

#### Actual:
Found only one service with name `myservice` of type web (and no database service). All database traces are mapped to the web service. 

#### Proposed fix:
Introduce a new boolean variable `DB_CLIENT_HOST_SPLIT_BY_INSTANCE_TYPE_SUFFIX` to control adding the database type as a suffix to the database service name in case of `DB_CLIENT_HOST_SPLIT_BY_INSTANCE` sets to `true`. For instance `myservice-postgresql` 