### PR TITLE
Add the musl specific build of async profiler for the relevn

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-auxiliary-async/profiling-auxiliary-async.gradle
+++ b/dd-java-agent/agent-profiling/profiling-auxiliary-async/profiling-auxiliary-async.gradle
@@ -45,7 +45,7 @@ shadowJar {
     rslt |= it.path == "one" || it.path == "one/profiler" || it.path.startsWith("one/profiler/")
     rslt |= it.path == "META-INF" || it.path == "META-INF/services" || it.path.startsWith("META-INF/services/")
     // TODO: modify the filter to include other OS/arch combinations once the overhead is evaluated
-    rslt |= it.path == "native-libs" || it.path.startsWith("native-libs/linux-arm64")
+    rslt |= it.path == "native-libs" || it.path.startsWith("native-libs/linux-x64") || it.path.startsWith("native-libs/linux-musl-x64")
     rslt |= (it.path.contains("async-profiler") && it.path.endsWith(".jar"))
     return rslt
   }


### PR DESCRIPTION
The musl x64 async profiler build was left out previously to minimize the footprint but it seems to be required for the relenv deployments.