### PR TITLE
Distinguish between trace written and trace sampled

### DIFF
--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/checkpoints/TimelineCheckpointer.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/checkpoints/TimelineCheckpointer.groovy
@@ -28,7 +28,7 @@ class TimelineCheckpointer implements Checkpointer {
   }
 
   @Override
-  void onRootSpan(AgentSpan rootSpan, boolean traceSampled, boolean checkpointsSampled) {
+  void onRootSpan(AgentSpan rootSpan, boolean published, boolean checkpointsSampled) {
   }
 
   void throwOnInvalidSequence(Collection<DDId> trackedSpanIds) {

--- a/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/JFRCheckpointer.java
+++ b/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/JFRCheckpointer.java
@@ -7,6 +7,7 @@ import datadog.trace.api.sampling.ConstantSampler;
 import datadog.trace.api.sampling.Sampler;
 import datadog.trace.bootstrap.config.provider.ConfigProvider;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.core.DDSpan;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.Objects;
@@ -178,15 +179,25 @@ public class JFRCheckpointer implements Checkpointer {
 
   @Override
   public final void onRootSpan(
-      final AgentSpan rootSpan, final boolean traceSampled, final boolean checkpointsSampled) {
+      final AgentSpan rootSpan, final boolean published, final boolean checkpointsSampled) {
     if (isEndpointCollectionEnabled) {
-      new EndpointEvent(
-              rootSpan.getResourceName().toString(),
-              rootSpan.getTraceId().toLong(),
-              rootSpan.getSpanId().toLong(),
-              traceSampled,
-              checkpointsSampled)
-          .commit();
+      if (rootSpan instanceof DDSpan) {
+        DDSpan span = (DDSpan) rootSpan;
+        /*
+        Here we need to track the sampling status of the trace.
+        Simply using the 'published' flag is not enough as a trace may be published even though
+        it is supposed to be dropped. Thus we need to check both the `published` flag and
+        the eligibility to be dropped.
+         */
+        boolean traceSampled = published && !span.eligibleForDropping();
+        new EndpointEvent(
+                rootSpan.getResourceName().toString(),
+                rootSpan.getTraceId().toLong(),
+                rootSpan.getSpanId().toLong(),
+                traceSampled,
+                checkpointsSampled)
+            .commit();
+      }
     }
   }
 

--- a/internal-api/src/main/java/datadog/trace/api/Checkpointer.java
+++ b/internal-api/src/main/java/datadog/trace/api/Checkpointer.java
@@ -36,7 +36,7 @@ public interface Checkpointer {
    * Callback to be called when a root span is written (together with the trace)
    *
    * @param rootSpan the local root span of the trace
-   * @param published {@literal true} the trace and root span sampled and published
+   * @param published {@literal true} the trace and root span published
    */
-  void onRootSpan(AgentSpan rootSpan, boolean traceSampled, boolean checkpointsSampled);
+  void onRootSpan(AgentSpan rootSpan, boolean published, boolean checkpointsSampled);
 }

--- a/internal-api/src/main/java/datadog/trace/api/SamplingCheckpointer.java
+++ b/internal-api/src/main/java/datadog/trace/api/SamplingCheckpointer.java
@@ -99,6 +99,6 @@ public final class SamplingCheckpointer implements SpanCheckpointer {
 
     @Override
     public void onRootSpan(
-        final AgentSpan rootSpan, final boolean traceSampled, final boolean checkpointsSampled) {}
+        final AgentSpan rootSpan, final boolean published, final boolean checkpointsSampled) {}
   }
 }


### PR DESCRIPTION
Currently, in the endpoint event we are assuming that a published trace == sampled trace.
This is not entirely true as in certain cases the trace can be published even though is marked for dropping.
This patch is taking this difference into account, making the endpoint event better reflect the reality.