### PR TITLE
Generate async profiler config event when async profiler is enabled.

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -36,10 +36,7 @@ jobs:
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
     - name: Build dd-trace-java for creating the CodeQL database
-      run: |
-        env
-        JAVA_HOME=$JAVA_HOME_8_X64 java -version
-        JAVA_HOME=$JAVA_HOME_8_X64 JAVA_11_HOME=$JAVA_HOME_11_X64 ./gradlew clean :dd-java-agent:shadowJar --build-cache --parallel --stacktrace --no-daemon --max-workers=8
+      run: JAVA_HOME=$JAVA_HOME_8_X64 JAVA_11_HOME=$JAVA_HOME_11_X64 ./gradlew clean :dd-java-agent:shadowJar --build-cache --parallel --stacktrace --no-daemon --max-workers=8
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -36,7 +36,10 @@ jobs:
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
     - name: Build dd-trace-java for creating the CodeQL database
-      run: JAVA_11_HOME=$JAVA_HOME_11_X64 ./gradlew clean :dd-java-agent:shadowJar --build-cache --parallel --stacktrace --no-daemon --max-workers=8
+      run: |
+        env
+        JAVA_HOME=$JAVA_HOME_8_X64 java -version
+        JAVA_HOME=$JAVA_HOME_8_X64 JAVA_11_HOME=$JAVA_HOME_11_X64 ./gradlew clean :dd-java-agent:shadowJar --build-cache --parallel --stacktrace --no-daemon --max-workers=8
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1

--- a/dd-java-agent/agent-profiling/profiling-auxiliary-async/profiling-auxiliary-async.gradle
+++ b/dd-java-agent/agent-profiling/profiling-auxiliary-async/profiling-auxiliary-async.gradle
@@ -17,8 +17,7 @@ excludedClassesCoverage += [
   // --
   // although it is quite well covered jacoco complains about branch coverage due to exception handlers
   'com.datadog.profiling.auxiliary.async.AsyncProfilerRecording',
-  'com.datadog.profiling.auxiliary.async.AsyncProfilerRecordingData'
-  'com.datadog.profiling.auxiliary.async.AsyncProfilerRecording',
+  'com.datadog.profiling.auxiliary.async.AsyncProfilerRecordingData',
   // the config event is a simple data holder
   'com.datadog.profiling.auxiliary.async.AsyncProfilerConfigEvent'
 ]

--- a/dd-java-agent/agent-profiling/profiling-auxiliary-async/profiling-auxiliary-async.gradle
+++ b/dd-java-agent/agent-profiling/profiling-auxiliary-async/profiling-auxiliary-async.gradle
@@ -40,28 +40,6 @@ dependencies {
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
-[JavaCompile, GroovyCompile].each {
-  tasks.withType(it).configureEach {
-    doFirst {
-      if (!System.env.JAVA_11_HOME) {
-        throw new GradleException('JAVA_11_HOME must be set to build auxiliary async profiling module')
-      }
-      // Disable '-processing' because some annotations are not claimed.
-      // Disable '-options' because we are compiling for java8 without specifying bootstrap - intentionally.
-      // Disable '-path' because we do not have some of the paths seem to be missing.
-      options.compilerArgs.addAll(['-Xlint:all,-processing,-options,-path'/*, '-Werror'*/])
-      options.fork = true
-      options.forkOptions.javaHome = file(System.env.JAVA_11_HOME)
-    }
-  }
-}
-
-idea {
-  module {
-    jdkName = '11'
-  }
-}
-
 shadowJar {
   classifier ""
   include {

--- a/dd-java-agent/agent-profiling/profiling-auxiliary-async/profiling-auxiliary-async.gradle
+++ b/dd-java-agent/agent-profiling/profiling-auxiliary-async/profiling-auxiliary-async.gradle
@@ -1,12 +1,14 @@
 plugins {
-  id "de.undercouch.download" version "4.1.1"
   id "com.github.johnrengelman.shadow"
 }
 
 apply from: "$rootDir/gradle/java.gradle"
+apply plugin: 'idea'
 
-minimumInstructionCoverage = 0.5
-minimumBranchCoverage = 0.5
+def osName = System.getProperty('os.name', '').toLowerCase()
+// currently, only linux binaries are included
+minimumInstructionCoverage = osName.contains("linux") ? 0.5 : 0
+minimumBranchCoverage = osName.contains("linux") ? 0.5 : 0
 
 excludedClassesCoverage += [
   // enums with no additional functionality
@@ -37,6 +39,28 @@ dependencies {
 
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
+
+[JavaCompile, GroovyCompile].each {
+  tasks.withType(it).configureEach {
+    doFirst {
+      if (!System.env.JAVA_11_HOME) {
+        throw new GradleException('JAVA_11_HOME must be set to build auxiliary async profiling module')
+      }
+      // Disable '-processing' because some annotations are not claimed.
+      // Disable '-options' because we are compiling for java8 without specifying bootstrap - intentionally.
+      // Disable '-path' because we do not have some of the paths seem to be missing.
+      options.compilerArgs.addAll(['-Xlint:all,-processing,-options,-path'/*, '-Werror'*/])
+      options.fork = true
+      options.forkOptions.javaHome = file(System.env.JAVA_11_HOME)
+    }
+  }
+}
+
+idea {
+  module {
+    jdkName = '11'
+  }
+}
 
 shadowJar {
   classifier ""

--- a/dd-java-agent/agent-profiling/profiling-auxiliary-async/profiling-auxiliary-async.gradle
+++ b/dd-java-agent/agent-profiling/profiling-auxiliary-async/profiling-auxiliary-async.gradle
@@ -18,6 +18,9 @@ excludedClassesCoverage += [
   // although it is quite well covered jacoco complains about branch coverage due to exception handlers
   'com.datadog.profiling.auxiliary.async.AsyncProfilerRecording',
   'com.datadog.profiling.auxiliary.async.AsyncProfilerRecordingData'
+  'com.datadog.profiling.auxiliary.async.AsyncProfilerRecording',
+  // the config event is a simple data holder
+  'com.datadog.profiling.auxiliary.async.AsyncProfilerConfigEvent'
 ]
 
 def AP_VERSION = project.findProperty("dd.async_profiler")

--- a/dd-java-agent/agent-profiling/profiling-auxiliary-async/src/main/java/com/datadog/profiling/auxiliary/async/AsyncProfilerConfigEvent.java
+++ b/dd-java-agent/agent-profiling/profiling-auxiliary-async/src/main/java/com/datadog/profiling/auxiliary/async/AsyncProfilerConfigEvent.java
@@ -1,0 +1,44 @@
+package com.datadog.profiling.auxiliary.async;
+
+import jdk.jfr.Category;
+import jdk.jfr.DataAmount;
+import jdk.jfr.Description;
+import jdk.jfr.Event;
+import jdk.jfr.Label;
+import jdk.jfr.Period;
+import jdk.jfr.StackTrace;
+import jdk.jfr.Timespan;
+
+@Label("Async Profiler Configuration")
+@Description("The active async profiler configuration")
+@Category("Datadog")
+@Period("endChunk")
+@StackTrace(false)
+public class AsyncProfilerConfigEvent extends Event {
+  @Label("CPU Sampling Interval")
+  @Description(
+      "Number of milliseconds used by a CPU between two subsequent samples or -1 if inactive")
+  @Timespan("MILLISECONDS")
+  private final long cpuInterval;
+
+  @Label("Allocation Sampling Interval")
+  @Description("Number of bytes allocated between two subsequent samples or -1 if inactive")
+  @DataAmount
+  private final long allocInterval;
+
+  @Label("Profiling Mode")
+  @Description("Profiling mode bitmask")
+  private final int modeMask;
+
+  @Label("Version")
+  @Description("Async profiler version string")
+  private final String version;
+
+  public AsyncProfilerConfigEvent(
+      String version, long cpuInterval, long allocInterval, int modeMask) {
+    this.version = version;
+    this.cpuInterval = cpuInterval;
+    this.allocInterval = allocInterval;
+    this.modeMask = modeMask;
+  }
+}

--- a/dd-java-agent/agent-profiling/profiling-auxiliary-async/src/main/java/com/datadog/profiling/auxiliary/async/AuxiliaryAsyncProfiler.java
+++ b/dd-java-agent/agent-profiling/profiling-auxiliary-async/src/main/java/com/datadog/profiling/auxiliary/async/AuxiliaryAsyncProfiler.java
@@ -20,7 +20,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.LockSupport;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-
 import jdk.jfr.EventType;
 import jdk.jfr.FlightRecorder;
 import one.profiler.AsyncProfiler;

--- a/dd-java-agent/agent-profiling/profiling-auxiliary-async/src/main/java/com/datadog/profiling/auxiliary/async/AuxiliaryAsyncProfiler.java
+++ b/dd-java-agent/agent-profiling/profiling-auxiliary-async/src/main/java/com/datadog/profiling/auxiliary/async/AuxiliaryAsyncProfiler.java
@@ -190,6 +190,9 @@ final class AuxiliaryAsyncProfiler implements AuxiliaryImplementation {
   }
 
   boolean isActive() {
+    if (!isAvailable()) {
+      return false;
+    }
     try {
       String status = executeProfilerCmd("status");
       log.debug("Async Profiler Status = {}", status);

--- a/dd-java-agent/agent-profiling/profiling-auxiliary-async/src/main/java/com/datadog/profiling/auxiliary/async/AuxiliaryAsyncProfiler.java
+++ b/dd-java-agent/agent-profiling/profiling-auxiliary-async/src/main/java/com/datadog/profiling/auxiliary/async/AuxiliaryAsyncProfiler.java
@@ -100,7 +100,12 @@ final class AuxiliaryAsyncProfiler implements AuxiliaryImplementation {
               ProfilingMode.mask(profilingModes))
           .commit();
     } catch (Throwable t) {
-      log.error("", t);
+      if (log.isDebugEnabled()) {
+        log.warn("Exception occurred while attempting to emit config event", t);
+      } else {
+        log.warn("Exception occurred while attempting to emit config event", t.toString());
+      }
+      throw t;
     }
   }
 

--- a/dd-java-agent/agent-profiling/profiling-auxiliary/src/main/java/com/datadog/profiling/auxiliary/ProfilingMode.java
+++ b/dd-java-agent/agent-profiling/profiling-auxiliary/src/main/java/com/datadog/profiling/auxiliary/ProfilingMode.java
@@ -1,9 +1,25 @@
 package com.datadog.profiling.auxiliary;
 
+import java.util.Set;
+
 /** Various profiling modes that can be supported by auxiliary profilers */
 public enum ProfilingMode {
-  CPU,
-  WALLCLOCK,
-  ALLOCATION,
-  MEMLEAK;
+  CPU(1),
+  WALLCLOCK(2),
+  ALLOCATION(4),
+  MEMLEAK(8);
+
+  public final int bitmask;
+
+  ProfilingMode(int bitmask) {
+    this.bitmask = bitmask;
+  }
+
+  public static int mask(Set<ProfilingMode> modes) {
+    int mask = 0;
+    for (ProfilingMode mode : modes) {
+      mask |= mode.bitmask;
+    }
+    return mask;
+  }
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
@@ -57,7 +57,7 @@ public final class ProfilingConfig {
   public static final int PROFILING_ASYNC_CPU_INTERVAL_DEFAULT = 10;
   public static final String PROFILING_ASYNC_MEMLEAK_ENABLED = "profiling.async.memleak.enabled";
   public static final String PROFILING_ASYNC_MEMLEAK_INTERVAL = "profiling.async.memleak.interval";
-  public static final String PROFILING_ASYNC_MEMLEAK_INTERVAL_DEFAULT = "256k";
+  public static final int PROFILING_ASYNC_MEMLEAK_INTERVAL_DEFAULT = 256 * 1024;
 
   public static final String PROFILING_LEGACY_TRACING_INTEGRATION =
       "profiling.legacy.tracing.integration";

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
@@ -51,8 +51,10 @@ public final class ProfilingConfig {
   public static final String PROFILING_ASYNC_LIBPATH = "profiling.async.lib";
   public static final String PROFILING_ASYNC_ALLOC_ENABLED = "profiling.async.alloc.enabled";
   public static final String PROFILING_ASYNC_ALLOC_INTERVAL = "profiling.async.alloc.interval";
-  public static final String PROFILING_ASYNC_ALLOC_INTERVAL_DEFAULT = "256k";
+  public static final int PROFILING_ASYNC_ALLOC_INTERVAL_DEFAULT = 256 * 1024;
   public static final String PROFILING_ASYNC_CPU_ENABLED = "profiling.async.cpu.enabled";
+  public static final String PROFILING_ASYNC_CPU_INTERVAL = "profiling.async.cpu.interval.ms";
+  public static final int PROFILING_ASYNC_CPU_INTERVAL_DEFAULT = 10;
   public static final String PROFILING_ASYNC_MEMLEAK_ENABLED = "profiling.async.memleak.enabled";
   public static final String PROFILING_ASYNC_MEMLEAK_INTERVAL = "profiling.async.memleak.interval";
   public static final String PROFILING_ASYNC_MEMLEAK_INTERVAL_DEFAULT = "256k";


### PR DESCRIPTION
In order to correctly interpret the async profiler collected samples a config describing event is needed.