### PR TITLE
[Serverless] add extension support

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/DDAgentWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/DDAgentWriter.java
@@ -53,7 +53,7 @@ public class DDAgentWriter implements Writer {
   private final TraceProcessingWorker traceProcessingWorker;
   private final PayloadDispatcher dispatcher;
   private final DDAgentFeaturesDiscovery discovery;
-  private boolean alwaysFlush = false;
+  private final boolean alwaysFlush;
 
   private volatile boolean closed;
 
@@ -179,7 +179,7 @@ public class DDAgentWriter implements Writer {
       final boolean traceAgentV05Enabled,
       boolean metricsReportingEnabled,
       DDAgentFeaturesDiscovery featureDiscovery,
-      final  boolean alwaysFlush) {
+      final boolean alwaysFlush) {
     HttpUrl agentUrl = HttpUrl.get("http://" + agentHost + ":" + traceAgentPort);
     OkHttpClient client =
         null == featureDiscovery || null == agentApi
@@ -222,6 +222,7 @@ public class DDAgentWriter implements Writer {
     this.healthMetrics = healthMetrics;
     this.traceProcessingWorker = worker;
     this.dispatcher = new PayloadDispatcher(discovery, api, healthMetrics, monitoring);
+    this.alwaysFlush = false;
   }
 
   private DDAgentWriter(
@@ -235,6 +236,7 @@ public class DDAgentWriter implements Writer {
     this.healthMetrics = healthMetrics;
     this.traceProcessingWorker = worker;
     this.dispatcher = dispatcher;
+    this.alwaysFlush = false;
   }
 
   public void addResponseListener(final DDAgentResponseListener listener) {
@@ -264,8 +266,8 @@ public class DDAgentWriter implements Writer {
     } else {
       handleDroppedTrace("Trace written after shutdown.", trace);
     }
-    if (this.alwaysFlush) {
-      this.flush();
+    if (alwaysFlush) {
+      flush();
     }
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/DDAgentWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/DDAgentWriter.java
@@ -7,6 +7,7 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_AGENT_PORT;
 import static datadog.trace.api.sampling.PrioritySampling.UNSET;
 import static datadog.trace.common.writer.ddagent.Prioritization.FAST_LANE;
 
+import datadog.common.container.ServerlessInfo;
 import datadog.communication.ddagent.DDAgentFeaturesDiscovery;
 import datadog.communication.monitor.Monitoring;
 import datadog.trace.api.Config;
@@ -253,6 +254,9 @@ public class DDAgentWriter implements Writer {
       }
     } else {
       handleDroppedTrace("Trace written after shutdown.", trace);
+    }
+    if (ServerlessInfo.get().isRunningInServerlessEnvironment()) {
+      this.flush();
     }
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/WriterFactory.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/WriterFactory.java
@@ -61,8 +61,13 @@ public class WriterFactory {
 
     if (config.isAgentConfiguredUsingDefault()
         && ServerlessInfo.get().isRunningInServerlessEnvironment()) {
-      log.info("Detected serverless environment.  Using PrintingWriter");
-      return new PrintingWriter(System.out, true);
+      log.info("Detected serverless environment");
+      if (!ServerlessInfo.get().hasExtension()) {
+        log.info("Serverless extension has not been detected, using PrintingWriter");
+        return new PrintingWriter(System.out, true);
+      } else {
+        log.info("Serverless extension has been detected, using DDAgentWriter");
+      }
     }
 
     String unixDomainSocket = discoverApmSocket(config);

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/WriterFactory.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/WriterFactory.java
@@ -62,12 +62,13 @@ public class WriterFactory {
     boolean alwaysFlush = false;
     if (config.isAgentConfiguredUsingDefault()
         && ServerlessInfo.get().isRunningInServerlessEnvironment()) {
-      log.info("Detected serverless environment");
       if (!ServerlessInfo.get().hasExtension()) {
-        log.info("Serverless extension has not been detected, using PrintingWriter");
+        log.info(
+            "Detected serverless environment. Serverless extension has not been detected, using PrintingWriter");
         return new PrintingWriter(System.out, true);
       } else {
-        log.info("Serverless extension has been detected, using DDAgentWriter");
+        log.info(
+            "Detected serverless environment. Serverless extension has been detected, using DDAgentWriter");
         alwaysFlush = true;
       }
     }

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/WriterFactory.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/WriterFactory.java
@@ -59,6 +59,7 @@ public class WriterFactory {
           "Writer type not configured correctly: Type {} not recognized. Ignoring", configuredType);
     }
 
+    boolean alwaysFlush = false;
     if (config.isAgentConfiguredUsingDefault()
         && ServerlessInfo.get().isRunningInServerlessEnvironment()) {
       log.info("Detected serverless environment");
@@ -67,6 +68,7 @@ public class WriterFactory {
         return new PrintingWriter(System.out, true);
       } else {
         log.info("Serverless extension has been detected, using DDAgentWriter");
+        alwaysFlush = true;
       }
     }
 
@@ -96,6 +98,7 @@ public class WriterFactory {
             .prioritization(prioritization)
             .healthMetrics(new HealthMetrics(statsDClient))
             .monitoring(commObjects.monitoring)
+            .alwaysFlush(alwaysFlush)
             .build();
 
     if (sampler instanceof DDAgentResponseListener) {

--- a/utils/container-utils/src/main/java/datadog/common/container/ServerlessInfo.java
+++ b/utils/container-utils/src/main/java/datadog/common/container/ServerlessInfo.java
@@ -8,11 +8,16 @@ public class ServerlessInfo {
   private static final ServerlessInfo INSTANCE = new ServerlessInfo();
 
   private final String functionName;
-  private final String extensionPath;
+  private final boolean hasExtension;
 
   private ServerlessInfo(final String extensionPath) {
-    this.extensionPath = extensionPath;
     this.functionName = System.getenv(AWS_FUNCTION_VARIABLE);
+    if (null == extensionPath) {
+      this.hasExtension = false;
+    } else {
+      File f = new File(extensionPath);
+      this.hasExtension = (f.exists() && !f.isDirectory());
+    }
   }
 
   public ServerlessInfo() {
@@ -30,11 +35,7 @@ public class ServerlessInfo {
   }
 
   public boolean hasExtension() {
-    if (null == this.extensionPath) {
-      return false;
-    }
-    File f = new File(this.extensionPath);
-    return (f.exists() && !f.isDirectory());
+    return this.hasExtension;
   }
 
   public String getFunctionName() {

--- a/utils/container-utils/src/main/java/datadog/common/container/ServerlessInfo.java
+++ b/utils/container-utils/src/main/java/datadog/common/container/ServerlessInfo.java
@@ -1,15 +1,24 @@
 package datadog.common.container;
 
+import java.io.File;
+
 public class ServerlessInfo {
   private static final String AWS_FUNCTION_VARIABLE = "AWS_LAMBDA_FUNCTION_NAME";
+  private static final String EXTENSION_PATH = "/opt/extensions/datadog-agent";
   private static final ServerlessInfo INSTANCE = new ServerlessInfo();
 
   private final String functionName;
+  private final String extensionPath;
+
+  private ServerlessInfo(final String extensionPath) {
+    this.extensionPath = extensionPath;
+    this.functionName = System.getenv(AWS_FUNCTION_VARIABLE);
+  }
 
   public ServerlessInfo() {
     // TODO add more serverless configuration properties
     // support envs other than AWS lambda
-    this.functionName = System.getenv(AWS_FUNCTION_VARIABLE);
+    this(EXTENSION_PATH);
   }
 
   public static ServerlessInfo get() {
@@ -18,6 +27,14 @@ public class ServerlessInfo {
 
   public boolean isRunningInServerlessEnvironment() {
     return functionName != null && !functionName.isEmpty();
+  }
+
+  public boolean hasExtension() {
+    if (null == this.extensionPath) {
+      return false;
+    }
+    File f = new File(this.extensionPath);
+    return (f.exists() && !f.isDirectory());
   }
 
   public String getFunctionName() {

--- a/utils/container-utils/src/main/java/datadog/common/container/ServerlessInfo.java
+++ b/utils/container-utils/src/main/java/datadog/common/container/ServerlessInfo.java
@@ -1,7 +1,6 @@
 package datadog.common.container;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
 import java.io.File;
 
 public class ServerlessInfo {

--- a/utils/container-utils/src/main/java/datadog/common/container/ServerlessInfo.java
+++ b/utils/container-utils/src/main/java/datadog/common/container/ServerlessInfo.java
@@ -1,5 +1,7 @@
 package datadog.common.container;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import java.io.File;
 
 public class ServerlessInfo {
@@ -20,6 +22,7 @@ public class ServerlessInfo {
     }
   }
 
+  @SuppressFBWarnings("DMI_HARDCODED_ABSOLUTE_FILENAME")
   public ServerlessInfo() {
     // TODO add more serverless configuration properties
     // support envs other than AWS lambda

--- a/utils/container-utils/src/main/java/datadog/common/container/ServerlessInfo.java
+++ b/utils/container-utils/src/main/java/datadog/common/container/ServerlessInfo.java
@@ -35,7 +35,7 @@ public class ServerlessInfo {
   }
 
   public boolean hasExtension() {
-    return this.hasExtension;
+    return hasExtension;
   }
 
   public String getFunctionName() {

--- a/utils/container-utils/src/test/groovy/ServerlessInfoTest.groovy
+++ b/utils/container-utils/src/test/groovy/ServerlessInfoTest.groovy
@@ -24,4 +24,27 @@ class ServerlessInfoTest extends DDSpecification {
     ""           | false
     "someName"   | true
   }
+
+  def "test serverless hasExtension false"() {
+    when:
+    def info = new ServerlessInfo()
+    then:
+    info.hasExtension() == false
+  }
+
+  def "test serverless hasExtension false since the extension path is null"() {
+    when:
+    def info = new ServerlessInfo(null)
+    then:
+    info.hasExtension() == false
+  }
+
+  def "test serverless hasExtension true"() {
+    when:
+    File f = File.createTempFile("fake-", "extension");
+    f.deleteOnExit()
+    def info = new ServerlessInfo(f.getAbsolutePath())
+    then:
+    info.hasExtension() == true
+  }
 }

--- a/utils/container-utils/src/test/groovy/ServerlessInfoTest.groovy
+++ b/utils/container-utils/src/test/groovy/ServerlessInfoTest.groovy
@@ -41,7 +41,7 @@ class ServerlessInfoTest extends DDSpecification {
 
   def "test serverless hasExtension true"() {
     when:
-    File f = File.createTempFile("fake-", "extension");
+    File f = File.createTempFile("fake-", "extension")
     f.deleteOnExit()
     def info = new ServerlessInfo(f.getAbsolutePath())
     then:


### PR DESCRIPTION
This PR adds support for the Serverless extension by
- detecting whether the extension is present
- depending on the result, switch the `PrinterWriter` for the regular `DDAgentWriter`
- flushing immediately after the write().


<img width="1003" alt="Screen Shot 2021-11-08 at 10 38 10 AM" src="https://user-images.githubusercontent.com/864493/140718930-79d2c4de-ada5-470f-8b82-ee2afa0557ec.png">

Note that I was not able to use the existing `flushFrequencySeconds` as when set to 0, switch to another behaviour (cc : https://github.com/DataDog/dd-trace-java/blob/master/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/TraceProcessingWorker.java#L124 )