### PR TITLE
Enable instrumentation of synthetic methods

### DIFF
--- a/dd-java-agent/testing/src/test/groovy/synthetic/SyntheticForkedTest.groovy
+++ b/dd-java-agent/testing/src/test/groovy/synthetic/SyntheticForkedTest.groovy
@@ -1,0 +1,39 @@
+package synthetic
+
+import datadog.trace.agent.test.AgentTestRunner
+
+abstract class SyntheticForkedTestBase extends AgentTestRunner {
+
+  def "test Synthetic methods"() {
+    expect:
+    SyntheticTestInstrumentation.Compute.result(i) == computed(i)
+
+    where:
+    i << [0, 1, 2, 3]
+  }
+
+  abstract int computed(int i)
+}
+
+class SyntheticForkedTest extends SyntheticForkedTestBase {
+
+  @Override
+  int computed(int i) {
+    return i * 2 + 1
+  }
+
+  @Override
+  protected void configurePreAgent() {
+    super.configurePreAgent()
+
+    System.setProperty("synthetic.test.enabled", "true")
+  }
+}
+
+class SyntheticDisabledForkedTest extends SyntheticForkedTestBase {
+
+  @Override
+  int computed(int i) {
+    return i + 1
+  }
+}

--- a/dd-java-agent/testing/src/test/java/synthetic/SyntheticTestInstrumentation.java
+++ b/dd-java-agent/testing/src/test/java/synthetic/SyntheticTestInstrumentation.java
@@ -1,0 +1,60 @@
+package synthetic;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.none;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+@AutoService(Instrumenter.class)
+public class SyntheticTestInstrumentation extends Instrumenter.Tracing {
+
+  public SyntheticTestInstrumentation() {
+    super("synthetic-test");
+  }
+
+  @Override
+  public ElementMatcher<? super TypeDescription> typeMatcher() {
+    return named(getClass().getName() + "$WithSynthetic");
+  }
+
+  @Override
+  public ElementMatcher<? super MethodDescription> methodIgnoreMatcher() {
+    if (Boolean.getBoolean("synthetic.test.enabled")) {
+      return none();
+    } else {
+      return super.methodIgnoreMatcher();
+    }
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(named("access$000"), getClass().getName() + "$AccessAdvice");
+  }
+
+  public static class Compute {
+    public static Integer result(Integer i) {
+      WithSynthetic p = new WithSynthetic(i);
+      return p.secret + 1;
+    }
+  }
+
+  private static final class WithSynthetic {
+    private Integer secret;
+
+    public WithSynthetic(Integer secret) {
+      this.secret = secret;
+    }
+  }
+
+  public static final class AccessAdvice {
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    public static void exit(@Advice.Return(readOnly = false) Integer i) {
+      i = i * 2;
+    }
+  }
+}


### PR DESCRIPTION
This is necessary to instrument the inner workings of some Scala frameworks.
* The default behavior is still to skip synthetic methods, but that can be changed on a per instrumentation basis.
* My highly unscientific running of the class loading benchmark with the whole of `http4s-blaze-client` and dependencies on the class path did not show any slowdown du to the changes in matchers.