### PR TITLE
byte-buddy 1.12.0

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -27,7 +27,7 @@ dependencies {
   implementation(gradleApi())
   implementation(localGroovy())
 
-  implementation("net.bytebuddy", "byte-buddy-gradle-plugin", "1.11.18")
+  implementation("net.bytebuddy", "byte-buddy-gradle-plugin", "1.12.0")
 
   implementation("org.eclipse.aether", "aether-connector-basic", "1.1.0")
   implementation("org.eclipse.aether", "aether-transport-http", "1.1.0")

--- a/buildSrc/src/test/groovy/InstrumentPluginTest.groovy
+++ b/buildSrc/src/test/groovy/InstrumentPluginTest.groovy
@@ -20,7 +20,7 @@ class InstrumentPluginTest extends Specification {
     }
 
     dependencies {
-      compileOnly group: 'net.bytebuddy', name: 'byte-buddy', version: '1.11.18' // just to build TestPlugin
+      compileOnly group: 'net.bytebuddy', name: 'byte-buddy', version: '1.12.0' // just to build TestPlugin
     }
 
     apply plugin: 'instrument'

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -13,7 +13,7 @@ final class CachedData {
     groovy        : groovyVer,
     junit5        : "5.6.2",
     logback       : "1.2.3",
-    bytebuddy     : "1.11.18",
+    bytebuddy     : "1.12.0",
     scala         : "2.11.12",  // Last version to support Java 7 (2.12+ require Java 8+)
     scala210      : "2.10.7",
     scala211      : "2.11.12",


### PR DESCRIPTION
Changes since last upgrade...

1.12.0

- Introduce detection for Graal native image execution.
- Correctly resolve interface implementations in revers order when compiling method graph.
- Adjust lambda instrumentation strategy to support Java 17.

1.11.22

- Remove automatic frame padding mechanism in favor of explicit NOP instruction after injected blocks.


1.11.21

- Allow Advice.PostProcessor to emitt frames.
- Add possibility for Advice.AssignReturned to suppress exceptions.
- Add frame when rebasing constructors to avoid breakage if frames are assumed prior to super constructor call.

1.11.20

- Add option for AsScalar annotation to assign default value instead of ignoring it.
- Add transform-runtime goal to Byte Buddy Mojo to allow for running plugins with runtime class path included.

1.11.19

- Add Advice.AssignReturned post processor to allow for assigning values from Advice that uses delegation rather than inlining.
- Allow for declaring Advice.Local values from both enter and exit advice.
- Add option for using runtime class path rather than only compile scope from Byte Buddy Maven plugin.
- Avoid loading of annotation proxies within Byte Buddy's internal API.
- Add plugin to add Java Repeatable annotations without requiring a JDK 8+.