### PR TITLE
[jmxfetch] `run()` will be non-static for App

### DIFF
--- a/dd-java-agent/agent-jmxfetch/agent-jmxfetch.gradle
+++ b/dd-java-agent/agent-jmxfetch/agent-jmxfetch.gradle
@@ -4,7 +4,7 @@ plugins {
 apply from: "$rootDir/gradle/java.gradle"
 
 dependencies {
-  api('com.datadoghq:jmxfetch:0.44.1') {
+  api('com.datadoghq:jmxfetch:0.45.1') {
     exclude group: 'org.apache.logging.log4j', module: 'log4j-slf4j-impl'
     exclude group: 'org.apache.logging.log4j', module: 'log4j-core'
     exclude group: 'org.slf4j', module: 'slf4j-api'

--- a/dd-java-agent/agent-jmxfetch/src/main/java/datadog/trace/agent/jmxfetch/JMXFetch.java
+++ b/dd-java-agent/agent-jmxfetch/src/main/java/datadog/trace/agent/jmxfetch/JMXFetch.java
@@ -100,6 +100,7 @@ public class JMXFetch {
       configBuilder.checkPeriod(checkPeriod);
     }
     final AppConfig appConfig = configBuilder.build();
+    private App app = new App(appConfig);
 
     final Thread thread =
         newAgentThread(
@@ -109,7 +110,7 @@ public class JMXFetch {
               public void run() {
                 while (true) {
                   try {
-                    final int result = App.run(appConfig);
+                    final int result = app.run();
                     log.error("jmx collector exited with result: " + result);
                   } catch (final Exception e) {
                     log.error("Exception in jmx collector thread", e);

--- a/dd-java-agent/agent-jmxfetch/src/main/java/datadog/trace/agent/jmxfetch/JMXFetch.java
+++ b/dd-java-agent/agent-jmxfetch/src/main/java/datadog/trace/agent/jmxfetch/JMXFetch.java
@@ -100,7 +100,7 @@ public class JMXFetch {
       configBuilder.checkPeriod(checkPeriod);
     }
     final AppConfig appConfig = configBuilder.build();
-    private App app = new App(appConfig);
+    final App app = new App(appConfig);
 
     final Thread thread =
         newAgentThread(


### PR DESCRIPTION
This is a very small PR to address a small change we expect to implement in the JMXFetch lib, by which the `App.run()` method will no longer be static. It is currently a nasty piece of code we have in JMXFetch we would like to get rid of. It should be of minor impact as it still seems very self contained within the tracer use of the lib.