### PR TITLE
Fork Java11 compiler for profiling-auxiliary-async

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-auxiliary-async/profiling-auxiliary-async.gradle
+++ b/dd-java-agent/agent-profiling/profiling-auxiliary-async/profiling-auxiliary-async.gradle
@@ -61,3 +61,25 @@ build.dependsOn shadowJar
 configurations.all {
   resolutionStrategy.cacheChangingModulesFor 0, 'seconds'
 }
+
+[JavaCompile, GroovyCompile].each {
+  tasks.withType(it).configureEach {
+    doFirst {
+      if (!System.env.JAVA_11_HOME) {
+        throw new GradleException('JAVA_11_HOME must be set to build profiling auxiliary')
+      }
+      // Disable '-processing' because some annotations are not claimed.
+      // Disable '-options' because we are compiling for java8 without specifying bootstrap - intentionally.
+      // Disable '-path' because we do not have some of the paths seem to be missing.
+      options.compilerArgs.addAll(['-Xlint:all,-processing,-options,-path'/*, '-Werror'*/])
+      options.fork = true
+      options.forkOptions.javaHome = file(System.env.JAVA_11_HOME)
+    }
+  }
+}
+
+idea {
+  module {
+    jdkName = '11'
+  }
+}


### PR DESCRIPTION
... in case main build JDK is Java8

Same technique as used in https://github.com/DataDog/dd-trace-java/blob/v0.90.0/dd-trace-core/jfr-openjdk/jfr-openjdk.gradle#L31 and https://github.com/DataDog/dd-trace-java/blob/v0.90.0/dd-java-agent/agent-profiling/profiling-controller-openjdk/profiling-controller-openjdk.gradle#L38