### PR TITLE
Implement 'closePrevious' and 'activateNext' to help track potentially open-ended iterations

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -43,6 +43,7 @@ public final class ConfigDefaults {
   static final boolean DEFAULT_DB_CLIENT_HOST_SPLIT_BY_INSTANCE = false;
   static final boolean DEFAULT_DB_CLIENT_HOST_SPLIT_BY_INSTANCE_TYPE_SUFFIX = false;
   static final int DEFAULT_SCOPE_DEPTH_LIMIT = 100;
+  static final int DEFAULT_SCOPE_ITERATION_KEEP_ALIVE = 60; // in seconds
   static final int DEFAULT_PARTIAL_FLUSH_MIN_SPANS = 1000;
   static final boolean DEFAULT_PROPAGATION_EXTRACT_LOG_HEADER_NAMES_ENABLED = false;
   static final String DEFAULT_PROPAGATION_STYLE_EXTRACT = PropagationStyle.DATADOG.name();

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -43,7 +43,7 @@ public final class ConfigDefaults {
   static final boolean DEFAULT_DB_CLIENT_HOST_SPLIT_BY_INSTANCE = false;
   static final boolean DEFAULT_DB_CLIENT_HOST_SPLIT_BY_INSTANCE_TYPE_SUFFIX = false;
   static final int DEFAULT_SCOPE_DEPTH_LIMIT = 100;
-  static final int DEFAULT_SCOPE_ITERATION_KEEP_ALIVE = 60; // in seconds
+  static final int DEFAULT_SCOPE_ITERATION_KEEP_ALIVE = 10; // in seconds
   static final int DEFAULT_PARTIAL_FLUSH_MIN_SPANS = 1000;
   static final boolean DEFAULT_PROPAGATION_EXTRACT_LOG_HEADER_NAMES_ENABLED = false;
   static final String DEFAULT_PROPAGATION_STYLE_EXTRACT = PropagationStyle.DATADOG.name();

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
@@ -49,6 +49,7 @@ public final class TracerConfig {
   public static final String SCOPE_STRICT_MODE = "trace.scope.strict.mode";
   public static final String SCOPE_INHERIT_ASYNC_PROPAGATION =
       "trace.scope.inherit.async.propagation";
+  public static final String SCOPE_ITERATION_KEEP_ALIVE = "trace.scope.iteration.keep.alive";
   public static final String PARTIAL_FLUSH_MIN_SPANS = "trace.partial.flush.min.spans";
   public static final String TRACE_STRICT_WRITES_ENABLED = "trace.strict.writes.enabled";
   public static final String PROPAGATION_EXTRACT_LOG_HEADER_NAMES_ENABLED =

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -599,6 +599,16 @@ public class CoreTracer implements AgentTracer.TracerAPI {
     return scopeManager.captureSpan(span, source);
   }
 
+  @Override
+  public void closePrevious(boolean finishSpan) {
+    scopeManager.closePrevious(finishSpan);
+  }
+
+  @Override
+  public AgentScope activateNext(AgentSpan span) {
+    return scopeManager.activateNext(span);
+  }
+
   public TagInterceptor getTagInterceptor() {
     return tagInterceptor;
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
@@ -770,7 +770,7 @@ public final class ContinuableScopeManager implements AgentScopeManager {
     private static final RootIterationCleaner CLEANER = new RootIterationCleaner();
 
     public static void scheduleFor(Map<ScopeStack, ContinuableScope> rootIterationScopes) {
-      long period = Math.min(iterationKeepAlive, 60_000);
+      long period = Math.min(iterationKeepAlive, 10_000);
       AgentTaskScheduler.INSTANCE.scheduleAtFixedRate(
           CLEANER, rootIterationScopes, iterationKeepAlive, period, TimeUnit.MILLISECONDS);
     }

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
@@ -2,7 +2,10 @@ package datadog.trace.core.scopemanager;
 
 import static datadog.trace.api.ConfigDefaults.DEFAULT_ASYNC_PROPAGATING;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.NoopAgentSpan;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
+import datadog.trace.api.Config;
 import datadog.trace.api.StatsDClient;
 import datadog.trace.api.scopemanager.ExtendedScopeListener;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
@@ -12,9 +15,15 @@ import datadog.trace.bootstrap.instrumentation.api.AgentTrace;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.bootstrap.instrumentation.api.ScopeSource;
 import datadog.trace.context.ScopeListener;
+import datadog.trace.util.AgentTaskScheduler;
 import java.util.ArrayDeque;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,6 +44,11 @@ public final class ContinuableScopeManager implements AgentScopeManager {
           return new ScopeStack();
         }
       };
+
+  static final long iterationKeepAlive =
+      SECONDS.toMillis(Config.get().getScopeIterationKeepAlive());
+
+  volatile ConcurrentMap<ScopeStack, ContinuableScope> iterationScopes;
 
   final List<ScopeListener> scopeListeners;
   final List<ExtendedScopeListener> extendedScopeListeners;
@@ -83,10 +97,10 @@ public final class ContinuableScopeManager implements AgentScopeManager {
       final boolean isAsyncPropagating) {
     ScopeStack scopeStack = scopeStack();
 
-    final ContinuableScope active = scopeStack.top();
-    if (active != null && active.span.equals(span)) {
-      active.incrementReferences();
-      return active;
+    final ContinuableScope top = scopeStack.top;
+    if (top != null && top.span.equals(span)) {
+      top.incrementReferences();
+      return top;
     }
 
     // DQH - This check could go before the check above, since depth limit checking is fast
@@ -102,8 +116,8 @@ public final class ContinuableScopeManager implements AgentScopeManager {
     boolean asyncPropagation =
         overrideAsyncPropagation
             ? isAsyncPropagating
-            : inheritAsyncPropagation && active != null
-                ? active.isAsyncPropagating()
+            : inheritAsyncPropagation && top != null
+                ? top.isAsyncPropagating()
                 : DEFAULT_ASYNC_PROPAGATING;
 
     final ContinuableScope scope = new ContinuableScope(this, span, source, asyncPropagation);
@@ -134,13 +148,63 @@ public final class ContinuableScopeManager implements AgentScopeManager {
   }
 
   @Override
+  public void closePrevious(final boolean finishSpan) {
+    ScopeStack scopeStack = scopeStack();
+
+    // close any immediately previous iteration scope
+    final ContinuableScope top = scopeStack.top;
+    if (top != null && top.source() == ScopeSource.ITERATION.id()) {
+      if (iterationKeepAlive > 0) {
+        cancelIterationScopeCleanup(scopeStack, top);
+      }
+      top.close();
+      scopeStack.cleanup();
+      if (finishSpan) {
+        top.span.finish();
+      }
+    }
+  }
+
+  @Override
+  public AgentScope activateNext(final AgentSpan span) {
+    ScopeStack scopeStack = scopeStack();
+
+    final int currentDepth = scopeStack.depth();
+    if (depthLimit <= currentDepth) {
+      log.debug("Scope depth limit exceeded ({}).  Returning NoopScope.", currentDepth);
+      return AgentTracer.NoopAgentScope.INSTANCE;
+    }
+
+    assert span != null;
+
+    final ContinuableScope top = scopeStack.top;
+
+    boolean asyncPropagation =
+        inheritAsyncPropagation && top != null
+            ? top.isAsyncPropagating()
+            : DEFAULT_ASYNC_PROPAGATING;
+
+    final ContinuableScope scope =
+        new ContinuableScope(this, span, ScopeSource.ITERATION.id(), asyncPropagation);
+
+    if (iterationKeepAlive > 0 && currentDepth == 0) {
+      // no surrounding scope to aid cleanup, so use background task instead
+      scheduleIterationScopeCleanup(scopeStack, scope);
+    }
+
+    scopeStack.push(scope);
+
+    return scope;
+  }
+
+  @Override
   public AgentScope active() {
-    return scopeStack().top();
+    return scopeStack().active();
   }
 
   @Override
   public AgentSpan activeSpan() {
-    final ContinuableScope active = scopeStack().top();
+    final ContinuableScope active = scopeStack().active();
     return active == null ? null : active.span;
   }
 
@@ -200,11 +264,11 @@ public final class ContinuableScopeManager implements AgentScopeManager {
     public final void close() {
       final ScopeStack scopeStack = scopeManager.scopeStack();
 
-      final boolean onTop = scopeStack.checkTop(this);
-      if (!onTop) {
+      // fast check first, only perform slower check when there's an inconsistency with the stack
+      if (!scopeStack.checkTop(this) && !scopeStack.checkOverdueScopes(this)) {
         if (log.isDebugEnabled()) {
           log.debug(
-              "Tried to close {} scope when not on top.  Current top: {}", this, scopeStack.top());
+              "Tried to close {} scope when not on top.  Current top: {}", this, scopeStack.top);
         }
 
         scopeManager.statsDClient.incrementCounter("scope.close.error");
@@ -264,6 +328,10 @@ public final class ContinuableScopeManager implements AgentScopeManager {
     /** Decrements ref count -- returns true if the scope is still alive */
     final boolean decrementReferences() {
       return --referenceCount > 0;
+    }
+
+    final void clearReferences() {
+      referenceCount = 0;
     }
 
     /** Returns true if the scope is still alive (non-zero ref count) */
@@ -343,7 +411,8 @@ public final class ContinuableScopeManager implements AgentScopeManager {
       }
     }
 
-    private byte source() {
+    @Override
+    public byte source() {
       return (byte) (flags & 0x7F);
     }
 
@@ -386,10 +455,14 @@ public final class ContinuableScopeManager implements AgentScopeManager {
   static final class ScopeStack {
     private final ArrayDeque<ContinuableScope> stack = new ArrayDeque<>(); // previous scopes
 
-    private ContinuableScope top; // current scope
+    ContinuableScope top; // current scope
 
-    ContinuableScope top() {
-      return top;
+    // set by background task when a root iteration scope remains unclosed for too long
+    volatile ContinuableScope overdueRootScope;
+
+    ContinuableScope active() {
+      // avoid attaching further spans to the root scope when it's been marked as overdue
+      return top != overdueRootScope ? top : null;
     }
 
     /** Removes and closes all scopes up to the nearest live scope */
@@ -402,7 +475,12 @@ public final class ContinuableScopeManager implements AgentScopeManager {
         changedTop = true;
         curScope = stack.poll();
       }
-      if (changedTop) {
+      if (curScope != null && curScope == overdueRootScope) {
+        // we know this scope is the last on the stack and is overdue
+        curScope.onProperClose();
+        overdueRootScope = null;
+        top = null;
+      } else if (changedTop) {
         top = curScope;
         if (curScope != null) {
           curScope.afterActivated();
@@ -422,6 +500,31 @@ public final class ContinuableScopeManager implements AgentScopeManager {
     /** Fast check to see if the expectedScope is on top */
     boolean checkTop(final ContinuableScope expectedScope) {
       return expectedScope.equals(top);
+    }
+
+    /**
+     * Slower check to see if overdue scopes ahead of the expected scope are all ITERATION scopes.
+     * These represent iterations that are now out-of-scope and can be finished ready for cleanup.
+     */
+    final boolean checkOverdueScopes(final ContinuableScope expectedScope) {
+      // we already know 'top' isn't the expected scope, so just need to check its source
+      if (top == null || top.source() != ScopeSource.ITERATION.id()) {
+        return false;
+      }
+      // avoid calling close() as we're already in that method, instead just clear any
+      // remaining references so the scope gets removed in the subsequent cleanup() call
+      top.clearReferences();
+      top.span.finish();
+      // now do the same for any previous iteration scopes ahead of the expected scope
+      for (ContinuableScope scope : stack) {
+        if (scope.source() != ScopeSource.ITERATION.id()) {
+          return expectedScope.equals(scope);
+        } else {
+          scope.clearReferences();
+          scope.span.finish();
+        }
+      }
+      return false; // we didn't find the expected scope
     }
 
     /** Returns the current depth, including the top scope */
@@ -638,6 +741,58 @@ public final class ContinuableScopeManager implements AgentScopeManager {
           + s
           + ")->"
           + spanUnderScope;
+    }
+  }
+
+  private void scheduleIterationScopeCleanup(ScopeStack scopeStack, ContinuableScope scope) {
+    if (iterationScopes == null) {
+      synchronized (this) {
+        if (iterationScopes == null) {
+          iterationScopes = new ConcurrentHashMap<>();
+          IterationCleaner.scheduleFor(iterationScopes);
+        }
+      }
+    }
+    iterationScopes.put(scopeStack, scope);
+  }
+
+  private void cancelIterationScopeCleanup(ScopeStack scopeStack, ContinuableScope scope) {
+    if (iterationScopes != null) {
+      iterationScopes.remove(scopeStack, scope);
+    }
+  }
+
+  private static final class IterationCleaner
+      implements AgentTaskScheduler.Task<Map<ScopeStack, ContinuableScope>> {
+    private static final IterationCleaner CLEANER = new IterationCleaner();
+
+    public static void scheduleFor(Map<ScopeStack, ContinuableScope> iterationScopes) {
+      long period = Math.min(iterationKeepAlive, 60_000);
+      AgentTaskScheduler.INSTANCE.scheduleAtFixedRate(
+          CLEANER, iterationScopes, iterationKeepAlive, period, TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public void run(Map<ScopeStack, ContinuableScope> iterationScopes) {
+      Iterator<Map.Entry<ScopeStack, ContinuableScope>> itr = iterationScopes.entrySet().iterator();
+
+      long cutOff = System.currentTimeMillis() - iterationKeepAlive;
+
+      while (itr.hasNext()) {
+        Map.Entry<ScopeStack, ContinuableScope> entry = itr.next();
+
+        ScopeStack scopeStack = entry.getKey();
+        ContinuableScope scope = entry.getValue();
+
+        if (!scope.alive()) { // no need to track this anymore
+          itr.remove();
+        } else if (NANOSECONDS.toMillis(scope.span.getStartTime()) < cutOff) {
+          // mark scope as overdue to allow cleanup and avoid further spans being attached
+          scopeStack.overdueRootScope = scope;
+          scope.span.finish();
+          itr.remove();
+        }
+      }
     }
   }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/IterationSpansForkedTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/IterationSpansForkedTest.groovy
@@ -1,0 +1,229 @@
+package datadog.trace.core.scopemanager
+
+import datadog.trace.api.Checkpointer
+import datadog.trace.api.StatsDClient
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan
+import datadog.trace.common.writer.ListWriter
+import datadog.trace.core.CoreTracer
+import datadog.trace.core.DDSpan
+import datadog.trace.core.test.DDCoreSpecification
+
+class IterationSpansForkedTest extends DDCoreSpecification {
+
+  ListWriter writer
+  CoreTracer tracer
+  ContinuableScopeManager scopeManager
+  StatsDClient statsDClient
+  Checkpointer checkpointer
+
+  def setup() {
+    injectSysConfig("dd.trace.scope.iteration.keep.alive", "1")
+
+    checkpointer = Mock()
+    writer = new ListWriter()
+    statsDClient = Mock()
+    tracer = tracerBuilder().writer(writer).statsDClient(statsDClient).build()
+    tracer.registerCheckpointer(checkpointer)
+    scopeManager = tracer.scopeManager
+  }
+
+  def cleanup() {
+    tracer.close()
+  }
+
+  def "root iteration scope lifecycle"() {
+    when:
+    tracer.closePrevious(true)
+    def span1 = tracer.buildSpan("next1").start()
+    def scope1 = tracer.activateNext(span1)
+
+    then:
+    writer.empty
+
+    and:
+    scope1.span() == span1
+    scopeManager.active() == scope1
+    !spanFinished(span1)
+
+    when:
+    tracer.closePrevious(true)
+    def span2 = tracer.buildSpan("next2").start()
+    def scope2 = tracer.activateNext(span2)
+
+    then:
+    spanFinished(span1)
+    writer == [[span1]]
+
+    and:
+    scope2.span() == span2
+    scopeManager.active() == scope2
+    !spanFinished(span2)
+
+    when:
+    tracer.closePrevious(true)
+    def span3 = tracer.buildSpan("next3").start()
+    def scope3 = tracer.activateNext(span3)
+
+    then:
+    spanFinished(span2)
+    writer == [[span1], [span2]]
+
+    and:
+    scope3.span() == span3
+    scopeManager.active() == scope3
+    !spanFinished(span3)
+
+    when:
+    // 'next3' should time out & finish after 1s
+    writer.waitForTraces(3)
+
+    then:
+    spanFinished(span3)
+    writer == [[span1], [span2], [span3]]
+
+    and:
+    scopeManager.active() == null
+  }
+
+  def "non-root iteration scope lifecycle"() {
+    setup:
+    def span0 = tracer.buildSpan("parent").start()
+    def scope0 = tracer.activateSpan(span0)
+
+    when:
+    tracer.closePrevious(true)
+    def span1 = tracer.buildSpan("next1").start()
+    def scope1 = tracer.activateNext(span1)
+
+    then:
+    writer.empty
+
+    and:
+    scope1.span() == span1
+    scopeManager.active() == scope1
+    !spanFinished(span1)
+
+    when:
+    tracer.closePrevious(true)
+    def span2 = tracer.buildSpan("next2").start()
+    def scope2 = tracer.activateNext(span2)
+
+    then:
+    spanFinished(span1)
+    writer.empty
+
+    and:
+    scope2.span() == span2
+    scopeManager.active() == scope2
+    !spanFinished(span2)
+
+    when:
+    tracer.closePrevious(true)
+    def span3 = tracer.buildSpan("next3").start()
+    def scope3 = tracer.activateNext(span3)
+
+    then:
+    spanFinished(span2)
+    writer.empty
+
+    and:
+    scope3.span() == span3
+    scopeManager.active() == scope3
+    !spanFinished(span3)
+
+    when:
+    scope0.close()
+    span0.finish()
+    // closing the parent scope will close & finish 'next3'
+    writer.waitForTraces(1)
+
+    then:
+    spanFinished(span3)
+    spanFinished(span0)
+    sortSpansByStart()
+    writer == [[span0, span1, span2, span3]]
+
+    and:
+    scopeManager.active() == null
+  }
+
+  def "nested iteration scope lifecycle"() {
+    when:
+    tracer.closePrevious(true)
+    def span1 = tracer.buildSpan("next").start()
+    def scope1 = tracer.activateNext(span1)
+
+    then:
+    writer.empty
+
+    and:
+    scope1.span() == span1
+    scopeManager.active() == scope1
+    !spanFinished(span1)
+
+    when:
+    def span1A = tracer.buildSpan("method").start()
+    def scope1A = tracer.activateSpan(span1A)
+
+    and:
+    tracer.closePrevious(true)
+    def span1A1 = tracer.buildSpan("next").start()
+    def scope1A1 = tracer.activateNext(span1A1)
+
+    then:
+    !spanFinished(span1)
+    writer.empty
+
+    and:
+    scope1A1.span() == span1A1
+    scopeManager.active() == scope1A1
+    !spanFinished(span1A1)
+
+    when:
+    tracer.closePrevious(true)
+    def span1A2 = tracer.buildSpan("next").start()
+    def scope1A2 = tracer.activateNext(span1A2)
+
+    then:
+    spanFinished(span1A1)
+    writer.empty
+
+    and:
+    scope1A2.span() == span1A2
+    scopeManager.active() == scope1A2
+    !spanFinished(span1A2)
+
+    when:
+    scope1A.close()
+    span1A.finish()
+    // closing the intervening scope will close & finish 'next1_2'
+
+    then:
+    spanFinished(span1A2)
+    spanFinished(span1A)
+    !spanFinished(span1)
+    writer.empty
+
+    when:
+    // 'next1' should time out & finish after 1s to complete the trace
+    writer.waitForTraces(1)
+
+    then:
+    spanFinished(span1)
+    sortSpansByStart()
+    writer == [[span1, span1A, span1A1, span1A2]]
+
+    and:
+    scopeManager.active() == null
+  }
+
+  boolean spanFinished(AgentSpan span) {
+    return ((DDSpan) span)?.isFinished()
+  }
+
+  private List<DDSpan> sortSpansByStart() {
+    writer.firstTrace().sort { a, b ->
+      return a.startTimeNano <=> b.startTimeNano
+    }
+  }
+}

--- a/dd-trace-ot/src/main/java/datadog/opentracing/CustomScopeManagerWrapper.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/CustomScopeManagerWrapper.java
@@ -146,7 +146,7 @@ class CustomScopeManagerWrapper implements AgentScopeManager {
         new CustomScopeManagerWrapper.IterationCleaner();
 
     public static void scheduleFor(Map<Thread, IterationSpanStack> iterationSpans) {
-      long period = Math.min(iterationKeepAlive, 60_000);
+      long period = Math.min(iterationKeepAlive, 10_000);
       AgentTaskScheduler.INSTANCE.scheduleAtFixedRate(
           CLEANER, iterationSpans, iterationKeepAlive, period, TimeUnit.MILLISECONDS);
     }

--- a/dd-trace-ot/src/main/java/datadog/opentracing/CustomScopeManagerWrapper.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/CustomScopeManagerWrapper.java
@@ -139,6 +139,7 @@ class CustomScopeManagerWrapper implements AgentScopeManager {
     }
   }
 
+  /** Background task to clean-up spans from overdue iterations. */
   private static final class IterationCleaner
       implements AgentTaskScheduler.Task<Map<Thread, IterationSpanStack>> {
     private static final CustomScopeManagerWrapper.IterationCleaner CLEANER =

--- a/dd-trace-ot/src/main/java/datadog/opentracing/CustomScopeManagerWrapper.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/CustomScopeManagerWrapper.java
@@ -1,12 +1,24 @@
 package datadog.opentracing;
 
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import datadog.trace.api.Config;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentScopeManager;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.ScopeSource;
+import datadog.trace.util.AgentTaskScheduler;
 import io.opentracing.Scope;
 import io.opentracing.ScopeManager;
 import io.opentracing.Span;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Allows custom OpenTracing ScopeManagers used by CoreTracer
@@ -24,8 +36,15 @@ import io.opentracing.Span;
  * <p>DDTracer.scopeManager = passed in scopemanager
  */
 class CustomScopeManagerWrapper implements AgentScopeManager {
+  private static final String DD_ITERATION = "_dd.iteration";
+
   private final ScopeManager delegate;
   private final TypeConverter converter;
+
+  static final long iterationKeepAlive =
+      SECONDS.toMillis(Config.get().getScopeIterationKeepAlive());
+
+  volatile ConcurrentMap<Thread, IterationSpanStack> iterationSpans;
 
   CustomScopeManagerWrapper(final ScopeManager scopeManager, final TypeConverter converter) {
     delegate = scopeManager;
@@ -64,6 +83,131 @@ class CustomScopeManagerWrapper implements AgentScopeManager {
     // I can't see a better way to do this, and I don't know if this even makes sense.
     try (AgentScope scope = this.activate(span, source)) {
       return scope.capture();
+    }
+  }
+
+  @Override
+  public void closePrevious(final boolean finishSpan) {
+    Scope scope = delegate.active();
+    if (scope != null) {
+      AgentSpan span = converter.toAgentSpan(scope.span());
+      if (span != null && span.getTag(DD_ITERATION) != null) {
+        if (iterationKeepAlive > 0) {
+          cancelIterationSpanCleanup(span);
+        }
+        scope.close();
+        if (finishSpan) {
+          span.finish();
+        }
+      }
+    }
+  }
+
+  @Override
+  public AgentScope activateNext(final AgentSpan agentSpan) {
+    agentSpan.setTag(DD_ITERATION, "true");
+    Span span = converter.toSpan(agentSpan);
+    Scope scope = delegate.activate(span);
+    if (iterationKeepAlive > 0) {
+      scheduleIterationSpanCleanup(agentSpan);
+    }
+    return converter.toAgentScope(scope);
+  }
+
+  private void scheduleIterationSpanCleanup(final AgentSpan span) {
+    if (iterationSpans == null) {
+      synchronized (this) {
+        if (iterationSpans == null) {
+          iterationSpans = new ConcurrentHashMap<Thread, IterationSpanStack>();
+          CustomScopeManagerWrapper.IterationCleaner.scheduleFor(iterationSpans);
+        }
+      }
+    }
+    IterationSpanStack spanStack = iterationSpans.get(Thread.currentThread());
+    if (spanStack == null) {
+      iterationSpans.put(Thread.currentThread(), spanStack = new IterationSpanStack());
+    }
+    spanStack.trackSpan(span);
+  }
+
+  private void cancelIterationSpanCleanup(AgentSpan span) {
+    if (iterationSpans != null) {
+      IterationSpanStack spanStack = iterationSpans.get(Thread.currentThread());
+      if (spanStack != null) {
+        spanStack.untrackSpan(span);
+      }
+    }
+  }
+
+  private static final class IterationCleaner
+      implements AgentTaskScheduler.Task<Map<Thread, IterationSpanStack>> {
+    private static final CustomScopeManagerWrapper.IterationCleaner CLEANER =
+        new CustomScopeManagerWrapper.IterationCleaner();
+
+    public static void scheduleFor(Map<Thread, IterationSpanStack> iterationSpans) {
+      long period = Math.min(iterationKeepAlive, 60_000);
+      AgentTaskScheduler.INSTANCE.scheduleAtFixedRate(
+          CLEANER, iterationSpans, iterationKeepAlive, period, TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public void run(Map<Thread, IterationSpanStack> iterationSpans) {
+      Iterator<Map.Entry<Thread, IterationSpanStack>> itr = iterationSpans.entrySet().iterator();
+
+      long cutOff = System.currentTimeMillis() - iterationKeepAlive;
+
+      while (itr.hasNext()) {
+        Map.Entry<Thread, IterationSpanStack> entry = itr.next();
+
+        Thread thread = entry.getKey();
+        IterationSpanStack spanStack = entry.getValue();
+
+        if (thread.isAlive()) {
+          spanStack.finishOverdueSpans(cutOff);
+        } else { // thread has stopped
+          spanStack.finishAllSpans();
+          itr.remove();
+        }
+      }
+    }
+  }
+
+  private static final class IterationSpanStack {
+    private final Deque<AgentSpan> spans = new ArrayDeque<>();
+
+    public void trackSpan(AgentSpan span) {
+      synchronized (spans) {
+        spans.push(span);
+      }
+    }
+
+    public void untrackSpan(AgentSpan span) {
+      synchronized (spans) {
+        spans.remove(span);
+      }
+    }
+
+    public void finishOverdueSpans(long cutOff) {
+      while (true) {
+        AgentSpan s;
+        synchronized (spans) {
+          s = spans.peek();
+          if (s == null || cutOff <= NANOSECONDS.toMillis(s.getStartTime())) {
+            break; // no more spans, or span started after the cut-off (keeps previous spans alive)
+          }
+          spans.poll();
+        }
+        s.finish();
+      }
+    }
+
+    public void finishAllSpans() {
+      synchronized (spans) {
+        for (AgentSpan s : spans) {
+          s.finish();
+        }
+        // no need to clear as this is only called when the owning thread is no longer alive
+      }
     }
   }
 }

--- a/dd-trace-ot/src/main/java/datadog/opentracing/TypeConverter.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/TypeConverter.java
@@ -3,6 +3,7 @@ package datadog.opentracing;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import datadog.trace.bootstrap.instrumentation.api.ScopeSource;
 import io.opentracing.Scope;
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
@@ -90,6 +91,11 @@ class TypeConverter {
     }
 
     @Override
+    public byte source() {
+      return delegate.source();
+    }
+
+    @Override
     public void close() {
       delegate.close();
       delegate.span().finish();
@@ -153,6 +159,11 @@ class TypeConverter {
     @Override
     public AgentSpan span() {
       return toAgentSpan(delegate.span());
+    }
+
+    @Override
+    public byte source() {
+      return ScopeSource.MANUAL.id();
     }
 
     @Override

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/CustomScopeManagerTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/CustomScopeManagerTest.groovy
@@ -3,6 +3,7 @@ package datadog.opentracing
 import datadog.trace.api.DDTags
 import datadog.trace.bootstrap.instrumentation.api.AgentScope
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan
+import datadog.trace.bootstrap.instrumentation.api.ScopeSource
 import datadog.trace.common.writer.ListWriter
 import datadog.trace.context.TraceScope
 import datadog.trace.core.CoreTracer
@@ -297,6 +298,11 @@ class TestScopeManager implements ScopeManager {
     @Override
     AgentSpan span() {
       return agentSpan
+    }
+
+    @Override
+    byte source() {
+      return ScopeSource.MANUAL.id()
     }
 
     @Override

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/IterationSpansForkedTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/IterationSpansForkedTest.groovy
@@ -1,0 +1,219 @@
+package datadog.opentracing
+
+import datadog.trace.api.StatsDClient
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan
+import datadog.trace.common.writer.ListWriter
+import datadog.trace.core.CoreTracer
+import datadog.trace.core.DDSpan
+import datadog.trace.test.util.DDSpecification
+import io.opentracing.ScopeManager
+import spock.util.concurrent.PollingConditions
+
+class IterationSpansForkedTest extends DDSpecification {
+  def conditions = new PollingConditions(timeout: 10, initialDelay: 0.1)
+
+  ListWriter writer
+  DDTracer tracer
+  ScopeManager scopeManager
+  StatsDClient statsDClient
+  CoreTracer coreTracer
+
+  def setup() {
+    injectSysConfig("dd.trace.scope.iteration.keep.alive", "1")
+
+    writer = new ListWriter()
+    statsDClient = Mock()
+    scopeManager = new TestScopeManager()
+    tracer = DDTracer.builder().writer(writer).statsDClient(statsDClient).scopeManager(scopeManager).build()
+    coreTracer = tracer.tracer
+  }
+
+  def cleanup() {
+    coreTracer.close()
+  }
+
+  def "root iteration scope lifecycle"() {
+    when:
+    coreTracer.closePrevious(true)
+    def span1 = coreTracer.buildSpan("next1").start()
+    def scope1 = coreTracer.activateNext(span1)
+
+    then:
+    writer.empty
+
+    and:
+    scope1.span() == span1
+    scopeManager.active() == scope1.delegate
+    !spanFinished(span1)
+
+    when:
+    coreTracer.closePrevious(true)
+    def span2 = coreTracer.buildSpan("next2").start()
+    def scope2 = coreTracer.activateNext(span2)
+
+    then:
+    spanFinished(span1)
+    writer == [[span1]]
+
+    and:
+    scope2.span() == span2
+    scopeManager.active() == scope2.delegate
+    !spanFinished(span2)
+
+    when:
+    coreTracer.closePrevious(true)
+    def span3 = coreTracer.buildSpan("next3").start()
+    def scope3 = coreTracer.activateNext(span3)
+    writer.waitForTraces(2)
+
+    then:
+    spanFinished(span2)
+    writer == [[span1], [span2]]
+
+    and:
+    scope3.span() == span3
+    scopeManager.active() == scope3.delegate
+    !spanFinished(span3)
+
+    when:
+    // 'next3' should time out & finish after 1s
+    writer.waitForTraces(3)
+
+    then:
+    spanFinished(span3)
+    writer == [[span1], [span2], [span3]]
+  }
+
+  def "non-root iteration scope lifecycle"() {
+    setup:
+    def span0 = coreTracer.buildSpan("parent").start()
+    def scope0 = coreTracer.activateSpan(span0)
+
+    when:
+    coreTracer.closePrevious(true)
+    def span1 = coreTracer.buildSpan("next1").start()
+    def scope1 = coreTracer.activateNext(span1)
+
+    then:
+    writer.empty
+
+    and:
+    scope1.span() == span1
+    scopeManager.active() == scope1.delegate
+    !spanFinished(span1)
+
+    when:
+    coreTracer.closePrevious(true)
+    def span2 = coreTracer.buildSpan("next2").start()
+    def scope2 = coreTracer.activateNext(span2)
+
+    then:
+    spanFinished(span1)
+    writer.empty
+
+    and:
+    scope2.span() == span2
+    scopeManager.active() == scope2.delegate
+    !spanFinished(span2)
+
+    when:
+    coreTracer.closePrevious(true)
+    def span3 = coreTracer.buildSpan("next3").start()
+    def scope3 = coreTracer.activateNext(span3)
+
+    then:
+    spanFinished(span2)
+    writer.empty
+
+    and:
+    scope3.span() == span3
+    scopeManager.active() == scope3.delegate
+    !spanFinished(span3)
+
+    when:
+    // 'next3' should time out & finish after 1s
+    conditions.eventually { assert spanFinished(span3) }
+
+    // close and finish the surrounding (non-iteration) span to complete the trace
+    scope0.close()
+    span0.finish()
+    writer.waitForTraces(1)
+
+    then:
+    spanFinished(span3)
+    spanFinished(span0)
+    sortSpansByStart()
+    writer == [[span0, span1, span2, span3]]
+  }
+
+  def "nested iteration scope lifecycle"() {
+    when:
+    coreTracer.closePrevious(true)
+    def span1 = coreTracer.buildSpan("next1").start()
+    def scope1 = coreTracer.activateNext(span1)
+
+    then:
+    writer.empty
+
+    and:
+    scope1.span() == span1
+    scopeManager.active() == scope1.delegate
+    !spanFinished(span1)
+
+    when:
+    def span1A = coreTracer.buildSpan("methodA").start()
+    def scope1A = coreTracer.activateSpan(span1A)
+
+    and:
+    coreTracer.closePrevious(true)
+    def span1A1 = coreTracer.buildSpan("next1A1").start()
+    def scope1A1 = coreTracer.activateNext(span1A1)
+
+    then:
+    !spanFinished(span1)
+    writer.empty
+
+    and:
+    scope1A1.span() == span1A1
+    scopeManager.active() == scope1A1.delegate
+    !spanFinished(span1A1)
+
+    when:
+    coreTracer.closePrevious(true)
+    def span1A2 = coreTracer.buildSpan("next1A2").start()
+    def scope1A2 = coreTracer.activateNext(span1A2)
+
+    then:
+    spanFinished(span1A1)
+    writer.empty
+
+    and:
+    scope1A2.span() == span1A2
+    scopeManager.active() == scope1A2.delegate
+    !spanFinished(span1A2)
+
+    when:
+    // close and finish the intermediate (non-iteration) span
+    scope1A.close()
+    span1A.finish()
+    // 'next1' (and 'next1A2') should time out & finish after 1s to complete the trace
+    writer.waitForTraces(1)
+
+    then:
+    spanFinished(span1A2)
+    spanFinished(span1A)
+    spanFinished(span1)
+    sortSpansByStart()
+    writer == [[span1, span1A, span1A1, span1A2]]
+  }
+
+  boolean spanFinished(AgentSpan span) {
+    return ((DDSpan) span)?.isFinished()
+  }
+
+  private List<DDSpan> sortSpansByStart() {
+    writer.firstTrace().sort { a, b ->
+      return a.startTimeNano <=> b.startTimeNano
+    }
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -49,6 +49,7 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_PROPAGATION_STYLE_INJECT;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_RABBIT_PROPAGATION_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_RUNTIME_CONTEXT_FIELD_INJECTION;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_SCOPE_DEPTH_LIMIT;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_SCOPE_ITERATION_KEEP_ALIVE;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_SERIALVERSIONUID_FIELD_INJECTION;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_SERVICE_NAME;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_SERVLET_ROOT_CONTEXT_SERVICE_NAME;
@@ -210,6 +211,7 @@ import static datadog.trace.api.config.TracerConfig.PROPAGATION_STYLE_INJECT;
 import static datadog.trace.api.config.TracerConfig.PROXY_NO_PROXY;
 import static datadog.trace.api.config.TracerConfig.SCOPE_DEPTH_LIMIT;
 import static datadog.trace.api.config.TracerConfig.SCOPE_INHERIT_ASYNC_PROPAGATION;
+import static datadog.trace.api.config.TracerConfig.SCOPE_ITERATION_KEEP_ALIVE;
 import static datadog.trace.api.config.TracerConfig.SCOPE_STRICT_MODE;
 import static datadog.trace.api.config.TracerConfig.SERVICE_MAPPING;
 import static datadog.trace.api.config.TracerConfig.SPAN_TAGS;
@@ -339,6 +341,7 @@ public class Config {
   private final int scopeDepthLimit;
   private final boolean scopeStrictMode;
   private final boolean scopeInheritAsyncPropagation;
+  private final int scopeIterationKeepAlive;
   private final int partialFlushMinSpans;
   private final boolean traceStrictWritesEnabled;
   private final boolean runtimeContextFieldInjection;
@@ -680,6 +683,9 @@ public class Config {
     scopeStrictMode = configProvider.getBoolean(SCOPE_STRICT_MODE, false);
 
     scopeInheritAsyncPropagation = configProvider.getBoolean(SCOPE_INHERIT_ASYNC_PROPAGATION, true);
+
+    scopeIterationKeepAlive =
+        configProvider.getInteger(SCOPE_ITERATION_KEEP_ALIVE, DEFAULT_SCOPE_ITERATION_KEEP_ALIVE);
 
     partialFlushMinSpans =
         configProvider.getInteger(PARTIAL_FLUSH_MIN_SPANS, DEFAULT_PARTIAL_FLUSH_MIN_SPANS);
@@ -1129,6 +1135,10 @@ public class Config {
 
   public boolean isScopeInheritAsyncPropagation() {
     return scopeInheritAsyncPropagation;
+  }
+
+  public int getScopeIterationKeepAlive() {
+    return scopeIterationKeepAlive;
   }
 
   public int getPartialFlushMinSpans() {
@@ -2169,6 +2179,8 @@ public class Config {
         + scopeStrictMode
         + ", scopeInheritAsyncPropagation="
         + scopeInheritAsyncPropagation
+        + ", scopeIterationKeepAlive="
+        + scopeIterationKeepAlive
         + ", partialFlushMinSpans="
         + partialFlushMinSpans
         + ", traceStrictWritesEnabled="

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentScope.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentScope.java
@@ -6,6 +6,8 @@ import java.io.Closeable;
 public interface AgentScope extends TraceScope, Closeable {
   AgentSpan span();
 
+  byte source();
+
   @Override
   Continuation capture();
 

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentScopeManager.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentScopeManager.java
@@ -14,4 +14,8 @@ public interface AgentScopeManager {
   AgentSpan activeSpan();
 
   AgentScope.Continuation captureSpan(AgentSpan span, ScopeSource source);
+
+  void closePrevious(boolean finishSpan);
+
+  AgentScope activateNext(AgentSpan span);
 }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -72,6 +72,23 @@ public class AgentTracer {
     return get().captureSpan(span, ScopeSource.INSTRUMENTATION);
   }
 
+  /**
+   * Closes the immediately previous iteration scope. Should be called before creating a new span
+   * for {@link #activateNext(AgentSpan)}.
+   */
+  public static void closePrevious(final boolean finishSpan) {
+    get().closePrevious(finishSpan);
+  }
+
+  /**
+   * Activates a new iteration scope; closes automatically after a fixed period.
+   *
+   * @see datadog.trace.api.config.TracerConfig#SCOPE_ITERATION_KEEP_ALIVE
+   */
+  public static AgentScope activateNext(final AgentSpan span) {
+    return get().activateNext(span);
+  }
+
   public static AgentSpan activeSpan() {
     return get().activeSpan();
   }
@@ -131,6 +148,10 @@ public class AgentTracer {
     AgentScope activateSpan(AgentSpan span, ScopeSource source, boolean isAsyncPropagating);
 
     AgentScope.Continuation captureSpan(AgentSpan span, ScopeSource source);
+
+    void closePrevious(boolean finishSpan);
+
+    AgentScope activateNext(AgentSpan span);
 
     AgentSpan activeSpan();
 
@@ -228,6 +249,14 @@ public class AgentTracer {
     @Override
     public AgentScope.Continuation captureSpan(final AgentSpan span, final ScopeSource source) {
       return NoopContinuation.INSTANCE;
+    }
+
+    @Override
+    public void closePrevious(final boolean finishSpan) {}
+
+    @Override
+    public AgentScope activateNext(final AgentSpan span) {
+      return NoopAgentScope.INSTANCE;
     }
 
     @Override
@@ -615,6 +644,11 @@ public class AgentTracer {
     @Override
     public AgentSpan span() {
       return NoopAgentSpan.INSTANCE;
+    }
+
+    @Override
+    public byte source() {
+      return 0;
     }
 
     @Override

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/ScopeSource.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/ScopeSource.java
@@ -2,7 +2,8 @@ package datadog.trace.bootstrap.instrumentation.api;
 
 public enum ScopeSource {
   INSTRUMENTATION((byte) 0),
-  MANUAL((byte) 1);
+  MANUAL((byte) 1),
+  ITERATION((byte) 2);
 
   private final byte id;
 


### PR DESCRIPTION
When iterating over a potentially open-ended iteration, such as polling messages from a queue:
* Call `AgentTracer.closePrevious(finishSpan)` just before receiving the message
  * set `finishSpan` to `false` if you intend to finish spans on a different condition, such as on a `commit`
* Create a new span for consuming the message
* Call `AgentTracer.activateNext(messageSpan)` to activate that span and register it for cleanup

There's no need to store the resulting scope - it will be automatically closed either when the next message is received, when a surrounding non-iterating scope is closed, or when the span times out. A background task is only scheduled when there's no surrounding non-iterating scope to detect when the iteration scope should be closed, or when a custom scope manager is used.

The "keep-alive" time for iteration spans can be adjusted with this system property:
```
-Ddd.trace.scope.iteration.keep.alive=<seconds>
```
or by setting this environment variable
```
DD_TRACE_SCOPE_ITERATION_KEEP_ALIVE=<seconds>
```

Setting the timeout to zero disables the background task.