### PR TITLE
[CIAPP] CI Visibility Mode v1: Instrumentation refactor

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
@@ -178,6 +178,9 @@ public class AgentInstaller {
     if (cfg.isAppSecEnabled()) {
       enabledSystems.add(Instrumenter.TargetSystem.APPSEC);
     }
+    if (cfg.isCiVisibilityEnabled()) {
+      enabledSystems.add(Instrumenter.TargetSystem.CIVISIBILITY);
+    }
     return enabledSystems;
   }
 

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Instrumenter.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Instrumenter.java
@@ -59,7 +59,8 @@ public interface Instrumenter {
   enum TargetSystem {
     TRACING,
     PROFILING,
-    APPSEC
+    APPSEC,
+    CIVISIBILITY
   }
 
   /**
@@ -412,6 +413,18 @@ public interface Instrumenter {
     @Override
     public boolean isApplicable(Set<TargetSystem> enabledSystems) {
       return enabledSystems.contains(TargetSystem.APPSEC);
+    }
+  }
+
+  abstract class CiVisibility extends Default {
+
+    public CiVisibility(String instrumentationName, String... additionalNames) {
+      super(instrumentationName, additionalNames);
+    }
+
+    @Override
+    public boolean isApplicable(Set<TargetSystem> enabledSystems) {
+      return enabledSystems.contains(TargetSystem.CIVISIBILITY);
     }
   }
 

--- a/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4Instrumentation.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4Instrumentation.java
@@ -16,7 +16,7 @@ import org.junit.runner.notification.RunListener;
 import org.junit.runner.notification.RunNotifier;
 
 @AutoService(Instrumenter.class)
-public class JUnit4Instrumentation extends Instrumenter.Tracing {
+public class JUnit4Instrumentation extends Instrumenter.CiVisibility {
 
   public JUnit4Instrumentation() {
     super("junit", "junit-4");
@@ -46,11 +46,6 @@ public class JUnit4Instrumentation extends Instrumenter.Tracing {
     transformation.applyAdvice(
         named("run").and(takesArgument(0, named("org.junit.runner.notification.RunNotifier"))),
         JUnit4Instrumentation.class.getName() + "$JUnit4Advice");
-  }
-
-  @Override
-  protected boolean defaultEnabled() {
-    return false;
   }
 
   public static class JUnit4Advice {

--- a/dd-java-agent/instrumentation/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/JUnit5Instrumentation.java
+++ b/dd-java-agent/instrumentation/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/JUnit5Instrumentation.java
@@ -17,7 +17,7 @@ import org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTest
 import org.junit.platform.launcher.Launcher;
 
 @AutoService(Instrumenter.class)
-public class JUnit5Instrumentation extends Instrumenter.Tracing {
+public class JUnit5Instrumentation extends Instrumenter.CiVisibility {
 
   public JUnit5Instrumentation() {
     super("junit", "junit-5");
@@ -43,11 +43,6 @@ public class JUnit5Instrumentation extends Instrumenter.Tracing {
   public void adviceTransformations(AdviceTransformation transformation) {
     transformation.applyAdvice(
         isConstructor(), JUnit5Instrumentation.class.getName() + "$JUnit5Advice");
-  }
-
-  @Override
-  protected boolean defaultEnabled() {
-    return false;
   }
 
   public static class JUnit5Advice {

--- a/dd-java-agent/instrumentation/testng-6.4/src/main/java/datadog/trace/instrumentation/testng/TestNGInstrumentation.java
+++ b/dd-java-agent/instrumentation/testng-6.4/src/main/java/datadog/trace/instrumentation/testng/TestNGInstrumentation.java
@@ -13,7 +13,7 @@ import org.testng.TestNG;
 import org.testng.annotations.DataProvider;
 
 @AutoService(Instrumenter.class)
-public class TestNGInstrumentation extends Instrumenter.Tracing {
+public class TestNGInstrumentation extends Instrumenter.CiVisibility {
 
   public TestNGInstrumentation() {
     super("testng");
@@ -34,11 +34,6 @@ public class TestNGInstrumentation extends Instrumenter.Tracing {
   @Override
   public String[] helperClassNames() {
     return new String[] {packageName + ".TestNGDecorator", packageName + ".TracingListener"};
-  }
-
-  @Override
-  protected boolean defaultEnabled() {
-    return false;
   }
 
   public static class TestNGAdvice {

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/TestFrameworkTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/TestFrameworkTest.groovy
@@ -15,8 +15,6 @@ abstract class TestFrameworkTest extends AgentTestRunner {
   void configurePreAgent() {
     super.configurePreAgent()
     injectSysConfig("dd.civisibility.enabled", "true")
-    injectSysConfig("dd.integration.junit.enabled", "true")
-    injectSysConfig("dd.integration.testng.enabled", "true")
   }
 
   void testSpan(TraceAssert trace, int index, final String testSuite, final String testName, final String testStatus, final Map<String, String> testTags = null, final Throwable exception = null) {

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/TestFrameworkTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/TestFrameworkTest.groovy
@@ -14,6 +14,7 @@ abstract class TestFrameworkTest extends AgentTestRunner {
   @Override
   void configurePreAgent() {
     super.configurePreAgent()
+    injectSysConfig("dd.civisibility.enabled", "true")
     injectSysConfig("dd.integration.junit.enabled", "true")
     injectSysConfig("dd.integration.testng.enabled", "true")
   }

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -76,6 +76,8 @@ public final class ConfigDefaults {
 
   static final boolean DEFAULT_APPSEC_ENABLED = false;
 
+  static final boolean DEFAULT_CIVISIBILITY_ENABLED = false;
+
   static final boolean DEFAULT_AWS_PROPAGATION_ENABLED = true;
   static final boolean DEFAULT_SQS_PROPAGATION_ENABLED = true;
   static final boolean DEFAULT_KAFKA_CLIENT_PROPAGATION_ENABLED = true;

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/CiVisibilityConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/CiVisibilityConfig.java
@@ -1,0 +1,9 @@
+package datadog.trace.api.config;
+
+/** Constant with names of configuration options for CI visibility. */
+public final class CiVisibilityConfig {
+
+  public static final String CIVISIBILITY_ENABLED = "civisibility.enabled";
+
+  private CiVisibilityConfig() {}
+}

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -6,6 +6,7 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_AGENT_WRITER_TYPE;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_ANALYTICS_SAMPLE_RATE;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_APPSEC_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_AWS_PROPAGATION_ENABLED;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_CIVISIBILITY_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_CWS_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_CWS_TLS_REFRESH;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_DB_CLIENT_HOST_SPLIT_BY_INSTANCE;
@@ -74,6 +75,7 @@ import static datadog.trace.api.IdGenerationStrategy.RANDOM;
 import static datadog.trace.api.Platform.isJavaVersionAtLeast;
 import static datadog.trace.api.config.AppSecConfig.APPSEC_ENABLED;
 import static datadog.trace.api.config.AppSecConfig.APPSEC_RULES_FILE;
+import static datadog.trace.api.config.CiVisibilityConfig.CIVISIBILITY_ENABLED;
 import static datadog.trace.api.config.CwsConfig.CWS_ENABLED;
 import static datadog.trace.api.config.CwsConfig.CWS_TLS_REFRESH;
 import static datadog.trace.api.config.GeneralConfig.API_KEY;
@@ -410,6 +412,8 @@ public class Config {
 
   private final boolean appSecEnabled;
   private final String appSecRulesFile;
+
+  private final boolean ciVisibilityEnabled;
 
   private final boolean awsPropagationEnabled;
   private final boolean sqsPropagationEnabled;
@@ -853,6 +857,9 @@ public class Config {
 
     appSecEnabled = configProvider.getBoolean(APPSEC_ENABLED, DEFAULT_APPSEC_ENABLED);
     appSecRulesFile = configProvider.getString(APPSEC_RULES_FILE, null);
+
+    ciVisibilityEnabled =
+        configProvider.getBoolean(CIVISIBILITY_ENABLED, DEFAULT_CIVISIBILITY_ENABLED);
 
     jdbcPreparedStatementClassName =
         configProvider.getString(JDBC_PREPARED_STATEMENT_CLASS_NAME, "");
@@ -1351,6 +1358,10 @@ public class Config {
 
   public boolean isAppSecEnabled() {
     return appSecEnabled;
+  }
+
+  public boolean isCiVisibilityEnabled() {
+    return ciVisibilityEnabled;
   }
 
   public String getAppSecRulesFile() {


### PR DESCRIPTION
In this PR, we refactor the Instrumentation for CI Visibility (JUnit4, JUnit5, and TestNG) to use a dedicated `Instrumenter` subclass called `Instrumenter.CiVisibility`.