### PR TITLE
Clean up Scala promise instrumentation

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/AdviceUtils.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/AdviceUtils.java
@@ -19,10 +19,16 @@ public class AdviceUtils {
    */
   public static <T> AgentScope startTaskScope(
       final ContextStore<T, State> contextStore, final T task) {
-    final State state = contextStore.get(task);
+    return startTaskScope(contextStore.get(task), false);
+  }
+
+  public static AgentScope startTaskScope(State state, boolean migrated) {
     if (state != null) {
       final AgentScope.Continuation continuation = state.getAndResetContinuation();
       if (continuation != null) {
+        if (migrated) {
+          continuation.migrated();
+        }
         final AgentScope scope = continuation.activate();
         scope.setAsyncPropagation(true);
         return scope;

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/ContinuationClaim.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/ContinuationClaim.java
@@ -18,6 +18,11 @@ final class ContinuationClaim implements AgentScope.Continuation {
   }
 
   @Override
+  public void migrated() {
+    throw new IllegalStateException();
+  }
+
+  @Override
   public AgentSpan getSpan() {
     throw new IllegalStateException();
   }

--- a/dd-java-agent/instrumentation/scala-promise/scala-promise-2.10/src/main/java/datadog/trace/instrumentation/scala/concurrent/PromiseObjectInstrumentation210.java
+++ b/dd-java-agent/instrumentation/scala-promise/scala-promise-2.10/src/main/java/datadog/trace/instrumentation/scala/concurrent/PromiseObjectInstrumentation210.java
@@ -75,11 +75,6 @@ public class PromiseObjectInstrumentation210 extends Instrumenter.Tracing {
         if (next != resolved) {
           contextStore.put(next, span);
           resolved = next;
-          /*
-          The span may be escaping via the context to other threads.
-          Need to mark it for migration.
-          */
-          span.startThreadMigration();
         }
       }
     }

--- a/dd-java-agent/instrumentation/scala-promise/scala-promise-2.13/src/main/java/datadog/trace/instrumentation/scala/concurrent/PromiseObjectInstrumentation213.java
+++ b/dd-java-agent/instrumentation/scala-promise/scala-promise-2.13/src/main/java/datadog/trace/instrumentation/scala/concurrent/PromiseObjectInstrumentation213.java
@@ -75,11 +75,6 @@ public class PromiseObjectInstrumentation213 extends Instrumenter.Tracing {
         if (next != resolved) {
           contextStore.put(next, span);
           resolved = next;
-          /*
-          The span may be escaping via the context to other threads.
-          Need to mark it for migration.
-          */
-          span.startThreadMigration();
         }
       }
     }

--- a/dd-java-agent/instrumentation/scala-promise/scala-promise-2.13/src/main/java/datadog/trace/instrumentation/scala/concurrent/PromiseTransformationInstrumentation.java
+++ b/dd-java-agent/instrumentation/scala-promise/scala-promise-2.13/src/main/java/datadog/trace/instrumentation/scala/concurrent/PromiseTransformationInstrumentation.java
@@ -1,8 +1,8 @@
 package datadog.trace.instrumentation.scala.concurrent;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
+import static datadog.trace.bootstrap.instrumentation.java.concurrent.AdviceUtils.capture;
+import static datadog.trace.bootstrap.instrumentation.java.concurrent.AdviceUtils.endTaskScope;
 import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.ExcludeType.EXECUTOR;
 import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.ExcludeType.RUNNABLE;
 import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
@@ -16,7 +16,6 @@ import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.bootstrap.instrumentation.java.concurrent.AdviceUtils;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.State;
 import datadog.trace.instrumentation.scala.PromiseHelper;
@@ -78,47 +77,26 @@ public final class PromiseTransformationInstrumentation extends Instrumenter.Tra
 
   public static final class Construct {
     @Advice.OnMethodExit(suppress = Throwable.class)
-    public static <F, T> void onConstruct(@Advice.This Transformation<F, T> task, @Advice.Argument(3) int xform) {
+    public static <F, T> void onConstruct(
+        @Advice.This Transformation<F, T> task, @Advice.Argument(3) int xform) {
       // Do not trace the Noop Transformation
       if (xform == 0) {
         return;
       }
-      final AgentScope scope = activeScope();
-      if (scope != null) {
-        State state = State.FACTORY.create();
-        state.captureAndSetContinuation(scope);
-        InstrumentationContext.get(Transformation.class, State.class).put(task, state);
-        scope.span().startThreadMigration();
-      }
+      capture(InstrumentationContext.get(Transformation.class, State.class), task, true);
     }
   }
 
   public static final class Run {
     @Advice.OnMethodEnter
     public static <F, T> AgentScope before(@Advice.This Transformation<F, T> task) {
-      ContextStore<Transformation, State> store =
-          InstrumentationContext.get(Transformation.class, State.class);
-      AgentSpan capturedSpan = AdviceUtils.getCapturedSpan(store, task);
-      AgentSpan activeSpan = activeSpan();
-      if (capturedSpan != null && capturedSpan != activeSpan) {
-        // the active span is changed - signal span resume
-        capturedSpan.finishThreadMigration();
-      }
-      return AdviceUtils.startTaskScope(
-          InstrumentationContext.get(Transformation.class, State.class), task);
+      return PromiseHelper.runActivateSpan(
+          InstrumentationContext.get(Transformation.class, State.class).get(task));
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class)
     public static void after(@Advice.Enter AgentScope scope) {
-      if (null != scope) {
-        /*
-        Normally, this would be handled by `endTaskScope(scope)` - but for that to work
-        one needs to 'migrate' continuation and introducing that into the current promise
-        instrumentation is much harder than just working it around here.
-        */
-        scope.span().finishWork();
-      }
-      AdviceUtils.endTaskScope(scope);
+      endTaskScope(scope);
     }
   }
 
@@ -136,32 +114,22 @@ public final class PromiseTransformationInstrumentation extends Instrumenter.Tra
     @Advice.OnMethodEnter
     public static <F, T> void beforeExecute(
         @Advice.This Transformation<F, T> task, @Advice.Argument(value = 0) Try<T> resolved) {
-      // about to enter an ExecutionContext so capture the scope if necessary
-      // (this used to happen automatically when the RunnableInstrumentation
-      // was relied on, and happens anyway if the ExecutionContext is backed
-      // by a wrapping Executor (e.g. FJP, ScheduledThreadPoolExecutor)
+      // About to enter an ExecutionContext so capture the Scope if necessary
       ContextStore<Transformation, State> contextStore =
           InstrumentationContext.get(Transformation.class, State.class);
       State state = contextStore.get(task);
       if (PromiseHelper.completionPriority) {
-        AgentSpan capturedSpan = AdviceUtils.getCapturedSpan(contextStore, task);
-        final AgentSpan span = InstrumentationContext.get(Try.class, AgentSpan.class).get(resolved);
-
-        State oldState = state;
-        state = PromiseHelper.handleSpan(span, state);
-        if (state != oldState) {
-          contextStore.put(task, state);
-        }
+        state =
+            PromiseHelper.executeCaptureSpan(
+                InstrumentationContext.get(Try.class, AgentSpan.class),
+                resolved,
+                contextStore,
+                task,
+                state);
       }
       // If nothing else has been picked up, then try to pick up the current Scope
       if (null == state) {
-        final AgentScope scope = activeScope();
-        if (scope != null) {
-          state = State.FACTORY.create();
-          state.captureAndSetContinuation(scope);
-          contextStore.put(task, state);
-          scope.span().startThreadMigration();
-        }
+        capture(contextStore, task, true);
       }
     }
   }

--- a/dd-java-agent/instrumentation/scala-promise/scala-promise-2.13/src/main/java/datadog/trace/instrumentation/scala/concurrent/PromiseTransformationInstrumentation.java
+++ b/dd-java-agent/instrumentation/scala-promise/scala-promise-2.13/src/main/java/datadog/trace/instrumentation/scala/concurrent/PromiseTransformationInstrumentation.java
@@ -78,7 +78,11 @@ public final class PromiseTransformationInstrumentation extends Instrumenter.Tra
 
   public static final class Construct {
     @Advice.OnMethodExit(suppress = Throwable.class)
-    public static <F, T> void onConstruct(@Advice.This Transformation<F, T> task) {
+    public static <F, T> void onConstruct(@Advice.This Transformation<F, T> task, @Advice.Argument(3) int xform) {
+      // Do not trace the Noop Transformation
+      if (xform == 0) {
+        return;
+      }
       final AgentScope scope = activeScope();
       if (scope != null) {
         State state = State.FACTORY.create();

--- a/dd-java-agent/instrumentation/scala-promise/src/main/java/datadog/trace/instrumentation/scala/PromiseHelper.java
+++ b/dd-java-agent/instrumentation/scala-promise/src/main/java/datadog/trace/instrumentation/scala/PromiseHelper.java
@@ -1,11 +1,14 @@
 package datadog.trace.instrumentation.scala;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.captureSpan;
 
 import datadog.trace.api.Config;
+import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.java.concurrent.AdviceUtils;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.State;
 import java.util.Collections;
 import scala.util.Failure;
@@ -57,27 +60,70 @@ public class PromiseHelper {
       return new Failure<>(failure.exception());
     }
 
+    if (null != span) {
+      // The span may be escaping via the context to other threads.
+      // Need to mark it for migration.
+      span.startThreadMigration();
+    }
     return resolved;
   }
 
   /**
-   * Capture the {@code Span} and store or swap out the existing {@code Continuation} if any.
+   * Activate the {@code AgentScope} stored in the {@code State} for the active task, if any, and
+   * mark migration accordingly.
    *
-   * @param span the Span to capture
-   * @param state the State to update
-   * @return the state where the Continuation was stored
+   * @param state the State related to the task becoming active.
+   * @return tha active AgentScope
    */
-  public static State handleSpan(final AgentSpan span, State state) {
-    if (completionPriority && null != span) {
-      // TODO Optimization
-      // One could possibly peek at the Span in the existing Continuation and not do anything if it
-      // was the same Span
+  public static AgentScope runActivateSpan(State state) {
+    if (state == null) {
+      return null;
+    }
+    AgentSpan capturedSpan = state.getSpan();
+    if (capturedSpan != null) {
+      AgentSpan activeSpan = activeSpan();
+      if (capturedSpan != activeSpan) {
+        return AdviceUtils.startTaskScope(state, true);
+      } else {
+        state.closeContinuation();
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Transfer and capture the {@code Span} from the {@code Try} to the task, and store or swap out
+   * the existing {@code Continuation} if any.
+   *
+   * @param tryStore the ContextStore for the Try
+   * @param resolved the Try in question
+   * @param taskStore the ContextStore for the task
+   * @param task the task in question
+   * @param state the current State associated with the task
+   * @return the current or updated state
+   */
+  public static <K> State executeCaptureSpan(
+      ContextStore<Try, AgentSpan> tryStore,
+      Try<?> resolved,
+      ContextStore<K, State> taskStore,
+      K task,
+      State state) {
+    final AgentSpan span = tryStore.get(resolved);
+    if (span != null) {
+      // Check if the new Span is the same as the currently stored one
+      if (null != state && state.getSpan() == span) {
+        return state;
+      }
       AgentScope.Continuation continuation = captureSpan(span);
+      // Since the continuation was created from a Span that was marked for migration,
+      // we make sure that the continuation will be marked as migrated
+      continuation.migrated();
       AgentScope.Continuation existing = null;
       if (null != state) {
         existing = state.getAndResetContinuation();
       } else {
         state = State.FACTORY.create();
+        taskStore.put(task, state);
       }
       state.setOrCancelContinuation(continuation);
       if (null != existing) {

--- a/dd-java-agent/instrumentation/scala-promise/src/test/groovy/ScalaUnitPromiseTestBase.groovy
+++ b/dd-java-agent/instrumentation/scala-promise/src/test/groovy/ScalaUnitPromiseTestBase.groovy
@@ -103,7 +103,7 @@ abstract class ScalaUnitPromiseTestPropagation extends ScalaUnitPromiseTestBase 
     injectSysConfig("dd.trace.integration.scala_future_object.enabled", "false")
   }
 
-  def "make sure that that without the unit context instrumentation we get a parent"() {
+  def "make sure that without the unit context instrumentation we get a parent"() {
     setup:
     assumeTrue(hasUnitPromise())
 

--- a/dd-java-agent/instrumentation/scala-promise/src/test/groovy/ScalaUnitPromiseTestBase.groovy
+++ b/dd-java-agent/instrumentation/scala-promise/src/test/groovy/ScalaUnitPromiseTestBase.groovy
@@ -10,12 +10,6 @@ import static org.junit.Assume.assumeTrue
 abstract class ScalaUnitPromiseTestBase extends AgentTestRunner {
 
   @Override
-  boolean useStrictTraceWrites() {
-    // TODO fix this by making sure that spans get closed properly
-    return false
-  }
-
-  @Override
   void configurePreAgent() {
     super.configurePreAgent()
 
@@ -109,7 +103,7 @@ abstract class ScalaUnitPromiseTestPropagation extends ScalaUnitPromiseTestBase 
     injectSysConfig("dd.trace.integration.scala_future_object.enabled", "false")
   }
 
-  def "make sure that that the unit context instrumentation works"() {
+  def "make sure that that without the unit context instrumentation we get a parent"() {
     setup:
     assumeTrue(hasUnitPromise())
 
@@ -119,6 +113,14 @@ abstract class ScalaUnitPromiseTestPropagation extends ScalaUnitPromiseTestBase 
         return "f1"
       }
     })
+
+    then:
+    // Since the execution is forked before the trace is started
+    // we need to wait for the future to finish to guarantee the
+    // order of the traces that we assert against in assertTraces
+    promiseUtils.await(f1) == "f1"
+
+    when:
     def f2 = promiseUtils.apply({
       runUnderTrace("f2") {
         return "f2"
@@ -126,13 +128,12 @@ abstract class ScalaUnitPromiseTestPropagation extends ScalaUnitPromiseTestBase 
     })
 
     then:
-    // Here we sort the spans by name in assertTraces, so we don't
-    // care in which order they actually happen
-    promiseUtils.await(f1) == "f1"
     promiseUtils.await(f2) == "f2"
-    assertTraces(1) {
-      trace(2, true) {
+    assertTraces(2) {
+      trace(1) {
         basicSpan(it, "f1", initSpan)
+      }
+      trace(1) {
         basicSpan(it, "f2", initSpan)
       }
     }

--- a/dd-java-agent/instrumentation/scala-promise/src/test/scala/PromiseUtils.scala
+++ b/dd-java-agent/instrumentation/scala-promise/src/test/scala/PromiseUtils.scala
@@ -7,7 +7,8 @@ import scala.concurrent.{Await, ExecutionContext, Future, Promise}
 class PromiseUtils(implicit ec: ExecutionContext) {
   // This code is only here to ensure that we in the unit promise tests do the
   // first apply inside a trace during the initialization of the PromiseUtils,
-  // so that we initialize the unit field if it exists with a context
+  // so that we initialize the unit field if it exists with a context, and
+  // the Noop Transformation if it exists with a context.
   Await.result(Future.apply("unused"), Timeout)
 
   def newPromise[T](): Promise[T] = Promise.apply()

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
@@ -485,6 +485,11 @@ public class ContinuableScopeManager implements AgentScopeManager {
     }
 
     @Override
+    public void migrated() {
+      this.migrated = true;
+    }
+
+    @Override
     public AgentSpan getSpan() {
       return spanUnderScope;
     }
@@ -576,6 +581,11 @@ public class ContinuableScopeManager implements AgentScopeManager {
 
     @Override
     public void migrate() {
+      // This has no meaning for a concurrent continuation
+    }
+
+    @Override
+    public void migrated() {
       // This has no meaning for a concurrent continuation
     }
 

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/CustomScopeManagerTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/CustomScopeManagerTest.groovy
@@ -319,6 +319,10 @@ class TestScopeManager implements ScopeManager {
           @Override
           void migrate() {
           }
+
+          @Override
+          void migrated() {
+          }
         }
     }
 

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentScope.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentScope.java
@@ -34,6 +34,12 @@ public interface AgentScope extends TraceScope, Closeable {
      */
     void migrate();
 
+    /**
+     * Mark that the continuation was created from a span or continuation that was already marked as
+     * migrated.
+     */
+    void migrated();
+
     /** Provide access to the captured span */
     AgentSpan getSpan();
   }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -679,6 +679,9 @@ public class AgentTracer {
     public void migrate() {}
 
     @Override
+    public void migrated() {}
+
+    @Override
     public AgentSpan getSpan() {
       return NoopAgentSpan.INSTANCE;
     }


### PR DESCRIPTION
This PR fixes a Scope leak (thanks @charliegracie) and moves common code that was repeated and diverging in 2.10/2.13 into the shared `PromiseHelper`, while also removing some workarounds for profiling migration events.