### PR TITLE
Make the JFR recording max size configurable

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkController.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkController.java
@@ -23,6 +23,8 @@ import com.datadog.profiling.controller.Controller;
 import com.datadog.profiling.controller.jfr.JfpUtils;
 import com.datadog.profiling.controller.openjdk.events.AvailableProcessorCoresEvent;
 import datadog.trace.api.Config;
+import datadog.trace.api.config.ProfilingConfig;
+import datadog.trace.bootstrap.config.provider.ConfigProvider;
 import de.thetaphi.forbiddenapis.SuppressForbidden;
 import java.io.IOException;
 import java.time.Duration;
@@ -37,7 +39,6 @@ import org.slf4j.LoggerFactory;
  * messier... ;)
  */
 public final class OpenJdkController implements Controller {
-  static final int RECORDING_MAX_SIZE = 64 * 1024 * 1024; // 64 megs
   static final Duration RECORDING_MAX_AGE = Duration.ofMinutes(5);
 
   private static final Logger log = LoggerFactory.getLogger(OpenJdkController.class);
@@ -149,9 +150,16 @@ public final class OpenJdkController implements Controller {
     AvailableProcessorCoresEvent.register();
   }
 
+  int getMaxSize() {
+    return ConfigProvider.getInstance()
+        .getInteger(
+            ProfilingConfig.PROFILING_JFR_REPOSITORY_MAXSIZE,
+            ProfilingConfig.PROFILING_JFR_REPOSITORY_MAXSIZE_DEFAULT);
+  }
+
   @Override
   public OpenJdkOngoingRecording createRecording(final String recordingName) {
     return new OpenJdkOngoingRecording(
-        recordingName, recordingSettings, RECORDING_MAX_SIZE, RECORDING_MAX_AGE);
+        recordingName, recordingSettings, getMaxSize(), RECORDING_MAX_AGE);
   }
 }

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/test/java/com/datadog/profiling/controller/openjdk/OpenJdkControllerTest.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/test/java/com/datadog/profiling/controller/openjdk/OpenJdkControllerTest.java
@@ -30,7 +30,7 @@ public class OpenJdkControllerTest {
     assertTrue(data instanceof OpenJdkRecordingData);
     try (final Recording recording = ((OpenJdkRecordingData) data).getRecording()) {
       assertEquals(TEST_NAME, recording.getName());
-      assertEquals(OpenJdkController.RECORDING_MAX_SIZE, recording.getMaxSize());
+      assertEquals(controller.getMaxSize(), recording.getMaxSize());
       assertEquals(OpenJdkController.RECORDING_MAX_AGE, recording.getMaxAge());
     }
   }

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
@@ -75,6 +75,10 @@ public final class ProfilingConfig {
       "profiling.endpoint.collection.enabled";
   public static final boolean PROFILING_ENDPOINT_COLLECTION_ENABLED_DEFAULT = true;
 
+  public static final String PROFILING_JFR_REPOSITORY_MAXSIZE = "profiling.jfr.repository.maxsize";
+  public static final int PROFILING_JFR_REPOSITORY_MAXSIZE_DEFAULT =
+      64 * 1024 * 1024; // 64MB default
+
   // Not intended for production use
   public static final String PROFILING_AGENTLESS = "profiling.agentless";
 


### PR DESCRIPTION
With unlimited checkpoints the raw JFR recording can grow significantly and this leads to truncated profiling data which can be particularly misleading.
The PR adds the possibility to change the maximum recording size while keeping the currently used value as the default (eg. nothing will change unless a user will override the default)