### PR TITLE
Limit spring-kafka version used in latestDepTest to 2.7.x

### DIFF
--- a/dd-java-agent/instrumentation/kafka-streams-0.11/kafka-streams-0.11.gradle
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/kafka-streams-0.11.gradle
@@ -3,6 +3,7 @@ muzzle {
     group = "org.apache.kafka"
     module = "kafka-streams"
     versions = "[0.11.0.0,3)"
+    // TODO shouldn't there be an assertInverse here, or do we support 3.x?
   }
 }
 
@@ -33,7 +34,8 @@ dependencies {
   latestDepTestImplementation group: 'org.apache.kafka', name: 'kafka_2.13', version: '2.+'
   latestDepTestImplementation group: 'org.apache.kafka', name: 'kafka-clients', version: '2.+'
   latestDepTestImplementation group: 'org.apache.kafka', name: 'kafka-streams', version: '2.+'
-  latestDepTestImplementation group: 'org.springframework.kafka', name: 'spring-kafka', version: '2.+'
-  latestDepTestImplementation group: 'org.springframework.kafka', name: 'spring-kafka-test', version: '2.+'
+  // spring-kafka 2.8.x pulls in kafka-clients/streams 3.x which behaves differently
+  latestDepTestImplementation group: 'org.springframework.kafka', name: 'spring-kafka', version: '2.7+'
+  latestDepTestImplementation group: 'org.springframework.kafka', name: 'spring-kafka-test', version: '2.7+'
   latestDepTestImplementation group: 'org.assertj', name: 'assertj-core', version: '3.+'
 }


### PR DESCRIPTION
New release of `spring-kafka` that pulls in kafka `3.x` causes latestDepTest to start failing (They're on 2.x)