### PR TITLE
Don't log that Oracle JDK 8 was found and try to start Profiler on JDK 7

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
@@ -1,6 +1,7 @@
 package datadog.trace.bootstrap;
 
 import static datadog.trace.api.Platform.isJavaVersionAtLeast;
+import static datadog.trace.api.Platform.isJavaVersionBetween;
 import static datadog.trace.bootstrap.Library.WILDFLY;
 import static datadog.trace.bootstrap.Library.detectLibraries;
 import static datadog.trace.util.AgentThreadFactory.AgentThread.JMX_STARTUP;
@@ -256,7 +257,7 @@ public class Agent {
   }
 
   private static boolean isOracleJDK8() {
-    return !isJavaVersionAtLeast(9)
+    return isJavaVersionBetween(8, 9)
         && System.getProperty("java.vendor").contains("Oracle")
         && !System.getProperty("java.runtime.name").contains("OpenJDK");
   }

--- a/internal-api/src/test/groovy/datadog/trace/api/PlatformTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/PlatformTest.groovy
@@ -29,6 +29,18 @@ class PlatformTest extends DDSpecification {
     major == javaVersion.major
     minor == javaVersion.minor
     update == javaVersion.update
+    javaVersion.is(major)
+    javaVersion.is(major, minor)
+    javaVersion.is(major, minor, update)
+    javaVersion.isAtLeast(major, minor, update)
+    javaVersion.isBetween(major, minor, update, Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE)
+    !javaVersion.isBetween(major, minor, update, major, minor, update)
+    !javaVersion.isBetween(major, minor, update, major - 1, 0, 0)
+    !javaVersion.isBetween(major, minor, update, major, minor -1, 0)
+    !javaVersion.isBetween(major, minor, update, major, minor, update - 1)
+    javaVersion.isBetween(major, minor, update, major + 1, 0, 0)
+    javaVersion.isBetween(major, minor, update, major, minor + 1, 0)
+    javaVersion.isBetween(major, minor, update, major, minor, update + 1)
 
     where:
     version     | major | minor | update


### PR DESCRIPTION
If running with the profiler enabled on Oracle JDK 7, we log that we found Oracle JDK 8.