### PR TITLE
[CIAPP] Ensure both the tracer and instrumentations are installed if `dd.civisibility.enabled` is `true`

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
@@ -53,13 +53,14 @@ public class AgentInstaller {
 
   public static void installBytebuddyAgent(final Instrumentation inst) {
     /*
-     * ByteBuddy agent is used by tracing, profiling and appsec and since they can
+     * ByteBuddy agent is used by tracing, profiling, appsec and civisibility and since they can
      * be enabled independently we need to install the agent when either of them
      * is active.
      */
     if (Config.get().isTraceEnabled()
         || Config.get().isProfilingEnabled()
-        || Config.get().isAppSecEnabled()) {
+        || Config.get().isAppSecEnabled()
+        || Config.get().isCiVisibilityEnabled()) {
       installBytebuddyAgent(inst, false, new AgentBuilder.Listener[0]);
       if (DEBUG) {
         log.debug("Class instrumentation installed");

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/TracerInstaller.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/TracerInstaller.java
@@ -13,7 +13,7 @@ public class TracerInstaller {
   /** Register a global tracer if no global tracer is already registered. */
   public static synchronized void installGlobalTracer(
       SharedCommunicationObjects sharedCommunicationObjects) {
-    if (Config.get().isTraceEnabled()) {
+    if (Config.get().isTraceEnabled() || Config.get().isCiVisibilityEnabled()) {
       if (!(GlobalTracer.get() instanceof CoreTracer)) {
         installGlobalTracer(
             CoreTracer.builder().sharedCommunicationObjects(sharedCommunicationObjects).build());


### PR DESCRIPTION
This PR allows installing tracer and instrumentations if `dd.civisibility.enabled` is `true`.

Context: CI Visibility also uses the tracer and instrumentations to provide its features. As we can disable `tracing` and enable `civisibility` manually, we need to add these checks explicitly to continue installing the tracer and instrumentations if `tracing` has been disabled.