### PR TITLE
[CIAPP] Avoid sending non-CIVisibility traces if `CIVisibility` mode is enabled.

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/civisibility/CiVisibilityTraceInterceptor.java
+++ b/dd-trace-core/src/main/java/datadog/trace/civisibility/CiVisibilityTraceInterceptor.java
@@ -1,0 +1,47 @@
+package datadog.trace.civisibility;
+
+import datadog.trace.api.interceptor.MutableSpan;
+import datadog.trace.api.interceptor.TraceInterceptor;
+import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
+import datadog.trace.core.DDSpan;
+import java.util.Collection;
+import java.util.Collections;
+
+public class CiVisibilityTraceInterceptor implements TraceInterceptor {
+
+  public static final CiVisibilityTraceInterceptor INSTANCE = new CiVisibilityTraceInterceptor();
+
+  static final String TEST_TYPE = "test";
+  static final UTF8BytesString CIAPP_TEST_ORIGIN = UTF8BytesString.create("ciapp-test");
+
+  @Override
+  public Collection<? extends MutableSpan> onTraceComplete(
+      Collection<? extends MutableSpan> trace) {
+    if (trace.isEmpty()) {
+      return trace;
+    }
+
+    final DDSpan firstSpan = (DDSpan) trace.iterator().next();
+    final DDSpan localRootSpan = firstSpan.getLocalRootSpan();
+
+    final DDSpan spanToCheck = null == localRootSpan ? firstSpan : localRootSpan;
+
+    // If root span does not have type == "test", we drop the full trace.
+    if (!TEST_TYPE.contentEquals(spanToCheck.getType())) {
+      return Collections.emptyList();
+    }
+
+    // If the trace belongs to a "test", we need to set the origin of the all spans of the trace to
+    // `ciapp-test`.
+    for (MutableSpan span : trace) {
+      ((DDSpan) span).context().setOrigin(CIAPP_TEST_ORIGIN);
+    }
+
+    return trace;
+  }
+
+  @Override
+  public int priority() {
+    return 0;
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -30,6 +30,7 @@ import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.bootstrap.instrumentation.api.ScopeSource;
 import datadog.trace.bootstrap.instrumentation.api.TagContext;
+import datadog.trace.civisibility.CiVisibilityTraceInterceptor;
 import datadog.trace.common.metrics.MetricsAggregator;
 import datadog.trace.common.sampling.PrioritySampler;
 import datadog.trace.common.sampling.Sampler;
@@ -466,6 +467,10 @@ public class CoreTracer implements AgentTracer.TracerAPI {
 
     this.tagInterceptor =
         null == tagInterceptor ? new TagInterceptor(new RuleFlags(config)) : tagInterceptor;
+
+    if (config.isCiVisibilityEnabled()) {
+      addTraceInterceptor(CiVisibilityTraceInterceptor.INSTANCE);
+    }
 
     this.instrumentationGateway = instrumentationGateway;
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/civisibility/CiVisibilityTraceInterceptorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/civisibility/CiVisibilityTraceInterceptorTest.groovy
@@ -1,0 +1,40 @@
+package datadog.trace.civisibility
+
+import datadog.trace.common.writer.ListWriter
+import datadog.trace.core.test.DDCoreSpecification
+import spock.lang.Timeout
+
+@Timeout(10)
+class CiVisibilityTraceInterceptorTest extends DDCoreSpecification {
+
+  def writer = new ListWriter()
+  def tracer = tracerBuilder().writer(writer).build()
+
+  def cleanup() {
+    tracer?.close()
+  }
+
+  def "discard a trace that does not come from a test"() {
+    tracer.addTraceInterceptor(CiVisibilityTraceInterceptor.INSTANCE)
+    tracer.buildSpan("sample-span").start().finish()
+
+    expect:
+    writer.size() == 0
+  }
+
+  def "add ciapp origin the context origin to all spans"() {
+    setup:
+    tracer.addTraceInterceptor(CiVisibilityTraceInterceptor.INSTANCE)
+
+    tracer.buildSpan("sample-span").withSpanType(CiVisibilityTraceInterceptor.TEST_TYPE).start().finish()
+    writer.waitForTraces(1)
+
+    expect:
+    def trace = writer.firstTrace()
+    trace.size() == 1
+
+    def span = trace[0]
+
+    span.context().origin == CiVisibilityTraceInterceptor.CIAPP_TEST_ORIGIN
+  }
+}

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/TraceInterceptorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/TraceInterceptorTest.groovy
@@ -94,7 +94,7 @@ class TraceInterceptorTest extends DDCoreSpecification {
         }
       })
     tracer.buildSpan("test " + score).start().finish()
-    if (score == 0) {
+    if (score == TestInterceptor.priority) {
       // the interceptor didn't get added, so latch will never be released.
       writer.waitForTraces(1)
     } else {
@@ -102,15 +102,15 @@ class TraceInterceptorTest extends DDCoreSpecification {
     }
 
     expect:
-    tracer.interceptors.size() == Math.abs(score) + 1
-    (called.get()) == (score != 0)
-    (writer == []) == (score != 0)
+    tracer.interceptors.size() == expectedSize
+    (called.get()) == (score != TestInterceptor.priority)
+    (writer == []) == (score != TestInterceptor.priority)
 
     where:
-    score | _
-    -1    | _
-    0     | _ // This conflicts with TestInterceptor, so it won't be added.
-    1     | _
+    score                         | expectedSize| _
+    TestInterceptor.priority-1    |            2| _
+    TestInterceptor.priority      |            1| _ // This conflicts with TestInterceptor, so it won't be added.
+    TestInterceptor.priority+1    |            2| _
   }
 
   def "interceptor can modify a span"() {

--- a/dd-trace-core/src/test/java/datadog/trace/TestInterceptor.java
+++ b/dd-trace-core/src/test/java/datadog/trace/TestInterceptor.java
@@ -7,7 +7,8 @@ import java.util.Collection;
 
 @AutoService(TraceInterceptor.class)
 public class TestInterceptor implements TraceInterceptor {
-  public volatile int priority = 0;
+  // We set a high priority to avoid competing with real TraceInterceptors.
+  public static volatile int priority = 999;
 
   @Override
   public Collection<? extends MutableSpan> onTraceComplete(


### PR DESCRIPTION
This PR adds a new `CiVisibilityTraceInterceptor` that applies the following changes:
* If the root span type is not `test`,  the entire trace is dropped.
* If the root span type is `test`, we ensure all spans have the CI Visibility origin metadata.

Context:
The `CI Visibility` mode can use the same integrations used by the `Tracing` mode to have the same visibility in end-to-end tests. That means a test span potentially can have HTTP, SQL, Kafka, etc. children spans. This fact may have implications with Billing. 

We want to ensure that all generated traces are billed by CI App and not by APM if CI Visibility is enabled.




