### PR TITLE
[AppSec] Check that all IG callbacks are called

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
@@ -1,5 +1,6 @@
 package datadog.trace.bootstrap.instrumentation.decorator;
 
+import static datadog.trace.api.cache.RadixTreeCache.UNSET_PORT;
 import static datadog.trace.api.cache.RadixTreeCache.UNSET_STATUS;
 import static datadog.trace.api.gateway.Events.EVENTS;
 import static datadog.trace.bootstrap.instrumentation.decorator.http.HttpResourceDecorator.HTTP_RESOURCE_DECORATOR;
@@ -296,7 +297,7 @@ public abstract class HttpServerDecorator<REQUEST, CONNECTION, RESPONSE, CARRIER
   private Flow<Void> callIGCallbackSocketAddress(
       @Nonnull final AgentSpan span, @Nonnull final String ip, final int port) {
     CallbackProvider cbp = tracer().instrumentationGateway();
-    if (cbp == null) {
+    if (cbp == null || (ip == null && port == UNSET_PORT)) {
       return Flow.ResultFlow.empty();
     }
     RequestContext<Object> ctx = span.getRequestContext();

--- a/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/main/java/datadog/trace/instrumentation/grizzlyhttp232/GrizzlyDecorator.java
+++ b/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/main/java/datadog/trace/instrumentation/grizzlyhttp232/GrizzlyDecorator.java
@@ -79,7 +79,10 @@ public class GrizzlyDecorator
   public static void onHttpServerFilterPrepareResponseExit(
       FilterChainContext ctx, HttpResponsePacket responsePacket) {
     AgentSpan span = (AgentSpan) ctx.getAttributes().getAttribute(DD_SPAN_ATTRIBUTE);
-    span.finish();
+    if (null != span) {
+      DECORATE.beforeFinish(span);
+      span.finish();
+    }
     ctx.getAttributes().removeAttribute(DD_SPAN_ATTRIBUTE);
     ctx.getAttributes().removeAttribute(DD_RESPONSE_ATTRIBUTE);
   }

--- a/dd-java-agent/instrumentation/jetty-7.0/src/main/java/datadog/trace/instrumentation/jetty70/JettyServerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-7.0/src/main/java/datadog/trace/instrumentation/jetty70/JettyServerInstrumentation.java
@@ -135,6 +135,7 @@ public final class JettyServerInstrumentation extends Instrumenter.Tracing {
         DECORATE.onResponse(span, channel);
         // span could have been originated on a different thread and migrated
         span.finishThreadMigration();
+        DECORATE.beforeFinish(span);
         span.finish();
       }
     }

--- a/dd-java-agent/instrumentation/spray-1.3/src/main/scala/datadog/trace/instrumentation/spray/SprayHelper.scala
+++ b/dd-java-agent/instrumentation/spray-1.3/src/main/scala/datadog/trace/instrumentation/spray/SprayHelper.scala
@@ -20,6 +20,7 @@ object SprayHelper {
         case throwable: Throwable   => DECORATE.onError(span, throwable)
         case x                      =>
       }
+      DECORATE.beforeFinish(span)
       span.finish()
       message
     })

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/utils/TraceUtils.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/utils/TraceUtils.groovy
@@ -89,20 +89,20 @@ class TraceUtils {
     DECORATOR.onError(span, e)
   }
 
-  static basicSpan(TraceAssert trace, String spanName, Object parentSpan = null, Throwable exception = null) {
-    basicSpan(trace, spanName, spanName, parentSpan, exception)
+  static basicSpan(TraceAssert trace, String spanName, Object parentSpan = null, Throwable exception = null, Map<String, Serializable> extraTags = [:]) {
+    basicSpan(trace, spanName, spanName, parentSpan, exception, extraTags)
   }
 
-  static basicSpan(TraceAssert trace, int index, String spanName, Object parentSpan = null, Throwable exception = null) {
-    basicSpan(trace, index, spanName, spanName, parentSpan, exception)
+  static basicSpan(TraceAssert trace, int index, String spanName, Object parentSpan = null, Throwable exception = null, Map<String, Serializable> extraTags = [:]) {
+    basicSpan(trace, index, spanName, spanName, parentSpan, exception, extraTags)
   }
 
-  static basicSpan(TraceAssert trace, String operation, String resource, Object parentSpan = null, Throwable exception = null) {
+  static basicSpan(TraceAssert trace, String operation, String resource, Object parentSpan = null, Throwable exception = null, Map<String, Serializable> extraTags = [:]) {
     int index = trace.nextSpanId()
-    basicSpan(trace, index, operation, resource, parentSpan, exception)
+    basicSpan(trace, index, operation, resource, parentSpan, exception, extraTags)
   }
 
-  static basicSpan(TraceAssert trace, int index, String operation, String resource, Object parentSpan = null, Throwable exception = null) {
+  static basicSpan(TraceAssert trace, int index, String operation, String resource, Object parentSpan = null, Throwable exception = null, Map<String, Serializable> extraTags = [:]) {
     trace.span(index) {
       if (parentSpan == null) {
         parent()
@@ -118,6 +118,7 @@ class TraceUtils {
           errorTags(exception.class, exception.message)
         }
         defaultTags()
+        addTags(extraTags)
       }
     }
   }


### PR DESCRIPTION
This is to ensure that every web server that tracing supports also reports all data to AppSec. A few of the instrumentations didn't call `DECORATOR.beforeFinish`, and have now been fixed.