### PR TITLE
Switch to profiling V2.4 format uploads

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-uploader/profiling-uploader.gradle
+++ b/dd-java-agent/agent-profiling/profiling-uploader/profiling-uploader.gradle
@@ -37,6 +37,8 @@ dependencies {
   testImplementation project(':dd-java-agent:agent-profiling:profiling-testing')
   testImplementation deps.mockito
   testImplementation group: 'com.squareup.okhttp3', name: 'mockwebserver', version: versions.okhttp
+
+  testImplementation(group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.9.10')
 }
 
 /* We use Java8 features, but there is no code needing JFR libraries */

--- a/dd-java-agent/agent-profiling/profiling-uploader/src/main/java/com/datadog/profiling/uploader/ProfileUploader.java
+++ b/dd-java-agent/agent-profiling/profiling-uploader/src/main/java/com/datadog/profiling/uploader/ProfileUploader.java
@@ -196,7 +196,7 @@ public final class ProfileUploader {
     }
     tags = tagsToList(tagsMap);
     // Comma separated tags string for V2.4 format
-    tagsV2_4 = tags.stream().collect(Collectors.joining(","));
+    tagsV2_4 = String.join(",", tags);
 
     // This is the same thing OkHttp Dispatcher is doing except thread naming and daemonization
     okHttpExecutorService =

--- a/dd-java-agent/agent-profiling/profiling-uploader/src/main/java/com/datadog/profiling/uploader/ProfileUploader.java
+++ b/dd-java-agent/agent-profiling/profiling-uploader/src/main/java/com/datadog/profiling/uploader/ProfileUploader.java
@@ -142,6 +142,7 @@ public final class ProfileUploader {
   private final List<String> tags;
   private final CompressionType compressionType;
   private final boolean useV2_4Format;
+  private final String tagsV2_4;
 
   public ProfileUploader(final Config config, final ConfigProvider configProvider)
       throws IOException {
@@ -194,6 +195,8 @@ public final class ProfileUploader {
       tagsMap.put(PidHelper.PID_TAG, PidHelper.PID.toString());
     }
     tags = tagsToList(tagsMap);
+    // Comma separated tags string for V2.4 format
+    tagsV2_4 = tags.stream().collect(Collectors.joining(","));
 
     // This is the same thing OkHttp Dispatcher is doing except thread naming and daemonization
     okHttpExecutorService =
@@ -320,7 +323,7 @@ public final class ProfileUploader {
     StringBuilder os = new StringBuilder();
     os.append("{");
     os.append("\"attachments\":[\"" + V4_ATTACHMENT_FILENAME + "\"],");
-    os.append("\"tags_profiler\":\"" + tags.stream().collect(Collectors.joining(",")) + "\",");
+    os.append("\"tags_profiler\":\"" + tagsV2_4 + "\",");
     os.append("\"" + V4_PROFILE_START_PARAM + "\":\"" + data.getStart() + "\",");
     os.append("\"" + V4_PROFILE_END_PARAM + "\":\"" + data.getEnd() + "\",");
     os.append("\"family\":\"" + V4_FAMILY + "\",");

--- a/dd-java-agent/agent-profiling/profiling-uploader/src/main/java/com/datadog/profiling/uploader/ProfileUploader.java
+++ b/dd-java-agent/agent-profiling/profiling-uploader/src/main/java/com/datadog/profiling/uploader/ProfileUploader.java
@@ -163,8 +163,7 @@ public final class ProfileUploader {
       final ConfigProvider configProvider,
       final IOLogger ioLogger,
       final String containerId,
-      final int terminationTimeout)
-      throws IOException {
+      final int terminationTimeout) {
     url = config.getFinalProfilingUrl();
     apiKey = config.getApiKey();
     agentless = config.isProfilingAgentless();

--- a/dd-java-agent/agent-profiling/profiling-uploader/src/test/java/com/datadog/profiling/uploader/ProfileUploaderTest.java
+++ b/dd-java-agent/agent-profiling/profiling-uploader/src/test/java/com/datadog/profiling/uploader/ProfileUploaderTest.java
@@ -15,8 +15,8 @@
  */
 package com.datadog.profiling.uploader;
 
-import static datadog.trace.api.config.ProfilingConfig.DEFAULT_PROFILING_FORMAT_V4_ENABLED;
-import static datadog.trace.api.config.ProfilingConfig.PROFILING_FORMAT_V4_ENABLED;
+import static datadog.trace.api.config.ProfilingConfig.DEFAULT_PROFILING_FORMAT_V2_4_ENABLED;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_FORMAT_V2_4_ENABLED;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -153,7 +153,7 @@ public class ProfileUploaderTest {
     when(config.getMergedProfilingTags()).thenReturn(TAGS);
     when(config.getProfilingUploadTimeout()).thenReturn((int) REQUEST_TIMEOUT.getSeconds());
     when(configProvider.getBoolean(
-            eq(PROFILING_FORMAT_V4_ENABLED), eq(DEFAULT_PROFILING_FORMAT_V4_ENABLED)))
+            eq(PROFILING_FORMAT_V2_4_ENABLED), eq(DEFAULT_PROFILING_FORMAT_V2_4_ENABLED)))
         .thenReturn(false);
 
     uploader =
@@ -180,7 +180,7 @@ public class ProfileUploaderTest {
     // Given
     when(config.getProfilingUploadTimeout()).thenReturn(500000);
     when(configProvider.getBoolean(
-            eq(PROFILING_FORMAT_V4_ENABLED), eq(DEFAULT_PROFILING_FORMAT_V4_ENABLED)))
+            eq(PROFILING_FORMAT_V2_4_ENABLED), eq(DEFAULT_PROFILING_FORMAT_V2_4_ENABLED)))
         .thenReturn(true);
 
     // When

--- a/dd-java-agent/agent-profiling/src/main/java/com/datadog/profiling/agent/ProfilingAgent.java
+++ b/dd-java-agent/agent-profiling/src/main/java/com/datadog/profiling/agent/ProfilingAgent.java
@@ -9,6 +9,7 @@ import com.datadog.profiling.controller.ProfilingSystem;
 import com.datadog.profiling.controller.UnsupportedEnvironmentException;
 import com.datadog.profiling.uploader.ProfileUploader;
 import datadog.trace.api.Config;
+import datadog.trace.bootstrap.config.provider.ConfigProvider;
 import java.io.IOException;
 import java.lang.ref.WeakReference;
 import java.time.Duration;
@@ -52,8 +53,9 @@ public class ProfilingAgent {
 
       try {
         final Controller controller = ControllerFactory.createController(config);
+        final ConfigProvider configProvider = ConfigProvider.getInstance();
 
-        final ProfileUploader uploader = new ProfileUploader(config);
+        final ProfileUploader uploader = new ProfileUploader(config, configProvider);
 
         final Duration startupDelay = Duration.ofSeconds(config.getProfilingStartDelay());
         final Duration uploadPeriod = Duration.ofSeconds(config.getProfilingUploadPeriod());

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -74,6 +74,7 @@ public final class ConfigDefaults {
   static final boolean DEFAULT_PROFILING_AGENTLESS = false;
   static final boolean DEFAULT_PROFILING_LEGACY_TRACING_INTEGRATION = true;
   static final boolean DEFAULT_PROFILING_UPLOAD_SUMMARY_ON_413 = false;
+  static final boolean DEFAULT_PROFILING_FORMAT_V4_ENABLED = false;
 
   static final boolean DEFAULT_APPSEC_ENABLED = false;
 

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -74,7 +74,6 @@ public final class ConfigDefaults {
   static final boolean DEFAULT_PROFILING_AGENTLESS = false;
   static final boolean DEFAULT_PROFILING_LEGACY_TRACING_INTEGRATION = true;
   static final boolean DEFAULT_PROFILING_UPLOAD_SUMMARY_ON_413 = false;
-  static final boolean DEFAULT_PROFILING_FORMAT_V4_ENABLED = false;
 
   static final boolean DEFAULT_APPSEC_ENABLED = false;
 

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
@@ -86,6 +86,7 @@ public final class ProfilingConfig {
   public static final String PROFILING_AGENTLESS = "profiling.agentless";
 
   public static final String PROFILING_UPLOAD_SUMMARY_ON_413 = "profiling.upload.summary-on-413";
+  public static final String PROFILING_FORMAT_V4_ENABLED = "profiling.format.v4.enabled";
 
   private ProfilingConfig() {}
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
@@ -86,9 +86,9 @@ public final class ProfilingConfig {
   public static final String PROFILING_AGENTLESS = "profiling.agentless";
 
   public static final String PROFILING_UPLOAD_SUMMARY_ON_413 = "profiling.upload.summary-on-413";
-  public static final String PROFILING_FORMAT_V4_ENABLED = "profiling.format.v4.enabled";
+  public static final String PROFILING_FORMAT_V2_4_ENABLED = "profiling.format.v4.enabled";
 
-  public static final boolean DEFAULT_PROFILING_FORMAT_V4_ENABLED = false;
+  public static final boolean DEFAULT_PROFILING_FORMAT_V2_4_ENABLED = false;
 
   private ProfilingConfig() {}
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
@@ -88,5 +88,7 @@ public final class ProfilingConfig {
   public static final String PROFILING_UPLOAD_SUMMARY_ON_413 = "profiling.upload.summary-on-413";
   public static final String PROFILING_FORMAT_V4_ENABLED = "profiling.format.v4.enabled";
 
+  public static final boolean DEFAULT_PROFILING_FORMAT_V4_ENABLED = false;
+
   private ProfilingConfig() {}
 }

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -34,6 +34,7 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_EXCEPTION_SAMPLE_LIMIT;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_FORMAT_V4_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_HEAP_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_LEGACY_TRACING_INTEGRATION;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_PROXY_PORT;
@@ -129,6 +130,7 @@ import static datadog.trace.api.config.ProfilingConfig.PROFILING_EXCEPTION_HISTO
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_EXCEPTION_SAMPLE_LIMIT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_EXCLUDE_AGENT_THREADS;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_FORMAT_V4_ENABLED;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_HEAP_ENABLED;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_HOTSPOTS_ENABLED;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_LEGACY_TRACING_INTEGRATION;
@@ -413,6 +415,7 @@ public class Config {
   private final boolean profilingExcludeAgentThreads;
   private final boolean profilingHotspotsEnabled;
   private final boolean profilingUploadSummaryOn413Enabled;
+  private final boolean profilingFormatV4Enabled;
 
   private final boolean appSecEnabled;
   private final String appSecRulesFile;
@@ -863,6 +866,9 @@ public class Config {
     profilingUploadSummaryOn413Enabled =
         configProvider.getBoolean(
             PROFILING_UPLOAD_SUMMARY_ON_413, DEFAULT_PROFILING_UPLOAD_SUMMARY_ON_413);
+
+    profilingFormatV4Enabled =
+        configProvider.getBoolean(PROFILING_FORMAT_V4_ENABLED, DEFAULT_PROFILING_FORMAT_V4_ENABLED);
 
     appSecEnabled = configProvider.getBoolean(APPSEC_ENABLED, DEFAULT_APPSEC_ENABLED);
     appSecRulesFile = configProvider.getString(APPSEC_RULES_FILE, null);
@@ -1367,6 +1373,10 @@ public class Config {
 
   public boolean isProfilingUploadSummaryOn413Enabled() {
     return profilingUploadSummaryOn413Enabled;
+  }
+
+  public boolean isProfilingFormatV4Enabled() {
+    return profilingFormatV4Enabled;
   }
 
   public boolean isProfilingLegacyTracingIntegrationEnabled() {

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -34,7 +34,6 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_EXCEPTION_SAMPLE_LIMIT;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_FORMAT_V4_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_HEAP_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_LEGACY_TRACING_INTEGRATION;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PROFILING_PROXY_PORT;
@@ -119,6 +118,7 @@ import static datadog.trace.api.config.JmxFetchConfig.JMX_FETCH_START_DELAY;
 import static datadog.trace.api.config.JmxFetchConfig.JMX_FETCH_STATSD_HOST;
 import static datadog.trace.api.config.JmxFetchConfig.JMX_FETCH_STATSD_PORT;
 import static datadog.trace.api.config.JmxFetchConfig.JMX_TAGS;
+import static datadog.trace.api.config.ProfilingConfig.DEFAULT_PROFILING_FORMAT_V4_ENABLED;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_AGENTLESS;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_ALLOCATION_ENABLED;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_API_KEY_FILE_OLD;
@@ -415,7 +415,6 @@ public class Config {
   private final boolean profilingExcludeAgentThreads;
   private final boolean profilingHotspotsEnabled;
   private final boolean profilingUploadSummaryOn413Enabled;
-  private final boolean profilingFormatV4Enabled;
 
   private final boolean appSecEnabled;
   private final String appSecRulesFile;
@@ -866,9 +865,6 @@ public class Config {
     profilingUploadSummaryOn413Enabled =
         configProvider.getBoolean(
             PROFILING_UPLOAD_SUMMARY_ON_413, DEFAULT_PROFILING_UPLOAD_SUMMARY_ON_413);
-
-    profilingFormatV4Enabled =
-        configProvider.getBoolean(PROFILING_FORMAT_V4_ENABLED, DEFAULT_PROFILING_FORMAT_V4_ENABLED);
 
     appSecEnabled = configProvider.getBoolean(APPSEC_ENABLED, DEFAULT_APPSEC_ENABLED);
     appSecRulesFile = configProvider.getString(APPSEC_RULES_FILE, null);
@@ -1375,10 +1371,6 @@ public class Config {
     return profilingUploadSummaryOn413Enabled;
   }
 
-  public boolean isProfilingFormatV4Enabled() {
-    return profilingFormatV4Enabled;
-  }
-
   public boolean isProfilingLegacyTracingIntegrationEnabled() {
     return profilingLegacyTracingIntegrationEnabled;
   }
@@ -1790,7 +1782,8 @@ public class Config {
       return profilingUrl;
     } else if (profilingAgentless) {
       // when agentless profiling is turned on we send directly to our intake
-      if (isProfilingFormatV4Enabled()) {
+      if (configProvider.getBoolean(
+          PROFILING_FORMAT_V4_ENABLED, DEFAULT_PROFILING_FORMAT_V4_ENABLED)) {
         return "https://intake.profile." + site + "/api/v2/profile";
       }
       return "https://intake.profile." + site + "/v1/input";

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -118,7 +118,7 @@ import static datadog.trace.api.config.JmxFetchConfig.JMX_FETCH_START_DELAY;
 import static datadog.trace.api.config.JmxFetchConfig.JMX_FETCH_STATSD_HOST;
 import static datadog.trace.api.config.JmxFetchConfig.JMX_FETCH_STATSD_PORT;
 import static datadog.trace.api.config.JmxFetchConfig.JMX_TAGS;
-import static datadog.trace.api.config.ProfilingConfig.DEFAULT_PROFILING_FORMAT_V4_ENABLED;
+import static datadog.trace.api.config.ProfilingConfig.DEFAULT_PROFILING_FORMAT_V2_4_ENABLED;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_AGENTLESS;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_ALLOCATION_ENABLED;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_API_KEY_FILE_OLD;
@@ -130,7 +130,7 @@ import static datadog.trace.api.config.ProfilingConfig.PROFILING_EXCEPTION_HISTO
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_EXCEPTION_SAMPLE_LIMIT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_EXCLUDE_AGENT_THREADS;
-import static datadog.trace.api.config.ProfilingConfig.PROFILING_FORMAT_V4_ENABLED;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_FORMAT_V2_4_ENABLED;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_HEAP_ENABLED;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_HOTSPOTS_ENABLED;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_LEGACY_TRACING_INTEGRATION;
@@ -1783,7 +1783,7 @@ public class Config {
     } else if (profilingAgentless) {
       // when agentless profiling is turned on we send directly to our intake
       if (configProvider.getBoolean(
-          PROFILING_FORMAT_V4_ENABLED, DEFAULT_PROFILING_FORMAT_V4_ENABLED)) {
+          PROFILING_FORMAT_V2_4_ENABLED, DEFAULT_PROFILING_FORMAT_V2_4_ENABLED)) {
         return "https://intake.profile." + site + "/api/v2/profile";
       }
       return "https://intake.profile." + site + "/v1/input";

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -1790,6 +1790,9 @@ public class Config {
       return profilingUrl;
     } else if (profilingAgentless) {
       // when agentless profiling is turned on we send directly to our intake
+      if (isProfilingFormatV4Enabled()) {
+        return "https://intake.profile." + site + "/api/v2/profile";
+      }
       return "https://intake.profile." + site + "/v1/input";
     } else {
       // when profilingUrl and agentless are not set we send to the dd trace agent running locally


### PR DESCRIPTION
This PR add supports for the V2.4 format uploads. It allows to send requests compliant with a new format used by Datadog profiling intake.

The new format can be activated by enabling `-Ddd.profiling.format.v4.enabled=true` flag, the new format is disabled by default.

The new format will supersede the current one for which the support will be removed afterwards.