### PR TITLE
Fix 'Forwarded' header extraction

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/B3HttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/B3HttpCodec.java
@@ -113,16 +113,28 @@ class B3HttpCodec {
       // overwrite those
       if (B3_KEY.equals(key)) {
         classification = B3_ID;
-      } else if (Character.toLowerCase(key.charAt(0)) == 'x') {
-        if ((traceId == null || traceId == DDId.ZERO) && TRACE_ID_KEY.equalsIgnoreCase(key)) {
-          classification = TRACE_ID;
-        } else if ((spanId == null || spanId == DDId.ZERO) && SPAN_ID_KEY.equalsIgnoreCase(key)) {
-          classification = SPAN_ID;
-        } else if (samplingPriority == defaultSamplingPriority()
-            && SAMPLING_PRIORITY_KEY.equalsIgnoreCase(key)) {
-          classification = SAMPLING_PRIORITY;
-        } else if (handledForwarding(key, value)) {
-          return true;
+      } else {
+        char first = Character.toLowerCase(key.charAt(0));
+        switch (first) {
+          case 'x':
+            if ((traceId == null || traceId == DDId.ZERO) && TRACE_ID_KEY.equalsIgnoreCase(key)) {
+              classification = TRACE_ID;
+            } else if ((spanId == null || spanId == DDId.ZERO)
+                && SPAN_ID_KEY.equalsIgnoreCase(key)) {
+              classification = SPAN_ID;
+            } else if (samplingPriority == defaultSamplingPriority()
+                && SAMPLING_PRIORITY_KEY.equalsIgnoreCase(key)) {
+              classification = SAMPLING_PRIORITY;
+            } else if (handledXForwarding(key, value)) {
+              return true;
+            }
+            break;
+          case 'f':
+            if (handledForwarding(key, value)) {
+              return true;
+            }
+            break;
+          default:
         }
       }
       if (!taggedHeaders.isEmpty() && classification == IGNORE) {

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ContextInterpreter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ContextInterpreter.java
@@ -1,10 +1,10 @@
 package datadog.trace.core.propagation;
 
-import static datadog.trace.core.propagation.HttpCodec.FORWARDED_FOR_KEY;
-import static datadog.trace.core.propagation.HttpCodec.FORWARDED_HOST_KEY;
 import static datadog.trace.core.propagation.HttpCodec.FORWARDED_KEY;
-import static datadog.trace.core.propagation.HttpCodec.FORWARDED_PORT_KEY;
-import static datadog.trace.core.propagation.HttpCodec.FORWARDED_PROTO_KEY;
+import static datadog.trace.core.propagation.HttpCodec.X_FORWARDED_FOR_KEY;
+import static datadog.trace.core.propagation.HttpCodec.X_FORWARDED_HOST_KEY;
+import static datadog.trace.core.propagation.HttpCodec.X_FORWARDED_PORT_KEY;
+import static datadog.trace.core.propagation.HttpCodec.X_FORWARDED_PROTO_KEY;
 
 import datadog.trace.api.Config;
 import datadog.trace.api.DDId;
@@ -66,24 +66,28 @@ public abstract class ContextInterpreter implements AgentPropagation.KeyClassifi
   }
 
   protected final boolean handledForwarding(String key, String value) {
+    if (null != value && FORWARDED_KEY.equalsIgnoreCase(key)) {
+      forwarded = value;
+      return true;
+    }
+    return false;
+  }
+
+  protected final boolean handledXForwarding(String key, String value) {
     if (null != value) {
-      if (FORWARDED_KEY.equalsIgnoreCase(key)) {
-        forwarded = value;
-        return true;
-      }
-      if (FORWARDED_PROTO_KEY.equalsIgnoreCase(key)) {
+      if (X_FORWARDED_PROTO_KEY.equalsIgnoreCase(key)) {
         forwardedProto = value;
         return true;
       }
-      if (FORWARDED_HOST_KEY.equalsIgnoreCase(key)) {
+      if (X_FORWARDED_HOST_KEY.equalsIgnoreCase(key)) {
         forwardedHost = value;
         return true;
       }
-      if (FORWARDED_FOR_KEY.equalsIgnoreCase(key)) {
+      if (X_FORWARDED_FOR_KEY.equalsIgnoreCase(key)) {
         forwardedIp = value;
         return true;
       }
-      if (FORWARDED_PORT_KEY.equalsIgnoreCase(key)) {
+      if (X_FORWARDED_PORT_KEY.equalsIgnoreCase(key)) {
         forwardedPort = value;
         return true;
       }

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/DatadogHttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/DatadogHttpCodec.java
@@ -101,7 +101,12 @@ class DatadogHttpCodec {
               && X_AMZN_TRACE_ID.equalsIgnoreCase(key)) {
             handleXRayTraceHeader(this, value);
             return true;
-          } else if (handledForwarding(key, value)) {
+          } else if (handledXForwarding(key, value)) {
+            return true;
+          }
+          break;
+        case 'f':
+          if (handledForwarding(key, value)) {
             return true;
           }
           break;

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/HaystackHttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/HaystackHttpCodec.java
@@ -154,6 +154,11 @@ class HaystackHttpCodec {
           }
           break;
         case 'x':
+          if (handledXForwarding(key, value)) {
+            return true;
+          }
+          break;
+        case 'f':
           if (handledForwarding(key, value)) {
             return true;
           }

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/HttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/HttpCodec.java
@@ -19,10 +19,10 @@ public class HttpCodec {
   private static final Logger log = LoggerFactory.getLogger(HttpCodec.class);
   // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded
   static final String FORWARDED_KEY = "forwarded";
-  static final String FORWARDED_PROTO_KEY = "x-forwarded-proto";
-  static final String FORWARDED_HOST_KEY = "x-forwarded-host";
-  static final String FORWARDED_FOR_KEY = "x-forwarded-for";
-  static final String FORWARDED_PORT_KEY = "x-forwarded-port";
+  static final String X_FORWARDED_PROTO_KEY = "x-forwarded-proto";
+  static final String X_FORWARDED_HOST_KEY = "x-forwarded-host";
+  static final String X_FORWARDED_FOR_KEY = "x-forwarded-for";
+  static final String X_FORWARDED_PORT_KEY = "x-forwarded-port";
 
   public interface Injector {
     <C> void inject(

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/B3HttpExtractorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/B3HttpExtractorTest.groovy
@@ -198,6 +198,37 @@ class B3HttpExtractorTest extends DDSpecification {
     then:
     context != null
     !(context instanceof ExtractedContext)
+    context.forwarded == "for=$forwardedIp:$forwardedPort"
+
+    when:
+    context = extractor.extract(fullCtx, ContextVisitors.stringValuesMap())
+
+    then:
+    context instanceof ExtractedContext
+    context.traceId.toLong() == 1
+    context.spanId.toLong() == 2
+    context.forwarded == "for=$forwardedIp:$forwardedPort"
+
+    where:
+    forwardedIp = "1.2.3.4"
+    forwardedPort = "1234"
+    tagOnlyCtx = [
+      "Forwarded" : "for=$forwardedIp:$forwardedPort"
+    ]
+    fullCtx = [
+      (TRACE_ID_KEY.toUpperCase()): 1,
+      (SPAN_ID_KEY.toUpperCase()) : 2,
+      "Forwarded" : "for=$forwardedIp:$forwardedPort"
+    ]
+  }
+
+  def "extract headers with x-forwarding"() {
+    when:
+    TagContext context = extractor.extract(tagOnlyCtx, ContextVisitors.stringValuesMap())
+
+    then:
+    context != null
+    !(context instanceof ExtractedContext)
     context.forwardedIp == forwardedIp
     context.forwardedPort == forwardedPort
 
@@ -208,7 +239,6 @@ class B3HttpExtractorTest extends DDSpecification {
     context instanceof ExtractedContext
     context.traceId.toLong() == 1
     context.spanId.toLong() == 2
-    context.forwardedIp == forwardedIp
     context.forwardedIp == forwardedIp
     context.forwardedPort == forwardedPort
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/DatadogHttpExtractorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/DatadogHttpExtractorTest.groovy
@@ -84,6 +84,37 @@ class DatadogHttpExtractorTest extends DDSpecification {
     then:
     context != null
     !(context instanceof ExtractedContext)
+    context.forwarded == "for=$forwardedIp:$forwardedPort"
+
+    when:
+    context = extractor.extract(fullCtx, ContextVisitors.stringValuesMap())
+
+    then:
+    context instanceof ExtractedContext
+    context.traceId.toLong() == 1
+    context.spanId.toLong() == 2
+    context.forwarded == "for=$forwardedIp:$forwardedPort"
+
+    where:
+    forwardedIp = "1.2.3.4"
+    forwardedPort = "1234"
+    tagOnlyCtx = [
+      "Forwarded" : "for=$forwardedIp:$forwardedPort"
+    ]
+    fullCtx = [
+      (TRACE_ID_KEY.toUpperCase()): 1,
+      (SPAN_ID_KEY.toUpperCase()) : 2,
+      "Forwarded" : "for=$forwardedIp:$forwardedPort"
+    ]
+  }
+
+  def "extract headers with x-forwarding"() {
+    when:
+    TagContext context = extractor.extract(tagOnlyCtx, ContextVisitors.stringValuesMap())
+
+    then:
+    context != null
+    !(context instanceof ExtractedContext)
     context.forwardedIp == forwardedIp
     context.forwardedPort == forwardedPort
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HaystackHttpExtractorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HaystackHttpExtractorTest.groovy
@@ -71,6 +71,37 @@ class HaystackHttpExtractorTest extends DDSpecification {
     then:
     context != null
     !(context instanceof ExtractedContext)
+    context.forwarded == "for=$forwardedIp:$forwardedPort"
+
+    when:
+    context = extractor.extract(fullCtx, ContextVisitors.stringValuesMap())
+
+    then:
+    context instanceof ExtractedContext
+    context.traceId.toLong() == 1
+    context.spanId.toLong() == 2
+    context.forwarded == "for=$forwardedIp:$forwardedPort"
+
+    where:
+    forwardedIp = "1.2.3.4"
+    forwardedPort = "123"
+    tagOnlyCtx = [
+      "Forwarded" : "for=$forwardedIp:$forwardedPort"
+    ]
+    fullCtx = [
+      (TRACE_ID_KEY.toUpperCase()): 1,
+      (SPAN_ID_KEY.toUpperCase()) : 2,
+      "Forwarded" : "for=$forwardedIp:$forwardedPort"
+    ]
+  }
+
+  def "extract headers with x-forwarding"() {
+    when:
+    TagContext context = extractor.extract(tagOnlyCtx, ContextVisitors.stringValuesMap())
+
+    then:
+    context != null
+    !(context instanceof ExtractedContext)
     context.forwardedIp == forwardedIp
     context.forwardedPort == forwardedPort
 
@@ -81,7 +112,6 @@ class HaystackHttpExtractorTest extends DDSpecification {
     context instanceof ExtractedContext
     context.traceId.toLong() == 1
     context.spanId.toLong() == 2
-    context.forwardedIp == forwardedIp
     context.forwardedIp == forwardedIp
     context.forwardedPort == forwardedPort
 


### PR DESCRIPTION
Previously we weren't extracting `Forwarded` headers because the code was only called when the header started with `X`

(`Forwarded` is the new [standard header](https://datatracker.ietf.org/doc/html/rfc7239) replacing `X-Forwarded-For` etc.)