### PR TITLE
Reduce extracted cost when no forwarded data

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
@@ -225,9 +225,8 @@ public abstract class HttpServerDecorator<REQUEST, CONNECTION, RESPONSE, CARRIER
         if (null != requestContextData) {
           TagContext tagContext = null;
           if (context == null) {
-            tagContext = TagContext.empty();
-          }
-          if (context instanceof TagContext) {
+            tagContext = new TagContext();
+          } else if (context instanceof TagContext) {
             tagContext = (TagContext) context;
           }
           if (null != tagContext) {

--- a/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/test/groovy/GrizzlyByteBodyInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/test/groovy/GrizzlyByteBodyInstrumentationTest.groovy
@@ -37,7 +37,7 @@ class GrizzlyByteBodyInstrumentationTest extends AgentTestRunner {
     }
     1 * attributeHolder.setAttribute('datadog.intercepted_request_body', Boolean.TRUE)
 
-    TagContext ctx = TagContext.empty().withRequestContextData(new Object())
+    TagContext ctx = new TagContext().withRequestContextData(new Object())
     def agentSpan = AgentTracer.startSpan('test-span', ctx, true)
     this.scope = AgentTracer.activateSpan(agentSpan)
 

--- a/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/test/groovy/GrizzlyCharBodyInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/test/groovy/GrizzlyCharBodyInstrumentationTest.groovy
@@ -32,7 +32,7 @@ class GrizzlyCharBodyInstrumentationTest extends AgentTestRunner {
     _ * mockHttpHeader.attributes >> attributeHolder
     1 * attributeHolder.setAttribute('datadog.intercepted_request_body', Boolean.TRUE)
 
-    TagContext ctx = TagContext.empty().withRequestContextData(new Object())
+    TagContext ctx = new TagContext().withRequestContextData(new Object())
     def agentSpan = AgentTracer.startSpan('test-span', ctx, true)
     this.scope = AgentTracer.activateSpan(agentSpan)
 

--- a/dd-java-agent/instrumentation/opentelemetry/src/test/groovy/OpenTelemetryTest.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/src/test/groovy/OpenTelemetryTest.groovy
@@ -133,10 +133,10 @@ class OpenTelemetryTest extends AgentTestRunner {
     setup:
     def builder = tracer.spanBuilder("some name")
     if (parentId) {
-      builder.setParent(tracer.converter.toSpanContext(new ExtractedContext(DDId.ONE, DDId.from(parentId), 0, null, null, null, null, null, null, [:], [:])))
+      builder.setParent(tracer.converter.toSpanContext(new ExtractedContext(DDId.ONE, DDId.from(parentId), 0, null, [:], [:])))
     }
     if (linkId) {
-      builder.addLink(tracer.converter.toSpanContext(new ExtractedContext(DDId.ONE, DDId.from(linkId), 0, null, null, null, null, null, null, [:], [:])))
+      builder.addLink(tracer.converter.toSpanContext(new ExtractedContext(DDId.ONE, DDId.from(linkId), 0, null, [:], [:])))
     }
     def result = builder.startSpan()
 

--- a/dd-java-agent/instrumentation/opentracing/api-0.31/src/test/groovy/OpenTracing31Test.groovy
+++ b/dd-java-agent/instrumentation/opentracing/api-0.31/src/test/groovy/OpenTracing31Test.groovy
@@ -33,7 +33,7 @@ class OpenTracing31Test extends AgentTestRunner {
         .withTag("boolean", true)
     }
     if (addReference) {
-      builder.addReference(addReference, tracer.tracer.converter.toSpanContext(new ExtractedContext(DDId.ONE, DDId.from(2), 0, null, null, null, null, null, null, [:], [:])))
+      builder.addReference(addReference, tracer.tracer.converter.toSpanContext(new ExtractedContext(DDId.ONE, DDId.from(2), 0, null, [:], [:])))
     }
     def result = builder.start()
     if (tagSpan) {

--- a/dd-java-agent/instrumentation/opentracing/api-0.32/src/test/groovy/OpenTracing32Test.groovy
+++ b/dd-java-agent/instrumentation/opentracing/api-0.32/src/test/groovy/OpenTracing32Test.groovy
@@ -33,7 +33,7 @@ class OpenTracing32Test extends AgentTestRunner {
         .withTag("boolean", true)
     }
     if (addReference) {
-      builder.addReference(addReference, tracer.tracer.converter.toSpanContext(new ExtractedContext(DDId.ONE, DDId.from(2), 0, null, null, null, null, null, null, [:], [:])))
+      builder.addReference(addReference, tracer.tracer.converter.toSpanContext(new ExtractedContext(DDId.ONE, DDId.from(2), 0, null, [:], [:])))
     }
     def result = builder.start()
     if (tagSpan) {

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ContextInterpreter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ContextInterpreter.java
@@ -107,6 +107,7 @@ public abstract class ContextInterpreter implements AgentPropagation.KeyClassifi
     spanId = DDId.ZERO;
     samplingPriority = defaultSamplingPriority();
     origin = null;
+    hasForwarded = false;
     forwarded = null;
     forwardedProto = null;
     forwardedHost = null;

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ExtractedContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ExtractedContext.java
@@ -20,14 +20,9 @@ public class ExtractedContext extends TagContext {
       final DDId spanId,
       final int samplingPriority,
       final String origin,
-      final String forwarded,
-      final String forwardedProto,
-      final String forwardedHost,
-      final String forwardedIp,
-      final String forwardedPort,
       final Map<String, String> baggage,
       final Map<String, String> tags) {
-    super(origin, forwarded, forwardedProto, forwardedHost, forwardedIp, forwardedPort, tags);
+    super(origin, tags);
     this.traceId = traceId;
     this.spanId = spanId;
     this.samplingPriority = samplingPriority;
@@ -35,33 +30,33 @@ public class ExtractedContext extends TagContext {
   }
 
   @Override
-  public Iterable<Map.Entry<String, String>> baggageItems() {
+  public final Iterable<Map.Entry<String, String>> baggageItems() {
     return baggage.entrySet();
   }
 
-  public void lockSamplingPriority() {
+  public final void lockSamplingPriority() {
     samplingPriorityLocked.set(true);
   }
 
   @Override
-  public DDId getTraceId() {
+  public final DDId getTraceId() {
     return traceId;
   }
 
   @Override
-  public DDId getSpanId() {
+  public final DDId getSpanId() {
     return spanId;
   }
 
-  public int getSamplingPriority() {
+  public final int getSamplingPriority() {
     return samplingPriority;
   }
 
-  public Map<String, String> getBaggage() {
+  public final Map<String, String> getBaggage() {
     return baggage;
   }
 
-  public boolean getSamplingPriorityLocked() {
+  public final boolean getSamplingPriorityLocked() {
     return samplingPriorityLocked.get();
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ForwardedExtractedContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ForwardedExtractedContext.java
@@ -1,0 +1,59 @@
+package datadog.trace.core.propagation;
+
+import datadog.trace.api.DDId;
+import java.util.Map;
+
+/** {@link ExtractedContext} with non-empty Forwarded metadata. */
+public final class ForwardedExtractedContext extends ExtractedContext {
+
+  private final String forwarded;
+  private final String forwardedProto;
+  private final String forwardedHost;
+  private final String forwardedIp;
+  private final String forwardedPort;
+
+  public ForwardedExtractedContext(
+      final DDId traceId,
+      final DDId spanId,
+      final int samplingPriority,
+      final String origin,
+      final String forwarded,
+      final String forwardedProto,
+      final String forwardedHost,
+      final String forwardedIp,
+      final String forwardedPort,
+      final Map<String, String> baggage,
+      final Map<String, String> tags) {
+    super(traceId, spanId, samplingPriority, origin, baggage, tags);
+    this.forwarded = forwarded;
+    this.forwardedProto = forwardedProto;
+    this.forwardedHost = forwardedHost;
+    this.forwardedIp = forwardedIp;
+    this.forwardedPort = forwardedPort;
+  }
+
+  @Override
+  public String getForwarded() {
+    return forwarded;
+  }
+
+  @Override
+  public String getForwardedProto() {
+    return forwardedProto;
+  }
+
+  @Override
+  public String getForwardedHost() {
+    return forwardedHost;
+  }
+
+  @Override
+  public String getForwardedIp() {
+    return forwardedIp;
+  }
+
+  @Override
+  public String getForwardedPort() {
+    return forwardedPort;
+  }
+}

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/CoreSpanBuilderTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/CoreSpanBuilderTest.groovy
@@ -319,9 +319,9 @@ class CoreSpanBuilderTest extends DDCoreSpecification {
     span.getTag(THREAD_NAME) == thread.name
 
     where:
-    extractedContext                                                                                                                                                  | _
-    new ExtractedContext(DDId.ONE, DDId.from(2), 0, null, null, null, null, null, null, [:], [:])                                                                     | _
-    new ExtractedContext(DDId.from(3), DDId.from(4), 1, "some-origin", null, null, null, null, null, ["asdf": "qwer"], [(ORIGIN_KEY): "some-origin", "zxcv": "1234"]) | _
+    extractedContext                                                                                                                    | _
+    new ExtractedContext(DDId.ONE, DDId.from(2), 0, null, [:], [:])                                                                     | _
+    new ExtractedContext(DDId.from(3), DDId.from(4), 1, "some-origin", ["asdf": "qwer"], [(ORIGIN_KEY): "some-origin", "zxcv": "1234"]) | _
   }
 
   def "TagContext should populate default span details"() {
@@ -340,9 +340,9 @@ class CoreSpanBuilderTest extends DDCoreSpecification {
       (THREAD_NAME)     : thread.name, (THREAD_ID): thread.id]
 
     where:
-    tagContext                                                                                                 | _
-    new TagContext(null, null, null, null, null, null, [:])                                                    | _
-    new TagContext("some-origin", null, null, null, null, null, ["asdf": "qwer"]) | _
+    tagContext                                      | _
+    new TagContext(null, [:])                       | _
+    new TagContext("some-origin", ["asdf": "qwer"]) | _
   }
 
   def "global span tags populated on each span"() {

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanTest.groovy
@@ -263,9 +263,9 @@ class DDSpanTest extends DDCoreSpecification {
     child.@origin == null // Access field directly instead of getter.
 
     where:
-    extractedContext                                                                                       | _
-    new TagContext("some-origin", null, null, null, null, null, [:])                                       | _
-    new ExtractedContext(DDId.ONE, DDId.from(2), 0, "some-origin", null, null, null, null, null, [:], [:]) | _
+    extractedContext                                                         | _
+    new TagContext("some-origin", [:])                                       | _
+    new ExtractedContext(DDId.ONE, DDId.from(2), 0, "some-origin", [:], [:]) | _
   }
 
   def "isRootSpan() in and not in the context of distributed tracing"() {
@@ -282,9 +282,9 @@ class DDSpanTest extends DDCoreSpecification {
     root.finish()
 
     where:
-    extractedContext                                                                                       | isTraceRootSpan
-    null                                                                                                   | true
-    new ExtractedContext(DDId.from(123), DDId.from(456), 1, "789", null, null, null, null, null, [:], [:]) | false
+    extractedContext                                                         | isTraceRootSpan
+    null                                                                     | true
+    new ExtractedContext(DDId.from(123), DDId.from(456), 1, "789", [:], [:]) | false
   }
 
   def "getApplicationRootSpan() in and not in the context of distributed tracing"() {
@@ -304,9 +304,9 @@ class DDSpanTest extends DDCoreSpecification {
     root.finish()
 
     where:
-    extractedContext                                                                                       | isTraceRootSpan
-    null                                                                                                   | true
-    new ExtractedContext(DDId.from(123), DDId.from(456), 1, "789", null, null, null, null, null, [:], [:]) | false
+    extractedContext                                                         | isTraceRootSpan
+    null                                                                     | true
+    new ExtractedContext(DDId.from(123), DDId.from(456), 1, "789", [:], [:]) | false
   }
 
   def "infer top level from parent service name"() {

--- a/internal-api/internal-api.gradle
+++ b/internal-api/internal-api.gradle
@@ -32,6 +32,7 @@ excludedClassesCoverage += [
   "datadog.trace.bootstrap.instrumentation.api.ScopeSource",
   "datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes",
   "datadog.trace.bootstrap.instrumentation.api.TagContext",
+  "datadog.trace.bootstrap.instrumentation.api.ForwardedTagContext",
   "datadog.trace.bootstrap.instrumentation.api.ResourceNamePriorities",
   "datadog.trace.bootstrap.instrumentation.ci.git.GitInfo",
   "datadog.trace.bootstrap.instrumentation.ci.git.GitInfo.GitInfoBuilder",

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/ForwardedTagContext.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/ForwardedTagContext.java
@@ -1,0 +1,54 @@
+package datadog.trace.bootstrap.instrumentation.api;
+
+import java.util.Map;
+
+/** {@link TagContext} with non-empty Forwarded metadata. */
+public final class ForwardedTagContext extends TagContext {
+
+  private final String forwarded;
+  private final String forwardedProto;
+  private final String forwardedHost;
+  private final String forwardedIp;
+  private final String forwardedPort;
+
+  public ForwardedTagContext(
+      final String origin,
+      final String forwarded,
+      final String forwardedProto,
+      final String forwardedHost,
+      final String forwardedIp,
+      final String forwardedPort,
+      final Map<String, String> tags) {
+    super(origin, tags);
+    this.forwarded = forwarded;
+    this.forwardedProto = forwardedProto;
+    this.forwardedHost = forwardedHost;
+    this.forwardedIp = forwardedIp;
+    this.forwardedPort = forwardedPort;
+  }
+
+  @Override
+  public String getForwarded() {
+    return forwarded;
+  }
+
+  @Override
+  public String getForwardedProto() {
+    return forwardedProto;
+  }
+
+  @Override
+  public String getForwardedHost() {
+    return forwardedHost;
+  }
+
+  @Override
+  public String getForwardedIp() {
+    return forwardedIp;
+  }
+
+  @Override
+  public String getForwardedPort() {
+    return forwardedPort;
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/TagContext.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/TagContext.java
@@ -10,64 +10,49 @@ import java.util.Map;
  */
 public class TagContext implements AgentSpan.Context.Extracted {
 
-  public static final TagContext empty() {
-    return new TagContext(null, null, null, null, null, null, null);
-  }
-
   private final String origin;
-  private final String forwarded;
-  private final String forwardedProto;
-  private final String forwardedHost;
-  private final String forwardedIp;
-  private final String forwardedPort;
   private final Map<String, String> tags;
   private Object requestContextData;
 
-  public TagContext(
-      final String origin,
-      String forwarded,
-      String forwardedProto,
-      String forwardedHost,
-      String forwardedIp,
-      String forwardedPort,
-      final Map<String, String> tags) {
+  public TagContext() {
+    this(null, null);
+  }
+
+  public TagContext(final String origin, final Map<String, String> tags) {
     this.origin = origin;
-    this.forwarded = forwarded;
-    this.forwardedProto = forwardedProto;
-    this.forwardedHost = forwardedHost;
-    this.forwardedIp = forwardedIp;
-    this.forwardedPort = forwardedPort;
     this.tags = tags;
   }
 
-  public String getOrigin() {
+  public final String getOrigin() {
     return origin;
   }
 
+  @Override
   public String getForwarded() {
-    return forwarded;
+    return null;
   }
 
   @Override
   public String getForwardedProto() {
-    return forwardedProto;
+    return null;
   }
 
+  @Override
   public String getForwardedHost() {
-    return forwardedHost;
+    return null;
   }
 
   @Override
   public String getForwardedIp() {
-    return forwardedIp;
+    return null;
   }
 
   @Override
   public String getForwardedPort() {
-    return forwardedPort;
+    return null;
   }
 
-  public Map<String, String> getTags() {
+  public final Map<String, String> getTags() {
     return tags;
   }
 
@@ -87,15 +72,15 @@ public class TagContext implements AgentSpan.Context.Extracted {
   }
 
   @Override
-  public AgentTrace getTrace() {
+  public final AgentTrace getTrace() {
     return AgentTracer.NoopAgentTrace.INSTANCE;
   }
 
-  public Object getRequestContextData() {
+  public final Object getRequestContextData() {
     return requestContextData;
   }
 
-  public TagContext withRequestContextData(Object requestContextData) {
+  public final TagContext withRequestContextData(Object requestContextData) {
     this.requestContextData = requestContextData;
     return this;
   }


### PR DESCRIPTION
Saves space when there's no Forwarded headers, such as when propagating traces over non-HTTP routes such as JMS or other messaging systems.