### PR TITLE
Remove unused 'samplingPriorityLocked' flag from ExtractedContext

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ContextInterpreter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ContextInterpreter.java
@@ -140,7 +140,6 @@ public abstract class ContextInterpreter implements AgentPropagation.KeyClassifi
         } else {
           context = new ExtractedContext(traceId, spanId, samplingPriority, origin, baggage, tags);
         }
-        context.lockSamplingPriority();
         return context;
       } else if (hasForwarded) {
         return new ForwardedTagContext(

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ExtractedContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ExtractedContext.java
@@ -3,7 +3,6 @@ package datadog.trace.core.propagation;
 import datadog.trace.api.DDId;
 import datadog.trace.bootstrap.instrumentation.api.TagContext;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Propagated data resulting from calling tracer.extract with header data from an incoming request.
@@ -13,7 +12,6 @@ public class ExtractedContext extends TagContext {
   private final DDId spanId;
   private final int samplingPriority;
   private final Map<String, String> baggage;
-  private final AtomicBoolean samplingPriorityLocked = new AtomicBoolean(false);
 
   public ExtractedContext(
       final DDId traceId,
@@ -34,10 +32,6 @@ public class ExtractedContext extends TagContext {
     return baggage.entrySet();
   }
 
-  public final void lockSamplingPriority() {
-    samplingPriorityLocked.set(true);
-  }
-
   @Override
   public final DDId getTraceId() {
     return traceId;
@@ -54,9 +48,5 @@ public class ExtractedContext extends TagContext {
 
   public final Map<String, String> getBaggage() {
     return baggage;
-  }
-
-  public final boolean getSamplingPriorityLocked() {
-    return samplingPriorityLocked.get();
   }
 }


### PR DESCRIPTION
it's only ever set just after construction time and is never read