### PR TITLE
[AppSec] Enabled WAF stateful mode (WAF Additive API)

### DIFF
--- a/dd-java-agent/appsec/appsec.gradle
+++ b/dd-java-agent/appsec/appsec.gradle
@@ -134,6 +134,7 @@ ext {
   excludedClassesBranchCoverage = [
     'com.datadog.appsec.gateway.GatewayBridge',
     'com.datadog.appsec.event.data.Address',
+    'com.datadog.appsec.powerwaf.PowerWAFModule.PowerWAFEventsCallback',
     // assert never fails
     'com.datadog.appsec.util.StandardizedLogging',
     'com.datadog.appsec.util.AbortStartupException',

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/AppSecRequestContext.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/AppSecRequestContext.java
@@ -8,6 +8,7 @@ import com.datadog.appsec.report.ReportService;
 import com.datadog.appsec.report.raw.events.AppSecEvent100;
 import com.datadog.appsec.util.StandardizedLogging;
 import datadog.trace.api.http.StoredBodySupplier;
+import io.sqreen.powerwaf.Additive;
 import java.io.Closeable;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -43,6 +44,8 @@ public class AppSecRequestContext implements DataBundle, ReportService, Closeabl
   private int responseStatus;
   private boolean blocked;
 
+  private Additive additive;
+
   // to be called by the Event Dispatcher
   public void addAll(DataBundle newData) {
     for (Map.Entry<Address<?>, Object> entry : newData) {
@@ -60,6 +63,14 @@ public class AppSecRequestContext implements DataBundle, ReportService, Closeabl
         StandardizedLogging.addressPushed(log, address);
       }
     }
+  }
+
+  public Additive getAdditive() {
+    return additive;
+  }
+
+  public void setAdditive(Additive additive) {
+    this.additive = additive;
   }
 
   /* Implementation of DataBundle */

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/powerwaf/PowerWAFModuleSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/powerwaf/PowerWAFModuleSpecification.groovy
@@ -3,6 +3,8 @@ package com.datadog.appsec.powerwaf
 import com.datadog.appsec.AppSecModule
 import com.datadog.appsec.event.ChangeableFlow
 import com.datadog.appsec.event.DataListener
+import com.datadog.appsec.event.EventListener
+import com.datadog.appsec.event.EventType
 import com.datadog.appsec.event.data.CaseInsensitiveMap
 import com.datadog.appsec.event.data.DataBundle
 import com.datadog.appsec.event.data.KnownAddresses
@@ -21,13 +23,15 @@ class PowerWAFModuleSpecification extends DDSpecification {
   AppSecRequestContext ctx = Mock()
 
   PowerWAFModule pwafModule = new PowerWAFModule()
-  DataListener listener
+  DataListener dataListener
+  EventListener eventListener
 
   private void setupWithStubConfigService() {
     def service = new StubAppSecConfigService()
     service.init(false)
     pwafModule.config(service)
-    listener = pwafModule.dataSubscriptions.first()
+    dataListener = pwafModule.dataSubscriptions.first()
+    eventListener = pwafModule.eventSubscriptions.first()
   }
 
   void 'is named powerwaf'() {
@@ -40,7 +44,8 @@ class PowerWAFModuleSpecification extends DDSpecification {
     ChangeableFlow flow = new ChangeableFlow()
 
     when:
-    listener.onDataAvailable(flow, ctx, ATTACK_BUNDLE)
+    dataListener.onDataAvailable(flow, ctx, ATTACK_BUNDLE)
+    eventListener.onEvent(ctx, EventType.REQUEST_END)
 
     then:
     flow.blocking == true
@@ -51,7 +56,8 @@ class PowerWAFModuleSpecification extends DDSpecification {
     AppSecEvent100 event
 
     when:
-    listener.onDataAvailable(Mock(ChangeableFlow), ctx, ATTACK_BUNDLE)
+    dataListener.onDataAvailable(Mock(ChangeableFlow), ctx, ATTACK_BUNDLE)
+    eventListener.onEvent(ctx, EventType.REQUEST_END)
 
     then:
     ctx.reportEvent(_ as AppSecEvent100) >> { event = it[0] }
@@ -79,7 +85,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
       new CaseInsensitiveMap<List<String>>(['user-agent': 'Harmless']))
 
     when:
-    listener.onDataAvailable(flow, ctx, db)
+    dataListener.onDataAvailable(flow, ctx, db)
 
     then:
     flow.blocking == false
@@ -91,15 +97,16 @@ class PowerWAFModuleSpecification extends DDSpecification {
     DataBundle db = MapDataBundle.of(KnownAddresses.HEADERS_NO_COOKIES, [get: { null }] as List)
 
     when:
-    listener.onDataAvailable(flow, ctx, db)
+    dataListener.onDataAvailable(flow, ctx, db)
 
     then:
     assert !flow.blocking
   }
 
-  void 'subscribes no events'() {
+  void 'subscribes 1 event'() {
     expect:
-    pwafModule.eventSubscriptions.empty == true
+    pwafModule.eventSubscriptions.isEmpty() == false
+    pwafModule.eventSubscriptions.first().eventType == EventType.REQUEST_END
   }
 
   void 'configuration can be given later'() {
@@ -113,9 +120,11 @@ class PowerWAFModuleSpecification extends DDSpecification {
     thrown AppSecModule.AppSecModuleActivationException
 
     when:
-    listener = pwafModule.dataSubscriptions.first()
+    dataListener = pwafModule.dataSubscriptions.first()
+    eventListener = pwafModule.eventSubscriptions.first()
     cfgService.listeners['waf'].onNewSubconfig(defaultConfig['waf'])
-    listener.onDataAvailable(Mock(ChangeableFlow), ctx, ATTACK_BUNDLE)
+    dataListener.onDataAvailable(Mock(ChangeableFlow), ctx, ATTACK_BUNDLE)
+    eventListener.onEvent(ctx, EventType.REQUEST_END)
 
     then:
     1 * ctx.reportEvent(_ as AppSecEvent100)
@@ -132,8 +141,8 @@ class PowerWAFModuleSpecification extends DDSpecification {
     thrown AppSecModule.AppSecModuleActivationException
 
     when:
-    listener = pwafModule.dataSubscriptions.first()
-    listener.onDataAvailable(Mock(ChangeableFlow), ctx, ATTACK_BUNDLE)
+    dataListener = pwafModule.dataSubscriptions.first()
+    dataListener.onDataAvailable(Mock(ChangeableFlow), ctx, ATTACK_BUNDLE)
 
     then:
     0 * ctx._


### PR DESCRIPTION
Changed the way we are calling WAF to enforce stateful mode (using WAF Additive API).
Since we are calling WAF several times at different stages of request processing, we need to keep state of WAF (collected data) between calls. 
For example, we will call WAF three times:
1. At the beginning, when parsed URI and http headers;
2. When request body read;
3. When response status available.

For each stage, we need to keep information about perviously collected data related to current request. This requirement based on fact that some of attacks could be detected by compounded data received at different stages.
Enforce using Additive API, allows to share collected data between WAF calls and will be bounded by request context lifetime.

Basically, we are creating WAF Additive context, during the first WAF call and dispose it when `REQUEST_END` event happens. Given WAF Additive context is kept with the `AppSecRequestContext` and used to process only the data related to current request.