### PR TITLE
Don't instrument Runnables internal to ConcurrentLinkedHashMap

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/ExcludeFilter.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/ExcludeFilter.java
@@ -114,6 +114,10 @@ public class ExcludeFilter {
     SKIP_TYPE_PREFIXES
         .get(ExcludeType.FORK_JOIN_TASK)
         .add("java.util.concurrent.ConcurrentHashMap");
+    // Exclude Runnables in the Google code ConcurrentLinkedHashMap
+    SKIP_TYPE_PREFIXES
+        .get(ExcludeType.RUNNABLE)
+        .add("com.googlecode.concurrentlinkedhashmap.ConcurrentLinkedHashMap");
   }
 
   /**


### PR DESCRIPTION
Please don't instrument the Runnables internal to the `WeakCache` implementation