### PR TITLE
Make it easier to correlate startup debug log lines

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/FieldBackedContextStores.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/FieldBackedContextStores.java
@@ -103,7 +103,10 @@ public final class FieldBackedContextStores {
         existingStore = STORES_BY_NAME.putIfAbsent(storeName, createStore(newStoreId));
         if (null == existingStore) {
           log.debug(
-              "Allocated ContextStore #{} to {} -> {}", newStoreId, keyClassName, contextClassName);
+              "Allocated ContextStore #{} - instrumentation.target.context={}->{}",
+              newStoreId,
+              keyClassName,
+              contextClassName);
           return newStoreId;
         }
       }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
@@ -66,7 +66,7 @@ public class AgentInstaller {
         log.debug("Class instrumentation installed");
       }
     } else if (DEBUG) {
-      log.debug("Tracing is disabled, not installing instrumentations.");
+      log.debug("There are not any enabled subsystems, not installing instrumentations.");
     }
   }
 
@@ -135,7 +135,8 @@ public class AgentInstaller {
         ExcludeFilter.add(provider.excludedClasses());
         if (DEBUG) {
           log.debug(
-              "Adding filtered classes from instrumentation {}", instrumenter.getClass().getName());
+              "Adding filtered classes - instrumentation.class={}",
+              instrumenter.getClass().getName());
         }
       }
     }
@@ -144,19 +145,20 @@ public class AgentInstaller {
     for (final Instrumenter instrumenter : loader) {
       if (!instrumenter.isApplicable(enabledSystems)) {
         if (DEBUG) {
-          log.debug("Instrumentation {} is not applicable", instrumenter.getClass().getName());
+          log.debug("Not applicable - instrumentation.class={}", instrumenter.getClass().getName());
         }
         continue;
       }
       if (DEBUG) {
-        log.debug("Loading instrumentation {}", instrumenter.getClass().getName());
+        log.debug("Loading - instrumentation.class={}", instrumenter.getClass().getName());
       }
 
       try {
         agentBuilder = instrumenter.instrument(agentBuilder);
         numInstrumenters++;
       } catch (final Exception | LinkageError e) {
-        log.error("Unable to load instrumentation {}", instrumenter.getClass().getName(), e);
+        log.error(
+            "Failed to load - instrumentation.class={}", instrumenter.getClass().getName(), e);
       }
     }
     if (DEBUG) {
@@ -269,7 +271,7 @@ public class AgentInstaller {
         final Throwable throwable) {
       if (DEBUG) {
         log.debug(
-            "Failed to handle {} for transformation on classloader {}",
+            "Transformation failed - instrumentation.target.class={} instrumentation.target.classloader={}",
             typeName,
             classLoader,
             throwable);
@@ -284,7 +286,10 @@ public class AgentInstaller {
         final boolean loaded,
         final DynamicType dynamicType) {
       if (DEBUG) {
-        log.debug("Transformed {} -- {}", typeDescription.getName(), classLoader);
+        log.debug(
+            "Transformed - instrumentation.target.class={} instrumentation.target.classloader={}",
+            typeDescription.getName(),
+            classLoader);
       }
     }
 

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/ClassLoaderMatcher.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/ClassLoaderMatcher.java
@@ -6,6 +6,7 @@ import static datadog.trace.util.Strings.getResourceName;
 import datadog.trace.api.Tracer;
 import datadog.trace.bootstrap.PatchLogger;
 import datadog.trace.bootstrap.WeakCache;
+import java.util.Arrays;
 import net.bytebuddy.matcher.ElementMatcher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -193,6 +194,11 @@ public final class ClassLoaderMatcher {
         PROBING_CLASSLOADER.end();
       }
     }
+
+    @Override
+    public String toString() {
+      return "ClassLoaderHasClassesNamedMatcher{named=" + Arrays.toString(resources) + "}";
+    }
   }
 
   private static class ClassLoaderHasClassNamedMatcher extends ClassLoaderHasNameMatcher {
@@ -212,6 +218,11 @@ public final class ClassLoaderMatcher {
       } finally {
         PROBING_CLASSLOADER.end();
       }
+    }
+
+    @Override
+    public String toString() {
+      return "ClassLoaderHasClassNamedMatcher{named='" + resource + "\'}";
     }
   }
 }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/HelperInjector.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/HelperInjector.java
@@ -4,6 +4,7 @@ import static datadog.trace.agent.tooling.ClassLoaderMatcher.BOOTSTRAP_CLASSLOAD
 import static datadog.trace.bootstrap.AgentClassLoading.INJECTING_HELPERS;
 
 import datadog.trace.api.Config;
+import datadog.trace.util.Strings;
 import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;
@@ -122,7 +123,13 @@ public class HelperInjector implements Transformer {
 
       if (!injectedClassLoaders.containsKey(classLoader)) {
         try {
-          log.debug("Injecting classes onto classloader {} -> {}", classLoader, helperClassNames);
+          if (log.isDebugEnabled()) {
+            log.debug(
+                "Injecting helper classes - instrumentation.class={} instrumentation.target.classloader={} instrumentation.helper_classes=[{}]",
+                requestingName,
+                classLoader,
+                Strings.join(",", helperClassNames));
+          }
 
           final Map<String, byte[]> classnameToBytes = getHelperMap();
           final Map<String, Class<?>> classes;
@@ -142,10 +149,10 @@ public class HelperInjector implements Transformer {
         } catch (final Exception e) {
           if (log.isErrorEnabled()) {
             log.error(
-                "Error preparing helpers while processing {} for {}. Failed to inject helper classes into instance {}",
-                typeDescription,
+                "Failed to inject helper classes - instrumentation.class={} instrumentation.target.classloader={} instrumentation.target.class={}",
                 requestingName,
                 classLoader,
+                typeDescription,
                 e);
           }
           throw new RuntimeException(e);

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Instrumenter.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Instrumenter.java
@@ -163,10 +163,12 @@ public interface Instrumenter {
     @Override
     public final AgentBuilder instrument(final AgentBuilder parentAgentBuilder) {
       if (!isEnabled()) {
-        log.debug(
-            "Disabled - instrumentation.names=[{}] instrumentation.class={}",
-            Strings.join(",", instrumentationNames),
-            getClass().getName());
+        if (log.isDebugEnabled()) {
+          log.debug(
+              "Disabled - instrumentation.names=[{}] instrumentation.class={}",
+              Strings.join(",", instrumentationNames),
+              getClass().getName());
+        }
         return parentAgentBuilder;
       }
 

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/context/FieldBackedContextProvider.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/context/FieldBackedContextProvider.java
@@ -111,9 +111,9 @@ public final class FieldBackedContextProvider implements InstrumentationContextP
             if (!installedContextMatchers.add(entry)) {
               if (log.isDebugEnabled()) {
                 log.debug(
-                    "Skipping duplicate builder in {} for matcher {}: {} -> {}",
-                    instrumenterName,
+                    "Skipping duplicate builder for matcher {} - instrumentation.class={} instrumentation.target.context={}->{}",
                     classLoaderMatcher,
+                    instrumenterName,
                     keyClassName,
                     contextClassName);
               }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/context/FieldBackedContextRequestRewriter.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/context/FieldBackedContextRequestRewriter.java
@@ -114,7 +114,8 @@ final class FieldBackedContextRequestRewriter implements AsmVisitorWrapper {
                 && INSTRUMENTATION_CONTEXT_CLASS.equals(owner)
                 && GET_METHOD.equals(name)
                 && GET_METHOD_DESCRIPTOR.equals(descriptor)) {
-              log.debug("Found context-store access in {}", instrumenterClassName);
+              log.debug(
+                  "Found context-store access - instrumentation.class={}", instrumenterClassName);
               // We track the last two constants pushed onto the stack to make sure they match
               // the expected key and context types. Matching calls are rewritten to call the
               // dynamically injected context store implementation instead.
@@ -123,7 +124,7 @@ final class FieldBackedContextRequestRewriter implements AsmVisitorWrapper {
                 final String contextClassName = ((Type) constant2).getClassName();
                 if (log.isDebugEnabled()) {
                   log.debug(
-                      "Rewriting context-store map fetch for instrumenter {}: {} -> {}",
+                      "Rewriting context-store map fetch - instrumentation.class={} instrumentation.target.context={}->{}",
                       instrumenterClassName,
                       keyClassName,
                       contextClassName);

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/context/ShouldInjectFieldsMatcher.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/context/ShouldInjectFieldsMatcher.java
@@ -61,7 +61,12 @@ final class ShouldInjectFieldsMatcher implements AgentBuilder.RawMatcher {
     if (skipType != null && ExcludeFilter.exclude(skipType, matchedType)) {
       excludeStoreForType(matchedType, getContextStoreId(keyType, valueType));
       if (log.isDebugEnabled()) {
-        log.debug("Skipping context-store field for {}: {} -> {}", matchedType, keyType, valueType);
+        log.debug(
+            "Skipping context-store field - instrumentation.target.class={} instrumentation.target.classloader={} instrumentation.target.context={}->{}",
+            matchedType,
+            classLoader,
+            keyType,
+            valueType);
       }
       return false;
     }
@@ -95,15 +100,21 @@ final class ShouldInjectFieldsMatcher implements AgentBuilder.RawMatcher {
       if (shouldInject) {
         // Only log success the first time we add it to the class
         if (classBeingRedefined == null) {
-          log.debug("Added context-store field to {}: {} -> {}", matchedType, keyType, valueType);
+          log.debug(
+              "Added context-store field - instrumentation.target.class={} instrumentation.target.classloader={} instrumentation.target.context={}->{}",
+              matchedType,
+              classLoader,
+              keyType,
+              valueType);
         }
       } else if (null != injectionTarget) {
         log.debug(
-            "Will not add context-store field to {}: {} -> {}, because it will be added to {}",
+            "Will not add context-store field, alternate target found {} - instrumentation.target.class={} instrumentation.target.classloader={} instrumentation.target.context={}->{}",
+            injectionTarget,
             matchedType,
+            classLoader,
             keyType,
-            valueType,
-            injectionTarget);
+            valueType);
       } else {
         // must be a redefine of a class that we weren't able to field-inject on startup
         // - make sure we'd have field-injected (if we'd had the chance) before tracking
@@ -114,7 +125,11 @@ final class ShouldInjectFieldsMatcher implements AgentBuilder.RawMatcher {
 
           // Only log failed redefines where we would have injected this class
           log.debug(
-              "Failed to add context-store field to {}: {} -> {}", matchedType, keyType, valueType);
+              "Failed to add context-store field - instrumentation.target.class={} instrumentation.target.classloader={} instrumentation.target.context={}->{}",
+              matchedType,
+              classLoader,
+              keyType,
+              valueType);
         }
       }
     }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/Reference.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/Reference.java
@@ -279,16 +279,22 @@ public class Reference {
     public static class MissingMethod extends Mismatch {
       private final String className;
       private final String method;
+      private final String methodType;
 
-      public MissingMethod(final String[] sources, final String className, final String method) {
+      public MissingMethod(
+          final String[] sources,
+          final String className,
+          final String method,
+          final String methodType) {
         super(sources);
         this.className = className;
         this.method = method;
+        this.methodType = methodType;
       }
 
       @Override
       String getMismatchDetails() {
-        return "Missing method " + className + "#" + method;
+        return "Missing method " + className + "#" + method + methodType;
       }
     }
 

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/ReferenceMatcher.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/ReferenceMatcher.java
@@ -183,7 +183,10 @@ public final class ReferenceMatcher implements IReferenceMatcher {
     for (Reference.Method missingMethod : indexedMethods.values()) {
       mismatches.add(
           new Reference.Mismatch.MissingMethod(
-              missingMethod.sources, missingMethod.name, missingMethod.methodType));
+              missingMethod.sources,
+              reference.className,
+              missingMethod.name,
+              missingMethod.methodType));
     }
 
     return mismatches.isEmpty();

--- a/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceConfigInstrumentation.java
+++ b/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceConfigInstrumentation.java
@@ -17,6 +17,7 @@ import static net.bytebuddy.matcher.ElementMatchers.not;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.Config;
+import datadog.trace.util.Strings;
 import de.thetaphi.forbiddenapis.SuppressForbidden;
 import java.util.Collections;
 import java.util.HashMap;
@@ -205,7 +206,12 @@ public class TraceConfigInstrumentation implements Instrumenter {
     }
 
     public TracerClassInstrumentation(final String className, final Set<String> methodNames) {
-      super("trace", "trace-config");
+      super(
+          "trace",
+          "trace-config",
+          "trace-config_"
+              + className
+              + (!Config.get().isDebugEnabled() ? "" : "[" + Strings.join(",", methodNames) + "]"));
       this.className = className;
       this.methodNames = methodNames;
     }

--- a/dd-smoke-tests/field-injection/src/test/groovy/datadog/smoketest/FieldInjectionSmokeTest.groovy
+++ b/dd-smoke-tests/field-injection/src/test/groovy/datadog/smoketest/FieldInjectionSmokeTest.groovy
@@ -21,7 +21,7 @@ import static datadog.trace.test.util.ForkedTestUtils.getMinMemoryArgumentForFor
 class FieldInjectionSmokeTest extends Specification {
 
   private static final Pattern CONTEXT_STORE_ALLOCATION =
-  Pattern.compile('.*Allocated ContextStore #(\\d+) to (\\S+) -> (\\S+)')
+  Pattern.compile('.*Allocated ContextStore #(\\d+) - instrumentation.target.context=(\\S+)->(\\S+)')
 
   String javaPath() {
     final String separator = System.getProperty("file.separator")

--- a/dd-smoke-tests/osgi/src/test/groovy/datadog/smoketest/AbstractOSGiSmokeTest.groovy
+++ b/dd-smoke-tests/osgi/src/test/groovy/datadog/smoketest/AbstractOSGiSmokeTest.groovy
@@ -48,7 +48,7 @@ abstract class AbstractOSGiSmokeTest extends AbstractSmokeTest {
         println it
         logHasErrors = true
       }
-      if (it.contains("Transformed datadog.smoketest.osgi.client.MessageClient")) {
+      if (it.contains("Transformed - instrumentation.target.class=datadog.smoketest.osgi.client.MessageClient")) {
         println it
         instrumentedMessageClient = true
       }


### PR DESCRIPTION
My goal is to make it easier to see all lines in debug logs related to a specific instrumentation or instrumenter class. Being able to correlate lines easily is great when we work with spans and traces, so working with the matchers and transformers should be as easy

TODO:

AgentInstaller$TransformLoggingListener

