### PR TITLE
Reduce size of emittingCheckpoints field from 4 bytes to 1 byte

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -76,7 +76,7 @@ public class DDSpan implements AgentSpan, CoreSpan<DDSpan> {
   private boolean forceKeep;
 
   // Marked as volatile to assure proper publication to child spans executed on different threads
-  volatile Boolean emittingCheckpoints = null;
+  private volatile byte emittingCheckpoints; // 0 = unset, 1 = true, -1 = false
 
   private final boolean withCheckpoints;
 
@@ -204,8 +204,8 @@ public class DDSpan implements AgentSpan, CoreSpan<DDSpan> {
     be emitted at all.
     */
     DDSpan rootSpan = getLocalRootSpan();
-    if (rootSpan.emittingCheckpoints == null) {
-      rootSpan.emittingCheckpoints = value;
+    if (rootSpan.emittingCheckpoints == 0) {
+      rootSpan.emittingCheckpoints = value ? 1 : (byte) -1;
       if (value) {
         rootSpan.setTag(CHECKPOINTED_TAG, value);
       }
@@ -220,7 +220,8 @@ public class DDSpan implements AgentSpan, CoreSpan<DDSpan> {
     local root span subtree must either be fully covered or no checkpoints should
     be emitted at all.
     */
-    return getLocalRootSpan().emittingCheckpoints;
+    byte flag = getLocalRootSpan().emittingCheckpoints;
+    return flag == 0 ? null : flag > 0 ? Boolean.TRUE : Boolean.FALSE;
   }
 
   @Override

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanTest.groovy
@@ -420,10 +420,10 @@ class DDSpanTest extends DDCoreSpecification {
 
     then:
     parent.isEmittingCheckpoints() == true
-    parent.@emittingCheckpoints == true // Access field directly instead of getter.
+    parent.@emittingCheckpoints == 1 // Access field directly instead of getter.
     parent.getTag(DDSpan.CHECKPOINTED_TAG) == true
     child.isEmittingCheckpoints() == true // flag is reflected in children
-    child.@emittingCheckpoints == null // but no value is stored in the field
+    child.@emittingCheckpoints == 0 // but no value is stored in the field
     child.getTag(DDSpan.CHECKPOINTED_TAG) == null // child span does not get the tag set
   }
 }


### PR DESCRIPTION
Estimated size before according to [JOL](https://github.com/openjdk/jol):
```
datadog.trace.core.DDSpan object internals:
OFF  SZ                                 TYPE DESCRIPTION                  VALUE
  0   8                                      (object header: mark)        N/A
  8   4                                      (object header: class)       N/A
 12   1                              boolean DDSpan.forceKeep             N/A
 13   1                              boolean DDSpan.withCheckpoints       N/A
 14   2                                      (alignment/padding gap)      
 16   8                                 long DDSpan.startTimeMicro        N/A
 24   8                                 long DDSpan.startTimeNano         N/A
 32   8                                 long DDSpan.durationNano          N/A
 40   4     datadog.trace.core.DDSpanContext DDSpan.context               N/A
 44   4                    java.lang.Boolean DDSpan.emittingCheckpoints   N/A
 48   4   datadog.trace.core.EndpointTracker DDSpan.endpointTracker       N/A
 52   4                                      (object alignment gap)      
Instance size: 56 bytes
Space losses: 2 bytes internal + 4 bytes external = 6 bytes total
```

After:
```
datadog.trace.core.DDSpan object internals:
OFF  SZ                                 TYPE DESCRIPTION                  VALUE
  0   8                                      (object header: mark)        N/A
  8   4                                      (object header: class)       N/A
 12   1                              boolean DDSpan.forceKeep             N/A
 13   1                                 byte DDSpan.emittingCheckpoints   N/A
 14   1                              boolean DDSpan.withCheckpoints       N/A
 15   1                                      (alignment/padding gap)      
 16   8                                 long DDSpan.startTimeMicro        N/A
 24   8                                 long DDSpan.startTimeNano         N/A
 32   8                                 long DDSpan.durationNano          N/A
 40   4     datadog.trace.core.DDSpanContext DDSpan.context               N/A
 44   4   datadog.trace.core.EndpointTracker DDSpan.endpointTracker       N/A
Instance size: 48 bytes
Space losses: 1 bytes internal + 0 bytes external = 1 bytes total
```