### PR TITLE
Save space by only storing the start-time in DDSpan once and converting it as appropriate

### DIFF
--- a/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanTest.groovy
@@ -219,10 +219,12 @@ class DDSpanTest extends DDCoreSpecification {
     span.durationNano % mod == 0
   }
 
-  def "stopping with a timestamp after start time yeilds a min duration of 1"() {
+  def "stopping with a timestamp before start time yields a min duration of 1"() {
     setup:
     def span = tracer.buildSpan("test").start()
-    span.finish(span.startTimeMicro - 10)
+
+    // remove tick precision part of our internal time to match previous test condition
+    span.finish(TimeUnit.MILLISECONDS.toMicros(TimeUnit.NANOSECONDS.toMillis(span.startTimeNano)) - 10)
 
     expect:
     span.durationNano == 1


### PR DESCRIPTION
This also avoids one call to `Clock.currentMicroTime()` / `System.currentTimeMillis()` for every internal-clock based span

One important historical behaviour to call out is "[stopping with a timestamp disables nanotime](https://github.com/DataDog/dd-trace-java/blob/v0.91.0/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanTest.groovy#L203)" - in other words when `finish` is called with a duration and the start time is from the internal clock then we need to remove the tick-based part (effectively anything smaller than millisecond precision.)

Estimated size before according to JOL: 
```
datadog.trace.core.DDSpan object internals:
OFF  SZ                                 TYPE DESCRIPTION                  VALUE
  0   8                                      (object header: mark)        N/A
  8   4                                      (object header: class)       N/A
 12   1                              boolean DDSpan.forceKeep             N/A
 13   1                                 byte DDSpan.emittingCheckpoints   N/A
 14   1                              boolean DDSpan.withCheckpoints       N/A
 15   1                                      (alignment/padding gap)      
 16   8                                 long DDSpan.startTimeMicro        N/A
 24   8                                 long DDSpan.startTimeNano         N/A
 32   8                                 long DDSpan.durationNano          N/A
 40   4     datadog.trace.core.DDSpanContext DDSpan.context               N/A
 44   4   datadog.trace.core.EndpointTracker DDSpan.endpointTracker       N/A
Instance size: 48 bytes
Space losses: 1 bytes internal + 0 bytes external = 1 bytes total
```

after:
```
datadog.trace.core.DDSpan object internals:
OFF  SZ                                 TYPE DESCRIPTION                  VALUE
  0   8                                      (object header: mark)        N/A
  8   4                                      (object header: class)       N/A
 12   1                              boolean DDSpan.externalClock         N/A
 13   1                              boolean DDSpan.forceKeep             N/A
 14   1                                 byte DDSpan.emittingCheckpoints   N/A
 15   1                              boolean DDSpan.withCheckpoints       N/A
 16   8                                 long DDSpan.startTimeNano         N/A
 24   8                                 long DDSpan.durationNano          N/A
 32   4     datadog.trace.core.DDSpanContext DDSpan.context               N/A
 36   4   datadog.trace.core.EndpointTracker DDSpan.endpointTracker       N/A
Instance size: 40 bytes
Space losses: 0 bytes internal + 0 bytes external = 0 bytes total
```