### PR TITLE
Move relative time calculations to tracer instance

### DIFF
--- a/dd-java-agent/instrumentation/jms/src/test/groovy/TimeInQueueForkedTest.groovy
+++ b/dd-java-agent/instrumentation/jms/src/test/groovy/TimeInQueueForkedTest.groovy
@@ -85,7 +85,7 @@ abstract class TimeInQueueForkedTestBase extends AgentTestRunner {
     receivedMessage4.text == messageText4
     receivedMessage5.text == messageText5
     // only four consume traces will be finished at this point
-    assertTraces(9) {
+    assertTraces(9, SORT_TRACES_BY_ID) {
       producerTrace(it, jmsResourceName)
       producerTrace(it, jmsResourceName)
       producerTrace(it, jmsResourceName)
@@ -102,7 +102,7 @@ abstract class TimeInQueueForkedTestBase extends AgentTestRunner {
 
     then:
     // now the last consume trace will also be finished
-    assertTraces(10) {
+    assertTraces(10, SORT_TRACES_BY_ID) {
       producerTrace(it, jmsResourceName)
       producerTrace(it, jmsResourceName)
       producerTrace(it, jmsResourceName)
@@ -155,7 +155,7 @@ abstract class TimeInQueueForkedTestBase extends AgentTestRunner {
     receivedMessage4.text == messageText4
     receivedMessage5.text == messageText5
     // only three consume traces will be finished at this point
-    assertTraces(6) {
+    assertTraces(6, SORT_TRACES_BY_ID) {
       producerTrace(it, jmsResourceName)
       producerTrace(it, jmsResourceName)
       producerTrace(it, jmsResourceName)
@@ -174,7 +174,7 @@ abstract class TimeInQueueForkedTestBase extends AgentTestRunner {
 
     then:
     // now the other consume traces will be finished
-    assertTraces(7) {
+    assertTraces(7, SORT_TRACES_BY_ID) {
       producerTrace(it, jmsResourceName)
       producerTrace(it, jmsResourceName)
       producerTrace(it, jmsResourceName)
@@ -233,7 +233,7 @@ abstract class TimeInQueueForkedTestBase extends AgentTestRunner {
     receivedMessage4.text == messageText4
     receivedMessage5.text == messageText5
     // only two consume traces will be finished at this point
-    assertTraces(6) {
+    assertTraces(6, SORT_TRACES_BY_ID) {
       producerTrace(it, jmsResourceName)
       producerTrace(it, jmsResourceName)
       producerTrace(it, jmsResourceName)
@@ -251,7 +251,7 @@ abstract class TimeInQueueForkedTestBase extends AgentTestRunner {
 
     then:
     // now the other consume traces will be finished
-    assertTraces(7) {
+    assertTraces(7, SORT_TRACES_BY_ID) {
       producerTrace(it, jmsResourceName)
       producerTrace(it, jmsResourceName)
       producerTrace(it, jmsResourceName)
@@ -312,7 +312,7 @@ abstract class TimeInQueueForkedTestBase extends AgentTestRunner {
     receivedMessage4.text == messageText4
     receivedMessage5.text == messageText5
     // only four consume traces will be finished at this point
-    assertTraces(9) {
+    assertTraces(9, SORT_TRACES_BY_ID) {
       producerTrace(it, jmsResourceName)
       producerTrace(it, jmsResourceName)
       producerTrace(it, jmsResourceName)
@@ -340,7 +340,7 @@ abstract class TimeInQueueForkedTestBase extends AgentTestRunner {
 
     then:
     // now the last consume trace will also be finished
-    assertTraces(10) {
+    assertTraces(10, SORT_TRACES_BY_ID) {
       producerTrace(it, jmsResourceName)
       producerTrace(it, jmsResourceName)
       producerTrace(it, jmsResourceName)
@@ -408,7 +408,7 @@ abstract class TimeInQueueForkedTestBase extends AgentTestRunner {
     receivedMessage4.text == messageText4
     receivedMessage5.text == messageText5
     // only three consume traces will be finished at this point
-    assertTraces(6) {
+    assertTraces(6, SORT_TRACES_BY_ID) {
       producerTrace(it, jmsResourceName)
       producerTrace(it, jmsResourceName)
       producerTrace(it, jmsResourceName)
@@ -427,7 +427,7 @@ abstract class TimeInQueueForkedTestBase extends AgentTestRunner {
 
     then:
     // now the other consume traces will be finished
-    assertTraces(7) {
+    assertTraces(7, SORT_TRACES_BY_ID) {
       producerTrace(it, jmsResourceName)
       producerTrace(it, jmsResourceName)
       producerTrace(it, jmsResourceName)
@@ -488,7 +488,7 @@ abstract class TimeInQueueForkedTestBase extends AgentTestRunner {
     receivedMessage4.text == messageText4
     receivedMessage5.text == messageText5
     // only two consume traces will be finished at this point
-    assertTraces(6) {
+    assertTraces(6, SORT_TRACES_BY_ID) {
       producerTrace(it, jmsResourceName)
       producerTrace(it, jmsResourceName)
       producerTrace(it, jmsResourceName)
@@ -506,7 +506,7 @@ abstract class TimeInQueueForkedTestBase extends AgentTestRunner {
 
     then:
     // now the other consume traces will be finished
-    assertTraces(7) {
+    assertTraces(7, SORT_TRACES_BY_ID) {
       producerTrace(it, jmsResourceName)
       producerTrace(it, jmsResourceName)
       producerTrace(it, jmsResourceName)

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTestBase.groovy
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTestBase.groovy
@@ -107,7 +107,7 @@ abstract class KafkaClientTestBase extends AgentTestRunner {
     received.value() == greeting
     received.key() == null
 
-    assertTraces(2) {
+    assertTraces(2, SORT_TRACES_BY_ID) {
       trace(3) {
         basicSpan(it, "parent")
         basicSpan(it, "producer callback", span(0))
@@ -188,7 +188,7 @@ abstract class KafkaClientTestBase extends AgentTestRunner {
     received.value() == greeting
     received.key() == null
 
-    assertTraces(2) {
+    assertTraces(2, SORT_TRACES_BY_ID) {
       trace(3) {
         basicSpan(it, "parent")
         basicSpan(it, "producer callback", span(0))
@@ -261,7 +261,7 @@ abstract class KafkaClientTestBase extends AgentTestRunner {
     received.value() == null
     received.key() == null
 
-    assertTraces(2) {
+    assertTraces(2, SORT_TRACES_BY_ID) {
       trace(1) {
         producerSpan(it, null, false, true)
       }
@@ -315,7 +315,7 @@ abstract class KafkaClientTestBase extends AgentTestRunner {
     first.value() == greeting
     first.key() == null
 
-    assertTraces(2) {
+    assertTraces(2, SORT_TRACES_BY_ID) {
       trace(1) {
         producerSpan(it)
       }
@@ -371,7 +371,7 @@ abstract class KafkaClientTestBase extends AgentTestRunner {
     first.value() == greeting
     first.key() == null
 
-    assertTraces(2) {
+    assertTraces(2, SORT_TRACES_BY_ID) {
       trace(1) {
         producerSpan(it)
       }
@@ -428,7 +428,7 @@ abstract class KafkaClientTestBase extends AgentTestRunner {
     last.value() == greeting
     last.key() == null
 
-    assertTraces(2) {
+    assertTraces(2, SORT_TRACES_BY_ID) {
       trace(1) {
         producerSpan(it)
       }
@@ -487,7 +487,7 @@ abstract class KafkaClientTestBase extends AgentTestRunner {
     }
     receivedSet.isEmpty()
 
-    assertTraces(9) {
+    assertTraces(9, SORT_TRACES_BY_ID) {
 
       // producing traces
       trace(1) {
@@ -610,7 +610,7 @@ abstract class KafkaClientTestBase extends AgentTestRunner {
     }
     assert receivedSet.isEmpty()
 
-    assertTraces(4) {
+    assertTraces(4, SORT_TRACES_BY_ID) {
       trace(7) {
         basicSpan(it, "parent")
         basicSpan(it, "producer callback", span(0))

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/test/groovy/RabbitMQTest.groovy
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/test/groovy/RabbitMQTest.groovy
@@ -117,7 +117,7 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
     new String(response.getBody()) == "Hello, world!"
 
     and:
-    assertTraces(2) {
+    assertTraces(2, SORT_TRACES_BY_ID) {
       def publishSpan = null
       trace(5, true) {
         publishSpan = span(0)
@@ -155,7 +155,7 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
     new String(response.getBody()) == "Hello, world!"
 
     and:
-    assertTraces(3) {
+    assertTraces(3, SORT_TRACES_BY_ID) {
       def publishSpan = null
       trace(1) {
         rabbitSpan(it, "queue.declare")
@@ -215,7 +215,7 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
     def resourceQueueName = messageCount % 2 == 0 ? "<generated>" : queueName
 
     expect:
-    assertTraces(4 + (messageCount * 2)) {
+    assertTraces(4 + (messageCount * 2), SORT_TRACES_BY_ID) {
       trace(1) {
         rabbitSpan(it, "exchange.declare")
       }
@@ -292,7 +292,7 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
     phaser.arriveAndAwaitAdvance()
 
     expect:
-    assertTraces(6) {
+    assertTraces(6, SORT_TRACES_BY_ID) {
       trace(1) {
         rabbitSpan(it, "exchange.declare")
       }
@@ -338,7 +338,7 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
 
     and:
 
-    assertTraces(1) {
+    assertTraces(1, SORT_TRACES_BY_ID) {
       trace(1) {
         rabbitSpan(it, command, false, null, throwable, errorMsg)
       }
@@ -371,7 +371,7 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
     message == "foo"
 
     and:
-    assertTraces(3) {
+    assertTraces(3, SORT_TRACES_BY_ID) {
       trace(1) {
         rabbitSpan(it, "queue.declare")
       }
@@ -426,7 +426,7 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
     body == "Hello, world!"
 
     and:
-    assertTraces(expectedTraces) {
+    assertTraces(expectedTraces, SORT_TRACES_BY_ID) {
       def publishSpan = null
       trace(5) {
         publishSpan = span(1)
@@ -500,7 +500,7 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
     body == "Hello, world!"
 
     and:
-    assertTraces(expectedTraces) {
+    assertTraces(expectedTraces, SORT_TRACES_BY_ID) {
       def publishSpan = null
       trace(5) {
         publishSpan = span(1)

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/AgentTestRunner.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/AgentTestRunner.groovy
@@ -270,6 +270,20 @@ abstract class AgentTestRunner extends DDSpecification implements AgentBuilder.L
     ListWriterAssert.assertTraces(TEST_WRITER, size, ignoreAdditionalTraces, spec)
   }
 
+  protected static final Comparator<List<DDSpan>> SORT_TRACES_BY_ID = ListWriterAssert.SORT_TRACES_BY_ID
+  protected static final Comparator<List<DDSpan>> SORT_TRACES_BY_START = ListWriterAssert.SORT_TRACES_BY_START
+
+  void assertTraces(
+    final int size,
+    final Comparator<List<DDSpan>> traceSorter,
+    @ClosureParams(
+    value = SimpleType,
+    options = "datadog.trace.agent.test.asserts.ListWriterAssert")
+    @DelegatesTo(value = ListWriterAssert, strategy = Closure.DELEGATE_FIRST)
+    final Closure spec) {
+    ListWriterAssert.assertTraces(TEST_WRITER, size, false, traceSorter, spec)
+  }
+
   void blockUntilChildSpansFinished(final int numberOfSpans) {
     final AgentSpan span = TEST_TRACER.activeSpan()
 

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/ListWriterAssert.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/ListWriterAssert.groovy
@@ -14,6 +14,9 @@ import java.util.concurrent.atomic.AtomicInteger
 import static TraceAssert.assertTrace
 
 class ListWriterAssert {
+  public static final Comparator<List<DDSpan>> SORT_TRACES_BY_ID = new SortTracesById()
+  public static final Comparator<List<DDSpan>> SORT_TRACES_BY_START = new SortTracesByStart()
+
   private List<List<DDSpan>> traces
   private final int size
   private final Set<Integer> assertedIndexes = new HashSet<>()
@@ -34,12 +37,20 @@ class ListWriterAssert {
     boolean ignoreAdditionalTraces,
     @ClosureParams(value = SimpleType, options = ['datadog.trace.agent.test.asserts.ListWriterAssert'])
     @DelegatesTo(value = ListWriterAssert, strategy = Closure.DELEGATE_FIRST) Closure spec) {
+    assertTraces(writer, expectedSize, ignoreAdditionalTraces, SORT_TRACES_BY_START, spec)
+  }
+
+  static void assertTraces(ListWriter writer, int expectedSize,
+    boolean ignoreAdditionalTraces,
+    Comparator<List<DDSpan>> traceSorter,
+    @ClosureParams(value = SimpleType, options = ['datadog.trace.agent.test.asserts.ListWriterAssert'])
+    @DelegatesTo(value = ListWriterAssert, strategy = Closure.DELEGATE_FIRST) Closure spec) {
     try {
       writer.waitForTraces(expectedSize)
       def array = writer.toArray()
       assert array.length == expectedSize
       def traces = (Arrays.asList(array) as List<List<DDSpan>>)
-      Collections.sort(traces, TraceSorter.SORTER)
+      Collections.sort(traces, traceSorter)
       def asserter = new ListWriterAssert(traces)
       def clone = (Closure) spec.clone()
       clone.delegate = asserter
@@ -116,9 +127,7 @@ class ListWriterAssert {
     assert assertedIndexes.size() == size
   }
 
-  private static class TraceSorter implements Comparator<List<DDSpan>> {
-    static final TraceSorter SORTER = new TraceSorter()
-
+  private static class SortTracesByStart implements Comparator<List<DDSpan>> {
     @Override
     int compare(List<DDSpan> o1, List<DDSpan> o2) {
       return Long.compare(traceStart(o1), traceStart(o2))
@@ -126,7 +135,19 @@ class ListWriterAssert {
 
     long traceStart(List<DDSpan> trace) {
       assert !trace.isEmpty()
-      return trace.get(0).localRootSpan.context().trace.startNanoTicks
+      return trace.get(0).localRootSpan.startTime
+    }
+  }
+
+  private static class SortTracesById implements Comparator<List<DDSpan>> {
+    @Override
+    int compare(List<DDSpan> o1, List<DDSpan> o2) {
+      return Long.compare(rootSpanId(o1), rootSpanId(o2))
+    }
+
+    long rootSpanId(List<DDSpan> trace) {
+      assert !trace.isEmpty()
+      return trace.get(0).localRootSpan.spanId.toLong()
     }
   }
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -50,6 +50,9 @@ public final class ConfigDefaults {
   static final String DEFAULT_PROPAGATION_STYLE_INJECT = PropagationStyle.DATADOG.name();
   static final boolean DEFAULT_JMX_FETCH_ENABLED = true;
   static final boolean DEFAULT_TRACE_AGENT_V05_ENABLED = false;
+  static final int DEFAULT_CLOCK_CHECK_PERIOD = 60; // seconds
+  static final int DEFAULT_CLOCK_SKEW_LIMIT = 10; // seconds
+
   static final boolean DEFAULT_JMX_FETCH_MULTIPLE_RUNTIME_SERVICES_ENABLED = false;
   static final int DEFAULT_JMX_FETCH_MULTIPLE_RUNTIME_SERVICES_LIMIT = 10;
 

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -51,8 +51,7 @@ public final class ConfigDefaults {
   static final boolean DEFAULT_JMX_FETCH_ENABLED = true;
   static final boolean DEFAULT_TRACE_AGENT_V05_ENABLED = false;
 
-  static final int DEFAULT_CLOCK_SYNC_PERIOD = 30_000; // milliseconds
-  static final int DEFAULT_CLOCK_DRIFT_LIMIT = 1; // milliseconds
+  static final int DEFAULT_CLOCK_SYNC_PERIOD = 30; // seconds
 
   static final boolean DEFAULT_JMX_FETCH_MULTIPLE_RUNTIME_SERVICES_ENABLED = false;
   static final int DEFAULT_JMX_FETCH_MULTIPLE_RUNTIME_SERVICES_LIMIT = 10;

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -50,8 +50,9 @@ public final class ConfigDefaults {
   static final String DEFAULT_PROPAGATION_STYLE_INJECT = PropagationStyle.DATADOG.name();
   static final boolean DEFAULT_JMX_FETCH_ENABLED = true;
   static final boolean DEFAULT_TRACE_AGENT_V05_ENABLED = false;
-  static final int DEFAULT_CLOCK_CHECK_PERIOD = 60; // seconds
-  static final int DEFAULT_CLOCK_SKEW_LIMIT = 10; // seconds
+
+  static final int DEFAULT_CLOCK_SYNC_PERIOD = 30_000; // milliseconds
+  static final int DEFAULT_CLOCK_DRIFT_LIMIT = 1; // milliseconds
 
   static final boolean DEFAULT_JMX_FETCH_MULTIPLE_RUNTIME_SERVICES_ENABLED = false;
   static final int DEFAULT_JMX_FETCH_MULTIPLE_RUNTIME_SERVICES_LIMIT = 10;

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
@@ -64,7 +64,6 @@ public final class TracerConfig {
       "trace.sampling.mechanism.validation.disabled";
 
   public static final String CLOCK_SYNC_PERIOD = "trace.clock.sync.period";
-  public static final String CLOCK_DRIFT_LIMIT = "trace.clock.drift.limit";
 
   private TracerConfig() {}
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
@@ -63,5 +63,8 @@ public final class TracerConfig {
   public static final String SAMPLING_MECHANISM_VALIDATION_DISABLED =
       "trace.sampling.mechanism.validation.disabled";
 
+  public static final String CLOCK_CHECK_PERIOD = "trace.clock.check.period";
+  public static final String CLOCK_SKEW_LIMIT = "trace.clock.skew.limit";
+
   private TracerConfig() {}
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
@@ -63,8 +63,8 @@ public final class TracerConfig {
   public static final String SAMPLING_MECHANISM_VALIDATION_DISABLED =
       "trace.sampling.mechanism.validation.disabled";
 
-  public static final String CLOCK_CHECK_PERIOD = "trace.clock.check.period";
-  public static final String CLOCK_SKEW_LIMIT = "trace.clock.skew.limit";
+  public static final String CLOCK_SYNC_PERIOD = "trace.clock.sync.period";
+  public static final String CLOCK_DRIFT_LIMIT = "trace.clock.drift.limit";
 
   private TracerConfig() {}
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -404,7 +404,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
 
     this.startTimeNano = Clock.currentNanoTime();
     this.startNanoTicks = Clock.currentNanoTicks();
-    this.clockSyncPeriod = SECONDS.toNanos(config.getClockSyncPeriod());
+    this.clockSyncPeriod = Math.max(1_000_000L, SECONDS.toNanos(config.getClockSyncPeriod()));
     this.lastSyncTicks = startNanoTicks;
 
     this.checkpointer = SamplingCheckpointer.create();
@@ -569,7 +569,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
    */
   long getTimeWithNanoTicks(long nanoTicks) {
     long computedNanoTime = startTimeNano + Math.max(0, nanoTicks - startNanoTicks);
-    if (nanoTicks - lastSyncTicks > clockSyncPeriod) {
+    if (nanoTicks - lastSyncTicks >= clockSyncPeriod) {
       lastSyncTicks = nanoTicks;
       long drift = computedNanoTime - Clock.currentNanoTime();
       if (Math.abs(drift + counterDrift) >= 1_000_000L) { // allow up to 1ms of drift

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -97,8 +97,6 @@ public class CoreTracer implements AgentTracer.TracerAPI {
   private final long startNanoTicks;
   /** How often should traced threads check clock ticks against the wall clock */
   private final long clockSyncPeriod;
-  /** Maximum amount of clock drift tolerated between ticks and the wall clock */
-  private final long clockDriftLimit;
   /** Last time (in nanosecond ticks) the clock was checked for drift */
   private volatile long lastSyncTicks;
   /** Nanosecond offset to counter clock drift */
@@ -406,8 +404,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
 
     this.startTimeNano = Clock.currentNanoTime();
     this.startNanoTicks = Clock.currentNanoTicks();
-    this.clockSyncPeriod = MILLISECONDS.toNanos(config.getClockSyncPeriod());
-    this.clockDriftLimit = MILLISECONDS.toNanos(config.getClockDriftLimit());
+    this.clockSyncPeriod = SECONDS.toNanos(config.getClockSyncPeriod());
     this.lastSyncTicks = startNanoTicks;
 
     this.checkpointer = SamplingCheckpointer.create();
@@ -575,7 +572,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
     if (nanoTicks - lastSyncTicks > clockSyncPeriod) {
       lastSyncTicks = nanoTicks;
       long drift = computedNanoTime - Clock.currentNanoTime();
-      if (Math.abs(drift + counterDrift) >= clockDriftLimit) {
+      if (Math.abs(drift + counterDrift) >= 1_000_000L) { // allow up to 1ms of drift
         counterDrift = -MILLISECONDS.toNanos(NANOSECONDS.toMillis(drift));
       }
     }

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -570,11 +570,11 @@ public class CoreTracer implements AgentTracer.TracerAPI {
   long getTimeWithNanoTicks(long nanoTicks) {
     long computedNanoTime = startTimeNano + Math.max(0, nanoTicks - startNanoTicks);
     if (nanoTicks - lastSyncTicks >= clockSyncPeriod) {
-      lastSyncTicks = nanoTicks;
       long drift = computedNanoTime - Clock.currentNanoTime();
       if (Math.abs(drift + counterDrift) >= 1_000_000L) { // allow up to 1ms of drift
         counterDrift = -MILLISECONDS.toNanos(NANOSECONDS.toMillis(drift));
       }
+      lastSyncTicks = nanoTicks;
     }
     return computedNanoTime + counterDrift;
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -108,7 +108,7 @@ public class DDSpan implements AgentSpan, CoreSpan<DDSpan>, AttachableWrapper {
     this.withCheckpoints = emitLocalCheckpoints;
 
     if (timestampMicro <= 0L) {
-      // capture internal time
+      // note: getting internal time from the trace implicitly 'touches' it
       startTimeNano = context.getTrace().getCurrentTimeNano();
       externalClock = false;
     } else {
@@ -150,6 +150,7 @@ public class DDSpan implements AgentSpan, CoreSpan<DDSpan>, AttachableWrapper {
       // first capture wall-clock offset from 'now' to external stop time
       long externalOffsetMicros = stopTimeMicros - Clock.currentMicroTime();
       // immediately afterwards calculate internal duration of span to 'now'
+      // note: getting internal time from the trace implicitly 'touches' it
       durationNano = context.getTrace().getCurrentTimeNano() - startTimeNano;
       // drop nanosecond precision part of internal duration (expected behaviour)
       durationNano = MILLISECONDS.toNanos(NANOSECONDS.toMillis(durationNano));
@@ -205,6 +206,7 @@ public class DDSpan implements AgentSpan, CoreSpan<DDSpan>, AttachableWrapper {
   public final boolean phasedFinish() {
     long durationNano;
     if (!externalClock) {
+      // note: getting internal time from the trace implicitly 'touches' it
       durationNano = context.getTrace().getCurrentTimeNano() - startTimeNano;
     } else {
       durationNano = MICROSECONDS.toNanos(Clock.currentMicroTime()) - startTimeNano;

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -149,7 +149,7 @@ public class DDSpan implements AgentSpan, CoreSpan<DDSpan>, AttachableWrapper {
     long adjustedStartTimeNano;
     if (!externalClock) {
       // remove tick precision part of our internal time to better match external clock
-      adjustedStartTimeNano = MILLISECONDS.toNanos(NANOSECONDS.toMillis(startTimeNano));
+      adjustedStartTimeNano = MILLISECONDS.toNanos(NANOSECONDS.toMillis(startTimeNano + 500_000));
     } else {
       adjustedStartTimeNano = startTimeNano;
     }

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -208,6 +208,7 @@ public class DDSpan implements AgentSpan, CoreSpan<DDSpan>, AttachableWrapper {
       durationNano = context.getTrace().getCurrentTimeNano() - startTimeNano;
     } else {
       durationNano = MICROSECONDS.toNanos(Clock.currentMicroTime()) - startTimeNano;
+      context.getTrace().touch(); // external clock: explicitly update lastReferenced
     }
     // Flip the negative bit of the result to allow verifying that publish() is only called once.
     if (DURATION_NANO_UPDATER.compareAndSet(this, 0, Math.max(1, durationNano) | Long.MIN_VALUE)) {

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -114,7 +114,7 @@ public class DDSpan implements AgentSpan, CoreSpan<DDSpan>, AttachableWrapper {
     } else {
       startTimeNano = MICROSECONDS.toNanos(timestampMicro);
       externalClock = true;
-      context.getTrace().touch(); // Update lastReferenced
+      context.getTrace().touch(); // external clock: explicitly update lastReferenced
     }
   }
 
@@ -157,8 +157,8 @@ public class DDSpan implements AgentSpan, CoreSpan<DDSpan>, AttachableWrapper {
       durationNano += MICROSECONDS.toNanos(externalOffsetMicros);
     } else {
       durationNano = MICROSECONDS.toNanos(stopTimeMicros) - startTimeNano;
+      context.getTrace().touch(); // external clock: explicitly update lastReferenced
     }
-    context.getTrace().touch(); // Update timestamp
     finishAndAddToTrace(durationNano);
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/PendingTrace.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/PendingTrace.java
@@ -60,13 +60,6 @@ public class PendingTrace implements AgentTrace, PendingTraceBuffer.Element {
   private final PendingTraceBuffer pendingTraceBuffer;
   private final boolean strictTraceWrites;
 
-  // TODO: consider moving these time fields into DDTracer to ensure that traces have precise
-  // relative time
-  /** Trace start time in nano seconds measured up to a millisecond accuracy */
-  private final long startTimeNano;
-  /** Nano second ticks value at trace start */
-  private final long startNanoTicks;
-
   private final ConcurrentLinkedDeque<DDSpan> finishedSpans = new ConcurrentLinkedDeque<>();
 
   // We must maintain a separate count because ConcurrentLinkedDeque.size() is a linear operation.
@@ -112,9 +105,6 @@ public class PendingTrace implements AgentTrace, PendingTraceBuffer.Element {
     this.traceId = traceId;
     this.pendingTraceBuffer = pendingTraceBuffer;
     this.strictTraceWrites = strictTraceWrites;
-
-    startTimeNano = Clock.currentNanoTime();
-    startNanoTicks = Clock.currentNanoTicks();
   }
 
   CoreTracer getTracer() {
@@ -134,7 +124,7 @@ public class PendingTrace implements AgentTrace, PendingTraceBuffer.Element {
   public long getCurrentTimeNano() {
     long nanoTicks = Clock.currentNanoTicks();
     lastReferenced = nanoTicks;
-    return startTimeNano + Math.max(0, nanoTicks - startNanoTicks);
+    return tracer.getTimeWithNanoTicks(nanoTicks);
   }
 
   public void touch() {

--- a/dd-trace-core/src/main/java/datadog/trace/core/PendingTrace.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/PendingTrace.java
@@ -112,7 +112,7 @@ public class PendingTrace implements AgentTrace, PendingTraceBuffer.Element {
   }
 
   /**
-   * Current timestamp in nanoseconds.
+   * Current timestamp in nanoseconds; 'touches' the trace by updating {@link #lastReferenced}.
    *
    * <p>Note: it is not possible to get 'real' nanosecond time. This method uses trace start time
    * (which has millisecond precision) as a reference and it gets time with nanosecond precision

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanTest.groovy
@@ -217,7 +217,8 @@ class DDSpanTest extends DDCoreSpecification {
     Math.abs(TimeUnit.NANOSECONDS.toSeconds(span.startTime) - TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis())) < 5
     span.durationNano >= TimeUnit.MILLISECONDS.toNanos(betweenDur)
     span.durationNano <= TimeUnit.MILLISECONDS.toNanos(total)
-    span.durationNano % mod == 0
+    // true span duration can be <1ms if clock was about to tick over, so allow for that
+    (span.durationNano % mod == 0) || (span.durationNano == 1)
   }
 
   def "stopping with a timestamp before start time yields a min duration of 1"() {

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceBufferTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceBufferTest.groovy
@@ -80,6 +80,7 @@ class PendingTraceBufferTest extends DDSpecification {
     trace.pendingReferenceCount == 1
     1 * bufferSpy.enqueue(trace)
     _ * tracer.getPartialFlushMinSpans() >> 10
+    1 * tracer.getTimeWithNanoTicks(_)
     1 * tracer.onFinish(span)
     0 * _
 
@@ -111,6 +112,7 @@ class PendingTraceBufferTest extends DDSpecification {
     trace.pendingReferenceCount == 1
     1 * bufferSpy.enqueue(trace)
     _ * tracer.getPartialFlushMinSpans() >> 10
+    1 * tracer.getTimeWithNanoTicks(_)
     1 * tracer.onFinish(parent)
     0 * _
 
@@ -123,6 +125,7 @@ class PendingTraceBufferTest extends DDSpecification {
     1 * tracer.write({ it.size() == 2 })
     1 * tracer.writeTimer() >> Monitoring.DISABLED.newTimer("")
     _ * tracer.getPartialFlushMinSpans() >> 10
+    1 * tracer.getTimeWithNanoTicks(_)
     1 * tracer.onFinish(child)
     0 * _
   }
@@ -142,6 +145,7 @@ class PendingTraceBufferTest extends DDSpecification {
     _ * tracer.getPartialFlushMinSpans() >> 10
     _ * tracer.mapServiceName(_)
     _ * tracer.onStart(_)
+    _ * tracer.getTimeWithNanoTicks(_)
     _ * tracer.onFinish(_)
     1 * tracer.writeTimer() >> Monitoring.DISABLED.newTimer("")
     1 * tracer.write(_) >> { List<List<DDSpan>> spans ->
@@ -168,6 +172,7 @@ class PendingTraceBufferTest extends DDSpecification {
     _ * tracer.getPartialFlushMinSpans() >> 10
     _ * tracer.mapServiceName(_)
     _ * tracer.onStart(_)
+    _ * tracer.getTimeWithNanoTicks(_)
     _ * tracer.onFinish(_)
     0 * _
 
@@ -182,6 +187,7 @@ class PendingTraceBufferTest extends DDSpecification {
     _ * tracer.getPartialFlushMinSpans() >> 10
     _ * tracer.mapServiceName(_)
     1 * tracer.onStart(_)
+    2 * tracer.getTimeWithNanoTicks(_)
     1 * tracer.onFinish(_)
     0 * _
     pendingTrace.isEnqueued == 0
@@ -207,6 +213,7 @@ class PendingTraceBufferTest extends DDSpecification {
     !trace.rootSpanWritten
     1 * bufferSpy.enqueue(trace)
     _ * tracer.getPartialFlushMinSpans() >> 10
+    1 * tracer.getTimeWithNanoTicks(_)
     1 * tracer.onFinish(parent)
     0 * _
 
@@ -258,6 +265,7 @@ class PendingTraceBufferTest extends DDSpecification {
       parentLatch.countDown()
     }
     _ * tracer.getPartialFlushMinSpans() >> 10
+    1 * tracer.getTimeWithNanoTicks(_)
     1 * tracer.onFinish(parent)
     0 * _
 
@@ -278,6 +286,7 @@ class PendingTraceBufferTest extends DDSpecification {
     }
     _ * tracer.mapServiceName(_)
     1 * tracer.onStart(_)
+    2 * tracer.getTimeWithNanoTicks(_)
     1 * tracer.onFinish(_)
     0 * _
   }
@@ -347,6 +356,7 @@ class PendingTraceBufferTest extends DDSpecification {
     1 * tracer.getPartialFlushMinSpans() >> 10000
     1 * tracer.mapServiceName(_)
     1 * tracer.onStart(_)
+    2 * tracer.getTimeWithNanoTicks(_)
     1 * tracer.onFinish(_)
     0 * _
 
@@ -362,6 +372,7 @@ class PendingTraceBufferTest extends DDSpecification {
     _ * tracer.getPartialFlushMinSpans() >> 10000
     _ * tracer.mapServiceName(_)
     _ * tracer.onStart(_)
+    _ * tracer.getTimeWithNanoTicks(_)
     _ * tracer.onFinish(_)
     0 * _
 

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -8,7 +8,6 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_APPSEC_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_APPSEC_REPORTING_INBAND;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_APPSEC_TRACE_RATE_LIMIT;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_CIVISIBILITY_ENABLED;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_CLOCK_DRIFT_LIMIT;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_CLOCK_SYNC_PERIOD;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_CWS_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_CWS_TLS_REFRESH;
@@ -195,7 +194,6 @@ import static datadog.trace.api.config.TracerConfig.AGENT_NAMED_PIPE;
 import static datadog.trace.api.config.TracerConfig.AGENT_PORT_LEGACY;
 import static datadog.trace.api.config.TracerConfig.AGENT_TIMEOUT;
 import static datadog.trace.api.config.TracerConfig.AGENT_UNIX_DOMAIN_SOCKET;
-import static datadog.trace.api.config.TracerConfig.CLOCK_DRIFT_LIMIT;
 import static datadog.trace.api.config.TracerConfig.CLOCK_SYNC_PERIOD;
 import static datadog.trace.api.config.TracerConfig.ENABLE_TRACE_AGENT_V05;
 import static datadog.trace.api.config.TracerConfig.HEADER_TAGS;
@@ -352,7 +350,6 @@ public class Config {
   private final Set<PropagationStyle> propagationStylesToExtract;
   private final Set<PropagationStyle> propagationStylesToInject;
   private final int clockSyncPeriod;
-  private final int clockDriftLimit;
 
   private final String dogStatsDNamedPipe;
   private final int dogStatsDStartDelay;
@@ -738,7 +735,6 @@ public class Config {
             PROPAGATION_STYLE_INJECT, DEFAULT_PROPAGATION_STYLE_INJECT);
 
     clockSyncPeriod = configProvider.getInteger(CLOCK_SYNC_PERIOD, DEFAULT_CLOCK_SYNC_PERIOD);
-    clockDriftLimit = configProvider.getInteger(CLOCK_DRIFT_LIMIT, DEFAULT_CLOCK_DRIFT_LIMIT);
 
     dogStatsDNamedPipe = configProvider.getString(DOGSTATSD_NAMED_PIPE);
 
@@ -1206,10 +1202,6 @@ public class Config {
 
   public int getClockSyncPeriod() {
     return clockSyncPeriod;
-  }
-
-  public int getClockDriftLimit() {
-    return clockDriftLimit;
   }
 
   public String getDogStatsDNamedPipe() {
@@ -2255,8 +2247,6 @@ public class Config {
         + propagationStylesToInject
         + ", clockSyncPeriod="
         + clockSyncPeriod
-        + ", clockDriftLimit="
-        + clockDriftLimit
         + ", jmxFetchEnabled="
         + jmxFetchEnabled
         + ", dogStatsDStartDelay="

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -8,8 +8,8 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_APPSEC_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_APPSEC_REPORTING_INBAND;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_APPSEC_TRACE_RATE_LIMIT;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_CIVISIBILITY_ENABLED;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_CLOCK_CHECK_PERIOD;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_CLOCK_SKEW_LIMIT;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_CLOCK_DRIFT_LIMIT;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_CLOCK_SYNC_PERIOD;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_CWS_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_CWS_TLS_REFRESH;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_DB_CLIENT_HOST_SPLIT_BY_INSTANCE;
@@ -195,8 +195,8 @@ import static datadog.trace.api.config.TracerConfig.AGENT_NAMED_PIPE;
 import static datadog.trace.api.config.TracerConfig.AGENT_PORT_LEGACY;
 import static datadog.trace.api.config.TracerConfig.AGENT_TIMEOUT;
 import static datadog.trace.api.config.TracerConfig.AGENT_UNIX_DOMAIN_SOCKET;
-import static datadog.trace.api.config.TracerConfig.CLOCK_CHECK_PERIOD;
-import static datadog.trace.api.config.TracerConfig.CLOCK_SKEW_LIMIT;
+import static datadog.trace.api.config.TracerConfig.CLOCK_DRIFT_LIMIT;
+import static datadog.trace.api.config.TracerConfig.CLOCK_SYNC_PERIOD;
 import static datadog.trace.api.config.TracerConfig.ENABLE_TRACE_AGENT_V05;
 import static datadog.trace.api.config.TracerConfig.HEADER_TAGS;
 import static datadog.trace.api.config.TracerConfig.HTTP_CLIENT_ERROR_STATUSES;
@@ -351,8 +351,8 @@ public class Config {
   private final boolean logExtractHeaderNames;
   private final Set<PropagationStyle> propagationStylesToExtract;
   private final Set<PropagationStyle> propagationStylesToInject;
-  private final int clockCheckPeriod;
-  private final int clockSkewLimit;
+  private final int clockSyncPeriod;
+  private final int clockDriftLimit;
 
   private final String dogStatsDNamedPipe;
   private final int dogStatsDStartDelay;
@@ -737,8 +737,8 @@ public class Config {
         getPropagationStyleSetSettingFromEnvironmentOrDefault(
             PROPAGATION_STYLE_INJECT, DEFAULT_PROPAGATION_STYLE_INJECT);
 
-    clockCheckPeriod = configProvider.getInteger(CLOCK_CHECK_PERIOD, DEFAULT_CLOCK_CHECK_PERIOD);
-    clockSkewLimit = configProvider.getInteger(CLOCK_SKEW_LIMIT, DEFAULT_CLOCK_SKEW_LIMIT);
+    clockSyncPeriod = configProvider.getInteger(CLOCK_SYNC_PERIOD, DEFAULT_CLOCK_SYNC_PERIOD);
+    clockDriftLimit = configProvider.getInteger(CLOCK_DRIFT_LIMIT, DEFAULT_CLOCK_DRIFT_LIMIT);
 
     dogStatsDNamedPipe = configProvider.getString(DOGSTATSD_NAMED_PIPE);
 
@@ -1204,12 +1204,12 @@ public class Config {
     return propagationStylesToInject;
   }
 
-  public int getClockCheckPeriod() {
-    return clockCheckPeriod;
+  public int getClockSyncPeriod() {
+    return clockSyncPeriod;
   }
 
-  public int getClockSkewLimit() {
-    return clockSkewLimit;
+  public int getClockDriftLimit() {
+    return clockDriftLimit;
   }
 
   public String getDogStatsDNamedPipe() {
@@ -2253,10 +2253,10 @@ public class Config {
         + propagationStylesToExtract
         + ", propagationStylesToInject="
         + propagationStylesToInject
-        + ", clockCheckPeriod="
-        + clockCheckPeriod
-        + ", clockSkewLimit="
-        + clockSkewLimit
+        + ", clockSyncPeriod="
+        + clockSyncPeriod
+        + ", clockDriftLimit="
+        + clockDriftLimit
         + ", jmxFetchEnabled="
         + jmxFetchEnabled
         + ", dogStatsDStartDelay="

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -8,6 +8,8 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_APPSEC_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_APPSEC_REPORTING_INBAND;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_APPSEC_TRACE_RATE_LIMIT;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_CIVISIBILITY_ENABLED;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_CLOCK_CHECK_PERIOD;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_CLOCK_SKEW_LIMIT;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_CWS_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_CWS_TLS_REFRESH;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_DB_CLIENT_HOST_SPLIT_BY_INSTANCE;
@@ -193,6 +195,8 @@ import static datadog.trace.api.config.TracerConfig.AGENT_NAMED_PIPE;
 import static datadog.trace.api.config.TracerConfig.AGENT_PORT_LEGACY;
 import static datadog.trace.api.config.TracerConfig.AGENT_TIMEOUT;
 import static datadog.trace.api.config.TracerConfig.AGENT_UNIX_DOMAIN_SOCKET;
+import static datadog.trace.api.config.TracerConfig.CLOCK_CHECK_PERIOD;
+import static datadog.trace.api.config.TracerConfig.CLOCK_SKEW_LIMIT;
 import static datadog.trace.api.config.TracerConfig.ENABLE_TRACE_AGENT_V05;
 import static datadog.trace.api.config.TracerConfig.HEADER_TAGS;
 import static datadog.trace.api.config.TracerConfig.HTTP_CLIENT_ERROR_STATUSES;
@@ -347,6 +351,8 @@ public class Config {
   private final boolean logExtractHeaderNames;
   private final Set<PropagationStyle> propagationStylesToExtract;
   private final Set<PropagationStyle> propagationStylesToInject;
+  private final int clockCheckPeriod;
+  private final int clockSkewLimit;
 
   private final String dogStatsDNamedPipe;
   private final int dogStatsDStartDelay;
@@ -730,6 +736,9 @@ public class Config {
     propagationStylesToInject =
         getPropagationStyleSetSettingFromEnvironmentOrDefault(
             PROPAGATION_STYLE_INJECT, DEFAULT_PROPAGATION_STYLE_INJECT);
+
+    clockCheckPeriod = configProvider.getInteger(CLOCK_CHECK_PERIOD, DEFAULT_CLOCK_CHECK_PERIOD);
+    clockSkewLimit = configProvider.getInteger(CLOCK_SKEW_LIMIT, DEFAULT_CLOCK_SKEW_LIMIT);
 
     dogStatsDNamedPipe = configProvider.getString(DOGSTATSD_NAMED_PIPE);
 
@@ -1193,6 +1202,14 @@ public class Config {
 
   public Set<PropagationStyle> getPropagationStylesToInject() {
     return propagationStylesToInject;
+  }
+
+  public int getClockCheckPeriod() {
+    return clockCheckPeriod;
+  }
+
+  public int getClockSkewLimit() {
+    return clockSkewLimit;
   }
 
   public String getDogStatsDNamedPipe() {
@@ -2236,6 +2253,10 @@ public class Config {
         + propagationStylesToExtract
         + ", propagationStylesToInject="
         + propagationStylesToInject
+        + ", clockCheckPeriod="
+        + clockCheckPeriod
+        + ", clockSkewLimit="
+        + clockSkewLimit
         + ", jmxFetchEnabled="
         + jmxFetchEnabled
         + ", dogStatsDStartDelay="


### PR DESCRIPTION
With this change we call `System.currentTimeMillis()` once when creating the tracer - we then use `System.nanoTime()` for all relative times of traces under that tracer, plus a periodic adjustment. As well as reducing the CPU overhead of each trace it also saves us 16 bytes in `PendingTrace` because we no longer need to save the start time and start ticks per-trace.

Every 30 seconds (configurable) we check for clock drift/skew by calling `System.currentTimeMillis()` and comparing that to our calculated time from the initial tracer wall clock time. Any difference more than 1ms is taken from future trace times while keeping the sub-nanosecond time intact.

Note: trace tests that don't involve synthetic spans now sort their test traces by the start time of the local root span (before we used the creation time of the `PendingTrace` structure which was before any spans were created.)

"time-in-queue" messaging tests are slightly different because the start time of the synthetic "time-in-queue" span is explicitly set back to the time the message was produced (with milliseconds granularity) and this isn't stable enough for sorting - so for these tests we sort by span id instead.

Simple span benchmark...

before: 580.509 ±(99.9%) 3.942 ns/op

<img width="1440" alt="Screen Shot 2021-12-21 at 01 27 05" src="https://user-images.githubusercontent.com/145851/146859694-06e37629-c8c7-4801-982c-b6fe4fa78586.png">

after: 501.727 ±(99.9%) 2.593 ns/op

<img width="1440" alt="Screen Shot 2021-12-21 at 01 27 32" src="https://user-images.githubusercontent.com/145851/146859708-98a93076-bdce-43a2-b55d-5f07d7a874be.png">
