### PR TITLE
Replace end-to-end baggage implementation

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/BaseDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/BaseDecorator.java
@@ -2,7 +2,6 @@ package datadog.trace.bootstrap.instrumentation.decorator;
 
 import static datadog.trace.api.cache.RadixTreeCache.PORTS;
 import static datadog.trace.api.cache.RadixTreeCache.UNSET_PORT;
-import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 import datadog.trace.api.Config;
 import datadog.trace.api.DDTags;
@@ -78,10 +77,7 @@ public abstract class BaseDecorator {
       span.setMetric(DDTags.ANALYTICS_SAMPLE_RATE, traceAnalyticsSampleRate);
     }
     if (endToEndDurationsEnabled) {
-      if (null == span.getBaggageItem(DDTags.TRACE_START_TIME)) {
-        span.setBaggageItem(
-            DDTags.TRACE_START_TIME, Long.toString(NANOSECONDS.toMillis(span.getStartTime())));
-      }
+      span.beginEndToEnd();
     }
     return span;
   }

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaDecorator.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaDecorator.java
@@ -2,13 +2,10 @@ package datadog.trace.instrumentation.kafka_clients;
 
 import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.OFFSET;
 import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.PARTITION;
-import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.RECORD_END_TO_END_DURATION_MS;
 import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.RECORD_QUEUE_TIME_MS;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 import datadog.trace.api.DDSpanTypes;
-import datadog.trace.api.DDTags;
 import datadog.trace.api.Functions;
 import datadog.trace.api.cache.DDCache;
 import datadog.trace.api.cache.DDCaches;
@@ -90,19 +87,7 @@ public class KafkaDecorator extends ClientDecorator {
 
   public void finishConsumerSpan(final AgentSpan span) {
     if (endToEndDurationsEnabled) {
-      long now = System.currentTimeMillis();
-      String traceStartTime = span.getBaggageItem(DDTags.TRACE_START_TIME);
-      if (null != traceStartTime) {
-        // we want to use the span end time, so need its duration, which is set
-        // on finish, but don't want to risk modifying the span after
-        // finishing it, in case it gets published, causing possible
-        // (functional) race conditions with the trace processing rules.
-        // getting the current time is a reasonable compromise.
-        // not being defensive here because we own the lifecycle of this value
-        span.setTag(
-            RECORD_END_TO_END_DURATION_MS, Math.max(0L, now - Long.parseLong(traceStartTime)));
-      }
-      span.finish(MILLISECONDS.toMicros(now));
+      span.finishEndToEnd();
     } else {
       span.finish();
     }

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaDecorator.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaDecorator.java
@@ -87,7 +87,7 @@ public class KafkaDecorator extends ClientDecorator {
 
   public void finishConsumerSpan(final AgentSpan span) {
     if (endToEndDurationsEnabled) {
-      span.finishEndToEnd();
+      span.finishWithEndToEnd();
     } else {
       span.finish();
     }

--- a/dd-java-agent/instrumentation/opentelemetry/src/test/groovy/OpenTelemetryTest.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/src/test/groovy/OpenTelemetryTest.groovy
@@ -133,10 +133,10 @@ class OpenTelemetryTest extends AgentTestRunner {
     setup:
     def builder = tracer.spanBuilder("some name")
     if (parentId) {
-      builder.setParent(tracer.converter.toSpanContext(new ExtractedContext(DDId.ONE, DDId.from(parentId), 0, null, [:], [:])))
+      builder.setParent(tracer.converter.toSpanContext(new ExtractedContext(DDId.ONE, DDId.from(parentId), 0, null, 0, [:], [:])))
     }
     if (linkId) {
-      builder.addLink(tracer.converter.toSpanContext(new ExtractedContext(DDId.ONE, DDId.from(linkId), 0, null, [:], [:])))
+      builder.addLink(tracer.converter.toSpanContext(new ExtractedContext(DDId.ONE, DDId.from(linkId), 0, null, 0, [:], [:])))
     }
     def result = builder.startSpan()
 

--- a/dd-java-agent/instrumentation/opentracing/api-0.31/src/test/groovy/OpenTracing31Test.groovy
+++ b/dd-java-agent/instrumentation/opentracing/api-0.31/src/test/groovy/OpenTracing31Test.groovy
@@ -33,7 +33,7 @@ class OpenTracing31Test extends AgentTestRunner {
         .withTag("boolean", true)
     }
     if (addReference) {
-      builder.addReference(addReference, tracer.tracer.converter.toSpanContext(new ExtractedContext(DDId.ONE, DDId.from(2), 0, null, [:], [:])))
+      builder.addReference(addReference, tracer.tracer.converter.toSpanContext(new ExtractedContext(DDId.ONE, DDId.from(2), 0, null, 0, [:], [:])))
     }
     def result = builder.start()
     if (tagSpan) {

--- a/dd-java-agent/instrumentation/opentracing/api-0.32/src/test/groovy/OpenTracing32Test.groovy
+++ b/dd-java-agent/instrumentation/opentracing/api-0.32/src/test/groovy/OpenTracing32Test.groovy
@@ -33,7 +33,7 @@ class OpenTracing32Test extends AgentTestRunner {
         .withTag("boolean", true)
     }
     if (addReference) {
-      builder.addReference(addReference, tracer.tracer.converter.toSpanContext(new ExtractedContext(DDId.ONE, DDId.from(2), 0, null, [:], [:])))
+      builder.addReference(addReference, tracer.tracer.converter.toSpanContext(new ExtractedContext(DDId.ONE, DDId.from(2), 0, null, 0, [:], [:])))
     }
     def result = builder.start()
     if (tagSpan) {

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitDecorator.java
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitDecorator.java
@@ -7,16 +7,13 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.AMQP_EXCHANGE;
 import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.AMQP_QUEUE;
 import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.AMQP_ROUTING_KEY;
-import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.RECORD_END_TO_END_DURATION_MS;
 import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.RECORD_QUEUE_TIME_MS;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.Command;
 import com.rabbitmq.client.Consumer;
 import com.rabbitmq.client.Envelope;
 import datadog.trace.api.Config;
-import datadog.trace.api.DDTags;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.ContextVisitors;
@@ -207,14 +204,7 @@ public class RabbitDecorator extends ClientDecorator {
   public static void finishReceivingSpan(AgentScope scope) {
     AgentSpan span = scope.span();
     if (CONSUMER_DECORATE.endToEndDurationsEnabled) {
-      long now = System.currentTimeMillis();
-      String traceStartTime = span.getBaggageItem(DDTags.TRACE_START_TIME);
-      if (null != traceStartTime) {
-        // not being defensive here because we own the lifecycle of this value
-        span.setTag(
-            RECORD_END_TO_END_DURATION_MS, Math.max(0L, now - Long.parseLong(traceStartTime)));
-      }
-      span.finish(MILLISECONDS.toMicros(now));
+      span.finishEndToEnd();
     } else {
       span.finish();
     }

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitDecorator.java
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitDecorator.java
@@ -204,7 +204,7 @@ public class RabbitDecorator extends ClientDecorator {
   public static void finishReceivingSpan(AgentScope scope) {
     AgentSpan span = scope.span();
     if (CONSUMER_DECORATE.endToEndDurationsEnabled) {
-      span.finishEndToEnd();
+      span.finishWithEndToEnd();
     } else {
       span.finish();
     }

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -1018,18 +1018,22 @@ public class CoreTracer implements AgentTracer.TracerAPI {
         RequestContext<Object> requestContext = ddsc.getRequestContext();
         requestContextData = null == requestContext ? null : requestContext.getData();
       } else {
+        long endToEndStartTime;
+
         if (parentContext instanceof ExtractedContext) {
           // Propagate external trace
           final ExtractedContext extractedContext = (ExtractedContext) parentContext;
           traceId = extractedContext.getTraceId();
           parentSpanId = extractedContext.getSpanId();
           samplingPriority = extractedContext.getSamplingPriority();
+          endToEndStartTime = extractedContext.getEndToEndStartTime();
           baggage = extractedContext.getBaggage();
         } else {
           // Start a new trace
           traceId = IdGenerationStrategy.RANDOM.generate();
           parentSpanId = DDId.ZERO;
           samplingPriority = PrioritySampling.UNSET;
+          endToEndStartTime = 0;
           baggage = null;
         }
 
@@ -1048,6 +1052,10 @@ public class CoreTracer implements AgentTracer.TracerAPI {
         rootSpanTags = localRootSpanTags;
 
         parentTrace = createTrace(traceId);
+
+        if (endToEndStartTime > 0) {
+          parentTrace.beginEndToEnd(endToEndStartTime);
+        }
       }
 
       if (serviceName == null) {

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -152,7 +152,7 @@ public class DDSpan implements AgentSpan, CoreSpan<DDSpan> {
   }
 
   @Override
-  public void finishEndToEnd() {
+  public void finishWithEndToEnd() {
     long recordStartNano = context.getEndToEndStartTime();
     if (recordStartNano > 0) {
       phasedFinish();

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -1,5 +1,6 @@
 package datadog.trace.core;
 
+import static datadog.trace.api.DDTags.TRACE_START_TIME;
 import static datadog.trace.api.sampling.PrioritySampling.SAMPLER_DROP;
 import static datadog.trace.api.sampling.PrioritySampling.USER_DROP;
 import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.RECORD_END_TO_END_DURATION_MS;
@@ -8,6 +9,7 @@ import static java.util.concurrent.TimeUnit.MICROSECONDS;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
+import datadog.trace.api.Config;
 import datadog.trace.api.DDId;
 import datadog.trace.api.DDTags;
 import datadog.trace.api.gateway.RequestContext;
@@ -146,19 +148,39 @@ public class DDSpan implements AgentSpan, CoreSpan<DDSpan> {
     finishAndAddToTrace(MICROSECONDS.toNanos(stopTimeMicros) - adjustedStartTimeNano);
   }
 
+  private static final boolean legacyEndToEndEnabled =
+      Config.get().isEndToEndDurationEnabled(false, "legacy");
+
   @Override
   public void beginEndToEnd() {
-    context.beginEndToEnd();
+    if (legacyEndToEndEnabled) {
+      if (null == getBaggageItem(TRACE_START_TIME)) {
+        setBaggageItem(TRACE_START_TIME, Long.toString(NANOSECONDS.toMillis(startTimeNano)));
+      }
+    } else {
+      context.beginEndToEnd();
+    }
   }
 
   @Override
   public void finishWithEndToEnd() {
-    long recordStartNano = context.getEndToEndStartTime();
-    if (recordStartNano > 0) {
+    long e2eStart;
+    if (legacyEndToEndEnabled) {
+      String value = context.getBaggageItem(TRACE_START_TIME);
+      try {
+        e2eStart = null != value ? MILLISECONDS.toNanos(Long.parseLong(value)) : 0;
+      } catch (RuntimeException e) {
+        log.debug("Ignoring invalid end-to-end start time {}", value, e);
+        e2eStart = 0;
+      }
+    } else {
+      e2eStart = context.getEndToEndStartTime();
+    }
+    if (e2eStart > 0) {
       phasedFinish();
       // get end time from start+duration, ignoring negative bit set by phasedFinish
-      long recordEndNano = startTimeNano + (durationNano & Long.MAX_VALUE);
-      setTag(RECORD_END_TO_END_DURATION_MS, NANOSECONDS.toMillis(recordEndNano - recordStartNano));
+      long e2eEnd = startTimeNano + (durationNano & Long.MAX_VALUE);
+      setTag(RECORD_END_TO_END_DURATION_MS, NANOSECONDS.toMillis(Math.max(0, e2eEnd - e2eStart)));
       publish();
     } else {
       finish();

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
@@ -335,6 +335,14 @@ public class DDSpanContext implements AgentSpan.Context, RequestContext<Object> 
     }
   }
 
+  public void beginEndToEnd() {
+    trace.beginEndToEnd();
+  }
+
+  public long getEndToEndStartTime() {
+    return trace.getEndToEndStartTime();
+  }
+
   public void setBaggageItem(final String key, final String value) {
     if (baggageItems == EMPTY_BAGGAGE) {
       synchronized (this) {

--- a/dd-trace-core/src/main/java/datadog/trace/core/PendingTrace.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/PendingTrace.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import javax.annotation.Nonnull;
 import org.slf4j.Logger;
@@ -93,6 +94,10 @@ public class PendingTrace implements AgentTrace, PendingTraceBuffer.Element {
    * finish of each span).
    */
   private volatile long lastReferenced = 0;
+
+  private volatile long endToEndStartTime;
+  private static final AtomicLongFieldUpdater<PendingTrace> END_TO_END_START_TIME =
+      AtomicLongFieldUpdater.newUpdater(PendingTrace.class, "endToEndStartTime");
 
   private PendingTrace(
       @Nonnull CoreTracer tracer,
@@ -279,5 +284,17 @@ public class PendingTrace implements AgentTrace, PendingTraceBuffer.Element {
 
   public int size() {
     return completedSpanCount;
+  }
+
+  public void beginEndToEnd() {
+    beginEndToEnd(getCurrentTimeNano());
+  }
+
+  void beginEndToEnd(long endToEndStartTime) {
+    END_TO_END_START_TIME.compareAndSet(this, 0, endToEndStartTime);
+  }
+
+  public long getEndToEndStartTime() {
+    return endToEndStartTime;
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ContextInterpreter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ContextInterpreter.java
@@ -29,6 +29,7 @@ public abstract class ContextInterpreter implements AgentPropagation.KeyClassifi
   protected Map<String, String> tags;
   protected Map<String, String> baggage;
   protected String origin;
+  protected long endToEndStartTime;
   protected boolean hasForwarded;
   protected String forwarded;
   protected String forwardedProto;
@@ -107,6 +108,7 @@ public abstract class ContextInterpreter implements AgentPropagation.KeyClassifi
     spanId = DDId.ZERO;
     samplingPriority = defaultSamplingPriority();
     origin = null;
+    endToEndStartTime = 0;
     hasForwarded = false;
     forwarded = null;
     forwardedProto = null;
@@ -130,6 +132,7 @@ public abstract class ContextInterpreter implements AgentPropagation.KeyClassifi
                   spanId,
                   samplingPriority,
                   origin,
+                  endToEndStartTime,
                   forwarded,
                   forwardedProto,
                   forwardedHost,
@@ -138,7 +141,9 @@ public abstract class ContextInterpreter implements AgentPropagation.KeyClassifi
                   baggage,
                   tags);
         } else {
-          context = new ExtractedContext(traceId, spanId, samplingPriority, origin, baggage, tags);
+          context =
+              new ExtractedContext(
+                  traceId, spanId, samplingPriority, origin, endToEndStartTime, baggage, tags);
         }
         return context;
       } else if (hasForwarded) {

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ExtractedContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ExtractedContext.java
@@ -11,6 +11,7 @@ public class ExtractedContext extends TagContext {
   private final DDId traceId;
   private final DDId spanId;
   private final int samplingPriority;
+  private final long endToEndStartTime;
   private final Map<String, String> baggage;
 
   public ExtractedContext(
@@ -18,12 +19,14 @@ public class ExtractedContext extends TagContext {
       final DDId spanId,
       final int samplingPriority,
       final String origin,
+      final long endToEndStartTime,
       final Map<String, String> baggage,
       final Map<String, String> tags) {
     super(origin, tags);
     this.traceId = traceId;
     this.spanId = spanId;
     this.samplingPriority = samplingPriority;
+    this.endToEndStartTime = endToEndStartTime;
     this.baggage = baggage;
   }
 
@@ -44,6 +47,10 @@ public class ExtractedContext extends TagContext {
 
   public final int getSamplingPriority() {
     return samplingPriority;
+  }
+
+  public final long getEndToEndStartTime() {
+    return endToEndStartTime;
   }
 
   public final Map<String, String> getBaggage() {

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ForwardedExtractedContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ForwardedExtractedContext.java
@@ -17,6 +17,7 @@ public final class ForwardedExtractedContext extends ExtractedContext {
       final DDId spanId,
       final int samplingPriority,
       final String origin,
+      final long endToEndStartTime,
       final String forwarded,
       final String forwardedProto,
       final String forwardedHost,
@@ -24,7 +25,7 @@ public final class ForwardedExtractedContext extends ExtractedContext {
       final String forwardedPort,
       final Map<String, String> baggage,
       final Map<String, String> tags) {
-    super(traceId, spanId, samplingPriority, origin, baggage, tags);
+    super(traceId, spanId, samplingPriority, origin, endToEndStartTime, baggage, tags);
     this.forwarded = forwarded;
     this.forwardedProto = forwardedProto;
     this.forwardedHost = forwardedHost;

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/XRayHttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/XRayHttpCodec.java
@@ -3,6 +3,8 @@ package datadog.trace.core.propagation;
 import static datadog.trace.api.DDTags.ORIGIN_KEY;
 import static datadog.trace.api.sampling.PrioritySampling.SAMPLER_DROP;
 import static datadog.trace.api.sampling.PrioritySampling.SAMPLER_KEEP;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 import datadog.trace.api.DDId;
 import datadog.trace.api.sampling.PrioritySampling;
@@ -32,6 +34,9 @@ class XRayHttpCodec {
   static final String SAMPLED_PREFIX = SAMPLED + '=';
   static final String SELF_PREFIX = SELF + '=';
   static final String ORIGIN_PREFIX = ORIGIN_KEY + '=';
+
+  static final String E2E_START_KEY = "e2e.start";
+  static final String E2E_START_PREFIX = E2E_START_KEY + '=';
 
   static final int MAX_ADDITIONAL_BYTES = 256;
 
@@ -63,6 +68,11 @@ class XRayHttpCodec {
       CharSequence origin = context.getOrigin();
       if (origin != null) {
         additionalPart(buf, ORIGIN_KEY, origin.toString(), maxCapacity);
+      }
+      long e2eStart = context.getEndToEndStartTime();
+      if (e2eStart > 0) {
+        additionalPart(
+            buf, E2E_START_KEY, Long.toString(NANOSECONDS.toMillis(e2eStart)), maxCapacity);
       }
 
       for (Map.Entry<String, String> entry : context.baggageItems()) {
@@ -178,6 +188,9 @@ class XRayHttpCodec {
           // Self is added by load-balancers and should be ignored
         } else if (part.startsWith(ORIGIN_PREFIX)) {
           interpreter.origin = part.substring(ORIGIN_PREFIX.length());
+        } else if (part.startsWith(E2E_START_PREFIX)) {
+          interpreter.endToEndStartTime =
+              MILLISECONDS.toNanos(Long.parseLong(part.substring(E2E_START_PREFIX.length())));
         } else {
           int eqIndex = part.indexOf('=');
           if (eqIndex > 0) {

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
@@ -160,7 +160,7 @@ public final class ContinuableScopeManager implements AgentScopeManager {
       top.close();
       scopeStack.cleanup();
       if (finishSpan) {
-        top.span.finish();
+        top.span.finishEndToEnd();
       }
     }
   }
@@ -514,14 +514,14 @@ public final class ContinuableScopeManager implements AgentScopeManager {
       // avoid calling close() as we're already in that method, instead just clear any
       // remaining references so the scope gets removed in the subsequent cleanup() call
       top.clearReferences();
-      top.span.finish();
+      top.span.finishEndToEnd();
       // now do the same for any previous iteration scopes ahead of the expected scope
       for (ContinuableScope scope : stack) {
         if (scope.source() != ScopeSource.ITERATION.id()) {
           return expectedScope.equals(scope);
         } else {
           scope.clearReferences();
-          scope.span.finish();
+          scope.span.finishEndToEnd();
         }
       }
       return false; // we didn't find the expected scope
@@ -793,7 +793,7 @@ public final class ContinuableScopeManager implements AgentScopeManager {
         } else if (NANOSECONDS.toMillis(rootScope.span.getStartTime()) < cutOff) {
           // mark scope as overdue to allow cleanup and avoid further spans being attached
           scopeStack.overdueRootScope = rootScope;
-          rootScope.span.finish();
+          rootScope.span.finishEndToEnd();
           itr.remove();
         }
       }

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
@@ -160,7 +160,7 @@ public final class ContinuableScopeManager implements AgentScopeManager {
       top.close();
       scopeStack.cleanup();
       if (finishSpan) {
-        top.span.finishEndToEnd();
+        top.span.finishWithEndToEnd();
       }
     }
   }
@@ -514,14 +514,14 @@ public final class ContinuableScopeManager implements AgentScopeManager {
       // avoid calling close() as we're already in that method, instead just clear any
       // remaining references so the scope gets removed in the subsequent cleanup() call
       top.clearReferences();
-      top.span.finishEndToEnd();
+      top.span.finishWithEndToEnd();
       // now do the same for any previous iteration scopes ahead of the expected scope
       for (ContinuableScope scope : stack) {
         if (scope.source() != ScopeSource.ITERATION.id()) {
           return expectedScope.equals(scope);
         } else {
           scope.clearReferences();
-          scope.span.finishEndToEnd();
+          scope.span.finishWithEndToEnd();
         }
       }
       return false; // we didn't find the expected scope
@@ -793,7 +793,7 @@ public final class ContinuableScopeManager implements AgentScopeManager {
         } else if (NANOSECONDS.toMillis(rootScope.span.getStartTime()) < cutOff) {
           // mark scope as overdue to allow cleanup and avoid further spans being attached
           scopeStack.overdueRootScope = rootScope;
-          rootScope.span.finishEndToEnd();
+          rootScope.span.finishWithEndToEnd();
           itr.remove();
         }
       }

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
@@ -793,6 +793,7 @@ public final class ContinuableScopeManager implements AgentScopeManager {
         } else if (NANOSECONDS.toMillis(rootScope.span.getStartTime()) < cutOff) {
           // mark scope as overdue to allow cleanup and avoid further spans being attached
           scopeStack.overdueRootScope = rootScope;
+          rootScope.span.finishThreadMigration();
           rootScope.span.finishWithEndToEnd();
           itr.remove();
         }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/CoreSpanBuilderTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/CoreSpanBuilderTest.groovy
@@ -319,9 +319,9 @@ class CoreSpanBuilderTest extends DDCoreSpecification {
     span.getTag(THREAD_NAME) == thread.name
 
     where:
-    extractedContext                                                                                                                    | _
-    new ExtractedContext(DDId.ONE, DDId.from(2), 0, null, [:], [:])                                                                     | _
-    new ExtractedContext(DDId.from(3), DDId.from(4), 1, "some-origin", ["asdf": "qwer"], [(ORIGIN_KEY): "some-origin", "zxcv": "1234"]) | _
+    extractedContext                                                                                                                       | _
+    new ExtractedContext(DDId.ONE, DDId.from(2), 0, null, 0, [:], [:])                                                                     | _
+    new ExtractedContext(DDId.from(3), DDId.from(4), 1, "some-origin", 0, ["asdf": "qwer"], [(ORIGIN_KEY): "some-origin", "zxcv": "1234"]) | _
   }
 
   def "TagContext should populate default span details"() {

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanTest.groovy
@@ -265,9 +265,9 @@ class DDSpanTest extends DDCoreSpecification {
     child.@origin == null // Access field directly instead of getter.
 
     where:
-    extractedContext                                                         | _
-    new TagContext("some-origin", [:])                                       | _
-    new ExtractedContext(DDId.ONE, DDId.from(2), 0, "some-origin", [:], [:]) | _
+    extractedContext                                                            | _
+    new TagContext("some-origin", [:])                                          | _
+    new ExtractedContext(DDId.ONE, DDId.from(2), 0, "some-origin", 0, [:], [:]) | _
   }
 
   def "isRootSpan() in and not in the context of distributed tracing"() {
@@ -284,9 +284,9 @@ class DDSpanTest extends DDCoreSpecification {
     root.finish()
 
     where:
-    extractedContext                                                         | isTraceRootSpan
-    null                                                                     | true
-    new ExtractedContext(DDId.from(123), DDId.from(456), 1, "789", [:], [:]) | false
+    extractedContext                                                            | isTraceRootSpan
+    null                                                                        | true
+    new ExtractedContext(DDId.from(123), DDId.from(456), 1, "789", 0, [:], [:]) | false
   }
 
   def "getApplicationRootSpan() in and not in the context of distributed tracing"() {
@@ -306,9 +306,9 @@ class DDSpanTest extends DDCoreSpecification {
     root.finish()
 
     where:
-    extractedContext                                                         | isTraceRootSpan
-    null                                                                     | true
-    new ExtractedContext(DDId.from(123), DDId.from(456), 1, "789", [:], [:]) | false
+    extractedContext                                                            | isTraceRootSpan
+    null                                                                        | true
+    new ExtractedContext(DDId.from(123), DDId.from(456), 1, "789", 0, [:], [:]) | false
   }
 
   def "infer top level from parent service name"() {

--- a/dd-trace-ot/src/main/java/datadog/opentracing/CustomScopeManagerWrapper.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/CustomScopeManagerWrapper.java
@@ -97,7 +97,7 @@ class CustomScopeManagerWrapper implements AgentScopeManager {
         }
         scope.close();
         if (finishSpan) {
-          span.finish();
+          span.finishEndToEnd();
         }
       }
     }
@@ -198,14 +198,14 @@ class CustomScopeManagerWrapper implements AgentScopeManager {
           }
           spans.poll();
         }
-        s.finish();
+        s.finishEndToEnd();
       }
     }
 
     public void finishAllSpans() {
       synchronized (spans) {
         for (AgentSpan s : spans) {
-          s.finish();
+          s.finishEndToEnd();
         }
         // no need to clear as this is only called when the owning thread is no longer alive
       }

--- a/dd-trace-ot/src/main/java/datadog/opentracing/CustomScopeManagerWrapper.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/CustomScopeManagerWrapper.java
@@ -198,6 +198,7 @@ class CustomScopeManagerWrapper implements AgentScopeManager {
           }
           spans.poll();
         }
+        s.finishThreadMigration();
         s.finishWithEndToEnd();
       }
     }
@@ -205,6 +206,7 @@ class CustomScopeManagerWrapper implements AgentScopeManager {
     public void finishAllSpans() {
       synchronized (spans) {
         for (AgentSpan s : spans) {
+          s.finishThreadMigration();
           s.finishWithEndToEnd();
         }
         // no need to clear as this is only called when the owning thread is no longer alive

--- a/dd-trace-ot/src/main/java/datadog/opentracing/CustomScopeManagerWrapper.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/CustomScopeManagerWrapper.java
@@ -97,7 +97,7 @@ class CustomScopeManagerWrapper implements AgentScopeManager {
         }
         scope.close();
         if (finishSpan) {
-          span.finishEndToEnd();
+          span.finishWithEndToEnd();
         }
       }
     }
@@ -198,14 +198,14 @@ class CustomScopeManagerWrapper implements AgentScopeManager {
           }
           spans.poll();
         }
-        s.finishEndToEnd();
+        s.finishWithEndToEnd();
       }
     }
 
     public void finishAllSpans() {
       synchronized (spans) {
         for (AgentSpan s : spans) {
-          s.finishEndToEnd();
+          s.finishWithEndToEnd();
         }
         // no need to clear as this is only called when the owning thread is no longer alive
       }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
@@ -89,6 +89,16 @@ public interface AgentSpan extends MutableSpan, IGSpanInfo {
 
   void finish(long finishMicros);
 
+  /** Marks the start of a message pipeline where we want to track end-to-end processing time. */
+  void beginEndToEnd();
+
+  /**
+   * Marks the end of a message pipeline where the final end-to-end processing time is recorded.
+   *
+   * <p>Note: this will also finish the span and publish it.
+   */
+  void finishEndToEnd();
+
   /**
    * Finishes the span but does not publish it. The {@link #publish()} method MUST be called once
    * otherwise the trace will not be reported.

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
@@ -97,7 +97,7 @@ public interface AgentSpan extends MutableSpan, IGSpanInfo {
    *
    * <p>Note: this will also finish the span and publish it.
    */
-  void finishEndToEnd();
+  void finishWithEndToEnd();
 
   /**
    * Finishes the span but does not publish it. The {@link #publish()} method MUST be called once

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -599,6 +599,12 @@ public class AgentTracer {
     public void finish(final long finishMicros) {}
 
     @Override
+    public void beginEndToEnd() {}
+
+    @Override
+    public void finishEndToEnd() {}
+
+    @Override
     public boolean phasedFinish() {
       return false;
     }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -602,7 +602,7 @@ public class AgentTracer {
     public void beginEndToEnd() {}
 
     @Override
-    public void finishEndToEnd() {}
+    public void finishWithEndToEnd() {}
 
     @Override
     public boolean phasedFinish() {


### PR DESCRIPTION
instead use a dedicated field in PendingTrace along with new internal span methods. These methods are also used to record end-to-end duration for iteration spans when they are overdue or go out-of-scope - this helps move messaging integrations over to iteration spans when consuming.

The old baggage headers are used when propagating end-to-end data, just in case we're receiving messages from an old tracer or sending messages to an old tracer.

There's also a new flag `dd.trace.legacy.e2e.duration.enabled` which re-enables the old baggage approach when `true`