### PR TITLE
Move the checkpoint hard limit info to CheckpointSummaryEvent

### DIFF
--- a/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/CheckpointSamplerConfigEvent.java
+++ b/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/CheckpointSamplerConfigEvent.java
@@ -29,19 +29,11 @@ public class CheckpointSamplerConfigEvent extends Event {
   @Label("budgetLookback")
   private final int budgetLookback;
 
-  @Label("sampleLimit")
-  private final int sampleLimit;
-
   public CheckpointSamplerConfigEvent(
-      long samplerWindow,
-      int sammplesPerWindow,
-      int averageLookback,
-      int budgetLookback,
-      int sampleLimit) {
+      long samplerWindow, int sammplesPerWindow, int averageLookback, int budgetLookback) {
     this.samplerWindow = samplerWindow;
     this.sammplesPerWindow = sammplesPerWindow;
     this.averageLookback = averageLookback;
     this.budgetLookback = budgetLookback;
-    this.sampleLimit = sampleLimit;
   }
 }

--- a/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/CheckpointSummaryEvent.java
+++ b/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/CheckpointSummaryEvent.java
@@ -27,10 +27,15 @@ public class CheckpointSummaryEvent extends Event {
   @Label("Truncated")
   private final boolean truncated;
 
-  public CheckpointSummaryEvent(int rateLimit, long emitted, long dropped, boolean truncated) {
+  @Label("Hard limit")
+  private final int hardLimit;
+
+  public CheckpointSummaryEvent(
+      int rateLimit, long emitted, long dropped, int hardLimit, boolean truncated) {
     this.rateLimit = rateLimit;
     this.dropped = dropped;
     this.emitted = emitted;
     this.truncated = truncated;
+    this.hardLimit = hardLimit;
   }
 }

--- a/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/JFRCheckpointer.java
+++ b/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/JFRCheckpointer.java
@@ -238,6 +238,7 @@ public class JFRCheckpointer implements Checkpointer, ProfilingListener<Profilin
             rateLimit,
             emitted.sumThenReset(),
             dropped.sumThenReset(),
+            recordingSampleLimit,
             recordingSampleCount > recordingSampleLimit)
         .commit();
   }
@@ -248,8 +249,7 @@ public class JFRCheckpointer implements Checkpointer, ProfilingListener<Profilin
               samplerConfig.windowSize.toMillis(),
               samplerConfig.samplesPerWindow,
               samplerConfig.averageLookback,
-              samplerConfig.budgetLookback,
-              recordingSampleLimit)
+              samplerConfig.budgetLookback)
           .commit();
     } catch (Throwable t) {
       if (log.isDebugEnabled()) {


### PR DESCRIPTION
# What Does This Do
Moves the information about the hard limit for the number of checkpoints in the recording to `CheckpointSummaryEvent` as the limit is applied even when no rate limit is specified and the `CheckpointSamplerConfigEvent` would not be emitted.

# Motivation
Make the information about the checkpoint hard limit always available.

# Additional Notes
