### PR TITLE
Bump CodeNarc to 2.2.0

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -12,3 +12,6 @@ if ! ./gradlew spotlessCheck; then
   echo ""
   exit 1
 fi
+
+# Run Groovy code check
+./gradlew codenarcTest -PskipTests

--- a/gradle/codenarc.gradle
+++ b/gradle/codenarc.gradle
@@ -1,7 +1,7 @@
 apply plugin: "codenarc"
 
 dependencies {
-  codenarc 'org.codenarc:CodeNarc:1.5'
+  codenarc 'org.codenarc:CodeNarc:2.2.0'
   // if the groovy transitive dependencies are upgraded, this may not be pulled
   codenarc 'org.codehaus.groovy:groovy-templates'
 }


### PR DESCRIPTION
# What Does This Do

Update CodeNarc to the latest version 2.2.0.
Added a git hook to run CodeNarc check.

# Motivation

Running CodeNarc prior the git push will catch Groovy issues before CI does it.

# Additional Notes

N/A
