### PR TITLE
Upgrade gradle to 6.9.1

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=1433372d903ffba27496f8d5af24265310d2da0d78bf6b4e5138831d4fe066e9
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-all.zip
+distributionSha256Sum=b13f5d97f08000996bf12d9dd70af3f2c6b694c2c663ab1b545e9695562ad1ee
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
# What Does This Do

Upgrades gradle to the latest `6.x` version `6.9.1`

# Motivation

Get bug fixes

# Additional Notes

This has support for running gradle natively on Apple Silicon