### PR TITLE
Default to cpu mode for async-profiler

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-auxiliary-async/src/test/java/com/datadog/profiling/auxiliary/async/AuxiliaryAsyncProfilerTest.java
+++ b/dd-java-agent/agent-profiling/profiling-auxiliary-async/src/test/java/com/datadog/profiling/auxiliary/async/AuxiliaryAsyncProfilerTest.java
@@ -86,7 +86,7 @@ class AuxiliaryAsyncProfilerTest {
     String cmd = profiler.cmdStartProfiling(targetFile);
 
     if (profiler.enabledModes().contains(ProfilingMode.CPU)) {
-      assertTrue(cmd.contains("event=itimer"));
+      assertTrue(cmd.contains("event=cpu"));
     }
     if (profiler.enabledModes().contains(ProfilingMode.ALLOCATION)) {
       assertTrue(cmd.contains("alloc="));

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
@@ -54,7 +54,7 @@ public final class ProfilingConfig {
   public static final int PROFILING_ASYNC_ALLOC_INTERVAL_DEFAULT = 256 * 1024;
   public static final String PROFILING_ASYNC_CPU_ENABLED = "profiling.async.cpu.enabled";
   public static final String PROFILING_ASYNC_CPU_MODE = "profiling.async.cpu.mode";
-  public static final String PROFILING_ASYNC_CPU_MODE_DEFAULT = "itimer";
+  public static final String PROFILING_ASYNC_CPU_MODE_DEFAULT = "cpu";
   public static final String PROFILING_ASYNC_CPU_INTERVAL = "profiling.async.cpu.interval.ms";
   public static final int PROFILING_ASYNC_CPU_INTERVAL_DEFAULT = 10;
   public static final String PROFILING_ASYNC_MEMLEAK_ENABLED = "profiling.async.memleak.enabled";


### PR DESCRIPTION
# What Does This Do

This tries to use perf and fallbacks to wall

# Motivation

`itimer` is very broken on Linux, we don't want to depend on it.

# Additional Notes
